### PR TITLE
Remove OIDC fields from OAuth metadata

### DIFF
--- a/backend/internal/oauth/oauth2/discovery/discovery_test.go
+++ b/backend/internal/oauth/oauth2/discovery/discovery_test.go
@@ -119,8 +119,12 @@ func (suite *DiscoveryTestSuite) TestOAuth2AuthorizationServerMetadata() {
 	assert.NotEmpty(suite.T(), metadata.JWKSUri)
 	assert.NotEmpty(suite.T(), metadata.RegistrationEndpoint)
 	assert.NotEmpty(suite.T(), metadata.IntrospectionEndpoint)
-	assert.NotEmpty(suite.T(), metadata.UserInfoEndpoint)
 	assert.NotEmpty(suite.T(), metadata.RevocationEndpoint)
+
+	body, err := json.Marshal(metadata)
+	assert.NoError(suite.T(), err)
+	assert.NotContains(suite.T(), string(body), "userinfo_endpoint")
+	assert.NotContains(suite.T(), string(body), "scopes_supported")
 
 	// Verify only implemented grant types are present
 	assert.Contains(suite.T(), metadata.GrantTypesSupported, "authorization_code")
@@ -165,6 +169,9 @@ func (suite *DiscoveryTestSuite) TestOIDCDiscovery() {
 	assert.NotEmpty(suite.T(), metadata.SubjectTypesSupported)
 	assert.NotEmpty(suite.T(), metadata.ClaimsSupported)
 	assert.NotEmpty(suite.T(), metadata.IDTokenSigningAlgValuesSupported)
+	assert.NotEmpty(suite.T(), metadata.UserInfoEndpoint)
+	assert.NotEmpty(suite.T(), metadata.ScopesSupported)
+	assert.Contains(suite.T(), metadata.ScopesSupported, "openid")
 
 	// Verify OIDC-specific fields
 	assert.Contains(suite.T(), metadata.SubjectTypesSupported, constants.SubjectTypePublic)

--- a/backend/internal/oauth/oauth2/discovery/model.go
+++ b/backend/internal/oauth/oauth2/discovery/model.go
@@ -23,7 +23,6 @@ type OAuth2AuthorizationServerMetadata struct {
 	Issuer                                     string   `json:"issuer"`
 	AuthorizationEndpoint                      string   `json:"authorization_endpoint"`
 	TokenEndpoint                              string   `json:"token_endpoint"`
-	UserInfoEndpoint                           string   `json:"userinfo_endpoint,omitempty"`
 	JWKSUri                                    string   `json:"jwks_uri"`
 	RegistrationEndpoint                       string   `json:"registration_endpoint,omitempty"`
 	RevocationEndpoint                         string   `json:"revocation_endpoint,omitempty"`
@@ -33,7 +32,6 @@ type OAuth2AuthorizationServerMetadata struct {
 	BackchannelAuthenticationEndpoint          string   `json:"backchannel_authentication_endpoint,omitempty"`
 	BackchannelTokenDeliveryModesSupported     []string `json:"backchannel_token_delivery_modes_supported,omitempty"`
 	BackchannelUserCodeParameterSupported      bool     `json:"backchannel_user_code_parameter_supported"`
-	ScopesSupported                            []string `json:"scopes_supported"`
 	ResponseTypesSupported                     []string `json:"response_types_supported"`
 	GrantTypesSupported                        []string `json:"grant_types_supported"`
 	TokenEndpointAuthMethodsSupported          []string `json:"token_endpoint_auth_methods_supported"`
@@ -45,6 +43,8 @@ type OAuth2AuthorizationServerMetadata struct {
 // OIDCProviderMetadata represents OpenID Connect Provider Metadata (OIDC Discovery 1.0)
 type OIDCProviderMetadata struct {
 	OAuth2AuthorizationServerMetadata
+	UserInfoEndpoint                     string   `json:"userinfo_endpoint"`
+	ScopesSupported                      []string `json:"scopes_supported"`
 	SubjectTypesSupported                []string `json:"subject_types_supported"`
 	IDTokenSigningAlgValuesSupported     []string `json:"id_token_signing_alg_values_supported"`
 	UserInfoSigningAlgValuesSupported    []string `json:"userinfo_signing_alg_values_supported,omitempty"`

--- a/backend/internal/oauth/oauth2/discovery/service.go
+++ b/backend/internal/oauth/oauth2/discovery/service.go
@@ -62,7 +62,6 @@ func (ds *discoveryService) GetOAuth2AuthorizationServerMetadata(
 		Issuer:                                     ds.getIssuer(),
 		AuthorizationEndpoint:                      ds.getAuthorizationEndpoint(),
 		TokenEndpoint:                              ds.getTokenEndpoint(),
-		UserInfoEndpoint:                           ds.getUserInfoEndpoint(),
 		JWKSUri:                                    ds.getJWKSUri(),
 		RegistrationEndpoint:                       ds.getRegistrationEndpoint(),
 		IntrospectionEndpoint:                      ds.getIntrospectionEndpoint(),
@@ -72,7 +71,6 @@ func (ds *discoveryService) GetOAuth2AuthorizationServerMetadata(
 		BackchannelAuthenticationEndpoint:          ds.getBackchannelAuthenticationEndpoint(),
 		BackchannelTokenDeliveryModesSupported:     []string{"poll"},
 		BackchannelUserCodeParameterSupported:      false,
-		ScopesSupported:                            ds.getSupportedScopes(),
 		ResponseTypesSupported:                     ds.getSupportedResponseTypes(),
 		GrantTypesSupported:                        ds.getSupportedGrantTypes(),
 		TokenEndpointAuthMethodsSupported:          ds.getSupportedTokenEndpointAuthMethods(),
@@ -94,6 +92,8 @@ func (ds *discoveryService) GetOIDCMetadata(ctx context.Context) (*OIDCProviderM
 	}
 	return &OIDCProviderMetadata{
 		OAuth2AuthorizationServerMetadata:    *oauth2Meta,
+		UserInfoEndpoint:                     ds.getUserInfoEndpoint(),
+		ScopesSupported:                      ds.getSupportedOIDCScopes(),
 		SubjectTypesSupported:                ds.getSupportedSubjectTypes(),
 		IDTokenSigningAlgValuesSupported:     signingAlgs,
 		UserInfoSigningAlgValuesSupported:    signingAlgs,
@@ -144,7 +144,7 @@ func (ds *discoveryService) getRegistrationEndpoint() string {
 	return ds.cfg.BaseURL + constants.OAuth2DCREndpoint
 }
 
-func (ds *discoveryService) getSupportedScopes() []string {
+func (ds *discoveryService) getSupportedOIDCScopes() []string {
 	scopes := make([]string, 0, len(constants.StandardOIDCScopes))
 	for scope := range constants.StandardOIDCScopes {
 		scopes = append(scopes, scope)

--- a/backend/internal/oauth/oauth2/userinfo/init.go
+++ b/backend/internal/oauth/oauth2/userinfo/init.go
@@ -19,7 +19,6 @@
 package userinfo
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/thunder-id/thunderid/internal/attributecache"
@@ -50,8 +49,7 @@ func Initialize(
 ) userInfoServiceInterface {
 	userInfoService := newUserInfoService(jwtService, jweService, resolver, tokenValidator,
 		actorProvider, attributeCacheSvc, dpopVerifier, cfg)
-	userInfoEndpoint := discoveryService.GetOAuth2AuthorizationServerMetadata(
-		context.Background()).UserInfoEndpoint
+	userInfoEndpoint := cfg.BaseURL + constants.OAuth2UserInfoEndpoint
 	dpopAlgs := cfg.OAuth.DPoP.AllowedAlgs
 	userInfoHandler := newUserInfoHandler(userInfoService, userInfoEndpoint, dpopAlgs)
 	registerRoutes(mux, userInfoHandler)

--- a/backend/internal/oauth/oauth2/userinfo/init_test.go
+++ b/backend/internal/oauth/oauth2/userinfo/init_test.go
@@ -26,11 +26,9 @@ import (
 	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/actorprovider"
-	"github.com/thunder-id/thunderid/internal/oauth/oauth2/discovery"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/tests/mocks/attributecachemock"
 	"github.com/thunder-id/thunderid/tests/mocks/entityprovidermock"
@@ -65,11 +63,6 @@ func (suite *InitTestSuite) SetupTest() {
 	suite.mockAttributeCacheService = attributecachemock.NewAttributeCacheServiceInterfaceMock(suite.T())
 	suite.mockDiscoveryService = discoverymock.NewDiscoveryServiceInterfaceMock(suite.T())
 	suite.mockDPoPVerifier = dpopmock.NewVerifierInterfaceMock(suite.T())
-	suite.mockDiscoveryService.On("GetOAuth2AuthorizationServerMetadata", mock.Anything).
-		Return(&discovery.OAuth2AuthorizationServerMetadata{
-			UserInfoEndpoint: "https://localhost:8090/oauth2/userinfo",
-		})
-
 	config.ResetServerRuntime()
 	_ = config.InitializeServerRuntime(
 		"test-home",

--- a/tests/integration/oauth/discovery/discovery_test.go
+++ b/tests/integration/oauth/discovery/discovery_test.go
@@ -20,12 +20,13 @@ package discovery
 
 import (
 	"encoding/json"
+	"io"
 
 	"net/http"
 	"testing"
 
-	"github.com/thunder-id/thunderid/tests/integration/testutils"
 	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
 )
 
 const (
@@ -39,12 +40,10 @@ type OAuth2AuthorizationServerMetadata struct {
 	Issuer                                     string   `json:"issuer"`
 	AuthorizationEndpoint                      string   `json:"authorization_endpoint"`
 	TokenEndpoint                              string   `json:"token_endpoint"`
-	UserInfoEndpoint                           string   `json:"userinfo_endpoint,omitempty"`
 	JWKSUri                                    string   `json:"jwks_uri"`
 	RevocationEndpoint                         string   `json:"revocation_endpoint,omitempty"`
 	IntrospectionEndpoint                      string   `json:"introspection_endpoint,omitempty"`
 	RegistrationEndpoint                       string   `json:"registration_endpoint,omitempty"`
-	ScopesSupported                            []string `json:"scopes_supported"`
 	ResponseTypesSupported                     []string `json:"response_types_supported"`
 	GrantTypesSupported                        []string `json:"grant_types_supported"`
 	TokenEndpointAuthMethodsSupported          []string `json:"token_endpoint_auth_methods_supported"`
@@ -55,6 +54,8 @@ type OAuth2AuthorizationServerMetadata struct {
 // OIDCProviderMetadata represents OpenID Connect Provider Metadata (OIDC Discovery 1.0)
 type OIDCProviderMetadata struct {
 	OAuth2AuthorizationServerMetadata
+	UserInfoEndpoint                 string   `json:"userinfo_endpoint"`
+	ScopesSupported                  []string `json:"scopes_supported"`
 	SubjectTypesSupported            []string `json:"subject_types_supported"`
 	IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
 	ClaimsSupported                  []string `json:"claims_supported"`
@@ -87,8 +88,15 @@ func (ts *DiscoveryTestSuite) TestOAuth2AuthorizationServerMetadata_GET_Success(
 	ts.Equal(http.StatusOK, resp.StatusCode)
 	ts.Equal("application/json", resp.Header.Get("Content-Type"))
 
+	body, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+
 	var metadata OAuth2AuthorizationServerMetadata
-	err = json.NewDecoder(resp.Body).Decode(&metadata)
+	err = json.Unmarshal(body, &metadata)
+	ts.Require().NoError(err)
+
+	var rawMetadata map[string]json.RawMessage
+	err = json.Unmarshal(body, &rawMetadata)
 	ts.Require().NoError(err)
 
 	// Verify required fields are present
@@ -106,9 +114,9 @@ func (ts *DiscoveryTestSuite) TestOAuth2AuthorizationServerMetadata_GET_Success(
 	ts.Contains(metadata.RegistrationEndpoint, "/oauth2/dcr/register", "RegistrationEndpoint should contain correct path")
 	ts.Contains(metadata.IntrospectionEndpoint, "/oauth2/introspect", "IntrospectionEndpoint should contain correct path")
 
-	// Verify userinfo endpoint is present
-	ts.NotEmpty(metadata.UserInfoEndpoint, "UserInfoEndpoint should be present")
-	ts.Contains(metadata.UserInfoEndpoint, "/oauth2/userinfo", "UserInfoEndpoint should contain correct path")
+	// Verify OIDC-specific fields are not present
+	ts.NotContains(rawMetadata, "userinfo_endpoint", "OAuth metadata should not include the UserInfo endpoint")
+	ts.NotContains(rawMetadata, "scopes_supported", "OAuth metadata should not include OIDC scopes")
 
 	// Verify revocation endpoint is present
 	ts.NotEmpty(metadata.RevocationEndpoint, "RevocationEndpoint should be present")
@@ -135,10 +143,6 @@ func (ts *DiscoveryTestSuite) TestOAuth2AuthorizationServerMetadata_GET_Success(
 	// Verify only S256 code challenge method is supported (plain is prohibited per OAuth 2.0 Security BCP)
 	ts.Equal([]string{"S256"}, metadata.CodeChallengeMethodsSupported,
 		"CodeChallengeMethodsSupported should contain exactly S256")
-
-	// Verify supported scopes
-	ts.NotEmpty(metadata.ScopesSupported, "ScopesSupported should not be empty")
-	ts.Contains(metadata.ScopesSupported, "openid", "Should support openid scope")
 
 	// Verify RFC 9207 issuer identification support
 	ts.True(metadata.AuthorizationResponseIssParameterSupported,
@@ -189,6 +193,10 @@ func (ts *DiscoveryTestSuite) TestOIDCDiscovery_GET_Success() {
 	ts.Contains(metadata.IDTokenSigningAlgValuesSupported, "RS256", "Should support RS256 signing algorithm")
 
 	ts.NotEmpty(metadata.ClaimsSupported, "ClaimsSupported should not be empty")
+	ts.NotEmpty(metadata.UserInfoEndpoint, "UserInfoEndpoint should be present")
+	ts.Contains(metadata.UserInfoEndpoint, "/oauth2/userinfo", "UserInfoEndpoint should contain correct path")
+	ts.NotEmpty(metadata.ScopesSupported, "ScopesSupported should not be empty")
+	ts.Contains(metadata.ScopesSupported, "openid", "Should support openid scope")
 	// Verify standard JWT claims
 	ts.Contains(metadata.ClaimsSupported, "sub", "Should support sub claim")
 	ts.Contains(metadata.ClaimsSupported, "iss", "Should support iss claim")
@@ -283,8 +291,6 @@ func (ts *DiscoveryTestSuite) TestOAuth2MetadataConsistency() {
 	ts.Equal(oauth2Metadata.ResponseTypesSupported, oidcMetadata.ResponseTypesSupported, "ResponseTypesSupported should match")
 	ts.Equal(oauth2Metadata.TokenEndpointAuthMethodsSupported, oidcMetadata.TokenEndpointAuthMethodsSupported, "TokenEndpointAuthMethodsSupported should match")
 	ts.Equal(oauth2Metadata.CodeChallengeMethodsSupported, oidcMetadata.CodeChallengeMethodsSupported, "CodeChallengeMethodsSupported should match")
-	// ScopesSupported order may differ, so we check that they contain the same scopes
-	ts.ElementsMatch(oauth2Metadata.ScopesSupported, oidcMetadata.ScopesSupported, "ScopesSupported should contain the same scopes")
 }
 
 // TestDiscoveryEndpointsAccessibility tests that discovery endpoints are accessible without authentication


### PR DESCRIPTION
### Purpose
Fixes #2189 by removing OpenID Connect-specific metadata from the OAuth authorization server metadata endpoint.

The OAuth metadata endpoint no longer returns `userinfo_endpoint` or OIDC `scopes_supported`, since ThunderID already exposes those through `/.well-known/openid-configuration`.


<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
- Removed `userinfo_endpoint` and OIDC `scopes_supported` from `/.well-known/oauth-authorization-server`.
- Kept `userinfo_endpoint` and OIDC scopes in `/.well-known/openid-configuration`.
- Updated UserInfo initialization so it no longer depends on OAuth metadata for the UserInfo endpoint.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2189

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * OAuth 2.0 discovery metadata now omits OpenID Connect-specific `userinfo_endpoint` and `scopes_supported` fields.
  * OpenID Connect discovery metadata now includes `userinfo_endpoint` and `scopes_supported`, including `openid`.
  * User information endpoint handling is now derived directly from the service base URL for consistent setup.
* **Tests**
  * Updated discovery and integration tests to reflect the new field placement and to validate the expected JSON output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->