### PR TITLE
[DOC] Update docs on removing handler and binding token to single resource server.

### DIFF
--- a/api/oauth2.yaml
+++ b/api/oauth2.yaml
@@ -112,7 +112,9 @@ paths:
           description: >-
             Resource indicator per RFC 8707 (absolute URI, no fragment). Only one value is
             supported; requests with multiple resource values are rejected with invalid_target.
-            When omitted, the configured defaultResourceServer is used.
+            When omitted from a permission-bearing request, the configured
+            defaultResourceServer is used. OIDC-only and scopeless requests use the
+            client_id audience.
         - name: acr_values
           in: query
           required: false
@@ -636,8 +638,9 @@ components:
           type: string
           description: >-
             Resource indicator (RFC 8707). For access-token issuance, binds the issued access token
-            to exactly one resource server; when omitted, the configured defaultResourceServer is
-            used, and if neither is available the request is rejected with invalid_target. Optional
+            to exactly one resource server. When omitted from a permission-bearing request, the
+            configured defaultResourceServer is used, and if neither is available the request is
+            rejected with invalid_target. OIDC-only and scopeless requests use the client_id audience. Optional
             for ID-JAG requests, where it is embedded in the issued ID-JAG's `resource` claim. For
             the jwt-bearer grant, when present it must be a subset of the assertion's own `resource`
             claim.

--- a/docs/content/guides/getting-started/configuration.mdx
+++ b/docs/content/guides/getting-started/configuration.mdx
@@ -394,6 +394,7 @@ OAuth 2.0 and OpenID Connect settings.
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `oauth.refresh_token.renew_on_grant` | `false` | If `true`, issues a new refresh token on each access token grant |
+| `oauth.refresh_token.revoke_previous_on_renew` | `true` | If `true`, revokes the consumed refresh token after a successful renewal. Applies when `renew_on_grant` is enabled |
 | `oauth.refresh_token.validity_period` | `86400` | Refresh token validity period in seconds (24 hours) |
 | `oauth.authorization_code.validity_period` | `600` | Authorization code validity period in seconds (10 minutes) |
 | `oauth.dcr.insecure` | `false` | If `true`, allows insecure dynamic client registration (development only) |
@@ -816,11 +817,11 @@ The `null` origin is shared by sandboxed iframes, `file://` and `data:` document
 
 ## Default Resource Server
 
-Sets the resource server that access tokens are bound to when a token request omits the `resource` parameter. It is stored in the server-config `defaultResourceServer` section, not in `deployment.yaml`. When no default is configured and the request omits `resource`, token issuance fails with `invalid_target`.
+Sets the resource server for permission-bearing token requests that omit the `resource` parameter. It is stored in the server-config `defaultResourceServer` section, not in `deployment.yaml`. When no default is configured, a request that contains permission scopes but omits `resource` fails with `invalid_target`. OIDC-only and scopeless requests use the `client_id` audience instead.
 
 | Field | Description |
 |-------|-------------|
-| `resourceServerId` | The ID of a registered resource server. It must reference an existing resource server, otherwise the update is rejected with `invalid_target`. |
+| `resourceServerId` | The ID of a registered resource server. It must reference an existing resource server, otherwise the update is rejected with `SCF-1003` ("Invalid server configuration value"). |
 
 Set it in either of these ways:
 

--- a/docs/content/guides/guides/agents/agent-authentication.mdx
+++ b/docs/content/guides/guides/agents/agent-authentication.mdx
@@ -104,7 +104,7 @@ Use `resource` (RFC 8707) for the resource server URI:
   -d 'resource=https://api.example.com/invoices'
 ```
 
-The RFC 8693 `audience` parameter is accepted for compatibility but does not determine the access token's `aud` claim. The access-token audience is the resolved `resource`, or the configured `defaultResourceServer` when `resource` is omitted.
+The RFC 8693 `audience` parameter is accepted for compatibility but does not determine the access token's `aud` claim. For permission-bearing requests, the access-token audience is the resolved `resource`, or the configured `defaultResourceServer` when `resource` is omitted. An OIDC-only or scopeless request without `resource` uses the `client_id` audience.
 
 ## Token Characteristics
 
@@ -114,7 +114,7 @@ All agent access tokens are signed JWTs (`typ: at+jwt`) and share a common set o
 |---|---|---|
 | `sub` | The agent's resource ID. | The original user's subject identifier. |
 | `iss` | <ProductName /> instance URL. | <ProductName /> instance URL. |
-| `aud` | The resolved resource server identifier. | The resolved resource server identifier. |
+| `aud` | The resolved resource server identifier, or Client ID for a scopeless request without `resource`. | The resolved resource server identifier, or Client ID when no permission scopes or `resource` are present. |
 | `scope` | Authorized scopes from the agent's group/role assignments. | A subset of the user's original scopes. |
 | `client_id` | The agent's Client ID. | The agent's Client ID. |
 | `grant_type` | `client_credentials` | `urn:ietf:params:oauth:grant-type:token-exchange` |

--- a/docs/content/guides/guides/identity-providers/token-exchange-idp.mdx
+++ b/docs/content/guides/guides/identity-providers/token-exchange-idp.mdx
@@ -103,7 +103,7 @@ A successful response returns a <ProductName />-issued access token:
 }
 ```
 
-The issued token's `sub` claim contains the external user's subject identifier from the original token. Its `aud` claim is the resolved resource server identifier. If you omit `resource`, configure `defaultResourceServer` first.
+The issued token's `sub` claim contains the external user's subject identifier from the original token. For permission-bearing requests, its `aud` claim is the explicit resource server identifier or the configured `defaultResourceServer`. An OIDC-only or scopeless request without `resource` uses the `client_id` audience.
 
 ## How <ProductName /> Validates the External Token
 

--- a/docs/content/guides/guides/integrations/apim-gateways/azure-apim.mdx
+++ b/docs/content/guides/guides/integrations/apim-gateways/azure-apim.mdx
@@ -225,7 +225,7 @@ Azure APIM enforces a subscription key requirement on APIs by default. You have 
 JWT validation confirms that a token is valid and was issued by <ProductName />. It does not control what the token holder is allowed to do. With the configuration from the previous section, Azure APIM accepts any valid <ProductName /> token regardless of the application or its assigned permissions.
 
 Scope-based authorization adds a second layer of control. <ProductName /> embeds scopes in tokens based on the roles assigned to an application. The `validate-jwt` policy checks those scopes on every request and rejects tokens that do not carry the required permissions. This lets you enforce scope-based access control, for example, 
-restricting a write endpoint to tokens with `booking-api:item:write` and a read endpoint to tokens with `booking-api:item:read`, without changing the backend service.
+restricting a write endpoint to tokens with `item:write` and a read endpoint to tokens with `item:read`, without changing the backend service.
 
 The steps below build on the JWT validation configuration from the previous section. You will define a Resource Server, a Resource, and Actions in <ProductName /> to model your API permissions. Then bundle those permissions into a Role, assign the Role to your application, and update the Azure APIM policy to enforce scope validation.
 
@@ -244,7 +244,6 @@ A Resource Server represents your API in <ProductName />. The Resource Server gr
 2. Navigate to **Resource Servers** → **New Resource Server**.
 3. Fill in the following fields:
    - **Name**: `Booking API`
-   - **Handle**: `booking-api`
    - **Identifier**: `https://api.example.com/bookings`
    - **Description**: `Handles item operations`
    - **Delimiter**: `:` (colon)
@@ -266,7 +265,7 @@ A Resource represents a specific entity within the API, such as `/api/items`. Re
 
 #### Create Resource Actions
 
