### PR TITLE
[Bug-fix][Docs]Update docs on input types for provisioning executor

### DIFF
--- a/docs/content/guides/flows/advanced-configurations.mdx
+++ b/docs/content/guides/flows/advanced-configurations.mdx
@@ -407,6 +407,26 @@ Executors do not collect inputs directly. All required inputs must already be av
 Use the **Add Input** option in the executor's properties to specify which inputs the executor expects. The execution validates that each declared input is available from a preceding View or executor output.
 :::
 
+### Input Types
+
+Each executor input has a `type` field that tells the client how to render the field and what client-side validation to apply.
+
+When an executor forwards inputs dynamically to a PROMPT node via its `onIncomplete` edge, the default type is `TEXT_INPUT` for non-credential inputs and `PASSWORD_INPUT` for credential inputs. To apply stricter client-side validation for a specific attribute (for example, email format validation), declare the input explicitly in the executor's `inputs` array with the appropriate type. The executor preserves the configured `type` when forwarding the input to the prompt node.
+
+| Type | Description |
+|---|---|
+| `TEXT_INPUT` | A single-line text field. Default for non-credential inputs. |
+| `EMAIL_INPUT` | An email address field with email format validation. |
+| `PASSWORD_INPUT` | A masked password field. Default for credential inputs. |
+| `OTP_INPUT` | A one-time password input field. |
+| `PHONE_INPUT` | A phone number field with phone format validation. |
+| `NUMBER_INPUT` | A numeric input field. |
+| `DATE_INPUT` | A date picker field. |
+| `CONSENT_INPUT` | A consent checkbox field. |
+| `HIDDEN` | A hidden field not rendered to the user. |
+| `SELECT` | A dropdown selection field. |
+| `OU_SELECT` | An organization unit selection field. |
+
 ### View and Executor Pairings
 
 Each View node (Step or Widget) collects user input that must be read by a specific Executor. If you place a View on the canvas without connecting its required Executor, the flow will stall at the yellow incomplete dot. The table below shows which Executor is required or recommended for each View, and any prerequisites that must be satisfied first.
@@ -1123,7 +1143,7 @@ Creates a new user record in the user store. This executor persists the user's i
 | `includeOptionalCredentials` | Include Optional Credentials | No | `false` | Whether to prompt for optional credential attributes |
 | `maxPerPrompt` | - | No | `0` (all at once) | Maximum number of missing inputs to forward per prompt cycle |
 
-**Input Configuration:** None. Required user attributes are dynamically determined from the user type schema, not registered as fixed node input defaults.
+**Input Configuration:** Required user attributes are dynamically determined from the user type schema, so no fixed input defaults are needed. However, you may optionally declare entries in the executor's `inputs` array to set a specific input type for an attribute (e.g., `EMAIL_INPUT` for an email field). Without an explicit override, non-credential inputs default to `TEXT_INPUT`. See [Input Types](#input-types) for valid types.
 
 **Example:**
 
@@ -1137,7 +1157,13 @@ Creates a new user record in the user store. This executor persists the user's i
     "assignRole": ""
   },
   "executor": {
-    "name": "ProvisioningExecutor"
+    "name": "ProvisioningExecutor",
+    "inputs": [
+      {
+        "identifier": "email",
+        "type": "EMAIL_INPUT"
+      }
+    ]
   },
   "onSuccess": "set_credentials",
   "onFailure": "error_prompt",


### PR DESCRIPTION
### Purpose
Fixes: https://github.com/thunder-id/thunderid/issues/4018

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
Update the documentation to ensure the provisioning_executor is configured with explicit input types for expected inputs with special input types.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4018

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an “Input Types” reference for executor inputs, including how the `type` field affects rendering and client-side validation.
  * Documented defaulting and how to override input types when executors forward inputs dynamically (e.g., via `onIncomplete`).
  * Updated the provisioning guidance and example JSON to include an explicit email input type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->