### PR TITLE
Fix double sign in after logout in console.

### DIFF
--- a/frontend/apps/console/src/layouts/DashboardLayout.tsx
+++ b/frontend/apps/console/src/layouts/DashboardLayout.tsx
@@ -117,7 +117,7 @@ function SidebarFooterButtons(): ReactNode {
 }
 
 export default function DashboardLayout(): ReactNode {
-  const {signIn, clearSession, discovery} = useThunderID();
+  const {clearSession, discovery} = useThunderID();
   const {isTrustedIssuerGenericOidc, getTrustedIssuerClientId, getClientUrl} = useConfig();
   const {t} = useTranslation();
   const logger = useLogger();
@@ -147,11 +147,9 @@ export default function DashboardLayout(): ReactNode {
       return;
     }
 
-    signOut()
-      .then(() => signIn())
-      .catch((error: unknown) => {
-        logger.error('Sign out/in failed', {error});
-      });
+    signOut().catch((error: unknown) => {
+      logger.error('Sign out failed', {error});
+    });
   };
 
   const appRoutes: NavCategory[] = useMemo(

--- a/frontend/apps/console/src/layouts/__tests__/DashboardLayout.test.tsx
+++ b/frontend/apps/console/src/layouts/__tests__/DashboardLayout.test.tsx
@@ -164,10 +164,9 @@ describe('DashboardLayout', () => {
     expect(screen.getByText(new RegExp(currentYear.toString()))).toBeInTheDocument();
   });
 
-  it('calls signIn after successful signOut when sign out is clicked', async () => {
+  it('does not start a second sign-in after signing out', async () => {
     const user = userEvent.setup();
     mockSignOut.mockResolvedValue(undefined);
-    mockSignIn.mockResolvedValue(undefined);
 
     render(<DashboardLayout />);
 
@@ -181,8 +180,8 @@ describe('DashboardLayout', () => {
 
     await waitFor(() => {
       expect(mockSignOut).toHaveBeenCalled();
-      expect(mockSignIn).toHaveBeenCalled();
     });
+    expect(mockSignIn).not.toHaveBeenCalled();
   });
 
   it('logs error when signOut fails', async () => {
@@ -202,7 +201,7 @@ describe('DashboardLayout', () => {
 
     await waitFor(() => {
       expect(mockSignOut).toHaveBeenCalled();
-      expect(mockLoggerError).toHaveBeenCalledWith('Sign out/in failed', {error: signOutError});
+      expect(mockLoggerError).toHaveBeenCalledWith('Sign out failed', {error: signOutError});
     });
   });
 


### PR DESCRIPTION
### Purpose

  Fix the Console login failure that occurs on the first authentication attempt immediately after logout.

  The Console previously called `signIn()` after the ThunderID SDK's `signOut()` completed. However, the SDK already initiates sign-in using its configured
  options during sign-out. This resulted in two competing authorization requests.

  The additional Console-initiated request did not include the configured RFC 8707 `resource` parameter. If that request won the redirect race, the
  authorization-code token exchange failed with:

  ```text
  invalid_target: No resource parameter supplied and no default resource server is configured
```

  The following login attempt succeeded because it used the Console's normal resource-aware sign-in configuration.

  ### Approach

  - Removed the redundant signIn() call after signOut().
  - Allowed the SDK to handle the post-logout authentication transition using its configured signInOptions.
  - Updated the logout error message to reflect that only sign-out is handled by the Console.
  - Updated the existing unit test to verify that:
      - signOut() is called when the user logs out.
      - The Console does not initiate a second sign-in.
      - Sign-out failures are logged correctly.

  This is a focused Console fix. No backend OAuth behavior or SDK behavior is changed.

  Validation performed:

  - Ran the focused Dashboard layout test suite.
  - All 13 focused tests passed.
  - Ran ESLint on the affected files.
  - Ran Prettier on the affected files.
  - Ran git diff --check.

  ### Related Issues

  - Fixes #4086

  ### Related PRs

  - N/A

  ### Checklist

  - [x] Followed the contribution guidelines.
  - [x] Manual test round performed and verified.
  - [ ] Documentation provided. (Not applicable; no documentation changes required.)
      - [ ] Ran Vale and fixed all errors and warnings

  - [x] Tests provided.
      - [x] Unit Tests
      - [ ] Integration Tests

  - [ ] Breaking changes. (Not applicable; this change is backward compatible.)
      - [ ] Breaking changes section filled.
      - [ ] breaking change label added.

  ### Security checks

  - [x] Followed secure coding standards in WSO2 Secure Coding Guidelines
    (https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)

  - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-out behavior by preventing an unnecessary sign-in attempt after logout.
  * Updated error handling and messaging when sign-out fails.
  * Preserved proper session clearing and identity-provider redirection during logout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->