### PR TITLE
Add Control Plane and Data Plane server builds with per-plane API gating

### DIFF
--- a/backend/cmd/cpserver/bootstrap_cmd.go
+++ b/backend/cmd/cpserver/bootstrap_cmd.go
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/thunder-id/thunderid/internal/system/bootstrap"
+	"github.com/thunder-id/thunderid/internal/system/cache"
+	"github.com/thunder-id/thunderid/internal/system/config"
+	dbprovider "github.com/thunder-id/thunderid/internal/system/database/provider"
+	"github.com/thunder-id/thunderid/internal/system/importer"
+	"github.com/thunder-id/thunderid/internal/system/log"
+)
+
+// bootstrapSubcommand is the first positional argument that selects the in-process
+// bootstrap one-shot instead of starting the long-running server.
+const bootstrapSubcommand = "bootstrap"
+
+// isBootstrapInvocation reports whether the process was started as the bootstrap
+// one-shot (e.g. `cpserver bootstrap --admin-username ...`).
+func isBootstrapInvocation() bool {
+	return flag.Arg(0) == bootstrapSubcommand
+}
+
+// runBootstrap parses the bootstrap subcommand options, runs the in-process
+// orchestrator, and tears down the shared resources. It does not start an HTTP
+// listener. It returns an error describing why bootstrap failed, if it did, so the
+// caller can log the reason before exiting.
+func runBootstrap(ctx context.Context, logger *log.Logger, serverHome string,
+	importSvc importer.ImportServiceInterface, cacheManager cache.CacheManagerInterface) error {
+	opts, err := parseBootstrapOptions(serverHome, flag.Args()[1:])
+	if err != nil {
+		shutdownBootstrap(ctx, logger, cacheManager)
+		return err
+	}
+	err = bootstrap.Run(ctx, importSvc, opts)
+	if err == nil {
+		printBootstrapSummary()
+	}
+	shutdownBootstrap(ctx, logger, cacheManager)
+	return err
+}
+
+// printBootstrapSummary prints the admin credentials and role created by the bootstrap.
+func printBootstrapSummary() {
+	fmt.Println()
+	fmt.Println("✅ Default resources setup completed successfully!")
+	fmt.Println()
+	fmt.Println("👤 Admin credentials:")
+	fmt.Printf("   Username: %s\n", os.Getenv("ADMIN_USERNAME"))
+	fmt.Printf("   Password: %s\n", os.Getenv("ADMIN_PASSWORD"))
+	fmt.Println("   Role: Administrator (system permission via Administrators group)")
+	fmt.Println()
+}
+
+// parseBootstrapOptions parses the bootstrap subcommand flags and exports the admin
+// credentials and public URL to the environment, so the bundle's
+// `{{ .ADMIN_USERNAME }}` / `{{ .ADMIN_PASSWORD }}` / `{{ .PUBLIC_URL }}` placeholders
+// resolve at import time. Flags override the environment. The admin username defaults
+// to "admin". The admin password has no default and no generation logic here: this
+// subcommand never invents security material on its own, so callers (setup.sh/setup.ps1
+// generate one if needed) must supply a non-empty ADMIN_PASSWORD, or bootstrap fails.
+func parseBootstrapOptions(serverHome string, args []string) (bootstrap.Options, error) {
+	fs := flag.NewFlagSet(bootstrapSubcommand, flag.ContinueOnError)
+	adminUsername := fs.String("admin-username", "", "Username for the default admin user")
+	adminPassword := fs.String("admin-password", "", "Password for the default admin user")
+	consoleRedirectURIs := fs.String("console-redirect-uris", "",
+		"Comma-separated extra redirect URIs for the Console application")
+	defaultsDir := fs.String("defaults", "", "Path to the bootstrap resource definitions directory")
+	// Flags are best-effort; unknown flags must not abort bootstrap.
+	_ = fs.Parse(args)
+
+	setEnv("ADMIN_USERNAME", firstNonEmpty(*adminUsername, os.Getenv("ADMIN_USERNAME"), "admin"))
+
+	password := firstNonEmpty(*adminPassword, os.Getenv("ADMIN_PASSWORD"))
+	if password == "" {
+		return bootstrap.Options{}, fmt.Errorf(
+			"no admin password supplied: set --admin-password or ADMIN_PASSWORD")
+	}
+	setEnv("ADMIN_PASSWORD", password)
+
+	setEnv("PUBLIC_URL", firstNonEmpty(os.Getenv("PUBLIC_URL"),
+		config.GetServerURL(&config.GetServerRuntime().Config.Server)))
+	// The bundle ranges over CONSOLE_REDIRECT_URIS, which buildArrayFromEnvVars
+	// reconstructs from the indexed CONSOLE_REDIRECT_URIS_0, _1, ... variables.
+	idx := 0
+	for _, uri := range strings.Split(*consoleRedirectURIs, ",") {
+		if uri = strings.TrimSpace(uri); uri != "" {
+			setEnv(fmt.Sprintf("CONSOLE_REDIRECT_URIS_%d", idx), uri)
+			idx++
+		}
+	}
+
+	dir := *defaultsDir
+	if dir == "" {
+		dir = path.Join(serverHome, "bootstrap")
+	}
+	return bootstrap.Options{DefaultsDir: dir}, nil
+}
+
+// setEnv sets an environment variable, ignoring the (practically impossible) error
+// for a fixed, valid key.
+func setEnv(key, value string) {
+	_ = os.Setenv(key, value)
+}
+
+// shutdownBootstrap releases the shared resources used by the bootstrap one-shot.
+func shutdownBootstrap(ctx context.Context, logger *log.Logger, cacheManager cache.CacheManagerInterface) {
+	unregisterServices()
+
+	if err := dbprovider.GetDBProviderCloser().Close(); err != nil {
+		logger.Error(ctx, "Error closing database connections", log.Error(err))
+	}
+
+	if cacheManager != nil {
+		cacheManager.Close()
+	}
+}
+
+// firstNonEmpty returns the first non-empty string from the provided values.
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/backend/cmd/cpserver/main.go
+++ b/backend/cmd/cpserver/main.go
@@ -1,0 +1,445 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package main is the entry point for starting the ThunderID Control Plane server.
+//
+// It is the CP counterpart of cmd/server/main.go. The lifecycle is identical (config load,
+// security middleware, TLS listener, graceful shutdown), with two intentional differences:
+// only the Console SPA is served (the Gate login SPA is a Data Plane concern), and the
+// service registration wires management services only (see servicemanager.go).
+//
+// NOTE: the server-lifecycle helpers below are duplicated from cmd/server for the scaffold.
+// A follow-up can extract them into a shared internal package consumed by both entry points.
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"flag"
+	"fmt"
+	"io/fs"
+	"mime"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"path"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/thunder-id/thunderid/internal/system/cache"
+	"github.com/thunder-id/thunderid/internal/system/config"
+	"github.com/thunder-id/thunderid/internal/system/constants"
+	"github.com/thunder-id/thunderid/internal/system/database/provider"
+	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
+	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/middleware"
+	"github.com/thunder-id/thunderid/internal/system/revocationcache"
+	"github.com/thunder-id/thunderid/internal/system/security"
+)
+
+// shutdownTimeout defines the timeout duration for graceful shutdown.
+const shutdownTimeout = 5 * time.Second
+
+var (
+	netListen = net.Listen
+	tlsListen = tls.Listen
+)
+
+func main() {
+	// Server bootstrap/shutdown logging has no request scope, so context.Background() is used.
+	ctx := context.Background()
+	startupStartedAt := time.Now()
+	logger := log.GetLogger()
+
+	flag.String("resources", "", "Path to declarative resources YAML file")
+	serverHome := getThunderHome(ctx, logger)
+
+	cfg := initThunderConfigurations(ctx, logger, serverHome)
+	if cfg == nil {
+		logger.Fatal(ctx, "Failed to initialize configurations")
+	}
+
+	// Apply the configured log level from deployment.yaml, now that config is loaded.
+	if cfg.Log.Level != "" {
+		if err := logger.SetLevel(cfg.Log.Level); err != nil {
+			logger.Fatal(ctx, "Invalid log level in configuration", log.Error(err))
+		}
+	}
+
+	// Apply the configured log output (console and/or rotating file), now that the
+	// server home is known and the file path can be resolved.
+	if err := logger.Configure(cfg.Log.BuildOutputOptions(serverHome)); err != nil {
+		logger.Fatal(ctx, "Failed to configure log output", log.Error(err))
+	}
+
+	// Initialize the cache manager.
+	cacheManager := cache.Initialize(cfg.Cache, cfg.Server.Identifier)
+
+	// Initialize system permission strings before any service or middleware uses them.
+	security.InitSystemPermissions(cfg.Server.SecurityConfig.SystemPermissionPrefix)
+
+	// Create a new HTTP multiplexer.
+	mux := http.NewServeMux()
+	if mux == nil {
+		logger.Fatal(ctx, "Failed to initialize multiplexer")
+	}
+
+	// Register the Control Plane services.
+	jwtService, runtimeCryptoSvc, importService := registerServices(mux, cacheManager)
+
+	// When invoked as the bootstrap one-shot (`cpserver bootstrap`), create the
+	// default resources in-process and exit without starting the HTTP server.
+	if isBootstrapInvocation() {
+		if err := runBootstrap(ctx, logger, serverHome, importService, cacheManager); err != nil {
+			logger.Error(ctx, "In-process bootstrap failed; exiting", log.Error(err))
+			os.Exit(1)
+		}
+		logger.Info(ctx, "In-process bootstrap finished successfully")
+		return
+	}
+
+	// Initialize the Resource Server token-revocation cache. The initial deny-list snapshot is loaded
+	// synchronously so enforcement is live before the first request; if that load fails the server
+	// still starts and the syncer repopulates the cache on its next tick.
+	revocationEnforcer, revocationSyncer := initRevocationCache(ctx, logger, cfg)
+	revocationSyncer.Start(ctx)
+
+	// Register static file handlers for frontend applications.
+	registerStaticFileHandlers(ctx, logger, mux, serverHome)
+
+	// Setup signal handling for graceful shutdown
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+
+	// Create the HTTP server.
+	server := createHTTPServer(ctx, logger, cfg, mux, jwtService, revocationEnforcer)
+	var ln net.Listener
+	if cfg.Server.HTTPOnly {
+		logger.Info(ctx, "TLS is not enabled, starting server without TLS")
+		ln = createListener(ctx, logger, server)
+	} else {
+		tlsConfig := loadCertConfig(ctx, logger, runtimeCryptoSvc)
+		ln = createTLSListener(ctx, logger, server, tlsConfig)
+	}
+
+	serverURL := config.GetServerURL(&cfg.Server)
+	consoleURL := fmt.Sprintf("%s/console", strings.TrimSuffix(serverURL, "/"))
+	logger.Info(ctx, "ThunderID Control Plane URL", log.String("url", serverURL))
+	logger.Info(ctx, "ThunderID Console URL", log.String("url", consoleURL))
+
+	// Start server in a goroutine
+	go func() {
+		startupDuration := time.Since(startupStartedAt)
+		logger.Info(ctx, "ThunderID Control Plane started", log.String("startup_time", startupDuration.String()))
+		if err := server.Serve(ln); err != nil && err != http.ErrServerClosed {
+			logger.Fatal(ctx, "Failed to serve requests", log.Error(err))
+		}
+	}()
+
+	// Wait for shutdown signal
+	<-sigChan
+	logger.Info(ctx, "Shutting down server...")
+	gracefulShutdown(ctx, logger, server, cacheManager, revocationSyncer)
+}
+
+// initRevocationCache builds the Resource Server token-revocation enforcer and its background syncer
+// from the server security configuration. An unsupported source configuration fails startup; a
+// failed initial deny-list load does not — the server starts and the syncer populates the cache later.
+func initRevocationCache(ctx context.Context, logger *log.Logger,
+	cfg *config.Config) (revocationcache.EnforcerInterface, revocationcache.Syncer) {
+	rc := cfg.Server.SecurityConfig.TokenRevocation
+	enforcer, syncer, err := revocationcache.Initialize(revocationcache.Config{
+		Enabled:      rc.Enabled,
+		Source:       rc.Source,
+		SyncInterval: time.Duration(rc.SyncIntervalSeconds) * time.Second,
+	})
+	if err != nil {
+		logger.Fatal(ctx, "Failed to initialize token revocation cache", log.Error(err))
+	}
+	return enforcer, syncer
+}
+
+// getThunderHome retrieves and return the home directory.
+func getThunderHome(ctx context.Context, logger *log.Logger) string {
+	// Parse project directory from command line arguments.
+	projectHome := ""
+	projectHomeFlag := flag.String("serverHome", "", "Path to ThunderID home directory")
+	flag.Parse()
+
+	if *projectHomeFlag != "" {
+		logger.Info(ctx, "Using serverHome from command line argument",
+			log.String("serverHome", *projectHomeFlag))
+		projectHome = *projectHomeFlag
+	} else {
+		// If no command line argument is provided, use the current working directory.
+		dir, dirErr := os.Getwd()
+		if dirErr != nil {
+			logger.Fatal(ctx, "Failed to get current working directory", log.Error(dirErr))
+		}
+		projectHome = dir
+	}
+
+	return projectHome
+}
+
+// initThunderConfigurations initializes the configurations.
+func initThunderConfigurations(ctx context.Context, logger *log.Logger, serverHome string) *config.Config {
+	// Load the configurations.
+	configFilePath := path.Join(serverHome, "deployment.yaml")
+	defaultConfigPath := path.Join(serverHome, "config/default.json")
+	cfg, err := config.LoadConfig(configFilePath, defaultConfigPath, serverHome)
+	if err != nil {
+		logger.Fatal(ctx, "Failed to load configurations", log.Error(err))
+	}
+
+	// This is the Control Plane build: default the instance mode to "cp" when the deployment does not
+	// set one, so control-plane authoring routes are served and any data-plane routes that a shared
+	// service registers (e.g. role assignment under /roles) are gated off. An explicit mode in
+	// deployment.yaml still takes precedence.
+	if cfg.Server.Mode == "" {
+		cfg.Server.Mode = "cp"
+	}
+
+	// Initialize runtime configurations.
+	if err := config.InitializeServerRuntime(serverHome, cfg); err != nil {
+		logger.Fatal(ctx, "Failed to initialize server runtime", log.Error(err))
+	}
+
+	return cfg
+}
+
+// loadCertConfig loads the TLS material via the runtime crypto provider.
+func loadCertConfig(ctx context.Context, logger *log.Logger, runtimeSvc kmprovider.RuntimeCryptoProvider) *tls.Config {
+	mat, err := runtimeSvc.GetTLSMaterial(ctx)
+	if err != nil {
+		logger.Fatal(ctx, "Failed to load TLS material", log.Error(err))
+	}
+	// #nosec G402 -- MinVersion is set to TLS 1.2 or higher by GetTLSMaterial
+	return &tls.Config{
+		Certificates: []tls.Certificate{mat.Certificate},
+		MinVersion:   mat.MinVersion,
+	}
+}
+
+// accessLogExcludePaths returns the path prefixes excluded from the access log: the always-excluded
+// Console frontend path plus any configured extras. Empty and root ("/") entries are dropped because
+// they match every request and would silently disable all access logging.
+func accessLogExcludePaths(configured []string) []string {
+	paths := []string{"/console/"}
+	for _, prefix := range configured {
+		if prefix != "" && prefix != "/" {
+			paths = append(paths, prefix)
+		}
+	}
+	return paths
+}
+
+// createHTTPServer creates and configures an HTTP server with common settings.
+func createHTTPServer(ctx context.Context, logger *log.Logger, cfg *config.Config, mux *http.ServeMux,
+	jwtService jwt.JWTServiceInterface, revocationEnforcer revocationcache.EnforcerInterface) *http.Server {
+	securityMiddleware := createSecurityMiddleware(ctx, logger, mux, jwtService, revocationEnforcer)
+
+	// Build the middleware chain with proper execution order.
+	// Request flow: CorrelationID (outermost) -> AccessLog -> Security -> Route Handler (innermost)
+	// Note: Middlewares are wrapped in reverse order - the last added will execute first.
+	handler := log.AccessLogHandler(logger, accessLogExcludePaths(cfg.Log.Access.ExcludePaths), securityMiddleware)
+	handler = middleware.CorrelationIDMiddleware(handler)
+
+	// Build the server address using hostname and port from the configurations.
+	serverAddr := fmt.Sprintf("%s:%d", cfg.Server.Hostname, cfg.Server.Port)
+
+	server := &http.Server{
+		Addr:              serverAddr,
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second, // Mitigate Slowloris attacks
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       120 * time.Second,
+		ErrorLog:          log.NewServerErrorLog(logger),
+	}
+
+	return server
+}
+
+// createListener creates and returns a listener for the HTTP server.
+func createListener(ctx context.Context, logger *log.Logger, server *http.Server) net.Listener {
+	ln, err := netListen("tcp", server.Addr)
+	if err != nil {
+		logger.Fatal(ctx, "Failed to start HTTP listener", log.Error(err))
+	}
+	return ln
+}
+
+// createTLSListener creates and returns a TLS listener for the HTTPS server.
+func createTLSListener(ctx context.Context, logger *log.Logger, server *http.Server,
+	tlsConfig *tls.Config) net.Listener {
+	ln, err := tlsListen("tcp", server.Addr, tlsConfig)
+	if err != nil {
+		logger.Fatal(ctx, "Failed to start TLS listener", log.Error(err))
+	}
+	return ln
+}
+
+func createSecurityMiddleware(ctx context.Context, logger *log.Logger, mux *http.ServeMux,
+	jwtService jwt.JWTServiceInterface, revocationEnforcer revocationcache.EnforcerInterface) http.Handler {
+	middlewareFunc, err := security.Initialize(jwtService, revocationEnforcer)
+	if err != nil {
+		logger.Fatal(ctx, "Failed to initialize security middleware", log.Error(err))
+	}
+	return middlewareFunc(mux)
+}
+
+// gracefulShutdown handles the graceful shutdown of all components.
+func gracefulShutdown(
+	ctx context.Context,
+	logger *log.Logger,
+	server *http.Server,
+	cacheManager cache.CacheManagerInterface,
+	revocationSyncer revocationcache.Syncer,
+) {
+	ctx, cancel := context.WithTimeout(ctx, shutdownTimeout)
+	defer cancel()
+
+	// Shutdown HTTP server
+	if err := server.Shutdown(ctx); err != nil {
+		logger.Error(ctx, "Error during server shutdown", log.Error(err))
+	} else {
+		logger.Debug(ctx, "HTTP server shutdown completed")
+	}
+
+	// Stop the token-revocation cache syncer.
+	revocationSyncer.Stop()
+
+	// Shutdown services
+	unregisterServices()
+
+	// Close database connections
+	dbCloser := provider.GetDBProviderCloser()
+	if err := dbCloser.Close(); err != nil {
+		logger.Error(ctx, "Error closing database connections", log.Error(err))
+	} else {
+		logger.Debug(ctx, "Database connections closed successfully")
+	}
+
+	if cacheManager != nil {
+		cacheManager.Close()
+		logger.Debug(ctx, "Cache manager closed successfully")
+	}
+
+	// Close the log file writer before the final shutdown log line.
+	if err := logger.Close(); err != nil {
+		logger.Error(ctx, "Error closing log file", log.Error(err))
+	}
+
+	logger.Info(ctx, "Server shutdown completed")
+}
+
+// registerStaticFileHandlers registers the static file handler for the Console SPA. The CP does not
+// serve the Gate login SPA, which belongs to the Data Plane.
+func registerStaticFileHandlers(ctx context.Context, logger *log.Logger, mux *http.ServeMux, serverHome string) {
+	// Override the OS-level MIME mapping so .js/.mjs files are served as
+	// application/javascript. Most proxies (Envoy, NGINX, Cloudflare) only
+	// compress application/javascript in their default allowlists, not
+	// text/javascript, which is Go's default on some systems.
+	_ = mime.AddExtensionType(".js", "application/javascript; charset=utf-8")
+	_ = mime.AddExtensionType(".mjs", "application/javascript; charset=utf-8")
+
+	// Serve console application from /console
+	consoleDir := path.Join(serverHome, "apps", "console")
+	if handler, err := createStaticFileHandler("/console/", consoleDir, logger); err != nil {
+		logger.Warn(ctx, "Console application not registered", log.String("directory", consoleDir), log.Error(err))
+	} else {
+		logger.Debug(ctx, "Registering static file handler for Console application",
+			log.String("path", "/console/"), log.String("directory", consoleDir))
+		mux.Handle("/console/", handler)
+	}
+}
+
+// createStaticFileHandler creates a handler for serving static files with SPA fallback.
+//
+// All filesystem access is performed through an os.Root anchored at `directory`, which
+// confines every lookup below that directory: any request path that would escape it fails
+// with a path-escape error rather than reaching the filesystem.
+func createStaticFileHandler(routePrefix, directory string, logger *log.Logger) (http.Handler, error) {
+	root, err := os.OpenRoot(directory)
+	if err != nil {
+		return nil, err
+	}
+	rootFS := root.FS()
+	fileServer := http.FileServerFS(rootFS)
+
+	// serveIndex serves index.html with no-cache headers. It reports whether index.html
+	// existed and was served.
+	serveIndex := func(w http.ResponseWriter, r *http.Request) bool {
+		if _, err := root.Stat("index.html"); err != nil {
+			return false
+		}
+		w.Header().Set(constants.CacheControlHeaderName, constants.CacheControlNoCacheComposite)
+		w.Header().Set(constants.PragmaHeaderName, constants.PragmaNoCache)
+		w.Header().Set(constants.ExpiresHeaderName, constants.ExpiresZero)
+		http.ServeFileFS(w, r, rootFS, "index.html")
+		return true
+	}
+
+	return http.StripPrefix(routePrefix, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Handle the application root by explicitly serving index.html.
+		if r.URL.Path == "/" || r.URL.Path == "" {
+			if serveIndex(w, r) {
+				return
+			}
+		}
+
+		// Resolve the request against the served directory.
+		name := strings.TrimPrefix(r.URL.Path, "/")
+		isIndexHTML := name == "index.html"
+
+		if name != "" {
+			if _, err := root.Stat(name); err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					// For SPA routing, serve index.html for non-existent in-bounds paths.
+					logger.Debug(r.Context(), "Serving index.html for SPA routing",
+						log.String("requested_path", r.URL.Path),
+						log.String("route_prefix", routePrefix))
+					if serveIndex(w, r) {
+						return
+					}
+				} else {
+					// The path escapes the served directory (or is otherwise invalid).
+					logger.Warn(r.Context(), "Rejected request with out-of-bounds path",
+						log.String("requested_path", r.URL.Path),
+						log.String("route_prefix", routePrefix))
+					http.NotFound(w, r)
+					return
+				}
+			}
+		}
+
+		// Serve index.html directly with no-cache headers when requested.
+		if isIndexHTML {
+			if serveIndex(w, r) {
+				return
+			}
+		}
+
+		// Serve the requested file or directory listing.
+		fileServer.ServeHTTP(w, r)
+	})), nil
+}

