### PR TITLE
Remove Obsolete Wayfinder AuthZEN client configuration from YAML files

### DIFF
--- a/samples/apps/wayfinder-sample/thunderid-config/app-native/thunderid-config.yaml
+++ b/samples/apps/wayfinder-sample/thunderid-config/app-native/thunderid-config.yaml
@@ -1668,28 +1668,6 @@ inboundAuthConfig:
 
 ---
 resource_type: application
-# Confidential OAuth client used by the Wayfinder backend to call the
-# ThunderID AuthZEN PDP. This client authenticates the backend and is not the
-# subject of the access evaluation.
-id: wayfinder-authzen-client
-name: Wayfinder AuthZEN Client
-description: Backend service that requests MCP tool authorization decisions from the ThunderID AuthZEN PDP.
-ouHandle: default
-inboundAuthConfig:
-  - type: oauth2
-    config:
-      clientId: "{{.AUTHZEN_CLIENT_ID}}"
-      clientSecret: "{{.AUTHZEN_CLIENT_SECRET}}"
-      grantTypes:
-        - client_credentials
-      tokenEndpointAuthMethod: client_secret_basic
-      publicClient: false
-      token:
-        accessToken:
-          validityPeriod: 3600
-
----
-resource_type: application
 # Public OAuth client used by external MCP clients (e.g. MCP Inspector)
 # to call the Wayfinder MCP server on /mcp.
 # Used by the MCP Authorization tryout to demonstrate ThunderID-secured MCP
@@ -1785,20 +1763,6 @@ permissions:
 assignments:
   - id: wayfinder-john-doe
     type: user
-
----
-resource_type: role
-id: wayfinder-authzen-client-role
-name: Wayfinder AuthZEN Client
-description: Grants the Wayfinder backend permission to call the ThunderID AuthZEN PDP.
-ouHandle: default
-permissions:
-  - resourceServerId: 01900000-0000-7000-8000-000000000020
-    permissions:
-      - system
-assignments:
-  - id: wayfinder-authzen-client
-    type: app
 
 ---
 resource_type: role

--- a/samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid-config.yaml
+++ b/samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid-config.yaml
@@ -1529,28 +1529,6 @@ inboundAuthConfig:
 
 ---
 resource_type: application
-# Confidential OAuth client used by the Wayfinder backend to call the
-# ThunderID AuthZEN PDP. This client authenticates the backend and is not the
-# subject of the access evaluation.
-id: wayfinder-authzen-client
-name: Wayfinder AuthZEN Client
-description: Backend service that requests MCP tool authorization decisions from the ThunderID AuthZEN PDP.
-ouHandle: default
-inboundAuthConfig:
-  - type: oauth2
-    config:
-      clientId: "{{.AUTHZEN_CLIENT_ID}}"
-      clientSecret: "{{.AUTHZEN_CLIENT_SECRET}}"
-      grantTypes:
-        - client_credentials
-      tokenEndpointAuthMethod: client_secret_basic
-      publicClient: false
-      token:
-        accessToken:
-          validityPeriod: 3600
-
----
-resource_type: application
 # Public OAuth client used by external MCP clients (e.g. MCP Inspector)
 # to call the Wayfinder MCP server on /mcp.
 # Used by the MCP Authorization tryout to demonstrate ThunderID-secured MCP
@@ -1646,20 +1624,6 @@ permissions:
 assignments:
   - id: wayfinder-john-doe
     type: user
-
----
-resource_type: role
-id: wayfinder-authzen-client-role
-name: Wayfinder AuthZEN Client
-description: Grants the Wayfinder backend permission to call the ThunderID AuthZEN PDP.
-ouHandle: default
-permissions:
-  - resourceServerId: 01900000-0000-7000-8000-000000000020
-    permissions:
-      - system
-assignments:
-  - id: wayfinder-authzen-client
-    type: app
 
 ---
 resource_type: role


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

Currently the Wayfinder sample configuration import is broken due to obsolete template fields on AuthZEN in the YAML config file.

The main reason for this is that a later merge of #3163  has reverted some changes done in the PR #3950.

These accidental changes are reverted in this PR

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

Revert the changes made to the AuthZen Client in #3163 

### Related Issues
- Fixes #4023 

### Related PRs
- #3950 
- #3163  

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the unused AuthZEN integration application and its associated permissions from the Wayfinder sample configurations.
  * Existing users, roles, booking flows, and other integrations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->