### PR TITLE
Add '/users/me/meta' endpoint to retrieve user's schema metadata

### DIFF
--- a/api/user.yaml
+++ b/api/user.yaml
@@ -1280,6 +1280,81 @@ paths:
                   key: "error.internal_server_error_description"
                   defaultValue: "An unexpected error occurred while processing the request"
 
+  /users/me/meta:
+    get:
+      tags:
+        - Self
+      summary: Get self user schema metadata
+      security:
+        - OAuth2: []
+      responses:
+        "200":
+          description: Schema metadata for the caller's user type
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [schema]
+                properties:
+                  schema:
+                    $ref: '#/components/schemas/UserType/properties/schema'
+        "400":
+          description: User type schema missing or not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                code: "USR-1021"
+                message:
+                  key: "error.userservice.user_type_not_found"
+                  defaultValue: "User type not found"
+                description:
+                  key: "error.userservice.user_type_not_found_description"
+                  defaultValue: "The specified user type does not exist"
+        "401":
+          description: Unauthorized - missing or invalid authentication token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                code: "AUTH-4010"
+                message:
+                  key: "error.unauthorized"
+                  defaultValue: "Unauthorized"
+                description:
+                  key: "error.unauthorized_description"
+                  defaultValue: "Authentication is required to access this resource"
+        "404":
+          description: User not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                code: "USR-1003"
+                message:
+                  key: "error.userservice.user_not_found"
+                  defaultValue: "User not found"
+                description:
+                  key: "error.userservice.user_not_found_description"
+                  defaultValue: "The user with the specified id does not exist"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                code: "USR-5000"
+                message:
+                  key: "error.internal_server_error"
+                  defaultValue: "Internal server error"
+                description:
+                  key: "error.internal_server_error_description"
+                  defaultValue: "An unexpected error occurred while processing the request"
+
   /users/me/update-credentials:
     post:
       tags:

--- a/backend/internal/entitytype/EntityTypeServiceInterface_mock_test.go
+++ b/backend/internal/entitytype/EntityTypeServiceInterface_mock_test.go
@@ -596,6 +596,82 @@ func (_c *EntityTypeServiceInterfaceMock_GetEntityTypeList_Call) RunAndReturn(ru
 	return _c
 }
 
