### PR TITLE
[Bug-fix] Fix loose hanging onFailure Nodes of email/sms send executors

### DIFF
--- a/backend/internal/flow/core/task_execution_node.go
+++ b/backend/internal/flow/core/task_execution_node.go
@@ -120,17 +120,16 @@ func (n *taskExecutionNode) Execute(ctx *providers.NodeContext) (*common.NodeRes
 		if n.onSuccess != "" {
 			nodeResp.NextNodeID = n.onSuccess
 		}
-	} else if nodeResp.Error != nil && n.onFailure != "" {
+	} else if nodeResp.Status == common.NodeStatusFailure && n.onFailure != "" {
 		// Change status to Forward so engine forwards execution to onFailure node
 		nodeResp.Status = common.NodeStatusForward
 		nodeResp.NextNodeID = n.onFailure
 
 		// Store failure reason in RuntimeData so it's available to the onFailure handler
-		if nodeResp.RuntimeData == nil {
-			nodeResp.RuntimeData = make(map[string]string)
-		}
-		if jsonBytes, err := json.Marshal(nodeResp.Error); err == nil {
-			nodeResp.RuntimeData["failureReasonJSON"] = string(jsonBytes)
+		if nodeResp.Error != nil {
+			if jsonBytes, err := json.Marshal(nodeResp.Error); err == nil {
+				nodeResp.RuntimeData["failureReasonJSON"] = string(jsonBytes)
+			}
 		}
 
 		// Clear user inputs consumed by this executor

--- a/backend/internal/flow/core/task_execution_node_test.go
+++ b/backend/internal/flow/core/task_execution_node_test.go
@@ -626,7 +626,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithOnFailureInitializesR
 	s.Equal("CUSTOM_ERROR", svcErr630.Error.DefaultValue, "Failure reason should be stored in RuntimeData")
 }
 
-func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithEmptyFailureReasonAndOnFailure() {
+func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithNilErrorAndOnFailure() {
 	mockExec := NewExecutorInterfaceMock(s.T())
 	node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false)
 	execNode, _ := node.(ExecutorBackedNodeInterface)
@@ -637,7 +637,7 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithEmptyFailureReasonAnd
 	mockExec.On("Execute", mock.Anything).Return(
 		&providers.ExecutorResponse{
 			Status: providers.ExecFailure,
-			Error:  nil, // No error — onFailure handler should NOT be triggered
+			Error:  nil, // No error — onFailure handler should still be triggered
 		},
 		nil,
 	).Once()
@@ -649,9 +649,11 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithEmptyFailureReasonAnd
 
 	s.Nil(err)
 	s.NotNil(resp)
-	// When FailureReason is empty, onFailure handler should NOT be triggered
-	s.Equal(common.NodeStatusFailure, resp.Status, "Status should remain failure when FailureReason is empty")
-	s.Empty(resp.NextNodeID, "NextNodeID should not be set when FailureReason is empty")
+	s.Equal(common.NodeStatusForward, resp.Status, "Should forward to onFailure handler even without error")
+	s.Equal("error-handler", resp.NextNodeID, "NextNodeID should be set to onFailure handler")
+	s.Nil(resp.Error, "Error should remain nil")
+	s.NotContains(resp.RuntimeData, "failureReasonJSON",
+		"failureReasonJSON should not be set when Error is nil")
 }
 
 func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithOnFailureClearsNodeInputs() {
@@ -730,6 +732,50 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithOnFailureNoNodeInputs
 	s.Equal("error-handler", resp.NextNodeID)
 	s.Equal("user@example.com", ctx.UserInputs["email"],
 		"UserInputs should be preserved when no node inputs are configured")
+}
+
+func (s *TaskExecutionNodeTestSuite) TestExecuteFailureWithOnFailureClearsMultipleInputsPreservesOthers() {
+	mockExec := NewExecutorInterfaceMock(s.T())
+
+	inputs := []providers.Input{
+		{Identifier: "username", Required: true},
+		{Identifier: "password", Required: true},
+	}
+
+	node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false)
+	execNode, _ := node.(ExecutorBackedNodeInterface)
+
+	execNode.SetOnFailure("error-handler")
+	execNode.(*taskExecutionNode).inputs = inputs
+
+	mockExec.On("GetName").Return("test-executor").Once()
+	mockExec.On("Execute", mock.Anything).Return(
+		&providers.ExecutorResponse{
+			Status: providers.ExecFailure,
+			Error:  &tidcommon.ServiceError{Error: tidcommon.I18nMessage{DefaultValue: "AUTH_FAILED"}},
+		}, nil,
+	).Once()
+
+	execNode.SetExecutor(mockExec)
+
+	ctx := &providers.NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs: map[string]string{
+			"username":    "testuser",
+			"password":    "wrongpassword",
+			"remember_me": "true",
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Equal(common.NodeStatusForward, resp.Status)
+	s.Equal("error-handler", resp.NextNodeID)
+	s.Empty(ctx.UserInputs["username"], "Node input 'username' should be cleared")
+	s.Empty(ctx.UserInputs["password"], "Node input 'password' should be cleared")
+	s.Equal("true", ctx.UserInputs["remember_me"],
+		"Non-node user inputs should be preserved after onFailure")
 }
 
 func (s *TaskExecutionNodeTestSuite) TestOnIncomplete() {
@@ -910,6 +956,52 @@ func (s *TaskExecutionNodeTestSuite) TestExecuteIncompleteWithOnIncompleteNoFail
 	// UserInputs should NOT be cleared when there's no failure reason
 	s.Equal("testuser", ctx.UserInputs["username"],
 		"UserInputs should not be cleared without failure reason")
+}
+
+func (s *TaskExecutionNodeTestSuite) TestExecuteIncompleteWithErrorAndBothOnFailureAndOnIncomplete() {
+	mockExec := NewExecutorInterfaceMock(s.T())
+
+	inputs := []providers.Input{
+		{Identifier: "username", Required: true},
+	}
+
+	node := newTaskExecutionNode("task-1", map[string]interface{}{}, false, false)
+	execNode, _ := node.(ExecutorBackedNodeInterface)
+
+	execNode.SetOnFailure("error-handler")
+	execNode.SetOnIncomplete("prompt-credentials")
+	execNode.(*taskExecutionNode).inputs = inputs
+
+	mockExec.On("GetName").Return("test-executor").Once()
+	mockExec.On("Execute", mock.Anything).Return(
+		&providers.ExecutorResponse{
+			Status: providers.ExecUserInputRequired,
+			Inputs: inputs,
+			Error: &tidcommon.ServiceError{
+				Error: tidcommon.I18nMessage{DefaultValue: "Invalid credentials"},
+			},
+		}, nil,
+	).Once()
+
+	execNode.SetExecutor(mockExec)
+
+	ctx := &providers.NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs: map[string]string{
+			"username": "testuser",
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Equal(common.NodeStatusForward, resp.Status, "Should forward to onIncomplete, not onFailure")
+	s.Equal("prompt-credentials", resp.NextNodeID, "Should go to onIncomplete node, not onFailure")
+	s.Equal("Invalid credentials", resp.Error.Error.DefaultValue)
+	var svcErr tidcommon.ServiceError
+	s.NoError(json.Unmarshal([]byte(resp.RuntimeData["failureReasonJSON"]), &svcErr))
+	s.Equal("Invalid credentials", svcErr.Error.DefaultValue)
+	s.Empty(ctx.UserInputs["username"], "Username should be cleared from UserInputs")
 }
 
 func (s *TaskExecutionNodeTestSuite) TestExecuteUserInputRequiredWithNoInputsReturnsServerError() {

--- a/frontend/apps/console/src/features/flows/data/templates.json
+++ b/frontend/apps/console/src/features/flows/data/templates.json
@@ -1182,7 +1182,8 @@
           "executor": {
             "name": "SMSExecutor"
           },
-          "onSuccess": "prompt_otp"
+          "onSuccess": "prompt_otp",
+          "onFailure": "prompt_mobile"
         },
         {
           "id": "prompt_otp",
@@ -1506,7 +1507,8 @@
               }
             ]
           },
