### PR TITLE
Brand and localize sign-out flow resources

### DIFF
--- a/backend/cmd/server/bootstrap/01-default-resources.yaml
+++ b/backend/cmd/server/bootstrap/01-default-resources.yaml
@@ -5090,3 +5090,8 @@ translations:
   elements:
     fields.usertype.label: User Type
     fields.usertype.placeholder: Select User Type
+  signout:
+    forms.confirm.title: Sign out?
+    forms.confirm.description: You are about to sign out of your account. Do you want to continue?
+    forms.confirm.actions.submit.label: Sign out
+    errors.failed.description: Something went wrong. Please try again.

--- a/frontend/apps/console/src/features/flows/data/templates.json
+++ b/frontend/apps/console/src/features/flows/data/templates.json
@@ -12958,10 +12958,19 @@
                 "align": "center",
                 "category": "DISPLAY",
                 "id": "text_signout_title",
-                "label": "Sign out of your account?",
+                "label": "{{ t(signout:forms.confirm.title) }}",
                 "resourceType": "ELEMENT",
                 "type": "TEXT",
-                "variant": "HEADING_3"
+                "variant": "HEADING_1"
+              },
+              {
+                "align": "center",
+                "category": "DISPLAY",
+                "id": "text_signout_desc",
+                "label": "{{ t(signout:forms.confirm.description) }}",
+                "resourceType": "ELEMENT",
+                "type": "TEXT",
+                "variant": "BODY_1"
               },
               {
                 "category": "BLOCK",
@@ -12970,7 +12979,7 @@
                     "category": "ACTION",
                     "eventType": "SUBMIT",
                     "id": "action_confirm",
-                    "label": "Sign out",
+                    "label": "{{ t(signout:forms.confirm.actions.submit.label) }}",
                     "resourceType": "ELEMENT",
                     "type": "ACTION",
                     "variant": "PRIMARY"

--- a/frontend/apps/console/src/features/login-flow/data/steps.json
+++ b/frontend/apps/console/src/features/login-flow/data/steps.json
@@ -171,5 +171,53 @@
         }
       ]
     }
+  },
+  {
+    "resourceType": "STEP",
+    "category": "INTERFACE",
+    "type": "VIEW",
+    "display": {
+      "label": "Sign Out Confirmation",
+      "description": "Screen asking the user to confirm signing out",
+      "image": "assets/images/icons/arrowhead-right-outline.svg",
+      "showOnResourcePanel": true
+    },
+    "config": {},
+    "data": {
+      "components": [
+        {
+          "id": "{{ID}}",
+          "category": "DISPLAY",
+          "type": "TEXT",
+          "variant": "HEADING_1",
+          "label": "{{ t(signout:forms.confirm.title) }}"
+        },
+        {
+          "id": "{{ID}}",
+          "category": "DISPLAY",
+          "type": "TEXT",
+          "variant": "BODY_1",
+          "label": "{{ t(signout:forms.confirm.description) }}"
+        },
+        {
+          "id": "{{ID}}",
+          "category": "BLOCK",
+          "type": "BLOCK",
+          "components": [
+            {
+              "id": "{{ID}}",
+              "category": "ACTION",
+              "type": "ACTION",
+              "variant": "PRIMARY",
+              "eventType": "SUBMIT",
+              "label": "{{ t(signout:forms.confirm.actions.submit.label) }}",
+              "action": {
+                "type": "NEXT"
+              }
+            }
+          ]
+        }
+      ]
+    }
   }
 ]

--- a/frontend/apps/gate/src/components/SignOut/SignOut.tsx
+++ b/frontend/apps/gate/src/components/SignOut/SignOut.tsx
@@ -16,16 +16,24 @@
  * under the License.
  */
 
-import {AuthPageLayout} from '@thunderid/design';
+import {useDesign, AuthPageLayout} from '@thunderid/design';
 import {useThunderID} from '@thunderid/react';
+import {ParticleBackground} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
 import SignOutBox from './SignOutBox';
