### PR TITLE
fix: Make the Releases page unversioned by moving it out of docs/next…

### DIFF
--- a/docs/content/guides/getting-started/get-thunderid.mdx
+++ b/docs/content/guides/getting-started/get-thunderid.mdx
@@ -30,7 +30,7 @@ Get the latest release of <ProductName /> and run it locally on your machine.
 
 ## Download the Distribution
 
-Download the latest release from the <a href="/docs/next/releases/" target="_blank">releases page</a>.
+Download the latest release from the <a href="/releases/" target="_blank">releases page</a>.
 
 ## Extract the Archive
 

--- a/docs/docusaurus.product.config.ts
+++ b/docs/docusaurus.product.config.ts
@@ -77,7 +77,7 @@ const DocusaurusProductConfig = {
         url: 'https://github.com/thunder-id/thunderid',
         discussionsUrl: 'https://github.com/thunder-id/thunderid/discussions',
         issuesUrl: 'https://github.com/thunder-id/thunderid/issues',
-        releasesUrl: '/docs/next/releases',
+        releasesUrl: '/releases',
         editUrls: {
           blog: 'https://github.com/thunder-id/thunderid/tree/main/blog/',
           content: 'https://github.com/thunder-id/thunderid/tree/main/docs/',

--- a/docs/src/pages/releases.tsx
+++ b/docs/src/pages/releases.tsx
@@ -837,7 +837,7 @@ export default function ReleasesPage() {
               </VersionList>
               {hasMoreReleases ? (
                 <VersionSidebarFooter>
-                  <VersionSidebarAllLink to="/docs/next/releases/archive">
+                  <VersionSidebarAllLink to="/releases/archive">
                     <span>Browse all {releases.length} releases</span>
                     <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                       <path d="M5 12h14M13 6l6 6-6 6" />

--- a/docs/src/pages/releases/archive.tsx
+++ b/docs/src/pages/releases/archive.tsx
@@ -195,7 +195,7 @@ export default function ReleaseArchivePage(): React.ReactElement {
   return (
     <Layout title="Release Archive" description={`Browse every ${productName} release.`}>
       <Shell>
-        <BackLink to="/docs/next/releases">
+        <BackLink to="/releases">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <path d="M19 12H5M11 18l-6-6 6-6" />
           </svg>
@@ -223,7 +223,7 @@ export default function ReleaseArchivePage(): React.ReactElement {
         {releases && releases.length > 0 ? (
           <ReleaseTable>
             {releases.map((release) => (
-              <ReleaseRow key={release.id} to={`/docs/next/releases?tag=${encodeURIComponent(release.tagName)}`}>
+              <ReleaseRow key={release.id} to={`/releases?tag=${encodeURIComponent(release.tagName)}`}>
                 <ReleaseTag>{release.tagName}</ReleaseTag>
                 {release.isLatest ? <ReleaseBadge ownerState={{tone: 'latest'}}>Latest</ReleaseBadge> : null}
                 {release.isPrerelease ? <ReleaseBadge ownerState={{tone: 'prerelease'}}>Pre-release</ReleaseBadge> : null}


### PR DESCRIPTION
### Purpose
The Releases page and its archive lived under the versioned `/docs/next/releases` route, but release data (versions, changelogs, downloads) isn't tied to a specific docs version. This ties its URL/lifecycle to doc versioning and can cause stale or duplicated routes once new doc versions are cut. This PR moves the Releases and Release Archive pages to a standalone, unversioned `/releases` route.

### Approach
- Moved `docs/src/pages/docs/next/releases.tsx` → `docs/src/pages/releases.tsx`
- Moved `docs/src/pages/docs/next/releases/archive.tsx` → `docs/src/pages/releases/archive.tsx`
- Updated internal route links inside both pages (version sidebar "browse all releases" link, archive back-link, and per-release tag links) to point at `/releases` and `/releases/archive`
- Updated `releasesUrl` in `docs/docusaurus.product.config.ts` from `/docs/next/releases` to `/releases`, which the navbar and footer already consume from this single source of truth
- Updated the release download link in `docs/content/guides/getting-started/get-thunderid.mdx`
- Verified with a full `pnpm run build:docs` (Docusaurus `onBrokenLinks: 'throw'`) that no links break as a result of the move

### Related Issues
- Fixes #3946

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated release documentation links to use the current `/releases` paths.
  * Corrected navigation between the releases page, release archive, and individual release tag filtering.
  * Updated the getting-started guide’s “Download the latest release” link to point to `/releases`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->