-Actions define the operations allowed on a resource. Each action produces a scope in the format `<resource-server-handle>:<resource-handle>:<action-handle>`. <ProductName /> includes these scopes in tokens issued to applications that hold the corresponding role.
+Actions define the operations allowed on a resource. Each action produces a scope in the format `<resource-handle>:<action-handle>`. <ProductName /> includes these scopes in tokens issued to applications that hold the corresponding role.
 
 **Using the Console:**
 
@@ -277,7 +276,7 @@ Actions define the operations allowed on a resource. Each action produces a scop
    - **Handle**: `write`
    - **Description**: `Permission to write an item`
 4. Click **Create**.
-5. Note the generated permission shown in the action details: `booking-api:item:write`.
+5. Note the generated permission shown in the action details: `item:write`.
 
 #### Create a Role and Assign Permission
 
@@ -289,7 +288,7 @@ Roles bundle one or more permissions together. Assign roles to applications to c
 2. Fill in the following fields:
    - **Name**: `Booking editor`
 3. Click **Continue**.
-4. Under **Assign permissions**, choose `booking-api:item:write`.
+4. Under **Assign permissions**, choose `item:write`.
 5. Click **Continue**.
 
 #### Assign a Role to the Application
@@ -319,7 +318,7 @@ Update the `validate-jwt` policy to add a `<required-claims>` block. Azure APIM 
     <openid-config url="https://<THUNDER_PUBLIC_URL>/.well-known/openid-configuration" />
     <required-claims>
       <claim name="scope" match="any" separator=" ">
-        <value>booking-api:item:write</value>
+        <value>item:write</value>
       </claim>
     </required-claims>
   </validate-jwt>
@@ -335,7 +334,7 @@ Update the `validate-jwt` policy to add a `<required-claims>` block. Azure APIM 
 | `name` | `scope` | JWT claim that stores scopes |
 | `match` | `any` | `any`: the token needs at least one matching value; `all`: the token must carry every listed value |
 | `separator` | ` ` (space) | Delimiter used to split the `scope` claim string into individual scope values |
-| `<value>` | `booking-api:item:write` | Required scope value to access this operation |
+| `<value>` | `item:write` | Required scope value to access this operation |
 
 ### Try It Out
 
@@ -347,7 +346,7 @@ Request a token for the application that has the role assigned:
 curl --location 'https://<THUNDER_PUBLIC_URL>/oauth2/token' \
   --header 'Content-Type: application/x-www-form-urlencoded' \
   --data-urlencode 'grant_type=client_credentials' \
-  --data-urlencode 'scope=booking-api:item:write' \
+  --data-urlencode 'scope=item:write' \
   --data-urlencode 'client_id=<CLIENT_ID>' \
   --data-urlencode 'client_secret=<CLIENT_SECRET>'
 ```
@@ -359,7 +358,7 @@ The response confirms the scope is present:
   "access_token": "<ACCESS_TOKEN>",
   "token_type": "Bearer",
   "expires_in": 3600,
-  "scope": "booking-api:item:write"
+  "scope": "item:write"
 }
 ```
 

--- a/docs/content/guides/guides/integrations/apim-gateways/kong.mdx
+++ b/docs/content/guides/guides/integrations/apim-gateways/kong.mdx
@@ -212,7 +212,7 @@ Update the OpenID Connect plugin on your `/bookings` route to require the genera
 The plugin reads scopes from the `scope` claim (the default `scopes_claim`) and rejects any token missing `bookings:read` with `403 Forbidden`, before the request reaches your upstream.
 
 :::tip
-To restrict which application's tokens are accepted, also set `audience_required` to the **Client ID** of the application. <ProductName /> sets each token's `aud` claim to the issuing application's Client ID, which the plugin reads from the default `audience_claim` (`aud`).
+To restrict tokens to this API, set `audience_required` to the protected resource server's identifier. <ProductName /> uses that identifier as the access token's `aud` claim, which the plugin reads from the default `audience_claim` (`aud`).
 :::
 
 ### Try It Out
@@ -274,5 +274,5 @@ Kong inspects the token, finds the `bookings:read` scope absent, and returns `40
 | `bearer_token_param_type` | `header` | Reads the bearer token from the `Authorization` header. |
 | `scopes_required` | `bookings:read` | Scopes the token must carry. Missing scopes are rejected with `403`. Omit to accept any valid token. |
 | `scopes_claim` | `scope` | The token claim the plugin reads scopes from. <ProductName /> emits resource scopes in the `scope` claim. |
-| `audience_required` | `<CLIENT_ID>` | Optional. Audiences the token must carry. <ProductName /> sets `aud` to the issuing application's Client ID. |
+| `audience_required` | `<RESOURCE_SERVER_IDENTIFIER>` | Optional. Audience the token must carry. Set it to the identifier of the resource server that protects this API. |
 | `audience_claim` | `aud` | The token claim the plugin reads the audience from. |

--- a/docs/content/guides/guides/integrations/apim-gateways/krakend.mdx
+++ b/docs/content/guides/guides/integrations/apim-gateways/krakend.mdx
@@ -194,7 +194,7 @@ curl --location 'http://localhost:8082/api/items' \
 
 JWT token validation confirms that a token is valid and was issued by <ProductName />. It does not control what the token holder is allowed to do. With the configuration from the previous section, KrakenD accepts any valid <ProductName /> token regardless of the application or its assigned permissions.
 
-Scope-based authorization adds a second layer of control. <ProductName /> embeds scopes in tokens based on the roles assigned to an application. KrakenD then checks those scopes on every request and rejects tokens that do not carry the required permissions. This lets you enforce scope-based access control, for example, restricting a read endpoint to tokens with `booking-api:item:read` and a write endpoint to tokens with `booking-api:item:write`, without changing the upstream service.
+Scope-based authorization adds a second layer of control. <ProductName /> embeds scopes in tokens based on the roles assigned to an application. KrakenD then checks those scopes on every request and rejects tokens that do not carry the required permissions. This lets you enforce scope-based access control, for example, restricting a read endpoint to tokens with `item:read` and a write endpoint to tokens with `item:write`, without changing the upstream service.
 
 The steps below build on the JWT Token Validation from the previous section. You will define a Resource Server, a Resource, and actions in <ProductName /> to model your API permissions. Then bundle them into a role, assign the role to your application, and update the KrakenD configuration to enforce scope validation.
 
@@ -212,7 +212,6 @@ For a full reference, see [Resource Servers](../../../resource-servers).
 2. Navigate to **Resource Servers** → **New Resource Server**.
 3. Fill in the following fields:
    - **Name**: `Booking API`
-   - **Handle**: `booking-api`
    - **Identifier**: `https://api.example.com/bookings`
    - **Description**: `Handles item operations`
    - **Delimiter**: `:` (colon)
@@ -236,7 +235,7 @@ A Resource represents a specific entity within the API, such as `/api/items`. Re
 #### Create Resource Actions
 
 Actions define the operations allowed on a resource. 
-Each action produces a scope in the format `<resource-server-handle>:<resource-handle>:<action-handle>`. 
+Each action produces a scope in the format `<resource-handle>:<action-handle>`. 
 <ProductName /> includes these scopes in tokens issued to applications that hold the corresponding role.
 
 **Using the Console:**
