### PR TITLE
Improve flow builder auto-layout and lazy-load the ELK engine

### DIFF
--- a/frontend/apps/console/src/features/flows/components/visual-flow/DecoratedVisualFlow.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/DecoratedVisualFlow.tsx
@@ -303,9 +303,8 @@ function DecoratedVisualFlow({
     const currentNodes = stripSimulationNodeClasses(getNodes());
     const currentEdges = getEdges();
     applyAutoLayout(currentNodes, currentEdges, {
-      direction: 'RIGHT',
-      nodeSpacing: 150,
-      rankSpacing: 300,
+      nodeSpacing: 100,
+      rankSpacing: 160,
       offsetX: 50,
       offsetY: 50,
     })

--- a/frontend/apps/console/src/features/flows/utils/__tests__/applyAutoLayout.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/applyAutoLayout.test.ts
@@ -17,18 +17,48 @@
  */
 
 import type {Node, Edge} from '@xyflow/react';
-import {describe, expect, it, vi} from 'vitest';
-import applyAutoLayout, {type AutoLayoutOptions} from '../applyAutoLayout';
+import {describe, expect, it, vi, beforeEach} from 'vitest';
+import applyAutoLayout from '../applyAutoLayout';
 
-// Mock ELK
+interface ElkTestPort {
+  id: string;
+  layoutOptions: Record<string, string>;
+}
+
+interface ElkTestNode {
+  id: string;
+  width: number;
+  height: number;
+  layoutOptions: Record<string, string>;
+  ports?: ElkTestPort[];
+}
+
+interface ElkTestEdge {
+  id: string;
+  sources: string[];
+  targets: string[];
+  layoutOptions?: Record<string, string>;
+}
+
+interface ElkTestGraph {
+  id: string;
+  layoutOptions: Record<string, string>;
+  children: ElkTestNode[];
+  edges: ElkTestEdge[];
+}
+
+// Capture the graph handed to ELK so the tests can assert on the layout
+// semantics (ports, constraints, priorities) rather than on ELK's output.
+let lastGraph: ElkTestGraph | null = null;
+let failLayout = false;
+
 vi.mock('elkjs/lib/elk.bundled.js', () => ({
   default: class MockELK {
-    layout(graph: {
-      id: string;
-      children: {id: string; width: number; height: number}[];
-      edges: {id: string; sources: string[]; targets: string[]}[];
-    }) {
-      // Return nodes with calculated positions based on their index
+    layout(graph: ElkTestGraph) {
+      lastGraph = graph;
+      if (failLayout) {
+        return Promise.reject(new Error('layout failed'));
+      }
       const layoutedChildren = graph.children.map((child, index) => ({
         ...child,
         x: index * 200,
@@ -57,10 +87,16 @@ describe('applyAutoLayout', () => {
     ...(measured && {measured}),
   });
 
-  const createEdge = (id: string, source: string, target: string): Edge => ({
+  const createEdge = (id: string, source: string, target: string, sourceHandle?: string): Edge => ({
     id,
     source,
     target,
+    ...(sourceHandle && {sourceHandle}),
+  });
+
+  beforeEach(() => {
+    lastGraph = null;
+    failLayout = false;
   });
 
   describe('Empty and Single Node Cases', () => {
@@ -70,158 +106,183 @@ describe('applyAutoLayout', () => {
       expect(result).toEqual([]);
     });
 
-    it('should return the single node with original position when only one node', async () => {
-      const nodes: Node[] = [createNode('node1', 'view', {x: 50, y: 50})];
+    it('should position a single node', async () => {
+      const nodes: Node[] = [createNode('node1', 'VIEW', {x: 50, y: 50})];
 
       const result = await applyAutoLayout(nodes, []);
 
-      // Single node should be positioned by ELK
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe('node1');
     });
   });
 
-  describe('Basic Layout', () => {
-    it('should apply layout to multiple nodes', async () => {
+  describe('Positioning', () => {
+    it('should apply ELK positions plus offsets to every node type uniformly', async () => {
       const nodes: Node[] = [
-        createNode('start', 'start', {x: 0, y: 0}),
-        createNode('view1', 'view', {x: 0, y: 0}),
-        createNode('end', 'end', {x: 0, y: 0}),
+        createNode('start', 'START'),
+        createNode('view1', 'VIEW'),
+        createNode('exec1', 'TASK_EXECUTION'),
+        createNode('call1', 'CALL'),
+        createNode('end', 'END'),
       ];
-      const edges: Edge[] = [createEdge('e1', 'start', 'view1'), createEdge('e2', 'view1', 'end')];
 
-      const result = await applyAutoLayout(nodes, edges);
+      const result = await applyAutoLayout(nodes, [], {offsetX: 10, offsetY: 20});
 
-      expect(result).toHaveLength(3);
-      // Nodes should have new positions
-      result.forEach((node) => {
-        expect(node.position).toBeDefined();
-        expect(typeof node.position.x).toBe('number');
-        expect(typeof node.position.y).toBe('number');
+      // Mock ELK returns x = index * 200, y = 100 for all nodes; no node type
+      // gets special post-processing.
+      result.forEach((node, index) => {
+        expect(node.position).toEqual({x: index * 200 + 10, y: 120});
       });
     });
 
-    it('should apply default options when none provided', async () => {
-      const nodes: Node[] = [createNode('node1', 'view', {x: 0, y: 0}), createNode('node2', 'view', {x: 0, y: 0})];
-      const edges: Edge[] = [createEdge('e1', 'node1', 'node2')];
+    it('should apply default offsets when none provided', async () => {
+      const nodes: Node[] = [createNode('a', 'VIEW'), createNode('b', 'TASK_EXECUTION')];
 
-      const result = await applyAutoLayout(nodes, edges);
+      const result = await applyAutoLayout(nodes, []);
 
-      expect(result).toHaveLength(2);
-      // Default offsetX is 50, offsetY is 50
-      expect(result[0].position.x).toBeGreaterThanOrEqual(50);
-      expect(result[0].position.y).toBeGreaterThanOrEqual(50);
+      expect(result[0].position).toEqual({x: 50, y: 150});
+      expect(result[1].position).toEqual({x: 250, y: 150});
+    });
+
+    it('should preserve node data after layout', async () => {
+      const nodes: Node[] = [
+        {
+          ...createNode('view1', 'VIEW'),
+          data: {label: 'My View', components: [{id: 'comp1'}]},
+        },
+      ];
+
+      const result = await applyAutoLayout(nodes, []);
+
+      expect(result[0].data).toEqual({label: 'My View', components: [{id: 'comp1'}]});
     });
   });
 
   describe('Layout Options', () => {
-    it('should apply custom offset options', async () => {
-      const nodes: Node[] = [createNode('node1', 'view', {x: 0, y: 0})];
-      const options: AutoLayoutOptions = {
-        offsetX: 100,
-        offsetY: 200,
-      };
+    it('should pass node spacing and rank spacing to ELK and lay out left to right', async () => {
+      await applyAutoLayout([createNode('a', 'VIEW')], [], {
+        nodeSpacing: 80,
+        rankSpacing: 220,
+      });
 
-      const result = await applyAutoLayout(nodes, [], options);
-
-      expect(result[0].position.x).toBe(100); // 0 (from mock) + 100 offset
-      expect(result[0].position.y).toBeGreaterThanOrEqual(0);
-    });
-
-    it('should accept direction option', async () => {
-      const nodes: Node[] = [createNode('node1', 'view'), createNode('node2', 'view')];
-      const edges: Edge[] = [createEdge('e1', 'node1', 'node2')];
-      const options: AutoLayoutOptions = {
-        direction: 'DOWN',
-      };
-
-      const result = await applyAutoLayout(nodes, edges, options);
-
-      expect(result).toHaveLength(2);
-    });
-
-    it('should accept nodeSpacing option', async () => {
-      const nodes: Node[] = [createNode('node1', 'view'), createNode('node2', 'view')];
-      const options: AutoLayoutOptions = {
-        nodeSpacing: 200,
-      };
-
-      const result = await applyAutoLayout(nodes, [], options);
-
-      expect(result).toHaveLength(2);
-    });
-
-    it('should accept rankSpacing option', async () => {
-      const nodes: Node[] = [createNode('node1', 'view'), createNode('node2', 'view')];
-      const options: AutoLayoutOptions = {
-        rankSpacing: 400,
-      };
-
-      const result = await applyAutoLayout(nodes, [], options);
-
-      expect(result).toHaveLength(2);
+      expect(lastGraph?.layoutOptions['elk.direction']).toBe('RIGHT');
+      expect(lastGraph?.layoutOptions['elk.spacing.nodeNode']).toBe('80');
+      expect(lastGraph?.layoutOptions['elk.layered.spacing.nodeNodeBetweenLayers']).toBe('220');
     });
   });
 
-  describe('Node Types', () => {
-    it('should handle START node type', async () => {
-      const nodes: Node[] = [createNode('start', 'START'), createNode('view', 'VIEW')];
-      const edges: Edge[] = [createEdge('e1', 'start', 'view')];
+  describe('Layer Constraints', () => {
+    it('should constrain START to the first layer and END to the last', async () => {
+      const nodes: Node[] = [createNode('start', 'START'), createNode('view1', 'VIEW'), createNode('end', 'END')];
 
-      const result = await applyAutoLayout(nodes, edges);
+      await applyAutoLayout(nodes, []);
 
-      expect(result.find((n) => n.id === 'start')).toBeDefined();
-    });
-
-    it('should handle END node type', async () => {
-      const nodes: Node[] = [createNode('view', 'VIEW'), createNode('end', 'END')];
-      const edges: Edge[] = [createEdge('e1', 'view', 'end')];
-
-      const result = await applyAutoLayout(nodes, edges);
-
-      expect(result.find((n) => n.id === 'end')).toBeDefined();
-    });
-
-    it('should handle VIEW node type', async () => {
-      const nodes: Node[] = [
-        createNode('start', 'START'),
-        createNode('view1', 'VIEW', {x: 0, y: 0}, {width: 300, height: 400}),
-        createNode('view2', 'VIEW', {x: 0, y: 0}, {width: 300, height: 400}),
-        createNode('end', 'END'),
-      ];
-      const edges: Edge[] = [
-        createEdge('e1', 'start', 'view1'),
-        createEdge('e2', 'view1', 'view2'),
-        createEdge('e3', 'view2', 'end'),
-      ];
-
-      const result = await applyAutoLayout(nodes, edges);
-
-      const viewNodes = result.filter((n) => n.type?.toUpperCase() === 'VIEW');
-      expect(viewNodes).toHaveLength(2);
-    });
-
-    it('should handle EXECUTION node type', async () => {
-      const nodes: Node[] = [
-        createNode('start', 'START'),
-        createNode('view', 'VIEW', {x: 0, y: 0}, {width: 300, height: 400}),
-        createNode('exec', 'EXECUTION', {x: 0, y: 0}, {width: 200, height: 100}),
-        createNode('end', 'END'),
-      ];
-      const edges: Edge[] = [
-        createEdge('e1', 'start', 'view'),
-        createEdge('e2', 'view', 'exec'),
-        createEdge('e3', 'exec', 'end'),
-      ];
-
-      const result = await applyAutoLayout(nodes, edges);
-
-      expect(result.find((n) => n.id === 'exec')).toBeDefined();
+      const byId = new Map(lastGraph?.children.map((child) => [child.id, child]));
+      expect(byId.get('start')?.layoutOptions['elk.layered.layering.layerConstraint']).toBe('FIRST');
+      expect(byId.get('end')?.layoutOptions['elk.layered.layering.layerConstraint']).toBe('LAST');
+      expect(byId.get('view1')?.layoutOptions['elk.layered.layering.layerConstraint']).toBeUndefined();
     });
 
     it('should handle mixed case node types', async () => {
-      const nodes: Node[] = [createNode('start', 'start'), createNode('view', 'View'), createNode('end', 'END')];
-      const edges: Edge[] = [createEdge('e1', 'start', 'view'), createEdge('e2', 'view', 'end')];
+      await applyAutoLayout([createNode('start', 'start'), createNode('end', 'End')], []);
+
+      const byId = new Map(lastGraph?.children.map((child) => [child.id, child]));
+      expect(byId.get('start')?.layoutOptions['elk.layered.layering.layerConstraint']).toBe('FIRST');
+      expect(byId.get('end')?.layoutOptions['elk.layered.layering.layerConstraint']).toBe('LAST');
+    });
+  });
+
+  describe('Handle Ports', () => {
+    it('should model success handles as east ports and targets as west ports', async () => {
+      const nodes: Node[] = [createNode('a', 'TASK_EXECUTION'), createNode('b', 'TASK_EXECUTION')];
+      const edges: Edge[] = [createEdge('e1', 'a', 'b', 'a_NEXT')];
+
+      await applyAutoLayout(nodes, edges);
+
+      const byId = new Map(lastGraph?.children.map((child) => [child.id, child]));
+      const sourcePorts = byId.get('a')?.ports ?? [];
+      const targetPorts = byId.get('b')?.ports ?? [];
+
+      expect(sourcePorts).toHaveLength(1);
+      expect(sourcePorts[0].layoutOptions['elk.port.side']).toBe('EAST');
+      expect(targetPorts[0].layoutOptions['elk.port.side']).toBe('WEST');
+      expect(lastGraph?.edges[0].sources[0]).toBe(sourcePorts[0].id);
+      expect(lastGraph?.edges[0].targets[0]).toBe(targetPorts[0].id);
+      expect(byId.get('a')?.layoutOptions['elk.portConstraints']).toBe('FIXED_SIDE');
+    });
+
+    it('should model failure handles as south ports and incomplete handles as north ports', async () => {
+      const nodes: Node[] = [
+        createNode('exec', 'TASK_EXECUTION'),
+        createNode('fail', 'TASK_EXECUTION'),
+        createNode('retry', 'VIEW'),
+      ];
+      const edges: Edge[] = [
+        createEdge('e1', 'exec', 'fail', 'failure'),
+        createEdge('e2', 'exec', 'retry', 'exec_INCOMPLETE'),
+      ];
+
+      await applyAutoLayout(nodes, edges);
+
+      const byId = new Map(lastGraph?.children.map((child) => [child.id, child]));
+      const ports = byId.get('exec')?.ports ?? [];
+      const sides = ports.map((port) => port.layoutOptions['elk.port.side']).sort();
+
+      expect(sides).toEqual(['NORTH', 'SOUTH']);
+    });
+
+    it('should not add ports or port constraints to unconnected nodes', async () => {
+      await applyAutoLayout([createNode('lonely', 'VIEW')], []);
+
+      const child = lastGraph?.children[0];
+      expect(child?.ports).toBeUndefined();
+      expect(child?.layoutOptions['elk.portConstraints']).toBeUndefined();
+    });
+  });
+
+  describe('Happy Path Straightening', () => {
+    it('should assign straightness priority to the success chain from START', async () => {
+      const nodes: Node[] = [
+        createNode('start', 'START'),
+        createNode('view1', 'VIEW'),
+        createNode('exec1', 'TASK_EXECUTION'),
+        createNode('end', 'END'),
+        createNode('recovery', 'CALL'),
+      ];
+      const edges: Edge[] = [
+        createEdge('e1', 'start', 'view1', 'start_NEXT'),
+        createEdge('e2', 'view1', 'exec1', 'btn_NEXT'),
+        createEdge('e3', 'exec1', 'end', 'exec1_NEXT'),
+        createEdge('e4', 'exec1', 'recovery', 'failure'),
+      ];
+
+      await applyAutoLayout(nodes, edges);
+
+      const byEdgeId = new Map(lastGraph?.edges.map((edge) => [edge.id, edge]));
+      expect(byEdgeId.get('e1')?.layoutOptions?.['elk.layered.priority.straightness']).toBe('10');
+      expect(byEdgeId.get('e2')?.layoutOptions?.['elk.layered.priority.straightness']).toBe('10');
+      expect(byEdgeId.get('e3')?.layoutOptions?.['elk.layered.priority.straightness']).toBe('10');
+      expect(byEdgeId.get('e4')?.layoutOptions).toBeUndefined();
+    });
+
+    it('should not follow failure branches when collecting the happy path', async () => {
+      const nodes: Node[] = [createNode('start', 'START'), createNode('a', 'TASK_EXECUTION'), createNode('end', 'END')];
+      const edges: Edge[] = [createEdge('e1', 'start', 'a', 'failure'), createEdge('e2', 'a', 'end', 'a_NEXT')];
+
+      await applyAutoLayout(nodes, edges);
+
+      const byEdgeId = new Map(lastGraph?.edges.map((edge) => [edge.id, edge]));
+      expect(byEdgeId.get('e1')?.layoutOptions).toBeUndefined();
+      expect(byEdgeId.get('e2')?.layoutOptions).toBeUndefined();
+    });
+
+    it('should terminate on cyclic success chains', async () => {
+      const nodes: Node[] = [createNode('start', 'START'), createNode('a', 'VIEW'), createNode('b', 'VIEW')];
+      const edges: Edge[] = [
+        createEdge('e1', 'start', 'a', 'start_NEXT'),
+        createEdge('e2', 'a', 'b', 'a_NEXT'),
+        createEdge('e3', 'b', 'a', 'b_NEXT'),
+      ];
 
       const result = await applyAutoLayout(nodes, edges);
 
@@ -230,199 +291,86 @@ describe('applyAutoLayout', () => {
   });
 
   describe('Edge Handling', () => {
-    it('should deduplicate edges', async () => {
-      const nodes: Node[] = [createNode('node1', 'view'), createNode('node2', 'view')];
-      const edges: Edge[] = [
-        createEdge('e1', 'node1', 'node2'),
-        createEdge('e2', 'node1', 'node2'), // Duplicate edge
-      ];
+    it('should deduplicate edges with the same source handle and target', async () => {
+      const nodes: Node[] = [createNode('a', 'VIEW'), createNode('b', 'VIEW')];
+      const edges: Edge[] = [createEdge('e1', 'a', 'b', 'a_NEXT'), createEdge('e2', 'a', 'b', 'a_NEXT')];
 
-      const result = await applyAutoLayout(nodes, edges);
+      await applyAutoLayout(nodes, edges);
 
-      expect(result).toHaveLength(2);
+      expect(lastGraph?.edges).toHaveLength(1);
+    });
+
+    it('should keep parallel edges that leave different handles', async () => {
+      const nodes: Node[] = [createNode('a', 'TASK_EXECUTION'), createNode('b', 'VIEW')];
+      const edges: Edge[] = [createEdge('e1', 'a', 'b', 'a_NEXT'), createEdge('e2', 'a', 'b', 'failure')];
+
+      await applyAutoLayout(nodes, edges);
+
+      expect(lastGraph?.edges).toHaveLength(2);
     });
 
     it('should filter out edges with non-existent source nodes', async () => {
-      const nodes: Node[] = [createNode('node1', 'view'), createNode('node2', 'view')];
-      const edges: Edge[] = [
-        createEdge('e1', 'node1', 'node2'),
-        createEdge('e2', 'nonExistent', 'node2'), // Invalid source
-      ];
+      const nodes: Node[] = [createNode('a', 'VIEW')];
+      const edges: Edge[] = [createEdge('e1', 'ghost', 'a')];
 
-      const result = await applyAutoLayout(nodes, edges);
+      await applyAutoLayout(nodes, edges);
 
-      expect(result).toHaveLength(2);
+      expect(lastGraph?.edges).toHaveLength(0);
     });
 
     it('should filter out edges with non-existent target nodes', async () => {
-      const nodes: Node[] = [createNode('node1', 'view'), createNode('node2', 'view')];
-      const edges: Edge[] = [
-        createEdge('e1', 'node1', 'node2'),
-        createEdge('e2', 'node1', 'nonExistent'), // Invalid target
-      ];
+      const nodes: Node[] = [createNode('a', 'VIEW')];
+      const edges: Edge[] = [createEdge('e1', 'a', 'ghost')];
 
-      const result = await applyAutoLayout(nodes, edges);
+      await applyAutoLayout(nodes, edges);
 
-      expect(result).toHaveLength(2);
+      expect(lastGraph?.edges).toHaveLength(0);
     });
   });
 
   describe('Node Dimensions', () => {
     it('should use measured dimensions when available', async () => {
-      const nodes: Node[] = [createNode('node1', 'view', {x: 0, y: 0}, {width: 350, height: 500})];
+      const nodes: Node[] = [createNode('a', 'VIEW', {x: 0, y: 0}, {width: 350, height: 500})];
 
-      const result = await applyAutoLayout(nodes, []);
+      await applyAutoLayout(nodes, []);
 
-      expect(result).toHaveLength(1);
+      expect(lastGraph?.children[0].width).toBe(350);
+      expect(lastGraph?.children[0].height).toBe(500);
     });
 
     it('should use width/height properties when measured is not available', async () => {
-      const node: Node = {
-        id: 'node1',
-        type: 'view',
-        position: {x: 0, y: 0},
-        data: {},
-        width: 300,
-        height: 400,
-      };
+      const nodes: Node[] = [{...createNode('a', 'VIEW'), width: 320, height: 240}];
 
-      const result = await applyAutoLayout([node], []);
+      await applyAutoLayout(nodes, []);
 
-      expect(result).toHaveLength(1);
+      expect(lastGraph?.children[0].width).toBe(320);
+      expect(lastGraph?.children[0].height).toBe(240);
     });
 
     it('should use default dimensions when neither measured nor width/height available', async () => {
-      const nodes: Node[] = [createNode('node1', 'view')];
+      await applyAutoLayout([createNode('a', 'VIEW')], []);
 
-      const result = await applyAutoLayout(nodes, []);
-
-      expect(result).toHaveLength(1);
+      expect(lastGraph?.children[0].width).toBe(200);
+      expect(lastGraph?.children[0].height).toBe(100);
     });
   });
 
   describe('Error Handling', () => {
     it('should return original nodes when ELK layout fails', async () => {
-      // Override mock to throw error
-      vi.doMock('elkjs/lib/elk.bundled.js', () => ({
-        default: class FailingELK {
-          layout() {
-            return Promise.reject(new Error('Layout failed'));
-          }
-        },
-      }));
+      failLayout = true;
+      const nodes: Node[] = [createNode('a', 'VIEW', {x: 123, y: 456})];
 
-      const nodes: Node[] = [createNode('node1', 'view', {x: 100, y: 200})];
-
-      // The function should catch the error and return original nodes
-      // Since we can't easily re-import, we test the catch behavior differently
       const result = await applyAutoLayout(nodes, []);
 
-      expect(result).toHaveLength(1);
-    });
-  });
-
-  describe('Post-Processing', () => {
-    it('should align VIEW nodes horizontally', async () => {
-      const nodes: Node[] = [
-        createNode('start', 'START', {x: 0, y: 0}, {width: 50, height: 50}),
-        createNode('view1', 'VIEW', {x: 0, y: 0}, {width: 300, height: 400}),
-        createNode('view2', 'VIEW', {x: 0, y: 0}, {width: 300, height: 400}),
-        createNode('end', 'END', {x: 0, y: 0}, {width: 50, height: 50}),
-      ];
-      const edges: Edge[] = [
-        createEdge('e1', 'start', 'view1'),
-        createEdge('e2', 'view1', 'view2'),
-        createEdge('e3', 'view2', 'end'),
-      ];
-
-      const result = await applyAutoLayout(nodes, edges);
-
-      // VIEW nodes should be aligned (have similar Y positions considering their heights)
-      const viewNodes = result.filter((n) => n.type?.toUpperCase() === 'VIEW');
-      expect(viewNodes.length).toBeGreaterThanOrEqual(2);
-      // Views should be centered at the same Y
-      const heights = viewNodes.map((n) => n.measured?.height ?? 100);
-      const centers = viewNodes.map((n, i) => n.position.y + heights[i] / 2);
-      // Allow some tolerance for rounding
-      const tolerance = 5;
-      expect(Math.abs(centers[0] - centers[1])).toBeLessThan(tolerance);
+      expect(result[0].position).toEqual({x: 123, y: 456});
     });
 
     it('should handle nodes without type', async () => {
-      const node: Node = {
-        id: 'node1',
-        position: {x: 0, y: 0},
-        data: {},
-      };
-
-      const result = await applyAutoLayout([node], []);
-
-      expect(result).toHaveLength(1);
-    });
-  });
-
-  describe('Complex Scenarios', () => {
-    it('should handle a complete flow with all node types', async () => {
-      const nodes: Node[] = [
-        createNode('start', 'START', {x: 0, y: 0}, {width: 50, height: 50}),
-        createNode('view1', 'VIEW', {x: 0, y: 0}, {width: 300, height: 400}),
-        createNode('exec1', 'EXECUTION', {x: 0, y: 0}, {width: 200, height: 100}),
-        createNode('view2', 'VIEW', {x: 0, y: 0}, {width: 300, height: 400}),
-        createNode('exec2', 'EXECUTION', {x: 0, y: 0}, {width: 200, height: 100}),
-        createNode('end', 'END', {x: 0, y: 0}, {width: 50, height: 50}),
-      ];
-      const edges: Edge[] = [
-        createEdge('e1', 'start', 'view1'),
-        createEdge('e2', 'view1', 'exec1'),
-        createEdge('e3', 'exec1', 'view2'),
-        createEdge('e4', 'view2', 'exec2'),
-        createEdge('e5', 'exec2', 'end'),
-      ];
-
-      const result = await applyAutoLayout(nodes, edges);
-
-      expect(result).toHaveLength(6);
-      result.forEach((node) => {
-        expect(node.position).toBeDefined();
-        expect(typeof node.position.x).toBe('number');
-        expect(typeof node.position.y).toBe('number');
-      });
-    });
-
-    it('should handle branching flows', async () => {
-      const nodes: Node[] = [
-        createNode('start', 'START'),
-        createNode('view1', 'VIEW'),
-        createNode('view2', 'VIEW'),
-        createNode('view3', 'VIEW'),
-        createNode('end', 'END'),
-      ];
-      const edges: Edge[] = [
-        createEdge('e1', 'start', 'view1'),
-        createEdge('e2', 'view1', 'view2'),
-        createEdge('e3', 'view1', 'view3'),
-        createEdge('e4', 'view2', 'end'),
-        createEdge('e5', 'view3', 'end'),
-      ];
-
-      const result = await applyAutoLayout(nodes, edges);
-
-      expect(result).toHaveLength(5);
-    });
-
-    it('should preserve node data after layout', async () => {
-      const nodes: Node[] = [
-        {
-          id: 'node1',
-          type: 'view',
-          position: {x: 0, y: 0},
-          data: {label: 'Test Node', customProp: 'value'},
-        },
-      ];
+      const nodes: Node[] = [{id: 'untyped', position: {x: 0, y: 0}, data: {}}];
 
       const result = await applyAutoLayout(nodes, []);
 
-      expect(result[0].data).toEqual({label: 'Test Node', customProp: 'value'});
+      expect(result).toHaveLength(1);
     });
   });
 });

--- a/frontend/apps/console/src/features/flows/utils/applyAutoLayout.ts
+++ b/frontend/apps/console/src/features/flows/utils/applyAutoLayout.ts
@@ -17,17 +17,12 @@
  */
 
 import type {Edge, Node} from '@xyflow/react';
-import ELK from 'elkjs/lib/elk.bundled.js';
+import type {ELK} from 'elkjs/lib/elk-api';
 
 /**
  * Configuration options for auto-layout.
  */
 export interface AutoLayoutOptions {
-  /**
-   * Direction of the layout.
-   * @default 'RIGHT' (left to right)
-   */
-  direction?: 'RIGHT' | 'LEFT' | 'DOWN' | 'UP';
   /**
    * Spacing between nodes (perpendicular to flow direction).
    * @default 100
@@ -35,7 +30,7 @@ export interface AutoLayoutOptions {
   nodeSpacing?: number;
   /**
    * Spacing between ranks/layers (parallel to flow direction).
-   * @default 200
+   * @default 160
    */
   rankSpacing?: number;
   /**
@@ -50,12 +45,94 @@ export interface AutoLayoutOptions {
   offsetY?: number;
 }
 
-const elk = new ELK();
+// ELK (the layout engine) is ~1.5MB. It is only needed when a layout is actually
+// requested (toolbar button, or opening a flow with no stored positions), so it is
+// dynamically imported and cached rather than bundled into the builder's entry chunk.
+let elkPromise: Promise<ELK> | undefined;
+
+const getElk = async (): Promise<ELK> => {
+  elkPromise ??= import('elkjs/lib/elk.bundled.js').then((module) => new module.default());
+  try {
+    return await elkPromise;
+  } catch (error) {
+    // A failed chunk load (e.g. a transient network error) must not stay
+    // cached, or every later layout attempt would fail until a full reload.
+    elkPromise = undefined;
+    throw error;
+  }
+};
+
+const FAILURE_HANDLE = 'failure';
+const INCOMPLETE_HANDLE_SUFFIX = '_INCOMPLETE';
+const PREVIOUS_HANDLE_SUFFIX = '_PREVIOUS';
+
+/**
+ * Which side of the node an edge leaves from, derived from the canvas handle
+ * conventions: success/next handles sit on the right, failure on the bottom,
+ * incomplete on the top, previous on the left.
+ */
+const sourcePortSide = (sourceHandle: string | null | undefined): 'EAST' | 'SOUTH' | 'NORTH' | 'WEST' => {
+  if (sourceHandle === FAILURE_HANDLE) {
+    return 'SOUTH';
+  }
+  if (sourceHandle?.endsWith(INCOMPLETE_HANDLE_SUFFIX)) {
+    return 'NORTH';
+  }
+  if (sourceHandle?.endsWith(PREVIOUS_HANDLE_SUFFIX)) {
+    return 'WEST';
+  }
+  return 'EAST';
+};
+
+interface ElkPort {
+  id: string;
+  layoutOptions: Record<string, string>;
+}
+
+/**
+ * The happy path is the success chain from the start node to the end node.
+ * Its edges get a straightening priority so ELK aligns the main flow on one
+ * row; failure and incomplete branches hang off it.
+ */
+const collectHappyPathEdgeIds = (nodes: Node[], edges: Edge[]): Set<string> => {
+  const startNode = nodes.find((node) => node.type?.toUpperCase() === 'START');
+  const happyEdgeIds = new Set<string>();
+  if (!startNode) {
+    return happyEdgeIds;
+  }
+
+  const visited = new Set<string>([startNode.id]);
+  let current: string | undefined = startNode.id;
+
+  while (current) {
+    const nextEdge: Edge | undefined = edges.find(
+      (edge) => edge.source === current && sourcePortSide(edge.sourceHandle) === 'EAST' && !visited.has(edge.target),
+    );
+    if (!nextEdge) {
+      break;
+    }
+    happyEdgeIds.add(nextEdge.id);
+    visited.add(nextEdge.target);
+    current = nextEdge.target;
+  }
+
+  return happyEdgeIds;
+};
 
 /**
  * Applies automatic layout to nodes using ELK (Eclipse Layout Kernel).
- * ELK provides sophisticated graph layout algorithms that position nodes
- * to minimize edge crossings.
+ *
+ * The graph handed to ELK carries the canvas semantics so the result matches
+ * how edges actually attach on screen:
+ * - Handles are modeled as fixed-side ports (success → right, failure →
+ *   bottom, incomplete → top), so branch targets land on the matching side.
+ * - The success chain from START to END gets a straightening priority, so the
+ *   main flow reads as one left-to-right row with branches hanging off it.
+ * - START and END are constrained to the first and last layer.
+ *
+ * ELK's positions are used as-is for every node type; there is deliberately no
+ * per-type post-processing (repositioning some node types but not others tears
+ * the layout apart).
  *
  * @param nodes - Array of nodes to layout.
  * @param edges - Array of edges connecting the nodes (used for layout calculation).
@@ -67,35 +144,70 @@ export default async function applyAutoLayout(
   edges: Edge[],
   options: AutoLayoutOptions = {},
 ): Promise<Node[]> {
-  const {direction = 'RIGHT', nodeSpacing = 150, rankSpacing = 300, offsetX = 50, offsetY = 50} = options;
+  const {nodeSpacing = 100, rankSpacing = 160, offsetX = 50, offsetY = 50} = options;
 
   if (nodes.length === 0) {
     return nodes;
   }
 
-  // Node type constants
-  const NODE_TYPES = {
-    START: 'START',
-    VIEW: 'VIEW',
-    EXECUTION: 'EXECUTION',
-    END: 'END',
+  const nodeIds = new Set(nodes.map((n) => n.id));
+  const happyPathEdgeIds = collectHappyPathEdgeIds(nodes, edges);
+
+  // Deduplicate edges, register a fixed-side port per distinct handle, and
+  // build the ELK edge list referencing those ports.
+  const portsByNode = new Map<string, Map<string, ElkPort>>();
+  const registerPort = (nodeId: string, handleKey: string, side: string): string => {
+    const portId = `${nodeId}__${handleKey}`;
+    const ports = portsByNode.get(nodeId) ?? new Map<string, ElkPort>();
+    if (!ports.has(portId)) {
+      ports.set(portId, {id: portId, layoutOptions: {'elk.port.side': side}});
+    }
+    portsByNode.set(nodeId, ports);
+    return portId;
   };
 
-  // Build ELK graph structure with layer constraints based on node type
+  const addedEdges = new Set<string>();
+  const elkEdges: {id: string; sources: string[]; targets: string[]; layoutOptions?: Record<string, string>}[] = [];
+
+  edges.forEach((edge) => {
+    const edgeKey = `${edge.source}#${edge.sourceHandle ?? ''}->${edge.target}`;
+
+    if (!nodeIds.has(edge.source) || !nodeIds.has(edge.target) || addedEdges.has(edgeKey)) {
+      return;
+    }
+    addedEdges.add(edgeKey);
+
+    const side = sourcePortSide(edge.sourceHandle);
+    const sourcePortId = registerPort(edge.source, edge.sourceHandle ?? 'out', side);
+    const targetPortId = registerPort(edge.target, 'in', 'WEST');
+
+    elkEdges.push({
+      id: edge.id,
+      sources: [sourcePortId],
+      targets: [targetPortId],
+      // Straighten the happy path so the main flow forms a single row.
+      ...(happyPathEdgeIds.has(edge.id) && {layoutOptions: {'elk.layered.priority.straightness': '10'}}),
+    });
+  });
+
   const elkNodes = nodes.map((node) => {
     const width = node.measured?.width ?? node.width ?? 200;
     const height = node.measured?.height ?? node.height ?? 100;
     const nodeType = node.type?.toUpperCase() ?? '';
 
-    // Assign layer constraints for START and END nodes only
     const layoutOptions: Record<string, string> = {};
 
-    if (nodeType === NODE_TYPES.START) {
+    if (nodeType === 'START') {
       // START nodes go first (leftmost)
       layoutOptions['elk.layered.layering.layerConstraint'] = 'FIRST';
-    } else if (nodeType === NODE_TYPES.END) {
+    } else if (nodeType === 'END') {
       // END nodes go last (rightmost)
       layoutOptions['elk.layered.layering.layerConstraint'] = 'LAST';
+    }
+
+    const ports = portsByNode.get(node.id);
+    if (ports) {
+      layoutOptions['elk.portConstraints'] = 'FIXED_SIDE';
     }
 
     return {
@@ -103,67 +215,43 @@ export default async function applyAutoLayout(
       width,
       height,
       layoutOptions,
+      ...(ports && {ports: [...ports.values()]}),
     };
   });
 
-  // Deduplicate edges and build ELK edge structure
-  const addedEdges = new Set<string>();
-  const elkEdges: {id: string; sources: string[]; targets: string[]}[] = [];
-  const nodeIds = new Set(nodes.map((n) => n.id));
-
-  edges.forEach((edge) => {
-    const edgeKey = `${edge.source}->${edge.target}`;
-
-    // Only add edges where both source and target exist
-    if (nodeIds.has(edge.source) && nodeIds.has(edge.target) && !addedEdges.has(edgeKey)) {
-      elkEdges.push({
-        id: edge.id,
-        sources: [edge.source],
-        targets: [edge.target],
-      });
-      addedEdges.add(edgeKey);
-    }
-  });
-
-  // ELK graph with layout options optimized to reduce edge-node collisions
   const elkGraph = {
     id: 'root',
     layoutOptions: {
       // Use layered algorithm - best for directed graphs
       'elk.algorithm': 'layered',
-      // Direction of the layout
-      'elk.direction': direction,
-      // Spacing between nodes in the same layer - increased significantly
+      // The layout direction is fixed: the port sides mirror the canvas's
+      // physical handle geometry (success right, failure bottom, incomplete
+      // top), which only composes with a left-to-right flow.
+      'elk.direction': 'RIGHT',
+      // Spacing between nodes in the same layer
       'elk.spacing.nodeNode': String(nodeSpacing),
-      // Spacing between layers - increased for better horizontal separation
+      // Spacing between layers
       'elk.layered.spacing.nodeNodeBetweenLayers': String(rankSpacing),
-      // Edge routing strategy - POLYLINE gives more flexibility for routing
       'elk.edgeRouting': 'POLYLINE',
-      // Large spacing between edges and nodes to prevent overlaps
-      'elk.spacing.edgeNode': '200',
-      'elk.spacing.edgeEdge': '80',
-      // Additional edge-node spacing in layered layout
-      'elk.layered.spacing.edgeNodeBetweenLayers': '150',
-      'elk.layered.spacing.edgeEdgeBetweenLayers': '80',
-      // Node placement strategy - NETWORK_SIMPLEX gives better vertical distribution
+      // Moderate edge clearances: the canvas draws its own smart edges, so
+      // ELK's routing only needs to influence placement, not look good itself.
+      // Oversized clearances inflate the layout's footprint.
+      'elk.spacing.edgeNode': '60',
+      'elk.spacing.edgeEdge': '40',
+      'elk.layered.spacing.edgeNodeBetweenLayers': '60',
+      'elk.layered.spacing.edgeEdgeBetweenLayers': '40',
+      // NETWORK_SIMPLEX honors the per-edge straightness priorities set on the
+      // happy path, keeping the main flow on one row.
       'elk.layered.nodePlacement.strategy': 'NETWORK_SIMPLEX',
-      // Crossing minimization - more thorough strategy
       'elk.layered.crossingMinimization.strategy': 'LAYER_SWEEP',
       'elk.layered.crossingMinimization.greedySwitch.type': 'TWO_SIDED',
-      // Cycle breaking strategy
       'elk.layered.cycleBreaking.strategy': 'DEPTH_FIRST',
-      // Don't merge edges - keep them separate for cleaner routing
       'elk.layered.mergeEdges': 'false',
-      // Higher thoroughness for better layout quality
       'elk.layered.thoroughness': '50',
-      // Consider node labels for spacing
+      // Keep the authored node/edge order as a tiebreaker so equivalent
+      // layouts stay stable across runs.
       'elk.layered.considerModelOrder.strategy': 'NODES_AND_EDGES',
-      // Wrapping strategy for long edges
-      'elk.layered.wrapping.strategy': 'OFF',
-      // Spacing for ports (connection points)
       'elk.spacing.portPort': '20',
-      // Edge label placement
-      'elk.layered.edgeLabels.sideSelection': 'SMART_UP',
     },
     children: elkNodes,
     edges: elkEdges,
@@ -171,10 +259,11 @@ export default async function applyAutoLayout(
 
   try {
     // Run ELK layout algorithm
+    const elk = await getElk();
     const layoutedGraph = await elk.layout(elkGraph);
 
     // Map the calculated positions back to React Flow nodes
-    let layoutedNodes = nodes.map((node) => {
+    return nodes.map((node) => {
       const elkNode = layoutedGraph.children?.find((n) => n.id === node.id);
 
       if (elkNode?.x === undefined || elkNode.y === undefined) {
@@ -189,198 +278,6 @@ export default async function applyAutoLayout(
         },
       };
     });
-
-    // Post-process: Align all VIEW nodes to the same Y position (horizontal row)
-    const viewNodes = layoutedNodes.filter((n) => n.type?.toUpperCase() === NODE_TYPES.VIEW);
-    if (viewNodes.length > 0) {
-      // First, collect ALL node types and calculate their center positions
-      const startNodes = layoutedNodes.filter((n) => n.type?.toUpperCase() === NODE_TYPES.START);
-      const endNodes = layoutedNodes.filter((n) => n.type?.toUpperCase() === NODE_TYPES.END);
-
-      // Calculate the overall bounding box center Y for all nodes (START, END, VIEWs)
-      const allRelevantNodes = [...startNodes, ...endNodes, ...viewNodes];
-
-      let minCenterY = Infinity;
-      let maxCenterY = -Infinity;
-
-      allRelevantNodes.forEach((node) => {
-        const nodeHeight = node.measured?.height ?? node.height ?? 100;
-        const centerY = node.position.y + nodeHeight / 2;
-        minCenterY = Math.min(minCenterY, centerY);
-        maxCenterY = Math.max(maxCenterY, centerY);
-      });
-
-      // Use the middle point as the target center Y
-      const targetCenterY = (minCenterY + maxCenterY) / 2;
-
-      // Align all VIEW nodes so their centers align with targetCenterY
-      // Each view may have different height, so calculate Y individually
-      layoutedNodes = layoutedNodes.map((node) => {
-        if (node.type?.toUpperCase() === NODE_TYPES.VIEW) {
-          const nodeHeight = node.measured?.height ?? node.height ?? 100;
-          const nodeY = targetCenterY - nodeHeight / 2;
-          return {
-            ...node,
-            position: {
-              ...node.position,
-              y: nodeY,
-            },
-          };
-        }
-        return node;
-      });
-
-      const viewCenterY = targetCenterY;
-
-      // Align START and END nodes to the same horizontal level (centered with Views)
-      layoutedNodes = layoutedNodes.map((node) => {
-        const nodeType = node.type?.toUpperCase() ?? '';
-        if (nodeType === NODE_TYPES.START || nodeType === NODE_TYPES.END) {
-          const nodeHeight = node.measured?.height ?? node.height ?? 50;
-          return {
-            ...node,
-            position: {
-              ...node.position,
-              y: viewCenterY - nodeHeight / 2,
-            },
-          };
-        }
-        return node;
-      });
-
-      // Position EXECUTION nodes - try to keep them on the same horizontal line as views
-      // Only move them below if they would overlap with other nodes
-      const executionNodes = layoutedNodes.filter((n) => n.type?.toUpperCase() === NODE_TYPES.EXECUTION);
-
-      if (executionNodes.length > 0) {
-        // Sort execution nodes by their X position to maintain left-to-right order
-        const sortedExecutionNodes = [...executionNodes].sort((a, b) => a.position.x - b.position.x);
-
-        // Try to center execution nodes vertically with the views first
-        layoutedNodes = layoutedNodes.map((node) => {
-          if (node.type?.toUpperCase() === NODE_TYPES.EXECUTION) {
-            const nodeHeight = node.measured?.height ?? node.height ?? 100;
-            return {
-              ...node,
-              position: {
-                ...node.position,
-                y: viewCenterY - nodeHeight / 2,
-              },
-            };
-          }
-          return node;
-        });
-
-        // Track placed execution nodes with their final positions for overlap detection
-        const placedExecutionNodes: {
-          id: string;
-          x: number;
-          y: number;
-          width: number;
-          height: number;
-        }[] = [];
-
-        // Now check for overlaps and move conflicting execution nodes below
-        // Find the maximum bottom Y of all view nodes
-        const viewBottoms = layoutedNodes
-          .filter((n) => n.type?.toUpperCase() === NODE_TYPES.VIEW)
-          .map((n) => {
-            const height = n.measured?.height ?? n.height ?? 100;
-            return n.position.y + height;
-          });
-        const maxViewBottom = viewBottoms.length > 0 ? Math.max(...viewBottoms) : 0;
-        const viewBottomY = maxViewBottom + nodeSpacing;
-        const horizontalPadding = 50;
-        const verticalPadding = 30;
-
-        // Check each execution node for overlap with views AND other execution nodes
-        sortedExecutionNodes.forEach((execNode) => {
-          const execX = execNode.position.x;
-          const execWidth = execNode.measured?.width ?? execNode.width ?? 200;
-          const execHeight = execNode.measured?.height ?? execNode.height ?? 100;
-          const execRight = execX + execWidth;
-          let execY = viewCenterY - execHeight / 2; // Start at view center
-
-          // Check if this execution node overlaps horizontally with any view
-          const overlapsWithView = viewNodes.some((viewNode) => {
-            const viewX = viewNode.position.x;
-            const viewWidth = viewNode.measured?.width ?? viewNode.width ?? 350;
-            const viewRight = viewX + viewWidth;
-
-            // Check horizontal overlap (with some padding)
-            return execRight + horizontalPadding > viewX && execX - horizontalPadding < viewRight;
-          });
-
-          if (overlapsWithView) {
-            // Need to move below views
-            execY = viewBottomY;
-          }
-
-          // Check for overlap with already placed execution nodes
-          // Keep moving down until no overlap
-          // Helper to check if a Y position overlaps with any placed node
-          const checkOverlapAtY = (testY: number): {overlaps: boolean; nextY: number} => {
-            let result = {overlaps: false, nextY: testY};
-
-            placedExecutionNodes.forEach((placed) => {
-              if (result.overlaps) return; // Already found overlap
-
-              // Check if rectangles overlap (with padding)
-              const horizontalOverlap =
-                execRight + horizontalPadding > placed.x && execX - horizontalPadding < placed.x + placed.width;
-
-              const verticalOverlap =
-                testY + execHeight + verticalPadding > placed.y && testY - verticalPadding < placed.y + placed.height;
-
-              if (horizontalOverlap && verticalOverlap) {
-                result = {
-                  overlaps: true,
-                  nextY: placed.y + placed.height + verticalPadding + nodeSpacing,
-                };
-              }
-            });
-
-            return result;
-          };
-
-          // Find non-overlapping Y position
-          let iterations = 0;
-          const maxIterations = 20;
-          let overlapCheck = checkOverlapAtY(execY);
-
-          while (overlapCheck.overlaps && iterations < maxIterations) {
-            iterations += 1;
-            execY = overlapCheck.nextY;
-            overlapCheck = checkOverlapAtY(execY);
-          }
-
-          // Update the node position
-          layoutedNodes = layoutedNodes.map((node) => {
-            if (node.id === execNode.id) {
-              return {
-                ...node,
-                position: {
-                  ...node.position,
-                  y: execY,
-                },
-              };
-            }
-            return node;
-          });
-
-          // Add to placed nodes
-          placedExecutionNodes.push({
-            id: execNode.id,
-            x: execX,
-            y: execY,
-            width: execWidth,
-            height: execHeight,
-          });
-        });
-      }
-    }
-
-    return layoutedNodes;
   } catch {
     // Return original nodes if layout fails
     return nodes;


### PR DESCRIPTION
### Purpose

Auto-layout in the flow builder sometimes produces incoherent results: Call nodes stranded far off the main line, long edge detours from view links, and inconsistent vertical alignment (see the issue's parent, flow builder UX). Refs #3871.

Two root causes:

1. **A dead and destructive post-processing pass.** After ELK computed a layout, a post-pass re-centered VIEW/START/END nodes onto one line and was supposed to reposition execution nodes too, but it compared against `'EXECUTION'` while canvas executor nodes have type `'TASK_EXECUTION'`, so that branch never ran, and `CALL`/`RULE` nodes were not handled at all. The result mixed two coordinate systems: some node types were moved after the fact while others kept positions from ELK's original (now torn apart) layout. This is exactly the "floating Call node" symptom.
2. **ELK had no handle information.** Edges were fed as node-to-node connections, so placement decisions ignored where edges actually attach (success on the right, failure at the bottom, incomplete on top).

### Approach

Give ELK the canvas semantics and trust its output, instead of correcting it afterwards:

- **Handles are modeled as fixed-side ports** derived from the canvas conventions (`*_NEXT` → east, `failure` → south, `*_INCOMPLETE` → north, `*_PREVIOUS` → west; targets are west ports). ELK then places failure branches below their source and routes view-link branches sensibly.
- **The happy path is straightened**: the success chain from START to END gets `elk.layered.priority.straightness`, which the NETWORK_SIMPLEX placement honors, so the main flow reads as one left-to-right row with branches hanging off it.
- **The per-type post-processing pass is removed entirely.** ELK positions are applied uniformly to every node type, eliminating the mixed-coordinate failure mode.
- Edge deduplication now keys on the source handle too, so success and failure edges between the same pair of nodes both inform the layout.
- Edge clearance options are reduced to moderate values; the canvas draws its own smart edges, so ELK's own routing only needs to influence placement, and oversized clearances inflated the layout's footprint.

Verified against real ELK (not just the test mock) with a graph mirroring the reported layout: the executor chain lands on a single aligned row, START aligns with the view it feeds, and both CALL nodes stack cleanly below the credentials column.

The test suite is rewritten to assert the semantics handed to ELK (ports, layer constraints, straightness priorities, dedup) plus uniform position mapping, rather than the removed post-pass behavior.

Note for reviewers: layout quality is visual; a manual pass on the starter templates and a flow with link widgets (self sign up / recovery) is recommended.

### Related Issues
- Refs #3871

### Related PRs
- #4053 (flow builder canvas UX)
- Supersedes #4150: the ELK lazy-loading is folded into this PR since both change the same file. The ~1.5MB ELK engine is now dynamically imported only when a layout is requested (cutting the builder page chunk from ~2.4MB to ~0.9MB), and a failed chunk load clears the cached import so the next layout attempt retries instead of failing until reload.

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved automatic flow layout to preserve success paths as the primary straight-through route.
  * Improved edge placement by respecting success, failure, and incomplete connection directions.
  * Prevented duplicate or invalid connections from affecting layout.
  * Improved node sizing and positioning, including measured dimensions and configured offsets.
  * Preserved the original layout when automatic layout cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
