### PR TITLE
Introduce configurable OTP properties with flow-level overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,9 @@ docs/static/api/next/postman/
 # Dev-only CORS seed staged by `build.sh run` / `build.ps1 run` for the bootstrap one-shot (never committed or packaged)
 backend/cmd/server/bootstrap/02-server-configurations.yaml
 
+# Nx build cache (generated, never committed)
+.nx/
+
+# Development internals guide (not intended for commit)
+THUNDERID_INTERNALS_GUIDE.md
+

--- a/backend/internal/authn/otp/service.go
+++ b/backend/internal/authn/otp/service.go
@@ -40,7 +40,7 @@ const (
 // OTPAuthnServiceInterface defines the interface for OTP authentication operations.
 // Authenticate returns an error only for actual failures; a missing local user is NOT an error.
 type OTPAuthnServiceInterface interface {
-	GenerateOTP(ctx context.Context, recipient, recipientAttr string) (
+	GenerateOTP(ctx context.Context, recipient, recipientAttr string, otpCfg *notifcommon.OTPConfig) (
 		sessionToken string, otpValue string, expirySeconds int64, svcErr *tidcommon.ServiceError)
 	Authenticate(ctx context.Context, sessionToken, otp string) (*common.AuthnResult, *tidcommon.ServiceError)
 }
@@ -59,7 +59,8 @@ func newOTPAuthnService(notifOTPSvc notification.OTPServiceInterface) OTPAuthnSe
 
 // GenerateOTP validates the recipient and delegates OTP generation to the notification service.
 func (s *otpAuthnService) GenerateOTP(ctx context.Context,
-	recipient, recipientAttr string) (string, string, int64, *tidcommon.ServiceError) {
+	recipient, recipientAttr string, otpCfg *notifcommon.OTPConfig) (
+	string, string, int64, *tidcommon.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 	logger.Debug(ctx, "Generating OTP", log.MaskedString("recipient", recipient))
 
@@ -71,7 +72,8 @@ func (s *otpAuthnService) GenerateOTP(ctx context.Context,
 		recipientAttr = authnprovidercm.UserAttributeUserID
 	}
 
-	sessionToken, otpValue, expirySeconds, svcErr := s.notifOTPService.GenerateOTP(ctx, recipient, recipientAttr)
+	sessionToken, otpValue, expirySeconds, svcErr :=
+		s.notifOTPService.GenerateOTP(ctx, recipient, recipientAttr, otpCfg)
 	if svcErr != nil {
 		if svcErr.Type == tidcommon.ClientErrorType {
 			return "", "", 0, &ErrorClientErrorFromOTPService

--- a/backend/internal/authn/otp/service_test.go
+++ b/backend/internal/authn/otp/service_test.go
@@ -59,7 +59,7 @@ func (suite *OTPAuthnServiceTestSuite) SetupTest() {
 
 func (suite *OTPAuthnServiceTestSuite) TestGenerateOTPEmptyRecipient() {
 	sessionToken, otpValue, _, err := suite.service.GenerateOTP(
-		context.Background(), "", authnprovidercm.UserAttributeUserID)
+		context.Background(), "", authnprovidercm.UserAttributeUserID, nil)
 	suite.Empty(sessionToken)
 	suite.Empty(otpValue)
 	suite.NotNil(err)
@@ -68,7 +68,7 @@ func (suite *OTPAuthnServiceTestSuite) TestGenerateOTPEmptyRecipient() {
 
 func (suite *OTPAuthnServiceTestSuite) TestGenerateOTPWhitespaceRecipient() {
 	sessionToken, otpValue, _, err := suite.service.GenerateOTP(
-		context.Background(), "   ", authnprovidercm.UserAttributeUserID)
+		context.Background(), "   ", authnprovidercm.UserAttributeUserID, nil)
 	suite.Empty(sessionToken)
 	suite.Empty(otpValue)
 	suite.NotNil(err)
@@ -77,20 +77,20 @@ func (suite *OTPAuthnServiceTestSuite) TestGenerateOTPWhitespaceRecipient() {
 
 func (suite *OTPAuthnServiceTestSuite) TestGenerateOTPDefaultsRecipientAttr() {
 	suite.mockNotifOTPSvc.On("GenerateOTP",
-		mock.Anything, testRecipient, authnprovidercm.UserAttributeUserID,
+		mock.Anything, testRecipient, authnprovidercm.UserAttributeUserID, mock.Anything,
 	).Return(testSessionToken, testOTPCode, int64(300), (*tidcommon.ServiceError)(nil)).Once()
 
-	_, _, _, err := suite.service.GenerateOTP(context.Background(), testRecipient, "")
+	_, _, _, err := suite.service.GenerateOTP(context.Background(), testRecipient, "", nil)
 	suite.Nil(err)
 }
 
 func (suite *OTPAuthnServiceTestSuite) TestGenerateOTPSuccess() {
 	suite.mockNotifOTPSvc.On("GenerateOTP",
-		mock.Anything, testRecipient, authnprovidercm.UserAttributeUserID,
+		mock.Anything, testRecipient, authnprovidercm.UserAttributeUserID, mock.Anything,
 	).Return(testSessionToken, testOTPCode, int64(300), (*tidcommon.ServiceError)(nil)).Once()
 
 	sessionToken, otpValue, expirySeconds, err := suite.service.GenerateOTP(
-		context.Background(), testRecipient, authnprovidercm.UserAttributeUserID)
+		context.Background(), testRecipient, authnprovidercm.UserAttributeUserID, nil)
 
 	suite.Nil(err)
 	suite.Equal(testSessionToken, sessionToken)
@@ -100,11 +100,11 @@ func (suite *OTPAuthnServiceTestSuite) TestGenerateOTPSuccess() {
 
 func (suite *OTPAuthnServiceTestSuite) TestGenerateOTPDelegatesError() {
 	suite.mockNotifOTPSvc.On("GenerateOTP",
-		mock.Anything, testRecipient, authnprovidercm.UserAttributeUserID,
+		mock.Anything, testRecipient, authnprovidercm.UserAttributeUserID, mock.Anything,
 	).Return("", "", int64(0), &tidcommon.InternalServerError).Once()
 
 	sessionToken, otpValue, _, err := suite.service.GenerateOTP(
-		context.Background(), testRecipient, authnprovidercm.UserAttributeUserID)
+		context.Background(), testRecipient, authnprovidercm.UserAttributeUserID, nil)
 
 	suite.Empty(sessionToken)
 	suite.Empty(otpValue)

--- a/backend/internal/authn/service.go
+++ b/backend/internal/authn/service.go
@@ -208,7 +208,7 @@ func (as *authenticationService) SendOTP(ctx context.Context, senderID string, c
 	recipient string) (string, *tidcommon.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, svcLoggerComponentName))
 
-	sessionToken, otpValue, _, svcErr := as.otpService.GenerateOTP(ctx, recipient, "mobile_number")
+	sessionToken, otpValue, _, svcErr := as.otpService.GenerateOTP(ctx, recipient, "mobile_number", nil)
 	if svcErr != nil {
 		if svcErr.Type == tidcommon.ServerErrorType {
 			logger.Error(ctx, "Failed to generate OTP", log.String("error", svcErr.Code))

--- a/backend/internal/authn/service_test.go
+++ b/backend/internal/authn/service_test.go
@@ -459,7 +459,7 @@ func (suite *AuthenticationServiceTestSuite) TestSendOTPSuccess() {
 	senderID := testSenderID
 	recipient := "+1234567890"
 
-	suite.mockOTPService.On("GenerateOTP", mock.Anything, recipient, "mobile_number").
+	suite.mockOTPService.On("GenerateOTP", mock.Anything, recipient, "mobile_number", mock.Anything).
 		Return(testSessionTkn, "123456", int64(300), nil)
 	suite.mockTemplateService.On("Render",
 		mock.Anything, template.ScenarioOTP, template.TemplateTypeSMS, mock.Anything).
@@ -485,7 +485,7 @@ func (suite *AuthenticationServiceTestSuite) TestSendOTPGenerateError() {
 			Key: "error.test.failed_to_generate_otp", DefaultValue: "Failed to generate OTP"},
 	}
 
-	suite.mockOTPService.On("GenerateOTP", mock.Anything, recipient, "mobile_number").
+	suite.mockOTPService.On("GenerateOTP", mock.Anything, recipient, "mobile_number", mock.Anything).
 		Return("", "", int64(0), svcErr)
 
 	result, err := suite.service.SendOTP(context.Background(), senderID, notifcommon.ChannelTypeSMS, recipient)
@@ -507,7 +507,7 @@ func (suite *AuthenticationServiceTestSuite) TestSendOTPSendError() {
 		},
 	}
 
-	suite.mockOTPService.On("GenerateOTP", mock.Anything, recipient, "mobile_number").
+	suite.mockOTPService.On("GenerateOTP", mock.Anything, recipient, "mobile_number", mock.Anything).
 		Return(testSessionTkn, "123456", int64(300), nil)
 	suite.mockTemplateService.On("Render",
 		mock.Anything, template.ScenarioOTP, template.TemplateTypeSMS, mock.Anything).

--- a/backend/internal/flow/executor/constants.go
+++ b/backend/internal/flow/executor/constants.go
@@ -115,6 +115,9 @@ const (
 	propertyKeyCallbackType                            = "callbackType"
 	propertyKeyLoginHintAttribute                      = "loginHintAttribute"
 	propertyKeyMaxOTPAttempts                          = "maxAttempts"
+	propertyKeyOTPLength                               = "otpLength"
+	propertyKeyOTPUseNumericOnly                       = "otpUseNumericOnly"
+	propertyKeyOTPValidityPeriodSeconds                = "otpValidityPeriodSeconds"
 	// propertyKeyPromptOnSignOut, when set to boolean true on a session sign-out node, makes the executor
 	// confirm the logout with the End-User (via the node's onIncomplete prompt) whenever the RP-initiated
 	// logout was not accompanied by a valid id_token_hint (RuntimeKeyLogoutPromptRequired).

--- a/backend/internal/flow/executor/otp_executor.go
+++ b/backend/internal/flow/executor/otp_executor.go
@@ -28,6 +28,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/entityprovider"
 	"github.com/thunder-id/thunderid/internal/flow/common"
 	"github.com/thunder-id/thunderid/internal/flow/core"
+	notifcommon "github.com/thunder-id/thunderid/internal/notification/common"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	systemutils "github.com/thunder-id/thunderid/internal/system/utils"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
@@ -81,6 +82,9 @@ func newOTPExecutor(
 			},
 			SupportedProperties: []providers.ExecutorSupportedProperties{
 				{Property: propertyKeyMaxOTPAttempts},
+				{Property: propertyKeyOTPLength},
+				{Property: propertyKeyOTPUseNumericOnly},
+				{Property: propertyKeyOTPValidityPeriodSeconds},
 			},
 		})
 
@@ -166,7 +170,9 @@ func (e *otpExecutor) executeGenerate(ctx *providers.NodeContext,
 		return execResp, nil
 	}
 
-	sessionToken, otpValue, expirySeconds, svcErr := e.otpService.GenerateOTP(ctx.Context, recipient, recipientAttr)
+	otpCfg := e.resolveOTPProperties(ctx)
+	sessionToken, otpValue, expirySeconds, svcErr :=
+		e.otpService.GenerateOTP(ctx.Context, recipient, recipientAttr, otpCfg)
 	if svcErr != nil {
 		return execResp, fmt.Errorf("failed to generate OTP: %s", svcErr.ErrorDescription.DefaultValue)
 	}
@@ -376,6 +382,46 @@ func (e *otpExecutor) validateAttempts(ctx *providers.NodeContext, execResp *pro
 	}
 
 	return attemptCount, nil
+}
+
+// resolveOTPProperties reads flow-level OTP configuration overrides from NodeProperties.
+// Returns nil if no override is specified; otherwise returns an OTPConfig with only
+// the fields that were explicitly set and valid.
+func (e *otpExecutor) resolveOTPProperties(ctx *providers.NodeContext) *notifcommon.OTPConfig {
+	var cfg notifcommon.OTPConfig
+	hasOverride := false
+
+	if v, ok := ctx.NodeProperties[propertyKeyOTPLength]; ok {
+		if n, ok := systemutils.ToInt64(v); ok {
+			if f, isFloat := v.(float64); !isFloat || f == float64(n) {
+				length := int(n)
+				cfg.Length = &length
+				hasOverride = true
+			}
+		}
+	}
+
+	if v, ok := ctx.NodeProperties[propertyKeyOTPUseNumericOnly]; ok {
+		if numericOnly, ok := systemutils.ToBool(v); ok {
+			cfg.UseNumericOnly = &numericOnly
+			hasOverride = true
+		}
+	}
+
+	if v, ok := ctx.NodeProperties[propertyKeyOTPValidityPeriodSeconds]; ok {
+		if n, ok := systemutils.ToInt64(v); ok {
+			if f, isFloat := v.(float64); !isFloat || f == float64(n) {
+				validity := int(n)
+				cfg.ValidityPeriodSeconds = &validity
+				hasOverride = true
+			}
+		}
+	}
+
+	if !hasOverride {
+		return nil
+	}
+	return &cfg
 }
 
 // getMaxOTPAttempts returns the maximum OTP generation attempts from NodeProperties,

--- a/backend/internal/flow/executor/otp_executor_test.go
+++ b/backend/internal/flow/executor/otp_executor_test.go
@@ -139,7 +139,9 @@ func (suite *OTPExecutorTestSuite) TestExecuteGenerate_Success_UserIdentifiedAnd
 		return hasMobile
 	})).Return(&userID, nil)
 
-	suite.mockOTPService.On("GenerateOTP", mock.Anything, userID, authnprovidercm.UserAttributeUserID).
+	suite.mockOTPService.On("GenerateOTP",
+		mock.Anything, userID, authnprovidercm.UserAttributeUserID,
+		mock.Anything).
 		Return("session-tok-1", "654321", int64(300), (*tidcommon.ServiceError)(nil))
 
 	ctx := &providers.NodeContext{
@@ -176,7 +178,9 @@ func (suite *OTPExecutorTestSuite) TestExecuteGenerate_MultipleInputs_Identifies
 		return hasMobile && hasEmail
 	})).Return(&userID, nil)
 
-	suite.mockOTPService.On("GenerateOTP", mock.Anything, userID, authnprovidercm.UserAttributeUserID).
+	suite.mockOTPService.On("GenerateOTP",
+		mock.Anything, userID, authnprovidercm.UserAttributeUserID,
+		mock.Anything).
 		Return("session-tok-2", "111222", int64(300), (*tidcommon.ServiceError)(nil))
 
 	ctx := &providers.NodeContext{
@@ -235,7 +239,9 @@ func (suite *OTPExecutorTestSuite) TestExecuteGenerate_Registration_UserNotFound
 		return hasMobile
 	})).Return((*string)(nil), &entityprovider.EntityProviderError{Code: entityprovider.ErrorCodeEntityNotFound})
 
