### PR TITLE
Validate `private_key_jwt` assertion audience against the issuer

### DIFF
--- a/backend/internal/oauth/oauth2/ciba/init.go
+++ b/backend/internal/oauth/oauth2/ciba/init.go
@@ -72,9 +72,8 @@ func registerRoutes(
 		MaxAge:           600,
 	}
 
-	endpointURL := discoveryService.GetOAuth2AuthorizationServerMetadata(
-		context.Background()).BackchannelAuthenticationEndpoint
-	clientAuthMiddleware := clientauth.ClientAuthMiddleware(actorProvider, authnProvider, jwtService, endpointURL)
+	issuer := discoveryService.GetOAuth2AuthorizationServerMetadata(context.Background()).Issuer
+	clientAuthMiddleware := clientauth.ClientAuthMiddleware(actorProvider, authnProvider, jwtService, issuer)
 	authHandler := clientAuthMiddleware(http.HandlerFunc(cibaHandler.HandleBackchannelAuthRequest))
 
 	authPattern, wrappedAuthHandler := middleware.WithCORS(

--- a/backend/internal/oauth/oauth2/clientauth/clientauth.go
+++ b/backend/internal/oauth/oauth2/clientauth/clientauth.go
@@ -40,7 +40,7 @@ import (
 
 // authenticate authenticates the OAuth2 client from the request.
 // It extracts credentials, validates them, and returns OAuthClientInfo on success.
-// The endpointURL is used as the expected audience when validating client assertion JWTs.
+// The issuer is the audience value accepted when validating client assertion JWTs.
 // Returns an authError on failure.
 func authenticate(
 	ctx context.Context,
@@ -48,7 +48,7 @@ func authenticate(
 	actorProvider providers.ActorProvider,
 	authnProvider providers.AuthnProviderManager,
 	jwtService jwt.JWTServiceInterface,
-	endpointURL string,
+	issuer string,
 ) (*OAuthClientInfo, *authError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "ClientAuthMiddleware"))
 
@@ -146,7 +146,7 @@ func authenticate(
 	switch detectedMethod {
 	// TODO: Move this to authnProvider.Authenticate
 	case providers.TokenEndpointAuthMethodPrivateKeyJWT:
-		if err := validateClientAssertion(ctx, oauthApp, jwtService, endpointURL, clientID,
+		if err := validateClientAssertion(ctx, oauthApp, jwtService, issuer, clientID,
 			clientAssertion); err != nil {
 			logger.Debug(ctx, "Invalid client assertion: "+err.Error())
 			return nil, errInvalidClientAssertion
@@ -230,18 +230,19 @@ func extractClientIDFromAssertion(ctx context.Context, assertion string) (string
 }
 
 // validateClientAssertion validates the provided client assertion JWT using the configured certificate and JWT service.
-// The endpointURL is used as the expected audience for JWT validation.
+// Per FAPI 2.0 Security Profile Section 5.3.2.1, the assertion's 'aud' claim must be the authorization server's
+// issuer identifier.
 func validateClientAssertion(ctx context.Context,
 	oauthApp *providers.OAuthClient,
 	jwtService jwt.JWTServiceInterface,
-	endpointURL string,
+	issuer string,
 	clientID, clientAssertion string) error {
 	if oauthApp.Certificate == nil {
 		return fmt.Errorf("no certificate configured for client assertion validation")
 	}
 
 	if oauthApp.Certificate.Type == cert.CertificateTypeJWKSURI {
-		if err := jwtService.VerifyJWTWithJWKS(ctx, clientAssertion, oauthApp.Certificate.Value, endpointURL,
+		if err := jwtService.VerifyJWTWithJWKS(ctx, clientAssertion, oauthApp.Certificate.Value, issuer,
 			clientID); err != nil {
 			return fmt.Errorf("client assertion verification with JWKS URI failed: %v", err.Error)
 		}
@@ -280,7 +281,7 @@ func validateClientAssertion(ctx context.Context,
 		return fmt.Errorf("failed to convert JWK to public key: %w", err)
 	}
 
-	if err := jwtService.VerifyJWTWithPublicKey(ctx, clientAssertion, pubKey, endpointURL, clientID); err != nil {
+	if err := jwtService.VerifyJWTWithPublicKey(ctx, clientAssertion, pubKey, issuer, clientID); err != nil {
 		return fmt.Errorf("client assertion verification failed: %v", err.Error)
 	}
 

--- a/backend/internal/oauth/oauth2/clientauth/clientauth_test.go
+++ b/backend/internal/oauth/oauth2/clientauth/clientauth_test.go
@@ -52,7 +52,7 @@ import (
 const (
 	testClientID     = "test-client-id"
 	testClientSecret = "test-secret"
-	testEndpointURL  = "https://localhost:9443/oauth2/token"
+	testIssuer       = "https://localhost:9443"
 )
 
 type ClientAuthTestSuite struct {
@@ -106,7 +106,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_Success_ClientSecretPost() {
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.Nil(suite.T(), authErr)
 	assert.NotNil(suite.T(), clientInfo)
@@ -134,7 +134,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_Success_ClientSecretBasic() {
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.Nil(suite.T(), authErr)
 	assert.NotNil(suite.T(), clientInfo)
@@ -165,7 +165,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_Success_ClientSecretBasic_URL
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.Nil(suite.T(), authErr)
 	assert.NotNil(suite.T(), clientInfo)
@@ -183,7 +183,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_InvalidBasicAuth_BadPercentEn
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -198,7 +198,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_InvalidBasicAuth_BadPercentEn
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -225,7 +225,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_Success_PublicClient() {
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.Nil(suite.T(), authErr)
 	assert.NotNil(suite.T(), clientInfo)
@@ -241,7 +241,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_MissingClientID() {
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -257,7 +257,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_EmptyClientIDInBasicAuth() {
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -272,7 +272,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_EmptyClientIDAndSecretInBasic
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -295,7 +295,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_MissingClientSecret() {
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -308,7 +308,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_InvalidBasicAuth() {
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -321,7 +321,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_InvalidAuthorizationHeader() 
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -340,7 +340,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_BothHeaderAndBody() {
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -362,7 +362,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_ClientNotFound() {
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -402,7 +402,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_InvalidClientSecret() {
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), failAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), failAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -426,7 +426,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_WrongAuthMethod() {
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -456,7 +456,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_PublicClientWithSecret() {
 	// Try to use client_secret_post with public client
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -484,7 +484,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_PublicClientMissingSecret() {
 	// Public client with authMethod = none should succeed
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.Nil(suite.T(), authErr)
 	assert.NotNil(suite.T(), clientInfo)
@@ -511,7 +511,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_ClientIDMismatch_HeaderVsBody
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -532,7 +532,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_ServiceError() {
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -600,7 +600,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_Success_PrivateKeyJWT() {
 			mock.Anything,
 			assertion,
 			mock.Anything,
-			"https://localhost:9443/oauth2/token",
+			testIssuer,
 			testClientID).
 		Return(nil)
 
@@ -614,7 +614,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_Success_PrivateKeyJWT() {
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.Nil(suite.T(), authErr)
 	assert.NotNil(suite.T(), clientInfo)
@@ -642,7 +642,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_Success_PrivateKeyJWT_WithCli
 			mock.Anything,
 			assertion,
 			mock.Anything,
-			"https://localhost:9443/oauth2/token",
+			testIssuer,
 			testClientID).
 		Return(nil)
 
@@ -657,7 +657,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_Success_PrivateKeyJWT_WithCli
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.Nil(suite.T(), authErr)
 	assert.NotNil(suite.T(), clientInfo)
@@ -677,7 +677,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_PrivateKeyJWT_UnsupportedAsse
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -696,7 +696,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_PrivateKeyJWT_OnlyAssertionTy
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -720,7 +720,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_PrivateKeyJWT_OnlyAssertionPr
 	// Then it checks assertion_type != SupportedClientAssertionType, which fails.
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -751,7 +751,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_PrivateKeyJWT_InvalidAssertio
 
 			clientInfo, authErr := authenticate(
 				req.Context(), req,
-				suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+				suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 			assert.NotNil(suite.T(), authErr)
 			assert.Nil(suite.T(), clientInfo)
@@ -778,7 +778,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_PrivateKeyJWT_ClientNotFound(
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -807,7 +807,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_PrivateKeyJWT_AuthMethodNotAl
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -837,7 +837,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_PrivateKeyJWT_AssertionValida
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -860,7 +860,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_PrivateKeyJWT_ClientIDMismatc
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -882,7 +882,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_PrivateKeyJWT_WithBasicAuth_M
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -905,7 +905,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_PrivateKeyJWT_WithClientSecre
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -929,7 +929,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_PrivateKeyJWT_ServiceError() 
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -952,7 +952,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_PrivateKeyJWT_InvalidBase64Pa
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -978,7 +978,7 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_PrivateKeyJWT_InvalidJSONPayl
 
 	clientInfo, authErr := authenticate(
 		req.Context(), req,
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testEndpointURL)
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	assert.NotNil(suite.T(), authErr)
 	assert.Nil(suite.T(), clientInfo)
@@ -996,7 +996,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_NilCertificate() {
 	}
 
 	err := validateClientAssertion(context.Background(),
-		oauthApp, suite.mockJwtService, testEndpointURL, "test-client",
+		oauthApp, suite.mockJwtService, testIssuer, "test-client",
 		"some.jwt.token")
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "no certificate configured")
@@ -1015,11 +1015,11 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_JWKSURI_Success() 
 
 	suite.mockJwtService.EXPECT().
 		VerifyJWTWithJWKS(mock.Anything, assertion, "https://example.com/.well-known/jwks.json",
-			"https://localhost:9443/oauth2/token", "test-client").
+			testIssuer, "test-client").
 		Return(nil)
 
 	err := validateClientAssertion(context.Background(),
-		oauthApp, suite.mockJwtService, testEndpointURL, "test-client", assertion)
+		oauthApp, suite.mockJwtService, testIssuer, "test-client", assertion)
 	assert.Nil(suite.T(), err)
 }
 
@@ -1036,11 +1036,11 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_JWKSURI_Verificati
 
 	suite.mockJwtService.EXPECT().
 		VerifyJWTWithJWKS(mock.Anything, assertion, "https://example.com/.well-known/jwks.json",
-			"https://localhost:9443/oauth2/token", "test-client").
+			testIssuer, "test-client").
 		Return(&tidcommon.ServiceError{Error: tidcommon.I18nMessage{DefaultValue: "verification failed"}})
 
 	err := validateClientAssertion(context.Background(),
-		oauthApp, suite.mockJwtService, testEndpointURL, "test-client", assertion)
+		oauthApp, suite.mockJwtService, testIssuer, "test-client", assertion)
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "client assertion verification with JWKS URI failed")
 }
@@ -1054,7 +1054,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_InvalidJWKSJSON() 
 		},
 	}
 
-	err := validateClientAssertion(context.Background(), oauthApp, suite.mockJwtService, testEndpointURL,
+	err := validateClientAssertion(context.Background(), oauthApp, suite.mockJwtService, testIssuer,
 		"test-client", "some.jwt.token")
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "invalid JWKS certificate format")
@@ -1070,7 +1070,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_InvalidJWTFormat()
 		},
 	}
 
-	err := validateClientAssertion(context.Background(), oauthApp, suite.mockJwtService, testEndpointURL,
+	err := validateClientAssertion(context.Background(), oauthApp, suite.mockJwtService, testIssuer,
 		"test-client", "invalid-jwt")
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "failed to decode header")
@@ -1089,7 +1089,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_MissingKidInHeader
 	fakeJWT := buildTestJWT(map[string]any{"alg": "RS256", "typ": "JWT"}, map[string]any{"sub": "test-client"})
 
 	err := validateClientAssertion(context.Background(),
-		oauthApp, suite.mockJwtService, testEndpointURL, "test-client", fakeJWT)
+		oauthApp, suite.mockJwtService, testIssuer, "test-client", fakeJWT)
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "JWT header missing 'kid' claim")
 }
@@ -1108,7 +1108,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_EmptyKidInHeader()
 		map[string]any{"sub": "test-client"})
 
 	err := validateClientAssertion(context.Background(),
-		oauthApp, suite.mockJwtService, testEndpointURL, "test-client", fakeJWT)
+		oauthApp, suite.mockJwtService, testIssuer, "test-client", fakeJWT)
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "JWT header missing 'kid' claim")
 }
@@ -1127,7 +1127,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_KidNotAString() {
 		map[string]any{"sub": "test-client"})
 
 	err := validateClientAssertion(context.Background(),
-		oauthApp, suite.mockJwtService, testEndpointURL, "test-client", fakeJWT)
+		oauthApp, suite.mockJwtService, testIssuer, "test-client", fakeJWT)
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "JWT header missing 'kid' claim")
 }
@@ -1146,7 +1146,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_NoMatchingKidInJWK
 		map[string]any{"sub": "test-client"})
 
 	err := validateClientAssertion(context.Background(),
-		oauthApp, suite.mockJwtService, testEndpointURL, "test-client", fakeJWT)
+		oauthApp, suite.mockJwtService, testIssuer, "test-client", fakeJWT)
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "no matching key found in JWKS")
 }
