### PR TITLE
Add database.operation support to the Helm chart

### DIFF
--- a/docs/content/guides/deployment-patterns/kubernetes.mdx
+++ b/docs/content/guides/deployment-patterns/kubernetes.mdx
@@ -101,6 +101,7 @@ helm install thunderid oci://ghcr.io/thunder-id/helm-charts/thunderid \
   --set configuration.database.config.type=sqlite \
   --set configuration.database.runtime.type=sqlite \
   --set configuration.database.user.type=sqlite \
+  --set configuration.database.operation.type=sqlite \
   --set deployment.securityContext.readOnlyRootFilesystem=false
 ```
 
@@ -158,6 +159,14 @@ For production deployments, use a values file to manage configuration:
           username: thunderid_user
           password: <user-db-password>
           sslmode: require
+        operation:
+          type: postgres
+          host: postgres.default.svc.cluster.local
+          port: 5432
+          name: operationdb
+          username: thunderid_user
+          password: <operation-db-password>
+          sslmode: require
     ```
 
 2. Install using the values file:
@@ -181,12 +190,13 @@ Never write database passwords directly into `custom-values.yaml` or commit it t
 
 Before deploying <ProductName />, prepare the PostgreSQL instance:
 
-1. Create the three required databases:
+1. Create the four required databases:
 
     ```sql
     CREATE DATABASE configdb;
     CREATE DATABASE runtimedb;
     CREATE DATABASE userdb;
+    CREATE DATABASE operationdb;
     ```
 
 2. Create a dedicated user:
@@ -198,7 +208,7 @@ Before deploying <ProductName />, prepare the PostgreSQL instance:
 3. Grant the required privileges in each database. Connect to each database and run both statements. Using `psql`:
 
     ```bash
-    for db in configdb runtimedb userdb; do
+    for db in configdb runtimedb userdb operationdb; do
       psql -h <db-host> -U postgres -d "$db" <<'SQL'
         GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO thunderid_user;
         ALTER DEFAULT PRIVILEGES IN SCHEMA public
@@ -210,7 +220,7 @@ Before deploying <ProductName />, prepare the PostgreSQL instance:
     `GRANT ON ALL TABLES` covers tables that already exist. `ALTER DEFAULT PRIVILEGES` ensures tables created by future migrations are also accessible.
 
 4. Run the initialization scripts to create the schema:
-    - Apply the database scripts for <RepoLink path="/blob/main/backend/dbscripts/configdb/postgres.sql">configdb</RepoLink>, <RepoLink path="/blob/main/backend/dbscripts/runtimedb/postgres.sql">runtimedb</RepoLink>, and <RepoLink path="/blob/main/backend/dbscripts/userdb/postgres.sql">userdb</RepoLink>.
+    - Apply the database scripts for <RepoLink path="/blob/main/backend/dbscripts/configdb/postgres.sql">configdb</RepoLink>, <RepoLink path="/blob/main/backend/dbscripts/runtimedb/postgres.sql">runtimedb</RepoLink>, <RepoLink path="/blob/main/backend/dbscripts/userdb/postgres.sql">userdb</RepoLink>, and <RepoLink path="/blob/main/backend/dbscripts/operationdb/postgres.sql">operationdb</RepoLink>.
 
 For a PostgreSQL setup using Helm, refer to the [Bitnami PostgreSQL Helm Chart](https://bitnami.com/stacks/postgresql).
 
@@ -243,6 +253,14 @@ configuration:
       username: thunderid_user
       password: <user-db-password>
       sslmode: require
+    operation:
+      type: postgres
+      host: postgres.example.com
+      port: 5432
+      name: operationdb
+      username: thunderid_user
+      password: <operation-db-password>
+      sslmode: require
 ```
 
 ### SQLite
@@ -263,6 +281,10 @@ configuration:
     user:
       type: sqlite
       sqlitePath: database/userdb.db
