### PR TITLE
Enable SSO and RP-initiated logout for the console application

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -538,7 +538,10 @@ jobs:
                 exit 0
               fi
               PATCH=$(printf '%s' "$COMPARE" | jq -r '.totals.patch.coverage' 2>/dev/null) || PATCH=""
-              if [ "$PATCH" = "null" ]; then
+              PATCH_LINES=$(printf '%s' "$COMPARE" | jq -r '.totals.patch.lines // 0' 2>/dev/null) || PATCH_LINES="0"
+              # A diff with no coverable lines (comment/config/CI-only changes) has nothing to gate.
+              # Codecov signals this either as coverage null or as coverage 0 with zero patch lines.
+              if [ "$PATCH" = "null" ] || [ "$PATCH_LINES" = "0" ]; then
                 echo "resolved=true" >> "$GITHUB_OUTPUT"
                 echo "✅ Codecov reports no coverable lines in this diff." | tee -a "$GITHUB_STEP_SUMMARY"
                 exit 0
@@ -892,9 +895,17 @@ jobs:
             exit 1
           fi
 
+          # The console login flow runs an SSO check before the credentials prompt. This bootstrap is a
+          # fresh, cookie-less login (no SSO session), so the first execute advances the flow past the
+          # SSO check to the credentials prompt and mints a challenge token; the second submits the admin
+          # credentials with that token.
+          PROMPT_RESP=$(curl -sk -X POST "$SERVER_URL/flow/execute" \
+            -H "Content-Type: application/json" \
+            -d "{\"executionId\": \"$EXEC_ID\"}")
+          CHALLENGE_TOKEN=$(echo "$PROMPT_RESP" | jq -r '.challengeToken // empty')
           FLOW_RESP=$(curl -sk -X POST "$SERVER_URL/flow/execute" \
             -H "Content-Type: application/json" \
-            -d "{\"executionId\": \"$EXEC_ID\", \"inputs\": {\"username\": \"admin\", \"password\": \"admin\"}, \"action\": \"action_001\"}")
+            -d "{\"executionId\": \"$EXEC_ID\", \"challengeToken\": \"$CHALLENGE_TOKEN\", \"inputs\": {\"username\": \"admin\", \"password\": \"admin\"}, \"action\": \"action_001\"}")
           ASSERTION=$(echo "$FLOW_RESP" | jq -r '.assertion // empty')
           if [ -z "$ASSERTION" ]; then
             echo "❌ Flow execution did not return an assertion: $FLOW_RESP"

--- a/backend/cmd/server/bootstrap/01-default-resources.yaml
+++ b/backend/cmd/server/bootstrap/01-default-resources.yaml
@@ -307,7 +307,15 @@ flowType: AUTHENTICATION
 nodes:
 - id: start
   type: START
-  onSuccess: prompt_credentials
+  onSuccess: sso_check
+- id: sso_check
+  type: TASK_EXECUTION
+  executor:
+    name: SSOCheckExecutor
+  properties:
+    checkpointRef: session
+  onSuccess: session
+  onFailure: prompt_credentials
 - id: prompt_credentials
   type: PROMPT
   meta:
@@ -363,8 +371,13 @@ nodes:
   type: TASK_EXECUTION
   executor:
     name: CredentialsAuthExecutor
-  onSuccess: authorization_check
+  onSuccess: session
   onIncomplete: prompt_credentials
+- id: session
+  type: TASK_EXECUTION
+  executor:
+    name: SessionExecutor
+  onSuccess: authorization_check
 - id: authorization_check
   type: TASK_EXECUTION
   executor:
@@ -377,6 +390,75 @@ nodes:
   onSuccess: end
 - id: end
   type: END
+---
+resource_type: flow
+id: 01900000-0000-7000-8000-00000000006a
+name: Default Sign Out Flow
+handle: console-signout-flow
+flowType: SIGNOUT
+nodes:
+- id: start
+  type: START
+  onSuccess: prompt_confirm
+  layout:
+    size:
+      width: 101
+      height: 34
+    position:
+      x: 62
+      y: 278
+- id: prompt_confirm
+  type: PROMPT
+  layout:
+    size:
+      width: 350
+      height: 300
+    position:
+      x: 463
+      y: 150
+  meta:
+    components:
+    - type: TEXT
+      id: text_signout_title
+      label: '{{ t(signout:forms.confirm.title) }}'
+      variant: HEADING_1
+    - type: TEXT
+      id: text_signout_desc
+      label: '{{ t(signout:forms.confirm.description) }}'
+      variant: BODY_1
+    - type: BLOCK
+      id: block_signout
+      components:
+      - type: ACTION
+        id: action_confirm
+        label: '{{ t(signout:forms.confirm.actions.submit.label) }}'
+        variant: PRIMARY
+        eventType: SUBMIT
+  prompts:
+  - action:
+      ref: action_confirm
+      nextNode: session_signout
+- id: session_signout
+  type: TASK_EXECUTION
+  layout:
+    size:
+      width: 217
+      height: 113
+    position:
+      x: 960
+      y: 240
+  executor:
+    name: SessionSignOutExecutor
+  onSuccess: end
+- id: end
+  type: END
+  layout:
+    size:
+      width: 85
+      height: 34
+    position:
+      x: 1400
+      y: 278
 ---
 resource_type: flow
 id: 01900000-0000-7000-8000-000000000067
