### PR TITLE
Validate duplicate application names early in the console creation wizard

### DIFF
--- a/frontend/apps/console/src/features/applications/components/create-application/ConfigureApplicationDetails.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/ConfigureApplicationDetails.tsx
@@ -103,6 +103,11 @@ export interface ConfigureApplicationDetailsProps {
    * Callback function to broadcast whether this step is ready to proceed.
    */
   onReadyChange?: (isReady: boolean) => void;
+
+  /**
+   * Application names already in use, so a duplicate name can be flagged before submission.
+   */
+  existingAppNames?: string[];
 }
 
 /**
@@ -128,17 +133,21 @@ export default function ConfigureApplicationDetails({
   selectedUserTypes,
   onUserTypesChange,
   onReadyChange = undefined,
+  existingAppNames = [],
 }: ConfigureApplicationDetailsProps): JSX.Element {
   const {t} = useTranslation();
   const {data: organizationUnit, isLoading: isOuLoading} = useGetOrganizationUnit(resolvedOuId, Boolean(resolvedOuId));
 
+  // Exact match, mirroring the server's uniqueness check.
+  const isDuplicateName: boolean = appName !== '' && existingAppNames.includes(appName);
+
   useEffect((): void => {
     if (!onReadyChange) return;
-    const nameReady = appName.trim().length > 0;
+    const nameReady = appName.trim().length > 0 && !isDuplicateName;
     const ouReady = !hasMultipleOUs || selectedOuId.length > 0;
     const userAccessReady = userTypes.length < 2 || selectedUserTypes.length > 0;
     onReadyChange(nameReady && ouReady && userAccessReady);
-  }, [appName, hasMultipleOUs, selectedOuId, userTypes, selectedUserTypes, onReadyChange]);
+  }, [appName, isDuplicateName, hasMultipleOUs, selectedOuId, userTypes, selectedUserTypes, onReadyChange]);
 
   // Default to "allow all" the first time user types load, mirroring the master checkbox's
   // default-checked state in UserAccessSection. Seeds at most once — otherwise this would fight
@@ -206,6 +215,7 @@ export default function ConfigureApplicationDetails({
         appLogo={appLogo}
         onLogoSelect={onLogoSelect}
         showTitle={false}
+        existingAppNames={existingAppNames}
       />
 
       {(showOuDefaults || showUserAccess) && (

--- a/frontend/apps/console/src/features/applications/components/create-application/ConfigureName.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/ConfigureName.tsx
@@ -45,6 +45,11 @@ export interface ConfigureNameProps {
    * @defaultValue true
    */
   showTitle?: boolean;
