### PR TITLE
Fall back to default flow when configured authentication flow is deleted

### DIFF
--- a/backend/internal/flow/flowexec/service.go
+++ b/backend/internal/flow/flowexec/service.go
@@ -316,9 +316,14 @@ func (s *flowExecService) initContext(ctx context.Context, appID string, flowTyp
 
 	flow, svcErr := s.flowProvider.GetFlow(ctx, graphID)
 	if svcErr != nil {
-		logger.Error(ctx, "Error retrieving flow from flow provider",
-			log.String("graphID", graphID), log.String("error", svcErr.Error.DefaultValue))
-		return nil, &tidcommon.InternalServerError
+		// The configured flow may have been deleted while still referenced by the
+		// application. For authentication flows, fall back to the default flow instead
+		// of failing the request.
+		flow, svcErr = s.fallbackToDefaultFlow(ctx, graphID, flowType, svcErr, logger)
+		if svcErr != nil {
+			return nil, svcErr
+		}
+		graphID = flow.ID
 	}
 
 	engineCtx.FlowType = flow.FlowType
@@ -340,6 +345,32 @@ func (s *flowExecService) initContext(ctx context.Context, appID string, flowTyp
 	}
 
 	return &engineCtx, nil
+}
+
+// fallbackToDefaultFlow attempts to recover from a failure to retrieve the configured flow.
+// If the flow was not found (e.g. it was deleted while still referenced by the application)
+// and the flow type is authentication, it falls back to the system default authentication
+// flow. Any other case surfaces an internal server error.
+func (s *flowExecService) fallbackToDefaultFlow(ctx context.Context, graphID string,
+	flowType providers.FlowType, origErr *tidcommon.ServiceError, logger *log.Logger) (
+	*providers.CompleteFlowDefinition, *tidcommon.ServiceError) {
+	if flowType != providers.FlowTypeAuthentication || origErr.Type != tidcommon.ClientErrorType {
+		logger.Error(ctx, "Error retrieving flow from flow provider",
+			log.String("graphID", graphID), log.String("error", origErr.Error.DefaultValue))
+		return nil, &tidcommon.InternalServerError
+	}
+
+	handle := s.cfg.Flow.DefaultAuthFlowHandle
+	logger.Warn(ctx, "Configured authentication flow not found; falling back to default flow",
+		log.String("graphID", graphID), log.String("defaultFlowHandle", handle))
+
+	flow, svcErr := s.flowProvider.GetFlowByHandle(ctx, handle, providers.FlowTypeAuthentication)
+	if svcErr != nil {
+		logger.Error(ctx, "Failed to retrieve default authentication flow",
+			log.String("defaultFlowHandle", handle), log.String("error", svcErr.Error.DefaultValue))
+		return nil, &tidcommon.InternalServerError
+	}
+	return flow, nil
 }
 
 // getFlowExpirySeconds returns the expiry time for a flow in seconds.

--- a/backend/internal/flow/flowexec/service_test.go
+++ b/backend/internal/flow/flowexec/service_test.go
@@ -60,6 +60,7 @@ import (
 )
 
 const existingExecutionID = "existing-execution-id"
+const testAppID = "test-app-123"
 
 // txMarkerKey is an unexported type used as a context key for the transaction marker in tests.
 type txMarkerKey struct{}
