### PR TITLE
Fix patch coverage false negative on partial Codecov reports and extract the gate into a composite action

### DIFF
--- a/.github/actions/patch-coverage-gate/action.yml
+++ b/.github/actions/patch-coverage-gate/action.yml
@@ -1,0 +1,56 @@
+name: Patch Coverage Gate
+description: >-
+  Enforces patch coverage for the current diff. Uses Codecov's own patch
+  coverage number via its public API when a fully processed report is
+  available, and computes patch coverage locally with diff-cover from the
+  archived coverage artifacts otherwise, so the check always reports a result
+  and can never hang on Codecov's backend.
+inputs:
+  fail-under:
+    description: 'Minimum patch coverage percentage required to pass'
+    required: false
+    default: '79'
+  pr-number:
+    description: >-
+      Pull request number used to query the Codecov API. Leave empty to skip
+      the API and compute patch coverage locally (e.g. on merge queue runs).
+    required: false
+    default: ''
+  head-sha:
+    description: 'Commit SHA whose Codecov report is polled'
+    required: true
+  base-ref:
+    description: 'Git ref or SHA the diff is compared against'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    # If this step fails, patch coverage is authoritatively below the
+    # threshold and the composite stops here. If it succeeds without
+    # resolving (Codecov unavailable or report incomplete), the local
+    # computation below takes over.
+    - name: 🔎 Enforce Codecov patch coverage via API
+      id: codecov-api
+      if: inputs.pr-number != ''
+      shell: bash
+      env:
+        PR_NUMBER: ${{ inputs.pr-number }}
+        HEAD_SHA: ${{ inputs.head-sha }}
+        FAIL_UNDER: ${{ inputs.fail-under }}
+      run: bash "${{ github.action_path }}/check-codecov-api.sh"
+
+    - name: 📥 Download coverage artifacts
+      if: steps.codecov-api.outcome == 'skipped' || steps.codecov-api.outputs.resolved != 'true'
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      with:
+        pattern: "*coverage*"
+        path: coverage-artifacts
+
+    - name: 🛡️ Compute patch coverage locally
+      if: steps.codecov-api.outcome == 'skipped' || steps.codecov-api.outputs.resolved != 'true'
+      shell: bash
+      env:
+        BASE_REF: ${{ inputs.base-ref }}
+        FAIL_UNDER: ${{ inputs.fail-under }}
+      run: bash "${{ github.action_path }}/compute-local-patch-coverage.sh"

