### PR TITLE
Enable HMR for frontend workspace packages in dev

### DIFF
--- a/frontend/apps/console/vite.config.ts
+++ b/frontend/apps/console/vite.config.ts
@@ -21,7 +21,7 @@ import {resolve, dirname} from 'path';
 import {fileURLToPath} from 'url';
 import {codecovVitePlugin} from '@codecov/vite-plugin';
 import babel from '@rolldown/plugin-babel';
-import {prismjsInjectCore} from '@thunderid/build-plugins/vite';
+import {linkWorkspaceSource, prismjsInjectCore} from '@thunderid/build-plugins/vite';
 import basicSsl from '@vitejs/plugin-basic-ssl';
 import react, {reactCompilerPreset} from '@vitejs/plugin-react';
 import {visualizer} from 'rollup-plugin-visualizer';
@@ -105,6 +105,7 @@ export default defineConfig(({command}) => ({
     ),
   },
   plugins: [
+    linkWorkspaceSource(),
     prismjsInjectCore(),
     basicSsl(),
     svgr(),

--- a/frontend/apps/gate/vite.config.ts
+++ b/frontend/apps/gate/vite.config.ts
@@ -20,7 +20,7 @@ import {resolve, dirname} from 'path';
 import {fileURLToPath} from 'url';
 import {codecovVitePlugin} from '@codecov/vite-plugin';
 import babel from '@rolldown/plugin-babel';
-import {prismjsInjectCore} from '@thunderid/build-plugins/vite';
+import {linkWorkspaceSource, prismjsInjectCore} from '@thunderid/build-plugins/vite';
 import basicSsl from '@vitejs/plugin-basic-ssl';
 import react, {reactCompilerPreset} from '@vitejs/plugin-react';
 import {visualizer} from 'rollup-plugin-visualizer';
@@ -91,6 +91,7 @@ export default defineConfig(({command}) => ({
     },
   },
   plugins: [
+    linkWorkspaceSource(),
     prismjsInjectCore(),
     basicSsl(),
     svgr(),

--- a/frontend/packages/build-plugins/src/vite/index.ts
+++ b/frontend/packages/build-plugins/src/vite/index.ts
@@ -16,7 +16,12 @@
  * under the License.
  */
 
+import {existsSync, readFileSync, realpathSync} from 'fs';
+import {join, sep} from 'path';
 import type {Plugin} from 'vite';
+
+// ThunderID npm scope / plugin-name prefix.
+const ORG = 'thunderid';
 
 // prismjs language files reference `Prism` as a global with no import — add one so
 // Rollup sees the dependency edge and evaluates the core before any language file.
@@ -31,4 +36,131 @@ export function prismjsInjectCore(): Plugin {
       return null;
     },
   };
+}
+
+interface AppPackageJson {
+  dependencies?: Record<string, string>;
+}
+
+interface ExportConditions {
+  types?: string;
+  import?: string;
+  require?: string;
+}
+
+type ExportsField = Record<string, string | ExportConditions>;
+
+interface WorkspacePackageJson {
+  exports?: ExportsField;
+}
+
+export interface LinkWorkspaceSourceOptions {
+  root?: string;
+}
+
+interface WorkspaceLinks {
+  specifierMap: Map<string, string>;
+  packageSrcRoots: string[];
+}
+
+// Redirects @thunderid/* workspace imports to package source during `vite serve` only
+// (never build, and never vitest, which also drives Vite in serve mode), so edits
+// under packages/*/src hot-update in the consuming app instead of resolving to the
+// prebuilt dist/ output that ships in the package's exports map.
+export function linkWorkspaceSource(options: LinkWorkspaceSourceOptions = {}): Plugin {
+  let links: WorkspaceLinks | undefined;
+  let appSrcRoot: string | undefined;
+
+  return {
+    name: `${ORG}:link-workspace-source`,
+    enforce: 'pre',
+    configResolved(config) {
+      if (config.command !== 'serve' || process.env['VITEST']) {
+        return;
+      }
+      const appRoot = options.root ?? config.root;
+      appSrcRoot = join(appRoot, 'src');
+      links = buildWorkspaceLinks(appRoot);
+    },
+    resolveId(source, importer) {
+      if (!links) {
+        return undefined;
+      }
+
+      const direct = links.specifierMap.get(source);
+      if (direct) {
+        return direct;
+      }
+
+      // The app's own `@`/`@/*` aliases (resolved by Vite before this plugin runs) assume
+      // every import lives under the app's `src`. When a linked package's own source uses
+      // the same alias convention internally, Vite mis-substitutes it onto the app's `src`
+      // before this plugin ever sees the original specifier. Detect that mis-substitution
+      // (importer lives inside a linked package's `src`, but the substituted id is rooted at
+      // the app's `src`) and re-root it onto the package the import actually came from.
+      if (importer && appSrcRoot && source.startsWith(appSrcRoot + sep)) {
+        const packageSrcRoot = links.packageSrcRoots.find((root) => importer.startsWith(root + sep));
+        if (packageSrcRoot) {
+          return resolveExistingFile(join(packageSrcRoot, source.slice(appSrcRoot.length)));
+        }
+      }
+
+      return undefined;
+    },
+  };
+}
+
+function buildWorkspaceLinks(appRoot: string): WorkspaceLinks {
+  const specifierMap = new Map<string, string>();
+  const packageSrcRoots: string[] = [];
+  const appPackageJson = readJson<AppPackageJson>(join(appRoot, 'package.json'));
+
+  for (const [name, spec] of Object.entries(appPackageJson.dependencies ?? {})) {
+    if (!name.startsWith(`@${ORG}/`) || !spec.startsWith('workspace:')) {
+      continue;
+    }
+
+    let packageDir: string;
+    try {
+      packageDir = realpathSync(join(appRoot, 'node_modules', name));
+    } catch {
+      continue;
+    }
+
+    const packageJson = readJson<WorkspacePackageJson>(join(packageDir, 'package.json'));
+    let linked = false;
+
+    for (const [subpath, target] of Object.entries(packageJson.exports ?? {})) {
+      const distTarget = typeof target === 'string' ? target : target.import;
+      const sourcePath = distTarget && resolveDistAsSource(packageDir, distTarget);
+      if (!sourcePath) {
+        continue;
+      }
+      specifierMap.set(subpath === '.' ? name : `${name}/${subpath.slice(2)}`, sourcePath);
+      linked = true;
+    }
+
+    if (linked) {
+      packageSrcRoots.push(join(packageDir, 'src'));
+    }
+  }
+
+  return {specifierMap, packageSrcRoots};
+}
+
+function resolveDistAsSource(packageDir: string, distTarget: string): string | undefined {
+  const sourceBase = distTarget.replace(/^\.\/dist\//, './src/').replace(/\.(m|c)?js$/, '');
+  return resolveExistingFile(join(packageDir, sourceBase));
+}
+
+// Tries the source as a file first (`foo/bar.ts`), then as a directory barrel
+// (`foo/bar/index.ts`), matching how the `@`-alias imports inside packages reference
+// both individual modules and folder barrels.
+function resolveExistingFile(base: string): string | undefined {
+  const candidates = [`${base}.ts`, `${base}.tsx`, join(base, 'index.ts'), join(base, 'index.tsx')];
+  return candidates.find((candidate) => existsSync(candidate));
+}
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, 'utf-8')) as T;
 }


