### PR TITLE
Remove openchoreo release artifacts

### DIFF
--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -533,37 +533,6 @@ jobs:
           echo "✅ Helm chart pushed successfully!"
           echo "📦 Helm chart available at: oci://${HELM_REGISTRY}/helm-charts"
 
-      - name: 📦 Package and Push OpenChoreo Helm Charts to GHCR
-        run: |
-          OWNER_NAME=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          HELM_REGISTRY="ghcr.io/${OWNER_NAME}/helm-charts"
-
-          CHART_VERSION="${{ needs.build.outputs.version }}"
-          if [[ $CHART_VERSION == v* ]]; then
-            CHART_VERSION="${CHART_VERSION#v}"
-          fi
-
-          mkdir -p target/dist/openchoreo
-
-          # Authenticate Helm to GHCR
-          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
-
-          # Package and push oc-componenttype
-          echo "📦 Packaging ${PRODUCT_NAME_LOWER}-oc-componenttype ${CHART_VERSION}"
-          helm package install/openchoreo/helm/charts/${PRODUCT_NAME_LOWER}-oc-componenttype \
-            --version "${CHART_VERSION}" --app-version "${CHART_VERSION}" \
-            --destination target/dist/openchoreo/
-          helm push "target/dist/openchoreo/${PRODUCT_NAME_LOWER}-oc-componenttype-${CHART_VERSION}.tgz" "oci://${HELM_REGISTRY}"
-          echo "✅ ${PRODUCT_NAME_LOWER}-oc-componenttype pushed to oci://${HELM_REGISTRY}"
-
-          # Package and push oc-resourcetype
-          echo "📦 Packaging ${PRODUCT_NAME_LOWER}-oc-resourcetype ${CHART_VERSION}"
-          helm package install/openchoreo/${PRODUCT_NAME_LOWER}-oc-resourcetype \
-            --version "${CHART_VERSION}" --app-version "${CHART_VERSION}" \
-            --destination target/dist/openchoreo/
-          helm push "target/dist/openchoreo/${PRODUCT_NAME_LOWER}-oc-resourcetype-${CHART_VERSION}.tgz" "oci://${HELM_REGISTRY}"
-          echo "✅ ${PRODUCT_NAME_LOWER}-oc-resourcetype pushed to oci://${HELM_REGISTRY}"
-
       - name: 📝 Calculate Next Version
         id: next_version
         run: |


### PR DESCRIPTION
### Purpose

Instead of releasing Helm deployment artifacts, we will use raw Kubernetes artifacts to create OC resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated release packaging to publish a single umbrella Helm chart.
  - Removed publishing of separate component-type and resource-type Helm charts.
  - Helm chart releases now use the computed chart/app version for consistency.
  - Streamlined the release workflow to continue directly to version calculation after packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->