+// GetEntityTypeSchema provides a mock function for the type EntityTypeServiceInterfaceMock
+func (_mock *EntityTypeServiceInterfaceMock) GetEntityTypeSchema(ctx context.Context, category TypeCategory, userTypeName string) (*EntityType, *common.ServiceError) {
+	ret := _mock.Called(ctx, category, userTypeName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetEntityTypeSchema")
+	}
+
+	var r0 *EntityType
+	var r1 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, TypeCategory, string) (*EntityType, *common.ServiceError)); ok {
+		return returnFunc(ctx, category, userTypeName)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, TypeCategory, string) *EntityType); ok {
+		r0 = returnFunc(ctx, category, userTypeName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*EntityType)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, TypeCategory, string) *common.ServiceError); ok {
+		r1 = returnFunc(ctx, category, userTypeName)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// EntityTypeServiceInterfaceMock_GetEntityTypeSchema_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetEntityTypeSchema'
+type EntityTypeServiceInterfaceMock_GetEntityTypeSchema_Call struct {
+	*mock.Call
+}
+
+// GetEntityTypeSchema is a helper method to define mock.On call
+//   - ctx context.Context
+//   - category TypeCategory
+//   - userTypeName string
+func (_e *EntityTypeServiceInterfaceMock_Expecter) GetEntityTypeSchema(ctx interface{}, category interface{}, userTypeName interface{}) *EntityTypeServiceInterfaceMock_GetEntityTypeSchema_Call {
+	return &EntityTypeServiceInterfaceMock_GetEntityTypeSchema_Call{Call: _e.mock.On("GetEntityTypeSchema", ctx, category, userTypeName)}
+}
+
+func (_c *EntityTypeServiceInterfaceMock_GetEntityTypeSchema_Call) Run(run func(ctx context.Context, category TypeCategory, userTypeName string)) *EntityTypeServiceInterfaceMock_GetEntityTypeSchema_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 TypeCategory
+		if args[1] != nil {
+			arg1 = args[1].(TypeCategory)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *EntityTypeServiceInterfaceMock_GetEntityTypeSchema_Call) Return(entityType *EntityType, serviceError *common.ServiceError) *EntityTypeServiceInterfaceMock_GetEntityTypeSchema_Call {
+	_c.Call.Return(entityType, serviceError)
+	return _c
+}
+
+func (_c *EntityTypeServiceInterfaceMock_GetEntityTypeSchema_Call) RunAndReturn(run func(ctx context.Context, category TypeCategory, userTypeName string) (*EntityType, *common.ServiceError)) *EntityTypeServiceInterfaceMock_GetEntityTypeSchema_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetUniqueAttributes provides a mock function for the type EntityTypeServiceInterfaceMock
 func (_mock *EntityTypeServiceInterfaceMock) GetUniqueAttributes(ctx context.Context, category TypeCategory, entityType string) ([]string, *common.ServiceError) {
 	ret := _mock.Called(ctx, category, entityType)

--- a/backend/internal/entitytype/handler_test.go
+++ b/backend/internal/entitytype/handler_test.go
@@ -112,6 +112,12 @@ func (s *InlineStubEntityTypeService) ValidateEntityUniqueness(
 	return true, nil
 }
 
+func (s *InlineStubEntityTypeService) GetEntityTypeSchema(
+	ctx context.Context, cat TypeCategory, name string,
+) (*EntityType, *tidcommon.ServiceError) {
+	return &EntityType{Name: name, Category: cat}, nil
+}
+
 // --- POST ENDPOINT TESTS ---
 
 func TestHandleEntityTypePostRequest_Success(t *testing.T) {

--- a/backend/internal/entitytype/service.go
+++ b/backend/internal/entitytype/service.go
@@ -84,6 +84,9 @@ type EntityTypeServiceInterface interface {
 		ctx context.Context, category TypeCategory, names []string,
 	) (map[string]string, *tidcommon.ServiceError)
 	ResolveEntityTypeHandles(ctx context.Context, entityType *EntityType) *tidcommon.ServiceError
+	GetEntityTypeSchema(
+		ctx context.Context, category TypeCategory, userTypeName string,
+	) (*EntityType, *tidcommon.ServiceError)
 }
 
 // entityTypeService is the default implementation of the EntityTypeServiceInterface.
@@ -322,6 +325,31 @@ func (us *entityTypeService) GetEntityType(
 		} else if handle, ok := handleMap[entityType.OUID]; ok {
 			entityType.OUHandle = handle
 		}
+	}
+
+	return &entityType, nil
+}
+
+// GetEntityTypeSchema retrieves the schema config by name without admin access check
+func (us *entityTypeService) GetEntityTypeSchema(
+	ctx context.Context, category TypeCategory, userTypeName string,
+) (*EntityType, *tidcommon.ServiceError) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, entityTypeLoggerComponentName))
+
+	if svcErr := validateCategory(category); svcErr != nil {
+		return nil, svcErr
+	}
+
+	if userTypeName == "" {
+		return nil, invalidEntityTypeRequestErr(category, "schema name must not be empty")
+	}
+
+	entityType, err := us.entityTypeStore.GetEntityTypeByName(ctx, category, userTypeName)
+	if err != nil {
+		if errors.Is(err, ErrEntityTypeNotFound) {
+			return nil, entityTypeNotFoundErr(category)
+		}
+		return nil, logAndReturnServerError(ctx, logger, "Failed to get entity type", err)
 	}
 
 	return &entityType, nil

--- a/backend/internal/entitytype/service_test.go
+++ b/backend/internal/entitytype/service_test.go
@@ -1916,6 +1916,67 @@ func (s *EntityTypeServiceTestSuite) TestGetAttributes_NonCredential_StoreError_
 	s.Require().Nil(attrs)
 }
 
