### PR TITLE
Restructure agent identity usecases documents

### DIFF
--- a/docs/content/use-cases/ai-agents/agent-as-subject.mdx
+++ b/docs/content/use-cases/ai-agents/agent-as-subject.mdx
@@ -1,0 +1,83 @@
+---
+title: Agent as Subject
+docType: use-case
+description: Let an AI agent prove its own identity to downstream systems with its own credentials, distinct from human users and service accounts.
+sidebar_position: 4
+---
+
+# Agent as Subject: Authenticating to Systems
+
+When an agent acts as a subject, it functions as a decision-making entity that evaluates context, selects tools, and initiates actions. In this posture, it must prove its own identity to the systems it accesses.
+
+## IAM Capabilities Required
+
+**Agent-specific authentication** to prove the agent's identity to downstream systems using credentials that are distinct from both human user accounts and legacy service accounts.
+
+**Machine-native credential management** to handle programmatic, non-interactive authentication mechanisms including signed assertions, client credentials, and API keys.
+
+**User-alike authentication flows** to enable agents to participate in authentication protocols originally designed for human users, such as OIDC and session-based access, without impersonating a human account.
+
+**Credential lifecycle management** to govern the full lifecycle of agent credentials including provisioning, rotation, renewal, and revocation.
+
+## The Challenge
+
+Enterprise applications were built for two audiences: human users logging in through browsers, and machine services exchanging credentials through APIs. Agents collapse this distinction. They require the contextual, session-based access patterns of a human user but cannot complete an interactive login flow. They need the programmatic reliability of a service account but carry far more autonomy and broader access scope than any service account was designed for.
+
+Organizations that force agents into existing identity categories, whether by registering them as service accounts or issuing them human user credentials, create ungovernable gaps. Service accounts lack lifecycle governance and contextual authorization. Shared user credentials destroy auditability and violate individual accountability.
+
+## How <ProductName /> Solves It
+
+<ProductName /> provisions agents as first-class organizational identities that are distinct from both human users and legacy service accounts. Each agent is registered directly with the organization's identity infrastructure with its own identity record, its own credentials, and its own lifecycle. Agents can access existing enterprise applications the same way employees do, without impersonating a human account or being forced into a service account.
+
+<ProductName /> supports two classes of authentication mechanism for agents as subjects.
+
+### Machine-Native Authentication
+
+Machine-native authentication is purpose-built for programmatic, non-interactive access. These mechanisms are optimized for speed, scalability, and zero human intervention.
+
+- **OAuth 2.0 Client Credentials** enables the agent to authenticate directly to an authorization server using its own client ID and secret, receiving a scoped access token. This is suitable when the agent acts on its own behalf rather than as a delegate.
+- **`private_key_jwt`** allows the agent to authenticate using a signed JWT assertion, eliminating shared secrets entirely. <ProductName /> manages key provisioning, rotation schedules (for example, 90-day cycles), and revocation. This is the recommended mechanism for high-security agent authentication.
+
+### User-Alike Authentication
+
+User-alike authentication enables agents to participate in flows originally designed for human users, without impersonating a human account, but with their own credentials that are on par with humans.
+
+- **OAuth 2.0 and OpenID Connect** allow agents to authenticate through standard OIDC flows, obtaining identity and access tokens that downstream applications already understand. <ProductName /> acts as the identity provider or brokers trust with existing providers.
+
+The distinction matters because, in an agentic enterprise, agents increasingly need to access the same applications as employees, including ERP systems, CRMs, HR platforms, and internal dashboards. These systems expect authentication patterns that look like a user login. <ProductName /> enables this without creating a fake human account for each agent.
+
+## Scenarios
+
+### Customer Success Agent Accessing the Support Portal
+
+An organization deploys a customer success agent to triage incoming tickets, summarize customer histories, and draft response recommendations. The support portal is an existing enterprise application that authenticates all users through the company's SSO provider via OpenID Connect. <ProductName /> provisions the customer success agent with its own dedicated account in the organization's identity provider, distinct from any human employee account. When the agent needs to access the support portal, it authenticates through the same enterprise SSO flow that human support staff use, presenting an assertion that identifies it as the registered customer success agent. The support portal accepts the session without any modification to its authentication logic because the agent's login looks identical to any other employee login. <ProductName /> manages the agent's SSO credentials, enforces session timeouts appropriate for a non-human entity, and logs every authentication event under the agent's own identity.
+
+### Autonomous Resource Access
+
+A data-engineer agent invokes a data warehouse MCP server using its own pre-provisioned RBAC permissions. No user delegation is involved. The agent obtains a token authenticating as itself, providing `client_credentials`, and <ProductName />'s authorization policies issue a token granting it access to the specific warehouse tables its role permits. Every query is logged under the agent's own identity.
+
+### Agent-Specific Model Access
+
+An engineering agent needs access to high-quota vision models through the AI gateway, while a customer support chatbot is restricted to standard text models. <ProductName /> authenticates each agent to the gateway using `private_key_jwt` credentials tied to their respective identity profiles. The gateway evaluates the agent's identity and applies model-access policies accordingly, granting the engineering agent access to the vision model while restricting the support chatbot to text-only models.
+
+## Key Principles
+
+**Agents are a new identity class.** They are not human users and they are not service accounts. <ProductName /> provisions them as first-class organizational identities with their own credentials, their own lifecycle, and their own governance.
+
+**Identity is not the model.** Two agents built on the same foundation model but carrying different system prompts, tool grants, and context scopes are distinct identities. <ProductName /> authenticates the configured agent, not the underlying model.
+
+**No credential sharing.** Agents never share credentials with human users, other agents, or service accounts. Every agent receives its own credentials under its own lifecycle.
+
+**Machine-friendly does not mean machine-only.** Agents need both programmatic credential mechanisms and the ability to participate in authentication flows designed for humans. <ProductName /> supports both without forcing agents into one category.
+
+## Guides
+
+- [Agent Authentication](../../../guides/guides/agents/agent-authentication): Configure client credentials and `private_key_jwt` for an agent.
+- [Manage Agents](../../../guides/guides/agents/manage-agents): Register an agent and manage its credential lifecycle.
+
+## Related Use Cases
+
+- [Invoking the Agent and Authenticating Users](../invoking-the-agent)
+- [Managed Identity](../managed-agent-identity)
+- [Model Interaction Controls](../model-interaction)
+- [Accessing Internal Business Services](../internal-services)

--- a/docs/content/use-cases/ai-agents/external-integration.mdx
+++ b/docs/content/use-cases/ai-agents/external-integration.mdx
@@ -1,0 +1,72 @@
+---
+title: External Integration
+docType: use-case
+description: Let AI agents act across third-party SaaS platforms with just-in-time tokens from a managed vault, never holding long-lived secrets.
+sidebar_position: 7
+---
+
+# Agents Invoking External Tools (Agent → Third-Party SaaS)
+
+Much of an agent's usefulness comes from reaching outside the organization: sending mail through Gmail, posting to Slack, updating records in Salesforce, opening pull requests on GitHub. Each of these platforms has its own OAuth flow, its own tokens, and its own refresh mechanics. The identity challenge is not *whether* the agent can hold those tokens, but whether it should ever handle the long-lived secrets behind them.
+
+An agent that stores a user's Google refresh token has become a high-value target. If the agent is compromised, so is the user's mailbox, permanently, until the user notices and revokes it manually. <ProductName /> never gives an agent a long-lived secret.
+
+## IAM Capabilities Required
+
+**Managed token vault** to securely store third-party access and refresh tokens on the user's or agent's behalf, so the agent never holds a long-lived secret.
+
+**Just-in-time credential issuance** to hand the agent a short-lived external access token at the moment it needs one, and no sooner.
+
+**Automatic token refresh** to renew expiring external tokens using stored refresh tokens, transparently, without exposing the refresh token to the agent.
+
+**Cross-platform credential management** to maintain separate, independent credential chains for each external platform an agent touches within a single workflow.
+
+## Managed External Token Access
+
+### The Challenge
+
+Third-party OAuth was designed for applications, not autonomous agents. An application obtains a refresh token and stores it, expecting to guard it behind server-side protections and a limited blast radius. An agent is a different risk profile: it is more autonomous, more numerous, and more exposed to manipulation through its inputs. Handing each agent the raw refresh tokens for every user it serves multiplies the number of places a long-lived credential can leak.
+
+The naive alternative, asking the user to re-authorize the SaaS platform every time the agent needs it, destroys the automation the agent exists to provide. Organizations need the convenience of stored credentials without the risk of stored credentials living inside the agent.
+
+### How <ProductName /> Solves It
+
+<ProductName /> operates a managed token vault. When a user connects an external platform, the resulting refresh token and long-lived secrets are stored in the vault, never in the agent. When the agent needs to act on that platform, it asks <ProductName />, which issues a short-lived external access token just-in-time. The agent uses the token, and it expires quickly.
+
+The refresh token never leaves the vault. <ProductName /> performs the refresh on the agent's behalf and returns only the freshly minted, short-lived access token. If an agent is compromised, the attacker captures at most a short-lived token for a single platform, not a permanent key to the user's account. Revoking the agent's access to the vault severs its reach to every connected platform at once, without the user re-authorizing anything.
+
+### Scenario: Sending Mail Without Holding the Key
+
+A personal-assistant agent drafts and sends email on a user's behalf through Gmail. The user connected their Google account once; <ProductName /> holds the resulting refresh token in the vault. Each time the agent sends a message, it requests a Gmail access token from <ProductName />, receives a short-lived token, and calls the Gmail API. The agent never sees the refresh token. When the user later revokes the agent, <ProductName /> stops issuing Gmail tokens to it immediately, and the connected Google account itself is untouched and available to the user's other tools.
+
+## Cross-Platform Credential Management
+
+### The Challenge
+
+Real workflows span platforms. An agent might read a Salesforce opportunity, summarize it, post the summary to a Slack channel, and file a follow-up task in Jira: four platforms, four independent OAuth relationships, four token lifecycles, each expiring on its own schedule. Managing these as a tangle of secrets inside the agent is fragile: one expired token or one leaked secret compromises the whole chain, and there is no clean way to revoke access to one platform without disturbing the others.
+
+### How <ProductName /> Solves It
+
+<ProductName /> manages each external platform's credential chain independently within the vault. An agent operating across Salesforce, Slack, and Jira in one workflow holds no long-lived secret for any of them; it requests a short-lived token per platform, just-in-time, as each step of the workflow reaches it. Each platform's refresh and expiry are handled separately, so a problem with one connection never cascades to the others.
+
+Because the chains are isolated, access is revocable per platform. Cutting the agent's Slack access leaves its Salesforce and Jira connections intact. The agent's reach across external services becomes a set of independently governed grants rather than an all-or-nothing bundle of secrets.
+
+### Scenario: A Multi-Platform Workflow
+
+A sales-operations agent runs a nightly routine: pull closed opportunities from Salesforce, post a digest to a Slack channel, and create renewal tasks in Jira. For each platform, the agent requests a short-lived token from <ProductName /> at the moment that step runs. <ProductName /> refreshes each platform's credential independently from the vault. When the Slack workspace rotates its app credentials, only the Slack chain is affected; the Salesforce and Jira steps continue unchanged, and the agent never handled a long-lived secret for any of the three.
+
+## Key Principles
+
+**Agents never hold long-lived secrets.** Refresh tokens and long-lived credentials live in the vault, not in the agent. The agent receives short-lived access tokens just-in-time.
+
+**Compromise is bounded.** A compromised agent leaks, at most, a short-lived token for a single platform, not permanent access to a user's account.
+
+**Credential chains are isolated per platform.** A problem with one connection never cascades to the others, and access is revocable one platform at a time.
+
+**Revocation is instant and central.** Cutting an agent's vault access severs its reach to every connected platform at once, without the user re-authorizing anything.
+
+## Related Use Cases
+
+- [Accessing Internal Business Services](../internal-services)
+- [Invoking the Agent and Authenticating Users](../invoking-the-agent)
+- [Multi-Agent Interactions](../multi-agent)

