### PR TITLE
Support batchwise deletion for Temporary Data Deletion

### DIFF
--- a/backend/dbscripts/operationdb/postgres-cleanup.sql
+++ b/backend/dbscripts/operationdb/postgres-cleanup.sql
@@ -16,15 +16,22 @@
 -- ----------------------------------------------------------------------------
 
 -- ============================================================
--- Stored procedure: purge expired operationdb rows.
+-- Stored procedure: purge expired operationdb rows in bounded batches.
 --
 -- Unlike runtimedb, operation data is authoritative and must survive a
 -- runtime flush; only rows past their EXPIRY_TIME are safe to delete. A revoked
 -- token's row is removable once the token itself would have naturally expired.
 --
+-- Deletes expired rows in batches of p_batch_size (default 1000), committing
+-- after each batch to keep locks short on large tables. Must run as a top-level
+-- CALL (the per-batch COMMIT cannot run inside an outer transaction).
+--
 -- Run once manually (ad-hoc / on-demand):
 --   PGPASSWORD=<pass> psql -h <host> -p <port> -U <user> -d <operationdb> \
 --     -c "CALL cleanup_expired_operationdb_data();"
+--
+--   -- Optional: override the batch size (rows deleted per batch):
+--   -c "CALL cleanup_expired_operationdb_data(500);"
 --
 -- Scheduled execution options:
 --
@@ -47,12 +54,29 @@
 -- --        >> /var/log/thunderid-operation-cleanup.log 2>&1
 -- ============================================================
 
-CREATE OR REPLACE PROCEDURE cleanup_expired_operationdb_data()
+-- Drop the old parameterless signature so re-applying doesn't leave an ambiguous overload.
+DROP PROCEDURE IF EXISTS cleanup_expired_operationdb_data();
+
+CREATE OR REPLACE PROCEDURE cleanup_expired_operationdb_data(p_batch_size INT DEFAULT 1000)
 LANGUAGE plpgsql
 AS $$
 DECLARE
-    v_now TIMESTAMP := NOW() AT TIME ZONE 'UTC';
+    v_now     TIMESTAMP := NOW() AT TIME ZONE 'UTC';
+    v_deleted INT;
 BEGIN
-    DELETE FROM "REVOKED_TOKEN" WHERE EXPIRY_TIME < v_now;
+    -- Guard against a batch size that would disable batching or make no progress.
+    IF p_batch_size IS NULL OR p_batch_size <= 0 THEN
+        p_batch_size := 1000;
+    END IF;
+
+    LOOP
+        DELETE FROM "REVOKED_TOKEN"
+        WHERE ctid IN (
+            SELECT ctid FROM "REVOKED_TOKEN" WHERE EXPIRY_TIME < v_now LIMIT p_batch_size
+        );
+        GET DIAGNOSTICS v_deleted = ROW_COUNT;
+        COMMIT;
+        EXIT WHEN v_deleted = 0;
+    END LOOP;
 END;
 $$;

--- a/backend/dbscripts/runtimedb/postgres-cleanup.sql
+++ b/backend/dbscripts/runtimedb/postgres-cleanup.sql
@@ -16,11 +16,18 @@
 -- ----------------------------------------------------------------------------
 
 -- ============================================================
--- Stored procedure: purge all expired runtimedb rows.
+-- Stored procedure: purge expired runtimedb rows in bounded batches.
+--
+-- Deletes expired rows in batches of p_batch_size (default 1000), committing
+-- after each batch to keep locks short on large tables. Must run as a top-level
+-- CALL (the per-batch COMMIT cannot run inside an outer transaction).
 --
 -- Run once manually (ad-hoc / on-demand):
 --   PGPASSWORD=<pass> psql -h <host> -p <port> -U <user> -d <runtimedb> \
 --     -c "CALL cleanup_expired_runtimedb_data();"
+--
+--   -- Optional: override the batch size (rows deleted per batch):
+--   -c "CALL cleanup_expired_runtimedb_data(500);"
 --
 -- Scheduled execution options:
 --
@@ -43,21 +50,60 @@
 -- --        >> /var/log/thunderid-cleanup.log 2>&1
 -- ============================================================
 
-CREATE OR REPLACE PROCEDURE cleanup_expired_runtimedb_data()
+-- Drop the old parameterless signature so re-applying doesn't leave an ambiguous overload.
+DROP PROCEDURE IF EXISTS cleanup_expired_runtimedb_data();
+
+CREATE OR REPLACE PROCEDURE cleanup_expired_runtimedb_data(p_batch_size INT DEFAULT 1000)
 LANGUAGE plpgsql
 AS $$
 DECLARE