@@ -1171,7 +1171,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_InvalidJWKCannotCo
 		map[string]any{"sub": "test-client"})
 
 	err := validateClientAssertion(context.Background(),
-		oauthApp, suite.mockJwtService, testEndpointURL, "test-client", fakeJWT)
+		oauthApp, suite.mockJwtService, testIssuer, "test-client", fakeJWT)
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "failed to convert JWK to public key")
 }
@@ -1194,7 +1194,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_VerificationFails(
 			mock.Anything,
 			fakeJWT,
 			mock.Anything,
-			"https://localhost:9443/oauth2/token",
+			testIssuer,
 			"test-client").
 		Return(&tidcommon.ServiceError{
 			Code:  "JWT-00001",
@@ -1203,7 +1203,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_VerificationFails(
 		})
 
 	err := validateClientAssertion(context.Background(),
-		oauthApp, suite.mockJwtService, testEndpointURL, "test-client", fakeJWT)
+		oauthApp, suite.mockJwtService, testIssuer, "test-client", fakeJWT)
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "client assertion verification failed")
 }
@@ -1226,12 +1226,12 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_Success() {
 			mock.Anything,
 			fakeJWT,
 			mock.Anything,
-			"https://localhost:9443/oauth2/token",
+			testIssuer,
 			"test-client").
 		Return(nil)
 
 	err := validateClientAssertion(context.Background(),
-		oauthApp, suite.mockJwtService, testEndpointURL, "test-client", fakeJWT)
+		oauthApp, suite.mockJwtService, testIssuer, "test-client", fakeJWT)
 	assert.Nil(suite.T(), err)
 }
 
