### PR TITLE
Move agent Delegated mode toggle to the Advanced tab

### DIFF
--- a/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/EditAdvancedSettings.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/EditAdvancedSettings.tsx
@@ -16,14 +16,17 @@
  * under the License.
  */
 
-import {Stack} from '@wso2/oxygen-ui';
+import {FormControlLabel, Stack, Switch} from '@wso2/oxygen-ui';
+import {useTranslation} from 'react-i18next';
 import AllowedUserTypesSection from './AllowedUserTypesSection';
 import OperationModesSection from './OperationModesSection';
 import OwnerSection from './OwnerSection';
 import SecuritySection from './SecuritySection';
 import TokenEndpointAuthMethodSection from './TokenEndpointAuthMethodSection';
 import AudienceSection from '../../../../applications/components/edit-application/advanced-settings/AudienceSection';
-import type {OAuth2Config} from '../../../../applications/models/oauth';
+import {OAuth2GrantTypes, type OAuth2Config} from '../../../../applications/models/oauth';
+import {applyGrantTypesChange} from '../../../../applications/utils/oauth2Rules';
+import {DELEGATED_ONLY_GRANTS} from '../../../constants/delegationGrants';
 import type {Agent, AgentInboundAuthConfig, OAuthAgentConfig} from '../../../models/agent';
 
 interface EditAdvancedSettingsProps {
@@ -39,12 +42,31 @@ export default function EditAdvancedSettings({
   oauth2Config = undefined,
   onFieldChange,
 }: EditAdvancedSettingsProps) {
+  const {t} = useTranslation();
+  const isUnlocked = oauth2Config?.grantTypes?.includes(OAuth2GrantTypes.AUTHORIZATION_CODE) ?? false;
+
   const handleOAuth2ConfigChange = (updates: Partial<OAuth2Config>) => {
     const currentInboundAuth: AgentInboundAuthConfig[] = editedAgent.inboundAuthConfig ?? agent.inboundAuthConfig ?? [];
     const updatedInboundAuth = currentInboundAuth.map((auth) =>
       auth.type === 'oauth2' ? {...auth, config: {...auth.config, ...updates} as OAuthAgentConfig} : auth,
     );
     onFieldChange('inboundAuthConfig', updatedInboundAuth);
+  };
+
+  // Delegated mode unlocks the delegated-only grants below and the Flows/Tokens tabs. Toggling it
+  // just flips authorization_code on/off; applyGrantTypesChange handles the dependent grants.
+  const handleDelegationToggle = (checked: boolean): void => {
+    if (!oauth2Config || checked === isUnlocked) return;
+    const grantTypes = oauth2Config.grantTypes ?? [];
+    const nextGrantTypes = checked
+      ? [...new Set([...grantTypes, OAuth2GrantTypes.AUTHORIZATION_CODE])]
+      : grantTypes.filter((grant) => !DELEGATED_ONLY_GRANTS.includes(grant));
+    const updates = applyGrantTypesChange(oauth2Config, nextGrantTypes);
+    // PKCE is fully derived from authorization_code for agents.
+    if (checked) {
+      updates.pkceRequired = true;
+    }
+    handleOAuth2ConfigChange(updates);
   };
 
   const handleDefaultAudienceChange = (audience: string) => {
@@ -58,6 +80,16 @@ export default function EditAdvancedSettings({
 
   return (
     <Stack spacing={3}>
+      <FormControlLabel
+        control={
+          <Switch
+            checked={isUnlocked}
+            onChange={(e) => handleDelegationToggle(e.target.checked)}
+            disabled={!oauth2Config || agent.isReadOnly === true}
+          />
+        }
+        label={t('agents:edit.advanced.delegationToggle.label', 'Delegated mode')}
+      />
       <OwnerSection agent={agent} editedAgent={editedAgent} onFieldChange={onFieldChange} />
       <AllowedUserTypesSection
         agent={agent}

--- a/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/OperationModesSection.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/OperationModesSection.tsx
@@ -98,7 +98,7 @@ export default function OperationModesSection({
             <Alert severity="info" sx={{mb: 1.5}}>
               {t(
                 'agents:edit.advanced.oauthAccess.grantTypes.hint',
-                'The greyed-out grants unlock once you turn on Delegated mode in the Flows tab.',
+                'The greyed-out grants unlock once you turn on Delegated mode at the top of this tab.',
               )}
             </Alert>
             <Select

--- a/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/__tests__/EditAdvancedSettings.test.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/__tests__/EditAdvancedSettings.test.tsx
@@ -174,4 +174,107 @@ describe('EditAdvancedSettings', () => {
     // No OAuth2 entry to merge into; should still call with an empty array
     expect(mockOnFieldChange).toHaveBeenCalledWith('inboundAuthConfig', []);
   });
+
+  describe('Delegated mode toggle', () => {
+    it('shows the toggle checked when Delegated mode is on', () => {
+      render(
+        <EditAdvancedSettings
+          agent={mockAgent}
+          editedAgent={{}}
+          oauth2Config={{grantTypes: ['authorization_code'], responseTypes: ['code']}}
+          onFieldChange={mockOnFieldChange}
+        />,
+      );
+
+      expect(screen.getByRole('switch', {name: 'Delegated mode'})).toBeChecked();
+    });
+
+    it('shows the toggle unchecked when Delegated mode is off', () => {
+      render(
+        <EditAdvancedSettings
+          agent={mockAgent}
+          editedAgent={{}}
+          oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
+          onFieldChange={mockOnFieldChange}
+        />,
+      );
+
+      expect(screen.getByRole('switch', {name: 'Delegated mode'})).not.toBeChecked();
+    });
+
+    it('turns on Delegated mode by adding authorization_code and requiring PKCE', async () => {
+      const user = userEvent.setup();
+      render(
+        <EditAdvancedSettings
+          agent={{
+            ...mockAgent,
+            inboundAuthConfig: [{type: 'oauth2', config: {grantTypes: ['client_credentials'], responseTypes: []}}],
+          }}
+          editedAgent={{}}
+          oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
+          onFieldChange={mockOnFieldChange}
+        />,
+      );
+
+      await user.click(screen.getByRole('switch', {name: 'Delegated mode'}));
+
+      expect(mockOnFieldChange).toHaveBeenCalledWith(
+        'inboundAuthConfig',
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'oauth2',
+            config: expect.objectContaining({
+              grantTypes: expect.arrayContaining(['client_credentials', 'authorization_code']) as string[],
+              pkceRequired: true,
+            }) as Record<string, unknown>,
+          }),
+        ]) as AgentInboundAuthConfig[],
+      );
+    });
+
+    it('turns off Delegated mode by dropping the delegated-only grants', async () => {
+      const user = userEvent.setup();
+      render(
+        <EditAdvancedSettings
+          agent={{
+            ...mockAgent,
+            inboundAuthConfig: [
+              {
+                type: 'oauth2',
+                config: {grantTypes: ['client_credentials', 'authorization_code'], responseTypes: ['code']},
+              },
+            ],
+          }}
+          editedAgent={{}}
+          oauth2Config={{grantTypes: ['client_credentials', 'authorization_code'], responseTypes: ['code']}}
+          onFieldChange={mockOnFieldChange}
+        />,
+      );
+
+      await user.click(screen.getByRole('switch', {name: 'Delegated mode'}));
+
+      expect(mockOnFieldChange).toHaveBeenCalledWith(
+        'inboundAuthConfig',
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'oauth2',
+            config: expect.objectContaining({grantTypes: ['client_credentials']}) as Record<string, unknown>,
+          }),
+        ]) as AgentInboundAuthConfig[],
+      );
+    });
+
+    it('disables the toggle for read-only agents', () => {
+      render(
+        <EditAdvancedSettings
+          agent={{...mockAgent, isReadOnly: true}}
+          editedAgent={{}}
+          oauth2Config={{grantTypes: ['authorization_code'], responseTypes: ['code']}}
+          onFieldChange={mockOnFieldChange}
+        />,
+      );
+
+      expect(screen.getByRole('switch', {name: 'Delegated mode'})).toBeDisabled();
+    });
+  });
 });

