### PR TITLE
Add agent system-attribute, OU claims and Groups & Roles claims

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -417,7 +417,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	// Initialize design resolve service for theme and layout resolution
 	designResolveService := resolve.Initialize(mux, themeMgtService, layoutMgtService, applicationService)
 
-	actorProvider := actorprovider.Initialize(inboundClientService, entityProvider, authnProvider)
+	actorProvider := actorprovider.Initialize(inboundClientService, entityProvider, authnProvider, roleService)
 
 	// Initialize flow metadata service
 	_ = flowmeta.Initialize(mux, actorProvider, ouService, designResolveService, i18nService)

--- a/backend/internal/actorprovider/init.go
+++ b/backend/internal/actorprovider/init.go
@@ -23,15 +23,17 @@ package actorprovider
 import (
 	"github.com/thunder-id/thunderid/internal/entityprovider"
 	"github.com/thunder-id/thunderid/internal/inboundclient"
+	"github.com/thunder-id/thunderid/internal/role"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
 
-// Initialize creates the default ActorProvider backed by inbound-client, entity-provider, and
-// authentication provider services.
+// Initialize creates the default ActorProvider backed by inbound-client, entity-provider,
+// authentication provider, and role services.
 func Initialize(
 	inboundClient inboundclient.InboundClientServiceInterface,
 	entityProvider entityprovider.EntityProviderInterface,
 	authnProvider providers.AuthnProviderManager,
+	roleService role.RoleServiceInterface,
 ) providers.ActorProvider {
-	return newActorProvider(inboundClient, entityProvider, authnProvider)
+	return newActorProvider(inboundClient, entityProvider, authnProvider, roleService)
 }

--- a/backend/internal/actorprovider/service.go
+++ b/backend/internal/actorprovider/service.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/entityprovider"
 	"github.com/thunder-id/thunderid/internal/inboundclient"
+	"github.com/thunder-id/thunderid/internal/role"
 	"github.com/thunder-id/thunderid/internal/system/log"
 )
 
@@ -36,20 +37,23 @@ type actorProvider struct {
 	inboundClient  inboundclient.InboundClientServiceInterface
 	entityProvider entityprovider.EntityProviderInterface
 	authnProvider  providers.AuthnProviderManager
+	roleService    role.RoleServiceInterface
 	logger         *log.Logger
 }
 
 // newActorProvider creates a new actorProvider backed by the given inbound-client, entity-provider,
-// and authentication provider.
+// authentication provider, and role service.
 func newActorProvider(
 	inboundClient inboundclient.InboundClientServiceInterface,
 	entityProvider entityprovider.EntityProviderInterface,
 	authnProvider providers.AuthnProviderManager,
+	roleService role.RoleServiceInterface,
 ) providers.ActorProvider {
 	return &actorProvider{
 		inboundClient:  inboundClient,
 		entityProvider: entityProvider,
 		authnProvider:  authnProvider,
+		roleService:    roleService,
 		logger:         log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ActorProvider")),
 	}
 }
@@ -133,6 +137,16 @@ func (p *actorProvider) GetActorGroups(
 		return nil, mapEntityProviderError(epErr)
 	}
 	return groups, nil
