### PR TITLE
Fix save behaviour in Application Edit Page

### DIFF
--- a/frontend/apps/console/src/features/applications/components/edit-application/customization-settings/EditCustomizationSettings.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/customization-settings/EditCustomizationSettings.tsx
@@ -44,6 +44,11 @@ interface EditCustomizationSettingsProps {
    * Singular noun used to refer to the entity in user-visible copy (default: 'application').
    */
   entityLabel?: string;
+  /**
+   * Callback function to handle validation changes
+   * @param hasErrors - Boolean indicating if the customization settings have validation errors
+   */
+  onValidationChange?: (hasErrors: boolean) => void;
 }
 
 /**
@@ -62,6 +67,7 @@ export default function EditCustomizationSettings({
   editedApp,
   onFieldChange,
   entityLabel = 'application',
+  onValidationChange = undefined,
 }: EditCustomizationSettingsProps) {
   return (
     <Stack spacing={3}>
@@ -76,6 +82,7 @@ export default function EditCustomizationSettings({
         editedApp={editedApp}
         onFieldChange={onFieldChange}
         entityLabel={entityLabel}
+        onValidationChange={onValidationChange}
       />
       <ContactsSection
         application={application}

--- a/frontend/apps/console/src/features/applications/components/edit-application/customization-settings/UrlsSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/customization-settings/UrlsSection.tsx
@@ -19,6 +19,7 @@
 import {zodResolver} from '@hookform/resolvers/zod';
 import {SettingsCard} from '@thunderid/components';
 import {Box, Stack, Typography, TextField} from '@wso2/oxygen-ui';
+import {useEffect} from 'react';
 import {useForm, Controller} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
 import {z} from 'zod';
@@ -46,6 +47,11 @@ interface UrlsSectionProps {
    * Singular noun used to refer to the entity in user-visible copy (default: 'application').
    */
   entityLabel?: string;
+  /**
+   * Callback function to handle validation changes
+   * @param hasErrors - Boolean indicating if the URLs have validation errors
+   */
+  onValidationChange?: (hasErrors: boolean) => void;
 }
 
 /**
@@ -66,6 +72,7 @@ export default function UrlsSection({
   editedApp,
   onFieldChange,
   entityLabel = 'application',
+  onValidationChange = undefined,
 }: UrlsSectionProps) {
   const {t} = useTranslation();
 
@@ -78,6 +85,7 @@ export default function UrlsSection({
 
   const {
     control,
+    trigger,
     formState: {errors},
   } = useForm<UrlsFormData>({
     resolver: zodResolver(urlsSchema),
@@ -87,6 +95,19 @@ export default function UrlsSection({
       policyUri: editedApp.policyUri ?? application.policyUri ?? '',
     },
   });
+
+  // Validate default values on mount so stale validation state doesn't survive a remount.
+  useEffect(() => {
+    void trigger();
+  }, [trigger]);
+
+  // Effect to notify parent component of validation state changes
+  useEffect(() => {
+    if (onValidationChange) {
+      const hasErrors = !!errors.tosUri || !!errors.policyUri;
+      onValidationChange(hasErrors);
+    }
+  }, [errors.tosUri, errors.policyUri, onValidationChange]);
 
   return (
     <SettingsCard

--- a/frontend/apps/console/src/features/applications/components/edit-application/customization-settings/__tests__/UrlsSection.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/customization-settings/__tests__/UrlsSection.test.tsx
@@ -205,6 +205,48 @@ describe('UrlsSection', () => {
     });
   });
 
+  describe('Validation Change Callback', () => {
+    it('should notify parent with no errors for valid default values', async () => {
+      const mockOnValidationChange = vi.fn();
+
+      render(
+        <UrlsSection
+          application={mockApplication}
+          editedApp={{}}
+          onFieldChange={mockOnFieldChange}
+          onValidationChange={mockOnValidationChange}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(mockOnValidationChange).toHaveBeenCalledWith(false);
+      });
+    });
+
+    it('should notify parent with errors when a URL becomes invalid', async () => {
+      const user = userEvent.setup({delay: null});
+      const mockOnValidationChange = vi.fn();
+      const appWithoutUrls = {...mockApplication, tosUri: '', policyUri: ''};
+
+      render(
+        <UrlsSection
+          application={appWithoutUrls}
+          editedApp={{}}
+          onFieldChange={mockOnFieldChange}
+          onValidationChange={mockOnValidationChange}
+        />,
+      );
+
+      const tosField = screen.getByPlaceholderText('applications:edit.customization.tosUri.placeholder');
+      await user.type(tosField, 'invalid-url');
+      await user.tab();
+
+      await waitFor(() => {
+        expect(mockOnValidationChange).toHaveBeenCalledWith(true);
+      });
+    });
+  });
+
   describe('Edge Cases', () => {
     it('should handle missing URLs in application', () => {
       const appWithoutUrls = {...mockApplication};

--- a/frontend/apps/console/src/features/applications/components/edit-application/general-settings/AccessSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/general-settings/AccessSection.tsx
@@ -34,7 +34,7 @@ import {
   Tooltip,
 } from '@wso2/oxygen-ui';
 import {Trash, Plus} from '@wso2/oxygen-ui-icons-react';
-import {useState} from 'react';
+import {useState, useEffect} from 'react';
 import {useForm, Controller} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
 import {z} from 'zod';
@@ -63,6 +63,11 @@ interface AccessSectionProps {
    * @param value - The new value for the field
    */
   onFieldChange: (field: keyof Application, value: unknown) => void;