--- a/backend/cmd/cpserver/servicemanager.go
+++ b/backend/cmd/cpserver/servicemanager.go
@@ -1,0 +1,437 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package main is the Control Plane (CP) server entry point. It registers only the
+// management services: resource CRUD APIs, their configuration/entity persistence, and
+// management-time validation. Runtime (Data Plane) components are deliberately not
+// wired here: no OAuth2/OIDC token issuance, no user login/authn, no flow execution,
+// no authorization evaluation, and no verifiable-credential issuance/verification.
+//
+// This file is the CP counterpart of cmd/server/servicemanager.go. Anything present
+// there but absent here is a Data Plane concern that the CP build drops.
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/thunder-id/thunderid/internal/agent"
+	"github.com/thunder-id/thunderid/internal/application"
+	"github.com/thunder-id/thunderid/internal/authn/github"
+	"github.com/thunder-id/thunderid/internal/authn/google"
+	authnOAuth "github.com/thunder-id/thunderid/internal/authn/oauth"
+	authnOIDC "github.com/thunder-id/thunderid/internal/authn/oidc"
+	"github.com/thunder-id/thunderid/internal/cert"
+	"github.com/thunder-id/thunderid/internal/connection"
+	layoutmgt "github.com/thunder-id/thunderid/internal/design/layout/mgt"
+	thememgt "github.com/thunder-id/thunderid/internal/design/theme/mgt"
+	"github.com/thunder-id/thunderid/internal/entity"
+	"github.com/thunder-id/thunderid/internal/entityprovider"
+	"github.com/thunder-id/thunderid/internal/entitytype"
+	flowconfig "github.com/thunder-id/thunderid/internal/flow/config"
+	flowcore "github.com/thunder-id/thunderid/internal/flow/core"
+	"github.com/thunder-id/thunderid/internal/flow/executor"
+	"github.com/thunder-id/thunderid/internal/flow/graphbuilder"
+	"github.com/thunder-id/thunderid/internal/flow/interceptor"
+	flowmgt "github.com/thunder-id/thunderid/internal/flow/mgt"
+	"github.com/thunder-id/thunderid/internal/group"
+	"github.com/thunder-id/thunderid/internal/idp"
+	"github.com/thunder-id/thunderid/internal/inboundclient"
+	"github.com/thunder-id/thunderid/internal/notification"
+	"github.com/thunder-id/thunderid/internal/ou"
+	"github.com/thunder-id/thunderid/internal/resource"
+	"github.com/thunder-id/thunderid/internal/role"
+	"github.com/thunder-id/thunderid/internal/serverconfig"
+	"github.com/thunder-id/thunderid/internal/system/cache"
+	"github.com/thunder-id/thunderid/internal/system/config"
+	"github.com/thunder-id/thunderid/internal/system/cors"
+	"github.com/thunder-id/thunderid/internal/system/cryptolib"
+	dbprovider "github.com/thunder-id/thunderid/internal/system/database/provider"
+	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
+	"github.com/thunder-id/thunderid/internal/system/export"
+	healthcheckservice "github.com/thunder-id/thunderid/internal/system/healthcheck/service"
+	i18nmgt "github.com/thunder-id/thunderid/internal/system/i18n/mgt"
+	"github.com/thunder-id/thunderid/internal/system/importer"
+	"github.com/thunder-id/thunderid/internal/system/jose"
+	joseconfig "github.com/thunder-id/thunderid/internal/system/jose/config"
+	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
+	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	"github.com/thunder-id/thunderid/internal/system/kmprovider/defaultkm/pki"
+	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/mcp"
+	"github.com/thunder-id/thunderid/internal/system/observability"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
+	"github.com/thunder-id/thunderid/internal/system/services"
+	"github.com/thunder-id/thunderid/internal/system/sysauthz"
+	"github.com/thunder-id/thunderid/internal/user"
+	"github.com/thunder-id/thunderid/internal/vc/credential"
+	"github.com/thunder-id/thunderid/internal/vc/presentation"
+)
+
+// observabilitySvc is the observability service instance. This is used for graceful shutdown.
+var observabilitySvc observability.ObservabilityServiceInterface
+
+// registerServices registers the Control Plane management services with the provided HTTP
+// multiplexer. It also returns the import service so the bootstrap subcommand can create default
+// resources in-process through the same service instances.
+func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterface) (
+	jwt.JWTServiceInterface, kmprovider.RuntimeCryptoProvider, importer.ImportServiceInterface) {
+	logger := log.GetLogger()
+
+	// Service registration runs during application startup, outside any request.
+	ctx := context.Background()
+
+	// Load the server's private key. On the CP this signs the management API surface's JWTs and
+	// provides the config-at-rest encryption key used by the application service; it does not issue
+	// end-user access/ID tokens (that is a Data Plane responsibility).
+	pkiService, err := pki.Initialize()
+	fatalOnError(ctx, logger, err, "Failed to initialize certificate service")
+
+	runtimeCryptoSvc, _, err := kmprovider.Initialize(pkiService)
+	fatalOnError(ctx, logger, err, "Failed to initialize key manager provider")
+
+	runtime := config.GetServerRuntime()
+	joseCfg := joseconfig.Config{
+		Issuer:         runtime.Config.JWT.Issuer,
+		ValidityPeriod: runtime.Config.JWT.ValidityPeriod,
+		Audience:       runtime.Config.JWT.Audience,
+		PreferredKeyID: runtime.Config.JWT.PreferredKeyID,
+		Leeway:         runtime.Config.JWT.Leeway,
+		JWKSCacheTTL:   time.Duration(runtime.Config.Server.SecurityConfig.JWKSCacheTTL) * time.Second,
+	}
+	jwtService, _, err := jose.Initialize(runtimeCryptoSvc, joseCfg)
+	fatalOnError(ctx, logger, err, "Failed to initialize JOSE services")
+
+	observabilitySvc = observability.Initialize(config.GetServerRuntime().Config.Observability)
+
+	// Initialize MCP server early so packages initializing below can register tools.
+	mcpServer := mcp.Initialize(mux, jwtService)
+
+	// List to collect exporters from each package
+	var exporters []declarativeresource.ResourceExporter
+
+	// Initialize i18n service for internationalization support.
+	i18nService, i18nExporter, err := i18nmgt.Initialize(mux, config.GetServerRuntime().Config.Translation)
+	fatalOnError(ctx, logger, err, "Failed to initialize i18n service")
+	exporters = append(exporters, i18nExporter)
+
+	ouAuthzService, err := sysauthz.Initialize()
+	fatalOnError(ctx, logger, err, "Failed to initialize system authorization service")
+
+	ouService, ouHierarchyResolver, ouExporter, err := ou.Initialize(mux, mcpServer, cacheManager, ouAuthzService)
+	fatalOnError(ctx, logger, err, "Failed to initialize OrganizationUnitService")
+	exporters = append(exporters, ouExporter)
+
+	// Complete the two-phase initialization: inject the OU hierarchy resolver into the
+	// authz service now that the ou package is ready.
+	ouAuthzService.SetOUHierarchyResolver(ouHierarchyResolver)
+
+	hashCfg, err := buildHashConfig()
+	fatalOnError(ctx, logger, err, "Failed to build HashService config")
+	hashService, err := cryptolib.Initialize(hashCfg)
+	fatalOnError(ctx, logger, err, "Failed to initialize HashService")
+
+	entityTypeService, entityTypeExporter, err := entitytype.Initialize(
+		mux, mcpServer, cacheManager, ouService, ouAuthzService)
+	fatalOnError(ctx, logger, err, "Failed to initialize EntityTypeService")
+	exporters = append(exporters, entityTypeExporter)
+
+	entityService, err := entity.Initialize(cacheManager, hashService, entityTypeService, ouService)
+	fatalOnError(ctx, logger, err, "Failed to initialize EntityService")
+
+	entityProvider := entityprovider.InitializeEntityProvider(entityService)
+
+	userService, ouUserResolver, userExporter, err := user.Initialize(
+		mux, entityService, ouService, entityTypeService, ouAuthzService,
+	)
+	fatalOnError(ctx, logger, err, "Failed to initialize UserService")
+	exporters = append(exporters, userExporter)
+
+	groupService, ouGroupResolver, groupExporter, err := group.Initialize(
+		mux, dbprovider.GetDBProvider(), ouService, entityService, entityTypeService, ouAuthzService,
+	)
+	fatalOnError(ctx, logger, err, "Failed to initialize GroupService")
+	exporters = append(exporters, groupExporter)
+
+	resourceService, resourceExporter, err := resource.Initialize(mux, ouService)
+	fatalOnError(ctx, logger, err, "Failed to initialize Resource Service")
+	exporters = append(exporters, resourceExporter)
+
+	roleService, roleAssignmentService, ouRoleResolver, roleExporter, err := role.Initialize(
+		mux, entityService, groupService, ouService, resourceService, entityTypeService,
+	)
+	fatalOnError(ctx, logger, err, "Failed to initialize RoleService")
+	exporters = append(exporters, roleExporter)
+
+	// Two-phase initialization: inject user/group/role resolvers into OU service.
+	ouService.SetOUUserResolver(ouUserResolver)
+	ouService.SetOUGroupResolver(ouGroupResolver)
+	ouService.SetOURoleResolver(ouRoleResolver)
+
+	idpService, err := idp.Initialize(cacheManager, entityTypeService)
+	fatalOnError(ctx, logger, err, "Failed to initialize IDPService")
+
+	// Notification: the CP keeps only the sender-management (CRUD) service. The OTP and
+	// sender runtime services returned here are Data Plane concerns and are dropped.
+	notifSenderMgtSvc, _, _, err := notification.Initialize(jwtService)
+	fatalOnError(ctx, logger, err, "Failed to initialize NotificationService")
+
+	// Register the /connections API as a thin layer over the identity-provider and
+	// notification-sender management services.
+	connectionExporter, err := connection.Initialize(mux, idpService, notifSenderMgtSvc)
+	fatalOnError(ctx, logger, err, "Failed to initialize connection declarative resources")
+	exporters = append(exporters, connectionExporter)
+
+	// Server-wide configuration handlers. The CP omits the "session" handler because SSO session
+	// lifetime is a Data Plane (flow/session) concern.
+	serverConfigHandlers := map[serverconfig.ConfigName]serverconfig.ServerConfigHandlerInterface{
+		serverconfig.ConfigNameCORS:                  cors.OriginHandler{},
+		serverconfig.ConfigNameDefaultResourceServer: resource.NewDefaultResourceServerConfigHandler(resourceService),
+	}
+	serverConfigService, serverConfigExporter, err := serverconfig.Initialize(mux, cacheManager, serverConfigHandlers)
+	fatalOnError(ctx, logger, err, "Failed to initialize server config service")
+	exporters = append(exporters, serverConfigExporter)
+
+	// CORS origins come from the server-config cors section.
+	cors.InitializeDynamicMatcher(serverConfigService)
+
+	// Verifiable-credential DEFINITION management. The CP stores presentation definitions and
+	// credential configurations; the OpenID4VP verifier and OpenID4VCI issuer runtimes are dropped.
+	openid4vpDefSvc, vpDefExp, err := presentation.Initialize(mux, ouService)
+	fatalOnError(ctx, logger, err, "Failed to initialize presentation definition service")
+	if vpDefExp != nil {
+		exporters = append(exporters, vpDefExp)
+	}
+	openid4vciCredSvc, vciCredExp, err := credential.Initialize(mux, ouService)
+	fatalOnError(ctx, logger, err, "Failed to initialize credential configuration service")
+	if vciCredExp != nil {
+		exporters = append(exporters, vciCredExp)
+	}
+
+	// Flow MANAGEMENT (CRUD + definition validation).
+	//
+	// TEMPORARY COUPLING: flow validation needs an executor/interceptor registry and a graph
+	// builder to check that flow nodes reference known executors and that the graph is well-formed.
+	// Building that registry links the flow/executor package, which transitively imports the Data
+	// Plane authn/oauth/idp-runtime/notification-otp packages. Validation only reads static executor
+	// metadata (GetMeta / IsRegistered) and never executes a node, so runtime dependencies are left
+	// nil where the executor constructor merely stores them. The federated-auth services below are
+	// the exception: three executor constructors (github/google/oidc) type-assert their auth service
+	// at construction, so the CP builds these lightweight services (never executed here) to satisfy
+	// them. Splitting executor metadata/registration from executor execution wiring (the follow-up
+	// flow refactor) removes both this link and the need for these services entirely.
+	oauthAuthnService := authnOAuth.Initialize(idpService, entityProvider)
+	oidcAuthnService := authnOIDC.Initialize(oauthAuthnService, jwtService)
+	googleAuthnService := google.Initialize(oidcAuthnService, jwtService)
+	githubAuthnService := github.Initialize(oauthAuthnService)
+
+	flowConfig := flowconfig.FromServerRuntime()
+	flowFactory, execRegistry, interceptorRegistry, graphBuilder := initializeFlowCoreAndExecutor(ctx, logger,
+		cacheManager, executor.ExecutorDependencies{
+			OUService:             ouService,
+			IDPService:            idpService,
+			JWTService:            jwtService,
+			EntityTypeService:     entityTypeService,
+			GroupService:          groupService,
+			RoleService:           roleService,
+			RoleAssignmentService: roleAssignmentService,
+			EntityProvider:        entityProvider,
+			OAuthSvc:              oauthAuthnService,
+			OIDCSvc:               oidcAuthnService,
+			GoogleSvc:             googleAuthnService,
+			GithubSvc:             githubAuthnService,
+		},
+		interceptor.InterceptorDependencies{},
+		flowConfig,
+	)
+
+	flowMgtService, flowMgtExporter, err := flowmgt.Initialize(
+		mux, mcpServer, cacheManager, flowFactory, execRegistry, interceptorRegistry, graphBuilder)
+	fatalOnError(ctx, logger, err, "Failed to initialize FlowMgtService")
+	exporters = append(exporters, flowMgtExporter)
+
+	certservice, err := cert.Initialize(cacheManager, dbprovider.GetDBProvider())
+	fatalOnError(ctx, logger, err, "Failed to initialize CertificateService")
+
+	themeMgtService, themeExporter, err := thememgt.Initialize(mux, mcpServer)
+	fatalOnError(ctx, logger, err, "Failed to initialize ThemeMgtService")
+	exporters = append(exporters, themeExporter)
+
+	layoutMgtService, layoutExporter, err := layoutmgt.Initialize(mux)
+	fatalOnError(ctx, logger, err, "Failed to initialize LayoutMgtService")
+	exporters = append(exporters, layoutExporter)
+
+	inboundClientService, err := inboundclient.Initialize(
+		cacheManager, certservice, entityProvider,
+		themeMgtService, layoutMgtService, flowMgtService, entityTypeService)
+	fatalOnError(ctx, logger, err, "Failed to initialize InboundClientService")
+
+	// TODO: Remove entityService dependency after finalizing declarative resource loading pattern
+	applicationService, applicationExporter, err := application.Initialize(
+		mux, mcpServer, entityProvider, entityService, inboundClientService, ouService, i18nService,
+		runtimeCryptoSvc)
+	fatalOnError(ctx, logger, err, "Failed to initialize ApplicationService")
+	exporters = append(exporters, applicationExporter)
+
+	agentService, agentExporter, err := agent.Initialize(mux, entityService, inboundClientService, ouService,
+		roleService)
+	fatalOnError(ctx, logger, err, "Failed to initialize AgentService")
+	exporters = append(exporters, agentExporter)
+
+	// Wire the dependency registry into the consuming services (two-phase init to avoid cyclic
+	// imports). All consumers and providers here are management services.
+	registerDependencyRegistry(dependencyConsumers{
+		theme:       themeMgtService,
+		layout:      layoutMgtService,
+		flow:        flowMgtService,
+		user:        userService,
+		idp:         idpService,
+		notifSender: notifSenderMgtSvc,
+		application: applicationService,
+		agent:       agentService,
+		group:       groupService,
+		ou:          ouService,
+		resource:    resourceService,
+	}, applicationService, agentService, flowMgtService, roleAssignmentService, groupService,
+		ouService, ouUserResolver, ouGroupResolver, resourceService)
+
+	// Initialize export service with collected exporters
+	_ = export.Initialize(mux, exporters)
+
+	// Initialize import service
+	importService := importer.Initialize(
+		mux,
+		applicationService,
+		idpService,
+		notifSenderMgtSvc,
+		flowMgtService,
+		ouService,
+		entityTypeService,
+		roleService,
+		roleAssignmentService,
+		groupService,
+		resourceService,
+		themeMgtService,
+		layoutMgtService,
+		userService,
+		i18nService,
+		agentService,
+		openid4vpDefSvc,
+		openid4vciCredSvc,
+		serverConfigService,
+	)
+
+	// Register the health service.
+	healthSvc := healthcheckservice.Initialize(dbprovider.GetDBProvider(), dbprovider.GetRedisProvider())
+	services.NewHealthCheckService(mux, healthSvc)
+
+	return jwtService, runtimeCryptoSvc, importService
+}
+
+// dependencyConsumers groups the services that check the dependency registry before deleting their
+// own resources.
+type dependencyConsumers struct {
+	theme       thememgt.ThemeMgtServiceInterface
+	layout      layoutmgt.LayoutMgtServiceInterface
+	flow        flowmgt.FlowMgtServiceInterface
+	user        user.UserServiceInterface
+	idp         idp.IDPServiceInterface
+	notifSender notification.NotificationSenderMgtSvcInterface
+	application application.ApplicationServiceInterface
+	agent       agent.AgentServiceInterface
+	group       group.GroupServiceInterface
+	ou          ou.ConfigurableOUService
+	resource    resource.ResourceServiceInterface
+}
+
+// registerDependencyRegistry builds the dependency registry from the given providers and wires it
+// into the consuming services.
+func registerDependencyRegistry(consumers dependencyConsumers, providers ...resourcedependency.Provider) {
+	registry := resourcedependency.Initialize(providers...)
+	consumers.theme.SetDependencyRegistry(registry)
+	consumers.layout.SetDependencyRegistry(registry)
+	consumers.flow.SetDependencyRegistry(registry)
+	consumers.user.SetDependencyRegistry(registry)
+	consumers.idp.SetDependencyRegistry(registry)
+	consumers.notifSender.SetDependencyRegistry(registry)
+	consumers.application.SetDependencyRegistry(registry)
+	consumers.agent.SetDependencyRegistry(registry)
+	consumers.group.SetDependencyRegistry(registry)
+	consumers.ou.SetDependencyRegistry(registry)
+	consumers.resource.SetDependencyRegistry(registry)
+}
+
+// unregisterServices unregisters all services that require cleanup during shutdown.
+func unregisterServices() {
+	observabilitySvc.Shutdown()
+}
+
+// fatalOnError logs msg and exits the process if err is non-nil.
+func fatalOnError(ctx context.Context, logger *log.Logger, err error, msg string) {
+	if err != nil {
+		logger.Fatal(ctx, msg, log.Error(err))
+	}
+}
+
+// initializeFlowCoreAndExecutor initializes the flow core and executor registries used for flow
+// definition validation. On the CP the executor dependencies carry only management services; the
+// runtime dependencies are left nil because validation reads static executor metadata only.
+func initializeFlowCoreAndExecutor(
+	ctx context.Context,
+	logger *log.Logger,
+	cacheManager cache.CacheManagerInterface,
+	execDeps executor.ExecutorDependencies,
+	interceptorDeps interceptor.InterceptorDependencies,
+	flowConfig flowconfig.Config,
+) (flowcore.FlowFactoryInterface, executor.ExecutorRegistryInterface,
+	interceptor.InterceptorRegistryInterface, graphbuilder.GraphBuilderInterface) {
+	flowFactory, graphCache := flowcore.Initialize(cacheManager)
+	execDeps.FlowFactory = flowFactory
+	interceptorDeps.FlowFactory = flowFactory
+
+	execRegistry, err := executor.Initialize(execDeps, flowConfig.Flow)
+	fatalOnError(ctx, logger, err, "Failed to register flow executors")
+	interceptorRegistry, err := interceptor.Initialize(interceptorDeps, flowConfig.Flow)
+	fatalOnError(ctx, logger, err, "Failed to initialize Interceptor registry")
+
+	graphBuilder := graphbuilder.Initialize(flowFactory, execRegistry, interceptorRegistry, graphCache)
+
+	return flowFactory, execRegistry, interceptorRegistry, graphBuilder
+}
+
+// buildHashConfig constructs a cryptolib.HashConfig from the server configuration.
+func buildHashConfig() (cryptolib.HashConfig, error) {
+	cfg := config.GetServerRuntime().Config.Crypto.PasswordHashing
+	alg := cryptolib.CredAlgorithm(strings.ToUpper(cfg.Algorithm))
+	switch alg {
+	case "", cryptolib.SHA256:
+		return cryptolib.HashConfig{Algorithm: cryptolib.SHA256, SaltSize: cfg.SHA256.SaltSize}, nil
+	case cryptolib.PBKDF2:
+		return cryptolib.HashConfig{Algorithm: alg, SaltSize: cfg.PBKDF2.SaltSize,
+			Iterations: cfg.PBKDF2.Iterations, KeySize: cfg.PBKDF2.KeySize}, nil
+	case cryptolib.ARGON2ID:
+		return cryptolib.HashConfig{Algorithm: alg, SaltSize: cfg.Argon2ID.SaltSize,
+			Iterations: cfg.Argon2ID.Iterations, Memory: cfg.Argon2ID.Memory,
+			Parallelism: cfg.Argon2ID.Parallelism, KeySize: cfg.Argon2ID.KeySize}, nil
+	default:
+		return cryptolib.HashConfig{}, fmt.Errorf("unrecognized password hashing algorithm %q", cfg.Algorithm)
+	}
+}

