### PR TITLE
Add Console UI for trusted IDPs and ID-JAG support

### DIFF
--- a/backend/internal/connection/handler_test.go
+++ b/backend/internal/connection/handler_test.go
@@ -185,6 +185,34 @@ func (s *HandlerTestSuite) TestListConnectionsIdentityProviderCategory() {
 	s.mockNotif.AssertNotCalled(s.T(), "ListSendersByType", mock.Anything, ncommon.NotificationSenderTypeMessage)
 }
 
+func (s *HandlerTestSuite) TestListConnectionsIDJagEnabledField() {
+	trusted := true
+	s.mockIDP.On("GetIdentityProviderList", mock.Anything).Return([]idp.BasicIDPDTO{
+		{ID: "1", Name: "Trusted Issuer", Type: providers.IDPTypeOIDC, IDJagEnabled: &trusted},
+		{ID: "2", Name: "Plain Federation", Type: providers.IDPTypeOIDC},
+	}, (*tidcommon.ServiceError)(nil))
+
+	req := httptest.NewRequest(http.MethodGet, "/connections?category=identity-provider", nil)
+	rr := httptest.NewRecorder()
+	s.handler.handleListConnections(rr, req)
+	s.Equal(http.StatusOK, rr.Code)
+
+	var raw struct {
+		Connections []map[string]interface{} `json:"connections"`
+	}
+	s.Require().NoError(json.NewDecoder(rr.Body).Decode(&raw))
+	s.Require().Len(raw.Connections, 2)
+
+	byID := make(map[string]map[string]interface{}, len(raw.Connections))
+	for _, c := range raw.Connections {
+		byID[c["id"].(string)] = c
+	}
+
+	s.Require().Contains(byID["1"], "idJagEnabled")
+	s.Equal(true, byID["1"]["idJagEnabled"])
+	s.NotContains(byID["2"], "idJagEnabled")
+}
+
 func (s *HandlerTestSuite) TestListConnectionsSMSProviderCategory() {
 	s.mockNotif.On("ListSendersByType", mock.Anything, ncommon.NotificationSenderTypeMessage).
 		Return([]ncommon.NotificationSenderDTO{

--- a/backend/internal/connection/models.go
+++ b/backend/internal/connection/models.go
@@ -67,11 +67,12 @@ func parseConnectionCategory(raw string) (connectionCategory, bool) {
 // connectionInstance is a single configured connection instance in the flat GET /connections
 // listing, spanning IdP- and sender-backed connections.
 type connectionInstance struct {
-	ID          string               `json:"id"`
-	Name        string               `json:"name"`
-	Description string               `json:"description,omitempty"`
-	Type        string               `json:"type"`
-	Categories  []connectionCategory `json:"categories"`
+	ID           string               `json:"id"`
+	Name         string               `json:"name"`
+	Description  string               `json:"description,omitempty"`
+	Type         string               `json:"type"`
+	Categories   []connectionCategory `json:"categories"`
+	IDJagEnabled *bool                `json:"idJagEnabled,omitempty"`
 }
 
 // connectionListResponse is the paginated payload for GET /connections (the flat instance list).

--- a/backend/internal/connection/service.go
+++ b/backend/internal/connection/service.go
@@ -114,11 +114,12 @@ func (s *service) listInstances(ctx context.Context, category connectionCategory
 				continue
 			}
 			instances = append(instances, connectionInstance{
-				ID:          instance.ID,
-				Name:        instance.Name,
-				Description: instance.Description,
-				Type:        vendor,
-				Categories:  []connectionCategory{categoryIdentityProvider},
+				ID:           instance.ID,
+				Name:         instance.Name,
+				Description:  instance.Description,
+				Type:         vendor,
+				Categories:   []connectionCategory{categoryIdentityProvider},
+				IDJagEnabled: instance.IDJagEnabled,
 			})
 		}
 	}

--- a/backend/internal/connection/service_test.go
+++ b/backend/internal/connection/service_test.go
@@ -113,6 +113,32 @@ func (s *ServiceTestSuite) TestListInstancesAllCategories() {
 	s.Equal("1", got.Connections[2].ID)
 }
 
+func (s *ServiceTestSuite) TestListInstancesIDJagEnabled() {
+	trusted := true
+	plainDisabled := false
+	s.mockIDP.On("GetIdentityProviderList", mock.Anything).Return([]idp.BasicIDPDTO{
+		{ID: "1", Name: "Trusted", Type: providers.IDPTypeOIDC, IDJagEnabled: &trusted},
+		{ID: "2", Name: "Disabled", Type: providers.IDPTypeOIDC, IDJagEnabled: &plainDisabled},
+		{ID: "3", Name: "Plain", Type: providers.IDPTypeOIDC},
+	}, (*tidcommon.ServiceError)(nil))
+
+	got, svcErr := s.svc.listInstances(context.Background(), categoryIdentityProvider,
+		serverconst.DefaultPageSize, 0)
+	s.Nil(svcErr)
+	s.Require().Len(got.Connections, 3)
+
+	byID := make(map[string]connectionInstance, len(got.Connections))
+	for _, c := range got.Connections {
+		byID[c.ID] = c
+	}
+
+	s.Require().NotNil(byID["1"].IDJagEnabled)
+	s.True(*byID["1"].IDJagEnabled)
+	s.Require().NotNil(byID["2"].IDJagEnabled)
+	s.False(*byID["2"].IDJagEnabled)
+	s.Nil(byID["3"].IDJagEnabled)
+}
+
 func (s *ServiceTestSuite) TestListInstancesPaginates() {
 	s.mockIDP.On("GetIdentityProviderList", mock.Anything).Return([]idp.BasicIDPDTO{
 		{ID: "1", Name: "A", Type: providers.IDPTypeGoogle},

--- a/backend/internal/idp/file_based_store.go
+++ b/backend/internal/idp/file_based_store.go
@@ -84,10 +84,11 @@ func (f *idpFileBasedStore) GetIdentityProviderList(ctx context.Context) ([]Basi
 	for _, item := range list {
 		if idp, ok := item.Data.(*providers.IDPDTO); ok {
 			basicIDP := BasicIDPDTO{
-				ID:          idp.ID,
-				Name:        idp.Name,
-				Description: idp.Description,
-				Type:        idp.Type,
+				ID:           idp.ID,
+				Name:         idp.Name,
+				Description:  idp.Description,
+				Type:         idp.Type,
+				IDJagEnabled: idJagEnabledFromProperties(idp.Properties),
 			}
 			idpList = append(idpList, basicIDP)
 		}

--- a/backend/internal/idp/file_based_store_test.go
+++ b/backend/internal/idp/file_based_store_test.go
@@ -177,6 +177,50 @@ func (suite *FileBasedStoreTestSuite) TestGetIdentityProviderList() {
 	suite.True(idNames["Test IDP 5"])
 }
 
+func (suite *FileBasedStoreTestSuite) TestGetIdentityProviderList_IDJagEnabled() {
+	trustedProp, _ := cmodels.NewProperty(PropIDJagEnabled, "true", false)
+	disabledProp, _ := cmodels.NewProperty(PropIDJagEnabled, "false", false)
+	plainProp, _ := cmodels.NewProperty("client_id", "client1", false)
+
+	trusted := providers.IDPDTO{
+		ID:         "test-idp-trusted",
+		Name:       "Trusted Issuer",
+		Type:       providers.IDPTypeOIDC,
+		Properties: []cmodels.Property{*trustedProp},
+	}
+	disabled := providers.IDPDTO{
+		ID:         "test-idp-disabled",
+		Name:       "Disabled Issuer",
+		Type:       providers.IDPTypeOIDC,
+		Properties: []cmodels.Property{*disabledProp},
+	}
+	plain := providers.IDPDTO{
+		ID:         "test-idp-plain",
+		Name:       "Plain Federation",
+		Type:       providers.IDPTypeOIDC,
+		Properties: []cmodels.Property{*plainProp},
+	}
+
+	suite.NoError(suite.store.CreateIdentityProvider(context.Background(), trusted))
+	suite.NoError(suite.store.CreateIdentityProvider(context.Background(), disabled))
+	suite.NoError(suite.store.CreateIdentityProvider(context.Background(), plain))
+
+	idpList, err := suite.store.GetIdentityProviderList(context.Background())
+	suite.NoError(err)
+	suite.Len(idpList, 3)
+
+	byID := make(map[string]BasicIDPDTO, len(idpList))
+	for _, basicIDP := range idpList {
+		byID[basicIDP.ID] = basicIDP
+	}
+
+	suite.Require().NotNil(byID["test-idp-trusted"].IDJagEnabled)
+	suite.True(*byID["test-idp-trusted"].IDJagEnabled)
+	suite.Require().NotNil(byID["test-idp-disabled"].IDJagEnabled)
+	suite.False(*byID["test-idp-disabled"].IDJagEnabled)
+	suite.Nil(byID["test-idp-plain"].IDJagEnabled)
+}
+
 func (suite *FileBasedStoreTestSuite) TestUpdateIdentityProvider_NotSupported() {
 	// Test that update is not supported in file-based store
 	idp := &providers.IDPDTO{

--- a/backend/internal/idp/model.go
+++ b/backend/internal/idp/model.go
@@ -25,11 +25,12 @@ import (
 
 // BasicIDPDTO represents a basic data transfer object for an identity provider.
 type BasicIDPDTO struct {
-	ID          string
-	Name        string
-	Description string
-	Type        providers.IDPType
-	IsReadOnly  bool
+	ID           string
+	Name         string
+	Description  string
+	Type         providers.IDPType
+	IsReadOnly   bool
+	IDJagEnabled *bool
 }
 
 // idpRequest represents the request payload for creating or updating an identity provider.

--- a/backend/internal/idp/store.go
+++ b/backend/internal/idp/store.go
@@ -112,12 +112,15 @@ func (s *idpStore) GetIdentityProviderList(ctx context.Context) ([]BasicIDPDTO, 
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
 
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IdPStore"))
+
 	idpList := make([]BasicIDPDTO, 0)
 	for _, row := range results {
 		idp, err := buildIDPFromResultRow(row)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build idp from result row: %w", err)
 		}
+		idp.IDJagEnabled = idJagEnabledFromRow(ctx, logger, idp.ID, row)
 		idpList = append(idpList, *idp)
 	}
 
@@ -363,6 +366,30 @@ func buildIDPFromResultRow(row map[string]interface{}) (*BasicIDPDTO, error) {
 	}
 
 	return &idp, nil
+}
+
+// idJagEnabledFromRow extracts and parses the id_jag_enabled property from a query result row's
+// PROPERTIES column, used only by the basic listing. A malformed PROPERTIES value only drops this
+// display flag for the affected row (logged and left nil) rather than failing the whole listing.
+func idJagEnabledFromRow(ctx context.Context, logger *log.Logger, idpID string, row map[string]interface{}) *bool {
+	var propertiesJSON string
+	switch v := row["properties"].(type) {
+	case string:
+		propertiesJSON = v
+	case []byte:
+		propertiesJSON = string(v)
+	}
+	if propertiesJSON == "" {
+		return nil
+	}
+
+	properties, err := cmodels.DeserializePropertiesFromJSONObject(propertiesJSON)
+	if err != nil {
+		logger.Warn(ctx, "Failed to deserialize IDP properties; omitting idJagEnabled flag",
+			log.String("idpID", idpID), log.Error(err))
+		return nil
+	}
+	return idJagEnabledFromProperties(properties)
 }
 
 // serializeAttributeConfiguration marshals the attribute mapping to a JSON string. Returns nil when

--- a/backend/internal/idp/store_test.go
+++ b/backend/internal/idp/store_test.go
@@ -195,6 +195,86 @@ func (s *IDPStoreTestSuite) TestGetIdentityProviderList_EmptyList() {
 	s.mockDBClient.AssertExpectations(s.T())
 }
 
+// TestGetIdentityProviderList_IDJagEnabled tests that the id_jag_enabled property value is
+// parsed onto the list item when present (true or false), and left nil when absent.
+func (s *IDPStoreTestSuite) TestGetIdentityProviderList_IDJagEnabled() {
+	results := []map[string]interface{}{
+		{
+			"id":          "idp-1",
+			"name":        "Trusted Issuer",
+			"description": "",
+			"type":        "OIDC",
+			"properties":  `{"id_jag_enabled":{"value":"true","isSecret":false}}`,
+		},
+		{
+			"id":          "idp-2",
+			"name":        "Disabled Issuer",
+			"description": "",
+			"type":        "OIDC",
+			"properties":  `{"id_jag_enabled":{"value":"false","isSecret":false}}`,
+		},
+		{
+			"id":          "idp-3",
+			"name":        "Plain Federation",
+			"description": "",
+			"type":        "OIDC",
+			"properties":  `{"client_id":{"value":"abc","isSecret":false}}`,
+		},
+	}
+
+	s.mockDBProvider.On("GetConfigDBClient").Return(s.mockDBClient, nil)
+	s.mockDBClient.On("QueryContext", context.Background(), queryGetIdentityProviderList,
+		testDeploymentID).Return(results, nil)
+
+	list, err := s.store.GetIdentityProviderList(context.Background())
+
+	s.NoError(err)
+	s.Require().Len(list, 3)
+	s.Require().NotNil(list[0].IDJagEnabled)
+	s.True(*list[0].IDJagEnabled)
+	s.Require().NotNil(list[1].IDJagEnabled)
+	s.False(*list[1].IDJagEnabled)
+	s.Nil(list[2].IDJagEnabled)
+	s.mockDBProvider.AssertExpectations(s.T())
+	s.mockDBClient.AssertExpectations(s.T())
+}
+
+// TestGetIdentityProviderList_MalformedPropertiesDegradesGracefully tests that a row with
+// unparseable PROPERTIES only drops the idJagEnabled flag for that row (nil) rather than
+// failing the entire listing.
+func (s *IDPStoreTestSuite) TestGetIdentityProviderList_MalformedPropertiesDegradesGracefully() {
+	results := []map[string]interface{}{
+		{
+			"id":          "idp-1",
+			"name":        "Malformed Properties",
+			"description": "",
+			"type":        "OIDC",
+			"properties":  `{not-valid-json`,
+		},
+		{
+			"id":          "idp-2",
+			"name":        "Trusted Issuer",
+			"description": "",
+			"type":        "OIDC",
+			"properties":  `{"id_jag_enabled":{"value":"true","isSecret":false}}`,
+		},
+	}
+
+	s.mockDBProvider.On("GetConfigDBClient").Return(s.mockDBClient, nil)
+	s.mockDBClient.On("QueryContext", context.Background(), queryGetIdentityProviderList,
+		testDeploymentID).Return(results, nil)
+
+	list, err := s.store.GetIdentityProviderList(context.Background())
+
+	s.NoError(err)
+	s.Require().Len(list, 2)
+	s.Nil(list[0].IDJagEnabled)
+	s.Require().NotNil(list[1].IDJagEnabled)
+	s.True(*list[1].IDJagEnabled)
+	s.mockDBProvider.AssertExpectations(s.T())
+	s.mockDBClient.AssertExpectations(s.T())
+}
+
 // TestGetIdentityProviderList_DBClientError tests DB client error
 func (s *IDPStoreTestSuite) TestGetIdentityProviderList_DBClientError() {
 	s.mockDBProvider.On("GetConfigDBClient").Return(nil, errors.New("db error"))

--- a/backend/internal/idp/utils.go
+++ b/backend/internal/idp/utils.go
@@ -21,6 +21,7 @@ package idp
 import (
 	"context"
 	"slices"
+	"strconv"
 	"strings"
 
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
@@ -47,6 +48,28 @@ func GetPropertyValue(properties []cmodels.Property, name string) string {
 		}
 	}
 	return ""
+}
+
+// idJagEnabledFromProperties returns a pointer to the parsed id_jag_enabled property value, or nil
+// when the property is absent (or its value cannot be parsed as a boolean). This lets basic IDP
+// listings distinguish trusted-issuer OIDC connections from plain federation ones without
+// exposing full property details.
+func idJagEnabledFromProperties(properties []cmodels.Property) *bool {
+	for i := range properties {
+		if properties[i].GetName() != PropIDJagEnabled {
+			continue
+		}
+		val, err := properties[i].GetValue()
+		if err != nil {
+			return nil
+		}
+		enabled, err := strconv.ParseBool(val)
+		if err != nil {
+			return nil
+		}
+		return &enabled
+	}
+	return nil
 }
 
 // GetMappedUserType returns the resolved local user type for the IDP's attribute mapping, or an
@@ -256,18 +279,35 @@ func validateIDPProperties(ctx context.Context, idpType providers.IDPType, prope
 				Params:       map[string]string{"property": propName},
 			})
 		}
+		if propName == PropIDJagEnabled || propName == PropTokenExchangeEnabled {
+			if propertyValue != "true" && propertyValue != "false" {
+				return nil, tidcommon.CustomServiceError(ErrorInvalidIDPProperty, tidcommon.I18nMessage{
+					Key: "error.idpservice.property_value_not_boolean_description",
+					DefaultValue: "value for property '{{param(property)}}' must be either " +
+						"'true' or 'false'",
+					Params: map[string]string{"property": propName},
+				})
+			}
+		}
 
 		filteredPropsMap[propName] = prop
 		filteredPropKeys = append(filteredPropKeys, propName)
 	}
 
 	// Check for required properties, using the token-exchange override when applicable.
+	// The reduced required set also applies when id_jag_enabled is present, since that property
+	// is only ever sent for trust-only connections which carry no OAuth client credentials.
 	requiredProps := config.Required
 	if teProps, ok := tokenExchangeRequiredProps[idpType]; ok {
+		_, idJagEnabledPresent := filteredPropsMap[PropIDJagEnabled]
+		tokenExchangeEnabled := false
 		if prop, exists := filteredPropsMap[PropTokenExchangeEnabled]; exists {
 			if val, err := prop.GetValue(); err == nil && val == "true" {
-				requiredProps = teProps
+				tokenExchangeEnabled = true
 			}
+		}
+		if tokenExchangeEnabled || idJagEnabledPresent {
+			requiredProps = teProps
 		}
 	}
 	for _, requiredProp := range requiredProps {

--- a/backend/internal/idp/utils_test.go
+++ b/backend/internal/idp/utils_test.go
@@ -708,6 +708,119 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_OIDCWithoutTokenExchange_M
 	s.Contains(err.ErrorDescription.String(), PropClientSecret)
 }
 
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_IDJagEnabledTrue_OIDC_Succeeds() {
+	// OIDC IDP with id_jag_enabled=true and no client credentials should succeed;
+	// issuer and jwks_endpoint alone are sufficient for trust-only connections.
+	prop1, _ := cmodels.NewProperty(PropIssuer, "https://api.asgardeo.io/t/myorg/oauth2/token", false)
+	prop2, _ := cmodels.NewProperty(PropJwksEndpoint, "https://api.asgardeo.io/t/myorg/oauth2/jwks", false)
+	prop3, _ := cmodels.NewProperty(PropIDJagEnabled, "true", false)
+	prop4, _ := cmodels.NewProperty(PropTokenExchangeEnabled, "false", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3, *prop4}
+
+	result, err := validateIDPProperties(context.Background(), providers.IDPTypeOIDC, properties, s.logger)
+
+	s.Nil(err)
+	s.NotNil(result)
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_IDJagEnabledFalse_OIDC_Succeeds() {
+	// OIDC IDP with id_jag_enabled=false (still present) should succeed without client credentials,
+	// since the mere presence of id_jag_enabled identifies a trust-only connection.
+	prop1, _ := cmodels.NewProperty(PropIssuer, "https://api.asgardeo.io/t/myorg/oauth2/token", false)
+	prop2, _ := cmodels.NewProperty(PropJwksEndpoint, "https://api.asgardeo.io/t/myorg/oauth2/jwks", false)
+	prop3, _ := cmodels.NewProperty(PropIDJagEnabled, "false", false)
+	prop4, _ := cmodels.NewProperty(PropTokenExchangeEnabled, "false", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3, *prop4}
+
+	result, err := validateIDPProperties(context.Background(), providers.IDPTypeOIDC, properties, s.logger)
+
+	s.Nil(err)
+	s.NotNil(result)
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_IDJagEnabled_MissingIssuer_Fails() {
+	// OIDC IDP with id_jag_enabled present but missing issuer should fail.
+	prop1, _ := cmodels.NewProperty(PropJwksEndpoint, "https://api.asgardeo.io/t/myorg/oauth2/jwks", false)
+	prop2, _ := cmodels.NewProperty(PropIDJagEnabled, "true", false)
+
+	properties := []cmodels.Property{*prop1, *prop2}
+
+	result, err := validateIDPProperties(context.Background(), providers.IDPTypeOIDC, properties, s.logger)
+
+	s.NotNil(err)
+	s.Nil(result)
+	s.Equal(ErrorInvalidIDPProperty.Code, err.Code)
+	s.Contains(err.ErrorDescription.DefaultValue, "required property")
+	s.Contains(err.ErrorDescription.String(), PropIssuer)
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_IDJagEnabled_MissingJWKS_Fails() {
+	// OIDC IDP with id_jag_enabled present but missing jwks_endpoint should fail.
+	prop1, _ := cmodels.NewProperty(PropIssuer, "https://api.asgardeo.io/t/myorg/oauth2/token", false)
+	prop2, _ := cmodels.NewProperty(PropIDJagEnabled, "true", false)
+
+	properties := []cmodels.Property{*prop1, *prop2}
+
+	result, err := validateIDPProperties(context.Background(), providers.IDPTypeOIDC, properties, s.logger)
+
+	s.NotNil(err)
+	s.Nil(result)
+	s.Equal(ErrorInvalidIDPProperty.Code, err.Code)
+	s.Contains(err.ErrorDescription.DefaultValue, "required property")
+	s.Contains(err.ErrorDescription.String(), PropJwksEndpoint)
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_IDJagEnabled_NonBooleanValue_Fails() {
+	// OIDC IDP with id_jag_enabled set to a non-boolean value should fail validation.
+	prop1, _ := cmodels.NewProperty(PropIssuer, "https://api.asgardeo.io/t/myorg/oauth2/token", false)
+	prop2, _ := cmodels.NewProperty(PropJwksEndpoint, "https://api.asgardeo.io/t/myorg/oauth2/jwks", false)
+	prop3, _ := cmodels.NewProperty(PropIDJagEnabled, "x", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3}
+
+	result, err := validateIDPProperties(context.Background(), providers.IDPTypeOIDC, properties, s.logger)
+
+	s.NotNil(err)
+	s.Nil(result)
+	s.Equal(ErrorInvalidIDPProperty.Code, err.Code)
+	s.Contains(err.ErrorDescription.String(), PropIDJagEnabled)
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_TokenExchangeEnabled_NonBooleanValue_Fails() {
+	// OIDC IDP with token_exchange_enabled set to a non-boolean value should fail validation.
+	prop1, _ := cmodels.NewProperty(PropIssuer, "https://api.asgardeo.io/t/myorg/oauth2/token", false)
+	prop2, _ := cmodels.NewProperty(PropJwksEndpoint, "https://api.asgardeo.io/t/myorg/oauth2/jwks", false)
+	prop3, _ := cmodels.NewProperty(PropTokenExchangeEnabled, "yes", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3}
+
+	result, err := validateIDPProperties(context.Background(), providers.IDPTypeOIDC, properties, s.logger)
+
+	s.NotNil(err)
+	s.Nil(result)
+	s.Equal(ErrorInvalidIDPProperty.Code, err.Code)
+	s.Contains(err.ErrorDescription.String(), PropTokenExchangeEnabled)
+}
+
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_PlainOIDCWithoutIDJagOrTokenExchange_StillFails() {
+	// Plain OIDC IDP without id_jag_enabled or token_exchange_enabled and without client
+	// credentials must still fail (regression guard for the full required set).
+	prop1, _ := cmodels.NewProperty(PropIssuer, "https://api.asgardeo.io/t/myorg/oauth2/token", false)
+	prop2, _ := cmodels.NewProperty(PropJwksEndpoint, "https://api.asgardeo.io/t/myorg/oauth2/jwks", false)
+
+	properties := []cmodels.Property{*prop1, *prop2}
+
+	result, err := validateIDPProperties(context.Background(), providers.IDPTypeOIDC, properties, s.logger)
+
+	s.NotNil(err)
+	s.Nil(result)
+	s.Equal(ErrorInvalidIDPProperty.Code, err.Code)
+	s.Contains(err.ErrorDescription.DefaultValue, "required property")
+	s.Contains(err.ErrorDescription.String(), PropClientID)
+}
+
 func (s *IDPUtilsTestSuite) TestValidateIDP_PropertyValidationFailure() {
 	prop, _ := cmodels.NewProperty("", "value", false)
 	idp := &providers.IDPDTO{
@@ -962,4 +1075,37 @@ func (s *IDPUtilsTestSuite) TestGetMappedUserType_DynamicResolutionNestedClaim()
 	}}
 	claims := map[string]interface{}{"profile": map[string]interface{}{"role": "admin"}}
 	s.Equal("employee", GetMappedUserType(idpDTO, claims))
+}
+
+func (s *IDPUtilsTestSuite) TestIDJagEnabledFromProperties_True() {
+	prop, err := cmodels.NewProperty(PropIDJagEnabled, "true", false)
+	s.NoError(err)
+
+	got := idJagEnabledFromProperties([]cmodels.Property{*prop})
+	s.Require().NotNil(got)
+	s.True(*got)
+}
+
+func (s *IDPUtilsTestSuite) TestIDJagEnabledFromProperties_False() {
+	prop, err := cmodels.NewProperty(PropIDJagEnabled, "false", false)
+	s.NoError(err)
+
+	got := idJagEnabledFromProperties([]cmodels.Property{*prop})
+	s.Require().NotNil(got)
+	s.False(*got)
+}
+
+func (s *IDPUtilsTestSuite) TestIDJagEnabledFromProperties_Absent() {
+	prop, err := cmodels.NewProperty("client_id", "abc", false)
+	s.NoError(err)
+
+	s.Nil(idJagEnabledFromProperties([]cmodels.Property{*prop}))
+	s.Nil(idJagEnabledFromProperties(nil))
+}
+
+func (s *IDPUtilsTestSuite) TestIDJagEnabledFromProperties_InvalidValue() {
+	prop, err := cmodels.NewProperty(PropIDJagEnabled, "not-a-bool", false)
+	s.NoError(err)
+
+	s.Nil(idJagEnabledFromProperties([]cmodels.Property{*prop}))
 }

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -755,6 +755,7 @@ var defaultMessages = map[string]string{
 	"error.idpservice.property_not_supported_for_type_description": "property '{{param(property)}}' is not supported for IDP type '{{param(idpType)}}'",
 	"error.idpservice.property_value_empty_description": "value cannot be empty for property '{{param(property)}}'",
 	"error.idpservice.property_value_get_failed_description": "failed to get value for property '{{param(property)}}': {{param(error)}}",
+	"error.idpservice.property_value_not_boolean_description": "value for property '{{param(property)}}' must be either 'true' or 'false'",
 	"error.idpservice.required_property_missing_description": "required property '{{param(property)}}' is missing for IDP type '{{param(idpType)}}'",
 	"error.idpservice.result_limit_exceeded": "Result limit exceeded in composite mode",
 	"error.idpservice.result_limit_exceeded_description": "The total number of records exceeds the maximum limit in composite mode",

--- a/frontend/apps/console/src/App.tsx
+++ b/frontend/apps/console/src/App.tsx
@@ -24,7 +24,7 @@ import {UserCreateProvider} from '@thunderid/configure-users';
 import {ToastProvider} from '@thunderid/contexts';
 import {ProtectedRoute} from '@thunderid/react-router';
 import {lazy, Suspense, type JSX} from 'react';
-import {BrowserRouter, Outlet, Route, Routes} from 'react-router';
+import {BrowserRouter, Navigate, Outlet, Route, Routes} from 'react-router';
 import AgentCreateProvider from './features/agents/contexts/AgentCreate/AgentCreateProvider';
 import ApplicationCreateProvider from './features/applications/contexts/ApplicationCreate/ApplicationCreateProvider';
 import LayoutBuilderProvider from './features/design/contexts/LayoutBuilder/LayoutBuilderProvider';
@@ -120,14 +120,13 @@ const ConnectionDetailPage = lazy(() =>
 const ConnectionConfigureWizardPage = lazy(() =>
   import('@thunderid/configure-connections').then((m) => ({default: m.ConnectionConfigureWizardPage})),
 );
-const ConnectionCreateWizardPage = lazy(() =>
-  import('@thunderid/configure-connections').then((m) => ({default: m.ConnectionCreateWizardPage})),
-);
+const ConnectionCreateWizardRoute = lazy(() => import('./features/connections/pages/ConnectionCreateWizardRoute'));
 const LoginFlowBuilderPage = lazy(() => import('./features/login-flow/pages/LoginFlowPage'));
 const CreateRolePage = lazy(() => import('./features/roles/pages/CreateRolePage'));
 const RoleEditPage = lazy(() => import('./features/roles/pages/RoleEditPage'));
 const RolesListPage = lazy(() => import('./features/roles/pages/RolesListPage'));
 const SettingsPage = lazy(() => import('./features/settings/pages/SettingsPage'));
+const TrustedIssuerDetailPage = lazy(() => import('./features/trusted-issuers/pages/TrustedIssuerDetailPage'));
 const VerifiablePresentationsListPage = lazy(
   () => import('./features/verifiable-presentations/pages/VerifiablePresentationsListPage'),
 );
@@ -183,6 +182,8 @@ export default function App(): JSX.Element {
               <Route path="connections" element={<ConnectionsListPage />} />
               <Route path="connections/:type" element={<ConnectionDetailPage />} />
               <Route path="connections/:type/:id" element={<ConnectionDetailPage />} />
+              <Route path="trusted-issuers" element={<Navigate to="/connections" replace />} />
+              <Route path="trusted-issuers/:id" element={<TrustedIssuerDetailPage />} />
               <Route path="groups" element={<GroupsListPage />} />
               <Route path="groups/:groupId" element={<GroupEditPage />} />
               <Route path="roles" element={<RolesListPage />} />
@@ -361,7 +362,7 @@ export default function App(): JSX.Element {
                 </ProtectedRoute>
               }
             >
-              <Route index element={<ConnectionCreateWizardPage />} />
+              <Route index element={<ConnectionCreateWizardRoute />} />
             </Route>
             <Route
               path="/connections/:type/configure"

--- a/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/__tests__/OperationModesSection.test.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/__tests__/OperationModesSection.test.tsx
@@ -68,7 +68,7 @@ describe('OperationModesSection', () => {
 
       const listbox = await screen.findByRole('listbox');
       expect(within(listbox).getByText('client_credentials')).toBeInTheDocument();
-      expect(within(listbox).getByText('urn:ietf:params:oauth:grant-type:token-exchange')).toBeInTheDocument();
+      expect(within(listbox).getByText('Token Exchange')).toBeInTheDocument();
       expect(within(listbox).getByText('authorization_code')).toBeInTheDocument();
       expect(within(listbox).getByText('CIBA (Client-Initiated Backchannel Authentication)')).toBeInTheDocument();
       expect(within(listbox).getByText('refresh_token')).toBeInTheDocument();
@@ -111,7 +111,7 @@ describe('OperationModesSection', () => {
 
       await user.click(document.getElementById('agent-grant-types')!);
       const listbox = await screen.findByRole('listbox');
-      await user.click(within(listbox).getByText('urn:ietf:params:oauth:grant-type:token-exchange'));
+      await user.click(within(listbox).getByText('Token Exchange'));
 
       expect(onOAuth2ConfigChange).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/EditAdvancedSettings.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/EditAdvancedSettings.tsx
@@ -19,12 +19,13 @@
 import {Stack} from '@wso2/oxygen-ui';
 import AttestationSection from './AttestationSection';
 import CertificateSection from './CertificateSection';
+import IdentityAssertionsSection from './IdentityAssertionsSection';
 import MetadataSection from './MetadataSection';
 import OAuth2ConfigSection from './OAuth2ConfigSection';
 import type {Application} from '../../../models/application';
 import type {ApplicationTemplate} from '../../../models/application-templates';
 import type {InboundAuthConfig} from '../../../models/inbound-auth';
-import type {AttestationConfig, OAuth2Config} from '../../../models/oauth';
+import type {AttestationConfig, OAuth2Config, OAuth2Token} from '../../../models/oauth';
 
 /**
  * Props for the {@link EditAdvancedSettings} component.
@@ -62,6 +63,11 @@ interface EditAdvancedSettingsProps {
    * capability, so it appears only for templates that support it (e.g. mobile).
    */
   showAttestation?: boolean;
+  /**
+   * Callback to report whether the identity assertions (ID-JAG) section currently has
+   * validation errors (feeds the Save bar).
+   */
+  onValidationChange?: (hasErrors: boolean) => void;
 }
 
 type OAuthCertificate = {type: string; value?: string} | null;
@@ -85,6 +91,7 @@ export default function EditAdvancedSettings({
   onFieldChange,
   allowedGrantTypes = undefined,
   showAttestation = false,
+  onValidationChange = undefined,
 }: EditAdvancedSettingsProps) {
   const handleOAuth2ConfigChange = (updates: Partial<OAuth2Config>) => {
     const currentInboundAuth: InboundAuthConfig[] = editedApp.inboundAuthConfig ?? application.inboundAuthConfig ?? [];
@@ -109,6 +116,23 @@ export default function EditAdvancedSettings({
   // the user clearing attestation. Only fall back to the stored value when the field is untouched.
   const currentAttestation = 'attestation' in editedApp ? editedApp.attestation : application.attestation;
 
+  const handleTokenConfigChange = (tokenUpdates: Partial<OAuth2Token>, oauth2Updates: Partial<OAuth2Config> = {}) => {
+    const currentInboundAuth: InboundAuthConfig[] = editedApp.inboundAuthConfig ?? application.inboundAuthConfig ?? [];
+    const updatedInboundAuth = currentInboundAuth.map((auth) =>
+      auth.type === 'oauth2'
+        ? {
+            ...auth,
+            config: {
+              ...auth.config,
+              ...oauth2Updates,
+              token: {...auth.config?.token, ...tokenUpdates},
+            },
+          }
+        : auth,
+    );
+    onFieldChange('inboundAuthConfig', updatedInboundAuth);
+  };
+
   return (
     <Stack spacing={3}>
       <OAuth2ConfigSection
@@ -118,6 +142,14 @@ export default function EditAdvancedSettings({
         disabled={application.isReadOnly}
         allowedGrantTypes={allowedGrantTypes}
       />
+      {oauth2Config && (
+        <IdentityAssertionsSection
+          oauth2Config={oauth2Config}
+          onTokenConfigChange={handleTokenConfigChange}
+          disabled={application.isReadOnly}
+          onValidationChange={onValidationChange}
+        />
+      )}
       <CertificateSection
         certificate={oauth2Config?.certificate}
         onCertificateChange={handleCertificateChange}

--- a/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/IdentityAssertionsSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/IdentityAssertionsSection.tsx
@@ -1,0 +1,292 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {SettingsCard} from '@thunderid/components';
+import {
+  Autocomplete,
+  Chip,
+  FormControl,
+  FormLabel,
+  InputAdornment,
+  Stack,
+  Switch,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@wso2/oxygen-ui';
+import {useEffect, useState} from 'react';
+import {useTranslation} from 'react-i18next';
+import {
+  OAuth2GrantTypes,
+  TokenEndpointAuthMethods,
+  type IDJAGConfig,
+  type OAuth2Config,
+  type OAuth2Token,
+} from '../../../models/oauth';
+import {applyGrantTypesChange} from '../../../utils/oauth2Rules';
+
+const DEFAULT_VALIDITY_PERIOD = 300;
+
+/**
+ * Props for the {@link IdentityAssertionsSection} component.
+ */
+interface IdentityAssertionsSectionProps {
+  /**
+   * OAuth2 configuration to display
+   */
+  oauth2Config?: OAuth2Config;
+  /**
+   * Callback to handle changes to the token configuration's ID-JAG settings. Accepts an optional
+   * `oauth2Updates` argument so that enabling ID-JAG (which also adds the token exchange grant
+   * type) can be applied as a single combined update instead of two separate ones, avoiding a
+   * lost update when both are derived from the same stale snapshot.
+   */
+  onTokenConfigChange: (tokenUpdates: Partial<OAuth2Token>, oauth2Updates?: Partial<OAuth2Config>) => void;
+  /**
+   * Whether inputs should be disabled (e.g. read-only resource).
+   */
+  disabled?: boolean;
+  /**
+   * Callback to report whether this section currently has validation errors (feeds the Save bar).
+   */
+  onValidationChange?: (hasErrors: boolean) => void;
+}
+
+/**
+ * Section component for configuring Identity Assertion Authorization Grant (ID-JAG) issuance.
+ *
+ * Lets admins enable signed identity assertions for an application, and configure the audiences
+ * an issued assertion may target and its validity period. Enabling ID-JAG also adds the token
+ * exchange grant type. ID-JAG issuance requires a confidential client, so the toggle is disabled
+ * with an explanatory tooltip while the application is a public client.
+ *
+ * @param props - Component props
+ * @returns Identity assertions configuration UI within a SettingsCard, or null
+ */
+export default function IdentityAssertionsSection({
+  oauth2Config = undefined,
+  onTokenConfigChange,
+  disabled = false,
+  onValidationChange = undefined,
+}: IdentityAssertionsSectionProps) {
+  const {t} = useTranslation();
+  const rawIdJag = oauth2Config?.token?.idJag;
+  const currentIdJag: IDJAGConfig = rawIdJag ?? {enabled: false};
+  const [invalidValidityPeriodInput, setInvalidValidityPeriodInput] = useState<string | null>(null);
+  const [reconciledIdJag, setReconciledIdJag] = useState<IDJAGConfig | undefined>(rawIdJag);
+
+  // Reconciles the locally-held invalid input with the external idJag config whenever the latter
+  // is replaced (e.g. on discard), so a rejected value doesn't linger after the page goes clean.
+  // Adjusted during render (rather than in an effect) per React's guidance for resetting state
+  // when a prop changes.
+  if (rawIdJag !== reconciledIdJag) {
+    setReconciledIdJag(rawIdJag);
+    setInvalidValidityPeriodInput(null);
+  }
+
+  // Computed ahead of the `!oauth2Config` early return (and reported via an effect below) so a
+  // previously-reported error is cleared when the section stops rendering its fields, either
+  // because ID-JAG is toggled off or this section is unmounted entirely (oauth2Config removed).
+  const isEnabled = currentIdJag.enabled;
+  const allowedAudiences = currentIdJag.allowedAudiences ?? [];
+  const showValidityPeriodError = invalidValidityPeriodInput !== null;
+  const showAudiencesError = isEnabled && allowedAudiences.length === 0;
+
+  useEffect(() => {
+    onValidationChange?.(showAudiencesError || showValidityPeriodError);
+  }, [showAudiencesError, showValidityPeriodError, onValidationChange]);
+
+  if (!oauth2Config) return null;
+
+  const validityPeriod = currentIdJag.validityPeriod ?? DEFAULT_VALIDITY_PERIOD;
+  const validityPeriodValue = invalidValidityPeriodInput ?? validityPeriod;
+  const isPublicClient =
+    oauth2Config.publicClient === true || oauth2Config.tokenEndpointAuthMethod === TokenEndpointAuthMethods.NONE;
+  const isToggleDisabled = disabled || isPublicClient;
+
+  const handleToggle = (checked: boolean) => {
+    setInvalidValidityPeriodInput(null);
+
+    const tokenUpdates: Partial<OAuth2Token> = {
+      idJag: checked
+        ? {
+            enabled: true,
+            allowedAudiences: currentIdJag.allowedAudiences ?? [],
+            validityPeriod: currentIdJag.validityPeriod ?? DEFAULT_VALIDITY_PERIOD,
+          }
+        : {
+            enabled: false,
+            allowedAudiences: currentIdJag.allowedAudiences,
+            validityPeriod: currentIdJag.validityPeriod,
+          },
+    };
+
+    const grantTypes = oauth2Config.grantTypes ?? [];
+    if (checked && !grantTypes.includes(OAuth2GrantTypes.TOKEN_EXCHANGE)) {
+      // Combine both updates into a single call so they're applied against the same snapshot
+      // instead of the second one clobbering the first (see EditAdvancedSettings.handleTokenConfigChange).
+      onTokenConfigChange(
+        tokenUpdates,
+        applyGrantTypesChange(oauth2Config, [...grantTypes, OAuth2GrantTypes.TOKEN_EXCHANGE]),
+      );
+      return;
+    }
+
+    onTokenConfigChange(tokenUpdates);
+  };
+
+  const handleAudiencesChange = (newValue: string[]) => {
+    onTokenConfigChange({idJag: {...currentIdJag, allowedAudiences: newValue}});
+  };
+
+  const handleValidityPeriodChange = (value: string) => {
+    if (value === '') {
+      setInvalidValidityPeriodInput(null);
+      onTokenConfigChange({idJag: {...currentIdJag, validityPeriod: undefined}});
+      return;
+    }
+
+    const parsed = Number(value);
+    if (Number.isNaN(parsed) || parsed < 1) {
+      setInvalidValidityPeriodInput(value);
+      return;
+    }
+
+    setInvalidValidityPeriodInput(null);
+    onTokenConfigChange({idJag: {...currentIdJag, validityPeriod: parsed}});
+  };
+
+  const toggleLabel = t('applications:edit.advanced.idJag.title', 'Identity Assertions (ID-JAG)');
+  const toggleSwitch = (
+    <Switch
+      checked={isEnabled}
+      disabled={isToggleDisabled}
+      onChange={(e) => handleToggle(e.target.checked)}
+      slotProps={{input: {'aria-label': toggleLabel, role: 'switch'}}}
+    />
+  );
+
+  return (
+    <SettingsCard
+      title={toggleLabel}
+      description={t(
+        'applications:edit.advanced.idJag.description',
+        "Issue signed assertions of the signed-in user's identity that external services accept for token issuance.",
+      )}
+      headerAction={
+        isPublicClient ? (
+          <Tooltip
+            title={t(
+              'applications:edit.advanced.idJag.publicClientGuard',
+              'Identity assertions require a confidential client. Turn off Public Client to enable.',
+            )}
+          >
+            <span>{toggleSwitch}</span>
+          </Tooltip>
+        ) : (
+          toggleSwitch
+        )
+      }
+    >
+      {isEnabled && (
+        <Stack spacing={3}>
+          <FormControl fullWidth size="small" error={showAudiencesError}>
+            <FormLabel htmlFor="idjag_allowed_audiences">
+              {t('applications:edit.advanced.idJag.labels.allowedAudiences', 'Allowed audiences')} *
+            </FormLabel>
+            <Autocomplete
+              id="idjag_allowed_audiences"
+              multiple
+              freeSolo
+              fullWidth
+              options={[]}
+              value={allowedAudiences}
+              disabled={disabled}
+              onChange={(_event, newValue) => handleAudiencesChange(newValue as string[])}
+              renderTags={(value, getTagProps) =>
+                value.map((option, index) => <Chip label={option} {...getTagProps({index})} key={option} />)
+              }
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  placeholder={t(
+                    'applications:edit.advanced.idJag.allowedAudiences.placeholder',
+                    'Type an audience and press Enter',
+                  )}
+                  error={showAudiencesError}
+                  helperText={
+                    showAudiencesError
+                      ? t('applications:edit.advanced.idJag.allowedAudiences.error', 'Add at least one audience.')
+                      : t(
+                          'applications:edit.advanced.idJag.allowedAudiences.hint',
+                          'Each assertion targets exactly one of these audiences.',
+                        )
+                  }
+                />
+              )}
+            />
+          </FormControl>
+
+          <FormControl size="small" error={showValidityPeriodError}>
+            <FormLabel htmlFor="idjag_validity_period">
+              {t('applications:edit.advanced.idJag.labels.validityPeriod', 'Assertion validity')}
+            </FormLabel>
+            <TextField
+              id="idjag_validity_period"
+              type="number"
+              size="small"
+              disabled={disabled}
+              value={validityPeriodValue}
+              error={showValidityPeriodError}
+              helperText={
+                showValidityPeriodError
+                  ? t('applications:edit.advanced.idJag.validityPeriod.error', 'Enter a value of at least 1 second.')
+                  : undefined
+              }
+              onChange={(e) => handleValidityPeriodChange(e.target.value)}
+              inputProps={{min: 1}}
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    {t('applications:edit.advanced.idJag.labels.seconds', 'seconds')}
+                  </InputAdornment>
+                ),
+              }}
+              sx={{maxWidth: 220}}
+            />
+            {!showValidityPeriodError && (
+              <Typography variant="caption" color="text.secondary" sx={{mt: 0.5}}>
+                {t(
+                  'applications:edit.advanced.idJag.validityPeriod.hint',
+                  'How long an issued assertion stays valid. Default 300.',
+                )}
+              </Typography>
+            )}
+          </FormControl>
+
+          <Typography variant="caption" color="text.secondary">
+            {t(
+              'applications:edit.advanced.idJag.grantTypeHint',
+              'The token exchange grant type is enabled together with this feature.',
+            )}
+          </Typography>
+        </Stack>
+      )}
+    </SettingsCard>
+  );
+}

--- a/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/__tests__/EditAdvancedSettings.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/__tests__/EditAdvancedSettings.test.tsx
@@ -311,4 +311,74 @@ describe('EditAdvancedSettings', () => {
       );
     });
   });
+
+  describe('ID-JAG Integration', () => {
+    it('should apply the idJag enable and the added token-exchange grant type in a single onFieldChange call on the first click', () => {
+      const oauth2ConfigWithoutTokenExchange: OAuth2Config = {
+        ...mockOAuth2Config,
+        grantTypes: ['authorization_code'],
+      };
+      const appWithInboundAuth = {
+        ...mockApplication,
+        inboundAuthConfig: [{type: 'oauth2', config: {...oauth2ConfigWithoutTokenExchange}}],
+      } as Application;
+
+      mockOnFieldChange.mockClear();
+
+      render(
+        <EditAdvancedSettings
+          application={appWithInboundAuth}
+          editedApp={{}}
+          oauth2Config={oauth2ConfigWithoutTokenExchange}
+          onFieldChange={mockOnFieldChange}
+        />,
+      );
+
+      const toggle = screen.getByLabelText('applications:edit.advanced.idJag.title');
+      fireEvent.click(toggle);
+
+      expect(mockOnFieldChange).toHaveBeenCalledTimes(1);
+      expect(mockOnFieldChange).toHaveBeenCalledWith(
+        'inboundAuthConfig',
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'oauth2',
+            config: expect.objectContaining({
+              grantTypes: expect.arrayContaining([
+                'authorization_code',
+                'urn:ietf:params:oauth:grant-type:token-exchange',
+              ]) as unknown,
+              token: expect.objectContaining({
+                idJag: expect.objectContaining({enabled: true}) as unknown,
+              }) as unknown,
+            }) as unknown,
+          }),
+        ]),
+      );
+    });
+
+    it('should forward onValidationChange to IdentityAssertionsSection', () => {
+      const onValidationChange = vi.fn();
+      const oauth2ConfigWithIdJagError: OAuth2Config = {
+        ...mockOAuth2Config,
+        token: {
+          accessToken: {} as never,
+          idToken: {} as never,
+          idJag: {enabled: true, allowedAudiences: [], validityPeriod: 300},
+        },
+      };
+
+      render(
+        <EditAdvancedSettings
+          application={mockApplication}
+          editedApp={{}}
+          oauth2Config={oauth2ConfigWithIdJagError}
+          onFieldChange={mockOnFieldChange}
+          onValidationChange={onValidationChange}
+        />,
+      );
+
+      expect(onValidationChange).toHaveBeenLastCalledWith(true);
+    });
+  });
 });

--- a/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/__tests__/IdentityAssertionsSection.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/__tests__/IdentityAssertionsSection.test.tsx
@@ -1,0 +1,484 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import type {OAuth2Config} from '../../../../models/oauth';
+import IdentityAssertionsSection from '../IdentityAssertionsSection';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback: string) => fallback ?? key,
+  }),
+}));
+
+describe('IdentityAssertionsSection', () => {
+  const mockOnTokenConfigChange = vi.fn();
+
+  const baseConfig: OAuth2Config = {
+    grantTypes: ['authorization_code'],
+    responseTypes: ['code'],
+    pkceRequired: false,
+    publicClient: false,
+  };
+
+  beforeEach(() => {
+    mockOnTokenConfigChange.mockClear();
+  });
+
+  describe('Rendering', () => {
+    it('should return null when oauth2Config is not provided', () => {
+      const {container} = render(<IdentityAssertionsSection onTokenConfigChange={mockOnTokenConfigChange} />);
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('should render the card title and description', () => {
+      render(<IdentityAssertionsSection oauth2Config={baseConfig} onTokenConfigChange={mockOnTokenConfigChange} />);
+
+      expect(screen.getByText('Identity Assertions (ID-JAG)')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Issue signed assertions of the signed-in user's identity that external services accept for token issuance.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('should render with the switch off and body hidden when idJag is undefined', () => {
+      render(<IdentityAssertionsSection oauth2Config={baseConfig} onTokenConfigChange={mockOnTokenConfigChange} />);
+
+      const toggle = screen.getByLabelText('Identity Assertions (ID-JAG)');
+      expect(toggle).not.toBeChecked();
+      expect(screen.queryByText('Allowed audiences *')).not.toBeInTheDocument();
+    });
+
+    it('should render the body when idJag is enabled', () => {
+      const oauth2Config: OAuth2Config = {
+        ...baseConfig,
+        token: {
+          accessToken: {} as never,
+          idToken: {} as never,
+          idJag: {enabled: true, allowedAudiences: ['https://api.example.com'], validityPeriod: 300},
+        },
+      };
+
+      render(<IdentityAssertionsSection oauth2Config={oauth2Config} onTokenConfigChange={mockOnTokenConfigChange} />);
+
+      const toggle = screen.getByLabelText('Identity Assertions (ID-JAG)');
+      expect(toggle).toBeChecked();
+      expect(screen.getByText('Allowed audiences *')).toBeInTheDocument();
+      expect(screen.getByText('https://api.example.com')).toBeInTheDocument();
+    });
+  });
+
+  describe('Toggle Behavior', () => {
+    it('should call onTokenConfigChange with idJag enabled true and the added grant type in a single combined call when toggled on', async () => {
+      const user = userEvent.setup();
+
+      render(<IdentityAssertionsSection oauth2Config={baseConfig} onTokenConfigChange={mockOnTokenConfigChange} />);
+
+      await user.click(screen.getByLabelText('Identity Assertions (ID-JAG)'));
+
+      expect(mockOnTokenConfigChange).toHaveBeenCalledTimes(1);
+      expect(mockOnTokenConfigChange).toHaveBeenCalledWith(
+        {idJag: {enabled: true, allowedAudiences: [], validityPeriod: 300}},
+        expect.objectContaining({
+          grantTypes: expect.arrayContaining([
+            'authorization_code',
+            'urn:ietf:params:oauth:grant-type:token-exchange',
+          ]) as unknown,
+        }),
+      );
+    });
+
+    it('should call onTokenConfigChange with only the token update when toggled on and the grant type is already present', async () => {
+      const user = userEvent.setup();
+      const oauth2Config: OAuth2Config = {
+        ...baseConfig,
+        grantTypes: ['authorization_code', 'urn:ietf:params:oauth:grant-type:token-exchange'],
+      };
+
+      render(<IdentityAssertionsSection oauth2Config={oauth2Config} onTokenConfigChange={mockOnTokenConfigChange} />);
+
+      await user.click(screen.getByLabelText('Identity Assertions (ID-JAG)'));
+
+      expect(mockOnTokenConfigChange).toHaveBeenCalledTimes(1);
+      expect(mockOnTokenConfigChange).toHaveBeenCalledWith({
+        idJag: {enabled: true, allowedAudiences: [], validityPeriod: 300},
+      });
+    });
+
+    it('should keep the token exchange grant type when toggled off', async () => {
+      const user = userEvent.setup();
+      const oauth2Config: OAuth2Config = {
+        ...baseConfig,
+        grantTypes: ['authorization_code', 'urn:ietf:params:oauth:grant-type:token-exchange'],
+        token: {
+          accessToken: {} as never,
+          idToken: {} as never,
+          idJag: {enabled: true, allowedAudiences: ['https://api.example.com'], validityPeriod: 300},
+        },
+      };
+
+      render(<IdentityAssertionsSection oauth2Config={oauth2Config} onTokenConfigChange={mockOnTokenConfigChange} />);
+
+      await user.click(screen.getByLabelText('Identity Assertions (ID-JAG)'));
+
+      expect(mockOnTokenConfigChange).toHaveBeenCalledTimes(1);
+      expect(mockOnTokenConfigChange).toHaveBeenCalledWith({
+        idJag: {enabled: false, allowedAudiences: ['https://api.example.com'], validityPeriod: 300},
+      });
+    });
+  });
+
+  describe('Allowed Audiences', () => {
+    const enabledConfig: OAuth2Config = {
+      ...baseConfig,
+      token: {
+        accessToken: {} as never,
+        idToken: {} as never,
+        idJag: {enabled: true, allowedAudiences: ['https://api.example.com'], validityPeriod: 300},
+      },
+    };
+
+    it('should add a new audience when typed and confirmed', async () => {
+      const user = userEvent.setup({delay: null});
+
+      render(<IdentityAssertionsSection oauth2Config={enabledConfig} onTokenConfigChange={mockOnTokenConfigChange} />);
+
+      const input = screen.getByPlaceholderText('Type an audience and press Enter');
+      await user.type(input, 'https://other.example.com');
+      await user.keyboard('{Enter}');
+
+      await waitFor(() => {
+        expect(mockOnTokenConfigChange).toHaveBeenCalledWith({
+          idJag: {
+            enabled: true,
+            allowedAudiences: ['https://api.example.com', 'https://other.example.com'],
+            validityPeriod: 300,
+          },
+        });
+      });
+    });
+
+    it('should remove an audience when its chip delete icon is clicked', async () => {
+      const user = userEvent.setup();
+
+      render(<IdentityAssertionsSection oauth2Config={enabledConfig} onTokenConfigChange={mockOnTokenConfigChange} />);
+
+      const chip = screen.getByText('https://api.example.com').closest('.MuiChip-root')!;
+      const deleteIcon = chip.querySelector('.MuiChip-deleteIcon')!;
+      await user.click(deleteIcon);
+
+      expect(mockOnTokenConfigChange).toHaveBeenCalledWith({
+        idJag: {enabled: true, allowedAudiences: [], validityPeriod: 300},
+      });
+    });
+
+    it('should show an error when idJag is enabled and audiences is empty', () => {
+      const oauth2Config: OAuth2Config = {
+        ...baseConfig,
+        token: {
+          accessToken: {} as never,
+          idToken: {} as never,
+          idJag: {enabled: true, allowedAudiences: [], validityPeriod: 300},
+        },
+      };
+
+      render(<IdentityAssertionsSection oauth2Config={oauth2Config} onTokenConfigChange={mockOnTokenConfigChange} />);
+
+      expect(screen.getByText('Add at least one audience.')).toBeInTheDocument();
+    });
+
+    it('should not show an error when idJag is disabled and audiences is empty', () => {
+      render(<IdentityAssertionsSection oauth2Config={baseConfig} onTokenConfigChange={mockOnTokenConfigChange} />);
+
+      expect(screen.queryByText('Add at least one audience.')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Validity Period', () => {
+    const enabledConfig: OAuth2Config = {
+      ...baseConfig,
+      token: {
+        accessToken: {} as never,
+        idToken: {} as never,
+        idJag: {enabled: true, allowedAudiences: ['https://api.example.com'], validityPeriod: 300},
+      },
+    };
+
+    it('should default the validity period to 300 when unset', () => {
+      const oauth2Config: OAuth2Config = {
+        ...baseConfig,
+        token: {
+          accessToken: {} as never,
+          idToken: {} as never,
+          idJag: {enabled: true, allowedAudiences: ['https://api.example.com']},
+        },
+      };
+
+      render(<IdentityAssertionsSection oauth2Config={oauth2Config} onTokenConfigChange={mockOnTokenConfigChange} />);
+
+      expect(screen.getByDisplayValue('300')).toBeInTheDocument();
+    });
+
+    it('should call onTokenConfigChange with the updated validity period', () => {
+      render(<IdentityAssertionsSection oauth2Config={enabledConfig} onTokenConfigChange={mockOnTokenConfigChange} />);
+
+      const input = screen.getByDisplayValue('300');
+      fireEvent.change(input, {target: {value: '600'}});
+
+      expect(mockOnTokenConfigChange).toHaveBeenCalledWith({
+        idJag: {enabled: true, allowedAudiences: ['https://api.example.com'], validityPeriod: 600},
+      });
+    });
+
+    it('should clear the validity period when the field is emptied', () => {
+      render(<IdentityAssertionsSection oauth2Config={enabledConfig} onTokenConfigChange={mockOnTokenConfigChange} />);
+
+      const input = screen.getByDisplayValue('300');
+      fireEvent.change(input, {target: {value: ''}});
+
+      expect(mockOnTokenConfigChange).toHaveBeenCalledWith({
+        idJag: {enabled: true, allowedAudiences: ['https://api.example.com'], validityPeriod: undefined},
+      });
+      expect(screen.queryByText('Enter a value of at least 1 second.')).not.toBeInTheDocument();
+    });
+
+    it('should show an inline error and not call onTokenConfigChange when the value is 0', () => {
+      render(<IdentityAssertionsSection oauth2Config={enabledConfig} onTokenConfigChange={mockOnTokenConfigChange} />);
+
+      const input = screen.getByDisplayValue('300');
+      fireEvent.change(input, {target: {value: '0'}});
+
+      expect(screen.getByText('Enter a value of at least 1 second.')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('0')).toBeInTheDocument();
+      expect(mockOnTokenConfigChange).not.toHaveBeenCalled();
+    });
+
+    it('should show an inline error and not call onTokenConfigChange when the value is negative', () => {
+      render(<IdentityAssertionsSection oauth2Config={enabledConfig} onTokenConfigChange={mockOnTokenConfigChange} />);
+
+      const input = screen.getByDisplayValue('300');
+      fireEvent.change(input, {target: {value: '-5'}});
+
+      expect(screen.getByText('Enter a value of at least 1 second.')).toBeInTheDocument();
+      expect(mockOnTokenConfigChange).not.toHaveBeenCalled();
+    });
+
+    it('should clear the error and call onTokenConfigChange once a valid value is entered', () => {
+      render(<IdentityAssertionsSection oauth2Config={enabledConfig} onTokenConfigChange={mockOnTokenConfigChange} />);
+
+      const input = screen.getByDisplayValue('300');
+      fireEvent.change(input, {target: {value: '0'}});
+      expect(screen.getByText('Enter a value of at least 1 second.')).toBeInTheDocument();
+
+      fireEvent.change(screen.getByDisplayValue('0'), {target: {value: '120'}});
+
+      expect(screen.queryByText('Enter a value of at least 1 second.')).not.toBeInTheDocument();
+      expect(mockOnTokenConfigChange).toHaveBeenCalledWith({
+        idJag: {enabled: true, allowedAudiences: ['https://api.example.com'], validityPeriod: 120},
+      });
+    });
+
+    it('should clear a pending invalid input and show the external value when the config is reset externally (e.g. discard)', () => {
+      const {rerender} = render(
+        <IdentityAssertionsSection oauth2Config={enabledConfig} onTokenConfigChange={mockOnTokenConfigChange} />,
+      );
+
+      const input = screen.getByDisplayValue('300');
+      fireEvent.change(input, {target: {value: '0'}});
+      expect(screen.getByText('Enter a value of at least 1 second.')).toBeInTheDocument();
+
+      const resetConfig: OAuth2Config = {
+        ...baseConfig,
+        token: {
+          accessToken: {} as never,
+          idToken: {} as never,
+          idJag: {enabled: true, allowedAudiences: ['https://api.example.com'], validityPeriod: 300},
+        },
+      };
+
+      rerender(<IdentityAssertionsSection oauth2Config={resetConfig} onTokenConfigChange={mockOnTokenConfigChange} />);
+
+      expect(screen.queryByText('Enter a value of at least 1 second.')).not.toBeInTheDocument();
+      expect(screen.getByDisplayValue('300')).toBeInTheDocument();
+    });
+  });
+
+  describe('Public Client Guard', () => {
+    it('should disable the toggle when publicClient is true', () => {
+      const oauth2Config: OAuth2Config = {...baseConfig, publicClient: true};
+
+      render(<IdentityAssertionsSection oauth2Config={oauth2Config} onTokenConfigChange={mockOnTokenConfigChange} />);
+
+      expect(screen.getByLabelText('Identity Assertions (ID-JAG)')).toBeDisabled();
+    });
+
+    it('should disable the toggle when tokenEndpointAuthMethod is none', () => {
+      const oauth2Config: OAuth2Config = {...baseConfig, tokenEndpointAuthMethod: 'none'};
+
+      render(<IdentityAssertionsSection oauth2Config={oauth2Config} onTokenConfigChange={mockOnTokenConfigChange} />);
+
+      expect(screen.getByLabelText('Identity Assertions (ID-JAG)')).toBeDisabled();
+    });
+
+    it('should show a tooltip explaining why the toggle is disabled', async () => {
+      const user = userEvent.setup();
+      const oauth2Config: OAuth2Config = {...baseConfig, publicClient: true};
+
+      render(<IdentityAssertionsSection oauth2Config={oauth2Config} onTokenConfigChange={mockOnTokenConfigChange} />);
+
+      const toggle = screen.getByLabelText('Identity Assertions (ID-JAG)');
+      const tooltipTrigger = toggle.closest('.MuiSwitch-root')?.parentElement;
+      await user.hover(tooltipTrigger!);
+
+      expect(
+        await screen.findByText('Identity assertions require a confidential client. Turn off Public Client to enable.'),
+      ).toBeInTheDocument();
+    });
+
+    it('should not disable the toggle when the client is confidential', () => {
+      render(<IdentityAssertionsSection oauth2Config={baseConfig} onTokenConfigChange={mockOnTokenConfigChange} />);
+
+      expect(screen.getByLabelText('Identity Assertions (ID-JAG)')).not.toBeDisabled();
+    });
+
+    it('should disable the toggle when the disabled prop is set', () => {
+      render(
+        <IdentityAssertionsSection oauth2Config={baseConfig} onTokenConfigChange={mockOnTokenConfigChange} disabled />,
+      );
+
+      expect(screen.getByLabelText('Identity Assertions (ID-JAG)')).toBeDisabled();
+    });
+  });
+
+  describe('Validation reporting', () => {
+    const enabledEmptyAudiencesConfig: OAuth2Config = {
+      ...baseConfig,
+      token: {
+        accessToken: {} as never,
+        idToken: {} as never,
+        idJag: {enabled: true, allowedAudiences: [], validityPeriod: 300},
+      },
+    };
+
+    it('should report hasErrors=true when enabled with empty audiences', () => {
+      const onValidationChange = vi.fn();
+
+      render(
+        <IdentityAssertionsSection
+          oauth2Config={enabledEmptyAudiencesConfig}
+          onTokenConfigChange={mockOnTokenConfigChange}
+          onValidationChange={onValidationChange}
+        />,
+      );
+
+      expect(onValidationChange).toHaveBeenLastCalledWith(true);
+    });
+
+    it('should report hasErrors=false once an audience is added', () => {
+      const onValidationChange = vi.fn();
+
+      const {rerender} = render(
+        <IdentityAssertionsSection
+          oauth2Config={enabledEmptyAudiencesConfig}
+          onTokenConfigChange={mockOnTokenConfigChange}
+          onValidationChange={onValidationChange}
+        />,
+      );
+      expect(onValidationChange).toHaveBeenLastCalledWith(true);
+
+      const withAudienceConfig: OAuth2Config = {
+        ...baseConfig,
+        token: {
+          accessToken: {} as never,
+          idToken: {} as never,
+          idJag: {enabled: true, allowedAudiences: ['https://api.example.com'], validityPeriod: 300},
+        },
+      };
+      rerender(
+        <IdentityAssertionsSection
+          oauth2Config={withAudienceConfig}
+          onTokenConfigChange={mockOnTokenConfigChange}
+          onValidationChange={onValidationChange}
+        />,
+      );
+
+      expect(onValidationChange).toHaveBeenLastCalledWith(false);
+    });
+
+    it('should report hasErrors=false when toggled off', () => {
+      const onValidationChange = vi.fn();
+
+      const {rerender} = render(
+        <IdentityAssertionsSection
+          oauth2Config={enabledEmptyAudiencesConfig}
+          onTokenConfigChange={mockOnTokenConfigChange}
+          onValidationChange={onValidationChange}
+        />,
+      );
+      expect(onValidationChange).toHaveBeenLastCalledWith(true);
+
+      const disabledConfig: OAuth2Config = {
+        ...baseConfig,
+        token: {
+          accessToken: {} as never,
+          idToken: {} as never,
+          idJag: {enabled: false, allowedAudiences: [], validityPeriod: 300},
+        },
+      };
+      rerender(
+        <IdentityAssertionsSection
+          oauth2Config={disabledConfig}
+          onTokenConfigChange={mockOnTokenConfigChange}
+          onValidationChange={onValidationChange}
+        />,
+      );
+
+      expect(onValidationChange).toHaveBeenLastCalledWith(false);
+    });
+
+    it('should report hasErrors=true when the validity period input is invalid (0)', () => {
+      const onValidationChange = vi.fn();
+      const enabledWithAudienceConfig: OAuth2Config = {
+        ...baseConfig,
+        token: {
+          accessToken: {} as never,
+          idToken: {} as never,
+          idJag: {enabled: true, allowedAudiences: ['https://api.example.com'], validityPeriod: 300},
+        },
+      };
+
+      render(
+        <IdentityAssertionsSection
+          oauth2Config={enabledWithAudienceConfig}
+          onTokenConfigChange={mockOnTokenConfigChange}
+          onValidationChange={onValidationChange}
+        />,
+      );
+      expect(onValidationChange).toHaveBeenLastCalledWith(false);
+
+      const input = screen.getByDisplayValue('300');
+      fireEvent.change(input, {target: {value: '0'}});
+
+      expect(onValidationChange).toHaveBeenLastCalledWith(true);
+    });
+  });
+});

--- a/frontend/apps/console/src/features/applications/models/__tests__/oauth.test.ts
+++ b/frontend/apps/console/src/features/applications/models/__tests__/oauth.test.ts
@@ -50,6 +50,10 @@ describe('OAuth Models', () => {
       expect(OAuth2GrantTypes.TOKEN_EXCHANGE).toBe('urn:ietf:params:oauth:grant-type:token-exchange');
     });
 
+    it('should have JWT_BEARER grant type', () => {
+      expect(OAuth2GrantTypes.JWT_BEARER).toBe('urn:ietf:params:oauth:grant-type:jwt-bearer');
+    });
+
     it('should have all expected grant types', () => {
       const expectedKeys = [
         'AUTHORIZATION_CODE',
@@ -59,6 +63,7 @@ describe('OAuth Models', () => {
         'IMPLICIT',
         'CIBA',
         'TOKEN_EXCHANGE',
+        'JWT_BEARER',
       ];
 
       expect(Object.keys(OAuth2GrantTypes)).toEqual(expectedKeys);

--- a/frontend/apps/console/src/features/applications/models/oauth.ts
+++ b/frontend/apps/console/src/features/applications/models/oauth.ts
@@ -32,7 +32,8 @@ export type OAuth2GrantType =
   | 'password'
   | 'implicit'
   | 'urn:openid:params:grant-type:ciba'
-  | 'urn:ietf:params:oauth:grant-type:token-exchange';
+  | 'urn:ietf:params:oauth:grant-type:token-exchange'
+  | 'urn:ietf:params:oauth:grant-type:jwt-bearer';
 
 /**
  * OAuth2 Grant Type Constants
@@ -63,6 +64,8 @@ export const OAuth2GrantTypes = {
   CIBA: 'urn:openid:params:grant-type:ciba',
   /** Token Exchange (RFC 8693) - Exchange a token for one scoped to a different resource/audience */
   TOKEN_EXCHANGE: 'urn:ietf:params:oauth:grant-type:token-exchange',
+  /** JWT Bearer - Exchanges a signed JWT assertion for an access token */
+  JWT_BEARER: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
 } as const;
 
 /**
@@ -226,6 +229,48 @@ export interface RefreshTokenConfig {
 }
 
 /**
+ * Identity Assertion Authorization Grant (ID-JAG) Configuration
+ *
+ * Configuration for issuing signed identity assertions that external services can accept
+ * for token issuance via the token exchange grant.
+ *
+ * @public
+ * @remarks
+ * `enabled` must be true and `allowedAudiences` must be non-empty for the application to
+ * request ID-JAGs via token exchange. ID-JAG issuance requires a confidential client;
+ * it cannot be used together with `tokenEndpointAuthMethod: 'none'`.
+ *
+ * @example
+ * ```typescript
+ * const idJagConfig: IDJAGConfig = {
+ *   enabled: true,
+ *   allowedAudiences: ['https://api.example.com'],
+ *   validityPeriod: 300
+ * };
+ * ```
+ */
+export interface IDJAGConfig {
+  /**
+   * Whether ID-JAG issuance is enabled for this application
+   */
+  enabled: boolean;
+
+  /**
+   * Resource authorization server identifiers for which this application may request ID-JAGs
+   * Each issued assertion targets exactly one of these audiences
+   * @example ['https://api.example.com']
+   */
+  allowedAudiences?: string[];
+
+  /**
+   * Validity period of an issued ID-JAG in seconds
+   * @defaultValue 300
+   * @example 300
+   */
+  validityPeriod?: number;
+}
+
+/**
  * OAuth2 Token Settings
  *
  * Complete token configuration for access tokens, ID tokens, and refresh tokens.
@@ -276,6 +321,12 @@ export interface OAuth2Token {
    * Defines the validity period for refresh tokens
    */
   refreshToken?: RefreshTokenConfig;
+
+  /**
+   * Identity Assertion Authorization Grant (ID-JAG) configuration
+   * Defines whether and how this application may issue signed identity assertions
+   */
+  idJag?: IDJAGConfig;
 }
 
 /**

--- a/frontend/apps/console/src/features/applications/pages/ApplicationEditPage.tsx
+++ b/frontend/apps/console/src/features/applications/pages/ApplicationEditPage.tsx
@@ -277,6 +277,7 @@ export default function ApplicationEditPage() {
                 oauth2Constraints={isMcpM2mOnly ? undefined : oauth2Constraints}
                 onFieldChange={handleFieldChange}
                 allowedGrantTypes={[...TemplateConstants.MCP_CLIENT_ALLOWED_GRANT_TYPES]}
+                onValidationChange={setHasValidationErrors}
               />
             ),
           },
@@ -559,6 +560,7 @@ export default function ApplicationEditPage() {
                 oauth2Constraints={oauth2Constraints}
                 onFieldChange={handleFieldChange}
                 showAttestation={supportsAttestation}
+                onValidationChange={setHasValidationErrors}
               />
             </TabPanel>
           </>

--- a/frontend/apps/console/src/features/applications/utils/__tests__/getGrantTypeLabel.test.ts
+++ b/frontend/apps/console/src/features/applications/utils/__tests__/getGrantTypeLabel.test.ts
@@ -32,9 +32,15 @@ describe('getGrantTypeLabel', () => {
     expect(getGrantTypeLabel('authorization_code', t)).toBe('authorization_code');
   });
 
+  it('returns the friendly Token Exchange label for the token-exchange URN', () => {
+    expect(getGrantTypeLabel('urn:ietf:params:oauth:grant-type:token-exchange', t)).toBe('Token Exchange');
+  });
+
+  it('returns the friendly JWT Bearer label for the jwt-bearer URN', () => {
+    expect(getGrantTypeLabel('urn:ietf:params:oauth:grant-type:jwt-bearer', t)).toBe('JWT Bearer');
+  });
+
   it('returns the raw value unchanged for an unknown/arbitrary grant type', () => {
-    expect(getGrantTypeLabel('urn:ietf:params:oauth:grant-type:token-exchange', t)).toBe(
-      'urn:ietf:params:oauth:grant-type:token-exchange',
-    );
+    expect(getGrantTypeLabel('urn:example:custom-grant', t)).toBe('urn:example:custom-grant');
   });
 });

--- a/frontend/apps/console/src/features/applications/utils/getGrantTypeLabel.ts
+++ b/frontend/apps/console/src/features/applications/utils/getGrantTypeLabel.ts
@@ -27,5 +27,11 @@ export function getGrantTypeLabel(grant: string, t: (key: string, fallback: stri
   if (grant === OAuth2GrantTypes.CIBA) {
     return t('applications:edit.advanced.grantTypes.labels.ciba', 'CIBA (Client-Initiated Backchannel Authentication)');
   }
+  if (grant === OAuth2GrantTypes.TOKEN_EXCHANGE) {
+    return t('applications:edit.advanced.grantTypes.labels.tokenExchange', 'Token Exchange');
+  }
+  if (grant === OAuth2GrantTypes.JWT_BEARER) {
+    return t('applications:edit.advanced.grantTypes.labels.jwtBearer', 'JWT Bearer');
+  }
   return grant;
 }

--- a/frontend/apps/console/src/features/connections/pages/ConnectionCreateWizardRoute.tsx
+++ b/frontend/apps/console/src/features/connections/pages/ConnectionCreateWizardRoute.tsx
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {ConnectionCreateWizardPage} from '@thunderid/configure-connections';
+import type {JSX} from 'react';
+import TrustedIssuerWizardStep from '../../trusted-issuers/pages/TrustedIssuerWizardStep';
+
+/**
+ * Console-level route for `/connections/create`. Wires the "Trusted Token Issuer" wizard
+ * type to its console-owned configure step, since trusted issuers live in the console app
+ * rather than the `configure-connections` package.
+ */
+export default function ConnectionCreateWizardRoute(): JSX.Element {
+  return <ConnectionCreateWizardPage customConfigureSteps={{'trusted-idp': <TrustedIssuerWizardStep />}} />;
+}

--- a/frontend/apps/console/src/features/connections/pages/__tests__/ConnectionCreateWizardRoute.test.tsx
+++ b/frontend/apps/console/src/features/connections/pages/__tests__/ConnectionCreateWizardRoute.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen} from '@thunderid/test-utils';
+import type {ReactNode} from 'react';
+import {describe, expect, it, vi} from 'vitest';
+import ConnectionCreateWizardRoute from '../ConnectionCreateWizardRoute';
+
+vi.mock('@thunderid/configure-connections', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@thunderid/configure-connections')>()),
+  ConnectionCreateWizardPage: ({
+    customConfigureSteps = undefined,
+  }: {
+    customConfigureSteps?: Record<string, ReactNode>;
+  }) => <div data-testid="stub-wizard">{customConfigureSteps?.['trusted-idp']}</div>,
+}));
+
+vi.mock('../../../trusted-issuers/pages/TrustedIssuerWizardStep', () => ({
+  default: function StubTrustedIssuerWizardStep() {
+    return <div data-testid="stub-trusted-issuer-wizard-step" />;
+  },
+}));
+
+describe('ConnectionCreateWizardRoute', () => {
+  it('should wire the trusted-idp custom configure step to TrustedIssuerWizardStep', () => {
+    render(<ConnectionCreateWizardRoute />);
+
+    expect(screen.getByTestId('stub-wizard')).toBeInTheDocument();
+    expect(screen.getByTestId('stub-trusted-issuer-wizard-step')).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/console/src/features/trusted-issuers/api/useCreateTrustedIssuer.ts
+++ b/frontend/apps/console/src/features/trusted-issuers/api/useCreateTrustedIssuer.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
+import {useConfig, useToast} from '@thunderid/contexts';
+import {useThunderID} from '@thunderid/react';
+import {useTranslation} from 'react-i18next';
+import type {TrustedIssuer, TrustedIssuerFormData} from '../models/trusted-issuer';
+import mapConnectionToTrustedIssuer from '../utils/mapConnectionToTrustedIssuer';
+import {
+  ConnectionQueryKeys,
+  ConnectionTypes,
+  isConflictError,
+  type ConnectionResponse,
+} from '@thunderid/configure-connections';
+
+/**
+ * Create a trusted issuer, i.e. a trust-only OIDC connection (POST /connections/oidc).
+ *
+ * Conflicts (409 duplicate name) are not toasted here — the caller surfaces them inline next
+ * to the name field.
+ *
+ * @example
+ * ```tsx
+ * const createTrustedIssuer = useCreateTrustedIssuer();
+ * createTrustedIssuer.mutate({name, issuer, jwksEndpoint, idJagEnabled: true});
+ * ```
+ *
+ * @public
+ */
+export default function useCreateTrustedIssuer(): UseMutationResult<TrustedIssuer, Error, TrustedIssuerFormData> {
+  const {http} = useThunderID();
+  const {getServerUrl} = useConfig();
+  const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
+  const {t} = useTranslation();
+  const {showToast} = useToast();
+
+  return useMutation<TrustedIssuer, Error, TrustedIssuerFormData>({
+    mutationFn: async (data: TrustedIssuerFormData): Promise<TrustedIssuer> => {
+      const serverUrl: string = getServerUrl();
+      const response: {
+        data: ConnectionResponse;
+      } = await http.request({
+        url: `${serverUrl}/connections/${ConnectionTypes.OIDC}`,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data,
+      } as unknown as Parameters<typeof http.request>[0]);
+
+      return mapConnectionToTrustedIssuer(response.data);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({queryKey: [ConnectionQueryKeys.CONNECTIONS]}).catch(() => {
+        // Ignore invalidation errors
+      });
+      queryClient
+        .invalidateQueries({queryKey: [ConnectionQueryKeys.CONNECTION_INSTANCES, ConnectionTypes.OIDC]})
+        .catch(() => {
+          // Ignore invalidation errors
+        });
+      showToast(t('trustedIssuers:create.success', 'Trusted issuer created successfully.'), 'success');
+    },
+    onError: (error) => {
+      if (!isConflictError(error)) {
+        showToast(t('trustedIssuers:create.error', 'Failed to create trusted issuer. Please try again.'), 'error');
+      }
+    },
+  });
+}

--- a/frontend/apps/console/src/features/trusted-issuers/api/useDeleteTrustedIssuer.ts
+++ b/frontend/apps/console/src/features/trusted-issuers/api/useDeleteTrustedIssuer.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
+import {useConfig, useToast} from '@thunderid/contexts';
+import {useThunderID} from '@thunderid/react';
+import {useTranslation} from 'react-i18next';
+import TrustedIssuerQueryKeys from '../constants/query-keys';
+import {ConnectionQueryKeys, ConnectionTypes} from '@thunderid/configure-connections';
+
+/**
+ * Delete a trusted issuer (DELETE /connections/oidc/{id}).
+ *
+ * @example
+ * ```tsx
+ * const deleteTrustedIssuer = useDeleteTrustedIssuer();
+ * deleteTrustedIssuer.mutate(id);
+ * ```
+ *
+ * @public
+ */
+export default function useDeleteTrustedIssuer(): UseMutationResult<void, Error, string> {
+  const {http} = useThunderID();
+  const {getServerUrl} = useConfig();
+  const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
+  const {t} = useTranslation();
+  const {showToast} = useToast();
+
+  return useMutation<void, Error, string>({
+    mutationFn: async (id: string): Promise<void> => {
+      const serverUrl: string = getServerUrl();
+      await http.request({
+        url: `${serverUrl}/connections/${ConnectionTypes.OIDC}/${id}`,
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      } as unknown as Parameters<typeof http.request>[0]);
+    },
+    onSuccess: (_data, id) => {
+      queryClient.removeQueries({queryKey: [TrustedIssuerQueryKeys.TRUSTED_ISSUER, id]});
+      queryClient.invalidateQueries({queryKey: [ConnectionQueryKeys.CONNECTIONS]}).catch(() => {
+        // Ignore invalidation errors
+      });
+      queryClient
+        .invalidateQueries({queryKey: [ConnectionQueryKeys.CONNECTION_INSTANCES, ConnectionTypes.OIDC]})
+        .catch(() => {
+          // Ignore invalidation errors
+        });
+      showToast(t('trustedIssuers:delete.success', 'Trusted issuer deleted successfully.'), 'success');
+    },
+    onError: () => {
+      showToast(t('trustedIssuers:delete.error', 'Failed to delete trusted issuer. Please try again.'), 'error');
+    },
+  });
+}

--- a/frontend/apps/console/src/features/trusted-issuers/api/useTrustedIssuer.ts
+++ b/frontend/apps/console/src/features/trusted-issuers/api/useTrustedIssuer.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useQuery, type UseQueryResult} from '@tanstack/react-query';
+import {useConfig} from '@thunderid/contexts';
+import {useThunderID} from '@thunderid/react';
+import TrustedIssuerQueryKeys from '../constants/query-keys';
+import type {TrustedIssuer} from '../models/trusted-issuer';
+import mapConnectionToTrustedIssuer from '../utils/mapConnectionToTrustedIssuer';
+import {ConnectionTypes, type ConnectionResponse} from '@thunderid/configure-connections';
+
+/**
+ * Fetch a single trusted issuer (GET /connections/oidc/{id}). Disabled until an id is provided.
+ *
+ * @example
+ * ```tsx
+ * const {data: trustedIssuer, isLoading} = useTrustedIssuer(id);
+ * ```
+ *
+ * @public
+ */
+export default function useTrustedIssuer(id: string | undefined): UseQueryResult<TrustedIssuer> {
+  const {http} = useThunderID();
+  const {getServerUrl} = useConfig();
+
+  return useQuery<TrustedIssuer>({
+    queryKey: [TrustedIssuerQueryKeys.TRUSTED_ISSUER, id],
+    enabled: Boolean(id),
+    queryFn: async (): Promise<TrustedIssuer> => {
+      const serverUrl: string = getServerUrl();
+      const response: {
+        data: ConnectionResponse;
+      } = await http.request({
+        url: `${serverUrl}/connections/${ConnectionTypes.OIDC}/${id}`,
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      } as unknown as Parameters<typeof http.request>[0]);
+
+      return mapConnectionToTrustedIssuer(response.data);
+    },
+  });
+}

--- a/frontend/apps/console/src/features/trusted-issuers/api/useUpdateTrustedIssuer.ts
+++ b/frontend/apps/console/src/features/trusted-issuers/api/useUpdateTrustedIssuer.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
+import {useConfig, useToast} from '@thunderid/contexts';
+import {useThunderID} from '@thunderid/react';
+import {useTranslation} from 'react-i18next';
+import TrustedIssuerQueryKeys from '../constants/query-keys';
+import type {TrustedIssuer, TrustedIssuerFormData} from '../models/trusted-issuer';
+import mapConnectionToTrustedIssuer from '../utils/mapConnectionToTrustedIssuer';
+import {
+  ConnectionQueryKeys,
+  ConnectionTypes,
+  isConflictError,
+  type ConnectionResponse,
+} from '@thunderid/configure-connections';
+
+/**
+ * Update a trusted issuer (PUT /connections/oidc/{id}).
+ *
+ * Conflicts (409 duplicate name) are not toasted here — the caller surfaces them inline next
+ * to the name field.
+ *
+ * @example
+ * ```tsx
+ * const updateTrustedIssuer = useUpdateTrustedIssuer(id);
+ * updateTrustedIssuer.mutate({name, issuer, jwksEndpoint, idJagEnabled: true});
+ * ```
+ *
+ * @public
+ */
+export default function useUpdateTrustedIssuer(
+  id: string,
+): UseMutationResult<TrustedIssuer, Error, TrustedIssuerFormData> {
+  const {http} = useThunderID();
+  const {getServerUrl} = useConfig();
+  const queryClient: ReturnType<typeof useQueryClient> = useQueryClient();
+  const {t} = useTranslation();
+  const {showToast} = useToast();
+
+  return useMutation<TrustedIssuer, Error, TrustedIssuerFormData>({
+    mutationFn: async (data: TrustedIssuerFormData): Promise<TrustedIssuer> => {
+      const serverUrl: string = getServerUrl();
+      const response: {
+        data: ConnectionResponse;
+      } = await http.request({
+        url: `${serverUrl}/connections/${ConnectionTypes.OIDC}/${id}`,
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data,
+      } as unknown as Parameters<typeof http.request>[0]);
+
+      return mapConnectionToTrustedIssuer(response.data);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({queryKey: [ConnectionQueryKeys.CONNECTIONS]}).catch(() => {
+        // Ignore invalidation errors
+      });
+      queryClient.invalidateQueries({queryKey: [TrustedIssuerQueryKeys.TRUSTED_ISSUER, id]}).catch(() => {
+        // Ignore invalidation errors
+      });
+      queryClient
+        .invalidateQueries({queryKey: [ConnectionQueryKeys.CONNECTION_INSTANCES, ConnectionTypes.OIDC]})
+        .catch(() => {
+          // Ignore invalidation errors
+        });
+      showToast(t('trustedIssuers:update.success', 'Trusted issuer updated successfully.'), 'success');
+    },
+    onError: (error) => {
+      if (!isConflictError(error)) {
+        showToast(t('trustedIssuers:update.error', 'Failed to update trusted issuer. Please try again.'), 'error');
+      }
+    },
+  });
+}

--- a/frontend/apps/console/src/features/trusted-issuers/components/TrustedIssuerCreateForm.tsx
+++ b/frontend/apps/console/src/features/trusted-issuers/components/TrustedIssuerCreateForm.tsx
@@ -1,0 +1,281 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  Box,
+  Button,
+  Collapse,
+  Divider,
+  FormControl,
+  FormControlLabel,
+  FormLabel,
+  Paper,
+  Stack,
+  Switch,
+  TextField,
+  Typography,
+} from '@wso2/oxygen-ui';
+import {useMemo, useState, type JSX} from 'react';
+import {useTranslation} from 'react-i18next';
+import {useNavigate} from 'react-router';
+import useCreateTrustedIssuer from '../api/useCreateTrustedIssuer';
+import validateTrustedIssuerForm, {
+  type TrustedIssuerFieldErrorKind,
+  type TrustedIssuerFormErrors,
+} from '../utils/validateTrustedIssuerForm';
+import {isConflictError} from '@thunderid/configure-connections';
+
+/**
+ * The trusted-issuer create form: fields, validation, and submission via
+ * {@link useCreateTrustedIssuer}. On success, navigates to the created issuer's detail page.
+ *
+ * Has no back/cancel affordance of its own — callers (the "Add custom connection" wizard) provide
+ * that chrome.
+ */
+export default function TrustedIssuerCreateForm(): JSX.Element {
+  const {t} = useTranslation();
+  const navigate = useNavigate();
+  const createTrustedIssuer = useCreateTrustedIssuer();
+
+  const [name, setName] = useState('');
+  const [issuer, setIssuer] = useState('');
+  const [jwksEndpoint, setJwksEndpoint] = useState('');
+  const [idJagEnabled, setIdJagEnabled] = useState(false);
+  const [clientId, setClientId] = useState('');
+  const [tokenExchangeEnabled, setTokenExchangeEnabled] = useState(true);
+  const [trustedTokenAudience, setTrustedTokenAudience] = useState('');
+  const [touched, setTouched] = useState<Record<string, boolean>>({});
+  const [nameError, setNameError] = useState<string | null>(null);
+
+  const errors: TrustedIssuerFormErrors = useMemo(
+    () => validateTrustedIssuerForm({name, issuer, jwksEndpoint}),
+    [name, issuer, jwksEndpoint],
+  );
+  const formValid: boolean = Object.keys(errors).length === 0;
+
+  const fieldErrorMessage = (kind: TrustedIssuerFieldErrorKind | undefined): string | undefined => {
+    if (kind === 'required') {
+      return t('trustedIssuers:validation.required', 'This field is required.');
+    }
+    if (kind === 'url') {
+      return t('trustedIssuers:validation.url', 'Enter a valid https:// URL.');
+    }
+    return undefined;
+  };
+
+  const setTouchedField = (field: string): void => setTouched((prev) => ({...prev, [field]: true}));
+
+  const handleCreate = (): void => {
+    if (!formValid) return;
+
+    setNameError(null);
+    createTrustedIssuer.mutate(
+      {
+        name: name.trim(),
+        issuer: issuer.trim(),
+        jwksEndpoint: jwksEndpoint.trim(),
+        idJagEnabled,
+        clientId: clientId.trim() || undefined,
+        tokenExchangeEnabled,
+        trustedTokenAudience: trustedTokenAudience.trim() || undefined,
+      },
+      {
+        onSuccess: (created) => {
+          void navigate(`/trusted-issuers/${created.id}`);
+        },
+        onError: (error) => {
+          if (isConflictError(error)) {
+            setNameError(t('trustedIssuers:create.duplicateName', 'A trusted issuer with this name already exists.'));
+          }
+        },
+      },
+    );
+  };
+
+  return (
+    <Stack direction="column" spacing={3}>
+      <Stack direction="column" spacing={1}>
+        <Typography variant="h4" fontWeight={700}>
+          {t('trustedIssuers:create.title', 'Add trusted issuer')}
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          {t(
+            'trustedIssuers:create.subtitle',
+            'Register an external identity provider whose identity assertions ThunderID can exchange for access tokens.',
+          )}
+        </Typography>
+      </Stack>
+
+      <Paper variant="outlined" sx={{p: 3}}>
+        <Stack direction="column" spacing={3}>
+          <FormControl fullWidth required error={Boolean(nameError ?? (touched.name && errors.name))}>
+            <FormLabel htmlFor="trusted-issuer-name">{t('trustedIssuers:create.form.name.label', 'Name')}</FormLabel>
+            <TextField
+              id="trusted-issuer-name"
+              fullWidth
+              value={name}
+              error={Boolean(nameError ?? (touched.name && errors.name))}
+              helperText={nameError ?? (touched.name ? fieldErrorMessage(errors.name) : undefined)}
+              onChange={(e) => {
+                setName(e.target.value);
+                setNameError(null);
+              }}
+              onBlur={() => setTouchedField('name')}
+            />
+          </FormControl>
+
+          <FormControl fullWidth required error={Boolean(touched.issuer && errors.issuer)}>
+            <FormLabel htmlFor="trusted-issuer-issuer">
+              {t('trustedIssuers:create.form.issuer.label', 'Issuer URI')}
+            </FormLabel>
+            <TextField
+              id="trusted-issuer-issuer"
+              fullWidth
+              placeholder="https://idp.example.com"
+              value={issuer}
+              error={Boolean(touched.issuer && errors.issuer)}
+              helperText={
+                touched.issuer
+                  ? fieldErrorMessage(errors.issuer)
+                  : t(
+                      'trustedIssuers:create.form.issuer.hint',
+                      "The issuer URI from the external IdP's OpenID Connect discovery document.",
+                    )
+              }
+              onChange={(e) => setIssuer(e.target.value)}
+              onBlur={() => setTouchedField('issuer')}
+            />
+          </FormControl>
+
+          <FormControl fullWidth>
+            <FormLabel htmlFor="trusted-issuer-client-id">
+              {t('trustedIssuers:create.form.clientId.label', 'Client ID')}
+            </FormLabel>
+            <TextField
+              id="trusted-issuer-client-id"
+              fullWidth
+              placeholder="your-thunderid-client-id"
+              value={clientId}
+              helperText={t(
+                'trustedIssuers:create.form.clientId.hint',
+                "ThunderID's client ID registered at this identity provider. Used for audience validation in incoming assertions.",
+              )}
+              onChange={(e) => setClientId(e.target.value)}
+            />
+          </FormControl>
+
+          <FormControl fullWidth required error={Boolean(touched.jwksEndpoint && errors.jwksEndpoint)}>
+            <FormLabel htmlFor="trusted-issuer-jwks-endpoint">
+              {t('trustedIssuers:create.form.jwksEndpoint.label', 'JWKS endpoint')}
+            </FormLabel>
+            <TextField
+              id="trusted-issuer-jwks-endpoint"
+              fullWidth
+              placeholder="https://idp.example.com/oauth2/v1/keys"
+              value={jwksEndpoint}
+              error={Boolean(touched.jwksEndpoint && errors.jwksEndpoint)}
+              helperText={
+                touched.jwksEndpoint
+                  ? fieldErrorMessage(errors.jwksEndpoint)
+                  : t(
+                      'trustedIssuers:create.form.jwksEndpoint.hint',
+                      'The JWKS endpoint used to validate the signature of incoming identity assertions.',
+                    )
+              }
+              onChange={(e) => setJwksEndpoint(e.target.value)}
+              onBlur={() => setTouchedField('jwksEndpoint')}
+            />
+          </FormControl>
+
+          <Box>
+            <Divider sx={{mb: 2}} />
+            <FormControlLabel
+              control={
+                <Switch checked={tokenExchangeEnabled} onChange={(e) => setTokenExchangeEnabled(e.target.checked)} />
+              }
+              label={
+                <Typography variant="subtitle2">
+                  {t('trustedIssuers:create.form.tokenExchangeEnabled.label', 'Enable token exchange')}
+                </Typography>
+              }
+            />
+            <Typography variant="caption" color="text.secondary" sx={{display: 'block', ml: '52px'}}>
+              {t(
+                'trustedIssuers:create.form.tokenExchangeEnabled.hint',
+                'Exchange subject tokens from this issuer for access tokens.',
+              )}
+            </Typography>
+
+            <Collapse in={tokenExchangeEnabled}>
+              <FormControl fullWidth sx={{mt: 3}}>
+                <FormLabel htmlFor="trusted-issuer-token-audience">
+                  {t('trustedIssuers:detail.tokenExchange.audience.label', 'Trusted token audience')}
+                </FormLabel>
+                <TextField
+                  id="trusted-issuer-token-audience"
+                  fullWidth
+                  placeholder="my-external-client-id"
+                  value={trustedTokenAudience}
+                  helperText={t(
+                    'trustedIssuers:detail.tokenExchange.audience.hint',
+                    'The audience value ThunderID expects in subject tokens from this issuer.',
+                  )}
+                  onChange={(e) => setTrustedTokenAudience(e.target.value)}
+                />
+              </FormControl>
+            </Collapse>
+          </Box>
+
+          <Box>
+            <Divider sx={{mb: 2}} />
+            <FormControlLabel
+              control={<Switch checked={idJagEnabled} onChange={(e) => setIdJagEnabled(e.target.checked)} />}
+              label={
+                <Typography variant="subtitle2">
+                  {t(
+                    'trustedIssuers:create.form.idJagEnabled.label',
+                    'Enable Identity Assertion JWT Authorization Grant (ID-JAG)',
+                  )}
+                </Typography>
+              }
+            />
+            <Typography variant="caption" color="text.secondary" sx={{display: 'block', ml: '52px'}}>
+              {t(
+                'trustedIssuers:create.form.idJagEnabled.hint',
+                'Accept and exchange signed identity assertions from this issuer for access tokens.',
+              )}
+            </Typography>
+          </Box>
+        </Stack>
+      </Paper>
+
+      <Box sx={{display: 'flex', justifyContent: 'flex-end'}}>
+        <Button
+          variant="contained"
+          disabled={!formValid || createTrustedIssuer.isPending}
+          onClick={handleCreate}
+          data-testid="trusted-issuer-create-submit"
+        >
+          {createTrustedIssuer.isPending
+            ? t('common:status.saving')
+            : t('trustedIssuers:create.submit', 'Add trusted issuer')}
+        </Button>
+      </Box>
+    </Stack>
+  );
+}

--- a/frontend/apps/console/src/features/trusted-issuers/components/TrustedIssuerDeleteDialog.tsx
+++ b/frontend/apps/console/src/features/trusted-issuers/components/TrustedIssuerDeleteDialog.tsx
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Alert, Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle} from '@wso2/oxygen-ui';
+import {useState, type JSX} from 'react';
+import {useTranslation} from 'react-i18next';
+import useDeleteTrustedIssuer from '../api/useDeleteTrustedIssuer';
+
+/**
+ * Props for the {@link TrustedIssuerDeleteDialog} component.
+ */
+export interface TrustedIssuerDeleteDialogProps {
+  /**
+   * Whether the dialog is open.
+   */
+  open: boolean;
+  /**
+   * The id of the trusted issuer to delete.
+   */
+  trustedIssuerId: string | null;
+  /**
+   * The display name of the trusted issuer, shown in the confirmation message.
+   */
+  trustedIssuerName: string;
+  /**
+   * Called when the dialog should be closed without deleting.
+   */
+  onClose: () => void;
+  /**
+   * Called when the trusted issuer is successfully deleted.
+   */
+  onSuccess?: () => void;
+}
+
+/**
+ * Confirmation dialog for deleting a trusted issuer.
+ */
+export default function TrustedIssuerDeleteDialog({
+  open,
+  trustedIssuerId,
+  trustedIssuerName,
+  onClose,
+  onSuccess = undefined,
+}: TrustedIssuerDeleteDialogProps): JSX.Element {
+  const {t} = useTranslation();
+  const deleteTrustedIssuer = useDeleteTrustedIssuer();
+  const [error, setError] = useState<string | null>(null);
+
+  const handleCancel = (): void => {
+    if (deleteTrustedIssuer.isPending) return;
+    setError(null);
+    onClose();
+  };
+
+  const handleConfirm = (): void => {
+    if (!trustedIssuerId) return;
+
+    deleteTrustedIssuer.mutate(trustedIssuerId, {
+      onSuccess: (): void => {
+        setError(null);
+        onClose();
+        onSuccess?.();
+      },
+      onError: (err: Error) => {
+        setError(err.message || t('trustedIssuers:delete.error', 'Failed to delete trusted issuer. Please try again.'));
+      },
+    });
+  };
+
+  return (
+    <Dialog open={open} onClose={handleCancel} maxWidth="sm" fullWidth>
+      <DialogTitle>{t('trustedIssuers:delete.title', 'Delete trusted issuer')}</DialogTitle>
+      <DialogContent>
+        <DialogContentText sx={{mb: 2}}>
+          {t(
+            'trustedIssuers:delete.message',
+            'Delete "{{name}}"? Applications relying on assertions from this issuer will stop receiving tokens. This cannot be undone.',
+            {name: trustedIssuerName},
+          )}
+        </DialogContentText>
+        {error && <Alert severity="error">{error}</Alert>}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleCancel} disabled={deleteTrustedIssuer.isPending}>
+          {t('common:actions.cancel')}
+        </Button>
+        <Button
+          onClick={handleConfirm}
+          color="error"
+          variant="contained"
+          disabled={deleteTrustedIssuer.isPending}
+          data-testid="trusted-issuer-delete-confirm"
+        >
+          {deleteTrustedIssuer.isPending ? t('common:status.deleting') : t('common:actions.delete')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/apps/console/src/features/trusted-issuers/components/__tests__/TrustedIssuerCreateForm.test.tsx
+++ b/frontend/apps/console/src/features/trusted-issuers/components/__tests__/TrustedIssuerCreateForm.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
+import userEvent from '@testing-library/user-event';
+import {render, screen, waitFor} from '@thunderid/test-utils';
+import type {NavigateFunction} from 'react-router';
+import {describe, it, expect, beforeEach, vi} from 'vitest';
+import TrustedIssuerCreateForm from '../TrustedIssuerCreateForm';
+
+const {mockMutate} = vi.hoisted(() => ({mockMutate: vi.fn()}));
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return {
+    ...actual,
+    useNavigate: vi.fn(),
+  };
+});
+
+vi.mock('../../api/useCreateTrustedIssuer', () => ({
+  default: () => ({mutate: mockMutate, isPending: false}),
+}));
+
+const {useNavigate} = await import('react-router');
+
+describe('TrustedIssuerCreateForm', () => {
+  let mockNavigate: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockNavigate = vi.fn();
+    mockMutate.mockReset();
+    vi.mocked(useNavigate).mockReturnValue(mockNavigate as unknown as NavigateFunction);
+  });
+
+  it('should render the form with the ID-JAG switch off and token exchange switch on by default', () => {
+    render(<TrustedIssuerCreateForm />);
+
+    expect(screen.getByLabelText(/^Name/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Issuer URI/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^JWKS endpoint/)).toBeInTheDocument();
+    expect(screen.getByRole('switch', {name: /id-jag/i})).not.toBeChecked();
+    expect(screen.getByRole('switch', {name: /enable token exchange/i})).toBeChecked();
+  });
+
+  it('should have no back or cancel affordance of its own', () => {
+    render(<TrustedIssuerCreateForm />);
+
+    expect(screen.queryByRole('button', {name: /back/i})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: /^cancel$/i})).not.toBeInTheDocument();
+  });
+
+  it('should disable the submit button until all required fields are valid', async () => {
+    const user = userEvent.setup();
+    render(<TrustedIssuerCreateForm />);
+
+    const submitButton = screen.getByTestId('trusted-issuer-create-submit');
+    expect(submitButton).toBeDisabled();
+
+    await user.type(screen.getByLabelText(/^Name/), 'Acme Okta');
+    expect(submitButton).toBeDisabled();
+
+    await user.type(screen.getByLabelText(/^Issuer URI/), 'https://acme.okta.com');
+    expect(submitButton).toBeDisabled();
+
+    await user.type(screen.getByLabelText(/^JWKS endpoint/), 'https://acme.okta.com/keys');
+    expect(submitButton).toBeEnabled();
+  });
+
+  it('should show a validation error when an issuer URI is not https', async () => {
+    const user = userEvent.setup();
+    render(<TrustedIssuerCreateForm />);
+
+    const issuerField = screen.getByLabelText(/^Issuer URI/);
+    await user.type(issuerField, 'http://acme.okta.com');
+    await user.tab();
+
+    expect(await screen.findByText('Enter a valid https:// URL.')).toBeInTheDocument();
+  });
+
+  it('should show a required error when a field is left blank on blur', async () => {
+    const user = userEvent.setup();
+    render(<TrustedIssuerCreateForm />);
+
+    const nameField = screen.getByLabelText(/^Name/);
+    await user.click(nameField);
+    await user.tab();
+
+    expect(await screen.findByText('This field is required.')).toBeInTheDocument();
+  });
+
+  it('should submit the form and navigate to the detail page on success', async () => {
+    const user = userEvent.setup();
+    mockMutate.mockImplementation((_data, opts) => {
+      opts.onSuccess({
+        id: 'ti-1',
+        name: 'Acme Okta',
+        issuer: 'https://acme.okta.com',
+        jwksEndpoint: 'https://acme.okta.com/keys',
+        idJagEnabled: true,
+      });
+    });
+
+    render(<TrustedIssuerCreateForm />);
+
+    await user.type(screen.getByLabelText(/^Name/), 'Acme Okta');
+    await user.type(screen.getByLabelText(/^Issuer URI/), 'https://acme.okta.com');
+    await user.type(screen.getByLabelText(/^JWKS endpoint/), 'https://acme.okta.com/keys');
+    await user.click(screen.getByTestId('trusted-issuer-create-submit'));
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      {
+        name: 'Acme Okta',
+        issuer: 'https://acme.okta.com',
+        jwksEndpoint: 'https://acme.okta.com/keys',
+        idJagEnabled: false,
+        clientId: undefined,
+        tokenExchangeEnabled: true,
+        trustedTokenAudience: undefined,
+      },
+      expect.any(Object),
+    );
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/trusted-issuers/ti-1');
+    });
+  });
+
+  it('should show an inline duplicate-name error on 409 conflict without navigating', async () => {
+    const user = userEvent.setup();
+    mockMutate.mockImplementation((_data, opts) => {
+      opts.onError({response: {status: 409}});
+    });
+
+    render(<TrustedIssuerCreateForm />);
+
+    await user.type(screen.getByLabelText(/^Name/), 'Acme Okta');
+    await user.type(screen.getByLabelText(/^Issuer URI/), 'https://acme.okta.com');
+    await user.type(screen.getByLabelText(/^JWKS endpoint/), 'https://acme.okta.com/keys');
+    await user.click(screen.getByTestId('trusted-issuer-create-submit'));
+
+    expect(await screen.findByText('A trusted issuer with this name already exists.')).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalledWith(expect.stringContaining('/trusted-issuers/'));
+  });
+
+  it('should turn on ID-JAG when the switch is toggled', async () => {
+    const user = userEvent.setup();
+    mockMutate.mockImplementation((_data, opts) => {
+      opts.onSuccess({
+        id: 'ti-2',
+        name: 'Beta AD',
+        issuer: 'https://beta.example.com',
+        jwksEndpoint: 'https://beta.example.com/keys',
+        idJagEnabled: true,
+      });
+    });
+
+    render(<TrustedIssuerCreateForm />);
+
+    await user.click(screen.getByRole('switch', {name: /id-jag/i}));
+    await user.type(screen.getByLabelText(/^Name/), 'Beta AD');
+    await user.type(screen.getByLabelText(/^Issuer URI/), 'https://beta.example.com');
+    await user.type(screen.getByLabelText(/^JWKS endpoint/), 'https://beta.example.com/keys');
+    await user.click(screen.getByTestId('trusted-issuer-create-submit'));
+
+    expect(mockMutate).toHaveBeenCalledWith(expect.objectContaining({idJagEnabled: true}), expect.any(Object));
+  });
+
+  it('should render the client id field', () => {
+    render(<TrustedIssuerCreateForm />);
+
+    expect(screen.getByLabelText(/^Client ID/)).toBeInTheDocument();
+  });
+
+  it('should include the client id in the create payload', async () => {
+    const user = userEvent.setup();
+    mockMutate.mockImplementation((_data, opts) => {
+      opts.onSuccess({
+        id: 'ti-3',
+        name: 'Acme Okta',
+        issuer: 'https://acme.okta.com',
+        jwksEndpoint: 'https://acme.okta.com/keys',
+        idJagEnabled: false,
+      });
+    });
+
+    render(<TrustedIssuerCreateForm />);
+
+    await user.type(screen.getByLabelText(/^Name/), 'Acme Okta');
+    await user.type(screen.getByLabelText(/^Issuer URI/), 'https://acme.okta.com');
+    await user.type(screen.getByLabelText(/^JWKS endpoint/), 'https://acme.okta.com/keys');
+    await user.type(screen.getByLabelText(/^Client ID/), 'thunderid-console');
+    await user.click(screen.getByTestId('trusted-issuer-create-submit'));
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientId: 'thunderid-console',
+      }),
+      expect.any(Object),
+    );
+  });
+});