--- a/.github/actions/patch-coverage-gate/check-codecov-api.sh
+++ b/.github/actions/patch-coverage-gate/check-codecov-api.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Polls the Codecov API for the pull request's patch coverage and enforces it.
+#
+# Environment:
+#   PR_NUMBER, HEAD_SHA, FAIL_UNDER  - provided by the composite action
+#   GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_STEP_SUMMARY - provided by the runner
+#
+# Sets the step output resolved=true when Codecov's number was authoritative
+# (pass or fail). Exits 0 with resolved=false when Codecov cannot be trusted
+# in time, so the caller falls back to the local computation. A fetch or parse
+# failure never passes the gate.
+
+set -euo pipefail
+
+# Number of coverage uploads in a complete report; mirrors notify.after_n_builds
+# in codecov.yml. Codecov processes uploads incrementally, and a comparison
+# against a partially processed head report yields a bogus patch number
+# (e.g. 0% when only backend sessions are in but the diff is frontend-only).
+REQUIRED_SESSIONS=6
+POLL_ATTEMPTS=10
+POLL_INTERVAL_SECONDS=30
+CURL_MAX_TIME=15
+
+OWNER="${GITHUB_REPOSITORY%/*}"
+REPO="${GITHUB_REPOSITORY#*/}"
+API="https://api.codecov.io/api/v2/github/${OWNER}/repos/${REPO}"
+
+echo "resolved=false" >> "$GITHUB_OUTPUT"
+
+for attempt in $(seq 1 "$POLL_ATTEMPTS"); do
+  PROCESSED=$(curl -sf --max-time "$CURL_MAX_TIME" "${API}/commits/${HEAD_SHA}" \
+    | jq -r --argjson n "$REQUIRED_SESSIONS" \
+        'select((.totals.sessions // 0) >= $n) | .totals.coverage // empty' || true)
+  if [ -n "$PROCESSED" ]; then
+    # The head report is fully processed; read patch coverage from the
+    # comparison. A fetch or parse failure here must NOT pass the gate:
+    # leave it unresolved so the local computation runs instead.
+    COMPARE=$(curl -sf --max-time "$CURL_MAX_TIME" "${API}/compare/?pullid=${PR_NUMBER}") || COMPARE=""
+    if [ -z "$COMPARE" ]; then
+      echo "⚠️ Could not fetch the Codecov comparison; falling back to local patch coverage." | tee -a "$GITHUB_STEP_SUMMARY"
+      exit 0
+    fi
+    # Validate the comparison is structurally complete before interpreting
+    # missing patch data: totals.patch is also null when the head report has
+    # not been incorporated yet, and an error payload has no totals at all.
+    # Only a comparison whose head totals are present can be trusted to mean
+    # "no coverable lines"; anything else falls back to the local computation.
+    HEAD_INCLUDED=$(printf '%s' "$COMPARE" | jq -r 'if (.totals != null) and (.totals.head != null) then "yes" else "no" end' 2>/dev/null) || HEAD_INCLUDED="no"
+    if [ "$HEAD_INCLUDED" != "yes" ]; then
+      echo "⚠️ Incomplete Codecov comparison response; falling back to local patch coverage." | tee -a "$GITHUB_STEP_SUMMARY"
+      exit 0
+    fi
+    PATCH=$(printf '%s' "$COMPARE" | jq -r '.totals.patch.coverage' 2>/dev/null) || PATCH=""
+    PATCH_LINES=$(printf '%s' "$COMPARE" | jq -r '.totals.patch.lines // 0' 2>/dev/null) || PATCH_LINES="0"
+    # A diff with no coverable lines (comment/config/CI-only changes) has nothing
+    # to gate. Codecov signals this either as coverage null or as coverage 0 with
+    # zero patch lines.
+    if [ "$PATCH" = "null" ] || [ "$PATCH_LINES" = "0" ]; then
+      echo "resolved=true" >> "$GITHUB_OUTPUT"
+      echo "✅ Codecov reports no coverable lines in this diff." | tee -a "$GITHUB_STEP_SUMMARY"
+      exit 0
+    fi
+    if ! printf '%s' "$PATCH" | grep -qE '^[0-9]+(\.[0-9]+)?$'; then
+      echo "⚠️ Unexpected Codecov comparison response; falling back to local patch coverage." | tee -a "$GITHUB_STEP_SUMMARY"
+      exit 0
+    fi
+    echo "resolved=true" >> "$GITHUB_OUTPUT"
+    echo "Codecov patch coverage: ${PATCH}% (required: ≥ ${FAIL_UNDER}%)" | tee -a "$GITHUB_STEP_SUMMARY"
+    awk -v patch="$PATCH" -v threshold="$FAIL_UNDER" 'BEGIN{exit !(patch + 0 >= threshold + 0)}' || {
+      echo "❌ Patch coverage is below the required threshold." | tee -a "$GITHUB_STEP_SUMMARY"
+      exit 1
+    }
+    exit 0
+  fi
+  echo "Codecov has not fully processed the report yet (attempt ${attempt}/${POLL_ATTEMPTS}); retrying in ${POLL_INTERVAL_SECONDS}s..."
+  sleep "$POLL_INTERVAL_SECONDS"
+done
+
+echo "⚠️ Codecov did not process the report in time; falling back to local patch coverage." | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/patch-coverage-gate/compute-local-patch-coverage.sh
+++ b/.github/actions/patch-coverage-gate/compute-local-patch-coverage.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Computes patch coverage locally from the archived coverage artifacts with
+# diff-cover and enforces the threshold. Mirrors Codecov's combined patch
+# semantics: all backend and frontend reports feed a single diff-cover
+# invocation, so one pooled percentage covers the whole diff.
+#
+# Go cover profiles are converted to LCOV in-house (go-cover-to-lcov.awk) and
+# frontend LCOV files are used as-is, so diff-cover receives a single format
+# and no third-party converters are needed.
+#
+# Environment:
+#   BASE_REF, FAIL_UNDER  - provided by the composite action
+#   GITHUB_STEP_SUMMARY   - provided by the runner
+#
+# Expects the coverage artifacts to be downloaded under coverage-artifacts/.
+
+set -euo pipefail
+
+DIFF_COVER_VERSION="10.4.0"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pipx install "diff_cover==${DIFF_COVER_VERSION}"
+
+FILES=()
+
+# Convert Go cover profiles to LCOV with repo-relative paths. Locate profiles
+# with find so the gate does not depend on the artifacts' internal layout.
+GO_LCOV_INDEX=0
+while IFS= read -r profile; do
+  GO_LCOV_INDEX=$((GO_LCOV_INDEX + 1))
+  lcov="go-coverage-${GO_LCOV_INDEX}-lcov.info"
+  awk -f "${SCRIPT_DIR}/go-cover-to-lcov.awk" "$profile" > "$lcov"
+  FILES+=("$lcov")
+done < <(find coverage-artifacts -type f \( -name 'coverage_unit.out' -o -name 'coverage_integration.out' \) 2>/dev/null | sort)
+
+# Rewrite LCOV SF paths (absolute or app-relative) to repo-relative paths.
+for app in console gate; do
+  src=$(find "coverage-artifacts/${app}-coverage" -type f -name 'lcov.info' 2>/dev/null | head -1)
+  [ -n "$src" ] || continue
+  dst="${app}-lcov.info"
+  sed -E "s|^SF:(.*/)?frontend/apps/${app}/|SF:frontend/apps/${app}/|; t; s|^SF:|SF:frontend/apps/${app}/|" "$src" > "$dst"
+  FILES+=("$dst")
+done
+
+if [ "${#FILES[@]}" -eq 0 ]; then
+  # Fail rather than pass silently when coverable code changed but no
+  # coverage data reached the gate; passing would defeat its purpose.
+  COVERABLE=$(git diff --name-only "${BASE_REF}...HEAD" \
+    | { grep -E '^(backend/.*\.go$|frontend/apps/(console|gate)/src/.*\.(ts|tsx)$)' || true; } \
+    | { grep -vE '(^backend/tests/|_test\.go$|\.test\.(ts|tsx)$|__tests__/|__mocks__/)' || true; })
+  if [ -n "$COVERABLE" ]; then
+    echo "❌ Coverable files changed but no coverage artifacts were found." | tee -a "$GITHUB_STEP_SUMMARY"
+    exit 1
+  fi
+  echo "✅ No coverage artifacts and no coverable changes; nothing to gate." | tee -a "$GITHUB_STEP_SUMMARY"
+  exit 0
+fi
+
+STATUS=0
+diff-cover "${FILES[@]}" \
+  --compare-branch "$BASE_REF" \
+  --fail-under "$FAIL_UNDER" \
+  --exclude 'backend/tests/**' '**/*_test.go' 'tests/**' 'samples/**' 'docs/**' 'api/**' \
+            '**/*.test.ts' '**/*.test.tsx' '**/__tests__/**' '**/__mocks__/**' \
+  --format markdown:patch-coverage.md || STATUS=$?
+cat patch-coverage.md >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+exit "$STATUS"

