### PR TITLE
Default OIDC and Google connections to `openid email profile` scopes

### DIFF
--- a/backend/internal/idp/constants.go
+++ b/backend/internal/idp/constants.go
@@ -39,6 +39,9 @@ const (
 	PropIDJagEnabled          = "id_jag_enabled"
 )
 
+// defaultOIDCScopes is seeded for OIDC and Google connections when no scopes are supplied.
+const defaultOIDCScopes = "openid,email,profile"
+
 // Known endpoints for Google OAuth2/OIDC.
 const (
 	googleAuthorizationEndpoint = "https://accounts.google.com/o/oauth2/v2/auth"

--- a/backend/internal/idp/utils.go
+++ b/backend/internal/idp/utils.go
@@ -400,12 +400,13 @@ func validateIDPProperties(ctx context.Context, idpType providers.IDPType, prope
 	return propertyMapToSlice(filteredPropsMap), nil
 }
 
-// ensureOpenIDScope ensures that the openid scope is present in the scopes property.
+// ensureOpenIDScope ensures that the openid scope is present in the scopes property,
+// defaulting to the standard OIDC scopes (openid, email, profile) when none are supplied.
 func ensureOpenIDScope(ctx context.Context, propertyMap map[string]cmodels.Property,
 	logger *log.Logger) *tidcommon.ServiceError {
 	scopesProp, exists := propertyMap[PropScopes]
 	if !exists {
-		err := createAndAppendProperty(ctx, propertyMap, PropScopes, "openid", false, logger)
+		err := createAndAppendProperty(ctx, propertyMap, PropScopes, defaultOIDCScopes, false, logger)
 		if err != nil {
 			return err
 		}
@@ -431,7 +432,7 @@ func ensureOpenIDScope(ctx context.Context, propertyMap map[string]cmodels.Prope
 	scopes = filteredScopes
 
 	if len(scopes) == 0 {
-		err := createAndAppendProperty(ctx, propertyMap, PropScopes, "openid", false, logger)
+		err := createAndAppendProperty(ctx, propertyMap, PropScopes, defaultOIDCScopes, false, logger)
 		if err != nil {
 			return err
 		}

--- a/backend/internal/idp/utils_test.go
+++ b/backend/internal/idp/utils_test.go
@@ -194,7 +194,7 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_Google_WithDefaults() {
 	s.Equal(googleTokenEndpoint, foundProperties[PropTokenEndpoint])
 	s.Equal(googleUserInfoEndpoint, foundProperties[PropUserInfoEndpoint])
 	s.Equal(googleJwksEndpoint, foundProperties[PropJwksEndpoint])
-	s.Contains(foundProperties[PropScopes], "openid")
+	s.Equal("openid,email,profile", foundProperties[PropScopes])
 }
 
 func (s *IDPUtilsTestSuite) TestValidateIDPProperties_Google_WithCustomEndpoints() {
@@ -352,7 +352,7 @@ func (s *IDPUtilsTestSuite) TestEnsureOpenIDScope_NoExistingScopes() {
 
 	scopesProp := propertyMap[PropScopes]
 	value, _ := scopesProp.GetValue()
-	s.Equal("openid", value)
+	s.Equal("openid,email,profile", value)
 }
 
 func (s *IDPUtilsTestSuite) TestEnsureOpenIDScope_WithExistingScopes() {
@@ -400,7 +400,7 @@ func (s *IDPUtilsTestSuite) TestEnsureOpenIDScope_EmptyScopesValue() {
 
 	scopesProp := propertyMap[PropScopes]
 	value, _ := scopesProp.GetValue()
-	s.Equal("openid", value)
+	s.Equal("openid,email,profile", value)
 }
 
 func (s *IDPUtilsTestSuite) TestValidateIDP_ValidOAuth() {
@@ -566,7 +566,7 @@ func (s *IDPUtilsTestSuite) TestEnsureOpenIDScope_WithWhitespaceScopes() {
 
 	scopesProp := propertyMap[PropScopes]
 	value, _ := scopesProp.GetValue()
-	s.Equal("openid", value)
+	s.Equal("openid,email,profile", value)
 }
 
 func (s *IDPUtilsTestSuite) TestEnsureOpenIDScope_CommaSeparatedScopes() {


### PR DESCRIPTION
### Purpose
Connections created without an explicit `scopes` property only received the bare `openid` scope, even for OIDC and Google. This left the `email` and `profile` claims unavailable until an admin added them manually, even though the docs already describe `openid email profile` as the expected scopes for a Google connection.

### Approach
Default OIDC and Google connections to `openid email profile` when no scopes are supplied, while still only ensuring `openid` is present when the caller provides their own scope list (existing scopes are never force-extended with `email`/`profile`). OAuth and GitHub connections are unaffected, since they don't use OIDC scopes.

### Related Issues
- Fixes #4320

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OIDC and Google connections now default to the standard scopes: `openid,email,profile` when no scopes are provided.
  * Existing custom scopes are preserved, and required scope inclusion behavior is now aligned with the full default scope set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->