+// Reuse the shared product-branding hero (logo + feature list) so the sign-out page matches sign-in.
+import SignInSlogan from '../SignIn/SignInSlogan';
 
 export default function SignOut(): JSX.Element {
   const {isMetaLoading} = useThunderID();
+  const {isDesignEnabled, isLoading: isDesignLoading} = useDesign();
+
+  const showSlogan = !isDesignLoading && !isDesignEnabled;
 
   return (
-    <AuthPageLayout isLoading={isMetaLoading} variant="Recovery">
+    <AuthPageLayout isLoading={isMetaLoading || isDesignLoading} variant="Recovery">
+      {showSlogan && <ParticleBackground opacity={0.5} />}
+      {showSlogan && <SignInSlogan />}
       <SignOutBox />
     </AuthPageLayout>
   );

--- a/frontend/apps/gate/src/components/SignOut/SignOutBox.tsx
+++ b/frontend/apps/gate/src/components/SignOut/SignOutBox.tsx
@@ -18,11 +18,13 @@
 
 import {useConfig} from '@thunderid/contexts';
 import {AuthCardLayout, FlowComponentRenderer, useDesign} from '@thunderid/design';
+import {useTemplateLiteralResolver} from '@thunderid/hooks';
 import {useLogger} from '@thunderid/logger/react';
 import {normalizeFlowResponse, useThunderID, type EmbeddedFlowComponent} from '@thunderid/react';
+import {TemplateLiteralType} from '@thunderid/utils';
 import {Alert, Box, CircularProgress} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useSearchParams} from 'react-router';
 
