### PR TITLE
Improve blog label readability in light mode

### DIFF
--- a/docs/src/components/Blog/BlogFeaturedCard.tsx
+++ b/docs/src/components/Blog/BlogFeaturedCard.tsx
@@ -71,7 +71,7 @@ export default function BlogFeaturedCard({content}: {content: Content}): JSX.Ele
                 fontSize: '10px',
                 fontWeight: 600,
                 textTransform: 'uppercase',
-                color: '#8bf9fa',
+                color: isLight ? '#1856b3' : '#8bf9fa',
                 bgcolor: 'rgba(54,136,255,0.12)',
                 border: '1px solid rgba(54,136,255,0.28)',
                 borderRadius: '6px',

--- a/docs/src/components/Blog/BlogHeader.tsx
+++ b/docs/src/components/Blog/BlogHeader.tsx
@@ -19,8 +19,11 @@
 import {Box, Typography} from '@wso2/oxygen-ui';
 import {JSX} from 'react';
 import ProductName from '@site/src/components/ProductName';
+import useIsDarkMode from '../../hooks/useIsDarkMode';
 
 export default function BlogHeader(): JSX.Element {
+  const isDark = useIsDarkMode();
+  const eyebrowColor = isDark ? '#8bf9fa' : '#1a6fe8';
   return (
     <Box sx={{maxWidth: 1200, width: '100%', mx: 'auto', px: {xs: 2, sm: 4}, pt: {xs: 5, md: 7}, pb: 1}}>
       <Box
@@ -34,10 +37,10 @@ export default function BlogHeader(): JSX.Element {
           fontWeight: 600,
           letterSpacing: '0.18em',
           textTransform: 'uppercase',
-          color: '#8bf9fa',
+          color: eyebrowColor,
         }}
       >
-        <Box component="span" sx={{width: 5, height: 5, borderRadius: '50%', bgcolor: '#8bf9fa', boxShadow: '0 0 10px #8bf9fa'}} />
+        <Box component="span" sx={{width: 5, height: 5, borderRadius: '50%', bgcolor: eyebrowColor, boxShadow: `0 0 10px ${eyebrowColor}`}} />
         The <ProductName /> blog
       </Box>
 

--- a/docs/src/components/Blog/BlogPostHero.tsx
+++ b/docs/src/components/Blog/BlogPostHero.tsx
@@ -98,7 +98,7 @@ export default function BlogPostHero({content}: {content: BlogPostContextValue})
               fontSize: '10px',
               fontWeight: 600,
               textTransform: 'uppercase',
-              color: '#8bf9fa',
+              color: isLight ? '#1856b3' : '#8bf9fa',
               bgcolor: 'rgba(54,136,255,0.12)',
               border: '1px solid rgba(54,136,255,0.28)',
               borderRadius: '6px',


### PR DESCRIPTION
## Purpose
Several accent-colored labels on the docs blog used a fixed light-cyan color that was nearly invisible against the pale background in light mode. This makes them legible in light mode while leaving dark mode unchanged.

## Related Issue
- N/A

## Behaviour
<img width="1776" height="767" alt="Screenshot 2026-07-13 at 2 28 38 PM" src="https://github.com/user-attachments/assets/71aacf72-bead-422d-895a-65a0b7584024" />
<img width="1771" height="735" alt="Screenshot 2026-07-13 at 2 28 46 PM" src="https://github.com/user-attachments/assets/42c0fc5e-d2f5-4b5a-800e-497b80d914e4" />


## Implementation
Made the affected label colors theme-aware, using a darker blue in light mode and keeping the existing cyan in dark mode:

- `docs/src/components/Blog/BlogPostHero.tsx` — the post category badge.
- `docs/src/components/Blog/BlogHeader.tsx` — the "The ThunderID blog" eyebrow text and its dot (added the `useIsDarkMode` hook).
- `docs/src/components/Blog/BlogFeaturedCard.tsx` — the "Featured" badge on the blog list page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved blog page color styling across light and dark modes.
  * Updated featured badges, header labels, category tags, and decorative elements for better theme consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->