### PR TITLE
Update external idp callback link in docs

### DIFF
--- a/docs/content/guides/guides/identity-providers/add-github.mdx
+++ b/docs/content/guides/guides/identity-providers/add-github.mdx
@@ -26,7 +26,7 @@ This guide walks you through registering a GitHub identity provider (IdP) in <Pr
    - **Authorization callback URL**: The callback URL for your <ProductName /> deployment:
 
      ```text
-     https://<your-thunderid-host>/oauth2/callback
+     https://<your-thunderid-host>/gate/callback
      ```
 
 4. Click **Register application**.
@@ -46,7 +46,7 @@ curl -kL -X POST https://localhost:8090/connections/github \
     "description": "GitHub social login",
     "clientId": "<github-client-id>",
     "clientSecret": "<github-client-secret>",
-    "redirectUri": "https://<your-thunderid-host>/oauth2/callback"
+    "redirectUri": "https://<your-thunderid-host>/gate/callback"
   }'
 ```
 
@@ -60,7 +60,7 @@ curl -kL -X POST https://localhost:8090/connections/github \
   "type": "github",
   "clientId": "<github-client-id>",
   "clientSecret": "******",
-  "redirectUri": "https://<your-thunderid-host>/oauth2/callback"
+  "redirectUri": "https://<your-thunderid-host>/gate/callback"
 }
 ```
 
@@ -87,7 +87,7 @@ curl -kL -X POST https://localhost:8090/connections/github \
     "name": "GitHub",
     "clientId": "<github-client-id>",
     "clientSecret": "<github-client-secret>",
-    "redirectUri": "https://<your-thunderid-host>/oauth2/callback",
+    "redirectUri": "https://<your-thunderid-host>/gate/callback",
     "scopes": ["user:email"]
   }'
 ```

--- a/docs/content/guides/guides/identity-providers/add-google.mdx
+++ b/docs/content/guides/guides/identity-providers/add-google.mdx
@@ -26,7 +26,7 @@ This guide walks you through registering a Google identity provider (IdP) in <Pr
 6. Under **Authorized redirect URIs**, add the callback URL for your <ProductName /> deployment:
 
    ```text
-   https://<your-thunderid-host>/oauth2/callback
+   https://<your-thunderid-host>/gate/callback
    ```
 
 7. Click **Create**. Google displays your **Client ID** and **Client Secret**. Copy both values. You need them in the next step.
@@ -44,7 +44,7 @@ curl -kL -X POST https://localhost:8090/connections/google \
     "description": "Google social login",
     "clientId": "<google-client-id>",
     "clientSecret": "<google-client-secret>",
-    "redirectUri": "https://<your-thunderid-host>/oauth2/callback"
+    "redirectUri": "https://<your-thunderid-host>/gate/callback"
   }'
 ```
 
@@ -58,7 +58,7 @@ curl -kL -X POST https://localhost:8090/connections/google \
   "type": "google",
   "clientId": "<google-client-id>",
   "clientSecret": "******",
