### PR TITLE
Add validation logic for token exchange grant audiences

### DIFF
--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
@@ -207,9 +207,10 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 	}
 
 	// Determine final audiences per RFC 8693 §2.1: audience and resource parameters may be
-	// combined. audience values are opaque logical names passed verbatim; resource values are
-	// RFC 8707 URIs that resolve to registered Resource Servers and participate in scope
-	// downscoping.
+	// combined. resource values are RFC 8707 URIs that resolve to registered Resource Servers and
+	// participate in scope downscoping. audience values must themselves correspond to a resolved
+	// Resource Server (or the client's own clientID) — an audience that matches neither is
+	// rejected rather than minted verbatim (see resolveAudiences).
 	resolvedRSes, resErr := resourceindicators.ResolveResourceServers(ctx, h.resourceService, tokenRequest.Resources)
 	if resErr != nil {
 		return nil, resErr
@@ -228,7 +229,10 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 	if audErr != nil {
 		return nil, audErr
 	}
-	finalAudiences := mergeAudiences(tokenRequest.Audiences, rsAudiences, tokenRequest.ClientID)
+	finalAudiences, audFilterErr := resolveAudiences(tokenRequest.Audiences, rsAudiences, tokenRequest.ClientID)
+	if audFilterErr != nil {
+		return nil, audFilterErr
+	}
 
 	// Build access token using token builder
 	userSubConfig := oauthApp.UserAccessTokenConfig()
@@ -401,45 +405,47 @@ func (h *tokenExchangeGrantHandler) getScopes(
 	return validRequestedScopes, nil
 }
 
-// mergeAudiences combines opaque audience values with RS-resolved audiences per RFC 8693 §2.1.
-// Rules:
-//   - Start with explicitAudiences verbatim (preserving order, deduped within itself).
-//   - Append rsAudiences items not already present.
-//   - If rsAudiences is the clientID-only fallback (len==1 and value==clientID) and
-//     explicitAudiences is non-empty, the clientID fallback is dropped — the explicit audience
-//     request is sufficient.
-//   - If the merged set is empty, fall back to []string{clientID} (or empty if clientID is empty).
-func mergeAudiences(explicitAudiences []string, rsAudiences []string, clientID string) []string {
-	seen := make(map[string]struct{}, len(explicitAudiences)+len(rsAudiences))
-	merged := make([]string, 0, len(explicitAudiences)+len(rsAudiences))
-
-	for _, a := range explicitAudiences {
-		if _, ok := seen[a]; ok {
-			continue
-		}
-		seen[a] = struct{}{}
-		merged = append(merged, a)
+// resolveAudiences determines the final audiences per RFC 8693 §2.1 while preventing audience
+// injection: the audience request parameter is client-supplied input and must not be honored
+// verbatim. Rules:
+//   - If the client did not request explicit audiences, rsAudiences is returned as-is (RS-resolved
+//     audiences with the clientID fallback already applied by ComposeAudiences).
+//   - If the client requested explicit audiences, each one must correspond to a resolved resource
+//     server (rsAudiences) or be the client's own clientID (self-audience). Any requested audience
+//     matching neither is rejected with invalid_target, mirroring RFC 8707 §2.2's handling of an
+//     unresolvable resource parameter.
+//   - Otherwise the final audiences are the requested audiences themselves (deduped, order
+//     preserved) — downscoped to the requested subset rather than unioned with rsAudiences.
+func resolveAudiences(
+	explicitAudiences []string, rsAudiences []string, clientID string,
+) ([]string, *model.ErrorResponse) {
+	if len(explicitAudiences) == 0 {
+		return rsAudiences, nil
 	}
 
-	// Drop the clientID-only fallback from rsAudiences when explicit audiences were provided.
-	isFallback := len(rsAudiences) == 1 && rsAudiences[0] == clientID
-	if isFallback && len(explicitAudiences) > 0 {
-		rsAudiences = nil
-	}
-
+	validAudiences := make(map[string]struct{}, len(rsAudiences)+1)
 	for _, a := range rsAudiences {
+		validAudiences[a] = struct{}{}
+	}
+	if clientID != "" {
+		validAudiences[clientID] = struct{}{}
+	}
+
+	seen := make(map[string]struct{}, len(explicitAudiences))
+	filtered := make([]string, 0, len(explicitAudiences))
+	for _, a := range explicitAudiences {
+		if _, ok := validAudiences[a]; !ok {
+			return nil, &model.ErrorResponse{
+				Error:            constants.ErrorInvalidTarget,
+				ErrorDescription: "The audience parameter does not match any valid value",
+			}
+		}
 		if _, ok := seen[a]; ok {
 			continue
 		}
 		seen[a] = struct{}{}
-		merged = append(merged, a)
+		filtered = append(filtered, a)
 	}
 
-	if len(merged) == 0 {
-		if clientID != "" {
-			return []string{clientID}
-		}
-		return []string{}
-	}
-	return merged
+	return filtered, nil
 }

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
@@ -730,6 +730,8 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_WithAct
 }
 
 func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_WithAudienceParameter() {
+	// The requested audience is honored only because it resolves to a registered resource
+	// server discovered via the subject token's granted scopes.
 	now := time.Now().Unix()
 	subjectToken := suite.createTestJWT(map[string]interface{}{
 		"sub": "user123",
@@ -741,12 +743,60 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_WithAud
 	tokenRequest := suite.createBasicTokenRequest(subjectToken)
 	tokenRequest.Audiences = []string{"https://api.example.com"}
 
+	rsvc := resourcemock.NewResourceServiceInterfaceMock(suite.T())
+	rsvc.On("FindResourceServersByPermissions", mock.Anything, []string{"read", "write"}).
+		Return([]providers.ResourceServer{{ID: "rs-api", Identifier: "https://api.example.com"}}, nil)
+	h := &tokenExchangeGrantHandler{
+		tokenBuilder:    suite.mockTokenBuilder,
+		tokenValidator:  suite.mockTokenValidator,
+		resourceService: rsvc,
+	}
+
 	suite.setupSuccessfulJWTMock(subjectToken, "https://api.example.com", now)
 
-	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+	result, errResp := h.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
 
 	assert.Nil(suite.T(), errResp)
 	assert.NotNil(suite.T(), result)
+}
+
+// A requested audience that does not correspond to any registered resource server (or the
+// client's own clientID) is rejected with invalid_target rather than minted verbatim. This is
+// the regression test for the audience-injection vulnerability the resolveAudiences fail-closed
+// check was introduced to close.
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_UnregisteredAudience_Rejected() {
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{
+		"sub": "user123",
+		"iss": testCustomIssuer,
+		"exp": float64(now + 3600),
+		"nbf": float64(now - 60),
+	})
+
+	tokenRequest := suite.createBasicTokenRequest(subjectToken)
+	tokenRequest.Audiences = []string{"https://attacker-controlled.example.com"}
+
+	rsvc := resourcemock.NewResourceServiceInterfaceMock(suite.T())
+	rsvc.On("FindResourceServersByPermissions", mock.Anything, mock.Anything).
+		Return([]providers.ResourceServer{}, nil).Maybe()
+	h := &tokenExchangeGrantHandler{
+		tokenBuilder:    suite.mockTokenBuilder,
+		tokenValidator:  suite.mockTokenValidator,
+		resourceService: rsvc,
+	}
+
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub:            testUserID,
+			Iss:            testCustomIssuer,
+			UserAttributes: map[string]interface{}{},
+		}, nil)
+
+	result, errResp := h.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorInvalidTarget, errResp.Error)
 }
 
 func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_WithResourceParameter() {
@@ -1275,7 +1325,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_CompleteTokenExchan
 		SubjectToken:       subjectToken,
 		SubjectTokenType:   string(constants.TokenTypeIdentifierAccessToken),
 		RequestedTokenType: string(constants.TokenTypeIdentifierAccessToken),
-		Audiences:          []string{"https://target-service.com"},
+		Audiences:          []string{testClientID},
 		Scope:              "read",
 	}
 
