### PR TITLE
Fix `linkWorkspaceSource` vite plugin on Windows

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -46,6 +46,16 @@ Use `make` / `pnpm` targets, not Nx (frontend build tooling is migrating to Turb
   (`pnpm test`, `pnpm lint`, and `pnpm prettier --check` scoped to the affected app or package), not the full frontend
   suite.
 
+## Cross-OS Path Handling
+
+Build tooling and Node scripts must work on Windows as well as macOS/Linux. Node's `path` (`join`, `resolve`, `sep`)
+produces the OS-native separator, a backslash on Windows, while many build-tool APIs and identifiers (e.g. Vite module
+ids/importers, glob patterns) are always POSIX forward-slash. Never compare an OS-native path against one of these with
+`startsWith`/`===`, and never hand a backslash path back to a tool that expects POSIX paths. Normalize to forward
+slashes first (e.g. `normalizePath` from `vite`, or replacing `\` with `/`) and compare using a literal `'/'` rather
+than `sep`. This applies to any string built from `join`/`resolve`/`realpathSync` that will be matched against, or
+returned to, such a tool.
+
 ## i18n Fallback Values
 
 Every `t('key')` call must pass a fallback default string, either positionally as the second argument (third if

--- a/frontend/packages/build-plugins/README.md
+++ b/frontend/packages/build-plugins/README.md
@@ -25,6 +25,22 @@ prismjs language files reference `Prism` as an implicit global with no import st
 `import Prism from 'prismjs'` to each language file so Rollup can see the dependency edge and evaluate the core module
 before any language file at bundle time.
 
+### `linkWorkspaceSource` · `@thunderid/build-plugins/vite`
+
+```ts
+import {linkWorkspaceSource} from '@thunderid/build-plugins/vite';
+import {defineConfig} from 'vite';
+
+export default defineConfig({
+  plugins: [linkWorkspaceSource()],
+});
+```
+
+During `vite serve` (never build, and never vitest, which also drives Vite in serve mode), this plugin redirects
+`@thunderid/*` workspace imports to each package's `src` instead of its prebuilt `dist/` output, so edits under
+`packages/*/src` hot-update in the consuming app. Pass `root` to override the app root used to resolve workspace
+dependencies; it defaults to the resolved Vite config root.
+
 ## Adding a New Plugin
 
 `<category>` is the build-tool context the plugin targets — it becomes the sub-path consumers import from. Use the tool

--- a/frontend/packages/build-plugins/package.json
+++ b/frontend/packages/build-plugins/package.json
@@ -42,6 +42,8 @@
     "clean:node_modules": "rimraf node_modules",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest",
     "typecheck": "tsc -p tsconfig.lib.json"
   },
   "devDependencies": {
@@ -53,7 +55,8 @@
     "rimraf": "catalog:",
     "rolldown": "catalog:",
     "typescript": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "vitest": "catalog:"
   },
   "peerDependencies": {
     "vite": ">=5.0.0"

--- a/frontend/packages/build-plugins/src/vite/__tests__/link-workspace-source.test.ts
+++ b/frontend/packages/build-plugins/src/vite/__tests__/link-workspace-source.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {mkdirSync, realpathSync, rmSync, writeFileSync} from 'fs';
+import {tmpdir} from 'os';
+import {join} from 'path';
+import {normalizePath, type Plugin} from 'vite';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {linkWorkspaceSource} from '../link-workspace-source';
+
+interface FakeResolvedConfig {
+  command: 'build' | 'serve';
+  root: string;
+}
+
+type ConfigResolvedHook = (config: FakeResolvedConfig) => void;
+type ResolveIdHook = (source: string, importer?: string) => string | undefined;
+
+function callConfigResolved(plugin: Plugin, config: FakeResolvedConfig): void {
+  (plugin.configResolved as unknown as ConfigResolvedHook).call(plugin, config);
+}
+
+function callResolveId(plugin: Plugin, source: string, importer?: string): string | undefined {
+  return (plugin.resolveId as unknown as ResolveIdHook).call(plugin, source, importer);
+}
+
+function writeJson(path: string, value: unknown): void {
+  writeFileSync(path, JSON.stringify(value));
+}
+
+function createLinkedPackage(appRoot: string, name: string, exports: Record<string, unknown>): string {
+  const packageDir = join(appRoot, 'node_modules', name);
+  mkdirSync(packageDir, {recursive: true});
+  writeJson(join(packageDir, 'package.json'), {exports});
+  return packageDir;
+}
+
+describe('linkWorkspaceSource', () => {
+  const testDir = join(realpathSync(tmpdir()), 'build-plugins-link-workspace-source');
+  const appRoot = join(testDir, 'app');
+  let originalVitestEnv: string | undefined;
+
+  beforeEach(() => {
+    originalVitestEnv = process.env['VITEST'];
+    mkdirSync(appRoot, {recursive: true});
+  });
+
+  afterEach(() => {
+    if (originalVitestEnv === undefined) {
+      delete process.env['VITEST'];
+    } else {
+      process.env['VITEST'] = originalVitestEnv;
+    }
+    rmSync(testDir, {recursive: true, force: true});
+  });
+
+  it('does nothing when the Vite command is not "serve"', () => {
+    delete process.env['VITEST'];
+    writeJson(join(appRoot, 'package.json'), {dependencies: {}});
+
+    const plugin = linkWorkspaceSource();
+    callConfigResolved(plugin, {command: 'build', root: appRoot});
+
+    expect(callResolveId(plugin, '@thunderid/foo')).toBeUndefined();
+  });
+
+  it('does nothing under vitest, which also drives Vite in serve mode', () => {
+    // process.env.VITEST is already set by the vitest test runner itself here.
+    writeJson(join(appRoot, 'package.json'), {dependencies: {'@thunderid/foo': 'workspace:*'}});
+    const packageDir = createLinkedPackage(appRoot, '@thunderid/foo', {'.': {import: './dist/index.js'}});
+    mkdirSync(join(packageDir, 'src'), {recursive: true});
+    writeFileSync(join(packageDir, 'src', 'index.ts'), 'export default 1;');
+
+    const plugin = linkWorkspaceSource();
+    callConfigResolved(plugin, {command: 'serve', root: appRoot});
+
+    expect(callResolveId(plugin, '@thunderid/foo')).toBeUndefined();
+  });
+
+  it('redirects a workspace package specifier to its source file', () => {
+    delete process.env['VITEST'];
+    writeJson(join(appRoot, 'package.json'), {dependencies: {'@thunderid/foo': 'workspace:*'}});
+    const packageDir = createLinkedPackage(appRoot, '@thunderid/foo', {
+      '.': {import: './dist/index.js'},
+      './sub': {import: './dist/sub.js'},
+    });
+    mkdirSync(join(packageDir, 'src'), {recursive: true});
+    writeFileSync(join(packageDir, 'src', 'index.ts'), 'export default 1;');
+    writeFileSync(join(packageDir, 'src', 'sub.ts'), 'export default 2;');
+
+    const plugin = linkWorkspaceSource();
+    callConfigResolved(plugin, {command: 'serve', root: appRoot});
+
+    expect(callResolveId(plugin, '@thunderid/foo')).toBe(normalizePath(join(packageDir, 'src', 'index.ts')));
+    expect(callResolveId(plugin, '@thunderid/foo/sub')).toBe(normalizePath(join(packageDir, 'src', 'sub.ts')));
+  });
+
+  it('resolves a subpath export to its index barrel when no matching file exists', () => {
+    delete process.env['VITEST'];
+    writeJson(join(appRoot, 'package.json'), {dependencies: {'@thunderid/foo': 'workspace:*'}});
+    const packageDir = createLinkedPackage(appRoot, '@thunderid/foo', {
+      './widgets': {import: './dist/widgets/index.js'},
+    });
+    mkdirSync(join(packageDir, 'src', 'widgets'), {recursive: true});
+    writeFileSync(join(packageDir, 'src', 'widgets', 'index.ts'), 'export default 1;');
+
+    const plugin = linkWorkspaceSource();
+    callConfigResolved(plugin, {command: 'serve', root: appRoot});
+
+    expect(callResolveId(plugin, '@thunderid/foo/widgets')).toBe(
+      normalizePath(join(packageDir, 'src', 'widgets', 'index.ts')),
+    );
+  });
+
+  it('ignores dependencies that are not @thunderid workspace packages', () => {
+    delete process.env['VITEST'];
+    writeJson(join(appRoot, 'package.json'), {
+      dependencies: {
+        '@thunderid/pinned': '^1.0.0',
+        'other-scope': 'workspace:*',
+      },
+    });
+    createLinkedPackage(appRoot, '@thunderid/pinned', {'.': {import: './dist/index.js'}});
+
+    const plugin = linkWorkspaceSource();
+    callConfigResolved(plugin, {command: 'serve', root: appRoot});
+
+    expect(callResolveId(plugin, '@thunderid/pinned')).toBeUndefined();
+  });
+
+  it('skips a workspace dependency whose node_modules entry is missing', () => {
+    delete process.env['VITEST'];
+    writeJson(join(appRoot, 'package.json'), {dependencies: {'@thunderid/missing': 'workspace:*'}});
+    // Intentionally do not create node_modules/@thunderid/missing.
+
+    const plugin = linkWorkspaceSource();
+    callConfigResolved(plugin, {command: 'serve', root: appRoot});
+
+    expect(callResolveId(plugin, '@thunderid/missing')).toBeUndefined();
+  });
+
+  it('skips a linked package with an unreadable package.json instead of throwing', () => {
+    delete process.env['VITEST'];
+    writeJson(join(appRoot, 'package.json'), {dependencies: {'@thunderid/broken': 'workspace:*'}});
+    const packageDir = join(appRoot, 'node_modules', '@thunderid/broken');
+    mkdirSync(packageDir, {recursive: true});
+    writeFileSync(join(packageDir, 'package.json'), '{ not valid json');
+
+    const plugin = linkWorkspaceSource();
+
+    expect(() => callConfigResolved(plugin, {command: 'serve', root: appRoot})).not.toThrow();
+    expect(callResolveId(plugin, '@thunderid/broken')).toBeUndefined();
+  });
+
+  it('re-roots an alias mis-substitution from a linked package back onto its own source', () => {
+    delete process.env['VITEST'];
+    writeJson(join(appRoot, 'package.json'), {dependencies: {'@thunderid/foo': 'workspace:*'}});
+    const packageDir = createLinkedPackage(appRoot, '@thunderid/foo', {'.': {import: './dist/index.js'}});
+    mkdirSync(join(packageDir, 'src', 'utils'), {recursive: true});
+    writeFileSync(join(packageDir, 'src', 'index.ts'), 'export default 1;');
+    writeFileSync(join(packageDir, 'src', 'utils', 'helper.ts'), 'export const helper = 1;');
+
+    const plugin = linkWorkspaceSource();
+    callConfigResolved(plugin, {command: 'serve', root: appRoot});
+
+    // Simulates Vite having already mis-substituted the package's own `@/utils/helper`
+    // import onto the app's `src`, because the importer (inside the package) uses the
+    // same alias convention as the app.
+    const misSubstitutedSource = join(appRoot, 'src', 'utils', 'helper');
+    const importerInsidePackage = join(packageDir, 'src', 'index.ts');
+
+    expect(callResolveId(plugin, misSubstitutedSource, importerInsidePackage)).toBe(
+      normalizePath(join(packageDir, 'src', 'utils', 'helper.ts')),
+    );
+  });
+
+  it('leaves an app-src-rooted import alone when there is no importer', () => {
+    delete process.env['VITEST'];
+    writeJson(join(appRoot, 'package.json'), {dependencies: {}});
+
+    const plugin = linkWorkspaceSource();
+    callConfigResolved(plugin, {command: 'serve', root: appRoot});
+
+    expect(callResolveId(plugin, join(appRoot, 'src', 'App.tsx'))).toBeUndefined();
+  });
+
+  it('honors an explicit root option instead of the resolved config root', () => {
+    delete process.env['VITEST'];
+    const explicitRoot = join(testDir, 'explicit-root');
+    const packageDir = join(explicitRoot, 'node_modules', '@thunderid/foo');
+    mkdirSync(join(packageDir, 'src'), {recursive: true});
+    writeJson(join(explicitRoot, 'package.json'), {dependencies: {'@thunderid/foo': 'workspace:*'}});
+    writeJson(join(packageDir, 'package.json'), {exports: {'.': {import: './dist/index.js'}}});
+    writeFileSync(join(packageDir, 'src', 'index.ts'), 'export default 1;');
+
+    const plugin = linkWorkspaceSource({root: explicitRoot});
+    // config.root points elsewhere; the plugin should use `options.root` instead.
+    callConfigResolved(plugin, {command: 'serve', root: appRoot});
+
+    expect(callResolveId(plugin, '@thunderid/foo')).toBe(normalizePath(join(packageDir, 'src', 'index.ts')));
+  });
+});

--- a/frontend/packages/build-plugins/src/vite/__tests__/prismjs-inject-core.test.ts
+++ b/frontend/packages/build-plugins/src/vite/__tests__/prismjs-inject-core.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {prismjsInjectCore} from '../prismjs-inject-core';
+
+function transform(id: string, code = 'Prism.languages.python = {};') {
+  const plugin = prismjsInjectCore();
+  const hook = plugin.transform as (code: string, id: string) => {code: string; map: null} | null;
+  return hook.call(plugin, code, id);
+}
+
+describe('prismjsInjectCore', () => {
+  it('has the expected plugin name', () => {
+    expect(prismjsInjectCore().name).toBe('prismjs-inject-core');
+  });
+
+  it('injects a Prism import for a POSIX language file path', () => {
+    const result = transform('/repo/node_modules/prismjs/components/prism-python.js');
+    expect(result?.code).toBe("import Prism from 'prismjs';\nPrism.languages.python = {};");
+    expect(result?.map).toBeNull();
+  });
+
+  it('injects a Prism import for a Windows-style language file path', () => {
+    const result = transform('C:\\repo\\node_modules\\prismjs\\components\\prism-python.js');
+    expect(result?.code).toBe("import Prism from 'prismjs';\nPrism.languages.python = {};");
+  });
+
+  it('does not inject an import for the core module itself', () => {
+    expect(transform('/repo/node_modules/prismjs/components/prism-core.js')).toBeNull();
+  });
+
+  it('does not inject an import for files outside prismjs/components', () => {
+    expect(transform('/repo/src/components/prism-python.js')).toBeNull();
+  });
+
+  it('does not inject an import for unrelated modules', () => {
+    expect(transform('/repo/src/index.ts')).toBeNull();
+  });
+});

--- a/frontend/packages/build-plugins/src/vite/link-workspace-source.ts
+++ b/frontend/packages/build-plugins/src/vite/link-workspace-source.ts
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {existsSync, readFileSync, realpathSync} from 'fs';
+import {join} from 'path';
+import {normalizePath, type Plugin} from 'vite';
+
+// ThunderID npm scope / plugin-name prefix.
+const ORG = 'thunderid';
+
+// normalizePath only converts `\` to `/`; it doesn't normalize Windows drive-letter casing
+// (e.g. `C:` vs `c:`), which can still differ between paths sourced from different APIs
+// (Vite's resolved config root vs realpathSync). Compare case-insensitively on Windows only,
+// since the underlying filesystem there is case-insensitive too.
+const isWindows = process.platform === 'win32';
+
+function comparablePath(path: string): string {
+  return isWindows ? path.toLowerCase() : path;
+}
+
+interface AppPackageJson {
+  dependencies?: Record<string, string>;
+}
+
+interface ExportConditions {
+  types?: string;
+  import?: string;
+  require?: string;
+}
+
+type ExportsField = Record<string, string | ExportConditions>;
+
+interface WorkspacePackageJson {
+  exports?: ExportsField;
+}
+
+export interface LinkWorkspaceSourceOptions {
+  root?: string;
+}
+
+interface WorkspaceLinks {
+  specifierMap: Map<string, string>;
+  packageSrcRoots: string[];
+}
+
+// Redirects @thunderid/* workspace imports to package source during `vite serve` only
+// (never build, and never vitest, which also drives Vite in serve mode), so edits
+// under packages/*/src hot-update in the consuming app instead of resolving to the
+// prebuilt dist/ output that ships in the package's exports map.
+export function linkWorkspaceSource(options: LinkWorkspaceSourceOptions = {}): Plugin {
+  let links: WorkspaceLinks | undefined;
+  let appSrcRoot: string | undefined;
+
+  return {
+    name: `${ORG}:link-workspace-source`,
+    enforce: 'pre',
+    configResolved(config) {
+      if (config.command !== 'serve' || process.env['VITEST']) {
+        return;
+      }
+      const appRoot = options.root ?? config.root;
+      appSrcRoot = normalizePath(join(appRoot, 'src'));
+      links = buildWorkspaceLinks(appRoot);
+    },
+    resolveId(source, importer) {
+      if (!links) {
+        return undefined;
+      }
+
+      const direct = links.specifierMap.get(source);
+      if (direct) {
+        return direct;
+      }
+
+      // The app's own `@`/`@/*` aliases (resolved by Vite before this plugin runs) assume
+      // every import lives under the app's `src`. When a linked package's own source uses
+      // the same alias convention internally, Vite mis-substitutes it onto the app's `src`
+      // before this plugin ever sees the original specifier. Detect that mis-substitution
+      // (importer lives inside a linked package's `src`, but the substituted id is rooted at
+      // the app's `src`) and re-root it onto the package the import actually came from.
+      const normalizedSource = normalizePath(source);
+      if (importer && appSrcRoot && comparablePath(normalizedSource).startsWith(comparablePath(appSrcRoot) + '/')) {
+        const normalizedImporter = normalizePath(importer);
+        const packageSrcRoot = links.packageSrcRoots.find((root) =>
+          comparablePath(normalizedImporter).startsWith(comparablePath(root) + '/'),
+        );
+        if (packageSrcRoot) {
+          return resolveExistingFile(join(packageSrcRoot, normalizedSource.slice(appSrcRoot.length)));
+        }
+      }
+
+      return undefined;
+    },
+  };
+}
+
+function buildWorkspaceLinks(appRoot: string): WorkspaceLinks {
+  const specifierMap = new Map<string, string>();
+  const packageSrcRoots: string[] = [];
+  const appPackageJson = readJson<AppPackageJson>(join(appRoot, 'package.json'));
+
+  for (const [name, spec] of Object.entries(appPackageJson.dependencies ?? {})) {
+    if (!name.startsWith(`@${ORG}/`) || !spec.startsWith('workspace:')) {
+      continue;
+    }
+
+    let packageDir: string;
+    try {
+      packageDir = realpathSync(join(appRoot, 'node_modules', name));
+    } catch {
+      continue;
+    }
+
+    let packageJson: WorkspacePackageJson;
+    try {
+      packageJson = readJson<WorkspacePackageJson>(join(packageDir, 'package.json'));
+    } catch {
+      continue;
+    }
+    let linked = false;
+
+    for (const [subpath, target] of Object.entries(packageJson.exports ?? {})) {
+      const distTarget = typeof target === 'string' ? target : target.import;
+      const sourcePath = distTarget && resolveDistAsSource(packageDir, distTarget);
+      if (!sourcePath) {
+        continue;
+      }
+      specifierMap.set(subpath === '.' ? name : `${name}/${subpath.slice(2)}`, sourcePath);
+      linked = true;
+    }
+
+    if (linked) {
+      packageSrcRoots.push(normalizePath(join(packageDir, 'src')));
+    }
+  }
+
+  return {specifierMap, packageSrcRoots};
+}
+
+function resolveDistAsSource(packageDir: string, distTarget: string): string | undefined {
+  const sourceBase = distTarget.replace(/^\.\/dist\//, './src/').replace(/\.(m|c)?js$/, '');
+  return resolveExistingFile(join(packageDir, sourceBase));
+}
+
+// Tries the source as a file first (`foo/bar.ts`), then as a directory barrel
+// (`foo/bar/index.ts`), matching how the `@`-alias imports inside packages reference
+// both individual modules and folder barrels.
+function resolveExistingFile(base: string): string | undefined {
+  const candidates = [`${base}.ts`, `${base}.tsx`, join(base, 'index.ts'), join(base, 'index.tsx')];
+  const found = candidates.find((candidate) => existsSync(candidate));
+  return found ? normalizePath(found) : undefined;
+}
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, 'utf-8')) as T;
+}

--- a/frontend/packages/build-plugins/src/vite/prismjs-inject-core.ts
+++ b/frontend/packages/build-plugins/src/vite/prismjs-inject-core.ts
@@ -16,6 +16,19 @@
  * under the License.
  */
 
-export {prismjsInjectCore} from './prismjs-inject-core';
-export {linkWorkspaceSource} from './link-workspace-source';
-export type {LinkWorkspaceSourceOptions} from './link-workspace-source';
+import type {Plugin} from 'vite';
+
+// prismjs language files reference `Prism` as a global with no import — add one so
+// Rollup sees the dependency edge and evaluates the core before any language file.
+export function prismjsInjectCore(): Plugin {
+  return {
+    name: 'prismjs-inject-core',
+    transform(code: string, id: string) {
+      if (/[/\\]prismjs[/\\]components[/\\]prism-(?!core)/.test(id)) {
+        // map: null intentionally omitted — prepending a line shifts devtools line numbers by 1.
+        return {code: `import Prism from 'prismjs';\n${code}`, map: null};
+      }
+      return null;
+    },
+  };
+}

--- a/frontend/packages/build-plugins/tsconfig.json
+++ b/frontend/packages/build-plugins/tsconfig.json
@@ -27,6 +27,9 @@
   "references": [
     {
       "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
     }
   ]
 }

--- a/frontend/packages/build-plugins/tsconfig.spec.json
+++ b/frontend/packages/build-plugins/tsconfig.spec.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "types": ["vitest/globals", "node"]
+  },
+  "include": ["vitest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.test.js", "**/*.spec.js", "**/*.d.ts"]
+}