@@ -248,7 +247,7 @@ Each action produces a scope in the format `<resource-server-handle>:<resource-h
    - **Handle**: `read`
    - **Description**: `Permission to read an item`
 4. Click **Create**.
-5. Note the generated permission shown in the action details: `booking-api:item:read`.
+5. Note the generated permission shown in the action details: `item:read`.
 
 
 #### Create a Role and assign permission
@@ -259,7 +258,7 @@ Roles bundle one or more permissions together. Assign roles to applications to c
 2. Fill in the following fields:
    - **Name**: `Booking Reader`
 3. Click **Continue**.
-4. Under **Assign permissions**, choose `booking-api:item:read`.
+4. Under **Assign permissions**, choose `item:read`.
 5. Click **Continue**.
 
 #### Assign a Role to the Application
@@ -298,7 +297,7 @@ Add `scopes`, `scopes_key`, and `scopes_matcher` to the `auth/validator` block y
           "cache": true,
           "scopes_key": "scope",
           "scopes_matcher": "any",
-          "scopes": ["booking-api:item:read"]
+          "scopes": ["item:read"]
         }
       },
       "backend": [
@@ -322,7 +321,7 @@ Add `scopes`, `scopes_key`, and `scopes_matcher` to the `auth/validator` block y
 |---|---|---|
 | `scopes_key` | `scope` | JWT claim that stores scopes |
 | `scopes_matcher` | `any` | `any`: the token needs at least one matching scope; `all`: the token must carry every listed scope |
-| `scopes` | `["booking-api:item:read"]` | Required scopes to access this endpoint |
+| `scopes` | `["item:read"]` | Required scopes to access this endpoint |
 
 Restart KrakenD to apply:
 
@@ -341,7 +340,7 @@ Request a token for the application that has the role assigned:
 curl --location 'https://<THUNDERID_HOST>:8090/oauth2/token' \
   --header 'Content-Type: application/x-www-form-urlencoded' \
   --data-urlencode 'grant_type=client_credentials' \
-  --data-urlencode 'scope=booking-api:item:read' \
+  --data-urlencode 'scope=item:read' \
   --data-urlencode 'client_id=<CLIENT_ID>' \
   --data-urlencode 'client_secret=<CLIENT_SECRET>'
 ```
@@ -353,7 +352,7 @@ The response confirms the scope is present:
   "access_token": "<ACCESS_TOKEN>",
   "token_type": "Bearer",
   "expires_in": 3600,
-  "scope": "booking-api:item:read"
+  "scope": "item:read"
 }
 ```
 

--- a/docs/content/guides/guides/protocols/oauth-oidc/authorization-code.mdx
+++ b/docs/content/guides/guides/protocols/oauth-oidc/authorization-code.mdx
@@ -93,7 +93,7 @@ curl -X POST https://{{productSlug}}.example.com/oauth2/token \
   -d "code_verifier=$CODE_VERIFIER"
 ```
 
-Access tokens issued by this flow are bound to one resource server. Send `resource=https://api.example.com/...` on the authorization or token request when the client knows the target API, or configure `defaultResourceServer` so token requests without a `resource` have a valid audience.
+Access tokens with permission scopes are bound to one resource server. Send `resource=https://api.example.com/...` on the authorization or token request when the client knows the target API, or configure `defaultResourceServer` for permission-bearing requests that omit `resource`. OIDC-only or scopeless requests without `resource` use the `client_id` audience.
 
 ## Related Guides
 

--- a/docs/content/guides/guides/protocols/oauth-oidc/client-credentials.mdx
+++ b/docs/content/guides/guides/protocols/oauth-oidc/client-credentials.mdx
@@ -30,7 +30,7 @@ Use it for service-to-service calls, internal daemons, scheduled jobs, and CLI t
 | User attributes | Not included: there is no authenticated user |
 | Refresh token | Not issued for this grant (re-request when needed) |
 | Scope filtering | Requested scopes are filtered to permissions defined on the target resource server, then intersected with the permissions the client holds through its **role and group assignments** |
-| `aud` claim | Exactly one resource server identifier: the supplied `resource`, or the configured `defaultResourceServer` when `resource` is omitted |
+| `aud` claim | The supplied resource server identifier, or `defaultResourceServer` for a permission-bearing request without `resource`. A scopeless request without `resource` uses `client_id` |
 | ID token | Not issued: this is an OAuth-only flow, not OIDC |
 
 </details>
@@ -48,7 +48,7 @@ Use it for service-to-service calls, internal daemons, scheduled jobs, and CLI t
 6. Save.
 
 :::note
-When requesting a token, the client must include the `resource` parameter unless a `defaultResourceServer` is configured globally.
+When requesting permission scopes, the client must include `resource` unless `defaultResourceServer` is configured globally. A scopeless request does not require either setting and uses `client_id` as its audience.
 :::
 
 </TabItem>
@@ -62,7 +62,7 @@ Content-Type: application/json
   "client_name": "Billing Service",
   "grant_types": ["client_credentials"],
   "token_endpoint_auth_method": "client_secret_basic",
-  "scope": "booking-api:reservations:create booking-api:reservations:view"
+  "scope": "reservations:create reservations:view"
 }
 ```
 
@@ -75,7 +75,7 @@ Content-Type: application/json
 curl -X POST https://{{productSlug}}.example.com/oauth2/token \
   -u "$CLIENT_ID:$CLIENT_SECRET" \
   -d "grant_type=client_credentials" \
-  -d "scope=booking-api:reservations:create" \
+  -d "scope=reservations:create" \
   -d "resource=https://api.example.com/booking"
 ```
 
@@ -86,7 +86,7 @@ Response:
   "access_token": "eyJhbGciOiJSUzI1NiI...",
   "token_type": "Bearer",
   "expires_in": 3600,
-  "scope": "booking-api:reservations:create"
+  "scope": "reservations:create"
 }
 ```
 

--- a/docs/content/guides/guides/protocols/oauth-oidc/refresh-token.mdx
+++ b/docs/content/guides/guides/protocols/oauth-oidc/refresh-token.mdx
@@ -26,7 +26,7 @@ Content-Type: application/x-www-form-urlencoded
 grant_type=refresh_token
 &refresh_token=<refresh_token>
 &scope=openid%20profile             # optional, narrow only
-&resource=https://api.example.com   # optional, narrow audience
+&resource=https://api.example.com   # optional, must match the existing audience
 ```
 
 Response (rotation enabled):
@@ -49,9 +49,9 @@ Response (rotation enabled):
 | Endpoint | `POST /oauth2/token` with `grant_type=refresh_token` |
 | Client authentication | Same methods as the original grant, see [Client Authentication Methods](../client-authentication-methods) |
 | Rotation | Controlled globally by `oauth.refresh_token.renew_on_grant` in `deployment.yaml`. When enabled, every refresh issues a new `refresh_token`; when disabled, the existing one is reused |
-| Old token after rotation | Stateless JWTs with no revocation: a rotated-out token stays valid until it expires. No reuse detection |
-| Audience preservation | Per RFC 8707 §5, the new access token carries the **full original `aud`** when `resource` is not supplied |
-| Audience narrowing | Supply `resource` to receive a new access token whose `aud` is a subset of the original |
+| Old token after rotation | When `oauth.refresh_token.revoke_previous_on_renew` is enabled, the consumed refresh token is revoked after renewal. A revocation failure stops the rotation |
+| Audience preservation | The new access token keeps the refresh token's single audience when `resource` is omitted |
+| Resource validation | When supplied, `resource` must match the refresh token's audience. A mismatch returns `invalid_target` |
 | Scope narrowing | The `scope` parameter may request a subset of the originally granted scopes. Asking for a wider scope returns `invalid_scope` |
 | DPoP binding | A DPoP-bound refresh token continues to require a DPoP proof on refresh; the new access token inherits the `cnf.jkt` binding |
 
@@ -61,7 +61,7 @@ Response (rotation enabled):
 |---|---|
 | `sub` | Unchanged |
 | `iss` | Unchanged |
-| `aud` | Preserved by default; narrowed when `resource` is supplied |
+| `aud` | Preserved. A supplied `resource` must match this value |
 | `scope` | Preserved by default; narrowed when `scope` is supplied |
 | `exp` / `iat` | New values |
 | `cnf.jkt` (DPoP) | Preserved |
