### PR TITLE
Improve Connections UI to match the Applications wizard patterns

### DIFF
--- a/docs/content/guides/identity-providers/add-github.mdx
+++ b/docs/content/guides/identity-providers/add-github.mdx
@@ -42,10 +42,9 @@ This guide walks you through registering a GitHub identity provider (IdP) in <Pr
 1. Sign in to the <ProductName /> Console.
 2. Navigate to **Connections**.
 3. Click the **GitHub** card. If the card shows **Not configured**, this opens a form to create the connection. If it already shows **Configured**, this opens the existing connection instead.
-4. Enter your **Client ID** and **Client secret** from the previous step.
-5. Copy the **Redirect URI** shown on the form and add it to your GitHub OAuth app if you have not already done so.
-6. Optionally, set **Scopes**. Include `user:email` to ensure the user's email address is accessible. Leave this blank to use GitHub's own default scope.
-7. Click **Create connection**.
+4. The form shows a setup hint with the **Redirect URI**. Copy it and add it to your GitHub OAuth app's authorization callback URL if you have not already done so.
+5. Enter your **Client ID** and **Client secret** from the previous step.
+6. Click **Create connection**. If you opened an existing **Configured** connection instead, update the credentials and click **Save changes**.
 
 <ProductName /> automatically uses the GitHub authorization, token, and userinfo endpoints. You do not need to supply them.
 
@@ -54,7 +53,9 @@ This guide walks you through registering a GitHub identity provider (IdP) in <Pr
 To map GitHub's profile fields (for example, `login` or `avatar_url`) to local user attributes, open the connection and go to the **Attribute Configuration** tab. See [Attribute Configuration](../add-oidc-provider#attribute-configuration).
 
 :::note
-The GitHub connection also accepts a `prompt` field, forwarded as a query parameter on the authorization request. GitHub's OAuth flow does not define a `prompt` parameter, so this typically has no effect. This field is not available in the Console and can only be set through the [Connections API](../../../apis#tag/connections).
+By default, the connection uses GitHub's own default scope, which does not include the user's email address. To ensure the email address is accessible, open the connection after creation and set **Scopes** to include `user:email` on its edit page.
+
+The GitHub connection also accepts a `prompt` field, forwarded as a query parameter on the authorization request. GitHub's OAuth flow supports `select_account` to force the account picker; other values have no effect. This field is not available in the Console and can only be set through the [Connections API](../../../apis#tag/connections).
 :::
 
 ## Next Steps

--- a/docs/content/guides/identity-providers/add-google.mdx
+++ b/docs/content/guides/identity-providers/add-google.mdx
@@ -40,16 +40,17 @@ This guide walks you through registering a Google identity provider (IdP) in <Pr
 1. Sign in to the <ProductName /> Console.
 2. Navigate to **Connections**.
 3. Click the **Google** card. If the card shows **Not configured**, this opens a form to create the connection. If it already shows **Configured**, this opens the existing connection instead.
-4. Enter your **Client ID** and **Client secret** from the previous step.
-5. Copy the **Redirect URI** shown on the form and add it to your Google OAuth client if you have not already done so.
-6. Optionally, set **Scopes**. This defaults to `openid email profile` if left blank.
-7. Click **Create connection**.
+4. The form shows a setup hint with the **Redirect URI**. Copy it and add it to your Google OAuth client's authorized redirect URIs if you have not already done so.
+5. Enter your **Client ID** and **Client secret** from the previous step.
+6. Click **Create connection**. If you opened an existing **Configured** connection instead, update the credentials and click **Save changes**.
 
 <ProductName /> automatically uses the Google authorization, token, userinfo, and JWKS endpoints. You do not need to supply them.
 
 </Stepper>
 
 :::note