+      sqliteOptions: "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)"
+    operation:
+      type: sqlite
+      sqlitePath: database/operationdb.db
       sqliteOptions: "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)"
 ```
 

--- a/docs/content/guides/deployment-patterns/production-guidelines.mdx
+++ b/docs/content/guides/deployment-patterns/production-guidelines.mdx
@@ -23,13 +23,14 @@ Before you begin, ensure you have:
 
 The default configuration uses SQLite, which stores data in local files. SQLite does not support concurrent writes from multiple processes and is not suitable for production use. Use PostgreSQL for production deployments.
 
-<ProductName /> uses three separate databases:
+<ProductName /> uses four separate databases:
 
 | Database | Purpose |
 |----------|---------|
 | `config` | Application configuration, flows, and identity providers |
 | `runtime` | Active sessions, tokens, and OAuth state |
 | `user` | User accounts and credentials |
+| `operation` | SSO sessions, revoked tokens, and consent records |
 
 Configure each database in `deployment.yaml`:
 
@@ -67,6 +68,19 @@ database:
       hostname: "your-db-host"
       port: "5432"
       name: "userdb"
+      username: "dbuser"
+      password: "dbpassword"
+      sslmode: "require"
+      max_open_conns: 500
+      max_idle_conns: 100
+      conn_max_lifetime: 3600
+
+  operation:
+    type: "postgres"
+    postgres:
+      hostname: "your-db-host"
+      port: "5432"
+      name: "operationdb"
       username: "dbuser"
       password: "dbpassword"
       sslmode: "require"

--- a/docs/content/guides/getting-started/configuration.mdx
+++ b/docs/content/guides/getting-started/configuration.mdx
@@ -130,7 +130,7 @@ This is the <ProductName /> **application log** (the `INFO`/`WARN`/`ERROR` lines
 
 ## Database Configuration
 
-<ProductName /> uses three separate databases for different purposes. Each database can be configured independently.
+<ProductName /> uses four separate databases for different purposes. Each database can be configured independently.
 
 Connection parameters are grouped under a type-specific sub-key (`postgres`, `sqlite`, or `redis`). Only `type` is a top-level field; all other settings belong under the matching sub-key.
 
@@ -281,6 +281,44 @@ Stores user profiles and credentials.
 | `database.user.sqlite.max_retries` | `3` | Maximum retry attempts for transient errors |
 | `database.user.sqlite.min_retry_backoff_ms` | `50` | Minimum delay before retrying in milliseconds |
 | `database.user.sqlite.max_retry_backoff_ms` | `2000` | Maximum delay before retrying in milliseconds |
+
+### Operation Database
+
+Stores SSO sessions, revoked tokens, and consent records. This database is required. <ProductName /> fails to start when `database.operation` is not configured.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `database.operation.type` | `sqlite` | Database type (`sqlite` or `postgres`) |
+
+**`database.operation.postgres.*`** is only read when `database.operation.type: postgres`:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `database.operation.postgres.hostname` | `""` | Database server hostname |
+| `database.operation.postgres.port` | `0` | Database server port |
+| `database.operation.postgres.name` | `""` | Database name |
+| `database.operation.postgres.username` | `""` | Database username |
+| `database.operation.postgres.password` | `""` | Database password |
+| `database.operation.postgres.sslmode` | `""` | SSL mode (`disable`, `require`, `verify-ca`, `verify-full`) |
+| `database.operation.postgres.max_open_conns` | `500` | Maximum number of open connections |
+| `database.operation.postgres.max_idle_conns` | `100` | Maximum number of idle connections |
+| `database.operation.postgres.conn_max_lifetime` | `3600` | Maximum connection lifetime in seconds |
+| `database.operation.postgres.max_retries` | `3` | Maximum retry attempts for transient errors |
+| `database.operation.postgres.min_retry_backoff_ms` | `50` | Minimum delay before retrying in milliseconds |
+| `database.operation.postgres.max_retry_backoff_ms` | `2000` | Maximum delay before retrying in milliseconds |
+
+**`database.operation.sqlite.*`** is only read when `database.operation.type: sqlite`:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `database.operation.sqlite.path` | `database/operationdb.db` | SQLite database file path |
+| `database.operation.sqlite.options` | `_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)` | SQLite connection options |
+| `database.operation.sqlite.max_open_conns` | `500` | Maximum number of open connections |
+| `database.operation.sqlite.max_idle_conns` | `100` | Maximum number of idle connections |
+| `database.operation.sqlite.conn_max_lifetime` | `3600` | Maximum connection lifetime in seconds |
+| `database.operation.sqlite.max_retries` | `3` | Maximum retry attempts for transient errors |
+| `database.operation.sqlite.min_retry_backoff_ms` | `50` | Minimum delay before retrying in milliseconds |
+| `database.operation.sqlite.max_retry_backoff_ms` | `2000` | Maximum delay before retrying in milliseconds |
 
 ## Cache Configuration
 

--- a/docs/content/guides/getting-started/get-thunderid.mdx
+++ b/docs/content/guides/getting-started/get-thunderid.mdx
@@ -189,9 +189,11 @@ helm install postgresql oci://registry-1.docker.io/bitnamicharts/postgresql \
 CREATE DATABASE configdb;
 CREATE DATABASE runtimedb;
 CREATE DATABASE userdb;
+CREATE DATABASE operationdb;
 GRANT ALL PRIVILEGES ON DATABASE configdb TO dbuser;
 GRANT ALL PRIVILEGES ON DATABASE runtimedb TO dbuser;
 GRANT ALL PRIVILEGES ON DATABASE userdb TO dbuser;
+GRANT ALL PRIVILEGES ON DATABASE operationdb TO dbuser;
 SQL
 )
 ```
