### PR TITLE
[CLI] Define a minimum Node.js Version + Add Console URL

### DIFF
--- a/tools/cli/internal/cli/root.go
+++ b/tools/cli/internal/cli/root.go
@@ -38,7 +38,25 @@ import (
 	"github.com/thunder-id/thunderid/tools/cli/internal/services/setup"
 	"github.com/thunder-id/thunderid/tools/cli/internal/ui"
 	"github.com/thunder-id/thunderid/tools/cli/internal/ui/spinner"
+	"github.com/thunder-id/thunderid/tools/cli/internal/utils"
 )
+
+// nodeVersionWarning returns a non-blocking warning message when the installed
+// Node.js version is below utils.MinNodeVersion, or "" if it's fine. Sample apps
+// launched via the try-* commands run on Node.js, so an outdated version can
+// break them even though it doesn't affect the core server started here.
+func nodeVersionWarning() string {
+	version, err := utils.DetectNodeVersion()
+	if err != nil {
+		return fmt.Sprintf("Could not detect Node.js — v%s or later is required to run sample apps (/try commands).\n%s",
+			utils.MinNodeVersion, utils.NodeUpgradeHint())
+	}
+	if !utils.MeetsMinNodeVersion(version) {
+		return fmt.Sprintf("Node.js v%s detected — v%s or later is recommended. Sample apps (/try commands) may not work correctly.\n%s",
+			version, utils.MinNodeVersion, utils.NodeUpgradeHint())
+	}
+	return ""
+}
 
 // BaseDir is the parent directory that holds all versioned installs and samples.
 func BaseDir() string {
@@ -58,6 +76,11 @@ func Run(verbose, forceSetup bool) {
 	}
 
 	ui.PrintBanner()
+
+	nodeWarning := nodeVersionWarning()
+	if nodeWarning != "" {
+		ui.Warn(nodeWarning)
+	}
 
 	fmt.Print(ui.Dim("  Fetching latest " + product.Name + " release..."))
 	latestVersion, err := release.FetchLatestVersion()
@@ -101,7 +124,7 @@ func Run(verbose, forceSetup bool) {
 		ui.Note("Already running",
 			fmt.Sprintf("%s is already running on port %d.\nAttaching to the existing instance.",
 				product.Name, health.DefaultPort))
-		replLoop(runVersion, path, nil, verbose, isFirstRun, newVersion, 0)
+		replLoop(runVersion, path, nil, verbose, isFirstRun, newVersion, nodeWarning, 0)
 		return
 	}
 
@@ -166,14 +189,14 @@ func Run(verbose, forceSetup bool) {
 	}
 	fmt.Printf("\r\033[2K  %s %s started  %s\n", ui.Green("✓"), product.Name, ui.Dim("logs: "+setup.LogDir(path)))
 
-	replLoop(runVersion, path, proc, verbose, isFirstRun, newVersion, port)
+	replLoop(runVersion, path, proc, verbose, isFirstRun, newVersion, nodeWarning, port)
 }
 
 // replLoop runs the REPL repeatedly, re-entering after no-op upgrades or version switches.
 // An actual upgrade or normal exit breaks the loop.
