### PR TITLE
Make default agent type schema attributes optional

### DIFF
--- a/api/agent.yaml
+++ b/api/agent.yaml
@@ -1482,11 +1482,11 @@ paths:
               schema:
                 modelProvider:
                   type: "string"
-                  required: true
+                  required: false
                   enum: ["openai", "anthropic", "gemini", "mistral", "custom"]
                 model:
                   type: "string"
-                  required: true
+                  required: false
                 function:
                   type: "string"
                   required: false
@@ -1508,11 +1508,11 @@ paths:
                 schema:
                   modelProvider:
                     type: "string"
-                    required: true
+                    required: false
                     enum: ["openai", "anthropic", "gemini", "mistral", "custom"]
                   model:
                     type: "string"
-                    required: true
+                    required: false
                   function:
                     type: "string"
                     required: false
@@ -1608,11 +1608,11 @@ paths:
                 schema:
                   modelProvider:
                     type: "string"
-                    required: true
+                    required: false
                     enum: ["openai", "anthropic", "gemini", "mistral", "custom"]
                   model:
                     type: "string"
-                    required: true
+                    required: false
                   function:
                     type: "string"
                     required: false
@@ -1669,11 +1669,11 @@ paths:
               schema:
                 modelProvider:
                   type: "string"
-                  required: true
+                  required: false
                   enum: ["openai", "anthropic", "gemini", "mistral", "custom"]
                 model:
                   type: "string"
-                  required: true
+                  required: false
                 function:
                   type: "string"
                   required: false
@@ -2802,11 +2802,11 @@ components:
           example:
             modelProvider:
               type: "string"
-              required: true
+              required: false
               enum: ["openai", "anthropic", "gemini", "mistral", "custom"]
             model:
               type: "string"
-              required: true
+              required: false
             function:
               type: "string"
               required: false

--- a/backend/cmd/server/bootstrap/01-default-resources.yaml
+++ b/backend/cmd/server/bootstrap/01-default-resources.yaml
@@ -67,7 +67,7 @@ schema:
   modelProvider:
     type: string
     displayName: Model Provider
-    required: true
+    required: false
     enum:
       - openai
       - anthropic
@@ -77,7 +77,7 @@ schema:
   model:
     type: string
     displayName: Model
-    required: true
+    required: false
   function:
     type: string
     displayName: Function


### PR DESCRIPTION
### Purpose
Makes the attributes in the default agent type schema optional. Previously the seeded default agent type marked modelProvider and model as required: true, so creating or updating any agent without those attributes failed schema validation.

Agents are not uniform: unlike user types, there is a single default agent type shared by all agents, and attributes like model or modelProvider are not applicable to every agent. Forcing them added unnecessary friction and rejected otherwise valid agents. This change makes all default agent schema attributes optional so agents can be registered without them.

### Approach

- Flipped modelProvider and model from required: true to required: false in the seeded default agent type. function was already optional. Attribute requiredness is fully declarative and enforced generically in Schema.Validate, so no validation code change is needed.
- Updated the agent OpenAPI spec to keep the documented default schema in sync: all five example blocks (create request/response, get response, update request, and the AgentType component example) now show these attributes as required: false.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4284

### Related PRs
- https://github.com/thunder-id/thunderid/pull/3545