### PR TITLE
[Bug-fix] Add nonce generation for oidc auth

### DIFF
--- a/backend/internal/authn/common/model.go
+++ b/backend/internal/authn/common/model.go
@@ -75,11 +75,19 @@ type AuthenticatorReference struct {
 	Timestamp int64 `json:"timestamp"`
 }
 
+// AuthorizationData holds authorization flow parameters exchanged during federated authentication.
+type AuthorizationData struct {
+	// Code is the authorization code received from the identity provider
+	Code string
+	// Nonce is the nonce parameter received from the identity provider (if applicable)
+	Nonce string
+}
+
 // FederatedAuthCredential carries the credential data for federated authentication.
 type FederatedAuthCredential struct {
-	IDPID   string
-	IDPType providers.IDPType
-	Code    string
+	IDPID             string
+	IDPType           providers.IDPType
+	AuthorizationData AuthorizationData
 }
 
 // OpenID4VPCredential carries the verified presentation result to the authn provider.
@@ -101,7 +109,7 @@ type FederatedAuthResult struct {
 // Authenticate performs the full flow (code exchange, claims extraction, internal user lookup).
 // It returns an error only for actual failures; a missing internal user is NOT an error.
 type FederatedAuthenticator interface {
-	Authenticate(ctx context.Context, idpID, code string) (*AuthnResult, *tidcommon.ServiceError)
+	Authenticate(ctx context.Context, idpID string, authzData AuthorizationData) (*AuthnResult, *tidcommon.ServiceError)
 }
 
 // AuthnResult represents the result of an authentication attempt,

--- a/backend/internal/authn/github/service.go
+++ b/backend/internal/authn/github/service.go
@@ -59,7 +59,7 @@ func newGithubOAuthAuthnService(internal authnoauth.OAuthAuthnServiceInterface,
 
 // BuildAuthorizeURL constructs the authorization request URL for GitHub OAuth authentication.
 func (g *githubOAuthAuthnService) BuildAuthorizeURL(
-	ctx context.Context, idpID string) (string, *tidcommon.ServiceError) {
+	ctx context.Context, idpID string) (string, map[string]string, *tidcommon.ServiceError) {
 	return g.internal.BuildAuthorizeURL(ctx, idpID)
 }
 
@@ -151,12 +151,12 @@ func (g *githubOAuthAuthnService) GetOAuthClientConfig(ctx context.Context, idpI
 // Authenticate performs the full GitHub OAuth authentication flow: exchanges the code for a token,
 // fetches user info, and resolves the internal user.
 // A missing internal user is NOT an error — the caller decides how to handle it.
-func (g *githubOAuthAuthnService) Authenticate(ctx context.Context, idpID, code string) (
-	*authncm.AuthnResult, *tidcommon.ServiceError) {
+func (g *githubOAuthAuthnService) Authenticate(ctx context.Context, idpID string,
+	authzData authncm.AuthorizationData) (*authncm.AuthnResult, *tidcommon.ServiceError) {
 	logger := g.logger.With(log.String("idpId", idpID))
 	logger.Debug(ctx, "Performing federated GitHub OAuth authentication")
 
-	tokenResp, svcErr := g.ExchangeCodeForToken(ctx, idpID, code, true)
+	tokenResp, svcErr := g.ExchangeCodeForToken(ctx, idpID, authzData.Code, true)
 	if svcErr != nil {
 		return nil, svcErr
 	}

--- a/backend/internal/authn/github/service_test.go
+++ b/backend/internal/authn/github/service_test.go
@@ -35,6 +35,7 @@ import (
 
 	authncm "github.com/thunder-id/thunderid/internal/authn/common"
 	"github.com/thunder-id/thunderid/internal/authn/oauth"
+	oauth2const "github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/tests/mocks/authn/oauthmock"
@@ -82,11 +83,13 @@ func (suite *GithubOAuthAuthnServiceTestSuite) SetupTest() {
 
 func (suite *GithubOAuthAuthnServiceTestSuite) TestBuildAuthorizeURLSuccess() {
 	expectedURL := "https://github.com/login/oauth/authorize?client_id=test"
-	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, testGithubIDPID).Return(expectedURL, nil)
+	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, testGithubIDPID).
+		Return(expectedURL, map[string]string{oauth2const.RequestParamState: "test-state"}, nil)
 
-	url, err := suite.service.BuildAuthorizeURL(context.Background(), testGithubIDPID)
+	url, metadata, err := suite.service.BuildAuthorizeURL(context.Background(), testGithubIDPID)
 	suite.Nil(err)
 	suite.Equal(expectedURL, url)
+	suite.Equal("test-state", metadata[oauth2const.RequestParamState])
 }
 
 func (suite *GithubOAuthAuthnServiceTestSuite) TestBuildAuthorizeURLError() {
@@ -96,10 +99,12 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestBuildAuthorizeURLError() {
 			Key: "error.test.failed_to_build_url", DefaultValue: "Failed to build URL",
 		},
 	}
-	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, testGithubIDPID).Return("", svcErr)
+	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, testGithubIDPID).
+		Return("", (map[string]string)(nil), svcErr)
 
-	url, err := suite.service.BuildAuthorizeURL(context.Background(), testGithubIDPID)
+	url, metadata, err := suite.service.BuildAuthorizeURL(context.Background(), testGithubIDPID)
 	suite.Empty(url)
+	suite.Nil(metadata)
 	suite.NotNil(err)
 	suite.Equal(svcErr.Code, err.Code)
 }
@@ -416,8 +421,9 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestConstructorAndInjectInternal(
 
 	// test BuildAuthorizeURL delegation
 	expectedURL := "https://github.com/login/oauth/authorize?client_id=test"
-	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, testGithubIDPID).Return(expectedURL, nil)
-	url, err := gsvc.BuildAuthorizeURL(context.Background(), testGithubIDPID)
+	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, testGithubIDPID).
+		Return(expectedURL, map[string]string{oauth2const.RequestParamState: "test-state"}, nil)
+	url, _, err := gsvc.BuildAuthorizeURL(context.Background(), testGithubIDPID)
 	suite.Nil(err)
 	suite.Equal(expectedURL, url)
 
@@ -548,7 +554,8 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestAuthenticateSuccess() {
 			AuthenticatedClaims: map[string]interface{}{"email": "test@example.com"},
 		}, nil)
 
-	result, err := suite.service.Authenticate(context.Background(), testGithubIDPID, code)
+	result, err := suite.service.Authenticate(context.Background(), testGithubIDPID,
+		authncm.AuthorizationData{Code: code})
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Equal("12345", result.Token["sub"])
@@ -565,7 +572,8 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestAuthenticateExchangeCodeError
 	}
 	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testGithubIDPID, code, true).Return(nil, svcErr)
 
-	result, err := suite.service.Authenticate(context.Background(), testGithubIDPID, code)
+	result, err := suite.service.Authenticate(context.Background(), testGithubIDPID,
+		authncm.AuthorizationData{Code: code})
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(svcErr.Code, err.Code)
@@ -584,7 +592,8 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestAuthenticateFetchUserInfoErro
 	suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testGithubIDPID).
 		Return(nil, svcErr).Once()
 
