### PR TITLE
[Bug-fix] Treat empty values as absent when enriching inputs from forwarded data

### DIFF
--- a/backend/internal/flow/core/prompt_node.go
+++ b/backend/internal/flow/core/prompt_node.go
@@ -532,14 +532,14 @@ func (n *promptNode) enrichInputsFromForwardedData(ctx *providers.NodeContext, n
 			}
 			continue
 		}
-		if _, ok := ctx.UserInputs[fwdInput.Identifier]; ok {
+		if val, ok := ctx.UserInputs[fwdInput.Identifier]; ok && val != "" {
 			continue
 		}
-		if _, ok := ctx.RuntimeData[fwdInput.Identifier]; ok {
+		if val, ok := ctx.RuntimeData[fwdInput.Identifier]; ok && val != "" {
 			continue
 		}
 		if value, ok := ctx.ForwardedData[fwdInput.Identifier]; ok {
-			if _, isString := value.(string); isString {
+			if val, isString := value.(string); isString && val != "" {
 				continue
 			}
 		}

--- a/backend/internal/flow/core/prompt_node_test.go
+++ b/backend/internal/flow/core/prompt_node_test.go
@@ -2223,6 +2223,75 @@ func (s *PromptOnlyNodeTestSuite) TestEnrichInputsFromForwardedData_PropagatesSe
 	s.Equal([]string{"admin", "user"}, resp.Inputs[0].Options, "options must be propagated from ForwardedData")
 }
 
+func (s *PromptOnlyNodeTestSuite) TestEnrichInputsFromForwardedData_EmptyUserInput_InputAppended() {
+	// A forwarded input whose identifier is present in UserInputs with an empty string must not be
+	// treated as satisfied — it should still be appended to the response.
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+
+	ctx := &providers.NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{testEmailAttr: ""},
+		ForwardedData: map[string]interface{}{
+			common.ForwardedDataKeyInputs: []providers.Input{
+				{Identifier: testEmailAttr, Type: "TEXT_INPUT", Required: true, DisplayName: "Email Address"},
+			},
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Len(resp.Inputs, 1)
+	s.Equal(testEmailAttr, resp.Inputs[0].Identifier)
+}
+
+func (s *PromptOnlyNodeTestSuite) TestEnrichInputsFromForwardedData_EmptyRuntimeData_InputAppended() {
+	// A forwarded input whose identifier is present in RuntimeData with an empty string must not be
+	// treated as satisfied — it should still be appended to the response.
+	// This is the federated-login scenario where the IdP sets the claim key but provides no value.
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+
+	ctx := &providers.NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{testEmailAttr: ""},
+		ForwardedData: map[string]interface{}{
+			common.ForwardedDataKeyInputs: []providers.Input{
+				{Identifier: testEmailAttr, Type: "TEXT_INPUT", Required: true, DisplayName: "Email Address"},
+			},
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Len(resp.Inputs, 1)
+	s.Equal(testEmailAttr, resp.Inputs[0].Identifier)
+}
+
+func (s *PromptOnlyNodeTestSuite) TestEnrichInputsFromForwardedData_EmptyScalarForwardedData_InputAppended() {
+	// A forwarded input whose identifier is also present as an empty scalar string in ForwardedData
+	// must not be treated as satisfied — it should still be appended to the response.
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+
+	ctx := &providers.NodeContext{
+		ExecutionID: "test-flow",
+		UserInputs:  map[string]string{},
+		ForwardedData: map[string]interface{}{
+			testEmailAttr: "",
+			common.ForwardedDataKeyInputs: []providers.Input{
+				{Identifier: testEmailAttr, Type: "TEXT_INPUT", Required: true, DisplayName: "Email Address"},
+			},
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.Len(resp.Inputs, 1)
+	s.Equal(testEmailAttr, resp.Inputs[0].Identifier)
+}
+
 func (s *PromptOnlyNodeTestSuite) TestHasRequiredInputs_UnknownActionFallsBackToAllInputs() {
 	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
 	pn := node.(PromptNodeInterface)


### PR DESCRIPTION
### Purpose
Fixes: https://github.com/thunder-id/thunderid/issues/4112
<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4112

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed input enrichment behavior so forwarded/schema-derived inputs are appended when existing stored values are empty strings.
  * Improved handling of empty-string values to avoid incorrectly treating “present but empty” data as satisfied.
* **Tests**
  * Added coverage for input enrichment when identifiers exist in prior inputs/runtime data/forwarded data with empty string values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->