+The connection requests the `openid email profile` scopes by default. To change this, open the connection after creation and set **Scopes** on its edit page.
+
 The Google connection also accepts a `prompt` field to control the Google consent screen behavior (for example, `consent` or `select_account`). This field is not available in the Console and can only be set through the [Connections API](../../../apis#tag/connections).
 :::
 

--- a/docs/content/guides/identity-providers/add-oauth-provider.mdx
+++ b/docs/content/guides/identity-providers/add-oauth-provider.mdx
@@ -14,7 +14,7 @@ This guide explains how to register a generic OAuth 2.0 identity provider (IdP) 
 
 - <ProductName /> is running. See [Get Started](../../../getting-started/get-thunderid).
 - You can sign in to the <ProductName /> Console.
-- A client application registered in the external OAuth 2.0 provider with a **Client ID**, **Client Secret**, and **redirect URI**.
+- A client application registered in the external OAuth 2.0 provider with a **Client ID** and **Client Secret**, and permission to add the **Redirect URI** shown by the Console.
 - The provider's authorization endpoint, token endpoint, and userinfo endpoint URLs.
 
 ## Create the OAuth 2.0 Connection
@@ -32,23 +32,28 @@ This guide explains how to register a generic OAuth 2.0 identity provider (IdP) 
 1. On the **Connection type** step, click **OAuth 2.0 Provider**.
 2. Click **Continue**.
 
-### Step 3: Configure the Connection
+### Step 3: Name the Connection
+
+1. Enter a **Connection name**, or pick one of the suggested names.
+2. Click **Continue**.
+
+### Step 4: Configure the Connection
+
+The form shows a setup hint with the **Redirect URI**. Before creating the connection, copy it and register it as the callback URL with your provider.
 
 Enter the following fields, then click **Create connection**:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| **Connection name** | Yes | A friendly name used to identify this connection. |
 | **Client ID** | Yes | The client ID issued by the OAuth 2.0 provider. |
 | **Client secret** | Yes | The client secret issued by the OAuth 2.0 provider. |
 | **Authorization endpoint** | Yes | The provider's authorization endpoint, used to start the sign-in flow. |
 | **Token endpoint** | Yes | The provider's token endpoint, used to exchange the authorization code for tokens. |
 | **UserInfo endpoint** | Yes | The provider's userinfo endpoint. <ProductName /> calls this endpoint to fetch the authenticated user's profile. |
-| **Scopes** | No | Space-separated OAuth scopes to request. |
-
-The **Redirect URI** field is read-only. Copy its value and register it as the callback URL with your provider.
 
 </Stepper>
+
+After creation, open the connection and set **Scopes** on its edit page to request space-separated OAuth scopes beyond the provider's default.
 
 :::note
 The connection also accepts `logoutEndpoint` and `prompt` fields, and an `attributeConfiguration` field to map this provider's claims to local user attributes. These are not available in the Console and can only be set through the [Connections API](../../../apis#tag/connections). See [Attribute Configuration](../add-oidc-provider#attribute-configuration) for the mapping concepts, which apply the same way to OAuth 2.0 connections.

--- a/docs/content/guides/identity-providers/add-oidc-provider.mdx
+++ b/docs/content/guides/identity-providers/add-oidc-provider.mdx
@@ -14,7 +14,7 @@ This guide explains how to register a generic OpenID Connect (OIDC) identity pro
 
 - <ProductName /> is running. See [Get Started](../../../getting-started/get-thunderid).
 - You can sign in to the <ProductName /> Console.
-- A client application registered in the external OIDC provider with a **Client ID**, **Client Secret**, and **redirect URI**.
+- A client application registered in the external OIDC provider with a **Client ID** and **Client Secret**, and permission to add the **Redirect URI** shown by the Console.
 
 :::tip Finding endpoint URLs
 Most OIDC providers publish their endpoint URLs in a discovery document at:
@@ -41,27 +41,36 @@ Open this URL in a browser to find the `authorization_endpoint`, `token_endpoint
 1. On the **Connection type** step, click **OpenID Connect Provider**.
 2. Click **Continue**.
 
-### Step 3: Configure the Connection
+### Step 3: Name the Connection
+
+1. Enter a **Connection name**, or pick one of the suggested names.
+2. Click **Continue**.
+
+### Step 4: Configure the Connection
+
+The form shows a setup hint with the **Redirect URI**. Before creating the connection, copy it and register it as the callback URL with your OIDC provider.
 
 Enter the following fields, then click **Create connection**:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| **Connection name** | Yes | A friendly name used to identify this connection. |
 | **Client ID** | Yes | The client ID issued by the OIDC provider. |
 | **Client secret** | Yes | The client secret issued by the OIDC provider. |
 | **Authorization endpoint** | Yes | The provider's authorization endpoint, used to start the sign-in flow. |
 | **Token endpoint** | Yes | The provider's token endpoint, used to exchange the authorization code for tokens. |
-| **UserInfo endpoint** | No | The provider's userinfo endpoint. Used to fetch additional profile claims. |
-| **JWKS endpoint** | No | The URL of the provider's JSON Web Key Set. Required when **Enable token exchange** is on. |
-| **Issuer** | No | The provider's issuer identifier, expected in tokens from this provider. Required when **Enable token exchange** is on. |
-| **Scopes** | No | Space-separated OIDC scopes to request. Defaults to `openid email profile` if left blank. |
-
-The **Redirect URI** field is read-only. Copy its value and register it as the callback URL with your OIDC provider.
-
-Under **Federation**, turn on **Enable token exchange** to accept subject tokens from this provider for token exchange. This makes **Issuer** and **JWKS endpoint** required, and reveals an optional **Trusted token audience** field, the accepted audience value for external tokens during token exchange.
 
 </Stepper>
+
+Optional settings are not part of the creation wizard. After creation, open the connection and configure them on its edit page:
+
+| Field | Description |
+|-------|-------------|
+| **UserInfo endpoint** | The provider's userinfo endpoint. Used to fetch additional profile claims. |
+| **JWKS endpoint** | The URL of the provider's JSON Web Key Set. Required when **Enable token exchange** is on. |
+| **Issuer** | The provider's issuer identifier, expected in tokens from this provider. Required when **Enable token exchange** is on. |
+| **Scopes** | Space-separated OIDC scopes to request. Defaults to `openid email profile` if left blank. |
+
+Under **Federation**, turn on **Enable token exchange** to accept subject tokens from this provider for token exchange. This makes **Issuer** and **JWKS endpoint** required, and reveals an optional **Trusted token audience** field, the accepted audience value for external tokens during token exchange.
 
 :::note
 The connection also accepts `logoutEndpoint` and `prompt` fields. These are not available in the Console and can only be set through the [Connections API](../../../apis#tag/connections).

--- a/docs/content/guides/identity-providers/manage-identity-providers.mdx
+++ b/docs/content/guides/identity-providers/manage-identity-providers.mdx
@@ -40,6 +40,8 @@ On the detail page, the **General** tab's **Quick copy** section shows the **Con
 
 Only custom OIDC and OAuth 2.0 connections have an editable **Connection name**. Google, GitHub, and other branded connections keep the vendor's name.
 
+Settings not shown during creation are also configured here: **Scopes** for all connection types, and for OIDC connections the **UserInfo endpoint**, **JWKS endpoint**, **Issuer**, and **Enable token exchange** with its **Trusted token audience** field.
+
 Changes take effect immediately for new authentication requests.
 
 ## Delete an Identity Provider

--- a/frontend/apps/console/src/features/connections/pages/ConnectionCreateWizardRoute.tsx
+++ b/frontend/apps/console/src/features/connections/pages/ConnectionCreateWizardRoute.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {ConnectionCreateWizardPage} from '@thunderid/configure-connections';
+import {ConnectionCreateWizardPage, type CustomConfigureStepProps} from '@thunderid/configure-connections';
 import type {JSX} from 'react';
 import TrustedIssuerWizardStep from '../../trusted-issuers/pages/TrustedIssuerWizardStep';
 
@@ -26,5 +26,13 @@ import TrustedIssuerWizardStep from '../../trusted-issuers/pages/TrustedIssuerWi
  * rather than the `configure-connections` package.
  */
 export default function ConnectionCreateWizardRoute(): JSX.Element {
-  return <ConnectionCreateWizardPage customConfigureSteps={{'trusted-idp': <TrustedIssuerWizardStep />}} />;
+  return (
+    <ConnectionCreateWizardPage
+      customConfigureSteps={{
+        'trusted-idp': ({name, onNameConflict}: CustomConfigureStepProps) => (
+          <TrustedIssuerWizardStep name={name} onNameConflict={onNameConflict} />
+        ),
+      }}
+    />
+  );
 }

--- a/frontend/apps/console/src/features/connections/pages/__tests__/ConnectionCreateWizardRoute.test.tsx
+++ b/frontend/apps/console/src/features/connections/pages/__tests__/ConnectionCreateWizardRoute.test.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import type {CustomConfigureStepProps} from '@thunderid/configure-connections';
 import {render, screen} from '@thunderid/test-utils';
 import type {ReactNode} from 'react';
 import {describe, expect, it, vi} from 'vitest';
@@ -26,21 +27,25 @@ vi.mock('@thunderid/configure-connections', async (importOriginal) => ({
   ConnectionCreateWizardPage: ({
     customConfigureSteps = undefined,
   }: {
-    customConfigureSteps?: Record<string, ReactNode>;
-  }) => <div data-testid="stub-wizard">{customConfigureSteps?.['trusted-idp']}</div>,
+    customConfigureSteps?: Record<string, (props: CustomConfigureStepProps) => ReactNode>;
+  }) => (
+    <div data-testid="stub-wizard">
+      {customConfigureSteps?.['trusted-idp']?.({name: 'Acme Issuer', onNameConflict: vi.fn()})}
+    </div>
+  ),
 }));
 
 vi.mock('../../../trusted-issuers/pages/TrustedIssuerWizardStep', () => ({
-  default: function StubTrustedIssuerWizardStep() {
-    return <div data-testid="stub-trusted-issuer-wizard-step" />;
+  default: function StubTrustedIssuerWizardStep({name}: {name: string}) {
+    return <div data-testid="stub-trusted-issuer-wizard-step">{name}</div>;
   },
 }));
 
 describe('ConnectionCreateWizardRoute', () => {
-  it('should wire the trusted-idp custom configure step to TrustedIssuerWizardStep', () => {
+  it('should wire the trusted-idp custom configure step to TrustedIssuerWizardStep, passing the wizard name through', () => {
     render(<ConnectionCreateWizardRoute />);
 
     expect(screen.getByTestId('stub-wizard')).toBeInTheDocument();
-    expect(screen.getByTestId('stub-trusted-issuer-wizard-step')).toBeInTheDocument();
+    expect(screen.getByTestId('stub-trusted-issuer-wizard-step')).toHaveTextContent('Acme Issuer');
   });
 });

--- a/frontend/apps/console/src/features/trusted-issuers/components/TrustedIssuerCreateForm.tsx
+++ b/frontend/apps/console/src/features/trusted-issuers/components/TrustedIssuerCreateForm.tsx
@@ -41,28 +41,33 @@ import validateTrustedIssuerForm, {
 } from '../utils/validateTrustedIssuerForm';
 import {isConflictError} from '@thunderid/configure-connections';
 
+interface TrustedIssuerCreateFormProps {
+  /** Connection name collected on the wizard's name step. */
+  name: string;
+  /** Call when the create request 409s on a duplicate name, to bounce back to the name step. */
+  onNameConflict: () => void;
+}
+
 /**
  * The trusted-issuer create form: fields, validation, and submission via
  * {@link useCreateTrustedIssuer}. On success, navigates to the created issuer's detail page.
  *
  * Has no back/cancel affordance of its own — callers (the "Add custom connection" wizard) provide
- * that chrome.
+ * that chrome, and collect the connection name on a preceding step.
  */
-export default function TrustedIssuerCreateForm(): JSX.Element {
+export default function TrustedIssuerCreateForm({name, onNameConflict}: TrustedIssuerCreateFormProps): JSX.Element {
   const {t} = useTranslation();
   const navigate = useNavigate();
   const {config} = useConfig();
   const productName = config.brand.product_name;
   const createTrustedIssuer = useCreateTrustedIssuer();
 
-  const [name, setName] = useState('');
   const [issuer, setIssuer] = useState('');
   const [jwksEndpoint, setJwksEndpoint] = useState('');
   const [idJagEnabled, setIdJagEnabled] = useState(false);
   const [tokenExchangeEnabled, setTokenExchangeEnabled] = useState(true);
   const [trustedTokenAudience, setTrustedTokenAudience] = useState('');
   const [touched, setTouched] = useState<Record<string, boolean>>({});
-  const [nameError, setNameError] = useState<string | null>(null);
 
   const errors: TrustedIssuerFormErrors = useMemo(
     () => validateTrustedIssuerForm({name, issuer, jwksEndpoint}),
@@ -85,10 +90,9 @@ export default function TrustedIssuerCreateForm(): JSX.Element {
   const handleCreate = (): void => {
     if (!formValid) return;
 
-    setNameError(null);
     createTrustedIssuer.mutate(
       {
-        name: name.trim(),
+        name,
         issuer: issuer.trim(),
         jwksEndpoint: jwksEndpoint.trim(),
         idJagEnabled,
@@ -101,7 +105,7 @@ export default function TrustedIssuerCreateForm(): JSX.Element {
         },
         onError: (error) => {
           if (isConflictError(error)) {
-            setNameError(t('trustedIssuers:create.duplicateName', 'A trusted issuer with this name already exists.'));
+            onNameConflict();
           }
         },
       },
@@ -111,10 +115,10 @@ export default function TrustedIssuerCreateForm(): JSX.Element {
   return (
     <Stack direction="column" spacing={3}>
       <Stack direction="column" spacing={1}>
-        <Typography variant="h4" fontWeight={700}>
+        <Typography variant="h1" gutterBottom>
           {t('trustedIssuers:create.title', 'Add trusted issuer')}
         </Typography>
-        <Typography variant="body1" color="text.secondary">
+        <Typography variant="subtitle1" gutterBottom>
           {t(
             'trustedIssuers:create.subtitle',
             'Register an external identity provider whose identity assertions ThunderID can exchange for access tokens.',
@@ -124,22 +128,6 @@ export default function TrustedIssuerCreateForm(): JSX.Element {
 
       <Paper variant="outlined" sx={{p: 3}}>
         <Stack direction="column" spacing={3}>
-          <FormControl fullWidth required error={Boolean(nameError ?? (touched.name && errors.name))}>
-            <FormLabel htmlFor="trusted-issuer-name">{t('trustedIssuers:create.form.name.label', 'Name')}</FormLabel>
-            <TextField
-              id="trusted-issuer-name"
-              fullWidth
-              value={name}
-              error={Boolean(nameError ?? (touched.name && errors.name))}
-              helperText={nameError ?? (touched.name ? fieldErrorMessage(errors.name) : undefined)}
-              onChange={(e) => {
-                setName(e.target.value);
-                setNameError(null);
-              }}
-              onBlur={() => setTouchedField('name')}
-            />
-          </FormControl>
-
           <FormControl fullWidth required error={Boolean(touched.issuer && errors.issuer)}>
             <FormLabel htmlFor="trusted-issuer-issuer">
               {t('trustedIssuers:create.form.issuer.label', 'Issuer URI')}

--- a/frontend/apps/console/src/features/trusted-issuers/components/__tests__/TrustedIssuerCreateForm.test.tsx
+++ b/frontend/apps/console/src/features/trusted-issuers/components/__tests__/TrustedIssuerCreateForm.test.tsx
@@ -41,25 +41,32 @@ const {useNavigate} = await import('react-router');
 
 describe('TrustedIssuerCreateForm', () => {
   let mockNavigate: ReturnType<typeof vi.fn>;
+  let onNameConflict: ReturnType<typeof vi.fn<() => void>>;
 
   beforeEach(() => {
     mockNavigate = vi.fn();
+    onNameConflict = vi.fn<() => void>();
     mockMutate.mockReset();
     vi.mocked(useNavigate).mockReturnValue(mockNavigate as unknown as NavigateFunction);
   });
 
   it('should render the form with the ID-JAG switch off and token exchange switch on by default', () => {
-    render(<TrustedIssuerCreateForm />);
+    render(<TrustedIssuerCreateForm name="Acme Okta" onNameConflict={onNameConflict} />);
 
-    expect(screen.getByLabelText(/^Name/)).toBeInTheDocument();
     expect(screen.getByLabelText(/^Issuer URI/)).toBeInTheDocument();
     expect(screen.getByLabelText(/^JWKS endpoint/)).toBeInTheDocument();
     expect(screen.getByRole('switch', {name: /id-jag/i})).not.toBeChecked();
     expect(screen.getByRole('switch', {name: /enable token exchange/i})).toBeChecked();
   });
 
+  it('should not render a name field (collected on the wizard name step)', () => {
+    render(<TrustedIssuerCreateForm name="Acme Okta" onNameConflict={onNameConflict} />);
+
+    expect(screen.queryByLabelText(/^Name/)).not.toBeInTheDocument();
+  });
+
   it('should have no back or cancel affordance of its own', () => {
-    render(<TrustedIssuerCreateForm />);
+    render(<TrustedIssuerCreateForm name="Acme Okta" onNameConflict={onNameConflict} />);
 
     expect(screen.queryByRole('button', {name: /back/i})).not.toBeInTheDocument();
     expect(screen.queryByRole('button', {name: /^cancel$/i})).not.toBeInTheDocument();
@@ -67,12 +74,9 @@ describe('TrustedIssuerCreateForm', () => {
 
   it('should disable the submit button until all required fields are valid', async () => {
     const user = userEvent.setup();
-    render(<TrustedIssuerCreateForm />);
+    render(<TrustedIssuerCreateForm name="Acme Okta" onNameConflict={onNameConflict} />);
 
     const submitButton = screen.getByTestId('trusted-issuer-create-submit');
-    expect(submitButton).toBeDisabled();
-
-    await user.type(screen.getByLabelText(/^Name/), 'Acme Okta');
     expect(submitButton).toBeDisabled();
 
     await user.type(screen.getByLabelText(/^Issuer URI/), 'https://acme.okta.com');
@@ -84,7 +88,7 @@ describe('TrustedIssuerCreateForm', () => {
 
   it('should show a validation error when an issuer URI is not https', async () => {
     const user = userEvent.setup();
-    render(<TrustedIssuerCreateForm />);
+    render(<TrustedIssuerCreateForm name="Acme Okta" onNameConflict={onNameConflict} />);
 
     const issuerField = screen.getByLabelText(/^Issuer URI/);
     await user.type(issuerField, 'http://acme.okta.com');
@@ -95,16 +99,16 @@ describe('TrustedIssuerCreateForm', () => {
 
   it('should show a required error when a field is left blank on blur', async () => {
     const user = userEvent.setup();
-    render(<TrustedIssuerCreateForm />);
+    render(<TrustedIssuerCreateForm name="Acme Okta" onNameConflict={onNameConflict} />);
 
-    const nameField = screen.getByLabelText(/^Name/);
-    await user.click(nameField);
+    const issuerField = screen.getByLabelText(/^Issuer URI/);
+    await user.click(issuerField);
     await user.tab();
 
     expect(await screen.findByText('This field is required.')).toBeInTheDocument();
   });
 
-  it('should submit the form and navigate to the detail page on success', async () => {
+  it('should submit the form with the wizard-collected name and navigate to the detail page on success', async () => {
     const user = userEvent.setup();
     mockMutate.mockImplementation((_data, opts) => {
       opts.onSuccess({
@@ -116,9 +120,8 @@ describe('TrustedIssuerCreateForm', () => {
       });
     });
 
-    render(<TrustedIssuerCreateForm />);
+    render(<TrustedIssuerCreateForm name="Acme Okta" onNameConflict={onNameConflict} />);
 
-    await user.type(screen.getByLabelText(/^Name/), 'Acme Okta');
     await user.type(screen.getByLabelText(/^Issuer URI/), 'https://acme.okta.com');
     await user.type(screen.getByLabelText(/^JWKS endpoint/), 'https://acme.okta.com/keys');
     await user.click(screen.getByTestId('trusted-issuer-create-submit'));
@@ -140,21 +143,20 @@ describe('TrustedIssuerCreateForm', () => {
     });
   });
 
-  it('should show an inline duplicate-name error on 409 conflict without navigating', async () => {
+  it('should call onNameConflict on a 409 conflict without navigating', async () => {
     const user = userEvent.setup();
     mockMutate.mockImplementation((_data, opts) => {
       opts.onError({response: {status: 409}});
     });
 
-    render(<TrustedIssuerCreateForm />);
+    render(<TrustedIssuerCreateForm name="Acme Okta" onNameConflict={onNameConflict} />);
 
-    await user.type(screen.getByLabelText(/^Name/), 'Acme Okta');
     await user.type(screen.getByLabelText(/^Issuer URI/), 'https://acme.okta.com');
     await user.type(screen.getByLabelText(/^JWKS endpoint/), 'https://acme.okta.com/keys');
     await user.click(screen.getByTestId('trusted-issuer-create-submit'));
 
-    expect(await screen.findByText('A trusted issuer with this name already exists.')).toBeInTheDocument();
-    expect(mockNavigate).not.toHaveBeenCalledWith(expect.stringContaining('/trusted-issuers/'));
+    await waitFor(() => expect(onNameConflict).toHaveBeenCalledTimes(1));
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it('should turn on ID-JAG when the switch is toggled', async () => {
@@ -169,10 +171,9 @@ describe('TrustedIssuerCreateForm', () => {
       });
     });
 
-    render(<TrustedIssuerCreateForm />);
+    render(<TrustedIssuerCreateForm name="Beta AD" onNameConflict={onNameConflict} />);
 
     await user.click(screen.getByRole('switch', {name: /id-jag/i}));
-    await user.type(screen.getByLabelText(/^Name/), 'Beta AD');
     await user.type(screen.getByLabelText(/^Issuer URI/), 'https://beta.example.com');
     await user.type(screen.getByLabelText(/^JWKS endpoint/), 'https://beta.example.com/keys');
     await user.click(screen.getByTestId('trusted-issuer-create-submit'));
@@ -181,7 +182,7 @@ describe('TrustedIssuerCreateForm', () => {
   });
 
   it('should not render a client id field', () => {
-    render(<TrustedIssuerCreateForm />);
+    render(<TrustedIssuerCreateForm name="Acme Okta" onNameConflict={onNameConflict} />);
 
     expect(screen.queryByLabelText(/^Client ID/)).not.toBeInTheDocument();
   });

--- a/frontend/apps/console/src/features/trusted-issuers/pages/TrustedIssuerWizardStep.tsx
+++ b/frontend/apps/console/src/features/trusted-issuers/pages/TrustedIssuerWizardStep.tsx
@@ -19,11 +19,19 @@
 import type {JSX} from 'react';
 import TrustedIssuerCreateForm from '../components/TrustedIssuerCreateForm';
 
+interface TrustedIssuerWizardStepProps {
+  /** Connection name collected on the wizard's name step. */
+  name: string;
+  /** Call when the create request 409s on a duplicate name, to bounce back to the name step. */
+  onNameConflict: () => void;
+}
+
 /**
  * The "trusted-idp" configure step plugged into the "Add custom connection" wizard (see
  * `customConfigureSteps` on `ConnectionCreateWizardPage`). Renders the trusted-issuer create
- * form; the wizard supplies the surrounding chrome (breadcrumb, progress, Back, close).
+ * form; the wizard supplies the surrounding chrome (breadcrumb, progress, Back, close) and the
+ * name, collected on its own name step.
  */
-export default function TrustedIssuerWizardStep(): JSX.Element {
-  return <TrustedIssuerCreateForm />;
+export default function TrustedIssuerWizardStep({name, onNameConflict}: TrustedIssuerWizardStepProps): JSX.Element {
+  return <TrustedIssuerCreateForm name={name} onNameConflict={onNameConflict} />;
 }

--- a/frontend/apps/console/src/features/trusted-issuers/pages/__tests__/TrustedIssuerWizardStep.test.tsx
+++ b/frontend/apps/console/src/features/trusted-issuers/pages/__tests__/TrustedIssuerWizardStep.test.tsx
@@ -21,15 +21,15 @@ import {describe, expect, it, vi} from 'vitest';
 import TrustedIssuerWizardStep from '../TrustedIssuerWizardStep';
 
 vi.mock('../../components/TrustedIssuerCreateForm', () => ({
-  default: function StubTrustedIssuerCreateForm() {
-    return <div data-testid="stub-trusted-issuer-create-form" />;
+  default: function StubTrustedIssuerCreateForm({name}: {name: string}) {
+    return <div data-testid="stub-trusted-issuer-create-form">{name}</div>;
   },
 }));
 
 describe('TrustedIssuerWizardStep', () => {
-  it('should render the trusted issuer create form', () => {
-    render(<TrustedIssuerWizardStep />);
+  it('should render the trusted issuer create form, forwarding the wizard name', () => {
+    render(<TrustedIssuerWizardStep name="Acme Issuer" onNameConflict={vi.fn()} />);
 
-    expect(screen.getByTestId('stub-trusted-issuer-create-form')).toBeInTheDocument();
+    expect(screen.getByTestId('stub-trusted-issuer-create-form')).toHaveTextContent('Acme Issuer');
   });
 });

--- a/frontend/packages/configure-connections/src/components/ConnectionCategoryFilters.tsx
+++ b/frontend/packages/configure-connections/src/components/ConnectionCategoryFilters.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {Chip, Stack, Typography} from '@wso2/oxygen-ui';
+import {Chip, Stack} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {AVAILABLE_CONNECTION_CATEGORIES} from '../config/connectionVendorMeta';
@@ -43,17 +43,14 @@ export default function ConnectionCategoryFilters({selected, onSelect}: Connecti
       useFlexGap
       data-testid="connection-category-filters"
     >
-      <Typography variant="caption" color="text.secondary" sx={{textTransform: 'uppercase', fontWeight: 600, mr: 0.5}}>
-        {t('filters.label')}
-      </Typography>
       {values.map((value) => (
         <Chip
           key={value}
           label={t(`categories.${value}`)}
-          clickable
           color={selected === value ? 'primary' : 'default'}
           variant={selected === value ? 'filled' : 'outlined'}
           onClick={() => onSelect(value)}
+          sx={{borderRadius: '20px', cursor: 'pointer'}}
         />
       ))}
     </Stack>

--- a/frontend/packages/configure-connections/src/components/ConnectionCreateHint.tsx
+++ b/frontend/packages/configure-connections/src/components/ConnectionCreateHint.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Alert, Stack, Typography} from '@wso2/oxygen-ui';
+import type {JSX} from 'react';
+import {useTranslation} from 'react-i18next';
+import ReadOnlyCopyField from './ReadOnlyCopyField';
+
+interface ConnectionCreateHintProps {
+  /** Translated setup instruction shown above the redirect URI. */
+  instruction: string;
+  /** Derived gate callback URL the admin must register with the provider. */
+  redirectUri: string;
+}
+
+/**
+ * Setup hint shown above the credentials form on connection creation: instructs the admin to
+ * register an OAuth app with the provider first, and surfaces the redirect URI to copy into it.
+ */
+export default function ConnectionCreateHint({instruction, redirectUri}: ConnectionCreateHintProps): JSX.Element {
+  const {t} = useTranslation('connections');
+
+  return (
+    <Alert severity="info" data-testid="connection-create-hint">
+      <Stack direction="column" spacing={1.5}>
+        <Typography variant="body2">{instruction}</Typography>
+        <ReadOnlyCopyField
+          id="create-hint-redirect-uri"
+          label={t('form.fields.redirectUri.label', 'Redirect URI')}
+          value={redirectUri}
+        />
+      </Stack>
+    </Alert>
+  );
+}

--- a/frontend/packages/configure-connections/src/components/ConnectionForm.tsx
+++ b/frontend/packages/configure-connections/src/components/ConnectionForm.tsx
@@ -32,7 +32,7 @@ import {type JSX, type ReactNode, useMemo, useState} from 'react';
 import {Trans, useTranslation} from 'react-i18next';
 import MaskedSecretField from './MaskedSecretField';
 import ReadOnlyCopyField from './ReadOnlyCopyField';
-import {CONNECTION_FORM_FIELDS, type ConnectionFieldDef} from '../config/connectionFormFields';
+import {fieldsForMode, type ConnectionFieldDef} from '../config/connectionFormFields';
 import type {ConnectionType} from '../models/connection';
 import {type ConnectionFormValues, validateConnectionForm} from '../utils/connectionFormMapping';
 
@@ -50,8 +50,6 @@ interface ConnectionFormProps {
   nameError?: string | null;
   /** Render the connection-name field (custom connections only; branded names are fixed). */
   showNameField?: boolean;
-  /** Render the redirect URI field (moved to a quick-copy section on the edit page). */
-  showRedirectUri?: boolean;
   onFieldChange: (name: string, value: string) => void;
   onSecretReplacingChange: (replacing: boolean) => void;
 }
@@ -65,17 +63,13 @@ export default function ConnectionForm({
   vendorDisplayName,
   nameError = null,
   showNameField = true,
-  showRedirectUri = true,
   onFieldChange,
   onSecretReplacingChange,
 }: ConnectionFormProps): JSX.Element {
   const {t} = useTranslation('connections');
   const fields: ConnectionFieldDef[] = useMemo(
-    () =>
-      CONNECTION_FORM_FIELDS[type].filter(
-        (field) => (showNameField || field.name !== 'name') && (showRedirectUri || field.name !== 'redirectUri'),
-      ),
-    [type, showNameField, showRedirectUri],
+    () => fieldsForMode(type, mode).filter((field) => showNameField || field.name !== 'name'),
+    [type, mode, showNameField],
   );
 
   const [touched, setTouched] = useState<Record<string, boolean>>({});

--- a/frontend/packages/configure-connections/src/components/ConnectionFullPageLayout.tsx
+++ b/frontend/packages/configure-connections/src/components/ConnectionFullPageLayout.tsx
@@ -27,6 +27,8 @@ interface ConnectionFullPageLayoutProps {
   progress?: number;
   /** Optional breadcrumb rendered in the header instead of the plain label. */
   breadcrumb?: ReactNode;
+  /** Let the content column span the full page width (e.g. a type-selection gallery). */
+  fullWidthContent?: boolean;
   children: ReactNode;
 }
 
@@ -40,6 +42,7 @@ export default function ConnectionFullPageLayout({
   onClose,
   progress = undefined,
   breadcrumb = undefined,
+  fullWidthContent = false,
   children,
 }: ConnectionFullPageLayoutProps): JSX.Element {
   return (
@@ -73,7 +76,10 @@ export default function ConnectionFullPageLayout({
             width: '100%',
           }}
         >
-          <Box data-testid="connection-fullpage-content" sx={{width: '100%', maxWidth: 920}}>
+          <Box
+            data-testid="connection-fullpage-content"
+            sx={{width: '100%', maxWidth: fullWidthContent ? 'none' : 920}}
+          >
             {children}
           </Box>
         </Box>

--- a/frontend/packages/configure-connections/src/components/__tests__/ConnectionCreateHint.test.tsx
+++ b/frontend/packages/configure-connections/src/components/__tests__/ConnectionCreateHint.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen} from '@thunderid/test-utils';
+import {describe, expect, it, vi} from 'vitest';
+import ConnectionCreateHint from '../ConnectionCreateHint';
+
+vi.mock('@thunderid/contexts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@thunderid/contexts')>()),
+  useToast: () => ({showToast: vi.fn()}),
+}));
+
+describe('ConnectionCreateHint', () => {
+  it('renders the instruction and the redirect URI as a read-only copy field', () => {
+    render(
+      <ConnectionCreateHint
+        instruction="Create an OAuth client for your app, then enter the credentials it gives you."
+        redirectUri="https://id.acme.io/gate/callback"
+      />,
+    );
+
+    expect(
+      screen.getByText('Create an OAuth client for your app, then enter the credentials it gives you.'),
+    ).toBeInTheDocument();
+    expect(screen.getByDisplayValue('https://id.acme.io/gate/callback')).toBeInTheDocument();
+    expect(screen.getByTestId('create-hint-redirect-uri-copy')).toBeInTheDocument();
+  });
+});

--- a/frontend/packages/configure-connections/src/components/__tests__/ConnectionForm.test.tsx
+++ b/frontend/packages/configure-connections/src/components/__tests__/ConnectionForm.test.tsx
@@ -61,7 +61,6 @@ describe('ConnectionForm', () => {
 
     expect(screen.getByText('OAuth2 client identifier used for authentication.')).toBeInTheDocument();
     expect(screen.getByText('OAuth2 client secret issued by your identity provider.')).toBeInTheDocument();
-    expect(screen.getByText(/Space-separated scopes to request during sign-in\. Defaults to/)).toBeInTheDocument();
 
     fireEvent.blur(getConnectionField('clientId'));
 
@@ -80,20 +79,61 @@ describe('ConnectionForm', () => {
     expect(onFieldChange).toHaveBeenCalledWith('clientId', 'my-client-id');
   });
 
-  it('renders the redirect URI as a read-only copy field with the derived value', () => {
+  it('does not render the redirect URI or scopes fields on create (moved to a create hint / edit view)', () => {
     render(<ConnectionForm {...baseProps} />);
+
+    expect(document.getElementById('connection-field-redirectUri')).not.toBeInTheDocument();
+    expect(document.getElementById('connection-field-scopes')).not.toBeInTheDocument();
+  });
+
+  it('renders the redirect URI as a read-only copy field and the scopes field on edit', () => {
+    render(<ConnectionForm {...baseProps} mode="edit" hasStoredSecret />);
 
     const field = getConnectionField('redirectUri') as HTMLInputElement;
     expect(field).toHaveValue('https://id.acme.io/oauth/callback/google');
     expect(field).toHaveAttribute('readonly');
     expect(screen.getByTestId('connection-field-redirectUri-copy')).toBeInTheDocument();
     expect(screen.getByText('Add this exact URI to your Google OAuth client.')).toBeInTheDocument();
+    expect(screen.getByText(/Space-separated scopes to request during sign-in\. Defaults to/)).toBeInTheDocument();
   });
 
-  describe('OIDC federation fields', () => {
-    const oidcProps = {
+  describe('OIDC create', () => {
+    const oidcCreateProps = {
       ...baseProps,
       type: 'oidc' as const,
+      values: {
+        name: '',
+        clientId: '',
+        clientSecret: '',
+        authorizationEndpoint: '',
+        tokenEndpoint: '',
+        redirectUri: 'https://id.acme.io/oauth/callback/oidc',
+      },
+    };
+
+    it('renders only the required fields and no Federation section', () => {
+      render(<ConnectionForm {...oidcCreateProps} />);
+
+      expect(getConnectionField('clientId')).toBeInTheDocument();
+      expect(getConnectionField('clientSecret')).toBeInTheDocument();
+      expect(getConnectionField('authorizationEndpoint')).toBeInTheDocument();
+      expect(getConnectionField('tokenEndpoint')).toBeInTheDocument();
+      expect(document.getElementById('connection-field-userInfoEndpoint')).not.toBeInTheDocument();
+      expect(document.getElementById('connection-field-issuer')).not.toBeInTheDocument();
+      expect(document.getElementById('connection-field-jwksEndpoint')).not.toBeInTheDocument();
+      expect(document.getElementById('connection-field-redirectUri')).not.toBeInTheDocument();
+      expect(document.getElementById('connection-field-scopes')).not.toBeInTheDocument();
+      expect(screen.queryByRole('switch', {name: 'Enable token exchange'})).not.toBeInTheDocument();
+      expect(screen.queryByRole('heading', {name: 'Federation'})).not.toBeInTheDocument();
+    });
+  });
+
+  describe('OIDC edit federation fields', () => {
+    const oidcEditProps = {
+      ...baseProps,
+      type: 'oidc' as const,
+      mode: 'edit' as const,
+      hasStoredSecret: true,
       values: {
         name: '',
         clientId: '',
@@ -111,13 +151,13 @@ describe('ConnectionForm', () => {
     };
 
     it('renders the Federation section heading above the tokenExchangeEnabled field', () => {
-      render(<ConnectionForm {...oidcProps} />);
+      render(<ConnectionForm {...oidcEditProps} />);
 
       expect(screen.getByRole('heading', {name: 'Federation'})).toBeInTheDocument();
     });
 
     it('renders a switch for the tokenExchangeEnabled field', () => {
-      render(<ConnectionForm {...oidcProps} />);
+      render(<ConnectionForm {...oidcEditProps} />);
 
       const toggle = screen.getByRole('switch', {name: 'Enable token exchange'});
       expect(toggle).toBeInTheDocument();
@@ -126,7 +166,7 @@ describe('ConnectionForm', () => {
 
     it('reports the switch toggle through onFieldChange as a "true"/"false" string', () => {
       const onFieldChange = vi.fn();
-      render(<ConnectionForm {...oidcProps} onFieldChange={onFieldChange} />);
+      render(<ConnectionForm {...oidcEditProps} onFieldChange={onFieldChange} />);
 
       const toggle = screen.getByRole('switch', {name: 'Enable token exchange'});
       fireEvent.click(toggle);
@@ -135,26 +175,26 @@ describe('ConnectionForm', () => {
     });
 
     it('hides trustedTokenAudience when tokenExchangeEnabled is off', () => {
-      render(<ConnectionForm {...oidcProps} />);
+      render(<ConnectionForm {...oidcEditProps} />);
 
       expect(document.getElementById('connection-field-trustedTokenAudience')).not.toBeInTheDocument();
     });
 
     it('shows trustedTokenAudience when tokenExchangeEnabled is on', () => {
-      render(<ConnectionForm {...oidcProps} values={{...oidcProps.values, tokenExchangeEnabled: 'true'}} />);
+      render(<ConnectionForm {...oidcEditProps} values={{...oidcEditProps.values, tokenExchangeEnabled: 'true'}} />);
 
       expect(document.getElementById('connection-field-trustedTokenAudience')).toBeInTheDocument();
     });
 
     it('does not mark issuer/jwksEndpoint required when tokenExchangeEnabled is off', () => {
-      render(<ConnectionForm {...oidcProps} />);
+      render(<ConnectionForm {...oidcEditProps} />);
 
       expect(isFieldMarkedRequired('issuer')).toBe(false);
       expect(isFieldMarkedRequired('jwksEndpoint')).toBe(false);
     });
 
     it('marks issuer/jwksEndpoint required when tokenExchangeEnabled is on', () => {
-      render(<ConnectionForm {...oidcProps} values={{...oidcProps.values, tokenExchangeEnabled: 'true'}} />);
+      render(<ConnectionForm {...oidcEditProps} values={{...oidcEditProps.values, tokenExchangeEnabled: 'true'}} />);
 
       expect(isFieldMarkedRequired('issuer')).toBe(true);
       expect(isFieldMarkedRequired('jwksEndpoint')).toBe(true);

--- a/frontend/packages/configure-connections/src/components/__tests__/ConnectionFullPageLayout.test.tsx
+++ b/frontend/packages/configure-connections/src/components/__tests__/ConnectionFullPageLayout.test.tsx
@@ -36,4 +36,17 @@ describe('ConnectionFullPageLayout', () => {
     expect(content).not.toHaveStyle({marginLeft: 'auto'});
     expect(content).not.toHaveStyle({marginRight: 'auto'});
   });
+
+  it('lets the content column span the full width when fullWidthContent is set', () => {
+    render(
+      <ConnectionFullPageLayout label="Choose a type" onClose={vi.fn()} fullWidthContent>
+        <div>Type gallery</div>
+      </ConnectionFullPageLayout>,
+    );
+
+    const content = screen.getByTestId('connection-fullpage-content');
+    const styles = window.getComputedStyle(content);
+
+    expect(styles.maxWidth).toBe('none');
+  });
 });

--- a/frontend/packages/configure-connections/src/components/create-connection/ConnectionNameStep.tsx
+++ b/frontend/packages/configure-connections/src/components/create-connection/ConnectionNameStep.tsx
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {generateRandomHumanReadableIdentifiers} from '@thunderid/utils';
+import {Box, Chip, FormControl, FormLabel, Stack, TextField, Typography, useTheme} from '@wso2/oxygen-ui';
+import {Lightbulb} from '@wso2/oxygen-ui-icons-react';
+import {type JSX, useMemo} from 'react';
+import {useTranslation} from 'react-i18next';
+
+interface ConnectionNameStepProps {
+  name: string;
+  onNameChange: (name: string) => void;
+  /** External error, e.g. a duplicate-name 409 bounced back from a later step. */
+  nameError?: string | null;
+}
+
+/**
+ * The name step of the "Add custom connection" wizard: a text field for the connection name plus
+ * random name suggestions, mirroring the application creation wizard's name step.
+ */
+export default function ConnectionNameStep({
+  name,
+  onNameChange,
+  nameError = null,
+}: ConnectionNameStepProps): JSX.Element {
+  const {t} = useTranslation('connections');
+  const theme = useTheme();
+
+  const nameSuggestions: string[] = useMemo((): string[] => generateRandomHumanReadableIdentifiers(), []);
+
+  return (
+    <Stack direction="column" spacing={4} data-testid="connection-name-step">
+      <Typography variant="h1" gutterBottom>
+        {t('wizard.name.title', "Let's give a name to your connection")}
+      </Typography>
+
+      <FormControl fullWidth required error={Boolean(nameError)}>
+        <FormLabel htmlFor="connection-name-input">{t('wizard.name.fieldLabel', 'Connection name')}</FormLabel>
+        <TextField
+          fullWidth
+          id="connection-name-input"
+          value={name}
+          error={Boolean(nameError)}
+          helperText={nameError ?? undefined}
+          onChange={(e) => onNameChange(e.target.value)}
+          placeholder={t('wizard.name.placeholder', 'Enter your connection name')}
+          inputProps={{'data-testid': 'connection-name-input'}}
+        />
+      </FormControl>
+
+      <Stack direction="column" spacing={2}>
+        <Stack direction="row" alignItems="center" spacing={1}>
+          <Lightbulb size={20} color={theme.vars?.palette.warning.main} />
+          <Typography variant="body2" color="text.secondary">
+            {t('wizard.name.suggestions.label', 'In a hurry? Pick a random name:')}
+          </Typography>
+        </Stack>
+        <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 1}}>
+          {nameSuggestions.map((suggestion) => (
+            <Chip
+              key={suggestion}
+              label={suggestion}
+              onClick={() => onNameChange(suggestion)}
+              variant="outlined"
+              clickable
+              sx={{
+                '&:hover': {
+                  bgcolor: 'primary.main',
+                  color: 'text.primary',
+                  borderColor: 'primary.main',
+                },
+              }}
+            />
+          ))}
+        </Box>
+      </Stack>
+    </Stack>
+  );
+}

--- a/frontend/packages/configure-connections/src/components/create-connection/SelectConnectionType.tsx
+++ b/frontend/packages/configure-connections/src/components/create-connection/SelectConnectionType.tsx
@@ -108,14 +108,21 @@ export default function SelectConnectionType({
 
   return (
     <Stack direction="column" spacing={1} data-testid="select-connection-type">
-      <Typography variant="h4" fontWeight={700}>
+      <Typography variant="h1" gutterBottom>
         {t('wizard.type.heading')}
       </Typography>
-      <Typography variant="body1" color="text.secondary">
+      <Typography variant="subtitle1" gutterBottom>
         {t('wizard.type.subheading')}
       </Typography>
 
-      <Box sx={{display: 'grid', gridTemplateColumns: {xs: '1fr', sm: 'repeat(2, 1fr)'}, gap: 2, mt: 3, maxWidth: 760}}>
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: {xs: '1fr', sm: 'repeat(2, 1fr)', md: 'repeat(3, 1fr)', xl: 'repeat(4, 1fr)'},
+          gap: 2,
+          mt: 3,
+        }}
+      >
         {options.map((option) => {
           const isSelected: boolean = selectedType === option.type;
           return (

--- a/frontend/packages/configure-connections/src/components/create-connection/__tests__/ConnectionNameStep.test.tsx
+++ b/frontend/packages/configure-connections/src/components/create-connection/__tests__/ConnectionNameStep.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {fireEvent, render, screen} from '@thunderid/test-utils';
+import {describe, expect, it, vi} from 'vitest';
+import ConnectionNameStep from '../ConnectionNameStep';
+
+describe('ConnectionNameStep', () => {
+  it('reports typed names through onNameChange', () => {
+    const onNameChange = vi.fn();
+    render(<ConnectionNameStep name="" onNameChange={onNameChange} />);
+
+    fireEvent.change(screen.getByTestId('connection-name-input'), {target: {value: 'Acme Connection'}});
+
+    expect(onNameChange).toHaveBeenCalledWith('Acme Connection');
+  });
+
+  it('fills the name field when a suggestion chip is clicked', () => {
+    const onNameChange = vi.fn();
+    render(<ConnectionNameStep name="" onNameChange={onNameChange} />);
+
+    const suggestions = screen.getAllByRole('button');
+    fireEvent.click(suggestions[0]);
+
+    expect(onNameChange).toHaveBeenCalledWith(expect.any(String));
+    expect(onNameChange.mock.calls[0][0]).not.toBe('');
+  });
+
+  it('shows an external name error', () => {
+    render(
+      <ConnectionNameStep
+        name="Taken"
+        onNameChange={vi.fn()}
+        nameError="A connection with this name already exists."
+      />,
+    );
+
+    expect(screen.getByText('A connection with this name already exists.')).toBeInTheDocument();
+  });
+});

--- a/frontend/packages/configure-connections/src/config/__tests__/connectionFormFields.test.ts
+++ b/frontend/packages/configure-connections/src/config/__tests__/connectionFormFields.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, expect, it} from 'vitest';
+import {ConnectionTypes} from '../../models/connection';
+import {fieldsForMode} from '../connectionFormFields';
+
+function fieldNames(type: (typeof ConnectionTypes)[keyof typeof ConnectionTypes], mode: 'create' | 'edit'): string[] {
+  return fieldsForMode(type, mode).map((field) => field.name);
+}
+
+describe('fieldsForMode', () => {
+  it('hides the redirect URI and scopes on create for Google/GitHub, showing them on edit', () => {
+    expect(fieldNames(ConnectionTypes.GOOGLE, 'create')).toEqual(['name', 'clientId', 'clientSecret']);
+    expect(fieldNames(ConnectionTypes.GOOGLE, 'edit')).toEqual([
+      'name',
+      'clientId',
+      'clientSecret',
+      'redirectUri',
+      'scopes',
+    ]);
+  });
+
+  it('shows only the required fields for OIDC on create, all fields on edit', () => {
+    expect(fieldNames(ConnectionTypes.OIDC, 'create')).toEqual([
+      'name',
+      'clientId',
+      'clientSecret',
+      'authorizationEndpoint',
+      'tokenEndpoint',
+    ]);
+    expect(fieldNames(ConnectionTypes.OIDC, 'edit')).toEqual([
+      'name',
+      'clientId',
+      'clientSecret',
+      'authorizationEndpoint',
+      'tokenEndpoint',
+      'issuer',
+      'userInfoEndpoint',
+      'jwksEndpoint',
+      'redirectUri',
+      'scopes',
+      'tokenExchangeEnabled',
+      'trustedTokenAudience',
+    ]);
+  });
+
+  it('shows only the required fields for OAuth 2.0 on create, all fields on edit', () => {
+    expect(fieldNames(ConnectionTypes.OAUTH, 'create')).toEqual([
+      'name',
+      'clientId',
+      'clientSecret',
+      'authorizationEndpoint',
+      'tokenEndpoint',
+      'userInfoEndpoint',
+    ]);
+    expect(fieldNames(ConnectionTypes.OAUTH, 'edit')).toEqual([
+      'name',
+      'clientId',
+      'clientSecret',
+      'authorizationEndpoint',
+      'tokenEndpoint',
+      'userInfoEndpoint',
+      'redirectUri',
+      'scopes',
+    ]);
+  });
+
+  it('does not hide any SMS vendor fields on create', () => {
+    expect(fieldNames(ConnectionTypes.TWILIO, 'create')).toEqual(fieldNames(ConnectionTypes.TWILIO, 'edit'));
+    expect(fieldNames(ConnectionTypes.VONAGE, 'create')).toEqual(fieldNames(ConnectionTypes.VONAGE, 'edit'));
+  });
+});

--- a/frontend/packages/configure-connections/src/config/connectionFormFields.ts
+++ b/frontend/packages/configure-connections/src/config/connectionFormFields.ts
@@ -20,6 +20,9 @@ import {type ConnectionType, ConnectionTypes} from '../models/connection';
 
 export type ConnectionFieldKind = 'text' | 'url' | 'secret' | 'scopes' | 'readonly-copy' | 'switch';
 
+/** Which form mode renders a field. Defaults to 'both' when unset. */
+export type ConnectionFieldVisibility = 'create' | 'edit' | 'both';
+
 export interface ConnectionFieldDef {
   /** Request payload property this field maps to. */
   name: string;
@@ -42,6 +45,8 @@ export interface ConnectionFieldDef {
   revealedBy?: string;
   /** Becomes required when the named switch field's value is truthy. */
   requiredWhen?: string;
+  /** Which form mode renders this field (default 'both'). Optional fields are edit-only to keep create simple. */
+  visibility?: ConnectionFieldVisibility;
 }
 
 const NAME_FIELD = (placeholder: string): ConnectionFieldDef => ({
@@ -74,6 +79,7 @@ const oauthFields = (namePlaceholder: string, clientIdPlaceholder: string): Conn
     name: 'redirectUri',
     labelKey: 'connections:form.fields.redirectUri.label',
     kind: 'readonly-copy',
+    visibility: 'edit',
   },
   {
     name: 'scopes',
@@ -81,6 +87,7 @@ const oauthFields = (namePlaceholder: string, clientIdPlaceholder: string): Conn
     hintKey: 'connections:form.fields.scopes.hint',
     kind: 'scopes',
     placeholder: 'openid email profile',
+    visibility: 'edit',
   },
 ];
 
@@ -90,6 +97,7 @@ const TOKEN_EXCHANGE_ENABLED_FIELD: ConnectionFieldDef = {
   hintKey: 'connections:form.fields.tokenExchangeEnabled.hint',
   kind: 'switch',
   section: 'connections:form.sections.federation',
+  visibility: 'edit',
 };
 
 const TRUSTED_TOKEN_AUDIENCE_FIELD: ConnectionFieldDef = {
@@ -100,6 +108,7 @@ const TRUSTED_TOKEN_AUDIENCE_FIELD: ConnectionFieldDef = {
   optional: true,
   placeholder: 'my-external-client-id',
   revealedBy: 'tokenExchangeEnabled',
+  visibility: 'edit',
 };
 
 /**
@@ -149,6 +158,7 @@ export const CONNECTION_FORM_FIELDS: Record<ConnectionType, ConnectionFieldDef[]
       kind: 'url',
       placeholder: 'https://idp.example.com',
       requiredWhen: 'tokenExchangeEnabled',
+      visibility: 'edit',
     },
     {
       name: 'userInfoEndpoint',
@@ -157,6 +167,7 @@ export const CONNECTION_FORM_FIELDS: Record<ConnectionType, ConnectionFieldDef[]
       kind: 'url',
       optional: true,
       placeholder: 'https://idp.example.com/userinfo',
+      visibility: 'edit',
     },
     {
       name: 'jwksEndpoint',
@@ -166,11 +177,13 @@ export const CONNECTION_FORM_FIELDS: Record<ConnectionType, ConnectionFieldDef[]
       optional: true,
       placeholder: 'https://idp.example.com/.well-known/jwks.json',
       requiredWhen: 'tokenExchangeEnabled',
+      visibility: 'edit',
     },
     {
       name: 'redirectUri',
       labelKey: 'connections:form.fields.redirectUri.label',
       kind: 'readonly-copy',
+      visibility: 'edit',
     },
     {
       name: 'scopes',
@@ -178,6 +191,7 @@ export const CONNECTION_FORM_FIELDS: Record<ConnectionType, ConnectionFieldDef[]
       hintKey: 'connections:form.fields.scopes.hint',
       kind: 'scopes',
       placeholder: 'openid email profile',
+      visibility: 'edit',
     },
     TOKEN_EXCHANGE_ENABLED_FIELD,
     TRUSTED_TOKEN_AUDIENCE_FIELD,
@@ -227,6 +241,7 @@ export const CONNECTION_FORM_FIELDS: Record<ConnectionType, ConnectionFieldDef[]
       name: 'redirectUri',
       labelKey: 'connections:form.fields.redirectUri.label',
       kind: 'readonly-copy',
+      visibility: 'edit',
     },
     {
       name: 'scopes',
@@ -234,6 +249,7 @@ export const CONNECTION_FORM_FIELDS: Record<ConnectionType, ConnectionFieldDef[]
       hintKey: 'connections:form.fields.scopes.hint',
       kind: 'scopes',
       placeholder: 'read:user email',
+      visibility: 'edit',
     },
   ],
   [ConnectionTypes.TWILIO]: [
@@ -291,3 +307,14 @@ export const CONNECTION_FORM_FIELDS: Record<ConnectionType, ConnectionFieldDef[]
     },
   ],
 };
+
+/**
+ * Field definitions rendered (and validated) for the given form mode. Fields hidden at create
+ * are still passed to the payload mapper via {@link CONNECTION_FORM_FIELDS} directly, so derived
+ * values (e.g. redirectUri) are still sent and empty optional values are still omitted.
+ */
+export function fieldsForMode(type: ConnectionType, mode: 'create' | 'edit'): ConnectionFieldDef[] {
+  return CONNECTION_FORM_FIELDS[type].filter(
+    (field) => (field.visibility ?? 'both') === 'both' || field.visibility === mode,
+  );
+}

--- a/frontend/packages/configure-connections/src/config/connectionVendorMeta.tsx
+++ b/frontend/packages/configure-connections/src/config/connectionVendorMeta.tsx
@@ -37,6 +37,7 @@ export const CONNECTION_VENDOR_META: ConnectionVendorMeta[] = [
     categories: ['social-login'],
     presentation: 'branded',
     supportsAttributeMapping: true,
+    createHintKey: 'connections:configure.hint.google',
   },
   {
     key: 'github',
@@ -47,6 +48,7 @@ export const CONNECTION_VENDOR_META: ConnectionVendorMeta[] = [
     categories: ['social-login'],
     presentation: 'branded',
     supportsAttributeMapping: true,
+    createHintKey: 'connections:configure.hint.github',
   },
   {
     key: 'oidc',
@@ -54,7 +56,7 @@ export const CONNECTION_VENDOR_META: ConnectionVendorMeta[] = [
     displayName: 'OpenID Connect',
     descriptionKey: 'connections:vendor.oidc.description',
     logo: <ShieldCheck />,
-    categories: ['enterprise'],
+    categories: ['enterprise', 'custom'],
     presentation: 'custom',
     supportsAttributeMapping: true,
   },
@@ -64,7 +66,7 @@ export const CONNECTION_VENDOR_META: ConnectionVendorMeta[] = [
     displayName: 'OAuth 2.0',
     descriptionKey: 'connections:vendor.oauth.description',
     logo: <KeyRound />,
-    categories: ['enterprise'],
+    categories: ['enterprise', 'custom'],
     presentation: 'custom',
   },
   {

--- a/frontend/packages/configure-connections/src/constants/connection-categories.ts
+++ b/frontend/packages/configure-connections/src/constants/connection-categories.ts
@@ -31,4 +31,5 @@ export const CONNECTION_CATEGORIES: ConnectionCategory[] = [
   'crm',
   'data-store',
   'trusted-idp',
+  'custom',
 ];

--- a/frontend/packages/configure-connections/src/index.ts
+++ b/frontend/packages/configure-connections/src/index.ts
@@ -60,7 +60,7 @@ export * from './models/responses';
 
 // Pages
 export {default as ConnectionConfigureWizardPage} from './pages/ConnectionConfigureWizardPage';
-export {default as ConnectionCreateWizardPage} from './pages/ConnectionCreateWizardPage';
+export {default as ConnectionCreateWizardPage, type CustomConfigureStepProps} from './pages/ConnectionCreateWizardPage';
 export {default as ConnectionDetailPage} from './pages/ConnectionDetailPage';
 export {default as ConnectionsListPage} from './pages/ConnectionsListPage';
 

--- a/frontend/packages/configure-connections/src/models/connection.ts
+++ b/frontend/packages/configure-connections/src/models/connection.ts
@@ -45,7 +45,8 @@ export type ConnectionCategory =
   | 'identity-verification'
   | 'crm'
   | 'data-store'
-  | 'trusted-idp';
+  | 'trusted-idp'
+  | 'custom';
 
 /**
  * Functional categories served by the backend /connections?category= filter.
@@ -294,6 +295,8 @@ export interface ConnectionVendorMeta {
   comingSoon?: boolean;
   /** Whether this connection provisions users and therefore exposes attribute mapping (IdPs only). */
   supportsAttributeMapping?: boolean;
+  /** i18n key for the create-wizard setup hint (vendors that need an OAuth app registered first). */
+  createHintKey?: string;
 }
 
 /**

--- a/frontend/packages/configure-connections/src/pages/ConnectionConfigureWizardPage.tsx
+++ b/frontend/packages/configure-connections/src/pages/ConnectionConfigureWizardPage.tsx
@@ -22,9 +22,10 @@ import {type JSX, useEffect, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate, useParams} from 'react-router';
 import useCreateConnection from '../api/useCreateConnection';
+import ConnectionCreateHint from '../components/ConnectionCreateHint';
 import ConnectionForm from '../components/ConnectionForm';
 import ConnectionFullPageLayout from '../components/ConnectionFullPageLayout';
-import {CONNECTION_FORM_FIELDS} from '../config/connectionFormFields';
+import {CONNECTION_FORM_FIELDS, fieldsForMode} from '../config/connectionFormFields';
 import {VENDOR_META_BY_TYPE} from '../config/connectionVendorMeta';
 import type {ConnectionResponse, ConnectionType} from '../models/connection';
 import {
@@ -69,7 +70,7 @@ export default function ConnectionConfigureWizardPage(): JSX.Element | null {
 
   const values: ConnectionFormValues = {...emptyValues, ...editedValues};
   // The connection name is fixed to the vendor display name, so it is hidden and excluded from validation.
-  const visibleFields = fields.filter((field) => field.name !== 'name');
+  const visibleFields = fieldsForMode(connectionType, 'create').filter((field) => field.name !== 'name');
   const formValid: boolean = Object.keys(validateConnectionForm(values, visibleFields, 'create')).length === 0;
 
   const close = (): void => {
@@ -109,13 +110,24 @@ export default function ConnectionConfigureWizardPage(): JSX.Element | null {
     >
       <Stack direction="column" spacing={3}>
         <Stack direction="column" spacing={1}>
-          <Typography variant="h4" fontWeight={700}>
+          <Typography variant="h1" gutterBottom>
             {t('configure.heading', {vendor: meta.displayName})}
           </Typography>
-          <Typography variant="body1" color="text.secondary">
+          <Typography variant="subtitle1" gutterBottom>
             {t('configure.subheading')}
           </Typography>
         </Stack>
+
+        {meta.createHintKey && (
+          <ConnectionCreateHint
+            instruction={t(meta.createHintKey, {
+              vendor: meta.displayName,
+              defaultValue:
+                'Create an OAuth client for {{vendor}}, then register the redirect URI below and enter the client ID and client secret it gives you.',
+            })}
+            redirectUri={redirectUri}
+          />
+        )}
 
         <Paper variant="outlined" sx={{p: 3}}>
           <ConnectionForm

--- a/frontend/packages/configure-connections/src/pages/ConnectionCreateWizardPage.tsx
+++ b/frontend/packages/configure-connections/src/pages/ConnectionCreateWizardPage.tsx
@@ -23,12 +23,14 @@ import {type JSX, type ReactNode, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
 import useCreateConnection from '../api/useCreateConnection';
+import ConnectionCreateHint from '../components/ConnectionCreateHint';
 import ConnectionForm from '../components/ConnectionForm';
 import ConnectionFullPageLayout from '../components/ConnectionFullPageLayout';
+import ConnectionNameStep from '../components/create-connection/ConnectionNameStep';
 import SelectConnectionType, {
   type SelectableConnectionType,
 } from '../components/create-connection/SelectConnectionType';
-import {CONNECTION_FORM_FIELDS} from '../config/connectionFormFields';
+import {CONNECTION_FORM_FIELDS, fieldsForMode} from '../config/connectionFormFields';
 import {VENDOR_META_BY_TYPE} from '../config/connectionVendorMeta';
 import {type ConnectionResponse, type ConnectionType, ConnectionTypes} from '../models/connection';
 import {
@@ -39,25 +41,33 @@ import {
 } from '../utils/connectionFormMapping';
 import isConflictError from '../utils/isConflictError';
 
-const Step = {TYPE: 'TYPE', CONFIGURE: 'CONFIGURE'} as const;
+const Step = {TYPE: 'TYPE', NAME: 'NAME', CONFIGURE: 'CONFIGURE'} as const;
 type Step = (typeof Step)[keyof typeof Step];
-const ALL_STEPS: Step[] = [Step.TYPE, Step.CONFIGURE];
+const ALL_STEPS: Step[] = [Step.TYPE, Step.NAME, Step.CONFIGURE];
+
+/** Props passed to a custom configure step (see {@link ConnectionCreateWizardPageProps.customConfigureSteps}). */
+export interface CustomConfigureStepProps {
+  /** Connection name collected on the wizard's name step. */
+  name: string;
+  /** Call when the create request 409s on a duplicate name, to bounce back to the name step. */
+  onNameConflict: () => void;
+}
 
 interface ConnectionCreateWizardPageProps {
   /**
-   * Renders a fully custom configure step (step 2) for the given selectable-type key instead of
+   * Renders a fully custom configure step (step 3) for the given selectable-type key instead of
    * the generic `ConnectionForm` + create button — e.g. a UI-only pseudo-type like
-   * `'trusted-idp'` that has no backend /connections vendor route of its own. The supplied node
-   * owns its own submit action; the wizard still provides the chrome (breadcrumb, progress,
-   * Back, and the X close button).
+   * `'trusted-idp'` that has no backend /connections vendor route of its own. The supplied
+   * render function receives the name collected on the wizard's name step; the wizard still
+   * provides the chrome (breadcrumb, progress, Back, and the X close button).
    */
-  customConfigureSteps?: Record<string, ReactNode>;
+  customConfigureSteps?: Record<string, (props: CustomConfigureStepProps) => ReactNode>;
 }
 
 /**
- * Two-step full-screen wizard for adding a custom connection: pick the type, then enter the
- * credentials/endpoints (with a connection name) and create it. A type can opt out of the
- * generic configure step via `customConfigureSteps`.
+ * Three-step full-screen wizard for adding a custom connection: pick the type, name it, then
+ * enter the credentials/endpoints and create it. A type can opt out of the generic configure step
+ * via `customConfigureSteps`.
  */
 export default function ConnectionCreateWizardPage({
   customConfigureSteps = undefined,
@@ -68,31 +78,39 @@ export default function ConnectionCreateWizardPage({
 
   const [step, setStep] = useState<Step>(Step.TYPE);
   const [selectedType, setSelectedType] = useState<SelectableConnectionType | null>(null);
+  const [connectionName, setConnectionName] = useState('');
   const [editedValues, setEditedValues] = useState<ConnectionFormValues>({});
   const [nameError, setNameError] = useState<string | null>(null);
 
-  const customStep: ReactNode | undefined = selectedType ? customConfigureSteps?.[selectedType] : undefined;
+  const customStepRenderer = selectedType ? customConfigureSteps?.[selectedType] : undefined;
   const customTypes: string[] = useMemo(() => Object.keys(customConfigureSteps ?? {}), [customConfigureSteps]);
 
   // Defaults to OIDC before the user picks a type on the first step; the SMS placeholder is
-  // disabled and unselectable, and pseudo-types render via `customStep` instead, so this is only
-  // read when rendering the generic configure step.
+  // disabled and unselectable, and pseudo-types render via `customStepRenderer` instead, so this
+  // is only read when rendering the generic configure step.
   const activeType: ConnectionType =
     selectedType && selectedType !== 'trusted-idp' ? selectedType : ConnectionTypes.OIDC;
   const createMutation = useCreateConnection(activeType);
   const meta = VENDOR_META_BY_TYPE[activeType];
   const fields = CONNECTION_FORM_FIELDS[activeType];
+  const createFields = useMemo(() => fieldsForMode(activeType, 'create'), [activeType]);
   const redirectUri = getGateCallbackUrl();
   const emptyValues = useMemo(() => emptyFormValues(fields, redirectUri), [fields, redirectUri]);
 
-  const values: ConnectionFormValues = {...emptyValues, ...editedValues};
-  const formValid: boolean = Object.keys(validateConnectionForm(values, fields, 'create')).length === 0;
+  const trimmedName: string = connectionName.trim();
+  const values: ConnectionFormValues = {...emptyValues, ...editedValues, name: trimmedName};
+  const formValid: boolean = Object.keys(validateConnectionForm(values, createFields, 'create')).length === 0;
 
   const close = (): void => {
     void navigate('/connections');
   };
 
   const progress: number = ((ALL_STEPS.indexOf(step) + 1) / ALL_STEPS.length) * 100;
+
+  const bounceToNameStep = (): void => {
+    setNameError(t('error.duplicateName'));
+    setStep(Step.NAME);
+  };
 
   const handleCreate = (): void => {
     if (!formValid) {
@@ -104,7 +122,7 @@ export default function ConnectionCreateWizardPage({
       onSuccess: (created: ConnectionResponse) => void navigate(`/connections/${activeType}/${created.id}`),
       onError: (error: Error) => {
         if (isConflictError(error)) {
-          setNameError(t('error.duplicateName'));
+          bounceToNameStep();
         }
       },
     });
@@ -114,6 +132,7 @@ export default function ConnectionCreateWizardPage({
     {key: 'connections', label: t('listing.title'), onClick: close},
     {key: 'add', label: t('wizard.title'), onClick: () => setStep(Step.TYPE)},
     ...(step === Step.TYPE ? [{key: 'type', label: t('wizard.steps.type')}] : []),
+    ...(step === Step.NAME ? [{key: 'name', label: t('wizard.steps.name', 'Name')}] : []),
     ...(step === Step.CONFIGURE ? [{key: 'configure', label: t('form.chrome.configure')}] : []),
   ];
 
@@ -123,6 +142,7 @@ export default function ConnectionCreateWizardPage({
       onClose={close}
       progress={progress}
       breadcrumb={<AppBreadcrumbs items={crumbs} />}
+      fullWidthContent={step === Step.TYPE}
     >
       {step === Step.TYPE && (
         <>
@@ -131,7 +151,7 @@ export default function ConnectionCreateWizardPage({
             <Button
               variant="contained"
               disabled={!selectedType}
-              onClick={() => setStep(Step.CONFIGURE)}
+              onClick={() => setStep(Step.NAME)}
               data-testid="wizard-continue"
             >
               {t('common:actions.continue')}
@@ -140,28 +160,62 @@ export default function ConnectionCreateWizardPage({
         </>
       )}
 
-      {step === Step.CONFIGURE && customStep && (
+      {step === Step.NAME && (
         <Stack direction="column" spacing={3}>
-          {customStep}
+          <ConnectionNameStep
+            name={connectionName}
+            onNameChange={(name) => {
+              setConnectionName(name);
+              setNameError(null);
+            }}
+            nameError={nameError}
+          />
+          <Box sx={{display: 'flex', justifyContent: 'space-between', alignItems: 'center'}}>
+            <Button variant="outlined" startIcon={<ChevronLeft size={16} />} onClick={() => setStep(Step.TYPE)}>
+              {t('common:actions.back')}
+            </Button>
+            <Button
+              variant="contained"
+              disabled={!trimmedName}
+              onClick={() => setStep(Step.CONFIGURE)}
+              data-testid="wizard-continue"
+            >
+              {t('common:actions.continue')}
+            </Button>
+          </Box>
+        </Stack>
+      )}
+
+      {step === Step.CONFIGURE && customStepRenderer && (
+        <Stack direction="column" spacing={3}>
+          {customStepRenderer({name: trimmedName, onNameConflict: bounceToNameStep})}
 
           <Box sx={{display: 'flex', justifyContent: 'flex-start'}}>
-            <Button variant="outlined" startIcon={<ChevronLeft size={16} />} onClick={() => setStep(Step.TYPE)}>
+            <Button variant="outlined" startIcon={<ChevronLeft size={16} />} onClick={() => setStep(Step.NAME)}>
               {t('common:actions.back')}
             </Button>
           </Box>
         </Stack>
       )}
 
-      {step === Step.CONFIGURE && !customStep && (
+      {step === Step.CONFIGURE && !customStepRenderer && (
         <Stack direction="column" spacing={3}>
           <Stack direction="column" spacing={1}>
-            <Typography variant="h4" fontWeight={700}>
+            <Typography variant="h1" gutterBottom>
               {t('wizard.configure.heading')}
             </Typography>
-            <Typography variant="body1" color="text.secondary">
+            <Typography variant="subtitle1" gutterBottom>
               {t('wizard.configure.subheading')}
             </Typography>
           </Stack>
+
+          <ConnectionCreateHint
+            instruction={t(
+              'wizard.configure.redirectHint',
+              'Register the redirect URI below with your identity provider as an allowed callback URL, then enter the credentials and endpoints it gives you.',
+            )}
+            redirectUri={redirectUri}
+          />
 
           <Paper variant="outlined" sx={{p: 3}}>
             <ConnectionForm
@@ -171,14 +225,14 @@ export default function ConnectionCreateWizardPage({
               secretReplacing={false}
               hasStoredSecret={false}
               vendorDisplayName={meta.displayName}
-              nameError={nameError}
+              showNameField={false}
               onFieldChange={(name, value) => setEditedValues((prev) => ({...prev, [name]: value}))}
               onSecretReplacingChange={() => undefined}
             />
           </Paper>
 
           <Box sx={{display: 'flex', justifyContent: 'space-between', alignItems: 'center'}}>
-            <Button variant="outlined" startIcon={<ChevronLeft size={16} />} onClick={() => setStep(Step.TYPE)}>
+            <Button variant="outlined" startIcon={<ChevronLeft size={16} />} onClick={() => setStep(Step.NAME)}>
               {t('common:actions.back')}
             </Button>
             <Button

--- a/frontend/packages/configure-connections/src/pages/ConnectionDetailPage.tsx
+++ b/frontend/packages/configure-connections/src/pages/ConnectionDetailPage.tsx
@@ -18,7 +18,7 @@
 
 import {SettingsCard, UnsavedChangesBar} from '@thunderid/components';
 import {useConfig} from '@thunderid/contexts';
-import {Alert, Box, Button, Chip, PageContent, Skeleton, Stack, Tab, Tabs, Typography} from '@wso2/oxygen-ui';
+import {Alert, Box, Button, PageContent, Skeleton, Stack, Tab, Tabs, Typography} from '@wso2/oxygen-ui';
 import {ChevronLeft, Trash2} from '@wso2/oxygen-ui-icons-react';
 import {type JSX, type ReactNode, type SyntheticEvent, useEffect, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
@@ -203,15 +203,15 @@ export default function ConnectionDetailPage(): JSX.Element | null {
               {meta.logo}
             </Box>
             <Stack direction="column" spacing={0.5}>
-              <Stack direction="row" spacing={1.5} alignItems="center" flexWrap="wrap" useFlexGap>
-                <Typography variant="h5" fontWeight={700}>
-                  {data?.name ?? meta.displayName}
-                </Typography>
-                <Chip size="small" color="success" label={t('card.configured')} />
-              </Stack>
-              <Typography variant="body2" color="text.secondary">
-                {t('detail.subtitle', {name: data?.name ?? meta.displayName})}
+              <Typography variant="h5" fontWeight={700}>
+                {data?.name ?? meta.displayName}
               </Typography>
+              <Stack direction="row" spacing={0.75} alignItems="center">
+                <Box sx={{width: 8, height: 8, borderRadius: '50%', bgcolor: 'success.main'}} />
+                <Typography variant="body2" color="text.secondary">
+                  {t('card.configured')}
+                </Typography>
+              </Stack>
             </Stack>
           </Stack>
 

--- a/frontend/packages/configure-connections/src/pages/__tests__/ConnectionConfigureWizardPage.test.tsx
+++ b/frontend/packages/configure-connections/src/pages/__tests__/ConnectionConfigureWizardPage.test.tsx
@@ -33,6 +33,7 @@ vi.mock('react-router', async (importOriginal) => ({
 vi.mock('@thunderid/contexts', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@thunderid/contexts')>()),
   useConfig: () => ({getGateCallbackUrl: () => 'https://id.acme.io/gate/callback'}),
+  useToast: () => ({showToast: vi.fn()}),
 }));
 vi.mock('../../api/useCreateConnection', () => ({default: () => ({mutate: mutateMock, isPending: false})}));
 
@@ -67,9 +68,29 @@ describe('ConnectionConfigureWizardPage', () => {
     fireEvent.click(screen.getByTestId('wizard-create'));
 
     expect(mutateMock).toHaveBeenCalledTimes(1);
-    const payload = mutateMock.mock.calls[0][0] as {name: string; clientId: string; attributeConfiguration?: unknown};
-    expect(payload).toMatchObject({name: 'Google', clientId: 'x', clientSecret: 's'});
+    const payload = mutateMock.mock.calls[0][0] as {
+      name: string;
+      clientId: string;
+      redirectUri: string;
+      scopes?: string[];
+      attributeConfiguration?: unknown;
+    };
+    expect(payload).toMatchObject({
+      name: 'Google',
+      clientId: 'x',
+      clientSecret: 's',
+      redirectUri: 'https://id.acme.io/gate/callback',
+    });
+    expect(payload.scopes).toBeUndefined();
     expect(payload.attributeConfiguration).toBeUndefined();
+  });
+
+  it('shows the setup hint with the redirect URI to copy for Google', () => {
+    render(<ConnectionConfigureWizardPage />);
+
+    const hint = screen.getByTestId('connection-create-hint');
+    expect(hint).toBeInTheDocument();
+    expect(screen.getByDisplayValue('https://id.acme.io/gate/callback')).toBeInTheDocument();
   });
 
   it('navigates to the connection detail page after a successful create', () => {

--- a/frontend/packages/configure-connections/src/pages/__tests__/ConnectionCreateWizardPage.test.tsx
+++ b/frontend/packages/configure-connections/src/pages/__tests__/ConnectionCreateWizardPage.test.tsx
@@ -19,7 +19,7 @@
 import {fireEvent, render, screen} from '@thunderid/test-utils';
 import {useEffect} from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import ConnectionCreateWizardPage from '../ConnectionCreateWizardPage';
+import ConnectionCreateWizardPage, {type CustomConfigureStepProps} from '../ConnectionCreateWizardPage';
 
 const mutateMock = vi.fn();
 const navigateMock = vi.fn();
@@ -31,6 +31,7 @@ vi.mock('react-router', async (importOriginal) => ({
 vi.mock('@thunderid/contexts', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@thunderid/contexts')>()),
   useConfig: () => ({getGateCallbackUrl: () => 'https://id.acme.io/gate/callback'}),
+  useToast: () => ({showToast: vi.fn()}),
 }));
 vi.mock('../../api/useCreateConnection', () => ({default: () => ({mutate: mutateMock, isPending: false})}));
 
@@ -38,7 +39,6 @@ vi.mock('../../components/ConnectionForm', () => ({
   default: function StubConnectionForm({onFieldChange}: {onFieldChange: (name: string, value: string) => void}) {
     useEffect(() => {
       // Populate the fields required by every connection type used in these tests (oidc, oauth).
-      onFieldChange('name', 'Acme Connection');
       onFieldChange('clientId', 'x');
       onFieldChange('clientSecret', 's');
       onFieldChange('authorizationEndpoint', 'https://idp.example.com/authorize');
@@ -49,6 +49,14 @@ vi.mock('../../components/ConnectionForm', () => ({
     return <div data-testid="stub-connection-form" />;
   },
 }));
+
+/** Drives the wizard from the type step through the name step, entering the given name. */
+function selectTypeAndName(typeTestId: string, name = 'Acme Connection'): void {
+  fireEvent.click(screen.getByTestId(typeTestId));
+  fireEvent.click(screen.getByTestId('wizard-continue'));
+  fireEvent.change(screen.getByTestId('connection-name-input'), {target: {value: name}});
+  fireEvent.click(screen.getByTestId('wizard-continue'));
+}
 
 describe('ConnectionCreateWizardPage', () => {
   beforeEach(() => vi.clearAllMocks());
@@ -61,11 +69,23 @@ describe('ConnectionCreateWizardPage', () => {
     expect(screen.getAllByText('Connection type')).toHaveLength(1);
   });
 
-  it('shows the configure heading without the redundant step label after continuing', () => {
+  it('shows the name step after selecting a type, gated on a non-empty name', () => {
     render(<ConnectionCreateWizardPage />);
 
     fireEvent.click(screen.getByTestId('connection-type-option-oidc'));
     fireEvent.click(screen.getByTestId('wizard-continue'));
+
+    expect(screen.getByTestId('connection-name-step')).toBeInTheDocument();
+    expect(screen.getByTestId('wizard-continue')).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId('connection-name-input'), {target: {value: 'Acme Connection'}});
+    expect(screen.getByTestId('wizard-continue')).toBeEnabled();
+  });
+
+  it('shows the configure heading without the redundant step label after continuing', () => {
+    render(<ConnectionCreateWizardPage />);
+
+    selectTypeAndName('connection-type-option-oidc');
 
     expect(screen.getByTestId('connection-fullpage-content')).toBeInTheDocument();
     expect(screen.getByTestId('stub-connection-form')).toBeInTheDocument();
@@ -74,26 +94,39 @@ describe('ConnectionCreateWizardPage', () => {
     expect(screen.queryByText('wizard.steps.configure')).not.toBeInTheDocument();
   });
 
+  it('shows the generic redirect-URI hint on the configure step', () => {
+    render(<ConnectionCreateWizardPage />);
+
+    selectTypeAndName('connection-type-option-oidc');
+
+    expect(screen.getByTestId('connection-create-hint')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('https://id.acme.io/gate/callback')).toBeInTheDocument();
+  });
+
   it('supports selecting the Custom OAuth2 type and configuring it', () => {
     render(<ConnectionCreateWizardPage />);
 
-    fireEvent.click(screen.getByTestId('connection-type-option-oauth'));
-    fireEvent.click(screen.getByTestId('wizard-continue'));
+    selectTypeAndName('connection-type-option-oauth');
 
     expect(screen.getByTestId('connection-fullpage-content')).toBeInTheDocument();
     expect(screen.getByTestId('stub-connection-form')).toBeInTheDocument();
     expect(screen.getByText('Configure your connection')).toBeInTheDocument();
   });
 
-  it('creates the connection from the configure step and navigates to its detail page', () => {
+  it('creates the connection from the configure step with the step-collected name and navigates to its detail page', () => {
     render(<ConnectionCreateWizardPage />);
 
-    fireEvent.click(screen.getByTestId('connection-type-option-oidc'));
-    fireEvent.click(screen.getByTestId('wizard-continue'));
+    selectTypeAndName('connection-type-option-oidc', 'Acme Workforce OIDC');
     fireEvent.click(screen.getByTestId('wizard-create'));
 
     expect(mutateMock).toHaveBeenCalledTimes(1);
-    const payload = mutateMock.mock.calls[0][0] as {attributeConfiguration?: unknown};
+    const payload = mutateMock.mock.calls[0][0] as {
+      name: string;
+      redirectUri: string;
+      attributeConfiguration?: unknown;
+    };
+    expect(payload.name).toBe('Acme Workforce OIDC');
+    expect(payload.redirectUri).toBe('https://id.acme.io/gate/callback');
     expect('attributeConfiguration' in payload).toBe(false);
 
     const {onSuccess} = mutateMock.mock.calls[0][1] as {onSuccess: (data: {id: string}) => void};
@@ -102,32 +135,72 @@ describe('ConnectionCreateWizardPage', () => {
     expect(navigateMock).toHaveBeenCalledWith('/connections/oidc/conn-1');
   });
 
+  it('returns to the name step with a duplicate-name error on a 409 create conflict', () => {
+    mutateMock.mockImplementationOnce((_payload, opts: {onError: (error: unknown) => void}) => {
+      opts.onError({response: {status: 409}});
+    });
+    render(<ConnectionCreateWizardPage />);
+
+    selectTypeAndName('connection-type-option-oidc');
+    fireEvent.click(screen.getByTestId('wizard-create'));
+
+    expect(screen.getByTestId('connection-name-step')).toBeInTheDocument();
+    expect(screen.getByText('A connection with this name already exists.')).toBeInTheDocument();
+  });
+
   it('renders a custom configure step instead of the generic ConnectionForm for a type with a slot', () => {
-    render(<ConnectionCreateWizardPage customConfigureSteps={{'trusted-idp': <div data-testid="custom-step" />}} />);
+    render(
+      <ConnectionCreateWizardPage
+        customConfigureSteps={{
+          'trusted-idp': ({name}: CustomConfigureStepProps) => <div data-testid="custom-step">{name}</div>,
+        }}
+      />,
+    );
 
-    fireEvent.click(screen.getByTestId('connection-type-option-trusted-idp'));
-    fireEvent.click(screen.getByTestId('wizard-continue'));
+    selectTypeAndName('connection-type-option-trusted-idp', 'My Trusted Issuer');
 
-    expect(screen.getByTestId('custom-step')).toBeInTheDocument();
+    expect(screen.getByTestId('custom-step')).toHaveTextContent('My Trusted Issuer');
     expect(screen.queryByTestId('stub-connection-form')).not.toBeInTheDocument();
     expect(screen.queryByTestId('wizard-create')).not.toBeInTheDocument();
   });
 
-  it('returns to the type step when Back is clicked from a custom configure step', () => {
-    render(<ConnectionCreateWizardPage customConfigureSteps={{'trusted-idp': <div data-testid="custom-step" />}} />);
+  it('lets a custom configure step bounce back to the name step via onNameConflict', () => {
+    render(
+      <ConnectionCreateWizardPage
+        customConfigureSteps={{
+          'trusted-idp': ({onNameConflict}: CustomConfigureStepProps) => (
+            <button type="button" data-testid="custom-step-conflict" onClick={onNameConflict}>
+              trigger conflict
+            </button>
+          ),
+        }}
+      />,
+    );
 
-    fireEvent.click(screen.getByTestId('connection-type-option-trusted-idp'));
-    fireEvent.click(screen.getByTestId('wizard-continue'));
+    selectTypeAndName('connection-type-option-trusted-idp');
+    fireEvent.click(screen.getByTestId('custom-step-conflict'));
+
+    expect(screen.getByTestId('connection-name-step')).toBeInTheDocument();
+    expect(screen.getByText('A connection with this name already exists.')).toBeInTheDocument();
+  });
+
+  it('returns to the name step when Back is clicked from a custom configure step', () => {
+    render(
+      <ConnectionCreateWizardPage customConfigureSteps={{'trusted-idp': () => <div data-testid="custom-step" />}} />,
+    );
+
+    selectTypeAndName('connection-type-option-trusted-idp');
     fireEvent.click(screen.getByRole('button', {name: /back/i}));
 
-    expect(screen.getByText('What kind of connection do you want to add?')).toBeInTheDocument();
+    expect(screen.getByTestId('connection-name-step')).toBeInTheDocument();
   });
 
   it('renders the generic ConnectionForm for a type with no custom configure step', () => {
-    render(<ConnectionCreateWizardPage customConfigureSteps={{'trusted-idp': <div data-testid="custom-step" />}} />);
+    render(
+      <ConnectionCreateWizardPage customConfigureSteps={{'trusted-idp': () => <div data-testid="custom-step" />}} />,
+    );
 
-    fireEvent.click(screen.getByTestId('connection-type-option-oidc'));
-    fireEvent.click(screen.getByTestId('wizard-continue'));
+    selectTypeAndName('connection-type-option-oidc');
 
     expect(screen.getByTestId('stub-connection-form')).toBeInTheDocument();
     expect(screen.queryByTestId('custom-step')).not.toBeInTheDocument();
@@ -141,7 +214,9 @@ describe('ConnectionCreateWizardPage', () => {
   });
 
   it('shows four type cards including trusted-idp when its customConfigureSteps slot is wired', () => {
-    render(<ConnectionCreateWizardPage customConfigureSteps={{'trusted-idp': <div data-testid="custom-step" />}} />);
+    render(
+      <ConnectionCreateWizardPage customConfigureSteps={{'trusted-idp': () => <div data-testid="custom-step" />}} />,
+    );
 
     expect(screen.getAllByTestId(/^connection-type-option-/)).toHaveLength(4);
     expect(screen.getByTestId('connection-type-option-trusted-idp')).toBeInTheDocument();

--- a/frontend/packages/configure-connections/src/pages/__tests__/ConnectionDetailPage.test.tsx
+++ b/frontend/packages/configure-connections/src/pages/__tests__/ConnectionDetailPage.test.tsx
@@ -125,6 +125,14 @@ describe('ConnectionDetailPage', () => {
     expect(screen.getByTestId('connection-delete-button')).toBeInTheDocument();
   });
 
+  it('shows the Configured status under the name in the card style, with no redundant subtitle', () => {
+    render(<ConnectionDetailPage />);
+    expect(screen.getByText('Google')).toBeInTheDocument();
+    expect(screen.getByText('Configured')).toBeInTheDocument();
+    expect(screen.queryByText('Google connection')).not.toBeInTheDocument();
+    expect(document.querySelector('.MuiChip-root')).not.toBeInTheDocument();
+  });
+
   it('hides the save bar until a field is edited', () => {
     render(<ConnectionDetailPage />);
     expect(screen.queryByTestId('save-bar')).not.toBeInTheDocument();

--- a/frontend/packages/configure-connections/src/utils/__tests__/buildConnectionCards.test.ts
+++ b/frontend/packages/configure-connections/src/utils/__tests__/buildConnectionCards.test.ts
@@ -159,7 +159,7 @@ describe('buildConnectionCards', () => {
       status: 'configured',
       comingSoon: false,
       navTarget: '/trusted-issuers/t1',
-      categories: ['trusted-idp'],
+      categories: ['trusted-idp', 'custom'],
     });
   });
 

--- a/frontend/packages/configure-connections/src/utils/buildConnectionCards.tsx
+++ b/frontend/packages/configure-connections/src/utils/buildConnectionCards.tsx
@@ -68,7 +68,7 @@ export default function buildConnectionCards(
       displayName: instance.name,
       descriptionKey: TRUSTED_IDP_DESCRIPTION_KEY,
       logo: <ResourceAvatar variant="rounded" size={44} fallback={ConnectionConstants.DEFAULT_TRUSTED_IDP_AVATAR} />,
-      categories: ['trusted-idp'],
+      categories: ['trusted-idp', 'custom'],
       status: 'configured',
       comingSoon: false,
       navTarget: `/trusted-issuers/${instance.id}`,

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1614,7 +1614,7 @@ const translations = {
     // Listing page
     'listing.title': 'Connections',
     'listing.subtitle': 'Configure the external services ThunderID connects to.',
-    'listing.search.placeholder': 'Search ..',
+    'listing.search.placeholder': 'Search connections',
     'listing.showingCount': 'Showing {{count}} connections',
     'listing.loading': 'Loading connections...',
     'listing.clearFilters': 'Clear filters',
@@ -1623,7 +1623,6 @@ const translations = {
       'Try a different search term, or clear the active filters to see all available connections.',
 
     // Filters / categories
-    'filters.label': 'Filter',
     'categories.all': 'All',
     'categories.social-login': 'Social Login',
     'categories.enterprise': 'Enterprise',
@@ -1633,6 +1632,7 @@ const translations = {
     'categories.crm': 'CRM',
     'categories.data-store': 'Data store',
     'categories.trusted-idp': 'Trusted Token Issuer',
+    'categories.custom': 'Custom',
 
     // Card
     'card.configured': 'Configured',
@@ -1654,6 +1654,7 @@ const translations = {
     // Add custom connection wizard
     'wizard.title': 'Add custom connection',
     'wizard.steps.type': 'Connection type',
+    'wizard.steps.name': 'Name',
     'wizard.steps.configure': 'Configure',
     'wizard.type.heading': 'What kind of connection do you want to add?',
     'wizard.type.subheading':
@@ -1671,17 +1672,26 @@ const translations = {
     'wizard.type.trustedIdp.description':
       "Trust an external IdP's identity assertions and exchange them for access tokens.",
     'wizard.type.trustedIdp.tag': 'Token exchange · ID-JAG',
+    'wizard.name.title': "Let's give a name to your connection",
+    'wizard.name.fieldLabel': 'Connection name',
+    'wizard.name.placeholder': 'Enter your connection name',
+    'wizard.name.suggestions.label': 'In a hurry? Pick a random name:',
     'wizard.configure.heading': 'Configure your connection',
     'wizard.configure.subheading':
       'Enter the credentials and endpoints for your custom connection. Secrets are stored write-only.',
+    'wizard.configure.redirectHint':
+      'Register the redirect URI below with your identity provider as an allowed callback URL, then enter the credentials and endpoints it gives you.',
 
     // Branded configure wizard
     'configure.heading': 'Configure your {{vendor}} connection',
     'configure.subheading': 'Enter the credentials and endpoints for this connection. Secrets are stored write-only.',
+    'configure.hint.google':
+      'Create an OAuth client for your app in the Google Cloud Console under APIs and Services, Credentials. Register the redirect URI below as an authorized redirect URI, then enter the client ID and client secret Google gives you.',
+    'configure.hint.github':
+      'Create an OAuth app in GitHub under Settings, Developer settings, OAuth Apps. Set the authorization callback URL to the redirect URI below, then enter the client ID and client secret GitHub gives you.',
 
     // Connection detail / edit page
     'detail.backToConnections': 'Back to Connections',
-    'detail.subtitle': '{{name}} connection',
     'detail.tabs.general': 'General',
     'detail.tabs.attributeMapping': 'Attribute Configuration',
     'detail.quickCopy.title': 'Quick copy',


### PR DESCRIPTION
### Purpose

The Connections UIs (list, creation wizards, edit view) predated the polished Applications onboarding flow and had drifted from it visually and structurally. This PR aligns Connections with the Applications UI patterns and simplifies creation.

### Approach

- **Vendor setup hints**: Google and GitHub creation now leads with a hint (create the OAuth app, then copy the redirect URI) above the client ID/secret fields. Scopes and the redirect URI moved to the edit view only. A new `visibility` flag on `ConnectionFieldDef` plus a `fieldsForMode()` helper drives which fields render per mode (create vs edit).
- **Wizard typography**: step titles/subtitles across the connection wizards now use the same `h1`/`subtitle1` pattern as the application creation wizard.
- **List search/filter**: category chips restyled to pills (no "Filter" label), matching the Applications "Choose a type" styling.
- **Edit view header**: the Configured status moved under the connection name, styled like the card's dot + text indicator; dropped the redundant "{name} connection" subtitle.
- **Full-width type selection**: the custom connection type-selection step now fills the screen (up to 4 columns) instead of a narrow centered column.
- **Simplified OIDC/OAuth creation**: custom OIDC and OAuth 2.0 wizards collect only the required fields at create time; optional fields (scopes, issuer, userInfo/JWKS endpoints, token exchange) remain in the edit view. The redirect URI moved into a generic setup hint above the form.
- **Shared name step**: custom OIDC, OAuth, and Trusted Token Issuer creation now collect the connection name on a dedicated first step with random name suggestions, mirroring the application creation wizard. Duplicate-name conflicts on create bounce back to this step via a new `onNameConflict` callback threaded through the wizard's `customConfigureSteps` contract.

No backend changes were needed: the backend already requires `redirectUri` in the create payload and defaults scopes when absent, so hiding those inputs at create doesn't change what's sent.

### Verification

- `configure-connections` package: 218/218 tests passing.
- Console app: full suite passing (478 files / 7400 tests).
- Lint and Prettier format checks clean on all changed files.
- `apps/console` production build (`tsc -b && vite build`) succeeds.
- Manually walked the Google/GitHub creation hints, the custom OIDC/OAuth/Trusted Token Issuer name step, the widened type-selection gallery, the list filter chips, and the connection detail header.

### Related Issues
- #3908

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **Name** step to the custom connection wizard (with suggestions).
  * Added vendor-specific setup hints with copyable **Redirect URI** values.
  * Improved create/edit experience by showing the correct fields per mode and supporting **trusted-idp** filtering.
* **Bug Fixes**
  * Duplicate-name (409) handling now reliably returns to the **Name** step and reflects the conflict state correctly.
* **Style**
  * Refreshed wizard/page typography, chip behavior, and the **Configured** header indicator.
* **Documentation**
  * Updated identity-provider guides (Google, GitHub, OAuth/OIDC, and related flows) to match the new step and redirect-hint guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->