--- a/.github/actions/patch-coverage-gate/go-cover-to-lcov.awk
+++ b/.github/actions/patch-coverage-gate/go-cover-to-lcov.awk
@@ -1,0 +1,40 @@
+# Converts a Go cover profile to LCOV so diff-cover can consume backend and
+# frontend coverage in a single invocation (it cannot mix LCOV and XML).
+# Maps Go import paths to repo-relative paths while emitting. Blocks may
+# overlap on a line; a line counts as covered if any block covering it has a
+# hit count > 0, so keep the maximum hit count seen per line.
+/^mode:/ { next }
+{
+  # Only convert lines matching the full Go cover profile block shape
+  # "<file>:<sl>.<sc>,<el>.<ec> <stmts> <hits>"; skip anything else so a
+  # blank or malformed line cannot become a bogus LCOV record.
+  colon = match($0, /:[0-9]+\.[0-9]+,[0-9]+\.[0-9]+ [0-9]+ [0-9]+$/)
+  if (colon <= 1) next
+  file = substr($0, 1, colon - 1)
+  sub(/^github\.com\/thunder-id\/thunderid\//, "", file)
+  if (file !~ /^backend\//) file = "backend/" file
+  rest = substr($0, colon + 1)
+  split(rest, parts, " ")
+  split(parts[1], range, ",")
+  split(range[1], s, ".")
+  split(range[2], e, ".")
+  hitcount = parts[3]
+  for (l = s[1] + 0; l <= e[1] + 0; l++) {
+    key = file SUBSEP l
+    # Record each file's line numbers on first sight so END can emit them
+    # in linear time instead of scanning the whole hits map per file.
+    if (!(key in hits)) lines[file] = lines[file] " " l
+    if (!(key in hits) || hitcount + 0 > hits[key]) hits[key] = hitcount + 0
+    seen[file] = 1
+  }
+}
+END {
+  for (file in seen) {
+    print "SF:" file
+    n = split(lines[file], nums, " ")
+    for (i = 1; i <= n; i++) {
+      if (nums[i] != "") print "DA:" nums[i] "," hits[file SUBSEP nums[i]]
+    }
+    print "end_of_record"
+  }
+}

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -492,19 +492,15 @@ jobs:
     name: 🛡️ Patch Coverage Gate
     # Deterministic patch coverage check that always reports, unlike the external
     # codecov/patch status which can hang at "Expected" (fork PRs, merge queue
-    # commits, Codecov processing stalls). Enforces Codecov's own patch coverage
-    # number via its public API when available, and computes patch coverage
-    # locally from the coverage artifacts when Codecov has not processed the
-    # report in time. Mirrors coverage.status.patch.default in codecov.yml
-    # (target 80%, threshold 1%).
-    needs: [build, test-integration, test-frontend-console-app, test-frontend-gate-app]
-    if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.build.result == 'success' && needs.test-integration.result == 'success' && needs.test-frontend-console-app.result == 'success' && needs.test-frontend-gate-app.result == 'success' }}
+    # commits, Codecov processing stalls). Mirrors coverage.status.patch.default
+    # in codecov.yml (target 80%, threshold 1%). The enforcement logic lives in
+    # .github/actions/patch-coverage-gate.
+    needs: [build, test-integration, test-frontend-console-app, test-frontend-gate-app, upload-frontend-coverage]
+    if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.build.result == 'success' && needs.test-integration.result == 'success' && needs.test-frontend-console-app.result == 'success' && needs.test-frontend-gate-app.result == 'success' && needs.upload-frontend-coverage.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
       contents: read