@@ -207,7 +209,7 @@ Apply the database schemas:
 ```bash
 kubectl run {{productSlug}}-dbinit --image=ghcr.io/thunder-id/{{productSlug}}:latest --restart=Never --command -- sleep 300
 kubectl wait --for=condition=ready pod/{{productSlug}}-dbinit --timeout=60s
-for db in configdb runtimedb userdb; do
+for db in configdb runtimedb userdb operationdb; do
   kubectl exec {{productSlug}}-dbinit -- cat /opt/{{productSlug}}/dbscripts/$db/postgres.sql | \
     kubectl exec -i postgresql-0 -- env PGPASSWORD=dbpassword psql -U dbuser -d $db
 done
@@ -226,6 +228,8 @@ helm install {{productSlug}} oci://ghcr.io/thunder-id/helm-charts/{{productSlug}
   --set configuration.database.runtime.postgres.sslmode=disable \
   --set configuration.database.user.postgres.hostname=postgresql \
   --set configuration.database.user.postgres.sslmode=disable \
+  --set configuration.database.operation.postgres.hostname=postgresql \
+  --set configuration.database.operation.postgres.sslmode=disable \
   --set configuration.server.publicUrl=https://localhost:8090 \
   --set configuration.gateClient.hostname=localhost \
   --set configuration.gateClient.port=8090

--- a/install/helm/README.md
+++ b/install/helm/README.md
@@ -84,7 +84,8 @@ If you want to install ThunderID with SQLite databases, use the following comman
 helm install my-thunderid oci://ghcr.io/thunder-id/helm-charts/thunderid \
   --set configuration.database.config.type=sqlite \
   --set configuration.database.runtime.type=sqlite \
-  --set configuration.database.user.type=sqlite
+  --set configuration.database.user.type=sqlite \
+  --set configuration.database.operation.type=sqlite
 ```
 
 **Note:** When using SQLite:
@@ -297,12 +298,13 @@ helm install my-thunderid oci://ghcr.io/thunder-id/helm-charts/thunderid \
   --set configuration.database.config.postgres.password=mypass1 \
   --set configuration.database.runtime.postgres.password=mypass2 \
   --set configuration.database.runtime.redis.password=myredispass \