+func (s *EntityTypeServiceTestSuite) TestGetEntityTypeSchema_Success() {
+	storeMock := newEntityTypeStoreInterfaceMock(s.T())
+	storeMock.
+		On("GetEntityTypeByName", context.Background(), TypeCategoryUser, "employee").
+		Return(EntityType{Name: "employee", Schema: json.RawMessage(`{}`)}, nil).
+		Once()
+
+	service := &entityTypeService{entityTypeStore: storeMock}
+
+	entityType, svcErr := service.GetEntityTypeSchema(context.Background(), TypeCategoryUser, "employee")
+	s.Require().Nil(svcErr)
+	s.Require().NotNil(entityType)
+	s.Require().Equal("employee", entityType.Name)
+}
+
+func (s *EntityTypeServiceTestSuite) TestGetEntityTypeSchema_InvalidCategory() {
+	service := &entityTypeService{}
+	entityType, svcErr := service.GetEntityTypeSchema(context.Background(), TypeCategory("invalid"), "employee")
+	s.Require().Nil(entityType)
+	s.Require().NotNil(svcErr)
+	s.Require().Equal(ErrorInvalidEntityTypeRequest.Code, svcErr.Code)
+}
+
+func (s *EntityTypeServiceTestSuite) TestGetEntityTypeSchema_EmptyName() {
+	service := &entityTypeService{}
+	entityType, svcErr := service.GetEntityTypeSchema(context.Background(), TypeCategoryUser, "")
+	s.Require().Nil(entityType)
+	s.Require().NotNil(svcErr)
+	s.Require().Equal(ErrorInvalidEntityTypeRequest.Code, svcErr.Code)
+}
+
+func (s *EntityTypeServiceTestSuite) TestGetEntityTypeSchema_NotFound() {
+	storeMock := newEntityTypeStoreInterfaceMock(s.T())
+	storeMock.
+		On("GetEntityTypeByName", context.Background(), TypeCategoryUser, "employee").
+		Return(EntityType{}, ErrEntityTypeNotFound).
+		Once()
+
+	service := &entityTypeService{entityTypeStore: storeMock}
+
+	entityType, svcErr := service.GetEntityTypeSchema(context.Background(), TypeCategoryUser, "employee")
+	s.Require().Nil(entityType)
+	s.Require().NotNil(svcErr)
+	s.Require().Equal(ErrorEntityTypeNotFound.Code, svcErr.Code)
+}
+
+func (s *EntityTypeServiceTestSuite) TestGetEntityTypeSchema_StoreError() {
+	storeMock := newEntityTypeStoreInterfaceMock(s.T())
+	storeMock.
+		On("GetEntityTypeByName", context.Background(), TypeCategoryUser, "employee").
+		Return(EntityType{}, errors.New("db error")).
+		Once()
+
+	service := &entityTypeService{entityTypeStore: storeMock}
+
+	entityType, svcErr := service.GetEntityTypeSchema(context.Background(), TypeCategoryUser, "employee")
+	s.Require().Nil(entityType)
+	s.Require().NotNil(svcErr)
+	s.Require().Equal(tidcommon.InternalServerError, *svcErr)
+}
+
 // TestGetCompiledSchemaForEntityType_CompileError verifies that a stored schema which fails to
 // compile surfaces as an internal server error through ValidateEntity.
 func TestGetCompiledSchemaForEntityType_CompileError(t *testing.T) {

--- a/backend/internal/user/UserServiceInterface_mock_test.go
+++ b/backend/internal/user/UserServiceInterface_mock_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 
 	mock "github.com/stretchr/testify/mock"
+	"github.com/thunder-id/thunderid/internal/entitytype"
 	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 )
@@ -487,6 +488,76 @@ func (_c *UserServiceInterfaceMock_GetUserList_Call) Return(userListResponse *Us
 }
 
 func (_c *UserServiceInterfaceMock_GetUserList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int, filters map[string]interface{}, includeDisplay bool) (*UserListResponse, *common.ServiceError)) *UserServiceInterfaceMock_GetUserList_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetUserMetadata provides a mock function for the type UserServiceInterfaceMock
