### PR TITLE
Fix issues with helm install for default credentials generation

### DIFF
--- a/docs/content/deployment/deployment-paths/kubernetes.mdx
+++ b/docs/content/deployment/deployment-paths/kubernetes.mdx
@@ -88,6 +88,12 @@ kubectl get ingress -n thunderid
 
 If you are using a cloud provider, the load balancer assigns the external IP automatically.
 
+When no password is configured (the default), the setup job generates a random admin password and stores it in the `{{productSlug}}-admin-credentials` Secret. Retrieve it to sign in to the Console as `admin`. If you set `setup.admin.password` or `setup.admin.passwordRef`, use that credential instead; no Secret is generated.
+
+```bash
+kubectl get secret {{productSlug}}-admin-credentials -n thunderid -o jsonpath="{.data.admin-password}" | base64 -d; echo
+```
+
 ## Installation Options
 
 ### Option 1: Inline Value Overrides
@@ -101,8 +107,7 @@ helm install thunderid oci://ghcr.io/thunder-id/helm-charts/thunderid \
   --set configuration.database.config.type=sqlite \
   --set configuration.database.runtime_transient.type=sqlite \
   --set configuration.database.entity.type=sqlite \
-  --set configuration.database.runtime_persistent.type=sqlite \
-  --set deployment.securityContext.readOnlyRootFilesystem=false
+  --set configuration.database.runtime_persistent.type=sqlite
 ```
 
 :::warning
@@ -297,8 +302,6 @@ persistence:
   accessMode: ReadWriteOnce
   size: 1Gi
 ```
-
-Also set `deployment.securityContext.readOnlyRootFilesystem: false` when using SQLite. The chart defaults it to `true`, which blocks the setup job and server from writing to the container filesystem, including the temporary files created during initialization.
 
 Set `replicaCount: 1` when using SQLite: multiple replicas writing to the same SQLite files will corrupt the database.
 

--- a/docs/content/getting-started/get-thunderid.mdx
+++ b/docs/content/getting-started/get-thunderid.mdx
@@ -234,8 +234,7 @@ helm install {{productSlug}} oci://ghcr.io/thunder-id/helm-charts/{{productSlug}
   --set configuration.database.runtime_persistent.postgres.sslmode=disable \
   --set configuration.server.publicUrl=https://localhost:8090 \
   --set configuration.gateClient.hostname=localhost \
-  --set configuration.gateClient.port=8090 \
-  --set deployment.securityContext.readOnlyRootFilesystem=false
+  --set configuration.gateClient.port=8090
 ```
 
 Wait for <ProductName /> to be ready:
@@ -251,6 +250,14 @@ Forward the service port to your local machine:
 ```bash
 kubectl port-forward svc/{{productSlug}}-service 8090:8090
 ```
+
+When no password is configured (the default), the setup job generates a random admin password and stores it in the `{{productSlug}}-admin-credentials` Secret. Retrieve it to sign in to the Console. If you supplied `setup.admin.password` or `setup.admin.passwordRef`, use that credential instead; no Secret is generated:
+
+```bash
+kubectl get secret {{productSlug}}-admin-credentials -o jsonpath="{.data.admin-password}" | base64 -d; echo
+```
+
+Open `https://localhost:8090/console` and sign in using the admin username with that password.
 
 :::tip Success
 Access <ProductName /> on **https://localhost:8090/console**

--- a/install/helm/README.md
+++ b/install/helm/README.md
@@ -728,22 +728,37 @@ The setup job runs `setup.sh` as a one-time Helm pre-install hook to initialize 
 | `setup.resources.requests.memory`      | Memory request for setup job                                    | `50Mi`                       |
 | `setup.resources.limits.cpu`           | CPU limit for setup job                                         | `200m`                       |
 | `setup.resources.limits.memory`        | Memory limit for setup job                                      | `100Mi`                      |