-  --set configuration.database.user.postgres.password=mypass3
+  --set configuration.database.user.postgres.password=mypass3 \
+  --set configuration.database.operation.postgres.password=mypass4
 ```
 
 Helm automatically:
 - Creates `<release-name>-db-credentials` Secret as a pre-install/pre-upgrade hook
-- Injects environment variables (`DB_CONFIG_PASSWORD`, `DB_RUNTIME_PASSWORD`, `DB_RUNTIME_REDIS_PASSWORD`, `DB_USER_PASSWORD`) into pods
+- Injects environment variables (`DB_CONFIG_PASSWORD`, `DB_RUNTIME_PASSWORD`, `DB_RUNTIME_REDIS_PASSWORD`, `DB_USER_PASSWORD`, `DB_OPERATION_PASSWORD`) into pods
 - Updates pods when passwords change (via checksum annotations)
 
 #### Pattern 2: External Secret (For Production - Recommended)
@@ -314,7 +316,8 @@ Reference a pre-existing Kubernetes Secret (created manually or by external-secr
 kubectl create secret generic my-db-secrets \
   --from-literal=config-password=secret1 \
   --from-literal=runtime-password=secret2 \
-  --from-literal=user-password=secret3
+  --from-literal=user-password=secret3 \
+  --from-literal=operation-password=secret4
 ```
 
 **Step 2:** Configure Helm to reference the external Secret:
@@ -340,6 +343,11 @@ configuration:
         passwordRef:
           name: "my-db-secrets"
           key: "user-password"
+    operation:
+      postgres:
+        passwordRef:
+          name: "my-db-secrets"
+          key: "operation-password"
 ```
 
 When `passwordRef.key` is set, the `password` field is ignored and Helm uses your external Secret.
@@ -354,7 +362,7 @@ when ThunderID reads configuration directly via its application config loader (e
 They are not resolved when the value is first converted into a Kubernetes Secret by this chart.
 
 #### Password Field Options
-Password fields are available in `configuration.database.config.postgres`, `configuration.database.runtime.postgres`, `configuration.database.runtime.redis`, and `configuration.database.user.postgres`:
+Password fields are available in `configuration.database.config.postgres`, `configuration.database.runtime.postgres`, `configuration.database.runtime.redis`, `configuration.database.user.postgres`, and `configuration.database.operation.postgres`:
 
 | Field                  | Description                                                                                                                                    | Example                      |
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
@@ -451,6 +459,23 @@ Password fields are available in `configuration.database.config.postgres`, `conf
 | `configuration.database.user.postgres.max_open_conns`      | Maximum number of open connections to the database                                                                                                      | `500`                        |
 | `configuration.database.user.postgres.max_idle_conns`      | Maximum number of idle connections in the pool                                                                                                          | `100`                        |
 | `configuration.database.user.postgres.conn_max_lifetime`   | Maximum lifetime of a connection in seconds                                                                                                             | `3600`                       |
+| `configuration.database.operation.type`           | Operation database type (postgres or sqlite). Stores SSO sessions, revoked tokens, and consent records.                                                 | `postgres`                   |
+| `configuration.database.operation.sqlite.path`     | SQLite database path (for SQLite only)                                                                                                                  | `database/operationdb.db` |
+| `configuration.database.operation.sqlite.options`  | SQLite options (for SQLite only)                                                                                                                        | `_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)` |
+| `configuration.database.operation.sqlite.max_open_conns` | Maximum number of open connections for SQLite                                                                                                     | `500`                        |
+| `configuration.database.operation.sqlite.max_idle_conns` | Maximum number of idle SQLite connections                                                                                                         | `100`                        |
+| `configuration.database.operation.sqlite.conn_max_lifetime` | Maximum SQLite connection lifetime in seconds                                                                                                  | `3600`                       |
+| `configuration.database.operation.postgres.name`           | Postgres database name (for postgres only)                                                                                                              | `operationdb`                |
+| `configuration.database.operation.postgres.hostname`       | Postgres hostname (for postgres only)                                                                                                                   | `localhost` |
+| `configuration.database.operation.postgres.port`           | Postgres port (for postgres only)                                                                                                                       | `5432`                       |
+| `configuration.database.operation.postgres.username`       | Postgres username (for postgres only)                                                                                                                   | `dbuser`                   |
+| `configuration.database.operation.postgres.password`       | Operation Postgres password - supports plaintext. When `passwordRef.key` is set, this field is ignored and the external Secret is used instead.         | `dbpassword`        |
+| `configuration.database.operation.postgres.passwordRef.name` | Kubernetes Secret name for operation Postgres password                                                                                                | `""`    |
+| `configuration.database.operation.postgres.passwordRef.key`  | Kubernetes Secret key for operation Postgres password                                                                                                 | `""`    |
+| `configuration.database.operation.postgres.sslmode`        | Postgres SSL mode (for postgres only)                                                                                                                   | `require`                    |
+| `configuration.database.operation.postgres.max_open_conns` | Maximum number of open connections to the database                                                                                                      | `500`                        |
+| `configuration.database.operation.postgres.max_idle_conns` | Maximum number of idle connections in the pool                                                                                                          | `100`                        |
+| `configuration.database.operation.postgres.conn_max_lifetime` | Maximum lifetime of a connection in seconds                                                                                                          | `3600`                       |
 | `configuration.cache.disabled`                    | Disable cache                                                                                                                                           | `true`                       |
 | `configuration.cache.type`                        | Cache type                                                                                                                                              | `inmemory`                   |
 | `configuration.cache.size`                        | Cache size                                                                                                                                              | `1000`                       |

