### PR TITLE
Remove consent audit table schema

### DIFF
--- a/backend/dbscripts/runtime_persistent/postgres.sql
+++ b/backend/dbscripts/runtime_persistent/postgres.sql
@@ -119,20 +119,3 @@ CREATE INDEX idx_consent_authz_user ON "CONSENT_AUTHORIZATION" (DEPLOYMENT_ID, U
 
 -- Index for loading a consent's authorization records.
 CREATE INDEX idx_consent_authz_consent ON "CONSENT_AUTHORIZATION" (CONSENT_ID, DEPLOYMENT_ID);
-
--- Table to store consent audit records.
-CREATE TABLE "CONSENT_AUDIT" (
-    DEPLOYMENT_ID VARCHAR(255) NOT NULL,
-    ID VARCHAR(36) NOT NULL PRIMARY KEY,
-    ACTION VARCHAR(30) NOT NULL,
-    CONSENT_ID VARCHAR(36) NOT NULL,
-    GROUP_ID VARCHAR(36) NOT NULL,
-    SUBJECT_USER_IDS JSONB,
-    ACTOR_ID VARCHAR(36),
-    TRACE_ID VARCHAR(255),
-    DETAILS JSONB,
-    CREATED_AT TIMESTAMPTZ DEFAULT NOW()
-);
-
--- Index for retrieving the audit trail of a consent.
-CREATE INDEX idx_consent_audit_consent ON "CONSENT_AUDIT" (DEPLOYMENT_ID, CONSENT_ID);

--- a/backend/dbscripts/runtime_persistent/sqlite.sql
+++ b/backend/dbscripts/runtime_persistent/sqlite.sql
@@ -119,20 +119,3 @@ CREATE INDEX idx_consent_authz_user ON "CONSENT_AUTHORIZATION" (DEPLOYMENT_ID, U
 
 -- Index for loading a consent's authorization records.
 CREATE INDEX idx_consent_authz_consent ON "CONSENT_AUTHORIZATION" (CONSENT_ID, DEPLOYMENT_ID);
-
--- Table to store consent audit records.
-CREATE TABLE "CONSENT_AUDIT" (
-    DEPLOYMENT_ID VARCHAR(255) NOT NULL,
-    ID VARCHAR(36) NOT NULL PRIMARY KEY,
-    ACTION VARCHAR(30) NOT NULL,
-    CONSENT_ID VARCHAR(36) NOT NULL,
-    GROUP_ID VARCHAR(36) NOT NULL,
-    SUBJECT_USER_IDS TEXT,
-    ACTOR_ID VARCHAR(36),
-    TRACE_ID VARCHAR(255),
-    DETAILS TEXT,
-    CREATED_AT TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-
--- Index for retrieving the audit trail of a consent.
-CREATE INDEX idx_consent_audit_consent ON "CONSENT_AUDIT" (DEPLOYMENT_ID, CONSENT_ID);


### PR DESCRIPTION
### Purpose

$subject

### Approach

Removed the schema definition from the DB scripts

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [x] Breaking changes. (Fill if applicable)
    - [x] Breaking changes section filled.
    - [x] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed consent audit history storage from the runtime database schema.
  * Consent authorization records remain available through the existing authorization schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->