@@ -1251,7 +1251,7 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_EmptyJWKSKeys() {
 		map[string]any{"sub": "test-client"})
 
 	err := validateClientAssertion(context.Background(),
-		oauthApp, suite.mockJwtService, testEndpointURL, "test-client", fakeJWT)
+		oauthApp, suite.mockJwtService, testIssuer, "test-client", fakeJWT)
 	assert.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "no matching key found in JWKS")
 }
@@ -1287,13 +1287,52 @@ func (suite *ClientAuthTestSuite) TestValidateClientAssertion_MultipleKeysMatche
 			mock.Anything,
 			fakeJWT,
 			mock.Anything,
-			"https://localhost:9443/oauth2/token",
+			testIssuer,
 			"test-client").
 		Return(nil)
 
 	err := validateClientAssertion(context.Background(),
-		oauthApp, suite.mockJwtService, testEndpointURL, "test-client", fakeJWT)
+		oauthApp, suite.mockJwtService, testIssuer, "test-client", fakeJWT)
 	assert.Nil(suite.T(), err)
+}
+
+// A private_key_jwt client authenticating with the issuer identifier as its assertion audience
+// succeeds; the JWT service verifies 'aud' against the issuer (FAPI 2.0 Security Profile Section 5.3.2.1).
+func (suite *ClientAuthTestSuite) TestAuthenticate_Success_PrivateKeyJWT_IssuerAudience() {
+	jwksJSON := buildTestRSAJWKS("test-kid")
+	assertion := buildTestJWT(
+		map[string]any{"alg": "RS256", "kid": "test-kid", "typ": "JWT"},
+		map[string]any{"sub": testClientID, "aud": testIssuer})
+	mockApp := &providers.OAuthClient{
+		ClientID:                testClientID,
+		TokenEndpointAuthMethod: providers.TokenEndpointAuthMethodPrivateKeyJWT,
+		GrantTypes:              []providers.GrantType{providers.GrantTypeAuthorizationCode},
+		Certificate:             &inboundmodel.Certificate{Value: jwksJSON},
+	}
+
+	suite.mockInboundClient.On("GetOAuthClientByClientID", mock.Anything, testClientID).
+		Return(mockApp, nil).Once()
+	suite.mockJwtService.EXPECT().
+		VerifyJWTWithPublicKey(mock.Anything, assertion, mock.Anything, testIssuer, testClientID).
+		Return(nil)
+
+	formData := url.Values{}
+	formData.Set("client_assertion_type", constants.SupportedClientAssertionType)
+	formData.Set("client_assertion", assertion)
+
+	req, _ := http.NewRequest("POST", "/test", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	_ = req.ParseForm()
+
+	clientInfo, authErr := authenticate(
+		req.Context(), req,
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
+
+	assert.Nil(suite.T(), authErr)
+	assert.NotNil(suite.T(), clientInfo)
+	if clientInfo != nil {
+		assert.Equal(suite.T(), testClientID, clientInfo.ClientID)
+	}
 }
 
 // noopAuthnMgr returns an authentication-provider mock with no expectations, for tests that

--- a/backend/internal/oauth/oauth2/clientauth/middleware.go
+++ b/backend/internal/oauth/oauth2/clientauth/middleware.go
@@ -28,17 +28,17 @@ import (
 )
 
 // ClientAuthMiddleware authenticates OAuth2 clients and attaches client info to request context.
-// The endpointURL is the full URL of the endpoint being protected, used as the expected audience
-// when validating client assertion JWTs (private_key_jwt authentication).
+// The issuer is the authorization server's issuer identifier, accepted as the audience of a client
+// assertion JWT (private_key_jwt authentication), per FAPI 2.0 Security Profile Section 5.3.2.1.
 func ClientAuthMiddleware(actorProvider providers.ActorProvider,
 	authnProvider providers.AuthnProviderManager,
 	jwtService jwt.JWTServiceInterface,
-	endpointURL string) func(http.Handler) http.Handler {
+	issuer string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 			// Authenticate client
-			clientInfo, authErr := authenticate(ctx, r, actorProvider, authnProvider, jwtService, endpointURL)
+			clientInfo, authErr := authenticate(ctx, r, actorProvider, authnProvider, jwtService, issuer)
 			if authErr != nil {
 				// If the client attempted to authenticate via the Authorization
 				// header, include WWW-Authenticate in 401 responses.

--- a/backend/internal/oauth/oauth2/clientauth/middleware_test.go
+++ b/backend/internal/oauth/oauth2/clientauth/middleware_test.go
@@ -85,7 +85,7 @@ func (suite *ClientAuthMiddlewareTestSuite) TestClientAuthMiddleware_Success_Cli
 
 	// Create middleware (authn success mock from SetupTest applies via Maybe())
 	middleware := ClientAuthMiddleware(
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, "https://localhost:9443/oauth2/token")
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	// Create test handler that checks context
 	var clientInfo *OAuthClientInfo
@@ -130,7 +130,7 @@ func (suite *ClientAuthMiddlewareTestSuite) TestClientAuthMiddleware_Success_Cli
 
 	// Create middleware
 	middleware := ClientAuthMiddleware(
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, "https://localhost:9443/oauth2/token")
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	// Create test handler
 	var clientInfo *OAuthClientInfo
@@ -158,7 +158,7 @@ func (suite *ClientAuthMiddlewareTestSuite) TestClientAuthMiddleware_Success_Cli
 func (suite *ClientAuthMiddlewareTestSuite) TestClientAuthMiddleware_MissingClientID() {
 	// Create middleware
 	middleware := ClientAuthMiddleware(
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, "https://localhost:9443/oauth2/token")
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -187,7 +187,7 @@ func (suite *ClientAuthMiddlewareTestSuite) TestClientAuthMiddleware_InvalidClie
 
 	// Create middleware
 	middleware := ClientAuthMiddleware(
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, "https://localhost:9443/oauth2/token")
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -239,7 +239,7 @@ func (suite *ClientAuthMiddlewareTestSuite) TestClientAuthMiddleware_InvalidClie
 
 	// Create middleware with failing authn provider
 	middleware := ClientAuthMiddleware(
-		suite.actorProvider(), failAuthnProvider, suite.mockJwtService, "https://localhost:9443/oauth2/token")
+		suite.actorProvider(), failAuthnProvider, suite.mockJwtService, testIssuer)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -273,7 +273,7 @@ func (suite *ClientAuthMiddlewareTestSuite) TestClientAuthMiddleware_HandlerNotC
 
 	// Create middleware
 	middleware := ClientAuthMiddleware(
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, "https://localhost:9443/oauth2/token")
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	// Track if handler was called
 	handlerCalled := false
@@ -313,7 +313,7 @@ func (suite *ClientAuthMiddlewareTestSuite) TestClientAuthMiddleware_ContextProp
 
 	// Create middleware
 	middleware := ClientAuthMiddleware(
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, "https://localhost:9443/oauth2/token")
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 
 	// Create nested handler that also checks context
 	var clientInfo *OAuthClientInfo
@@ -352,7 +352,7 @@ func (suite *ClientAuthMiddlewareTestSuite) TestClientAuthMiddleware_BasicAuth_4
 		Return(nil, nil).Once()
 
 	middleware := ClientAuthMiddleware(
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, "https://localhost:9443/oauth2/token")
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -390,7 +390,7 @@ func (suite *ClientAuthMiddlewareTestSuite) TestClientAuthMiddleware_BasicAuth_I
 			}).Maybe()
 
 	middleware := ClientAuthMiddleware(
-		suite.actorProvider(), failAuthnProvider, suite.mockJwtService, "https://localhost:9443/oauth2/token")
+		suite.actorProvider(), failAuthnProvider, suite.mockJwtService, testIssuer)
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -411,7 +411,7 @@ func (suite *ClientAuthMiddlewareTestSuite) TestClientAuthMiddleware_PostAuth_40
 		Return(nil, nil).Once()
 
 	middleware := ClientAuthMiddleware(
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, "https://localhost:9443/oauth2/token")
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -433,7 +433,7 @@ func (suite *ClientAuthMiddlewareTestSuite) TestClientAuthMiddleware_PostAuth_40
 func (suite *ClientAuthMiddlewareTestSuite) TestClientAuthMiddleware_InvalidBasicAuth_IncludesWWWAuthenticate() {
 	// Invalid Basic auth header format should include WWW-Authenticate: Basic
 	middleware := ClientAuthMiddleware(
-		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, "https://localhost:9443/oauth2/token")
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})

