### PR TITLE
Reject unsupported OAuth response modes

### DIFF
--- a/api/oauth2.yaml
+++ b/api/oauth2.yaml
@@ -55,6 +55,16 @@ paths:
             type: string
             enum: [code]
           description: Must be `code` for the authorization code flow.
+        - name: response_mode
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [query]
+          description: >-
+            OAuth 2.0 response mode. When omitted, query mode is used by default.
+            Only query mode is supported. Requests with unsupported values such as
+            fragment or form_post are rejected with invalid_request.
         - name: client_id
           in: query
           required: true

--- a/backend/internal/oauth/oauth2/authz/requestvalidator/validator.go
+++ b/backend/internal/oauth/oauth2/authz/requestvalidator/validator.go
@@ -49,6 +49,7 @@ func ValidateAuthorizationRequestParams(
 	params map[string]string, oauthApp *providers.OAuthClient, dpopHeaderJkt string,
 ) (string, string) {
 	responseType := params[constants.RequestParamResponseType]
+	responseMode := params[constants.RequestParamResponseMode]
 
 	// Validate the prompt parameter if present.
 	prompt, promptExists := params[constants.RequestParamPrompt]
@@ -70,6 +71,9 @@ func ValidateAuthorizationRequestParams(
 	}
 	if !oauthApp.IsAllowedResponseType(responseType) {
 		return constants.ErrorUnsupportedResponseType, "Unsupported response type"
+	}
+	if !constants.IsSupportedResponseMode(responseMode) {
+		return constants.ErrorInvalidRequest, "Unsupported response_mode parameter"
 	}
 
 	// Validate PKCE parameters.

--- a/backend/internal/oauth/oauth2/authz/requestvalidator/validator_test.go
+++ b/backend/internal/oauth/oauth2/authz/requestvalidator/validator_test.go
@@ -88,6 +88,30 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_UnsupportedResponseTyp
 	assert.Equal(suite.T(), constants.ErrorUnsupportedResponseType, errCode)
 }
 
