### PR TITLE
[Bug-fix] Fix validation on required properties

### DIFF
--- a/backend/internal/flow/executor/passkey_executor.go
+++ b/backend/internal/flow/executor/passkey_executor.go
@@ -136,7 +136,9 @@ func newPasskeyAuthExecutor(
 				passkeyExecutorModeRegFinish,
 			},
 			SupportedProperties: []providers.ExecutorSupportedProperties{
-				{Property: "relyingPartyId", IsRequired: true},
+				{Property: "relyingPartyId", IsRequired: true, ApplicableModes: []string{
+					passkeyExecutorModeChallenge, passkeyExecutorModeRegStart,
+				}},
 				{Property: "relyingPartyName"},
 				{Property: "authenticatorSelection"},
 				{Property: "attestation"},

--- a/backend/internal/flow/mgt/validator.go
+++ b/backend/internal/flow/mgt/validator.go
@@ -928,11 +928,21 @@ func (v *flowValidator) validateExecutorProperties(
 		return nil
 	}
 
+	// Resolve effective mode: explicit node mode, or executor default.
+	effectiveMode := node.Executor.Mode
+	if effectiveMode == "" {
+		effectiveMode = meta.DefaultMode
+	}
+
 	supported := make(map[string]bool, len(meta.SupportedProperties))
 	for _, prop := range meta.SupportedProperties {
 		supported[prop.Property] = true
 		// Check required properties
 		if prop.IsRequired {
+			// If RequiredForModes is specified, only enforce for those modes.
+			if len(prop.ApplicableModes) > 0 && !containsMode(prop.ApplicableModes, effectiveMode) {
+				continue
+			}
 			val, ok := node.Properties[prop.Property]
 			if !ok || val == nil || val == "" {
 				return tidcommon.CustomServiceError(ErrorInvalidExecutorConfig, tidcommon.I18nMessage{
@@ -965,6 +975,16 @@ func (v *flowValidator) validateExecutorProperties(
 		}
 	}
 	return nil
+}
+
+// containsMode returns true if the given mode is present in the modes slice.
+func containsMode(modes []string, mode string) bool {
+	for _, m := range modes {
+		if m == mode {
+			return true
+		}
+	}
+	return false
 }
 
 // validateSSOCheckExecutor validates that an SSOCheck node's checkpointRef property references

--- a/backend/internal/flow/mgt/validator_test.go
+++ b/backend/internal/flow/mgt/validator_test.go
@@ -1598,6 +1598,107 @@ func (s *ValidatorServiceTestSuite) TestValidateExecutorConstraints_NoMetaSkipsC
 	s.Nil(err)
 }
 
+func (s *ValidatorServiceTestSuite) TestValidateExecutorConstraints_RequiredForModes_MatchingModeMissing() {
+	s.mockExecutorRegistry.On("GetExecutorMeta", "my-exec").Return(&providers.ExecutorMeta{
+		SupportedModes: []string{"challenge", "verify"},
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: "relyingPartyId", IsRequired: true, ApplicableModes: []string{"challenge"}},
+		},
+	}, nil)
+	node := &providers.NodeDefinition{
+		ID:         "task",
+		Executor:   &providers.ExecutorDefinition{Name: "my-exec", Mode: "challenge"},
+		Properties: map[string]interface{}{},
+	}
+	err := s.v.validateExecutorMeta(node, providers.FlowTypeAuthentication)
+	s.Require().NotNil(err)
+	s.Equal(ErrorInvalidExecutorConfig.Code, err.Code)
+}
+
+func (s *ValidatorServiceTestSuite) TestValidateExecutorConstraints_RequiredForModes_NonMatchingModeSkipped() {
+	s.mockExecutorRegistry.On("GetExecutorMeta", "my-exec").Return(&providers.ExecutorMeta{
+		SupportedModes: []string{"challenge", "verify"},
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: "relyingPartyId", IsRequired: true, ApplicableModes: []string{"challenge"}},
+		},
+	}, nil)
+	node := &providers.NodeDefinition{
+		ID:         "task",
+		Executor:   &providers.ExecutorDefinition{Name: "my-exec", Mode: "verify"},
+		Properties: map[string]interface{}{},
+	}
+	err := s.v.validateExecutorMeta(node, providers.FlowTypeAuthentication)
+	s.Nil(err)
+}
+
+func (s *ValidatorServiceTestSuite) TestValidateExecutorConstraints_RequiredForModes_MatchingModePresent() {
+	s.mockExecutorRegistry.On("GetExecutorMeta", "my-exec").Return(&providers.ExecutorMeta{
+		SupportedModes: []string{"challenge", "verify"},
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: "relyingPartyId", IsRequired: true, ApplicableModes: []string{"challenge"}},
+		},
+	}, nil)
+	node := &providers.NodeDefinition{
+		ID:         "task",
+		Executor:   &providers.ExecutorDefinition{Name: "my-exec", Mode: "challenge"},
+		Properties: map[string]interface{}{"relyingPartyId": "example.com"},
+	}
+	err := s.v.validateExecutorMeta(node, providers.FlowTypeAuthentication)
+	s.Nil(err)
+}
+
+func (s *ValidatorServiceTestSuite) TestValidateExecutorConstraints_RequiredForModes_EmptyModesEnforcedForAll() {
+	s.mockExecutorRegistry.On("GetExecutorMeta", "my-exec").Return(&providers.ExecutorMeta{
+		SupportedModes: []string{"challenge", "verify"},
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: "emailTemplate", IsRequired: true},
+		},
+	}, nil)
+	node := &providers.NodeDefinition{
+		ID:         "task",
+		Executor:   &providers.ExecutorDefinition{Name: "my-exec", Mode: "verify"},
+		Properties: map[string]interface{}{},
+	}
+	err := s.v.validateExecutorMeta(node, providers.FlowTypeAuthentication)
+	s.Require().NotNil(err)
+	s.Equal(ErrorInvalidExecutorConfig.Code, err.Code)
+}
+
+func (s *ValidatorServiceTestSuite) TestValidateExecutorConstraints_RequiredForModes_DefaultModeMatching() {
+	s.mockExecutorRegistry.On("GetExecutorMeta", "my-exec").Return(&providers.ExecutorMeta{
+		DefaultMode:    "challenge",
+		SupportedModes: []string{"challenge", "verify"},
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: "relyingPartyId", IsRequired: true, ApplicableModes: []string{"challenge"}},
+		},
+	}, nil)
+	node := &providers.NodeDefinition{
+		ID:         "task",
+		Executor:   &providers.ExecutorDefinition{Name: "my-exec"},
+		Properties: map[string]interface{}{},
+	}
+	err := s.v.validateExecutorMeta(node, providers.FlowTypeAuthentication)
+	s.Require().NotNil(err)
+	s.Equal(ErrorInvalidExecutorConfig.Code, err.Code)
+}
+
+func (s *ValidatorServiceTestSuite) TestValidateExecutorConstraints_RequiredForModes_DefaultModeNonMatching() {
+	s.mockExecutorRegistry.On("GetExecutorMeta", "my-exec").Return(&providers.ExecutorMeta{
+		DefaultMode:    "verify",
+		SupportedModes: []string{"challenge", "verify"},
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: "relyingPartyId", IsRequired: true, ApplicableModes: []string{"challenge"}},
+		},
+	}, nil)
+	node := &providers.NodeDefinition{
+		ID:         "task",
+		Executor:   &providers.ExecutorDefinition{Name: "my-exec"},
+		Properties: map[string]interface{}{},
+	}
+	err := s.v.validateExecutorMeta(node, providers.FlowTypeAuthentication)
+	s.Nil(err)
+}
+
 // ---------------------------------------------------------------------------
 // Tests for validateSSOCheckExecutor
 // ---------------------------------------------------------------------------

