### PR TITLE
[Docs] Fatten skills directory structure

### DIFF
--- a/docs/content/guides/working-with-ai/skills.mdx
+++ b/docs/content/guides/working-with-ai/skills.mdx
@@ -132,7 +132,7 @@ Skills for installing and running the <ProductName /> server.
 
 Skills for launching demos of <ProductName /> features in action.
 
-### Usecase samples
+### Use Case Samples
 
 Product usecase samples that are ready to run in your local environment. These demos showcase how <ProductName /> features work in practice.
 

--- a/docs/content/guides/working-with-ai/skills.mdx
+++ b/docs/content/guides/working-with-ai/skills.mdx
@@ -5,84 +5,101 @@ sidebar_position: 2
 description: Use ThunderID agent skills to set up the server and integrate authentication into any framework with a single prompt.
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import {Box, Card, CardContent, Grid, Typography, Chip} from '@wso2/oxygen-ui';
+import {Box, Card, CardContent, Grid, Typography, Chip, Tooltip} from '@wso2/oxygen-ui';
+import {Check, Copy} from '@wso2/oxygen-ui-icons-react';
+import {useState} from 'react';
 import ProductName from '@site/src/components/ProductName';
 import ReactLogo from '@site/src/components/icons/ReactLogo';
 import NextLogo from '@site/src/components/icons/NextLogo';
 import NuxtLogo from '@site/src/components/icons/NuxtLogo';
 import VueLogo from '@site/src/components/icons/VueLogo';
 import ExpressLogo from '@site/src/components/icons/ExpressLogo';
-import NodeLogo from '@site/src/components/icons/NodeLogo';
 import Html5Logo from '@site/src/components/icons/Html5Logo';
-import JavaScriptLogo from '@site/src/components/icons/JavaScriptLogo';
-import AngularLogo from '@site/src/components/icons/AngularLogo';
-import ReactRouterLogo from '@site/src/components/icons/ReactRouterLogo';
-import TanStackLogo from '@site/src/components/icons/TanStackLogo';
 import SkillsLogo from '@site/src/components/icons/SkillsLogo';
-import ClaudeLogo from '@site/src/components/icons/ClaudeLogo';
-import CodexLogo from '@site/src/components/icons/CodexLogo';
-import CliLogo from '@site/src/components/icons/CliLogo';
 
