### PR TITLE
Update MCP client UI wordings

### DIFF
--- a/frontend/apps/console/src/features/applications/components/create-application/mcp/__tests__/McpConnectComplete.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/mcp/__tests__/McpConnectComplete.test.tsx
@@ -166,11 +166,11 @@ describe('McpConnectComplete', () => {
       expect(screen.queryByText('App Name')).not.toBeInTheDocument();
     });
 
-    it('should render a single "Go to application" button that calls onContinue', async () => {
+    it('should render a single "Go to MCP client" button that calls onContinue', async () => {
       const user = userEvent.setup();
       renderComponent();
 
-      const continueButton = screen.getByRole('button', {name: /go to application/i});
+      const continueButton = screen.getByRole('button', {name: /go to mcp client/i});
       await user.click(continueButton);
 
       expect(mockOnContinue).toHaveBeenCalled();
@@ -242,7 +242,7 @@ describe('McpConnectComplete', () => {
       expect(screen.queryByText('Registered redirect URIs')).not.toBeInTheDocument();
     });
 
-    it('should render "Copy secret" and "Go to application" footer buttons', async () => {
+    it('should render "Copy secret" and "Go to MCP client" footer buttons', async () => {
       const user = userEvent.setup();
       renderComponent(m2mProps);
 
@@ -253,7 +253,7 @@ describe('McpConnectComplete', () => {
         expect(mockCopy).toHaveBeenCalledWith('super-secret-value');
       });
 
-      const continueButton = screen.getByRole('button', {name: /go to application/i});
+      const continueButton = screen.getByRole('button', {name: /go to mcp client/i});
       await user.click(continueButton);
       expect(mockOnContinue).toHaveBeenCalled();
     });

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -2100,7 +2100,7 @@ const translations = {
       "This secret is shown only once. Store it securely — you'll need to regenerate it if it's lost.",
     'onboarding.mcp.complete.m2m.tokenHint':
       "Request tokens with grant_type=client_credentials and include the target MCP server's resource parameter so the token is audience-scoped.",
-    'onboarding.mcp.complete.goToApp': 'Go to application',
+    'onboarding.mcp.complete.goToApp': 'Go to MCP client',
     'onboarding.mcp.complete.copySecret': 'Copy secret',
     'onboarding.mcp.complete.copied': 'Copied',
     'onboarding.configure.design.title': 'Design Your Application',


### PR DESCRIPTION
### Purpose

Update the MCP client onboarding completion CTA to say **"Go to MCP client"** instead of **"Go to application"**, so the wording matches the entity type. Also aligns the related i18n entry and tests.

Fixes #4203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the MCP onboarding completion call-to-action to say **“Go to MCP client”** instead of **“Go to application.”**
  * Confirmed the correct continuation behavior for both user-delegated and machine-to-machine flows.
  * Adjusted English localization to match the updated CTA text.
  * Updated onboarding completion tests to assert the new button label and rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