@@ -1292,11 +1342,10 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_CompleteTokenExchan
 		}, nil)
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
 		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-			// Verify claims structure per RFC 8693 - explicit audience is used verbatim; clientID
-			// fallback is dropped when explicit audience is non-empty.
+			// Verify claims structure per RFC 8693 - explicit self-audience (clientID) is honored.
 			return ctx.Subject == testUserID &&
 				len(ctx.Audiences) == 1 &&
-				ctx.Audiences[0] == "https://target-service.com" &&
+				ctx.Audiences[0] == testClientID &&
 				ctx.ClientID == testClientID &&
 				tokenservice.JoinScopes(ctx.Scopes) == testScopeRead &&
 				ctx.SubjectAttributes["email"] == "user@example.com" &&
@@ -1328,8 +1377,9 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_CompleteTokenExchan
 }
 
 func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_AudienceCombinedWithResource() {
-	// RFC 8693 §2.1: audience and resource parameters may be combined; audience is opaque,
-	// resource is RS-resolved. Both contribute to the final aud simultaneously.
+	// RFC 8693 §2.1: audience and resource parameters may be combined. The requested audience is
+	// only honored when it corresponds to the resolved resource server; the final aud is the
+	// requested audience itself (downscoped), not a union with every resolved resource.
 	now := time.Now().Unix()
 	subjectToken := suite.createTestJWT(map[string]interface{}{
 		"sub": "user123",
@@ -1344,7 +1394,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_AudienceCombinedWit
 		ClientID:         testClientID,
 		SubjectToken:     subjectToken,
 		SubjectTokenType: string(constants.TokenTypeIdentifierAccessToken),
-		Audiences:        []string{"request-audience"},
+		Audiences:        []string{"https://resource.example.com"},
 		Resources:        []string{"https://resource.example.com"},
 	}
 
@@ -1358,12 +1408,9 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestRFC8693_AudienceCombinedWit
 		}, nil)
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
 		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-			// explicit audience first, then RS-resolved audience; clientID fallback absent since