--- a/backend/pkg/thunderidengine/providers/model.go
+++ b/backend/pkg/thunderidengine/providers/model.go
@@ -926,6 +926,8 @@ type ExecutorSupportedProperties struct {
 	Property string `json:"property"`
 	// IsRequired indicates whether the property is required for the executor to function correctly.
 	IsRequired bool `json:"isRequired"`
+	// ApplicableModes limits the required check to the listed modes.
+	ApplicableModes []string `json:"applicableModes,omitempty"`
 }
 
 // ExecutorMeta describes the static capabilities of an executor.

--- a/frontend/apps/console/src/features/flows/data/templates.json
+++ b/frontend/apps/console/src/features/flows/data/templates.json
@@ -1491,7 +1491,6 @@
             }
           },
           "properties": {
-            "senderId": "{{SENDER_ID}}",
             "emailTemplate": "OTP"
           },
           "executor": {
@@ -7127,7 +7126,6 @@
             }
           },
           "properties": {
-            "senderId": "{{SENDER_ID}}",
             "emailTemplate": "OTP"
           },
           "executor": {


### PR DESCRIPTION
### Purpose
Fixes: https://github.com/thunder-id/thunderid/issues/4048

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4048

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Passkey authentication properties are now required only for the executor modes that need them.
  - Flow validation now enforces (or skips) executor-supported properties based on the selected or default executor mode.
  - Email OTP sign-in and sign-up now use OTP templates without requiring a sender ID.

- **Tests**
  - Added unit tests for mode-specific validation covering matching, non-matching, default, and unspecified modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->