--- a/install/helm/conf/deployment.yaml
+++ b/install/helm/conf/deployment.yaml
@@ -181,6 +181,33 @@ database:
       min_retry_backoff_ms: {{ .Values.configuration.database.user.postgres.min_retry_backoff_ms }}
       max_retry_backoff_ms: {{ .Values.configuration.database.user.postgres.max_retry_backoff_ms }}
     {{- end }}
+  operation:
+    type: {{ .Values.configuration.database.operation.type | quote }}
+    {{- if eq .Values.configuration.database.operation.type "sqlite" }}
+    sqlite:
+      path: {{ .Values.configuration.database.operation.sqlite.path | quote }}
+      options: {{ .Values.configuration.database.operation.sqlite.options | quote }}
+      max_open_conns: {{ .Values.configuration.database.operation.sqlite.max_open_conns }}
+      max_idle_conns: {{ .Values.configuration.database.operation.sqlite.max_idle_conns }}
+      conn_max_lifetime: {{ .Values.configuration.database.operation.sqlite.conn_max_lifetime }}
+      max_retries: {{ .Values.configuration.database.operation.sqlite.max_retries }}
+      min_retry_backoff_ms: {{ .Values.configuration.database.operation.sqlite.min_retry_backoff_ms }}
+      max_retry_backoff_ms: {{ .Values.configuration.database.operation.sqlite.max_retry_backoff_ms }}
+    {{- else }}
+    postgres:
+      hostname: {{ .Values.configuration.database.operation.postgres.hostname | quote }}
+      port: {{ .Values.configuration.database.operation.postgres.port }}
+      name: {{ .Values.configuration.database.operation.postgres.name | quote }}
+      username: {{ .Values.configuration.database.operation.postgres.username | quote }}
+      password: {{ "{{.DB_OPERATION_PASSWORD}}" | quote }}
+      sslmode: {{ .Values.configuration.database.operation.postgres.sslmode | quote }}
+      max_open_conns: {{ .Values.configuration.database.operation.postgres.max_open_conns }}
+      max_idle_conns: {{ .Values.configuration.database.operation.postgres.max_idle_conns }}
+      conn_max_lifetime: {{ .Values.configuration.database.operation.postgres.conn_max_lifetime }}
+      max_retries: {{ .Values.configuration.database.operation.postgres.max_retries }}
+      min_retry_backoff_ms: {{ .Values.configuration.database.operation.postgres.min_retry_backoff_ms }}
+      max_retry_backoff_ms: {{ .Values.configuration.database.operation.postgres.max_retry_backoff_ms }}
+    {{- end }}
 
 cache:
   disabled: {{ .Values.configuration.cache.disabled }}

--- a/install/helm/templates/_helpers.tpl
+++ b/install/helm/templates/_helpers.tpl
@@ -95,14 +95,16 @@ This is used to trigger pod restarts when auto-generated Secrets change.
 {{- $runtimePostgres := default dict $runtime.postgres -}}
 {{- $runtimeRedis := default dict $runtime.redis -}}
 {{- $userPostgres := default dict $user.postgres -}}
+{{- $operation := default dict $database.operation -}}
+{{- $operationPostgres := default dict $operation.postgres -}}
 {{- $cache := default dict $configuration.cache -}}
 {{- $redis := default dict $cache.redis -}}