--- a/docs/content/use-cases/ai-agents/internal-services.mdx
+++ b/docs/content/use-cases/ai-agents/internal-services.mdx
@@ -1,0 +1,108 @@
+---
+title: Internal Business Services
+docType: use-case
+description: Solve the dual-identity problem when an AI agent calls internal APIs, MCP servers, and tools on its own behalf or for a user.
+sidebar_position: 6
+---
+
+# Accessing Internal Business Services (Agent → Resource)
+
+An agent's real work happens against internal systems: it queries a knowledge base, calls an internal API, invokes a tool on an MCP server, or writes a record to a system of record. Sometimes it does this on its own behalf, as part of infrastructure-level automation; more often it does it for a user who asked for something. Either way, the resource on the other side has to make an access decision, and for agents that decision has two halves.
+
+This is the dual-identity problem. When an agent calls an internal service for a user, the service must validate two things at once: that the *agent* is a known, authorized caller, and that the *user* it is acting for is entitled to the operation. Miss the first and any agent can pass itself off as a trusted one; miss the second and the agent becomes a confused deputy, using its own broad access to do things the user could never do directly. <ProductName /> makes both identities explicit in every call and lets each resource enforce both.
+
+## IAM Capabilities Required
+
+**Secure agent-to-service authentication** to let an agent prove its own identity to internal tools, MCP servers, and APIs with its own credentials, never a shared key or a borrowed account.
+
+**Agent RBAC** to grant an agent access to internal resources through roles and group memberships, so its permissions are managed as policy rather than baked into code.
+
+**Delegated authorization (on-behalf-of)** to carry the user's identity alongside the agent's when the agent acts for a user, so downstream services can enforce the user's own entitlements.
+
+**Fine-grained tool authorization** to control access down to the individual tool or endpoint, and to the operation within it, so a grant can permit a read while denying a delete.
+
+## Autonomous Resource Access
+
+### The Challenge
+
+Not everything an agent does is on behalf of a user. A data-pipeline agent refreshes a warehouse table; a monitoring agent reads metrics; a build agent publishes an artifact. These are infrastructure-level tasks the agent performs under its own authority, with no user in the loop. The temptation is to run them with a shared service-account key or an over-broad admin credential, because "it is just a background job." That is exactly how an agent ends up with far more access than its task needs and no way to attribute what it did.
+
+### How <ProductName /> Solves It
+
+When an agent acts on its own behalf, <ProductName /> authenticates it as a first-class identity using its own credentials (client credentials or `private_key_jwt`) and issues an access token scoped to what its role permits. The agent's permissions come from its group memberships and role assignments in <ProductName />, not from a secret with implicit power. Access is granted as policy, and every call the agent makes is attributable to its identity, so an autonomous task is governed and auditable rather than anonymous.
+
+Because authorization is role-based, widening or narrowing what an autonomous agent can reach is a membership change, not a redeployment, and the resource sees a token whose scopes describe exactly what this agent is allowed to do.
+
+### Scenario: A Data-Pipeline Agent
+
+A data-engineering agent runs a nightly job that loads records into a warehouse. It authenticates to <ProductName /> with `private_key_jwt` and receives a token scoped, through its role, to write only the staging tables it owns. It calls the warehouse's internal API under its own identity, with no user delegation involved. Every write is logged against the agent, and when the team later narrows its access to a single schema, they change its role membership; the agent's credential and code are untouched.
+
+## Delegated Access and the Dual-Identity Problem
+
+### The Challenge
+
+When an agent acts for a user, the naive approaches both fail. If the agent calls the internal service under only its own identity, the service cannot enforce the user's permissions and the audit trail loses the user entirely: it looks like the agent did everything itself. If instead the agent borrows the user's credentials, it becomes a credential proxy that can act as the user long after the request, with none of the scoping the user intended. A service receiving such a call cannot tell a legitimate delegated action from an over-reaching one.
+
+### How <ProductName /> Solves It
+
+<ProductName /> carries both identities in a single token using OAuth token exchange ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)). The token identifies the user as the `subject` and the agent as the `actor`, so the internal service can answer both questions from one credential: is the user entitled to this operation, and is this agent an authorized delegate acting for them? The agent proves it is a specific, registered delegate with its own credentials; the user's authority is present but bounded by the delegated scope, never handed over wholesale.
+
+Downstream propagation preserves both identities. When a call crosses from one internal service to the next (an API to an MCP server, for example), <ProductName /> exchanges the token for a new one that still carries the user as subject and the agent as actor, so the dual-identity check can be re-applied at every hop rather than trusted once at the edge.
+
+### Scenario: An Agent Querying an Internal API for a User
+
+A support agent, asked by an analyst to pull a customer's account history, calls the internal Accounts API. <ProductName /> issues a token with the analyst as `subject` and the support agent as `actor`. The API validates both: the analyst is cleared to see this customer's records, and the support agent is authorized to act on the analyst's behalf for this scope. The agent cannot see any account the analyst could not see, and the access log records both the analyst who authorized it and the agent that executed it.
+
+## Fine-Grained Tool Authorization
+
+### The Challenge
+
+An MCP server or an internal API is not a single permission; it is a surface of many operations, and they are not equally sensitive. A tool that can `read_document` and one that can `delete_document` may sit behind the same endpoint. Treating access as all-or-nothing (the agent may call the server, or it may not) gives an agent that needs to read the ability to delete. For autonomous systems acting at machine speed, that gap between "can reach the tool" and "may perform this specific operation" is where real damage happens.
+
+### How <ProductName /> Solves It
+
+<ProductName /> scopes authorization to the individual tool and operation, not just the service. An agent's grant can permit `get_revenue_report` while denying `issue_refund` on the same MCP server, or allow a read on an API resource while rejecting a write. The scopes an agent carries name the operations it may perform, and the resource enforces them per call, so the line is drawn at the operation rather than the endpoint.
+
+This makes least privilege practical for tool use. An agent is provisioned with exactly the operations its task requires, and expanding that set is a deliberate authorization change, not a side effect of granting access to a server that happens to expose more.
+
+### Scenario: Read Allowed, Delete Denied
+
+A knowledge-management agent is authorized to search and retrieve documents from an internal MCP server but must never remove them. <ProductName /> grants it the `search` and `read` tool scopes and withholds `delete`. When the agent invokes retrieval, the server accepts the call; if a manipulated prompt ever induces it to attempt a delete, the server rejects the request because the scope was never granted. The destructive operation fails at the authorization layer, not at the agent's discretion.
+
+## Context-Aware Delegation
+
+### The Challenge
+
+For the most sensitive resources, a static "this agent may access this API" grant is too blunt. Whether a given request should be allowed can depend on context: how sensitive the target data is, how much the user is actually cleared for, and how trusted the specific agent is. A high-clearance user working through a low-trust agent, or a trusted agent reaching for data above the user's clearance, should not automatically succeed just because a coarse grant exists.
+
+### How <ProductName /> Solves It
+
+For sensitive requests, <ProductName /> evaluates the user's clearance and the agent's trust tier together before issuing a credential, and the credential it issues is short-lived and downscoped to that specific request rather than a standing grant. The decision combines both identities' context: the user's entitlements and the agent's attributes (its risk tier, environment, and role) shape what, if anything, is authorized for this call.
+
+Because the resulting token is narrow and short-lived, authority does not accumulate. The agent receives just enough access for the operation in front of it, and that access expires quickly, so a sensitive grant cannot be replayed or repurposed later.
+
+### Scenario: Clearance and Trust Tier Together
+
+A finance analyst asks an agent to open a restricted revenue forecast. <ProductName /> sees that the analyst is cleared for the forecast but that the requesting agent sits in a lower trust tier, and issues a short-lived, read-only token scoped to just that document for this request. The same agent asked to reach a document above the analyst's clearance is refused outright. Access reflects both who authorized it and how much the agent acting for them can be trusted, decided per request rather than granted once and left open.
+
+## Key Principles
+
+**Both identities are always present.** When an agent acts for a user, every call carries the user as subject and the agent as actor, so resources enforce the user's entitlements and the agent's delegation rights together.
+
+**Agents authenticate as themselves.** An agent proves its own identity with its own credentials to every internal service, never a shared key or a borrowed account, and every call is attributable to it.
+
+**Authorization is role-based and least-privilege.** Access comes from roles and group memberships and is scoped to the specific tools and operations a task requires, down to allowing a read while denying a delete.
+
+**Sensitive access is contextual and short-lived.** For high-value resources, <ProductName /> weighs the user's clearance and the agent's trust tier and issues a downscoped, short-lived credential for that request rather than a standing grant.
+
+## Guides
+
+- [Agent Authentication](../../../guides/guides/agents/agent-authentication): Authenticate an agent to an internal API or MCP server and issue on-behalf-of tokens.
+- [Resource Servers](../../../guides/guides/resource-servers): Define resources, actions, and the scopes that make fine-grained tool authorization possible.
+
+## Related Use Cases
+
+- [Invoking the Agent and Authenticating Users](../invoking-the-agent): How the user's identity and consent enter the delegation carried into these resource calls.
+- [Agent as Subject](../agent-as-subject): The authentication mechanisms an agent uses to prove its own identity.
+- [Multi-Agent Interactions](../multi-agent): How the dual-identity token is preserved as work passes between agents.
+- [External Integration](../external-integration): The equivalent pattern for third-party SaaS beyond the organization's own services.

