### PR TITLE
Fix disabled and tinted element colors

### DIFF
--- a/frontend/packages/design/src/themes/DefaultTheme.ts
+++ b/frontend/packages/design/src/themes/DefaultTheme.ts
@@ -27,32 +27,43 @@ export const DefaultThemeConfig = {
   colorSchemes: {
     light: {
       palette: {
+        // Explicit transparency channels: Oxygen freezes these at its own palette during the theme merge.
         primary: {
           main: '#3688FF',
+          mainChannel: '54 136 255',
           dark: '#2d78e0',
+          darkChannel: '45 120 224',
           light: '#6ba8f5',
+          lightChannel: '107 168 245',
           contrastText: '#ffffff',
         },
         secondary: {
           main: '#5498b4',
+          mainChannel: '84 152 180',
           dark: '#2d8eac',
+          darkChannel: '45 142 172',
           light: '#85cde3',
+          lightChannel: '133 205 227',
           contrastText: '#ffffff',
         },
         warning: {
           main: '#f59e0b',
+          mainChannel: '245 158 11',
           contrastText: '#ffffff',
         },
         error: {
           main: '#ef4444',
+          mainChannel: '239 68 68',
           contrastText: '#ffffff',
         },
         info: {
           main: '#8bf9fa',
+          mainChannel: '139 249 250',
           contrastText: '#0a1628',
         },
         success: {
           main: '#10b981',
+          mainChannel: '16 185 129',
           contrastText: '#ffffff',
         },
         background: {
@@ -64,36 +75,52 @@ export const DefaultThemeConfig = {
           primary: '#181818',
           secondary: 'rgba(24, 24, 24, 0.72)',
         },
+        // Explicit disabled Switch shades.
+        Switch: {
+          primaryDisabledColor: '#b2d1ff',
+          secondaryDisabledColor: '#bed7e2',
+        },
       },
     },
     dark: {
       palette: {
+        // Explicit transparency channels: Oxygen freezes these at its own palette during the theme merge.
         primary: {
           main: '#3688FF',
+          mainChannel: '54 136 255',
           dark: '#2d78e0',
+          darkChannel: '45 120 224',
           light: '#6ba8f5',
+          lightChannel: '107 168 245',
           contrastText: '#ffffff',
         },
         secondary: {
           main: '#5498b4',
+          mainChannel: '84 152 180',
           dark: '#2d8eac',
+          darkChannel: '45 142 172',
           light: '#85cde3',
+          lightChannel: '133 205 227',
           contrastText: '#0a2230',
         },
         warning: {
           main: '#f59e0b',
+          mainChannel: '245 158 11',
           contrastText: '#ffffff',
         },
         error: {
           main: '#ef4444',
+          mainChannel: '239 68 68',
           contrastText: '#ffffff',
         },
         info: {
           main: '#8bf9fa',
+          mainChannel: '139 249 250',
           contrastText: '#0a1628',
         },
         success: {
           main: '#10b981',
+          mainChannel: '16 185 129',
           contrastText: '#ffffff',
         },
         background: {
@@ -104,6 +131,11 @@ export const DefaultThemeConfig = {
         text: {
           primary: '#FFFFFF',
           secondary: 'rgba(255, 255, 255, 0.7)',
+        },
+        // Explicit disabled Switch shades.
+        Switch: {
+          primaryDisabledColor: '#183d72',
+          secondaryDisabledColor: '#254450',
         },
       },
     },

--- a/frontend/packages/design/src/themes/__tests__/DefaultTheme.test.tsx
+++ b/frontend/packages/design/src/themes/__tests__/DefaultTheme.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, cleanup} from '@testing-library/react';
+import {OxygenUIThemeProvider} from '@wso2/oxygen-ui';
+import {afterEach, describe, expect, it} from 'vitest';
+import DefaultTheme from '../DefaultTheme';
+
+// Normalize any CSS color to its `rgb(...)` form so hex and rgb values compare equal.
+function toRgb(color: string): string {
+  const probe = document.createElement('span');
+  probe.style.color = color;
+  document.body.appendChild(probe);
+  const resolved = getComputedStyle(probe).color;
+  probe.remove();
+  return resolved;
+}
+
+// The "r g b" channel MUI stores for alpha tints is the hex split into decimals.
+function channelOf(hex: string): string {
+  const n = parseInt(hex.slice(1), 16);
+  return `${(n >> 16) & 255} ${(n >> 8) & 255} ${n & 255}`;
+}
+
+const PALETTE_COLORS = ['primary', 'secondary', 'error', 'warning', 'info', 'success'] as const;
+const CHANNEL_VARIANTS = ['main', 'light', 'dark'] as const;
+
+// Oxygen's frozen orange primary channel — what mainChannel resolves to if override is dropped.
+const OXYGEN_ORANGE_CHANNEL = '255 115 0';
+
+interface PaletteColor {
+  main: string;
+  light?: string;
+  dark?: string;
+  mainChannel?: string;
+  lightChannel?: string;
+  darkChannel?: string;
+}
+
+function palette(scheme: 'light' | 'dark'): Record<(typeof PALETTE_COLORS)[number], PaletteColor> {
+  const {colorSchemes} = DefaultTheme as unknown as {
+    colorSchemes: Record<'light' | 'dark', {palette: Record<(typeof PALETTE_COLORS)[number], PaletteColor>}>;
+  };
+  return colorSchemes[scheme].palette;
+}
+
+// createOxygenTheme merges our palette over Oxygen's base but doesn't recompute the baked
+// channels, so each must be set explicitly or MUI tints resolve to Oxygen's defaults. Asserting
+// each channel against its own hex keeps this robust to future colour changes.
+describe('DefaultTheme transparent-tint channels', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('derives every colour channel from its own hex, not the Oxygen defaults', () => {
+    (['light', 'dark'] as const).forEach((scheme) => {
+      const colors = palette(scheme);
+
+      PALETTE_COLORS.flatMap((name) =>
+        CHANNEL_VARIANTS.filter((variant) => typeof colors[name][variant] === 'string').map((variant) => ({
+          actual: colors[name][`${variant}Channel`],
+          expected: channelOf(colors[name][variant]!),
+        })),
+      ).forEach(({actual, expected}) => {
+        expect(actual).toBe(expected);
+      });
+
+      expect(colors.primary.mainChannel).not.toBe(OXYGEN_ORANGE_CHANNEL);
+    });
+  });
+
+  it('resolves a primary-tinted surface to primary.main at runtime', () => {
+    const {container} = render(
+      <OxygenUIThemeProvider
+        themes={[{key: 'default', label: 'Default Theme', theme: DefaultTheme}]}
+        initialTheme="default"
+      >
+        <div data-testid="tint" style={{backgroundColor: 'rgba(var(--oxygen-palette-primary-mainChannel) / 1)'}} />
+      </OxygenUIThemeProvider>,
+    );
+
+    const tint = container.querySelector('[data-testid="tint"]');
+    expect(tint).not.toBeNull();
+
+    const bg = toRgb(getComputedStyle(tint!).backgroundColor);
+    expect(bg).toBe(toRgb(palette('light').primary.main));
+  });
+});


### PR DESCRIPTION
### Purpose

Disabled Switch controls and tinted surfaces (hover and selected states, and other elements MUI renders with a transparent tint of a palette color) were rendering in the wrong color. Tinted surfaces picked up Oxygen's default orange palette instead of the ThunderID blue, and disabled switches had no defined shade.

The root cause is that `createOxygenTheme` merges the ThunderID palette over Oxygen's base palette, but it does not recompute the baked transparency channels (the `mainChannel` / `lightChannel` / `darkChannel` values MUI uses for `rgba(...)` tints). As a result those channels stayed frozen at Oxygen's own palette even though the visible `main` / `light` / `dark` colors were overridden, so any tinted element resolved to the wrong color.

Fixes #3290

### Approach

- Added explicit transparency channels (`mainChannel`, `lightChannel`, `darkChannel`) alongside the existing `main` / `light` / `dark` colors for every palette color (primary, secondary, warning, error, info, success) in both the light and dark schemes. Each channel is the decimal `r g b` form of its own hex value, so tinted elements now resolve to the ThunderID palette instead of Oxygen's defaults.
- Added explicit disabled Switch shades (`Switch.primaryDisabledColor` and `Switch.secondaryDisabledColor`) for both schemes so disabled switches render a defined color.
- Added a unit test suite for `DefaultTheme` that verifies every color channel is derived from its own hex, and that a primary-tinted surface resolves to `primary.main` at runtime through the real `OxygenUIThemeProvider`.

The channel values are kept in sync with their hex colors by the new test, which asserts each channel against the decimal split of its hex, so a future color change that forgets to update a channel will fail the test rather than silently regress.

### Screenshots

#### Organizations list

| Theme | Before | After |
|-------|--------|-------|
| Light | <img width="440" alt="Organizations light before" src="https://github.com/user-attachments/assets/b6fbea77-7643-4b3e-bd74-f6dda5218105" /> | <img width="440" alt="Organizations light after" src="https://github.com/user-attachments/assets/8f081115-bc13-4953-8bb6-fc1a2f3b0358" /> |
| Dark  | <img width="440" alt="Organizations dark before" src="https://github.com/user-attachments/assets/05ed4584-16aa-4b88-86a6-1a9b75cdd894" /> | <img width="440" alt="Organizations dark after" src="https://github.com/user-attachments/assets/3a594aae-d9de-40fc-b9e1-d322bfd83aa4" /> |

#### Dropdown

| Theme | Before | After |
|-------|--------|-------|
| Light | <img width="440" alt="Dropdown light before" src="https://github.com/user-attachments/assets/8ac0b045-b9ce-4413-a5b6-1c3211d86279" /> | <img width="440" alt="Dropdown light after" src="https://github.com/user-attachments/assets/7d60c55c-93b7-490d-a888-234319c7d245" /> |
| Dark  | <img width="440" alt="Dropdown dark before" src="https://github.com/user-attachments/assets/bca53ae9-b2a8-4fbc-b4d0-005d720f86ed" /> | <img width="440" alt="Dropdown dark after" src="https://github.com/user-attachments/assets/27f1df4c-38d0-407f-9244-aab55cad2914" /> |

#### Disabled switch

| Theme | Before | After |
|-------|--------|-------|
| Light | <img width="440" alt="Disabled switch light before" src="https://github.com/user-attachments/assets/a0e83c3d-9564-47f9-99b6-7be8d5a05801" /> | <img width="440" alt="Disabled switch light after" src="https://github.com/user-attachments/assets/043ea26e-4c5b-4da4-9a53-5a87a3c849d9" /> |
| Dark  | <img width="440" alt="Disabled switch dark before" src="https://github.com/user-attachments/assets/e38c720a-69ec-4b41-8f73-5f07df737414" /> | <img width="440" alt="Disabled switch dark after" src="https://github.com/user-attachments/assets/29a317eb-3dd1-478f-abfe-251f386276cd" /> |


### Related Issues
- https://github.com/thunder-id/thunderid/issues/3290


### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