-	suite.mockOTPService.On("GenerateOTP", mock.Anything, "+1234567890", common.AttributeMobileNumber).
+	suite.mockOTPService.On("GenerateOTP",
+		mock.Anything, "+1234567890",
+		common.AttributeMobileNumber, mock.Anything).
 		Return("session-reg-1", "777888", int64(300), (*tidcommon.ServiceError)(nil))
 
 	ctx := &providers.NodeContext{
@@ -605,7 +611,9 @@ func (suite *OTPExecutorTestSuite) TestResolveUserID_AuthenticatedUser_ReturnsEn
 		RuntimeData: map[string]string{},
 	}
 
-	suite.mockOTPService.On("GenerateOTP", mock.Anything, entityID, authnprovidercm.UserAttributeUserID).
+	suite.mockOTPService.On("GenerateOTP",
+		mock.Anything, entityID, authnprovidercm.UserAttributeUserID,
+		mock.Anything).
 		Return("session-auth-tok", "112233", int64(300), (*tidcommon.ServiceError)(nil))
 
 	resp, err := suite.executor.Execute(ctx)
@@ -704,7 +712,9 @@ func (suite *OTPExecutorTestSuite) TestExecuteGenerate_GenerateOTPError_ReturnsE
 		Code:             "OTP-ERR",
 		ErrorDescription: tidcommon.I18nMessage{DefaultValue: "otp generation failed"},
 	}