--- a/docs/content/use-cases/ai-agents/invoking-the-agent.mdx
+++ b/docs/content/use-cases/ai-agents/invoking-the-agent.mdx
@@ -1,0 +1,156 @@
+---
+title: Invoking the Agent
+docType: use-case
+description: Authenticate users, applications, and other agents that invoke an AI agent, and manage the consent and delegation they carry.
+sidebar_position: 2
+---
+
+# Invoking the Agent and Authenticating Users
+
+This interaction controls how users, applications, and other agents interact with an AI agent. The IAM system governs who can access the agent, at what assurance level (ACR), and with what delegated permissions.
+
+Authentication in the agentic era is multi-directional. An agent must authenticate its callers when invoked as a resource. It must prove its own identity when accessing downstream systems as a subject. It must also carry verifiable delegated identity when acting on behalf of a user as a client. Each direction demands distinct mechanisms, policies, and credential management.
+
+## IAM Capabilities Required
+
+**Machine-native and user-alike authentication mechanisms** for agents to support both programmatic access and flows originally designed for human users.
+
+**Authentication policy enforcement** to control agent invocation and enforce specific assurance levels based on the sensitivity of the agent's task.
+
+**Permission delegation** to allow agents to act as the actor for a subject (the user), carrying verifiable proof of who authorized the action.
+
+**Consent management** for user approval of data sharing and the specific actions an agent may take on their behalf.
+
+**Agent as a protected resource**, meaning agents can expose protected resources with unique Resource IDs and granular scopes. Just like an API endpoint, an agent must authenticate its callers and verify they are authorized before accepting any invocation.
+
+## Agent as Client: User Authentication
+
+When a human user invokes an agent, the authentication requirements depend on the sensitivity of what the agent can do. A general-purpose assistant and a financial trading agent demand very different assurance levels.
+
+### The Challenge
+
+Agents serve users across wildly different contexts: employees authenticating through corporate SSO, consumers signing in with social accounts, and users on mobile devices who need passwordless flows. The assurance level must match the risk. A low-sensitivity query can proceed with basic authentication, but a high-value action such as booking a flight, executing a trade, or accessing medical records requires step-up authentication before the agent is allowed to proceed.
+
+Traditional applications handle this with static login pages. Agents operate conversationally and continuously. The authentication decision is not a one-time gate at session start; it may need to be re-evaluated mid-task when the agent encounters a sensitive action.
+
+### How <ProductName /> Solves It
+
+<ProductName /> enforces authentication policies at the point of agent invocation and supports dynamic step-up during an active session. The assurance level required is defined per agent, per scope, and per action sensitivity rather than as a blanket policy applied at the front door.
+
+<ProductName /> supports the following user authentication mechanisms:
+
+**Enterprise (B2E) flows** enable corporate SSO via SAML or OIDC with MFA enforcement. Agents inherit the organization's existing authentication infrastructure, so an employee authenticating to an agent goes through the same identity provider they use for every other enterprise application.
+
+**Consumer (B2C) flows** support social login, email OTP, passkeys, and other passwordless mechanisms. <ProductName /> adapts the authentication challenge to the channel and the action sensitivity, enabling low-friction access for low-risk queries and stronger verification when the stakes increase.
+
+**Step-up authentication** allows <ProductName /> to trigger an additional verification challenge mid-session when an agent needs to perform a high-sensitivity action. This could be biometric verification, a hardware key, or an email OTP. The user does not need to restart the session because the step-up is scoped to the specific action.
+
+### Scenario: Employee Research Assistant (B2E)
+
+Sarah, a financial analyst, logs in through corporate SSO with MFA to access a research assistant agent. <ProductName /> defines her role-based access: she can query SEC filings (read scope) but cannot trigger trading actions (write scope). When she asks the agent to summarize a filing, <ProductName /> validates her session, confirms her role grants read access, and issues a delegated token. The agent proceeds under Sarah's authority, bounded by her permissions.
+
+### Scenario: Consumer Travel Planner (B2C)
+
+Priya uses social login to access a travel planning agent. For general searches such as browsing destinations and comparing prices, her social login session is sufficient. When she asks the agent to book a flight, <ProductName /> triggers step-up authentication via email OTP, upgrades her session's assurance level, and issues a time-bound consent grant scoping the agent to this specific booking action. The consent expires after the transaction completes.
+
+## Agent as Client: Delegated Authority
+
+When an agent acts as a client, it operates on behalf of a human user, another system, or another agent. Authentication in this posture serves two purposes: the agent must carry verifiable proof of the delegating principal's identity, and it must present its own client credentials proving it is an authorized delegate.
+
+### The Challenge
+
+Delegation creates a trust chain. A user asks an agent to perform a task. The agent calls downstream services carrying the user's authority. Every system in that chain needs answers to two questions: who is the user, and is this agent authorized to act for them?
+
+If the agent relays the user's credentials directly, it becomes a credential proxy, which is a security anti-pattern that exposes secrets across the chain. If the agent only presents its own identity without binding it to the delegating user, downstream systems cannot enforce user-specific policies and the audit trail loses attribution.
+
+### How <ProductName /> Solves It
+
+<ProductName /> separates user identity from agent client identity, ensuring both are present in every delegated interaction.
+
+**User identity in the delegation chain:** <ProductName /> uses the `act` (actor) claim pattern defined in OAuth token exchange ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)). The resulting token identifies the user as the `subject` and the agent as the `actor`. Downstream systems can enforce the user's permissions while knowing exactly which agent executed the request.
+
+**Agent client authentication:** Independent of the user's identity, the agent proves it is an authorized delegate using its own credentials. <ProductName /> supports `private_key_jwt`, client certificates, and OAuth client credentials for agent client authentication. This answers the second question in the trust chain: the calling agent is not just any agent, but a specific, registered, and governed entity.
+
+**Token exchange for downstream propagation:** When the agent calls an internal API or MCP server, <ProductName /> exchanges the original delegation token for a new token that carries both identities. The downstream service validates that the user is authorized for the requested operation and that the agent is permitted to act as their delegate.
+
+### Scenario: User-Delegated API Invocation
+
+Sarah asks a research agent to pull SEC filings. <ProductName /> issues a delegated token with Sarah as the `subject` and the research agent as the `actor`. When the agent calls the SEC Filing API, the API validates two things: Sarah has access to the requested filings, and the research agent is authorized to act on Sarah's behalf for this specific scope. The agent cannot exceed Sarah's actual permissions.
+
+### Scenario: MCP On-Behalf-of User
+
+An agent uses an MCP client to pull revenue data from an internal MCP server. The MCP server validates both the user's authorization for the `get_revenue_data` tool and the agent's authorization to invoke that tool as a delegate. <ProductName />'s token carries both claims, and the MCP server enforces both checks before returning results.
+
+## Consent and Delegation Management
+
+Authentication proves who the user is. Consent defines what the agent is allowed to do on their behalf. These are separate decisions, and <ProductName /> manages them independently.
+
+### The Challenge
+
+Users rarely understand the full scope of what they are authorizing when they "allow" an agent to act on their behalf. Broad, open-ended consent grants create risk. But overly granular consent prompts create friction that drives users away. Organizations need a consent model that is specific enough to be meaningful and simple enough to be usable, with clear expiration, revocation, and auditability.
+
+Compounding this, consent must track the user's own access status. If the delegating user's permissions change because they leave the company, change roles, or lose access to a system, the agent's delegated authority must adjust immediately.
+
+### How <ProductName /> Solves It
+
+<ProductName /> manages consent as a structured, time-bound, revocable grant. When a user delegates authority to an agent, <ProductName /> records the specific scopes approved, the duration of the grant, and the conditions under which it expires or is revoked. Users can grant partial consent such as read access but not write, or access to one system but not another.
+
+Critically, <ProductName /> links the agent's delegated authority to the user's live access status. If the user's corporate permissions are modified or revoked, <ProductName /> automatically adjusts or revokes the agent's delegated grants. The agent never retains authority that the user no longer holds.
+
+### Scenario: Personal Assistant Delegation
+
+David provisions an agent to monitor his email and calendar. <ProductName /> establishes a 30-day consent grant scoped to read-only access on email and read-write on calendar events. If David's corporate access is modified, for example when he transfers to a different team and loses access to certain distribution lists, <ProductName /> automatically revokes the agent's access to those same resources. David does not need to remember to update the agent's permissions because the linkage is enforced by policy.
+
+### Scenario: Partial Consent
+
+Sarah grants the research assistant read access to SEC filings but explicitly denies write access to the trading platform. <ProductName /> records this as a structured consent decision: the delegated token the agent carries permits filing queries but will be rejected by the trading API. The consent decision is auditable, and if anyone asks what Sarah authorized, the answer is precise and timestamped.
+
+## Agent as a Protected Resource
+
+Agents expose capabilities and data that carry real consequences when invoked. Before accepting any request, an agent must control who is allowed to invoke it and what operations they can perform. An agent is not an open endpoint. It exposes protected resources with their own scopes and caller verification requirements.
+
+### The Challenge
+
+Most deployments treat agents as backend services that accept any authenticated request. This ignores a fundamental requirement: agents expose resources and actions with real consequences, and different callers should have different levels of access to the resources an agent exposes. A user with view-only scope should be able to query a knowledge-base agent but must be blocked from invoking a write action on a database management agent. An application triggering an agent via machine-to-machine flow requires different validation than a human user signing in through a browser.
+
+Without resource-level modeling, every caller gets the same access to every resource an agent exposes, and there is no mechanism to enforce that the right caller reached the right agent with the right scope.
+
+### How <ProductName /> Solves It
+
+<ProductName /> enables agents to expose protected resources with unique Resource IDs, granular invocation scopes, and authentication policies that vary by caller type. When a user, application, or another agent attempts to invoke an agent, <ProductName /> verifies three things: the caller's identity, the caller's authorization to access the specific resource the agent exposes, and the assurance level required for the requested operation.
+
+This means organizations can deploy multiple agents and enforce isolation between the resources each agent exposes. An agent is not just a function to call but a governed entity that protects its resources with access controls as rigorous as any API endpoint.
+
+### Scenario: Granular Resource Scoping
+
+An organization deploys a Knowledge Base agent and a Database Management agent. Each agent exposes distinct protected resources with their own scope definitions. <ProductName />'s IAM policy ensures that a user with a "View-Only" scope can query the resources exposed by the Knowledge Base agent but is blocked from invoking any write action on the resources exposed by the Database Management agent. This effectively isolates the two agents from one another even though both are accessible to the same user pool.
+
+### Scenario: M2M Application Invocation
+
+A CRM application triggers a lead-scoring agent over an event hook exposed by the agent. No user is involved because this is application-to-agent communication. <ProductName /> authenticates the CRM as a machine client and validates its authorization to invoke the lead-scoring agent, then issues a token for the CRM application. The CRM application presents the token to the agent, and the agent validates the entitlements and proceeds. No user involvement is required because no user delegation exists.
+
+## Key Principles
+
+**Agents expose protected resources, not open endpoints.** Every agent must verify its callers, enforce scopes on the resources it exposes, and reject unauthorized invocations just like any API.
+
+**Authentication is multi-directional.** A single agent may authenticate inbound callers (as a resource), authenticate outbound to downstream systems (as a subject), and carry delegated user identity (as a client), all within one task.
+
+**Assurance levels match action sensitivity.** Low-risk queries proceed with basic authentication. High-value actions trigger step-up verification. The decision is made per action, not per session.
+
+**Consent is structured, time-bound, and linked to the user's live access.** If the user's permissions change, the agent's delegated authority adjusts immediately.
+
+**No credential sharing.** Agents never share credentials with human users, other agents, or service accounts. Every agent receives its own credentials under its own lifecycle.
+
+**Machine-friendly does not mean machine-only.** Agents need both programmatic credential mechanisms and the ability to participate in authentication flows designed for humans. <ProductName /> supports both without forcing agents into one category.
+
+## Guides
+
+- [Manage Agents](../../../guides/guides/agents/manage-agents): Model an agent as a protected resource with its own scopes.
+- [Agent Authentication](../../../guides/guides/agents/agent-authentication): Configure delegated (on-behalf-of) token issuance and agent client authentication.
+
+## Related Use Cases
+
+- [Managed Identity](../managed-agent-identity)
+- [Accessing Internal Business Services](../internal-services)
+- [Agent as Subject](../agent-as-subject)
+- [Multi-Agent Interactions](../multi-agent)