+func (suite *AuthzValidationTestSuite) TestValidateParams_QueryResponseMode() {
+	params := suite.validParams()
+	params[constants.RequestParamResponseMode] = constants.ResponseModeQuery
+
+	errCode, errMsg := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
+
+	assert.Empty(suite.T(), errCode)
+	assert.Empty(suite.T(), errMsg)
+}
+
+func (suite *AuthzValidationTestSuite) TestValidateParams_UnsupportedResponseMode() {
+	for _, responseMode := range []string{"fragment", "form_post"} {
+		suite.T().Run(responseMode, func(t *testing.T) {
+			params := suite.validParams()
+			params[constants.RequestParamResponseMode] = responseMode
+
+			errCode, errMsg := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
+
+			assert.Equal(t, constants.ErrorInvalidRequest, errCode)
+			assert.Equal(t, "Unsupported response_mode parameter", errMsg)
+		})
+	}
+}
+
 func (suite *AuthzValidationTestSuite) TestValidateParams_GrantTypeNotAllowed() {
 	app := &providers.OAuthClient{
 		ClientID:                "test-client-id",

--- a/backend/internal/oauth/oauth2/constants/constants.go
+++ b/backend/internal/oauth/oauth2/constants/constants.go
@@ -43,6 +43,7 @@ const (
 	RequestParamCodeChallengeMethod string = "code_challenge_method"
 	RequestParamRefreshToken        string = "refresh_token"
 	RequestParamResponseType        string = "response_type"
+	RequestParamResponseMode        string = "response_mode"
 	RequestParamState               string = "state"
 	RequestParamIss                 string = "iss"
 	RequestParamResource            string = "resource"
@@ -78,6 +79,16 @@ const (
 const (
 	HeaderDPoP string = "DPoP"
 )
+
+// OAuth2 response modes.
+const (
+	ResponseModeQuery string = "query"
+)
+
+// IsSupportedResponseMode checks if the response mode is supported.
+func IsSupportedResponseMode(responseMode string) bool {
+	return responseMode == "" || responseMode == ResponseModeQuery
+}
 
 // OIDC prompt parameter values.
 const (

--- a/docs/content/guides/guides/protocols/oauth-oidc/authorization-code.mdx
+++ b/docs/content/guides/guides/protocols/oauth-oidc/authorization-code.mdx
@@ -26,6 +26,7 @@ Authorization codes are single-use, bound to the redirect URI and client, and sh
 | Authorization endpoint | `GET /oauth2/authorize` |
 | Token endpoint | `POST /oauth2/token` |
 | Response type | `code` only (implicit and hybrid response types are not supported) |
+| Response mode | `query` only. Omitted `response_mode` defaults to `query`; unsupported values such as `fragment` and `form_post` return `invalid_request` |
 | PKCE | **Required** for public clients (`publicClient: true`); recommended for confidential clients |
 | Redirect URI matching | Exact match against the application's registered `redirect_uris` |
 | Redirect URI at token endpoint | Required only when included in the authorization request ([RFC 6749 §4.1.3](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3)); identical value enforced when present |
@@ -92,6 +93,8 @@ curl -X POST https://{{productSlug}}.example.com/oauth2/token \
   -d "redirect_uri=https://app.example.com/callback" \
   -d "code_verifier=$CODE_VERIFIER"
 ```
+
+The `response_mode` parameter is optional. For `response_type=code`, <ProductName /> uses `query` by default and returns the authorization response in the callback URL query string. Explicit `response_mode=query` is also accepted. Other response modes, such as `fragment` and `form_post`, return `invalid_request`.
 
 Access tokens with permission scopes are bound to one resource server. Send `resource=https://api.example.com/...` on the authorization or token request when the client knows the target API, or configure `defaultResourceServer` for permission-bearing requests that omit `resource`. OIDC-only or scopeless requests without `resource` use the `client_id` audience.
 


### PR DESCRIPTION
### Purpose
ThunderID previously accepted unsupported OAuth `response_mode` values such as `fragment` and `form_post`, but still returned the authorization code in query parameters. This silently downgraded the client-requested response mode.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
Validate `response_mode` during authorization request validation.

- Treat a missing `response_mode` as the default `query` mode.
- Allow explicit `response_mode=query`.
- Reject unsupported response modes such as `fragment` and `form_post` with `invalid_request`.

Now:

query

```
Request:
https://localhost:8090/oauth2/authorize?client_id=19gbJ4xMMMtlvME-cD7jww&redirect_uri=https%3A%2F%2Foidcdebugger.com%2Fdebug&scope=openid%20profile&response_type=code&response_mode=query&code_challenge_method=S256&code_challenge=T7GcE9_-VCCESUmtbD6vrsGXPSoth6vwh81LasrJgos&state=test-query

Response:
https://oidcdebugger.com/debug?code=EHqQNJQb2-aZQjq-uITSMg3srhg&iss=https%3A%2F%2Flocalhost%3A8090&state=test-query

```

fragment

```
Request:
https://localhost:8090/oauth2/authorize?client_id=19gbJ4xMMMtlvME-cD7jww&redirect_uri=https%3A%2F%2Foidcdebugger.com%2Fdebug&scope=openid%20profile&response_type=code&response_mode=fragment&code_challenge_method=S256&code_challenge=T7GcE9_-VCCESUmtbD6vrsGXPSoth6vwh81LasrJgos&state=test-fragment

Response:
https://oidcdebugger.com/debug?error=invalid_request&error_description=Unsupported+response_mode+parameter&iss=https%3A%2F%2Flocalhost%3A8090&state=test-fragment
```

form_post

```
Request:
https://localhost:8090/oauth2/authorize?client_id=19gbJ4xMMMtlvME-cD7jww&redirect_uri=https%3A%2F%2Foidcdebugger.com%2Fdebug&scope=openid%20profile&response_type=code&response_mode=form_post&code_challenge_method=S256&code_challenge=T7GcE9_-VCCESUmtbD6vrsGXPSoth6vwh81LasrJgos&state=test-form-post

Response:
https://oidcdebugger.com/debug?error=invalid_request&error_description=Unsupported+response_mode+parameter&iss=https%3A%2F%2Flocalhost%3A8090&state=test-form-post

```

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3713

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the OAuth 2.0 `response_mode` parameter on authorization requests.
  * Supports `response_mode=query` (omitting it defaults to `query`).
* **Bug Fixes**
  * Rejects unsupported `response_mode` values (e.g., `fragment`, `form_post`) with `invalid_request`.
* **Tests**
  * Added validation tests for supported and unsupported `response_mode` values.
* **Documentation**
  * Updated OpenAPI and OAuth/OIDC authorization-code documentation to describe accepted and rejected `response_mode` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->