### PR TITLE
Add consent flow widget with automatic wiring

### DIFF
--- a/docs/content/guides/consent.mdx
+++ b/docs/content/guides/consent.mdx
@@ -26,15 +26,20 @@ Attribute consent requirements are driven by the requested attributes during app
 
 ## Configuring Consent in Flows
 
-To enable the consent prompt during authentication flows, configure it within the <ProductName /> flow builder:
+The **User Consent** widget adds a pre-wired consent executor and consent screen and connects them into your flow automatically:
 
 1. Navigate to the **Flows** section in the <ProductName /> console and select the flow you want to update (e.g., the default login flow).
-2. In the flow builder, expand the **Executors** section and add the **User Consent** executor node. It should be placed after the necessary authentication steps and before the **Auth Assert Generator** node.
-3. Connect the `onSuccess` edge of the preceding node to the input of the **User Consent** node, and then connect the `onSuccess` edge of the **User Consent** node to the next node in the flow (e.g., **Auth Assert Generator**).
-4. Expand the **Steps** section and add the **Consent View** step to the flow. This step will render the consent page to the user during the login process.
-5. Connect the `onIncomplete` edge of the **User Consent** node to the input of the **Consent View** step.
-6. Then connect both **Allow** and **Deny** buttons in the **Consent View** step back to the **User Consent** node to handle user responses.
-7. Save the flow configuration.
+2. In the flow builder, expand the **Widgets** section and add the **User Consent** widget. The consent screen and the **Allow** and **Deny** responses come pre-connected. The widget also connects its output to the **Auth Assert Generator** node and its input to the **Authorization** node when those are present in the flow. If either is missing, that edge is left open for you to connect to the node you want.
+3. Save the flow configuration.
+
+To assemble the consent step manually, add and connect the individual nodes instead:
+
+1. In the flow builder, expand the **Executors** section and add the **User Consent** executor node. It should be placed after the necessary authentication steps and before the **Auth Assert Generator** node.
+2. Connect the `onSuccess` edge of the preceding node to the input of the **User Consent** node, and then connect the `onSuccess` edge of the **User Consent** node to the next node in the flow (e.g., **Auth Assert Generator**).
+3. Expand the **Steps** section and add the **Consent View** step to the flow. This step will render the consent page to the user during the login process.
+4. Connect the `onIncomplete` edge of the **User Consent** node to the input of the **Consent View** step.
+5. Then connect both **Allow** and **Deny** buttons in the **Consent View** step back to the **User Consent** node to handle user responses.
+6. Save the flow configuration.
 
 {/* Placeholder for the flow graph image */}
 <ThemedImage