-func replLoop(version, installPath string, proc *exec.Cmd, verbose, isFirstRun bool, newVersion string, port int) {
+func replLoop(version, installPath string, proc *exec.Cmd, verbose, isFirstRun bool, newVersion, nodeWarning string, port int) {
 	for {
-		upgradeRequested, switchRequested, err := ui.RunREPL(version, proc, installPath, verbose, isFirstRun, newVersion, port)
+		upgradeRequested, switchRequested, err := ui.RunREPL(version, proc, installPath, verbose, isFirstRun, newVersion, nodeWarning, port)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "\nREPL error: %v\n", err)
 			os.Exit(1)

--- a/tools/cli/internal/commands/sample/sample.go
+++ b/tools/cli/internal/commands/sample/sample.go
@@ -34,6 +34,7 @@ import (
 	"github.com/thunder-id/thunderid/tools/cli/internal/services/release"
 	"github.com/thunder-id/thunderid/tools/cli/internal/services/setup"
 	"github.com/thunder-id/thunderid/tools/cli/internal/ui/spinner"
+	"github.com/thunder-id/thunderid/tools/cli/internal/utils"
 )
 
 // Options carries use-case-specific configuration collected by the CLI before the sample starts.
@@ -180,6 +181,10 @@ func runWithResult(
 	meta, ok := knownSamples[sampleName]
 	if !ok {
 		return nil, "", "", fmt.Errorf("unknown sample %q — available: %s", sampleName, availableList())
+	}
+
+	if err := checkNodeVersion(); err != nil {
+		return nil, "", "", err
 	}
 
 	// Fetch latest version.
@@ -619,6 +624,22 @@ func readCachedSampleVersion(dir string) string {
 
 func writeCachedSampleVersion(dir, version string) error {
 	return os.WriteFile(filepath.Join(dir, ".version"), []byte(version+"\n"), 0o644)
+}
+
+// checkNodeVersion returns an error if Node.js is missing or older than
+// utils.MinNodeVersion. Sample apps are installed and run via npm, so an
+// unsupported Node.js version must stop the command before it downloads or
+// touches anything.
+func checkNodeVersion() error {
+	version, err := utils.DetectNodeVersion()
+	if err != nil {
+		return err
+	}
+	if !utils.MeetsMinNodeVersion(version) {
+		return fmt.Errorf("node.js v%s detected — v%s or later is required to run sample apps.\n%s",
+			version, utils.MinNodeVersion, utils.NodeUpgradeHint())
+	}
+	return nil
 }
 
 func availableList() string {

--- a/tools/cli/internal/commands/upgrade/upgrade.go
+++ b/tools/cli/internal/commands/upgrade/upgrade.go
@@ -157,7 +157,7 @@ func Switch(baseDir, currentVersion string, verbose bool) (bool, error) {
 	}
 	fmt.Printf("\r\033[2K  %s Switched to %s v%s  %s\n", ui.Green("✓"), product.Name, selected, ui.Dim("logs: "+setup.LogDir(installPath)))
 
-	_, _, err = ui.RunREPL(selected, proc, installPath, verbose, false, "", 0)
+	_, _, err = ui.RunREPL(selected, proc, installPath, verbose, false, "", "", 0)
 	return true, err
 }
 
@@ -204,7 +204,7 @@ func runDirect(baseDir, activeVersion, newVersion string, verbose bool) error {
 	}
 	fmt.Printf("\r\033[2K  %s %s v%s started  %s\n", ui.Green("✓"), product.Name, newVersion, ui.Dim("logs: "+setup.LogDir(newPath)))
 
-	_, _, err = ui.RunREPL(newVersion, proc, newPath, verbose, false, "", 0)
+	_, _, err = ui.RunREPL(newVersion, proc, newPath, verbose, false, "", "", 0)
 	return err
 }
 
@@ -272,7 +272,7 @@ func performCutover(baseDir, activeVersion, newVersion, newPath string, stagingP
 	}
 	fmt.Printf("\r\033[2K  %s %s v%s is now live on port %d\n", ui.Green("✓"), product.Name, newVersion, health.DefaultPort)
 
-	_, _, err = ui.RunREPL(newVersion, proc, newPath, verbose, false, "", 0)
+	_, _, err = ui.RunREPL(newVersion, proc, newPath, verbose, false, "", "", 0)
 	return err
 }
 

--- a/tools/cli/internal/ui/banner.go
+++ b/tools/cli/internal/ui/banner.go
@@ -114,6 +114,24 @@ func PrintBanner() {
 	fmt.Println(BannerString())
 }
 
+// StatusBoxString returns a bordered box showing the backend and console URLs
+// for a running server, styled to match the rest of the intro/banner chrome.
+func StatusBoxString(baseURL string) string {
+	dot := greenStyle.Render("●")
+	label := lipgloss.NewStyle().Foreground(lipgloss.Color(colorGrey)).Width(9)
+
+	rows := lipgloss.JoinVertical(lipgloss.Left,
+		dot+" "+label.Render("Backend")+CyanStyle.Render(baseURL),
+		dot+" "+label.Render("Console")+CyanStyle.Render(baseURL+"/console"),
+	)
+
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color(colorGreen)).
+		Padding(0, 1).
+		Render(rows)
+}
+
 // Note prints a bordered note box with title and body.
 func Note(title, body string) {
 	content := boldStyle.Render(title) + "\n" + greyStyle.Render(body)

--- a/tools/cli/internal/ui/repl.go
+++ b/tools/cli/internal/ui/repl.go
@@ -329,6 +329,7 @@ type ReplModel struct {
 	upgradeRequested  bool // set when the /upgrade command is executed
 	switchRequested   bool // set when the /use command is executed
 	newVersion        string
+	nodeWarning       string // non-empty shows a persistent Node.js version notice below the banner
 
 	showWalkthrough  bool
 	walkthroughPanes []walkthroughPane
@@ -1380,6 +1381,10 @@ func (m ReplModel) render() string {
 
 	b.WriteString(BannerString() + "\n")
 
+	if m.nodeWarning != "" {
+		b.WriteString(noteBoxStyle.Render(Yellow("⚠ "+m.nodeWarning)) + "\n\n")
+	}
+
 	statusPart := ""
 	switch m.status {
 	case statusStarting:
@@ -1474,14 +1479,16 @@ func clamp(v, min, max int) int {
 
 // RunREPL starts the interactive REPL and blocks until the user exits.
 // newVersion, if non-empty, causes a banner to appear prompting the user to /upgrade.
+// nodeWarning, if non-empty, is shown below the banner for the life of the session.
 // port overrides the default health-check port when non-zero.
 // Returns upgradeRequested=true when the user ran /upgrade, switchRequested=true when /use.
 func RunREPL(
 	version string, proc *exec.Cmd, installPath string,
-	verbose, isFirstRun bool, newVersion string, port int,
+	verbose, isFirstRun bool, newVersion, nodeWarning string, port int,
 ) (upgradeRequested, switchRequested bool, err error) {
 	m := NewReplModel(version, proc, installPath, verbose, isFirstRun)
 	m.newVersion = newVersion
+	m.nodeWarning = nodeWarning
 	if port > 0 {
 		m.checkPort = port
 	}

--- a/tools/cli/internal/ui/repl.go
+++ b/tools/cli/internal/ui/repl.go
@@ -58,7 +58,10 @@ var defaultCommands = []SlashCommand{
 		Section:     "Server",
 		Action: func(baseURL string) ([]string, error) {
 			if health.CheckReady(baseURL) {
-				return []string{Green("●") + " " + product.Name + " is running at " + Cyan(baseURL)}, nil
+				return []string{
+					Green("●") + " " + product.Name + " is running at " + Cyan(baseURL),
+					Green("●") + " Console: " + Cyan(baseURL+"/console"),
+				}, nil
 			}
 			return []string{Yellow("○") + " " + product.Name + " is not responding"}, nil
 		},
@@ -919,9 +922,6 @@ func (m ReplModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,fu
 				} else {
 					m.input.Focus()
 					m.input.Placeholder = "Type / for commands, Ctrl+C to exit"
-					m.messages = append(m.messages,
-						Green("●")+" "+product.Name+" is running at "+Cyan(m.baseURL),
-					)
 				}
 				if m.newVersion != "" {
 					m.messages = append(m.messages,
@@ -1385,17 +1385,15 @@ func (m ReplModel) render() string {
 		b.WriteString(noteBoxStyle.Render(Yellow("⚠ "+m.nodeWarning)) + "\n\n")
 	}
 
-	statusPart := ""
+	b.WriteString(Bold("⚡ "+product.Name+" v"+m.version) + "\n")
 	switch m.status {
 	case statusStarting:
-		statusPart = m.spinner.View() + " Starting..."
+		b.WriteString(m.spinner.View() + " Starting...\n")
 	case statusReady:
-		statusPart = Green("●") + " Running at " + Cyan(m.baseURL)
+		b.WriteString(StatusBoxString(m.baseURL) + "\n")
 	case statusStopped:
-		statusPart = Red("○") + " Stopped"
+		b.WriteString(Red("○") + " Stopped\n")
 	}
-
-	b.WriteString(Bold("⚡ "+product.Name+" v"+m.version) + "  " + statusPart + "\n")
 	b.WriteString(Dim(strings.Repeat("─", clamp(m.width-2, 20, 80))) + "\n\n")
 
 	if m.showOnboarding && m.status == statusReady {

--- a/tools/cli/internal/utils/node.go
+++ b/tools/cli/internal/utils/node.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package utils
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// MinNodeVersion is the lowest Node.js version the sample apps (installed and
+// run via npm by the try-* commands) are supported on.
+const MinNodeVersion = "22.23.1"
+
+// NodeUpgradeHint returns instructions for updating Node.js via nvm, plus the
+// download URL for developers who don't use nvm.
+func NodeUpgradeHint() string {
+	return fmt.Sprintf(
+		"Update with nvm:\n  nvm install %s\n  nvm use %s\nOr download it from https://nodejs.org/en/download",
+		MinNodeVersion, MinNodeVersion,
+	)
+}
+
+// DetectNodeVersion runs "node --version" and returns the version string
+// without the leading "v" (e.g. "22.23.1").
+func DetectNodeVersion() (string, error) {
+	out, err := exec.Command("node", "--version").Output()
+	if err != nil {
+		return "", fmt.Errorf("node.js not found — v%s or later is required to run sample apps; install it from https://nodejs.org/en/download", MinNodeVersion)
+	}
+	return strings.TrimPrefix(strings.TrimSpace(string(out)), "v"), nil
+}
+
+// MeetsMinNodeVersion reports whether version is >= MinNodeVersion.
+func MeetsMinNodeVersion(version string) bool {
+	return compareVersions(version, MinNodeVersion) >= 0
+}
+
+// compareVersions compares two dot-separated numeric version strings,
+// returning -1, 0, or 1 depending on whether a is less than, equal to, or
+// greater than b. Missing or non-numeric components are treated as 0.
+func compareVersions(a, b string) int {
+	as := strings.Split(a, ".")
+	bs := strings.Split(b, ".")
+	for i := 0; i < len(as) || i < len(bs); i++ {
+		var av, bv int
+		if i < len(as) {
+			av, _ = strconv.Atoi(as[i])
+		}
+		if i < len(bs) {
+			bv, _ = strconv.Atoi(bs[i])
+		}
+		if av != bv {
+			if av < bv {
+				return -1
+			}
+			return 1
+		}
+	}
+	return 0
+}

--- a/tools/cli/internal/utils/node_test.go
+++ b/tools/cli/internal/utils/node_test.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/thunder-id/thunderid/tools/cli/internal/utils"
+)
+
+func TestMeetsMinNodeVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{utils.MinNodeVersion, true},
+		{"22.23.2", true},
+		{"22.24.0", true},
+		{"23.0.0", true},
+		{"22.23.0", false},
+		{"22.22.9", false},
+		{"20.11.0", false},
+		{"9.0.0", false},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, utils.MeetsMinNodeVersion(tt.version), "version %q", tt.version)
+	}
+}
+
+func TestNodeUpgradeHint_MentionsNvmAndDownloadURL(t *testing.T) {
+	hint := utils.NodeUpgradeHint()
+	assert.Contains(t, hint, "nvm install "+utils.MinNodeVersion)
+	assert.Contains(t, hint, "https://nodejs.org/en/download")
+}


### PR DESCRIPTION
### Purpose
Two small CLI usability fixes:

1. The CLI never checked the installed Node.js version. Sample apps (`/try-*` commands) run on Node.js under the hood, so an unsupported version caused confusing runtime failures instead of a clear message up front.
2. After `npx thunderid` starts the server, the REPL only printed the backend URL. There was no indication of the Console URL, so users had no way to discover `/console` from the CLI output.

### Approach
- Added `tools/cli/internal/utils/node.go` with `DetectNodeVersion`, `MeetsMinNodeVersion`, and `NodeUpgradeHint`, backed by a `MinNodeVersion` constant (`22.23.1`) and covered by unit tests in `node_test.go`.
- On CLI startup (`root.go`), a non-blocking warning is shown below the banner if Node.js is missing or below the minimum version — core server functionality still works, only the Node-dependent `/try-*` commands are affected.
- The `sample` command (`sample.go`) hard-fails before downloading or installing anything if the Node.js version check doesn't pass, with a message explaining the required version and how to upgrade.
- Threaded a `nodeWarning` string through `RunREPL`/`replLoop` so the warning persists for the life of the REPL session, rendered in a bordered `noteBoxStyle` box.
- Added `StatusBoxString` in `ui/banner.go`: a bordered, green-accented box shown under the version line in the REPL that lists both the **Backend** and **Console** URLs, aligned and styled consistently with the rest of the banner chrome. Replaced the old single-line "Running at ..." status with this box, and kept the `/status` slash command's output in sync so it reports the Console URL too.

#### Node.js Disclaimer

<img width="952" height="122" alt="Screenshot 2026-07-14 at 00 06 33" src="https://github.com/user-attachments/assets/5c53db74-d930-43e1-9b9a-cfd1f92172bd" />

#### Show Console URL

<img width="661" height="322" alt="Screenshot 2026-07-14 at 11 52 07" src="https://github.com/user-attachments/assets/da074df8-9371-4bc6-ad5b-906db3241817" />


### Related Issues
- Fixes https://github.com/thunder-id/thunderid/issues/3957
- Fixes https://github.com/thunder-id/thunderid/issues/3845

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Node.js version compatibility checks before sample app setup.
  * Added clear upgrade guidance when Node.js is unavailable or below the required version.
  * Added persistent Node.js warnings in the CLI experience.
  * Enhanced `/status` output with backend and console URLs.
  * Improved status presentation with a clearly formatted connection box.

* **Tests**
  * Added coverage for Node.js version validation and upgrade guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->