@@ -73,9 +74,11 @@ func (s *stubTransactioner) Transact(ctx context.Context, txFunc func(context.Co
 }
 
 const testUserOnboardingFlowHandle = "onboarding-handle"
+const testDefaultAuthFlowHandle = "default-auth-handle"
 
 var testFlowConfig = engineconfig.FlowConfig{
 	UserOnboardingFlowHandle: testUserOnboardingFlowHandle,
+	DefaultAuthFlowHandle:    testDefaultAuthFlowHandle,
 }
 
 var testFlowExecCfg = flowconfig.Config{
@@ -161,7 +164,7 @@ func TestInitiateFlowInvalidFlowType(t *testing.T) {
 }
 
 func TestInitiateFlowSuccessScenarios(t *testing.T) {
-	appID := "test-app-123"
+	appID := testAppID
 
 	testConfig := &config.Config{}
 	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
@@ -327,7 +330,7 @@ func TestInitiateFlowSuccessScenarios(t *testing.T) {
 }
 
 func TestInitiateFlowErrorScenarios(t *testing.T) {
-	appID := "test-app-123"
+	appID := testAppID
 
 	testConfig := &config.Config{}
 	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
@@ -471,6 +474,140 @@ func TestInitiateFlowErrorScenarios(t *testing.T) {
 			// All mocks automatically verified by mockery
 		})
 	}
+}
+
+func TestInitiateFlowFallsBackToDefaultFlow(t *testing.T) {
+	appID := testAppID
+
+	testConfig := &config.Config{}
+	_ = config.InitializeServerRuntime("/tmp/test", testConfig)
+
+	flowFactory, _ := core.Initialize(cache.Initialize(config.GetServerRuntime().Config.Cache, "test-deployment"))
+	defaultGraph := flowFactory.CreateGraph("default-auth-graph", providers.FlowTypeAuthentication, 1)
+
+	flowNotFound := &tidcommon.ServiceError{
+		Type:  tidcommon.ClientErrorType,
+		Code:  "FLM-1003",
+		Error: tidcommon.I18nMessage{DefaultValue: "Flow not found"},
+	}
+
+	t.Run("auth flow deleted - falls back to default", func(t *testing.T) {
+		mockStore := newFlowStoreInterfaceMock(t)
+		mockInboundClient := inboundclientmock.NewInboundClientServiceInterfaceMock(t)
+		mockEntityProvider := entityprovidermock.NewEntityProviderInterfaceMock(t)
+		mockFlowProvider := NewFlowProviderMock(t)
+		mockGraphBuilder := NewGraphBuilderInterfaceMock(t)
+		mockCrypto := cryptomock.NewRuntimeCryptoProviderMock(t)
+		mockCrypto.EXPECT().Encrypt(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return([]byte("encrypted-ctx"), nil, nil)
+
+		service := &flowExecService{
+			graphBuilder:  mockGraphBuilder,
+			flowProvider:  mockFlowProvider,
+			flowStore:     mockStore,
+			actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+			transactioner: &stubTransactioner{},
+			cryptoSvc:     mockCrypto,
+			cfg:           testFlowExecCfg,
+		}
+
+		mockInboundClient.EXPECT().GetInboundClientByEntityID(mock.Anything, appID).
+			Return(&inboundmodel.InboundClient{ID: appID, AuthFlowID: "stale-auth-graph"}, nil)
+		mockEntityProvider.EXPECT().GetEntity(appID).
+			Return(&providers.Entity{ID: appID, Category: providers.EntityCategoryApp},
+				(*entityprovider.EntityProviderError)(nil))
+
+		// The referenced flow was deleted.
+		mockFlowProvider.EXPECT().GetFlow(mock.Anything, "stale-auth-graph").
+			Return(nil, flowNotFound)
+		// Fallback resolves the default authentication flow by handle.
+		mockFlowProvider.EXPECT().
+			GetFlowByHandle(mock.Anything, testDefaultAuthFlowHandle, providers.FlowTypeAuthentication).
+			Return(&providers.CompleteFlowDefinition{
+				ID:       "default-auth-graph",
+				FlowType: providers.FlowTypeAuthentication,
+			}, nil)
+		mockGraphBuilder.EXPECT().GetGraph(mock.Anything, mock.Anything).Return(defaultGraph, nil)
+		mockStore.EXPECT().StoreFlowContext(mock.Anything, mock.MatchedBy(
+			func(encryptedEngineCtx FlowContextDB) bool {
+				return encryptedEngineCtx.ExecutionID != ""
+			}), mock.Anything).Return(nil)
+
+		executionID, svcErr := service.InitiateFlow(context.Background(), &FlowInitContext{
+			ApplicationID: appID,
+			FlowType:      "AUTHENTICATION",
+		})
+
+		assert.Nil(t, svcErr)
+		assert.NotEmpty(t, executionID)
+	})
+
+	t.Run("server error retrieving flow - no fallback", func(t *testing.T) {
+		mockStore := newFlowStoreInterfaceMock(t)
+		mockInboundClient := inboundclientmock.NewInboundClientServiceInterfaceMock(t)
+		mockEntityProvider := entityprovidermock.NewEntityProviderInterfaceMock(t)
+		mockFlowProvider := NewFlowProviderMock(t)
+		mockGraphBuilder := NewGraphBuilderInterfaceMock(t)
+
+		service := &flowExecService{
+			graphBuilder:  mockGraphBuilder,
+			flowProvider:  mockFlowProvider,
+			flowStore:     mockStore,
+			actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+			transactioner: &stubTransactioner{},
+			cfg:           testFlowExecCfg,
+		}
+
+		mockInboundClient.EXPECT().GetInboundClientByEntityID(mock.Anything, appID).
+			Return(&inboundmodel.InboundClient{ID: appID, AuthFlowID: "stale-auth-graph"}, nil)
+		mockFlowProvider.EXPECT().GetFlow(mock.Anything, "stale-auth-graph").
+			Return(nil, &tidcommon.InternalServerError)
+
+		executionID, svcErr := service.InitiateFlow(context.Background(), &FlowInitContext{
+			ApplicationID: appID,
+			FlowType:      "AUTHENTICATION",
+		})
+
+		assert.NotNil(t, svcErr)
+		assert.Empty(t, executionID)
+		assert.Equal(t, tidcommon.InternalServerError.Code, svcErr.Code)
+	})
+
+	t.Run("default flow retrieval fails during fallback", func(t *testing.T) {
+		mockStore := newFlowStoreInterfaceMock(t)
+		mockInboundClient := inboundclientmock.NewInboundClientServiceInterfaceMock(t)
+		mockEntityProvider := entityprovidermock.NewEntityProviderInterfaceMock(t)
+		mockFlowProvider := NewFlowProviderMock(t)
+		mockGraphBuilder := NewGraphBuilderInterfaceMock(t)
+
+		service := &flowExecService{
+			graphBuilder:  mockGraphBuilder,
+			flowProvider:  mockFlowProvider,
+			flowStore:     mockStore,
+			actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+			transactioner: &stubTransactioner{},
+			cfg:           testFlowExecCfg,
+		}
+
+		mockInboundClient.EXPECT().GetInboundClientByEntityID(mock.Anything, appID).
+			Return(&inboundmodel.InboundClient{ID: appID, AuthFlowID: "stale-auth-graph"}, nil)
+		// The referenced flow was deleted, triggering the fallback.
+		mockFlowProvider.EXPECT().GetFlow(mock.Anything, "stale-auth-graph").
+			Return(nil, flowNotFound)
+		// Resolving the default authentication flow also fails.
+		mockFlowProvider.EXPECT().
+			GetFlowByHandle(mock.Anything, testDefaultAuthFlowHandle, providers.FlowTypeAuthentication).
+			Return(nil, &tidcommon.InternalServerError)
+
+		executionID, svcErr := service.InitiateFlow(context.Background(), &FlowInitContext{
+			ApplicationID: appID,
+			FlowType:      "AUTHENTICATION",
+		})
+
+		assert.NotNil(t, svcErr)
+		assert.Empty(t, executionID)
+		assert.Equal(t, tidcommon.InternalServerError.Code, svcErr.Code)
+	})
 }
 
 func TestGetFlowExpirySeconds(t *testing.T) {


### PR DESCRIPTION
### Purpose

Fixes the case where an application references an authentication flow that has since been deleted. Previously, initiating authentication for such an application failed with an internal server error (`SSE-5000`) instead of falling back to the default flow.

Fixes #3990

### Approach

Added a runtime fallback in the flow execution path:

- In `initContext`, when `flowProvider.GetFlow` fails to retrieve the configured flow, the failure is now routed through a new `fallbackToDefaultFlow` helper instead of erroring out immediately.
- `fallbackToDefaultFlow` falls back to the configured default authentication flow (`flow.default_auth_flow_handle`) **only** when:
  - the flow type is `AUTHENTICATION`, and
  - the error is a client error (i.e. the flow was genuinely not found).

  A server-side error (e.g. a DB failure) still surfaces as an internal server error, so real infrastructure problems are not masked.
- Registration/recovery flows are intentionally not covered, since there is no configured system default handle for them.

This is a resilient runtime fix that also covers references broken by direct DB edits or imports, not just deletions.

### Related Issues
- #3990

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication flow initiation to recover from client-side failures when the requested authentication flow can’t be loaded (for example, when it was deleted or is stale) by falling back to the configured default authentication flow.
  * Ensures fallback only happens for eligible client errors; server-side errors do not trigger fallback.
  * When fallback succeeds, the flow session is persisted so execution can continue.

* **Tests**
  * Added test coverage for successful fallback, and for cases where fallback should not occur (server error or default lookup failure).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->