### PR TITLE
Update transitive dependency overrides to fix security audit

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,7 +354,7 @@ catalogs:
       version: 4.3.6
 
 overrides:
-  '@thunderid/docs>shell-quote': 1.8.4
+  shell-quote: '>=1.8.5'
   ws: '>=8.21.0'
   websocket-driver: '>=0.7.5'
   postcss: 8.5.10
@@ -379,9 +379,10 @@ overrides:
   yaml: 2.8.3
   path-to-regexp: 0.1.13
   svgo: 3.3.3
-  brace-expansion@>=4.0.0 <5.0.5: 5.0.5
+  brace-expansion@<1.1.16: 1.1.16
+  brace-expansion@>=3.0.0 <5.0.7: 5.0.7
   lodash: 4.18.1
-  js-yaml@>=4.0.0 <=4.1.1: 4.2.0
+  js-yaml@>=4.0.0 <4.3.0: 4.3.0
   js-yaml@<3.15.0: 3.15.0
   http-proxy-middleware: 2.0.10
   devalue: 5.8.1
@@ -7280,11 +7281,11 @@ packages:
     resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
     engines: {node: '>=14.16'}
 
-  brace-expansion@1.1.14:
-    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -9510,8 +9511,8 @@ packages:
     resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsdom@27.0.1:
@@ -11774,8 +11775,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
 
   should-equal@2.0.0:
@@ -14894,7 +14895,7 @@ snapshots:
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.5
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       lodash: 4.18.1
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
@@ -15448,7 +15449,7 @@ snapshots:
       '@docusaurus/utils-common': 3.9.2(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.10))(html-minifier-terser@7.2.0)(postcss@8.5.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       fs-extra: 11.3.5
       joi: 18.2.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       lodash: 4.18.1
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -15482,7 +15483,7 @@ snapshots:
       globby: 11.1.0
       gray-matter: 4.0.3
       jiti: 1.21.7
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       lodash: 4.18.1
       micromatch: 4.0.8
       p-queue: 6.6.2
@@ -15766,7 +15767,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -19211,12 +19212,12 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@1.1.14:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -19493,7 +19494,7 @@ snapshots:
     dependencies:
       chalk: 5.6.2
       rxjs: 7.8.2
-      shell-quote: 1.8.4
+      shell-quote: 1.10.0
       supports-color: 10.2.2
       tree-kill: 1.2.2
       yargs: 18.0.0
@@ -19579,7 +19580,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -21781,7 +21782,7 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -21892,7 +21893,7 @@ snapshots:
   launch-editor@2.14.1:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.4
+      shell-quote: 1.10.0
 
   leven@3.1.0: {}
 
@@ -22641,11 +22642,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.14
+      brace-expansion: 1.1.16
 
   minimist@1.2.8: {}
 
@@ -22889,7 +22890,7 @@ snapshots:
       async: 3.2.4
       commander: 2.20.3
       graphlib: 2.1.8
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       json-schema-merge-allof: 0.8.1
       lodash: 4.18.1
       neotraverse: 0.6.14
@@ -24519,7 +24520,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.4: {}
+  shell-quote@1.10.0: {}
 
   should-equal@2.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -81,8 +81,9 @@ catalog:
   zod: 4.3.6
 
 overrides:
-  # JUSTIFICATION: Fixes GHSA-w7jw-789q-3m8p by overriding to fix docusaurus version in docs workspace only.
-  "@thunderid/docs>shell-quote": 1.8.4
+  # JUSTIFICATION: Fixes GHSA-w7jw-789q-3m8p and GHSA-395f-4hp3-45gv (quadratic-complexity DoS in
+  # shell-quote parse()). Transitive via docusaurus dev server (launch-editor), so overridden globally.
+  shell-quote: '>=1.8.5'
   # JUSTIFICATION: The `ws` package is a transitive dependency of `docusaurus/core -> webpack-bundle-analyzer` and it requires a major version bump.
   ws: '>=8.21.0'
   # JUSTIFICATION: Fixes GHSA-xv26-6w52-cph6 — websocket-driver message corruption via protocol length headers, transitive via Docusaurus dev server sockjs/faye-websocket.
@@ -113,9 +114,13 @@ overrides:
   yaml: 2.8.3
   path-to-regexp: 0.1.13
   svgo: 3.3.3
-  brace-expansion@>=4.0.0 <5.0.5: 5.0.5
+  # JUSTIFICATION: Fixes GHSA-3jxr-9vmj-r5cp — DoS via exponential-time expansion of consecutive
+  # non-expanding {} groups. Covers both the 1.x line and the 3.x/4.x line flagged by the advisory.
+  brace-expansion@<1.1.16: 1.1.16
+  brace-expansion@>=3.0.0 <5.0.7: 5.0.7
   lodash: 4.18.1
-  js-yaml@>=4.0.0 <=4.1.1: 4.2.0
+  # JUSTIFICATION: Fixes GHSA-52cp-r559-cp3m — YAML merge-key chains forcing quadratic CPU consumption.
+  js-yaml@>=4.0.0 <4.3.0: 4.3.0
   # JUSTIFICATION: Fixes GHSA-h67p-54hq-rp68 — quadratic-complexity DoS in js-yaml merge key handling.
   js-yaml@<3.15.0: 3.15.0
   # JUSTIFICATION: Fixes GHSA-64mm-vxmg-q3vj — http-proxy-middleware router host+path substring match bypass.


### PR DESCRIPTION
### Purpose

Fixes the repo-wide **Security Audit** CI gate (`pnpm audit --audit-level=high`), which started failing because three advisories were re-scoped to wider version ranges than the existing transitive-dependency overrides in `pnpm-workspace.yaml` covered. This is not tied to any feature change; it surfaced on open PRs (e.g. #4161) because the gate runs on every PR.

All three packages are deep transitive dependencies (via docusaurus, eslint, rimraf, webpack-dev-server), so they are updated through pnpm `overrides` rather than a direct `package.json` bump.

### Approach

Updated the stale overrides to patched versions:

- **brace-expansion** (GHSA-3jxr-9vmj-r5cp, DoS): advisory now covers `<1.1.16` (1.x line, previously unhandled) and `>=3.0.0 <5.0.7` (old override capped at `5.0.5`, still vulnerable). Now overrides `<1.1.16 -> 1.1.16` and `>=3.0.0 <5.0.7 -> 5.0.7`.
- **js-yaml** (GHSA-52cp-r559-cp3m, quadratic CPU via merge keys): advisory `>=4.0.0 <4.3.0`; old override capped at `4.2.0`, still vulnerable. Now `>=4.0.0 <4.3.0 -> 4.3.0`.
- **shell-quote** (GHSA-395f-4hp3-45gv, quadratic DoS in `parse()`): advisory `<=1.8.4`. The old `@thunderid/docs>shell-quote: 1.8.4` scope only matched a direct child of the docs package, so it never applied to the actual `...launch-editor>shell-quote` path. Replaced with a global `shell-quote: >=1.8.5` override.

Regenerated `pnpm-lock.yaml`. Local `pnpm audit --ignore-registry-errors --audit-level=high` now reports 0 high-severity findings.

### Related Issues

N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)
- [ ] Breaking changes. (Fill if applicable)

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dependency security overrides to address vulnerabilities affecting shell-quote, brace-expansion, and js-yaml.
  * Expanded shell-quote protection across the workspace.
  * Refined version constraints to ensure secure dependency resolutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->