-| `setup.admin.username`                 | Username for the default admin user                             | `admin`                      |
-| `setup.admin.password`                 | Password for the default admin user. Ignored when `setup.admin.passwordRef.name` is set | `admin` |
-| `setup.admin.passwordRef.name`         | Existing Kubernetes Secret name containing the admin password. Must be set together with `passwordRef.key` | `""` |
-| `setup.admin.passwordRef.key`          | Key in the Secret whose value is used as the admin password. Must be set together with `passwordRef.name` | `""` |
+| `setup.admin.username`                 | Username for the admin user. Ignored when `usernameRef` is set                | `admin`    |
+| `setup.admin.usernameRef.name`         | Existing Secret holding the username. Set together with `usernameRef.key`; takes precedence over inline username | `""` |
+| `setup.admin.usernameRef.key`          | Key in the Secret holding the username. Set together with `usernameRef.name`  | `""`         |
+| `setup.admin.password`                 | Inline password for the admin user. Leave empty to generate one. Ignored when `passwordRef` is set | `""` |
+| `setup.admin.passwordRef.name`         | Existing Secret holding the password. Set together with `passwordRef.key`; takes precedence over inline password and generation | `""` |
+| `setup.admin.passwordRef.key`          | Key in the Secret holding the password. Set together with `passwordRef.name`  | `""`         |
 | `setup.extraVolumeMounts`              | Additional volume mounts for setup job                          | `[]`                         |
 | `setup.extraVolumes`                   | Additional volumes for setup job                                | `[]`                         |
 
 ### Admin Credentials
 
-The setup job seeds a default admin user during first install. The password can be supplied as a plain value (for development) or sourced from an existing Kubernetes Secret (recommended for production).
+The setup job seeds an admin user during first install (only when `setup.enabled=true`). No default password is shipped. The password is resolved in the following order of precedence:
 
-#### Security Warning
+1. **`passwordRef`** — sourced from an existing Kubernetes Secret.
+2. **`password`** — the inline value in `values.yaml`.
+3. **generated** — a random password is generated and stored in the `<release>-admin-credentials` Secret.
 
-⚠️ **The default `admin`/`admin` credentials must be changed before any non-development deployment.** When defaults are used, the credentials are printed in the setup completion summary. Always set explicit credentials for any non-development environment.
+The username is resolved independently: **`usernameRef`** (existing Secret) if set, otherwise the inline **`username`** (default `admin`).
 
-#### Pattern 1: Plain value (Development / Quick-start)
+#### Pattern 1: Generated password (default)
+
+Leave `setup.admin.password` and `setup.admin.passwordRef` unset. A random password is generated during install and stored in a Kubernetes Secret. Retrieve it with:
+
+```bash
+kubectl get secret --namespace <namespace> <release>-thunderid-admin-credentials \
+  -o jsonpath="{.data.admin-password}" | base64 -d; echo
+```
+
+The Secret name follows the chart's fullname (`nameOverride`/`fullnameOverride` change it), so use the exact command printed in the post-install notes.
+
+#### Pattern 2: Inline value (Development / Quick-start)
 
 ```yaml
 setup:
@@ -760,29 +775,32 @@ helm install my-thunderid oci://ghcr.io/thunder-id/helm-charts/thunderid \
   --set setup.admin.password='MyP@ssw0rd!'
 ```
 
-#### Pattern 2: External Kubernetes Secret (Production — Recommended)
+#### Pattern 3: Existing Kubernetes Secret (Production — Recommended)
 
-**Step 1:** Create the Secret:
+**Step 1:** Create a Secret holding the credentials. Read the values from files (each written without a trailing newline) so they do not appear in your shell history or process arguments:
 
 ```bash
 kubectl create secret generic thunderid-admin-credentials \
-  --from-literal=password='MyP@ssw0rd!'
+  --from-file=username=./admin-username \
+  --from-file=password=./admin-password
 ```
 
-**Step 2:** Reference it in your values:
+**Step 2:** Reference it in your values. Point both refs at the same Secret name with different keys (or at different Secrets):
 
 ```yaml
 setup:
   admin:
-    username: "myAdmin"
+    usernameRef:              # optional; falls back to setup.admin.username
+      name: "thunderid-admin-credentials"
+      key: "username"
     passwordRef:
       name: "thunderid-admin-credentials"
       key: "password"
 ```
 
-When `passwordRef.name` and `passwordRef.key` are both set, the `password` field is ignored and the admin password is injected directly from the Secret — no plaintext appears in the rendered Job manifest.
+When `passwordRef` is set it takes precedence over the inline password and over generation; likewise `usernameRef` over the inline username. Credentials are injected directly from the Secret via `secretKeyRef`, so no plaintext appears in the rendered Job manifest.
 
-**Validation:** The chart fails at render time if only one of `passwordRef.name` / `passwordRef.key` is provided. Both must be set together or both must be left empty.
+**Validation:** The chart fails at render time if either ref has only one of `name`/`key` set. Provide both or neither.
 
 Environment variable item structure for plain value environment variables in `deployment.env` and `setup.env`:
 

