### PR TITLE
Remove search components from listing pages which are not functional

### DIFF
--- a/frontend/apps/console/src/features/agents/pages/AgentsListPage.tsx
+++ b/frontend/apps/console/src/features/agents/pages/AgentsListPage.tsx
@@ -18,8 +18,8 @@
 
 import {useGetAgentTypes} from '@thunderid/configure-agent-types';
 import {useLogger} from '@thunderid/logger/react';
-import {Stack, Button, TextField, InputAdornment, PageContent, PageTitle} from '@wso2/oxygen-ui';
-import {FileCog, Plus, Search} from '@wso2/oxygen-ui-icons-react';
+import {Button, PageContent, PageTitle} from '@wso2/oxygen-ui';
+import {FileCog, Plus} from '@wso2/oxygen-ui-icons-react';
 import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
@@ -78,23 +78,6 @@ export default function AgentsListPage(): JSX.Element {
           </Button>
         </PageTitle.Actions>
       </PageTitle>
-
-      <Stack direction="row" spacing={2} mb={4} flexWrap="wrap" useFlexGap>
-        <TextField
-          placeholder={t('agents:listing.search.placeholder', 'Search agents')}
-          size="small"
-          sx={{flexGrow: 1, minWidth: 300}}
-          slotProps={{
-            input: {
-              startAdornment: (
-                <InputAdornment position="start">
-                  <Search size={16} />
-                </InputAdornment>
-              ),
-            },
-          }}
-        />
-      </Stack>
 
       <AgentsList />
     </PageContent>

--- a/frontend/apps/console/src/features/agents/pages/__tests__/AgentsListPage.test.tsx
+++ b/frontend/apps/console/src/features/agents/pages/__tests__/AgentsListPage.test.tsx
@@ -86,13 +86,6 @@ describe('AgentsListPage', () => {
     expect(screen.getByTestId('agent-add-button')).toBeInTheDocument();
   });
 
-  it('renders the search field', () => {
-    render(<AgentsListPage />);
-
-    const searchInput = screen.getByPlaceholderText('Search agents');
-    expect(searchInput).toBeInTheDocument();
-  });
-
   it('renders the AgentsList component', () => {
     render(<AgentsListPage />);
 

--- a/frontend/apps/console/src/features/applications/pages/ApplicationsListPage.tsx
+++ b/frontend/apps/console/src/features/applications/pages/ApplicationsListPage.tsx
@@ -17,8 +17,8 @@
  */
 
 import {useLogger} from '@thunderid/logger/react';
-import {Stack, Button, TextField, InputAdornment, PageContent, PageTitle} from '@wso2/oxygen-ui';
-import {Plus, Search} from '@wso2/oxygen-ui-icons-react';
+import {Button, PageContent, PageTitle} from '@wso2/oxygen-ui';
+import {Plus} from '@wso2/oxygen-ui-icons-react';
 import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
@@ -53,23 +53,6 @@ export default function ApplicationsListPage(): JSX.Element {
         </PageTitle.Actions>
       </PageTitle>
 
-      {/* Search and Filters */}
-      <Stack direction="row" spacing={2} mb={4} flexWrap="wrap" useFlexGap>
-        <TextField
-          placeholder={t('applications:listing.search.placeholder')}
-          size="small"
-          sx={{flexGrow: 1, minWidth: 300}}
-          slotProps={{
-            input: {
-              startAdornment: (
-                <InputAdornment position="start">
-                  <Search size={16} />
-                </InputAdornment>
-              ),
-            },
-          }}
-        />
-      </Stack>
       <ApplicationsList />
     </PageContent>
   );

--- a/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationTemplateSelectPage.test.tsx
+++ b/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationTemplateSelectPage.test.tsx
@@ -129,16 +129,6 @@ describe('ApplicationTemplateSelectPage', () => {
     expect(screen.queryByTestId(`template-card-${TechnologyApplicationTemplate.REACT}`)).not.toBeInTheDocument();
   });
 
-  it('filters templates by search query', async () => {
-    const user = userEvent.setup();
-    renderPage();
-
-    await user.type(screen.getByPlaceholderText('Search types by name'), 'React');
-
-    expect(screen.getByTestId(`template-card-${TechnologyApplicationTemplate.REACT}`)).toBeInTheDocument();
-    expect(screen.queryByTestId(`template-card-${TechnologyApplicationTemplate.EXPRESS}`)).not.toBeInTheDocument();
-  });
-
   it('seeds a technology template and launches the wizard when a card is clicked', async () => {
     const user = userEvent.setup();
     const setSelectedTechnology = vi.fn();

--- a/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationsListPage.test.tsx
+++ b/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationsListPage.test.tsx
@@ -17,7 +17,7 @@
  */
 
 import userEvent from '@testing-library/user-event';
-import {fireEvent, render, screen} from '@thunderid/test-utils';
+import {render, screen} from '@thunderid/test-utils';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import ApplicationsListPage from '../ApplicationsListPage';
 
@@ -77,27 +77,10 @@ describe('ApplicationsListPage', () => {
       expect(screen.getByRole('button', {name: /Create Application/i})).toBeInTheDocument();
     });
 
-    it('should render the search field', () => {
-      renderWithProviders();
-
-      const searchInput = screen.getByPlaceholderText('Search applications...');
-      expect(searchInput).toBeInTheDocument();
-      expect(searchInput).toHaveAttribute('type', 'text');
-    });
-
     it('should render the ApplicationsList component', () => {
       renderWithProviders();
 
       expect(screen.getByTestId('applications-list')).toBeInTheDocument();
-    });
-
-    it('should render search icon in the search field', () => {
-      renderWithProviders();
-
-      const searchInput = screen.getByPlaceholderText('Search applications...');
-      const searchInputContainer = searchInput.closest('.MuiInputBase-root');
-
-      expect(searchInputContainer).toBeInTheDocument();
     });
   });
 
@@ -132,40 +115,6 @@ describe('ApplicationsListPage', () => {
     });
   });
 
-  describe('Search Functionality', () => {
-    it('should allow typing in the search field', async () => {
-      const user = userEvent.setup();
-      renderWithProviders();
-
-      const searchInput = screen.getByPlaceholderText('Search applications...');
-      await user.type(searchInput, 'My App');
-
-      expect(searchInput).toHaveValue('My App');
-    });
-
-    it('should clear search field value', async () => {
-      const user = userEvent.setup();
-      renderWithProviders();
-
-      const searchInput = screen.getByPlaceholderText('Search applications...');
-      await user.type(searchInput, 'Test');
-      expect(searchInput).toHaveValue('Test');
-
-      await user.clear(searchInput);
-      expect(searchInput).toHaveValue('');
-    });
-
-    it('should handle special characters in search', async () => {
-      const user = userEvent.setup();
-      renderWithProviders();
-
-      const searchInput = screen.getByPlaceholderText('Search applications...');
-      await user.type(searchInput, '!@#$%^&*()');
-
-      expect(searchInput).toHaveValue('!@#$%^&*()');
-    });
-  });
-
   describe('Layout', () => {
     it('should have proper page structure', () => {
       const {container} = renderWithProviders();
@@ -178,50 +127,8 @@ describe('ApplicationsListPage', () => {
       expect(screen.getByRole('heading', {level: 1})).toBeInTheDocument();
       expect(screen.getByRole('button', {name: /Create Application/i})).toBeInTheDocument();
 
-      // Search section
-      expect(screen.getByPlaceholderText('Search applications...')).toBeInTheDocument();
-
       // Content section
       expect(screen.getByTestId('applications-list')).toBeInTheDocument();
-    });
-
-    it('should render components in correct order', () => {
-      const {container} = renderWithProviders();
-
-      const elements = [
-        screen.getByRole('heading', {level: 1}),
-        screen.getByRole('button', {name: /Create Application/i}),
-        screen.getByPlaceholderText('Search applications...'),
-        screen.getByTestId('applications-list'),
-      ];
-
-      // Verify each element exists in the DOM
-      elements.forEach((element) => {
-        expect(element).toBeInTheDocument();
-      });
-
-      // Verify order by checking positions in the DOM
-      const mainContainer = container.firstChild;
-      expect(mainContainer).toBeInTheDocument();
-    });
-  });
-
-  describe('Responsive Behavior', () => {
-    it('should render with responsive flex properties', () => {
-      const {container} = renderWithProviders();
-
-      // Header stack should have flexWrap
-      const headerStack = container.querySelector('.MuiStack-root');
-      expect(headerStack).toBeInTheDocument();
-    });
-
-    it('should render search field with minimum width', () => {
-      renderWithProviders();
-
-      const searchInput = screen.getByPlaceholderText('Search applications...');
-      const searchField = searchInput.closest('.MuiTextField-root');
-
-      expect(searchField).toBeInTheDocument();
     });
   });
 
@@ -256,17 +163,6 @@ describe('ApplicationsListPage', () => {
       expect(() => renderWithProviders()).not.toThrow();
     });
 
-    it('should render the search input adornment with icon', () => {
-      renderWithProviders();
-
-      const searchInput = screen.getByPlaceholderText('Search applications...');
-      const inputContainer = searchInput.closest('.MuiInputBase-root');
-
-      // The InputAdornment with Search icon should be present
-      expect(inputContainer).toBeInTheDocument();
-      expect(inputContainer?.querySelector('svg')).toBeInTheDocument();
-    });
-
     it('should render with all required MUI components', () => {
       renderWithProviders();
 
@@ -281,14 +177,6 @@ describe('ApplicationsListPage', () => {
       const createButton = screen.getByRole('button', {name: /Create Application/i});
       // Button should have SVG icon
       expect(createButton.querySelector('svg')).toBeInTheDocument();
-    });
-
-    it('should render TextField with correct size', () => {
-      renderWithProviders();
-
-      const searchInput = screen.getByPlaceholderText('Search applications...');
-      const textField = searchInput.closest('.MuiTextField-root');
-      expect(textField).toBeInTheDocument();
     });
 
     it('should render ApplicationsList component', () => {
@@ -312,33 +200,6 @@ describe('ApplicationsListPage', () => {
       // Navigation should be attempted for each click
       expect(mockNavigate).toHaveBeenCalledTimes(3);
     });
-
-    it('should handle long search queries', () => {
-      renderWithProviders();
-
-      const searchInput = screen.getByPlaceholderText('Search applications...');
-      const longQuery = 'A'.repeat(500);
-
-      // Use fireEvent for long input to avoid userEvent.type() per-keystroke overhead
-      fireEvent.change(searchInput, {target: {value: longQuery}});
-
-      expect(searchInput).toHaveValue(longQuery);
-    });
-
-    it('should maintain state after multiple interactions', () => {
-      renderWithProviders();
-
-      // Type in search using fireEvent for cross-platform reliability
-      const searchInput = screen.getByPlaceholderText('Search applications...');
-      fireEvent.change(searchInput, {target: {value: 'Test App'}});
-
-      // Click create button
-      const createButton = screen.getByRole('button', {name: /Create Application/i});
-      fireEvent.click(createButton);
-
-      // Search value should still be there
-      expect(searchInput).toHaveValue('Test App');
-    });
   });
 
   describe('Accessibility', () => {
@@ -350,35 +211,12 @@ describe('ApplicationsListPage', () => {
       expect(h1).toHaveTextContent('Applications');
     });
 
-    it('should have accessible search field', () => {
-      renderWithProviders();
-
-      const searchInput = screen.getByPlaceholderText('Search applications...');
-      expect(searchInput).toHaveAttribute('placeholder', 'Search applications...');
-    });
-
     it('should have accessible buttons', () => {
       renderWithProviders();
 
       const createButton = screen.getByRole('button', {name: /Create Application/i});
       expect(createButton).toBeEnabled();
       expect(createButton).toHaveAccessibleName();
-    });
-
-    it('should be keyboard navigable', async () => {
-      const user = userEvent.setup();
-      renderWithProviders();
-
-      // Tab through interactive elements
-      await user.tab();
-
-      const createButton = screen.getByRole('button', {name: /Create Application/i});
-      expect(createButton).toHaveFocus();
-
-      await user.tab();
-
-      const searchInput = screen.getByPlaceholderText('Search applications...');
-      expect(searchInput).toHaveFocus();
     });
 
     it('should support Enter key on Create Application button', async () => {

--- a/frontend/apps/console/src/features/flows/components/create-flow/__tests__/SelectFlowTemplate.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/create-flow/__tests__/SelectFlowTemplate.test.tsx
@@ -177,33 +177,6 @@ describe('SelectFlowTemplate', () => {
     });
   });
 
-  describe('Search', () => {
-    it('should render the search input', () => {
-      render(<SelectFlowTemplate {...defaultProps} />);
-
-      expect(screen.getByPlaceholderText('Search templates...')).toBeInTheDocument();
-    });
-
-    it('should filter templates by search query', () => {
-      render(<SelectFlowTemplate {...defaultProps} />);
-
-      const searchInput = screen.getByPlaceholderText('Search templates...');
-      fireEvent.change(searchInput, {target: {value: 'Google'}});
-
-      expect(screen.getByText('Google')).toBeInTheDocument();
-      expect(screen.queryByText('Username & Password')).not.toBeInTheDocument();
-    });
-
-    it('should show no results message when search matches nothing', () => {
-      render(<SelectFlowTemplate {...defaultProps} />);
-
-      const searchInput = screen.getByPlaceholderText('Search templates...');
-      fireEvent.change(searchInput, {target: {value: 'nonexistent'}});
-
-      expect(screen.getByText('No templates match your search.')).toBeInTheDocument();
-    });
-  });
-
   describe('Selection', () => {
     it('should auto-select the first template when no template is selected', () => {
       render(<SelectFlowTemplate {...defaultProps} />);

--- a/frontend/apps/console/src/features/groups/pages/GroupsListPage.tsx
+++ b/frontend/apps/console/src/features/groups/pages/GroupsListPage.tsx
@@ -17,8 +17,8 @@
  */
 
 import {useLogger} from '@thunderid/logger/react';
-import {Stack, Button, TextField, InputAdornment, PageContent, PageTitle} from '@wso2/oxygen-ui';
-import {Plus, Search} from '@wso2/oxygen-ui-icons-react';
+import {Stack, Button, PageContent, PageTitle} from '@wso2/oxygen-ui';
+import {Plus} from '@wso2/oxygen-ui-icons-react';
 import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
@@ -53,23 +53,6 @@ export default function GroupsListPage(): JSX.Element {
         </PageTitle.Actions>
       </PageTitle>
 
-      {/* TODO: Connect search field to state and implement server-side filtering. */}
-      <Stack direction="row" spacing={2} mb={4} flexWrap="wrap" useFlexGap>
-        <TextField
-          placeholder={t('groups:listing.search.placeholder')}
-          size="small"
-          sx={{flexGrow: 1, minWidth: 300}}
-          slotProps={{
-            input: {
-              startAdornment: (
-                <InputAdornment position="start">
-                  <Search size={16} />
-                </InputAdornment>
-              ),
-            },
-          }}
-        />
-      </Stack>
       <GroupsList />
     </PageContent>
   );

--- a/frontend/apps/console/src/features/groups/pages/__tests__/GroupsListPage.test.tsx
+++ b/frontend/apps/console/src/features/groups/pages/__tests__/GroupsListPage.test.tsx
@@ -67,12 +67,6 @@ describe('GroupsListPage', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/groups/create');
   });
 
-  it('should render search field', () => {
-    renderWithProviders(<GroupsListPage />);
-
-    expect(screen.getByPlaceholderText('Search groups...')).toBeInTheDocument();
-  });
-
   it('should render GroupsList component', () => {
     renderWithProviders(<GroupsListPage />);
 

--- a/frontend/apps/console/src/features/roles/pages/RolesListPage.tsx
+++ b/frontend/apps/console/src/features/roles/pages/RolesListPage.tsx
@@ -17,8 +17,8 @@
  */
 
 import {useLogger} from '@thunderid/logger/react';
-import {Stack, Button, TextField, InputAdornment, PageContent, PageTitle} from '@wso2/oxygen-ui';
-import {Plus, Search} from '@wso2/oxygen-ui-icons-react';
+import {Stack, Button, PageContent, PageTitle} from '@wso2/oxygen-ui';
+import {Plus} from '@wso2/oxygen-ui-icons-react';
 import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
@@ -53,23 +53,6 @@ export default function RolesListPage(): JSX.Element {
         </PageTitle.Actions>
       </PageTitle>
 
-      {/* TODO: Connect search field to state and implement server-side filtering. */}
-      <Stack direction="row" spacing={2} mb={4} flexWrap="wrap" useFlexGap>
-        <TextField
-          placeholder={t('roles:listing.search.placeholder')}
-          size="small"
-          sx={{flexGrow: 1, minWidth: 300}}
-          slotProps={{
-            input: {
-              startAdornment: (
-                <InputAdornment position="start">
-                  <Search size={16} />
-                </InputAdornment>
-              ),
-            },
-          }}
-        />
-      </Stack>
       <RolesList />
     </PageContent>
   );

--- a/frontend/apps/console/src/features/roles/pages/__tests__/RolesListPage.test.tsx
+++ b/frontend/apps/console/src/features/roles/pages/__tests__/RolesListPage.test.tsx
@@ -84,12 +84,6 @@ describe('RolesListPage', () => {
     expect(screen.getByRole('button', {name: /add role/i})).toBeInTheDocument();
   });
 
-  it('should render the search field', () => {
-    render(<RolesListPage />);
-
-    expect(screen.getByRole('textbox')).toBeInTheDocument();
-  });
-
   it('should navigate to create page when Add Role button is clicked', async () => {
     const user = userEvent.setup();
     render(<RolesListPage />);

--- a/frontend/packages/configure-users/src/pages/UsersListPage.tsx
+++ b/frontend/packages/configure-users/src/pages/UsersListPage.tsx
@@ -17,8 +17,8 @@
  */
 
 import {useLogger} from '@thunderid/logger/react';
-import {Stack, TextField, Button, InputAdornment, PageContent, PageTitle} from '@wso2/oxygen-ui';
-import {Plus, Search} from '@wso2/oxygen-ui-icons-react';
+import {Button, PageContent, PageTitle} from '@wso2/oxygen-ui';
+import {Plus} from '@wso2/oxygen-ui-icons-react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
 import UsersList from '../components/UsersList';
@@ -51,21 +51,6 @@ export default function UsersListPage() {
         </PageTitle.Actions>
       </PageTitle>
 
-      {/* Search */}
-      <Stack direction="row" spacing={2} mb={4} flexWrap="wrap" useFlexGap>
-        <TextField
-          placeholder={t('users:searchUsers')}
-          size="small"
-          sx={{flexGrow: 1, minWidth: 300}}
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <Search size={16} />
-              </InputAdornment>
-            ),
-          }}
-        />
-      </Stack>
       <UsersList />
     </PageContent>
   );

--- a/frontend/packages/configure-users/src/pages/__tests__/UserCreatePage.test.tsx
+++ b/frontend/packages/configure-users/src/pages/__tests__/UserCreatePage.test.tsx
@@ -27,6 +27,12 @@ const mockNavigate = vi.fn();
 const mockMutateAsync = vi.fn();
 const mockReset = vi.fn();
 
+// Helper to get the Create User action button (not the breadcrumb)
+const getCreateUserButton = () => {
+  const createButtons = screen.getAllByRole('button', {name: /create user/i});
+  return createButtons[createButtons.length - 1];
+};
+
 // Mock react-router
 vi.mock('react-router', async () => {
   const actual = await vi.importActual<typeof import('react-router')>('react-router');
@@ -524,10 +530,12 @@ describe('UserCreatePage', () => {
 
     // Wait for step ready state to update before clicking submit
     await waitFor(() => {
-      expect(screen.getByRole('button', {name: /create user/i})).not.toBeDisabled();
+      const createButtons = screen.getAllByRole('button', {name: /create user/i});
+      expect(createButtons[createButtons.length - 1]).not.toBeDisabled();
     });
 
-    await user.click(screen.getByRole('button', {name: /create user/i}));
+    const createButtons = screen.getAllByRole('button', {name: /create user/i});
+    await user.click(createButtons[createButtons.length - 1]);
 
     await waitFor(() => {
       expect(mockMutateAsync).toHaveBeenCalledWith({
@@ -552,10 +560,12 @@ describe('UserCreatePage', () => {
     await user.click(screen.getByTestId('fill-form-with-empty-values'));
 
     await waitFor(() => {
-      expect(screen.getByRole('button', {name: /create user/i})).not.toBeDisabled();
+      const createButtons = screen.getAllByRole('button', {name: /create user/i});
+      expect(createButtons[createButtons.length - 1]).not.toBeDisabled();
     });
 
-    await user.click(screen.getByRole('button', {name: /create user/i}));
+    const createButtons = screen.getAllByRole('button', {name: /create user/i});
+    await user.click(createButtons[createButtons.length - 1]);
 
     await waitFor(() => {
       const calledWith = mockMutateAsync.mock.calls[0][0] as {attributes: Record<string, unknown>};
@@ -627,11 +637,11 @@ describe('UserCreatePage', () => {
     await user.click(screen.getByTestId('fill-form'));
 
     await waitFor(() => {
-      expect(screen.getByRole('button', {name: /create user/i})).not.toBeDisabled();
+      expect(getCreateUserButton()).not.toBeDisabled();
     });
 
     // Trigger validation error to open snackbar
-    await user.click(screen.getByRole('button', {name: /create user/i}));
+    await user.click(getCreateUserButton());
 
     await waitFor(() => {
       expect(screen.getByText('Organization unit ID is missing for the selected user type.')).toBeInTheDocument();
@@ -685,10 +695,12 @@ describe('UserCreatePage', () => {
     await user.click(screen.getByTestId('fill-form'));
 
     await waitFor(() => {
-      expect(screen.getByRole('button', {name: /create user/i})).not.toBeDisabled();
+      const createButtons = screen.getAllByRole('button', {name: /create user/i});
+      expect(createButtons[createButtons.length - 1]).not.toBeDisabled();
     });
 
-    await user.click(screen.getByRole('button', {name: /create user/i}));
+    const createButtons = screen.getAllByRole('button', {name: /create user/i});
+    await user.click(createButtons[createButtons.length - 1]);
 
     await waitFor(() => {
       expect(screen.getByText('Organization unit ID is missing for the selected user type.')).toBeInTheDocument();
@@ -719,10 +731,12 @@ describe('UserCreatePage', () => {
     await user.click(screen.getByTestId('fill-form'));
 
     await waitFor(() => {
-      expect(screen.getByRole('button', {name: /create user/i})).not.toBeDisabled();
+      const createButtons = screen.getAllByRole('button', {name: /create user/i});
+      expect(createButtons[createButtons.length - 1]).not.toBeDisabled();
     });
 
-    await user.click(screen.getByRole('button', {name: /create user/i}));
+    const createButtons = screen.getAllByRole('button', {name: /create user/i});
+    await user.click(createButtons[createButtons.length - 1]);
 
     await waitFor(() => {
       expect(mockMutateAsync).toHaveBeenCalled();
@@ -856,9 +870,9 @@ describe('UserCreatePage', () => {
       await user.click(screen.getByTestId('fill-form'));
 
       await waitFor(() => {
-        expect(screen.getByRole('button', {name: /create user/i})).not.toBeDisabled();
+        expect(getCreateUserButton()).not.toBeDisabled();
       });
-      await user.click(screen.getByRole('button', {name: /create user/i}));
+      await user.click(getCreateUserButton());
 
       await waitFor(() => {
         expect(mockMutateAsync).toHaveBeenCalledWith({
@@ -891,9 +905,9 @@ describe('UserCreatePage', () => {
       await user.click(screen.getByTestId('fill-form'));
 
       await waitFor(() => {
-        expect(screen.getByRole('button', {name: /create user/i})).not.toBeDisabled();
+        expect(getCreateUserButton()).not.toBeDisabled();
       });
-      await user.click(screen.getByRole('button', {name: /create user/i}));
+      await user.click(getCreateUserButton());
 
       await waitFor(() => {
         expect(mockMutateAsync).toHaveBeenCalledWith({

--- a/frontend/packages/configure-users/src/pages/__tests__/UsersListPage.test.tsx
+++ b/frontend/packages/configure-users/src/pages/__tests__/UsersListPage.test.tsx
@@ -72,28 +72,11 @@ describe('UsersListPage', () => {
     expect(createButton).toBeInTheDocument();
   });
 
-  it('renders search input', () => {
-    render(<UsersListPage />);
-
-    const searchInput = screen.getByPlaceholderText('Search users...');
-    expect(searchInput).toBeInTheDocument();
-  });
-
   it('renders search icon', () => {
     const {container} = render(<UsersListPage />);
 
     const searchIcon = container.querySelector('svg');
     expect(searchIcon).toBeInTheDocument();
-  });
-
-  it('allows typing in search input', async () => {
-    const user = userEvent.setup();
-    render(<UsersListPage />);
-
-    const searchInput = screen.getByPlaceholderText('Search users...');
-    await user.type(searchInput, 'john doe');
-
-    expect(searchInput).toHaveValue('john doe');
   });
 
   it('navigates to add user flow when create button is clicked', async () => {


### PR DESCRIPTION
This pull request removes the search input fields and their related UI elements from the list pages for agents, applications, groups, roles, and users. It also removes all associated tests for these search fields, cleaning up both the UI and the test code. Additionally, there is a small navigation path update for the users page. These changes simplify the list pages by focusing them on displaying their respective lists without search/filter functionality.

**UI Cleanup:**

* Removed the search input field and related UI (e.g., `TextField`, `InputAdornment`, `Search` icon) from `AgentsListPage.tsx`, `ApplicationsListPage.tsx`, `GroupsListPage.tsx`, `RolesListPage.tsx`, and `UsersListPage.tsx`. [[1]](diffhunk://#diff-5b8cdad2fe8b5f0cc3937fc62e43186c197a0eaa8b53c3e2d19e97cdf1175525L21-R22) [[2]](diffhunk://#diff-5b8cdad2fe8b5f0cc3937fc62e43186c197a0eaa8b53c3e2d19e97cdf1175525L82-L98) [[3]](diffhunk://#diff-98078c1a65fe7dda110a34c16e9d3f1ffaec90413d72a9b3fa918d6727747b77L20-R21) [[4]](diffhunk://#diff-98078c1a65fe7dda110a34c16e9d3f1ffaec90413d72a9b3fa918d6727747b77L56-L72) [[5]](diffhunk://#diff-f4ccc9021d4db82e46b625addb85f9ad88b6e4909c7c81094f3a25dbe7f204c7L20-R21) [[6]](diffhunk://#diff-f4ccc9021d4db82e46b625addb85f9ad88b6e4909c7c81094f3a25dbe7f204c7L56-L72) [[7]](diffhunk://#diff-52d67c92ae161ba3ab26ff69b8b47edf949f042393ebcbd9020d424b09906085L20-R21) [[8]](diffhunk://#diff-52d67c92ae161ba3ab26ff69b8b47edf949f042393ebcbd9020d424b09906085L56-L72) [[9]](diffhunk://#diff-07a1d7e2e25b5c17a94acd3c791bcfbadac9c582cac098bfc15e24535defc8aeL20-R21)

**Test Cleanup:**

* Removed tests that check for the presence or behavior of the search input fields from the corresponding test files for agents, applications, groups, roles, and flows. [[1]](diffhunk://#diff-8f8ff1ee081ca6d93d6a03b73a0ed142f8f3769729d95195f2ea98119b0a19ecL89-L95) [[2]](diffhunk://#diff-a973e5989e8bcb4b3df3bd229c26fade34d224765bf1eb4a044376458fc93f29L80-L101) [[3]](diffhunk://#diff-a973e5989e8bcb4b3df3bd229c26fade34d224765bf1eb4a044376458fc93f29L135-L168) [[4]](diffhunk://#diff-a973e5989e8bcb4b3df3bd229c26fade34d224765bf1eb4a044376458fc93f29L181-L226) [[5]](diffhunk://#diff-a973e5989e8bcb4b3df3bd229c26fade34d224765bf1eb4a044376458fc93f29L259-L269) [[6]](diffhunk://#diff-a973e5989e8bcb4b3df3bd229c26fade34d224765bf1eb4a044376458fc93f29L286-L293) [[7]](diffhunk://#diff-a973e5989e8bcb4b3df3bd229c26fade34d224765bf1eb4a044376458fc93f29L316-L341) [[8]](diffhunk://#diff-a973e5989e8bcb4b3df3bd229c26fade34d224765bf1eb4a044376458fc93f29L353-L359) [[9]](diffhunk://#diff-a973e5989e8bcb4b3df3bd229c26fade34d224765bf1eb4a044376458fc93f29L368-L383) [[10]](diffhunk://#diff-2f199c27a6b560805eac71be1814c1db296c5d4f2f42ead74269324d185f28b3L70-L75) [[11]](diffhunk://#diff-b66a394730111633b1610a9065c9512d22e7a58ac241109461fb486fa209ea31L87-L92) [[12]](diffhunk://#diff-e614d0d7522494f45bb5d2cee7890e26c4a594e1f4f9e4bae8e740ad1b2b122fL180-L206)

**Minor Navigation Update:**

* Changed the navigation path from `/users/invite` to `/users/add` when adding a new user in `UsersListPage.tsx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Removed inline search inputs from the Agents, Applications, Groups, Roles, and Users list pages, simplifying layouts to show header actions followed by the list.
  * Removed template search/filtering UI from application and flow template selection screens.
* **Tests**
  * Updated/removed tests that asserted search input rendering and typing/filtering/empty-state messaging.
  * Kept existing coverage for titles/actions, list rendering, navigation, loading/disabled states, accessibility checks, and error handling (with some narrowing where search was no longer present).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->