### PR TITLE
Fix Console import resource type identification

### DIFF
--- a/frontend/apps/console/src/features/import-export/pages/ImportConfigurationUploadPage.tsx
+++ b/frontend/apps/console/src/features/import-export/pages/ImportConfigurationUploadPage.tsx
@@ -165,17 +165,12 @@ export default function ImportConfigurationUploadPage(): JSX.Element {
           let resourceType = 'unknown';
           let fileName = 'unknown';
 
-          // First pass: extract metadata from comment lines
+          // First pass: extract the file name from comment lines
           for (const line of lines) {
             if (line.startsWith('#')) {
-              const resourceTypeRegex = /resource_type:\s*(\w+)/;
               const fileNameRegex = /File:\s*(.+\.yaml)/i;
-              const resourceTypeMatch = resourceTypeRegex.exec(line);
               const fileNameMatch = fileNameRegex.exec(line);
 
-              if (resourceTypeMatch) {
-                resourceType = resourceTypeMatch[1];
-              }
               if (fileNameMatch) {
                 fileName = fileNameMatch[1].trim();
               }
@@ -220,6 +215,13 @@ export default function ImportConfigurationUploadPage(): JSX.Element {
             const resource = yaml.parse(yamlContent) as unknown;
 
             if (resource && typeof resource === 'object') {
+              // Determine the resource type from the `resource_type` YAML field, the documented,
+              // spec-compliant format also emitted by export.
+              const fieldResourceType = (resource as {resource_type?: unknown}).resource_type;
+              if (typeof fieldResourceType === 'string' && fieldResourceType.trim() !== '') {
+                resourceType = fieldResourceType.trim();
+              }
+
               if (!resourcesByType[resourceType]) {
                 resourcesByType[resourceType] = [];
               }

--- a/frontend/apps/console/src/features/import-export/pages/__tests__/ImportConfigurationUploadPage.test.tsx
+++ b/frontend/apps/console/src/features/import-export/pages/__tests__/ImportConfigurationUploadPage.test.tsx
@@ -185,7 +185,7 @@ describe('ImportConfigurationUploadPage', () => {
     const user = userEvent.setup();
     render(<ImportConfigurationUploadPage />);
 
-    const yamlContent = '---\n# resource_type: application\nname: test-app\n';
+    const yamlContent = 'resource_type: application\nname: test-app\n';
     const yamlFile = new File([yamlContent], 'config.yaml', {type: 'text/yaml'});
     Object.defineProperty(yamlFile, 'text', {value: () => Promise.resolve(yamlContent)});
 
@@ -213,7 +213,7 @@ describe('ImportConfigurationUploadPage', () => {
     const user = userEvent.setup();
     render(<ImportConfigurationUploadPage />);
 
-    const yamlContent = '---\n# resource_type: application\nname: test-app\n';
+    const yamlContent = 'resource_type: application\nname: test-app\n';
     const envContent = 'KEY=VALUE';
     const yamlFile = new File([yamlContent], 'config.yaml', {type: 'text/yaml'});
     const envFile = new File([envContent], '.env', {type: 'text/plain'});
@@ -242,7 +242,7 @@ describe('ImportConfigurationUploadPage', () => {
     render(<ImportConfigurationUploadPage />);
 
     const yamlContent =
-      '---\n# resource_type: server_config\nname: cors\nvalue:\n  allowedOrigins:\n    - https://example.com\n';
+      'resource_type: server_config\nname: cors\nvalue:\n  allowedOrigins:\n    - https://example.com\n';
     const yamlFile = new File([yamlContent], 'config.yaml', {type: 'text/yaml'});
     Object.defineProperty(yamlFile, 'text', {value: () => Promise.resolve(yamlContent)});
 
@@ -264,6 +264,49 @@ describe('ImportConfigurationUploadPage', () => {
       },
       {timeout: 5000},
     );
+  });
+
+  it('detects resource types from the resource_type YAML field (not comments)', async () => {
+    const user = userEvent.setup();
+    render(<ImportConfigurationUploadPage />);
+
+    const yamlContent =
+      'resource_type: application\n' +
+      'id: claims-demo-m2m-app\n' +
+      'name: Claims Demo M2M Application\n' +
+      'ouHandle: default\n' +
+      '---\n' +
+      'resource_type: agent\n' +
+      'id: claims-demo-agent\n' +
+      'name: Claims Demo Agent\n' +
+      'ouHandle: default\n' +
+      'type: default\n';
+    const yamlFile = new File([yamlContent], 'config.yaml', {type: 'text/yaml'});
+    Object.defineProperty(yamlFile, 'text', {value: () => Promise.resolve(yamlContent)});
+
+    await user.upload(document.getElementById('file-upload') as HTMLInputElement, yamlFile);
+    await user.click(screen.getByRole('button', {name: 'common:actions.continue'}));
+
+    await waitFor(
+      () => {
+        expect(mockNavigate).toHaveBeenCalledWith(
+          '/welcome/import-configuration/validate',
+          expect.objectContaining({
+            state: expect.objectContaining({
+              method: 'file',
+              parseErrors: [],
+              parseStats: {successCount: 2, failCount: 0},
+            }) as Record<string, unknown>,
+          }),
+        );
+      },
+      {timeout: 5000},
+    );
+
+    const {state} = (mockNavigate.mock.calls[0] as [string, {state: {configData: Record<string, unknown[]>}}])[1];
+    expect(Object.keys(state.configData)).toEqual(['application', 'agent']);
+    expect(state.configData.application).toHaveLength(1);
+    expect(state.configData.agent).toHaveLength(1);
   });
 
   it('shows error when file.text() throws during continue', async () => {


### PR DESCRIPTION
### Purpose

Fixes the Console Import UI so it identifies a document's resource type from the `resource_type` YAML field instead of a `# resource_type:` comment.

Previously the UI derived each document's type only by scanning comment lines for `resource_type`, while the backend importer, the export output, and the docs all use `resource_type` as a real YAML field. As a result a spec-compliant file (field form, no comment) imported fine on the backend but the Console preview showed **0 resources**, since every document was categorized as `unknown` and silently dropped.

### Approach

- Read `resource_type` from the parsed YAML field after `yaml.parse()`, using it as the resource type.
- Removed the comment-based `resource_type` detection entirely (no longer supported). The `File:` filename comment extraction is retained for `originalFileName` metadata.
- Updated the affected unit tests to use the field form, and added a test using the issue's exact reproduction YAML (application + agent as fields, no comments).

### Related Issues
- Fixes asgardeo/thunder#4195

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML import handling so resource types are detected from the YAML document’s `resource_type` field.
  * Prevented commented metadata from being misinterpreted during multi-document imports.
  * Enhanced validation and navigation behavior for YAML files containing multiple resources.
* **Tests**
  * Updated YAML fixtures used by import/navigation tests to reflect the updated parsing behavior.
  * Added coverage to confirm multi-resource YAML uploads correctly detect and import resource types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->