### PR TITLE
Validate organization unit and entity type references in declarative resource loaders

### DIFF
--- a/backend/internal/entitytype/EntityTypeServiceInterface_mock_test.go
+++ b/backend/internal/entitytype/EntityTypeServiceInterface_mock_test.go
@@ -672,6 +672,80 @@ func (_c *EntityTypeServiceInterfaceMock_GetUniqueAttributes_Call) RunAndReturn(
 	return _c
 }
 
+// IsEntityTypeExists provides a mock function for the type EntityTypeServiceInterfaceMock
+func (_mock *EntityTypeServiceInterfaceMock) IsEntityTypeExists(ctx context.Context, category TypeCategory, name string) (bool, *common.ServiceError) {
+	ret := _mock.Called(ctx, category, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsEntityTypeExists")
+	}
+
+	var r0 bool
+	var r1 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, TypeCategory, string) (bool, *common.ServiceError)); ok {
+		return returnFunc(ctx, category, name)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, TypeCategory, string) bool); ok {
+		r0 = returnFunc(ctx, category, name)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, TypeCategory, string) *common.ServiceError); ok {
+		r1 = returnFunc(ctx, category, name)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// EntityTypeServiceInterfaceMock_IsEntityTypeExists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsEntityTypeExists'
+type EntityTypeServiceInterfaceMock_IsEntityTypeExists_Call struct {
+	*mock.Call
+}
+
+// IsEntityTypeExists is a helper method to define mock.On call
+//   - ctx context.Context
+//   - category TypeCategory
+//   - name string
+func (_e *EntityTypeServiceInterfaceMock_Expecter) IsEntityTypeExists(ctx interface{}, category interface{}, name interface{}) *EntityTypeServiceInterfaceMock_IsEntityTypeExists_Call {
+	return &EntityTypeServiceInterfaceMock_IsEntityTypeExists_Call{Call: _e.mock.On("IsEntityTypeExists", ctx, category, name)}
+}
+
+func (_c *EntityTypeServiceInterfaceMock_IsEntityTypeExists_Call) Run(run func(ctx context.Context, category TypeCategory, name string)) *EntityTypeServiceInterfaceMock_IsEntityTypeExists_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 TypeCategory
+		if args[1] != nil {
+			arg1 = args[1].(TypeCategory)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *EntityTypeServiceInterfaceMock_IsEntityTypeExists_Call) Return(b bool, serviceError *common.ServiceError) *EntityTypeServiceInterfaceMock_IsEntityTypeExists_Call {
+	_c.Call.Return(b, serviceError)
+	return _c
+}
+
+func (_c *EntityTypeServiceInterfaceMock_IsEntityTypeExists_Call) RunAndReturn(run func(ctx context.Context, category TypeCategory, name string) (bool, *common.ServiceError)) *EntityTypeServiceInterfaceMock_IsEntityTypeExists_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ResolveEntityTypeHandles provides a mock function for the type EntityTypeServiceInterfaceMock
 func (_mock *EntityTypeServiceInterfaceMock) ResolveEntityTypeHandles(ctx context.Context, entityType *EntityType) *common.ServiceError {
 	ret := _mock.Called(ctx, entityType)

--- a/backend/internal/entitytype/declarative_resource.go
+++ b/backend/internal/entitytype/declarative_resource.go
@@ -27,6 +27,7 @@ import (
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 
 	"github.com/thunder-id/thunderid/internal/entitytype/model"
+	oupkg "github.com/thunder-id/thunderid/internal/ou"
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/log"
@@ -125,7 +126,9 @@ func (e *entityTypeExporter) GetResourceRules() *declarativeresource.ResourceRul
 // - In declarative mode: entityTypeStore is a fileBasedStore
 // - In composite mode: entityTypeStore is a compositeEntityTypeStore (contains both file and DB stores)
 func loadDeclarativeResources(
-	entityTypeStore entityTypeStoreInterface, service EntityTypeServiceInterface) error {
+	entityTypeStore entityTypeStoreInterface, service EntityTypeServiceInterface,
+	ouService oupkg.OrganizationUnitServiceInterface,
+) error {
 	var fileStore entityTypeStoreInterface
 
 	// Determine store type and extract file store
@@ -150,7 +153,7 @@ func loadDeclarativeResources(
 		ResourceType:  "EntityType",
 		DirectoryName: "user_types",
 		Parser:        parseToEntityTypeDTOWrapper,
-		Validator:     validateEntityTypeWrapper(service),
+		Validator:     validateEntityTypeWrapper(service, ouService),
 		IDExtractor: func(data interface{}) string {
 			return data.(*EntityType).ID
 		},
@@ -217,7 +220,9 @@ func parseToEntityTypeDTO(data []byte) (*EntityType, error) {
 
 // validateEntityTypeWrapper wraps validateEntityType to match ResourceConfig.Validator signature.
 // When a service is provided, OU handles are resolved before validation runs.
-func validateEntityTypeWrapper(service EntityTypeServiceInterface) func(interface{}) error {
+func validateEntityTypeWrapper(
+	service EntityTypeServiceInterface, ouService oupkg.OrganizationUnitServiceInterface,
+) func(interface{}) error {
 	return func(dto interface{}) error {
 		schemaDTO, ok := dto.(*EntityType)
 		if !ok {
@@ -229,6 +234,17 @@ func validateEntityTypeWrapper(service EntityTypeServiceInterface) func(interfac
 					schemaDTO.OUHandle, schemaDTO.Name)
 			}
 		}
+		if ouService != nil && schemaDTO.OUID != "" {
+			exists, svcErr := ouService.IsOrganizationUnitExists(context.Background(), schemaDTO.OUID)
+			if svcErr != nil {
+				return fmt.Errorf("failed to verify organization unit %q for entity type '%s': %s",
+					schemaDTO.OUID, schemaDTO.Name, svcErr.Error.DefaultValue)
+			}
+			if !exists {
+				return fmt.Errorf("organization unit %q not found for entity type '%s'", schemaDTO.OUID, schemaDTO.Name)
+			}
+		}
+
 		return validateEntityType(schemaDTO)
 	}
 }

--- a/backend/internal/entitytype/declarative_resource_internal_test.go
+++ b/backend/internal/entitytype/declarative_resource_internal_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/thunder-id/thunderid/tests/mocks/oumock"
+
 	"github.com/thunder-id/thunderid/internal/system/config"
 )
 
@@ -163,7 +165,7 @@ func TestValidateEntityTypeWrapper(t *testing.T) {
 
 		mockSvc.EXPECT().ResolveEntityTypeHandles(mock.Anything, schema).Return(nil).Once()
 
-		validator := validateEntityTypeWrapper(mockSvc)
+		validator := validateEntityTypeWrapper(mockSvc, nil)
 		err := validator(schema)
 
 		assert.NoError(t, err)
@@ -184,7 +186,7 @@ func TestValidateEntityTypeWrapper(t *testing.T) {
 				return nil
 			}).Once()
 
-		validator := validateEntityTypeWrapper(mockSvc)
+		validator := validateEntityTypeWrapper(mockSvc, nil)
 		err := validator(schema)
 
 		assert.NoError(t, err)
@@ -203,7 +205,7 @@ func TestValidateEntityTypeWrapper(t *testing.T) {
 		mockSvc.EXPECT().ResolveEntityTypeHandles(mock.Anything, schema).
 			Return(&ErrorInvalidRequestFormat).Once()
 
-		validator := validateEntityTypeWrapper(mockSvc)
+		validator := validateEntityTypeWrapper(mockSvc, nil)
 		err := validator(schema)
 
 		assert.Error(t, err)
@@ -214,11 +216,54 @@ func TestValidateEntityTypeWrapper(t *testing.T) {
 		mockSvc := NewEntityTypeServiceInterfaceMock(t)
 		invalidData := "not a schema"
 
-		validator := validateEntityTypeWrapper(mockSvc)
+		validator := validateEntityTypeWrapper(mockSvc, nil)
 		err := validator(invalidData)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid type: expected *EntityType")
+	})
+	t.Run("ou existence check error", func(t *testing.T) {
+		mockSvc := NewEntityTypeServiceInterfaceMock(t)
+		schema := &EntityType{
+			ID:     "schema-1",
+			Name:   "Valid Schema",
+			OUID:   "ou-1",
+			Schema: json.RawMessage(`{"email":{"type":"string"}}`),
+		}
+
+		mockSvc.EXPECT().ResolveEntityTypeHandles(mock.Anything, schema).Return(nil).Once()
+
+		ouSvcMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+		ouSvcMock.On("IsOrganizationUnitExists", mock.Anything, "ou-1").
+			Return(false, &tidcommon.InternalServerError)
+
+		validator := validateEntityTypeWrapper(mockSvc, ouSvcMock)
+		err := validator(schema)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to verify organization unit")
+	})
+
+	t.Run("ou not found", func(t *testing.T) {
+		mockSvc := NewEntityTypeServiceInterfaceMock(t)
+		schema := &EntityType{
+			ID:     "schema-1",
+			Name:   "Valid Schema",
+			OUID:   "missing-ou",
+			Schema: json.RawMessage(`{"email":{"type":"string"}}`),
+		}
+
+		mockSvc.EXPECT().ResolveEntityTypeHandles(mock.Anything, schema).Return(nil).Once()
+
+		ouSvcMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+		ouSvcMock.On("IsOrganizationUnitExists", mock.Anything, "missing-ou").
+			Return(false, nil)
+
+		validator := validateEntityTypeWrapper(mockSvc, ouSvcMock)
+		err := validator(schema)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "organization unit \"missing-ou\" not found")
 	})
 }
 
@@ -392,7 +437,7 @@ func TestLoadDeclarativeResources(t *testing.T) {
 		mockSvc := NewEntityTypeServiceInterfaceMock(t)
 		mockSvc.On("ResolveEntityTypeHandles", mock.Anything, mock.Anything).Return(nil).Maybe()
 
-		err = loadDeclarativeResources(compositeStore, mockSvc)
+		err = loadDeclarativeResources(compositeStore, mockSvc, nil)
 		assert.True(t, err == nil || err != nil, "Function should complete regardless of directory presence")
 	})
 
@@ -407,7 +452,7 @@ func TestLoadDeclarativeResources(t *testing.T) {
 		mockSvc := NewEntityTypeServiceInterfaceMock(t)
 		mockSvc.On("ResolveEntityTypeHandles", mock.Anything, mock.Anything).Return(nil).Maybe()
 
-		err = loadDeclarativeResources(fileStore, mockSvc)
+		err = loadDeclarativeResources(fileStore, mockSvc, nil)
 		_ = err // Don't assert on error as it depends on file system state
 	})
 
@@ -421,7 +466,7 @@ func TestLoadDeclarativeResources(t *testing.T) {
 
 		mockSvc := NewEntityTypeServiceInterfaceMock(t)
 
-		err = loadDeclarativeResources(dbStore, mockSvc)
+		err = loadDeclarativeResources(dbStore, mockSvc, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid store type")
 	})
@@ -475,6 +520,6 @@ func TestLoadDeclarativeResources_WithNilService(t *testing.T) {
 	dbStore, _, _ := newEntityTypeStore()
 	compositeStore := newCompositeEntityTypeStore(fileStore, dbStore)
 
-	err = loadDeclarativeResources(compositeStore, nil)
+	err = loadDeclarativeResources(compositeStore, nil, nil)
 	_ = err // outcome depends on file system state; important that it doesn't panic
 }

--- a/backend/internal/entitytype/handler_test.go
+++ b/backend/internal/entitytype/handler_test.go
@@ -99,6 +99,12 @@ func (s *InlineStubEntityTypeService) ResolveEntityTypeHandles(
 	return nil
 }
 
+func (s *InlineStubEntityTypeService) IsEntityTypeExists(
+	ctx context.Context, cat TypeCategory, name string,
+) (bool, *tidcommon.ServiceError) {
+	return true, nil
+}
+
 func (s *InlineStubEntityTypeService) ValidateEntity(
 	ctx context.Context, cat TypeCategory, name string, schema json.RawMessage, flag bool,
 ) (bool, *tidcommon.ServiceError) {

--- a/backend/internal/entitytype/init.go
+++ b/backend/internal/entitytype/init.go
@@ -53,7 +53,7 @@ func Initialize(
 
 	// Step 3: Load declarative resources into store (if applicable)
 	if storeMode == serverconst.StoreModeComposite || storeMode == serverconst.StoreModeDeclarative {
-		if err := loadDeclarativeResources(entityTypeStore, entityTypeService); err != nil {
+		if err := loadDeclarativeResources(entityTypeStore, entityTypeService, ouService); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/backend/internal/entitytype/init_test.go
+++ b/backend/internal/entitytype/init_test.go
@@ -1189,6 +1189,9 @@ schema: |
 
 	mux := http.NewServeMux()
 	mockOUService := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+	mockOUService.On("IsOrganizationUnitExists", mock.Anything, "550e8400-e29b-41d4-a716-446655440000").
+		Return(true, nil)
+
 	// Initialize should return an error due to validation failure
 	_, _, err = Initialize(mux, nil, testCacheManager(), mockOUService, nil)
 	assert.Error(t, err)

--- a/backend/internal/entitytype/service.go
+++ b/backend/internal/entitytype/service.go
@@ -84,6 +84,7 @@ type EntityTypeServiceInterface interface {
 		ctx context.Context, category TypeCategory, names []string,
 	) (map[string]string, *tidcommon.ServiceError)
 	ResolveEntityTypeHandles(ctx context.Context, entityType *EntityType) *tidcommon.ServiceError
+	IsEntityTypeExists(ctx context.Context, category TypeCategory, name string) (bool, *tidcommon.ServiceError)
 }
 
 // entityTypeService is the default implementation of the EntityTypeServiceInterface.
@@ -355,6 +356,32 @@ func (us *entityTypeService) GetEntityTypeByName(
 	}
 
 	return &entityType, nil
+}
+
+// IsEntityTypeExists checks whether an entity type with the given name exists within a category,
+// without enforcing authorization. Used for reference validation (e.g. by the declarative
+// resource loader) where no authenticated actor is available in the context.
+func (us *entityTypeService) IsEntityTypeExists(
+	ctx context.Context, category TypeCategory, name string,
+) (bool, *tidcommon.ServiceError) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, entityTypeLoggerComponentName))
+
+	if svcErr := validateCategory(category); svcErr != nil {
+		return false, svcErr
+	}
+	if name == "" {
+		return false, invalidEntityTypeRequestErr(category, "schema name must not be empty")
+	}
+
+	_, err := us.entityTypeStore.GetEntityTypeByName(ctx, category, name)
+	if err != nil {
+		if errors.Is(err, ErrEntityTypeNotFound) {
+			return false, nil
+		}
+		return false, logAndReturnServerError(ctx, logger, "Failed to check entity type existence", err)
+	}
+
+	return true, nil
 }
 
 // UpdateEntityType updates an entity type by its ID within the given category.

