### PR TITLE
Add MCP quickstart for securing a Python MCP server

### DIFF
--- a/docs/content/getting-started/connect-your-mcp/_category_.json
+++ b/docs/content/getting-started/connect-your-mcp/_category_.json
@@ -1,0 +1,5 @@
+{
+  "position": 2,
+  "label": "MCP",
+  "collapsible": false
+}

--- a/docs/content/getting-started/connect-your-mcp/python.mdx
+++ b/docs/content/getting-started/connect-your-mcp/python.mdx
@@ -1,0 +1,325 @@
+---
+toc_progress: quickstart
+title: Secure Your MCP Server
+docType: quickstart
+sidebar_position: 1
+persona: app
+description: Protect a Python MCP server with {{ProductName}} OAuth scopes and validate tokens offline via JWKS.
+---
+
+import {
+  ShieldCheck,
+  KeyRound,
+  ListChecks,
+  Clock,
+  Terminal,
+  Server,
+  FileCode,
+} from '@wso2/oxygen-ui-icons-react';
+
+# Secure Your MCP Server
+
+Use this guide to build a Python MCP server whose tools are each protected by a <ProductName /> OAuth scope, using FastMCP, then verify the setup end to end with MCP Inspector.
+
+<TutorialHero>
+
+## What You Will Learn
+
+<TutorialHeroItem icon={<ShieldCheck />}>Turn an MCP server into an OAuth 2.0 resource server that answers unauthenticated calls with a <code>401</code> and RFC 9728 protected-resource metadata</TutorialHeroItem>
+<TutorialHeroItem icon={<KeyRound />}>Validate <ProductName /> JWTs offline (signature, issuer, audience, and expiry) against the JWKS endpoint</TutorialHeroItem>
+<TutorialHeroItem icon={<ListChecks />}>Protect each tool with its own scope, so a token missing a scope cannot see or call that tool</TutorialHeroItem>
+
+## Prerequisites
+
+<TutorialHeroItem icon={<Clock />}>About 10 minutes</TutorialHeroItem>
+<TutorialHeroItem icon={<Terminal />}><code>uv</code>, which manages Python and dependencies automatically</TutorialHeroItem>
+<TutorialHeroItem icon={<Server />}>Node.js 20+ (for MCP Inspector)</TutorialHeroItem>
+<TutorialHeroItem icon={<FileCode />}>Your preferred code editor</TutorialHeroItem>
+
+</TutorialHero>
+
+## How It Works
+
+Your MCP server becomes an OAuth 2.0 resource server. When a client connects without a token, the server responds with a `401` and RFC 9728 metadata that points the client to <ProductName /> for authentication. The client runs an Authorization Code + PKCE flow, gets a JWT scoped to the user's role-based permissions, and presents it on reconnect. The server validates the token offline against <ProductName />'s JWKS and filters visible tools by the token's scopes.
+
+<McpOAuthFlowDiagram />
+
+<Stepper stepNode="h2" as="h2">
+
+## Run <ProductName />
+
+Start a local <ProductName /> instance. Pick the method that works best for you:
+
+<RunThunderID />
+
+Once it's running, the console is available at [https://localhost:8090/console](https://localhost:8090/console).
+
+## Register the MCP Resource and Scopes
+
+1. Sign in to the Console.
+
+    :::info Test User
+    If you used the default setup, sign in to the Console as `admin` with the password generated during setup and printed to the setup output (unless you supplied your own).
+    :::
+
+2. Navigate to **Resource Servers** and click **Add resource server**.
+3. On the **Type** step, select **MCP**.
+4. On the **Name** step, enter:
+   - **MCP Server Name**: `Calculator MCP`
+   - **Identifier**: `http://localhost:8000/mcp`
+5. On the **Permission Delimiter** step, keep the default colon (`:`) and click **Create MCP server**. If your deployment has multiple organization units, click **Continue** instead, select one, then click **Create MCP server**.
+
+Now add each of the four calculator tools as a tool permission:
+
+6. On the **Capabilities** tab, the server has no capabilities yet. Click **Add tool permission**.
+7. Repeat for the remaining three tools: click the **+** icon in the panel header, then select **Add tool permission** from the menu.
+8. For each tool, enter the **Name**. <ProductName /> generates the **Handle** automatically from the name (lowercased), so confirm it matches the table below before clicking **Add**: the handle becomes the exact scope `require_scopes(...)` checks for in `server.py`.
+
+   | Name | Handle | Generated permission |
+   | --- | --- | --- |
+   | Add | `add` | `add` |
+   | Subtract | `subtract` | `subtract` |
+   | Multiply | `multiply` | `multiply` |
+   | Divide | `divide` | `divide` |
+
+## Create a Role for the Calculator Permissions
+
+Registering the permissions in the previous step only defines them. <ProductName /> puts a scope into an access token only when the signing-in user actually holds the matching permission through a role, and scopes the user doesn't hold are silently dropped from the token. A token missing a tool's scope means that tool never appears in the tool list, so before you connect Inspector, create a role that grants the four calculator permissions and assign it to the user you'll sign in with.
+
+1. Navigate to **Roles** and click **Add Role**.
+2. On the **Create a Role** step, enter a name (for example, `Calculator`) and click **Continue**. If prompted, select an organization unit and click **Continue** again.
+3. On the **Permissions** step, expand **Calculator MCP** and check **add**, **subtract**, **multiply**, and **divide** under **Tools**.
+4. Click **Continue** to create the role.
+5. Open the role from the **Roles** list, select the **Assignments** tab, and click **Add**.
+6. In the **Add Assignment** dialog, on the **Users** tab, select `admin` and click **Add Selected**.
+
+## Create the Server
+
+The whole server lives in a single file. Create `server.py`.
+
+FastMCP's `RemoteAuthProvider` turns the server into an OAuth 2.0 resource server: it publishes RFC 9728 protected-resource metadata and rejects requests without a valid token before any tool runs. The `JWTVerifier` validates each token offline, with no call back to <ProductName /> per request, by checking the signature against the JWKS endpoint, the issuer, the audience, and the expiry:
+
+```python title="server.py" {25-30,32-40} showLineNumbers
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["fastmcp>=3.4,<4", "python-dotenv>=1"]
+# ///
+"""Scope-protected calculator MCP server."""
+
+import os
+
+import httpx
+from dotenv import load_dotenv
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+from fastmcp.server.auth import RemoteAuthProvider, require_scopes
+from fastmcp.server.auth.providers.jwt import JWTVerifier
+
+load_dotenv(override=True)
+
+ISSUER = os.environ["THUNDERID_ISSUER"]
+JWKS_URI = os.environ["THUNDERID_JWKS_URI"]
+AUDIENCE = os.environ["MCP_AUDIENCE"]
+CA_CERT = os.environ.get("THUNDERID_CA_CERT")
+
+SCOPES = ["add", "subtract", "multiply", "divide"]
+
+verifier = JWTVerifier(
+    jwks_uri=JWKS_URI,
+    issuer=ISSUER,
+    audience=AUDIENCE,
+    http_client=httpx.AsyncClient(verify=CA_CERT) if CA_CERT else None,
+)
+
+mcp = FastMCP(
+    "Calculator",
+    auth=RemoteAuthProvider(
+        token_verifier=verifier,
+        authorization_servers=[ISSUER],
+        base_url="http://localhost:8000",
+        scopes_supported=SCOPES,
+    ),
+)
+```
+
+:::note No install step
+The `# /// script` header at the top of the file is inline script metadata (PEP 723). `uv run server.py` reads it and resolves `fastmcp` and `python-dotenv` automatically, in an isolated environment, so there's no separate `pip install` step.
+:::
+
+Append the four tools below the auth setup, still in the same `server.py` file. Each tool declares the single scope it needs with `require_scopes(...)`. A token that doesn't carry that scope can't see the tool in `tools/list` and can't call it:
+
+```python title="server.py" {1,7,13,19}
+@mcp.tool(auth=require_scopes("add"))
+def add(a: float, b: float) -> float:
+    """Add two numbers."""
+    return a + b
+
+
+@mcp.tool(auth=require_scopes("subtract"))
+def subtract(a: float, b: float) -> float:
+    """Subtract b from a."""
+    return a - b
+
+
+@mcp.tool(auth=require_scopes("multiply"))
+def multiply(a: float, b: float) -> float:
+    """Multiply two numbers."""
+    return a * b
+
+
+@mcp.tool(auth=require_scopes("divide"))
+def divide(a: float, b: float) -> float:
+    """Divide a by b."""
+    if b == 0:
+        raise ToolError("Cannot divide by zero.")
+    return a / b
+
+
+if __name__ == "__main__":
+    mcp.run(transport="http", host="localhost", port=8000)
+```
+
+## Configure the Environment
+
+A local <ProductName /> instance uses a self-signed certificate, so the server needs that certificate exported to verify the JWKS endpoint over HTTPS. With <ProductName /> running, run this from the same directory as `server.py`:
+
+```bash
+openssl s_client -connect localhost:8090 -showcerts </dev/null 2>/dev/null | openssl x509 > thunderid.cert
+```
+
+Create a `.env` file next to `server.py`:
+
+```bash title=".env"
+THUNDERID_ISSUER=https://localhost:8090
+THUNDERID_JWKS_URI=https://localhost:8090/oauth2/jwks
+MCP_AUDIENCE=http://localhost:8000/mcp
+THUNDERID_CA_CERT=./thunderid.cert
+```
+
+| Variable | Description |
+| --- | --- |
+| `THUNDERID_ISSUER` | Must exactly match the `iss` claim <ProductName /> puts in every access token. |
+| `THUNDERID_JWKS_URI` | Where the server fetches <ProductName />'s public signing keys to verify token signatures. |
+| `MCP_AUDIENCE` | The resource server identifier you registered in the previous step. `JWTVerifier` rejects tokens whose `aud` claim doesn't match. |
+| `THUNDERID_CA_CERT` | Path to the certificate you just exported. Must point to the actual file location; a relative path like `./thunderid.cert` is resolved from the directory you start the server in. |
+
+Both the issuer and the JWKS URI are discoverable from [https://localhost:8090/.well-known/openid-configuration](https://localhost:8090/.well-known/openid-configuration) if you're pointing at a non-default host or port.
+
+:::note Certificate not found at startup
+If the server fails at startup with a `FileNotFoundError`, `THUNDERID_CA_CERT` doesn't point to the exported file. Check the path, or re-export the certificate. The export only writes a local file, nothing is added to your system trust store, and it regenerates whenever <ProductName /> is reinstalled or rebuilt, so re-export after a rebuild.
+:::
+
+## Run and Verify Protection
+
+Start the server:
+
+```bash
+uv run server.py
+```
+
+It serves the MCP endpoint at `http://localhost:8000/mcp`.
+
+With no token, the server rejects the request:
+
+```bash
+curl -si -X POST http://localhost:8000/mcp
+```
+
+```text
+HTTP/1.1 401 Unauthorized
+www-authenticate: Bearer resource_metadata="http://localhost:8000/.well-known/oauth-protected-resource/mcp"
+```
+
+Fetch that metadata directly:
+
+```bash
+curl -s http://localhost:8000/.well-known/oauth-protected-resource/mcp
+```
+
+The response names <ProductName /> as the authorization server and lists the four scopes:
+
+```json
+{
+  "resource": "http://localhost:8000/mcp",
+  "authorization_servers": ["https://localhost:8090/"],
+  "scopes_supported": ["add", "subtract", "multiply", "divide"],
+  "bearer_methods_supported": ["header"]
+}
+```
+
+## Connect with MCP Inspector
+
+### Register an MCP Client for Inspector
+
+<ProductName /> has a dedicated application type for MCP clients like Inspector. In the Console:
+
+1. Go to **Applications** and click **Add Application**.
+2. Select **MCP Client**.
+3. Enter a name (for example, `Calculator Inspector`).
+4. If prompted, select an organization unit.
+5. On the **Client type** step, select **On behalf of a user**. This configures the Authorization Code flow with PKCE as a public client.
+6. Under **Redirect URIs**, add `http://localhost:6274/oauth/callback`.
+7. Click **Finish**.
+8. From the completion screen, copy the **Client ID**. No client secret is required because this is a public client.
+
+### Allow the MCP Inspector Origin
+
+MCP Inspector runs in the browser at `http://localhost:6274` and calls <ProductName /> cross-origin, so its origin must be allowed in the CORS configuration.
+
+Create or update `config/resources/server_configs/cors.yaml` in your <ProductName /> distribution, or use `PUT /server-config/cors` after startup:
+
+```yaml
+name: cors
+value:
+  allowedOrigins:
+    - "http://localhost:6274"
+```
+
+If the file already exists, append the origin to the existing `allowedOrigins` list instead of replacing it. Restart <ProductName /> after editing the file.
+
+### Launch and Connect
+
+Inspector's proxy runs on Node.js and must also trust the self-signed <ProductName /> certificate to discover the OAuth endpoints, so reuse the certificate you exported earlier. Run this from the same directory as `server.py`:
+
+```bash
+NODE_EXTRA_CA_CERTS=./thunderid.cert npx @modelcontextprotocol/inspector
+```
+
+Inspector opens in your browser at `http://localhost:6274`.
+
+1. Set **Transport Type** to **Streamable HTTP** and **URL** to `http://localhost:8000/mcp`.
+2. Expand the **Authentication** section and select **OAuth**.
+3. Enter the **Client ID** you copied earlier. Leave **Client Secret** empty.
+4. Click **Connect**. Inspector reads your server's protected-resource metadata, discovers <ProductName /> as the authorization server, and requests all four scopes by default.
+5. A browser tab opens with <ProductName />'s sign-in page. Sign in with your test user and approve the request.
+6. You're redirected back to Inspector, now connected.
+7. Open the **Tools** tab and click **List Tools**. You see `add`, `subtract`, `multiply`, and `divide`.
+
+:::note Sign-in page never appears
+If the browser shows "Cannot GET /authorize" instead of the sign-in page, first confirm **Transport Type** is set to **Streamable HTTP**, since the deprecated SSE transport probes without a token and misroutes the authorize request to Inspector's own proxy. If Transport Type is already correct, Inspector was launched without `NODE_EXTRA_CA_CERTS` or the path is wrong, so it couldn't fetch <ProductName />'s OAuth discovery metadata. Relaunch with the variable pointing at the exported certificate.
+:::
+
+:::tip Success
+The tools you see in Inspector are exactly the ones your token's scopes allow. Try it: click **Disconnect**, edit the **Scope** field in the Auth panel to remove `divide`, then **Connect** again. Sign in once more and list the tools. `divide` is gone, because the token Inspector obtained this time never carries that scope, and `require_scopes("divide")` hides the tool from anyone without it.
+:::
+
+</Stepper>
+
+## What's Next
+
+<div style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: '1rem', marginTop: '1.5rem'}}>
+  <a href="../../../use-cases/ai-agents/mcp-authorization/overview" style={{textDecoration: 'none', color: 'inherit'}}>
+    <div style={{border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '10px', padding: '1.25rem', cursor: 'pointer'}}>
+      <div style={{fontSize: '1rem', fontWeight: '700', marginBottom: '0.4rem'}}>Securing MCP</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-emphasis-700)', marginBottom: '0.75rem'}}>Authorization patterns for MCP servers, audience binding, and AuthZEN policy decisions.</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-primary)', fontWeight: 600}}>MCP Authorization →</div>
+    </div>
+  </a>
+  <a href="../../../working-with-ai/mcp-server" style={{textDecoration: 'none', color: 'inherit'}}>
+    <div style={{border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '10px', padding: '1.25rem', cursor: 'pointer'}}>
+      <div style={{fontSize: '1rem', fontWeight: '700', marginBottom: '0.4rem'}}><ProductName /> MCP Server</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-emphasis-700)', marginBottom: '0.75rem'}}>Manage <ProductName /> itself, applications, flows, and users, from AI tools.</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-primary)', fontWeight: 600}}>MCP Server Guide →</div>
+    </div>
+  </a>
+</div>

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -101,10 +101,12 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'category',
-          label: 'MCP Server',
+          label: 'MCP',
           className: 'connect-section connect-section--mcp',
           collapsible: true,