--- a/install/helm/templates/NOTES.txt
+++ b/install/helm/templates/NOTES.txt
@@ -1,0 +1,19 @@
+{{- if eq (include "thunderid.adminPasswordGenerated" .) "true" }}
+{{- $admin := default dict .Values.setup.admin }}
+{{- $usernameRef := default dict $admin.usernameRef }}
+
+Admin credentials
+=================
+
+A random admin password was generated and stored in a Kubernetes Secret.
+Retrieve it with:
+
+  kubectl get secret --namespace {{ .Release.Namespace }} {{ include "thunderid.fullname" . }}-admin-credentials -o jsonpath="{.data.admin-password}" | base64 -d; echo
+{{ if $usernameRef.name }}
+  The username comes from Secret "{{ $usernameRef.name }}" (key "{{ $usernameRef.key }}"). Retrieve it with:
+
+  kubectl get secret --namespace {{ .Release.Namespace }} {{ $usernameRef.name }} -o jsonpath="{.data.{{ $usernameRef.key }}}" | base64 -d; echo
+{{- else }}
+  Username: {{ $admin.username }}
+{{- end }}
+{{- end }}

--- a/install/helm/templates/_helpers.tpl
+++ b/install/helm/templates/_helpers.tpl
@@ -81,6 +81,19 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Returns "true" when the admin password is auto-generated, i.e. the setup job is enabled
+and neither an existing Secret nor an inline password is supplied. Used to gate the
+generated -admin-credentials Secret and the retrieval instructions in NOTES.txt.
+*/}}
+{{- define "thunderid.adminPasswordGenerated" -}}
+{{- $admin := default dict .Values.setup.admin -}}
+{{- $passwordRef := default dict $admin.passwordRef -}}
+{{- if and .Values.setup.enabled (not $passwordRef.name) (not $admin.password) -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
 Check if auto-generated database credentials Secret should be included in checksum annotation.
 Returns true if any database password is set without a passwordRef.key.
 This is used to trigger pod restarts when auto-generated Secrets change.

--- a/install/helm/templates/admin-secret.yaml
+++ b/install/helm/templates/admin-secret.yaml
@@ -1,0 +1,47 @@
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{{- if eq (include "thunderid.adminPasswordGenerated" .) "true" }}
+{{- $secretName := printf "%s-admin-credentials" (include "thunderid.fullname" .) -}}
+{{- /*
+  Reuse the existing password when the Secret is already present so re-renders
+  (e.g. helm upgrade, or a re-run of the pre-install hook) never rotate the
+  admin password out from under the operator. Only generate on first install.
+*/ -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $password := "" -}}
+{{- if and $existing $existing.data (index $existing.data "admin-password") -}}
+{{- $password = index $existing.data "admin-password" | b64dec -}}
+{{- else -}}
+{{- $password = randAlphaNum 16 -}}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "thunderid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: admin-credentials
+  annotations:
+    "helm.sh/hook": pre-install
+    # Lower weight than the setup job (-5) so the Secret exists before the job consumes it.
+    "helm.sh/hook-weight": "-6"
+    "helm.sh/hook-delete-policy": before-hook-creation
+type: Opaque
+data:
+  admin-password: {{ $password | b64enc | quote }}
+{{- end }}

--- a/install/helm/templates/setup-job.yaml
+++ b/install/helm/templates/setup-job.yaml
@@ -126,23 +126,46 @@ spec:
             - name: DEBUG
               value: "true"
             {{- end }}
-            - name: ADMIN_USERNAME
-              value: {{ .Values.setup.admin.username | quote }}
-            {{- if and .Values.setup.admin.passwordRef.key (not .Values.setup.admin.passwordRef.name) }}
-            {{- fail "setup.admin.passwordRef.name is required when setup.admin.passwordRef.key is set" }}
+            {{- $admin := default dict .Values.setup.admin }}
+            {{- $usernameRef := default dict $admin.usernameRef }}
+            {{- $passwordRef := default dict $admin.passwordRef }}
+            {{- if and $usernameRef.name (not $usernameRef.key) }}
+            {{- fail "setup.admin.usernameRef.key is required when setup.admin.usernameRef.name is set" }}
             {{- end }}
-            {{- if .Values.setup.admin.passwordRef.name }}
-            {{- if not .Values.setup.admin.passwordRef.key }}
+            {{- if and $usernameRef.key (not $usernameRef.name) }}
+            {{- fail "setup.admin.usernameRef.name is required when setup.admin.usernameRef.key is set" }}
+            {{- end }}
+            {{- if and $passwordRef.name (not $passwordRef.key) }}
             {{- fail "setup.admin.passwordRef.key is required when setup.admin.passwordRef.name is set" }}
             {{- end }}
+            {{- if and $passwordRef.key (not $passwordRef.name) }}
+            {{- fail "setup.admin.passwordRef.name is required when setup.admin.passwordRef.key is set" }}
+            {{- end }}
+            {{- if $usernameRef.name }}
+            - name: ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $usernameRef.name | quote }}
+                  key: {{ $usernameRef.key | quote }}
+            {{- else }}
+            - name: ADMIN_USERNAME
+              value: {{ $admin.username | quote }}
+            {{- end }}
+            {{- if $passwordRef.name }}
             - name: ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.setup.admin.passwordRef.name | quote }}
