### PR TITLE
Fix docs mobile layout collapse after closing Ask AI panel

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -3275,6 +3275,18 @@ a.connect-card {
   transform: none !important;
 }
 
+/* On mobile the Ask AI sidepanel opens as a full-screen overlay, but DocSearch's
+   inline mode still sets an inline margin-right on the app root to reserve space
+   for it. On a phone-width viewport that margin (~360px) squeezes the page into a
+   sliver, collapsing the content into a single vertical column that persists after
+   the panel is closed. Cancel the reserved space at this breakpoint so the page
+   keeps its full width behind the overlay. */
+@media screen and (max-width: 768px) {
+  #__docusaurus:has(~ .DocSearch-Sidepanel-Container) {
+    margin-right: 0 !important;
+  }
+}
+
 /* ------------------------------ OneTrust Cookie Consent ---------------------- */
 /* OneTrust (CookiePro) injects its banner and preference-center modal outside the
    React tree with inline styles, so we override it here rather than via sx/styled(). */


### PR DESCRIPTION
### Purpose
Fixes a UI bug in the documentation site on mobile. Opening the Ask AI panel and then closing it collapsed the page into a narrow vertical strip (text wrapping to one letter per line), with a stray box of navbar icons floating over the logo in the top-left corner. The broken layout stayed on screen until the user scrolled, tapped, or rotated the device.

The cause: on mobile the Ask AI panel is meant to open as a full-screen overlay, but DocSearch's inline side-panel mode still reserved horizontal space by setting a margin-right (~360px) on the app root. On a phone-width viewport that margin squeezed the content down to ~30px. The collapse happened behind the overlay, so it only became visible once the panel was closed, and mobile browsers did not reliably repaint the root back to full width.

### Approach
Cancel the space DocSearch reserves on the app root at mobile widths so the page keeps its full width behind the full-screen overlay.

A single CSS rule was added in [docs/src/css/custom.css](vscode-webview://0l7s42gstiq5v32u68ttgmrujd31fctsi645akgv33uuro2up19e/docs/src/css/custom.css), next to the existing DocSearch side-panel override:

```
@media screen and (max-width: 768px) {
  #__docusaurus:has(~ .DocSearch-Sidepanel-Container) {
    margin-right: 0 !important;
  }
}
```
Key decisions:

- Target the mechanism, not the symptom. The reset is applied to the exact inline margin-right DocSearch writes on **#__docusaurus**, which is what collapses the layout. !important is required to override that inline style.
- Scope to mobile only. The max-width: 768px breakpoint matches DocSearch's own mobile breakpoint, so the desktop side-by-side panel behavior is unchanged.
- CSS-only, consistent with the existing pattern. The file already patches DocSearch side-panel behavior with a CSS override, so no JavaScript, config, or dependency version changes were needed.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4202