--- a/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/__tests__/OperationModesSection.test.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/__tests__/OperationModesSection.test.tsx
@@ -55,7 +55,7 @@ describe('OperationModesSection', () => {
     render(<OperationModesSection oauth2Config={autonomousOnlyConfig} onOAuth2ConfigChange={vi.fn()} />);
 
     expect(
-      screen.getByText(/greyed-out grants unlock once you turn on Delegated mode in the Flows tab/i),
+      screen.getByText(/greyed-out grants unlock once you turn on Delegated mode at the top of this tab/i),
     ).toBeInTheDocument();
   });
 

--- a/frontend/apps/console/src/features/agents/components/edit-agent/flows/EditFlowsSettings.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/flows/EditFlowsSettings.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {FormControlLabel, Stack, Switch} from '@wso2/oxygen-ui';
+import {Stack} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import AuthenticationFlowSection from '../../../../applications/components/edit-application/flows-settings/AuthenticationFlowSection';
@@ -24,9 +24,7 @@ import RecoveryFlowSection from '../../../../applications/components/edit-applic
 import RegistrationFlowSection from '../../../../applications/components/edit-application/flows-settings/RegistrationFlowSection';
 import type {Application} from '../../../../applications/models/application';
 import {OAuth2GrantTypes} from '../../../../applications/models/oauth';
