### PR TITLE
Add an Application/User sub-tab split to the application token tab

### DIFF
--- a/docs/content/guides/applications/application-settings.mdx
+++ b/docs/content/guides/applications/application-settings.mdx
@@ -19,7 +19,7 @@ The **Application ID** and **Client ID** are shown on the application's General 
 
 ## Control Who Can Sign In
 
-Under **Access** on the General tab, you can configure which users can register with this application and provide the application's URL and redirect URIs.
+Under **Access** on the General tab, you can configure which users can register with this application and provide the application's URL and redirect URIs. The **Allowed User Types** and **Authorized Redirect URIs** settings apply to applications that let users sign in and are hidden for applications that use only the `client_credentials` grant.
 
 | Setting | Description |
 |---------|-------------|
@@ -69,7 +69,16 @@ On the **Customization** tab, control how your application looks and what legal 
 This section applies to OAuth 2.0 / OIDC applications (Browser App, Full-stack App, Mobile App, and Backend Service). For applications that use the embedded sign-in approach, user attributes are configured in the assertion returned by the flow, not in tokens.
 :::
 
-On the **Token** tab, choose which user attributes each token carries, how long tokens stay valid, and the response format for ID tokens and userinfo.
+On the **Token** tab, configure what your application's tokens carry and how long they stay valid. The tab has two sub-tabs:
+
+- **User**: the tokens issued when a user signs in. Available when the application supports a user sign-in grant, such as `authorization_code`.
+- **Application**: the access token the application receives for itself through the `client_credentials` grant.
+
+Each sub-tab stays read-only until its grant type is enabled on the Advanced Settings tab.
+
+### User Tokens
+
+On the **User** sub-tab, choose which user attributes each token carries, how long tokens stay valid, and the response format for ID tokens and userinfo.
 
 **Access Token**: select the user attributes to include in the access token payload. Default attributes (`sub`, `iss`, `exp`, and others) are always included and cannot be removed. Set **Token Validity** in seconds (for example, `3600` for one hour).
 
@@ -93,7 +102,13 @@ You can also configure the ID token response format via the API. These settings 
 | **Encryption Algorithm** | Required for `JWE` and `NESTED_JWT`. Options: `RSA-OAEP`, `RSA-OAEP-256`. Requires an OAuth client certificate. |
 | **Encryption Encoding** | Required when Encryption Algorithm is set. Options: `A128CBC-HS256`, `A256GCM`. |
 
-For the `client_credentials` grant, the token represents the application itself rather than a user. You can add the application's OU claims (`ouId`, `ouName`, `ouHandle`) to it via the API using `clientConfig.attributes`.
+### Application Token
+
+On the **Application** sub-tab, configure the access token the application receives through the `client_credentials` grant. This token represents the application itself, so it carries no user attributes.
+
+**Claims**: add the application's own claims to the token. The available claims are `groups`, `roles`, and the organization unit claims `ouHandle`, `ouId`, and `ouName`. Default claims (`sub`, `iss`, `exp`, and others) are always included and cannot be removed.
+
+**Token Validity**: set how long this token stays valid, in seconds, independently of the user access token.
 
 ## Rotate the Client Secret
 

--- a/frontend/apps/console/src/features/agents/components/edit-agent/flows/EditFlowsSettings.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/flows/EditFlowsSettings.tsx
@@ -19,13 +19,13 @@
 import {Stack} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
+import SettingsLockNotice from '../../../../applications/components/common/SettingsLockNotice';
 import AuthenticationFlowSection from '../../../../applications/components/edit-application/flows-settings/AuthenticationFlowSection';
 import RecoveryFlowSection from '../../../../applications/components/edit-application/flows-settings/RecoveryFlowSection';
 import RegistrationFlowSection from '../../../../applications/components/edit-application/flows-settings/RegistrationFlowSection';
 import type {Application} from '../../../../applications/models/application';
 import {OAuth2GrantTypes} from '../../../../applications/models/oauth';
 import type {Agent, OAuthAgentConfig} from '../../../models/agent';
