### PR TITLE
Drop unused idx_sso_session_subject_flow index

### DIFF
--- a/backend/dbscripts/runtime_persistent/postgres.sql
+++ b/backend/dbscripts/runtime_persistent/postgres.sql
@@ -62,9 +62,6 @@ CREATE UNIQUE INDEX idx_sso_session_handle_id ON "SSO_SESSION" (HANDLE_ID, DEPLO
 -- concurrent joins in a single flow execution converge on one session instead of duplicating it.
 CREATE UNIQUE INDEX idx_sso_session_flow_execution ON "SSO_SESSION" (FLOW_EXECUTION_ID, DEPLOYMENT_ID);
 
--- Index for subject + flow lookup on SSO_SESSION
-CREATE INDEX idx_sso_session_subject_flow ON "SSO_SESSION" (SUBJECT_ID, FLOW_ID, DEPLOYMENT_ID);
-
 -- Index for absolute expiry on SSO_SESSION (supports cleanup)
 CREATE INDEX idx_sso_session_absolute_expires_at ON "SSO_SESSION" (ABSOLUTE_EXPIRES_AT);
 

--- a/backend/dbscripts/runtime_persistent/sqlite.sql
+++ b/backend/dbscripts/runtime_persistent/sqlite.sql
@@ -62,9 +62,6 @@ CREATE UNIQUE INDEX idx_sso_session_handle_id ON "SSO_SESSION" (HANDLE_ID, DEPLO
 -- concurrent joins in a single flow execution converge on one session instead of duplicating it.
 CREATE UNIQUE INDEX idx_sso_session_flow_execution ON "SSO_SESSION" (FLOW_EXECUTION_ID, DEPLOYMENT_ID);
 
--- Index for subject + flow lookup on SSO_SESSION
-CREATE INDEX idx_sso_session_subject_flow ON "SSO_SESSION" (SUBJECT_ID, FLOW_ID, DEPLOYMENT_ID);
-
 -- Index for absolute expiry on SSO_SESSION (supports cleanup)
 CREATE INDEX idx_sso_session_absolute_expires_at ON "SSO_SESSION" (ABSOLUTE_EXPIRES_AT);
 


### PR DESCRIPTION
### Purpose
idx_sso_session_subject_flow, the (SUBJECT_ID, FLOW_ID, DEPLOYMENT_ID) index on SSO_SESSION, is not read by any query. SUBJECT_ID and FLOW_ID appear only in the INSERT column list and SELECT projections, never in a WHERE or ON CONFLICT clause. On a hot, write-heavy table the index only added write-maintenance and storage overhead, so this PR removes it.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
Removed the index (and its comment) from both backend/dbscripts/runtime_persistent/postgres.sql and backend/dbscripts/runtime_persistent/sqlite.sql.

Verified against the current query set (internal/flow/session/store_constants.go) that the remaining SSO_SESSION indexes are all query-backed and were kept:
- idx_sso_session_handle_id — GetByHandle (WHERE HANDLE_ID = ... AND DEPLOYMENT_ID = ...)
- idx_sso_session_flow_execution — GetByExecutionID and the idempotent-insert ON CONFLICT (FLOW_EXECUTION_ID, DEPLOYMENT_ID) target
- idx_sso_session_absolute_expires_at — the expiry sweep

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed a redundant session lookup index from PostgreSQL and SQLite database schemas.
  * Existing session data structures and other indexes remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->