-import {applyGrantTypesChange} from '../../../../applications/utils/oauth2Rules';
-import {DELEGATED_ONLY_GRANTS} from '../../../constants/delegationGrants';
-import type {Agent, AgentInboundAuthConfig, OAuthAgentConfig} from '../../../models/agent';
+import type {Agent, OAuthAgentConfig} from '../../../models/agent';
 import DelegationLockNotice from '../shared/DelegationLockNotice';
 
 interface EditFlowsSettingsProps {
@@ -45,27 +43,6 @@ export default function EditFlowsSettings({
   const {t} = useTranslation();
   const isUnlocked = oauth2Config?.grantTypes?.includes(OAuth2GrantTypes.AUTHORIZATION_CODE) ?? false;
 
-  // Lets the user turn on Delegated mode directly from this tab instead of having to visit
-  // Advanced — same grant-type rules as OperationModesSection's mode toggle.
-  const handleDelegationToggle = (checked: boolean): void => {
-    if (!oauth2Config || checked === isUnlocked) return;
-    const grantTypes = oauth2Config.grantTypes ?? [];
-    const nextGrantTypes = checked
-      ? [...new Set([...grantTypes, OAuth2GrantTypes.AUTHORIZATION_CODE])]
-      : grantTypes.filter((grant) => !DELEGATED_ONLY_GRANTS.includes(grant));
-    const updates = applyGrantTypesChange(oauth2Config, nextGrantTypes);
-    // PKCE is fully derived from authorization_code for agents (mirrors OperationModesSection).
-    if (checked) {
-      updates.pkceRequired = true;
-    }
-
-    const currentInboundAuth: AgentInboundAuthConfig[] = editedAgent.inboundAuthConfig ?? agent.inboundAuthConfig ?? [];
-    const updatedInboundAuth = currentInboundAuth.map((auth) =>
-      auth.type === 'oauth2' ? {...auth, config: {...auth.config, ...updates} as OAuthAgentConfig} : auth,
-    );
-    onFieldChange('inboundAuthConfig', updatedInboundAuth);
-  };
-
   // Agents share the inbound-client shape with applications (auth_flow_id, registration/recovery
   // flow config), so the same components are reused with an entity-label override. Forcing
   // isReadOnly disables every input via their existing disabled={application.isReadOnly} wiring
@@ -76,21 +53,11 @@ export default function EditFlowsSettings({
 
   return (
     <Stack spacing={3}>
-      <FormControlLabel
-        control={
-          <Switch
-            checked={isUnlocked}
-            onChange={(e) => handleDelegationToggle(e.target.checked)}
-            disabled={!oauth2Config || agent.isReadOnly === true}
-          />
-        }
-        label={t('agents:edit.flows.delegationToggle.label', 'Delegated mode')}
-      />
       <DelegationLockNotice
         isUnlocked={isUnlocked}
         message={t(
           'agents:edit.flows.delegationLock.message',
-          'These settings are frozen for this agent. Turn on Delegated mode above to unlock and start using them.',
+          'These settings are frozen for this agent. Turn on Delegated mode in the Advanced tab to unlock and start using them.',
         )}
       >
         <Stack spacing={3}>

--- a/frontend/apps/console/src/features/agents/components/edit-agent/flows/__tests__/EditFlowsSettings.test.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/flows/__tests__/EditFlowsSettings.test.tsx
@@ -17,7 +17,6 @@
  */
 
 import {render, screen} from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import {describe, it, expect, vi} from 'vitest';
 import type {Application} from '../../../../../applications/models/application';
 import type {Agent} from '../../../../models/agent';
@@ -99,108 +98,5 @@ describe('EditFlowsSettings', () => {
     );
 
     expect(screen.getByTestId('auth-flow')).toHaveAttribute('data-readonly', 'true');
-  });
-
-  describe('Delegated mode toggle', () => {
-    it('shows the toggle checked when Delegated mode is on', () => {
-      render(
-        <EditFlowsSettings
-          agent={baseAgent}
-          editedAgent={{}}
-          oauth2Config={{grantTypes: ['authorization_code'], responseTypes: ['code']}}
-          onFieldChange={mockOnFieldChange}
-        />,
-      );
-
-      expect(screen.getByRole('switch', {name: 'Delegated mode'})).toBeChecked();
-    });
-
-    it('shows the toggle unchecked when Delegated mode is off', () => {
-      render(
-        <EditFlowsSettings
-          agent={baseAgent}
-          editedAgent={{}}
-          oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
-          onFieldChange={mockOnFieldChange}
-        />,
-      );
-
-      expect(screen.getByRole('switch', {name: 'Delegated mode'})).not.toBeChecked();
-    });
-
-    it('turns on Delegated mode by adding authorization_code and requiring PKCE', async () => {
-      const user = userEvent.setup();
-      render(
-        <EditFlowsSettings
-          agent={{
-            ...baseAgent,
-            inboundAuthConfig: [{type: 'oauth2', config: {grantTypes: ['client_credentials'], responseTypes: []}}],
-          }}
-          editedAgent={{}}
-          oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
-          onFieldChange={mockOnFieldChange}
-        />,
-      );
-
-      await user.click(screen.getByRole('switch', {name: 'Delegated mode'}));
-
-      expect(mockOnFieldChange).toHaveBeenCalledWith(
-        'inboundAuthConfig',
-        expect.arrayContaining([
-          expect.objectContaining({
-            type: 'oauth2',
-            config: expect.objectContaining({
-              grantTypes: expect.arrayContaining(['client_credentials', 'authorization_code']) as string[],
-              pkceRequired: true,
-            }) as Record<string, unknown>,
-          }),
-        ]),
-      );
-    });
-
-    it('turns off Delegated mode by dropping the delegated-only grants', async () => {
-      const user = userEvent.setup();
-      render(
-        <EditFlowsSettings
-          agent={{
-            ...baseAgent,
-            inboundAuthConfig: [
-              {
-                type: 'oauth2',
-                config: {grantTypes: ['client_credentials', 'authorization_code'], responseTypes: ['code']},
-              },
-            ],
-          }}
-          editedAgent={{}}
-          oauth2Config={{grantTypes: ['client_credentials', 'authorization_code'], responseTypes: ['code']}}
-          onFieldChange={mockOnFieldChange}
-        />,
-      );
-
-      await user.click(screen.getByRole('switch', {name: 'Delegated mode'}));
-
-      expect(mockOnFieldChange).toHaveBeenCalledWith(
-        'inboundAuthConfig',
-        expect.arrayContaining([
-          expect.objectContaining({
-            type: 'oauth2',
-            config: expect.objectContaining({grantTypes: ['client_credentials']}) as Record<string, unknown>,
-          }),
-        ]),
-      );
-    });
-
-    it('disables the toggle for read-only agents', () => {
-      render(
-        <EditFlowsSettings
-          agent={{...baseAgent, isReadOnly: true}}
-          editedAgent={{}}
-          oauth2Config={{grantTypes: ['authorization_code'], responseTypes: ['code']}}
-          onFieldChange={mockOnFieldChange}
-        />,
-      );
-
-      expect(screen.getByRole('switch', {name: 'Delegated mode'})).toBeDisabled();
-    });
   });
 });

--- a/frontend/apps/console/src/features/agents/components/edit-agent/tokens/EditTokensSettings.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/tokens/EditTokensSettings.tsx
@@ -82,7 +82,7 @@ export default function EditTokensSettings({
             isUnlocked={isUnlocked}
             message={t(
               'agents:edit.tokens.delegationLock.message',
-              'These settings are frozen for this agent. Turn on Delegated mode in the Flows tab to unlock and start using them.',
+              'These settings are frozen for this agent. Turn on Delegated mode in the Advanced tab to unlock and start using them.',
             )}
           >
             <Stack spacing={3}>

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1171,11 +1171,11 @@ const translations = {
     'edit.flows.allowedUserTypes.placeholder': 'Select or add user types',
     'edit.flows.allowedUserTypes.hint': 'Only these user types can authenticate or register through this agent.',
     'edit.flows.allowedUserTypes.required': 'Select at least one user type that can sign in through this agent.',
-    'edit.flows.delegationToggle.label': 'Delegated mode',
     'edit.flows.delegationLock.message':
-      'These settings are frozen for this agent. Turn on Delegated mode above to unlock and start using them.',
+      'These settings are frozen for this agent. Turn on Delegated mode in the Advanced tab to unlock and start using them.',
 
     // Edit page - Advanced tab
+    'edit.advanced.delegationToggle.label': 'Delegated mode',
     'edit.advanced.redirectUris.title': 'Authorized redirect URIs',
     'edit.advanced.redirectUris.description': 'For use with requests from a web server',
     'edit.advanced.redirectUris.empty': 'No redirect URIs configured.',
@@ -1187,7 +1187,7 @@ const translations = {
     'edit.advanced.oauthAccess.description': 'The grants and redirect URIs this agent is authorized to use.',
     'edit.advanced.oauthAccess.grantTypes.label': 'Grant Types',
     'edit.advanced.oauthAccess.grantTypes.hint':
-      'The greyed-out grants unlock once you turn on Delegated mode in the Flows tab.',
+      'The greyed-out grants unlock once you turn on Delegated mode at the top of this tab.',
     'edit.advanced.security.title': 'Security',
     'edit.advanced.security.description':
       'Controls how this agent protects the authorization code exchange when a user signs in.',
@@ -1205,7 +1205,7 @@ const translations = {
     'edit.tokens.tabs.user': 'User',
     'edit.tokens.tabs.agent': 'Agent',
     'edit.tokens.delegationLock.message':
-      'These settings are frozen for this agent. Turn on Delegated mode in the Flows tab to unlock and start using them.',
+      'These settings are frozen for this agent. Turn on Delegated mode in the Advanced tab to unlock and start using them.',
     'edit.tokens.agent.attributes.title': 'Access Token Attributes',
     'edit.tokens.agent.attributes.description':
       'Attributes included in the access token this agent receives for its own requests (client_credentials grant).',


### PR DESCRIPTION
### Purpose

Moves the agent "Delegated mode" toggle from the **Flows** tab to the top of the **Advanced** tab in the agent edit view, and updates the related info messages so they point users to the new location.

### Approach

The toggle only flips the `authorization_code` grant on/off (adding it plus deriving PKCE when enabled, and dropping the delegated-only grants when disabled). In `EditAdvancedSettings` this reuses the existing `handleOAuth2ConfigChange` helper to merge the grant changes into the agent's `inboundAuthConfig`, so no logic is duplicated; the previous inline mapping in `EditFlowsSettings` was removed.

`EditFlowsSettings` still computes `isUnlocked` to drive the frozen/read-only state of the flow sections and the lock notice, but no longer owns the toggle. The three info strings were moved to reference the Advanced tab, and the toggle's i18n key was moved under the Advanced tab group.


<img width="1726" height="888" alt="image" src="https://github.com/user-attachments/assets/77d71e37-0873-4f0f-b7d6-c1d4c35a33e2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Delegated mode toggle to the agent’s Advanced settings.
  * Enabling Delegated mode unlocks related OAuth settings and automatically configures required security options.
  * Delegated mode is unavailable when agent settings are read-only.

* **Documentation**
  * Updated guidance across Advanced, Flows, and Tokens settings to direct users to enable Delegated mode from the Advanced tab.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->