### PR TITLE
Document session logout for OIDC and app-native flows

### DIFF
--- a/api/flow-execution.yaml
+++ b/api/flow-execution.yaml
@@ -64,6 +64,11 @@ paths:
                 value:
                   applicationId: "550e8400-e29b-41d4-a716-446655440000"
                   flowType: "AUTHENTICATION"
+              initialSignOutRequest:
+                summary: Initial request to terminate the SSO session established for the application
+                value:
+                  applicationId: "550e8400-e29b-41d4-a716-446655440000"
+                  flowType: "SIGNOUT"
               subSequentRequestExample:
                 summary: Subsequent request
                 value:
@@ -259,6 +264,7 @@ components:
             - AUTHENTICATION
             - REGISTRATION
             - RECOVERY
+            - SIGNOUT
           example: "AUTHENTICATION"
         verbose:
           type: boolean

--- a/docs/content/guides/flows/advanced-configurations.mdx
+++ b/docs/content/guides/flows/advanced-configurations.mdx
@@ -382,6 +382,7 @@ Every flow you deploy must reference only executors that are registered on the s
 | **Send Email** | Sends email using configured templates. | Email service configured |
 | **Send SMS** | Sends SMS using configured templates and sender. | SMS sender configured |
 | **Auth Assertion Generator** | Generates the final authentication assertion on successful flow completion. | User authenticated; assertion settings configured |
+| **End Session** | Terminates the SSO session established by the authentication flow and clears its session cookie. | - |
 | **HTTP Request** | Makes HTTP requests to external endpoints. | - |
 
 :::tip 

--- a/docs/content/guides/flows/build-a-flow.mdx
+++ b/docs/content/guides/flows/build-a-flow.mdx
@@ -44,7 +44,7 @@ The canvas opens with a **START** node, a blank **View** node, a **Auth Assertio
 1. Delete **Blank View**.
 2. From **Steps**, click **+** next to **Username + Password**. This replaces the default blank View with the login form View node.
 3. From **Executors**, click **+** next to **Identifier + Password**.
-4. On the **Username + Password** View node, click the **Sign In** button component and set its **Type** property to `SUBMIT`.
+4. On the **Username + Password** View node, click the **Sign In** button component and set its **Action** property to **Submit Form**.
 5. Connect **START** → **Username + Password View** → **Identifier + Password Executor**.
 
 ## Add the Google Social Login Option
@@ -89,7 +89,7 @@ After a successful username + password check, the flow sends a one-time password
 
 ## Add the OTP View and Verify OTP Executor
 
-1. From **Steps**, click **+** next to **SMS OTP View**. Click the **Verify** button component and set its **Type** property to `SUBMIT`.
+1. From **Steps**, click **+** next to **SMS OTP View**. Click the **Verify** button component and set its **Action** property to **Submit Form**.
 2. From **Executors**, click **+** next to **Verify OTP**.
 3. Connect **Send SMS** success → **SMS OTP View**.
 4. Connect **SMS OTP View** action output → **Verify OTP** Executor.
@@ -197,7 +197,7 @@ A flow has no effect until it is assigned to an application.
 
   1. **Permission check**: validates that the caller holds the required `system` scope.
   2. **User type selection**: if multiple user types are configured, prompts the admin to select one.
-  3. **Organisation unit (OU) selection**: prompts the admin to choose the target OU from the OU tree.
+  3. **Organization unit (OU) selection**: prompts the admin to choose the target OU from the OU tree.
   4. **Onboarding mode**: the admin chooses between two paths:
      - **Create now**: the admin fills in the user's profile details immediately and the user is provisioned on the spot.
      - **Invite**: the admin enters the user's email address and selects a delivery method: send an invitation email, or copy a shareable link. The invited user follows the link to complete their own registration (the invite link is valid for 24 hours).
