### PR TITLE
Return default OIDC scope-to-claims mappings in API responses

### DIFF
--- a/backend/internal/inboundclient/service.go
+++ b/backend/internal/inboundclient/service.go
@@ -38,6 +38,7 @@ import (
 	flowmgt "github.com/thunder-id/thunderid/internal/flow/mgt"
 	inboundmodel "github.com/thunder-id/thunderid/internal/inboundclient/model"
 	oauth2const "github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
+	oauthutils "github.com/thunder-id/thunderid/internal/oauth/oauth2/utils"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	syshttp "github.com/thunder-id/thunderid/internal/system/http"
@@ -1346,7 +1347,8 @@ func applyInboundDefaults(c *inboundmodel.InboundClient, oauthProfile *providers
 		IDJAG:        resolveIDJAG(oauthProfile.Token),
 	}
 	oauthProfile.UserInfo = resolveUserInfo(oauthProfile.UserInfo, idToken)
-	oauthProfile.ScopeClaims = resolveScopeClaims(oauthProfile.ScopeClaims)
+	// Persist the effective scope-to-claims mapping: standard OIDC defaults merged with any overrides.
+	oauthProfile.ScopeClaims = oauthutils.ResolveEffectiveScopeClaims(oauthProfile.ScopeClaims)
 }
 
 // getDefaultAssertionFromDeployment returns the assertion config from the deployment-level JWT settings.
@@ -1511,14 +1513,6 @@ func resolveUserInfo(in *providers.UserInfoConfig,
 		out.UserAttributes = idToken.UserAttributes
 	}
 	return out
-}
-
-// resolveScopeClaims returns the input scope claims map, defaulting to an empty map if nil.
-func resolveScopeClaims(in map[string][]string) map[string][]string {
-	if in == nil {
-		return make(map[string][]string)
-	}
-	return in
 }
 
 // reconcileReferencedFlows walks call-node targets reachable from the inbound client's configured

--- a/backend/internal/inboundclient/service_test.go
+++ b/backend/internal/inboundclient/service_test.go
@@ -1241,20 +1241,6 @@ func (suite *InboundClientServiceTestSuite) TestResolveOAuthTokens_CarriesDefaul
 	assert.Equal(suite.T(), "https://api.example.com", at.DefaultAudience)
 }
 
-// ----- resolveScopeClaims -----
-
-func (suite *InboundClientServiceTestSuite) TestResolveScopeClaims_NilReturnsEmptyMap() {
-	out := resolveScopeClaims(nil)
-	assert.NotNil(suite.T(), out)
-	assert.Empty(suite.T(), out)
-}
-
-func (suite *InboundClientServiceTestSuite) TestResolveScopeClaims_PassesThroughExistingMap() {
-	in := map[string][]string{"profile": {"given_name"}}
-	out := resolveScopeClaims(in)
-	assert.Equal(suite.T(), in, out)
-}
-
 // ----- validateRedirectURIs error branches -----
 
 func (suite *InboundClientServiceTestSuite) TestValidateRedirectURIs_SchemeWildcardRejected() {

--- a/backend/internal/oauth/oauth2/utils/oauthutils.go
+++ b/backend/internal/oauth/oauth2/utils/oauthutils.go
@@ -172,6 +172,22 @@ func FilterOIDCScopesByAllowedScopes(oidcScopes []string, allowedScopes []string
 	return filteredScopes
 }
 
+// ResolveEffectiveScopeClaims returns the scope-to-claims mapping as it is applied at runtime: the
+// standard OIDC defaults from StandardOIDCScopes, with any per-scope overrides from the stored mapping
+// applied on top and any custom scopes carried through.
+func ResolveEffectiveScopeClaims(stored map[string][]string) map[string][]string {
+	effective := make(map[string][]string, len(constants.StandardOIDCScopes)+len(stored))
+	for scope, def := range constants.StandardOIDCScopes {
+		claims := make([]string, len(def.Claims))
+		copy(claims, def.Claims)
+		effective[scope] = claims
+	}
+	for scope, claims := range stored {
+		effective[scope] = claims
+	}
+	return effective
+}
+
 // ParseClaimsRequest parses the claims parameter JSON string into a ClaimsRequest struct.
 // Returns nil if the input is empty.
 // Returns an error if the JSON is malformed or violates OIDC spec constraints.

--- a/backend/internal/oauth/oauth2/utils/oauthutils_test.go
+++ b/backend/internal/oauth/oauth2/utils/oauthutils_test.go
@@ -1788,3 +1788,45 @@ func (suite *OAuth2UtilsTestSuite) TestDecodeFlowAssertionClaims_MissingOptional
 	suite.Empty(claims.AttributeCacheID)
 	suite.Empty(claims.CompletedACR)
 }
