### PR TITLE
Improve CLI tool to prompt for admin credentials and generate random password

### DIFF
--- a/tools/cli/internal/cli/root.go
+++ b/tools/cli/internal/cli/root.go
@@ -124,11 +124,12 @@ func Run(verbose, forceSetup bool) {
 		ui.Note("Already running",
 			fmt.Sprintf("%s is already running on port %d.\nAttaching to the existing instance.",
 				product.Name, health.DefaultPort))
-		replLoop(runVersion, path, nil, verbose, isFirstRun, newVersion, nodeWarning, 0)
+		replLoop(runVersion, path, nil, verbose, isFirstRun, newVersion, nodeWarning, 0, nil)
 		return
 	}
 
 	port := health.DefaultPort
+	var creds *setup.AdminCredentials
 
 	if alreadyInstalled && !forceSetup {
 		ui.Note("Starting "+product.Name, fmt.Sprintf("%s v%s is ready\n%s", product.Name, runVersion, path))
@@ -148,7 +149,7 @@ func Run(verbose, forceSetup bool) {
 			ui.Note("First-time setup", fmt.Sprintf("Setting up %s v%s\n%s", product.Name, runVersion, path))
 		}
 		port = resolvePort(path)
-		runSetupPhase(runVersion, path, verbose)
+		creds = runSetupPhase(runVersion, path, verbose)
 	} else {
 		// If the previously-active version is no longer in the manifest we'd need
 		// to download it, so fall back to the latest available version.
@@ -168,7 +169,7 @@ func Run(verbose, forceSetup bool) {
 		}
 		path = absPath
 		port = resolvePort(path)
-		runSetupPhase(runVersion, path, verbose)
+		creds = runSetupPhase(runVersion, path, verbose)
 		if err := config.WriteActiveVersion(runVersion); err != nil {
 			ui.Fatal("Failed to record active version: " + err.Error())
 			os.Exit(1)
@@ -184,19 +185,22 @@ func Run(verbose, forceSetup bool) {
 	proc, err := setup.StartBackgroundOnPort(path, verbose, port)
 	if err != nil {
 		fmt.Println()
+		// The REPL normally displays generated credentials; since we exit before it,
+		// print them here so a fresh password is not lost (setup won't regenerate it).
+		ui.PrintCredentialsFallback(creds)
 		ui.Fatal("Failed to start " + product.Name + ": " + err.Error())
 		os.Exit(1)
 	}
 	fmt.Printf("\r\033[2K  %s %s started  %s\n", ui.Green("✓"), product.Name, ui.Dim("logs: "+setup.LogDir(path)))
 
-	replLoop(runVersion, path, proc, verbose, isFirstRun, newVersion, nodeWarning, port)
+	replLoop(runVersion, path, proc, verbose, isFirstRun, newVersion, nodeWarning, port, creds)
 }
 
 // replLoop runs the REPL repeatedly, re-entering after no-op upgrades or version switches.
 // An actual upgrade or normal exit breaks the loop.
-func replLoop(version, installPath string, proc *exec.Cmd, verbose, isFirstRun bool, newVersion, nodeWarning string, port int) {
+func replLoop(version, installPath string, proc *exec.Cmd, verbose, isFirstRun bool, newVersion, nodeWarning string, port int, creds *setup.AdminCredentials) {
 	for {
-		upgradeRequested, switchRequested, err := ui.RunREPL(version, proc, installPath, verbose, isFirstRun, newVersion, nodeWarning, port)
+		upgradeRequested, switchRequested, err := ui.RunREPL(version, proc, installPath, verbose, isFirstRun, newVersion, nodeWarning, port, creds)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "\nREPL error: %v\n", err)
 			os.Exit(1)
@@ -302,15 +306,66 @@ func downloadAndInstall(version, path string, verbose bool) {
 	fmt.Printf("  %s %s v%s installed to %s\n", ui.Green("✓"), product.Name, version, path)
 }
 
+// collectAdminCredentials prompts for the admin username and password before setup,
+// showing the default username and a freshly generated password as the values that
+// will be used if nothing is entered (mirroring setup.sh). It exports the results via
+// the THUNDERID_ADMIN_* env vars that setup consumes.
+//
+// It is skipped when both values are already provided via the environment (scripted
+// runs) or when stdin is not interactive; in those cases setup.sh generates and
+// surfaces the password itself. When the operator accepts the generated password it
+// is returned so the REPL can display it; a typed password returns nil (the operator
+// already knows it), matching setup.sh's notice behavior.
+func collectAdminCredentials() *setup.AdminCredentials {
+	if os.Getenv("THUNDERID_ADMIN_USERNAME") != "" && os.Getenv("THUNDERID_ADMIN_PASSWORD") != "" {
+		return nil
+	}
+	defaultUser := os.Getenv("THUNDERID_ADMIN_USERNAME")
+	if defaultUser == "" {
+		defaultUser = "admin"
+	}
+	username, password, useGenerated, ok := ui.PromptAdminCredentials(defaultUser, defaultAdminPassword())
+	if !ok {
+		return nil
+	}
+	if err := os.Setenv("THUNDERID_ADMIN_USERNAME", username); err != nil {
+		ui.Fatal("Failed to set admin username: " + err.Error())
+		os.Exit(1)
+	}
+	if err := os.Setenv("THUNDERID_ADMIN_PASSWORD", password); err != nil {
+		ui.Fatal("Failed to set admin password: " + err.Error())
+		os.Exit(1)
+	}
+	if useGenerated {
+		return &setup.AdminCredentials{Username: username, Password: password}
+	}
+	return nil
+}
+
+// defaultAdminPassword returns the password to offer as the prompt default: a
+// pre-configured THUNDERID_ADMIN_PASSWORD if set (so accepting the prompt keeps it
+// instead of overwriting it with a fresh one), otherwise a freshly generated one.
+func defaultAdminPassword() string {
+	if p := os.Getenv("THUNDERID_ADMIN_PASSWORD"); p != "" {
+		return p
+	}
+	return setup.GenerateAdminPassword()
+}
+
 // runSetupPhase runs setup.sh with a spinner (non-verbose) or raw output (verbose).
 // On failure in non-verbose mode, the captured stderr is printed before the error box.
-func runSetupPhase(version, installPath string, verbose bool) {
+// It returns the generated admin credentials when setup produced them, or nil.
+func runSetupPhase(version, installPath string, verbose bool) *setup.AdminCredentials {
+	promptCreds := collectAdminCredentials()
+	var setupCreds *setup.AdminCredentials
 	if verbose {
 		fmt.Printf("\n  Running %s setup (v%s)...\n", product.Name, version)
-		if err := setup.RunSetup(installPath, true); err != nil {
+		c, err := setup.RunSetup(installPath, true)
+		if err != nil {
 			ui.Fatal("Setup failed: " + err.Error())
 			os.Exit(1)
 		}
+		setupCreds = c
 	} else {
 		fmt.Println()
 		var setupErr error
@@ -323,7 +378,7 @@ func runSetupPhase(version, installPath string, verbose bool) {
 			})).
 			Title("Setting up " + product.Name + "...").
 			Action(func() {
-				setupErr = setup.RunSetup(installPath, false)
+				setupCreds, setupErr = setup.RunSetup(installPath, false)
 			}).
 			Run(); err != nil {
 			ui.Fatal("Setup interrupted: " + err.Error())
@@ -348,8 +403,19 @@ func runSetupPhase(version, installPath string, verbose bool) {
 	}
 
 	if err := config.MarkSetupComplete(version); err != nil {
+		creds := setupCreds
+		if promptCreds != nil {
+			creds = promptCreds
+		}
+		ui.PrintCredentialsFallback(creds)
 		ui.Fatal("Failed to mark setup complete: " + err.Error())
 		os.Exit(1)
 	}
 	fmt.Printf("  %s Setup complete\n", ui.Green("✓"))
+	// Prefer the interactively collected credentials; fall back to whatever setup.sh
+	// generated and printed (non-interactive path).
+	if promptCreds != nil {
+		return promptCreds
+	}
+	return setupCreds
 }

--- a/tools/cli/internal/cli/root_internal_test.go
+++ b/tools/cli/internal/cli/root_internal_test.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cli
+
+import "testing"
+
+func TestDefaultAdminPassword_UsesPresetEnv(t *testing.T) {
+	t.Setenv("THUNDERID_ADMIN_PASSWORD", "Preset#1Pass")
+	if got := defaultAdminPassword(); got != "Preset#1Pass" {
+		t.Fatalf("expected pre-set password to be reused, got %q", got)
+	}
+}
+
+func TestDefaultAdminPassword_GeneratesWhenUnset(t *testing.T) {
+	t.Setenv("THUNDERID_ADMIN_PASSWORD", "")
+	if got := defaultAdminPassword(); len(got) != 12 {
+		t.Fatalf("expected a generated 12-char password, got %q (len %d)", got, len(got))
+	}
+}
+
+func TestCollectAdminCredentials_SkipsWhenBothPreset(t *testing.T) {
+	t.Setenv("THUNDERID_ADMIN_USERNAME", "operator")
+	t.Setenv("THUNDERID_ADMIN_PASSWORD", "Preset#1Pass")
+	if creds := collectAdminCredentials(); creds != nil {
+		t.Fatalf("expected nil when both env vars are preset, got %+v", creds)
+	}
+}
+
+func TestCollectAdminCredentials_NonInteractiveReturnsNil(t *testing.T) {
+	// Under `go test` stdin is not a character device, so the interactive prompt
+	// is skipped and the function falls through to setup's own defaults.
+	t.Setenv("THUNDERID_ADMIN_USERNAME", "")
+	t.Setenv("THUNDERID_ADMIN_PASSWORD", "")
+	if creds := collectAdminCredentials(); creds != nil {
+		t.Fatalf("expected nil on non-interactive stdin, got %+v", creds)
+	}
+}

--- a/tools/cli/internal/commands/upgrade/upgrade.go
+++ b/tools/cli/internal/commands/upgrade/upgrade.go
@@ -157,7 +157,7 @@ func Switch(baseDir, currentVersion string, verbose bool) (bool, error) {
 	}
 	fmt.Printf("\r\033[2K  %s Switched to %s v%s  %s\n", ui.Green("✓"), product.Name, selected, ui.Dim("logs: "+setup.LogDir(installPath)))
 
-	_, _, err = ui.RunREPL(selected, proc, installPath, verbose, false, "", "", 0)
+	_, _, err = ui.RunREPL(selected, proc, installPath, verbose, false, "", "", 0, nil)
 	return true, err
 }
 
@@ -180,7 +180,8 @@ func runDirect(baseDir, activeVersion, newVersion string, verbose bool) error {
 	if err := downloadVersion(newVersion, newPath, verbose); err != nil {
 		return err
 	}
-	if err := runSetupWithPort(newVersion, newPath, verbose, 0); err != nil {
+	creds, err := runSetupWithPort(newVersion, newPath, verbose, 0)
+	if err != nil {
 		return err
 	}
 
@@ -188,6 +189,7 @@ func runDirect(baseDir, activeVersion, newVersion string, verbose bool) error {
 	proc, err := setup.StartBackground(newPath, verbose)
 	if err != nil {
 		fmt.Println()
+		ui.PrintCredentialsFallback(creds)
 		ui.Fatal("Failed to start " + product.Name + ": " + err.Error())
 		return err
 	}
@@ -204,7 +206,7 @@ func runDirect(baseDir, activeVersion, newVersion string, verbose bool) error {
 	}
 	fmt.Printf("\r\033[2K  %s %s v%s started  %s\n", ui.Green("✓"), product.Name, newVersion, ui.Dim("logs: "+setup.LogDir(newPath)))
 
-	_, _, err = ui.RunREPL(newVersion, proc, newPath, verbose, false, "", "", 0)
+	_, _, err = ui.RunREPL(newVersion, proc, newPath, verbose, false, "", "", 0, creds)
 	return err
 }
 
@@ -213,7 +215,8 @@ func runSideBySide(baseDir, activeVersion, newVersion string, verbose bool) erro
 	if err := downloadVersion(newVersion, newPath, verbose); err != nil {
 		return err
 	}
-	if err := runSetupWithPort(newVersion, newPath, verbose, stagingPort); err != nil {
+	creds, err := runSetupWithPort(newVersion, newPath, verbose, stagingPort)
+	if err != nil {
 		return err
 	}
 
@@ -221,6 +224,7 @@ func runSideBySide(baseDir, activeVersion, newVersion string, verbose bool) erro
 	proc, err := setup.StartBackgroundOnPort(newPath, verbose, stagingPort)
 	if err != nil {
 		fmt.Println()
+		ui.PrintCredentialsFallback(creds)
 		ui.Fatal("Failed to start staging instance: " + err.Error())
 		return err
 	}
@@ -229,17 +233,17 @@ func runSideBySide(baseDir, activeVersion, newVersion string, verbose bool) erro
 	fmt.Printf("  Type %s in the REPL to cut over to v%s and restart on port %d.\n\n",
 		ui.Cyan("/cutover"), newVersion, health.DefaultPort)
 
-	cutoverRequested, err := ui.RunStagingREPL(newVersion, proc, newPath, verbose, stagingPort)
+	cutoverRequested, err := ui.RunStagingREPL(newVersion, proc, newPath, verbose, stagingPort, creds)
 	if err != nil {
 		return err
 	}
 	if !cutoverRequested {
 		return nil // user exited without cutting over
 	}
-	return performCutover(baseDir, activeVersion, newVersion, newPath, proc, verbose)
+	return performCutover(baseDir, activeVersion, newVersion, newPath, proc, verbose, creds)
 }
 
-func performCutover(baseDir, activeVersion, newVersion, newPath string, stagingProc *exec.Cmd, verbose bool) error {
+func performCutover(baseDir, activeVersion, newVersion, newPath string, stagingProc *exec.Cmd, verbose bool, creds *setup.AdminCredentials) error {
 	fmt.Printf("\n  %s Cutting over from v%s to v%s...\n\n", ui.Cyan("→"), activeVersion, newVersion)
 
 	if stagingProc != nil && stagingProc.Process != nil {
@@ -272,7 +276,7 @@ func performCutover(baseDir, activeVersion, newVersion, newPath string, stagingP
 	}
 	fmt.Printf("\r\033[2K  %s %s v%s is now live on port %d\n", ui.Green("✓"), product.Name, newVersion, health.DefaultPort)
 
-	_, _, err = ui.RunREPL(newVersion, proc, newPath, verbose, false, "", "", 0)
+	_, _, err = ui.RunREPL(newVersion, proc, newPath, verbose, false, "", "", 0, creds)
 	return err
 }
 
@@ -307,13 +311,16 @@ func downloadVersion(version, destDir string, verbose bool) error {
 	return nil
 }
 
-func runSetupWithPort(version, installPath string, verbose bool, port int) error {
+func runSetupWithPort(version, installPath string, verbose bool, port int) (*setup.AdminCredentials, error) {
+	var creds *setup.AdminCredentials
 	if verbose {
 		fmt.Printf("\n  Running %s setup (v%s)...\n", product.Name, version)
-		if err := setup.RunSetupOnPort(installPath, true, port); err != nil {
+		c, err := setup.RunSetupOnPort(installPath, true, port)
+		if err != nil {
 			ui.Fatal("Setup failed: " + err.Error())
-			return err
+			return nil, err
 		}
+		creds = c
 	} else {
 		fmt.Println()
 		var setupErr error
@@ -326,11 +333,11 @@ func runSetupWithPort(version, installPath string, verbose bool, port int) error
 			})).
 			Title("Setting up " + product.Name + " v" + version + "...").
 			Action(func() {
-				setupErr = setup.RunSetupOnPort(installPath, false, port)
+				creds, setupErr = setup.RunSetupOnPort(installPath, false, port)
 			}).
 			Run(); err != nil {
 			ui.Fatal("Setup interrupted: " + err.Error())
-			return err
+			return nil, err
 		}
 		if setupErr != nil {
 			msg := setupErr.Error()
@@ -346,15 +353,16 @@ func runSetupWithPort(version, installPath string, verbose bool, port int) error
 				msg = strings.TrimSpace(msg[:idx])
 			}
 			ui.Fatal(msg)
-			return setupErr
+			return nil, setupErr
 		}
 	}
 	if err := config.MarkSetupComplete(version); err != nil {
+		ui.PrintCredentialsFallback(creds)
 		ui.Fatal("Failed to mark setup complete: " + err.Error())
-		return err
+		return nil, err
 	}
 	fmt.Printf("  %s Setup complete\n", ui.Green("✓"))
-	return nil
+	return creds, nil
 }
 
 func versionedPath(baseDir, version string) string {

--- a/tools/cli/internal/services/setup/setup.go
+++ b/tools/cli/internal/services/setup/setup.go
@@ -20,8 +20,10 @@ package setup
 
 import (
 	"bytes"
+	"crypto/rand"
 	"fmt"
 	"io"
+	"math/big"
 	"net"
 	"os"
 	"os/exec"
@@ -107,17 +109,27 @@ func FindThunderRoot(installPath string) (string, error) {
 	return filepath.Dir(script), nil
 }
 
+// AdminCredentials holds the admin username and password surfaced by setup, so the
+// caller can display them after the setup spinner has finished rather than printing
+// them mid-run (which interleaves with the spinner and is hidden by the REPL's
+// alternate screen).
+type AdminCredentials struct {
+	Username string
+	Password string
+}
+
 // RunSetup executes the platform setup script non-interactively on the default port.
-func RunSetup(installPath string, verbose bool) error {
+func RunSetup(installPath string, verbose bool) (*AdminCredentials, error) {
 	return RunSetupOnPort(installPath, verbose, 0)
 }
 
 // RunSetupOnPort executes the platform setup script with an optional custom port.
-// Pass port=0 to use the default.
-func RunSetupOnPort(installPath string, verbose bool, port int) error {
+// Pass port=0 to use the default. When the setup run generated an admin password,
+// the parsed credentials are returned; otherwise the returned credentials are nil.
+func RunSetupOnPort(installPath string, verbose bool, port int) (*AdminCredentials, error) {
 	root, err := FindThunderRoot(installPath)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var cmd *exec.Cmd
@@ -146,9 +158,15 @@ func RunSetupOnPort(installPath string, verbose bool, port int) error {
 	cmd.Stdin = nil // no stdin → prevents any remaining interactive prompts
 
 	if verbose {
-		cmd.Stdout = os.Stdout
+		// Mirror to the terminal live, but also capture so the credentials can be
+		// re-surfaced inside the REPL (which draws on the alternate screen).
+		var outBuf bytes.Buffer
+		cmd.Stdout = io.MultiWriter(os.Stdout, &outBuf)
 		cmd.Stderr = os.Stderr
-		return cmd.Run()
+		if err := cmd.Run(); err != nil {
+			return nil, err
+		}
+		return parseAdminCredentials(outBuf.String()), nil
 	}
 
 	// Non-verbose: capture stdout+stderr so we can surface them on failure.
@@ -159,23 +177,49 @@ func RunSetupOnPort(installPath string, verbose bool, port int) error {
 		detail := strings.TrimSpace(errBuf.String() + "\n" + outBuf.String())
 		detail = strings.TrimSpace(detail)
 		if detail != "" {
-			return fmt.Errorf("%w\n\n%s", err, detail)
+			return nil, fmt.Errorf("%w\n\n%s", err, detail)
 		}
-		return fmt.Errorf("%w\n\nRun with --verbose for full setup output", err)
+		return nil, fmt.Errorf("%w\n\nRun with --verbose for full setup output", err)
 	}
-	// Always surface the admin credentials block, even in non-verbose mode — this is
-	// the only place a generated admin password is shown when running non-verbosely.
-	printAdminCredentials(outBuf.String())
-	return nil
+	return parseAdminCredentials(outBuf.String()), nil
 }
 
-// printAdminCredentials extracts and prints the admin credentials block from captured
-// setup output, if present. setup.sh/setup.ps1 print this block followed by a blank
-// line, only when the password was generated this run.
-func printAdminCredentials(output string) {
+// GenerateAdminPassword returns a random 12-character password using the same
+// character set and constraints as setup.sh (at least one digit and one special
+// character). The CLI generates it up-front so it can be shown as the default value
+// in the interactive prompt before setup runs.
+func GenerateAdminPassword() string {
+	const (
+		digits  = "0123456789"
+		special = "@#%+=_.?-"
+		letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+		charset = letters + digits + special
+		length  = 12
+	)
+	for {
+		b := make([]byte, length)
+		for i := range b {
+			n, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+			if err != nil {
+				panic("crypto/rand unavailable: " + err.Error())
+			}
+			b[i] = charset[n.Int64()]
+		}
+		s := string(b)
+		if strings.ContainsAny(s, digits) && strings.ContainsAny(s, special) {
+			return s
+		}
+	}
+}
+
+// parseAdminCredentials extracts the admin username and password from captured setup
+// output. setup.sh/setup.ps1 print an "Admin credentials:" block followed by a blank
+// line, but only when the password was generated this run; returns nil when no such
+// block is present.
+func parseAdminCredentials(output string) *AdminCredentials {
 	start := strings.Index(output, "Admin credentials:")
 	if start == -1 {
-		return
+		return nil
 	}
 	block := output[start:]
 	if idx := strings.Index(block, "\n\n"); idx != -1 {
@@ -183,7 +227,19 @@ func printAdminCredentials(output string) {
 	} else if idx := strings.Index(block, "\r\n\r\n"); idx != -1 {
 		block = block[:idx+2]
 	}
-	fmt.Print(block)
+	creds := &AdminCredentials{}
+	for _, line := range strings.Split(block, "\n") {
+		line = strings.TrimSpace(line)
+		if v := strings.TrimPrefix(line, "Username:"); v != line {
+			creds.Username = strings.TrimSpace(v)
+		} else if v := strings.TrimPrefix(line, "Password:"); v != line {
+			creds.Password = strings.TrimSpace(v)
+		}
+	}
+	if creds.Username == "" && creds.Password == "" {
+		return nil
+	}
+	return creds
 }
 
 // StartBackground starts Thunder detached from the terminal on the default port.

--- a/tools/cli/internal/services/setup/setup_internal_test.go
+++ b/tools/cli/internal/services/setup/setup_internal_test.go
@@ -18,33 +18,13 @@
 package setup
 
 import (
-	"io"
-	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func captureStdout(t *testing.T, fn func()) string {
-	t.Helper()
-	orig := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("failed to create pipe: %v", err)
-	}
-	os.Stdout = w
-	fn()
-	_ = w.Close()
-	os.Stdout = orig
-
-	out, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("failed to read captured stdout: %v", err)
-	}
-	return string(out)
-}
-
-func TestPrintAdminCredentials_PrintsBlock(t *testing.T) {
+func TestParseAdminCredentials_ParsesBlock(t *testing.T) {
 	output := "some noise\n" +
 		"Admin credentials:\n" +
 		"  Username: admin\n" +
@@ -53,18 +33,14 @@ func TestPrintAdminCredentials_PrintsBlock(t *testing.T) {
 		"\n" +
 		"trailing noise\n"
 
-	captured := captureStdout(t, func() {
-		printAdminCredentials(output)
-	})
+	creds := parseAdminCredentials(output)
 
-	assert.Contains(t, captured, "Admin credentials:")
-	assert.Contains(t, captured, "Username: admin")
-	assert.Contains(t, captured, "Password: abc123")
-	assert.NotContains(t, captured, "trailing noise")
-	assert.NotContains(t, captured, "some noise")
+	assert.NotNil(t, creds)
+	assert.Equal(t, "admin", creds.Username)
+	assert.Equal(t, "abc123", creds.Password)
 }
 
-func TestPrintAdminCredentials_CRLFPrintsBlock(t *testing.T) {
+func TestParseAdminCredentials_CRLF(t *testing.T) {
 	output := "some noise\r\n" +
 		"Admin credentials:\r\n" +
 		"  Username: admin\r\n" +
@@ -73,21 +49,24 @@ func TestPrintAdminCredentials_CRLFPrintsBlock(t *testing.T) {
 		"\r\n" +
 		"trailing noise\r\n"
 
-	captured := captureStdout(t, func() {
-		printAdminCredentials(output)
-	})
+	creds := parseAdminCredentials(output)
 
-	assert.Contains(t, captured, "Admin credentials:")
-	assert.Contains(t, captured, "Username: admin")
-	assert.Contains(t, captured, "Password: abc123")
-	assert.NotContains(t, captured, "trailing noise")
-	assert.NotContains(t, captured, "some noise")
+	assert.NotNil(t, creds)
+	assert.Equal(t, "admin", creds.Username)
+	assert.Equal(t, "abc123", creds.Password)
 }
 
-func TestPrintAdminCredentials_NoBlockPrintsNothing(t *testing.T) {
-	captured := captureStdout(t, func() {
-		printAdminCredentials("no credentials here at all")
-	})
+func TestParseAdminCredentials_NoBlockReturnsNil(t *testing.T) {
+	assert.Nil(t, parseAdminCredentials("no credentials here at all"))
+}
 
-	assert.Empty(t, captured)
+func TestGenerateAdminPassword(t *testing.T) {
+	const special = "@#%+=_.?-"
+	for i := 0; i < 100; i++ {
+		pw := GenerateAdminPassword()
+		assert.Len(t, pw, 12)
+		assert.True(t, strings.ContainsAny(pw, "0123456789"), "must contain a digit: %q", pw)
+		assert.True(t, strings.ContainsAny(pw, special), "must contain a special char: %q", pw)
+	}
+	assert.NotEqual(t, GenerateAdminPassword(), GenerateAdminPassword())
 }

--- a/tools/cli/internal/ui/banner.go
+++ b/tools/cli/internal/ui/banner.go
@@ -20,12 +20,14 @@ package ui
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"charm.land/huh/v2"
 	"charm.land/lipgloss/v2"
 
 	"github.com/thunder-id/thunderid/tools/cli/internal/product"
+	"github.com/thunder-id/thunderid/tools/cli/internal/services/setup"
 )
 
 const (
@@ -236,6 +238,65 @@ func PromptPortConflict(port, altPort int) (PortConflictChoice, int) {
 		return choice, altPort
 	}
 	return choice, port
+}
+
+// PromptAdminCredentials interactively collects the admin username and password
+// before setup runs. The defaults (defaultUsername and generatedPassword) are shown
+// as the values that will be used if the operator provides nothing, mirroring
+// setup.sh; neither field is prefilled with editable text. Pressing Enter on the
+// password field accepts the generated one, in which case usedGenerated is true.
+//
+// It returns ok=false (a no-op) when stdin is not an interactive terminal, so
+// scripted and CI runs fall through to setup's own defaults.
+func PromptAdminCredentials(defaultUsername, generatedPassword string) (username, password string, usedGenerated, ok bool) {
+	if fi, err := os.Stdin.Stat(); err != nil || (fi.Mode()&os.ModeCharDevice) == 0 {
+		return "", "", false, false
+	}
+	var userInput, passInput string
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewNote().
+				Title("Configure the default admin user").
+				Description("Press Enter to accept the shown default."),
+			huh.NewInput().
+				Title("Admin username").
+				Description("Default: "+defaultUsername).
+				Placeholder(defaultUsername).
+				Value(&userInput),
+			huh.NewInput().
+				Title("Admin password").
+				Description("Press Enter to use the generated password: "+generatedPassword).
+				Placeholder("leave blank to use the generated password").
+				EchoMode(huh.EchoModePassword).
+				Value(&passInput),
+		),
+	)
+	if err := form.Run(); err != nil {
+		return "", "", false, false
+	}
+	username = strings.TrimSpace(userInput)
+	if username == "" {
+		username = defaultUsername
+	}
+	if passInput == "" {
+		return username, generatedPassword, true, true
+	}
+	return username, passInput, false, true
+}
+
+// PrintCredentialsFallback prints generated admin credentials to stdout when the
+// REPL that normally displays them will not be reached (e.g. startup failed). Setup
+// does not regenerate the password on a later run, so this is the last chance to
+// surface it. No-op when no credentials were generated.
+func PrintCredentialsFallback(creds *setup.AdminCredentials) {
+	if creds == nil {
+		return
+	}
+	fmt.Println("  " + Bold("Admin credentials"))
+	fmt.Println("    Username: " + Cyan(creds.Username))
+	fmt.Println("    Password: " + Cyan(creds.Password))
+	fmt.Println("    " + Dim("Sign in to the Console with these credentials once it is running."))
+	fmt.Println()
 }
 
 // PromptUpgrade shows the "new version available" banner and asks the user what to do.

--- a/tools/cli/internal/ui/repl.go
+++ b/tools/cli/internal/ui/repl.go
@@ -309,6 +309,7 @@ type ReplModel struct {
 	baseURL     string
 	installPath string
 	verbose     bool
+	adminCreds  *setup.AdminCredentials
 
 	showCompletions bool
 	completions     []SlashCommand
@@ -361,7 +362,7 @@ type ReplModel struct {
 }
 
 // NewReplModel initializes the REPL model.
-func NewReplModel(version string, proc *exec.Cmd, installPath string, verbose bool, isFirstRun bool) ReplModel {
+func NewReplModel(version string, proc *exec.Cmd, installPath string, verbose bool, isFirstRun bool, creds *setup.AdminCredentials) ReplModel {
 	ti := textinput.New()
 	ti.Placeholder = "Starting " + product.Name + "..."
 	ti.Prompt = "> "
@@ -470,6 +471,7 @@ func NewReplModel(version string, proc *exec.Cmd, installPath string, verbose bo
 		version:        version,
 		installPath:    installPath,
 		verbose:        verbose,
+		adminCreds:     creds,
 		status:         statusStarting,
 		proc:           proc,
 		width:          80,
@@ -1364,6 +1366,27 @@ func renderIntegrate(m ReplModel) string {
 	return b.String()
 }
 
+// credentialsBox renders a bordered box with the generated admin credentials, so
+// they stay visible on the alternate screen for the whole session. Returns an empty
+// string when no credentials were generated this run.
+func (m ReplModel) credentialsBox() string {
+	if m.adminCreds == nil {
+		return ""
+	}
+	label := lipgloss.NewStyle().Foreground(lipgloss.Color(colorGrey)).Width(10)
+	rows := lipgloss.JoinVertical(lipgloss.Left,
+		Bold("Admin credentials"),
+		label.Render("Username")+Cyan(m.adminCreds.Username),
+		label.Render("Password")+Cyan(m.adminCreds.Password),
+		Dim("Sign in to the Console with these credentials."),
+	)
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color(colorBrandBlue)).
+		Padding(0, 1).
+		Render(rows)
+}
+
 // View implements tea.Model.
 func (m ReplModel) View() tea.View {
 	v := tea.NewView(m.render())
@@ -1393,6 +1416,9 @@ func (m ReplModel) render() string {
 		b.WriteString(StatusBoxString(m.baseURL) + "\n")
 	case statusStopped:
 		b.WriteString(Red("○") + " Stopped\n")
+	}
+	if box := m.credentialsBox(); box != "" {
+		b.WriteString(box + "\n")
 	}
 	b.WriteString(Dim(strings.Repeat("─", clamp(m.width-2, 20, 80))) + "\n\n")
 
@@ -1482,9 +1508,9 @@ func clamp(v, min, max int) int {
 // Returns upgradeRequested=true when the user ran /upgrade, switchRequested=true when /use.
 func RunREPL(
 	version string, proc *exec.Cmd, installPath string,
-	verbose, isFirstRun bool, newVersion, nodeWarning string, port int,
+	verbose, isFirstRun bool, newVersion, nodeWarning string, port int, creds *setup.AdminCredentials,
 ) (upgradeRequested, switchRequested bool, err error) {
-	m := NewReplModel(version, proc, installPath, verbose, isFirstRun)
+	m := NewReplModel(version, proc, installPath, verbose, isFirstRun, creds)
 	m.newVersion = newVersion
 	m.nodeWarning = nodeWarning
 	if port > 0 {
@@ -1501,8 +1527,8 @@ func RunREPL(
 // RunStagingREPL runs the REPL connected to a staging instance on stagingPort.
 // It injects a /cutover command; when the user runs it the REPL exits and
 // cutoverRequested=true is returned so the caller can perform the cut-over.
-func RunStagingREPL(version string, proc *exec.Cmd, installPath string, verbose bool, stagingPort int) (cutoverRequested bool, err error) {
-	m := NewReplModel(version, proc, installPath, verbose, false)
+func RunStagingREPL(version string, proc *exec.Cmd, installPath string, verbose bool, stagingPort int, creds *setup.AdminCredentials) (cutoverRequested bool, err error) {
+	m := NewReplModel(version, proc, installPath, verbose, false, creds)
 	m.checkPort = stagingPort
 	m.commands = append([]SlashCommand{
 		{

--- a/tools/cli/internal/ui/repl_internal_test.go
+++ b/tools/cli/internal/ui/repl_internal_test.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package ui
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/thunder-id/thunderid/tools/cli/internal/services/setup"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+	fn()
+	w.Close() //nolint:errcheck
+	os.Stdout = orig
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("failed to read captured stdout: %v", err)
+	}
+	return string(out)
+}
+
+func TestPrintCredentialsFallback_PrintsValues(t *testing.T) {
+	creds := &setup.AdminCredentials{Username: "admin", Password: "s3cr3t#Pass"}
+	out := captureStdout(t, func() { PrintCredentialsFallback(creds) })
+	if !strings.Contains(out, "admin") || !strings.Contains(out, "s3cr3t#Pass") {
+		t.Fatalf("fallback output missing credentials:\n%s", out)
+	}
+}
+
+func TestPrintCredentialsFallback_NilIsNoOp(t *testing.T) {
+	out := captureStdout(t, func() { PrintCredentialsFallback(nil) })
+	if out != "" {
+		t.Fatalf("expected no output for nil creds, got:\n%s", out)
+	}
+}
+
+func TestCredentialsBox_RendersValues(t *testing.T) {
+	creds := &setup.AdminCredentials{Username: "admin", Password: "s3cr3t#Pass"}
+	m := NewReplModel("1.0.0", nil, "/tmp/x", false, false, creds)
+	box := m.credentialsBox()
+	if !strings.Contains(box, "admin") || !strings.Contains(box, "s3cr3t#Pass") {
+		t.Fatalf("credentials box missing values:\n%s", box)
+	}
+}
+
+func TestCredentialsBox_NilReturnsEmpty(t *testing.T) {
+	m := NewReplModel("1.0.0", nil, "/tmp/x", false, false, nil)
+	if box := m.credentialsBox(); box != "" {
+		t.Fatalf("expected empty box for nil creds, got:\n%s", box)
+	}
+}
+
+func TestRender_IncludesCredentials(t *testing.T) {
+	creds := &setup.AdminCredentials{Username: "admin", Password: "s3cr3t#Pass"}
+	m := NewReplModel("1.0.0", nil, "/tmp/x", false, false, creds)
+	out := m.render()
+	if !strings.Contains(out, "admin") || !strings.Contains(out, "s3cr3t#Pass") {
+		t.Fatalf("render output missing credentials:\n%s", out)
+	}
+}


### PR DESCRIPTION
### Purpose
When bootstrapping ThunderID via `npx thunderid`, the generated admin credentials were printed with `fmt.Print` from inside the setup spinner's goroutine. Two problems resulted:

1. The credential output interleaved with the spinner redrawing on the same stream, so it appeared garbled.
2. It was written to the terminal's primary screen buffer, which the interactive REPL then hid behind its alternate screen for the whole session. The credentials only surfaced after running `/stop` or Ctrl+C.

On a default (non-verbose) first run, this made the generated admin password, which is required to sign in to the Console, effectively unreadable.

This PR fixes both problems and adds an interactive prompt to configure the admin username and password before setup runs.

### Approach
- Setup no longer prints credentials mid-run. `RunSetup` / `RunSetupOnPort` now parse and return the admin credentials (`*setup.AdminCredentials`) instead of calling `fmt.Print` inside the spinner action, which removes the concurrent-write garbling.
- The REPL renders the credentials in a persistent box drawn on the alternate screen, so they stay readable for the whole session and no longer require `/stop`.
- If startup fails before the REPL is reached, the credentials are printed to stdout as a fallback, so a freshly generated password is not lost.
- An interactive admin username/password prompt is shown before setup, mirroring `setup.sh`: the default username and a freshly generated password are shown as the values that will be used if nothing is entered, and neither field is prefilled. The chosen values are exported via the existing `THUNDERID_ADMIN_*` environment variables that setup already consumes. The prompt is skipped when both values are supplied via the environment (scripted runs) or when stdin is not a TTY.
- Password generation was added in Go (`GenerateAdminPassword`) using the same character set and constraints as `setup.sh`, so the value can be shown as the default before setup runs.

### Related Issues
- Fixes #4212

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The CLI REPL persistently shows an “Admin credentials” panel (username + password) for the full session when available.
  * Setup, upgrade, side-by-side, and cutover workflows now retain and reuse admin credentials end-to-end.
* **Bug Fixes**
  * Prevents losing generated admin credentials if the background startup fails before the REPL can display them.
* **Tests**
  * Added/updated coverage for credential parsing (including CRLF), generated password rules, and REPL credential rendering, plus fallback output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