--- a/backend/cmd/dpserver/bootstrap_cmd.go
+++ b/backend/cmd/dpserver/bootstrap_cmd.go
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/thunder-id/thunderid/internal/system/bootstrap"
+	"github.com/thunder-id/thunderid/internal/system/cache"
+	"github.com/thunder-id/thunderid/internal/system/config"
+	dbprovider "github.com/thunder-id/thunderid/internal/system/database/provider"
+	"github.com/thunder-id/thunderid/internal/system/importer"
+	"github.com/thunder-id/thunderid/internal/system/log"
+)
+
+// bootstrapSubcommand is the first positional argument that selects the in-process
+// bootstrap one-shot instead of starting the long-running server.
+const bootstrapSubcommand = "bootstrap"
+
+// isBootstrapInvocation reports whether the process was started as the bootstrap
+// one-shot (e.g. `thunderid bootstrap --admin-username ...`).
+func isBootstrapInvocation() bool {
+	return flag.Arg(0) == bootstrapSubcommand
+}
+
+// runBootstrap parses the bootstrap subcommand options, runs the in-process
+// orchestrator, and tears down the shared resources. It does not start an HTTP
+// listener. It returns an error describing why bootstrap failed, if it did, so the
+// caller can log the reason before exiting.
+func runBootstrap(ctx context.Context, logger *log.Logger, serverHome string,
+	importSvc importer.ImportServiceInterface, cacheManager cache.CacheManagerInterface) error {
+	opts, err := parseBootstrapOptions(serverHome, flag.Args()[1:])
+	if err != nil {
+		shutdownBootstrap(ctx, logger, cacheManager)
+		return err
+	}
+	err = bootstrap.Run(ctx, importSvc, opts)
+	if err == nil {
+		printBootstrapSummary()
+	}
+	shutdownBootstrap(ctx, logger, cacheManager)
+	return err
+}
+
+// printBootstrapSummary prints the admin credentials and role created by the bootstrap.
+func printBootstrapSummary() {
+	fmt.Println()
+	fmt.Println("✅ Default resources setup completed successfully!")
+	fmt.Println()
+	fmt.Println("👤 Admin credentials:")
+	fmt.Printf("   Username: %s\n", os.Getenv("ADMIN_USERNAME"))
+	fmt.Printf("   Password: %s\n", os.Getenv("ADMIN_PASSWORD"))
+	fmt.Println("   Role: Administrator (system permission via Administrators group)")
+	fmt.Println()
+}
+
+// parseBootstrapOptions parses the bootstrap subcommand flags and exports the admin
+// credentials and public URL to the environment, so the bundle's
+// `{{ .ADMIN_USERNAME }}` / `{{ .ADMIN_PASSWORD }}` / `{{ .PUBLIC_URL }}` placeholders
+// resolve at import time. Flags override the environment. The admin username defaults
+// to "admin". The admin password has no default and no generation logic here: this
+// subcommand never invents security material on its own, so callers (setup.sh/setup.ps1
+// generate one if needed) must supply a non-empty ADMIN_PASSWORD, or bootstrap fails.
+func parseBootstrapOptions(serverHome string, args []string) (bootstrap.Options, error) {
+	fs := flag.NewFlagSet(bootstrapSubcommand, flag.ContinueOnError)
+	adminUsername := fs.String("admin-username", "", "Username for the default admin user")
+	adminPassword := fs.String("admin-password", "", "Password for the default admin user")
+	consoleRedirectURIs := fs.String("console-redirect-uris", "",
+		"Comma-separated extra redirect URIs for the Console application")
+	defaultsDir := fs.String("defaults", "", "Path to the bootstrap resource definitions directory")
+	// Flags are best-effort; unknown flags must not abort bootstrap.
+	_ = fs.Parse(args)
+
+	setEnv("ADMIN_USERNAME", firstNonEmpty(*adminUsername, os.Getenv("ADMIN_USERNAME"), "admin"))
+
+	password := firstNonEmpty(*adminPassword, os.Getenv("ADMIN_PASSWORD"))
+	if password == "" {
+		return bootstrap.Options{}, fmt.Errorf(
+			"no admin password supplied: set --admin-password or ADMIN_PASSWORD")
+	}
+	setEnv("ADMIN_PASSWORD", password)
+
+	setEnv("PUBLIC_URL", firstNonEmpty(os.Getenv("PUBLIC_URL"),
+		config.GetServerURL(&config.GetServerRuntime().Config.Server)))
+	// The bundle ranges over CONSOLE_REDIRECT_URIS, which buildArrayFromEnvVars
+	// reconstructs from the indexed CONSOLE_REDIRECT_URIS_0, _1, ... variables.
+	idx := 0
+	for _, uri := range strings.Split(*consoleRedirectURIs, ",") {
+		if uri = strings.TrimSpace(uri); uri != "" {
+			setEnv(fmt.Sprintf("CONSOLE_REDIRECT_URIS_%d", idx), uri)
+			idx++
+		}
+	}
+
+	dir := *defaultsDir
+	if dir == "" {
+		dir = path.Join(serverHome, "bootstrap")
+	}
+	return bootstrap.Options{DefaultsDir: dir}, nil
+}
+
+// setEnv sets an environment variable, ignoring the (practically impossible) error
+// for a fixed, valid key.
+func setEnv(key, value string) {
+	_ = os.Setenv(key, value)
+}
+
+// shutdownBootstrap releases the shared resources used by the bootstrap one-shot.
+func shutdownBootstrap(ctx context.Context, logger *log.Logger, cacheManager cache.CacheManagerInterface) {
+	unregisterServices()
+
+	if err := dbprovider.GetDBProviderCloser().Close(); err != nil {
+		logger.Error(ctx, "Error closing database connections", log.Error(err))
+	}
+
+	if cacheManager != nil {
+		cacheManager.Close()
+	}
+}
+
+// firstNonEmpty returns the first non-empty string from the provided values.
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/backend/cmd/dpserver/main.go
+++ b/backend/cmd/dpserver/main.go
@@ -1,0 +1,447 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package main is the entry point for starting the server.
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"flag"
+	"fmt"
+	"io/fs"
+	"mime"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"path"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/thunder-id/thunderid/internal/system/cache"
+	"github.com/thunder-id/thunderid/internal/system/config"
+	"github.com/thunder-id/thunderid/internal/system/constants"
+	"github.com/thunder-id/thunderid/internal/system/database/provider"
+	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
+	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/middleware"
+	"github.com/thunder-id/thunderid/internal/system/revocationcache"
+	"github.com/thunder-id/thunderid/internal/system/security"
+)
+
+// shutdownTimeout defines the timeout duration for graceful shutdown.
+const shutdownTimeout = 5 * time.Second
+
+var (
+	netListen = net.Listen
+	tlsListen = tls.Listen
+)
+
+func main() {
+	// Server bootstrap/shutdown logging has no request scope, so context.Background() is used.
+	ctx := context.Background()
+	startupStartedAt := time.Now()
+	logger := log.GetLogger()
+
+	flag.String("resources", "", "Path to declarative resources YAML file")
+	serverHome := getThunderHome(ctx, logger)
+
+	cfg := initThunderConfigurations(ctx, logger, serverHome)
+	if cfg == nil {
+		logger.Fatal(ctx, "Failed to initialize configurations")
+	}
+
+	// Apply the configured log level from deployment.yaml, now that config is loaded.
+	if cfg.Log.Level != "" {
+		if err := logger.SetLevel(cfg.Log.Level); err != nil {
+			logger.Fatal(ctx, "Invalid log level in configuration", log.Error(err))
+		}
+	}
+
+	// Apply the configured log output (console and/or rotating file), now that the
+	// server home is known and the file path can be resolved.
+	if err := logger.Configure(cfg.Log.BuildOutputOptions(serverHome)); err != nil {
+		logger.Fatal(ctx, "Failed to configure log output", log.Error(err))
+	}
+
+	// Initialize the cache manager.
+	cacheManager := cache.Initialize(cfg.Cache, cfg.Server.Identifier)
+
+	// Initialize system permission strings before any service or middleware uses them.
+	security.InitSystemPermissions(cfg.Server.SecurityConfig.SystemPermissionPrefix)
+
+	// Create a new HTTP multiplexer.
+	mux := http.NewServeMux()
+	if mux == nil {
+		logger.Fatal(ctx, "Failed to initialize multiplexer")
+	}
+
+	// Register the services.
+	jwtService, runtimeCryptoSvc, importService := registerServices(mux, cacheManager)
+
+	// When invoked as the bootstrap one-shot (`dpserver bootstrap`), create the
+	// default resources in-process and exit without starting the HTTP server.
+	if isBootstrapInvocation() {
+		if err := runBootstrap(ctx, logger, serverHome, importService, cacheManager); err != nil {
+			logger.Error(ctx, "In-process bootstrap failed; exiting", log.Error(err))
+			os.Exit(1)
+		}
+		logger.Info(ctx, "In-process bootstrap finished successfully")
+		return
+	}
+
+	// Initialize the Resource Server token-revocation cache. The initial deny-list snapshot is loaded
+	// synchronously so enforcement is live before the first request; if that load fails the server
+	// still starts and the syncer repopulates the cache on its next tick.
+	revocationEnforcer, revocationSyncer := initRevocationCache(ctx, logger, cfg)
+	revocationSyncer.Start(ctx)
+
+	// Register static file handlers for frontend applications.
+	registerStaticFileHandlers(ctx, logger, mux, serverHome)
+
+	// Setup signal handling for graceful shutdown
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+
+	// Create the HTTP server.
+	server := createHTTPServer(ctx, logger, cfg, mux, jwtService, revocationEnforcer)
+	var ln net.Listener
+	if cfg.Server.HTTPOnly {
+		logger.Info(ctx, "TLS is not enabled, starting server without TLS")
+		ln = createListener(ctx, logger, server)
+	} else {
+		tlsConfig := loadCertConfig(ctx, logger, runtimeCryptoSvc)
+		ln = createTLSListener(ctx, logger, server, tlsConfig)
+	}
+
+	serverURL := config.GetServerURL(&cfg.Server)
+	consoleURL := fmt.Sprintf("%s/console", strings.TrimSuffix(serverURL, "/"))
+	logger.Info(ctx, "ThunderID Data Plane URL", log.String("url", serverURL))
+	logger.Info(ctx, "ThunderID Console URL", log.String("url", consoleURL))
+
+	// Start server in a goroutine
+	go func() {
+		startupDuration := time.Since(startupStartedAt)
+		logger.Info(ctx, "ThunderID Data Plane started", log.String("startup_time", startupDuration.String()))
+		if err := server.Serve(ln); err != nil && err != http.ErrServerClosed {
+			logger.Fatal(ctx, "Failed to serve requests", log.Error(err))
+		}
+	}()
+
+	// Wait for shutdown signal
+	<-sigChan
+	logger.Info(ctx, "Shutting down server...")
+	gracefulShutdown(ctx, logger, server, cacheManager, revocationSyncer)
+}
+
+// initRevocationCache builds the Resource Server token-revocation enforcer and its background syncer
+// from the server security configuration. An unsupported source configuration fails startup; a
+// failed initial deny-list load does not — the server starts and the syncer populates the cache later.
+func initRevocationCache(ctx context.Context, logger *log.Logger,
+	cfg *config.Config) (revocationcache.EnforcerInterface, revocationcache.Syncer) {
+	rc := cfg.Server.SecurityConfig.TokenRevocation
+	enforcer, syncer, err := revocationcache.Initialize(revocationcache.Config{
+		Enabled:      rc.Enabled,
+		Source:       rc.Source,
+		SyncInterval: time.Duration(rc.SyncIntervalSeconds) * time.Second,
+	})
+	if err != nil {
+		logger.Fatal(ctx, "Failed to initialize token revocation cache", log.Error(err))
+	}
+	return enforcer, syncer
+}
+
+// getThunderHome retrieves and return the home directory.
+func getThunderHome(ctx context.Context, logger *log.Logger) string {
+	// Parse project directory from command line arguments.
+	projectHome := ""
+	projectHomeFlag := flag.String("serverHome", "", "Path to ThunderID home directory")
+	flag.Parse()
+
+	if *projectHomeFlag != "" {
+		logger.Info(ctx, "Using serverHome from command line argument",
+			log.String("serverHome", *projectHomeFlag))
+		projectHome = *projectHomeFlag
+	} else {
+		// If no command line argument is provided, use the current working directory.
+		dir, dirErr := os.Getwd()
+		if dirErr != nil {
+			logger.Fatal(ctx, "Failed to get current working directory", log.Error(dirErr))
+		}
+		projectHome = dir
+	}
+
+	return projectHome
+}
+
+// initThunderConfigurations initializes the configurations.
+func initThunderConfigurations(ctx context.Context, logger *log.Logger, serverHome string) *config.Config {
+	// Load the configurations.
+	configFilePath := path.Join(serverHome, "deployment.yaml")
+	defaultConfigPath := path.Join(serverHome, "config/default.json")
+	cfg, err := config.LoadConfig(configFilePath, defaultConfigPath, serverHome)
+	if err != nil {
+		logger.Fatal(ctx, "Failed to load configurations", log.Error(err))
+	}
+
+	// This is the Data Plane build: default the instance mode to "dp" when the deployment does not
+	// set one, so this binary serves the data plane (runtime + live identities) and gates the
+	// control-plane authoring routes. An explicit mode in deployment.yaml still takes precedence.
+	if cfg.Server.Mode == "" {
+		cfg.Server.Mode = "dp"
+	}
+
+	// Initialize runtime configurations.
+	if err := config.InitializeServerRuntime(serverHome, cfg); err != nil {
+		logger.Fatal(ctx, "Failed to initialize server runtime", log.Error(err))
+	}
+
+	return cfg
+}
+
+// loadCertConfig loads the TLS material via the runtime crypto provider.
+func loadCertConfig(ctx context.Context, logger *log.Logger, runtimeSvc kmprovider.RuntimeCryptoProvider) *tls.Config {
+	mat, err := runtimeSvc.GetTLSMaterial(ctx)
+	if err != nil {
+		logger.Fatal(ctx, "Failed to load TLS material", log.Error(err))
+	}
+	// #nosec G402 -- MinVersion is set to TLS 1.2 or higher by GetTLSMaterial
+	return &tls.Config{
+		Certificates: []tls.Certificate{mat.Certificate},
+		MinVersion:   mat.MinVersion,
+	}
+}
+
+// accessLogExcludePaths returns the path prefixes excluded from the access log: the always-excluded
+// Gate and Console frontend paths plus any configured extras. Empty and root ("/") entries are
+// dropped because they match every request and would silently disable all access logging.
+func accessLogExcludePaths(configured []string) []string {
+	paths := []string{"/gate/", "/console/"}
+	for _, prefix := range configured {
+		if prefix != "" && prefix != "/" {
+			paths = append(paths, prefix)
+		}
+	}
+	return paths
+}
+
+// createHTTPServer creates and configures an HTTP server with common settings.
+func createHTTPServer(ctx context.Context, logger *log.Logger, cfg *config.Config, mux *http.ServeMux,
+	jwtService jwt.JWTServiceInterface, revocationEnforcer revocationcache.EnforcerInterface) *http.Server {
+	securityMiddleware := createSecurityMiddleware(ctx, logger, mux, jwtService, revocationEnforcer)
+
+	// Build the middleware chain with proper execution order.
+	// Request flow: CorrelationID (outermost) -> AccessLog -> Security -> Route Handler (innermost)
+	// Note: Middlewares are wrapped in reverse order - the last added will execute first.
+	// The Gate and Console frontend paths are always excluded from the access log to keep it
+	// focused on API traffic. Additional prefixes can be excluded via log.access.exclude_paths.
+	handler := log.AccessLogHandler(logger, accessLogExcludePaths(cfg.Log.Access.ExcludePaths), securityMiddleware)
+	handler = middleware.CorrelationIDMiddleware(handler)
+
+	// Build the server address using hostname and port from the configurations.
+	serverAddr := fmt.Sprintf("%s:%d", cfg.Server.Hostname, cfg.Server.Port)
+
+	server := &http.Server{
+		Addr:              serverAddr,
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second, // Mitigate Slowloris attacks
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       120 * time.Second,
+		ErrorLog:          log.NewServerErrorLog(logger),
+	}
+
+	return server
+}
+
+// createListener creates and returns a listener for the HTTP server.
+func createListener(ctx context.Context, logger *log.Logger, server *http.Server) net.Listener {
+	ln, err := netListen("tcp", server.Addr)
+	if err != nil {
+		logger.Fatal(ctx, "Failed to start HTTP listener", log.Error(err))
+	}
+	return ln
+}
+
+// createTLSListener creates and returns a TLS listener for the HTTPS server.
+func createTLSListener(ctx context.Context, logger *log.Logger, server *http.Server,
+	tlsConfig *tls.Config) net.Listener {
+	ln, err := tlsListen("tcp", server.Addr, tlsConfig)
+	if err != nil {
+		logger.Fatal(ctx, "Failed to start TLS listener", log.Error(err))
+	}
+	return ln
+}
+
+func createSecurityMiddleware(ctx context.Context, logger *log.Logger, mux *http.ServeMux,
+	jwtService jwt.JWTServiceInterface, revocationEnforcer revocationcache.EnforcerInterface) http.Handler {
+	middlewareFunc, err := security.Initialize(jwtService, revocationEnforcer)
+	if err != nil {
+		logger.Fatal(ctx, "Failed to initialize security middleware", log.Error(err))
+	}
+	return middlewareFunc(mux)
+}
+
+// gracefulShutdown handles the graceful shutdown of all components.
+func gracefulShutdown(
+	ctx context.Context,
+	logger *log.Logger,
+	server *http.Server,
+	cacheManager cache.CacheManagerInterface,
+	revocationSyncer revocationcache.Syncer,
+) {
+	ctx, cancel := context.WithTimeout(ctx, shutdownTimeout)
+	defer cancel()
+
+	// Shutdown HTTP server
+	if err := server.Shutdown(ctx); err != nil {
+		logger.Error(ctx, "Error during server shutdown", log.Error(err))
+	} else {
+		logger.Debug(ctx, "HTTP server shutdown completed")
+	}
+
+	// Stop the token-revocation cache syncer.
+	revocationSyncer.Stop()
+
+	// Shutdown services
+	unregisterServices()
+
+	// Close database connections
+	dbCloser := provider.GetDBProviderCloser()
+	if err := dbCloser.Close(); err != nil {
+		logger.Error(ctx, "Error closing database connections", log.Error(err))
+	} else {
+		logger.Debug(ctx, "Database connections closed successfully")
+	}
+
+	if cacheManager != nil {
+		cacheManager.Close()
+		logger.Debug(ctx, "Cache manager closed successfully")
+	}
+
+	// Close the log file writer before the final shutdown log line.
+	if err := logger.Close(); err != nil {
+		logger.Error(ctx, "Error closing log file", log.Error(err))
+	}
+
+	logger.Info(ctx, "Server shutdown completed")
+}
+
+// registerStaticFileHandlers registers static file handlers for frontend applications.
+func registerStaticFileHandlers(ctx context.Context, logger *log.Logger, mux *http.ServeMux, serverHome string) {
+	// Override the OS-level MIME mapping so .js/.mjs files are served as
+	// application/javascript. Most proxies (Envoy, NGINX, Cloudflare) only
+	// compress application/javascript in their default allowlists, not
+	// text/javascript, which is Go's default on some systems.
+	_ = mime.AddExtensionType(".js", "application/javascript; charset=utf-8")
+	_ = mime.AddExtensionType(".mjs", "application/javascript; charset=utf-8")
+
+	// Serve gate application from /gate
+	gateDir := path.Join(serverHome, "apps", "gate")
+	if handler, err := createStaticFileHandler("/gate/", gateDir, logger); err != nil {
+		logger.Warn(ctx, "Gate application not registered", log.String("directory", gateDir), log.Error(err))
+	} else {
+		logger.Debug(ctx, "Registering static file handler for Gate application",
+			log.String("path", "/gate/"), log.String("directory", gateDir))
+		mux.Handle("/gate/", handler)
+	}
+
+	// Serve console application from /console
+	consoleDir := path.Join(serverHome, "apps", "console")
+	if handler, err := createStaticFileHandler("/console/", consoleDir, logger); err != nil {
+		logger.Warn(ctx, "Console application not registered", log.String("directory", consoleDir), log.Error(err))
+	} else {
+		logger.Debug(ctx, "Registering static file handler for Console application",
+			log.String("path", "/console/"), log.String("directory", consoleDir))
+		mux.Handle("/console/", handler)
+	}
+}
+
+// createStaticFileHandler creates a handler for serving static files with SPA fallback.
+//
+// All filesystem access is performed through an os.Root anchored at `directory`, which
+// confines every lookup below that directory: any request path that would escape it fails
+// with a path-escape error rather than reaching the filesystem.
+func createStaticFileHandler(routePrefix, directory string, logger *log.Logger) (http.Handler, error) {
+	root, err := os.OpenRoot(directory)
+	if err != nil {
+		return nil, err
+	}
+	rootFS := root.FS()
+	fileServer := http.FileServerFS(rootFS)
+
+	// serveIndex serves index.html with no-cache headers. It reports whether index.html
+	// existed and was served.
+	serveIndex := func(w http.ResponseWriter, r *http.Request) bool {
+		if _, err := root.Stat("index.html"); err != nil {
+			return false
+		}
+		w.Header().Set(constants.CacheControlHeaderName, constants.CacheControlNoCacheComposite)
+		w.Header().Set(constants.PragmaHeaderName, constants.PragmaNoCache)
+		w.Header().Set(constants.ExpiresHeaderName, constants.ExpiresZero)
+		http.ServeFileFS(w, r, rootFS, "index.html")
+		return true
+	}
+
+	return http.StripPrefix(routePrefix, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Handle the application root by explicitly serving index.html.
+		if r.URL.Path == "/" || r.URL.Path == "" {
+			if serveIndex(w, r) {
+				return
+			}
+		}
+
+		// Resolve the request against the served directory.
+		name := strings.TrimPrefix(r.URL.Path, "/")
+		isIndexHTML := name == "index.html"
+
+		if name != "" {
+			if _, err := root.Stat(name); err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					// For SPA routing, serve index.html for non-existent in-bounds paths.
+					logger.Debug(r.Context(), "Serving index.html for SPA routing",
+						log.String("requested_path", r.URL.Path),
+						log.String("route_prefix", routePrefix))
+					if serveIndex(w, r) {
+						return
+					}
+				} else {
+					// The path escapes the served directory (or is otherwise invalid).
+					logger.Warn(r.Context(), "Rejected request with out-of-bounds path",
+						log.String("requested_path", r.URL.Path),
+						log.String("route_prefix", routePrefix))
+					http.NotFound(w, r)
+					return
+				}
+			}
+		}
+
+		// Serve index.html directly with no-cache headers when requested.
+		if isIndexHTML {
+			if serveIndex(w, r) {
+				return
+			}
+		}
+
+		// Serve the requested file or directory listing.
+		fileServer.ServeHTTP(w, r)
+	})), nil
+}

