### PR TITLE
Fix Wayfinder SQLite support

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2662,6 +2662,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.17.4
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
       dotenv:
         specifier: ^16.5.0
         version: 16.6.1
@@ -12967,6 +12970,72 @@ packages:
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
+  better-sqlite3@11.10.0:
+    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  node-abi@3.94.0:
+    resolution: {integrity: sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==}
+    engines: {node: '>=10'}
+
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  tar-fs@2.1.5:
+    resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
 snapshots:
 
@@ -25878,3 +25947,92 @@ snapshots:
       react: 19.2.3
 
   zwitch@2.0.4: {}
+
+  better-sqlite3@11.10.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  chownr@1.1.4: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
+  expand-template@2.0.3: {}
+
+  file-uri-to-path@1.0.0: {}
+
+  fs-constants@1.0.0: {}
+
+  github-from-package@0.0.0: {}
+
+  mkdirp-classic@0.5.3: {}
+
+  napi-build-utils@2.0.0: {}
+
+  node-abi@3.94.0:
+    dependencies:
+      semver: 7.8.1
+
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.94.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.5
+      tunnel-agent: 0.6.0
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
+  tar-fs@2.1.5:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,8 @@ verifyDepsBeforeRun: false
 allowBuilds:
   '@parcel/watcher': false
   '@swc/core': false
+  # JUSTIFICATION: Wayfinder uses better-sqlite3 as the Node 18/20 fallback for node:sqlite.
+  better-sqlite3: true
   core-js: false
   core-js-pure: false
   # JUSTIFICATION: The `esbuild` package is not directly and might be coming from a transitive dependency. Not required to be built as part of the workspace.

--- a/samples/apps/wayfinder-sample/backend/package.json
+++ b/samples/apps/wayfinder-sample/backend/package.json
@@ -6,14 +6,16 @@
   "scripts": {
     "dev": "node scripts/seed.js && node --watch src/server.js",
     "seed": "node scripts/seed.js",
-    "start": "node scripts/seed.js && node src/server.js"
+    "start": "node scripts/seed.js && node src/server.js",
+    "test": "node --test src/*.test.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.4",
+    "better-sqlite3": "^11.10.0",
     "dotenv": "^16.5.0",
     "zod": "^3.25.76"
   },
   "engines": {
-    "node": ">=22.13.0"
+    "node": ">=18.19.0"
   }
 }

--- a/samples/apps/wayfinder-sample/backend/scripts/seed.js
+++ b/samples/apps/wayfinder-sample/backend/scripts/seed.js
@@ -16,10 +16,10 @@
  * under the License.
  */
 