-          "onSuccess": "prompt_otp"
+          "onSuccess": "prompt_otp",
+          "onFailure": "prompt_email"
         },
         {
           "id": "prompt_otp",
@@ -6665,7 +6667,8 @@
           "executor": {
             "name": "SMSExecutor"
           },
-          "onSuccess": "prompt_otp"
+          "onSuccess": "prompt_otp",
+          "onFailure": "prompt_mobile"
         },
         {
           "id": "prompt_otp",
@@ -7142,7 +7145,8 @@
               }
             ]
           },
-          "onSuccess": "prompt_otp"
+          "onSuccess": "prompt_otp",
+          "onFailure": "prompt_email"
         },
         {
           "id": "prompt_otp",
@@ -9314,7 +9318,8 @@
           "executor": {
             "name": "SMSExecutor"
           },
-          "onSuccess": "prompt_otp"
+          "onSuccess": "prompt_otp",
+          "onFailure": "prompt_mobile"
         },
         {
           "id": "prompt_otp",

--- a/tests/integration/flow/recovery/sms_otp_recovery_test.go
+++ b/tests/integration/flow/recovery/sms_otp_recovery_test.go
@@ -298,8 +298,8 @@ func (ts *SMSOTPRecoveryFlowTestSuite) TestSMSOTPRecoveryFlow_UnknownUsername() 
 		"No SMS should be sent for a non-existent username")
 }
 
