### PR TITLE
Harden dependency-validation workflow

### DIFF
--- a/.github/workflows/dependency-validation.yml
+++ b/.github/workflows/dependency-validation.yml
@@ -21,17 +21,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Fetch PR head as data
+        run: |
+          git fetch --no-tags origin \
+            "pull/${{ github.event.pull_request.number }}/head:pr-head"
 
       - name: Detect modified go.mod files
         id: detect-changes
         run: |
           # Get the base branch SHA
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          # Pin to the event SHA and verify the fetched ref matches, so detection
+          # and validation use the same commit even if the PR head moved.
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          FETCHED_SHA="$(git rev-parse pr-head)"
+          if [ "$HEAD_SHA" != "$FETCHED_SHA" ]; then
+            echo "::error::PR head moved after the workflow was triggered (event: $HEAD_SHA, fetched: $FETCHED_SHA). Re-run the workflow."
+            exit 1
+          fi
 
           echo "Comparing $BASE_SHA...$HEAD_SHA"
 
@@ -51,7 +62,7 @@ jobs:
 
       - name: Checkout engineering-governance repository
         if: steps.detect-changes.outputs.has_changes == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: wso2/engineering-governance
           path: engineering-governance
@@ -72,7 +83,7 @@ jobs:
 
       - name: Comment on PR - Validation Failed
         if: steps.validate.outcome == 'failure'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -139,7 +150,7 @@ jobs:
 
       - name: Comment on PR - Validation Passed
         if: steps.validate.outcome == 'success' && steps.detect-changes.outputs.has_changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## Purpose

Fixes the Dependency Validation workflow, which was failing at checkout and carried a security risk.

## Changes

- **Remove the unsafe fork checkout.** The `pull_request_target` job checked out fork code via `head.sha`, exposing the trusted `GITHUB_TOKEN` and secrets to untrusted PR code (a "pwn request" risk). It now checks out the base repo and fetches the PR head as a git ref, so the fork's `go.mod` is analyzed as data and never executed.
- **Single, verified head SHA.** Detection and validation now both use the event-pinned `head.sha`; the fetched ref is verified to match it, and the job fails fast if the PR head moved after the trigger.
- **Bump actions.** `actions/checkout` v4 → v6 and `actions/github-script` v7 → v8 (runs on Node 24, clears the Node 20 deprecation warning).

No change to the validation logic or PR-gating behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency validation reliability by confirming that the pull request commit remains unchanged during validation.
  * Validation now stops when the pull request commit differs from the expected event data.

* **Chores**
  * Updated workflow tooling to improve repository checks and validation status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->