@@ -54,7 +56,8 @@ export default function SignOutBox(): JSX.Element {
   const executionId = searchParams.get('executionId') ?? '';
   const logoutId = searchParams.get('logoutId') ?? '';
   const {getServerUrl} = useConfig();
-  const {resolveFlowTemplateLiterals} = useThunderID();
+  const {meta} = useThunderID();
+  const {resolveAll} = useTemplateLiteralResolver();
   const {t} = useTranslation();
   const logger = useLogger('SignOutBox');
   const {isDesignEnabled} = useDesign();
@@ -109,7 +112,10 @@ export default function SignOutBox(): JSX.Element {
 
       // Each interactive step mints a fresh challenge token that the next submit must echo back.
       setChallengeToken(res.challengeToken ?? '');
-      const {components: next} = normalizeFlowResponse(res, t, {throwOnError: false});
+      // Keep the raw `{{ t(ns:key) }}` labels: resolving them here would use the SDK resolver, which
+      // flattens the namespace `:` to `.` and misses the backend-injected `signout` namespace. The
+      // FlowComponentRenderer `resolve` prop resolves them at render, preserving the namespace form.
+      const {components: next} = normalizeFlowResponse(res, t, {throwOnError: false, resolveTranslations: false});
       setComponents(next);
     } catch (error) {
       logger.error('Sign-out flow error:', error instanceof Error ? error : undefined);
@@ -119,9 +125,24 @@ export default function SignOutBox(): JSX.Element {
     }
   };
 
-  // Resume the execution the sign-out endpoint initiated.
+  // Resume the execution the sign-out endpoint initiated, guarding against React StrictMode's
+  // double-invocation and any re-render.
+  const resumedRef = useRef<string | null>(null);
   useEffect(() => {
-    void run({executionId});
+    if (!executionId) {
+      // Reached without an execution to resume (e.g. a malformed link): surface an error instead of
+      // leaving the initial spinner running indefinitely.
+      setIsLoading(false);
+      setFlowError(t('signout:errors.failed.description', 'Something went wrong. Please try again.'));
+      return;
+    }
+    // Resume once per executionId. A second resume re-runs the step without the challenge token the
+    // first one minted, which the interceptor rejects (ICS-1002) and whose empty error response would
+    // otherwise clear the rendered prompt.
+    if (resumedRef.current !== executionId) {
+      resumedRef.current = executionId;
+      void run({executionId});
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [executionId]);
 
@@ -157,7 +178,21 @@ export default function SignOutBox(): JSX.Element {
                 index={index}
                 values={values}
                 isLoading={isLoading}
-                resolve={resolveFlowTemplateLiterals}
+                resolve={(template) =>
+                  resolveAll(template, {
+                    [TemplateLiteralType.TRANSLATION]: t,
+                    [TemplateLiteralType.META]: (path: string) => {
+                      const keys = path.split('.');
+                      const value: unknown = keys.reduce<unknown>((acc: unknown, key: string): unknown => {
+                        if (acc == null || typeof acc !== 'object') return undefined;
+                        const record = acc as Record<string, unknown>;
+                        return record[key] ?? record[key.replace(/([A-Z])/g, '_$1').toLowerCase()];
+                      }, meta as unknown);
+
+                      return (value as string | undefined) ?? `{{meta(${path})}}`;
+                    },
+                  })
+                }
                 onInputChange={(id: string, value: string) => setValues((prev) => ({...prev, [id]: value}))}
                 onSubmit={(action: {id?: string}, inputs: Record<string, string>) => {
                   void run({executionId, challengeToken, action: action.id ?? component.id, inputs});

--- a/frontend/apps/gate/src/components/SignOut/__tests__/SignOut.test.tsx
+++ b/frontend/apps/gate/src/components/SignOut/__tests__/SignOut.test.tsx
@@ -20,9 +20,13 @@ import {render, screen} from '@thunderid/test-utils';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import SignOut from '../SignOut';
 
-// Mock child component
+// Mock child components
 vi.mock('../SignOutBox', () => ({
   default: () => <div data-testid="signout-box">SignOutBox</div>,
+}));
+
+vi.mock('../../SignIn/SignInSlogan', () => ({
+  default: () => <div data-testid="signin-slogan">SignInSlogan</div>,
 }));
 
 // Mock useThunderID hook
@@ -36,12 +40,15 @@ vi.mock('@thunderid/react', async (importOriginal) => {
   };
 });
 
-// Mock AuthPageLayout
+// Mock AuthPageLayout and useDesign
+const mockUseDesign = vi.fn();
 vi.mock('@thunderid/design', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@thunderid/design')>();
   return {
     ...actual,
     AuthPageLayout: ({children}: {children: React.ReactNode}) => <div data-testid="auth-page-layout">{children}</div>,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    useDesign: () => mockUseDesign(),
   };
 });
 
@@ -50,6 +57,10 @@ describe('SignOut', () => {
     vi.clearAllMocks();
     mockUseThunderID.mockReturnValue({
       isMetaLoading: false,
+    });
+    mockUseDesign.mockReturnValue({
+      isDesignEnabled: false,
+      isLoading: false,
     });
   });
 
@@ -66,6 +77,20 @@ describe('SignOut', () => {
   it('renders AuthPageLayout', () => {
     render(<SignOut />);
     expect(screen.getByTestId('auth-page-layout')).toBeInTheDocument();
+  });
+
+  it('shows the branding slogan when design is not enabled and not loading', () => {
+    render(<SignOut />);
+    expect(screen.getByTestId('signin-slogan')).toBeInTheDocument();
+  });
+
+  it('hides the branding slogan when design is enabled', () => {
+    mockUseDesign.mockReturnValue({
+      isDesignEnabled: true,
+      isLoading: false,
+    });
+    render(<SignOut />);
+    expect(screen.queryByTestId('signin-slogan')).not.toBeInTheDocument();
   });
 
   it('renders when isMetaLoading is true', () => {

--- a/frontend/apps/gate/src/components/SignOut/__tests__/SignOutBox.test.tsx
+++ b/frontend/apps/gate/src/components/SignOut/__tests__/SignOutBox.test.tsx
@@ -41,6 +41,8 @@ vi.mock('@thunderid/logger/react', async (importOriginal) => {
 // Mock useDesign + layout/renderer so the box renders without the real design context.
 const mockUseDesign = vi.fn();
 let capturedOnSubmit: ((action: {id?: string}, inputs: Record<string, string>) => void) | undefined;
+let capturedResolve: ((template: string) => string) | undefined;
+let capturedOnInputChange: ((id: string, value: string) => void) | undefined;
 vi.mock('@thunderid/design', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@thunderid/design')>();
   return {
@@ -51,11 +53,17 @@ vi.mock('@thunderid/design', async (importOriginal) => {
     FlowComponentRenderer: ({
       component,
       onSubmit,
+      resolve,
+      onInputChange,
     }: {
       component: {id?: string; type: string};
       onSubmit: (action: {id?: string}, inputs: Record<string, string>) => void;
+      resolve: (template: string) => string;
+      onInputChange: (id: string, value: string) => void;
     }) => {
       capturedOnSubmit = onSubmit;
+      capturedResolve = resolve;
+      capturedOnInputChange = onInputChange;
       return (
         <div data-testid={`flow-component-${component.id ?? component.type}`}>{component.id ?? component.type}</div>
       );
@@ -83,7 +91,7 @@ vi.mock('@thunderid/react', async () => {
   const actual = await vi.importActual('@thunderid/react');
   return {
     ...actual,
-    useThunderID: () => ({resolveFlowTemplateLiterals: (template: string) => template}),
+    useThunderID: () => ({meta: {application: {name: 'My App'}}}),
     normalizeFlowResponse: (...args: unknown[]) => mockNormalize(...args) as {components: unknown[]},
   };
 });
@@ -98,6 +106,8 @@ describe('SignOutBox', () => {
     mockSearchParams = new URLSearchParams({executionId: 'exec-1', logoutId: 'logout-1'});
     mockNormalize.mockReturnValue({components: [], additionalData: {}, executionId: ''});
     capturedOnSubmit = undefined;
+    capturedResolve = undefined;
+    capturedOnInputChange = undefined;
     // Default: an interactive step so the mount fetch neither redirects nor errors.
     vi.stubGlobal(
       'fetch',
@@ -203,6 +213,56 @@ describe('SignOutBox', () => {
 
   it('shows an error alert and logs when the flow execute call fails', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ok: false, status: 500}));
+    render(<SignOutBox />);
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+
+  it('resolves translation and meta literals through the FlowComponentRenderer resolve prop', async () => {
+    mockNormalize.mockReturnValue({components: [{id: 'confirm', type: 'ACTION'}], additionalData: {}, executionId: ''});
+    render(<SignOutBox />);
+    await screen.findByTestId('flow-component-confirm');
+
+    expect(capturedResolve).toBeDefined();
+    // Translation literal resolves via the i18n `t` handler.
+    expect(typeof capturedResolve?.('{{ t(signout:forms.confirm.title) }}')).toBe('string');
+    // A valid meta path resolves to the value from the flow meta.
+    expect(capturedResolve?.('{{ meta(application.name) }}')).toBe('My App');
+    // A path that overshoots a primitive falls back to the unresolved literal (not the primitive).
+    expect(capturedResolve?.('{{ meta(application.name.first) }}')).toBe('{{meta(application.name.first)}}');
+    // An unknown meta path falls back to the unresolved literal.
+    expect(capturedResolve?.('{{ meta(unknown.key) }}')).toBe('{{meta(unknown.key)}}');
+  });
+
+  it('tracks input changes through the FlowComponentRenderer onInputChange prop', async () => {
+    mockNormalize.mockReturnValue({components: [{id: 'confirm', type: 'ACTION'}], additionalData: {}, executionId: ''});
+    render(<SignOutBox />);
+    await screen.findByTestId('flow-component-confirm');
+
+    expect(capturedOnInputChange).toBeDefined();
+    await act(async () => {
+      capturedOnInputChange?.('field', 'value');
+      await Promise.resolve();
+    });
+  });
+
+  it('shows an error and does not resume the flow when there is no executionId', async () => {
+    mockSearchParams = new URLSearchParams({logoutId: 'logout-1'});
+    render(<SignOutBox />);
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('shows an error alert when the logout completion callback fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string) => {
+        if (url.endsWith('/oauth2/logout/callback')) {
+          return Promise.resolve({ok: false, status: 500});
+        }
+        return Promise.resolve({ok: true, json: () => Promise.resolve({flowStatus: 'COMPLETE'})});
+      }),
+    );
     render(<SignOutBox />);
     expect(await screen.findByRole('alert')).toBeInTheDocument();
     expect(mockLogger.error).toHaveBeenCalled();


### PR DESCRIPTION
### Purpose
Brand and localize the sign-out flow authoring experience so it matches sign-in, and make its copy translatable.

Changes:
- Gate sign-out page now renders with the same branded layout as sign-in (product hero panel with logo + feature list, particle background, and the confirmation card), instead of just the bare card.
- Basic Sign Out Flow template is branded (heading, description, primary action) and its copy is resolved through i18n.
- New Sign Out Confirmation view step in the flow-builder resource panel, so a branded sign-out page can be dragged into a flow.
- New signout i18n namespace (en-US) for the confirmation copy.

<img width="1724" height="958" alt="image" src="https://github.com/user-attachments/assets/c6f5676d-bd3b-4b84-801e-980affde449b" />

<img width="1724" height="828" alt="Screenshot 2026-07-21 at 2 56 43 PM" src="https://github.com/user-attachments/assets/008cd8eb-c2fc-4cf3-9287-e1d388c521ba" />


<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
- Page layout parity: the gate SignOut component reuses the existing SignInSlogan (generic product branding) and ParticleBackground inside AuthPageLayout, mirroring SignIn. AuthPageLayout already lays its children out in a row, so this yields the same two-column branded page with no layout/variant CSS changes. The slogan is desktop-only, matching sign-in.
- Card content convention: title and description live outside the form BLOCK, with only the interactive action inside — matching the existing login "Consent View" step. This layout is kept consistent across the template and the builder step.
- Localization: added a signout namespace to the bootstrap translation resource (en-US). The template resolves via {{ t(signout:...) }}; it reaches the frontend through GET /flow/meta, which returns all namespaces when no namespace filter is passed (verified). The builder step uses plain editable text, consistent with the other steps.json entries (they are starting points users customize).


### Related Issues
- N/A

### Related PRs
- https://github.com/thunder-id/thunderid/issues/2036

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized sign-out confirmation UI copy (confirmation title, description, and submit label).
  * Added a localized generic sign-out failure message.
  * Extended the sign-out/login sequence with a dedicated “Sign Out Confirmation” step.
* **Bug Fixes**
  * Improved sign-out rendering for design-aware branding and correct loading behavior.
  * Enhanced flow template handling by resolving translation/meta placeholders at render time, with safe meta fallbacks.
  * Prevented duplicate sign-out execution resume to avoid token desync.
* **Tests**
  * Expanded sign-out and sign-out box coverage for branding visibility, template resolution, input-change wiring, missing execution IDs, and logout failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->