--- a/docs/content/use-cases/ai-agents/managed-agent-identity.mdx
+++ b/docs/content/use-cases/ai-agents/managed-agent-identity.mdx
@@ -1,0 +1,123 @@
+---
+title: Managed Identity
+docType: use-case
+description: Register, rotate, revoke, and transfer ownership of AI agents as governed identities with an accountable owner.
+sidebar_position: 3
+---
+
+# Managed Identity
+
+Before an agent authenticates to anything, calls a single API, or acts for a single user, it must exist as a governed identity. Governance covers the administrative lifecycle of an agent: registration, credential management, authorization changes, suspension, transfer, revocation, and the accountability that ties every action back to a human.
+
+An agent without governance is an agent nobody owns, nobody can revoke, and nobody is answerable for. That is the failure mode <ProductName /> is built to prevent. Every agent is a managed identity with an accountable owner from the moment it is created.
+
+## IAM Capabilities Required
+
+**Identity registration** to assign every agent a unique identity, descriptive metadata, an organizational placement, and its own credentials before it executes its first action.
+
+**Lifecycle management** to move an agent through its full lifecycle, from creation and credential rotation to authorization changes, suspension, transfer, and decommissioning, all under policy control.
+
+**Credential rotation** to issue, renew, and retire agent credentials on a schedule or on demand, without downtime and without sharing secrets.
+
+**Revocation cascades** to instantly invalidate an agent's access across every service, and to cascade that revocation to every dependent identity and sub-agent in its delegation chain.
+
+**Liability tracking and ownership transfer** to trace every action an agent takes back to the human accountable for it, and to transfer that accountability cleanly between people and teams.
+
+## Agent Provisioning and Registration
+
+### The Challenge
+
+Agents proliferate quickly. A single team can stand up dozens of agents in a week, each built from a copied credential, a shared API key, or a service account borrowed from an unrelated system. Within a month, no one can answer basic questions: How many agents are running? What can each one access? Who is responsible for this one?
+
+The root cause is that agents are usually created as an afterthought of deployment rather than as a deliberate identity event. There is no registration step, so there is no record, no owner, and no lifecycle. The agent simply appears, holding whatever credential its author had at hand.
+
+### How <ProductName /> Solves It
+
+<ProductName /> makes registration the gate every agent passes through before it can act. Registering an agent creates a managed identity record with a unique **Agent ID**, an accountable **owner**, a placement in the organization unit hierarchy, and its own OAuth 2.0 credentials distinct from any human or service account.
+
+Registration also defines what the agent *is* through a shared **agent schema**: a set of custom attributes (model, environment, risk tier, cost center) that every agent carries. The schema turns an ad-hoc collection of agents into an inventory you can query, filter, and govern by policy.
+
+Because the agent holds its own credentials under its own identity, every downstream authentication and every issued token is attributable to that specific agent. There is no shared secret to trace back to a group and no borrowed account that muddies the audit trail.
+
+### Scenario: Onboarding a New Agent
+
+A platform team builds a "Contract Analyzer" agent. Before it runs, an administrator registers it in <ProductName />: names it, assigns the data-governance lead as its owner, places it in the `Legal` organization unit, and sets its risk-tier attribute to `high`. <ProductName /> generates the Agent ID and issues a client secret shown once. From this point the agent is discoverable in the inventory, its permissions are grantable through group membership, and every token it ever requests carries its identity. No part of its behavior is anonymous.
+
+## Lifecycle Management and Credential Rotation
+
+### The Challenge
+
+Credentials that never change are credentials that eventually leak. A client secret pasted into a config file, baked into a container image, or shared in a chat message has a long tail of exposure. Human accounts are protected by rotation policies, MFA, and session expiry; agents are too often issued a static secret at creation and left with it for the life of the deployment.
+
+Rotation is only half the problem. An agent's authority also changes over time: it takes on new tasks, sheds old ones, moves between environments, or needs to be paused during an investigation. Without lifecycle controls, every one of those changes means editing code or recreating the agent, which breaks the audit trail.
+
+### How <ProductName /> Solves It
+
+<ProductName /> governs the full credential lifecycle. Secrets can be regenerated on demand, invalidating the previous secret immediately while the agent's identity, ID, and authorization remain intact. For higher-security agents, `private_key_jwt` eliminates shared secrets entirely: the agent proves its identity with a signed assertion, and <ProductName /> manages key registration and rotation schedules.
+
+Authorization is managed independently of credentials. An agent's permissions come from its group memberships and role assignments, so granting or removing access is a membership change, not a redeployment. Suspending an agent, moving it between organization units, or decommissioning it are all first-class lifecycle operations that preserve the agent's history.
+
+Because authorization is decoupled from the credential, secret rotation and permission changes are independent operations.
+
+### Scenario: Scheduled Rotation Without Downtime
+
+A finance-reconciliation agent authenticates with `private_key_jwt`. Security policy requires a 90-day key rotation. The owner registers a new key alongside the current one, deploys it, and retires the old key once traffic has cut over. The agent never stops running, its Agent ID and permissions are untouched, and the audit log records the rotation as a governed lifecycle event rather than a mysterious credential change.
+
+## Emergency Revocation
+
+### The Challenge
+
+When an agent misbehaves, whether a prompt injection turns it hostile, a credential leaks, or a bug sends it into a destructive loop, every second of continued access compounds the damage. The response cannot be "open a ticket to rotate a key." It has to be immediate and total.
+
+Revocation is harder for agents than for humans because agents delegate. A compromised primary agent may have handed scoped authority to a dozen worker agents, each holding a live token. Killing the primary agent's credential does nothing to the tokens already in the hands of its delegates. The blast radius is the entire delegation chain, not a single identity.
+
+### How <ProductName /> Solves It
+
+<ProductName /> can instantly invalidate an agent's access across every service. Revoking the agent disables its credentials and refuses any new token request under its identity. Combined with short token lifetimes, the recommended posture for agents, the window of continued access closes quickly even for tokens already issued.
+
+Revocation also cascades. When an agent is revoked, <ProductName /> cascades the action through the agent's dependency graph, invalidating the grants held by every sub-agent it empowered. The delegation chain that made a compromise dangerous is the same structure <ProductName /> walks to contain it. Because every delegated token records the chain it descended from, there is no orphaned authority left behind.
+
+### Scenario: Containing a Compromised Agent
+
+An operations team detects that a research agent has been manipulated into exfiltrating data. They trigger emergency revocation. <ProductName /> immediately blocks the research agent from obtaining new tokens and cascades revocation to the three worker agents it had delegated sub-tasks to, invalidating their grants as well. Within the token-lifetime window, the entire branch of the delegation tree rooted at the compromised agent has lost access. The incident is contained without taking down unrelated agents.
+
+## Liability Tracking and Ownership Transfer
+
+### The Challenge
+
+An autonomous agent that can spend money, move data, or change records raises a question every organization must answer before regulators or auditors do: **who is responsible when the agent acts?** If the answer is "the system" or "the team, generally," accountability has already failed. Responsibility must resolve to a specific, named human.
+
+Ownership is not static. People change roles, leave the company, or hand a project to another team. If accountability is recorded informally, in a wiki or in someone's memory, it decays. An agent outlives the tenure of the person who built it, and the moment that person leaves, the agent becomes unowned.
+
+### How <ProductName /> Solves It
+
+Every agent in <ProductName /> has an owner: the human accountable for its behavior, access, and lifecycle. Ownership is a required, first-class property of the identity, not a comment. An unowned agent is an ungoverned agent, and <ProductName /> treats the owner as the anchor of the agent's audit trail: every action the agent takes traces back through its identity to the human who owns it.
+
+Ownership transfers are structured operations. When a person changes roles or leaves, their agents are reassigned to a new owner through a governed transfer that updates the accountability record without disrupting the agent's operation or breaking its history. Accountability moves cleanly from one human to the next, and the audit trail reflects exactly who was responsible at any point in time.
+
+### Scenario: Transferring Ownership on a Team Change
+
+An engineer who owns four internal agents transfers to a different organization. As part of offboarding, their manager reassigns the four agents to a new owner on the receiving team. <ProductName /> records the transfer, updates each agent's accountability anchor, and preserves the full history: actions taken before the transfer remain attributed to the original owner, and actions after it to the new one. No agent is orphaned, and the chain of responsibility is never broken.
+
+## Key Principles
+
+**Registration is the gate.** An agent becomes a governed identity, with an ID, an owner, and credentials, before it takes its first action, not after something goes wrong.
+
+**Every agent has an accountable owner.** Ownership is a required property of the identity. An unowned agent is an ungoverned agent.
+
+**Credentials and authorization are separate lifecycles.** Rotating a secret never changes what an agent can do; changing what an agent can do never requires touching its secret.
+
+**Revocation is immediate and cascading.** Revoking an agent contains not just that agent but every sub-agent it empowered, following the same delegation chain that created the risk.
+
+**Accountability transfers cleanly.** Ownership moves between humans through governed operations that preserve the audit trail rather than breaking it.
+
+## Guides
+
+- [Manage Agents](../../../guides/guides/agents/manage-agents): Register a governed agent identity with an owner, an organization unit, and OAuth credentials, and manage its lifecycle.
+- [Agent Authentication](../../../guides/guides/agents/agent-authentication): Configure the credentials an agent uses and rotate them without downtime.
+
+## Related Use Cases
+
+- [Invoking the Agent and Authenticating Users](../invoking-the-agent)
+- [Accessing Internal Business Services](../internal-services)
+- [Multi-Agent Interactions](../multi-agent)

--- a/docs/content/use-cases/ai-agents/mcp-authorization/identity-concepts.mdx
+++ b/docs/content/use-cases/ai-agents/mcp-authorization/identity-concepts.mdx
@@ -1,13 +1,13 @@
 ---
 title: Identity Concepts
 docType: use-case
-description: "How the Securing MCP tryout maps to product concepts: the external MCP client application, the protected MCP resource server, and the consent step that narrows what the client can do."
+description: How the Securing MCP tryout maps to product concepts, including the external MCP client application, the protected MCP resource server, and the consent step that narrows what the client can do.
 sidebar_position: 5
 ---
 
 # Identity Concepts
 