--- a/frontend/apps/console/src/features/trusted-issuers/constants/query-keys.ts
+++ b/frontend/apps/console/src/features/trusted-issuers/constants/query-keys.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Query key constants for trusted-issuers feature cache management.
+ */
+const TrustedIssuerQueryKeys = {
+  /**
+   * Key for a single trusted issuer (GET /connections/oidc/{id})
+   */
+  TRUSTED_ISSUER: 'trustedIssuer',
+} as const;
+
+export default TrustedIssuerQueryKeys;

--- a/frontend/apps/console/src/features/trusted-issuers/models/trusted-issuer.ts
+++ b/frontend/apps/console/src/features/trusted-issuers/models/trusted-issuer.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * A trusted issuer is a trust-only OIDC connection (`/connections/oidc`) that stores just
+ * enough configuration for ThunderID to validate identity assertions issued by an external
+ * IdP for ID-JAG consumption. Unlike a full OIDC connection, it carries no OAuth client
+ * credentials.
+ *
+ * @public
+ * @remarks
+ * Trusted issuers are OIDC connections with `idJagEnabled` set (`true` or `false`); the
+ * listing filters out plain federation OIDC connections where the field is `undefined`.
+ */
+export interface TrustedIssuerFormData {
+  /**
+   * Display name for the trusted issuer.
+   * @example "Acme Corp Okta"
+   */
+  name: string;
+  /**
+   * The issuer URI from the external IdP's OpenID Connect discovery document.
+   * @example "https://acme.okta.com"
+   */
+  issuer: string;
+  /**
+   * The JWKS endpoint used to validate the signature of incoming identity assertions.
+   * @example "https://acme.okta.com/oauth2/v1/keys"
+   */
+  jwksEndpoint: string;
+  /**
+   * Whether ThunderID accepts and exchanges identity assertions issued by this issuer.
+   * @example true
+   */
+  idJagEnabled: boolean;
+  /**
+   * ThunderID's client ID registered at this external identity provider.
+   * @example "thunderid-console"
+   */
+  clientId?: string;
+  /**
+   * Whether token exchange is enabled for this issuer.
+   * @example true
+   */
+  tokenExchangeEnabled?: boolean;
+  /**
+   * The audience value ThunderID expects in subject tokens from this issuer during token exchange.
+   * @example "thunderid-console"
+   */
+  trustedTokenAudience?: string;
+}
+
+/**
+ * A trusted issuer as returned by the API, including its connection id.
+ * @public
+ */
+export interface TrustedIssuer extends TrustedIssuerFormData {
+  /**
+   * The underlying OIDC connection id.
+   * @example "8f14e45f-ceea-467e-b0a4-fbc3c7f8b52a"
+   */
+  id: string;
+}