+}
+
+// GetActorRoles returns the roles assigned to the actor, directly and through the given groups.
+func (p *actorProvider) GetActorRoles(
+	actorID string, groupIDs []string,
+) ([]string, *tidcommon.ServiceError) {
+	if p.roleService == nil {
+		return nil, nil
+	}
+	return p.roleService.GetUserRoles(context.Background(), actorID, groupIDs)
 }
 
 func mapEntityProviderError(epErr *entityprovider.EntityProviderError) *tidcommon.ServiceError {

--- a/backend/internal/actorprovider/service_test.go
+++ b/backend/internal/actorprovider/service_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/thunder-id/thunderid/tests/mocks/authnprovider/managermock"
 	"github.com/thunder-id/thunderid/tests/mocks/entityprovidermock"
 	"github.com/thunder-id/thunderid/tests/mocks/inboundclientmock"
+	"github.com/thunder-id/thunderid/tests/mocks/rolemock"
 )
 
 type ActorProviderTestSuite struct {
@@ -42,6 +43,7 @@ type ActorProviderTestSuite struct {
 	mockInbound *inboundclientmock.InboundClientServiceInterfaceMock
 	mockEntity  *entityprovidermock.EntityProviderInterfaceMock
 	mockAuthn   *managermock.AuthnProviderManagerMock
+	mockRole    *rolemock.RoleServiceInterfaceMock
 	provider    providers.ActorProvider
 }
 
@@ -53,7 +55,8 @@ func (s *ActorProviderTestSuite) SetupTest() {
 	s.mockInbound = inboundclientmock.NewInboundClientServiceInterfaceMock(s.T())
 	s.mockEntity = entityprovidermock.NewEntityProviderInterfaceMock(s.T())
 	s.mockAuthn = managermock.NewAuthnProviderManagerMock(s.T())
-	s.provider = Initialize(s.mockInbound, s.mockEntity, s.mockAuthn)
+	s.mockRole = rolemock.NewRoleServiceInterfaceMock(s.T())
+	s.provider = Initialize(s.mockInbound, s.mockEntity, s.mockAuthn, s.mockRole)
 }
 
 func (s *ActorProviderTestSuite) TestGetOAuthClientByClientID_Delegates() {
@@ -163,4 +166,38 @@ func (s *ActorProviderTestSuite) TestGetActorGroups_Delegates() {
 
 	s.Nil(err)
 	s.Equal(expected, groups)
+}
+
+func (s *ActorProviderTestSuite) TestGetActorRoles_Delegates() {
+	expected := []string{"admin", "editor"}
+	groupIDs := []string{"group-1"}
+	s.mockRole.On("GetUserRoles", mock.Anything, "app-1", groupIDs).
+		Return(expected, (*tidcommon.ServiceError)(nil))
+
+	roles, err := s.provider.GetActorRoles("app-1", groupIDs)
+
+	s.Nil(err)
+	s.Equal(expected, roles)
+}
+
+func (s *ActorProviderTestSuite) TestGetActorRoles_PropagatesError() {
+	svcErr := &tidcommon.ServiceError{
+		Code:  "ROLE-0001",
+		Error: tidcommon.I18nMessage{Key: "error.test.role", DefaultValue: "role lookup failed"},
+	}
+	s.mockRole.On("GetUserRoles", mock.Anything, "app-1", []string{"group-1"}).Return(nil, svcErr)
+
+	roles, err := s.provider.GetActorRoles("app-1", []string{"group-1"})
+
+	s.Nil(roles)
+	s.Equal(svcErr, err)
+}
+
+func (s *ActorProviderTestSuite) TestGetActorRoles_NilRoleService_ReturnsNil() {
+	provider := Initialize(s.mockInbound, s.mockEntity, s.mockAuthn, nil)
+
+	roles, err := provider.GetActorRoles("app-1", []string{"group-1"})
+
+	s.Nil(err)
+	s.Nil(roles)
 }

--- a/backend/internal/actorprovider/utils_test.go
+++ b/backend/internal/actorprovider/utils_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/thunder-id/thunderid/tests/mocks/authnprovider/managermock"
 	"github.com/thunder-id/thunderid/tests/mocks/entityprovidermock"
 	"github.com/thunder-id/thunderid/tests/mocks/inboundclientmock"
+	"github.com/thunder-id/thunderid/tests/mocks/rolemock"
 )
 
 type UtilsTestSuite struct {
@@ -54,7 +55,8 @@ func TestUtilsTestSuite(t *testing.T) {
 func (s *UtilsTestSuite) SetupTest() {
 	s.mockInbound = inboundclientmock.NewInboundClientServiceInterfaceMock(s.T())
 	s.mockEntity = entityprovidermock.NewEntityProviderInterfaceMock(s.T())
-	s.provider = Initialize(s.mockInbound, s.mockEntity, managermock.NewAuthnProviderManagerMock(s.T()))
+	s.provider = Initialize(s.mockInbound, s.mockEntity, managermock.NewAuthnProviderManagerMock(s.T()),
+		rolemock.NewRoleServiceInterfaceMock(s.T()))
 }
 
 func (s *UtilsTestSuite) TestBuildApplication_Success() {
@@ -215,7 +217,8 @@ func (s *UtilsTestSuite) TestReadEntitySystemAttributes_EmptyAttributes() {
 func TestBuildApplication_InboundClientStoreError(t *testing.T) {
 	mockInbound := inboundclientmock.NewInboundClientServiceInterfaceMock(t)
 	mockEntity := entityprovidermock.NewEntityProviderInterfaceMock(t)
-	provider := Initialize(mockInbound, mockEntity, managermock.NewAuthnProviderManagerMock(t))
+	provider := Initialize(mockInbound, mockEntity, managermock.NewAuthnProviderManagerMock(t),
+		rolemock.NewRoleServiceInterfaceMock(t))
 
 	mockInbound.On("GetInboundClientByEntityID", mock.Anything, "app-1").
 		Return((*inboundmodel.InboundClient)(nil), errors.New("db error"))

--- a/backend/internal/flow/flowexec/service_test.go
+++ b/backend/internal/flow/flowexec/service_test.go
@@ -258,7 +258,7 @@ func TestInitiateFlowSuccessScenarios(t *testing.T) {
 				graphBuilder:  mockGraphBuilder,
 				flowProvider:  mockFlowProvider,
 				flowStore:     mockStore,
-				actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+				actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 				flowEngine:    nil,
 				transactioner: &stubTransactioner{},
 				cryptoSvc:     mockCrypto,
@@ -446,7 +446,7 @@ func TestInitiateFlowErrorScenarios(t *testing.T) {
 				graphBuilder:  mockGraphBuilder,
 				flowProvider:  mockFlowProvider,
 				flowStore:     mockStore,
-				actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+				actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 				flowEngine:    nil,
 				transactioner: &stubTransactioner{},
 				cryptoSvc:     mockCrypto,
@@ -506,7 +506,7 @@ func TestInitiateFlowFallsBackToDefaultFlow(t *testing.T) {
 			graphBuilder:  mockGraphBuilder,
 			flowProvider:  mockFlowProvider,
 			flowStore:     mockStore,
-			actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+			actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 			transactioner: &stubTransactioner{},
 			cryptoSvc:     mockCrypto,
 			cfg:           testFlowExecCfg,
@@ -554,7 +554,7 @@ func TestInitiateFlowFallsBackToDefaultFlow(t *testing.T) {
 			graphBuilder:  mockGraphBuilder,
 			flowProvider:  mockFlowProvider,
 			flowStore:     mockStore,
-			actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+			actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 			transactioner: &stubTransactioner{},
 			cfg:           testFlowExecCfg,
 		}
@@ -585,7 +585,7 @@ func TestInitiateFlowFallsBackToDefaultFlow(t *testing.T) {
 			graphBuilder:  mockGraphBuilder,
 			flowProvider:  mockFlowProvider,
 			flowStore:     mockStore,
-			actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+			actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 			transactioner: &stubTransactioner{},
 			cfg:           testFlowExecCfg,
 		}
@@ -689,7 +689,7 @@ func TestEncryptedPayloadStoredBeforeWrite(t *testing.T) {
 		graphBuilder:  mockGraphBuilder,
 		flowProvider:  mockFlowProvider,
 		flowStore:     mockStore,
-		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 		transactioner: &stubTransactioner{},
 		cryptoSvc:     mockCrypto,
 		cfg:           testFlowExecCfg,
@@ -771,7 +771,7 @@ func TestDecryptCalledForEncryptedStoredContext(t *testing.T) {
 		graphBuilder:  mockGraphBuilder,
 		flowProvider:  mockFlowProvider,
 		flowEngine:    mockEngine,
-		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 		transactioner: &stubTransactioner{},
 		cryptoSvc:     mockCrypto,
 		cfg:           testFlowExecCfg,
@@ -1067,7 +1067,7 @@ func TestExecute_ContextDecryptionSuccess(t *testing.T) {
 		graphBuilder:  mockGraphBuilder,
 		flowProvider:  mockFlowProvider,
 		flowEngine:    mockEngine,
-		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 		transactioner: &stubTransactioner{},
 		cryptoSvc:     mockCrypto,
 		cfg:           testFlowExecCfg,
@@ -1135,7 +1135,7 @@ func TestExecute_ExistingFlowWithoutChallengeToken(t *testing.T) {
 		graphBuilder:  mockGraphBuilder,
 		flowProvider:  mockFlowProvider,
 		flowEngine:    mockEngine,
-		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 		transactioner: &stubTransactioner{},
 		cryptoSvc:     mockCrypto,
 		cfg:           testFlowExecCfg,
@@ -1230,7 +1230,7 @@ func TestExecute_ExistingFlowWithDifferentChallengeTokens(t *testing.T) {
 				graphBuilder:  mockGraphBuilder,
 				flowProvider:  mockFlowProvider,
 				flowEngine:    mockEngine,
-				actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+				actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 				transactioner: &stubTransactioner{},
 				cryptoSvc:     mockCrypto,
 				cfg:           testFlowExecCfg,
@@ -1307,7 +1307,7 @@ func TestExecute_EngineError_InvalidChallengeToken_PreservesContext(t *testing.T
 		graphBuilder:  mockGraphBuilder,
 		flowProvider:  mockFlowProvider,
 		flowEngine:    mockEngine,
-		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 		transactioner: &stubTransactioner{},
 		cryptoSvc:     mockCrypto,
 		cfg:           testFlowExecCfg,
@@ -1384,7 +1384,7 @@ func TestExecute_EngineError_NonChallengeToken_RemovesContext(t *testing.T) {
 		graphBuilder:  mockGraphBuilder,
 		flowProvider:  mockFlowProvider,
 		flowEngine:    mockEngine,
-		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 		transactioner: &stubTransactioner{},
 		cfg:           testFlowExecCfg,
 	}
@@ -1445,7 +1445,7 @@ func TestExecute_EngineError_NewFlow_ContextNeverRemoved(t *testing.T) {
 		graphBuilder:  mockGraphBuilder,
 		flowProvider:  mockFlowProvider,
 		flowEngine:    mockEngine,
-		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, mockAuthn),
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, mockAuthn, nil),
 		transactioner: &stubTransactioner{},
 		cryptoSvc:     mockCrypto,
 		cfg:           testFlowExecCfg,
@@ -1470,7 +1470,7 @@ func newBuildAppProvider(
 	*entityprovidermock.EntityProviderInterfaceMock) {
 	mockInbound := inboundclientmock.NewInboundClientServiceInterfaceMock(t)
 	mockEP := entityprovidermock.NewEntityProviderInterfaceMock(t)
-	return actorprovider.Initialize(mockInbound, mockEP, noopAuthnMgr()), mockInbound, mockEP
+	return actorprovider.Initialize(mockInbound, mockEP, noopAuthnMgr(), nil), mockInbound, mockEP
 }
 
 func TestBuildApplication_InboundClientNotFound(t *testing.T) {
@@ -1684,7 +1684,7 @@ func TestInitiateAndExecute_CustomExpiryUsed(t *testing.T) {
 		graphBuilder:  mockGraphBuilder,
 		flowProvider:  mockFlowProvider,
 		flowEngine:    mockEngineInner,
-		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 		transactioner: &stubTransactioner{},
 		cryptoSvc:     mockCrypto,
 		cfg:           testFlowExecCfg,
@@ -1739,7 +1739,7 @@ func TestInitiateAndExecute_ZeroExpiryUsesDefault(t *testing.T) {
 		graphBuilder:  mockGraphBuilder,
 		flowProvider:  mockFlowProvider,
 		flowEngine:    mockEngineInner,
-		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 		transactioner: &stubTransactioner{},
 		cryptoSvc:     mockCrypto,
 		cfg:           testFlowExecCfg,
@@ -1806,7 +1806,7 @@ func TestInitiateAndExecute_InitialInputsAndRuntimeData(t *testing.T) {
 		graphBuilder:  mockGraphBuilder,
 		flowProvider:  mockFlowProvider,
 		flowEngine:    mockEngineInner,
-		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 		transactioner: &stubTransactioner{},
 		cryptoSvc:     mockCrypto,
 		cfg:           testFlowExecCfg,
@@ -1861,7 +1861,7 @@ func TestInitiateAndExecute_FlowComplete_ContextNotStored(t *testing.T) {
 		graphBuilder:  mockGraphBuilder,
 		flowProvider:  mockFlowProvider,
 		flowEngine:    mockEngineInner,
-		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 		transactioner: &stubTransactioner{},
 		cryptoSvc:     mockCrypto,
 		cfg:           testFlowExecCfg,
@@ -1914,7 +1914,7 @@ func TestInitiateAndExecute_EngineError(t *testing.T) {
 		graphBuilder:  mockGraphBuilder,
 		flowProvider:  mockFlowProvider,
 		flowEngine:    mockEngineInner,
-		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 		transactioner: &stubTransactioner{},
 		cryptoSvc:     mockCrypto,
 		cfg:           testFlowExecCfg,
@@ -1969,7 +1969,7 @@ func TestInitiateAndExecute_StoreError_ReturnsError(t *testing.T) {
 		graphBuilder:  mockGraphBuilder,
 		flowProvider:  mockFlowProvider,
 		flowEngine:    mockEngineInner,
-		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 		transactioner: &stubTransactioner{},
 		cryptoSvc:     mockCrypto,
 		cfg:           testFlowExecCfg,
@@ -2048,7 +2048,7 @@ func (s *ServiceTestSuite) TestGetFlowGraph_RegistrationAndRecovery() {
 			mockInboundClient := inboundclientmock.NewInboundClientServiceInterfaceMock(s.T())
 			mockEntityProvider := entityprovidermock.NewEntityProviderInterfaceMock(s.T())
 			service := &flowExecService{
-				actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+				actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 				cfg:           testFlowExecCfg,
 			}
 
@@ -2081,7 +2081,7 @@ func (s *ServiceTestSuite) TestGetFlowGraph_MissingConfiguredFlowID() {
 	mockInboundClient := inboundclientmock.NewInboundClientServiceInterfaceMock(s.T())
 	mockEntityProvider := entityprovidermock.NewEntityProviderInterfaceMock(s.T())
 	service := &flowExecService{
-		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 		cfg:           testFlowExecCfg,
 	}
 
@@ -2105,7 +2105,7 @@ func (s *ServiceTestSuite) TestGetFlowGraph_NilClient() {
 	mockInboundClient := inboundclientmock.NewInboundClientServiceInterfaceMock(s.T())
 	mockEntityProvider := entityprovidermock.NewEntityProviderInterfaceMock(s.T())
 	service := &flowExecService{
-		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 		cfg:           testFlowExecCfg,
 	}
 
@@ -2164,7 +2164,7 @@ func (s *ServiceTestSuite) TestExecute_NewFlow_IncompleteStoresContext() {
 		graphBuilder:  mockGraphBuilder,
 		flowProvider:  mockFlowProvider,
 		flowEngine:    mockEngine,
-		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, mockAuthn),
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, mockAuthn, nil),
 		transactioner: &stubTransactioner{},
 		cryptoSvc:     mockCrypto,
 		cfg:           testFlowExecCfg,
@@ -2226,7 +2226,7 @@ func (s *ServiceTestSuite) TestExecute_ExistingFlow_CompleteRemovesContext() {
 		graphBuilder:  mockGraphBuilder,
 		flowProvider:  mockFlowProvider,
 		flowEngine:    mockEngine,
-		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 		transactioner: &stubTransactioner{},
 		cfg:           testFlowExecCfg,
 	}
@@ -2254,7 +2254,7 @@ func (s *ServiceTestSuite) TestSetApplicationToContext_ActorNotFound() {
 	mockInboundClient := inboundclientmock.NewInboundClientServiceInterfaceMock(s.T())
 	mockEntityProvider := entityprovidermock.NewEntityProviderInterfaceMock(s.T())
 	service := &flowExecService{
-		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 		cfg:           testFlowExecCfg,
 	}
 
@@ -2470,7 +2470,7 @@ func (s *ServiceTestSuite) TestExecute_NewFlow_BackendApp_ValidSecret_Allowed() 
 		graphBuilder:  mockGraphBuilder,
 		flowProvider:  mockFlowProvider,
 		flowEngine:    mockEngine,
-		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, mockAuthn),
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, mockAuthn, nil),
 		transactioner: &stubTransactioner{},
 	}
 
@@ -2586,7 +2586,7 @@ func (s *ServiceTestSuite) TestExecute_NewFlow_EmbeddedApp_ValidSecret_Allowed()
 		graphBuilder:  mockGraphBuilder,
 		flowProvider:  mockFlowProvider,
 		flowEngine:    mockEngine,
-		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, mockAuthn),
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, mockAuthn, nil),
 		transactioner: &stubTransactioner{},
 	}
 
@@ -2614,7 +2614,7 @@ func (s *ServiceTestSuite) TestExecute_NewFlow_EmbeddedApp_MissingSecret_Rejecte
 	mockObservability.EXPECT().IsEnabled().Return(false)
 
 	service := &flowExecService{
-		actorProvider:    actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+		actorProvider:    actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 		observabilitySvc: mockObservability,
 		transactioner:    &stubTransactioner{},
 	}
@@ -2676,7 +2676,7 @@ func (s *ServiceTestSuite) TestExecute_ContinuationFlow_AuthCodeApp_NotBlocked()
 		graphBuilder:  mockGraphBuilder,
 		flowProvider:  mockFlowProvider,
 		flowEngine:    mockEngine,
-		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr()),
+		actorProvider: actorprovider.Initialize(mockInboundClient, mockEntityProvider, noopAuthnMgr(), nil),
 		transactioner: &stubTransactioner{},
 	}
 

--- a/backend/internal/flow/flowmeta/service_test.go
+++ b/backend/internal/flow/flowmeta/service_test.go
@@ -72,7 +72,7 @@ func (suite *FlowMetaServiceTestSuite) SetupTest() {
 	suite.mockDesignResolve = resolvemock.NewDesignResolveServiceInterfaceMock(suite.T())
 	suite.mockI18nService = mgtmock.NewI18nServiceInterfaceMock(suite.T())
 	suite.service = newFlowMetaService(
-		actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr()),
+		actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr(), nil),
 		suite.mockOUService,
 		suite.mockDesignResolve,
 		suite.mockI18nService,

--- a/backend/internal/oauth/oauth2/authz/init_test.go
+++ b/backend/internal/oauth/oauth2/authz/init_test.go
@@ -93,7 +93,7 @@ func (suite *InitTestSuite) TestInitialize() {
 
 	service, err := Initialize(
 		mux,
-		actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr()),
+		actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr(), nil),
 		suite.mockResourceService,
 		suite.mockJWTService, suite.mockFlowExecService, nil, testhelpers.OAuthConfig(),
 		inmemory.Initialize("test-deployment"), transaction.NewNoOpTransactioner(),
@@ -109,7 +109,7 @@ func (suite *InitTestSuite) TestInitialize_RegistersRoutes() {
 
 	_, err := Initialize(
 		mux,
-		actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr()),
+		actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr(), nil),
 		suite.mockResourceService,
 		suite.mockJWTService, suite.mockFlowExecService, nil, testhelpers.OAuthConfig(),
 		inmemory.Initialize("test-deployment"), transaction.NewNoOpTransactioner(),
@@ -127,7 +127,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_CORSConfiguration() {
 
 	_, err := Initialize(
 		mux,
-		actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr()),
+		actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr(), nil),
 		suite.mockResourceService,
 		suite.mockJWTService, suite.mockFlowExecService, nil, testhelpers.OAuthConfig(),
 		inmemory.Initialize("test-deployment"), transaction.NewNoOpTransactioner(),

--- a/backend/internal/oauth/oauth2/authz/service_test.go
+++ b/backend/internal/oauth/oauth2/authz/service_test.go
@@ -156,7 +156,7 @@ func (suite *AuthorizeServiceTestSuite) SetupTest() {
 
 // newService builds an authorizeService with all mocked dependencies.
 func (suite *AuthorizeServiceTestSuite) newService() *authorizeService {
-	inboundClient := actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr())
+	inboundClient := actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr(), nil)
 	return &authorizeService{
 		cfg:             authorizeServiceCfgFromRuntime(),
 		inboundClient:   inboundClient,

--- a/backend/internal/oauth/oauth2/ciba/service_test.go
+++ b/backend/internal/oauth/oauth2/ciba/service_test.go
@@ -76,7 +76,7 @@ func (suite *CIBAServiceTestSuite) SetupTest() {
 	suite.mockInboundClient = inboundclientmock.NewInboundClientServiceInterfaceMock(suite.T())
 	suite.mockEntityProvider = entityprovidermock.NewEntityProviderInterfaceMock(suite.T())
 	suite.mockResourceSvc = resourcemock.NewResourceServiceInterfaceMock(suite.T())
-	actorProv := actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr())
+	actorProv := actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr(), nil)
 	suite.service = newCIBAService(suite.mockStore, suite.mockFlowExec,
 		suite.mockJWTService, actorProv, suite.mockResourceSvc, testhelpers.OAuthConfig())
 	suite.oauthApp = &providers.OAuthClient{
@@ -961,7 +961,7 @@ const testEntityID = "entity-abc-123"
 func (suite *CIBAServiceTestSuite) withIssuer() {
 	cfg := testhelpers.OAuthConfig()
 	cfg.JWT.Issuer = testIssuer
-	actorProv := actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr())
+	actorProv := actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr(), nil)
 	suite.service = newCIBAService(suite.mockStore, suite.mockFlowExec,
 		suite.mockJWTService, actorProv, suite.mockResourceSvc, cfg)
 }

--- a/backend/internal/oauth/oauth2/clientauth/clientauth_test.go
+++ b/backend/internal/oauth/oauth2/clientauth/clientauth_test.go
@@ -68,7 +68,7 @@ func TestClientAuthTestSuite(t *testing.T) {
 }
 
 func (suite *ClientAuthTestSuite) actorProvider() providers.ActorProvider {
-	return actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr())
+	return actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr(), nil)
 }
 
 func (suite *ClientAuthTestSuite) SetupTest() {

--- a/backend/internal/oauth/oauth2/clientauth/middleware_test.go
+++ b/backend/internal/oauth/oauth2/clientauth/middleware_test.go
@@ -54,7 +54,7 @@ func TestClientAuthMiddlewareTestSuite(t *testing.T) {
 }
 
 func (suite *ClientAuthMiddlewareTestSuite) actorProvider() providers.ActorProvider {
-	return actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr())
+	return actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr(), nil)
 }
 
 func (suite *ClientAuthMiddlewareTestSuite) SetupTest() {

--- a/backend/internal/oauth/oauth2/constants/constants.go
+++ b/backend/internal/oauth/oauth2/constants/constants.go
@@ -268,10 +268,13 @@ const (
 
 // Custom JWT claim names.
 const (
-	ClaimUserType               string = "userType"
-	ClaimOUID                   string = "ouId"
-	ClaimOUName                 string = "ouName"
-	ClaimOUHandle               string = "ouHandle"
+	ClaimUserType string = "userType"
+	ClaimOUID     string = "ouId"
+	ClaimOUName   string = "ouName"
+	ClaimOUHandle string = "ouHandle"
+	// ClaimName and ClaimOwner carry an agent's system-attribute name/owner on its client token.
+	ClaimName                   string = "name"
+	ClaimOwner                  string = "owner"
 	ClaimClaimsRequest          string = "claims_req"
 	ClaimClaimsLocales          string = "claims_locales"
 	ClaimCompletedAuthClass     string = "completed_auth_class"
@@ -284,6 +287,13 @@ const (
 	// principal from a local one.
 	ClaimIDP string = "idp"
 )
+
+// SurfaceableClientSystemClaims is the fixed set of entity system-attribute keys that may be
+// surfaced as client-token claims.
+var SurfaceableClientSystemClaims = map[string]bool{
+	ClaimName:  true,
+	ClaimOwner: true,
+}
 
 // OIDC subject types.
 const (

--- a/backend/internal/oauth/oauth2/granthandlers/client_credentials_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/client_credentials_test.go
@@ -445,6 +445,11 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_ClientAttri
 		OUID:                    "ou-456",
 		GrantTypes:              []providers.GrantType{providers.GrantTypeClientCredentials},
 		TokenEndpointAuthMethod: providers.TokenEndpointAuthMethodClientSecretBasic,
+		Token: &providers.OAuthTokenConfig{
+			AccessToken: &providers.AccessTokenConfig{
+				ClientConfig: &providers.AccessTokenSubConfig{Attributes: []string{constants.ClaimOUID}},
+			},
+		},
 	}
 
 	mockEvaluateAccessBatch(suite.mockAuthzService, oauthAppWithOU.ID, defaultRSID, []string{"read"}, []string{"read"})
@@ -705,6 +710,101 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_AgentOwnAtt
 	}, nil)
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, agentApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+}
+
+func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_AgentSystemAttributes_Embedded() {
+	tokenRequest := &model.TokenRequest{
+		GrantType:    "client_credentials",
+		ClientID:     testClientID,
+		ClientSecret: "secret123",
+		Scope:        "",
+	}
+
+	agentApp := &providers.OAuthClient{
+		ID:                      testEntityID,
+		ClientID:                testClientID,
+		EntityCategory:          providers.EntityCategoryAgent,
+		GrantTypes:              []providers.GrantType{providers.GrantTypeClientCredentials},
+		TokenEndpointAuthMethod: providers.TokenEndpointAuthMethodClientSecretBasic,
+		Token: &providers.OAuthTokenConfig{
+			AccessToken: &providers.AccessTokenConfig{
+				ClientConfig: &providers.AccessTokenSubConfig{Attributes: []string{"name", "owner"}},
+			},
+		},
+	}
+
+	suite.mockEntityProvider.On("GetActor", agentApp.ID).Return(&providers.Entity{
+		ID:               agentApp.ID,
+		Category:         providers.EntityCategoryAgent,
+		SystemAttributes: []byte(`{"name":"Ledger Agent","owner":"user-123","clientId":"cid"}`),
+	}, (*tidcommon.ServiceError)(nil))
+
+	suite.mockTokenBuilder.On("BuildAccessToken",
+		mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return ctx.SubjectAttributes["name"] == "Ledger Agent" &&
+				ctx.SubjectAttributes["owner"] == "user-123" &&
+				ctx.SubjectAttributes["clientId"] == nil
+		})).Return(&model.TokenDTO{
+		Token:     testJWTToken,
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  int64(1234567890),
+		ExpiresIn: 3600,
+		Scopes:    []string{},
+		ClientID:  testClientID,
+	}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, agentApp)
+
+	assert.Nil(suite.T(), errResp)
+	assert.NotNil(suite.T(), result)
+}
+
+func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_ApplicationSystemAttributes_NotEmbedded() {
+	tokenRequest := &model.TokenRequest{
+		GrantType:    "client_credentials",
+		ClientID:     testClientID,
+		ClientSecret: "secret123",
+		Scope:        "",
+	}
+
+	appApp := &providers.OAuthClient{
+		ID:                      testEntityID,
+		ClientID:                testClientID,
+		EntityCategory:          providers.EntityCategoryApp,
+		GrantTypes:              []providers.GrantType{providers.GrantTypeClientCredentials},
+		TokenEndpointAuthMethod: providers.TokenEndpointAuthMethodClientSecretBasic,
+		Token: &providers.OAuthTokenConfig{
+			AccessToken: &providers.AccessTokenConfig{
+				ClientConfig: &providers.AccessTokenSubConfig{Attributes: []string{"name", "owner"}},
+			},
+		},
+	}
+
+	// Applications store name in SystemAttributes too; the category gate must keep it out of the token.
+	suite.mockEntityProvider.On("GetActor", appApp.ID).Return(&providers.Entity{
+		ID:               appApp.ID,
+		Category:         providers.EntityCategoryApp,
+		SystemAttributes: []byte(`{"name":"My Application","clientId":"cid"}`),
+	}, (*tidcommon.ServiceError)(nil))
+
+	suite.mockTokenBuilder.On("BuildAccessToken",
+		mock.Anything,
+		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return ctx.SubjectAttributes["name"] == nil && ctx.SubjectAttributes["owner"] == nil
+		})).Return(&model.TokenDTO{
+		Token:     testJWTToken,
+		TokenType: constants.TokenTypeBearer,
+		IssuedAt:  int64(1234567890),
+		ExpiresIn: 3600,
+		Scopes:    []string{},
+		ClientID:  testClientID,
+	}, nil)
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, appApp)
 
 	assert.Nil(suite.T(), errResp)
 	assert.NotNil(suite.T(), result)

--- a/backend/internal/oauth/oauth2/tokenservice/utils.go
+++ b/backend/internal/oauth/oauth2/tokenservice/utils.go
@@ -473,11 +473,33 @@ func BuildClientAttributes(
 		claims[k] = v
 	}
 
-	entityClaims, err := resolveClientEntityAttributes(oauthApp, actorProvider)
+	entity, err := fetchClientEntity(oauthApp, actorProvider)
+	if err != nil {
+		return nil, err
+	}
+
+	entityClaims, err := resolveClientEntityAttributes(oauthApp, entity)
 	if err != nil {
 		return nil, err
 	}
 	for k, v := range entityClaims {
+		claims[k] = v
+	}
+
+	// Merge system attributes last so they win over a colliding schema attribute.
+	systemClaims, err := resolveClientSystemAttributes(oauthApp, entity)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range systemClaims {
+		claims[k] = v
+	}
+
+	groupRoleClaims, err := resolveClientGroupRoleClaims(oauthApp, actorProvider)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range groupRoleClaims {
 		claims[k] = v
 	}
 
@@ -487,17 +509,73 @@ func BuildClientAttributes(
 	return claims, nil
 }
 
-// resolveClientOUAttributes returns the OAuth client/application's organization unit claims
-// (ouId, ouName, ouHandle) when the app has an associated OU.
+// isClientOUClaim reports whether name is one of the OU claims resolved from the OU service
+// (not from the entity).
+func isClientOUClaim(name string) bool {
+	return name == constants.ClaimOUID || name == constants.ClaimOUName || name == constants.ClaimOUHandle
+}
+
+// resolvedWithoutEntity reports whether name is a claim resolved from a source other than the
+// entity record (OU service, or the actor's group/role assignments).
+func resolvedWithoutEntity(name string) bool {
+	return isClientOUClaim(name) ||
+		name == constants.UserAttributeGroups || name == constants.UserAttributeRoles
+}
+
+// fetchClientEntity loads the backing entity for the OAuth client once, so the schema- and
+// system-attribute resolvers can share it. Returns nil when no requested attribute needs the
+// entity: an empty allow-list, or one that lists only claims resolved elsewhere (OU, groups, roles).
+func fetchClientEntity(
+	oauthApp *providers.OAuthClient,
+	actorProvider providers.ActorProvider,
+) (*providers.Entity, error) {
+	if oauthApp == nil || actorProvider == nil {
+		return nil, nil
+	}
+
+	needsEntity := false
+	for _, name := range clientConfigAttributeNames(oauthApp) {
+		if !resolvedWithoutEntity(name) {
+			needsEntity = true
+			break
+		}
+	}
+	if !needsEntity {
+		return nil, nil
+	}
+
+	entity, svcErr := actorProvider.GetActor(oauthApp.ID)
+	if svcErr != nil {
+		return nil, fmt.Errorf("failed to fetch entity %s for client attributes: %s", oauthApp.ID, svcErr.Error)
+	}
+	return entity, nil
+}
+
+// clientConfigAttributeNames returns the client-token attribute allow-list, or nil when unset.
+func clientConfigAttributeNames(oauthApp *providers.OAuthClient) []string {
+	if oauthApp == nil || oauthApp.Token == nil || oauthApp.Token.AccessToken == nil ||
+		oauthApp.Token.AccessToken.ClientConfig == nil {
+		return nil
+	}
+	return oauthApp.Token.AccessToken.ClientConfig.Attributes
+}
+
+// resolveClientOUAttributes returns the OAuth client's organization unit claims (ouId, ouName,
+// ouHandle) selected by ClientConfig.Attributes. Opt-in for every client (agent and application).
 func resolveClientOUAttributes(
 	ctx context.Context,
 	oauthApp *providers.OAuthClient,
 	ouService providers.OrganizationUnitProvider,
 ) (map[string]interface{}, error) {
-	if oauthApp == nil || oauthApp.OUID == "" {
+	if oauthApp == nil || oauthApp.OUID == "" || ouService == nil {
 		return nil, nil
 	}
-	if ouService == nil {
+
+	attrNames := clientConfigAttributeNames(oauthApp)
+	wantOUID := slices.Contains(attrNames, constants.ClaimOUID)
+	wantOUName := slices.Contains(attrNames, constants.ClaimOUName)
+	wantOUHandle := slices.Contains(attrNames, constants.ClaimOUHandle)
+	if !wantOUID && !wantOUName && !wantOUHandle {
 		return nil, nil
 	}
 
@@ -507,37 +585,27 @@ func resolveClientOUAttributes(
 			oauthApp.OUID, oauthApp.ID, svcErr.Error)
 	}
 
-	return map[string]interface{}{
-		constants.ClaimOUID:     orgUnit.ID,
-		constants.ClaimOUName:   orgUnit.Name,
-		constants.ClaimOUHandle: orgUnit.Handle,
-	}, nil
+	claims := make(map[string]interface{})
+	if wantOUID {
+		claims[constants.ClaimOUID] = orgUnit.ID
+	}
+	if wantOUName && orgUnit.Name != "" {
+		claims[constants.ClaimOUName] = orgUnit.Name
+	}
+	if wantOUHandle && orgUnit.Handle != "" {
+		claims[constants.ClaimOUHandle] = orgUnit.Handle
+	}
+	return claims, nil
 }
 
-// resolveClientEntityAttributes returns the subset of the OAuth client's own entity attributes
+// resolveClientEntityAttributes returns the subset of the OAuth client's own schema attributes
 // selected by ClientConfig.Attributes. Resolves generically off Entity.Attributes regardless of
-// EntityCategory — populated today only for Agent entities (the only category with a schema and
+// EntityCategory — populated only for Agent entities (the only category with a schema and
 // stored attributes); a no-op for plain Application clients, which have neither.
 func resolveClientEntityAttributes(
 	oauthApp *providers.OAuthClient,
-	actorProvider providers.ActorProvider,
+	entity *providers.Entity,
 ) (map[string]interface{}, error) {
-	if oauthApp == nil || actorProvider == nil {
-		return nil, nil
-	}
-	if oauthApp.Token == nil || oauthApp.Token.AccessToken == nil ||
-		oauthApp.Token.AccessToken.ClientConfig == nil {
-		return nil, nil
-	}
-	attrNames := oauthApp.Token.AccessToken.ClientConfig.Attributes
-	if len(attrNames) == 0 {
-		return nil, nil
-	}
-
-	entity, svcErr := actorProvider.GetActor(oauthApp.ID)
-	if svcErr != nil {
-		return nil, fmt.Errorf("failed to fetch entity %s for client attributes: %s", oauthApp.ID, svcErr.Error)
-	}
 	if entity == nil || len(entity.Attributes) == 0 {
 		return nil, nil
 	}
@@ -549,7 +617,7 @@ func resolveClientEntityAttributes(
 
 	reserved := ReservedAccessTokenClaimNames()
 	filtered := make(map[string]interface{})
-	for _, name := range attrNames {
+	for _, name := range clientConfigAttributeNames(oauthApp) {
 		if reserved[name] {
 			continue
 		}
@@ -557,8 +625,86 @@ func resolveClientEntityAttributes(
 			filtered[name] = val
 		}
 	}
-	if len(filtered) == 0 {
+	return filtered, nil
+}
+
+// resolveClientSystemAttributes returns the agent system attributes (name, owner) selected by
+// ClientConfig.Attributes, read from Entity.SystemAttributes. Restricted to agent entities so an
+// application client can never surface these claims regardless of its stored allow-list.
+func resolveClientSystemAttributes(
+	oauthApp *providers.OAuthClient,
+	entity *providers.Entity,
+) (map[string]interface{}, error) {
+	if entity == nil || entity.Category != providers.EntityCategoryAgent || len(entity.SystemAttributes) == 0 {
 		return nil, nil
 	}
+
+	var sysAttrs map[string]interface{}
+	if err := json.Unmarshal(entity.SystemAttributes, &sysAttrs); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal entity system attributes for %s: %w", oauthApp.ID, err)
+	}
+
+	filtered := make(map[string]interface{})
+	for _, name := range clientConfigAttributeNames(oauthApp) {
+		if !constants.SurfaceableClientSystemClaims[name] {
+			continue
+		}
+		if val, ok := sysAttrs[name]; ok {
+			filtered[name] = val
+		}
+	}
 	return filtered, nil
+}
+
+// resolveClientGroupRoleClaims returns the client's groups and/or roles claims selected by
+// ClientConfig.Attributes. Groups come from the actor's transitive memberships; roles are resolved
+// from those groups plus direct assignments. The shared group lookup runs once for both.
+func resolveClientGroupRoleClaims(
+	oauthApp *providers.OAuthClient,
+	actorProvider providers.ActorProvider,
+) (map[string]interface{}, error) {
+	if oauthApp == nil || actorProvider == nil {
+		return nil, nil
+	}
+
+	attrNames := clientConfigAttributeNames(oauthApp)
+	wantGroups := slices.Contains(attrNames, constants.UserAttributeGroups)
+	wantRoles := slices.Contains(attrNames, constants.UserAttributeRoles)
+	if !wantGroups && !wantRoles {
+		return nil, nil
+	}
+
+	groups, svcErr := actorProvider.GetActorGroups(oauthApp.ID)
+	if svcErr != nil {
+		return nil, fmt.Errorf("failed to fetch groups for client %s: %s", oauthApp.ID, svcErr.Error)
+	}
+
+	claims := make(map[string]interface{})
+	if wantGroups {
+		names := make([]string, 0, len(groups))
+		for _, g := range groups {
+			if g.Name != "" {
+				names = append(names, g.Name)
+			}
+		}
+		if len(names) > 0 {
+			claims[constants.UserAttributeGroups] = names
+		}
+	}
+	if wantRoles {
+		groupIDs := make([]string, 0, len(groups))
+		for _, g := range groups {
+			if g.ID != "" {
+				groupIDs = append(groupIDs, g.ID)
+			}
+		}
+		roles, roleErr := actorProvider.GetActorRoles(oauthApp.ID, groupIDs)
+		if roleErr != nil {
+			return nil, fmt.Errorf("failed to fetch roles for client %s: %s", oauthApp.ID, roleErr.Error)
+		}
+		if len(roles) > 0 {
+			claims[constants.UserAttributeRoles] = roles
+		}
+	}
+	return claims, nil
 }

--- a/backend/internal/oauth/oauth2/tokenservice/utils_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/utils_test.go
@@ -766,9 +766,19 @@ const (
 )
 
 func newOAuthAppForClientAttributes(ouID string) *providers.OAuthClient {
+	return newOAuthAppForClientAttributesWith(ouID,
+		[]string{constants.ClaimOUID, constants.ClaimOUName, constants.ClaimOUHandle})
+}
+
+func newOAuthAppForClientAttributesWith(ouID string, clientAttributes []string) *providers.OAuthClient {
 	return &providers.OAuthClient{
 		ID:   testBCCAppID,
 		OUID: ouID,
+		Token: &providers.OAuthTokenConfig{
+			AccessToken: &providers.AccessTokenConfig{
+				ClientConfig: &providers.AccessTokenSubConfig{Attributes: clientAttributes},
+			},
+		},
 	}
 }
 
@@ -833,6 +843,53 @@ func (suite *UtilsTestSuite) TestBuildClientAttributes_NilOUService_ReturnsNil()
 	claims, err := BuildClientAttributes(context.Background(), app, nil, nil)
 	assert.NoError(suite.T(), err)
 	assert.Nil(suite.T(), claims)
+}
+
+func (suite *UtilsTestSuite) TestBuildClientAttributes_OUAttributes_SkippedWhenNotRequested() {
+	ous := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+
+	app := newOAuthAppForClientAttributesWith(testBCCOUID, nil)
+	claims, err := BuildClientAttributes(context.Background(), app, ous, nil)
+
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), claims)
+	ous.AssertNotCalled(suite.T(), "GetOrganizationUnit")
+}
+
+func (suite *UtilsTestSuite) TestBuildClientAttributes_OUOnly_SkipsEntityFetch() {
+	ous := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+	ous.On("GetOrganizationUnit", context.Background(), testBCCOUID).Return(providers.OrganizationUnit{
+		ID:     testBCCOUID,
+		Name:   "Engineering",
+		Handle: "eng",
+	}, (*tidcommon.ServiceError)(nil))
+	actors := actorprovidermock.NewActorProviderMock(suite.T())
+
+	app := newOAuthAppForClientAttributesWith(testBCCOUID,
+		[]string{constants.ClaimOUID, constants.ClaimOUName, constants.ClaimOUHandle})
+	claims, err := BuildClientAttributes(context.Background(), app, ous, actors)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), testBCCOUID, claims[constants.ClaimOUID])
+	actors.AssertNotCalled(suite.T(), "GetActor")
+}
+
+func (suite *UtilsTestSuite) TestBuildClientAttributes_OUAttributes_PartialSelection() {
+	ous := oumock.NewOrganizationUnitServiceInterfaceMock(suite.T())
+
+	ous.On("GetOrganizationUnit", context.Background(), testBCCOUID).Return(providers.OrganizationUnit{
+		ID:     testBCCOUID,
+		Name:   "Engineering",
+		Handle: "eng",
+	}, (*tidcommon.ServiceError)(nil))
+
+	app := newOAuthAppForClientAttributesWith(testBCCOUID, []string{constants.ClaimOUID})
+	claims, err := BuildClientAttributes(context.Background(), app, ous, nil)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), testBCCOUID, claims[constants.ClaimOUID])
+	assert.NotContains(suite.T(), claims, constants.ClaimOUName)
+	assert.NotContains(suite.T(), claims, constants.ClaimOUHandle)
 }
 
 func newOAuthAppForOwnAttributes(clientAttributes []string) *providers.OAuthClient {
@@ -901,6 +958,123 @@ func (suite *UtilsTestSuite) TestBuildClientAttributes_AgentOwnAttributes_SkipsR
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "anthropic", claims["modelProvider"])
 	assert.NotContains(suite.T(), claims, "scope")
+}
+
+func (suite *UtilsTestSuite) TestBuildClientAttributes_AgentSystemAttributes_HappyPath() {
+	actors := actorprovidermock.NewActorProviderMock(suite.T())
+	actors.On("GetActor", testBCCAppID).Return(&providers.Entity{
+		ID:               testBCCAppID,
+		Category:         providers.EntityCategoryAgent,
+		Attributes:       []byte(`{"modelProvider":"anthropic"}`),
+		SystemAttributes: []byte(`{"name":"Ledger Agent","owner":"user-123","clientId":"cid","description":"d"}`),
+	}, (*tidcommon.ServiceError)(nil))
+
+	app := newOAuthAppForOwnAttributes([]string{"modelProvider", "name", "owner"})
+	claims, err := BuildClientAttributes(context.Background(), app, nil, actors)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "anthropic", claims["modelProvider"])
+	assert.Equal(suite.T(), "Ledger Agent", claims["name"])
+	assert.Equal(suite.T(), "user-123", claims["owner"])
+	assert.NotContains(suite.T(), claims, "clientId")
+	assert.NotContains(suite.T(), claims, "description")
+}
+
+func (suite *UtilsTestSuite) TestBuildClientAttributes_GroupsAndRoles_Resolved() {
+	actors := actorprovidermock.NewActorProviderMock(suite.T())
+	actors.On("GetActorGroups", testBCCAppID).Return([]providers.EntityGroup{
+		{ID: "g1", Name: "engineering"},
+		{ID: "g2", Name: "admins"},
+	}, (*tidcommon.ServiceError)(nil))
+	actors.On("GetActorRoles", testBCCAppID, []string{"g1", "g2"}).
+		Return([]string{"admin", "editor"}, (*tidcommon.ServiceError)(nil))
+
+	app := newOAuthAppForOwnAttributes([]string{"groups", "roles"})
+	claims, err := BuildClientAttributes(context.Background(), app, nil, actors)
+
+	assert.NoError(suite.T(), err)
+	assert.ElementsMatch(suite.T(), []string{"engineering", "admins"}, claims["groups"])
+	assert.ElementsMatch(suite.T(), []string{"admin", "editor"}, claims["roles"])
+	actors.AssertNotCalled(suite.T(), "GetActor")
+}
+
+func (suite *UtilsTestSuite) TestBuildClientAttributes_GroupsOnly_DoesNotResolveRoles() {
+	actors := actorprovidermock.NewActorProviderMock(suite.T())
+	actors.On("GetActorGroups", testBCCAppID).Return([]providers.EntityGroup{
+		{ID: "g1", Name: "engineering"},
+	}, (*tidcommon.ServiceError)(nil))
+
+	app := newOAuthAppForOwnAttributes([]string{"groups"})
+	claims, err := BuildClientAttributes(context.Background(), app, nil, actors)
+
+	assert.NoError(suite.T(), err)
+	assert.ElementsMatch(suite.T(), []string{"engineering"}, claims["groups"])
+	assert.NotContains(suite.T(), claims, "roles")
+	actors.AssertNotCalled(suite.T(), "GetActorRoles")
+}
+
+func (suite *UtilsTestSuite) TestBuildClientAttributes_GroupRoles_SkippedWhenNotRequested() {
+	actors := actorprovidermock.NewActorProviderMock(suite.T())
+	actors.On("GetActor", testBCCAppID).Return(&providers.Entity{
+		ID:         testBCCAppID,
+		Category:   providers.EntityCategoryAgent,
+		Attributes: []byte(`{"modelProvider":"anthropic"}`),
+	}, (*tidcommon.ServiceError)(nil))
+
+	app := newOAuthAppForOwnAttributes([]string{"modelProvider"})
+	claims, err := BuildClientAttributes(context.Background(), app, nil, actors)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "anthropic", claims["modelProvider"])
+	assert.NotContains(suite.T(), claims, "groups")
+	assert.NotContains(suite.T(), claims, "roles")
+	actors.AssertNotCalled(suite.T(), "GetActorGroups")
+	actors.AssertNotCalled(suite.T(), "GetActorRoles")
+}
+
+func (suite *UtilsTestSuite) TestBuildClientAttributes_SystemAttributes_SkippedForNonAgentEntity() {
+	actors := actorprovidermock.NewActorProviderMock(suite.T())
+	actors.On("GetActor", testBCCAppID).Return(&providers.Entity{
+		ID:               testBCCAppID,
+		Category:         providers.EntityCategoryApp,
+		SystemAttributes: []byte(`{"name":"My App"}`),
+	}, (*tidcommon.ServiceError)(nil))
+
+	app := newOAuthAppForOwnAttributes([]string{"name"})
+	claims, err := BuildClientAttributes(context.Background(), app, nil, actors)
+
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), claims)
+}
+
+func (suite *UtilsTestSuite) TestBuildClientAttributes_SystemAttributes_EmptyWhenNotStored() {
+	actors := actorprovidermock.NewActorProviderMock(suite.T())
+	actors.On("GetActor", testBCCAppID).Return(&providers.Entity{
+		ID:       testBCCAppID,
+		Category: providers.EntityCategoryAgent,
+	}, (*tidcommon.ServiceError)(nil))
+
+	app := newOAuthAppForOwnAttributes([]string{"name", "owner"})
+	claims, err := BuildClientAttributes(context.Background(), app, nil, actors)
+
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), claims)
+}
+
+func (suite *UtilsTestSuite) TestBuildClientAttributes_SystemAttributeWinsOverSchemaOnCollision() {
+	actors := actorprovidermock.NewActorProviderMock(suite.T())
+	actors.On("GetActor", testBCCAppID).Return(&providers.Entity{
+		ID:               testBCCAppID,
+		Category:         providers.EntityCategoryAgent,
+		Attributes:       []byte(`{"name":"schema-name"}`),
+		SystemAttributes: []byte(`{"name":"system-name"}`),
+	}, (*tidcommon.ServiceError)(nil))
+
+	app := newOAuthAppForOwnAttributes([]string{"name"})
+	claims, err := BuildClientAttributes(context.Background(), app, nil, actors)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "system-name", claims["name"])
 }
 
 func (suite *UtilsTestSuite) TestBuildClientAttributes_AgentGetActorError_ReturnsError() {

--- a/backend/internal/oauth/oauth2/userinfo/init_test.go
+++ b/backend/internal/oauth/oauth2/userinfo/init_test.go
@@ -81,7 +81,7 @@ func (suite *InitTestSuite) TestInitialize() {
 
 	service := Initialize(mux, suite.mockJWTService, nil, nil,
 		suite.mockTokenValidator,
-		actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr()),
+		actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr(), nil),
 		suite.mockAttributeCacheService, suite.mockDiscoveryService, suite.mockDPoPVerifier, testhelpers.OAuthConfig())
 
 	assert.NotNil(suite.T(), service)