-This page explains the identity concepts behind the Securing MCP tryout you set up in [Try It Out](../try-it-out). For the underlying user types, roles, the booking resource server, and the Wayfinder Concierge agent, see [Identity Concepts](../../identity-concepts) under Securing AI Agents. This page covers only the MCP-specific additions.
+This page explains the identity concepts behind the Securing MCP tryout you set up in [Try It Out](../try-it-out). For the underlying user types, roles, the booking resource server, and the Wayfinder Concierge agent, see the [Identity Model](../../try-it-out#identity-model) under Securing AI Agents. This page covers only the MCP-specific additions.
 
 ## Application
 
@@ -15,8 +15,8 @@ An application is the OAuth2 client that <ProductName /> issues tokens to. This 
 
 The application registers redirect URIs for MCP Inspector:
 
-- `http://localhost:6274/oauth/callback/debug`: MCP Inspector's debug callback.
-- `http://localhost:6274/oauth/callback`: MCP Inspector's standard callback.
+- `http://localhost:6274/oauth/callback/debug`, MCP Inspector's debug callback.
+- `http://localhost:6274/oauth/callback`, MCP Inspector's standard callback.
 
 `EXTERNAL-MCP-CLIENT` is wired to the same authentication flow as the Wayfinder Concierge, so the OAuth consent screen surfaces each requested `booking:*` permission as an individual toggle at sign-in time.
 

--- a/docs/content/use-cases/ai-agents/model-interaction.mdx
+++ b/docs/content/use-cases/ai-agents/model-interaction.mdx
@@ -1,0 +1,78 @@
+---
+title: Model Interaction Controls
+docType: use-case
+description: Give an AI gateway a verifiable agent identity so model access, quotas, and guardrails can be enforced per agent and per delegated user.
+sidebar_position: 5
+---
+
+# Model Interaction Controls (Agent → Model)
+
+Agents reach foundation models through an AI gateway: a control point that sits between the agent and one or more model providers. The gateway is where cost, safety, and access policy are enforced. But a gateway can only enforce policy if it knows *who* is calling. Identity is the input that turns a shared model endpoint into a governed one.
+
+When an agent authenticates to the gateway with its own identity, the gateway can decide which models it may use, what quotas apply, and which guardrails to enforce, applying them per agent rather than as a single blanket policy for all traffic, and per delegated user where a user is involved.
+
+## IAM Capabilities Required
+
+**Agent-specific gateway authentication** so the AI gateway can identify the calling agent and evaluate policy against its identity rather than treating all model traffic as anonymous.
+
+**Identity-based access control for models** to determine which models, model tiers, and quotas each agent may reach based on the agent's identity profile.
+
+**Delegated identity inspection** so the gateway can see not only which agent is calling but, when the agent acts for a user, who that user is, and shape controls accordingly.
+
+**Identity-aware guardrails** to apply safety and content policy based on the combination of the agent's role and the delegated user's attributes.
+
+## Agent-Specific Model Access
+
+### The Challenge
+
+Not every agent should reach every model. A frontier vision model is expensive and highly capable; a customer-facing chatbot has no business calling it, while an internal engineering agent might legitimately need it. Without identity at the gateway, the only controls available are coarse: one API key for everyone, or a separate key per model that teams copy and share until the mapping between key and caller is meaningless.
+
+The result is uncontrolled cost and uncontrolled capability. A misconfigured or compromised agent can burn through a premium-model budget or reach a model far more capable than its task warrants, and there is no per-agent record of who called what.
+
+### How <ProductName /> Solves It
+
+<ProductName /> authenticates each agent to the AI gateway with credentials tied to its own identity profile: typically `private_key_jwt` for high-security agents, or client credentials. The gateway evaluates the agent's identity and applies model-access policy accordingly: which models the agent may reach, which tiers, and what quota it holds.
+
+Because the policy keys off the agent's identity profile rather than a shared secret, model access becomes a property of *who the agent is*, not of which key happened to be in its config. Changing an agent's model access is an authorization change on its identity, not a key swap. Every model call is attributable to a specific agent, so cost and usage roll up per identity.
+
+### Scenario: Tiered Model Access
+
+An engineering agent needs a high-quota vision model to analyze diagrams, while a support chatbot is restricted to standard text models. <ProductName /> authenticates each agent to the gateway using credentials tied to its respective identity profile. The gateway reads the engineering agent's identity, confirms its policy grants vision-model access, and allows the call. When the support chatbot attempts the same model, the gateway reads its identity, finds no such grant, and restricts it to text-only models. Both agents share the same gateway; neither shares the other's access.
+
+## Identity-Based Guardrails
+
+### The Challenge
+
+Safety controls that ignore identity are either too loose or too tight. A single content policy strict enough for a public consumer chatbot will block a legitimate internal agent doing sensitive but authorized work; a policy permissive enough for the internal agent will expose the consumer bot. Worse, when an agent acts on behalf of a user, the safety decision should depend on *that user*: their clearance, region, and entitlements, not just on the agent.
+
+A gateway that sees only "an API call arrived" cannot make these distinctions. It has no notion of the agent's role and no notion of the human the agent is acting for, so it falls back to one policy for all traffic.
+
+### How <ProductName /> Solves It
+
+<ProductName /> gives the gateway both identities in the call: the agent's, and, when the agent operates in the actor posture, the delegated user's. Guardrails then adapt to the combination. The gateway can apply one content policy for an agent acting autonomously and a stricter or looser one when the same agent acts for a specific user, based on that user's attributes.
+
+This means safety controls follow the principal, not just the pipe. An agent acting for a user in a regulated region inherits that region's constraints; the same agent acting for an unrestricted user does not. The guardrail decision is a function of *who the agent is* and *who it is acting for*, both of which <ProductName /> carries into the request as verifiable identity.
+
+### Scenario: Guardrails That Follow the User
+
+A research agent summarizes internal documents for employees. When a general employee invokes it, the gateway applies the standard content policy. When an employee with elevated clearance invokes the same agent to summarize restricted filings, the gateway reads the delegated user's clearance attribute from the agent's actor context and relaxes the redaction guardrail accordingly, while still enforcing the agent's own role limits. The agent is identical in both calls; the guardrail differs because the delegated identity differs.
+
+## Key Principles
+
+**The gateway enforces what it can identify.** Model access and guardrails are only as good as the identity the gateway sees. <ProductName /> makes every model call carry a verifiable agent identity.
+
+**Model access is a property of the agent, not the key.** Which models an agent may reach follows its identity profile, so access changes are authorization changes, not shared-secret swaps.
+
+**Guardrails follow the principal.** When an agent acts for a user, safety controls adapt to that user's attributes, not only to the agent's role.
+
+**Every model call is attributable.** Cost, quota, and content decisions roll up to a specific agent identity, and to the delegated user when one is present.
+
+## Guides
+
+- [Agent Authentication](../../../guides/guides/agents/agent-authentication): Authenticate an agent to an AI gateway with `private_key_jwt` or client credentials.
+
+## Related Use Cases
+
+- [Agent as Subject](../agent-as-subject)
+- [Accessing Internal Business Services](../internal-services)
+- [Invoking the Agent and Authenticating Users](../invoking-the-agent)

--- a/docs/content/use-cases/ai-agents/multi-agent.mdx
+++ b/docs/content/use-cases/ai-agents/multi-agent.mdx
@@ -1,0 +1,93 @@
+---
+title: Multi-Agent Interactions
+docType: use-case
+description: Delegate work between AI agents with downscoped tokens, a preserved delegation chain, and backchannel approval for headless agents.
+sidebar_position: 8
+---
+
+# Multi-Agent Interactions (Agent → Agent)
+
+Complex tasks decompose. A primary agent receives a goal, breaks it into sub-tasks, and hands each to a specialized worker agent: one to search, one to summarize, one to write to a system of record. Each hand-off is a delegation, and each delegation is an identity event. The question at every hop is the same: does the receiving agent have exactly the authority it needs for its sub-task, and no more, and can the whole chain be traced back to the human who started it?
+
+Get this wrong and delegation becomes privilege escalation by convenience: the primary agent shares its full token with every worker, each worker can do everything the primary could, and when something goes wrong there is no way to tell which agent in the chain did it. <ProductName /> makes delegation narrow and traceable by construction.
+
+## IAM Capabilities Required
+
+**Nested delegation** to let a primary agent delegate to worker agents, and those workers to delegate further, while preserving the identity of every principal in the chain.
+
+**Token downscoping** to issue each sub-agent a token restricted to its specific sub-task, so authority shrinks at every hop and never grows.
+
+**Delegation-chain preservation** to record the full path, from the originating user through every intermediate agent to the final actor, in the tokens themselves.
+
+**Ambient (headless) authorization** to obtain a user's approval out-of-band when an agent in the chain needs it but no interactive session is available.
+
+## Delegation and Downscoping
+
+### The Challenge
+
+The path of least resistance in a multi-agent system is credential sharing. The primary agent has a capable token, so it passes that token to each worker. Now every worker holds the primary's full authority (a summarizer agent can write to the database, a search agent can cancel bookings) because they all carry the same over-broad credential. A single compromised worker exposes everything the primary could reach.
+
+The problem is that the token was scoped for the primary's whole job, not for any individual worker's sub-task. Sharing it hands each worker far more than it needs, and there is no mechanism to say "this worker gets only the search scope."
+
+### How <ProductName /> Solves It
+
+<ProductName /> uses token exchange ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)) to issue each worker a *new* token, downscoped to its sub-task. When the primary agent delegates search to a worker, <ProductName /> mints a token carrying only the search scope, not the primary's full authority. Authority shrinks at every hop: a delegated token can only ever be a subset of the token it descended from. Downscoping is enforced by <ProductName />, not left to the honesty of the calling agent.
+
+Each worker therefore operates within a strict scope. The summarizer cannot write to the database because its token never carried a write scope; the search agent cannot cancel a booking because that scope was never delegated to it. A compromised worker is contained to its own narrow grant, and the primary's broader authority is never in the worker's hands to begin with.
+
+### Scenario: A Primary Agent Delegating Sub-Tasks
+
+A travel-planning agent holds a token scoped to search flights, read the user's profile, and book travel. It delegates the search sub-task to a flight-search worker. <ProductName /> exchanges the primary's token for a worker token carrying only the flight-search scope: no profile read, no booking. The worker does its job within that scope. When it is time to book, the primary handles that step itself under its own booking scope. No worker ever holds more authority than its sub-task requires.
+
+## Multi-Hop Token Exchange
+
+### The Challenge
+
+When a task passes through several agents, attribution collapses. If each hop simply issues a fresh token with no record of what came before, the final service sees only "some agent called me" and has no way to reconstruct who actually initiated the request or which agents it passed through. Auditors asking "who authorized this database write, and through what path?" get no answer. In a world of autonomous agents acting for users, a broken chain of attribution is a broken chain of accountability.
+
+### How <ProductName /> Solves It
+
+<ProductName /> preserves the delegation chain inside the tokens. Each token exchange records the actor, and when the token being exchanged already carries an `act` (actor) claim, that claim nests inside the new one, so the token accumulates the full path rather than overwriting it. Agents always include the actor claim, so the chain is preserved by default, not by opt-in.
+
+The result is a token whose `sub` identifies the originating user and whose nested `act` claims record every agent hop from the user to the final actor. A downstream service can enforce the user's permissions while seeing exactly which agent executed the request and which chain of delegates it came through. Attribution survives every hop, and the audit trail reads end to end: user → primary agent → worker agent → service.
+
+### Scenario: Tracing a Chain to Its Origin
+
+A user asks an orchestrator agent to reconcile an invoice. The orchestrator delegates to a data-fetch agent, which calls the finance API. The token the finance API receives identifies the user as the subject and carries nested actor claims for both the orchestrator and the data-fetch agent. When the finance team later audits the write, they follow the chain in the token itself: the user authorized it, the orchestrator delegated it, and the data-fetch agent executed it. No hop is anonymous.
+
+## Ambient Agent Authorization
+
+### The Challenge
+
+Some agents run headless: a monitoring agent, a scheduled reconciliation job, an event-triggered workflow. When such an agent reaches a step that needs a specific human's approval, there is no browser session to redirect to and no user actively present to click "allow." The classic interactive consent flow assumes a front-channel and a live user; a background agent has neither. Without an out-of-band path, the agent either blocks indefinitely or, worse, proceeds without the approval it should have obtained.
+
+### How <ProductName /> Solves It
+
+<ProductName /> supports backchannel (ambient) authorization through OpenID Connect CIBA. When a headless agent needs a user's approval, it initiates a backchannel authorization request identifying the user. The user authenticates and approves on their own device, while the agent polls <ProductName /> for the result. The moment the user approves, the poll returns the scoped authorization, with no interactive session and no browser redirect on the agent's side.
+
+This enables just-in-time human-in-the-loop decisions for autonomous agents. The agent can pause at a sensitive step, request approval through the backchannel, and proceed only once the specific user has granted it, turning "the agent acted without anyone's say-so" into "the agent acted the instant the right person approved."
+
+### Scenario: Approval for a Headless Agent
+
+A nightly spend-reconciliation agent finds a payment that exceeds its autonomous threshold and requires the finance owner's sign-off. No one is at a browser at 2 a.m. The agent initiates a backchannel authorization request identifying the finance owner and polls for the outcome. In the morning the owner authenticates and approves on their device, the agent's next poll returns the scoped authorization, and the agent completes the payment step, with the approval recorded against the specific human who granted it.
+
+## Key Principles
+
+**Delegation narrows; it never escalates.** Every hop issues a downscoped token that is a strict subset of the one it descended from. A worker can never hold more than its sub-task requires.
+
+**No credential sharing between agents.** Each agent receives its own downscoped token through token exchange, never a copy of another agent's credential.
+
+**The chain lives in the token.** Nested actor claims record the full path from originating user to final actor, so attribution survives every hop by default.
+
+**Headless does not mean unauthorized.** Backchannel (CIBA) authorization lets background agents obtain a specific human's approval out-of-band by polling for the result, without an interactive session.
+
+## Guides
+
+- [Agent Authentication](../../../guides/guides/agents/agent-authentication): Exchange a token to downscope it for a worker agent and inspect nested `act` claims.
+- [Backchannel Authentication (CIBA)](../../../guides/guides/protocols/oauth-oidc/backchannel-authentication): Initiate out-of-band approval for a headless agent.
+
+## Related Use Cases
+
+- [Managed Identity](../managed-agent-identity): Emergency revocation cascades through the delegation chain described here.
+- [Accessing Internal Business Services](../internal-services)
+- [Invoking the Agent and Authenticating Users](../invoking-the-agent)