--- a/frontend/apps/console/src/features/trusted-issuers/pages/TrustedIssuerDetailPage.tsx
+++ b/frontend/apps/console/src/features/trusted-issuers/pages/TrustedIssuerDetailPage.tsx
@@ -1,0 +1,331 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {ResourceAvatar, SettingsCard, UnsavedChangesBar} from '@thunderid/components';
+import {
+  Alert,
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  PageContent,
+  Skeleton,
+  Stack,
+  TextField,
+  Typography,
+} from '@wso2/oxygen-ui';
+import {ChevronLeft, Trash2} from '@wso2/oxygen-ui-icons-react';
+import {useMemo, useState, type JSX} from 'react';
+import {useTranslation} from 'react-i18next';
+import {useNavigate, useParams} from 'react-router';
+import useTrustedIssuer from '../api/useTrustedIssuer';
+import useUpdateTrustedIssuer from '../api/useUpdateTrustedIssuer';
+import TrustedIssuerDeleteDialog from '../components/TrustedIssuerDeleteDialog';
+import type {TrustedIssuerFormData} from '../models/trusted-issuer';
+import isTrustedIssuerFormDirty from '../utils/isTrustedIssuerFormDirty';
+import validateTrustedIssuerForm, {
+  type TrustedIssuerFieldErrorKind,
+  type TrustedIssuerFormErrors,
+} from '../utils/validateTrustedIssuerForm';
+import {isConflictError} from '@thunderid/configure-connections';
+
+export default function TrustedIssuerDetailPage(): JSX.Element {
+  const {t} = useTranslation();
+  const navigate = useNavigate();
+  const {id} = useParams<{id: string}>();
+
+  const trustedIssuerQuery = useTrustedIssuer(id);
+  const updateMutation = useUpdateTrustedIssuer(id ?? '');
+
+  const [editedValues, setEditedValues] = useState<Partial<TrustedIssuerFormData>>({});
+  const [touched, setTouched] = useState<Record<string, boolean>>({});
+  const [nameError, setNameError] = useState<string | null>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const data = trustedIssuerQuery.data;
+
+  const baseline: TrustedIssuerFormData = useMemo(
+    () => ({
+      name: data?.name ?? '',
+      issuer: data?.issuer ?? '',
+      jwksEndpoint: data?.jwksEndpoint ?? '',
+      idJagEnabled: data?.idJagEnabled ?? false,
+      clientId: data?.clientId ?? undefined,
+      tokenExchangeEnabled: data?.tokenExchangeEnabled ?? false,
+      trustedTokenAudience: data?.trustedTokenAudience ?? undefined,
+    }),
+    [data],
+  );
+
+  const values: TrustedIssuerFormData = useMemo(() => ({...baseline, ...editedValues}), [baseline, editedValues]);
+  const dirty: boolean = isTrustedIssuerFormDirty(values, baseline);
+
+  const errors: TrustedIssuerFormErrors = useMemo(() => validateTrustedIssuerForm(values), [values]);
+  const valid: boolean = Object.keys(errors).length === 0;
+
+  const fieldErrorMessage = (kind: TrustedIssuerFieldErrorKind | undefined): string | undefined => {
+    if (kind === 'required') {
+      return t('trustedIssuers:validation.required', 'This field is required.');
+    }
+    if (kind === 'url') {
+      return t('trustedIssuers:validation.url', 'Enter a valid https:// URL.');
+    }
+    return undefined;
+  };
+
+  const setField = <K extends keyof TrustedIssuerFormData>(field: K, value: TrustedIssuerFormData[K]): void => {
+    setEditedValues((prev) => ({...prev, [field]: value}));
+  };
+
+  const setTouchedField = (field: string): void => setTouched((prev) => ({...prev, [field]: true}));
+
+  const resetEdits = (): void => {
+    setEditedValues({});
+    setTouched({});
+    setNameError(null);
+  };
+
+  const isLoading: boolean = trustedIssuerQuery.isLoading;
+  const notFound: boolean = !isLoading && !data;
+
+  const handleSave = (): void => {
+    if (!valid || !id) return;
+
+    setNameError(null);
+    updateMutation.mutate(values, {
+      onSuccess: () => {
+        void trustedIssuerQuery.refetch();
+        resetEdits();
+      },
+      onError: (error) => {
+        if (isConflictError(error)) {
+          setNameError(t('trustedIssuers:detail.duplicateName', 'A trusted issuer with this name already exists.'));
+        }
+      },
+    });
+  };
+
+  return (
+    <PageContent>
+      <Button
+        variant="text"
+        startIcon={<ChevronLeft size={16} />}
+        onClick={() => void navigate('/connections')}
+        sx={{mb: 2, alignSelf: 'flex-start'}}
+      >
+        {t('trustedIssuers:detail.back', 'Back to connections')}
+      </Button>
+
+      {isLoading ? (
+        <Skeleton variant="rounded" height={480} />
+      ) : notFound || trustedIssuerQuery.isError ? (
+        <Alert severity="error">{t('trustedIssuers:detail.loadError', 'Failed to load trusted issuer.')}</Alert>
+      ) : (
+        <>
+          <Stack direction="row" spacing={2} alignItems="flex-start" sx={{mb: 3}}>
+            <Box
+              sx={{
+                width: 52,
+                height: 52,
+                borderRadius: 2,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                bgcolor: 'action.hover',
+                flexShrink: 0,
+              }}
+            >
+              <ResourceAvatar size={32} fallback="emoji:🤝" />
+            </Box>
+            <Stack direction="column" spacing={0.5}>
+              <Typography variant="h5" fontWeight={700}>
+                {data?.name}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {data?.issuer}
+              </Typography>
+            </Stack>
+          </Stack>
+
+          <Stack direction="column" spacing={4}>
+            <SettingsCard
+              title={t('trustedIssuers:detail.general.title', 'General')}
+              description={t('trustedIssuers:detail.general.description', 'Core identity of this trusted issuer.')}
+            >
+              <Stack direction="column" spacing={3}>
+                <FormControl fullWidth required error={Boolean(nameError ?? (touched.name && errors.name))}>
+                  <FormLabel htmlFor="trusted-issuer-name">
+                    {t('trustedIssuers:create.form.name.label', 'Name')}
+                  </FormLabel>
+                  <TextField
+                    id="trusted-issuer-name"
+                    fullWidth
+                    value={values.name}
+                    error={Boolean(nameError ?? (touched.name && errors.name))}
+                    helperText={nameError ?? (touched.name ? fieldErrorMessage(errors.name) : undefined)}
+                    onChange={(e) => {
+                      setField('name', e.target.value);
+                      setNameError(null);
+                    }}
+                    onBlur={() => setTouchedField('name')}
+                  />
+                </FormControl>
+
+                <FormControl fullWidth required error={Boolean(touched.issuer && errors.issuer)}>
+                  <FormLabel htmlFor="trusted-issuer-issuer">
+                    {t('trustedIssuers:create.form.issuer.label', 'Issuer URI')}
+                  </FormLabel>
+                  <TextField
+                    id="trusted-issuer-issuer"
+                    fullWidth
+                    value={values.issuer}
+                    error={Boolean(touched.issuer && errors.issuer)}
+                    helperText={touched.issuer ? fieldErrorMessage(errors.issuer) : undefined}
+                    onChange={(e) => setField('issuer', e.target.value)}
+                    onBlur={() => setTouchedField('issuer')}
+                  />
+                </FormControl>
+
+                <FormControl fullWidth>
+                  <FormLabel htmlFor="trusted-issuer-client-id">
+                    {t('trustedIssuers:create.form.clientId.label', 'Client ID')}
+                  </FormLabel>
+                  <TextField
+                    id="trusted-issuer-client-id"
+                    fullWidth
+                    placeholder="your-thunderid-client-id"
+                    value={values.clientId ?? ''}
+                    helperText={t(
+                      'trustedIssuers:create.form.clientId.hint',
+                      "ThunderID's client ID registered at this identity provider. Used for audience validation in incoming assertions.",
+                    )}
+                    onChange={(e) => setField('clientId', e.target.value || undefined)}
+                  />
+                </FormControl>
+
+                <FormControl fullWidth required error={Boolean(touched.jwksEndpoint && errors.jwksEndpoint)}>
+                  <FormLabel htmlFor="trusted-issuer-jwks-endpoint">
+                    {t('trustedIssuers:create.form.jwksEndpoint.label', 'JWKS endpoint')}
+                  </FormLabel>
+                  <TextField
+                    id="trusted-issuer-jwks-endpoint"
+                    fullWidth
+                    value={values.jwksEndpoint}
+                    error={Boolean(touched.jwksEndpoint && errors.jwksEndpoint)}
+                    helperText={touched.jwksEndpoint ? fieldErrorMessage(errors.jwksEndpoint) : undefined}
+                    onChange={(e) => setField('jwksEndpoint', e.target.value)}
+                    onBlur={() => setTouchedField('jwksEndpoint')}
+                  />
+                </FormControl>
+              </Stack>
+            </SettingsCard>
+
+            <SettingsCard
+              title={t('trustedIssuers:detail.tokenExchange.title', 'Token Exchange')}
+              description={t(
+                'trustedIssuers:detail.tokenExchange.description',
+                'Exchange subject tokens from this issuer for access tokens.',
+              )}
+              enabled={values.tokenExchangeEnabled}
+              onToggle={(checked) => setField('tokenExchangeEnabled', checked)}
+            >
+              <FormControl fullWidth>
+                <FormLabel htmlFor="trusted-issuer-token-audience">
+                  {t('trustedIssuers:detail.tokenExchange.audience.label', 'Trusted token audience')}
+                </FormLabel>
+                <TextField
+                  id="trusted-issuer-token-audience"
+                  fullWidth
+                  placeholder="my-external-client-id"
+                  value={values.trustedTokenAudience ?? ''}
+                  helperText={t(
+                    'trustedIssuers:detail.tokenExchange.audience.hint',
+                    'The audience value ThunderID expects in subject tokens from this issuer.',
+                  )}
+                  onChange={(e) => setField('trustedTokenAudience', e.target.value || undefined)}
+                />
+              </FormControl>
+            </SettingsCard>
+
+            <SettingsCard
+              title={t(
+                'trustedIssuers:detail.consumption.title',
+                'Identity Assertion JWT Authorization Grant (ID-JAG)',
+              )}
+              description={t(
+                'trustedIssuers:detail.idJag.description',
+                'Accept and exchange signed identity assertions from this issuer for access tokens.',
+              )}
+              enabled={values.idJagEnabled}
+              onToggle={(checked) => setField('idJagEnabled', checked)}
+            >
+              <Typography variant="body2" color="text.secondary">
+                {t(
+                  'trustedIssuers:detail.idJag.enabledNote',
+                  'Identity assertions from this issuer are accepted via the ID-JAG protocol.',
+                )}
+              </Typography>
+            </SettingsCard>
+
+            <SettingsCard title={t('trustedIssuers:detail.dangerZone.title', 'Danger zone')}>
+              <Typography variant="h6" gutterBottom color="error">
+                {t('trustedIssuers:detail.dangerZone.delete.title', 'Delete trusted issuer')}
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{mb: 3}}>
+                {t(
+                  'trustedIssuers:detail.dangerZone.delete.description',
+                  'Applications relying on assertions from this issuer will stop receiving tokens. This cannot be undone.',
+                )}
+              </Typography>
+              <Button
+                variant="contained"
+                color="error"
+                startIcon={<Trash2 size={16} />}
+                onClick={() => setDeleteOpen(true)}
+                data-testid="trusted-issuer-delete-button"
+              >
+                {t('common:actions.delete')}
+              </Button>
+            </SettingsCard>
+          </Stack>
+
+          {dirty && (
+            <UnsavedChangesBar
+              message={t('trustedIssuers:detail.saveBar.unsaved', 'You have unsaved changes')}
+              resetLabel={t('trustedIssuers:detail.saveBar.discard', 'Discard')}
+              saveLabel={t('trustedIssuers:detail.saveBar.save', 'Save changes')}
+              savingLabel={t('common:status.saving', 'Saving...')}
+              isSaving={updateMutation.isPending}
+              saveDisabled={!valid}
+              onReset={resetEdits}
+              onSave={handleSave}
+            />
+          )}
+
+          <TrustedIssuerDeleteDialog
+            open={deleteOpen}
+            trustedIssuerId={id ?? null}
+            trustedIssuerName={data?.name ?? ''}
+            onClose={() => setDeleteOpen(false)}
+            onSuccess={() => void navigate('/connections')}
+          />
+        </>
+      )}
+    </PageContent>
+  );
+}