@@ -97,11 +97,11 @@ Content-Type: application/json
 </TabItem>
 </Tabs>
 
-Refresh token rotation is a deployment-wide setting, not per client. Enable it by setting `oauth.refresh_token.renew_on_grant: true` in `deployment.yaml`.
+Refresh token rotation is a deployment-wide setting, not per client. Enable it by setting `oauth.refresh_token.renew_on_grant: true` in `deployment.yaml`. By default, `oauth.refresh_token.revoke_previous_on_renew` is `true`, so a successful rotation revokes the consumed refresh token.
 
 ## Related Guides
 
 - [Authorization Code](../authorization-code), the most common source of refresh tokens
-- [Resource Indicators](../resource-indicators), narrow the audience of the refreshed access token
+- [Resource Indicators](../resource-indicators), preserve and validate the resource binding during refresh
 - [DPoP](../dpop), refresh tokens issued under DPoP remain sender-constrained
 - [Token Formats](../token-formats), token lifetimes, signing and encryption settings

--- a/docs/content/guides/guides/protocols/oauth-oidc/resource-indicators.mdx
+++ b/docs/content/guides/guides/protocols/oauth-oidc/resource-indicators.mdx
@@ -7,13 +7,13 @@ description: RFC 8707 Resource Indicators in {{ProductName}}, to target access t
 
 # Resource Indicators
 
-**Resource Indicators for OAuth 2.0** ([RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707)) lets a client tell <ProductName /> *which* resource server the access token is for. The client passes a single `resource` parameter. <ProductName /> looks it up against the registered resource servers, narrows the granted scopes to those owned by that resource server, and writes its identifier into the token's `aud` claim. When the client omits `resource`, <ProductName /> uses the configured `defaultResourceServer`; if neither is available, token issuance fails with `invalid_target`.
+**Resource Indicators for OAuth 2.0** ([RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707)) lets a client tell <ProductName /> *which* resource server the access token is for. The client passes a single `resource` parameter. <ProductName /> looks it up against the registered resource servers, narrows the granted permission scopes to those owned by that resource server, and writes its identifier into the token's `aud` claim. When permission scopes are requested without `resource`, <ProductName /> uses the configured `defaultResourceServer`. If neither target is available, token issuance fails with `invalid_target`. OIDC-only and scopeless requests without `resource` use the `client_id` as the access-token audience.
 
 The effect: a token issued for the payments API cannot be replayed against the bookings API. Each token is bound to its intended audience.
 
 ## How It Works
 
-The `resource` parameter is accepted on the authorization request, the token request, and the refresh request.
+The `resource` parameter is accepted on authorization and PAR requests and on authorization code, client credentials, JWT bearer, refresh token, and token exchange requests. CIBA does not currently support resource indicators.
 
 ```http
 GET /oauth2/authorize
@@ -49,11 +49,11 @@ The issued access token carries the resource identifier as its `aud`:
 
 | Aspect | Behavior |
 |---|---|
-| Accepted on | `/oauth2/authorize`, `/oauth2/par`, `/oauth2/token` (every grant), `/oauth2/token` with `grant_type=refresh_token` |
+| Accepted on | `/oauth2/authorize`, `/oauth2/par`, and `/oauth2/token` for authorization code, client credentials, JWT bearer, refresh token, and token exchange grants |
 | Value rules | The `resource` must be an absolute URI with no fragment. A request with more than one `resource` parameter is rejected with `invalid_target`. |
 | Resolution | The URI is matched to a registered resource server's `identifier` |
 | Unknown identifier | Request rejected with `invalid_target` |
-| No `resource` | The configured `defaultResourceServer` is used; if none is configured, the request is rejected with `invalid_target` |
+| No `resource` | Permission-bearing requests use `defaultResourceServer` and return `invalid_target` if it is unset. OIDC-only and scopeless requests use `client_id` as the audience |
 | Scope filtering | Requested scopes are filtered to those defined on the targeted resource server. Scopes not owned by that resource server are silently dropped |
 | OIDC standard scopes | `openid`, `profile`, `email`, `phone`, `address` are **not** filtered by resource indicators |
 | Custom scope_claims | Scopes covered by an application's `scopeClaims` mapping also pass through unchanged |
@@ -64,7 +64,8 @@ The issued access token carries the resource identifier as its `aud`:
 |---|---|
 | One `resource` | JSON string: `"aud": "https://api.example.com/payments"` |
 | Multiple `resource` parameters | Rejected with `invalid_target` |
-| No `resource` parameter | The configured `defaultResourceServer` identifier. If no default is configured, the request is rejected with `invalid_target`. |
+| No `resource`, permission scopes requested | The configured `defaultResourceServer` identifier. If no default is configured, the request is rejected with `invalid_target`. |
+| No `resource`, no permission scopes | The requesting client's `client_id`. |
 
 The `aud` claim is always a single string, per [RFC 7519 §4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3).
 
@@ -123,5 +124,5 @@ curl -X POST https://{{productSlug}}.example.com/oauth2/token \
 
 - [Authorization](../../../../key-concepts/authorization), how resource servers, permissions, and scopes fit together
 - [Resource Servers](../../../resource-servers), register a resource server
-- [Refresh Token](../refresh-token), narrowing on refresh
+- [Refresh Token](../refresh-token), preserving the resource binding on refresh
 - [Token Exchange](../token-exchange), `resource` is supported on exchange too

--- a/docs/content/guides/guides/protocols/oauth-oidc/token-exchange.mdx
+++ b/docs/content/guides/guides/protocols/oauth-oidc/token-exchange.mdx
@@ -33,7 +33,7 @@ Typical uses:
 | `actor_token_type` (input) | Same set as `subject_token_type`; used for delegation chains |
 | `requested_token_type` (output) | `urn:ietf:params:oauth:token-type:access_token` · `:jwt` only. **`id_token` and `refresh_token` outputs are not supported.** |
 | `audience` parameter | Accepted for RFC 8693 compatibility but does not determine the issued access token's `aud` claim |
-| `resource` parameter | RFC 8707 resource indicator. The issued access token is bound to exactly this resource server. If omitted, `defaultResourceServer` is used. |
+| `resource` parameter | RFC 8707 resource indicator. The issued access token is bound to exactly this resource server. Permission-bearing requests use `defaultResourceServer` when it is omitted. OIDC-only or scopeless requests use `client_id` |
 | `scope` parameter | Requested scopes; downscoping is allowed, widening is rejected with `invalid_scope`. Final scopes must also be permissions on the target resource server and authorized for the issuing app or agent. |
 | Client authentication | Required, same methods as the token endpoint |
 | Issued token shape | `issued_token_type` is echoed in the response so the caller knows what it received |
@@ -49,7 +49,7 @@ Typical uses:
 | `actor_token` | No | Token of the acting party in delegation |
 | `actor_token_type` | No | Required when `actor_token` is supplied |
 | `audience` | No | Logical audience value from RFC 8693. It is ignored for the access-token `aud`; use `resource` to select the token audience. |
-| `resource` | No | Absolute URI of the target resource server (see [Resource Indicators](../resource-indicators)). If omitted, the configured default resource server is used. |
+| `resource` | No | Absolute URI of the target resource server (see [Resource Indicators](../resource-indicators)). If omitted, permission-bearing requests use the configured default resource server, while OIDC-only or scopeless requests use `client_id`. |
 | `scope` | No | Requested scopes must be a subset of the subject token's grant |
 
 </details>

--- a/docs/content/guides/key-concepts/tokens.mdx
+++ b/docs/content/guides/key-concepts/tokens.mdx
@@ -16,7 +16,7 @@ Access tokens are JWTs that a client presents to a resource server to access pro
 | Claim | Description |
 |-------|-------------|
 | `sub` | The subject, the user ID or client ID the token represents. |
-| `aud` | The audience: the single resource server identifier the access token is intended for. |
+| `aud` | The audience: one resource server identifier, or the `client_id` for an unbound OIDC-only or scopeless token. |
 | `scope` | The granted scopes, the permissions the token carries. |
 | `iss` | The issuer, the <ProductName /> instance that issued the token. |
 | `exp` | The expiry time as a Unix timestamp. |
@@ -26,7 +26,8 @@ Access tokens are JWTs that a client presents to a resource server to access pro
 The `aud` claim varies based on whether the client used [resource indicators](../../guides/protocols/oauth-oidc/resource-indicators):
 
 - **With `resource` parameter:** The `aud` claim contains the identifier of the targeted resource server.
-- **Without `resource` parameter:** <ProductName /> uses the configured `defaultResourceServer`. If no default is configured, token issuance fails with `invalid_target`.
+- **Without `resource`, with permission scopes:** <ProductName /> uses the configured `defaultResourceServer`. If no default is configured, token issuance fails with `invalid_target`.
+- **Without `resource` or permission scopes:** The `aud` claim contains the requesting client's `client_id`.
 - **Serialization:** The single audience is serialized as a JSON string (for example, `"aud": "https://api.example.com/booking"`), per [RFC 7519 Section 4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3).
 
 Resource servers that validate tokens should require `aud` to match their own resource server identifier.

--- a/docs/content/use-cases/ai-agents/configure-it-yourself.mdx
+++ b/docs/content/use-cases/ai-agents/configure-it-yourself.mdx
@@ -58,20 +58,11 @@ The foundation creates the two resource servers, three roles, two demo users, an
    | -------- | -------------------- |
    | `access` | `agent:access`       |
 
-   Configure it as the default resource server for ordinary Wayfinder web-app sign-in tokens. The AI agent sends `resource=http://localhost:8787/mcp` explicitly when it needs tokens for MCP calls.
-
-   ```bash
-   curl -kL -X PUT https://localhost:8090/server-config/defaultResourceServer \
-     -H 'Content-Type: application/json' \
-     -H 'Authorization: Bearer <access-token>' \
-     -d '{ "resourceServerId": "<wayfinder-agent-rs-id>" }'
-   ```
-
    See [Resource Servers](../../../guides/guides/resource-servers).
 
 2. **Create the `wayfinder` resource server.**
 