@@ -4697,6 +4779,8 @@ logoUrl: "avatar:shape=rounded,variant=anonymous_entity,content=cube,colors=0,bg
 authFlowId: 01900000-0000-7000-8000-000000000068
 registrationFlowId: 01900000-0000-7000-8000-000000000069
 isRegistrationFlowEnabled: false
+signOutFlowId: 01900000-0000-7000-8000-00000000006a
+isSignOutFlowEnabled: true
 allowedUserTypes:
   - Person
 inboundAuthConfig:
@@ -4704,6 +4788,11 @@ inboundAuthConfig:
     config:
       clientId: CONSOLE
       redirectUris:
+        - "{{ .PUBLIC_URL }}/console"
+        {{- range .CONSOLE_REDIRECT_URIS }}
+        - "{{ . }}"
+        {{- end }}
+      postLogoutRedirectUris:
         - "{{ .PUBLIC_URL }}/console"
         {{- range .CONSOLE_REDIRECT_URIS }}
         - "{{ . }}"

--- a/frontend/apps/console/src/layouts/DashboardLayout.tsx
+++ b/frontend/apps/console/src/layouts/DashboardLayout.tsx
@@ -158,6 +158,11 @@ export default function DashboardLayout({collapseSidebar = false}: DashboardLayo
       return;
     }
 
+    // Native ThunderID session: signOut() performs OIDC RP-Initiated Logout, the SDK's default
+    // behavior (no client config required). It clears the local session and redirects to ThunderID's
+    // end_session_endpoint, which confirms the sign-out, terminates the SSO session server-side, and
+    // returns to the console. It falls back to a local-only sign out when no end_session_endpoint is
+    // advertised.
     signOut().catch((error: unknown) => {
       logger.error('Sign out failed', {error});
     });


### PR DESCRIPTION
### Purpose
This PR enables SSO for the console login flow (reuse an existing session instead of forcing a fresh login) and adds OIDC RP-Initiated Logout for console sign-out.

Today the console login flow does not use SSO, so each sign-in is a fresh authentication and sign-out only clears the local session. Introducing SSO establishes a server-side session, which then has to be terminated on sign-out rather than left to expire. So this change pairs the SSO login flow with a console sign-out flow: signing out now confirms, terminates the SSO session server-side, and returns the user to the console.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
- **Bootstrap flows (`01-default-resources.yaml`):**
  - Console login flow gains SSO reuse: a `SSOCheckExecutor` step (reuse the existing session when present) followed by a `SessionExecutor` step (establish/refresh it).
  - New **Console App Sign Out Flow** (`flowType: SIGNOUT`): a confirmation prompt, then session termination via `SessionSignOutExecutor`. Node layout mirrors the "Basic Sign Out Flow" template so the graph renders cleanly.
  - Console client links the sign-out flow (`signOutFlowId` + `isSignOutFlowEnabled`) and registers `postLogoutRedirectUris`.
- **Frontend:** no provider config is required. The console's existing `signOut()` performs RP-Initiated Logout via the SDK default (redirect to the `end_session_endpoint`, then back to the console). `DashboardLayout` gets an explanatory comment only; the generic-OIDC path is unchanged (it logs out at the external IdP directly and never calls the SDK `signOut()`).

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2036

### Related PRs
- https://github.com/thunder-id/javascript-sdks/pull/36

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an SSO check before console credential sign-in.
  * Added a dedicated console sign-out flow with confirmation and session termination.
  * Enabled post-logout redirects for the console.

* **Bug Fixes**
  * Improved authentication flow handling when SSO checks succeed or fail.
  * Updated end-to-end login validation to support the new multi-step authentication process.

* **Documentation**
  * Documented native session sign-out behavior, including fallback handling when provider logout is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->