-			// explicit audiences were supplied.
 			return ctx.Subject == testUserID &&
-				len(ctx.Audiences) == 2 &&
-				ctx.Audiences[0] == "request-audience" &&
-				ctx.Audiences[1] == "https://resource.example.com"
+				len(ctx.Audiences) == 1 &&
+				ctx.Audiences[0] == "https://resource.example.com"
 		})).Return(&model.TokenDTO{
 		Token:     testTokenExchangeJWT,
 		TokenType: constants.TokenTypeBearer,
@@ -1999,8 +2046,10 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_ServerAuthAsser
 // §6 — audience + resource together in token_exchange (RFC 8693 §2.1)
 // ============================================================================
 
-func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_OnlyAudience_AudIsExplicitValue() { //nolint:dupl
-	// Only audience=logical://x → aud = ["logical://x"]; clientID fallback dropped.
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_OnlyAudienceUnReg_Rejected() { //nolint:dupl
+	// Only audience=logical://x, no resource, no granted scopes → logical://x corresponds to no
+	// registered resource server and isn't the clientID, so the request is rejected rather than
+	// minting a token with an arbitrary aud.
 	now := time.Now().Unix()
 	subjectToken := suite.createTestJWT(map[string]interface{}{
 		"sub": testUserID,
@@ -2018,15 +2067,12 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_OnlyAudience_Au
 			Scopes:         []string{},
 			UserAttributes: map[string]interface{}{},
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
-		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-			return len(ctx.Audiences) == 1 && ctx.Audiences[0] == "logical://x"
-		})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
 
-	assert.Nil(suite.T(), errResp)
-	assert.NotNil(suite.T(), result)
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorInvalidTarget, errResp.Error)
 }
 
 func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_OnlyResource_AudIsResolvedRS() { //nolint:dupl
@@ -2060,7 +2106,9 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_OnlyResource_Au
 }
 
 func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AudienceAndResource_BothContribute() {
-	// audience=logical://x, resource=https://rs01 → aud = ["logical://x", testRS01URI].
+	// audience=logical://x, resource=https://rs01 → logical://x matches neither the resolved
+	// resource server nor the clientID, so the request is rejected instead of minting an
+	// arbitrary aud alongside the resolved resource.
 	now := time.Now().Unix()
 	subjectToken := suite.createTestJWT(map[string]interface{}{
 		"sub": testUserID,
@@ -2079,21 +2127,17 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AudienceAndReso
 			Scopes:         []string{},
 			UserAttributes: map[string]interface{}{},
 		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
-		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-			return len(ctx.Audiences) == 2 &&
-				ctx.Audiences[0] == "logical://x" &&
-				ctx.Audiences[1] == testRS01URI
-		})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
 
-	assert.Nil(suite.T(), errResp)
-	assert.NotNil(suite.T(), result)
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorInvalidTarget, errResp.Error)
 }
 
-func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_TwoAudiencesTwoResources_OrderPreserved() {
-	// audience=[a1,a2], resource=[rs01,rs02] → aud=[a1,a2,rs01,rs02] (audience order first).
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AudienceMatchingResource_Downscoped() { //nolint:dupl
+	// audience=testRS01URI, resource=testRS01URI → aud=[testRS01URI]; the explicit audience is
+	// honored because it matches the resolved resource server.
 	now := time.Now().Unix()
 	subjectToken := suite.createTestJWT(map[string]interface{}{
 		"sub": testUserID,
@@ -2103,7 +2147,39 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_TwoAudiencesTwo
 	})
 
 	tokenRequest := suite.createBasicTokenRequest(subjectToken)
-	tokenRequest.Audiences = []string{"https://a1.example.com", "https://a2.example.com"}
+	tokenRequest.Audiences = []string{testRS01URI}
+	tokenRequest.Resources = []string{testRS01URI}
+
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub:            testUserID,
+			Scopes:         []string{},
+			UserAttributes: map[string]interface{}{},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return len(ctx.Audiences) == 1 && ctx.Audiences[0] == testRS01URI
+		})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+}
+
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_TwoAudiencesTwoResources_OrderPreserved() {
+	// audience=[rs02,rs01] (both resolved via resource), resource=[rs01,rs02] →
+	// aud=[rs02,rs01]: downscoped to exactly the requested audiences, in request order.
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{
+		"sub": testUserID,
+		"iss": testCustomIssuer,
+		"exp": float64(now + 3600),
+		"nbf": float64(now - 60),
+	})
+
+	tokenRequest := suite.createBasicTokenRequest(subjectToken)
+	tokenRequest.Audiences = []string{"https://rs02.example.com", testRS01URI}
 	tokenRequest.Resources = []string{testRS01URI, "https://rs02.example.com"}
 
 	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
