### PR TITLE
[docs] Convert identity provider and SMS provider guides to Console UI steps

### DIFF
--- a/.agent/skills/docs-edit/SKILL.md
+++ b/.agent/skills/docs-edit/SKILL.md
@@ -70,18 +70,3 @@ Don't draw one just because a section theoretically could have one.
 When going ahead: use a fenced ` ```mermaid ` block, never raw SVG/ASCII art, and no per-diagram color overrides (brand colors apply site-wide via `docusaurus.config.ts` → `themeConfig.mermaid`). Full rule: `/docs-review-style`.
 
 No emojis anywhere you write, including table cells and headings. Full rule: `/docs-review-style`.
-
-### Checking step count and screen locality before finalizing
-
-Before writing a final Stepper or numbered sequence, count steps and check each one's UI location. Neither blocks writing — both resolve by asking the user. If both apply to the same sequence, ask together in one message.
-
-- **10+ steps in one sequence**: propose a restructuring (split across pages, group into labeled phases, fold trivial steps into a neighbor) and ask whether the flat structure or the proposal works better. Write whichever they confirm.
-- **Back-and-forth between UI locations with no dependency forcing it**: if two same-screen steps are separated by a different-screen step with nothing depending on the order, propose the regrouped sequence and ask. Write whichever they confirm.
-
-Both are drafting-time applications of what `/docs-review-style` checks later (Step Count and Decomposition, Step Locality) — surfacing them now means the user decides once, not again on review.
-
-Unlike `/docs-review-style`, this skill writes directly, so add the matching confirmation marker as part of the same edit, immediately above the Stepper/list:
-- `<!-- docs-review-style: step-count-confirmed steps={N} -->`
-- `<!-- docs-review-style: step-locality-confirmed screens={ordered list, e.g. Applications,Settings} -->`
-
-A page confirmed here won't get re-asked by `/docs-review-style` or `/docs-review` later, as long as the step count or screen order hasn't changed.

--- a/.agent/skills/docs-review-style/SKILL.md
+++ b/.agent/skills/docs-review-style/SKILL.md
@@ -245,24 +245,20 @@ For quickstart/guide steps:
 ### Step Count and Decomposition
 Count steps in a single Stepper/numbered sequence.
 
-**Confirmation marker**: `<!-- docs-review-style: step-count-confirmed steps=N -->` immediately above, with matching N → skip to ✅. Stale (N mismatched) → treat as absent.
-
-Not a hard gate. No valid marker and 10+ steps:
+Not a hard gate. 10+ steps:
 1. Propose a specific restructuring: split into multiple pages (genuinely separate tasks), group into labeled phases (one continuous task with natural internal structure), or fold trivial steps ("click Save") into a neighbor.
 2. Ask the user directly whether the flat structure or the restructuring is better (batch with Step Locality below if both apply).
-3. If confirmed intentional: mark ✅ passed, tell them the exact marker to add (`steps={N}`) — this skill is read-only, so `/docs-edit` or a manual edit adds it. If they want to restructure: mark `[needs writer input]`.
+3. If confirmed intentional: mark ✅ passed. If they want to restructure: mark `[needs writer input]`.
 
 "Too many steps, shorten it" alone is not a finding — the count only triggers the conversation.
 
 ### Step Locality (Minimize Screen Switching)
 Identify each step's UI location (tab/page/screen named or clearly implied).
 
-**Confirmation marker**: `<!-- docs-review-style: step-locality-confirmed screens=A,B,C -->` above the sequence, matching the current screen order exactly → skip to ✅. Stale → treat as absent.
-
-Not a hard gate. No valid marker, and 2+ steps at the same location are separated by an unrelated-location step with no dependency either way:
+Not a hard gate. 2+ steps at the same location are separated by an unrelated-location step with no dependency either way:
 - ❌ Settings → Applications → back to Settings → ✅ Applications first, then both Settings actions merged.
 
-Before flagging, check for a genuine dependency (an intervening step produces something the return step needs) — if so, skip the flag. When it applies: propose the reordered/regrouped sequence, ask the user directly (batch with Step Count if both fire). If confirmed intentional: mark ✅, give the marker (`screens={ordered list}`). Otherwise `[needs writer input]`.
+Before flagging, check for a genuine dependency (an intervening step produces something the return step needs) — if so, skip the flag. When it applies: propose the reordered/regrouped sequence, ask the user directly (batch with Step Count if both fire). If confirmed intentional: mark ✅. Otherwise `[needs writer input]`.
 
 ### Batching Step Count and Step Locality Questions
 If both need to ask on the same page, combine into one message (matching how `/docs-new-page` batches its questions):

--- a/docs/content/guides/guides/identity-providers/add-github.mdx
+++ b/docs/content/guides/guides/identity-providers/add-github.mdx
@@ -13,8 +13,10 @@ This guide walks you through registering a GitHub identity provider (IdP) in <Pr
 ## Prerequisites
 
 - <ProductName /> is running. See [Get Started](../../../getting-started/get-thunderid).
-- An access token with the `system` scope.
+- You can sign in to the <ProductName /> Console.
 - A GitHub account.
+
+<Stepper stepNode="h2" as="h2">
 
 ## Step 1: Register an OAuth App in GitHub
 
@@ -29,68 +31,31 @@ This guide walks you through registering a GitHub identity provider (IdP) in <Pr
      https://<your-thunderid-host>/gate/callback
      ```
 
+     You can copy this value exactly from the Console in the next step, so it does not need to match character for character here.
+
 4. Click **Register application**.
 5. On the app page, copy the **Client ID**.
 6. Click **Generate a new client secret** and copy the **Client Secret**. GitHub shows it only once.
 
-## Step 2: Create the GitHub IdP
+## Step 2: Configure the GitHub Connection in the Console
 