-   Invoke the **Resource Management API** again. The identifier is `http://localhost:8787/mcp`, a URL-shaped identifier per [RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707) that matches what the Wayfinder MCP server advertises in `/.well-known/oauth-protected-resource`. MCP Inspector reads that metadata and passes the value back as `resource=...` on `/oauth2/token`; <ProductName /> would reject the request with `invalid_target` otherwise. This resource server protects both the REST surface (`/api/*`) and the MCP surface (`/mcp`) of the Wayfinder server. Both check the same `wayfinder:booking:*` permissions:
+   Invoke the **Resource Management API** again. The identifier is `http://localhost:8787/mcp`, a URL-shaped identifier per [RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707) that matches what the Wayfinder MCP server advertises in `/.well-known/oauth-protected-resource`. MCP Inspector reads that metadata and passes the value back as `resource=...` on `/oauth2/token`; <ProductName /> would reject the request with `invalid_target` otherwise. This resource server protects both the REST surface (`/api/*`) and the MCP surface (`/mcp`) of the Wayfinder server. Both check the same `booking:*` permissions:
 
    ```bash
    curl -kL -X POST https://localhost:8090/resource-servers \
@@ -107,10 +98,19 @@ The foundation creates the two resource servers, three roles, two demo users, an
 
    | Action      | Generated permission |
    | ----------- | -------------------- |
-   | `read`      | `wayfinder:booking:read`       |
-   | `create`    | `wayfinder:booking:create`     |
-   | `cancel`    | `wayfinder:booking:cancel`     |
-   | `recommend` | `wayfinder:booking:recommend`  |
+   | `read`      | `booking:read`       |
+   | `create`    | `booking:create`     |
+   | `cancel`    | `booking:cancel`     |
+   | `recommend` | `booking:recommend`  |
+
+   Configure the booking resource server as the default for Wayfinder web sign-in tokens. The web application requests `booking:*` permissions without a `resource`, so the default must be the resource server that defines those permissions. The chat widget targets `http://localhost:8790/chat` explicitly.
+
+   ```bash
+   curl -kL -X PUT https://localhost:8090/server-config/defaultResourceServer \
+     -H 'Content-Type: application/json' \
+     -H 'Authorization: Bearer <access-token>' \
+     -d '{ "resourceServerId": "<wayfinder-rs-id>" }'
+   ```
 
 3. **Create the `Chat User` role.**
 
@@ -135,7 +135,7 @@ The foundation creates the two resource servers, three roles, two demo users, an
 
 4. **Create the `Booking User` role.**
 
-   Grant it `wayfinder:booking:read`, `wayfinder:booking:create`, and `wayfinder:booking:cancel` on `wayfinder`:
+   Grant it `booking:read`, `booking:create`, and `booking:cancel` on `wayfinder`:
 
    ```bash
    curl -kL -X POST https://localhost:8090/roles \
@@ -148,7 +148,7 @@ The foundation creates the two resource servers, three roles, two demo users, an
        "permissions": [
          {
            "resourceServerId": "<wayfinder-rs-id>",
-           "permissions": ["wayfinder:booking:read", "wayfinder:booking:create", "wayfinder:booking:cancel"]
+           "permissions": ["booking:read", "booking:create", "booking:cancel"]
          }
        ]
      }'
@@ -156,7 +156,7 @@ The foundation creates the two resource servers, three roles, two demo users, an
 
 5. **Create the `Recommender` role.**
 
-   Grant it `wayfinder:booking:recommend` on `wayfinder`. This role will be assigned to the Wayfinder Concierge in a later step, not to a user:
+   Grant it `booking:recommend` on `wayfinder`. This role will be assigned to the Wayfinder Concierge in a later step, not to a user:
 
    ```bash
    curl -kL -X POST https://localhost:8090/roles \
@@ -164,12 +164,12 @@ The foundation creates the two resource servers, three roles, two demo users, an
      -H 'Authorization: Bearer <access-token>' \
      -d '{
        "name": "Recommender",
-       "description": "Grants the wayfinder:booking:recommend permission to the Wayfinder Concierge",
+       "description": "Grants the booking:recommend permission to the Wayfinder Concierge",
        "ouId": "<organization-unit-id>",
        "permissions": [
          {
            "resourceServerId": "<wayfinder-rs-id>",
-           "permissions": ["wayfinder:booking:recommend"]
+           "permissions": ["booking:recommend"]
          }
        ]
      }'
@@ -243,7 +243,7 @@ The Concierge runs as a first-class agent in <ProductName />. It needs its own c
 
 ## Build the Agent Authentication Flow
 
-The Wayfinder Concierge needs a separate authentication flow that drives the on-behalf-of (OBO) consent screen when a chat request triggers a mutating tool. The flow authenticates the user with username and password, then shows a consent screen listing the `wayfinder:booking:*` permissions the agent is requesting.
+The Wayfinder Concierge needs a separate authentication flow that drives the on-behalf-of (OBO) consent screen when a chat request triggers a mutating tool. The flow authenticates the user with username and password, then shows a consent screen listing the `booking:*` permissions the agent is requesting.
 
 Navigate to **Flows** and create a flow with these steps:
 

--- a/docs/content/use-cases/ai-agents/identity-concepts.mdx
+++ b/docs/content/use-cases/ai-agents/identity-concepts.mdx
@@ -23,7 +23,7 @@ See [User Types](../../../guides/guides/users/user-types).
 
 The **AI Agent API** and the **Wayfinder Server** both need protection in the sample. The AI Agent API decides who is allowed to chat with the agent at all, and the Wayfinder Server decides who can book travel. Each is registered as a resource server, with its actions generating one permission per action.
 