@@ -2114,11 +2190,9 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_TwoAudiencesTwo
 		}, nil)
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
 		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-			return len(ctx.Audiences) == 4 &&
-				ctx.Audiences[0] == "https://a1.example.com" &&
-				ctx.Audiences[1] == "https://a2.example.com" &&
-				ctx.Audiences[2] == testRS01URI &&
-				ctx.Audiences[3] == "https://rs02.example.com"
+			return len(ctx.Audiences) == 2 &&
+				ctx.Audiences[0] == "https://rs02.example.com" &&
+				ctx.Audiences[1] == testRS01URI
 		})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
@@ -2127,8 +2201,9 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_TwoAudiencesTwo
 	assert.NotNil(suite.T(), result)
 }
 
-func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AudienceIsClientID_WithResource_BothKept() {
-	// audience=<clientID>, resource=rs01 → aud=[<clientID>, rs01] (no dedup; client asked for clientID).
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AudienceIsClientID_Downscoped() { //nolint:dupl
+	// audience=<clientID>, resource=rs01 → aud=[<clientID>] only: the client only asked for
+	// itself as audience, so the resolved resource server is not appended.
 	now := time.Now().Unix()
 	subjectToken := suite.createTestJWT(map[string]interface{}{
 		"sub": testUserID,
@@ -2149,9 +2224,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AudienceIsClien
 		}, nil)
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
 		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-			return len(ctx.Audiences) == 2 &&
-				ctx.Audiences[0] == testClientID &&
-				ctx.Audiences[1] == testRS01URI
+			return len(ctx.Audiences) == 1 && ctx.Audiences[0] == testClientID
 		})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
