### PR TITLE
[Bug-fix] Fix displaying two error messages in sign up flow

### DIFF
--- a/frontend/apps/gate/src/components/SignUp/SignUpBox.tsx
+++ b/frontend/apps/gate/src/components/SignUp/SignUpBox.tsx
@@ -25,7 +25,6 @@ import {FlowComponentRenderer, AuthCardLayout, useDesign} from '@thunderid/desig
 import {EmbeddedFlowEventType, SignUp, useThunderID, type EmbeddedFlowComponent} from '@thunderid/react';
 import {Box, Button, Alert, Typography, AlertTitle, CircularProgress} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
-import {useState} from 'react';
 import {Trans, useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
 import ROUTES from '../../constants/routes';
@@ -35,8 +34,6 @@ export default function SignUpBox(): JSX.Element {
   const {resolveFlowTemplateLiterals: resolve, meta} = useThunderID();
   const {t} = useTranslation();
   const {isDesignEnabled} = useDesign();
-  const [flowError, setFlowError] = useState<string | null>(null);
-
   // For React Router navigate() — basename is handled by the router.
   const signInPath = ROUTES.AUTH.SIGN_IN;
   // For window.location.href and new URL() (via afterSignUpUrl) — React Router basename is
@@ -79,7 +76,6 @@ export default function SignUpBox(): JSX.Element {
               resolve={resolve}
               onInputChange={handleInputChange}
               onSubmit={(action, inputs) => {
-                setFlowError(null);
                 const isTrigger = action.eventType === EmbeddedFlowEventType.Trigger || action.eventType === 'TRIGGER';
                 void handleSubmit(action, inputs, isTrigger);
               }}
@@ -112,23 +108,7 @@ export default function SignUpBox(): JSX.Element {
       showLogo={!isDesignEnabled}
       logoDisplay={!isDesignEnabled ? {xs: 'flex', md: 'none'} : {display: 'none'}}
     >
-      <SignUp
-        afterSignUpUrl={afterSignUpUrl}
-        onFlowChange={(response: any) => {
-          const messageKey: string | undefined = response?.error?.message?.key;
-          if (messageKey) {
-            const translated: string = t(messageKey);
-            if (translated !== messageKey) {
-              setFlowError(translated);
-
-              return;
-            }
-          }
-          const fallback: string | undefined =
-            response?.error?.message?.defaultValue ?? response?.error?.description?.defaultValue;
-          setFlowError(fallback ?? null);
-        }}
-      >
+      <SignUp afterSignUpUrl={afterSignUpUrl}>
         {({values, fieldErrors, error, touched, handleInputChange, handleSubmit, isLoading, components}: any) => (
           <>
             {!components ? (
@@ -143,12 +123,6 @@ export default function SignUpBox(): JSX.Element {
                     {error.message ?? t('signup:errors.signup.failed.description')}
                   </Alert>
                 )}
-                {flowError && (
-                  <Alert severity="error" sx={{mb: 2}}>
-                    {flowError}
-                  </Alert>
-                )}
-
                 {renderFlowContent(
                   components as EmbeddedFlowComponent[],
                   error,

--- a/frontend/apps/gate/src/components/SignUp/__tests__/SignUpBox.test.tsx
+++ b/frontend/apps/gate/src/components/SignUp/__tests__/SignUpBox.test.tsx
@@ -19,7 +19,6 @@
 import userEvent from '@testing-library/user-event';
 import {DesignContext, type DesignContextType} from '@thunderid/design';
 import {screen, fireEvent, waitFor, render as testRender} from '@thunderid/test-utils';
-import {act} from 'react';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import SignUpBox from '../SignUpBox';
 
@@ -97,7 +96,6 @@ const createMockSignUpRenderProps = (overrides: Partial<MockSignUpRenderProps> =
 });
 
 let mockSignUpRenderProps: MockSignUpRenderProps = createMockSignUpRenderProps();
-let capturedOnFlowChange: ((response: unknown) => void) | undefined;
 let capturedAfterSignUpUrl: string | undefined;
 let mockMeta: {application?: {url?: string}} | null = null;
 
@@ -111,14 +109,11 @@ vi.mock('@thunderid/react', async () => {
     }),
     SignUp: ({
       children,
-      onFlowChange = undefined,
       afterSignUpUrl = undefined,
     }: {
       children: (props: typeof mockSignUpRenderProps) => React.ReactNode;
-      onFlowChange?: (response: unknown) => void;
       afterSignUpUrl?: string;
     }) => {
-      capturedOnFlowChange = onFlowChange;
       capturedAfterSignUpUrl = afterSignUpUrl;
       return <div data-testid="thunderid-signup">{children(mockSignUpRenderProps)}</div>;
     },
@@ -143,7 +138,6 @@ describe('SignUpBox', () => {
       isDesignEnabled: false,
     });
     mockSignUpRenderProps = createMockSignUpRenderProps();
-    capturedOnFlowChange = undefined;
     capturedAfterSignUpUrl = undefined;
     mockMeta = null;
   });
@@ -183,97 +177,6 @@ describe('SignUpBox', () => {
     render(<SignUpBox />);
 
     expect(screen.getByText(/Already have an account/)).toBeInTheDocument();
-
-    expect(capturedOnFlowChange).toBeDefined();
-
-    act(() => {
-      capturedOnFlowChange!({data: {additionalData: {}}});
-    });
-
-    // Link remains visible after any flow change
-    expect(screen.getByText(/Already have an account/)).toBeInTheDocument();
-  });
-
-  it('shows flowError alert when onFlowChange reports error', () => {
-    mockSignUpRenderProps = createMockSignUpRenderProps({
-      components: [{id: 'block', type: 'BLOCK', components: []}],
-    });
-    render(<SignUpBox />);
-
-    expect(capturedOnFlowChange).toBeDefined();
-
-    act(() => {
-      capturedOnFlowChange!({
-        error: {
-          code: 'FEE-60005',
-          message: {
-            key: 'flows.errors.user_exists',
-            defaultValue: 'A user with this email already exists. Please use a different value.',
-          },
-          description: {
-            key: 'flows.errors.user_exists_desc',
-            defaultValue: 'A user with this email already exists. Please use a different value.',
-          },
-        },
-        data: {additionalData: {}},
-      });
-    });
-
-    expect(
-      screen.getByText('A user with this email already exists. Please use a different value.'),
-    ).toBeInTheDocument();
-  });
-
-  it('clears flowError when submit is triggered', async () => {
-    mockSignUpRenderProps = createMockSignUpRenderProps({
-      components: [
-        {
-          id: 'block-1',
-          type: 'BLOCK',
-          components: [
-            {
-              id: 'submit-btn',
-              type: 'ACTION',
-              eventType: 'SUBMIT',
-              label: 'Register',
-              variant: 'PRIMARY',
-            },
-          ],
-        },
-      ],
-    });
-    render(<SignUpBox />);
-
-    expect(capturedOnFlowChange).toBeDefined();
-
-    act(() => {
-      capturedOnFlowChange!({
-        error: {
-          code: 'FEE-60005',
-          message: {
-            key: 'flows.errors.user_exists',
-            defaultValue: 'A user with this email already exists. Please use a different value.',
-          },
-          description: {
-            key: 'flows.errors.user_exists_desc',
-            defaultValue: 'A user with this email already exists. Please use a different value.',
-          },
-        },
-        data: {additionalData: {}},
-      });
-    });
-
-    expect(
-      screen.getByText('A user with this email already exists. Please use a different value.'),
-    ).toBeInTheDocument();
-
-    fireEvent.click(screen.getByText('Register'));
-
-    await waitFor(() => {
-      expect(
-        screen.queryByText('A user with this email already exists. Please use a different value.'),
-      ).not.toBeInTheDocument();
-    });
   });
 
   it('renders TEXT component as heading', () => {


### PR DESCRIPTION
### Purpose
Fixes: https://github.com/thunder-id/thunderid/issues/4072

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4072

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-up error handling by displaying errors directly from the sign-up flow.
  * Removed outdated flow-error alerts and behavior, providing more consistent failure messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->