--- a/backend/internal/entitytype/service_test.go
+++ b/backend/internal/entitytype/service_test.go
@@ -643,6 +643,63 @@ func TestGetEntityTypeByNameRequiresName(t *testing.T) {
 	require.Equal(t, ErrorInvalidEntityTypeRequest.Code, svcErr.Code)
 }
 
+func TestIsEntityTypeExistsReturnsTrueWhenFound(t *testing.T) {
+	storeMock := newEntityTypeStoreInterfaceMock(t)
+	storeMock.
+		On("GetEntityTypeByName", context.Background(), TypeCategoryUser, "employee").
+		Return(EntityType{ID: "schema-id", Name: "employee"}, nil).
+		Once()
+
+	service := &entityTypeService{entityTypeStore: storeMock}
+
+	exists, svcErr := service.IsEntityTypeExists(context.Background(), TypeCategoryUser, "employee")
+
+	require.Nil(t, svcErr)
+	require.True(t, exists)
+}
+
+func TestIsEntityTypeExistsReturnsFalseWhenNotFound(t *testing.T) {
+	storeMock := newEntityTypeStoreInterfaceMock(t)
+	storeMock.
+		On("GetEntityTypeByName", context.Background(), TypeCategoryUser, "employee").
+		Return(EntityType{}, ErrEntityTypeNotFound).
+		Once()
+
+	service := &entityTypeService{entityTypeStore: storeMock}
+
+	exists, svcErr := service.IsEntityTypeExists(context.Background(), TypeCategoryUser, "employee")
+
+	require.Nil(t, svcErr)
+	require.False(t, exists)
+}
+
+func TestIsEntityTypeExistsReturnsInternalErrorOnStoreFailure(t *testing.T) {
+	storeMock := newEntityTypeStoreInterfaceMock(t)
+	storeMock.
+		On("GetEntityTypeByName", context.Background(), TypeCategoryUser, "employee").
+		Return(EntityType{}, errors.New("db failure")).
+		Once()
+
+	service := &entityTypeService{entityTypeStore: storeMock}
+
+	exists, svcErr := service.IsEntityTypeExists(context.Background(), TypeCategoryUser, "employee")
+
+	require.False(t, exists)
+	require.NotNil(t, svcErr)
+	require.Equal(t, tidcommon.InternalServerError, *svcErr)
+}
+
+func TestIsEntityTypeExistsRequiresName(t *testing.T) {
+	storeMock := newEntityTypeStoreInterfaceMock(t)
+	service := &entityTypeService{entityTypeStore: storeMock}
+
+	exists, svcErr := service.IsEntityTypeExists(context.Background(), TypeCategoryUser, "")
+
+	require.False(t, exists)
+	require.NotNil(t, svcErr)
+	require.Equal(t, ErrorInvalidEntityTypeRequest.Code, svcErr.Code)
+}
+
 func TestValidateEntityReturnsTrueWhenValidationPasses(t *testing.T) {
 	storeMock := newEntityTypeStoreInterfaceMock(t)
 	storeMock.

--- a/backend/internal/group/declarative_resource.go
+++ b/backend/internal/group/declarative_resource.go
@@ -256,6 +256,17 @@ func validateGroupWrapper(
 			return fmt.Errorf("organization unit with handle %q not found for group '%s': %w",
 				grp.OUHandle, grp.Name, err)
 		}
+
+		if grp.OUID != "" {
+			exists, svcErr := ouService.IsOrganizationUnitExists(context.Background(), grp.OUID)
+			if svcErr != nil {
+				return fmt.Errorf("failed to check existence of organization unit with ID %q: %s",
+					grp.OUID, svcErr.Error.DefaultValue)
+			}
+			if !exists {
+				return fmt.Errorf("organization unit with ID %q not found for group '%s'", grp.OUID, grp.Name)
+			}
+		}
 	}
 
 	if grp.OUID == "" {

--- a/backend/internal/group/declarative_resource_test.go
+++ b/backend/internal/group/declarative_resource_test.go
@@ -35,6 +35,7 @@ import (
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/declarative_resource/entity"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/tests/mocks/oumock"
 )
 
 // GroupExporterTestSuite contains tests for the groupExporter.
@@ -484,6 +485,42 @@ func (suite *GroupExporterTestSuite) TestValidateGroupWrapper_WithMembers() {
 	err := validateGroupWrapper(grp, nil, nil, nil)
 
 	assert.NoError(suite.T(), err)
+}
+
+func (suite *GroupExporterTestSuite) TestValidateGroupWrapper_OUExists() {
+	grp := &groupDeclarativeResource{ID: "group1", Name: "Admins", OUID: "ou1"}
+
+	ouSvcMock := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	ouSvcMock.On("IsOrganizationUnitExists", context.Background(), "ou1").Return(true, nil)
+
+	err := validateGroupWrapper(grp, nil, nil, ouSvcMock)
+
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *GroupExporterTestSuite) TestValidateGroupWrapper_OUNotFound() {
+	grp := &groupDeclarativeResource{ID: "group1", Name: "Admins", OUID: "missing-ou"}
+
+	ouSvcMock := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	ouSvcMock.On("IsOrganizationUnitExists", context.Background(), "missing-ou").Return(false, nil)
+
+	err := validateGroupWrapper(grp, nil, nil, ouSvcMock)
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "not found for group")
+}
+
+func (suite *GroupExporterTestSuite) TestValidateGroupWrapper_OUCheckServiceError() {
+	grp := &groupDeclarativeResource{ID: "group1", Name: "Admins", OUID: "ou1"}
+
+	ouSvcMock := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	ouSvcMock.On("IsOrganizationUnitExists", context.Background(), "ou1").
+		Return(false, &tidcommon.InternalServerError)
+
+	err := validateGroupWrapper(grp, nil, nil, ouSvcMock)
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "failed to check existence of organization unit")
 }
 
 // Test validateGroupWrapper - wrong type

