### PR TITLE
Rename Call flow node label to Flow

### DIFF
--- a/frontend/apps/console/src/features/flows/components/resources/steps/call/Call.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/steps/call/Call.tsx
@@ -80,7 +80,7 @@ function Call({resources, data}: CallPropsInterface): ReactElement {
   const callData: CallStepData = (data as CallStepData) ?? {};
   const flowRef: string = callData.flow?.ref ?? '';
   const paletteEntry: Step | undefined = resources?.[0];
-  const displayLabel: string = paletteEntry?.display?.label ?? t('flows:core.call.unconfiguredLabel', 'Call flow');
+  const displayLabel: string = paletteEntry?.display?.label ?? t('flows:core.call.unconfiguredLabel', 'Flow');
 
   const referencedFlow: BasicFlowDefinition | undefined = useMemo<BasicFlowDefinition | undefined>(
     () => (flowsData?.flows ?? []).find((f: BasicFlowDefinition) => f.id === flowRef),

--- a/frontend/apps/console/src/features/flows/components/resources/steps/call/__tests__/Call.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/steps/call/__tests__/Call.test.tsx
@@ -69,7 +69,7 @@ const paletteResource: Step = {
   type: 'CALL',
   category: 'WORKFLOW',
   resourceType: 'STEP',
-  display: {label: 'Call Flow'},
+  display: {label: 'Flow'},
 } as unknown as Step;
 
 const renderCall = (data?: Record<string, unknown>) => {
@@ -107,7 +107,7 @@ describe('Call', () => {
         isConnectable: true,
       } as unknown as Parameters<typeof Call>[0];
       render(<Call {...props} />);
-      expect(screen.getAllByText(/call flow/i).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/^flow$/i).length).toBeGreaterThan(0);
     });
 
     it('records the last interacted resource when the card body is clicked', () => {
@@ -142,7 +142,7 @@ describe('Call', () => {
     it('shows the palette label in the header without a node context', () => {
       mockUseNodeId.mockReturnValue(null);
       renderCall({});
-      expect(screen.getAllByText('Call Flow').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Flow').length).toBeGreaterThan(0);
     });
   });
 

--- a/frontend/apps/console/src/features/flows/data/steps.json
+++ b/frontend/apps/console/src/features/flows/data/steps.json
@@ -283,7 +283,7 @@
     "deprecated": false,
     "deletable": true,
     "display": {
-      "label": "Call Flow",
+      "label": "Flow",
       "image": "assets/images/icons/play.svg",
       "showOnResourcePanel": true,
       "description": "Invoke another flow and resume when it completes."

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -3411,7 +3411,7 @@ const translations = {
     'core.elements.richText.action.ref.label': 'Connected step',
 
     // Call step
-    'core.call.unconfiguredLabel': 'Call flow',
+    'core.call.unconfiguredLabel': 'Flow',
     'core.call.selectFlow': 'Select a flow to invoke',
     'core.call.referencedFlow': 'Referenced flow',
     'core.call.tooltip.configure': 'Configure',


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

Fixes #3981 
Rename the "Call flow" node label to "Flow" in the flow editor ui, updated the label in the `steps.json`, the fallback label in the `Call.tsx` and the en-US translation and adjust the tests to match it. 

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Renamed the workflow call step label from **“Call Flow”** to **“Flow”** throughout the interface.
  * Updated the fallback label shown when no flow is configured.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->