### PR TITLE
Serve static frontend files via os.Root and set docs data-page through the dataset API

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -22,15 +22,16 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"flag"
 	"fmt"
+	"io/fs"
 	"mime"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
 	"path"
-	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -335,100 +336,92 @@ func registerStaticFileHandlers(ctx context.Context, logger *log.Logger, mux *ht
 
 	// Serve gate application from /gate
 	gateDir := path.Join(serverHome, "apps", "gate")
-	if directoryExists(gateDir) {
+	if handler, err := createStaticFileHandler("/gate/", gateDir, logger); err != nil {
+		logger.Warn(ctx, "Gate application not registered", log.String("directory", gateDir), log.Error(err))
+	} else {
 		logger.Debug(ctx, "Registering static file handler for Gate application",
 			log.String("path", "/gate/"), log.String("directory", gateDir))
-		mux.Handle("/gate/", createStaticFileHandler("/gate/", gateDir, logger))
-	} else {
-		logger.Warn(ctx, "Gate application directory not found", log.String("directory", gateDir))
+		mux.Handle("/gate/", handler)
 	}
 
 	// Serve console application from /console
 	consoleDir := path.Join(serverHome, "apps", "console")
-	if directoryExists(consoleDir) {
+	if handler, err := createStaticFileHandler("/console/", consoleDir, logger); err != nil {
+		logger.Warn(ctx, "Console application not registered", log.String("directory", consoleDir), log.Error(err))
+	} else {
 		logger.Debug(ctx, "Registering static file handler for Console application",
 			log.String("path", "/console/"), log.String("directory", consoleDir))
-		mux.Handle("/console/", createStaticFileHandler("/console/", consoleDir, logger))
-	} else {
-		logger.Warn(ctx, "Console application directory not found", log.String("directory", consoleDir))
+		mux.Handle("/console/", handler)
 	}
 }
 
 // createStaticFileHandler creates a handler for serving static files with SPA fallback.
-func createStaticFileHandler(routePrefix, directory string, logger *log.Logger) http.Handler {
-	fileServer := http.FileServer(http.Dir(directory))
+//
+// All filesystem access is performed through an os.Root anchored at `directory`, which
+// confines every lookup below that directory: any request path that would escape it fails
+// with a path-escape error rather than reaching the filesystem.
+func createStaticFileHandler(routePrefix, directory string, logger *log.Logger) (http.Handler, error) {
+	root, err := os.OpenRoot(directory)
+	if err != nil {
+		return nil, err
+	}
+	rootFS := root.FS()
+	fileServer := http.FileServerFS(rootFS)
+
+	// serveIndex serves index.html with no-cache headers. It reports whether index.html
+	// existed and was served.
+	serveIndex := func(w http.ResponseWriter, r *http.Request) bool {
+		if _, err := root.Stat("index.html"); err != nil {
+			return false
+		}
+		w.Header().Set(constants.CacheControlHeaderName, constants.CacheControlNoCacheComposite)
+		w.Header().Set(constants.PragmaHeaderName, constants.PragmaNoCache)
+		w.Header().Set(constants.ExpiresHeaderName, constants.ExpiresZero)
+		http.ServeFileFS(w, r, rootFS, "index.html")
+		return true
+	}
 
 	return http.StripPrefix(routePrefix, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Handle root path "/" by explicitly serving index.html
+		// Handle the application root by explicitly serving index.html.
 		if r.URL.Path == "/" || r.URL.Path == "" {
-			indexPath := path.Join(directory, "index.html")
-			if fileExists(indexPath) {
-				// Set no-cache headers for index.html
-				w.Header().Set(constants.CacheControlHeaderName, constants.CacheControlNoCacheComposite)
-				w.Header().Set(constants.PragmaHeaderName, constants.PragmaNoCache)
-				w.Header().Set(constants.ExpiresHeaderName, constants.ExpiresZero)
-				http.ServeFile(w, r, indexPath)
+			if serveIndex(w, r) {
 				return
 			}
 		}
 
-		// Assert the resolved path stays within `directory` before touching the filesystem.
-		filePath := path.Join(directory, r.URL.Path)
-		cleanDir := filepath.Clean(directory)
-		if filePath != cleanDir && !strings.HasPrefix(filePath, cleanDir+string(os.PathSeparator)) {
-			logger.Warn(r.Context(), "Rejected request with out-of-bounds path",
-				log.String("requested_path", r.URL.Path),
-				log.String("route_prefix", routePrefix))
-			http.NotFound(w, r)
-			return
-		}
+		// Resolve the request against the served directory.
+		name := strings.TrimPrefix(r.URL.Path, "/")
+		isIndexHTML := name == "index.html"
 
-		// Check if the requested file is index.html
-		isIndexHTML := r.URL.Path == "/index.html" || path.Base(filePath) == "index.html"
-
-		// Check if file exists
-		if _, err := os.Stat(filePath); os.IsNotExist(err) {
-			// For SPA routing, serve index.html for non-existent files
-			indexPath := path.Join(directory, "index.html")
-			if fileExists(indexPath) {
-				logger.Debug(r.Context(), "Serving index.html for SPA routing",
-					log.String("requested_path", r.URL.Path),
-					log.String("route_prefix", routePrefix))
-				// Set no-cache headers for index.html
-				w.Header().Set(constants.CacheControlHeaderName, constants.CacheControlNoCacheComposite)
-				w.Header().Set(constants.PragmaHeaderName, constants.PragmaNoCache)
-				w.Header().Set(constants.ExpiresHeaderName, constants.ExpiresZero)
-				http.ServeFile(w, r, indexPath)
-				return
+		if name != "" {
+			if _, err := root.Stat(name); err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					// For SPA routing, serve index.html for non-existent in-bounds paths.
+					logger.Debug(r.Context(), "Serving index.html for SPA routing",
+						log.String("requested_path", r.URL.Path),
+						log.String("route_prefix", routePrefix))
+					if serveIndex(w, r) {
+						return
+					}
+				} else {
+					// The path escapes the served directory (or is otherwise invalid).
+					logger.Warn(r.Context(), "Rejected request with out-of-bounds path",
+						log.String("requested_path", r.URL.Path),
+						log.String("route_prefix", routePrefix))
+					http.NotFound(w, r)
+					return
+				}
 			}
 		}
 
-		// Serve index.html directly with no-cache headers when requested
+		// Serve index.html directly with no-cache headers when requested.
 		if isIndexHTML {
-			indexPath := path.Join(directory, "index.html")
-			if fileExists(indexPath) {
-				// Set no-cache headers for index.html
-				w.Header().Set(constants.CacheControlHeaderName, constants.CacheControlNoCacheComposite)
-				w.Header().Set(constants.PragmaHeaderName, constants.PragmaNoCache)
-				w.Header().Set(constants.ExpiresHeaderName, constants.ExpiresZero)
-				http.ServeFile(w, r, indexPath)
+			if serveIndex(w, r) {
 				return
 			}
 		}
 
-		// Serve the requested file or directory listing
+		// Serve the requested file or directory listing.
 		fileServer.ServeHTTP(w, r)
-	}))
-}
-
-// directoryExists checks if a directory exists.
-func directoryExists(path string) bool {
-	info, err := os.Stat(path)
-	return err == nil && info.IsDir()
-}
-
-// fileExists checks if a file exists.
-func fileExists(path string) bool {
-	info, err := os.Stat(path)
-	return err == nil && !info.IsDir()
+	})), nil
 }

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -42,6 +42,7 @@ import (
 	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/system/config"
@@ -257,7 +258,8 @@ func TestCreateStaticFileHandler(t *testing.T) {
 	requireWriteFile(t, filepath.Join(tmpDir, "index.html"), indexContent)
 	requireWriteFile(t, filepath.Join(tmpDir, "hello.txt"), fileContent)
 
-	handler := createStaticFileHandler("/app/", tmpDir, logger)
+	handler, err := createStaticFileHandler("/app/", tmpDir, logger)
+	require.NoError(t, err)
 
 	t.Run("serves existing file", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/app/hello.txt", nil)
@@ -291,6 +293,38 @@ func TestCreateStaticFileHandler(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, rr.Code)
 		assert.NotContains(t, rr.Body.String(), "root:")
 	})
+
+	t.Run("returns error when the directory cannot be opened", func(t *testing.T) {
+		_, err := createStaticFileHandler("/app/", filepath.Join(tmpDir, "does-not-exist"), logger)
+		require.Error(t, err)
+	})
+
+	t.Run("returns 404 when index.html is absent and file not found", func(t *testing.T) {
+		noIndexDir := t.TempDir()
+		requireWriteFile(t, filepath.Join(noIndexDir, "asset.txt"), []byte("asset"))
+		noIndexHandler, err := createStaticFileHandler("/app/", noIndexDir, logger)
+		require.NoError(t, err)
+
+		req := httptest.NewRequest(http.MethodGet, "/app/unknown", nil)
+		rr := httptest.NewRecorder()
+
+		noIndexHandler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusNotFound, rr.Code)
+	})
+
+	t.Run("serves nested index.html through the normal file flow", func(t *testing.T) {
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "nested"), 0o750))
+		requireWriteFile(t, filepath.Join(tmpDir, "nested", "index.html"), []byte("nested index"))
+
+		req := httptest.NewRequest(http.MethodGet, "/app/nested/index.html", nil)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		// The nested file must not be served through the root index.html no-cache branch.
+		assert.Empty(t, rr.Header().Get(constants.CacheControlHeaderName))
+	})
 }
 
 func TestCreateStaticFileHandler_CacheHeaders(t *testing.T) {
@@ -307,7 +341,8 @@ func TestCreateStaticFileHandler_CacheHeaders(t *testing.T) {
 	requireWriteFile(t, filepath.Join(tmpDir, "styles.css"), cssContent)
 	requireWriteFile(t, filepath.Join(tmpDir, "logo.png"), imageContent)
 
-	handler := createStaticFileHandler("/app/", tmpDir, logger)
+	handler, err := createStaticFileHandler("/app/", tmpDir, logger)
+	require.NoError(t, err)
 
 	t.Run("sets cache headers when serving index.html at root", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/app/", nil)
@@ -421,42 +456,6 @@ func TestCreateStaticFileHandler_CacheHeaders(t *testing.T) {
 		assert.Empty(t, rr.Header().Get(constants.ExpiresHeaderName),
 			"Expires should not be set for files that contain 'index.html' but are not exactly 'index.html'")
 		assert.Equal(t, string(customIndexFile), rr.Body.String())
-	})
-}
-
-func TestDirectoryExists(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	t.Run("returns true for existing directory", func(t *testing.T) {
-		assert.True(t, directoryExists(tmpDir))
-	})
-
-	t.Run("returns false for non-existent directory", func(t *testing.T) {
-		assert.False(t, directoryExists(filepath.Join(tmpDir, "nonexistent")))
-	})
-
-	t.Run("returns false for file, not directory", func(t *testing.T) {
-		filePath := filepath.Join(tmpDir, "file.txt")
-		requireWriteFile(t, filePath, []byte("content"))
-		assert.False(t, directoryExists(filePath))
-	})
-}
-
-func TestFileExists(t *testing.T) {
-	tmpDir := t.TempDir()
-	filePath := filepath.Join(tmpDir, "file.txt")
-	requireWriteFile(t, filePath, []byte("content"))
-
-	t.Run("returns true for existing file", func(t *testing.T) {
-		assert.True(t, fileExists(filePath))
-	})
-
-	t.Run("returns false for non-existent file", func(t *testing.T) {
-		assert.False(t, fileExists(filepath.Join(tmpDir, "nonexistent.txt")))
-	})
-
-	t.Run("returns false for directory, not file", func(t *testing.T) {
-		assert.False(t, fileExists(tmpDir))
 	})
 }
 

--- a/docs/src/theme/Root.tsx
+++ b/docs/src/theme/Root.tsx
@@ -45,12 +45,11 @@ export default function Root({children = null}: PropsWithChildren<Record<string,
       ? 'home'
       : pathname.replace(/\//g, '-').replace(/^-|-$/g, '') || 'home';
 
-    // Allowlist the derived value to safe attribute characters. setAttribute writes an
-    // attribute value (not markup) and does not execute HTML, but this makes the safety
-    // explicit and clears the DOM-XSS finding for this sink.
+    // Restrict the derived value to a known-safe character set and write it through the
+    // dataset API, which can only ever set an inert data-* attribute (read by CSS selectors).
     const safePagePath = pagePath.replace(/[^a-z0-9-]/gi, '') || 'home';
 
-    html.setAttribute('data-page', safePagePath);
+    html.dataset.page = safePagePath;
   }, [location.pathname, baseUrl]);
 
   // Restore persona selection from localStorage before first paint.


### PR DESCRIPTION
### Purpose

Refactors how the backend serves the bundled frontend applications and how the docs theme records the current page, using the standard-library and DOM APIs intended for these jobs. No behavior change for end users.

### Approach

- Static file handler (`backend/cmd/server/main.go`): serve the Gate and Console applications through an `os.Root` anchored at each application directory, using `http.FileServerFS` and `http.ServeFileFS` over `root.FS()`. All lookups (existence checks and file serving) now go through the rooted filesystem, which keeps every resolved path within the served directory and removes the manual path-joining and prefix-checking logic. `createStaticFileHandler` now returns an error, and opening the root is the single gate for registration: if the application directory is missing or cannot be opened, it is logged and skipped. The SPA index fallback and no-cache header behavior are unchanged. The now-unused `fileExists` and `directoryExists` helpers are removed.
- Docs theme (`docs/src/theme/Root.tsx`): set the `data-page` attribute through the `dataset` API instead of `setAttribute`. The derived value is still restricted to a known-safe character set, and existing `html[data-page=...]` CSS selectors continue to match.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved static-file serving for `/gate/` and `/console/` to ensure requests can’t escape the configured directories.
  * Corrected routing and asset handling, including safe fallback to `index.html` for SPA navigation with proper no-cache behavior.
  * The server now skips static route registration if the static handler can’t be initialized, logging warnings instead of risking unexpected behavior.
* **Documentation**
  * Updated page metadata to be written via an inert `data-*` DOM field (same visual behavior).
* **Tests**
  * Expanded and adjusted static-file handler tests to cover new success and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->