### PR TITLE
Serve organization unit and user type reads on all planes

### DIFF
--- a/backend/internal/system/security/permissions.go
+++ b/backend/internal/system/security/permissions.go
@@ -139,6 +139,19 @@ var managementRoutePlanes = []planeRoute{
 	{"/export/**", PlaneControl},
 }
 
+// planeSharedRoutes are management routes served on every plane regardless of mode, matched as
+// "METHOD /path" (same glob syntax as apiPermissionEntries). The Data Plane authors no organization
+// units or user types, but it must read them to create and place users, so their reads are shared
+// while their writes stay owned by the Control Plane via managementRoutePlanes. Checked before the
+// path-based classification, so a shared read is never plane-gated even though the same path is
+// otherwise a Control Plane route.
+var planeSharedRoutes = []string{
+	"GET /organization-units",
+	"GET /organization-units/**",
+	"GET /user-types",
+	"GET /user-types/**",
+}
+
 // ---- Resource types ----
 
 // ResourceType defines the category of system resource being acted upon.

--- a/backend/internal/system/security/service.go
+++ b/backend/internal/system/security/service.go
@@ -55,6 +55,8 @@ type securityService struct {
 	mode Plane
 	// compiledPlaneRoutes is the pre-compiled per-plane classification of the management surface.
 	compiledPlaneRoutes []compiledPlaneRoute
+	// compiledPlaneSharedRoutes are management routes served on every plane (matched as "METHOD /path").
+	compiledPlaneSharedRoutes []*regexp.Regexp
 }
 
 // newSecurityService creates a new instance of the security service.
@@ -85,16 +87,22 @@ func newSecurityService(authenticators []AuthenticatorInterface, revocationEnfor
 		return nil, err
 	}
 
+	compiledShared, err := compilePathPatterns(planeSharedRoutes)
+	if err != nil {
+		return nil, err
+	}
+
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 
 	return &securityService{
-		authenticators:         authenticators,
-		revocationEnforcer:     revocationEnforcer,
-		logger:                 logger,
-		compiledPaths:          compiledPaths,
-		compiledAPIPermissions: compiledPerms,
-		mode:                   PlaneHybrid,
-		compiledPlaneRoutes:    compiledPlanes,
+		authenticators:            authenticators,
+		revocationEnforcer:        revocationEnforcer,
+		logger:                    logger,
+		compiledPaths:             compiledPaths,
+		compiledAPIPermissions:    compiledPerms,
+		mode:                      PlaneHybrid,
+		compiledPlaneRoutes:       compiledPlanes,
+		compiledPlaneSharedRoutes: compiledShared,
 	}, nil
 }
 