--- a/frontend/apps/console/src/features/trusted-issuers/pages/TrustedIssuerWizardStep.tsx
+++ b/frontend/apps/console/src/features/trusted-issuers/pages/TrustedIssuerWizardStep.tsx
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {JSX} from 'react';
+import TrustedIssuerCreateForm from '../components/TrustedIssuerCreateForm';
+
+/**
+ * The "trusted-idp" configure step plugged into the "Add custom connection" wizard (see
+ * `customConfigureSteps` on `ConnectionCreateWizardPage`). Renders the trusted-issuer create
+ * form; the wizard supplies the surrounding chrome (breadcrumb, progress, Back, close).
+ */
+export default function TrustedIssuerWizardStep(): JSX.Element {
+  return <TrustedIssuerCreateForm />;
+}

--- a/frontend/apps/console/src/features/trusted-issuers/pages/__tests__/TrustedIssuerDetailPage.test.tsx
+++ b/frontend/apps/console/src/features/trusted-issuers/pages/__tests__/TrustedIssuerDetailPage.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import userEvent from '@testing-library/user-event';
+import {render, screen} from '@thunderid/test-utils';
+import type {NavigateFunction, Params} from 'react-router';
+import {describe, it, expect, beforeEach, vi} from 'vitest';
+import type {TrustedIssuer} from '../../models/trusted-issuer';
+import TrustedIssuerDetailPage from '../TrustedIssuerDetailPage';
+
+const {mockMutate, mockRefetch} = vi.hoisted(() => ({mockMutate: vi.fn(), mockRefetch: vi.fn()}));
+
+const TRUSTED_ISSUER: TrustedIssuer = {
+  id: 'ti-1',
+  name: 'Acme Okta',
+  issuer: 'https://acme.okta.com',
+  jwksEndpoint: 'https://acme.okta.com/keys',
+  idJagEnabled: true,
+  clientId: 'thunderid-console',
+};
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return {
+    ...actual,
+    useNavigate: vi.fn(),
+    useParams: vi.fn(),
+  };
+});
+
+vi.mock('../../api/useTrustedIssuer', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('../../api/useUpdateTrustedIssuer', () => ({
+  default: () => ({mutate: mockMutate, isPending: false}),
+}));
+
+vi.mock('../../components/TrustedIssuerDeleteDialog', () => ({
+  default: function StubTrustedIssuerDeleteDialog({open, onSuccess}: {open: boolean; onSuccess?: () => void}) {
+    return open ? (
+      <div data-testid="stub-delete-dialog">
+        <button type="button" onClick={onSuccess}>
+          Simulate delete success
+        </button>
+      </div>
+    ) : null;
+  },
+}));
+
+const {useNavigate, useParams} = await import('react-router');
+const {default: useTrustedIssuer} = await import('../../api/useTrustedIssuer');
+
+describe('TrustedIssuerDetailPage', () => {
+  let mockNavigate: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockNavigate = vi.fn();
+    mockMutate.mockReset();
+    mockRefetch.mockReset();
+    vi.mocked(useNavigate).mockReturnValue(mockNavigate as unknown as NavigateFunction);
+    vi.mocked(useParams).mockReturnValue({id: 'ti-1'} as unknown as Params);
+    vi.mocked(useTrustedIssuer).mockReturnValue({
+      data: TRUSTED_ISSUER,
+      isLoading: false,
+      isError: false,
+      refetch: mockRefetch,
+    } as unknown as ReturnType<typeof useTrustedIssuer>);
+  });
+
+  it('should render the client id field with the stored value', () => {
+    render(<TrustedIssuerDetailPage />);
+
+    expect(screen.getByLabelText(/^Client ID/)).toHaveValue('thunderid-console');
+  });
+
+  it('should render the ID-JAG card title and enabled note when assertions are accepted', () => {
+    render(<TrustedIssuerDetailPage />);
+
+    expect(
+      screen.getByRole('heading', {name: 'Identity Assertion JWT Authorization Grant (ID-JAG)'}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Identity assertions from this issuer are accepted via the ID-JAG protocol.'),
+    ).toBeInTheDocument();
+  });
+
+  it('should not render capability chips next to the page title', () => {
+    render(<TrustedIssuerDetailPage />);
+
+    expect(screen.queryByText('Token exchange')).not.toBeInTheDocument();
+    expect(screen.queryByText('Inactive')).not.toBeInTheDocument();
+    expect(screen.queryByText('ID-JAG')).not.toBeInTheDocument();
+  });
+
+  it('should hide the ID-JAG enabled note when assertions are not accepted', () => {
+    vi.mocked(useTrustedIssuer).mockReturnValue({
+      data: {...TRUSTED_ISSUER, idJagEnabled: false},
+      isLoading: false,
+      isError: false,
+      refetch: mockRefetch,
+    } as unknown as ReturnType<typeof useTrustedIssuer>);
+
+    render(<TrustedIssuerDetailPage />);
+
+    expect(
+      screen.queryByText('Identity assertions from this issuer are accepted via the ID-JAG protocol.'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should show the unsaved changes bar and save the updated client id', async () => {
+    const user = userEvent.setup();
+    render(<TrustedIssuerDetailPage />);
+
+    expect(screen.queryByTestId('save-bar')).not.toBeInTheDocument();
+
+    const clientIdField = screen.getByLabelText(/^Client ID/);
+    await user.clear(clientIdField);
+    await user.type(clientIdField, 'updated-client-id');
+
+    expect(await screen.findByText('You have unsaved changes')).toBeInTheDocument();
+
+    await user.click(screen.getByText('Save changes'));
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({clientId: 'updated-client-id'}),
+      expect.any(Object),
+    );
+  });
+
+  it('should navigate back to connections when Back is clicked', async () => {
+    const user = userEvent.setup();
+    render(<TrustedIssuerDetailPage />);
+
+    await user.click(screen.getByRole('button', {name: /back to connections/i}));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/connections');
+  });
+
+  it('should navigate to connections when the trusted issuer is deleted', async () => {
+    const user = userEvent.setup();
+    render(<TrustedIssuerDetailPage />);
+
+    await user.click(screen.getByTestId('trusted-issuer-delete-button'));
+    await user.click(screen.getByRole('button', {name: /simulate delete success/i}));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/connections');
+  });
+});

--- a/frontend/apps/console/src/features/trusted-issuers/pages/__tests__/TrustedIssuerWizardStep.test.tsx
+++ b/frontend/apps/console/src/features/trusted-issuers/pages/__tests__/TrustedIssuerWizardStep.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen} from '@thunderid/test-utils';
+import {describe, expect, it, vi} from 'vitest';
+import TrustedIssuerWizardStep from '../TrustedIssuerWizardStep';
+
+vi.mock('../../components/TrustedIssuerCreateForm', () => ({
+  default: function StubTrustedIssuerCreateForm() {
+    return <div data-testid="stub-trusted-issuer-create-form" />;
+  },
+}));
+
+describe('TrustedIssuerWizardStep', () => {
+  it('should render the trusted issuer create form', () => {
+    render(<TrustedIssuerWizardStep />);
+
+    expect(screen.getByTestId('stub-trusted-issuer-create-form')).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/console/src/features/trusted-issuers/utils/__tests__/isTrustedIssuerFormDirty.test.ts
+++ b/frontend/apps/console/src/features/trusted-issuers/utils/__tests__/isTrustedIssuerFormDirty.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, it, expect} from 'vitest';
+import type {TrustedIssuerFormData} from '../../models/trusted-issuer';
+import isTrustedIssuerFormDirty from '../isTrustedIssuerFormDirty';
+
+const BASELINE: TrustedIssuerFormData = {
+  name: 'Acme Okta',
+  issuer: 'https://acme.okta.com',
+  jwksEndpoint: 'https://acme.okta.com/keys',
+  idJagEnabled: true,
+  clientId: undefined,
+  tokenExchangeEnabled: false,
+  trustedTokenAudience: undefined,
+};
+
+describe('isTrustedIssuerFormDirty', () => {
+  it('should return false when values equal the baseline', () => {
+    expect(isTrustedIssuerFormDirty({...BASELINE}, BASELINE)).toBe(false);
+  });
+
+  it('should return false when key order differs but values are equal', () => {
+    const values: TrustedIssuerFormData = {
+      trustedTokenAudience: undefined,
+      tokenExchangeEnabled: false,
+      clientId: undefined,
+      idJagEnabled: true,
+      jwksEndpoint: 'https://acme.okta.com/keys',
+      issuer: 'https://acme.okta.com',
+      name: 'Acme Okta',
+    };
+
+    expect(isTrustedIssuerFormDirty(values, BASELINE)).toBe(false);
+  });
+
+  it('should return false when clientId is an empty string and baseline is undefined', () => {
+    expect(isTrustedIssuerFormDirty({...BASELINE, clientId: ''}, BASELINE)).toBe(false);
+  });
+
+  it('should return false when trustedTokenAudience is an empty string and baseline is undefined', () => {
+    expect(isTrustedIssuerFormDirty({...BASELINE, trustedTokenAudience: ''}, BASELINE)).toBe(false);
+  });
+
+  it('should return true when name changes', () => {
+    expect(isTrustedIssuerFormDirty({...BASELINE, name: 'Beta AD'}, BASELINE)).toBe(true);
+  });
+
+  it('should return true when issuer changes', () => {
+    expect(isTrustedIssuerFormDirty({...BASELINE, issuer: 'https://beta.example.com'}, BASELINE)).toBe(true);
+  });
+
+  it('should return true when jwksEndpoint changes', () => {
+    expect(isTrustedIssuerFormDirty({...BASELINE, jwksEndpoint: 'https://beta.example.com/keys'}, BASELINE)).toBe(true);
+  });
+
+  it('should return true when idJagEnabled changes', () => {
+    expect(isTrustedIssuerFormDirty({...BASELINE, idJagEnabled: false}, BASELINE)).toBe(true);
+  });
+
+  it('should return true when clientId changes to a non-empty value', () => {
+    expect(isTrustedIssuerFormDirty({...BASELINE, clientId: 'thunderid-console'}, BASELINE)).toBe(true);
+  });
+
+  it('should return true when tokenExchangeEnabled changes', () => {
+    expect(isTrustedIssuerFormDirty({...BASELINE, tokenExchangeEnabled: true}, BASELINE)).toBe(true);
+  });
+
+  it('should return true when trustedTokenAudience changes to a non-empty value', () => {
+    expect(isTrustedIssuerFormDirty({...BASELINE, trustedTokenAudience: 'my-external-client-id'}, BASELINE)).toBe(true);
+  });
+});

--- a/frontend/apps/console/src/features/trusted-issuers/utils/__tests__/mapConnectionToTrustedIssuer.test.ts
+++ b/frontend/apps/console/src/features/trusted-issuers/utils/__tests__/mapConnectionToTrustedIssuer.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, it, expect} from 'vitest';
+import type {TrustedIssuer} from '../../models/trusted-issuer';
+import mapConnectionToTrustedIssuer from '../mapConnectionToTrustedIssuer';
+import {ConnectionTypes, type ConnectionResponse} from '@thunderid/configure-connections';
+
+const BASE_CONNECTION: ConnectionResponse = {
+  id: 'ti-1',
+  type: ConnectionTypes.OIDC,
+  name: 'Acme Okta',
+  clientId: '',
+  redirectUri: '',
+  authorizationEndpoint: '',
+  tokenEndpoint: '',
+  issuer: 'https://acme.okta.com',
+  jwksEndpoint: 'https://acme.okta.com/keys',
+  idJagEnabled: true,
+};
+
+describe('mapConnectionToTrustedIssuer', () => {
+  it('should map the client id when present on the connection', () => {
+    const result: TrustedIssuer = mapConnectionToTrustedIssuer({
+      ...BASE_CONNECTION,
+      clientId: 'thunderid-console',
+    });
+
+    expect(result.clientId).toBe('thunderid-console');
+  });
+
+  it('should default the client id when absent on the connection', () => {
+    const result: TrustedIssuer = mapConnectionToTrustedIssuer({
+      ...BASE_CONNECTION,
+      clientId: undefined,
+    } as unknown as ConnectionResponse);
+
+    expect(result.clientId).toBeUndefined();
+  });
+
+  it('should map the core trusted-issuer fields', () => {
+    const result: TrustedIssuer = mapConnectionToTrustedIssuer(BASE_CONNECTION);
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: 'ti-1',
+        name: 'Acme Okta',
+        issuer: 'https://acme.okta.com',
+        jwksEndpoint: 'https://acme.okta.com/keys',
+        idJagEnabled: true,
+      }),
+    );
+  });
+});