-Send a `POST` request to `/connections/github` with your GitHub credentials:
-
-```bash
-curl -kL -X POST https://localhost:8090/connections/github \
-  -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer <access-token>' \
-  -d '{
-    "name": "GitHub",
-    "description": "GitHub social login",
-    "clientId": "<github-client-id>",
-    "clientSecret": "<github-client-secret>",
-    "redirectUri": "https://<your-thunderid-host>/gate/callback"
-  }'
-```
-
-**Response (201 Created):**
-
-```json
-{
-  "id": "660e8400-e29b-41d4-a716-446655440001",
-  "name": "GitHub",
-  "description": "GitHub social login",
-  "type": "github",
-  "clientId": "<github-client-id>",
-  "clientSecret": "******",
-  "redirectUri": "https://<your-thunderid-host>/gate/callback"
-}
-```
+1. Sign in to the <ProductName /> Console.
+2. Navigate to **Connections**.
+3. Click the **GitHub** card. If the card shows **Not configured**, this opens a form to create the connection. If it already shows **Configured**, this opens the existing connection instead.
+4. Enter your **Client ID** and **Client secret** from the previous step.
+5. Copy the **Redirect URI** shown on the form and add it to your GitHub OAuth app if you have not already done so.
+6. Optionally, set **Scopes**. Include `user:email` to ensure the user's email address is accessible. Leave this blank to use GitHub's own default scope.
+7. Click **Create connection**.
 
 <ProductName /> automatically uses the GitHub authorization, token, and userinfo endpoints. You do not need to supply them.
 
-## Optional Fields
+</Stepper>
 
-You can include the following optional fields in the request body:
+To map GitHub's profile fields (for example, `login` or `avatar_url`) to local user attributes, open the connection and go to the **Attribute Configuration** tab. See [Attribute Configuration](../add-oidc-provider#attribute-configuration).
 
-| Field | Description |
-|----------|-------------|
-| `scopes` | Array of OAuth scopes to request. Include `user:email` to ensure the user's email address is accessible. |
-| `prompt` | Controls GitHub's consent screen behavior. |
-
-To map GitHub's profile fields (e.g. `login`, `avatar_url`) to local user attributes, set the top-level `attributeConfiguration` field. See [Attribute Configuration](../add-oidc-provider#attribute-configuration).
-
-Example with optional fields:
-
-```bash
-curl -kL -X POST https://localhost:8090/connections/github \
-  -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer <access-token>' \
-  -d '{
-    "name": "GitHub",
-    "clientId": "<github-client-id>",
-    "clientSecret": "<github-client-secret>",
-    "redirectUri": "https://<your-thunderid-host>/gate/callback",
-    "scopes": ["user:email"]
-  }'
-```
+:::note
+The GitHub connection also accepts a `prompt` field, forwarded as a query parameter on the authorization request. GitHub's OAuth flow does not define a `prompt` parameter, so this typically has no effect. This field is not available in the Console and can only be set through the [Connections API](../../../../apis#tag/connections).
+:::
 
 ## Next Steps
 

--- a/docs/content/guides/guides/identity-providers/add-google.mdx
+++ b/docs/content/guides/guides/identity-providers/add-google.mdx
@@ -13,8 +13,10 @@ This guide walks you through registering a Google identity provider (IdP) in <Pr
 ## Prerequisites
 
 - <ProductName /> is running. See [Get Started](../../../getting-started/get-thunderid).