--- a/backend/internal/resource/declarative_resource.go
+++ b/backend/internal/resource/declarative_resource.go
@@ -28,6 +28,7 @@ import (
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
+	oupkg "github.com/thunder-id/thunderid/internal/ou"
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/log"
@@ -201,7 +202,10 @@ func (e *resourceServerExporter) GetResourceRules() *declarativeresource.Resourc
 // Works in both declarative-only and composite modes:
 // - In declarative mode: resourceStore is a fileBasedResourceStore
 // - In composite mode: resourceStore is a compositeResourceStore (contains both file and DB stores)
-func loadDeclarativeResources(resourceStore resourceStoreInterface, resourceService ResourceServiceInterface) error {
+func loadDeclarativeResources(
+	resourceStore resourceStoreInterface, resourceService ResourceServiceInterface,
+	ouService oupkg.OrganizationUnitServiceInterface,
+) error {
 	var fileStore resourceStoreInterface
 	var dbStore resourceStoreInterface
 
@@ -231,7 +235,7 @@ func loadDeclarativeResources(resourceStore resourceStoreInterface, resourceServ
 		DirectoryName: "resource_servers",
 		Parser:        parseAndValidateResourceServerWrapper(resourceService),
 		Validator: func(data interface{}) error {
-			return validateResourceServerWrapper(data, fileStore, dbStore, resourceService)
+			return validateResourceServerWrapper(data, fileStore, dbStore, resourceService, ouService)
 		},
 		IDExtractor: func(data interface{}) string {
 			return data.(*providers.ResourceServer).ID
@@ -452,6 +456,7 @@ func validateResourceServerWrapper(
 	fileStore resourceStoreInterface,
 	dbStore resourceStoreInterface,
 	service ResourceServiceInterface,
+	ouService oupkg.OrganizationUnitServiceInterface,
 ) error {
 	rs, ok := data.(*providers.ResourceServer)
 	if !ok {
@@ -470,6 +475,16 @@ func validateResourceServerWrapper(
 		if svcErr := service.ResolveResourceServerOUHandle(context.Background(), rs); svcErr != nil {
 			return fmt.Errorf("organization unit with handle %q not found for resource server '%s'",
 				rs.OUHandle, rs.Name)
+		}
+	}
+	if ouService != nil && rs.OUID != "" {
+		exists, svcErr := ouService.IsOrganizationUnitExists(context.Background(), rs.OUID)
+		if svcErr != nil {
+			return fmt.Errorf("failed to verify organization unit %q for resource server '%s': %s",
+				rs.OUID, rs.Name, svcErr.Error.DefaultValue)
+		}
+		if !exists {
+			return fmt.Errorf("organization unit %q not found for resource server '%s'", rs.OUID, rs.Name)
 		}
 	}
 

--- a/backend/internal/resource/declarative_resource_test.go
+++ b/backend/internal/resource/declarative_resource_test.go
@@ -33,6 +33,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"gopkg.in/yaml.v3"
+
+	"github.com/thunder-id/thunderid/tests/mocks/oumock"
 )
 
 // ResourceServerExporterTestSuite tests the resourceServerExporter.
@@ -905,7 +907,7 @@ func TestParseAndValidateResourceServerWrapper_InvalidYAML(t *testing.T) {
 }
 
 func TestValidateResourceServerWrapper_InvalidType(t *testing.T) {
-	err := validateResourceServerWrapper("invalid", newResourceStoreInterfaceMock(t), nil, nil)
+	err := validateResourceServerWrapper("invalid", newResourceStoreInterfaceMock(t), nil, nil, nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid type")
@@ -914,7 +916,7 @@ func TestValidateResourceServerWrapper_InvalidType(t *testing.T) {
 func TestValidateResourceServerWrapper_EmptyName(t *testing.T) {
 	fileStore := newResourceStoreInterfaceMock(t)
 
-	err := validateResourceServerWrapper(&providers.ResourceServer{ID: "rs1"}, fileStore, nil, nil)
+	err := validateResourceServerWrapper(&providers.ResourceServer{ID: "rs1"}, fileStore, nil, nil, nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "name cannot be empty")
@@ -923,7 +925,7 @@ func TestValidateResourceServerWrapper_EmptyName(t *testing.T) {
 func TestValidateResourceServerWrapper_EmptyIdentifier(t *testing.T) {
 	fileStore := newResourceStoreInterfaceMock(t)
 
-	err := validateResourceServerWrapper(&providers.ResourceServer{ID: "rs1", Name: "Server"}, fileStore, nil, nil)
+	err := validateResourceServerWrapper(&providers.ResourceServer{ID: "rs1", Name: "Server"}, fileStore, nil, nil, nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "identifier cannot be empty")
@@ -935,7 +937,7 @@ func TestValidateResourceServerWrapper_DuplicateInFileStore(t *testing.T) {
 
 	err := validateResourceServerWrapper(
 		&providers.ResourceServer{ID: "rs1", Name: "Server", Identifier: "test-server", OUID: "ou1"},
-		fileStore, nil, nil)
+		fileStore, nil, nil, nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "duplicate resource server ID")
@@ -947,7 +949,7 @@ func TestValidateResourceServerWrapper_FileStoreError(t *testing.T) {
 
 	err := validateResourceServerWrapper(
 		&providers.ResourceServer{ID: "rs1", Name: "Server", Identifier: "test-server", OUID: "ou1"},
-		fileStore, nil, nil)
+		fileStore, nil, nil, nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to check")
@@ -962,7 +964,7 @@ func TestValidateResourceServerWrapper_DuplicateInDBStore(t *testing.T) {
 
 	err := validateResourceServerWrapper(
 		&providers.ResourceServer{ID: "rs1", Name: "Server", Identifier: "test-server", OUID: "ou1"},
-		fileStore, dbStore, nil)
+		fileStore, dbStore, nil, nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "database store")
@@ -977,7 +979,7 @@ func TestValidateResourceServerWrapper_DBStoreError(t *testing.T) {
 
 	err := validateResourceServerWrapper(
 		&providers.ResourceServer{ID: "rs1", Name: "Server", Identifier: "test-server", OUID: "ou1"},
-		fileStore, dbStore, nil)
+		fileStore, dbStore, nil, nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "database store")
@@ -990,9 +992,49 @@ func TestValidateResourceServerWrapper_Success(t *testing.T) {
 
 	err := validateResourceServerWrapper(
 		&providers.ResourceServer{ID: "rs1", Name: "Server", Identifier: "test-server", OUID: "ou1"},
-		fileStore, nil, nil)
+		fileStore, nil, nil, nil)
 
 	assert.NoError(t, err)
+}
+
+func TestValidateResourceServerWrapper_OUExists(t *testing.T) {
+	fileStore := newResourceStoreInterfaceMock(t)
+	fileStore.On("GetResourceServer", mock.Anything, "rs1").
+		Return(providers.ResourceServer{}, errResourceServerNotFound)
+
+	ouSvcMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+	ouSvcMock.On("IsOrganizationUnitExists", mock.Anything, "ou1").Return(true, nil)
+
+	err := validateResourceServerWrapper(
+		&providers.ResourceServer{ID: "rs1", Name: "Server", Identifier: "test-server", OUID: "ou1"},
+		fileStore, nil, nil, ouSvcMock)
+
+	assert.NoError(t, err)
+}
+
+func TestValidateResourceServerWrapper_OUNotFound(t *testing.T) {
+	ouSvcMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+	ouSvcMock.On("IsOrganizationUnitExists", mock.Anything, "missing-ou").Return(false, nil)
+
+	err := validateResourceServerWrapper(
+		&providers.ResourceServer{ID: "rs1", Name: "Server", Identifier: "test-server", OUID: "missing-ou"},
+		nil, nil, nil, ouSvcMock)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "organization unit \"missing-ou\" not found")
+}
+
+func TestValidateResourceServerWrapper_OUCheckServiceError(t *testing.T) {
+	ouSvcMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+	ouSvcMock.On("IsOrganizationUnitExists", mock.Anything, "ou1").
+		Return(false, &tidcommon.InternalServerError)
+
+	err := validateResourceServerWrapper(
+		&providers.ResourceServer{ID: "rs1", Name: "Server", Identifier: "test-server", OUID: "ou1"},
+		nil, nil, nil, ouSvcMock)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to verify organization unit")
 }
 
 func TestLoadDeclarativeResources_CompositeFileStoreTypeError(t *testing.T) {
@@ -1000,7 +1042,7 @@ func TestLoadDeclarativeResources_CompositeFileStoreTypeError(t *testing.T) {
 	dbStore := newResourceStoreInterfaceMock(t)
 	compositeStore := newCompositeResourceStore(fileStore, dbStore)
 
-	err := loadDeclarativeResources(compositeStore, nil)
+	err := loadDeclarativeResources(compositeStore, nil, nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to assert fileStore")
@@ -1009,7 +1051,7 @@ func TestLoadDeclarativeResources_CompositeFileStoreTypeError(t *testing.T) {
 func TestLoadDeclarativeResources_InvalidStoreType(t *testing.T) {
 	invalidStore := newResourceStoreInterfaceMock(t)
 
-	err := loadDeclarativeResources(invalidStore, nil)
+	err := loadDeclarativeResources(invalidStore, nil, nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid store type")

--- a/backend/internal/resource/init.go
+++ b/backend/internal/resource/init.go
@@ -49,7 +49,7 @@ func Initialize(
 	// Load declarative resources if applicable (declarative or composite mode)
 	storeMode := getResourceStoreMode()
 	if storeMode == serverconst.StoreModeDeclarative || storeMode == serverconst.StoreModeComposite {
-		if err := loadDeclarativeResources(resourceStore, resourceService); err != nil {
+		if err := loadDeclarativeResources(resourceStore, resourceService, ouService); err != nil {
 			return nil, nil, fmt.Errorf("failed to load declarative resources: %w", err)
 		}
 	}

--- a/backend/internal/role/declarative_resource.go
+++ b/backend/internal/role/declarative_resource.go
@@ -26,9 +26,14 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/thunder-id/thunderid/internal/entity"
+	"github.com/thunder-id/thunderid/internal/group"
+	oupkg "github.com/thunder-id/thunderid/internal/ou"
+	resourcepkg "github.com/thunder-id/thunderid/internal/resource"
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/utils"
 )
 
 const (
@@ -151,13 +156,16 @@ func (e *roleExporter) GetResourceRules() *declarativeresource.ResourceRules {
 // The service parameter is optional (can be nil) and is used to resolve ou_handle to ou_id.
 func loadDeclarativeResources(
 	fileStore *fileBasedStore, dbStore roleStoreInterface, service RoleServiceInterface,
+	entityService entity.EntityServiceInterface, ouService oupkg.OrganizationUnitServiceInterface,
+	groupService group.GroupServiceInterface, resourceService resourcepkg.ResourceServiceInterface,
 ) error {
 	resourceConfig := declarativeresource.ResourceConfig{
 		ResourceType:  "Role",
 		DirectoryName: "roles",
 		Parser:        parseToRoleWrapper,
 		Validator: func(data interface{}) error {
-			return validateRoleWrapper(data, fileStore, dbStore, service)
+			return validateRoleWrapper(
+				data, fileStore, dbStore, service, entityService, ouService, groupService, resourceService)
 		},
 		IDExtractor: func(data interface{}) string {
 			// Use safe type assertion to prevent panic
@@ -238,6 +246,8 @@ func parseToRole(data []byte) (*RoleWithPermissionsAndAssignments, error) {
 // When a service is provided, OU handles are resolved before validation runs.
 func validateRoleWrapper(
 	data interface{}, fileStore *fileBasedStore, dbStore roleStoreInterface, service RoleServiceInterface,
+	entityService entity.EntityServiceInterface, ouService oupkg.OrganizationUnitServiceInterface,
+	groupService group.GroupServiceInterface, resourceService resourcepkg.ResourceServiceInterface,
 ) error {
 	role, ok := data.(*RoleWithPermissionsAndAssignments)
 	if !ok {
@@ -250,29 +260,17 @@ func validateRoleWrapper(
 	if role.Name == "" {
 		return fmt.Errorf("role name is required")
 	}
-	if service != nil {
-		if svcErr := service.ResolveRoleOUHandle(context.Background(), role); svcErr != nil {
-			return fmt.Errorf("organization unit with handle %q not found for role '%s'",
-				role.OUHandle, role.Name)
-		}
-	}
-	if role.OUID == "" {
-		return fmt.Errorf("ouId or ouHandle is required for role '%s'", role.Name)
+
+	if err := validateRoleOU(role, service, ouService); err != nil {
+		return err
 	}
 
-	for _, assignment := range role.Assignments {
-		if assignment.ID == "" {
-			return fmt.Errorf("assignment ID is required")
-		}
-		if assignment.Type != assigneeTypeEntity && assignment.Type != AssigneeTypeGroup {
-			return fmt.Errorf("invalid assignment type '%s'", assignment.Type)
-		}
+	if err := validateRoleAssignments(role, entityService, groupService); err != nil {
+		return err
 	}
 
-	for _, resourcePerms := range role.Permissions {
-		if resourcePerms.ResourceServerID == "" {
-			return fmt.Errorf("resource server ID is required")
-		}
+	if err := validateRolePermissions(role, resourceService); err != nil {
+		return err
 	}
 
 	if fileStore != nil {
@@ -292,6 +290,110 @@ func validateRoleWrapper(
 		}
 	}
 
+	return nil
+}
+
+// validateRoleOU resolves the role's ou_handle (when service is provided) and confirms the
+// resulting ou_id refers to an existing organization unit.
+func validateRoleOU(
+	role *RoleWithPermissionsAndAssignments, service RoleServiceInterface,
+	ouService oupkg.OrganizationUnitServiceInterface,
+) error {
+	if service != nil {
+		if svcErr := service.ResolveRoleOUHandle(context.Background(), role); svcErr != nil {
+			return fmt.Errorf("organization unit with handle %q not found for role '%s'",
+				role.OUHandle, role.Name)
+		}
+	}
+	if ouService != nil && role.OUID != "" {
+		exists, svcErr := ouService.IsOrganizationUnitExists(context.Background(), role.OUID)
+		if svcErr != nil {
+			return fmt.Errorf("failed to check organization unit existence for role '%s': %s",
+				role.Name, svcErr.Error.DefaultValue)
+		}
+		if !exists {
+			return fmt.Errorf("organization unit with ID %q not found for role '%s'", role.OUID, role.Name)
+		}
+	}
+
+	if role.OUID == "" {
+		return fmt.Errorf("ouId or ouHandle is required for role '%s'", role.Name)
+	}
+
+	return nil
+}
+
+// validateRoleAssignments checks assignment shape, then, when the relevant service is available,
+// confirms each assignment ID resolves to a real entity or group.
+//
+// This does not reuse the API path's validateAssignmentIDs: that function cross-checks each
+// assignment's claimed category (user/app/agent) against the entity's actual category, but by
+// the time declarative resources reach validation, parseToRole has already collapsed those public
+// types into the generic internal assigneeTypeEntity, discarding the specific category. Reusing it
+// here would compare "entity" against the entity's real category and always mismatch.
+func validateRoleAssignments(
+	role *RoleWithPermissionsAndAssignments, entityService entity.EntityServiceInterface,
+	groupService group.GroupServiceInterface,
+) error {
+	var entityIDs, groupIDs []string
+	for _, assignment := range role.Assignments {
+		if assignment.ID == "" {
+			return fmt.Errorf("assignment ID is required")
+		}
+		switch assignment.Type {
+		case assigneeTypeEntity:
+			entityIDs = append(entityIDs, assignment.ID)
+		case AssigneeTypeGroup:
+			groupIDs = append(groupIDs, assignment.ID)
+		default:
+			return fmt.Errorf("invalid assignment type '%s'", assignment.Type)
+		}
+	}
+	entityIDs = utils.UniqueStrings(entityIDs)
+	groupIDs = utils.UniqueStrings(groupIDs)
+
+	if entityService != nil && len(entityIDs) > 0 {
+		entities, err := entityService.GetEntitiesByIDs(context.Background(), entityIDs)
+		if err != nil {
+			return fmt.Errorf("failed to verify assignment entities for role '%s': %w", role.Name, err)
+		}
+		if len(entities) != len(entityIDs) {
+			return fmt.Errorf("role '%s' references a nonexistent entity assignment", role.Name)
+		}
+	}
+
+	if groupService != nil && len(groupIDs) > 0 {
+		if svcErr := groupService.ValidateGroupIDs(context.Background(), groupIDs); svcErr != nil {
+			return fmt.Errorf("failed to verify assignment groups for role '%s': %s",
+				role.Name, svcErr.Error.DefaultValue)
+		}
+	}
+
+	return nil
+}
+
+// validateRolePermissions checks that each permission entry has a resource server ID, then, when
+// resourceService is available, confirms the permissions are known to that resource server.
+func validateRolePermissions(
+	role *RoleWithPermissionsAndAssignments, resourceService resourcepkg.ResourceServiceInterface,
+) error {
+	for _, resourcePerms := range role.Permissions {
+		if resourcePerms.ResourceServerID == "" {
+			return fmt.Errorf("resource server ID is required")
+		}
+		if resourceService != nil && len(resourcePerms.Permissions) > 0 {
+			invalidPerms, svcErr := resourceService.ValidatePermissions(
+				context.Background(), resourcePerms.ResourceServerID, resourcePerms.Permissions)
+			if svcErr != nil {
+				return fmt.Errorf("failed to validate permissions for role '%s': %s",
+					role.Name, svcErr.Error.DefaultValue)
+			}
+			if len(invalidPerms) > 0 {
+				return fmt.Errorf("role '%s' references unknown permissions %v for resource server '%s'",
+					role.Name, invalidPerms, resourcePerms.ResourceServerID)
+			}
+		}
+	}
 	return nil
 }
 

--- a/backend/internal/role/declarative_resource_test.go
+++ b/backend/internal/role/declarative_resource_test.go
@@ -27,9 +27,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
+
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/tests/mocks/entitymock"
+	"github.com/thunder-id/thunderid/tests/mocks/groupmock"
+	"github.com/thunder-id/thunderid/tests/mocks/oumock"
+	"github.com/thunder-id/thunderid/tests/mocks/resourcemock"
 )
 
 // RoleExporterTestSuite contains tests for the roleExporter.
@@ -345,9 +351,171 @@ func (suite *RoleExporterTestSuite) TestValidateRoleWrapper_ValidRole() {
 	}
 
 	// Pass nil for fileStore to skip duplicate check (for unit test purposes)
-	err := validateRoleWrapper(role, nil, nil, nil)
+	err := validateRoleWrapper(role, nil, nil, nil, nil, nil, nil, nil)
 
 	assert.NoError(suite.T(), err)
+}
+
+func (suite *RoleExporterTestSuite) TestValidateRoleWrapper_OUNotFound() {
+	role := &RoleWithPermissionsAndAssignments{ID: "role1", Name: "Admin", OUID: "missing-ou"}
+
+	ouSvcMock := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	ouSvcMock.On("IsOrganizationUnitExists", context.Background(), "missing-ou").
+		Return(false, nil)
+
+	err := validateRoleWrapper(role, nil, nil, nil, nil, ouSvcMock, nil, nil)
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "organization unit with ID \"missing-ou\" not found")
+}
+
+func (suite *RoleExporterTestSuite) TestValidateRoleWrapper_OUCheckServiceError() {
+	role := &RoleWithPermissionsAndAssignments{ID: "role1", Name: "Admin", OUID: "ou1"}
+
+	ouSvcMock := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	ouSvcMock.On("IsOrganizationUnitExists", context.Background(), "ou1").
+		Return(false, &tidcommon.InternalServerError)
+
+	err := validateRoleWrapper(role, nil, nil, nil, nil, ouSvcMock, nil, nil)
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "failed to check organization unit existence")
+}
+
+func (suite *RoleExporterTestSuite) TestValidateRoleWrapper_InvalidAssignmentIDs() {
+	role := &RoleWithPermissionsAndAssignments{
+		ID:   "role1",
+		Name: "Admin",
+		OUID: "ou1",
+		Assignments: []RoleAssignment{
+			{ID: "user1", Type: assigneeTypeEntity},
+		},
+	}
+
+	ouSvcMock := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	ouSvcMock.On("IsOrganizationUnitExists", context.Background(), "ou1").Return(true, nil)
+
+	entityMock := entitymock.NewEntityServiceInterfaceMock(suite.T())
+	entityMock.On("GetEntitiesByIDs", context.Background(), []string{"user1"}).
+		Return([]providers.Entity{}, nil)
+
+	err := validateRoleWrapper(role, nil, nil, nil, entityMock, ouSvcMock, nil, nil)
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "nonexistent entity assignment")
+}
+
+func (suite *RoleExporterTestSuite) TestValidateRoleWrapper_ValidAssignmentIDs() {
+	role := &RoleWithPermissionsAndAssignments{
+		ID:   "role1",
+		Name: "Admin",
+		OUID: "ou1",
+		Assignments: []RoleAssignment{
+			{ID: "user1", Type: assigneeTypeEntity},
+		},
+	}
+
+	ouSvcMock := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	ouSvcMock.On("IsOrganizationUnitExists", context.Background(), "ou1").Return(true, nil)
+
+	entityMock := entitymock.NewEntityServiceInterfaceMock(suite.T())
+	entityMock.On("GetEntitiesByIDs", context.Background(), []string{"user1"}).
+		Return([]providers.Entity{{ID: "user1", Category: providers.EntityCategoryUser}}, nil)
+
+	err := validateRoleWrapper(role, nil, nil, nil, entityMock, ouSvcMock, nil, nil)
+
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *RoleExporterTestSuite) TestValidateRoleWrapper_InvalidGroupAssignment() {
+	role := &RoleWithPermissionsAndAssignments{
+		ID:   "role1",
+		Name: "Admin",
+		OUID: "ou1",
+		Assignments: []RoleAssignment{
+			{ID: "group1", Type: AssigneeTypeGroup},
+		},
+	}
+
+	ouSvcMock := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	ouSvcMock.On("IsOrganizationUnitExists", context.Background(), "ou1").Return(true, nil)
+
+	groupMock := groupmock.NewGroupServiceInterfaceMock(suite.T())
+	groupMock.On("ValidateGroupIDs", context.Background(), []string{"group1"}).
+		Return(&tidcommon.InternalServerError)
+
+	err := validateRoleWrapper(role, nil, nil, nil, nil, ouSvcMock, groupMock, nil)
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "failed to verify assignment groups")
+}
+
+func (suite *RoleExporterTestSuite) TestValidateRoleWrapper_ValidGroupAssignment() {
+	role := &RoleWithPermissionsAndAssignments{
+		ID:   "role1",
+		Name: "Admin",
+		OUID: "ou1",
+		Assignments: []RoleAssignment{
+			{ID: "group1", Type: AssigneeTypeGroup},
+		},
+	}
+
+	ouSvcMock := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	ouSvcMock.On("IsOrganizationUnitExists", context.Background(), "ou1").Return(true, nil)
+
+	groupMock := groupmock.NewGroupServiceInterfaceMock(suite.T())
+	groupMock.On("ValidateGroupIDs", context.Background(), []string{"group1"}).
+		Return(nil)
+
+	err := validateRoleWrapper(role, nil, nil, nil, nil, ouSvcMock, groupMock, nil)
+
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *RoleExporterTestSuite) TestValidateRoleWrapper_InvalidPermissions() {
+	role := &RoleWithPermissionsAndAssignments{
+		ID:   "role1",
+		Name: "Admin",
+		OUID: "ou1",
+		Permissions: []ResourcePermissions{
+			{ResourceServerID: "rs1", Permissions: []string{"unknown-perm"}},
+		},
+	}
+
+	ouSvcMock := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	ouSvcMock.On("IsOrganizationUnitExists", context.Background(), "ou1").Return(true, nil)
+
+	resourceMock := resourcemock.NewResourceServiceInterfaceMock(suite.T())
+	resourceMock.On("ValidatePermissions", context.Background(), "rs1", []string{"unknown-perm"}).
+		Return([]string{"unknown-perm"}, nil)
+
+	err := validateRoleWrapper(role, nil, nil, nil, nil, ouSvcMock, nil, resourceMock)
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "references unknown permissions")
+}
+
+func (suite *RoleExporterTestSuite) TestValidateRoleWrapper_PermissionsServiceError() {
+	role := &RoleWithPermissionsAndAssignments{
+		ID:   "role1",
+		Name: "Admin",
+		OUID: "ou1",
+		Permissions: []ResourcePermissions{
+			{ResourceServerID: "rs1", Permissions: []string{"read"}},
+		},
+	}
+
+	ouSvcMock := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	ouSvcMock.On("IsOrganizationUnitExists", context.Background(), "ou1").Return(true, nil)
+
+	resourceMock := resourcemock.NewResourceServiceInterfaceMock(suite.T())
+	resourceMock.On("ValidatePermissions", context.Background(), "rs1", []string{"read"}).
+		Return(nil, &tidcommon.InternalServerError)
+
+	err := validateRoleWrapper(role, nil, nil, nil, nil, ouSvcMock, nil, resourceMock)
+
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "failed to validate permissions")
 }
 
 // Test validateRoleWrapper - missing ID
@@ -357,7 +525,7 @@ func (suite *RoleExporterTestSuite) TestValidateRoleWrapper_MissingID() {
 		OUID: "ou1",
 	}
 
-	err := validateRoleWrapper(role, nil, nil, nil)
+	err := validateRoleWrapper(role, nil, nil, nil, nil, nil, nil, nil)
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "role ID is required")
@@ -370,7 +538,7 @@ func (suite *RoleExporterTestSuite) TestValidateRoleWrapper_MissingName() {
 		OUID: "ou1",
 	}
 
-	err := validateRoleWrapper(role, nil, nil, nil)
+	err := validateRoleWrapper(role, nil, nil, nil, nil, nil, nil, nil)
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "role name is required")
@@ -383,7 +551,7 @@ func (suite *RoleExporterTestSuite) TestValidateRoleWrapper_MissingOUID() {
 		Name: "Admin",
 	}
 
-	err := validateRoleWrapper(role, nil, nil, nil)
+	err := validateRoleWrapper(role, nil, nil, nil, nil, nil, nil, nil)
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "ouId or ouHandle is required for role 'Admin'")
@@ -400,7 +568,7 @@ func (suite *RoleExporterTestSuite) TestValidateRoleWrapper_InvalidAssignmentTyp
 		},
 	}
 
-	err := validateRoleWrapper(role, nil, nil, nil)
+	err := validateRoleWrapper(role, nil, nil, nil, nil, nil, nil, nil)
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "invalid assignment type")
@@ -417,7 +585,7 @@ func (suite *RoleExporterTestSuite) TestValidateRoleWrapper_MissingAssignmentID(
 		},
 	}
 
-	err := validateRoleWrapper(role, nil, nil, nil)
+	err := validateRoleWrapper(role, nil, nil, nil, nil, nil, nil, nil)
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "assignment ID is required")
@@ -434,7 +602,7 @@ func (suite *RoleExporterTestSuite) TestValidateRoleWrapper_MissingResourceServe
 		},
 	}
 
-	err := validateRoleWrapper(role, nil, nil, nil)
+	err := validateRoleWrapper(role, nil, nil, nil, nil, nil, nil, nil)
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "resource server ID is required")

--- a/backend/internal/role/init.go
+++ b/backend/internal/role/init.go
@@ -59,7 +59,9 @@ func Initialize(
 
 	// Step 3: Load declarative resources into store (if applicable)
 	if fileStore != nil {
-		if err := loadDeclarativeResources(fileStore, dbStore, roleService); err != nil {
+		if err := loadDeclarativeResources(
+			fileStore, dbStore, roleService, entityService, ouService, groupService, resourceService,
+		); err != nil {
 			return nil, nil, nil, nil, err
 		}
 	}

--- a/backend/internal/role/init_test.go
+++ b/backend/internal/role/init_test.go
@@ -240,7 +240,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesWith
 	genericStore := declarativeresource.NewGenericFileBasedStoreForTest(entity.KeyTypeRole)
 	fileStore := &fileBasedStore{GenericFileBasedStore: genericStore}
 
-	err := loadDeclarativeResources(fileStore, nil, nil)
+	err := loadDeclarativeResources(fileStore, nil, nil, nil, nil, nil, nil)
 
 	// Should not error even if no resources are found (empty directory)
 	suite.NoError(err)
@@ -252,7 +252,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesWith
 	fileStore := &fileBasedStore{GenericFileBasedStore: genericStore}
 
 	// Should handle nil dbStore gracefully (no duplicate checking against DB)
-	err := loadDeclarativeResources(fileStore, nil, nil)
+	err := loadDeclarativeResources(fileStore, nil, nil, nil, nil, nil, nil)
 
 	suite.NoError(err)
 }
@@ -266,7 +266,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesWith
 	mockDbStore := newRoleStoreInterfaceMock(suite.T())
 	// Don't setup any expectations since no resources are loaded by default
 
-	err := loadDeclarativeResources(fileStore, mockDbStore, nil)
+	err := loadDeclarativeResources(fileStore, mockDbStore, nil, nil, nil, nil, nil)
 
 	suite.NoError(err)
 }
@@ -291,7 +291,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 	}
 
 	// Validate the role with no dbStore (validation should pass for valid role)
-	err := validateRoleWrapper(testRole, fileStore, nil, nil)
+	err := validateRoleWrapper(testRole, fileStore, nil, nil, nil, nil, nil, nil)
 
 	suite.NoError(err)
 }
@@ -311,7 +311,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesIDEx
 	suite.NoError(err)
 
 	// Load should correctly extract the ID
-	err = loadDeclarativeResources(fileStore, nil, nil)
+	err = loadDeclarativeResources(fileStore, nil, nil, nil, nil, nil, nil)
 
 	suite.NoError(err)
 	// Verify the role is still in the store with correct ID
@@ -366,7 +366,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 		Name: "No ID",
 		OUID: "ou1",
 	}
-	err := validateRoleWrapper(roleNoID, fileStore, nil, nil)
+	err := validateRoleWrapper(roleNoID, fileStore, nil, nil, nil, nil, nil, nil)
 	suite.Error(err)
 	suite.Contains(err.Error(), "role ID is required")
 
@@ -375,7 +375,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 		ID:   "role1",
 		OUID: "ou1",
 	}
-	err = validateRoleWrapper(roleNoName, fileStore, nil, nil)
+	err = validateRoleWrapper(roleNoName, fileStore, nil, nil, nil, nil, nil, nil)
 	suite.Error(err)
 	suite.Contains(err.Error(), "role name is required")
 
@@ -384,7 +384,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 		ID:   "role1",
 		Name: "Test Role",
 	}
-	err = validateRoleWrapper(roleNoOU, fileStore, nil, nil)
+	err = validateRoleWrapper(roleNoOU, fileStore, nil, nil, nil, nil, nil, nil)
 	suite.Error(err)
 	suite.Contains(err.Error(), "ouId or ouHandle is required for role 'Test Role'")
 }
@@ -403,7 +403,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 			{ID: "user1", Type: assigneeTypeEntity},
 		},
 	}
-	err := validateRoleWrapper(roleValidUser, fileStore, nil, nil)
+	err := validateRoleWrapper(roleValidUser, fileStore, nil, nil, nil, nil, nil, nil)
 	suite.NoError(err)
 
 	// Test role with valid group assignment
@@ -415,7 +415,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 			{ID: "group1", Type: AssigneeTypeGroup},
 		},
 	}
