### PR TITLE
Lazy-load the ELK layout engine in the flow builder

### DIFF
--- a/frontend/apps/console/src/features/flows/utils/applyAutoLayout.ts
+++ b/frontend/apps/console/src/features/flows/utils/applyAutoLayout.ts
@@ -17,7 +17,7 @@
  */
 
 import type {Edge, Node} from '@xyflow/react';
-import ELK from 'elkjs/lib/elk.bundled.js';
+import type {ELK} from 'elkjs/lib/elk-api';
 
 /**
  * Configuration options for auto-layout.
@@ -50,7 +50,15 @@ export interface AutoLayoutOptions {
   offsetY?: number;
 }
 
-const elk = new ELK();
+// ELK (the layout engine) is ~1.5MB. It is only needed when a layout is actually
+// requested (toolbar button, or opening a flow with no stored positions), so it is
+// dynamically imported and cached rather than bundled into the builder's entry chunk.
+let elkPromise: Promise<ELK> | undefined;
+
+const getElk = async (): Promise<ELK> => {
+  elkPromise ??= import('elkjs/lib/elk.bundled.js').then((module) => new module.default());
+  return elkPromise;
+};
 
 /**
  * Applies automatic layout to nodes using ELK (Eclipse Layout Kernel).
@@ -171,6 +179,7 @@ export default async function applyAutoLayout(
 
   try {
     // Run ELK layout algorithm
+    const elk = await getElk();
     const layoutedGraph = await elk.layout(elkGraph);
 
     // Map the calculated positions back to React Flow nodes


### PR DESCRIPTION
### Purpose

Speed up opening the flow builder. Clicking a flow in the flows list showed a noticeable delay before the canvas appeared.

The builder page is code-split, so opening it downloads and parses a single large chunk before anything but the loading spinner renders. `applyAutoLayout` statically imported `elkjs` (the ELK layout engine, ~1.5MB) at module top level, so the entire engine was bundled into the builder's entry chunk and parsed on every open, even though auto-layout only runs on demand (the toolbar action, or opening a flow whose nodes have no stored positions). Saved flows carry node positions, so the common editing path never uses ELK at all.

### Approach

Dynamically import ELK on first layout and cache the instance, instead of importing it eagerly at module load. The static import becomes type-only. No behavior change: `applyAutoLayout` is already async, so the layout call simply awaits the engine before running.

Result (production build of the console app):

| | Before | After |
|---|---|---|
| Builder entry chunk (raw) | 2,399 KB | 985 KB |
| Builder entry chunk (gzipped) | 727 KB | 308 KB |
| ELK | in entry chunk | separate on-demand chunk |

ELK now downloads only when a layout is actually requested.

### Related Issues
- Refs #3871

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests (existing `applyAutoLayout` suite, 25 tests, still passing)
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved flow editor loading by loading auto-layout functionality only when needed.
  * Preserved existing layout behavior and fallback handling when layout operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->