--- a/docs/content/use-cases/ai-agents/overview.mdx
+++ b/docs/content/use-cases/ai-agents/overview.mdx
@@ -1,81 +1,78 @@
 ---
-title: Identity for AI Agents
 docType: use-case
-description: Identify common AI agent identity needs - protecting your agent, calling services, and orchestrating multi-agent workflows.
+title: Identity for AI Agents
+description: Identify when to use this pattern for AI agent identity and access management, and review the supported use case scope.
 sidebar_position: 1
 ---
 
-
 # Identity for AI Agents
 
-Build secure identity for agents that accept requests, call services, act on behalf of users, and delegate work to other agents. Every agent action should answer: who is acting, what can it access, and on whose authority?
+An application owner deploying an autonomous AI agent has to answer three questions about every action it takes: who is acting, what are they allowed to do, and on whose authority. <ProductName /> answers them by giving each agent a managed identity, verifiable credentials, scoped authorization, and a complete audit trail.
 
-## What You Can Build
+## Why Agents Need Their Own Identity Class
 
-<div className="uc-cap-grid">
-  <article className="uc-cap-card"><h3>Protected Agents</h3><p>Require callers to present valid tokens before invoking agent capabilities.</p></article>
-  <article className="uc-cap-card"><h3>Agent Credentials</h3><p>Register each agent as its own identity with credentials, scopes, and lifecycle controls.</p></article>
-  <article className="uc-cap-card"><h3>Delegated Access</h3><p>Let agents act on behalf of users with consent, scope intersection, and actor context.</p></article>
-  <article className="uc-cap-card"><h3>Multi-Agent Workflows</h3><p>Downscope tokens across agent chains while preserving traceability from the original user or caller.</p></article>
-</div>
+Enterprise identity was built for two audiences: humans who sign in through a browser, and machines that exchange credentials through an API. Agents fit neither. An agent needs the contextual, session-based access patterns of a human user, but it cannot complete an interactive sign-in. It needs the programmatic reliability of a service account, but it carries far more autonomy and a far broader access scope than any service account was designed for.
 
-## When to Use This Pattern
-
-Use this pattern when an agent calls protected services, exposes capabilities to clients, acts on behalf of users, stores credentials, delegates to other agents, or must produce an audit trail.
+Forcing an agent into an existing category creates ungovernable gaps. Registered as a service account, it lacks lifecycle governance, contextual authorization, and individual accountability. Issued a human user's credentials, it destroys auditability: you can no longer tell whether the human or the agent took an action. <ProductName /> provisions agents as a distinct identity class, with governance built for how agents actually behave.
 
 ## How Agent Identity Works
 
-In this model:
+- **Agent**: A first-class identity with its own credentials, assigned permissions, owner, and lifecycle. Identity is bound to the configured agent, not the underlying model, so two agents built on the same model but carrying different prompts, tool grants, and scopes are two distinct identities.
+- **Owner**: The accountable party, a liable human or team, that every action the agent takes traces back to.
+- **Postures**: A single agent occupies three identity postures, sometimes within one task, and each demands a different mechanism:
 
-- Each agent is a first-class identity with its own credentials and assigned permissions.
-- Callers authenticate before invoking protected agent capabilities.
-- <ProductName /> issues tokens that represent the agent, the user, or both depending on the flow.
-- Services validate tokens, check scopes, and enforce audience restrictions.
-- Delegated and multi-agent flows preserve actor context so downstream services can audit who initiated each action.
+    | Posture | The agent is... | Question it must answer |
+    |---|---|---|
+    | **Subject** | acting on its own behalf | "Who is this agent?" |
+    | **Actor** | acting on behalf of a principal | "Who authorized this, and is the agent a permitted delegate?" | 
+    | **Resource** | being invoked by a caller | "Who is calling, and are they authorized?" | 
 
-## Building Blocks of the AI Agent Identity Journey
+<ProductName /> handles authentication and authorization for agents, issues tokens that represent the agent, the user, or both depending on the flow. Services validate those tokens, check scopes, and enforce audience restrictions, and delegated flows preserve actor context so downstream services can audit who initiated each action.
 
-Use these building blocks to design agent identity across inbound requests, outbound service calls, and multi-agent delegation. Select a block to see what it solves, where it appears in the journey, which capabilities it uses, and which guide to start with.
+## AI Agent Identity and Access Journey
 
-<AIAgentIdentityExplorer />
+From an application owner's perspective, you need to solve the full agent lifecycle: registering an accountable identity, letting users invoke the agent, and governing every interaction the agent has with models, internal services, external platforms, and other agents. <ProductName /> provides capabilities for each stage. It governs every interaction, but first it governs the agent itself.
 
-## Solution Patterns
+An agent sits at the center of a web of interactions. Invoking parties call it, it reasons over foundation models, it reaches internal services and external systems, and it delegates work to sub-agents.
 
-Choose the token and delegation pattern before implementation. Agent identity design depends on whether the agent acts as itself, acts for a user, receives background approval, or delegates work to other agents.
+<AgentInteractionsDiagram />
 
-<div className="uc-cap-grid">
-  <article id="client-credentials-grant" className="uc-cap-card"><h3>Client Credentials</h3><p>Use this when an agent acts autonomously as its own identity to call protected services.</p></article>
-  <article id="authorization-code-with-obo" className="uc-cap-card"><h3>Authorization Code with OBO</h3><p>Use this when an agent receives user context and needs delegated tokens for downstream services.</p></article>
-  <article id="backchannel-authorization-ciba" className="uc-cap-card"><h3>Backchannel Authorization</h3><p>Use this when a background agent needs out-of-band user approval before acting.</p></article>
-  <article id="token-exchange" className="uc-cap-card"><h3>Token Exchange</h3><p>Use this when one agent delegates to another agent or needs a narrower token for a specific service.</p></article>
-</div>
+Each of these interactions is a distinct identity and access boundary that <ProductName /> governs, and each maps to a use case below.
 
-Review the full pattern guide: [Solution Patterns](../solution-patterns).
+## Start With Governance
 
-## Implementation Paths
+Before an agent handles a single interaction, it has to exist as a governed identity with an accountable owner. Registration, credential rotation, revocation, and ownership transfer are the foundation every other pattern builds on.
 
-<div className="uc-cap-grid">
-  <article id="protect-your-agent" className="uc-cap-card"><h3>Protect Your Agent</h3><p>Require callers to present valid tokens before invoking agent capabilities.</p><p><a href="../try-it-out/">Start with: Try It Out - Protect Your Agent</a></p></article>
-  <article id="connect-to-services" className="uc-cap-card"><h3>Connect to Services</h3><p>Let agents call APIs, MCP servers, tools, and internal services with the right token flow.</p><p><a href="../try-it-out/">Start with: Try It Out - Connect to Services</a></p></article>
-  <article id="multi-agent-workflows" className="uc-cap-card"><h3>Secure Multi-Agent Workflows</h3><p>Downscope tokens as one agent delegates work to another and preserve the original actor context.</p><p><a href="../solution-patterns#token-exchange">Start with: Token Exchange</a></p></article>
-  <article id="scope-intersection" className="uc-cap-card"><h3>Apply Scope Intersection</h3><p>Keep delegated tokens within the overlap of user authority and agent permissions.</p><p><a href="../solution-patterns#scope-granularity">Start with: Scope Granularity</a></p></article>
-  <article id="credential-lifecycle" className="uc-cap-card"><h3>Manage Credential Lifecycle</h3><p>Issue, rotate, expire, revoke, and audit credentials for each agent identity.</p><p><a href="../solution-patterns#credential-lifecycle">Start with: Credential Lifecycle</a></p></article>
-  <article id="audience-locking" className="uc-cap-card"><h3>Lock Tokens to Audiences</h3><p>Bind tokens to the service they are meant to call so they cannot be replayed elsewhere.</p><p><a href="../solution-patterns#resource-servers-and-audience-locking">Start with: Audience Locking</a></p></article>
-  <article id="consent-for-delegation" className="uc-cap-card"><h3>Configure Delegation Consent</h3><p>Ask users to approve delegated access before an agent acts on their behalf.</p><p><a href="../solution-patterns#authorization-code-with-obo">Start with: Authorization Code with OBO</a></p></article>
-  <article id="audit-and-delegation-chain" className="uc-cap-card"><h3>Audit Delegation Chains</h3><p>Trace every agent action and delegation hop back to the original caller or user.</p><p><a href="../solution-patterns#delegation-chain-preservation">Start with: Delegation Chain Preservation</a></p></article>
-</div>
+- **[Managed Identity](../managed-agent-identity)**: register an agent as a first-class identity, rotate its credentials, revoke it (and cascade that revocation through its delegation chain), and trace every action back to a liable human.
 
-## Recommended Starting Point
+## Being Invoked (Inbound)
 
-Start by choosing the token pattern, then register the agent and define the resource scopes it needs. After that, protect the agent's inbound API and configure the outbound service flow.
+These patterns govern who may call an agent and how the agent proves its own identity when it is the one calling.
 
