### PR TITLE
Add undo/redo and unsaved-changes protection to the flow builder

### DIFF
--- a/frontend/apps/console/src/features/flows/components/visual-flow/CanvasToolbar.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/CanvasToolbar.tsx
@@ -17,7 +17,7 @@
  */
 
 import {Box, IconButton, Tooltip} from '@wso2/oxygen-ui';
-import {LayoutGrid, Maximize, Minus, Plus} from '@wso2/oxygen-ui-icons-react';
+import {LayoutGrid, Maximize, Minus, Plus, Redo2, Undo2} from '@wso2/oxygen-ui-icons-react';
 import {useReactFlow} from '@xyflow/react';
 import {type ReactElement} from 'react';
 import {useTranslation} from 'react-i18next';
@@ -28,17 +28,33 @@ import getEdgeStyleIcon from '../../utils/getEdgeStyleIcon';
 
 export interface CanvasToolbarProps {
   onAutoLayout: () => void;
+  /** Undo the last canvas edit. Omit to hide the undo/redo controls. */
+  onUndo?: () => void;
+  /** Redo the last undone canvas edit. */
+  onRedo?: () => void;
+  /** Whether an undo step is available. */
+  canUndo?: boolean;
+  /** Whether a redo step is available. */
+  canRedo?: boolean;
 }
 
 function ToolbarDivider(): ReactElement {
   return <Box sx={{width: '1px', height: 16, bgcolor: 'divider', mx: 0.5, flexShrink: 0}} />;
 }
 