+func (_mock *UserServiceInterfaceMock) GetUserMetadata(ctx context.Context, userID string) (*entitytype.EntityType, *common.ServiceError) {
+	ret := _mock.Called(ctx, userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserMetadata")
+	}
+
+	var r0 *entitytype.EntityType
+	var r1 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*entitytype.EntityType, *common.ServiceError)); ok {
+		return returnFunc(ctx, userID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *entitytype.EntityType); ok {
+		r0 = returnFunc(ctx, userID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*entitytype.EntityType)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *common.ServiceError); ok {
+		r1 = returnFunc(ctx, userID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// UserServiceInterfaceMock_GetUserMetadata_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserMetadata'
+type UserServiceInterfaceMock_GetUserMetadata_Call struct {
+	*mock.Call
+}
+
+// GetUserMetadata is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID string
+func (_e *UserServiceInterfaceMock_Expecter) GetUserMetadata(ctx interface{}, userID interface{}) *UserServiceInterfaceMock_GetUserMetadata_Call {
+	return &UserServiceInterfaceMock_GetUserMetadata_Call{Call: _e.mock.On("GetUserMetadata", ctx, userID)}
+}
+
+func (_c *UserServiceInterfaceMock_GetUserMetadata_Call) Run(run func(ctx context.Context, userID string)) *UserServiceInterfaceMock_GetUserMetadata_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_GetUserMetadata_Call) Return(entityType *entitytype.EntityType, serviceError *common.ServiceError) *UserServiceInterfaceMock_GetUserMetadata_Call {
+	_c.Call.Return(entityType, serviceError)
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_GetUserMetadata_Call) RunAndReturn(run func(ctx context.Context, userID string) (*entitytype.EntityType, *common.ServiceError)) *UserServiceInterfaceMock_GetUserMetadata_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/user/handler.go
+++ b/backend/internal/user/handler.go
@@ -436,6 +436,31 @@ func (uh *userHandler) HandleSelfUserPutRequest(w http.ResponseWriter, r *http.R
 	logger.Debug(ctx, "Self user PUT response sent", log.MaskedString(log.LoggerKeyUserID, userID))
 }
 
+// HandleSelfUserMetadataGetRequest handles the self user metadata retrieval.
+func (uh *userHandler) HandleSelfUserMetadataGetRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, handlerLoggerComponentName))
+
+	userID := security.GetSubject(ctx)
+	if strings.TrimSpace(userID) == "" {
+		handleError(ctx, w, &ErrorAuthenticationFailed)
+		return
+	}
+
+	userMetadata, svcErr := uh.userService.GetUserMetadata(ctx, userID)
+	if svcErr != nil {
+		handleError(ctx, w, svcErr)
+		return
+	}
+
+	response := map[string]interface{}{
+		"schema": userMetadata.Schema,
+	}
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, response)
+
+	logger.Debug(ctx, "Self user metadata GET response sent", log.MaskedString(log.LoggerKeyUserID, userID))
+}
+
 // HandleSelfUserCredentialUpdateRequest handles the credential update for the authenticated user.
 func (uh *userHandler) HandleSelfUserCredentialUpdateRequest(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()

--- a/backend/internal/user/handler_test.go
+++ b/backend/internal/user/handler_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/thunder-id/thunderid/internal/entitytype"
 	"github.com/thunder-id/thunderid/internal/system/error/apierror"
 	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/internal/system/security"
@@ -1299,6 +1300,60 @@ func TestHandleUserUsagesGetRequest_NotFound(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	handler.HandleUserUsagesGetRequest(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestHandleSelfUserMetadataGetRequest_Success(t *testing.T) {
+	userID := testUserID123
+	authCtx := security.NewSecurityContextForTest(userID, "", "", nil, nil)
+
+	mockSvc := NewUserServiceInterfaceMock(t)
+	expectedSchema := &entitytype.EntityType{
+		Name:   "employee",
+		Schema: json.RawMessage(`{"email":{"type":"string"}}`),
+	}
+	mockSvc.On("GetUserMetadata", mock.Anything, userID).Return(expectedSchema, nil)
+
+	handler := newUserHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodGet, "/users/me/meta", nil)
+	req = req.WithContext(security.WithSecurityContextTest(req.Context(), authCtx))
+	rr := httptest.NewRecorder()
+
+	handler.HandleSelfUserMetadataGetRequest(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Header().Get("Content-Type"), "application/json")
+
+	var res map[string]interface{}
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&res))
+	require.NotNil(t, res["schema"])
+}
+
+func TestHandleSelfUserMetadataGetRequest_Unauthorized(t *testing.T) {
+	mockSvc := NewUserServiceInterfaceMock(t)
+	handler := newUserHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodGet, "/users/me/meta", nil)
+	rr := httptest.NewRecorder()
+
+	handler.HandleSelfUserMetadataGetRequest(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestHandleSelfUserMetadataGetRequest_ServiceError(t *testing.T) {
+	userID := testUserID123
+	authCtx := security.NewSecurityContextForTest(userID, "", "", nil, nil)
+
+	mockSvc := NewUserServiceInterfaceMock(t)
+	mockSvc.On("GetUserMetadata", mock.Anything, userID).Return(nil, &ErrorUserNotFound)
+
+	handler := newUserHandler(mockSvc)
+	req := httptest.NewRequest(http.MethodGet, "/users/me/meta", nil)
+	req = req.WithContext(security.WithSecurityContextTest(req.Context(), authCtx))
+	rr := httptest.NewRecorder()
+
+	handler.HandleSelfUserMetadataGetRequest(rr, req)
 
 	require.Equal(t, http.StatusNotFound, rr.Code)
 }

--- a/backend/internal/user/init.go
+++ b/backend/internal/user/init.go
@@ -160,6 +160,17 @@ func registerRoutes(mux *http.ServeMux, userHandler *userHandler) {
 		w.WriteHeader(http.StatusNoContent)
 	}, optsSelf))
 
