### PR TITLE
Skip user type step in Create User when only one type exists

### DIFF
--- a/frontend/packages/configure-users/src/pages/UserCreatePage.tsx
+++ b/frontend/packages/configure-users/src/pages/UserCreatePage.tsx
@@ -32,7 +32,7 @@ import {
 } from '@wso2/oxygen-ui';
 import {X} from '@wso2/oxygen-ui-icons-react';
 import type {JSX} from 'react';
-import {useState, useCallback, useMemo} from 'react';
+import {useState, useCallback, useMemo, useEffect} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
 import useCreateUser from '../api/useCreateUser';
@@ -63,7 +63,7 @@ export default function UserCreatePage(): JSX.Element {
     setError,
   } = useUserCreate();
 
-  const {data: userTypesData} = useGetUserTypes();
+  const {data: userTypesData, isLoading: isUserTypesLoading, isFetching: isUserTypesFetching} = useGetUserTypes();
   const {data: userTypeDetails, isLoading: isSchemaLoading} = useGetUserType(selectedSchema?.id);
   const {
     data: childOuData,
@@ -79,26 +79,31 @@ export default function UserCreatePage(): JSX.Element {
   const isChildOuProbeFailed = !!childOuError && !isChildOuForbidden;
   const userTypes = useMemo(() => userTypesData?.types ?? [], [userTypesData]);
   const hasChildOUs = !isChildOuLoading && !childOuError && (childOuData?.totalResults ?? 0) > 0;
+  const isSingleUserType = !isUserTypesLoading && !isUserTypesFetching && userTypes.length === 1;
 
   const activeSteps = useMemo((): UserCreateFlowStep[] => {
-    const base: UserCreateFlowStep[] = [UserCreateFlowStep.USER_TYPE];
+    const base: UserCreateFlowStep[] = [];
+    if (!isSingleUserType) {
+      base.push(UserCreateFlowStep.USER_TYPE);
+    }
     if (hasChildOUs) {
       base.push(UserCreateFlowStep.ORGANIZATION_UNIT);
     }
     base.push(UserCreateFlowStep.USER_DETAILS);
     return base;
-  }, [hasChildOUs]);
+  }, [isSingleUserType, hasChildOUs]);
 
   const steps: Partial<Record<UserCreateFlowStep, {label: string}>> = useMemo(() => {
-    const map: Partial<Record<UserCreateFlowStep, {label: string}>> = {
-      USER_TYPE: {label: t('users:createWizard.steps.userType')},
-    };
+    const map: Partial<Record<UserCreateFlowStep, {label: string}>> = {};
+    if (!isSingleUserType) {
+      map.USER_TYPE = {label: t('users:createWizard.steps.userType')};
+    }
     if (hasChildOUs) {
       map.ORGANIZATION_UNIT = {label: t('users:createWizard.steps.organizationUnit')};
     }
     map.USER_DETAILS = {label: t('users:createWizard.steps.userDetails')};
     return map;
-  }, [t, hasChildOUs]);
+  }, [t, isSingleUserType, hasChildOUs]);
 
   const [validationError, setValidationError] = useState<string | null>(null);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
@@ -163,6 +168,58 @@ export default function UserCreatePage(): JSX.Element {
     [selectedSchema, setSelectedSchema, setSelectedOuId, setFormValues],
   );
 