+
+  /**
+   * Application names already in use, so a duplicate can be flagged before submission
+   */
+  existingAppNames?: string[];
 }
 
 /**
@@ -96,8 +101,12 @@ export default function ConfigureName({
   onLogoSelect,
   onReadyChange = undefined,
   showTitle = true,
+  existingAppNames = [],
 }: ConfigureNameProps): JSX.Element {
   const {t} = useTranslation();
+
+  // Exact match, mirroring the server's uniqueness check.
+  const isDuplicateName: boolean = appName !== '' && existingAppNames.includes(appName);
 
   /**
    * Default to a generated entity avatar the first time this step is reached, so the logo
@@ -121,11 +130,11 @@ export default function ConfigureName({
    * Broadcast readiness whenever appName changes.
    */
   useEffect((): void => {
-    const isReady: boolean = appName.trim().length > 0;
+    const isReady: boolean = appName.trim().length > 0 && !isDuplicateName;
     if (onReadyChange) {
       onReadyChange(isReady);
     }
-  }, [appName, onReadyChange]);
+  }, [appName, isDuplicateName, onReadyChange]);
 
   return (
     <Stack direction="column" spacing={4} data-testid="application-configure-name">
@@ -155,6 +164,8 @@ export default function ConfigureName({
               value={appName}
               onChange={(e: ChangeEvent<HTMLInputElement>): void => onAppNameChange(e.target.value)}
               placeholder={t('applications:onboarding.configure.name.placeholder')}
+              error={isDuplicateName}
+              helperText={isDuplicateName ? t('applications:errors.APP-1020') : undefined}
               inputProps={{
                 'data-testid': 'app-name-input',
               }}

--- a/frontend/apps/console/src/features/applications/components/create-application/__tests__/ConfigureName.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/__tests__/ConfigureName.test.tsx
@@ -310,4 +310,63 @@ describe('ConfigureName', () => {
       expect(mockOnReadyChange).toHaveBeenCalledWith(false);
     });
   });
+
+  describe('duplicate name detection', () => {
+    const duplicateMessage = 'An application with this name already exists. Choose a different name.';
+
+    it('should show an inline error and block readiness for an exact duplicate name', () => {
+      const mockOnReadyChange = vi.fn();
+      renderComponent({appName: 'My App', existingAppNames: ['My App'], onReadyChange: mockOnReadyChange});
+
+      expect(screen.getByText(duplicateMessage)).toBeInTheDocument();
+      expect(mockOnReadyChange).toHaveBeenCalledWith(false);
+    });
+
+    it('should not flag case-variant names as duplicates', () => {
+      const mockOnReadyChange = vi.fn();
+      renderComponent({appName: 'my app', existingAppNames: ['My App'], onReadyChange: mockOnReadyChange});
+
+      expect(screen.queryByText(duplicateMessage)).not.toBeInTheDocument();
+      expect(mockOnReadyChange).toHaveBeenCalledWith(true);
+    });
+
+    it('should become ready again when the name is edited to a unique one', () => {
+      const mockOnReadyChange = vi.fn();
+      const {rerender} = render(
+        <ConfigureName
+          appName="My App"
+          existingAppNames={['My App']}
+          onAppNameChange={mockOnAppNameChange}
+          appLogo={defaultProps.appLogo}
+          onLogoSelect={mockOnLogoSelect}
+          onReadyChange={mockOnReadyChange}
+        />,
+      );
+
+      expect(mockOnReadyChange).toHaveBeenCalledWith(false);
+      mockOnReadyChange.mockClear();
+
+      rerender(
+        <ConfigureName
+          appName="My App 2"
+          existingAppNames={['My App']}
+          onAppNameChange={mockOnAppNameChange}
+          appLogo={defaultProps.appLogo}
+          onLogoSelect={mockOnLogoSelect}
+          onReadyChange={mockOnReadyChange}
+        />,
+      );
+
+      expect(screen.queryByText(duplicateMessage)).not.toBeInTheDocument();
+      expect(mockOnReadyChange).toHaveBeenCalledWith(true);
+    });
+
+    it('should behave as before when existingAppNames is omitted', () => {
+      const mockOnReadyChange = vi.fn();
+      renderComponent({appName: 'My App', onReadyChange: mockOnReadyChange});
+
+      expect(screen.queryByText(duplicateMessage)).not.toBeInTheDocument();
+      expect(mockOnReadyChange).toHaveBeenCalledWith(true);
+    });
+  });
 });

--- a/frontend/apps/console/src/features/applications/constants/application-constants.ts
+++ b/frontend/apps/console/src/features/applications/constants/application-constants.ts
@@ -9,6 +9,11 @@ const ApplicationConstants = {
    * Fallback avatar rendered when an application has no logo set.
    */
   DEFAULT_AVATAR: 'avatar:shape=rounded,variant=anonymous_entity,content=cube,colors=0',
+
+  /**
+   * Backend error code (HTTP 400 body code) returned when an application name is already in use.
+   */
+  DUPLICATE_APP_NAME_ERROR_CODE: 'APP-1020',
 } as const;
 
 export default ApplicationConstants;

--- a/frontend/apps/console/src/features/applications/pages/ApplicationCreatePage.tsx
+++ b/frontend/apps/console/src/features/applications/pages/ApplicationCreatePage.tsx
@@ -36,6 +36,7 @@ import ConfigureApplicationDetails from '../components/create-application/Config
 import ConfigureDesign from '../components/create-application/ConfigureDesign';
 import ConfigureDetails from '../components/create-application/ConfigureDetails';
 import ConfigureMcpClientType from '../components/create-application/mcp/ConfigureMcpClientType';
