### PR TITLE
[Docs] Fix clone command in prerequisites documentation

### DIFF
--- a/docs/content/community/contributing/contributing-code/prerequisites.mdx
+++ b/docs/content/community/contributing/contributing-code/prerequisites.mdx
@@ -35,8 +35,8 @@ Start by forking the WSO2 <ProductName /> repository to your GitHub account.
 Clone your forked repository to your local machine.
 
 ```bash
-git clone https://github.com/<your-username>/thunder.git
-cd thunder
+git clone https://github.com/<your-username>/thunderid.git
+cd thunderid
 ```
 
 ## 💻 macOS / Linux Prerequisites


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

The clone repo url in the contributing docs is incorrect.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

Changed the docs to correct url

### Related Issues
- Closes #3935 

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository setup instructions with the correct clone URL.
  * Updated the directory navigation command to match the cloned repository name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->