@@ -212,6 +212,30 @@ A flow has no effect until it is assigned to an application.
   ```
 
   Restart <ProductName /> for the change to take effect. All admin user creation actions, from the Console and the API, use the new flow.
+
+</details>
+
+<details>
+  <summary>Build and configure a sign-out flow</summary>
+
+  A sign-out flow terminates the [Single Sign-On session](../../../key-concepts/authentication/sessions) an authentication flow established, so a user is fully signed out rather than silently signed in again on their next visit. The default flow ends the session without prompting, and a custom flow can confirm the sign-out with the user first. Every application already resolves to a flow, the one it pins, its organization unit's default, or the server-level default, so you only build a sign-out flow when you want to change that behavior. To create one:
+
+  1. In the Console, go to **Flows** → **+ Create New Flow**.
+  2. Select **Sign Out** as the flow type and click **Continue**.
+  3. Choose a template, for example, **Silent Sign Out** ("Terminate the user's SSO session immediately, with no confirmation step"), **Confirm & Sign Out** (prompt on every request), **Conditional Confirmation** (prompt only when the request has no `id_token_hint`), or **Blank** to start from scratch.
+  4. Give the flow a name and click **Create**.
+  5. The canvas opens with the template pre-wired. The **End Session** executor is the node that terminates the session. Customize the steps as needed, then click **Save**.
+
+  To use your flow instead of the default on an application:
+
+  1. Go to **Applications** and open the application.
+  2. Open the **Flows** tab and find the **Sign Out Flow** section.
+  3. Select the flow you created from the dropdown.
+  4. Click **Save**.
+
+  To make it the default for every application in an organization unit instead, go to **Organization Units** and open the organization unit. Open the **Flows** tab, select the flow under **Sign Out Flow**, then click **Save**. An application that pins its own flow keeps using that flow.
+
+  The sign-out flow runs when a user signs out of the application. Browser-based applications trigger it over OIDC through the [RP-Initiated Logout](../../protocols/oauth-oidc/rp-initiated-logout) endpoint; app-native applications run it directly through the Flow Execution API by initiating a `SIGNOUT` flow. See [API Reference](../../../apis).
 
 </details>
 

--- a/docs/content/guides/protocols/oauth-oidc/index.mdx
+++ b/docs/content/guides/protocols/oauth-oidc/index.mdx
@@ -73,6 +73,7 @@ The identity layer on top of OAuth 2.1.
 | Protocol | Spec | Summary |
 |---|---|---|
 | [OpenID Connect](./openid-connect) | OIDC Core 1.0 | ID tokens, the `openid` scope, and authentication context parameters (`nonce`, `prompt`, `acr_values`). |
+| [RP-Initiated Logout](./rp-initiated-logout) | OIDC RP-Initiated Logout 1.0 | The `end_session_endpoint` that terminates the user's SSO session and returns the browser to your application. |
 | [UserInfo](./userinfo) | OIDC Core 1.0 §5.3 | Endpoint that returns claims about the authenticated user. |
 | [Claims & Scopes](./claims-and-scopes) | OIDC Core 1.0 §5 | Standard OIDC scopes, custom scope-to-claim mapping, and the `claims` parameter. |
 | [Token Formats](./token-formats) | RFC 7515 · RFC 7516 | ID Token and UserInfo response formats: JWS, JWE, and NESTED_JWT. |

--- a/docs/content/guides/protocols/oauth-oidc/rp-initiated-logout.mdx
+++ b/docs/content/guides/protocols/oauth-oidc/rp-initiated-logout.mdx
@@ -1,0 +1,119 @@
+---
+title: RP-Initiated Logout
+docType: reference
+sidebar_position: 5
+description: OpenID Connect RP-Initiated Logout 1.0 in {{ProductName}}, the end_session_endpoint that terminates a user's Single Sign-On session and returns the browser to your application.
+---
+import { RPInitiatedLogoutDiagram } from '@site/src/components/OAuthFlowDiagrams';
+
+# RP-Initiated Logout
+
+**OpenID Connect RP-Initiated Logout 1.0** ([RP-Initiated Logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html)) lets a relying party (your application) end a user's session at the OpenID Provider. <ProductName /> implements it as the `end_session_endpoint` at `GET`/`POST /oauth2/logout`. When your application signs a user out locally, it redirects the browser to this endpoint so <ProductName /> also terminates the [Single Sign-On session](../../../flows/single-sign-on) it established, and then returns the user to a page you choose.
+
+Signing out of your application alone leaves the <ProductName /> session intact, so the next sign-in reuses it and the user is not prompted. RP-Initiated Logout closes that gap: it ends the session at <ProductName /> too, so the next sign-in authenticates the user again.
+
+## How It Works
+
+<RPInitiatedLogoutDiagram />
+
+1. Your application clears its own session, then redirects the browser to `/oauth2/logout`.
+2. <ProductName /> validates the request: it resolves the client from the `id_token_hint` or `client_id`, and checks any `post_logout_redirect_uri` against the client's registered list.
+3. <ProductName /> runs the application's **sign-out flow** to terminate the SSO session and clear the per-flow session cookie. Depending on how the flow is built, this step may prompt the user to confirm the sign-out first.
+4. <ProductName /> redirects the browser to `post_logout_redirect_uri`, appending `state` when the application supplied it. If the application supplied no redirect URI, the browser lands on the default <ProductName /> sign-out page.
+
+Whether the user is asked to confirm depends on the sign-out flow. <ProductName /> flags a request that carries no `id_token_hint` as needing confirmation, and the sign-out flow decides what to do with that signal. The default sign-out flow ends the session without prompting, which is the path the diagram above shows. The built-in **Conditional Confirmation** template prompts only when the hint is absent, and **Confirm & Sign Out** prompts on every request.
+
+<details>
+<summary>How <ProductName /> Implements It</summary>
+
+| Aspect | Behavior |
+|---|---|
+| Endpoint | `GET`/`POST /oauth2/logout` |
+| Discovery | Advertised as `end_session_endpoint` in `/.well-known/openid-configuration`, see [Server Metadata](../server-metadata) |
+| Session termination | Runs the application's sign-out flow, which ends the SSO session and clears the per-flow cookie, see [Sessions and Single Sign-On](../../../../key-concepts/authentication/sessions) |
+| `id_token_hint` | Optional. When supplied, its signature and issuer are verified; expiry is **not** enforced, so an expired ID token is accepted. When omitted, the request is flagged as needing confirmation, which a sign-out flow can branch on |
+| Redirect validation | `post_logout_redirect_uri` must match one of the client's registered `postLogoutRedirectUris` exactly. Registered wildcard patterns also match when the server sets `allow_wildcard_redirect_uri` to `true`, which is off by default |
+| Sign-out flow | Resolved in order: the flow the application pins, then the default on its organization unit, then the server-level default |
+
+</details>
+
+## Request Methods
+
+The endpoint accepts the same request as either an HTTP `GET` or an HTTP `POST`, carrying the same parameters:
+
+- **`GET`** carries the parameters in the query string. This is the usual choice, because signing out is a browser redirect to the endpoint.
+- **`POST`** carries the parameters in an `application/x-www-form-urlencoded` body. Use it when the `id_token_hint` would make the URL too long, or to keep it out of the URL and browser history. Note that a request body can still be recorded by applications, proxies, or middleware, so treat `id_token_hint` as sensitive and redact it from logs.
+
+## Request Parameters
+
+| Parameter | Required | Description |
+|---|---|---|
+| `id_token_hint` | Recommended | An ID token that <ProductName /> previously issued to this client. It identifies the client whose session is ending. The token may be expired. When omitted, <ProductName /> flags the request as needing confirmation, and the sign-out flow decides whether to prompt. |
+| `client_id` | Optional | The client that is signing out. Used when `id_token_hint` is absent, and at least one of the two must be present. When both are present, the `client_id` must match the client in `id_token_hint`. |
+| `post_logout_redirect_uri` | Optional | Where to send the browser after sign-out. Must exactly match one of the client's registered `postLogoutRedirectUris`. |
+| `state` | Optional | An opaque value <ProductName /> appends to `post_logout_redirect_uri` on the return, when supplied, for your application to correlate the response. |
+
+### Validation Rules
+
+<ProductName /> rejects the request with `400 Bad Request` when:
+
+- `post_logout_redirect_uri` does not exactly match a URI registered on the client.
+- `id_token_hint` is present but was not signed by <ProductName /> or carries a different issuer.
+- both `id_token_hint` and `client_id` are present and identify different clients.
+- neither `id_token_hint` nor `client_id` is supplied.
+- the client id, whether supplied as `client_id` or derived from `id_token_hint`, does not resolve to a registered client.
+
+## Configure Your Application
+
+### Sign-Out Flow
+
+<ProductName /> terminates the SSO session by running the application's sign-out flow. The flow is resolved in three steps, and the first match wins:
+
+1. The sign-out flow pinned on the application under its **Flows** tab.
+2. The default sign-out flow set on the application's organization unit, under **Organization Units** → the organization unit → **Flows**.
+3. The server-level default sign-out flow.
+
+<ProductName /> ships a server-level default, so an application that pins nothing still signs users out. To use a custom flow instead, build one and select it under the application's **Flows** tab. See [Build a Sign-Out Flow](../../../flows/build-a-flow#go-further).
+
+### Register Post-Logout Redirect URIs
+
+For <ProductName /> to return the browser to your application, the `post_logout_redirect_uri` you send must be registered on the application under `postLogoutRedirectUris`. Configure it through the application's OAuth configuration in a [declarative configuration](../../../declarative-configurations/what-is-import-and-export) or through the `/applications` API, see [API Reference](../../../../apis).
+
+```yaml
+postLogoutRedirectUris:
+  - https://app.example.com/signed-out
+```
+
+## Try It in <ProductName />
+
+Redirect the browser to the endpoint when the user signs out of your application:
+
+```http
+GET /oauth2/logout
+  ?id_token_hint=$ID_TOKEN
+  &post_logout_redirect_uri=https://app.example.com/signed-out
+  &state=xyz
+```
+
+The same request as a `POST` sends the parameters in the body instead:
+
+```http
+POST /oauth2/logout
+Content-Type: application/x-www-form-urlencoded
+
+id_token_hint=$ID_TOKEN&post_logout_redirect_uri=https://app.example.com/signed-out&state=xyz
+```
+
+<ProductName /> ends the SSO session and redirects the browser to:
+
+```http
+https://app.example.com/signed-out?state=xyz
+```
+
+## Related Guides
+
+- [Sessions and Single Sign-On](../../../../key-concepts/authentication/sessions), the session model that logout terminates
+- [Single Sign-On for Flows](../../../flows/single-sign-on), how a session is established in the first place
+- [Build a Sign-Out Flow](../../../flows/build-a-flow#go-further), the flow that RP-Initiated Logout runs
+- [OpenID Connect](../openid-connect), the identity layer these tokens come from
+- [Server Metadata](../server-metadata), the `/.well-known/openid-configuration` document that advertises the endpoint

--- a/docs/content/key-concepts/authentication/sessions.mdx
+++ b/docs/content/key-concepts/authentication/sessions.mdx
@@ -9,7 +9,7 @@ description: Understand how {{ProductName}} sessions work and how flow Single Si
 
 A session records that a user authenticated, so <ProductName /> can trust that authentication again later without prompting the user to repeat it. Single Sign-On (SSO) builds on sessions: when a user has a valid session, <ProductName /> reuses it and skips the steps the session already covers.
 
-This page explains the session model and how SSO applies to authentication flows. To add SSO to a flow, see [Single Sign-On for Flows](../../guides/flows/single-sign-on.mdx).
+This page explains the session model and how SSO applies to authentication flows. To add SSO to a flow, see [Single Sign-On for Flows](../../../guides/flows/single-sign-on).
 
 ## Flow-Centric Sessions
 
@@ -32,12 +32,28 @@ Two independent timeouts bound every session:
 | Idle | Moves forward on each use of the session, so an active session stays alive. The session expires after this much inactivity. | 30 minutes |
 | Absolute | Fixed when the session is created and never extended. The session expires this long after creation regardless of activity. | 8 hours |
 
-A session expires when it passes either deadline. After expiry, the next sign-in through the flow authenticates the user again. An administrator configures both timeouts in the server configuration. See [Configure Session Lifetime](../../guides/flows/single-sign-on.mdx#configure-session-lifetime).
+A session expires when it passes either deadline. After expiry, the next sign-in through the flow authenticates the user again. An administrator configures both timeouts in the server configuration. See [Configure Session Lifetime](../../../guides/flows/single-sign-on#configure-session-lifetime).
 
 ## Browser Scope
 
 Flow SSO applies to browser-based authentication. <ProductName /> references each session with a per-flow cookie that carries only an opaque handle, never user data. Because the cookie is the reference, SSO reuse happens within a browser: a user who authenticates in one browser does not gain a session in another.
 
+## Ending a Session
+
+Signing a user out of an application does not, on its own, end their <ProductName /> session. Because SSO reuses the session, the next sign-in would find it still valid and skip authentication. To sign the user out fully, terminate the session at <ProductName /> as well.
+
+A session is terminated by running the application's **sign-out flow**, which ends the session and clears its per-flow cookie. Terminating a session is idempotent: ending an already-ended or expired session is not an error.
+
+Every application resolves a sign-out flow from the first of three sources that is set: the flow pinned on the application, the default on its organization unit, or the server-level default. <ProductName /> ships a server-level default, so an application that pins nothing still signs users out. See [Build a Sign-Out Flow](../../../guides/flows/build-a-flow#go-further).
+
+There are two ways to run the sign-out flow, matching the two [integration models](../integration-models):
+
+- **Redirect-based (OIDC).** A browser-based application redirects the user to the `end_session_endpoint`, which runs the sign-out flow and returns the browser to the application. See [RP-Initiated Logout](../../../guides/protocols/oauth-oidc/rp-initiated-logout).
+- **App-native.** An application that drives flows directly runs the sign-out flow through the Flow Execution API. See [Build a Sign-Out Flow](../../../guides/flows/build-a-flow#go-further).
+
+A session also ends on its own when it passes the idle or absolute timeout, as described above.
+
 ## Related
 
-- [Single Sign-On for Flows](../../guides/flows/single-sign-on.mdx) shows how to add the SSO nodes to a flow in the Console Flow Builder.
+- [Single Sign-On for Flows](../../../guides/flows/single-sign-on) shows how to add the SSO nodes to a flow in the Console Flow Builder.
+- [RP-Initiated Logout](../../../guides/protocols/oauth-oidc/rp-initiated-logout) shows how a browser-based application ends the session over OIDC.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -842,6 +842,11 @@ const sidebars: SidebarsConfig = {
                   collapsible: true,
                   items: [
                     {type: 'doc', id: 'guides/protocols/oauth-oidc/openid-connect', label: 'OpenID Connect'},
+                    {
+                      type: 'doc',
+                      id: 'guides/protocols/oauth-oidc/rp-initiated-logout',
+                      label: 'RP-Initiated Logout',
+                    },
                     {type: 'doc', id: 'guides/protocols/oauth-oidc/userinfo', label: 'UserInfo'},
                     {type: 'doc', id: 'guides/protocols/oauth-oidc/claims-and-scopes', label: 'Claims & Scopes'},
                     {type: 'doc', id: 'guides/protocols/oauth-oidc/token-formats', label: 'Token Formats'},

--- a/docs/src/components/OAuthFlowDiagrams.tsx
+++ b/docs/src/components/OAuthFlowDiagrams.tsx
@@ -181,6 +181,26 @@ export function OIDCFlowDiagram() {
   );
 }
 
+export function RPInitiatedLogoutDiagram() {
+  return (
+    <SequenceDiagram
+      actors={['User Agent', 'Application', 'ThunderID']}
+      gaps={[360, 360]}
+      ariaLabel="RP-Initiated Logout flow: the user signs out of the application, the application clears its local session and redirects the browser to the end_session_endpoint, ThunderID validates the request and runs the sign-out flow to terminate the SSO session, then redirects the browser to the post-logout redirect URI."
+      rows={[
+        { from: 0, to: 1, label: 'Sign out' },
+        { note: 'Application clears its local session', between: [1, 1] },
+        { from: 1, to: 0, label: ['302 Redirect to', '/oauth2/logout'] },
+        { from: 0, to: 2, label: 'GET /oauth2/logout', sublabel: ['id_token_hint,', 'post_logout_redirect_uri, state'] },
+        { note: 'Validate request, run the sign-out flow', between: [2, 2] },
+        { note: 'Terminate SSO session, clear session cookie', between: [2, 2] },
+        { from: 2, to: 0, label: ['302 Redirect to', 'post_logout_redirect_uri?state=...'] },
+        { from: 0, to: 1, label: 'Land on the post-logout page' },
+      ]}
+    />
+  );
+}
+
 export function UserInfoDiagram() {
   return (
     <SequenceDiagram

--- a/docs/static/api/v1.0.x/combined.yaml
+++ b/docs/static/api/v1.0.x/combined.yaml
@@ -5713,6 +5713,12 @@ paths:
                 value:
                   applicationId: 550e8400-e29b-41d4-a716-446655440000
                   flowType: AUTHENTICATION
+              initialSignOutRequest:
+                summary: Initial request to terminate the SSO session established for the
+                  application
+                value:
+                  applicationId: 550e8400-e29b-41d4-a716-446655440000
+                  flowType: SIGNOUT
               subSequentRequestExample:
                 summary: Subsequent request
                 value:
@@ -20225,6 +20231,7 @@ components:
             - AUTHENTICATION
             - REGISTRATION
             - RECOVERY
+            - SIGNOUT
           example: AUTHENTICATION
         verbose:
           type: boolean

--- a/docs/versioned_docs/version-v1.0.x/guides/flows/advanced-configurations.mdx
+++ b/docs/versioned_docs/version-v1.0.x/guides/flows/advanced-configurations.mdx
@@ -382,6 +382,7 @@ Every flow you deploy must reference only executors that are registered on the s
 | **Send Email** | Sends email using configured templates. | Email service configured |
 | **Send SMS** | Sends SMS using configured templates and sender. | SMS sender configured |
 | **Auth Assertion Generator** | Generates the final authentication assertion on successful flow completion. | User authenticated; assertion settings configured |
+| **End Session** | Terminates the SSO session established by the authentication flow and clears its session cookie. | - |
 | **HTTP Request** | Makes HTTP requests to external endpoints. | - |
 
 :::tip 

--- a/docs/versioned_docs/version-v1.0.x/guides/flows/build-a-flow.mdx
+++ b/docs/versioned_docs/version-v1.0.x/guides/flows/build-a-flow.mdx
@@ -44,7 +44,7 @@ The canvas opens with a **START** node, a blank **View** node, a **Auth Assertio
 1. Delete **Blank View**.
 2. From **Steps**, click **+** next to **Username + Password**. This replaces the default blank View with the login form View node.
 3. From **Executors**, click **+** next to **Identifier + Password**.
-4. On the **Username + Password** View node, click the **Sign In** button component and set its **Type** property to `SUBMIT`.
+4. On the **Username + Password** View node, click the **Sign In** button component and set its **Action** property to **Submit Form**.
 5. Connect **START** → **Username + Password View** → **Identifier + Password Executor**.
 
 ## Add the Google Social Login Option
@@ -89,7 +89,7 @@ After a successful username + password check, the flow sends a one-time password
 
 ## Add the OTP View and Verify OTP Executor
 
-1. From **Steps**, click **+** next to **SMS OTP View**. Click the **Verify** button component and set its **Type** property to `SUBMIT`.
+1. From **Steps**, click **+** next to **SMS OTP View**. Click the **Verify** button component and set its **Action** property to **Submit Form**.
 2. From **Executors**, click **+** next to **Verify OTP**.
 3. Connect **Send SMS** success → **SMS OTP View**.
 4. Connect **SMS OTP View** action output → **Verify OTP** Executor.
@@ -197,7 +197,7 @@ A flow has no effect until it is assigned to an application.
 
   1. **Permission check**: validates that the caller holds the required `system` scope.
   2. **User type selection**: if multiple user types are configured, prompts the admin to select one.
-  3. **Organisation unit (OU) selection**: prompts the admin to choose the target OU from the OU tree.
+  3. **Organization unit (OU) selection**: prompts the admin to choose the target OU from the OU tree.
   4. **Onboarding mode**: the admin chooses between two paths:
      - **Create now**: the admin fills in the user's profile details immediately and the user is provisioned on the spot.
      - **Invite**: the admin enters the user's email address and selects a delivery method: send an invitation email, or copy a shareable link. The invited user follows the link to complete their own registration (the invite link is valid for 24 hours).
@@ -212,6 +212,30 @@ A flow has no effect until it is assigned to an application.
   ```
 
   Restart <ProductName /> for the change to take effect. All admin user creation actions, from the Console and the API, use the new flow.