-import { DatabaseSync } from "node:sqlite";
 import { existsSync, mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { DatabaseSync } from "../src/sqlite.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const apiRoot = resolve(__dirname, "..");

--- a/samples/apps/wayfinder-sample/backend/src/db.js
+++ b/samples/apps/wayfinder-sample/backend/src/db.js
@@ -16,10 +16,10 @@
  * under the License.
  */
 
-import { DatabaseSync } from "node:sqlite";
 import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { DatabaseSync } from "./sqlite.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const defaultDbPath = resolve(__dirname, "..", "wayfinder.sqlite");

--- a/samples/apps/wayfinder-sample/backend/src/sqlite.js
+++ b/samples/apps/wayfinder-sample/backend/src/sqlite.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class NodeSqliteDatabase {
+  constructor(DatabaseSync, path) {
+    this.database = new DatabaseSync(path);
+  }
+
+  close() {
+    return this.database.close();
+  }
+
+  exec(sql) {
+    return this.database.exec(sql);
+  }
+
+  prepare(sql) {
+    return this.database.prepare(sql);
+  }
+
+  transaction(callback) {
+    return (...args) => {
+      this.exec("BEGIN TRANSACTION");
+
+      try {
+        const result = callback(...args);
+        this.exec("COMMIT");
+
+        return result;
+      } catch (error) {
+        this.exec("ROLLBACK");
+
+        throw error;
+      }
+    };
+  }
+}
+
+export function isNodeSqlitePublicVersion(version = process.versions.node) {
+  const [major = 0, minor = 0] = version.split(".").map(Number);
+
+  return major > 23 || (major === 23 && minor >= 4) || (major === 22 && minor >= 13);
+}
+
+async function loadDatabaseSync() {
+  const provider = process.env.WAYFINDER_SQLITE_PROVIDER || "auto";
+
+  if (provider !== "auto" && provider !== "node:sqlite" && provider !== "better-sqlite3") {
+    throw new Error(`Unsupported WAYFINDER_SQLITE_PROVIDER: ${provider}`);
+  }
+
+  if (provider === "node:sqlite" || (provider === "auto" && isNodeSqlitePublicVersion())) {
+    try {
+      const { DatabaseSync } = await import("node:sqlite");
+
+      return class Database extends NodeSqliteDatabase {
+        constructor(path) {
+          super(DatabaseSync, path);
+        }
+      };
+    } catch (error) {
+      if (provider === "node:sqlite" || error.code !== "ERR_UNKNOWN_BUILTIN_MODULE") {
+        throw error;
+      }
+    }
+  }
+
+  try {
+    const { default: Database } = await import("better-sqlite3");
+
+    return Database;
+  } catch (error) {
+    if (provider === "better-sqlite3") {
+      throw error;
+    }
+
+    throw new Error(
+      "SQLite requires Node.js with node:sqlite support or an installed better-sqlite3 fallback.",
+      { cause: error },
+    );
+  }
+}
+
+export const DatabaseSync = await loadDatabaseSync();

--- a/samples/apps/wayfinder-sample/backend/src/sqlite.test.js
+++ b/samples/apps/wayfinder-sample/backend/src/sqlite.test.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+
+import { DatabaseSync, isNodeSqlitePublicVersion } from "./sqlite.js";
+
+const execFileAsync = promisify(execFile);
+
+test("identifies Node versions where node:sqlite is public", () => {
+    assert.equal(isNodeSqlitePublicVersion("20.19.0"), false);
+    assert.equal(isNodeSqlitePublicVersion("22.12.0"), false);
+    assert.equal(isNodeSqlitePublicVersion("22.13.0"), true);
+    assert.equal(isNodeSqlitePublicVersion("23.3.0"), false);
+    assert.equal(isNodeSqlitePublicVersion("23.4.0"), true);
+    assert.equal(isNodeSqlitePublicVersion("24.0.0"), true);
+});
+
+test("sqlite adapter supports the synchronous database API used by Wayfinder", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "wayfinder-sqlite-"));
+    const db = new DatabaseSync(join(tempDir, "test.sqlite"));
+
+    try {
+        db.exec("CREATE TABLE records (id TEXT PRIMARY KEY, value TEXT NOT NULL)");
+
+        const insert = db.prepare("INSERT INTO records (id, value) VALUES (@id, @value)");
+        db.transaction(() => {
+            insert.run({ id: "record-1", value: "created" });
+        })();
+
+        const row = db.prepare("SELECT * FROM records WHERE id = @id").get({ id: "record-1" });
+
+        assert.deepEqual({ ...row }, { id: "record-1", value: "created" });
+    } finally {
+        db.close();
+        await rm(tempDir, { recursive: true, force: true });
+    }
+});
+
+test("sqlite adapter can force the better-sqlite3 fallback", async () => {
+    const { stdout } = await execFileAsync(
+        process.execPath,
+        [
+            "--input-type=module",
+            "--eval",
+            `
+                import { DatabaseSync } from "./src/sqlite.js";
+
+                const db = new DatabaseSync(":memory:");
+                db.exec("CREATE TABLE records (id TEXT PRIMARY KEY)");
+                db.prepare("INSERT INTO records (id) VALUES (@id)").run({ id: "fallback" });
+                console.log(db.prepare("SELECT id FROM records").get().id);
+                db.close();
+            `,
+        ],
+        {
+            cwd: new URL("..", import.meta.url),
+            env: {
+                ...process.env,
+                WAYFINDER_SQLITE_PROVIDER: "better-sqlite3",
+            },
+        },
+    );
+
+    assert.equal(stdout.trim(), "fallback");
+});


### PR DESCRIPTION
### Purpose
Fixes the Wayfinder sample startup failure on Node 20 caused by direct imports of `node:sqlite`.

`node:sqlite` is not available on Node 20, so the sample backend seed/database path can fail with:

`Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
`
<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach

- Added a small SQLite adapter for the Wayfinder backend.
- The adapter:
   Uses `node:sqlite` when the runtime supports it.
   Falls back to `better-sqlite3` when `node:sqlite` is unavailable.
- Normalizes the synchronous database API used by the sample, including the transaction helper.
- Adds test coverage for both the normal adapter path and the forced `better-sqlite3` fallback path.
- Also updated the Wayfinder backend Node engine range to >=18.19.0 and added better-sqlite3 as the fallback dependency.

### Related Issues
- Fixes https://github.com/thunder-id/thunderid/issues/3959

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic SQLite provider selection for the Wayfinder sample backend, with a `WAYFINDER_SQLITE_PROVIDER` setting to choose explicitly.
  * Included `better-sqlite3` support as an alternative provider when needed.
  * Added a backend test script to run SQLite adapter tests.

* **Compatibility**
  * Lowered the Wayfinder sample backend’s minimum supported Node.js version to **18.19.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->