### PR TITLE
Added WithAttestationProvider option

### DIFF
--- a/backend/pkg/thunderidengine/engine.go
+++ b/backend/pkg/thunderidengine/engine.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/thunder-id/thunderid/internal/attestation"
 	"github.com/thunder-id/thunderid/internal/attributecache"
 	"github.com/thunder-id/thunderid/internal/authn/assert"
 	authnprovidermgr "github.com/thunder-id/thunderid/internal/authnprovider/manager"
@@ -170,13 +169,9 @@ func New(mux *http.ServeMux, opts ...Option) *Engine {
 	engineCtx.graphBuilder = graphbuilder.Initialize(engineCtx.flowFactory, engineCtx.execRegistry,
 		engineCtx.interceptorRegistry, graphCache)
 
-	attestationProvider, err := attestation.Initialize(engineCtx.runtimeCryptoSvc)
-	if err != nil {
-		logger.Fatal(ctx, "Failed to initialize attestation provider", log.Error(err))
-	}
 	engineCtx.flowExecService, err = flowexec.Initialize(mux, engineCtx.flowProvider, engineCtx.actorProvider,
 		engineCtx.execRegistry, engineCtx.interceptorRegistry, engineCtx.observabilitySvc,
-		engineCtx.runtimeCryptoSvc, attestationProvider, engineCtx.graphBuilder,
+		engineCtx.runtimeCryptoSvc, engineCtx.attestationProvider, engineCtx.graphBuilder,
 		engineCtx.runtimeStoreProvider, engineCtx.transactioner, flowConfig)
 	if err != nil {
 		logger.Fatal(ctx, "Failed to initialize flow execution service", log.Error(err))
@@ -337,6 +332,7 @@ type engineContext struct {
 	customExecutors       map[string]providers.Executor
 	observabilitySvc      providers.ObservabilityProvider
 	authzProvider         providers.AuthorizationProvider
+	attestationProvider   providers.AttestationProvider
 
 	runtimeStoreProvider providers.RuntimeStoreProvider
 }
@@ -487,4 +483,9 @@ func WithLogConfig(config engineconfig.LogConfig) Option {
 	return func(ctx *engineContext) {
 		ctx.logConfig = config
 	}
+}
+
+// WithAttestationProvider supplies the Attestation provider.
+func WithAttestationProvider(provider providers.AttestationProvider) Option {
+	return func(c *engineContext) { c.attestationProvider = provider }
 }

--- a/backend/pkg/thunderidengine/engine_test.go
+++ b/backend/pkg/thunderidengine/engine_test.go
@@ -40,6 +40,7 @@ import (
 	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 	"github.com/thunder-id/thunderid/tests/mocks/actorprovidermock"
+	"github.com/thunder-id/thunderid/tests/mocks/attestationprovidermock"
 	"github.com/thunder-id/thunderid/tests/mocks/authnprovider/providermock"
 	"github.com/thunder-id/thunderid/tests/mocks/authzmock"
 	"github.com/thunder-id/thunderid/tests/mocks/consentprovidermock"
@@ -75,6 +76,10 @@ func newTestAuthzProvider(t *testing.T) providers.AuthorizationProvider {
 
 func newTestDefaultAuthnProvider(t *testing.T) providers.AuthnProviderInterface {
 	return providermock.NewAuthnProviderInterfaceMock(t)
+}
+
+func newTestAttestationProvider(t *testing.T) providers.AttestationProvider {
+	return attestationprovidermock.NewAttestationProviderMock(t)
 }
 
 func newTestExecutor(t *testing.T, name string) providers.Executor {
@@ -264,6 +269,7 @@ func (suite *EngineTestSuite) TestEngineOptions() {
 		WithAuthorizationProvider(newTestAuthzProvider(suite.T())),
 		WithRuntimeStoreProvider(runtimeStoreProvider),
 		WithDefaultAuthnProvider(newTestDefaultAuthnProvider(suite.T())),
+		WithAttestationProvider(newTestAttestationProvider(suite.T())),
 	}
 	for _, opt := range opts {
 		opt(&ctx)
@@ -287,6 +293,7 @@ func (suite *EngineTestSuite) TestEngineOptions() {
 	assert.NotNil(suite.T(), ctx.observabilitySvc)
 	assert.NotNil(suite.T(), ctx.authzProvider)
 	assert.NotNil(suite.T(), ctx.defaultAuthnProvider)
+	assert.NotNil(suite.T(), ctx.attestationProvider)
 }
 
 func (suite *EngineTestSuite) TestJOSEConfig() {


### PR DESCRIPTION
### Purpose
Added WithAttestationProvider option to thunderidengine

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- #3037 

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to supply a custom attestation provider when initializing the ThunderID engine.
  * Engine startup now uses the provided provider for more flexible integration.

* **Tests**
  * Updated engine tests to inject a mock attestation provider and confirm it is correctly applied during initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->