-export default function CanvasToolbar({onAutoLayout}: CanvasToolbarProps): ReactElement {
+export default function CanvasToolbar({
+  onAutoLayout,
+  onUndo = undefined,
+  onRedo = undefined,
+  canUndo = false,
+  canRedo = false,
+}: CanvasToolbarProps): ReactElement {
   const {t} = useTranslation();
   const {fitView, zoomIn, zoomOut} = useReactFlow();
   const {edgeStyle} = useFlowConfig();
   const {anchorEl, handleClick: handleEdgeStyleClick, handleClose: handleEdgeStyleClose} = useEdgeStyleSelector();
+
+  const showHistoryControls = Boolean(onUndo ?? onRedo);
 
   return (
     <>
@@ -58,6 +74,40 @@ export default function CanvasToolbar({onAutoLayout}: CanvasToolbarProps): React
           borderColor: 'divider',
         }}
       >
+        {showHistoryControls && (
+          <>
+            <Tooltip title={t('flows:core.headerPanel.undoTooltip', 'Undo (Ctrl+Z / Cmd+Z)')}>
+              <span>
+                <IconButton
+                  size="small"
+                  onClick={onUndo}
+                  disabled={!canUndo || !onUndo}
+                  sx={{borderRadius: 1, color: 'text.secondary'}}
+                  aria-label={t('flows:core.headerPanel.undo', 'Undo')}
+                >
+                  <Undo2 size={16} />
+                </IconButton>
+              </span>
+            </Tooltip>
+
+            <Tooltip title={t('flows:core.headerPanel.redoTooltip', 'Redo (Ctrl+Shift+Z / Cmd+Shift+Z)')}>
+              <span>
+                <IconButton
+                  size="small"
+                  onClick={onRedo}
+                  disabled={!canRedo || !onRedo}
+                  sx={{borderRadius: 1, color: 'text.secondary'}}
+                  aria-label={t('flows:core.headerPanel.redo', 'Redo')}
+                >
+                  <Redo2 size={16} />
+                </IconButton>
+              </span>
+            </Tooltip>
+
+            <ToolbarDivider />
+          </>
+        )}
+
         <Tooltip title={t('flows:core.headerPanel.autoLayout')}>
           <IconButton
             size="small"

--- a/frontend/apps/console/src/features/flows/components/visual-flow/DecoratedVisualFlow.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/DecoratedVisualFlow.tsx
@@ -20,7 +20,7 @@ import {CollisionPriority} from '@dnd-kit/abstract';
 import {move} from '@dnd-kit/helpers';
 import {DragDropProvider, DragOverlay, type DragDropEventHandlers} from '@dnd-kit/react';
 import {useIdentityProviders, useSMSProviders} from '@thunderid/configure-connections';
-import {Box, Button, Card, CardContent, Tooltip, Typography, type Theme} from '@wso2/oxygen-ui';
+import {Badge, Box, Button, Card, CardContent, Tooltip, Typography, type Theme} from '@wso2/oxygen-ui';
 import {ArrowLeft, Play, Save, Square} from '@wso2/oxygen-ui-icons-react';
 import {
   type Connection,
@@ -46,6 +46,7 @@ import {
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
 import CanvasToolbar from './CanvasToolbar';
+import DiscardChangesDialog from './DiscardChangesDialog';
 import FormRequiresViewDialog from './FormRequiresViewDialog';
 import SimulationStepPreview from './SimulationStepPreview';
 import ValidationBadge from './ValidationBadge';
@@ -131,6 +132,26 @@ export interface DecoratedVisualFlowPropsInterface extends Omit<VisualFlowPropsI
    * Extra controls rendered at the bottom of the resource panel, below the resource sections.
    */
   resourcePanelFooter?: ReactNode;
+  /**
+   * Undo the last canvas edit. When provided, undo/redo controls appear in the toolbar.
+   */
+  onUndo?: () => void;
+  /**
+   * Redo the last undone canvas edit.
+   */
+  onRedo?: () => void;
+  /**
+   * Whether an undo step is available.
+   */
+  canUndo?: boolean;
+  /**
+   * Whether a redo step is available.
+   */
+  canRedo?: boolean;
+  /**
+   * Whether the flow has unsaved changes (drives the Save-button indicator).
+   */
+  isDirty?: boolean;
 }
 
 /**
@@ -159,6 +180,11 @@ function DecoratedVisualFlow({
   onFlowTitleChange,
   triggerAutoLayoutOnLoad = false,
   resourcePanelFooter = undefined,
+  onUndo = undefined,
+  onRedo = undefined,
+  canUndo = false,
+  canRedo = false,
+  isDirty = false,
   ...rest
 }: DecoratedVisualFlowPropsInterface): ReactElement {
   useDeleteExecutionResource();
@@ -298,7 +324,7 @@ function DecoratedVisualFlow({
   // Memoized handleSave. Nodes/edges come back from the React Flow store, which
   // holds the decorated display arrays while previewing — strip the simulation
   // styling so it is never persisted into the flow's layout data.
-  const handleSave = useCallback((): void => {
+  const persistCanvas = useCallback((): void => {
     const {viewport} = toObject();
     const canvasData = {
       nodes: stripSimulationNodeClasses(getNodes()),
@@ -392,6 +418,17 @@ function DecoratedVisualFlow({
       startSimulation();
     }
   }, [isSimulationActive, stopSimulation, startSimulation]);
+
+  const handleSave = useCallback((): void => {
+    if (isSimulationActive) {
+      // Saving during preview: exit the preview first so the persisted viewport
+      // is the settled canvas view rather than the preview's zoomed-in camera.
+      stopSimulation();
+      fitView({padding: 0.2, duration: 0}).then(persistCanvas).catch(persistCanvas);
+      return;
+    }
+    persistCanvas();
+  }, [isSimulationActive, stopSimulation, fitView, persistCanvas]);
 
   // Derived presentation state: while simulating, dim everything off the walked
   // path and animate the traversed edges. Returns the original arrays untouched
@@ -705,7 +742,19 @@ function DecoratedVisualFlow({
     [updateNodeData, updateNodeInternals],
   );
 
+  const [isDiscardDialogOpen, setIsDiscardDialogOpen] = useState<boolean>(false);
+
   const handleBackToFlows = useCallback((): void => {
+    if (isDirty) {
+      setIsDiscardDialogOpen(true);
+      return;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    navigate(RouteConfig.flows.list());
+  }, [isDirty, navigate]);
+
+  const handleConfirmDiscard = useCallback((): void => {
+    setIsDiscardDialogOpen(false);
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     navigate(RouteConfig.flows.list());
   }, [navigate]);
@@ -841,7 +890,13 @@ function DecoratedVisualFlow({
 
         {/* Centered toolbar */}
         <Box sx={{flex: 1, display: 'flex', justifyContent: 'center'}}>
-          <CanvasToolbar onAutoLayout={handleAutoLayout} />
+          <CanvasToolbar
+            onAutoLayout={handleAutoLayout}
+            onUndo={onUndo}
+            onRedo={onRedo}
+            canUndo={canUndo}
+            canRedo={canRedo}
+          />
         </Box>
 
         <Box sx={{display: 'flex', alignItems: 'center', gap: 1}}>
@@ -860,23 +915,48 @@ function DecoratedVisualFlow({
             title={
               hasErrors
                 ? t('flows:core.headerPanel.saveDisabledTooltip', 'Fix validation errors before saving')
-                : isSimulationActive
-                  ? t('flows:core.headerPanel.saveDisabledDuringPreview', 'Stop the preview before saving')
+                : isDirty && onSave
+                  ? t('flows:core.headerPanel.unsavedChanges', 'You have unsaved changes')
                   : ''
             }
           >
             <span>
-              <Button
-                variant="contained"
-                // Saving mid-preview would persist the preview's zoomed-in camera
-                // as the flow's viewport — stop the preview first.
-                disabled={hasErrors || !onSave || isSimulationActive}
-                startIcon={<Save size={18} />}
-                onClick={handleSave}
-                data-testid="save-flow-button"
+              <Badge
+                color="primary"
+                variant="dot"
+                invisible={!isDirty || hasErrors || !onSave}
+                overlap="rectangular"
+                anchorOrigin={{vertical: 'top', horizontal: 'right'}}
+                data-testid="save-dirty-indicator"
+                sx={(theme) => ({
+                  '& .MuiBadge-badge': {
+                    minWidth: 12,
+                    height: 12,
+                    borderRadius: '50%',
+                    // A ring in the header background separates the blue dot from
+                    // the filled Save button so it stays visible.
+                    border: `2px solid ${theme.palette.background.default}`,
+                    boxShadow: `0 0 0 1px ${theme.palette.primary.main}`,
+                    animation: 'save-dirty-pulse 1.8s ease-in-out infinite',
+                  },
+                  '@keyframes save-dirty-pulse': {
+                    '0%, 100%': {transform: 'scale(1)', opacity: 1},
+                    '50%': {transform: 'scale(1.25)', opacity: 0.75},
+                  },
+                })}
               >
-                {t('flows:core.headerPanel.save')}
-              </Button>
+                <Button
+                  variant="contained"
+                  disabled={hasErrors || !onSave}
+                  startIcon={<Save size={18} />}
+                  // Saving during preview stops it first (handleSave), so the
+                  // button stays enabled instead of blocking on the preview.
+                  onClick={handleSave}
+                  data-testid="save-flow-button"
+                >
+                  {t('flows:core.headerPanel.save', 'Save')}
+                </Button>
+              </Badge>
             </span>
           </Tooltip>
         </Box>
@@ -962,6 +1042,11 @@ function DecoratedVisualFlow({
         scenario={dropScenario}
         onClose={handleContainerDialogClose}
         onConfirm={handleContainerDialogConfirm}
+      />
+      <DiscardChangesDialog
+        open={isDiscardDialogOpen}
+        onClose={() => setIsDiscardDialogOpen(false)}
+        onConfirm={handleConfirmDiscard}
       />
     </Box>
   );

--- a/frontend/apps/console/src/features/flows/components/visual-flow/DiscardChangesDialog.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/DiscardChangesDialog.tsx
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle} from '@wso2/oxygen-ui';
+import type {JSX} from 'react';
+import {useTranslation} from 'react-i18next';
+
+export interface DiscardChangesDialogProps {
+  /** Whether the dialog is open. */
+  open: boolean;
+  /** Called when the user chooses to stay and keep editing. */
+  onClose: () => void;
+  /** Called when the user confirms discarding unsaved changes. */
+  onConfirm: () => void;
+}
+
+/**
+ * Confirmation dialog shown before leaving the flow builder with unsaved changes.
+ */
+export default function DiscardChangesDialog({open, onClose, onConfirm}: DiscardChangesDialogProps): JSX.Element {
+  const {t} = useTranslation();
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby="discard-changes-dialog-title"
+      aria-describedby="discard-changes-dialog-description"
+      data-testid="discard-changes-dialog"
+    >
+      <DialogTitle id="discard-changes-dialog-title">
+        {t('flows:core.dialogs.discardChanges.title', 'Discard unsaved changes?')}
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText id="discard-changes-dialog-description">
+          {t(
+            'flows:core.dialogs.discardChanges.description',
+            'You have unsaved changes to this flow. If you leave now, your changes will be lost.',
+          )}
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>{t('flows:core.dialogs.discardChanges.cancelButton', 'Keep editing')}</Button>
+        <Button onClick={onConfirm} color="error" variant="contained" data-testid="discard-changes-confirm-button">
+          {t('flows:core.dialogs.discardChanges.confirmButton', 'Discard changes')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/CanvasToolbar.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/CanvasToolbar.test.tsx
@@ -168,4 +168,41 @@ describe('CanvasToolbar', () => {
 
     expect(mockFitView).toHaveBeenCalledWith({padding: 0.2, duration: 300});
   });
+
+  it('should not render undo/redo controls when no history handlers are provided', () => {
+    render(<CanvasToolbar onAutoLayout={mockOnAutoLayout} />, {wrapper: Wrapper});
+
+    expect(screen.queryByLabelText('Undo')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Redo')).not.toBeInTheDocument();
+  });
+
+  it('should render undo/redo controls when history handlers are provided', () => {
+    render(<CanvasToolbar onAutoLayout={mockOnAutoLayout} onUndo={vi.fn()} onRedo={vi.fn()} canUndo canRedo />, {
+      wrapper: Wrapper,
+    });
+
+    expect(screen.getByRole('button', {name: 'Undo'})).toBeEnabled();
+    expect(screen.getByRole('button', {name: 'Redo'})).toBeEnabled();
+  });
+
+  it('should disable undo/redo when there is nothing to undo/redo', () => {
+    render(<CanvasToolbar onAutoLayout={mockOnAutoLayout} onUndo={vi.fn()} onRedo={vi.fn()} />, {wrapper: Wrapper});
+
+    expect(screen.getByRole('button', {name: 'Undo'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Redo'})).toBeDisabled();
+  });
+
+  it('should call onUndo and onRedo when the buttons are clicked', () => {
+    const onUndo = vi.fn();
+    const onRedo = vi.fn();
+    render(<CanvasToolbar onAutoLayout={mockOnAutoLayout} onUndo={onUndo} onRedo={onRedo} canUndo canRedo />, {
+      wrapper: Wrapper,
+    });
+
+    fireEvent.click(screen.getByRole('button', {name: 'Undo'}));
+    fireEvent.click(screen.getByRole('button', {name: 'Redo'}));
+
+    expect(onUndo).toHaveBeenCalledTimes(1);
+    expect(onRedo).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/DecoratedVisualFlow.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/DecoratedVisualFlow.test.tsx
@@ -436,7 +436,7 @@ describe('DecoratedVisualFlow', () => {
       expect(screen.getByTestId('simulate-flow-button')).toBeInTheDocument();
     });
 
-    it('should disable save while previewing so the zoomed viewport is not persisted', () => {
+    it('should keep save enabled while previewing (clicking it stops the preview first)', () => {
       const nodes = [{id: 'node-1', position: {x: 0, y: 0}, data: {}}] as Node[];
       renderComponent(<DecoratedVisualFlow {...defaultProps} nodes={nodes} onSave={vi.fn()} />);
 
@@ -444,7 +444,7 @@ describe('DecoratedVisualFlow', () => {
 
       fireEvent.click(screen.getByTestId('simulate-flow-button'));
 
-      expect(screen.getByTestId('save-flow-button')).toBeDisabled();
+      expect(screen.getByTestId('save-flow-button')).toBeEnabled();
     });
 
     it('should focus the clicked node via fitView', () => {
@@ -512,7 +512,7 @@ describe('DecoratedVisualFlow', () => {
     it('should render save button in top bar', () => {
       renderComponent(<DecoratedVisualFlow {...defaultProps} onSave={vi.fn()} />);
 
-      expect(screen.getByText('core.headerPanel.save')).toBeInTheDocument();
+      expect(screen.getByTestId('save-flow-button')).toBeInTheDocument();
     });
 
     it('should render canvas toolbar', () => {
@@ -531,7 +531,7 @@ describe('DecoratedVisualFlow', () => {
 
       renderComponent(<DecoratedVisualFlow {...defaultProps} onSave={mockOnSave} />);
 
-      const saveButton = screen.getByText('core.headerPanel.save');
+      const saveButton = screen.getByTestId('save-flow-button');
       fireEvent.click(saveButton);
 
       expect(mockOnSave).toHaveBeenCalledWith({
@@ -544,7 +544,7 @@ describe('DecoratedVisualFlow', () => {
     it('should not throw when onSave is not provided', () => {
       renderComponent(<DecoratedVisualFlow {...defaultProps} onSave={undefined} />);
 
-      const saveButton = screen.getByText('core.headerPanel.save');
+      const saveButton = screen.getByTestId('save-flow-button');
       expect(() => fireEvent.click(saveButton)).not.toThrow();
     });
   });

--- a/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/DiscardChangesDialog.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/DiscardChangesDialog.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {fireEvent, render, screen} from '@testing-library/react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import DiscardChangesDialog from '../DiscardChangesDialog';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({t: (key: string, fallback?: string) => fallback ?? key}),
+}));
+
+describe('DiscardChangesDialog', () => {
+  const onClose = vi.fn();
+  const onConfirm = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders when open', () => {
+    render(<DiscardChangesDialog open onClose={onClose} onConfirm={onConfirm} />);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Discard unsaved changes?')).toBeInTheDocument();
+  });
+
+  it('does not render content when closed', () => {
+    render(<DiscardChangesDialog open={false} onClose={onClose} onConfirm={onConfirm} />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('calls onConfirm when the discard button is clicked', () => {
+    render(<DiscardChangesDialog open onClose={onClose} onConfirm={onConfirm} />);
+
+    fireEvent.click(screen.getByTestId('discard-changes-confirm-button'));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('calls onClose when the keep-editing button is clicked', () => {
+    render(<DiscardChangesDialog open onClose={onClose} onConfirm={onConfirm} />);
+
+    fireEvent.click(screen.getByText('Keep editing'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/apps/console/src/features/login-flow/components/LoginFlowBuilder.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/LoginFlowBuilder.tsx
@@ -20,7 +20,7 @@ import {useIdentityProviders, useSMSProviders} from '@thunderid/configure-connec
 import {Alert, Box, Snackbar, Stack} from '@wso2/oxygen-ui';
 import type {Edge, Node} from '@xyflow/react';
 import {useEdgesState, useNodesState, useUpdateNodeInternals} from '@xyflow/react';
-import {useCallback, useEffect, useMemo, useRef} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useParams} from 'react-router';
 import '@xyflow/react/dist/style.css';
@@ -31,6 +31,7 @@ import SsoToggle from '../components/SsoToggle';
 import LoginFlowConstants from '../constants/LoginFlowConstants';
 import useEdgeGeneration from '../hooks/useEdgeGeneration';
 import useElementAddition from '../hooks/useElementAddition';
+import useFlowHistory, {computeGraphSignature} from '../hooks/useFlowHistory';
 import useFlowInitialization from '../hooks/useFlowInitialization';
 import useFlowNaming from '../hooks/useFlowNaming';
 import useFlowSave from '../hooks/useFlowSave';
@@ -42,6 +43,7 @@ import {mutateComponents} from '../utils/componentMutations';
 import GradientBorderButton from '@/features/applications/components/GradientBorderButton';
 import useGetFlowById from '@/features/flows/api/useGetFlowById';
 import FlowBuilder from '@/features/flows/components/FlowBuilder';
+import FlowConstants from '@/features/flows/constants/FlowConstants';
 import useFlowConfig from '@/features/flows/hooks/useFlowConfig';
 import useFlowEvents from '@/features/flows/hooks/useFlowEvents';
 import useValidationStatus from '@/features/flows/hooks/useValidationStatus';
@@ -221,6 +223,59 @@ function LoginFlowBuilder() {
     setGraphValidationRules(flowType === 'AUTHENTICATION' ? GRAPH_VALIDATION_RULES : []);
   }, [flowType, setGraphValidationRules]);
 
+  // Undo/redo history over the canvas graph.
+  const {undo, redo, canUndo, canRedo, settledSignature, resetHistory} = useFlowHistory({
+    edges,
+    maxHistoryItems: FlowConstants.MAX_HISTORY_ITEMS,
+    nodes,
+    setEdges,
+    setNodes,
+  });
+
+  // Unsaved-changes tracking. The flow is considered clean until the user first
+  // interacts with the builder: the graph keeps mutating on its own after load
+  // (metadata resolution, field normalization, node internals, auto-layout), and
+  // none of that should count as an edit. The baseline signature is frozen at the
+  // first user interaction — every real edit begins with a pointer/key event, so
+  // the pre-edit graph is always captured — and re-frozen after each save.
+  // Dirtiness compares against the history hook's settled signature, so no
+  // per-render (or per-drag-tick) re-serialization of the graph is needed.
+  const [savedSignature, setSavedSignature] = useState<string | null>(null);
+  const isDirty = savedSignature !== null && settledSignature !== null && settledSignature !== savedSignature;
+
+  const resetHistoryRef = useRef(resetHistory);
+  useEffect(() => {
+    resetHistoryRef.current = resetHistory;
+  }, [resetHistory]);
+
+  const hasInteractedRef = useRef<boolean>(false);
+  useEffect(() => {
+    const freezeBaseline = (): void => {
+      if (hasInteractedRef.current) {
+        return;
+      }
+      hasInteractedRef.current = true;
+      // Rebase history on the settled pre-edit graph (discarding any entries
+      // recorded while it was still settling) and take it as the clean baseline.
+      setSavedSignature(resetHistoryRef.current());
+    };
+    window.addEventListener('pointerdown', freezeBaseline, true);
+    window.addEventListener('keydown', freezeBaseline, true);
+    return () => {
+      window.removeEventListener('pointerdown', freezeBaseline, true);
+      window.removeEventListener('keydown', freezeBaseline, true);
+    };
+  }, []);
+
+  // Rebase the clean baseline on the canvas snapshot that was actually
+  // persisted — the user may have kept editing while the save request was in
+  // flight, and those edits must stay dirty. History is intentionally NOT
+  // reset here: undoing past a save point simply makes the flow dirty again.
+  const handleSaved = useCallback((savedCanvas: {nodes: Node[]; edges: Edge[]}) => {
+    hasInteractedRef.current = true;
+    setSavedSignature(computeGraphSignature(savedCanvas.nodes, savedCanvas.edges));
+  }, []);
+
   // Flow save hook
   const {handleSave} = useFlowSave({
     flowId,
@@ -232,6 +287,7 @@ function LoginFlowBuilder() {
     showError,
     showSuccess,
     setOpenValidationPanel,
+    onSaved: handleSaved,
   });
 
   // SSO toggle orchestration (enable/disable transformations, placement mode)
@@ -246,6 +302,65 @@ function LoginFlowBuilder() {
   });
 
   const onNodesChange = defaultOnNodesChange;
+
+  // Undo/redo keyboard shortcuts. Ignore edits inside text fields / rich text so
+  // native text undo keeps working there.
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (!(event.ctrlKey || event.metaKey)) {
+        return;
+      }
+      const target = event.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.isContentEditable ||
+          target.closest('[contenteditable="true"]'))
+      ) {
+        return;
+      }
+      const key = event.key.toLowerCase();
+      if (key === 'z' && !event.shiftKey) {
+        event.preventDefault();
+        undo();
+      } else if ((key === 'z' && event.shiftKey) || key === 'y') {
+        event.preventDefault();
+        redo();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [undo, redo]);
+
+  // Warn before leaving (tab close / reload) with unsaved changes. Dirtiness is
+  // computed at unload time from the live graph, so the check stays exact even
+  // when the latest edit is still inside the history debounce window.
+  const graphRef = useRef<{nodes: Node[]; edges: Edge[]}>({edges, nodes});
+  useEffect(() => {
+    graphRef.current = {edges, nodes};
+  }, [nodes, edges]);
+
+  const savedSignatureRef = useRef<string | null>(savedSignature);
+  useEffect(() => {
+    savedSignatureRef.current = savedSignature;
+  }, [savedSignature]);
+
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent): void => {
+      if (savedSignatureRef.current === null) {
+        return;
+      }
+      const {nodes: liveNodes, edges: liveEdges} = graphRef.current;
+      if (computeGraphSignature(liveNodes, liveEdges) === savedSignatureRef.current) {
+        return;
+      }
+      event.preventDefault();
+      event.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, []);
 
   // Handle restore from history event
   useEffect(
@@ -384,6 +499,11 @@ function LoginFlowBuilder() {
         onFlowTitleChange={handleFlowNameChange}
         triggerAutoLayoutOnLoad={needsAutoLayout}
         resourcePanelFooter={ssoToggleFooter}
+        onUndo={undo}
+        onRedo={redo}
+        canUndo={canUndo}
+        canRedo={canRedo}
+        isDirty={isDirty}
       />
       <SsoDisableConfirmDialog
         open={sso.isConfirmDialogOpen}

--- a/frontend/apps/console/src/features/login-flow/hooks/__tests__/useFlowHistory.test.tsx
+++ b/frontend/apps/console/src/features/login-flow/hooks/__tests__/useFlowHistory.test.tsx
@@ -1,0 +1,313 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {act, renderHook} from '@testing-library/react';
+import type {Edge, Node} from '@xyflow/react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import useFlowHistory from '../useFlowHistory';
+
+const DEBOUNCE = 400;
+
+function node(id: string, x = 0, y = 0): Node {
+  return {data: {}, id, position: {x, y}, type: 'VIEW'};
+}
+
+function edge(id: string, source: string, target: string): Edge {
+  return {id, source, target};
+}
+
+/**
+ * Drives the hook like the state owner does: an external nodes/edges store the
+ * test mutates, re-rendering the hook with the new arrays (mirroring
+ * useNodesState/useEdgesState in LoginFlowBuilder).
+ */
+function setupHistory(initialNodes: Node[], initialEdges: Edge[]) {
+  let currentNodes = initialNodes;
+  let currentEdges = initialEdges;
+
+  const setNodes = vi.fn((update: Node[] | ((prev: Node[]) => Node[])) => {
+    currentNodes = typeof update === 'function' ? (update as (p: Node[]) => Node[])(currentNodes) : update;
+  });
+  const setEdges = vi.fn((update: Edge[] | ((prev: Edge[]) => Edge[])) => {
+    currentEdges = typeof update === 'function' ? (update as (p: Edge[]) => Edge[])(currentEdges) : update;
+  });
+
+  const view = renderHook(
+    ({nodes, edges}: {nodes: Node[]; edges: Edge[]}) =>
+      useFlowHistory({edges, maxHistoryItems: 20, nodes, setEdges, setNodes}),
+    {initialProps: {edges: initialEdges, nodes: initialNodes}},
+  );
+
+  const settle = (nodes: Node[], edges: Edge[]): void => {
+    currentNodes = nodes;
+    currentEdges = edges;
+    view.rerender({edges, nodes});
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE);
+    });
+  };
+
+  const flushApply = (): void => {
+    // apply() releases its guard in a requestAnimationFrame; then re-render with
+    // the restored arrays so the observer sees the settled (guarded-past) state.
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+    view.rerender({edges: currentEdges, nodes: currentNodes});
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE);
+    });
+  };
+
+  return {flushApply, getEdges: () => currentEdges, getNodes: () => currentNodes, settle, view};
+}
+
+describe('useFlowHistory', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (cb: FrameRequestCallback) => setTimeout(() => cb(0), 0) as unknown as number,
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('starts with empty undo/redo stacks', () => {
+    const {view} = setupHistory([node('a')], []);
+    expect(view.result.current.canUndo).toBe(false);
+    expect(view.result.current.canRedo).toBe(false);
+  });
+
+  it('does not record the initial load as a history entry', () => {
+    const {view, settle} = setupHistory([node('a')], []);
+    // First settle establishes the baseline only.
+    settle([node('a')], []);
+    expect(view.result.current.canUndo).toBe(false);
+  });
+
+  it('records a committed edit and can undo it', () => {
+    const {view, settle} = setupHistory([node('a')], []);
+    settle([node('a')], []); // baseline
+    settle([node('a'), node('b')], []); // add node b
+
+    expect(view.result.current.canUndo).toBe(true);
+    expect(view.result.current.canRedo).toBe(false);
+  });
+
+  it('undo restores the previous graph and enables redo', () => {
+    const {view, settle, getNodes} = setupHistory([node('a')], []);
+    settle([node('a')], []);
+    settle([node('a'), node('b')], []);
+
+    act(() => {
+      view.result.current.undo();
+    });
+
+    expect(getNodes().map((n) => n.id)).toEqual(['a']);
+    expect(view.result.current.canRedo).toBe(true);
+  });
+
+  it('redo re-applies an undone edit', () => {
+    const {view, settle, getNodes, flushApply} = setupHistory([node('a')], []);
+    settle([node('a')], []);
+    settle([node('a'), node('b')], []);
+
+    act(() => {
+      view.result.current.undo();
+    });
+    flushApply();
+
+    act(() => {
+      view.result.current.redo();
+    });
+    expect(getNodes().map((n) => n.id)).toEqual(['a', 'b']);
+  });
+
+  it('clears the redo stack when a new edit is made after an undo', () => {
+    const {view, settle, flushApply} = setupHistory([node('a')], []);
+    settle([node('a')], []);
+    settle([node('a'), node('b')], []);
+
+    act(() => {
+      view.result.current.undo();
+    });
+    flushApply();
+    expect(view.result.current.canRedo).toBe(true);
+
+    settle([node('a'), node('c')], []); // divergent new edit
+    expect(view.result.current.canRedo).toBe(false);
+  });
+
+  it('coalesces rapid changes within the debounce window into one entry', () => {
+    const {view, settle} = setupHistory([node('a')], []);
+    settle([node('a')], []); // baseline
+
+    // Three rapid re-renders inside one debounce window -> single commit.
+    view.rerender({edges: [], nodes: [node('a', 1, 0)]});
+    view.rerender({edges: [], nodes: [node('a', 2, 0)]});
+    view.rerender({edges: [], nodes: [node('a', 3, 0)]});
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE);
+    });
+
+    expect(view.result.current.canUndo).toBe(true);
+    act(() => {
+      view.result.current.undo();
+    });
+    // Only one undo returns to baseline.
+    expect(view.result.current.canUndo).toBe(false);
+  });
+
+  it('caps the undo stack at maxHistoryItems', () => {
+    let current: Node[] = [node('n0')];
+    const setNodes = vi.fn((update: Node[] | ((prev: Node[]) => Node[])) => {
+      current = typeof update === 'function' ? (update as (p: Node[]) => Node[])(current) : update;
+    });
+    const setEdges = vi.fn();
+    const view = renderHook(
+      ({nodes}: {nodes: Node[]}) => useFlowHistory({edges: [], maxHistoryItems: 3, nodes, setEdges, setNodes}),
+      {initialProps: {nodes: [node('n0')]}},
+    );
+
+    const commit = (nodes: Node[]): void => {
+      current = nodes;
+      view.rerender({nodes});
+      act(() => {
+        vi.advanceTimersByTime(DEBOUNCE);
+      });
+    };
+
+    commit([node('n0')]); // baseline
+    for (let i = 1; i <= 6; i += 1) {
+      commit([node(`n${i}`)]);
+    }
+
+    // At most 3 undos are retained.
+    let undoCount = 0;
+    while (view.result.current.canUndo && undoCount < 10) {
+      act(() => {
+        view.result.current.undo();
+      });
+      act(() => {
+        vi.advanceTimersByTime(16);
+      });
+      // Reflect the restored graph back into the hook, as the state owner does.
+      view.rerender({nodes: current});
+      undoCount += 1;
+    }
+    expect(undoCount).toBe(3);
+  });
+
+  it('resetHistory clears both stacks', () => {
+    const {view, settle} = setupHistory([node('a')], []);
+    settle([node('a')], []);
+    settle([node('a'), node('b')], []);
+    expect(view.result.current.canUndo).toBe(true);
+
+    act(() => {
+      view.result.current.resetHistory();
+    });
+    expect(view.result.current.canUndo).toBe(false);
+    expect(view.result.current.canRedo).toBe(false);
+  });
+
+  it('records edge changes', () => {
+    const {view, settle} = setupHistory([node('a'), node('b')], []);
+    settle([node('a'), node('b')], []);
+    settle([node('a'), node('b')], [edge('e1', 'a', 'b')]);
+    expect(view.result.current.canUndo).toBe(true);
+  });
+
+  it('undo within the debounce window reverts exactly the in-flight edit', () => {
+    const {view, settle, getNodes} = setupHistory([node('a')], []);
+    settle([node('a')], []); // baseline
+
+    // Edit that has NOT yet passed the debounce window.
+    view.rerender({edges: [], nodes: [node('a'), node('b')]});
+
+    act(() => {
+      view.result.current.undo();
+    });
+
+    // The pending edit is flushed into history first, so undo restores the
+    // graph the user was looking at just before the edit — not two steps back.
+    expect(getNodes().map((n) => n.id)).toEqual(['a']);
+    expect(view.result.current.canRedo).toBe(true);
+  });
+
+  it('a pending edit invalidates the redo branch', () => {
+    const {view, settle, flushApply} = setupHistory([node('a')], []);
+    settle([node('a')], []);
+    settle([node('a'), node('b')], []);
+
+    act(() => {
+      view.result.current.undo();
+    });
+    flushApply();
+    expect(view.result.current.canRedo).toBe(true);
+
+    // New divergent edit, still inside the debounce window.
+    view.rerender({edges: [], nodes: [node('a'), node('c')]});
+
+    act(() => {
+      view.result.current.redo();
+    });
+
+    // The flush committed the divergent edit and cleared the redo stack; the
+    // redo itself became a no-op instead of applying a stale future state.
+    expect(view.result.current.canRedo).toBe(false);
+  });
+
+  it('ignores a second undo while the first restore is still applying', () => {
+    const {view, settle, getNodes} = setupHistory([node('a')], []);
+    settle([node('a')], []);
+    settle([node('a'), node('b')], []);
+    settle([node('a'), node('b'), node('c')], []);
+
+    act(() => {
+      view.result.current.undo();
+      // Second call lands before the restore has been observed (rAF pending).
+      view.result.current.undo();
+    });
+
+    // Only one step back, not two.
+    expect(getNodes().map((n) => n.id)).toEqual(['a', 'b']);
+  });
+
+  it('exposes the settled signature and returns it from resetHistory', () => {
+    const {view, settle} = setupHistory([node('a')], []);
+    expect(view.result.current.settledSignature).toBeNull();
+
+    settle([node('a')], []); // baseline
+    const baselineSignature = view.result.current.settledSignature;
+    expect(baselineSignature).not.toBeNull();
+
+    settle([node('a'), node('b')], []);
+    expect(view.result.current.settledSignature).not.toBe(baselineSignature);
+
+    let returned = '';
+    act(() => {
+      returned = view.result.current.resetHistory();
+    });
+    expect(returned).toBe(view.result.current.settledSignature);
+  });
+});

--- a/frontend/apps/console/src/features/login-flow/hooks/__tests__/useFlowSave.test.ts
+++ b/frontend/apps/console/src/features/login-flow/hooks/__tests__/useFlowSave.test.ts
@@ -202,6 +202,46 @@ describe('useFlowSave', () => {
 
       expect(mockShowError).toHaveBeenCalledWith('flows:core.loginFlowBuilder.errors.saveFailed');
     });
+
+    it('should invoke onSaved with the persisted canvas data on create success', () => {
+      mockCreateFlowMutate.mockImplementation((_, options: {onSuccess: () => void}) => {
+        options.onSuccess();
+      });
+      const onSaved = vi.fn();
+      const canvasData = createMockCanvasData();
+
+      const {result} = renderUseFlowSave({
+        isEditingExistingFlow: false,
+        isFlowValid: true,
+        onSaved,
+      });
+
+      act(() => {
+        result.current.handleSave(canvasData);
+      });
+
+      expect(onSaved).toHaveBeenCalledTimes(1);
+      expect(onSaved).toHaveBeenCalledWith(canvasData);
+    });
+
+    it('should not invoke onSaved on create failure', () => {
+      mockCreateFlowMutate.mockImplementation((_, options: {onError: () => void}) => {
+        options.onError();
+      });
+      const onSaved = vi.fn();
+
+      const {result} = renderUseFlowSave({
+        isEditingExistingFlow: false,
+        isFlowValid: true,
+        onSaved,
+      });
+
+      act(() => {
+        result.current.handleSave(createMockCanvasData());
+      });
+
+      expect(onSaved).not.toHaveBeenCalled();
+    });
   });
 
   describe('handleSave - update existing flow', () => {
@@ -255,6 +295,28 @@ describe('useFlowSave', () => {
       });
 
       expect(mockShowSuccess).toHaveBeenCalledWith('flows:core.loginFlowBuilder.success.flowUpdated');
+    });
+
+    it('should invoke onSaved with the persisted canvas data on update success', () => {
+      mockUpdateFlowMutate.mockImplementation((_, options: {onSuccess: () => void}) => {
+        options.onSuccess();
+      });
+      const onSaved = vi.fn();
+      const canvasData = createMockCanvasData();
+
+      const {result} = renderUseFlowSave({
+        flowId: 'flow-123',
+        isEditingExistingFlow: true,
+        isFlowValid: true,
+        onSaved,
+      });
+
+      act(() => {
+        result.current.handleSave(canvasData);
+      });
+
+      expect(onSaved).toHaveBeenCalledTimes(1);
+      expect(onSaved).toHaveBeenCalledWith(canvasData);
     });
 
     it('should show error message on update failure', () => {

--- a/frontend/apps/console/src/features/login-flow/hooks/useFlowHistory.ts
+++ b/frontend/apps/console/src/features/login-flow/hooks/useFlowHistory.ts
@@ -1,0 +1,292 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {Edge, Node} from '@xyflow/react';
+import cloneDeep from 'lodash-es/cloneDeep';
+import type {Dispatch, SetStateAction} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
+import type {StepData} from '@/features/flows/models/steps';
+
+/**
+ * A point-in-time copy of the canvas graph.
+ */
+interface Snapshot {
+  nodes: Node[];
+  edges: Edge[];
+}
+
+export interface UseFlowHistoryProps {
+  /** Current canvas nodes (the full, unfiltered set). */
+  nodes: Node[];
+  /** Current canvas edges (the full, unfiltered set). */
+  edges: Edge[];
+  /** Setter for canvas nodes. */
+  setNodes: Dispatch<SetStateAction<Node[]>>;
+  /** Setter for canvas edges. */
+  setEdges: Dispatch<SetStateAction<Edge[]>>;
+  /** Maximum number of undo steps to retain. */
+  maxHistoryItems: number;
+  /** Debounce window (ms) for coalescing rapid edits into one history entry. */
+  debounceMs?: number;
+}
+
+export interface UseFlowHistoryReturn {
+  undo: () => void;
+  redo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+  /**
+   * Signature of the last settled (committed) graph state. Updates after edits
+   * settle, after undo/redo, and after {@link UseFlowHistoryReturn.resetHistory}
+   * — cheap to compare for dirty tracking without re-serializing per render.
+   */
+  settledSignature: string | null;
+  /**
+   * Discard all history and rebase the baseline on the current graph.
+   * Returns the signature of that baseline.
+   */
+  resetHistory: () => string;
+}
+
+/**
+ * Builds a structural signature of the graph. Captures everything an edit can
+ * change (ids, types, executors, positions, edge endpoints, node properties and
+ * components) so equal graphs share a signature and drag ticks that settle to
+ * the same layout do not record spurious history.
+ */
+export function computeGraphSignature(nodes: Node[], edges: Edge[]): string {
+  // Iterate in id order so the signature is insensitive to array ordering and
+  // equal graphs always share a signature.
+  const sortedNodes = [...nodes].sort((a, b) => a.id.localeCompare(b.id));
+  const sortedEdges = [...edges].sort((a, b) => a.id.localeCompare(b.id));
+
+  let signature = '';
+  for (const node of sortedNodes) {
+    const data = node.data as StepData | undefined;
+    signature +=
+      `${node.id}|${node.type ?? ''}|${Math.round(node.position?.x ?? 0)},${Math.round(node.position?.y ?? 0)}|` +
+      `${data?.action?.executor?.name ?? ''}|${JSON.stringify(data?.properties ?? null)}|` +
+      `${JSON.stringify(data?.components ?? null)};`;
+  }
+  signature += '::';
+  for (const edge of sortedEdges) {
+    signature += `${edge.id}|${edge.source}|${edge.sourceHandle ?? ''}|${edge.target}|${edge.targetHandle ?? ''};`;
+  }
+  return signature;
+}
+
+/**
+ * Snapshot-based undo/redo for the flow builder canvas.
+ *
+ * Because graph mutations are scattered across many hooks and go through both
+ * `setNodes`/`setEdges` and React Flow's internal store (which syncs back into
+ * the controlled arrays), history is observed at the state owner rather than at
+ * each call site: a debounced effect commits the previous graph to the undo
+ * stack whenever the graph settles into a new structural state.
+ *
+ * The stacks live in refs and are mutated synchronously from event handlers and
+ * the debounce timer, so rapid undo/redo (held shortcut, double clicks) never
+ * works off stale state; `canUndo`/`canRedo` are mirrored into state for the
+ * UI. Undo/redo first flush any pending (not yet debounced) edit so they always
+ * operate on exactly what the user sees.
+ */
+const useFlowHistory = ({
+  nodes,
+  edges,
+  setNodes,
+  setEdges,
+  maxHistoryItems,
+  debounceMs = 400,
+}: UseFlowHistoryProps): UseFlowHistoryReturn => {
+  const pastRef = useRef<Snapshot[]>([]);
+  const futureRef = useRef<Snapshot[]>([]);
+
+  const [availability, setAvailability] = useState<{canUndo: boolean; canRedo: boolean}>({
+    canRedo: false,
+    canUndo: false,
+  });
+  const [settledSignature, setSettledSignature] = useState<string | null>(null);
+
+  // The last graph state recorded as a committed baseline.
+  const committedRef = useRef<Snapshot>({edges, nodes});
+  const committedSignatureRef = useRef<string | null>(null);
+
+  // Guards the observer so an undo/redo (which calls setNodes/setEdges) does not
+  // record its own restore as a new edit, and undo/redo don't re-enter while a
+  // restore is still being observed.
+  const isApplyingRef = useRef<boolean>(false);
+  // The first observed state (initial mount / flow load) becomes the baseline.
+  const isInitializedRef = useRef<boolean>(false);
+
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const syncAvailability = useCallback(() => {
+    setAvailability((previous) => {
+      const next = {canRedo: futureRef.current.length > 0, canUndo: pastRef.current.length > 0};
+      return previous.canRedo === next.canRedo && previous.canUndo === next.canUndo ? previous : next;
+    });
+  }, []);
+
+  /**
+   * Commits the given graph as the new baseline, pushing the previous baseline
+   * to the undo stack. Returns whether anything was committed.
+   */
+  const commitIfChanged = useCallback(
+    (nextNodes: Node[], nextEdges: Edge[]): boolean => {
+      const nextSignature = computeGraphSignature(nextNodes, nextEdges);
+
+      if (!isInitializedRef.current) {
+        // First settle after load — establish the baseline, record nothing.
+        isInitializedRef.current = true;
+        committedRef.current = {edges: cloneDeep(nextEdges), nodes: cloneDeep(nextNodes)};
+        committedSignatureRef.current = nextSignature;
+        setSettledSignature(nextSignature);
+        return false;
+      }
+
+      if (nextSignature === committedSignatureRef.current) {
+        return false;
+      }
+
+      pastRef.current = [...pastRef.current, committedRef.current].slice(-maxHistoryItems);
+      futureRef.current = [];
+      committedRef.current = {edges: cloneDeep(nextEdges), nodes: cloneDeep(nextNodes)};
+      committedSignatureRef.current = nextSignature;
+      setSettledSignature(nextSignature);
+      syncAvailability();
+      return true;
+    },
+    [maxHistoryItems, syncAvailability],
+  );
+
+  /**
+   * Cancels the debounce and commits any in-flight edit immediately, so
+   * undo/redo act on the graph the user currently sees.
+   */
+  const flushPending = useCallback(
+    (currentNodes: Node[], currentEdges: Edge[]): boolean => {
+      if (debounceTimerRef.current !== null) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+      return commitIfChanged(currentNodes, currentEdges);
+    },
+    [commitIfChanged],
+  );
+
+  // Observe graph changes and, once settled, commit the prior state to history.
+  useEffect(() => {
+    if (isApplyingRef.current) {
+      return undefined;
+    }
+
+    if (debounceTimerRef.current !== null) {
+      clearTimeout(debounceTimerRef.current);
+    }
+
+    debounceTimerRef.current = setTimeout(() => {
+      debounceTimerRef.current = null;
+      commitIfChanged(nodes, edges);
+    }, debounceMs);
+
+    return () => {
+      if (debounceTimerRef.current !== null) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, [nodes, edges, debounceMs, commitIfChanged]);
+
+  const apply = useCallback(
+    (snapshot: Snapshot) => {
+      isApplyingRef.current = true;
+      committedRef.current = snapshot;
+      const signature = computeGraphSignature(snapshot.nodes, snapshot.edges);
+      committedSignatureRef.current = signature;
+      setSettledSignature(signature);
+      setNodes(cloneDeep(snapshot.nodes));
+      setEdges(cloneDeep(snapshot.edges));
+      // Release the guard after the resulting state change has been observed.
+      requestAnimationFrame(() => {
+        isApplyingRef.current = false;
+      });
+    },
+    [setNodes, setEdges],
+  );
+
+  const undo = useCallback(() => {
+    if (isApplyingRef.current) {
+      return;
+    }
+    // An edit still inside the debounce window becomes the top history entry,
+    // so this undo reverts exactly what is on screen.
+    flushPending(nodes, edges);
+    if (pastRef.current.length === 0) {
+      return;
+    }
+    const previous = pastRef.current[pastRef.current.length - 1];
+    pastRef.current = pastRef.current.slice(0, -1);
+    futureRef.current = [committedRef.current, ...futureRef.current];
+    apply(previous);
+    syncAvailability();
+  }, [nodes, edges, flushPending, apply, syncAvailability]);
+
+  const redo = useCallback(() => {
+    if (isApplyingRef.current) {
+      return;
+    }
+    // A pending edit invalidates the redo branch (same as a committed edit).
+    if (flushPending(nodes, edges)) {
+      return;
+    }
+    if (futureRef.current.length === 0) {
+      return;
+    }
+    const [next, ...rest] = futureRef.current;
+    futureRef.current = rest;
+    pastRef.current = [...pastRef.current, committedRef.current];
+    apply(next);
+    syncAvailability();
+  }, [nodes, edges, flushPending, apply, syncAvailability]);
+
+  const resetHistory = useCallback((): string => {
+    if (debounceTimerRef.current !== null) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+    pastRef.current = [];
+    futureRef.current = [];
+    const signature = computeGraphSignature(nodes, edges);
+    committedRef.current = {edges: cloneDeep(edges), nodes: cloneDeep(nodes)};
+    committedSignatureRef.current = signature;
+    isInitializedRef.current = true;
+    setSettledSignature(signature);
+    syncAvailability();
+    return signature;
+  }, [nodes, edges, syncAvailability]);
+
+  return {
+    canRedo: availability.canRedo,
+    canUndo: availability.canUndo,
+    redo,
+    resetHistory,
+    settledSignature,
+    undo,
+  };
+};
+
+export default useFlowHistory;

--- a/frontend/apps/console/src/features/login-flow/hooks/useFlowSave.ts
+++ b/frontend/apps/console/src/features/login-flow/hooks/useFlowSave.ts
@@ -58,6 +58,13 @@ export interface UseFlowSaveProps {
   showSuccess: (message: string) => void;
   /** Callback to open the validation panel. */
   setOpenValidationPanel?: (open: boolean) => void;
+  /**
+   * Called after the flow is persisted successfully, with the canvas data that
+   * was actually saved. Saving is async and editing stays enabled meanwhile, so
+   * dirty tracking must be rebased on this snapshot rather than on the live
+   * graph at success time.
+   */
+  onSaved?: (savedCanvas: CanvasData) => void;
 }
 
 /**
@@ -87,6 +94,7 @@ const useFlowSave = (props: UseFlowSaveProps): UseFlowSaveReturn => {
     showError,
     showSuccess,
     setOpenValidationPanel,
+    onSaved,
   } = props;
 
   const {t} = useTranslation();
@@ -124,6 +132,7 @@ const useFlowSave = (props: UseFlowSaveProps): UseFlowSaveReturn => {
           {
             onSuccess: () => {
               showSuccess(t('flows:core.loginFlowBuilder.success.flowUpdated'));
+              onSaved?.(canvasData);
             },
             onError: () => {
               showError(t('flows:core.loginFlowBuilder.errors.saveFailed'));
@@ -135,6 +144,7 @@ const useFlowSave = (props: UseFlowSaveProps): UseFlowSaveReturn => {
         createFlow.mutate(flowConfig as CreateFlowRequest, {
           onSuccess: () => {
             showSuccess(t('flows:core.loginFlowBuilder.success.flowCreated'));
+            onSaved?.(canvasData);
           },
           onError: () => {
             showError(t('flows:core.loginFlowBuilder.errors.saveFailed'));
@@ -152,6 +162,7 @@ const useFlowSave = (props: UseFlowSaveProps): UseFlowSaveReturn => {
       showError,
       showSuccess,
       setOpenValidationPanel,
+      onSaved,
       t,
       createFlow,
       updateFlow,

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -3620,6 +3620,13 @@ const translations = {
     'sso.properties.checkpointLabel': 'Session checkpoint',
     'sso.properties.checkpointDangling': 'The referenced session step no longer exists. Select a valid session step.',
 
+    // Discard unsaved changes dialog
+    'core.dialogs.discardChanges.title': 'Discard unsaved changes?',
+    'core.dialogs.discardChanges.description':
+      'You have unsaved changes to this flow. If you leave now, your changes will be lost.',
+    'core.dialogs.discardChanges.cancelButton': 'Keep editing',
+    'core.dialogs.discardChanges.confirmButton': 'Discard changes',
+
     // Form adapter
     'core.adapters.form.badgeLabel': 'Form',
     'core.adapters.form.placeholder': 'DROP FORM COMPONENTS HERE',
@@ -3628,6 +3635,11 @@ const translations = {
     'core.headerPanel.goBack': 'Go back to Flows',
     'core.headerPanel.autoLayout': 'Auto Layout',
     'core.headerPanel.save': 'Save',
+    'core.headerPanel.unsavedChanges': 'You have unsaved changes',
+    'core.headerPanel.undo': 'Undo',
+    'core.headerPanel.undoTooltip': 'Undo (Ctrl+Z / Cmd+Z)',
+    'core.headerPanel.redo': 'Redo',
+    'core.headerPanel.redoTooltip': 'Redo (Ctrl+Shift+Z / Cmd+Shift+Z)',
     'core.headerPanel.editTitle': 'Edit flow name',
     'core.headerPanel.saveTitle': 'Save flow name',
     'core.headerPanel.cancelEdit': 'Cancel',


### PR DESCRIPTION
### Purpose
Adds a safety net for editing in the flow builder canvas, implementing all three parts of #4062:

1. **Undo/redo** for canvas edits — a snapshot history over add/delete/move/rewire/rename/property changes, capped by the existing `MAX_HISTORY_ITEMS` (20). Ctrl/Cmd+Z undoes, Ctrl/Cmd+Shift+Z (and Ctrl+Y) redoes; undo/redo buttons sit in the canvas toolbar next to auto-layout/zoom.
2. **Unsaved-changes protection** — a dirty-state dot on the Save button, a "Discard unsaved changes?" dialog when clicking Back-to-Flows with unsaved work, and a `beforeunload` prompt on tab-close/reload.
3. **Save during preview** — the Save button is no longer disabled while previewing; clicking it stops the preview first (so the persisted viewport is the settled canvas, not the zoomed preview camera) and then saves.

Node/edge deletion stays a single click with no confirmation — with undo/redo in place that is the intended safety net, per the issue.

### Approach

**Undo/redo (snapshot history).** Canvas mutations are scattered across ~15 hooks and go through both `setNodes`/`setEdges` and React Flow's `updateNodeData`/`deleteElements`, so a new `useFlowHistory` hook observes the authoritative `nodes`/`edges` at the state owner (`LoginFlowBuilder`) rather than wrapping every call site. A debounced (400ms) effect commits the prior graph to the undo stack once the graph settles into a new structural signature, so one drag or one burst of typing collapses to a single entry. Undo/redo apply cloned snapshots through the existing setters; an "applying" guard stops a restore from recording itself. `undo`/`redo`/`canUndo`/`canRedo` thread down to `CanvasToolbar` as props (mirroring `onAutoLayout`); a keydown listener in `LoginFlowBuilder` handles the shortcuts and ignores events from inputs/rich-text so native text undo still works.

**Dirty tracking + navigation guard.** `LoginFlowBuilder` captures a graph-signature baseline after load and after each save (`useFlowSave` gained an `onSaved` callback); `isDirty` is the current-vs-baseline diff. The app uses `BrowserRouter` (no `useBlocker`), so the guard is manual: a `beforeunload` handler for hard exits and a new `DiscardChangesDialog` on the Back-to-Flows button. (Known gap: SPA sidebar navigation isn't intercepted — that needs a data-router migration, deferred.)

**Save during preview.** Since the preview only affects the viewport and transient CSS classes (never the authoritative nodes/edges), `handleSave` stops the simulation, fits the view instantly, then persists.

Scope decisions (confirmed before implementing): one PR for all three parts; local draft autosave via `AUTO_SAVE_INTERVAL` deferred to a follow-up; manual nav guard rather than a router migration.

### Related Issues
- Part of #4062

### Related PRs
- Touches the same flow-builder files as #4219 (Enable SSO toggle); whichever merges first, the other rebases.

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Undo and Redo controls to the flow designer, including keyboard shortcuts.
  * Added unsaved-change indicators and warnings when leaving or closing the page.
  * Added a confirmation dialog before discarding unsaved changes.
  * Saving remains available during flow preview.

* **Bug Fixes**
  * Improved save-state handling so successful saves clear the unsaved-change indicator.

* **Tests**
  * Added coverage for undo/redo behavior, history tracking, save state, and discard confirmations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->