@@ -2160,8 +2233,9 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AudienceIsClien
 	assert.NotNil(suite.T(), result)
 }
 
-func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AudienceOnly_ClientIDFallbackDropped() { //nolint:dupl
-	// audience=<something>, no resource, no granted scopes → aud=[<something>] (clientID fallback dropped).
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AudienceOnly_SelfAudienceHonored() { //nolint:dupl
+	// audience=<clientID>, no resource, no granted scopes → aud=[<clientID>]: a client may always
+	// request itself as the audience (self-audience), even with no resource server involved.
 	now := time.Now().Unix()
 	subjectToken := suite.createTestJWT(map[string]interface{}{
 		"sub": testUserID,
@@ -2171,7 +2245,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AudienceOnly_Cl
 	})
 
 	tokenRequest := suite.createBasicTokenRequest(subjectToken)
-	tokenRequest.Audiences = []string{"https://other-service.example.com"}
+	tokenRequest.Audiences = []string{testClientID}
 
 	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
 		Return(&tokenservice.SubjectTokenClaims{
@@ -2181,7 +2255,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AudienceOnly_Cl
 		}, nil)
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
 		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-			return len(ctx.Audiences) == 1 && ctx.Audiences[0] == "https://other-service.example.com"
+			return len(ctx.Audiences) == 1 && ctx.Audiences[0] == testClientID
 		})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)

--- a/docs/content/guides/guides/protocols/oauth-oidc/token-exchange.mdx
+++ b/docs/content/guides/guides/protocols/oauth-oidc/token-exchange.mdx
@@ -2,21 +2,27 @@
 title: Token Exchange
 docType: reference
 sidebar_position: 4
-description: RFC 8693 Token Exchange in {{ProductName}}, swap one token for another to delegate, impersonate, or downscope across services.
+description:
+  RFC 8693 Token Exchange in {{ProductName}} - swap one token for another to delegate, impersonate, or downscope across
+  services.
 ---
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import { TokenExchangeDiagram } from '../../../../../src/components/OAuthFlowDiagrams';
+import {TokenExchangeDiagram} from '../../../../../src/components/OAuthFlowDiagrams';
 
 # Token Exchange
 
-**Token Exchange** ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)) lets a client present an existing token to <ProductName /> and request a different token in return. The exchanged token can target a different audience, carry narrower scopes, or represent an "on-behalf-of" act in a service-to-service call chain.
+**Token Exchange** ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)) lets a client present an existing token
+to <ProductName /> and request a different token in return. The exchanged token can target a different audience, carry
+narrower scopes, or represent an "on-behalf-of" act in a service-to-service call chain.
 
 Typical uses:
 
 - A frontend exchanges a user's access token for a downscoped token before passing it to a third-party API.
 - A gateway exchanges an inbound token for a service-mesh token whose `aud` matches a downstream microservice.
