### PR TITLE
Honour the id specified when importing a layout

### DIFF
--- a/backend/internal/design/layout/mgt/LayoutMgtServiceInterface_mock_test.go
+++ b/backend/internal/design/layout/mgt/LayoutMgtServiceInterface_mock_test.go
@@ -40,7 +40,7 @@ func (_m *LayoutMgtServiceInterfaceMock) EXPECT() *LayoutMgtServiceInterfaceMock
 }
 
 // CreateLayout provides a mock function for the type LayoutMgtServiceInterfaceMock
-func (_mock *LayoutMgtServiceInterfaceMock) CreateLayout(ctx context.Context, layout CreateLayoutRequest) (*Layout, *common.ServiceError) {
+func (_mock *LayoutMgtServiceInterfaceMock) CreateLayout(ctx context.Context, layout CreateLayoutRequestWithID) (*Layout, *common.ServiceError) {
 	ret := _mock.Called(ctx, layout)
 
 	if len(ret) == 0 {
@@ -49,17 +49,17 @@ func (_mock *LayoutMgtServiceInterfaceMock) CreateLayout(ctx context.Context, la
 
 	var r0 *Layout
 	var r1 *common.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, CreateLayoutRequest) (*Layout, *common.ServiceError)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, CreateLayoutRequestWithID) (*Layout, *common.ServiceError)); ok {
 		return returnFunc(ctx, layout)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, CreateLayoutRequest) *Layout); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, CreateLayoutRequestWithID) *Layout); ok {
 		r0 = returnFunc(ctx, layout)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*Layout)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, CreateLayoutRequest) *common.ServiceError); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, CreateLayoutRequestWithID) *common.ServiceError); ok {
 		r1 = returnFunc(ctx, layout)
 	} else {
 		if ret.Get(1) != nil {
@@ -76,20 +76,20 @@ type LayoutMgtServiceInterfaceMock_CreateLayout_Call struct {
 
 // CreateLayout is a helper method to define mock.On call
 //   - ctx context.Context
-//   - layout CreateLayoutRequest
+//   - layout CreateLayoutRequestWithID
 func (_e *LayoutMgtServiceInterfaceMock_Expecter) CreateLayout(ctx interface{}, layout interface{}) *LayoutMgtServiceInterfaceMock_CreateLayout_Call {
 	return &LayoutMgtServiceInterfaceMock_CreateLayout_Call{Call: _e.mock.On("CreateLayout", ctx, layout)}
 }
 
-func (_c *LayoutMgtServiceInterfaceMock_CreateLayout_Call) Run(run func(ctx context.Context, layout CreateLayoutRequest)) *LayoutMgtServiceInterfaceMock_CreateLayout_Call {
+func (_c *LayoutMgtServiceInterfaceMock_CreateLayout_Call) Run(run func(ctx context.Context, layout CreateLayoutRequestWithID)) *LayoutMgtServiceInterfaceMock_CreateLayout_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 CreateLayoutRequest
+		var arg1 CreateLayoutRequestWithID
 		if args[1] != nil {
-			arg1 = args[1].(CreateLayoutRequest)
+			arg1 = args[1].(CreateLayoutRequestWithID)
 		}
 		run(
 			arg0,
@@ -104,7 +104,7 @@ func (_c *LayoutMgtServiceInterfaceMock_CreateLayout_Call) Return(layout1 *Layou
 	return _c
 }
 
-func (_c *LayoutMgtServiceInterfaceMock_CreateLayout_Call) RunAndReturn(run func(ctx context.Context, layout CreateLayoutRequest) (*Layout, *common.ServiceError)) *LayoutMgtServiceInterfaceMock_CreateLayout_Call {
+func (_c *LayoutMgtServiceInterfaceMock_CreateLayout_Call) RunAndReturn(run func(ctx context.Context, layout CreateLayoutRequestWithID) (*Layout, *common.ServiceError)) *LayoutMgtServiceInterfaceMock_CreateLayout_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/design/layout/mgt/handler.go
+++ b/backend/internal/design/layout/mgt/handler.go
@@ -102,7 +102,12 @@ func (lh *layoutMgtHandler) HandleLayoutPostRequest(w http.ResponseWriter, r *ht
 		return
 	}
 
-	createdLayout, svcErr := lh.layoutMgtService.CreateLayout(ctx, *createRequest)
+	createdLayout, svcErr := lh.layoutMgtService.CreateLayout(ctx, CreateLayoutRequestWithID{
+		Handle:      createRequest.Handle,
+		DisplayName: createRequest.DisplayName,
+		Description: createRequest.Description,
+		Layout:      createRequest.Layout,
+	})
 	if svcErr != nil {
 		handleError(ctx, w, svcErr)
 		return

--- a/backend/internal/design/layout/mgt/handler_test.go
+++ b/backend/internal/design/layout/mgt/handler_test.go
@@ -47,7 +47,7 @@ func TestLayoutHandlerTestSuite(t *testing.T) {
 // mockLayoutService implements LayoutMgtServiceInterface for handler tests
 type mockLayoutService struct {
 	getLayoutListFunc   func(limit, offset int) (*LayoutList, *tidcommon.ServiceError)
-	createLayoutFunc    func(layout CreateLayoutRequest) (*Layout, *tidcommon.ServiceError)
+	createLayoutFunc    func(layout CreateLayoutRequestWithID) (*Layout, *tidcommon.ServiceError)
 	getLayoutFunc       func(id string) (*Layout, *tidcommon.ServiceError)
 	updateLayoutFunc    func(id string, layout UpdateLayoutRequest) (*Layout, *tidcommon.ServiceError)
 	deleteLayoutFunc    func(id string) *tidcommon.ServiceError
@@ -62,7 +62,7 @@ func (m *mockLayoutService) GetLayoutList(
 }
 
 func (m *mockLayoutService) CreateLayout(
-	_ context.Context, layout CreateLayoutRequest) (*Layout, *tidcommon.ServiceError) {
+	_ context.Context, layout CreateLayoutRequestWithID) (*Layout, *tidcommon.ServiceError) {
 	return m.createLayoutFunc(layout)
 }
 
@@ -175,7 +175,7 @@ func (suite *LayoutHandlerTestSuite) TestHandleLayoutPostRequest_Success() {
 	}
 
 	mockSvc := &mockLayoutService{
-		createLayoutFunc: func(layout CreateLayoutRequest) (*Layout, *tidcommon.ServiceError) {
+		createLayoutFunc: func(layout CreateLayoutRequestWithID) (*Layout, *tidcommon.ServiceError) {
 			return createdLayout, nil
 		},
 	}
@@ -216,7 +216,7 @@ func (suite *LayoutHandlerTestSuite) TestHandleLayoutPostRequest_InvalidJSON() {
 // Test HandleLayoutPostRequest - Service error
 func (suite *LayoutHandlerTestSuite) TestHandleLayoutPostRequest_ServiceError() {
 	mockSvc := &mockLayoutService{
-		createLayoutFunc: func(layout CreateLayoutRequest) (*Layout, *tidcommon.ServiceError) {
+		createLayoutFunc: func(layout CreateLayoutRequestWithID) (*Layout, *tidcommon.ServiceError) {
 			return nil, &tidcommon.InternalServerError
 		},
 	}

--- a/backend/internal/design/layout/mgt/init_test.go
+++ b/backend/internal/design/layout/mgt/init_test.go
@@ -46,7 +46,7 @@ func (suite *LayoutInitTestSuite) TestRegisterRoutes() {
 		getLayoutListFunc: func(limit, offset int) (*LayoutList, *tidcommon.ServiceError) {
 			return &LayoutList{Layouts: []Layout{}, Links: []Link{}}, nil
 		},
-		createLayoutFunc: func(layout CreateLayoutRequest) (*Layout, *tidcommon.ServiceError) {
+		createLayoutFunc: func(layout CreateLayoutRequestWithID) (*Layout, *tidcommon.ServiceError) {
 			return &Layout{}, nil
 		},
 		getLayoutFunc: func(id string) (*Layout, *tidcommon.ServiceError) {

--- a/backend/internal/design/layout/mgt/model.go
+++ b/backend/internal/design/layout/mgt/model.go
@@ -51,6 +51,15 @@ type CreateLayoutRequest struct {
 	Layout      json.RawMessage `json:"layout"`
 }
 
+// CreateLayoutRequestWithID represents the service-level request for creating a layout, including an optional ID.
+type CreateLayoutRequestWithID struct {
+	ID          string          `json:"id,omitempty" yaml:"id,omitempty"`
+	Handle      string          `json:"handle"`
+	DisplayName string          `json:"displayName"`
+	Description string          `json:"description,omitempty"`
+	Layout      json.RawMessage `json:"layout"`
+}
+
 // UpdateLayoutRequest represents the request body for updating a layout configuration.
 type UpdateLayoutRequest struct {
 	Handle      string          `json:"handle"`

--- a/backend/internal/design/layout/mgt/service.go
+++ b/backend/internal/design/layout/mgt/service.go
@@ -39,7 +39,7 @@ const loggerComponentName = "LayoutMgtService"
 // LayoutMgtServiceInterface defines the interface for the layout management service.
 type LayoutMgtServiceInterface interface {
 	GetLayoutList(ctx context.Context, limit, offset int) (*LayoutList, *tidcommon.ServiceError)
-	CreateLayout(ctx context.Context, layout CreateLayoutRequest) (*Layout, *tidcommon.ServiceError)
+	CreateLayout(ctx context.Context, layout CreateLayoutRequestWithID) (*Layout, *tidcommon.ServiceError)
 	GetLayout(ctx context.Context, id string) (*Layout, *tidcommon.ServiceError)
 	UpdateLayout(ctx context.Context, id string, layout UpdateLayoutRequest) (*Layout, *tidcommon.ServiceError)
 	DeleteLayout(ctx context.Context, id string) *tidcommon.ServiceError
@@ -97,7 +97,7 @@ func (ls *layoutMgtService) GetLayoutList(
 
 // CreateLayout creates a new layout configuration.
 func (ls *layoutMgtService) CreateLayout(
-	ctx context.Context, layout CreateLayoutRequest) (*Layout, *tidcommon.ServiceError) {
+	ctx context.Context, layout CreateLayoutRequestWithID) (*Layout, *tidcommon.ServiceError) {
 	ls.logger.Debug(ctx, "Creating layout configuration")
 
 	if layout.DisplayName == "" {
@@ -126,13 +126,24 @@ func (ls *layoutMgtService) CreateLayout(
 		return nil, err
 	}
 
-	id, err := utils.GenerateUUIDv7()
-	if err != nil {
-		ls.logger.Error(ctx, "Failed to generate UUID", log.Error(err))
-		return nil, &tidcommon.InternalServerError
+	id := layout.ID
+	if id == "" {
+		var err error
+		id, err = utils.GenerateUUIDv7()
+		if err != nil {
+			ls.logger.Error(ctx, "Failed to generate UUID", log.Error(err))
+			return nil, &tidcommon.InternalServerError
+		}
 	}
 
-	if err := ls.layoutMgtStore.CreateLayout(id, layout); err != nil {
+	storeReq := CreateLayoutRequest{
+		Handle:      layout.Handle,
+		DisplayName: layout.DisplayName,
+		Description: layout.Description,
+		Layout:      layout.Layout,
+	}
+
+	if err := ls.layoutMgtStore.CreateLayout(id, storeReq); err != nil {
 		ls.logger.Error(ctx, "Failed to create layout", log.Error(err))
 		return nil, &tidcommon.InternalServerError
 	}

--- a/backend/internal/design/layout/mgt/service_test.go
+++ b/backend/internal/design/layout/mgt/service_test.go
@@ -131,7 +131,7 @@ func (suite *LayoutServiceTestSuite) TestGetLayoutList_InvalidOffset() {
 
 // Test CreateLayout - Success
 func (suite *LayoutServiceTestSuite) TestCreateLayout_Success() {
-	layoutRequest := CreateLayoutRequest{
+	layoutRequest := CreateLayoutRequestWithID{
 		Handle:      "new-layout",
 		DisplayName: "New Layout",
 		Description: "A new layout",
@@ -139,7 +139,8 @@ func (suite *LayoutServiceTestSuite) TestCreateLayout_Success() {
 	}
 
 	suite.mockStore.On("IsLayoutHandleConflict", "new-layout", "").Return(false, nil)
-	suite.mockStore.On("CreateLayout", mock.AnythingOfType("string"), layoutRequest).Return(nil)
+	suite.mockStore.On("CreateLayout", mock.AnythingOfType("string"),
+		mock.AnythingOfType("CreateLayoutRequest")).Return(nil)
 
 	result, err := suite.service.CreateLayout(context.Background(), layoutRequest)
 
@@ -151,9 +152,30 @@ func (suite *LayoutServiceTestSuite) TestCreateLayout_Success() {
 	assert.NotEmpty(suite.T(), result.ID)
 }
 
+// Test CreateLayout - Honors the provided ID
+func (suite *LayoutServiceTestSuite) TestCreateLayout_HonorsProvidedID() {
+	layoutRequest := CreateLayoutRequestWithID{
+		ID:          "provided-layout-id",
+		Handle:      "new-layout",
+		DisplayName: "New Layout",
+		Description: "A new layout",
+		Layout:      json.RawMessage(`{"structure": "grid"}`),
+	}
+
+	suite.mockStore.On("IsLayoutHandleConflict", "new-layout", "").Return(false, nil)
+	suite.mockStore.On("CreateLayout", "provided-layout-id",
+		mock.AnythingOfType("CreateLayoutRequest")).Return(nil)
+
+	result, err := suite.service.CreateLayout(context.Background(), layoutRequest)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), "provided-layout-id", result.ID)
+}
+
 // Test CreateLayout - Missing Display Name
 func (suite *LayoutServiceTestSuite) TestCreateLayout_MissingDisplayName() {
-	layoutRequest := CreateLayoutRequest{
+	layoutRequest := CreateLayoutRequestWithID{
 		Handle:      "my-layout",
 		DisplayName: "",
 		Description: "A layout without name",
@@ -169,7 +191,7 @@ func (suite *LayoutServiceTestSuite) TestCreateLayout_MissingDisplayName() {
 
 // Test CreateLayout - Missing Handle
 func (suite *LayoutServiceTestSuite) TestCreateLayout_MissingHandle() {
-	layoutRequest := CreateLayoutRequest{
+	layoutRequest := CreateLayoutRequestWithID{
 		Handle:      "",
 		DisplayName: "My Layout",
 		Description: "A layout without handle",
@@ -185,7 +207,7 @@ func (suite *LayoutServiceTestSuite) TestCreateLayout_MissingHandle() {
 
 // Test CreateLayout - Duplicate Handle
 func (suite *LayoutServiceTestSuite) TestCreateLayout_DuplicateHandle() {
-	layoutRequest := CreateLayoutRequest{
+	layoutRequest := CreateLayoutRequestWithID{
 		Handle:      "existing-layout",
 		DisplayName: "My Layout",
 		Description: "A layout with duplicate handle",
@@ -206,7 +228,7 @@ func (suite *LayoutServiceTestSuite) TestCreateLayout_DeclarativeModeEnabled() {
 	runtime := config.GetServerRuntime()
 	runtime.Config.Layout.Store = "declarative"
 
-	layoutRequest := CreateLayoutRequest{
+	layoutRequest := CreateLayoutRequestWithID{
 		Handle:      "declarative-layout",
 		DisplayName: "Declarative Layout",
 		Description: "Should be blocked",
@@ -222,7 +244,7 @@ func (suite *LayoutServiceTestSuite) TestCreateLayout_DeclarativeModeEnabled() {
 
 // Test CreateLayout - Invalid Layout JSON
 func (suite *LayoutServiceTestSuite) TestCreateLayout_InvalidJSON() {
-	layoutRequest := CreateLayoutRequest{
+	layoutRequest := CreateLayoutRequestWithID{
 		Handle:      "my-layout",
 		DisplayName: "Layout",
 		Description: "Invalid JSON layout",
@@ -240,7 +262,7 @@ func (suite *LayoutServiceTestSuite) TestCreateLayout_InvalidJSON() {
 
 // Test CreateLayout - Store Error
 func (suite *LayoutServiceTestSuite) TestCreateLayout_StoreError() {
-	layoutRequest := CreateLayoutRequest{
+	layoutRequest := CreateLayoutRequestWithID{
 		Handle:      "my-layout",
 		DisplayName: "Layout",
 		Description: "A layout",
@@ -248,7 +270,8 @@ func (suite *LayoutServiceTestSuite) TestCreateLayout_StoreError() {
 	}
 
 	suite.mockStore.On("IsLayoutHandleConflict", "my-layout", "").Return(false, nil)
-	suite.mockStore.On("CreateLayout", mock.AnythingOfType("string"), layoutRequest).
+	suite.mockStore.On("CreateLayout", mock.AnythingOfType("string"),
+		mock.AnythingOfType("CreateLayoutRequest")).
 		Return(errors.New("database error"))
 
 	result, err := suite.service.CreateLayout(context.Background(), layoutRequest)
@@ -523,7 +546,7 @@ func (suite *LayoutServiceTestSuite) TestIsLayoutExist_StoreError() {
 
 // Test CreateLayout - Handle conflict check error
 func (suite *LayoutServiceTestSuite) TestCreateLayout_HandleConflictError() {
-	layoutRequest := CreateLayoutRequest{
+	layoutRequest := CreateLayoutRequestWithID{
 		Handle:      "my-layout",
 		DisplayName: "Layout",
 		Description: "A layout",

--- a/backend/internal/system/importer/service.go
+++ b/backend/internal/system/importer/service.go
@@ -168,7 +168,7 @@ type themeAdapter interface {
 
 type layoutAdapter interface {
 	CreateLayout(ctx context.Context,
-		layout layoutmgt.CreateLayoutRequest) (*layoutmgt.Layout, *tidcommon.ServiceError)
+		layout layoutmgt.CreateLayoutRequestWithID) (*layoutmgt.Layout, *tidcommon.ServiceError)
 	GetLayout(ctx context.Context, id string) (*layoutmgt.Layout, *tidcommon.ServiceError)
 	UpdateLayout(ctx context.Context,
 		id string, layout layoutmgt.UpdateLayoutRequest) (*layoutmgt.Layout, *tidcommon.ServiceError)

--- a/backend/internal/system/importer/service_adapters.go
+++ b/backend/internal/system/importer/service_adapters.go
@@ -617,35 +617,59 @@ func (s *importService) importLayout(
 		}
 	}
 
-	createReq := layoutmgt.CreateLayoutRequest{
+	createReq := layoutmgt.CreateLayoutRequestWithID{
+		ID:          req.ID,
 		Handle:      req.Handle,
 		DisplayName: req.DisplayName,
 		Description: req.Description,
 		Layout:      layoutBytes,
 	}
-	updateReq := layoutmgt.UpdateLayoutRequest(createReq)
+	updateReq := layoutmgt.UpdateLayoutRequest{
+		Handle:      req.Handle,
+		DisplayName: req.DisplayName,
+		Description: req.Description,
+		Layout:      layoutBytes,
+	}
 
-	return importDesignResource(options.IsUpsertEnabled(), dryRun, req.ID, req.DisplayName,
-		func() *tidcommon.ServiceError {
+	if dryRun {
+		if options.IsUpsertEnabled() && req.ID != "" {
 			_, svcErr := s.layoutService.GetLayout(ctx, req.ID)
-			return svcErr
-		},
-		func() (string, string, *tidcommon.ServiceError) {
-			updated, svcErr := s.layoutService.UpdateLayout(ctx, req.ID, updateReq)
-			if svcErr != nil {
-				return "", "", svcErr
+			if svcErr == nil {
+				return successOutcome(resourceTypeLayout, req.ID, req.DisplayName, operationUpdate)
 			}
-			return updated.ID, updated.DisplayName, nil
-		},
-		func() (string, string, *tidcommon.ServiceError) {
-			created, svcErr := s.layoutService.CreateLayout(ctx, createReq)
-			if svcErr != nil {
-				return "", "", svcErr
+
+			if !isNotFoundServiceError(svcErr) {
+				return serviceErrorOutcome(resourceTypeLayout, req.ID, req.DisplayName, operationUpdate, svcErr)
 			}
-			return created.ID, created.DisplayName, nil
-		},
-		resourceTypeLayout,
-	)
+		}
+
+		return successOutcome(resourceTypeLayout, req.ID, req.DisplayName, operationCreate)
+	}
+
+	if options.IsUpsertEnabled() && req.ID != "" {
+		updated, svcErr := s.layoutService.UpdateLayout(ctx, req.ID, updateReq)
+		if svcErr == nil {
+			return successOutcome(resourceTypeLayout, updated.ID, updated.DisplayName, operationUpdate)
+		}
+
+		if !isNotFoundServiceError(svcErr) {
+			return serviceErrorOutcome(resourceTypeLayout, req.ID, req.DisplayName, operationUpdate, svcErr)
+		}
+
+		created, createErr := s.layoutService.CreateLayout(ctx, createReq)
+		if createErr != nil {
+			return serviceErrorOutcome(resourceTypeLayout, req.ID, req.DisplayName, operationCreate, createErr)
+		}
+
+		return successOutcome(resourceTypeLayout, created.ID, created.DisplayName, operationCreate)
+	}
+
+	created, svcErr := s.layoutService.CreateLayout(ctx, createReq)
+	if svcErr != nil {
+		return serviceErrorOutcome(resourceTypeLayout, req.ID, req.DisplayName, operationCreate, svcErr)
+	}
+
+	return successOutcome(resourceTypeLayout, created.ID, created.DisplayName, operationCreate)
 }
 
 func (s *importService) importUser(
@@ -1052,74 +1076,6 @@ func successOutcome(resourceType, id, name, operation string) ImportItemOutcome 
 		Operation:    operation,
 		Status:       statusSuccess,
 	}
-}
-
-func importDesignResource(
-	upsert bool,
-	dryRun bool,
-	resourceID string,
-	resourceName string,
-	getFn func() *tidcommon.ServiceError,
-	updateFn func() (string, string, *tidcommon.ServiceError),
-	createFn func() (string, string, *tidcommon.ServiceError),
-	resourceType string,
-) ImportItemOutcome {
-	if dryRun {
-		if upsert && resourceID != "" {
-			svcErr := getFn()
-			if svcErr == nil {
-				return successOutcome(resourceType, resourceID, resourceName, operationUpdate)
-			}
-
-			if !isNotFoundServiceError(svcErr) {
-				return serviceErrorOutcome(
-					resourceType,
-					resourceID,
-					resourceName,
-					operationUpdate,
-					svcErr,
-				)
-			}
-		}
-
-		return successOutcome(resourceType, resourceID, resourceName, operationCreate)
-	}
-
-	if upsert && resourceID != "" {
-		updatedID, updatedName, svcErr := updateFn()
-		if svcErr == nil {
-			return successOutcome(resourceType, updatedID, updatedName, operationUpdate)
-		}
-
-		if !isNotFoundServiceError(svcErr) {
-			return serviceErrorOutcome(
-				resourceType,
-				resourceID,
-				resourceName,
-				operationUpdate,
-				svcErr,
-			)
-		}
-
-		// ID-preserving create is not supported; return a clear failure when ID is set but not found.
-		return ImportItemOutcome{
-			ResourceType: resourceType,
-			ResourceID:   resourceID,
-			ResourceName: resourceName,
-			Operation:    operationCreate,
-			Status:       statusFailed,
-			Code:         ErrorInvalidImportRequest.Code,
-			Message: fmt.Sprintf("%s with given ID not found; ID-preserving create not supported",
-				resourceType),
-		}
-	}
-
-	createdID, createdName, svcErr := createFn()
-	if svcErr != nil {
-		return serviceErrorOutcome(resourceType, resourceID, resourceName, operationCreate, svcErr)
-	}
-
-	return successOutcome(resourceType, createdID, createdName, operationCreate)
 }
 
 //nolint:dupl // parallel to importCredentialConfiguration; kept separate per resource type.

--- a/backend/internal/system/importer/service_test.go
+++ b/backend/internal/system/importer/service_test.go
@@ -34,6 +34,7 @@ import (
 	agentmodel "github.com/thunder-id/thunderid/internal/agent/model"
 	"github.com/thunder-id/thunderid/internal/application"
 	"github.com/thunder-id/thunderid/internal/application/model"
+	layoutmgt "github.com/thunder-id/thunderid/internal/design/layout/mgt"
 	thememgt "github.com/thunder-id/thunderid/internal/design/theme/mgt"
 	"github.com/thunder-id/thunderid/internal/entitytype"
 	flowmgt "github.com/thunder-id/thunderid/internal/flow/mgt"
@@ -351,6 +352,86 @@ func (f *fakeThemeService) UpdateTheme(_ context.Context,
 		Theme:       theme.Theme,
 	}
 	f.updated = append(f.updated, theme)
+	f.byID[id] = updated
+	f.byHandle[updated.Handle] = updated
+	return updated, nil
+}
+
+type fakeLayoutService struct {
+	created   []layoutmgt.CreateLayoutRequestWithID
+	updated   []layoutmgt.UpdateLayoutRequest
+	byID      map[string]*layoutmgt.Layout
+	byHandle  map[string]*layoutmgt.Layout
+	createErr *tidcommon.ServiceError
+	updateErr *tidcommon.ServiceError
+}
+
+func layoutNotFoundErr() *tidcommon.ServiceError {
+	return &tidcommon.ServiceError{
+		Type:  tidcommon.ClientErrorType,
+		Code:  layoutmgt.ErrorLayoutNotFound.Code,
+		Error: tidcommon.I18nMessage{DefaultValue: "not found"},
+	}
+}
+
+func (f *fakeLayoutService) CreateLayout(_ context.Context,
+	layout layoutmgt.CreateLayoutRequestWithID,
+) (*layoutmgt.Layout, *tidcommon.ServiceError) {
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+
+	id := layout.ID
+	if id == "" {
+		id = "generated-layout-id"
+	}
+
+	created := &layoutmgt.Layout{
+		ID:          id,
+		Handle:      layout.Handle,
+		DisplayName: layout.DisplayName,
+		Description: layout.Description,
+		Layout:      layout.Layout,
+	}
+	f.created = append(f.created, layout)
+	if f.byID == nil {
+		f.byID = map[string]*layoutmgt.Layout{}
+	}
+	if f.byHandle == nil {
+		f.byHandle = map[string]*layoutmgt.Layout{}
+	}
+	f.byID[created.ID] = created
+	f.byHandle[created.Handle] = created
+	return created, nil
+}
+
+func (f *fakeLayoutService) GetLayout(_ context.Context, id string) (*layoutmgt.Layout, *tidcommon.ServiceError) {
+	if existing, ok := f.byID[id]; ok {
+		return existing, nil
+	}
+
+	return nil, layoutNotFoundErr()
+}
+
+func (f *fakeLayoutService) UpdateLayout(_ context.Context,
+	id string, layout layoutmgt.UpdateLayoutRequest,
+) (*layoutmgt.Layout, *tidcommon.ServiceError) {
+	if f.updateErr != nil {
+		return nil, f.updateErr
+	}
+
+	if _, ok := f.byID[id]; !ok {
+		return nil, layoutNotFoundErr()
+	}
+
+	updated := &layoutmgt.Layout{
+		ID:          id,
+		Handle:      layout.Handle,
+		DisplayName: layout.DisplayName,
+		Description: layout.Description,
+		Layout:      layout.Layout,
+	}
+	f.updated = append(f.updated, layout)
 	f.byID[id] = updated
 	f.byHandle[updated.Handle] = updated
 	return updated, nil
@@ -1744,6 +1825,173 @@ func TestImportResources_ThemeUpsertCreatePreservesID(t *testing.T) {
 	assert.Equal(t, "thm-123", resp.Results[0].ResourceID)
 	assert.Len(t, themeSvc.created, 1)
 	assert.Equal(t, "thm-123", themeSvc.created[0].ID)
+}
+
+func layoutImportContent() string {
+	return strings.Join([]string{
+		"resource_type: layout",
+		"id: lay-123",
+		"handle: default-layout",
+		"displayName: Default Layout",
+		"layout:",
+		"  head:",
+		"    stylesheets: []",
+		"",
+	}, "\n")
+}
+
+func newLayoutImportService(layoutSvc *fakeLayoutService) ImportServiceInterface {
+	return newImportService(
+		nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, layoutSvc, nil, nil, nil, nil, nil, nil,
+	)
+}
+
+// Upsert with an ID that does not exist falls back to a create that preserves the ID.
+func TestImportResources_LayoutUpsertCreatePreservesID(t *testing.T) {
+	layoutSvc := &fakeLayoutService{byID: map[string]*layoutmgt.Layout{}, byHandle: map[string]*layoutmgt.Layout{}}
+	svc := newLayoutImportService(layoutSvc)
+
+	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
+		Content: layoutImportContent(),
+		Options: &ImportOptions{Upsert: boolPtr(true)},
+	})
+
+	require.Nil(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusSuccess, resp.Results[0].Status)
+	assert.Equal(t, operationCreate, resp.Results[0].Operation)
+	assert.Equal(t, "lay-123", resp.Results[0].ResourceID)
+	require.Len(t, layoutSvc.created, 1)
+	assert.Equal(t, "lay-123", layoutSvc.created[0].ID)
+	assert.Empty(t, layoutSvc.updated)
+}
+
+// Upsert with an existing ID updates in place instead of creating.
+func TestImportResources_LayoutUpsertUpdatesExisting(t *testing.T) {
+	layoutSvc := &fakeLayoutService{
+		byID:     map[string]*layoutmgt.Layout{"lay-123": {ID: "lay-123", Handle: "default-layout"}},
+		byHandle: map[string]*layoutmgt.Layout{"default-layout": {ID: "lay-123", Handle: "default-layout"}},
+	}
+	svc := newLayoutImportService(layoutSvc)
+
+	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
+		Content: layoutImportContent(),
+		Options: &ImportOptions{Upsert: boolPtr(true)},
+	})
+
+	require.Nil(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusSuccess, resp.Results[0].Status)
+	assert.Equal(t, operationUpdate, resp.Results[0].Operation)
+	assert.Equal(t, "lay-123", resp.Results[0].ResourceID)
+	require.Len(t, layoutSvc.updated, 1)
+	assert.Empty(t, layoutSvc.created)
+}
+
+// A non-not-found error from update surfaces as a failed update outcome without attempting a create.
+//
+//nolint:dupl // Parallel error-path tests differ only by the failing operation and error code.
+func TestImportResources_LayoutUpsertUpdateError(t *testing.T) {
+	layoutSvc := &fakeLayoutService{
+		byID:     map[string]*layoutmgt.Layout{},
+		byHandle: map[string]*layoutmgt.Layout{},
+		updateErr: &tidcommon.ServiceError{
+			Type:  tidcommon.ServerErrorType,
+			Code:  "LAY-5000",
+			Error: tidcommon.I18nMessage{DefaultValue: "update failed"},
+		},
+	}
+	svc := newLayoutImportService(layoutSvc)
+
+	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
+		Content: layoutImportContent(),
+		Options: &ImportOptions{Upsert: boolPtr(true), ContinueOnError: boolPtr(true)},
+	})
+
+	require.Nil(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusFailed, resp.Results[0].Status)
+	assert.Equal(t, operationUpdate, resp.Results[0].Operation)
+	assert.Equal(t, "LAY-5000", resp.Results[0].Code)
+	assert.Empty(t, layoutSvc.created)
+}
+
+// When update reports not-found but the fallback create fails, it surfaces as a failed create outcome.
+//
+//nolint:dupl // Parallel error-path tests differ only by the failing operation and error code.
+func TestImportResources_LayoutUpsertCreateError(t *testing.T) {
+	layoutSvc := &fakeLayoutService{
+		byID:     map[string]*layoutmgt.Layout{},
+		byHandle: map[string]*layoutmgt.Layout{},
+		createErr: &tidcommon.ServiceError{
+			Type:  tidcommon.ServerErrorType,
+			Code:  "LAY-5001",
+			Error: tidcommon.I18nMessage{DefaultValue: "create failed"},
+		},
+	}
+	svc := newLayoutImportService(layoutSvc)
+
+	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
+		Content: layoutImportContent(),
+		Options: &ImportOptions{Upsert: boolPtr(true), ContinueOnError: boolPtr(true)},
+	})
+
+	require.Nil(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusFailed, resp.Results[0].Status)
+	assert.Equal(t, operationCreate, resp.Results[0].Operation)
+	assert.Equal(t, "LAY-5001", resp.Results[0].Code)
+	assert.Empty(t, layoutSvc.updated)
+}
+
+// Without upsert, a create that preserves the ID is issued directly.
+func TestImportResources_LayoutCreatePreservesID(t *testing.T) {
+	layoutSvc := &fakeLayoutService{byID: map[string]*layoutmgt.Layout{}, byHandle: map[string]*layoutmgt.Layout{}}
+	svc := newLayoutImportService(layoutSvc)
+
+	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
+		Content: layoutImportContent(),
+		Options: &ImportOptions{Upsert: boolPtr(false)},
+	})
+
+	require.Nil(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusSuccess, resp.Results[0].Status)
+	assert.Equal(t, operationCreate, resp.Results[0].Operation)
+	assert.Equal(t, "lay-123", resp.Results[0].ResourceID)
+	require.Len(t, layoutSvc.created, 1)
+	assert.Equal(t, "lay-123", layoutSvc.created[0].ID)
+}
+
+// Without upsert, a create failure surfaces as a failed create outcome.
+func TestImportResources_LayoutCreateError(t *testing.T) {
+	layoutSvc := &fakeLayoutService{
+		byID:     map[string]*layoutmgt.Layout{},
+		byHandle: map[string]*layoutmgt.Layout{},
+		createErr: &tidcommon.ServiceError{
+			Type:  tidcommon.ServerErrorType,
+			Code:  "LAY-5001",
+			Error: tidcommon.I18nMessage{DefaultValue: "create failed"},
+		},
+	}
+	svc := newLayoutImportService(layoutSvc)
+
+	resp, err := svc.ImportResources(context.Background(), &ImportRequest{
+		Content: layoutImportContent(),
+		Options: &ImportOptions{Upsert: boolPtr(false), ContinueOnError: boolPtr(true)},
+	})
+
+	require.Nil(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusFailed, resp.Results[0].Status)
+	assert.Equal(t, operationCreate, resp.Results[0].Operation)
+	assert.Equal(t, "LAY-5001", resp.Results[0].Code)
 }
 
 //nolint:dupl // Test pattern repeated across resource types to verify ID preservation behavior

--- a/backend/tests/mocks/design/layoutmock/LayoutMgtServiceInterface_mock.go
+++ b/backend/tests/mocks/design/layoutmock/LayoutMgtServiceInterface_mock.go
@@ -41,7 +41,7 @@ func (_m *LayoutMgtServiceInterfaceMock) EXPECT() *LayoutMgtServiceInterfaceMock
 }
 
 // CreateLayout provides a mock function for the type LayoutMgtServiceInterfaceMock
-func (_mock *LayoutMgtServiceInterfaceMock) CreateLayout(ctx context.Context, layout layoutmgt.CreateLayoutRequest) (*layoutmgt.Layout, *common.ServiceError) {
+func (_mock *LayoutMgtServiceInterfaceMock) CreateLayout(ctx context.Context, layout layoutmgt.CreateLayoutRequestWithID) (*layoutmgt.Layout, *common.ServiceError) {
 	ret := _mock.Called(ctx, layout)
 
 	if len(ret) == 0 {
@@ -50,17 +50,17 @@ func (_mock *LayoutMgtServiceInterfaceMock) CreateLayout(ctx context.Context, la
 
 	var r0 *layoutmgt.Layout
 	var r1 *common.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, layoutmgt.CreateLayoutRequest) (*layoutmgt.Layout, *common.ServiceError)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, layoutmgt.CreateLayoutRequestWithID) (*layoutmgt.Layout, *common.ServiceError)); ok {
 		return returnFunc(ctx, layout)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, layoutmgt.CreateLayoutRequest) *layoutmgt.Layout); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, layoutmgt.CreateLayoutRequestWithID) *layoutmgt.Layout); ok {
 		r0 = returnFunc(ctx, layout)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*layoutmgt.Layout)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, layoutmgt.CreateLayoutRequest) *common.ServiceError); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, layoutmgt.CreateLayoutRequestWithID) *common.ServiceError); ok {
 		r1 = returnFunc(ctx, layout)
 	} else {
 		if ret.Get(1) != nil {
@@ -77,20 +77,20 @@ type LayoutMgtServiceInterfaceMock_CreateLayout_Call struct {
 
 // CreateLayout is a helper method to define mock.On call
 //   - ctx context.Context
-//   - layout layoutmgt.CreateLayoutRequest
+//   - layout layoutmgt.CreateLayoutRequestWithID
 func (_e *LayoutMgtServiceInterfaceMock_Expecter) CreateLayout(ctx interface{}, layout interface{}) *LayoutMgtServiceInterfaceMock_CreateLayout_Call {
 	return &LayoutMgtServiceInterfaceMock_CreateLayout_Call{Call: _e.mock.On("CreateLayout", ctx, layout)}
 }
 
-func (_c *LayoutMgtServiceInterfaceMock_CreateLayout_Call) Run(run func(ctx context.Context, layout layoutmgt.CreateLayoutRequest)) *LayoutMgtServiceInterfaceMock_CreateLayout_Call {
+func (_c *LayoutMgtServiceInterfaceMock_CreateLayout_Call) Run(run func(ctx context.Context, layout layoutmgt.CreateLayoutRequestWithID)) *LayoutMgtServiceInterfaceMock_CreateLayout_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 layoutmgt.CreateLayoutRequest
+		var arg1 layoutmgt.CreateLayoutRequestWithID
 		if args[1] != nil {
-			arg1 = args[1].(layoutmgt.CreateLayoutRequest)
+			arg1 = args[1].(layoutmgt.CreateLayoutRequestWithID)
 		}
 		run(
 			arg0,
@@ -105,7 +105,7 @@ func (_c *LayoutMgtServiceInterfaceMock_CreateLayout_Call) Return(layout1 *layou
 	return _c
 }
 
-func (_c *LayoutMgtServiceInterfaceMock_CreateLayout_Call) RunAndReturn(run func(ctx context.Context, layout layoutmgt.CreateLayoutRequest) (*layoutmgt.Layout, *common.ServiceError)) *LayoutMgtServiceInterfaceMock_CreateLayout_Call {
+func (_c *LayoutMgtServiceInterfaceMock_CreateLayout_Call) RunAndReturn(run func(ctx context.Context, layout layoutmgt.CreateLayoutRequestWithID) (*layoutmgt.Layout, *common.ServiceError)) *LayoutMgtServiceInterfaceMock_CreateLayout_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### Purpose

When a layout is imported via the declarative import flow, the `id` specified in the YAML was silently discarded and a fresh UUID was generated instead. The imported layout therefore never got the intended id, which breaks references to it (e.g. `layoutId` on organization units) and makes imports non-idempotent by id.

Themes and every other importable resource (organization unit, entity type, role, user, agent) already honor the incoming `id`; layout was the only outlier.

### Approach

Mirror the theme pattern for layouts:

- Add a `CreateLayoutRequestWithID` service request type that carries an optional `id`.
- `CreateLayout` now honors `layout.ID` when non-empty and only generates a UUID when it is empty, then builds a plain `CreateLayoutRequest` for the store (the store signature is unchanged).
- The public create HTTP handler wraps the request into the WithID form without an id, so the public API still cannot set a client-supplied id (same as themes).
- The layout import adapter passes `ID: req.ID` through to `CreateLayout`.

### Related Issues
- Fixes #4316

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Layout creation now supports optional client-provided IDs.
  * Layout imports preserve IDs specified in imported layout data.
  * When no ID is provided, new IDs are generated automatically.
* **Bug Fixes**
  * Improved consistency between layout creation and layout import behavior, including ID-aware request handling.
* **Tests**
  * Added/expanded coverage for ID preservation and layout import upsert/create scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->