-  "redirectUri": "https://<your-thunderid-host>/oauth2/callback"
+  "redirectUri": "https://<your-thunderid-host>/gate/callback"
 }
 ```
 
@@ -83,7 +83,7 @@ curl -kL -X POST https://localhost:8090/connections/google \
     "name": "Google",
     "clientId": "<google-client-id>",
     "clientSecret": "<google-client-secret>",
-    "redirectUri": "https://<your-thunderid-host>/oauth2/callback",
+    "redirectUri": "https://<your-thunderid-host>/gate/callback",
     "scopes": ["openid", "email", "profile"],
     "prompt": "select_account"
   }'

--- a/docs/content/guides/guides/identity-providers/add-oauth-provider.mdx
+++ b/docs/content/guides/guides/identity-providers/add-oauth-provider.mdx
@@ -30,7 +30,7 @@ curl -kL -X POST https://localhost:8090/connections/oauth \
     "description": "Custom OAuth 2.0 provider",
     "clientId": "<client-id>",
     "clientSecret": "<client-secret>",
-    "redirectUri": "https://<your-thunderid-host>/oauth2/callback",
+    "redirectUri": "https://<your-thunderid-host>/gate/callback",
     "authorizationEndpoint": "https://<provider>/oauth/authorize",
     "tokenEndpoint": "https://<provider>/oauth/token",
     "userInfoEndpoint": "https://<provider>/api/userinfo"
@@ -46,7 +46,7 @@ curl -kL -X POST https://localhost:8090/connections/oauth \
   "type": "oauth",
   "clientId": "<client-id>",
   "clientSecret": "******",
-  "redirectUri": "https://<your-thunderid-host>/oauth2/callback",
+  "redirectUri": "https://<your-thunderid-host>/gate/callback",
   "authorizationEndpoint": "https://<provider>/oauth/authorize",
   "tokenEndpoint": "https://<provider>/oauth/token",
   "userInfoEndpoint": "https://<provider>/api/userinfo"
@@ -84,7 +84,7 @@ curl -kL -X POST https://localhost:8090/connections/oauth \
     "name": "My OAuth Provider",
     "clientId": "<client-id>",
     "clientSecret": "<client-secret>",
-    "redirectUri": "https://<your-thunderid-host>/oauth2/callback",
+    "redirectUri": "https://<your-thunderid-host>/gate/callback",
     "authorizationEndpoint": "https://<provider>/oauth/authorize",
     "tokenEndpoint": "https://<provider>/oauth/token",
     "userInfoEndpoint": "https://<provider>/api/userinfo",

--- a/docs/content/guides/guides/identity-providers/add-oidc-provider.mdx
+++ b/docs/content/guides/guides/identity-providers/add-oidc-provider.mdx
@@ -39,7 +39,7 @@ curl -kL -X POST https://localhost:8090/connections/oidc \
     "description": "Corporate OIDC provider",
     "clientId": "<client-id>",
     "clientSecret": "<client-secret>",
-    "redirectUri": "https://<your-thunderid-host>/oauth2/callback",
+    "redirectUri": "https://<your-thunderid-host>/gate/callback",
     "authorizationEndpoint": "https://<provider>/oauth2/authorize",
     "tokenEndpoint": "https://<provider>/oauth2/token"
   }'
@@ -54,7 +54,7 @@ curl -kL -X POST https://localhost:8090/connections/oidc \
   "type": "oidc",
   "clientId": "<client-id>",
   "clientSecret": "******",
-  "redirectUri": "https://<your-thunderid-host>/oauth2/callback",
+  "redirectUri": "https://<your-thunderid-host>/gate/callback",
   "authorizationEndpoint": "https://<provider>/oauth2/authorize",
   "tokenEndpoint": "https://<provider>/oauth2/token"
 }
@@ -91,7 +91,7 @@ External providers emit attributes under their own names, which may differ from 
   "name": "My OIDC Provider",
   "clientId": "<client-id>",
   "clientSecret": "<client-secret>",
-  "redirectUri": "https://<your-thunderid-host>/oauth2/callback",
+  "redirectUri": "https://<your-thunderid-host>/gate/callback",
   "authorizationEndpoint": "https://<provider>/oauth2/authorize",
   "tokenEndpoint": "https://<provider>/oauth2/token",
   "attributeConfiguration": {
@@ -168,7 +168,7 @@ curl -kL -X POST https://localhost:8090/connections/oidc \
     "name": "My OIDC Provider",
     "clientId": "<client-id>",
     "clientSecret": "<client-secret>",
-    "redirectUri": "https://<your-thunderid-host>/oauth2/callback",
+    "redirectUri": "https://<your-thunderid-host>/gate/callback",
     "authorizationEndpoint": "https://<provider>/oauth2/authorize",
     "tokenEndpoint": "https://<provider>/oauth2/token",
     "userInfoEndpoint": "https://<provider>/userinfo",

--- a/docs/content/guides/guides/identity-providers/connect-idp-to-application.mdx
+++ b/docs/content/guides/guides/identity-providers/connect-idp-to-application.mdx
@@ -27,6 +27,10 @@ Applications in <ProductName /> do not reference IdPs directly. The connection r
   - [Add an OAuth 2.0 Identity Provider](../add-oauth-provider)
 - You have created an application. See [Manage Applications](../../applications/manage-applications).
 
+:::note Federated sign-in requires a local user
+By default, federated sign-in maps the external identity to a local user, which must already exist in the user store or the sign-in step fails. To sign in a first-time federated user, enable **Allow Authentication Without Local User** (`allowAuthenticationWithoutLocalUser`) on the social login executor and add a **Provisioning** executor to create the local account. See [Federated Authentication](../../flows/advanced-configurations#federated-authentication).
+:::
+
 <Stepper stepNode="h2" as="h2">
 
 ## Step 1: Open the Flow Designer

--- a/docs/content/guides/guides/identity-providers/manage-identity-providers.mdx
+++ b/docs/content/guides/guides/identity-providers/manage-identity-providers.mdx
@@ -39,7 +39,7 @@ curl -kL -X POST https://localhost:8090/connections/google \
     "description": "Optional description",
     "clientId": "<client-id>",
     "clientSecret": "<client-secret>",
-    "redirectUri": "https://localhost:8090/oauth2/callback"
+    "redirectUri": "https://localhost:8090/gate/callback"
   }'
 ```
 
@@ -55,7 +55,7 @@ Each vendor accepts a different set of fields. See [Add a Google Identity Provid
   "type": "google",
   "clientId": "<client-id>",
   "clientSecret": "******",
-  "redirectUri": "https://localhost:8090/oauth2/callback"
+  "redirectUri": "https://localhost:8090/gate/callback"
 }
 ```
 
@@ -129,7 +129,7 @@ curl -kL -X PUT https://localhost:8090/connections/google/<idp-id> \
   -d '{
     "name": "My Provider",
     "clientId": "<new-client-id>",
-    "redirectUri": "https://localhost:8090/oauth2/callback"
+    "redirectUri": "https://localhost:8090/gate/callback"
   }'
 ```
 

--- a/docs/content/guides/guides/identity-providers/token-exchange-idp.mdx
+++ b/docs/content/guides/guides/identity-providers/token-exchange-idp.mdx
@@ -45,7 +45,7 @@ curl -X POST https://thunderid.example.com/connections/oidc \
     "name": "Asgardeo",
     "clientId": "my-external-client-id",
     "clientSecret": "my-external-client-secret",
-    "redirectUri": "https://thunderid.example.com/oauth2/callback",
+    "redirectUri": "https://thunderid.example.com/gate/callback",
     "authorizationEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/authorize",
     "tokenEndpoint": "https://api.asgardeo.io/t/myorg/oauth2/token",
     "issuer": "https://api.asgardeo.io/t/myorg/oauth2/token",


### PR DESCRIPTION
- **Documentation**
  - Updated GitHub, Google, OAuth, and OIDC identity provider guides to use the `/gate/callback` redirect URI.
  - Updated identity provider management examples with the current callback URL.
  - Clarified that social sign-in requires a local user by default.
  - Documented how to enable authentication without an existing local user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->