-	suite.mockOTPService.On("GenerateOTP", mock.Anything, userID, authnprovidercm.UserAttributeUserID).
+	suite.mockOTPService.On("GenerateOTP",
+		mock.Anything, userID, authnprovidercm.UserAttributeUserID,
+		mock.Anything).
 		Return("", "", int64(0), &svcErr)
 
 	ctx := &providers.NodeContext{
@@ -787,7 +797,9 @@ func (suite *OTPExecutorTestSuite) TestExecuteGenerate_MaxAttemptsFromNodeProper
 func (suite *OTPExecutorTestSuite) TestExecuteGenerate_MaxAttemptsFromNodeProperties_InvalidStringFallsBack() {
 	userID := testOTPUserID
 	suite.mockEntityProvider.On("IdentifyEntity", mock.Anything).Return(&userID, nil)
-	suite.mockOTPService.On("GenerateOTP", mock.Anything, userID, authnprovidercm.UserAttributeUserID).
+	suite.mockOTPService.On("GenerateOTP",
+		mock.Anything, userID, authnprovidercm.UserAttributeUserID,
+		mock.Anything).
 		Return("session-tok-fb", "999111", int64(300), (*tidcommon.ServiceError)(nil))
 
 	ctx := &providers.NodeContext{
@@ -817,7 +829,9 @@ func (suite *OTPExecutorTestSuite) TestExecuteGenerate_Registration_DestinationF
 	suite.mockEntityProvider.On("IdentifyEntity", mock.Anything).
 		Return((*string)(nil), &entityprovider.EntityProviderError{Code: entityprovider.ErrorCodeEntityNotFound})
 
-	suite.mockOTPService.On("GenerateOTP", mock.Anything, "+9876543210", common.AttributeMobileNumber).
+	suite.mockOTPService.On("GenerateOTP",
+		mock.Anything, "+9876543210",
+		common.AttributeMobileNumber, mock.Anything).
 		Return("session-rt", "445566", int64(300), (*tidcommon.ServiceError)(nil))
 
 	ctx := &providers.NodeContext{
@@ -845,7 +859,9 @@ func (suite *OTPExecutorTestSuite) TestExecuteGenerate_Registration_DestinationF
 	suite.mockEntityProvider.On("IdentifyEntity", mock.Anything).
 		Return((*string)(nil), &entityprovider.EntityProviderError{Code: entityprovider.ErrorCodeEntityNotFound})
 
-	suite.mockOTPService.On("GenerateOTP", mock.Anything, "+1112223333", common.AttributeMobileNumber).
+	suite.mockOTPService.On("GenerateOTP",
+		mock.Anything, "+1112223333",
+		common.AttributeMobileNumber, mock.Anything).
 		Return("session-fwd", "334455", int64(300), (*tidcommon.ServiceError)(nil))
 
 	ctx := &providers.NodeContext{
@@ -873,7 +889,9 @@ func (suite *OTPExecutorTestSuite) TestExecuteGenerate_Registration_DestinationF
 // resolveUserID: userID already in RuntimeData (early return path)
 
 func (suite *OTPExecutorTestSuite) TestExecuteGenerate_UserIDAlreadyInRuntimeData() {
-	suite.mockOTPService.On("GenerateOTP", mock.Anything, testOTPUserID, authnprovidercm.UserAttributeUserID).
+	suite.mockOTPService.On("GenerateOTP",
+		mock.Anything, testOTPUserID,
+		authnprovidercm.UserAttributeUserID, mock.Anything).
 		Return("session-cached", "221100", int64(300), (*tidcommon.ServiceError)(nil))
 
 	ctx := &providers.NodeContext{
@@ -950,4 +968,206 @@ func (suite *OTPExecutorTestSuite) TestExecuteVerify_AuthenticateUserUnexpectedE
 	_, err := suite.executor.Execute(ctx)
 
 	assert.Error(suite.T(), err)
+}
+
+// --- resolveOTPProperties tests ---
+
+func (suite *OTPExecutorTestSuite) TestResolveOTPProperties_AllValid() {
+	ctx := &providers.NodeContext{
+		NodeProperties: map[string]interface{}{
+			propertyKeyOTPLength:                8,
+			propertyKeyOTPUseNumericOnly:        true,
+			propertyKeyOTPValidityPeriodSeconds: 120,
+		},
+	}
+
+	cfg := suite.executor.resolveOTPProperties(ctx)
+
+	suite.NotNil(cfg)
+	suite.NotNil(cfg.Length)
+	suite.Equal(8, *cfg.Length)
+	suite.NotNil(cfg.UseNumericOnly)
+	suite.True(*cfg.UseNumericOnly)
+	suite.NotNil(cfg.ValidityPeriodSeconds)
+	suite.Equal(120, *cfg.ValidityPeriodSeconds)
+}
+
+func (suite *OTPExecutorTestSuite) TestResolveOTPProperties_NoProperties() {
+	ctx := &providers.NodeContext{
+		NodeProperties: map[string]interface{}{},
+	}
+
+	cfg := suite.executor.resolveOTPProperties(ctx)
+
+	suite.Nil(cfg)
+}
+
+func (suite *OTPExecutorTestSuite) TestResolveOTPProperties_OnlyLength() {
+	ctx := &providers.NodeContext{
+		NodeProperties: map[string]interface{}{
+			propertyKeyOTPLength: 6,
+		},
+	}
+
+	cfg := suite.executor.resolveOTPProperties(ctx)
+
+	suite.NotNil(cfg)
+	suite.NotNil(cfg.Length)
+	suite.Equal(6, *cfg.Length)
+	suite.Nil(cfg.UseNumericOnly)
+	suite.Nil(cfg.ValidityPeriodSeconds)
+}
+
+func (suite *OTPExecutorTestSuite) TestResolveOTPProperties_OnlyNumericOnly() {
+	ctx := &providers.NodeContext{
+		NodeProperties: map[string]interface{}{
+			propertyKeyOTPUseNumericOnly: false,
+		},
+	}
+
+	cfg := suite.executor.resolveOTPProperties(ctx)
+
+	suite.NotNil(cfg)
+	suite.Nil(cfg.Length)
+	suite.NotNil(cfg.UseNumericOnly)
+	suite.False(*cfg.UseNumericOnly)
+	suite.Nil(cfg.ValidityPeriodSeconds)
+}
+
+func (suite *OTPExecutorTestSuite) TestResolveOTPProperties_OnlyValidity() {
+	ctx := &providers.NodeContext{
+		NodeProperties: map[string]interface{}{
+			propertyKeyOTPValidityPeriodSeconds: 60,
+		},
+	}
+
+	cfg := suite.executor.resolveOTPProperties(ctx)
+
+	suite.NotNil(cfg)
+	suite.Nil(cfg.Length)
+	suite.Nil(cfg.UseNumericOnly)
+	suite.NotNil(cfg.ValidityPeriodSeconds)
+	suite.Equal(60, *cfg.ValidityPeriodSeconds)
+}
+
+func (suite *OTPExecutorTestSuite) TestResolveOTPProperties_LengthBelowMin() {
+	ctx := &providers.NodeContext{
+		NodeProperties: map[string]interface{}{
+			propertyKeyOTPLength: 3,
+		},
+	}
+
+	cfg := suite.executor.resolveOTPProperties(ctx)
+
+	suite.NotNil(cfg)
+	suite.NotNil(cfg.Length)
+	suite.Equal(3, *cfg.Length)
+}
+
+func (suite *OTPExecutorTestSuite) TestResolveOTPProperties_LengthAboveMax() {
+	ctx := &providers.NodeContext{
+		NodeProperties: map[string]interface{}{
+			propertyKeyOTPLength: 11,
+		},
+	}
+
+	cfg := suite.executor.resolveOTPProperties(ctx)
+
+	suite.NotNil(cfg)
+	suite.NotNil(cfg.Length)
+	suite.Equal(11, *cfg.Length)
+}
+
+func (suite *OTPExecutorTestSuite) TestResolveOTPProperties_ValidityBelowMin() {
+	ctx := &providers.NodeContext{
+		NodeProperties: map[string]interface{}{
+			propertyKeyOTPValidityPeriodSeconds: 29,
+		},
+	}
+
+	cfg := suite.executor.resolveOTPProperties(ctx)
+
+	suite.NotNil(cfg)
+	suite.NotNil(cfg.ValidityPeriodSeconds)
+	suite.Equal(29, *cfg.ValidityPeriodSeconds)
+}
+
+func (suite *OTPExecutorTestSuite) TestResolveOTPProperties_ValidityAboveMax() {
+	ctx := &providers.NodeContext{
+		NodeProperties: map[string]interface{}{
+			propertyKeyOTPValidityPeriodSeconds: 601,
+		},
+	}
+
+	cfg := suite.executor.resolveOTPProperties(ctx)
+
+	suite.NotNil(cfg)
+	suite.NotNil(cfg.ValidityPeriodSeconds)
+	suite.Equal(601, *cfg.ValidityPeriodSeconds)
+}
+
+func (suite *OTPExecutorTestSuite) TestResolveOTPProperties_InvalidBool() {
+	ctx := &providers.NodeContext{
+		NodeProperties: map[string]interface{}{
+			propertyKeyOTPUseNumericOnly: "not-a-bool",
+		},
+	}
+
+	cfg := suite.executor.resolveOTPProperties(ctx)
+
+	suite.Nil(cfg)
+}
+
+func (suite *OTPExecutorTestSuite) TestResolveOTPProperties_InvalidLengthType() {
+	ctx := &providers.NodeContext{
+		NodeProperties: map[string]interface{}{
+			propertyKeyOTPLength: "abc",
+		},
+	}
+
+	cfg := suite.executor.resolveOTPProperties(ctx)
+
+	suite.Nil(cfg)
+}
+
+func (suite *OTPExecutorTestSuite) TestResolveOTPProperties_MixedValidAndInvalid() {
+	ctx := &providers.NodeContext{
+		NodeProperties: map[string]interface{}{
+			propertyKeyOTPLength:                8,
+			propertyKeyOTPValidityPeriodSeconds: 29,
+		},
+	}
+
+	cfg := suite.executor.resolveOTPProperties(ctx)
+
+	suite.NotNil(cfg)
+	suite.NotNil(cfg.Length)
+	suite.Equal(8, *cfg.Length)
+	suite.Nil(cfg.UseNumericOnly)
+	suite.NotNil(cfg.ValidityPeriodSeconds)
+	suite.Equal(29, *cfg.ValidityPeriodSeconds)
+}
+
+func (suite *OTPExecutorTestSuite) TestResolveOTPProperties_FractionalLength() {
+	ctx := &providers.NodeContext{
+		NodeProperties: map[string]interface{}{
+			propertyKeyOTPLength: 4.9,
+		},
+	}
+
+	cfg := suite.executor.resolveOTPProperties(ctx)
+
+	suite.Nil(cfg)
+}
+
+func (suite *OTPExecutorTestSuite) TestResolveOTPProperties_FractionalValidity() {
+	ctx := &providers.NodeContext{
+		NodeProperties: map[string]interface{}{
+			propertyKeyOTPValidityPeriodSeconds: 30.9,
+		},
+	}
+
+	cfg := suite.executor.resolveOTPProperties(ctx)
+
+	suite.Nil(cfg)
 }

--- a/backend/internal/notification/OTPServiceInterface_mock_test.go
+++ b/backend/internal/notification/OTPServiceInterface_mock_test.go
@@ -8,8 +8,8 @@ import (
 	"context"
 
 	mock "github.com/stretchr/testify/mock"
-	common0 "github.com/thunder-id/thunderid/internal/notification/common"
-	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
+	"github.com/thunder-id/thunderid/internal/notification/common"
+	common0 "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 )
 
 // NewOTPServiceInterfaceMock creates a new instance of OTPServiceInterfaceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
@@ -40,8 +40,8 @@ func (_m *OTPServiceInterfaceMock) EXPECT() *OTPServiceInterfaceMock_Expecter {
 }
 
 // GenerateOTP provides a mock function for the type OTPServiceInterfaceMock
-func (_mock *OTPServiceInterfaceMock) GenerateOTP(ctx context.Context, recipient string, recipientAttr string) (string, string, int64, *common.ServiceError) {
-	ret := _mock.Called(ctx, recipient, recipientAttr)
+func (_mock *OTPServiceInterfaceMock) GenerateOTP(ctx context.Context, recipient string, recipientAttr string, otpCfg *common.OTPConfig) (string, string, int64, *common0.ServiceError) {
+	ret := _mock.Called(ctx, recipient, recipientAttr, otpCfg)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GenerateOTP")
@@ -50,30 +50,30 @@ func (_mock *OTPServiceInterfaceMock) GenerateOTP(ctx context.Context, recipient
 	var r0 string
 	var r1 string
 	var r2 int64
-	var r3 *common.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (string, string, int64, *common.ServiceError)); ok {
-		return returnFunc(ctx, recipient, recipientAttr)
+	var r3 *common0.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *common.OTPConfig) (string, string, int64, *common0.ServiceError)); ok {
+		return returnFunc(ctx, recipient, recipientAttr, otpCfg)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) string); ok {
-		r0 = returnFunc(ctx, recipient, recipientAttr)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *common.OTPConfig) string); ok {
+		r0 = returnFunc(ctx, recipient, recipientAttr, otpCfg)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) string); ok {
-		r1 = returnFunc(ctx, recipient, recipientAttr)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, *common.OTPConfig) string); ok {
+		r1 = returnFunc(ctx, recipient, recipientAttr, otpCfg)
 	} else {
 		r1 = ret.Get(1).(string)
 	}
-	if returnFunc, ok := ret.Get(2).(func(context.Context, string, string) int64); ok {
-		r2 = returnFunc(ctx, recipient, recipientAttr)
+	if returnFunc, ok := ret.Get(2).(func(context.Context, string, string, *common.OTPConfig) int64); ok {
+		r2 = returnFunc(ctx, recipient, recipientAttr, otpCfg)
 	} else {
 		r2 = ret.Get(2).(int64)
 	}
-	if returnFunc, ok := ret.Get(3).(func(context.Context, string, string) *common.ServiceError); ok {
-		r3 = returnFunc(ctx, recipient, recipientAttr)
+	if returnFunc, ok := ret.Get(3).(func(context.Context, string, string, *common.OTPConfig) *common0.ServiceError); ok {
+		r3 = returnFunc(ctx, recipient, recipientAttr, otpCfg)
 	} else {
 		if ret.Get(3) != nil {
-			r3 = ret.Get(3).(*common.ServiceError)
+			r3 = ret.Get(3).(*common0.ServiceError)
 		}
 	}
 	return r0, r1, r2, r3
@@ -88,11 +88,12 @@ type OTPServiceInterfaceMock_GenerateOTP_Call struct {
 //   - ctx context.Context
 //   - recipient string
 //   - recipientAttr string
-func (_e *OTPServiceInterfaceMock_Expecter) GenerateOTP(ctx interface{}, recipient interface{}, recipientAttr interface{}) *OTPServiceInterfaceMock_GenerateOTP_Call {
-	return &OTPServiceInterfaceMock_GenerateOTP_Call{Call: _e.mock.On("GenerateOTP", ctx, recipient, recipientAttr)}
+//   - otpCfg *common.OTPConfig
+func (_e *OTPServiceInterfaceMock_Expecter) GenerateOTP(ctx interface{}, recipient interface{}, recipientAttr interface{}, otpCfg interface{}) *OTPServiceInterfaceMock_GenerateOTP_Call {
+	return &OTPServiceInterfaceMock_GenerateOTP_Call{Call: _e.mock.On("GenerateOTP", ctx, recipient, recipientAttr, otpCfg)}
 }
 
-func (_c *OTPServiceInterfaceMock_GenerateOTP_Call) Run(run func(ctx context.Context, recipient string, recipientAttr string)) *OTPServiceInterfaceMock_GenerateOTP_Call {
+func (_c *OTPServiceInterfaceMock_GenerateOTP_Call) Run(run func(ctx context.Context, recipient string, recipientAttr string, otpCfg *common.OTPConfig)) *OTPServiceInterfaceMock_GenerateOTP_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -106,50 +107,55 @@ func (_c *OTPServiceInterfaceMock_GenerateOTP_Call) Run(run func(ctx context.Con
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
+		var arg3 *common.OTPConfig
+		if args[3] != nil {
+			arg3 = args[3].(*common.OTPConfig)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
 }
 
-func (_c *OTPServiceInterfaceMock_GenerateOTP_Call) Return(sessionToken string, otpValue string, expirySeconds int64, svcErr *common.ServiceError) *OTPServiceInterfaceMock_GenerateOTP_Call {
+func (_c *OTPServiceInterfaceMock_GenerateOTP_Call) Return(sessionToken string, otpValue string, expirySeconds int64, svcErr *common0.ServiceError) *OTPServiceInterfaceMock_GenerateOTP_Call {
 	_c.Call.Return(sessionToken, otpValue, expirySeconds, svcErr)
 	return _c
 }
 
-func (_c *OTPServiceInterfaceMock_GenerateOTP_Call) RunAndReturn(run func(ctx context.Context, recipient string, recipientAttr string) (string, string, int64, *common.ServiceError)) *OTPServiceInterfaceMock_GenerateOTP_Call {
+func (_c *OTPServiceInterfaceMock_GenerateOTP_Call) RunAndReturn(run func(ctx context.Context, recipient string, recipientAttr string, otpCfg *common.OTPConfig) (string, string, int64, *common0.ServiceError)) *OTPServiceInterfaceMock_GenerateOTP_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // VerifyOTP provides a mock function for the type OTPServiceInterfaceMock
-func (_mock *OTPServiceInterfaceMock) VerifyOTP(ctx context.Context, request common0.VerifyOTPDTO) (*common0.VerifyOTPResultDTO, *common.ServiceError) {
+func (_mock *OTPServiceInterfaceMock) VerifyOTP(ctx context.Context, request common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *common0.ServiceError) {
 	ret := _mock.Called(ctx, request)
 
 	if len(ret) == 0 {
 		panic("no return value specified for VerifyOTP")
 	}
 
-	var r0 *common0.VerifyOTPResultDTO
-	var r1 *common.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, common0.VerifyOTPDTO) (*common0.VerifyOTPResultDTO, *common.ServiceError)); ok {
+	var r0 *common.VerifyOTPResultDTO
+	var r1 *common0.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *common0.ServiceError)); ok {
 		return returnFunc(ctx, request)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, common0.VerifyOTPDTO) *common0.VerifyOTPResultDTO); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.VerifyOTPDTO) *common.VerifyOTPResultDTO); ok {
 		r0 = returnFunc(ctx, request)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*common0.VerifyOTPResultDTO)
+			r0 = ret.Get(0).(*common.VerifyOTPResultDTO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, common0.VerifyOTPDTO) *common.ServiceError); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, common.VerifyOTPDTO) *common0.ServiceError); ok {
 		r1 = returnFunc(ctx, request)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*common.ServiceError)
+			r1 = ret.Get(1).(*common0.ServiceError)
 		}
 	}
 	return r0, r1
@@ -162,20 +168,20 @@ type OTPServiceInterfaceMock_VerifyOTP_Call struct {
 
 // VerifyOTP is a helper method to define mock.On call
 //   - ctx context.Context
-//   - request common0.VerifyOTPDTO
+//   - request common.VerifyOTPDTO
 func (_e *OTPServiceInterfaceMock_Expecter) VerifyOTP(ctx interface{}, request interface{}) *OTPServiceInterfaceMock_VerifyOTP_Call {
 	return &OTPServiceInterfaceMock_VerifyOTP_Call{Call: _e.mock.On("VerifyOTP", ctx, request)}
 }
 
-func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) Run(run func(ctx context.Context, request common0.VerifyOTPDTO)) *OTPServiceInterfaceMock_VerifyOTP_Call {
+func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) Run(run func(ctx context.Context, request common.VerifyOTPDTO)) *OTPServiceInterfaceMock_VerifyOTP_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 common0.VerifyOTPDTO
+		var arg1 common.VerifyOTPDTO
 		if args[1] != nil {
-			arg1 = args[1].(common0.VerifyOTPDTO)
+			arg1 = args[1].(common.VerifyOTPDTO)
 		}
 		run(
 			arg0,
@@ -185,12 +191,12 @@ func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) Run(run func(ctx context.Conte
 	return _c
 }
 
-func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) Return(verifyOTPResultDTO *common0.VerifyOTPResultDTO, serviceError *common.ServiceError) *OTPServiceInterfaceMock_VerifyOTP_Call {
+func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) Return(verifyOTPResultDTO *common.VerifyOTPResultDTO, serviceError *common0.ServiceError) *OTPServiceInterfaceMock_VerifyOTP_Call {
 	_c.Call.Return(verifyOTPResultDTO, serviceError)
 	return _c
 }
 
-func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) RunAndReturn(run func(ctx context.Context, request common0.VerifyOTPDTO) (*common0.VerifyOTPResultDTO, *common.ServiceError)) *OTPServiceInterfaceMock_VerifyOTP_Call {
+func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) RunAndReturn(run func(ctx context.Context, request common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *common0.ServiceError)) *OTPServiceInterfaceMock_VerifyOTP_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/notification/common/model.go
+++ b/backend/internal/notification/common/model.go
@@ -55,3 +55,11 @@ type VerifyOTPResultDTO struct {
 	Recipient     string
 	RecipientAttr string
 }
+
+// OTPConfig holds optional OTP generation overrides.
+// Nil pointer = use server default.
+type OTPConfig struct {
+	Length                *int
+	UseNumericOnly        *bool
+	ValidityPeriodSeconds *int
+}

--- a/backend/internal/notification/otp_service.go
+++ b/backend/internal/notification/otp_service.go
@@ -55,7 +55,7 @@ type generatedOTP struct {
 
 // OTPServiceInterface defines the interface for OTP operations.
 type OTPServiceInterface interface {
-	GenerateOTP(ctx context.Context, recipient, recipientAttr string) (
+	GenerateOTP(ctx context.Context, recipient, recipientAttr string, otpCfg *common.OTPConfig) (
 		sessionToken string, otpValue string, expirySeconds int64, svcErr *tidcommon.ServiceError)
 	VerifyOTP(ctx context.Context, request common.VerifyOTPDTO) (
 		*common.VerifyOTPResultDTO, *tidcommon.ServiceError)
@@ -76,7 +76,8 @@ func newOTPService(jwtSvc jwt.JWTServiceInterface) OTPServiceInterface {
 }
 
 // GenerateOTP generates an OTP and session token for the recipient without delivering it.
-func (s *otpService) GenerateOTP(ctx context.Context, recipient, recipientAttr string) (
+// An optional otpCfg override can override the global OTP configuration (pass nil to use defaults).
+func (s *otpService) GenerateOTP(ctx context.Context, recipient, recipientAttr string, otpCfg *common.OTPConfig) (
 	string, string, int64, *tidcommon.ServiceError) {
 	logger := s.logger
 
@@ -85,7 +86,7 @@ func (s *otpService) GenerateOTP(ctx context.Context, recipient, recipientAttr s
 		return "", "", 0, &ErrorInvalidRecipient
 	}
 
-	otp, err := s.generateOTP()
+	otp, err := s.generateOTP(otpCfg)
 	if err != nil {
 		logger.Error(ctx, "Failed to generate OTP", log.Error(err))
 		return "", "", 0, &tidcommon.InternalServerError
@@ -104,7 +105,7 @@ func (s *otpService) GenerateOTP(ctx context.Context, recipient, recipientAttr s
 		return "", "", 0, &tidcommon.InternalServerError
 	}
 
-	expirySeconds := s.getOTPValidityPeriodInMillis() / 1000
+	expirySeconds := s.getOTPValidityPeriodInMillis(otpCfg) / 1000
 	logger.Debug(ctx, "OTP generated successfully", log.MaskedString("recipient", recipient))
 	return sessionToken, otp.Value, expirySeconds, nil
 }
@@ -161,9 +162,11 @@ func (s *otpService) validateOTPVerifyRequest(request common.VerifyOTPDTO) *tidc
 }
 
 // generateOTP generates a random OTP value based on server configuration.
-func (s *otpService) generateOTP() (generatedOTP, error) {
-	charSet := s.getOTPCharset()
-	length := s.getOTPLength()
+// An optional otpCfg override can override specific fields (length, numeric-only, validity).
+func (s *otpService) generateOTP(otpCfg *common.OTPConfig) (generatedOTP, error) {
+	mergedCfg := s.resolveOTPConfig(otpCfg)
+	charSet := s.getOTPCharset(mergedCfg.UseNumericOnly)
+	length := mergedCfg.Length
 
 	chars := []rune(charSet)
 	result := make([]rune, length)
@@ -176,7 +179,7 @@ func (s *otpService) generateOTP() (generatedOTP, error) {
 	}
 
 	now := time.Now().UnixMilli()
-	validity := s.getOTPValidityPeriodInMillis()
+	validity := int64(mergedCfg.ValidityPeriodSeconds) * 1000
 	return generatedOTP{
 		Value:              string(result),
 		ExpiryTimeInMillis: now + validity,
@@ -233,25 +236,41 @@ func (s *otpService) verifyAndDecodeSessionToken(ctx context.Context, token stri
 }
 
 // resolveOTPConfig returns the effective OTP configuration for this otpService.
-// This is the single point of config access; future callers can pass flow-level overrides here.
-func (s *otpService) resolveOTPConfig() config.OTPConfig {
-	return config.GetServerRuntime().Config.Notification.OTP
+// An optional override can override specific fields from the global config (pass nil to use defaults).
+func (s *otpService) resolveOTPConfig(otpCfg *common.OTPConfig) config.OTPConfig {
+	cfg := config.GetServerRuntime().Config.Notification.OTP
+
+	if otpCfg == nil {
+		return cfg
+	}
+
+	if otpCfg.Length != nil {
+		if *otpCfg.Length >= 4 && *otpCfg.Length <= 10 {
+			cfg.Length = *otpCfg.Length
+		}
+	}
+	if otpCfg.UseNumericOnly != nil {
+		cfg.UseNumericOnly = *otpCfg.UseNumericOnly
+	}
+	if otpCfg.ValidityPeriodSeconds != nil {
+		if *otpCfg.ValidityPeriodSeconds >= 30 && *otpCfg.ValidityPeriodSeconds <= 600 {
+			cfg.ValidityPeriodSeconds = *otpCfg.ValidityPeriodSeconds
+		}
+	}
+
+	return cfg
 }
 
 // getOTPCharset returns the character set for OTP generation.
-func (s *otpService) getOTPCharset() string {
-	if s.resolveOTPConfig().UseNumericOnly {
+func (s *otpService) getOTPCharset(useNumericOnly bool) string {
+	if useNumericOnly {
 		return "9245378016"
 	}
 	return "KIGXHOYSPRWCEFMVUQLZDNABJT9245378016"
 }
 
-// getOTPLength returns the configured OTP length.
-func (s *otpService) getOTPLength() int {
-	return s.resolveOTPConfig().Length
-}
-
 // getOTPValidityPeriodInMillis returns the OTP validity period in milliseconds.
-func (s *otpService) getOTPValidityPeriodInMillis() int64 {
-	return int64(s.resolveOTPConfig().ValidityPeriodSeconds) * 1000
+func (s *otpService) getOTPValidityPeriodInMillis(otpCfg *common.OTPConfig) int64 {
+	mergedCfg := s.resolveOTPConfig(otpCfg)
+	return int64(mergedCfg.ValidityPeriodSeconds) * 1000
 }

--- a/backend/internal/notification/otp_service_test.go
+++ b/backend/internal/notification/otp_service_test.go
@@ -102,13 +102,13 @@ func (suite *OTPServiceTestSuite) SetupTest() {
 // --- GenerateOTP tests ---
 
 func (suite *OTPServiceTestSuite) TestGenerateOTP_EmptyRecipient() {
-	_, _, _, err := suite.service.GenerateOTP(context.Background(), "", "mobile_number")
+	_, _, _, err := suite.service.GenerateOTP(context.Background(), "", "mobile_number", nil)
 	suite.NotNil(err)
 	suite.Equal(ErrorInvalidRecipient.Code, err.Code)
 }
 
 func (suite *OTPServiceTestSuite) TestGenerateOTP_WhitespaceRecipient() {
-	_, _, _, err := suite.service.GenerateOTP(context.Background(), "   ", "mobile_number")
+	_, _, _, err := suite.service.GenerateOTP(context.Background(), "   ", "mobile_number", nil)
 	suite.NotNil(err)
 	suite.Equal(ErrorInvalidRecipient.Code, err.Code)
 }
@@ -120,7 +120,7 @@ func (suite *OTPServiceTestSuite) TestGenerateOTP_Success() {
 	).Return("session-token-123", int64(0), (*tidcommon.ServiceError)(nil)).Once()
 
 	sessionToken, otpValue, expirySeconds, err := suite.service.GenerateOTP(
-		context.Background(), "+15559876543", "mobile_number")
+		context.Background(), "+15559876543", "mobile_number", nil)
 
 	suite.Nil(err)
 	suite.Equal("session-token-123", sessionToken)
@@ -143,12 +143,74 @@ func (suite *OTPServiceTestSuite) TestGenerateOTP_JWTError() {
 	).Return("", int64(0), jwtErr).Once()
 
 	sessionToken, otpValue, _, err := suite.service.GenerateOTP(
-		context.Background(), "+15559876543", "mobile_number")
+		context.Background(), "+15559876543", "mobile_number", nil)
 
 	suite.Empty(sessionToken)
 	suite.Empty(otpValue)
 	suite.NotNil(err)
 	suite.Equal(tidcommon.InternalServerError.Code, err.Code)
+}
+
+// --- OTPConfig override tests ---
+
+func (suite *OTPServiceTestSuite) TestGenerateOTP_WithLengthOverride() {
+	length := 8
+	cfg := &common.OTPConfig{Length: &length}
+
+	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything, otpSessionAudience, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything,
+	).Return("session-token-123", int64(0), (*tidcommon.ServiceError)(nil)).Once()
+
+	sessionToken, otpValue, expirySeconds, err := suite.service.GenerateOTP(
+		context.Background(), "+15559876543", "mobile_number", cfg)
+
+	suite.Nil(err)
+	suite.Equal("session-token-123", sessionToken)
+	suite.Len(otpValue, 8)
+	suite.Greater(expirySeconds, int64(0))
+	for _, ch := range otpValue {
+		suite.Contains("9245378016", string(ch))
+	}
+}
+
+func (suite *OTPServiceTestSuite) TestGenerateOTP_WithAlphanumericOverride() {
+	numericOnly := false
+	cfg := &common.OTPConfig{UseNumericOnly: &numericOnly}
+
+	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything, otpSessionAudience, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything,
+	).Return("session-token-123", int64(0), (*tidcommon.ServiceError)(nil)).Once()
+
+	sessionToken, otpValue, expirySeconds, err := suite.service.GenerateOTP(
+		context.Background(), "+15559876543", "mobile_number", cfg)
+
+	suite.Nil(err)
+	suite.Equal("session-token-123", sessionToken)
+	suite.Greater(expirySeconds, int64(0))
+	alphanumericCharset := "KIGXHOYSPRWCEFMVUQLZDNABJT9245378016"
+	for _, ch := range otpValue {
+		suite.Contains(alphanumericCharset, string(ch))
+	}
+}
+
+func (suite *OTPServiceTestSuite) TestGenerateOTP_WithValidityOverride() {
+	validity := 300
+	cfg := &common.OTPConfig{ValidityPeriodSeconds: &validity}
+
+	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything, otpSessionAudience, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything,
+	).Return("session-token-123", int64(0), (*tidcommon.ServiceError)(nil)).Once()
+
+	sessionToken, otpValue, expirySeconds, err := suite.service.GenerateOTP(
+		context.Background(), "+15559876543", "mobile_number", cfg)
+
+	suite.Nil(err)
+	suite.Equal("session-token-123", sessionToken)
+	suite.GreaterOrEqual(expirySeconds, int64(300))
+	suite.Len(otpValue, 6)
 }
 
 // --- VerifyOTP tests ---
@@ -280,4 +342,63 @@ func (suite *OTPServiceTestSuite) TestVerifyOTP_MalformedJWTPayload() {
 func (suite *OTPServiceTestSuite) TestNewOTPService_Constructor() {
 	svc := newOTPService(suite.mockJWTService)
 	suite.NotNil(svc)
+}
+
+// --- resolveOTPConfig tests ---
+
+func (suite *OTPServiceTestSuite) TestResolveOTPConfig_NilOverride() {
+	cfg := suite.service.resolveOTPConfig(nil)
+
+	suite.Equal(6, cfg.Length)
+	suite.True(cfg.UseNumericOnly)
+	suite.Equal(120, cfg.ValidityPeriodSeconds)
+}
+
+func (suite *OTPServiceTestSuite) TestResolveOTPConfig_ValidLength() {
+	length := 8
+	cfg := suite.service.resolveOTPConfig(&common.OTPConfig{Length: &length})
+
+	suite.Equal(8, cfg.Length)
+}
+
+func (suite *OTPServiceTestSuite) TestResolveOTPConfig_InvalidLengthBelowMin() {
+	length := 3
+	cfg := suite.service.resolveOTPConfig(&common.OTPConfig{Length: &length})
+
+	suite.Equal(6, cfg.Length)
+}
+
+func (suite *OTPServiceTestSuite) TestResolveOTPConfig_InvalidLengthAboveMax() {
+	length := 11
+	cfg := suite.service.resolveOTPConfig(&common.OTPConfig{Length: &length})
+
+	suite.Equal(6, cfg.Length)
+}
+
+func (suite *OTPServiceTestSuite) TestResolveOTPConfig_ValidValidity() {
+	validity := 300
+	cfg := suite.service.resolveOTPConfig(&common.OTPConfig{ValidityPeriodSeconds: &validity})
+
+	suite.Equal(300, cfg.ValidityPeriodSeconds)
+}
+
+func (suite *OTPServiceTestSuite) TestResolveOTPConfig_InvalidValidityBelowMin() {
+	validity := 29
+	cfg := suite.service.resolveOTPConfig(&common.OTPConfig{ValidityPeriodSeconds: &validity})
+
+	suite.Equal(120, cfg.ValidityPeriodSeconds)
+}
+
+func (suite *OTPServiceTestSuite) TestResolveOTPConfig_InvalidValidityAboveMax() {
+	validity := 601
+	cfg := suite.service.resolveOTPConfig(&common.OTPConfig{ValidityPeriodSeconds: &validity})
+
+	suite.Equal(120, cfg.ValidityPeriodSeconds)
+}
+
+func (suite *OTPServiceTestSuite) TestResolveOTPConfig_UseNumericOnly() {
+	numericOnly := false
+	cfg := suite.service.resolveOTPConfig(&common.OTPConfig{UseNumericOnly: &numericOnly})
+
+	suite.False(cfg.UseNumericOnly)
 }

--- a/backend/internal/system/utils/value_util.go
+++ b/backend/internal/system/utils/value_util.go
@@ -147,6 +147,24 @@ func ToInt64(v any) (int64, bool) {
 	}
 }
 
+// ToBool attempts to convert a value to bool.
+// Supports bool and string types ("true"/"false"/"1"/"0" etc. via strconv.ParseBool).
+// Returns the bool value and true if successful, or false and false if not convertible.
+func ToBool(v any) (bool, bool) {
+	switch n := v.(type) {
+	case bool:
+		return n, true
+	case string:
+		b, err := strconv.ParseBool(n)
+		if err != nil {
+			return false, false
+		}
+		return b, true
+	default:
+		return false, false
+	}
+}
+
 // SecondsToMinutes converts seconds to minutes and returns as a string.
 func SecondsToMinutes(seconds int64) string {
 	minutes := seconds / 60

--- a/backend/internal/system/utils/value_util_test.go
+++ b/backend/internal/system/utils/value_util_test.go
@@ -125,6 +125,50 @@ func (suite *ValueUtilTestSuite) TestToFloat64_Failure() {
 	}
 }
 
+func (suite *ValueUtilTestSuite) TestToBool_Success() {
+	testCases := []struct {
+		name     string
+		input    interface{}
+		expected bool
+	}{
+		{"bool true", true, true},
+		{"bool false", false, false},
+		{"string true", "true", true},
+		{"string false", "false", false},
+		{"string 1", "1", true},
+		{"string 0", "0", false},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			result, ok := ToBool(tc.input)
+			assert.True(suite.T(), ok)
+			assert.Equal(suite.T(), tc.expected, result)
+		})
+	}
+}
+
+func (suite *ValueUtilTestSuite) TestToBool_Failure() {
+	testCases := []struct {
+		name  string
+		input interface{}
+	}{
+		{"invalid string", "not-a-bool"},
+		{"int", 123},
+		{"float64", float64(1.0)},
+		{"nil", nil},
+		{"slice", []int{1, 2, 3}},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			result, ok := ToBool(tc.input)
+			assert.False(suite.T(), ok)
+			assert.False(suite.T(), result)
+		})
+	}
+}
+
 func (suite *ValueUtilTestSuite) TestSecondsToMinutes() {
 	testCases := []struct {
 		name     string

--- a/backend/tests/mocks/authn/otpmock/OTPAuthnServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/otpmock/OTPAuthnServiceInterface_mock.go
@@ -9,6 +9,7 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 	"github.com/thunder-id/thunderid/internal/authn/common"
+	common1 "github.com/thunder-id/thunderid/internal/notification/common"
 	common0 "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 )
 
@@ -116,8 +117,8 @@ func (_c *OTPAuthnServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(
 }
 
 // GenerateOTP provides a mock function for the type OTPAuthnServiceInterfaceMock
-func (_mock *OTPAuthnServiceInterfaceMock) GenerateOTP(ctx context.Context, recipient string, recipientAttr string) (string, string, int64, *common0.ServiceError) {
-	ret := _mock.Called(ctx, recipient, recipientAttr)
+func (_mock *OTPAuthnServiceInterfaceMock) GenerateOTP(ctx context.Context, recipient string, recipientAttr string, otpCfg *common1.OTPConfig) (string, string, int64, *common0.ServiceError) {
+	ret := _mock.Called(ctx, recipient, recipientAttr, otpCfg)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GenerateOTP")
@@ -127,26 +128,26 @@ func (_mock *OTPAuthnServiceInterfaceMock) GenerateOTP(ctx context.Context, reci
 	var r1 string
 	var r2 int64
 	var r3 *common0.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (string, string, int64, *common0.ServiceError)); ok {
-		return returnFunc(ctx, recipient, recipientAttr)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *common1.OTPConfig) (string, string, int64, *common0.ServiceError)); ok {
+		return returnFunc(ctx, recipient, recipientAttr, otpCfg)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) string); ok {
-		r0 = returnFunc(ctx, recipient, recipientAttr)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *common1.OTPConfig) string); ok {
+		r0 = returnFunc(ctx, recipient, recipientAttr, otpCfg)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) string); ok {
-		r1 = returnFunc(ctx, recipient, recipientAttr)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, *common1.OTPConfig) string); ok {
+		r1 = returnFunc(ctx, recipient, recipientAttr, otpCfg)
 	} else {
 		r1 = ret.Get(1).(string)
 	}
-	if returnFunc, ok := ret.Get(2).(func(context.Context, string, string) int64); ok {
-		r2 = returnFunc(ctx, recipient, recipientAttr)
+	if returnFunc, ok := ret.Get(2).(func(context.Context, string, string, *common1.OTPConfig) int64); ok {
+		r2 = returnFunc(ctx, recipient, recipientAttr, otpCfg)
 	} else {
 		r2 = ret.Get(2).(int64)
 	}
-	if returnFunc, ok := ret.Get(3).(func(context.Context, string, string) *common0.ServiceError); ok {
-		r3 = returnFunc(ctx, recipient, recipientAttr)
+	if returnFunc, ok := ret.Get(3).(func(context.Context, string, string, *common1.OTPConfig) *common0.ServiceError); ok {
+		r3 = returnFunc(ctx, recipient, recipientAttr, otpCfg)
 	} else {
 		if ret.Get(3) != nil {
 			r3 = ret.Get(3).(*common0.ServiceError)
@@ -164,11 +165,12 @@ type OTPAuthnServiceInterfaceMock_GenerateOTP_Call struct {
 //   - ctx context.Context
 //   - recipient string
 //   - recipientAttr string
-func (_e *OTPAuthnServiceInterfaceMock_Expecter) GenerateOTP(ctx interface{}, recipient interface{}, recipientAttr interface{}) *OTPAuthnServiceInterfaceMock_GenerateOTP_Call {
-	return &OTPAuthnServiceInterfaceMock_GenerateOTP_Call{Call: _e.mock.On("GenerateOTP", ctx, recipient, recipientAttr)}
+//   - otpCfg *common1.OTPConfig
+func (_e *OTPAuthnServiceInterfaceMock_Expecter) GenerateOTP(ctx interface{}, recipient interface{}, recipientAttr interface{}, otpCfg interface{}) *OTPAuthnServiceInterfaceMock_GenerateOTP_Call {
+	return &OTPAuthnServiceInterfaceMock_GenerateOTP_Call{Call: _e.mock.On("GenerateOTP", ctx, recipient, recipientAttr, otpCfg)}
 }
 
-func (_c *OTPAuthnServiceInterfaceMock_GenerateOTP_Call) Run(run func(ctx context.Context, recipient string, recipientAttr string)) *OTPAuthnServiceInterfaceMock_GenerateOTP_Call {
+func (_c *OTPAuthnServiceInterfaceMock_GenerateOTP_Call) Run(run func(ctx context.Context, recipient string, recipientAttr string, otpCfg *common1.OTPConfig)) *OTPAuthnServiceInterfaceMock_GenerateOTP_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -182,10 +184,15 @@ func (_c *OTPAuthnServiceInterfaceMock_GenerateOTP_Call) Run(run func(ctx contex
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
+		var arg3 *common1.OTPConfig
+		if args[3] != nil {
+			arg3 = args[3].(*common1.OTPConfig)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -196,7 +203,7 @@ func (_c *OTPAuthnServiceInterfaceMock_GenerateOTP_Call) Return(sessionToken str
 	return _c
 }
 
-func (_c *OTPAuthnServiceInterfaceMock_GenerateOTP_Call) RunAndReturn(run func(ctx context.Context, recipient string, recipientAttr string) (string, string, int64, *common0.ServiceError)) *OTPAuthnServiceInterfaceMock_GenerateOTP_Call {
+func (_c *OTPAuthnServiceInterfaceMock_GenerateOTP_Call) RunAndReturn(run func(ctx context.Context, recipient string, recipientAttr string, otpCfg *common1.OTPConfig) (string, string, int64, *common0.ServiceError)) *OTPAuthnServiceInterfaceMock_GenerateOTP_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/notification/notificationmock/OTPServiceInterface_mock.go
+++ b/backend/tests/mocks/notification/notificationmock/OTPServiceInterface_mock.go
@@ -8,8 +8,8 @@ import (
 	"context"
 
 	mock "github.com/stretchr/testify/mock"
-	common0 "github.com/thunder-id/thunderid/internal/notification/common"
-	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
+	"github.com/thunder-id/thunderid/internal/notification/common"
+	common0 "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 )
 
 // NewOTPServiceInterfaceMock creates a new instance of OTPServiceInterfaceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
@@ -40,8 +40,8 @@ func (_m *OTPServiceInterfaceMock) EXPECT() *OTPServiceInterfaceMock_Expecter {
 }
 
 // GenerateOTP provides a mock function for the type OTPServiceInterfaceMock
-func (_mock *OTPServiceInterfaceMock) GenerateOTP(ctx context.Context, recipient string, recipientAttr string) (string, string, int64, *common.ServiceError) {
-	ret := _mock.Called(ctx, recipient, recipientAttr)
+func (_mock *OTPServiceInterfaceMock) GenerateOTP(ctx context.Context, recipient string, recipientAttr string, otpCfg *common.OTPConfig) (string, string, int64, *common0.ServiceError) {
+	ret := _mock.Called(ctx, recipient, recipientAttr, otpCfg)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GenerateOTP")
@@ -50,30 +50,30 @@ func (_mock *OTPServiceInterfaceMock) GenerateOTP(ctx context.Context, recipient
 	var r0 string
 	var r1 string
 	var r2 int64
-	var r3 *common.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (string, string, int64, *common.ServiceError)); ok {
-		return returnFunc(ctx, recipient, recipientAttr)
+	var r3 *common0.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *common.OTPConfig) (string, string, int64, *common0.ServiceError)); ok {
+		return returnFunc(ctx, recipient, recipientAttr, otpCfg)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) string); ok {
-		r0 = returnFunc(ctx, recipient, recipientAttr)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *common.OTPConfig) string); ok {
+		r0 = returnFunc(ctx, recipient, recipientAttr, otpCfg)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) string); ok {
-		r1 = returnFunc(ctx, recipient, recipientAttr)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, *common.OTPConfig) string); ok {
+		r1 = returnFunc(ctx, recipient, recipientAttr, otpCfg)
 	} else {
 		r1 = ret.Get(1).(string)
 	}
-	if returnFunc, ok := ret.Get(2).(func(context.Context, string, string) int64); ok {
-		r2 = returnFunc(ctx, recipient, recipientAttr)
+	if returnFunc, ok := ret.Get(2).(func(context.Context, string, string, *common.OTPConfig) int64); ok {
+		r2 = returnFunc(ctx, recipient, recipientAttr, otpCfg)
 	} else {
 		r2 = ret.Get(2).(int64)
 	}
-	if returnFunc, ok := ret.Get(3).(func(context.Context, string, string) *common.ServiceError); ok {
-		r3 = returnFunc(ctx, recipient, recipientAttr)
+	if returnFunc, ok := ret.Get(3).(func(context.Context, string, string, *common.OTPConfig) *common0.ServiceError); ok {
+		r3 = returnFunc(ctx, recipient, recipientAttr, otpCfg)
 	} else {
 		if ret.Get(3) != nil {
-			r3 = ret.Get(3).(*common.ServiceError)
+			r3 = ret.Get(3).(*common0.ServiceError)
 		}
 	}
 	return r0, r1, r2, r3
@@ -88,11 +88,12 @@ type OTPServiceInterfaceMock_GenerateOTP_Call struct {
 //   - ctx context.Context
 //   - recipient string
 //   - recipientAttr string
-func (_e *OTPServiceInterfaceMock_Expecter) GenerateOTP(ctx interface{}, recipient interface{}, recipientAttr interface{}) *OTPServiceInterfaceMock_GenerateOTP_Call {
-	return &OTPServiceInterfaceMock_GenerateOTP_Call{Call: _e.mock.On("GenerateOTP", ctx, recipient, recipientAttr)}
+//   - otpCfg *common.OTPConfig
+func (_e *OTPServiceInterfaceMock_Expecter) GenerateOTP(ctx interface{}, recipient interface{}, recipientAttr interface{}, otpCfg interface{}) *OTPServiceInterfaceMock_GenerateOTP_Call {
+	return &OTPServiceInterfaceMock_GenerateOTP_Call{Call: _e.mock.On("GenerateOTP", ctx, recipient, recipientAttr, otpCfg)}
 }
 
-func (_c *OTPServiceInterfaceMock_GenerateOTP_Call) Run(run func(ctx context.Context, recipient string, recipientAttr string)) *OTPServiceInterfaceMock_GenerateOTP_Call {
+func (_c *OTPServiceInterfaceMock_GenerateOTP_Call) Run(run func(ctx context.Context, recipient string, recipientAttr string, otpCfg *common.OTPConfig)) *OTPServiceInterfaceMock_GenerateOTP_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -106,50 +107,55 @@ func (_c *OTPServiceInterfaceMock_GenerateOTP_Call) Run(run func(ctx context.Con
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
+		var arg3 *common.OTPConfig
+		if args[3] != nil {
+			arg3 = args[3].(*common.OTPConfig)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
 }
 
-func (_c *OTPServiceInterfaceMock_GenerateOTP_Call) Return(sessionToken string, otpValue string, expirySeconds int64, svcErr *common.ServiceError) *OTPServiceInterfaceMock_GenerateOTP_Call {
+func (_c *OTPServiceInterfaceMock_GenerateOTP_Call) Return(sessionToken string, otpValue string, expirySeconds int64, svcErr *common0.ServiceError) *OTPServiceInterfaceMock_GenerateOTP_Call {
 	_c.Call.Return(sessionToken, otpValue, expirySeconds, svcErr)
 	return _c
 }
 
-func (_c *OTPServiceInterfaceMock_GenerateOTP_Call) RunAndReturn(run func(ctx context.Context, recipient string, recipientAttr string) (string, string, int64, *common.ServiceError)) *OTPServiceInterfaceMock_GenerateOTP_Call {
+func (_c *OTPServiceInterfaceMock_GenerateOTP_Call) RunAndReturn(run func(ctx context.Context, recipient string, recipientAttr string, otpCfg *common.OTPConfig) (string, string, int64, *common0.ServiceError)) *OTPServiceInterfaceMock_GenerateOTP_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // VerifyOTP provides a mock function for the type OTPServiceInterfaceMock
-func (_mock *OTPServiceInterfaceMock) VerifyOTP(ctx context.Context, request common0.VerifyOTPDTO) (*common0.VerifyOTPResultDTO, *common.ServiceError) {
+func (_mock *OTPServiceInterfaceMock) VerifyOTP(ctx context.Context, request common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *common0.ServiceError) {
 	ret := _mock.Called(ctx, request)
 
 	if len(ret) == 0 {
 		panic("no return value specified for VerifyOTP")
 	}
 
-	var r0 *common0.VerifyOTPResultDTO
-	var r1 *common.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, common0.VerifyOTPDTO) (*common0.VerifyOTPResultDTO, *common.ServiceError)); ok {
+	var r0 *common.VerifyOTPResultDTO
+	var r1 *common0.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *common0.ServiceError)); ok {
 		return returnFunc(ctx, request)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, common0.VerifyOTPDTO) *common0.VerifyOTPResultDTO); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, common.VerifyOTPDTO) *common.VerifyOTPResultDTO); ok {
 		r0 = returnFunc(ctx, request)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*common0.VerifyOTPResultDTO)
+			r0 = ret.Get(0).(*common.VerifyOTPResultDTO)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, common0.VerifyOTPDTO) *common.ServiceError); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, common.VerifyOTPDTO) *common0.ServiceError); ok {
 		r1 = returnFunc(ctx, request)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*common.ServiceError)
+			r1 = ret.Get(1).(*common0.ServiceError)
 		}
 	}
 	return r0, r1
@@ -162,20 +168,20 @@ type OTPServiceInterfaceMock_VerifyOTP_Call struct {
 
 // VerifyOTP is a helper method to define mock.On call
 //   - ctx context.Context
-//   - request common0.VerifyOTPDTO
+//   - request common.VerifyOTPDTO
 func (_e *OTPServiceInterfaceMock_Expecter) VerifyOTP(ctx interface{}, request interface{}) *OTPServiceInterfaceMock_VerifyOTP_Call {
 	return &OTPServiceInterfaceMock_VerifyOTP_Call{Call: _e.mock.On("VerifyOTP", ctx, request)}
 }
 
-func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) Run(run func(ctx context.Context, request common0.VerifyOTPDTO)) *OTPServiceInterfaceMock_VerifyOTP_Call {
+func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) Run(run func(ctx context.Context, request common.VerifyOTPDTO)) *OTPServiceInterfaceMock_VerifyOTP_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 common0.VerifyOTPDTO
+		var arg1 common.VerifyOTPDTO
 		if args[1] != nil {
-			arg1 = args[1].(common0.VerifyOTPDTO)
+			arg1 = args[1].(common.VerifyOTPDTO)
 		}
 		run(
 			arg0,
@@ -185,12 +191,12 @@ func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) Run(run func(ctx context.Conte
 	return _c
 }
 
-func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) Return(verifyOTPResultDTO *common0.VerifyOTPResultDTO, serviceError *common.ServiceError) *OTPServiceInterfaceMock_VerifyOTP_Call {
+func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) Return(verifyOTPResultDTO *common.VerifyOTPResultDTO, serviceError *common0.ServiceError) *OTPServiceInterfaceMock_VerifyOTP_Call {
 	_c.Call.Return(verifyOTPResultDTO, serviceError)
 	return _c
 }
 
-func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) RunAndReturn(run func(ctx context.Context, request common0.VerifyOTPDTO) (*common0.VerifyOTPResultDTO, *common.ServiceError)) *OTPServiceInterfaceMock_VerifyOTP_Call {
+func (_c *OTPServiceInterfaceMock_VerifyOTP_Call) RunAndReturn(run func(ctx context.Context, request common.VerifyOTPDTO) (*common.VerifyOTPResultDTO, *common0.ServiceError)) *OTPServiceInterfaceMock_VerifyOTP_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/execution-properties/OtpProperties.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/execution-properties/OtpProperties.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {FormHelperText, FormLabel, Stack, TextField, Typography} from '@wso2/oxygen-ui';
+import {Checkbox, FormControlLabel, FormHelperText, FormLabel, Stack, TextField, Typography} from '@wso2/oxygen-ui';
 import {useMemo, type ReactNode} from 'react';
 import {useTranslation} from 'react-i18next';
 import type {CommonResourcePropertiesPropsInterface} from './types';
@@ -30,11 +30,59 @@ function OtpProperties({resource, onChange}: CommonResourcePropertiesPropsInterf
     return stepData?.properties ?? {};
   }, [resource]);
 
+  const handleBooleanPropertyChange = (propertyName: string, value: boolean): void => {
+    onChange(`data.properties.${propertyName}`, value, resource);
+  };
+
   return (
     <Stack gap={2}>
       <Typography variant="body2" color="text.secondary">
         {t('flows:core.executions.otp.description')}
       </Typography>
+
+      <div>
+        <FormLabel htmlFor="otp-length">{t('flows:core.executions.otp.otpLength.label')}</FormLabel>
+        <TextField
+          id="otp-length"
+          type="number"
+          value={(properties.otpLength as string) ?? ''}
+          onChange={(e) => onChange('data.properties.otpLength', e.target.value, resource, true)}
+          placeholder={t('flows:core.executions.otp.otpLength.placeholder')}
+          fullWidth
+          size="small"
+          inputProps={{min: 4, max: 10}}
+        />
+        <FormHelperText>{t('flows:core.executions.otp.otpLength.hint')}</FormHelperText>
+      </div>
+
+      <div>
+        <FormLabel htmlFor="otp-validity">{t('flows:core.executions.otp.otpValidityPeriodSeconds.label')}</FormLabel>
+        <TextField
+          id="otp-validity"
+          type="number"
+          value={(properties.otpValidityPeriodSeconds as string) ?? ''}
+          onChange={(e) => onChange('data.properties.otpValidityPeriodSeconds', e.target.value, resource, true)}
+          placeholder={t('flows:core.executions.otp.otpValidityPeriodSeconds.placeholder')}
+          fullWidth
+          size="small"
+          inputProps={{min: 30, max: 600}}
+        />
+        <FormHelperText>{t('flows:core.executions.otp.otpValidityPeriodSeconds.hint')}</FormHelperText>
+      </div>
+
+      <div>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={!!properties.otpUseNumericOnly}
+              onChange={(e) => handleBooleanPropertyChange('otpUseNumericOnly', e.target.checked)}
+              size="small"
+            />
+          }
+          label={t('flows:core.executions.otp.otpUseNumericOnly.label')}
+        />
+        <FormHelperText>{t('flows:core.executions.otp.otpUseNumericOnly.hint')}</FormHelperText>
+      </div>
 
       <div>
         <FormLabel htmlFor="otp-max-attempts">{t('flows:core.executions.otp.maxAttempts.label')}</FormLabel>

--- a/frontend/apps/console/src/features/login-flow/data/executors.json
+++ b/frontend/apps/console/src/features/login-flow/data/executors.json
@@ -48,6 +48,11 @@
             }
           ]
         },
+        "properties": {
+          "otpLength": 6,
+          "otpUseNumericOnly": true,
+          "otpValidityPeriodSeconds": 120
+        },
         "onSuccess": "",
         "onFailure": "",
         "onIncomplete": ""
@@ -71,6 +76,11 @@
         "executor": {
           "name": "OTPExecutor",
           "mode": "verify"
+        },
+        "properties": {
+          "otpLength": 6,
+          "otpUseNumericOnly": true,
+          "otpValidityPeriodSeconds": 120
         },
         "onSuccess": "",
         "onFailure": "",

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -3182,6 +3182,14 @@ const translations = {
 
     // OTP executor
     'core.executions.otp.description': 'Configure the OTP executor settings.',
+    'core.executions.otp.otpLength.label': 'OTP Length',
+    'core.executions.otp.otpLength.placeholder': 'e.g., 6',
+    'core.executions.otp.otpLength.hint': 'Number of characters in the generated OTP (4-10).',
+    'core.executions.otp.otpUseNumericOnly.label': 'Numeric Only',
+    'core.executions.otp.otpUseNumericOnly.hint': 'When enabled, OTP will contain only numeric characters.',
+    'core.executions.otp.otpValidityPeriodSeconds.label': 'Validity Period (seconds)',
+    'core.executions.otp.otpValidityPeriodSeconds.placeholder': 'e.g., 120',
+    'core.executions.otp.otpValidityPeriodSeconds.hint': 'Time in seconds before the OTP expires (30-600).',
     'core.executions.otp.maxAttempts.label': 'Maximum Attempts',
     'core.executions.otp.maxAttempts.placeholder': 'e.g., 3',
     'core.executions.otp.maxAttempts.hint': 'The maximum number of OTP verification attempts before the flow fails.',


### PR DESCRIPTION
### Purpose

Add flow-level OTP configuration overrides (length, character set, validity period) to the OTP executor, allowing flow authors to override the global `notification.otp.*` defaults per flow node.

Design discussion: [#3233](https://github.com/thunder-id/thunderid/issues/3425) — Phase 2 redirected to flow-level, per alignment with @rajithacharith and @ThaminduDilshan. Skips the notification-provider layer and goes direct to flow-level node properties using the existing `propertyKey*` pattern.

### Approach

Three OTP property keys added to `flow/executor/constants.go`:
- `propertyKeyOTPLength` — OTP digit length (`[4, 10]`)
- `propertyKeyOTPUseNumericOnly` — numeric-only charset toggle
- `propertyKeyOTPValidityPeriodSeconds` — validity in seconds (`[30, 600]`)

**Resolution behaviour:**
- Node properties set → use them (full or partial override).
- Node properties unset → fall back to server config.
- Partial node config → use node values where set, server config for the rest.

**Plumbing:**
1. `OTPConfig` struct (pointer fields for partial overrides) added to `notification/common/model.go`, aliased as `notification.OTPConfig`.
2. `SendOTPDTO` gains an `OTPConfigOverride *OTPConfig` field.
3. `resolveOTPConfig()` takes an optional `*OTPConfig` and merges non-nil fields over the global config.
4. `otpExecutor.resolveOTPConfigOverride()` reads NodeProperties and constructs the override; passes it through `otpAuthnService.GenerateOTP()` → `notifOTPService.GenerateOTP()` → `generateOTP()` + accessor methods.
5. Console API path (`authenticationService.SendOTP`) passes `nil` — no overrides on that path.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3425

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable OTP settings for flow steps, including code length, numeric-only mode, and validity period.
  * OTP configuration overrides now apply consistently during code generation and delivery.
  * Added support for converting common boolean values from configuration inputs.

* **Bug Fixes**
  * Invalid OTP configuration values are safely rejected while preserving existing fallback behavior.

* **Tests**
  * Added coverage for valid, invalid, partial, and boundary OTP configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->