### PR TITLE
Add an Enable SSO toggle to the flow builder for login flows

### DIFF
--- a/frontend/apps/console/src/features/flows/components/react-flow-overrides/BaseEdge.tsx
+++ b/frontend/apps/console/src/features/flows/components/react-flow-overrides/BaseEdge.tsx
@@ -26,64 +26,19 @@ import {
   useReactFlow,
   useStore,
   type EdgeProps,
-  type ReactFlowState,
 } from '@xyflow/react';
-import {useMemo, useState, type ReactElement, type SyntheticEvent} from 'react';
+import {useContext, useEffect, useMemo, useState, type ReactElement, type SyntheticEvent} from 'react';
+import EdgeGeometryContext from '../../context/EdgeGeometryContext';
+import EdgePathsContext from '../../context/EdgePathsContext';
 import useFlowConfig from '../../hooks/useFlowConfig';
 import {EdgeStyleTypes} from '../../models/steps';
 import {calculateEdgePath, type EdgePathResult, type EdgeStyle} from '../../utils/calculateEdgePath';
+import {DRAGGING_OBSTACLES_KEY, SMOOTH_STEP_BORDER_RADIUS, selectObstaclesKey} from '../../utils/edgeRoutingKeys';
 
 /**
  * Props interface of {@link BaseEdge}
  */
 export type BaseEdgePropsInterface = EdgeProps;
-
-/**
- * Border radius for smooth step edges in pixels.
- */
-const SMOOTH_STEP_BORDER_RADIUS = 20;
-
-/**
- * Sentinel obstacle key returned while any node is being dragged, so edges skip
- * the expensive smart routing and stay stable across drag ticks.
- */
-const DRAGGING_OBSTACLES_KEY = 'dragging';
-
-/**
- * Cache of computed obstacle keys per store nodes snapshot. The selector runs for
- * every edge on every store update (including pan/zoom frames); React Flow only
- * replaces the nodes array when a node actually changes, so caching on the array
- * identity turns the O(edges × nodes) string building into a single computation.
- */
-const obstaclesKeyCache = new WeakMap<object, string>();
-
-/**
- * Derives a coarse key of all node bounds from the React Flow store. The key only
- * changes when a node settles at a new position or size — during a drag it returns
- * a constant, so edges neither re-render per drag tick nor re-route until drop.
- */
-function selectObstaclesKey(state: ReactFlowState): string {
-  const {nodes} = state;
-
-  if (nodes.some((node) => node.dragging)) {
-    return DRAGGING_OBSTACLES_KEY;
-  }
-
-  const cached = obstaclesKeyCache.get(nodes);
-  if (cached !== undefined) {
-    return cached;
-  }
-
-  const key = nodes
-    .map(
-      (node) =>
-        `${node.id}:${Math.round(node.position.x)},${Math.round(node.position.y)},` +
-        `${Math.round(node.measured?.width ?? 0)}x${Math.round(node.measured?.height ?? 0)}`,
-    )
-    .join('|');
-  obstaclesKeyCache.set(nodes, key);
-  return key;
-}
 
 /**
  * Enhanced edge component with custom routing algorithm to avoid nodes.
@@ -112,6 +67,21 @@ function BaseEdge({
   const [isHovered, setIsHovered] = useState<boolean>(false);
   const {edgeStyle} = useFlowConfig();
   const obstaclesKey = useStore(selectObstaclesKey);
+  const separatedPaths = useContext(EdgePathsContext);
+  const geometryRegistry = useContext(EdgeGeometryContext);
+
+  // Report this edge's exact endpoint geometry so the provider can route all
+  // edges together and separate the ones sharing a corridor. Registration is
+  // skipped while dragging (transient geometry would churn the provider per
+  // tick); the obstacles key change on drop re-fires it with settled values.
+  useEffect(() => {
+    if (obstaclesKey === DRAGGING_OBSTACLES_KEY) {
+      return;
+    }
+    geometryRegistry?.register({id, sourcePosition, sourceX, sourceY, targetPosition, targetX, targetY});
+  }, [geometryRegistry, id, sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, obstaclesKey]);
+
+  useEffect(() => () => geometryRegistry?.unregister(id), [geometryRegistry, id]);
 
   const {
     path: edgePath,
@@ -130,6 +100,13 @@ function BaseEdge({
       return {centerX, centerY, path};
     }
 
+    // Prefer the centrally computed path: it is routed together with every
+    // other edge so shared corridors are separated into parallel lanes.
+    const separated = separatedPaths?.get(id);
+    if (separated) {
+      return separated;
+    }
+
     // Calculate smart path that routes around nodes with the selected edge style
     return calculateEdgePath(
       sourceX,
@@ -142,7 +119,19 @@ function BaseEdge({
       edgeStyle as EdgeStyle,
       SMOOTH_STEP_BORDER_RADIUS,
     );
-  }, [sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, obstaclesKey, edgeStyle, getNodes]);
+  }, [
+    id,
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+    obstaclesKey,
+    edgeStyle,
+    getNodes,
+    separatedPaths,
+  ]);
 
   const handleDelete = (event: SyntheticEvent) => {
     event.stopPropagation();

--- a/frontend/apps/console/src/features/flows/components/react-flow-overrides/EdgePathsProvider.tsx
+++ b/frontend/apps/console/src/features/flows/components/react-flow-overrides/EdgePathsProvider.tsx
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {useStore, useStoreApi} from '@xyflow/react';
+import {useMemo, useRef, useState, type PropsWithChildren, type ReactElement} from 'react';
+import EdgeGeometryContext, {type EdgeGeometryRegistry} from '../../context/EdgeGeometryContext';
+import EdgePathsContext from '../../context/EdgePathsContext';
+import useFlowConfig from '../../hooks/useFlowConfig';
+import {
+  calculateAllEdgePaths,
+  type EdgeInput,
+  type EdgePathResult,
+  type EdgeStyle,
+} from '../../utils/calculateEdgePath';
+import {DRAGGING_OBSTACLES_KEY, SMOOTH_STEP_BORDER_RADIUS, selectObstaclesKey} from '../../utils/edgeRoutingKeys';
+
+function sameGeometry(a: EdgeInput, b: EdgeInput): boolean {
+  return (
+    a.sourceX === b.sourceX &&
+    a.sourceY === b.sourceY &&
+    a.targetX === b.targetX &&
+    a.targetY === b.targetY &&
+    a.sourcePosition === b.sourcePosition &&
+    a.targetPosition === b.targetPosition
+  );
+}
+
+/**
+ * Routes all edges together so overlapping segments separate into parallel
+ * lanes (calculateAllEdgePaths), instead of each edge routing independently
+ * and stacking on the same corridor.
+ *
+ * Each edge registers the endpoint geometry React Flow handed it, so the
+ * combined routing works from exactly the coordinates the edges would use on
+ * their own. Until an edge's geometry is registered (first paint), it renders
+ * its individual path and picks up the separated one on the next pass.
+ */
+function EdgePathsProvider({children}: PropsWithChildren): ReactElement {
+  const {edgeStyle} = useFlowConfig();
+  const obstaclesKey = useStore(selectObstaclesKey);
+  const store = useStoreApi();
+
+  const geometryRef = useRef<Map<string, EdgeInput>>(new Map());
+  const [version, setVersion] = useState<number>(0);
+
+  const registry = useMemo(
+    (): EdgeGeometryRegistry => ({
+      register: (input: EdgeInput): void => {
+        const current = geometryRef.current.get(input.id);
+        if (current && sameGeometry(current, input)) {
+          return;
+        }
+        geometryRef.current.set(input.id, input);
+        setVersion((previous) => previous + 1);
+      },
+      unregister: (id: string): void => {
+        if (geometryRef.current.delete(id)) {
+          setVersion((previous) => previous + 1);
+        }
+      },
+    }),
+    [],
+  );
+
+  const paths = useMemo((): Map<string, EdgePathResult> | null => {
+    // While dragging, edges render their cheap built-in paths; recompute on drop.
+    if (obstaclesKey === DRAGGING_OBSTACLES_KEY || geometryRef.current.size < 2) {
+      return null;
+    }
+    const {nodes} = store.getState();
+    return calculateAllEdgePaths(
+      [...geometryRef.current.values()],
+      nodes,
+      edgeStyle as EdgeStyle,
+      SMOOTH_STEP_BORDER_RADIUS,
+    );
+    // `version` tracks the registry content, which lives in a ref.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [version, obstaclesKey, edgeStyle, store]);
+
+  return (
+    <EdgeGeometryContext.Provider value={registry}>
+      <EdgePathsContext.Provider value={paths}>{children}</EdgePathsContext.Provider>
+    </EdgeGeometryContext.Provider>
+  );
+}
+
+export default EdgePathsProvider;

--- a/frontend/apps/console/src/features/flows/components/react-flow-overrides/__tests__/BaseEdge.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/react-flow-overrides/__tests__/BaseEdge.test.tsx
@@ -141,6 +141,8 @@ describe('BaseEdge', () => {
     setFlowEdgeTypes: vi.fn(),
     flowNodes: [],
     setFlowNodes: vi.fn(),
+    graphValidationRules: [],
+    setGraphValidationRules: vi.fn(),
   };
 
   const createWrapper = (overrides: Partial<FlowConfigContextProps> = {}) => {

--- a/frontend/apps/console/src/features/flows/components/react-flow-overrides/__tests__/EdgePathsProvider.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/react-flow-overrides/__tests__/EdgePathsProvider.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen, waitFor} from '@testing-library/react';
+import {Position} from '@xyflow/react';
+import {useContext, useEffect} from 'react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import EdgeGeometryContext from '../../../context/EdgeGeometryContext';
+import EdgePathsContext from '../../../context/EdgePathsContext';
+import type {EdgeInput} from '../../../utils/calculateEdgePath';
+import EdgePathsProvider from '../EdgePathsProvider';
+
+const {mockState} = vi.hoisted(() => ({
+  mockState: {nodes: [] as unknown[]},
+}));
+
+vi.mock('@xyflow/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@xyflow/react')>();
+  return {
+    ...actual,
+    useStore: (selector: (state: unknown) => unknown) => selector(mockState),
+    useStoreApi: () => ({getState: () => mockState}),
+  };
+});
+
+vi.mock('../../../hooks/useFlowConfig', () => ({
+  default: () => ({edgeStyle: 'step'}),
+}));
+
+function edgeInput(id: string, sourceX: number, sourceY: number, targetX: number, targetY: number): EdgeInput {
+  return {
+    id,
+    sourcePosition: Position.Right,
+    sourceX,
+    sourceY,
+    targetPosition: Position.Left,
+    targetX,
+    targetY,
+  };
+}
+
+function Probe({inputs}: {inputs: EdgeInput[]}) {
+  const registry = useContext(EdgeGeometryContext);
+  const paths = useContext(EdgePathsContext);
+
+  useEffect(() => {
+    inputs.forEach((input) => registry?.register(input));
+  }, [registry, inputs]);
+
+  return (
+    <div data-testid="paths">
+      {paths ? [...paths.entries()].map(([id, result]) => `${id}=${result.path}`).join(';') : 'none'}
+    </div>
+  );
+}
+
+describe('EdgePathsProvider', () => {
+  beforeEach(() => {
+    mockState.nodes = [];
+  });
+
+  it('should publish combined paths once edges register their geometry', async () => {
+    render(
+      <EdgePathsProvider>
+        <Probe inputs={[edgeInput('e1', 0, 0, 300, 200), edgeInput('e2', 0, 400, 300, 250)]} />
+      </EdgePathsProvider>,
+    );
+
+    await waitFor(() => {
+      const text = screen.getByTestId('paths').textContent ?? '';
+      expect(text).toContain('e1=M 0,0 ');
+      expect(text).toContain('e2=M 0,400 ');
+    });
+  });
+
+  it('should keep each combined path anchored to its endpoints', async () => {
+    render(
+      <EdgePathsProvider>
+        <Probe inputs={[edgeInput('e1', 0, 0, 300, 200), edgeInput('e2', 0, 0, 300, 200)]} />
+      </EdgePathsProvider>,
+    );
+
+    await waitFor(() => {
+      const text = screen.getByTestId('paths').textContent ?? '';
+      const paths = text.split(';');
+      expect(paths).toHaveLength(2);
+      paths.forEach((entry) => {
+        expect(entry).toMatch(/=M 0,0 /);
+        expect(entry.endsWith('L 300,200')).toBe(true);
+      });
+    });
+  });
+
+  it('should publish no paths while a node is being dragged', async () => {
+    mockState.nodes = [{dragging: true, id: 'a', position: {x: 0, y: 0}}];
+
+    render(
+      <EdgePathsProvider>
+        <Probe inputs={[edgeInput('e1', 0, 0, 300, 200), edgeInput('e2', 0, 400, 300, 250)]} />
+      </EdgePathsProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('paths').textContent).toBe('none');
+    });
+  });
+
+  it('should publish no paths while fewer than two edges are registered', async () => {
+    render(
+      <EdgePathsProvider>
+        <Probe inputs={[edgeInput('e1', 0, 0, 300, 200)]} />
+      </EdgePathsProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('paths').textContent).toBe('none');
+    });
+  });
+});

--- a/frontend/apps/console/src/features/flows/components/resource-panel/ResourcePanel.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-panel/ResourcePanel.tsx
@@ -85,6 +85,10 @@ export interface ResourcePanelPropsInterface extends HTMLAttributes<HTMLDivEleme
    * Optional right-hand side panel content rendered via BuilderLayout.
    */
   rightPanel?: ReactNode;