+
+</details>
+
+<details>
+  <summary>Build and configure a sign-out flow</summary>
+
+  A sign-out flow terminates the [Single Sign-On session](../../../key-concepts/authentication/sessions) an authentication flow established, so a user is fully signed out rather than silently signed in again on their next visit. The default flow ends the session without prompting, and a custom flow can confirm the sign-out with the user first. Every application already resolves to a flow, the one it pins, its organization unit's default, or the server-level default, so you only build a sign-out flow when you want to change that behavior. To create one:
+
+  1. In the Console, go to **Flows** → **+ Create New Flow**.
+  2. Select **Sign Out** as the flow type and click **Continue**.
+  3. Choose a template, for example, **Silent Sign Out** ("Terminate the user's SSO session immediately, with no confirmation step"), **Confirm & Sign Out** (prompt on every request), **Conditional Confirmation** (prompt only when the request has no `id_token_hint`), or **Blank** to start from scratch.
+  4. Give the flow a name and click **Create**.
+  5. The canvas opens with the template pre-wired. The **End Session** executor is the node that terminates the session. Customize the steps as needed, then click **Save**.
+
+  To use your flow instead of the default on an application:
+
+  1. Go to **Applications** and open the application.
+  2. Open the **Flows** tab and find the **Sign Out Flow** section.
+  3. Select the flow you created from the dropdown.
+  4. Click **Save**.
+
+  To make it the default for every application in an organization unit instead, go to **Organization Units** and open the organization unit. Open the **Flows** tab, select the flow under **Sign Out Flow**, then click **Save**. An application that pins its own flow keeps using that flow.
+
+  The sign-out flow runs when a user signs out of the application. Browser-based applications trigger it over OIDC through the [RP-Initiated Logout](../../protocols/oauth-oidc/rp-initiated-logout) endpoint; app-native applications run it directly through the Flow Execution API by initiating a `SIGNOUT` flow. See [API Reference](../../../apis).
 
 </details>
 

