### PR TITLE
Gate PR Builder on the trigger-pr-builder label as a temporary workaround

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -5,9 +5,15 @@
 
 name: 👷🛠️ PR Builder
 
+# TEMPORARY WORKAROUND for runner saturation (see #4268): on pull requests, the
+# builder only runs once the `trigger-pr-builder` label is present. Early pushes
+# iterate against the review bots without consuming runners, and the label
+# (added when the PR is ready) turns CI on for that push and every subsequent
+# one. Merge queue runs are always on. Remove this gate (restore unconditional
+# pull_request runs) once queue pressure is resolved.
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
   merge_group:
   workflow_dispatch:
 
@@ -26,7 +32,7 @@ env:
 jobs:
   security-audit:
     name: 🔒 Security Audit
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+    if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -47,7 +53,7 @@ jobs:
 
   dependency-review:
     name: 🔎 Dependency Review
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+    if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -91,7 +97,7 @@ jobs:
 
   verify-mocks:
     name: 🔍 Verify Mock Files
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+    if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -127,7 +133,7 @@ jobs:
 
   lint:
     name: 🧹 Lint Code
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+    if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -171,7 +177,7 @@ jobs:
   build:
     name: 🛠️ Build Product
     needs: [detect-code-changes]
-    if: ${{ always() && (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'merge_group') && (needs.detect-code-changes.result == 'skipped' || needs.detect-code-changes.outputs.should-run == 'true') }}
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder')) || github.event_name == 'merge_group') && (needs.detect-code-changes.result == 'skipped' || needs.detect-code-changes.outputs.should-run == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -268,7 +274,7 @@ jobs:
 
   detect-code-changes:
     name: 🔍 Detect Code Changes
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder')) || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -304,7 +310,7 @@ jobs:
   test-frontend-packages:
     name: 🧪 Frontend Packages Tests
     needs: [detect-code-changes]
-    if: ${{ always() && (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'merge_group') && (needs.detect-code-changes.result == 'skipped' || needs.detect-code-changes.outputs.should-run == 'true') }}
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder')) || github.event_name == 'merge_group') && (needs.detect-code-changes.result == 'skipped' || needs.detect-code-changes.outputs.should-run == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -342,7 +348,7 @@ jobs:
   test-frontend-gate-app:
     name: 🧪 Gate App Tests with Coverage
     needs: [detect-code-changes]
-    if: ${{ always() && (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'merge_group') && (needs.detect-code-changes.result == 'skipped' || needs.detect-code-changes.outputs.should-run == 'true') }}
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder')) || github.event_name == 'merge_group') && (needs.detect-code-changes.result == 'skipped' || needs.detect-code-changes.outputs.should-run == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -391,7 +397,7 @@ jobs:
   test-frontend-console-app:
     name: 🧪 Console App Tests with Coverage
     needs: [detect-code-changes]
-    if: ${{ always() && (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'merge_group') && (needs.detect-code-changes.result == 'skipped' || needs.detect-code-changes.outputs.should-run == 'true') }}
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder')) || github.event_name == 'merge_group') && (needs.detect-code-changes.result == 'skipped' || needs.detect-code-changes.outputs.should-run == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -519,7 +525,7 @@ jobs:
   build_samples:
     name: 🛠️ Build Sample Apps
     needs: [detect-code-changes]
-    if: ${{ always() && (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'merge_group') && (needs.detect-code-changes.result == 'skipped' || needs.detect-code-changes.outputs.should-run == 'true') }}
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder')) || github.event_name == 'merge_group') && (needs.detect-code-changes.result == 'skipped' || needs.detect-code-changes.outputs.should-run == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -660,7 +666,7 @@ jobs:
   test-integration-status:
     name: ✅ Integration Tests Status
     needs: [test-integration]
-    if: always()
+    if: ${{ always() && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -1061,7 +1067,7 @@ jobs:
 
   detect-powershell-changes:
     name: 🔍 Detect PowerShell Changes
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder')) || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
@@ -1086,7 +1092,7 @@ jobs:
 
   detect-docs-changes:
     name: 🔍 Detect Documentation Changes
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder')) || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -1139,7 +1145,7 @@ jobs:
     name: 🗑️ Cleanup Stale Turbo Cache
     runs-on: ubuntu-latest
     # Skip on fork PRs — GITHUB_TOKEN is always read-only there regardless of permissions declared here.
-    if: always() && github.event.pull_request.head.repo.full_name == github.repository
+    if: always() && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder')
     needs:
       - build
       - test-frontend-packages


### PR DESCRIPTION
### Purpose

> **Note**: This is a temporary workaround for the current CI runner saturation, to be reverted once queue pressure is resolved (tracked in #4268).

Every push to a PR currently runs the full PR Builder (~15 jobs), but during early review iteration devs are mostly addressing CodeRabbit/Copilot comments, so those runs are wasted and they saturate the shared runner pool for everyone. This gates the PR Builder on a `trigger-pr-builder` label: devs iterate freely without consuming runners, then add the label when the PR is ready, which runs CI for that push and every subsequent one.

Part of the queue-pressure work in #4268.

### Approach

Built directly on `main` as a single commit, independent of #4269. `labeled` is added to the `pull_request` trigger types, and each root job's condition requires the `trigger-pr-builder` label on `pull_request` events. `merge_group` and `workflow_dispatch` behavior is unchanged, so the merge queue still fully validates every PR regardless of labels. Downstream jobs cascade off their `needs` and skip automatically on unlabeled runs; the two `always()` jobs and the detect-* jobs get the same label check so unlabeled pushes consume zero runners. (The build/test jobs are gated directly rather than relying on `detect-code-changes` skipping, because their existing condition treats a skipped detect job as a green light.)

The label is sticky: once added, later pushes run CI normally. Unlabeled runs report their jobs as skipped, and the `codecov/patch` status stays at "Expected" until CI actually runs, so an unlabeled PR cannot enter the merge queue with skipped checks.

Known limitation, deferred on purpose: adding any label to an already-labeled PR re-triggers the workflow, which restarts CI (and cancels an in-flight run via the concurrency group). Refinements for that (no-op concurrency group for unrelated label events) were prototyped and can be added later if it becomes annoying in practice.

The `trigger-pr-builder` label has been created in the repo.


### Related Issues
- Refs #4268

### Related PRs
- #4269 touches the same file for other CI speedups; whichever merges second needs a trivial rebase.

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pull request validation workflows now run only when the `trigger-pr-builder` label is present.
  * Adding or updating the label can initiate the relevant checks.
  * Builds, tests, security scans, linting, documentation validation, and Windows validation now follow the same label-based conditions.
  * Merge queue and manually triggered workflows continue to follow their existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->