--- a/backend/cmd/dpserver/servicemanager.go
+++ b/backend/cmd/dpserver/servicemanager.go
@@ -1,0 +1,630 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package managers provides functionality for managing and registering system services.
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/thunder-id/thunderid/internal/actorprovider"
+	"github.com/thunder-id/thunderid/internal/agent"
+	"github.com/thunder-id/thunderid/internal/application"
+	"github.com/thunder-id/thunderid/internal/attestation"
+	"github.com/thunder-id/thunderid/internal/attributecache"
+	"github.com/thunder-id/thunderid/internal/authn"
+	authnAssert "github.com/thunder-id/thunderid/internal/authn/assert"
+	authncm "github.com/thunder-id/thunderid/internal/authn/common"
+	authnConsent "github.com/thunder-id/thunderid/internal/authn/consent"
+	"github.com/thunder-id/thunderid/internal/authn/github"
+	"github.com/thunder-id/thunderid/internal/authn/google"
+	"github.com/thunder-id/thunderid/internal/authn/magiclink"
+	authnOAuth "github.com/thunder-id/thunderid/internal/authn/oauth"
+	authnOIDC "github.com/thunder-id/thunderid/internal/authn/oidc"
+	"github.com/thunder-id/thunderid/internal/authn/openid4vp"
+	"github.com/thunder-id/thunderid/internal/authn/otp"
+	"github.com/thunder-id/thunderid/internal/authn/passkey"
+	authnprovidermgr "github.com/thunder-id/thunderid/internal/authnprovider/manager"
+	"github.com/thunder-id/thunderid/internal/authz"
+	"github.com/thunder-id/thunderid/internal/authzen"
+	"github.com/thunder-id/thunderid/internal/cert"
+	"github.com/thunder-id/thunderid/internal/connection"
+	"github.com/thunder-id/thunderid/internal/consent"
+	layoutmgt "github.com/thunder-id/thunderid/internal/design/layout/mgt"
+	"github.com/thunder-id/thunderid/internal/design/resolve"
+	thememgt "github.com/thunder-id/thunderid/internal/design/theme/mgt"
+	"github.com/thunder-id/thunderid/internal/entity"
+	"github.com/thunder-id/thunderid/internal/entityprovider"
+	"github.com/thunder-id/thunderid/internal/entitytype"
+	flowconfig "github.com/thunder-id/thunderid/internal/flow/config"
+	flowcore "github.com/thunder-id/thunderid/internal/flow/core"
+	"github.com/thunder-id/thunderid/internal/flow/executor"
+	"github.com/thunder-id/thunderid/internal/flow/flowexec"
+	"github.com/thunder-id/thunderid/internal/flow/flowmeta"
+	"github.com/thunder-id/thunderid/internal/flow/graphbuilder"
+	"github.com/thunder-id/thunderid/internal/flow/interceptor"
+	flowmgt "github.com/thunder-id/thunderid/internal/flow/mgt"
+	flowsession "github.com/thunder-id/thunderid/internal/flow/session"
+	"github.com/thunder-id/thunderid/internal/group"
+	"github.com/thunder-id/thunderid/internal/idp"
+	"github.com/thunder-id/thunderid/internal/inboundclient"
+	"github.com/thunder-id/thunderid/internal/notification"
+	"github.com/thunder-id/thunderid/internal/oauth"
+	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/dcr"
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/dpop"
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/jti"
+	"github.com/thunder-id/thunderid/internal/openid4vci"
+	"github.com/thunder-id/thunderid/internal/ou"
+	"github.com/thunder-id/thunderid/internal/resource"
+	"github.com/thunder-id/thunderid/internal/role"
+	"github.com/thunder-id/thunderid/internal/runtimestore"
+	"github.com/thunder-id/thunderid/internal/serverconfig"
+	"github.com/thunder-id/thunderid/internal/system/cache"
+	"github.com/thunder-id/thunderid/internal/system/config"
+	"github.com/thunder-id/thunderid/internal/system/cors"
+	"github.com/thunder-id/thunderid/internal/system/cryptolib"
+	dbprovider "github.com/thunder-id/thunderid/internal/system/database/provider"
+	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
+	"github.com/thunder-id/thunderid/internal/system/email"
+	"github.com/thunder-id/thunderid/internal/system/export"
+	healthcheckservice "github.com/thunder-id/thunderid/internal/system/healthcheck/service"
+	i18nmgt "github.com/thunder-id/thunderid/internal/system/i18n/mgt"
+	"github.com/thunder-id/thunderid/internal/system/importer"
+	"github.com/thunder-id/thunderid/internal/system/jose"
+	joseconfig "github.com/thunder-id/thunderid/internal/system/jose/config"
+	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
+	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	"github.com/thunder-id/thunderid/internal/system/kmprovider/defaultkm/pki"
+	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/mcp"
+	"github.com/thunder-id/thunderid/internal/system/observability"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
+	"github.com/thunder-id/thunderid/internal/system/services"
+	"github.com/thunder-id/thunderid/internal/system/sysauthz"
+	"github.com/thunder-id/thunderid/internal/system/template"
+	"github.com/thunder-id/thunderid/internal/user"
+	"github.com/thunder-id/thunderid/internal/vc/credential"
+	"github.com/thunder-id/thunderid/internal/vc/presentation"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
+)
+
+// observabilitySvc is the observability service instance. This is used for graceful shutdown.
+var observabilitySvc observability.ObservabilityServiceInterface
+
+// registerServices registers all the services with the provided HTTP multiplexer.
+// It also returns the import service so the bootstrap subcommand can create default
+// resources in-process through the same service instances.
+func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterface) (
+	jwt.JWTServiceInterface, kmprovider.RuntimeCryptoProvider, importer.ImportServiceInterface) {
+	logger := log.GetLogger()
+
+	// Service registration runs during application startup, outside any request.
+	ctx := context.Background()
+
+	// Load the server's private key for signing JWTs.
+	pkiService, err := pki.Initialize()
+	fatalOnError(ctx, logger, err, "Failed to initialize certificate service")
+
+	runtimeCryptoSvc, configCryptoSvc, err := kmprovider.Initialize(pkiService)
+	fatalOnError(ctx, logger, err, "Failed to initialize key manager provider")
+
+	runtime := config.GetServerRuntime()
+	joseCfg := joseconfig.Config{
+		Issuer:         runtime.Config.JWT.Issuer,
+		ValidityPeriod: runtime.Config.JWT.ValidityPeriod,
+		Audience:       runtime.Config.JWT.Audience,
+		PreferredKeyID: runtime.Config.JWT.PreferredKeyID,
+		Leeway:         runtime.Config.JWT.Leeway,
+		JWKSCacheTTL:   time.Duration(runtime.Config.Server.SecurityConfig.JWKSCacheTTL) * time.Second,
+	}
+	jwtService, jweService, err := jose.Initialize(runtimeCryptoSvc, joseCfg)
+	fatalOnError(ctx, logger, err, "Failed to initialize JOSE services")
+
+	observabilitySvc = observability.Initialize(config.GetServerRuntime().Config.Observability)
+
+	// Initialize MCP server early so packages initializing below can register tools.
+	mcpServer := mcp.Initialize(mux, jwtService)
+
+	// List to collect exporters from each package
+	var exporters []declarativeresource.ResourceExporter
+
+	// Initialize i18n service for internationalization support.
+	i18nService, i18nExporter, err := i18nmgt.Initialize(mux, config.GetServerRuntime().Config.Translation)
+	fatalOnError(ctx, logger, err, "Failed to initialize i18n service")
+	// Add to exporters list (must be done after initializing list)
+	exporters = append(exporters, i18nExporter)
+
+	ouAuthzService, err := sysauthz.Initialize()
+	fatalOnError(ctx, logger, err, "Failed to initialize system authorization service")
+
+	ouService, ouHierarchyResolver, ouExporter, err := ou.Initialize(mux, mcpServer, cacheManager, ouAuthzService)
+	fatalOnError(ctx, logger, err, "Failed to initialize OrganizationUnitService")
+	exporters = append(exporters, ouExporter)
+
+	// Complete the two-phase initialization: inject the OU hierarchy resolver into the
+	// authz service now that the ou package is ready. This breaks the import-cycle that
+	// would arise if sysauthz were to directly import the ou package.
+	ouAuthzService.SetOUHierarchyResolver(ouHierarchyResolver)
+
+	hashCfg, err := buildHashConfig()
+	fatalOnError(ctx, logger, err, "Failed to build HashService config")
+	hashService, err := cryptolib.Initialize(hashCfg)
+	fatalOnError(ctx, logger, err, "Failed to initialize HashService")
+
+	// Initialize user type service
+	entityTypeService, entityTypeExporter, err := entitytype.Initialize(
+		mux, mcpServer, cacheManager, ouService, ouAuthzService)
+	fatalOnError(ctx, logger, err, "Failed to initialize EntityTypeService")
+	exporters = append(exporters, entityTypeExporter)
+
+	// Initialize entity service
+	entityService, err := entity.Initialize(cacheManager, hashService, entityTypeService, ouService)
+	fatalOnError(ctx, logger, err, "Failed to initialize EntityService")
+
+	// Initialize entity provider
+	entityProvider := entityprovider.InitializeEntityProvider(entityService)
+
+	userService, ouUserResolver, userExporter, err := user.Initialize(
+		mux, entityService, ouService, entityTypeService, ouAuthzService,
+	)
+	fatalOnError(ctx, logger, err, "Failed to initialize UserService")
+	exporters = append(exporters, userExporter)
+
+	groupService, ouGroupResolver, groupExporter, err := group.Initialize(
+		mux, dbprovider.GetDBProvider(), ouService, entityService, entityTypeService, ouAuthzService,
+	)
+	fatalOnError(ctx, logger, err, "Failed to initialize GroupService")
+	exporters = append(exporters, groupExporter)
+
+	resourceService, resourceExporter, err := resource.Initialize(mux, ouService)
+	fatalOnError(ctx, logger, err, "Failed to initialize Resource Service")
+	exporters = append(exporters, resourceExporter)
+
+	roleService, roleAssignmentService, ouRoleResolver, roleExporter, err := role.Initialize(
+		mux, entityService, groupService, ouService, resourceService, entityTypeService,
+	)
+	fatalOnError(ctx, logger, err, "Failed to initialize RoleService")
+	exporters = append(exporters, roleExporter)
+
+	// Two-phase initialization: inject user/group/role resolvers into OU service.
+	ouService.SetOUUserResolver(ouUserResolver)
+	ouService.SetOUGroupResolver(ouGroupResolver)
+	ouService.SetOURoleResolver(ouRoleResolver)
+
+	authZService := authz.Initialize(roleService)
+
+	idpService, err := idp.Initialize(cacheManager, entityTypeService)
+	fatalOnError(ctx, logger, err, "Failed to initialize IDPService")
+
+	templateService, err := template.Initialize()
+	fatalOnError(ctx, logger, err, "Failed to initialize template service")
+
+	notifSenderMgtSvc, notifOTPService, notifSenderSvc, err := notification.Initialize(jwtService)
+	fatalOnError(ctx, logger, err, "Failed to initialize NotificationService")
+
+	// Register the /connections API as a thin layer over the identity-provider and
+	// notification-sender services.
+	connectionExporter, err := connection.Initialize(mux, idpService, notifSenderMgtSvc)
+	fatalOnError(ctx, logger, err, "Failed to initialize connection declarative resources")
+	exporters = append(exporters, connectionExporter)
+
+	// Initialize passkey service
+	passkeyService := passkey.Initialize(entityService)
+
+	// Initialize magic link service
+	magicLinkService := magiclink.Initialize(jwtService)
+
+	// Initialize otp core service
+	otpCoreService := otp.Initialize(notifOTPService)
+
+	// Initialize federated authentication services.
+	oauthAuthnService := authnOAuth.Initialize(idpService, entityProvider)
+	oidcAuthnService := authnOIDC.Initialize(oauthAuthnService, jwtService)
+	googleAuthnService := google.Initialize(oidcAuthnService, jwtService)
+	githubAuthnService := github.Initialize(oauthAuthnService)
+
+	federatedAuths := map[providers.IDPType]authncm.FederatedAuthenticator{
+		providers.IDPTypeOAuth:  oauthAuthnService,
+		providers.IDPTypeOIDC:   oidcAuthnService,
+		providers.IDPTypeGoogle: googleAuthnService,
+		providers.IDPTypeGitHub: githubAuthnService,
+	}
+
+	// Shared DPoP verifier (and its JTI replay cache) so OAuth and OpenID4VCI
+	// share JTI replay protection.
+	oauthCfg := oauthconfig.FromServerRuntime()
+	dpopVerifier := dpop.Initialize(oauthCfg, jti.Initialize(oauthCfg))
+
+	runtimeStoreProvider, transactioner, err := runtimestore.Initialize(runtime.Config.Database.RuntimeTransient.Type,
+		runtime.Config.Server.Identifier)
+	fatalOnError(ctx, logger, err, "Failed to initialize runtime store")
+
+	openid4vpSvc, openid4vpDefSvc, openid4vciCredSvc, exporters :=
+		initializeVCServices(ctx, logger, mux, runtimeCryptoSvc, configCryptoSvc, jwtService, userService,
+			ouService, dpopVerifier, runtimeStoreProvider, exporters)
+
+	// Initialize authn provider
+	authnProvider := authnprovidermgr.InitializeAuthnProviderManager(entityService, passkeyService, otpCoreService,
+		magicLinkService, openid4vpSvc, federatedAuths)
+
+	// Initialize authentication services.
+	authAssertGen := authnAssert.Initialize()
+	consentEnforcer := authnConsent.Initialize(jwtService)
+
+	_, directAuthGuard := authn.Initialize(mux, mcpServer, idpService, jwtService, authnProvider, authAssertGen,
+		passkeyService, otpCoreService, notifSenderSvc, templateService, magicLinkService, oauthAuthnService,
+		oidcAuthnService, googleAuthnService, githubAuthnService,
+		runtime.Config.Server.SecurityConfig.DirectAuthSecret)
+
+	// AuthZEN access-evaluation endpoints are Direct API endpoints, so they reuse the Direct Auth
+	// guard created by the authn service.
+	authzen.Initialize(mux, authZService, entityProvider, resourceService, directAuthGuard)
+
+	attributeCacheService := attributecache.Initialize(runtimeStoreProvider)
+
+	emailClient := initEmailClient(ctx, logger)
+
+	// Initialize server-wide configuration after its handler dependencies.
+	serverConfigHandlers := map[serverconfig.ConfigName]serverconfig.ServerConfigHandlerInterface{
+		serverconfig.ConfigNameCORS:                  cors.OriginHandler{},
+		serverconfig.ConfigNameDefaultResourceServer: resource.NewDefaultResourceServerConfigHandler(resourceService),
+		serverconfig.ConfigNameSession:               flowsession.ConfigHandler{},
+	}
+	serverConfigService, serverConfigExporter, err := serverconfig.Initialize(mux, cacheManager, serverConfigHandlers)
+	fatalOnError(ctx, logger, err, "Failed to initialize server config service")
+	exporters = append(exporters, serverConfigExporter)
+
+	// CORS origins come from the server-config cors section.
+	cors.InitializeDynamicMatcher(serverConfigService)
+
+	flowConfig := flowconfig.FromServerRuntime()
+	sessionService, sessionCfg := initSessionService(ctx, serverConfigService, runtime.Config.Server.Identifier, logger)
+	flowConfig.Session = sessionCfg
+	flowFactory, execRegistry, interceptorRegistry, graphBuilder := initializeFlowCoreAndExecutor(ctx, logger,
+		cacheManager, executor.ExecutorDependencies{
+			OUService:             ouService,
+			IDPService:            idpService,
+			NotifSenderSvc:        notifSenderSvc,
+			JWTService:            jwtService,
+			AuthAssertGen:         authAssertGen,
+			ConsentEnforcer:       consentEnforcer,
+			AuthnProvider:         authnProvider,
+			OTPService:            otpCoreService,
+			PasskeyService:        passkeyService,
+			MagicLinkService:      magicLinkService,
+			AuthZService:          authZService,
+			EntityTypeService:     entityTypeService,
+			GroupService:          groupService,
+			RoleService:           roleService,
+			RoleAssignmentService: roleAssignmentService,
+			EntityProvider:        entityProvider,
+			AttributeCacheSvc:     attributeCacheService,
+			EmailClient:           emailClient,
+			TemplateService:       templateService,
+			OAuthSvc:              oauthAuthnService,
+			OIDCSvc:               oidcAuthnService,
+			GithubSvc:             githubAuthnService,
+			GoogleSvc:             googleAuthnService,
+			OpenID4VPVerifierSvc:  openid4vpSvc,
+			SessionService:        sessionService,
+		},
+		interceptor.InterceptorDependencies{},
+		flowConfig,
+	)
+
+	flowMgtService, flowMgtExporter, err := flowmgt.Initialize(
+		mux, mcpServer, cacheManager, flowFactory, execRegistry, interceptorRegistry, graphBuilder)
+	fatalOnError(ctx, logger, err, "Failed to initialize FlowMgtService")
+
+	exporters = append(exporters, flowMgtExporter)
+	certservice, err := cert.Initialize(cacheManager, dbprovider.GetDBProvider())
+	fatalOnError(ctx, logger, err, "Failed to initialize CertificateService")
+
+	// Initialize theme and layout services
+	themeMgtService, themeExporter, err := thememgt.Initialize(mux, mcpServer)
+	fatalOnError(ctx, logger, err, "Failed to initialize ThemeMgtService")
+	exporters = append(exporters, themeExporter)
+
+	layoutMgtService, layoutExporter, err := layoutmgt.Initialize(mux)
+	fatalOnError(ctx, logger, err, "Failed to initialize LayoutMgtService")
+	exporters = append(exporters, layoutExporter)
+
+	inboundClientService, err := inboundclient.Initialize(
+		cacheManager, certservice, entityProvider,
+		themeMgtService, layoutMgtService, flowMgtService, entityTypeService)
+	fatalOnError(ctx, logger, err, "Failed to initialize InboundClientService")
+
+	// Inject the consent service into the consent enforcer. It is wired here rather than at enforcer
+	// construction because it depends on the inbound client service, which is only available after the
+	// flow services (which themselves depend on the enforcer) are initialized.
+	consentEnforcer.SetConsentService(initConsentService(ctx, logger, inboundClientService))
+
+	// TODO: Remove entityService dependency after finalizing declarative resource loading pattern
+	applicationService, applicationExporter, err := application.Initialize(
+		mux, mcpServer, entityProvider, entityService, inboundClientService, ouService, i18nService,
+		runtimeCryptoSvc)
+	fatalOnError(ctx, logger, err, "Failed to initialize ApplicationService")
+	exporters = append(exporters, applicationExporter)
+
+	agentService, agentExporter, err := agent.Initialize(mux, entityService, inboundClientService, ouService,
+		roleService)
+	fatalOnError(ctx, logger, err, "Failed to initialize AgentService")
+	exporters = append(exporters, agentExporter)
+
+	// Wire the dependency registry into the consuming services (two-phase init to avoid cyclic
+	// imports). flowMgtService is both a consumer and a provider: it reports which flows reference an
+	// identity provider or notification sender.
+	registerDependencyRegistry(dependencyConsumers{
+		theme:       themeMgtService,
+		layout:      layoutMgtService,
+		flow:        flowMgtService,
+		user:        userService,
+		idp:         idpService,
+		notifSender: notifSenderMgtSvc,
+		application: applicationService,
+		agent:       agentService,
+		group:       groupService,
+		ou:          ouService,
+		resource:    resourceService,
+	}, applicationService, agentService, flowMgtService, roleAssignmentService, groupService,
+		ouService, ouUserResolver, ouGroupResolver, resourceService)
+
+	// Initialize design resolve service for theme and layout resolution
+	designResolveService := resolve.Initialize(mux, themeMgtService, layoutMgtService, applicationService)
+
+	actorProvider := actorprovider.Initialize(inboundClientService, entityProvider, authnProvider)
+
+	// Initialize flow metadata service
+	_ = flowmeta.Initialize(mux, actorProvider, ouService, designResolveService, i18nService)
+
+	// Initialize export service with collected exporters
+	_ = export.Initialize(mux, exporters)
+
+	// Initialize import service
+	importService := importer.Initialize(
+		mux,
+		applicationService,
+		idpService,
+		notifSenderMgtSvc,
+		flowMgtService,
+		ouService,
+		entityTypeService,
+		roleService,
+		roleAssignmentService,
+		groupService,
+		resourceService,
+		themeMgtService,
+		layoutMgtService,
+		userService,
+		i18nService,
+		agentService,
+		openid4vpDefSvc,
+		openid4vciCredSvc,
+		serverConfigService,
+	)
+
+	attestationProvider := initAttestationProvider(ctx, logger, runtimeCryptoSvc)
+	flowExecService, err := flowexec.Initialize(mux, flowMgtService, actorProvider,
+		execRegistry, interceptorRegistry, observabilitySvc, runtimeCryptoSvc, attestationProvider,
+		graphBuilder, runtimeStoreProvider, transactioner, flowConfig)
+	fatalOnError(ctx, logger, err, "Failed to initialize flow execution service")
+
+	// Initialize OAuth services.
+	err = oauth.Initialize(mux, actorProvider, authnProvider, jwtService, jweService,
+		flowExecService, observabilitySvc, runtimeCryptoSvc, ouService, attributeCacheService, authZService,
+		resourceService, serverConfigService, i18nService, idpService, dpopVerifier,
+		runtimeStoreProvider, oauthCfg)
+	fatalOnError(ctx, logger, err, "Failed to initialize OAuth services")
+
+	// Register OAuth2 DCR service.
+	err = dcr.Initialize(mux, applicationService, ouService, i18nService, oauthCfg)
+	fatalOnError(ctx, logger, err, "Failed to initialize OAuth2 DCR service")
+
+	// Register the health service.
+	healthSvc := healthcheckservice.Initialize(dbprovider.GetDBProvider(), dbprovider.GetRedisProvider())
+	services.NewHealthCheckService(mux, healthSvc)
+
+	return jwtService, runtimeCryptoSvc, importService
+}
+
+// initAttestationProvider initializes the platform attestation provider, terminating server startup
+// on failure rather than running with a non-functional verifier.
+func initAttestationProvider(ctx context.Context, logger *log.Logger,
+	cryptoSvc kmprovider.RuntimeCryptoProvider) providers.AttestationProvider {
+	attestationProvider, err := attestation.Initialize(cryptoSvc)
+	if err != nil {
+		logger.Fatal(ctx, "Failed to initialize attestation provider", log.Error(err))
+	}
+	return attestationProvider
+}
+
+// dependencyConsumers groups the services that check the dependency registry before deleting their
+// own resources.
+type dependencyConsumers struct {
+	theme       thememgt.ThemeMgtServiceInterface
+	layout      layoutmgt.LayoutMgtServiceInterface
+	flow        flowmgt.FlowMgtServiceInterface
+	user        user.UserServiceInterface
+	idp         idp.IDPServiceInterface
+	notifSender notification.NotificationSenderMgtSvcInterface
+	application application.ApplicationServiceInterface
+	agent       agent.AgentServiceInterface
+	group       group.GroupServiceInterface
+	ou          ou.ConfigurableOUService
+	resource    resource.ResourceServiceInterface
+}
+
+// registerDependencyRegistry builds the dependency registry from the given providers and wires it
+// into the consuming services.
+func registerDependencyRegistry(consumers dependencyConsumers, providers ...resourcedependency.Provider) {
+	registry := resourcedependency.Initialize(providers...)
+	consumers.theme.SetDependencyRegistry(registry)
+	consumers.layout.SetDependencyRegistry(registry)
+	consumers.flow.SetDependencyRegistry(registry)
+	consumers.user.SetDependencyRegistry(registry)
+	consumers.idp.SetDependencyRegistry(registry)
+	consumers.notifSender.SetDependencyRegistry(registry)
+	consumers.application.SetDependencyRegistry(registry)
+	consumers.agent.SetDependencyRegistry(registry)
+	consumers.group.SetDependencyRegistry(registry)
+	consumers.ou.SetDependencyRegistry(registry)
+	consumers.resource.SetDependencyRegistry(registry)
+}
+
+// unregisterServices unregisters all services that require cleanup during shutdown.
+func unregisterServices() {
+	observabilitySvc.Shutdown()
+}
+
+// initSessionService reads the effective SSO session configuration from the server-config section and
+// builds the session service, returning both so the caller can thread the config into flowexec too.
+func initSessionService(ctx context.Context, svc serverconfig.ServerConfigService, deploymentID string,
+	logger *log.Logger) (flowsession.Service, flowsession.Config) {
+	cfg := readSessionConfig(ctx, svc, logger)
+	sessionService, err := flowsession.Initialize(dbprovider.GetDBProvider(), deploymentID,
+		flowsession.NewTimeouts(cfg.IdleTimeoutSeconds, cfg.AbsoluteTimeoutSeconds))
+	fatalOnError(ctx, logger, err, "Failed to initialize SSO session service")
+	return sessionService, cfg
+}
+
+// readSessionConfig reads the effective SSO session lifetime configuration from the server-config
+// "session" section. An unset section resolves to the zero Config, which NewTimeouts turns into the
+// built-in defaults; a read error is non-fatal for the same reason, so it logs and falls back.
+func readSessionConfig(ctx context.Context, svc serverconfig.ServerConfigService,
+	logger *log.Logger) flowsession.Config {
+	merged, svcErr := svc.GetMergedConfig(ctx, string(serverconfig.ConfigNameSession))
+	if svcErr != nil {
+		logger.Warn(ctx, "Failed to read session server config; using default timeouts",
+			log.String("code", svcErr.Code))
+		return flowsession.Config{}
+	}
+	cfg, _ := merged.(flowsession.Config)
+	return cfg
+}
+
+// initConsentService initializes the consent service backed by the inbound client service, which
+// satisfies consent.InboundClientProvider directly.
+func initConsentService(ctx context.Context, logger *log.Logger,
+	inboundClientService inboundclient.InboundClientServiceInterface) consent.ConsentServiceInterface {
+	consentService, err := consent.Initialize(inboundClientService)
+	fatalOnError(ctx, logger, err, "Failed to initialize consent service")
+	return consentService
+}
+
+// fatalOnError logs msg and exits the process if err is non-nil.
+func fatalOnError(ctx context.Context, logger *log.Logger, err error, msg string) {
+	if err != nil {
+		logger.Fatal(ctx, msg, log.Error(err))
+	}
+}
+
+// initEmailClient initializes the email client, returning nil if not configured.
+func initEmailClient(ctx context.Context, logger *log.Logger) email.EmailClientInterface {
+	client, err := email.Initialize()
+	if err != nil {
+		logger.Debug(ctx, "Email client not configured. "+
+			"EmailExecutor will be registered but will not send emails.", log.Error(err))
+		return nil
+	}
+	return client
+}
+
+// initializeFlowCoreAndExecutor initializes the flow core and executor services.
+func initializeFlowCoreAndExecutor(
+	ctx context.Context,
+	logger *log.Logger,
+	cacheManager cache.CacheManagerInterface,
+	execDeps executor.ExecutorDependencies,
+	interceptorDeps interceptor.InterceptorDependencies,
+	flowConfig flowconfig.Config,
+) (flowcore.FlowFactoryInterface, executor.ExecutorRegistryInterface,
+	interceptor.InterceptorRegistryInterface, graphbuilder.GraphBuilderInterface) {
+	// Initialize flow core services.
+	flowFactory, graphCache := flowcore.Initialize(cacheManager)
+	execDeps.FlowFactory = flowFactory
+	interceptorDeps.FlowFactory = flowFactory
+
+	// Initialize flow executor registry
+	execRegistry, err := executor.Initialize(execDeps, flowConfig.Flow)
+	fatalOnError(ctx, logger, err, "Failed to register flow executors")
+	interceptorRegistry, err := interceptor.Initialize(interceptorDeps, flowConfig.Flow)
+	fatalOnError(ctx, logger, err, "Failed to initialize Interceptor registry")
+
+	graphBuilder := graphbuilder.Initialize(flowFactory, execRegistry, interceptorRegistry, graphCache)
+
+	return flowFactory, execRegistry, interceptorRegistry, graphBuilder
+}
+
+// initializeVCServices initializes the OpenID4VP verifier and OpenID4VCI issuer services,
+// appending their declarative-resource exporters to exporters.
+func initializeVCServices(
+	ctx context.Context, logger *log.Logger, mux *http.ServeMux,
+	runtimeCrypto kmprovider.RuntimeCryptoProvider, configCrypto kmprovider.ConfigCryptoProvider,
+	jwtService jwt.JWTServiceInterface, userService user.UserServiceInterface,
+	ouService ou.OrganizationUnitServiceInterface,
+	dpopVerifier dpop.VerifierInterface,
+	runtimeStoreProvider providers.RuntimeStoreProvider,
+	exporters []declarativeresource.ResourceExporter,
+) (openid4vp.OpenID4VPServiceInterface, presentation.PresentationDefinitionServiceInterface,
+	credential.CredentialConfigurationServiceInterface, []declarativeresource.ResourceExporter) {
+	openid4vpDefSvc, vpDefExp, err := presentation.Initialize(mux, ouService)
+	fatalOnError(ctx, logger, err, "Failed to initialize presentation definition service")
+	if vpDefExp != nil {
+		exporters = append(exporters, vpDefExp)
+	}
+
+	openid4vpSvc, err := openid4vp.Initialize(mux, runtimeCrypto, configCrypto, jwtService, openid4vpDefSvc,
+		runtimeStoreProvider)
+	fatalOnError(ctx, logger, err, "Failed to initialize OpenID4VP verifier service")
+
+	openid4vciCredSvc, vciCredExp, err := credential.Initialize(mux, ouService)
+	fatalOnError(ctx, logger, err, "Failed to initialize credential configuration service")
+	if vciCredExp != nil {
+		exporters = append(exporters, vciCredExp)
+	}
+
+	_, err = openid4vci.Initialize(mux, runtimeCrypto, jwtService, userService, dpopVerifier, openid4vciCredSvc,
+		runtimeStoreProvider)
+	fatalOnError(ctx, logger, err, "Failed to initialize OpenID4VCI issuer service")
+
+	return openid4vpSvc, openid4vpDefSvc, openid4vciCredSvc, exporters
+}
+
+// buildHashConfig constructs a cryptolib.HashConfig from the server configuration.
+func buildHashConfig() (cryptolib.HashConfig, error) {
+	cfg := config.GetServerRuntime().Config.Crypto.PasswordHashing
+	alg := cryptolib.CredAlgorithm(strings.ToUpper(cfg.Algorithm))
+	switch alg {
+	case "", cryptolib.SHA256:
+		return cryptolib.HashConfig{Algorithm: cryptolib.SHA256, SaltSize: cfg.SHA256.SaltSize}, nil
+	case cryptolib.PBKDF2:
+		return cryptolib.HashConfig{Algorithm: alg, SaltSize: cfg.PBKDF2.SaltSize,
+			Iterations: cfg.PBKDF2.Iterations, KeySize: cfg.PBKDF2.KeySize}, nil
+	case cryptolib.ARGON2ID:
+		return cryptolib.HashConfig{Algorithm: alg, SaltSize: cfg.Argon2ID.SaltSize,
+			Iterations: cfg.Argon2ID.Iterations, Memory: cfg.Argon2ID.Memory,
+			Parallelism: cfg.Argon2ID.Parallelism, KeySize: cfg.Argon2ID.KeySize}, nil
+	default:
+		return cryptolib.HashConfig{}, fmt.Errorf("unrecognized password hashing algorithm %q", cfg.Algorithm)
+	}
+}

