### PR TITLE
Purge expired SSO sessions in runtime-persistent cleanup

### DIFF
--- a/backend/dbscripts/runtime_persistent/postgres-cleanup.sql
+++ b/backend/dbscripts/runtime_persistent/postgres-cleanup.sql
@@ -78,5 +78,44 @@ BEGIN
         COMMIT;
         EXIT WHEN v_deleted = 0;
     END LOOP;
+
+    -- SSO sessions past their absolute deadline, together with their context and participant
+    -- children. A session is live only while now < IDLE_EXPIRES_AT AND now < ABSOLUTE_EXPIRES_AT, so
+    -- a row past ABSOLUTE_EXPIRES_AT can never resume and is safe to delete; idle-expired-but-absolute-
+    -- live rows are left for a later sweep (the resolver already rejects them). Sweeping by
+    -- ABSOLUTE_EXPIRES_AT (immutable and indexed) keeps this an index-backed scan over cold rows and
+    -- leaves the mutable IDLE_EXPIRES_AT unindexed so the hot activity touch stays HOT-eligible.
+    -- There is no FK cascade between the three SSO tables, so each batch deletes the children
+    -- explicitly using the same victim set as the parents; the victim set is located via
+    -- idx_sso_session_absolute_expires_at (ORDER BY drives the index scan) and all data-modifying
+    -- CTEs run against the statement-start snapshot, so delete order among them is irrelevant.
+    LOOP
+        WITH victims AS (
+            SELECT SESSION_ID, DEPLOYMENT_ID
+            FROM "SSO_SESSION"
+            WHERE ABSOLUTE_EXPIRES_AT <= v_now
+            ORDER BY ABSOLUTE_EXPIRES_AT
+            LIMIT p_batch_size
+        ),
+        del_ctx AS (
+            DELETE FROM "SSO_SESSION_CONTEXT" c
+            USING victims v
+            WHERE c.SESSION_ID = v.SESSION_ID AND c.DEPLOYMENT_ID = v.DEPLOYMENT_ID
+        ),
+        del_part AS (
+            DELETE FROM "SSO_SESSION_PARTICIPANT" p
+            USING victims v
+            WHERE p.SESSION_ID = v.SESSION_ID AND p.DEPLOYMENT_ID = v.DEPLOYMENT_ID
+        ),
+        del_sess AS (
+            DELETE FROM "SSO_SESSION" s
+            USING victims v
+            WHERE s.SESSION_ID = v.SESSION_ID AND s.DEPLOYMENT_ID = v.DEPLOYMENT_ID
+            RETURNING 1
+        )
+        SELECT COUNT(*) INTO v_deleted FROM del_sess;
+        COMMIT;
+        EXIT WHEN v_deleted = 0;
+    END LOOP;
 END;
 $$;


### PR DESCRIPTION
### Purpose
With SSO and logout now in place, expired SSO_SESSION rows and their SSO_SESSION_CONTEXT / SSO_SESSION_PARTICIPANT children accumulated without bound: logout hard-deletes a session, but sessions that simply expire (never explicitly logged out) were never removed. This PR extends the stored procedure to purge them.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
Extended cleanup_expired_runtime_persistent_data() in backend/dbscripts/runtime_persistent/postgres-cleanup.sql with a batched loop that deletes expired SSO_SESSION rows together with their context and participant children (one data-modifying CTE per batch), alongside the existing REVOKED_TOKEN loop.

Key design decisions, given this table is read and written on the hot session path:

- Sweep by ABSOLUTE_EXPIRES_AT. A session is live only while now < IDLE_EXPIRES_AT AND now < ABSOLUTE_EXPIRES_AT, so a row past its absolute deadline can never resume and is always safe to delete. That column is immutable after creation and already indexed (idx_sso_session_absolute_expires_at), so the sweep is an index-backed scan over cold rows the hot path never touches again. Idle-expired-but-absolute-live rows are left for a later sweep (the resolver already rejects them). The mutable IDLE_EXPIRES_AT is deliberately not used as the predicate, keeping the frequent activity-refresh UPDATE HOT-eligible.
- Explicit child deletes, no schema change. There is no FK cascade between the three SSO tables, so each batch deletes the context and participant children for the same victim set as the parents (a single CTE: locate victims via the absolute-expiry index, delete children USING that set, then delete the parents). This keeps the change confined to the cleanup procedure and adds no cost to the hot write path.
- Committed batches keep the lock footprint small so cleanup interleaves with live traffic.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3398

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of expired SSO session data by deleting records in batches rather than as one large operation.
  * Ensured related session information (session context and participants) is removed together with parent sessions.
  * Reduced database lock time by committing after each batch completes.
* **Chores**
  * Added configurable batch sizing for runtime persistent cleanup, defaulting to 1,000 when unset or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->