-    env:
-      FAIL_UNDER: "79"
     steps:
       - name: 📥 Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -512,123 +508,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: 🔎 Enforce Codecov patch coverage via API
-        id: codecov-api
-        # Fork PRs upload tokenlessly, so their reports can exist on Codecov
-        # too; poll for every PR and fall back to the local computation only
-        # when Codecov has not processed the report in time.
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          OWNER="${GITHUB_REPOSITORY%/*}"
-          REPO="${GITHUB_REPOSITORY#*/}"
-          API="https://api.codecov.io/api/v2/github/${OWNER}/repos/${REPO}"
-          echo "resolved=false" >> "$GITHUB_OUTPUT"
-          for attempt in $(seq 1 10); do
-            PROCESSED=$(curl -sf --max-time 15 "${API}/commits/${HEAD_SHA}" | jq -r '.totals.coverage // empty' || true)
-            if [ -n "$PROCESSED" ]; then
-              # The head report exists; read patch coverage from the comparison.
-              # A fetch or parse failure here must NOT pass the gate: leave it
-              # unresolved so the local computation runs instead.
-              COMPARE=$(curl -sf --max-time 15 "${API}/compare/?pullid=${PR_NUMBER}") || COMPARE=""
-              if [ -z "$COMPARE" ]; then
-                echo "⚠️ Could not fetch the Codecov comparison; falling back to local patch coverage." | tee -a "$GITHUB_STEP_SUMMARY"
-                exit 0
-              fi
-              PATCH=$(printf '%s' "$COMPARE" | jq -r '.totals.patch.coverage' 2>/dev/null) || PATCH=""
-              PATCH_LINES=$(printf '%s' "$COMPARE" | jq -r '.totals.patch.lines // 0' 2>/dev/null) || PATCH_LINES="0"
-              # A diff with no coverable lines (comment/config/CI-only changes) has nothing to gate.
-              # Codecov signals this either as coverage null or as coverage 0 with zero patch lines.
-              if [ "$PATCH" = "null" ] || [ "$PATCH_LINES" = "0" ]; then
-                echo "resolved=true" >> "$GITHUB_OUTPUT"
-                echo "✅ Codecov reports no coverable lines in this diff." | tee -a "$GITHUB_STEP_SUMMARY"
-                exit 0
-              fi
-              if ! printf '%s' "$PATCH" | grep -qE '^[0-9]+(\.[0-9]+)?$'; then
-                echo "⚠️ Unexpected Codecov comparison response; falling back to local patch coverage." | tee -a "$GITHUB_STEP_SUMMARY"
-                exit 0
-              fi
-              echo "resolved=true" >> "$GITHUB_OUTPUT"
-              echo "Codecov patch coverage: ${PATCH}% (required: ≥ ${FAIL_UNDER}%)" | tee -a "$GITHUB_STEP_SUMMARY"
-              awk "BEGIN{exit !(${PATCH} >= ${FAIL_UNDER})}" || {
-                echo "❌ Patch coverage is below the required threshold." | tee -a "$GITHUB_STEP_SUMMARY"
-                exit 1
-              }
-              exit 0
-            fi
-            echo "Codecov has not processed the report yet (attempt ${attempt}/10); retrying in 30s..."
-            sleep 30
-          done
-          echo "⚠️ Codecov did not process the report in time; falling back to local patch coverage." | tee -a "$GITHUB_STEP_SUMMARY"
-
-      - name: 📥 Download coverage artifacts
-        if: ${{ success() && (github.event_name == 'merge_group' || steps.codecov-api.outcome == 'skipped' || steps.codecov-api.outputs.resolved != 'true') }}
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - name: 🛡️ Enforce Patch Coverage
+        uses: ./.github/actions/patch-coverage-gate
         with:
-          pattern: "*coverage*"
-          path: coverage-artifacts
-
-      - name: ⚙️ Set up Go Environment
-        if: ${{ success() && (github.event_name == 'merge_group' || steps.codecov-api.outcome == 'skipped' || steps.codecov-api.outputs.resolved != 'true') }}
-        uses: ./.github/actions/setup-go
-
-      - name: 🛡️ Compute patch coverage locally
-        if: ${{ success() && (github.event_name == 'merge_group' || steps.codecov-api.outcome == 'skipped' || steps.codecov-api.outputs.resolved != 'true') }}
-        env:
-          BASE_REF: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || format('origin/{0}', github.base_ref) }}
-        run: |
-          set -e
-          pipx install "diff_cover==10.4.0"
-          pipx install "lcov_cobertura==2.1.1"
-          FILES=()
-          # Convert Go cover profiles to Cobertura XML and map Go import paths
-          # to repo-relative paths so diff-cover can match them to the git diff.
-          # Locate profiles with find so the gate does not depend on the
-          # artifacts' internal directory layout.
-          GO_XML_INDEX=0
-          while IFS= read -r profile; do
-            GO_XML_INDEX=$((GO_XML_INDEX + 1))
-            xml="go-coverage-${GO_XML_INDEX}.xml"
-            (cd backend && go run github.com/boumenot/gocover-cobertura@v1.5.0) < "$profile" > "$xml"
-            sed -i -E 's#filename="(github\.com/thunder-id/thunderid/|backend/)?#filename="backend/#g' "$xml"
-            FILES+=("$xml")
-          done < <(find coverage-artifacts -type f \( -name 'coverage_unit.out' -o -name 'coverage_integration.out' \) 2>/dev/null | sort)
-          # Rewrite LCOV SF paths (absolute or app-relative) to repo-relative
-          # paths, then convert to Cobertura XML: diff-cover cannot mix LCOV
-          # and XML reports in a single invocation, and a single invocation is
-          # required for combined patch coverage semantics matching Codecov.
-          for app in console gate; do
-            src=$(find "coverage-artifacts/${app}-coverage" -type f -name 'lcov.info' 2>/dev/null | head -1)
-            [ -n "$src" ] || continue
-            normalized="${app}-lcov.info"
-            sed -E "s|^SF:(.*/)?frontend/apps/${app}/|SF:frontend/apps/${app}/|; t; s|^SF:|SF:frontend/apps/${app}/|" "$src" > "$normalized"
-            lcov_cobertura "$normalized" --base-dir . --output "${app}-coverage.xml"
-            FILES+=("${app}-coverage.xml")
-          done
-          if [ "${#FILES[@]}" -eq 0 ]; then
-            # Fail rather than pass silently when coverable code changed but no
-            # coverage data reached the gate; passing would defeat its purpose.
-            COVERABLE=$(git diff --name-only "${BASE_REF}...HEAD" \
-              | { grep -E '^(backend/.*\.go|frontend/apps/(console|gate)/src/)' || true; } \
-              | { grep -vE '(^backend/tests/|_test\.go$|\.test\.(ts|tsx)$|__tests__/|__mocks__/)' || true; })
-            if [ -n "$COVERABLE" ]; then
-              echo "❌ Coverable files changed but no coverage artifacts were found." | tee -a "$GITHUB_STEP_SUMMARY"
-              exit 1
-            fi
-            echo "✅ No coverage artifacts and no coverable changes; nothing to gate." | tee -a "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-          STATUS=0
-          diff-cover "${FILES[@]}" \
-            --compare-branch "$BASE_REF" \
-            --fail-under "$FAIL_UNDER" \
-            --exclude 'backend/tests/**' '**/*_test.go' 'tests/**' 'samples/**' 'docs/**' 'api/**' \
-                      '**/*.test.ts' '**/*.test.tsx' '**/__tests__/**' '**/__mocks__/**' \
-            --format markdown:patch-coverage.md || STATUS=$?
-          cat patch-coverage.md >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
-          exit "$STATUS"
+          fail-under: "79"
+          pr-number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
+          head-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          base-ref: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || format('origin/{0}', github.base_ref) }}
 
   build_samples:
     name: 🛠️ Build Sample Apps