-{{- if or (and $configPostgres.password (not (default dict $configPostgres.passwordRef).key)) (and $runtimePostgres.password (not (default dict $runtimePostgres.passwordRef).key)) (and $runtimeRedis.password (not (default dict $runtimeRedis.passwordRef).key)) (and $userPostgres.password (not (default dict $userPostgres.passwordRef).key)) (and $redis.password (eq $cache.type "redis") (not (default dict $redis.passwordRef).key)) }}true{{- end }}
+{{- if or (and $configPostgres.password (not (default dict $configPostgres.passwordRef).key)) (and $runtimePostgres.password (not (default dict $runtimePostgres.passwordRef).key)) (and $runtimeRedis.password (not (default dict $runtimeRedis.passwordRef).key)) (and $userPostgres.password (not (default dict $userPostgres.passwordRef).key)) (and $operationPostgres.password (not (default dict $operationPostgres.passwordRef).key)) (and $redis.password (eq $cache.type "redis") (not (default dict $redis.passwordRef).key)) }}true{{- end }}
 {{- end }}
 
 {{/*
 Generate database password environment variable definitions for both deployment and setup job.
-Injects DB_CONFIG_PASSWORD, DB_RUNTIME_PASSWORD, and DB_USER_PASSWORD from either auto-generated or external Secrets.
+Injects DB_CONFIG_PASSWORD, DB_RUNTIME_PASSWORD, DB_USER_PASSWORD, and DB_OPERATION_PASSWORD from either auto-generated or external Secrets.
 */}}
 {{- define "thunderid.databasePasswordEnvVars" -}}
 {{- $defaultDbSecretName := printf "%s-db-credentials" (include "thunderid.fullname" .) -}}
@@ -111,14 +113,17 @@ Injects DB_CONFIG_PASSWORD, DB_RUNTIME_PASSWORD, and DB_USER_PASSWORD from eithe
 {{- $config := default dict $database.config -}}
 {{- $runtime := default dict $database.runtime -}}
 {{- $user := default dict $database.user -}}
+{{- $operation := default dict $database.operation -}}
 {{- $configPostgres := default dict $config.postgres -}}
 {{- $runtimePostgres := default dict $runtime.postgres -}}
 {{- $runtimeRedis := default dict $runtime.redis -}}
 {{- $userPostgres := default dict $user.postgres -}}
+{{- $operationPostgres := default dict $operation.postgres -}}
 {{- $configPasswordRef := default dict $configPostgres.passwordRef -}}
 {{- $runtimePasswordRef := default dict $runtimePostgres.passwordRef -}}
 {{- $runtimeRedisPasswordRef := default dict $runtimeRedis.passwordRef -}}
 {{- $userPasswordRef := default dict $userPostgres.passwordRef -}}
+{{- $operationPasswordRef := default dict $operationPostgres.passwordRef -}}
 {{- if or $configPostgres.password $configPasswordRef.key }}
 - name: DB_CONFIG_PASSWORD
   valueFrom:
@@ -146,6 +151,13 @@ Injects DB_CONFIG_PASSWORD, DB_RUNTIME_PASSWORD, and DB_USER_PASSWORD from eithe
     secretKeyRef:
       name: {{ if $userPasswordRef.key }}{{ $userPasswordRef.name | default $defaultDbSecretName }}{{ else }}{{ $defaultDbSecretName }}{{ end }}
       key: {{ $userPasswordRef.key | default "user-db-password" }}
+{{- end }}
+{{- if or $operationPostgres.password $operationPasswordRef.key }}
+- name: DB_OPERATION_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ if $operationPasswordRef.key }}{{ $operationPasswordRef.name | default $defaultDbSecretName }}{{ else }}{{ $defaultDbSecretName }}{{ end }}
+      key: {{ $operationPasswordRef.key | default "operation-db-password" }}
 {{- end }}
 {{- end }}
 

