### PR TITLE
Remove the client ID field from trusted issuer forms and clarify the trusted token audience copy

### DIFF
--- a/frontend/apps/console/src/features/trusted-issuers/components/TrustedIssuerCreateForm.tsx
+++ b/frontend/apps/console/src/features/trusted-issuers/components/TrustedIssuerCreateForm.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import {useConfig} from '@thunderid/contexts';
 import {
   Box,
   Button,
@@ -50,13 +51,14 @@ import {isConflictError} from '@thunderid/configure-connections';
 export default function TrustedIssuerCreateForm(): JSX.Element {
   const {t} = useTranslation();
   const navigate = useNavigate();
+  const {config} = useConfig();
+  const productName = config.brand.product_name;
   const createTrustedIssuer = useCreateTrustedIssuer();
 
   const [name, setName] = useState('');
   const [issuer, setIssuer] = useState('');
   const [jwksEndpoint, setJwksEndpoint] = useState('');
   const [idJagEnabled, setIdJagEnabled] = useState(false);
-  const [clientId, setClientId] = useState('');
   const [tokenExchangeEnabled, setTokenExchangeEnabled] = useState(true);
   const [trustedTokenAudience, setTrustedTokenAudience] = useState('');
   const [touched, setTouched] = useState<Record<string, boolean>>({});
@@ -90,7 +92,6 @@ export default function TrustedIssuerCreateForm(): JSX.Element {
         issuer: issuer.trim(),
         jwksEndpoint: jwksEndpoint.trim(),
         idJagEnabled,
-        clientId: clientId.trim() || undefined,
         tokenExchangeEnabled,
         trustedTokenAudience: trustedTokenAudience.trim() || undefined,
       },
@@ -162,23 +163,6 @@ export default function TrustedIssuerCreateForm(): JSX.Element {
             />
           </FormControl>
 
-          <FormControl fullWidth>
-            <FormLabel htmlFor="trusted-issuer-client-id">
-              {t('trustedIssuers:create.form.clientId.label', 'Client ID')}
-            </FormLabel>
-            <TextField
-              id="trusted-issuer-client-id"
-              fullWidth
-              placeholder="your-thunderid-client-id"
-              value={clientId}
-              helperText={t(
-                'trustedIssuers:create.form.clientId.hint',
-                "ThunderID's client ID registered at this identity provider. Used for audience validation in incoming assertions.",
-              )}
-              onChange={(e) => setClientId(e.target.value)}
-            />
-          </FormControl>
-
           <FormControl fullWidth required error={Boolean(touched.jwksEndpoint && errors.jwksEndpoint)}>
             <FormLabel htmlFor="trusted-issuer-jwks-endpoint">
               {t('trustedIssuers:create.form.jwksEndpoint.label', 'JWKS endpoint')}
@@ -229,11 +213,12 @@ export default function TrustedIssuerCreateForm(): JSX.Element {
                 <TextField
                   id="trusted-issuer-token-audience"
                   fullWidth
-                  placeholder="my-external-client-id"
+                  placeholder="api://thunderid"
                   value={trustedTokenAudience}
                   helperText={t(
                     'trustedIssuers:detail.tokenExchange.audience.hint',
-                    'The audience value ThunderID expects in subject tokens from this issuer.',
+                    "An additional audience value {{productName}} will accept in subject tokens from this issuer. Tokens whose audience is {{productName}}'s own issuer URL are always accepted.",
+                    {productName},
                   )}
                   onChange={(e) => setTrustedTokenAudience(e.target.value)}
                 />

--- a/frontend/apps/console/src/features/trusted-issuers/components/__tests__/TrustedIssuerCreateForm.test.tsx
+++ b/frontend/apps/console/src/features/trusted-issuers/components/__tests__/TrustedIssuerCreateForm.test.tsx
@@ -129,7 +129,6 @@ describe('TrustedIssuerCreateForm', () => {
         issuer: 'https://acme.okta.com',
         jwksEndpoint: 'https://acme.okta.com/keys',
         idJagEnabled: false,
-        clientId: undefined,
         tokenExchangeEnabled: true,
         trustedTokenAudience: undefined,
       },
@@ -181,37 +180,9 @@ describe('TrustedIssuerCreateForm', () => {
     expect(mockMutate).toHaveBeenCalledWith(expect.objectContaining({idJagEnabled: true}), expect.any(Object));
   });
 
-  it('should render the client id field', () => {
+  it('should not render a client id field', () => {
     render(<TrustedIssuerCreateForm />);
 
-    expect(screen.getByLabelText(/^Client ID/)).toBeInTheDocument();
-  });
-
-  it('should include the client id in the create payload', async () => {
-    const user = userEvent.setup();
-    mockMutate.mockImplementation((_data, opts) => {
-      opts.onSuccess({
-        id: 'ti-3',
-        name: 'Acme Okta',
-        issuer: 'https://acme.okta.com',
-        jwksEndpoint: 'https://acme.okta.com/keys',
-        idJagEnabled: false,
-      });
-    });
-
-    render(<TrustedIssuerCreateForm />);
-
-    await user.type(screen.getByLabelText(/^Name/), 'Acme Okta');
-    await user.type(screen.getByLabelText(/^Issuer URI/), 'https://acme.okta.com');
-    await user.type(screen.getByLabelText(/^JWKS endpoint/), 'https://acme.okta.com/keys');
-    await user.type(screen.getByLabelText(/^Client ID/), 'thunderid-console');
-    await user.click(screen.getByTestId('trusted-issuer-create-submit'));
-
-    expect(mockMutate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        clientId: 'thunderid-console',
-      }),
-      expect.any(Object),
-    );
+    expect(screen.queryByLabelText(/^Client ID/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/apps/console/src/features/trusted-issuers/models/trusted-issuer.ts
+++ b/frontend/apps/console/src/features/trusted-issuers/models/trusted-issuer.ts
@@ -49,11 +49,6 @@ export interface TrustedIssuerFormData {
    */
   idJagEnabled: boolean;
   /**
-   * ThunderID's client ID registered at this external identity provider.
-   * @example "thunderid-console"
-   */
-  clientId?: string;
-  /**
    * Whether token exchange is enabled for this issuer.
    * @example true
    */

--- a/frontend/apps/console/src/features/trusted-issuers/pages/TrustedIssuerDetailPage.tsx
+++ b/frontend/apps/console/src/features/trusted-issuers/pages/TrustedIssuerDetailPage.tsx
@@ -17,6 +17,7 @@
  */
 
 import {ResourceAvatar, SettingsCard, UnsavedChangesBar} from '@thunderid/components';
+import {useConfig} from '@thunderid/contexts';
 import {
   Alert,
   Box,
@@ -48,6 +49,8 @@ export default function TrustedIssuerDetailPage(): JSX.Element {
   const {t} = useTranslation();
   const navigate = useNavigate();
   const {id} = useParams<{id: string}>();
+  const {config} = useConfig();
+  const productName = config.brand.product_name;
 
   const trustedIssuerQuery = useTrustedIssuer(id);
   const updateMutation = useUpdateTrustedIssuer(id ?? '');
@@ -65,7 +68,6 @@ export default function TrustedIssuerDetailPage(): JSX.Element {
       issuer: data?.issuer ?? '',
       jwksEndpoint: data?.jwksEndpoint ?? '',
       idJagEnabled: data?.idJagEnabled ?? false,
-      clientId: data?.clientId ?? undefined,
       tokenExchangeEnabled: data?.tokenExchangeEnabled ?? false,
       trustedTokenAudience: data?.trustedTokenAudience ?? undefined,
     }),
@@ -201,23 +203,6 @@ export default function TrustedIssuerDetailPage(): JSX.Element {
                   />
                 </FormControl>
 
-                <FormControl fullWidth>
-                  <FormLabel htmlFor="trusted-issuer-client-id">
-                    {t('trustedIssuers:create.form.clientId.label', 'Client ID')}
-                  </FormLabel>
-                  <TextField
-                    id="trusted-issuer-client-id"
-                    fullWidth
-                    placeholder="your-thunderid-client-id"
-                    value={values.clientId ?? ''}
-                    helperText={t(
-                      'trustedIssuers:create.form.clientId.hint',
-                      "ThunderID's client ID registered at this identity provider. Used for audience validation in incoming assertions.",
-                    )}
-                    onChange={(e) => setField('clientId', e.target.value || undefined)}
-                  />
-                </FormControl>
-
                 <FormControl fullWidth required error={Boolean(touched.jwksEndpoint && errors.jwksEndpoint)}>
                   <FormLabel htmlFor="trusted-issuer-jwks-endpoint">
                     {t('trustedIssuers:create.form.jwksEndpoint.label', 'JWKS endpoint')}
@@ -251,11 +236,12 @@ export default function TrustedIssuerDetailPage(): JSX.Element {
                 <TextField
                   id="trusted-issuer-token-audience"
                   fullWidth
-                  placeholder="my-external-client-id"
+                  placeholder="api://thunderid"
                   value={values.trustedTokenAudience ?? ''}
                   helperText={t(
                     'trustedIssuers:detail.tokenExchange.audience.hint',
-                    'The audience value ThunderID expects in subject tokens from this issuer.',
+                    "An additional audience value {{productName}} will accept in subject tokens from this issuer. Tokens whose audience is {{productName}}'s own issuer URL are always accepted.",
+                    {productName},
                   )}
                   onChange={(e) => setField('trustedTokenAudience', e.target.value || undefined)}
                 />

--- a/frontend/apps/console/src/features/trusted-issuers/pages/__tests__/TrustedIssuerDetailPage.test.tsx
+++ b/frontend/apps/console/src/features/trusted-issuers/pages/__tests__/TrustedIssuerDetailPage.test.tsx
@@ -31,7 +31,6 @@ const TRUSTED_ISSUER: TrustedIssuer = {
   issuer: 'https://acme.okta.com',
   jwksEndpoint: 'https://acme.okta.com/keys',
   idJagEnabled: true,
-  clientId: 'thunderid-console',
 };
 
 vi.mock('react-router', async () => {
@@ -83,10 +82,10 @@ describe('TrustedIssuerDetailPage', () => {
     } as unknown as ReturnType<typeof useTrustedIssuer>);
   });
 
-  it('should render the client id field with the stored value', () => {
+  it('should not render a client id field', () => {
     render(<TrustedIssuerDetailPage />);
 
-    expect(screen.getByLabelText(/^Client ID/)).toHaveValue('thunderid-console');
+    expect(screen.queryByLabelText(/^Client ID/)).not.toBeInTheDocument();
   });
 
   it('should render the ID-JAG card title and enabled note when assertions are accepted', () => {
@@ -123,24 +122,21 @@ describe('TrustedIssuerDetailPage', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('should show the unsaved changes bar and save the updated client id', async () => {
+  it('should show the unsaved changes bar and save the updated name', async () => {
     const user = userEvent.setup();
     render(<TrustedIssuerDetailPage />);
 
     expect(screen.queryByTestId('save-bar')).not.toBeInTheDocument();
 
-    const clientIdField = screen.getByLabelText(/^Client ID/);
-    await user.clear(clientIdField);
-    await user.type(clientIdField, 'updated-client-id');
+    const nameField = screen.getByLabelText(/^Name/);
+    await user.clear(nameField);
+    await user.type(nameField, 'Updated Acme Okta');
 
     expect(await screen.findByText('You have unsaved changes')).toBeInTheDocument();
 
     await user.click(screen.getByText('Save changes'));
 
-    expect(mockMutate).toHaveBeenCalledWith(
-      expect.objectContaining({clientId: 'updated-client-id'}),
-      expect.any(Object),
-    );
+    expect(mockMutate).toHaveBeenCalledWith(expect.objectContaining({name: 'Updated Acme Okta'}), expect.any(Object));
   });
 
   it('should navigate back to connections when Back is clicked', async () => {

--- a/frontend/apps/console/src/features/trusted-issuers/utils/__tests__/isTrustedIssuerFormDirty.test.ts
+++ b/frontend/apps/console/src/features/trusted-issuers/utils/__tests__/isTrustedIssuerFormDirty.test.ts
@@ -25,7 +25,6 @@ const BASELINE: TrustedIssuerFormData = {
   issuer: 'https://acme.okta.com',
   jwksEndpoint: 'https://acme.okta.com/keys',
   idJagEnabled: true,
-  clientId: undefined,
   tokenExchangeEnabled: false,
   trustedTokenAudience: undefined,
 };
@@ -39,7 +38,6 @@ describe('isTrustedIssuerFormDirty', () => {
     const values: TrustedIssuerFormData = {
       trustedTokenAudience: undefined,
       tokenExchangeEnabled: false,
-      clientId: undefined,
       idJagEnabled: true,
       jwksEndpoint: 'https://acme.okta.com/keys',
       issuer: 'https://acme.okta.com',
@@ -47,10 +45,6 @@ describe('isTrustedIssuerFormDirty', () => {
     };
 
     expect(isTrustedIssuerFormDirty(values, BASELINE)).toBe(false);
-  });
-
-  it('should return false when clientId is an empty string and baseline is undefined', () => {
-    expect(isTrustedIssuerFormDirty({...BASELINE, clientId: ''}, BASELINE)).toBe(false);
   });
 
   it('should return false when trustedTokenAudience is an empty string and baseline is undefined', () => {
@@ -71,10 +65,6 @@ describe('isTrustedIssuerFormDirty', () => {
 
   it('should return true when idJagEnabled changes', () => {
     expect(isTrustedIssuerFormDirty({...BASELINE, idJagEnabled: false}, BASELINE)).toBe(true);
-  });
-
-  it('should return true when clientId changes to a non-empty value', () => {
-    expect(isTrustedIssuerFormDirty({...BASELINE, clientId: 'thunderid-console'}, BASELINE)).toBe(true);
   });
 
   it('should return true when tokenExchangeEnabled changes', () => {

--- a/frontend/apps/console/src/features/trusted-issuers/utils/__tests__/mapConnectionToTrustedIssuer.test.ts
+++ b/frontend/apps/console/src/features/trusted-issuers/utils/__tests__/mapConnectionToTrustedIssuer.test.ts
@@ -35,24 +35,6 @@ const BASE_CONNECTION: ConnectionResponse = {
 };
 
 describe('mapConnectionToTrustedIssuer', () => {
-  it('should map the client id when present on the connection', () => {
-    const result: TrustedIssuer = mapConnectionToTrustedIssuer({
-      ...BASE_CONNECTION,
-      clientId: 'thunderid-console',
-    });
-
-    expect(result.clientId).toBe('thunderid-console');
-  });
-
-  it('should default the client id when absent on the connection', () => {
-    const result: TrustedIssuer = mapConnectionToTrustedIssuer({
-      ...BASE_CONNECTION,
-      clientId: undefined,
-    } as unknown as ConnectionResponse);
-
-    expect(result.clientId).toBeUndefined();
-  });
-
   it('should map the core trusted-issuer fields', () => {
     const result: TrustedIssuer = mapConnectionToTrustedIssuer(BASE_CONNECTION);
 

--- a/frontend/apps/console/src/features/trusted-issuers/utils/isTrustedIssuerFormDirty.ts
+++ b/frontend/apps/console/src/features/trusted-issuers/utils/isTrustedIssuerFormDirty.ts
@@ -24,13 +24,12 @@ const TRUSTED_ISSUER_FORM_FIELDS: (keyof TrustedIssuerFormData)[] = [
   'issuer',
   'jwksEndpoint',
   'idJagEnabled',
-  'clientId',
   'tokenExchangeEnabled',
   'trustedTokenAudience',
 ];
 
 /** Fields where the form maps an empty string to `undefined`, so the two should compare equal. */
-const EMPTY_STRING_AS_UNDEFINED_FIELDS: (keyof TrustedIssuerFormData)[] = ['clientId', 'trustedTokenAudience'];
+const EMPTY_STRING_AS_UNDEFINED_FIELDS: (keyof TrustedIssuerFormData)[] = ['trustedTokenAudience'];
 
 function normalize(field: keyof TrustedIssuerFormData, value: unknown): unknown {
   if (EMPTY_STRING_AS_UNDEFINED_FIELDS.includes(field) && value === '') {

--- a/frontend/apps/console/src/features/trusted-issuers/utils/mapConnectionToTrustedIssuer.ts
+++ b/frontend/apps/console/src/features/trusted-issuers/utils/mapConnectionToTrustedIssuer.ts
@@ -31,7 +31,6 @@ export default function mapConnectionToTrustedIssuer(connection: ConnectionRespo
     issuer: connection.issuer ?? '',
     jwksEndpoint: connection.jwksEndpoint ?? '',
     idJagEnabled: connection.idJagEnabled ?? false,
-    clientId: connection.clientId ?? undefined,
     tokenExchangeEnabled: connection.tokenExchangeEnabled ?? false,
     trustedTokenAudience: connection.trustedTokenAudience ?? undefined,
   };

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1836,9 +1836,6 @@ const translations = {
     'create.form.name.label': 'Name',
     'create.form.issuer.label': 'Issuer URI',
     'create.form.issuer.hint': "The issuer URI from the external IdP's OpenID Connect discovery document.",
-    'create.form.clientId.label': 'Client ID',
-    'create.form.clientId.hint':
-      "ThunderID's client ID registered at this identity provider. Used for audience validation in incoming assertions.",
     'create.form.jwksEndpoint.label': 'JWKS endpoint',
     'create.form.jwksEndpoint.hint':
       'The JWKS endpoint used to validate the signature of incoming identity assertions.',
@@ -1857,7 +1854,8 @@ const translations = {
     'detail.tokenExchange.title': 'Token Exchange',
     'detail.tokenExchange.description': 'Exchange subject tokens from this issuer for access tokens.',
     'detail.tokenExchange.audience.label': 'Trusted token audience',
-    'detail.tokenExchange.audience.hint': 'The audience value ThunderID expects in subject tokens from this issuer.',
+    'detail.tokenExchange.audience.hint':
+      "An additional audience value {{productName}} will accept in subject tokens from this issuer. Tokens whose audience is {{productName}}'s own issuer URL are always accepted.",
     'detail.consumption.title': 'Identity Assertion JWT Authorization Grant (ID-JAG)',
     'detail.idJag.description': 'Accept and exchange signed identity assertions from this issuer for access tokens.',
     'detail.idJag.enabledNote': 'Identity assertions from this issuer are accepted via the ID-JAG protocol.',


### PR DESCRIPTION
### Purpose

Improves the trusted issuer registration and management UI in the Console:

1. **Removes the Client ID field** from the Add trusted issuer form and the trusted issuer detail page. Trusted issuers are trust-only OIDC connections, and the backend performs no validation with the stored `client_id` property on the trust paths. Token exchange resolves the connection by issuer, verifies the signature against the JWKS endpoint, and validates the audience. ID-JAG matches the assertion's `client_id` claim against the client authenticated at the token endpoint, not the stored property. The field was dead weight, and its hint described a validation that does not happen.
2. **Rewords the Trusted token audience copy** to describe a generic audience value instead of a client ID. The backend compares the configured value verbatim against the subject token's `aud`, with no client ID semantics. The placeholder is now `api://thunderid` and the hint reads: "An additional audience value ThunderID will accept in subject tokens from this issuer. Tokens whose audience is ThunderID's own issuer URL are always accepted."

<img width="1529" height="1109" alt="Screenshot 2026-07-20 at 11 35 21 AM" src="https://github.com/user-attachments/assets/88ec42c3-e9bb-481e-bcc2-394207ede757" />
<img width="701" height="544" alt="Screenshot 2026-07-20 at 11 35 31 AM" src="https://github.com/user-attachments/assets/1838aeb1-738d-4098-a940-2d32d0aa1f49" />


### Approach

- Removed the Client ID field, state, and payload wiring from `TrustedIssuerCreateForm` and `TrustedIssuerDetailPage`, and removed `clientId` from `TrustedIssuerFormData`, `mapConnectionToTrustedIssuer`, and `isTrustedIssuerFormDirty`. The `/connections/oidc` API keeps `clientId` optional for trust-only connections, so no backend change is needed.
- Updated the trusted token audience placeholder and hint in both surfaces, and updated the authoritative strings in the shared i18n bundle (`en-US.ts`), removing the now-orphaned Client ID keys.
- Updated the feature's unit tests to assert the field no longer renders and that create/update payloads omit `clientId`, preserving equivalent behavioral coverage.

Verified manually end to end against a local server: trust-only creation with only name, issuer URI, and JWKS endpoint succeeds; detail page editing and deletion work; the new copy renders on both surfaces; and no regressions in the trusted issuer flows.

### Related Issues

- Fixes https://github.com/thunder-id/thunderid/issues/4131

### Related PRs

- N/A

### Checklist

- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks

- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Updates**
  * Removed the **Client ID** field from trusted issuer create and detail/edit forms, including related payload handling and form translations.
  * Updated **Trusted token audience** guidance: now uses the `api://thunderid` example and clarifies that ThunderID’s own issuer URL audience is always accepted (with messaging parameterized by product name).

* **Bug Fixes**
  * Improved form dirtiness/unsaved-changes detection and submission behavior to exclude the removed **Client ID** value.
  * Adjusted automated tests to match the updated UI and payload expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->