-          items: [{type: 'html', value: '<span aria-hidden="true"></span>'}],
+          items: [
+            {type: 'doc', id: 'getting-started/connect-your-mcp/python', label: 'Python', customProps: {icon: 'python'}},
+          ],
         },
       ],
     },

--- a/docs/src/components/DeveloperShortcut.tsx
+++ b/docs/src/components/DeveloperShortcut.tsx
@@ -30,6 +30,7 @@ import LangChainLogo from './icons/LangChainLogo';
 import NextLogo from './icons/NextLogo';
 import NodeLogo from './icons/NodeLogo';
 import NuxtLogo from './icons/NuxtLogo';
+import PythonLogo from './icons/PythonLogo';
 import ReactLogo from './icons/ReactLogo';
 import VueLogo from './icons/VueLogo';
 import {applyConnectType, useConnectType} from '../utils/connectType';
@@ -53,10 +54,14 @@ const AGENT_QUICKSTARTS = [
   {Logo: LangChainLogo, href: '/docs/next/getting-started/connect-your-agent/langchain', label: 'LangChain'},
 ];
 
+const MCP_QUICKSTARTS = [
+  {Logo: PythonLogo, href: '/docs/next/getting-started/connect-your-mcp/python', label: 'Python'},
+];
+
 const CATEGORIES: {id: ConnectType; icon: React.ReactElement; label: string; description: string; comingSoon: boolean}[] = [
   {id: 'app',   icon: <MonitorSmartphone size={20} />, label: 'Application', description: 'Web, mobile and desktop apps.', comingSoon: false},
   {id: 'agent', icon: <Bot size={20} />,               label: 'AI Agent',    description: 'LLM-powered agents.',            comingSoon: false},
-  {id: 'mcp',   icon: <Server size={20} />,            label: 'MCP Server',  description: 'Model Context Protocol servers.', comingSoon: true},
+  {id: 'mcp',   icon: <Server size={20} />,            label: 'MCP',         description: 'Model Context Protocol servers and clients.', comingSoon: false},
 ];
 
 function selectCategory(type: ConnectType): void {
@@ -161,11 +166,15 @@ export default function DeveloperShortcut({
       ? ALL_FRAMEWORKS.filter(f => ['React', 'Next.js', 'Express', 'Vue'].includes(f.label))
       : selected === 'agent'
         ? AGENT_QUICKSTARTS
-        : null;
+        : selected === 'mcp'
+          ? MCP_QUICKSTARTS
+          : null;
   const quickstartFooter =
     selected === 'app'
       ? 'All application quickstarts are available in the sidebar.'
-      : 'More agent frameworks are coming soon.';
+      : selected === 'agent'
+        ? 'More agent frameworks are coming soon.'
+        : 'All MCP quickstarts are available in the sidebar.';
 
   return (
     <Box

--- a/docs/src/components/McpQuickstartFlow.tsx
+++ b/docs/src/components/McpQuickstartFlow.tsx
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import type {DocusaurusProductConfig} from '@site/docusaurus.product.config';
+import './WayfinderDiagrams.css';
+
+function PersonIcon({className = undefined}: {className?: string}) {
+  return (
+    <g className={className}>
+      <circle cx="28" cy="28" r="26" />
+      <g transform="translate(28,28)" className="uc-agent-wayfinder-person-glyph">
+        <circle cx="0" cy="-6" r="7" />
+        <path d="M -13 14 C -13 4 13 4 13 14 Z" />
+      </g>
+    </g>
+  );
+}
+
+export function McpOAuthFlowDiagram() {
+  const {siteConfig} = useDocusaurusContext();
+  const productName =
+    (siteConfig.customFields?.product as DocusaurusProductConfig | undefined)?.project.name ?? siteConfig.title;
+
+  return (
+    <div className="uc-agent-wayfinder-arch uc-mcp-qs-arch">
+      <svg
+        className="uc-agent-wayfinder-arch__svg"
+        viewBox="0 0 820 330"
+        xmlns="http://www.w3.org/2000/svg"
+        role="img"
+        aria-label={`MCP OAuth flow: an MCP client discovers ${productName} as the authorization server through RFC 9728 metadata, obtains a scoped JWT via Authorization Code with PKCE, then calls MCP tools with the token. The MCP server validates the JWT offline against ${productName}'s JWKS endpoint.`}
+      >
+        <defs>
+          <marker
+            id="mcp-qs-arrow"
+            viewBox="0 0 10 10"
+            refX="9"
+            refY="5"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto-start-reverse"
+          >
+            <path d="M0,0 L10,5 L0,10 z" fill="currentColor" />
+          </marker>
+        </defs>
+
+        {/* User at top */}
+        <g className="uc-agent-wayfinder-arch__consumers">
+          <text x="170" y="12" textAnchor="middle" className="uc-agent-wayfinder-arch__group-label">
+            User
+          </text>
+          <g transform="translate(156,20)">
+            <g transform="scale(0.5)">
+              <PersonIcon className="uc-agent-wayfinder-arch__icon" />
+            </g>
+          </g>
+        </g>
+
+        {/* User → MCP Client */}
+        <g className="uc-agent-wayfinder-arch__edges">
+          <line x1="170" y1="52" x2="170" y2="76" markerEnd="url(#mcp-qs-arrow)" />
+        </g>
+
+        {/* MCP Client */}
+        <g className="uc-agent-wayfinder-arch__app" transform="translate(20,76)">
+          <rect width="300" height="88" rx="10" />
+          <text x="150" y="30" textAnchor="middle" className="uc-agent-wayfinder-arch__app-title">
+            MCP Client
+          </text>
+          <text x="150" y="50" textAnchor="middle" className="uc-agent-wayfinder-arch__sub">
+            e.g., Claude Desktop, MCP Inspector
+          </text>
+          <line x1="24" y1="62" x2="276" y2="62" className="uc-agent-wayfinder-arch__divider" />
+          <text x="150" y="79" textAnchor="middle" className="uc-agent-wayfinder-arch__detail">
+            Discovers auth, signs in, calls tools
+          </text>
+        </g>
+
+        {/* ThunderID — tall box on the right */}
+        <g className="uc-agent-wayfinder-arch__idp" transform="translate(560,76)">
+          <rect width="220" height="240" rx="10" />
+          <text x="110" y="42" textAnchor="middle" className="uc-agent-wayfinder-arch__idp-title">
+            {productName}
+          </text>
+          <text x="110" y="64" textAnchor="middle" className="uc-agent-wayfinder-arch__sub">
+            Authorization Server
+          </text>
+          <line x1="26" y1="78" x2="194" y2="78" className="uc-agent-wayfinder-arch__divider" />
+          <text x="110" y="104" textAnchor="middle" className="uc-agent-wayfinder-arch__detail">
+            Signs users in and
+          </text>
+          <text x="110" y="122" textAnchor="middle" className="uc-agent-wayfinder-arch__detail">
+            issues scoped JWTs
+          </text>
+        </g>
+
+        {/* Your MCP Server — bottom left */}
+        <g className="uc-agent-wayfinder-arch__svc" transform="translate(20,228)">
+          <rect width="300" height="88" rx="10" />
+          <text x="150" y="30" textAnchor="middle" className="uc-agent-wayfinder-arch__app-title">
+            Your MCP Server
+          </text>
+          <text x="150" y="50" textAnchor="middle" className="uc-agent-wayfinder-arch__sub">
+            OAuth 2.0 Resource Server
+          </text>
+          <line x1="24" y1="62" x2="276" y2="62" className="uc-agent-wayfinder-arch__divider" />
+          <text x="150" y="79" textAnchor="middle" className="uc-agent-wayfinder-arch__detail">
+            Publishes RFC 9728 metadata, validates JWTs
+          </text>
+        </g>
+
+        {/* Edges */}
+        <g className="uc-agent-wayfinder-arch__edges">
+          {/* MCP Client → ThunderID: Sign in */}
+          <line x1="320" y1="110" x2="560" y2="110" markerEnd="url(#mcp-qs-arrow)" />
+          <text x="440" y="102" textAnchor="middle" className="uc-agent-wayfinder-arch__edge-label">
+            Sign in (Auth Code + PKCE)
+          </text>
+
+          {/* ThunderID → MCP Client: Token */}
+          <line x1="560" y1="136" x2="320" y2="136" markerEnd="url(#mcp-qs-arrow)" />
+          <text x="440" y="152" textAnchor="middle" className="uc-agent-wayfinder-arch__edge-label">
+            Scoped access token (JWT)
+          </text>
+
+          {/* MCP Client → Your MCP Server: Call tools */}
+          <line x1="170" y1="164" x2="170" y2="228" markerEnd="url(#mcp-qs-arrow)" />
+          <text x="184" y="200" className="uc-agent-wayfinder-arch__edge-label">
+            Call tools with token
+          </text>
+
+          {/* Your MCP Server → ThunderID: Validate */}
+          <line x1="320" y1="272" x2="560" y2="272" markerEnd="url(#mcp-qs-arrow)" />
+          <text x="440" y="264" textAnchor="middle" className="uc-agent-wayfinder-arch__edge-label">
+            Validate JWT via JWKS
+          </text>
+        </g>
+      </svg>
+    </div>
+  );
+}

--- a/docs/src/components/WayfinderDiagrams.css
+++ b/docs/src/components/WayfinderDiagrams.css
@@ -646,3 +646,8 @@
   stroke-linejoin: round;
 }
 
+/* MCP quickstart architecture — narrower than the use-case diagrams */
+.uc-mcp-qs-arch .uc-agent-wayfinder-arch__svg {
+  max-width: 780px;
+}
+

--- a/docs/src/theme/DocSidebarItem/Category/index.tsx
+++ b/docs/src/theme/DocSidebarItem/Category/index.tsx
@@ -27,15 +27,14 @@ import {ConnectType, applyConnectType, useConnectType} from '@site/src/utils/con
 
 type OriginalProps = Props;
 
-// The "What are you building?" options (Application / AI Agent / MCP Server)
+// The "What are you building?" options (Application / AI Agent / MCP)
 // render as always-visible cards. Only the one matching the shared connect-type
 // is expanded; clicking a card sets the connect-type, which collapses the
-// others and stays in sync with the docs-home selector. MCP Server is a
-// disabled card while its quickstarts are still coming.
+// others and stays in sync with the docs-home selector.
 const SECTIONS: Record<ConnectType, {Icon: typeof Bot; comingSoon: boolean}> = {
   app: {Icon: MonitorSmartphone, comingSoon: false},
   agent: {Icon: Bot, comingSoon: false},
-  mcp: {Icon: Server, comingSoon: true},
+  mcp: {Icon: Server, comingSoon: false},
 };
 
 function connectTypeFromClassName(className: string | undefined): ConnectType | undefined {

--- a/docs/src/theme/DocSidebarItem/Link/index.tsx
+++ b/docs/src/theme/DocSidebarItem/Link/index.tsx
@@ -29,6 +29,7 @@ import LangChainLogo from '@site/src/components/icons/LangChainLogo';
 import NextLogo from '@site/src/components/icons/NextLogo';
 import NodeLogo from '@site/src/components/icons/NodeLogo';
 import NuxtLogo from '@site/src/components/icons/NuxtLogo';
+import PythonLogo from '@site/src/components/icons/PythonLogo';
 import ReactLogo from '@site/src/components/icons/ReactLogo';
 import VueLogo from '@site/src/components/icons/VueLogo';
 
@@ -58,6 +59,7 @@ const TECH_LOGOS: Record<string, React.ReactElement> = {
   next: <NextLogo size={20} />,
   node: <NodeLogo size={20} />,
   nuxt: <NuxtLogo size={20} />,
+  python: <PythonLogo size={20} />,
   react: <ReactLogo size={20} />,
   vue: <VueLogo size={20} />,
   langchain: <LangChainLogo size={20} />,

--- a/docs/src/theme/MDXComponents.tsx
+++ b/docs/src/theme/MDXComponents.tsx
@@ -81,6 +81,7 @@ import {InfographicTimeline, InfographicStep} from '@site/src/components/Infogra
 import IntegrationTypePicker from '@site/src/components/IntegrationTypePicker';
 import {K8sArchDiagram} from '@site/src/components/K8sArchDiagram';
 import {ConsoleUrl, WayFinderSampleUrl, WayFinderMailUrl} from '@site/src/components/LocalUrls';
+import {McpOAuthFlowDiagram} from '@site/src/components/McpQuickstartFlow';
 import {NextSteps, NextStepsCard} from '@site/src/components/NextSteps';
 import ProductName from '@site/src/components/ProductName';
 import RepoLink from '@site/src/components/RepoLink';
@@ -167,6 +168,7 @@ export default {
   AIAgentSolutionPatternsRoadmap,
   AgentOwnTokenFlow,
   AgentOboFlow,
+  McpOAuthFlowDiagram,
   LangTabs,
   Lang,
   AgentModeSelector,


### PR DESCRIPTION
### Purpose

Adds the first quickstart for the MCP path on the docs home page: **Secure Your MCP Server**, a step-by-step guide for protecting a Python (FastMCP) MCP server with ThunderID OAuth, where each tool is guarded by its own scope and tokens are validated offline against the JWKS endpoint.

The "MCP Server" card on the docs landing selector was previously marked coming soon. This PR activates it as **MCP** (covering servers now, clients later) with a Python quickstart chip, and adds a matching **MCP** section to the Get Started sidebar.

### Approach

- New page `docs/content/getting-started/connect-your-mcp/python.mdx`, following the established quickstart template (`TutorialHero`, `Stepper`, `CodeGroup`, What's Next cards) used by the application quickstarts.
- The walkthrough: run ThunderID, register an MCP resource server with four tool permissions, create a role granting them and assign the signing-in user, build a single-file FastMCP server, export the local dev certificate, verify the 401 + RFC 9728 protected-resource metadata with curl, and connect end to end with MCP Inspector (including `NODE_EXTRA_CA_CERTS` for the self-signed certificate and a scope-removal demonstration of per-tool gating).
- Console navigation in the guide was verified against the actual Console implementation (resource-server creation wizard, MCP Capabilities panel, role creation wizard, assignment dialog), and the whole flow was validated end to end against a running instance, including negative paths that were folded into the troubleshooting notes (wrong transport type, missing certificate trust, missing role).
- Selector wiring: `mcp` entry activated in `ConnectTypeSelector` and `DeveloperShortcut` (relabeled to "MCP", description covering servers and clients), Python chip added, and a `python` icon registered in the sidebar icon map using the existing `PythonLogo` component.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4305

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [x] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP as an available connection type in the developer experience.
  * Added a Python quickstart for securing MCP servers with OAuth scopes.
  * Added MCP quickstarts and Python branding to navigation and developer shortcuts.
  * Added guidance for connecting and testing MCP servers with MCP Inspector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->