-import DelegationLockNotice from '../shared/DelegationLockNotice';
 
 interface EditFlowsSettingsProps {
   agent: Agent;
@@ -53,7 +53,7 @@ export default function EditFlowsSettings({
 
   return (
     <Stack spacing={3}>
-      <DelegationLockNotice
+      <SettingsLockNotice
         isUnlocked={isUnlocked}
         message={t(
           'agents:edit.flows.delegationLock.message',
@@ -80,7 +80,7 @@ export default function EditFlowsSettings({
             entityLabel="agent"
           />
         </Stack>
-      </DelegationLockNotice>
+      </SettingsLockNotice>
     </Stack>
   );
 }

--- a/frontend/apps/console/src/features/agents/components/edit-agent/tokens/AgentAccessTokenSection.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/tokens/AgentAccessTokenSection.tsx
@@ -16,15 +16,13 @@
  * under the License.
  */
 
-import {SettingsCard} from '@thunderid/components';
 import {useGetAgentType, useGetAgentTypes} from '@thunderid/configure-agent-types';
-import {Card, CardContent, Chip, FormControl, FormLabel, Grid, Stack, TextField, Typography} from '@wso2/oxygen-ui';
-import {useEffect, useState, type JSX} from 'react';
+import {type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
-import JwtPreview from '../../../../applications/components/edit-application/token-settings/JwtPreview';
+import ClientAccessTokenSection from '../../../../applications/components/edit-application/token-settings/ClientAccessTokenSection';
 import TokenConstants from '../../../../applications/constants/token-constants';
-import type {OAuth2Config} from '../../../../applications/models/oauth';
-import type {Agent, AgentInboundAuthConfig, OAuthAgentConfig} from '../../../models/agent';
+import type {InboundAuthConfig} from '../../../../applications/models/inbound-auth';
+import type {Agent, OAuthAgentConfig} from '../../../models/agent';
 
 interface AgentAccessTokenSectionProps {
   agent: Agent;
@@ -34,13 +32,10 @@ interface AgentAccessTokenSectionProps {
   onValidationChange?: (hasErrors: boolean) => void;
 }
 
-// The client_credentials grant has no scopes, so `scope` never appears on this token.
-const ACCESS_TOKEN_DEFAULT_CLAIMS = TokenConstants.DEFAULT_TOKEN_ATTRIBUTES.filter((attr) => attr !== 'scope');
-
 /**
- * Access-token settings for the agent acting as its own client (client_credentials grant) —
- * the "clientConfig" half of AccessTokenConfig, as opposed to the "User" tab's userConfig
- * half. Not gated by Delegated mode, since client_credentials is available regardless.
+ * Access-token settings for the agent acting as its own client (client_credentials grant), backed
+ * by the shared ClientAccessTokenSection. The selectable claims merge the agent's type-schema
+ * attributes with the agent system, OU, group, and role attributes.
  */
 export default function AgentAccessTokenSection({
   agent,
@@ -50,64 +45,10 @@ export default function AgentAccessTokenSection({
   onValidationChange = undefined,
 }: AgentAccessTokenSectionProps): JSX.Element {
   const {t} = useTranslation();
-  const disabled = agent.isReadOnly === true;
 
   const {data: agentTypesData} = useGetAgentTypes();
   const matchedSchema = agentTypesData?.types?.find((s) => s.name === agent.type);
   const {data: schemaDetails, isLoading} = useGetAgentType(matchedSchema?.id);
-
-  const clientConfig = oauth2Config?.token?.accessToken?.clientConfig;
-  const currentAttributes = clientConfig?.attributes ?? [];
-
-  const [validityInput, setValidityInput] = useState<string>(String(clientConfig?.validityPeriod ?? 3600));
-  const parsedValidity = parseInt(validityInput, 10);
-  const isValidityInvalid = validityInput.trim() === '' || Number.isNaN(parsedValidity) || parsedValidity < 1;
-
-  useEffect(() => {
-    onValidationChange?.(isValidityInvalid);
-  }, [isValidityInvalid, onValidationChange]);
-
-  const handleOAuth2ConfigChange = (updates: Partial<OAuth2Config>): void => {
-    if (!oauth2Config || disabled) return;
-    const updatedConfig = {...oauth2Config, ...updates} as OAuthAgentConfig;
-    const currentInboundAuth: AgentInboundAuthConfig[] = editedAgent.inboundAuthConfig ?? agent.inboundAuthConfig ?? [];
-    const updatedInboundAuth = currentInboundAuth.map((auth) =>
-      auth.type === 'oauth2' ? {...auth, config: updatedConfig} : auth,
-    );
-    onFieldChange('inboundAuthConfig', updatedInboundAuth);
-  };
-
-  const handleAttributeClick = (attr: string): void => {
-    const nextAttrs = currentAttributes.includes(attr)
-      ? currentAttributes.filter((a) => a !== attr)
-      : [...currentAttributes, attr];
-
-    handleOAuth2ConfigChange({
-      token: {
-        ...oauth2Config?.token,
-        accessToken: {
-          ...oauth2Config?.token?.accessToken,
-          clientConfig: {...clientConfig, attributes: nextAttrs},
-        },
-      } as OAuth2Config['token'],
-    });
-  };
-
-  const handleValidityChange = (value: string): void => {
-    setValidityInput(value);
-    const parsed = parseInt(value, 10);
-    if (value.trim() !== '' && !Number.isNaN(parsed) && parsed >= 1) {
-      handleOAuth2ConfigChange({
-        token: {
-          ...oauth2Config?.token,
-          accessToken: {
-            ...oauth2Config?.token?.accessToken,
-            clientConfig: {...clientConfig, validityPeriod: parsed},
-          },
-        } as OAuth2Config['token'],
-      });
-    }
-  };
 
   const schemaAttributes = schemaDetails?.schema
     ? Object.entries(schemaDetails.schema)
@@ -115,104 +56,51 @@ export default function AgentAccessTokenSection({
         .map(([name]) => name)
     : [];
 
-  // Merge agent schema attributes with system attributes (name, owner) into a single chip list.
   const availableAttributes = Array.from(
     new Set([...schemaAttributes, ...TokenConstants.ADDITIONAL_AGENT_ATTRIBUTES]),
   ).sort();
 
-  const jwtPreview: Record<string, unknown> = {};
-  ACCESS_TOKEN_DEFAULT_CLAIMS.forEach((attr) => {
-    jwtPreview[attr] = `<${attr}>`;
-  });
-  currentAttributes.forEach((attr) => {
-    jwtPreview[attr] = `<${attr}>`;
-  });
+  const inboundAuthConfig = (editedAgent.inboundAuthConfig ??
+    agent.inboundAuthConfig ??
+    []) as unknown as InboundAuthConfig[];
 
   return (
-    <Stack spacing={3}>
-      <SettingsCard
-        title={t('agents:edit.tokens.agent.attributes.title', 'Access Token Attributes')}
-        description={t(
+    <ClientAccessTokenSection
+      oauth2Config={oauth2Config}
+      inboundAuthConfig={inboundAuthConfig}
+      onFieldChange={onFieldChange}
+      availableAttributes={availableAttributes}
+      isLoadingAttributes={isLoading}
+      disabled={agent.isReadOnly === true}
+      onValidationChange={onValidationChange}
+      inputId="agent-access-token-validity"
+      copy={{
+        attributesTitle: t('agents:edit.tokens.agent.attributes.title', 'Access Token Attributes'),
+        attributesDescription: t(
           'agents:edit.tokens.agent.attributes.description',
           'Attributes included in the access token this agent receives for its own requests (client_credentials grant).',
-        )}
-      >
-        <Grid container spacing={3}>
-          <Grid size={{xs: 12, md: 7}}>
-            <Typography variant="body2" sx={{mb: 1}}>
-              {t('agents:edit.tokens.agent.attributes.label', 'Add or Remove Attributes')}
-            </Typography>
-            <Typography variant="body2" color="text.disabled" sx={{mb: 2}}>
-              {t(
-                'agents:edit.tokens.agent.attributes.hint',
-                'Click on agent attributes to add them to its access token.',
-              )}
-            </Typography>
-            <Card>
-              <CardContent>
-                {isLoading && (
-                  <Typography variant="body2" color="text.secondary">
-                    {t('common:status.loading', 'Loading…')}
-                  </Typography>
-                )}
-                {!isLoading && (
-                  <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-                    {availableAttributes.map((attr) => {
-                      const isActive = currentAttributes.includes(attr);
-                      return (
-                        <Chip
-                          key={attr}
-                          label={attr}
-                          size="small"
-                          variant={isActive ? 'filled' : 'outlined'}
-                          color={isActive ? 'primary' : 'default'}
-                          onClick={disabled ? undefined : () => handleAttributeClick(attr)}
-                          sx={{cursor: disabled ? 'default' : 'pointer'}}
-                        />
-                      );
-                    })}
-                  </Stack>
-                )}
-              </CardContent>
-            </Card>
-          </Grid>
-          <Grid size={{xs: 12, md: 5}}>
-            <JwtPreview payload={jwtPreview} defaultClaims={ACCESS_TOKEN_DEFAULT_CLAIMS} />
-          </Grid>
-        </Grid>
-      </SettingsCard>
-
-      <SettingsCard
-        title={t('agents:edit.tokens.agent.validity.title', 'Token Validity')}
-        description={t(
+        ),
+        attributesLabel: t('agents:edit.tokens.agent.attributes.label', 'Add or Remove Attributes'),
+        attributesHint: t(
+          'agents:edit.tokens.agent.attributes.hint',
+          'Click on agent attributes to add them to its access token.',
+        ),
+        attributesEmpty: t(
+          'agents:edit.tokens.agent.attributes.empty',
+          'No attributes available. Configure attributes for this agent in the Attributes tab.',
+        ),
+        validityTitle: t('agents:edit.tokens.agent.validity.title', 'Token Validity'),
+        validityDescription: t(
           'agents:edit.tokens.agent.validity.description',
           'How long this access token remains valid before expiration.',
-        )}
-      >
-        <FormControl fullWidth required>
-          <FormLabel htmlFor="agent-access-token-validity">
-            {t('agents:edit.tokens.agent.validity.label', 'Token Validity')}
-          </FormLabel>
-          <TextField
-            id="agent-access-token-validity"
-            type="number"
-            fullWidth
-            value={validityInput}
-            onChange={(e) => handleValidityChange(e.target.value)}
-            error={isValidityInvalid}
-            helperText={
-              isValidityInvalid
-                ? t('agents:edit.tokens.agent.validity.error', 'Enter a validity period of at least 1 second.')
-                : t(
-                    'agents:edit.tokens.agent.validity.hint',
-                    'Token validity period in seconds (e.g., 3600 for 1 hour).',
-                  )
-            }
-            inputProps={{min: 1}}
-            disabled={disabled}
-          />
-        </FormControl>
-      </SettingsCard>
-    </Stack>
+        ),
+        validityLabel: t('agents:edit.tokens.agent.validity.label', 'Token Validity'),
+        validityHint: t(
+          'agents:edit.tokens.agent.validity.hint',
+          'Token validity period in seconds (e.g., 3600 for 1 hour).',
+        ),
+        validityError: t('agents:edit.tokens.agent.validity.error', 'Enter a validity period of at least 1 second.'),
+      }}
+    />
   );
 }

--- a/frontend/apps/console/src/features/agents/components/edit-agent/tokens/EditTokensSettings.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/tokens/EditTokensSettings.tsx
@@ -20,11 +20,11 @@ import {Box, Stack, Tab, Tabs} from '@wso2/oxygen-ui';
 import {useEffect, useState, type JSX, type SyntheticEvent} from 'react';
 import {useTranslation} from 'react-i18next';
 import AgentAccessTokenSection from './AgentAccessTokenSection';
+import SettingsLockNotice from '../../../../applications/components/common/SettingsLockNotice';
 import EditTokenSettings from '../../../../applications/components/edit-application/token-settings/EditTokenSettings';
 import type {Application} from '../../../../applications/models/application';
 import {OAuth2GrantTypes} from '../../../../applications/models/oauth';
 import type {Agent, OAuthAgentConfig} from '../../../models/agent';
-import DelegationLockNotice from '../shared/DelegationLockNotice';
 
 interface EditTokensSettingsProps {
   agent: Agent;
@@ -78,7 +78,7 @@ export default function EditTokensSettings({
           />
         )}
         {subTab === 1 && (
-          <DelegationLockNotice
+          <SettingsLockNotice
             isUnlocked={isUnlocked}
             message={t(
               'agents:edit.tokens.delegationLock.message',
@@ -96,7 +96,7 @@ export default function EditTokensSettings({
                 showActorClaim
               />
             </Stack>
-          </DelegationLockNotice>
+          </SettingsLockNotice>
         )}
       </Box>
     </Box>

--- a/frontend/apps/console/src/features/applications/components/common/SettingsLockNotice.tsx
+++ b/frontend/apps/console/src/features/applications/components/common/SettingsLockNotice.tsx
@@ -20,22 +20,20 @@ import {Alert, Box} from '@wso2/oxygen-ui';
 import {Lock} from '@wso2/oxygen-ui-icons-react';
 import type {ReactNode} from 'react';
 
-interface DelegationLockNoticeProps {
-  /** Whether Delegated mode is on for this agent. */
+interface SettingsLockNoticeProps {
+  /** Whether the wrapped settings are active. When false, they are shown but frozen. */
   isUnlocked: boolean;
-  /** Explains where/how to turn on Delegated mode — differs by caller (see Flows/Tokens). */
+  /** Explains why the settings are frozen and how to unlock them. */
   message: ReactNode;
   children: ReactNode;
 }
 
 /**
- * Wraps Flows/Tokens tab content with an info banner explaining that the settings shown below
- * aren't in effect for this agent yet, and gives the content a frozen look (dimmed, no pointer
- * interaction) rather than a blur — the values stay fully legible. The caller is still
- * responsible for disabling the inputs themselves (e.g. by forcing `isReadOnly` on the
- * agent/application it passes down) when `isUnlocked` is false.
+ * Wraps settings with an info banner and a frozen (dimmed, non-interactive) look when locked,
+ * keeping the values legible. Callers must still disable the inputs themselves (e.g. by forcing
+ * `isReadOnly`) when `isUnlocked` is false.
  */
-export default function DelegationLockNotice({isUnlocked, message, children}: DelegationLockNoticeProps): ReactNode {
+export default function SettingsLockNotice({isUnlocked, message, children}: SettingsLockNoticeProps): ReactNode {
   if (isUnlocked) {
     return children;
   }

--- a/frontend/apps/console/src/features/applications/components/common/__tests__/SettingsLockNotice.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/common/__tests__/SettingsLockNotice.test.tsx
@@ -18,14 +18,14 @@
 
 import {render, screen} from '@testing-library/react';
 import {describe, it, expect} from 'vitest';
-import DelegationLockNotice from '../DelegationLockNotice';
+import SettingsLockNotice from '../SettingsLockNotice';
 
-describe('DelegationLockNotice', () => {
+describe('SettingsLockNotice', () => {
   it('renders only the children when unlocked', () => {
     render(
-      <DelegationLockNotice isUnlocked message="Turn on Delegated mode to unlock these settings.">
+      <SettingsLockNotice isUnlocked message="Turn on Delegated mode to unlock these settings.">
         <div data-testid="content">content</div>
-      </DelegationLockNotice>,
+      </SettingsLockNotice>,
     );
 
     expect(screen.getByTestId('content')).toBeInTheDocument();
@@ -34,9 +34,9 @@ describe('DelegationLockNotice', () => {
 
   it('shows the given message and gives the (still visible) children a frozen look when locked', () => {
     render(
-      <DelegationLockNotice isUnlocked={false} message="Turn on Delegated mode to unlock these settings.">
+      <SettingsLockNotice isUnlocked={false} message="Turn on Delegated mode to unlock these settings.">
         <div data-testid="content">content</div>
-      </DelegationLockNotice>,
+      </SettingsLockNotice>,
     );
 
     expect(screen.getByTestId('content')).toBeInTheDocument();

--- a/frontend/apps/console/src/features/applications/components/edit-application/general-settings/AccessSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/general-settings/AccessSection.tsx
@@ -40,6 +40,7 @@ import {useTranslation} from 'react-i18next';
 import {z} from 'zod';
 import type {Application} from '../../../models/application';
 import type {OAuth2Config} from '../../../models/oauth';
+import isValidRedirectUriFormat from '../../../utils/isValidRedirectUriFormat';
 
 /**
  * Props for the {@link AccessSection} component.
@@ -68,6 +69,11 @@ interface AccessSectionProps {
    * @param hasErrors - Boolean indicating if the access settings have validation errors
    */
   onValidationChange?: (hasErrors: boolean) => void;
+  /**
+   * Whether to show user-facing access config (allowed user types, redirect URIs). Hidden for
+   * clients with no user-facing grant.
+   */
+  showUserAccessConfig?: boolean;
 }
 
 /**
@@ -89,6 +95,7 @@ export default function AccessSection({
   oauth2Config = undefined,
   onFieldChange,
   onValidationChange = undefined,
+  showUserAccessConfig = true,
 }: AccessSectionProps) {
   const {t} = useTranslation();
   const {data: userTypesData, isLoading: loadingUserTypes} = useGetUserTypes();
@@ -126,46 +133,22 @@ export default function AccessSection({
     void trigger();
   }, [trigger]);
 
-  // Effect to notify parent component of validation state changes
+  // Effect to notify parent component of validation state changes. Redirect URI errors are ignored
+  // when the user-access fields are hidden, since those settings no longer apply to the client.
   useEffect(() => {
     if (onValidationChange) {
-      const hasErrors =
-        !!errors.url || Object.keys(uriErrors).length > 0 || Object.keys(postLogoutUriErrors).length > 0;
-      onValidationChange(hasErrors);
+      const hasUriErrors =
+        showUserAccessConfig && (Object.keys(uriErrors).length > 0 || Object.keys(postLogoutUriErrors).length > 0);
+      onValidationChange(!!errors.url || hasUriErrors);
     }
-  }, [errors.url, uriErrors, postLogoutUriErrors, onValidationChange]);
-
-  // Pure URI-format check shared by the redirect and post-logout redirect URI fields.
-  const isValidUriFormat = (uri: string): boolean => {
-    try {
-      // Replace wildcards in the host portion with a placeholder so new URL() can parse it.
-      // Path wildcards (e.g., /callback/*, /**) parse fine natively.
-      // The backend enforces all wildcard rules (allowed patterns, server config).
-      const schemeEnd = uri.indexOf('://');
-      let uriForValidation = uri;
-      if (schemeEnd !== -1) {
-        const pathStart = uri.indexOf('/', schemeEnd + 3);
-        const hostPart = pathStart !== -1 ? uri.slice(schemeEnd + 3, pathStart) : uri.slice(schemeEnd + 3);
-        if (hostPart.includes('*')) {
-          const sanitizedHost = hostPart.replace(/\*/g, 'wildcard-placeholder');
-          uriForValidation =
-            uri.slice(0, schemeEnd + 3) + sanitizedHost + (pathStart !== -1 ? uri.slice(pathStart) : '');
-        }
-      }
-      // eslint-disable-next-line no-new
-      new URL(uriForValidation);
-      return true;
-    } catch {
-      return false;
-    }
-  };
+  }, [errors.url, uriErrors, postLogoutUriErrors, onValidationChange, showUserAccessConfig]);
 
   const validateUri = (uri: string, index: number): boolean => {
     if (!uri || uri.trim() === '') {
       setUriErrors((prev) => ({...prev, [index]: t('applications:edit.general.redirectUris.error.empty')}));
       return false;
     }
-    if (!isValidUriFormat(uri)) {
+    if (!isValidRedirectUriFormat(uri)) {
       setUriErrors((prev) => ({...prev, [index]: t('applications:edit.general.redirectUris.error.invalid')}));
       return false;
     }
@@ -188,7 +171,7 @@ export default function AccessSection({
       });
       return false;
     }
-    if (!isValidUriFormat(uri)) {
+    if (!isValidRedirectUriFormat(uri)) {
       setPostLogoutUriErrors((prev) => ({
         ...prev,
         [index]: t('applications:edit.general.postLogoutRedirectUris.error.invalid', 'Enter a valid URI'),
@@ -315,42 +298,44 @@ export default function AccessSection({
       description={t('applications:edit.general.sections.access.description')}
     >
       <Stack spacing={3}>
-        <FormControl fullWidth>
-          <FormLabel htmlFor="allowed-user-types-autocomplete">
-            {t('applications:edit.general.labels.allowedUserTypes')}
-          </FormLabel>
-          <Autocomplete
-            multiple
-            fullWidth
-            id="allowed-user-types-autocomplete"
-            options={userTypeOptions}
-            value={editedApp.allowedUserTypes ?? application.allowedUserTypes ?? []}
-            onChange={(_event, newValue) => onFieldChange('allowedUserTypes', newValue)}
-            loading={loadingUserTypes}
-            disabled={application.isReadOnly}
-            renderInput={(params) => (
-              <TextField
-                {...params}
-                placeholder={t('applications:edit.general.allowedUserTypes.placeholder')}
-                helperText={t('applications:edit.general.allowedUserTypes.hint')}
-                InputProps={{
-                  ...params.InputProps,
-                  endAdornment: (
-                    <>
-                      {loadingUserTypes ? <CircularProgress color="inherit" size={20} /> : null}
-                      {params.InputProps.endAdornment}
-                    </>
-                  ),
-                }}
-              />
-            )}
-            renderTags={(value, getTagProps) =>
-              value.map((option, index) => <Chip label={option} {...getTagProps({index})} key={option} />)
-            }
-            freeSolo={false}
-            disableClearable={false}
-          />
-        </FormControl>
+        {showUserAccessConfig && (
+          <FormControl fullWidth>
+            <FormLabel htmlFor="allowed-user-types-autocomplete">
+              {t('applications:edit.general.labels.allowedUserTypes')}
+            </FormLabel>
+            <Autocomplete
+              multiple
+              fullWidth
+              id="allowed-user-types-autocomplete"
+              options={userTypeOptions}
+              value={editedApp.allowedUserTypes ?? application.allowedUserTypes ?? []}
+              onChange={(_event, newValue) => onFieldChange('allowedUserTypes', newValue)}
+              loading={loadingUserTypes}
+              disabled={application.isReadOnly}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  placeholder={t('applications:edit.general.allowedUserTypes.placeholder')}
+                  helperText={t('applications:edit.general.allowedUserTypes.hint')}
+                  InputProps={{
+                    ...params.InputProps,
+                    endAdornment: (
+                      <>
+                        {loadingUserTypes ? <CircularProgress color="inherit" size={20} /> : null}
+                        {params.InputProps.endAdornment}
+                      </>
+                    ),
+                  }}
+                />
+              )}
+              renderTags={(value, getTagProps) =>
+                value.map((option, index) => <Chip label={option} {...getTagProps({index})} key={option} />)
+              }
+              freeSolo={false}
+              disableClearable={false}
+            />
+          </FormControl>
+        )}
 
         <FormControl fullWidth>
           <FormLabel htmlFor="application-url-input">{t('applications:edit.general.labels.applicationUrl')}</FormLabel>
@@ -375,7 +360,7 @@ export default function AccessSection({
           />
         </FormControl>
 
-        {oauth2Config && (
+        {showUserAccessConfig && oauth2Config && (
           <FormControl fullWidth>
             <FormLabel htmlFor="redirect-uris-section">{t('applications:edit.general.redirectUris.title')}</FormLabel>
             <Typography variant="caption" color="text.secondary" sx={{display: 'block', mb: 2}}>
@@ -428,7 +413,7 @@ export default function AccessSection({
           </FormControl>
         )}
 
-        {oauth2Config && (
+        {showUserAccessConfig && oauth2Config && (
           <FormControl fullWidth>
             <FormLabel htmlFor="post-logout-redirect-uris-section">
               {t('applications:edit.general.postLogoutRedirectUris.title', 'Post-Logout Redirect URIs')}

--- a/frontend/apps/console/src/features/applications/components/edit-application/general-settings/EditGeneralSettings.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/general-settings/EditGeneralSettings.tsx
@@ -74,6 +74,11 @@ interface EditGeneralSettingsProps {
    * @param hasErrors - Boolean indicating if the general settings have validation errors
    */
   onValidationChange?: (hasErrors: boolean) => void;
+  /**
+   * Whether to show user-facing access config (allowed user types, redirect URIs). Hidden for
+   * clients with no user-facing grant.
+   */
+  showUserAccessConfig?: boolean;
 }
 
 /**
@@ -96,6 +101,7 @@ export default function EditGeneralSettings({
   onCopyToClipboard,
   onDeleteSuccess = undefined,
   onValidationChange = undefined,
+  showUserAccessConfig = true,
 }: EditGeneralSettingsProps): JSX.Element {
   const {config} = useConfig();
   const {t} = useTranslation();
@@ -165,6 +171,7 @@ export default function EditGeneralSettings({
           oauth2Config={oauth2Config}
           onFieldChange={onFieldChange}
           onValidationChange={onValidationChange}
+          showUserAccessConfig={showUserAccessConfig}
         />
         {!application.isReadOnly && oauth2Config?.clientId?.toUpperCase() !== systemConsoleClientId && (
           <DangerZoneSection

--- a/frontend/apps/console/src/features/applications/components/edit-application/general-settings/__tests__/AccessSection.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/general-settings/__tests__/AccessSection.test.tsx
@@ -113,6 +113,28 @@ describe('AccessSection', () => {
       expect(screen.getByDisplayValue('https://example.com')).toBeInTheDocument();
     });
 
+    it('hides allowed user types and redirect URIs when user access config is disabled', () => {
+      vi.mocked(useGetUserTypes).mockReturnValue({
+        data: mockUserTypes,
+        isLoading: false,
+      } as unknown as MockedUseGetUserTypes);
+
+      render(
+        <AccessSection
+          application={mockApplication}
+          editedApp={{}}
+          oauth2Config={mockOAuth2Config}
+          onFieldChange={mockOnFieldChange}
+          showUserAccessConfig={false}
+        />,
+      );
+
+      expect(screen.queryByLabelText('Allowed User Types')).not.toBeInTheDocument();
+      expect(screen.queryByText('Authorized redirect URIs')).not.toBeInTheDocument();
+      // The generic application URL field stays visible for every client type.
+      expect(screen.getByLabelText('Application URL')).toBeInTheDocument();
+    });
+
     it('should render redirect URIs section when OAuth2 config is provided', () => {
       vi.mocked(useGetUserTypes).mockReturnValue({
         data: mockUserTypes,
@@ -572,6 +594,49 @@ describe('AccessSection', () => {
 
       await waitFor(() => {
         expect(mockOnValidationChange).toHaveBeenCalledWith(true);
+      });
+    });
+
+    it('stops reporting redirect URI errors once user access config is hidden', async () => {
+      const user = userEvent.setup();
+      const mockOnValidationChange = vi.fn();
+      vi.mocked(useGetUserTypes).mockReturnValue({
+        data: mockUserTypes,
+        isLoading: false,
+      } as unknown as MockedUseGetUserTypes);
+
+      const {rerender} = render(
+        <AccessSection
+          application={mockApplication}
+          editedApp={{}}
+          oauth2Config={mockOAuth2Config}
+          onFieldChange={mockOnFieldChange}
+          onValidationChange={mockOnValidationChange}
+        />,
+      );
+
+      const uriInput = screen.getByDisplayValue('https://example.com/callback');
+      await user.clear(uriInput);
+      await user.type(uriInput, 'not-a-valid-url');
+      await user.tab();
+      await waitFor(() => {
+        expect(mockOnValidationChange).toHaveBeenLastCalledWith(true);
+      });
+
+      // Removing the user-facing grant hides these fields; their stale error must no longer block save.
+      rerender(
+        <AccessSection
+          application={mockApplication}
+          editedApp={{}}
+          oauth2Config={mockOAuth2Config}
+          onFieldChange={mockOnFieldChange}
+          onValidationChange={mockOnValidationChange}
+          showUserAccessConfig={false}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(mockOnValidationChange).toHaveBeenLastCalledWith(false);
       });
     });
   });

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/ClientAccessTokenSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/ClientAccessTokenSection.tsx
@@ -1,0 +1,207 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {SettingsCard} from '@thunderid/components';
+import {
+  Alert,
+  Card,
+  CardContent,
+  Chip,
+  FormControl,
+  FormLabel,
+  Grid,
+  Stack,
+  TextField,
+  Typography,
+} from '@wso2/oxygen-ui';
+import {useEffect, useState, type JSX} from 'react';
+import {useTranslation} from 'react-i18next';
+import JwtPreview from './JwtPreview';
+import TokenConstants from '../../../constants/token-constants';
+import type {InboundAuthConfig} from '../../../models/inbound-auth';
+import type {OAuth2Config} from '../../../models/oauth';
+
+// The client_credentials grant carries no scopes, so `scope` never appears on this token.
+const ACCESS_TOKEN_DEFAULT_CLAIMS = TokenConstants.DEFAULT_TOKEN_ATTRIBUTES.filter((attr) => attr !== 'scope');
+
+/** Display copy for the section, supplied by the caller so agents and applications read differently. */
+export interface ClientAccessTokenCopy {
+  attributesTitle: string;
+  attributesDescription: string;
+  attributesLabel: string;
+  attributesHint: string;
+  attributesEmpty: string;
+  validityTitle: string;
+  validityDescription: string;
+  validityLabel: string;
+  validityHint: string;
+  validityError: string;
+}
+
+interface ClientAccessTokenSectionProps {
+  oauth2Config?: OAuth2Config;
+  inboundAuthConfig?: InboundAuthConfig[];
+  onFieldChange: (field: 'inboundAuthConfig', value: InboundAuthConfig[]) => void;
+  /** Claims the caller offers as selectable chips (agent schema attributes, or fixed OU/roles/groups). */
+  availableAttributes: string[];
+  isLoadingAttributes?: boolean;
+  disabled?: boolean;
+  onValidationChange?: (hasErrors: boolean) => void;
+  copy: ClientAccessTokenCopy;
+  inputId?: string;
+}
+
+/**
+ * Access-token settings for the OAuth client acting as its own subject (client_credentials grant) —
+ * the `clientConfig` half of AccessTokenConfig, with its own attribute set and validity period.
+ * Shared by the application and agent token tabs; the selectable attributes and copy are supplied
+ * by the caller.
+ */
+export default function ClientAccessTokenSection({
+  oauth2Config = undefined,
+  inboundAuthConfig = undefined,
+  onFieldChange,
+  availableAttributes,
+  isLoadingAttributes = false,
+  disabled = false,
+  onValidationChange = undefined,
+  copy,
+  inputId = 'client-access-token-validity',
+}: ClientAccessTokenSectionProps): JSX.Element {
+  const {t} = useTranslation();
+
+  const clientConfig = oauth2Config?.token?.accessToken?.clientConfig;
+  const currentAttributes = clientConfig?.attributes ?? [];
+
+  const [validityInput, setValidityInput] = useState<string>(String(clientConfig?.validityPeriod ?? 3600));
+  const parsedValidity = parseInt(validityInput, 10);
+  const isValidityInvalid = validityInput.trim() === '' || Number.isNaN(parsedValidity) || parsedValidity < 1;
+
+  useEffect(() => {
+    onValidationChange?.(isValidityInvalid);
+  }, [isValidityInvalid, onValidationChange]);
+
+  const commitClientConfig = (updates: {attributes?: string[]; validityPeriod?: number}): void => {
+    if (!oauth2Config || disabled) return;
+    const updatedConfig: OAuth2Config = {
+      ...oauth2Config,
+      token: {
+        ...oauth2Config.token,
+        accessToken: {
+          ...oauth2Config.token?.accessToken,
+          clientConfig: {...clientConfig, ...updates},
+        },
+      } as OAuth2Config['token'],
+    };
+    const currentInboundAuth = inboundAuthConfig ?? [];
+    const updatedInboundAuth = currentInboundAuth.map((auth) =>
+      auth.type === 'oauth2' ? {...auth, config: updatedConfig} : auth,
+    );
+    onFieldChange('inboundAuthConfig', updatedInboundAuth);
+  };
+
+  const handleAttributeClick = (attr: string): void => {
+    const nextAttrs = currentAttributes.includes(attr)
+      ? currentAttributes.filter((a) => a !== attr)
+      : [...currentAttributes, attr];
+    commitClientConfig({attributes: nextAttrs});
+  };
+
+  const handleValidityChange = (value: string): void => {
+    setValidityInput(value);
+    const parsed = parseInt(value, 10);
+    if (value.trim() !== '' && !Number.isNaN(parsed) && parsed >= 1) {
+      commitClientConfig({validityPeriod: parsed});
+    }
+  };
+
+  const jwtPreview: Record<string, unknown> = {};
+  ACCESS_TOKEN_DEFAULT_CLAIMS.forEach((attr) => {
+    jwtPreview[attr] = `<${attr}>`;
+  });
+  currentAttributes.forEach((attr) => {
+    jwtPreview[attr] = `<${attr}>`;
+  });
+
+  return (
+    <Stack spacing={3}>
+      <SettingsCard title={copy.attributesTitle} description={copy.attributesDescription}>
+        <Grid container spacing={3}>
+          <Grid size={{xs: 12, md: 7}}>
+            <Typography variant="body2" sx={{mb: 1}}>
+              {copy.attributesLabel}
+            </Typography>
+            <Typography variant="body2" color="text.disabled" sx={{mb: 2}}>
+              {copy.attributesHint}
+            </Typography>
+            <Card>
+              <CardContent>
+                {isLoadingAttributes && (
+                  <Typography variant="body2" color="text.secondary">
+                    {t('common:status.loading', 'Loading…')}
+                  </Typography>
+                )}
+                {!isLoadingAttributes && availableAttributes.length > 0 && (
+                  <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                    {availableAttributes.map((attr) => {
+                      const isActive = currentAttributes.includes(attr);
+                      return (
+                        <Chip
+                          key={attr}
+                          label={attr}
+                          size="small"
+                          variant={isActive ? 'filled' : 'outlined'}
+                          color={isActive ? 'primary' : 'default'}
+                          onClick={disabled ? undefined : () => handleAttributeClick(attr)}
+                          sx={{cursor: disabled ? 'default' : 'pointer'}}
+                        />
+                      );
+                    })}
+                  </Stack>
+                )}
+                {!isLoadingAttributes && availableAttributes.length === 0 && (
+                  <Alert severity="info">{copy.attributesEmpty}</Alert>
+                )}
+              </CardContent>
+            </Card>
+          </Grid>
+          <Grid size={{xs: 12, md: 5}}>
+            <JwtPreview payload={jwtPreview} defaultClaims={ACCESS_TOKEN_DEFAULT_CLAIMS} />
+          </Grid>
+        </Grid>
+      </SettingsCard>
+
+      <SettingsCard title={copy.validityTitle} description={copy.validityDescription}>
+        <FormControl fullWidth required>
+          <FormLabel htmlFor={inputId}>{copy.validityLabel}</FormLabel>
+          <TextField
+            id={inputId}
+            type="number"
+            fullWidth
+            value={validityInput}
+            onChange={(e) => handleValidityChange(e.target.value)}
+            error={isValidityInvalid}
+            helperText={isValidityInvalid ? copy.validityError : copy.validityHint}
+            inputProps={{min: 1}}
+            disabled={disabled}
+          />
+        </FormControl>
+      </SettingsCard>
+    </Stack>
+  );
+}

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/EditTokenSettingsTabs.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/EditTokenSettingsTabs.tsx
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Box, Tab, Tabs} from '@wso2/oxygen-ui';
+import {useEffect, useState, type JSX, type SyntheticEvent} from 'react';
+import {useTranslation} from 'react-i18next';
+import ClientAccessTokenSection from './ClientAccessTokenSection';
+import EditTokenSettings from './EditTokenSettings';
+import TokenConstants from '../../../constants/token-constants';
+import type {Application} from '../../../models/application';
+import type {OAuth2Config} from '../../../models/oauth';
+import {hasClientAccess, hasUserAccess} from '../../../utils/oauth2Rules';
+import SettingsLockNotice from '../../common/SettingsLockNotice';
+
+interface EditTokenSettingsTabsProps {
+  application: Application;
+  oauth2Config?: OAuth2Config;
+  onFieldChange: (field: keyof Application, value: unknown) => void;
+  onValidationChange?: (hasErrors: boolean) => void;
+}
+
+/**
+ * Token settings split into Application (client_credentials) and User sub-tabs. Each sub-tab is
+ * frozen with a lock notice when its enabling grant type is not selected.
+ */
+export default function EditTokenSettingsTabs({
+  application,
+  oauth2Config = undefined,
+  onFieldChange,
+  onValidationChange = undefined,
+}: EditTokenSettingsTabsProps): JSX.Element {
+  const {t} = useTranslation();
+  const [subTab, setSubTab] = useState(0);
+  const [clientTabHasError, setClientTabHasError] = useState(false);
+  const [userTabHasError, setUserTabHasError] = useState(false);
+
+  const grantTypes = oauth2Config?.grantTypes;
+  const clientUnlocked = hasClientAccess(grantTypes);
+  const userUnlocked = hasUserAccess(grantTypes);
+
+  useEffect(() => {
+    onValidationChange?.(clientTabHasError || userTabHasError);
+  }, [clientTabHasError, userTabHasError, onValidationChange]);
+
+  // Forcing isReadOnly disables every input via EditTokenSettings' existing
+  // disabled={application.isReadOnly} wiring when the user tab is locked.
+  const userTabApplication = {
+    ...application,
+    isReadOnly: (application.isReadOnly ?? false) || !userUnlocked,
+  };
+
+  const handleSubTabChange = (_event: SyntheticEvent, newValue: number): void => {
+    setSubTab(newValue);
+  };
+
+  return (
+    <Box>
+      <Tabs value={subTab} onChange={handleSubTabChange} aria-label="application token settings sub-tabs">
+        <Tab label={t('applications:edit.token.tabs.application', 'Application')} sx={{textTransform: 'none'}} />
+        <Tab label={t('applications:edit.token.tabs.user', 'User')} sx={{textTransform: 'none'}} />
+      </Tabs>
+      <Box sx={{pt: 3}}>
+        {subTab === 0 && (
+          <SettingsLockNotice
+            isUnlocked={clientUnlocked}
+            message={t(
+              'applications:edit.token.clientLock.message',
+              'These settings apply only when the client credentials grant is enabled. Add it in the Advanced tab to configure them.',
+            )}
+          >
+            <ClientAccessTokenSection
+              oauth2Config={oauth2Config}
+              inboundAuthConfig={application.inboundAuthConfig}
+              onFieldChange={onFieldChange}
+              availableAttributes={[...TokenConstants.CLIENT_TOKEN_OPTIONAL_CLAIMS]}
+              disabled={(application.isReadOnly ?? false) || !clientUnlocked}
+              onValidationChange={setClientTabHasError}
+              copy={{
+                attributesTitle: t('applications:edit.token.client.attributes.title', 'Access Token Claims'),
+                attributesDescription: t(
+                  'applications:edit.token.client.attributes.description',
+                  'Optional claims to include in the access token this application receives for its own requests (client_credentials grant).',
+                ),
+                attributesLabel: t('applications:edit.token.client.attributes.label', 'Add or Remove Claims'),
+                attributesHint: t(
+                  'applications:edit.token.client.attributes.hint',
+                  "Click a claim to include it in this application's client access token.",
+                ),
+                attributesEmpty: t('applications:edit.token.client.attributes.empty', 'No optional claims available.'),
+                validityTitle: t('applications:edit.token.client.validity.title', 'Token Validity'),
+                validityDescription: t(
+                  'applications:edit.token.client.validity.description',
+                  'How long this client access token remains valid before expiration.',
+                ),
+                validityLabel: t('applications:edit.token.client.validity.label', 'Token Validity'),
+                validityHint: t(
+                  'applications:edit.token.client.validity.hint',
+                  'Token validity period in seconds (e.g., 3600 for 1 hour).',
+                ),
+                validityError: t(
+                  'applications:edit.token.client.validity.error',
+                  'Enter a validity period of at least 1 second.',
+                ),
+              }}
+            />
+          </SettingsLockNotice>
+        )}
+        {subTab === 1 && (
+          <SettingsLockNotice
+            isUnlocked={userUnlocked}
+            message={t(
+              'applications:edit.token.userLock.message',
+              'These settings apply only when a user-facing grant is enabled. Add one in the Advanced tab to configure them.',
+            )}
+          >
+            <EditTokenSettings
+              application={userTabApplication}
+              oauth2Config={oauth2Config}
+              onFieldChange={onFieldChange}
+              onValidationChange={setUserTabHasError}
+            />
+          </SettingsLockNotice>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/ClientAccessTokenSection.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/ClientAccessTokenSection.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import userEvent from '@testing-library/user-event';
+import {render, screen} from '@thunderid/test-utils';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import type {InboundAuthConfig} from '../../../../models/inbound-auth';
+import ClientAccessTokenSection, {type ClientAccessTokenCopy} from '../ClientAccessTokenSection';
+
+vi.mock('../JwtPreview', () => ({
+  default: ({payload}: {payload: Record<string, unknown>}) => (
+    <pre data-testid="jwt-preview">{JSON.stringify(payload)}</pre>
+  ),
+}));
+
+const copy: ClientAccessTokenCopy = {
+  attributesTitle: 'Access Token Claims',
+  attributesDescription: 'Optional claims for the client access token.',
+  attributesLabel: 'Add or Remove Claims',
+  attributesHint: 'Click a claim to include it.',
+  attributesEmpty: 'No optional claims available.',
+  validityTitle: 'Token Validity',
+  validityDescription: 'How long the token is valid.',
+  validityLabel: 'Token Validity',
+  validityHint: 'Token validity period in seconds.',
+  validityError: 'Enter a validity period of at least 1 second.',
+};
+
+describe('ClientAccessTokenSection', () => {
+  const onFieldChange = vi.fn();
+  const inboundAuthConfig: InboundAuthConfig[] = [
+    {type: 'oauth2', config: {grantTypes: ['client_credentials'], responseTypes: []}},
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the supplied claims as selectable chips', () => {
+    render(
+      <ClientAccessTokenSection
+        oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
+        inboundAuthConfig={inboundAuthConfig}
+        onFieldChange={onFieldChange}
+        availableAttributes={['groups', 'roles']}
+        copy={copy}
+      />,
+    );
+
+    expect(screen.getByText('groups')).toBeInTheDocument();
+    expect(screen.getByText('roles')).toBeInTheDocument();
+  });
+
+  it('adds a claim to clientConfig when its chip is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <ClientAccessTokenSection
+        oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
+        inboundAuthConfig={inboundAuthConfig}
+        onFieldChange={onFieldChange}
+        availableAttributes={['groups', 'roles']}
+        copy={copy}
+      />,
+    );
+
+    await user.click(screen.getByText('roles'));
+
+    expect(onFieldChange).toHaveBeenCalledWith(
+      'inboundAuthConfig',
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'oauth2',
+          config: expect.objectContaining({
+            token: expect.objectContaining({
+              accessToken: expect.objectContaining({
+                clientConfig: expect.objectContaining({attributes: ['roles']}) as Record<string, unknown>,
+              }) as Record<string, unknown>,
+            }) as Record<string, unknown>,
+          }) as Record<string, unknown>,
+        }),
+      ]),
+    );
+  });
+
+  it('defaults the validity to 3600 and commits a valid change', async () => {
+    const user = userEvent.setup();
+    render(
+      <ClientAccessTokenSection
+        oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
+        inboundAuthConfig={inboundAuthConfig}
+        onFieldChange={onFieldChange}
+        availableAttributes={['groups']}
+        copy={copy}
+        inputId="client-access-token-validity"
+      />,
+    );
+
+    const input = document.getElementById('client-access-token-validity')!;
+    expect(input).toHaveValue(3600);
+
+    await user.clear(input);
+    await user.type(input, '7200');
+
+    expect(onFieldChange).toHaveBeenLastCalledWith(
+      'inboundAuthConfig',
+      expect.arrayContaining([
+        expect.objectContaining({
+          config: expect.objectContaining({
+            token: expect.objectContaining({
+              accessToken: expect.objectContaining({
+                clientConfig: expect.objectContaining({validityPeriod: 7200}) as Record<string, unknown>,
+              }) as Record<string, unknown>,
+            }) as Record<string, unknown>,
+          }) as Record<string, unknown>,
+        }),
+      ]),
+    );
+  });
+
+  it('reports a validation error without committing when the validity is cleared', async () => {
+    const user = userEvent.setup();
+    const onValidationChange = vi.fn();
+    render(
+      <ClientAccessTokenSection
+        oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
+        inboundAuthConfig={inboundAuthConfig}
+        onFieldChange={onFieldChange}
+        availableAttributes={['groups']}
+        copy={copy}
+        inputId="client-access-token-validity"
+        onValidationChange={onValidationChange}
+      />,
+    );
+
+    onFieldChange.mockClear();
+    await user.clear(document.getElementById('client-access-token-validity')!);
+
+    expect(screen.getByText('Enter a validity period of at least 1 second.')).toBeInTheDocument();
+    expect(onValidationChange).toHaveBeenLastCalledWith(true);
+    expect(onFieldChange).not.toHaveBeenCalled();
+  });
+
+  it('disables the validity input when disabled', () => {
+    render(
+      <ClientAccessTokenSection
+        oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
+        inboundAuthConfig={inboundAuthConfig}
+        onFieldChange={onFieldChange}
+        availableAttributes={['groups']}
+        copy={copy}
+        inputId="client-access-token-validity"
+        disabled
+      />,
+    );
+
+    expect(document.getElementById('client-access-token-validity')!).toBeDisabled();
+  });
+});

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/EditTokenSettingsTabs.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/EditTokenSettingsTabs.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import userEvent from '@testing-library/user-event';
+import {render, screen} from '@thunderid/test-utils';
+import {describe, it, expect, vi} from 'vitest';
+import type {Application} from '../../../../models/application';
+import EditTokenSettingsTabs from '../EditTokenSettingsTabs';
+
+vi.mock('../ClientAccessTokenSection', () => ({
+  default: () => <div data-testid="client-token-section" />,
+}));
+vi.mock('../EditTokenSettings', () => ({
+  default: () => <div data-testid="user-token-section" />,
+}));
+
+const application: Application = {id: 'app-1', name: 'Test App'};
+const clientLockMessage = /client credentials grant is enabled/i;
+const userLockMessage = /user-facing grant is enabled/i;
+
+describe('EditTokenSettingsTabs', () => {
+  const onFieldChange = vi.fn();
+
+  it('renders Application and User sub-tabs', () => {
+    render(
+      <EditTokenSettingsTabs
+        application={application}
+        oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
+        onFieldChange={onFieldChange}
+      />,
+    );
+
+    expect(screen.getByRole('tab', {name: 'Application'})).toBeInTheDocument();
+    expect(screen.getByRole('tab', {name: 'User'})).toBeInTheDocument();
+  });
+
+  it('unlocks the Application tab when client_credentials is granted', () => {
+    render(
+      <EditTokenSettingsTabs
+        application={application}
+        oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
+        onFieldChange={onFieldChange}
+      />,
+    );
+
+    expect(screen.getByTestId('client-token-section')).toBeInTheDocument();
+    expect(screen.queryByText(clientLockMessage)).not.toBeInTheDocument();
+  });
+
+  it('freezes the Application tab with a lock notice when client_credentials is not granted', () => {
+    render(
+      <EditTokenSettingsTabs
+        application={application}
+        oauth2Config={{grantTypes: ['authorization_code'], responseTypes: []}}
+        onFieldChange={onFieldChange}
+      />,
+    );
+
+    expect(screen.getByText(clientLockMessage)).toBeInTheDocument();
+  });
+
+  it('freezes the User tab with a lock notice when no user-facing grant is present', async () => {
+    const user = userEvent.setup();
+    render(
+      <EditTokenSettingsTabs
+        application={application}
+        oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
+        onFieldChange={onFieldChange}
+      />,
+    );
+
+    await user.click(screen.getByRole('tab', {name: 'User'}));
+
+    expect(screen.getByText(userLockMessage)).toBeInTheDocument();
+  });
+
+  it('unlocks the User tab when a user-facing grant is present', async () => {
+    const user = userEvent.setup();
+    render(
+      <EditTokenSettingsTabs
+        application={application}
+        oauth2Config={{grantTypes: ['authorization_code'], responseTypes: []}}
+        onFieldChange={onFieldChange}
+      />,
+    );
+
+    await user.click(screen.getByRole('tab', {name: 'User'}));
+
+    expect(screen.getByTestId('user-token-section')).toBeInTheDocument();
+    expect(screen.queryByText(userLockMessage)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/apps/console/src/features/applications/constants/token-constants.ts
+++ b/frontend/apps/console/src/features/applications/constants/token-constants.ts
@@ -42,6 +42,12 @@ const TokenConstants = {
   ADDITIONAL_AGENT_ATTRIBUTES: ['name', 'owner', 'ouHandle', 'ouId', 'ouName', 'groups', 'roles'],
 
   /**
+   * Optional claims that can be added to the client access token (client_credentials grant),
+   * where there is no end user to source attributes from.
+   */
+  CLIENT_TOKEN_OPTIONAL_CLAIMS: ['groups', 'ouHandle', 'ouId', 'ouName', 'roles'],
+
+  /**
    * Supported UserInfo response types
    */
   /**

--- a/frontend/apps/console/src/features/applications/pages/ApplicationEditPage.tsx
+++ b/frontend/apps/console/src/features/applications/pages/ApplicationEditPage.tsx
@@ -39,6 +39,7 @@ import {Link, useNavigate, useParams} from 'react-router';
 import RouteConfig from '../../../configs/RouteConfig';
 import useGetApplication from '../api/useGetApplication';
 import useUpdateApplication from '../api/useUpdateApplication';
+import SettingsLockNotice from '../components/common/SettingsLockNotice';
 import EditAdvancedSettings from '../components/edit-application/advanced-settings/EditAdvancedSettings';
 import EditCustomizationSettings from '../components/edit-application/customization-settings/EditCustomizationSettings';
 import EditFlowsSettings from '../components/edit-application/flows-settings/EditFlowsSettings';
@@ -46,16 +47,19 @@ import EditGeneralSettings from '../components/edit-application/general-settings
 import IntegrationGuides from '../components/edit-application/integration-guides/IntegrationGuides';
 import McpConnectTab from '../components/edit-application/mcp/McpConnectTab';
 import EditTokenSettings from '../components/edit-application/token-settings/EditTokenSettings';
+import EditTokenSettingsTabs from '../components/edit-application/token-settings/EditTokenSettingsTabs';
 import ApplicationConstants from '../constants/application-constants';
 import TemplateConstants from '../constants/template-constants';
 import type {Application} from '../models/application';
 import {McpClientTypes} from '../models/mcp-client';
-import type {OAuth2Config} from '../models/oauth';
+import {OAuth2GrantTypes, TokenEndpointAuthMethods, type OAuth2Config} from '../models/oauth';
 import deriveMcpClientType from '../utils/deriveMcpClientType';
 import {getIntegrationGuideForTemplate} from '../utils/getIntegrationGuidesForTemplate';
 import getTemplateCapabilities from '../utils/getTemplateCapabilities';
 import getTemplateFieldConstraints from '../utils/getTemplateFieldConstraints';
 import getTemplateMetadata from '../utils/getTemplateMetadata';
+import isValidRedirectUriFormat from '../utils/isValidRedirectUriFormat';
+import {hasUserAccess} from '../utils/oauth2Rules';
 
 interface McpTabConfig {
   key: string;
@@ -216,6 +220,40 @@ export default function ApplicationEditPage() {
 
   const isMcpClient = application.template === TemplateConstants.MCP_CLIENT_TEMPLATE_ID;
   const isMcpM2mOnly = deriveMcpClientType(oauth2Config?.grantTypes) === McpClientTypes.M2M;
+
+  // User-facing tabs (Flows, Customization) and the general Access section only apply when the
+  // client can act on behalf of a user. When it can't, they are frozen/hidden rather than removed.
+  const userAccessUnlocked = !oauth2Config || hasUserAccess(oauth2Config.grantTypes);
+  const userGatedApplication = userAccessUnlocked ? application : {...application, isReadOnly: true};
+  const userAccessLockMessage = t(
+    'applications:edit.userAccessLock.message',
+    'These settings apply only to user-facing flows. Enable a user-facing grant (e.g. authorization code) in the Advanced tab to configure them.',
+  );
+
+  // Page-level required checks, gated on the grant types they apply to, surfaced by name in the
+  // save bar. Computed from state (not reported by the tabs) since inactive tabs are unmounted.
+  // MCP clients run their own validation via McpConnectTab, so these are skipped there.
+  const grantTypes = oauth2Config?.grantTypes ?? [];
+  const hasAuthorizationCodeGrant = grantTypes.includes(OAuth2GrantTypes.AUTHORIZATION_CODE);
+  const hasValidRedirectUri = (oauth2Config?.redirectUris ?? []).some((uri) => isValidRedirectUriFormat(uri));
+  const isMissingRedirectUri = !isMcpClient && hasAuthorizationCodeGrant && !hasValidRedirectUri;
+  const isMissingCertificate =
+    !isMcpClient &&
+    oauth2Config?.tokenEndpointAuthMethod === TokenEndpointAuthMethods.PRIVATE_KEY_JWT &&
+    !oauth2Config?.certificate?.value;
+
+  // Each issue is a full, standalone sentence so the message needs no grammar assembly and stays
+  // translatable; multiple issues read as consecutive sentences.
+  const validationIssues: string[] = [];
+  if (isMissingRedirectUri) {
+    validationIssues.push(t('applications:edit.page.validation.missingRedirectUri', 'A redirect URI is required.'));
+  }
+  if (isMissingCertificate) {
+    validationIssues.push(t('applications:edit.page.validation.missingCertificate', 'A certificate is required.'));
+  }
+
+  const unsavedChangesMessage =
+    validationIssues.length > 0 ? validationIssues.join(' ') : t('applications:edit.page.unsavedChanges');
 
   const mcpTabs: McpTabConfig[] = isMcpClient
     ? (
@@ -543,27 +581,36 @@ export default function ApplicationEditPage() {
                   handleBack().catch(() => null);
                 }}
                 onValidationChange={setGeneralSettingsInvalid}
+                showUserAccessConfig={userAccessUnlocked}
               />
             </TabPanel>
 
             {/* Flows Tab */}
             <TabPanel value={activeTab} index={hasIntegrationGuides ? 2 : 1}>
-              <EditFlowsSettings application={application} editedApp={editedApp} onFieldChange={handleFieldChange} />
+              <SettingsLockNotice isUnlocked={userAccessUnlocked} message={userAccessLockMessage}>
+                <EditFlowsSettings
+                  application={userGatedApplication}
+                  editedApp={editedApp}
+                  onFieldChange={handleFieldChange}
+                />
+              </SettingsLockNotice>
             </TabPanel>
 
             {/* Customization Tab */}
             <TabPanel value={activeTab} index={hasIntegrationGuides ? 3 : 2}>
-              <EditCustomizationSettings
-                application={application}
-                editedApp={editedApp}
-                onFieldChange={handleFieldChange}
-                onValidationChange={setCustomizationSettingsInvalid}
-              />
+              <SettingsLockNotice isUnlocked={userAccessUnlocked} message={userAccessLockMessage}>
+                <EditCustomizationSettings
+                  application={userGatedApplication}
+                  editedApp={editedApp}
+                  onFieldChange={handleFieldChange}
+                  onValidationChange={setCustomizationSettingsInvalid}
+                />
+              </SettingsLockNotice>
             </TabPanel>
 
             {/* Token Tab */}
             <TabPanel value={activeTab} index={hasIntegrationGuides ? 4 : 3}>
-              <EditTokenSettings
+              <EditTokenSettingsTabs
                 application={application}
                 oauth2Config={oauth2Config}
                 onFieldChange={handleFieldChange}
@@ -590,7 +637,7 @@ export default function ApplicationEditPage() {
       {/* Floating Action Bar */}
       {hasChanges && (
         <UnsavedChangesBar
-          message={t('applications:edit.page.unsavedChanges')}
+          message={unsavedChangesMessage}
           resetLabel={t('applications:edit.page.reset')}
           saveLabel={t('applications:edit.page.save')}
           savingLabel={t('applications:edit.page.saving')}
@@ -601,6 +648,8 @@ export default function ApplicationEditPage() {
             customizationSettingsInvalid ||
             advancedSettingsInvalid ||
             generalSettingsInvalid ||
+            isMissingRedirectUri ||
+            isMissingCertificate ||
             application.isReadOnly === true
           }
           onReset={() => {

--- a/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationEditPage.test.tsx
+++ b/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationEditPage.test.tsx
@@ -115,6 +115,10 @@ vi.mock('../../components/edit-application/token-settings/EditTokenSettings', ()
   default: vi.fn(() => <div data-testid="edit-token-settings">Token Settings</div>),
 }));
 
+vi.mock('../../components/edit-application/token-settings/EditTokenSettingsTabs', () => ({
+  default: vi.fn(() => <div data-testid="edit-token-settings">Token Settings</div>),
+}));
+
 vi.mock('../../components/edit-application/advanced-settings/EditAdvancedSettings', () => ({
   default: vi.fn(() => <div data-testid="edit-advanced-settings">Advanced Settings</div>),
 }));
@@ -229,6 +233,7 @@ describe('ApplicationEditPage', () => {
     template: 'react',
     logoUrl: 'https://example.com/logo.png',
     url: 'https://example.com',
+    allowedUserTypes: ['user'],
     inboundAuthConfig: [
       {
         type: 'oauth2',
@@ -742,6 +747,74 @@ describe('ApplicationEditPage', () => {
       await waitFor(() => {
         expect(screen.getByText('You have unsaved changes')).toBeInTheDocument();
       });
+    });
+
+    it('keeps save enabled for a user-facing client with a redirect URI but no allowed user types', async () => {
+      const user = userEvent.setup();
+      mockUseGetApplication.mockReturnValue({
+        data: {...mockApplication, allowedUserTypes: []},
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as unknown as UseQueryResult<Application>);
+      renderComponent();
+
+      const nameSection = screen.getByText('Test Application').closest('div');
+      const editButton = nameSection?.querySelector('button');
+      await user.click(editButton!);
+      const nameInput = screen.getByRole('textbox');
+      await user.clear(nameInput);
+      await user.type(nameInput, 'Updated Application{Enter}');
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: /save changes/i})).toBeEnabled();
+      });
+    });
+
+    it('disables save with a named issue when authorization_code has no redirect URI', async () => {
+      const user = userEvent.setup();
+      mockUseGetApplication.mockReturnValue({
+        data: {
+          ...mockApplication,
+          inboundAuthConfig: [
+            {type: 'oauth2', config: {grantTypes: ['authorization_code'], responseTypes: ['code'], redirectUris: []}},
+          ],
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as unknown as UseQueryResult<Application>);
+      renderComponent();
+
+      const nameSection = screen.getByText('Test Application').closest('div');
+      const editButton = nameSection?.querySelector('button');
+      await user.click(editButton!);
+      const nameInput = screen.getByRole('textbox');
+      await user.clear(nameInput);
+      await user.type(nameInput, 'Updated Application{Enter}');
+
+      await waitFor(() => {
+        expect(screen.getByText('applications:edit.page.validation.missingRedirectUri')).toBeInTheDocument();
+      });
+      expect(screen.getByRole('button', {name: /save changes/i})).toBeDisabled();
+    });
+
+    it('freezes the flows tab when no user-facing grant is granted', async () => {
+      const user = userEvent.setup();
+      mockUseGetApplication.mockReturnValue({
+        data: {
+          ...mockApplication,
+          inboundAuthConfig: [{type: 'oauth2', config: {grantTypes: ['client_credentials'], responseTypes: []}}],
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as unknown as UseQueryResult<Application>);
+      renderComponent();
+
+      await user.click(screen.getByRole('tab', {name: /flows/i}));
+
+      expect(screen.getByText('applications:edit.userAccessLock.message')).toBeInTheDocument();
     });
 
     it('should display reset and save buttons in action bar', async () => {

--- a/frontend/apps/console/src/features/applications/utils/__tests__/isValidRedirectUriFormat.test.ts
+++ b/frontend/apps/console/src/features/applications/utils/__tests__/isValidRedirectUriFormat.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, it, expect} from 'vitest';
+import isValidRedirectUriFormat from '../isValidRedirectUriFormat';
+
+describe('isValidRedirectUriFormat', () => {
+  it('accepts well-formed URIs', () => {
+    expect(isValidRedirectUriFormat('https://example.com/callback')).toBe(true);
+    expect(isValidRedirectUriFormat('http://localhost:3000/cb')).toBe(true);
+  });
+
+  it('accepts host wildcards', () => {
+    expect(isValidRedirectUriFormat('https://*.example.com/callback')).toBe(true);
+    expect(isValidRedirectUriFormat('https://app-*.example.com/cb')).toBe(true);
+  });
+
+  it('accepts path wildcards', () => {
+    expect(isValidRedirectUriFormat('https://example.com/callback/*')).toBe(true);
+  });
+
+  it('rejects empty or whitespace-only input', () => {
+    expect(isValidRedirectUriFormat('')).toBe(false);
+    expect(isValidRedirectUriFormat('   ')).toBe(false);
+  });
+
+  it('rejects malformed URIs', () => {
+    expect(isValidRedirectUriFormat('not a uri')).toBe(false);
+    expect(isValidRedirectUriFormat('://missing-scheme')).toBe(false);
+  });
+});

--- a/frontend/apps/console/src/features/applications/utils/__tests__/oauth2Rules.test.ts
+++ b/frontend/apps/console/src/features/applications/utils/__tests__/oauth2Rules.test.ts
@@ -25,6 +25,8 @@ import {
   deriveOAuth2Flags,
   getPkceCaption,
   getPublicClientCaption,
+  hasClientAccess,
+  hasUserAccess,
   isGrantItemDisabled,
 } from '../oauth2Rules';
 
@@ -251,6 +253,28 @@ describe('getPublicClientCaption', () => {
     expect(getPublicClientCaption(deriveOAuth2Flags(confidentialConfig), confidentialConfig)[0]).toBe(
       'applications:edit.advanced.publicClient.confidential',
     );
+  });
+});
+
+describe('hasUserAccess', () => {
+  it('is true for authorization_code, CIBA, and password grants', () => {
+    expect(hasUserAccess([OAuth2GrantTypes.AUTHORIZATION_CODE])).toBe(true);
+    expect(hasUserAccess([OAuth2GrantTypes.CIBA])).toBe(true);
+    expect(hasUserAccess([OAuth2GrantTypes.PASSWORD])).toBe(true);
+  });
+
+  it('is false for client_credentials only and for no grants', () => {
+    expect(hasUserAccess([OAuth2GrantTypes.CLIENT_CREDENTIALS])).toBe(false);
+    expect(hasUserAccess([])).toBe(false);
+    expect(hasUserAccess(undefined)).toBe(false);
+  });
+});
+
+describe('hasClientAccess', () => {
+  it('is true only when client_credentials is granted', () => {
+    expect(hasClientAccess([OAuth2GrantTypes.CLIENT_CREDENTIALS])).toBe(true);
+    expect(hasClientAccess([OAuth2GrantTypes.AUTHORIZATION_CODE])).toBe(false);
+    expect(hasClientAccess(undefined)).toBe(false);
   });
 });
 

--- a/frontend/apps/console/src/features/applications/utils/isValidRedirectUriFormat.ts
+++ b/frontend/apps/console/src/features/applications/utils/isValidRedirectUriFormat.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Checks that a redirect URI is well formed, tolerating host wildcards. Wildcards in the host are
+ * replaced with a placeholder so `new URL()` can parse it; path wildcards (e.g. `/callback/*`) parse
+ * natively. The backend enforces the actual wildcard rules (allowed patterns, server config).
+ *
+ * Empty or whitespace-only input is rejected. Used by both the redirect and post-logout redirect
+ * URI fields and the page-level save validation, so a valid wildcard URI never disables Save.
+ *
+ * @param uri - The redirect URI to check
+ * @returns Whether the URI is a parseable, non-empty redirect URI
+ *
+ * @public
+ */
+export default function isValidRedirectUriFormat(uri: string): boolean {
+  if (!uri.trim()) return false;
+
+  try {
+    const schemeEnd = uri.indexOf('://');
+    let uriForValidation = uri;
+    if (schemeEnd !== -1) {
+      const pathStart = uri.indexOf('/', schemeEnd + 3);
+      const hostPart = pathStart !== -1 ? uri.slice(schemeEnd + 3, pathStart) : uri.slice(schemeEnd + 3);
+      if (hostPart.includes('*')) {
+        const sanitizedHost = hostPart.replace(/\*/g, 'wildcard-placeholder');
+        uriForValidation = uri.slice(0, schemeEnd + 3) + sanitizedHost + (pathStart !== -1 ? uri.slice(pathStart) : '');
+      }
+    }
+    // eslint-disable-next-line no-new
+    new URL(uriForValidation);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/frontend/apps/console/src/features/applications/utils/oauth2Rules.ts
+++ b/frontend/apps/console/src/features/applications/utils/oauth2Rules.ts
@@ -57,6 +57,30 @@ export function deriveOAuth2Flags(config: OAuth2Config): OAuth2Flags {
 }
 
 /**
+ * Grant types that authenticate an end user, unlocking the user-facing tabs (User token, Flows,
+ * Customization, and the general Access section).
+ */
+export const USER_ACCESS_GRANTS: readonly string[] = [
+  OAuth2GrantTypes.AUTHORIZATION_CODE,
+  OAuth2GrantTypes.CIBA,
+  OAuth2GrantTypes.PASSWORD,
+];
+
+/**
+ * Returns whether any granted flow acts on behalf of an end user.
+ */
+export function hasUserAccess(grantTypes: string[] | undefined): boolean {
+  return (grantTypes ?? []).some((grant) => USER_ACCESS_GRANTS.includes(grant));
+}
+
+/**
+ * Returns whether the client can obtain tokens as its own subject (client_credentials grant).
+ */
+export function hasClientAccess(grantTypes: string[] | undefined): boolean {
+  return (grantTypes ?? []).includes(OAuth2GrantTypes.CLIENT_CREDENTIALS);
+}
+
+/**
  * Returns whether the grant list contains a token-issuing grant.
  */
 function hasTokenIssuingGrant(grants: string[]): boolean {

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -2511,9 +2511,13 @@ const translations = {
     'edit.page.tabs.token': 'Token',
     'edit.page.tabs.advanced': 'Advanced Settings',
     'edit.page.unsavedChanges': 'Unsaved changes',
+    'edit.page.validation.missingRedirectUri': 'A redirect URI is required.',
+    'edit.page.validation.missingCertificate': 'A certificate is required.',
     'edit.page.reset': 'Reset',
     'edit.page.save': 'Save',
     'edit.page.saving': 'Saving...',
+    'edit.userAccessLock.message':
+      'These settings apply only to user-facing flows. Enable a user-facing grant (e.g. authorization code) in the Advanced tab to configure them.',
 
     'edit.mcp.connect.sections.identity': 'Connection',
     'edit.mcp.connect.sections.identity.description': 'Client identity and credentials for connecting to MCP servers.',
@@ -2653,6 +2657,23 @@ const translations = {
     'edit.token.scopes.add_custom.error.duplicate': 'This scope is already added',
     'edit.token.scopes.add_custom.error.invalid': 'Scope name must not contain spaces',
     'edit.token.scopes.openid_required': 'The openid scope is required and cannot be removed',
+    'edit.token.tabs.application': 'Application',
+    'edit.token.tabs.user': 'User',
+    'edit.token.clientLock.message':
+      'These settings apply only when the client credentials grant is enabled. Add it in the Advanced tab to configure them.',
+    'edit.token.userLock.message':
+      'These settings apply only when a user-facing grant is enabled. Add one in the Advanced tab to configure them.',
+    'edit.token.client.attributes.title': 'Access Token Claims',
+    'edit.token.client.attributes.description':
+      'Optional claims to include in the access token this application receives for its own requests (client_credentials grant).',
+    'edit.token.client.attributes.label': 'Add or Remove Claims',
+    'edit.token.client.attributes.hint': "Click a claim to include it in this application's client access token.",
+    'edit.token.client.attributes.empty': 'No optional claims available.',
+    'edit.token.client.validity.title': 'Token Validity',
+    'edit.token.client.validity.description': 'How long this client access token remains valid before expiration.',
+    'edit.token.client.validity.label': 'Token Validity',
+    'edit.token.client.validity.hint': 'Token validity period in seconds (e.g., 3600 for 1 hour).',
+    'edit.token.client.validity.error': 'Enter a validity period of at least 1 second.',
     'edit.advanced.audience.title': 'Default Audience',
     'edit.advanced.audience.description':
       "The default aud for access tokens that don't target a resource server (OIDC only or scopeless).",


### PR DESCRIPTION
### Purpose

Bring the agent edit page's token and grant-type experience to the application
edit page.

Previously the application Token tab exposed only user-token config, while the
agent Token tab already had a separate Application (client_credentials) token
tab, grant-type-aware locking of user-facing settings, and named save-time
validation. This PR gives applications the same behavior:

- A two sub-tab Token view: **Application** (client_credentials token) and **User**.
  The Application tab lets you add optional `ouHandle`, `ouId`, `ouName`, `roles`,
  and `groups` claims to the client access token and configure its own validity
  period, independent of the user token.
- Grant-type gating: the User token, Flows, Customization, and the general Access
  section (allowed user types, redirect URIs) are frozen or hidden when no
  user-facing grant (`authorization_code`, CIBA, `password`) is selected, and the
  Application token tab is frozen when `client_credentials` is not selected.
- Named save-time validation: the save bar now lists the exact required items to
  fix (e.g. "Before saving, add a redirect URI and select at least one allowed
  user type") instead of a generic message, matching the agent edit page.

### Approach

The change is frontend only. The data model already supported it
(`AccessTokenConfig` carries separate `userConfig` and `clientConfig`, each with
its own `validityPeriod` and attributes).

Key design decisions:

- **Share, don't duplicate.** Following the existing agent → application import
  convention, the client-credentials token section was extracted into a shared
  `ClientAccessTokenSection` (in `applications/.../token-settings/`), parameterized
  by attribute source and display copy. The agent tab now consumes it, passing its
  type-schema attributes merged with the agent system/OU/role attributes; the
  application tab passes the fixed OU/roles/groups claim list. The agent-only
  `DelegationLockNotice` was promoted to a shared, domain-neutral
  `SettingsLockNotice` used by both features.
- **Grant helpers.** `hasUserAccess` / `hasClientAccess` were added to
  `oauth2Rules` so the page and token container derive tab locking from grant
  types in one place. User access = `authorization_code`, CIBA, or `password`.
- **Locked, not hidden, tabs.** Tabs whose grant is absent stay visible but frozen
  (dimmed, non-interactive) via `SettingsLockNotice` plus a forced `isReadOnly`,
  mirroring the agent UX. Only the user-oriented fields inside the general Access
  section are hidden outright, since they are meaningless for a machine client.
- **Page-level validation.** Required checks (redirect URI, allowed user type,
  certificate) are computed in `ApplicationEditPage` from state and gated on the
  grant types they apply to, so inactive/unmounted tabs still contribute. MCP
  clients keep their own `McpConnectTab` validation and single token view and are
  left unchanged to keep the scope focused.

Note: applications with a user-facing grant but no allowed user type now require one before saving (parity with the agent page). This is a UX validation change, not an API/config breaking change.


### Related Issues
- https://github.com/thunder-id/thunderid/issues/4250

### Related PRs
- https://github.com/thunder-id/thunderid/pull/4214


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary
* **New Features**
  * Added grant-based locking and read-only gating for user-facing application settings, flows, and token tabs (Application vs User).
  * Introduced client access token claim selection, JWT preview, and validity-period validation guidance.
* **Bug Fixes**
  * Improved validation/save behavior for missing redirect URIs and required certificates, with errors suppressed when user-facing config is hidden.
* **Tests**
  * Added/updated coverage for lock notices, token settings, redirect URI format validation, and save-state scenarios.
* **Documentation**
  * Updated application settings guidance and UI text for the new access/token behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->