-- An access token with the `system` scope.
+- You can sign in to the <ProductName /> Console.
 - A Google account with access to [Google Cloud Console](https://console.cloud.google.com).
+
+<Stepper stepNode="h2" as="h2">
 
 ## Step 1: Register an OAuth App in Google Cloud Console
 
@@ -29,65 +31,27 @@ This guide walks you through registering a Google identity provider (IdP) in <Pr
    https://<your-thunderid-host>/gate/callback
    ```
 
+   You can copy this value exactly from the Console in the next step, so it does not need to match character for character here.
+
 7. Click **Create**. Google displays your **Client ID** and **Client Secret**. Copy both values. You need them in the next step.
 
-## Step 2: Create the Google IdP
+## Step 2: Configure the Google Connection in the Console
 
-Send a `POST` request to `/connections/google` with your Google credentials:
-
-```bash
-curl -kL -X POST https://localhost:8090/connections/google \
-  -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer <access-token>' \
-  -d '{
-    "name": "Google",
-    "description": "Google social login",
-    "clientId": "<google-client-id>",
-    "clientSecret": "<google-client-secret>",
-    "redirectUri": "https://<your-thunderid-host>/gate/callback"
-  }'
-```
-
-**Response (201 Created):**
-
-```json
-{
-  "id": "550e8400-e29b-41d4-a716-446655440000",
-  "name": "Google",
-  "description": "Google social login",
-  "type": "google",
-  "clientId": "<google-client-id>",
-  "clientSecret": "******",
-  "redirectUri": "https://<your-thunderid-host>/gate/callback"
-}
-```
+1. Sign in to the <ProductName /> Console.
+2. Navigate to **Connections**.
+3. Click the **Google** card. If the card shows **Not configured**, this opens a form to create the connection. If it already shows **Configured**, this opens the existing connection instead.
+4. Enter your **Client ID** and **Client secret** from the previous step.
+5. Copy the **Redirect URI** shown on the form and add it to your Google OAuth client if you have not already done so.
+6. Optionally, set **Scopes**. This defaults to `openid email profile` if left blank.
+7. Click **Create connection**.
 
 <ProductName /> automatically uses the Google authorization, token, userinfo, and JWKS endpoints. You do not need to supply them.
 
-## Optional Fields
+</Stepper>
 
-You can include the following optional fields in the request body:
-
-| Field | Description |
-|----------|-------------|
-| `scopes` | Array of OAuth scopes to request. Defaults to `["openid", "email", "profile"]` if not set. |
-| `prompt` | Controls the Google consent screen behavior. Common values: `consent`, `select_account`. |
-
-Example with optional fields:
-
-```bash
-curl -kL -X POST https://localhost:8090/connections/google \
-  -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer <access-token>' \
-  -d '{
-    "name": "Google",
-    "clientId": "<google-client-id>",
-    "clientSecret": "<google-client-secret>",
-    "redirectUri": "https://<your-thunderid-host>/gate/callback",
-    "scopes": ["openid", "email", "profile"],
-    "prompt": "select_account"
-  }'
-```
+:::note
+The Google connection also accepts a `prompt` field to control the Google consent screen behavior (for example, `consent` or `select_account`). This field is not available in the Console and can only be set through the [Connections API](../../../../apis#tag/connections).
+:::
 
 ## Next Steps
 

--- a/docs/content/guides/guides/identity-providers/add-oauth-provider.mdx
+++ b/docs/content/guides/guides/identity-providers/add-oauth-provider.mdx
@@ -13,85 +13,46 @@ This guide explains how to register a generic OAuth 2.0 identity provider (IdP) 
 ## Prerequisites
 
 - <ProductName /> is running. See [Get Started](../../../getting-started/get-thunderid).
-- An access token with the `system` scope.
+- You can sign in to the <ProductName /> Console.
 - A client application registered in the external OAuth 2.0 provider with a **Client ID**, **Client Secret**, and **redirect URI**.
 - The provider's authorization endpoint, token endpoint, and userinfo endpoint URLs.
 
-## Create the OAuth 2.0 IdP
+## Create the OAuth 2.0 Connection
 
-Send a `POST` request to `/connections/oauth` with your OAuth 2.0 provider credentials and endpoints:
+<Stepper stepNode="h3" as="h3">
 
-```bash
-curl -kL -X POST https://localhost:8090/connections/oauth \
-  -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer <access-token>' \
-  -d '{
-    "name": "My OAuth Provider",
-    "description": "Custom OAuth 2.0 provider",
-    "clientId": "<client-id>",
-    "clientSecret": "<client-secret>",
-    "redirectUri": "https://<your-thunderid-host>/gate/callback",
-    "authorizationEndpoint": "https://<provider>/oauth/authorize",
-    "tokenEndpoint": "https://<provider>/oauth/token",
-    "userInfoEndpoint": "https://<provider>/api/userinfo"
-  }'
-```
+### Step 1: Add a Custom Connection
 
-**Response (201 Created):**
+1. Sign in to the <ProductName /> Console.
+2. Navigate to **Connections**.
+3. Click the **Add custom connection** card.
 
-```json
-{
-  "id": "880e8400-e29b-41d4-a716-446655440003",
-  "name": "My OAuth Provider",
-  "type": "oauth",
-  "clientId": "<client-id>",
-  "clientSecret": "******",
-  "redirectUri": "https://<your-thunderid-host>/gate/callback",
-  "authorizationEndpoint": "https://<provider>/oauth/authorize",
-  "tokenEndpoint": "https://<provider>/oauth/token",
-  "userInfoEndpoint": "https://<provider>/api/userinfo"
-}
-```
+### Step 2: Choose the Connection Type
 
-## Required Fields
+1. On the **Connection type** step, click **OAuth 2.0 Provider**.
+2. Click **Continue**.
 
-| Field | Description |
-|----------|-------------|
-| `clientId` | The client ID issued by the OAuth 2.0 provider. |
-| `clientSecret` | The client secret issued by the OAuth 2.0 provider. |
-| `redirectUri` | The callback URL registered in the provider. |
-| `authorizationEndpoint` | The provider's authorization endpoint URL. |
-| `tokenEndpoint` | The provider's token endpoint URL. |
-| `userInfoEndpoint` | The provider's userinfo endpoint URL. <ProductName /> calls this endpoint to fetch the authenticated user's profile. |
+### Step 3: Configure the Connection
 
-## Optional Fields
+Enter the following fields, then click **Create connection**:
 
-| Field | Description |
-|----------|-------------|
-| `scopes` | Array of OAuth scopes to request. |
-| `logoutEndpoint` | The provider's logout endpoint URL. |
-| `prompt` | The `prompt` parameter to send in authorization requests. |
+| Field | Required | Description |
+|-------|----------|-------------|
+| **Connection name** | Yes | A friendly name used to identify this connection. |
+| **Client ID** | Yes | The client ID issued by the OAuth 2.0 provider. |
+| **Client secret** | Yes | The client secret issued by the OAuth 2.0 provider. |
+| **Authorization endpoint** | Yes | The provider's authorization endpoint, used to start the sign-in flow. |
+| **Token endpoint** | Yes | The provider's token endpoint, used to exchange the authorization code for tokens. |
+| **UserInfo endpoint** | Yes | The provider's userinfo endpoint. <ProductName /> calls this endpoint to fetch the authenticated user's profile. |
+| **Scopes** | No | Space-separated OAuth scopes to request. |
 
-To map this provider's claims to local user attributes, set the top-level `attributeConfiguration` field. See [Attribute Configuration](../add-oidc-provider#attribute-configuration).
+The **Redirect URI** field is read-only. Copy its value and register it as the callback URL with your provider.
 
-Example with optional fields:
+</Stepper>
 
-```bash
-curl -kL -X POST https://localhost:8090/connections/oauth \
-  -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer <access-token>' \
-  -d '{
-    "name": "My OAuth Provider",
-    "clientId": "<client-id>",
-    "clientSecret": "<client-secret>",
-    "redirectUri": "https://<your-thunderid-host>/gate/callback",
-    "authorizationEndpoint": "https://<provider>/oauth/authorize",
-    "tokenEndpoint": "https://<provider>/oauth/token",
-    "userInfoEndpoint": "https://<provider>/api/userinfo",
-    "scopes": ["profile", "email"],
-    "logoutEndpoint": "https://<provider>/oauth/logout"
-  }'
-```
+:::note
+The connection also accepts `logoutEndpoint` and `prompt` fields, and an `attributeConfiguration` field to map this provider's claims to local user attributes. These are not available in the Console and can only be set through the [Connections API](../../../../apis#tag/connections). See [Attribute Configuration](../add-oidc-provider#attribute-configuration) for the mapping concepts, which apply the same way to OAuth 2.0 connections.
+:::
 
 ## Next Steps
 

--- a/docs/content/guides/guides/identity-providers/add-oidc-provider.mdx
+++ b/docs/content/guides/guides/identity-providers/add-oidc-provider.mdx
@@ -13,7 +13,7 @@ This guide explains how to register a generic OpenID Connect (OIDC) identity pro
 ## Prerequisites
 
 - <ProductName /> is running. See [Get Started](../../../getting-started/get-thunderid).
-- An access token with the `system` scope.
+- You can sign in to the <ProductName /> Console.
 - A client application registered in the external OIDC provider with a **Client ID**, **Client Secret**, and **redirect URI**.
 
 :::tip Finding endpoint URLs
@@ -26,183 +26,88 @@ https://<provider-domain>/.well-known/openid-configuration
 Open this URL in a browser to find the `authorization_endpoint`, `token_endpoint`, `userinfo_endpoint`, `jwks_uri`, and `issuer` values.
 :::
 
-## Create the OIDC IdP
+## Create the OIDC Connection
 
-Send a `POST` request to `/connections/oidc` with your OIDC provider credentials and endpoints:
+<Stepper stepNode="h3" as="h3">
 
-```bash
-curl -kL -X POST https://localhost:8090/connections/oidc \
-  -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer <access-token>' \
-  -d '{
-    "name": "My OIDC Provider",
-    "description": "Corporate OIDC provider",
-    "clientId": "<client-id>",
-    "clientSecret": "<client-secret>",
-    "redirectUri": "https://<your-thunderid-host>/gate/callback",
-    "authorizationEndpoint": "https://<provider>/oauth2/authorize",
-    "tokenEndpoint": "https://<provider>/oauth2/token"
-  }'
-```
+### Step 1: Add a Custom Connection
 
-**Response (201 Created):**
+1. Sign in to the <ProductName /> Console.
+2. Navigate to **Connections**.
+3. Click the **Add custom connection** card.
 
-```json
-{
-  "id": "770e8400-e29b-41d4-a716-446655440002",
-  "name": "My OIDC Provider",
-  "type": "oidc",
-  "clientId": "<client-id>",
-  "clientSecret": "******",
-  "redirectUri": "https://<your-thunderid-host>/gate/callback",
-  "authorizationEndpoint": "https://<provider>/oauth2/authorize",
-  "tokenEndpoint": "https://<provider>/oauth2/token"
-}
-```
+### Step 2: Choose the Connection Type
 
-## Required Fields
+1. On the **Connection type** step, click **OpenID Connect Provider**.
+2. Click **Continue**.
 
-| Field | Description |
-|----------|-------------|
-| `clientId` | The client ID issued by the OIDC provider. |
-| `clientSecret` | The client secret issued by the OIDC provider. |
-| `redirectUri` | The callback URL registered in the OIDC provider. |
-| `authorizationEndpoint` | The provider's authorization endpoint URL. |
-| `tokenEndpoint` | The provider's token endpoint URL. |
+### Step 3: Configure the Connection
 
-## Optional Fields
+Enter the following fields, then click **Create connection**:
 
-| Field | Description |
-|----------|-------------|
-| `userInfoEndpoint` | The provider's userinfo endpoint URL. Used to fetch user profile claims. |
-| `jwksEndpoint` | The URL of the provider's JSON Web Key Set. Required when `tokenExchangeEnabled` is `true`. |
-| `issuer` | The provider's issuer identifier. Required when `tokenExchangeEnabled` is `true`. |
-| `scopes` | Array of OIDC scopes to request (for example, `["openid", "email", "profile"]`). |
-| `logoutEndpoint` | The provider's end-session endpoint. |
-| `prompt` | The `prompt` parameter to send in authorization requests (for example, `login`, `consent`). |
-| `tokenExchangeEnabled` | Set to `true` to enable token exchange with this provider. Requires `issuer` and `jwksEndpoint`. |
+| Field | Required | Description |
+|-------|----------|-------------|
+| **Connection name** | Yes | A friendly name used to identify this connection. |
+| **Client ID** | Yes | The client ID issued by the OIDC provider. |
+| **Client secret** | Yes | The client secret issued by the OIDC provider. |
+| **Authorization endpoint** | Yes | The provider's authorization endpoint, used to start the sign-in flow. |
+| **Token endpoint** | Yes | The provider's token endpoint, used to exchange the authorization code for tokens. |
+| **UserInfo endpoint** | No | The provider's userinfo endpoint. Used to fetch additional profile claims. |
+| **JWKS endpoint** | No | The URL of the provider's JSON Web Key Set. Required when **Enable token exchange** is on. |
+| **Issuer** | No | The provider's issuer identifier, expected in tokens from this provider. Required when **Enable token exchange** is on. |
+| **Scopes** | No | Space-separated OIDC scopes to request. Defaults to `openid email profile` if left blank. |
+
+The **Redirect URI** field is read-only. Copy its value and register it as the callback URL with your OIDC provider.
+
+Under **Federation**, turn on **Enable token exchange** to accept subject tokens from this provider for token exchange. This makes **Issuer** and **JWKS endpoint** required, and reveals an optional **Trusted token audience** field, the accepted audience value for external tokens during token exchange.
+
+</Stepper>
+
+:::note
+The connection also accepts `logoutEndpoint` and `prompt` fields. These are not available in the Console and can only be set through the [Connections API](../../../../apis#tag/connections).
+:::
 
 ## Attribute Configuration
 
-External providers emit attributes under their own names, which may differ from the attribute names <ProductName /> uses locally (for example, a provider may emit `given_name` where your user type defines `firstName`). Configure the IdP's `attributeConfiguration` to map external attributes to local user attributes.
+External providers emit attributes under their own names, which may differ from the attribute names <ProductName /> uses locally (for example, a provider may emit `given_name` where your user type defines `firstName`). Open the connection and go to the **Attribute Configuration** tab to map external attributes to local user attributes.
 
-```json
-{
-  "name": "My OIDC Provider",
-  "clientId": "<client-id>",
-  "clientSecret": "<client-secret>",
-  "redirectUri": "https://<your-thunderid-host>/gate/callback",
-  "authorizationEndpoint": "https://<provider>/oauth2/authorize",
-  "tokenEndpoint": "https://<provider>/oauth2/token",
-  "attributeConfiguration": {
-    "userTypeResolution": {
-      "default": "Person"
-    },
-    "userTypeAttributeMappings": [
-      {
-        "userType": "Person",
-        "attributes": [
-          { "externalAttribute": "given_name", "localAttribute": "firstName" },
-          { "externalAttribute": "email.work", "localAttribute": "email" }
-        ]
-      }
-    ]
-  }
-}
-```
+### User Type Resolution
+
+By default, every federated identity resolves to the connection's **Default User Type**. To derive the user type from an incoming claim instead, turn on **Resolve user type from an attribute** and set the attribute whose value decides the user type (for example, `user_type`; supports dot notation for nested claims, for example `profile.role`).
+
+Under **Value Mapping**, map each external attribute value to a local user type (for example, `staff` to `Employee`, `partner` to `Contractor`) using **Add Value**. The **Default User Type** remains the fallback used when the claim is missing or its value has no mapping.
+
+The resolved user type selects which mapping set applies under **Attribute Mappings**.
+
+### Attribute Mappings
+
+Click **Add User Type** to add a mapping set for a user type, then click **Add Mapping** to add attribute mappings within that set. Each mapping has:
 
 | Field | Description |
 |-------|-------------|
-| `userTypeResolution` | Resolves the local user type for an incoming identity. **Required** when `userTypeAttributeMappings` is configured (it selects which mapping profile applies); otherwise optional. Can be a static `default` or derived from a claim. See [Claim-driven user type resolution](#claim-driven-user-type-resolution). |
-| `userTypeAttributeMappings` | An array where each entry holds the attribute mappings for one user type. |
-
-Each entry has a `userType` (the user type whose schema defines the valid local targets) and an `attributes` array. Each item in `attributes` has the following fields:
-
-| Field | Description |
-|-------|-------------|
-| `externalAttribute` | **Required.** The external attribute name. |
-| `localAttribute` | **Required.** The target local attribute. Must be an attribute defined in `userType` schema. |
+| **External Attribute** | The external attribute name (for example, `given_name`). |
+| **Local Attribute** | The target local attribute (for example, `firstName`). Must be an attribute defined in that user type's schema. |
 
 Behavior:
 
-- The `externalAttribute` (source) supports attributes in complex forms. Use **dot notation** to read a value nested inside another attribute. For example, `email.work` reads the `work` field from an `email` object.
-- The `localAttribute` (target) must be an attribute defined in the profile's `userType` schema; this is validated when the IdP is created or updated.
+- The external attribute supports complex forms. Use **dot notation** to read a value nested inside another attribute. For example, `email.work` reads the `work` field from an `email` object.
+- The local attribute must be defined in the user type's schema; this is validated when you save the connection.
 - An attribute whose name is mapped is renamed to its local attribute; attributes without a mapping pass through unchanged.
 
-The mapping applies both when a user signs in through this IdP in an authentication flow and when a token from this IdP is exchanged (see [Trusted Issuer](../../trusted-issuer#attribute-configuration)). The resulting local attributes flow into the issued access and ID tokens, subject to the application's `userAttributes` configuration.
+The mapping applies both when a user signs in through this connection in an authentication flow and when a token from this provider is exchanged (see [Trusted Issuer](../../trusted-issuer#attribute-configuration)). The resulting local attributes flow into the issued access and ID tokens, subject to the application's `userAttributes` configuration.
 
-### Claim-driven user type resolution
+### Account Linking
 
-By default, every federated identity resolves to the `default` user type. To derive the user type from an incoming claim instead, set `externalAttribute` (the claim to read) and `valueMapping` (external value to local user type):
-
-```json
-{
-  "attributeConfiguration": {
-    "userTypeResolution": {
-      "default": "Person",
-      "externalAttribute": "user_type",
-      "valueMapping": {
-        "staff": "Employee",
-        "partner": "Contractor"
-      }
-    }
-  }
-}
-```
-
-| Field | Description |
-|-------|-------------|
-| `default` | **Required.** Fallback user type, used when the claim is missing or its value is not mapped. |
-| `externalAttribute` | External claim whose value selects the local user type. Supports dot notation for nested claims (for example, `profile.role`). |
-| `valueMapping` | Maps an external claim value to a local user type. Requires `externalAttribute`. |
-
-The resolved user type selects which `userTypeAttributeMappings` profile applies.
-
-Example with token exchange enabled:
-
-```bash
-curl -kL -X POST https://localhost:8090/connections/oidc \
-  -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer <access-token>' \
-  -d '{
-    "name": "My OIDC Provider",
-    "clientId": "<client-id>",
-    "clientSecret": "<client-secret>",
-    "redirectUri": "https://<your-thunderid-host>/gate/callback",
-    "authorizationEndpoint": "https://<provider>/oauth2/authorize",
-    "tokenEndpoint": "https://<provider>/oauth2/token",
-    "userInfoEndpoint": "https://<provider>/userinfo",
-    "jwksEndpoint": "https://<provider>/oauth2/v1/keys",
-    "issuer": "https://<provider>",
-    "scopes": ["openid", "email", "profile"],
-    "tokenExchangeEnabled": true
-  }'
-```
-
-## Account Linking
-
-To resolve an incoming federated identity to an existing local user by attributes when the subject identifier (`sub`) does not match, configure `accountLinking` under `attributeConfiguration`:
-
-```json
-{
-  "attributeConfiguration": {
-    "accountLinking": {
-      "attributes": ["email"]
-    }
-  }
-}
-```
-
-| Field | Description |
-|-------|-------------|
-| `accountLinking.attributes` | External attribute names matched together to resolve a unique local user when `sub` does not. |
+To resolve an incoming federated identity to an existing local user by attributes when the subject identifier (`sub`) does not match, add attributes under **Account Linking**. Click **Add Attribute** to add an external attribute (for example, `email`) that is matched to find the associated local user.
 
 Behavior:
 
 - Resolution tries the subject identifier (`sub`) first. If it resolves an existing user, that user is used.
-- Otherwise, all configured attributes that have a value are matched together (as a single query) to resolve a unique local user.
-- Each attribute is an external claim name; if it's mapped via `userTypeAttributeMappings` (e.g. `email` → `work_email`), the mapped local attribute is used for the lookup instead.
+- Otherwise, all configured attributes that have a value are matched together (AND) to resolve a unique local user.
+- Each attribute is an external claim name; if it's mapped under **Attribute Mappings** (for example, `email` to `work_email`), the mapped local attribute is used for the lookup instead.
 - If neither `sub` nor the configured attributes resolve a user, the user is treated as new (subject to the flow's provisioning configuration).
+
+Click **Save changes** to apply your attribute configuration.
 
 ## Next Steps
 

--- a/docs/content/guides/guides/identity-providers/connect-idp-to-application.mdx
+++ b/docs/content/guides/guides/identity-providers/connect-idp-to-application.mdx
@@ -20,7 +20,7 @@ Applications in <ProductName /> do not reference IdPs directly. The connection r
 
 ## Prerequisites
 
-- You have created an identity provider using the API. See:
+- You have configured an identity provider connection. See:
   - [Add a Google Identity Provider](../add-google)
   - [Add a GitHub Identity Provider](../add-github)
   - [Add an OIDC Identity Provider](../add-oidc-provider)

--- a/docs/content/guides/guides/identity-providers/manage-identity-providers.mdx
+++ b/docs/content/guides/guides/identity-providers/manage-identity-providers.mdx
@@ -3,16 +3,12 @@ title: Manage Identity Providers
 docType: guide
 sidebar_position: 1
 persona: iam
-description: Create, update, and delete identity providers in {{ProductName}} using the REST API.
+description: View, update, and delete identity provider connections from the {{ProductName}} Console.
 ---
 
 # Manage Identity Providers
 
-This guide explains how to create, update, and delete identity providers using the <ProductName /> Identity Provider API.
-
-:::note
-Identity provider management through the <ProductName /> Console is not yet available. Use the API commands in this guide to manage identity providers.
-:::
+This guide explains how to view, update, and delete identity providers from the <ProductName /> Console.
 
 For provider-specific setup instructions, see:
 
@@ -24,134 +20,38 @@ For provider-specific setup instructions, see:
 ## Prerequisites
 
 - <ProductName /> is running. See [Get Started](../../../getting-started/get-thunderid).
-- An access token with the `system` scope.
+- You can sign in to the <ProductName /> Console.
 
-## Create an Identity Provider
+## View Identity Providers
 
-The vendor is selected by URL path: `/connections/google`, `/connections/github`, `/connections/oidc`, or `/connections/oauth`. Send a `POST` request to `/connections/{vendor}`:
+1. Sign in to the <ProductName /> Console.
+2. Navigate to **Connections**. Each configured identity provider appears as a card, showing **Configured**, **Not configured**, or **Coming soon**.
+3. Use the **Social Login** or **Enterprise** category filters to narrow the list to identity providers.
+4. Click a card to open the connection's detail page.
 
-```bash
-curl -kL -X POST https://localhost:8090/connections/google \
-  -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer <access-token>' \
-  -d '{
-    "name": "My Provider",
-    "description": "Optional description",
-    "clientId": "<client-id>",
-    "clientSecret": "<client-secret>",
-    "redirectUri": "https://localhost:8090/gate/callback"
-  }'
-```
-
-Each vendor accepts a different set of fields. See [Add a Google Identity Provider](../add-google), [Add a GitHub Identity Provider](../add-github), [Add an OIDC Identity Provider](../add-oidc-provider), and [Add an OAuth 2.0 Identity Provider](../add-oauth-provider) for the full field reference of each.
-
-**Response (201 Created):**
-
-```json
-{
-  "id": "550e8400-e29b-41d4-a716-446655440000",
-  "name": "My Provider",
-  "description": "Optional description",
-  "type": "google",
-  "clientId": "<client-id>",
-  "clientSecret": "******",
-  "redirectUri": "https://localhost:8090/gate/callback"
-}
-```
-
-Secret field values are masked (`******`) in all API responses.
-
-## List Identity Providers
-
-To list identity providers across all vendors, send a `GET` request to `/connections?category=identity-provider`:
-
-```bash
-curl -kL https://localhost:8090/connections?category=identity-provider \
-  -H 'Authorization: Bearer <access-token>'
-```
-
-**Response (200 OK):**
-
-```json
-{
-  "totalResults": 1,
-  "startIndex": 1,
-  "count": 1,
-  "connections": [
-    {
-      "id": "550e8400-e29b-41d4-a716-446655440000",
-      "name": "Google",
-      "description": "Google social login",
-      "type": "google",
-      "categories": ["identity-provider"]
-    }
-  ],
-  "links": []
-}
-```
-
-To list only the identity providers of one vendor, send a `GET` request to `/connections/{vendor}` instead:
-
-```bash
-curl -kL https://localhost:8090/connections/google \
-  -H 'Authorization: Bearer <access-token>'
-```
-
-**Response (200 OK):**
-
-```json
-[
-  {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "name": "Google",
-    "description": "Google social login"
-  }
-]
-```
-
-## Get an Identity Provider
-
-Send a `GET` request to `/connections/{vendor}/{id}`:
-
-```bash
-curl -kL https://localhost:8090/connections/google/<idp-id> \
-  -H 'Authorization: Bearer <access-token>'
-```
+On the detail page, the **General** tab's **Quick copy** section shows the **Connection ID**, an identifier you can copy for use in your integration.
 
 ## Update an Identity Provider
 
-Send a `PUT` request to `/connections/{vendor}/{id}` with the full updated payload. The request body uses the same structure as the create request. Omit the secret field (for example `clientSecret`) to keep the value currently stored:
+1. Open the connection from the Connections page.
+2. On the **General** tab, edit the fields under **Credentials**.
+3. Stored secrets, such as **Client secret**, are write-only: the field stays locked until you click **Update**. Leave it unchanged to keep the stored secret.
+4. Click **Save changes** in the bar at the bottom of the page. You can click **Discard** instead to abandon your edits.
 
-```bash
-curl -kL -X PUT https://localhost:8090/connections/google/<idp-id> \
-  -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer <access-token>' \
-  -d '{
-    "name": "My Provider",
-    "clientId": "<new-client-id>",
-    "redirectUri": "https://localhost:8090/gate/callback"
-  }'
-```
+Only custom OIDC and OAuth 2.0 connections have an editable **Connection name**. Google, GitHub, and other branded connections keep the vendor's name.
 
 Changes take effect immediately for new authentication requests.
 
 ## Delete an Identity Provider
 
-Send a `DELETE` request to `/connections/{vendor}/{id}`:
+1. Open the connection from the Connections page.
+2. On the **General** tab, go to **Danger zone** and click **Delete connection**.
+3. Confirm the deletion in the dialog.
 
-```bash
-curl -kL -X DELETE https://localhost:8090/connections/google/<idp-id> \
-  -H 'Authorization: Bearer <access-token>'
-```
-
-A successful delete returns `204 No Content`.
-
-:::warning
-Deleting an identity provider is permanent. If an authentication flow (or another resource) still references this identity provider, the delete request is rejected with `409 Conflict`. Remove or update the referencing resources, for example, the flow node that uses this IdP, before deleting it.
-:::
+If an authentication flow or another resource still references this identity provider, the dialog lists the resources and blocks the deletion until you remove or update them, for example, the flow node that uses this connection.
 
 :::note
-Read-only identity providers created through declarative configuration return an error when you attempt to delete them via the API.
+Identity providers created through declarative configuration are read-only. Deleting one fails even when no other resource references it.
 :::
 
 ## Next Steps

--- a/docs/content/guides/guides/identity-providers/overview.mdx
+++ b/docs/content/guides/guides/identity-providers/overview.mdx
@@ -19,15 +19,11 @@ An identity provider (IdP) in <ProductName /> represents an external system that
 | **OIDC** | Connect any standard OpenID Connect-compliant provider. You supply the endpoints. |
 | **OAuth** | Connect any OAuth 2.0 provider that does not support OIDC discovery. You supply all endpoint URLs. |
 
-:::note
-Identity provider management through the <ProductName /> Console is not yet available. Use the Identity Provider REST API to create and manage identity providers.
-:::
-
 ## How IdPs Connect to Applications
 
 Applications in <ProductName /> do not reference IdPs directly. The connection runs through authentication flows:
 
-1. You create an IdP using the API and configure its credentials.
+1. You configure the IdP as a connection on the Console's **Connections** page.
 2. You add a social login executor to an authentication flow and configure it with the IdP.
 3. You assign that flow to your application.
 
@@ -46,7 +42,7 @@ Choose the guide for your provider type:
 
 ## Manage Identity Providers
 
-- [Manage Identity Providers](../manage-identity-providers): Create, update, and delete identity providers using the API.
+- [Manage Identity Providers](../manage-identity-providers): View, update, and delete identity providers from the <ProductName /> Console.
 
 ## Next Steps
 

--- a/docs/content/guides/guides/notifications/sms-providers.mdx
+++ b/docs/content/guides/guides/notifications/sms-providers.mdx
@@ -1,12 +1,13 @@
 ---
 title: Configure an SMS Provider
 docType: guide
-description: Set up an SMS notification sender to deliver One-Time Passwords and other SMS messages in {{ProductName}}.
+persona: iam
+description: Connect a messaging provider from the {{ProductName}} Console to deliver One-Time Passwords and other SMS messages.
 ---
 
 # Configure an SMS Provider
 
-<ProductName /> sends SMS messages, such as One-Time Passwords (OTPs), through a notification sender. A notification sender connects <ProductName /> to a messaging provider that delivers SMS to end users.
+<ProductName /> sends SMS messages, such as One-Time Passwords (OTPs), through an SMS connection. An SMS connection links <ProductName /> to a messaging provider that delivers SMS to end users.
 
 Three messaging providers are supported:
 
@@ -17,6 +18,7 @@ Three messaging providers are supported:
 ## Prerequisites
 
 - A <ProductName /> instance running and accessible
+- You can sign in to the <ProductName /> Console
 - An active account with your chosen messaging provider
 
 ## Add an SMS Provider
@@ -24,56 +26,28 @@ Three messaging providers are supported:
 ### Twilio
 
 1. Log in to [Twilio](https://www.twilio.com) and retrieve your **Account SID**, **Auth Token**, and the phone number or messaging service SID to use as the sender.
+2. Sign in to the <ProductName /> Console and navigate to **Connections**.
+3. Click the **Twilio** card. If the card shows **Not configured**, this opens a form to create the connection. If it already shows **Configured**, this opens the existing connection instead.
+4. Enter the following fields, then click **Create connection**:
 
-2. Send a `POST` request to the Twilio connection API:
-
-```bash
-curl -X POST https://localhost:8090/connections/twilio \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer <access_token>" \
-  -d '{
-    "name": "TwilioSMSSender",
-    "description": "Twilio SMS provider for OTP delivery",
-    "accountSid": "<your-account-sid>",
-    "authToken": "<your-auth-token>",
-    "senderId": "<your-phone-number>"
-  }'
-```
-
-#### Twilio Fields
-
-| Field | Required | Secret | Description |
-| :--- | :---: | :---: | :--- |
-| `accountSid` | ✅ | ❌ | Twilio Account SID. Must start with `AC`. |
-| `authToken` | ✅ | ✅ | Twilio Auth Token used to authenticate API requests. |
-| `senderId` | ✅ | ❌ | The Twilio phone number or messaging service SID used as the sender. |
+   | Field | Description |
+   | :--- | :--- |
+   | **Account SID** | Twilio Account SID, starting with `AC` followed by 32 hex characters. |
+   | **Auth token** | Twilio auth token used to authenticate API requests. |
+   | **Sender ID** | The Twilio phone number or messaging service SID used as the sender. |
 
 ### Vonage
 
 1. Log in to the [Vonage API Dashboard](https://dashboard.nexmo.com) and retrieve your **API Key**, **API Secret**, and sender name or virtual number.
+2. Sign in to the <ProductName /> Console and navigate to **Connections**.
+3. Click the **Vonage** card. If the card shows **Not configured**, this opens a form to create the connection. If it already shows **Configured**, this opens the existing connection instead.
+4. Enter the following fields, then click **Create connection**:
 
-2. Send a `POST` request to the Vonage connection API:
-
-```bash
-curl -X POST https://localhost:8090/connections/vonage \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer <access_token>" \
-  -d '{
-    "name": "VonageSMSSender",
-    "description": "Vonage SMS provider for OTP delivery",
-    "apiKey": "<your-api-key>",
-    "apiSecret": "<your-api-secret>",
-    "senderId": "<your-sender-name>"
-  }'
-```
-
-#### Vonage Fields
-
-| Field | Required | Secret | Description |
-| :--- | :---: | :---: | :--- |
-| `apiKey` | ✅ | ❌ | Vonage API Key from the API Dashboard. |
-| `apiSecret` | ✅ | ✅ | Vonage API Secret used to authenticate API requests. |
-| `senderId` | ✅ | ❌ | Sender name or virtual number displayed to recipients. |
+   | Field | Description |
+   | :--- | :--- |
+   | **API key** | Vonage API key from your Vonage dashboard. |
+   | **API secret** | Vonage API secret used to authenticate API requests. |
+   | **Sender ID** | Phone number or alphanumeric sender ID messages are sent from. |
 
 :::note
 Vonage requires the recipient phone number in E.164 format without a leading `+` or `00`. <ProductName /> strips these prefixes automatically before sending.
@@ -81,7 +55,11 @@ Vonage requires the recipient phone number in E.164 format without a leading `+`
 
 ### Custom Provider
 
-Use the `sms-gateway` connection to connect <ProductName /> to any SMS gateway that accepts HTTP requests.
+:::note
+The Console's **SMS gateway** connection type is coming soon. Until it ships, create a custom SMS gateway connection through the API.
+:::
+
+Use the `sms-gateway` connection to connect <ProductName /> to any SMS gateway that accepts HTTP requests. Send a `POST` request to `/connections/sms-gateway` with an access token that has the `system` scope:
 
 ```bash
 curl -X POST https://localhost:8090/connections/sms-gateway \
