### PR TITLE
Default the agent edit Token tab to the Agent sub-tab

### DIFF
--- a/frontend/apps/console/src/features/agents/components/edit-agent/tokens/EditTokensSettings.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/tokens/EditTokensSettings.tsx
@@ -64,11 +64,20 @@ export default function EditTokensSettings({
   return (
     <Box>
       <Tabs value={subTab} onChange={handleSubTabChange} aria-label="agent token settings sub-tabs">
-        <Tab label={t('agents:edit.tokens.tabs.user', 'User')} sx={{textTransform: 'none'}} />
         <Tab label={t('agents:edit.tokens.tabs.agent', 'Agent')} sx={{textTransform: 'none'}} />
+        <Tab label={t('agents:edit.tokens.tabs.user', 'User')} sx={{textTransform: 'none'}} />
       </Tabs>
       <Box sx={{pt: 3}}>
         {subTab === 0 && (
+          <AgentAccessTokenSection
+            agent={agent}
+            editedAgent={editedAgent}
+            oauth2Config={oauth2Config}
+            onFieldChange={onFieldChange}
+            onValidationChange={setAgentTabHasError}
+          />
+        )}
+        {subTab === 1 && (
           <DelegationLockNotice
             isUnlocked={isUnlocked}
             message={t(
@@ -88,15 +97,6 @@ export default function EditTokensSettings({
               />
             </Stack>
           </DelegationLockNotice>
-        )}
-        {subTab === 1 && (
-          <AgentAccessTokenSection
-            agent={agent}
-            editedAgent={editedAgent}
-            oauth2Config={oauth2Config}
-            onFieldChange={onFieldChange}
-            onValidationChange={setAgentTabHasError}
-          />
         )}
       </Box>
     </Box>

--- a/frontend/apps/console/src/features/agents/components/edit-agent/tokens/__tests__/EditTokensSettings.test.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/tokens/__tests__/EditTokensSettings.test.tsx
@@ -39,7 +39,7 @@ describe('EditTokensSettings', () => {
   const mockOnFieldChange = vi.fn();
   const baseAgent: Agent = {id: 'agent-1', ouId: 'ou-1', type: 'default', name: 'Test Agent'};
 
-  it('shows both "User" and "Agent" secondary tabs, defaulting to User', () => {
+  it('shows both "Agent" and "User" secondary tabs, defaulting to Agent', () => {
     render(
       <EditTokensSettings
         agent={baseAgent}
@@ -49,12 +49,12 @@ describe('EditTokensSettings', () => {
       />,
     );
 
-    expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual(['User', 'Agent']);
-    expect(screen.getByTestId('token-settings')).toBeInTheDocument();
-    expect(screen.queryByTestId('agent-access-token')).not.toBeInTheDocument();
+    expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual(['Agent', 'User']);
+    expect(screen.getByTestId('agent-access-token')).toBeInTheDocument();
+    expect(screen.queryByTestId('token-settings')).not.toBeInTheDocument();
   });
 
-  it('switches to the Agent tab content when clicked', async () => {
+  it('switches to the User tab content when clicked', async () => {
     const user = userEvent.setup();
     render(
       <EditTokensSettings
@@ -65,13 +65,14 @@ describe('EditTokensSettings', () => {
       />,
     );
 
-    await user.click(screen.getByRole('tab', {name: 'Agent'}));
+    await user.click(screen.getByRole('tab', {name: 'User'}));
 
-    expect(screen.getByTestId('agent-access-token')).toBeInTheDocument();
-    expect(screen.queryByTestId('token-settings')).not.toBeInTheDocument();
+    expect(screen.getByTestId('token-settings')).toBeInTheDocument();
+    expect(screen.queryByTestId('agent-access-token')).not.toBeInTheDocument();
   });
 
-  it('keeps token settings editable and hides the lock notice when Delegated mode is on', () => {
+  it('keeps token settings editable and hides the lock notice when Delegated mode is on', async () => {
+    const user = userEvent.setup();
     render(
       <EditTokensSettings
         agent={baseAgent}
@@ -81,11 +82,14 @@ describe('EditTokensSettings', () => {
       />,
     );
 
+    await user.click(screen.getByRole('tab', {name: 'User'}));
+
     expect(screen.getByTestId('token-settings')).toHaveAttribute('data-readonly', 'false');
     expect(screen.queryByText(/These settings are frozen for this agent/)).not.toBeInTheDocument();
   });
 
-  it('forces token settings read-only and shows the lock notice when Delegated mode is off', () => {
+  it('forces token settings read-only and shows the lock notice when Delegated mode is off', async () => {
+    const user = userEvent.setup();
     render(
       <EditTokensSettings
         agent={baseAgent}
@@ -95,11 +99,14 @@ describe('EditTokensSettings', () => {
       />,
     );
 
+    await user.click(screen.getByRole('tab', {name: 'User'}));
+
     expect(screen.getByTestId('token-settings')).toHaveAttribute('data-readonly', 'true');
     expect(screen.getByText(/These settings are frozen for this agent/)).toBeInTheDocument();
   });
 
-  it('stays read-only when the agent is already read-only, even with Delegated mode on', () => {
+  it('stays read-only when the agent is already read-only, even with Delegated mode on', async () => {
+    const user = userEvent.setup();
     render(
       <EditTokensSettings
         agent={{...baseAgent, isReadOnly: true}}
@@ -109,11 +116,12 @@ describe('EditTokensSettings', () => {
       />,
     );
 
+    await user.click(screen.getByRole('tab', {name: 'User'}));
+
     expect(screen.getByTestId('token-settings')).toHaveAttribute('data-readonly', 'true');
   });
 
-  it('keeps the Agent tab fully editable regardless of Delegated mode', async () => {
-    const user = userEvent.setup();
+  it('keeps the Agent tab fully editable regardless of Delegated mode', () => {
     render(
       <EditTokensSettings
         agent={{...baseAgent, isReadOnly: false}}
@@ -122,8 +130,6 @@ describe('EditTokensSettings', () => {
         onFieldChange={mockOnFieldChange}
       />,
     );
-
-    await user.click(screen.getByRole('tab', {name: 'Agent'}));
 
     expect(screen.getByTestId('agent-access-token')).toHaveAttribute('data-readonly', 'false');
     expect(screen.queryByText(/These settings are frozen for this agent/)).not.toBeInTheDocument();


### PR DESCRIPTION
### Purpose

On the agent edit page, the Token tab has two sub-tabs: User and Agent. They previously appeared as User (first, default-selected) then Agent (second).

Since this is the agent edit page, the agent's own token configuration is the primary concern and should be the first, default-selected sub-tab. The user token configuration (delegated/on-behalf-of settings) is secondary and should come after.

This PR swaps the sub-tab order so **Agent** is first and default-selected, and **User** is second.

### Approach

- In `EditTokensSettings.tsx`, reordered the `<Tab>` labels so Agent renders first and User second, and swapped the corresponding content blocks so `subTab === 0` now renders `AgentAccessTokenSection` and `subTab === 1` renders the user token settings (wrapped in `DelegationLockNotice`). The default `subTab` state stays `0`, which now resolves to the Agent tab.
- Updated `EditTokensSettings.test.tsx` to match the new order and default: the expected tab labels are now `['Agent', 'User']`, the default content assertion targets the Agent section, and the tests covering the user-token delegation lock / read-only behavior now click into the User tab first. The Agent-tab editability test no longer needs a click since Agent is the default.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4155

### Related PRs
- https://github.com/thunder-id/thunderid/pull/3755

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Reordered the token settings secondary tabs so **Agent** appears first and is selected by default.
  * Updated tab content rendering so the **Agent** token section shows on initial load.
  * The **User** tab now contains the delegated-mode lock notice and the correct read-only/editable states.

* **Bug Fixes**
  * Corrected tab-specific mapping to ensure the right token section and locking/validation behavior display for the active tab.

* **Tests**
  * Updated automated tests to reflect the new tab order and delegated-mode editability behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->