--- a/frontend/apps/console/src/features/trusted-issuers/utils/isTrustedIssuerFormDirty.ts
+++ b/frontend/apps/console/src/features/trusted-issuers/utils/isTrustedIssuerFormDirty.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {TrustedIssuerFormData} from '../models/trusted-issuer';
+
+/** Fields compared to detect unsaved changes, in the order they appear on the form. */
+const TRUSTED_ISSUER_FORM_FIELDS: (keyof TrustedIssuerFormData)[] = [
+  'name',
+  'issuer',
+  'jwksEndpoint',
+  'idJagEnabled',
+  'clientId',
+  'tokenExchangeEnabled',
+  'trustedTokenAudience',
+];
+
+/** Fields where the form maps an empty string to `undefined`, so the two should compare equal. */
+const EMPTY_STRING_AS_UNDEFINED_FIELDS: (keyof TrustedIssuerFormData)[] = ['clientId', 'trustedTokenAudience'];
+
+function normalize(field: keyof TrustedIssuerFormData, value: unknown): unknown {
+  if (EMPTY_STRING_AS_UNDEFINED_FIELDS.includes(field) && value === '') {
+    return undefined;
+  }
+  return value;
+}
+
+/**
+ * Whether `values` differs from `baseline` on any known trusted-issuer form field. Compares
+ * fields individually (rather than via `JSON.stringify`) so that key order and `undefined` vs.
+ * missing keys don't produce false positives.
+ */
+export default function isTrustedIssuerFormDirty(
+  values: TrustedIssuerFormData,
+  baseline: TrustedIssuerFormData,
+): boolean {
+  return TRUSTED_ISSUER_FORM_FIELDS.some(
+    (field) => normalize(field, values[field]) !== normalize(field, baseline[field]),
+  );
+}

