### PR TITLE
Add support for importBehaviour Flag for serverconfig import yaml files

### DIFF
--- a/backend/internal/serverconfig/ServerConfigService_mock_test.go
+++ b/backend/internal/serverconfig/ServerConfigService_mock_test.go
@@ -382,16 +382,24 @@ func (_c *ServerConfigServiceMock_ListConfigNames_Call) RunAndReturn(run func(ct
 }
 
 // SetConfig provides a mock function for the type ServerConfigServiceMock
-func (_mock *ServerConfigServiceMock) SetConfig(ctx context.Context, name ConfigName, value json.RawMessage) *common.ServiceError {
-	ret := _mock.Called(ctx, name, value)
+func (_mock *ServerConfigServiceMock) SetConfig(ctx context.Context, name ConfigName, value json.RawMessage, merge ...bool) *common.ServiceError {
+	// bool
+	_va := make([]interface{}, len(merge))
+	for _i := range merge {
+		_va[_i] = merge[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, name, value)
+	_ca = append(_ca, _va...)
+	ret := _mock.Called(_ca...)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SetConfig")
 	}
 
 	var r0 *common.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, ConfigName, json.RawMessage) *common.ServiceError); ok {
-		r0 = returnFunc(ctx, name, value)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ConfigName, json.RawMessage, ...bool) *common.ServiceError); ok {
+		r0 = returnFunc(ctx, name, value, merge...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.ServiceError)
@@ -409,11 +417,13 @@ type ServerConfigServiceMock_SetConfig_Call struct {
 //   - ctx context.Context
 //   - name ConfigName
 //   - value json.RawMessage
-func (_e *ServerConfigServiceMock_Expecter) SetConfig(ctx interface{}, name interface{}, value interface{}) *ServerConfigServiceMock_SetConfig_Call {
-	return &ServerConfigServiceMock_SetConfig_Call{Call: _e.mock.On("SetConfig", ctx, name, value)}
+//   - merge ...bool
+func (_e *ServerConfigServiceMock_Expecter) SetConfig(ctx interface{}, name interface{}, value interface{}, merge ...interface{}) *ServerConfigServiceMock_SetConfig_Call {
+	return &ServerConfigServiceMock_SetConfig_Call{Call: _e.mock.On("SetConfig",
+		append([]interface{}{ctx, name, value}, merge...)...)}
 }
 
-func (_c *ServerConfigServiceMock_SetConfig_Call) Run(run func(ctx context.Context, name ConfigName, value json.RawMessage)) *ServerConfigServiceMock_SetConfig_Call {
+func (_c *ServerConfigServiceMock_SetConfig_Call) Run(run func(ctx context.Context, name ConfigName, value json.RawMessage, merge ...bool)) *ServerConfigServiceMock_SetConfig_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -427,10 +437,19 @@ func (_c *ServerConfigServiceMock_SetConfig_Call) Run(run func(ctx context.Conte
 		if args[2] != nil {
 			arg2 = args[2].(json.RawMessage)
 		}
+		var arg3 []bool
+		variadicArgs := make([]bool, len(args)-3)
+		for i, a := range args[3:] {
+			if a != nil {
+				variadicArgs[i] = a.(bool)
+			}
+		}
+		arg3 = variadicArgs
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3...,
 		)
 	})
 	return _c
@@ -441,7 +460,7 @@ func (_c *ServerConfigServiceMock_SetConfig_Call) Return(serviceError *common.Se
 	return _c
 }
 
-func (_c *ServerConfigServiceMock_SetConfig_Call) RunAndReturn(run func(ctx context.Context, name ConfigName, value json.RawMessage) *common.ServiceError) *ServerConfigServiceMock_SetConfig_Call {
+func (_c *ServerConfigServiceMock_SetConfig_Call) RunAndReturn(run func(ctx context.Context, name ConfigName, value json.RawMessage, merge ...bool) *common.ServiceError) *ServerConfigServiceMock_SetConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/serverconfig/service.go
+++ b/backend/internal/serverconfig/service.go
@@ -21,7 +21,11 @@ type ServerConfigService interface {
 	GetReadOnlyConfig(ctx context.Context, name string) (any, *common.ServiceError)
 	GetWritableConfig(ctx context.Context, name string) (any, *common.ServiceError)
 	GetMergedConfig(ctx context.Context, name string) (any, *common.ServiceError)
-	SetConfig(ctx context.Context, name ConfigName, value json.RawMessage) *common.ServiceError
+	// SetConfig decodes and validates an incoming value against the current layers and persists it to the
+	// writable layer. merge defaults to false when omitted. With merge true, a handler that composes its
+	// writable value keeps the layer's current value as well, rather than composing from the incoming
+	// value alone; importing a collection section therefore adds to it instead of replacing it.
+	SetConfig(ctx context.Context, name ConfigName, value json.RawMessage, merge ...bool) *common.ServiceError
 }
 
 // serverConfigService is the default implementation of ServerConfigService.
@@ -121,10 +125,12 @@ func (s *serverConfigService) getConfigLayer(ctx context.Context, name string,
 	return s.decodeLayer(ctx, configName, handler, raw, layer)
 }
 
-// SetConfig decodes and validates an incoming value against the current layers and persists the raw
-// bytes to the writable layer. A bad incoming value is a client error; the stored bytes are kept as-is.
-func (s *serverConfigService) SetConfig(ctx context.Context,
-	name ConfigName, value json.RawMessage) *common.ServiceError {
+// SetConfig decodes and validates an incoming value against the current layers and persists it to the
+// writable layer. A bad incoming value is a client error; the stored bytes are kept as-is. merge defaults
+// to false when omitted.
+func (s *serverConfigService) SetConfig(ctx context.Context, name ConfigName, value json.RawMessage,
+	merge ...bool) *common.ServiceError {
+	m := len(merge) > 0 && merge[0]
 	handler, svcErr := s.handlerFor(ctx, name)
 	if svcErr != nil {
 		return svcErr
@@ -147,6 +153,26 @@ func (s *serverConfigService) SetConfig(ctx context.Context,
 	readOnly, writable, svcErr := s.decodeLayers(ctx, name, handler, rawLayers)
 	if svcErr != nil {
 		return svcErr
+	}
+
+	// A handler whose section owns a collection composes what the writable layer stores, leaving out
+	// entries the readOnly (declarative) layer already covers. The existing writable value is offered
+	// only when merging, so an import does not drop entries another import wrote.
+	type writableComposer interface {
+		ComposeWritable(readOnly, existing, incoming any) any
+	}
+	if composer, ok := handler.(writableComposer); ok {
+		var existing any
+		if m {
+			existing = writable
+		}
+		incoming = composer.ComposeWritable(readOnly, existing, incoming)
+		value, err = json.Marshal(incoming)
+		if err != nil {
+			s.logger.Error(ctx, "Failed to encode composed server config",
+				log.String("name", string(name)), log.Error(err))
+			return &common.InternalServerError
+		}
 	}
 
 	if err := handler.Validate(incoming, readOnly, writable); err != nil {

--- a/backend/internal/serverconfig/service_test.go
+++ b/backend/internal/serverconfig/service_test.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/thunder-id/thunderid/internal/system/cors"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 )
 
@@ -271,6 +273,107 @@ func (suite *ServiceTestSuite) TestSetConfig_OK() {
 	suite.mockStore.EXPECT().
 		UpsertServerConfig(mock.Anything, ServerConfig{Name: ConfigNameCORS, Value: incomingRaw}).Return(nil)
 	svcErr := suite.service.SetConfig(suite.ctx, ConfigNameCORS, incomingRaw)
+	assert.Nil(suite.T(), svcErr)
+}
+
+// --- writable composition ---
+
+// composingHandler adds the optional writable composition to the suite's handler mock, recording the
+// layers it was handed.
+type composingHandler struct {
+	*ServerConfigHandlerInterfaceMock
+	readOnly, existing, incoming any
+}
+
+func (h *composingHandler) ComposeWritable(readOnly, existing, incoming any) any {
+	h.readOnly, h.existing, h.incoming = readOnly, existing, incoming
+	return mergedVal
+}
+
+// TestSetConfig_RealCORSHandlerSkipsDeclarativeOrigin covers the PUT path (and a replacing import): an
+// incoming document may list origins the declarative layer already allows, and storing them in the
+// writable layer would leave them allowed after the declarative layer stops declaring them.
+func (suite *ServiceTestSuite) TestSetConfig_RealCORSHandlerSkipsDeclarativeOrigin() {
+	suite.mockStore.EXPECT().GetServerConfig(mock.Anything, ConfigNameCORS).
+		Return(storeLayers{ReadOnly: json.RawMessage(`{"allowedOrigins":["https://declared.example.com"]}`)}, nil)
+	var stored json.RawMessage
+	suite.mockStore.EXPECT().UpsertServerConfig(mock.Anything, mock.Anything).
+		Run(func(_ context.Context, cfg ServerConfig) { stored = cfg.Value }).Return(nil)
+
+	svc := newServerConfigService(suite.mockStore,
+		map[ConfigName]ServerConfigHandlerInterface{ConfigNameCORS: cors.OriginHandler{}})
+	svcErr := svc.SetConfig(suite.ctx, ConfigNameCORS,
+		json.RawMessage(`{"allowedOrigins":["https://declared.example.com","https://db.example.com"]}`), false)
+
+	require.Nil(suite.T(), svcErr)
+	assert.JSONEq(suite.T(), `{"allowedOrigins":["https://db.example.com"]}`, string(stored))
+}
+
+// TestSetConfig_RealCORSHandlerReplacesWritable pins the default path as replacing: an origin already in
+// the writable layer and absent from the incoming document is dropped, the same as the PUT API.
+func (suite *ServiceTestSuite) TestSetConfig_RealCORSHandlerReplacesWritable() {
+	suite.mockStore.EXPECT().GetServerConfig(mock.Anything, ConfigNameCORS).
+		Return(storeLayers{Writable: json.RawMessage(`{"allowedOrigins":["https://a.example.com"]}`)}, nil)
+	var stored json.RawMessage
+	suite.mockStore.EXPECT().UpsertServerConfig(mock.Anything, mock.Anything).
+		Run(func(_ context.Context, cfg ServerConfig) { stored = cfg.Value }).Return(nil)
+
+	svc := newServerConfigService(suite.mockStore,
+		map[ConfigName]ServerConfigHandlerInterface{ConfigNameCORS: cors.OriginHandler{}})
+	svcErr := svc.SetConfig(suite.ctx, ConfigNameCORS,
+		json.RawMessage(`{"allowedOrigins":["https://b.example.com"]}`), false)
+
+	require.Nil(suite.T(), svcErr)
+	assert.JSONEq(suite.T(), `{"allowedOrigins":["https://b.example.com"]}`, string(stored))
+}
+
+func (suite *ServiceTestSuite) TestSetConfig_MergeTrue_PersistsHandlerComposition() {
+	handler := &composingHandler{ServerConfigHandlerInterfaceMock: suite.mockHandler}
+	service := newServerConfigService(suite.mockStore,
+		map[ConfigName]ServerConfigHandlerInterface{ConfigNameCORS: handler})
+	suite.mockHandler.EXPECT().Decode(incomingRaw).Return(incomingVal, nil)
+	suite.mockStore.EXPECT().GetServerConfig(mock.Anything, ConfigNameCORS).
+		Return(storeLayers{ReadOnly: declarative, Writable: corsValue}, nil)
+	suite.mockHandler.EXPECT().Decode(declarative).Return(readOnlyVal, nil)
+	suite.mockHandler.EXPECT().Decode(corsValue).Return(writableVal, nil)
+	suite.mockHandler.EXPECT().Validate(mergedVal, readOnlyVal, writableVal).Return(nil)
+	suite.mockStore.EXPECT().UpsertServerConfig(mock.Anything,
+		ServerConfig{Name: ConfigNameCORS, Value: json.RawMessage(`"` + mergedVal + `"`)}).Return(nil)
+	svcErr := service.SetConfig(suite.ctx, ConfigNameCORS, incomingRaw, true)
+	assert.Nil(suite.T(), svcErr)
+	assert.Equal(suite.T(), readOnlyVal, handler.readOnly)
+	assert.Equal(suite.T(), writableVal, handler.existing)
+	assert.Equal(suite.T(), incomingVal, handler.incoming)
+}
+
+// TestSetConfig_MergeTrue_RealCORSHandlerIsAdditive wires the real CORS handler through the service. The
+// composition is duck-typed, so a change to either side of the contract would otherwise revert a merging
+// import to replacing the writable layer without a compile error; only this test fails.
+func (suite *ServiceTestSuite) TestSetConfig_MergeTrue_RealCORSHandlerIsAdditive() {
+	suite.mockStore.EXPECT().GetServerConfig(mock.Anything, ConfigNameCORS).
+		Return(storeLayers{Writable: json.RawMessage(`{"allowedOrigins":["https://a.example.com"]}`)}, nil)
+	var stored json.RawMessage
+	suite.mockStore.EXPECT().UpsertServerConfig(mock.Anything, mock.Anything).
+		Run(func(_ context.Context, cfg ServerConfig) { stored = cfg.Value }).Return(nil)
+
+	svc := newServerConfigService(suite.mockStore,
+		map[ConfigName]ServerConfigHandlerInterface{ConfigNameCORS: cors.OriginHandler{}})
+	svcErr := svc.SetConfig(suite.ctx, ConfigNameCORS,
+		json.RawMessage(`{"allowedOrigins":["https://b.example.com"]}`), true)
+
+	require.Nil(suite.T(), svcErr)
+	assert.JSONEq(suite.T(), `{"allowedOrigins":["https://a.example.com","https://b.example.com"]}`, string(stored))
+}
+
+// A handler that does not compose its writable value stores the incoming value regardless of merge.
+func (suite *ServiceTestSuite) TestSetConfig_MergeTrue_HandlerWithoutComposition() {
+	suite.mockHandler.EXPECT().Decode(incomingRaw).Return(incomingVal, nil)
+	suite.mockStore.EXPECT().GetServerConfig(mock.Anything, ConfigNameCORS).Return(storeLayers{}, nil)
+	suite.mockHandler.EXPECT().Decode(json.RawMessage(nil)).Return(nil, nil)
+	suite.mockHandler.EXPECT().Validate(incomingVal, nil, nil).Return(nil)
+	suite.mockStore.EXPECT().UpsertServerConfig(mock.Anything,
+		ServerConfig{Name: ConfigNameCORS, Value: incomingRaw}).Return(nil)
+	svcErr := suite.service.SetConfig(suite.ctx, ConfigNameCORS, incomingRaw, true)
 	assert.Nil(suite.T(), svcErr)
 }
 

--- a/backend/internal/system/cors/origin_handler.go
+++ b/backend/internal/system/cors/origin_handler.go
@@ -34,6 +34,29 @@ func (OriginHandler) Validate(incoming, _, _ any) error {
 	return Validate(cfg.AllowedOrigins)
 }
 
+// ComposeWritable builds the value to store in the writable layer. Origins the read-only (declarative)
+// layer already allows are left out: they need no writable entry, and keeping one would leave the origin
+// allowed even after the declarative layer stops declaring it. A non-nil existing (the layer's current
+// value, offered on a merging import) is kept and the incoming origins are added to it, so an import
+// cannot revoke origins another import registered.
+func (h OriginHandler) ComposeWritable(readOnly, existing, incoming any) any {
+	declared := make(map[string]struct{})
+	ro, _ := readOnly.(OriginConfig)
+	for _, e := range ro.AllowedOrigins {
+		declared[entryKey(e)] = struct{}{}
+	}
+
+	merged, _ := h.Merge(existing, incoming).(OriginConfig)
+	out := make(OriginEntries, 0, len(merged.AllowedOrigins))
+	for _, e := range merged.AllowedOrigins {
+		if _, dup := declared[entryKey(e)]; dup {
+			continue
+		}
+		out = append(out, e)
+	}
+	return OriginConfig{AllowedOrigins: out}
+}
+
 // Merge combines read-only and writable origins, de-duplicated with read-only entries first.
 func (OriginHandler) Merge(readOnly, writable any) any {
 	seen := make(map[string]struct{})

--- a/backend/internal/system/cors/origin_handler_test.go
+++ b/backend/internal/system/cors/origin_handler_test.go
@@ -106,6 +106,42 @@ func (suite *OriginHandlerTestSuite) TestMergeRegexEntryMarshals() {
 		suite.merge(`[{"regex":"^https://x$"}]`, ""))
 }
 
+// --- ComposeWritable ---
+
+func (suite *OriginHandlerTestSuite) composeWritable(readOnly, existing, incoming string) string {
+	composed := OriginHandler{}.ComposeWritable(suite.decode(readOnly), suite.decode(existing),
+		suite.decode(incoming))
+	out, err := json.Marshal(composed)
+	suite.Require().NoError(err)
+	return string(out)
+}
+
+func (suite *OriginHandlerTestSuite) TestComposeWritableKeepsExistingOrigins() {
+	assert.Equal(suite.T(), `{"allowedOrigins":["https://kept.example.com","https://imported.example.com"]}`,
+		suite.composeWritable("", `["https://kept.example.com"]`, `["https://imported.example.com"]`))
+}
+
+// A nil existing is how a replacing write is composed: the current writable value is not offered, so only
+// the incoming origins survive.
+func (suite *OriginHandlerTestSuite) TestComposeWritableNilExistingDropsCurrentOrigins() {
+	composed := OriginHandler{}.ComposeWritable(suite.decode(""), nil,
+		suite.decode(`["https://imported.example.com"]`))
+	out, err := json.Marshal(composed)
+	suite.Require().NoError(err)
+	assert.Equal(suite.T(), `{"allowedOrigins":["https://imported.example.com"]}`, string(out))
+}
+
+func (suite *OriginHandlerTestSuite) TestComposeWritableSkipsDeclarativeOrigins() {
+	assert.Equal(suite.T(), `{"allowedOrigins":[]}`,
+		suite.composeWritable(`["https://declarative.example.com"]`, "", `["https://declarative.example.com"]`))
+}
+
+func (suite *OriginHandlerTestSuite) TestComposeWritableFlattensExistingShadowCopies() {
+	assert.Equal(suite.T(), `{"allowedOrigins":["https://db.example.com"]}`,
+		suite.composeWritable(`["https://declarative.example.com"]`,
+			`["https://declarative.example.com","https://db.example.com"]`, `["https://db.example.com"]`))
+}
+
 // --- Decode ---
 
 func (suite *OriginHandlerTestSuite) TestDecodeEmptyYieldsEmptyAllowedOrigins() {

--- a/backend/internal/system/importer/server_config_import.go
+++ b/backend/internal/system/importer/server_config_import.go
@@ -17,19 +17,29 @@ import (
 // serverConfigAdapter is the subset of the server-config service used to import a section's value into
 // the writable (db) layer.
 type serverConfigAdapter interface {
-	SetConfig(ctx context.Context, name serverconfig.ConfigName, value json.RawMessage) *common.ServiceError
+	SetConfig(ctx context.Context, name serverconfig.ConfigName,
+		value json.RawMessage, merge ...bool) *common.ServiceError
 }
 
-// serverConfigDeclarativeYAML is a server-config section document as produced by export: a section name
-// and its value.
+// importBehaviorReplace and importBehaviorMerge are the values a document's importBehavior field can ask
+// for; replace is the default when the field is omitted.
+const (
+	importBehaviorReplace = "replace"
+	importBehaviorMerge   = "merge"
+)
+
+// serverConfigDeclarativeYAML is a server-config section document as produced by export: a section name,
+// its value, and an optional import behavior ("merge"/"replace").
 type serverConfigDeclarativeYAML struct {
-	Name  string    `yaml:"name"`
-	Value yaml.Node `yaml:"value"`
+	Name           string    `yaml:"name"`
+	Value          yaml.Node `yaml:"value"`
+	ImportBehavior string    `yaml:"importBehavior,omitempty"`
 }
 
 // importServerConfig applies a server-config section to the writable layer via SetConfig. The section is
-// identified by name; SetConfig upserts the writable layer and the declarative layer (if any) is left
-// untouched. There is no create/update distinction, so the operation is always reported as an update.
+// identified by name; with importBehavior "merge" the write adds to the current writable value for a
+// section that owns a collection and otherwise replaces it, the same as SetConfig with merge always false.
+// There is no create/update distinction, so the operation is always reported as an update.
 func (s *importService) importServerConfig(ctx context.Context, doc parsedDocument, dryRun bool) ImportItemOutcome {
 	if s.serverConfigService == nil {
 		return unsupportedAdapterOutcome(resourceTypeServerConfig, "server config")
@@ -57,6 +67,18 @@ func (s *importService) importServerConfig(ctx context.Context, doc parsedDocume
 		}
 	}
 
+	// A typo would otherwise silently replace the writable layer and drop entries the document never
+	// mentioned.
+	if b := req.ImportBehavior; b != "" && b != importBehaviorReplace && b != importBehaviorMerge {
+		return ImportItemOutcome{
+			ResourceType: resourceTypeServerConfig,
+			ResourceName: req.Name,
+			Status:       statusFailed,
+			Code:         ErrorInvalidYAMLContent.Code,
+			Message:      `server config importBehavior must be "replace" or "merge"`,
+		}
+	}
+
 	value, err := serverConfigValueToJSON(req.Value)
 	if err != nil {
 		return decodeErrorOutcome(resourceTypeServerConfig, "", req.Name, err)
@@ -66,7 +88,8 @@ func (s *importService) importServerConfig(ctx context.Context, doc parsedDocume
 		return successOutcome(resourceTypeServerConfig, req.Name, req.Name, operationUpdate)
 	}
 
-	if svcErr := s.serverConfigService.SetConfig(ctx, serverconfig.ConfigName(req.Name), value); svcErr != nil {
+	merge := req.ImportBehavior == importBehaviorMerge
+	if svcErr := s.serverConfigService.SetConfig(ctx, serverconfig.ConfigName(req.Name), value, merge); svcErr != nil {
 		return serviceErrorOutcome(resourceTypeServerConfig, req.Name, req.Name, operationUpdate, svcErr)
 	}
 	return successOutcome(resourceTypeServerConfig, req.Name, req.Name, operationUpdate)

--- a/backend/internal/system/importer/server_config_import_test.go
+++ b/backend/internal/system/importer/server_config_import_test.go
@@ -15,21 +15,22 @@ import (
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 )
 
+// fakeServerConfigService records the value and merge flag passed to SetConfig, so tests can assert the
+// importer routed a document's importBehavior to the right merge value.
 type fakeServerConfigService struct {
-	set       map[string]json.RawMessage
+	value     json.RawMessage
+	merge     bool
 	returnErr *common.ServiceError
 }
 
 func (f *fakeServerConfigService) SetConfig(
-	_ context.Context, name serverconfig.ConfigName, value json.RawMessage,
+	_ context.Context, _ serverconfig.ConfigName, value json.RawMessage, merge ...bool,
 ) *common.ServiceError {
 	if f.returnErr != nil {
 		return f.returnErr
 	}
-	if f.set == nil {
-		f.set = map[string]json.RawMessage{}
-	}
-	f.set[string(name)] = value
+	f.value = value
+	f.merge = len(merge) > 0 && merge[0]
 	return nil
 }
 
@@ -55,7 +56,50 @@ func TestImportResources_ServerConfig_SetsWritable(t *testing.T) {
 	assert.Equal(t, statusSuccess, resp.Results[0].Status)
 	assert.Equal(t, resourceTypeServerConfig, resp.Results[0].ResourceType)
 	assert.Equal(t, "cors", resp.Results[0].ResourceName)
-	assert.JSONEq(t, `["https://app.example.com", {"regex":"^https://x$"}]`, string(scSvc.set["cors"]))
+	assert.JSONEq(t, `["https://app.example.com", {"regex":"^https://x$"}]`, string(scSvc.value))
+}
+
+// serverConfigBehaviorDoc builds a cors import document with the given importBehavior line (empty, or
+// "importBehavior: merge\n") inserted before value.
+func serverConfigBehaviorDoc(behaviorYAML string) string {
+	return "resource_type: server_config\nname: cors\n" + behaviorYAML +
+		"value:\n  - \"https://app.example.com\"\n"
+}
+
+func TestImportResources_ServerConfig_BehaviorOmittedDoesNotMerge(t *testing.T) {
+	scSvc := &fakeServerConfigService{}
+	svc := newServerConfigImportService(scSvc)
+
+	resp, err := svc.ImportResources(context.Background(), &ImportRequest{Content: serverConfigBehaviorDoc("")})
+
+	require.Nil(t, err)
+	assert.Equal(t, statusSuccess, resp.Results[0].Status)
+	assert.False(t, scSvc.merge)
+}
+
+func TestImportResources_ServerConfig_BehaviorMergeMerges(t *testing.T) {
+	scSvc := &fakeServerConfigService{}
+	svc := newServerConfigImportService(scSvc)
+
+	resp, err := svc.ImportResources(context.Background(),
+		&ImportRequest{Content: serverConfigBehaviorDoc("importBehavior: merge\n")})
+
+	require.Nil(t, err)
+	assert.Equal(t, statusSuccess, resp.Results[0].Status)
+	assert.True(t, scSvc.merge)
+}
+
+func TestImportResources_ServerConfig_UnknownBehaviorRejected(t *testing.T) {
+	scSvc := &fakeServerConfigService{}
+	svc := newServerConfigImportService(scSvc)
+
+	resp, err := svc.ImportResources(context.Background(),
+		&ImportRequest{Content: serverConfigBehaviorDoc("importBehavior: Merge\n")})
+
+	require.Nil(t, err)
+	assert.Equal(t, statusFailed, resp.Results[0].Status)
+	assert.Equal(t, ErrorInvalidYAMLContent.Code, resp.Results[0].Code)
+	assert.Nil(t, scSvc.value)
 }
 
 func TestImportResources_ServerConfig_DryRunDoesNotWrite(t *testing.T) {
@@ -68,7 +112,7 @@ func TestImportResources_ServerConfig_DryRunDoesNotWrite(t *testing.T) {
 	require.Nil(t, err)
 	require.Len(t, resp.Results, 1)
 	assert.Equal(t, statusSuccess, resp.Results[0].Status)
-	assert.Empty(t, scSvc.set)
+	assert.Nil(t, scSvc.value)
 }
 
 func TestImportResources_ServerConfig_ServiceErrorReported(t *testing.T) {

--- a/backend/tests/mocks/serverconfigmock/ServerConfigService_mock.go
+++ b/backend/tests/mocks/serverconfigmock/ServerConfigService_mock.go
@@ -383,16 +383,24 @@ func (_c *ServerConfigServiceMock_ListConfigNames_Call) RunAndReturn(run func(ct
 }
 
 // SetConfig provides a mock function for the type ServerConfigServiceMock
-func (_mock *ServerConfigServiceMock) SetConfig(ctx context.Context, name serverconfig.ConfigName, value json.RawMessage) *common.ServiceError {
-	ret := _mock.Called(ctx, name, value)
+func (_mock *ServerConfigServiceMock) SetConfig(ctx context.Context, name serverconfig.ConfigName, value json.RawMessage, merge ...bool) *common.ServiceError {
+	// bool
+	_va := make([]interface{}, len(merge))
+	for _i := range merge {
+		_va[_i] = merge[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, name, value)
+	_ca = append(_ca, _va...)
+	ret := _mock.Called(_ca...)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SetConfig")
 	}
 
 	var r0 *common.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, serverconfig.ConfigName, json.RawMessage) *common.ServiceError); ok {
-		r0 = returnFunc(ctx, name, value)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, serverconfig.ConfigName, json.RawMessage, ...bool) *common.ServiceError); ok {
+		r0 = returnFunc(ctx, name, value, merge...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.ServiceError)
@@ -410,11 +418,13 @@ type ServerConfigServiceMock_SetConfig_Call struct {
 //   - ctx context.Context
 //   - name serverconfig.ConfigName
 //   - value json.RawMessage
-func (_e *ServerConfigServiceMock_Expecter) SetConfig(ctx interface{}, name interface{}, value interface{}) *ServerConfigServiceMock_SetConfig_Call {
-	return &ServerConfigServiceMock_SetConfig_Call{Call: _e.mock.On("SetConfig", ctx, name, value)}
+//   - merge ...bool
+func (_e *ServerConfigServiceMock_Expecter) SetConfig(ctx interface{}, name interface{}, value interface{}, merge ...interface{}) *ServerConfigServiceMock_SetConfig_Call {
+	return &ServerConfigServiceMock_SetConfig_Call{Call: _e.mock.On("SetConfig",
+		append([]interface{}{ctx, name, value}, merge...)...)}
 }
 
-func (_c *ServerConfigServiceMock_SetConfig_Call) Run(run func(ctx context.Context, name serverconfig.ConfigName, value json.RawMessage)) *ServerConfigServiceMock_SetConfig_Call {
+func (_c *ServerConfigServiceMock_SetConfig_Call) Run(run func(ctx context.Context, name serverconfig.ConfigName, value json.RawMessage, merge ...bool)) *ServerConfigServiceMock_SetConfig_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -428,10 +438,19 @@ func (_c *ServerConfigServiceMock_SetConfig_Call) Run(run func(ctx context.Conte
 		if args[2] != nil {
 			arg2 = args[2].(json.RawMessage)
 		}
+		var arg3 []bool
+		variadicArgs := make([]bool, len(args)-3)
+		for i, a := range args[3:] {
+			if a != nil {
+				variadicArgs[i] = a.(bool)
+			}
+		}
+		arg3 = variadicArgs
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3...,
 		)
 	})
 	return _c
@@ -442,7 +461,7 @@ func (_c *ServerConfigServiceMock_SetConfig_Call) Return(serviceError *common.Se
 	return _c
 }
 
-func (_c *ServerConfigServiceMock_SetConfig_Call) RunAndReturn(run func(ctx context.Context, name serverconfig.ConfigName, value json.RawMessage) *common.ServiceError) *ServerConfigServiceMock_SetConfig_Call {
+func (_c *ServerConfigServiceMock_SetConfig_Call) RunAndReturn(run func(ctx context.Context, name serverconfig.ConfigName, value json.RawMessage, merge ...bool) *common.ServiceError) *ServerConfigServiceMock_SetConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/build.ps1
+++ b/build.ps1
@@ -1546,6 +1546,7 @@ function Run {
     $devServerConfig = @"
 resource_type: server_config
 name: cors
+importBehavior: merge
 value:
   allowedOrigins:
     - "https://localhost:$GATE_APP_DEFAULT_PORT"

--- a/build.sh
+++ b/build.sh
@@ -1040,6 +1040,7 @@ function run() {
     cat > "$BACKEND_DIR/bootstrap/03-dev-server-configurations.yaml" <<EOF
 resource_type: server_config
 name: cors
+importBehavior: merge
 value:
   allowedOrigins:
     - "https://localhost:$GATE_APP_DEFAULT_PORT"

--- a/docs/content/deployment/configuration.mdx
+++ b/docs/content/deployment/configuration.mdx
@@ -867,7 +867,7 @@ Add origins in either of these ways:
       - "https://app.example.com"
       - regex: '^https://[a-z0-9-]+\.staging\.example\.com(:[0-9]+)?$'
   ```
-- **Runtime** - send the new value to `PUT /server-config/cors`; it is applied immediately and merged with the declarative file:
+- **Runtime** - send the new value to `PUT /server-config/cors`; it is applied immediately and merged with the declarative file. An origin the declarative file already lists is not stored again, so removing it from the file still revokes it:
   ```http
   PUT /server-config/cors
   Content-Type: application/json

--- a/docs/content/guides/declarative-configurations/import-resources.mdx
+++ b/docs/content/guides/declarative-configurations/import-resources.mdx
@@ -180,6 +180,24 @@ Example response:
 
 When import runs with `dryRun=false`, <ProductName /> persists resource changes in runtime stores.
 
+The `server_config` resource type supports an optional `importBehavior` field alongside `name` and `value`:
+
+- `importBehavior`:
+  - Omitted: defaults to `replace`.
+  - `replace`: replaces the writable layer entirely, the same way `PUT /server-config/{name}` does. Use this to remove an entry through import.
+  - `merge`: adds the incoming entries to the writable layer instead of replacing it. Applies only to collection-valued sections, such as the `cors` section's allowed origins.
+
+`importBehavior: merge` has no effect on a section whose value is not a collection. <ProductName /> always replaces that value.
+
+```yaml
+resource_type: server_config
+name: cors
+importBehavior: merge
+value:
+  allowedOrigins:
+    - "https://app.example.com"
+```
+
 When `POST /import/delete` succeeds, <ProductName /> removes the matching declarative YAML file from `config/resources`.
 
 ## Error Handling

--- a/samples/apps/react-api-based-sample/thunderid-config/thunderid-config.yaml
+++ b/samples/apps/react-api-based-sample/thunderid-config/thunderid-config.yaml
@@ -51,6 +51,7 @@ schema: {
 ---
 resource_type: server_config
 name: cors
+importBehavior: merge
 value:
   allowedOrigins:
     - "https://localhost:3000"

--- a/samples/apps/react-sdk-sample/thunderid-config/thunderid-config.yaml
+++ b/samples/apps/react-sdk-sample/thunderid-config/thunderid-config.yaml
@@ -180,6 +180,7 @@ inboundAuthConfig:
 ---
 resource_type: server_config
 name: cors
+importBehavior: merge
 value:
   allowedOrigins:
     - "https://localhost:3000"

--- a/samples/apps/wayfinder-sample/thunderid-config/app-native/thunderid-config.yaml
+++ b/samples/apps/wayfinder-sample/thunderid-config/app-native/thunderid-config.yaml
@@ -1999,6 +1999,7 @@ value:
 resource_type: server_config
 # Allows the Wayfinder web app's browser origin to call the server
 name: cors
+importBehavior: merge
 value:
   allowedOrigins:
     - "http://localhost:5173"

--- a/samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid-config.yaml
+++ b/samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid-config.yaml
@@ -1968,6 +1968,7 @@ value:
 resource_type: server_config
 # Allows the Wayfinder web app's browser origin to call the server
 name: cors
+importBehavior: merge
 value:
   allowedOrigins:
     - "http://localhost:5173"

--- a/tests/e2e/thunderid-config.yaml
+++ b/tests/e2e/thunderid-config.yaml
@@ -20,6 +20,7 @@ resource_type: server_config
 # Allows the sample apps' browser origins to reach the API during E2E tests. CORS origins come only from
 # the server-config "cors" section (no default ships), so the E2E setup imports them here.
 name: cors
+importBehavior: merge
 value:
   allowedOrigins:
     - "https://localhost:3000"


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

Importing a `server_config` bundle always replaced the writable layer wholesale via SetConfig. When two `YAML` bundles each declared allowed origins for the same section, the second import silently dropped every origin the first one added. There was also no way to add origins from an import without stomping on the writable layer. Since the Console's own dev-mode CORS origins live in that same DB row, any later import that includes a `cors` section, such as using the Wayfinder sample via the welcome screen's "Try sample" flow, replaces them, making the console to crash with cors errors, and need to run the bootstrap process again through `make run`. Also there is another issue of running `make run` resetting the CORS list to just the console and gate ports.


<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

- Added an optional `importBehavior` field to server-config declarative documents (`replace`, the default when omitted, or `merge`). Unknown values fail the import instead of silently falling back to replace.
- `serverconfig.SetConfig` takes a variadic `merge ...bool`, defaulting to `false` when omitted, so existing 3-arg call sites (the `PUT /server-config/{name}` handler, the passkey origin sync) keep compiling unchanged.
- A handler can now optionally implement `ComposeWritable(readOnly, existing, incoming any) any` to control what gets stored in the writable layer. `SetConfig` calls it whenever present, passing the current writable value only when `merge` is true, so a replace composes from the incoming value alone and a merge adds to what's already stored.
- Implemented `ComposeWritable` on the CORS `OriginHandler`: merges incoming origins with the existing writable set (when merging) and always excludes origins the declarative (read-only) layer already allows, so a stored origin can't outlive its declarative entry being removed. This dedup now runs on the replace path too, not just merge.
- The importer routes `importBehavior: merge` through `SetConfig(..., true)` and everything else through the default (`false`).
- Added `importBehavior: merge` to every shipped bundle that imports the CORS section (react-sdk-sample, react-api-based-sample, wayfinder app-native/redirect, the E2E config, and the generated dev bootstrap doc in `build.sh`/`build.ps1`), since those are exactly the imports that previously clobbered each other.
- Updated the deployment and import-resources docs to describe `importBehavior` and the declarative-origin dedup on `PUT /server-config/cors`.

### Related Issues
- Fixes #4005

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [x] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * CORS origins imported via server configuration now merge with existing writable origins rather than replacing them.
  * Importing CORS settings continues even when the existing CORS configuration can’t be retrieved or interpreted.
* **Tests**
  * Added test coverage for successful CORS merging and the fallback behavior when existing CORS data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->