-A **resource server** groups the APIs of one backend. Each resource server defines one or more **resources**, each resource defines **actions**, and <ProductName /> automatically generates one permission per action. When a resource server has a handle, the complete permission string uses the form `<resource-server-handle>:<resource>:<action>`.
+A **resource server** groups the APIs of one backend. Each resource server defines one or more **resources**, each resource defines **actions**, and <ProductName /> automatically generates one permission per action. The permission string uses the form `<resource>:<action>` and is not prefixed by the resource server.
 
 ```text
 wayfinder-agent                         (Resource Server)
@@ -32,13 +32,13 @@ wayfinder-agent                         (Resource Server)
 
 wayfinder                               (Resource Server)
 └── booking                             (Resource)
-    ├── read       →  wayfinder:booking:read      (Permission)
-    ├── create     →  wayfinder:booking:create
-    ├── cancel     →  wayfinder:booking:cancel
-    └── recommend  →  wayfinder:booking:recommend
+    ├── read       →  booking:read      (Permission)
+    ├── create     →  booking:create
+    ├── cancel     →  booking:cancel
+    └── recommend  →  booking:recommend
 ```
 
-`wayfinder` protects both the booking REST API on `/api/*` and the MCP tools on `/mcp`. The Wayfinder Server checks the same `wayfinder:booking:*` permissions on both surfaces in scope mode. In AuthZEN mode, the MCP server sends the same complete permission string as `action.name` in an AuthZEN access evaluation request.
+`wayfinder` protects both the booking REST API on `/api/*` and the MCP tools on `/mcp`. The Wayfinder Server checks the same `booking:*` permissions on both surfaces in scope mode. In AuthZEN mode, the MCP server sends the same complete permission string as `action.name` in an AuthZEN access evaluation request.
 
 Permissions are included in access tokens. See [Resource Servers](../../../guides/guides/resource-servers).
 