+import ApplicationConstants from '../constants/application-constants';
 import TemplateConstants from '../constants/template-constants';
 import useApplicationCreate from '../contexts/ApplicationCreate/useApplicationCreate';
 import {
@@ -169,7 +170,22 @@ export default function ApplicationCreatePage(): JSX.Element {
     [applicationsData],
   );
 
+  // Application names already in use, so the details step can flag a duplicate before submission.
+  const existingAppNames = useMemo(
+    (): string[] => (applicationsData?.applications ?? []).map((app) => app.name).filter(Boolean),
+    [applicationsData],
+  );
+
   const [selectedUserTypes, setSelectedUserTypes] = useState<string[]>([]);
+  // Names the server rejected as duplicates (APP-1020) that weren't in the fetched existingAppNames
+  // (e.g. beyond the pagination limit). Treated as additional existing names so the details step
+  // flags them and blocks readiness until the name is edited, avoiding a resubmit-and-fail loop.
+  const [rejectedAppNames, setRejectedAppNames] = useState<string[]>([]);
+
+  const knownAppNames = useMemo(
+    (): string[] => [...existingAppNames, ...rejectedAppNames],
+    [existingAppNames, rejectedAppNames],
+  );
 
   const createFlow = useCreateFlow();
   const {data: idpData} = useIdentityProviders();
@@ -660,6 +676,16 @@ export default function ApplicationCreatePage(): JSX.Element {
         });
       },
       onError: (err: Error) => {
+        // The client-side pre-check can miss names beyond the fetched list; when the backend rejects
+        // a name as a duplicate, record it so the details step flags it and stays un-ready until the
+        // name is edited (preventing a resubmit-and-fail loop), then return there.
+        // getApplicationErrorMessage resolves the errors.APP-1020 message for this case (and the
+        // generic message otherwise).
+        const errorCode = (err as {response?: {data?: {code?: string}}})?.response?.data?.code;
+        if (errorCode === ApplicationConstants.DUPLICATE_APP_NAME_ERROR_CODE) {
+          setRejectedAppNames((prev) => (prev.includes(appName) ? prev : [...prev, appName]));
+          setCurrentStep(ApplicationCreateFlowStep.DETAILS);
+        }
         setError(
           getApplicationErrorMessage(
             err,
@@ -813,6 +839,7 @@ export default function ApplicationCreatePage(): JSX.Element {
             selectedUserTypes={selectedUserTypes}
             onUserTypesChange={handleUserTypesChange}
             onReadyChange={handleDetailsStepReadyChange}
+            existingAppNames={knownAppNames}
           />
         );
 

--- a/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationCreatePage.test.tsx
+++ b/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationCreatePage.test.tsx
@@ -169,15 +169,17 @@ vi.mock('@thunderid/configure-organization-units', () => ({
 // "application-configure-name" (rather than the real component's "application-configure-details")
 // to avoid colliding with the CONFIGURE step's mock below, which never renders at the same time
 // but shares the same real-component testid convention.
-vi.mock('../../components/create-application/ConfigureApplicationDetails', () => ({
-  default: ({
+vi.mock('../../components/create-application/ConfigureApplicationDetails', async () => {
+  const {useEffect} = await import('react');
+  const MockConfigureApplicationDetails = ({
     hasMultipleOUs,
     onChangeOu,
     appName,
     onAppNameChange,
     appLogo,
     onLogoSelect,
-    onReadyChange,
+    onReadyChange = undefined,
+    existingAppNames = [],
   }: {
     hasMultipleOUs: boolean;
     onChangeOu: () => void;
@@ -186,29 +188,37 @@ vi.mock('../../components/create-application/ConfigureApplicationDetails', () =>
     appLogo: string | null;
     onLogoSelect: (logo: string) => void;
     onReadyChange?: (ready: boolean) => void;
-  }) => (
-    <div data-testid="application-configure-name">
-      {hasMultipleOUs && (
-        <button type="button" onClick={onChangeOu}>
-          Change
+    existingAppNames?: string[];
+  }) => {
+    // Mirror the real component: readiness is broadcast from an effect (including on mount) and a
+    // name already in the list is treated as a duplicate that blocks readiness.
+    const isDuplicate = appName.length > 0 && existingAppNames.includes(appName);
+    useEffect(() => {
+      onReadyChange?.(appName.trim().length > 0 && !isDuplicate);
+    }, [appName, isDuplicate, onReadyChange]);
+    return (
+      <div data-testid="application-configure-name" data-existing-names={existingAppNames.join(',')}>
+        {hasMultipleOUs && (
+          <button type="button" onClick={onChangeOu}>
+            Change
+          </button>
+        )}
+        {appLogo ? <span data-testid="preview-logo">{appLogo}</span> : null}
+        <button type="button" data-testid="logo-select-btn" onClick={() => onLogoSelect('test-logo.png')}>
+          Select Logo
         </button>
-      )}
-      {appLogo ? <span data-testid="preview-logo">{appLogo}</span> : null}
-      <button type="button" data-testid="logo-select-btn" onClick={() => onLogoSelect('test-logo.png')}>
-        Select Logo
-      </button>
-      <input
-        data-testid="app-name-input"
-        value={appName}
-        onChange={(e) => {
-          onAppNameChange(e.target.value);
-          onReadyChange?.(e.target.value.length > 0);
-        }}
-        placeholder="Enter app name"
-      />
-    </div>
-  ),
-}));
+        <input
+          data-testid="app-name-input"
+          value={appName}
+          onChange={(e) => onAppNameChange(e.target.value)}
+          placeholder="Enter app name"
+        />
+        {isDuplicate ? <span data-testid="app-name-duplicate-error">duplicate</span> : null}
+      </div>
+    );
+  };
+  return {default: MockConfigureApplicationDetails};
+});
 
 // The Design step now also hosts the sign-in approach picker (hosted pages vs. embedded) that used
 // to live on a separate Experience step, so this mock folds what used to be the ConfigureExperience
@@ -1457,6 +1467,81 @@ describe('ApplicationCreatePage', () => {
       await waitFor(() => {
         expect(screen.queryByText(/failed to create application/i)).not.toBeInTheDocument();
       });
+    });
+
+    it('should show the duplicate name message and return to the details step on APP-1020', async () => {
+      const duplicateError = Object.assign(new Error('Bad Request'), {
+        response: {status: 400, data: {code: 'APP-1020', message: 'Application already exists'}},
+      });
+      mockCreateApplication.mockImplementation((_data, {onError}: {onError: (error: Error) => void}) => {
+        onError(duplicateError);
+      });
+
+      renderWithProviders();
+
+      await goToDesignStep();
+      // DESIGN → CONFIGURE
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
+      });
+      // CONFIGURE → Create (rejected with APP-1020)
+      await user.click(screen.getByTestId('application-wizard-next-button'));
+
+      await waitFor(
+        () => {
+          expect(screen.getByText(/an application with this name already exists/i)).toBeInTheDocument();
+        },
+        {timeout: 10000},
+      );
+      expect(screen.queryByText(/bad request/i)).not.toBeInTheDocument();
+      // The wizard navigates back to the details step, which hosts the name field.
+      expect(screen.getByTestId('application-configure-name')).toBeInTheDocument();
+    });
+
+    it('should block resubmitting the same name after APP-1020 until it is edited', async () => {
+      const duplicateError = Object.assign(new Error('Bad Request'), {
+        response: {status: 400, data: {code: 'APP-1020', message: 'Application already exists'}},
+      });
+      mockCreateApplication.mockImplementation((_data, {onError}: {onError: (error: Error) => void}) => {
+        onError(duplicateError);
+      });
+
+      renderWithProviders();
+
+      await goToDesignStep();
+      // DESIGN → CONFIGURE
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
+      });
+      // CONFIGURE → Create (rejected with APP-1020)
+      await user.click(screen.getByTestId('application-wizard-next-button'));
+
+      // Back on the details step, the rejected name is now treated as existing: flagged as a
+      // duplicate and Continue disabled, so the same name cannot be resubmitted.
+      await waitFor(() => {
+        expect(screen.getByTestId('application-configure-name')).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('application-configure-name')).toHaveAttribute(
+        'data-existing-names',
+        expect.stringContaining('My App'),
+      );
+      expect(screen.getByTestId('app-name-duplicate-error')).toBeInTheDocument();
+      expect(screen.getByTestId('application-wizard-next-button')).toBeDisabled();
+      expect(screen.getByText(/an application with this name already exists/i)).toBeInTheDocument();
+
+      // Editing to a new name clears the duplicate flag and re-enables Continue. The stale create
+      // error is cleared too, by the provider's form fingerprint.
+      await user.type(screen.getByTestId('app-name-input'), ' v2');
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('app-name-duplicate-error')).not.toBeInTheDocument();
+      });
+      expect(screen.queryByText(/an application with this name already exists/i)).not.toBeInTheDocument();
+      expect(screen.getByTestId('application-wizard-next-button')).toBeEnabled();
     });
   });
 