--- a/backend/internal/system/error/apierror/error.go
+++ b/backend/internal/system/error/apierror/error.go
@@ -57,4 +57,18 @@ var (
 			DefaultValue: "You do not have sufficient permissions to access this resource",
 		},
 	}
+
+	// ErrNotFound is returned when the requested resource or endpoint is not available on this
+	// instance (HTTP 404), for example a management route on a data-plane instance.
+	ErrNotFound = ErrorResponse{
+		Code: "AUTH-4040",
+		Message: tidcommon.I18nMessage{
+			Key:          "error.auth.not_found",
+			DefaultValue: "Not Found",
+		},
+		Description: tidcommon.I18nMessage{
+			Key:          "error.auth.not_found_description",
+			DefaultValue: "The requested endpoint is not available on this instance",
+		},
+	}
 )

--- a/backend/internal/system/security/errors.go
+++ b/backend/internal/system/security/errors.go
@@ -38,4 +38,8 @@ var (
 
 	// errMissingAuthHeader indicates that the Authorization header is missing.
 	errMissingAuthHeader = errors.New("missing authorization header")
+
+	// errManagementDisabled indicates the request targets a management route on an instance that has
+	// the management (control-plane) API surface disabled. It is surfaced as a 404.
+	errManagementDisabled = errors.New("management apis disabled")
 )

