### PR TITLE
Improve the end-user flow preview panel

### DIFF
--- a/frontend/apps/console/src/components/GatePreview/IframeContent.tsx
+++ b/frontend/apps/console/src/components/GatePreview/IframeContent.tsx
@@ -29,11 +29,12 @@ import {
   type Stylesheet,
 } from '@thunderid/design';
 import {useTemplateLiteralResolver} from '@thunderid/hooks';
-import type {EmbeddedFlowComponent} from '@thunderid/react';
+import {EmbeddedFlowComponentType, EmbeddedFlowEventType, type EmbeddedFlowComponent} from '@thunderid/react';
 import {TemplateLiteralType} from '@thunderid/utils';
 import {Box, ParticleBackground, useTheme} from '@wso2/oxygen-ui';
 import {useEffect, useMemo, type JSX} from 'react';
 import PreviewThemeProvider from './PreviewThemeProvider';
+import {resolveAnchorActionRef, resolveHoverTarget} from './richTextClickResolution';
 import ElementInspector from '../../features/design/components/layouts/ElementInspector';
 
 /**
@@ -71,32 +72,6 @@ function IframeBodyBackground({iframeDoc}: {iframeDoc: Document}): null {
   }, [iframeDoc, muiTheme]);
 
   return null;
-}
-
-function findComponentById(root: EmbeddedFlowComponent, id: string): EmbeddedFlowComponent | null {
-  if (root.id === id) {
-    return root;
-  }
-  for (const child of root.components ?? []) {
-    const found = findComponentById(child, id);
-    if (found) {
-      return found;
-    }
-  }
-  return null;
-}
-
-/**
- * Resolves the most specific component for a hover/focus event: the gate's
- * button adapters carry their component id in the DOM, so a block with several
- * actions can be previewed per button instead of as one unit.
- */
-function resolveHoverTarget(component: EmbeddedFlowComponent, target: EventTarget | null): EmbeddedFlowComponent {
-  const buttonId = (target as HTMLElement | null)?.closest?.('button')?.id;
-  if (!buttonId) {
-    return component;
-  }
-  return findComponentById(component, buttonId) ?? component;
 }
 
 /** No-op handlers for preview mode — the form is purely visual. */
@@ -276,6 +251,22 @@ export default function IframeContent({
                         onMouseLeave={() => onComponentHover(null)}
                         onFocus={(event) => onComponentHover(resolveHoverTarget(component, event.target))}
                         onBlur={() => onComponentHover(null)}
+                        onClick={(event) => {
+                          // Only handle wired rich-text links; buttons dispatch through
+                          // their own handler. Prevent the decorative `href="#"` from
+                          // scrolling the iframe.
+                          const actionRef = resolveAnchorActionRef(event.target);
+                          if (actionRef === null) {
+                            return;
+                          }
+                          event.preventDefault();
+                          onSubmit?.({
+                            eventType: EmbeddedFlowEventType.Trigger,
+                            id: actionRef,
+                            ref: actionRef,
+                            type: EmbeddedFlowComponentType.Action,
+                          } as EmbeddedFlowComponent);
+                        }}
                       >
                         {renderer}
                       </Box>

--- a/frontend/apps/console/src/components/GatePreview/__tests__/richTextClickResolution.test.ts
+++ b/frontend/apps/console/src/components/GatePreview/__tests__/richTextClickResolution.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {EmbeddedFlowComponent} from '@thunderid/react';
+import {describe, expect, it} from 'vitest';
+import {findComponentById, resolveAnchorActionRef, resolveHoverTarget} from '../richTextClickResolution';
+
+/**
+ * These target `EventTarget | null`, matching the real DOM events the preview's
+ * iframe delivers; unlike `instanceof Element` checks, plain DOM elements
+ * created via `document.createElement` here behave identically to elements from
+ * another realm (e.g. an iframe), which is the whole point of these helpers.
+ */
+describe('findComponentById', () => {
+  const tree: EmbeddedFlowComponent = {
+    id: 'root',
+    components: [
+      {id: 'child-a'} as EmbeddedFlowComponent,
+      {id: 'child-b', components: [{id: 'grandchild'} as EmbeddedFlowComponent]} as EmbeddedFlowComponent,
+    ],
+  } as EmbeddedFlowComponent;
+
+  it('should return the root when its id matches', () => {
+    expect(findComponentById(tree, 'root')).toBe(tree);
+  });
+
+  it('should find a nested component by id', () => {
+    expect(findComponentById(tree, 'grandchild')).toEqual({id: 'grandchild'});
+  });
+
+  it('should return null when no component matches', () => {
+    expect(findComponentById(tree, 'missing')).toBeNull();
+  });
+});
+
+describe('resolveAnchorActionRef', () => {
+  it('should read data-action-ref from the clicked anchor', () => {
+    const anchor = document.createElement('a');
+    anchor.setAttribute('data-action-ref', 'action_recovery');
+    document.body.appendChild(anchor);
+
+    expect(resolveAnchorActionRef(anchor)).toBe('action_recovery');
+
+    document.body.removeChild(anchor);
+  });
+
+  it('should resolve through a nested click target via closest', () => {
+    const anchor = document.createElement('a');
+    anchor.setAttribute('data-action-ref', 'action_recovery');
+    const span = document.createElement('span');
+    anchor.appendChild(span);
+    document.body.appendChild(anchor);
+
+    expect(resolveAnchorActionRef(span)).toBe('action_recovery');
+
+    document.body.removeChild(anchor);
+  });
+
+  it('should return null when the target is not inside an anchor', () => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+
+    expect(resolveAnchorActionRef(div)).toBeNull();
+
+    document.body.removeChild(div);
+  });
+
+  it('should return null when the anchor has no data-action-ref', () => {
+    const anchor = document.createElement('a');
+    document.body.appendChild(anchor);
+
+    expect(resolveAnchorActionRef(anchor)).toBeNull();
+
+    document.body.removeChild(anchor);
+  });
+
+  it('should fall back to parentElement for a target without closest (e.g. a text node)', () => {
+    const anchor = document.createElement('a');
+    anchor.setAttribute('data-action-ref', 'action_recovery');
+    const text = document.createTextNode('Reset');
+    anchor.appendChild(text);
+    document.body.appendChild(anchor);
+
+    expect(resolveAnchorActionRef(text)).toBe('action_recovery');
+
+    document.body.removeChild(anchor);
+  });
+
+  it('should return null for a null target', () => {
+    expect(resolveAnchorActionRef(null)).toBeNull();
+  });
+});
+
+describe('resolveHoverTarget', () => {
+  const component: EmbeddedFlowComponent = {
+    id: 'block_001',
+    components: [{id: 'action_001'} as EmbeddedFlowComponent],
+  } as EmbeddedFlowComponent;
+
+  it('should resolve to the specific button component under the pointer', () => {
+    const button = document.createElement('button');
+    button.id = 'action_001';
+    document.body.appendChild(button);
+
+    expect(resolveHoverTarget(component, button)).toEqual({id: 'action_001'});
+
+    document.body.removeChild(button);
+  });
+
+  it('should resolve to a synthetic component carrying the anchor action ref', () => {
+    const anchor = document.createElement('a');
+    anchor.setAttribute('data-action-ref', 'action_recovery');
+    document.body.appendChild(anchor);
+
+    expect(resolveHoverTarget(component, anchor)).toEqual({id: 'action_recovery'});
+
+    document.body.removeChild(anchor);
+  });
+
+  it('should fall back to the whole component when neither a button nor a wired anchor is hovered', () => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+
+    expect(resolveHoverTarget(component, div)).toBe(component);
+
+    document.body.removeChild(div);
+  });
+});

--- a/frontend/apps/console/src/components/GatePreview/mocks/__tests__/buildPreviewMock.test.ts
+++ b/frontend/apps/console/src/components/GatePreview/mocks/__tests__/buildPreviewMock.test.ts
@@ -22,8 +22,19 @@ import buildPreviewMock from '../buildPreviewMock';
 
 type MockComponent = Record<string, unknown>;
 