@@ -47,8 +47,8 @@ Permissions are included in access tokens. See [Resource Servers](../../../guide
 A role bundles permissions for a class of principal. A user's or agent's effective permissions are the union of permissions across their roles. Wayfinder defines three roles for the AI agent tryout:
 
 - `Chat User`: grants `agent:access`, the permission required to talk to the Wayfinder Concierge.
-- `Booking User`: grants `wayfinder:booking:read`, `wayfinder:booking:create`, and `wayfinder:booking:cancel` for booking travel through the UI.
-- `Recommender`: grants `wayfinder:booking:recommend`, the permission the Wayfinder Concierge needs to surface flight recommendations on its own.
+- `Booking User`: grants `booking:read`, `booking:create`, and `booking:cancel` for booking travel through the UI.
+- `Recommender`: grants `booking:recommend`, the permission the Wayfinder Concierge needs to surface flight recommendations on its own.
 
 John Doe carries both user roles; Jane Smith carries only `Booking User`. The `Recommender` role is assigned to the `WAYFINDER-CONCIERGE` agent, not to a user.
 
@@ -73,6 +73,6 @@ See [Manage Agents](../../../guides/guides/agents/manage-agents) and [Agent Auth
 
 A flow is the sequence of steps a user moves through when signing in or granting consent. Wayfinder Web uses the bundled `default-flow` for sign-in. The agent uses a separate **Wayfinder Agent Authentication Flow** that drives the OBO consent screen.
 
-The consent screen surfaces each requested `wayfinder:booking:*` permission as an individual toggle. The user picks which ones to grant, and the issued token carries only what they ticked. The agent cannot widen its access after the fact. The resulting OBO token identifies *both* the user (as the subject) and the agent (as the actor), so downstream services know the request was made by an agent acting for that user. The token's effective permissions are the intersection of what the user holds and what the user just consented to.
+The consent screen surfaces each requested `booking:*` permission as an individual toggle. The user picks which ones to grant, and the issued token carries only what they ticked. The agent cannot widen its access after the fact. The resulting OBO token identifies *both* the user (as the subject) and the agent (as the actor), so downstream services know the request was made by an agent acting for that user. The token's effective permissions are the intersection of what the user holds and what the user just consented to.
 
 See [Build a Flow](../../../guides/guides/flows/build-a-flow) and [Agent Authentication](../../../guides/guides/agents/agent-authentication).

--- a/docs/content/use-cases/ai-agents/try-it-out/act-on-behalf-of-user.mdx
+++ b/docs/content/use-cases/ai-agents/try-it-out/act-on-behalf-of-user.mdx
@@ -36,16 +36,16 @@ Complete [Setup](../#setup) before starting this walkthrough.
    ```
 
 3. The agent decides this is a mutating tool and returns `need_user_consent`. A popup opens, hosted by <ProductName />. Sign in inside the popup as `john.doe`.
-4. On the consent screen, pick which permissions to grant. Tick **at least** `wayfinder:booking:create` for the booking to succeed. You can also grant `wayfinder:booking:read` and `wayfinder:booking:cancel` if you want the agent to manage existing bookings in the same session.
+4. On the consent screen, pick which permissions to grant. Tick **at least** `booking:create` for the booking to succeed. You can also grant `booking:read` and `booking:cancel` if you want the agent to manage existing bookings in the same session.
 5. Approve. The popup closes. The agent picks up where it paused, calls `create_booking` with the OBO token, and confirms the booking in the chat.
 
 ## Try a Variant
 
-- Repeat the walkthrough but **uncheck `wayfinder:booking:create`** on the consent screen. The agent retries, the tool returns `403`, and the agent surfaces the failure honestly in the chat.
-- Ask the agent to cancel a booking without granting `wayfinder:booking:cancel`. Same outcome: the OBO token doesn't carry the scope, the API rejects, and the agent reports back.
+- Repeat the walkthrough but **uncheck `booking:create`** on the consent screen. The agent retries, the tool returns `403`, and the agent surfaces the failure honestly in the chat.
+- Ask the agent to cancel a booking without granting `booking:cancel`. Same outcome: the OBO token doesn't carry the scope, the API rejects, and the agent reports back.
 
 :::info[Concepts]
-**Consent.** This walkthrough is consent in action. John doesn't grant the agent a blanket "do anything bookings-related": the consent screen surfaces the individual `wayfinder:booking:*` permissions and the issued token carries only what he ticked. The agent cannot widen its access after the fact.
+**Consent.** This walkthrough is consent in action. John doesn't grant the agent a blanket "do anything bookings-related": the consent screen surfaces the individual `booking:*` permissions and the issued token carries only what he ticked. The agent cannot widen its access after the fact.
 
 **Delegation.** The OBO token identifies *both* John (as the subject) and the agent (as the actor). Downstream services know the booking was triggered by an agent acting for John, not by John directly. The token's effective permissions are the intersection of what John holds and what John just consented to. See [Agent Authentication](../../../../guides/guides/agents/agent-authentication) for the full OBO exchange.
 

--- a/docs/content/use-cases/ai-agents/try-it-out/act-on-its-own.mdx
+++ b/docs/content/use-cases/ai-agents/try-it-out/act-on-its-own.mdx
@@ -34,17 +34,17 @@ Complete [Setup](../#setup) before starting this walkthrough.
    Suggest a few flight deals.
    ```
 
-   This calls the `recommend_bookings` MCP tool, which requires the `wayfinder:booking:recommend` scope. The agent gets it because it requests `scope=wayfinder:booking:recommend` when fetching its M2M token. The `Recommender` role you assigned to `WAYFINDER-CONCIERGE` during setup grants exactly that permission.
+   This calls the `recommend_bookings` MCP tool, which requires the `booking:recommend` scope. The agent gets it because it requests `scope=booking:recommend` when fetching its M2M token. The `Recommender` role you assigned to `WAYFINDER-CONCIERGE` during setup grants exactly that permission.
 
 No consent popup appears at any point. The user never sees the agent's M2M token: it lives entirely inside the AI Agent.
 
 ## Try a Variant
 
-- Tail the AI Agent logs while sending the message. You can see the `client_credentials` token request go out to <ProductName /> with `scope=wayfinder:booking:recommend`, and the `Authorization: Bearer …` header on the MCP call.
-- Remove the `Recommender` role assignment from the agent in the Console. Ask for recommendations again and watch the agent surface the `403` back to you in natural language: the M2M token no longer carries `wayfinder:booking:recommend`.
+- Tail the AI Agent logs while sending the message. You can see the `client_credentials` token request go out to <ProductName /> with `scope=booking:recommend`, and the `Authorization: Bearer …` header on the MCP call.
+- Remove the `Recommender` role assignment from the agent in the Console. Ask for recommendations again and watch the agent surface the `403` back to you in natural language: the M2M token no longer carries `booking:recommend`.
 
 :::info[Concepts]
 **Agent identity.** `WAYFINDER-CONCIERGE` is a first-class principal in <ProductName /> with its own credentials. Treating it as an identity, not just an API key, is what lets you grant, restrict, audit, and revoke its access independently of any user. See [Manage Agents](../../../../guides/guides/agents/manage-agents) and [Agent Authentication](../../../../guides/guides/agents/agent-authentication).
 
-**Authorization.** The `recommend_bookings` tool is protected by `wayfinder:booking:recommend` on the `wayfinder` resource server. The agent's M2M token carries that permission because the agent holds the `Recommender` role, exactly the same `requireScope` check that gates user tokens applies to the agent's. See [Authorization](../../../../guides/key-concepts/authorization).
+**Authorization.** The `recommend_bookings` tool is protected by `booking:recommend` on the `wayfinder` resource server. The agent's M2M token carries that permission because the agent holds the `Recommender` role, exactly the same `requireScope` check that gates user tokens applies to the agent's. See [Authorization](../../../../guides/key-concepts/authorization).
 :::

--- a/docs/content/use-cases/ai-agents/try-it-out/index.mdx
+++ b/docs/content/use-cases/ai-agents/try-it-out/index.mdx
@@ -60,10 +60,10 @@ wayfinder-agent                         (Resource Server)
 
 wayfinder                               (Resource Server)
 └── booking                             (Resource)
-    ├── read       →  wayfinder:booking:read      (Permission)
-    ├── create     →  wayfinder:booking:create
-    ├── cancel     →  wayfinder:booking:cancel
-    └── recommend  →  wayfinder:booking:recommend
+    ├── read       →  booking:read      (Permission)
+    ├── create     →  booking:create
+    ├── cancel     →  booking:cancel
+    └── recommend  →  booking:recommend
 ```
 
 Permissions are issued to the access tokens. See [Resource Servers](../../../guides/guides/resource-servers).
@@ -73,8 +73,8 @@ Permissions are issued to the access tokens. See [Resource Servers](../../../gui
 A role bundles permissions for a class of principal. A user's or agent's effective permissions are the union of permissions across their roles. Wayfinder defines three roles:
 
 - `Chat User`: grants `agent:access`, the permission required to talk to the Wayfinder Concierge.
-- `Booking User`: grants `wayfinder:booking:read`, `wayfinder:booking:create`, and `wayfinder:booking:cancel` for booking travel through the UI.
-- `Recommender`: grants `wayfinder:booking:recommend`, the permission the Wayfinder Concierge needs to surface flight recommendations on its own.
+- `Booking User`: grants `booking:read`, `booking:create`, and `booking:cancel` for booking travel through the UI.
+- `Recommender`: grants `booking:recommend`, the permission the Wayfinder Concierge needs to surface flight recommendations on its own.
 
 John Doe carries both user roles; Jane Smith carries only `Booking User`. The `Recommender` role is assigned to the `WAYFINDER-CONCIERGE` agent, not to a user.
 

--- a/docs/content/use-cases/ai-agents/try-it-out/setup.mdx
+++ b/docs/content/use-cases/ai-agents/try-it-out/setup.mdx
@@ -39,8 +39,8 @@ Import the Wayfinder configuration bundle.
 
    The import creates:
 
-   - **Resource servers:** `wayfinder-agent` (identifier `http://localhost:8790/chat`, with `agent:access`) and `wayfinder` (identifier `http://localhost:8787/mcp`, with `wayfinder:booking:read`, `wayfinder:booking:create`, `wayfinder:booking:cancel`, `wayfinder:booking:recommend`).
-   - **Default resource server:** set to `wayfinder-agent`, so sign-in tokens that omit `resource` are bound to it. The agent sends `resource=http://localhost:8787/mcp` explicitly for MCP calls.
+   - **Resource servers:** `wayfinder-agent` (identifier `http://localhost:8790/chat`, with `agent:access`) and `wayfinder` (identifier `http://localhost:8787/mcp`, with `booking:read`, `booking:create`, `booking:cancel`, `booking:recommend`).
+   - **Default resource server:** set to `wayfinder`, so web sign-in tokens that omit `resource` are bound to the booking API. The chat widget sends `resource=http://localhost:8790/chat`, and the agent sends `resource=http://localhost:8787/mcp` for MCP calls.
    - **Roles:** `Chat User`, `Booking User`, and `Recommender`, with users and the agent pre-assigned:
      - `Chat User` → `john.doe`.
      - `Booking User` → `john.doe` and `jane.smith`.

--- a/docs/content/use-cases/b2c/identity-concepts.mdx
+++ b/docs/content/use-cases/b2c/identity-concepts.mdx
@@ -26,16 +26,16 @@ See [User Types](../../../guides/guides/users/user-types).
 
 Wayfinder Server protects its API endpoints using permissions issued by <ProductName />.
 
-A **resource server** represents the APIs of a single backend. Each resource server defines one or more **resources**, and each resource defines **actions**. <ProductName /> automatically generates a **permission** of the form `<resource-server>:<resource>:<action>` for every action.
+A **resource server** represents the APIs of a single backend. Each resource server defines one or more **resources**, and each resource defines **actions**. <ProductName /> automatically generates a **permission** of the form `<resource>:<action>` for every action, not prefixed by the resource server.
 
-Wayfinder's API is one resource server with the `wayfinder` handle. It includes a `booking` resource that has three actions: `read`, `create`, and `cancel`. The generated permissions are `wayfinder:booking:read`, `wayfinder:booking:create`, and `wayfinder:booking:cancel`.
+Wayfinder's API is one resource server named `wayfinder`. It includes a `booking` resource that has three actions: `read`, `create`, and `cancel`. The generated permissions are `booking:read`, `booking:create`, and `booking:cancel`.
 
 ```text
 wayfinder                               (Resource Server)
 └── booking                             (Resource)
-    ├── read     →  wayfinder:booking:read        (Permission)
-    ├── create   →  wayfinder:booking:create
-    └── cancel   →  wayfinder:booking:cancel
+    ├── read     →  booking:read        (Permission)
+    ├── create   →  booking:create
+    └── cancel   →  booking:cancel
 ```
 
 Permissions are included in access tokens. See [Resource Servers](../../../guides/guides/resource-servers).
@@ -44,7 +44,7 @@ Permissions are included in access tokens. See [Resource Servers](../../../guide
 
 A role groups permissions for a user category. A user's effective permissions are the combined set of permissions across all their assigned roles. Wayfinder defines four roles:
 
-- `Traveler`: consumer role with all three `wayfinder:booking:*` permissions.
+- `Traveler`: consumer role with all three `booking:*` permissions.
 - `Support`: staff role for consumer support workflows.
 - `DestinationsAdmin`: staff role for curating featured destinations.
 - `OpsAdmin`: staff role for inviting and managing other staff.

--- a/docs/content/use-cases/b2c/try-it-out/add-login.mdx
+++ b/docs/content/use-cases/b2c/try-it-out/add-login.mdx
@@ -33,13 +33,13 @@ In the redirect-based pattern, the consumer app sends the user to <ProductName /
 
 1. Open <WayFinderSampleUrl />. Wayfinder's home page loads.
 2. Select **Sign in**. The browser navigates to <ProductName />.
-3. Sign in as John (`john.doe` / `john.doe`). <ProductName /> runs the authentication flow and grants John's `wayfinder:booking:*` permissions into the access token.
-4. The browser returns to Wayfinder, the dashboard loads, and John's bookings render because the Wayfinder API accepted the token's `wayfinder:booking:read` permission.
+3. Sign in as John (`john.doe` / `john.doe`). <ProductName /> runs the authentication flow and grants John's `booking:*` permissions into the access token.
+4. The browser returns to Wayfinder, the dashboard loads, and John's bookings render because the Wayfinder API accepted the token's `booking:read` permission.
 
 **Try a Variant**
 
 - Add Google as a sign-in option on the flow and verify that a **Sign in with Google** button appears on the <ProductName /> page.
-- Restrict the application's allowed scopes so the token only carries `wayfinder:booking:read`. Attempt a booking and confirm the API rejects it.
+- Restrict the application's allowed scopes so the token only carries `booking:read`. Attempt a booking and confirm the API rejects it.
 
 </TabItem>
 <TabItem value="app-native-steps" label="App-native step-by-step">

--- a/docs/content/use-cases/b2c/try-it-out/configure-it-yourself.mdx
+++ b/docs/content/use-cases/b2c/try-it-out/configure-it-yourself.mdx
@@ -66,13 +66,13 @@ These resources are shared by every B2C walkthrough.
      }'
    ```
 
-   This generates three permissions: `wayfinder:booking:read`, `wayfinder:booking:create`, and `wayfinder:booking:cancel`.
+   This generates three permissions: `booking:read`, `booking:create`, and `booking:cancel`.
 
    See [Resource Servers](../../../../guides/guides/resource-servers).
 
 3. **Create the `Traveler` role.**
 
-   Roles and their permissions are managed through the Role Management API. Create the role with the three `wayfinder:booking:*` permissions in one call. Replace `<default-ou-id>` with the ID of your default organization unit (look it up via `GET /organization-units`) and `<wayfinder-rs-id>` with the ID returned when you created the `wayfinder` resource server.
+   Roles and their permissions are managed through the Role Management API. Create the role with the three `booking:*` permissions in one call. Replace `<default-ou-id>` with the ID of your default organization unit (look it up via `GET /organization-units`) and `<wayfinder-rs-id>` with the ID returned when you created the `wayfinder` resource server.
 
    ```bash
    curl -k -X POST https://localhost:8090/roles \
@@ -85,7 +85,7 @@ These resources are shared by every B2C walkthrough.
        "permissions": [
          {
            "resourceServerId": "<wayfinder-rs-id>",
-           "permissions": ["wayfinder:booking:read", "wayfinder:booking:create", "wayfinder:booking:cancel"]
+           "permissions": ["booking:read", "booking:create", "booking:cancel"]
          }
        ]
      }'

--- a/samples/apps/wayfinder-sample/ai-agent/.env.example
+++ b/samples/apps/wayfinder-sample/ai-agent/.env.example
@@ -35,8 +35,8 @@ AGENT_REDIRECT_URI=http://localhost:5173/agent-callback
 MCP_SERVER_URL=http://localhost:8787/mcp
 
 # Scope required on the user's token to connect to the chat WebSocket.
-# Must match a permission on the Wayfinder Agent resource server. The imported
-# ThunderID config sets wayfinder-agent-rs as defaultResourceServer for this token.
+# Must match a permission on the Wayfinder Agent resource server. The frontend
+# requests this token with resource=http://localhost:8790/chat.
 AGENT_ACCESS_SCOPE=agent:access
 
 # Set to "true" to start the background upgrade scheduler that polls for pending upgrade


### PR DESCRIPTION
### Purpose

  Fixes documentation inconsistencies introduced by the single-resource-server token binding model and RFC 8707 Resource Indicator support.

  The changes align the documentation, API reference, and Wayfinder sample guidance with the current implementation:

  - Access and refresh tokens are bound to a single resource-server audience.
  - Multiple `resource` parameters are rejected with `invalid_target`.
  - Permission-bearing requests without `resource` use `defaultResourceServer`.
  - OIDC-only and scopeless requests without `resource` use `client_id` as the access-token audience.
  - Wayfinder uses `wayfinder-booking-rs` as its default resource server.
  - Permission strings are no longer prefixed or modified by resource servers.

  This is a documentation-only change and does not modify production behavior.

  ### Approach

  Updated the relevant documentation and sample comments to consistently describe the current token-issuance behavior:

  - Corrected Wayfinder documentation to use `wayfinder-booking-rs` as the default resource server.
  - Clarified that the ordinary Wayfinder booking sign-in relies on the default resource server, while chat and MCP flows explicitly send `resource`.
  - Updated refresh-token documentation to describe single-resource binding, matching-resource validation, and `invalid_target` responses.
  - Removed stale multi-audience and resource-subset refresh-token guidance.
  - Documented `oauth.refresh_token.revoke_previous_on_renew`.
  - Corrected the default resource-server configuration error from `invalid_target` to `invalid-config-value` (`SCF-1003`).
  - Updated audience-claim guidance for resource-bound and OIDC-only/scopeless tokens.
  - Corrected API gateway documentation that previously assumed `aud` was always the OAuth client ID.
  - Removed obsolete resource-server prefixes from permission examples.
  - Documented that ThunderID accepts at most one `resource` parameter, including across authorization code, PAR, client credentials, refresh token, token
  exchange, and JWT bearer flows.
  - Clarified that Resource Indicators are not currently supported for CIBA.
  - Reviewed the React and Wayfinder samples to avoid adding unnecessary resource indicators to OIDC-only or native authentication flows.

  Validation performed:

  - Ran `git diff --check`.
  - Ran the documentation linter using Node.js 22.
  - Regenerated the API specifications.
  - Searched for stale multi-audience descriptions, prefixed permissions, and contradictory Wayfinder default-resource-server guidance.

  Vale could not be run because it was not available in the local environment.

  ### Related Issues

  - Fixes #4084

  ### Related PRs

  - #4009

  ### Checklist

  - [x] Followed the contribution guidelines.
  - [x] Manual documentation review performed and verified.
  - [x] Documentation provided.
      - [ ] Ran Vale and fixed all errors and warnings
  - [ ] Tests provided. (Documentation-only change; no new automated tests required.)
      - [ ] Unit Tests
      - [ ] Integration Tests
  - [ ] Breaking changes. (Not applicable; documentation-only change.)
      - [ ] Breaking changes section filled.
      - [ ] `breaking change` label added.

  ### Security checks

  - [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-
  guidelines/secure-coding-guidlines/introduction/)
  - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified OAuth resource and audience behavior, including default resource handling, OIDC-only requests, token exchange, and refresh-token validation.
  * Documented refresh-token rotation and the option to revoke consumed tokens after renewal.
  * Updated authorization code, client credentials, resource indicators, and agent authentication guidance.
  * Simplified permission examples across API gateway, B2C, and AI-agent guides to use `resource:action` formats.
  * Updated sample walkthroughs, roles, consent screens, scopes, and token examples to match the revised permission naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->