@@ -111,7 +119,7 @@ func (s *securityService) Process(r *http.Request) (context.Context, error) {
 	// On a single-plane instance (cp or dp), a management route owned by the other plane is not
 	// served here and is reported as 404. Public runtime routes are never plane-gated.
 	if s.mode != PlaneHybrid && !isPublic {
-		if plane, ok := s.classifyPlane(r.URL.Path); ok && plane != s.mode {
+		if plane, ok := s.classifyPlane(r.Method, r.URL.Path); ok && plane != s.mode {
 			return r.Context(), errManagementDisabled
 		}
 	}
@@ -192,9 +200,17 @@ func (s *securityService) getRequiredPermissionForAPI(method, path string) strin
 	return GetSystemRootPermission()
 }
 
-// classifyPlane returns the plane that owns the given request path, or false when the path is not a
-// classified management route. Public/runtime paths and any unlisted path are never plane-gated.
-func (s *securityService) classifyPlane(requestPath string) (Plane, bool) {
+// classifyPlane returns the plane that owns the given request, or false when it is not a
+// plane-gated management route. Shared routes (matched as "METHOD /path") are served on every plane
+// and return false so they are never gated; otherwise classification is by path. Public/runtime
+// paths and any unlisted path are never plane-gated.
+func (s *securityService) classifyPlane(method, requestPath string) (Plane, bool) {
+	key := method + " " + requestPath
+	for _, re := range s.compiledPlaneSharedRoutes {
+		if re.MatchString(key) {
+			return "", false
+		}
+	}
 	for _, r := range s.compiledPlaneRoutes {
 		if r.re.MatchString(requestPath) {
 			return r.plane, true

--- a/backend/internal/system/security/service_test.go
+++ b/backend/internal/system/security/service_test.go
@@ -598,3 +598,54 @@ func (suite *SecurityServiceTestSuite) TestProcess_AuthorizationFailure_Insuffic
 	assert.Nil(suite.T(), ctx)
 	assert.ErrorIs(suite.T(), err, errInsufficientPermissions)
 }
+
+// TestClassifyPlane verifies per-plane classification of the management surface, including the
+// shared reads (organization units and user types) that must be served on every plane so the Data
+// Plane can create and place users while their writes stay owned by the Control Plane.
+func TestClassifyPlane(t *testing.T) {
+	service, err := newSecurityService(nil, nil, testPublicPaths, apiPermissionEntries)
+	if err != nil {
+		t.Fatalf("newSecurityService: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		method    string
+		path      string
+		wantPlane Plane
+		wantGated bool
+	}{
+		// Shared reads: not plane-gated (served on cp and dp).
+		{"read OU list is shared", http.MethodGet, "/organization-units", "", false},
+		{"read OU tree is shared", http.MethodGet, "/organization-units/tree", "", false},
+		{"read OU by id is shared", http.MethodGet, "/organization-units/019000", "", false},
+		{"read user types is shared", http.MethodGet, "/user-types", "", false},
+		{"read user type by id is shared", http.MethodGet, "/user-types/Person", "", false},
+
+		// Writes to the same resources stay on the Control Plane.
+		{"create OU is cp", http.MethodPost, "/organization-units", PlaneControl, true},
+		{"update OU is cp", http.MethodPut, "/organization-units/019000", PlaneControl, true},
+		{"delete OU is cp", http.MethodDelete, "/organization-units/019000", PlaneControl, true},
+		{"create user type is cp", http.MethodPost, "/user-types", PlaneControl, true},
+
+		// Data-plane routes.
+		{"list users is dp", http.MethodGet, "/users", PlaneData, true},
+		{"create user is dp", http.MethodPost, "/users", PlaneData, true},
+		{"role assignment is dp", http.MethodPut, "/roles/019000/assignments/users", PlaneData, true},
+
+		// Other control-plane routes are unaffected.
+		{"read applications is cp", http.MethodGet, "/applications", PlaneControl, true},
+		{"read flows is cp", http.MethodGet, "/flows", PlaneControl, true},
+
+		// Unlisted / runtime paths are never plane-gated.
+		{"health is not gated", http.MethodGet, "/health/liveness", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plane, gated := service.classifyPlane(tt.method, tt.path)
+			assert.Equal(t, tt.wantGated, gated, "gated")
+			assert.Equal(t, tt.wantPlane, plane, "plane")
+		})
+	}
+}


### PR DESCRIPTION
### Purpose

On a Data Plane instance, creating a user requires reading the organization units and user types the user will be placed in. Those resources are authored on the Control Plane, so their routes were classified as Control Plane only and returned 404 on the Data Plane, which blocked user creation from the Data Plane console.

This change serves the read (GET) operations for organization units and user types on every plane, while keeping their write operations (create/update/delete) owned by the Control Plane.

### Approach

Per-plane gating classified whole management paths to a single plane. Reads and writes of the same resource could not be split.

- Added `planeSharedRoutes`: management routes served on every plane, matched as `METHOD /path` (the same glob syntax already used by the API permission entries). It lists the organization unit and user type reads (`GET /organization-units`, `GET /organization-units/**`, `GET /user-types`, `GET /user-types/**`).
- `classifyPlane` now takes the request method and checks the shared routes first. A shared read returns "not gated", so it is served regardless of the instance mode. Everything else falls through to the existing path based classification, so the writes for those resources stay on the Control Plane.

Verified on a Data Plane instance:

| Route | Result | Meaning |
|---|---|---|
| `GET /organization-units`, `/organization-units/tree`, `/user-types` | 401 | served (needs auth) |
| `POST /organization-units`, `/user-types` | 404 | write still Control Plane only |
| `GET /applications` | 404 | unaffected Control Plane route |
| `GET /users` | 401 | Data Plane route |

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests

### Security checks
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