@@ -106,41 +84,26 @@ curl -X POST https://localhost:8090/connections/sms-gateway \
 | `contentType` | ❌ | ❌ | Request body format. Supported values: `JSON`, `FORM`. |
 | `httpHeaders` | ❌ | ❌ | Comma-separated list of additional HTTP headers in `Key: Value` format. |
 
+See the [Connections API Reference](../../../../apis#tag/connections) for the full request and response shapes.
+
 ## Update an SMS Provider
 
-To update an existing sender, send a `PUT` request to `/connections/{vendor}/{id}` with the sender's ID:
-
-```bash
-curl -X PUT https://localhost:8090/connections/twilio/<sender-id> \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer <access_token>" \
-  -d '{
-    "name": "TwilioSMSSender",
-    "accountSid": "<your-account-sid>",
-    "authToken": "<new-auth-token>",
-    "senderId": "<your-phone-number>"
-  }'
-```
+1. Open the connection from the Connections page.
+2. On the **General** tab, edit the fields under **Credentials**.
+3. Stored secrets, such as **Auth token** or **API secret**, are write-only: the field stays locked until you click **Update**. Leave it unchanged to keep the stored secret.
+4. Click **Save changes** in the bar at the bottom of the page. You can click **Discard** instead to abandon your edits.
 
 :::note
-A connection's vendor cannot be changed after creation. To switch providers, delete the existing connection and create a new one under the new vendor's path.
+A connection's vendor cannot be changed after creation. To switch providers, delete the existing connection and create a new one for the new vendor.
 :::
 
-## List and Remove SMS Providers
+## Remove an SMS Provider
 
-**List all SMS providers:**
+1. Open the connection from the Connections page.
+2. On the **General** tab, go to **Danger zone** and click **Delete connection**.
+3. Confirm the deletion in the dialog.
 
-```bash
-curl https://localhost:8090/connections?category=sms-provider \
-  -H "Authorization: Bearer <access_token>"
-```
-
-**Delete an SMS provider:**
-
-```bash
-curl -X DELETE https://localhost:8090/connections/twilio/<sender-id> \
-  -H "Authorization: Bearer <access_token>"
-```
+If another resource still references this SMS provider, the dialog lists the resources and blocks the deletion until you remove or update them.
 
 ## Next Steps
 


### PR DESCRIPTION
### Purpose
The Console now has a unified Connections UI covering identity providers (Google, GitHub, OIDC, OAuth 2.0) and SMS providers (Twilio, Vonage). The identity-provider and SMS-provider guides still walked through curl/API steps only. This PR rewrites the setup, management, and SMS guides to use the Console UI, no screenshots, and keeps API-only detail (custom SMS gateway, `prompt`, `logoutEndpoint`, `attributeConfiguration` on OAuth) called out as such with links to the API reference.

It also removes a small skill-tooling issue found while doing this: `/docs-edit` was stamping `<!-- docs-review-style: step-count-confirmed ... -->` / `step-locality-confirmed` HTML comments into published `.mdx` files so `/docs-review-style` could skip re-asking two structural review questions on a later pass. That leaked tool-internal review state into version-controlled doc content. Both checks are now review-time only: `docs-review-style` still asks when a sequence trips a threshold (10+ steps, or unforced screen bouncing), it just no longer persists the answer inline in the page.

### Approach
- `add-google.mdx` / `add-github.mdx`: the OAuth app registration step (external provider console) is unchanged; the "create the connection" step now walks the Console's Connections page and vendor configure form instead of a curl POST. `prompt` (no UI field) is called out as API-only.
- `add-oidc-provider.mdx` / `add-oauth-provider.mdx`: the create flow now follows the "Add custom connection" wizard (type picker → configure form). The Attribute Configuration and Account Linking sections describe the connection detail page's Attribute Configuration tab instead of raw JSON payloads. OAuth 2.0 correctly notes it has no Attribute Configuration tab (API-only via `attributeConfiguration`).
- `manage-identity-providers.mdx`: rebuilt around View / Update / Delete through the Console (write-only secrets with an Update button, deletion blocked while another resource references the connection, read-only declarative connections).
- `sms-providers.mdx`: Twilio and Vonage go through the Console; the custom SMS gateway keeps its curl steps behind a note since the Console's "SMS gateway" wizard card is disabled ("Coming soon").
- `overview.mdx` / `connect-idp-to-application.mdx`: small wording updates removing the "Console not yet available" note and repointing prerequisite text at the Console.
- No API reference changes were needed: `api/connections.yaml` already documents the full Connections CRUD surface (including `sms-gateway`), and the legacy `/identity-providers` and `/notification-senders` specs are already gone from this branch with no remaining backend routes.
- All Console UI labels, field names, and button text used in the rewritten guides were verified against `frontend/packages/i18n/src/locales/en-US.ts` and `frontend/packages/configure-connections/src/config/connectionFormFields.ts`.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3503

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [x] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated identity provider guides (GitHub, Google, OAuth 2.0, OIDC) to use Console-driven connection setup with revised prerequisites and step-by-step workflows.
  * Expanded guidance on connection configuration details (copyable/read-only Redirect URI, federation/token exchange requirements, and attribute configuration/account linking behavior).
  * Clarified fields not editable in Console (e.g., advanced options like prompt/logout endpoint must be set via the API).
  * Refreshed identity provider overview, connection-to-application linking, and Console-based management (including credential edit behavior and deletion safeguards).
  * Updated SMS provider guide to emphasize Console setup for Twilio/Vonage and Console-based credential updates/deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->