-// TestSMSOTPRecoveryFlow_InvalidOTP tests that a wrong OTP causes verify_otp to fail
-// and the flow returns to prompt_username (as configured in onFailure).
+// TestSMSOTPRecoveryFlow_InvalidOTP tests that a wrong OTP causes verify_otp to return
+// incomplete and the flow redirects to otp_sent_status (as configured in onIncomplete).
 func (ts *SMSOTPRecoveryFlowTestSuite) TestSMSOTPRecoveryFlow_InvalidOTP() {
 	ts.mockSMSServer.ClearMessages()
 
@@ -320,7 +320,7 @@ func (ts *SMSOTPRecoveryFlowTestSuite) TestSMSOTPRecoveryFlow_InvalidOTP() {
 	time.Sleep(1 * time.Second)
 	ts.mockSMSServer.ClearMessages()
 
-	// Submit an incorrect OTP — verify_otp fails, onFailure → prompt_username.
+	// Submit an incorrect OTP — verify_otp onIncomplete → otp_sent_status.
 	flowStep, err = common.CompleteFlow(
 		flowStep.ExecutionID,
 		map[string]string{"otp": "000000"},
@@ -329,7 +329,7 @@ func (ts *SMSOTPRecoveryFlowTestSuite) TestSMSOTPRecoveryFlow_InvalidOTP() {
 	)
 	ts.Require().NoError(err)
 
-	// The flow must be INCOMPLETE (restarted to prompt_username), not COMPLETE.
+	// The flow must be INCOMPLETE (restarted to otp_sent_status), not COMPLETE.
 	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus,
 		"Invalid OTP must not complete the recovery flow")
 	ts.Require().NotEqual("COMPLETE", flowStep.FlowStatus)
@@ -338,9 +338,9 @@ func (ts *SMSOTPRecoveryFlowTestSuite) TestSMSOTPRecoveryFlow_InvalidOTP() {
 	ts.Require().NotNil(flowStep.Error,
 		"Expected an error for invalid OTP")
 
-	// The flow should loop back to username prompt.
-	ts.Require().True(common.HasInput(flowStep.Data.Inputs, "username"),
-		"After invalid OTP, flow must restart at prompt_username")
+	// The flow should loop back to OTP prompt.
+	ts.Require().True(common.HasInput(flowStep.Data.Inputs, "otp"),
+		"After invalid OTP, flow must return to otp_sent_status")
 }
 
 // TestSMSOTPRecoveryFlow_MissingMobileNumber tests that a user without a mobileNumber
@@ -491,8 +491,9 @@ func buildSMSOTPRecoveryFlow(senderID string) testutils.Flow {
 					"name": "OTPExecutor",
 					"mode": "verify",
 				},
-				"onSuccess": "prompt_new_password",
-				"onFailure": "prompt_username",
+				"onSuccess":    "prompt_new_password",
+				"onFailure":    "prompt_username",
+				"onIncomplete": "otp_sent_status",
 			},
 			{
 				"id":   "prompt_new_password",


### PR DESCRIPTION
### Purpose
Fixes: https://github.com/thunder-id/thunderid/issues/3980

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3980

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SMS and email OTP flows by routing OTP-send failures back to the correct phone/email entry prompts.
  * Updated additional registration flows so OTP-send failures return users to the appropriate mobile entry step.
  * Refined flow transition handling so failure/incomplete outcomes follow configured `onFailure`/`onIncomplete`, including “failure without error” cases.

* **Tests**
  * Updated SMS OTP recovery expectations for invalid OTP submissions and aligned flow configuration for `verify_otp` incomplete behavior.
  * Expanded unit and integration coverage for failure/incomplete edge cases and input-clearing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->