+	optsMeta := middleware.CORSOptions{
+		AllowedMethods:   []string{"GET"},
+		AllowedHeaders:   middleware.DefaultAllowedHeaders,
+		AllowCredentials: true,
+		MaxAge:           600,
+	}
+	mux.HandleFunc(middleware.WithCORS("GET /users/me/meta", userHandler.HandleSelfUserMetadataGetRequest, optsMeta))
+	mux.HandleFunc(middleware.WithCORS("OPTIONS /users/me/meta", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}, optsMeta))
+
 	optsSelfCredentials := middleware.CORSOptions{
 		AllowedMethods:   []string{"POST"},
 		AllowedHeaders:   middleware.DefaultAllowedHeaders,

--- a/backend/internal/user/init_test.go
+++ b/backend/internal/user/init_test.go
@@ -17,3 +17,47 @@
  */
 
 package user
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/thunder-id/thunderid/internal/entitytype"
+	"github.com/thunder-id/thunderid/internal/system/security"
+)
+
+func TestRegisterRoutes_SelfUserMetadata(t *testing.T) {
+	mux := http.NewServeMux()
+	mockSvc := NewUserServiceInterfaceMock(t)
+	expectedSchema := &entitytype.EntityType{
+		Name:   "employee",
+		Schema: json.RawMessage(`{"email":{"type":"string"}}`),
+	}
+	mockSvc.On("GetUserMetadata", mock.Anything, testUserID123).Return(expectedSchema, nil)
+
+	handler := newUserHandler(mockSvc)
+	registerRoutes(mux, handler)
+
+	// Test GET /users/me/meta
+	authCtx := security.NewSecurityContextForTest(testUserID123, "", "", nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/users/me/meta", nil)
+	req = req.WithContext(security.WithSecurityContextTest(req.Context(), authCtx))
+	rr := httptest.NewRecorder()
+
+	mux.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Test OPTIONS /users/me/meta
+	optionsReq := httptest.NewRequest(http.MethodOptions, "/users/me/meta", nil)
+	optionsReq.Header.Set("Origin", "http://localhost:3000")
+	optionsReq.Header.Set("Access-Control-Request-Method", "GET")
+	optionsRr := httptest.NewRecorder()
+
+	mux.ServeHTTP(optionsRr, optionsReq)
+	require.Equal(t, http.StatusNoContent, optionsRr.Code)
+}

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -59,6 +59,7 @@ type UserServiceInterface interface {
 	UpdateUser(ctx context.Context, userID string, user *User) (*User, *tidcommon.ServiceError)
 	UpdateUserAttributes(ctx context.Context, userID string,
 		attributes json.RawMessage) (*User, *tidcommon.ServiceError)
+	GetUserMetadata(ctx context.Context, userID string) (*entitytype.EntityType, *tidcommon.ServiceError)
 	UpdateUserCredentials(ctx context.Context, userID string,
 		credentials json.RawMessage) *tidcommon.ServiceError
 	DeleteUser(ctx context.Context, userID string) *tidcommon.ServiceError
@@ -434,6 +435,23 @@ func (us *userService) GetUser(
 
 	logger.Debug(ctx, "Successfully retrieved user", log.MaskedString(log.LoggerKeyUserID, userID))
 	return &user, nil
+}
+
+// GetUserMetadata retrieves the schema metadata for the authenticated user's type.
+func (us *userService) GetUserMetadata(
+	ctx context.Context, userID string,
+) (*entitytype.EntityType, *tidcommon.ServiceError) {
+	user, svcErr := us.GetUser(ctx, userID, false)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	schema, svcErr := us.entityTypeService.GetEntityTypeSchema(ctx, entitytype.TypeCategoryUser, user.Type)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	return schema, nil
 }
 
 // GetUserGroups retrieves groups of a user with pagination.

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -3844,3 +3844,77 @@ func TestUserService_GetUserUsages_RegistryError(t *testing.T) {
 	require.Nil(t, result)
 	require.NotNil(t, err)
 }
+
+func TestGetUserMetadata_Success(t *testing.T) {
+	entityTypeMock := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	expectedSchema := &entitytype.EntityType{
+		Name:   testUserType,
+		Schema: json.RawMessage(`{"email":{"type":"string"}}`),
+	}
+	entityTypeMock.On("GetEntityTypeSchema", mock.Anything, entitytype.TypeCategoryUser, testUserType).
+		Return(expectedSchema, (*tidcommon.ServiceError)(nil)).Once()
+
+	entityServiceMock := entitymock.NewEntityServiceInterfaceMock(t)
+	entityUser := &providers.Entity{
+		ID:         svcTestUserID123,
+		Category:   providers.EntityCategoryUser,
+		Type:       testUserType,
+		Attributes: json.RawMessage(`{"username":"test"}`),
+	}
+	entityServiceMock.On("GetEntity", mock.Anything, svcTestUserID123).
+		Return(entityUser, nil).Once()
+
+	service := &userService{
+		entityService:     entityServiceMock,
+		entityTypeService: entityTypeMock,
+		authzService:      newAllowAllAuthz(t),
+	}
+
+	schema, svcErr := service.GetUserMetadata(context.Background(), svcTestUserID123)
+	require.Nil(t, svcErr)
+	require.NotNil(t, schema)
+	require.Equal(t, testUserType, schema.Name)
+}
+
+func TestGetUserMetadata_GetUserError(t *testing.T) {
+	entityServiceMock := entitymock.NewEntityServiceInterfaceMock(t)
+	entityServiceMock.On("GetEntity", mock.Anything, svcTestUserID123).
+		Return((*providers.Entity)(nil), entitypkg.ErrEntityNotFound).Once()
+
+	service := &userService{
+		entityService: entityServiceMock,
+		authzService:  newAllowAllAuthz(t),
+	}
+
+	schema, svcErr := service.GetUserMetadata(context.Background(), svcTestUserID123)
+	require.Nil(t, schema)
+	require.NotNil(t, svcErr)
+	require.Equal(t, ErrorUserNotFound.Code, svcErr.Code)
+}
+
+func TestGetUserMetadata_GetEntityTypeSchemaError(t *testing.T) {
+	entityServiceMock := entitymock.NewEntityServiceInterfaceMock(t)
+	entityUser := &providers.Entity{
+		ID:         svcTestUserID123,
+		Category:   providers.EntityCategoryUser,
+		Type:       testUserType,
+		Attributes: json.RawMessage(`{"username":"test"}`),
+	}
+	entityServiceMock.On("GetEntity", mock.Anything, svcTestUserID123).
+		Return(entityUser, nil).Once()
+
+	entityTypeMock := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	entityTypeMock.On("GetEntityTypeSchema", mock.Anything, entitytype.TypeCategoryUser, testUserType).
+		Return((*entitytype.EntityType)(nil), &entitytype.ErrorEntityTypeNotFound).Once()
+
+	service := &userService{
+		entityService:     entityServiceMock,
+		entityTypeService: entityTypeMock,
+		authzService:      newAllowAllAuthz(t),
+	}
+
+	schema, svcErr := service.GetUserMetadata(context.Background(), svcTestUserID123)
+	require.Nil(t, schema)
+	require.NotNil(t, svcErr)
+	require.Equal(t, entitytype.ErrorEntityTypeNotFound.Code, svcErr.Code)
+}

--- a/backend/tests/mocks/entitytypemock/EntityTypeServiceInterface_mock.go
+++ b/backend/tests/mocks/entitytypemock/EntityTypeServiceInterface_mock.go
@@ -597,6 +597,82 @@ func (_c *EntityTypeServiceInterfaceMock_GetEntityTypeList_Call) RunAndReturn(ru
 	return _c
 }
 
+// GetEntityTypeSchema provides a mock function for the type EntityTypeServiceInterfaceMock
+func (_mock *EntityTypeServiceInterfaceMock) GetEntityTypeSchema(ctx context.Context, category entitytype.TypeCategory, userTypeName string) (*entitytype.EntityType, *common.ServiceError) {
+	ret := _mock.Called(ctx, category, userTypeName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetEntityTypeSchema")
+	}
+
+	var r0 *entitytype.EntityType
+	var r1 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, entitytype.TypeCategory, string) (*entitytype.EntityType, *common.ServiceError)); ok {
+		return returnFunc(ctx, category, userTypeName)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, entitytype.TypeCategory, string) *entitytype.EntityType); ok {
+		r0 = returnFunc(ctx, category, userTypeName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*entitytype.EntityType)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, entitytype.TypeCategory, string) *common.ServiceError); ok {
+		r1 = returnFunc(ctx, category, userTypeName)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// EntityTypeServiceInterfaceMock_GetEntityTypeSchema_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetEntityTypeSchema'
+type EntityTypeServiceInterfaceMock_GetEntityTypeSchema_Call struct {
+	*mock.Call
+}
+
+// GetEntityTypeSchema is a helper method to define mock.On call
+//   - ctx context.Context
+//   - category entitytype.TypeCategory
+//   - userTypeName string
+func (_e *EntityTypeServiceInterfaceMock_Expecter) GetEntityTypeSchema(ctx interface{}, category interface{}, userTypeName interface{}) *EntityTypeServiceInterfaceMock_GetEntityTypeSchema_Call {
+	return &EntityTypeServiceInterfaceMock_GetEntityTypeSchema_Call{Call: _e.mock.On("GetEntityTypeSchema", ctx, category, userTypeName)}
+}
+
+func (_c *EntityTypeServiceInterfaceMock_GetEntityTypeSchema_Call) Run(run func(ctx context.Context, category entitytype.TypeCategory, userTypeName string)) *EntityTypeServiceInterfaceMock_GetEntityTypeSchema_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 entitytype.TypeCategory
+		if args[1] != nil {
+			arg1 = args[1].(entitytype.TypeCategory)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *EntityTypeServiceInterfaceMock_GetEntityTypeSchema_Call) Return(entityType *entitytype.EntityType, serviceError *common.ServiceError) *EntityTypeServiceInterfaceMock_GetEntityTypeSchema_Call {
+	_c.Call.Return(entityType, serviceError)
+	return _c
+}
+
+func (_c *EntityTypeServiceInterfaceMock_GetEntityTypeSchema_Call) RunAndReturn(run func(ctx context.Context, category entitytype.TypeCategory, userTypeName string) (*entitytype.EntityType, *common.ServiceError)) *EntityTypeServiceInterfaceMock_GetEntityTypeSchema_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetUniqueAttributes provides a mock function for the type EntityTypeServiceInterfaceMock
 func (_mock *EntityTypeServiceInterfaceMock) GetUniqueAttributes(ctx context.Context, category entitytype.TypeCategory, entityType string) ([]string, *common.ServiceError) {
 	ret := _mock.Called(ctx, category, entityType)

--- a/backend/tests/mocks/usermock/UserServiceInterface_mock.go
+++ b/backend/tests/mocks/usermock/UserServiceInterface_mock.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 
 	mock "github.com/stretchr/testify/mock"
+	"github.com/thunder-id/thunderid/internal/entitytype"
 	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/internal/user"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
@@ -488,6 +489,76 @@ func (_c *UserServiceInterfaceMock_GetUserList_Call) Return(userListResponse *us
 }
 
 func (_c *UserServiceInterfaceMock_GetUserList_Call) RunAndReturn(run func(ctx context.Context, limit int, offset int, filters map[string]interface{}, includeDisplay bool) (*user.UserListResponse, *common.ServiceError)) *UserServiceInterfaceMock_GetUserList_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetUserMetadata provides a mock function for the type UserServiceInterfaceMock
+func (_mock *UserServiceInterfaceMock) GetUserMetadata(ctx context.Context, userID string) (*entitytype.EntityType, *common.ServiceError) {
+	ret := _mock.Called(ctx, userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserMetadata")
+	}
+
+	var r0 *entitytype.EntityType
+	var r1 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*entitytype.EntityType, *common.ServiceError)); ok {
+		return returnFunc(ctx, userID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *entitytype.EntityType); ok {
+		r0 = returnFunc(ctx, userID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*entitytype.EntityType)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *common.ServiceError); ok {
+		r1 = returnFunc(ctx, userID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// UserServiceInterfaceMock_GetUserMetadata_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserMetadata'
+type UserServiceInterfaceMock_GetUserMetadata_Call struct {
+	*mock.Call
+}
+
+// GetUserMetadata is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID string
+func (_e *UserServiceInterfaceMock_Expecter) GetUserMetadata(ctx interface{}, userID interface{}) *UserServiceInterfaceMock_GetUserMetadata_Call {
+	return &UserServiceInterfaceMock_GetUserMetadata_Call{Call: _e.mock.On("GetUserMetadata", ctx, userID)}
+}
+
+func (_c *UserServiceInterfaceMock_GetUserMetadata_Call) Run(run func(ctx context.Context, userID string)) *UserServiceInterfaceMock_GetUserMetadata_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_GetUserMetadata_Call) Return(entityType *entitytype.EntityType, serviceError *common.ServiceError) *UserServiceInterfaceMock_GetUserMetadata_Call {
+	_c.Call.Return(entityType, serviceError)
+	return _c
+}
+
+func (_c *UserServiceInterfaceMock_GetUserMetadata_Call) RunAndReturn(run func(ctx context.Context, userID string) (*entitytype.EntityType, *common.ServiceError)) *UserServiceInterfaceMock_GetUserMetadata_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/docs/content/use-cases/b2c/try-in-your-own-app/profile-section.mdx
+++ b/docs/content/use-cases/b2c/try-in-your-own-app/profile-section.mdx
@@ -22,7 +22,7 @@ Complete the [Login](../add-login) walkthrough first. The user type and applicat
 <details open>
   <summary>Redirect-based</summary>
 
-In the redirect-based pattern, your application renders the profile UI itself. Profile attributes are read from the ID token on sign-in. Attribute updates and credential changes go to <ProductName />'s self-service endpoints, which act on the signed-in user's own record: no additional permissions are needed beyond the access token.
+In the redirect-based pattern, the consumer app renders the profile screen itself. Profile attributes are read from `/users/me` and ID token. Schema metadata is retrieved from `/users/me/meta`. Attribute updates go through `/users/me` and password changes go through `/users/me/update-credentials`. These endpoints act on the signed-in user's own record, so no extra permissions are needed; the access token alone is enough.
 
 ### Configure <ProductName />
 
@@ -51,11 +51,12 @@ Your app reads profile attributes from the ID token and calls the self-service e
 
 For direct API access, profile attributes are read and updated through the self-service endpoints:
 
-| Operation         | Endpoint                             | Method |
-| ----------------- | ------------------------------------ | ------ |
-| Read profile      | `/users/me`                          | GET    |
-| Update attributes | `/users/me`                          | PATCH  |
-| Change password   | `/users/me/update-credentials`       | POST   |
+| Operation            | Endpoint                       | Method |
+| -------------------- | ------------------------------ | ------ |
+| Read profile         | `/users/me`                    | GET    |
+| Read schema metadata | `/users/me/meta`               | GET    |
+| Update attributes    | `/users/me`                    | PUT    |
+| Change password      | `/users/me/update-credentials` | POST   |
 
 See the [APIs reference](../../../../apis).
 

--- a/docs/content/use-cases/b2c/try-it-out/profile-section.mdx
+++ b/docs/content/use-cases/b2c/try-it-out/profile-section.mdx
@@ -22,7 +22,7 @@ Complete [Set Up Your Environment](../setup#set-up-your-environment) before star
 <details open>
   <summary>Redirect-based</summary>
 
-In the redirect-based pattern, the consumer app renders the profile screen itself. Profile attributes are read directly from the ID token, and updates go through <ProductName />'s self-service endpoints: `/users/me` for attribute changes and `/users/me/update-credentials` for password changes. These endpoints act on the signed-in user's own record, so no extra permissions are needed; the access token alone is enough.
+In the redirect-based pattern, the consumer application renders the profile screen itself. Profile attributes are read from `/users/me` and ID token. Updates go through <ProductName />'s self-service endpoints: `/users/me` for attribute changes, `/users/me/meta` for schema metadata retrieve, and `/users/me/update-credentials` for password changes. These endpoints act on the signed-in user's own record, so no extra permissions are needed; the access token alone is enough.
 
 **Try the Use Case**
 

--- a/tests/integration/user/user_self_api_test.go
+++ b/tests/integration/user/user_self_api_test.go
@@ -203,3 +203,20 @@ func (s *SelfUserEndpointsSuite) TestSelfUserUpdateCredentials() {
 	s.Require().NoError(json.NewDecoder(verifyResp.Body).Decode(&userResp))
 	s.Equal(s.userID, userResp.ID)
 }
+
+func (s *SelfUserEndpointsSuite) TestSelfUserGetMetadata() {
+	resp, err := s.doUserRequest(http.MethodGet, "/users/me/meta", nil)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	s.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var res map[string]interface{}
+	s.Require().NoError(json.NewDecoder(resp.Body).Decode(&res))
+
+	schema, ok := res["schema"].(map[string]interface{})
+	s.Require().True(ok, "response should contain schema map")
+	s.Require().NotNil(schema["username"])
+	s.Require().NotNil(schema["email"])
+}
+


### PR DESCRIPTION
### Purpose

Introduces a new authenticated endpoint `GET /users/me/meta` that allows end-users to retrieve the schema metadata (such as displayName, validation regex, and required status) for their assigned userType. This enables client-side dynamic rendering and UX-level input validation on profile pages without requiring administrator scopes.

This is related with [Design Discussion] #4082 

### Approach
- Added `GET /users/me/meta` and `OPTIONS /users/me/meta` route mapping in the `user` package.
- Implemented a dedicated self-service service method `GetSelfUserTypeSchema` on the `entityType` service. It resolves the user's schema metadata by UUID.
- Resolved the user type name (`user.Type`) to its UUID on the backend using the cached in-memory store so that the schema is fetched strictly by ID (`queryGetEntityTypeByID`).
- Structured the handler response to output only the `schema` key to match client contract expectations.

#### `GET /users/me/meta` request response structure
```json
{
    "schema": {
        "email": {
            "displayName": "Email",
            "regex": "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
            "required": true,
            "type": "string",
            "unique": true
        },
        "family_name": {
            "displayName": "Last Name",
            "required": false,
            "type": "string"
        },
        "given_name": {
            "displayName": "First Name",
            "required": false,
            "type": "string"
        },
        "mobile_number": {
            "displayName": "Mobile Number",
            "required": false,
            "type": "string"
        },
        "name": {
            "displayName": "Full Name",
            "required": false,
            "type": "string"
        },
        "password": {
            "credential": true,
            "displayName": "Password",
            "required": false,
            "type": "string"
        },
        "phone_number": {
            "displayName": "Phone Number",
            "required": false,
            "type": "string"
        },
        "picture": {
            "displayName": "Picture",
            "required": false,
            "type": "string"
        },
        "sub": {
            "displayName": "Subject",
            "required": false,
            "type": "string"
        },
        "username": {
            "displayName": "Username",
            "required": true,
            "type": "string",
            "unique": true
        }
    }
}
```

#### Sequence diagram of new endpoint workflow

```mermaid
sequenceDiagram
    autonumber
    actor Client
    participant Router as router (init.go)
    participant Handler as HandleSelfUserMetadataGetRequest
    participant UserService as UserService (service.go)
    participant EntityTypeService as EntityTypeService (service.go)
    participant DB as Stores / Database

    Client->>Router: GET /users/me/meta (with Auth Token)
    Router->>Handler: Route request & extract context
    Handler->>UserService: GetUserMetadata(ctx, callerID)
    UserService->>DB: userStore.Get(ctx, callerID)
    DB-->>UserService: Return User Entity (contains user.Type, user.OUID)
    UserService->>EntityTypeService: GetSelfUserTypeSchema(ctx, user.Type, user.OUID)
    EntityTypeService->>DB: entityService.GetEntity(ctx, CategoryUser, user.Type, user.OUID)
    DB-->>EntityTypeService: Return UserType Entity
    EntityTypeService-->>UserService: Return Schema map
    UserService-->>Handler: Return UserMetadata{ Schema }
    Handler-->>Client: 200 OK {"schema": {...}}
```

### Related Issues
- #3490 
- fixes #4135 

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added an authenticated `GET /users/me/meta` endpoint that returns the caller’s user-type metadata schema (including a `schema` object with fields like `username` and `email`).
  * Added `OPTIONS /users/me/meta` support for CORS preflight.

* **Bug Fixes**
  * Added consistent error responses for unauthorized access, missing metadata, invalid requests, and internal server errors.

* **Documentation**
  * Updated B2C “Try in your own app”/“Try it out” profile sections to include the new endpoint.

* **Tests**
  * Added unit, route, and integration tests for the new endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->