### PR TITLE
Speed up PR builder with pnpm/turbo caching, job consolidation, and parallel E2E workers

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -16,12 +16,15 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-      with:
-        node-version: ${{ inputs.node-version }}
-
+    # pnpm must be installed before setup-node so that `cache: pnpm` can
+    # locate the store to cache.
     - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
       with:
         run_install: false
-        cache_dependency_path: pnpm-lock.yaml
         version: ${{ inputs.pnpm-version }}
+
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: pnpm
+        cache-dependency-path: pnpm-lock.yaml

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -27,17 +27,44 @@ env:
   PRODUCT_NAME: "ThunderID"
   PRODUCT_NAME_LOWER: "thunderid"
   NODE_VERSION: "lts/*"
-  PNPM_VERSION: "latest"
 
 jobs:
-  security-audit:
-    name: 🔒 Security Audit
+  # Single job for the fast gate checks (security audit, dependency review, and
+  # change detection for docs/PowerShell) so they occupy one runner slot instead
+  # of four. Runner concurrency is shared across all PRs, so fewer jobs per run
+  # directly reduces queue time on busy periods.
+  preflight:
+    name: 🛡️ Preflight Checks
     if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+    outputs:
+      docs-changed: ${{ steps.filter.outputs.docs }}
+      powershell-changed: ${{ steps.filter.outputs.powershell }}
     steps:
       - name: 📥 Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: 🔍 Detect Docs and PowerShell Changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        id: filter
+        with:
+          base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
+          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
+          filters: |
+            docs:
+              - 'docs/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+            powershell:
+              - '**.ps1'
+              - '.github/workflows/windows-powershell-validation.yml'
 
       - name: ⚙️ Set up Node.js and pnpm
         uses: ./.github/actions/setup-pnpm
@@ -50,18 +77,6 @@ jobs:
           # CVE ignores are managed via auditConfig.ignoreCves in pnpm-workspace.yaml
           # Remove `--ignore-registry-errors` once pnpm 11 is generally available. Tracker: https://github.com/pnpm/pnpm/issues/11265
           pnpm audit --ignore-registry-errors --audit-level=high
-
-  dependency-review:
-    name: 🔎 Dependency Review
-    if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: 📥 Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: 🔎 Dependency Review
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
@@ -160,6 +175,12 @@ jobs:
       - name: 🔍 Run Backend Linter
         run: make lint_backend
 
+      # The frontend build is needed because linting is type-aware: apps resolve
+      # @thunderid/* package types from their built dist output. The Turbo cache
+      # makes it a near no-op when nothing relevant changed.
+      - name: 🗂️ Set up Turbo Cache
+        uses: ./.github/actions/setup-turbo-cache
+
       - name: 🧩 Install Dependencies & Build Frontend
         run: |
           make build_frontend
@@ -176,8 +197,7 @@ jobs:
 
   build:
     name: 🛠️ Build Product