-const getComponentById = (components: MockComponent[], id: string): MockComponent | undefined =>
-  components.find((c) => c.id === id);
+const getComponentById = (components: MockComponent[], id: string): MockComponent | undefined => {
+  for (const component of components) {
+    if (component.id === id) {
+      return component;
+    }
+    const nested = component.components as MockComponent[] | undefined;
+    const found = nested && getComponentById(nested, id);
+    if (found) {
+      return found;
+    }
+  }
+  return undefined;
+};
 
 describe('buildPreviewMock', () => {
   describe('Always-present components', () => {

--- a/frontend/apps/console/src/components/GatePreview/mocks/buildPreviewMock.ts
+++ b/frontend/apps/console/src/components/GatePreview/mocks/buildPreviewMock.ts
@@ -71,16 +71,25 @@ export default function buildPreviewMock(
 
   const components: Record<string, unknown>[] = [];
 
-  // App Logo
+  // App Logo — wrapped in a STACK so it centers via the SDK's container-driven
+  // alignment (StackAdapter defaults alignItems: 'center'), like the real gate.
   components.push({
-    alt: '',
     category: 'DISPLAY',
-    id: 'app_logo',
+    components: [
+      {
+        alt: '',
+        category: 'DISPLAY',
+        id: 'app_logo',
+        resourceType: 'ELEMENT',
+        src: meta?.application?.logoUrl ?? '',
+        type: 'IMAGE',
+        width: '60',
+        height: '60',
+      },
+    ],
+    id: 'app_logo_stack',
     resourceType: 'ELEMENT',
-    src: meta?.application?.logoUrl ?? '',
-    type: 'IMAGE',
-    width: '60',
-    height: '60',
+    type: 'STACK',
   });
 
   // Heading

--- a/frontend/apps/console/src/components/GatePreview/richTextClickResolution.ts
+++ b/frontend/apps/console/src/components/GatePreview/richTextClickResolution.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {EmbeddedFlowComponent} from '@thunderid/react';
+
+/**
+ * Finds a component by id within the mock component tree (including nested
+ * `components`).
+ */
+export function findComponentById(root: EmbeddedFlowComponent, id: string): EmbeddedFlowComponent | null {
+  if (root.id === id) {
+    return root;
+  }
+  for (const child of root.components ?? []) {
+    const found = findComponentById(child, id);
+    if (found) {
+      return found;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolves the wired action ref for a click that landed on a rich-text link.
+ * The preview renders inside an iframe, so the SDK's own anchor handler, which
+ * gates on `instanceof Element`, silently bails (the anchor belongs to the
+ * iframe's realm, not the host bundle's). We compensate here using the
+ * `data-action-ref` the renderer stamps on wired anchors — realm-safe because it
+ * only calls DOM methods on the element, never an `instanceof` check.
+ */
+export function resolveAnchorActionRef(target: EventTarget | null): string | null {
+  // Click targets are elements, but fall back to `parentElement` defensively for
+  // any node that lacks `closest` (e.g. an SVG glyph inside the link). Both are
+  // realm-safe DOM lookups — no `instanceof`.
+  const node = target as (Element & {parentElement: HTMLElement | null}) | null;
+  const element = typeof node?.closest === 'function' ? node : (node?.parentElement ?? null);
+  return element?.closest('a')?.getAttribute('data-action-ref') ?? null;
+}
+
+/**
+ * Resolves the most specific component for a hover/focus event: the gate's
+ * button adapters carry their component id in the DOM, so a block with several
+ * actions can be previewed per button instead of as one unit. A hovered
+ * rich-text link is resolved the same way the click handler resolves it — via
+ * its `data-action-ref` — as a synthetic component carrying just that ref, so a
+ * link sharing a container with another wired component (e.g. a button) always
+ * previews its own transition rather than whichever option the subtree search
+ * happens to find first.
+ */
+export function resolveHoverTarget(
+  component: EmbeddedFlowComponent,
+  target: EventTarget | null,
+): EmbeddedFlowComponent {
+  const buttonId = (target as HTMLElement | null)?.closest?.('button')?.id;
+  if (buttonId) {
+    return findComponentById(component, buttonId) ?? component;
+  }
+  const anchorRef = resolveAnchorActionRef(target);
+  if (anchorRef) {
+    return {id: anchorRef} as EmbeddedFlowComponent;
+  }
+  return component;
+}

--- a/frontend/apps/console/src/features/flows/components/visual-flow/SimulationOptionsFooter.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/SimulationOptionsFooter.tsx
@@ -20,7 +20,7 @@ import {useTemplateLiteralResolver} from '@thunderid/hooks';
 import {Box, Button, Stack, Typography} from '@wso2/oxygen-ui';
 import {ArrowRight, CheckCircle, CircleAlert, CircleX, MousePointerClick} from '@wso2/oxygen-ui-icons-react';
 import DOMPurify from 'dompurify';
-import type {ReactElement} from 'react';
+import type {ReactElement, Ref} from 'react';
 import {useTranslation} from 'react-i18next';
 import {KIND_COLORS, KIND_LABEL_FALLBACKS, KIND_LABEL_KEYS} from '../../constants/simulationPreviewConstants';
 import {SimulationOptionKinds, type SimulationOption} from '../../utils/getSimulationOptions';
@@ -57,6 +57,15 @@ export interface SimulationOptionsFooterProps {
    * Previews the given transition on the canvas (null clears the preview).
    */
   onPreview: (option: SimulationOption | null) => void;
+  /**
+   * Where the options sit in the panel. Background steps render them at the
+   * top (divider below, free height); screen steps keep them at the bottom.
+   */
+  placement?: 'top' | 'bottom';
+  /**
+   * Ref to the footer's root element (used by the panel's keyboard navigation).
+   */
+  rootRef?: Ref<HTMLDivElement>;
 }
 
 /**
@@ -73,6 +82,8 @@ function SimulationOptionsFooter({
   hasScreenOptions,
   onChoose,
   onPreview,
+  placement = 'bottom',
+  rootRef = undefined,
 }: SimulationOptionsFooterProps): ReactElement | null {
   const {t} = useTranslation();
   const {resolveAll} = useTemplateLiteralResolver();
@@ -95,15 +106,14 @@ function SimulationOptionsFooter({
 
   return (
     <Box
+      ref={rootRef}
       data-testid="simulation-preview-footer"
       sx={{
-        borderTop: '1px solid',
-        borderColor: 'divider',
         px: 0.5,
         py: 1.25,
         flexShrink: 0,
-        maxHeight: '45%',
         overflow: 'auto',
+        ...(placement === 'bottom' && {borderTop: '1px solid', borderColor: 'divider', maxHeight: '45%'}),
       }}
     >
       {isComplete && (

--- a/frontend/apps/console/src/features/flows/components/visual-flow/SimulationScreenSketch.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/SimulationScreenSketch.tsx
@@ -20,7 +20,7 @@ import {useTemplateLiteralResolver} from '@thunderid/hooks';
 import {Box, Button, Checkbox, Divider, FormControlLabel, Stack, TextField, Typography} from '@wso2/oxygen-ui';
 import {ImageIcon, Workflow} from '@wso2/oxygen-ui-icons-react';
 import DOMPurify from 'dompurify';
-import {Fragment, type ReactElement, type ReactNode} from 'react';
+import {Fragment, type MouseEvent, type ReactElement, type ReactNode} from 'react';
 import {useTranslation} from 'react-i18next';
 import {GATE_CARD_WIDTH, SKETCH_TEXT_INPUT_TYPES, SKETCH_ZOOM} from '../../constants/simulationPreviewConstants';
 import {VARIANT_TO_MUI_MAP} from '../../constants/typographyVariantMaps';
@@ -88,12 +88,59 @@ function SimulationScreenSketch({components, options, onChoose, onPreview}: Simu
       case ElementTypes.RichText: {
         // Mirrors RichTextAdapter: resolve templates, then render sanitized HTML.
         const raw = component.label ?? '';
+
+        // A rich text can carry more than one anchor (e.g. a plain "Terms" link
+        // next to a wired "Reset" link) — resolve the option from the specific
+        // anchor interacted with, not from the whole component, so clicking an
+        // unrelated anchor cannot fire the wired transition. This mirrors the
+        // SDK's own RichTextAdapter: when any anchor in the container carries
+        // `data-action-ref` (the sentinel, stamped at save time on the wired
+        // anchor — see reactFlowTransformer), the clicked anchor's own ref must
+        // match an option's `edgeId`. Only when NO anchor carries the attribute
+        // at all (hand-authored content predating the convention, with a single
+        // wired link) does any anchor click fall back to the component-level
+        // match — safe there because there is no other anchor it could be.
+        const resolveAnchorOption = (
+          container: HTMLElement,
+          target: EventTarget | null,
+        ): SimulationOption | undefined => {
+          const anchor = target instanceof HTMLElement ? target.closest('a') : null;
+          if (!anchor) {
+            return undefined;
+          }
+          const hasSentinel = container.querySelector('a[data-action-ref]') !== null;
+          if (hasSentinel) {
+            const actionRef = anchor.getAttribute('data-action-ref');
+            return actionRef
+              ? options.find((candidate: SimulationOption) => candidate.edgeId === actionRef)
+              : undefined;
+          }
+          return findOption(component.id);
+        };
+
         return (
           <Typography
             component="div"
             variant="body2"
             align={component.align ?? 'left'}
-            sx={{'& a': {color: 'primary.main'}, '& p': {m: 0}}}
+            // A wired rich text (e.g. a sign-up link) follows its transition when
+            // the embedded link is clicked, like in the real gate. Unwired
+            // anchors are neutralized - the sketch must never navigate away.
+            onClick={(event: MouseEvent<HTMLElement>) => {
+              if (!(event.target instanceof HTMLElement) || !event.target.closest('a')) {
+                return;
+              }
+              event.preventDefault();
+              const option = resolveAnchorOption(event.currentTarget, event.target);
+              if (option) {
+                onChoose(option);
+              }
+            }}
+            onMouseOver={(event: MouseEvent<HTMLElement>) =>
+              onPreview(resolveAnchorOption(event.currentTarget, event.target) ?? null)
+            }
+            onMouseLeave={() => onPreview(null)}
+            sx={{'& a': {color: 'primary.main', cursor: 'pointer'}, '& p': {m: 0}}}
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{
               __html: DOMPurify.sanitize(resolveAll(raw, {t}) ?? raw, {

--- a/frontend/apps/console/src/features/flows/components/visual-flow/SimulationStepPreview.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/SimulationStepPreview.tsx
@@ -42,10 +42,11 @@ import {
   Smartphone,
   Sun,
   Tablet,
+  Workflow,
   X,
 } from '@wso2/oxygen-ui-icons-react';
 import type {Node} from '@xyflow/react';
-import {useCallback, useMemo, useState, type ReactElement} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState, type ReactElement} from 'react';
 import {useTranslation} from 'react-i18next';
 import SimulationOptionsFooter from './SimulationOptionsFooter';
 import SimulationScreenSketch from './SimulationScreenSketch';
@@ -53,6 +54,8 @@ import {
   DEVICE_ASPECT_RATIOS,
   DEVICE_LABEL_FALLBACKS,
   GATE_DEFAULT_THEME,
+  PREVIEW_APP_STORAGE_KEY,
+  PREVIEW_DEVICE_STORAGE_KEY,
   PREVIEW_DEVICES,
   type PreviewDevice,
 } from '../../constants/simulationPreviewConstants';
@@ -64,6 +67,7 @@ import {
   resolveTemplatesDeep,
   withDerivedEventTypes,
   withDynamicFieldStandIns,
+  withRichTextActionRefs,
   type PreviewComponent,
 } from '../../utils/gatePreviewTransforms';
 import type {SimulationOption} from '../../utils/getSimulationOptions';
@@ -94,13 +98,33 @@ export interface SimulationStepPreviewProps {
  * @param props - Props injected to the component.
  * @returns The SimulationStepPreview component.
  */
+const readStored = (key: string): string | null => {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+};
+
+const writeStored = (key: string, value: string): void => {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // Persistence is best-effort (e.g. blocked storage access).
+  }
+};
+
 export default function SimulationStepPreview({node, simulation}: SimulationStepPreviewProps): ReactElement | null {
   const {t} = useTranslation();
   const {resolveAll} = useTemplateLiteralResolver();
   const {mode, systemMode} = useColorScheme();
   const consoleScheme: 'light' | 'dark' = (mode === 'system' ? systemMode : mode) === 'dark' ? 'dark' : 'light';
-  const [selectedAppId, setSelectedAppId] = useState<string>('');
-  const [device, setDevice] = useState<PreviewDevice>('mobile');
+  // Device and application picks persist across preview sessions.
+  const [selectedAppId, setSelectedAppId] = useState<string>(() => readStored(PREVIEW_APP_STORAGE_KEY) ?? '');
+  const [device, setDevice] = useState<PreviewDevice>(() => {
+    const stored = readStored(PREVIEW_DEVICE_STORAGE_KEY);
+    return stored && (PREVIEW_DEVICES as readonly string[]).includes(stored) ? (stored as PreviewDevice) : 'mobile';
+  });
   const [previewColorScheme, setPreviewColorScheme] = useState<'light' | 'dark'>(consoleScheme);
 
   const {data: applicationsData} = useGetApplications();
@@ -111,7 +135,8 @@ export default function SimulationStepPreview({node, simulation}: SimulationStep
     () => applications.find((application: BasicApplication) => application.name === 'Console')?.id ?? '',
     [applications],
   );
-  const effectiveAppId = selectedAppId || defaultAppId;
+  const isKnownApp = applications.some((application: BasicApplication) => application.id === selectedAppId);
+  const effectiveAppId = selectedAppId && isKnownApp ? selectedAppId : defaultAppId;
   const {data: selectedApplication} = useGetApplication(effectiveAppId);
   // The gate's own design resolution for the application. Responds 404 when the
   // application has no design configured at all — the gate then falls back to
@@ -126,13 +151,17 @@ export default function SimulationStepPreview({node, simulation}: SimulationStep
     [node?.data],
   );
 
-  // Action components rendered inside the screen — options wired to these are
-  // triggerable by clicking the screen itself, so they are left out of the footer.
-  const screenActionIds = useMemo(() => {
+  // Interactive components rendered inside the screen (buttons, resend actions,
+  // rich-text links) — options wired to these are triggerable by clicking the
+  // screen itself, so they are left out of the footer to avoid duplication.
+  // Deliberately restricted to types both renderers make clickable: an option
+  // wired to anything else stays in the footer so its path remains reachable.
+  const screenComponentIds = useMemo(() => {
+    const triggerableTypes = new Set<string>([ElementTypes.Action, ElementTypes.Resend, ElementTypes.RichText]);
     const ids = new Set<string>();
     const collect = (list: PreviewComponent[]): void => {
       list.forEach((component: PreviewComponent) => {
-        if (component.type === ElementTypes.Action || component.type === ElementTypes.Resend) {
+        if (triggerableTypes.has(component.type)) {
           ids.add(component.id);
         }
         if (component.components?.length) {
@@ -197,64 +226,154 @@ export default function SimulationStepPreview({node, simulation}: SimulationStep
   // i18n templates resolved into the step components, rendered by the real gate
   // renderer. resolveAll handles mixed content (e.g. rich text HTML containing
   // several templates) — resolve() would drop everything after the first one.
+  // Maps each wired component id to its edge id (the SDK action ref) so rich-text
+  // links can have their `action.ref` re-attached for the gate renderer.
+  const refByComponentId = useMemo(() => {
+    const map = new Map<string, string>();
+    simulation.options.forEach((option: SimulationOption) => {
+      if (option.sourceComponentId) {
+        map.set(option.sourceComponentId, option.edgeId);
+      }
+    });
+    return map;
+  }, [simulation.options]);
+
   const themedComponents: EmbeddedFlowComponent[] = useMemo(
     () =>
       selectedApplication
         ? (resolveTemplatesDeep(
             resolveApplicationMeta(
-              withDerivedEventTypes(
-                withDynamicFieldStandIns(
-                  components,
-                  t('flows:core.simulation.preview.dynamicFieldsHint', 'Input fields resolved at runtime'),
+              withRichTextActionRefs(
+                withDerivedEventTypes(
+                  withDynamicFieldStandIns(
+                    components,
+                    t('flows:core.simulation.preview.dynamicFieldsHint', 'Input fields resolved at runtime'),
+                  ),
                 ),
+                refByComponentId,
               ),
               selectedApplication,
             ),
             (raw: string) => resolveAll(raw, {t}) ?? raw,
           ) as EmbeddedFlowComponent[])
         : [],
-    [components, selectedApplication, resolveAll, t],
+    [components, selectedApplication, resolveAll, t, refByComponentId],
   );
 
   // Depend on the stable members, not the aggregate object — new handler
   // identities would reconcile the whole iframe subtree on every state change.
   const {options: simulationOptions, choose: chooseOption, preview: previewOption} = simulation;
 
-  const handleGateSubmit = useCallback(
-    (component: EmbeddedFlowComponent): void => {
-      const option = simulationOptions.find(
-        (candidate: SimulationOption) => candidate.sourceComponentId === component.id,
-      );
-      if (option) {
-        chooseOption(option);
-      }
-    },
-    [simulationOptions, chooseOption],
-  );
-
-  // Hovering a component inside the themed screen previews the edge of the first
-  // wired action in that component's subtree (e.g. a social login block's button).
-  const handleGateHover = useCallback(
-    (component: EmbeddedFlowComponent | null): void => {
-      if (!component) {
-        previewOption(null);
-        return;
-      }
-      const subtreeIds = new Set<string>();
+  // Both gate handlers resolve the first wired option in the reported
+  // component's subtree — the gate may report a container (e.g. a social login
+  // block) rather than the wired child itself.
+  //
+  // Rich-text links are reported as a synthetic action whose id is the
+  // component's `action.ref`. That ref is also the edge id (and therefore the
+  // option's `edgeId`), so options are matched on `sourceComponentId` OR
+  // `edgeId` — the latter covers link clicks without depending on the loaded
+  // component still carrying its `action.ref`.
+  const findWiredOption = useCallback(
+    (component: EmbeddedFlowComponent): SimulationOption | undefined => {
+      const candidateIds = new Set<string>();
       const collect = (current: EmbeddedFlowComponent): void => {
         if (current.id) {
-          subtreeIds.add(current.id);
+          candidateIds.add(current.id);
         }
         current.components?.forEach(collect);
       };
       collect(component);
-      const option = simulationOptions.find(
-        (candidate: SimulationOption) => candidate.sourceComponentId && subtreeIds.has(candidate.sourceComponentId),
+      return simulationOptions.find(
+        (candidate: SimulationOption) =>
+          candidateIds.has(candidate.edgeId) ||
+          (candidate.sourceComponentId !== undefined && candidateIds.has(candidate.sourceComponentId)),
       );
-      previewOption(option ?? null);
     },
-    [simulationOptions, previewOption],
+    [simulationOptions],
   );
+
+  const handleGateSubmit = useCallback(
+    (component: EmbeddedFlowComponent): void => {
+      const option = findWiredOption(component);
+      if (option) {
+        chooseOption(option);
+      }
+    },
+    [findWiredOption, chooseOption],
+  );
+
+  const handleGateHover = useCallback(
+    (component: EmbeddedFlowComponent | null): void => {
+      previewOption(component ? (findWiredOption(component) ?? null) : null);
+    },
+    [findWiredOption, previewOption],
+  );
+
+  const footerRef = useRef<HTMLDivElement | null>(null);
+
+  // Keyboard support while the preview is open: Escape exits, Backspace steps
+  // back, ArrowUp/ArrowDown walk the transition options (a focused option is
+  // previewed via its own focus handler; Enter activates it natively). Keys are
+  // ignored while typing in an input, and cannot reach here while focus is
+  // inside the themed gate's iframe (keydown does not cross the frame boundary).
+  //
+  // stop/back are read through refs, kept fresh every render, so the listener
+  // effect below only depends on `isSimulating` — attaching/detaching the
+  // window listener on preview start/stop, not on every step (stop/back's
+  // identity changes every step because it closes over the traversal path).
+  const {isSimulating} = simulation;
+  const stopRef = useRef(simulation.stop);
+  const backRef = useRef(simulation.back);
+  useEffect(() => {
+    stopRef.current = simulation.stop;
+  }, [simulation.stop]);
+  useEffect(() => {
+    backRef.current = simulation.back;
+  }, [simulation.back]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (!isSimulating) {
+        return;
+      }
+      const target = event.target instanceof HTMLElement ? event.target : null;
+      if (target?.closest('input, textarea, select, [contenteditable="true"]')) {
+        return;
+      }
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        stopRef.current();
+        return;
+      }
+      if (event.key === 'Backspace') {
+        event.preventDefault();
+        backRef.current();
+        return;
+      }
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        const footer = footerRef.current;
+        const optionButtons = footer
+          ? Array.from(footer.querySelectorAll<HTMLButtonElement>('button:not([disabled])'))
+          : [];
+        if (optionButtons.length === 0) {
+          return;
+        }
+        event.preventDefault();
+        const activeIndex = optionButtons.findIndex((button) => button === document.activeElement);
+        const delta = event.key === 'ArrowDown' ? 1 : -1;
+        const nextIndex =
+          activeIndex === -1
+            ? delta === 1
+              ? 0
+              : optionButtons.length - 1
+            : (activeIndex + delta + optionButtons.length) % optionButtons.length;
+        optionButtons[nextIndex].focus();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isSimulating]);
 
   if (!simulation.isSimulating || !node) {
     return null;
@@ -273,14 +392,42 @@ export default function SimulationStepPreview({node, simulation}: SimulationStep
   // Requires the loaded application (not just its id) — while the fetch is
   // pending or failed, the themed screen would render an empty card while the
   // footer still hides its screen-wired actions, stranding the walk.
-  const isThemedPreview = Boolean(effectiveAppId && selectedApplication && components.length > 0);
+  // Background steps (no screen components) get no preview chrome at all: the
+  // device frame, device toggles, and application selector only make sense when
+  // there is a screen to render.
+  const hasScreen = components.length > 0;
+
+  // Start and End are structural markers, not background work - the hint card
+  // would only add noise there.
+  const nodeType = node?.type?.toUpperCase() ?? '';
+  const showBackgroundStepCard = !hasScreen && nodeType !== 'START' && nodeType !== 'END';
+
+  // Identify the background step in the hint card: prefer the executor's
+  // display label, then the executor name; Call steps invoke another flow.
+  const backgroundStepData = node?.data as
+    | {display?: {label?: string}; action?: {executor?: {name?: string}}}
+    | undefined;
+  const backgroundStepLabel =
+    backgroundStepData?.display?.label ??
+    backgroundStepData?.action?.executor?.name ??
+    (nodeType === 'CALL' ? t('flows:core.simulation.preview.callStepLabel', 'Calls another flow') : undefined);
+  const isThemedPreview = Boolean(effectiveAppId && selectedApplication && hasScreen);
 
   const isComplete = simulation.options.length === 0;
   const canGoBack = simulation.pathNodeIds.length > 1;
+
   const footerOptions = simulation.options.filter(
-    (option: SimulationOption) => !(option.sourceComponentId && screenActionIds.has(option.sourceComponentId)),
+    (option: SimulationOption) => !(option.sourceComponentId && screenComponentIds.has(option.sourceComponentId)),
   );
   const hasScreenOptions = footerOptions.length < simulation.options.length;
+
+  const footerProps = {
+    options: footerOptions,
+    isComplete,
+    hasScreenOptions,
+    onChoose: chooseOption,
+    onPreview: previewOption,
+  };
 
   const deviceIcon = (previewDevice: PreviewDevice): ReactElement => {
     if (previewDevice === 'mobile') return <Smartphone size={14} />;
@@ -372,138 +519,190 @@ export default function SimulationStepPreview({node, simulation}: SimulationStep
         data-device={device}
         sx={{flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column'}}
       >
-        <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{px: 0.5, py: 1, flexShrink: 0}}>
-          <Stack direction="row" spacing={0.25}>
-            {PREVIEW_DEVICES.map((previewDevice: PreviewDevice) => (
-              <Tooltip
-                key={previewDevice}
-                title={t(
-                  `flows:core.simulation.preview.devices.${previewDevice}`,
-                  DEVICE_LABEL_FALLBACKS[previewDevice],
-                )}
+        {!hasScreen && (
+          <Stack spacing={0.5} sx={{pt: 0.5}}>
+            <SimulationOptionsFooter {...footerProps} placement="top" rootRef={footerRef} />
+            {showBackgroundStepCard && (
+              <Stack
+                direction="row"
+                spacing={1.25}
+                alignItems="flex-start"
+                data-testid="simulation-background-step"
+                sx={{
+                  mx: 0.5,
+                  px: 1.5,
+                  py: 1.25,
+                  borderRadius: 1.5,
+                  bgcolor: 'action.hover',
+                  color: 'text.secondary',
+                }}
               >
-                <IconButton
-                  size="small"
-                  onClick={() => setDevice(previewDevice)}
-                  aria-label={t(
+                <Box sx={{display: 'inline-flex', flexShrink: 0, mt: '2px'}}>
+                  <Workflow size={16} />
+                </Box>
+                <Box>
+                  <Typography variant="body2" color="text.primary">
+                    {backgroundStepLabel ??
+                      t('flows:core.simulation.preview.noScreen', 'No screen is shown for this step')}
+                  </Typography>
+                  <Typography variant="caption">
+                    {node?.id
+                      ? t(
+                          'flows:core.simulation.preview.noScreenHintNamed',
+                          '{{id}} runs in the background before the flow continues',
+                          {id: node.id},
+                        )
+                      : t(
+                          'flows:core.simulation.preview.noScreenHint',
+                          'This step runs in the background before the flow continues',
+                        )}
+                  </Typography>
+                </Box>
+              </Stack>
+            )}
+          </Stack>
+        )}
+
+        {hasScreen && (
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+            sx={{px: 0.5, py: 1, flexShrink: 0}}
+          >
+            <Stack direction="row" spacing={0.25}>
+              {PREVIEW_DEVICES.map((previewDevice: PreviewDevice) => (
+                <Tooltip
+                  key={previewDevice}
+                  title={t(
                     `flows:core.simulation.preview.devices.${previewDevice}`,
                     DEVICE_LABEL_FALLBACKS[previewDevice],
                   )}
-                  aria-pressed={device === previewDevice}
-                  sx={{
-                    borderRadius: 1,
-                    color: device === previewDevice ? 'primary.main' : 'text.secondary',
-                    bgcolor: device === previewDevice ? 'action.selected' : 'transparent',
-                  }}
-                >
-                  {deviceIcon(previewDevice)}
-                </IconButton>
-              </Tooltip>
-            ))}
-            {isThemedPreview && (
-              <>
-                <Box sx={{width: '1px', height: 16, bgcolor: 'divider', mx: 0.5, alignSelf: 'center'}} />
-                <Tooltip
-                  title={
-                    previewColorScheme === 'dark'
-                      ? t('flows:core.simulation.preview.lightMode', 'Switch to light preview')
-                      : t('flows:core.simulation.preview.darkMode', 'Switch to dark preview')
-                  }
                 >
                   <IconButton
                     size="small"
-                    onClick={() =>
-                      setPreviewColorScheme((prev: 'light' | 'dark') => (prev === 'dark' ? 'light' : 'dark'))
-                    }
-                    aria-label={
+                    onClick={() => {
+                      setDevice(previewDevice);
+                      writeStored(PREVIEW_DEVICE_STORAGE_KEY, previewDevice);
+                    }}
+                    aria-label={t(
+                      `flows:core.simulation.preview.devices.${previewDevice}`,
+                      DEVICE_LABEL_FALLBACKS[previewDevice],
+                    )}
+                    aria-pressed={device === previewDevice}
+                    sx={{
+                      borderRadius: 1,
+                      color: device === previewDevice ? 'primary.main' : 'text.secondary',
+                      bgcolor: device === previewDevice ? 'action.selected' : 'transparent',
+                    }}
+                  >
+                    {deviceIcon(previewDevice)}
+                  </IconButton>
+                </Tooltip>
+              ))}
+              {isThemedPreview && (
+                <>
+                  <Box sx={{width: '1px', height: 16, bgcolor: 'divider', mx: 0.5, alignSelf: 'center'}} />
+                  <Tooltip
+                    title={
                       previewColorScheme === 'dark'
                         ? t('flows:core.simulation.preview.lightMode', 'Switch to light preview')
                         : t('flows:core.simulation.preview.darkMode', 'Switch to dark preview')
                     }
-                    sx={{borderRadius: 1, color: 'text.secondary'}}
                   >
-                    {previewColorScheme === 'dark' ? <Sun size={14} /> : <Moon size={14} />}
-                  </IconButton>
-                </Tooltip>
-              </>
-            )}
-          </Stack>
-          <TextField
-            select
-            size="small"
-            label={t('flows:core.simulation.preview.applicationLabel', 'Preview as application')}
-            value={effectiveAppId}
-            onChange={(event) => setSelectedAppId(event.target.value)}
-            sx={{
-              minWidth: 180,
-            }}
-            slotProps={{
-              inputLabel: {shrink: true},
-              input: {
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <AppWindow size={14} />
-                  </InputAdornment>
-                ),
-              },
-            }}
-          >
-            {applications.map((application: BasicApplication) => (
-              <MenuItem key={application.id} value={application.id}>
-                {application.name}
-              </MenuItem>
-            ))}
-          </TextField>
-        </Stack>
-
-        {isThemedPreview ? (
-          <Box sx={{flex: 1, minHeight: 0, overflow: 'auto'}}>
-            <Box
+                    <IconButton
+                      size="small"
+                      onClick={() =>
+                        setPreviewColorScheme((prev: 'light' | 'dark') => (prev === 'dark' ? 'light' : 'dark'))
+                      }
+                      aria-label={
+                        previewColorScheme === 'dark'
+                          ? t('flows:core.simulation.preview.lightMode', 'Switch to light preview')
+                          : t('flows:core.simulation.preview.darkMode', 'Switch to dark preview')
+                      }
+                      sx={{borderRadius: 1, color: 'text.secondary'}}
+                    >
+                      {previewColorScheme === 'dark' ? <Sun size={14} /> : <Moon size={14} />}
+                    </IconButton>
+                  </Tooltip>
+                </>
+              )}
+            </Stack>
+            <TextField
+              select
+              size="small"
+              label={t('flows:core.simulation.preview.applicationLabel', 'Preview as application')}
+              value={effectiveAppId}
+              onChange={(event) => {
+                setSelectedAppId(event.target.value);
+                writeStored(PREVIEW_APP_STORAGE_KEY, event.target.value);
+              }}
               sx={{
-                width: '100%',
-                aspectRatio: DEVICE_ASPECT_RATIOS[device],
-                border: '1px solid',
-                borderColor: 'divider',
-                borderRadius: 1,
-                overflow: 'hidden',
+                minWidth: 180,
+              }}
+              slotProps={{
+                inputLabel: {shrink: true},
+                input: {
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <AppWindow size={14} />
+                    </InputAdornment>
+                  ),
+                },
               }}
             >
-              <GatePreview
-                frameless
-                theme={theme}
-                // The gate merges resolved designs over its default theme and shows
-                // its default branding when no design is configured — mirror both.
-                baseTheme={DefaultTheme as Theme}
-                themelessBranding
-                displayName={selectedApplication?.name ?? ''}
-                showToolbar={false}
-                colorScheme={previewColorScheme}
-                mock={themedComponents}
-                stylesheets={resolvedDesign?.layout?.head?.stylesheets ?? []}
-                onSubmit={handleGateSubmit}
-                onComponentHover={handleGateHover}
-                additionalData={gateAdditionalData}
-              />
-            </Box>
-          </Box>
-        ) : (
-          <Box sx={{flex: 1, minHeight: 0, overflow: 'auto', display: 'flex', justifyContent: 'center', py: 1}}>
-            <SimulationScreenSketch
-              components={components}
-              options={simulationOptions}
-              onChoose={chooseOption}
-              onPreview={previewOption}
-            />
-          </Box>
+              {applications.map((application: BasicApplication) => (
+                <MenuItem key={application.id} value={application.id}>
+                  {application.name}
+                </MenuItem>
+              ))}
+            </TextField>
+          </Stack>
         )}
 
-        <SimulationOptionsFooter
-          options={footerOptions}
-          isComplete={isComplete}
-          hasScreenOptions={hasScreenOptions}
-          onChoose={chooseOption}
-          onPreview={previewOption}
-        />
+        {hasScreen &&
+          (isThemedPreview ? (
+            <Box sx={{flex: 1, minHeight: 0, overflow: 'auto'}}>
+              <Box
+                sx={{
+                  width: '100%',
+                  aspectRatio: DEVICE_ASPECT_RATIOS[device],
+                  border: '1px solid',
+                  borderColor: 'divider',
+                  borderRadius: 1,
+                  overflow: 'hidden',
+                }}
+              >
+                <GatePreview
+                  frameless
+                  theme={theme}
+                  // The gate merges resolved designs over its default theme and shows
+                  // its default branding when no design is configured — mirror both.
+                  baseTheme={DefaultTheme as Theme}
+                  themelessBranding
+                  displayName={selectedApplication?.name ?? ''}
+                  showToolbar={false}
+                  colorScheme={previewColorScheme}
+                  mock={themedComponents}
+                  stylesheets={resolvedDesign?.layout?.head?.stylesheets ?? []}
+                  onSubmit={handleGateSubmit}
+                  onComponentHover={handleGateHover}
+                  additionalData={gateAdditionalData}
+                />
+              </Box>
+            </Box>
+          ) : (
+            <Box sx={{flex: 1, minHeight: 0, overflow: 'auto', display: 'flex', justifyContent: 'center', py: 1}}>
+              <SimulationScreenSketch
+                components={components}
+                options={simulationOptions}
+                onChoose={chooseOption}
+                onPreview={previewOption}
+              />
+            </Box>
+          ))}
+
+        {hasScreen && <SimulationOptionsFooter {...footerProps} rootRef={footerRef} />}
       </Box>
     </BuilderStaticPanel>
   );

--- a/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/SimulationScreenSketch.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/SimulationScreenSketch.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen, fireEvent} from '@testing-library/react';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import type {SimulationOption} from '../../../utils/getSimulationOptions';
+import {SimulationOptionKinds} from '../../../utils/getSimulationOptions';
+import SimulationScreenSketch from '../SimulationScreenSketch';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}));
+
+vi.mock('@thunderid/hooks', () => ({
+  useTemplateLiteralResolver: () => ({
+    resolve: (value: string) => value,
+    resolveAll: (value: string) => value,
+  }),
+}));
+
+const linkOption: SimulationOption = {
+  edgeId: 'e-reset',
+  targetNodeId: 'recovery-1',
+  kind: SimulationOptionKinds.Action,
+  actionLabel: 'Forgot password? Reset',
+  sourceComponentId: 'rich_001',
+};
+
+const richTextComponent = {
+  id: 'rich_001',
+  type: 'RICH_TEXT',
+  label: '<p>Forgot password? <a href="#">Reset</a></p>',
+};
+
+describe('SimulationScreenSketch', () => {
+  const onChoose = vi.fn();
+  const onPreview = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should follow the wired transition when a rich-text link is clicked', () => {
+    render(
+      <SimulationScreenSketch
+        components={[richTextComponent] as never}
+        options={[linkOption]}
+        onChoose={onChoose}
+        onPreview={onPreview}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Reset'));
+
+    expect(onChoose).toHaveBeenCalledWith(linkOption);
+  });
+
+  it('should not follow the transition when the rich text is clicked outside the link', () => {
+    render(
+      <SimulationScreenSketch
+        components={[richTextComponent] as never}
+        options={[linkOption]}
+        onChoose={onChoose}
+        onPreview={onPreview}
+      />,
+    );
+
+    fireEvent.click(screen.getByText(/Forgot password\?/));
+
+    expect(onChoose).not.toHaveBeenCalled();
+  });
+
+  it('should preview the wired transition while hovering the link itself', () => {
+    render(
+      <SimulationScreenSketch
+        components={[richTextComponent] as never}
+        options={[linkOption]}
+        onChoose={onChoose}
+        onPreview={onPreview}
+      />,
+    );
+
+    fireEvent.mouseOver(screen.getByText('Reset'));
+    expect(onPreview).toHaveBeenCalledWith(linkOption);
+
+    fireEvent.mouseLeave(screen.getByText('Reset'));
+    expect(onPreview).toHaveBeenCalledWith(null);
+  });
+
+  it('should not preview anything when hovering the rich text outside the link', () => {
+    render(
+      <SimulationScreenSketch
+        components={[richTextComponent] as never}
+        options={[linkOption]}
+        onChoose={onChoose}
+        onPreview={onPreview}
+      />,
+    );
+
+    fireEvent.mouseOver(screen.getByText(/Forgot password\?/));
+
+    expect(onPreview).toHaveBeenCalledWith(null);
+  });
+
+  it('should fire the correct option when a rich text has two anchors that each carry an action ref', () => {
+    const multiLinkComponent = {
+      id: 'rich_002',
+      type: 'RICH_TEXT',
+      label:
+        '<p>By continuing you agree to the <a href="#" data-action-ref="action_terms">Terms</a>. ' +
+        '<a href="#" data-action-ref="action_reset">Reset</a></p>',
+    };
+    const termsOption: SimulationOption = {
+      edgeId: 'action_terms',
+      targetNodeId: 'terms-1',
+      kind: SimulationOptionKinds.Action,
+      actionLabel: 'Terms',
+      sourceComponentId: 'rich_002',
+    };
+    const resetOption: SimulationOption = {
+      edgeId: 'action_reset',
+      targetNodeId: 'recovery-1',
+      kind: SimulationOptionKinds.Action,
+      actionLabel: 'Reset',
+      sourceComponentId: 'rich_002',
+    };
+    render(
+      <SimulationScreenSketch
+        components={[multiLinkComponent] as never}
+        options={[termsOption, resetOption]}
+        onChoose={onChoose}
+        onPreview={onPreview}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Terms'));
+    expect(onChoose).toHaveBeenCalledWith(termsOption);
+
+    onChoose.mockClear();
+    fireEvent.click(screen.getByText('Reset'));
+    expect(onChoose).toHaveBeenCalledWith(resetOption);
+  });
+
+  it('should not fire any option for a plain anchor sharing a rich text with a wired link', () => {
+    // The exact regression this guards against: a rich text mixing an unwired
+    // link (no data-action-ref, e.g. an external Terms link) with a wired one.
+    // Before the fix, clicking the unwired anchor incorrectly fired the wired
+    // link's option because both were matched by the whole component's id.
+    const mixedComponent = {
+      id: 'rich_003',
+      type: 'RICH_TEXT',
+      label:
+        '<p>By continuing you agree to the <a href="https://example.com/terms">Terms</a>. ' +
+        '<a href="#" data-action-ref="action_reset">Reset</a></p>',
+    };
+    const resetOption: SimulationOption = {
+      edgeId: 'action_reset',
+      targetNodeId: 'recovery-1',
+      kind: SimulationOptionKinds.Action,
+      actionLabel: 'Reset',
+      sourceComponentId: 'rich_003',
+    };
+    render(
+      <SimulationScreenSketch
+        components={[mixedComponent] as never}
+        options={[resetOption]}
+        onChoose={onChoose}
+        onPreview={onPreview}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Terms'));
+    expect(onChoose).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText('Reset'));
+    expect(onChoose).toHaveBeenCalledWith(resetOption);
+  });
+
+  it('should render unwired rich text without click behavior', () => {
+    render(
+      <SimulationScreenSketch
+        components={[richTextComponent] as never}
+        options={[]}
+        onChoose={onChoose}
+        onPreview={onPreview}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Reset'));
+
+    expect(onChoose).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/SimulationStepPreview.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/SimulationStepPreview.test.tsx
@@ -25,11 +25,13 @@ import SimulationStepPreview from '../SimulationStepPreview';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => {
+    t: (key: string, ...args: unknown[]) => {
+      const params = args.find((arg): arg is Record<string, string> => typeof arg === 'object' && arg !== null);
       const translations: Record<string, string> = {
         'flows:core.simulation.preview.title': 'End-user preview',
         'flows:core.simulation.preview.noScreen': 'No screen is shown for this step',
         'flows:core.simulation.preview.noScreenHint': 'This step runs in the background',
+        'flows:core.simulation.preview.noScreenHintNamed': '{{id}} runs in the background',
         'flows:core.simulation.preview.devices.mobile': 'Mobile',
         'flows:core.simulation.preview.devices.tablet': 'Tablet',
         'flows:core.simulation.preview.devices.desktop': 'Desktop',
@@ -47,7 +49,7 @@ vi.mock('react-i18next', () => ({
         'flows:core.simulation.kinds.success': 'On success',
         'flows:core.simulation.preview.dynamicFieldsHint': 'Input fields resolved at runtime',
       };
-      return translations[key] || key;
+      return (translations[key] || key).replace(/{{(\w+)}}/g, (match, name: string) => params?.[name] ?? match);
     },
   }),
 }));
@@ -108,7 +110,7 @@ vi.mock('@/components/GatePreview/GatePreview', () => ({
     additionalData,
   }: {
     mock?: {id?: string}[];
-    onSubmit?: (component: {id?: string}) => void;
+    onSubmit?: (component: {id?: string; components?: {id?: string}[]}) => void;
     onComponentHover?: (component: {id?: string} | null) => void;
     toolbarStart?: React.ReactNode;
     toolbarEnd?: React.ReactNode;
@@ -127,6 +129,12 @@ vi.mock('@/components/GatePreview/GatePreview', () => ({
       {toolbarEnd}
       <button type="button" onClick={() => onSubmit?.({id: 'action_001'})}>
         gate-submit
+      </button>
+      <button type="button" onClick={() => onSubmit?.({id: 'wrapper_001', components: [{id: 'action_001'}]})}>
+        gate-submit-nested
+      </button>
+      <button type="button" onClick={() => onSubmit?.({id: 'action_recovery'})}>
+        gate-submit-link
       </button>
       <button
         type="button"
@@ -192,6 +200,19 @@ const executorNode = {
   data: {},
 } as unknown as Node;
 
+const startNode = {id: 'start-1', type: 'START', position: {x: 0, y: 0}, data: {}} as unknown as Node;
+const endNode = {id: 'end', type: 'END', position: {x: 0, y: 0}, data: {}} as unknown as Node;
+
+const namedExecutorNode = {
+  id: 'credentials_auth',
+  type: 'TASK_EXECUTION',
+  position: {x: 0, y: 0},
+  data: {
+    display: {label: 'Identifier + Password'},
+    action: {executor: {name: 'CredentialsAuthExecutor'}},
+  },
+} as unknown as Node;
+
 const dynamicInputNode = {
   id: 'view-1',
   type: 'VIEW',
@@ -236,6 +257,7 @@ const consentNode = {
 describe('SimulationStepPreview', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.localStorage.clear();
     mockColorSchemeMode = 'light';
     mockDesignResolve = {data: {theme: {palette: {}}, layout: {}}, isError: false};
     mockApplications = [{id: 'app-1', name: 'My App'}];
@@ -496,6 +518,54 @@ describe('SimulationStepPreview', () => {
       expect(simulation.choose).toHaveBeenCalledWith(simulation.options[0]);
     });
 
+    it('should resolve gate submits through the reported component subtree', () => {
+      const simulation = createSimulation();
+      render(<SimulationStepPreview node={viewNode} simulation={simulation} />);
+
+      selectApplication();
+      fireEvent.click(screen.getByText('gate-submit-nested'));
+
+      expect(simulation.choose).toHaveBeenCalledWith(simulation.options[0]);
+    });
+
+    it('should resolve rich-text link submits reported by their action ref', () => {
+      // The gate dispatches wired link clicks as a synthetic action whose id is
+      // the rich text's action.ref, not the component id.
+      const linkViewNode = {
+        id: 'view-1',
+        type: 'VIEW',
+        position: {x: 0, y: 0},
+        data: {
+          components: [
+            {
+              id: 'rich_001',
+              type: 'RICH_TEXT',
+              label: '<p><a href="#" data-action-ref="action_recovery">Reset</a></p>',
+              action: {ref: 'action_recovery'},
+            },
+          ],
+        },
+      } as unknown as Node;
+      // The rich-text link's edge id is its action.ref ('action_recovery'), which
+      // is also what the gate reports on click. sourceComponentId is the rich
+      // text component id, unrelated to the reported id - so the match must be
+      // by edgeId.
+      const linkOption = {
+        edgeId: 'action_recovery',
+        targetNodeId: 'recovery-1',
+        kind: SimulationOptionKinds.Action,
+        actionLabel: 'Reset',
+        sourceComponentId: 'rich_001',
+      };
+      const simulation = createSimulation({options: [linkOption]});
+      render(<SimulationStepPreview node={linkViewNode} simulation={simulation} />);
+
+      selectApplication();
+      fireEvent.click(screen.getByText('gate-submit-link'));
+
+      expect(simulation.choose).toHaveBeenCalledWith(linkOption);
+    });
+
     it('should render the gate default design when the application has no design configured', () => {
       // The design resolve endpoint responds 404 for applications without a design.
       // The gate falls back to an empty theme merged over the renderer defaults —
@@ -552,10 +622,114 @@ describe('SimulationStepPreview', () => {
         <SimulationStepPreview node={executorNode} simulation={createSimulation({currentNodeId: 'executor-1'})} />,
       );
 
-      selectApplication();
-
       expect(screen.queryByTestId('gate-preview')).not.toBeInTheDocument();
+      expect(screen.getByTestId('simulation-background-step')).toBeInTheDocument();
       expect(screen.getByText('No screen is shown for this step')).toBeInTheDocument();
+    });
+
+    it('should hide the preview chrome and put the options first for steps without a screen', () => {
+      render(
+        <SimulationStepPreview node={executorNode} simulation={createSimulation({currentNodeId: 'executor-1'})} />,
+      );
+
+      // No device toggles or application selector - there is nothing to preview.
+      expect(screen.queryByLabelText('Preview as application')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: 'Mobile'})).not.toBeInTheDocument();
+
+      // The transition options come before the background-step note.
+      const footer = screen.getByTestId('simulation-preview-footer');
+      const note = screen.getByTestId('simulation-background-step');
+      expect(footer.compareDocumentPosition(note) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+
+    it('should name the background step in the hint card when its label is known', () => {
+      render(
+        <SimulationStepPreview
+          node={namedExecutorNode}
+          simulation={createSimulation({currentNodeId: 'credentials_auth'})}
+        />,
+      );
+
+      const note = screen.getByTestId('simulation-background-step');
+      expect(note).toHaveTextContent('Identifier + Password');
+      expect(note).toHaveTextContent('credentials_auth runs in the background');
+    });
+
+    it('should still name the step by id when it has no label', () => {
+      const unlabeledNode = {
+        id: 'mystery_step',
+        type: 'TASK_EXECUTION',
+        position: {x: 0, y: 0},
+        data: {},
+      } as unknown as Node;
+      render(
+        <SimulationStepPreview node={unlabeledNode} simulation={createSimulation({currentNodeId: 'mystery_step'})} />,
+      );
+
+      const note = screen.getByTestId('simulation-background-step');
+      expect(note).toHaveTextContent('mystery_step runs in the background');
+    });
+
+    it('should not show the background-step card on Start and End nodes', () => {
+      const {rerender} = render(
+        <SimulationStepPreview node={startNode} simulation={createSimulation({currentNodeId: 'start-1'})} />,
+      );
+      expect(screen.queryByTestId('simulation-background-step')).not.toBeInTheDocument();
+
+      rerender(<SimulationStepPreview node={endNode} simulation={createSimulation({currentNodeId: 'end'})} />);
+      expect(screen.queryByTestId('simulation-background-step')).not.toBeInTheDocument();
+    });
+
+    it('should keep only options wired to screen-triggerable components out of the footer', () => {
+      const linksViewNode = {
+        id: 'view-1',
+        type: 'VIEW',
+        position: {x: 0, y: 0},
+        data: {
+          components: [
+            {id: 'text_001', type: 'TEXT', label: 'Sign In', variant: 'HEADING_1'},
+            {id: 'rich_001', type: 'RICH_TEXT', label: '<p>Forgot password? <a href="#">Reset</a></p>'},
+            {
+              id: 'block_001',
+              type: 'BLOCK',
+              components: [{id: 'action_001', type: 'ACTION', label: 'Sign In', variant: 'PRIMARY'}],
+            },
+          ],
+        },
+      } as unknown as Node;
+      const simulation = createSimulation({
+        options: [
+          {
+            edgeId: 'e1',
+            targetNodeId: 'executor-1',
+            kind: SimulationOptionKinds.Action,
+            actionLabel: 'Sign In',
+            sourceComponentId: 'action_001',
+          },
+          {
+            edgeId: 'e2',
+            targetNodeId: 'recovery-1',
+            kind: SimulationOptionKinds.Action,
+            actionLabel: 'Forgot password? Reset',
+            sourceComponentId: 'rich_001',
+          },
+          {
+            edgeId: 'e3',
+            targetNodeId: 'somewhere-1',
+            kind: SimulationOptionKinds.Action,
+            actionLabel: 'Wired plain text',
+            sourceComponentId: 'text_001',
+          },
+        ],
+      });
+      render(<SimulationStepPreview node={linksViewNode} simulation={simulation} />);
+
+      const footer = screen.getByTestId('simulation-preview-footer');
+      // Buttons and rich-text links are clickable on the screen itself.
+      expect(footer).not.toHaveTextContent('Forgot password? Reset');
+      // A non-interactive component keeps its option in the footer so the path
+      // stays reachable.
+      expect(footer).toHaveTextContent('Wired plain text');
     });
 
     it('should default the themed preview to the console color scheme', () => {
@@ -732,6 +906,106 @@ describe('SimulationStepPreview', () => {
 
       fireEvent.click(screen.getByRole('button', {name: 'Desktop'}));
       expect(panel).toHaveAttribute('data-device', 'desktop');
+    });
+  });
+
+  describe('Keyboard support', () => {
+    it('should exit the preview on Escape', () => {
+      const simulation = createSimulation();
+      render(<SimulationStepPreview node={viewNode} simulation={simulation} />);
+
+      fireEvent.keyDown(window, {key: 'Escape'});
+
+      expect(simulation.stop).toHaveBeenCalled();
+    });
+
+    it('should step back on Backspace', () => {
+      const simulation = createSimulation();
+      render(<SimulationStepPreview node={viewNode} simulation={simulation} />);
+
+      fireEvent.keyDown(window, {key: 'Backspace'});
+
+      expect(simulation.back).toHaveBeenCalled();
+    });
+
+    it('should not react to keys typed into inputs', () => {
+      const simulation = createSimulation();
+      render(
+        <div>
+          <input data-testid="outside-input" />
+          <SimulationStepPreview node={viewNode} simulation={simulation} />
+        </div>,
+      );
+
+      fireEvent.keyDown(screen.getByTestId('outside-input'), {key: 'Escape'});
+
+      expect(simulation.stop).not.toHaveBeenCalled();
+    });
+
+    it('should walk the transition options with the arrow keys', () => {
+      render(
+        <SimulationStepPreview node={executorNode} simulation={createSimulation({currentNodeId: 'executor-1'})} />,
+      );
+
+      fireEvent.keyDown(window, {key: 'ArrowDown'});
+
+      const footer = screen.getByTestId('simulation-preview-footer');
+      expect(footer.contains(document.activeElement)).toBe(true);
+    });
+
+    it('should not re-attach the window listener when back/stop change identity across a step, and should call the latest one', () => {
+      const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+      const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+
+      const staleBack = vi.fn();
+      const freshBack = vi.fn();
+      const simulation = createSimulation({back: staleBack});
+      const {rerender} = render(<SimulationStepPreview node={viewNode} simulation={simulation} />);
+
+      const keydownAttachCount = addEventListenerSpy.mock.calls.filter(([type]) => type === 'keydown').length;
+      addEventListenerSpy.mockClear();
+      removeEventListenerSpy.mockClear();
+
+      // Simulate advancing a step: `back`'s identity changes (as it does in the
+      // real hook, which closes over the traversal path) but `isSimulating`
+      // stays true - the listener should not be torn down and re-added for this.
+      rerender(<SimulationStepPreview node={viewNode} simulation={{...simulation, back: freshBack}} />);
+
+      expect(addEventListenerSpy.mock.calls.filter(([type]) => type === 'keydown')).toHaveLength(0);
+      expect(removeEventListenerSpy.mock.calls.filter(([type]) => type === 'keydown')).toHaveLength(0);
+      expect(keydownAttachCount).toBeGreaterThan(0);
+
+      fireEvent.keyDown(window, {key: 'Backspace'});
+
+      expect(staleBack).not.toHaveBeenCalled();
+      expect(freshBack).toHaveBeenCalled();
+
+      addEventListenerSpy.mockRestore();
+      removeEventListenerSpy.mockRestore();
+    });
+  });
+
+  describe('Preference persistence', () => {
+    it('should restore the persisted device on open', () => {
+      window.localStorage.setItem('thunderid.flows.preview.device', 'desktop');
+      render(<SimulationStepPreview node={viewNode} simulation={createSimulation()} />);
+
+      expect(screen.getByRole('button', {name: 'Desktop'})).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('should persist the device pick', () => {
+      render(<SimulationStepPreview node={viewNode} simulation={createSimulation()} />);
+
+      fireEvent.click(screen.getByRole('button', {name: 'Tablet'}));
+
+      expect(window.localStorage.getItem('thunderid.flows.preview.device')).toBe('tablet');
+    });
+
+    it('should ignore an unknown persisted device', () => {
+      window.localStorage.setItem('thunderid.flows.preview.device', 'holodeck');
+      render(<SimulationStepPreview node={viewNode} simulation={createSimulation()} />);
+
+      expect(screen.getByRole('button', {name: 'Mobile'})).toHaveAttribute('aria-pressed', 'true');
     });
   });
 });

--- a/frontend/apps/console/src/features/flows/constants/simulationPreviewConstants.ts
+++ b/frontend/apps/console/src/features/flows/constants/simulationPreviewConstants.ts
@@ -107,3 +107,13 @@ export const KIND_COLORS: Record<SimulationOptionKinds, 'primary' | 'success' | 
   [SimulationOptionKinds.Incomplete]: 'warning',
   [SimulationOptionKinds.Failure]: 'error',
 };
+
+/**
+ * localStorage key persisting the preview's device frame pick across sessions.
+ */
+export const PREVIEW_DEVICE_STORAGE_KEY = 'thunderid.flows.preview.device';
+
+/**
+ * localStorage key persisting the preview's application pick across sessions.
+ */
+export const PREVIEW_APP_STORAGE_KEY = 'thunderid.flows.preview.appId';

--- a/frontend/apps/console/src/features/flows/hooks/__tests__/useFlowSimulation.test.ts
+++ b/frontend/apps/console/src/features/flows/hooks/__tests__/useFlowSimulation.test.ts
@@ -140,6 +140,122 @@ describe('useFlowSimulation', () => {
     expect(mockFitView).not.toHaveBeenCalled();
   });
 
+  it('should bring both the current step and the hovered target into view on preview', () => {
+    const {result} = renderHook(() => useFlowSimulation(nodes, edges));
+
+    act(() => result.current.start());
+    mockFitView.mockClear();
+    act(() => result.current.preview(result.current.options[0]));
+
+    expect(mockFitView).toHaveBeenCalledWith(expect.objectContaining({nodes: [{id: 'start'}, {id: 'view-1'}]}));
+  });
+
+  it('should restore the current-step focus after a grace period when the preview hover ends', () => {
+    vi.useFakeTimers();
+    try {
+      const {result} = renderHook(() => useFlowSimulation(nodes, edges));
+
+      act(() => result.current.start());
+      act(() => result.current.preview(result.current.options[0]));
+      mockFitView.mockClear();
+      act(() => result.current.preview(null));
+
+      // The camera holds during the grace period so option-to-option hovers do
+      // not bounce it.
+      expect(mockFitView).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+
+      expect(mockFitView).toHaveBeenCalledWith(expect.objectContaining({nodes: [{id: 'start'}]}));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should not fire a pending restore after switching to the static view', () => {
+    vi.useFakeTimers();
+    try {
+      const {result} = renderHook(() => useFlowSimulation(nodes, edges));
+
+      act(() => result.current.start());
+      act(() => result.current.preview(result.current.options[0]));
+      act(() => result.current.preview(null));
+      act(() => result.current.toggleFollowCamera());
+      mockFitView.mockClear();
+
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+
+      expect(mockFitView).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should cancel the pending restore when another option is hovered', () => {
+    vi.useFakeTimers();
+    try {
+      const {result} = renderHook(() => useFlowSimulation(nodes, edges));
+
+      act(() => result.current.start());
+      act(() => result.current.preview(result.current.options[0]));
+      act(() => result.current.preview(null));
+      mockFitView.mockClear();
+      act(() => result.current.preview(result.current.options[0]));
+
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+
+      // Only the two-node preview fit ran - the single-step restore was cancelled.
+      expect(mockFitView).toHaveBeenCalledTimes(1);
+      expect(mockFitView).toHaveBeenCalledWith(expect.objectContaining({nodes: [{id: 'start'}, {id: 'view-1'}]}));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should not fire a stale restore after choosing an option while the hover-restore timer is pending', () => {
+    vi.useFakeTimers();
+    try {
+      const {result} = renderHook(() => useFlowSimulation(nodes, edges));
+
+      act(() => result.current.start());
+      act(() => result.current.preview(result.current.options[0]));
+      act(() => result.current.preview(null));
+      // The 200ms restore-to-'start' is now pending. Choosing the option
+      // navigates before it fires.
+      act(() => result.current.choose(result.current.options[0]));
+      mockFitView.mockClear();
+
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+
+      // The pending restore must not fire and re-focus the node the user just
+      // navigated away from.
+      expect(mockFitView).not.toHaveBeenCalled();
+      expect(result.current.currentNodeId).toBe('view-1');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should not move the camera on preview when follow camera is off', () => {
+    const {result} = renderHook(() => useFlowSimulation(nodes, edges));
+
+    act(() => result.current.start());
+    act(() => result.current.toggleFollowCamera());
+    mockFitView.mockClear();
+    act(() => result.current.preview(result.current.options[0]));
+    act(() => result.current.preview(null));
+
+    expect(mockFitView).not.toHaveBeenCalled();
+  });
+
   it('should keep the options array identity across unrelated node changes', () => {
     const {result, rerender} = renderHook(({n, e}: {n: Node[]; e: Edge[]}) => useFlowSimulation(n, e), {
       initialProps: {n: nodes, e: edges},

--- a/frontend/apps/console/src/features/flows/hooks/useFlowSimulation.ts
+++ b/frontend/apps/console/src/features/flows/hooks/useFlowSimulation.ts
@@ -92,7 +92,9 @@ export interface FlowSimulation {
    */
   back: () => void;
   /**
-   * Previews a transition's edge on the canvas (null clears the preview).
+   * Previews a transition's edge on the canvas (null clears the preview). While
+   * the camera follows the flow, previewing also brings the transition's target
+   * into view alongside the current step.
    */
   preview: (option: SimulationOption | null) => void;
   /**
@@ -111,6 +113,11 @@ export interface FlowSimulation {
 }
 
 const FOCUS_OPTIONS = {duration: 500, maxZoom: 1.2, padding: 0.3};
+
+// Grace period before the camera zooms back after a hover preview ends, so
+// sweeping across the options list reads as one motion instead of the camera
+// bouncing between every row.
+const PREVIEW_RESTORE_DELAY_MS = 200;
 
 const NO_OPTIONS: SimulationOption[] = [];
 
@@ -148,8 +155,34 @@ function useFlowSimulation(nodes: Node[], edges: Edge[]): FlowSimulation {
 
   const currentNodeId: string | null = isSimulating ? (pathNodeIds[pathNodeIds.length - 1] ?? null) : null;
 
+  // Read through a ref so `preview` stays referentially stable while still
+  // seeing the step that is current at hover time.
+  const currentNodeIdRef = useRef<string | null>(currentNodeId);
+  useEffect(() => {
+    currentNodeIdRef.current = currentNodeId;
+  }, [currentNodeId]);
+
+  const restoreTimerRef = useRef<number | null>(null);
+  const hasActivePreviewRef = useRef<boolean>(false);
+
+  const cancelPendingRestore = useCallback((): void => {
+    if (restoreTimerRef.current !== null) {
+      window.clearTimeout(restoreTimerRef.current);
+      restoreTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => cancelPendingRestore, [cancelPendingRestore]);
+
+  const clearPreview = useCallback((): void => {
+    cancelPendingRestore();
+    hasActivePreviewRef.current = false;
+    setPreviewedOption(null);
+  }, [cancelPendingRestore]);
+
   const focusNode = useCallback(
     (nodeId: string): void => {
+      cancelPendingRestore();
       if (!followCameraRef.current) {
         return;
       }
@@ -157,7 +190,7 @@ function useFlowSimulation(nodes: Node[], edges: Edge[]): FlowSimulation {
         // Ignore fitView errors - focusing is best-effort
       });
     },
-    [fitView],
+    [fitView, cancelPendingRestore],
   );
 
   const start = useCallback((): void => {
@@ -170,9 +203,9 @@ function useFlowSimulation(nodes: Node[], edges: Edge[]): FlowSimulation {
     setIsSimulating(true);
     setPathNodeIds([startNode.id]);
     setPathEdges([]);
-    setPreviewedOption(null);
+    clearPreview();
     focusNode(startNode.id);
-  }, [focusNode]);
+  }, [focusNode, clearPreview]);
 
   const startAt = useCallback(
     (nodeId: string): void => {
@@ -182,20 +215,20 @@ function useFlowSimulation(nodes: Node[], edges: Edge[]): FlowSimulation {
       setIsSimulating(true);
       setPathNodeIds([nodeId]);
       setPathEdges([]);
-      setPreviewedOption(null);
+      clearPreview();
       focusNode(nodeId);
     },
-    [focusNode],
+    [focusNode, clearPreview],
   );
 
   const choose = useCallback(
     (option: SimulationOption): void => {
       setPathNodeIds((prev: string[]) => [...prev, option.targetNodeId]);
       setPathEdges((prev: TraversedEdge[]) => [...prev, {edgeId: option.edgeId, kind: option.kind}]);
-      setPreviewedOption(null);
+      clearPreview();
       focusNode(option.targetNodeId);
     },
-    [focusNode],
+    [focusNode, clearPreview],
   );
 
   const back = useCallback((): void => {
@@ -205,25 +238,62 @@ function useFlowSimulation(nodes: Node[], edges: Edge[]): FlowSimulation {
     const nextPath = pathNodeIds.slice(0, -1);
     setPathNodeIds(nextPath);
     setPathEdges((prev: TraversedEdge[]) => prev.slice(0, -1));
-    setPreviewedOption(null);
+    clearPreview();
     focusNode(nextPath[nextPath.length - 1]);
-  }, [pathNodeIds, focusNode]);
+  }, [pathNodeIds, focusNode, clearPreview]);
 
-  const preview = useCallback((option: SimulationOption | null): void => {
-    setPreviewedOption(option);
-  }, []);
+  const preview = useCallback(
+    (option: SimulationOption | null): void => {
+      setPreviewedOption(option);
+      if (!followCameraRef.current) {
+        hasActivePreviewRef.current = Boolean(option);
+        return;
+      }
+      cancelPendingRestore();
+      const currentId = currentNodeIdRef.current;
+      if (option) {
+        hasActivePreviewRef.current = true;
+        // Bring the hovered option's target into view together with the current
+        // step, so the previewed transition is fully visible.
+        const ids =
+          currentId && currentId !== option.targetNodeId ? [currentId, option.targetNodeId] : [option.targetNodeId];
+        fitView({...FOCUS_OPTIONS, duration: 400, nodes: ids.map((id) => ({id}))}).catch(() => {
+          // Ignore fitView errors - focusing is best-effort
+        });
+      } else if (hasActivePreviewRef.current) {
+        hasActivePreviewRef.current = false;
+        if (!currentId) {
+          return;
+        }
+        // Hover ended - restore the single-step focus after a short grace
+        // period, so moving on to the next option does not bounce the camera.
+        restoreTimerRef.current = window.setTimeout(() => {
+          restoreTimerRef.current = null;
+          // Re-checked at fire time: the user may have switched to the static
+          // view while the restore was pending.
+          if (!followCameraRef.current) {
+            return;
+          }
+          fitView({...FOCUS_OPTIONS, nodes: [{id: currentId}]}).catch(() => {
+            // Ignore fitView errors - focusing is best-effort
+          });
+        }, PREVIEW_RESTORE_DELAY_MS);
+      }
+    },
+    [fitView, cancelPendingRestore],
+  );
 
   const stop = useCallback((): void => {
     setIsSimulating(false);
     setPathNodeIds([]);
     setPathEdges([]);
-    setPreviewedOption(null);
+    clearPreview();
     if (followCameraRef.current) {
       fitView({duration: 500, padding: 0.2}).catch(() => {
         // Ignore fitView errors - focusing is best-effort
       });
     }
-  }, [fitView]);
+  }, [fitView, clearPreview]);
 
   const computedOptions: SimulationOption[] = useMemo(
     () => (currentNodeId ? getSimulationOptions(currentNodeId, nodes, edges) : NO_OPTIONS),

--- a/frontend/apps/console/src/features/flows/utils/__tests__/gatePreviewTransforms.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/gatePreviewTransforms.test.ts
@@ -22,6 +22,7 @@ import {
   resolveTemplatesDeep,
   withDerivedEventTypes,
   withDynamicFieldStandIns,
+  withRichTextActionRefs,
   type PreviewComponent,
 } from '../gatePreviewTransforms';
 import type {Application} from '@/features/applications/models/application';
@@ -158,5 +159,40 @@ describe('withDynamicFieldStandIns', () => {
     const text = {id: 'text_001', type: 'TEXT', label: 'Sign In'} as unknown as PreviewComponent;
 
     expect(withDynamicFieldStandIns([text], 'caption')[0]).toEqual(text);
+  });
+});
+
+describe('withRichTextActionRefs', () => {
+  it('should attach the edge id as action.ref on a wired rich-text component', () => {
+    const richText = {id: 'rich_001', type: 'RICH_TEXT', label: '<p><a href="#">Reset</a></p>'} as PreviewComponent;
+    const [result] = withRichTextActionRefs([richText], new Map([['rich_001', 'action_recovery']]));
+
+    expect((result as PreviewComponent & {action?: {ref?: string}}).action?.ref).toBe('action_recovery');
+  });
+
+  it('should re-attach action.ref on rich text nested inside a block', () => {
+    const block = {
+      id: 'block_001',
+      type: 'BLOCK',
+      components: [{id: 'rich_001', type: 'RICH_TEXT', label: '<p><a href="#">Reset</a></p>'}],
+    } as unknown as PreviewComponent;
+    const [result] = withRichTextActionRefs([block], new Map([['rich_001', 'action_recovery']]));
+    const [nested] = result.components as (PreviewComponent & {action?: {ref?: string}})[];
+
+    expect(nested.action?.ref).toBe('action_recovery');
+  });
+
+  it('should not touch rich text without a matching option', () => {
+    const richText = {id: 'rich_002', type: 'RICH_TEXT', label: 'plain'} as PreviewComponent;
+    const [result] = withRichTextActionRefs([richText], new Map([['rich_001', 'action_recovery']]));
+
+    expect((result as PreviewComponent & {action?: unknown}).action).toBeUndefined();
+  });
+
+  it('should leave non-rich-text components untouched', () => {
+    const action = {id: 'action_001', type: 'ACTION', label: 'Sign In'} as unknown as PreviewComponent;
+    const [result] = withRichTextActionRefs([action], new Map([['action_001', 'action_001']]));
+
+    expect((result as PreviewComponent & {action?: unknown}).action).toBeUndefined();
   });
 });

--- a/frontend/apps/console/src/features/flows/utils/gatePreviewTransforms.ts
+++ b/frontend/apps/console/src/features/flows/utils/gatePreviewTransforms.ts
@@ -160,3 +160,31 @@ export function withDynamicFieldStandIns(list: PreviewComponent[], caption: stri
     return component;
   });
 }
+
+/**
+ * Re-attaches the SDK-facing `action.ref` to RICH_TEXT components from the
+ * simulation options. A rich-text link's option carries the component id as
+ * `sourceComponentId` and the wiring ref as `edgeId`; the gate's RichTextAdapter
+ * only dispatches an anchor click when the component exposes `action.ref`, and
+ * that field can be lost by the time a loaded flow reaches the preview. Sourcing
+ * it from the simulation graph makes link clicks work regardless.
+ */
+export function withRichTextActionRefs(
+  list: PreviewComponent[],
+  optionsByComponentId: Map<string, string>,
+): PreviewComponent[] {
+  return list.map((component: PreviewComponent) => {
+    let next = component;
+    const ref = component.type === ElementTypes.RichText ? optionsByComponentId.get(component.id) : undefined;
+    if (ref && (component as {action?: {ref?: string}}).action?.ref !== ref) {
+      next = {...component, action: {...(component as {action?: object}).action, ref}} as PreviewComponent;
+    }
+    if (next.components?.length) {
+      next = {
+        ...next,
+        components: withRichTextActionRefs(next.components as PreviewComponent[], optionsByComponentId),
+      };
+    }
+    return next;
+  });
+}

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -3548,6 +3548,8 @@ const translations = {
     'core.simulation.preview.title': 'End-user preview',
     'core.simulation.preview.noScreen': 'No screen is shown for this step',
     'core.simulation.preview.noScreenHint': 'This step runs in the background before the flow continues',
+    'core.simulation.preview.noScreenHintNamed': '{{id}} runs in the background before the flow continues',
+    'core.simulation.preview.callStepLabel': 'Calls another flow',
     'core.simulation.preview.applicationLabel': 'Preview as application',
     'core.simulation.preview.devices.mobile': 'Mobile',
     'core.simulation.preview.devices.tablet': 'Tablet',


### PR DESCRIPTION
### Purpose

A set of usability improvements for the end-user flow preview panel, addressing gaps found while using it: hovered transitions could point at off-screen nodes, background (no-screen) steps wasted the whole panel on empty preview chrome, options triggerable from the screen were duplicated in the footer, preferences reset on every session, and the panel was mouse-only. Refs #3871.

### Approach

**Hover focus.** Hovering a transition option pans/zooms the canvas so both the current step and the option's target are visible (`useFlowSimulation.preview`). When the hover ends, the camera restores the single-step focus after a short grace period, and moving to another option cancels the pending restore, so sweeping the options list reads as one motion instead of the camera bouncing per row. Explicit navigation (choose, back, restart) also cancels any pending restore. The whole behavior honors the existing follow-camera/static-view toggle: in static view the camera never moves.

**Background steps.** Steps without a screen no longer render preview chrome (device toggles, application selector, empty device frame). The transition options come first, directly under the header, followed by a compact hint card that names the step: its display label (or executor name) with "<step id> runs in the background before the flow continues" as the caption. Start and End nodes suppress the card entirely - they are structural markers, not background work. Screen steps are unchanged.

**No duplicated options.** Options wired to components rendered inside the screen (buttons, resend actions, and now rich-text links such as "Forgot password? Reset") are excluded from the footer - clicking the screen is the way to take them, with the existing "or select an option on the preview screen" hint. To make that safe in the unthemed sketch renderer, rich-text links there are now clickable (and hoverable for edge preview), matching the themed gate's behavior.

**Persisted preferences.** The device pick and "Preview as application" selection persist in localStorage across sessions. A stored application that no longer exists falls back to the default; an unrecognized stored device falls back to mobile; storage access is guarded for restricted environments.

**Keyboard support.** While the preview is open: Escape exits, Backspace steps back, ArrowUp/ArrowDown walk the transition options with roving focus, and Enter activates the focused option. Focused options reuse the existing focus-to-preview wiring, so keyboard navigation drives the hover-focus camera and edge highlight exactly like the mouse. Keys are ignored while typing in inputs.

**Preview mock fidelity.** The app logo in the gate preview mock is wrapped in a STACK so it centers through the SDK's container-driven alignment, matching the real gate's rendering.

Tests cover the camera fit/restore/cancel behavior (fake-timer based), the background-step layout, named hint card and its Start/End suppression, footer dedup for screen-triggerable options, sketch link clicking, keyboard handling (including the input guard), and preference persistence.

### Related Issues
- Refs #3871

### Related PRs
- Builds on the preview work merged in #4053.

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “runs in the background” hints for simulation steps without screens, including improved background-step rendering.
  * Sketch-mode rich-text links now support wired preview/choose interactions.
  * Added keyboard controls for simulation preview navigation and option focus.
  * Persisted simulation preview app and device selections across sessions.
* **Bug Fixes**
  * Improved option resolution and wired rich-text handling by searching within rendered component subtrees.
  * Refined camera/focus timing for hover previews to reduce bouncing.
  * Enabled wired rich-text link submission from iframe previews; adjusted footer placement/styling by option position.
* **Tests**
  * Expanded simulation preview, rich-text link, keyboard, persistence, and preview-cam timing coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->