### PR TITLE
Resolve federated subject to local user on token exchange via account linking

### DIFF
--- a/backend/internal/oauth/init.go
+++ b/backend/internal/oauth/init.go
@@ -93,7 +93,7 @@ func Initialize(
 	grantHandlerProvider := granthandlers.Initialize(
 		jwtService, oauth2AuthzService, tokenBuilder, tokenValidator,
 		attributeCacheSvc, ouService, authzService, actorProvider, resourceService, serverConfigService,
-		cibaService, refreshTokenRevoker, cfg)
+		cibaService, refreshTokenRevoker, authnProvider, idpService, cfg)
 	token.Initialize(mux, jwtService, actorProvider, authnProvider, grantHandlerProvider,
 		scopeValidator, observabilitySvc, discoveryService, dpopVerifier, cfg)
 	introspect.Initialize(mux, jwtService, actorProvider, authnProvider, discoveryService, tokenValidator)

--- a/backend/internal/oauth/oauth2/granthandlers/init.go
+++ b/backend/internal/oauth/oauth2/granthandlers/init.go
@@ -46,6 +46,8 @@ func Initialize(
 	serverConfigService serverconfig.ServerConfigService,
 	cibaService ciba.CIBAServiceInterface,
 	refreshTokenRevoker revocation.RefreshTokenRevokerInterface,
+	authnProvider providers.AuthnProviderManager,
+	idpService providers.IDPProvider,
 	cfg oauthconfig.Config,
 ) GrantHandlerProviderInterface {
 	return newGrantHandlerProvider(
@@ -61,6 +63,8 @@ func Initialize(
 		serverConfigService,
 		cibaService,
 		refreshTokenRevoker,
+		authnProvider,
+		idpService,
 		cfg,
 	)
 }

--- a/backend/internal/oauth/oauth2/granthandlers/provider.go
+++ b/backend/internal/oauth/oauth2/granthandlers/provider.go
@@ -60,6 +60,8 @@ func newGrantHandlerProvider(
 	serverConfigService serverconfig.ServerConfigService,
 	cibaService ciba.CIBAServiceInterface,
 	refreshTokenRevoker revocation.RefreshTokenRevokerInterface,
+	authnProvider providers.AuthnProviderManager,
+	idpService providers.IDPProvider,
 	cfg oauthconfig.Config,
 ) GrantHandlerProviderInterface {
 	return &GrantHandlerProvider{
@@ -71,7 +73,8 @@ func newGrantHandlerProvider(
 			jwtService, tokenBuilder, tokenValidator, attrCacheService, resourceService,
 			serverConfigService, refreshTokenRevoker, cfg),
 		tokenExchangeGrantHandler: newTokenExchangeGrantHandler(
-			tokenBuilder, tokenValidator, rbacAuthzService, actorProvider, resourceService, serverConfigService),
+			tokenBuilder, tokenValidator, rbacAuthzService, actorProvider, resourceService,
+			serverConfigService, authnProvider, idpService, cfg),
 		cibaGrantHandler: newCIBAGrantHandler(cibaService, tokenBuilder, attrCacheService),
 		jwtBearerGrantHandler: newJWTBearerGrantHandler(
 			tokenBuilder, tokenValidator, resourceService, serverConfigService),

--- a/backend/internal/oauth/oauth2/granthandlers/provider_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/provider_test.go
@@ -85,6 +85,8 @@ func (suite *GrantHandlerProviderTestSuite) SetupTest() {
 		suite.mockServerConfig,
 		suite.mockCIBAService,
 		revocationmock.NewRefreshTokenRevokerInterfaceMock(suite.T()),
+		nil,
+		nil,
 		testhelpers.OAuthConfig(),
 	)
 }
@@ -103,6 +105,8 @@ func (suite *GrantHandlerProviderTestSuite) TestNewGrantHandlerProvider() {
 		suite.mockServerConfig,
 		suite.mockCIBAService,
 		revocationmock.NewRefreshTokenRevokerInterfaceMock(suite.T()),
+		nil,
+		nil,
 		testhelpers.OAuthConfig(),
 	)
 	assert.NotNil(suite.T(), provider)

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
@@ -23,6 +23,8 @@ import (
 	"errors"
 	"slices"
 
+	"github.com/thunder-id/thunderid/internal/idp"
+	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/dpop"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/model"
@@ -32,6 +34,8 @@ import (
 	oauth2utils "github.com/thunder-id/thunderid/internal/oauth/oauth2/utils"
 	"github.com/thunder-id/thunderid/internal/serverconfig"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	sysutils "github.com/thunder-id/thunderid/internal/system/utils"
+	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
 
@@ -43,6 +47,9 @@ type tokenExchangeGrantHandler struct {
 	actorProvider       providers.ActorProvider
 	resourceService     providers.ResourceServerProvider
 	serverConfigService serverconfig.ServerConfigService
+	authnProvider       providers.AuthnProviderManager
+	idpService          providers.IDPProvider
+	cfg                 oauthconfig.Config
 }
 
 // newTokenExchangeGrantHandler creates a new instance of tokenExchangeGrantHandler.
@@ -53,6 +60,9 @@ func newTokenExchangeGrantHandler(
 	actorProvider providers.ActorProvider,
 	resourceService providers.ResourceServerProvider,
 	serverConfigService serverconfig.ServerConfigService,
+	authnProvider providers.AuthnProviderManager,
+	idpService providers.IDPProvider,
+	cfg oauthconfig.Config,
 ) GrantHandlerInterface {
 	return &tokenExchangeGrantHandler{
 		tokenBuilder:        tokenBuilder,
@@ -61,6 +71,9 @@ func newTokenExchangeGrantHandler(
 		actorProvider:       actorProvider,
 		resourceService:     resourceService,
 		serverConfigService: serverConfigService,
+		authnProvider:       authnProvider,
+		idpService:          idpService,
+		cfg:                 cfg,
 	}
 }
 
@@ -254,14 +267,25 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 		finalAudiences = []string{targetRS.Identifier}
 	}
 
+	subject := subjectClaims.Sub
+	subjectAttributes := subjectClaims.UserAttributes
+	localUserID, localAttributes, errResp := h.resolveLinkedLocalUser(ctx, subjectClaims)
+	if errResp != nil {
+		return nil, errResp
+	}
+	if localUserID != "" {
+		subject = localUserID
+		subjectAttributes = mergeSubjectAttributes(subjectClaims.UserAttributes, localAttributes)
+	}
+
 	// Build access token using token builder
 	userSubConfig := oauthApp.UserAccessTokenConfig()
 	accessToken, err := h.tokenBuilder.BuildAccessToken(ctx, &tokenservice.AccessTokenBuildContext{
-		Subject:           subjectClaims.Sub,
+		Subject:           subject,
 		Audiences:         finalAudiences,
 		ClientID:          tokenRequest.ClientID,
 		Scopes:            finalScopes,
-		SubjectAttributes: tokenservice.FilterAttributesByAllowList(subjectClaims.UserAttributes, userSubConfig),
+		SubjectAttributes: tokenservice.FilterAttributesByAllowList(subjectAttributes, userSubConfig),
 		GrantType:         string(providers.GrantTypeTokenExchange),
 		OAuthApp:          oauthApp,
 		ActorClaims:       actorClaims,
@@ -425,6 +449,125 @@ func (h *tokenExchangeGrantHandler) getScopes(
 	return validRequestedScopes, nil
 }
 
+// resolveLinkedLocalUser resolves the local user linked to a federated subject token via account
+// linking. Returns an empty ID when unresolved (caller keeps the federated subject) and an
+// ErrorResponse only on an infrastructure failure.
+func (h *tokenExchangeGrantHandler) resolveLinkedLocalUser(ctx context.Context,
+	subjectClaims *tokenservice.SubjectTokenClaims) (string, map[string]interface{}, *model.ErrorResponse) {
+	// Local-user resolution only applies to externally-issued subject tokens.
+	if h.idpService == nil || h.authnProvider == nil || subjectClaims.Iss == "" ||
+		subjectClaims.Iss == h.cfg.JWT.Issuer {
+		return "", nil, nil
+	}
+
+	filter := h.accountLinkingFilter(ctx, subjectClaims)
+	if len(filter) == 0 {
+		return "", nil, nil
+	}
+	return h.resolveByFilter(ctx, filter)
+}
+
+// accountLinkingFilter builds the local-user lookup filter from the issuing IDP's account-linking
+// attributes, translated from external to local names via the IDP's attribute mappings and read from
+// the subject token's already-mapped attributes.
+func (h *tokenExchangeGrantHandler) accountLinkingFilter(ctx context.Context,
+	subjectClaims *tokenservice.SubjectTokenClaims) map[string]interface{} {
+	idpDTOs, svcErr := h.idpService.GetIdentityProvidersByProperty(ctx, idp.PropIssuer, subjectClaims.Iss)
+	if svcErr != nil || len(idpDTOs) == 0 {
+		return nil
+	}
+	idpDTO := idpDTOs[0]
+	if idpDTO.AttributeConfiguration == nil || idpDTO.AttributeConfiguration.AccountLinking == nil {
+		return nil
+	}
+
+	externalToLocal := make(map[string]string)
+	for _, m := range idp.GetAttributeMappings(&idpDTO, subjectClaims.UserAttributes) {
+		externalToLocal[m.ExternalAttribute] = m.LocalAttribute
+	}
+
+	filter := make(map[string]interface{})
+	for _, attr := range idpDTO.AttributeConfiguration.AccountLinking.Attributes {
+		local := attr
+		if mapped, ok := externalToLocal[attr]; ok {
+			local = mapped
+		}
+		if value := sysutils.ConvertInterfaceValueToString(subjectClaims.UserAttributes[local]); value != "" {
+			filter[local] = value
+		}
+	}
+	if len(filter) == 0 {
+		return nil
+	}
+	return filter
+}
+
+// resolveByFilter resolves a local user by lookup filter and returns its ID and stored attributes.
+func (h *tokenExchangeGrantHandler) resolveByFilter(ctx context.Context,
+	filter map[string]interface{}) (string, map[string]interface{}, *model.ErrorResponse) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "TokenExchangeGrantHandler"))
+
+	var authUser providers.AuthUser
+	authUser.SetEntityReferenceToken(filter)
+	authUser.SetAttributeToken(filter)
+
+	authUser, entityRef, svcErr := h.authnProvider.GetEntityReference(ctx, authUser)
+	if svcErr != nil {
+		if svcErr.Type == tidcommon.ClientErrorType {
+			return "", nil, nil
+		}
+		logger.Error(ctx, "Failed to resolve linked local user for token exchange",
+			log.String("errorCode", svcErr.Code))
+		return "", nil, &model.ErrorResponse{
+			Error:            constants.ErrorServerError,
+			ErrorDescription: "Failed to resolve subject",
+		}
+	}
+
+	// The local user is already resolved, so a failure to load its attributes is a server-side error,
+	// not a "not linked" signal; fail rather than fall back to the federated subject.
+	_, attrResp, svcErr := h.authnProvider.GetUserAttributes(ctx, nil, nil, authUser)
+	if svcErr != nil {
+		logger.Error(ctx, "Failed to fetch linked local user attributes for token exchange",
+			log.String("errorCode", svcErr.Code))
+		return "", nil, &model.ErrorResponse{
+			Error:            constants.ErrorServerError,
+			ErrorDescription: "Failed to resolve subject",
+		}
+	}
+
+	return entityRef.EntityID, extractLocalUserAttributes(attrResp), nil
+}
+
+// extractLocalUserAttributes flattens an attributes response into a claim map, stripping reserved
+// claim names.
+func extractLocalUserAttributes(resp *providers.AttributesResponse) map[string]interface{} {
+	if resp == nil {
+		return nil
+	}
+	attrs := make(map[string]interface{}, len(resp.Attributes))
+	for name, attr := range resp.Attributes {
+		if attr != nil {
+			attrs[name] = attr.Value
+		}
+	}
+	return tokenservice.ExtractUserAttributes(attrs)
+}
+
+// mergeSubjectAttributes merges federated and local attributes, with local values taking precedence.
+func mergeSubjectAttributes(federated, local map[string]interface{}) map[string]interface{} {
+	merged := make(map[string]interface{}, len(federated)+len(local))
+	for k, v := range federated {
+		merged[k] = v
+	}
+	for k, v := range local {
+		merged[k] = v
+	}
+	return merged
+}
+
+// filterScopesAuthorizedForApp filters the given scopes to those the app is authorized for on the
+// target resource server.
 func (h *tokenExchangeGrantHandler) filterScopesAuthorizedForApp(
 	ctx context.Context,
 	oauthApp *providers.OAuthClient,

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
+	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/dpop"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/model"
@@ -44,7 +45,9 @@ import (
 	"github.com/thunder-id/thunderid/internal/resource"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/tests/mocks/actorprovidermock"
+	"github.com/thunder-id/thunderid/tests/mocks/authnprovider/managermock"
 	"github.com/thunder-id/thunderid/tests/mocks/authzmock"
+	"github.com/thunder-id/thunderid/tests/mocks/idp/idpmock"
 	"github.com/thunder-id/thunderid/tests/mocks/jose/jwtmock"
 	"github.com/thunder-id/thunderid/tests/mocks/oauth/oauth2/tokenservicemock"
 	"github.com/thunder-id/thunderid/tests/mocks/resourcemock"
@@ -59,6 +62,7 @@ const (
 	testClientID         = "client123"
 	testUserID           = "user123"
 	testScopeRead        = "read"
+	testLocalEmail       = "local@example.com"
 	// testTokenExchangeDefaultRSID / testTokenExchangeDefaultRSAudience model the
 	// deployment-configured default resource server used when a request carries no explicit
 	// resource parameter.
@@ -261,9 +265,375 @@ func (suite *TokenExchangeGrantHandlerTestSuite) setupSuccessfulJWTMockWithScope
 // TestNewTokenExchangeGrantHandler tests the constructor
 func (suite *TokenExchangeGrantHandlerTestSuite) TestNewTokenExchangeGrantHandler() {
 	handler := newTokenExchangeGrantHandler(suite.mockTokenBuilder, suite.mockTokenValidator,
-		suite.mockAuthzService, suite.mockActorProvider, suite.mockResourceService, suite.mockServerConfigSvc)
+		suite.mockAuthzService, suite.mockActorProvider, suite.mockResourceService, suite.mockServerConfigSvc,
+		nil, nil, oauthconfig.Config{})
 	assert.NotNil(suite.T(), handler)
 	assert.Implements(suite.T(), (*GrantHandlerInterface)(nil), handler)
+}
+
+// newAccountLinkingHandler builds a token exchange handler wired with the given authn provider and IDP
+// service, reusing the suite's mocks. Its configured issuer is the suite's server issuer so an external
+// subject token (testCustomIssuer) is treated as federated.
+func (suite *TokenExchangeGrantHandlerTestSuite) newAccountLinkingHandler(
+	authnProvider providers.AuthnProviderManager, idpService providers.IDPProvider) *tokenExchangeGrantHandler {
+	return &tokenExchangeGrantHandler{
+		tokenBuilder:        suite.mockTokenBuilder,
+		tokenValidator:      suite.mockTokenValidator,
+		authzService:        suite.mockAuthzService,
+		actorProvider:       suite.mockActorProvider,
+		resourceService:     suite.mockResourceService,
+		serverConfigService: suite.mockServerConfigSvc,
+		authnProvider:       authnProvider,
+		idpService:          idpService,
+		cfg:                 oauthconfig.Config{JWT: engineconfig.JWTConfig{Issuer: "https://auth.example.com"}},
+	}
+}
+
+// accountLinkingIDPService returns an IDP service mock resolving the issuer to an IDP configured to
+// link accounts by the "email" attribute (external name equal to its local name, no attribute mapping
+// configured).
+func (suite *TokenExchangeGrantHandlerTestSuite) accountLinkingIDPService() *idpmock.IDPServiceInterfaceMock {
+	m := idpmock.NewIDPServiceInterfaceMock(suite.T())
+	m.On("GetIdentityProvidersByProperty", mock.Anything, mock.Anything, mock.Anything).
+		Return([]providers.IDPDTO{{
+			AttributeConfiguration: &providers.AttributeConfiguration{
+				AccountLinking: &providers.AccountLinking{Attributes: []string{"email"}},
+			},
+		}}, nil)
+	return m
+}
+
+// remappedAccountLinkingIDPService returns an IDP service mock resolving the issuer to an IDP that
+// links accounts by the external attribute "mail", mapped to the local attribute "emailAddress" under
+// the default user type.
+func (suite *TokenExchangeGrantHandlerTestSuite) remappedAccountLinkingIDPService() *idpmock.IDPServiceInterfaceMock {
+	m := idpmock.NewIDPServiceInterfaceMock(suite.T())
+	m.On("GetIdentityProvidersByProperty", mock.Anything, mock.Anything, mock.Anything).
+		Return([]providers.IDPDTO{{
+			AttributeConfiguration: &providers.AttributeConfiguration{
+				UserTypeResolution: &providers.UserTypeResolution{Default: "Person"},
+				UserTypeAttributeMappings: []providers.UserTypeAttributeMapping{{
+					UserType: "Person",
+					Attributes: []providers.AttributeMapping{
+						{ExternalAttribute: "mail", LocalAttribute: "emailAddress"},
+					},
+				}},
+				AccountLinking: &providers.AccountLinking{Attributes: []string{"mail"}},
+			},
+		}}, nil)
+	return m
+}
+
+// noLinkingIDPService returns an IDP service mock resolving the issuer to an IDP with no account-linking
+// configured.
+func (suite *TokenExchangeGrantHandlerTestSuite) noLinkingIDPService() *idpmock.IDPServiceInterfaceMock {
+	m := idpmock.NewIDPServiceInterfaceMock(suite.T())
+	m.On("GetIdentityProvidersByProperty", mock.Anything, mock.Anything, mock.Anything).
+		Return([]providers.IDPDTO{{}}, nil)
+	return m
+}
+
+// federatedSubjectClaims returns validated subject-token claims for an externally-issued (federated)
+// subject token, as the validator would produce.
+func federatedSubjectClaims(userAttributes map[string]interface{}) *tokenservice.SubjectTokenClaims {
+	return &tokenservice.SubjectTokenClaims{
+		Sub:            "fed-sub",
+		Iss:            testCustomIssuer,
+		Scopes:         []string{testScopeRead},
+		UserAttributes: userAttributes,
+	}
+}
+
+// TestHandleGrant_AccountLinking_ResolvesByLinkedAttribute verifies that a federated subject token whose
+// issuing IDP links accounts by a configured attribute yields a token subject equal to the resolved
+// local user ID, with the local user's stored attributes merged over the federated claims (local
+// attributes win).
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AccountLinking_ResolvesByLinkedAttribute() {
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{"sub": "fed-sub"})
+	tokenRequest := suite.createBasicTokenRequest(subjectToken)
+
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
+		Return(federatedSubjectClaims(map[string]interface{}{"email": "fed@example.com", "name": "Fed Name"}), nil)
+
+	authnProvider := managermock.NewAuthnProviderManagerMock(suite.T())
+	authnProvider.On("GetEntityReference", mock.Anything, mock.Anything).
+		Return(providers.AuthUser{}, &providers.EntityReference{EntityID: testUserID}, nil)
+	authnProvider.On("GetUserAttributes", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(providers.AuthUser{}, &providers.AttributesResponse{
+			Attributes: map[string]*providers.AttributeResponse{
+				"email":        {Value: testLocalEmail},
+				"organization": {Value: "Acme"},
+			},
+		}, nil)
+
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return ctx.Subject == testUserID &&
+				ctx.SubjectAttributes["email"] == testLocalEmail &&
+				ctx.SubjectAttributes["name"] == "Fed Name" &&
+				ctx.SubjectAttributes["organization"] == "Acme"
+		})).Return(&model.TokenDTO{
+		Token:     testTokenExchangeJWT,
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  now,
+		ExpiresIn: 7200,
+		Scopes:    []string{testScopeRead},
+		ClientID:  testClientID,
+	}, nil)
+
+	handler := suite.newAccountLinkingHandler(authnProvider, suite.accountLinkingIDPService())
+	result, errResp := handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), testTokenExchangeJWT, result.AccessToken.Token)
+}
+
+// TestHandleGrant_AccountLinking_ResolvesByRemappedAttribute verifies that when the account-linking
+// attribute's external name differs from its local name (per the IDP's attribute mappings), the filter
+// is built from the translated local name and its value in the already-mapped subject-token attributes.
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AccountLinking_ResolvesByRemappedAttribute() {
+	now := time.Now().Unix()
+	suite.oauthApp.Token.AccessToken.UserConfig.Attributes = []string{"emailAddress"}
+
+	subjectToken := suite.createTestJWT(map[string]interface{}{"sub": "fed-sub"})
+	tokenRequest := suite.createBasicTokenRequest(subjectToken)
+
+	// The validator would have mapped the external "mail" claim to the local "emailAddress" attribute.
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
+		Return(federatedSubjectClaims(map[string]interface{}{"emailAddress": "fed@example.com"}), nil)
+
+	authnProvider := managermock.NewAuthnProviderManagerMock(suite.T())
+	authnProvider.On("GetEntityReference", mock.Anything, mock.Anything).
+		Return(providers.AuthUser{}, &providers.EntityReference{EntityID: testUserID}, nil)
+	authnProvider.On("GetUserAttributes", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(providers.AuthUser{}, &providers.AttributesResponse{
+			Attributes: map[string]*providers.AttributeResponse{
+				"emailAddress": {Value: testLocalEmail},
+			},
+		}, nil)
+
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return ctx.Subject == testUserID && ctx.SubjectAttributes["emailAddress"] == testLocalEmail
+		})).Return(&model.TokenDTO{
+		Token:     testTokenExchangeJWT,
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  now,
+		ExpiresIn: 7200,
+		Scopes:    []string{testScopeRead},
+		ClientID:  testClientID,
+	}, nil)
+
+	handler := suite.newAccountLinkingHandler(authnProvider, suite.remappedAccountLinkingIDPService())
+	result, errResp := handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), testTokenExchangeJWT, result.AccessToken.Token)
+}
+
+// TestHandleGrant_AccountLinking_StripsReservedLocalClaims verifies that reserved/standard claim names
+// present in the linked local user's stored attributes never leak into the issued token, even when the
+// app's attribute allow-list would otherwise permit them.
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AccountLinking_StripsReservedLocalClaims() {
+	now := time.Now().Unix()
+	// Allow-list a reserved claim name so this test isolates the ExtractUserAttributes filtering from
+	// the allow-list filtering.
+	suite.oauthApp.Token.AccessToken.UserConfig.Attributes = []string{"email", "scope"}
+
+	subjectToken := suite.createTestJWT(map[string]interface{}{"sub": "fed-sub"})
+	tokenRequest := suite.createBasicTokenRequest(subjectToken)
+
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
+		Return(federatedSubjectClaims(map[string]interface{}{"email": "fed@example.com"}), nil)
+
+	authnProvider := managermock.NewAuthnProviderManagerMock(suite.T())
+	authnProvider.On("GetEntityReference", mock.Anything, mock.Anything).
+		Return(providers.AuthUser{}, &providers.EntityReference{EntityID: testUserID}, nil)
+	authnProvider.On("GetUserAttributes", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(providers.AuthUser{}, &providers.AttributesResponse{
+			Attributes: map[string]*providers.AttributeResponse{
+				"email": {Value: testLocalEmail},
+				"scope": {Value: "injected admin"}, // reserved claim name; must be stripped
+			},
+		}, nil)
+
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			_, hasScope := ctx.SubjectAttributes["scope"]
+			return ctx.Subject == testUserID &&
+				ctx.SubjectAttributes["email"] == testLocalEmail &&
+				!hasScope
+		})).Return(&model.TokenDTO{
+		Token:     testTokenExchangeJWT,
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  now,
+		ExpiresIn: 7200,
+		Scopes:    []string{testScopeRead},
+		ClientID:  testClientID,
+	}, nil)
+
+	handler := suite.newAccountLinkingHandler(authnProvider, suite.accountLinkingIDPService())
+	result, errResp := handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+}
+
+// TestHandleGrant_AccountLinking_SkippedWhenNoLinkedAttributes verifies that when the issuing IDP has no
+// account-linking configured, no local-user lookup is attempted and the federated subject is kept.
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AccountLinking_SkippedWhenNoLinkedAttributes() {
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{"sub": "fed-sub"})
+	tokenRequest := suite.createBasicTokenRequest(subjectToken)
+
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
+		Return(federatedSubjectClaims(map[string]interface{}{"email": "fed@example.com"}), nil)
+
+	// No account linking configured, so the authn provider must never be consulted.
+	authnProvider := managermock.NewAuthnProviderManagerMock(suite.T())
+
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return ctx.Subject == "fed-sub" && ctx.SubjectAttributes["email"] == "fed@example.com"
+		})).Return(&model.TokenDTO{
+		Token:     testTokenExchangeJWT,
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  now,
+		ExpiresIn: 7200,
+		Scopes:    []string{testScopeRead},
+		ClientID:  testClientID,
+	}, nil)
+
+	handler := suite.newAccountLinkingHandler(authnProvider, suite.noLinkingIDPService())
+	result, errResp := handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), testTokenExchangeJWT, result.AccessToken.Token)
+	authnProvider.AssertNotCalled(suite.T(), "GetEntityReference", mock.Anything, mock.Anything)
+}
+
+// TestHandleGrant_AccountLinking_FallsBackWhenNoLocalUser verifies that when account linking is
+// configured but no unique local user matches, the exchange keeps the federated subject and claims.
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AccountLinking_FallsBackWhenNoLocalUser() {
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{"sub": "fed-sub"})
+	tokenRequest := suite.createBasicTokenRequest(subjectToken)
+
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
+		Return(federatedSubjectClaims(map[string]interface{}{"email": "fed@example.com"}), nil)
+
+	authnProvider := managermock.NewAuthnProviderManagerMock(suite.T())
+	authnProvider.On("GetEntityReference", mock.Anything, mock.Anything).
+		Return(providers.AuthUser{}, nil, &tidcommon.ServiceError{Type: tidcommon.ClientErrorType})
+
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return ctx.Subject == "fed-sub" && ctx.SubjectAttributes["email"] == "fed@example.com"
+		})).Return(&model.TokenDTO{
+		Token:     testTokenExchangeJWT,
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  now,
+		ExpiresIn: 7200,
+		Scopes:    []string{testScopeRead},
+		ClientID:  testClientID,
+	}, nil)
+
+	handler := suite.newAccountLinkingHandler(authnProvider, suite.accountLinkingIDPService())
+	result, errResp := handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), testTokenExchangeJWT, result.AccessToken.Token)
+}
+
+// TestHandleGrant_AccountLinking_ServerErrorFails verifies that a server error while resolving the
+// linked local user fails the exchange with server_error rather than issuing a token.
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AccountLinking_ServerErrorFails() {
+	subjectToken := suite.createTestJWT(map[string]interface{}{"sub": "fed-sub"})
+	tokenRequest := suite.createBasicTokenRequest(subjectToken)
+
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
+		Return(federatedSubjectClaims(map[string]interface{}{"email": "fed@example.com"}), nil)
+
+	authnProvider := managermock.NewAuthnProviderManagerMock(suite.T())
+	authnProvider.On("GetEntityReference", mock.Anything, mock.Anything).
+		Return(providers.AuthUser{}, nil, &tidcommon.InternalServerError)
+
+	handler := suite.newAccountLinkingHandler(authnProvider, suite.accountLinkingIDPService())
+	result, errResp := handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorServerError, errResp.Error)
+}
+
+// TestHandleGrant_AccountLinking_AttributeFetchFailureFails verifies that once a local user is resolved,
+// a failure to load its attributes fails the exchange instead of falling back to the federated subject.
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AccountLinking_AttributeFetchFailureFails() {
+	subjectToken := suite.createTestJWT(map[string]interface{}{"sub": "fed-sub"})
+	tokenRequest := suite.createBasicTokenRequest(subjectToken)
+
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
+		Return(federatedSubjectClaims(map[string]interface{}{"email": "fed@example.com"}), nil)
+
+	authnProvider := managermock.NewAuthnProviderManagerMock(suite.T())
+	authnProvider.On("GetEntityReference", mock.Anything, mock.Anything).
+		Return(providers.AuthUser{}, &providers.EntityReference{EntityID: testUserID}, nil)
+	authnProvider.On("GetUserAttributes", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(providers.AuthUser{}, nil, &tidcommon.ServiceError{Type: tidcommon.ClientErrorType})
+
+	handler := suite.newAccountLinkingHandler(authnProvider, suite.accountLinkingIDPService())
+	result, errResp := handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorServerError, errResp.Error)
+}
+
+// TestHandleGrant_AccountLinking_SkippedForSelfIssued verifies that a self-issued subject token (issuer
+// equal to the server issuer) never engages the IDP service or authn provider, keeping the subject
+// unchanged.
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AccountLinking_SkippedForSelfIssued() {
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{"sub": testUserID})
+	tokenRequest := suite.createBasicTokenRequest(subjectToken)
+
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub:            testUserID,
+			Iss:            "https://auth.example.com",
+			Scopes:         []string{testScopeRead},
+			UserAttributes: map[string]interface{}{"email": testUserEmail},
+		}, nil)
+
+	// The IDP service and authn provider are wired but must never be called for a self-issued token.
+	authnProvider := managermock.NewAuthnProviderManagerMock(suite.T())
+	idpService := idpmock.NewIDPServiceInterfaceMock(suite.T())
+
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return ctx.Subject == testUserID && ctx.SubjectAttributes["email"] == testUserEmail
+		})).Return(&model.TokenDTO{
+		Token:     testTokenExchangeJWT,
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  now,
+		ExpiresIn: 7200,
+		Scopes:    []string{testScopeRead},
+		ClientID:  testClientID,
+	}, nil)
+
+	handler := suite.newAccountLinkingHandler(authnProvider, idpService)
+	result, errResp := handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+	idpService.AssertNotCalled(suite.T(), "GetIdentityProvidersByProperty",
+		mock.Anything, mock.Anything, mock.Anything)
+	authnProvider.AssertNotCalled(suite.T(), "GetEntityReference", mock.Anything, mock.Anything)
 }
 
 func (suite *TokenExchangeGrantHandlerTestSuite) TestValidateGrant_Success() {

--- a/docs/content/guides/guides/identity-providers/token-exchange-idp.mdx
+++ b/docs/content/guides/guides/identity-providers/token-exchange-idp.mdx
@@ -121,10 +121,18 @@ If any step fails, the exchange returns HTTP 400 with `error=invalid_request` an
 
 Attribute configuration for token exchange uses the same `attributeConfiguration` structure as federated sign-in. See [Add an OIDC Identity Provider](../add-oidc-provider#attribute-configuration) for the full reference.
 
+## Account Linking
+
+By default, the exchanged token carries the external user's `sub` and mapped attributes. When the issuing IdP has account linking configured through `attributeConfiguration.accountLinking.attributes`, <ProductName /> resolves the external subject to a local user:
+
+1. The configured account-linking attributes (resolved to local attribute names via the IdP's attribute mappings) are matched against the token's mapped attributes to look up a unique local user.
+2. When a unique local user is found, the exchanged token's subject becomes the local user ID, and the local user's stored attributes are merged over the mapped external attributes. Local attributes take precedence on conflict.
+3. When account linking is not configured, or no unique local user matches, the exchange retains the external subject and attributes.
+
 ## Limitations
 
 - Only JWT tokens are supported. Opaque tokens (for example, GitHub access tokens) cannot be exchanged.
-- The external user's `sub` is passed through as-is. No local user lookup or just-in-time provisioning occurs.
+- Without account linking configured, the external user's `sub` is passed through as-is and no just-in-time provisioning occurs. See [Account Linking](#account-linking).
 - No scope mapping is applied; external token scopes use the existing intersection logic. External claims can be renamed to local attributes via the IdP's `attributeConfiguration` (see [Attribute Configuration](#attribute-configuration)); the resulting attributes are still filtered by the application's `userAttributes` configuration.
 - Token exchange is available to all applications that have the token exchange grant type. No per-application IdP restriction applies.
 


### PR DESCRIPTION
### Purpose

Today, token exchange passes an external IdP subject token's `sub` and mapped claims straight through to the issued token. This PR resolves the federated subject to a local user when the issuing IdP has account linking configured, so the exchanged token represents the linked local user instead of the raw federated identity.

- The issuing IdP's configured account-linking attributes are matched against the subject token's already-mapped claims to find a unique local user.
- When one is found, the token's subject becomes the local user ID, and the local user's stored attributes are merged over the federated claims (local attributes win on conflict).
- When no unique local user is linked (not configured, no match, or ambiguous), the exchange falls back to the existing pass-through behavior. Self-issued subject tokens are unaffected.

This is additive and non-breaking.

### Approach

The logic is self-contained in the token-exchange grant handler, reusing the existing `AuthnProviderManager` and `IDPProvider` dependencies already available to `oauth.Initialize` — no changes to the token validator, `SubjectTokenClaims`, or the interactive login flow's account-linking code.

**Deferred follow-up (same as the interactive login-flow account linking):** linking by email does not yet require the IdP's `email_verified` claim. Out of scope for this PR.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token exchange can now link externally-issued (federated) subject tokens to existing local accounts.
  * When linking is configured and a match is found, issued tokens use the linked local user as the subject; locally stored attributes take precedence and allow-listed subject attributes are applied.
  * Supports account-linking attribute mapping (including remapped external attribute names) and strips reserved/standard claim names from linked attributes.
* **Bug Fixes**
  * Client-side “not resolvable” lookup results no longer override the federated subject; unexpected failures return an OAuth `server_error`.
  * Account-linking is skipped for self-issued subject tokens and when required linking configuration isn’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->