### PR TITLE
Fix release build

### DIFF
--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -643,6 +643,8 @@ jobs:
 
       - name: ⚙️ Setup Samples Environment
         uses: ./.github/actions/setup-samples-environment
+        with:
+          download-certificates: 'false'
 
       - name: 📝 Update Sample Apps Version
         uses: ./.github/actions/update-sample-versions

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@
 FROM golang:1.26-alpine3.23 AS builder
 
 # Install build dependencies including Node.js and npm
-RUN apk add --no-cache git make bash sqlite openssl zip nodejs npm curl
+RUN apk add --no-cache git make bash sqlite openssl zip nodejs npm curl python3 g++ build-base sqlite-dev
 
 # Set environment variables for CI build
 ENV CI=true


### PR DESCRIPTION
### Purpose
Fix two failures in the release build pipeline:

1. **Docker build failure** — the builder image was missing native toolchain packages (`python3`, `g++`, `build-base`, `sqlite-dev`) required to compile frontend/native dependencies during the image build, causing the build to fail.
2. **Release builder workflow failure** — the `setup-samples-environment` action step attempted to download certificates during the release build, which is not needed and was breaking the job.

### Approach
- **Dockerfile**: Add `python3 g++ build-base sqlite-dev` to the `apk add` install list in the builder stage so native modules compile successfully.
- **.github/workflows/release-builder.yml**: Pass `download-certificates: 'false'` to the `Setup Samples Environment` step to skip the unneeded certificate download.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the package build environment by adding required tooling and SQLite development support.
  * Updated sample environment setup to skip certificate downloads during release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->