--- a/frontend/apps/console/src/features/flows/constants/VisualFlowConstants.ts
+++ b/frontend/apps/console/src/features/flows/constants/VisualFlowConstants.ts
@@ -83,6 +83,7 @@ class VisualFlowConstants {
     WidgetTypes.EUDIWallet,
     WidgetTypes.PasskeyAuthentication,
     WidgetTypes.Provisioning,
+    WidgetTypes.Consent,
     WidgetTypes.MagicLink,
     WidgetTypes.SelfSignUpLink,
     WidgetTypes.SignInLink,

--- a/frontend/apps/console/src/features/flows/models/widget.ts
+++ b/frontend/apps/console/src/features/flows/models/widget.ts
@@ -48,6 +48,7 @@ export const WidgetTypes = {
   EUDIWallet: 'EUDI_WALLET',
   PasskeyAuthentication: 'PASSKEY_AUTHENTICATION',
   Provisioning: 'PROVISIONING',
+  Consent: 'CONSENT',
   MagicLink: 'MAGIC_LINK',
   SelfSignUpLink: 'SELF_SIGN_UP_LINK',
   SignInLink: 'SIGN_IN_LINK',

--- a/frontend/apps/console/src/features/flows/utils/__tests__/autoWireWidget.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/autoWireWidget.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {Edge, Node} from '@xyflow/react';
+import {describe, expect, it} from 'vitest';
+import VisualFlowConstants from '../../constants/VisualFlowConstants';
+import autoWireWidget, {type AutoWireMeta} from '../autoWireWidget';
+import generateUnconnectedEdges from '@/features/login-flow/utils/edgeUtils';
+
+const NEXT = VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX;
+const EDGE_STYLE = 'base-edge';
+
+const onSuccessOf = (nodes: Node[], id: string): string | undefined =>
+  (nodes.find((n: Node) => n.id === id) as {data?: {action?: {onSuccess?: string}}} | undefined)?.data?.action
+    ?.onSuccess;
+
+const executorNode = (id: string, name: string, onSuccess = ''): Node =>
+  ({
+    id,
+    type: 'TASK_EXECUTION',
+    position: {x: 0, y: 0},
+    data: {action: {executor: {name}, onSuccess}},
+  }) as unknown as Node;
+
+const viewNode = (id: string): Node =>
+  ({id, type: 'VIEW', position: {x: 0, y: 0}, data: {components: []}}) as unknown as Node;
+
+const endNode = (id: string): Node => ({id, type: 'END', position: {x: 0, y: 0}, data: {}}) as unknown as Node;
+
+const edge = (source: string, target: string, sourceHandle?: string): Edge => ({
+  id: `${source}->${target}`,
+  source,
+  target,
+  sourceHandle: sourceHandle ?? `${source}${NEXT}`,
+  type: EDGE_STYLE,
+});
+
+const has = (edges: Edge[], source: string, target: string): boolean =>
+  edges.some((e: Edge) => e.source === source && e.target === target);
+
+describe('autoWireWidget', () => {
+  it('returns inputs unchanged when no autoWire metadata is present', () => {
+    const nodes: Node[] = [executorNode('cred', 'CredentialsAuthExecutor'), endNode('end')];
+    const edges: Edge[] = [edge('cred', 'end')];
+
+    const result = autoWireWidget(nodes, nodes, edges, undefined, new Map(), EDGE_STYLE);
+
+    expect(result.nodes).toBe(nodes);
+    expect(result.edges).toBe(edges);
+  });
+
+  describe('two-sided splice (consent / provisioning shape)', () => {
+    const consentAutoWire: AutoWireMeta = {
+      entry: {stepRef: 'CONSENT_EXECUTOR_STEP_ID'},
+      exit: {stepRef: 'CONSENT_EXECUTOR_STEP_ID', handle: 'success'},
+      spliceAfter: [{executorName: 'AuthorizationExecutor'}],
+      spliceBefore: [{executorName: 'AuthAssertExecutor'}],
+    };
+    const resolved = new Map([['CONSENT_EXECUTOR_STEP_ID', 'consent_check_1']]);
+
+    it('inserts the widget between the authorization executor and the auth assert generator', () => {
+      const preExisting: Node[] = [
+        executorNode('authz', 'AuthorizationExecutor', 'auth_assert'),
+        executorNode('auth_assert', 'AuthAssertExecutor'),
+        endNode('end'),
+      ];
+      const cluster: Node[] = [executorNode('consent_check_1', 'ConsentExecutor'), viewNode('consent_view_1')];
+      const resultNodes: Node[] = [...preExisting, ...cluster];
+      const resultEdges: Edge[] = [edge('authz', 'auth_assert'), edge('auth_assert', 'end')];
+
+      const {nodes, edges} = autoWireWidget(
+        preExisting,
+        resultNodes,
+        resultEdges,
+        consentAutoWire,
+        resolved,
+        EDGE_STYLE,
+      );
+
+      // The authorization -> auth assert edge is redirected through the widget.
+      expect(has(edges, 'authz', 'auth_assert')).toBe(false);
+      expect(has(edges, 'authz', 'consent_check_1')).toBe(true);
+      expect(
+        edges.some(
+          (e: Edge) =>
+            e.source === 'consent_check_1' && e.sourceHandle === `consent_check_1${NEXT}` && e.target === 'auth_assert',
+        ),
+      ).toBe(true);
+      expect(has(edges, 'auth_assert', 'end')).toBe(true);
+
+      // Node action.onSuccess is reconciled with the rewired edges, so it no longer points at the
+      // bypassed target.
+      expect(onSuccessOf(nodes, 'authz')).toBe('consent_check_1');
+      expect(onSuccessOf(nodes, 'consent_check_1')).toBe('auth_assert');
+    });
+
+    it('leaves no stale action.onSuccess, so a later edge-regeneration pass adds no fork edge', () => {
+      const preExisting: Node[] = [
+        executorNode('authz', 'AuthorizationExecutor', 'auth_assert'),
+        executorNode('auth_assert', 'AuthAssertExecutor'),
+        endNode('end'),
+      ];
+      const cluster: Node[] = [executorNode('consent_check_1', 'ConsentExecutor'), viewNode('consent_view_1')];
+      const resultNodes: Node[] = [...preExisting, ...cluster];
+      const resultEdges: Edge[] = [edge('authz', 'auth_assert'), edge('auth_assert', 'end')];
+
+      const {nodes, edges} = autoWireWidget(
+        preExisting,
+        resultNodes,
+        resultEdges,
+        consentAutoWire,
+        resolved,
+        EDGE_STYLE,
+      );
+
+      // Re-running edge generation (as the next widget drop would) finds nothing to repair.
+      expect(generateUnconnectedEdges(edges, nodes, EDGE_STYLE)).toHaveLength(0);
+    });
+
+    it('leaves the entry unconnected when there is no authorization executor upstream', () => {
+      const preExisting: Node[] = [
+        executorNode('cred', 'CredentialsAuthExecutor'),
+        executorNode('auth_assert', 'AuthAssertExecutor'),
+        endNode('end'),
+      ];
+      const cluster: Node[] = [executorNode('consent_check_1', 'ConsentExecutor')];
+      const resultNodes: Node[] = [...preExisting, ...cluster];
+      const resultEdges: Edge[] = [edge('cred', 'auth_assert'), edge('auth_assert', 'end')];
+
+      const {edges} = autoWireWidget(preExisting, resultNodes, resultEdges, consentAutoWire, resolved, EDGE_STYLE);
+
+      // Exit wires to the auth assert generator; entry is left dangling for the user.
+      expect(has(edges, 'consent_check_1', 'auth_assert')).toBe(true);
+      expect(edges.some((e: Edge) => e.target === 'consent_check_1')).toBe(false);
+      // The pre-existing incoming edge of the anchor is not stolen.
+      expect(has(edges, 'cred', 'auth_assert')).toBe(true);
+    });
+
+    it('leaves the exit unconnected when there is no auth assert generator downstream', () => {
+      const preExisting: Node[] = [executorNode('authz', 'AuthorizationExecutor'), endNode('end')];
+      const cluster: Node[] = [executorNode('consent_check_1', 'ConsentExecutor')];
+      const resultNodes: Node[] = [...preExisting, ...cluster];
+      const resultEdges: Edge[] = [edge('authz', 'end')];
+
+      const {edges} = autoWireWidget(preExisting, resultNodes, resultEdges, consentAutoWire, resolved, EDGE_STYLE);
+
+      // Entry wires from authorization; exit is left dangling for the user.
+      expect(has(edges, 'authz', 'end')).toBe(false);
+      expect(has(edges, 'authz', 'consent_check_1')).toBe(true);
+      expect(edges.some((e: Edge) => e.source === 'consent_check_1')).toBe(false);
+    });
+
+    it('adds an edge from the upstream node when it has no outgoing success edge yet', () => {
+      const preExisting: Node[] = [executorNode('authz', 'AuthorizationExecutor')];
+      const cluster: Node[] = [executorNode('consent_check_1', 'ConsentExecutor')];
+      const resultNodes: Node[] = [...preExisting, ...cluster];
+      const resultEdges: Edge[] = [];
+
+      const {edges} = autoWireWidget(preExisting, resultNodes, resultEdges, consentAutoWire, resolved, EDGE_STYLE);
+
+      expect(
+        edges.some(
+          (e: Edge) => e.source === 'authz' && e.sourceHandle === `authz${NEXT}` && e.target === 'consent_check_1',
+        ),
+      ).toBe(true);
+    });
+
+    it('leaves the graph unchanged when neither anchor is present (blank canvas)', () => {
+      const preExisting: Node[] = [viewNode('v')];
+      const cluster: Node[] = [executorNode('consent_check_1', 'ConsentExecutor')];
+      const resultNodes: Node[] = [...preExisting, ...cluster];
+      const resultEdges: Edge[] = [];
+
+      const {nodes, edges} = autoWireWidget(
+        preExisting,
+        resultNodes,
+        resultEdges,
+        consentAutoWire,
+        resolved,
+        EDGE_STYLE,
+      );
+
+      expect(nodes).toHaveLength(2);
+      expect(edges).toHaveLength(0);
+    });
+  });
+
+  describe('reuse / dedup (federation shape)', () => {
+    const federationAutoWire: AutoWireMeta = {
+      reuse: [{stepRef: 'AUTH_ASSERT_EXECUTOR_ID', matchBy: 'executorName', match: 'AuthAssertExecutor'}],
+    };
+    const resolved = new Map([['AUTH_ASSERT_EXECUTOR_ID', 'bundled_auth']]);
+
+    it('drops the bundled AuthAssert and redirects the executor edge onto the existing one', () => {
+      const preExisting: Node[] = [viewNode('v'), executorNode('auth_assert', 'AuthAssertExecutor'), endNode('end')];
+      const cluster: Node[] = [
+        executorNode('google', 'GoogleOIDCAuthExecutor', 'bundled_auth'),
+        executorNode('bundled_auth', 'AuthAssertExecutor', 'END'),
+      ];
+      const resultNodes: Node[] = [...preExisting, ...cluster];
+      const resultEdges: Edge[] = [edge('google', 'bundled_auth'), edge('bundled_auth', 'end')];
+
+      const {nodes, edges} = autoWireWidget(
+        preExisting,
+        resultNodes,
+        resultEdges,
+        federationAutoWire,
+        resolved,
+        EDGE_STYLE,
+      );
+
+      expect(nodes.some((n: Node) => n.id === 'bundled_auth')).toBe(false);
+      expect(has(edges, 'google', 'auth_assert')).toBe(true);
+      expect(edges.some((e: Edge) => e.source === 'bundled_auth' || e.target === 'bundled_auth')).toBe(false);
+      // The executor's action.onSuccess is repointed off the dropped bundled node onto the reused one.
+      expect(onSuccessOf(nodes, 'google')).toBe('auth_assert');
+    });
+
+    it('keeps the bundled AuthAssert on a blank canvas and wires it to the END node by type', () => {
+      const preExisting: Node[] = [viewNode('v'), endNode('end')];
+      const cluster: Node[] = [
+        executorNode('google', 'GoogleOIDCAuthExecutor'),
+        executorNode('bundled_auth', 'AuthAssertExecutor', 'END'),
+      ];
+      const resultNodes: Node[] = [...preExisting, ...cluster];
+      // generateUnconnectedEdges misses bundled_auth -> end because the END id is "end", not "END".
+      const resultEdges: Edge[] = [edge('google', 'bundled_auth')];
+
+      const {nodes, edges} = autoWireWidget(
+        preExisting,
+        resultNodes,
+        resultEdges,
+        federationAutoWire,
+        resolved,
+        EDGE_STYLE,
+      );
+
+      expect(nodes.some((n: Node) => n.id === 'bundled_auth')).toBe(true);
+      expect(has(edges, 'bundled_auth', 'end')).toBe(true);
+    });
+  });
+});

--- a/frontend/apps/console/src/features/flows/utils/autoWireWidget.ts
+++ b/frontend/apps/console/src/features/flows/utils/autoWireWidget.ts
@@ -1,0 +1,306 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {Edge, Node} from '@xyflow/react';
+import {MarkerType} from '@xyflow/react';
+import VisualFlowConstants from '@/features/flows/constants/VisualFlowConstants';
+import {StepTypes} from '@/features/flows/models/steps';
+
+/**
+ * Which exit of a widget node carries the flow onward to the downstream node.
+ */
+export type AutoWireHandle = 'success' | 'failure' | 'incomplete';
+
+/**
+ * A reference to one of a widget's own steps by its `__generationMeta__.replacers` key
+ * (pre-substitution). Resolved to a concrete node id at drop time.
+ */
+export interface AutoWireStepRef {
+  stepRef: string;
+}
+
+/**
+ * A candidate node to attach the widget cluster against. Matched by executor name or node type,
+ * never by id (ids differ across templates, e.g. "END" vs "end").
+ */
+export interface AutoWireAnchorCandidate {
+  executorName?: string;
+  nodeType?: string;
+}
+
+/**
+ * Declares how a dropped widget cluster attaches to the existing flow graph.
+ */
+export interface AutoWireMeta {
+  /** Internal node that receives the incoming edge from the upstream node. */
+  entry?: AutoWireStepRef;
+  /** Internal node + exit handle that connects onward to the downstream node. */
+  exit?: AutoWireStepRef & {handle: AutoWireHandle};
+  /**
+   * Ordered upstream candidates. The first one present in the flow has its success edge
+   * redirected into the widget entry. If none match, the entry is left unconnected for the
+   * user to wire manually.
+   */
+  spliceAfter?: AutoWireAnchorCandidate[];
+  /**
+   * Ordered downstream candidates. The widget exit is connected to the first one present in
+   * the flow. If none match, the exit is left unconnected for the user to wire manually.
+   */
+  spliceBefore?: AutoWireAnchorCandidate[];
+  /** Dedup rules: reuse an existing equivalent node instead of the widget's bundled copy. */
+  reuse?: {
+    stepRef: string;
+    matchBy: 'executorName';
+    match: string;
+  }[];
+}
+
+interface ActionCarrier {
+  data?: {
+    action?: {
+      executor?: {name?: string};
+      onSuccess?: string;
+    };
+  };
+}
+
+const executorName = (node: Node): string | undefined => (node as ActionCarrier).data?.action?.executor?.name;
+
+const matchesCandidate = (node: Node, candidate: AutoWireAnchorCandidate): boolean => {
+  if (candidate.executorName) {
+    return executorName(node) === candidate.executorName;
+  }
+  if (candidate.nodeType) {
+    return node.type === candidate.nodeType;
+  }
+
+  return false;
+};
+
+const handleId = (nodeId: string, handle: AutoWireHandle): string => {
+  switch (handle) {
+    case 'failure':
+      return 'failure';
+    case 'incomplete':
+      return `${nodeId}${VisualFlowConstants.FLOW_BUILDER_INCOMPLETE_HANDLE_SUFFIX}`;
+    case 'success':
+    default:
+      return `${nodeId}${VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX}`;
+  }
+};
+
+const makeEdge = (id: string, source: string, sourceHandle: string, target: string, edgeStyle: string): Edge => ({
+  animated: false,
+  id,
+  markerEnd: {type: MarkerType.Arrow},
+  source,
+  sourceHandle,
+  target,
+  type: edgeStyle,
+});
+
+/**
+ * Splices a freshly dropped widget cluster into the existing flow graph by adding and removing
+ * edges according to the widget's declarative `autoWire` metadata. When no metadata is present,
+ * or no anchor/reusable node can be found, the graph is returned unchanged (append-only fallback,
+ * identical to the pre-existing behaviour).
+ *
+ * @param preExistingNodes - The nodes present before this widget was dropped.
+ * @param resultNodes - The full node set after the widget's steps were appended and id-resolved.
+ * @param resultEdges - The edges after the widget's internal edges were generated.
+ * @param autoWire - The widget's auto-wiring metadata, if any.
+ * @param resolvedIds - Map of replacer key to concrete id, from `updateTemplatePlaceholderReferences`.
+ * @param edgeStyle - The edge style to apply to generated edges.
+ * @returns The spliced node and edge sets.
+ */
+const autoWireWidget = (
+  preExistingNodes: Node[],
+  resultNodes: Node[],
+  resultEdges: Edge[],
+  autoWire: AutoWireMeta | undefined,
+  resolvedIds: Map<string, string>,
+  edgeStyle: string,
+): {nodes: Node[]; edges: Edge[]} => {
+  if (!autoWire) {
+    return {nodes: resultNodes, edges: resultEdges};
+  }
+
+  const preIds = new Set<string>(preExistingNodes.map((node: Node) => node.id));
+  const clusterIds = new Set<string>(resultNodes.filter((node: Node) => !preIds.has(node.id)).map((n) => n.id));
+
+  const resolve = (ref: string): string => resolvedIds.get(ref) ?? ref;
+
+  let edges: Edge[] = [...resultEdges];
+  const nodesToDrop = new Set<string>();
+
+  // Reconcile node `action.onSuccess` with the rewired edges once all passes are done. `remapTarget`
+  // repoints any reference to a dropped node; `nodeOnSuccess` sets a specific node's success target.
+  // Leaving a stale onSuccess would make a later generateUnconnectedEdges pass re-create the old
+  // edge (forking the flow) or leave a dangling reference to a removed node.
+  const remapTarget = new Map<string, string>();
+  const nodeOnSuccess = new Map<string, string>();
+
+  // Pass A: reuse / dedup. Drop the widget's bundled copy of a node the flow already has and
+  // redirect edges that pointed at the bundled copy onto the pre-existing one.
+  (autoWire.reuse ?? []).forEach((rule) => {
+    const dupId: string = resolve(rule.stepRef);
+    const dupNode: Node | undefined = resultNodes.find((node: Node) => node.id === dupId);
+    const existing: Node | undefined = preExistingNodes.find((node: Node) => executorName(node) === rule.match);
+
+    if (dupNode && existing) {
+      edges = edges
+        .filter((edge: Edge) => edge.source !== dupId)
+        .map((edge: Edge) => (edge.target === dupId ? {...edge, id: `${edge.id}__reuse`, target: existing.id} : edge));
+      nodesToDrop.add(dupId);
+      remapTarget.set(dupId, existing.id);
+    }
+  });
+
+  // Pass B: two-sided splice. Connect the widget entry from an upstream node and its exit to a
+  // downstream node. Each side is optional: when no candidate matches, that edge is deliberately
+  // left unconnected for the user to wire wherever they want.
+  if (autoWire.entry && autoWire.exit) {
+    const entryId: string = resolve(autoWire.entry.stepRef);
+    const exitId: string = resolve(autoWire.exit.stepRef);
+
+    const findPresent = (candidates: AutoWireAnchorCandidate[] | undefined): Node | undefined => {
+      for (const candidate of candidates ?? []) {
+        const match: Node | undefined = resultNodes.find(
+          (node: Node) => !clusterIds.has(node.id) && !nodesToDrop.has(node.id) && matchesCandidate(node, candidate),
+        );
+
+        if (match) {
+          return match;
+        }
+      }
+
+      return undefined;
+    };
+
+    // Downstream: connect the widget exit to the first present downstream candidate.
+    const downstream: Node | undefined = findPresent(autoWire.spliceBefore);
+
+    if (downstream) {
+      edges.push(
+        makeEdge(
+          `${exitId}->${downstream.id}__autowire`,
+          exitId,
+          handleId(exitId, autoWire.exit.handle),
+          downstream.id,
+          edgeStyle,
+        ),
+      );
+
+      if (autoWire.exit.handle === 'success') {
+        nodeOnSuccess.set(exitId, downstream.id);
+      }
+    }
+
+    // Upstream: redirect the first present upstream candidate's success edge into the widget entry
+    // (inserting the widget right after it). If it has no success edge yet, add one.
+    const upstream: Node | undefined = findPresent(autoWire.spliceAfter);
+
+    if (upstream) {
+      const successHandle: string = handleId(upstream.id, 'success');
+      const outgoing: Edge[] = edges.filter(
+        (edge: Edge) => edge.source === upstream.id && edge.sourceHandle === successHandle,
+      );
+
+      if (outgoing.length > 0) {
+        edges = edges.map((edge: Edge) =>
+          edge.source === upstream.id && edge.sourceHandle === successHandle
+            ? {...edge, id: `${upstream.id}->${entryId}__autowire`, target: entryId}
+            : edge,
+        );
+      } else {
+        edges.push(makeEdge(`${upstream.id}->${entryId}__autowire`, upstream.id, successHandle, entryId, edgeStyle));
+      }
+
+      nodeOnSuccess.set(upstream.id, entryId);
+    }
+  }
+
+  // Pass C: resolve a cluster executor's literal "END" onSuccess to the END node found by type
+  // (create-flow templates use the id "end", so a literal match in edge generation misses it).
+  const endNode: Node | undefined = resultNodes.find((node: Node) => node.type === StepTypes.End);
+
+  if (endNode) {
+    resultNodes.forEach((node: Node) => {
+      if (!clusterIds.has(node.id) || nodesToDrop.has(node.id)) {
+        return;
+      }
+
+      if ((node as ActionCarrier).data?.action?.onSuccess === 'END') {
+        const source: string = handleId(node.id, 'success');
+        const alreadyWired: boolean = edges.some(
+          (edge: Edge) => edge.source === node.id && edge.sourceHandle === source,
+        );
+
+        if (!alreadyWired) {
+          edges.push(makeEdge(`${node.id}->${endNode.id}__end`, node.id, source, endNode.id, edgeStyle));
+        }
+
+        nodeOnSuccess.set(node.id, endNode.id);
+      }
+    });
+  }
+
+  const finalNodes: Node[] = resultNodes
+    .filter((node: Node) => !nodesToDrop.has(node.id))
+    .map((node: Node) => {
+      const action = (node as ActionCarrier).data?.action;
+
+      if (!action) {
+        return node;
+      }
+
+      const current: string | undefined = action.onSuccess;
+      let next: string | undefined;
+
+      if (nodeOnSuccess.has(node.id)) {
+        next = nodeOnSuccess.get(node.id);
+      } else if (current !== undefined && remapTarget.has(current)) {
+        next = remapTarget.get(current);
+      }
+
+      if (next === undefined || next === current) {
+        return node;
+      }
+
+      return {...node, data: {...node.data, action: {...action, onSuccess: next}}};
+    });
+  const finalIds = new Set<string>(finalNodes.map((node: Node) => node.id));
+  const seen = new Set<string>();
+
+  const finalEdges: Edge[] = edges
+    .filter((edge: Edge) => finalIds.has(edge.source) && finalIds.has(edge.target))
+    .filter((edge: Edge) => {
+      const key = `${edge.source}|${edge.sourceHandle ?? ''}|${edge.target}`;
+
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+
+      return true;
+    });
+
+  return {nodes: finalNodes, edges: finalEdges};
+};
+
+export default autoWireWidget;

--- a/frontend/apps/console/src/features/login-flow/data/widgets.json
+++ b/frontend/apps/console/src/features/login-flow/data/widgets.json
@@ -83,6 +83,15 @@
     "config": {
       "data": {
         "__generationMeta__": {
+          "autoWire": {
+            "reuse": [
+              {
+                "stepRef": "AUTH_ASSERT_EXECUTOR_ID",
+                "matchBy": "executorName",
+                "match": "AuthAssertExecutor"
+              }
+            ]
+          },
           "defaultPropertySelectorId": "{{GOOGLE_EXECUTION_STEP_ID}}",
           "replacers": [
             {
@@ -191,6 +200,15 @@
     "config": {
       "data": {
         "__generationMeta__": {
+          "autoWire": {
+            "reuse": [
+              {
+                "stepRef": "AUTH_ASSERT_EXECUTOR_ID",
+                "matchBy": "executorName",
+                "match": "AuthAssertExecutor"
+              }
+            ]
+          },
           "defaultPropertySelectorId": "{{GITHUB_EXECUTION_STEP_ID}}",
           "replacers": [
             {
@@ -299,6 +317,15 @@
     "config": {
       "data": {
         "__generationMeta__": {
+          "autoWire": {
+            "reuse": [
+              {
+                "stepRef": "AUTH_ASSERT_EXECUTOR_ID",
+                "matchBy": "executorName",
+                "match": "AuthAssertExecutor"
+              }
+            ]
+          },
           "defaultPropertySelectorId": "{{EUDI_EXECUTION_STEP_ID}}",
           "replacers": [
             {
@@ -461,6 +488,15 @@
     "config": {
       "data": {
         "__generationMeta__": {
+          "autoWire": {
+            "reuse": [
+              {
+                "stepRef": "AUTH_ASSERT_EXECUTOR_ID",
+                "matchBy": "executorName",
+                "match": "AuthAssertExecutor"
+              }
+            ]
+          },
           "replacers": [
             {
               "key": "MOBILE_NUMBER_VIEW_ID",
@@ -756,6 +792,15 @@
     "config": {
       "data": {
         "__generationMeta__": {
+          "autoWire": {
+            "reuse": [
+              {
+                "stepRef": "AUTH_ASSERT_EXECUTOR_ID",
+                "matchBy": "executorName",
+                "match": "AuthAssertExecutor"
+              }
+            ]
+          },
           "replacers": [
             {
               "key": "EMAIL_VIEW_ID",
@@ -1061,6 +1106,15 @@
     "config": {
       "data": {
         "__generationMeta__": {
+          "autoWire": {
+            "reuse": [
+              {
+                "stepRef": "AUTH_ASSERT_EXECUTOR_ID",
+                "matchBy": "executorName",
+                "match": "AuthAssertExecutor"
+              }
+            ]
+          },
           "defaultPropertySelectorId": "{{PASSKEY_CHALLENGE_EXECUTOR_ID}}",
           "replacers": [
             {
@@ -1435,6 +1489,15 @@
     "config": {
       "data": {
         "__generationMeta__": {
+          "autoWire": {
+            "reuse": [
+              {
+                "stepRef": "AUTH_ASSERT_EXECUTOR_ID",
+                "matchBy": "executorName",
+                "match": "AuthAssertExecutor"
+              }
+            ]
+          },
           "replacers": [
             {
               "key": "EMAIL_VIEW_ID",
@@ -1734,7 +1797,26 @@
               "key": "PROVISIONING_PROMPT_STEP_ID",
               "type": "ID"
             }
-          ]
+          ],
+          "autoWire": {
+            "entry": {
+              "stepRef": "PROVISIONING_EXECUTOR_STEP_ID"
+            },
+            "exit": {
+              "stepRef": "PROVISIONING_EXECUTOR_STEP_ID",
+              "handle": "success"
+            },
+            "spliceAfter": [
+              {
+                "executorName": "AuthorizationExecutor"
+              }
+            ],
+            "spliceBefore": [
+              {
+                "executorName": "AuthAssertExecutor"
+              }
+            ]
+          }
         },
         "steps": [
           {
@@ -1821,6 +1903,155 @@
                       }
                     }
                   ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "resourceType": "WIDGET",
+    "category": "FLOW",
+    "type": "CONSENT",
+    "display": {
+      "label": "User Consent",
+      "description": "Prompt the user to consent to sharing requested attributes with the application",
+      "image": "assets/images/icons/stamp.svg",
+      "showOnResourcePanel": true
+    },
+    "config": {
+      "data": {
+        "__generationMeta__": {
+          "defaultPropertySelectorId": "{{CONSENT_EXECUTOR_STEP_ID}}",
+          "replacers": [
+            {
+              "key": "CONSENT_EXECUTOR_STEP_ID",
+              "type": "ID",
+              "prefix": "consent_check"
+            },
+            {
+              "key": "CONSENT_VIEW_STEP_ID",
+              "type": "ID",
+              "prefix": "consent_view"
+            }
+          ],
+          "autoWire": {
+            "entry": {
+              "stepRef": "CONSENT_EXECUTOR_STEP_ID"
+            },
+            "exit": {
+              "stepRef": "CONSENT_EXECUTOR_STEP_ID",
+              "handle": "success"
+            },
+            "spliceAfter": [
+              {
+                "executorName": "AuthorizationExecutor"
+              }
+            ],
+            "spliceBefore": [
+              {
+                "executorName": "AuthAssertExecutor"
+              }
+            ]
+          }
+        },
+        "steps": [
+          {
+            "id": "{{CONSENT_EXECUTOR_STEP_ID}}",
+            "type": "TASK_EXECUTION",
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 760,
+              "y": 360
+            },
+            "data": {
+              "action": {
+                "type": "EXECUTOR",
+                "executor": {
+                  "name": "ConsentExecutor"
+                },
+                "onSuccess": "",
+                "onFailure": "",
+                "onIncomplete": "{{CONSENT_VIEW_STEP_ID}}"
+              },
+              "properties": {
+                "timeout": "0"
+              }
+            }
+          },
+          {
+            "id": "{{CONSENT_VIEW_STEP_ID}}",
+            "type": "VIEW",
+            "size": {
+              "width": 350,
+              "height": 500
+            },
+            "position": {
+              "x": 1120,
+              "y": 100
+            },
+            "data": {
+              "components": [
+                {
+                  "id": "{{ID}}",
+                  "category": "DISPLAY",
+                  "type": "TEXT",
+                  "variant": "HEADING_3",
+                  "label": "{{meta(application.name)}} wants to access your account"
+                },
+                {
+                  "id": "{{ID}}",
+                  "category": "DISPLAY",
+                  "type": "TEXT",
+                  "variant": "BODY_1",
+                  "label": "Please review the information requested by the application and provide your consent to proceed."
+                },
+                {
+                  "id": "{{ID}}",
+                  "category": "BLOCK",
+                  "type": "BLOCK",
+                  "components": [
+                    {
+                      "id": "{{ID}}",
+                      "category": "DISPLAY",
+                      "type": "CONSENT"
+                    },
+                    {
+                      "id": "{{ID}}",
+                      "category": "ACTION",
+                      "type": "ACTION",
+                      "variant": "PRIMARY",
+                      "eventType": "SUBMIT",
+                      "label": "Allow",
+                      "action": {
+                        "type": "NEXT",
+                        "onSuccess": "{{CONSENT_EXECUTOR_STEP_ID}}"
+                      }
+                    },
+                    {
+                      "id": "{{ID}}",
+                      "category": "ACTION",
+                      "type": "ACTION",
+                      "variant": "SECONDARY",
+                      "eventType": "SUBMIT",
+                      "label": "Deny",
+                      "action": {
+                        "type": "NEXT",
+                        "onSuccess": "{{CONSENT_EXECUTOR_STEP_ID}}"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "id": "{{ID}}",
+                  "category": "DISPLAY",
+                  "type": "RICH_TEXT",
+                  "label": "<p class=\"rich-text-paragraph\"><span class=\"rich-text-pre-wrap\">Go back to </span><a href=\"{{meta(application.url)}}\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Application</span></a></p>"
                 }
               ]
             }

--- a/frontend/apps/console/src/features/login-flow/hooks/__tests__/useTemplateAndWidgetLoading.test.ts
+++ b/frontend/apps/console/src/features/login-flow/hooks/__tests__/useTemplateAndWidgetLoading.test.ts
@@ -771,6 +771,60 @@ describe('useTemplateAndWidgetLoading', () => {
       const otherNode = nodes.find((n) => n.id === 'other-node');
       expect(otherNode).toBeDefined();
     });
+
+    it('auto-wires a consent-shaped widget between the authorization executor and the auth assert generator', () => {
+      const {result} = renderUseTemplateAndWidgetLoading();
+
+      const widget = {
+        id: 'consent-widget',
+        config: {
+          data: {
+            __generationMeta__: {
+              defaultPropertySelectorId: 'consent_check',
+              autoWire: {
+                entry: {stepRef: 'consent_check'},
+                exit: {stepRef: 'consent_check', handle: 'success'},
+                spliceAfter: [{executorName: 'AuthorizationExecutor'}],
+                spliceBefore: [{executorName: 'AuthAssertExecutor'}],
+              },
+            },
+            steps: [
+              {
+                id: 'consent_check',
+                type: StepTypes.Execution,
+                position: {x: 0, y: 0},
+                data: {action: {type: 'EXECUTOR', executor: {name: 'ConsentExecutor'}, onSuccess: ''}},
+              },
+              {id: 'consent_view', type: StepTypes.View, position: {x: 0, y: 0}, data: {components: []}},
+            ],
+          },
+        },
+      } as unknown as Widget;
+
+      const currentNodes: Node[] = [
+        createMockNode({
+          id: 'authz',
+          type: StepTypes.Execution,
+          data: {action: {executor: {name: 'AuthorizationExecutor'}}},
+        }),
+        createMockNode({
+          id: 'auth_assert',
+          type: StepTypes.Execution,
+          data: {action: {executor: {name: 'AuthAssertExecutor'}}},
+        }),
+        createMockNode({id: 'end', type: StepTypes.End}),
+      ];
+      const currentEdges: Edge[] = [
+        {id: 'authz->auth_assert', source: 'authz', target: 'auth_assert', sourceHandle: 'authz_NEXT', type: 'default'},
+      ];
+
+      const [nodes, edges] = result.current.handleWidgetLoad(widget, {} as Resource, currentNodes, currentEdges);
+
+      expect(nodes.some((n) => n.id === 'consent_check')).toBe(true);
+      expect(edges.some((e) => e.source === 'authz' && e.target === 'auth_assert')).toBe(false);
+      expect(edges.some((e) => e.source === 'authz' && e.target === 'consent_check')).toBe(true);
+      expect(edges.some((e) => e.source === 'consent_check' && e.target === 'auth_assert')).toBe(true);
+    });
   });
 
   describe('handleResourceAdd', () => {

--- a/frontend/apps/console/src/features/login-flow/hooks/useTemplateAndWidgetLoading.ts
+++ b/frontend/apps/console/src/features/login-flow/hooks/useTemplateAndWidgetLoading.ts
@@ -30,6 +30,7 @@ import {ResourceTypes, type Resource, type Resources} from '@/features/flows/mod
 import {StepTypes, type Step, type StepData} from '@/features/flows/models/steps';
 import {type Template, TemplateTypes, type TemplateReplacer} from '@/features/flows/models/templates';
 import type {Widget} from '@/features/flows/models/widget';
+import autoWireWidget, {type AutoWireMeta} from '@/features/flows/utils/autoWireWidget';
 import generateIdsForResources from '@/features/flows/utils/generateIdsForResources';
 import resolveComponentMetadata from '@/features/flows/utils/resolveComponentMetadata';
 import resolveStepMetadata from '@/features/flows/utils/resolveStepMetadata';
@@ -186,6 +187,7 @@ const useTemplateAndWidgetLoading = (props: UseTemplateAndWidgetLoadingProps): U
         __generationMeta__?: {
           replacers?: TemplateReplacer[];
           defaultPropertySelectorId?: string;
+          autoWire?: AutoWireMeta;
         };
       };
 
@@ -292,6 +294,15 @@ const useTemplateAndWidgetLoading = (props: UseTemplateAndWidgetLoadingProps): U
 
       newEdges = [...newEdges, ...generateUnconnectedEdges(newEdges, updatedNodes, edgeStyle)];
 
+      const wired = autoWireWidget(
+        currentNodes,
+        updatedNodes,
+        newEdges,
+        widgetFlow.__generationMeta__?.autoWire,
+        replacedPlaceholders,
+        edgeStyle,
+      );
+
       // Check if `defaultPropertySelector.id` is in the `replacedPlaceholders`.
       // If so, update them with the replaced value.
       if (defaultPropertySelector && 'id' in defaultPropertySelector) {
@@ -325,7 +336,7 @@ const useTemplateAndWidgetLoading = (props: UseTemplateAndWidgetLoadingProps): U
         }
       }
 
-      return [updatedNodes, newEdges, defaultPropertySelector, defaultPropertySelectorStepId];
+      return [wired.nodes, wired.edges, defaultPropertySelector, defaultPropertySelectorStepId];
     },
     [resources, edgeStyle],
   );


### PR DESCRIPTION
### Purpose

Adds a **User Consent** widget to the flow builder and, more broadly, introduces automatic wiring so dropped widgets integrate into the existing flow instead of landing as disconnected node clusters.

Resolves the consent request in #3778, and fixes the long-standing rough edge where standalone widgets (consent, provisioning) drop in unconnected and federation widgets duplicate the Auth Assert node.

**What the user sees**
- A new **User Consent** widget under the flow builder **Widgets** section. Dropping it adds a pre-wired `ConsentExecutor` + consent screen (Allow/Deny), and connects it into the flow: after the **Authorization** executor and before the **Auth Assert Generator** when those are present.
- Federation widgets (Google, GitHub, EUDI, SMS/Email OTP, Passkey, Magic Link) no longer create a second Auth Assert node when the flow already has one; they wire into the existing one.

### Approach

- **Consent widget**: a new `CONSENT` entry in `login-flow/data/widgets.json` (registered via `WidgetTypes.Consent`, allowed on the canvas). It rides entirely on the existing backend consent machinery (`ConsentExecutor`, `CONSENT_INPUT`), so no backend changes are needed.
- **Auto-wiring**: a small declarative `autoWire` block in each widget's `__generationMeta__`, consumed by a new pure util `flows/utils/autoWireWidget.ts` invoked from `handleWidgetLoad`:
    - `spliceAfter` / `spliceBefore` — ordered upstream/downstream candidate lists. The entry is fed from the first present upstream node (redirecting its success edge) and the exit connects to the first present downstream node. Each side is left unconnected when no candidate matches, so the user wires it wherever they want. Consent/provisioning use Authorization (upstream) and Auth Assert (downstream).
    - `reuse` — drops a widget's bundled duplicate (e.g. federation Auth Assert) and rewires onto the pre-existing node.
    - Also resolves the widget path's `"END"` id to the END node by type, fixing exit wiring on create-flow templates that use the lowercase `end` id.
- Widgets without `autoWire` (Username+Password merge widget, the CALL-exit link widgets) behave exactly as before.

Auto-wiring is fully declarative, so future widgets only add an `autoWire` block rather than new code.

### Related Issues
- Fixes #3778

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. Updated `docs/content/guides/guides/consent.mdx` to present the widget as the primary path.
- [x] Tests provided.
    - [x] Unit Tests (`autoWireWidget.test.ts`; extended `useTemplateAndWidgetLoading` and `widgetUtils` tests)
- [ ] Breaking changes. (Not applicable)

### Security checks
- [x] Followed secure coding standards.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