--- a/install/helm/templates/pvc.yaml
+++ b/install/helm/templates/pvc.yaml
@@ -14,7 +14,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-{{- $usingSqlite := or (eq .Values.configuration.database.config.type "sqlite") (eq .Values.configuration.database.runtime.type "sqlite") (eq .Values.configuration.database.user.type "sqlite") }}
+{{- $usingSqlite := or (eq .Values.configuration.database.config.type "sqlite") (eq .Values.configuration.database.runtime.type "sqlite") (eq .Values.configuration.database.user.type "sqlite") (eq .Values.configuration.database.operation.type "sqlite") }}
 {{- if or .Values.persistence.enabled $usingSqlite }}
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/install/helm/templates/secret.yaml
+++ b/install/helm/templates/secret.yaml
@@ -23,6 +23,8 @@
 {{- $runtimePostgres := default dict $runtime.postgres -}}
 {{- $runtimeRedis := default dict $runtime.redis -}}
 {{- $userPostgres := default dict $user.postgres -}}
+{{- $operation := default dict $database.operation -}}
+{{- $operationPostgres := default dict $operation.postgres -}}
 {{- $cache := default dict $configuration.cache -}}
 {{- $redis := default dict $cache.redis -}}
 
@@ -30,6 +32,7 @@
 {{- $runtimePassword := "" }}
 {{- $runtimeRedisPassword := "" }}
 {{- $userPassword := "" }}
+{{- $operationPassword := "" }}
 {{- $redisPassword := "" }}
 
 {{- if and $configPostgres.password (not (default dict $configPostgres.passwordRef).key) }}
@@ -44,11 +47,14 @@
 {{- if and $userPostgres.password (not (default dict $userPostgres.passwordRef).key) }}
   {{- $userPassword = $userPostgres.password }}
 {{- end }}
+{{- if and $operationPostgres.password (not (default dict $operationPostgres.passwordRef).key) }}
+  {{- $operationPassword = $operationPostgres.password }}
+{{- end }}
 {{- if and (eq $cache.type "redis") $redis.password (not (default dict $redis.passwordRef).key) }}
   {{- $redisPassword = $redis.password }}
 {{- end }}
 
-{{- $createSecret := or $configPassword $runtimePassword $runtimeRedisPassword $userPassword $redisPassword}}
+{{- $createSecret := or $configPassword $runtimePassword $runtimeRedisPassword $userPassword $operationPassword $redisPassword}}
 
 {{- if $createSecret }}
 apiVersion: v1
@@ -78,6 +84,9 @@ data:
   {{- end }}
   {{- if $userPassword }}
   user-db-password: {{ $userPassword | b64enc | quote }}
+  {{- end }}
+  {{- if $operationPassword }}
+  operation-db-password: {{ $operationPassword | b64enc | quote }}
   {{- end }}
   {{- if $redisPassword }}
   cache-redis-password: {{ $redisPassword | b64enc | quote }}

--- a/install/helm/templates/setup-job.yaml
+++ b/install/helm/templates/setup-job.yaml
@@ -15,7 +15,7 @@
 # under the License.
 
 {{- if .Values.setup.enabled }}
-{{- $usingSqlite := or (eq .Values.configuration.database.config.type "sqlite") (eq .Values.configuration.database.runtime.type "sqlite") (eq .Values.configuration.database.user.type "sqlite") }}
+{{- $usingSqlite := or (eq .Values.configuration.database.config.type "sqlite") (eq .Values.configuration.database.runtime.type "sqlite") (eq .Values.configuration.database.user.type "sqlite") (eq .Values.configuration.database.operation.type "sqlite") }}
 {{- if and .Values.declarativeResources.enabled .Values.declarativeResources.configMap.name .Values.declarativeResources.secret.name }}
 {{- fail "Invalid declarativeResources configuration: set only one source, declarativeResources.configMap.name or declarativeResources.secret.name." }}
 {{- end }}

--- a/install/helm/templates/thunderid-deployment.yaml
+++ b/install/helm/templates/thunderid-deployment.yaml
@@ -14,7 +14,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-{{- $usingSqlite := or (eq .Values.configuration.database.config.type "sqlite") (eq .Values.configuration.database.runtime.type "sqlite") (eq .Values.configuration.database.user.type "sqlite") }}
+{{- $usingSqlite := or (eq .Values.configuration.database.config.type "sqlite") (eq .Values.configuration.database.runtime.type "sqlite") (eq .Values.configuration.database.user.type "sqlite") (eq .Values.configuration.database.operation.type "sqlite") }}
 {{- if and .Values.declarativeResources.enabled .Values.declarativeResources.configMap.name .Values.declarativeResources.secret.name }}
 {{- fail "Invalid declarativeResources configuration: set only one source, declarativeResources.configMap.name or declarativeResources.secret.name." }}
 {{- end }}

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -343,6 +343,35 @@ configuration:
         max_retries: 3
         min_retry_backoff_ms: 50
         max_retry_backoff_ms: 2000
