### PR TITLE
Improve executor metadata handling

### DIFF
--- a/backend/internal/authn/consent/service.go
+++ b/backend/internal/authn/consent/service.go
@@ -70,7 +70,7 @@ func (s *consentEnforcerService) SetConsentService(consentService consent.Consen
 func (s *consentEnforcerService) ResolveConsent(ctx context.Context, ouID, appID, appName, userID string,
 	essentialAttributes, optionalAttributes, authorizedPermissions []string,
 	availableAttributes *providers.AttributesResponse, forceReprompt bool,
-	runtimeMetadata map[string]string) (
+	runtimeMetadata map[string][]string) (
 	*providers.ConsentPromptData, *tidcommon.ServiceError) {
 	logger := s.logger.With(log.String("appID", appID), log.MaskedString(log.LoggerKeyUserID, userID))
 	logger.Debug(ctx, "Resolving consent for user")
@@ -156,7 +156,7 @@ func (s *consentEnforcerService) ResolveConsent(ctx context.Context, ouID, appID
 // attribute denials, and then persists the consent record.
 func (s *consentEnforcerService) RecordConsent(ctx context.Context, ouID, appID, userID string,
 	decisions *providers.ConsentDecisions, sessionToken string,
-	validityPeriod int64, runtimeMetadata map[string]string) (*providers.Consent, *tidcommon.ServiceError) {
+	validityPeriod int64, runtimeMetadata map[string][]string) (*providers.Consent, *tidcommon.ServiceError) {
 	logger := s.logger.With(log.String("appID", appID), log.MaskedString(log.LoggerKeyUserID, userID))
 	logger.Debug(ctx, "Recording consent for user")
 

--- a/backend/internal/flow/core/executor_test.go
+++ b/backend/internal/flow/core/executor_test.go
@@ -667,188 +667,85 @@ func (s *ExecutorTestSuite) TestGetExecutionPolicy() {
 	s.Nil(exec.GetExecutionPolicy("custom"))
 }
 
-func (s *ExecutorTestSuite) TestBuildAuthnMetadata_WithAllFields() {
+func (s *ExecutorTestSuite) TestBuildProviderMetadata_Empty() {
+	ctx := &providers.NodeContext{}
+
+	metadata := BuildProviderMetadata(ctx)
+
+	s.NotNil(metadata)
+	s.Empty(metadata.RuntimeMetadata)
+}
+
+func (s *ExecutorTestSuite) TestBuildProviderMetadata_ProviderExtKeysIncluded() {
 	ctx := &providers.NodeContext{
-		Application: providers.Application{
-			Metadata: map[string]interface{}{
-				"tenant_id": "tenant-123",
-				"region":    "us-west",
-			},
-			InboundAuthConfig: []providers.InboundAuthConfigWithSecret{
-				{
-					Type: providers.OAuthInboundAuthType,
-					OAuthConfig: &providers.OAuthConfigWithSecret{
-						ClientID: "oauth-client-1",
-					},
-				},
-				{
-					Type: providers.OAuthInboundAuthType,
-					OAuthConfig: &providers.OAuthConfigWithSecret{
-						ClientID: "oauth-client-2",
-					},
-				},
-			},
+		RuntimeData: map[string]string{
+			"provider_ext_tenant": "tenant-123",
+			"provider_ext_hint":   "hint-value",
+			"other_key":           "should-be-excluded",
 		},
 	}
 
-	metadata := BuildAuthnMetadata(ctx)
+	metadata := BuildProviderMetadata(ctx)
 
-	s.NotNil(metadata)
-	s.NotNil(metadata.AppMetadata)
-	s.Equal("tenant-123", metadata.AppMetadata["tenant_id"])
-	s.Equal("us-west", metadata.AppMetadata["region"])
-
-	clientIDs, ok := metadata.AppMetadata["client_ids"].([]string)
-	s.True(ok)
-	s.Len(clientIDs, 2)
-	s.Contains(clientIDs, "oauth-client-1")
-	s.Contains(clientIDs, "oauth-client-2")
+	s.Equal([]string{"tenant-123"}, metadata.RuntimeMetadata["provider_ext_tenant"])
+	s.Equal([]string{"hint-value"}, metadata.RuntimeMetadata["provider_ext_hint"])
+	s.NotContains(metadata.RuntimeMetadata, "other_key")
 }
 
-func (s *ExecutorTestSuite) TestBuildAuthnMetadata_WithNoMetadata() {
-	ctx := &providers.NodeContext{
-		Application: providers.Application{},
-	}
-
-	metadata := BuildAuthnMetadata(ctx)
-
-	s.NotNil(metadata)
-	s.NotNil(metadata.AppMetadata)
-	s.Len(metadata.AppMetadata, 0)
-	s.NotNil(metadata.RuntimeMetadata)
-	s.Equal("", metadata.RuntimeMetadata["authorization_request_id"])
-	s.Equal("", metadata.RuntimeMetadata["current_client_id"])
-}
-
-func (s *ExecutorTestSuite) TestBuildAuthnMetadata_WithOnlyAppMetadata() {
-	ctx := &providers.NodeContext{
-		Application: providers.Application{
-			Metadata: map[string]interface{}{
-				"environment": "production",
-				"version":     "1.0.0",
-			},
+func (s *ExecutorTestSuite) TestBuildProviderMetadata_InitiatorRequestFlattened() {
+	ctx := &providers.NodeContext{}
+	ctx.SetInitiatorRequest(&providers.InitiatorRequest{
+		Headers: map[string][]string{
+			"X-Custom-Header": {"header-value"},
+			"Accept":          {"application/json", "text/html"},
 		},
-	}
+		QueryParams: map[string][]string{
+			"client_id":  {"my-client"},
+			"MyCustomQP": {"value"},
+		},
+	})
 
-	metadata := BuildAuthnMetadata(ctx)
+	metadata := BuildProviderMetadata(ctx)
 
-	s.NotNil(metadata)
-	s.Equal("production", metadata.AppMetadata["environment"])
-	s.Equal("1.0.0", metadata.AppMetadata["version"])
-	_, hasClientIDs := metadata.AppMetadata["client_ids"]
-	s.False(hasClientIDs)
+	// Header names are lowercased (HTTP headers are case-insensitive).
+	s.Equal([]string{"header-value"}, metadata.RuntimeMetadata["initiator_header_x-custom-header"])
+	s.Equal([]string{"application/json", "text/html"}, metadata.RuntimeMetadata["initiator_header_accept"])
+	// Query param names preserve original casing (query params are case-sensitive).
+	s.Equal([]string{"my-client"}, metadata.RuntimeMetadata["initiator_query_client_id"])
+	s.Equal([]string{"value"}, metadata.RuntimeMetadata["initiator_query_MyCustomQP"])
+	s.Nil(metadata.RuntimeMetadata["initiator_query_mycustomqp"])
 }
 
-func (s *ExecutorTestSuite) TestBuildAuthnMetadata_WithOnlyClientIDs() {
-	ctx := &providers.NodeContext{
-		Application: providers.Application{
-			InboundAuthConfig: []providers.InboundAuthConfigWithSecret{
-				{
-					Type: providers.OAuthInboundAuthType,
-					OAuthConfig: &providers.OAuthConfigWithSecret{
-						ClientID: "single-oauth-client",
-					},
-				},
-			},
+func (s *ExecutorTestSuite) TestBuildProviderMetadata_HeaderCasingCollisionMerges() {
+	ctx := &providers.NodeContext{}
+	ctx.SetInitiatorRequest(&providers.InitiatorRequest{
+		Headers: map[string][]string{
+			"X-Custom": {"a"},
+			"x-custom": {"b"},
 		},
-	}
+	})
 
-	metadata := BuildAuthnMetadata(ctx)
+	metadata := BuildProviderMetadata(ctx)
 
-	s.NotNil(metadata)
-	clientIDs, ok := metadata.AppMetadata["client_ids"].([]string)
-	s.True(ok)
-	s.Len(clientIDs, 1)
-	s.Equal("single-oauth-client", clientIDs[0])
+	// Both header variants normalize to the same lowercase key, so values must be merged
+	// rather than one silently overwriting the other. Order is nondeterministic due to
+	// Go map iteration, so assert on set membership.
+	merged := metadata.RuntimeMetadata["initiator_header_x-custom"]
+	s.ElementsMatch([]string{"a", "b"}, merged)
 }
 
-func (s *ExecutorTestSuite) TestBuildAuthnMetadata_WithNilOAuthConfig() {
+func (s *ExecutorTestSuite) TestBuildProviderMetadata_NilInitiatorRequest() {
 	ctx := &providers.NodeContext{
-		Application: providers.Application{
-			InboundAuthConfig: []providers.InboundAuthConfigWithSecret{
-				{
-					Type:        providers.OAuthInboundAuthType,
-					OAuthConfig: nil,
-				},
-			},
-		},
+		RuntimeData: map[string]string{"provider_ext_k": "v"},
 	}
 
-	metadata := BuildAuthnMetadata(ctx)
+	metadata := BuildProviderMetadata(ctx)
 
-	s.NotNil(metadata)
-	_, hasClientIDs := metadata.AppMetadata["client_ids"]
-	s.False(hasClientIDs)
-}
-
-func (s *ExecutorTestSuite) TestBuildAuthnMetadata_WithEmptyClientID() {
-	ctx := &providers.NodeContext{
-		Application: providers.Application{
-			InboundAuthConfig: []providers.InboundAuthConfigWithSecret{
-				{
-					Type: providers.OAuthInboundAuthType,
-					OAuthConfig: &providers.OAuthConfigWithSecret{
-						ClientID: "",
-					},
-				},
-			},
-		},
-	}
-
-	metadata := BuildAuthnMetadata(ctx)
-
-	s.NotNil(metadata)
-	_, hasClientIDs := metadata.AppMetadata["client_ids"]
-	s.False(hasClientIDs)
-}
-
-func (s *ExecutorTestSuite) TestBuildAuthnMetadata_WithMixedInboundConfigs() {
-	ctx := &providers.NodeContext{
-		Application: providers.Application{
-			InboundAuthConfig: []providers.InboundAuthConfigWithSecret{
-				{
-					Type: providers.OAuthInboundAuthType,
-					OAuthConfig: &providers.OAuthConfigWithSecret{
-						ClientID: "valid-client",
-					},
-				},
-				{
-					Type:        providers.OAuthInboundAuthType,
-					OAuthConfig: nil,
-				},
-				{
-					Type: providers.OAuthInboundAuthType,
-					OAuthConfig: &providers.OAuthConfigWithSecret{
-						ClientID: "",
-					},
-				},
-				{
-					Type: providers.OAuthInboundAuthType,
-					OAuthConfig: &providers.OAuthConfigWithSecret{
-						ClientID: "another-valid-client",
-					},
-				},
-			},
-		},
-	}
-
-	metadata := BuildAuthnMetadata(ctx)
-
-	s.NotNil(metadata)
-	clientIDs, ok := metadata.AppMetadata["client_ids"].([]string)
-	s.True(ok)
-	s.Len(clientIDs, 2)
-	s.Contains(clientIDs, "valid-client")
-	s.Contains(clientIDs, "another-valid-client")
+	s.Equal([]string{"v"}, metadata.RuntimeMetadata["provider_ext_k"])
 }
 
 func (s *ExecutorTestSuite) TestBuildGetAttributesMetadata_WithLocale() {
 	ctx := &providers.NodeContext{
-		Application: providers.Application{
-			Metadata: map[string]interface{}{
-				"tenant_id": "tenant-123",
-			},
-		},
 		RuntimeData: map[string]string{
 			"required_locales": "en-US",
 		},
@@ -858,12 +755,10 @@ func (s *ExecutorTestSuite) TestBuildGetAttributesMetadata_WithLocale() {
 
 	s.NotNil(metadata)
 	s.Equal("en-US", metadata.Locale)
-	s.Equal("tenant-123", metadata.AppMetadata["tenant_id"])
 }
 
 func (s *ExecutorTestSuite) TestBuildGetAttributesMetadata_WithoutLocale() {
 	ctx := &providers.NodeContext{
-		Application: providers.Application{},
 		RuntimeData: map[string]string{},
 	}
 
@@ -871,57 +766,28 @@ func (s *ExecutorTestSuite) TestBuildGetAttributesMetadata_WithoutLocale() {
 
 	s.NotNil(metadata)
 	s.Empty(metadata.Locale)
-	s.NotNil(metadata.AppMetadata)
-	s.Len(metadata.AppMetadata, 0)
-	s.NotNil(metadata.RuntimeMetadata)
-	s.Equal("", metadata.RuntimeMetadata["authorization_request_id"])
-	s.Equal("", metadata.RuntimeMetadata["current_client_id"])
+	s.Empty(metadata.RuntimeMetadata)
 }
 
-func (s *ExecutorTestSuite) TestBuildAuthnMetadata_WithRuntimeMetadata() {
+func (s *ExecutorTestSuite) TestBuildGetAttributesMetadata_ProviderExtAndInitiator() {
 	ctx := &providers.NodeContext{
-		Application: providers.Application{},
 		RuntimeData: map[string]string{
-			common.RuntimeKeyAuthorizationRequestID: "auth-req-123",
-			common.RuntimeKeyClientID:               "oauth-client-abc",
-			"ext_customKey":                         "custom-value",
-			"non_ext_key":                           "should-be-excluded",
+			"provider_ext_hint": "hint-value",
+			"required_locales":  "en-GB",
+			"ignored":           "yes",
 		},
 	}
-
-	metadata := BuildAuthnMetadata(ctx)
-
-	s.NotContains(metadata.AppMetadata, "current_client_id")
-	s.Equal("oauth-client-abc", metadata.RuntimeMetadata["current_client_id"])
-	s.Equal("auth-req-123", metadata.RuntimeMetadata["authorization_request_id"])
-	s.Equal("custom-value", metadata.RuntimeMetadata["ext_customKey"])
-	s.NotContains(metadata.RuntimeMetadata, "non_ext_key")
-}
-
-func (s *ExecutorTestSuite) TestBuildGetAttributesMetadata_WithRuntimeMetadata() {
-	ctx := &providers.NodeContext{
-		Application: providers.Application{
-			Metadata: map[string]interface{}{
-				"tenant_id": "tenant-123",
-			},
+	ctx.SetInitiatorRequest(&providers.InitiatorRequest{
+		QueryParams: map[string][]string{
+			"scope": {"openid"},
 		},
-		RuntimeData: map[string]string{
-			common.RuntimeKeyAuthorizationRequestID: "auth-req-456",
-			common.RuntimeKeyClientID:               "oauth-client-xyz",
-			"ext_tenantHint":                        "hint-value",
-			"required_locales":                      "en-GB",
-			"internal_key":                          "ignored",
-		},
-	}
+	})
 
 	metadata := BuildGetAttributesMetadata(ctx)
 
 	s.Equal("en-GB", metadata.Locale)
-	s.Equal("tenant-123", metadata.AppMetadata["tenant_id"])
-	s.NotContains(metadata.AppMetadata, "current_client_id")
-	s.Equal("oauth-client-xyz", metadata.RuntimeMetadata["current_client_id"])
-	s.Equal("auth-req-456", metadata.RuntimeMetadata["authorization_request_id"])
-	s.Equal("hint-value", metadata.RuntimeMetadata["ext_tenantHint"])
-	s.NotContains(metadata.RuntimeMetadata, "internal_key")
+	s.Equal([]string{"hint-value"}, metadata.RuntimeMetadata["provider_ext_hint"])
+	s.Equal([]string{"openid"}, metadata.RuntimeMetadata["initiator_query_scope"])
+	s.NotContains(metadata.RuntimeMetadata, "ignored")
 	s.NotContains(metadata.RuntimeMetadata, "required_locales")
 }

--- a/backend/internal/flow/core/utils.go
+++ b/backend/internal/flow/core/utils.go
@@ -198,64 +198,19 @@ func MergePresentedOptionalInputIdentifiers(raw string, identifiers []string) st
 	return strings.Join(parts, " ")
 }
 
-// buildAppMetadataFromContext constructs application metadata from the node context,
-// including application metadata and OAuth client IDs.
-func buildAppMetadataFromContext(ctx *providers.NodeContext) map[string]interface{} {
-	appMetadata := make(map[string]interface{})
-
-	if ctx.Application.Metadata != nil {
-		for key, value := range ctx.Application.Metadata {
-			appMetadata[key] = value
-		}
-	}
-
-	var clientIDs []string
-	for _, inboundConfig := range ctx.Application.InboundAuthConfig {
-		if inboundConfig.OAuthConfig != nil && inboundConfig.OAuthConfig.ClientID != "" {
-			clientIDs = append(clientIDs, inboundConfig.OAuthConfig.ClientID)
-		}
-	}
-
-	if len(clientIDs) > 0 {
-		appMetadata[providers.MetadataKeyClientIDs] = clientIDs
-	}
-
-	return appMetadata
-}
-
-// BuildRuntimeMetadata constructs the runtime metadata for authentication.
-func BuildRuntimeMetadata(ctx *providers.NodeContext) map[string]string {
-	runtimeMetadata := map[string]string{
-		providers.MetadataKeyAuthorizationRequestID: ctx.RuntimeData[common.RuntimeKeyAuthorizationRequestID],
-		providers.MetadataKeyCurrentClientID:        ctx.RuntimeData[common.RuntimeKeyClientID],
-		providers.MetadataKeyEssentialAttributes:    ctx.RuntimeData[common.RuntimeKeyRequiredEssentialAttributes],
-		providers.MetadataKeyOptionalAttributes:     ctx.RuntimeData[common.RuntimeKeyRequiredOptionalAttributes],
-	}
-
-	if ctx.RuntimeData != nil {
-		for key, value := range ctx.RuntimeData {
-			// Only the ext_* runtime data keys are passed to the authn provider.
-			if strings.HasPrefix(key, "ext_") {
-				runtimeMetadata[key] = value
-			}
-		}
-	}
-	return runtimeMetadata
-}
-
-// BuildAuthnMetadata constructs the metadata for authentication.
-func BuildAuthnMetadata(ctx *providers.NodeContext) *providers.AuthnMetadata {
+// BuildProviderMetadata constructs the metadata for providers. It includes
+// provider_ext_* runtime keys and the initiator request data (headers and query params).
+func BuildProviderMetadata(ctx *providers.NodeContext) *providers.AuthnMetadata {
 	return &providers.AuthnMetadata{
-		AppMetadata:     buildAppMetadataFromContext(ctx),
-		RuntimeMetadata: BuildRuntimeMetadata(ctx),
+		RuntimeMetadata: buildRuntimeMetadata(ctx),
 	}
 }
 
-// BuildGetAttributesMetadata constructs the metadata for fetching user attributes.
+// BuildGetAttributesMetadata constructs the metadata for fetching user attributes. It includes
+// provider_ext_* runtime keys and the initiator request data (headers and query params).
 func BuildGetAttributesMetadata(ctx *providers.NodeContext) *providers.GetAttributesMetadata {
 	metadata := &providers.GetAttributesMetadata{
-		AppMetadata:     buildAppMetadataFromContext(ctx),
-		RuntimeMetadata: BuildRuntimeMetadata(ctx),
+		RuntimeMetadata: buildRuntimeMetadata(ctx),
 	}
 
 	if locale, exists := ctx.RuntimeData[common.RuntimeKeyRequiredLocales]; exists && locale != "" {
@@ -263,4 +218,34 @@ func BuildGetAttributesMetadata(ctx *providers.NodeContext) *providers.GetAttrib
 	}
 
 	return metadata
+}
+
+// buildRuntimeMetadata collects provider_ext_* runtime keys and flattens initiator request
+// headers/query params into the metadata map.
+func buildRuntimeMetadata(ctx *providers.NodeContext) map[string][]string {
+	runtimeMetadata := make(map[string][]string)
+
+	if ctx.RuntimeData != nil {
+		for key, value := range ctx.RuntimeData {
+			if strings.HasPrefix(key, "provider_ext_") {
+				runtimeMetadata[key] = []string{value}
+			}
+		}
+	}
+
+	if req := ctx.GetInitiatorRequest(); req != nil {
+		// Header names are case-insensitive per RFC 7230, so lowercase the key to give consumers
+		// a stable form. Since distinct-casing entries (e.g. "Foo" and "foo") normalize to the
+		// same key, merge the value slices instead of overwriting so nothing is silently dropped.
+		for name, values := range req.Headers {
+			key := "initiator_header_" + strings.ToLower(name)
+			runtimeMetadata[key] = append(runtimeMetadata[key], values...)
+		}
+		// Query parameter names are case-sensitive; preserve original casing verbatim.
+		for name, values := range req.QueryParams {
+			runtimeMetadata["initiator_query_"+name] = values
+		}
+	}
+
+	return runtimeMetadata
 }

--- a/backend/internal/flow/executor/consent_executor.go
+++ b/backend/internal/flow/executor/consent_executor.go
@@ -160,7 +160,7 @@ func (e *consentExecutor) checkConsent(ctx *providers.NodeContext, execResp *pro
 	promptData, svcErr := e.consentEnforcer.ResolveConsent(
 		ctx.Context, ouID, appID, appName, entityRef.EntityID,
 		essentialAttributes, optionalAttributes, authorizedPermissions,
-		availableAttributes, forceReprompt, core.BuildRuntimeMetadata(ctx))
+		availableAttributes, forceReprompt, core.BuildProviderMetadata(ctx).RuntimeMetadata)
 	if svcErr != nil {
 		if svcErr.Type == tidcommon.ClientErrorType {
 			logger.Debug(ctx.Context, "Client error while resolving user consent", log.Any("error", svcErr))
@@ -264,7 +264,7 @@ func (e *consentExecutor) handleConsentDecisions(ctx *providers.NodeContext, exe
 	// Always record consent decisions (including denials) for audit/compliance purposes.
 	// The session token is used to verify completeness and enforce essential attribute rules
 	consentRecord, svcErr := e.consentEnforcer.RecordConsent(ctx.Context, ouID, appID, userID,
-		&decisions, sessionToken, validityPeriod, core.BuildRuntimeMetadata(ctx))
+		&decisions, sessionToken, validityPeriod, core.BuildProviderMetadata(ctx).RuntimeMetadata)
 	if svcErr != nil {
 		// Essential consent denied: the consent record was persisted but the user denied
 		// a required attribute, so the flow cannot proceed

--- a/backend/internal/flow/executor/credentials_auth_executor.go
+++ b/backend/internal/flow/executor/credentials_auth_executor.go
@@ -203,7 +203,7 @@ func (b *credentialsAuthExecutor) authenticateUser(ctx *providers.NodeContext,
 	}
 
 	// For authentication flows, call Authenticate directly.
-	metadata := core.BuildAuthnMetadata(ctx)
+	metadata := core.BuildProviderMetadata(ctx)
 	authUser, authenticatedClaims, svcErr := b.authnProvider.AuthenticateUser(ctx.Context, userIdentifiers,
 		userCredentials, nil, metadata, execResp.AuthUser)
 	execResp.AuthUser = authUser

--- a/backend/internal/flow/executor/federated_auth_resolver_executor.go
+++ b/backend/internal/flow/executor/federated_auth_resolver_executor.go
@@ -166,7 +166,7 @@ func (f *federatedAuthResolverExecutor) Execute(ctx *providers.NodeContext) (*pr
 	credentials := map[string]interface{}{
 		userAttributeSub: sub,
 	}
-	metadata := core.BuildAuthnMetadata(ctx)
+	metadata := core.BuildProviderMetadata(ctx)
 	authUser, _, err := f.authnProvider.AuthenticateUser(
 		ctx.Context, identifiers, credentials, nil, metadata, execResp.AuthUser)
 	execResp.AuthUser = authUser

--- a/backend/internal/flow/executor/oauth_executor.go
+++ b/backend/internal/flow/executor/oauth_executor.go
@@ -254,7 +254,7 @@ func (o *oAuthExecutor) ProcessAuthFlowResponse(ctx *providers.NodeContext,
 		},
 	}
 
-	metadata := core.BuildAuthnMetadata(ctx)
+	metadata := core.BuildProviderMetadata(ctx)
 	authUser, federatedAttributes, svcErr := o.authnProvider.AuthenticateUser(
 		ctx.Context, nil, credentials, nil, metadata, execResp.AuthUser)
 	if svcErr != nil {

--- a/backend/internal/flow/flowexec/engine.go
+++ b/backend/internal/flow/flowexec/engine.go
@@ -195,6 +195,7 @@ func (fe *flowEngine) executeNodePackage(ctx *EngineContext,
 		AuthUser:         ctx.AuthUser,
 		ExecutionHistory: ctx.ExecutionHistory,
 	}
+	nodeCtx.SetInitiatorRequest(ctx.GetInitiatorRequest())
 	if nodeCtx.NodeInputs == nil {
 		nodeCtx.NodeInputs = make([]providers.Input, 0)
 	}

--- a/backend/internal/flow/flowexec/model.go
+++ b/backend/internal/flow/flowexec/model.go
@@ -54,7 +54,8 @@ type frame struct {
 // TODO: fields on EngineContext are currently exposed directly. Convert to unexported
 // fields accessed via getters and setters so that mutation can be encapsulated.
 type EngineContext struct {
-	Context context.Context
+	Context          context.Context
+	initiatorRequest *providers.InitiatorRequest
 
 	ExecutionID    string
 	FlowType       providers.FlowType
@@ -100,6 +101,16 @@ type EngineContext struct {
 	// that flow rather than the running sign-out flow. Empty for all other flows. Transient — re-derived
 	// from the application on each context load, never persisted.
 	SessionFlowID string
+}
+
+// GetInitiatorRequest returns the original HTTP request that triggered the flow.
+func (ec *EngineContext) GetInitiatorRequest() *providers.InitiatorRequest {
+	return ec.initiatorRequest
+}
+
+// SetInitiatorRequest sets the original HTTP request that triggered the flow.
+func (ec *EngineContext) SetInitiatorRequest(req *providers.InitiatorRequest) {
+	ec.initiatorRequest = req
 }
 
 // mergeRuntimeData merges the given data into RuntimeData.
@@ -275,11 +286,12 @@ type FlowRequest struct {
 
 // FlowInitContext represents the context for initiating a new flow with runtime data
 type FlowInitContext struct {
-	ApplicationID string
-	FlowType      string
-	RuntimeData   map[string]string
-	InitialInputs map[string]string
-	ExpirySeconds int64
+	ApplicationID    string
+	FlowType         string
+	RuntimeData      map[string]string
+	InitialInputs    map[string]string
+	ExpirySeconds    int64
+	InitiatorRequest *providers.InitiatorRequest
 }
 
 // FlowContextDB represents the database row for a flow context.
@@ -323,6 +335,7 @@ type flowContextContent struct {
 	InterceptorSharedData *string `json:"interceptorSharedData,omitempty"`
 	FrameStack            *string `json:"frameStack,omitempty"`
 	SharedRuntimeData     *string `json:"sharedRuntimeData,omitempty"`
+	InitiatorRequest      *string `json:"initiatorRequest,omitempty"`
 }
 
 // graphResolverFunc resolves a flow graph by its flow ID. Used during context deserialization to
@@ -470,7 +483,17 @@ func (f *FlowContextDB) ToEngineContext(ctx context.Context,
 		}
 	}
 
-	return EngineContext{
+	// Parse initiator request if present
+	var initiatorRequest *providers.InitiatorRequest
+	if content.InitiatorRequest != nil {
+		var req providers.InitiatorRequest
+		if err := json.Unmarshal([]byte(*content.InitiatorRequest), &req); err != nil {
+			return EngineContext{}, err
+		}
+		initiatorRequest = &req
+	}
+
+	engineCtx := EngineContext{
 		Context:               ctx,
 		ExecutionID:           f.ExecutionID,
 		TraceID:               "", // TraceID is transient and set from request context
@@ -489,7 +512,10 @@ func (f *FlowContextDB) ToEngineContext(ctx context.Context,
 		InterceptorSharedData: interceptorSharedData,
 		frameStack:            frameStack,
 		sharedRuntimeData:     sharedRuntimeData,
-	}, nil
+	}
+	engineCtx.SetInitiatorRequest(initiatorRequest)
+
+	return engineCtx, nil
 }
 
 // FromEngineContext converts an EngineContext to the database model for persistence.
@@ -616,6 +642,17 @@ func (f *FlowContextDB) FromEngineContext(ctx EngineContext) error {
 		sharedRuntimeDataStr = &s
 	}
 
+	// Serialize initiator request if present
+	var initiatorRequestStr *string
+	if ctx.initiatorRequest != nil {
+		initiatorRequestJSON, err := json.Marshal(ctx.initiatorRequest)
+		if err != nil {
+			return err
+		}
+		s := string(initiatorRequestJSON)
+		initiatorRequestStr = &s
+	}
+
 	content := flowContextContent{
 		AppID:                 ctx.AppID,
 		Verbose:               ctx.Verbose,
@@ -637,6 +674,7 @@ func (f *FlowContextDB) FromEngineContext(ctx EngineContext) error {
 		InterceptorSharedData: &interceptorSharedData,
 		FrameStack:            frameStackStr,
 		SharedRuntimeData:     sharedRuntimeDataStr,
+		InitiatorRequest:      initiatorRequestStr,
 	}
 
 	contextJSON, err := json.Marshal(content)

--- a/backend/internal/flow/flowexec/model_test.go
+++ b/backend/internal/flow/flowexec/model_test.go
@@ -1175,6 +1175,67 @@ func (s *ModelTestSuite) TestToEngineContext_WithFrameStack_NilResolver_Empty() 
 	s.Equal(0, resultCtx.frameDepth())
 }
 
+// --- InitiatorRequest round-trip ---
+
+func (s *ModelTestSuite) TestInitiatorRequest_RoundTrip() {
+	mockGraph := coremock.NewGraphInterfaceMock(s.T())
+	mockGraph.On("GetID").Return("graph-init-req")
+	mockGraph.On("GetType").Return(providers.FlowTypeAuthentication)
+
+	ctx := EngineContext{
+		Context:          context.Background(),
+		ExecutionID:      "exec-init-req",
+		FlowType:         providers.FlowTypeAuthentication,
+		AppID:            "app-id",
+		Graph:            mockGraph,
+		UserInputs:       map[string]string{},
+		RuntimeData:      map[string]string{},
+		ExecutionHistory: map[string]*providers.NodeExecutionRecord{},
+	}
+	ctx.SetInitiatorRequest(&providers.InitiatorRequest{
+		Headers:     map[string][]string{"X-Request-Id": {"req-123"}, "Content-Type": {"application/json"}},
+		QueryParams: map[string][]string{"client_id": {"my-client"}, "scope": {"openid"}},
+	})
+
+	dbModel := &FlowContextDB{}
+	s.NoError(dbModel.FromEngineContext(ctx))
+
+	restored, err := dbModel.ToEngineContext(context.Background(), mockGraph, nil)
+	s.NoError(err)
+
+	req := restored.GetInitiatorRequest()
+	s.Require().NotNil(req)
+	s.Equal([]string{"req-123"}, req.Headers["X-Request-Id"])
+	s.Equal([]string{"application/json"}, req.Headers["Content-Type"])
+	s.Equal([]string{"my-client"}, req.QueryParams["client_id"])
+	s.Equal([]string{"openid"}, req.QueryParams["scope"])
+}
+
+func (s *ModelTestSuite) TestInitiatorRequest_NilRoundTrip() {
+	mockGraph := coremock.NewGraphInterfaceMock(s.T())
+	mockGraph.On("GetID").Return("graph-nil-init")
+	mockGraph.On("GetType").Return(providers.FlowTypeAuthentication)
+
+	ctx := EngineContext{
+		Context:          context.Background(),
+		ExecutionID:      "exec-nil-init",
+		FlowType:         providers.FlowTypeAuthentication,
+		AppID:            "app-id",
+		Graph:            mockGraph,
+		UserInputs:       map[string]string{},
+		RuntimeData:      map[string]string{},
+		ExecutionHistory: map[string]*providers.NodeExecutionRecord{},
+	}
+	// initiatorRequest is nil by default
+
+	dbModel := &FlowContextDB{}
+	s.NoError(dbModel.FromEngineContext(ctx))
+
+	restored, err := dbModel.ToEngineContext(context.Background(), mockGraph, nil)
+	s.NoError(err)
+	s.Nil(restored.GetInitiatorRequest())
+}
+
 // --- serializeFrameStack ---
 
 func (s *ModelTestSuite) TestSerializeFrameStack_EmptyStack() {

--- a/backend/internal/flow/flowexec/service.go
+++ b/backend/internal/flow/flowexec/service.go
@@ -810,6 +810,7 @@ func (s *flowExecService) InitiateFlow(ctx context.Context,
 
 	// Replace the RuntimeData with initContext RuntimeData
 	engineCtx.RuntimeData = initContext.RuntimeData
+	engineCtx.SetInitiatorRequest(initContext.InitiatorRequest)
 
 	// Store the context without executing the flow
 	if storeErr := s.storeContext(ctx, engineCtx, 0, logger); storeErr != nil {
@@ -859,6 +860,7 @@ func (s *flowExecService) InitiateAndExecute(ctx context.Context,
 	}
 
 	engineCtx.RuntimeData = initContext.RuntimeData
+	engineCtx.SetInitiatorRequest(initContext.InitiatorRequest)
 	prepareContext(engineCtx, "", initContext.InitialInputs)
 
 	flowStep, flowErr := s.flowEngine.Execute(engineCtx)

--- a/backend/internal/oauth/oauth2/authz/handler.go
+++ b/backend/internal/oauth/oauth2/authz/handler.go
@@ -29,7 +29,7 @@ import (
 	oauth2const "github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	oauth2utils "github.com/thunder-id/thunderid/internal/oauth/oauth2/utils"
 	"github.com/thunder-id/thunderid/internal/system/log"
-	"github.com/thunder-id/thunderid/internal/system/utils"
+	sysutils "github.com/thunder-id/thunderid/internal/system/utils"
 )
 
 // AuthorizeHandlerInterface defines the interface for handling OAuth2 authorization requests.
@@ -119,7 +119,7 @@ func (ah *authorizeHandler) HandleAuthCallbackPostRequest(w http.ResponseWriter,
 		//  Verify whether we need separate session data key for consent flow.
 		//  Alternatively could add consent info also to the same session object.
 	default:
-		utils.WriteJSONError(ctx, w, oauth2const.ErrorInvalidRequest, "Invalid authorization request",
+		sysutils.WriteJSONError(ctx, w, oauth2const.ErrorInvalidRequest, "Invalid authorization request",
 			http.StatusBadRequest, nil)
 	}
 }
@@ -148,7 +148,7 @@ func (ah *authorizeHandler) getOAuthMessage(r *http.Request, w http.ResponseWrit
 
 	if err != nil {
 		ah.logger.Debug(r.Context(), "Invalid authorize request", log.Error(err))
-		utils.WriteJSONError(r.Context(), w, oauth2const.ErrorInvalidRequest, "Invalid authorization request",
+		sysutils.WriteJSONError(r.Context(), w, oauth2const.ErrorInvalidRequest, "Invalid authorization request",
 			http.StatusBadRequest, nil)
 	}
 
@@ -163,33 +163,29 @@ func (ah *authorizeHandler) getOAuthMessageForGetRequest(r *http.Request) (*OAut
 		return nil, fmt.Errorf("failed to parse form data: %w", err)
 	}
 
-	queryParams := make(map[string]string)
+	queryParams := r.URL.Query()
 	var resources []string
-	for key, values := range r.URL.Query() {
-		if len(values) == 0 {
-			continue
-		}
+	for key, values := range queryParams {
 		if key == oauth2const.RequestParamResource {
 			resources = values
-			queryParams[key] = values[0]
 			continue
 		}
 		if len(values) > 1 {
 			return nil, fmt.Errorf("query parameter %q must not be repeated", key)
 		}
-		queryParams[key] = values[0]
 	}
 
 	return &OAuthMessage{
 		RequestType:        oauth2const.TypeInitialAuthorizationRequest,
-		RequestQueryParams: queryParams,
 		Resources:          resources,
+		RequestHeaders:     sysutils.SanitizeRawMultiValueStringMap(r.Header),
+		RequestQueryParams: sysutils.SanitizeRawMultiValueStringMap(queryParams),
 	}, nil
 }
 
 // getOAuthMessageForPostRequest extracts the OAuth message from an authorization POST request.
 func (ah *authorizeHandler) getOAuthMessageForPostRequest(r *http.Request) (*OAuthMessage, error) {
-	authZReq, err := utils.DecodeJSONBody[AuthZPostRequest](r)
+	authZReq, err := sysutils.DecodeJSONBody[AuthZPostRequest](r)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode JSON body: %w", err)
 	}
@@ -289,7 +285,7 @@ func (ah *authorizeHandler) writeAuthZResponse(ctx context.Context, w http.Respo
 	authZResp := AuthZPostResponse{
 		RedirectURI: redirectURI,
 	}
-	utils.WriteSuccessResponse(ctx, w, http.StatusOK, authZResp)
+	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, authZResp)
 }
 
 // writeAuthZResponseToErrorPage writes the authorization response redirecting to the error page.

--- a/backend/internal/oauth/oauth2/authz/handler_test.go
+++ b/backend/internal/oauth/oauth2/authz/handler_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -108,8 +109,8 @@ func (suite *AuthorizeHandlerTestSuite) TestGetOAuthMessageForGetRequest_Success
 	assert.NotNil(suite.T(), msg)
 	if msg != nil {
 		assert.Equal(suite.T(), oauth2const.TypeInitialAuthorizationRequest, msg.RequestType)
-		assert.Equal(suite.T(), "test-client", msg.RequestQueryParams["client_id"])
-		assert.Equal(suite.T(), "https://example.com", msg.RequestQueryParams["redirect_uri"])
+		assert.Equal(suite.T(), "test-client", url.Values(msg.RequestQueryParams).Get("client_id"))
+		assert.Equal(suite.T(), "https://example.com", url.Values(msg.RequestQueryParams).Get("redirect_uri"))
 		assert.Empty(suite.T(), msg.AuthID)
 	}
 }
@@ -133,8 +134,8 @@ func (suite *AuthorizeHandlerTestSuite) TestGetOAuthMessageForGetRequest_WithCla
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), msg)
 	if msg != nil {
-		assert.Equal(suite.T(), "test-client", msg.RequestQueryParams["client_id"])
-		assert.Equal(suite.T(), "en-US fr-CA ja", msg.RequestQueryParams["claims_locales"])
+		assert.Equal(suite.T(), "test-client", url.Values(msg.RequestQueryParams).Get("client_id"))
+		assert.Equal(suite.T(), "en-US fr-CA ja", url.Values(msg.RequestQueryParams).Get("claims_locales"))
 	}
 }
 
@@ -165,7 +166,7 @@ func (suite *AuthorizeHandlerTestSuite) TestGetOAuthMessageForGetRequest_Multipl
 		assert.Equal(suite.T(), 2, len(msg.Resources))
 		assert.Contains(suite.T(), msg.Resources, "https://rs1.example.com")
 		assert.Contains(suite.T(), msg.Resources, "https://rs2.example.com")
-		assert.Equal(suite.T(), "test-client", msg.RequestQueryParams["client_id"])
+		assert.Equal(suite.T(), "test-client", url.Values(msg.RequestQueryParams).Get("client_id"))
 	}
 }
 

--- a/backend/internal/oauth/oauth2/authz/model.go
+++ b/backend/internal/oauth/oauth2/authz/model.go
@@ -28,8 +28,9 @@ import (
 type OAuthMessage struct {
 	RequestType        string
 	AuthID             string
-	RequestQueryParams map[string]string
 	Resources          []string
+	RequestHeaders     map[string][]string
+	RequestQueryParams map[string][]string
 	RequestBodyParams  map[string]string
 }
 

--- a/backend/internal/oauth/oauth2/authz/requestvalidator/validator.go
+++ b/backend/internal/oauth/oauth2/authz/requestvalidator/validator.go
@@ -21,6 +21,7 @@
 package requestvalidator
 
 import (
+	"net/url"
 	"slices"
 	"strings"
 
@@ -46,15 +47,15 @@ import (
 //
 // Returns (errorCode, errorDescription). Empty errorCode means validation passed.
 func ValidateAuthorizationRequestParams(
-	params map[string]string, oauthApp *providers.OAuthClient, dpopHeaderJkt string,
+	rawParams map[string][]string, oauthApp *providers.OAuthClient, dpopHeaderJkt string,
 ) (string, string) {
-	responseType := params[constants.RequestParamResponseType]
-	responseMode := params[constants.RequestParamResponseMode]
+	params := url.Values(rawParams)
+	responseType := params.Get(constants.RequestParamResponseType)
+	responseMode := params.Get(constants.RequestParamResponseMode)
 
 	// Validate the prompt parameter if present.
-	prompt, promptExists := params[constants.RequestParamPrompt]
-	if promptExists {
-		if errCode, errMsg := ValidatePromptParameter(prompt); errCode != "" {
+	if params.Has(constants.RequestParamPrompt) {
+		if errCode, errMsg := ValidatePromptParameter(params.Get(constants.RequestParamPrompt)); errCode != "" {
 			return errCode, errMsg
 		}
 	}
@@ -78,8 +79,8 @@ func ValidateAuthorizationRequestParams(
 
 	// Validate PKCE parameters.
 	if responseType == string(providers.ResponseTypeCode) {
-		codeChallenge := params[constants.RequestParamCodeChallenge]
-		codeChallengeMethod := params[constants.RequestParamCodeChallengeMethod]
+		codeChallenge := params.Get(constants.RequestParamCodeChallenge)
+		codeChallengeMethod := params.Get(constants.RequestParamCodeChallengeMethod)
 
 		if oauthApp.RequiresPKCE() && codeChallenge == "" {
 			return constants.ErrorInvalidRequest, "code_challenge is required for this application"
@@ -94,12 +95,12 @@ func ValidateAuthorizationRequestParams(
 	}
 
 	// Validate nonce length.
-	nonce := params[constants.RequestParamNonce]
+	nonce := params.Get(constants.RequestParamNonce)
 	if nonce != "" && len(nonce) > constants.MaxNonceLength {
 		return constants.ErrorInvalidRequest, "nonce exceeds maximum allowed length"
 	}
 
-	if dpopJktParam := params[constants.RequestParamDPoPJkt]; dpopJktParam != "" {
+	if dpopJktParam := params.Get(constants.RequestParamDPoPJkt); dpopJktParam != "" {
 		if !jws.IsValidJKT(dpopJktParam) {
 			return constants.ErrorInvalidRequest, "Invalid dpop_jkt parameter"
 		}

--- a/backend/internal/oauth/oauth2/authz/requestvalidator/validator_test.go
+++ b/backend/internal/oauth/oauth2/authz/requestvalidator/validator_test.go
@@ -19,6 +19,7 @@
 package requestvalidator
 
 import (
+	"net/url"
 	"strings"
 	"testing"
 
@@ -53,9 +54,9 @@ func (suite *AuthzValidationTestSuite) SetupTest() {
 	}
 }
 
-func (suite *AuthzValidationTestSuite) validParams() map[string]string {
-	return map[string]string{
-		constants.RequestParamResponseType: string(providers.ResponseTypeCode),
+func (suite *AuthzValidationTestSuite) validParams() url.Values {
+	return url.Values{
+		constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
 	}
 }
 
@@ -71,7 +72,7 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_Success() {
 }
 
 func (suite *AuthzValidationTestSuite) TestValidateParams_MissingResponseType() {
-	params := map[string]string{}
+	params := url.Values{}
 
 	errCode, _ := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
 
@@ -79,8 +80,8 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_MissingResponseType() 
 }
 
 func (suite *AuthzValidationTestSuite) TestValidateParams_UnsupportedResponseType() {
-	params := map[string]string{
-		constants.RequestParamResponseType: "token",
+	params := url.Values{
+		constants.RequestParamResponseType: {"token"},
 	}
 
 	errCode, _ := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
@@ -90,7 +91,7 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_UnsupportedResponseTyp
 
 func (suite *AuthzValidationTestSuite) TestValidateParams_QueryResponseMode() {
 	params := suite.validParams()
-	params[constants.RequestParamResponseMode] = constants.ResponseModeQuery
+	params.Set(constants.RequestParamResponseMode, constants.ResponseModeQuery)
 
 	errCode, errMsg := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
 
@@ -102,7 +103,7 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_UnsupportedResponseMod
 	for _, responseMode := range []string{"fragment", "form_post"} {
 		suite.T().Run(responseMode, func(t *testing.T) {
 			params := suite.validParams()
-			params[constants.RequestParamResponseMode] = responseMode
+			params.Set(constants.RequestParamResponseMode, responseMode)
 
 			errCode, errMsg := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
 
@@ -154,8 +155,8 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_PKCERequired_InvalidCo
 		PKCERequired:            true,
 	}
 	params := suite.validParams()
-	params[constants.RequestParamCodeChallenge] = "invalid"
-	params[constants.RequestParamCodeChallengeMethod] = "plain"
+	params.Set(constants.RequestParamCodeChallenge, "invalid")
+	params.Set(constants.RequestParamCodeChallengeMethod, "plain")
 
 	errCode, _ := ValidateAuthorizationRequestParams(params, app, "")
 
@@ -172,8 +173,8 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_PKCERequired_ValidPKCE
 		PKCERequired:            true,
 	}
 	params := suite.validParams()
-	params[constants.RequestParamCodeChallenge] = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
-	params[constants.RequestParamCodeChallengeMethod] = "S256"
+	params.Set(constants.RequestParamCodeChallenge, "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+	params.Set(constants.RequestParamCodeChallengeMethod, "S256")
 
 	errCode, errMsg := ValidateAuthorizationRequestParams(params, app, "")
 
@@ -183,7 +184,7 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_PKCERequired_ValidPKCE
 
 func (suite *AuthzValidationTestSuite) TestValidateParams_NonceTooLong() {
 	params := suite.validParams()
-	params[constants.RequestParamNonce] = strings.Repeat("a", constants.MaxNonceLength+1)
+	params.Set(constants.RequestParamNonce, strings.Repeat("a", constants.MaxNonceLength+1))
 
 	errCode, errMsg := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
 
@@ -193,7 +194,7 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_NonceTooLong() {
 
 func (suite *AuthzValidationTestSuite) TestValidateParams_ValidNonce() {
 	params := suite.validParams()
-	params[constants.RequestParamNonce] = strings.Repeat("a", constants.MaxNonceLength)
+	params.Set(constants.RequestParamNonce, strings.Repeat("a", constants.MaxNonceLength))
 
 	errCode, errMsg := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
 
@@ -203,7 +204,7 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_ValidNonce() {
 
 func (suite *AuthzValidationTestSuite) TestValidateParams_PromptLogin_Success() {
 	params := suite.validParams()
-	params[constants.RequestParamPrompt] = "login"
+	params.Set(constants.RequestParamPrompt, "login")
 
 	errCode, errMsg := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
 
@@ -213,7 +214,7 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_PromptLogin_Success() 
 
 func (suite *AuthzValidationTestSuite) TestValidateParams_PromptNone_LoginRequired() {
 	params := suite.validParams()
-	params[constants.RequestParamPrompt] = "none"
+	params.Set(constants.RequestParamPrompt, "none")
 
 	errCode, _ := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
 
@@ -222,7 +223,7 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_PromptNone_LoginRequir
 
 func (suite *AuthzValidationTestSuite) TestValidateParams_PromptInvalid() {
 	params := suite.validParams()
-	params[constants.RequestParamPrompt] = "invalid_value"
+	params.Set(constants.RequestParamPrompt, "invalid_value")
 
 	errCode, _ := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
 
@@ -231,7 +232,7 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_PromptInvalid() {
 
 func (suite *AuthzValidationTestSuite) TestValidateParams_PromptNoneCombined() {
 	params := suite.validParams()
-	params[constants.RequestParamPrompt] = "none login"
+	params.Set(constants.RequestParamPrompt, "none login")
 
 	errCode, errMsg := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
 
@@ -241,7 +242,7 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_PromptNoneCombined() {
 
 func (suite *AuthzValidationTestSuite) TestValidateParams_PromptConsent_Success() {
 	params := suite.validParams()
-	params[constants.RequestParamPrompt] = "consent"
+	params.Set(constants.RequestParamPrompt, "consent")
 
 	errCode, errMsg := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
 
@@ -251,7 +252,7 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_PromptConsent_Success(
 
 func (suite *AuthzValidationTestSuite) TestValidateParams_PromptLoginConsent_Success() {
 	params := suite.validParams()
-	params[constants.RequestParamPrompt] = "login consent"
+	params.Set(constants.RequestParamPrompt, "login consent")
 
 	errCode, errMsg := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
 
@@ -261,7 +262,7 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_PromptLoginConsent_Suc
 
 func (suite *AuthzValidationTestSuite) TestValidateParams_PromptSelectAccount() {
 	params := suite.validParams()
-	params[constants.RequestParamPrompt] = "select_account"
+	params.Set(constants.RequestParamPrompt, "select_account")
 
 	errCode, _ := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
 
@@ -270,7 +271,7 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_PromptSelectAccount() 
 
 func (suite *AuthzValidationTestSuite) TestValidateParams_PromptEmpty() {
 	params := suite.validParams()
-	params[constants.RequestParamPrompt] = ""
+	params.Set(constants.RequestParamPrompt, "")
 
 	errCode, errMsg := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
 
@@ -280,7 +281,7 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_PromptEmpty() {
 
 func (suite *AuthzValidationTestSuite) TestValidateParams_DPoPJktParamOnly_Success() {
 	params := suite.validParams()
-	params[constants.RequestParamDPoPJkt] = testJKT
+	params.Set(constants.RequestParamDPoPJkt, testJKT)
 
 	errCode, errMsg := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
 
@@ -299,7 +300,7 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_DPoPHeaderOnly_Success
 
 func (suite *AuthzValidationTestSuite) TestValidateParams_DPoPJktAndHeaderMatch_Success() {
 	params := suite.validParams()
-	params[constants.RequestParamDPoPJkt] = testJKT
+	params.Set(constants.RequestParamDPoPJkt, testJKT)
 
 	errCode, errMsg := ValidateAuthorizationRequestParams(params, suite.oauthApp, testJKT)
 
@@ -309,7 +310,7 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_DPoPJktAndHeaderMatch_
 
 func (suite *AuthzValidationTestSuite) TestValidateParams_DPoPJktAndHeaderMismatch_Rejected() {
 	params := suite.validParams()
-	params[constants.RequestParamDPoPJkt] = testJKT
+	params.Set(constants.RequestParamDPoPJkt, testJKT)
 
 	errCode, errMsg := ValidateAuthorizationRequestParams(params, suite.oauthApp, testOtherJKT)
 
@@ -319,7 +320,7 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_DPoPJktAndHeaderMismat
 
 func (suite *AuthzValidationTestSuite) TestValidateParams_DPoPJktParamMalformed_Rejected() {
 	params := suite.validParams()
-	params[constants.RequestParamDPoPJkt] = "not-a-thumbprint"
+	params.Set(constants.RequestParamDPoPJkt, "not-a-thumbprint")
 
 	errCode, errMsg := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
 

--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"net/url"
 	"slices"
 	"strings"
 	"time"
@@ -134,8 +135,9 @@ func (as *authorizeService) GetAuthorizationCodeDetails(
 // Returns the query params needed to redirect to the login page, or a structured authorization error.
 func (as *authorizeService) HandleInitialAuthorizationRequest(ctx context.Context, msg *OAuthMessage) (
 	*AuthorizationInitResult, *AuthorizationError) {
-	clientID := msg.RequestQueryParams[oauth2const.RequestParamClientID]
-	requestURI := msg.RequestQueryParams[oauth2const.RequestParamRequestURI]
+	queryParams := url.Values(msg.RequestQueryParams)
+	clientID := queryParams.Get(oauth2const.RequestParamClientID)
+	requestURI := queryParams.Get(oauth2const.RequestParamRequestURI)
 
 	if clientID == "" {
 		return nil, &AuthorizationError{
@@ -161,9 +163,14 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(ctx context.Contex
 		}
 	}
 
+	initiatorReq := &providers.InitiatorRequest{
+		Headers:     utils.FilterSensitiveHeaders(msg.RequestHeaders),
+		QueryParams: msg.RequestQueryParams,
+	}
+
 	// If request_uri is present, resolve the pushed authorization request.
 	if requestURI != "" {
-		return as.handlePARAuthorizationRequest(ctx, requestURI, clientID, app)
+		return as.handlePARAuthorizationRequest(ctx, requestURI, clientID, app, initiatorReq)
 	}
 
 	// Enforce PAR requirement: if PAR is required (per-client or global), reject requests without request_uri.
@@ -174,13 +181,14 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(ctx context.Contex
 		}
 	}
 
-	return as.handleStandardAuthorizationRequest(ctx, msg, app)
+	return as.handleStandardAuthorizationRequest(ctx, msg, app, initiatorReq)
 }
 
 // handlePARAuthorizationRequest resolves a request_uri from a PAR and continues the authorization flow.
 func (as *authorizeService) handlePARAuthorizationRequest(
-	ctx context.Context, requestURI string, clientID string, app *providers.OAuthClient,
-) (*AuthorizationInitResult, *AuthorizationError) {
+	ctx context.Context, requestURI string, clientID string,
+	app *providers.OAuthClient, initiatorReq *providers.InitiatorRequest) (
+	*AuthorizationInitResult, *AuthorizationError) {
 	oauthParams, err := as.parService.ResolvePushedAuthorizationRequest(ctx, requestURI, clientID)
 	if err != nil {
 		as.logger.Debug(ctx, "Failed to resolve PAR request", log.Error(err))
@@ -196,22 +204,25 @@ func (as *authorizeService) handlePARAuthorizationRequest(
 		}
 	}
 
-	return as.initiateFlowAndStoreRequest(ctx, oauthParams, app)
+	return as.initiateFlowAndStoreRequest(ctx, oauthParams, app, initiatorReq)
 }
 
 // handleStandardAuthorizationRequest processes a standard authorization request (without PAR).
 func (as *authorizeService) handleStandardAuthorizationRequest(
 	ctx context.Context, msg *OAuthMessage, app *providers.OAuthClient,
+	initiatorReq *providers.InitiatorRequest,
 ) (*AuthorizationInitResult, *AuthorizationError) {
+	queryParams := url.Values(msg.RequestQueryParams)
+
 	// Extract required parameters.
-	redirectURI := msg.RequestQueryParams[oauth2const.RequestParamRedirectURI]
-	scope := msg.RequestQueryParams[oauth2const.RequestParamScope]
-	state := msg.RequestQueryParams[oauth2const.RequestParamState]
-	responseType := msg.RequestQueryParams[oauth2const.RequestParamResponseType]
+	redirectURI := queryParams.Get(oauth2const.RequestParamRedirectURI)
+	scope := queryParams.Get(oauth2const.RequestParamScope)
+	state := queryParams.Get(oauth2const.RequestParamState)
+	responseType := queryParams.Get(oauth2const.RequestParamResponseType)
 
 	// Extract PKCE parameters.
-	codeChallenge := msg.RequestQueryParams[oauth2const.RequestParamCodeChallenge]
-	codeChallengeMethod := msg.RequestQueryParams[oauth2const.RequestParamCodeChallengeMethod]
+	codeChallenge := queryParams.Get(oauth2const.RequestParamCodeChallenge)
+	codeChallengeMethod := queryParams.Get(oauth2const.RequestParamCodeChallengeMethod)
 
 	resources := msg.Resources
 	// A token is bound to exactly one resource server, so an authorization request may target at
@@ -224,16 +235,16 @@ func (as *authorizeService) handleStandardAuthorizationRequest(
 	}
 
 	// Extract claims parameter.
-	claimsParam := msg.RequestQueryParams[oauth2const.RequestParamClaims]
+	claimsParam := queryParams.Get(oauth2const.RequestParamClaims)
 
 	// Extract claims_locales parameter.
-	claimsLocales := msg.RequestQueryParams[oauth2const.RequestParamClaimsLocales]
+	claimsLocales := queryParams.Get(oauth2const.RequestParamClaimsLocales)
 
-	nonce := msg.RequestQueryParams[oauth2const.RequestParamNonce]
-	acrValues := msg.RequestQueryParams[oauth2const.RequestParamAcrValues]
-	maxAge := msg.RequestQueryParams[oauth2const.RequestParamMaxAge]
-	dpopJkt := msg.RequestQueryParams[oauth2const.RequestParamDPoPJkt]
-	prompt := msg.RequestQueryParams[oauth2const.RequestParamPrompt]
+	nonce := queryParams.Get(oauth2const.RequestParamNonce)
+	acrValues := queryParams.Get(oauth2const.RequestParamAcrValues)
+	maxAge := queryParams.Get(oauth2const.RequestParamMaxAge)
+	dpopJkt := queryParams.Get(oauth2const.RequestParamDPoPJkt)
+	prompt := queryParams.Get(oauth2const.RequestParamPrompt)
 
 	// Parse the claims parameter if present.
 	var claimsRequest *oauth2model.ClaimsRequest
@@ -317,13 +328,14 @@ func (as *authorizeService) handleStandardAuthorizationRequest(
 		oauthParams.RedirectURI = app.RedirectURIs[0]
 	}
 
-	return as.initiateFlowAndStoreRequest(ctx, oauthParams, app)
+	return as.initiateFlowAndStoreRequest(ctx, oauthParams, app, initiatorReq)
 }
 
 // initiateFlowAndStoreRequest initiates the authentication flow and stores the authorization request context.
 // This is the common path shared by both standard and PAR-based authorization requests.
 func (as *authorizeService) initiateFlowAndStoreRequest(
-	ctx context.Context, oauthParams *oauth2model.OAuthParameters, app *providers.OAuthClient,
+	ctx context.Context, oauthParams *oauth2model.OAuthParameters,
+	app *providers.OAuthClient, initiatorReq *providers.InitiatorRequest,
 ) (*AuthorizationInitResult, *AuthorizationError) {
 	effectiveAcrValues := requestvalidator.ResolveACRValues(oauthParams.AcrValues, app.AcrValues)
 	essentialAttributes, optionalAttributes := getRequiredAttributes(
@@ -366,9 +378,10 @@ func (as *authorizeService) initiateFlowAndStoreRequest(
 		runtimeData[flowcm.RuntimeKeyMaxAge] = oauthParams.MaxAge
 	}
 	flowInitCtx := &flowexec.FlowInitContext{
-		ApplicationID: app.ID,
-		FlowType:      string(providers.FlowTypeAuthentication),
-		RuntimeData:   runtimeData,
+		ApplicationID:    app.ID,
+		FlowType:         string(providers.FlowTypeAuthentication),
+		RuntimeData:      runtimeData,
+		InitiatorRequest: initiatorReq,
 	}
 
 	executionID, flowErr := as.flowExecService.InitiateFlow(ctx, flowInitCtx)

--- a/backend/internal/oauth/oauth2/authz/service_test.go
+++ b/backend/internal/oauth/oauth2/authz/service_test.go
@@ -21,6 +21,7 @@ package authz
 import (
 	"context"
 	"errors"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -173,12 +174,12 @@ func (suite *AuthorizeServiceTestSuite) testApp() *providers.OAuthClient {
 func (suite *AuthorizeServiceTestSuite) testMsg() *OAuthMessage {
 	return &OAuthMessage{
 		RequestType: oauth2const.TypeInitialAuthorizationRequest,
-		RequestQueryParams: map[string]string{
-			"client_id":     "test-client-id",
-			"redirect_uri":  "https://client.example.com/callback",
-			"response_type": "code",
-			"scope":         "read write",
-			"state":         "test-state",
+		RequestQueryParams: url.Values{
+			"client_id":     {"test-client-id"},
+			"redirect_uri":  {"https://client.example.com/callback"},
+			"response_type": {"code"},
+			"scope":         {"read write"},
+			"state":         {"test-state"},
 		},
 	}
 }
@@ -186,9 +187,9 @@ func (suite *AuthorizeServiceTestSuite) testMsg() *OAuthMessage {
 func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_MissingClientID() {
 	msg := &OAuthMessage{
 		RequestType: oauth2const.TypeInitialAuthorizationRequest,
-		RequestQueryParams: map[string]string{
-			"redirect_uri":  "https://client.example.com/callback",
-			"response_type": "code",
+		RequestQueryParams: url.Values{
+			"redirect_uri":  {"https://client.example.com/callback"},
+			"response_type": {"code"},
 		},
 	}
 
@@ -206,10 +207,10 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_In
 
 	msg := &OAuthMessage{
 		RequestType: oauth2const.TypeInitialAuthorizationRequest,
-		RequestQueryParams: map[string]string{
-			"client_id":     "invalid-client",
-			"redirect_uri":  "https://client.example.com/callback",
-			"response_type": "code",
+		RequestQueryParams: url.Values{
+			"client_id":     {"invalid-client"},
+			"redirect_uri":  {"https://client.example.com/callback"},
+			"response_type": {"code"},
 		},
 	}
 
@@ -227,10 +228,10 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_In
 
 	msg := &OAuthMessage{
 		RequestType: oauth2const.TypeInitialAuthorizationRequest,
-		RequestQueryParams: map[string]string{
-			"client_id":    "test-client-id",
-			"redirect_uri": "https://client.example.com/callback",
-			"claims":       "{invalid json}",
+		RequestQueryParams: url.Values{
+			"client_id":    {"test-client-id"},
+			"redirect_uri": {"https://client.example.com/callback"},
+			"claims":       {"{invalid json}"},
 		},
 	}
 
@@ -354,12 +355,12 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_Fi
 
 	msg := &OAuthMessage{
 		RequestType: oauth2const.TypeInitialAuthorizationRequest,
-		RequestQueryParams: map[string]string{
-			"client_id":     "test-client-id",
-			"redirect_uri":  "https://client.example.com/callback",
-			"response_type": "code",
-			"scope":         "openid email profile",
-			"state":         "test-state",
+		RequestQueryParams: url.Values{
+			"client_id":     {"test-client-id"},
+			"redirect_uri":  {"https://client.example.com/callback"},
+			"response_type": {"code"},
+			"scope":         {"openid email profile"},
+			"state":         {"test-state"},
 		},
 	}
 
@@ -382,11 +383,11 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_In
 
 	msg := &OAuthMessage{
 		RequestType: oauth2const.TypeInitialAuthorizationRequest,
-		RequestQueryParams: map[string]string{
-			"client_id":     "test-client-id",
-			"redirect_uri":  "http://client.example.com/callback",
-			"response_type": "code",
-			"scope":         "read write",
+		RequestQueryParams: url.Values{
+			"client_id":     {"test-client-id"},
+			"redirect_uri":  {"http://client.example.com/callback"},
+			"response_type": {"code"},
+			"scope":         {"read write"},
 		},
 	}
 
@@ -408,10 +409,10 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_Em
 
 	msg := &OAuthMessage{
 		RequestType: oauth2const.TypeInitialAuthorizationRequest,
-		RequestQueryParams: map[string]string{
-			"client_id":     "test-client-id",
-			"response_type": "code",
-			"scope":         "read write",
+		RequestQueryParams: url.Values{
+			"client_id":     {"test-client-id"},
+			"response_type": {"code"},
+			"scope":         {"read write"},
 			// No redirect_uri — service should use app.RedirectURIs[0].
 		},
 	}
@@ -433,12 +434,12 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_Wi
 
 	msg := &OAuthMessage{
 		RequestType: oauth2const.TypeInitialAuthorizationRequest,
-		RequestQueryParams: map[string]string{
-			"client_id":      "test-client-id",
-			"redirect_uri":   "https://client.example.com/callback",
-			"response_type":  "code",
-			"scope":          "openid read write",
-			"claims_locales": "en-US fr-CA",
+		RequestQueryParams: url.Values{
+			"client_id":      {"test-client-id"},
+			"redirect_uri":   {"https://client.example.com/callback"},
+			"response_type":  {"code"},
+			"scope":          {"openid read write"},
+			"claims_locales": {"en-US fr-CA"},
 		},
 	}
 
@@ -483,12 +484,12 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_Se
 
 	msg := &OAuthMessage{
 		RequestType: oauth2const.TypeInitialAuthorizationRequest,
-		RequestQueryParams: map[string]string{
-			"client_id":     "test-client-id",
-			"redirect_uri":  "https://client.example.com/callback",
-			"response_type": "code",
-			"scope":         "openid",
-			"claims":        `{"id_token":{"email":{"essential":true}},"userinfo":{"phone_number":{}}}`,
+		RequestQueryParams: url.Values{
+			"client_id":     {"test-client-id"},
+			"redirect_uri":  {"https://client.example.com/callback"},
+			"response_type": {"code"},
+			"scope":         {"openid"},
+			"claims":        {`{"id_token":{"email":{"essential":true}},"userinfo":{"phone_number":{}}}`},
 		},
 	}
 
@@ -1922,8 +1923,8 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_Ac
 	suite.mockAuthReqStore.EXPECT().AddRequest(mock.Anything, mock.Anything).Return(testAuthID, nil)
 
 	msg := suite.testMsg()
-	msg.RequestQueryParams[oauth2const.RequestParamAcrValues] =
-		"urn:thunder:acr:password urn:thunder:acr:generated-code"
+	acrValues := "urn:thunder:acr:password urn:thunder:acr:generated-code"
+	url.Values(msg.RequestQueryParams).Set(oauth2const.RequestParamAcrValues, acrValues)
 
 	svc := suite.newService()
 	result, authErr := svc.HandleInitialAuthorizationRequest(context.Background(), msg)
@@ -1954,8 +1955,8 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_Ac
 	suite.mockAuthReqStore.EXPECT().AddRequest(mock.Anything, mock.Anything).Return(testAuthID, nil)
 
 	msg := suite.testMsg()
-	msg.RequestQueryParams[oauth2const.RequestParamAcrValues] =
-		"urn:thunder:acr:generated-code urn:thunder:acr:password"
+	acrValues := "urn:thunder:acr:generated-code urn:thunder:acr:password"
+	url.Values(msg.RequestQueryParams).Set(oauth2const.RequestParamAcrValues, acrValues)
 
 	svc := suite.newService()
 	result, authErr := svc.HandleInitialAuthorizationRequest(context.Background(), msg)
@@ -1985,7 +1986,8 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_Ac
 	suite.mockAuthReqStore.EXPECT().AddRequest(mock.Anything, mock.Anything).Return(testAuthID, nil)
 
 	msg := suite.testMsg()
-	msg.RequestQueryParams[oauth2const.RequestParamAcrValues] = "urn:thunder:acr:password urn:thunder:acr:biometrics"
+	url.Values(msg.RequestQueryParams).Set(oauth2const.RequestParamAcrValues,
+		"urn:thunder:acr:password urn:thunder:acr:biometrics")
 
 	svc := suite.newService()
 	result, authErr := svc.HandleInitialAuthorizationRequest(context.Background(), msg)
@@ -2012,8 +2014,8 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_Ac
 	suite.mockAuthReqStore.EXPECT().AddRequest(mock.Anything, mock.Anything).Return(testAuthID, nil)
 
 	msg := suite.testMsg()
-	msg.RequestQueryParams[oauth2const.RequestParamAcrValues] =
-		"urn:thunder:acr:biometrics urn:thunder:acr:linked-wallet"
+	acrValues := "urn:thunder:acr:biometrics urn:thunder:acr:linked-wallet"
+	url.Values(msg.RequestQueryParams).Set(oauth2const.RequestParamAcrValues, acrValues)
 
 	svc := suite.newService()
 	result, authErr := svc.HandleInitialAuthorizationRequest(context.Background(), msg)
@@ -2043,8 +2045,8 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_Ac
 	suite.mockAuthReqStore.EXPECT().AddRequest(mock.Anything, mock.Anything).Return(testAuthID, nil)
 
 	msg := suite.testMsg()
-	msg.RequestQueryParams[oauth2const.RequestParamAcrValues] =
-		"urn:thunder:acr:password urn:thunder:acr:password urn:thunder:acr:generated-code"
+	acrValues := "urn:thunder:acr:password urn:thunder:acr:password urn:thunder:acr:generated-code"
+	url.Values(msg.RequestQueryParams).Set(oauth2const.RequestParamAcrValues, acrValues)
 
 	svc := suite.newService()
 	result, authErr := svc.HandleInitialAuthorizationRequest(context.Background(), msg)
@@ -2071,7 +2073,7 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_Ac
 	suite.mockAuthReqStore.EXPECT().AddRequest(mock.Anything, mock.Anything).Return(testAuthID, nil)
 
 	msg := suite.testMsg()
-	msg.RequestQueryParams[oauth2const.RequestParamAcrValues] = "urn:thunder:acr:password"
+	url.Values(msg.RequestQueryParams).Set(oauth2const.RequestParamAcrValues, "urn:thunder:acr:password")
 
 	svc := suite.newService()
 	result, authErr := svc.HandleInitialAuthorizationRequest(context.Background(), msg)

--- a/backend/internal/oauth/oauth2/authz/validator.go
+++ b/backend/internal/oauth/oauth2/authz/validator.go
@@ -20,6 +20,7 @@ package authz
 
 import (
 	"context"
+	"net/url"
 
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/authz/requestvalidator"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
@@ -47,8 +48,9 @@ func (av *authorizationValidator) validateInitialAuthorizationRequest(ctx contex
 	oauthApp *providers.OAuthClient) (bool, string, string) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "AuthorizationValidator"))
 
-	clientID := msg.RequestQueryParams[constants.RequestParamClientID]
-	redirectURI := msg.RequestQueryParams[constants.RequestParamRedirectURI]
+	queryParams := url.Values(msg.RequestQueryParams)
+	clientID := queryParams.Get(constants.RequestParamClientID)
+	redirectURI := queryParams.Get(constants.RequestParamRedirectURI)
 
 	if clientID == "" {
 		return false, constants.ErrorInvalidRequest, "Missing client_id parameter"

--- a/backend/internal/oauth/oauth2/authz/validator_test.go
+++ b/backend/internal/oauth/oauth2/authz/validator_test.go
@@ -20,6 +20,7 @@ package authz
 
 import (
 	"context"
+	"net/url"
 	"testing"
 
 	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
@@ -72,10 +73,10 @@ func (suite *AuthorizationValidatorTestSuite) TestnewAuthorizationValidator() {
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_Success() {
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {"https://client.example.com/callback"},
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
 		},
 	}
 
@@ -89,9 +90,9 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_MissingClientID() {
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
+		RequestQueryParams: url.Values{
+			constants.RequestParamRedirectURI:  {"https://client.example.com/callback"},
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
 		},
 	}
 
@@ -105,10 +106,10 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_InvalidRedirectURI() {
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "https://malicious.example.com/callback", // not in allowed list
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {"https://malicious.example.com/callback"}, // not in allowed list
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
 		},
 	}
 
@@ -132,10 +133,10 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateAuthzRequest_CodeGrant
 	}
 
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {"https://client.example.com/callback"},
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
 		},
 	}
 
@@ -149,9 +150,9 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateAuthzRequest_CodeGrant
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_MissingResponseType() {
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:    "test-client-id",
-			constants.RequestParamRedirectURI: "https://client.example.com/callback",
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:    {"test-client-id"},
+			constants.RequestParamRedirectURI: {"https://client.example.com/callback"},
 		},
 	}
 
@@ -175,10 +176,10 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 	}
 
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {"https://client.example.com/callback"},
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
 		},
 	}
 
@@ -192,10 +193,10 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_EmptyRedirectURI() {
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "", // empty redirect URI should be OK if app has only one registered
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {""}, // empty redirect URI should be OK if app has only one registered
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
 		},
 	}
 
@@ -211,11 +212,11 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_ValidResource() {
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
-			constants.RequestParamResource:     "https://api.example.com/resource",
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {"https://client.example.com/callback"},
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
+			constants.RequestParamResource:     {"https://api.example.com/resource"},
 		},
 		Resources: []string{"https://api.example.com/resource"},
 	}
@@ -230,11 +231,11 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_ValidMCPServerResource() {
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
-			constants.RequestParamResource:     "https://mcp.example.com/mcp",
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {"https://client.example.com/callback"},
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
+			constants.RequestParamResource:     {"https://mcp.example.com/mcp"},
 		},
 		Resources: []string{"https://mcp.example.com/mcp"},
 	}
@@ -249,11 +250,11 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_ValidResourceWithPort() {
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
-			constants.RequestParamResource:     "https://mcp.example.com:8443",
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {"https://client.example.com/callback"},
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
+			constants.RequestParamResource:     {"https://mcp.example.com:8443"},
 		},
 		Resources: []string{"https://mcp.example.com:8443"},
 	}
@@ -268,11 +269,11 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_EmptyResource() {
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
-			constants.RequestParamResource:     "",
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {"https://client.example.com/callback"},
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
+			constants.RequestParamResource:     {""},
 		},
 	}
 
@@ -286,11 +287,11 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_ResourceMissingScheme() {
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
-			constants.RequestParamResource:     "api.example.com/resource",
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {"https://client.example.com/callback"},
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
+			constants.RequestParamResource:     {"api.example.com/resource"},
 		},
 		Resources: []string{"api.example.com/resource"},
 	}
@@ -305,11 +306,11 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_ResourceWithFragment() {
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
-			constants.RequestParamResource:     "https://api.example.com/resource#fragment",
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {"https://client.example.com/callback"},
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
+			constants.RequestParamResource:     {"https://api.example.com/resource#fragment"},
 		},
 		Resources: []string{"https://api.example.com/resource#fragment"},
 	}
@@ -324,11 +325,11 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_ResourceRelativeURI() {
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
-			constants.RequestParamResource:     "/api/resource",
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {"https://client.example.com/callback"},
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
+			constants.RequestParamResource:     {"/api/resource"},
 		},
 		Resources: []string{"/api/resource"},
 	}
@@ -343,11 +344,11 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_ResourceInvalidURI() {
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
-			constants.RequestParamResource:     "not a valid uri format",
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {"https://client.example.com/callback"},
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
+			constants.RequestParamResource:     {"not a valid uri format"},
 		},
 		Resources: []string{"not a valid uri format"},
 	}
@@ -363,11 +364,11 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_ResourceParameterWithQuery() {
 	// Test resource parameter with query component (should be valid per RFC 8707)
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
-			constants.RequestParamResource:     "https://api.example.com/resource?param=value",
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {"https://client.example.com/callback"},
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
+			constants.RequestParamResource:     {"https://api.example.com/resource?param=value"},
 		},
 		Resources: []string{"https://api.example.com/resource?param=value"},
 	}
@@ -393,10 +394,10 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateAuthzReq_PKCERequired_
 	}
 
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {"https://client.example.com/callback"},
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
 			// Missing code_challenge
 		},
 	}
@@ -422,12 +423,12 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateAuthzReq_PKCERequired_
 	}
 
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:            "test-client-id",
-			constants.RequestParamRedirectURI:         "https://client.example.com/callback",
-			constants.RequestParamResponseType:        string(providers.ResponseTypeCode),
-			constants.RequestParamCodeChallenge:       "invalid-challenge",
-			constants.RequestParamCodeChallengeMethod: "plain", // Not supported per OAuth 2.0 Security BCP
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:            {"test-client-id"},
+			constants.RequestParamRedirectURI:         {"https://client.example.com/callback"},
+			constants.RequestParamResponseType:        {string(providers.ResponseTypeCode)},
+			constants.RequestParamCodeChallenge:       {"invalid-challenge"},
+			constants.RequestParamCodeChallengeMethod: {"plain"}, // Not supported per OAuth 2.0 Security BCP
 		},
 	}
 
@@ -454,12 +455,12 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 	// Use a valid S256 code challenge (base64url encoded SHA256 hash)
 	// This is a valid format for testing
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:            "test-client-id",
-			constants.RequestParamRedirectURI:         "https://client.example.com/callback",
-			constants.RequestParamResponseType:        string(providers.ResponseTypeCode),
-			constants.RequestParamCodeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
-			constants.RequestParamCodeChallengeMethod: "S256",
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:            {"test-client-id"},
+			constants.RequestParamRedirectURI:         {"https://client.example.com/callback"},
+			constants.RequestParamResponseType:        {string(providers.ResponseTypeCode)},
+			constants.RequestParamCodeChallenge:       {"E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"},
+			constants.RequestParamCodeChallengeMethod: {"S256"},
 		},
 	}
 
@@ -484,11 +485,11 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateAuthzReq_PKCERequired_
 	}
 
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:      "test-client-id",
-			constants.RequestParamRedirectURI:   "https://client.example.com/callback",
-			constants.RequestParamResponseType:  string(providers.ResponseTypeCode),
-			constants.RequestParamCodeChallenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:      {"test-client-id"},
+			constants.RequestParamRedirectURI:   {"https://client.example.com/callback"},
+			constants.RequestParamResponseType:  {string(providers.ResponseTypeCode)},
+			constants.RequestParamCodeChallenge: {"E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"},
 			// Missing code_challenge_method - should fail instead of defaulting to S256
 		},
 	}
@@ -514,10 +515,10 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 	}
 
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {"https://client.example.com/callback"},
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
 			// No PKCE parameters - should be OK since PKCE is not required
 		},
 	}
@@ -543,11 +544,11 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateAuthzReq_PKCENotRequir
 	}
 
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:      "test-client-id",
-			constants.RequestParamRedirectURI:   "https://client.example.com/callback",
-			constants.RequestParamResponseType:  string(providers.ResponseTypeCode),
-			constants.RequestParamCodeChallenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:      {"test-client-id"},
+			constants.RequestParamRedirectURI:   {"https://client.example.com/callback"},
+			constants.RequestParamResponseType:  {string(providers.ResponseTypeCode)},
+			constants.RequestParamCodeChallenge: {"E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"},
 			// Missing code_challenge_method - should fail even when PKCE is not required
 		},
 	}
@@ -564,11 +565,11 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateAuthzReq_PKCENotRequir
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_PromptNone_LoginRequired() {
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
-			constants.RequestParamPrompt:       "none",
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {"https://client.example.com/callback"},
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
+			constants.RequestParamPrompt:       {"none"},
 		},
 	}
 
@@ -582,11 +583,11 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_Pr
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRequest_PromptLogin_Success() {
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
-			constants.RequestParamPrompt:       "login",
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {"https://client.example.com/callback"},
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
+			constants.RequestParamPrompt:       {"login"},
 		},
 	}
 
@@ -600,11 +601,11 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_PromptConsent_Success() {
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
-			constants.RequestParamPrompt:       "consent",
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {"https://client.example.com/callback"},
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
+			constants.RequestParamPrompt:       {"consent"},
 		},
 	}
 
@@ -618,11 +619,11 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_Pr
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_PromptNoneCombined_InvalidRequest() {
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
-			constants.RequestParamPrompt:       "none login",
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {"https://client.example.com/callback"},
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
+			constants.RequestParamPrompt:       {"none login"},
 		},
 	}
 
@@ -636,11 +637,11 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_Pr
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_PromptInvalidValue_InvalidRequest() {
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
-			constants.RequestParamPrompt:       "invalid_value",
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {"https://client.example.com/callback"},
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
+			constants.RequestParamPrompt:       {"invalid_value"},
 		},
 	}
 
@@ -654,11 +655,11 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_Pr
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_PromptSelectAccount() {
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
-			constants.RequestParamPrompt:       "select_account",
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {"https://client.example.com/callback"},
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
+			constants.RequestParamPrompt:       {"select_account"},
 		},
 	}
 
@@ -672,11 +673,11 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_Pr
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_PromptLoginConsent_Success() {
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
-			constants.RequestParamPrompt:       "login consent",
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {"https://client.example.com/callback"},
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
+			constants.RequestParamPrompt:       {"login consent"},
 		},
 	}
 
@@ -690,11 +691,11 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_Pr
 
 func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthzRequest_PromptEmpty_InvalidRequest() {
 	msg := &OAuthMessage{
-		RequestQueryParams: map[string]string{
-			constants.RequestParamClientID:     "test-client-id",
-			constants.RequestParamRedirectURI:  "https://client.example.com/callback",
-			constants.RequestParamResponseType: string(providers.ResponseTypeCode),
-			constants.RequestParamPrompt:       "",
+		RequestQueryParams: url.Values{
+			constants.RequestParamClientID:     {"test-client-id"},
+			constants.RequestParamRedirectURI:  {"https://client.example.com/callback"},
+			constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
+			constants.RequestParamPrompt:       {""},
 		},
 	}
 
@@ -804,10 +805,10 @@ func (suite *AuthorizationValidatorTestSuite) TestValidateInitialAuthorizationRe
 				TokenEndpointAuthMethod: providers.TokenEndpointAuthMethodClientSecretPost,
 			}
 			msg := &OAuthMessage{
-				RequestQueryParams: map[string]string{
-					constants.RequestParamClientID:     "test-client-id",
-					constants.RequestParamRedirectURI:  tt.incomingURI,
-					constants.RequestParamResponseType: string(providers.ResponseTypeCode),
+				RequestQueryParams: url.Values{
+					constants.RequestParamClientID:     {"test-client-id"},
+					constants.RequestParamRedirectURI:  {tt.incomingURI},
+					constants.RequestParamResponseType: {string(providers.ResponseTypeCode)},
 				},
 			}
 

--- a/backend/internal/oauth/oauth2/ciba/handler.go
+++ b/backend/internal/oauth/oauth2/ciba/handler.go
@@ -104,6 +104,8 @@ func (h *cibaHandler) HandleBackchannelAuthRequest(w http.ResponseWriter, r *htt
 		BindingMessage:  r.FormValue(oauth2const.RequestParamBindingMessage),
 		RequestedExpiry: r.FormValue(oauth2const.RequestParamRequestedExpiry),
 		ACRValues:       r.FormValue(oauth2const.RequestParamAcrValues),
+		Headers:         utils.SanitizeRawMultiValueStringMap(r.Header),
+		QueryParams:     utils.SanitizeRawMultiValueStringMap(r.URL.Query()),
 	}
 
 	response, cibaErr := h.cibaService.InitiateBackchannelAuth(r.Context(), request, clientInfo.OAuthApp)

--- a/backend/internal/oauth/oauth2/ciba/model.go
+++ b/backend/internal/oauth/oauth2/ciba/model.go
@@ -19,7 +19,9 @@
 // Package ciba implements the OpenID Connect CIBA (Client-Initiated Backchannel Authentication) grant.
 package ciba
 
-import "time"
+import (
+	"time"
+)
 
 // CIBARequestState represents the lifecycle state of a CIBA authentication request.
 type CIBARequestState string
@@ -77,6 +79,8 @@ type BackchannelAuthRequest struct {
 	BindingMessage  string
 	RequestedExpiry string
 	ACRValues       string
+	Headers         map[string][]string
+	QueryParams     map[string][]string
 }
 
 // assertionClaims represents the claims extracted from the flow assertion JWT.

--- a/backend/internal/oauth/oauth2/ciba/service.go
+++ b/backend/internal/oauth/oauth2/ciba/service.go
@@ -193,6 +193,10 @@ func (s *cibaService) InitiateBackchannelAuth(
 		InitialInputs: map[string]string{
 			oauth2const.RequestParamLoginHint: loginHint,
 		},
+		InitiatorRequest: &providers.InitiatorRequest{
+			Headers:     utils.FilterSensitiveHeaders(request.Headers),
+			QueryParams: request.QueryParams,
+		},
 	})
 	if flowErr != nil {
 		s.logger.Error(ctx, "Failed to initiate and execute CIBA authentication flow",

--- a/backend/internal/oauth/oauth2/logout/handler.go
+++ b/backend/internal/oauth/oauth2/logout/handler.go
@@ -29,6 +29,7 @@ import (
 	oauth2utils "github.com/thunder-id/thunderid/internal/oauth/oauth2/utils"
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	sysutils "github.com/thunder-id/thunderid/internal/system/utils"
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 )
 
@@ -68,6 +69,8 @@ func (h *logoutHandler) HandleLogout(w http.ResponseWriter, r *http.Request) {
 		ClientID:              r.FormValue(constants.RequestParamClientID),
 		PostLogoutRedirectURI: r.FormValue(constants.RequestParamPostLogoutRedirect),
 		State:                 r.FormValue(constants.RequestParamState),
+		Headers:               sysutils.SanitizeRawMultiValueStringMap(r.Header),
+		QueryParams:           sysutils.SanitizeRawMultiValueStringMap(r.URL.Query()),
 	}
 
 	// Validate before initiating anything: the post-logout redirect URI is validated here (against the

--- a/backend/internal/oauth/oauth2/logout/handler_test.go
+++ b/backend/internal/oauth/oauth2/logout/handler_test.go
@@ -79,7 +79,7 @@ func (suite *LogoutHandlerTestSuite) TestHandleLogout_InitiatesFlowAndRedirectsT
 			suite.Equal("app-1", ic.ApplicationID)
 			suite.Equal("SIGNOUT", ic.FlowType)
 			capturedRuntime = ic.RuntimeData
-			return "exec-1", nil
+			return testExecutionID, nil
 		})
 
 	// A post_logout_redirect_uri is only honored with an id_token_hint, so drive the flow with one.
@@ -102,7 +102,7 @@ func (suite *LogoutHandlerTestSuite) TestHandleLogout_InitiatesFlowAndRedirectsT
 	location := rec.Header().Get("Location")
 	suite.Contains(location, "https://gate.example:9443/signout")
 	suite.Contains(location, "applicationId=app-1")
-	suite.Contains(location, "executionId=exec-1")
+	suite.Contains(location, "executionId="+testExecutionID)
 	suite.Contains(location, "logoutId=", "the gate needs the logout id to complete on callback")
 
 	// The post-logout target is kept in the OAuth layer, not threaded through the flow.

--- a/backend/internal/oauth/oauth2/logout/service.go
+++ b/backend/internal/oauth/oauth2/logout/service.go
@@ -31,6 +31,7 @@ import (
 	oauth2utils "github.com/thunder-id/thunderid/internal/oauth/oauth2/utils"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	sysutils "github.com/thunder-id/thunderid/internal/system/utils"
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
@@ -50,6 +51,8 @@ type LogoutRequest struct {
 	ClientID              string
 	PostLogoutRedirectURI string
 	State                 string
+	Headers               map[string][]string
+	QueryParams           map[string][]string
 }
 
 // LogoutResolution is the validated target of a logout request.
@@ -57,6 +60,8 @@ type LogoutResolution struct {
 	AppID                 string
 	PostLogoutRedirectURI string
 	State                 string
+	Headers               map[string][]string
+	QueryParams           map[string][]string
 }
 
 // SignOutInitiation is the result of starting an RP-initiated sign-out: the stored logout-request id
@@ -117,9 +122,18 @@ func (s *logoutService) InitiateSignOutFlow(
 		return nil, &tidcommon.InternalServerError
 	}
 
+	// id_token_hint is used by the OAuth layer to resolve the target client; the sign-out flow
+	// itself never consumes it. Strip it from the forwarded initiator request so we don't persist a
+	// JWT with user identity claims into the flow context store.
+	forwardedQueryParams := filterQueryParams(resolution.QueryParams, constants.RequestParamIDTokenHint)
+
 	executionID, svcErr := s.flowExecService.InitiateFlow(ctx, &flowexec.FlowInitContext{
 		ApplicationID: resolution.AppID,
 		FlowType:      string(providers.FlowTypeSignOut),
+		InitiatorRequest: &providers.InitiatorRequest{
+			Headers:     sysutils.FilterSensitiveHeaders(resolution.Headers),
+			QueryParams: forwardedQueryParams,
+		},
 	})
 	if svcErr != nil {
 		return nil, svcErr
@@ -207,6 +221,8 @@ func (s *logoutService) Resolve(ctx context.Context, req LogoutRequest) (*Logout
 		AppID:                 client.ID,
 		PostLogoutRedirectURI: req.PostLogoutRedirectURI,
 		State:                 req.State,
+		Headers:               req.Headers,
+		QueryParams:           req.QueryParams,
 	}, nil
 }
 
@@ -225,6 +241,25 @@ func (s *logoutService) clientIDFromIDTokenHint(ctx context.Context, idTokenHint
 		return "", errInvalidIDTokenHint
 	}
 	return audienceClientID(payload), nil
+}
+
+// filterQueryParams returns a copy of the given query-parameter map with the named keys removed.
+func filterQueryParams(params map[string][]string, exclude ...string) map[string][]string {
+	if len(params) == 0 {
+		return params
+	}
+	excluded := make(map[string]struct{}, len(exclude))
+	for _, name := range exclude {
+		excluded[name] = struct{}{}
+	}
+	filtered := make(map[string][]string, len(params))
+	for name, values := range params {
+		if _, drop := excluded[name]; drop {
+			continue
+		}
+		filtered[name] = values
+	}
+	return filtered
 }
 
 // audienceClientID extracts the client id from an ID token. When the token has multiple audiences the

--- a/backend/internal/oauth/oauth2/logout/service_test.go
+++ b/backend/internal/oauth/oauth2/logout/service_test.go
@@ -37,7 +37,10 @@ import (
 	"github.com/thunder-id/thunderid/tests/mocks/jose/jwtmock"
 )
 
-const testIssuer = "https://issuer.test"
+const (
+	testIssuer      = "https://issuer.test"
+	testExecutionID = "exec-1"
+)
 
 type LogoutServiceTestSuite struct {
 	suite.Suite
@@ -82,7 +85,7 @@ func (suite *LogoutServiceTestSuite) TestInitiateSignOutFlow_StoresContextAndIni
 	flowSvc.EXPECT().InitiateFlow(mock.Anything, mock.Anything).RunAndReturn(
 		func(_ context.Context, ic *flowexec.FlowInitContext) (string, *tidcommon.ServiceError) {
 			captured = ic
-			return "exec-1", nil
+			return testExecutionID, nil
 		})
 	svc := suite.newServiceWithStore(store, flowSvc)
 
@@ -92,7 +95,7 @@ func (suite *LogoutServiceTestSuite) TestInitiateSignOutFlow_StoresContextAndIni
 
 	suite.Nil(svcErr)
 	suite.Require().NotNil(initiation)
-	suite.Equal("exec-1", initiation.ExecutionID)
+	suite.Equal(testExecutionID, initiation.ExecutionID)
 	suite.Equal("logout-1", initiation.LogoutID)
 	// The flow carries no post-logout data — it stays protocol-agnostic.
 	suite.Require().NotNil(captured)
@@ -139,6 +142,141 @@ func (suite *LogoutServiceTestSuite) TestCompleteSignOut_UnknownID() {
 
 	suite.Require().NoError(err)
 	suite.Empty(redirectURI)
+}
+
+func (suite *LogoutServiceTestSuite) TestInitiateSignOutFlow_StripsIDTokenHintFromInitiatorRequest() {
+	// id_token_hint has already been consumed by the OAuth layer at Resolve() to identify the
+	// target client; it must not be persisted into the flow context store as part of the initiator
+	// request. Other logout params (state, client_id, post_logout_redirect_uri) are not
+	// credential-bearing and must be preserved.
+	store := newLogoutRequestStoreInterfaceMock(suite.T())
+	store.EXPECT().AddRequest(mock.Anything, mock.Anything).Return("logout-1", nil)
+	flowSvc := flowexecmock.NewFlowExecServiceInterfaceMock(suite.T())
+	var captured *flowexec.FlowInitContext
+	flowSvc.EXPECT().InitiateFlow(mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, ic *flowexec.FlowInitContext) (string, *tidcommon.ServiceError) {
+			captured = ic
+			return testExecutionID, nil
+		})
+	svc := suite.newServiceWithStore(store, flowSvc)
+
+	_, svcErr := svc.InitiateSignOutFlow(context.Background(), &LogoutResolution{
+		AppID: "app-1",
+		QueryParams: map[string][]string{
+			"id_token_hint":            {"header.payload.sig"},
+			"client_id":                {"client-x"},
+			"post_logout_redirect_uri": {"https://rp.example/after"},
+			"state":                    {"xyz"},
+		},
+	})
+
+	suite.Nil(svcErr)
+	suite.Require().NotNil(captured)
+	suite.Require().NotNil(captured.InitiatorRequest)
+	forwarded := captured.InitiatorRequest.QueryParams
+	suite.NotContains(forwarded, "id_token_hint")
+	suite.Equal([]string{"client-x"}, forwarded["client_id"])
+	suite.Equal([]string{"https://rp.example/after"}, forwarded["post_logout_redirect_uri"])
+	suite.Equal([]string{"xyz"}, forwarded["state"])
+}
+
+func (suite *LogoutServiceTestSuite) TestFilterQueryParams() {
+	testCases := []struct {
+		name     string
+		input    map[string][]string
+		exclude  []string
+		expected map[string][]string
+	}{
+		{
+			name:     "NilInputReturnedAsIs",
+			input:    nil,
+			exclude:  []string{"id_token_hint"},
+			expected: nil,
+		},
+		{
+			name:     "EmptyInputReturnedAsIs",
+			input:    map[string][]string{},
+			exclude:  []string{"id_token_hint"},
+			expected: map[string][]string{},
+		},
+		{
+			name: "NoExcludeReturnsCopy",
+			input: map[string][]string{
+				"client_id": {"c1"},
+				"state":     {"s1"},
+			},
+			exclude: nil,
+			expected: map[string][]string{
+				"client_id": {"c1"},
+				"state":     {"s1"},
+			},
+		},
+		{
+			name: "RemovesNamedKey",
+			input: map[string][]string{
+				"id_token_hint": {"header.payload.sig"},
+				"client_id":     {"c1"},
+			},
+			exclude: []string{"id_token_hint"},
+			expected: map[string][]string{
+				"client_id": {"c1"},
+			},
+		},
+		{
+			name: "RemovesMultipleKeys",
+			input: map[string][]string{
+				"a": {"1"},
+				"b": {"2"},
+				"c": {"3"},
+			},
+			exclude: []string{"a", "c"},
+			expected: map[string][]string{
+				"b": {"2"},
+			},
+		},
+		{
+			name: "UnknownExcludeIsNoOp",
+			input: map[string][]string{
+				"client_id": {"c1"},
+			},
+			exclude: []string{"not_present"},
+			expected: map[string][]string{
+				"client_id": {"c1"},
+			},
+		},
+		{
+			name: "MatchIsCaseSensitive",
+			input: map[string][]string{
+				"ID_Token_Hint": {"header.payload.sig"},
+				"id_token_hint": {"other"},
+			},
+			exclude: []string{"id_token_hint"},
+			expected: map[string][]string{
+				"ID_Token_Hint": {"header.payload.sig"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			result := filterQueryParams(tc.input, tc.exclude...)
+			suite.Equal(tc.expected, result)
+		})
+	}
+}
+
+func (suite *LogoutServiceTestSuite) TestFilterQueryParams_DoesNotMutateInput() {
+	input := map[string][]string{
+		"id_token_hint": {"header.payload.sig"},
+		"client_id":     {"c1"},
+	}
+
+	_ = filterQueryParams(input, "id_token_hint")
+
+	// Original map must remain intact — filterQueryParams returns a copy.
+	suite.Contains(input, "id_token_hint")
+	suite.Equal([]string{"header.payload.sig"}, input["id_token_hint"])
+	suite.Equal([]string{"c1"}, input["client_id"])
 }
 
 func clientWithPostLogout(uris ...string) *providers.OAuthClient {

--- a/backend/internal/oauth/oauth2/par/service.go
+++ b/backend/internal/oauth/oauth2/par/service.go
@@ -20,6 +20,7 @@ package par
 
 import (
 	"context"
+	"net/url"
 	"strings"
 
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
@@ -86,7 +87,11 @@ func (s *parService) HandlePushedAuthorizationRequest(
 	}
 
 	// Validate the authorization parameters using the same rules as the authorize endpoint.
-	errCode, errMsg := requestvalidator.ValidateAuthorizationRequestParams(params, oauthApp, dpopHeaderJkt)
+	parParams := make(url.Values, len(params))
+	for k, v := range params {
+		parParams.Set(k, v)
+	}
+	errCode, errMsg := requestvalidator.ValidateAuthorizationRequestParams(parParams, oauthApp, dpopHeaderJkt)
 	if errCode != "" {
 		return nil, errCode, errMsg
 	}

--- a/backend/internal/system/constants/server_constants.go
+++ b/backend/internal/system/constants/server_constants.go
@@ -25,6 +25,15 @@ const DefaultLogLevel = "info"
 // AuthorizationHeaderName is the name of the authorization header used in HTTP requests.
 const AuthorizationHeaderName = "Authorization"
 
+// CookieHeaderName is the name of the cookie header used in HTTP requests.
+const CookieHeaderName = "Cookie"
+
+// SetCookieHeaderName is the name of the set-cookie header used in HTTP responses.
+const SetCookieHeaderName = "Set-Cookie"
+
+// ProxyAuthorizationHeaderName is the name of the proxy-authorization header used in HTTP requests.
+const ProxyAuthorizationHeaderName = "Proxy-Authorization"
+
 // AcceptHeaderName is the name of the accept header used in HTTP requests.
 const AcceptHeaderName = "Accept"
 

--- a/backend/internal/system/utils/http_util.go
+++ b/backend/internal/system/utils/http_util.go
@@ -502,6 +502,69 @@ func SanitizeStringMap(inputs map[string]string) map[string]string {
 	return sanitized
 }
 
+// sanitizeRaw trims whitespace and removes control characters but does NOT HTML-escape.
+// Use this for values that must remain structurally intact (e.g. JSON, URIs, JWTs)
+// and are not rendered in an HTML context.
+func sanitizeRaw(input string) string {
+	if input == "" {
+		return input
+	}
+
+	trimmed := strings.TrimSpace(input)
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, trimmed)
+}
+
+// SanitizeRawMultiValueStringMap sanitizes a map[string][]string by trimming whitespace and
+// removing control characters from values but does NOT HTML-escape and does NOT modify keys.
+// Keys are preserved verbatim to prevent normalization collisions (e.g. " X " and "X" trimming
+// to the same key). Use this for structured HTTP values such as JSON, URIs, and JWTs.
+func SanitizeRawMultiValueStringMap(inputs map[string][]string) map[string][]string {
+	if len(inputs) == 0 {
+		return inputs
+	}
+
+	sanitized := make(map[string][]string, len(inputs))
+	for key, values := range inputs {
+		sanitizedValues := make([]string, len(values))
+		for i, v := range values {
+			sanitizedValues[i] = sanitizeRaw(v)
+		}
+		sanitized[key] = sanitizedValues
+	}
+
+	return sanitized
+}
+
+// sensitiveHeaders is the deny-list of header names (lowercase) that must not be forwarded
+// beyond the HTTP boundary into provider metadata or initiator requests.
+var sensitiveHeaders = map[string]bool{
+	strings.ToLower(constants.AuthorizationHeaderName):      true,
+	strings.ToLower(constants.CookieHeaderName):             true,
+	strings.ToLower(constants.SetCookieHeaderName):          true,
+	strings.ToLower(constants.ProxyAuthorizationHeaderName): true,
+}
+
+// FilterSensitiveHeaders returns a copy of the header map with credential-bearing headers removed.
+func FilterSensitiveHeaders(h map[string][]string) map[string][]string {
+	if len(h) == 0 {
+		return h
+	}
+
+	filtered := make(map[string][]string, len(h))
+	for name, values := range h {
+		if !sensitiveHeaders[strings.ToLower(name)] {
+			filtered[name] = values
+		}
+	}
+
+	return filtered
+}
+
 // IsBearerAuth checks if the Authorization header uses the Bearer scheme (case-insensitive).
 func IsBearerAuth(authHeader string) bool {
 	parts := strings.SplitN(authHeader, " ", 2)

--- a/backend/internal/system/utils/http_util_test.go
+++ b/backend/internal/system/utils/http_util_test.go
@@ -536,6 +536,131 @@ func (suite *HTTPUtilTestSuite) TestSanitizeStringMap() {
 	}
 }
 
+func (suite *HTTPUtilTestSuite) TestFilterSensitiveHeaders() {
+	testCases := []struct {
+		name     string
+		input    map[string][]string
+		expected map[string][]string
+	}{
+		{
+			name:     "NilHeader",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "EmptyHeader",
+			input:    map[string][]string{},
+			expected: map[string][]string{},
+		},
+		{
+			name: "RemovesSensitiveHeaders",
+			input: map[string][]string{
+				"Authorization":       {"Bearer token"},
+				"Cookie":              {"session=abc"},
+				"Set-Cookie":          {"id=1"},
+				"Proxy-Authorization": {"Basic xyz"},
+				"X-Request-Id":        {"req-123"},
+			},
+			expected: map[string][]string{
+				"X-Request-Id": {"req-123"},
+			},
+		},
+		{
+			name: "PreservesNonSensitiveHeaders",
+			input: map[string][]string{
+				"Content-Type": {"application/json"},
+				"Accept":       {"text/html"},
+			},
+			expected: map[string][]string{
+				"Content-Type": {"application/json"},
+				"Accept":       {"text/html"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.T().Run(tc.name, func(t *testing.T) {
+			result := FilterSensitiveHeaders(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func (suite *HTTPUtilTestSuite) TestSanitizeRawMultiValueStringMap() {
+	testCases := []struct {
+		name     string
+		input    map[string][]string
+		expected map[string][]string
+	}{
+		{
+			name:     "NilMap",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "EmptyMap",
+			input:    map[string][]string{},
+			expected: map[string][]string{},
+		},
+		{
+			name: "NormalValues",
+			input: map[string][]string{
+				"Content-Type": {"application/json"},
+				"Accept":       {"text/html", "application/json"},
+			},
+			expected: map[string][]string{
+				"Content-Type": {"application/json"},
+				"Accept":       {"text/html", "application/json"},
+			},
+		},
+		{
+			name: "PreservesHTMLInValues",
+			input: map[string][]string{
+				"X-Claims":  {`{"email":{"essential":true}}`},
+				"X-Snippet": {"<script>alert('xss')</script>"},
+			},
+			expected: map[string][]string{
+				"X-Claims":  {`{"email":{"essential":true}}`},
+				"X-Snippet": {"<script>alert('xss')</script>"},
+			},
+		},
+		{
+			name: "RemovesControlCharsAndTrimsFromValues",
+			input: map[string][]string{
+				"X-Custom": {"  value\x01  "},
+			},
+			expected: map[string][]string{
+				"X-Custom": {"value"},
+			},
+		},
+		{
+			name: "RemovesNewlineAndTab",
+			input: map[string][]string{
+				"X-Inject": {"line1\nline2", "col1\tcol2"},
+			},
+			expected: map[string][]string{
+				"X-Inject": {"line1line2", "col1col2"},
+			},
+		},
+		{
+			name: "PreservesKeysVerbatim",
+			input: map[string][]string{
+				"X-Custom\x00": {"val"},
+			},
+			expected: map[string][]string{
+				"X-Custom\x00": {"val"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.T().Run(tc.name, func(t *testing.T) {
+			result := SanitizeRawMultiValueStringMap(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
 func (suite *HTTPUtilTestSuite) TestExtractBearerToken() {
 	testCases := []struct {
 		name        string

--- a/backend/pkg/thunderidengine/providers/constants.go
+++ b/backend/pkg/thunderidengine/providers/constants.go
@@ -533,12 +533,3 @@ var (
 	// ErrRuntimeStoreKeyNotFound to identify key not found error in the runtime store providers
 	ErrRuntimeStoreKeyNotFound = errors.New("RuntimeStore key not found")
 )
-
-// Key constants used in the runtime metadata map
-const (
-	MetadataKeyAuthorizationRequestID string = "authorization_request_id"
-	MetadataKeyCurrentClientID        string = "current_client_id"
-	MetadataKeyEssentialAttributes    string = "essential_attributes"
-	MetadataKeyOptionalAttributes     string = "optional_attributes"
-	MetadataKeyClientIDs              string = "client_ids"
-)

--- a/backend/pkg/thunderidengine/providers/interface.go
+++ b/backend/pkg/thunderidengine/providers/interface.go
@@ -130,14 +130,14 @@ type ConsentProvider interface {
 	ResolveConsent(ctx context.Context, ouID, appID, appName, userID string,
 		essentialAttributes, optionalAttributes, authorizedPermissions []string,
 		availableAttributes *AttributesResponse, forceReprompt bool,
-		runtimeMetadata map[string]string) (
+		runtimeMetadata map[string][]string) (
 		*ConsentPromptData, *common.ServiceError)
 
 	// RecordConsent records the user's consent decisions and returns the persisted consent record.
 	// If the user denied any essential attribute, ErrorEssentialConsentDenied is returned.
 	RecordConsent(ctx context.Context, ouID, appID, userID string,
 		decisions *ConsentDecisions, sessionToken string, validityPeriod int64,
-		runtimeMetadata map[string]string) (
+		runtimeMetadata map[string][]string) (
 		*Consent, *common.ServiceError)
 }
 

--- a/backend/pkg/thunderidengine/providers/model.go
+++ b/backend/pkg/thunderidengine/providers/model.go
@@ -359,8 +359,7 @@ type ConditionDefinition struct {
 
 // AuthnMetadata contains metadata for authentication.
 type AuthnMetadata struct {
-	AppMetadata     map[string]interface{} `json:"appMetadata,omitempty"`
-	RuntimeMetadata map[string]string      `json:"runtimeMetadata,omitempty"`
+	RuntimeMetadata map[string][]string `json:"runtimeMetadata,omitempty"`
 }
 
 // AuthenticatedClaims holds claims produced by an authentication mechanism.
@@ -452,9 +451,8 @@ type EntityReference struct {
 
 // GetAttributesMetadata holds metadata used when retrieving entity attributes.
 type GetAttributesMetadata struct {
-	AppMetadata     map[string]interface{} `json:"appMetadata,omitempty"`
-	Locale          string                 `json:"locale"`
-	RuntimeMetadata map[string]string      `json:"runtimeMetadata,omitempty"`
+	Locale          string              `json:"locale"`
+	RuntimeMetadata map[string][]string `json:"runtimeMetadata,omitempty"`
 }
 
 // AuthState is the per-provider authentication state held inside an AuthUser.
@@ -1055,12 +1053,19 @@ type InboundAuthConfigWithSecret struct {
 	OAuthConfig *OAuthConfigWithSecret `json:"config,omitempty" yaml:"config,omitempty" jsonschema:"OAuth/OIDC configuration. Required when type is 'oauth2'. Defines OAuth grant types, redirect URIs, client authentication, and PKCE settings."`
 }
 
+// InitiatorRequest holds the original HTTP request data that triggered the flow.
+type InitiatorRequest struct {
+	Headers     map[string][]string `json:"headers,omitempty"     yaml:"headers,omitempty"`
+	QueryParams map[string][]string `json:"queryParams,omitempty" yaml:"queryParams,omitempty"`
+}
+
 // NodeContext holds the context for a specific node in the flow execution.
 //
 // TODO: fields on NodeContext are currently exposed directly. Convert to unexported
 // fields accessed via getters and setters so that mutation can be encapsulated.
 type NodeContext struct {
-	Context context.Context
+	Context          context.Context
+	initiatorRequest *InitiatorRequest
 
 	ExecutionID   string
 	FlowType      FlowType
@@ -1109,6 +1114,16 @@ func (nc *NodeContext) AppendConsumedInputs(keys []string) {
 // during this call.
 func (nc *NodeContext) GetConsumedInputs() []string {
 	return nc.consumedInputs
+}
+
+// GetInitiatorRequest returns the original HTTP request that triggered the flow.
+func (nc *NodeContext) GetInitiatorRequest() *InitiatorRequest {
+	return nc.initiatorRequest
+}
+
+// SetInitiatorRequest sets the original HTTP request that triggered the flow.
+func (nc *NodeContext) SetInitiatorRequest(req *InitiatorRequest) {
+	nc.initiatorRequest = req
 }
 
 // NodeExecutionRecord represents a record of a node execution in the flow.

--- a/backend/pkg/thunderidengine/providers/model_test.go
+++ b/backend/pkg/thunderidengine/providers/model_test.go
@@ -242,6 +242,38 @@ func (suite *ModelTestSuite) TestNodeContext_ConsumeInput_AccumulatesAcrossCalls
 	assert.Equal(suite.T(), []string{"a", "c", "b"}, nc.GetConsumedInputs())
 }
 
+// ----- NodeContext initiator request -----
+
+func (suite *ModelTestSuite) TestNodeContext_GetInitiatorRequest_NilByDefault() {
+	nc := &NodeContext{}
+
+	assert.Nil(suite.T(), nc.GetInitiatorRequest())
+}
+
+func (suite *ModelTestSuite) TestNodeContext_SetAndGetInitiatorRequest() {
+	nc := &NodeContext{}
+	req := &InitiatorRequest{
+		Headers:     map[string][]string{"X-Custom": {"val"}},
+		QueryParams: map[string][]string{"client_id": {"my-client"}},
+	}
+
+	nc.SetInitiatorRequest(req)
+
+	got := nc.GetInitiatorRequest()
+	assert.Equal(suite.T(), req, got)
+	assert.Equal(suite.T(), []string{"val"}, got.Headers["X-Custom"])
+	assert.Equal(suite.T(), []string{"my-client"}, got.QueryParams["client_id"])
+}
+
+func (suite *ModelTestSuite) TestNodeContext_SetInitiatorRequest_Nil() {
+	nc := &NodeContext{}
+	nc.SetInitiatorRequest(&InitiatorRequest{})
+
+	nc.SetInitiatorRequest(nil)
+
+	assert.Nil(suite.T(), nc.GetInitiatorRequest())
+}
+
 // ----- AttestationConfig -----
 
 func (suite *ModelTestSuite) TestAttestationConfig_WithoutCredentials_NilReceiver() {

--- a/backend/tests/mocks/consentprovidermock/ConsentProvider_mock.go
+++ b/backend/tests/mocks/consentprovidermock/ConsentProvider_mock.go
@@ -40,7 +40,7 @@ func (_m *ConsentProviderMock) EXPECT() *ConsentProviderMock_Expecter {
 }
 
 // RecordConsent provides a mock function for the type ConsentProviderMock
-func (_mock *ConsentProviderMock) RecordConsent(ctx context.Context, ouID string, appID string, userID string, decisions *providers.ConsentDecisions, sessionToken string, validityPeriod int64, runtimeMetadata map[string]string) (*providers.Consent, *common.ServiceError) {
+func (_mock *ConsentProviderMock) RecordConsent(ctx context.Context, ouID string, appID string, userID string, decisions *providers.ConsentDecisions, sessionToken string, validityPeriod int64, runtimeMetadata map[string][]string) (*providers.Consent, *common.ServiceError) {
 	ret := _mock.Called(ctx, ouID, appID, userID, decisions, sessionToken, validityPeriod, runtimeMetadata)
 
 	if len(ret) == 0 {
@@ -49,17 +49,17 @@ func (_mock *ConsentProviderMock) RecordConsent(ctx context.Context, ouID string
 
 	var r0 *providers.Consent
 	var r1 *common.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, *providers.ConsentDecisions, string, int64, map[string]string) (*providers.Consent, *common.ServiceError)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, *providers.ConsentDecisions, string, int64, map[string][]string) (*providers.Consent, *common.ServiceError)); ok {
 		return returnFunc(ctx, ouID, appID, userID, decisions, sessionToken, validityPeriod, runtimeMetadata)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, *providers.ConsentDecisions, string, int64, map[string]string) *providers.Consent); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, *providers.ConsentDecisions, string, int64, map[string][]string) *providers.Consent); ok {
 		r0 = returnFunc(ctx, ouID, appID, userID, decisions, sessionToken, validityPeriod, runtimeMetadata)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*providers.Consent)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, *providers.ConsentDecisions, string, int64, map[string]string) *common.ServiceError); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, *providers.ConsentDecisions, string, int64, map[string][]string) *common.ServiceError); ok {
 		r1 = returnFunc(ctx, ouID, appID, userID, decisions, sessionToken, validityPeriod, runtimeMetadata)
 	} else {
 		if ret.Get(1) != nil {
@@ -82,12 +82,12 @@ type ConsentProviderMock_RecordConsent_Call struct {
 //   - decisions *providers.ConsentDecisions
 //   - sessionToken string
 //   - validityPeriod int64
-//   - runtimeMetadata map[string]string
+//   - runtimeMetadata map[string][]string
 func (_e *ConsentProviderMock_Expecter) RecordConsent(ctx interface{}, ouID interface{}, appID interface{}, userID interface{}, decisions interface{}, sessionToken interface{}, validityPeriod interface{}, runtimeMetadata interface{}) *ConsentProviderMock_RecordConsent_Call {
 	return &ConsentProviderMock_RecordConsent_Call{Call: _e.mock.On("RecordConsent", ctx, ouID, appID, userID, decisions, sessionToken, validityPeriod, runtimeMetadata)}
 }
 
-func (_c *ConsentProviderMock_RecordConsent_Call) Run(run func(ctx context.Context, ouID string, appID string, userID string, decisions *providers.ConsentDecisions, sessionToken string, validityPeriod int64, runtimeMetadata map[string]string)) *ConsentProviderMock_RecordConsent_Call {
+func (_c *ConsentProviderMock_RecordConsent_Call) Run(run func(ctx context.Context, ouID string, appID string, userID string, decisions *providers.ConsentDecisions, sessionToken string, validityPeriod int64, runtimeMetadata map[string][]string)) *ConsentProviderMock_RecordConsent_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -117,9 +117,9 @@ func (_c *ConsentProviderMock_RecordConsent_Call) Run(run func(ctx context.Conte
 		if args[6] != nil {
 			arg6 = args[6].(int64)
 		}
-		var arg7 map[string]string
+		var arg7 map[string][]string
 		if args[7] != nil {
-			arg7 = args[7].(map[string]string)
+			arg7 = args[7].(map[string][]string)
 		}
 		run(
 			arg0,
@@ -140,13 +140,13 @@ func (_c *ConsentProviderMock_RecordConsent_Call) Return(consent *providers.Cons
 	return _c
 }
 
-func (_c *ConsentProviderMock_RecordConsent_Call) RunAndReturn(run func(ctx context.Context, ouID string, appID string, userID string, decisions *providers.ConsentDecisions, sessionToken string, validityPeriod int64, runtimeMetadata map[string]string) (*providers.Consent, *common.ServiceError)) *ConsentProviderMock_RecordConsent_Call {
+func (_c *ConsentProviderMock_RecordConsent_Call) RunAndReturn(run func(ctx context.Context, ouID string, appID string, userID string, decisions *providers.ConsentDecisions, sessionToken string, validityPeriod int64, runtimeMetadata map[string][]string) (*providers.Consent, *common.ServiceError)) *ConsentProviderMock_RecordConsent_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ResolveConsent provides a mock function for the type ConsentProviderMock
-func (_mock *ConsentProviderMock) ResolveConsent(ctx context.Context, ouID string, appID string, appName string, userID string, essentialAttributes []string, optionalAttributes []string, authorizedPermissions []string, availableAttributes *providers.AttributesResponse, forceReprompt bool, runtimeMetadata map[string]string) (*providers.ConsentPromptData, *common.ServiceError) {
+func (_mock *ConsentProviderMock) ResolveConsent(ctx context.Context, ouID string, appID string, appName string, userID string, essentialAttributes []string, optionalAttributes []string, authorizedPermissions []string, availableAttributes *providers.AttributesResponse, forceReprompt bool, runtimeMetadata map[string][]string) (*providers.ConsentPromptData, *common.ServiceError) {
 	ret := _mock.Called(ctx, ouID, appID, appName, userID, essentialAttributes, optionalAttributes, authorizedPermissions, availableAttributes, forceReprompt, runtimeMetadata)
 
 	if len(ret) == 0 {
@@ -155,17 +155,17 @@ func (_mock *ConsentProviderMock) ResolveConsent(ctx context.Context, ouID strin
 
 	var r0 *providers.ConsentPromptData
 	var r1 *common.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string, []string, []string, []string, *providers.AttributesResponse, bool, map[string]string) (*providers.ConsentPromptData, *common.ServiceError)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string, []string, []string, []string, *providers.AttributesResponse, bool, map[string][]string) (*providers.ConsentPromptData, *common.ServiceError)); ok {
 		return returnFunc(ctx, ouID, appID, appName, userID, essentialAttributes, optionalAttributes, authorizedPermissions, availableAttributes, forceReprompt, runtimeMetadata)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string, []string, []string, []string, *providers.AttributesResponse, bool, map[string]string) *providers.ConsentPromptData); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string, []string, []string, []string, *providers.AttributesResponse, bool, map[string][]string) *providers.ConsentPromptData); ok {
 		r0 = returnFunc(ctx, ouID, appID, appName, userID, essentialAttributes, optionalAttributes, authorizedPermissions, availableAttributes, forceReprompt, runtimeMetadata)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*providers.ConsentPromptData)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, string, []string, []string, []string, *providers.AttributesResponse, bool, map[string]string) *common.ServiceError); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string, string, []string, []string, []string, *providers.AttributesResponse, bool, map[string][]string) *common.ServiceError); ok {
 		r1 = returnFunc(ctx, ouID, appID, appName, userID, essentialAttributes, optionalAttributes, authorizedPermissions, availableAttributes, forceReprompt, runtimeMetadata)
 	} else {
 		if ret.Get(1) != nil {
@@ -191,12 +191,12 @@ type ConsentProviderMock_ResolveConsent_Call struct {
 //   - authorizedPermissions []string
 //   - availableAttributes *providers.AttributesResponse
 //   - forceReprompt bool
-//   - runtimeMetadata map[string]string
+//   - runtimeMetadata map[string][]string
 func (_e *ConsentProviderMock_Expecter) ResolveConsent(ctx interface{}, ouID interface{}, appID interface{}, appName interface{}, userID interface{}, essentialAttributes interface{}, optionalAttributes interface{}, authorizedPermissions interface{}, availableAttributes interface{}, forceReprompt interface{}, runtimeMetadata interface{}) *ConsentProviderMock_ResolveConsent_Call {
 	return &ConsentProviderMock_ResolveConsent_Call{Call: _e.mock.On("ResolveConsent", ctx, ouID, appID, appName, userID, essentialAttributes, optionalAttributes, authorizedPermissions, availableAttributes, forceReprompt, runtimeMetadata)}
 }
 
-func (_c *ConsentProviderMock_ResolveConsent_Call) Run(run func(ctx context.Context, ouID string, appID string, appName string, userID string, essentialAttributes []string, optionalAttributes []string, authorizedPermissions []string, availableAttributes *providers.AttributesResponse, forceReprompt bool, runtimeMetadata map[string]string)) *ConsentProviderMock_ResolveConsent_Call {
+func (_c *ConsentProviderMock_ResolveConsent_Call) Run(run func(ctx context.Context, ouID string, appID string, appName string, userID string, essentialAttributes []string, optionalAttributes []string, authorizedPermissions []string, availableAttributes *providers.AttributesResponse, forceReprompt bool, runtimeMetadata map[string][]string)) *ConsentProviderMock_ResolveConsent_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -238,9 +238,9 @@ func (_c *ConsentProviderMock_ResolveConsent_Call) Run(run func(ctx context.Cont
 		if args[9] != nil {
 			arg9 = args[9].(bool)
 		}
-		var arg10 map[string]string
+		var arg10 map[string][]string
 		if args[10] != nil {
-			arg10 = args[10].(map[string]string)
+			arg10 = args[10].(map[string][]string)
 		}
 		run(
 			arg0,
@@ -264,7 +264,7 @@ func (_c *ConsentProviderMock_ResolveConsent_Call) Return(consentPromptData *pro
 	return _c
 }
 
-func (_c *ConsentProviderMock_ResolveConsent_Call) RunAndReturn(run func(ctx context.Context, ouID string, appID string, appName string, userID string, essentialAttributes []string, optionalAttributes []string, authorizedPermissions []string, availableAttributes *providers.AttributesResponse, forceReprompt bool, runtimeMetadata map[string]string) (*providers.ConsentPromptData, *common.ServiceError)) *ConsentProviderMock_ResolveConsent_Call {
+func (_c *ConsentProviderMock_ResolveConsent_Call) RunAndReturn(run func(ctx context.Context, ouID string, appID string, appName string, userID string, essentialAttributes []string, optionalAttributes []string, authorizedPermissions []string, availableAttributes *providers.AttributesResponse, forceReprompt bool, runtimeMetadata map[string][]string) (*providers.ConsentPromptData, *common.ServiceError)) *ConsentProviderMock_ResolveConsent_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose
This pull request refactors how authentication and attribute metadata are constructed and passed through the flow engine, focusing on runtime and initiator request data. It simplifies metadata handling by removing the inclusion of application metadata and client IDs, and instead only includes relevant runtime keys and initiator request data. The changes also ensure that the initiator request is consistently propagated through the flow execution context. Additionally, some minor code cleanup and naming consistency improvements are made.

### Approach
**Metadata construction and propagation refactor:**

* `BuildAuthnMetadata` and `BuildGetAttributesMetadata` now only include `provider_ext_*` runtime keys and flattened initiator request headers/query parameters, removing all logic related to application metadata and OAuth client IDs.
* All test cases for `BuildAuthnMetadata` and `BuildGetAttributesMetadata` are updated or replaced to reflect the new structure, focusing on runtime and initiator request metadata only.
* Consent executor and related services are updated to use the new metadata structure, replacing usage of the old `BuildRuntimeMetadata` with the new `BuildAuthnMetadata(...).RuntimeMetadata`.

**Initiator request propagation:**

* The initiator request is now a first-class property of the flow execution context, with explicit getter/setter methods added, and is propagated from flow initiation through to node execution.

**Minor improvements and code cleanup:**

* Consistent use of the `sysutils` import alias for utility functions in OAuth2 authorization handler, and improved handling of request headers and query parameters as multi-value maps.

### Related Issues
- N/A

### Related PRs
- https://github.com/thunder-id/thunderid/pull/4216

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Propagate originating request headers and query parameters end-to-end (including flow persistence/restoration).
  * Enrich runtime metadata with `provider_ext_*` values and flattened initiator data (`initiator_header_*` / `initiator_query_*`) using multi-valued entries.
* **Security Improvements**
  * Sanitize incoming header/query values and filter sensitive headers; sanitize runtime-derived metadata.
  * Enforce OAuth authorization GET repetition rules (only `resource` may repeat).
* **Bug Fixes**
  * Correct locale/runtime metadata composition for attribute requests.
  * Ensure consent enforcement uses authentication/provider-derived runtime metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->