### PR TITLE
Wrap WebAuthn library errors and log their category server-side

### DIFF
--- a/backend/internal/authn/passkey/service.go
+++ b/backend/internal/authn/passkey/service.go
@@ -255,7 +255,7 @@ func (w *passkeyService) FinishRegistration(ctx context.Context, req *PasskeyReg
 	// Verify the credential using WebAuthn service
 	credential, err := webAuthnService.CreateCredential(webAuthnUser, *sessionData, parsedCredential)
 	if err != nil {
-		logger.Error(ctx, "Failed to verify and create credential", log.String("error", err.Error()))
+		logger.Error(ctx, "Failed to verify and create credential", webAuthnErrorFields(err)...)
 		return nil, &ErrorInvalidAttestationResponse
 	}
 
@@ -478,14 +478,14 @@ func (w *passkeyService) FinishAuthentication(ctx context.Context, req *PasskeyA
 
 		_, credential, err = webAuthnService.ValidatePasskeyLogin(userHandler, *sessionData, parsedResponse)
 		if err != nil {
-			logger.Debug(ctx, "Failed to validate passkey assertion", log.String("error", err.Error()))
+			logger.Debug(ctx, "Failed to validate passkey assertion", webAuthnErrorFields(err)...)
 			return nil, &ErrorInvalidSignature
 		}
 	} else {
 		// Username-based flow: Use ValidateLogin with specific user
 		credential, err = webAuthnService.ValidateLogin(webAuthnUser, *sessionData, parsedResponse)
 		if err != nil {
-			logger.Debug(ctx, "Failed to validate WebAuthn assertion", log.String("error", err.Error()))
+			logger.Debug(ctx, "Failed to validate WebAuthn assertion", webAuthnErrorFields(err)...)
 			return nil, &ErrorInvalidSignature
 		}
 	}

--- a/backend/internal/authn/passkey/webauthn_error_fields_test.go
+++ b/backend/internal/authn/passkey/webauthn_error_fields_test.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package passkey
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-webauthn/webauthn/protocol"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/thunder-id/thunderid/internal/system/log"
+)
+
+// fieldMap collapses the log fields into a map keyed by field name for easy assertions.
+func fieldMap(fields []log.Field) map[string]interface{} {
+	m := make(map[string]interface{}, len(fields))
+	for _, f := range fields {
+		m[f.Key] = f.Value
+	}
+	return m
+}
+
+// TestWebAuthnErrorFields_ProtocolError verifies that a go-webauthn protocol error is broken
+// down into its category, detail and debug info for server-side logging.
+func TestWebAuthnErrorFields_ProtocolError(t *testing.T) {
+	libErr := protocol.ErrVerification.
+		WithDetails("stored challenge and received challenge do not match").
+		WithInfo("origin mismatch debug info")
+
+	fields := fieldMap(webAuthnErrorFields(libErr))
+
+	assert.Equal(t, "verification_error", fields["webAuthnErrorType"])
+	assert.Equal(t, "stored challenge and received challenge do not match", fields["webAuthnErrorDetail"])
+	assert.Equal(t, "origin mismatch debug info", fields["webAuthnErrorDebug"])
+	// A plain "error" field must not be used for protocol errors; the detail is structured.
+	_, hasPlainError := fields["error"]
+	assert.False(t, hasPlainError)
+}
+
+// TestWebAuthnErrorFields_WrappedProtocolError verifies a protocol error wrapped with
+// fmt.Errorf is still recognized through errors.As.
+func TestWebAuthnErrorFields_WrappedProtocolError(t *testing.T) {
+	wrapped := fmt.Errorf("failed to validate assertion: %w", protocol.ErrAssertionSignature)
+
+	fields := fieldMap(webAuthnErrorFields(wrapped))
+
+	assert.Equal(t, "invalid_signature", fields["webAuthnErrorType"])
+}
+
+// TestWebAuthnErrorFields_NonProtocolError verifies non-protocol errors fall back to a single
+// error field carrying the message.
+func TestWebAuthnErrorFields_NonProtocolError(t *testing.T) {
+	fields := fieldMap(webAuthnErrorFields(errors.New("some plain error")))
+
+	assert.Equal(t, "some plain error", fields["error"])
+	_, hasType := fields["webAuthnErrorType"]
+	assert.False(t, hasType)
+}

