### PR TITLE
Remove app-scope intersection from jwt-bearer (ID-JAG) grant

### DIFF
--- a/backend/internal/oauth/oauth2/granthandlers/jwt_bearer.go
+++ b/backend/internal/oauth/oauth2/granthandlers/jwt_bearer.go
@@ -101,9 +101,12 @@ func (h *jwtBearerGrantHandler) HandleGrant(ctx context.Context, tokenRequest *m
 		}
 	}
 
-	// Granted scopes = (assertion scope ∩ the app's registered scopes), further intersected with the
-	// request scope parameter when present.
-	grantedScopes := intersectScopes(assertionClaims.Scopes, oauthApp.Scopes)
+	// Granted scopes start from the assertion's scope claim, narrowed by the request scope parameter
+	// when present. The app's registered scopes are intentionally NOT intersected here: no other grant
+	// enforces oauthApp.Scopes (the scope validator is a passthrough), and resource-server-scoped
+	// narrowing below (when a resource claim is present) is the correct authorization boundary. Per-app
+	// resource authorization is expected to be handled by app-resource subscription once implemented.
+	grantedScopes := assertionClaims.Scopes
 	if tokenRequest.Scope != "" {
 		grantedScopes = intersectScopes(grantedScopes, tokenservice.ParseScopes(tokenRequest.Scope))
 	}

--- a/backend/internal/oauth/oauth2/granthandlers/jwt_bearer_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/jwt_bearer_test.go
@@ -234,8 +234,8 @@ func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_InvalidAssertion() 
 	assert.Equal(suite.T(), "Invalid assertion", errResp.ErrorDescription)
 }
 
-// Granted scopes are the intersection of the assertion scopes, the app's registered scopes, and the
-// request scope parameter.
+// Granted scopes are the intersection of the assertion scopes and the request scope parameter. The
+// app's registered scopes are not consulted.
 func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_ScopeIntersection() {
 	now := time.Now().Unix()
 	tokenRequest := &model.TokenRequest{
@@ -245,8 +245,8 @@ func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_ScopeIntersection()
 		Scope:     "read admin",
 	}
 
-	// Assertion carries [read write], app registers [read write], request narrows to [read admin].
-	// Only "read" survives all three; "write" not requested, "admin" not registered/asserted.
+	// Assertion carries [read write], request narrows to [read admin]. Only "read" survives the
+	// intersection; "write" was not requested, "admin" was not asserted.
 	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion, testClientID).
 		Return(&tokenservice.IDJAGAssertionClaims{
 			Sub:    testUserID,
@@ -271,6 +271,44 @@ func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_ScopeIntersection()
 	assert.Nil(suite.T(), errResp)
 	assert.NotNil(suite.T(), result)
 	assert.Equal(suite.T(), []string{"read"}, result.AccessToken.Scopes)
+}
+
+// Regression test: previously the granted scopes were intersected with oauthApp.Scopes, so an app with
+// no registered scopes silently produced an empty-scope token. The app's registered scopes are no
+// longer consulted, so the assertion's scopes are granted in full when no request scope narrows them.
+func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_EmptyAppScopes_AssertionScopesGranted() {
+	now := time.Now().Unix()
+	suite.oauthApp.Scopes = []string{}
+	tokenRequest := &model.TokenRequest{
+		GrantType: string(providers.GrantTypeJWTBearer),
+		ClientID:  testClientID,
+		Assertion: testAssertion,
+	}
+
+	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion, testClientID).
+		Return(&tokenservice.IDJAGAssertionClaims{
+			Sub:    testUserID,
+			Iss:    testCustomIssuer,
+			Scopes: []string{"read", "write"},
+		}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return tokenservice.JoinScopes(ctx.Scopes) == testScopeReadWrite
+		})).Return(&model.TokenDTO{
+		Token:     testTokenExchangeJWT,
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  now,
+		ExpiresIn: 3600,
+		Scopes:    []string{"read", "write"},
+		ClientID:  testClientID,
+		Subject:   testUserID,
+	}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), []string{"read", "write"}, result.AccessToken.Scopes)
 }
 
 // RFC 8707: when the assertion carries a resource claim, the resource AS resolves it to registered


### PR DESCRIPTION
## Description

Follow-up to #3893 (ID-JAG support), addressing a post-merge review comment.

The jwt-bearer grant handler narrowed granted scopes by intersecting the ID-JAG assertion's scopes with the OAuth application's registered scopes (`oauthApp.Scopes`):

```go
grantedScopes := intersectScopes(assertionClaims.Scopes, oauthApp.Scopes)
```

This is inconsistent with the rest of the system and has a silent failure mode:

- **No other grant handler enforces `oauthApp.Scopes`.** The global scope validator (`internal/oauth/scope/validator.go`) is a passthrough (`Return all requested scopes for now`), so `oauthApp.Scopes` is not a validation input anywhere else. jwt-bearer was the only place it gated anything.
- **Silent empty-scope tokens.** Because every other grant ignores `oauthApp.Scopes`, an app can reasonably leave that list empty — and everything works. On jwt-bearer, an empty list made the intersection collapse to `[]`, so the access token came back with **no scopes and no error**, even when the assertion and request both carried scopes.

## Change

Granted scopes now start from the assertion's `scope` claim, narrowed by:
1. the request `scope` parameter (when present), and
2. the resolved resource servers' permitted scopes (when the assertion carries a `resource` claim) — the correct RFC 8707 authorization boundary, unchanged by this PR.

The `oauthApp.Scopes` intersection is removed. Per-app resource authorization is left to the app-resource subscription model once implemented.

## Testing

- Updated the scope tests to reflect that granted scopes are `assertion ∩ request`, independent of `oauthApp.Scopes`.
- Added a regression test (`TestHandleGrant_EmptyAppScopes_AssertionScopesGranted`) proving an app with an empty scopes list now yields the assertion's scopes.
- Resource-claim narrowing tests unchanged.
- `make lint` (backend) and `make test_unit` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JWT bearer access tokens now preserve the scopes authorized by the assertion, even when the application has no registered scopes.
  * Requested scopes and resource-specific authorization continue to narrow access appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->