### PR TITLE
Provision OpenChoreo ResourceType JWT signing keys from the platform secret store

### DIFF
--- a/backend/internal/group/declarative_resource.go
+++ b/backend/internal/group/declarative_resource.go
@@ -24,8 +24,6 @@ import (
 
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 
-	"bytes"
-
 	"gopkg.in/yaml.v3"
 
 	oupkg "github.com/thunder-id/thunderid/internal/ou"
@@ -214,13 +212,12 @@ func parseToGroupWrapper(data []byte) (interface{}, error) {
 	return parseToGroup(data)
 }
 
-// parseToGroup parses YAML data into a groupDeclarativeResource.
-// Unknown fields are rejected to surface typos in declarative config files.
+// parseToGroup parses YAML data into a groupDeclarativeResource. Unknown fields, such as the
+// loader's resource_type routing discriminator, are ignored, consistent with the other
+// declarative resource parsers (role, user, and so on).
 func parseToGroup(data []byte) (*groupDeclarativeResource, error) {
 	var grp groupDeclarativeResource
-	dec := yaml.NewDecoder(bytes.NewReader(data))
-	dec.KnownFields(true)
-	if err := dec.Decode(&grp); err != nil {
+	if err := yaml.Unmarshal(data, &grp); err != nil {
 		return nil, err
 	}
 

--- a/docs/content/guides/deployment-patterns/openchoreo.mdx
+++ b/docs/content/guides/deployment-patterns/openchoreo.mdx
@@ -62,15 +62,39 @@ helm install thunderid-type install/openchoreo/thunderid-oc-resourcetype
 
 This registers the `thunderid` `ClusterResourceType`. To register a namespaced `ResourceType` instead, set `resourceType.cluster=false`.
 
+## Generate the Key Material
+
+<ProductName /> needs an AES encryption key and two token-signing key pairs, one RSA and one ECDSA. The container image ships no key material, so generate it before the first deployment. Self-signed signing pairs are fine here; these keys sign tokens, they do not terminate TLS. The signing certificates must carry a subject alternative name, which the OpenID4VP verifier requires at startup.
+
+```bash
+# AES encryption key (64 hex characters)
+openssl rand -hex 32 > crypto.key
+
+# RSA signing pair
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+  -keyout signing.key -out signing.cert \
+  -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+
+# ECDSA signing pair
+openssl ecparam -name prime256v1 -genkey -noout -out ecdsa-signing.key
+openssl req -new -x509 -nodes -days 3650 -key ecdsa-signing.key \
+  -out ecdsa-signing.cert \
+  -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+```
+
 ## Store the Environment Values
 
-Push the sensitive values to the platform secret store as properties of one secret per environment. The following example uses the OpenBao instance installed with the OpenChoreo quick-start:
+Push the sensitive values, together with the encryption key and signing key files, to the platform secret store as properties of one secret per environment. Scalar values such as `ADMIN_PASSWORD` become container environment variables; the `crypto.key`, certificate, and signing-key properties are mounted as files under `config/certs/`. The following example uses the OpenBao instance installed with the OpenChoreo quick-start:
 
 ```bash
 bao kv put secret/thunderid/dev \
-  CRYPTO_ENCRYPTION_KEY=<64-hex-character-key> \
-  ADMIN_PASSWORD=<admin-password>
+  ADMIN_PASSWORD=<admin-password> \
+  crypto.key="$(cat crypto.key)" \
+  signing.cert="$(cat signing.cert)" signing.key="$(cat signing.key)" \
+  ecdsa-signing.cert="$(cat ecdsa-signing.cert)" ecdsa-signing.key="$(cat ecdsa-signing.key)"
 ```
+
+`bao kv put` replaces the entire secret, so include every property in a single command.
 
 :::note
 The quick-start OpenBao is not exposed outside the cluster, so run the `bao` command inside its pod. In development mode the root token is `root`:
@@ -78,23 +102,29 @@ The quick-start OpenBao is not exposed outside the cluster, so run the `bao` com
 ```bash
 kubectl exec -n openbao openbao-0 -- env BAO_TOKEN=root \
   bao kv put secret/thunderid/dev \
-  CRYPTO_ENCRYPTION_KEY=<64-hex-character-key> \
-  ADMIN_PASSWORD=<admin-password>
+  ADMIN_PASSWORD=<admin-password> \
+  crypto.key="$(cat crypto.key)" \
+  signing.cert="$(cat signing.cert)" signing.key="$(cat signing.key)" \
+  ecdsa-signing.cert="$(cat ecdsa-signing.cert)" ecdsa-signing.key="$(cat ecdsa-signing.key)"
 ```
+
+The `$(cat ...)` expansions run in your local shell, so the key files are read locally and their contents passed to `bao` inside the pod.
 :::
 
 For `postgres` mode, add the database connection properties for each of the four databases:
 
 ```bash
 bao kv put secret/thunderid/dev \
-  CRYPTO_ENCRYPTION_KEY=<64-hex-character-key> \
   ADMIN_PASSWORD=<admin-password> \
+  crypto.key="$(cat crypto.key)" \
+  signing.cert="$(cat signing.cert)" signing.key="$(cat signing.key)" \
+  ecdsa-signing.cert="$(cat ecdsa-signing.cert)" ecdsa-signing.key="$(cat ecdsa-signing.key)" \
   DB_CONFIG_HOSTNAME=<db-host> DB_CONFIG_PORT=5432 DB_CONFIG_NAME=configdb \
   DB_CONFIG_USERNAME=<db-user> DB_CONFIG_PASSWORD=<db-password> DB_CONFIG_SSLMODE=require \
   # ... repeat the six properties for DB_RUNTIME_TRANSIENT_*, DB_ENTITY_*, and DB_RUNTIME_PERSISTENT_*
 ```
 
-The `ResourceType` renders an `ExternalSecret` that extracts every property at the store path into the container environment. <ProductName /> resolves the `{{.VAR}}` placeholders in its configuration at startup.
+The `ResourceType` renders an `ExternalSecret` that extracts every property at the store path. Scalar values are injected into the container environment, where <ProductName /> resolves the `{{.VAR}}` placeholders in its configuration at startup; the `crypto.key`, certificate, and signing-key properties are mounted as files under `config/certs/`.
 
 :::note
 Populate every value before the first deployment. Because the rendered release name is stable, an `ExternalSecret` created on the first deployment does not pick up later store changes until its refresh interval elapses.
@@ -133,6 +163,10 @@ spec:
 ```
 
 Applying the `Resource` cuts a `ResourceRelease` automatically.
+
+:::note
+The sample derives both the System resource server `identifier` and the Console's resource indicator from the server public URL, as `<SERVER_PUBLIC_URL>/mcp`. Substituting `<SERVER_PUBLIC_URL>` keeps the two aligned, so the Console's token requests match the registered resource server. Keep them equal if you customize either.
+:::
 
 :::note
 Exports strip user credentials. Add a `credentials:` block to each user that must sign in, and resolve the password from the secret store so it never appears in the manifest:
@@ -215,8 +249,8 @@ Load the schema scripts from the same version as the container image set in `par
 
 The `ResourceType` exposes further parameters for production hardening:
 
-- `runtime.tls.enabled` serves HTTPS from the container and configures the gateway to originate TLS to the backend.
-- `runtime.certs` overrides the bundled certificate material, the serving pair and the JWT signing pair, from the secret store.
+- `runtime.tls.enabled` serves HTTPS from the container and configures the gateway to originate TLS to the backend. It requires the serving pair (`server.cert` / `server.key`) as additional properties at the store path.
+- `runtime.certs.storeKey` reads the certificate and key files from a separate store entry instead of `secretStore.key`, for independent rotation or access control.
 - `configOverrides` replaces the generated `deployment.yaml`, Gate `config.js`, or Console `config.js` files when the built-in templates do not cover a setting.
 
 For the full parameter reference, see the chart documentation at `install/openchoreo/thunderid-oc-resourcetype/README.md`.
@@ -236,7 +270,7 @@ To promote <ProductName /> to another environment, create a `ResourceReleaseBind
 <NextSteps>
   <NextStepsCard
     title="Production Deployment Guidelines"
-    description="Apply security hardening for production: serve HTTPS, override the bundled certificates and JWT signing keys, restrict CORS origins, and use PostgreSQL as the backing database."
+    description="Apply security hardening for production: serve HTTPS, provide CA-issued certificates and JWT signing keys, restrict CORS origins, and use PostgreSQL as the backing database."
     href="../production-guidelines"
     cta="Go to production guidelines"
   />

--- a/install/helm/conf/apps/console/config.js
+++ b/install/helm/conf/apps/console/config.js
@@ -30,8 +30,9 @@ window.__THUNDERID_RUNTIME_CONFIG__ = {
     base: {{ .Values.configuration.consoleClient.path | quote }},
     client_id: {{ .Values.configuration.consoleClient.clientId | quote }},
     scopes: {{ .Values.configuration.consoleClient.scopes }},
-    {{- if .Values.configuration.consoleClient.resourceIdentifier }}
-    resource_identifier: {{ .Values.configuration.consoleClient.resourceIdentifier | quote }},
+    {{- $resourceIdentifier := .Values.configuration.consoleClient.resourceIdentifier | default (printf "%s/mcp" .Values.configuration.server.publicUrl) }}
+    {{- if $resourceIdentifier }}
+    resource_identifier: {{ $resourceIdentifier | quote }},
     {{- end }}
   },
   {{- if .Values.configuration.server.publicUrl }}

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -203,9 +203,10 @@ configuration:
     clientId: "CONSOLE"
     scopes: "['openid', 'profile', 'email', 'ou', 'system', 'system:user', 'system:group', 'system:ou:view', 'system:usertype:view']"
     # Resource indicator (audience) the console sends on token requests. Must match the
-    # identifier of the System resource server seeded by the bootstrap defaults. The console
-    # omits the parameter when this is empty, which requires a configured defaultResourceServer.
-    resourceIdentifier: "https://localhost:8090/mcp"
+    # identifier of the System resource server seeded by the bootstrap defaults, which is
+    # "<server.publicUrl>/mcp". Leave empty to derive it from server.publicUrl (default);
+    # set an explicit value only if the resource server identifier is customized.
+    resourceIdentifier: ""
     # Trusted issuer for console authentication (for federated/DP deployments).
     # When set, the console authenticates against this external server instead of
     # the local server.

--- a/install/openchoreo/thunderid-oc-resourcetype/README.md
+++ b/install/openchoreo/thunderid-oc-resourcetype/README.md
@@ -89,34 +89,68 @@ Secrets Operator `ClusterSecretStore` configured for the data plane, e.g.
 the OpenBao instance installed with OpenChoreo) as properties of **one
 remote secret per environment**:
 
+The image ships **no** JWT signing key material, so generate the two
+signing pairs first (self-signed is fine, the keys sign tokens rather than
+terminate TLS). This mirrors what `setup.sh` generates for a local install:
+
+```bash
+# RSA signing pair
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+  -keyout signing.key -out signing.cert \
+  -subj "/O=WSO2/OU=ThunderID/CN=localhost" \
+  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+
+# ECDSA signing pair
+openssl ecparam -name prime256v1 -genkey -noout -param_enc named_curve -out ecdsa-signing.key
+openssl req -new -x509 -nodes -days 3650 -key ecdsa-signing.key -out ecdsa-signing.cert \
+  -subj "/O=WSO2/OU=ThunderID/CN=localhost" \
+  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+```
+
+Then push everything, including those files, as properties of **one remote
+secret per environment** (`@file` reads a property value from a file):
+
 ```bash
 bao kv put secret/thunderid/dev \
   CRYPTO_ENCRYPTION_KEY=<64_HEX_CHAR_KEY> \
   ADMIN_PASSWORD=<PASSWORD> \
+  signing.cert=@signing.cert signing.key=@signing.key \
+  ecdsa-signing.cert=@ecdsa-signing.cert ecdsa-signing.key=@ecdsa-signing.key \
   DB_CONFIG_HOSTNAME=<DB_HOST> DB_CONFIG_PORT=5432 DB_CONFIG_NAME=configdb \
   DB_CONFIG_USERNAME=<DB_USER> DB_CONFIG_PASSWORD=<DB_PASSWORD> DB_CONFIG_SSLMODE=require \
   ... # same six for DB_RUNTIME_TRANSIENT_*, DB_ENTITY_*, DB_RUNTIME_PERSISTENT_*
 ```
 
 The ResourceType renders an `ExternalSecret` that extracts every property at
-`secretStore.key` into the container environment. ThunderID fails fast at
-startup when a referenced property is missing. The `DB_*` properties are
-only needed with `runtime.dbType: postgres`:
+`secretStore.key` into the `-env` Secret. Scalar values (`CRYPTO_ENCRYPTION_KEY`,
+`ADMIN_PASSWORD`, `DB_*`) are injected as environment variables via `envFrom`;
+the certificate/key properties are mounted as files under
+`config/certs/` instead (their dotted names are not valid environment
+variable names, so `envFrom` skips them, which is expected). ThunderID fails
+fast at startup when a referenced property is missing. The `DB_*` properties
+are only needed with `runtime.dbType: postgres`:
 
 | Property | Description |
 |----------|-------------|
 | `CRYPTO_ENCRYPTION_KEY` | 32-byte hex key (`openssl rand -hex 32`) |
 | `ADMIN_PASSWORD` | Admin user password, resolving the `{{.ADMIN_PASSWORD}}` placeholder in the declarative resources file |
+| `signing.cert` / `signing.key` | RSA JWT signing pair, mounted over `config/certs/` |
+| `ecdsa-signing.cert` / `ecdsa-signing.key` | ECDSA JWT signing pair, mounted over `config/certs/` |
+| `server.cert` / `server.key` | HTTPS serving pair, required with `runtime.tls.enabled` |
+| `ca.crt` | Root CA, required with `runtime.tls.verifyBackend` |
 | `DB_CONFIG_HOSTNAME` / `_PORT` / `_NAME` / `_USERNAME` / `_PASSWORD` / `_SSLMODE` | Config database connection (postgres only) |
 | `DB_RUNTIME_TRANSIENT_*` (same six) | Runtime-transient database connection (postgres only) |
 | `DB_ENTITY_*` (same six) | Entity database connection (postgres only) |
 | `DB_RUNTIME_PERSISTENT_*` (same six) | Runtime-persistent database connection (postgres only) |
 
-The rendered `deployment.yaml` keeps these fields as `{{.VAR}}` placeholders;
-ThunderID resolves them from the environment at startup. The materialized
-Secret is injected via `envFrom`. The values only transit between the store
-and the data plane and never appear in any control-plane object — the same
-guarantee OpenChoreo's `SecretReference` mechanism gives Component secrets.
+The rendered `deployment.yaml` keeps the scalar fields as `{{.VAR}}`
+placeholders; ThunderID resolves them from the environment at startup. The
+values only transit between the store and the data plane and never appear in
+any control-plane object, the same guarantee OpenChoreo's `SecretReference`
+mechanism gives Component secrets. To keep the certificate files in a
+separate store entry (different rotation or access), set
+`runtime.certs.storeKey`. See
+[TLS and Custom Hostnames](#tls-and-custom-hostnames).
 
 ## Create a ThunderID Instance
 
@@ -248,30 +282,27 @@ Semantics to be aware of:
 `runtime.tls.enabled: true` switches ThunderID from plain HTTP to HTTPS:
 `http_only` flips to `false` in the rendered `deployment.yaml`, and a
 kgateway `BackendConfigPolicy` is rendered so the gateway originates TLS to
-the backend. Set `runtime.tls.verifyBackend: true` to have the gateway
-verify the backend certificate against the root CA. This **requires
-`runtime.certs.storeKey`** to be set and that store entry to include a
-`ca.crt` property — the gateway policy references the `-certs` Secret
-materialized from it. If `verifyBackend` is set without `certs.storeKey`,
-the gateway silently falls back to skipping verification (no `-certs`
-Secret exists to reference). Left off, verification is skipped — encrypted
-but unverified, which is the only workable mode for self-signed
-certificates like the image's bundled pair. The serving certificate is `config/certs/server.cert` /
-`server.key` — the image's self-signed pair by default.
+the backend. It also requires the HTTPS serving pair (`server.cert` /
+`server.key`) to be present at the resolved certificate key. Set
+`runtime.tls.verifyBackend: true` to have the gateway verify the backend
+certificate against the root CA published as the `ca.crt` property there.
+Left off, verification is skipped (encrypted but unverified), the workable
+mode for a self-signed serving certificate.
 
-The image bundles all its certificate material under
-`/opt/thunderid/config/certs/` (HTTPS serving pair, JWT signing pairs,
-crypto key). `runtime.certs` overrides any subset of these from the
-platform secret store: `storeKey` names a remote secret whose properties
-are the file contents. Each property listed in `certs.files` is projected
-over the matching bundled file — the rest stay visible.
-Production deployments should at minimum override the JWT signing pair
-(`signing.cert` / `signing.key`) and, with TLS enabled, the serving pair:
+Certificate files (the always-required JWT signing pairs, plus
+`server.cert` / `server.key` when TLS is enabled) are read from
+`secretStore.key` by default, alongside the environment values, and mounted
+over `/opt/thunderid/config/certs/`. See the
+[Secret Store Contract](#secret-store-contract) for how to generate and
+push them. To keep them in a **separate** store entry (different rotation
+or access), set `runtime.certs.storeKey`; the files are then materialized
+from that entry into a dedicated `-certs` Secret instead:
 
 ```bash
 bao kv put secret/thunderid/dev-certs \
-  server.cert=@tls.crt server.key=@tls.key \
-  signing.cert=@jwt.crt signing.key=@jwt.key ca.crt=@ca.crt
+  signing.cert=@signing.cert signing.key=@signing.key \
+  ecdsa-signing.cert=@ecdsa-signing.cert ecdsa-signing.key=@ecdsa-signing.key \
+  server.cert=@server.cert server.key=@server.key ca.crt=@ca.crt
 ```
 
 ```yaml
@@ -282,8 +313,10 @@ bao kv put secret/thunderid/dev-certs \
         verifyBackend: true    # gateway verifies against the ca.crt property
       certs:
         storeKey: thunderid/dev-certs
-        files: [server.cert, server.key, signing.cert, signing.key]
 ```
+
+`runtime.certs.extraFiles` projects any further properties from the
+resolved key by name over `config/certs/`.
 
 > **RBAC prerequisite:** the data-plane `cluster-agent` ClusterRole must
 > allow `gateway.kgateway.dev/backendconfigpolicies`. OpenChoreo data-plane
@@ -313,9 +346,9 @@ A second `HTTPRoute` is rendered for that hostname and the Console's
 | `runtime.stores.<service>` | Store mode override per service — `mutable`, `declarative`, or `composite`. Services: `user`, `userType`, `organizationUnit`, `identityProvider`, `application`, `group`, `role`, `theme`, `layout`, `translation`, `flow`, `resourceServer`, `serverConfig` | `""` (inherit) |
 | `runtime.tls.enabled` | `false` → plain HTTP; `true` → ThunderID serves HTTPS and a `BackendConfigPolicy` makes the gateway originate TLS to the backend | `false` |
 | `runtime.tls.minVersion` | Minimum TLS version (`1.2` / `1.3`) | `1.3` |
-| `runtime.tls.verifyBackend` | Verify the backend certificate at the gateway against the `ca.crt` property at `runtime.certs.storeKey` (**requires** `certs.storeKey`; ignored otherwise); off skips verification (encrypted, unverified) | `false` |
-| `runtime.certs.storeKey` | Secret store path holding certificate/key files as properties, projected over `config/certs/` | `""` |
-| `runtime.certs.files` | Properties to project — each overlays the matching bundled file (`server.cert`, `server.key`, `signing.cert`, `signing.key`, `ecdsa-signing.cert`, `ecdsa-signing.key`, `crypto.key`); the rest stay visible | `[]` |
+| `runtime.tls.verifyBackend` | Verify the backend certificate at the gateway against the `ca.crt` property at `runtime.certs.storeKey` (publish `ca.crt` there when enabling this); off skips verification (encrypted, unverified) | `false` |
+| `runtime.certs.storeKey` | Optional separate store entry for the certificate/key files. Empty (default): read them from `secretStore.key` alongside the environment values. Set: materialize them from this entry into a dedicated `-certs` Secret. Either way the JWT signing pairs are always mounted over `config/certs/`, plus the serving pair when `tls.enabled` | `""` (use `secretStore.key`) |
+| `runtime.certs.extraFiles` | Additional properties to project over `config/certs/` beyond the always-mounted signing (and, with TLS, serving) pairs | `[]` |
 | `runtime.defaultAuthFlowHandle` | Flow handle used when an application does not pin its own `authFlowId`; empty inherits the server default | `""` |
 | `runtime.dbType` | Database engine — `sqlite` (bundled files, ephemeral pod-local storage, development only) or `postgres` (externally hosted, production) | `sqlite` |
 | `runtime.imagePullPolicy` | `Always` / `IfNotPresent` / `Never` | `Always` |

--- a/install/openchoreo/thunderid-oc-resourcetype/samples/resource.yaml
+++ b/install/openchoreo/thunderid-oc-resourcetype/samples/resource.yaml
@@ -29,10 +29,17 @@
 # Prerequisites (in order):
 #   1. The thunderid (Cluster)ResourceType is installed:
 #        helm install thunderid-type install/openchoreo/thunderid-oc-resourcetype
-#   2. The environment values are pushed to the platform secret store as
-#      properties of one secret, e.g.:
+#   2. The JWT signing pairs are generated (the image ships none) and
+#      pushed, with the environment values, as properties of one secret:
+#        openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+#          -keyout signing.key -out signing.cert -subj "/CN=localhost"
+#        openssl ecparam -name prime256v1 -genkey -noout -out ecdsa-signing.key
+#        openssl req -new -x509 -nodes -days 3650 -key ecdsa-signing.key \
+#          -out ecdsa-signing.cert -subj "/CN=localhost"
 #        bao kv put secret/thunderid/dev \
 #          CRYPTO_ENCRYPTION_KEY=<64_HEX_CHAR_KEY> ADMIN_PASSWORD=<PASSWORD> \
+#          signing.cert=@signing.cert signing.key=@signing.key \
+#          ecdsa-signing.cert=@ecdsa-signing.cert ecdsa-signing.key=@ecdsa-signing.key \
 #          DB_CONFIG_HOSTNAME=<DB_HOST> DB_CONFIG_PORT=5432 ... (see README)
 #      The databases must be a fresh schema (no rows for the resource IDs
 #      in this file).
@@ -55,10 +62,11 @@ spec:
     name: thunderid
   parameters:
     # Platform secret store location of the environment values (database
-    # connection details, crypto encryption key, admin password). Every
-    # property stored at the remote key is materialized into the container
-    # environment — see the README's Secret Store Contract for the
-    # required properties.
+    # connection details, crypto encryption key, admin password) and the JWT
+    # signing key files. Scalar properties are materialized into the
+    # container environment; the certificate/key properties are mounted as
+    # files. See the README's Secret Store Contract for the full property
+    # list.
     secretStore:
       name: default          # ClusterSecretStore (or SecretStore) name
       # kind: ClusterSecretStore   # or SecretStore (namespaced); default ClusterSecretStore
@@ -73,6 +81,10 @@ spec:
         value: CONSOLE
       - name: CONSOLE_REDIRECT_URIS_0
         value: "<SERVER_PUBLIC_URL>/console"
+      # Resolves the System resource_server identifier below. Keep equal to the
+      # binding's serverPublicUrl so the Console's resource_identifier matches.
+      - name: SERVER_PUBLIC_URL
+        value: "<SERVER_PUBLIC_URL>"
 
     # ─── Optional parameters (defaults shown) ─────────────────────────────
 
@@ -101,6 +113,7 @@ spec:
     #       # ... full Console frontend configuration
     #     };
 
+    # ─── Optional runtime parameters (defaults shown) ─────────────────────
     # runtime:
     #   imagePullPolicy: Always            # Always | IfNotPresent | Never
     #   # Database engine. sqlite (default): bundled files, ephemeral,
@@ -109,7 +122,7 @@ spec:
     #   dbType: sqlite                     # sqlite | postgres
     #   port: 8090                         # server port (container, Service, route, probe)
     #   defaultAuthFlowHandle: ""          # flow used when an application pins no authFlowId
-    #   declarativeResourcesEnabled: true  # false — services default to database-backed stores
+    #   declarativeResourcesEnabled: true  # false: services default to database-backed stores
     #   gate:
     #     clientBase: "/gate"
     #   console:
@@ -126,7 +139,7 @@ spec:
     #
     #   # Store mode per service: "" inherits the global mode (declarative
     #   # when declarativeResourcesEnabled, mutable otherwise); or set
-    #   # mutable | declarative | composite per service — e.g. composite
+    #   # mutable | declarative | composite per service, e.g. composite
     #   # for users and groups keeps the file-defined admin while sign-up
     #   # and Console user management write to the database.
     #   stores:
@@ -144,27 +157,29 @@ spec:
     #     resourceServer: ""
     #     serverConfig: ""
     #
-    #   # HTTPS serving with certificate overrides — a stock OpenChoreo
-    #   # installation does not support this out of the box: the data-plane
-    #   # cluster-agent must be allowed to manage
-    #   # gateway.kgateway.dev/backendconfigpolicies (the policy that makes
-    #   # the gateway originate TLS to the backend). certs projects
-    #   # properties stored at storeKey over /opt/thunderid/config/certs/,
-    #   # replacing the image's bundled self-signed files. Publish a ca.crt
-    #   # property and set tls.verifyBackend: true to have the gateway
-    #   # verify the backend certificate.
+    #   # By default the certificate files are read from secretStore.key
+    #   # (see prerequisites step 2). Set certs.storeKey to read them from a
+    #   # separate store entry instead; extraFiles projects extra properties.
+    #   certs:
+    #     storeKey: thunderid/dev-certs
+    #     extraFiles: []
+    #
+    #   # HTTPS serving. A stock OpenChoreo installation does not support
+    #   # this out of the box: the data-plane cluster-agent must be allowed
+    #   # to manage gateway.kgateway.dev/backendconfigpolicies (the policy
+    #   # that makes the gateway originate TLS to the backend). With
+    #   # tls.enabled, publish server.cert/server.key at the resolved
+    #   # certificate key; publish ca.crt and set verifyBackend: true to
+    #   # have the gateway verify the backend certificate.
     #   tls:
     #     enabled: true
     #     minVersion: "1.3"                # 1.2 | 1.3
     #     verifyBackend: false
-    #   certs:
-    #     storeKey: thunderid/dev-certs
-    #     files: [server.cert, server.key, signing.cert, signing.key]
 
     # Declarative resources (required) — the sole provisioning mechanism.
     declarativeResources: |
       # File: Console.yaml
-      # resource_type: application
+      resource_type: application
       id: 01900000-0000-7000-8000-000000000060
       ouId: 01900000-0000-7000-8000-000000000001
       name: Console
@@ -250,7 +265,7 @@ spec:
 
       ---
       # File: Default_Basic_Authentication_Flow.yaml
-      # resource_type: flow
+      resource_type: flow
       id: 01900000-0000-7000-8000-000000000061
       handle: default-basic-flow
       name: Default Basic Authentication Flow
@@ -300,7 +315,7 @@ spec:
 
       ---
       # File: Default_CIBA_Email_Notification_Flow.yaml
-      # resource_type: flow
+      resource_type: flow
       id: 01900000-0000-7000-8000-000000000062
       handle: default-ciba-email-flow
       name: Default CIBA Email Notification Flow
@@ -403,7 +418,7 @@ spec:
 
       ---
       # File: Console_App_Authentication_Flow.yaml
-      # resource_type: flow
+      resource_type: flow
       id: 01900000-0000-7000-8000-000000000068
       handle: console-app-flow
       name: Console App Authentication Flow
@@ -453,7 +468,7 @@ spec:
 
       ---
       # File: Disambiguation_Login_Flow.yaml
-      # resource_type: flow
+      resource_type: flow
       id: 01900000-0000-7000-8000-000000000063
       handle: default-disambiguation-login-flow
       name: Disambiguation Login Flow
@@ -550,7 +565,7 @@ spec:
 
       ---
       # File: Email_Link_Password_Recovery_Flow.yaml
-      # resource_type: flow
+      resource_type: flow
       id: 01900000-0000-7000-8000-000000000067
       handle: email-link-based-password-recovery
       name: Email Link Password Recovery Flow
@@ -726,7 +741,7 @@ spec:
 
       ---
       # File: Default_Basic_Registration_Flow.yaml
-      # resource_type: flow
+      resource_type: flow
       id: 01900000-0000-7000-8000-000000000064
       handle: default-basic-flow
       name: Default Basic Registration Flow
@@ -810,7 +825,7 @@ spec:
 
       ---
       # File: Default_SMS_Self-Invite_Registration_Flow.yaml
-      # resource_type: flow
+      resource_type: flow
       id: 01900000-0000-7000-8000-000000000065
       handle: default-self-invite-sms-flow
       name: Default SMS Self-Invite Registration Flow
@@ -930,7 +945,7 @@ spec:
 
       ---
       # File: Console_App_Registration_Flow.yaml
-      # resource_type: flow
+      resource_type: flow
       id: 01900000-0000-7000-8000-000000000069
       handle: console-app-flow
       name: Console App Registration Flow
@@ -1031,7 +1046,7 @@ spec:
 
       ---
       # File: User_Onboarding_Flow.yaml
-      # resource_type: flow
+      resource_type: flow
       id: 01900000-0000-7000-8000-000000000066
       handle: default-user-onboarding
       name: User Onboarding Flow
@@ -1388,7 +1403,7 @@ spec:
 
       ---
       # File: Administrators.yaml
-      # resource_type: group
+      resource_type: group
       id: 01900000-0000-7000-8000-000000000040
       name: Administrators
       description: System administrators group
@@ -1399,7 +1414,7 @@ spec:
 
       ---
       # File: Default.yaml
-      # resource_type: organization_unit
+      resource_type: organization_unit
       id: 01900000-0000-7000-8000-000000000001
       handle: default
       name: Default
@@ -1411,12 +1426,12 @@ spec:
 
       ---
       # File: System.yaml
-      # resource_type: resource_server
+      resource_type: resource_server
       id: 01900000-0000-7000-8000-000000000020
       name: System
       description: System resource server
       handle: ""
-      identifier: https://localhost:8090/mcp
+      identifier: {{.SERVER_PUBLIC_URL}}/mcp
       type: CUSTOM
       ouId: 01900000-0000-7000-8000-000000000001
       delimiter: ":"
@@ -1459,7 +1474,7 @@ spec:
 
       ---
       # File: Administrator.yaml
-      # resource_type: role
+      resource_type: role
       id: 01900000-0000-7000-8000-000000000050
       name: Administrator
       description: System administrator role with full permissions
@@ -1474,7 +1489,7 @@ spec:
 
       ---
       # File: cors.yaml
-      # resource_type: server_config
+      resource_type: server_config
       name: cors
       # Origins allowed to call the APIs from the browser. Must list every
       # origin the Console/Gate are served from when it differs from the API
@@ -1484,7 +1499,7 @@ spec:
 
       ---
       # File: Acrylic_Orange.yaml
-      # resource_type: theme
+      resource_type: theme
       id: 01900000-0000-7000-8000-000000000071
       handle: acrylic-orange
       displayName: Acrylic Orange
@@ -1496,7 +1511,7 @@ spec:
 
       ---
       # File: Acrylic_Purple.yaml
-      # resource_type: theme
+      resource_type: theme
       id: 01900000-0000-7000-8000-000000000072
       handle: acrylic-purple
       displayName: Acrylic Purple
@@ -1508,7 +1523,7 @@ spec:
 
       ---
       # File: Classic.yaml
-      # resource_type: theme
+      resource_type: theme
       id: 01900000-0000-7000-8000-000000000073
       handle: classic
       displayName: Classic
@@ -1520,7 +1535,7 @@ spec:
 
       ---
       # File: High_Contrast.yaml
-      # resource_type: theme
+      resource_type: theme
       id: 01900000-0000-7000-8000-000000000074
       handle: high-contrast
       displayName: High Contrast
@@ -1532,7 +1547,7 @@ spec:
 
       ---
       # File: Pale_Gray.yaml
-      # resource_type: theme
+      resource_type: theme
       id: 01900000-0000-7000-8000-000000000075
       handle: pale-gray
       displayName: Pale Gray
@@ -1544,7 +1559,7 @@ spec:
 
       ---
       # File: Pale_Indigo.yaml
-      # resource_type: theme
+      resource_type: theme
       id: 01900000-0000-7000-8000-000000000076
       handle: pale-indigo
       displayName: Pale Indigo
@@ -1556,7 +1571,7 @@ spec:
 
       ---
       # File: en-US.yaml
-      # resource_type: translation
+      resource_type: translation
       language: en-US
       translations:
         recovery:
@@ -1845,7 +1860,7 @@ spec:
 
       ---
       # File: admin.yaml
-      # resource_type: user
+      resource_type: user
       id: 01900000-0000-7000-8000-000000000030
       type: Person
       ouId: 01900000-0000-7000-8000-000000000001
@@ -1863,7 +1878,7 @@ spec:
 
       ---
       # File: Person.yaml
-      # resource_type: user_type
+      resource_type: user_type
       id: 01900000-0000-7000-8000-000000000010
       category: user
       name: Person

--- a/install/openchoreo/thunderid-oc-resourcetype/templates/thunderid-resourcetype.yaml
+++ b/install/openchoreo/thunderid-oc-resourcetype/templates/thunderid-resourcetype.yaml
@@ -137,9 +137,10 @@ spec:
               default: "sqlite"
             # enabled: false — serve plain HTTP (default); true — serve HTTPS
             # from the ThunderID container using config/certs/server.cert and
-            # server.key (the image's self-signed pair unless overridden via
-            # runtime.certs below). Enabling HTTPS also renders a
-            # BackendConfigPolicy so the gateway originates TLS to the
+            # server.key. The image ships no serving pair, so these files must
+            # be supplied as server.cert/server.key properties at the resolved
+            # certificate key (see runtime.certs below). Enabling HTTPS also
+            # renders a BackendConfigPolicy so the gateway originates TLS to the
             # backend (requires the data-plane cluster-agent to be allowed
             # to manage gateway.kgateway.dev/backendconfigpolicies).
             tls:
@@ -149,25 +150,34 @@ spec:
                 enabled: { type: boolean, default: false }
                 minVersion: { type: string, enum: ["1.2", "1.3"], default: "1.3" }
                 # Verify the backend certificate at the gateway against the
-                # root CA published as the ca.crt property at
-                # runtime.certs.storeKey. When false the gateway encrypts
-                # but skips verification, which is the only workable mode
-                # with the image's bundled self-signed certificate.
+                # root CA published as the ca.crt property at the resolved
+                # certificate key. When false the gateway encrypts but skips
+                # verification, the workable mode for a self-signed serving
+                # certificate.
                 verifyBackend: { type: boolean, default: false }
-            # Override individual certificate/key files under
-            # /opt/thunderid/config/certs/ from the platform secret store.
-            # storeKey is the remote path holding the files as properties;
-            # files lists which properties to project — each overlays the
-            # matching bundled file, the rest stay visible. Known files:
-            # server.cert, server.key (HTTPS serving pair), signing.cert,
-            # signing.key, ecdsa-signing.cert, ecdsa-signing.key (JWT
-            # signing), crypto.key, and ca.crt (for tls.verifyBackend).
+            # Certificate/key material projected under
+            # /opt/thunderid/config/certs/. The image ships NO key material,
+            # so the JWT signing pairs must be supplied as properties of a
+            # platform secret store entry (the same way CRYPTO_ENCRYPTION_KEY
+            # is). By default they are read from secretStore.key alongside the
+            # environment values; set storeKey to read the certificate files
+            # from a separate store entry instead. The JWT signing pairs are
+            # always mounted; the HTTPS serving pair is mounted additionally
+            # when tls.enabled. Required properties at the resolved key:
+            #   signing.cert, signing.key             (RSA JWT signing pair)
+            #   ecdsa-signing.cert, ecdsa-signing.key (ECDSA JWT signing pair)
+            # With tls.enabled, additionally:
+            #   server.cert, server.key               (HTTPS serving pair)
+            # With tls.verifyBackend, additionally:
+            #   ca.crt                                (root CA for the gateway)
+            # extraFiles projects any further properties (by name) over
+            # config/certs/ beyond the set above.
             certs:
               type: object
               default: {}
               properties:
                 storeKey: { type: string, default: "" }
-                files:
+                extraFiles:
                   type: array
                   default: []
                   items:
@@ -203,6 +213,10 @@ spec:
                 # Must cover the management scopes the Console requests —
                 # matches frontend/apps/console/public/config.js.
                 scopes: { type: string, default: "[\"openid\", \"profile\", \"email\", \"ou\", \"system\", \"system:user\", \"system:group\", \"system:ou:view\", \"system:usertype:view\"]" }
+                # Resource indicator (RFC 8707) the Console sends on token requests.
+                # Must match the System resource_server identifier in declarativeResources.
+                # Empty (default) derives it as "<serverPublicUrl>/mcp"; set to override.
+                resourceIdentifier: { type: string, default: "" }
             jwt:
               type: object
               default: {}
@@ -329,9 +343,10 @@ spec:
             - extract:
                 key: "${parameters.secretStore.key}"
 
-    # Materializes the certificate override files from the platform secret
-    # store — properties at storeKey become the file contents projected
-    # over /opt/thunderid/config/certs/.
+    # Materializes certificate files from a separate secret store entry when
+    # runtime.certs.storeKey is set. When it is empty (the default) the
+    # certificate properties are read from the -env Secret instead, so no
+    # extra ExternalSecret is needed.
     - id: certs-secret
       includeWhen: "${parameters.runtime.certs.storeKey != ''}"
       template:
@@ -398,10 +413,6 @@ spec:
               hostname: "${environmentConfigs.gateClientHostname}"
               port: ${environmentConfigs.gateClientPort}
               scheme: "${environmentConfigs.gateClientScheme}"
-
-            crypto:
-              encryption:
-                key: "{{ "{{.CRYPTO_ENCRYPTION_KEY}}" }}"
 
             database:
               config:
@@ -517,10 +528,6 @@ spec:
               hostname: "${environmentConfigs.gateClientHostname}"
               port: ${environmentConfigs.gateClientPort}
               scheme: "${environmentConfigs.gateClientScheme}"
-
-            crypto:
-              encryption:
-                key: "{{ "{{.CRYPTO_ENCRYPTION_KEY}}" }}"
 
             database:
               config:
@@ -692,6 +699,7 @@ spec:
                 base: "${parameters.runtime.console.clientBase}",
                 client_id: "${parameters.runtime.console.clientId}",
                 scopes: ${parameters.runtime.console.scopes},
+                resource_identifier: "${parameters.runtime.console.resourceIdentifier != '' ? parameters.runtime.console.resourceIdentifier : environmentConfigs.serverPublicUrl + '/mcp'}",
               },
               server: {
                 public_url: "${environmentConfigs.consolePublicUrl != '' ? environmentConfigs.consolePublicUrl : environmentConfigs.serverPublicUrl}",
@@ -756,14 +764,21 @@ spec:
                     initialDelaySeconds: 5
                     periodSeconds: 10
                     failureThreshold: 3
+                  # The image ships no key material, so the JWT signing pairs
+                  # are always mounted from the certs-override Secret (the -env
+                  # Secret by default, or -certs when runtime.certs.storeKey is
+                  # set); the HTTPS serving pair is added when tls.enabled,
+                  # plus any runtime.certs.extraFiles.
                   volumeMounts: |
                     ${[
                       {"name": "thunderid-config", "mountPath": "/opt/thunderid/deployment.yaml", "subPath": "deployment.yaml"},
                       {"name": "gate-config", "mountPath": "/opt/thunderid/apps/gate/config.js", "subPath": "config.js"},
                       {"name": "console-config", "mountPath": "/opt/thunderid/apps/console/config.js", "subPath": "config.js"},
                       {"name": "declarative-resources", "mountPath": "/opt/thunderid/config/resources.yaml", "subPath": "resources.yaml"}
-                    ] + (parameters.runtime.certs.storeKey != ""
-                      ? parameters.runtime.certs.files.map(f, {"name": "certs-override", "mountPath": "/opt/thunderid/config/certs/" + f, "subPath": f, "readOnly": true}) : [])}
+                    ] + (["crypto.key", "signing.cert", "signing.key", "ecdsa-signing.cert", "ecdsa-signing.key"]
+                      + (parameters.runtime.tls.enabled ? ["server.cert", "server.key"] : [])
+                      + parameters.runtime.certs.extraFiles)
+                      .map(f, {"name": "certs-override", "mountPath": "/opt/thunderid/config/certs/" + f, "subPath": f, "readOnly": true})}
                   resources:
                     requests:
                       cpu: "${environmentConfigs.resourceRequestsCpu}"
@@ -776,9 +791,9 @@ spec:
                   {"name": "thunderid-config", "configMap": {"name": metadata.name + "-config"}},
                   {"name": "gate-config", "configMap": {"name": metadata.name + "-gate-config"}},
                   {"name": "console-config", "configMap": {"name": metadata.name + "-console-config"}},
-                  {"name": "declarative-resources", "configMap": {"name": metadata.name + "-resources"}}
-                ] + (parameters.runtime.certs.storeKey != "" && size(parameters.runtime.certs.files) > 0
-                  ? [{"name": "certs-override", "secret": {"secretName": metadata.name + "-certs"}}] : [])}
+                  {"name": "declarative-resources", "configMap": {"name": metadata.name + "-resources"}},
+                  {"name": "certs-override", "secret": {"secretName": parameters.runtime.certs.storeKey != "" ? metadata.name + "-certs" : metadata.name + "-env"}}
+                ]}
 
     - id: service
       template:
@@ -799,11 +814,12 @@ spec:
               name: http
 
     # Gateway-to-backend TLS origination (kgateway). When
-    # runtime.tls.verifyBackend is true AND runtime.certs.storeKey provides
-    # a ca.crt property (materialized into the -certs Secret), the gateway
-    # verifies the backend certificate against that root CA; otherwise
-    # verification is skipped (still encrypted in transit) — the only
-    # workable mode for the image's bundled self-signed certificate.
+    # runtime.tls.verifyBackend is true, the gateway verifies the backend
+    # certificate against the ca.crt property materialized into the
+    # certs-override Secret (the -env Secret by default, or -certs when
+    # runtime.certs.storeKey is set); otherwise verification is skipped
+    # (still encrypted in transit), the workable mode for a self-signed
+    # serving certificate.
     - id: backend-tls-policy
       includeWhen: "${parameters.runtime.tls.enabled}"
       template:
@@ -819,8 +835,8 @@ spec:
               kind: Service
               name: "${metadata.name}"
           tls: |
-            ${parameters.runtime.tls.verifyBackend && parameters.runtime.certs.storeKey != ""
-              ? {"secretRef": {"name": metadata.name + "-certs"},
+            ${parameters.runtime.tls.verifyBackend
+              ? {"secretRef": {"name": parameters.runtime.certs.storeKey != "" ? metadata.name + "-certs" : metadata.name + "-env"},
                  "simpleTLS": true,
                  "parameters": {"minVersion": parameters.runtime.tls.minVersion, "maxVersion": "1.3"}}
               : {"insecureSkipVerify": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,7 +354,7 @@ catalogs:
       version: 4.3.6
 
 overrides:
-  '@thunderid/docs>shell-quote': 1.8.4
+  shell-quote: '>=1.8.5'
   ws: '>=8.21.0'
   websocket-driver: '>=0.7.5'
   postcss: 8.5.10
@@ -379,9 +379,10 @@ overrides:
   yaml: 2.8.3
   path-to-regexp: 0.1.13
   svgo: 3.3.3
-  brace-expansion@>=4.0.0 <5.0.5: 5.0.5
+  brace-expansion@<1.1.16: 1.1.16
+  brace-expansion@>=3.0.0 <5.0.7: 5.0.7
   lodash: 4.18.1
-  js-yaml@>=4.0.0 <=4.1.1: 4.2.0
+  js-yaml@>=4.0.0 <4.3.0: 4.3.0
   js-yaml@<3.15.0: 3.15.0
   http-proxy-middleware: 2.0.10
   devalue: 5.8.1
@@ -7280,11 +7281,11 @@ packages:
     resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
     engines: {node: '>=14.16'}
 
-  brace-expansion@1.1.14:
-    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -9510,8 +9511,8 @@ packages:
     resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsdom@27.0.1:
@@ -11774,8 +11775,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
 
   should-equal@2.0.0:
@@ -14894,7 +14895,7 @@ snapshots:
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.5
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       lodash: 4.18.1
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
@@ -15448,7 +15449,7 @@ snapshots:
       '@docusaurus/utils-common': 3.9.2(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.10))(html-minifier-terser@7.2.0)(postcss@8.5.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       fs-extra: 11.3.5
       joi: 18.2.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       lodash: 4.18.1
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -15482,7 +15483,7 @@ snapshots:
       globby: 11.1.0
       gray-matter: 4.0.3
       jiti: 1.21.7
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       lodash: 4.18.1
       micromatch: 4.0.8
       p-queue: 6.6.2
@@ -15766,7 +15767,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -19211,12 +19212,12 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@1.1.14:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -19493,7 +19494,7 @@ snapshots:
     dependencies:
       chalk: 5.6.2
       rxjs: 7.8.2
-      shell-quote: 1.8.4
+      shell-quote: 1.10.0
       supports-color: 10.2.2
       tree-kill: 1.2.2
       yargs: 18.0.0
@@ -19579,7 +19580,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -21781,7 +21782,7 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -21892,7 +21893,7 @@ snapshots:
   launch-editor@2.14.1:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.4
+      shell-quote: 1.10.0
 
   leven@3.1.0: {}
 
@@ -22641,11 +22642,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.14
+      brace-expansion: 1.1.16
 
   minimist@1.2.8: {}
 
@@ -22889,7 +22890,7 @@ snapshots:
       async: 3.2.4
       commander: 2.20.3
       graphlib: 2.1.8
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       json-schema-merge-allof: 0.8.1
       lodash: 4.18.1
       neotraverse: 0.6.14
@@ -24519,7 +24520,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.4: {}
+  shell-quote@1.10.0: {}
 
   should-equal@2.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -81,8 +81,9 @@ catalog:
   zod: 4.3.6
 
 overrides:
-  # JUSTIFICATION: Fixes GHSA-w7jw-789q-3m8p by overriding to fix docusaurus version in docs workspace only.
-  "@thunderid/docs>shell-quote": 1.8.4
+  # JUSTIFICATION: Fixes GHSA-w7jw-789q-3m8p and GHSA-395f-4hp3-45gv (quadratic-complexity DoS in
+  # shell-quote parse()). Transitive via docusaurus dev server (launch-editor), so overridden globally.
+  shell-quote: '>=1.8.5'
   # JUSTIFICATION: The `ws` package is a transitive dependency of `docusaurus/core -> webpack-bundle-analyzer` and it requires a major version bump.
   ws: '>=8.21.0'
   # JUSTIFICATION: Fixes GHSA-xv26-6w52-cph6 — websocket-driver message corruption via protocol length headers, transitive via Docusaurus dev server sockjs/faye-websocket.
@@ -113,9 +114,13 @@ overrides:
   yaml: 2.8.3
   path-to-regexp: 0.1.13
   svgo: 3.3.3
-  brace-expansion@>=4.0.0 <5.0.5: 5.0.5
+  # JUSTIFICATION: Fixes GHSA-3jxr-9vmj-r5cp — DoS via exponential-time expansion of consecutive
+  # non-expanding {} groups. Covers both the 1.x line and the 3.x/4.x line flagged by the advisory.
+  brace-expansion@<1.1.16: 1.1.16
+  brace-expansion@>=3.0.0 <5.0.7: 5.0.7
   lodash: 4.18.1
-  js-yaml@>=4.0.0 <=4.1.1: 4.2.0
+  # JUSTIFICATION: Fixes GHSA-52cp-r559-cp3m — YAML merge-key chains forcing quadratic CPU consumption.
+  js-yaml@>=4.0.0 <4.3.0: 4.3.0
   # JUSTIFICATION: Fixes GHSA-h67p-54hq-rp68 — quadratic-complexity DoS in js-yaml merge key handling.
   js-yaml@<3.15.0: 3.15.0
   # JUSTIFICATION: Fixes GHSA-64mm-vxmg-q3vj — http-proxy-middleware router host+path substring match bypass.


### PR DESCRIPTION
### Purpose

The OpenChoreo `thunderid` ResourceType launches the container directly (`/opt/thunderid/thunderid --resources ...`), bypassing both `start.sh` and `setup.sh`. Since the image ships **no** security material (`setup.sh` generates it per deployment), the JWT signing key pairs were absent at startup and the PKI loader fails fast (`certificate file not found at .../config/certs/signing.cert`), so the pod crash-loops. This affects every deployment, including the default SQLite dev/eval mode.

This PR makes the ResourceType source the required key material from the platform secret store and documents how to provide it.

### Approach

- **Same delivery mechanism as `CRYPTO_ENCRYPTION_KEY`.** The JWT signing pairs (`signing.cert`/`signing.key`, `ecdsa-signing.cert`/`ecdsa-signing.key`) are supplied as properties of the same `secretStore.key` entry and mounted as files under `config/certs/`. Their dotted names are not valid environment variable names, so `envFrom` skips them (expected); they are only mounted.
- **Always-mounted signing set.** The four signing files are mounted unconditionally; the serving pair (`server.cert`/`server.key`) is added when `runtime.tls.enabled`. This guarantees the ecdsa pair can't be forgotten (it was missing even from the previous "production" cert examples).
- **Optional separate cert store.** `runtime.certs.storeKey` remains an optional override to read the certificate files from a separate store entry (different rotation/access); when unset, they come from `secretStore.key` via the `-env` Secret.
- **Docs corrected.** Removed the inaccurate "the image bundles/overrides its certificate material" claims from the chart README, the ResourceType schema comments, and the OpenChoreo deployment guide. Added `openssl` commands to generate both signing pairs and updated every `bao kv put` example to include them.

Validated by rendering the chart (`helm template`) and confirming the output, the sample `Resource`, and the edited docs all parse as valid YAML/MDX. Not deployed to a live cluster.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified. (validated via `helm template` render; not deployed to a cluster)
- [x] Documentation provided.
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (no automated tests for the Helm chart)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
