### PR TITLE
Emit entityState from federated auth executors based on account-linking result

### DIFF
--- a/backend/internal/flow/common/constants.go
+++ b/backend/internal/flow/common/constants.go
@@ -202,7 +202,8 @@ const (
 	// RuntimeKeyBindingMessage holds the human-readable binding message displayed to the user
 	// on both the consumption device and the authentication device to correlate the CIBA request.
 	RuntimeKeyBindingMessage = "bindingMessage"
-	// RuntimeKeyEntityState holds the entity existence state set by the IdentifyingExecutor in check_state mode.
+	// RuntimeKeyEntityState holds the entity existence state, set by the IdentifyingExecutor in
+	// check_state mode or by the federated auth executors from their account-linking result.
 	RuntimeKeyEntityState = "entityState"
 	// RuntimeKeyAuthorizationRequestID holds the auth request identifier bound to the current flow
 	// execution (the OAuth authorize authId or the CIBA auth_req_id), if applicable.

--- a/backend/internal/flow/executor/oauth_executor.go
+++ b/backend/internal/flow/executor/oauth_executor.go
@@ -281,6 +281,8 @@ func (o *oAuthExecutor) ProcessAuthFlowResponse(ctx *providers.NodeContext,
 		}
 	}
 
+	setFederatedEntityState(execResp)
+
 	switch ctx.FlowType {
 	case providers.FlowTypeAuthentication:
 		if isAuthenticationWithoutLocalUserAllowed(ctx) {

--- a/backend/internal/flow/executor/oauth_executor_test.go
+++ b/backend/internal/flow/executor/oauth_executor_test.go
@@ -399,6 +399,73 @@ func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_AuthFlow_UserNo
 	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
+func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoLocalUser_EntityStateNotExists() { //nolint:dupl
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    providers.FlowTypeAuthentication,
+		UserInputs: map[string]string{
+			"code": "auth_code_123",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &providers.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	// newOAuthAuthenticatedUser carries an entity-reference token but no resolved EntityReference,
+	// modeling account linking that found no matching local account.
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(newOAuthAuthenticatedUser(), providers.AuthenticatedClaims{
+			"sub": "user-sub-123", "email": "new@example.com",
+		}, (*tidcommon.ServiceError)(nil))
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecComplete, execResp.Status)
+	assert.Equal(suite.T(), entityStateNotExists, execResp.RuntimeData[common.RuntimeKeyEntityState])
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
+}
+
+func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_LocalUser_EntityStateExists() { //nolint:dupl
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    providers.FlowTypeAuthentication,
+		UserInputs: map[string]string{
+			"code": "auth_code_123",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &providers.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	// A resolved EntityReference models account linking matching an existing local user.
+	var authUser providers.AuthUser
+	authUser.SetEntityReference(&providers.EntityReference{EntityID: "local-user-123"})
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authUser, providers.AuthenticatedClaims{
+			"sub": "user-sub-123", "email": "existing@example.com",
+		}, (*tidcommon.ServiceError)(nil))
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecComplete, execResp.Status)
+	assert.Equal(suite.T(), entityStateExists, execResp.RuntimeData[common.RuntimeKeyEntityState])
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
+}
+
 func (suite *OAuthExecutorTestSuite) TestProcessAuthFlowResponse_UserAlreadyExists_RegistrationFlow() { //nolint:dupl
 	ctx := &providers.NodeContext{
 		ExecutionID: "flow-123",

--- a/backend/internal/flow/executor/oidc_auth_executor.go
+++ b/backend/internal/flow/executor/oidc_auth_executor.go
@@ -217,6 +217,8 @@ func (o *oidcAuthExecutor) ProcessAuthFlowResponse(ctx *providers.NodeContext,
 		}
 	}
 
+	setFederatedEntityState(execResp)
+
 	switch ctx.FlowType {
 	case providers.FlowTypeAuthentication:
 		if isAuthenticationWithoutLocalUserAllowed(ctx) {

--- a/backend/internal/flow/executor/oidc_auth_executor_test.go
+++ b/backend/internal/flow/executor/oidc_auth_executor_test.go
@@ -166,6 +166,73 @@ func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_ValidIDToken
 	suite.mockAuthnProvider.AssertExpectations(suite.T())
 }
 
+func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_NoLocalUser_EntityStateNotExists() { //nolint:dupl
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    providers.FlowTypeAuthentication,
+		UserInputs: map[string]string{
+			"code": "auth_code_123",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &providers.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	// newOIDCAuthenticatedUser carries an entity-reference token but no resolved EntityReference,
+	// modeling account linking that found no matching local account.
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(newOIDCAuthenticatedUser(), providers.AuthenticatedClaims{
+			"sub": "user-sub-123", "email": "new@example.com",
+		}, (*tidcommon.ServiceError)(nil))
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecComplete, execResp.Status)
+	assert.Equal(suite.T(), entityStateNotExists, execResp.RuntimeData[common.RuntimeKeyEntityState])
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
+}
+
+func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_LocalUser_EntityStateExists() { //nolint:dupl
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    providers.FlowTypeAuthentication,
+		UserInputs: map[string]string{
+			"code": "auth_code_123",
+		},
+		NodeProperties: map[string]interface{}{
+			"idpId": "idp-123",
+		},
+	}
+
+	execResp := &providers.ExecutorResponse{
+		AdditionalData: make(map[string]string),
+		RuntimeData:    make(map[string]string),
+	}
+
+	// A resolved EntityReference models account linking matching an existing local user.
+	var authUser providers.AuthUser
+	authUser.SetEntityReference(&providers.EntityReference{EntityID: "local-user-123"})
+	suite.mockAuthnProvider.On("AuthenticateUser", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(authUser, providers.AuthenticatedClaims{
+			"sub": "user-sub-123", "email": "existing@example.com",
+		}, (*tidcommon.ServiceError)(nil))
+
+	err := suite.executor.ProcessAuthFlowResponse(ctx, execResp)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecComplete, execResp.Status)
+	assert.Equal(suite.T(), entityStateExists, execResp.RuntimeData[common.RuntimeKeyEntityState])
+	suite.mockAuthnProvider.AssertExpectations(suite.T())
+}
+
 func (suite *OIDCAuthExecutorTestSuite) TestProcessAuthFlowResponse_InvalidNonce() {
 	ctx := &providers.NodeContext{
 		ExecutionID: "flow-123",

--- a/backend/internal/flow/executor/utils.go
+++ b/backend/internal/flow/executor/utils.go
@@ -127,6 +127,15 @@ func isCrossOUProvisioningAllowed(ctx *providers.NodeContext) bool {
 	return false
 }
 
+// setFederatedEntityState records whether federated authentication resolved a concrete local user
+// (via account linking) into the entityState runtime key.
+func setFederatedEntityState(execResp *providers.ExecutorResponse) {
+	execResp.RuntimeData[common.RuntimeKeyEntityState] = entityStateNotExists
+	if execResp.AuthUser.EntityReference() != nil {
+		execResp.RuntimeData[common.RuntimeKeyEntityState] = entityStateExists
+	}
+}
+
 // isAllowAuthenticationWithoutLocalUserRuntimeFlagSet checks if the runtime flag for allowing authentication without
 // a local user is set in the context.
 func isAllowRegistrationWithExistingUserRuntimeFlagSet(ctx *providers.NodeContext) bool {

--- a/docs/content/guides/guides/flows/advanced-configurations.mdx
+++ b/docs/content/guides/guides/flows/advanced-configurations.mdx
@@ -536,6 +536,8 @@ Sets credentials (e.g., password) for an existing user. Typically used in regist
 
 #### Federated Authentication
 
+After a successful federated authentication, these executors set the `entityState` runtime key from the account-linking result: `exists` when the federated identity resolves to a unique existing local user. A later node can branch on `{{ctx(entityState)}}`.
+
 <details>
 <summary>OAuth</summary>
 


### PR DESCRIPTION
### Purpose
Let authentication flows branch new-vs-existing user **after social login** without a dedicated `IdentifyingExecutor` `check_state` node.

Resolving whether a federated identity maps to an existing local user is already done by account linking during the federated auth step (`buildAccountLinkingFilter` → `AuthUser.EntityReference()`). But the only way for a flow to *branch* on that result (e.g. to decide whether to run an org-creation / provisioning sub-flow for brand-new users) was to add an `IdentifyingExecutor` in `check_state` mode, which re-searches the store by an attribute. That is redundant work and risks an inconsistent verdict (probe-by-`sub` vs link-by-`email`).

This PR surfaces the account-linking result directly as the `entityState` runtime key from the federated executors themselves.

### Approach
- Add `setFederatedEntityState` in `internal/flow/executor/utils.go`: sets `RuntimeKeyEntityState` to `exists` when `AuthUser.EntityReference() != nil` (account linking resolved a unique local user), otherwise `not_exists`.
- Call it from `oAuthExecutor.ProcessAuthFlowResponse` and `oidcAuthExecutor.ProcessAuthFlowResponse` after a successful federated authentication.
- A flow can then gate a provisioning / org-creation branch on `{{ctx(entityState)}}` with no extra executor and a single user lookup.

Note: the federated path cannot distinguish `ambiguous` (account linking collapses an ambiguous match to "not resolved"), so only `exists`/`not_exists` are emitted here; `IdentifyingExecutor` still owns the `ambiguous` case for flows that need disambiguation.

### Usage example
A federated auth node hands control to a node that decides whether to onboard a brand-new user. Because the federated executor now emits `entityState`, the branch is a plain node condition, no extra executor:

```yaml
- id: google_auth
  type: TASK_EXECUTION
  properties:
    idpId: <google-idp-id>
    allowAuthenticationWithoutLocalUser: true
  executor:
    name: GoogleOIDCAuthExecutor
    inputs:
      - identifier: code
        type: TEXT_INPUT
        required: true
  onSuccess: org_registration_prompt

# New users fall through to org creation; existing users skip straight to assertion.
- id: org_registration_prompt
  type: PROMPT
  condition:
    key: "{{ctx(entityState)}}"
    value: not_exists
    onSkip: auth_assert          # entityState == exists -> local user found -> skip onboarding
  # ... prompt for org details, then -> ou_creation -> provisioning -> auth_assert

- id: auth_assert
  type: TASK_EXECUTION
  executor:
    name: AuthAssertExecutor
  onSuccess: end
```

Flow of control:
- **Existing local user** — account linking attaches an `EntityReference`, `entityState = exists`; the `org_registration_prompt` condition is not met, so `onSkip` routes directly to `auth_assert`. No prompt, no provisioning.
- **New user** — no local match, `entityState = not_exists`; the flow falls into `org_registration_prompt` and its onboarding/provisioning sub-flow before asserting.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [x] Tests provided.
    - [x] Unit Tests
    - [ ] Integration Tests

### Security checks
- [x] Followed secure coding standards.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Federated authentication now records whether a matching local account exists in runtime state, enabling later steps to branch accordingly.
* **Bug Fixes**
  * OIDC and OAuth flow processing now set this account-resolution state consistently after federated authentication completes.
* **Documentation**
  * Updated federated authentication flow docs to describe the new `entityState` values (`exists` / `not_exists`) and how to use `{{ctx(entityState)}}`.
* **Tests**
  * Added unit test coverage for OIDC and OAuth cases with no local account vs a resolved local account.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->