@@ -92,7 +92,7 @@ func (suite *InitTestSuite) TestInitialize_RegistersRoutes() {
 
 	Initialize(mux, suite.mockJWTService, nil, nil,
 		suite.mockTokenValidator,
-		actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr()),
+		actorprovider.Initialize(suite.mockInboundClient, suite.mockEntityProvider, noopAuthnMgr(), nil),
 		suite.mockAttributeCacheService, suite.mockDiscoveryService, suite.mockDPoPVerifier, testhelpers.OAuthConfig())
 
 	// Verify that the routes are registered by attempting to get a handler for them.

--- a/backend/internal/oauth/oauth2/userinfo/service_test.go
+++ b/backend/internal/oauth/oauth2/userinfo/service_test.go
@@ -87,7 +87,7 @@ func (s *UserInfoServiceTestSuite) SetupTest() {
 	s.mockAttributeCacheService = attributecachemock.NewAttributeCacheServiceInterfaceMock(s.T())
 	s.userInfoService = newUserInfoService(
 		s.mockJWTService, nil, nil, s.mockTokenValidator,
-		actorprovider.Initialize(s.mockInboundClient, s.mockEntityProvider, noopAuthnMgr()),
+		actorprovider.Initialize(s.mockInboundClient, s.mockEntityProvider, noopAuthnMgr(), nil),
 		s.mockAttributeCacheService, nil,
 		oauthconfig.Config{JWT: engineconfig.JWTConfig{Issuer: testUserInfoIssuer, ValidityPeriod: 600}},
 	)
@@ -152,7 +152,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_RevocationUnavailable() {
 // path: the request is rejected with a server error before any proof binding checks.
 func (s *UserInfoServiceTestSuite) TestGetUserInfoForDPoP_RevocationUnavailable() {
 	verifier := dpopmock.NewVerifierInterfaceMock(s.T())
-	actorProv := actorprovider.Initialize(s.mockInboundClient, s.mockEntityProvider, noopAuthnMgr())
+	actorProv := actorprovider.Initialize(s.mockInboundClient, s.mockEntityProvider, noopAuthnMgr(), nil)
 	s.userInfoService = newUserInfoService(
 		s.mockJWTService, nil, nil, s.mockTokenValidator,
 		actorProv, s.mockAttributeCacheService, verifier, userInfoTestConfig())
@@ -1185,7 +1185,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_BearerScheme_DPoPBoundToken_R
 // presented under the DPoP scheme is rejected.
 func (s *UserInfoServiceTestSuite) TestGetUserInfoForDPoP_NotBoundToken_Rejected() {
 	verifier := dpopmock.NewVerifierInterfaceMock(s.T())
-	actorProv := actorprovider.Initialize(s.mockInboundClient, s.mockEntityProvider, noopAuthnMgr())
+	actorProv := actorprovider.Initialize(s.mockInboundClient, s.mockEntityProvider, noopAuthnMgr(), nil)
 	s.userInfoService = newUserInfoService(
 		s.mockJWTService, nil, nil, s.mockTokenValidator,
 		actorProv, s.mockAttributeCacheService, verifier, userInfoTestConfig())
@@ -1211,7 +1211,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfoForDPoP_NotBoundToken_Rejected
 // token whose proof fails verification is rejected.
 func (s *UserInfoServiceTestSuite) TestGetUserInfoForDPoP_VerifierFails_Rejected() {
 	verifier := dpopmock.NewVerifierInterfaceMock(s.T())
-	actorProv := actorprovider.Initialize(s.mockInboundClient, s.mockEntityProvider, noopAuthnMgr())
+	actorProv := actorprovider.Initialize(s.mockInboundClient, s.mockEntityProvider, noopAuthnMgr(), nil)
 	s.userInfoService = newUserInfoService(
 		s.mockJWTService, nil, nil, s.mockTokenValidator,
 		actorProv, s.mockAttributeCacheService, verifier, userInfoTestConfig())

--- a/backend/pkg/thunderidengine/providers/interface.go
+++ b/backend/pkg/thunderidengine/providers/interface.go
@@ -82,6 +82,7 @@ type ActorProvider interface {
 	) *common.ServiceError
 	GetActor(actorID string) (*Entity, *common.ServiceError)
 	GetActorGroups(actorID string) ([]EntityGroup, *common.ServiceError)
+	GetActorRoles(actorID string, groupIDs []string) ([]string, *common.ServiceError)
 }
 
 // I18nProvider defines the interface for the i18n provider.

--- a/backend/tests/mocks/actorprovidermock/ActorProvider_mock.go
+++ b/backend/tests/mocks/actorprovidermock/ActorProvider_mock.go
@@ -232,6 +232,76 @@ func (_c *ActorProviderMock_GetActorGroups_Call) RunAndReturn(run func(actorID s
 	return _c
 }
 
+// GetActorRoles provides a mock function for the type ActorProviderMock
+func (_mock *ActorProviderMock) GetActorRoles(actorID string, groupIDs []string) ([]string, *common.ServiceError) {
+	ret := _mock.Called(actorID, groupIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetActorRoles")
+	}
+
+	var r0 []string
+	var r1 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(string, []string) ([]string, *common.ServiceError)); ok {
+		return returnFunc(actorID, groupIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, []string) []string); ok {
+		r0 = returnFunc(actorID, groupIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, []string) *common.ServiceError); ok {
+		r1 = returnFunc(actorID, groupIDs)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// ActorProviderMock_GetActorRoles_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetActorRoles'
+type ActorProviderMock_GetActorRoles_Call struct {
+	*mock.Call
+}
+
+// GetActorRoles is a helper method to define mock.On call
+//   - actorID string
+//   - groupIDs []string
+func (_e *ActorProviderMock_Expecter) GetActorRoles(actorID interface{}, groupIDs interface{}) *ActorProviderMock_GetActorRoles_Call {
+	return &ActorProviderMock_GetActorRoles_Call{Call: _e.mock.On("GetActorRoles", actorID, groupIDs)}
+}
+
+func (_c *ActorProviderMock_GetActorRoles_Call) Run(run func(actorID string, groupIDs []string)) *ActorProviderMock_GetActorRoles_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *ActorProviderMock_GetActorRoles_Call) Return(strings []string, serviceError *common.ServiceError) *ActorProviderMock_GetActorRoles_Call {
+	_c.Call.Return(strings, serviceError)
+	return _c
+}
+
+func (_c *ActorProviderMock_GetActorRoles_Call) RunAndReturn(run func(actorID string, groupIDs []string) ([]string, *common.ServiceError)) *ActorProviderMock_GetActorRoles_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetInboundClientByID provides a mock function for the type ActorProviderMock
 func (_mock *ActorProviderMock) GetInboundClientByID(ctx context.Context, id string) (*providers.InboundClient, *common.ServiceError) {
 	ret := _mock.Called(ctx, id)

--- a/docs/content/guides/agents/agent-authentication.mdx
+++ b/docs/content/guides/agents/agent-authentication.mdx
@@ -121,7 +121,7 @@ All agent access tokens are signed JWTs (`typ: at+jwt`) and share a common set o
 | `act` | Not present. | Present only when an explicit `actor_token` is provided in the request. |
 | `exp`, `iat`, `nbf`, `jti` | Standard JWT lifetime and identity claims. | Standard JWT lifetime and identity claims. |
 
-Custom attributes configured in the agent's **Token** settings are included as additional claims on M2M tokens.
+The agent's **Token** settings control which additional claims appear on M2M tokens: the agent's schema attributes, its system attributes (`name`, `owner`), OU claims (`ouId`, `ouName`, `ouHandle`), and its `groups` and `roles`. Each is opt-in and included only when selected.
 
 ### `act` Claim
 

--- a/docs/content/guides/agents/manage-agents.mdx
+++ b/docs/content/guides/agents/manage-agents.mdx
@@ -70,11 +70,10 @@ The **Flows** tab is available when the agent has an OAuth 2.0 configuration. It
 
 ### Token
 
-The **Token** tab controls token issuance settings:
+The **Token** tab configures token contents and validity across two sub-tabs:
 
-- Access token and ID token validity periods.
-- Custom claims added to issued tokens.
-- Token signing and encryption options.
+- **User**: applies to tokens whose subject is a user the agent acts on behalf of, through the authorization code and on-behalf-of flows. Select the user attributes carried in the access token and ID token, map scopes to claims, select the ID token response format, and set the access token and ID token validity periods. These settings stay frozen until you turn on Delegated mode on the **Flows** tab.
+- **Agent**: applies to the agent's own access token, issued through the `client_credentials` grant. Select the claims it carries, its schema attributes, its system attributes (`name`, `owner`), OU claims (`ouId`, `ouName`, `ouHandle`), and its `groups` and `roles`, and set the token validity period.
 
 ### Advanced Settings
 

--- a/docs/content/guides/applications/application-settings.mdx
+++ b/docs/content/guides/applications/application-settings.mdx
@@ -93,6 +93,8 @@ You can also configure the ID token response format via the API. These settings 
 | **Encryption Algorithm** | Required for `JWE` and `NESTED_JWT`. Options: `RSA-OAEP`, `RSA-OAEP-256`. Requires an OAuth client certificate. |
 | **Encryption Encoding** | Required when Encryption Algorithm is set. Options: `A128CBC-HS256`, `A256GCM`. |
 
+For the `client_credentials` grant, the token represents the application itself rather than a user. You can add the application's OU claims (`ouId`, `ouName`, `ouHandle`) to it via the API using `clientConfig.attributes`.
+
 ## Rotate the Client Secret
 
 :::note

--- a/docs/content/guides/protocols/oauth-oidc/client-credentials.mdx
+++ b/docs/content/guides/protocols/oauth-oidc/client-credentials.mdx
@@ -27,13 +27,18 @@ Use it for service-to-service calls, internal daemons, scheduled jobs, and CLI t
 | Grant type | `client_credentials` |
 | Client type | Intended for confidential clients that authenticate with their own credentials |
 | Token subject | `sub` in the issued access token is the `client_id` |
-| User attributes | Not included: there is no authenticated user |
+| End-user attributes | Not included: there is no authenticated user |
+| Client attributes | The client's own attributes can be added as subject claims via `clientConfig.attributes`. OU claims (`ouId`, `ouName`, `ouHandle`), `groups`, and `roles` are available to any client; agents can also include their schema attributes and system attributes (`name`, `owner`). All are opt-in and must be listed explicitly. |
 | Refresh token | Not issued for this grant (re-request when needed) |
 | Scope filtering | Requested scopes are filtered to permissions defined on the target resource server, then intersected with the permissions the client holds through its **role and group assignments** |
 | `aud` claim | The supplied resource server identifier, or `defaultResourceServer` for a permission-bearing request without `resource`. A scopeless request without `resource` uses the application's `token.accessToken.defaultAudience`, falling back to `client_id` |
 | ID token | Not issued: this is an OAuth-only flow, not OIDC |
 
 </details>
+
+:::note
+OU claims are opt-in: a client receives only the claims it lists in `clientConfig.attributes`. Agents configure these on the **Token** tab in the Console. Applications can set `clientConfig.attributes` through the API when needed.
+:::
 
 ## Try It in <ProductName />
 

--- a/frontend/apps/console/src/features/agents/components/edit-agent/tokens/AgentAccessTokenSection.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/tokens/AgentAccessTokenSection.tsx
@@ -18,18 +18,7 @@
 
 import {SettingsCard} from '@thunderid/components';
 import {useGetAgentType, useGetAgentTypes} from '@thunderid/configure-agent-types';
-import {
-  Alert,
-  Card,
-  CardContent,
-  Chip,
-  FormControl,
-  FormLabel,
-  Grid,
-  Stack,
-  TextField,
-  Typography,
-} from '@wso2/oxygen-ui';
+import {Card, CardContent, Chip, FormControl, FormLabel, Grid, Stack, TextField, Typography} from '@wso2/oxygen-ui';
 import {useEffect, useState, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import JwtPreview from '../../../../applications/components/edit-application/token-settings/JwtPreview';
@@ -120,14 +109,15 @@ export default function AgentAccessTokenSection({
     }
   };
 
-  const availableAttributes = (
-    schemaDetails?.schema
-      ? Object.entries(schemaDetails.schema)
-          .filter(
-            ([, fieldDef]) => !((fieldDef.type === 'string' || fieldDef.type === 'number') && fieldDef.credential),
-          )
-          .map(([name]) => name)
-      : []
+  const schemaAttributes = schemaDetails?.schema
+    ? Object.entries(schemaDetails.schema)
+        .filter(([, fieldDef]) => !((fieldDef.type === 'string' || fieldDef.type === 'number') && fieldDef.credential))
+        .map(([name]) => name)
+    : [];
+
+  // Merge agent schema attributes with system attributes (name, owner) into a single chip list.
+  const availableAttributes = Array.from(
+    new Set([...schemaAttributes, ...TokenConstants.ADDITIONAL_AGENT_ATTRIBUTES]),
   ).sort();
 
   const jwtPreview: Record<string, unknown> = {};
@@ -155,7 +145,7 @@ export default function AgentAccessTokenSection({
             <Typography variant="body2" color="text.disabled" sx={{mb: 2}}>
               {t(
                 'agents:edit.tokens.agent.attributes.hint',
-                "Click on this agent's attributes to add them to its access token.",
+                'Click on agent attributes to add them to its access token.',
               )}
             </Typography>
             <Card>
@@ -165,7 +155,7 @@ export default function AgentAccessTokenSection({
                     {t('common:status.loading', 'Loading…')}
                   </Typography>
                 )}
-                {!isLoading && availableAttributes.length > 0 && (
+                {!isLoading && (
                   <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
                     {availableAttributes.map((attr) => {
                       const isActive = currentAttributes.includes(attr);
@@ -182,14 +172,6 @@ export default function AgentAccessTokenSection({
                       );
                     })}
                   </Stack>
-                )}
-                {!isLoading && availableAttributes.length === 0 && (
-                  <Alert severity="info">
-                    {t(
-                      'agents:edit.tokens.agent.attributes.empty',
-                      'No attributes available. Configure attributes for this agent in the Attributes tab.',
-                    )}
-                  </Alert>
                 )}
               </CardContent>
             </Card>

--- a/frontend/apps/console/src/features/agents/components/edit-agent/tokens/__tests__/AgentAccessTokenSection.test.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/tokens/__tests__/AgentAccessTokenSection.test.tsx
@@ -20,7 +20,7 @@
 import userEvent from '@testing-library/user-event';
 import {render, screen} from '@thunderid/test-utils';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import type {Agent, AgentInboundAuthConfig} from '../../../../models/agent';
+import type {Agent, AgentInboundAuthConfig, OAuthAgentConfig} from '../../../../models/agent';
 import AgentAccessTokenSection from '../AgentAccessTokenSection';
 
 const {mockUseGetAgentTypes, mockUseGetAgentType} = vi.hoisted(() => ({
@@ -77,6 +77,158 @@ describe('AgentAccessTokenSection', () => {
 
     expect(screen.getByText('department')).toBeInTheDocument();
     expect(screen.queryByText('apiKey')).not.toBeInTheDocument();
+  });
+
+  it('lists the name and owner system attributes alongside the schema attributes', () => {
+    render(
+      <AgentAccessTokenSection
+        agent={{...baseAgent, inboundAuthConfig: baseInboundAuthConfig}}
+        editedAgent={{}}
+        oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
+        onFieldChange={mockOnFieldChange}
+      />,
+    );
+
+    expect(screen.getByText('department')).toBeInTheDocument();
+    expect(screen.getByText('name')).toBeInTheDocument();
+    expect(screen.getByText('owner')).toBeInTheDocument();
+  });
+
+  it('adds a system attribute to clientConfig when its chip is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <AgentAccessTokenSection
+        agent={{...baseAgent, inboundAuthConfig: baseInboundAuthConfig}}
+        editedAgent={{}}
+        oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
+        onFieldChange={mockOnFieldChange}
+      />,
+    );
+
+    await user.click(screen.getByText('owner'));
+
+    expect(mockOnFieldChange).toHaveBeenCalledWith(
+      'inboundAuthConfig',
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'oauth2',
+          config: expect.objectContaining({
+            token: expect.objectContaining({
+              accessToken: expect.objectContaining({
+                clientConfig: expect.objectContaining({attributes: ['owner']}) as Record<string, unknown>,
+              }) as Record<string, unknown>,
+            }) as Record<string, unknown>,
+          }) as Record<string, unknown>,
+        }),
+      ]),
+    );
+  });
+
+  it('lists the OU attributes as selectable chips', () => {
+    render(
+      <AgentAccessTokenSection
+        agent={{...baseAgent, inboundAuthConfig: baseInboundAuthConfig}}
+        editedAgent={{}}
+        oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
+        onFieldChange={mockOnFieldChange}
+      />,
+    );
+
+    expect(screen.getByText('ouId')).toBeInTheDocument();
+    expect(screen.getByText('ouName')).toBeInTheDocument();
+    expect(screen.getByText('ouHandle')).toBeInTheDocument();
+  });
+
+  it('adds an OU attribute to clientConfig when its chip is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <AgentAccessTokenSection
+        agent={{...baseAgent, inboundAuthConfig: baseInboundAuthConfig}}
+        editedAgent={{}}
+        oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
+        onFieldChange={mockOnFieldChange}
+      />,
+    );
+
+    await user.click(screen.getByText('ouId'));
+
+    expect(mockOnFieldChange).toHaveBeenCalledWith(
+      'inboundAuthConfig',
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'oauth2',
+          config: expect.objectContaining({
+            token: expect.objectContaining({
+              accessToken: expect.objectContaining({
+                clientConfig: expect.objectContaining({attributes: ['ouId']}) as Record<string, unknown>,
+              }) as Record<string, unknown>,
+            }) as Record<string, unknown>,
+          }) as Record<string, unknown>,
+        }),
+      ]),
+    );
+  });
+
+  it('lists the groups and roles attributes as selectable chips', () => {
+    render(
+      <AgentAccessTokenSection
+        agent={{...baseAgent, inboundAuthConfig: baseInboundAuthConfig}}
+        editedAgent={{}}
+        oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
+        onFieldChange={mockOnFieldChange}
+      />,
+    );
+
+    expect(screen.getByText('groups')).toBeInTheDocument();
+    expect(screen.getByText('roles')).toBeInTheDocument();
+  });
+
+  it('adds the roles attribute to clientConfig when its chip is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <AgentAccessTokenSection
+        agent={{...baseAgent, inboundAuthConfig: baseInboundAuthConfig}}
+        editedAgent={{}}
+        oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
+        onFieldChange={mockOnFieldChange}
+      />,
+    );
+
+    await user.click(screen.getByText('roles'));
+
+    expect(mockOnFieldChange).toHaveBeenCalledWith(
+      'inboundAuthConfig',
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'oauth2',
+          config: expect.objectContaining({
+            token: expect.objectContaining({
+              accessToken: expect.objectContaining({
+                clientConfig: expect.objectContaining({attributes: ['roles']}) as Record<string, unknown>,
+              }) as Record<string, unknown>,
+            }) as Record<string, unknown>,
+          }) as Record<string, unknown>,
+        }),
+      ]),
+    );
+  });
+
+  it('renders a selected system attribute in the JWT preview', () => {
+    render(
+      <AgentAccessTokenSection
+        agent={{...baseAgent, inboundAuthConfig: baseInboundAuthConfig}}
+        editedAgent={{}}
+        oauth2Config={{
+          grantTypes: ['client_credentials'],
+          responseTypes: [],
+          // Client tokens have no ID token; cast the partial fixture the component reads from.
+          token: {accessToken: {clientConfig: {attributes: ['name']}}} as OAuthAgentConfig['token'],
+        }}
+        onFieldChange={mockOnFieldChange}
+      />,
+    );
+
+    expect(screen.getByTestId('jwt-preview')).toHaveTextContent('"name":"<name>"');
   });
 
   it('does not show a scopes section', () => {

--- a/frontend/apps/console/src/features/applications/constants/token-constants.ts
+++ b/frontend/apps/console/src/features/applications/constants/token-constants.ts
@@ -36,6 +36,12 @@ const TokenConstants = {
   ADDITIONAL_USER_ATTRIBUTES: ['groups', 'ouHandle', 'ouId', 'ouName', 'roles', 'userType'],
 
   /**
+   * Agent system, OU, group, and role attributes that can be added to the agent's own access token
+   * (client_credentials)
+   */
+  ADDITIONAL_AGENT_ATTRIBUTES: ['name', 'owner', 'ouHandle', 'ouId', 'ouName', 'groups', 'roles'],
+
+  /**
    * Supported UserInfo response types
    */
   /**

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1211,7 +1211,7 @@ const translations = {
     'edit.tokens.agent.attributes.description':
       'Attributes included in the access token this agent receives for its own requests (client_credentials grant).',
     'edit.tokens.agent.attributes.label': 'Add or Remove Attributes',
-    'edit.tokens.agent.attributes.hint': "Click on this agent's attributes to add them to its access token.",
+    'edit.tokens.agent.attributes.hint': 'Click on agent attributes to add them to its access token.',
     'edit.tokens.agent.attributes.empty':
       'No attributes available. Configure attributes for this agent in the Attributes tab.',
     'edit.tokens.agent.validity.title': 'Token Validity',

--- a/tests/integration/oauth/token/token_test.go
+++ b/tests/integration/oauth/token/token_test.go
@@ -109,6 +109,15 @@ func (ts *TokenTestSuite) createTestApplication(authMethod string) string {
 						"refresh_token",
 					},
 					"tokenEndpointAuthMethod": authMethod,
+					// OU claims are opt-in for client tokens; list them so the client_credentials
+					// token carries ouId/ouName/ouHandle.
+					"token": map[string]interface{}{
+						"accessToken": map[string]interface{}{
+							"clientConfig": map[string]interface{}{
+								"attributes": []string{"ouId", "ouName", "ouHandle"},
+							},
+						},
+					},
 				},
 			},
 		},
@@ -325,7 +334,7 @@ func (ts *TokenTestSuite) TestClientCredentialsGrantWithHeaderCredentials() {
 		})
 	}
 
-	// Verify that client OU claims are included in the access token.
+	// Verify that the OU claims the client opted into are included in the access token.
 	ts.Run("WithClientOUClaims", func() {
 		reqBody := strings.NewReader(tokenTestClientCredentialsForm(""))
 		request, err := http.NewRequest("POST", testServerURL+"/oauth2/token", reqBody)


### PR DESCRIPTION
### Purpose

Agent access tokens issued through the `client_credentials` grant could only carry the agent's schema attributes as custom claims. Important agent metadata such as its **name** and **owner** was not available as claims, even though it is essential for traceability and observability of what an agent did.

This PR lets an agent include its system attributes (`name`, `owner`) as claims in its own access token, selectable from the **Edit Agent → Token → Agent** tab alongside the schema attributes. It also brings OU claims (`ouId`, `ouName`, `ouHandle`) under the same opt-in model, so client tokens now behave consistently with user access tokens:
each token carries only the claims it explicitly selects.

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
OU claims (`ouId`, `ouName`, `ouHandle`) are now **opt-in** for `client_credentials` tokens. Previously they were added automatically whenever the client had an organization unit. Now a client receives only the OU claims listed in its `clientConfig.attributes`, matching how user access tokens already gate OU claims.

---
### Approach

The change rides entirely on the existing clientConfig.attributes allow-list. No new config field, API shape, or DB change.

Backend (tokenservice): BuildClientAttributes fetches the client entity once and composes three resolvers, each gated by clientConfig.attributes:

- resolveClientEntityAttributes — the client's schema attributes (from Entity.Attributes).
- resolveClientSystemAttributes — name / owner from Entity.SystemAttributes, restricted to agent entities so application client tokens can never surface them.
- resolveClientOUAttributes — ouId / ouName / ouHandle, now allow-list gated (uniform for agents and applications), mirroring the user-token appendOUDetailsToClaims (per-claim opt-in, OU fetched only when at least one is requested, ouName/ouHandle dropped when empty).

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4010
- https://github.com/thunder-id/thunderid/issues/4213
- https://github.com/thunder-id/thunderid/issues/4244

### Related PRs
- https://github.com/thunder-id/thunderid/pull/3755


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent client-credentials tokens can now include opt-in system attributes (`name`, `owner`), selected OU claims (`ouId`, `ouName`, `ouHandle`), and group/role-derived claims (`groups`, `roles`).
  * Agent token configuration UI now supports selecting these attributes and previews the resulting JWT.
  * Application client-credentials tokens support explicitly requested OU claims via client attributes.
* **Documentation**
  * Updated OAuth/OIDC and agent/application guides to clarify opt-in claim behavior for client-credentials.
* **Bug Fixes**
  * Improved claim allow-listing, embedding rules (including agent-only system attributes), and precedence to handle collisions and avoid embedding unrequested claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->