+    # Operation database configuration. Stores SSO sessions, revoked tokens, and consent records.
+    operation:
+      # WARNING: Use sqlite only if you are running a single pod.
+      type: "postgres" # postgres or sqlite
+      postgres:
+        hostname: "localhost"
+        port: "5432"
+        name: "operationdb"
+        username: "dbuser"
+        password: "dbpassword"
+        passwordRef:
+          name: ""
+          key: ""
+        sslmode: "require"
+        max_open_conns: 500
+        max_idle_conns: 100
+        conn_max_lifetime: 3600
+        max_retries: 3
+        min_retry_backoff_ms: 50
+        max_retry_backoff_ms: 2000
+      sqlite:
+        path: "database/operationdb.db"
+        options: "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)"
+        max_open_conns: 500
+        max_idle_conns: 100
+        conn_max_lifetime: 3600
+        max_retries: 3
+        min_retry_backoff_ms: 50
+        max_retry_backoff_ms: 2000
 
   # Cache configuration
   cache:


### PR DESCRIPTION
### Purpose

ThunderID fails to start unless `database.operation` is configured, but the Helm chart had no way to set it. `configuration.database` rendered only `config`, `runtime`, and `user`, so `--set configuration.database.operation.*` was accepted by Helm and then silently dropped. There was no values path that produced a startable configuration, which made the chart undeployable.

The operation database holds SSO sessions, revoked tokens, and consent records. The SSO session service initialises unconditionally at startup, so a missing `database.operation` is fatal:

```
level=ERROR msg="Failed to initialize SSO session service"
  error="failed to get operation database client: database type is not configured"
```

### Approach

Added `operation` as a first-class database in the chart, following the existing `config` / `runtime` / `user` pattern:

- `values.yaml`: new `configuration.database.operation` block with `postgres` and `sqlite` sub-keys.
- `conf/deployment.yaml`: renders the block alongside the other databases.
- `_helpers.tpl`, `secret.yaml`: wire `DB_OPERATION_PASSWORD` for both the auto-generated Secret and an external `passwordRef`.
- `thunderid-deployment.yaml`, `setup-job.yaml`, `pvc.yaml`: include `operation` in the `$usingSqlite` check.

`pvc.yaml` was a gap beyond the issue. Its `$usingSqlite` check omitted `operation`, so an operation-only SQLite install rendered no PVC while the deployment still mounted `database-storage`, leaving the pod stuck on a claim that never existed.

Docs updated to match. `get-thunderid.mdx` had two live breakages: its install command sets hostname and sslmode per database, so without an `operation` entry the database pointed at `localhost` with `sslmode: require`, and its setup SQL never created `operationdb`.

Issue suggestion 4 (failing fast on an unset database) is not implemented. With a default in `values.yaml`, an unconfigured operation database now surfaces as an ordinary connection error, same as the other three. Happy to add a guard if reviewers want one.

### Verification

`helm lint` and `vale docs/` pass. Verified rendering for the default, all-SQLite, operation-only-SQLite, `--set` override, and external `passwordRef` cases. Both Secret modes resolve correctly, and the reproduction from the issue now renders the overridden hostname instead of nothing.

### Related Issues
- Fixes #4013

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [x] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a required Operation Database for SSO sessions, revoked tokens, and consent records.
  * Added PostgreSQL and SQLite configuration options, including connection pooling, retries, SSL, and storage settings.
  * Helm installations now support operation database credentials, secrets, persistent storage, and automatic configuration.
* **Documentation**
  * Updated deployment, installation, configuration, and production guidance with Operation Database setup instructions and examples.
  * Expanded PostgreSQL initialization steps to create, grant access to, and initialize the additional database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->