### PR TITLE
Fix CORS configuration and set admin password in dev bootstrap

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1554,7 +1554,7 @@ function Run {
     # the backend without manual configuration. Regenerated on every run and picked up by
     # the bootstrap one-shot; it is git-ignored and never packaged (see Build).
     $devServerConfig = @"
-# resource_type: server_config
+resource_type: server_config
 name: cors
 value:
   allowedOrigins:
@@ -1564,6 +1564,7 @@ value:
     Set-Content -Path (Join-Path $BACKEND_DIR "bootstrap/02-server-configurations.yaml") -Value $devServerConfig
 
     $env:PUBLIC_URL = $PUBLIC_URL
+    if (-not $env:ADMIN_PASSWORD) { $env:ADMIN_PASSWORD = "admin" }
     Push-Location $BACKEND_DIR
     try {
         & go run . bootstrap --console-redirect-uris "https://localhost:${CONSOLE_APP_DEFAULT_PORT}/console"


### PR DESCRIPTION
### Purpose

Running `.\build.ps1 run` on Windows could not complete a clean first-run setup, while the equivalent Bash workflow succeeded.

The generated CORS server configuration had its `resource_type` key commented out. Since `resource_type` is used by the bootstrap importer to determine the document handler, the configuration was ignored and Gate and Console origins were never added to the CORS allowlist.

Additionally, `ADMIN_PASSWORD` was not set before invoking the bootstrap subcommand. When no password was provided, bootstrap aborted instead of creating the default resources.

**Before (bootstrap fails on a clean checkout):**

<img width="1656" height="397" alt="image" src="https://github.com/user-attachments/assets/423c2e8f-f08a-466b-9397-88ff06ca64ad" />


**Before (Gate and Console blocked by CORS):**

<img width="1647" height="592" alt="image" src="https://github.com/user-attachments/assets/0a90736d-89db-4620-8d43-f587efd8a5ed" />


<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach

Aligned the Windows from-source bootstrap in `build.ps1` with the existing `build.sh` behavior.

The stray `#` was removed from the seeded server configuration so it is imported correctly

```yaml
resource_type: server_config
```

`ADMIN_PASSWORD` is now defaulted for the local dev path only:

```powershell
if (-not $env:ADMIN_PASSWORD) { $env:ADMIN_PASSWORD = "admin" }
```

This matches the `${ADMIN_PASSWORD:-admin}` behavior in `build.sh`, so an explicitly exported password still takes precedence and the default applies only when the variable is unset or empty. 

The change is limited to the from-source development bootstrap (`.\build.ps1 run`). Container images and packaged distributions continue to generate or require their existing credentials unchanged.

**After (clean first-run setup completes):**

<img width="1667" height="350" alt="image" src="https://github.com/user-attachments/assets/6a74a466-c7bd-4d0d-a94e-dbb93c71eee8" />



**After (Console login succeeds):**

<img width="1693" height="687" alt="image" src="https://github.com/user-attachments/assets/c65cdc8a-ccb5-476a-b9e3-a954293c3f8b" />


### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development environment setup by ensuring server configuration is recognized correctly.
  * Added a default administrator password when none is provided during local bootstrap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->