-- A backend acts on behalf of a user it received an `id_token` for, asking <ProductName /> to mint an access token for that user against a specific resource server.
+- A backend acts on behalf of a user it received an `id_token` for, asking <ProductName /> to mint an access token for
+  that user against a specific resource server.
 
 ## How It Works
 
@@ -32,8 +38,8 @@ Typical uses:
 | `subject_token_type` (input) | `urn:ietf:params:oauth:token-type:access_token` · `:refresh_token` · `:id_token` · `:jwt` |
 | `actor_token_type` (input) | Same set as `subject_token_type`; used for delegation chains |
 | `requested_token_type` (output) | `urn:ietf:params:oauth:token-type:access_token` · `:jwt` only. **`id_token` and `refresh_token` outputs are not supported.** |
-| `audience` parameter | Narrows the `aud` claim on the issued token |
-| `resource` parameter | RFC 8707 resource indicator, combined with `audience` when present |
+| `audience` parameter | Restricts the `aud` claim on the issued token. Each value must resolve to a registered resource server or equal the client's own `client_id` — a value that matches neither is rejected with `invalid_target` |
+| `resource` parameter | RFC 8707 resource indicator — see [Audience Validation](#audience-validation) for how it combines with `audience` |
 | `scope` parameter | Requested scopes; downscoping is allowed, widening is rejected with `invalid_scope` |
 | Client authentication | Required, same methods as the token endpoint |
 | Issued token shape | `issued_token_type` is echoed in the response so the caller knows what it received |
@@ -48,9 +54,39 @@ Typical uses:
 | `requested_token_type` | No | Defaults to `:access_token` |
 | `actor_token` | No | Token of the acting party in delegation |
 | `actor_token_type` | No | Required when `actor_token` is supplied |
-| `audience` | No | Logical name(s) of the target service |
+| `audience` | No | Target audience(s) for the issued token. Each value must be a registered resource server's `identifier` or the client's own `client_id` — see [Audience Validation](#audience-validation) |
 | `resource` | No | Absolute URI of the target resource server (see [Resource Indicators](../resource-indicators)) |
 | `scope` | No | Requested scopes must be a subset of the subject token's grant |
+
+### Audience Validation
+
+An explicit `audience` value is validated, not passed through verbatim:
+
+| `audience` value                                                                                                    | Accepted when                  |
+| ------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| Matches a resource server resolved via `resource` (or discovered from the granted scopes when `resource` is absent) | Accepted                       |
+| Equals the requesting client's own `client_id`                                                                      | Accepted                       |
+| Anything else                                                                                                       | Rejected with `invalid_target` |
+
+When `audience` and `resource` are both supplied, the issued `aud` claim contains only the explicitly requested
+`audience` values (deduplicated). It is **not** the union of `audience` and every resource server resolved via
+`resource`. To include a resource server's identifier in `aud`, name it in `audience` directly.
+
+```bash
+curl -X POST https://{{productSlug}}.example.com/oauth2/token \
+  -u "$CLIENT_ID:$CLIENT_SECRET" \
+  -d "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
+  -d "subject_token=$ACCESS_TOKEN" \
+  -d "subject_token_type=urn:ietf:params:oauth:token-type:access_token" \
+  -d "audience=https://unregistered.example.com"
+```
+
+```json
+{
+  "error": "invalid_target",
+  "error_description": "The audience parameter does not match any valid value"
+}
+```
 
 </details>
 
@@ -59,7 +95,8 @@ Typical uses:
 <Tabs groupId="client-registration">
 <TabItem value="console" label="Console" default>
 
-1. Open **Applications** or **Agents** in the <ProductName /> Console and select the client that will perform the exchange.
+1. Open **Applications** or **Agents** in the <ProductName /> Console and select the client that will perform the
+   exchange.
 2. Open the **Advanced Settings** tab.
 3. Under **Grant Types**, add `urn:ietf:params:oauth:grant-type:token-exchange`.
 4. Save.
@@ -108,6 +145,6 @@ Response:
 
 ## Related Guides
 
-- [Resource Indicators](../resource-indicators), target the new token at a specific resource server
-- [Client Credentials](../client-credentials), for service tokens that don't require a subject token
-- [Refresh Token](../refresh-token), for renewing access tokens without exchange semantics
+- [Resource Indicators](../resource-indicators) - target the new token at a specific resource server
+- [Client Credentials](../client-credentials) - for service tokens that don't require a subject token
+- [Refresh Token](../refresh-token) - for renewing access tokens without exchange semantics

--- a/tests/integration/agent/agent_oauth_test.go
+++ b/tests/integration/agent/agent_oauth_test.go
@@ -998,13 +998,14 @@ func (s *AgentTokenExchangeTestSuite) TestAgentTE_BasicSuccess() {
 	s.Equal(s.userID, claims.Sub, "Subject must match the authenticated user")
 }
 
-// TestAgentTE_WithAudience verifies that the audience parameter is reflected in the issued token.
+// TestAgentTE_WithAudience verifies that an audience matching the requesting client's own
+// client_id (self-audience) is reflected in the issued token.
 func (s *AgentTokenExchangeTestSuite) TestAgentTE_WithAudience() {
 	formData := url.Values{}
 	formData.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
 	formData.Set("subject_token", s.assertionToken)
 	formData.Set("subject_token_type", "urn:ietf:params:oauth:token-type:jwt")
-	formData.Set("audience", "https://agent-api.example.com")
+	formData.Set("audience", agentTEClientID)
 
 	resp, statusCode, err := s.doTokenExchange(formData)
 	s.Require().NoError(err)
@@ -1018,11 +1019,11 @@ func (s *AgentTokenExchangeTestSuite) TestAgentTE_WithAudience() {
 	s.Require().True(ok, "JWT must contain an aud claim")
 	switch aud := rawAud.(type) {
 	case string:
-		s.Equal("https://agent-api.example.com", aud)
+		s.Equal(agentTEClientID, aud)
 	case []interface{}:
 		found := false
 		for _, v := range aud {
-			if str, ok := v.(string); ok && str == "https://agent-api.example.com" {
+			if str, ok := v.(string); ok && str == agentTEClientID {
 				found = true
 				break
 			}
@@ -1031,6 +1032,23 @@ func (s *AgentTokenExchangeTestSuite) TestAgentTE_WithAudience() {
 	default:
 		s.Failf("unexpected aud type", "%T", rawAud)
 	}
+}
+
+// TestAgentTE_UnregisteredAudienceRejected verifies that an audience value not corresponding to
+// a registered resource server or the client's own client_id is rejected with invalid_target,
+// rather than being minted into the token verbatim.
+func (s *AgentTokenExchangeTestSuite) TestAgentTE_UnregisteredAudienceRejected() {
+	formData := url.Values{}
+	formData.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+	formData.Set("subject_token", s.assertionToken)
+	formData.Set("subject_token_type", "urn:ietf:params:oauth:token-type:jwt")
+	formData.Set("audience", "https://agent-api.example.com")
+
+	resp, statusCode, err := s.doTokenExchange(formData)
+	s.Require().NoError(err)
+	s.Equal(http.StatusBadRequest, statusCode)
+	s.Equal("invalid_target", resp.Error)
+	s.Empty(resp.AccessToken)
 }
 
 // TestAgentTE_InvalidSubjectToken verifies that a malformed subject_token is rejected.

--- a/tests/integration/oauth/token/tokenexchange_test.go
+++ b/tests/integration/oauth/token/tokenexchange_test.go
@@ -546,13 +546,15 @@ func (ts *TokenExchangeTestSuite) TestTokenExchange_ExternalIDP_WithTrustedToken
 	)
 }
 
-// TestTokenExchange_WithAudience tests token exchange with audience parameter
+// TestTokenExchange_WithAudience tests token exchange with the audience parameter set to the
+// requesting client's own client_id — a client may always request itself as audience
+// (self-audience), even without a matching resource server.
 func (ts *TokenExchangeTestSuite) TestTokenExchange_WithAudience() {
 	formData := url.Values{}
 	formData.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
 	formData.Set("subject_token", ts.assertionToken)
 	formData.Set("subject_token_type", "urn:ietf:params:oauth:token-type:jwt")
-	formData.Set("audience", "https://api.example.com")
+	formData.Set("audience", tokenExchangeClientID)
 
 	authHeader := "Basic " + basicAuth(tokenExchangeClientID, tokenExchangeClientSecret)
 
@@ -564,7 +566,26 @@ func (ts *TokenExchangeTestSuite) TestTokenExchange_WithAudience() {
 	// Verify audience in JWT contains the requested audience
 	claims, err := testutils.DecodeJWT(resp.AccessToken)
 	ts.Require().NoError(err)
-	ts.assertAudienceContains(claims, "https://api.example.com")
+	ts.assertAudienceContains(claims, tokenExchangeClientID)
+}
+
+// TestTokenExchange_UnregisteredAudienceRejected tests that an audience value not corresponding
+// to a registered resource server or the client's own client_id is rejected with invalid_target,
+// rather than being minted into the token verbatim.
+func (ts *TokenExchangeTestSuite) TestTokenExchange_UnregisteredAudienceRejected() {
+	formData := url.Values{}
+	formData.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+	formData.Set("subject_token", ts.assertionToken)
+	formData.Set("subject_token_type", "urn:ietf:params:oauth:token-type:jwt")
+	formData.Set("audience", "https://api.example.com")
+
+	authHeader := "Basic " + basicAuth(tokenExchangeClientID, tokenExchangeClientSecret)
+
+	resp, statusCode, err := ts.exchangeToken(formData.Encode(), authHeader)
+	ts.Require().NoError(err)
+	ts.Equal(http.StatusBadRequest, statusCode)
+	ts.Equal("invalid_target", resp.Error)
+	ts.Empty(resp.AccessToken)
 }
 
 // TestTokenExchange_WithResource tests token exchange with resource parameter


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

Currently the Token Exchange grant merges all the explicit audience values from the requests with the resolved audiences from the scopes and resource parameter. This makes it possible to include arbitrary audience values and get valid tokens from them.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->

### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
All the explicit audience values are validated against the resolved Audience values from the resource servers through scope lookup and the audience values are downscoped with the explicit audience parameter if multiple valid audiences exist.

#### 💥 Impact
_What will break? Who is affected?_
- Any integration that was passing an opaque/logical audience not backed by a registered Resource Server will start getting a 400 error where it previously got a 200
- A client relying on resource implicitly widening the aud list alongside an explicit audience will see a smaller aud claim than before, even though the request itself still succeeds.

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_
- Convert all the opaque/logical explicit audience values to be valid resource server identifiers. 
- Use the audience parameter to downscope.


### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

Removed the audience merging which was not validating and created a valid audience list from the valid resource servers. Then explicit audience claim is used to filter and downscope the available valid resource servers.

### Related Issues
- #2861 

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [x] Breaking changes. (Fill if applicable)
    - [x] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened OAuth token-exchange `audience` handling to fail-closed: unregistered/invalid audiences are rejected with `invalid_target`, and no token is issued.
  * Updated issued token `aud` behavior when combining `audience` with `resource` to use validated/downscoped audiences only (no union), with deduplication and order preservation.

* **Tests**
  * Added and updated regression coverage for rejected unregistered audiences and the correct `aud` downscoping/self-audience behavior (including agent and integration flows).

* **Documentation**
  * Updated the Token Exchange guide with precise `audience` validation rules, `aud` computation, and `invalid_target` examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->