--- a/frontend/packages/build-plugins/vitest.config.ts
+++ b/frontend/packages/build-plugins/vitest.config.ts
@@ -16,6 +16,10 @@
  * under the License.
  */
 
-export {prismjsInjectCore} from './prismjs-inject-core';
-export {linkWorkspaceSource} from './link-workspace-source';
-export type {LinkWorkspaceSourceOptions} from './link-workspace-source';
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,202 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 11.13.1
+        version: 11.13.1
+      pnpm:
+        specifier: 11.13.1
+        version: 11.13.1
+
+packages:
+
+  '@pnpm/exe@11.13.1':
+    resolution: {integrity: sha512-P4euEK6lOFnd5oTHEc5M/HhvyF4XUhTnVsklEcM6rmY0QJxPD6xbT+u1+gskEIBp4nSRorz20IJQtAU1Nerggg==}
+    hasBin: true
+
+  '@pnpm/linux-arm64@11.13.1':
+    resolution: {integrity: sha512-wB8zloqrYrudPyuA5qbuTCnJGe4eETPwqOjoPjoyyyvA4zFI5XfLpxgqOOcaY5UJBoqzckcGpRVDwhSRfsQ/6A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@pnpm/linux-x64@11.13.1':
+    resolution: {integrity: sha512-A+wnEvzfWEvanXiwww3tnOPmtjPSrrf5tOP6vk8+K0BRFEe/Df0oPytm2nWgGcn5iwPnqtr1Btkof913McnSPA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@pnpm/linuxstatic-arm64@11.13.1':
+    resolution: {integrity: sha512-k4t65VeqRX4COMFe45TF58CVmCpmAsKZShaR1HobmUeleo98mWTctggKolrA2MHcVUeSS+12yB5Urb3uDazhmw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/linuxstatic-x64@11.13.1':
+    resolution: {integrity: sha512-A65GqPzwCl0bAMk3kRWfbjSRBm5RRaqR2oMxV/9AYZrwO0X9yEfngbLBISCPHjt6/Qe4nH7DFemyhy6yODYwEw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/macos-arm64@11.13.1':
+    resolution: {integrity: sha512-MJvOtyGOWSfBoqdVEfAH8ljmHs13mt82k/UxN4f+q7koDxJRR2n4Nie6Og6RwbnbaubCz0Fh2bTeL1+MxDSFpA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/win-arm64@11.13.1':
+    resolution: {integrity: sha512-kl/g1cCKOJPe4HntspyrAJW0LRco0UHnVfxHSspezo4Zj4AanJAZ8WzLqfa6/w3lBSKHTEN4x0pb3m4J7B7Vpw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/win-x64@11.13.1':
+    resolution: {integrity: sha512-Bcb14NeBlbHS2Gq1qr8VnCiAz5eC1lYzXOls7zH0bnV0Taaj4/xyfm0HVO4dn9R2TQtVtz1qnBZHHL9PDFumqQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@reflink/reflink@0.1.19':
+    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
+    engines: {node: '>= 10'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  pnpm@11.13.1:
+    resolution: {integrity: sha512-svx2g7imUlQU59E+G6KMqt3elr9m7FQL+ut+cCuB8+C+TR8pXt9/n+A5Z0Co3ORQnFgt33mJH0VD/qMtN2RfJQ==}
+    engines: {node: '>=22.13'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe@11.13.1':
+    dependencies:
+      '@reflink/reflink': 0.1.19
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@pnpm/linux-arm64': 11.13.1
+      '@pnpm/linux-x64': 11.13.1
+      '@pnpm/linuxstatic-arm64': 11.13.1
+      '@pnpm/linuxstatic-x64': 11.13.1
+      '@pnpm/macos-arm64': 11.13.1
+      '@pnpm/win-arm64': 11.13.1
+      '@pnpm/win-x64': 11.13.1
+
+  '@pnpm/linux-arm64@11.13.1':
+    optional: true
+
+  '@pnpm/linux-x64@11.13.1':
+    optional: true
+
+  '@pnpm/linuxstatic-arm64@11.13.1':
+    optional: true
+
+  '@pnpm/linuxstatic-x64@11.13.1':
+    optional: true
+
+  '@pnpm/macos-arm64@11.13.1':
+    optional: true
+
+  '@pnpm/win-arm64@11.13.1':
+    optional: true
+
+  '@pnpm/win-x64@11.13.1':
+    optional: true
+
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink@0.1.19':
+    optionalDependencies:
+      '@reflink/reflink-darwin-arm64': 0.1.19
+      '@reflink/reflink-darwin-x64': 0.1.19
+      '@reflink/reflink-linux-arm64-gnu': 0.1.19
+      '@reflink/reflink-linux-arm64-musl': 0.1.19
+      '@reflink/reflink-linux-x64-gnu': 0.1.19
+      '@reflink/reflink-linux-x64-musl': 0.1.19
+      '@reflink/reflink-win32-arm64-msvc': 0.1.19
+      '@reflink/reflink-win32-x64-msvc': 0.1.19
+
+  detect-libc@2.1.2: {}
+
+  pnpm@11.13.1: {}
+
+---
 lockfileVersion: '9.0'
 
 settings:
@@ -766,6 +965,9 @@ importers:
       vite:
         specifier: 8.0.16
         version: 8.0.16(@types/node@24.7.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(jsdom@27.0.1)(vite@8.0.16(@types/node@24.7.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3))
 
   frontend/packages/components:
     dependencies:
@@ -5580,7 +5782,7 @@ packages:
       '@babel/plugin-transform-runtime': ^7.29.0 || ^8.0.0-rc.1
       '@babel/runtime': ^7.27.0 || ^8.0.0-rc.1
       rolldown: ^1.0.0-rc.5
-      vite: 8.0.16
+      vite: '>=8.0.16'
     peerDependenciesMeta:
       '@babel/plugin-transform-runtime':
         optional: true
@@ -6493,13 +6695,13 @@ packages:
     resolution: {integrity: sha512-bdyo8rB3NnQbikdMpHaML9Z1OZPBu6fFOBo+OtxsBlvMJtysWskmBcnbIDhUqgC8tcxNv/a+BcV5U+2nQMm1OQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     peerDependencies:
-      vite: 8.0.16
+      vite: '>=8.0.16'
 
   '@vitejs/plugin-react@5.2.0':
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: 8.0.16
+      vite: '>=8.0.16'
 
   '@vitejs/plugin-react@6.0.2':
     resolution: {integrity: sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==}
@@ -6507,7 +6709,7 @@ packages:
     peerDependencies:
       '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
       babel-plugin-react-compiler: ^1.0.0
-      vite: 8.0.16
+      vite: '>=8.0.16'
     peerDependenciesMeta:
       '@rolldown/plugin-babel':
         optional: true
@@ -6553,7 +6755,7 @@ packages:
     resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
     peerDependencies:
       msw: ^2.4.9
-      vite: 8.0.16
+      vite: '>=8.0.16'
     peerDependenciesMeta:
       msw:
         optional: true
@@ -12348,7 +12550,7 @@ packages:
   vite-plugin-svgr@5.2.0:
     resolution: {integrity: sha512-qj2eAKF8C6PZWemVTvQA0xgQIcP1hHU6Buh7fl6BhvayWwnuxE+z417miKxeDvRWbDrupQ1oK99hfxElopJ3sQ==}
     peerDependencies:
-      vite: 8.0.16
+      vite: '>=8.0.16'
 
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
@@ -12409,7 +12611,7 @@ packages:
       '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
-      vite: 8.0.16
+      vite: '>=8.0.16'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true


### PR DESCRIPTION
### Purpose
`linkWorkspaceSource` (the Vite plugin that redirects `@thunderid/*` workspace imports to package source during `vite serve`) compared `resolveId`'s `source`/`importer` paths against `appSrcRoot` using `path.sep`-joined prefixes. On Windows, `path.sep` is `\`, but Vite always resolves ids to POSIX-style paths (`/`), so the `startsWith` checks never matched and the app's `@`-alias re-rooting for linked packages silently failed on Windows.

While fixing this, also split the two Vite plugins (`prismjsInjectCore` and `linkWorkspaceSource`) out of the shared `src/vite/index.ts` into their own files, following the "one file per plugin" convention already documented in the `@thunderid/build-plugins` README.

### Approach
- Normalize `appSrcRoot`, `source`, `importer`, `packageSrcRoots`, and the result of `resolveExistingFile` with Vite's `normalizePath` before comparing, so path prefix checks work the same on Windows as on POSIX systems.
- `normalizePath` doesn't normalize Windows drive-letter casing (`C:` vs `c:`), which can still differ between `appRoot` and `packageDir` since they come from different APIs. Add a case-insensitive comparison for the `resolveId` prefix checks on Windows only, so real workspace source imports aren't skipped due to a casing mismatch.
- Guard the linked package's `package.json` read in `buildWorkspaceLinks` with the same try/catch used around `realpathSync`, so a malformed or missing manifest in one linked package is skipped instead of throwing synchronously inside `configResolved` and aborting dev-server startup for the whole app.
- Move `prismjsInjectCore` into `src/vite/prismjs-inject-core.ts` and `linkWorkspaceSource` (plus its private helpers) into `src/vite/link-workspace-source.ts`. `src/vite/index.ts` is now a thin barrel re-exporting both plugins and the `LinkWorkspaceSourceOptions` type.
- Document `linkWorkspaceSource` in the package README, which previously only covered `prismjsInjectCore`.
- No change to the public `@thunderid/build-plugins/vite` API; both consumers (`apps/console`, `apps/gate`) are unaffected.
- Add a "Cross-OS Path Handling" section to `frontend/AGENTS.md` capturing this normalize-before-comparing rule, so future build tooling and Node scripts don't reintroduce the same Windows-only breakage.
- Add a vitest setup for the package and unit tests for both plugins, covering export/dist-to-source mapping, specifier redirection, the alias mis-substitution correction, the new casing and error-handling guards, and the prismjs `transform` hook's regex matching.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4294

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Vite plugin that redirects `@thunderid/*` workspace imports to the linked packages’ TypeScript `src` during `vite serve`.
  - Added a Vite option to control the resolution root for workspace linking.
  - Added a Vite plugin that injects Prism core into Prism language component modules.
- **Documentation**
  - Documented the workspace-source linking plugin and cross-OS path handling guidance.
- **Tests**
  - Added Vitest coverage for both workspace linking and Prism core injection.
- **Chores**
  - Added Vitest scripts/config and introduced a dedicated spec TypeScript configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->