-export const SkillCard = ({icon, title, skillCommand, pkg, description}) => (
-  <Card sx={{border: '1px solid', borderColor: 'divider'}}>
-    <CardContent sx={{p: 2, '&:last-child': {pb: 2}}}>
-      <Box sx={{display: 'flex', alignItems: 'center', gap: 2}}>
-        <Box sx={{display: 'flex', alignItems: 'center', justifyContent: 'center', width: 36, height: 36, flexShrink: 0}}>
-          {icon}
-        </Box>
-        <Box sx={{flex: 1, minWidth: 0}}>
-          <Box sx={{display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap'}}>
-            <Typography variant="subtitle2" sx={{fontWeight: 600}}>
-              {title}
-            </Typography>
-            {pkg && (
-              <Typography
-                component="span"
-                sx={{
-                  fontFamily: 'monospace',
-                  fontSize: '0.7rem',
-                  color: 'text.secondary',
-                  bgcolor: 'action.hover',
-                  px: 0.75,
-                  py: 0.2,
-                  borderRadius: 0.5,
-                }}
-              >
-                {pkg}
-              </Typography>
-            )}
+export const SkillCard = ({icon, title, skillCommand, pkg, description}) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(skillCommand);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard API unavailable or denied, silently ignore.
+    }
+  };
+
+  return (
+    <Card sx={{border: '1px solid', borderColor: 'divider'}}>
+      <CardContent sx={{p: 2, '&:last-child': {pb: 2}}}>
+        <Box sx={{display: 'flex', alignItems: 'center', gap: 2}}>
+          <Box sx={{display: 'flex', alignItems: 'center', justifyContent: 'center', width: 36, height: 36, flexShrink: 0}}>
+            {icon}
           </Box>
-          <Typography variant="body2" sx={{color: 'text.secondary', mt: 0.25, lineHeight: 1.5}}>
-            {description}
-          </Typography>
+          <Box sx={{flex: 1, minWidth: 0}}>
+            <Box sx={{display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap'}}>
+              <Typography variant="subtitle2" sx={{fontWeight: 600}}>
+                {title}
+              </Typography>
+              {pkg && (
+                <Typography
+                  component="span"
+                  sx={{
+                    fontFamily: 'monospace',
+                    fontSize: '0.7rem',
+                    color: 'text.secondary',
+                    bgcolor: 'action.hover',
+                    px: 0.75,
+                    py: 0.2,
+                    borderRadius: 0.5,
+                  }}
+                >
+                  {pkg}
+                </Typography>
+              )}
+            </Box>
+            <Typography variant="body2" sx={{color: 'text.secondary', mt: 0.25, lineHeight: 1.5}}>
+              {description}
+            </Typography>
+          </Box>
+          <Tooltip title={copied ? 'Copied!' : 'Copy command'} placement="top">
+            <Box
+              component="button"
+              type="button"
+              onClick={() => void handleCopy()}
+              sx={{
+                flexShrink: 0,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.5,
+                bgcolor: 'action.selected',
+                border: '1px solid',
+                borderColor: 'divider',
+                borderRadius: 1,
+                px: 1,
+                py: 0.5,
+                fontFamily: 'monospace',
+                fontSize: '0.72rem',
+                color: 'text.primary',
+                whiteSpace: 'nowrap',
+                cursor: 'pointer',
+                '&:hover': {
+                  bgcolor: 'action.hover',
+                  borderColor: 'text.secondary',
+                },
+              }}
+            >
+              {copied ? <Check size={11} /> : <SkillsLogo size={11} />}
+              {skillCommand}
+              <Copy size={11} style={{opacity: 0.5}} />
+            </Box>
+          </Tooltip>
         </Box>
-        <Box
-          sx={{
-            flexShrink: 0,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 0.5,
-            bgcolor: 'action.selected',
-            border: '1px solid',
-            borderColor: 'divider',
-            borderRadius: 1,
-            px: 1,
-            py: 0.5,
-            fontFamily: 'monospace',
-            fontSize: '0.72rem',
-            color: 'text.primary',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          <SkillsLogo size={11} />
-          {skillCommand}
-        </Box>
-      </Box>
-    </CardContent>
-  </Card>
-);
+      </CardContent>
+    </Card>
+  );
+};
 
 # Skills
 
@@ -94,76 +111,46 @@ Skills are available for [Claude Code](https://claude.ai/code), [Codex](https://
 
 Add the <ProductName /> skill pack to your AI coding assistant once. All skills in the pack become immediately available.
 
-<Tabs groupId="install-method">
-  <TabItem
-    value="oasci"
-    label={
-      <Box sx={{display: 'flex', alignItems: 'center', gap: 1}}>
-        <Box component="span" sx={{filter: 'grayscale(1) opacity(0.75)'}}><CliLogo size={16} /></Box>
-        Open Agent Skills CLI
-      </Box>
-    }
-    default
-  >
-
-Run the following command in your terminal:
-
-```bash
-npx skills add thunder-id/skills
-```
-
-  </TabItem>
-  <TabItem
-    value="claude"
-    label={
-      <Box sx={{display: 'flex', alignItems: 'center', gap: 1}}>
-        <Box component="span" sx={{filter: 'grayscale(1) opacity(0.75)'}}><ClaudeLogo size={16} /></Box>
-        Claude Code
-      </Box>
-    }
-  >
-
-Run the following slash command in Claude Code:
-
-```tsx
-/plugin marketplace add thunder-id/skills
-```
-
-{/* Screenshot placeholder: Claude Code terminal showing /plugin marketplace add thunder-id/skills command and confirmation output */}
-
-  </TabItem>
-  <TabItem
-    value="codex"
-    label={
-      <Box sx={{display: 'flex', alignItems: 'center', gap: 1}}>
-        <Box component="span" sx={{filter: 'grayscale(1) opacity(0.75)'}}><CodexLogo size={16} /></Box>
-        Codex
-      </Box>
-    }
-  >
-
-Run the following command in your terminal, then restart Codex:
-
-```bash
-codex plugin marketplace add thunder-id/skills
-```
-
-After restarting, open **`/plugins`**, select **<ProductName /> Skills**, install and enable `thunder-id-skills`, then start a new thread.
-
-{/* Screenshot placeholder: Codex /plugins panel showing <ProductName /> Skills installed and enabled */}
-
-  </TabItem>
-</Tabs>
+<RunThunderID tabs={['skills', 'claude', 'codex']} defaultTab="skills" />
 
 ## Core Skills
+
+Skills for installing and running the <ProductName /> server.
 
 <Grid container spacing={2} sx={{mt: 1, mb: 4}}>
   <Grid size={{xs: 12}}>
     <SkillCard
       icon={<SkillsLogo size={28} />}
-      title="Setup <ProductName />"
-      skillCommand="/setup-thunderid"
-      description="Download, configure, and start the <ProductName /> server. Supports npx (recommended) and Docker Compose. Outputs the Sample App Client ID you need for SDK integration."
+      title="Install <ProductName />"
+      skillCommand="/thunderid-install"
+      description="Download, configure, and start the <ProductName /> server. Outputs the Sample App Client ID you need for SDK integration."
+    />
+  </Grid>
+</Grid>
+
+## Tryout Skills
+
+Skills for launching demos of <ProductName /> features in action.
+
+### Usecase samples
+
+Product usecase samples that are ready to run in your local environment. These demos showcase how <ProductName /> features work in practice.
+
+<Grid container spacing={2} sx={{mt: 1, mb: 4}}>
+  <Grid size={{xs: 12}}>
+    <SkillCard
+      icon={<SkillsLogo size={28} />}
+      title="Try the Consumer Demo"
+      skillCommand="/thunderid-try-consumer"
+      description="Launch the Wayfinder B2C consumer login demo to see social login and passkey sign-in in action."
+    />
+  </Grid>
+  <Grid size={{xs: 12}}>
+    <SkillCard
+      icon={<SkillsLogo size={28} />}
+      title="Try the AgentID Demo"
+      skillCommand="/thunderid-try-agentid"
+      description="Launch the AgentID demo to see AI agent authentication in action."
     />
   </Grid>
 </Grid>
@@ -172,23 +159,46 @@ After restarting, open **`/plugins`**, select **<ProductName /> Skills**, instal
 
 Choose the skill that matches your framework. Each skill registers an application in the <ProductName /> Console, installs the correct SDK, and wires up authentication in your project.
 
-### Frontend
+### SPA
 
 <Grid container spacing={2} sx={{mt: 1, mb: 3}}>
   <Grid size={{xs: 12}}>
     <SkillCard
       icon={<ReactLogo size={36} />}
       title="React"
-      skillCommand="/integrate-react"
+      skillCommand="/thunderid-integrate-react"
       pkg="@thunderid/react"
-      description="Add authentication to a React + Vite app. For React Router or TanStack Router projects, use the dedicated router skills instead."
+      description="Add authentication to a React application."
     />
   </Grid>
   <Grid size={{xs: 12}}>
     <SkillCard
+      icon={<VueLogo size={36} />}
+      title="Vue"
+      skillCommand="/thunderid-integrate-vue"
+      pkg="@thunderid/vue"
+      description="Integrate authentication into a Vue 3 application with composables for session access and route guards."
+    />
+  </Grid>
+  <Grid size={{xs: 12}}>
+    <SkillCard
+      icon={<Html5Logo size={36} />}
+      title="Browser / Vanilla JS"
+      skillCommand="/thunderid-integrate-browser"
+      pkg="@thunderid/browser"
+      description="Add authentication to a plain HTML and JavaScript app with no framework, ideal for simple SPAs or prototype projects."
+    />
+  </Grid>
+</Grid>
+
+### Fullstack
+
+<Grid container spacing={2} sx={{mt: 1, mb: 3}}>
+  <Grid size={{xs: 12}}>
+    <SkillCard
       icon={<NextLogo size={36} />}
       title="Next.js"
-      skillCommand="/integrate-nextjs"
+      skillCommand="/thunderid-integrate-nextjs"
       pkg="@thunderid/nextjs"
       description="Integrate authentication into a Next.js App Router application with server-side session management and route protection middleware."
     />
@@ -197,90 +207,23 @@ Choose the skill that matches your framework. Each skill registers an applicatio
     <SkillCard
       icon={<NuxtLogo size={36} />}
       title="Nuxt"
-      skillCommand="/integrate-nuxt"
+      skillCommand="/thunderid-integrate-nuxt"
       pkg="@thunderid/nuxt"
       description="Add authentication to a Nuxt 3 application using the official <ProductName /> Nuxt module."
-    />
-  </Grid>
-  <Grid size={{xs: 12}}>
-    <SkillCard
-      icon={<VueLogo size={36} />}
-      title="Vue"
-      skillCommand="/integrate-vue"
-      pkg="@thunderid/vue"
-      description="Integrate authentication into a Vue 3 application with composables for session access and route guards."
-    />
-  </Grid>
-  <Grid size={{xs: 12}}>
-    <SkillCard
-      icon={<ReactRouterLogo size={36} />}
-      title="React + React Router"
-      skillCommand="/integrate-react-router"
-      pkg="@thunderid/react-router"
-      description="Protect routes and handle OAuth callbacks in a React Router v6 application."
-    />
-  </Grid>
-  <Grid size={{xs: 12}}>
-    <SkillCard
-      icon={<TanStackLogo size={36} />}
-      title="React + TanStack Router"
-      skillCommand="/integrate-tanstack-router"
-      pkg="@thunderid/tanstack-router"
-      description="Protect routes and handle OAuth callbacks in a TanStack Router application."
-    />
-  </Grid>
-  <Grid size={{xs: 12}}>
-    <SkillCard
-      icon={<Html5Logo size={36} />}
-      title="Browser / Vanilla JS"
-      skillCommand="/integrate-browser"
-      pkg="@thunderid/browser"
-      description="Add authentication to a plain HTML and JavaScript app with no framework, ideal for simple SPAs or prototype projects."
     />
   </Grid>
 </Grid>
 
 ### Backend
 
-<Grid container spacing={2} sx={{mt: 1, mb: 3}}>
+<Grid container spacing={2} sx={{mt: 1, mb: 4}}>
   <Grid size={{xs: 12}}>
     <SkillCard
       icon={<ExpressLogo size={36} />}
       title="Express"
-      skillCommand="/integrate-express"
+      skillCommand="/thunderid-integrate-express"
       pkg="@thunderid/express"
       description="Protect routes in an Express application with session-based authentication middleware and callback handling."
-    />
-  </Grid>
-  <Grid size={{xs: 12}}>
-    <SkillCard
-      icon={<NodeLogo size={36} />}
-      title="Node.js"
-      skillCommand="/integrate-node"
-      pkg="@thunderid/node"
-      description="Add authentication to a Node.js server built with Fastify, Hono, Koa, or the built-in HTTP module. For Express, use the Express skill."
-    />
-  </Grid>
-  <Grid size={{xs: 12}}>
-    <SkillCard
-      icon={<JavaScriptLogo size={36} />}
-      title="Universal JavaScript"
-      skillCommand="/integrate-javascript"
-      pkg="@thunderid/javascript"
-      description="Use the core JavaScript SDK directly for custom integrations, edge runtimes, or any environment without a dedicated <ProductName /> SDK."
-    />
-  </Grid>
-</Grid>
-
-### Other Frameworks and Languages
-
-<Grid container spacing={2} sx={{mt: 1, mb: 4}}>
-  <Grid size={{xs: 12}}>
-    <SkillCard
-      icon={<AngularLogo size={36} />}
-      title="Generic OIDC"
-      skillCommand="/integrate-oidc"
-      description="Integrate <ProductName /> via a standard OIDC library for any framework or language without an official SDK, such as Angular, SvelteKit, Python, Go, .NET, and more."
     />
   </Grid>
 </Grid>
@@ -291,20 +234,17 @@ Type a plain-language request in your AI assistant's chat. The assistant detects
 
 | You Say | Skill |
 |---|---|
-| "Set up <ProductName /> on my machine" | `/setup-thunderid` |
-| "Add <ProductName /> to my Next.js app" | `/integrate-nextjs` |
-| "Add <ProductName /> to my Nuxt app" | `/integrate-nuxt` |
-| "Integrate <ProductName /> into my React app" | `/integrate-react` |
-| "Add <ProductName /> to my React Router app" | `/integrate-react-router` |
-| "Add <ProductName /> to my TanStack Router app" | `/integrate-tanstack-router` |
-| "Add <ProductName /> to my Vue app" | `/integrate-vue` |
-| "Protect routes in my Express app" | `/integrate-express` |
-| "Add <ProductName /> to my Fastify / Hono app" | `/integrate-node` |
-| "Add <ProductName /> to my vanilla JS app" | `/integrate-browser` |
-| "Integrate <ProductName /> without a framework" | `/integrate-javascript` |
-| "Add <ProductName /> to my Angular / SvelteKit / Python / Go app" | `/integrate-oidc` |
+| "Set up <ProductName /> on my machine" | `/thunderid-install` |
+| "Try <ProductName />" | `/thunderid-try-consumer` |
+| "Demo AI agent auth" | `/thunderid-try-agentid` |
+| "Add <ProductName /> to my Next.js app" | `/thunderid-integrate-nextjs` |
+| "Add <ProductName /> to my Nuxt app" | `/thunderid-integrate-nuxt` |
+| "Integrate <ProductName /> into my React app" | `/thunderid-integrate-react` |
+| "Add <ProductName /> to my Vue app" | `/thunderid-integrate-vue` |
+| "Protect routes in my Express app" | `/thunderid-integrate-express` |
+| "Add <ProductName /> to my vanilla JS app" | `/thunderid-integrate-browser` |
 
-You can also invoke skills directly by name. In Claude Code, type `/integrate-nextjs`. In Codex, type `/integrate-nextjs` in a thread. Both assistants run the skill immediately without further prompting.
+You can also invoke skills directly by name. In Claude Code, type `/thunderid-integrate-nextjs`. In Codex, type `/thunderid-integrate-nextjs` in a thread. Both assistants run the skill immediately without further prompting.
 
 {/* Screenshot placeholder: Split view showing the same "Add <ProductName /> to my Next.js app" prompt in Claude Code (left) and Codex (right), each running the integrate-nextjs skill */}
 

--- a/docs/src/components/RunThunderID.tsx
+++ b/docs/src/components/RunThunderID.tsx
@@ -86,8 +86,14 @@ function CopyButton({text}: {text: string}): React.ReactElement {
   );
 }
 
-export default function RunThunderID(): React.ReactElement {
-  const [activeTab, setActiveTab] = useState<TabId>('cli');
+interface RunThunderIDProps {
+  tabs?: TabId[];
+  defaultTab?: TabId;
+}
+
+export default function RunThunderID({tabs, defaultTab}: RunThunderIDProps = {}): React.ReactElement {
+  const visibleTabs = tabs ? TABS.filter(({id}) => tabs.includes(id)) : TABS;
+  const [activeTab, setActiveTab] = useState<TabId>(defaultTab ?? visibleTabs[0]?.id ?? 'cli');
   const theme = useTheme();
   const {command, hint, shell} = CONTENT[activeTab];
 
@@ -119,7 +125,7 @@ export default function RunThunderID(): React.ReactElement {
           '[data-theme="light"] &': {bgcolor: 'rgba(0,0,0,0.02)'},
         }}
       >
-        {TABS.map(({id, label, icon}) => {
+        {visibleTabs.map(({id, label, icon}) => {
           const isActive = activeTab === id;
           return (
             <Box


### PR DESCRIPTION
### Purpose
Flatten the skills directory structure so all ThunderID skill commands live under a single `thunderid-*` namespace instead of the previous mix of unprefixed names (`/setup-thunderid`, `/integrate-react`, etc.). This avoids collisions with other plugins in the same marketplace and makes it clear at a glance which slash commands belong to ThunderID.

Also adds a copy-to-clipboard button on each skill card, and lets the shared `RunThunderID` install snippet component render a subset of tabs so it can be reused on the Skills page (previously the page duplicated its own install tabs markup).

### Approach
- Renamed all skill commands to the `thunderid-*` prefix (`/thunderid-install`, `/thunderid-integrate-react`, `/thunderid-try-consumer`, etc.) and updated every reference across the Skills guide, including the "You Say" table.
- Reorganized the Integration Skills section into **SPA**, **Fullstack**, and **Backend** categories (previously **Frontend**/**Backend**), and added a new **Tryout Skills** section with cards for the Consumer and AgentID demos.
- Removed skills that don't have a corresponding command yet (React Router, TanStack Router, Node.js, Universal JavaScript, Generic OIDC), trimming the guide down to the skills that currently exist.
- Made `SkillCard` support copying its skill command to the clipboard, with a checkmark and tooltip confirming the copy.
- Extended `RunThunderID` with optional `tabs` and `defaultTab` props so the Skills page can reuse it (showing only the Skills CLI, Claude Code, and Codex tabs) instead of hand-rolling its own tab markup.

### Related Issues
- Fixes https://github.com/thunder-id/thunderid/issues/4040

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