-- [Solution Patterns](../solution-patterns)
-- [Try It Out - Protect Your Agent](../try-it-out/)
-- [MCP Authorization](../mcp-authorization/overview)
+- **[Invoking the Agent and Authenticating Users](../invoking-the-agent)**: authenticate the users, applications, and agents that call an agent; enforce step-up for sensitive actions; and manage the structured, time-bound consent that lets an agent act for a user.
+- **[Agent as Subject](../agent-as-subject)**: let an agent prove its own identity to the systems it accesses with its own credentials (`client_credentials`, `private_key_jwt`, OIDC), distinct from human users and service accounts.
 
-## Related Use Cases
+## Reaching Out (Outbound)
 
-<div className="uc-cap-grid">
-  <article className="uc-cap-card"><h3>B2C Overview</h3><p>Use this when public-facing users sign themselves up and manage their own accounts.</p></article>
-  <article className="uc-cap-card"><h3>B2B SaaS Identity</h3><p>Use this when organizations, tenants, delegated admins, and enterprise customers shape the identity model.</p></article>
-</div>
+These patterns govern what an agent may reach once it is running: models, internal tools, and third-party platforms.
+
+- **[Model Interaction Controls](../model-interaction)**: give an AI gateway a verifiable agent identity so model access, quotas, and guardrails are enforced per agent and, when the agent acts for a user, per delegated user.
+- **[Accessing Internal Business Services](../internal-services)**: solve the dual-identity problem when an agent calls internal APIs and MCP servers, carrying both the agent and the user in one token and scoping access down to individual tool operations.
+- **[External Integration](../external-integration)**: let an agent act across third-party SaaS (Gmail, Slack, Salesforce) using short-lived, just-in-time tokens from a managed vault, so the agent never holds a long-lived secret.
+
+## Working With Other Agents
+
+- **[Multi-Agent Interactions](../multi-agent)**: delegate work between agents with tokens that downscope at every hop, preserve the full delegation chain from the originating user to the final actor, and obtain out-of-band approval (CIBA) for headless agents.
+
+## Choosing the Pattern You Need
+
+Most agents need more than one of these. A useful way to narrow down is to answer two questions about how the agent is invoked, then read the use cases that apply:
+
+- **Is the agent acting on its own, or on behalf of a user?** Acting on its own points to [Agent as Subject](../agent-as-subject) and the autonomous sections of [Internal Business Services](../internal-services). Acting for a user points to the delegated sections of [Invoking the Agent](../invoking-the-agent) and [Internal Business Services](../internal-services).
+- **If on behalf of a user, is the user present at the moment of the call?** A present user is handled by an interactive consent flow in [Invoking the Agent](../invoking-the-agent). An absent user is handled by backchannel (CIBA) approval, covered in [Multi-Agent Interactions](../multi-agent).
+
+Whichever patterns apply, [Managed Identity](../managed-agent-identity) underpins all of them.
+
+## Next Steps
+
+Read the use case that fits your agent, then see the patterns running against a working sample in **[Try It Out](../try-it-out)**.