-	err = validateRoleWrapper(roleValidGroup, fileStore, nil, nil)
+	err = validateRoleWrapper(roleValidGroup, fileStore, nil, nil, nil, nil, nil, nil)
 	suite.NoError(err)
 
 	// Test role with invalid assignment type
@@ -427,7 +427,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 			{ID: "invalid1", Type: "invalid_type"},
 		},
 	}
-	err = validateRoleWrapper(roleInvalidType, fileStore, nil, nil)
+	err = validateRoleWrapper(roleInvalidType, fileStore, nil, nil, nil, nil, nil, nil)
 	suite.Error(err)
 	suite.Contains(err.Error(), "invalid assignment type")
 
@@ -440,7 +440,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 			{Type: assigneeTypeEntity},
 		},
 	}
-	err = validateRoleWrapper(roleNoAssignmentID, fileStore, nil, nil)
+	err = validateRoleWrapper(roleNoAssignmentID, fileStore, nil, nil, nil, nil, nil, nil)
 	suite.Error(err)
 	suite.Contains(err.Error(), "assignment ID is required")
 }
@@ -459,7 +459,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 			{Permissions: []string{"read"}},
 		},
 	}
-	err := validateRoleWrapper(roleNoResourceServer, fileStore, nil, nil)
+	err := validateRoleWrapper(roleNoResourceServer, fileStore, nil, nil, nil, nil, nil, nil)
 	suite.Error(err)
 	suite.Contains(err.Error(), "resource server ID is required")
 