--- a/backend/internal/oauth/oauth2/introspect/init.go
+++ b/backend/internal/oauth/oauth2/introspect/init.go
@@ -61,8 +61,8 @@ func registerRoutes(
 		MaxAge:           600,
 	}
 
-	endpointURL := discoveryService.GetOAuth2AuthorizationServerMetadata(context.Background()).IntrospectionEndpoint
-	clientAuthMiddleware := clientauth.ClientAuthMiddleware(actorProvider, authnProvider, jwtService, endpointURL)
+	issuer := discoveryService.GetOAuth2AuthorizationServerMetadata(context.Background()).Issuer
+	clientAuthMiddleware := clientauth.ClientAuthMiddleware(actorProvider, authnProvider, jwtService, issuer)
 	handler := clientAuthMiddleware(http.HandlerFunc(introspectHandler.HandleIntrospect))
 
 	pattern, wrappedHandler := middleware.WithCORS(

--- a/backend/internal/oauth/oauth2/par/init.go
+++ b/backend/internal/oauth/oauth2/par/init.go
@@ -77,9 +77,8 @@ func registerRoutes(
 		MaxAge:           600,
 	}
 
-	metadata := discoveryService.GetOAuth2AuthorizationServerMetadata(context.Background())
-	endpointURL := metadata.PushedAuthorizationRequestEndpoint
-	clientAuthMiddleware := clientauth.ClientAuthMiddleware(actorProvider, authnProvider, jwtService, endpointURL)
+	issuer := discoveryService.GetOAuth2AuthorizationServerMetadata(context.Background()).Issuer
+	clientAuthMiddleware := clientauth.ClientAuthMiddleware(actorProvider, authnProvider, jwtService, issuer)
 	wrappedHandler := clientAuthMiddleware(http.HandlerFunc(handler.HandlePARRequest))
 
 	pattern, corsHandler := middleware.WithCORS(

--- a/backend/internal/oauth/oauth2/revocation/init.go
+++ b/backend/internal/oauth/oauth2/revocation/init.go
@@ -68,8 +68,8 @@ func registerRoutes(
 		MaxAge:           600,
 	}
 
-	endpointURL := discoveryService.GetOAuth2AuthorizationServerMetadata(context.Background()).RevocationEndpoint
-	clientAuthMiddleware := clientauth.ClientAuthMiddleware(actorProvider, authnProvider, jwtService, endpointURL)
+	issuer := discoveryService.GetOAuth2AuthorizationServerMetadata(context.Background()).Issuer
+	clientAuthMiddleware := clientauth.ClientAuthMiddleware(actorProvider, authnProvider, jwtService, issuer)
 	handler := clientAuthMiddleware(http.HandlerFunc(revocationHandler.HandleRevoke))
 
 	pattern, wrappedHandler := middleware.WithCORS(

--- a/backend/internal/oauth/oauth2/token/init.go
+++ b/backend/internal/oauth/oauth2/token/init.go
@@ -71,8 +71,8 @@ func registerRoutes(
 		MaxAge:           600,
 	}
 
-	endpointURL := discoveryService.GetOAuth2AuthorizationServerMetadata(context.Background()).TokenEndpoint
-	clientAuthMiddleware := clientauth.ClientAuthMiddleware(actorProvider, authnProvider, jwtService, endpointURL)
+	issuer := discoveryService.GetOAuth2AuthorizationServerMetadata(context.Background()).Issuer
+	clientAuthMiddleware := clientauth.ClientAuthMiddleware(actorProvider, authnProvider, jwtService, issuer)
 	handler := clientAuthMiddleware(http.HandlerFunc(tokenHandler.HandleTokenRequest))
 
 	pattern, wrappedHandler := middleware.WithCORS(


### PR DESCRIPTION
### Purpose

Fix the PAR endpoint rejecting `private_key_jwt` client authentication under FAPI 2.0 conformance (401 instead of 201). The client-assertion `aud` claim was validated against the endpoint's own URL, so an assertion carrying the issuer identifier (as FAPI 2.0 requires) was rejected. The `aud` claim is now validated against the **issuer identifier**, per [FAPI 2.0 §5.3.2.1(8)](https://openid.net/specs/fapi-security-profile-2_0-final.html). Applies to all client-authenticated endpoints (token, PAR, introspection, revocation, CIBA).

---
### ⚠️ Breaking Changes

#### 🔧 Summary
`private_key_jwt` client assertions must set `aud` to the AS **issuer identifier**. The endpoint URL is no longer accepted.

#### 💥 Impact
Any confidential client whose assertion sets `aud` to an endpoint URL now fails with `401 invalid_client`, across all client-auth endpoints.

#### 🔄 Migration
Set `aud` to the `issuer` from `/.well-known/openid-configuration`:
```diff
- "aud": "https://<host>/oauth2/token"
+ "aud": "https://<host>"