--- a/frontend/apps/console/src/features/trusted-issuers/utils/mapConnectionToTrustedIssuer.ts
+++ b/frontend/apps/console/src/features/trusted-issuers/utils/mapConnectionToTrustedIssuer.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {TrustedIssuer} from '../models/trusted-issuer';
+import type {ConnectionResponse} from '@thunderid/configure-connections';
+
+/**
+ * Maps an OIDC connection API response to the narrower trusted-issuer shape this feature works
+ * with. `idJagEnabled` defaults to `false` for the (unreachable in practice) case where it is
+ * missing — callers are expected to have already filtered to entries where it is present.
+ */
+export default function mapConnectionToTrustedIssuer(connection: ConnectionResponse): TrustedIssuer {
+  return {
+    id: connection.id,
+    name: connection.name,
+    issuer: connection.issuer ?? '',
+    jwksEndpoint: connection.jwksEndpoint ?? '',
+    idJagEnabled: connection.idJagEnabled ?? false,
+    clientId: connection.clientId ?? undefined,
+    tokenExchangeEnabled: connection.tokenExchangeEnabled ?? false,
+    trustedTokenAudience: connection.trustedTokenAudience ?? undefined,
+  };
+}

--- a/frontend/apps/console/src/features/trusted-issuers/utils/validateTrustedIssuerForm.ts
+++ b/frontend/apps/console/src/features/trusted-issuers/utils/validateTrustedIssuerForm.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {TrustedIssuerFormData} from '../models/trusted-issuer';
+
+/** The subset of trusted-issuer fields collected via text inputs. */
+export type TrustedIssuerTextFields = Pick<TrustedIssuerFormData, 'name' | 'issuer' | 'jwksEndpoint'>;
+
+/** A validation failure reason for a single field. */
+export type TrustedIssuerFieldErrorKind = 'required' | 'url';
+
+/** Field name → failure reason, present only for invalid fields. */
+export type TrustedIssuerFormErrors = Partial<Record<keyof TrustedIssuerTextFields, TrustedIssuerFieldErrorKind>>;
+
+/** Whether a value is an absolute `https://` URL. */
+function isValidHttpsUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validate trusted-issuer form values. Name is required; issuer and JWKS endpoint are required
+ * and must be `https://` URLs. Returns a map of field name → failure reason (empty when valid).
+ */
+export default function validateTrustedIssuerForm(values: TrustedIssuerTextFields): TrustedIssuerFormErrors {
+  const errors: TrustedIssuerFormErrors = {};
+
+  if (!values.name.trim()) {
+    errors.name = 'required';
+  }
+
+  const issuer: string = values.issuer.trim();
+  if (!issuer) {
+    errors.issuer = 'required';
+  } else if (!isValidHttpsUrl(issuer)) {
+    errors.issuer = 'url';
+  }
+
+  const jwksEndpoint: string = values.jwksEndpoint.trim();
+  if (!jwksEndpoint) {
+    errors.jwksEndpoint = 'required';
+  } else if (!isValidHttpsUrl(jwksEndpoint)) {
+    errors.jwksEndpoint = 'url';
+  }
+
+  return errors;
+}

--- a/frontend/packages/configure-connections/src/components/ConnectionForm.tsx
+++ b/frontend/packages/configure-connections/src/components/ConnectionForm.tsx
@@ -16,7 +16,18 @@
  * under the License.
  */
 
-import {Box, FormControl, FormLabel, Stack, TextField, Typography} from '@wso2/oxygen-ui';
+import {
+  Box,
+  Collapse,
+  Divider,
+  FormControl,
+  FormControlLabel,
+  FormLabel,
+  Stack,
+  Switch,
+  TextField,
+  Typography,
+} from '@wso2/oxygen-ui';
 import {type JSX, type ReactNode, useMemo, useState} from 'react';
 import {Trans, useTranslation} from 'react-i18next';
 import MaskedSecretField from './MaskedSecretField';