@@ -475,7 +475,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 			},
 		},
 	}
-	err = validateRoleWrapper(roleValidPermission, fileStore, nil, nil)
+	err = validateRoleWrapper(roleValidPermission, fileStore, nil, nil, nil, nil, nil, nil)
 	suite.NoError(err)
 }
 
@@ -494,7 +494,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 	suite.NoError(err)
 
 	// Try to validate same role again
-	err = validateRoleWrapper(existingRole, fileStore, nil, nil)
+	err = validateRoleWrapper(existingRole, fileStore, nil, nil, nil, nil, nil, nil)
 	suite.Error(err)
 	suite.Contains(err.Error(), "duplicate role ID")
 	suite.Contains(err.Error(), "declarative resources")
@@ -515,7 +515,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 	// Mock database store to indicate role exists
 	mockDbStore.On("IsRoleExist", mock.Anything, "db-duplicate").Return(true, nil).Once()
 
-	err := validateRoleWrapper(role, fileStore, mockDbStore, nil)
+	err := validateRoleWrapper(role, fileStore, mockDbStore, nil, nil, nil, nil, nil)
 	suite.Error(err)
 	suite.Contains(err.Error(), "duplicate role ID")
 	suite.Contains(err.Error(), "database store")
@@ -539,7 +539,7 @@ func (suite *LoadDeclarativeResourcesTestSuite) TestLoadDeclarativeResourcesVali
 		false, fmt.Errorf("database error"),
 	).Once()
 
