### PR TITLE
Update the docker deployment guide documentation

### DIFF
--- a/docs/content/deployment/deployment-paths/docker-production.mdx
+++ b/docs/content/deployment/deployment-paths/docker-production.mdx
@@ -17,11 +17,11 @@ This guide covers Docker-specific hardening steps for running <ProductName /> in
 Always pin to a specific release tag rather than `latest`:
 
 ```bash
-# Avoid — resolves to a different image after each release
+# Avoid: resolves to a different image after each release
 ghcr.io/thunder-id/thunderid:latest
 
-# Prefer — explicit and reproducible
-ghcr.io/thunder-id/thunderid:latest
+# Prefer: explicit and reproducible
+ghcr.io/thunder-id/thunderid:<version>
 ```
 
 Pinning ensures upgrades are intentional and your deployment is reproducible across environments.
@@ -61,14 +61,15 @@ Without a volume, all data inside the container is lost when it is stopped or re
 docker run -d \
   --name thunderid \
   --restart unless-stopped \
-  -v thunderid-data:/opt/thunder/database \
+  -v thunderid-data:/opt/thunderid/database \
   ghcr.io/thunder-id/thunderid:latest
 ```
 
-Also mount the security directory to keep TLS certificates and the encryption key outside the container lifecycle:
+Also mount the named volumes that setup populates, so the TLS certificates, encryption key, and Direct Auth Secret persist outside the container lifecycle:
 
 ```bash
--v $(pwd)/security:/opt/thunder/config/resources/security
+-v thunderid-certs:/opt/thunderid/config/certs \
+-v thunderid-secrets:/opt/thunderid/config/secrets
 ```
 
 ## Terminate TLS at a Reverse Proxy
@@ -117,7 +118,7 @@ services:
     expose:
       - "8090"
     volumes:
-      - ./deployment.yaml:/opt/thunder/deployment.yaml
+      - ./deployment.yaml:/opt/thunderid/deployment.yaml
 ```
 
 ## Set Resource Constraints
@@ -149,7 +150,7 @@ services:
   thunderid:
     image: ghcr.io/thunder-id/thunderid:latest
     healthcheck:
-      test: ["CMD", "curl", "-fsk", "https://localhost:8090/health"]
+      test: ["CMD", "curl", "-fsk", "https://localhost:8090/health/liveness"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -163,7 +164,7 @@ Never pass secrets as inline environment variables or in `docker run` commands: 
 **Use an environment file:**
 
 ```bash
-# .env  — add to .gitignore
+# .env (add to .gitignore)
 DB_HOST=postgres.example.com
 DB_USER=thunderid_user
 DB_PASS=<secure-password>

--- a/docs/content/deployment/deployment-paths/docker.mdx
+++ b/docs/content/deployment/deployment-paths/docker.mdx
@@ -19,13 +19,11 @@ Before you begin, ensure the following tools are installed:
 | Tool | Minimum Version | Installation Guide | Version Check |
 |------|----------------|--------------------|---------------|
 | Docker | 20.10 | [Install Docker](https://docs.docker.com/engine/install/) | `docker --version` |
-| Docker Compose | 2.0 | [Install Docker Compose](https://docs.docker.com/compose/install/) | `docker compose version` |
 
 Verify your installation:
 
 ```bash
 docker --version
-docker compose version
 docker run hello-world
 ```
 
@@ -81,7 +79,18 @@ docker logs -f thunderid
 
 ### Customize the Configuration
 
-To override the default server configuration, mount a custom `deployment.yaml` file. Create a `deployment.yaml` based on the <RepoLink path="/blob/main/backend/cmd/server/deployment.yaml">default configuration</RepoLink> and pass it to the container:
+To override the default server configuration, mount a custom `deployment.yaml` file. Create a `deployment.yaml` based on the <RepoLink path="/blob/main/backend/cmd/server/deployment.yaml">default configuration</RepoLink>. For Docker, update the `server` block so the server is reachable through the published port, setting `hostname` to `0.0.0.0` and adding a `public_url`:
+
+```yaml
+server:
+  hostname: "0.0.0.0"
+  public_url: "https://localhost:8090"
+  port: 8090
+  security:
+    direct_auth_secret: "file://config/secrets/direct_auth_secret"
+```
+
+Then pass it to the container:
 
 ```bash
 docker run -d \
@@ -113,86 +122,13 @@ docker run -d \
 
 The mounted files provide the server TLS certificate; the JWT signing and encryption keys still come from the `thunderid-certs` volume that setup populated.
 
-## Run with Docker Compose
-
-Docker Compose is the recommended way to run <ProductName /> alongside a PostgreSQL database. Create a `docker-compose.yml` in your working directory:
-
-```yaml
-services:
-  thunderid:
-    image: ghcr.io/thunder-id/thunderid:latest
-    restart: unless-stopped
-    ports:
-      - "8090:8090"
-    volumes:
-      - ./deployment.yaml:/opt/thunderid/deployment.yaml
-      - thunderid-certs:/opt/thunderid/config/certs
-      - thunderid-secrets:/opt/thunderid/config/secrets
-    depends_on:
-      postgres:
-        condition: service_healthy
-
-  postgres:
-    image: postgres:16-alpine
-    restart: unless-stopped
-    env_file: .env
-    environment:
-      POSTGRES_USER: thunderid_user
-      POSTGRES_DB: configdb
-    volumes:
-      - postgres-data:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U thunderid_user"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
-volumes:
-  postgres-data:
-  thunderid-certs:
-  thunderid-secrets:
-```
-
-This snippet runs the server only. Before the first start, run setup once (see [Set Up the Server](#step-2-set-up-the-server)) against the same `thunderid-certs` and `thunderid-secrets` volumes so the key material and Direct Auth Secret exist, since the server does not start without them. For a Compose setup that runs the setup step automatically, see the quick-start under `install/quick-start`.
-
-Create a `.env` file alongside `docker-compose.yml` to keep credentials out of version control:
-
-```bash
-POSTGRES_PASSWORD=<your-database-password>
-```
-
-Start the stack:
-
-```bash
-docker compose up -d
-```
-
-View logs:
-
-```bash
-docker compose logs -f
-```
-
-Stop the stack:
-
-```bash
-docker compose down
-```
-
-Stop and remove all data volumes:
-
-```bash
-docker compose down -v
-```
-
 ## Access <ProductName />
 
 Once the container is running, access <ProductName /> at the following endpoints:
 
 | Endpoint | URL |
 |----------|-----|
-| Application | `https://localhost:8090` |
-| Sign-in / Register | `https://localhost:8090/signin` |
+| Server URL | `https://localhost:8090` |
 | <ProductName /> Console | `https://localhost:8090/console` |
 
 ## Database Setup
@@ -210,6 +146,10 @@ Mount a named volume to persist the database across container restarts:
 ### External PostgreSQL
 
 For a more durable setup, connect <ProductName /> to an external PostgreSQL database. <ProductName /> ships with a Docker Compose file to spin up a PostgreSQL instance alongside the server.
+
+:::note
+This step requires [Docker Compose](https://docs.docker.com/compose/install/) (version 2.0 or later).
+:::
 
 1. Navigate to the `install/local-development` directory:
 

--- a/docs/content/deployment/production-guidelines.mdx
+++ b/docs/content/deployment/production-guidelines.mdx
@@ -40,7 +40,7 @@ database:
     type: "postgres"
     postgres:
       hostname: "your-db-host"
-      port: "5432"
+      port: 5432
       name: "configdb"
       username: "dbuser"
       password: "dbpassword"
@@ -53,7 +53,7 @@ database:
     type: "postgres"
     postgres:
       hostname: "your-db-host"
-      port: "5432"
+      port: 5432
       name: "runtime_transient"
       username: "dbuser"
       password: "dbpassword"
@@ -66,7 +66,7 @@ database:
     type: "postgres"
     postgres:
       hostname: "your-db-host"
-      port: "5432"
+      port: 5432
       name: "entitydb"
       username: "dbuser"
       password: "dbpassword"
@@ -79,7 +79,7 @@ database:
     type: "postgres"
     postgres:
       hostname: "your-db-host"
-      port: "5432"
+      port: 5432
       name: "runtime_persistent"
       username: "dbuser"
       password: "dbpassword"
@@ -134,11 +134,15 @@ When deploying with Docker, mount the certificates as volumes:
 ```bash
 docker run --rm \
   -p 8090:8090 \
-  -v $(pwd)/deployment.yaml:/opt/thunder/deployment.yaml \
-  -v $(pwd)/certs/server.cert:/opt/thunder/config/certs/server.cert \
-  -v $(pwd)/certs/server.key:/opt/thunder/config/certs/server.key \
+  -v $(pwd)/deployment.yaml:/opt/thunderid/deployment.yaml \
+  -v thunderid-certs:/opt/thunderid/config/certs \
+  -v thunderid-secrets:/opt/thunderid/config/secrets \
+  -v $(pwd)/config/certs/server.cert:/opt/thunderid/config/certs/server.cert \
+  -v $(pwd)/config/certs/server.key:/opt/thunderid/config/certs/server.key \
   ghcr.io/thunder-id/thunderid:latest
 ```
+
+The `thunderid-certs` and `thunderid-secrets` volumes are populated by `./setup.sh`. The file mounts override the TLS certificate and key.
 
 ## Generate a Unique Encryption Key
 

--- a/install/local-development/docker-compose.yml
+++ b/install/local-development/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   postgres:
-    image: postgres
+    image: postgres:16-alpine
     container_name: local_postgres
     restart: always
     environment:


### PR DESCRIPTION
### Purpose

The Docker deployment guides contained several errors that caused documented commands to fail silently or produce a non-working deployment. All fixes were reproduced against `ghcr.io/thunder-id/thunderid:latest`.
Fixes #4228

Affected files:
- `docs/content/deployment/deployment-paths/docker.mdx`
- `docs/content/deployment/deployment-paths/docker-production.mdx`
- `docs/content/deployment/production-guidelines.mdx`
- `install/local-development/docker-compose.yml`

### Approach

Fixed the following issues:

1. **Incorrect container paths.** Several `docker run` / Compose examples mounted into `/opt/thunder/...`, but the container's application directory is `/opt/thunderid`. Corrected the data volume, security-directory, and `deployment.yaml` mounts in `docker-production.mdx`, and the TLS command mounts (`deployment.yaml`, `server.cert`, `server.key`) in `production-guidelines.mdx`.

2. **Security directory mounted to the wrong subpath.** `docker-production.mdx` mounted to `config/resources/security`, but setup writes the TLS, JWT, and encryption keys to `config/certs`. Corrected the target to `/opt/thunderid/config/certs`.

3. **Identical "Avoid" and "Prefer" image-pin examples.** In "Pin the Image Version", both examples showed `:latest`. The "Prefer" example now shows a pinned tag (`ghcr.io/thunder-id/thunderid:<version>`).

4. **Health check hit a non-existent endpoint.** The Compose health check used `/health` The server registers `/health/liveness` and `/health/readiness`. Updated to `/health/liveness`.

5. **Customize section pointed to a config that cannot work in Docker.** The "Customize the Configuration" section pointed readers to the default `deployment.yaml` (`hostname: "localhost"`, no `public_url`), which the image only works with because the Dockerfile patches those values at build time. A mounted file bypasses that patch. Replaced the pointer with a Docker-ready inline configuration (`hostname: "0.0.0.0"` and a `public_url`).

6. **PostgreSQL `port` quoted as a string.** The Postgres blocks in `production-guidelines.mdx` used `port: "5432"` (string); the schema expects an integer.

7. **Removed the "Run with Docker Compose" section** from `docker.mdx`, since its example could not produce a working PostgreSQL deployment as written.

8. **Pinned the PostgreSQL version** in `install/local-development/docker-compose.yml`. The volume is mounted at `postgres_data:/var/lib/postgresql/data`, but PostgreSQL 18 and later changed the data directory, so the untagged `postgres` image crash-loops. Pinned to `postgres:16-alpine` to keep the data directory consistent with the mount.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4228

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker production and deployment guides for more reproducible, hardened setup, including versioned image guidance, improved persistent mounts for database/TLS/secrets, and a corrected reverse-proxy mount.
  * Refined health check to use the liveness endpoint.
  * Simplified Docker access instructions and clarified external PostgreSQL requirements.
  * Updated production examples (including PostgreSQL port formatting) to align with the container’s `/opt/thunderid/...` layout.

* **Chores**
  * Pinned local development PostgreSQL to `16-alpine` for consistent deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->