+  /**
+   * Optional content rendered at the bottom of the panel, below the resource sections.
+   */
+  footer?: ReactNode;
 }
 
 interface ResourcePanelSection {
@@ -113,6 +117,7 @@ function ResourcePanel({
   flowHandle = '',
   onFlowTitleChange = undefined,
   rightPanel = undefined,
+  footer = undefined,
   ...rest
 }: ResourcePanelPropsInterface): ReactElement {
   const {t} = useTranslation();
@@ -230,76 +235,107 @@ function ResourcePanel({
           />
         </Box>
 
-        {visibleSections.map((section: ResourcePanelSection) => (
-          <Accordion
-            key={`${section.id}-${isSearching}`}
-            defaultExpanded={isSearching}
-            square
-            disableGutters
-            sx={{
-              backgroundColor: 'transparent',
-              '&:before': {
-                display: 'none',
-              },
-              overflow: 'hidden',
-              flexShrink: 0,
-            }}
-          >
-            <AccordionSummary
-              expandIcon={<ChevronDownIcon size={14} />}
-              aria-controls={`panel-${section.id}-content`}
-              id={`panel-${section.id}-header`}
+        <Box
+          sx={{
+            flex: 1,
+            minHeight: 0,
+            overflow: 'hidden auto',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 1,
+            mx: -2,
+            px: 2,
+          }}
+        >
+          {visibleSections.map((section: ResourcePanelSection) => (
+            <Accordion
+              key={`${section.id}-${isSearching}`}
+              defaultExpanded={isSearching}
+              square
+              disableGutters
               sx={{
-                minHeight: 48,
-                '&.Mui-expanded': {
-                  minHeight: 48,
+                backgroundColor: 'transparent',
+                '&:before': {
+                  display: 'none',
                 },
-                '& .MuiAccordionSummary-content': {
-                  margin: '12px 0',
-                  gap: 1,
-                },
-              }}
-              slotProps={{
-                content: {
-                  sx: {alignItems: 'center'},
-                },
+                overflow: 'hidden',
+                flexShrink: 0,
               }}
             >
-              <Box component="span" display="inline-flex" alignItems="center" sx={{flexShrink: 0}}>
-                {section.icon}
-              </Box>
-              <Stack direction="column">
-                <Typography variant="subtitle2" fontWeight={600}>
-                  {t(section.titleKey, section.titleFallback)}
-                </Typography>
-                <Typography variant="caption" color="text.secondary" sx={{lineHeight: 1.3}}>
-                  {t(section.descriptionKey, section.descriptionFallback)}
-                </Typography>
-              </Stack>
-            </AccordionSummary>
-            <AccordionDetails sx={{pt: 0, pb: 2, px: 2}}>
-              <Stack direction="column" spacing={1}>
-                {section.items.map(({id, resource}: ResourcePanelListItem) => (
-                  <ResourcePanelDraggable id={id} key={id} resource={resource} onAdd={onAdd} disabled={disabled} />
-                ))}
-              </Stack>
-            </AccordionDetails>
-          </Accordion>
-        ))}
+              <AccordionSummary
+                expandIcon={<ChevronDownIcon size={14} />}
+                aria-controls={`panel-${section.id}-content`}
+                id={`panel-${section.id}-header`}
+                sx={{
+                  minHeight: 48,
+                  '&.Mui-expanded': {
+                    minHeight: 48,
+                  },
+                  '& .MuiAccordionSummary-content': {
+                    margin: '12px 0',
+                    gap: 1,
+                  },
+                }}
+                slotProps={{
+                  content: {
+                    sx: {alignItems: 'center'},
+                  },
+                }}
+              >
+                <Box component="span" display="inline-flex" alignItems="center" sx={{flexShrink: 0}}>
+                  {section.icon}
+                </Box>
+                <Stack direction="column">
+                  <Typography variant="subtitle2" fontWeight={600}>
+                    {t(section.titleKey, section.titleFallback)}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary" sx={{lineHeight: 1.3}}>
+                    {t(section.descriptionKey, section.descriptionFallback)}
+                  </Typography>
+                </Stack>
+              </AccordionSummary>
+              <AccordionDetails sx={{pt: 0, pb: 2, px: 2}}>
+                <Stack direction="column" spacing={1}>
+                  {section.items.map(({id, resource}: ResourcePanelListItem) => (
+                    <ResourcePanelDraggable id={id} key={id} resource={resource} onAdd={onAdd} disabled={disabled} />
+                  ))}
+                </Stack>
+              </AccordionDetails>
+            </Accordion>
+          ))}
 
-        {isSearching && visibleSections.length === 0 && (
-          <Stack alignItems="center" spacing={1} sx={{px: 2, py: 4, color: 'text.secondary'}}>
-            <SearchXIcon size={24} />
-            <Typography variant="body2">
-              {t('flows:core.resourcePanel.search.noResults', 'No matching resources')}
-            </Typography>
-            <Typography variant="caption" color="text.secondary" textAlign="center">
-              {t(
-                'flows:core.resourcePanel.search.noResultsHint',
-                'Try a different keyword, such as "OTP", "Google", or "passkey"',
-              )}
-            </Typography>
-          </Stack>
+          {isSearching && visibleSections.length === 0 && (
+            <Stack alignItems="center" spacing={1} sx={{px: 2, py: 4, color: 'text.secondary'}}>
+              <SearchXIcon size={24} />
+              <Typography variant="body2">
+                {t('flows:core.resourcePanel.search.noResults', 'No matching resources')}
+              </Typography>
+              <Typography variant="caption" color="text.secondary" textAlign="center">
+                {t(
+                  'flows:core.resourcePanel.search.noResultsHint',
+                  'Try a different keyword, such as "OTP", "Google", or "passkey"',
+                )}
+              </Typography>
+            </Stack>
+          )}
+        </Box>
+
+        {footer && (
+          <Box
+            sx={{
+              flexShrink: 0,
+              borderTop: '1px solid',
+              borderColor: 'divider',
+              // Bleed through the drawer paper's padding so the band spans the
+              // full panel width and sits flush with the bottom edge.
+              mx: -2,
+              mb: -2,
+              px: 2,
+              py: 1.5,
+            }}
+          >
+            {footer}
+          </Box>
         )}
       </>
     ),
@@ -313,6 +349,7 @@ function ResourcePanel({
       handleTogglePanel,
       onAdd,
       disabled,
+      footer,
       t,
     ],
   );
@@ -324,7 +361,9 @@ function ResourcePanel({
       expandTooltip={t('flows:core.resourcePanel.showResources')}
       panelContent={panelContent}
       panelPaperSx={{
-        overflow: 'hidden auto',
+        // The section list scrolls in its own container so the header, search
+        // field, and footer stay fixed.
+        overflow: 'hidden',
         display: 'flex',
         flexDirection: 'column',
         borderRight: '1px solid',

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/ResourceProperties.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/ResourceProperties.test.tsx
@@ -151,6 +151,8 @@ describe('ResourceProperties', () => {
       setFlowEdgeTypes: vi.fn(),
       flowNodes: [],
       setFlowNodes: vi.fn(),
+      graphValidationRules: [],
+      setGraphValidationRules: vi.fn(),
     };
 
     function Wrapper({children}: {children: ReactNode}) {

--- a/frontend/apps/console/src/features/flows/components/visual-flow/DecoratedVisualFlow.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/DecoratedVisualFlow.tsx
@@ -40,6 +40,7 @@ import {
   useRef,
   useState,
   type ReactElement,
+  type ReactNode,
   type SetStateAction,
 } from 'react';
 import {useTranslation} from 'react-i18next';
@@ -86,6 +87,7 @@ import {
 import {findContainingComponent} from '../../utils/updateNestedComponent';
 import {widgetNeedsViewContainer} from '../../utils/widgetUtils';
 import Droppable from '../dnd/Droppable';
+import EdgePathsProvider from '../react-flow-overrides/EdgePathsProvider';
 import ResourcePanel from '../resource-panel/ResourcePanel';
 import ResourcePropertyPanel from '../resource-property-panel/ResourcePropertyPanel';
 import ValidationPanel from '../validation-panel/ValidationPanel';
@@ -124,6 +126,10 @@ export interface DecoratedVisualFlowPropsInterface extends Omit<VisualFlowPropsI
    * This is useful when loading flows that don't have saved canvas positions.
    */
   triggerAutoLayoutOnLoad?: boolean;
+  /**
+   * Extra controls rendered at the bottom of the resource panel, below the resource sections.
+   */
+  resourcePanelFooter?: ReactNode;
 }
 
 /**
@@ -151,6 +157,7 @@ function DecoratedVisualFlow({
   flowHandle,
   onFlowTitleChange,
   triggerAutoLayoutOnLoad = false,
+  resourcePanelFooter = undefined,
   ...rest
 }: DecoratedVisualFlowPropsInterface): ReactElement {
   useDeleteExecutionResource();
@@ -369,11 +376,18 @@ function DecoratedVisualFlow({
     }
   }, [isSimulatingNow, setIsResourcePanelOpen, setIsOpenResourcePropertiesPanel]);
 
+  // Edge under the pointer, tracked so the edge and the node it leads into can
+  // be spotlighted (same visual language as the preview's option highlight).
+  // Styled via data-id selectors so no node/edge objects change on hover.
+  const [hoveredEdge, setHoveredEdge] = useState<{id: string; targetId: string} | null>(null);
+
   const {isSimulating: isSimulationActive, start: startSimulation, stop: stopSimulation} = simulation;
   const handleToggleSimulation = useCallback((): void => {
     if (isSimulationActive) {
       stopSimulation();
     } else {
+      // Drop any hover highlight so it doesn't resurface when the preview ends.
+      setHoveredEdge(null);
       startSimulation();
     }
   }, [isSimulationActive, stopSimulation, startSimulation]);
@@ -438,6 +452,21 @@ function DecoratedVisualFlow({
     },
     [fitView, simulation.isSimulating, simulation.followCamera],
   );
+
+  const handleEdgeMouseEnter = useCallback(
+    (_event: unknown, edge: Edge): void => {
+      // The preview mode has its own path decoration; don't fight it.
+      if (simulation.isSimulating) {
+        return;
+      }
+      setHoveredEdge({id: edge.id, targetId: edge.target});
+    },
+    [simulation.isSimulating],
+  );
+
+  const handleEdgeMouseLeave = useCallback((): void => {
+    setHoveredEdge(null);
+  }, []);
 
   const handleNodeDragStop = useCallback((): void => {
     const currentNodes = stripSimulationNodeClasses(getNodes());
@@ -768,6 +797,33 @@ function DecoratedVisualFlow({
           '70%': {boxShadow: '0 0 0 15px transparent'},
           '100%': {boxShadow: '0 0 0 0 transparent'},
         },
+        // Each edge renders in its own svg layer; lift the hovered one so its
+        // highlight stays visible where edges overlap or run close together.
+        '& .react-flow__edges svg:has(.react-flow__edge:hover)': {zIndex: '1000 !important'},
+        // Spotlight the hovered edge and the node it leads into, mirroring the
+        // preview's option highlight. Targeted via data-id so hovering never
+        // mutates node/edge objects (React Flow's memoization stays intact).
+        // Suppressed while previewing — the simulation owns path decoration.
+        ...(hoveredEdge && !simulation.isSimulating
+          ? {
+              [`& .react-flow__edge[data-id="${hoveredEdge.id}"] .react-flow__edge-path`]: {
+                stroke: `${theme.palette.primary.main} !important`,
+              },
+              [`& .react-flow__node[data-id="${hoveredEdge.targetId}"] .flow-builder-step, ` +
+              `& .react-flow__node[data-id="${hoveredEdge.targetId}"] .execution-minimal-step, ` +
+              `& .react-flow__node[data-id="${hoveredEdge.targetId}"] .flow-builder-rule, ` +
+              `& .react-flow__node[data-id="${hoveredEdge.targetId}"] .MuiFab-root`]: {
+                outline: `2px solid ${theme.palette.primary.main}`,
+                outlineOffset: '4px',
+                animation: 'edge-hover-target-pulse 1s infinite',
+              },
+              '@keyframes edge-hover-target-pulse': {
+                '0%': {boxShadow: `0 0 0 0 ${theme.palette.primary.main}`},
+                '70%': {boxShadow: '0 0 0 15px transparent'},
+                '100%': {boxShadow: '0 0 0 0 transparent'},
+              },
+            }
+          : {}),
       })}
     >
       {/* ── Top bar: back button | toolbar | save button ── */}
@@ -839,6 +895,7 @@ function DecoratedVisualFlow({
               flowHandle={flowHandle}
               onFlowTitleChange={onFlowTitleChange}
               rightPanel={rightPanel}
+              footer={resourcePanelFooter}
             >
               <Droppable
                 id={generateResourceId(VisualFlowConstants.FLOW_BUILDER_CANVAS_ID)}
@@ -847,19 +904,23 @@ function DecoratedVisualFlow({
                 hideDropZones
                 collisionPriority={CollisionPriority.Low}
               >
-                <VisualFlow
-                  nodes={displayNodes}
-                  onNodesChange={onNodesChange}
-                  edges={displayEdges}
-                  edgeTypes={edgeTypes}
-                  onEdgesChange={onEdgesChange}
-                  onConnect={handleConnect}
-                  onNodesDelete={handleNodesDelete}
-                  onEdgesDelete={handleEdgesDelete}
-                  onNodeDragStop={handleNodeDragStop}
-                  onNodeClick={handleNodeClick}
-                  {...rest}
-                />
+                <EdgePathsProvider>
+                  <VisualFlow
+                    nodes={displayNodes}
+                    onNodesChange={onNodesChange}
+                    edges={displayEdges}
+                    edgeTypes={edgeTypes}
+                    onEdgesChange={onEdgesChange}
+                    onConnect={handleConnect}
+                    onNodesDelete={handleNodesDelete}
+                    onEdgesDelete={handleEdgesDelete}
+                    onNodeDragStop={handleNodeDragStop}
+                    onNodeClick={handleNodeClick}
+                    onEdgeMouseEnter={handleEdgeMouseEnter}
+                    onEdgeMouseLeave={handleEdgeMouseLeave}
+                    {...rest}
+                  />
+                </EdgePathsProvider>
               </Droppable>
             </ResourcePanel>
             <DragOverlay>

--- a/frontend/apps/console/src/features/flows/components/visual-flow/VisualFlow.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/VisualFlow.tsx
@@ -53,6 +53,9 @@ function VisualFlow({
   onEdgesDelete,
   onNodeDragStop,
   onNodeClick,
+  onEdgeClick,
+  onEdgeMouseEnter,
+  onEdgeMouseLeave,
 }: VisualFlowPropsInterface): ReactElement {
   const {mode, systemMode} = useColorScheme();
 
@@ -73,6 +76,9 @@ function VisualFlow({
       onEdgesDelete={onEdgesDelete}
       onNodeDragStop={onNodeDragStop}
       onNodeClick={onNodeClick}
+      onEdgeClick={onEdgeClick}
+      onEdgeMouseEnter={onEdgeMouseEnter}
+      onEdgeMouseLeave={onEdgeMouseLeave}
       proOptions={{hideAttribution: true}}
       colorMode={colorMode}
       minZoom={0.2}

--- a/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/CanvasToolbar.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/CanvasToolbar.test.tsx
@@ -75,6 +75,8 @@ describe('CanvasToolbar', () => {
     setFlowEdgeTypes: vi.fn(),
     flowNodes: [],
     setFlowNodes: vi.fn(),
+    graphValidationRules: [],
+    setGraphValidationRules: vi.fn(),
   };
 
   function Wrapper({children}: {children: ReactNode}) {

--- a/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/DecoratedVisualFlow.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/DecoratedVisualFlow.test.tsx
@@ -151,12 +151,17 @@ const {mockToObject, mockGetNodes, mockGetEdges, mockUpdateNodeData, mockFitView
 );
 
 vi.mock('@xyflow/react', () => ({
+  Position: {Bottom: 'bottom', Left: 'left', Right: 'right', Top: 'top'},
   useReactFlow: () => ({
     toObject: mockToObject,
     getNodes: mockGetNodes,
     getEdges: mockGetEdges,
     updateNodeData: mockUpdateNodeData,
     fitView: mockFitView,
+  }),
+  useStore: (selector: (state: {nodes: never[]; edges: never[]}) => unknown) => selector({edges: [], nodes: []}),
+  useStoreApi: () => ({
+    getState: () => ({edges: [], nodeLookup: new Map(), nodes: []}),
   }),
   useUpdateNodeInternals: () => mockUpdateNodeInternals,
 }));

--- a/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/EdgeStyleSelector.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/EdgeStyleSelector.test.tsx
@@ -56,6 +56,8 @@ describe('EdgeStyleMenu', () => {
     setFlowEdgeTypes: vi.fn(),
     flowNodes: [],
     setFlowNodes: vi.fn(),
+    graphValidationRules: [],
+    setGraphValidationRules: vi.fn(),
   };
 
   const createWrapper = (overrides: Partial<FlowConfigContextProps> = {}) => {

--- a/frontend/apps/console/src/features/flows/context/EdgeGeometryContext.ts
+++ b/frontend/apps/console/src/features/flows/context/EdgeGeometryContext.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {createContext, type Context} from 'react';
+import type {EdgeInput} from '../utils/calculateEdgePath';
+
+/**
+ * Registry where each rendered edge reports the exact endpoint geometry React
+ * Flow computed for it, so {@link EdgePathsProvider} can route all edges
+ * together (with overlap separation) from the same coordinates the edges
+ * would use individually.
+ */
+export interface EdgeGeometryRegistry {
+  register: (input: EdgeInput) => void;
+  unregister: (id: string) => void;
+}
+
+const EdgeGeometryContext: Context<EdgeGeometryRegistry | null> = createContext<EdgeGeometryRegistry | null>(null);
+
+EdgeGeometryContext.displayName = 'EdgeGeometryContext';
+
+export default EdgeGeometryContext;

--- a/frontend/apps/console/src/features/flows/context/EdgePathsContext.ts
+++ b/frontend/apps/console/src/features/flows/context/EdgePathsContext.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {createContext, type Context} from 'react';
+import type {EdgePathResult} from '../utils/calculateEdgePath';
+
+/**
+ * Separated (lane-offset) paths for every edge on the canvas, keyed by edge id.
+ * `null` while a node is being dragged — edges then fall back to their cheap
+ * per-edge paths. Populated by {@link EdgePathsProvider}.
+ */
+const EdgePathsContext: Context<Map<string, EdgePathResult> | null> = createContext<Map<string, EdgePathResult> | null>(
+  null,
+);
+
+EdgePathsContext.displayName = 'EdgePathsContext';
+
+export default EdgePathsContext;

--- a/frontend/apps/console/src/features/flows/context/FlowBuilderCoreProvider.tsx
+++ b/frontend/apps/console/src/features/flows/context/FlowBuilderCoreProvider.tsx
@@ -47,6 +47,7 @@ import type {FlowCompletionConfigsInterface} from '../models/flows';
 import type {Claim} from '../models/metadata';
 import {type Resource, ResourceTypes} from '../models/resources';
 import {StepTypes, EdgeStyleTypes, type EdgeStyleTypes as EdgeStyleTypesType} from '../models/steps';
+import type {GraphValidationRule} from '../validation/validation-rules';
 
 /**
  * Props interface for ElementFactory component
@@ -135,6 +136,7 @@ function FlowContextWrapper({
   const [isVerboseMode, setIsVerboseMode] = useState<boolean>(true);
   const [edgeStyle, setEdgeStyle] = useState<EdgeStyleTypesType>(EdgeStyleTypes.SmoothStep);
   const [flowNodes, setFlowNodes] = useState<Node[]>([]);
+  const [graphValidationRules, setGraphValidationRules] = useState<GraphValidationRule[]>([]);
 
   // ── I18n State ──
   const [language, setLanguage] = useState<string>(I18nDefaultConstants.FALLBACK_LANGUAGE);
@@ -327,6 +329,8 @@ function FlowContextWrapper({
       publishFlow: undefined as (() => Promise<boolean>) | undefined,
       flowNodes,
       setFlowNodes,
+      graphValidationRules,
+      setGraphValidationRules,
     }),
     [
       ElementFactory,
@@ -339,6 +343,7 @@ function FlowContextWrapper({
       flowNodeTypes,
       flowEdgeTypes,
       flowNodes,
+      graphValidationRules,
     ],
   );
 

--- a/frontend/apps/console/src/features/flows/context/FlowConfigContext.tsx
+++ b/frontend/apps/console/src/features/flows/context/FlowConfigContext.tsx
@@ -23,6 +23,7 @@ import type {FlowCompletionConfigsInterface} from '../models/flows';
 import type {MetadataInterface} from '../models/metadata';
 import type {Resource} from '../models/resources';
 import type {EdgeStyleTypes} from '../models/steps';
+import type {GraphValidationRule} from '../validation/validation-rules';
 
 /**
  * Props interface of {@link FlowConfigContext}
@@ -112,6 +113,16 @@ export interface FlowConfigContextProps {
    * Setter to push the latest nodes into the shared context.
    */
   setFlowNodes: Dispatch<SetStateAction<Node[]>>;
+  /**
+   * Cross-node validation rules active for the current flow. Empty by
+   * default; flow-type-specific hosts register the rules that apply
+   * (e.g. the SSO pairing rules for AUTHENTICATION flows).
+   */
+  graphValidationRules: GraphValidationRule[];
+  /**
+   * Setter to register the graph validation rules for the current flow.
+   */
+  setGraphValidationRules: Dispatch<SetStateAction<GraphValidationRule[]>>;
 }
 
 const FlowConfigContext: Context<FlowConfigContextProps | undefined> = createContext<

--- a/frontend/apps/console/src/features/flows/context/ValidationProvider.tsx
+++ b/frontend/apps/console/src/features/flows/context/ValidationProvider.tsx
@@ -46,15 +46,17 @@ function ValidationProvider({
   },
 }: PropsWithChildren<ValidationProviderProps>): ReactElement {
   const {setIsOpenResourcePropertiesPanel, registerCloseValidationPanel} = useUIPanelState();
-  const {flowNodes} = useFlowConfig();
+  const {flowNodes, graphValidationRules} = useFlowConfig();
   const {t} = useTranslation();
 
   // Computed validation notifications — derived from flow node data + rule registry.
   // This replaces the old useEffect-based approach where each adapter/executor
   // imperatively called addNotification/removeNotification.
+  // Graph rules are flow-type-specific and registered by the host (e.g. the
+  // SSO pairing rules for AUTHENTICATION flows).
   const computedNotifications = useMemo(
-    () => computeValidationNotifications(flowNodes, VALIDATION_RULES, t),
-    [flowNodes, t],
+    () => computeValidationNotifications(flowNodes, VALIDATION_RULES, t, graphValidationRules),
+    [flowNodes, graphValidationRules, t],
   );
 
   // Operational notifications (e.g. delete errors from ReorderableElement).

--- a/frontend/apps/console/src/features/flows/hooks/__tests__/useVisualFlowHandlers.test.tsx
+++ b/frontend/apps/console/src/features/flows/hooks/__tests__/useVisualFlowHandlers.test.tsx
@@ -95,6 +95,8 @@ describe('useVisualFlowHandlers', () => {
     setFlowEdgeTypes: vi.fn(),
     flowNodes: [],
     setFlowNodes: vi.fn(),
+    graphValidationRules: [],
+    setGraphValidationRules: vi.fn(),
   };
 
   const createWrapper = (overrides: Partial<FlowConfigContextProps> = {}) => {

--- a/frontend/apps/console/src/features/flows/models/__tests__/steps.test.ts
+++ b/frontend/apps/console/src/features/flows/models/__tests__/steps.test.ts
@@ -174,8 +174,24 @@ describe('steps models', () => {
       expect(ExecutionTypes.UserTypeResolver).toBe('UserTypeResolver');
     });
 
-    it('should have exactly 21 execution types', () => {
-      expect(Object.keys(ExecutionTypes)).toHaveLength(21);
+    it('should have SSOCheck type', () => {
+      expect(ExecutionTypes.SSOCheck).toBe('SSOCheckExecutor');
+    });
+
+    it('should have Session type', () => {
+      expect(ExecutionTypes.Session).toBe('SessionExecutor');
+    });
+
+    it('should have AuthAssert type', () => {
+      expect(ExecutionTypes.AuthAssert).toBe('AuthAssertExecutor');
+    });
+
+    it('should have Authorization type', () => {
+      expect(ExecutionTypes.Authorization).toBe('AuthorizationExecutor');
+    });
+
+    it('should have exactly 25 execution types', () => {
+      expect(Object.keys(ExecutionTypes)).toHaveLength(25);
     });
   });
 

--- a/frontend/apps/console/src/features/flows/models/steps.ts
+++ b/frontend/apps/console/src/features/flows/models/steps.ts
@@ -119,6 +119,10 @@ export const ExecutionTypes = {
   HTTPRequestExecutor: 'HTTPRequestExecutor',
   OUExecutor: 'OUExecutor',
   UserTypeResolver: 'UserTypeResolver',
+  SSOCheck: 'SSOCheckExecutor',
+  Session: 'SessionExecutor',
+  AuthAssert: 'AuthAssertExecutor',
+  Authorization: 'AuthorizationExecutor',
 } as const;
 
 export const ExecutionStepViewTypes = {

--- a/frontend/apps/console/src/features/flows/utils/__tests__/calculateEdgePath.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/calculateEdgePath.test.ts
@@ -482,6 +482,35 @@ describe('calculateAllEdgePaths', () => {
       expect(result.size).toBe(2);
     });
 
+    it('should never offset the terminal segments away from the handles', () => {
+      // Both edges are a single straight segment; that segment touches both
+      // handles, so no separation may be applied to it at all.
+      const edges: EdgeInput[] = [createEdgeInput('e1', 0, 100, 200, 100), createEdgeInput('e2', 0, 100, 200, 100)];
+
+      const result = calculateAllEdgePaths(edges, [], 'step');
+
+      expect(result.get('e1')?.path).toBe('M 0,100 L 200,100');
+      expect(result.get('e2')?.path).toBe('M 0,100 L 200,100');
+    });
+
+    it('should separate interior segments while keeping paths anchored to the handles', () => {
+      // Identical Z-shaped routes: the shared interior vertical segment must be
+      // offset apart, but both paths must still start and end exactly on the
+      // source and target handles.
+      const edges: EdgeInput[] = [createEdgeInput('e1', 0, 0, 300, 200), createEdgeInput('e2', 0, 0, 300, 200)];
+
+      const result = calculateAllEdgePaths(edges, [], 'step');
+      const path1 = result.get('e1')!.path;
+      const path2 = result.get('e2')!.path;
+
+      expect(path1.startsWith('M 0,0 ')).toBe(true);
+      expect(path2.startsWith('M 0,0 ')).toBe(true);
+      expect(path1.endsWith('L 300,200')).toBe(true);
+      expect(path2.endsWith('L 300,200')).toBe(true);
+      // The interior corridor is separated, so the full paths differ.
+      expect(path1).not.toBe(path2);
+    });
+
     it('should handle edges with different paths (no overlap)', () => {
       const edges: EdgeInput[] = [createEdgeInput('e1', 0, 0, 200, 0), createEdgeInput('e2', 0, 200, 200, 200)];
       const nodes: Node[] = [];

--- a/frontend/apps/console/src/features/flows/utils/__tests__/edgeRoutingKeys.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/edgeRoutingKeys.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {ReactFlowState} from '@xyflow/react';
+import {describe, expect, it} from 'vitest';
+import {DRAGGING_OBSTACLES_KEY, selectObstaclesKey} from '../edgeRoutingKeys';
+
+function makeState(nodes: unknown[]): ReactFlowState {
+  return {nodes} as unknown as ReactFlowState;
+}
+
+describe('selectObstaclesKey', () => {
+  it('should return the dragging sentinel while any node is dragging', () => {
+    const state = makeState([
+      {id: 'a', position: {x: 0, y: 0}, dragging: false},
+      {id: 'b', position: {x: 10, y: 10}, dragging: true},
+    ]);
+
+    expect(selectObstaclesKey(state)).toBe(DRAGGING_OBSTACLES_KEY);
+  });
+
+  it('should encode rounded node bounds into the key', () => {
+    const state = makeState([{id: 'a', position: {x: 10.4, y: 20.6}, measured: {width: 150.2, height: 50.5}}]);
+
+    expect(selectObstaclesKey(state)).toBe('a:10,21,150x51');
+  });
+
+  it('should join multiple nodes and default missing sizes to zero', () => {
+    const state = makeState([
+      {id: 'a', position: {x: 0, y: 0}, measured: {width: 100, height: 40}},
+      {id: 'b', position: {x: 200, y: 0}},
+    ]);
+
+    expect(selectObstaclesKey(state)).toBe('a:0,0,100x40|b:200,0,0x0');
+  });
+
+  it('should return an identical key for the same nodes array (cached)', () => {
+    const nodes = [{id: 'a', position: {x: 1, y: 2}, measured: {width: 10, height: 10}}];
+    const state = makeState(nodes);
+
+    const first = selectObstaclesKey(state);
+    const second = selectObstaclesKey(makeState(nodes));
+
+    expect(second).toBe(first);
+  });
+});

--- a/frontend/apps/console/src/features/flows/utils/__tests__/reactFlowTransformer.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/reactFlowTransformer.test.ts
@@ -1596,6 +1596,86 @@ describe('reactFlowTransformer', () => {
       expect(errors).toHaveLength(0);
     });
 
+    describe('SSO pairing', () => {
+      const layout = {size: {width: 100, height: 50}, position: {x: 0, y: 0}};
+
+      const baseNodes = [
+        {id: 'start-1', type: 'START', layout, onSuccess: 'end-1'},
+        {id: 'end-1', type: 'END', layout},
+      ];
+
+      it('should accept a valid SSO check and session pair', () => {
+        const flowGraph: FlowGraph = {
+          nodes: [
+            ...baseNodes,
+            {
+              id: 'sso_check_1',
+              type: 'TASK_EXECUTION',
+              layout,
+              executor: {name: 'SSOCheckExecutor'},
+              properties: {checkpointRef: 'session_1'},
+              onSuccess: 'session_1',
+            },
+            {id: 'session_1', type: 'TASK_EXECUTION', layout, executor: {name: 'SessionExecutor'}, onSuccess: 'end-1'},
+          ],
+        };
+
+        expect(validateFlowGraph(flowGraph)).toHaveLength(0);
+      });
+
+      it('should detect an SSO check without a checkpointRef', () => {
+        const flowGraph: FlowGraph = {
+          nodes: [
+            ...baseNodes,
+            {
+              id: 'sso_check_1',
+              type: 'TASK_EXECUTION',
+              layout,
+              executor: {name: 'SSOCheckExecutor'},
+              onSuccess: 'end-1',
+            },
+          ],
+        };
+
+        expect(validateFlowGraph(flowGraph)).toContain(
+          'Node sso_check_1: SSO check must reference a session checkpoint via checkpointRef',
+        );
+      });
+
+      it('should detect a checkpointRef pointing to a missing session node', () => {
+        const flowGraph: FlowGraph = {
+          nodes: [
+            ...baseNodes,
+            {
+              id: 'sso_check_1',
+              type: 'TASK_EXECUTION',
+              layout,
+              executor: {name: 'SSOCheckExecutor'},
+              properties: {checkpointRef: 'session_gone'},
+              onSuccess: 'end-1',
+            },
+          ],
+        };
+
+        expect(validateFlowGraph(flowGraph)).toContain(
+          'Node sso_check_1: checkpointRef references non-existent session node session_gone',
+        );
+      });
+
+      it('should detect a session node not referenced by any SSO check', () => {
+        const flowGraph: FlowGraph = {
+          nodes: [
+            ...baseNodes,
+            {id: 'session_1', type: 'TASK_EXECUTION', layout, executor: {name: 'SessionExecutor'}, onSuccess: 'end-1'},
+          ],
+        };
+
+        expect(validateFlowGraph(flowGraph)).toContain(
+          'Node session_1: session node is not referenced by any SSO check',
+        );
+      });
+    });
+
     it('should detect duplicate node IDs', () => {
       const flowGraph: FlowGraph = {
         nodes: [

--- a/frontend/apps/console/src/features/flows/utils/calculateEdgePath.ts
+++ b/frontend/apps/console/src/features/flows/utils/calculateEdgePath.ts
@@ -828,10 +828,16 @@ export function calculateAllEdgePaths(
     initialPaths.set(edge.id, fullPath);
   });
 
-  // Step 2: Extract all segments
+  // Step 2: Extract the interior segments. The first and last segments are
+  // anchored to the node handles — offsetting them would detach the path from
+  // its endpoints — so only segments between them participate in separation.
   const allSegments: Segment[] = [];
   initialPaths.forEach((path, edgeId) => {
-    allSegments.push(...extractSegments(edgeId, path));
+    allSegments.push(
+      ...extractSegments(edgeId, path).filter(
+        (segment) => segment.segmentIndex > 0 && segment.segmentIndex < path.length - 2,
+      ),
+    );
   });
 
   // Step 3: Find overlapping groups

--- a/frontend/apps/console/src/features/flows/utils/edgeRoutingKeys.ts
+++ b/frontend/apps/console/src/features/flows/utils/edgeRoutingKeys.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {ReactFlowState} from '@xyflow/react';
+
+/**
+ * Border radius for smooth step edges in pixels.
+ */
+export const SMOOTH_STEP_BORDER_RADIUS = 20;
+
+/**
+ * Sentinel obstacle key returned while any node is being dragged, so edges skip
+ * the expensive smart routing and stay stable across drag ticks.
+ */
+export const DRAGGING_OBSTACLES_KEY = 'dragging';
+
+/**
+ * Cache of computed obstacle keys per store nodes snapshot. The selector runs for
+ * every edge on every store update (including pan/zoom frames); React Flow only
+ * replaces the nodes array when a node actually changes, so caching on the array
+ * identity turns the O(edges × nodes) string building into a single computation.
+ */
+const obstaclesKeyCache = new WeakMap<object, string>();
+
+/**
+ * Derives a coarse key of all node bounds from the React Flow store. The key only
+ * changes when a node settles at a new position or size — during a drag it returns
+ * a constant, so edges neither re-render per drag tick nor re-route until drop.
+ */
+export function selectObstaclesKey(state: ReactFlowState): string {
+  const {nodes} = state;
+
+  if (nodes.some((node) => node.dragging)) {
+    return DRAGGING_OBSTACLES_KEY;
+  }
+
+  const cached = obstaclesKeyCache.get(nodes);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const key = nodes
+    .map(
+      (node) =>
+        `${node.id}:${Math.round(node.position.x)},${Math.round(node.position.y)},` +
+        `${Math.round(node.measured?.width ?? 0)}x${Math.round(node.measured?.height ?? 0)}`,
+    )
+    .join('|');
+  obstaclesKeyCache.set(nodes, key);
+  return key;
+}

--- a/frontend/apps/console/src/features/flows/utils/reactFlowTransformer.ts
+++ b/frontend/apps/console/src/features/flows/utils/reactFlowTransformer.ts
@@ -23,7 +23,7 @@ import {ActionTypes} from '../models/actions';
 import type {Element} from '../models/elements';
 import {ElementCategories, ElementTypes, ActionEventTypes, ButtonTypes} from '../models/elements';
 import type {StepAction, StepData} from '../models/steps';
-import {StepTypes, StaticStepTypes} from '../models/steps';
+import {ExecutionTypes, StepTypes, StaticStepTypes} from '../models/steps';
 
 /**
  * Suffix used in edge sourceHandle to identify the connection point
@@ -924,6 +924,34 @@ export function validateFlowGraph(flowGraph: FlowGraph): string[] {
   if (endNodes.length === 0) {
     errors.push('Flow must have at least one END node');
   }
+
+  // SSO pairing: mirrors the backend contract so an invalid pairing never
+  // reaches the API, even when live validation could not see the executors.
+  const sessionNodeIds = new Set(
+    flowGraph.nodes.filter((node) => node.executor?.name === ExecutionTypes.Session).map((node) => node.id),
+  );
+  const referencedSessionIds = new Set<string>();
+
+  flowGraph.nodes.forEach((node) => {
+    if (node.executor?.name !== ExecutionTypes.SSOCheck) {
+      return;
+    }
+
+    const checkpointRef = node.properties?.checkpointRef;
+    if (typeof checkpointRef !== 'string' || checkpointRef === '') {
+      errors.push(`Node ${node.id}: SSO check must reference a session checkpoint via checkpointRef`);
+    } else if (!sessionNodeIds.has(checkpointRef)) {
+      errors.push(`Node ${node.id}: checkpointRef references non-existent session node ${checkpointRef}`);
+    } else {
+      referencedSessionIds.add(checkpointRef);
+    }
+  });
+
+  sessionNodeIds.forEach((sessionNodeId) => {
+    if (!referencedSessionIds.has(sessionNodeId)) {
+      errors.push(`Node ${sessionNodeId}: session node is not referenced by any SSO check`);
+    }
+  });
 
   return errors;
 }

--- a/frontend/apps/console/src/features/flows/validation/__tests__/computeValidationNotifications.test.ts
+++ b/frontend/apps/console/src/features/flows/validation/__tests__/computeValidationNotifications.test.ts
@@ -21,7 +21,7 @@ import {describe, it, expect, vi} from 'vitest';
 import {NotificationType} from '../../models/notification';
 import type {StepData} from '../../models/steps';
 import {computeValidationNotifications} from '../computeValidationNotifications';
-import {VALIDATION_RULES} from '../validation-rules';
+import {GRAPH_VALIDATION_RULES, VALIDATION_RULES} from '../validation-rules';
 
 // Simple mock t function that returns the key
 const t = vi.fn((key: string) => key) as unknown as import('i18next').TFunction;
@@ -518,6 +518,73 @@ describe('computeValidationNotifications', () => {
 
       const notification = result.get('btn-1_REQUIRED_FIELD_ERROR')!;
       expect(notification.hasResource('btn-1')).toBe(true);
+    });
+  });
+
+  describe('SSO pairing rule', () => {
+    function createSsoCheckNode(id: string, checkpointRef?: string): Node {
+      return createNode({
+        id,
+        type: 'TASK_EXECUTION',
+        data: {
+          action: {type: 'EXECUTOR', executor: {name: 'SSOCheckExecutor'}},
+          ...(checkpointRef !== undefined ? {properties: {checkpointRef}} : {}),
+        } as unknown as StepData,
+      });
+    }
+
+    function createSessionNode(id: string): Node {
+      return createNode({
+        id,
+        type: 'TASK_EXECUTION',
+        data: {action: {type: 'EXECUTOR', executor: {name: 'SessionExecutor'}}} as unknown as StepData,
+      });
+    }
+
+    it('should not run graph rules by default (flow-type-specific opt-in)', () => {
+      const nodes = [createSsoCheckNode('sso_check_1'), createSessionNode('session_1')];
+
+      const result = computeValidationNotifications(nodes, VALIDATION_RULES, t);
+
+      expect(result.size).toBe(0);
+    });
+
+    it('should not report anything for a healthy pair', () => {
+      const nodes = [createSsoCheckNode('sso_check_1', 'session_1'), createSessionNode('session_1')];
+
+      const result = computeValidationNotifications(nodes, VALIDATION_RULES, t, GRAPH_VALIDATION_RULES);
+
+      expect(result.size).toBe(0);
+    });
+
+    it('should report an SSO check with a missing checkpointRef', () => {
+      const nodes = [createSsoCheckNode('sso_check_1'), createSessionNode('session_1')];
+
+      const result = computeValidationNotifications(nodes, VALIDATION_RULES, t, GRAPH_VALIDATION_RULES);
+
+      expect(result.has('sso_check_1_SSO_MISSING_CHECKPOINT_REF')).toBe(true);
+      expect(result.get('sso_check_1_SSO_MISSING_CHECKPOINT_REF')!.getType()).toBe(NotificationType.ERROR);
+      // The session is unreferenced as a consequence.
+      expect(result.has('session_1_SSO_ORPHAN_SESSION')).toBe(true);
+    });
+
+    it('should report an SSO check whose checkpointRef points to a deleted session', () => {
+      const nodes = [createSsoCheckNode('sso_check_1', 'session_gone')];
+
+      const result = computeValidationNotifications(nodes, VALIDATION_RULES, t, GRAPH_VALIDATION_RULES);
+
+      expect(result.has('sso_check_1_SSO_INVALID_CHECKPOINT_REF')).toBe(true);
+    });
+
+    it('should report a session node not referenced by any SSO check', () => {
+      const nodes = [createSessionNode('session_1')];
+
+      const result = computeValidationNotifications(nodes, VALIDATION_RULES, t, GRAPH_VALIDATION_RULES);
+
+      expect(result.has('session_1_SSO_ORPHAN_SESSION')).toBe(true);
+      const notification = result.get('session_1_SSO_ORPHAN_SESSION')!;
+      expect(notification.getType()).toBe(NotificationType.ERROR);
+      expect(notification.hasResource('session_1')).toBe(true);
     });
   });
 });

--- a/frontend/apps/console/src/features/flows/validation/computeValidationNotifications.ts
+++ b/frontend/apps/console/src/features/flows/validation/computeValidationNotifications.ts
@@ -21,7 +21,7 @@ import type {TFunction} from 'i18next';
 import get from 'lodash-es/get';
 import {createElement, type ReactElement} from 'react';
 import {Trans} from 'react-i18next';
-import type {RequiredFieldRule, ValidationRuleDefinition} from './validation-rules';
+import type {GraphValidationRule, RequiredFieldRule, ValidationRuleDefinition} from './validation-rules';
 import ValidationConstants from '../constants/ValidationConstants';
 import type {Element} from '../models/elements';
 import Notification, {NotificationType} from '../models/notification';
@@ -150,12 +150,16 @@ function walkElements(
  * @param nodes - All React Flow nodes in the current flow.
  * @param rules - The validation rule registry.
  * @param t     - i18next translate function.
+ * @param graphRules - Cross-node rules applied against the whole node set.
+ *                     Empty by default; the host registers the rules that
+ *                     apply to the current flow type.
  * @returns A map of notification ID → Notification.
  */
 export function computeValidationNotifications(
   nodes: Node[],
   rules: ValidationRuleDefinition[],
   t: TFunction,
+  graphRules: GraphValidationRule[] = [],
 ): Map<string, Notification> {
   const notifications = new Map<string, Notification>();
 
@@ -168,6 +172,12 @@ export function computeValidationNotifications(
     // Walk the element tree within each step.
     if (stepData?.components) {
       walkElements(stepData.components, rules, t, notifications);
+    }
+  }
+
+  for (const graphRule of graphRules) {
+    for (const notification of graphRule(nodes)) {
+      notifications.set(notification.getId(), notification);
     }
   }
 

--- a/frontend/apps/console/src/features/flows/validation/validation-rules.ts
+++ b/frontend/apps/console/src/features/flows/validation/validation-rules.ts
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import type {Node} from '@xyflow/react';
 import {createElement} from 'react';
 import {Trans} from 'react-i18next';
 import {ActionEventTypes, BlockTypes, ElementCategories, ElementTypes} from '../models/elements';
@@ -243,3 +244,87 @@ export const VALIDATION_RULES: ValidationRuleDefinition[] = [
     },
   },
 ];
+
+// ---------------------------------------------------------------------------
+// Graph Validation Rules (cross-node)
+// ---------------------------------------------------------------------------
+
+/**
+ * A validation rule that inspects the whole node set instead of a single
+ * resource, for constraints that span multiple nodes.
+ */
+export type GraphValidationRule = (nodes: Node[]) => Notification[];
+
+function getNodeExecutorName(node: Node): string | undefined {
+  return (node.data as StepData | undefined)?.action?.executor?.name;
+}
+
+function createGraphErrorNotification(errorId: string, i18nKey: string, node: Node): Notification {
+  const message = createElement(Trans, {
+    i18nKey,
+    values: {id: node.id},
+    components: {code: createElement('code')},
+  });
+  const notification = new Notification(errorId, message, NotificationType.ERROR);
+
+  notification.addResource(node as unknown as Resource);
+
+  return notification;
+}
+
+/**
+ * Mirrors the backend SSO pairing contract: every SSO check must reference an
+ * existing session node via `checkpointRef`, and every session node must be
+ * referenced by at least one SSO check. Surfaces hand-deleting half of a pair
+ * immediately instead of at save time.
+ */
+export const ssoPairingRule: GraphValidationRule = (nodes: Node[]): Notification[] => {
+  const notifications: Notification[] = [];
+
+  const ssoCheckNodes = nodes.filter((node) => getNodeExecutorName(node) === ExecutionTypes.SSOCheck);
+  const sessionNodeIds = new Set(
+    nodes.filter((node) => getNodeExecutorName(node) === ExecutionTypes.Session).map((node) => node.id),
+  );
+
+  const referencedSessionIds = new Set<string>();
+
+  for (const node of ssoCheckNodes) {
+    const checkpointRef = (node.data as StepData | undefined)?.properties?.checkpointRef;
+
+    if (typeof checkpointRef !== 'string' || checkpointRef === '') {
+      notifications.push(
+        createGraphErrorNotification(
+          `${node.id}_SSO_MISSING_CHECKPOINT_REF`,
+          'flows:core.validation.sso.missingCheckpointRef',
+          node,
+        ),
+      );
+      continue;
+    }
+
+    if (!sessionNodeIds.has(checkpointRef)) {
+      notifications.push(
+        createGraphErrorNotification(
+          `${node.id}_SSO_INVALID_CHECKPOINT_REF`,
+          'flows:core.validation.sso.invalidCheckpointRef',
+          node,
+        ),
+      );
+      continue;
+    }
+
+    referencedSessionIds.add(checkpointRef);
+  }
+
+  for (const node of nodes) {
+    if (getNodeExecutorName(node) === ExecutionTypes.Session && !referencedSessionIds.has(node.id)) {
+      notifications.push(
+        createGraphErrorNotification(`${node.id}_SSO_ORPHAN_SESSION`, 'flows:core.validation.sso.orphanSession', node),
+      );
+    }
+  }
+
+  return notifications;
+};
+
+export const GRAPH_VALIDATION_RULES: GraphValidationRule[] = [ssoPairingRule];

--- a/frontend/apps/console/src/features/login-flow/components/LoginFlowBuilder.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/LoginFlowBuilder.tsx
@@ -26,6 +26,8 @@ import {useParams} from 'react-router';
 import '@xyflow/react/dist/style.css';
 import useGetLoginFlowBuilderResources from '../api/useGetLoginFlowBuilderResources';
 import {EXECUTOR_TO_IDP_TYPE_MAP} from '../components/resource-property-panel/extended-properties/execution-properties/constants';
+import SsoDisableConfirmDialog from '../components/SsoDisableConfirmDialog';
+import SsoToggle from '../components/SsoToggle';
 import LoginFlowConstants from '../constants/LoginFlowConstants';
 import useEdgeGeneration from '../hooks/useEdgeGeneration';
 import useElementAddition from '../hooks/useElementAddition';
@@ -34,6 +36,7 @@ import useFlowNaming from '../hooks/useFlowNaming';
 import useFlowSave from '../hooks/useFlowSave';
 import useNodeTypes from '../hooks/useNodeTypes';
 import useSnackbarNotifications from '../hooks/useSnackbarNotifications';
+import useSsoToggle from '../hooks/useSsoToggle';
 import useTemplateAndWidgetLoading from '../hooks/useTemplateAndWidgetLoading';
 import {mutateComponents} from '../utils/componentMutations';
 import GradientBorderButton from '@/features/applications/components/GradientBorderButton';
@@ -43,6 +46,7 @@ import useFlowConfig from '@/features/flows/hooks/useFlowConfig';
 import useFlowEvents from '@/features/flows/hooks/useFlowEvents';
 import useValidationStatus from '@/features/flows/hooks/useValidationStatus';
 import {ExecutionTypes, StepTypes, type StepData} from '@/features/flows/models/steps';
+import {GRAPH_VALIDATION_RULES} from '@/features/flows/validation/validation-rules';
 
 const SMS_EXECUTORS = new Set<string>([ExecutionTypes.SMSExecutor]);
 
@@ -53,7 +57,7 @@ function LoginFlowBuilder() {
   const {t} = useTranslation();
 
   const {data: resources} = useGetLoginFlowBuilderResources();
-  const {edgeStyle, isVerboseMode} = useFlowConfig();
+  const {edgeStyle, isVerboseMode, setGraphValidationRules} = useFlowConfig();
   const {triggerAutoLayout, onRestoreFromHistory, onElementAdded} = useFlowEvents();
   const {isValid: isFlowValid, setOpenValidationPanel} = useValidationStatus();
   const updateNodeInternals = useUpdateNodeInternals();
@@ -209,6 +213,14 @@ function LoginFlowBuilder() {
     updateNodeInternals,
   });
 
+  const flowType = (existingFlowData as {flowType?: string} | undefined)?.flowType ?? 'AUTHENTICATION';
+
+  // The SSO pairing rules only apply to AUTHENTICATION flows; other flow
+  // types run without graph-level rules.
+  useEffect(() => {
+    setGraphValidationRules(flowType === 'AUTHENTICATION' ? GRAPH_VALIDATION_RULES : []);
+  }, [flowType, setGraphValidationRules]);
+
   // Flow save hook
   const {handleSave} = useFlowSave({
     flowId,
@@ -216,10 +228,21 @@ function LoginFlowBuilder() {
     isFlowValid,
     flowName,
     flowHandle,
-    flowType: (existingFlowData as {flowType?: string} | undefined)?.flowType ?? 'AUTHENTICATION',
+    flowType,
     showError,
     showSuccess,
     setOpenValidationPanel,
+  });
+
+  // SSO toggle orchestration (enable/disable transformations, placement mode)
+  const sso = useSsoToggle({
+    nodes,
+    edges,
+    setNodes,
+    setEdges,
+    resources,
+    showInfo,
+    showSuccess,
   });
 
   const onNodesChange = defaultOnNodesChange;
@@ -273,11 +296,66 @@ function LoginFlowBuilder() {
     return edges.filter((edge) => !executionNodeIds.has(edge.source) && !executionNodeIds.has(edge.target));
   }, [edges, nodes, isVerboseMode]);
 
+  // While the SSO placement mode is active, spotlight the candidate join edges
+  // and dim the rest (same visual language as the simulation path decoration).
+  const displayEdges = useMemo(() => {
+    if (!sso.placement.active) {
+      return filteredEdges;
+    }
+    const candidateEdgeIds = new Set(sso.placement.candidateEdgeIds);
+    return filteredEdges.map((edge) => ({
+      ...edge,
+      className: candidateEdgeIds.has(edge.id) ? 'sso-placement-candidate' : 'sso-placement-dimmed',
+    }));
+  }, [filteredEdges, sso.placement]);
+
+  const isReadOnlyFlow = Boolean(existingFlowData?.isReadOnly);
+
+  // Memoized so the resource panel (which renders this as its footer and is
+  // itself memoized) is not re-rendered on unrelated graph changes like drags.
+  const ssoToggleFooter = useMemo(
+    () =>
+      flowType === 'AUTHENTICATION' ? (
+        <SsoToggle
+          ssoState={sso.ssoState}
+          joinResolution={sso.joinResolution}
+          placement={sso.placement}
+          isReadOnly={isReadOnlyFlow}
+          focusRequest={sso.focusRequest}
+          onFocusHandled={sso.clearFocusRequest}
+          onEnable={sso.handleEnable}
+          onDisableRequest={sso.handleDisableRequest}
+        />
+      ) : undefined,
+    [
+      flowType,
+      isReadOnlyFlow,
+      sso.ssoState,
+      sso.joinResolution,
+      sso.placement,
+      sso.focusRequest,
+      sso.clearFocusRequest,
+      sso.handleEnable,
+      sso.handleDisableRequest,
+    ],
+  );
+
   return (
     <Box
-      sx={{
+      sx={(theme) => ({
         width: '100%',
-      }}
+        ['& .react-flow__edge.sso-placement-candidate .react-flow__edge-path']: {
+          stroke: theme.palette.primary.main,
+          strokeWidth: 3,
+        },
+        ['& .react-flow__edge.sso-placement-candidate']: {
+          cursor: 'pointer',
+        },
+        ['& .react-flow__edge.sso-placement-dimmed']: {
+          opacity: 0.2,
+          pointerEvents: 'none',
+        },
+      })}
     >
       {existingFlowData?.isReadOnly && (
         <Alert severity="info" sx={{mb: 2}}>
@@ -295,16 +373,39 @@ function LoginFlowBuilder() {
         onResourceAdd={handleResourceAdd}
         onSave={existingFlowData?.isReadOnly ? undefined : handleSave}
         nodes={filteredNodes}
-        edges={filteredEdges}
+        edges={displayEdges}
         setNodes={setNodes}
         setEdges={setEdges}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
+        onEdgeClick={sso.handleEdgeClick}
         flowTitle={flowName}
         flowHandle={flowHandle}
         onFlowTitleChange={handleFlowNameChange}
         triggerAutoLayoutOnLoad={needsAutoLayout}
+        resourcePanelFooter={ssoToggleFooter}
       />
+      <SsoDisableConfirmDialog
+        open={sso.isConfirmDialogOpen}
+        checkpointCount={sso.ssoState.ssoCheckIds.length}
+        onClose={sso.handleCloseConfirmDialog}
+        onConfirm={sso.handleConfirmDisable}
+      />
+      <Snackbar open={sso.placement.active} anchorOrigin={{vertical: 'top', horizontal: 'center'}}>
+        <Alert severity="info" sx={{width: '100%', alignItems: 'center'}}>
+          <Stack direction="row" spacing={2} alignItems="center">
+            <span>
+              {t(
+                'flows:sso.placementHint',
+                'Click a highlighted connection to choose where the session checkpoint joins the flow.',
+              )}
+            </span>
+            <GradientBorderButton size="small" onClick={sso.handleCancelPlacement}>
+              {t('flows:sso.placementCancel', 'Cancel')}
+            </GradientBorderButton>
+          </Stack>
+        </Alert>
+      </Snackbar>
       <Snackbar
         open={errorSnackbar.open}
         autoHideDuration={6000}

--- a/frontend/apps/console/src/features/login-flow/components/SsoDisableConfirmDialog.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/SsoDisableConfirmDialog.tsx
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle} from '@wso2/oxygen-ui';
+import type {JSX} from 'react';
+import {useTranslation} from 'react-i18next';
+
+export interface SsoDisableConfirmDialogProps {
+  /**
+   * Whether the dialog is open.
+   */
+  open: boolean;
+  /**
+   * Number of SSO checkpoints that will be removed.
+   */
+  checkpointCount: number;
+  /**
+   * Callback when the dialog should be closed without removing anything.
+   */
+  onClose: () => void;
+  /**
+   * Callback when the user confirms the removal.
+   */
+  onConfirm: () => void;
+}
+
+/**
+ * Confirmation dialog shown before removing the SSO wiring from a login flow.
+ */
+export default function SsoDisableConfirmDialog({
+  open,
+  checkpointCount,
+  onClose,
+  onConfirm,
+}: SsoDisableConfirmDialogProps): JSX.Element {
+  const {t} = useTranslation();
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>{t('flows:sso.confirmDialog.title', 'Remove single sign-on?')}</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          {t('flows:sso.confirmDialog.description', {
+            count: checkpointCount,
+            defaultValue_one:
+              'This removes {{count}} SSO checkpoint and its session step, and reconnects the flow. Users will authenticate with their credentials every time.',
+            defaultValue_other:
+              'This removes {{count}} SSO checkpoints and their session steps, and reconnects the flow. Users will authenticate with their credentials every time.',
+          })}
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>{t('flows:sso.confirmDialog.cancelButton', 'Cancel')}</Button>
+        <Button onClick={onConfirm} color="error" variant="contained" data-testid="sso-disable-confirm-button">
+          {t('flows:sso.confirmDialog.confirmButton', 'Remove SSO')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/apps/console/src/features/login-flow/components/SsoToggle.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/SsoToggle.tsx
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Box, Stack, Switch, Tooltip, Typography} from '@wso2/oxygen-ui';
+import {ShieldCheck} from '@wso2/oxygen-ui-icons-react';
+import {useReactFlow, useUpdateNodeInternals} from '@xyflow/react';
+import {useEffect, type ReactElement} from 'react';
+import {useTranslation} from 'react-i18next';
+import type {SsoFocusRequest, SsoPlacementState} from '../hooks/useSsoToggle';
+import type {JoinResolution, SsoState} from '../utils/ssoGraphTransforms';
+import useInteractionState from '@/features/flows/hooks/useInteractionState';
+
+export interface SsoTogglePropsInterface {
+  ssoState: SsoState;
+  joinResolution: JoinResolution;
+  placement: SsoPlacementState;
+  isReadOnly: boolean;
+  focusRequest: SsoFocusRequest | null;
+  onFocusHandled: () => void;
+  onEnable: () => void;
+  onDisableRequest: () => void;
+}
+
+/**
+ * Resource panel row that enables or disables SSO for a login flow. The toggle
+ * state is derived from the graph, so template-created SSO flows read as
+ * enabled without any stored flag.
+ */
+function SsoToggle({
+  ssoState,
+  joinResolution,
+  placement,
+  isReadOnly,
+  focusRequest,
+  onFocusHandled,
+  onEnable,
+  onDisableRequest,
+}: SsoTogglePropsInterface): ReactElement {
+  const {t} = useTranslation();
+  const {fitView} = useReactFlow();
+  const updateNodeInternals = useUpdateNodeInternals();
+  const {setLastInteractedResource, setLastInteractedStepId} = useInteractionState();
+
+  // Select the freshly inserted SSO check (opening its properties panel) and
+  // focus it once the nodes have rendered.
+  useEffect(() => {
+    if (!focusRequest) {
+      return;
+    }
+    setLastInteractedStepId(focusRequest.ssoCheckId);
+    setLastInteractedResource(focusRequest.resource);
+    requestAnimationFrame(() => {
+      updateNodeInternals([focusRequest.ssoCheckId, focusRequest.sessionId]);
+      fitView({duration: 500, maxZoom: 1.2, nodes: [{id: focusRequest.ssoCheckId}], padding: 0.3}).catch(() => {
+        // Focusing is best-effort.
+      });
+    });
+    onFocusHandled();
+  }, [focusRequest, fitView, updateNodeInternals, setLastInteractedStepId, setLastInteractedResource, onFocusHandled]);
+
+  let disabledReason: string | null = null;
+  if (isReadOnly) {
+    disabledReason = t('flows:sso.disabledReadOnly', 'This flow is read-only and cannot be modified.');
+  } else if (!ssoState.enabled) {
+    if (joinResolution.status === 'no-entry') {
+      disabledReason = t('flows:sso.disabledNoEntry', 'Connect the Start step to a view step to enable SSO.');
+    } else if (joinResolution.status === 'entry-not-prompt') {
+      disabledReason = t(
+        'flows:sso.disabledEntryNotPrompt',
+        'To enable SSO, the flow must start with a view step. The SSO check needs a login screen to fall back to.',
+      );
+    } else if (joinResolution.status === 'no-assert') {
+      disabledReason = t(
+        'flows:sso.disabledNoAssert',
+        'Add an authentication completion step to the flow before enabling SSO.',
+      );
+    }
+  }
+
+  const isDisabled = Boolean(disabledReason) || placement.active;
+  const tooltip =
+    disabledReason ??
+    (ssoState.enabled
+      ? t('flows:sso.toggleTooltipOn', 'Single sign-on is active for this flow. Turn off to remove the SSO wiring.')
+      : '');
+
+  return (
+    <Tooltip title={tooltip} placement="right">
+      <Stack direction="row" alignItems="center" gap={1} sx={{width: '100%'}}>
+        <Box
+          component="span"
+          display="inline-flex"
+          alignItems="center"
+          sx={{flexShrink: 0, color: isDisabled ? 'text.disabled' : 'text.primary'}}
+        >
+          <ShieldCheck size={16} />
+        </Box>
+        <Stack direction="column" sx={{flex: 1, minWidth: 0}}>
+          <Typography variant="subtitle2" fontWeight={600} color={isDisabled ? 'text.disabled' : 'text.primary'}>
+            {t('flows:sso.toggleLabel', 'Enable SSO')}
+          </Typography>
+          <Typography variant="caption" color="text.secondary" sx={{lineHeight: 1.3}}>
+            {t('flows:sso.toggleDescription', 'Reuse an active session to skip sign-in')}
+          </Typography>
+        </Stack>
+        <Switch
+          size="small"
+          checked={ssoState.enabled}
+          disabled={isDisabled}
+          onChange={() => (ssoState.enabled ? onDisableRequest() : onEnable())}
+          data-testid="sso-toggle"
+          slotProps={{input: {'aria-label': t('flows:sso.toggleLabel', 'Enable SSO')}}}
+        />
+      </Stack>
+    </Tooltip>
+  );
+}
+
+export default SsoToggle;

--- a/frontend/apps/console/src/features/login-flow/components/__tests__/LoginFlowBuilder.test.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/__tests__/LoginFlowBuilder.test.tsx
@@ -54,6 +54,7 @@ const {
   getDefaultFlowConfigMock,
 } = vi.hoisted(() => {
   const setFlowCompletionConfigsFn = vi.fn();
+  const setGraphValidationRulesFn = vi.fn();
   const isVerboseModeObj = {value: true};
   const edgeStyleObj = {value: 'default'};
 
@@ -83,6 +84,7 @@ const {
       setFlowCompletionConfigs: setFlowCompletionConfigsFn,
       edgeStyle: edgeStyleObj.value,
       isVerboseMode: isVerboseModeObj.value,
+      setGraphValidationRules: setGraphValidationRulesFn,
     }),
   };
 });
@@ -469,6 +471,34 @@ vi.mock('@/features/flows/hooks/useFlowEvents', () => ({
 vi.mock('@/features/flows/hooks/useGenerateStepElement', () => ({
   default: () => ({
     generateStepElement: mockGenerateStepElement,
+  }),
+}));
+
+// Mock useInteractionState (used by useSsoToggle)
+vi.mock('@/features/flows/hooks/useInteractionState', () => ({
+  default: () => ({
+    lastInteractedResource: undefined,
+    lastInteractedStepId: '',
+    setLastInteractedResource: vi.fn(),
+    setLastInteractedStepId: vi.fn(),
+    onResourceDropOnCanvas: vi.fn(),
+    selectedAttributes: {},
+    setSelectedAttributes: vi.fn(),
+  }),
+}));
+
+// Mock useUIPanelState (used by useSsoToggle)
+vi.mock('@/features/flows/hooks/useUIPanelState', () => ({
+  default: () => ({
+    isResourcePanelOpen: true,
+    isResourcePropertiesPanelOpen: false,
+    isVersionHistoryPanelOpen: false,
+    resourcePropertiesPanelHeading: null,
+    setIsResourcePanelOpen: vi.fn(),
+    setIsOpenResourcePropertiesPanel: vi.fn(),
+    setIsVersionHistoryPanelOpen: vi.fn(),
+    setResourcePropertiesPanelHeading: vi.fn(),
+    registerCloseValidationPanel: vi.fn(),
   }),
 }));
 
@@ -3418,6 +3448,7 @@ describe('Edge Style Update Effect - Component Integration', () => {
     mockExistingFlowData.value = null;
     mockUseFlowConfig.mockReturnValue({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: 'default',
       isVerboseMode: true,
     });
@@ -3440,6 +3471,7 @@ describe('Edge Style Update Effect - Component Integration', () => {
   it('should update edge types when edgeStyle value changes', () => {
     mockUseFlowConfig.mockReturnValue({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: 'bezier',
       isVerboseMode: true,
     });
@@ -3466,6 +3498,7 @@ describe('StepsByType Ref Update Effect - Component Integration', () => {
     mockExistingFlowData.value = null;
     mockUseFlowConfig.mockReturnValue({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: 'default',
       isVerboseMode: true,
     });
@@ -3491,6 +3524,7 @@ describe('NodeTypes and StaticStepFactory Creation - Component Integration', () 
     mockExistingFlowData.value = null;
     mockUseFlowConfig.mockReturnValue({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: 'default',
       isVerboseMode: true,
     });
@@ -3516,6 +3550,7 @@ describe('Snackbar State Management - Close Handlers', () => {
     mockExistingFlowData.value = null;
     mockUseFlowConfig.mockReturnValue({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: 'default',
       isVerboseMode: true,
     });
@@ -4271,6 +4306,7 @@ describe('Edge Style Effect - setEdges Callback Execution', () => {
     mockExistingFlowData.value = null;
     mockUseFlowConfig.mockReturnValue({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: 'smoothstep',
       isVerboseMode: true,
     });
@@ -4349,6 +4385,7 @@ describe('Verbose Mode Filtering - Component Integration', () => {
 
     mockUseFlowConfig.mockReturnValue({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: 'default',
       isVerboseMode: true,
     });
@@ -5625,6 +5662,7 @@ describe('Verbose Mode Filtering Integration', () => {
     // Override the mock implementation
     mockUseFlowConfig.mockImplementation(() => ({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: mockEdgeStyle.value,
       isVerboseMode: false,
     }));
@@ -5657,6 +5695,7 @@ describe('Verbose Mode Filtering Integration', () => {
     // Override the mock implementation
     mockUseFlowConfig.mockImplementation(() => ({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: mockEdgeStyle.value,
       isVerboseMode: true,
     }));
@@ -5683,6 +5722,7 @@ describe('Snackbar Display and Close - Branch Coverage', () => {
     mockIsVerboseMode.value = true;
     mockUseFlowConfig.mockImplementation(() => ({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: mockEdgeStyle.value,
       isVerboseMode: true,
     }));
@@ -5893,6 +5933,7 @@ describe('Verbose Mode Filtering - Component Integration with Execution Nodes', 
     mockIsVerboseMode.value = false;
     mockUseFlowConfig.mockImplementation(() => ({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: mockEdgeStyle.value,
       isVerboseMode: false,
     }));
@@ -5924,6 +5965,7 @@ describe('Verbose Mode Filtering - Component Integration with Execution Nodes', 
     mockIsVerboseMode.value = true;
     mockUseFlowConfig.mockImplementation(() => ({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: mockEdgeStyle.value,
       isVerboseMode: true,
     }));
@@ -5957,6 +5999,7 @@ describe('Verbose Mode Filtering - Component Integration with Execution Nodes', 
     mockIsVerboseMode.value = false;
     mockUseFlowConfig.mockImplementation(() => ({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: mockEdgeStyle.value,
       isVerboseMode: false,
     }));
@@ -5981,6 +6024,7 @@ describe('isEditingExistingFlow Branch Coverage', () => {
     mockIsVerboseMode.value = true;
     mockUseFlowConfig.mockImplementation(() => ({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: mockEdgeStyle.value,
       isVerboseMode: true,
     }));
@@ -6079,6 +6123,7 @@ describe('Verbose Mode - Empty Arrays Edge Cases', () => {
     mockIsVerboseMode.value = false;
     mockUseFlowConfig.mockImplementation(() => ({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: mockEdgeStyle.value,
       isVerboseMode: false,
     }));
@@ -6102,6 +6147,7 @@ describe('Verbose Mode - Empty Arrays Edge Cases', () => {
     mockIsVerboseMode.value = false;
     mockUseFlowConfig.mockImplementation(() => ({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: mockEdgeStyle.value,
       isVerboseMode: false,
     }));
@@ -6127,6 +6173,7 @@ describe('Verbose Mode - Empty Arrays Edge Cases', () => {
     mockIsVerboseMode.value = false;
     mockUseFlowConfig.mockImplementation(() => ({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: mockEdgeStyle.value,
       isVerboseMode: false,
     }));
@@ -6151,6 +6198,7 @@ describe('Edge Style Effect - Branch Coverage', () => {
     mockIsVerboseMode.value = true;
     mockUseFlowConfig.mockImplementation(() => ({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: 'smoothstep',
       isVerboseMode: true,
     }));
@@ -6192,6 +6240,7 @@ describe('Snackbar onClose Handlers - Direct Coverage', () => {
     mockIsVerboseMode.value = true;
     mockUseFlowConfig.mockImplementation(() => ({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: mockEdgeStyle.value,
       isVerboseMode: true,
     }));
@@ -6269,6 +6318,7 @@ describe('Verbose Mode Node and Edge Filtering', () => {
     mockIsVerboseMode.value = false;
     mockUseFlowConfig.mockImplementation(() => ({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: mockEdgeStyle.value,
       isVerboseMode: false,
     }));
@@ -6287,6 +6337,7 @@ describe('Verbose Mode Node and Edge Filtering', () => {
     mockIsVerboseMode.value = false;
     mockUseFlowConfig.mockImplementation(() => ({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: mockEdgeStyle.value,
       isVerboseMode: false,
     }));
@@ -6312,6 +6363,7 @@ describe('Verbose Mode Node and Edge Filtering', () => {
     mockIsVerboseMode.value = false;
     mockUseFlowConfig.mockImplementation(() => ({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: mockEdgeStyle.value,
       isVerboseMode: false,
     }));
@@ -6337,6 +6389,7 @@ describe('Verbose Mode Node and Edge Filtering', () => {
     mockIsVerboseMode.value = false;
     mockUseFlowConfig.mockImplementation(() => ({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: mockEdgeStyle.value,
       isVerboseMode: false,
     }));
@@ -6357,6 +6410,7 @@ describe('Verbose Mode Node and Edge Filtering', () => {
     mockIsVerboseMode.value = true;
     mockUseFlowConfig.mockImplementation(() => ({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: mockEdgeStyle.value,
       isVerboseMode: true,
     }));
@@ -6375,6 +6429,7 @@ describe('Verbose Mode Node and Edge Filtering', () => {
     mockIsVerboseMode.value = true;
     mockUseFlowConfig.mockImplementation(() => ({
       setFlowCompletionConfigs: mockSetFlowCompletionConfigs,
+      setGraphValidationRules: vi.fn(),
       edgeStyle: mockEdgeStyle.value,
       isVerboseMode: true,
     }));

--- a/frontend/apps/console/src/features/login-flow/components/__tests__/SsoDisableConfirmDialog.test.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/__tests__/SsoDisableConfirmDialog.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {fireEvent, render, screen} from '@testing-library/react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import SsoDisableConfirmDialog from '../SsoDisableConfirmDialog';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: unknown) => {
+      if (typeof options === 'string') {
+        return options;
+      }
+      return key;
+    },
+  }),
+}));
+
+describe('SsoDisableConfirmDialog', () => {
+  const mockOnClose = vi.fn();
+  const mockOnConfirm = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render the dialog when open', () => {
+    render(<SsoDisableConfirmDialog open checkpointCount={1} onClose={mockOnClose} onConfirm={mockOnConfirm} />);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Remove single sign-on?')).toBeInTheDocument();
+  });
+
+  it('should not render dialog content when closed', () => {
+    render(
+      <SsoDisableConfirmDialog open={false} checkpointCount={1} onClose={mockOnClose} onConfirm={mockOnConfirm} />,
+    );
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should call onConfirm when the remove button is clicked', () => {
+    render(<SsoDisableConfirmDialog open checkpointCount={2} onClose={mockOnClose} onConfirm={mockOnConfirm} />);
+
+    fireEvent.click(screen.getByTestId('sso-disable-confirm-button'));
+
+    expect(mockOnConfirm).toHaveBeenCalledTimes(1);
+    expect(mockOnClose).not.toHaveBeenCalled();
+  });
+
+  it('should call onClose when the cancel button is clicked', () => {
+    render(<SsoDisableConfirmDialog open checkpointCount={1} onClose={mockOnClose} onConfirm={mockOnConfirm} />);
+
+    fireEvent.click(screen.getByText('Cancel'));
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+    expect(mockOnConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/apps/console/src/features/login-flow/components/__tests__/SsoToggle.test.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/__tests__/SsoToggle.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {fireEvent, render, screen} from '@testing-library/react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import type {SsoTogglePropsInterface} from '../SsoToggle';
+import SsoToggle from '../SsoToggle';
+import type {Resource} from '@/features/flows/models/resources';
+
+const mockFitView = vi.fn(() => Promise.resolve(true));
+const mockUpdateNodeInternals = vi.fn();
+const mockSetLastInteractedResource = vi.fn();
+const mockSetLastInteractedStepId = vi.fn();
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: unknown) => (typeof options === 'string' ? options : key),
+  }),
+}));
+
+vi.mock('@xyflow/react', () => ({
+  useReactFlow: () => ({fitView: mockFitView}),
+  useUpdateNodeInternals: () => mockUpdateNodeInternals,
+}));
+
+vi.mock('@/features/flows/hooks/useInteractionState', () => ({
+  default: () => ({
+    setLastInteractedResource: mockSetLastInteractedResource,
+    setLastInteractedStepId: mockSetLastInteractedStepId,
+  }),
+}));
+
+const baseProps: SsoTogglePropsInterface = {
+  focusRequest: null,
+  isReadOnly: false,
+  joinResolution: {joinNodeId: 'authorization_check', status: 'ok'},
+  onDisableRequest: vi.fn(),
+  onEnable: vi.fn(),
+  onFocusHandled: vi.fn(),
+  placement: {active: false, candidateEdgeIds: []},
+  ssoState: {enabled: false, ssoCheckIds: []},
+};
+
+function getSwitch(): HTMLInputElement {
+  return screen.getByTestId('sso-toggle').querySelector('input')!;
+}
+
+describe('SsoToggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render the label and description', () => {
+    render(<SsoToggle {...baseProps} />);
+
+    expect(screen.getByText('Enable SSO')).toBeInTheDocument();
+    expect(screen.getByText('Reuse an active session to skip sign-in')).toBeInTheDocument();
+  });
+
+  it('should call onEnable when toggled on', () => {
+    render(<SsoToggle {...baseProps} />);
+
+    fireEvent.click(getSwitch());
+
+    expect(baseProps.onEnable).toHaveBeenCalledTimes(1);
+    expect(baseProps.onDisableRequest).not.toHaveBeenCalled();
+  });
+
+  it('should call onDisableRequest when toggled off', () => {
+    render(<SsoToggle {...baseProps} ssoState={{enabled: true, ssoCheckIds: ['sso_check_1']}} />);
+
+    const toggle = getSwitch();
+    expect(toggle.checked).toBe(true);
+
+    fireEvent.click(toggle);
+
+    expect(baseProps.onDisableRequest).toHaveBeenCalledTimes(1);
+    expect(baseProps.onEnable).not.toHaveBeenCalled();
+  });
+
+  it.each([['no-entry' as const], ['entry-not-prompt' as const], ['no-assert' as const]])(
+    'should disable the toggle when the join resolution is %s',
+    (status) => {
+      render(<SsoToggle {...baseProps} joinResolution={{status}} />);
+
+      expect(getSwitch()).toBeDisabled();
+    },
+  );
+
+  it('should disable the toggle for read-only flows', () => {
+    render(<SsoToggle {...baseProps} isReadOnly />);
+
+    expect(getSwitch()).toBeDisabled();
+  });
+
+  it('should disable the toggle while placement mode is active', () => {
+    render(<SsoToggle {...baseProps} placement={{active: true, candidateEdgeIds: ['e1']}} />);
+
+    expect(getSwitch()).toBeDisabled();
+  });
+
+  it('should keep the toggle enabled when the join is ambiguous (placement mode entry)', () => {
+    render(
+      <SsoToggle
+        {...baseProps}
+        joinResolution={{candidateEdgeIds: ['e1'], candidateJoinNodeIds: ['a'], status: 'ambiguous'}}
+      />,
+    );
+
+    expect(getSwitch()).not.toBeDisabled();
+  });
+
+  it('should select and focus the inserted SSO check when a focus request arrives', () => {
+    const rafSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        callback(0);
+        return 0;
+      });
+    const onFocusHandled = vi.fn();
+    const resource = {id: 'sso_check_ab12'} as unknown as Resource;
+
+    render(
+      <SsoToggle
+        {...baseProps}
+        focusRequest={{resource, sessionId: 'session_ab12', ssoCheckId: 'sso_check_ab12'}}
+        onFocusHandled={onFocusHandled}
+      />,
+    );
+
+    expect(mockSetLastInteractedStepId).toHaveBeenCalledWith('sso_check_ab12');
+    expect(mockSetLastInteractedResource).toHaveBeenCalledWith(resource);
+    expect(mockUpdateNodeInternals).toHaveBeenCalledWith(['sso_check_ab12', 'session_ab12']);
+    expect(mockFitView).toHaveBeenCalledWith(expect.objectContaining({nodes: [{id: 'sso_check_ab12'}]}));
+    expect(onFocusHandled).toHaveBeenCalledTimes(1);
+
+    rafSpy.mockRestore();
+  });
+});

--- a/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/ExecutionExtendedProperties.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/ExecutionExtendedProperties.tsx
@@ -36,6 +36,7 @@ import PasskeyProperties from './execution-properties/PasskeyProperties';
 import PermissionValidatorProperties from './execution-properties/PermissionValidatorProperties';
 import ProvisioningProperties from './execution-properties/ProvisioningProperties';
 import SmsProperties from './execution-properties/SmsProperties';
+import SsoCheckProperties from './execution-properties/SsoCheckProperties';
 import UserTypeResolverProperties from './execution-properties/UserTypeResolverProperties';
 import type {CommonResourcePropertiesPropsInterface} from '@/features/flows/components/resource-property-panel/ResourceProperties';
 import type {FlowNodeInput} from '@/features/flows/models/responses';
@@ -126,8 +127,12 @@ function ExecutionExtendedProperties({resource, onChange}: ExecutionExtendedProp
     case ExecutionTypes.OpenID4VPVerify:
       executorSpecificProperties = <OpenID4VPProperties resource={resource} onChange={onChange} />;
       break;
+    case ExecutionTypes.SSOCheck:
+      executorSpecificProperties = <SsoCheckProperties resource={resource} onChange={onChange} />;
+      break;
     case ExecutionTypes.CredentialSetter:
     case ExecutionTypes.AttributeUniquenessValidator:
+    case ExecutionTypes.Session:
       executorSpecificProperties = <NoConfigProperties />;
       break;
     default:

--- a/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/execution-properties/SsoCheckProperties.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/execution-properties/SsoCheckProperties.tsx
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Alert, FormLabel, MenuItem, Select, Stack} from '@wso2/oxygen-ui';
+import {useMemo, type ReactNode} from 'react';
+import {useTranslation} from 'react-i18next';
+import type {CommonResourcePropertiesPropsInterface} from './types';
+import useFlowConfig from '@/features/flows/hooks/useFlowConfig';
+import type {StepData} from '@/features/flows/models/steps';
+import {isSessionNode} from '@/features/login-flow/utils/ssoGraphTransforms';
+
+/**
+ * Properties panel for the SSO check executor: a picker for the session
+ * checkpoint (`checkpointRef`) the check skips to when a live session exists.
+ */
+function SsoCheckProperties({resource, onChange}: CommonResourcePropertiesPropsInterface): ReactNode {
+  const {t} = useTranslation();
+  const {flowNodes} = useFlowConfig();
+
+  const checkpointRef = useMemo(() => {
+    const stepData = resource?.data as StepData | undefined;
+    return (stepData?.properties?.checkpointRef as string) ?? '';
+  }, [resource]);
+
+  const sessionNodes = useMemo(() => (flowNodes ?? []).filter(isSessionNode), [flowNodes]);
+
+  const isDangling = checkpointRef !== '' && !sessionNodes.some((node) => node.id === checkpointRef);
+
+  return (
+    <Stack gap={2}>
+      {isDangling && (
+        <Alert severity="warning">
+          {t(
+            'flows:sso.properties.checkpointDangling',
+            'The referenced session step no longer exists. Select a valid session step.',
+          )}
+        </Alert>
+      )}
+      <div>
+        <FormLabel htmlFor="sso-checkpoint-select">
+          {t('flows:sso.properties.checkpointLabel', 'Session checkpoint')}
+        </FormLabel>
+        <Select
+          id="sso-checkpoint-select"
+          value={sessionNodes.some((node) => node.id === checkpointRef) ? checkpointRef : ''}
+          onChange={(e) => onChange('data.properties.checkpointRef', e.target.value, resource)}
+          fullWidth
+        >
+          {sessionNodes.map((node) => {
+            const label = ((node.data as StepData | undefined)?.properties?.displayName as string) || node.id;
+            return (
+              <MenuItem key={node.id} value={node.id}>
+                {label}
+              </MenuItem>
+            );
+          })}
+        </Select>
+      </div>
+    </Stack>
+  );
+}
+
+export default SsoCheckProperties;

--- a/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/execution-properties/__tests__/SsoCheckProperties.test.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/execution-properties/__tests__/SsoCheckProperties.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type {Node} from '@xyflow/react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import SsoCheckProperties from '../SsoCheckProperties';
+import type {Resource} from '@/features/flows/models/resources';
+
+const {mockFlowNodes} = vi.hoisted(() => ({
+  mockFlowNodes: {value: [] as unknown[]},
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultValue?: string) => defaultValue ?? key,
+  }),
+}));
+
+vi.mock('@/features/flows/hooks/useFlowConfig', () => ({
+  default: () => ({flowNodes: mockFlowNodes.value}),
+}));
+
+function makeExecutionNode(id: string, executorName: string): Node {
+  return {
+    data: {action: {executor: {name: executorName}, type: 'EXECUTOR'}},
+    id,
+    position: {x: 0, y: 0},
+    type: 'TASK_EXECUTION',
+  };
+}
+
+function makeSsoCheckResource(checkpointRef: string): Resource {
+  return {
+    data: {
+      action: {executor: {name: 'SSOCheckExecutor'}, type: 'EXECUTOR'},
+      properties: {checkpointRef},
+    },
+    id: 'sso_check_1',
+  } as unknown as Resource;
+}
+
+describe('SsoCheckProperties', () => {
+  const mockOnChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFlowNodes.value = [
+      makeExecutionNode('session_1', 'SessionExecutor'),
+      makeExecutionNode('session_2', 'SessionExecutor'),
+      makeExecutionNode('credentials_auth', 'CredentialsAuthExecutor'),
+    ];
+  });
+
+  it('should render the checkpoint picker label', () => {
+    render(<SsoCheckProperties resource={makeSsoCheckResource('session_1')} onChange={mockOnChange} />);
+
+    expect(screen.getByText('Session checkpoint')).toBeInTheDocument();
+    expect(screen.queryByText(/no longer exists/)).not.toBeInTheDocument();
+  });
+
+  it('should list only session nodes as options and report a selection', async () => {
+    const user = userEvent.setup();
+    render(<SsoCheckProperties resource={makeSsoCheckResource('session_1')} onChange={mockOnChange} />);
+
+    await user.click(screen.getByRole('combobox'));
+
+    expect(screen.getByRole('option', {name: 'session_2'})).toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'credentials_auth'})).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('option', {name: 'session_2'}));
+
+    expect(mockOnChange).toHaveBeenCalledWith('data.properties.checkpointRef', 'session_2', expect.anything());
+  });
+
+  it('should warn when the referenced session step no longer exists', () => {
+    render(<SsoCheckProperties resource={makeSsoCheckResource('session_gone')} onChange={mockOnChange} />);
+
+    expect(
+      screen.getByText('The referenced session step no longer exists. Select a valid session step.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/execution-properties/constants.ts
+++ b/frontend/apps/console/src/features/login-flow/components/resource-property-panel/extended-properties/execution-properties/constants.ts
@@ -141,4 +141,6 @@ export const EXECUTORS_WITH_FIXED_INPUTS = new Set<string>([
   ExecutionTypes.OIDCAuthExecutor,
   ExecutionTypes.ConsentExecutor,
   ExecutionTypes.OpenID4VPVerify,
+  ExecutionTypes.SSOCheck,
+  ExecutionTypes.Session,
 ]);

--- a/frontend/apps/console/src/features/login-flow/hooks/__tests__/useSsoToggle.test.tsx
+++ b/frontend/apps/console/src/features/login-flow/hooks/__tests__/useSsoToggle.test.tsx
@@ -1,0 +1,353 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {act, renderHook} from '@testing-library/react';
+import type {Edge, Node} from '@xyflow/react';
+import type {MouseEvent as ReactMouseEvent} from 'react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import useSsoToggle from '../useSsoToggle';
+import type {Resources} from '@/features/flows/models/resources';
+import {ExecutionTypes, StaticStepTypes, StepTypes} from '@/features/flows/models/steps';
+
+const {mockFlowConfig, mockSetIsVerboseMode, mockInteractionState, mockSetIsOpenResourcePropertiesPanel} = vi.hoisted(
+  () => {
+    const setIsVerboseMode = vi.fn();
+    return {
+      mockFlowConfig: {edgeStyle: 'default', isVerboseMode: true, setIsVerboseMode},
+      mockInteractionState: {lastInteractedResource: undefined as unknown, lastInteractedStepId: ''},
+      mockSetIsOpenResourcePropertiesPanel: vi.fn(),
+      mockSetIsVerboseMode: setIsVerboseMode,
+    };
+  },
+);
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: unknown) => (typeof options === 'string' ? options : key),
+  }),
+}));
+
+vi.mock('@/features/flows/hooks/useFlowConfig', () => ({
+  default: () => mockFlowConfig,
+}));
+
+vi.mock('@/features/flows/hooks/useInteractionState', () => ({
+  default: () => mockInteractionState,
+}));
+
+vi.mock('@/features/flows/hooks/useUIPanelState', () => ({
+  default: () => ({
+    setIsOpenResourcePropertiesPanel: mockSetIsOpenResourcePropertiesPanel,
+  }),
+}));
+
+const resources = {
+  executors: [
+    {
+      data: {action: {executor: {name: ExecutionTypes.SSOCheck}, onFailure: '', onSuccess: '', type: 'EXECUTOR'}},
+      display: {label: 'Check SSO Session'},
+      resourceType: 'STEP',
+      type: StepTypes.Execution,
+    },
+    {
+      data: {action: {executor: {name: ExecutionTypes.Session}, onSuccess: '', type: 'EXECUTOR'}},
+      display: {label: 'Save / Load Session'},
+      resourceType: 'STEP',
+      type: StepTypes.Execution,
+    },
+  ],
+} as unknown as Resources;
+
+function makeExecution(id: string, executorName: string): Node {
+  return {
+    data: {action: {executor: {name: executorName}, type: 'EXECUTOR'}},
+    id,
+    position: {x: 0, y: 0},
+    type: StepTypes.Execution,
+  };
+}
+
+function basicFlow(): {nodes: Node[]; edges: Edge[]} {
+  return {
+    edges: [
+      {id: 'start-to-prompt', source: 'start', sourceHandle: 'start_NEXT', target: 'prompt'},
+      {id: 'prompt-to-auth', source: 'prompt', sourceHandle: 'button_NEXT', target: 'credentials_auth'},
+      {
+        id: 'credentials_auth-to-assert',
+        source: 'credentials_auth',
+        sourceHandle: 'credentials_auth_NEXT',
+        target: 'auth_assert',
+      },
+      {id: 'assert-to-end', source: 'auth_assert', sourceHandle: 'auth_assert_NEXT', target: 'end'},
+    ],
+    nodes: [
+      {data: {}, id: 'start', position: {x: 0, y: 0}, type: StaticStepTypes.Start},
+      {data: {components: []}, id: 'prompt', position: {x: 200, y: 0}, type: StepTypes.View},
+      makeExecution('credentials_auth', 'CredentialsAuthExecutor'),
+      makeExecution('auth_assert', ExecutionTypes.AuthAssert),
+      {data: {}, id: 'end', position: {x: 900, y: 0}, type: StepTypes.End},
+    ],
+  };
+}
+
+function renderSsoToggle(overrides: {nodes?: Node[]; edges?: Edge[]} = {}) {
+  const {nodes, edges} = basicFlow();
+  const setNodes = vi.fn();
+  const setEdges = vi.fn();
+  const showInfo = vi.fn();
+  const showSuccess = vi.fn();
+
+  const hook = renderHook(() =>
+    useSsoToggle({
+      edges: overrides.edges ?? edges,
+      nodes: overrides.nodes ?? nodes,
+      resources,
+      setEdges,
+      setNodes,
+      showInfo,
+      showSuccess,
+    }),
+  );
+
+  return {hook, setEdges, setNodes, showInfo, showSuccess};
+}
+
+describe('useSsoToggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFlowConfig.isVerboseMode = true;
+    mockInteractionState.lastInteractedStepId = '';
+    mockInteractionState.lastInteractedResource = undefined;
+  });
+
+  it('should derive a disabled SSO state for a flow without SSO checks', () => {
+    const {hook} = renderSsoToggle();
+
+    expect(hook.result.current.ssoState).toEqual({enabled: false, ssoCheckIds: []});
+    expect(hook.result.current.joinResolution).toEqual({joinNodeId: 'auth_assert', status: 'ok'});
+  });
+
+  it('should insert the SSO pair, notify, and request focus on enable', () => {
+    const {hook, setNodes, setEdges, showInfo} = renderSsoToggle();
+
+    act(() => {
+      hook.result.current.handleEnable();
+    });
+
+    expect(setNodes).toHaveBeenCalledTimes(1);
+    expect(setEdges).toHaveBeenCalledTimes(1);
+    expect(showInfo).toHaveBeenCalledTimes(1);
+
+    const newNodes = setNodes.mock.calls[0][0] as Node[];
+    expect(newNodes.some((node) => node.id.startsWith('sso_check_'))).toBe(true);
+    expect(newNodes.some((node) => node.id.startsWith('session_'))).toBe(true);
+    expect(hook.result.current.focusRequest?.ssoCheckId).toMatch(/^sso_check_/);
+  });
+
+  it('should force verbose mode on before inserting when it is off', () => {
+    mockFlowConfig.isVerboseMode = false;
+    const {hook} = renderSsoToggle();
+
+    act(() => {
+      hook.result.current.handleEnable();
+    });
+
+    expect(mockSetIsVerboseMode).toHaveBeenCalledWith(true);
+  });
+
+  it('should clear the focus request', () => {
+    const {hook} = renderSsoToggle();
+
+    act(() => {
+      hook.result.current.handleEnable();
+    });
+    expect(hook.result.current.focusRequest).not.toBeNull();
+
+    act(() => {
+      hook.result.current.clearFocusRequest();
+    });
+    expect(hook.result.current.focusRequest).toBeNull();
+  });
+
+  describe('ambiguous join (placement mode)', () => {
+    function ambiguousFlow(): {nodes: Node[]; edges: Edge[]} {
+      const {nodes, edges} = basicFlow();
+      return {
+        edges: [
+          ...edges,
+          {id: 'prompt-to-assert2', source: 'prompt', sourceHandle: 'other_NEXT', target: 'auth_assert_2'},
+        ],
+        nodes: [...nodes, makeExecution('auth_assert_2', ExecutionTypes.AuthAssert)],
+      };
+    }
+
+    it('should enter placement mode instead of guessing', () => {
+      const {hook, setNodes} = renderSsoToggle(ambiguousFlow());
+
+      act(() => {
+        hook.result.current.handleEnable();
+      });
+
+      expect(setNodes).not.toHaveBeenCalled();
+      expect(hook.result.current.placement.active).toBe(true);
+      expect(hook.result.current.placement.candidateEdgeIds.length).toBeGreaterThan(0);
+    });
+
+    it('should apply the enable transformation when a candidate edge is clicked', () => {
+      const {hook, setNodes} = renderSsoToggle(ambiguousFlow());
+
+      act(() => {
+        hook.result.current.handleEnable();
+      });
+      const [candidateEdgeId] = hook.result.current.placement.candidateEdgeIds;
+
+      act(() => {
+        hook.result.current.handleEdgeClick(
+          {} as ReactMouseEvent,
+          {
+            id: candidateEdgeId,
+            source: 'credentials_auth',
+            target: 'auth_assert',
+          } as Edge,
+        );
+      });
+
+      expect(setNodes).toHaveBeenCalledTimes(1);
+      expect(hook.result.current.placement.active).toBe(false);
+    });
+
+    it('should ignore clicks on non-candidate edges', () => {
+      const {hook, setNodes} = renderSsoToggle(ambiguousFlow());
+
+      act(() => {
+        hook.result.current.handleEnable();
+      });
+      act(() => {
+        hook.result.current.handleEdgeClick(
+          {} as ReactMouseEvent,
+          {
+            id: 'start-to-prompt',
+            source: 'start',
+            target: 'prompt',
+          } as Edge,
+        );
+      });
+
+      expect(setNodes).not.toHaveBeenCalled();
+      expect(hook.result.current.placement.active).toBe(true);
+    });
+
+    it('should cancel placement mode explicitly and via Escape', () => {
+      const {hook} = renderSsoToggle(ambiguousFlow());
+
+      act(() => {
+        hook.result.current.handleEnable();
+      });
+      act(() => {
+        hook.result.current.handleCancelPlacement();
+      });
+      expect(hook.result.current.placement.active).toBe(false);
+
+      act(() => {
+        hook.result.current.handleEnable();
+      });
+      act(() => {
+        window.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape'}));
+      });
+      expect(hook.result.current.placement.active).toBe(false);
+    });
+  });
+
+  describe('disable', () => {
+    function ssoFlow(): {nodes: Node[]; edges: Edge[]} {
+      const ssoCheck = makeExecution('sso_check_1', ExecutionTypes.SSOCheck);
+      ssoCheck.data = {...ssoCheck.data, properties: {checkpointRef: 'session_1'}};
+      const {nodes, edges} = basicFlow();
+      return {
+        edges: [
+          {id: 'start-to-check', source: 'start', sourceHandle: 'start_NEXT', target: 'sso_check_1'},
+          {id: 'check-to-session', source: 'sso_check_1', sourceHandle: 'sso_check_1_NEXT', target: 'session_1'},
+          {id: 'check-fail-to-prompt', source: 'sso_check_1', sourceHandle: 'failure', target: 'prompt'},
+          {id: 'session-to-assert', source: 'session_1', sourceHandle: 'session_1_NEXT', target: 'auth_assert'},
+          ...edges.filter((edge) => edge.id !== 'start-to-prompt' && edge.id !== 'credentials_auth-to-assert'),
+          {
+            id: 'auth-to-session',
+            source: 'credentials_auth',
+            sourceHandle: 'credentials_auth_NEXT',
+            target: 'session_1',
+          },
+        ],
+        nodes: [...nodes, ssoCheck, makeExecution('session_1', ExecutionTypes.Session)],
+      };
+    }
+
+    it('should open and close the confirmation dialog', () => {
+      const {hook} = renderSsoToggle(ssoFlow());
+
+      act(() => {
+        hook.result.current.handleDisableRequest();
+      });
+      expect(hook.result.current.isConfirmDialogOpen).toBe(true);
+
+      act(() => {
+        hook.result.current.handleCloseConfirmDialog();
+      });
+      expect(hook.result.current.isConfirmDialogOpen).toBe(false);
+    });
+
+    it('should remove the SSO pair and notify on confirm', () => {
+      const {hook, setNodes, setEdges, showSuccess} = renderSsoToggle(ssoFlow());
+
+      act(() => {
+        hook.result.current.handleDisableRequest();
+      });
+      act(() => {
+        hook.result.current.handleConfirmDisable();
+      });
+
+      const remainingNodes = setNodes.mock.calls[0][0] as Node[];
+      expect(remainingNodes.some((node) => node.id === 'sso_check_1')).toBe(false);
+      expect(remainingNodes.some((node) => node.id === 'session_1')).toBe(false);
+      expect(setEdges).toHaveBeenCalledTimes(1);
+      expect(showSuccess).toHaveBeenCalledTimes(1);
+      expect(hook.result.current.isConfirmDialogOpen).toBe(false);
+    });
+
+    it('should close the properties panel when it shows a removed node', () => {
+      mockInteractionState.lastInteractedStepId = 'sso_check_1';
+      const {hook} = renderSsoToggle(ssoFlow());
+
+      act(() => {
+        hook.result.current.handleConfirmDisable();
+      });
+
+      expect(mockSetIsOpenResourcePropertiesPanel).toHaveBeenCalledWith(false);
+    });
+
+    it('should leave the properties panel open when it shows an unrelated node', () => {
+      mockInteractionState.lastInteractedStepId = 'prompt';
+      const {hook} = renderSsoToggle(ssoFlow());
+
+      act(() => {
+        hook.result.current.handleConfirmDisable();
+      });
+
+      expect(mockSetIsOpenResourcePropertiesPanel).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/apps/console/src/features/login-flow/hooks/useSsoToggle.ts
+++ b/frontend/apps/console/src/features/login-flow/hooks/useSsoToggle.ts
@@ -1,0 +1,322 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {Edge, Node} from '@xyflow/react';
+import type {Dispatch, MouseEvent as ReactMouseEvent, SetStateAction} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useTranslation} from 'react-i18next';
+import type {JoinResolution, SsoState} from '../utils/ssoGraphTransforms';
+import {
+  deriveSsoState,
+  disableSso,
+  enableSso,
+  findJoinCandidates,
+  isSessionNode,
+  isSsoCheckNode,
+} from '../utils/ssoGraphTransforms';
+import useFlowConfig from '@/features/flows/hooks/useFlowConfig';
+import useInteractionState from '@/features/flows/hooks/useInteractionState';
+import useUIPanelState from '@/features/flows/hooks/useUIPanelState';
+import type {Resource, Resources} from '@/features/flows/models/resources';
+import {ResourceTypes} from '@/features/flows/models/resources';
+import type {Step, StepData} from '@/features/flows/models/steps';
+import {ExecutionTypes, StepCategories} from '@/features/flows/models/steps';
+import {resolveCollisions} from '@/features/flows/utils/resolveCollisions';
+
+export interface SsoPlacementState {
+  active: boolean;
+  candidateEdgeIds: string[];
+}
+
+export interface SsoFocusRequest {
+  ssoCheckId: string;
+  sessionId: string;
+  /** Resource descriptor of the inserted SSO check, for selection and opening its properties panel. */
+  resource: Resource;
+}
+
+export interface UseSsoToggleProps {
+  nodes: Node[];
+  edges: Edge[];
+  setNodes: Dispatch<SetStateAction<Node[]>>;
+  setEdges: Dispatch<SetStateAction<Edge[]>>;
+  resources: Resources;
+  showInfo: (message: string) => void;
+  showSuccess: (message: string) => void;
+}
+
+export interface UseSsoToggleReturn {
+  ssoState: SsoState;
+  joinResolution: JoinResolution;
+  placement: SsoPlacementState;
+  isConfirmDialogOpen: boolean;
+  focusRequest: SsoFocusRequest | null;
+  clearFocusRequest: () => void;
+  handleEnable: () => void;
+  handleDisableRequest: () => void;
+  handleConfirmDisable: () => void;
+  handleCloseConfirmDialog: () => void;
+  handleCancelPlacement: () => void;
+  handleEdgeClick: (event: ReactMouseEvent, edge: Edge) => void;
+}
+
+const INACTIVE_PLACEMENT: SsoPlacementState = {active: false, candidateEdgeIds: []};
+
+function findExecutorResource(resources: Resources, executorName: string): Step | undefined {
+  return resources.executors?.find(
+    (executor) => (executor.data as StepData | undefined)?.action?.executor?.name === executorName,
+  );
+}
+
+/**
+ * Builds the resource descriptor for a freshly inserted execution node so it
+ * can be selected and its properties panel opened (same shape the Execution
+ * node component passes on click).
+ */
+function toExecutionResource(node: Node): Resource {
+  const data = node.data as StepData & {display?: {label?: string; image?: string}};
+  return {
+    category: StepCategories.Workflow,
+    data,
+    display: {
+      image: data.display?.image ?? '',
+      label: data.display?.label ?? '',
+    },
+    id: node.id,
+    resourceType: ResourceTypes.Step,
+    type: 'EXECUTION',
+  } as unknown as Resource;
+}
+
+/**
+ * Orchestrates the "Enable SSO" toggle for login flows: derives the toggle
+ * state from the graph, runs the enable/disable transformations, and manages
+ * the interactive placement mode used when the join point is ambiguous.
+ */
+const useSsoToggle = ({
+  nodes,
+  edges,
+  setNodes,
+  setEdges,
+  resources,
+  showInfo,
+  showSuccess,
+}: UseSsoToggleProps): UseSsoToggleReturn => {
+  const {t} = useTranslation();
+  const {edgeStyle, isVerboseMode, setIsVerboseMode} = useFlowConfig();
+  const {lastInteractedResource, lastInteractedStepId} = useInteractionState();
+  const {setIsOpenResourcePropertiesPanel} = useUIPanelState();
+
+  const [placement, setPlacement] = useState<SsoPlacementState>(INACTIVE_PLACEMENT);
+  const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState<boolean>(false);
+  const [focusRequest, setFocusRequest] = useState<SsoFocusRequest | null>(null);
+
+  // The graph is read through a ref inside the handlers so their identity
+  // stays stable across node-drag ticks.
+  const graphRef = useRef<{nodes: Node[]; edges: Edge[]}>({edges, nodes});
+  useEffect(() => {
+    graphRef.current = {edges, nodes};
+  }, [nodes, edges]);
+
+  // The derivation only depends on the graph structure, never on node
+  // positions, so it is keyed on a cheap structural signature: drag ticks
+  // (position-only changes) cost one string build here instead of the full
+  // derive-and-serialize, and the derived object identity stays stable so
+  // the memoized toggle UI doesn't re-render for equivalent graphs.
+  const structuralSignature = useMemo(() => {
+    let signature = '';
+    for (const node of nodes) {
+      signature += `${node.id}|${node.type ?? ''}|${(node.data as StepData | undefined)?.action?.executor?.name ?? ''};`;
+    }
+    for (const edge of edges) {
+      signature += `${edge.id}|${edge.source}|${edge.sourceHandle ?? ''}|${edge.target};`;
+    }
+    return signature;
+  }, [nodes, edges]);
+
+  const {ssoState, joinResolution} = useMemo(
+    () => ({joinResolution: findJoinCandidates(nodes, edges), ssoState: deriveSsoState(nodes)}),
+    // The signature captures every structural input of the derivation.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [structuralSignature],
+  );
+
+  const ssoResources = useMemo(() => {
+    const ssoCheck = findExecutorResource(resources, ExecutionTypes.SSOCheck);
+    const session = findExecutorResource(resources, ExecutionTypes.Session);
+    return ssoCheck && session ? {session, ssoCheck} : null;
+  }, [resources]);
+
+  const applyEnable = useCallback(
+    (joinNodeId?: string): void => {
+      if (!ssoResources) {
+        return;
+      }
+
+      const {nodes: currentNodes, edges: currentEdges} = graphRef.current;
+      const result = enableSso(currentNodes, currentEdges, ssoResources, edgeStyle, joinNodeId);
+      if (!result.newSsoCheckId || !result.newSessionId) {
+        return;
+      }
+
+      // Execution nodes are hidden in non-verbose mode; never mutate the graph invisibly.
+      if (!isVerboseMode) {
+        setIsVerboseMode(true);
+      }
+
+      const resolvedNodes = resolveCollisions(result.nodes, {
+        margin: 50,
+        maxIterations: 10,
+        overlapThreshold: 0.5,
+      });
+      setNodes(resolvedNodes);
+      setEdges(result.edges);
+      setPlacement(INACTIVE_PLACEMENT);
+
+      const insertedSsoCheck = result.nodes.find((node) => node.id === result.newSsoCheckId);
+      if (insertedSsoCheck) {
+        setFocusRequest({
+          resource: toExecutionResource(insertedSsoCheck),
+          sessionId: result.newSessionId,
+          ssoCheckId: result.newSsoCheckId,
+        });
+      }
+
+      showInfo(
+        t(
+          'flows:sso.enabledSnackbar',
+          'SSO enabled. A session check now runs after Start, and sessions are saved before the flow completes.',
+        ),
+      );
+    },
+    [ssoResources, edgeStyle, isVerboseMode, setIsVerboseMode, setNodes, setEdges, showInfo, t],
+  );
+
+  const handleEnable = useCallback((): void => {
+    if (ssoState.enabled) {
+      return;
+    }
+
+    if (joinResolution.status === 'ok') {
+      applyEnable();
+      return;
+    }
+
+    if (joinResolution.status === 'ambiguous') {
+      // The candidate edges enter execution nodes, which non-verbose mode
+      // hides; force verbose mode so the highlights are actually visible.
+      if (!isVerboseMode) {
+        setIsVerboseMode(true);
+      }
+      // Don't guess the join point; let the user click one of the candidate edges.
+      setPlacement({active: true, candidateEdgeIds: joinResolution.candidateEdgeIds});
+    }
+  }, [ssoState.enabled, joinResolution, applyEnable, isVerboseMode, setIsVerboseMode]);
+
+  const handleDisableRequest = useCallback((): void => {
+    if (ssoState.enabled) {
+      setIsConfirmDialogOpen(true);
+    }
+  }, [ssoState.enabled]);
+
+  const handleConfirmDisable = useCallback((): void => {
+    const {nodes: currentNodes, edges: currentEdges} = graphRef.current;
+    const result = disableSso(currentNodes, currentEdges);
+
+    // Close the properties panel when it is showing one of the removed nodes,
+    // so it doesn't linger with a stale, dangling-reference view.
+    const removedIds = new Set(
+      currentNodes.filter((node) => isSsoCheckNode(node) || isSessionNode(node)).map((node) => node.id),
+    );
+    if (removedIds.has(lastInteractedStepId) || removedIds.has(lastInteractedResource?.id ?? '')) {
+      setIsOpenResourcePropertiesPanel(false);
+    }
+
+    setNodes(result.nodes);
+    setEdges(result.edges);
+    setIsConfirmDialogOpen(false);
+    showSuccess(
+      t('flows:sso.disabledSnackbar', {
+        count: result.removedCount,
+        defaultValue_one: 'SSO disabled. {{count}} checkpoint was removed and the flow reconnected.',
+        defaultValue_other: 'SSO disabled. {{count}} checkpoints were removed and the flow reconnected.',
+      }),
+    );
+  }, [
+    lastInteractedStepId,
+    lastInteractedResource,
+    setIsOpenResourcePropertiesPanel,
+    setNodes,
+    setEdges,
+    showSuccess,
+    t,
+  ]);
+
+  const handleCloseConfirmDialog = useCallback((): void => {
+    setIsConfirmDialogOpen(false);
+  }, []);
+
+  const handleCancelPlacement = useCallback((): void => {
+    setPlacement(INACTIVE_PLACEMENT);
+  }, []);
+
+  const handleEdgeClick = useCallback(
+    (_event: ReactMouseEvent, edge: Edge): void => {
+      if (!placement.active || !placement.candidateEdgeIds.includes(edge.id)) {
+        return;
+      }
+      applyEnable(edge.target);
+    },
+    [placement, applyEnable],
+  );
+
+  const clearFocusRequest = useCallback((): void => {
+    setFocusRequest(null);
+  }, []);
+
+  // Esc cancels placement mode.
+  useEffect(() => {
+    if (!placement.active) {
+      return undefined;
+    }
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') {
+        setPlacement(INACTIVE_PLACEMENT);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [placement.active]);
+
+  return {
+    clearFocusRequest,
+    focusRequest,
+    handleCancelPlacement,
+    handleCloseConfirmDialog,
+    handleConfirmDisable,
+    handleDisableRequest,
+    handleEdgeClick,
+    handleEnable,
+    isConfirmDialogOpen,
+    joinResolution,
+    placement,
+    ssoState,
+  };
+};
+
+export default useSsoToggle;

--- a/frontend/apps/console/src/features/login-flow/utils/__tests__/ssoGraphTransforms.test.ts
+++ b/frontend/apps/console/src/features/login-flow/utils/__tests__/ssoGraphTransforms.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {Edge, Node} from '@xyflow/react';
+import {describe, expect, it} from 'vitest';
+import {deriveSsoState, disableSso, enableSso, findJoinCandidates} from '../ssoGraphTransforms';
+import type {Step} from '@/features/flows/models/steps';
+import {ExecutionTypes, StaticStepTypes, StepTypes} from '@/features/flows/models/steps';
+
+const ssoCheckResource = {
+  category: 'EXECUTOR',
+  data: {
+    action: {
+      executor: {name: ExecutionTypes.SSOCheck},
+      onFailure: '',
+      onSuccess: '',
+      type: 'EXECUTOR',
+    },
+  },
+  display: {header: 'SSO Check Executor', label: 'Check SSO Session'},
+  resourceType: 'STEP',
+  type: StepTypes.Execution,
+} as unknown as Step;
+
+const sessionResource = {
+  category: 'EXECUTOR',
+  data: {
+    action: {
+      executor: {name: ExecutionTypes.Session},
+      onSuccess: '',
+      type: 'EXECUTOR',
+    },
+  },
+  display: {header: 'Session Executor', label: 'Save / Load Session'},
+  resourceType: 'STEP',
+  type: StepTypes.Execution,
+} as unknown as Step;
+
+const ssoResources = {session: sessionResource, ssoCheck: ssoCheckResource};
+
+function makeStart(id = 'start'): Node {
+  return {data: {displayOnly: true}, id, position: {x: 0, y: 400}, type: StaticStepTypes.Start};
+}
+
+function makeView(id: string, x = 300): Node {
+  return {data: {components: []}, id, position: {x, y: 400}, type: StepTypes.View};
+}
+
+function makeExecution(id: string, executorName: string, x = 600): Node {
+  return {
+    data: {action: {executor: {name: executorName}, type: 'EXECUTOR'}},
+    id,
+    position: {x, y: 400},
+    type: StepTypes.Execution,
+  };
+}
+
+function makeEnd(id = 'end'): Node {
+  return {data: {}, id, position: {x: 2000, y: 400}, type: StepTypes.End};
+}
+
+function successEdge(source: string, target: string, sourceHandle?: string): Edge {
+  return {
+    id: `${source}-to-${target}`,
+    source,
+    sourceHandle: sourceHandle ?? `${source}_NEXT`,
+    target,
+    type: 'default',
+  };
+}
+
+function failureEdge(source: string, target: string): Edge {
+  return {id: `${source}-failure-to-${target}`, source, sourceHandle: 'failure', target, type: 'default'};
+}
+
+/**
+ * BASIC-template shaped canvas:
+ * start -> prompt -> credentials_auth -> authorization -> assert -> end
+ */
+function basicFlow(): {nodes: Node[]; edges: Edge[]} {
+  return {
+    edges: [
+      successEdge('start', 'prompt_credentials', 'start_NEXT'),
+      successEdge('prompt_credentials', 'credentials_auth', 'submit_button_NEXT'),
+      successEdge('credentials_auth', 'authorization_check'),
+      successEdge('authorization_check', 'auth_assert'),
+      successEdge('auth_assert', 'end'),
+    ],
+    nodes: [
+      makeStart(),
+      makeView('prompt_credentials'),
+      makeExecution('credentials_auth', 'CredentialsAuthExecutor', 700),
+      makeExecution('authorization_check', ExecutionTypes.Authorization, 1400),
+      makeExecution('auth_assert', ExecutionTypes.AuthAssert, 1700),
+      makeEnd(),
+    ],
+  };
+}
+
+/**
+ * BASIC_SSO-template shaped canvas (what a template-created flow loads as).
+ */
+function basicSsoFlow(): {nodes: Node[]; edges: Edge[]} {
+  const ssoCheck = makeExecution('sso_check', ExecutionTypes.SSOCheck, 200);
+  ssoCheck.data = {...ssoCheck.data, properties: {checkpointRef: 'session'}};
+  return {
+    edges: [
+      successEdge('start', 'sso_check', 'start_NEXT'),
+      successEdge('sso_check', 'session'),
+      failureEdge('sso_check', 'prompt_credentials'),
+      successEdge('prompt_credentials', 'credentials_auth', 'submit_button_NEXT'),
+      successEdge('credentials_auth', 'session'),
+      successEdge('session', 'authorization_check'),
+      successEdge('authorization_check', 'auth_assert'),
+      successEdge('auth_assert', 'end'),
+    ],
+    nodes: [
+      makeStart(),
+      ssoCheck,
+      makeView('prompt_credentials'),
+      makeExecution('credentials_auth', 'CredentialsAuthExecutor', 700),
+      makeExecution('session', ExecutionTypes.Session, 1100),
+      makeExecution('authorization_check', ExecutionTypes.Authorization, 1400),
+      makeExecution('auth_assert', ExecutionTypes.AuthAssert, 1700),
+      makeEnd(),
+    ],
+  };
+}
+
+function connectionTriples(edges: Edge[]): string[] {
+  return edges.map((edge) => `${edge.source}|${edge.sourceHandle ?? ''}|${edge.target}`).sort();
+}
+
+describe('deriveSsoState', () => {
+  it('reports disabled for a flow without SSO check nodes', () => {
+    const {nodes} = basicFlow();
+    expect(deriveSsoState(nodes)).toEqual({enabled: false, ssoCheckIds: []});
+  });
+
+  it('reports enabled for a template-created SSO flow', () => {
+    const {nodes} = basicSsoFlow();
+    expect(deriveSsoState(nodes)).toEqual({enabled: true, ssoCheckIds: ['sso_check']});
+  });
+});
+
+describe('findJoinCandidates', () => {
+  it('hops back from the assert to the authorization node feeding it', () => {
+    const {nodes, edges} = basicFlow();
+    expect(findJoinCandidates(nodes, edges)).toEqual({joinNodeId: 'authorization_check', status: 'ok'});
+  });
+
+  it('uses the assert node itself when no authorization executor feeds it', () => {
+    const {nodes, edges} = basicFlow();
+    const withoutAuthorization = nodes.filter((node) => node.id !== 'authorization_check');
+    const rewired = edges
+      .filter((edge) => edge.source !== 'authorization_check' && edge.target !== 'authorization_check')
+      .concat(successEdge('credentials_auth', 'auth_assert'));
+    expect(findJoinCandidates(withoutAuthorization, rewired)).toEqual({joinNodeId: 'auth_assert', status: 'ok'});
+  });
+
+  it('returns no-assert when the flow has no auth assert executor', () => {
+    const {nodes, edges} = basicFlow();
+    expect(
+      findJoinCandidates(
+        nodes.filter((node) => node.id !== 'auth_assert'),
+        edges,
+      ),
+    ).toEqual({
+      status: 'no-assert',
+    });
+  });
+
+  it('returns no-entry when start has no outgoing edge', () => {
+    const {nodes, edges} = basicFlow();
+    expect(
+      findJoinCandidates(
+        nodes,
+        edges.filter((edge) => edge.source !== 'start'),
+      ),
+    ).toEqual({status: 'no-entry'});
+  });
+
+  it('returns entry-not-prompt when start leads to an execution node', () => {
+    const {nodes, edges} = basicFlow();
+    const rewired = edges.map((edge) => (edge.source === 'start' ? {...edge, target: 'credentials_auth'} : edge));
+    expect(findJoinCandidates(nodes, rewired)).toEqual({status: 'entry-not-prompt'});
+  });
+
+  it('returns ambiguous with candidate edges when multiple asserts exist', () => {
+    const {nodes, edges} = basicFlow();
+    const secondAssert = makeExecution('auth_assert_2', ExecutionTypes.AuthAssert, 1700);
+    const withSecond = [...nodes, secondAssert];
+    const withEdges = [...edges, successEdge('prompt_credentials', 'auth_assert_2', 'other_button_NEXT')];
+
+    const resolution = findJoinCandidates(withSecond, withEdges);
+    expect(resolution).toEqual({
+      candidateEdgeIds: ['credentials_auth-to-authorization_check', 'prompt_credentials-to-auth_assert_2'],
+      candidateJoinNodeIds: ['authorization_check', 'auth_assert_2'],
+      status: 'ambiguous',
+    });
+  });
+});
+
+describe('enableSso', () => {
+  it('produces the BASIC_SSO topology from a BASIC flow', () => {
+    const {nodes, edges} = basicFlow();
+    const result = enableSso(nodes, edges, ssoResources, 'default');
+
+    expect(result.newSsoCheckId).toMatch(/^sso_check_[a-z0-9]{4}$/);
+    expect(result.newSessionId).toMatch(/^session_[a-z0-9]{4}$/);
+    // The pair shares an id suffix so the two nodes read as related.
+    expect(result.newSsoCheckId?.replace('sso_check_', '')).toBe(result.newSessionId?.replace('session_', ''));
+
+    const ssoCheckNode = result.nodes.find((node) => node.id === result.newSsoCheckId);
+    const sessionNode = result.nodes.find((node) => node.id === result.newSessionId);
+    expect((ssoCheckNode?.data as {properties?: {checkpointRef?: string}}).properties?.checkpointRef).toBe(
+      result.newSessionId,
+    );
+    expect((sessionNode?.data as {properties?: unknown}).properties).toBeUndefined();
+
+    expect(connectionTriples(result.edges)).toEqual(
+      connectionTriples([
+        successEdge('start', result.newSsoCheckId!, 'start_NEXT'),
+        successEdge(result.newSsoCheckId!, result.newSessionId!),
+        failureEdge(result.newSsoCheckId!, 'prompt_credentials'),
+        successEdge('prompt_credentials', 'credentials_auth', 'submit_button_NEXT'),
+        successEdge('credentials_auth', result.newSessionId!),
+        successEdge(result.newSessionId!, 'authorization_check'),
+        successEdge('authorization_check', 'auth_assert'),
+        successEdge('auth_assert', 'end'),
+      ]),
+    );
+
+    // No dangling endpoints.
+    const nodeIds = new Set(result.nodes.map((node) => node.id));
+    result.edges.forEach((edge) => {
+      expect(nodeIds.has(edge.source)).toBe(true);
+      expect(nodeIds.has(edge.target)).toBe(true);
+    });
+  });
+
+  it('preserves default executor properties when setting checkpointRef', () => {
+    const {nodes, edges} = basicFlow();
+    const ssoCheckWithDefaults = {
+      ...ssoCheckResource,
+      data: {...(ssoCheckResource as unknown as {data: object}).data, properties: {someDefault: 'value'}},
+    } as unknown as Step;
+
+    const result = enableSso(nodes, edges, {session: sessionResource, ssoCheck: ssoCheckWithDefaults}, 'default');
+
+    const ssoCheckNode = result.nodes.find((node) => node.id === result.newSsoCheckId);
+    expect((ssoCheckNode?.data as {properties?: Record<string, unknown>}).properties).toEqual({
+      checkpointRef: result.newSessionId,
+      someDefault: 'value',
+    });
+  });
+
+  it('is a no-op when SSO is already enabled', () => {
+    const {nodes, edges} = basicSsoFlow();
+    const result = enableSso(nodes, edges, ssoResources, 'default');
+    expect(result.nodes).toBe(nodes);
+    expect(result.edges).toBe(edges);
+    expect(result.newSsoCheckId).toBeNull();
+  });
+
+  it('honors an explicit join node from placement mode', () => {
+    const {nodes, edges} = basicFlow();
+    const result = enableSso(nodes, edges, ssoResources, 'default', 'auth_assert');
+
+    const triples = connectionTriples(result.edges);
+    expect(triples).toContain(`${result.newSessionId}|${result.newSessionId}_NEXT|auth_assert`);
+    expect(triples).toContain(`authorization_check|authorization_check_NEXT|${result.newSessionId}`);
+  });
+
+  it('retargets multiple fresh-path feeders of the join to the session node', () => {
+    const {nodes, edges} = basicFlow();
+    const otpAuth = makeExecution('otp_auth', 'OTPExecutor', 900);
+    const withOtp = [...nodes, otpAuth];
+    const withOtpEdges = [...edges, successEdge('otp_auth', 'authorization_check')];
+
+    const result = enableSso(withOtp, withOtpEdges, ssoResources, 'default');
+    const triples = connectionTriples(result.edges);
+    expect(triples).toContain(`credentials_auth|credentials_auth_NEXT|${result.newSessionId}`);
+    expect(triples).toContain(`otp_auth|otp_auth_NEXT|${result.newSessionId}`);
+  });
+});
+
+describe('disableSso', () => {
+  it('removes the pair and splices the flow back to the BASIC topology', () => {
+    const {nodes, edges} = basicSsoFlow();
+    const result = disableSso(nodes, edges);
+
+    expect(result.removedCount).toBe(1);
+    expect(result.nodes.map((node) => node.id).sort()).toEqual(
+      ['auth_assert', 'authorization_check', 'credentials_auth', 'end', 'prompt_credentials', 'start'].sort(),
+    );
+    expect(connectionTriples(result.edges)).toEqual(connectionTriples(basicFlow().edges));
+  });
+
+  it('round-trips: enable then disable restores the original connections', () => {
+    const {nodes, edges} = basicFlow();
+    const enabled = enableSso(nodes, edges, ssoResources, 'default');
+    const restored = disableSso(enabled.nodes, enabled.edges);
+
+    expect(connectionTriples(restored.edges)).toEqual(connectionTriples(edges));
+    expect(restored.nodes.map((node) => node.id).sort()).toEqual(nodes.map((node) => node.id).sort());
+  });
+
+  it('removes an orphaned session node left from a hand-deleted SSO check', () => {
+    const {nodes, edges} = basicSsoFlow();
+    const withoutCheck = nodes.filter((node) => node.id !== 'sso_check');
+    const withoutCheckEdges = edges.filter((edge) => edge.source !== 'sso_check' && edge.target !== 'sso_check');
+
+    const result = disableSso(withoutCheck, withoutCheckEdges);
+    expect(result.removedCount).toBe(0);
+    expect(result.nodes.some((node) => node.id === 'session')).toBe(false);
+    expect(connectionTriples(result.edges)).toContain('credentials_auth|credentials_auth_NEXT|authorization_check');
+  });
+
+  it('is a no-op on a flow without SSO wiring', () => {
+    const {nodes, edges} = basicFlow();
+    const result = disableSso(nodes, edges);
+    expect(result.removedCount).toBe(0);
+    expect(result.nodes).toBe(nodes);
+    expect(result.edges).toBe(edges);
+  });
+});

--- a/frontend/apps/console/src/features/login-flow/utils/ssoGraphTransforms.ts
+++ b/frontend/apps/console/src/features/login-flow/utils/ssoGraphTransforms.ts
@@ -1,0 +1,342 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {Edge, Node} from '@xyflow/react';
+import {MarkerType} from '@xyflow/react';
+import cloneDeep from 'lodash-es/cloneDeep';
+import VisualFlowConstants from '@/features/flows/constants/VisualFlowConstants';
+import type {Step, StepData} from '@/features/flows/models/steps';
+import {ExecutionTypes, StaticStepTypes, StepTypes} from '@/features/flows/models/steps';
+
+/**
+ * Pure graph transformations for the "Enable SSO" toggle.
+ *
+ * The transformations operate on React Flow nodes/edges (edges are the source
+ * of truth for connections, mirroring reactFlowTransformer) and must produce
+ * graphs that satisfy the backend pairing contract by construction:
+ * - `SSOCheckExecutor.properties.checkpointRef` references a `SessionExecutor` node id.
+ * - Every `SessionExecutor` node is referenced by at least one SSO check.
+ * - A TASK_EXECUTION node's failure branch may only target a PROMPT (View) node.
+ */
+
+export interface SsoState {
+  enabled: boolean;
+  ssoCheckIds: string[];
+}
+
+export type JoinResolution =
+  | {status: 'ok'; joinNodeId: string}
+  | {status: 'ambiguous'; candidateJoinNodeIds: string[]; candidateEdgeIds: string[]}
+  | {status: 'no-assert'}
+  | {status: 'entry-not-prompt'}
+  | {status: 'no-entry'};
+
+export interface EnableSsoResult {
+  nodes: Node[];
+  edges: Edge[];
+  newSsoCheckId: string | null;
+  newSessionId: string | null;
+}
+
+export interface DisableSsoResult {
+  nodes: Node[];
+  edges: Edge[];
+  removedCount: number;
+}
+
+const SSO_CHECK_ID_PREFIX = 'sso_check';
+const SESSION_ID_PREFIX = 'session';
+
+function getExecutorName(node: Node): string | undefined {
+  return (node.data as StepData | undefined)?.action?.executor?.name;
+}
+
+export function isSsoCheckNode(node: Node): boolean {
+  return node.type === StepTypes.Execution && getExecutorName(node) === ExecutionTypes.SSOCheck;
+}
+
+export function isSessionNode(node: Node): boolean {
+  return node.type === StepTypes.Execution && getExecutorName(node) === ExecutionTypes.Session;
+}
+
+/**
+ * Derives the toggle state from the graph: SSO is enabled iff the flow
+ * contains at least one SSO check node. Template-created SSO flows therefore
+ * read as enabled without any stored flag or migration.
+ */
+export function deriveSsoState(nodes: Node[]): SsoState {
+  const ssoCheckIds = nodes.filter(isSsoCheckNode).map((node) => node.id);
+  return {enabled: ssoCheckIds.length > 0, ssoCheckIds};
+}
+
+function findStartEdge(nodes: Node[], edges: Edge[]): Edge | undefined {
+  const startNode = nodes.find((node) => node.type === StaticStepTypes.Start);
+  if (!startNode) {
+    return undefined;
+  }
+  return edges.find((edge) => edge.source === startNode.id);
+}
+
+/**
+ * Resolves the join node for a given auth-assert node: the assert itself, or
+ * the AuthorizationExecutor immediately before it when that is its sole feeder.
+ */
+function resolveJoinForAssert(assertNode: Node, nodes: Node[], edges: Edge[]): string {
+  const incoming = edges.filter((edge) => edge.target === assertNode.id);
+  if (incoming.length === 1) {
+    const feeder = nodes.find((node) => node.id === incoming[0].source);
+    if (feeder && getExecutorName(feeder) === ExecutionTypes.Authorization) {
+      return feeder.id;
+    }
+  }
+  return assertNode.id;
+}
+
+/**
+ * Finds where the session checkpoint should join the flow. The join point is
+ * the authentication-complete boundary: the node feeding AuthAssertExecutor
+ * (or the AuthorizationExecutor immediately before it). When the heuristic
+ * cannot decide, it reports the ambiguity instead of guessing.
+ */
+export function findJoinCandidates(nodes: Node[], edges: Edge[]): JoinResolution {
+  const startEdge = findStartEdge(nodes, edges);
+  if (!startEdge) {
+    return {status: 'no-entry'};
+  }
+
+  const entryNode = nodes.find((node) => node.id === startEdge.target);
+  if (entryNode?.type !== StepTypes.View) {
+    // The SSO check's failure branch must target a PROMPT node (backend rule),
+    // so the flow has to start with a view step.
+    return {status: 'entry-not-prompt'};
+  }
+
+  const assertNodes = nodes.filter((node) => getExecutorName(node) === ExecutionTypes.AuthAssert);
+  if (assertNodes.length === 0) {
+    return {status: 'no-assert'};
+  }
+
+  const joinNodeIds = [...new Set(assertNodes.map((assertNode) => resolveJoinForAssert(assertNode, nodes, edges)))];
+  if (joinNodeIds.length === 1) {
+    return {status: 'ok', joinNodeId: joinNodeIds[0]};
+  }
+
+  const joinIdSet = new Set(joinNodeIds);
+  const candidateEdgeIds = edges.filter((edge) => joinIdSet.has(edge.target)).map((edge) => edge.id);
+  return {status: 'ambiguous', candidateJoinNodeIds: joinNodeIds, candidateEdgeIds};
+}
+
+function generatePairSuffix(existingIds: Set<string>): string {
+  let suffix = Math.random().toString(36).substring(2, 6);
+  while (
+    suffix.length < 4 ||
+    existingIds.has(`${SSO_CHECK_ID_PREFIX}_${suffix}`) ||
+    existingIds.has(`${SESSION_ID_PREFIX}_${suffix}`)
+  ) {
+    suffix = Math.random().toString(36).substring(2, 6);
+  }
+  return suffix;
+}
+
+function createSuccessEdge(sourceId: string, targetId: string, edgeStyle: string): Edge {
+  return {
+    animated: false,
+    id: `${sourceId}-to-${targetId}`,
+    markerEnd: {type: MarkerType.Arrow},
+    source: sourceId,
+    sourceHandle: `${sourceId}${VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX}`,
+    target: targetId,
+    type: edgeStyle,
+  };
+}
+
+function createFailureEdge(sourceId: string, targetId: string, edgeStyle: string): Edge {
+  return {
+    animated: false,
+    id: `${sourceId}-failure-to-${targetId}`,
+    markerEnd: {type: MarkerType.Arrow},
+    source: sourceId,
+    sourceHandle: 'failure',
+    target: targetId,
+    type: edgeStyle,
+  };
+}
+
+function buildExecutorNode(resource: Step, id: string, position: {x: number; y: number}): Node {
+  const cloned = cloneDeep(resource) as unknown as Node & {display?: unknown};
+  return {
+    ...cloned,
+    // The display metadata is mirrored into data so the Execution node component
+    // can render the label, icon and outcome tooltips (same as resolveStepMetadata).
+    data: {components: [], ...(cloned.data ?? {}), ...(cloned.display ? {display: cloned.display} : {})},
+    deletable: true,
+    id,
+    position,
+  };
+}
+
+/**
+ * Inserts an SSO check + session checkpoint pair into the flow.
+ *
+ * The SSO check is spliced in right after Start (success skips to the session
+ * checkpoint, failure falls back to the original entry prompt) and the session
+ * node is spliced in front of the join node so every fresh-path edge that
+ * entered the join now saves the session first.
+ *
+ * @param joinNodeId - Explicit join override from placement mode; when omitted
+ *   the heuristic must resolve to a single join node.
+ */
+export function enableSso(
+  nodes: Node[],
+  edges: Edge[],
+  ssoResources: {ssoCheck: Step; session: Step},
+  edgeStyle: string,
+  joinNodeId?: string,
+): EnableSsoResult {
+  if (deriveSsoState(nodes).enabled) {
+    return {edges, newSsoCheckId: null, newSessionId: null, nodes};
+  }
+
+  const startEdge = findStartEdge(nodes, edges);
+  if (!startEdge) {
+    return {edges, newSsoCheckId: null, newSessionId: null, nodes};
+  }
+  const entryNodeId = startEdge.target;
+
+  let resolvedJoinId = joinNodeId;
+  if (!resolvedJoinId) {
+    const resolution = findJoinCandidates(nodes, edges);
+    if (resolution.status !== 'ok') {
+      return {edges, newSsoCheckId: null, newSessionId: null, nodes};
+    }
+    resolvedJoinId = resolution.joinNodeId;
+  }
+
+  const startNode = nodes.find((node) => node.type === StaticStepTypes.Start);
+  const joinNode = nodes.find((node) => node.id === resolvedJoinId);
+  if (!startNode || !joinNode) {
+    return {edges, newSsoCheckId: null, newSessionId: null, nodes};
+  }
+
+  const suffix = generatePairSuffix(new Set(nodes.map((node) => node.id)));
+  const ssoCheckId = `${SSO_CHECK_ID_PREFIX}_${suffix}`;
+  const sessionId = `${SESSION_ID_PREFIX}_${suffix}`;
+
+  const ssoCheckNode = buildExecutorNode(ssoResources.ssoCheck, ssoCheckId, {
+    x: startNode.position.x + 200,
+    y: startNode.position.y - 50,
+  });
+  // Merge over any default properties the executor resource declares.
+  const ssoCheckProperties = (ssoCheckNode.data as StepData | undefined)?.properties ?? {};
+  ssoCheckNode.data = {...ssoCheckNode.data, properties: {...ssoCheckProperties, checkpointRef: sessionId}};
+
+  // SessionExecutor supports no properties on the backend, so none are set.
+  const sessionNode = buildExecutorNode(ssoResources.session, sessionId, {
+    x: joinNode.position.x - 300,
+    y: joinNode.position.y,
+  });
+
+  const rewiredEdges = edges.map((edge) => {
+    if (edge.id === startEdge.id) {
+      // Start now enters the SSO check instead of the original entry step.
+      return {...edge, target: ssoCheckId, targetHandle: undefined};
+    }
+    if (edge.target === resolvedJoinId) {
+      // Fresh-path feeders of the join now save the session first.
+      return {...edge, target: sessionId, targetHandle: undefined};
+    }
+    return edge;
+  });
+
+  return {
+    edges: [
+      ...rewiredEdges,
+      createSuccessEdge(ssoCheckId, sessionId, edgeStyle),
+      createFailureEdge(ssoCheckId, entryNodeId, edgeStyle),
+      createSuccessEdge(sessionId, resolvedJoinId, edgeStyle),
+    ],
+    newSsoCheckId: ssoCheckId,
+    newSessionId: sessionId,
+    nodes: [...nodes, ssoCheckNode, sessionNode],
+  };
+}
+
+/**
+ * Removes every SSO check and session checkpoint from the flow, splicing the
+ * surrounding edges back together: whatever entered an SSO check re-enters its
+ * fresh-authentication (failure) target, and whatever entered a session node
+ * re-enters the session's success target. Orphaned halves of a pair are
+ * removed too, since any leftover SSO wiring is invalid on the backend.
+ */
+export function disableSso(nodes: Node[], edges: Edge[]): DisableSsoResult {
+  const ssoCheckNodes = nodes.filter(isSsoCheckNode);
+  const sessionNodes = nodes.filter(isSessionNode);
+  const removedIds = new Set([...ssoCheckNodes, ...sessionNodes].map((node) => node.id));
+
+  if (removedIds.size === 0) {
+    return {edges, nodes, removedCount: 0};
+  }
+
+  // Where traffic entering a removed node should be redirected.
+  const redirects = new Map<string, string | undefined>();
+  ssoCheckNodes.forEach((node) => {
+    const failureEdge = edges.find((edge) => edge.source === node.id && edge.sourceHandle === 'failure');
+    const successEdge = edges.find((edge) => edge.source === node.id && edge.sourceHandle !== 'failure');
+    redirects.set(node.id, failureEdge?.target ?? successEdge?.target);
+  });
+  sessionNodes.forEach((node) => {
+    const successEdge = edges.find((edge) => edge.source === node.id && edge.sourceHandle !== 'failure');
+    redirects.set(node.id, successEdge?.target);
+  });
+
+  const resolveTarget = (target: string): string | undefined => {
+    let resolved: string | undefined = target;
+    let hops = 0;
+    while (resolved && removedIds.has(resolved) && hops < removedIds.size + 1) {
+      resolved = redirects.get(resolved);
+      hops += 1;
+    }
+    return resolved && !removedIds.has(resolved) ? resolved : undefined;
+  };
+
+  const splicedEdges: Edge[] = [];
+  const seenConnections = new Set<string>();
+  edges.forEach((edge) => {
+    if (removedIds.has(edge.source)) {
+      return;
+    }
+    const resolvedTarget = resolveTarget(edge.target);
+    if (!resolvedTarget) {
+      return;
+    }
+    const connectionKey = `${edge.source}|${edge.sourceHandle ?? ''}|${resolvedTarget}`;
+    if (seenConnections.has(connectionKey)) {
+      return;
+    }
+    seenConnections.add(connectionKey);
+    splicedEdges.push(
+      edge.target === resolvedTarget ? edge : {...edge, target: resolvedTarget, targetHandle: undefined},
+    );
+  });
+
+  return {
+    edges: splicedEdges,
+    nodes: nodes.filter((node) => !removedIds.has(node.id)),
+    removedCount: ssoCheckNodes.length,
+  };
+}

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -3444,6 +3444,14 @@ const translations = {
     'core.validation.fields.form.noSubmitButton':
       'Form <code>{{id}}</code> has input fields but no submit button. Add a button with type "Submit" so that users can submit the form.',
 
+    // Validation messages - SSO pairing
+    'core.validation.sso.missingCheckpointRef':
+      'SSO check <code>{{id}}</code> does not reference a session checkpoint. Select one in its properties, or remove the step.',
+    'core.validation.sso.invalidCheckpointRef':
+      'SSO check <code>{{id}}</code> references a session step that no longer exists. Select a valid session checkpoint in its properties.',
+    'core.validation.sso.orphanSession':
+      'Session step <code>{{id}}</code> is not referenced by any SSO check. Add an SSO check that uses it, or remove the step.',
+
     // Elements - rich text
     'core.elements.richText.placeholder': 'Enter text here...',
     'core.elements.richText.resolvedI18nValue': 'Resolved i18n value',
@@ -3557,6 +3565,31 @@ const translations = {
       'Would you like to create a View and add the Widget inside it?',
     'core.dialogs.formRequiresView.widgetOnCanvas.confirmButton': 'Add View with Widget',
     'core.dialogs.formRequiresView.cancelButton': 'Cancel',
+
+    // SSO toggle (login flows)
+    'sso.toggleLabel': 'Enable SSO',
+    'sso.toggleDescription': 'Reuse an active session to skip sign-in',
+    'sso.toggleTooltipOn': 'Single sign-on is active for this flow. Turn off to remove the SSO wiring.',
+    'sso.disabledNoEntry': 'Connect the Start step to a view step to enable SSO.',
+    'sso.disabledEntryNotPrompt':
+      'To enable SSO, the flow must start with a view step. The SSO check needs a login screen to fall back to.',
+    'sso.disabledNoAssert': 'Add an authentication completion step to the flow before enabling SSO.',
+    'sso.disabledReadOnly': 'This flow is read-only and cannot be modified.',
+    'sso.enabledSnackbar':
+      'SSO enabled. A session check now runs after Start, and sessions are saved before the flow completes.',
+    'sso.disabledSnackbar_one': 'SSO disabled. {{count}} checkpoint was removed and the flow reconnected.',
+    'sso.disabledSnackbar_other': 'SSO disabled. {{count}} checkpoints were removed and the flow reconnected.',
+    'sso.placementHint': 'Click a highlighted connection to choose where the session checkpoint joins the flow.',
+    'sso.placementCancel': 'Cancel',
+    'sso.confirmDialog.title': 'Remove single sign-on?',
+    'sso.confirmDialog.description_one':
+      'This removes {{count}} SSO checkpoint and its session step, and reconnects the flow. Users will authenticate with their credentials every time.',
+    'sso.confirmDialog.description_other':
+      'This removes {{count}} SSO checkpoints and their session steps, and reconnects the flow. Users will authenticate with their credentials every time.',
+    'sso.confirmDialog.confirmButton': 'Remove SSO',
+    'sso.confirmDialog.cancelButton': 'Cancel',
+    'sso.properties.checkpointLabel': 'Session checkpoint',
+    'sso.properties.checkpointDangling': 'The referenced session step no longer exists. Select a valid session step.',
 
     // Form adapter
     'core.adapters.form.badgeLabel': 'Form',


### PR DESCRIPTION
### Purpose
Adds an **Enable SSO** toggle to the flow builder for AUTHENTICATION (login) flows, so builders can add or remove SSO session reuse on an existing flow without rebuilding it from the "Basic with SSO" template or hand-wiring the `SSOCheckExecutor` / `SessionExecutor` pairing contract.

This implements #4066: the toggle with graph-derived state, single-checkpoint auto-insert with the join heuristic, the interactive placement fallback, confirmed removal, the `checkpointRef` picker in the SSO check's properties panel, and mirrored client-side validation. 

### Approach

**Toggle (resource panel footer, AUTHENTICATION flows only)**
- Toggle state is derived from the graph (ON iff an `SSOCheckExecutor` node exists), so template-created SSO flows read as enabled with no migration or stored flag.
- **Enable** runs a pure graph transformation (`ssoGraphTransforms.ts`): splices `sso_check_<suffix>` after Start (success skips to the checkpoint, failure falls back to the entry view) and `session_<suffix>` in front of the join node, retargeting all fresh-path feeders through it. The join is found heuristically (the node feeding `AuthAssertExecutor`, or the `AuthorizationExecutor` immediately before it). The pair shares an id suffix, and `properties.checkpointRef` is set by construction so the result always passes backend pairing validation.
- When the heuristic is ambiguous (multiple completion points), the builder enters a lightweight placement mode: candidate edges highlight, the rest dim, and clicking a candidate places the checkpoint (Esc or Cancel exits).
- When enabling is impossible (no Start wiring, entry step is not a view, no auth assert step), the toggle is disabled with a reason tooltip instead of producing an invalid graph.
- **Disable** shows a confirmation dialog, then removes every SSO check and session node (orphaned halves included) and splices the edges back. If the properties panel is showing a removed node, it closes.
- New nodes are placed relative to their anchors and de-overlapped with the existing collision resolver; the whole-graph layout is never touched. Enabling forces verbose mode on so the change is never invisible.

**Validation**
- New graph-level validation rules mirror the backend pairing contract (missing/dangling `checkpointRef`, session node unreferenced by any SSO check) so hand-deleting half a pair surfaces immediately in the notifications panel and blocks Save. The same checks were added to the save-time `validateFlowGraph` backstop.

**Canvas UX (came out of testing this feature)**
- Hovering an edge now highlights it and spotlights the node it leads into, using the preview mode's visual language. Implemented with `data-id` CSS selectors so hovering never mutates node or edge objects.
- Edges no longer overlap on shared corridors: `BaseEdge` previously routed each edge independently, so edges taking the same corridor stacked exactly. A new `EdgePathsProvider` collects the endpoint geometry each edge already receives and routes all edges together through the existing (previously unused) `calculateAllEdgePaths`, separating shared corridors into parallel lanes. Fixed a latent bug in that algorithm where offsetting terminal segments detached paths from their handles (regression tests added).

**Core / feature boundary**: all SSO knowledge lives in the `login-flow` feature; the shared `flows` engine only gained generic extensions (resource panel `footer` slot, `onEdgeClick` pass-through, edge path provider).

### Related Issues
- Fixes #4066

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SSO enable/disable workflow in the login-flow editor, including join-placement guidance, session checkpoint selection, and confirmation + success messages.
  * Introduced cross-node SSO pairing validation (missing/invalid/orphaned checkpoint/session references).
  * Improved flow visuals with centralized edge-path routing and non-simulation edge-hover spotlighting.
  * Added an optional bottom **footer** area to the Resource Panel.
* **Bug Fixes**
  * Fixed edge routing to better preserve handle anchoring and separation behavior.
  * Restored forwarding of edge click/hover handlers.
* **Tests**
  * Expanded coverage for SSO transforms, graph validation, and edge-path routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->