### PR TITLE
Fix OpenID4VP config mismatches that crash the Helm chart on startup

### DIFF
--- a/install/helm/conf/deployment.yaml
+++ b/install/helm/conf/deployment.yaml
@@ -265,7 +265,7 @@ passkey:
   {{- end }}
 
 openid4vp:
-  client_id: {{ .Values.configuration.openid4vp.clientId | quote }}
+  client_id_scheme: {{ .Values.configuration.openid4vp.clientIdScheme | quote }}
   signing_key_id: {{ .Values.configuration.openid4vp.signingKeyId | quote }}
   ephemeral_key_id: {{ .Values.configuration.openid4vp.ephemeralKeyId | quote }}
   response_enc_values:

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -246,6 +246,10 @@ configuration:
       - id: "default-key"
         certFile: "config/certs/signing.cert"
         keyFile: "config/certs/signing.key"
+      # Certificate-backed ECDSA key used by the OpenID4VP and OpenID4VCI engines.
+      - id: "ecdsa-key"
+        certFile: "config/certs/ecdsa-signing.cert"
+        keyFile: "config/certs/ecdsa-signing.key"
 
   # Database configuration
   database:
@@ -425,12 +429,13 @@ configuration:
       - "https://localhost:8090"
 
   # OpenID4VP (verifiable presentation / verifier) configuration.
-  # Leave signingKeyId empty to keep the verifier signing engine disabled.
   openid4vp:
-    # Verifier client_id, scheme-prefixed (e.g. "x509_san_dns:<host>" or "x509_hash:<hash>").
-    clientId: "x509_san_dns:localhost"
-    # Key ID (from crypto.keys) used to sign the request object. Empty disables OpenID4VP.
-    signingKeyId: ""
+    # Scheme used to derive the verifier client_id from the signing certificate.
+    # One of: "x509_hash", "x509_san_dns", "redirect_uri".
+    clientIdScheme: "x509_san_dns"
+    # Key ID (from crypto.keys) used to sign the request object. The key must be
+    # certificate-backed. Leaving this empty falls back to the built-in default.
+    signingKeyId: "ecdsa-key"
     # Ephemeral key ID (from crypto.keys) used for response encryption.
     ephemeralKeyId: "vp-enc"
     # Supported response encryption (JWE enc) values.
@@ -453,10 +458,10 @@ configuration:
     trustedAnchors: []
 
   # OpenID4VCI (verifiable credential issuance / issuer) configuration.
-  # Leave signingKeyId empty to keep the issuer engine disabled.
   openid4vci:
-    # Key ID (from crypto.keys) used to sign issued SD-JWT credentials. Empty disables OpenID4VCI.
-    signingKeyId: ""
+    # Key ID (from crypto.keys) used to sign issued SD-JWT credentials.
+    # Leaving this empty falls back to the built-in default.
+    signingKeyId: "ecdsa-key"
     nonceTtlSeconds: 300
     proofMaxAgeSeconds: 300
     credentialValiditySeconds: 2592000


### PR DESCRIPTION
### Purpose

The bundled Helm chart does not deploy out of the box. The ThunderID server pod crashes on startup with:

```
level=ERROR msg="Failed to load configurations" error="yaml: unmarshal errors:
  line 143: field client_id not found in type config.OpenID4VPConfig"
```

This PR fixes two separate defects that both prevent startup. The second one is not mentioned in the issue, but the chart still fails to start without it.

**1. Unknown `client_id` key (the reported crash)**

The chart emitted `openid4vp.client_id`, but `config.OpenID4VPConfig` has no such field. It defines `client_id_scheme`. The server decodes configuration with `KnownFields(true)`, so the unknown key is rejected and config loading fails.

There was also a semantic mismatch. `client_id_scheme` is a bare scheme selector (`x509_hash`, `x509_san_dns`, `redirect_uri`) and the full client_id is derived from the signing certificate at runtime by `deriveClientID`. The chart's value `x509_san_dns:localhost` was scheme-prefixed, so it would have been rejected as an unsupported scheme even if the key name had been correct.

**2. Signing key `ecdsa-key` was never declared by the chart**

Fixing the key name alone is not enough. `mergeConfigs` only overrides a default when the user-supplied value is non-zero, so the chart's `signingKeyId: ""` never overrode anything and the effective value fell back to `ecdsa-key` from `config/default.json`. The chart's `crypto.keys` declared only `default-key`, so `openid4vp.Initialize` found no matching key, returned `ErrPolicy`, and `fatalOnError` exited the process.

Confirmed by resolving the rendered chart config through the server's own `LoadConfig`:

```
effective openid4vp.signing_key_id  = "ecdsa-key"
effective openid4vci.signing_key_id = "ecdsa-key"
crypto key ids declared by chart    = [default-key]
```

This also means the `Empty disables OpenID4VP` comments in `values.yaml` were incorrect. An empty value does not disable the engine, it falls back to the built-in default.

### Approach

- Renamed the chart key `client_id` to `client_id_scheme` and set the bare scheme value `x509_san_dns`, matching `config/default.json`.
- Declared the `ecdsa-key` entry in `configuration.crypto.keys`, pointing at `ecdsa-signing.cert` / `ecdsa-signing.key`, which already ship in the image. This matches `backend/cmd/server/deployment.yaml`.
- Set `openid4vp.signingKeyId` and `openid4vci.signingKeyId` explicitly to `ecdsa-key` so the rendered configuration reflects actual behaviour instead of relying on an implicit fallback.
- Corrected the misleading `Empty disables ...` comments.

No Go code changed. The struct is correct; the chart had drifted from it.

**Verification**

- Rendered the chart and strict-decoded both ConfigMaps against `config.Config` using `KnownFields(true)`. Fails before the change, passes after.
- Since yaml.v3 accumulates every unknown-field error into a single error, `client_id` was confirmed to be the only key mismatch in the whole rendered configuration.
- Repeated the check with a non-default values override to exercise the conditional template branches (trusted anchors, registration cert file). Trust anchors parse correctly.
- Cross-checked every `.Values.configuration.openid4vp.*` and `.Values.configuration.openid4vci.*` template reference against `values.yaml`. No missing or unused keys.
- Resolved the rendered config through `LoadConfig` and confirmed both signing key IDs now resolve against `crypto.keys`.
- `helm lint install/helm` passes.

**Note on `ephemeralKeyId`**

`ephemeralKeyId: "vp-enc"` is also absent from `crypto.keys`, but it is resolved lazily at response-encryption time rather than at startup, and the local `deployment.yaml` has the same gap. It is pre-existing parity rather than a startup crash, so it is left unchanged.

### Related Issues
- Fixes #4102

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring OpenID4VP with a client ID scheme.
  * Added certificate-backed ECDSA signing configuration for OpenID4VP and OpenID4VCI.

* **Improvements**
  * Enabled issuer signing for OpenID4VCI through the configured ECDSA key.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->