+  /**
+   * Callback function to handle validation changes
+   * @param hasErrors - Boolean indicating if the access settings have validation errors
+   */
+  onValidationChange?: (hasErrors: boolean) => void;
 }
 
 /**
@@ -83,6 +88,7 @@ export default function AccessSection({
   editedApp,
   oauth2Config = undefined,
   onFieldChange,
+  onValidationChange = undefined,
 }: AccessSectionProps) {
   const {t} = useTranslation();
   const {data: userTypesData, isLoading: loadingUserTypes} = useGetUserTypes();
@@ -105,6 +111,7 @@ export default function AccessSection({
 
   const {
     control,
+    trigger,
     formState: {errors},
   } = useForm<GeneralSettingsFormData>({
     resolver: zodResolver(generalSettingsSchema),
@@ -113,6 +120,20 @@ export default function AccessSection({
       url: editedApp.url ?? application.url ?? '',
     },
   });
+
+  // Validate default values on mount so stale validation state doesn't survive a remount.
+  useEffect(() => {
+    void trigger();
+  }, [trigger]);
+
+  // Effect to notify parent component of validation state changes
+  useEffect(() => {
+    if (onValidationChange) {
+      const hasErrors =
+        !!errors.url || Object.keys(uriErrors).length > 0 || Object.keys(postLogoutUriErrors).length > 0;
+      onValidationChange(hasErrors);
+    }
+  }, [errors.url, uriErrors, postLogoutUriErrors, onValidationChange]);
 
   // Pure URI-format check shared by the redirect and post-logout redirect URI fields.
   const isValidUriFormat = (uri: string): boolean => {

--- a/frontend/apps/console/src/features/applications/components/edit-application/general-settings/EditGeneralSettings.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/general-settings/EditGeneralSettings.tsx
@@ -68,6 +68,11 @@ interface EditGeneralSettingsProps {
    * Callback invoked after the application is successfully deleted
    */
   onDeleteSuccess?: () => void;
