### PR TITLE
feat(scim): Add filter query (eq) support for SCIM Users

### DIFF
--- a/backend/internal/scim/SCIMUsersServiceInterface_mock_test.go
+++ b/backend/internal/scim/SCIMUsersServiceInterface_mock_test.go
@@ -256,8 +256,8 @@ func (_c *SCIMUsersServiceInterfaceMock_GetUser_Call) RunAndReturn(run func(ctx 
 }
 
 // ListUsers provides a mock function for the type SCIMUsersServiceInterfaceMock
-func (_mock *SCIMUsersServiceInterfaceMock) ListUsers(ctx context.Context, startIndex int, count int, baseURL string) (SCIMUserListResponse, *common.ServiceError) {
-	ret := _mock.Called(ctx, startIndex, count, baseURL)
+func (_mock *SCIMUsersServiceInterfaceMock) ListUsers(ctx context.Context, startIndex int, count int, filters map[string]interface{}, baseURL string) (SCIMUserListResponse, *common.ServiceError) {
+	ret := _mock.Called(ctx, startIndex, count, filters, baseURL)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListUsers")
@@ -265,16 +265,16 @@ func (_mock *SCIMUsersServiceInterfaceMock) ListUsers(ctx context.Context, start
 
 	var r0 SCIMUserListResponse
 	var r1 *common.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int, string) (SCIMUserListResponse, *common.ServiceError)); ok {
-		return returnFunc(ctx, startIndex, count, baseURL)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int, map[string]interface{}, string) (SCIMUserListResponse, *common.ServiceError)); ok {
+		return returnFunc(ctx, startIndex, count, filters, baseURL)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int, string) SCIMUserListResponse); ok {
-		r0 = returnFunc(ctx, startIndex, count, baseURL)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int, map[string]interface{}, string) SCIMUserListResponse); ok {
+		r0 = returnFunc(ctx, startIndex, count, filters, baseURL)
 	} else {
 		r0 = ret.Get(0).(SCIMUserListResponse)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int, string) *common.ServiceError); ok {
-		r1 = returnFunc(ctx, startIndex, count, baseURL)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int, map[string]interface{}, string) *common.ServiceError); ok {
+		r1 = returnFunc(ctx, startIndex, count, filters, baseURL)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*common.ServiceError)
@@ -292,12 +292,13 @@ type SCIMUsersServiceInterfaceMock_ListUsers_Call struct {
 //   - ctx context.Context
 //   - startIndex int
 //   - count int
+//   - filters map[string]interface{}
 //   - baseURL string
-func (_e *SCIMUsersServiceInterfaceMock_Expecter) ListUsers(ctx interface{}, startIndex interface{}, count interface{}, baseURL interface{}) *SCIMUsersServiceInterfaceMock_ListUsers_Call {
-	return &SCIMUsersServiceInterfaceMock_ListUsers_Call{Call: _e.mock.On("ListUsers", ctx, startIndex, count, baseURL)}
+func (_e *SCIMUsersServiceInterfaceMock_Expecter) ListUsers(ctx interface{}, startIndex interface{}, count interface{}, filters interface{}, baseURL interface{}) *SCIMUsersServiceInterfaceMock_ListUsers_Call {
+	return &SCIMUsersServiceInterfaceMock_ListUsers_Call{Call: _e.mock.On("ListUsers", ctx, startIndex, count, filters, baseURL)}
 }
 
-func (_c *SCIMUsersServiceInterfaceMock_ListUsers_Call) Run(run func(ctx context.Context, startIndex int, count int, baseURL string)) *SCIMUsersServiceInterfaceMock_ListUsers_Call {
+func (_c *SCIMUsersServiceInterfaceMock_ListUsers_Call) Run(run func(ctx context.Context, startIndex int, count int, filters map[string]interface{}, baseURL string)) *SCIMUsersServiceInterfaceMock_ListUsers_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -311,15 +312,20 @@ func (_c *SCIMUsersServiceInterfaceMock_ListUsers_Call) Run(run func(ctx context
 		if args[2] != nil {
 			arg2 = args[2].(int)
 		}
-		var arg3 string
+		var arg3 map[string]interface{}
 		if args[3] != nil {
-			arg3 = args[3].(string)
+			arg3 = args[3].(map[string]interface{})
+		}
+		var arg4 string
+		if args[4] != nil {
+			arg4 = args[4].(string)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -330,7 +336,7 @@ func (_c *SCIMUsersServiceInterfaceMock_ListUsers_Call) Return(sCIMUserListRespo
 	return _c
 }
 
-func (_c *SCIMUsersServiceInterfaceMock_ListUsers_Call) RunAndReturn(run func(ctx context.Context, startIndex int, count int, baseURL string) (SCIMUserListResponse, *common.ServiceError)) *SCIMUsersServiceInterfaceMock_ListUsers_Call {
+func (_c *SCIMUsersServiceInterfaceMock_ListUsers_Call) RunAndReturn(run func(ctx context.Context, startIndex int, count int, filters map[string]interface{}, baseURL string) (SCIMUserListResponse, *common.ServiceError)) *SCIMUsersServiceInterfaceMock_ListUsers_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/scim/config/config.go
+++ b/backend/internal/scim/config/config.go
@@ -31,7 +31,7 @@ import (
 const (
 	// PatchSupported indicates that the SCIM PATCH operation is supported
 	// per RFC 7644 §3.5.2.
-	PatchSupported = true
+	PatchSupported = false
 
 	// BulkSupported indicates that SCIM Bulk operations are not yet
 	// implemented per RFC 7644 §3.7.
@@ -47,7 +47,7 @@ const (
 
 	// FilterSupported indicates whether SCIM filtering is supported
 	// per RFC 7644 §3.4.2.2.
-	FilterSupported = false
+	FilterSupported = true
 
 	// FilterMaxResults caps the number of resources returned in a single
 	// filtered query, guarding against excessively large result sets.

--- a/backend/internal/scim/core_attr_mapper.go
+++ b/backend/internal/scim/core_attr_mapper.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package scim
 
 import (
@@ -156,6 +174,77 @@ var coreAttrRules = []coreAttrRule{
 		kind:      kindAddrPart,
 		subAttr:   "country",
 	},
+}
+
+// scimToThunderAttrIndex is a pre-built, lowercase-keyed reverse lookup of
+// coreAttrRules, mapping a SCIM filter attribute path (e.g. "username",
+// "emails.value", "name.givenname", "addresses.streetaddress") to its
+// ThunderID attribute name. Built once at package init so filter translation
+// is an O(1) map lookup instead of a per-request scan of coreAttrRules.
+var scimToThunderAttrIndex = buildSCIMToThunderAttrIndex()
+
+func buildSCIMToThunderAttrIndex() map[string]string {
+	index := make(map[string]string)
+	for _, rule := range coreAttrRules {
+		switch rule.kind {
+		case kindSimpleString:
+			index[strings.ToLower(string(rule.scimField))] = rule.candidate
+		case kindMultiComplex:
+			index[strings.ToLower(string(rule.scimField))] = rule.candidate
+			valueKey := rule.valueKey
+			if valueKey == "" {
+				valueKey = scimValueKey
+			}
+			index[strings.ToLower(string(rule.scimField)+"."+valueKey)] = rule.candidate
+		case kindSubAttr:
+			index[strings.ToLower(string(rule.parentField)+"."+rule.subAttr)] = rule.candidate
+		case kindAddrPart:
+			index[strings.ToLower(string(scimFieldAddresses)+"."+rule.subAttr)] = rule.candidate
+		}
+	}
+	return index
+}
+
+// translateSCIMFilterAttr translates a SCIM filter attribute path into its
+// ThunderID attribute name using scimToThunderAttrIndex. Attributes with no
+// core mapping (id, active, custom schema attributes already in ThunderID
+// naming, etc.) are passed through unchanged.
+func translateSCIMFilterAttr(attr string) string {
+	if thunderAttr, ok := scimToThunderAttrIndex[strings.ToLower(attr)]; ok {
+		return thunderAttr
+	}
+	return attr
+}
+
+// scimUnsupportedMultiComplexSubAttrs: sub-attrs ThunderID never stores as a flat
+// field, regardless of scalar/array schema. "value" excluded — wrong only for
+// array schemas, undetectable at filter-parse time.
+var scimUnsupportedMultiComplexSubAttrs = []string{"type", "primary"}
+
+// scimUnsupportedFilterAttrs: filter paths on multi-valued core attrs (emails,
+// phoneNumbers, photos) with no flat equivalent to compare against, e.g.
+// "emails.type". Filtering these errors instead of silently matching nothing.
+var scimUnsupportedFilterAttrs = buildSCIMUnsupportedFilterAttrs()
+
+func buildSCIMUnsupportedFilterAttrs() map[string]struct{} {
+	unsupported := make(map[string]struct{})
+	for _, rule := range coreAttrRules {
+		if rule.kind != kindMultiComplex {
+			continue
+		}
+		for _, subAttr := range scimUnsupportedMultiComplexSubAttrs {
+			unsupported[strings.ToLower(string(rule.scimField)+"."+subAttr)] = struct{}{}
+		}
+	}
+	return unsupported
+}
+
+// isUnsupportedSCIMFilterAttr reports whether attr is a recognized but
+// currently unsupported SCIM filter attribute path (see
+// scimUnsupportedFilterAttrs).
+func isUnsupportedSCIMFilterAttr(attr string) bool {
+	_, ok := scimUnsupportedFilterAttrs[strings.ToLower(attr)]
+	return ok
 }
 
 func mapToCoreAttrs(rawAttrs json.RawMessage) map[string]json.RawMessage {

--- a/backend/internal/scim/core_attr_mapper_test.go
+++ b/backend/internal/scim/core_attr_mapper_test.go
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package scim
 
 import (
@@ -461,4 +479,54 @@ func TestHasPrimary_False(t *testing.T) {
 func TestHasPrimary_Missing(t *testing.T) {
 	arr := []map[string]interface{}{{}}
 	require.False(t, hasPrimary(arr))
+}
+
+// --- translateSCIMFilterAttr ---
+
+func TestTranslateSCIMFilterAttr(t *testing.T) {
+	tests := []struct {
+		name string
+		attr string
+		want string
+	}{
+		{"simple string", "userName", "username"},
+		{"sub-attribute", "name.givenName", "given_name"},
+		{"multi-valued bare key", "emails", "email"},
+		{"multi-valued value sub-key", "emails.value", "email"},
+		{"address sub-attribute", "addresses.streetAddress", "street_address"},
+		{"case insensitive", "USERNAME", "username"},
+		{"unmapped passthrough", "active", "active"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, translateSCIMFilterAttr(tt.attr))
+		})
+	}
+}
+
+// --- isUnsupportedSCIMFilterAttr ---
+
+func TestIsUnsupportedSCIMFilterAttr(t *testing.T) {
+	tests := []struct {
+		name string
+		attr string
+		want bool
+	}{
+		{"emails type sub-key", "emails.type", true},
+		{"phoneNumbers type sub-key", "phoneNumbers.type", true},
+		{"photos type sub-key", "photos.type", true},
+		{"emails primary sub-key", "emails.primary", true},
+		{"phoneNumbers primary sub-key", "phoneNumbers.primary", true},
+		{"photos primary sub-key", "photos.primary", true},
+		{"case insensitive type", "EMAILS.TYPE", true},
+		{"case insensitive primary", "EMAILS.PRIMARY", true},
+		{"emails value sub-key is supported", "emails.value", false},
+		{"emails bare key is supported", "emails", false},
+		{"unrelated attribute", "userName", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isUnsupportedSCIMFilterAttr(tt.attr))
+		})
+	}
 }

--- a/backend/internal/scim/users_handler.go
+++ b/backend/internal/scim/users_handler.go
@@ -4,13 +4,22 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strconv"
+	"strings"
 
+	"github.com/thunder-id/thunderid/internal/system/database/utils"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 )
 
 const loggerComponentName = "scim"
+
+var (
+	scimFilterQuotedStringRe = regexp.MustCompile(`"([^"\\]|\\.)*"`)
+	scimFilterEqRe           = regexp.MustCompile(`(?i)^((?:[A-Za-z0-9][A-Za-z0-9.\-_]*:)*)` +
+		`([A-Za-z][A-Za-z0-9.\-_]*)\s+eq\s+(.+)$`)
+)
 
 // scimUsersHandler handles all /scim/v2/Users HTTP requests.
 type scimUsersHandler struct {
@@ -28,10 +37,20 @@ func (h *scimUsersHandler) HandleUsersListRequest(w http.ResponseWriter, r *http
 	ctx := r.Context()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 
-	// ?filter is not supported in this implementation.
-	if r.URL.Query().Get("filter") != "" {
-		h.handleSCIMError(w, r, &ErrorFilterNotSupported)
-		return
+	// Parse optional SCIM filter — only single "eq" expressions are supported.
+	var parsedFilters map[string]interface{}
+	if filterStr := r.URL.Query().Get("filter"); filterStr != "" {
+		var err error
+		parsedFilters, err = parseSCIMFilterForEq(filterStr)
+		if err != nil {
+			writeSCIMErrorResponse(ctx, w, http.StatusBadRequest, SCIMErrorResponse{
+				Schemas:  []string{SCIMErrorSchemaURN},
+				Status:   "400",
+				ScimType: "invalidFilter",
+				Detail:   err.Error(),
+			})
+			return
+		}
 	}
 	startIndex := 1
 	count := 20
@@ -45,7 +64,7 @@ func (h *scimUsersHandler) HandleUsersListRequest(w http.ResponseWriter, r *http
 			count = n
 		}
 	}
-	listResp, svcErr := h.svc.ListUsers(ctx, startIndex, count, h.baseURL)
+	listResp, svcErr := h.svc.ListUsers(ctx, startIndex, count, parsedFilters, h.baseURL)
 	if svcErr != nil {
 		h.handleSCIMError(w, r, svcErr)
 		return
@@ -183,4 +202,94 @@ func (h *scimUsersHandler) handleSCIMError(w http.ResponseWriter, r *http.Reques
 		ScimType: scimType,
 		Detail:   svcErr.ErrorDescription.DefaultValue,
 	})
+}
+
+// parseSCIMFilterForEq parses a SCIM filter string that contains exactly one
+// "eq" comparison and no logical operators, grouping, or square brackets.
+// Returns a native filter map suitable for userService.GetUserList, or an
+// error if the expression uses any unsupported syntax.
+func parseSCIMFilterForEq(filterStr string) (map[string]interface{}, error) {
+	filterStr = strings.TrimSpace(filterStr)
+	if filterStr == "" {
+		return nil, nil
+	}
+	sanitized := scimFilterQuotedStringRe.ReplaceAllString(filterStr, `""`)
+	lower := strings.ToLower(sanitized)
+	// Reject all compound/complex expressions up front (outside of quoted strings).
+	if strings.Contains(lower, " and ") ||
+		strings.Contains(lower, " or ") ||
+		strings.HasPrefix(lower, "not ") ||
+		strings.ContainsAny(sanitized, "()[]") {
+		return nil, fmt.Errorf(
+			"compound filter expressions are not supported; only a single 'eq' expression is supported",
+		)
+	}
+	// Reject any operator that is not "eq".
+	// These keywords may appear as part of an unsupported operator.
+	unsupportedOps := []string{" ne ", " co ", " sw ", " ew ", " pr", " gt ", " lt ", " ge ", " le "}
+	for _, op := range unsupportedOps {
+		if strings.Contains(lower, op) {
+			// Extract the actual operator token for the error message.
+			return nil, fmt.Errorf(
+				"the specified filter operator is not supported; only 'eq' is supported",
+			)
+		}
+	}
+	// Match: [optional-URN-prefix:]attrPath eq compValue
+	// attrPath allows alphanumeric, underscore, hyphen, and dot (for sub-attributes).
+	// compValue is a quoted string, a boolean literal, or a number.
+	matches := scimFilterEqRe.FindStringSubmatch(filterStr)
+	if len(matches) == 0 {
+		return nil, fmt.Errorf(
+			"invalid filter expression; expected format: 'attrPath eq value'",
+		)
+	}
+	// matches[1] = optional URN prefix (e.g. "urn:thunderid:params:scim:schemas:employee:2.0:User:")
+	// matches[2] = attribute path (e.g. "profile.manager.id")
+	// matches[3] = raw comparison value
+	if isUnsupportedSCIMFilterAttr(matches[2]) {
+		return nil, fmt.Errorf("filtering on %q is not supported", matches[2])
+	}
+	attribute := translateSCIMFilterAttr(matches[2])
+	if err := utils.ValidateKey(attribute); err != nil {
+		return nil, fmt.Errorf("filtering on %q is not supported", matches[2])
+	}
+	rawValue := strings.TrimSpace(matches[3])
+	value, err := parseSCIMCompValue(rawValue)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{attribute: value}, nil
+}
+
+// parseSCIMCompValue converts a raw SCIM compValue token into a typed Go value.
+// compValue = false / null / true / number / string  (RFC 7159 JSON rules)
+func parseSCIMCompValue(raw string) (interface{}, error) {
+	// Quoted string — parse as a JSON string literal so escapes are handled correctly.
+	if len(raw) > 0 && raw[0] == '"' {
+		s, err := strconv.Unquote(raw)
+		if err == nil {
+			return s, nil
+		}
+		return nil, fmt.Errorf("invalid quoted string comparison value: %q", raw)
+	}
+	lower := strings.ToLower(raw)
+	switch lower {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	case "null":
+		// null comparisons are not meaningful for our store.
+		return nil, fmt.Errorf("null comparison values are not supported")
+	}
+	// Integer
+	if intVal, err := strconv.ParseInt(raw, 10, 64); err == nil {
+		return intVal, nil
+	}
+	// Decimal
+	if floatVal, err := strconv.ParseFloat(raw, 64); err == nil {
+		return floatVal, nil
+	}
+	return nil, fmt.Errorf("unrecognized comparison value: %q", raw)
 }

--- a/backend/internal/scim/users_handler_test.go
+++ b/backend/internal/scim/users_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	neturl "net/url"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -114,7 +115,8 @@ func TestHandleUsersListRequest_Success(t *testing.T) {
 		ItemsPerPage: 20,
 		Resources:    []SCIMUser{},
 	}
-	mockSvc.On("ListUsers", mock.Anything, 1, 20, testBaseURL).Return(expectedResp, (*tidcommon.ServiceError)(nil))
+	mockSvc.On("ListUsers", mock.Anything, 1, 20, mock.Anything,
+		testBaseURL).Return(expectedResp, (*tidcommon.ServiceError)(nil))
 
 	h := newSCIMUsersHandler(mockSvc, testBaseURL)
 	req := httptest.NewRequest(http.MethodGet, "/scim/v2/Users", nil)
@@ -372,6 +374,19 @@ func TestHandleUsersReplaceRequest_EmptyBody_Returns400(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
+func TestHandleUsersReplaceRequest_InvalidJSON_Returns400(t *testing.T) {
+	h := newSCIMUsersHandler(NewSCIMUsersServiceInterfaceMock(t), testBaseURL)
+	req := httptest.NewRequest(http.MethodPut, "/scim/v2/Users/user-123",
+		bytes.NewBufferString(`not json`))
+	req.SetPathValue("id", "user-123")
+	req.Header.Set("Content-Type", constants.SCIMContentType)
+	rr := httptest.NewRecorder()
+
+	h.HandleUsersReplaceRequest(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
 func TestHandleUsersReplaceRequest_NotFound_Returns404(t *testing.T) {
 	mockSvc := NewSCIMUsersServiceInterfaceMock(t)
 	mockSvc.On("ReplaceUser", mock.Anything, "no-such",
@@ -419,7 +434,9 @@ func TestHandleUsersReplaceRequest_MutabilityViolation_Returns400(t *testing.T) 
 
 func TestHandleUsersListRequest_FilterNotSupported_Returns400(t *testing.T) {
 	h := newSCIMUsersHandler(NewSCIMUsersServiceInterfaceMock(t), testBaseURL)
-	req := httptest.NewRequest(http.MethodGet, `/scim/v2/Users?filter=userName+eq+"alice"`, nil)
+	// Compound "and" expressions are unsupported; only single "eq" is allowed.
+	req := httptest.NewRequest(http.MethodGet,
+		`/scim/v2/Users?filter=userName+eq+"alice"+and+active+eq+true`, nil)
 	rr := httptest.NewRecorder()
 
 	h.HandleUsersListRequest(rr, req)
@@ -430,9 +447,107 @@ func TestHandleUsersListRequest_FilterNotSupported_Returns400(t *testing.T) {
 	require.Equal(t, "invalidFilter", errResp.ScimType)
 }
 
+func TestHandleUsersListRequest_FilterOnMultiValueUnsupportedSubAttr_Returns400(t *testing.T) {
+	// "emails.type"/"emails.primary" have no matching flat ThunderID attribute
+	// — ThunderID only stores the value, never a per-entry type or primary
+	// flag — so they're rejected explicitly instead of silently matching
+	// nothing.
+	tests := []string{
+		`emails.type+eq+"work"`,
+		`emails.primary+eq+true`,
+	}
+	for _, filter := range tests {
+		t.Run(filter, func(t *testing.T) {
+			h := newSCIMUsersHandler(NewSCIMUsersServiceInterfaceMock(t), testBaseURL)
+			req := httptest.NewRequest(http.MethodGet,
+				"/scim/v2/Users?filter="+filter, nil)
+			rr := httptest.NewRecorder()
+
+			h.HandleUsersListRequest(rr, req)
+
+			require.Equal(t, http.StatusBadRequest, rr.Code)
+			var errResp SCIMErrorResponse
+			require.NoError(t, json.NewDecoder(rr.Body).Decode(&errResp))
+			require.Equal(t, "invalidFilter", errResp.ScimType)
+		})
+	}
+}
+
+func TestHandleUsersListRequest_FilterOnHyphenatedAttr_Returns400(t *testing.T) {
+	// "-" is valid in an attrPath per RFC 7643 but rejected by the store-layer
+	// key charset; must be caught here as invalidFilter, not surface as a 500.
+	h := newSCIMUsersHandler(NewSCIMUsersServiceInterfaceMock(t), testBaseURL)
+	req := httptest.NewRequest(http.MethodGet,
+		"/scim/v2/Users?filter="+neturl.QueryEscape(`custom-attr eq "x"`), nil)
+	rr := httptest.NewRecorder()
+
+	h.HandleUsersListRequest(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	var errResp SCIMErrorResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&errResp))
+	require.Equal(t, "invalidFilter", errResp.ScimType)
+}
+
+func TestHandleUsersListRequest_FilterTranslatesCoreAttributes(t *testing.T) {
+	tests := []struct {
+		name           string
+		filter         string
+		expectedFilter map[string]interface{}
+	}{
+		{
+			name:           "simple string attribute",
+			filter:         `userName eq "alice"`,
+			expectedFilter: map[string]interface{}{"username": "alice"},
+		},
+		{
+			name:           "sub-attribute of complex object",
+			filter:         `name.givenName eq "Alice"`,
+			expectedFilter: map[string]interface{}{"given_name": "Alice"},
+		},
+		{
+			name:           "multi-valued complex attribute value",
+			filter:         `emails.value eq "alice@example.com"`,
+			expectedFilter: map[string]interface{}{"email": "alice@example.com"},
+		},
+		{
+			name:           "address sub-attribute",
+			filter:         `addresses.streetAddress eq "Main St"`,
+			expectedFilter: map[string]interface{}{"street_address": "Main St"},
+		},
+		{
+			name:           "unmapped attribute passes through unchanged",
+			filter:         `active eq true`,
+			expectedFilter: map[string]interface{}{"active": true},
+		},
+		{
+			name:           "URN-prefixed attribute with numeric version segment",
+			filter:         `urn:thunderid:params:scim:schemas:employee_hier:2.0:User:active eq true`,
+			expectedFilter: map[string]interface{}{"active": true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockSvc := NewSCIMUsersServiceInterfaceMock(t)
+			mockSvc.On("ListUsers", mock.Anything, 1, 20, tt.expectedFilter, testBaseURL).
+				Return(SCIMUserListResponse{}, (*tidcommon.ServiceError)(nil))
+
+			h := newSCIMUsersHandler(mockSvc, testBaseURL)
+			req := httptest.NewRequest(http.MethodGet,
+				"/scim/v2/Users?filter="+neturl.QueryEscape(tt.filter), nil)
+			rr := httptest.NewRecorder()
+
+			h.HandleUsersListRequest(rr, req)
+
+			require.Equal(t, http.StatusOK, rr.Code)
+		})
+	}
+}
+
 func TestHandleUsersListRequest_ServiceError_Returns500(t *testing.T) {
 	mockSvc := NewSCIMUsersServiceInterfaceMock(t)
-	mockSvc.On("ListUsers", mock.Anything, 1, 20, testBaseURL).
+	mockSvc.On("ListUsers", mock.Anything, 1, 20, mock.Anything, testBaseURL).
 		Return(SCIMUserListResponse{}, &ErrorInternalServer)
 
 	h := newSCIMUsersHandler(mockSvc, testBaseURL)
@@ -446,7 +561,7 @@ func TestHandleUsersListRequest_ServiceError_Returns500(t *testing.T) {
 
 func TestHandleUsersListRequest_CustomPagination(t *testing.T) {
 	mockSvc := NewSCIMUsersServiceInterfaceMock(t)
-	mockSvc.On("ListUsers", mock.Anything, 5, 10, testBaseURL).
+	mockSvc.On("ListUsers", mock.Anything, 5, 10, mock.Anything, testBaseURL).
 		Return(SCIMUserListResponse{
 			Schemas:      []string{SCIMListResponseSchemaURN},
 			TotalResults: 0,
@@ -500,4 +615,73 @@ func TestHandleUsersDeleteRequest_PreconditionFailed(t *testing.T) {
 	h.HandleUsersDeleteRequest(rr, req)
 
 	require.Equal(t, http.StatusPreconditionFailed, rr.Code)
+}
+
+// --- parseSCIMFilterForEq direct unit tests ---
+
+func TestParseSCIMFilterForEq_EmptyString_ReturnsNil(t *testing.T) {
+	filters, err := parseSCIMFilterForEq("")
+	require.NoError(t, err)
+	require.Nil(t, filters)
+}
+
+func TestParseSCIMFilterForEq_UnsupportedOperator_ReturnsError(t *testing.T) {
+	tests := []string{
+		`userName ne "alice"`,
+		`userName co "ali"`,
+		`userName sw "al"`,
+		`userName ew "ce"`,
+		`userName pr`,
+		`age gt 5`,
+		`age lt 5`,
+		`age ge 5`,
+		`age le 5`,
+	}
+	for _, filter := range tests {
+		t.Run(filter, func(t *testing.T) {
+			_, err := parseSCIMFilterForEq(filter)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestParseSCIMFilterForEq_MalformedExpression_ReturnsError(t *testing.T) {
+	_, err := parseSCIMFilterForEq("userName")
+	require.Error(t, err)
+}
+
+func TestParseSCIMFilterForEq_InvalidCompValue_ReturnsError(t *testing.T) {
+	_, err := parseSCIMFilterForEq("userName eq null")
+	require.Error(t, err)
+}
+
+// --- parseSCIMCompValue direct unit tests ---
+
+func TestParseSCIMCompValue(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		expected  interface{}
+		expectErr bool
+	}{
+		{name: "quoted string", raw: `"alice"`, expected: "alice"},
+		{name: "unterminated quoted string", raw: `"alice`, expectErr: true},
+		{name: "true", raw: "true", expected: true},
+		{name: "false", raw: "false", expected: false},
+		{name: "null", raw: "null", expectErr: true},
+		{name: "integer", raw: "42", expected: int64(42)},
+		{name: "decimal", raw: "3.14", expected: 3.14},
+		{name: "unrecognized", raw: "notavalue", expectErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSCIMCompValue(tt.raw)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, got)
+		})
+	}
 }

--- a/backend/internal/scim/users_service.go
+++ b/backend/internal/scim/users_service.go
@@ -15,7 +15,8 @@ import (
 // SCIMUsersServiceInterface defines the Users CRUD operations exposed to the users handler.
 type SCIMUsersServiceInterface interface {
 	ListUsers(
-		ctx context.Context, startIndex, count int, baseURL string,
+		ctx context.Context, startIndex, count int,
+		filters map[string]interface{}, baseURL string,
 	) (SCIMUserListResponse, *tidcommon.ServiceError)
 	CreateUser(
 		ctx context.Context, payload *SCIMUserPayload, baseURL string,
@@ -45,7 +46,7 @@ func newSCIMUsersService(
 }
 
 func (s *scimUsersService) ListUsers(ctx context.Context, startIndex, count int,
-	baseURL string) (SCIMUserListResponse, *tidcommon.ServiceError) {
+	filters map[string]interface{}, baseURL string) (SCIMUserListResponse, *tidcommon.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 
 	if startIndex < 1 {
@@ -55,7 +56,7 @@ func (s *scimUsersService) ListUsers(ctx context.Context, startIndex, count int,
 		count = 20
 	}
 	offset := startIndex - 1
-	listResp, svcErr := s.userService.GetUserList(ctx, count, offset, nil, false)
+	listResp, svcErr := s.userService.GetUserList(ctx, count, offset, filters, false)
 	if svcErr != nil {
 		logger.Error(ctx, "SCIM ListUsers: failed to get user list", log.Any("error", svcErr))
 		return SCIMUserListResponse{}, mapUserServiceErrorToSCIM(svcErr)

--- a/backend/internal/scim/users_service_test.go
+++ b/backend/internal/scim/users_service_test.go
@@ -148,7 +148,7 @@ func TestListUsers_Success(t *testing.T) {
 		"GetAttributes", mock.Anything, entitytype.TypeCategoryUser, "employee", true, false, false,
 	).Return([]entitytype.AttributeInfo{}, (*tidcommon.ServiceError)(nil))
 
-	resp, err := service.ListUsers(context.Background(), 1, 20, testBaseURL)
+	resp, err := service.ListUsers(context.Background(), 1, 20, nil, testBaseURL)
 
 	require.Nil(t, err)
 	require.Equal(t, 1, resp.TotalResults)
@@ -165,7 +165,7 @@ func TestListUsers_ServiceError(t *testing.T) {
 	mockUserService.On("GetUserList", mock.Anything, 20, 0, (map[string]interface{})(nil), false).
 		Return((*user.UserListResponse)(nil), &user.ErrorUserNotFound)
 
-	resp, err := service.ListUsers(context.Background(), 1, 20, testBaseURL)
+	resp, err := service.ListUsers(context.Background(), 1, 20, nil, testBaseURL)
 
 	require.NotNil(t, err)
 	require.Equal(t, ErrorUserNotFound.Code, err.Code)
@@ -181,7 +181,7 @@ func TestListUsers_DefaultsInvalidPagination(t *testing.T) {
 	mockUserService.On("GetUserList", mock.Anything, 20, 0, (map[string]interface{})(nil), false).
 		Return(&user.UserListResponse{TotalResults: 0, Users: []user.User{}}, (*tidcommon.ServiceError)(nil))
 
-	resp, err := service.ListUsers(context.Background(), 0, 0, testBaseURL)
+	resp, err := service.ListUsers(context.Background(), 0, 0, nil, testBaseURL)
 
 	require.Nil(t, err)
 	require.Equal(t, 0, resp.TotalResults)

--- a/backend/tests/mocks/scim/SCIMUsersServiceInterface_mock.go
+++ b/backend/tests/mocks/scim/SCIMUsersServiceInterface_mock.go
@@ -257,8 +257,8 @@ func (_c *SCIMUsersServiceInterfaceMock_GetUser_Call) RunAndReturn(run func(ctx 
 }
 
 // ListUsers provides a mock function for the type SCIMUsersServiceInterfaceMock
-func (_mock *SCIMUsersServiceInterfaceMock) ListUsers(ctx context.Context, startIndex int, count int, baseURL string) (scim.SCIMUserListResponse, *common.ServiceError) {
-	ret := _mock.Called(ctx, startIndex, count, baseURL)
+func (_mock *SCIMUsersServiceInterfaceMock) ListUsers(ctx context.Context, startIndex int, count int, filters map[string]interface{}, baseURL string) (scim.SCIMUserListResponse, *common.ServiceError) {
+	ret := _mock.Called(ctx, startIndex, count, filters, baseURL)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListUsers")
@@ -266,16 +266,16 @@ func (_mock *SCIMUsersServiceInterfaceMock) ListUsers(ctx context.Context, start
 
 	var r0 scim.SCIMUserListResponse
 	var r1 *common.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int, string) (scim.SCIMUserListResponse, *common.ServiceError)); ok {
-		return returnFunc(ctx, startIndex, count, baseURL)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int, map[string]interface{}, string) (scim.SCIMUserListResponse, *common.ServiceError)); ok {
+		return returnFunc(ctx, startIndex, count, filters, baseURL)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int, string) scim.SCIMUserListResponse); ok {
-		r0 = returnFunc(ctx, startIndex, count, baseURL)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int, map[string]interface{}, string) scim.SCIMUserListResponse); ok {
+		r0 = returnFunc(ctx, startIndex, count, filters, baseURL)
 	} else {
 		r0 = ret.Get(0).(scim.SCIMUserListResponse)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int, string) *common.ServiceError); ok {
-		r1 = returnFunc(ctx, startIndex, count, baseURL)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int, map[string]interface{}, string) *common.ServiceError); ok {
+		r1 = returnFunc(ctx, startIndex, count, filters, baseURL)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*common.ServiceError)
@@ -293,12 +293,13 @@ type SCIMUsersServiceInterfaceMock_ListUsers_Call struct {
 //   - ctx context.Context
 //   - startIndex int
 //   - count int
+//   - filters map[string]interface{}
 //   - baseURL string
-func (_e *SCIMUsersServiceInterfaceMock_Expecter) ListUsers(ctx interface{}, startIndex interface{}, count interface{}, baseURL interface{}) *SCIMUsersServiceInterfaceMock_ListUsers_Call {
-	return &SCIMUsersServiceInterfaceMock_ListUsers_Call{Call: _e.mock.On("ListUsers", ctx, startIndex, count, baseURL)}
+func (_e *SCIMUsersServiceInterfaceMock_Expecter) ListUsers(ctx interface{}, startIndex interface{}, count interface{}, filters interface{}, baseURL interface{}) *SCIMUsersServiceInterfaceMock_ListUsers_Call {
+	return &SCIMUsersServiceInterfaceMock_ListUsers_Call{Call: _e.mock.On("ListUsers", ctx, startIndex, count, filters, baseURL)}
 }
 
-func (_c *SCIMUsersServiceInterfaceMock_ListUsers_Call) Run(run func(ctx context.Context, startIndex int, count int, baseURL string)) *SCIMUsersServiceInterfaceMock_ListUsers_Call {
+func (_c *SCIMUsersServiceInterfaceMock_ListUsers_Call) Run(run func(ctx context.Context, startIndex int, count int, filters map[string]interface{}, baseURL string)) *SCIMUsersServiceInterfaceMock_ListUsers_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -312,15 +313,20 @@ func (_c *SCIMUsersServiceInterfaceMock_ListUsers_Call) Run(run func(ctx context
 		if args[2] != nil {
 			arg2 = args[2].(int)
 		}
-		var arg3 string
+		var arg3 map[string]interface{}
 		if args[3] != nil {
-			arg3 = args[3].(string)
+			arg3 = args[3].(map[string]interface{})
+		}
+		var arg4 string
+		if args[4] != nil {
+			arg4 = args[4].(string)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -331,7 +337,7 @@ func (_c *SCIMUsersServiceInterfaceMock_ListUsers_Call) Return(sCIMUserListRespo
 	return _c
 }
 
-func (_c *SCIMUsersServiceInterfaceMock_ListUsers_Call) RunAndReturn(run func(ctx context.Context, startIndex int, count int, baseURL string) (scim.SCIMUserListResponse, *common.ServiceError)) *SCIMUsersServiceInterfaceMock_ListUsers_Call {
+func (_c *SCIMUsersServiceInterfaceMock_ListUsers_Call) RunAndReturn(run func(ctx context.Context, startIndex int, count int, filters map[string]interface{}, baseURL string) (scim.SCIMUserListResponse, *common.ServiceError)) *SCIMUsersServiceInterfaceMock_ListUsers_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose
Adds SCIM filter query support (`eq` operator) for the SCIM Users list/search endpoint. Enables clients to filter users by core attributes, e.g. `userName eq "john"`, `emails.value eq "john@example.com"`, using ThunderID's underlying flat user attributes for the actual comparison.

### Approach
- `users_handler.go`: parses the SCIM `filter` query parameter on list requests, restricted to a single `eq` expression against a supported attribute path.
- `core_attr_mapper.go`: added `scimToThunderAttrIndex`, a lowercase-keyed reverse lookup built once at package init from `coreAttrRules`, mapping SCIM filter attribute paths (e.g. `username`, `emails.value`, `name.givenname`) to their ThunderID attribute names in O(1). `translateSCIMFilterAttr` resolves a filter attribute through this index; attributes with no core mapping (e.g. `id`, `active`, custom schema attrs) pass through unchanged.
- Multi-valued sub-attributes ThunderID doesn't store as a flat field (`type`, `primary`) are explicitly unsupported for filtering — `scimUnsupportedFilterAttrs` returns an error for paths like `emails.type` instead of silently matching nothing, since no flat ThunderID attribute exists to compare against.
- `users_service.go` wires the translated attribute/value into the existing user query path.

### Related Issues
- #4129 

### Related PRs
- #4184 

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