-	result, err := suite.service.Authenticate(context.Background(), testGithubIDPID, code)
+	result, err := suite.service.Authenticate(context.Background(), testGithubIDPID,
+		authncm.AuthorizationData{Code: code})
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal("FETCH-001", err.Code)
@@ -614,7 +623,8 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestAuthenticateSubClaimNotFound(
 	suite.mockOAuthService.On("FetchUserInfoWithClientConfig", mock.Anything, oauthConfig, testAccessToken).
 		Return(userInfo, nil)
 
-	result, err := suite.service.Authenticate(context.Background(), testGithubIDPID, code)
+	result, err := suite.service.Authenticate(context.Background(), testGithubIDPID,
+		authncm.AuthorizationData{Code: code})
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(authncm.ErrorSubClaimNotFound.Code, err.Code)
@@ -644,7 +654,8 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestAuthenticateSubClaimEmptyStri
 	suite.mockOAuthService.On("FetchUserInfoWithClientConfig", mock.Anything, oauthConfig, testAccessToken).
 		Return(userInfo, nil)
 
-	result, err := suite.service.Authenticate(context.Background(), testGithubIDPID, code)
+	result, err := suite.service.Authenticate(context.Background(), testGithubIDPID,
+		authncm.AuthorizationData{Code: code})
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(authncm.ErrorSubClaimNotFound.Code, err.Code)
@@ -674,7 +685,8 @@ func (suite *GithubOAuthAuthnServiceTestSuite) TestAuthenticateSubClaimNonString
 	suite.mockOAuthService.On("FetchUserInfoWithClientConfig", mock.Anything, oauthConfig, testAccessToken).
 		Return(userInfo, nil)
 
-	result, err := suite.service.Authenticate(context.Background(), testGithubIDPID, code)
+	result, err := suite.service.Authenticate(context.Background(), testGithubIDPID,
+		authncm.AuthorizationData{Code: code})
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(authncm.ErrorSubClaimNotFound.Code, err.Code)

--- a/backend/internal/authn/google/service.go
+++ b/backend/internal/authn/google/service.go
@@ -62,7 +62,7 @@ func newGoogleOIDCAuthnService(internal authnoidc.OIDCAuthnServiceInterface,
 
 // BuildAuthorizeURL constructs the authorization request URL for Google OIDC authentication.
 func (g *googleOIDCAuthnService) BuildAuthorizeURL(
-	ctx context.Context, idpID string) (string, *tidcommon.ServiceError) {
+	ctx context.Context, idpID string) (string, map[string]string, *tidcommon.ServiceError) {
 	return g.internal.BuildAuthorizeURL(ctx, idpID)
 }
 
@@ -235,20 +235,26 @@ func (g *googleOIDCAuthnService) GetOAuthClientConfig(ctx context.Context, idpID
 }
 
 // Authenticate performs the full Google OIDC authentication flow: exchanges the code for a token,
-// extracts ID token claims, and resolves the internal user.
+// extracts ID token claims, validates the nonce, and resolves the internal user.
 // A missing internal user is NOT an error — the caller decides how to handle it.
-func (g *googleOIDCAuthnService) Authenticate(ctx context.Context, idpID, code string) (
-	*common.AuthnResult, *tidcommon.ServiceError) {
+func (g *googleOIDCAuthnService) Authenticate(ctx context.Context, idpID string,
+	authzData common.AuthorizationData) (*common.AuthnResult, *tidcommon.ServiceError) {
 	logger := g.logger.With(log.String("idpId", idpID))
 	logger.Debug(ctx, "Performing federated Google OIDC authentication")
 
-	tokenResp, svcErr := g.ExchangeCodeForToken(ctx, idpID, code, true)
+	tokenResp, svcErr := g.ExchangeCodeForToken(ctx, idpID, authzData.Code, true)
 	if svcErr != nil {
 		return nil, svcErr
 	}
 
 	claims, svcErr := g.GetIDTokenClaims(ctx, tokenResp.IDToken)
 	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	// Validate that the ID token nonce matches the server-generated nonce.
+	if svcErr := authnoauth.ValidateNonce(ctx, claims, authzData.Nonce, logger); svcErr != nil {
+		logger.Debug(ctx, "OIDC nonce validation failed")
 		return nil, svcErr
 	}
 

--- a/backend/internal/authn/google/service_test.go
+++ b/backend/internal/authn/google/service_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/authn/common"
 	"github.com/thunder-id/thunderid/internal/authn/oauth"
 	"github.com/thunder-id/thunderid/internal/authn/oidc"
+	oauth2const "github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/tests/mocks/authn/oidcmock"
@@ -46,6 +47,7 @@ const (
 	testGoogleIDPID = "google_idp"
 	testClientID    = "test-client-id"
 	testAuthCode    = "auth_code"
+	testNonceValue  = "test-nonce-value"
 )
 
 type GoogleOIDCAuthnServiceTestSuite struct {
@@ -79,11 +81,16 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) SetupTest() {
 
 func (suite *GoogleOIDCAuthnServiceTestSuite) TestBuildAuthorizeURLSuccess() {
 	expectedURL := "https://accounts.google.com/o/oauth2/v2/auth?client_id=test"
-	suite.mockOIDCService.On("BuildAuthorizeURL", mock.Anything, testGoogleIDPID).Return(expectedURL, nil)
+	suite.mockOIDCService.On("BuildAuthorizeURL", mock.Anything, testGoogleIDPID).
+		Return(expectedURL, map[string]string{
+			oauth2const.RequestParamState: "test-state", oauth2const.RequestParamNonce: "test-nonce",
+		}, nil)
 
-	url, err := suite.service.BuildAuthorizeURL(context.Background(), testGoogleIDPID)
+	url, metadata, err := suite.service.BuildAuthorizeURL(context.Background(), testGoogleIDPID)
 	suite.Nil(err)
 	suite.Equal(expectedURL, url)
+	suite.Equal("test-state", metadata[oauth2const.RequestParamState])
+	suite.Equal("test-nonce", metadata[oauth2const.RequestParamNonce])
 }
 
 func (suite *GoogleOIDCAuthnServiceTestSuite) TestExchangeCodeForTokenSuccess() {
@@ -836,11 +843,12 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestGetOAuthClientConfigFailure() 
 func (suite *GoogleOIDCAuthnServiceTestSuite) TestAuthenticateSuccess() {
 	now := time.Now()
 	validClaims := map[string]interface{}{
-		"iss": Issuer1,
-		"aud": testClientID,
-		"sub": "user123",
-		"exp": float64(now.Add(1 * time.Hour).Unix()),
-		"iat": float64(now.Add(-1 * time.Minute).Unix()),
+		"iss":   Issuer1,
+		"aud":   testClientID,
+		"sub":   "user123",
+		"exp":   float64(now.Add(1 * time.Hour).Unix()),
+		"iat":   float64(now.Add(-1 * time.Minute).Unix()),
+		"nonce": testNonceValue,
 	}
 	idToken := generateTestJWT(validClaims)
 
@@ -868,7 +876,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestAuthenticateSuccess() {
 			AuthenticatedClaims: validClaims,
 		}, nil)
 
-	result, err := suite.service.Authenticate(context.Background(), testGoogleIDPID, testAuthCode)
+	result, err := suite.service.Authenticate(context.Background(), testGoogleIDPID,
+		common.AuthorizationData{Code: testAuthCode, Nonce: testNonceValue})
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Equal("user123", result.Token["sub"])
@@ -879,7 +888,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestAuthenticateExchangeCodeFailur
 	suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, testGoogleIDPID, testAuthCode, false).
 		Return(nil, &tidcommon.ServiceError{Code: "TOKEN-001"})
 
-	result, err := suite.service.Authenticate(context.Background(), testGoogleIDPID, testAuthCode)
+	result, err := suite.service.Authenticate(context.Background(), testGoogleIDPID,
+		common.AuthorizationData{Code: testAuthCode})
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal("TOKEN-001", err.Code)
@@ -916,7 +926,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestAuthenticateGetIDTokenClaimsFa
 	suite.mockOIDCService.On("GetIDTokenClaims", mock.Anything, idToken).
 		Return(nil, &tidcommon.ServiceError{Code: "CLAIMS-001"})
 
-	result, err := suite.service.Authenticate(context.Background(), testGoogleIDPID, testAuthCode)
+	result, err := suite.service.Authenticate(context.Background(), testGoogleIDPID,
+		common.AuthorizationData{Code: testAuthCode})
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal("CLAIMS-001", err.Code)
@@ -925,10 +936,11 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestAuthenticateGetIDTokenClaimsFa
 func (suite *GoogleOIDCAuthnServiceTestSuite) TestAuthenticateMissingSub() {
 	now := time.Now()
 	claimsWithoutSub := map[string]interface{}{
-		"iss": Issuer1,
-		"aud": testClientID,
-		"exp": float64(now.Add(1 * time.Hour).Unix()),
-		"iat": float64(now.Add(-1 * time.Minute).Unix()),
+		"iss":   Issuer1,
+		"aud":   testClientID,
+		"exp":   float64(now.Add(1 * time.Hour).Unix()),
+		"iat":   float64(now.Add(-1 * time.Minute).Unix()),
+		"nonce": testNonceValue,
 	}
 	idToken := generateTestJWT(claimsWithoutSub)
 
@@ -951,7 +963,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestAuthenticateMissingSub() {
 	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).Return(oAuthConfig, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", mock.Anything, idToken).Return(claimsWithoutSub, nil)
 
-	result, err := suite.service.Authenticate(context.Background(), testGoogleIDPID, testAuthCode)
+	result, err := suite.service.Authenticate(context.Background(), testGoogleIDPID,
+		common.AuthorizationData{Code: testAuthCode, Nonce: testNonceValue})
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(common.ErrorSubClaimNotFound.Code, err.Code)
@@ -960,11 +973,12 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestAuthenticateMissingSub() {
 func (suite *GoogleOIDCAuthnServiceTestSuite) TestAuthenticateEmptySub() {
 	now := time.Now()
 	claimsWithEmptySub := map[string]interface{}{
-		"iss": Issuer1,
-		"aud": testClientID,
-		"sub": "",
-		"exp": float64(now.Add(1 * time.Hour).Unix()),
-		"iat": float64(now.Add(-1 * time.Minute).Unix()),
+		"iss":   Issuer1,
+		"aud":   testClientID,
+		"sub":   "",
+		"exp":   float64(now.Add(1 * time.Hour).Unix()),
+		"iat":   float64(now.Add(-1 * time.Minute).Unix()),
+		"nonce": testNonceValue,
 	}
 	idToken := generateTestJWT(claimsWithEmptySub)
 
@@ -987,7 +1001,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestAuthenticateEmptySub() {
 	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).Return(oAuthConfig, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", mock.Anything, idToken).Return(claimsWithEmptySub, nil)
 
-	result, err := suite.service.Authenticate(context.Background(), testGoogleIDPID, testAuthCode)
+	result, err := suite.service.Authenticate(context.Background(), testGoogleIDPID,
+		common.AuthorizationData{Code: testAuthCode, Nonce: testNonceValue})
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(common.ErrorSubClaimNotFound.Code, err.Code)
@@ -996,11 +1011,12 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestAuthenticateEmptySub() {
 func (suite *GoogleOIDCAuthnServiceTestSuite) TestAuthenticateSubNilValue() {
 	now := time.Now()
 	claimsWithNilSub := map[string]interface{}{
-		"iss": Issuer1,
-		"aud": testClientID,
-		"sub": nil,
-		"exp": float64(now.Add(1 * time.Hour).Unix()),
-		"iat": float64(now.Add(-1 * time.Minute).Unix()),
+		"iss":   Issuer1,
+		"aud":   testClientID,
+		"sub":   nil,
+		"exp":   float64(now.Add(1 * time.Hour).Unix()),
+		"iat":   float64(now.Add(-1 * time.Minute).Unix()),
+		"nonce": testNonceValue,
 	}
 	idToken := generateTestJWT(claimsWithNilSub)
 
@@ -1023,7 +1039,8 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestAuthenticateSubNilValue() {
 	suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).Return(oAuthConfig, nil)
 	suite.mockOIDCService.On("GetIDTokenClaims", mock.Anything, idToken).Return(claimsWithNilSub, nil)
 
-	result, err := suite.service.Authenticate(context.Background(), testGoogleIDPID, testAuthCode)
+	result, err := suite.service.Authenticate(context.Background(), testGoogleIDPID,
+		common.AuthorizationData{Code: testAuthCode, Nonce: testNonceValue})
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(common.ErrorSubClaimNotFound.Code, err.Code)
@@ -1255,6 +1272,104 @@ func (suite *GoogleOIDCAuthnServiceTestSuite) TestValidateIDToken_Leeway_IatJust
 	suite.NotNil(err)
 	suite.Equal(oidc.ErrorInvalidIDToken.Code, err.Code)
 	suite.Contains(err.ErrorDescription.DefaultValue, "future")
+}
+
+func (suite *GoogleOIDCAuthnServiceTestSuite) TestAuthenticateNonceValidationErrors() {
+	now := time.Now()
+
+	testCases := []struct {
+		name              string
+		claims            map[string]interface{}
+		authzNonce        string
+		expectedErrorCode string
+	}{
+		{
+			name: "NonceMissingInIDToken",
+			claims: map[string]interface{}{
+				"iss": Issuer1,
+				"aud": testClientID,
+				"sub": "user123",
+				"exp": float64(now.Add(1 * time.Hour).Unix()),
+				"iat": float64(now.Add(-1 * time.Minute).Unix()),
+			},
+			authzNonce:        testNonceValue,
+			expectedErrorCode: tidcommon.InternalServerError.Code,
+		},
+		{
+			name: "NonceEmptyInIDToken",
+			claims: map[string]interface{}{
+				"iss":   Issuer1,
+				"aud":   testClientID,
+				"sub":   "user123",
+				"exp":   float64(now.Add(1 * time.Hour).Unix()),
+				"iat":   float64(now.Add(-1 * time.Minute).Unix()),
+				"nonce": "",
+			},
+			authzNonce:        testNonceValue,
+			expectedErrorCode: tidcommon.InternalServerError.Code,
+		},
+		{
+			name: "NonceMissingInAuthzData",
+			claims: map[string]interface{}{
+				"iss":   Issuer1,
+				"aud":   testClientID,
+				"sub":   "user123",
+				"exp":   float64(now.Add(1 * time.Hour).Unix()),
+				"iat":   float64(now.Add(-1 * time.Minute).Unix()),
+				"nonce": testNonceValue,
+			},
+			authzNonce:        "",
+			expectedErrorCode: tidcommon.InternalServerError.Code,
+		},
+		{
+			name: "NonceMismatch",
+			claims: map[string]interface{}{
+				"iss":   Issuer1,
+				"aud":   testClientID,
+				"sub":   "user123",
+				"exp":   float64(now.Add(1 * time.Hour).Unix()),
+				"iat":   float64(now.Add(-1 * time.Minute).Unix()),
+				"nonce": "server-generated-nonce",
+			},
+			authzNonce:        "different-nonce-value",
+			expectedErrorCode: tidcommon.InternalServerError.Code,
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			suite.mockOIDCService = oidcmock.NewOIDCAuthnServiceInterfaceMock(suite.T())
+			suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
+			suite.service = &googleOIDCAuthnService{
+				internal:   suite.mockOIDCService,
+				jwtService: suite.mockJWTService,
+				logger:     log.GetLogger().With(log.String(log.LoggerKeyComponentName, "GoogleOIDCAuthnService")),
+			}
+
+			idToken := generateTestJWT(tc.claims)
+			tokenResp := &oauth.TokenResponse{
+				AccessToken: "access_token", IDToken: idToken, TokenType: "Bearer",
+			}
+			oAuthConfig := &oauth.OAuthClientConfig{
+				ClientID:       testClientID,
+				ClientSecret:   "test-secret",
+				OAuthEndpoints: oauth.OAuthEndpoints{},
+			}
+
+			suite.mockOIDCService.On("ExchangeCodeForToken", mock.Anything, testGoogleIDPID, testAuthCode, false).
+				Return(tokenResp, nil)
+			suite.mockOIDCService.On("ValidateTokenResponse", mock.Anything, testGoogleIDPID, tokenResp, false).
+				Return(nil)
+			suite.mockOIDCService.On("GetOAuthClientConfig", mock.Anything, testGoogleIDPID).Return(oAuthConfig, nil)
+			suite.mockOIDCService.On("GetIDTokenClaims", mock.Anything, idToken).Return(tc.claims, nil)
+
+			result, svcErr := suite.service.Authenticate(context.Background(), testGoogleIDPID,
+				common.AuthorizationData{Code: testAuthCode, Nonce: tc.authzNonce})
+			suite.Nil(result)
+			suite.NotNil(svcErr)
+			suite.Equal(tc.expectedErrorCode, svcErr.Code)
+		})
+	}
 }
 
 func (suite *GoogleOIDCAuthnServiceTestSuite) TestBuildFederatedAuthResultDelegates() {

--- a/backend/internal/authn/model.go
+++ b/backend/internal/authn/model.go
@@ -30,6 +30,7 @@ type IDPAuthInitData struct {
 type AuthSessionData struct {
 	IDPID   string            `json:"idpId"`
 	IDPType providers.IDPType `json:"idpType"`
+	Nonce   string            `json:"nonce,omitempty"`
 }
 
 // AuthenticationResponseDTO represents the data transfer object for the authentication response.

--- a/backend/internal/authn/oauth/service.go
+++ b/backend/internal/authn/oauth/service.go
@@ -41,13 +41,14 @@ const (
 
 // OAuthAuthnCoreServiceInterface defines the core contract for OAuth based authenticator services.
 type OAuthAuthnCoreServiceInterface interface {
-	BuildAuthorizeURL(ctx context.Context, idpID string) (string, *tidcommon.ServiceError)
+	BuildAuthorizeURL(ctx context.Context, idpID string) (string, map[string]string, *tidcommon.ServiceError)
 	ExchangeCodeForToken(ctx context.Context, idpID, code string, validateResponse bool) (
 		*TokenResponse, *tidcommon.ServiceError)
 	FetchUserInfo(ctx context.Context, idpID, accessToken string) (
 		map[string]interface{}, *tidcommon.ServiceError)
 	GetOAuthClientConfig(ctx context.Context, idpID string) (*OAuthClientConfig, *tidcommon.ServiceError)
-	Authenticate(ctx context.Context, idpID, code string) (*common.AuthnResult, *tidcommon.ServiceError)
+	Authenticate(ctx context.Context, idpID string, authzData common.AuthorizationData) (
+		*common.AuthnResult, *tidcommon.ServiceError)
 	BuildFederatedAuthResult(ctx context.Context, idpID, sub string, claims map[string]interface{}) (
 		*common.AuthnResult, *tidcommon.ServiceError)
 }
@@ -115,17 +116,17 @@ func (s *oAuthAuthnService) GetOAuthClientConfig(ctx context.Context, idpID stri
 
 // BuildAuthorizeURL constructs the authorization request URL for the external identity provider.
 func (s *oAuthAuthnService) BuildAuthorizeURL(
-	ctx context.Context, idpID string) (string, *tidcommon.ServiceError) {
+	ctx context.Context, idpID string) (string, map[string]string, *tidcommon.ServiceError) {
 	logger := s.logger.With(log.String("idpId", idpID))
 	logger.Debug(ctx, "Building authorize URL")
 
 	oAuthClientConfig, svcErr := s.GetOAuthClientConfig(ctx, idpID)
 	if svcErr != nil {
-		return "", svcErr
+		return "", nil, svcErr
 	}
 	if oAuthClientConfig.OAuthEndpoints.AuthorizationEndpoint == "" {
 		logger.Error(ctx, "Authorization endpoint is not configured for the identity provider")
-		return "", &tidcommon.InternalServerError
+		return "", nil, &tidcommon.InternalServerError
 	}
 
 	queryParams := map[string]string{
@@ -144,14 +145,22 @@ func (s *oAuthAuthnService) BuildAuthorizeURL(
 		queryParams[key] = value
 	}
 
+	// Generate a random state parameter for CSRF protection.
+	state := sysutils.GenerateUUID()
+	queryParams[oauth2const.RequestParamState] = state
+
 	authZURL, err := sysutils.GetURIWithQueryParams(oAuthClientConfig.OAuthEndpoints.AuthorizationEndpoint,
 		queryParams)
 	if err != nil {
 		logger.Error(ctx, "Failed to build authorize URL", log.Error(err))
-		return "", &tidcommon.InternalServerError
+		return "", nil, &tidcommon.InternalServerError
 	}
 
-	return authZURL, nil
+	metadata := map[string]string{
+		oauth2const.RequestParamState: state,
+	}
+
+	return authZURL, metadata, nil
 }
 
 // ExchangeCodeForToken exchanges the authorization code for a token with the external identity provider
@@ -304,12 +313,12 @@ func (s *oAuthAuthnService) GetInternalUser(
 // Authenticate performs the full OAuth authentication flow: exchanges the code for a token,
 // fetches user info, extracts the subject claim, and resolves the internal user.
 // A missing internal user is NOT an error — the caller decides how to handle it.
-func (s *oAuthAuthnService) Authenticate(ctx context.Context, idpID, code string) (
-	*common.AuthnResult, *tidcommon.ServiceError) {
+func (s *oAuthAuthnService) Authenticate(ctx context.Context, idpID string,
+	authzData common.AuthorizationData) (*common.AuthnResult, *tidcommon.ServiceError) {
 	logger := s.logger.With(log.String("idpId", idpID))
 	logger.Debug(ctx, "Performing federated OAuth authentication")
 
-	tokenResp, svcErr := s.ExchangeCodeForToken(ctx, idpID, code, true)
+	tokenResp, svcErr := s.ExchangeCodeForToken(ctx, idpID, authzData.Code, true)
 	if svcErr != nil {
 		return nil, svcErr
 	}

--- a/backend/internal/authn/oauth/service_test.go
+++ b/backend/internal/authn/oauth/service_test.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/authn/common"
 	"github.com/thunder-id/thunderid/internal/entityprovider"
+	oauth2const "github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/system/cmodels"
 	"github.com/thunder-id/thunderid/tests/mocks/entityprovidermock"
 	"github.com/thunder-id/thunderid/tests/mocks/httpmock"
@@ -209,7 +210,7 @@ func (suite *OAuthAuthnServiceTestSuite) TestBuildAuthorizeURLSuccess() {
 	}
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpDTO, nil)
 
-	url, err := suite.service.BuildAuthorizeURL(context.Background(), testIDPID)
+	url, metadata, err := suite.service.BuildAuthorizeURL(context.Background(), testIDPID)
 	suite.Nil(err)
 	suite.NotNil(url)
 	suite.Contains(url, "https://example.com/oauth/authorize?")
@@ -217,6 +218,8 @@ func (suite *OAuthAuthnServiceTestSuite) TestBuildAuthorizeURLSuccess() {
 	suite.Contains(url, "client_id=test_client_id")
 	suite.Contains(url, "redirect_uri=https%3A%2F%2Fapp.example.com%2Fcallback")
 	suite.Contains(url, "scope=openid+profile")
+	suite.Contains(url, "state=")
+	suite.NotEmpty(metadata[oauth2const.RequestParamState])
 }
 
 func (suite *OAuthAuthnServiceTestSuite) TestBuildAuthorizeURLSuccessWithAdditionalParams() {
@@ -271,12 +274,14 @@ func (suite *OAuthAuthnServiceTestSuite) TestBuildAuthorizeURLSuccessWithAdditio
 			}
 			suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpDTO, nil)
 
-			url, err := suite.service.BuildAuthorizeURL(context.Background(), testIDPID)
+			url, metadata, err := suite.service.BuildAuthorizeURL(context.Background(), testIDPID)
 			suite.Nil(err)
 			suite.NotNil(url)
 			suite.Contains(url, "https://example.com/oauth/authorize?")
 			suite.Contains(url, "client_id=test_client_id")
 			suite.Contains(url, "redirect_uri=https%3A%2F%2Fapp.example.com%2Fcallback")
+			suite.Contains(url, "state=")
+			suite.NotEmpty(metadata[oauth2const.RequestParamState])
 
 			// Ensure the forbidden string (empty-key value or empty-value key) is not present in the URL
 			suite.NotContains(url, tc.forbiddenStr)
@@ -298,8 +303,9 @@ func (suite *OAuthAuthnServiceTestSuite) TestBuildAuthorizeURLWithError() {
 	}
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(nil, serverErr)
 
-	url, err := suite.service.BuildAuthorizeURL(context.Background(), testIDPID)
+	url, metadata, err := suite.service.BuildAuthorizeURL(context.Background(), testIDPID)
 	suite.Empty(url)
+	suite.Nil(metadata)
 	suite.NotNil(err)
 	suite.Equal(tidcommon.InternalServerError.Code, err.Code)
 }
@@ -709,8 +715,9 @@ func (suite *OAuthAuthnServiceTestSuite) TestBuildAuthorizeURLErrors() {
 			}
 			suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpDTO, nil)
 
-			url, err := suite.service.BuildAuthorizeURL(context.Background(), testIDPID)
+			url, metadata, err := suite.service.BuildAuthorizeURL(context.Background(), testIDPID)
 			suite.Empty(url)
+			suite.Nil(metadata)
 			suite.NotNil(err)
 			suite.Equal(tidcommon.InternalServerError.Code, err.Code)
 		})
@@ -850,7 +857,8 @@ func (suite *OAuthAuthnServiceTestSuite) TestAuthenticateSuccess() {
 	suite.mockHTTPClient.On("Do", mock.Anything).Return(tokenHTTPResp, nil).Once()
 	suite.mockHTTPClient.On("Do", mock.Anything).Return(userInfoHTTPResp, nil).Once()
 
-	result, err := suite.service.Authenticate(context.Background(), testIDPID, "auth_code")
+	result, err := suite.service.Authenticate(context.Background(), testIDPID,
+		common.AuthorizationData{Code: "auth_code"})
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Equal("user_sub_123", result.Token["sub"])
@@ -858,7 +866,7 @@ func (suite *OAuthAuthnServiceTestSuite) TestAuthenticateSuccess() {
 }
 
 func (suite *OAuthAuthnServiceTestSuite) TestAuthenticateTokenExchangeFailure() {
-	result, err := suite.service.Authenticate(context.Background(), testIDPID, "")
+	result, err := suite.service.Authenticate(context.Background(), testIDPID, common.AuthorizationData{})
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(ErrorEmptyAuthorizationCode.Code, err.Code)
@@ -889,7 +897,8 @@ func (suite *OAuthAuthnServiceTestSuite) TestAuthenticateFetchUserInfoFailure() 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, testIDPID).Return(idpDTO, nil)
 	suite.mockHTTPClient.On("Do", mock.Anything).Return(tokenHTTPResp, nil).Once()
 
-	result, err := suite.service.Authenticate(context.Background(), testIDPID, "auth_code")
+	result, err := suite.service.Authenticate(context.Background(), testIDPID,
+		common.AuthorizationData{Code: "auth_code"})
 	suite.Nil(result)
 	suite.NotNil(err)
 }
@@ -958,7 +967,8 @@ func (suite *OAuthAuthnServiceTestSuite) TestAuthenticateMissingSub() {
 			freshHTTPMock.On("Do", mock.Anything).Return(tokenHTTPResp, nil).Once()
 			freshHTTPMock.On("Do", mock.Anything).Return(userInfoHTTPResp, nil).Once()
 
-			result, err := suite.service.Authenticate(context.Background(), testIDPID, "auth_code")
+			result, err := suite.service.Authenticate(context.Background(), testIDPID,
+				common.AuthorizationData{Code: "auth_code"})
 			suite.Nil(result)
 			suite.NotNil(err)
 			suite.Equal(common.ErrorSubClaimNotFound.Code, err.Code)

--- a/backend/internal/authn/oauth/utils.go
+++ b/backend/internal/authn/oauth/utils.go
@@ -165,8 +165,8 @@ func buildUserInfoRequest(ctx context.Context, userInfoEndpoint string, accessTo
 }
 
 // sendUserInfoRequest sends the user info request to the identity provider and processes the response.
-func sendUserInfoRequest(httpReq *http.Request, httpClient httpservice.HTTPClientInterface, logger *log.Logger) (
-	map[string]interface{}, *tidcommon.ServiceError) {
+func sendUserInfoRequest(httpReq *http.Request, httpClient httpservice.HTTPClientInterface,
+	logger *log.Logger) (map[string]interface{}, *tidcommon.ServiceError) {
 	ctx := httpReq.Context()
 	resp, err := httpClient.Do(httpReq)
 	if err != nil {
@@ -217,6 +217,27 @@ func ProcessSubClaim(userInfo map[string]interface{}) {
 		delete(userInfo, "id")
 		return
 	}
+}
+
+// ValidateNonce checks that the nonce in the ID token claims matches the expected nonce
+// from the authorization flow. Returns nil on success or an InternalServerError on mismatch.
+func ValidateNonce(ctx context.Context, claims map[string]interface{}, expectedNonce string,
+	logger *log.Logger) *tidcommon.ServiceError {
+	claimNonce, ok := claims[oauth2const.RequestParamNonce].(string)
+	if !ok || claimNonce == "" {
+		logger.Error(ctx, "Nonce missing in ID token claims")
+		return &tidcommon.InternalServerError
+	}
+	if expectedNonce == "" {
+		logger.Error(ctx, "Nonce expected from authorization flow is missing")
+		return &tidcommon.InternalServerError
+	}
+	if claimNonce != expectedNonce {
+		logger.Error(ctx, "Nonce in ID token claims does not match expected nonce")
+		return &tidcommon.InternalServerError
+	}
+
+	return nil
 }
 
 // GetStringUserClaimValue retrieves a string claim value from the user info map.

--- a/backend/internal/authn/oauth/utils_test.go
+++ b/backend/internal/authn/oauth/utils_test.go
@@ -651,3 +651,61 @@ func (suite *OAuthUtilsTestSuite) TestSendTokenRequestCloseErrorAndDoReturnsResp
 	suite.Nil(got2)
 	suite.NotNil(err2)
 }
+
+func (suite *OAuthUtilsTestSuite) TestValidateNonce() {
+	tests := []struct {
+		name          string
+		claims        map[string]interface{}
+		expectedNonce string
+		expectError   bool
+	}{
+		{
+			name:          "Success",
+			claims:        map[string]interface{}{"nonce": "abc123"},
+			expectedNonce: "abc123",
+			expectError:   false,
+		},
+		{
+			name:          "MissingNonceInClaims",
+			claims:        map[string]interface{}{},
+			expectedNonce: "abc123",
+			expectError:   true,
+		},
+		{
+			name:          "EmptyNonceInClaims",
+			claims:        map[string]interface{}{"nonce": ""},
+			expectedNonce: "abc123",
+			expectError:   true,
+		},
+		{
+			name:          "NonStringNonceInClaims",
+			claims:        map[string]interface{}{"nonce": 12345},
+			expectedNonce: "abc123",
+			expectError:   true,
+		},
+		{
+			name:          "EmptyExpectedNonce",
+			claims:        map[string]interface{}{"nonce": "abc123"},
+			expectedNonce: "",
+			expectError:   true,
+		},
+		{
+			name:          "Mismatch",
+			claims:        map[string]interface{}{"nonce": "abc123"},
+			expectedNonce: "xyz789",
+			expectError:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			err := ValidateNonce(context.Background(), tc.claims, tc.expectedNonce, log.GetLogger())
+			if tc.expectError {
+				suite.NotNil(err)
+				suite.Equal(tidcommon.InternalServerError.Code, err.Code)
+			} else {
+				suite.Nil(err)
+			}
+		})
+	}
+}

--- a/backend/internal/authn/oidc/service.go
+++ b/backend/internal/authn/oidc/service.go
@@ -27,8 +27,10 @@ import (
 
 	authncm "github.com/thunder-id/thunderid/internal/authn/common"
 	authnoauth "github.com/thunder-id/thunderid/internal/authn/oauth"
+	oauth2const "github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	systemutils "github.com/thunder-id/thunderid/internal/system/utils"
 )
 
 const (
@@ -72,10 +74,24 @@ func (s *oidcAuthnService) GetOAuthClientConfig(ctx context.Context, idpID strin
 	return s.internal.GetOAuthClientConfig(ctx, idpID)
 }
 
-// BuildAuthorizeURL constructs the authorization request URL for the external identity provider.
+// BuildAuthorizeURL constructs the authorization request URL for the external identity provider
+// with an OIDC nonce parameter appended.
 func (s *oidcAuthnService) BuildAuthorizeURL(
-	ctx context.Context, idpID string) (string, *tidcommon.ServiceError) {
-	return s.internal.BuildAuthorizeURL(ctx, idpID)
+	ctx context.Context, idpID string) (string, map[string]string, *tidcommon.ServiceError) {
+	authorizeURL, metadata, svcErr := s.internal.BuildAuthorizeURL(ctx, idpID)
+	if svcErr != nil {
+		return "", nil, svcErr
+	}
+
+	nonce := systemutils.GenerateUUID()
+	authorizeURL = authorizeURL + "&nonce=" + nonce
+
+	if metadata == nil {
+		metadata = make(map[string]string)
+	}
+	metadata[oauth2const.RequestParamNonce] = nonce
+
+	return authorizeURL, metadata, nil
 }
 
 // ExchangeCodeForToken exchanges the authorization code for a token with the external identity provider
@@ -192,20 +208,26 @@ func (s *oidcAuthnService) FetchUserInfo(ctx context.Context, idpID, accessToken
 }
 
 // Authenticate performs the full OIDC authentication flow: exchanges the code for a token,
-// extracts ID token claims, and resolves the internal user.
+// extracts ID token claims, validates the nonce, and resolves the internal user.
 // A missing internal user is NOT an error — the caller decides how to handle it.
-func (s *oidcAuthnService) Authenticate(ctx context.Context, idpID, code string) (
-	*authncm.AuthnResult, *tidcommon.ServiceError) {
+func (s *oidcAuthnService) Authenticate(ctx context.Context, idpID string,
+	authzData authncm.AuthorizationData) (*authncm.AuthnResult, *tidcommon.ServiceError) {
 	logger := s.logger.With(log.String("idpId", idpID))
 	logger.Debug(ctx, "Performing federated OIDC authentication")
 
-	tokenResp, svcErr := s.ExchangeCodeForToken(ctx, idpID, code, true)
+	tokenResp, svcErr := s.ExchangeCodeForToken(ctx, idpID, authzData.Code, true)
 	if svcErr != nil {
 		return nil, svcErr
 	}
 
 	claims, svcErr := s.GetIDTokenClaims(ctx, tokenResp.IDToken)
 	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	// Validate that the ID token nonce matches the server-generated nonce.
+	if svcErr := authnoauth.ValidateNonce(ctx, claims, authzData.Nonce, logger); svcErr != nil {
+		logger.Debug(ctx, "OIDC nonce validation failed")
 		return nil, svcErr
 	}
 

--- a/backend/internal/authn/oidc/service_test.go
+++ b/backend/internal/authn/oidc/service_test.go
@@ -30,6 +30,7 @@ import (
 
 	authncm "github.com/thunder-id/thunderid/internal/authn/common"
 	"github.com/thunder-id/thunderid/internal/authn/oauth"
+	oauth2const "github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/tests/mocks/authn/oauthmock"
 	"github.com/thunder-id/thunderid/tests/mocks/jose/jwtmock"
 )
@@ -107,11 +108,14 @@ func (suite *OIDCAuthnServiceTestSuite) TestGetOAuthClientConfigWithoutOpenIDSco
 
 func (suite *OIDCAuthnServiceTestSuite) TestBuildAuthorizeURLSuccess() {
 	expectedURL := "https://example.com/authorize?client_id=test"
-	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, testOIDCIDPID).Return(expectedURL, nil)
+	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, testOIDCIDPID).
+		Return(expectedURL, map[string]string{oauth2const.RequestParamState: "test-state"}, nil)
 
-	url, err := suite.service.BuildAuthorizeURL(context.Background(), testOIDCIDPID)
+	url, metadata, err := suite.service.BuildAuthorizeURL(context.Background(), testOIDCIDPID)
 	suite.Nil(err)
-	suite.Equal(expectedURL, url)
+	suite.Contains(url, expectedURL)
+	suite.NotEmpty(metadata[oauth2const.RequestParamState])
+	suite.NotEmpty(metadata[oauth2const.RequestParamNonce])
 }
 
 func (suite *OIDCAuthnServiceTestSuite) TestBuildAuthorizeURLError() {
@@ -121,10 +125,12 @@ func (suite *OIDCAuthnServiceTestSuite) TestBuildAuthorizeURLError() {
 			Key: "error.test.failed_to_build_url", DefaultValue: "Failed to build URL",
 		},
 	}
-	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, testOIDCIDPID).Return("", svcErr)
+	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, testOIDCIDPID).
+		Return("", (map[string]string)(nil), svcErr)
 
-	url, err := suite.service.BuildAuthorizeURL(context.Background(), testOIDCIDPID)
+	url, metadata, err := suite.service.BuildAuthorizeURL(context.Background(), testOIDCIDPID)
 	suite.Empty(url)
+	suite.Nil(metadata)
 	suite.NotNil(err)
 	suite.Equal(svcErr.Code, err.Code)
 }
@@ -464,8 +470,9 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateSuccess() {
 	suite.service = *cast
 
 	idToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
-		"eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ." +
-		"SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+		"eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0Ijox" +
+		"NTE2MjM5MDIyLCJub25jZSI6InRlc3Qtbm9uY2UtdmFsdWUifQ." +
+		"fake_sig"
 	tokenResp := &oauth.TokenResponse{AccessToken: "access_token", IDToken: idToken, TokenType: "Bearer"}
 	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testOIDCIDPID, "auth_code", false).
 		Return(tokenResp, nil)
@@ -481,7 +488,8 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateSuccess() {
 			AuthenticatedClaims: map[string]interface{}{"sub": "1234567890", "name": "John Doe"},
 		}, nil)
 
-	result, svcErr := suite.service.Authenticate(context.Background(), testOIDCIDPID, "auth_code")
+	result, svcErr := suite.service.Authenticate(context.Background(), testOIDCIDPID,
+		authncm.AuthorizationData{Code: "auth_code", Nonce: "test-nonce-value"})
 	suite.Nil(svcErr)
 	suite.NotNil(result)
 	suite.Equal("1234567890", result.Token["sub"])
@@ -498,8 +506,9 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateWithUserInfoMerge() {
 	suite.service = *cast
 
 	idToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
-		"eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ." +
-		"SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+		"eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0Ijox" +
+		"NTE2MjM5MDIyLCJub25jZSI6InRlc3Qtbm9uY2UtdmFsdWUifQ." +
+		"fake_sig"
 	tokenResp := &oauth.TokenResponse{AccessToken: "access_token", IDToken: idToken, TokenType: "Bearer"}
 	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testOIDCIDPID, "auth_code", false).
 		Return(tokenResp, nil)
@@ -521,7 +530,8 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateWithUserInfoMerge() {
 			AuthenticatedClaims: map[string]interface{}{"email": "john@example.com", "name": "John Doe"},
 		}, nil)
 
-	result, svcErr := suite.service.Authenticate(context.Background(), testOIDCIDPID, "auth_code")
+	result, svcErr := suite.service.Authenticate(context.Background(), testOIDCIDPID,
+		authncm.AuthorizationData{Code: "auth_code", Nonce: "test-nonce-value"})
 	suite.Nil(svcErr)
 	suite.NotNil(result)
 	suite.Equal("john@example.com", result.AuthenticatedClaims["email"])
@@ -538,8 +548,9 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateUserInfoSubMismatch() {
 	suite.service = *cast
 
 	idToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
-		"eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ." +
-		"SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+		"eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0Ijox" +
+		"NTE2MjM5MDIyLCJub25jZSI6InRlc3Qtbm9uY2UtdmFsdWUifQ." +
+		"fake_sig"
 	tokenResp := &oauth.TokenResponse{AccessToken: "access_token", IDToken: idToken, TokenType: "Bearer"}
 	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testOIDCIDPID, "auth_code", false).
 		Return(tokenResp, nil)
@@ -556,7 +567,8 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateUserInfoSubMismatch() {
 		mock.MatchedBy(func(c map[string]interface{}) bool { _, ok := c["email"]; return !ok })).
 		Return(&authncm.AuthnResult{Token: map[string]interface{}{"sub": "1234567890"}}, nil)
 
-	result, svcErr := suite.service.Authenticate(context.Background(), testOIDCIDPID, "auth_code")
+	result, svcErr := suite.service.Authenticate(context.Background(), testOIDCIDPID,
+		authncm.AuthorizationData{Code: "auth_code", Nonce: "test-nonce-value"})
 	suite.Nil(svcErr)
 	suite.NotNil(result)
 	suite.Equal("1234567890", result.Token["sub"])
@@ -574,7 +586,8 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateExchangeCodeError() {
 	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testOIDCIDPID, "bad_code", false).
 		Return(nil, &tidcommon.ServiceError{Code: "TOKEN-ERR"})
 
-	result, svcErr := suite.service.Authenticate(context.Background(), testOIDCIDPID, "bad_code")
+	result, svcErr := suite.service.Authenticate(context.Background(), testOIDCIDPID,
+		authncm.AuthorizationData{Code: "bad_code"})
 	suite.Nil(result)
 	suite.NotNil(svcErr)
 	suite.Equal("TOKEN-ERR", svcErr.Code)
@@ -590,8 +603,8 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateSubClaimNotFound() {
 	suite.service = *cast
 
 	idToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
-		"eyJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9." +
-		"hqWGSaFpvbrXR1LDcB2vlcSBCB0pT5D8N3f7Ox6SaKM"
+		"eyJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjIsIm5vbmNlIjoidGVzdC1ub25jZS12YWx1ZSJ9." +
+		"fake_sig"
 	tokenResp := &oauth.TokenResponse{AccessToken: "access_token", IDToken: idToken, TokenType: "Bearer"}
 	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testOIDCIDPID, "auth_code", false).
 		Return(tokenResp, nil)
@@ -599,7 +612,8 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateSubClaimNotFound() {
 	suite.mockOAuthService.On("GetOAuthClientConfig", mock.Anything, testOIDCIDPID).Return(cfg, nil)
 	suite.mockJWTService.On("VerifyJWTWithJWKS", mock.Anything, idToken, "https://example.com/jwks", "", "").Return(nil)
 
-	result, svcErr := suite.service.Authenticate(context.Background(), testOIDCIDPID, "auth_code")
+	result, svcErr := suite.service.Authenticate(context.Background(), testOIDCIDPID,
+		authncm.AuthorizationData{Code: "auth_code", Nonce: "test-nonce-value"})
 	suite.Nil(result)
 	suite.NotNil(svcErr)
 	suite.Equal(authncm.ErrorSubClaimNotFound.Code, svcErr.Code)
@@ -615,8 +629,9 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateUserInfoFetchError() {
 	suite.service = *cast
 
 	idToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
-		"eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ." +
-		"SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+		"eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0Ijox" +
+		"NTE2MjM5MDIyLCJub25jZSI6InRlc3Qtbm9uY2UtdmFsdWUifQ." +
+		"fake_sig"
 	tokenResp := &oauth.TokenResponse{AccessToken: "access_token", IDToken: idToken, TokenType: "Bearer"}
 	suite.mockOAuthService.On("ExchangeCodeForToken", mock.Anything, testOIDCIDPID, "auth_code", false).
 		Return(tokenResp, nil)
@@ -632,10 +647,112 @@ func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateUserInfoFetchError() {
 	suite.mockOAuthService.On("BuildFederatedAuthResult", mock.Anything, testOIDCIDPID, "1234567890", mock.Anything).
 		Return(&authncm.AuthnResult{Token: map[string]interface{}{"sub": "1234567890"}}, nil)
 
-	result, svcErr := suite.service.Authenticate(context.Background(), testOIDCIDPID, "auth_code")
+	result, svcErr := suite.service.Authenticate(context.Background(), testOIDCIDPID,
+		authncm.AuthorizationData{Code: "auth_code", Nonce: "test-nonce-value"})
 	suite.Nil(svcErr)
 	suite.NotNil(result)
 	suite.Equal("1234567890", result.Token["sub"])
+}
+
+func (suite *OIDCAuthnServiceTestSuite) TestAuthenticateNonceValidation() {
+	// Token with nonce "test-nonce-123".
+	nonceTokenPayload := "eyJzdWIiOiAiMTIzNDU2Nzg5MCIsICJuYW1lIjogIkpvaG4gRG9lIiwg" +
+		"ImlhdCI6IDE1MTYyMzkwMjIsICJub25jZSI6ICJ0ZXN0LW5vbmNlLTEyMyJ9"
+	nonceToken := "eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9." + nonceTokenPayload + ".fake_sig"
+
+	// Token without nonce claim: {"sub":"1234567890","name":"John Doe","iat":1516239022}
+	noNonceToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+		"eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.fake_sig"
+
+	// Token with empty nonce: {"sub":"1234567890","name":"John Doe","iat":1516239022,"nonce":""}
+	emptyNonceToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+		"eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJub25jZSI6IiJ9.fake_sig"
+
+	testCases := []struct {
+		name          string
+		idToken       string
+		authzNonce    string
+		expectSuccess bool
+		expectedError string
+	}{
+		{
+			name:          "MatchingNonce",
+			idToken:       nonceToken,
+			authzNonce:    "test-nonce-123",
+			expectSuccess: true,
+		},
+		{
+			name:          "NonceMissingInIDToken",
+			idToken:       noNonceToken,
+			authzNonce:    "test-nonce-123",
+			expectedError: tidcommon.InternalServerError.Code,
+		},
+		{
+			name:          "NonceEmptyInIDToken",
+			idToken:       emptyNonceToken,
+			authzNonce:    "test-nonce-123",
+			expectedError: tidcommon.InternalServerError.Code,
+		},
+		{
+			name:          "NonceMissingInAuthzData",
+			idToken:       nonceToken,
+			authzNonce:    "",
+			expectedError: tidcommon.InternalServerError.Code,
+		},
+		{
+			name:          "NonceMismatch",
+			idToken:       nonceToken,
+			authzNonce:    "wrong-nonce",
+			expectedError: tidcommon.InternalServerError.Code,
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			suite.mockOAuthService = oauthmock.NewOAuthAuthnServiceInterfaceMock(suite.T())
+			suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
+
+			service := newOIDCAuthnService(suite.mockOAuthService, suite.mockJWTService)
+			cast, ok := service.(*oidcAuthnService)
+			suite.True(ok)
+			suite.service = *cast
+
+			tokenResp := &oauth.TokenResponse{
+				AccessToken: "access_token", IDToken: tc.idToken, TokenType: "Bearer",
+			}
+			suite.mockOAuthService.On("ExchangeCodeForToken",
+				mock.Anything, testOIDCIDPID, "auth_code", false).Return(tokenResp, nil)
+			cfg := &oauth.OAuthClientConfig{
+				OAuthEndpoints: oauth.OAuthEndpoints{JwksEndpoint: "https://example.com/jwks"},
+				Scopes:         []string{"openid"},
+			}
+			suite.mockOAuthService.On("GetOAuthClientConfig",
+				mock.Anything, testOIDCIDPID).Return(cfg, nil)
+			suite.mockJWTService.On("VerifyJWTWithJWKS",
+				mock.Anything, tc.idToken, "https://example.com/jwks", "", "").Return(nil)
+
+			if tc.expectSuccess {
+				suite.mockOAuthService.On("BuildFederatedAuthResult",
+					mock.Anything, testOIDCIDPID, "1234567890", mock.Anything).
+					Return(&authncm.AuthnResult{
+						Token: map[string]interface{}{"sub": "1234567890"},
+					}, nil)
+			}
+
+			result, svcErr := suite.service.Authenticate(context.Background(), testOIDCIDPID,
+				authncm.AuthorizationData{Code: "auth_code", Nonce: tc.authzNonce})
+
+			if tc.expectSuccess {
+				suite.Nil(svcErr)
+				suite.NotNil(result)
+				suite.Equal("1234567890", result.Token["sub"])
+			} else {
+				suite.Nil(result)
+				suite.NotNil(svcErr)
+				suite.Equal(tc.expectedError, svcErr.Code)
+			}
+		})
+	}
 }
 
 func (suite *OIDCAuthnServiceTestSuite) TestBuildFederatedAuthResultDelegates() {

--- a/backend/internal/authn/service.go
+++ b/backend/internal/authn/service.go
@@ -44,6 +44,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/idp"
 	"github.com/thunder-id/thunderid/internal/notification"
 	notifcommon "github.com/thunder-id/thunderid/internal/notification/common"
+	oauth2const "github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
 	"github.com/thunder-id/thunderid/internal/system/log"
@@ -320,16 +321,17 @@ func (as *authenticationService) StartIDPAuthentication(
 
 	// Route to appropriate service based on IDP type
 	var redirectURL string
+	var metadata map[string]string
 	var buildURLErr *tidcommon.ServiceError
 	switch identityProvider.Type {
 	case providers.IDPTypeOAuth:
-		redirectURL, buildURLErr = as.oauthService.BuildAuthorizeURL(ctx, idpID)
+		redirectURL, _, buildURLErr = as.oauthService.BuildAuthorizeURL(ctx, idpID)
 	case providers.IDPTypeOIDC:
-		redirectURL, buildURLErr = as.oidcService.BuildAuthorizeURL(ctx, idpID)
+		redirectURL, metadata, buildURLErr = as.oidcService.BuildAuthorizeURL(ctx, idpID)
 	case providers.IDPTypeGoogle:
-		redirectURL, buildURLErr = as.googleService.BuildAuthorizeURL(ctx, idpID)
+		redirectURL, metadata, buildURLErr = as.googleService.BuildAuthorizeURL(ctx, idpID)
 	case providers.IDPTypeGitHub:
-		redirectURL, buildURLErr = as.githubService.BuildAuthorizeURL(ctx, idpID)
+		redirectURL, _, buildURLErr = as.githubService.BuildAuthorizeURL(ctx, idpID)
 	default:
 		logger.Error(ctx, "Unsupported IDP type", log.String("idpId", idpID),
 			log.String("type", string(identityProvider.Type)))
@@ -340,8 +342,12 @@ func (as *authenticationService) StartIDPAuthentication(
 		return nil, buildURLErr
 	}
 
-	// Generate session token
-	sessionToken, err := as.createSessionToken(ctx, idpID, identityProvider.Type)
+	// Generate session token, embedding the OIDC nonce when present.
+	var nonce string
+	if metadata != nil {
+		nonce = metadata[oauth2const.RequestParamNonce]
+	}
+	sessionToken, err := as.createSessionToken(ctx, idpID, identityProvider.Type, nonce)
 	if err != nil {
 		logger.Error(ctx, "Failed to create session token", log.String("idpId", idpID),
 			log.String("error", err.Error.DefaultValue))
@@ -382,7 +388,10 @@ func (as *authenticationService) FinishIDPAuthentication(ctx context.Context, re
 		"federated": &common.FederatedAuthCredential{
 			IDPID:   sessionData.IDPID,
 			IDPType: sessionData.IDPType,
-			Code:    code,
+			AuthorizationData: common.AuthorizationData{
+				Code:  code,
+				Nonce: sessionData.Nonce,
+			},
 		},
 	}
 	authUser, _, svcErr := as.authnProvider.AuthenticateUser(
@@ -658,11 +667,12 @@ func (as *authenticationService) validateIDPType(ctx context.Context, requestedT
 }
 
 // createSessionToken creates a JWT session token with authentication session data.
-func (as *authenticationService) createSessionToken(ctx context.Context, idpID string, idpType providers.IDPType) (
-	string, *tidcommon.ServiceError) {
+func (as *authenticationService) createSessionToken(ctx context.Context, idpID string,
+	idpType providers.IDPType, nonce string) (string, *tidcommon.ServiceError) {
 	sessionData := AuthSessionData{
 		IDPID:   idpID,
 		IDPType: idpType,
+		Nonce:   nonce,
 	}
 	claims := map[string]interface{}{
 		"auth_data": sessionData,

--- a/backend/internal/authn/service_test.go
+++ b/backend/internal/authn/service_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/authn/passkey"
 	authnprovidermgr "github.com/thunder-id/thunderid/internal/authnprovider/manager"
 	notifcommon "github.com/thunder-id/thunderid/internal/notification/common"
+	oauth2const "github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/template"
@@ -663,7 +664,8 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationOAuthSucc
 	}
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
-	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
+	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, idpID).
+		Return(redirectURL, map[string]string{oauth2const.RequestParamState: "test-state"}, nil)
 	suite.mockJWTService.On("GenerateJWT", mock.Anything, "auth-svc",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
@@ -676,46 +678,52 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationOAuthSucc
 	suite.Equal(testSessionTkn, result.SessionToken)
 }
 
-func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationOIDCSuccess() {
+func (suite *AuthenticationServiceTestSuite) assertStartIDPAuthSuccess(
+	idpType providers.IDPType, redirectURL string, setupBuildURL func(string),
+) {
 	idpID := testIDPID
-	redirectURL := "https://oidc.provider.com/authorize"
-	identityProvider := &providers.IDPDTO{
-		ID:   idpID,
-		Type: providers.IDPTypeOIDC,
-	}
 
-	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
-	suite.mockOIDCService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
+	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).
+		Return(&providers.IDPDTO{ID: idpID, Type: idpType}, nil)
+	setupBuildURL(idpID)
 	suite.mockJWTService.On("GenerateJWT", mock.Anything, "auth-svc",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
 
-	result, err := suite.service.StartIDPAuthentication(context.Background(), providers.IDPTypeOIDC, idpID)
+	result, err := suite.service.StartIDPAuthentication(
+		context.Background(), idpType, idpID)
 
 	suite.Nil(err)
 	suite.NotNil(result)
 	suite.Equal(redirectURL, result.RedirectURL)
 }
 
-func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationGoogleSuccess() {
-	idpID := testIDPID
-	redirectURL := "https://accounts.google.com/o/oauth2/v2/auth"
-	identityProvider := &providers.IDPDTO{
-		ID:   idpID,
-		Type: providers.IDPTypeGoogle,
+func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationOIDCSuccess() {
+	metadata := map[string]string{
+		oauth2const.RequestParamState: "test-state",
+		oauth2const.RequestParamNonce: "test-nonce",
 	}
+	suite.assertStartIDPAuthSuccess(
+		providers.IDPTypeOIDC, "https://oidc.provider.com/authorize",
+		func(idpID string) {
+			suite.mockOIDCService.On("BuildAuthorizeURL", mock.Anything, idpID).
+				Return("https://oidc.provider.com/authorize", metadata, nil)
+		},
+	)
+}
 
-	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
-	suite.mockGoogleService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
-	suite.mockJWTService.On("GenerateJWT", mock.Anything, "auth-svc",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return(testSessionTkn, int64(600), nil)
-
-	result, err := suite.service.StartIDPAuthentication(context.Background(), providers.IDPTypeGoogle, idpID)
-
-	suite.Nil(err)
-	suite.NotNil(result)
-	suite.Equal(redirectURL, result.RedirectURL)
+func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationGoogleSuccess() {
+	metadata := map[string]string{
+		oauth2const.RequestParamState: "test-state",
+		oauth2const.RequestParamNonce: "test-nonce",
+	}
+	suite.assertStartIDPAuthSuccess(
+		providers.IDPTypeGoogle, "https://accounts.google.com/o/oauth2/v2/auth",
+		func(idpID string) {
+			suite.mockGoogleService.On("BuildAuthorizeURL", mock.Anything, idpID).
+				Return("https://accounts.google.com/o/oauth2/v2/auth", metadata, nil)
+		},
+	)
 }
 
 func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationGitHubSuccess() {
@@ -727,7 +735,8 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationGitHubSuc
 	}
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
-	suite.mockGithubService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
+	suite.mockGithubService.On("BuildAuthorizeURL", mock.Anything, idpID).
+		Return(redirectURL, map[string]string{oauth2const.RequestParamState: "test-state"}, nil)
 	suite.mockJWTService.On("GenerateJWT", mock.Anything, "auth-svc",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
@@ -792,7 +801,8 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationCrossType
 	}
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
-	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
+	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, idpID).
+		Return(redirectURL, map[string]string{oauth2const.RequestParamState: "test-state"}, nil)
 	suite.mockJWTService.On("GenerateJWT", mock.Anything, "auth-svc",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(testSessionTkn, int64(600), nil)
@@ -812,7 +822,8 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationJWTGenera
 	}
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
-	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, idpID).Return(redirectURL, nil)
+	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, idpID).
+		Return(redirectURL, map[string]string{oauth2const.RequestParamState: "test-state"}, nil)
 	suite.mockJWTService.On("GenerateJWT", mock.Anything, "auth-svc",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return("", int64(0), &tidcommon.ServiceError{
@@ -1193,7 +1204,8 @@ func (suite *AuthenticationServiceTestSuite) TestStartIDPAuthenticationBuildURLE
 	}
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, idpID).Return(identityProvider, nil)
-	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, idpID).Return("", svcErr)
+	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, idpID).
+		Return("", (map[string]string)(nil), svcErr)
 
 	result, err := suite.service.StartIDPAuthentication(context.Background(), providers.IDPTypeOAuth, idpID)
 

--- a/backend/internal/authnprovider/provider/default_authn_provider.go
+++ b/backend/internal/authnprovider/provider/default_authn_provider.go
@@ -366,7 +366,7 @@ func (p *defaultAuthnProvider) authenticateWithFederated(
 		return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
 			"Missing IDP ID", "The federated credential must include a non-empty IDP ID")
 	}
-	if cred.Code == "" {
+	if cred.AuthorizationData.Code == "" {
 		return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
 			"Missing authorization code", "The federated credential must include a non-empty authorization code")
 	}
@@ -375,7 +375,7 @@ func (p *defaultAuthnProvider) authenticateWithFederated(
 		return nil, newClientError(authnprovidercm.ErrorCodeInvalidRequest,
 			"Unsupported IDP type", "The provided IDP type is not supported for federated authentication")
 	}
-	result, authErr := svc.Authenticate(ctx, cred.IDPID, cred.Code)
+	result, authErr := svc.Authenticate(ctx, cred.IDPID, cred.AuthorizationData)
 	if authErr != nil {
 		if authErr.Type == tidcommon.ClientErrorType {
 			return nil, newClientError(authnprovidercm.ErrorCodeAuthenticationFailed,

--- a/backend/internal/authnprovider/provider/default_authn_provider_test.go
+++ b/backend/internal/authnprovider/provider/default_authn_provider_test.go
@@ -1176,8 +1176,8 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_Federated_MissingID
 
 	credentials := map[string]interface{}{
 		"federated": &authncommon.FederatedAuthCredential{
-			Code:    "auth-code",
-			IDPType: providers.IDPType("google"),
+			IDPType:           providers.IDPType("google"),
+			AuthorizationData: authncommon.AuthorizationData{Code: "auth-code"},
 		},
 	}
 
@@ -1211,9 +1211,9 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_Federated_Unsupport
 
 	credentials := map[string]interface{}{
 		"federated": &authncommon.FederatedAuthCredential{
-			IDPID:   "idp-1",
-			IDPType: providers.IDPType("unsupported"),
-			Code:    "auth-code",
+			IDPID:             "idp-1",
+			IDPType:           providers.IDPType("unsupported"),
+			AuthorizationData: authncommon.AuthorizationData{Code: "auth-code"},
 		},
 	}
 
@@ -1287,7 +1287,8 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_Passkey_AuthFailed(
 
 func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_Federated_Success() {
 	fedToken := map[string]interface{}{"sub": "fed-sub-1"}
-	suite.mockFederated.On("Authenticate", mock.Anything, "idp-1", "auth-code").
+	suite.mockFederated.On("Authenticate", mock.Anything, "idp-1",
+		authncommon.AuthorizationData{Code: "auth-code"}).
 		Return(&authncommon.AuthnResult{
 			Token:               fedToken,
 			AuthenticatedClaims: map[string]interface{}{"sub": "fed-sub-1"},
@@ -1299,9 +1300,9 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_Federated_Success()
 
 	credentials := map[string]interface{}{
 		"federated": &authncommon.FederatedAuthCredential{
-			IDPID:   "idp-1",
-			IDPType: providers.IDPType("google"),
-			Code:    "auth-code",
+			IDPID:             "idp-1",
+			IDPType:           providers.IDPType("google"),
+			AuthorizationData: authncommon.AuthorizationData{Code: "auth-code"},
 		},
 	}
 
@@ -1327,7 +1328,8 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_Federated_Success()
 }
 
 func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_Federated_ClientError() {
-	suite.mockFederated.On("Authenticate", mock.Anything, "idp-1", "auth-code").
+	suite.mockFederated.On("Authenticate", mock.Anything, "idp-1",
+		authncommon.AuthorizationData{Code: "auth-code"}).
 		Return(nil, &tidcommon.ServiceError{
 			Type:             tidcommon.ClientErrorType,
 			Code:             "FED-001",
@@ -1341,9 +1343,9 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_Federated_ClientErr
 
 	credentials := map[string]interface{}{
 		"federated": &authncommon.FederatedAuthCredential{
-			IDPID:   "idp-1",
-			IDPType: providers.IDPType("google"),
-			Code:    "auth-code",
+			IDPID:             "idp-1",
+			IDPType:           providers.IDPType("google"),
+			AuthorizationData: authncommon.AuthorizationData{Code: "auth-code"},
 		},
 	}
 
@@ -1355,7 +1357,8 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_Federated_ClientErr
 }
 
 func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_Federated_ServerError() {
-	suite.mockFederated.On("Authenticate", mock.Anything, "idp-1", "auth-code").
+	suite.mockFederated.On("Authenticate", mock.Anything, "idp-1",
+		authncommon.AuthorizationData{Code: "auth-code"}).
 		Return(nil, &tidcommon.ServiceError{
 			Type:             tidcommon.ServerErrorType,
 			Code:             "INTERNAL",
@@ -1369,9 +1372,9 @@ func (suite *DefaultAuthnProviderTestSuite) TestAuthenticate_Federated_ServerErr
 
 	credentials := map[string]interface{}{
 		"federated": &authncommon.FederatedAuthCredential{
-			IDPID:   "idp-1",
-			IDPType: providers.IDPType("google"),
-			Code:    "auth-code",
+			IDPID:             "idp-1",
+			IDPType:           providers.IDPType("google"),
+			AuthorizationData: authncommon.AuthorizationData{Code: "auth-code"},
 		},
 	}
 

--- a/backend/internal/flow/common/constants.go
+++ b/backend/internal/flow/common/constants.go
@@ -186,6 +186,8 @@ const (
 	RuntimeKeyMagicLinkUsedJti = "magicLinkUsedJti"
 	// RuntimeKeyOAuthState holds the generated OAuth state parameter for CSRF validation.
 	RuntimeKeyOAuthState = "oauthState"
+	// RuntimeKeyOIDCNonce holds the server-generated nonce for OIDC ID token replay protection.
+	RuntimeKeyOIDCNonce = "oidcNonce"
 	// RuntimeKeyOpenID4VPState holds the OpenID4VP request state across poll steps.
 	RuntimeKeyOpenID4VPState = "openid4vpVerificationState"
 	// RuntimeKeyRequestedAuthClasses holds the space-separated ACR values from acr_values.

--- a/backend/internal/flow/executor/constants.go
+++ b/backend/internal/flow/executor/constants.go
@@ -72,7 +72,6 @@ const (
 	userAttributeSub      = "sub"
 
 	userInputCode  = "code"
-	userInputNonce = "nonce"
 	userInputState = "state"
 
 	userInputOuName           = "ouName"
@@ -120,5 +119,5 @@ const (
 
 // nonSearchableInputs contains the list of user inputs/ attributes that are non-searchable.
 var nonSearchableInputs = []string{
-	"password", "code", "nonce", "otp", "token", "userInputMagicLinkToken", "otpSessionToken",
+	"password", "code", "otp", "token", "userInputMagicLinkToken", "otpSessionToken",
 }

--- a/backend/internal/flow/executor/error_constants.go
+++ b/backend/internal/flow/executor/error_constants.go
@@ -193,24 +193,10 @@ var (
 		},
 	}
 
-	// ErrNonceMismatch is returned when the nonce in the ID token does not match.
-	ErrNonceMismatch = tidcommon.ServiceError{
-		Type: tidcommon.ClientErrorType,
-		Code: "FET-1013",
-		Error: tidcommon.I18nMessage{
-			Key:          "flows.executor.errors.nonce_mismatch",
-			DefaultValue: "Nonce mismatch in ID token",
-		},
-		ErrorDescription: tidcommon.I18nMessage{
-			Key:          "flows.executor.errors.nonce_mismatch_desc",
-			DefaultValue: "The nonce in the ID token claims does not match the expected value",
-		},
-	}
-
 	// ErrInvalidOAuthCode is returned when the OAuth authorization code is invalid.
 	ErrInvalidOAuthCode = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1014",
+		Code: "FET-1013",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.invalid_oauth_code",
 			DefaultValue: "Invalid OAuth authorization code",
@@ -224,7 +210,7 @@ var (
 	// ErrInvalidFederatedUser is returned when the federated user information is invalid during authentication.
 	ErrInvalidFederatedUser = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1015",
+		Code: "FET-1014",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.invalid_federated_user",
 			DefaultValue: "Invalid federated user",
@@ -238,7 +224,7 @@ var (
 	// ErrInvalidPasskey is returned when the passkey credentials are invalid.
 	ErrInvalidPasskey = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1016",
+		Code: "FET-1015",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.invalid_passkey",
 			DefaultValue: "Invalid passkey credentials",
@@ -252,7 +238,7 @@ var (
 	// ErrNoRegisteredPasskeys is returned when no registered passkeys are found for the user.
 	ErrNoRegisteredPasskeys = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1017",
+		Code: "FET-1016",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.no_registered_passkeys",
 			DefaultValue: "No registered passkeys found",
@@ -266,7 +252,7 @@ var (
 	// ErrUserIDRequiredForPasskeyReg is returned when user ID is missing for passkey registration.
 	ErrUserIDRequiredForPasskeyReg = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1018",
+		Code: "FET-1017",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.user_id_required_for_passkey_reg",
 			DefaultValue: "User ID missing for passkey registration",
@@ -280,7 +266,7 @@ var (
 	// ErrPasskeyRegistrationFailed is returned when passkey registration fails.
 	ErrPasskeyRegistrationFailed = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1019",
+		Code: "FET-1018",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.passkey_registration_failed",
 			DefaultValue: "Passkey registration failed",
@@ -294,7 +280,7 @@ var (
 	// ErrPasskeyAuthFailed is returned when passkey authentication fails.
 	ErrPasskeyAuthFailed = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1020",
+		Code: "FET-1019",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.passkey_auth_failed",
 			DefaultValue: "Passkey authentication failed",
@@ -308,7 +294,7 @@ var (
 	// ErrProvisioningUserAttrsMissing is returned when no user attributes are provided for provisioning.
 	ErrProvisioningUserAttrsMissing = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1021",
+		Code: "FET-1020",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.provisioning_user_attrs_missing",
 			DefaultValue: "No user attributes provided for provisioning",
@@ -322,7 +308,7 @@ var (
 	// ErrProvisioningFailed is returned when user provisioning fails.
 	ErrProvisioningFailed = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1022",
+		Code: "FET-1021",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.provisioning_failed",
 			DefaultValue: "User provisioning failed",
@@ -336,7 +322,7 @@ var (
 	// ErrProvisioningAssignmentFailed is returned when group or role assignment fails during provisioning.
 	ErrProvisioningAssignmentFailed = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1023",
+		Code: "FET-1022",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.provisioning_assignment_failed",
 			DefaultValue: "Failed to assign groups and roles",
@@ -350,7 +336,7 @@ var (
 	// ErrCrossOUProvisioningTargetMissing is returned when target OU is missing for cross-OU provisioning.
 	ErrCrossOUProvisioningTargetMissing = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1024",
+		Code: "FET-1023",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.cross_ou_provisioning_target_missing",
 			DefaultValue: "Target OU is not set for cross-OU provisioning",
@@ -364,7 +350,7 @@ var (
 	// ErrUserAlreadyExistsInTargetOU is returned when the user already exists in the target organization.
 	ErrUserAlreadyExistsInTargetOU = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1025",
+		Code: "FET-1024",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.user_already_exists_in_target_ou",
 			DefaultValue: "User already exists in the target organization",
@@ -378,7 +364,7 @@ var (
 	// ErrCannotProvisionAutomatically is returned when the user cannot be provisioned automatically.
 	ErrCannotProvisionAutomatically = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1026",
+		Code: "FET-1025",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.cannot_provision_automatically",
 			DefaultValue: "Cannot provision user automatically",
@@ -392,7 +378,7 @@ var (
 	// ErrSelfRegistrationDisabled is returned when self-registration is not enabled.
 	ErrSelfRegistrationDisabled = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1027",
+		Code: "FET-1026",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.self_registration_disabled",
 			DefaultValue: "Self-registration not enabled",
@@ -406,7 +392,7 @@ var (
 	// ErrInsufficientPermissions is returned when the user lacks required permissions.
 	ErrInsufficientPermissions = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1028",
+		Code: "FET-1027",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.insufficient_permissions",
 			DefaultValue: "Insufficient permissions",
@@ -420,7 +406,7 @@ var (
 	// ErrAuthorizationFailed is returned when authorization validation fails.
 	ErrAuthorizationFailed = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1029",
+		Code: "FET-1028",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.authorization_failed",
 			DefaultValue: "Authorization validation failed",
@@ -434,7 +420,7 @@ var (
 	// ErrInvalidOU is returned when the selected organization unit is invalid.
 	ErrInvalidOU = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1030",
+		Code: "FET-1029",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.invalid_ou",
 			DefaultValue: "Selected organization unit is invalid",
@@ -448,7 +434,7 @@ var (
 	// ErrOUNotFound is returned when the organization unit is not found.
 	ErrOUNotFound = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1031",
+		Code: "FET-1030",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.ou_not_found",
 			DefaultValue: "Organization unit not found",
@@ -462,7 +448,7 @@ var (
 	// ErrOUNameConflict is returned when an organization unit with the same name already exists.
 	ErrOUNameConflict = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1032",
+		Code: "FET-1031",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.ou_name_conflict",
 			DefaultValue: "Organization unit with the same name already exists",
@@ -476,7 +462,7 @@ var (
 	// ErrOUHandleConflict is returned when an organization unit with the same handle already exists.
 	ErrOUHandleConflict = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1033",
+		Code: "FET-1032",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.ou_handle_conflict",
 			DefaultValue: "Organization unit with the same handle already exists",
@@ -490,7 +476,7 @@ var (
 	// ErrOUCreationPrereqFailed is returned when prerequisites validation fails for OU creation.
 	ErrOUCreationPrereqFailed = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1034",
+		Code: "FET-1033",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.ou_creation_prereq_failed",
 			DefaultValue: "Prerequisites validation failed for OU creation",
@@ -504,7 +490,7 @@ var (
 	// ErrOUResolutionFailed is returned when the organization unit cannot be resolved.
 	ErrOUResolutionFailed = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1035",
+		Code: "FET-1034",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.ou_resolution_failed",
 			DefaultValue: "Failed to resolve organization unit",
@@ -518,7 +504,7 @@ var (
 	// ErrOUCreationFailed is returned when organization unit creation fails.
 	ErrOUCreationFailed = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1036",
+		Code: "FET-1035",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.ou_creation_failed",
 			DefaultValue: "Organization unit creation failed",
@@ -532,7 +518,7 @@ var (
 	// ErrEmailSendFailed is returned when the email fails to send.
 	ErrEmailSendFailed = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1037",
+		Code: "FET-1036",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.email_send_failed",
 			DefaultValue: "Failed to send email",
@@ -546,7 +532,7 @@ var (
 	// ErrEmailRecipientMissing is returned when the email recipient is not provided.
 	ErrEmailRecipientMissing = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1038",
+		Code: "FET-1037",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.email_recipient_missing",
 			DefaultValue: "Email recipient is required",
@@ -560,7 +546,7 @@ var (
 	// ErrEmailServiceNotConfigured is returned when the email service is not configured.
 	ErrEmailServiceNotConfigured = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1039",
+		Code: "FET-1038",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.email_service_not_configured",
 			DefaultValue: "Email service is not configured",
@@ -574,7 +560,7 @@ var (
 	// ErrSMSRecipientMissing is returned when the SMS recipient is not provided.
 	ErrSMSRecipientMissing = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1040",
+		Code: "FET-1039",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.sms_recipient_missing",
 			DefaultValue: "SMS recipient is required",
@@ -588,7 +574,7 @@ var (
 	// ErrSMSInvalidPhone is returned when the SMS recipient phone number is invalid.
 	ErrSMSInvalidPhone = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1041",
+		Code: "FET-1040",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.sms_invalid_phone",
 			DefaultValue: "SMS recipient is not a valid phone number",
@@ -602,7 +588,7 @@ var (
 	// ErrSMSTemplateMissing is returned when the SMS template is not provided.
 	ErrSMSTemplateMissing = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1042",
+		Code: "FET-1041",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.sms_template_missing",
 			DefaultValue: "SMS template is required",
@@ -616,7 +602,7 @@ var (
 	// ErrSMSProviderNotConfigured is returned when the SMS provider is not configured.
 	ErrSMSProviderNotConfigured = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1043",
+		Code: "FET-1042",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.sms_provider_not_configured",
 			DefaultValue: "SMS notification provider is not configured",
@@ -630,7 +616,7 @@ var (
 	// ErrPrerequisitesFailed is returned when prerequisites validation fails.
 	ErrPrerequisitesFailed = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1044",
+		Code: "FET-1043",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.prerequisites_failed",
 			DefaultValue: "Prerequisites validation failed",
@@ -644,7 +630,7 @@ var (
 	// ErrUserIDMissingInContext is returned when the user ID is not found in the flow context.
 	ErrUserIDMissingInContext = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1045",
+		Code: "FET-1044",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.user_id_missing_in_context",
 			DefaultValue: "User ID not found",
@@ -658,7 +644,7 @@ var (
 	// ErrCredentialInputMissing is returned when no credential input is configured.
 	ErrCredentialInputMissing = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1046",
+		Code: "FET-1045",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.credential_input_missing",
 			DefaultValue: "No credential input configured",
@@ -672,7 +658,7 @@ var (
 	// ErrCredentialInputInvalid is returned when the credential input configuration is invalid.
 	ErrCredentialInputInvalid = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1047",
+		Code: "FET-1046",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.credential_input_invalid",
 			DefaultValue: "Invalid credential input configuration",
@@ -686,7 +672,7 @@ var (
 	// ErrCredentialValueEmpty is returned when the credential value is empty.
 	ErrCredentialValueEmpty = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1048",
+		Code: "FET-1047",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.credential_value_empty",
 			DefaultValue: "Credential value is empty",
@@ -700,7 +686,7 @@ var (
 	// ErrCredentialSetFailed is returned when setting credentials fails.
 	ErrCredentialSetFailed = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1049",
+		Code: "FET-1048",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.credential_set_failed",
 			DefaultValue: "Failed to set credentials",
@@ -714,7 +700,7 @@ var (
 	// ErrAttributeCollectFailed is returned when updating user attributes fails.
 	ErrAttributeCollectFailed = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1050",
+		Code: "FET-1049",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.attribute_collect_failed",
 			DefaultValue: "Failed to update user attributes",
@@ -728,7 +714,7 @@ var (
 	// ErrHTTPRequestConfigInvalid is returned when the HTTP request executor configuration is invalid.
 	ErrHTTPRequestConfigInvalid = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1051",
+		Code: "FET-1050",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.http_request_config_invalid",
 			DefaultValue: "Configuration error",
@@ -742,7 +728,7 @@ var (
 	// ErrAuthNotAvailableForApp is returned when authentication is not available for the application.
 	ErrAuthNotAvailableForApp = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1052",
+		Code: "FET-1051",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.auth_not_available_for_app",
 			DefaultValue: "Authentication not available for this application",
@@ -756,7 +742,7 @@ var (
 	// ErrSelfRegNotAvailableForApp is returned when self-registration is not available for the application.
 	ErrSelfRegNotAvailableForApp = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1053",
+		Code: "FET-1052",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.self_reg_not_available_for_app",
 			DefaultValue: "Self-registration not available for this application",
@@ -770,7 +756,7 @@ var (
 	// ErrNoValidUserTypes is returned when no valid user types are available for the flow.
 	ErrNoValidUserTypes = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1054",
+		Code: "FET-1053",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.no_valid_user_types",
 			DefaultValue: "No valid user types available",
@@ -784,7 +770,7 @@ var (
 	// ErrUserTypeNotAllowed is returned when the user type is not allowed for the flow.
 	ErrUserTypeNotAllowed = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1055",
+		Code: "FET-1054",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.user_type_not_allowed",
 			DefaultValue: "User type not allowed for this flow",
@@ -798,7 +784,7 @@ var (
 	// ErrInvalidUserType is returned when the user type is invalid.
 	ErrInvalidUserType = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1056",
+		Code: "FET-1055",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.invalid_user_type",
 			DefaultValue: "Invalid user type",
@@ -812,7 +798,7 @@ var (
 	// ErrNoUserTypesAvailable is returned when no user types are available.
 	ErrNoUserTypesAvailable = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1057",
+		Code: "FET-1056",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.no_user_types_available",
 			DefaultValue: "No user types available",
@@ -826,7 +812,7 @@ var (
 	// ErrUserTypeRetrievalFailed is returned when user type retrieval fails.
 	ErrUserTypeRetrievalFailed = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1058",
+		Code: "FET-1057",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.user_type_retrieval_failed",
 			DefaultValue: "Failed to retrieve user types",
@@ -840,7 +826,7 @@ var (
 	// ErrUserTypeNotValidForOU is returned when the user type is not valid for the selected OU.
 	ErrUserTypeNotValidForOU = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1059",
+		Code: "FET-1058",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.user_type_not_valid_for_ou",
 			DefaultValue: "User type is not valid",
@@ -854,7 +840,7 @@ var (
 	// ErrSelfRegDisabledForUserType is returned when self-registration is disabled for a specific user type.
 	ErrSelfRegDisabledForUserType = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1060",
+		Code: "FET-1059",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.self_reg_disabled_for_user_type",
 			DefaultValue: "Self-registration is disabled for the user type",
@@ -868,7 +854,7 @@ var (
 	// ErrAttributeNotFoundForUser is returned when a required attribute is not found for the user.
 	ErrAttributeNotFoundForUser = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1061",
+		Code: "FET-1060",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.attribute_not_found_for_user",
 			DefaultValue: "Required attribute not found",
@@ -882,7 +868,7 @@ var (
 	// ErrAttributeNotUnique is returned when an attribute value already exists.
 	ErrAttributeNotUnique = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1062",
+		Code: "FET-1061",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.attribute_not_unique",
 			DefaultValue: "User already exists with the provided {{param(attribute)}}",
@@ -897,7 +883,7 @@ var (
 	// ErrAttributeRetrievalFailed is returned when user attribute retrieval fails.
 	ErrAttributeRetrievalFailed = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1063",
+		Code: "FET-1062",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.attribute_retrieval_failed",
 			DefaultValue: "Failed to retrieve user attributes",
@@ -911,7 +897,7 @@ var (
 	// ErrCredentialProcessingFailed is returned when credential processing fails.
 	ErrCredentialProcessingFailed = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1064",
+		Code: "FET-1063",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.credential_processing_failed",
 			DefaultValue: "Failed to process credentials",
@@ -925,7 +911,7 @@ var (
 	// ErrInvalidAction is returned when an invalid action is provided to a prompt node.
 	ErrInvalidAction = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1065",
+		Code: "FET-1064",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.invalid_action",
 			DefaultValue: "Invalid action provided",
@@ -939,7 +925,7 @@ var (
 	// ErrConsentPrereqFailed is returned when prerequisites validation fails for consent.
 	ErrConsentPrereqFailed = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1066",
+		Code: "FET-1065",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.consent_prereq_failed",
 			DefaultValue: "Prerequisites validation failed for consent",
@@ -953,7 +939,7 @@ var (
 	// ErrConsentDenied is returned when the user denies consent.
 	ErrConsentDenied = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1067",
+		Code: "FET-1066",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.consent_denied",
 			DefaultValue: "User denied consent",
@@ -967,7 +953,7 @@ var (
 	// ErrConsentDecisionsMissing is returned when consent decisions input is missing.
 	ErrConsentDecisionsMissing = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1068",
+		Code: "FET-1067",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.consent_decisions_missing",
 			DefaultValue: "Consent decisions input is missing or empty",
@@ -981,7 +967,7 @@ var (
 	// ErrConsentDecisionsParseFail is returned when consent decisions cannot be parsed.
 	ErrConsentDecisionsParseFail = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1069",
+		Code: "FET-1068",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.consent_decisions_parse",
 			DefaultValue: "Failed to parse consent decisions",
@@ -995,7 +981,7 @@ var (
 	// ErrConsentPromptTimedOut is returned when the consent prompt times out.
 	ErrConsentPromptTimedOut = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1070",
+		Code: "FET-1069",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.consent_prompt_timed_out",
 			DefaultValue: "Consent prompt has timed out",
@@ -1009,7 +995,7 @@ var (
 	// ErrConsentRecordFailed is returned when recording consent fails.
 	ErrConsentRecordFailed = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1071",
+		Code: "FET-1070",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.consent_record_failed",
 			DefaultValue: "Failed to record consent",
@@ -1023,7 +1009,7 @@ var (
 	// ErrConsentResolutionFailed is returned when resolving consent fails.
 	ErrConsentResolutionFailed = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1072",
+		Code: "FET-1071",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.consent_resolution_failed",
 			DefaultValue: "Failed to resolve consent",
@@ -1037,7 +1023,7 @@ var (
 	// ErrHTTPRequestFailed is returned when the HTTP request executor fails.
 	ErrHTTPRequestFailed = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1073",
+		Code: "FET-1072",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.http_request_failed",
 			DefaultValue: "HTTP request executor failed",
@@ -1051,7 +1037,7 @@ var (
 	// ErrInvalidInviteToken is returned when the invite token is invalid.
 	ErrInvalidInviteToken = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1074",
+		Code: "FET-1073",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.invalid_invite_token",
 			DefaultValue: "Invalid invite token",
@@ -1065,7 +1051,7 @@ var (
 	// ErrInviteTokenGenerationFailed is returned when generating an invite token fails.
 	ErrInviteTokenGenerationFailed = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1075",
+		Code: "FET-1074",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.invite_token_generation_failed",
 			DefaultValue: "Failed to generate invite token",
@@ -1079,7 +1065,7 @@ var (
 	// ErrOUNotValidForUserType is returned when the selected OU is not valid for the chosen user type.
 	ErrOUNotValidForUserType = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1076",
+		Code: "FET-1075",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.ou_not_valid_for_user_type",
 			DefaultValue: "The selected organization unit is not valid for the chosen user type.",
@@ -1093,7 +1079,7 @@ var (
 	// ErrOpenID4VPDefinitionNotConfigured is returned when the OpenID4VP node has no presentation_definition_id.
 	ErrOpenID4VPDefinitionNotConfigured = tidcommon.ServiceError{
 		Type: tidcommon.ServerErrorType,
-		Code: "FET-1082",
+		Code: "FET-1076",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.openid4vp_definition_not_configured",
 			DefaultValue: "OpenID4VP presentation definition is not configured",
@@ -1107,7 +1093,7 @@ var (
 	// ErrOpenID4VPInitiateFailed is returned when initiating the OpenID4VP request fails.
 	ErrOpenID4VPInitiateFailed = tidcommon.ServiceError{
 		Type: tidcommon.ServerErrorType,
-		Code: "FET-1078",
+		Code: "FET-1077",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.openid4vp_initiate_failed",
 			DefaultValue: "Failed to initiate the OpenID4VP request",
@@ -1121,7 +1107,7 @@ var (
 	// ErrOpenID4VPExpired is returned when the OpenID4VP request expires before a response is received.
 	ErrOpenID4VPExpired = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1079",
+		Code: "FET-1078",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.openid4vp_expired",
 			DefaultValue: "The OpenID4VP request expired before a response was received",
@@ -1135,7 +1121,7 @@ var (
 	// ErrOpenID4VPVerificationFailed is returned when the OpenID4VP presentation verification fails.
 	ErrOpenID4VPVerificationFailed = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1080",
+		Code: "FET-1079",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.openid4vp_verification_failed",
 			DefaultValue: "OpenID4VP presentation verification failed",
@@ -1149,7 +1135,7 @@ var (
 	// ErrProvisioningAttributeConflict is returned when user provisioning fails due to an attribute conflict.
 	ErrProvisioningAttributeConflict = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1081",
+		Code: "FET-1080",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.provisioning_attribute_conflict",
 			DefaultValue: "A user with the provided attributes already exists",
@@ -1165,7 +1151,7 @@ var (
 	// (onFailure) outcome to the full-authentication path.
 	ErrNoLiveSSOSession = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1082",
+		Code: "FET-1081",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.no_live_sso_session",
 			DefaultValue: "No live SSO session",
@@ -1184,7 +1170,7 @@ var (
 	// drive step-up re-authentication.
 	ErrInteractionRequired = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,
-		Code: "FET-1083",
+		Code: "FET-1082",
 		Error: tidcommon.I18nMessage{
 			Key:          "flows.executor.errors.interaction_required",
 			DefaultValue: "Interaction required",

--- a/backend/internal/flow/executor/github_auth_executor_test.go
+++ b/backend/internal/flow/executor/github_auth_executor_test.go
@@ -21,69 +21,20 @@ package executor
 import (
 	"testing"
 
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 
-	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
-
-	authnoauth "github.com/thunder-id/thunderid/internal/authn/oauth"
 	"github.com/thunder-id/thunderid/tests/mocks/authn/githubmock"
-	"github.com/thunder-id/thunderid/tests/mocks/authn/oauthmock"
-	"github.com/thunder-id/thunderid/tests/mocks/authnprovider/managermock"
-	"github.com/thunder-id/thunderid/tests/mocks/flow/coremock"
-	"github.com/thunder-id/thunderid/tests/mocks/idp/idpmock"
 )
 
-type GithubAuthExecutorTestSuite struct {
-	suite.Suite
-	mockFlowFactory   *coremock.FlowFactoryInterfaceMock
-	mockIDPService    *idpmock.IDPServiceInterfaceMock
-	mockGithubService *githubmock.GithubOAuthAuthnServiceInterfaceMock
-	mockOAuthService  *oauthmock.OAuthAuthnCoreServiceInterfaceMock
-	mockAuthnProvider *managermock.AuthnProviderManagerMock
-}
+func TestNewGithubOAuthExecutor_Success(t *testing.T) {
+	mockFlowFactory, mockIDPService, mockAuthnProvider := setupSocialAuthExecutorMock(t, ExecutorNameGitHubAuth)
+	mockGithubSvc := githubmock.NewGithubOAuthAuthnServiceInterfaceMock(t)
 
-func TestGithubAuthExecutorTestSuite(t *testing.T) {
-	suite.Run(t, new(GithubAuthExecutorTestSuite))
-}
+	executor := newGithubOAuthExecutor(mockFlowFactory, mockIDPService, mockGithubSvc, mockAuthnProvider)
 
-func (suite *GithubAuthExecutorTestSuite) SetupTest() {
-	suite.mockFlowFactory = coremock.NewFlowFactoryInterfaceMock(suite.T())
-	suite.mockIDPService = idpmock.NewIDPServiceInterfaceMock(suite.T())
-	suite.mockGithubService = githubmock.NewGithubOAuthAuthnServiceInterfaceMock(suite.T())
-	suite.mockOAuthService = oauthmock.NewOAuthAuthnCoreServiceInterfaceMock(suite.T())
-	suite.mockAuthnProvider = managermock.NewAuthnProviderManagerMock(suite.T())
-}
-
-func (suite *GithubAuthExecutorTestSuite) TestNewGithubOAuthExecutor_Success() {
-	defaultInputs := []providers.Input{
-		{
-			Identifier: "code",
-			Type:       "string",
-			Required:   true,
-		},
-	}
-	baseExec := coremock.NewExecutorInterfaceMock(suite.T())
-	suite.mockFlowFactory.On("CreateExecutor", ExecutorNameGitHubAuth,
-		providers.ExecutorTypeAuthentication, defaultInputs, []providers.Input{}, mock.Anything).
-		Return(baseExec).Once()
-
-	mockGithubSvc := &mockGithubServiceWithOAuth{
-		GithubOAuthAuthnServiceInterfaceMock: suite.mockGithubService,
-		oauthService:                         suite.mockOAuthService,
-	}
-
-	executor := newGithubOAuthExecutor(suite.mockFlowFactory, suite.mockIDPService,
-		mockGithubSvc, suite.mockAuthnProvider)
-
-	suite.NotNil(executor)
-	githubExec, ok := executor.(*githubOAuthExecutor)
-	suite.True(ok)
-	suite.NotNil(githubExec.oAuthExecutorInterface)
-	suite.Equal(mockGithubSvc, githubExec.githubAuthService)
-}
-
-type mockGithubServiceWithOAuth struct {
-	*githubmock.GithubOAuthAuthnServiceInterfaceMock
-	oauthService authnoauth.OAuthAuthnCoreServiceInterface
+	assert.NotNil(t, executor)
+	result, ok := executor.(*githubOAuthExecutor)
+	assert.True(t, ok)
+	assert.NotNil(t, result.oAuthExecutorInterface)
+	assert.Equal(t, mockGithubSvc, result.githubAuthService)
 }

--- a/backend/internal/flow/executor/google_auth_executor.go
+++ b/backend/internal/flow/executor/google_auth_executor.go
@@ -47,11 +47,6 @@ func newGoogleOIDCAuthExecutor(
 			Type:       "string",
 			Required:   true,
 		},
-		{
-			Identifier: "nonce",
-			Type:       "string",
-			Required:   false,
-		},
 	}
 
 	oidcSvcCast, ok := authService.(authnoidc.OIDCAuthnCoreServiceInterface)

--- a/backend/internal/flow/executor/google_auth_executor_test.go
+++ b/backend/internal/flow/executor/google_auth_executor_test.go
@@ -21,74 +21,20 @@ package executor
 import (
 	"testing"
 
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 
-	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
-
-	authnoidc "github.com/thunder-id/thunderid/internal/authn/oidc"
 	"github.com/thunder-id/thunderid/tests/mocks/authn/googlemock"
-	"github.com/thunder-id/thunderid/tests/mocks/authn/oidcmock"
-	"github.com/thunder-id/thunderid/tests/mocks/authnprovider/managermock"
-	"github.com/thunder-id/thunderid/tests/mocks/flow/coremock"
-	"github.com/thunder-id/thunderid/tests/mocks/idp/idpmock"
 )
 
-type GoogleAuthExecutorTestSuite struct {
-	suite.Suite
-	mockFlowFactory   *coremock.FlowFactoryInterfaceMock
-	mockIDPService    *idpmock.IDPServiceInterfaceMock
-	mockGoogleService *googlemock.GoogleOIDCAuthnServiceInterfaceMock
-	mockOIDCService   *oidcmock.OIDCAuthnCoreServiceInterfaceMock
-	mockAuthnProvider *managermock.AuthnProviderManagerMock
-}
+func TestNewGoogleOIDCAuthExecutor_Success(t *testing.T) {
+	mockFlowFactory, mockIDPService, mockAuthnProvider := setupSocialAuthExecutorMock(t, ExecutorNameGoogleAuth)
+	mockGoogleSvc := googlemock.NewGoogleOIDCAuthnServiceInterfaceMock(t)
 
-func TestGoogleAuthExecutorTestSuite(t *testing.T) {
-	suite.Run(t, new(GoogleAuthExecutorTestSuite))
-}
+	executor := newGoogleOIDCAuthExecutor(mockFlowFactory, mockIDPService, mockGoogleSvc, mockAuthnProvider)
 
-func (suite *GoogleAuthExecutorTestSuite) SetupTest() {
-	suite.mockFlowFactory = coremock.NewFlowFactoryInterfaceMock(suite.T())
-	suite.mockIDPService = idpmock.NewIDPServiceInterfaceMock(suite.T())
-	suite.mockGoogleService = googlemock.NewGoogleOIDCAuthnServiceInterfaceMock(suite.T())
-	suite.mockOIDCService = oidcmock.NewOIDCAuthnCoreServiceInterfaceMock(suite.T())
-	suite.mockAuthnProvider = managermock.NewAuthnProviderManagerMock(suite.T())
-}
-
-func (suite *GoogleAuthExecutorTestSuite) TestNewGoogleOIDCAuthExecutor_Success() {
-	defaultInputs := []providers.Input{
-		{
-			Identifier: "code",
-			Type:       "string",
-			Required:   true,
-		},
-		{
-			Identifier: "nonce",
-			Type:       "string",
-			Required:   false,
-		},
-	}
-	baseExec := coremock.NewExecutorInterfaceMock(suite.T())
-	suite.mockFlowFactory.On("CreateExecutor", ExecutorNameGoogleAuth,
-		providers.ExecutorTypeAuthentication, defaultInputs, []providers.Input{}, mock.Anything).
-		Return(baseExec).Once()
-
-	mockGoogleSvc := &mockGoogleServiceWithOIDC{
-		GoogleOIDCAuthnServiceInterfaceMock: suite.mockGoogleService,
-		oidcService:                         suite.mockOIDCService,
-	}
-
-	executor := newGoogleOIDCAuthExecutor(suite.mockFlowFactory, suite.mockIDPService,
-		mockGoogleSvc, suite.mockAuthnProvider)
-
-	suite.NotNil(executor)
-	googleExec, ok := executor.(*googleOIDCAuthExecutor)
-	suite.True(ok)
-	suite.NotNil(googleExec.oidcAuthExecutorInterface)
-	suite.Equal(mockGoogleSvc, googleExec.googleAuthService)
-}
-
-type mockGoogleServiceWithOIDC struct {
-	*googlemock.GoogleOIDCAuthnServiceInterfaceMock
-	oidcService authnoidc.OIDCAuthnCoreServiceInterface
+	assert.NotNil(t, executor)
+	result, ok := executor.(*googleOIDCAuthExecutor)
+	assert.True(t, ok)
+	assert.NotNil(t, result.oidcAuthExecutorInterface)
+	assert.Equal(t, mockGoogleSvc, result.googleAuthService)
 }

--- a/backend/internal/flow/executor/identifying_executor_test.go
+++ b/backend/internal/flow/executor/identifying_executor_test.go
@@ -148,7 +148,6 @@ func (suite *IdentifyingExecutorTestSuite) TestIdentifyUser_FilterNonSearchableA
 		"username": "testuser",
 		"password": "secret123",
 		"code":     "auth-code",
-		"nonce":    "nonce-value",
 		"otp":      "123456",
 	}
 	execResp := &providers.ExecutorResponse{

--- a/backend/internal/flow/executor/oAuthExecutorInterface_mock_test.go
+++ b/backend/internal/flow/executor/oAuthExecutorInterface_mock_test.go
@@ -37,20 +37,31 @@ func (_m *oAuthExecutorInterfaceMock) EXPECT() *oAuthExecutorInterfaceMock_Expec
 }
 
 // BuildAuthorizeFlow provides a mock function for the type oAuthExecutorInterfaceMock
-func (_mock *oAuthExecutorInterfaceMock) BuildAuthorizeFlow(ctx *providers.NodeContext, execResp *providers.ExecutorResponse) error {
+func (_mock *oAuthExecutorInterfaceMock) BuildAuthorizeFlow(ctx *providers.NodeContext, execResp *providers.ExecutorResponse) (map[string]string, error) {
 	ret := _mock.Called(ctx, execResp)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BuildAuthorizeFlow")
 	}
 
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(*providers.NodeContext, *providers.ExecutorResponse) error); ok {
+	var r0 map[string]string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(*providers.NodeContext, *providers.ExecutorResponse) (map[string]string, error)); ok {
+		return returnFunc(ctx, execResp)
+	}
+	if returnFunc, ok := ret.Get(0).(func(*providers.NodeContext, *providers.ExecutorResponse) map[string]string); ok {
 		r0 = returnFunc(ctx, execResp)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]string)
+		}
 	}
-	return r0
+	if returnFunc, ok := ret.Get(1).(func(*providers.NodeContext, *providers.ExecutorResponse) error); ok {
+		r1 = returnFunc(ctx, execResp)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
 }
 
 // oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BuildAuthorizeFlow'
@@ -83,12 +94,12 @@ func (_c *oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) Run(run func(ctx *
 	return _c
 }
 
-func (_c *oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) Return(err error) *oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call {
-	_c.Call.Return(err)
+func (_c *oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) Return(stringToString map[string]string, err error) *oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call {
+	_c.Call.Return(stringToString, err)
 	return _c
 }
 
-func (_c *oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) RunAndReturn(run func(ctx *providers.NodeContext, execResp *providers.ExecutorResponse) error) *oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call {
+func (_c *oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) RunAndReturn(run func(ctx *providers.NodeContext, execResp *providers.ExecutorResponse) (map[string]string, error)) *oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/flow/executor/oauth_executor.go
+++ b/backend/internal/flow/executor/oauth_executor.go
@@ -32,6 +32,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/flow/common"
 	"github.com/thunder-id/thunderid/internal/flow/core"
 	"github.com/thunder-id/thunderid/internal/idp"
+	oauth2const "github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	systemutils "github.com/thunder-id/thunderid/internal/system/utils"
 )
@@ -56,7 +57,7 @@ var userInfoSkipAttributes = []string{"username", "sub", "id"}
 // oAuthExecutorInterface defines the interface for OAuth authentication executors.
 type oAuthExecutorInterface interface {
 	providers.Executor
-	BuildAuthorizeFlow(ctx *providers.NodeContext, execResp *providers.ExecutorResponse) error
+	BuildAuthorizeFlow(ctx *providers.NodeContext, execResp *providers.ExecutorResponse) (map[string]string, error)
 	ProcessAuthFlowResponse(ctx *providers.NodeContext, execResp *providers.ExecutorResponse) error
 	GetIdpID(ctx *providers.NodeContext) (string, error)
 }
@@ -132,7 +133,7 @@ func (o *oAuthExecutor) Execute(ctx *providers.NodeContext) (*providers.Executor
 
 	if !o.HasRequiredInputs(ctx, execResp) {
 		logger.Debug(ctx.Context, "Required inputs for OAuth authentication executor is not provided")
-		err := o.BuildAuthorizeFlow(ctx, execResp)
+		_, err := o.BuildAuthorizeFlow(ctx, execResp)
 		if err != nil {
 			return nil, err
 		}
@@ -151,37 +152,35 @@ func (o *oAuthExecutor) Execute(ctx *providers.NodeContext) (*providers.Executor
 }
 
 // BuildAuthorizeFlow constructs the redirection to the external OAuth provider for user authentication.
-func (o *oAuthExecutor) BuildAuthorizeFlow(ctx *providers.NodeContext, execResp *providers.ExecutorResponse) error {
+// It returns the service-level metadata so that subtype executors can extract additional values.
+func (o *oAuthExecutor) BuildAuthorizeFlow(ctx *providers.NodeContext,
+	execResp *providers.ExecutorResponse) (map[string]string, error) {
 	logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
 	logger.Debug(ctx.Context, "Initiating OAuth authentication flow")
 
 	idpID, err := o.GetIdpID(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	authorizeURL, svcErr := o.authService.BuildAuthorizeURL(ctx.Context, idpID)
+	authorizeURL, metadata, svcErr := o.authService.BuildAuthorizeURL(ctx.Context, idpID)
 	if svcErr != nil {
 		if svcErr.Type == tidcommon.ClientErrorType {
 			execResp.Status = providers.ExecFailure
 			execResp.Error = svcErr
-			return nil
+			return nil, nil
 		}
 
 		logger.Error(ctx.Context, "Failed to build authorize URL", log.String("errorCode", svcErr.Code),
 			log.String("errorDescription", svcErr.ErrorDescription.DefaultValue))
-		return errors.New("failed to build authorize URL")
+		return nil, errors.New("failed to build authorize URL")
 	}
 
 	// Get the idp name for additional data
 	idpName, err := o.getIDPName(ctx.Context, idpID)
 	if err != nil {
-		return fmt.Errorf("failed to get idp name: %w", err)
+		return nil, fmt.Errorf("failed to get idp name: %w", err)
 	}
-
-	// Generate a random state parameter for CSRF protection and append it to the authorize URL.
-	state := systemutils.GenerateUUID()
-	authorizeURL = authorizeURL + "&" + "state=" + state
 
 	// Set the response to redirect the user to the authorization URL.
 	execResp.Status = providers.ExecExternalRedirection
@@ -192,9 +191,11 @@ func (o *oAuthExecutor) BuildAuthorizeFlow(ctx *providers.NodeContext, execResp 
 	if execResp.RuntimeData == nil {
 		execResp.RuntimeData = make(map[string]string)
 	}
-	execResp.RuntimeData[common.RuntimeKeyOAuthState] = state
+	if state, ok := metadata[oauth2const.RequestParamState]; ok {
+		execResp.RuntimeData[common.RuntimeKeyOAuthState] = state
+	}
 
-	return nil
+	return metadata, nil
 }
 
 // ProcessAuthFlowResponse processes the response from the OAuth authentication flow and authenticates the user.
@@ -246,7 +247,9 @@ func (o *oAuthExecutor) ProcessAuthFlowResponse(ctx *providers.NodeContext,
 		"federated": &authncm.FederatedAuthCredential{
 			IDPID:   idpID,
 			IDPType: o.idpType,
-			Code:    code,
+			AuthorizationData: authncm.AuthorizationData{
+				Code: code,
+			},
 		},
 	}
 

--- a/backend/internal/flow/executor/oauth_executor_test.go
+++ b/backend/internal/flow/executor/oauth_executor_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/flow/common"
+	oauth2const "github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/tests/mocks/authn/oauthmock"
 	"github.com/thunder-id/thunderid/tests/mocks/authnprovider/managermock"
 	"github.com/thunder-id/thunderid/tests/mocks/flow/coremock"
@@ -54,12 +55,11 @@ func (suite *OAuthExecutorTestSuite) SetupTest() {
 	suite.mockFlowFactory = coremock.NewFlowFactoryInterfaceMock(suite.T())
 	suite.mockAuthnProvider = managermock.NewAuthnProviderManagerMock(suite.T())
 
-	defaultInputs := []providers.Input{{Identifier: "code", Type: "string", Required: true}}
 	mockExec := createMockAuthExecutor(suite.T(), ExecutorNameOAuth)
 	suite.mockFlowFactory.On("CreateExecutor", ExecutorNameOAuth, providers.ExecutorTypeAuthentication,
-		defaultInputs, []providers.Input{}, mock.Anything).Return(mockExec)
+		defaultCodeOnlyInputs, []providers.Input{}, mock.Anything).Return(mockExec)
 
-	suite.executor = newOAuthExecutor(ExecutorNameOAuth, defaultInputs, []providers.Input{},
+	suite.executor = newOAuthExecutor(ExecutorNameOAuth, defaultCodeOnlyInputs, []providers.Input{},
 		suite.mockFlowFactory, suite.mockIDPService, suite.mockOAuthService,
 		suite.mockAuthnProvider, providers.IDPTypeOAuth)
 }
@@ -85,8 +85,9 @@ func (suite *OAuthExecutorTestSuite) TestExecute_CodeNotProvided_BuildsAuthorize
 		},
 	}
 
+	oauthURL := "https://oauth.provider.com/authorize?client_id=abc&state=test-state"
 	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, "idp-123").
-		Return("https://oauth.provider.com/authorize?client_id=abc", nil)
+		Return(oauthURL, map[string]string{oauth2const.RequestParamState: "test-state"}, nil)
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, "idp-123").
 		Return(&providers.IDPDTO{ID: "idp-123", Name: "TestIDP"}, nil)
@@ -96,10 +97,9 @@ func (suite *OAuthExecutorTestSuite) TestExecute_CodeNotProvided_BuildsAuthorize
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), resp)
 	assert.Equal(suite.T(), providers.ExecExternalRedirection, resp.Status)
-	assert.Contains(suite.T(), resp.RedirectURL, "https://oauth.provider.com/authorize?client_id=abc")
-	assert.Contains(suite.T(), resp.RedirectURL, "state=")
+	assert.Contains(suite.T(), resp.RedirectURL, "https://oauth.provider.com/authorize?client_id=abc&state=test-state")
 	assert.Equal(suite.T(), "TestIDP", resp.AdditionalData[common.DataIDPName])
-	assert.NotEmpty(suite.T(), resp.RuntimeData[common.RuntimeKeyOAuthState])
+	assert.Equal(suite.T(), "test-state", resp.RuntimeData[common.RuntimeKeyOAuthState])
 	suite.mockOAuthService.AssertExpectations(suite.T())
 	suite.mockIDPService.AssertExpectations(suite.T())
 }
@@ -148,18 +148,18 @@ func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_Success() {
 	}
 
 	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, "idp-123").
-		Return("https://oauth.provider.com/authorize", nil)
+		Return("https://oauth.provider.com/authorize?state=test-state",
+			map[string]string{oauth2const.RequestParamState: "test-state"}, nil)
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, "idp-123").
 		Return(&providers.IDPDTO{ID: "idp-123", Name: "GoogleIDP"}, nil)
 
-	err := suite.executor.BuildAuthorizeFlow(ctx, execResp)
+	_, err := suite.executor.BuildAuthorizeFlow(ctx, execResp)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), providers.ExecExternalRedirection, execResp.Status)
-	assert.Contains(suite.T(), execResp.RedirectURL, "https://oauth.provider.com/authorize")
-	assert.Contains(suite.T(), execResp.RedirectURL, "state=")
+	assert.Contains(suite.T(), execResp.RedirectURL, "https://oauth.provider.com/authorize?state=test-state")
 	assert.Equal(suite.T(), "GoogleIDP", execResp.AdditionalData[common.DataIDPName])
-	assert.NotEmpty(suite.T(), execResp.RuntimeData[common.RuntimeKeyOAuthState])
+	assert.Equal(suite.T(), "test-state", execResp.RuntimeData[common.RuntimeKeyOAuthState])
 	suite.mockOAuthService.AssertExpectations(suite.T())
 	suite.mockIDPService.AssertExpectations(suite.T())
 }
@@ -176,7 +176,7 @@ func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_IDPNotConfigured() {
 		RuntimeData:    make(map[string]string),
 	}
 
-	err := suite.executor.BuildAuthorizeFlow(ctx, execResp)
+	_, err := suite.executor.BuildAuthorizeFlow(ctx, execResp)
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "idpId is not configured")
@@ -265,14 +265,14 @@ func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_BuildURLClientError(
 	}
 
 	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, "idp-123").
-		Return("", &tidcommon.ServiceError{
+		Return("", (map[string]string)(nil), &tidcommon.ServiceError{
 			Type: tidcommon.ClientErrorType,
 			ErrorDescription: tidcommon.I18nMessage{
 				Key: "error.test.invalid_idp_configuration", DefaultValue: "Invalid IDP configuration",
 			},
 		})
 
-	err := suite.executor.BuildAuthorizeFlow(ctx, execResp)
+	_, err := suite.executor.BuildAuthorizeFlow(ctx, execResp)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), providers.ExecFailure, execResp.Status)
@@ -295,7 +295,7 @@ func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_BuildURLServerError(
 	}
 
 	suite.mockOAuthService.On("BuildAuthorizeURL", mock.Anything, "idp-123").
-		Return("", &tidcommon.ServiceError{
+		Return("", (map[string]string)(nil), &tidcommon.ServiceError{
 			Type: tidcommon.ServerErrorType,
 			Code: "OAUTH-5000",
 			ErrorDescription: tidcommon.I18nMessage{
@@ -303,7 +303,7 @@ func (suite *OAuthExecutorTestSuite) TestBuildAuthorizeFlow_BuildURLServerError(
 			},
 		})
 
-	err := suite.executor.BuildAuthorizeFlow(ctx, execResp)
+	_, err := suite.executor.BuildAuthorizeFlow(ctx, execResp)
 
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "failed to build authorize URL")

--- a/backend/internal/flow/executor/oidcAuthExecutorInterface_mock_test.go
+++ b/backend/internal/flow/executor/oidcAuthExecutorInterface_mock_test.go
@@ -37,20 +37,31 @@ func (_m *oidcAuthExecutorInterfaceMock) EXPECT() *oidcAuthExecutorInterfaceMock
 }
 
 // BuildAuthorizeFlow provides a mock function for the type oidcAuthExecutorInterfaceMock
-func (_mock *oidcAuthExecutorInterfaceMock) BuildAuthorizeFlow(ctx *providers.NodeContext, execResp *providers.ExecutorResponse) error {
+func (_mock *oidcAuthExecutorInterfaceMock) BuildAuthorizeFlow(ctx *providers.NodeContext, execResp *providers.ExecutorResponse) (map[string]string, error) {
 	ret := _mock.Called(ctx, execResp)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BuildAuthorizeFlow")
 	}
 
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(*providers.NodeContext, *providers.ExecutorResponse) error); ok {
+	var r0 map[string]string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(*providers.NodeContext, *providers.ExecutorResponse) (map[string]string, error)); ok {
+		return returnFunc(ctx, execResp)
+	}
+	if returnFunc, ok := ret.Get(0).(func(*providers.NodeContext, *providers.ExecutorResponse) map[string]string); ok {
 		r0 = returnFunc(ctx, execResp)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]string)
+		}
 	}
-	return r0
+	if returnFunc, ok := ret.Get(1).(func(*providers.NodeContext, *providers.ExecutorResponse) error); ok {
+		r1 = returnFunc(ctx, execResp)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
 }
 
 // oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BuildAuthorizeFlow'
@@ -83,12 +94,12 @@ func (_c *oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) Run(run func(ct
 	return _c
 }
 
-func (_c *oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) Return(err error) *oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call {
-	_c.Call.Return(err)
+func (_c *oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) Return(stringToString map[string]string, err error) *oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call {
+	_c.Call.Return(stringToString, err)
 	return _c
 }
 
-func (_c *oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) RunAndReturn(run func(ctx *providers.NodeContext, execResp *providers.ExecutorResponse) error) *oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call {
+func (_c *oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) RunAndReturn(run func(ctx *providers.NodeContext, execResp *providers.ExecutorResponse) (map[string]string, error)) *oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/flow/executor/oidc_auth_executor.go
+++ b/backend/internal/flow/executor/oidc_auth_executor.go
@@ -31,6 +31,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/flow/common"
 	"github.com/thunder-id/thunderid/internal/flow/core"
 	"github.com/thunder-id/thunderid/internal/idp"
+	oauth2const "github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	systemutils "github.com/thunder-id/thunderid/internal/system/utils"
 )
@@ -106,7 +107,7 @@ func (o *oidcAuthExecutor) Execute(ctx *providers.NodeContext) (*providers.Execu
 
 	if !o.HasRequiredInputs(ctx, execResp) {
 		logger.Debug(ctx.Context, "Required inputs for OIDC authentication executor is not provided")
-		err := o.BuildAuthorizeFlow(ctx, execResp)
+		_, err := o.BuildAuthorizeFlow(ctx, execResp)
 		if err != nil {
 			return nil, err
 		}
@@ -122,6 +123,30 @@ func (o *oidcAuthExecutor) Execute(ctx *providers.NodeContext) (*providers.Execu
 		log.Bool("isAuthenticated", execResp.AuthUser.IsAuthenticated()))
 
 	return execResp, nil
+}
+
+// BuildAuthorizeFlow extends the base OAuth authorize flow by storing the OIDC nonce from
+// the service-level metadata into runtime data for later ID token validation.
+func (o *oidcAuthExecutor) BuildAuthorizeFlow(ctx *providers.NodeContext,
+	execResp *providers.ExecutorResponse) (map[string]string, error) {
+	metadata, err := o.oAuthExecutorInterface.BuildAuthorizeFlow(ctx, execResp)
+	if err != nil {
+		return nil, err
+	}
+
+	if execResp.Status != providers.ExecExternalRedirection {
+		return metadata, nil
+	}
+
+	nonce, ok := metadata[oauth2const.RequestParamNonce]
+	if !ok || nonce == "" {
+		logger := o.logger.With(log.String(log.LoggerKeyExecutionID, ctx.ExecutionID))
+		logger.Error(ctx.Context, "OIDC nonce is missing in the authorization flow metadata")
+		return nil, errors.New("OIDC nonce is missing in the authorization flow")
+	}
+	execResp.RuntimeData[common.RuntimeKeyOIDCNonce] = nonce
+
+	return metadata, nil
 }
 
 // ProcessAuthFlowResponse processes the response from the OIDC authentication flow and authenticates the user.
@@ -174,7 +199,10 @@ func (o *oidcAuthExecutor) ProcessAuthFlowResponse(ctx *providers.NodeContext,
 		"federated": &authncm.FederatedAuthCredential{
 			IDPID:   idpID,
 			IDPType: o.idpType,
-			Code:    code,
+			AuthorizationData: authncm.AuthorizationData{
+				Code:  code,
+				Nonce: ctx.RuntimeData[common.RuntimeKeyOIDCNonce],
+			},
 		},
 	}
 	authUser, federatedAttributes, svcErr := o.authnProvider.AuthenticateUser(
@@ -191,16 +219,6 @@ func (o *oidcAuthExecutor) ProcessAuthFlowResponse(ctx *providers.NodeContext,
 		return errors.New("OIDC authentication failed")
 	}
 	execResp.AuthUser = authUser
-
-	// Validate nonce if configured
-	if claimNonce, ok := federatedAttributes[userInputNonce]; ok && claimNonce != "" {
-		expectedNonce := ctx.UserInputs[userInputNonce]
-		if expectedNonce != "" && claimNonce != expectedNonce {
-			execResp.Status = providers.ExecFailure
-			execResp.Error = &ErrNonceMismatch
-			return nil
-		}
-	}
 
 	if !validateFederatedIdentifierConsistency(ctx, federatedAttributes, existingCtxUserAttributes) {
 		execResp.Status = providers.ExecFailure

--- a/backend/internal/flow/executor/oidc_auth_executor_test.go
+++ b/backend/internal/flow/executor/oidc_auth_executor_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/flow/common"
+	oauth2const "github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/tests/mocks/authn/oidcmock"
 	"github.com/thunder-id/thunderid/tests/mocks/authnprovider/managermock"
 	"github.com/thunder-id/thunderid/tests/mocks/flow/coremock"
@@ -54,12 +55,11 @@ func (suite *OIDCAuthExecutorTestSuite) SetupTest() {
 	suite.mockFlowFactory = coremock.NewFlowFactoryInterfaceMock(suite.T())
 	suite.mockAuthnProvider = managermock.NewAuthnProviderManagerMock(suite.T())
 
-	defaultInputs := []providers.Input{{Identifier: "code", Type: "string", Required: true}}
 	mockExec := createMockAuthExecutor(suite.T(), ExecutorNameOIDCAuth)
 	suite.mockFlowFactory.On("CreateExecutor", ExecutorNameOIDCAuth, providers.ExecutorTypeAuthentication,
-		defaultInputs, []providers.Input{}, mock.Anything).Return(mockExec)
+		defaultCodeOnlyInputs, []providers.Input{}, mock.Anything).Return(mockExec)
 
-	suite.executor = newOIDCAuthExecutor(ExecutorNameOIDCAuth, defaultInputs, []providers.Input{},
+	suite.executor = newOIDCAuthExecutor(ExecutorNameOIDCAuth, defaultCodeOnlyInputs, []providers.Input{},
 		suite.mockFlowFactory, suite.mockIDPService, suite.mockOIDCService,
 		suite.mockAuthnProvider, providers.IDPTypeOIDC)
 }
@@ -85,8 +85,13 @@ func (suite *OIDCAuthExecutorTestSuite) TestExecute_CodeNotProvided_BuildsAuthor
 		},
 	}
 
+	oidcURL := "https://oidc.provider.com/authorize?client_id=abc&scope=openid&state=test-state&nonce=test-nonce"
+	oidcParams := map[string]string{
+		oauth2const.RequestParamState: "test-state",
+		oauth2const.RequestParamNonce: "test-nonce",
+	}
 	suite.mockOIDCService.On("BuildAuthorizeURL", mock.Anything, "idp-123").
-		Return("https://oidc.provider.com/authorize?client_id=abc&scope=openid", nil)
+		Return(oidcURL, oidcParams, nil)
 
 	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, "idp-123").
 		Return(&providers.IDPDTO{ID: "idp-123", Name: "TestOIDCProvider"}, nil)
@@ -96,10 +101,92 @@ func (suite *OIDCAuthExecutorTestSuite) TestExecute_CodeNotProvided_BuildsAuthor
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), resp)
 	assert.Equal(suite.T(), providers.ExecExternalRedirection, resp.Status)
-	assert.Contains(suite.T(), resp.RedirectURL, "https://oidc.provider.com/authorize")
+	assert.Contains(suite.T(), resp.RedirectURL, oidcURL)
+	assert.Equal(suite.T(), "test-nonce", resp.RuntimeData[common.RuntimeKeyOIDCNonce])
+	assert.Equal(suite.T(), "test-state", resp.RuntimeData[common.RuntimeKeyOAuthState])
 	assert.Equal(suite.T(), "TestOIDCProvider", resp.AdditionalData[common.DataIDPName])
 	suite.mockOIDCService.AssertExpectations(suite.T())
 	suite.mockIDPService.AssertExpectations(suite.T())
+}
+
+func (suite *OIDCAuthExecutorTestSuite) TestExecute_BuildAuthorizeFlow_NonceMissingInMetadata() {
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    providers.FlowTypeAuthentication,
+		UserInputs:  map[string]string{},
+		NodeInputs:  []providers.Input{{Identifier: "code", Type: "string", Required: true}},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	oidcURL := "https://oidc.provider.com/authorize?client_id=abc&scope=openid&state=test-state"
+	suite.mockOIDCService.On("BuildAuthorizeURL", mock.Anything, "idp-123").
+		Return(oidcURL, map[string]string{oauth2const.RequestParamState: "test-state"}, nil)
+
+	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, "idp-123").
+		Return(&providers.IDPDTO{ID: "idp-123", Name: "TestOIDCProvider"}, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), resp)
+	assert.Contains(suite.T(), err.Error(), "OIDC nonce is missing")
+}
+
+func (suite *OIDCAuthExecutorTestSuite) TestExecute_BuildAuthorizeFlow_NonceEmptyInMetadata() {
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    providers.FlowTypeAuthentication,
+		UserInputs:  map[string]string{},
+		NodeInputs:  []providers.Input{{Identifier: "code", Type: "string", Required: true}},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	oidcURL := "https://oidc.provider.com/authorize?client_id=abc&scope=openid&state=test-state"
+	suite.mockOIDCService.On("BuildAuthorizeURL", mock.Anything, "idp-123").
+		Return(oidcURL, map[string]string{
+			oauth2const.RequestParamState: "test-state",
+			oauth2const.RequestParamNonce: "",
+		}, nil)
+
+	suite.mockIDPService.On("GetIdentityProvider", mock.Anything, "idp-123").
+		Return(&providers.IDPDTO{ID: "idp-123", Name: "TestOIDCProvider"}, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), resp)
+	assert.Contains(suite.T(), err.Error(), "OIDC nonce is missing")
+}
+
+func (suite *OIDCAuthExecutorTestSuite) TestExecute_BuildAuthorizeFlow_ClientErrorSkipsNonceCheck() {
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    providers.FlowTypeAuthentication,
+		UserInputs:  map[string]string{},
+		NodeInputs:  []providers.Input{{Identifier: "code", Type: "string", Required: true}},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	clientErr := &tidcommon.ServiceError{
+		Type:             tidcommon.ClientErrorType,
+		Code:             "IDP-001",
+		ErrorDescription: tidcommon.I18nMessage{DefaultValue: "IDP not configured"},
+	}
+	suite.mockOIDCService.On("BuildAuthorizeURL", mock.Anything, "idp-123").
+		Return("", (map[string]string)(nil), clientErr)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), providers.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), clientErr, resp.Error)
 }
 
 func (suite *OIDCAuthExecutorTestSuite) TestExecute_CodeProvided_ValidIDToken_AuthenticatesUser() {
@@ -238,8 +325,10 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_InvalidNonce
 		ExecutionID: "flow-123",
 		FlowType:    providers.FlowTypeAuthentication,
 		UserInputs: map[string]string{
-			"code":  "auth_code_123",
-			"nonce": "expected_nonce_123",
+			"code": "auth_code_123",
+		},
+		RuntimeData: map[string]string{
+			common.RuntimeKeyOIDCNonce: "expected_nonce_123",
 		},
 		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",
@@ -251,18 +340,91 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_InvalidNonce
 		RuntimeData:    make(map[string]string),
 	}
 
+	nonceMismatchErr := &tidcommon.ServiceError{
+		Type:  tidcommon.ClientErrorType,
+		Code:  "AUTH-OIDC-1003",
+		Error: tidcommon.I18nMessage{DefaultValue: "Nonce mismatch"},
+	}
 	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything).
-		Return(providers.AuthUser{}, providers.AuthenticatedClaims{
-			"sub":   "user-sub-123",
-			"nonce": "different_nonce_456",
-		}, (*tidcommon.ServiceError)(nil))
+		Return(providers.AuthUser{}, providers.AuthenticatedClaims(nil), nonceMismatchErr)
 
 	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), providers.ExecFailure, execResp.Status)
-	assert.Contains(suite.T(), execResp.Error.Error.DefaultValue, "Nonce mismatch")
+	assert.Equal(suite.T(), nonceMismatchErr, execResp.Error)
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
+}
+
+func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_ValidNonce() {
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    providers.FlowTypeAuthentication,
+		UserInputs: map[string]string{
+			"code": "auth_code_123",
+		},
+		RuntimeData: map[string]string{
+			common.RuntimeKeyOIDCNonce: "matching_nonce_123",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &providers.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	authenticatedAuthUser := newOIDCAuthenticatedUser()
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authenticatedAuthUser, providers.AuthenticatedClaims{
+			"sub":   "user-sub-123",
+			"email": "test@example.com",
+			"nonce": "matching_nonce_123",
+		}, (*tidcommon.ServiceError)(nil))
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecComplete, execResp.Status)
+	assert.True(suite.T(), execResp.AuthUser.IsAuthenticated())
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
+}
+
+func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_NonceMissingInRuntimeData() {
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    providers.FlowTypeAuthentication,
+		UserInputs: map[string]string{
+			"code": "auth_code_123",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &providers.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	nonceMismatchErr := &tidcommon.ServiceError{
+		Type:  tidcommon.ClientErrorType,
+		Code:  "AUTH-OIDC-1003",
+		Error: tidcommon.I18nMessage{DefaultValue: "Nonce mismatch"},
+	}
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(providers.AuthUser{}, providers.AuthenticatedClaims(nil), nonceMismatchErr)
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecFailure, execResp.Status)
+	assert.Equal(suite.T(), nonceMismatchErr, execResp.Error)
 	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
@@ -484,6 +646,9 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_FiltersNonUs
 		FlowType:    providers.FlowTypeAuthentication,
 		UserInputs: map[string]string{
 			"code": "auth_code_123",
+		},
+		RuntimeData: map[string]string{
+			common.RuntimeKeyOIDCNonce: "nonce_value",
 		},
 		NodeProperties: map[string]interface{}{
 			"idpId": "idp-123",

--- a/backend/internal/flow/executor/provisioning_executor_test.go
+++ b/backend/internal/flow/executor/provisioning_executor_test.go
@@ -373,7 +373,6 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Sch
 			"username": "testuser",
 			"userID":   "user-123",
 			"code":     "auth-code",
-			"nonce":    "test-nonce",
 		},
 		RuntimeData: map[string]string{userTypeKey: testUserType},
 		NodeInputs:  []providers.Input{},
@@ -384,7 +383,6 @@ func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_Sch
 	assert.Equal(suite.T(), "testuser", result["username"])
 	assert.NotContains(suite.T(), result, "userID")
 	assert.NotContains(suite.T(), result, "code")
-	assert.NotContains(suite.T(), result, "nonce")
 }
 
 // TestGetAttributesForProvisioning_RequiredAttrsFromMultipleSources verifies that required schema

--- a/backend/internal/flow/executor/utils_test.go
+++ b/backend/internal/flow/executor/utils_test.go
@@ -28,8 +28,28 @@ import (
 	authncm "github.com/thunder-id/thunderid/internal/authn/common"
 	"github.com/thunder-id/thunderid/internal/flow/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
+	"github.com/thunder-id/thunderid/tests/mocks/authnprovider/managermock"
 	"github.com/thunder-id/thunderid/tests/mocks/flow/coremock"
+	"github.com/thunder-id/thunderid/tests/mocks/idp/idpmock"
 )
+
+// setupSocialAuthExecutorMock creates the shared mocks for social auth executor constructor tests
+// (GitHub, Google) and wires the CreateExecutor expectation for the given executor name.
+func setupSocialAuthExecutorMock(t *testing.T, executorName string) (
+	*coremock.FlowFactoryInterfaceMock,
+	*idpmock.IDPServiceInterfaceMock,
+	*managermock.AuthnProviderManagerMock,
+) {
+	t.Helper()
+	mockFlowFactory := coremock.NewFlowFactoryInterfaceMock(t)
+	mockIDPService := idpmock.NewIDPServiceInterfaceMock(t)
+	mockAuthnProvider := managermock.NewAuthnProviderManagerMock(t)
+	baseExec := coremock.NewExecutorInterfaceMock(t)
+	mockFlowFactory.On("CreateExecutor", executorName,
+		providers.ExecutorTypeAuthentication, defaultCodeOnlyInputs, []providers.Input{}, mock.Anything).
+		Return(baseExec).Once()
+	return mockFlowFactory, mockIDPService, mockAuthnProvider
+}
 
 type UtilsTestSuite struct {
 	suite.Suite
@@ -65,14 +85,18 @@ func (s *UtilsTestSuite) TestGetAuthnServiceName() {
 	}
 }
 
+// defaultCodeOnlyInputs is the standard default input set for OAuth/OIDC executors that only require an
+// authorization code.
+var defaultCodeOnlyInputs = []providers.Input{
+	{Identifier: "code", Type: "string", Required: true},
+}
+
 // createMockAuthExecutor creates a mock executor for OAuth/OIDC authentication.
 func createMockAuthExecutor(t *testing.T, executorName string) providers.Executor {
 	mockExec := coremock.NewExecutorInterfaceMock(t)
 	mockExec.On("GetName").Return(executorName).Maybe()
 	mockExec.On("GetType").Return(providers.ExecutorTypeAuthentication).Maybe()
-	mockExec.On("GetDefaultInputs").Return([]providers.Input{
-		{Identifier: "code", Type: "string", Required: true},
-	}).Maybe()
+	mockExec.On("GetDefaultInputs").Return(defaultCodeOnlyInputs).Maybe()
 	mockExec.On("GetPrerequisites").Return([]providers.Input{}).Maybe()
 	mockExec.On("HasRequiredInputs", mock.Anything, mock.Anything).Return(
 		func(ctx *providers.NodeContext, execResp *providers.ExecutorResponse) bool {

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -1201,8 +1201,6 @@ var defaultMessages = map[string]string{
 	"flows.executor.errors.no_user_types_available_desc": "No user types are currently available",
 	"flows.executor.errors.no_valid_user_types": "No valid user types available",
 	"flows.executor.errors.no_valid_user_types_desc": "There are no valid user types configured for this flow",
-	"flows.executor.errors.nonce_mismatch": "Nonce mismatch in ID token",
-	"flows.executor.errors.nonce_mismatch_desc": "The nonce in the ID token claims does not match the expected value",
 	"flows.executor.errors.openid4vp_definition_not_configured": "OpenID4VP presentation definition is not configured",
 	"flows.executor.errors.openid4vp_definition_not_configured_desc": "The OpenID4VP node is missing the presentation_definition_id property",
 	"flows.executor.errors.openid4vp_expired": "The OpenID4VP request expired before a response was received",

--- a/backend/tests/mocks/authn/commonmock/FederatedAuthenticator_mock.go
+++ b/backend/tests/mocks/authn/commonmock/FederatedAuthenticator_mock.go
@@ -40,8 +40,8 @@ func (_m *FederatedAuthenticatorMock) EXPECT() *FederatedAuthenticatorMock_Expec
 }
 
 // Authenticate provides a mock function for the type FederatedAuthenticatorMock
-func (_mock *FederatedAuthenticatorMock) Authenticate(ctx context.Context, idpID string, code string) (*common.AuthnResult, *common0.ServiceError) {
-	ret := _mock.Called(ctx, idpID, code)
+func (_mock *FederatedAuthenticatorMock) Authenticate(ctx context.Context, idpID string, authzData common.AuthorizationData) (*common.AuthnResult, *common0.ServiceError) {
+	ret := _mock.Called(ctx, idpID, authzData)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Authenticate")
@@ -49,18 +49,18 @@ func (_mock *FederatedAuthenticatorMock) Authenticate(ctx context.Context, idpID
 
 	var r0 *common.AuthnResult
 	var r1 *common0.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*common.AuthnResult, *common0.ServiceError)); ok {
-		return returnFunc(ctx, idpID, code)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common.AuthorizationData) (*common.AuthnResult, *common0.ServiceError)); ok {
+		return returnFunc(ctx, idpID, authzData)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *common.AuthnResult); ok {
-		r0 = returnFunc(ctx, idpID, code)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common.AuthorizationData) *common.AuthnResult); ok {
+		r0 = returnFunc(ctx, idpID, authzData)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.AuthnResult)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *common0.ServiceError); ok {
-		r1 = returnFunc(ctx, idpID, code)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, common.AuthorizationData) *common0.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, authzData)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*common0.ServiceError)
@@ -77,12 +77,12 @@ type FederatedAuthenticatorMock_Authenticate_Call struct {
 // Authenticate is a helper method to define mock.On call
 //   - ctx context.Context
 //   - idpID string
-//   - code string
-func (_e *FederatedAuthenticatorMock_Expecter) Authenticate(ctx interface{}, idpID interface{}, code interface{}) *FederatedAuthenticatorMock_Authenticate_Call {
-	return &FederatedAuthenticatorMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, idpID, code)}
+//   - authzData common.AuthorizationData
+func (_e *FederatedAuthenticatorMock_Expecter) Authenticate(ctx interface{}, idpID interface{}, authzData interface{}) *FederatedAuthenticatorMock_Authenticate_Call {
+	return &FederatedAuthenticatorMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, idpID, authzData)}
 }
 
-func (_c *FederatedAuthenticatorMock_Authenticate_Call) Run(run func(ctx context.Context, idpID string, code string)) *FederatedAuthenticatorMock_Authenticate_Call {
+func (_c *FederatedAuthenticatorMock_Authenticate_Call) Run(run func(ctx context.Context, idpID string, authzData common.AuthorizationData)) *FederatedAuthenticatorMock_Authenticate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -92,9 +92,9 @@ func (_c *FederatedAuthenticatorMock_Authenticate_Call) Run(run func(ctx context
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 string
+		var arg2 common.AuthorizationData
 		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg2 = args[2].(common.AuthorizationData)
 		}
 		run(
 			arg0,
@@ -110,7 +110,7 @@ func (_c *FederatedAuthenticatorMock_Authenticate_Call) Return(authnResult *comm
 	return _c
 }
 
-func (_c *FederatedAuthenticatorMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, idpID string, code string) (*common.AuthnResult, *common0.ServiceError)) *FederatedAuthenticatorMock_Authenticate_Call {
+func (_c *FederatedAuthenticatorMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, idpID string, authzData common.AuthorizationData) (*common.AuthnResult, *common0.ServiceError)) *FederatedAuthenticatorMock_Authenticate_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/authn/githubmock/GithubOAuthAuthnServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/githubmock/GithubOAuthAuthnServiceInterface_mock.go
@@ -41,8 +41,8 @@ func (_m *GithubOAuthAuthnServiceInterfaceMock) EXPECT() *GithubOAuthAuthnServic
 }
 
 // Authenticate provides a mock function for the type GithubOAuthAuthnServiceInterfaceMock
-func (_mock *GithubOAuthAuthnServiceInterfaceMock) Authenticate(ctx context.Context, idpID string, code string) (*common.AuthnResult, *common0.ServiceError) {
-	ret := _mock.Called(ctx, idpID, code)
+func (_mock *GithubOAuthAuthnServiceInterfaceMock) Authenticate(ctx context.Context, idpID string, authzData common.AuthorizationData) (*common.AuthnResult, *common0.ServiceError) {
+	ret := _mock.Called(ctx, idpID, authzData)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Authenticate")
@@ -50,18 +50,18 @@ func (_mock *GithubOAuthAuthnServiceInterfaceMock) Authenticate(ctx context.Cont
 
 	var r0 *common.AuthnResult
 	var r1 *common0.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*common.AuthnResult, *common0.ServiceError)); ok {
-		return returnFunc(ctx, idpID, code)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common.AuthorizationData) (*common.AuthnResult, *common0.ServiceError)); ok {
+		return returnFunc(ctx, idpID, authzData)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *common.AuthnResult); ok {
-		r0 = returnFunc(ctx, idpID, code)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common.AuthorizationData) *common.AuthnResult); ok {
+		r0 = returnFunc(ctx, idpID, authzData)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.AuthnResult)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *common0.ServiceError); ok {
-		r1 = returnFunc(ctx, idpID, code)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, common.AuthorizationData) *common0.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, authzData)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*common0.ServiceError)
@@ -78,12 +78,12 @@ type GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call struct {
 // Authenticate is a helper method to define mock.On call
 //   - ctx context.Context
 //   - idpID string
-//   - code string
-func (_e *GithubOAuthAuthnServiceInterfaceMock_Expecter) Authenticate(ctx interface{}, idpID interface{}, code interface{}) *GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call {
-	return &GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, idpID, code)}
+//   - authzData common.AuthorizationData
+func (_e *GithubOAuthAuthnServiceInterfaceMock_Expecter) Authenticate(ctx interface{}, idpID interface{}, authzData interface{}) *GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call {
+	return &GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, idpID, authzData)}
 }
 
-func (_c *GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call) Run(run func(ctx context.Context, idpID string, code string)) *GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call {
+func (_c *GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call) Run(run func(ctx context.Context, idpID string, authzData common.AuthorizationData)) *GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -93,9 +93,9 @@ func (_c *GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call) Run(run func(c
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 string
+		var arg2 common.AuthorizationData
 		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg2 = args[2].(common.AuthorizationData)
 		}
 		run(
 			arg0,
@@ -111,13 +111,13 @@ func (_c *GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call) Return(authnRe
 	return _c
 }
 
-func (_c *GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, idpID string, code string) (*common.AuthnResult, *common0.ServiceError)) *GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call {
+func (_c *GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, idpID string, authzData common.AuthorizationData) (*common.AuthnResult, *common0.ServiceError)) *GithubOAuthAuthnServiceInterfaceMock_Authenticate_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // BuildAuthorizeURL provides a mock function for the type GithubOAuthAuthnServiceInterfaceMock
-func (_mock *GithubOAuthAuthnServiceInterfaceMock) BuildAuthorizeURL(ctx context.Context, idpID string) (string, *common0.ServiceError) {
+func (_mock *GithubOAuthAuthnServiceInterfaceMock) BuildAuthorizeURL(ctx context.Context, idpID string) (string, map[string]string, *common0.ServiceError) {
 	ret := _mock.Called(ctx, idpID)
 
 	if len(ret) == 0 {
@@ -125,8 +125,9 @@ func (_mock *GithubOAuthAuthnServiceInterfaceMock) BuildAuthorizeURL(ctx context
 	}
 
 	var r0 string
-	var r1 *common0.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (string, *common0.ServiceError)); ok {
+	var r1 map[string]string
+	var r2 *common0.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (string, map[string]string, *common0.ServiceError)); ok {
 		return returnFunc(ctx, idpID)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string) string); ok {
@@ -134,14 +135,21 @@ func (_mock *GithubOAuthAuthnServiceInterfaceMock) BuildAuthorizeURL(ctx context
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *common0.ServiceError); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) map[string]string); ok {
 		r1 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*common0.ServiceError)
+			r1 = ret.Get(1).(map[string]string)
 		}
 	}
-	return r0, r1
+	if returnFunc, ok := ret.Get(2).(func(context.Context, string) *common0.ServiceError); ok {
+		r2 = returnFunc(ctx, idpID)
+	} else {
+		if ret.Get(2) != nil {
+			r2 = ret.Get(2).(*common0.ServiceError)
+		}
+	}
+	return r0, r1, r2
 }
 
 // GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BuildAuthorizeURL'
@@ -174,12 +182,12 @@ func (_c *GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Run(run f
 	return _c
 }
 
-func (_c *GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Return(s string, serviceError *common0.ServiceError) *GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
-	_c.Call.Return(s, serviceError)
+func (_c *GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Return(s string, stringToString map[string]string, serviceError *common0.ServiceError) *GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
+	_c.Call.Return(s, stringToString, serviceError)
 	return _c
 }
 
-func (_c *GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(ctx context.Context, idpID string) (string, *common0.ServiceError)) *GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
+func (_c *GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(ctx context.Context, idpID string) (string, map[string]string, *common0.ServiceError)) *GithubOAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/authn/googlemock/GoogleOIDCAuthnServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/googlemock/GoogleOIDCAuthnServiceInterface_mock.go
@@ -41,8 +41,8 @@ func (_m *GoogleOIDCAuthnServiceInterfaceMock) EXPECT() *GoogleOIDCAuthnServiceI
 }
 
 // Authenticate provides a mock function for the type GoogleOIDCAuthnServiceInterfaceMock
-func (_mock *GoogleOIDCAuthnServiceInterfaceMock) Authenticate(ctx context.Context, idpID string, code string) (*common.AuthnResult, *common0.ServiceError) {
-	ret := _mock.Called(ctx, idpID, code)
+func (_mock *GoogleOIDCAuthnServiceInterfaceMock) Authenticate(ctx context.Context, idpID string, authzData common.AuthorizationData) (*common.AuthnResult, *common0.ServiceError) {
+	ret := _mock.Called(ctx, idpID, authzData)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Authenticate")
@@ -50,18 +50,18 @@ func (_mock *GoogleOIDCAuthnServiceInterfaceMock) Authenticate(ctx context.Conte
 
 	var r0 *common.AuthnResult
 	var r1 *common0.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*common.AuthnResult, *common0.ServiceError)); ok {
-		return returnFunc(ctx, idpID, code)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common.AuthorizationData) (*common.AuthnResult, *common0.ServiceError)); ok {
+		return returnFunc(ctx, idpID, authzData)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *common.AuthnResult); ok {
-		r0 = returnFunc(ctx, idpID, code)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common.AuthorizationData) *common.AuthnResult); ok {
+		r0 = returnFunc(ctx, idpID, authzData)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.AuthnResult)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *common0.ServiceError); ok {
-		r1 = returnFunc(ctx, idpID, code)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, common.AuthorizationData) *common0.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, authzData)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*common0.ServiceError)
@@ -78,12 +78,12 @@ type GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call struct {
 // Authenticate is a helper method to define mock.On call
 //   - ctx context.Context
 //   - idpID string
-//   - code string
-func (_e *GoogleOIDCAuthnServiceInterfaceMock_Expecter) Authenticate(ctx interface{}, idpID interface{}, code interface{}) *GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call {
-	return &GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, idpID, code)}
+//   - authzData common.AuthorizationData
+func (_e *GoogleOIDCAuthnServiceInterfaceMock_Expecter) Authenticate(ctx interface{}, idpID interface{}, authzData interface{}) *GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call {
+	return &GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, idpID, authzData)}
 }
 
-func (_c *GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call) Run(run func(ctx context.Context, idpID string, code string)) *GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call {
+func (_c *GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call) Run(run func(ctx context.Context, idpID string, authzData common.AuthorizationData)) *GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -93,9 +93,9 @@ func (_c *GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call) Run(run func(ct
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 string
+		var arg2 common.AuthorizationData
 		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg2 = args[2].(common.AuthorizationData)
 		}
 		run(
 			arg0,
@@ -111,13 +111,13 @@ func (_c *GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call) Return(authnRes
 	return _c
 }
 
-func (_c *GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, idpID string, code string) (*common.AuthnResult, *common0.ServiceError)) *GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call {
+func (_c *GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, idpID string, authzData common.AuthorizationData) (*common.AuthnResult, *common0.ServiceError)) *GoogleOIDCAuthnServiceInterfaceMock_Authenticate_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // BuildAuthorizeURL provides a mock function for the type GoogleOIDCAuthnServiceInterfaceMock
-func (_mock *GoogleOIDCAuthnServiceInterfaceMock) BuildAuthorizeURL(ctx context.Context, idpID string) (string, *common0.ServiceError) {
+func (_mock *GoogleOIDCAuthnServiceInterfaceMock) BuildAuthorizeURL(ctx context.Context, idpID string) (string, map[string]string, *common0.ServiceError) {
 	ret := _mock.Called(ctx, idpID)
 
 	if len(ret) == 0 {
@@ -125,8 +125,9 @@ func (_mock *GoogleOIDCAuthnServiceInterfaceMock) BuildAuthorizeURL(ctx context.
 	}
 
 	var r0 string
-	var r1 *common0.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (string, *common0.ServiceError)); ok {
+	var r1 map[string]string
+	var r2 *common0.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (string, map[string]string, *common0.ServiceError)); ok {
 		return returnFunc(ctx, idpID)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string) string); ok {
@@ -134,14 +135,21 @@ func (_mock *GoogleOIDCAuthnServiceInterfaceMock) BuildAuthorizeURL(ctx context.
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *common0.ServiceError); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) map[string]string); ok {
 		r1 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*common0.ServiceError)
+			r1 = ret.Get(1).(map[string]string)
 		}
 	}
-	return r0, r1
+	if returnFunc, ok := ret.Get(2).(func(context.Context, string) *common0.ServiceError); ok {
+		r2 = returnFunc(ctx, idpID)
+	} else {
+		if ret.Get(2) != nil {
+			r2 = ret.Get(2).(*common0.ServiceError)
+		}
+	}
+	return r0, r1, r2
 }
 
 // GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BuildAuthorizeURL'
@@ -174,12 +182,12 @@ func (_c *GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Run(run fu
 	return _c
 }
 
-func (_c *GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Return(s string, serviceError *common0.ServiceError) *GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
-	_c.Call.Return(s, serviceError)
+func (_c *GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Return(s string, stringToString map[string]string, serviceError *common0.ServiceError) *GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
+	_c.Call.Return(s, stringToString, serviceError)
 	return _c
 }
 
-func (_c *GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(ctx context.Context, idpID string) (string, *common0.ServiceError)) *GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
+func (_c *GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(ctx context.Context, idpID string) (string, map[string]string, *common0.ServiceError)) *GoogleOIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/authn/oauthmock/OAuthAuthnCoreServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/oauthmock/OAuthAuthnCoreServiceInterface_mock.go
@@ -41,8 +41,8 @@ func (_m *OAuthAuthnCoreServiceInterfaceMock) EXPECT() *OAuthAuthnCoreServiceInt
 }
 
 // Authenticate provides a mock function for the type OAuthAuthnCoreServiceInterfaceMock
-func (_mock *OAuthAuthnCoreServiceInterfaceMock) Authenticate(ctx context.Context, idpID string, code string) (*common.AuthnResult, *common0.ServiceError) {
-	ret := _mock.Called(ctx, idpID, code)
+func (_mock *OAuthAuthnCoreServiceInterfaceMock) Authenticate(ctx context.Context, idpID string, authzData common.AuthorizationData) (*common.AuthnResult, *common0.ServiceError) {
+	ret := _mock.Called(ctx, idpID, authzData)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Authenticate")
@@ -50,18 +50,18 @@ func (_mock *OAuthAuthnCoreServiceInterfaceMock) Authenticate(ctx context.Contex
 
 	var r0 *common.AuthnResult
 	var r1 *common0.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*common.AuthnResult, *common0.ServiceError)); ok {
-		return returnFunc(ctx, idpID, code)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common.AuthorizationData) (*common.AuthnResult, *common0.ServiceError)); ok {
+		return returnFunc(ctx, idpID, authzData)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *common.AuthnResult); ok {
-		r0 = returnFunc(ctx, idpID, code)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common.AuthorizationData) *common.AuthnResult); ok {
+		r0 = returnFunc(ctx, idpID, authzData)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.AuthnResult)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *common0.ServiceError); ok {
-		r1 = returnFunc(ctx, idpID, code)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, common.AuthorizationData) *common0.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, authzData)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*common0.ServiceError)
@@ -78,12 +78,12 @@ type OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call struct {
 // Authenticate is a helper method to define mock.On call
 //   - ctx context.Context
 //   - idpID string
-//   - code string
-func (_e *OAuthAuthnCoreServiceInterfaceMock_Expecter) Authenticate(ctx interface{}, idpID interface{}, code interface{}) *OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call {
-	return &OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, idpID, code)}
+//   - authzData common.AuthorizationData
+func (_e *OAuthAuthnCoreServiceInterfaceMock_Expecter) Authenticate(ctx interface{}, idpID interface{}, authzData interface{}) *OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call {
+	return &OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, idpID, authzData)}
 }
 
-func (_c *OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call) Run(run func(ctx context.Context, idpID string, code string)) *OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call {
+func (_c *OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call) Run(run func(ctx context.Context, idpID string, authzData common.AuthorizationData)) *OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -93,9 +93,9 @@ func (_c *OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call) Run(run func(ctx
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 string
+		var arg2 common.AuthorizationData
 		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg2 = args[2].(common.AuthorizationData)
 		}
 		run(
 			arg0,
@@ -111,13 +111,13 @@ func (_c *OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call) Return(authnResu
 	return _c
 }
 
-func (_c *OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, idpID string, code string) (*common.AuthnResult, *common0.ServiceError)) *OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call {
+func (_c *OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, idpID string, authzData common.AuthorizationData) (*common.AuthnResult, *common0.ServiceError)) *OAuthAuthnCoreServiceInterfaceMock_Authenticate_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // BuildAuthorizeURL provides a mock function for the type OAuthAuthnCoreServiceInterfaceMock
-func (_mock *OAuthAuthnCoreServiceInterfaceMock) BuildAuthorizeURL(ctx context.Context, idpID string) (string, *common0.ServiceError) {
+func (_mock *OAuthAuthnCoreServiceInterfaceMock) BuildAuthorizeURL(ctx context.Context, idpID string) (string, map[string]string, *common0.ServiceError) {
 	ret := _mock.Called(ctx, idpID)
 
 	if len(ret) == 0 {
@@ -125,8 +125,9 @@ func (_mock *OAuthAuthnCoreServiceInterfaceMock) BuildAuthorizeURL(ctx context.C
 	}
 
 	var r0 string
-	var r1 *common0.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (string, *common0.ServiceError)); ok {
+	var r1 map[string]string
+	var r2 *common0.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (string, map[string]string, *common0.ServiceError)); ok {
 		return returnFunc(ctx, idpID)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string) string); ok {
@@ -134,14 +135,21 @@ func (_mock *OAuthAuthnCoreServiceInterfaceMock) BuildAuthorizeURL(ctx context.C
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *common0.ServiceError); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) map[string]string); ok {
 		r1 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*common0.ServiceError)
+			r1 = ret.Get(1).(map[string]string)
 		}
 	}
-	return r0, r1
+	if returnFunc, ok := ret.Get(2).(func(context.Context, string) *common0.ServiceError); ok {
+		r2 = returnFunc(ctx, idpID)
+	} else {
+		if ret.Get(2) != nil {
+			r2 = ret.Get(2).(*common0.ServiceError)
+		}
+	}
+	return r0, r1, r2
 }
 
 // OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BuildAuthorizeURL'
@@ -174,12 +182,12 @@ func (_c *OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call) Run(run fun
 	return _c
 }
 
-func (_c *OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call) Return(s string, serviceError *common0.ServiceError) *OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call {
-	_c.Call.Return(s, serviceError)
+func (_c *OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call) Return(s string, stringToString map[string]string, serviceError *common0.ServiceError) *OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call {
+	_c.Call.Return(s, stringToString, serviceError)
 	return _c
 }
 
-func (_c *OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(ctx context.Context, idpID string) (string, *common0.ServiceError)) *OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call {
+func (_c *OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(ctx context.Context, idpID string) (string, map[string]string, *common0.ServiceError)) *OAuthAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/authn/oauthmock/OAuthAuthnServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/oauthmock/OAuthAuthnServiceInterface_mock.go
@@ -41,8 +41,8 @@ func (_m *OAuthAuthnServiceInterfaceMock) EXPECT() *OAuthAuthnServiceInterfaceMo
 }
 
 // Authenticate provides a mock function for the type OAuthAuthnServiceInterfaceMock
-func (_mock *OAuthAuthnServiceInterfaceMock) Authenticate(ctx context.Context, idpID string, code string) (*common.AuthnResult, *common0.ServiceError) {
-	ret := _mock.Called(ctx, idpID, code)
+func (_mock *OAuthAuthnServiceInterfaceMock) Authenticate(ctx context.Context, idpID string, authzData common.AuthorizationData) (*common.AuthnResult, *common0.ServiceError) {
+	ret := _mock.Called(ctx, idpID, authzData)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Authenticate")
@@ -50,18 +50,18 @@ func (_mock *OAuthAuthnServiceInterfaceMock) Authenticate(ctx context.Context, i
 
 	var r0 *common.AuthnResult
 	var r1 *common0.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*common.AuthnResult, *common0.ServiceError)); ok {
-		return returnFunc(ctx, idpID, code)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common.AuthorizationData) (*common.AuthnResult, *common0.ServiceError)); ok {
+		return returnFunc(ctx, idpID, authzData)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *common.AuthnResult); ok {
-		r0 = returnFunc(ctx, idpID, code)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common.AuthorizationData) *common.AuthnResult); ok {
+		r0 = returnFunc(ctx, idpID, authzData)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.AuthnResult)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *common0.ServiceError); ok {
-		r1 = returnFunc(ctx, idpID, code)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, common.AuthorizationData) *common0.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, authzData)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*common0.ServiceError)
@@ -78,12 +78,12 @@ type OAuthAuthnServiceInterfaceMock_Authenticate_Call struct {
 // Authenticate is a helper method to define mock.On call
 //   - ctx context.Context
 //   - idpID string
-//   - code string
-func (_e *OAuthAuthnServiceInterfaceMock_Expecter) Authenticate(ctx interface{}, idpID interface{}, code interface{}) *OAuthAuthnServiceInterfaceMock_Authenticate_Call {
-	return &OAuthAuthnServiceInterfaceMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, idpID, code)}
+//   - authzData common.AuthorizationData
+func (_e *OAuthAuthnServiceInterfaceMock_Expecter) Authenticate(ctx interface{}, idpID interface{}, authzData interface{}) *OAuthAuthnServiceInterfaceMock_Authenticate_Call {
+	return &OAuthAuthnServiceInterfaceMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, idpID, authzData)}
 }
 
-func (_c *OAuthAuthnServiceInterfaceMock_Authenticate_Call) Run(run func(ctx context.Context, idpID string, code string)) *OAuthAuthnServiceInterfaceMock_Authenticate_Call {
+func (_c *OAuthAuthnServiceInterfaceMock_Authenticate_Call) Run(run func(ctx context.Context, idpID string, authzData common.AuthorizationData)) *OAuthAuthnServiceInterfaceMock_Authenticate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -93,9 +93,9 @@ func (_c *OAuthAuthnServiceInterfaceMock_Authenticate_Call) Run(run func(ctx con
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 string
+		var arg2 common.AuthorizationData
 		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg2 = args[2].(common.AuthorizationData)
 		}
 		run(
 			arg0,
@@ -111,13 +111,13 @@ func (_c *OAuthAuthnServiceInterfaceMock_Authenticate_Call) Return(authnResult *
 	return _c
 }
 
-func (_c *OAuthAuthnServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, idpID string, code string) (*common.AuthnResult, *common0.ServiceError)) *OAuthAuthnServiceInterfaceMock_Authenticate_Call {
+func (_c *OAuthAuthnServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, idpID string, authzData common.AuthorizationData) (*common.AuthnResult, *common0.ServiceError)) *OAuthAuthnServiceInterfaceMock_Authenticate_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // BuildAuthorizeURL provides a mock function for the type OAuthAuthnServiceInterfaceMock
-func (_mock *OAuthAuthnServiceInterfaceMock) BuildAuthorizeURL(ctx context.Context, idpID string) (string, *common0.ServiceError) {
+func (_mock *OAuthAuthnServiceInterfaceMock) BuildAuthorizeURL(ctx context.Context, idpID string) (string, map[string]string, *common0.ServiceError) {
 	ret := _mock.Called(ctx, idpID)
 
 	if len(ret) == 0 {
@@ -125,8 +125,9 @@ func (_mock *OAuthAuthnServiceInterfaceMock) BuildAuthorizeURL(ctx context.Conte
 	}
 
 	var r0 string
-	var r1 *common0.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (string, *common0.ServiceError)); ok {
+	var r1 map[string]string
+	var r2 *common0.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (string, map[string]string, *common0.ServiceError)); ok {
 		return returnFunc(ctx, idpID)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string) string); ok {
@@ -134,14 +135,21 @@ func (_mock *OAuthAuthnServiceInterfaceMock) BuildAuthorizeURL(ctx context.Conte
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *common0.ServiceError); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) map[string]string); ok {
 		r1 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*common0.ServiceError)
+			r1 = ret.Get(1).(map[string]string)
 		}
 	}
-	return r0, r1
+	if returnFunc, ok := ret.Get(2).(func(context.Context, string) *common0.ServiceError); ok {
+		r2 = returnFunc(ctx, idpID)
+	} else {
+		if ret.Get(2) != nil {
+			r2 = ret.Get(2).(*common0.ServiceError)
+		}
+	}
+	return r0, r1, r2
 }
 
 // OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BuildAuthorizeURL'
@@ -174,12 +182,12 @@ func (_c *OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Run(run func(ct
 	return _c
 }
 
-func (_c *OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Return(s string, serviceError *common0.ServiceError) *OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
-	_c.Call.Return(s, serviceError)
+func (_c *OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Return(s string, stringToString map[string]string, serviceError *common0.ServiceError) *OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
+	_c.Call.Return(s, stringToString, serviceError)
 	return _c
 }
 
-func (_c *OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(ctx context.Context, idpID string) (string, *common0.ServiceError)) *OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
+func (_c *OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(ctx context.Context, idpID string) (string, map[string]string, *common0.ServiceError)) *OAuthAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/authn/oidcmock/OIDCAuthnCoreServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/oidcmock/OIDCAuthnCoreServiceInterface_mock.go
@@ -41,8 +41,8 @@ func (_m *OIDCAuthnCoreServiceInterfaceMock) EXPECT() *OIDCAuthnCoreServiceInter
 }
 
 // Authenticate provides a mock function for the type OIDCAuthnCoreServiceInterfaceMock
-func (_mock *OIDCAuthnCoreServiceInterfaceMock) Authenticate(ctx context.Context, idpID string, code string) (*common.AuthnResult, *common0.ServiceError) {
-	ret := _mock.Called(ctx, idpID, code)
+func (_mock *OIDCAuthnCoreServiceInterfaceMock) Authenticate(ctx context.Context, idpID string, authzData common.AuthorizationData) (*common.AuthnResult, *common0.ServiceError) {
+	ret := _mock.Called(ctx, idpID, authzData)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Authenticate")
@@ -50,18 +50,18 @@ func (_mock *OIDCAuthnCoreServiceInterfaceMock) Authenticate(ctx context.Context
 
 	var r0 *common.AuthnResult
 	var r1 *common0.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*common.AuthnResult, *common0.ServiceError)); ok {
-		return returnFunc(ctx, idpID, code)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common.AuthorizationData) (*common.AuthnResult, *common0.ServiceError)); ok {
+		return returnFunc(ctx, idpID, authzData)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *common.AuthnResult); ok {
-		r0 = returnFunc(ctx, idpID, code)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common.AuthorizationData) *common.AuthnResult); ok {
+		r0 = returnFunc(ctx, idpID, authzData)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.AuthnResult)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *common0.ServiceError); ok {
-		r1 = returnFunc(ctx, idpID, code)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, common.AuthorizationData) *common0.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, authzData)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*common0.ServiceError)
@@ -78,12 +78,12 @@ type OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call struct {
 // Authenticate is a helper method to define mock.On call
 //   - ctx context.Context
 //   - idpID string
-//   - code string
-func (_e *OIDCAuthnCoreServiceInterfaceMock_Expecter) Authenticate(ctx interface{}, idpID interface{}, code interface{}) *OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call {
-	return &OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, idpID, code)}
+//   - authzData common.AuthorizationData
+func (_e *OIDCAuthnCoreServiceInterfaceMock_Expecter) Authenticate(ctx interface{}, idpID interface{}, authzData interface{}) *OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call {
+	return &OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, idpID, authzData)}
 }
 
-func (_c *OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call) Run(run func(ctx context.Context, idpID string, code string)) *OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call {
+func (_c *OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call) Run(run func(ctx context.Context, idpID string, authzData common.AuthorizationData)) *OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -93,9 +93,9 @@ func (_c *OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call) Run(run func(ctx 
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 string
+		var arg2 common.AuthorizationData
 		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg2 = args[2].(common.AuthorizationData)
 		}
 		run(
 			arg0,
@@ -111,13 +111,13 @@ func (_c *OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call) Return(authnResul
 	return _c
 }
 
-func (_c *OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, idpID string, code string) (*common.AuthnResult, *common0.ServiceError)) *OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call {
+func (_c *OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, idpID string, authzData common.AuthorizationData) (*common.AuthnResult, *common0.ServiceError)) *OIDCAuthnCoreServiceInterfaceMock_Authenticate_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // BuildAuthorizeURL provides a mock function for the type OIDCAuthnCoreServiceInterfaceMock
-func (_mock *OIDCAuthnCoreServiceInterfaceMock) BuildAuthorizeURL(ctx context.Context, idpID string) (string, *common0.ServiceError) {
+func (_mock *OIDCAuthnCoreServiceInterfaceMock) BuildAuthorizeURL(ctx context.Context, idpID string) (string, map[string]string, *common0.ServiceError) {
 	ret := _mock.Called(ctx, idpID)
 
 	if len(ret) == 0 {
@@ -125,8 +125,9 @@ func (_mock *OIDCAuthnCoreServiceInterfaceMock) BuildAuthorizeURL(ctx context.Co
 	}
 
 	var r0 string
-	var r1 *common0.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (string, *common0.ServiceError)); ok {
+	var r1 map[string]string
+	var r2 *common0.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (string, map[string]string, *common0.ServiceError)); ok {
 		return returnFunc(ctx, idpID)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string) string); ok {
@@ -134,14 +135,21 @@ func (_mock *OIDCAuthnCoreServiceInterfaceMock) BuildAuthorizeURL(ctx context.Co
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *common0.ServiceError); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) map[string]string); ok {
 		r1 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*common0.ServiceError)
+			r1 = ret.Get(1).(map[string]string)
 		}
 	}
-	return r0, r1
+	if returnFunc, ok := ret.Get(2).(func(context.Context, string) *common0.ServiceError); ok {
+		r2 = returnFunc(ctx, idpID)
+	} else {
+		if ret.Get(2) != nil {
+			r2 = ret.Get(2).(*common0.ServiceError)
+		}
+	}
+	return r0, r1, r2
 }
 
 // OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BuildAuthorizeURL'
@@ -174,12 +182,12 @@ func (_c *OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call) Run(run func
 	return _c
 }
 
-func (_c *OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call) Return(s string, serviceError *common0.ServiceError) *OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call {
-	_c.Call.Return(s, serviceError)
+func (_c *OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call) Return(s string, stringToString map[string]string, serviceError *common0.ServiceError) *OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call {
+	_c.Call.Return(s, stringToString, serviceError)
 	return _c
 }
 
-func (_c *OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(ctx context.Context, idpID string) (string, *common0.ServiceError)) *OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call {
+func (_c *OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(ctx context.Context, idpID string) (string, map[string]string, *common0.ServiceError)) *OIDCAuthnCoreServiceInterfaceMock_BuildAuthorizeURL_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/authn/oidcmock/OIDCAuthnServiceInterface_mock.go
+++ b/backend/tests/mocks/authn/oidcmock/OIDCAuthnServiceInterface_mock.go
@@ -41,8 +41,8 @@ func (_m *OIDCAuthnServiceInterfaceMock) EXPECT() *OIDCAuthnServiceInterfaceMock
 }
 
 // Authenticate provides a mock function for the type OIDCAuthnServiceInterfaceMock
-func (_mock *OIDCAuthnServiceInterfaceMock) Authenticate(ctx context.Context, idpID string, code string) (*common.AuthnResult, *common0.ServiceError) {
-	ret := _mock.Called(ctx, idpID, code)
+func (_mock *OIDCAuthnServiceInterfaceMock) Authenticate(ctx context.Context, idpID string, authzData common.AuthorizationData) (*common.AuthnResult, *common0.ServiceError) {
+	ret := _mock.Called(ctx, idpID, authzData)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Authenticate")
@@ -50,18 +50,18 @@ func (_mock *OIDCAuthnServiceInterfaceMock) Authenticate(ctx context.Context, id
 
 	var r0 *common.AuthnResult
 	var r1 *common0.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*common.AuthnResult, *common0.ServiceError)); ok {
-		return returnFunc(ctx, idpID, code)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common.AuthorizationData) (*common.AuthnResult, *common0.ServiceError)); ok {
+		return returnFunc(ctx, idpID, authzData)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *common.AuthnResult); ok {
-		r0 = returnFunc(ctx, idpID, code)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, common.AuthorizationData) *common.AuthnResult); ok {
+		r0 = returnFunc(ctx, idpID, authzData)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*common.AuthnResult)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *common0.ServiceError); ok {
-		r1 = returnFunc(ctx, idpID, code)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, common.AuthorizationData) *common0.ServiceError); ok {
+		r1 = returnFunc(ctx, idpID, authzData)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*common0.ServiceError)
@@ -78,12 +78,12 @@ type OIDCAuthnServiceInterfaceMock_Authenticate_Call struct {
 // Authenticate is a helper method to define mock.On call
 //   - ctx context.Context
 //   - idpID string
-//   - code string
-func (_e *OIDCAuthnServiceInterfaceMock_Expecter) Authenticate(ctx interface{}, idpID interface{}, code interface{}) *OIDCAuthnServiceInterfaceMock_Authenticate_Call {
-	return &OIDCAuthnServiceInterfaceMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, idpID, code)}
+//   - authzData common.AuthorizationData
+func (_e *OIDCAuthnServiceInterfaceMock_Expecter) Authenticate(ctx interface{}, idpID interface{}, authzData interface{}) *OIDCAuthnServiceInterfaceMock_Authenticate_Call {
+	return &OIDCAuthnServiceInterfaceMock_Authenticate_Call{Call: _e.mock.On("Authenticate", ctx, idpID, authzData)}
 }
 
-func (_c *OIDCAuthnServiceInterfaceMock_Authenticate_Call) Run(run func(ctx context.Context, idpID string, code string)) *OIDCAuthnServiceInterfaceMock_Authenticate_Call {
+func (_c *OIDCAuthnServiceInterfaceMock_Authenticate_Call) Run(run func(ctx context.Context, idpID string, authzData common.AuthorizationData)) *OIDCAuthnServiceInterfaceMock_Authenticate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -93,9 +93,9 @@ func (_c *OIDCAuthnServiceInterfaceMock_Authenticate_Call) Run(run func(ctx cont
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 string
+		var arg2 common.AuthorizationData
 		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg2 = args[2].(common.AuthorizationData)
 		}
 		run(
 			arg0,
@@ -111,13 +111,13 @@ func (_c *OIDCAuthnServiceInterfaceMock_Authenticate_Call) Return(authnResult *c
 	return _c
 }
 
-func (_c *OIDCAuthnServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, idpID string, code string) (*common.AuthnResult, *common0.ServiceError)) *OIDCAuthnServiceInterfaceMock_Authenticate_Call {
+func (_c *OIDCAuthnServiceInterfaceMock_Authenticate_Call) RunAndReturn(run func(ctx context.Context, idpID string, authzData common.AuthorizationData) (*common.AuthnResult, *common0.ServiceError)) *OIDCAuthnServiceInterfaceMock_Authenticate_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // BuildAuthorizeURL provides a mock function for the type OIDCAuthnServiceInterfaceMock
-func (_mock *OIDCAuthnServiceInterfaceMock) BuildAuthorizeURL(ctx context.Context, idpID string) (string, *common0.ServiceError) {
+func (_mock *OIDCAuthnServiceInterfaceMock) BuildAuthorizeURL(ctx context.Context, idpID string) (string, map[string]string, *common0.ServiceError) {
 	ret := _mock.Called(ctx, idpID)
 
 	if len(ret) == 0 {
@@ -125,8 +125,9 @@ func (_mock *OIDCAuthnServiceInterfaceMock) BuildAuthorizeURL(ctx context.Contex
 	}
 
 	var r0 string
-	var r1 *common0.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (string, *common0.ServiceError)); ok {
+	var r1 map[string]string
+	var r2 *common0.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (string, map[string]string, *common0.ServiceError)); ok {
 		return returnFunc(ctx, idpID)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string) string); ok {
@@ -134,14 +135,21 @@ func (_mock *OIDCAuthnServiceInterfaceMock) BuildAuthorizeURL(ctx context.Contex
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *common0.ServiceError); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) map[string]string); ok {
 		r1 = returnFunc(ctx, idpID)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*common0.ServiceError)
+			r1 = ret.Get(1).(map[string]string)
 		}
 	}
-	return r0, r1
+	if returnFunc, ok := ret.Get(2).(func(context.Context, string) *common0.ServiceError); ok {
+		r2 = returnFunc(ctx, idpID)
+	} else {
+		if ret.Get(2) != nil {
+			r2 = ret.Get(2).(*common0.ServiceError)
+		}
+	}
+	return r0, r1, r2
 }
 
 // OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BuildAuthorizeURL'
@@ -174,12 +182,12 @@ func (_c *OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Run(run func(ctx
 	return _c
 }
 
-func (_c *OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Return(s string, serviceError *common0.ServiceError) *OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
-	_c.Call.Return(s, serviceError)
+func (_c *OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) Return(s string, stringToString map[string]string, serviceError *common0.ServiceError) *OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
+	_c.Call.Return(s, stringToString, serviceError)
 	return _c
 }
 
-func (_c *OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(ctx context.Context, idpID string) (string, *common0.ServiceError)) *OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
+func (_c *OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call) RunAndReturn(run func(ctx context.Context, idpID string) (string, map[string]string, *common0.ServiceError)) *OIDCAuthnServiceInterfaceMock_BuildAuthorizeURL_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/flow/executormock/oAuthExecutorInterface_mock.go
+++ b/backend/tests/mocks/flow/executormock/oAuthExecutorInterface_mock.go
@@ -37,20 +37,31 @@ func (_m *oAuthExecutorInterfaceMock) EXPECT() *oAuthExecutorInterfaceMock_Expec
 }
 
 // BuildAuthorizeFlow provides a mock function for the type oAuthExecutorInterfaceMock
-func (_mock *oAuthExecutorInterfaceMock) BuildAuthorizeFlow(ctx *providers.NodeContext, execResp *providers.ExecutorResponse) error {
+func (_mock *oAuthExecutorInterfaceMock) BuildAuthorizeFlow(ctx *providers.NodeContext, execResp *providers.ExecutorResponse) (map[string]string, error) {
 	ret := _mock.Called(ctx, execResp)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BuildAuthorizeFlow")
 	}
 
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(*providers.NodeContext, *providers.ExecutorResponse) error); ok {
+	var r0 map[string]string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(*providers.NodeContext, *providers.ExecutorResponse) (map[string]string, error)); ok {
+		return returnFunc(ctx, execResp)
+	}
+	if returnFunc, ok := ret.Get(0).(func(*providers.NodeContext, *providers.ExecutorResponse) map[string]string); ok {
 		r0 = returnFunc(ctx, execResp)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]string)
+		}
 	}
-	return r0
+	if returnFunc, ok := ret.Get(1).(func(*providers.NodeContext, *providers.ExecutorResponse) error); ok {
+		r1 = returnFunc(ctx, execResp)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
 }
 
 // oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BuildAuthorizeFlow'
@@ -83,12 +94,12 @@ func (_c *oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) Run(run func(ctx *
 	return _c
 }
 
-func (_c *oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) Return(err error) *oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call {
-	_c.Call.Return(err)
+func (_c *oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) Return(stringToString map[string]string, err error) *oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call {
+	_c.Call.Return(stringToString, err)
 	return _c
 }
 
-func (_c *oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) RunAndReturn(run func(ctx *providers.NodeContext, execResp *providers.ExecutorResponse) error) *oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call {
+func (_c *oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) RunAndReturn(run func(ctx *providers.NodeContext, execResp *providers.ExecutorResponse) (map[string]string, error)) *oAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/flow/executormock/oidcAuthExecutorInterface_mock.go
+++ b/backend/tests/mocks/flow/executormock/oidcAuthExecutorInterface_mock.go
@@ -37,20 +37,31 @@ func (_m *oidcAuthExecutorInterfaceMock) EXPECT() *oidcAuthExecutorInterfaceMock
 }
 
 // BuildAuthorizeFlow provides a mock function for the type oidcAuthExecutorInterfaceMock
-func (_mock *oidcAuthExecutorInterfaceMock) BuildAuthorizeFlow(ctx *providers.NodeContext, execResp *providers.ExecutorResponse) error {
+func (_mock *oidcAuthExecutorInterfaceMock) BuildAuthorizeFlow(ctx *providers.NodeContext, execResp *providers.ExecutorResponse) (map[string]string, error) {
 	ret := _mock.Called(ctx, execResp)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BuildAuthorizeFlow")
 	}
 
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(*providers.NodeContext, *providers.ExecutorResponse) error); ok {
+	var r0 map[string]string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(*providers.NodeContext, *providers.ExecutorResponse) (map[string]string, error)); ok {
+		return returnFunc(ctx, execResp)
+	}
+	if returnFunc, ok := ret.Get(0).(func(*providers.NodeContext, *providers.ExecutorResponse) map[string]string); ok {
 		r0 = returnFunc(ctx, execResp)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]string)
+		}
 	}
-	return r0
+	if returnFunc, ok := ret.Get(1).(func(*providers.NodeContext, *providers.ExecutorResponse) error); ok {
+		r1 = returnFunc(ctx, execResp)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
 }
 
 // oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BuildAuthorizeFlow'
@@ -83,12 +94,12 @@ func (_c *oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) Run(run func(ct
 	return _c
 }
 
-func (_c *oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) Return(err error) *oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call {
-	_c.Call.Return(err)
+func (_c *oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) Return(stringToString map[string]string, err error) *oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call {
+	_c.Call.Return(stringToString, err)
 	return _c
 }
 
-func (_c *oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) RunAndReturn(run func(ctx *providers.NodeContext, execResp *providers.ExecutorResponse) error) *oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call {
+func (_c *oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call) RunAndReturn(run func(ctx *providers.NodeContext, execResp *providers.ExecutorResponse) (map[string]string, error)) *oidcAuthExecutorInterfaceMock_BuildAuthorizeFlow_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/docs/content/guides/guides/flows/advanced-configurations.mdx
+++ b/docs/content/guides/guides/flows/advanced-configurations.mdx
@@ -611,7 +611,6 @@ Authenticates users via a generic OIDC provider. After the OIDC redirect, <Produ
 
 **Input Configuration:**
 - `code` (required): the authorization code returned by the OIDC provider after redirect. Default: `code`. If not provided, the executor redirects to the OIDC provider to start the authorization flow and get a code.
-- `nonce` (optional): the nonce value for OIDC replay protection. Default: `nonce`
 
 **Example:**
 
@@ -663,7 +662,6 @@ Authenticates users via Google OIDC. After the OAuth redirect, <ProductName /> e
 
 **Input Configuration:**
 - `code` (required): the authorization code returned by Google after user consent. Default: `code`
-- `nonce` (optional): the nonce value for OIDC replay protection. Default: `nonce`
 
 **Example:**
 

--- a/tests/integration/authn/google_auth_test.go
+++ b/tests/integration/authn/google_auth_test.go
@@ -486,13 +486,15 @@ func (suite *GoogleAuthTestSuite) simulateGoogleAuthorization(redirectURL string
 	state := query.Get("state")
 	redirectURI := query.Get("redirect_uri")
 	scope := query.Get("scope")
+	nonce := query.Get("nonce")
 
-	authURL := fmt.Sprintf("%s/o/oauth2/v2/auth?client_id=%s&redirect_uri=%s&response_type=code&scope=%s&state=%s",
+	authURL := fmt.Sprintf("%s/o/oauth2/v2/auth?client_id=%s&redirect_uri=%s&response_type=code&scope=%s&state=%s&nonce=%s",
 		suite.mockGoogleServer.GetURL(),
 		url.QueryEscape(clientID),
 		url.QueryEscape(redirectURI),
 		url.QueryEscape(scope),
-		url.QueryEscape(state))
+		url.QueryEscape(state),
+		url.QueryEscape(nonce))
 
 	client := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {


### PR DESCRIPTION
### Purpose

Fixes: https://github.com/thunder-id/thunderid/issues/813
<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach

- OAuth auth service generates `state` value and append to the redirectURI and pass it to caller.
- OIDC auth service generates the `nonce` value and append to the redirectURI and pass it to caller.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/813

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic security checks for OIDC and Google sign-ins using server-managed nonce values.
  * Authorization flows now securely preserve state and nonce information throughout sign-in.

* **Bug Fixes**
  * Improved protection against replayed or mismatched authentication responses.
  * Removed the need to provide nonce as a flow input for OIDC and Google authentication.

* **Documentation**
  * Updated flow configuration guidance to reflect the simplified authentication inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->