-    v_now TIMESTAMP := NOW() AT TIME ZONE 'UTC';
+    v_now     TIMESTAMP := NOW() AT TIME ZONE 'UTC';
+    v_deleted INT;
+    v_table   TEXT;
+    -- Tables located by ctid. Safe because each is a single, non-partitioned
+    -- relation, so ctid uniquely identifies a row within it.
+    v_ctid_tables TEXT[] := ARRAY[
+        'AUTHORIZATION_CODE',
+        'AUTHORIZATION_REQUEST',
+        'CIBA_AUTH_REQUEST',
+        'WEBAUTHN_SESSION',
+        'PAR_REQUEST',
+        'JTI_RECORD',
+        'OPENID4VP_REQUEST_STATE',
+        'OPENID4VCI_NONCE',
+        'OPENID4VCI_CREDENTIAL_OFFER'
+    ];
 BEGIN
-    DELETE FROM "AUTHORIZATION_CODE"    WHERE EXPIRY_TIME < v_now;
-    DELETE FROM "AUTHORIZATION_REQUEST" WHERE EXPIRY_TIME < v_now;
-    DELETE FROM "CIBA_AUTH_REQUEST"     WHERE EXPIRY_TIME < v_now;
-    DELETE FROM "WEBAUTHN_SESSION"      WHERE EXPIRY_TIME < v_now;
-    DELETE FROM "PAR_REQUEST"           WHERE EXPIRY_TIME < v_now;
-    DELETE FROM "JTI_RECORD"            WHERE EXPIRY_TIME < v_now;
-    DELETE FROM "OPENID4VP_REQUEST_STATE"      WHERE EXPIRY_TIME < v_now;
-    DELETE FROM "OPENID4VCI_NONCE"             WHERE EXPIRY_TIME < v_now;
-    DELETE FROM "OPENID4VCI_CREDENTIAL_OFFER"  WHERE EXPIRY_TIME < v_now;
-    DELETE FROM "RUNTIME_STORE"         WHERE EXPIRY_TIME < v_now;
+    -- Guard against a batch size that would disable batching or make no progress.
+    IF p_batch_size IS NULL OR p_batch_size <= 0 THEN
+        p_batch_size := 1000;
+    END IF;
+
+    FOREACH v_table IN ARRAY v_ctid_tables LOOP
+        LOOP
+            EXECUTE format(
+                'DELETE FROM %I WHERE ctid IN ' ||
+                '(SELECT ctid FROM %I WHERE EXPIRY_TIME < $1 LIMIT $2)',
+                v_table, v_table
+            ) USING v_now, p_batch_size;
+            GET DIAGNOSTICS v_deleted = ROW_COUNT;
+            COMMIT;
+            EXIT WHEN v_deleted = 0;
+        END LOOP;
+    END LOOP;
+
+    -- RUNTIME_STORE is LIST-partitioned by NAMESPACE, where ctid is not unique across
+    -- partitions; match rows by primary key rather than ctid. ORDER BY EXPIRY_TIME lets
+    -- the batch be located via an index scan.
+    LOOP
+        DELETE FROM "RUNTIME_STORE"
+        WHERE (DEPLOYMENT_ID, NAMESPACE, KEY) IN (
+            SELECT DEPLOYMENT_ID, NAMESPACE, KEY FROM "RUNTIME_STORE"
+            WHERE EXPIRY_TIME < v_now ORDER BY EXPIRY_TIME LIMIT p_batch_size
+        );
+        GET DIAGNOSTICS v_deleted = ROW_COUNT;
+        COMMIT;
+        EXIT WHEN v_deleted = 0;
+    END LOOP;
 END;
 $$;


### PR DESCRIPTION
### Purpose
The PostgreSQL cleanup procedures for the operation and runtime databases deleted all expired rows in a single statement per table. On large tables this takes a long lock and produces one very large transaction.

This PR changes both procedures to delete expired rows in bounded batches, committing after each batch, so locks stay short and each transaction stays small regardless of how much expired data has accumulated.

### Approach
Both `cleanup_expired_operationdb_data` and `cleanup_expired_runtimedb_data` now accept an optional `p_batch_size` parameter (default 1000) and loop, deleting up to that many expired rows per iteration and committing after each batch. 

Because each batch commits, the procedures must run as a top-level `CALL` and cannot be nested inside an outer transaction. This is documented in the header comments along with an example of overriding the batch size.

Per-table batch selection:

- Most tables are located by `ctid`, which is safe because each is a single, non-partitioned relation where `ctid` uniquely identifies a row. The runtime procedure iterates these tables from an array to avoid repeating the batch loop.
- `RUNTIME_STORE` is LIST-partitioned by `NAMESPACE`, where `ctid` is not unique across partitions, so its batch is matched by primary key (`DEPLOYMENT_ID`, `NAMESPACE`, `KEY`) instead. The subselect orders by `EXPIRY_TIME` so the batch can be located via an index scan.

The operation database procedure keeps its existing semantics: only `REVOKED_TOKEN` rows past their `EXPIRY_TIME` are removed.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3799


### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved cleanup of expired data by processing records in manageable batches.
  * Reduced transaction and lock duration during cleanup operations.
  * Added configurable batch sizes, with a safe default applied for invalid values.
  * Cleanup now continues in repeated batches until all expired records are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->