### PR DESCRIPTION
### Purpose

The Patch Coverage Gate produced a false negative on #4264: it read a 0% patch coverage number from Codecov's comparison API while the head report was only partially processed (backend sessions in, frontend sessions still pending, on a frontend-only diff). The real number, once all six uploads were processed, was 92.1%.

This PR also extracts the gate's inline bash (~120 lines across two workflow steps) into a dedicated composite action so the logic is reviewable, shellcheck-able, and reusable.

### Approach

- The Codecov readiness probe now requires `totals.sessions >= 6` (mirroring `notify.after_n_builds` in codecov.yml) before trusting the comparison, so a partially processed report is treated the same as an unprocessed one: keep polling, then fall back to the local computation.
- The gate job now `needs` `upload-frontend-coverage`, so polling cannot start before all six uploads have been sent.
- The enforcement logic moves to `.github/actions/patch-coverage-gate/` (an `action.yml` plus `check-codecov-api.sh`, `compute-local-patch-coverage.sh`, and `go-cover-to-lcov.awk`), following the existing composite action conventions in `.github/actions/`. The workflow job shrinks to a checkout plus one `uses:` step.
- Go cover profiles are now converted to LCOV in-house (a small awk script) instead of converting everything to Cobertura XML. diff-cover consumes a single format, the `gocover-cobertura` and `lcov-cobertura` dependencies disappear, and `diff-cover` remains the only external tool in the fallback. Verified end to end locally: a mixed backend/frontend diff produces the same combined percentage, per-file attribution, and threshold verdict as the previous XML pipeline, and all three Go path forms (import path, module-relative, repo-relative) map to the same repo-relative file.

### Related Issues
- N/A

### Related PRs
- Follow-up to #4245. Fixes the false negative observed on #4264.

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified. (The jq session filter was verified against partial and complete report payloads; the failed #4264 gate run was re-run and passed once the report completed. YAML and bash syntax validated.)
- [ ] Documentation provided.
- [ ] Tests provided. (CI workflow change.)
- [ ] Breaking changes. (N/A)

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated patch coverage enforcement in CI with a configurable default threshold of 79%.
  * Patch coverage results are surfaced in the workflow summary.
* **Bug Fixes**
  * Improved handling when Codecov processing is delayed or unreliable, avoiding misleading gate outcomes.
  * Gate now passes when no coverable lines are detected.
* **Changes**
  * CI workflow now delegates patch coverage enforcement to a reusable action.
  * Patch coverage runs only after frontend coverage upload succeeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->