### PR TITLE
Update Helm chart guides to set readOnlyRootFilesystem false

### DIFF
--- a/docs/content/guides/deployment-patterns/kubernetes.mdx
+++ b/docs/content/guides/deployment-patterns/kubernetes.mdx
@@ -298,7 +298,7 @@ persistence:
   size: 1Gi
 ```
 
-Also set `deployment.securityContext.readOnlyRootFilesystem: false` when using SQLite: the chart sets this to `true` by default, which prevents SQLite from writing its database files.
+Also set `deployment.securityContext.readOnlyRootFilesystem: false` when using SQLite. The chart defaults it to `true`, which blocks the setup job and server from writing to the container filesystem, including the temporary files created during initialization.
 
 Set `replicaCount: 1` when using SQLite: multiple replicas writing to the same SQLite files will corrupt the database.
 

--- a/docs/content/guides/getting-started/get-thunderid.mdx
+++ b/docs/content/guides/getting-started/get-thunderid.mdx
@@ -234,7 +234,8 @@ helm install {{productSlug}} oci://ghcr.io/thunder-id/helm-charts/{{productSlug}
   --set configuration.database.runtime_persistent.postgres.sslmode=disable \
   --set configuration.server.publicUrl=https://localhost:8090 \
   --set configuration.gateClient.hostname=localhost \
-  --set configuration.gateClient.port=8090
+  --set configuration.gateClient.port=8090 \
+  --set deployment.securityContext.readOnlyRootFilesystem=false
 ```
 
 Wait for <ProductName /> to be ready:

--- a/install/helm/README.md
+++ b/install/helm/README.md
@@ -85,13 +85,15 @@ helm install my-thunderid oci://ghcr.io/thunder-id/helm-charts/thunderid \
   --set configuration.database.config.type=sqlite \
   --set configuration.database.runtime_transient.type=sqlite \
   --set configuration.database.entity.type=sqlite \
-  --set configuration.database.runtime_persistent.type=sqlite
+  --set configuration.database.runtime_persistent.type=sqlite \
+  --set deployment.securityContext.readOnlyRootFilesystem=false
 ```
 
 **Note:** When using SQLite:
 - **Persistence is automatically enabled** when any database is configured to use SQLite
 - The setup job's init container will automatically copy SQLite databases from the image to a PVC
 - Database files will persist across pod restarts
+- **`deployment.securityContext.readOnlyRootFilesystem` must be `false`** (the chart defaults it to `true`), otherwise the setup job and server cannot write to the container filesystem
 
 ### 2. Get the External IP
 


### PR DESCRIPTION
### Purpose
Update the Helm chart documentation to instruct users to set `deployment.securityContext.readOnlyRootFilesystem=false`.

The setup job runs `setup.sh`, which calls `mktemp` (writing to `/tmp` on the container root filesystem). Because the chart defaults `readOnlyRootFilesystem` to `true`, the setup job fails with `mktemp: Read-only file system` on any default install. This affects both PostgreSQL and SQLite deployments, since the setup job runs whenever `setup.enabled=true` (the default).

### Approach
Documentation-only change. No chart templates were modified.

- `install/helm/README.md`: add the flag to the SQLite install command and a note explaining it must be `false`.
- `docs/content/guides/getting-started/get-thunderid.mdx`: add the flag to the Helm quickstart install command (PostgreSQL flow).
- `docs/content/guides/deployment-patterns/kubernetes.mdx`: correct the stated reason. Read-only root does not block SQLite database files (those live on a writable PVC); it blocks the setup job and server from writing to the container filesystem, including temp files created during initialization.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Kubernetes and Helm deployment guidance for SQLite.
  * Added the required `readOnlyRootFilesystem=false` setting to SQLite installation commands.
  * Clarified that SQLite setup and runtime require filesystem write access.
  * Updated quick-start instructions to explicitly configure SQLite persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->