--- a/docs/versioned_docs/version-v1.0.x/guides/protocols/oauth-oidc/index.mdx
+++ b/docs/versioned_docs/version-v1.0.x/guides/protocols/oauth-oidc/index.mdx
@@ -73,6 +73,7 @@ The identity layer on top of OAuth 2.1.
 | Protocol | Spec | Summary |
 |---|---|---|
 | [OpenID Connect](./openid-connect) | OIDC Core 1.0 | ID tokens, the `openid` scope, and authentication context parameters (`nonce`, `prompt`, `acr_values`). |
+| [RP-Initiated Logout](./rp-initiated-logout) | OIDC RP-Initiated Logout 1.0 | The `end_session_endpoint` that terminates the user's SSO session and returns the browser to your application. |
 | [UserInfo](./userinfo) | OIDC Core 1.0 §5.3 | Endpoint that returns claims about the authenticated user. |
 | [Claims & Scopes](./claims-and-scopes) | OIDC Core 1.0 §5 | Standard OIDC scopes, custom scope-to-claim mapping, and the `claims` parameter. |
 | [Token Formats](./token-formats) | RFC 7515 · RFC 7516 | ID Token and UserInfo response formats: JWS, JWE, and NESTED_JWT. |

--- a/docs/versioned_docs/version-v1.0.x/guides/protocols/oauth-oidc/rp-initiated-logout.mdx
+++ b/docs/versioned_docs/version-v1.0.x/guides/protocols/oauth-oidc/rp-initiated-logout.mdx
@@ -1,0 +1,119 @@
+---
+title: RP-Initiated Logout
+docType: reference
+sidebar_position: 5
+description: OpenID Connect RP-Initiated Logout 1.0 in {{ProductName}}, the end_session_endpoint that terminates a user's Single Sign-On session and returns the browser to your application.
+---
+import { RPInitiatedLogoutDiagram } from '@site/src/components/OAuthFlowDiagrams';
+
+# RP-Initiated Logout
+
+**OpenID Connect RP-Initiated Logout 1.0** ([RP-Initiated Logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html)) lets a relying party (your application) end a user's session at the OpenID Provider. <ProductName /> implements it as the `end_session_endpoint` at `GET`/`POST /oauth2/logout`. When your application signs a user out locally, it redirects the browser to this endpoint so <ProductName /> also terminates the [Single Sign-On session](../../../flows/single-sign-on) it established, and then returns the user to a page you choose.
+
+Signing out of your application alone leaves the <ProductName /> session intact, so the next sign-in reuses it and the user is not prompted. RP-Initiated Logout closes that gap: it ends the session at <ProductName /> too, so the next sign-in authenticates the user again.
+
+## How It Works
+
+<RPInitiatedLogoutDiagram />
+
+1. Your application clears its own session, then redirects the browser to `/oauth2/logout`.
+2. <ProductName /> validates the request: it resolves the client from the `id_token_hint` or `client_id`, and checks any `post_logout_redirect_uri` against the client's registered list.
+3. <ProductName /> runs the application's **sign-out flow** to terminate the SSO session and clear the per-flow session cookie. Depending on how the flow is built, this step may prompt the user to confirm the sign-out first.
+4. <ProductName /> redirects the browser to `post_logout_redirect_uri`, appending `state` when the application supplied it. If the application supplied no redirect URI, the browser lands on the default <ProductName /> sign-out page.
+
+Whether the user is asked to confirm depends on the sign-out flow. <ProductName /> flags a request that carries no `id_token_hint` as needing confirmation, and the sign-out flow decides what to do with that signal. The default sign-out flow ends the session without prompting, which is the path the diagram above shows. The built-in **Conditional Confirmation** template prompts only when the hint is absent, and **Confirm & Sign Out** prompts on every request.
+
+<details>
+<summary>How <ProductName /> Implements It</summary>
+
+| Aspect | Behavior |
+|---|---|
+| Endpoint | `GET`/`POST /oauth2/logout` |
+| Discovery | Advertised as `end_session_endpoint` in `/.well-known/openid-configuration`, see [Server Metadata](../server-metadata) |
+| Session termination | Runs the application's sign-out flow, which ends the SSO session and clears the per-flow cookie, see [Sessions and Single Sign-On](../../../../key-concepts/authentication/sessions) |
+| `id_token_hint` | Optional. When supplied, its signature and issuer are verified; expiry is **not** enforced, so an expired ID token is accepted. When omitted, the request is flagged as needing confirmation, which a sign-out flow can branch on |
+| Redirect validation | `post_logout_redirect_uri` must match one of the client's registered `postLogoutRedirectUris` exactly. Registered wildcard patterns also match when the server sets `allow_wildcard_redirect_uri` to `true`, which is off by default |
+| Sign-out flow | Resolved in order: the flow the application pins, then the default on its organization unit, then the server-level default |
+
+</details>
+
+## Request Methods
+
+The endpoint accepts the same request as either an HTTP `GET` or an HTTP `POST`, carrying the same parameters:
+
+- **`GET`** carries the parameters in the query string. This is the usual choice, because signing out is a browser redirect to the endpoint.
+- **`POST`** carries the parameters in an `application/x-www-form-urlencoded` body. Use it when the `id_token_hint` would make the URL too long, or to keep it out of the URL and browser history. Note that a request body can still be recorded by applications, proxies, or middleware, so treat `id_token_hint` as sensitive and redact it from logs.
+
+## Request Parameters
+
+| Parameter | Required | Description |
+|---|---|---|
+| `id_token_hint` | Recommended | An ID token that <ProductName /> previously issued to this client. It identifies the client whose session is ending. The token may be expired. When omitted, <ProductName /> flags the request as needing confirmation, and the sign-out flow decides whether to prompt. |
+| `client_id` | Optional | The client that is signing out. Used when `id_token_hint` is absent, and at least one of the two must be present. When both are present, the `client_id` must match the client in `id_token_hint`. |
+| `post_logout_redirect_uri` | Optional | Where to send the browser after sign-out. Must exactly match one of the client's registered `postLogoutRedirectUris`. |
+| `state` | Optional | An opaque value <ProductName /> appends to `post_logout_redirect_uri` on the return, when supplied, for your application to correlate the response. |
+
+### Validation Rules
+
+<ProductName /> rejects the request with `400 Bad Request` when:
+
+- `post_logout_redirect_uri` does not exactly match a URI registered on the client.
+- `id_token_hint` is present but was not signed by <ProductName /> or carries a different issuer.
+- both `id_token_hint` and `client_id` are present and identify different clients.
+- neither `id_token_hint` nor `client_id` is supplied.
+- the client id, whether supplied as `client_id` or derived from `id_token_hint`, does not resolve to a registered client.
+
+## Configure Your Application
+
+### Sign-Out Flow
+
+<ProductName /> terminates the SSO session by running the application's sign-out flow. The flow is resolved in three steps, and the first match wins:
+
+1. The sign-out flow pinned on the application under its **Flows** tab.
+2. The default sign-out flow set on the application's organization unit, under **Organization Units** → the organization unit → **Flows**.
+3. The server-level default sign-out flow.
+
+<ProductName /> ships a server-level default, so an application that pins nothing still signs users out. To use a custom flow instead, build one and select it under the application's **Flows** tab. See [Build a Sign-Out Flow](../../../flows/build-a-flow#go-further).
+
+### Register Post-Logout Redirect URIs
+
+For <ProductName /> to return the browser to your application, the `post_logout_redirect_uri` you send must be registered on the application under `postLogoutRedirectUris`. Configure it through the application's OAuth configuration in a [declarative configuration](../../../declarative-configurations/what-is-import-and-export) or through the `/applications` API, see [API Reference](../../../../apis).
+
+```yaml
+postLogoutRedirectUris:
+  - https://app.example.com/signed-out
+```
+
+## Try It in <ProductName />
+
+Redirect the browser to the endpoint when the user signs out of your application:
+
+```http
+GET /oauth2/logout
+  ?id_token_hint=$ID_TOKEN
+  &post_logout_redirect_uri=https://app.example.com/signed-out
+  &state=xyz
+```
+
+The same request as a `POST` sends the parameters in the body instead:
+
+```http
+POST /oauth2/logout
+Content-Type: application/x-www-form-urlencoded
+
+id_token_hint=$ID_TOKEN&post_logout_redirect_uri=https://app.example.com/signed-out&state=xyz
+```
+
+<ProductName /> ends the SSO session and redirects the browser to:
+
+```http
+https://app.example.com/signed-out?state=xyz
+```
+
+## Related Guides
+
+- [Sessions and Single Sign-On](../../../../key-concepts/authentication/sessions), the session model that logout terminates
+- [Single Sign-On for Flows](../../../flows/single-sign-on), how a session is established in the first place
+- [Build a Sign-Out Flow](../../../flows/build-a-flow#go-further), the flow that RP-Initiated Logout runs
+- [OpenID Connect](../openid-connect), the identity layer these tokens come from
+- [Server Metadata](../server-metadata), the `/.well-known/openid-configuration` document that advertises the endpoint

--- a/docs/versioned_docs/version-v1.0.x/key-concepts/authentication/sessions.mdx
+++ b/docs/versioned_docs/version-v1.0.x/key-concepts/authentication/sessions.mdx
@@ -9,7 +9,7 @@ description: Understand how {{ProductName}} sessions work and how flow Single Si
 
 A session records that a user authenticated, so <ProductName /> can trust that authentication again later without prompting the user to repeat it. Single Sign-On (SSO) builds on sessions: when a user has a valid session, <ProductName /> reuses it and skips the steps the session already covers.
 
-This page explains the session model and how SSO applies to authentication flows. To add SSO to a flow, see [Single Sign-On for Flows](../../guides/flows/single-sign-on.mdx).
+This page explains the session model and how SSO applies to authentication flows. To add SSO to a flow, see [Single Sign-On for Flows](../../../guides/flows/single-sign-on).
 
 ## Flow-Centric Sessions
 
@@ -32,12 +32,28 @@ Two independent timeouts bound every session:
 | Idle | Moves forward on each use of the session, so an active session stays alive. The session expires after this much inactivity. | 30 minutes |
 | Absolute | Fixed when the session is created and never extended. The session expires this long after creation regardless of activity. | 8 hours |
 
-A session expires when it passes either deadline. After expiry, the next sign-in through the flow authenticates the user again. An administrator configures both timeouts in the server configuration. See [Configure Session Lifetime](../../guides/flows/single-sign-on.mdx#configure-session-lifetime).
+A session expires when it passes either deadline. After expiry, the next sign-in through the flow authenticates the user again. An administrator configures both timeouts in the server configuration. See [Configure Session Lifetime](../../../guides/flows/single-sign-on#configure-session-lifetime).
 
 ## Browser Scope
 
 Flow SSO applies to browser-based authentication. <ProductName /> references each session with a per-flow cookie that carries only an opaque handle, never user data. Because the cookie is the reference, SSO reuse happens within a browser: a user who authenticates in one browser does not gain a session in another.
 
+## Ending a Session
+
+Signing a user out of an application does not, on its own, end their <ProductName /> session. Because SSO reuses the session, the next sign-in would find it still valid and skip authentication. To sign the user out fully, terminate the session at <ProductName /> as well.
+
+A session is terminated by running the application's **sign-out flow**, which ends the session and clears its per-flow cookie. Terminating a session is idempotent: ending an already-ended or expired session is not an error.
+
+Every application resolves a sign-out flow from the first of three sources that is set: the flow pinned on the application, the default on its organization unit, or the server-level default. <ProductName /> ships a server-level default, so an application that pins nothing still signs users out. See [Build a Sign-Out Flow](../../../guides/flows/build-a-flow#go-further).
+
+There are two ways to run the sign-out flow, matching the two [integration models](../integration-models):
+
+- **Redirect-based (OIDC).** A browser-based application redirects the user to the `end_session_endpoint`, which runs the sign-out flow and returns the browser to the application. See [RP-Initiated Logout](../../../guides/protocols/oauth-oidc/rp-initiated-logout).
+- **App-native.** An application that drives flows directly runs the sign-out flow through the Flow Execution API. See [Build a Sign-Out Flow](../../../guides/flows/build-a-flow#go-further).
+
+A session also ends on its own when it passes the idle or absolute timeout, as described above.
+
 ## Related
 
-- [Single Sign-On for Flows](../../guides/flows/single-sign-on.mdx) shows how to add the SSO nodes to a flow in the Console Flow Builder.
+- [Single Sign-On for Flows](../../../guides/flows/single-sign-on) shows how to add the SSO nodes to a flow in the Console Flow Builder.
+- [RP-Initiated Logout](../../../guides/protocols/oauth-oidc/rp-initiated-logout) shows how a browser-based application ends the session over OIDC.

--- a/docs/versioned_sidebars/version-v1.0.x-sidebars.json
+++ b/docs/versioned_sidebars/version-v1.0.x-sidebars.json
@@ -1139,6 +1139,11 @@
                     },
                     {
                       "type": "doc",
+                      "id": "guides/protocols/oauth-oidc/rp-initiated-logout",
+                      "label": "RP-Initiated Logout"
+                    },
+                    {
+                      "type": "doc",
                       "id": "guides/protocols/oauth-oidc/userinfo",
                       "label": "UserInfo"
                     },


### PR DESCRIPTION
### Purpose
Adds product documentation for session logout, covering both the OIDC redirect-based path and the app-native flow path. This documents the RP-initiated logout endpoint and the sign-out flow that were added to the backend, so integrators know how to end a user's SSO session (not just their local application session).

Changes:
- **New page: RP-Initiated Logout** (`guides/protocols/oauth-oidc/rp-initiated-logout.mdx`) covering the `end_session_endpoint` (`GET`/`POST /oauth2/logout`): the sequence, request methods, request parameters, validation rules, and the sign-out-flow / `postLogoutRedirectUris` prerequisites. Registered in the sidebar under OIDC and added to the OAuth & OIDC index catalogue.
- **Sessions concept page**: added an "Ending a Session" section explaining that app-side sign-out does not end the ThunderID session, and the two paths that do (redirect-based OIDC vs app-native Flow Execution API).
- **Build a Flow guide**: added a "Build and configure a sign-out flow" section to *Go Further*, aligned with the existing registration/recovery sections (Sign Out flow type, Confirm & Sign Out template, End Session executor, assignment under the app's Flows tab).
- **Flow Execution API spec** (`api/flow-execution.yaml`): added the `SIGNOUT` flow type to the `flowType` enum and a sign-out request example.


<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
- The new sequence diagram uses the repo's custom `SequenceDiagram` component (via a new `RPInitiatedLogoutDiagram` in `OAuthFlowDiagrams.tsx`), consistent with the other OAuth/OIDC pages, since Mermaid is not enabled in this repo.
- Documented `postLogoutRedirectUris` as configured via declarative config / the `/applications` API, because no Console UI currently exposes that field.
- Console-facing names are taken verbatim from the code (flow type "Sign Out", template "Confirm & Sign Out", executor node "End Session", app section "Sign Out").

### Related Issues
- N/A

### Related PRs
- https://github.com/thunder-id/thunderid/issues/2036

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for initiating **sign-out** flows through the Flow Execution API using the **SIGNOUT** flow type.
  * Introduced the **End Session** executor to terminate SSO sessions and clear session cookies.
  * Added OIDC **RP-Initiated Logout**, including session termination and post-logout redirects.

* **Documentation**
  * Expanded guidance for configuring and triggering sign-out flows across browser and native applications.
  * Added RP-Initiated Logout documentation covering parameters, validation, redirects, state handling, and session-ending behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->