+
+func (suite *OAuth2UtilsTestSuite) TestResolveEffectiveScopeClaims_NilReturnsAllStandardDefaults() {
+	effective := ResolveEffectiveScopeClaims(nil)
+
+	suite.Len(effective, len(constants.StandardOIDCScopes))
+	suite.Equal([]string{"sub"}, effective["openid"])
+	suite.Equal([]string{"email", "email_verified"}, effective["email"])
+	suite.Contains(effective["profile"], "name")
+	suite.Contains(effective["profile"], "family_name")
+}
+
+func (suite *OAuth2UtilsTestSuite) TestResolveEffectiveScopeClaims_PartialOverrideMergesWithDefaults() {
+	effective := ResolveEffectiveScopeClaims(map[string][]string{
+		"profile":     {"name"},
+		"customScope": {"customClaim"},
+	})
+
+	// Overridden scope wins.
+	suite.Equal([]string{"name"}, effective["profile"])
+	// Custom scope is carried through.
+	suite.Equal([]string{"customClaim"}, effective["customScope"])
+	// Untouched standard scopes keep their defaults.
+	suite.Equal([]string{"email", "email_verified"}, effective["email"])
+}
+
+func (suite *OAuth2UtilsTestSuite) TestResolveEffectiveScopeClaims_EmptySliceOverrideIsPreserved() {
+	effective := ResolveEffectiveScopeClaims(map[string][]string{
+		"profile": {},
+	})
+
+	claims, ok := effective["profile"]
+	suite.True(ok, "profile key should be present")
+	suite.Empty(claims, "explicit empty override should suppress default claims")
+}
+
+func (suite *OAuth2UtilsTestSuite) TestResolveEffectiveScopeClaims_DoesNotMutateStandardDefaults() {
+	effective := ResolveEffectiveScopeClaims(nil)
+	effective["email"][0] = "mutated"
+
+	suite.Equal([]string{"email", "email_verified"}, constants.StandardOIDCScopes["email"].Claims,
+		"the shared StandardOIDCScopes constant must not be mutated via the returned map")
+}

--- a/tests/integration/application/application_api_test.go
+++ b/tests/integration/application/application_api_test.go
@@ -2035,7 +2035,17 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithOnlyIDToken() {
 	ts.Assert().NotNil(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token)
 	ts.Assert().NotNil(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken)
 	ts.Assert().Equal(int64(3600), retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken.ValidityPeriod)
-	ts.Assert().Len(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.ScopeClaims, 2)
+	// The response returns the effective scope-claims mapping: the standard OIDC defaults with the
+	// app's stored overrides applied on top, so all six standard scopes are present. The overridden
+	// scopes carry the stored values; the rest carry the exact standard defaults.
+	scopeClaims := retrievedApp.InboundAuthConfig[0].OAuthAppConfig.ScopeClaims
+	ts.Assert().Len(scopeClaims, 6)
+	ts.Assert().Equal([]string{"name", "given_name", "family_name", "middle_name"}, scopeClaims["profile"])
+	ts.Assert().Equal([]string{"email", "email_verified"}, scopeClaims["email"])
+	ts.Assert().Equal([]string{"sub"}, scopeClaims["openid"])
+	ts.Assert().Equal([]string{"phone_number", "phone_number_verified"}, scopeClaims["phone"])
+	ts.Assert().Equal([]string{"address"}, scopeClaims["address"])
+	ts.Assert().Equal([]string{"roles"}, scopeClaims["roles"])
 }
 
 // TestApplicationWithBothTokenTypes tests creating application with both AccessToken and IDToken.
