### PR TITLE
Log HTTP error responses by status class in WriteJSONError

### DIFF
--- a/backend/internal/system/utils/http_util.go
+++ b/backend/internal/system/utils/http_util.go
@@ -193,8 +193,14 @@ func isZeroValue(v reflect.Value) bool {
 func WriteJSONError(ctx context.Context, w http.ResponseWriter, code, desc string, statusCode int,
 	respHeaders []map[string]string) {
 	logger := log.GetLogger()
-	logger.Error(ctx, "Error in HTTP response",
-		log.String("error", code), log.String("description", desc))
+	// Log 5xx as errors (server faults) and 4xx as debug (client errors).
+	if statusCode >= http.StatusInternalServerError {
+		logger.Error(ctx, "Error in HTTP response",
+			log.String("error", code), log.String("description", desc))
+	} else {
+		logger.Debug(ctx, "Error in HTTP response",
+			log.String("error", code), log.String("description", desc))
+	}
 
 	// Set the response headers.
 	for _, header := range respHeaders {


### PR DESCRIPTION
### Purpose

`WriteJSONError` logged every error response at `ERROR`, including expected 4xx client errors. This flooded the logs during normal operation, most visibly with CIBA/device-flow poll mode, where each poll returns `authorization_pending` (HTTP 400) until the user completes or the request expires.

### Approach

Log by status class in `WriteJSONError`: 5xx (server faults) stays at `ERROR`, 4xx (client errors) drops to `DEBUG`. This is a generic fix in the shared HTTP util, so it applies to all OAuth endpoints, not just CIBA.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON error logging: server-side failures are now logged at error severity, while client-side (e.g., 4xx) issues are logged with lower severity.
  * Error response formatting (headers and JSON payload) remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->