### PR TITLE
Fix credential routing

### DIFF
--- a/backend/internal/authnprovider/manager/manager.go
+++ b/backend/internal/authnprovider/manager/manager.go
@@ -422,26 +422,36 @@ func (m *authnProviderManager) updateAuthUser(ctx context.Context, authResult *p
 	return authUser, nil
 }
 
-// selectProvider resolves the single credential key to its provider, falling back to the
-// default provider for keys not claimed by a custom provider. Callers must supply exactly one
-// credential key; zero or multiple keys indicates an internal fault and is treated as a server error.
+// selectProvider resolves the supplied credential keys to a single provider. The request is valid as long
+// as every key resolves to the same provider; keys that fan out to different providers are ambiguous
+// and treated as an internal fault. At least one key must be supplied.
 func (m *authnProviderManager) selectProvider(ctx context.Context, credentialTypes []string) (
 	string, providers.AuthnProviderInterface, *tidcommon.ServiceError) {
-	if len(credentialTypes) != 1 {
-		m.logger.Error(ctx, "expected exactly one credential key; rejecting ambiguous request",
-			log.Any("credentialKeys", credentialTypes))
+	if len(credentialTypes) == 0 {
+		m.logger.Error(ctx, "no credential keys supplied; cannot select a provider")
 		return "", nil, &tidcommon.InternalServerError
 	}
-	credentialType := credentialTypes[0]
-	selectedProviderName, ok := m.credToProviderMapping[credentialType]
-	if !ok {
-		// Credentials not claimed by a custom provider fall through to the default provider.
-		selectedProviderName = defaultProviderName
+
+	selectedProviderName := ""
+	for i, credentialType := range credentialTypes {
+		providerName, ok := m.credToProviderMapping[credentialType]
+		if !ok {
+			// Credentials not claimed by a custom provider fall through to the default provider.
+			providerName = defaultProviderName
+		}
+		if i == 0 {
+			selectedProviderName = providerName
+		} else if providerName != selectedProviderName {
+			m.logger.Error(ctx, "credential keys map to multiple providers; rejecting ambiguous request",
+				log.Any("credentialKeys", credentialTypes))
+			return "", nil, &tidcommon.InternalServerError
+		}
 	}
+
 	selectedProvider, ok := m.authnProviders[selectedProviderName]
 	if !ok || selectedProvider == nil {
 		m.logger.Error(ctx, "credential key mapped to a provider that is not registered",
-			log.String("credentialType", credentialType), log.String("providerName", selectedProviderName))
+			log.String("providerName", selectedProviderName))
 		return "", nil, &tidcommon.InternalServerError
 	}
 	return selectedProviderName, selectedProvider, nil

--- a/backend/internal/authnprovider/manager/manager_test.go
+++ b/backend/internal/authnprovider/manager/manager_test.go
@@ -825,20 +825,55 @@ func TestNewAuthnProviderManager_NamedProviderHandlesClaimedCredential(t *testin
 	defaultMock.AssertNotCalled(t, "Authenticate")
 }
 
-func (s *ManagerTestSuite) TestAuthenticateUser_MultipleCredentialKeys() {
+func (s *ManagerTestSuite) TestAuthenticateUser_MultipleCredentialKeysSameProvider() {
 	identifiers := map[string]interface{}{"username": "alice"}
-	// Multiple credential keys make the request ambiguous. Callers must supply exactly one
-	// key, so this is treated as an internal fault (server error) rather than a client error.
+	// Multiple credential keys that all resolve to the same provider (here the default, since no
+	// custom provider claims them) are routed to that provider.
 	credentials := map[string]interface{}{"password": "secret", "otp": "123456"}
 	meta := &providers.AuthnMetadata{}
+
+	s.mockProvider.On("Authenticate", context.Background(), identifiers, credentials, meta).
+		Return(&providers.AuthnResult{
+			EntityReferenceToken: map[string]interface{}{"userID": "user-1"},
+			AttributeToken:       "tok",
+		}, (*tidcommon.ServiceError)(nil))
 
 	authUser, _, svcErr := s.mgr.AuthenticateUser(context.Background(), identifiers, credentials,
 		nil, meta, providers.AuthUser{})
 
-	s.NotNil(svcErr)
-	s.Equal(tidcommon.InternalServerError.Code, svcErr.Code)
-	s.False(authUser.IsAuthenticated())
-	s.mockProvider.AssertNotCalled(s.T(), "Authenticate")
+	s.Nil(svcErr)
+	s.True(authUser.IsAuthenticated())
+	_, ok := authUser.StateFor(defaultProviderName)
+	s.True(ok)
+}
+
+func TestAuthenticateUser_MultipleCredentialKeysDifferentProviders(t *testing.T) {
+	identifiers := map[string]interface{}{"username": "alice"}
+	// "password" falls through to the default provider while "otp" is claimed by acme, so the keys
+	// fan out to different providers. That is ambiguous and treated as an internal fault.
+	credentials := map[string]interface{}{"password": "secret", "otp": "123456"}
+	meta := &providers.AuthnMetadata{}
+
+	defaultMock := providermock.NewAuthnProviderInterfaceMock(t)
+	acmeMock := providermock.NewAuthnProviderInterfaceMock(t)
+	mgr, err := Initialize(defaultMock, map[string]providers.CustomAuthnProvider{
+		"acme": {Instance: acmeMock, Creds: []string{"otp"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	authUser, _, svcErr := mgr.AuthenticateUser(context.Background(), identifiers, credentials,
+		nil, meta, providers.AuthUser{})
+
+	if svcErr == nil || svcErr.Code != tidcommon.InternalServerError.Code {
+		t.Fatalf("expected InternalServerError for keys mapping to different providers, got %v", svcErr)
+	}
+	if authUser.IsAuthenticated() {
+		t.Fatalf("expected authUser to remain unauthenticated")
+	}
+	defaultMock.AssertNotCalled(t, "Authenticate")
+	acmeMock.AssertNotCalled(t, "Authenticate")
 }
 
 func (s *ManagerTestSuite) TestInitiateAuthentication_RoutesToDefaultProvider() {
@@ -938,7 +973,7 @@ func (s *ManagerTestSuite) TestEnroll_ClientErrorMapping() {
 }
 
 func (s *ManagerTestSuite) TestEnroll_EmptyCredentials() {
-	// Empty credentials must not panic (selectProvider guards len != 1) and is a server error.
+	// Empty credentials must not panic (selectProvider guards len == 0) and is a server error.
 	authUser, _, svcErr := s.mgr.Enroll(context.Background(), nil, map[string]interface{}{},
 		nil, nil, providers.AuthUser{})
 
@@ -948,14 +983,51 @@ func (s *ManagerTestSuite) TestEnroll_EmptyCredentials() {
 	s.mockProvider.AssertNotCalled(s.T(), "Enroll")
 }
 
-func (s *ManagerTestSuite) TestEnroll_MultipleCredentialKeys() {
+func (s *ManagerTestSuite) TestEnroll_MultipleCredentialKeysSameProvider() {
+	// Multiple credential keys that all resolve to the same provider (here the default) are routed
+	// to that provider.
 	credentials := map[string]interface{}{"passkey": "cred", "otp": "123456"}
-	authUser, _, svcErr := s.mgr.Enroll(context.Background(), nil, credentials, nil, nil, providers.AuthUser{})
+	meta := &providers.AuthnMetadata{}
+	entityRefToken := map[string]interface{}{"userID": "user-1"}
 
-	s.NotNil(svcErr)
-	s.Equal(tidcommon.InternalServerError.Code, svcErr.Code)
-	s.False(authUser.IsAuthenticated())
-	s.mockProvider.AssertNotCalled(s.T(), "Enroll")
+	s.mockProvider.On("Enroll", context.Background(), map[string]interface{}(nil), credentials, meta).
+		Return(&providers.AuthnResult{
+			EntityReferenceToken: entityRefToken,
+			AttributeToken:       entityRefToken,
+		}, (*tidcommon.ServiceError)(nil))
+
+	authUser, _, svcErr := s.mgr.Enroll(context.Background(), nil, credentials, nil, meta, providers.AuthUser{})
+
+	s.Nil(svcErr)
+	s.True(authUser.IsAuthenticated())
+	_, ok := authUser.StateFor(defaultProviderName)
+	s.True(ok)
+}
+
+func TestEnroll_MultipleCredentialKeysDifferentProviders(t *testing.T) {
+	// "passkey" falls through to the default provider while "otp" is claimed by acme, so the keys
+	// fan out to different providers. That is ambiguous and treated as an internal fault.
+	credentials := map[string]interface{}{"passkey": "cred", "otp": "123456"}
+
+	defaultMock := providermock.NewAuthnProviderInterfaceMock(t)
+	acmeMock := providermock.NewAuthnProviderInterfaceMock(t)
+	mgr, err := Initialize(defaultMock, map[string]providers.CustomAuthnProvider{
+		"acme": {Instance: acmeMock, Creds: []string{"otp"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	authUser, _, svcErr := mgr.Enroll(context.Background(), nil, credentials, nil, nil, providers.AuthUser{})
+
+	if svcErr == nil || svcErr.Code != tidcommon.InternalServerError.Code {
+		t.Fatalf("expected InternalServerError for keys mapping to different providers, got %v", svcErr)
+	}
+	if authUser.IsAuthenticated() {
+		t.Fatalf("expected authUser to remain unauthenticated")
+	}
+	defaultMock.AssertNotCalled(t, "Enroll")
+	acmeMock.AssertNotCalled(t, "Enroll")
 }
 
 func (s *ManagerTestSuite) TestAuthenticateUser_Disambiguation_NoDefaultProviderState() {


### PR DESCRIPTION
### Purpose

This pull request updates the authentication provider selection logic to support requests with multiple credential keys, as long as all keys map to the same provider. It also adds tests to ensure correct routing and error handling when credential keys are ambiguous or map to different providers.

### Approach

#### Authentication provider selection logic:

* Updated `selectProvider` in `manager.go` to accept multiple credential keys, routing the request to a provider only if all keys resolve to the same provider; otherwise, it returns an internal server error.

#### Test coverage improvements:

* Added and updated tests in `manager_test.go` to verify that:
  - Multiple credential keys mapping to the same provider are accepted and routed correctly.
  - Requests with credential keys mapping to different providers are rejected with an internal server error.
  - Empty credential keys are handled as a server error without panicking. [[1]](diffhunk://#diff-5853dd6bfff9aa0692b8070951835e16523a32b5b5a7bfa1940115820362731cL828-R876) [[2]](diffhunk://#diff-5853dd6bfff9aa0692b8070951835e16523a32b5b5a7bfa1940115820362731cL941-R976) [[3]](diffhunk://#diff-5853dd6bfff9aa0692b8070951835e16523a32b5b5a7bfa1940115820362731cL951-R1030)

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Authentication and enrollment now support multiple credential keys when they route to the same provider.
  - Requests using credentials mapped to different providers are rejected with an appropriate server error.

- **Bug Fixes**
  - Improved provider selection for multi-credential authentication and enrollment.
  - Empty or unregistered credential mappings continue to return clear server errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->