-    needs: [detect-code-changes]
-    if: ${{ always() && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group') && (needs.detect-code-changes.result == 'skipped' || needs.detect-code-changes.outputs.should-run == 'true') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -252,8 +272,7 @@ jobs:
 
   test-backend-unit:
     name: 🧪 Backend Unit Tests
-    needs: [detect-code-changes]
-    if: ${{ always() && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group') && (needs.detect-code-changes.result == 'skipped' || needs.detect-code-changes.outputs.should-run == 'true') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -310,45 +329,9 @@ jobs:
           path: backend/coverage_unit.out
           if-no-files-found: error
 
-  detect-code-changes:
-    name: 🔍 Detect Code Changes
-    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      should-run: ${{ steps.filter.outputs.code }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: 🔍 Detect non-docs file changes
-        id: filter
-        # TODO: Temporarily always treat as code changes to unblock docs-only PRs hanging on the
-        # codecov/patch status check. Revisit once the workflow_run-based fix is in place.
-        # env:
-        #   BASE_SHA: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
-        run: |
-          # git fetch --depth=1 origin "$BASE_SHA"
-          # CHANGED=$(git diff --name-only "$BASE_SHA" HEAD)
-          # echo "Changed files:"
-          # echo "$CHANGED"
-          # NON_DOCS=$(echo "$CHANGED" | grep -v '^docs/' | grep -v -i 'readme\.md' | grep -c . || true)
-          # echo "Non-docs changed file count: $NON_DOCS"
-          # if [ "$NON_DOCS" -gt 0 ]; then
-          #   echo "code=true" >> $GITHUB_OUTPUT
-          # else
-          #   echo "code=false" >> $GITHUB_OUTPUT
-          # fi
-          echo "code=true" >> $GITHUB_OUTPUT
-      # - name: ✅ Code changes detected
-      #   if: steps.filter.outputs.code == 'true'
-      #   run: echo "Non-documentation files changed - frontend and E2E tests will run"
-      # - name: ⏭️ Docs-only changes
-      #   if: steps.filter.outputs.code != 'true'
-      #   run: echo "Only documentation changes detected - skipping frontend and E2E tests"
-
   test-frontend-packages:
     name: 🧪 Frontend Packages Tests
-    needs: [detect-code-changes]
-    if: ${{ always() && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group') && (needs.detect-code-changes.result == 'skipped' || needs.detect-code-changes.outputs.should-run == 'true') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
@@ -410,8 +393,7 @@ jobs:
 
   test-frontend-gate-app:
     name: 🧪 Gate App Tests with Coverage
-    needs: [detect-code-changes]
-    if: ${{ always() && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group') && (needs.detect-code-changes.result == 'skipped' || needs.detect-code-changes.outputs.should-run == 'true') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -459,8 +441,7 @@ jobs:
 
   test-frontend-console-app:
     name: 🧪 Console App Tests with Coverage
-    needs: [detect-code-changes]
-    if: ${{ always() && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group') && (needs.detect-code-changes.result == 'skipped' || needs.detect-code-changes.outputs.should-run == 'true') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -587,8 +568,7 @@ jobs:
 
   build_samples:
     name: 🛠️ Build Sample Apps
-    needs: [detect-code-changes]
-    if: ${{ always() && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group') && (needs.detect-code-changes.result == 'skipped' || needs.detect-code-changes.outputs.should-run == 'true') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -615,7 +595,7 @@ jobs:
 
   test-integration:
     name: 🧪 Integration Tests (${{ matrix.database }})
-    needs: [build, build_samples, detect-code-changes]
+    needs: [build, build_samples]
     if: ${{ always() && needs.build.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -737,8 +717,8 @@ jobs:
 
   test-e2e:
     name: 🎭 Playwright E2E Tests
-    needs: [build, build_samples, detect-code-changes]
-    if: ${{ always() && (needs.build.result == 'success' && needs.build_samples.result == 'success' && (needs.detect-code-changes.result == 'skipped' || needs.detect-code-changes.outputs.should-run == 'true')) }}
+    needs: [build, build_samples]
+    if: ${{ always() && needs.build.result == 'success' && needs.build_samples.result == 'success' }}
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
@@ -1145,62 +1125,10 @@ jobs:
           retention-days: 30
 
 
-  detect-powershell-changes:
-    name: 🔍 Detect PowerShell Changes
-    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group'
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    outputs:
-      should-run: ${{ steps.filter.outputs.powershell }}
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
-        id: filter
-        with:
-          base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
-          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
-          filters: |
-            powershell:
-              - '**.ps1'
-              - '.github/workflows/windows-powershell-validation.yml'
-      - name: ✅ PowerShell files detected
-        if: steps.filter.outputs.powershell == 'true'
-        run: echo "PowerShell files changed - validation will run"
-      - name: ⏭️ No PowerShell changes
-        if: steps.filter.outputs.powershell != 'true'
-        run: echo "No PowerShell changes - skipping validation"
-
-  detect-docs-changes:
-    name: 🔍 Detect Documentation Changes
-    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      should-run: ${{ steps.filter.outputs.docs }}
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
-        id: filter
-        with:
-          base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
-          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
-          filters: |
-            docs:
-              - 'docs/**'
-              - 'package.json'
-              - 'pnpm-lock.yaml'
-              - 'pnpm-workspace.yaml'
-      - name: ✅ Documentation changes detected
-        if: steps.filter.outputs.docs == 'true'
-        run: echo "Documentation files changed - docs build will run"
-      - name: ⏭️ No documentation changes
-        if: steps.filter.outputs.docs != 'true'
-        run: echo "No documentation changes - skipping docs build"
-
   build-docs:
     name: 📚 Build Documentation
-    needs: [detect-docs-changes]
-    if: ${{ always() && needs.detect-docs-changes.outputs.should-run == 'true' }}
+    needs: [preflight]
+    if: ${{ always() && needs.preflight.outputs.docs-changed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -1217,8 +1145,8 @@ jobs:
 
   validate-windows:
     name: 🪟 Validate Windows PowerShell
-    needs: detect-powershell-changes
-    if: needs.detect-powershell-changes.outputs.should-run == 'true'
+    needs: preflight
+    if: always() && needs.preflight.outputs.powershell-changed == 'true'
     uses: ./.github/workflows/windows-powershell-validation.yml
 
   cleanup-turbo-cache:


### PR DESCRIPTION
### Purpose

Cut PR Builder wall-clock time and runner queue pressure. Phase 1 of #4268.

Scope note: this PR originally also parallelized the Playwright E2E suite and raised the worker count; that work has since landed on main independently (via `078ba2031`), so this PR now carries only the remaining, complementary changes.

### Approach

**pnpm store caching (was broken).** The `setup-pnpm` composite action passed `cache_dependency_path` to `pnpm/action-setup`, which ignores it, so no job using the composite ever cached the pnpm store and every install cost ~2 min. The action now installs pnpm first, then runs `setup-node` with `cache: pnpm`. Benefits every job that uses the composite (preflight, verify-mocks, lint, build, gate/console tests, build_samples, build-docs) plus the other workflows that consume it.

**Gate-job consolidation (fewer runner slots per run).**
- `security-audit`, `dependency-review`, `detect-docs-changes`, and `detect-powershell-changes` are folded into a single `preflight` job (one checkout, one runner slot, one paths-filter invocation) exposing `docs-changed` / `powershell-changed` outputs for `build-docs` and `validate-windows`. Same tools, same configuration, same enforcement; one required check instead of three.
- `detect-code-changes` was hardcoded to `code=true` (codecov workaround) but still burned a runner slot and gated 7 jobs behind an extra scheduling hop; it is removed and its dependents start immediately.
- The orphaned `PNPM_VERSION` env var is removed (its last consumer went away with the containerized E2E job).

**Turbo cache in the lint job.** Lint is the only frontend-building job without `setup-turbo-cache`, so its pre-lint frontend build runs cold (~4 min vs ~1 min cached). The build itself must stay because linting is type-aware and resolves `@thunderid/*` types from built `dist/` output, but it is now cached.

**⚠️ Required-checks settings (admin action needed before merge):** `🔒 Security Audit`, `🔎 Dependency Review`, and `🔍 Detect PowerShell Changes` are currently required status checks on main. They must be replaced with `🛡️ Preflight Checks`, or this PR (and afterwards every PR) blocks at "Expected - Waiting for status to be reported".

### Related Issues
- Refs #4268

### Related PRs
- #4292 (merged) added the trigger-pr-builder label gate this PR preserves.

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