+  // Resolve the OU for the selected type and move to the next step.
+  const advanceFromUserTypeStep = useCallback((): void => {
+    if (selectedSchema?.ouId && isChildOuLoading) {
+      // Wait for child OU probe to resolve before deciding
+      return;
+    }
+    if (isChildOuProbeFailed) {
+      setError(t('users:createWizard.errors.childOuProbeFailed'));
+      return;
+    }
+    if (hasChildOUs) {
+      setCurrentStep(UserCreateFlowStep.ORGANIZATION_UNIT);
+      return;
+    }
+    if (isChildOuForbidden) {
+      // User doesn't have permission to list child OUs — fall back to the OU from the access token
+      if (tokenOuId) {
+        setSelectedOuId(tokenOuId);
+        setCurrentStep(UserCreateFlowStep.USER_DETAILS);
+      } else {
+        setError(t('users:createWizard.errors.noOuAccess'));
+      }
+      return;
+    }
+    // No child OUs - skip OU step and use the schema's OU directly
+    setSelectedOuId(selectedSchema?.ouId ?? null);
+    setCurrentStep(UserCreateFlowStep.USER_DETAILS);
+  }, [
+    selectedSchema,
+    isChildOuLoading,
+    isChildOuProbeFailed,
+    hasChildOUs,
+    isChildOuForbidden,
+    tokenOuId,
+    setError,
+    setSelectedOuId,
+    setCurrentStep,
+    t,
+  ]);
+
+  // With only one user type, auto-select it and skip the selection step.
+  useEffect((): void => {
+    if (!isSingleUserType || currentStep !== UserCreateFlowStep.USER_TYPE) {
+      return;
+    }
+    if (!selectedSchema) {
+      setSelectedSchema(userTypes[0]);
+      return;
+    }
+    advanceFromUserTypeStep();
+  }, [isSingleUserType, currentStep, selectedSchema, userTypes, setSelectedSchema, advanceFromUserTypeStep]);
+
   const handleSubmit = async (): Promise<void> => {
     setValidationError(null);
     setError(null);
@@ -205,29 +262,7 @@ export default function UserCreatePage(): JSX.Element {
   const handleNextStep = (): void => {
     switch (currentStep) {
       case UserCreateFlowStep.USER_TYPE:
-        if (selectedSchema?.ouId && isChildOuLoading) {
-          // Wait for child OU probe to resolve before deciding
-          return;
-        }
-        if (isChildOuProbeFailed) {
-          setError(t('users:createWizard.errors.childOuProbeFailed'));
-          return;
-        }
-        if (hasChildOUs) {
-          setCurrentStep(UserCreateFlowStep.ORGANIZATION_UNIT);
-        } else if (isChildOuForbidden) {
-          // User doesn't have permission to list child OUs — fall back to the OU from the access token
-          if (tokenOuId) {
-            setSelectedOuId(tokenOuId);
-            setCurrentStep(UserCreateFlowStep.USER_DETAILS);
-          } else {
-            setError(t('users:createWizard.errors.noOuAccess'));
-          }
-        } else {
-          // No child OUs - skip OU step and use the schema's OU directly
-          setSelectedOuId(selectedSchema?.ouId ?? null);
-          setCurrentStep(UserCreateFlowStep.USER_DETAILS);
-        }
+        advanceFromUserTypeStep();
         break;
       case UserCreateFlowStep.ORGANIZATION_UNIT:
         setCurrentStep(UserCreateFlowStep.USER_DETAILS);
@@ -262,6 +297,16 @@ export default function UserCreatePage(): JSX.Element {
   const renderStepContent = (): JSX.Element | null => {
     switch (currentStep) {
       case UserCreateFlowStep.USER_TYPE:
+        if ((isUserTypesLoading || isUserTypesFetching || isSingleUserType) && !error) {
+          // Show loading while resolving types; on auto-resolution failure, allow retry.
+          return (
+            <Box sx={{textAlign: 'center', py: 4}}>
+              <Typography variant="body2" color="text.secondary">
+                {t('common:status.loading')}
+              </Typography>
+            </Box>
+          );
+        }
         return (
           <ConfigureUserType
             schemas={userTypes}
@@ -410,7 +455,7 @@ export default function UserCreatePage(): JSX.Element {
 
               {/* Navigation buttons */}
               <Stack direction="row" justifyContent="flex-end" alignItems="center" spacing={2} sx={{mt: 4}}>
-                {currentStep !== UserCreateFlowStep.USER_TYPE && (
+                {currentStep !== activeSteps[0] && (
                   <Button variant="text" onClick={handlePrevStep} disabled={createUserMutation.isPending}>
                     {t('common:actions.back')}
                   </Button>

--- a/frontend/packages/configure-users/src/pages/__tests__/UserCreatePage.test.tsx
+++ b/frontend/packages/configure-users/src/pages/__tests__/UserCreatePage.test.tsx
@@ -75,6 +75,7 @@ interface UseCreateUserReturn {
 interface UseGetUserTypesReturn {
   data: UserTypeListResponse | undefined;
   isLoading: boolean;
+  isFetching?: boolean;
   error: Error | null;
 }
 
@@ -645,7 +646,10 @@ describe('UserCreatePage', () => {
 
     renderPage();
 
-    await goToDetailsStep(user);
+    // Single user type with an empty ouId: the User Type step is skipped.
+    await waitFor(() => {
+      expect(screen.getByTestId('configure-user-details')).toBeInTheDocument();
+    });
     await user.click(screen.getByTestId('fill-form'));
 
     await waitFor(() => {
@@ -703,7 +707,10 @@ describe('UserCreatePage', () => {
 
     renderPage();
 
-    await goToDetailsStep(user);
+    // Single user type with an empty ouId: the User Type step is skipped.
+    await waitFor(() => {
+      expect(screen.getByTestId('configure-user-details')).toBeInTheDocument();
+    });
     await user.click(screen.getByTestId('fill-form'));
 
     await waitFor(() => {
@@ -1014,6 +1021,111 @@ describe('UserCreatePage', () => {
       await waitFor(() => {
         expect(screen.getByTestId('configure-user-type')).toBeInTheDocument();
       });
+    });
+  });
+
+  // ============================================================================
+  // Single user type (User Type step skipped)
+  // ============================================================================
+
+  describe('single user type', () => {
+    const singleTypeData: UserTypeListResponse = {
+      totalResults: 1,
+      startIndex: 1,
+      count: 1,
+      types: [{id: 'schema1', name: 'Employee', ouId: 'root-ou'}],
+    };
+
+    beforeEach(() => {
+      mockUseGetUserTypes.mockReturnValue({
+        data: singleTypeData,
+        isLoading: false,
+        error: null,
+      });
+    });
+
+    it('auto-selects the only user type and skips to User Details', async () => {
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('configure-user-details')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('configure-user-type')).not.toBeInTheDocument();
+    });
+
+    it('does not show the User Type step in the breadcrumb', async () => {
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('configure-user-details')).toBeInTheDocument();
+      });
+      expect(screen.queryByRole('button', {name: /user type/i})).not.toBeInTheDocument();
+    });
+
+    it('does not show the Back button on the first step', async () => {
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('configure-user-details')).toBeInTheDocument();
+      });
+      expect(screen.queryByRole('button', {name: /back/i})).not.toBeInTheDocument();
+    });
+
+    it('submits with the single user type', async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('configure-user-details')).toBeInTheDocument();
+      });
+      await user.click(screen.getByTestId('fill-form'));
+
+      await waitFor(() => {
+        expect(getCreateUserButton()).not.toBeDisabled();
+      });
+      await user.click(getCreateUserButton());
+
+      await waitFor(() => {
+        expect(mockMutateAsync).toHaveBeenCalledWith({
+          ouId: 'root-ou',
+          type: 'Employee',
+          attributes: {username: 'john_doe', age: 30},
+        });
+      });
+    });
+
+    it('shows loading and does not auto-skip while the types response is still fetching', async () => {
+      mockUseGetUserTypes.mockReturnValue({
+        data: singleTypeData,
+        isLoading: false,
+        isFetching: true,
+        error: null,
+      });
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Loading...')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('configure-user-type')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('configure-user-details')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('configure-organization-unit')).not.toBeInTheDocument();
+    });
+
+    it('skips User Type and shows the OU step first when child OUs exist', async () => {
+      mockUseGetChildOrganizationUnits.mockReturnValue({
+        data: {totalResults: 3, startIndex: 1, count: 3, organizationUnits: [{}, {}, {}]},
+        isLoading: false,
+        error: null,
+      });
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('configure-organization-unit')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('configure-user-type')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: /back/i})).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
### Purpose
The Console Create User wizard prompted for a user type even when only one user type existed, forcing a pointless selection. When a single type is applicable it is now resolved automatically and the selection step is skipped, consistent with the self-registration flow.

Fixes #4083

### Approach
The Create User wizard is REST driven (`GET /user-types`, `POST /users`), not flow-engine driven, so the skip is handled in the Console frontend (`UserCreatePage.tsx`):
- When exactly one user type exists, auto-select it and drop the `USER_TYPE` step from the wizard steps, breadcrumb, and progress.
- Advancing past the (now skipped) step reuses the same OU-resolution path as the manual case, so behavior is identical whether the step is skipped or shown.
- The Back button is hidden on the effective first step.
- The single-type skip only triggers once the user-types query has settled, so a stale cached response (e.g. right after adding a second type) cannot wrongly skip the step. A loading placeholder is shown until it settles.

Multi-type behavior is unchanged: the selection step is still shown.

### Related Issues
- Fixes #4083

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided.
- [x] Tests provided.
    - [x] Unit Tests

### Security checks
- [x] Followed secure coding standards.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically selects the only available user type to streamline user creation.
  * Conditionally skips the user-type step and hides related breadcrumb/back controls when applicable.
  * Shows loading feedback while user types are being retrieved.
  * Improves step order and navigation when child organizational units exist.

* **Bug Fixes**
  * Avoids auto-selection until user-type data is fully loaded/ready.
  * Improves fallback behavior when organizational-unit access is restricted or unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->