### PR DESCRIPTION
### Purpose

Fixes the poor UX around duplicate application names in the Console's application creation wizard. Previously, entering a name that already exists was only rejected by the backend when clicking **Finish** on the final "Sign-In Experience" step. Even then, the wizard banner showed a generic "Bad Request" (the raw HTTP status text) while the actual reason ("An application with the same name already exists.", error code `APP-1020`) was hidden in a bottom-right toast away from the user's focus.

With this change:

- The name step flags a duplicate name immediately with an inline error under the field and disables **Continue** until the name is unique.
- If the backend still rejects with `APP-1020` (a name beyond the fetched list, or a race with another session), the wizard shows the specific localized message in the banner instead of "Bad Request" and navigates back to the name step.
- The redundant bottom-right toast is suppressed for this error, so the message appears in one clear place.

<img width="824" height="703" alt="Screenshot 2026-07-12 184712" src="https://github.com/user-attachments/assets/fecf7800-6cee-46d2-9b0f-4b49eda935a9" />

### Approach

1. **Client-side pre-check on the name step**: `ApplicationCreatePage` derives `existingAppNames` from the applications list it already fetches (`useGetApplications({limit: 100})`) and passes it to `ConfigureName`, following the same pattern as the existing duplicate client ID check (`existingClientIds` in `ConfigureDetails`). `ConfigureName` compares the entered name against the list using an exact match, mirroring the backend's exact, case-sensitive uniqueness check, and blocks "Continue" while showing an inline field error.

2. **Server error fallback**: the backend remains the authority for the duplicate check. On create failure, the wizard's `onError` now uses the shared `getErrorMessage` utility (which resolves `errors.APP-1020` from the `applications` i18n namespace) instead of `err.message`. For `APP-1020` specifically, it also navigates back to the name step.

3. **Toast suppression**: a new `isDuplicateAppNameError` utility detects the `APP-1020` error body (the endpoint returns HTTP 400, not 409, so the existing `isConflictError` helper does not apply). `useCreateApplication` skips the toast for this error, mirroring how `useCreateConnection` suppresses conflict toasts so the caller can surface them inline.

4. **i18n**: added `onboarding.configure.name.duplicate` to the `applications` namespace with an actionable message.

### Related Issues

- Fixes #3838

### Related PRs

- N/A

### Checklist

- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks

- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added duplicate application name validation during application creation.
  * Duplicate names now show clear inline feedback and prevent continuing until corrected.
  * Server-rejected duplicate names return users to the details step while preserving the relevant error message.
  * Submission is re-enabled automatically after the name is changed to a unique value.

* **Tests**
  * Added coverage for duplicate detection, case sensitivity, error handling, and recovery after editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->