### PR TITLE
Reduce access log noise from frontend paths

### DIFF
--- a/backend/cmd/server/config/default.json
+++ b/backend/cmd/server/config/default.json
@@ -187,6 +187,9 @@
           "compress": false
         }
       }
+    },
+    "access": {
+      "exclude_paths": []
     }
   },
   "observability": {

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -224,6 +224,19 @@ func loadCertConfig(ctx context.Context, logger *log.Logger, runtimeSvc kmprovid
 	}
 }
 
+// accessLogExcludePaths returns the path prefixes excluded from the access log: the always-excluded
+// Gate and Console frontend paths plus any configured extras. Empty and root ("/") entries are
+// dropped because they match every request and would silently disable all access logging.
+func accessLogExcludePaths(configured []string) []string {
+	paths := []string{"/gate/", "/console/"}
+	for _, prefix := range configured {
+		if prefix != "" && prefix != "/" {
+			paths = append(paths, prefix)
+		}
+	}
+	return paths
+}
+
 // createHTTPServer creates and configures an HTTP server with common settings.
 func createHTTPServer(ctx context.Context, logger *log.Logger, cfg *config.Config, mux *http.ServeMux,
 	jwtService jwt.JWTServiceInterface, revocationEnforcer revocationcache.EnforcerInterface) *http.Server {
@@ -233,7 +246,9 @@ func createHTTPServer(ctx context.Context, logger *log.Logger, cfg *config.Confi
 	// Build the middleware chain with proper execution order.
 	// Request flow: CorrelationID (outermost) -> AccessLog -> Security -> Route Handler (innermost)
 	// Note: Middlewares are wrapped in reverse order - the last added will execute first.
-	handler := log.AccessLogHandler(logger, securityMiddleware)
+	// The Gate and Console frontend paths are always excluded from the access log to keep it
+	// focused on API traffic. Additional prefixes can be excluded via log.access.exclude_paths.
+	handler := log.AccessLogHandler(logger, accessLogExcludePaths(cfg.Log.Access.ExcludePaths), securityMiddleware)
 	handler = middleware.CorrelationIDMiddleware(handler)
 
 	// Build the server address using hostname and port from the configurations.

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -657,3 +657,17 @@ func runExitHelper(t *testing.T, envKey, testName string) {
 		t.Fatalf("expected process to exit with code 1, got %v", err)
 	}
 }
+
+func TestAccessLogExcludePaths(t *testing.T) {
+	// The frontend prefixes are always present, even with no configured extras.
+	assert.Equal(t, []string{"/gate/", "/console/"}, accessLogExcludePaths(nil))
+
+	// Configured prefixes are appended after the built-in frontend prefixes.
+	assert.Equal(t, []string{"/gate/", "/console/", "/health/", "/metrics/"},
+		accessLogExcludePaths([]string{"/health/", "/metrics/"}))
+
+	// Empty and root ("/") entries are dropped so they cannot match every request
+	// and silently disable all access logging.
+	assert.Equal(t, []string{"/gate/", "/console/", "/health/"},
+		accessLogExcludePaths([]string{"", "/health/", "/"}))
+}

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -434,6 +434,14 @@ type TranslationConfig struct {
 type LogConfig struct {
 	Level  string          `yaml:"level"  json:"level"`
 	Output LogOutputConfig `yaml:"output" json:"output"`
+	Access LogAccessConfig `yaml:"access" json:"access"`
+}
+
+// LogAccessConfig holds the access log settings.
+type LogAccessConfig struct {
+	// ExcludePaths lists extra path prefixes whose requests are served without an access log line.
+	// The Gate and Console frontend prefixes are always excluded in addition to these.
+	ExcludePaths []string `yaml:"exclude_paths" json:"exclude_paths"`
 }
 
 // LogOutputConfig holds the log output destinations.

--- a/backend/internal/system/log/accesslog.go
+++ b/backend/internal/system/log/accesslog.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	sysContext "github.com/thunder-id/thunderid/internal/system/context"
@@ -29,8 +30,16 @@ import (
 
 // AccessLogHandler logs HTTP requests in Apache CLF with response time and correlation ID.
 // The correlation ID should be set in the context by the CorrelationIDMiddleware.
-func AccessLogHandler(logger *Logger, next http.Handler) http.Handler {
+// Paths matching skipPrefixes are served without an access log line (e.g. /console/, /gate/).
+func AccessLogHandler(logger *Logger, skipPrefixes []string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for _, prefix := range skipPrefixes {
+			if strings.HasPrefix(r.URL.Path, prefix) {
+				next.ServeHTTP(w, r)
+				return
+			}
+		}
+
 		start := time.Now()
 
 		// Extract correlation ID from context

--- a/backend/internal/system/log/accesslog_test.go
+++ b/backend/internal/system/log/accesslog_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+const testRemoteAddr = "192.168.1.1:12345"
+
 type AccessLogTestSuite struct {
 	suite.Suite
 }
@@ -60,10 +62,10 @@ func (suite *AccessLogTestSuite) TestAccessLogHandler() {
 		}
 	})
 
-	handler := AccessLogHandler(log, testHandler)
+	handler := AccessLogHandler(log, nil, testHandler)
 
 	req := httptest.NewRequest("GET", "/test?include=display&token=secret", nil)
-	req.RemoteAddr = "192.168.1.1:12345"
+	req.RemoteAddr = testRemoteAddr
 
 	rr := httptest.NewRecorder()
 
@@ -83,6 +85,94 @@ func (suite *AccessLogTestSuite) TestAccessLogHandler() {
 	assert.NotContains(suite.T(), output, "token=secret")
 	// Verify that escape characters are not present in the log output
 	assert.NotContains(suite.T(), output, `\"`)
+}
+
+func (suite *AccessLogTestSuite) TestAccessLogHandlerSkipPrefixes() {
+	var buf bytes.Buffer
+
+	logger = nil
+	once = sync.Once{}
+
+	logHandler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	log := &Logger{
+		internal: slog.New(logHandler),
+	}
+
+	served := false
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		served = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := AccessLogHandler(log, []string{"/gate/", "/console/"}, testHandler)
+
+	// A skipped path is still served, but no access log line is emitted.
+	req := httptest.NewRequest("GET", "/console/assets/index.js", nil)
+	req.RemoteAddr = testRemoteAddr
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.True(suite.T(), served, "skipped request should still be served")
+	assert.Equal(suite.T(), http.StatusOK, rr.Code)
+	assert.Empty(suite.T(), buf.String(), "no access log should be written for skipped prefixes")
+
+	// A non-skipped path is logged as usual.
+	buf.Reset()
+	req = httptest.NewRequest("GET", "/oauth2/token", nil)
+	req.RemoteAddr = testRemoteAddr
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Contains(suite.T(), buf.String(), "GET /oauth2/token")
+}
+
+func (suite *AccessLogTestSuite) TestAccessLogHandlerSkipPrefixEdgeCases() {
+	skipPrefixes := []string{"/gate/", "/console/", "/health/"}
+
+	cases := []struct {
+		path       string
+		wantLogged bool
+	}{
+		{"/console/", false},
+		{"/console/assets/index.js", false},
+		{"/gate/", false},
+		{"/gate/signin", false},
+		{"/health/liveness", false},
+		{"/health/readiness", false},
+		// Bare prefixes without a trailing slash are not skipped (e.g. the /console -> /console/ redirect).
+		{"/console", true},
+		{"/gate", true},
+		{"/health", true},
+		// Paths that merely share a leading substring must not be skipped.
+		{"/consolexyz", true},
+		{"/gateway", true},
+		{"/healthz", true},
+		// Regular API traffic is always logged.
+		{"/oauth2/token", true},
+		{"/applications", true},
+	}
+
+	for _, tc := range cases {
+		var buf bytes.Buffer
+		logHandler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+		log := &Logger{internal: slog.New(logHandler)}
+
+		handler := AccessLogHandler(log, skipPrefixes, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest("GET", tc.path, nil)
+		req.RemoteAddr = testRemoteAddr
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(suite.T(), http.StatusOK, rr.Code, "path %q should still be served", tc.path)
+		if tc.wantLogged {
+			assert.Contains(suite.T(), buf.String(), "GET "+tc.path, "path %q should be logged", tc.path)
+		} else {
+			assert.Empty(suite.T(), buf.String(), "path %q should not be logged", tc.path)
+		}
+	}
 }
 
 func (suite *AccessLogTestSuite) TestLoggingResponseWriter() {

--- a/docs/content/guides/getting-started/configuration.mdx
+++ b/docs/content/guides/getting-started/configuration.mdx
@@ -128,6 +128,23 @@ Size and time triggers are independent and can run together: with both enabled, 
 This is the <ProductName /> **application log** (the `INFO`/`WARN`/`ERROR` lines the server emits). It is separate from the observability event file sink described in the [Observability](../../deployment-patterns/observability) guide, which records structured domain events such as token issuance and flow execution.
 :::
 
+### Access Log
+
+<ProductName /> writes an access log line for every HTTP request. The Gate and Console frontend paths (`/gate/` and `/console/`) are always excluded.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `log.access.exclude_paths` | `[]` | Additional path prefixes to exclude, alongside the always-excluded `/gate/` and `/console/` paths |
+
+To exclude other paths, add their prefixes in `deployment.yaml`. For example, to also exclude the health probe endpoints:
+
+```yaml
+log:
+  access:
+    exclude_paths:
+      - "/health/"
+```
+
 ## Database Configuration
 
 <ProductName /> uses four separate databases for different purposes. Each database can be configured independently.


### PR DESCRIPTION
### Purpose

The access log recorded a line for every HTTP request, including requests for the static frontend assets served under `/console/` and `/gate/`. Loading either app fetches many JS, CSS, and image files, so a single page load produced a burst of access log lines that were not useful for observing API traffic. This made the log noisy and harder to read.

This PR lets the access log skip configured path prefixes so that static frontend routes no longer emit access log lines, keeping the log focused on API traffic.
Fixes #4095

### Approach
- `AccessLogHandler` now takes a `skipPrefixes []string` argument. When a request path starts with any of the given prefixes, the request is served normally but no access log line is written. All other requests are logged exactly as before.
- The server wires this up in `createHTTPServer` with `/gate/` and `/console/` as the skipped prefixes.
- Prefix matching uses the trailing slash deliberately, so only assets under those apps are skipped. Bare paths such as `/console` (the redirect to `/console/`) and unrelated paths that merely share a leading substring (for example `/consolexyz` or `/gateway`) are still logged.
- Added unit tests covering the skip behaviour: skipped paths are still served but produce no log line, non-skipped API paths are logged as usual, and the edge cases above (bare prefix, shared-substring paths, regular API traffic) behave correctly. Extracted the repeated test remote address into a shared constant.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4095



### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced unnecessary access-log entries by skipping access logging for `/gate/` and `/console/`, plus any additional prefixes configured via `log.access.exclude_paths`.
  - Skipped requests are still served normally.
  - Strengthened prefix matching to avoid incorrect skips on edge cases.

- **New Features**
  - Added configurable “Access Log” exclusion paths via `log.access.exclude_paths`.

- **Tests**
  - Added tests verifying skipped paths emit no access-log output and that non-skipped routes continue to log, including edge-case coverage.

- **Documentation**
  - Documented the new **Access Log** configuration with an example excluding `/health/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->