+  /**
+   * Callback function to handle validation changes
+   * @param hasErrors - Boolean indicating if the general settings have validation errors
+   */
+  onValidationChange?: (hasErrors: boolean) => void;
 }
 
 /**
@@ -89,6 +94,7 @@ export default function EditGeneralSettings({
   copiedField,
   onCopyToClipboard,
   onDeleteSuccess = undefined,
+  onValidationChange = undefined,
 }: EditGeneralSettingsProps): JSX.Element {
   const {config} = useConfig();
   const {t} = useTranslation();
@@ -155,6 +161,7 @@ export default function EditGeneralSettings({
           editedApp={editedApp}
           oauth2Config={oauth2Config}
           onFieldChange={onFieldChange}
+          onValidationChange={onValidationChange}
         />
         {!application.isReadOnly && oauth2Config?.clientId?.toUpperCase() !== systemConsoleClientId && (
           <DangerZoneSection

--- a/frontend/apps/console/src/features/applications/components/edit-application/general-settings/__tests__/AccessSection.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/general-settings/__tests__/AccessSection.test.tsx
@@ -499,6 +499,83 @@ describe('AccessSection', () => {
     });
   });
 
+  describe('Validation Change Callback', () => {
+    it('should notify parent with no errors for a valid URL', async () => {
+      const mockOnValidationChange = vi.fn();
+      vi.mocked(useGetUserTypes).mockReturnValue({
+        data: mockUserTypes,
+        isLoading: false,
+      } as unknown as MockedUseGetUserTypes);
+
+      render(
+        <AccessSection
+          application={mockApplication}
+          editedApp={{}}
+          onFieldChange={mockOnFieldChange}
+          onValidationChange={mockOnValidationChange}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(mockOnValidationChange).toHaveBeenCalledWith(false);
+      });
+    });
+
+    it('should notify parent with errors when the URL becomes invalid', async () => {
+      const user = userEvent.setup();
+      const mockOnValidationChange = vi.fn();
+      vi.mocked(useGetUserTypes).mockReturnValue({
+        data: mockUserTypes,
+        isLoading: false,
+      } as unknown as MockedUseGetUserTypes);
+
+      render(
+        <AccessSection
+          application={mockApplication}
+          editedApp={{}}
+          onFieldChange={mockOnFieldChange}
+          onValidationChange={mockOnValidationChange}
+        />,
+      );
+
+      const urlInput = screen.getByLabelText('Application URL');
+      await user.clear(urlInput);
+      await user.type(urlInput, 'invalid-url');
+
+      await waitFor(() => {
+        expect(mockOnValidationChange).toHaveBeenCalledWith(true);
+      });
+    });
+
+    it('should notify parent with errors when a redirect URI is invalid', async () => {
+      const user = userEvent.setup();
+      const mockOnValidationChange = vi.fn();
+      vi.mocked(useGetUserTypes).mockReturnValue({
+        data: mockUserTypes,
+        isLoading: false,
+      } as unknown as MockedUseGetUserTypes);
+
+      render(
+        <AccessSection
+          application={mockApplication}
+          editedApp={{}}
+          oauth2Config={mockOAuth2Config}
+          onFieldChange={mockOnFieldChange}
+          onValidationChange={mockOnValidationChange}
+        />,
+      );
+
+      const uriInput = screen.getByDisplayValue('https://example.com/callback');
+      await user.clear(uriInput);
+      await user.type(uriInput, 'not-a-valid-url');
+      await user.tab();
+
+      await waitFor(() => {
+        expect(mockOnValidationChange).toHaveBeenCalledWith(true);
+      });
+    });
+  });
+
   describe('Handle empty user types data', () => {
     it('should handle undefined user types data gracefully', () => {
       vi.mocked(useGetUserTypes).mockReturnValue({

--- a/frontend/apps/console/src/features/applications/pages/ApplicationEditPage.tsx
+++ b/frontend/apps/console/src/features/applications/pages/ApplicationEditPage.tsx
@@ -103,6 +103,8 @@ export default function ApplicationEditPage() {
   const [hasValidationErrors, setHasValidationErrors] = useState(false);
   const [mcpAccessInvalid, setMcpAccessInvalid] = useState(false);
   const [advancedSettingsInvalid, setAdvancedSettingsInvalid] = useState(false);
+  const [customizationSettingsInvalid, setCustomizationSettingsInvalid] = useState(false);
+  const [generalSettingsInvalid, setGeneralSettingsInvalid] = useState(false);
 
   const handleBack = async () => {
     await navigate(RouteConfig.applications.list());
@@ -250,6 +252,7 @@ export default function ApplicationEditPage() {
                 application={application}
                 editedApp={editedApp}
                 onFieldChange={handleFieldChange}
+                onValidationChange={setCustomizationSettingsInvalid}
               />
             ),
             hidden: isMcpM2mOnly,
@@ -539,6 +542,7 @@ export default function ApplicationEditPage() {
                 onDeleteSuccess={() => {
                   handleBack().catch(() => null);
                 }}
+                onValidationChange={setGeneralSettingsInvalid}
               />
             </TabPanel>
 
@@ -553,6 +557,7 @@ export default function ApplicationEditPage() {
                 application={application}
                 editedApp={editedApp}
                 onFieldChange={handleFieldChange}
+                onValidationChange={setCustomizationSettingsInvalid}
               />
             </TabPanel>
 
@@ -591,9 +596,21 @@ export default function ApplicationEditPage() {
           savingLabel={t('applications:edit.page.saving')}
           isSaving={updateApplication.isPending}
           saveDisabled={
-            hasValidationErrors || mcpAccessInvalid || advancedSettingsInvalid || application.isReadOnly === true
+            hasValidationErrors ||
+            mcpAccessInvalid ||
+            customizationSettingsInvalid ||
+            advancedSettingsInvalid ||
+            generalSettingsInvalid ||
+            application.isReadOnly === true
           }
-          onReset={() => setEditedApp({})}
+          onReset={() => {
+            setEditedApp({});
+            setHasValidationErrors(false);
+            setMcpAccessInvalid(false);
+            setAdvancedSettingsInvalid(false);
+            setCustomizationSettingsInvalid(false);
+            setGeneralSettingsInvalid(false);
+          }}
           onSave={() => {
             handleSave().catch(() => null);
           }}


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

Currently the save button functions even when there are URL validation errors in the Application Edit Page. This PR fixes the client side implementation so that the save button is disabled when there are URL errors present.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

Propagate and correctly set, `onValidationError` with each URL validation error.

### Related Issues
- Fixes #4139 

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Save is now blocked when customization URL fields contain validation errors.
  * Save is also blocked when general access fields (including redirect/logout URIs) contain validation errors.
* **Improvements**
  * Validation state now updates in real time across general and customization sections, keeping the save button accurately enabled/disabled.
  * Validation is refreshed when the edit page loads to avoid stale error states, and reset now clears the associated invalid-state tracking.
* **Tests**
  * Added coverage to verify validation-state callbacks for URL and access sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->