### PR TITLE
[Bug-fix] Fix debounce issue in header key value update

### DIFF
--- a/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/__tests__/ExecutionExtendedProperties.test.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/__tests__/ExecutionExtendedProperties.test.tsx
@@ -1272,7 +1272,7 @@ describe('ExecutionExtendedProperties', () => {
         target: {value: '15'},
       });
 
-      expect(mockOnChange).toHaveBeenCalledWith('data.properties.timeout', 15, httpResource, true);
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.timeout', 15, httpResource);
     });
 
     it('should clamp timeout to max 20', () => {
@@ -1282,7 +1282,7 @@ describe('ExecutionExtendedProperties', () => {
         target: {value: '99'},
       });
 
-      expect(mockOnChange).toHaveBeenCalledWith('data.properties.timeout', 20, httpResource, true);
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.timeout', 20, httpResource);
     });
 
     it('should call onChange with debounce when body changes', () => {
@@ -1292,7 +1292,7 @@ describe('ExecutionExtendedProperties', () => {
         target: {value: 'raw body text'},
       });
 
-      expect(mockOnChange).toHaveBeenCalledWith('data.properties.body', 'raw body text', httpResource, true);
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.body', 'raw body text', httpResource);
     });
 
     it('should parse valid JSON body', () => {
@@ -1302,7 +1302,7 @@ describe('ExecutionExtendedProperties', () => {
         target: {value: '{"key":"value"}'},
       });
 
-      expect(mockOnChange).toHaveBeenCalledWith('data.properties.body', {key: 'value'}, httpResource, true);
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.body', {key: 'value'}, httpResource);
     });
 
     it('should call onChange with debounce when retryCount changes', () => {

--- a/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/execution-properties/HttpRequestProperties.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/execution-properties/HttpRequestProperties.tsx
@@ -63,7 +63,7 @@ function HttpRequestProperties({resource, onChange}: CommonResourcePropertiesPro
   const handleNumberPropertyChange = useCallback(
     (propertyName: string, value: string, min: number, max: number): void => {
       if (value === '') {
-        onChange(`data.properties.${propertyName}`, min, resource, true);
+        onChange(`data.properties.${propertyName}`, min, resource);
         return;
       }
 
@@ -72,7 +72,7 @@ function HttpRequestProperties({resource, onChange}: CommonResourcePropertiesPro
         return;
       }
 
-      onChange(`data.properties.${propertyName}`, Math.min(max, Math.max(min, Math.floor(num))), resource, true);
+      onChange(`data.properties.${propertyName}`, Math.min(max, Math.max(min, Math.floor(num))), resource);
     },
     [resource, onChange],
   );
@@ -80,11 +80,11 @@ function HttpRequestProperties({resource, onChange}: CommonResourcePropertiesPro
   const entriesToRecord = (entries: [string, string][]): Record<string, string> => Object.fromEntries(entries);
 
   const updateHeaderEntries = (updater: (prev: [string, string][]) => [string, string][]): void => {
-    onChange('data.properties.headers', entriesToRecord(updater(headerEntries)), resource, true);
+    onChange('data.properties.headers', entriesToRecord(updater(headerEntries)), resource);
   };
 
   const updateResponseMappingEntries = (updater: (prev: [string, string][]) => [string, string][]): void => {
-    onChange('data.properties.responseMapping', entriesToRecord(updater(responseMappingEntries)), resource, true);
+    onChange('data.properties.responseMapping', entriesToRecord(updater(responseMappingEntries)), resource);
   };
 
   return (
@@ -146,9 +146,9 @@ function HttpRequestProperties({resource, onChange}: CommonResourcePropertiesPro
           onChange={(e) => {
             try {
               const parsed: unknown = JSON.parse(e.target.value);
-              onChange('data.properties.body', parsed, resource, true);
+              onChange('data.properties.body', parsed, resource);
             } catch {
-              onChange('data.properties.body', e.target.value, resource, true);
+              onChange('data.properties.body', e.target.value, resource);
             }
           }}
           placeholder={t('flows:core.executions.httpRequest.body.placeholder')}

--- a/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/execution-properties/__tests__/HttpRequestProperties.test.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/execution-properties/__tests__/HttpRequestProperties.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen, fireEvent} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import HttpRequestProperties from '../HttpRequestProperties';
+import type {Resource} from '@/features/flows/models/resources';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'flows:core.executions.httpRequest.description': 'Configure the HTTP Request step.',
+        'flows:core.executions.httpRequest.url.label': 'URL',
+        'flows:core.executions.httpRequest.url.placeholder': 'https://example.com',
+        'flows:core.executions.httpRequest.method.label': 'Method',
+        'flows:core.executions.httpRequest.headers.label': 'Headers',
+        'flows:core.executions.httpRequest.headers.keyPlaceholder': 'Header name',
+        'flows:core.executions.httpRequest.headers.valuePlaceholder': 'Header value',
+        'flows:core.executions.httpRequest.body.label': 'Body',
+        'flows:core.executions.httpRequest.body.placeholder': '{}',
+        'flows:core.executions.httpRequest.timeout.label': 'Timeout',
+        'flows:core.executions.httpRequest.timeout.placeholder': '10',
+        'flows:core.executions.httpRequest.timeout.hint': 'Timeout in seconds (1-20)',
+        'flows:core.executions.httpRequest.responseMapping.label': 'Response Mapping',
+        'flows:core.executions.httpRequest.responseMapping.keyPlaceholder': 'Response key',
+        'flows:core.executions.httpRequest.responseMapping.valuePlaceholder': 'Variable name',
+        'flows:core.executions.httpRequest.errorHandling.label': 'Error Handling',
+        'flows:core.executions.httpRequest.errorHandling.failOnError.label': 'Fail on error',
+        'flows:core.executions.httpRequest.errorHandling.retryCount.label': 'Retry count',
+        'flows:core.executions.httpRequest.errorHandling.retryCount.placeholder': '0',
+        'flows:core.executions.httpRequest.errorHandling.retryCount.hint': 'Number of retries (0-5)',
+        'flows:core.executions.httpRequest.errorHandling.retryDelay.label': 'Retry delay',
+        'flows:core.executions.httpRequest.errorHandling.retryDelay.placeholder': '0',
+        'flows:core.executions.httpRequest.errorHandling.retryDelay.hint': 'Delay between retries in ms (0-5000)',
+      };
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+describe('HttpRequestProperties', () => {
+  const mockOnChange = vi.fn();
+
+  const createResource = (properties: Record<string, unknown> = {}): Resource =>
+    ({
+      data: {
+        properties,
+      },
+    }) as unknown as Resource;
+
+  beforeEach(() => {
+    mockOnChange.mockClear();
+  });
+
+  describe('handleNumberPropertyChange with empty value', () => {
+    it('should call onChange with min value when timeout is cleared', () => {
+      const resource = createResource({timeout: 10});
+
+      render(<HttpRequestProperties resource={resource} onChange={mockOnChange} />);
+
+      const timeoutInput = screen.getByLabelText('Timeout');
+      fireEvent.change(timeoutInput, {target: {value: ''}});
+
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.timeout', 1, resource);
+    });
+  });
+
+  describe('updateHeaderEntries', () => {
+    it('should add a new empty header entry when add button is clicked', async () => {
+      const user = userEvent.setup();
+      const resource = createResource({headers: {}});
+
+      render(<HttpRequestProperties resource={resource} onChange={mockOnChange} />);
+
+      const addButtons = screen.getAllByLabelText('Add entry');
+      // First "Add entry" button belongs to headers KeyValueEditor
+      await user.click(addButtons[0]);
+
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.headers', {'': ''}, resource);
+    });
+
+    it('should update a header value when the value field is edited', async () => {
+      const user = userEvent.setup();
+      const resource = createResource({headers: {'Content-Type': 'application/json', Accept: 'text/html'}});
+
+      render(<HttpRequestProperties resource={resource} onChange={mockOnChange} />);
+
+      const valueInputs = screen.getAllByPlaceholderText('Header value');
+      // Edit the first header's value
+      await user.clear(valueInputs[0]);
+      await user.type(valueInputs[0], 'text/plain');
+      await user.tab();
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        'data.properties.headers',
+        {'Content-Type': 'text/plain', Accept: 'text/html'},
+        resource,
+      );
+    });
+
+    it('should remove a header entry when remove button is clicked', async () => {
+      const user = userEvent.setup();
+      const resource = createResource({headers: {'Content-Type': 'application/json', Accept: 'text/html'}});
+
+      render(<HttpRequestProperties resource={resource} onChange={mockOnChange} />);
+
+      const removeButtons = screen.getAllByLabelText('Remove entry');
+      // Remove the first header entry
+      await user.click(removeButtons[0]);
+
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.headers', {Accept: 'text/html'}, resource);
+    });
+  });
+
+  describe('updateResponseMappingEntries', () => {
+    it('should add a new empty response mapping entry when add button is clicked', async () => {
+      const user = userEvent.setup();
+      const resource = createResource({responseMapping: {}});
+
+      render(<HttpRequestProperties resource={resource} onChange={mockOnChange} />);
+
+      const addButtons = screen.getAllByLabelText('Add entry');
+      // Second "Add entry" button belongs to responseMapping KeyValueEditor
+      await user.click(addButtons[1]);
+
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.responseMapping', {'': ''}, resource);
+    });
+
+    it('should remove a response mapping entry when remove button is clicked', async () => {
+      const user = userEvent.setup();
+      const resource = createResource({responseMapping: {'data.id': 'userId', 'data.name': 'userName'}});
+
+      render(<HttpRequestProperties resource={resource} onChange={mockOnChange} />);
+
+      // There should be remove buttons for both headers (0 entries) and responseMapping (2 entries)
+      const removeButtons = screen.getAllByLabelText('Remove entry');
+      // Remove the first response mapping entry
+      await user.click(removeButtons[0]);
+
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.responseMapping', {'data.name': 'userName'}, resource);
+    });
+  });
+});


### PR DESCRIPTION
### Purpose
fixes: https://github.com/thunder-id/thunderid/issues/4075

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4075

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the HTTP request editor’s change handling so timeout, request body (including JSON), headers, and response mappings now consistently propagate updates without extra parameters.
* **Tests**
  * Added a dedicated test suite for HTTP request properties (timeout, headers, response mappings).
  * Updated existing assertions to match the corrected on-change behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->