-                  key: {{ .Values.setup.admin.passwordRef.key | quote }}
+                  name: {{ $passwordRef.name | quote }}
+                  key: {{ $passwordRef.key | quote }}
+            {{- else if $admin.password }}
+            - name: ADMIN_PASSWORD
+              value: {{ $admin.password | quote }}
             {{- else }}
             - name: ADMIN_PASSWORD
-              value: {{ .Values.setup.admin.password | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ printf "%s-admin-credentials" (include "thunderid.fullname" .) | quote }}
+                  key: admin-password
             {{- end }}
             {{- include "thunderid.databasePasswordEnvVars" . | nindent 12 }}
             {{- include "thunderid.secretEnvVars" (dict "secretEnv" .Values.setup.secretEnv) | nindent 12 }}
@@ -168,6 +191,9 @@ spec:
               drop:
                 - all
           volumeMounts:
+            # Writable scratch space so setup.sh can use mktemp under a read-only root filesystem.
+            - name: tmp
+              mountPath: /tmp
             {{- if or .Values.persistence.enabled $usingSqlite }}
             - name: database-storage
               mountPath: /opt/thunderid/database
@@ -229,6 +255,8 @@ spec:
             {{- end }}
             {{- end }}
       volumes:
+        - name: tmp
+          emptyDir: {}
         - name: certs-storage
           persistentVolumeClaim:
             claimName: {{ include "thunderid.fullname" . }}-certs-pvc

--- a/install/helm/templates/thunderid-deployment.yaml
+++ b/install/helm/templates/thunderid-deployment.yaml
@@ -145,6 +145,9 @@ spec:
             - containerPort: {{ .Values.deployment.container.port }}
               protocol: TCP
           volumeMounts:
+            # Writable scratch space (/tmp) so the server can write temp files under a read-only root filesystem.
+            - name: tmp
+              mountPath: /tmp
             {{- if or .Values.persistence.enabled $usingSqlite }}
             - name: database-storage
               mountPath: /opt/thunderid/database
@@ -182,6 +185,8 @@ spec:
             {{- end }}
             {{- end }}
       volumes:
+        - name: tmp
+          emptyDir: {}
         {{- if .Values.setup.enabled }}
         - name: certs-storage
           persistentVolumeClaim:

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -21,7 +21,7 @@ deployment:
       maxSurge: 1
       maxUnavailable: 0
   securityContext:
-    readOnlyRootFilesystem: true # This must be false if sqlite is used as the database
+    readOnlyRootFilesystem: true
     enableRunAsUser: true
     runAsUser: 10001
     enableRunAsGroup: true
@@ -597,13 +597,31 @@ setup:
   ttlSecondsAfterFinished: 86400  # 24 hours
   # Enable debug mode for setup
   debug: false
-  # Default admin user credentials seeded by the setup job.
-  # WARNING: Replace the default password before deploying to any non-development environment.
+  # Admin user credentials seeded by the setup job (only when setup.enabled=true).
+  #
+  # Password resolution order (highest precedence first):
+  #   1. passwordRef  - sourced from an existing Kubernetes Secret
+  #   2. password     - the inline value below
+  #   3. generated    - a random password is stored in the "<release>-admin-credentials"
+  #                     Secret. Retrieve it with the command printed after installation.
+  # Username resolution: usernameRef if set, otherwise the inline username below.
+  # No default password is shipped: leaving everything unset generates one securely.
   admin:
     username: "admin"
