### PR TITLE
Change Rollback changes labels to 'Reset'

### DIFF
--- a/frontend/apps/console/src/features/settings/components/cors/CorsSection.tsx
+++ b/frontend/apps/console/src/features/settings/components/cors/CorsSection.tsx
@@ -135,10 +135,10 @@ export default function CorsSection(): JSX.Element {
       </SettingsCard>
       {origins.dirty && (
         <UnsavedChangesBar
-          message={t('settings:cors.unsavedChanges')}
-          resetLabel={t('settings:cors.discard')}
-          saveLabel={t('settings:cors.save')}
-          savingLabel={t('settings:cors.saving')}
+          message={t('settings:cors.unsavedChanges', 'You have unsaved changes')}
+          resetLabel={t('settings:cors.reset', 'Reset')}
+          saveLabel={t('settings:cors.save', 'Save changes')}
+          savingLabel={t('settings:cors.saving', 'Saving...')}
           isSaving={updateCors.isPending}
           saveDisabled={origins.hasErrors}
           onReset={origins.reset}

--- a/frontend/apps/console/src/features/settings/hooks/useAllowedOriginsDraft.ts
+++ b/frontend/apps/console/src/features/settings/hooks/useAllowedOriginsDraft.ts
@@ -45,7 +45,7 @@ export interface AllowedOriginsDraft {
   changeRow: (index: number, value: string) => void;
   /** Normalizes and validates the row at the given index. */
   blurRow: (index: number) => void;
-  /** Clears local edits, reverting to the saved server value (used by Discard and after a save). */
+  /** Clears local edits, reverting to the saved server value (used by Reset and after a save). */
   reset: () => void;
   /** Validates every row, sets errors, and returns whether the draft is savable. */
   validateAll: () => boolean;

--- a/frontend/packages/configure-connections/src/pages/ConnectionDetailPage.tsx
+++ b/frontend/packages/configure-connections/src/pages/ConnectionDetailPage.tsx
@@ -292,10 +292,10 @@ export default function ConnectionDetailPage(): JSX.Element | null {
 
           {dirty && (
             <UnsavedChangesBar
-              message={t('detail.saveBar.unsaved')}
-              resetLabel={t('detail.saveBar.discard')}
-              saveLabel={t('detail.saveBar.save')}
-              savingLabel={t('detail.saveBar.saving')}
+              message={t('detail.saveBar.unsaved', 'You have unsaved changes.')}
+              resetLabel={t('detail.saveBar.reset', 'Reset')}
+              saveLabel={t('detail.saveBar.save', 'Save changes')}
+              savingLabel={t('detail.saveBar.saving', 'Saving changes...')}
               isSaving={updateMutation.isPending}
               saveDisabled={!valid}
               onReset={resetEdits}

--- a/frontend/packages/configure-connections/src/pages/TrustedIssuerDetailPage.tsx
+++ b/frontend/packages/configure-connections/src/pages/TrustedIssuerDetailPage.tsx
@@ -299,7 +299,7 @@ export default function TrustedIssuerDetailPage(): JSX.Element {
           {dirty && (
             <UnsavedChangesBar
               message={t('trustedIssuers:detail.saveBar.unsaved', 'You have unsaved changes')}
-              resetLabel={t('trustedIssuers:detail.saveBar.discard', 'Discard')}
+              resetLabel={t('trustedIssuers:detail.saveBar.reset', 'Reset')}
               saveLabel={t('trustedIssuers:detail.saveBar.save', 'Save changes')}
               savingLabel={t('common:status.saving', 'Saving...')}
               isSaving={updateMutation.isPending}

--- a/frontend/packages/configure-resource-servers/src/components/resource-tree/ResourceDetailPanel.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/resource-tree/ResourceDetailPanel.tsx
@@ -409,7 +409,7 @@ function DetailForm({selectedNode, resourceServer, onRefresh}: DetailFormProps):
       {!isReadOnly && dirty && (
         <Box sx={{mt: 'auto', pt: 2, display: 'flex', gap: 1, justifyContent: 'flex-end'}}>
           <Button variant="outlined" size="small" onClick={resetForm} disabled={isPending}>
-            {t('common:discard', 'Discard')}
+            {t('common:actions.reset', 'Reset')}
           </Button>
           <Button variant="contained" size="small" onClick={handleSave} disabled={isPending}>
             {isPending ? t('common:saving', 'Saving…') : t('common:save', 'Save')}

--- a/frontend/packages/configure-resource-servers/src/pages/ResourceServerEditPage.tsx
+++ b/frontend/packages/configure-resource-servers/src/pages/ResourceServerEditPage.tsx
@@ -433,7 +433,7 @@ export default function ResourceServerEditPage(): JSX.Element {
       {hasChanges && (
         <UnsavedChangesBar
           message={t('resourceServers:edit.unsavedChanges', 'You have unsaved changes.')}
-          resetLabel={t('common:discard', 'Discard')}
+          resetLabel={t('common:actions.reset', 'Reset')}
           saveLabel={t('common:save', 'Save')}
           savingLabel={t('common:saving', 'Saving…')}
           isSaving={updateRs.isPending}

--- a/frontend/packages/configure-resource-servers/src/pages/__tests__/ResourceServerEditPage.test.tsx
+++ b/frontend/packages/configure-resource-servers/src/pages/__tests__/ResourceServerEditPage.test.tsx
@@ -79,14 +79,26 @@ vi.mocked(componentsModule.SettingsCard).mockImplementation(
   ),
 );
 vi.mocked(componentsModule.UnsavedChangesBar).mockImplementation(
-  ({message, onReset, onSave}: {message: string; onReset: () => void; onSave: () => void}) => (
+  ({
+    message,
+    resetLabel,
+    saveLabel,
+    onReset,
+    onSave,
+  }: {
+    message: string;
+    resetLabel: string;
+    saveLabel: string;
+    onReset: () => void;
+    onSave: () => void;
+  }) => (
     <div data-testid="unsaved-changes-bar">
       <span>{message}</span>
       <button type="button" onClick={onReset}>
-        Discard
+        {resetLabel}
       </button>
       <button type="button" onClick={onSave}>
-        Save
+        {saveLabel}
       </button>
     </div>
   ),

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1707,7 +1707,7 @@ const translations = {
     'detail.saveBar.unsaved': 'You have unsaved changes',
     'detail.saveBar.save': 'Save changes',
     'detail.saveBar.saving': 'Saving...',
-    'detail.saveBar.discard': 'Discard',
+    'detail.saveBar.reset': 'Reset',
 
     // Per-vendor configure / edit form
     'form.chrome.configure': 'Configure connection',
@@ -1872,7 +1872,7 @@ const translations = {
     'detail.dangerZone.delete.description':
       'Applications relying on assertions from this issuer will stop receiving tokens. This cannot be undone.',
     'detail.saveBar.unsaved': 'You have unsaved changes',
-    'detail.saveBar.discard': 'Discard',
+    'detail.saveBar.reset': 'Reset',
     'detail.saveBar.save': 'Save changes',
 
     // Toasts
@@ -4628,9 +4628,9 @@ const translations = {
     'cors.validation.invalid': 'Enter a valid origin (e.g. https://app.example.com) or a valid regular expression.',
     'cors.validation.duplicate': 'This origin is already in the list.',
     'cors.unsavedChanges': 'You have unsaved changes',
-    'cors.discard': 'Discard',
+    'cors.reset': 'Reset',
     'cors.save': 'Save changes',
-    'cors.saving': 'Saving…',
+    'cors.saving': 'Saving...',
     'cors.load.error': 'Failed to load allowed origins.',
     'cors.save.success': 'Allowed origins updated.',
     'cors.save.error': 'Failed to update allowed origins.',


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

Throughout the Console UI, 'Reset' was used as the button label for 'Rollback Changes' function buttons. But in some pages, 'Discard' text was used as the label. 

Impact: A bad UX due to inconsistent label texts.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

Changed the label texts to 'Reset'

### Related Issues
- Closes #4243 

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style / UX**
  * Standardized unsaved-changes reset actions across Settings and configuration screens to display **“Reset”** (instead of **“Discard”**).
  * Updated the CORS “Saving…” text formatting and aligned save-bar/i18n labels for Connections and Trusted Issuers.
* **Documentation**
  * Clarified allowed-origins draft “reset” terminology in the JSDoc comment.
* **Tests**
  * Updated mocks and assertions to render the **reset** and **save** button labels based on provided props.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->