### PR DESCRIPTION
### Purpose

HMR did not work for edits under `frontend/packages/*/src` in the console and gate dev servers. Only edits in an app's own `src` hot-updated; editing a workspace package (e.g. `@thunderid/components`) required a manual restart or rebuild.

Root cause: every `@thunderid/*` package's `exports` resolves to prebuilt `dist/`. During `vite serve` the app imports that compiled output through the workspace symlink, which Vite treats as a pre-bundled dependency, so package source never enters the module graph and no HMR fires. Only apps run a dev server; nothing rebuilds packages during dev.

### Approach

Add a dev-only Vite plugin, `linkWorkspaceSource`, to `@thunderid/build-plugins`, and wire it into the console and gate Vite configs.

- Active only during the real dev server: `command === 'serve'` and not under vitest (`!process.env.VITEST`). Production builds (`vite build`) and tests continue to resolve to `dist/` unchanged.
- It reads each app's own `dependencies`, keeps the `@thunderid/*` entries with a `workspace:` specifier (console's 14, gate's 7), and maps each export subpath (the `.` barrel plus subpaths like `@thunderid/i18n/locales/en-US` and `@thunderid/logger/react`) to the package's `src` entry. Resolution is done in a `resolveId` hook keyed on exact specifiers, so barrels and subpaths never collide.
- It also re-roots the packages' own internal `@/...` alias imports onto the correct package `src`, which the app's `@` alias would otherwise mis-resolve onto the app's `src`.
- No package `package.json` is modified; the change lives entirely in the apps' dev tooling. An alternative (adding a `development` export condition to each package) was considered, but the shared-plugin approach keeps package manifests untouched and centralizes the logic for reuse across apps.

### Verification

- `pnpm dev`: edits under `frontend/packages/components/src` and a `configure-*` package hot-update in the browser (confirmed via `hmr update` log lines and `@fs/.../packages/*/src` resolution). Gate verified the same for its packages.
- Production still resolves to `dist/`: `pnpm build:packages` + `pnpm build:apps` succeed with no source or `@fs` paths leaked into `dist`.
- Tests unchanged: console (477 files / 7396 tests) and gate (30 / 364) pass; the dev-server guard keeps tests on `dist`.
- `make pr_checks` passes end to end.

### Related Issues
- #4167

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

Note on tests: this is a dev-only Vite plugin (like its sibling `prismjsInjectCore`, which is also untested). Behavior was verified manually and through the full `make pr_checks` gate rather than a new unit test.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved local development by linking workspace packages directly to their source code.
  * Enabled faster, more accurate live updates across the Console and Gate applications.
* **Bug Fixes**
  * Corrected module resolution for linked packages, including source aliases and barrel files.
  * Prevented source-linking behavior from affecting test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->