-    password: "admin"
-    # Optional: source the admin password from an existing Kubernetes Secret.
-    # When `passwordRef.name` is set, it takes precedence over the plain `password` above.
+    # Source the admin username from an existing Kubernetes Secret. When
+    # usernameRef.name and usernameRef.key are both set, it takes precedence over
+    # the inline username above. name and key must be set together.
+    usernameRef:
+      name: ""
+      key: ""
+    # Inline admin password. Leave empty to generate a random one.
+    # Ignored when passwordRef is set.
+    password: ""
+    # Source the admin password from an existing Kubernetes Secret. When
+    # passwordRef.name and passwordRef.key are both set, it takes precedence over
+    # the inline password above and over generation. name and key must be set
+    # together. Point usernameRef and passwordRef at the same Secret name with
+    # different keys to source both credentials from one Secret.
     passwordRef:
       name: ""
       key: ""


### PR DESCRIPTION
### Purpose

The Helm chart shipped a well-known default admin credential (`admin`/`admin`) and required operators to set `deployment.securityContext.readOnlyRootFilesystem=false` for the setup job to run. This PR addresses both:

1. **No default admin password.** When no password is supplied, the chart generates a random one, stores it in a Kubernetes Secret, and prints a retrieval command in the post-install notes. Both the admin username and password can also be sourced from existing Kubernetes Secrets.
2. **Setup job works under the secure `readOnlyRootFilesystem: true` default.** The setup job previously failed with `mktemp: Read-only file system`; it now runs without relaxing the read-only root, on both SQLite and PostgreSQL.

Note on behavior change: a fresh install no longer yields `admin`/`admin`. Operators using defaults now retrieve the generated password from the `<release>-admin-credentials` Secret (the command is printed in the install notes). Existing releases are unaffected on upgrade, since the credentials Secret is a pre-install hook and is not regenerated.

### Approach

**Admin credentials (`setup.admin`)**
- Removed the `password: "admin"` default (now empty).
- Password resolution order (highest first): `passwordRef` (existing Secret) → inline `password` → generated `<release>-admin-credentials` Secret. The generated Secret is a `pre-install` hook using `randAlphaNum`, with a `lookup` guard so re-renders reuse the existing value (stable across upgrades).
- Username resolution: `usernameRef` (existing Secret) → inline `username` (default `admin`, retained since a username is not a secret).
- Both `usernameRef` and `passwordRef` use `{name, key}` and inject via `secretKeyRef`, so no plaintext appears in the rendered Job manifest. Point them at the same Secret with different keys, or at separate Secrets.
- The generated password is surfaced via `NOTES.txt` with the `kubectl get secret ... | base64 -d` retrieval command (shown only when a password is generated).

**Read-only root filesystem fix**
- Root cause: `setup.sh` creates a scratch file with `mktemp` under `/tmp`, which is on the read-only container root. Certificates, keys, and the Direct Auth Secret already land on writable PVCs, so they were never the problem; the failure was backend independent (SQLite and PostgreSQL both hit it).
- Fix: mount a writable `/tmp` `emptyDir` in both the setup Job and the server Deployment, keeping `readOnlyRootFilesystem: true` (retains Pod Security `restricted` compliance) instead of relaxing it.

**Documentation**
- Rewrote the Helm chart README admin-credentials section (generated / inline / existing-Secret patterns) and updated the parameter table.
- Removed the now-unnecessary `readOnlyRootFilesystem=false` flag from the SQLite and PostgreSQL install commands and deleted the stale note; added admin-password retrieval snippets to the Kubernetes and Get started guides.

### Related Issues
- Refs #4168 (read-only root filesystem; previously handled with a docs-only workaround, now fixed in the chart)

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Helm installations now generate a secure random ThunderID admin password when no explicit password is configured.
  * The generated password is stored in a Kubernetes Secret and reused on upgrades/repeated runs when possible.
  * Admin username and password can be provided independently via Secret references, with documented precedence rules.
  * Helm now mounts writable `/tmp` support while keeping the root filesystem read-only.
* **Documentation**
  * Updated Kubernetes/Helm install guides with Secret-based admin credential retrieval and configuration behavior.
  * Simplified SQLite Helm instructions by removing the prior `readOnlyRootFilesystem` override guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->