-	err := validateRoleWrapper(role, fileStore, mockDbStore, nil)
+	err := validateRoleWrapper(role, fileStore, mockDbStore, nil, nil, nil, nil, nil)
 	suite.Error(err)
 	suite.Contains(err.Error(), "database error")
 	mockDbStore.AssertExpectations(suite.T())

--- a/backend/internal/user/declarative_resource.go
+++ b/backend/internal/user/declarative_resource.go
@@ -31,6 +31,8 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/thunder-id/thunderid/internal/entity"
+	"github.com/thunder-id/thunderid/internal/entitytype"
+	oupkg "github.com/thunder-id/thunderid/internal/ou"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
@@ -184,13 +186,19 @@ func (e *userExporter) GetResourceRules() *declarativeresource.ResourceRules {
 
 // makeUserDeclarativeConfig creates the declarative loader configuration for user resources.
 // This provides user-specific parser and validator callbacks to the entity service.
-// When userService is non-nil, ou_handle is resolved to ou_id during parsing.
-func makeUserDeclarativeConfig(userService UserServiceInterface) entity.DeclarativeLoaderConfig {
+// When userService is non-nil, ou_handle is resolved to ou_id during parsing. ouService and
+// entityTypeService are used to validate references without requiring an authenticated actor,
+// since declarative resources are loaded at startup outside any request context.
+func makeUserDeclarativeConfig(
+	userService UserServiceInterface,
+	ouService oupkg.OrganizationUnitServiceInterface,
+	entityTypeService entitytype.EntityTypeServiceInterface,
+) entity.DeclarativeLoaderConfig {
 	return entity.DeclarativeLoaderConfig{
 		Directory: "users",
 		Category:  providers.EntityCategoryUser,
 		Parser:    makeUserParser(userService),
-		Validator: makeUserValidator(),
+		Validator: makeUserValidator(ouService, entityTypeService),
 	}
 }
 
@@ -223,7 +231,13 @@ func makeUserParser(
 }
 
 // makeUserValidator creates a validator callback for declarative user resources.
-func makeUserValidator() func(e *providers.Entity, svc entity.EntityServiceInterface) error {
+// ouService and entityTypeService validate references directly at the store/existence level,
+// bypassing the authorization checks that entityTypeService.GetEntityTypeByName enforces for
+// authenticated API requests, since declarative loading runs at startup with no actor in context.
+func makeUserValidator(
+	ouService oupkg.OrganizationUnitServiceInterface,
+	entityTypeService entitytype.EntityTypeServiceInterface,
+) func(e *providers.Entity, svc entity.EntityServiceInterface) error {
 	return func(e *providers.Entity, svc entity.EntityServiceInterface) error {
 		if e.ID == "" {
 			return fmt.Errorf("user ID is required")
@@ -236,6 +250,29 @@ func makeUserValidator() func(e *providers.Entity, svc entity.EntityServiceInter
 		}
 		if len(e.Attributes) == 0 {
 			return fmt.Errorf("user attributes are required")
+		}
+
+		if ouService != nil {
+			exists, svcErr := ouService.IsOrganizationUnitExists(context.Background(), e.OUID)
+			if svcErr != nil {
+				return fmt.Errorf("failed to verify organization unit %q for user '%s': %s",
+					e.OUID, e.ID, svcErr.Error.DefaultValue)
+			}
+			if !exists {
+				return fmt.Errorf("organization unit %q not found for user '%s'", e.OUID, e.ID)
+			}
+		}
+
+		if entityTypeService != nil {
+			exists, svcErr := entityTypeService.IsEntityTypeExists(
+				context.Background(), entitytype.TypeCategoryUser, e.Type)
+			if svcErr != nil {
+				return fmt.Errorf("failed to verify user type %q for user '%s': %s",
+					e.Type, e.ID, svcErr.Error.DefaultValue)
+			}
+			if !exists {
+				return fmt.Errorf("user type %q not found for user '%s'", e.Type, e.ID)
+			}
 		}
 
 		var attrs map[string]interface{}

--- a/backend/internal/user/declarative_resource_test.go
+++ b/backend/internal/user/declarative_resource_test.go
@@ -27,13 +27,18 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
+	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
+
 	entitypkg "github.com/thunder-id/thunderid/internal/entity"
+	"github.com/thunder-id/thunderid/internal/entitytype"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 	"github.com/thunder-id/thunderid/tests/mocks/entitymock"
+	"github.com/thunder-id/thunderid/tests/mocks/entitytypemock"
+	"github.com/thunder-id/thunderid/tests/mocks/oumock"
 )
 
 // DeclarativeResourceTestSuite tests user declarative resource parsing and export.
@@ -293,9 +298,108 @@ func (suite *DeclarativeResourceTestSuite) TestMakeUserValidator_Success() {
 	svcMock.On("GetEntity", context.Background(), "user-1").
 		Return((*providers.Entity)(nil), entitypkg.ErrEntityNotFound)
 
-	validator := makeUserValidator()
+	ouSvcMock := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	ouSvcMock.On("IsOrganizationUnitExists", context.Background(), "ou-1").
+		Return(true, nil)
+	entityTypeSvcMock := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	entityTypeSvcMock.On("IsEntityTypeExists", context.Background(), entitytype.TypeCategoryUser, "person").
+		Return(true, nil)
+
+	validator := makeUserValidator(ouSvcMock, entityTypeSvcMock)
 	err = validator(e, svcMock)
 	suite.NoError(err)
+}
+
+func (suite *DeclarativeResourceTestSuite) TestMakeUserValidator_UnresolvedOrganizationUnit() {
+	attrs, err := json.Marshal(map[string]interface{}{"username": "alice"})
+	suite.Require().NoError(err)
+
+	e := &providers.Entity{
+		ID:         "user-1",
+		Type:       "person",
+		OUID:       "nonexistent-ou",
+		Attributes: attrs,
+	}
+
+	ouSvcMock := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	ouSvcMock.On("IsOrganizationUnitExists", context.Background(), "nonexistent-ou").
+		Return(false, nil)
+
+	validator := makeUserValidator(ouSvcMock, nil)
+	err = validator(e, entitymock.NewEntityServiceInterfaceMock(suite.T()))
+	suite.Error(err)
+	suite.Contains(err.Error(), "organization unit \"nonexistent-ou\" not found")
+}
+
+func (suite *DeclarativeResourceTestSuite) TestMakeUserValidator_OUCheckServiceError() {
+	attrs, err := json.Marshal(map[string]interface{}{"username": "alice"})
+	suite.Require().NoError(err)
+
+	e := &providers.Entity{
+		ID:         "user-1",
+		Type:       "person",
+		OUID:       "ou-1",
+		Attributes: attrs,
+	}
+
+	ouSvcMock := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	ouSvcMock.On("IsOrganizationUnitExists", context.Background(), "ou-1").
+		Return(false, &tidcommon.InternalServerError)
+
+	validator := makeUserValidator(ouSvcMock, nil)
+	err = validator(e, entitymock.NewEntityServiceInterfaceMock(suite.T()))
+	suite.Error(err)
+	suite.Contains(err.Error(), "failed to verify organization unit")
+}
+
+func (suite *DeclarativeResourceTestSuite) TestMakeUserValidator_EntityTypeCheckServiceError() {
+	attrs, err := json.Marshal(map[string]interface{}{"username": "alice"})
+	suite.Require().NoError(err)
+
+	e := &providers.Entity{
+		ID:         "user-1",
+		Type:       "person",
+		OUID:       "ou-1",
+		Attributes: attrs,
+	}
+
+	ouSvcMock := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	ouSvcMock.On("IsOrganizationUnitExists", context.Background(), "ou-1").
+		Return(true, nil)
+
+	entityTypeSvcMock := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	entityTypeSvcMock.On("IsEntityTypeExists", context.Background(), entitytype.TypeCategoryUser, "person").
+		Return(false, &tidcommon.InternalServerError)
+
+	validator := makeUserValidator(ouSvcMock, entityTypeSvcMock)
+	err = validator(e, entitymock.NewEntityServiceInterfaceMock(suite.T()))
+	suite.Error(err)
+	suite.Contains(err.Error(), "failed to verify user type")
+}
+
+func (suite *DeclarativeResourceTestSuite) TestMakeUserValidator_EntityTypeNotFound() {
+	attrs, err := json.Marshal(map[string]interface{}{"username": "alice"})
+	suite.Require().NoError(err)
+
+	e := &providers.Entity{
+		ID:         "user-1",
+		Type:       "person",
+		OUID:       "ou-1",
+		Attributes: attrs,
+	}
+
+	ouSvcMock := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	ouSvcMock.On("IsOrganizationUnitExists", context.Background(), "ou-1").
+		Return(true, nil)
+
+	entityTypeSvcMock := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	entityTypeSvcMock.On("IsEntityTypeExists", context.Background(), entitytype.TypeCategoryUser, "person").
+		Return(false, nil)
+
+	validator := makeUserValidator(ouSvcMock, entityTypeSvcMock)
+	err = validator(e, entitymock.NewEntityServiceInterfaceMock(suite.T()))
+	suite.Error(err)
+	suite.Contains(err.Error(), "user type \"person\" not found")
 }
 
 func (suite *DeclarativeResourceTestSuite) TestMakeUserValidator_DuplicateEntity() {
@@ -313,7 +417,14 @@ func (suite *DeclarativeResourceTestSuite) TestMakeUserValidator_DuplicateEntity
 	svcMock.On("GetEntity", context.Background(), "user-1").
 		Return(&providers.Entity{Category: providers.EntityCategoryUser, ID: "user-1"}, nil)
 
-	validator := makeUserValidator()
+	ouSvcMock := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	ouSvcMock.On("IsOrganizationUnitExists", context.Background(), "ou-1").
+		Return(true, nil)
+	entityTypeSvcMock := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	entityTypeSvcMock.On("IsEntityTypeExists", context.Background(), entitytype.TypeCategoryUser, "person").
+		Return(true, nil)
+
+	validator := makeUserValidator(ouSvcMock, entityTypeSvcMock)
 	err = validator(e, svcMock)
 	suite.Error(err)
 	suite.Contains(err.Error(), "duplicate user ID")
@@ -334,7 +445,14 @@ func (suite *DeclarativeResourceTestSuite) TestMakeUserValidator_DBError() {
 	svcMock.On("GetEntity", context.Background(), "user-1").
 		Return((*providers.Entity)(nil), errors.New("db error"))
 
-	validator := makeUserValidator()
+	ouSvcMock := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	ouSvcMock.On("IsOrganizationUnitExists", context.Background(), "ou-1").
+		Return(true, nil)
+	entityTypeSvcMock := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	entityTypeSvcMock.On("IsEntityTypeExists", context.Background(), entitytype.TypeCategoryUser, "person").
+		Return(true, nil)
+
+	validator := makeUserValidator(ouSvcMock, entityTypeSvcMock)
 	err = validator(e, svcMock)
 	suite.Error(err)
 	suite.Contains(err.Error(), "checking user existence")

--- a/backend/internal/user/init.go
+++ b/backend/internal/user/init.go
@@ -51,7 +51,8 @@ func Initialize(
 	// Step 3: Load declarative resources if user store mode requires it.
 	storeMode := getUserStoreMode()
 	if storeMode == serverconst.StoreModeDeclarative || storeMode == serverconst.StoreModeComposite {
-		if err := entityService.LoadDeclarativeResources(makeUserDeclarativeConfig(userService)); err != nil {
+		declarativeConfig := makeUserDeclarativeConfig(userService, ouService, entityTypeService)
+		if err := entityService.LoadDeclarativeResources(declarativeConfig); err != nil {
 			return nil, nil, nil, err
 		}
 	}

--- a/backend/tests/mocks/entitytypemock/EntityTypeServiceInterface_mock.go
+++ b/backend/tests/mocks/entitytypemock/EntityTypeServiceInterface_mock.go
@@ -673,6 +673,80 @@ func (_c *EntityTypeServiceInterfaceMock_GetUniqueAttributes_Call) RunAndReturn(
 	return _c
 }
 
+// IsEntityTypeExists provides a mock function for the type EntityTypeServiceInterfaceMock
+func (_mock *EntityTypeServiceInterfaceMock) IsEntityTypeExists(ctx context.Context, category entitytype.TypeCategory, name string) (bool, *common.ServiceError) {
+	ret := _mock.Called(ctx, category, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsEntityTypeExists")
+	}
+
+	var r0 bool
+	var r1 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, entitytype.TypeCategory, string) (bool, *common.ServiceError)); ok {
+		return returnFunc(ctx, category, name)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, entitytype.TypeCategory, string) bool); ok {
+		r0 = returnFunc(ctx, category, name)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, entitytype.TypeCategory, string) *common.ServiceError); ok {
+		r1 = returnFunc(ctx, category, name)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// EntityTypeServiceInterfaceMock_IsEntityTypeExists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsEntityTypeExists'
+type EntityTypeServiceInterfaceMock_IsEntityTypeExists_Call struct {
+	*mock.Call
+}
+
+// IsEntityTypeExists is a helper method to define mock.On call
+//   - ctx context.Context
+//   - category entitytype.TypeCategory
+//   - name string
+func (_e *EntityTypeServiceInterfaceMock_Expecter) IsEntityTypeExists(ctx interface{}, category interface{}, name interface{}) *EntityTypeServiceInterfaceMock_IsEntityTypeExists_Call {
+	return &EntityTypeServiceInterfaceMock_IsEntityTypeExists_Call{Call: _e.mock.On("IsEntityTypeExists", ctx, category, name)}
+}
+
+func (_c *EntityTypeServiceInterfaceMock_IsEntityTypeExists_Call) Run(run func(ctx context.Context, category entitytype.TypeCategory, name string)) *EntityTypeServiceInterfaceMock_IsEntityTypeExists_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 entitytype.TypeCategory
+		if args[1] != nil {
+			arg1 = args[1].(entitytype.TypeCategory)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *EntityTypeServiceInterfaceMock_IsEntityTypeExists_Call) Return(b bool, serviceError *common.ServiceError) *EntityTypeServiceInterfaceMock_IsEntityTypeExists_Call {
+	_c.Call.Return(b, serviceError)
+	return _c
+}
+
+func (_c *EntityTypeServiceInterfaceMock_IsEntityTypeExists_Call) RunAndReturn(run func(ctx context.Context, category entitytype.TypeCategory, name string) (bool, *common.ServiceError)) *EntityTypeServiceInterfaceMock_IsEntityTypeExists_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ResolveEntityTypeHandles provides a mock function for the type EntityTypeServiceInterfaceMock
 func (_mock *EntityTypeServiceInterfaceMock) ResolveEntityTypeHandles(ctx context.Context, entityType *entitytype.EntityType) *common.ServiceError {
 	ret := _mock.Called(ctx, entityType)

--- a/tests/integration/resources/declarative_resources/users/user-declarative-1.yaml
+++ b/tests/integration/resources/declarative_resources/users/user-declarative-1.yaml
@@ -1,6 +1,6 @@
 resource_type: user
 id: decl-user-1
-type: person
+type: Declarative Test Schema
 ouId: decl-ou-1
 attributes:
   username: decl-user-1


### PR DESCRIPTION
### Purpose
Declarative YAML resources (users, groups, roles, resource servers, entity types) could reference a nonexistent organization unit or entity type with no error. The REST API already validated these references. The declarative loader did not.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
Added existence checks for `ouId` (organization unit) and `type` (entity type) references to the declarative validators for `user`, `group`, `role`, `resource_server`, and `entity_type`. Since declarative loading runs at startup with no authenticated actor, these checks call authz-free existence lookups rather than the authz-gated API-path methods, including a new `IsEntityTypeExists` method on `EntityTypeServiceInterface`. `role` also validates that assignment IDs and permissions resolve to real resources.

Also fixed a stale `type: person` reference in an integration test fixture that this validation exposed (it previously loaded without error only because no validation existed.)

### Related Issues
- #3941

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Declarative startup validation now verifies referenced organization units for users, roles, groups, and resource servers.
  * Added entity-type existence validation for user `type` during startup.
* **Bug Fixes**
  * Validation failures now more clearly separate missing references (“not found”) from validation service errors.
* **Tests**
  * Expanded unit test coverage for organization-unit and entity-type validation scenarios.
  * Updated declarative user integration fixture to use a new user type value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->