@@ -88,6 +99,11 @@ export default function ConnectionForm({
     return undefined;
   };
 
+  const isRequiredNow = (field: ConnectionFieldDef): boolean => {
+    const requiredWhen: string | undefined = field.requiredWhen;
+    return Boolean(field.required) || (requiredWhen !== undefined && values[requiredWhen] === 'true');
+  };
+
   // Render a hint, resolving inline <code> markup in the translation to a styled code element.
   const renderHint = (hintKey: string): ReactNode => (
     <Trans
@@ -115,11 +131,33 @@ export default function ConnectionForm({
     <Stack direction="column" spacing={3} data-testid="connection-form">
       {fields.map((field) => {
         const label: string = t(field.labelKey);
+        const visible: boolean = !field.revealedBy || values[field.revealedBy] === 'true';
 
-        if (field.kind === 'secret') {
-          return (
+        let fieldContent: ReactNode;
+
+        if (field.kind === 'switch') {
+          fieldContent = (
+            <Box>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={values[field.name] === 'true'}
+                    onChange={(e) => setField(field.name, e.target.checked ? 'true' : 'false')}
+                    slotProps={{input: {'aria-label': label, role: 'switch'}}}
+                  />
+                }
+                label={<Typography variant="subtitle2">{label}</Typography>}
+              />
+              {field.hintKey && (
+                <Typography variant="caption" color="text.secondary" sx={{display: 'block', ml: '52px'}}>
+                  {t(field.hintKey)}
+                </Typography>
+              )}
+            </Box>
+          );
+        } else if (field.kind === 'secret') {
+          fieldContent = (
             <MaskedSecretField
-              key={field.name}
               id={`connection-field-${field.name}`}
               label={label}
               value={values[field.name] ?? ''}
@@ -132,12 +170,9 @@ export default function ConnectionForm({
               hint={field.hintKey ? t(field.hintKey) : undefined}
             />
           );
-        }
-
-        if (field.kind === 'readonly-copy') {
-          return (
+        } else if (field.kind === 'readonly-copy') {
+          fieldContent = (
             <ReadOnlyCopyField
-              key={field.name}
               id={`connection-field-${field.name}`}
               label={label}
               value={values[field.name] ?? ''}
@@ -148,30 +183,51 @@ export default function ConnectionForm({
               }
             />
           );
+        } else {
+          const error: string | undefined = fieldError(field.name);
+          const required: boolean = isRequiredNow(field);
+          fieldContent = (
+            <FormControl fullWidth required={required} error={Boolean(error)}>
+              <FormLabel htmlFor={`connection-field-${field.name}`}>
+                {label}
+                {field.optional && !required && (
+                  <Typography component="span" variant="caption" color="text.secondary" sx={{ml: 1}}>
+                    {t('form.optional')}
+                  </Typography>
+                )}
+              </FormLabel>
+              <TextField
+                id={`connection-field-${field.name}`}
+                fullWidth
+                value={values[field.name] ?? ''}
+                placeholder={field.placeholder}
+                error={Boolean(error)}
+                helperText={error ?? (field.hintKey ? renderHint(field.hintKey) : undefined)}
+                onChange={(e) => setField(field.name, e.target.value)}
+                onBlur={() => setTouched((prev) => ({...prev, [field.name]: true}))}
+              />
+            </FormControl>
+          );
         }
 
-        const error: string | undefined = fieldError(field.name);
         return (
-          <FormControl key={field.name} fullWidth required={field.required} error={Boolean(error)}>
-            <FormLabel htmlFor={`connection-field-${field.name}`}>
-              {label}
-              {field.optional && (
-                <Typography component="span" variant="caption" color="text.secondary" sx={{ml: 1}}>
-                  {t('form.optional')}
+          <Box key={field.name}>
+            {field.section && (
+              <Box>
+                <Divider sx={{mt: 3, mb: 2}} />
+                <Typography variant="subtitle2" component="h3">
+                  {t(field.section)}
                 </Typography>
-              )}
-            </FormLabel>
-            <TextField
-              id={`connection-field-${field.name}`}
-              fullWidth
-              value={values[field.name] ?? ''}
-              placeholder={field.placeholder}
-              error={Boolean(error)}
-              helperText={error ?? (field.hintKey ? renderHint(field.hintKey) : undefined)}
-              onChange={(e) => setField(field.name, e.target.value)}
-              onBlur={() => setTouched((prev) => ({...prev, [field.name]: true}))}
-            />
-          </FormControl>
+              </Box>
+            )}
+            {field.revealedBy ? (
+              <Collapse in={visible} timeout="auto" unmountOnExit>
+                <Box sx={{mt: 3}}>{fieldContent}</Box>
+              </Collapse>
+            ) : (
+              fieldContent
+            )}
+          </Box>
         );
       })}
     </Stack>

--- a/frontend/packages/configure-connections/src/components/__tests__/ConnectionForm.test.tsx
+++ b/frontend/packages/configure-connections/src/components/__tests__/ConnectionForm.test.tsx
@@ -33,6 +33,11 @@ function getConnectionField(id: string): HTMLElement {
   return field;
 }
 
+function isFieldMarkedRequired(id: string): boolean {
+  const label = document.querySelector(`label[for="connection-field-${id}"]`);
+  return Boolean(label?.querySelector('.MuiFormLabel-asterisk'));
+}
+
 describe('ConnectionForm', () => {
   const baseProps = {
     type: 'google' as const,
@@ -83,5 +88,76 @@ describe('ConnectionForm', () => {
     fireEvent.change(input, {target: {value: 'https://gate.example.com/gate/callback'}});
 
     expect(onFieldChange).toHaveBeenCalledWith('redirectUri', 'https://gate.example.com/gate/callback');
+  });
+
+  describe('OIDC federation fields', () => {
+    const oidcProps = {
+      ...baseProps,
+      type: 'oidc' as const,
+      values: {
+        name: '',
+        clientId: '',
+        clientSecret: '',
+        authorizationEndpoint: '',
+        tokenEndpoint: '',
+        issuer: '',
+        userInfoEndpoint: '',
+        jwksEndpoint: '',
+        redirectUri: 'https://id.acme.io/oauth/callback/oidc',
+        scopes: '',
+        tokenExchangeEnabled: 'false',
+        trustedTokenAudience: '',
+      },
+    };
+
+    it('renders the Federation section heading above the tokenExchangeEnabled field', () => {
+      render(<ConnectionForm {...oidcProps} />);
+
+      expect(screen.getByRole('heading', {name: 'Federation'})).toBeInTheDocument();
+    });
+
+    it('renders a switch for the tokenExchangeEnabled field', () => {
+      render(<ConnectionForm {...oidcProps} />);
+
+      const toggle = screen.getByRole('switch', {name: 'Enable token exchange'});
+      expect(toggle).toBeInTheDocument();
+      expect(toggle).not.toBeChecked();
+    });
+
+    it('reports the switch toggle through onFieldChange as a "true"/"false" string', () => {
+      const onFieldChange = vi.fn();
+      render(<ConnectionForm {...oidcProps} onFieldChange={onFieldChange} />);
+
+      const toggle = screen.getByRole('switch', {name: 'Enable token exchange'});
+      fireEvent.click(toggle);
+
+      expect(onFieldChange).toHaveBeenCalledWith('tokenExchangeEnabled', 'true');
+    });
+
+    it('hides trustedTokenAudience when tokenExchangeEnabled is off', () => {
+      render(<ConnectionForm {...oidcProps} />);
+
+      expect(document.getElementById('connection-field-trustedTokenAudience')).not.toBeInTheDocument();
+    });
+
+    it('shows trustedTokenAudience when tokenExchangeEnabled is on', () => {
+      render(<ConnectionForm {...oidcProps} values={{...oidcProps.values, tokenExchangeEnabled: 'true'}} />);
+
+      expect(document.getElementById('connection-field-trustedTokenAudience')).toBeInTheDocument();
+    });
+
+    it('does not mark issuer/jwksEndpoint required when tokenExchangeEnabled is off', () => {
+      render(<ConnectionForm {...oidcProps} />);
+
+      expect(isFieldMarkedRequired('issuer')).toBe(false);
+      expect(isFieldMarkedRequired('jwksEndpoint')).toBe(false);
+    });
+
+    it('marks issuer/jwksEndpoint required when tokenExchangeEnabled is on', () => {
+      render(<ConnectionForm {...oidcProps} values={{...oidcProps.values, tokenExchangeEnabled: 'true'}} />);
+
+      expect(isFieldMarkedRequired('issuer')).toBe(true);
+      expect(isFieldMarkedRequired('jwksEndpoint')).toBe(true);
+    });
   });
 });

--- a/frontend/packages/configure-connections/src/components/create-connection/SelectConnectionType.tsx
+++ b/frontend/packages/configure-connections/src/components/create-connection/SelectConnectionType.tsx
@@ -17,30 +17,51 @@
  */
 
 import {Box, Card, CardActionArea, CardContent, Chip, Stack, Typography} from '@wso2/oxygen-ui';
-import {CircleCheck, KeyRound, LogIn, Send, ShieldCheck, Webhook} from '@wso2/oxygen-ui-icons-react';
+import {ArrowLeftRight, CircleCheck, KeyRound, LogIn, Send, ShieldCheck, Webhook} from '@wso2/oxygen-ui-icons-react';
 import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {type ConnectionType, ConnectionTypes} from '../../models/connection';
 
+/**
+ * Selectable option in the "Add custom connection" wizard's type step. `'trusted-idp'` is a
+ * UI-only pseudo-type (not a backend /connections vendor route) for configuring a trust-only
+ * OIDC connection through the dedicated trusted-issuer form rather than the generic
+ * `ConnectionForm`.
+ */
+export type SelectableConnectionType = ConnectionType | 'trusted-idp';
+
 interface SelectConnectionTypeProps {
-  selectedType: ConnectionType | null;
-  onSelect: (type: ConnectionType) => void;
+  selectedType: SelectableConnectionType | null;
+  onSelect: (type: SelectableConnectionType) => void;
+  /**
+   * Keys with a wired `customConfigureSteps` slot on the parent wizard (see
+   * `ConnectionCreateWizardPage`). Options that require a custom configure step (e.g.
+   * `'trusted-idp'`) are only rendered when their key is present here — the package can't let a
+   * consumer select a type it has no way to complete.
+   */
+  customTypes?: string[];
 }
 
 interface TypeOption {
-  type: ConnectionType;
+  type: SelectableConnectionType;
   labelKey: string;
   descriptionKey: string;
   tagKey: string;
   icon: JSX.Element;
   tagIcon: JSX.Element;
   comingSoon: boolean;
+  /** Whether this option only works when the consumer supplies a matching `customConfigureSteps` entry. */
+  requiresCustomStep?: boolean;
 }
 
-export default function SelectConnectionType({selectedType, onSelect}: SelectConnectionTypeProps): JSX.Element {
+export default function SelectConnectionType({
+  selectedType,
+  onSelect,
+  customTypes = [],
+}: SelectConnectionTypeProps): JSX.Element {
   const {t} = useTranslation('connections');
 
-  const options: TypeOption[] = [
+  const allOptions: TypeOption[] = [
     {
       type: ConnectionTypes.OIDC,
       labelKey: 'wizard.type.oidc.label',
@@ -60,6 +81,16 @@ export default function SelectConnectionType({selectedType, onSelect}: SelectCon
       comingSoon: false,
     },
     {
+      type: 'trusted-idp',
+      labelKey: 'wizard.type.trustedIdp.label',
+      descriptionKey: 'wizard.type.trustedIdp.description',
+      tagKey: 'wizard.type.trustedIdp.tag',
+      icon: <ShieldCheck size={28} />,
+      tagIcon: <ArrowLeftRight size={14} />,
+      comingSoon: false,
+      requiresCustomStep: true,
+    },
+    {
       // FE-only placeholder; the backend SMS provider API is not wired yet.
       type: 'custom-sms' as ConnectionType,
       labelKey: 'wizard.type.sms.label',
@@ -70,6 +101,9 @@ export default function SelectConnectionType({selectedType, onSelect}: SelectCon
       comingSoon: true,
     },
   ];
+  const options: TypeOption[] = allOptions.filter(
+    (option) => !option.requiresCustomStep || customTypes.includes(option.type),
+  );
 
   return (
     <Stack direction="column" spacing={1} data-testid="select-connection-type">

--- a/frontend/packages/configure-connections/src/components/create-connection/__tests__/SelectConnectionType.test.tsx
+++ b/frontend/packages/configure-connections/src/components/create-connection/__tests__/SelectConnectionType.test.tsx
@@ -24,13 +24,19 @@ describe('SelectConnectionType', () => {
   const onSelect = vi.fn();
   beforeEach(() => vi.clearAllMocks());
 
-  it('renders the OIDC, OAuth2, and SMS gateway options', () => {
+  it('renders the OIDC, OAuth2, and SMS gateway options without a trusted-idp card by default', () => {
     render(<SelectConnectionType selectedType={null} onSelect={onSelect} />);
     expect(screen.getByText('What kind of connection do you want to add?')).toBeInTheDocument();
     expect(screen.queryByText('Connection type')).not.toBeInTheDocument();
     expect(screen.getByTestId('connection-type-option-oidc')).toBeInTheDocument();
     expect(screen.getByTestId('connection-type-option-oauth')).toBeInTheDocument();
     expect(screen.getByTestId('connection-type-option-custom-sms')).toBeInTheDocument();
+    expect(screen.queryByTestId('connection-type-option-trusted-idp')).not.toBeInTheDocument();
+  });
+
+  it('renders the Trusted Token Issuer option only when its key is in customTypes', () => {
+    render(<SelectConnectionType selectedType={null} onSelect={onSelect} customTypes={['trusted-idp']} />);
+    expect(screen.getByTestId('connection-type-option-trusted-idp')).toBeInTheDocument();
   });
 
   it('selects the OIDC type when clicked', () => {
@@ -49,5 +55,20 @@ describe('SelectConnectionType', () => {
     render(<SelectConnectionType selectedType={null} onSelect={onSelect} />);
     fireEvent.click(screen.getByTestId('connection-type-option-custom-sms'));
     expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('selects the Trusted Token Issuer type when clicked', () => {
+    render(<SelectConnectionType selectedType={null} onSelect={onSelect} customTypes={['trusted-idp']} />);
+    fireEvent.click(screen.getByTestId('connection-type-option-trusted-idp'));
+    expect(onSelect).toHaveBeenCalledWith('trusted-idp');
+  });
+
+  it('renders the Trusted Token Issuer option before the coming-soon SMS gateway option', () => {
+    render(<SelectConnectionType selectedType={null} onSelect={onSelect} customTypes={['trusted-idp']} />);
+
+    const optionIds = screen.getAllByTestId(/^connection-type-option-/).map((el) => el.getAttribute('data-testid'));
+    expect(optionIds.indexOf('connection-type-option-trusted-idp')).toBeLessThan(
+      optionIds.indexOf('connection-type-option-custom-sms'),
+    );
   });
 });

--- a/frontend/packages/configure-connections/src/config/connectionFormFields.ts
+++ b/frontend/packages/configure-connections/src/config/connectionFormFields.ts
@@ -18,7 +18,7 @@
 
 import {type ConnectionType, ConnectionTypes} from '../models/connection';
 
-export type ConnectionFieldKind = 'text' | 'url' | 'secret' | 'scopes' | 'readonly-copy';
+export type ConnectionFieldKind = 'text' | 'url' | 'secret' | 'scopes' | 'readonly-copy' | 'switch';
 
 export interface ConnectionFieldDef {
   /** Request payload property this field maps to. */
@@ -36,6 +36,12 @@ export interface ConnectionFieldDef {
   pattern?: RegExp;
   /** i18n key for the error shown when {@link pattern} does not match. */
   patternErrorKey?: string;
+  /** i18n key for a group sub-heading rendered above this field. */
+  section?: string;
+  /** Renders only when the named switch field's value is truthy. */
+  revealedBy?: string;
+  /** Becomes required when the named switch field's value is truthy. */
+  requiredWhen?: string;
 }
 
 const NAME_FIELD = (placeholder: string): ConnectionFieldDef => ({
@@ -81,6 +87,14 @@ const oauthFields = (namePlaceholder: string, clientIdPlaceholder: string): Conn
   },
 ];
 
+const TOKEN_EXCHANGE_ENABLED_FIELD: ConnectionFieldDef = {
+  name: 'tokenExchangeEnabled',
+  labelKey: 'connections:form.fields.tokenExchangeEnabled.label',
+  hintKey: 'connections:form.fields.tokenExchangeEnabled.hint',
+  kind: 'switch',
+  section: 'connections:form.sections.federation',
+};
+
 const TRUSTED_TOKEN_AUDIENCE_FIELD: ConnectionFieldDef = {
   name: 'trustedTokenAudience',
   labelKey: 'connections:form.fields.trustedTokenAudience.label',
@@ -88,6 +102,7 @@ const TRUSTED_TOKEN_AUDIENCE_FIELD: ConnectionFieldDef = {
   kind: 'text',
   optional: true,
   placeholder: 'my-external-client-id',
+  revealedBy: 'tokenExchangeEnabled',
 };
 
 /**
@@ -136,6 +151,7 @@ export const CONNECTION_FORM_FIELDS: Record<ConnectionType, ConnectionFieldDef[]
       hintKey: 'connections:form.fields.issuer.hint',
       kind: 'url',
       placeholder: 'https://idp.example.com',
+      requiredWhen: 'tokenExchangeEnabled',
     },
     {
       name: 'userInfoEndpoint',
@@ -152,6 +168,7 @@ export const CONNECTION_FORM_FIELDS: Record<ConnectionType, ConnectionFieldDef[]
       kind: 'url',
       optional: true,
       placeholder: 'https://idp.example.com/.well-known/jwks.json',
+      requiredWhen: 'tokenExchangeEnabled',
     },
     {
       name: 'redirectUri',
@@ -168,6 +185,7 @@ export const CONNECTION_FORM_FIELDS: Record<ConnectionType, ConnectionFieldDef[]
       kind: 'scopes',
       placeholder: 'openid email profile',
     },
+    TOKEN_EXCHANGE_ENABLED_FIELD,
     TRUSTED_TOKEN_AUDIENCE_FIELD,
   ],
   [ConnectionTypes.OAUTH]: [

--- a/frontend/packages/configure-connections/src/config/connectionVendorMeta.tsx
+++ b/frontend/packages/configure-connections/src/config/connectionVendorMeta.tsx
@@ -90,9 +90,14 @@ export const CONNECTION_VENDOR_META: ConnectionVendorMeta[] = [
 /**
  * Categories actually represented by the vendor catalog, in display order. Drives the listing
  * filter chips so categories with no connections (e.g. Email, CRM) are not shown.
+ *
+ * `trusted-idp` is always included even though it has no vendor catalog entry — trusted issuer
+ * cards are synthesized directly from connection instances by `buildConnectionCards`, not from
+ * `CONNECTION_VENDOR_META`.
  */
-export const AVAILABLE_CONNECTION_CATEGORIES: ConnectionCategory[] = CONNECTION_CATEGORIES.filter((category) =>
-  CONNECTION_VENDOR_META.some((vendor) => vendor.categories.includes(category)),
+export const AVAILABLE_CONNECTION_CATEGORIES: ConnectionCategory[] = CONNECTION_CATEGORIES.filter(
+  (category) =>
+    category === 'trusted-idp' || CONNECTION_VENDOR_META.some((vendor) => vendor.categories.includes(category)),
 );
 
 /**

--- a/frontend/packages/configure-connections/src/constants/connection-categories.ts
+++ b/frontend/packages/configure-connections/src/constants/connection-categories.ts
@@ -30,4 +30,5 @@ export const CONNECTION_CATEGORIES: ConnectionCategory[] = [
   'identity-verification',
   'crm',
   'data-store',
+  'trusted-idp',
 ];

--- a/frontend/packages/configure-connections/src/models/connection.ts
+++ b/frontend/packages/configure-connections/src/models/connection.ts
@@ -34,6 +34,8 @@ export type ConnectionType = (typeof ConnectionTypes)[keyof typeof ConnectionTyp
 
 /**
  * Presentation categories owned entirely by the frontend (drive filter chips + card tags).
+ * `trusted-idp` is synthesized directly from connection instances (not a vendor catalog entry)
+ * — see `buildConnectionCards`.
  */
 export type ConnectionCategory =
   | 'social-login'
@@ -42,7 +44,8 @@ export type ConnectionCategory =
   | 'email'
   | 'identity-verification'
   | 'crm'
-  | 'data-store';
+  | 'data-store'
+  | 'trusted-idp';
 
 /**
  * Functional categories served by the backend /connections?category= filter.
@@ -70,6 +73,12 @@ export interface ConnectionInstance {
   description?: string;
   type: ConnectionInstanceType;
   categories: ConnectionInstanceCategory[];
+  /**
+   * Present only for trust-only OIDC instances (trusted issuers); absent for plain federation
+   * OIDC connections. See `buildConnectionCards`, which uses this to render trusted issuers as
+   * their own card variant.
+   */
+  idJagEnabled?: boolean;
 }
 
 /**
@@ -197,6 +206,8 @@ export interface OIDCConnectionRequest extends OAuthConnectionRequest {
   issuer?: string;
   tokenExchangeEnabled?: boolean;
   trustedTokenAudience?: string;
+  /** Whether this connection is exposed as an ID-JAG issuer. Managed by the Trusted Issuers feature. */
+  idJagEnabled?: boolean;
 }
 
 /**

--- a/frontend/packages/configure-connections/src/pages/ConnectionCreateWizardPage.tsx
+++ b/frontend/packages/configure-connections/src/pages/ConnectionCreateWizardPage.tsx
@@ -19,13 +19,15 @@
 import {useConfig} from '@thunderid/contexts';
 import {AppBreadcrumbs, Box, Button, Paper, Stack, Typography} from '@wso2/oxygen-ui';
 import {ChevronLeft} from '@wso2/oxygen-ui-icons-react';
-import {type JSX, useMemo, useState} from 'react';
+import {type JSX, type ReactNode, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
 import useCreateConnection from '../api/useCreateConnection';
 import ConnectionForm from '../components/ConnectionForm';
 import ConnectionFullPageLayout from '../components/ConnectionFullPageLayout';
-import SelectConnectionType from '../components/create-connection/SelectConnectionType';
+import SelectConnectionType, {
+  type SelectableConnectionType,
+} from '../components/create-connection/SelectConnectionType';
 import {CONNECTION_FORM_FIELDS} from '../config/connectionFormFields';
 import {VENDOR_META_BY_TYPE} from '../config/connectionVendorMeta';
 import {type ConnectionResponse, type ConnectionType, ConnectionTypes} from '../models/connection';
@@ -41,23 +43,42 @@ const Step = {TYPE: 'TYPE', CONFIGURE: 'CONFIGURE'} as const;
 type Step = (typeof Step)[keyof typeof Step];
 const ALL_STEPS: Step[] = [Step.TYPE, Step.CONFIGURE];
 
+interface ConnectionCreateWizardPageProps {
+  /**
+   * Renders a fully custom configure step (step 2) for the given selectable-type key instead of
+   * the generic `ConnectionForm` + create button — e.g. a UI-only pseudo-type like
+   * `'trusted-idp'` that has no backend /connections vendor route of its own. The supplied node
+   * owns its own submit action; the wizard still provides the chrome (breadcrumb, progress,
+   * Back, and the X close button).
+   */
+  customConfigureSteps?: Record<string, ReactNode>;
+}
+
 /**
  * Two-step full-screen wizard for adding a custom connection: pick the type, then enter the
- * credentials/endpoints (with a connection name) and create it.
+ * credentials/endpoints (with a connection name) and create it. A type can opt out of the
+ * generic configure step via `customConfigureSteps`.
  */
-export default function ConnectionCreateWizardPage(): JSX.Element {
+export default function ConnectionCreateWizardPage({
+  customConfigureSteps = undefined,
+}: ConnectionCreateWizardPageProps): JSX.Element {
   const {t} = useTranslation('connections');
   const navigate = useNavigate();
   const {getServerUrl} = useConfig();
 
   const [step, setStep] = useState<Step>(Step.TYPE);
-  const [selectedType, setSelectedType] = useState<ConnectionType | null>(null);
+  const [selectedType, setSelectedType] = useState<SelectableConnectionType | null>(null);
   const [editedValues, setEditedValues] = useState<ConnectionFormValues>({});
   const [nameError, setNameError] = useState<string | null>(null);
 
+  const customStep: ReactNode | undefined = selectedType ? customConfigureSteps?.[selectedType] : undefined;
+  const customTypes: string[] = useMemo(() => Object.keys(customConfigureSteps ?? {}), [customConfigureSteps]);
+
   // Defaults to OIDC before the user picks a type on the first step; the SMS placeholder is
-  // disabled and unselectable, so once chosen selectedType is always a wired connection type.
-  const activeType: ConnectionType = selectedType ?? ConnectionTypes.OIDC;
+  // disabled and unselectable, and pseudo-types render via `customStep` instead, so this is only
+  // read when rendering the generic configure step.
+  const activeType: ConnectionType =
+    selectedType && selectedType !== 'trusted-idp' ? selectedType : ConnectionTypes.OIDC;
   const createMutation = useCreateConnection(activeType);
   const meta = VENDOR_META_BY_TYPE[activeType];
   const fields = CONNECTION_FORM_FIELDS[activeType];
@@ -105,7 +126,7 @@ export default function ConnectionCreateWizardPage(): JSX.Element {
     >
       {step === Step.TYPE && (
         <>
-          <SelectConnectionType selectedType={selectedType} onSelect={setSelectedType} />
+          <SelectConnectionType selectedType={selectedType} onSelect={setSelectedType} customTypes={customTypes} />
           <Box sx={{mt: 4, display: 'flex', justifyContent: 'flex-end'}}>
             <Button
               variant="contained"
@@ -119,7 +140,19 @@ export default function ConnectionCreateWizardPage(): JSX.Element {
         </>
       )}
 
-      {step === Step.CONFIGURE && (
+      {step === Step.CONFIGURE && customStep && (
+        <Stack direction="column" spacing={3}>
+          {customStep}
+
+          <Box sx={{display: 'flex', justifyContent: 'flex-start'}}>
+            <Button variant="outlined" startIcon={<ChevronLeft size={16} />} onClick={() => setStep(Step.TYPE)}>
+              {t('common:actions.back')}
+            </Button>
+          </Box>
+        </Stack>
+      )}
+
+      {step === Step.CONFIGURE && !customStep && (
         <Stack direction="column" spacing={3}>
           <Stack direction="column" spacing={1}>
             <Typography variant="h4" fontWeight={700}>

--- a/frontend/packages/configure-connections/src/pages/__tests__/ConnectionCreateWizardPage.test.tsx
+++ b/frontend/packages/configure-connections/src/pages/__tests__/ConnectionCreateWizardPage.test.tsx
@@ -101,4 +101,49 @@ describe('ConnectionCreateWizardPage', () => {
 
     expect(navigateMock).toHaveBeenCalledWith('/connections/oidc/conn-1');
   });
+
+  it('renders a custom configure step instead of the generic ConnectionForm for a type with a slot', () => {
+    render(<ConnectionCreateWizardPage customConfigureSteps={{'trusted-idp': <div data-testid="custom-step" />}} />);
+
+    fireEvent.click(screen.getByTestId('connection-type-option-trusted-idp'));
+    fireEvent.click(screen.getByTestId('wizard-continue'));
+
+    expect(screen.getByTestId('custom-step')).toBeInTheDocument();
+    expect(screen.queryByTestId('stub-connection-form')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('wizard-create')).not.toBeInTheDocument();
+  });
+
+  it('returns to the type step when Back is clicked from a custom configure step', () => {
+    render(<ConnectionCreateWizardPage customConfigureSteps={{'trusted-idp': <div data-testid="custom-step" />}} />);
+
+    fireEvent.click(screen.getByTestId('connection-type-option-trusted-idp'));
+    fireEvent.click(screen.getByTestId('wizard-continue'));
+    fireEvent.click(screen.getByRole('button', {name: /back/i}));
+
+    expect(screen.getByText('What kind of connection do you want to add?')).toBeInTheDocument();
+  });
+
+  it('renders the generic ConnectionForm for a type with no custom configure step', () => {
+    render(<ConnectionCreateWizardPage customConfigureSteps={{'trusted-idp': <div data-testid="custom-step" />}} />);
+
+    fireEvent.click(screen.getByTestId('connection-type-option-oidc'));
+    fireEvent.click(screen.getByTestId('wizard-continue'));
+
+    expect(screen.getByTestId('stub-connection-form')).toBeInTheDocument();
+    expect(screen.queryByTestId('custom-step')).not.toBeInTheDocument();
+  });
+
+  it('shows three type cards and no trusted-idp card without customConfigureSteps', () => {
+    render(<ConnectionCreateWizardPage />);
+
+    expect(screen.getAllByTestId(/^connection-type-option-/)).toHaveLength(3);
+    expect(screen.queryByTestId('connection-type-option-trusted-idp')).not.toBeInTheDocument();
+  });
+
+  it('shows four type cards including trusted-idp when its customConfigureSteps slot is wired', () => {
+    render(<ConnectionCreateWizardPage customConfigureSteps={{'trusted-idp': <div data-testid="custom-step" />}} />);
+
+    expect(screen.getAllByTestId(/^connection-type-option-/)).toHaveLength(4);
+    expect(screen.getByTestId('connection-type-option-trusted-idp')).toBeInTheDocument();
+  });
 });

--- a/frontend/packages/configure-connections/src/utils/__tests__/buildConnectionCards.test.ts
+++ b/frontend/packages/configure-connections/src/utils/__tests__/buildConnectionCards.test.ts
@@ -144,4 +144,61 @@ describe('buildConnectionCards', () => {
     const keys = cards.map((c) => c.vendorKey);
     expect(keys).toEqual(['google', 'github', 'twilio']);
   });
+
+  it('renders an OIDC instance with idJagEnabled as a trusted-idp card, not a plain oidc card', () => {
+    const instances: ConnectionInstance[] = [
+      {id: 't1', name: 'Acme Okta', type: 'oidc', categories: ['identity-provider'], idJagEnabled: true},
+    ];
+    const cards = buildConnectionCards(instances, VENDORS);
+
+    expect(cards.filter((c) => c.vendorKey === 'oidc')).toHaveLength(0);
+    const trustedIdpCard = cards.find((c) => c.vendorKey === 'trusted-idp');
+    expect(trustedIdpCard).toMatchObject({
+      id: 'trusted-idp:t1',
+      displayName: 'Acme Okta',
+      status: 'configured',
+      comingSoon: false,
+      navTarget: '/trusted-issuers/t1',
+      categories: ['trusted-idp'],
+    });
+  });
+
+  it('renders an OIDC instance with idJagEnabled: false as a trusted-idp card', () => {
+    const instances: ConnectionInstance[] = [
+      {id: 't2', name: 'Disabled Trust', type: 'oidc', categories: ['identity-provider'], idJagEnabled: false},
+    ];
+    const cards = buildConnectionCards(instances, VENDORS);
+
+    const trustedIdpCard = cards.find((c) => c.vendorKey === 'trusted-idp');
+    expect(trustedIdpCard).toMatchObject({navTarget: '/trusted-issuers/t2'});
+  });
+
+  it('renders a plain OIDC instance without idJagEnabled as the normal oidc card, unchanged', () => {
+    const instances: ConnectionInstance[] = [
+      {id: 'f1', name: 'Federation OIDC', type: 'oidc', categories: ['identity-provider']},
+    ];
+    const cards = buildConnectionCards(instances, VENDORS);
+
+    expect(cards.some((c) => c.vendorKey === 'trusted-idp')).toBe(false);
+    const oidcCard = cards.find((c) => c.vendorKey === 'oidc');
+    expect(oidcCard).toMatchObject({
+      displayName: 'Federation OIDC',
+      navTarget: '/connections/oidc/f1',
+    });
+  });
+
+  it('renders a non-OIDC instance with idJagEnabled as its normal vendor card, not a trusted-idp card', () => {
+    const instances: ConnectionInstance[] = [
+      {id: 'g1', name: 'Corp Google', type: 'google', categories: ['identity-provider'], idJagEnabled: true},
+    ];
+    const cards = buildConnectionCards(instances, VENDORS);
+
+    expect(cards.some((c) => c.vendorKey === 'trusted-idp')).toBe(false);
+    const googleCard = cards.find((c) => c.vendorKey === 'google');
+    expect(googleCard).toMatchObject({
+      id: 'google:g1',
+      displayName: 'Corp Google',
+      navTarget: '/connections/google/g1',
+    });
+  });
 });

--- a/frontend/packages/configure-connections/src/utils/__tests__/connectionFormMapping.test.ts
+++ b/frontend/packages/configure-connections/src/utils/__tests__/connectionFormMapping.test.ts
@@ -17,7 +17,7 @@
  */
 
 import {describe, expect, it} from 'vitest';
-import {CONNECTION_FORM_FIELDS} from '../../config/connectionFormFields';
+import {CONNECTION_FORM_FIELDS, type ConnectionFieldDef} from '../../config/connectionFormFields';
 import type {ConnectionResponse} from '../../models/connection';
 import {
   emptyFormValues,
@@ -66,6 +66,26 @@ describe('responseToFormValues', () => {
     const response = {id: '1', type: 'google', name: 'X', clientId: 'y'} as ConnectionResponse;
     const values = responseToFormValues(response, GOOGLE_FIELDS, REDIRECT);
     expect(values.redirectUri).toBe(REDIRECT);
+  });
+
+  it('converts a boolean tokenExchangeEnabled into a "true"/"false" form string', () => {
+    const enabled = {
+      id: '1',
+      type: 'oidc',
+      name: 'X',
+      clientId: 'y',
+      tokenExchangeEnabled: true,
+    } as ConnectionResponse;
+    expect(responseToFormValues(enabled, OIDC_FIELDS, REDIRECT).tokenExchangeEnabled).toBe('true');
+
+    const disabled = {
+      id: '1',
+      type: 'oidc',
+      name: 'X',
+      clientId: 'y',
+      tokenExchangeEnabled: false,
+    } as ConnectionResponse;
+    expect(responseToFormValues(disabled, OIDC_FIELDS, REDIRECT).tokenExchangeEnabled).toBe('false');
   });
 });
 
@@ -124,6 +144,35 @@ describe('formValuesToRequest', () => {
       secretReplaced: true,
     }) as unknown as Record<string, unknown>;
     expect(payload).not.toHaveProperty('clientSecret');
+  });
+
+  it('emits a boolean tokenExchangeEnabled instead of the raw string form value', () => {
+    const payload = formValuesToRequest(
+      {
+        ...base,
+        authorizationEndpoint: 'https://i/a',
+        tokenEndpoint: 'https://i/t',
+        tokenExchangeEnabled: 'true',
+      },
+      OIDC_FIELDS,
+      {mode: 'create'},
+    ) as unknown as Record<string, unknown>;
+    expect(payload.tokenExchangeEnabled).toBe(true);
+    expect(typeof payload.tokenExchangeEnabled).toBe('boolean');
+  });
+
+  it('emits tokenExchangeEnabled as false when the switch is off', () => {
+    const payload = formValuesToRequest(
+      {
+        ...base,
+        authorizationEndpoint: 'https://i/a',
+        tokenEndpoint: 'https://i/t',
+        tokenExchangeEnabled: 'false',
+      },
+      OIDC_FIELDS,
+      {mode: 'create'},
+    ) as unknown as Record<string, unknown>;
+    expect(payload.tokenExchangeEnabled).toBe(false);
   });
 
   it('omits empty optional fields but keeps required ones', () => {
@@ -220,5 +269,39 @@ describe('validateConnectionForm', () => {
       'create',
     );
     expect(errors.accountSid).toBe('connections:validation.required');
+  });
+
+  it('requires issuer and jwksEndpoint only when tokenExchangeEnabled is on', () => {
+    const base = {
+      name: 'n',
+      clientId: 'c',
+      clientSecret: 's',
+      redirectUri: REDIRECT,
+      authorizationEndpoint: 'https://i/a',
+      tokenEndpoint: 'https://i/t',
+      issuer: '',
+      jwksEndpoint: '',
+    };
+
+    const withExchangeOff = validateConnectionForm({...base, tokenExchangeEnabled: 'false'}, OIDC_FIELDS, 'create');
+    expect(withExchangeOff).not.toHaveProperty('issuer');
+    expect(withExchangeOff).not.toHaveProperty('jwksEndpoint');
+
+    const withExchangeOn = validateConnectionForm({...base, tokenExchangeEnabled: 'true'}, OIDC_FIELDS, 'create');
+    expect(withExchangeOn.issuer).toBe('connections:validation.required');
+    expect(withExchangeOn.jwksEndpoint).toBe('connections:validation.required');
+  });
+
+  it('skips validation for a field hidden by revealedBy, even if it would otherwise be invalid', () => {
+    const fields: ConnectionFieldDef[] = [
+      {name: 'gate', labelKey: 'x', kind: 'switch'},
+      {name: 'child', labelKey: 'y', kind: 'url', required: true, revealedBy: 'gate'},
+    ];
+
+    const hidden = validateConnectionForm({gate: 'false', child: 'not-a-url'}, fields, 'create');
+    expect(hidden).not.toHaveProperty('child');
+
+    const shown = validateConnectionForm({gate: 'true', child: 'not-a-url'}, fields, 'create');
+    expect(shown.child).toBe('connections:validation.url');
   });
 });

--- a/frontend/packages/configure-connections/src/utils/buildConnectionCards.tsx
+++ b/frontend/packages/configure-connections/src/utils/buildConnectionCards.tsx
@@ -16,13 +16,35 @@
  * under the License.
  */
 
-import type {ConnectionCardModel, ConnectionInstance, ConnectionVendorMeta} from '../models/connection';
+import {ShieldCheck} from '@wso2/oxygen-ui-icons-react';
+import {
+  ConnectionTypes,
+  type ConnectionCardModel,
+  type ConnectionInstance,
+  type ConnectionVendorMeta,
+} from '../models/connection';
+
+/** i18n key for the trusted issuer card's description, resolved by the rendering component. */
+const TRUSTED_IDP_DESCRIPTION_KEY = 'connections:vendor.trustedIdp.description';
+
+/**
+ * Whether a connection instance is a trusted issuer — a trust-only OIDC instance used for ID-JAG
+ * identity assertion consumption — rather than a plain federation OIDC connection. Trusted
+ * issuers always carry `idJagEnabled` (`true` or `false`); plain federation OIDC connections
+ * leave it `undefined`.
+ */
+function isTrustedIdpInstance(instance: ConnectionInstance): boolean {
+  return instance.type === ConnectionTypes.OIDC && instance.idJagEnabled !== undefined;
+}
 
 /**
  * Merge the flat GET /connections instance list with the FE vendor-meta catalog into the list
  * of cards the listing grid renders.
  *
- * - every configured instance → one card titled by the instance name (each opens its own
+ * - OIDC instances that are trusted issuers (`idJagEnabled` present) are pulled out first and
+ *   rendered as their own card variant, before the normal per-vendor grouping below — each opens
+ *   the trusted issuer detail page rather than the generic connection detail page.
+ * - every other configured instance → one card titled by the instance name (each opens its own
  *   detail page), for branded and custom vendors alike.
  * - branded vendors with no instances → one unconfigured card that opens the configure wizard.
  * - custom vendors with no instances → no card (creation goes through the custom-connection
@@ -37,12 +59,29 @@ export default function buildConnectionCards(
   instances: ConnectionInstance[],
   vendorMetas: ConnectionVendorMeta[],
 ): ConnectionCardModel[] {
+  const trustedIdpCards: ConnectionCardModel[] = instances.filter(isTrustedIdpInstance).map(
+    (instance): ConnectionCardModel => ({
+      id: `trusted-idp:${instance.id}`,
+      vendorKey: 'trusted-idp',
+      backendType: ConnectionTypes.OIDC,
+      displayName: instance.name,
+      descriptionKey: TRUSTED_IDP_DESCRIPTION_KEY,
+      logo: <ShieldCheck />,
+      categories: ['trusted-idp'],
+      status: 'configured',
+      comingSoon: false,
+      navTarget: `/trusted-issuers/${instance.id}`,
+    }),
+  );
+
+  const remainingInstances: ConnectionInstance[] = instances.filter((instance) => !isTrustedIdpInstance(instance));
+
   const instancesByType: Record<string, ConnectionInstance[]> = {};
-  for (const instance of instances) {
+  for (const instance of remainingInstances) {
     (instancesByType[instance.type] ??= []).push(instance);
   }
 
-  const cards: ConnectionCardModel[] = [];
+  const cards: ConnectionCardModel[] = [...trustedIdpCards];
 
   for (const meta of vendorMetas) {
     if ((meta.presentation === 'branded' || meta.presentation === 'custom') && meta.backendType) {

--- a/frontend/packages/configure-connections/src/utils/connectionFormMapping.ts
+++ b/frontend/packages/configure-connections/src/utils/connectionFormMapping.ts
@@ -61,6 +61,10 @@ export function responseToFormValues(
       continue;
     }
     const raw: unknown = (response as unknown as Record<string, unknown>)[field.name];
+    if (field.kind === 'switch') {
+      values[field.name] = raw === true ? 'true' : 'false';
+      continue;
+    }
     values[field.name] = typeof raw === 'string' ? raw : '';
   }
   return values;
@@ -109,6 +113,11 @@ export function formValuesToRequest(
       continue;
     }
 
+    if (field.kind === 'switch') {
+      payload[field.name] = raw === 'true';
+      continue;
+    }
+
     // Always include required fields and any non-empty value; omit empty optional fields.
     if (field.required || raw !== '') {
       payload[field.name] = raw;
@@ -139,6 +148,10 @@ export function validateConnectionForm(
   const errors: Record<string, string> = {};
 
   for (const field of fields) {
+    if (field.revealedBy && values[field.revealedBy] !== 'true') {
+      continue;
+    }
+
     const raw: string = (values[field.name] ?? '').trim();
 
     if (field.kind === 'secret') {
@@ -148,11 +161,15 @@ export function validateConnectionForm(
       continue;
     }
 
-    if (field.kind === 'readonly-copy' || field.kind === 'scopes') {
+    if (field.kind === 'readonly-copy' || field.kind === 'scopes' || field.kind === 'switch') {
       continue;
     }
 
-    if (field.required && raw === '') {
+    const requiredWhen: string | undefined = field.requiredWhen;
+    const isRequired: boolean =
+      Boolean(field.required) || (requiredWhen !== undefined && values[requiredWhen] === 'true');
+
+    if (isRequired && raw === '') {
       errors[field.name] = 'connections:validation.required';
       continue;
     }

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1632,6 +1632,7 @@ const translations = {
     'categories.identity-verification': 'Identity Verification',
     'categories.crm': 'CRM',
     'categories.data-store': 'Data store',
+    'categories.trusted-idp': 'Trusted Token Issuer',
 
     // Card
     'card.configured': 'Configured',
@@ -1648,6 +1649,7 @@ const translations = {
     'vendor.twilio.description': 'Send SMS one-time passcodes via Twilio.',
     'vendor.vonage.description': 'Deliver SMS and email passcodes through Vonage.',
     'vendor.custom-sms.description': 'Route SMS through your own HTTP gateway.',
+    'vendor.trustedIdp.description': 'Trusted token issuer for token exchange and ID-JAG.',
 
     // Add custom connection wizard
     'wizard.title': 'Add custom connection',
@@ -1655,7 +1657,7 @@ const translations = {
     'wizard.steps.configure': 'Configure',
     'wizard.type.heading': 'What kind of connection do you want to add?',
     'wizard.type.subheading':
-      'Custom connections aren’t in the vendor catalog — pick the type of integration you want to wire up.',
+      "Custom connections aren't in the vendor catalog. Pick the type of integration you want to wire up.",
     'wizard.type.oidc.label': 'OpenID Connect Provider',
     'wizard.type.oidc.description': 'Connect any OpenID Connect identity provider.',
     'wizard.type.oidc.tag': 'Login provider · Enterprise',
@@ -1665,6 +1667,10 @@ const translations = {
     'wizard.type.sms.label': 'SMS gateway',
     'wizard.type.sms.description': 'Route SMS through your own HTTP gateway.',
     'wizard.type.sms.tag': 'Message sender · SMS',
+    'wizard.type.trustedIdp.label': 'Trusted Token Issuer',
+    'wizard.type.trustedIdp.description':
+      "Trust an external IdP's identity assertions and exchange them for access tokens.",
+    'wizard.type.trustedIdp.tag': 'Token exchange · ID-JAG',
     'wizard.configure.heading': 'Configure your connection',
     'wizard.configure.subheading':
       'Enter the credentials and endpoints for your custom connection. Secrets are stored write-only.',
@@ -1724,6 +1730,8 @@ const translations = {
     'form.fields.issuer.label': 'Issuer',
     'form.fields.issuer.hint': 'Issuer identifier expected in tokens from this provider.',
     'form.fields.tokenExchangeEnabled.label': 'Enable token exchange',
+    'form.fields.tokenExchangeEnabled.hint':
+      "Let backend services exchange this provider's tokens for ThunderID access tokens.",
     'form.fields.trustedTokenAudience.label': 'Trusted token audience',
     'form.fields.trustedTokenAudience.hint': 'Accepted audience value for external tokens during token exchange.',
     'form.fields.accountSid.label': 'Account SID',
@@ -1736,6 +1744,7 @@ const translations = {
     'form.fields.apiSecret.hint': 'Vonage API secret used to authenticate API requests.',
     'form.fields.senderId.label': 'Sender ID',
     'form.fields.senderId.hint': 'Phone number or alphanumeric sender ID messages are sent from.',
+    'form.sections.federation': 'Federation',
     'form.optional': 'Optional',
     'form.secret.update': 'Update',
     'form.secret.keepHelp': 'Leave unchanged to keep the stored secret.',
@@ -1808,6 +1817,70 @@ const translations = {
     'validation.required': 'This field is required.',
     'validation.url': 'Enter a valid URL.',
     'validation.accountSid': 'Enter a valid Account SID: “AC” followed by 32 hexadecimal characters.',
+  },
+
+  // ============================================================================
+  // Trusted issuers namespace - Trusted issuer (trust-only OIDC connection) feature translations
+  // ============================================================================
+  trustedIssuers: {
+    // Validation
+    'validation.required': 'This field is required.',
+    'validation.url': 'Enter a valid https:// URL.',
+
+    // Create form
+    'create.title': 'Add trusted issuer',
+    'create.subtitle':
+      'Register an external identity provider whose identity assertions ThunderID can exchange for access tokens.',
+    'create.duplicateName': 'A trusted issuer with this name already exists.',
+    'create.submit': 'Add trusted issuer',
+    'create.form.name.label': 'Name',
+    'create.form.issuer.label': 'Issuer URI',
+    'create.form.issuer.hint': "The issuer URI from the external IdP's OpenID Connect discovery document.",
+    'create.form.clientId.label': 'Client ID',
+    'create.form.clientId.hint':
+      "ThunderID's client ID registered at this identity provider. Used for audience validation in incoming assertions.",
+    'create.form.jwksEndpoint.label': 'JWKS endpoint',
+    'create.form.jwksEndpoint.hint':
+      'The JWKS endpoint used to validate the signature of incoming identity assertions.',
+    'create.form.tokenExchangeEnabled.label': 'Enable token exchange',
+    'create.form.tokenExchangeEnabled.hint': 'Exchange subject tokens from this issuer for access tokens.',
+    'create.form.idJagEnabled.label': 'Enable Identity Assertion JWT Authorization Grant (ID-JAG)',
+    'create.form.idJagEnabled.hint':
+      'Accept and exchange signed identity assertions from this issuer for access tokens.',
+
+    // Detail page
+    'detail.back': 'Back to connections',
+    'detail.loadError': 'Failed to load trusted issuer.',
+    'detail.duplicateName': 'A trusted issuer with this name already exists.',
+    'detail.general.title': 'General',
+    'detail.general.description': 'Core identity of this trusted issuer.',
+    'detail.tokenExchange.title': 'Token Exchange',
+    'detail.tokenExchange.description': 'Exchange subject tokens from this issuer for access tokens.',
+    'detail.tokenExchange.audience.label': 'Trusted token audience',
+    'detail.tokenExchange.audience.hint': 'The audience value ThunderID expects in subject tokens from this issuer.',
+    'detail.consumption.title': 'Identity Assertion JWT Authorization Grant (ID-JAG)',
+    'detail.idJag.description': 'Accept and exchange signed identity assertions from this issuer for access tokens.',
+    'detail.idJag.enabledNote': 'Identity assertions from this issuer are accepted via the ID-JAG protocol.',
+    'detail.dangerZone.title': 'Danger zone',
+    'detail.dangerZone.delete.title': 'Delete trusted issuer',
+    'detail.dangerZone.delete.description':
+      'Applications relying on assertions from this issuer will stop receiving tokens. This cannot be undone.',
+    'detail.saveBar.unsaved': 'You have unsaved changes',
+    'detail.saveBar.discard': 'Discard',
+    'detail.saveBar.save': 'Save changes',
+
+    // Delete dialog
+    'delete.title': 'Delete trusted issuer',
+    'delete.message':
+      'Delete "{{name}}"? Applications relying on assertions from this issuer will stop receiving tokens. This cannot be undone.',
+
+    // Toasts
+    'create.success': 'Trusted issuer created successfully.',
+    'create.error': 'Failed to create trusted issuer. Please try again.',
+    'update.success': 'Trusted issuer updated successfully.',
+    'update.error': 'Failed to update trusted issuer. Please try again.',
+    'delete.success': 'Trusted issuer deleted successfully.',
+    'delete.error': 'Failed to delete trusted issuer. Please try again.',
   },
 
   // ============================================================================
@@ -2603,6 +2676,23 @@ const translations = {
     'edit.advanced.acrValues.placeholder': 'Select ACR values',
     'edit.advanced.acrValues.hint':
       'When acr_values is included in the authorization request, only values configured here are accepted.',
+    'edit.advanced.grantTypes.labels.ciba': 'CIBA (Client-Initiated Backchannel Authentication)',
+    'edit.advanced.grantTypes.labels.tokenExchange': 'Token Exchange',
+    'edit.advanced.grantTypes.labels.jwtBearer': 'JWT Bearer',
+    'edit.advanced.idJag.title': 'Identity Assertions (ID-JAG)',
+    'edit.advanced.idJag.description':
+      "Issue signed assertions of the signed-in user's identity that external services accept for token issuance.",
+    'edit.advanced.idJag.publicClientGuard':
+      'Identity assertions require a confidential client. Turn off Public Client to enable.',
+    'edit.advanced.idJag.labels.allowedAudiences': 'Allowed audiences',
+    'edit.advanced.idJag.allowedAudiences.placeholder': 'Type an audience and press Enter',
+    'edit.advanced.idJag.allowedAudiences.error': 'Add at least one audience.',
+    'edit.advanced.idJag.allowedAudiences.hint': 'Each assertion targets exactly one of these audiences.',
+    'edit.advanced.idJag.labels.validityPeriod': 'Assertion validity',
+    'edit.advanced.idJag.labels.seconds': 'seconds',
+    'edit.advanced.idJag.validityPeriod.error': 'Enter a value of at least 1 second.',
+    'edit.advanced.idJag.validityPeriod.hint': 'How long an issued assertion stays valid. Default 300.',
+    'edit.advanced.idJag.grantTypeHint': 'The token exchange grant type is enabled together with this feature.',
     'create.success': 'Application created successfully.',
     'create.error': 'Failed to create application. Please try again.',
     'update.success': 'Application updated successfully.',


### PR DESCRIPTION
### Purpose

Adds Console UI support for the Identity Assertion Authorization Grant (ID-JAG), covering both sides of the trust relationship:

- **Trusted issuers (consumption side):** external identity providers whose identity assertions ThunderID accepts and exchanges for access tokens. Managed under **Connections**: a new **Trusted Identity Provider** option in the *Add custom connection* wizard creates a trust-only OIDC connection (issuer URI, JWKS endpoint, optional client ID, token exchange and ID-JAG toggles). Configured trusted issuers render as distinct cards in the Connections grid with a **Trusted IDP** filter chip and open a detail page with General, Token Exchange, ID-JAG, and Danger zone sections.
- **Identity assertion issuance (application side):** a new *Identity Assertions (ID-JAG)* card in the application's Advanced tab with a public client guard, automatic token-exchange grant wiring, allowed audiences, and validity period configuration.
- **Connection form:** a *Federation* section with a token exchange toggle, trusted token audience field, and conditional required validation for issuer/JWKS.

<img width="1948" height="1196" alt="Screenshot 2026-07-16 at 12 05 36 AM" src="https://github.com/user-attachments/assets/2e4cb4f6-e78b-4bea-ae59-2cd4d37e5799" />
<img width="1936" height="1181" alt="Screenshot 2026-07-16 at 12 05 45 AM" src="https://github.com/user-attachments/assets/3c3d3aa4-ef0a-4e19-a7dc-31c60a398f05" />
<img width="1088" height="1174" alt="Screenshot 2026-07-16 at 12 05 52 AM" src="https://github.com/user-attachments/assets/f6723cf5-b425-46c4-b6d1-0fdf77e7924a" />
<img width="1844" height="1151" alt="Screenshot 2026-07-16 at 12 06 01 AM" src="https://github.com/user-attachments/assets/39c269c8-c517-45f7-903d-3e7f69afed1c" />



### Approach

- Trusted issuers reuse the existing `/connections/oidc` API (no new endpoints). They are OIDC connections carrying the `idJagEnabled` flag; the flat `GET /connections` listing now exposes `idJagEnabled` per item so the grid can distinguish them without per-item detail calls (computed once in the IdP list store path, degrading gracefully on malformed property rows).
- IdP validation accepts credential-less trust-only OIDC connections whenever the `id_jag_enabled` property is present (any value), so trusted issuers are savable in every toggle combination, while plain federation OIDC connections still require full OAuth client configuration. `id_jag_enabled` and `token_exchange_enabled` values are validated as strict booleans.
- The *Add custom connection* wizard gains a generic `customConfigureSteps` slot; the Console injects the trusted issuer create form, and the Trusted Identity Provider card only renders when the slot is supplied, so the shared package never advertises a flow it cannot complete.
- Enabling ID-JAG on an application composes the `idJag` config update and the auto-granted token-exchange grant type into a single state update to avoid a lost-update race.

Verified end-to-end against a running server: API-level create/update/delete in all toggle combinations plus UI walkthroughs of the wizard, grid filter, detail page, and delete flow. Diff-reviewed and security-audited (validation relaxation confirmed fail-closed on all runtime consumption paths).

### Related Issues
- N/A

### Related PRs
- Builds on the ID-JAG grant support merged in #3893 and #4032

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

