### PR TITLE
Update react-router to 7.18.1 to fix DoS advisory

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,8 +320,8 @@ catalogs:
       specifier: 16.0.1
       version: 16.0.1
     react-router:
-      specifier: 7.15.1
-      version: 7.15.1
+      specifier: 7.18.1
+      version: 7.18.1
     rimraf:
       specifier: 6.1.3
       version: 6.1.3
@@ -644,7 +644,7 @@ importers:
         version: 0.10.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@thunderid/react-router':
         specifier: 'catalog:'
-        version: 0.9.0(@thunderid/react@0.10.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 0.9.0(@thunderid/react@0.10.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@thunderid/utils':
         specifier: workspace:^
         version: link:../../packages/utils
@@ -707,7 +707,7 @@ importers:
         version: 16.0.1(i18next@25.6.0(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react-router:
         specifier: 'catalog:'
-        version: 7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-syntax-highlighter:
         specifier: ^16.1.0
         version: 16.1.1(react@19.2.3)
@@ -834,7 +834,7 @@ importers:
         version: 0.10.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@thunderid/react-router':
         specifier: 'catalog:'
-        version: 0.9.0(@thunderid/react@0.10.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 0.9.0(@thunderid/react@0.10.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@thunderid/utils':
         specifier: workspace:^
         version: link:../../packages/utils
@@ -861,7 +861,7 @@ importers:
         version: 16.0.1(i18next@25.6.0(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react-router:
         specifier: 'catalog:'
-        version: 7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@codecov/vite-plugin':
         specifier: 'catalog:'
@@ -988,7 +988,7 @@ importers:
         version: 16.0.1(i18next@25.6.0(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react-router:
         specifier: 'catalog:'
-        version: 7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'
@@ -1085,7 +1085,7 @@ importers:
         version: 16.0.1(i18next@25.6.0(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react-router:
         specifier: 'catalog:'
-        version: 7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'
@@ -1176,7 +1176,7 @@ importers:
         version: 16.0.1(i18next@25.6.0(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react-router:
         specifier: 'catalog:'
-        version: 7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'
@@ -1276,7 +1276,7 @@ importers:
         version: 16.0.1(i18next@25.6.0(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react-router:
         specifier: 'catalog:'
-        version: 7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -1388,7 +1388,7 @@ importers:
         version: 16.0.1(i18next@25.6.0(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react-router:
         specifier: 'catalog:'
-        version: 7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -1497,7 +1497,7 @@ importers:
         version: 16.0.1(i18next@25.6.0(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react-router:
         specifier: 'catalog:'
-        version: 7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'
@@ -1597,7 +1597,7 @@ importers:
         version: 16.0.1(i18next@25.6.0(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react-router:
         specifier: 'catalog:'
-        version: 7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -1712,7 +1712,7 @@ importers:
         version: 16.0.1(i18next@25.6.0(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react-router:
         specifier: 'catalog:'
-        version: 7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -2358,7 +2358,7 @@ importers:
         version: 16.0.1(i18next@25.6.0(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react-router:
         specifier: 'catalog:'
-        version: 7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -2458,7 +2458,7 @@ importers:
         version: 19.2.3(react@19.2.3)
       react-router:
         specifier: 'catalog:'
-        version: 7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@eslint/js':
         specifier: 9.39.1
@@ -2579,8 +2579,8 @@ importers:
         specifier: 'catalog:'
         version: 19.2.3(react@19.2.3)
       react-router-dom:
-        specifier: 7.15.1
-        version: 7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: 7.18.1
+        version: 7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@eslint/js':
         specifier: 9.27.0
@@ -11206,8 +11206,8 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  react-router-dom@7.15.1:
-    resolution: {integrity: sha512-AzF62gjY6U9rkMq4RfP/r2EVtQ7DMfNMjyOp/flLTCrtRylLiK4wT4pSq6O8rOXZ2eXdZYJPEYe+ifomiv+Igg==}
+  react-router-dom@7.18.1:
+    resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -11224,8 +11224,8 @@ packages:
     peerDependencies:
       react: '>=16.8'
 
-  react-router@7.15.1:
-    resolution: {integrity: sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==}
+  react-router@7.18.1:
+    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -17812,11 +17812,11 @@ snapshots:
       jose: 5.2.0
       tslib: 2.8.1
 
-  '@thunderid/react-router@0.9.0(@thunderid/react@0.10.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@thunderid/react-router@0.9.0(@thunderid/react@0.10.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@thunderid/react': 0.10.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
-      react-router: 7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react-router: 7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tslib: 2.8.1
 
   '@thunderid/react@0.10.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
@@ -23777,11 +23777,11 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       react-router: 6.30.4(react@19.2.3)
 
-  react-router-dom@7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  react-router-dom@7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      react-router: 7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react-router: 7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   react-router@5.3.4(react@19.2.3):
     dependencies:
@@ -23801,7 +23801,7 @@ snapshots:
       '@remix-run/router': 1.23.3
       react: 19.2.3
 
-  react-router@7.15.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  react-router@7.18.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       cookie: 1.1.1
       react: 19.2.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -67,7 +67,7 @@ catalog:
   react-dom: 19.2.3
   react-hook-form: 7.65.0
   react-i18next: 16.0.1
-  react-router: 7.15.1
+  react-router: 7.18.1
   rimraf: 6.1.3
   rolldown: 1.0.0-beta.45
   rollup-plugin-visualizer: 6.0.5

--- a/samples/apps/react-vanilla-sample/package.json
+++ b/samples/apps/react-vanilla-sample/package.json
@@ -18,7 +18,7 @@
     "@mui/system": "7.1.0",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-router-dom": "7.15.1"
+    "react-router-dom": "7.18.1"
   },
   "devDependencies": {
     "@eslint/js": "9.27.0",


### PR DESCRIPTION
### Purpose
Fixes the `pnpm audit` high-severity finding [GHSA-chx6-hx7r-mcp5](https://github.com/advisories/GHSA-chx6-hx7r-mcp5): React Router unauthenticated Denial of Service via inefficient route matching, affecting `react-router` `>=7.0.0 <7.18.0`.

### Approach
- Bumped the workspace catalog `react-router` from `7.15.1` to `7.18.1` in `pnpm-workspace.yaml`. All console/gate apps and workspace packages consume it via `catalog:`, and `@thunderid/react-router` takes it as a peer dependency, so this covers all 15 workspace resolution paths.
- Bumped `react-router-dom` from `7.15.1` to `7.18.1` in `samples/apps/react-vanilla-sample`, which pulled the last remaining vulnerable transitive `react-router`.
- Regenerated `pnpm-lock.yaml`.

After the change every `react-router`/`react-router-dom` resolution is `7.18.1`, and the advisory no longer appears in `pnpm audit`.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated React Router to version 7.18.1 across the workspace and the React vanilla sample.
  * Brings the newest improvements and fixes included in this React Router release.
  * Helps ensure consistency of routing behavior between workspace packages and the sample app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->