--- a/backend/internal/authn/passkey/webauthn_service.go
+++ b/backend/internal/authn/passkey/webauthn_service.go
@@ -21,10 +21,13 @@ package passkey
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
+
+	"github.com/thunder-id/thunderid/internal/system/log"
 )
 
 // Wrapper types to abstract the underlying WebAuthn library.
@@ -365,4 +368,21 @@ func parseAttestationResponse(
 	}
 
 	return parsed, nil
+}
+
+// webAuthnErrorFields returns structured log fields describing an error returned by the
+// underlying WebAuthn library. When the error is a go-webauthn protocol.Error, its category,
+// detail and debug info are captured as separate fields so that failures can be diagnosed
+// server-side. Callers log these fields but always return a generic internal ServiceError to
+// clients, so that library-specific details are never exposed externally.
+func webAuthnErrorFields(err error) []log.Field {
+	var protoErr *protocol.Error
+	if errors.As(err, &protoErr) {
+		return []log.Field{
+			log.String("webAuthnErrorType", protoErr.Type),
+			log.String("webAuthnErrorDetail", protoErr.Details),
+			log.String("webAuthnErrorDebug", protoErr.DevInfo),
+		}
+	}
+	return []log.Field{log.String("error", err.Error())}
 }


### PR DESCRIPTION
### Purpose
Keep library-specific details generated by the underlying `go-webauthn` library from reaching external clients, while making WebAuthn verification failures debuggable server-side. Refs thunder-id/thunderid#1647.

The passkey service already returned generic internal `PSK` codes to clients for verification failures (no library string ever reached a client). What was missing was **structured, debuggable server-side detail** about *why* the library rejected a ceremony.

### Approach
- Added a small `webAuthnErrorFields(err)` helper in `webauthn_service.go` (the layer that already abstracts the WebAuthn library, so library-specific knowledge stays in one place). When the error is a `protocol.Error` it logs the category, detail and debug info as separate fields (recognized through wrapped errors via `errors.As`); otherwise it logs the plain message.
- Used it at the three library verification sites (`CreateCredential`, `ValidateLogin`, `ValidatePasskeyLogin`), which continue to return the existing generic `PSK` codes to clients.
- Added unit tests for the helper.

**Why not a per-category error taxonomy?** An earlier revision mapped each library error category to a distinct client-facing code. That was dropped deliberately: exposing exactly *why* an authentication ceremony failed (challenge vs. signature vs. origin) is a verification oracle, and hardened WebAuthn implementations return a single generic failure to the client with the specifics kept in server logs. This revision does exactly that, with far less code and no new API surface.

### Evidence (local)
Real registration verification failure (origin mismatch fixture):
```
level=ERROR msg="Failed to verify and create credential" component=PasskeyService \
  webAuthnErrorType=verification_error \
  webAuthnErrorDetail="Error validating origin" \
  webAuthnErrorDebug="Expected Values: [https://localhost:8090], Received: https://webauthn.io"
```
The caller receives generic `PSK-1011` (invalid attestation response); no library detail is exposed. All passkey/authn/flow tests pass, `golangci-lint` reports 0 issues, i18n catalog unchanged from baseline.

### Related Issues
- thunder-id/thunderid#1647

### Checklist
- [x] Followed the contribution guidelines.
- [x] Tests provided.
    - [x] Unit Tests (`webauthn_error_fields_test.go`; existing `service_test.go` covers real library failures returning generic codes)
- [ ] Breaking changes. (Not applicable)

### Security checks
- [x] Followed secure coding standards (generic client errors avoid a verification oracle; specifics logged server-side only).
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)