--- a/docs/content/use-cases/ai-agents/try-it-out/act-on-behalf-of-user.mdx
+++ b/docs/content/use-cases/ai-agents/try-it-out/act-on-behalf-of-user.mdx
@@ -16,7 +16,7 @@ Complete [Setup](../#setup) before starting this walkthrough.
 :::
 
 :::info Background
-[Implementation Paths](../../overview#implementation-paths) covers the requirements story behind this use case.
+The [AI Agent Identity and Access Journey](../../overview#ai-agent-identity-and-access-journey) covers the requirements story behind this use case.
 :::
 
 ## Walk Through the Use Case
@@ -49,5 +49,5 @@ Complete [Setup](../#setup) before starting this walkthrough.
 
 **Delegation.** The OBO token identifies *both* John (as the subject) and the agent (as the actor). Downstream services know the booking was triggered by an agent acting for John, not by John directly. The token's effective permissions are the intersection of what John holds and what John just consented to. See [Agent Authentication](../../../../guides/guides/agents/agent-authentication) for the full OBO exchange.
 
-**Branding.** The consent popup is rendered by <ProductName /> hosted pages. The Wayfinder sample uses <ProductName />'s default branding out of the box. To make the popup feel like part of Wayfinder, customize the logo and color theme for the `WAYFINDER-CONCIERGE` agent from its **Design** settings in the Console. The same pattern applies to applications. See [Register an Application](../../../../guides/guides/applications/manage-applications).
+**Branding.** The consent popup is rendered by <ProductName /> hosted pages. The Wayfinder sample uses <ProductName />'s default branding out of the box. To make the popup feel like part of Wayfinder, customize the logo and color theme for the `WAYFINDER-CONCIERGE` agent from its **Design** settings in the Console. The same pattern applies to applications, see [Register an Application](../../../../guides/guides/applications/manage-applications).
 :::

--- a/docs/content/use-cases/ai-agents/try-it-out/act-on-its-own.mdx
+++ b/docs/content/use-cases/ai-agents/try-it-out/act-on-its-own.mdx
@@ -7,14 +7,14 @@ sidebar_position: 3
 
 # Acting on Its Own
 
-In this walkthrough, John asks the Wayfinder Concierge for flights from Colombo to Singapore and follows up with a request for recommendations. The Concierge answers from the booking API catalog. No popup, no extra consent, it makes the calls under its own identity, using its M2M token.
+In this walkthrough, John asks the Wayfinder Concierge for flights from Colombo to Singapore and follows up with a request for recommendations. The Concierge answers from the booking API catalog. No popup, no extra consent: it makes the calls under its own identity, using its M2M token.
 
 :::note Prerequisites
 Complete [Setup](../#setup) before starting this walkthrough.
 :::
 
 :::info Background
-[Implementation Paths](../../overview#implementation-paths) covers the requirements story behind this use case.
+The [AI Agent Identity and Access Journey](../../overview#ai-agent-identity-and-access-journey) covers the requirements story behind this use case.
 :::
 
 ## Walk Through the Use Case
@@ -36,7 +36,7 @@ Complete [Setup](../#setup) before starting this walkthrough.
 
    This calls the `recommend_bookings` MCP tool, which requires the `booking:recommend` scope. The agent gets it because it requests `scope=booking:recommend` when fetching its M2M token. The `Recommender` role you assigned to `WAYFINDER-CONCIERGE` during setup grants exactly that permission.
 
-No consent popup appears at any point. The user never sees the agent's M2M token: it lives entirely inside the AI Agent.
+No consent popup appears at any point. The user never sees the agent's M2M token, it lives entirely inside the AI Agent.
 
 ## Try a Variant
 

--- a/docs/content/use-cases/ai-agents/try-it-out/protect-the-agent.mdx
+++ b/docs/content/use-cases/ai-agents/try-it-out/protect-the-agent.mdx
@@ -14,7 +14,7 @@ Complete [Setup](../#setup) before starting this walkthrough.
 :::
 
 :::info Background
-[Implementation Paths](../../overview#implementation-paths) covers the requirements story behind this use case.
+The [AI Agent Identity and Access Journey](../../overview#ai-agent-identity-and-access-journey) covers the requirements story behind this use case.
 :::
 
 ## Walk Through the Use Case
@@ -33,5 +33,5 @@ Complete [Setup](../#setup) before starting this walkthrough.
 :::info[Concepts]
 **Authorization.** The AI Agent is a resource server (`wayfinder-agent`) with a single permission (`agent:access`). The `Chat User` role bundles that permission. <ProductName /> writes only the permissions the user actually holds into the access token, so the same edge check (`token has agent:access?`) lets John in and turns Jane away. See [Authorization](../../../../guides/key-concepts/authorization).
 
-**Branding.** The sign-in surface is the <ProductName /> hosted page. The Wayfinder sample ships with <ProductName />'s default branding. You can customize the logo and color theme for the `WAYFINDER` application from its **Design** settings in the Console. See [Register an Application](../../../../guides/guides/applications/manage-applications) for where the Design step sits.
+**Branding.** The sign-in surface is the <ProductName /> hosted page. The Wayfinder sample ships with <ProductName />'s default branding. You can customize the logo and color theme for the `WAYFINDER` application from its **Design** settings in the Console, see [Register an Application](../../../../guides/guides/applications/manage-applications) for where the Design step sits.
 :::

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -241,23 +241,18 @@ const sidebars: SidebarsConfig = {
           items: [
             {
               type: 'category',
-              label: 'Identity for AI Agents',
+              label: 'Agent ID',
               collapsible: true,
               collapsed: true,
+              link: {type: 'doc', id: 'use-cases/ai-agents/overview'},
               items: [
-                {type: 'doc', id: 'use-cases/ai-agents/overview', label: 'Agent Identity'},
-                {
-                  type: 'doc',
-                  id: 'use-cases/ai-agents/solution-patterns',
-                  label: 'Solution Patterns',
-                  key: 'ai-agents-solution-patterns',
-                },
-                {
-                  type: 'doc',
-                  id: 'use-cases/ai-agents/identity-concepts',
-                  label: 'Identity Concepts',
-                  key: 'ai-agents-identity-concepts',
-                },
+                {type: 'doc', id: 'use-cases/ai-agents/managed-agent-identity', label: 'Managed Identity'},
+                {type: 'doc', id: 'use-cases/ai-agents/invoking-the-agent', label: 'Invoking the Agent'},
+                {type: 'doc', id: 'use-cases/ai-agents/agent-as-subject', label: 'Agent as Subject'},
+                {type: 'doc', id: 'use-cases/ai-agents/model-interaction', label: 'Model Interaction Controls'},
+                {type: 'doc', id: 'use-cases/ai-agents/internal-services', label: 'Internal Business Services'},
+                {type: 'doc', id: 'use-cases/ai-agents/external-integration', label: 'External Integration'},
+                {type: 'doc', id: 'use-cases/ai-agents/multi-agent', label: 'Multi-Agent Interactions'},
                 {
                   type: 'category',
                   label: 'Try It Out',

--- a/docs/src/components/AgentInteractionsDiagram.tsx
+++ b/docs/src/components/AgentInteractionsDiagram.tsx
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Box, Typography} from '@wso2/oxygen-ui';
+import {
+  AppWindow,
+  Bot,
+  Brain,
+  Calendar,
+  Cloud,
+  Code2,
+  Cpu,
+  Database,
+  FileSpreadsheet,
+  GitHub,
+  Mail,
+  MCP,
+  MessageSquare,
+  MonitorSmartphone,
+  MoreHorizontal,
+  Settings,
+  Share2,
+  Sparkles,
+  User,
+  Video,
+} from '@wso2/oxygen-ui-icons-react';
+import React from 'react';
+
+// ── Canvas geometry ──
+// Fixed canvas; the figure scrolls horizontally on screens narrower than W.
+// Every element (labels included) sits inside [0, W] × [0, H] with margins so
+// nothing is clipped by the scroll container.
+const W = 920;
+const H = 560;
+
+const lineSx = {stroke: 'var(--ifm-color-emphasis-400)', strokeWidth: 1.6, fill: 'none'};
+
+const iconSx = {
+  color: 'var(--ifm-color-emphasis-700)',
+  '& svg': {
+    fill: 'none',
+    stroke: 'currentColor',
+    strokeLinecap: 'round',
+    strokeLinejoin: 'round',
+    strokeWidth: 1.7,
+  },
+};
+
+const groupCardSx = {
+  position: 'absolute',
+  borderRadius: '16px',
+  border: '1px solid var(--ifm-color-emphasis-200)',
+  background: 'var(--ifm-background-surface-color)',
+  boxShadow: '0 6px 18px color-mix(in srgb, var(--ifm-color-emphasis-900) 6%, transparent)',
+};
+
+const groupHeaderSx = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+  padding: '0.6rem 0.85rem',
+  fontSize: '0.85rem',
+  fontWeight: 700,
+  color: 'var(--ifm-font-color-base)',
+};
+
+const captionSx = {
+  position: 'absolute',
+  textAlign: 'center',
+  fontSize: '0.8rem',
+  fontWeight: 700,
+  color: 'var(--ifm-color-emphasis-700)',
+  lineHeight: 1.3,
+};
+
+function Tile({icon, label}: {icon: React.ReactNode; label: string}) {
+  return (
+    <Box sx={{display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0.3rem', textAlign: 'center'}}>
+      <Box aria-hidden sx={iconSx}>{icon}</Box>
+      <Typography component="span" sx={{fontSize: '0.72rem', fontWeight: 600, color: 'var(--ifm-color-emphasis-700)'}}>
+        {label}
+      </Typography>
+    </Box>
+  );
+}
+
+export function AgentInteractionsDiagram() {
+  return (
+    <Box component="figure" aria-label="An AI agent at the center of its interactions" sx={{margin: '2rem 0 2.5rem', border: 0, padding: 0, overflow: 'visible'}}>
+      <Box sx={{overflowX: 'auto', overflowY: 'hidden', WebkitOverflowScrolling: 'touch', padding: '0.25rem'}}>
+        <Box sx={{position: 'relative', width: W, height: H, minWidth: W, margin: '0 auto'}}>
+
+          {/* ── Connector layer ── */}
+          <Box component="svg" viewBox={`0 0 ${W} ${H}`} width={W} height={H} aria-hidden sx={{position: 'absolute', inset: 0, pointerEvents: 'none'}}>
+            <defs>
+              <marker id="aid-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+                <path d="M0,0 L10,5 L0,10 z" fill="var(--ifm-color-emphasis-500)" />
+              </marker>
+            </defs>
+            {/* Invoking Parties → Agent */}
+            <path d="M170,290 H358" style={lineSx} markerEnd="url(#aid-arrow)" />
+            {/* Agent → AI Providers (up) */}
+            <path d="M460,238 V134" style={lineSx} markerEnd="url(#aid-arrow)" />
+            {/* Agent → Sub Agent (down) */}
+            <path d="M460,342 V436" style={lineSx} markerEnd="url(#aid-arrow)" />
+            {/* Agent → Internal Services (elbow, up-right) */}
+            <path d="M562,272 H626 V132 H688" style={lineSx} markerEnd="url(#aid-arrow)" />
+            {/* Agent → External Systems (elbow, down-right) */}
+            <path d="M562,308 H626 V416 H688" style={lineSx} markerEnd="url(#aid-arrow)" />
+          </Box>
+
+          {/* ── Invoking Parties (left) ── */}
+          <Typography component="span" sx={{...captionSx, left: 50, top: 152, width: 120}}>
+            Invoking<br />Parties
+          </Typography>
+          <Box sx={{position: 'absolute', left: 50, top: 190, width: 120, height: 200, borderRadius: '999px', border: '1px solid var(--ifm-color-emphasis-200)', background: 'var(--ifm-background-surface-color)', boxShadow: '0 6px 18px color-mix(in srgb, var(--ifm-color-emphasis-900) 6%, transparent)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: '1rem'}}>
+            <Box aria-hidden sx={iconSx}><User size={30} /></Box>
+            <Box aria-hidden sx={iconSx}><MonitorSmartphone size={30} /></Box>
+            <Box aria-hidden sx={iconSx}><Bot size={30} /></Box>
+          </Box>
+
+          {/* ── AI Providers and LLMs (top) ── */}
+          <Typography component="span" sx={{...captionSx, left: 300, top: 16, width: 320}}>
+            AI Providers and LLMs
+          </Typography>
+          <Box sx={{...groupCardSx, left: 300, top: 46, width: 320, height: 84}}>
+            <Box sx={{display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '1.4rem', height: '100%', ...iconSx}}>
+              <Sparkles size={26} /><Brain size={26} /><Cpu size={26} /><Bot size={26} /><Cloud size={26} />
+            </Box>
+          </Box>
+
+          {/* ── Agent (center) ── */}
+          <Box sx={{position: 'absolute', left: 360, top: 240, width: 200, height: 100, borderRadius: '14px', color: '#fff', background: 'linear-gradient(150deg, color-mix(in srgb, var(--ifm-color-primary) 92%, #fff), color-mix(in srgb, var(--ifm-color-primary) 62%, #b3540a))', boxShadow: '0 14px 30px color-mix(in srgb, var(--ifm-color-primary) 34%, transparent)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: '0.35rem'}}>
+            <Box sx={{position: 'absolute', top: 10, right: 10, display: 'inline-flex', alignItems: 'center', gap: '0.2rem', padding: '0.15rem 0.45rem', borderRadius: '999px', background: 'rgba(255,255,255,0.22)', fontSize: '0.68rem', fontWeight: 700}}>
+              <Sparkles size={12} /> AI
+            </Box>
+            <Box aria-hidden sx={{'& svg': {fill: 'none', stroke: 'currentColor', strokeLinecap: 'round', strokeLinejoin: 'round', strokeWidth: 1.7}}}><Bot size={34} /></Box>
+            <Typography component="span" sx={{fontSize: '1.05rem', fontWeight: 800}}>Agent</Typography>
+          </Box>
+
+          {/* ── Sub Agent (bottom) ── */}
+          <Box sx={{position: 'absolute', left: 390, top: 438, width: 140, height: 80, borderRadius: '12px', border: '1px solid var(--ifm-color-emphasis-200)', background: 'var(--ifm-background-surface-color)', boxShadow: '0 6px 18px color-mix(in srgb, var(--ifm-color-emphasis-900) 6%, transparent)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: '0.3rem', ...iconSx}}>
+            <Bot size={26} />
+            <Typography component="span" sx={{fontSize: '0.82rem', fontWeight: 700, color: 'var(--ifm-color-emphasis-800)'}}>Sub Agent</Typography>
+          </Box>
+
+          {/* ── Internal Services (top-right) ── */}
+          <Box sx={{...groupCardSx, left: 690, top: 46, width: 200, height: 190}}>
+            <Box sx={groupHeaderSx}><Settings size={16} /> Internal Services</Box>
+            <Box sx={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.9rem 0.5rem', padding: '0.4rem 0.9rem'}}>
+              <Tile icon={<MCP size={26} />} label="MCPs" />
+              <Tile icon={<Code2 size={26} />} label="APIs" />
+              <Tile icon={<Database size={26} />} label="KBs" />
+              <Tile icon={<AppWindow size={26} />} label="Apps" />
+            </Box>
+            <Box aria-hidden sx={{...iconSx, position: 'absolute', right: 14, bottom: 8}}><MoreHorizontal size={20} /></Box>
+          </Box>
+
+          {/* ── External Systems (bottom-right) ── */}
+          <Box sx={{...groupCardSx, left: 690, top: 320, width: 200, height: 200}}>
+            <Box sx={groupHeaderSx}><Settings size={16} /> External Systems</Box>
+            <Box sx={{display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '0.85rem', placeItems: 'center', padding: '0.5rem 0.9rem', ...iconSx}}>
+              <Mail size={24} /><Calendar size={24} /><FileSpreadsheet size={24} />
+              <MessageSquare size={24} /><Video size={24} /><Share2 size={24} />
+              <GitHub size={24} /><Cloud size={24} /><MoreHorizontal size={24} />
+            </Box>
+          </Box>
+
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/docs/src/theme/MDXComponents.tsx
+++ b/docs/src/theme/MDXComponents.tsx
@@ -19,6 +19,7 @@
 import MDXComponents from '@theme-original/MDXComponents';
 import {Box, Card, CardContent, Typography, ColorSchemeSVG, Table, TableBody, TableCell, TableContainer, TableHead, TableRow} from '@wso2/oxygen-ui';
 import {AIAgentIdentityRoadmap as AIAgentIdentityExplorer, AIAgentSolutionPatternsRoadmap} from '@site/src/components/AIAgentIdentityJourney';
+import {AgentInteractionsDiagram} from '@site/src/components/AgentInteractionsDiagram';
 import ApiReference from '@site/src/components/ApiReference';
 import ApiVersionReference from '@site/src/components/ApiVersionReference';
 import {
@@ -146,6 +147,7 @@ export default {
   B2CNextSteps,
   AIAgentIdentityExplorer,
   AIAgentSolutionPatternsRoadmap,
+  AgentInteractionsDiagram,
   BuildAFlowDiagram,
   FlowNodeTypesRoadmap,
   FlowBuildingBlocksRoadmap,


### PR DESCRIPTION
### Purpose

  Reorganizes the **Identity for AI Agents** documentation into focused, per-interaction use-case pages.

  Previously the section carried a single generic "Solution Patterns" page (organized around abstract token flows) plus a standalone "Identity Concepts" page. This PR replaces that structure with one page per
  agent interaction and turns the overview into the landing/index that ties them together.

  **Added** seven use-case pages under `docs/content/use-cases/ai-agents/`:

  - Managed Identity — registration, credential rotation, revocation, ownership/liability
  - Invoking the Agent — authenticating callers, consent, delegated authority, agent-as-resource
  - Agent as Subject — the agent proving its own identity with its own credentials
  - Model Interaction Controls — per-agent model access and guardrails via an AI gateway
  - Internal Business Services — the dual-identity problem and fine-grained tool authorization
  - External Integration — acting across third-party SaaS without holding long-lived secrets
  - Multi-Agent Interactions — downscoped delegation, chain preservation, backchannel (CIBA) approval

  **Rewrote** `overview.mdx` as the index that links to the seven pages, and **removed**:

  - `solution-patterns.mdx` — its index content moved into the overview
  - `identity-concepts.mdx` — redundant with the Try It Out "Identity Model"; incoming links repointed

  **Also**: registered the new pages in `sidebars.ts` under the "Solution Patterns" group, repointed cross-links in `mcp-authorization/identity-concepts.mdx` and the Try It Out subpages, and added the
  `AgentInteractionsDiagram` component used by the overview.

  ### Approach

  - Flat sibling pages under `ai-agents/`, grouped in the sidebar under a "Solution Patterns" category linked to the overview.
  - Each use-case page follows the established house structure: *Challenge → How ThunderID Solves It → Scenario → Key Principles*, consistent with the existing pages in the section.
  - Applied a docs-review style pass across the new and edited pages (removed em/en dashes, "sign in" terminology, tightened phrasing, scenario-first intro).
  - Verified the full site builds with no broken links (`pnpm build`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added new use-case pages covering AI agent identity (including “Agent as Subject” and “Managed Identity”), secure invocation/authentication, delegated user authority, internal business services, and safe external integrations.
  - Added guidance for model access controls (agent → model) and multi-agent interaction security.
  - Reworked the AI Agents overview into an identity/access journey, updated navigation/links, and removed outdated “Identity Concepts” and “Solution Patterns” pages.

- **Enhancements**
  - Added an on-page interaction diagram to visualize agent identity and access flows across systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->