### PR TITLE
Fix invite page hanging on Add Another User

### DIFF
--- a/frontend/packages/configure-users/src/pages/UserInvitePage.tsx
+++ b/frontend/packages/configure-users/src/pages/UserInvitePage.tsx
@@ -810,6 +810,12 @@ function InviteUserFlowBridge({
     }
   }, [inviteAction, renderProps]);
 
+  // Clear the auto-invite guard on reset so the restarted prompt is auto-submitted again.
+  const handleReset = useCallback(() => {
+    autoInviteTriggeredRef.current = false;
+    onResetLocalState();
+  }, [onResetLocalState]);
+
   // Derive current step label from the HEADING_1 component
   const currentStepLabel = components?.length ? deriveStepLabel(components, resolve, t) : '';
 
@@ -847,7 +853,7 @@ function InviteUserFlowBridge({
       renderProps={renderProps}
       flowError={flowError}
       handleClose={handleClose}
-      onResetLocalState={onResetLocalState}
+      onResetLocalState={handleReset}
     />
   );
 }

--- a/frontend/packages/configure-users/src/pages/__tests__/UserInvitePage.test.tsx
+++ b/frontend/packages/configure-users/src/pages/__tests__/UserInvitePage.test.tsx
@@ -549,6 +549,35 @@ describe('UserInvitePage', () => {
       expect(mockResetFlow).toHaveBeenCalled();
     });
 
+    it('should re-trigger the auto-invite after "Add Another User" resets the flow', async () => {
+      const invitePrompt: EmbeddedFlowComponent[] = [
+        heading('How would you like to add a user?'),
+        block([submitAction('Invite user', {id: 'action_invite_user'})]),
+      ];
+
+      // Auto-invite fires once on arrival.
+      mockInviteUserRenderProps.components = invitePrompt;
+      const {rerender} = render(<UserInvitePage />);
+
+      await waitFor(() => {
+        expect(mockHandleSubmit).toHaveBeenCalledTimes(1);
+      });
+
+      // Advance to the completion step, then click "Add Another User".
+      mockInviteUserRenderProps = {...mockInviteUserRenderProps, components: [heading('Done')]};
+      rerender(<UserInvitePage />);
+      await userEvent.click(screen.getByRole('button', {name: /add another user/i}));
+      expect(mockResetFlow).toHaveBeenCalled();
+
+      // Prompt returns; auto-invite must fire again.
+      mockInviteUserRenderProps = {...mockInviteUserRenderProps, components: invitePrompt};
+      rerender(<UserInvitePage />);
+
+      await waitFor(() => {
+        expect(mockHandleSubmit).toHaveBeenCalledTimes(2);
+      });
+    });
+
     it('should navigate to /users when footer Close button is clicked in display-only state', async () => {
       mockInviteUserRenderProps.components = [heading('Done')];
 


### PR DESCRIPTION
### Purpose
Fixes #4104 where the Invite User page hangs on an infinite loading spinner when the user clicks Add Another User after completing an invite.

The invite route auto-submits the onboarding-mode prompt (the "create vs invite" fork) so the user skips straight to inviting. That auto-submit is guarded by a one-shot `useRef`(`autoInviteTriggeredRef`) so it fires only once. Clicking "Add Another User" calls the SDK's `resetFlow()`, which restarts the flow without remounting `UserInvitePage`. Because the component is not remounted, the guard stays `true` from the first invite, so the restarted onboarding prompt is never auto-submitted and the page returns \<PageLoadingAnimation /> indefinitely.

This is purely a frontend state bug on the onboarding-flow path. The /flow/execute call on reset succeeds and returns the correct next step; the UI simply never acts on it. It does not involve the manual /users fallback.



### Approach

The fix ties the guard reset to the user action. The button already calls resetFlow() and onResetLocalState() together, so we wrap onResetLocalState to also clear the guard:
```
const handleReset = useCallback(() => {
  autoInviteTriggeredRef.current = false;
  onResetLocalState();
}, [onResetLocalState]);
```
and pass handleReset down to InviteUserStepContent. On restart the guard is false again, so the prompt is auto-submitted and the flow proceeds instead of stalling.


### Related Issues
- https://github.com/thunder-id/thunderid/issues/4104

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the “Add Another User” invitation flow so auto-submit can trigger again after the onboarding flow is reset.
  - Prevented the invitation process from stalling when flow components are cleared and restored.

- **Tests**
  - Added coverage verifying that invitations are submitted again after resetting the flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->