--- a/backend/internal/system/security/init.go
+++ b/backend/internal/system/security/init.go
@@ -21,11 +21,14 @@ package security
 import (
 	"net/http"
 
+	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
 )
 
 // Initialize creates and returns the security middleware with necessary authenticators. The
-// revocationEnforcer is consulted after authentication to reject revoked tokens.
+// revocationEnforcer is consulted after authentication to reject revoked tokens. The instance mode
+// (cp/dp/hybrid) gates the management surface: on a single-plane instance the other plane's
+// management routes are rejected with 404.
 func Initialize(jwtService jwt.JWTServiceInterface, revocationEnforcer RevocationEnforcerInterface,
 ) (func(http.Handler) http.Handler, error) {
 	jwtAuthenticator := newJWTAuthenticator(jwtService)
@@ -34,5 +37,6 @@ func Initialize(jwtService jwt.JWTServiceInterface, revocationEnforcer Revocatio
 	if err != nil {
 		return nil, err
 	}
+	securityService.mode = ParsePlane(config.GetServerRuntime().Config.Server.Mode)
 	return middleware(securityService)
 }

--- a/backend/internal/system/security/middleware.go
+++ b/backend/internal/system/security/middleware.go
@@ -59,6 +59,13 @@ func middleware(service SecurityServiceInterface) (func(http.Handler) http.Handl
 // writeSecurityError writes an appropriate HTTP error response based on the security error, including
 // the RFC 6750 WWW-Authenticate challenge.
 func writeSecurityError(ctx context.Context, w http.ResponseWriter, err error) {
+	// A management route on a data-plane instance is reported as 404: the endpoint is simply not
+	// available here, and no authentication challenge is appropriate.
+	if errors.Is(err, errManagementDisabled) {
+		utils.WriteErrorResponse(ctx, w, http.StatusNotFound, apierror.ErrNotFound)
+		return
+	}
+
 	// A 403 is an authorization failure: the caller authenticated successfully but lacks the required
 	// permission. It is not an authentication challenge, so no WWW-Authenticate header is emitted.
 	// (A future change may add the RFC 6750 insufficient_scope challenge here.)

--- a/backend/internal/system/security/permissions.go
+++ b/backend/internal/system/security/permissions.go
@@ -62,6 +62,83 @@ var publicPaths = []string{
 	"/access/**",
 }
 
+// ---- Instance plane / mode ----
+
+// Plane identifies which deployment plane a management route or instance belongs to.
+type Plane string
+
+const (
+	// PlaneControl is the control plane: configuration/design-time management.
+	PlaneControl Plane = "cp"
+	// PlaneData is the data plane: runtime plus live-identity management.
+	PlaneData Plane = "dp"
+	// PlaneHybrid serves both planes (the default).
+	PlaneHybrid Plane = "hybrid"
+)
+
+// ParsePlane maps a configured mode string to a Plane, defaulting to PlaneHybrid for empty or
+// unrecognized values so an unset/typo mode fails open to the full (hybrid) surface.
+func ParsePlane(mode string) Plane {
+	switch Plane(strings.ToLower(strings.TrimSpace(mode))) {
+	case PlaneControl:
+		return PlaneControl
+	case PlaneData:
+		return PlaneData
+	default:
+		return PlaneHybrid
+	}
+}
+
+// planeRoute maps a request-path glob (same syntax as publicPaths) to the plane that owns it.
+type planeRoute struct {
+	pattern string
+	plane   Plane
+}
+
+// managementRoutePlanes classifies the management (non-public) API surface by plane, so an instance
+// running in "cp" or "dp" mode serves only its own routes and returns 404 for the other plane's.
+// Evaluation is first-match-wins, so more specific patterns come first (role assignment before the
+// generic role routes). Public runtime routes (OAuth2, flow execution, gate, well-known, health, the
+// VC/i18n runtime endpoints) are intentionally absent: they are never gated by plane.
+var managementRoutePlanes = []planeRoute{
+	// Data plane: live identities and assignment operations.
+	{"/roles/*/assignments/**", PlaneData},
+	{"/users", PlaneData},
+	{"/users/**", PlaneData},
+	{"/agents", PlaneData},
+	{"/agents/**", PlaneData},
+
+	// Control plane: configuration/design-time resources.
+	{"/roles", PlaneControl},
+	{"/roles/**", PlaneControl},
+	{"/groups", PlaneControl},
+	{"/groups/**", PlaneControl},
+	{"/organization-units", PlaneControl},
+	{"/organization-units/**", PlaneControl},
+	{"/applications", PlaneControl},
+	{"/applications/**", PlaneControl},
+	{"/user-types", PlaneControl},
+	{"/user-types/**", PlaneControl},
+	{"/agent-types", PlaneControl},
+	{"/agent-types/**", PlaneControl},
+	{"/resource-servers", PlaneControl},
+	{"/resource-servers/**", PlaneControl},
+	{"/flows", PlaneControl},
+	{"/flows/**", PlaneControl},
+	{"/design/**", PlaneControl},
+	{"/connections", PlaneControl},
+	{"/connections/**", PlaneControl},
+	{"/openid4vp/presentation-definitions/**", PlaneControl},
+	{"/openid4vci/credential-configurations/**", PlaneControl},
+	{"/server-config", PlaneControl},
+	{"/server-config/**", PlaneControl},
+	{"/i18n/**", PlaneControl},
+	{"/import", PlaneControl},
+	{"/import/**", PlaneControl},
+	{"/export", PlaneControl},
+	{"/export/**", PlaneControl},
+}
+
 // ---- Resource types ----
 
 // ResourceType defines the category of system resource being acted upon.

--- a/backend/internal/system/security/service.go
+++ b/backend/internal/system/security/service.go
@@ -50,6 +50,11 @@ type securityService struct {
 	logger                 *log.Logger
 	compiledPaths          []*regexp.Regexp
 	compiledAPIPermissions []compiledAPIPermission
+	// mode selects which plane's management routes this instance serves. When it is cp or dp, a
+	// management route classified to the other plane is rejected with 404; hybrid serves both.
+	mode Plane
+	// compiledPlaneRoutes is the pre-compiled per-plane classification of the management surface.
+	compiledPlaneRoutes []compiledPlaneRoute
 }
 
 // newSecurityService creates a new instance of the security service.
@@ -75,6 +80,11 @@ func newSecurityService(authenticators []AuthenticatorInterface, revocationEnfor
 		return nil, err
 	}
 
+	compiledPlanes, err := compilePlaneRoutes(managementRoutePlanes)
+	if err != nil {
+		return nil, err
+	}
+
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 
 	return &securityService{
@@ -83,6 +93,8 @@ func newSecurityService(authenticators []AuthenticatorInterface, revocationEnfor
 		logger:                 logger,
 		compiledPaths:          compiledPaths,
 		compiledAPIPermissions: compiledPerms,
+		mode:                   PlaneHybrid,
+		compiledPlaneRoutes:    compiledPlanes,
 	}, nil
 }
 
@@ -94,6 +106,14 @@ func (s *securityService) Process(r *http.Request) (context.Context, error) {
 	// Check if the request is options (CORS preflight)
 	if r.Method == http.MethodOptions {
 		return r.Context(), nil
+	}
+
+	// On a single-plane instance (cp or dp), a management route owned by the other plane is not
+	// served here and is reported as 404. Public runtime routes are never plane-gated.
+	if s.mode != PlaneHybrid && !isPublic {
+		if plane, ok := s.classifyPlane(r.URL.Path); ok && plane != s.mode {
+			return r.Context(), errManagementDisabled
+		}
 	}
 
 	// Find an authenticator that can process this request
@@ -170,6 +190,17 @@ func (s *securityService) getRequiredPermissionForAPI(method, path string) strin
 		}
 	}
 	return GetSystemRootPermission()
+}
+
+// classifyPlane returns the plane that owns the given request path, or false when the path is not a
+// classified management route. Public/runtime paths and any unlisted path are never plane-gated.
+func (s *securityService) classifyPlane(requestPath string) (Plane, bool) {
+	for _, r := range s.compiledPlaneRoutes {
+		if r.re.MatchString(requestPath) {
+			return r.plane, true
+		}
+	}
+	return "", false
 }
 
 // isPublicPath checks if the given request path matches any of the configured public path patterns.

--- a/backend/internal/system/security/utils.go
+++ b/backend/internal/system/security/utils.go
@@ -30,6 +30,26 @@ type compiledAPIPermission struct {
 	permission string
 }
 
+// compiledPlaneRoute holds the pre-compiled regex form of a single planeRoute.
+type compiledPlaneRoute struct {
+	re    *regexp.Regexp
+	plane Plane
+}
+
+// compilePlaneRoutes compiles the management-route plane classification into regex form.
+// It returns an error if any pattern is invalid.
+func compilePlaneRoutes(routes []planeRoute) ([]compiledPlaneRoute, error) {
+	compiled := make([]compiledPlaneRoute, 0, len(routes))
+	for _, r := range routes {
+		re, err := compilePathPattern(r.pattern)
+		if err != nil {
+			return nil, err
+		}
+		compiled = append(compiled, compiledPlaneRoute{re: re, plane: r.plane})
+	}
+	return compiled, nil
+}
+
 // compilePathPattern compiles a single glob-style path pattern into a regular expression.
 // It returns an error if the pattern is invalid.
 //

--- a/backend/pkg/thunderidengine/config/config.go
+++ b/backend/pkg/thunderidengine/config/config.go
@@ -125,9 +125,15 @@ type RedisConfig struct {
 
 // ServerConfig holds the server configuration details.
 type ServerConfig struct {
-	Hostname       string         `yaml:"hostname"   json:"hostname"`
-	Port           int            `yaml:"port"       json:"port"`
-	HTTPOnly       bool           `yaml:"http_only"  json:"http_only"`
+	Hostname string `yaml:"hostname"   json:"hostname"`
+	Port     int    `yaml:"port"       json:"port"`
+	HTTPOnly bool   `yaml:"http_only"  json:"http_only"`
+	// Mode selects which planes this instance serves: "hybrid" (default, both the control-plane
+	// configuration APIs and the data-plane runtime + identity APIs), "cp" (control plane only:
+	// configuration management such as applications, IdPs, flows, roles, groups, OUs), or "dp"
+	// (data plane only: runtime plus data-plane management such as users, agents, role assignment).
+	// It gates only the management HTTP surface; public runtime endpoints are always served.
+	Mode           string         `yaml:"mode"       json:"mode"`
 	PublicURL      string         `yaml:"public_url" json:"public_url"`
 	Identifier     string         `yaml:"identifier" json:"identifier"`
 	SecurityConfig SecurityConfig `yaml:"security"   json:"security"`


### PR DESCRIPTION
### Purpose

Introduce Control Plane (CP) and Data Plane (DP) server builds alongside the existing hybrid server, as the first step toward separating identity configuration authoring from live authentication traffic.

- `cmd/cpserver` (Control Plane): management/configuration APIs only. Does not link or expose the runtime (no OAuth2/OIDC token issuance, login, or flow execution).
- `cmd/dpserver` (Data Plane): runtime plus live-identity management. Defaults to `dp` mode.
- `cmd/server` (Hybrid): unchanged; serves both planes.

A new `server.mode` config (`cp` / `dp` / `hybrid`, default `hybrid`) gates the management HTTP surface per plane in the security middleware: on a single-plane instance the other plane's management routes return 404, while public runtime endpoints are never gated. The split follows the resource ownership model, e.g. role definition is a CP operation while role assignment is a DP operation.

### Approach

- Add `server.mode` to the engine `SecurityConfig`/`ServerConfig` and classify the management route surface by plane in `internal/system/security` (`permissions.go`, `service.go`, `utils.go`). The middleware rejects a management route owned by the other plane with 404 (`middleware.go`, `errors.go`, `apierror`), while public routes stay open.
- Each build defaults its own plane in its entry point: `cpserver` defaults `mode=cp`, `dpserver` defaults `mode=dp`; an explicit `mode` in `deployment.yaml` still takes precedence. Hybrid keeps the empty/`hybrid` default.
- `cpserver` registers only the configuration services (no runtime packages linked), so the CP build is genuinely reduced. `dpserver` reuses the full service graph (the runtime reads configuration) with `mode=dp`.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