@@ -2267,9 +2277,13 @@ func (ts *ApplicationAPITestSuite) TestApplicationWithComplexScopeClaims() {
 	retrievedApp, err := getApplicationByID(appID)
 	ts.Require().NoError(err)
 	ts.Assert().NotNil(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.Token.IDToken)
-	ts.Assert().Len(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.ScopeClaims, 5)
-	ts.Assert().Contains(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.ScopeClaims, "profile")
-	ts.Assert().GreaterOrEqual(len(retrievedApp.InboundAuthConfig[0].OAuthAppConfig.ScopeClaims["profile"]), 10)
+	// The response returns the effective mapping: the six standard OIDC scopes (defaults with the
+	// app's overrides applied) plus the "custom" scope carried through.
+	scopeClaims := retrievedApp.InboundAuthConfig[0].OAuthAppConfig.ScopeClaims
+	ts.Assert().Len(scopeClaims, 7)
+	ts.Assert().Contains(scopeClaims, "profile")
+	ts.Assert().GreaterOrEqual(len(scopeClaims["profile"]), 10)
+	ts.Assert().Equal([]string{"organization", "department", "employee_id"}, scopeClaims["custom"])
 }
 
 // TestApplicationCertificateRollbackOnOAuthFail tests certificate rollback when OAuth creation fails.


### PR DESCRIPTION
### Purpose

Return default OIDC scope-to-claims mappings in the application and agent management API responses so the Console UI shows them.

Previously the backend stored only explicit overrides for `scopeClaims` (nil when uncustomized) and omitted the field from responses, so the Console rendered every scope with zero mapped attributes even though the runtime applied the standard OIDC defaults. Responses now include the effective mapping (standard OIDC defaults from `StandardOIDCScopes` overlaid with any stored per-scope overrides), matching exactly what tokens and userinfo emit at runtime.

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
Application and Agent management API responses (GET, create, update, and Export, DCR, and MCP responses) now always include the effective OIDC `scopeClaims` mapping: the standard OIDC scope-to-claim defaults merged with any stored per-scope overrides. Previously the field was omitted from the response when a client had not customized it.

#### 💥 Impact
- Response shape: `scopeClaims` is now always present and populated with all standard OIDC scopes, instead of being omitted when not customized. Consumers can no longer infer "using defaults" from the field being absent.
- Round-trip writes: a client that reads a configuration and re-submits it (GET then PUT) now persists the full default mapping, converting an implicit "inherit defaults" into an explicit stored map (a frozen snapshot). The stored record changes, though token and UserInfo output do not.
- Declarative/GitOps and export: exported application and agent resources now include the full `scopeClaims` map, so a re-apply shows a nil to explicit diff on the first apply and pins the defaults into the resource.
- Not affected: runtime token and UserInfo claim issuance is unchanged. The emitted claims are identical.

#### 🔄 Migration Guide
- No action is required for token or UserInfo behavior; it is unchanged.
- Consumers that treated an absent `scopeClaims` as "using defaults" should treat a populated map as the effective mapping. To detect explicit customization, compare each scope's claims against the standard OIDC defaults.
- Declarative/GitOps users should re-export resources after upgrading so stored files reflect the effective mapping, or ignore the additive `scopeClaims` entries in diffs.
---

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3710

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scope claims now automatically include standard OIDC defaults.
  * Application-specific scope-claim overrides and custom scopes are preserved and merged with the defaults.
  * Providing an explicit empty claim list can suppress default claims for a scope.

* **Bug Fixes**
  * When no stored scope-claims are provided, the effective scope-claims now correctly resolve to the full default set (rather than an empty result).
  * Resolved scope-claims no longer risk altering the shared default claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->