### PR TITLE
Add integration tests for VC issuance and verifications flows

### DIFF
--- a/tests/integration/openid4vci/issuance_test.go
+++ b/tests/integration/openid4vci/issuance_test.go
@@ -1,0 +1,559 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package openid4vci exercises the OpenID4VCI credential issuer end to end against the live test server.
+package openid4vci
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	credentialConfigHandle = "integration_test_credential"
+	credentialVCT          = "https://credentials.thunderid.local/IntegrationTestCredential"
+
+	vciClientID     = "openid4vci_test_client"
+	vciClientSecret = "openid4vci_test_secret"
+	vciAppName      = "OpenID4VCITestApp"
+	vciRedirectURI  = "https://localhost:3000"
+
+	vciTestUsername = "vci_test_user"
+	vciTestPassword = "VciTest123!"
+)
+
+var (
+	vciTestOU = testutils.OrganizationUnit{
+		Handle:      "openid4vci-test-ou",
+		Name:        "OpenID4VCI Test OU",
+		Description: "Organization unit for OpenID4VCI integration testing",
+		Parent:      nil,
+	}
+
+	vciUserSchema = testutils.UserType{
+		Name: "openid4vci-test-person",
+		Schema: map[string]any{
+			"username":    map[string]any{"type": "string"},
+			"password":    map[string]any{"type": "string", "credential": true},
+			"email":       map[string]any{"type": "string"},
+			"given_name":  map[string]any{"type": "string"},
+			"family_name": map[string]any{"type": "string"},
+		},
+	}
+
+	vciAuthFlow = testutils.Flow{
+		Name:     "OpenID4VCI Test Auth Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_openid4vci_test",
+		Nodes: []map[string]any{
+			{
+				"id":        "start",
+				"type":      "START",
+				"onSuccess": "prompt_credentials",
+			},
+			{
+				"id":   "prompt_credentials",
+				"type": "PROMPT",
+				"prompts": []map[string]any{
+					{
+						"inputs": []map[string]any{
+							{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+							{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+						},
+						"action": map[string]any{"ref": "action_001", "nextNode": "credentials_auth"},
+					},
+				},
+			},
+			{
+				"id":   "credentials_auth",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]any{
+					"name": "CredentialsAuthExecutor",
+					"inputs": []map[string]any{
+						{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+						{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+					},
+				},
+				"onSuccess": "auth_assert",
+			},
+			{
+				"id":        "auth_assert",
+				"type":      "TASK_EXECUTION",
+				"executor":  map[string]any{"name": "AuthAssertExecutor"},
+				"onSuccess": "end",
+			},
+			{"id": "end", "type": "END"},
+		},
+	}
+)
+
+// OpenID4VCITestSuite runs the OpenID4VCI issuance tests against the live server.
+type OpenID4VCITestSuite struct {
+	suite.Suite
+	ouID         string
+	userSchemaID string
+	authFlowID   string
+	userID       string
+	appID        string
+	configID     string
+	client       *http.Client
+}
+
+// TestOpenID4VCITestSuite is the single entrypoint that runs every Test* method.
+func TestOpenID4VCITestSuite(t *testing.T) {
+	suite.Run(t, new(OpenID4VCITestSuite))
+}
+
+func (ts *OpenID4VCITestSuite) SetupSuite() {
+	ts.client = testutils.GetHTTPClient()
+
+	ouID, err := testutils.CreateOrganizationUnit(vciTestOU)
+	ts.Require().NoError(err, "create test OU")
+	ts.ouID = ouID
+
+	vciUserSchema.OUID = ouID
+	schemaID, err := testutils.CreateUserType(vciUserSchema)
+	ts.Require().NoError(err, "create user schema")
+	ts.userSchemaID = schemaID
+
+	flowID, err := testutils.CreateFlow(vciAuthFlow)
+	ts.Require().NoError(err, "create auth flow")
+	ts.authFlowID = flowID
+
+	user := testutils.User{
+		OUID: ts.ouID,
+		Type: "openid4vci-test-person",
+		Attributes: json.RawMessage(fmt.Sprintf(`{
+			"username": %q,
+			"password": %q,
+			"email": "vci_test_user@example.com",
+			"given_name": "Ada",
+			"family_name": "Lovelace"
+		}`, vciTestUsername, vciTestPassword)),
+	}
+	userID, err := testutils.CreateUser(user)
+	ts.Require().NoError(err, "create test user")
+	ts.userID = userID
+
+	ts.appID = ts.createApp()
+
+	validity := 3600
+	configID, err := testutils.CreateCredentialConfiguration(testutils.CredentialConfiguration{
+		Handle:      credentialConfigHandle,
+		OUID:        ts.ouID,
+		Name:        "Integration Test Credential",
+		Description: "Credential configuration for OpenID4VCI integration testing",
+		Format:      "dc+sd-jwt",
+		VCT:         credentialVCT,
+		Claims: []testutils.ClaimMapping{
+			{Name: "given_name", DisplayName: "Given Name"},
+			{Name: "family_name", DisplayName: "Family Name"},
+		},
+		ValiditySeconds: &validity,
+	})
+	ts.Require().NoError(err, "create credential configuration")
+	ts.configID = configID
+}
+
+func (ts *OpenID4VCITestSuite) TearDownSuite() {
+	if ts.configID != "" {
+		_ = testutils.DeleteCredentialConfiguration(ts.configID)
+	}
+	if ts.appID != "" {
+		_ = testutils.DeleteApplication(ts.appID)
+	}
+	if ts.userID != "" {
+		_ = testutils.DeleteUser(ts.userID)
+	}
+	if ts.authFlowID != "" {
+		_ = testutils.DeleteFlow(ts.authFlowID)
+	}
+	if ts.userSchemaID != "" {
+		_ = testutils.DeleteUserType(ts.userSchemaID)
+	}
+	if ts.ouID != "" {
+		_ = testutils.DeleteOrganizationUnit(ts.ouID)
+	}
+}
+
+// createApp registers the OAuth application used to obtain user access tokens.
+func (ts *OpenID4VCITestSuite) createApp() string {
+	app := map[string]any{
+		"name":                      vciAppName,
+		"description":               "OpenID4VCI integration test app",
+		"ouId":                      ts.ouID,
+		"authFlowId":                ts.authFlowID,
+		"isRegistrationFlowEnabled": false,
+		"allowedUserTypes":          []string{"openid4vci-test-person"},
+		"inboundAuthConfig": []map[string]any{
+			{
+				"type": "oauth2",
+				"config": map[string]any{
+					"clientId":                vciClientID,
+					"clientSecret":            vciClientSecret,
+					"redirectUris":            []string{vciRedirectURI},
+					"grantTypes":              []string{"authorization_code", "refresh_token"},
+					"responseTypes":           []string{"code"},
+					"tokenEndpointAuthMethod": "client_secret_post",
+					"scopes":                  []string{"openid", "profile", "email"},
+				},
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(app)
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testutils.TestServerURL+"/applications", bytes.NewBuffer(jsonData))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	ts.Require().Equalf(http.StatusCreated, resp.StatusCode, "create app failed: %s", string(body))
+
+	var created map[string]any
+	ts.Require().NoError(json.Unmarshal(body, &created))
+	id, _ := created["id"].(string)
+	ts.Require().NotEmpty(id, "app id missing")
+	return id
+}
+
+// obtainUserAccessToken runs the password-based auth-code flow and returns an
+// access token whose subject is the test user.
+func (ts *OpenID4VCITestSuite) obtainUserAccessToken(scope string) string {
+	tokenResp, err := testutils.ObtainAccessTokenWithPassword(
+		vciClientID, vciRedirectURI, scope, vciTestUsername, vciTestPassword, true, vciClientSecret)
+	ts.Require().NoError(err, "obtain user access token")
+	ts.Require().NotNil(tokenResp)
+	ts.Require().NotEmpty(tokenResp.AccessToken, "empty access token")
+	return tokenResp.AccessToken
+}
+
+// credentialIssuer reads the credential_issuer identifier from issuer metadata,
+// used as the holder proof audience.
+func (ts *OpenID4VCITestSuite) credentialIssuer() string {
+	res, meta, err := testutils.GetVCIIssuerMetadata()
+	ts.Require().NoError(err)
+	ts.Require().Equalf(http.StatusOK, res.StatusCode, "metadata: %s", string(res.Body))
+	issuer, _ := meta["credential_issuer"].(string)
+	ts.Require().NotEmpty(issuer, "credential_issuer missing from metadata")
+	return issuer
+}
+
+// jwtProof wraps a holder proof JWT in the single-proof credential-request shape.
+func jwtProof(proof string) map[string]any {
+	return map[string]any{"proof_type": "jwt", "jwt": proof}
+}
+
+// TestMetadata_ReflectsConfiguration verifies the issuer metadata advertises the
+// seeded credential configuration keyed by its handle.
+func (ts *OpenID4VCITestSuite) TestMetadata_ReflectsConfiguration() {
+	res, meta, err := testutils.GetVCIIssuerMetadata()
+	ts.Require().NoError(err)
+	ts.Require().Equalf(http.StatusOK, res.StatusCode, "metadata: %s", string(res.Body))
+
+	ts.NotEmpty(meta["credential_issuer"])
+	ts.NotEmpty(meta["credential_endpoint"])
+
+	supported, ok := meta["credential_configurations_supported"].(map[string]any)
+	ts.Require().Truef(ok, "credential_configurations_supported missing: %s", string(res.Body))
+	cfg, ok := supported[credentialConfigHandle].(map[string]any)
+	ts.Require().Truef(ok, "configuration %q not advertised: %s", credentialConfigHandle, string(res.Body))
+	ts.Equal(credentialConfigHandle, cfg["scope"])
+	ts.Equal(credentialVCT, cfg["vct"])
+}
+
+// TestCredentialOffer verifies an issuer-initiated offer, its deep link, and
+// resolving the linked stored offer by id.
+func (ts *OpenID4VCITestSuite) TestCredentialOffer() {
+	res, offer, err := testutils.GetVCICredentialOffer(credentialConfigHandle)
+	ts.Require().NoError(err)
+	ts.Require().Equalf(http.StatusOK, res.StatusCode, "offer: %s", string(res.Body))
+
+	credentialOffer, ok := offer["credential_offer"].(map[string]any)
+	ts.Require().Truef(ok, "credential_offer missing: %s", string(res.Body))
+	configs, ok := credentialOffer["credential_configuration_ids"].([]any)
+	ts.Require().Truef(ok, "credential_configuration_ids missing: %s", string(res.Body))
+	ts.Contains(configs, credentialConfigHandle)
+
+	deepLink, _ := offer["credential_offer_uri"].(string)
+	ts.Require().NotEmpty(deepLink, "credential_offer_uri missing")
+
+	// Resolve the deep link's credential_offer_uri to the stored offer by id.
+	parsed, err := url.Parse(deepLink)
+	ts.Require().NoError(err, "parse deep link")
+	offerURI := parsed.Query().Get("credential_offer_uri")
+	ts.Require().NotEmpty(offerURI, "credential_offer_uri query param missing from deep link")
+	offerID := offerURI[strings.LastIndex(offerURI, "/")+1:]
+	ts.Require().NotEmpty(offerID, "offer id missing")
+
+	storedRes, stored, err := testutils.GetVCIStoredOffer(offerID)
+	ts.Require().NoError(err)
+	ts.Require().Equalf(http.StatusOK, storedRes.StatusCode, "stored offer: %s", string(storedRes.Body))
+	storedConfigs, ok := stored["credential_configuration_ids"].([]any)
+	ts.Require().Truef(ok, "stored offer credential_configuration_ids missing: %s", string(storedRes.Body))
+	ts.Contains(storedConfigs, credentialConfigHandle)
+}
+
+// TestNonce verifies fresh c_nonce issuance.
+func (ts *OpenID4VCITestSuite) TestNonce() {
+	res, nonce, err := testutils.RequestVCINonce()
+	ts.Require().NoError(err)
+	ts.Require().Equalf(http.StatusOK, res.StatusCode, "nonce: %s", string(res.Body))
+	ts.NotEmpty(nonce)
+
+	res2, nonce2, err := testutils.RequestVCINonce()
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusOK, res2.StatusCode)
+	ts.NotEqual(nonce, nonce2, "each c_nonce must be unique")
+}
+
+// TestIssueCredential_HappyPath drives the full issuance flow: token -> nonce ->
+// holder proof -> credential, and asserts the issued SD-JWT VC binds the holder
+// key and discloses the configured claims.
+func (ts *OpenID4VCITestSuite) TestIssueCredential_HappyPath() {
+	token := ts.obtainUserAccessToken("openid")
+	issuer := ts.credentialIssuer()
+
+	_, nonce, err := testutils.RequestVCINonce()
+	ts.Require().NoError(err)
+
+	holderKey, err := testutils.GenerateDPoPKey("ES256")
+	ts.Require().NoError(err)
+	proof, err := testutils.CreateVCIHolderProof(holderKey, issuer, nonce, testutils.VCIHolderProofOptions{})
+	ts.Require().NoError(err)
+
+	res, err := testutils.RequestVCICredential("Bearer", token, "", map[string]any{
+		"credential_configuration_id": credentialConfigHandle,
+		"proof":                       jwtProof(proof),
+	})
+	ts.Require().NoError(err)
+	ts.Require().Equalf(http.StatusOK, res.StatusCode, "credential: %s", string(res.Body))
+
+	credential := ts.firstCredential(res.Body)
+	issuerClaims, disclosed := ts.decodeSDJWT(credential)
+
+	ts.Equal(credentialVCT, issuerClaims["vct"])
+	ts.NotEmpty(issuerClaims["sub"], "issued credential must carry sub")
+	cnf, ok := issuerClaims["cnf"].(map[string]any)
+	ts.Require().True(ok, "cnf missing from issued credential")
+	cnfJWK, ok := cnf["jwk"].(map[string]any)
+	ts.Require().True(ok, "cnf.jwk missing")
+	ts.Equal(holderKey.JWK, cnfJWK, "credential must bind the full holder public key")
+
+	ts.Equal("Ada", disclosed["given_name"])
+	ts.Equal("Lovelace", disclosed["family_name"])
+}
+
+// TestIssueCredential_MissingToken rejects a request with no access token.
+func (ts *OpenID4VCITestSuite) TestIssueCredential_MissingToken() {
+	res, err := testutils.RequestVCICredential("", "", "", map[string]any{
+		"credential_configuration_id": credentialConfigHandle,
+		"proof":                       jwtProof("dummy"),
+	})
+	ts.Require().NoError(err)
+	ts.Equal(http.StatusUnauthorized, res.StatusCode)
+	ts.Equal("invalid_token", ts.errorCode(res.Body))
+}
+
+// TestIssueCredential_AccessTokenInQuery rejects tokens presented in the query
+// string (RFC 6750 §2).
+func (ts *OpenID4VCITestSuite) TestIssueCredential_AccessTokenInQuery() {
+	token := ts.obtainUserAccessToken("openid")
+	body, _ := json.Marshal(map[string]any{
+		"credential_configuration_id": credentialConfigHandle,
+		"proof":                       jwtProof("dummy"),
+	})
+	req, err := http.NewRequest("POST",
+		testutils.TestServerURL+"/openid4vci/credential?access_token="+token, strings.NewReader(string(body)))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutils.GetRawHTTPClient().Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	ts.Equal(http.StatusUnauthorized, resp.StatusCode)
+	ts.Equal("invalid_token", ts.errorCode(raw))
+}
+
+// TestIssueCredential_InvalidProofAudience rejects a proof whose aud is not the
+// credential issuer and returns a fresh c_nonce for retry.
+func (ts *OpenID4VCITestSuite) TestIssueCredential_InvalidProofAudience() {
+	token := ts.obtainUserAccessToken("openid")
+	_, nonce, err := testutils.RequestVCINonce()
+	ts.Require().NoError(err)
+
+	holderKey, err := testutils.GenerateDPoPKey("ES256")
+	ts.Require().NoError(err)
+	proof, err := testutils.CreateVCIHolderProof(holderKey, "https://wrong-issuer.example.com", nonce,
+		testutils.VCIHolderProofOptions{})
+	ts.Require().NoError(err)
+
+	res, err := testutils.RequestVCICredential("Bearer", token, "", map[string]any{
+		"credential_configuration_id": credentialConfigHandle,
+		"proof":                       jwtProof(proof),
+	})
+	ts.Require().NoError(err)
+	ts.Equal(http.StatusBadRequest, res.StatusCode)
+	ts.Equal("invalid_proof", ts.errorCode(res.Body))
+	freshNonce := ts.errorField(res.Body, "c_nonce")
+	ts.NotEmpty(freshNonce, "error response must supply a c_nonce")
+	ts.NotEqual(nonce, freshNonce, "retry c_nonce must be rotated, not the original")
+}
+
+// TestIssueCredential_InvalidNonce rejects a proof carrying an unknown nonce.
+func (ts *OpenID4VCITestSuite) TestIssueCredential_InvalidNonce() {
+	token := ts.obtainUserAccessToken("openid")
+	issuer := ts.credentialIssuer()
+
+	holderKey, err := testutils.GenerateDPoPKey("ES256")
+	ts.Require().NoError(err)
+	proof, err := testutils.CreateVCIHolderProof(holderKey, issuer, "not-a-real-nonce",
+		testutils.VCIHolderProofOptions{})
+	ts.Require().NoError(err)
+
+	res, err := testutils.RequestVCICredential("Bearer", token, "", map[string]any{
+		"credential_configuration_id": credentialConfigHandle,
+		"proof":                       jwtProof(proof),
+	})
+	ts.Require().NoError(err)
+	ts.Equal(http.StatusBadRequest, res.StatusCode)
+	ts.Equal("invalid_nonce", ts.errorCode(res.Body))
+}
+
+// TestIssueCredential_NonceSingleUse rejects a second issuance that reuses an
+// already consumed c_nonce.
+func (ts *OpenID4VCITestSuite) TestIssueCredential_NonceSingleUse() {
+	token := ts.obtainUserAccessToken("openid")
+	issuer := ts.credentialIssuer()
+
+	_, nonce, err := testutils.RequestVCINonce()
+	ts.Require().NoError(err)
+	holderKey, err := testutils.GenerateDPoPKey("ES256")
+	ts.Require().NoError(err)
+
+	proof1, err := testutils.CreateVCIHolderProof(holderKey, issuer, nonce, testutils.VCIHolderProofOptions{})
+	ts.Require().NoError(err)
+	res1, err := testutils.RequestVCICredential("Bearer", token, "", map[string]any{
+		"credential_configuration_id": credentialConfigHandle,
+		"proof":                       jwtProof(proof1),
+	})
+	ts.Require().NoError(err)
+	ts.Require().Equalf(http.StatusOK, res1.StatusCode, "first issuance: %s", string(res1.Body))
+
+	proof2, err := testutils.CreateVCIHolderProof(holderKey, issuer, nonce, testutils.VCIHolderProofOptions{})
+	ts.Require().NoError(err)
+	res2, err := testutils.RequestVCICredential("Bearer", token, "", map[string]any{
+		"credential_configuration_id": credentialConfigHandle,
+		"proof":                       jwtProof(proof2),
+	})
+	ts.Require().NoError(err)
+	ts.Equal(http.StatusBadRequest, res2.StatusCode)
+	ts.Equal("invalid_nonce", ts.errorCode(res2.Body))
+}
+
+// TestIssueCredential_UnknownConfiguration rejects an unknown credential
+// configuration id.
+func (ts *OpenID4VCITestSuite) TestIssueCredential_UnknownConfiguration() {
+	token := ts.obtainUserAccessToken("openid")
+	issuer := ts.credentialIssuer()
+	_, nonce, err := testutils.RequestVCINonce()
+	ts.Require().NoError(err)
+	holderKey, err := testutils.GenerateDPoPKey("ES256")
+	ts.Require().NoError(err)
+	proof, err := testutils.CreateVCIHolderProof(holderKey, issuer, nonce, testutils.VCIHolderProofOptions{})
+	ts.Require().NoError(err)
+
+	res, err := testutils.RequestVCICredential("Bearer", token, "", map[string]any{
+		"credential_configuration_id": "does_not_exist",
+		"proof":                       jwtProof(proof),
+	})
+	ts.Require().NoError(err)
+	ts.Equal(http.StatusBadRequest, res.StatusCode)
+}
+
+// firstCredential extracts credentials[0].credential from a success response.
+func (ts *OpenID4VCITestSuite) firstCredential(body []byte) string {
+	var parsed struct {
+		Credentials []struct {
+			Credential string `json:"credential"`
+		} `json:"credentials"`
+	}
+	ts.Require().NoErrorf(json.Unmarshal(body, &parsed), "parse credential response: %s", string(body))
+	ts.Require().NotEmpty(parsed.Credentials, "no credentials returned")
+	ts.Require().NotEmpty(parsed.Credentials[0].Credential, "empty credential")
+	return parsed.Credentials[0].Credential
+}
+
+// decodeSDJWT splits a combined SD-JWT VC into the issuer JWT payload claims and
+// the map of disclosed claim name -> value.
+func (ts *OpenID4VCITestSuite) decodeSDJWT(sdjwt string) (map[string]any, map[string]any) {
+	parts := strings.Split(sdjwt, "~")
+	ts.Require().GreaterOrEqual(len(parts), 1)
+
+	issuerClaims, err := testutils.DecodeJWTPayloadMap(parts[0])
+	ts.Require().NoErrorf(err, "decode issuer JWT: %s", parts[0])
+
+	disclosed := map[string]any{}
+	for _, seg := range parts[1:] {
+		if seg == "" {
+			continue
+		}
+		decoded, err := base64.RawURLEncoding.DecodeString(seg)
+		if err != nil {
+			continue
+		}
+		var arr []any
+		if err := json.Unmarshal(decoded, &arr); err != nil || len(arr) != 3 {
+			continue
+		}
+		name, _ := arr[1].(string)
+		disclosed[name] = arr[2]
+	}
+	return issuerClaims, disclosed
+}
+
+// errorCode extracts the "error" field from an OpenID4VCI error body.
+func (ts *OpenID4VCITestSuite) errorCode(body []byte) string {
+	return ts.errorField(body, "error")
+}
+
+// errorField extracts a string field from a JSON error body.
+func (ts *OpenID4VCITestSuite) errorField(body []byte, field string) string {
+	var parsed map[string]any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return ""
+	}
+	v, _ := parsed[field].(string)
+	return v
+}

--- a/tests/integration/openid4vp/verification_test.go
+++ b/tests/integration/openid4vp/verification_test.go
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package openid4vp exercises the OpenID4VP verifier end to end against the live test server.
+package openid4vp
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	presentationDefinitionHandle = "integration_test_presentation"
+	presentationVCT              = "https://credentials.thunderid.local/IntegrationTestCredential"
+
+	// expectedClientID is derived by the verifier from the ecdsa signing cert
+	// under the default client_id_scheme (x509_san_dns) whose DNS SAN is localhost.
+	expectedClientID = "x509_san_dns:localhost"
+)
+
+var (
+	vpTestOU = testutils.OrganizationUnit{
+		Handle:      "openid4vp-test-ou",
+		Name:        "OpenID4VP Test OU",
+		Description: "Organization unit for OpenID4VP integration testing",
+		Parent:      nil,
+	}
+)
+
+// OpenID4VPTestSuite runs the OpenID4VP verification tests against the live server.
+type OpenID4VPTestSuite struct {
+	suite.Suite
+	ouID         string
+	definitionID string
+}
+
+// TestOpenID4VPTestSuite is the single entrypoint that runs every Test* method.
+func TestOpenID4VPTestSuite(t *testing.T) {
+	suite.Run(t, new(OpenID4VPTestSuite))
+}
+
+func (ts *OpenID4VPTestSuite) SetupSuite() {
+	ouID, err := testutils.CreateOrganizationUnit(vpTestOU)
+	ts.Require().NoError(err, "create test OU")
+	ts.ouID = ouID
+
+	enforceTrustedIssuer := false
+	definitionID, err := testutils.CreatePresentationDefinition(testutils.PresentationDefinition{
+		Handle:               presentationDefinitionHandle,
+		OUID:                 ts.ouID,
+		Name:                 "Integration Test Presentation",
+		Description:          "Presentation definition for OpenID4VP integration testing",
+		VCT:                  presentationVCT,
+		Format:               "dc+sd-jwt",
+		RequestedClaims:      []string{"given_name", "family_name"},
+		MandatoryClaims:      []string{"given_name"},
+		EnforceTrustedIssuer: &enforceTrustedIssuer,
+	})
+	ts.Require().NoError(err, "create presentation definition")
+	ts.definitionID = definitionID
+}
+
+func (ts *OpenID4VPTestSuite) TearDownSuite() {
+	if ts.definitionID != "" {
+		_ = testutils.DeletePresentationDefinition(ts.definitionID)
+	}
+	if ts.ouID != "" {
+		_ = testutils.DeleteOrganizationUnit(ts.ouID)
+	}
+}
+
+// initiateSession starts a verification session and returns the parsed response.
+func (ts *OpenID4VPTestSuite) initiateSession() *testutils.VPInitiateResponse {
+	res, init, err := testutils.InitiateVP(presentationDefinitionHandle)
+	ts.Require().NoError(err)
+	ts.Require().Equalf(http.StatusOK, res.StatusCode, "initiate: %s", string(res.Body))
+	ts.Require().NotEmpty(init.TxnID, "txn_id missing")
+	return init
+}
+
+// TestInitiate verifies a verification session is created with a wallet deep
+// link and status URL.
+func (ts *OpenID4VPTestSuite) TestInitiate() {
+	init := ts.initiateSession()
+	ts.NotEmpty(init.WalletURL, "wallet_url missing")
+	ts.True(strings.HasPrefix(init.WalletURL, "openid4vp://"), "wallet_url should be an openid4vp deep link")
+	ts.Equal("/openid4vp/status/"+init.TxnID, init.StatusURL)
+	ts.NotEmpty(init.ExpiresAt, "expires_at missing")
+}
+
+// TestRequestObject verifies the signed request object served to the wallet
+// carries the client id, nonce, DCQL query and the verifier encryption key.
+func (ts *OpenID4VPTestSuite) TestRequestObject() {
+	init := ts.initiateSession()
+
+	res, jar, ctype, err := testutils.FetchVPRequestObject(init.TxnID)
+	ts.Require().NoError(err)
+	ts.Require().Equalf(http.StatusOK, res.StatusCode, "request object: %s", string(res.Body))
+	ts.Contains(ctype, "application/oauth-authz-req+jwt")
+
+	req, err := testutils.ParseVPRequestObject(jar)
+	ts.Require().NoError(err)
+	ts.Equal(expectedClientID, req.ClientID)
+	ts.NotEmpty(req.Nonce, "nonce missing from request object")
+	ts.Equal(presentationVCT, req.VCT)
+	ts.Equal(presentationDefinitionHandle, req.CredentialID)
+	ts.NotNil(req.EncKey, "verifier encryption key missing")
+}
+
+// TestStatus_PendingBeforeResponse verifies a fresh session reports PENDING.
+func (ts *OpenID4VPTestSuite) TestStatus_PendingBeforeResponse() {
+	init := ts.initiateSession()
+
+	res, status, err := testutils.GetVPStatus(init.TxnID)
+	ts.Require().NoError(err)
+	ts.Require().Equalf(http.StatusOK, res.StatusCode, "status: %s", string(res.Body))
+	ts.Equal("PENDING", status.Status)
+	ts.Empty(status.ResultToken, "result token must not be present before verification")
+}
+
+// TestFullVerification_HappyPath drives the full flow: initiate, fetch request
+// object, present a self-signed SD-JWT VC from the wallet, and read the result
+// token from the status endpoint.
+func (ts *OpenID4VPTestSuite) TestFullVerification_HappyPath() {
+	init := ts.initiateSession()
+
+	_, jar, _, err := testutils.FetchVPRequestObject(init.TxnID)
+	ts.Require().NoError(err)
+	req, err := testutils.ParseVPRequestObject(jar)
+	ts.Require().NoError(err)
+
+	wallet, err := testutils.NewVPWallet()
+	ts.Require().NoError(err)
+	presentation, err := wallet.BuildPresentation(req, map[string]any{
+		"given_name":  "Ada",
+		"family_name": "Lovelace",
+	})
+	ts.Require().NoError(err)
+	response, err := wallet.EncryptResponse(req, presentation)
+	ts.Require().NoError(err)
+
+	res, err := testutils.SubmitVPResponse(init.TxnID, response)
+	ts.Require().NoError(err)
+	ts.Require().Equalf(http.StatusOK, res.StatusCode, "submit response: %s", string(res.Body))
+
+	status, err := testutils.PollVPStatusUntilTerminal(init.TxnID, 10, 200*time.Millisecond)
+	ts.Require().NoError(err)
+	ts.Require().Equalf("COMPLETED", status.Status, "final status; error=%q", status.Error)
+	ts.Require().NotEmpty(status.ResultToken, "result_token missing")
+
+	claims, err := testutils.DecodeJWTPayloadMap(status.ResultToken)
+	ts.Require().NoError(err)
+	ts.Equal(presentationDefinitionHandle, claims["definition_id"])
+
+	claimsJSON, _ := json.Marshal(claims)
+	ts.Contains(string(claimsJSON), "Ada", "result token should carry the verified given_name")
+	ts.Contains(string(claimsJSON), "Lovelace", "result token should carry the verified family_name")
+
+	// The result is delivered once: a second poll finds no session.
+	res2, _, err := testutils.GetVPStatus(init.TxnID)
+	ts.Require().NoError(err)
+	ts.Equal(http.StatusNotFound, res2.StatusCode, "session must be consumed after result delivery")
+}
+
+// TestWalletErrorResponse verifies a wallet-posted error marks the session FAILED.
+func (ts *OpenID4VPTestSuite) TestWalletErrorResponse() {
+	init := ts.initiateSession()
+
+	res, err := testutils.SubmitVPError(init.TxnID, "access_denied", "user cancelled the request")
+	ts.Require().NoError(err)
+	ts.Require().Equalf(http.StatusOK, res.StatusCode, "submit error: %s", string(res.Body))
+
+	status, err := testutils.PollVPStatusUntilTerminal(init.TxnID, 10, 200*time.Millisecond)
+	ts.Require().NoError(err)
+	ts.Equal("FAILED", status.Status)
+}
+
+// TestResponse_MalformedJWE rejects a response body that is not a valid JWE.
+func (ts *OpenID4VPTestSuite) TestResponse_MalformedJWE() {
+	init := ts.initiateSession()
+
+	res, err := testutils.SubmitVPResponse(init.TxnID, "this-is-not-a-valid-jwe")
+	ts.Require().NoError(err)
+	ts.Equal(http.StatusBadRequest, res.StatusCode)
+}
+
+// TestStatus_UnknownState returns 404 for an unknown transaction id.
+func (ts *OpenID4VPTestSuite) TestStatus_UnknownState() {
+	res, _, err := testutils.GetVPStatus("00000000-0000-0000-0000-000000000000")
+	ts.Require().NoError(err)
+	ts.Equal(http.StatusNotFound, res.StatusCode)
+}
+
+// TestInitiate_UnknownDefinition rejects an unknown presentation definition.
+func (ts *OpenID4VPTestSuite) TestInitiate_UnknownDefinition() {
+	res, _, err := testutils.InitiateVP("no_such_definition")
+	ts.Require().NoError(err)
+	ts.NotEqual(http.StatusOK, res.StatusCode)
+	ts.True(res.StatusCode == http.StatusNotFound || res.StatusCode == http.StatusBadRequest,
+		"expected 400 or 404, got %d: %s", res.StatusCode, string(res.Body))
+}
+
+// TestInitiate_MissingDefinitionID rejects a request with no definition id.
+func (ts *OpenID4VPTestSuite) TestInitiate_MissingDefinitionID() {
+	res, _, err := testutils.InitiateVP("")
+	ts.Require().NoError(err)
+	ts.Equal(http.StatusBadRequest, res.StatusCode)
+}
+
+// TestTrustAnchors returns the configured trust anchors (empty by default).
+func (ts *OpenID4VPTestSuite) TestTrustAnchors() {
+	req, err := http.NewRequest("GET", testutils.TestServerURL+"/openid4vp/trust-anchors", nil)
+	ts.Require().NoError(err)
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	ts.Require().Equalf(http.StatusOK, resp.StatusCode, "trust anchors: %s", string(body))
+
+	var anchors []map[string]any
+	ts.Require().NoErrorf(json.Unmarshal(body, &anchors), "trust anchors body: %s", string(body))
+}

--- a/tests/integration/testutils/models.go
+++ b/tests/integration/testutils/models.go
@@ -353,3 +353,72 @@ type AgentListResponse struct {
 	Count        int     `json:"count"`
 	Agents       []Agent `json:"agents"`
 }
+
+// ClaimMapping is a single selectively-disclosable claim in a credential
+// configuration. Name must match a user profile attribute key.
+type ClaimMapping struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName,omitempty"`
+}
+
+// CredentialDisplay is the optional display metadata of a credential configuration.
+type CredentialDisplay struct {
+	Locale  string `json:"locale,omitempty"`
+	LogoURI string `json:"logoUri,omitempty"`
+}
+
+// CredentialConfiguration is the request body for the OpenID4VCI credential
+// configuration management API. Handle is both the credential_configuration_id
+// and the OAuth scope; VCT and an OU (OUID or OUHandle) are required.
+type CredentialConfiguration struct {
+	Handle          string             `json:"handle"`
+	OUID            string             `json:"ouId,omitempty"`
+	OUHandle        string             `json:"ouHandle,omitempty"`
+	Name            string             `json:"name,omitempty"`
+	Description     string             `json:"description,omitempty"`
+	Format          string             `json:"format,omitempty"`
+	VCT             string             `json:"vct"`
+	Claims          []ClaimMapping     `json:"claims,omitempty"`
+	Display         *CredentialDisplay `json:"display,omitempty"`
+	ValiditySeconds *int               `json:"validitySeconds,omitempty"`
+}
+
+// PresentationDefinition is the request body for the OpenID4VP presentation
+// definition management API. Handle is the definition_id used on initiate and
+// the DCQL credential id; VCT and an OU (OUID or OUHandle) are required.
+type PresentationDefinition struct {
+	Handle               string              `json:"handle"`
+	OUID                 string              `json:"ouId,omitempty"`
+	OUHandle             string              `json:"ouHandle,omitempty"`
+	Name                 string              `json:"name,omitempty"`
+	Description          string              `json:"description,omitempty"`
+	VCT                  string              `json:"vct"`
+	Format               string              `json:"format,omitempty"`
+	RequestedClaims      []string            `json:"requestedClaims,omitempty"`
+	MandatoryClaims      []string            `json:"mandatoryClaims,omitempty"`
+	OptionalClaims       []string            `json:"optionalClaims,omitempty"`
+	ClaimValues          map[string][]string `json:"claimValues,omitempty"`
+	EnforceTrustedIssuer *bool               `json:"enforceTrustedIssuer,omitempty"`
+	TrustedAuthorities   []string            `json:"trustedAuthorities,omitempty"`
+}
+
+// VPInitiateResponse is the body returned by POST /openid4vp/initiate.
+type VPInitiateResponse struct {
+	TxnID     string `json:"txn_id"`
+	WalletURL string `json:"wallet_url"`
+	StatusURL string `json:"status_url"`
+	ExpiresAt string `json:"expires_at"`
+}
+
+// VPStatusResponse is the body returned by GET /openid4vp/status/{txn_id}.
+type VPStatusResponse struct {
+	Status      string `json:"status"`
+	ResultToken string `json:"result_token"`
+	Error       string `json:"error"`
+}
+
+// VCHTTPResult captures a raw HTTP status and body from a VC endpoint for assertions.
+type VCHTTPResult struct {
+	StatusCode int
+	Body       []byte
+}

--- a/tests/integration/testutils/vc_utils.go
+++ b/tests/integration/testutils/vc_utils.go
@@ -1,0 +1,831 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// OpenID4VCI/OpenID4VP test helpers: management-API seeding, wallet-facing HTTP
+// calls, the holder proof, and a self-contained wallet simulator (SD-JWT VC +
+// ECDH-ES encrypted response) built from stdlib.
+package testutils
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ecdh"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+// VC management APIs are platform-protected, so these helpers use the
+// admin-authenticated GetHTTPClient.
+
+// Base paths for the VC management APIs.
+const (
+	credentialConfigurationsEndpoint = "/openid4vci/credential-configurations"
+	presentationDefinitionsEndpoint  = "/openid4vp/presentation-definitions"
+)
+
+// CreateCredentialConfiguration creates a credential configuration via API and
+// returns the generated configuration ID.
+func CreateCredentialConfiguration(cfg CredentialConfiguration) (string, error) {
+	cfgJSON, err := json.Marshal(cfg)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal credential configuration: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", TestServerURL+credentialConfigurationsEndpoint, bytes.NewReader(cfgJSON))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := GetHTTPClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("expected status 201, got %d. Response: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	var created map[string]any
+	if err := json.Unmarshal(bodyBytes, &created); err != nil {
+		return "", fmt.Errorf("failed to parse response body: %w. Response: %s", err, string(bodyBytes))
+	}
+
+	id, ok := created["id"].(string)
+	if !ok {
+		return "", fmt.Errorf("response does not contain id or id is not a string. Response: %s", string(bodyBytes))
+	}
+	return id, nil
+}
+
+// DeleteCredentialConfiguration deletes a credential configuration by ID.
+func DeleteCredentialConfiguration(id string) error {
+	req, err := http.NewRequest("DELETE", TestServerURL+credentialConfigurationsEndpoint+"/"+id, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create delete request: %w", err)
+	}
+
+	client := GetHTTPClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send delete request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		responseBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("expected status 200 or 204, got %d. Response: %s", resp.StatusCode, string(responseBody))
+	}
+	return nil
+}
+
+// CreatePresentationDefinition creates a presentation definition via API and
+// returns the generated definition ID.
+func CreatePresentationDefinition(def PresentationDefinition) (string, error) {
+	defJSON, err := json.Marshal(def)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal presentation definition: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", TestServerURL+presentationDefinitionsEndpoint, bytes.NewReader(defJSON))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := GetHTTPClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("expected status 201, got %d. Response: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	var created map[string]any
+	if err := json.Unmarshal(bodyBytes, &created); err != nil {
+		return "", fmt.Errorf("failed to parse response body: %w. Response: %s", err, string(bodyBytes))
+	}
+
+	id, ok := created["id"].(string)
+	if !ok {
+		return "", fmt.Errorf("response does not contain id or id is not a string. Response: %s", string(bodyBytes))
+	}
+	return id, nil
+}
+
+// DeletePresentationDefinition deletes a presentation definition by ID.
+func DeletePresentationDefinition(id string) error {
+	req, err := http.NewRequest("DELETE", TestServerURL+presentationDefinitionsEndpoint+"/"+id, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create delete request: %w", err)
+	}
+
+	client := GetHTTPClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send delete request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		responseBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("expected status 200 or 204, got %d. Response: %s", resp.StatusCode, string(responseBody))
+	}
+	return nil
+}
+
+// OpenID4VCI wallet-facing endpoints are public, so these use the raw client;
+// the credential endpoint carries the OAuth access token set by the caller.
+
+// GetVCIIssuerMetadata fetches the credential issuer metadata document.
+func GetVCIIssuerMetadata() (*VCHTTPResult, map[string]any, error) {
+	req, err := http.NewRequest("GET", TestServerURL+"/.well-known/openid-credential-issuer", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	res, raw, err := doRawVCRequest(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	var parsed map[string]any
+	if res.StatusCode == http.StatusOK {
+		if err := json.Unmarshal(raw, &parsed); err != nil {
+			return res, nil, fmt.Errorf("parse metadata response: %w. Body: %s", err, string(raw))
+		}
+	}
+	return res, parsed, nil
+}
+
+// GetVCICredentialOffer fetches an issuer-initiated credential offer for a
+// credential configuration handle.
+func GetVCICredentialOffer(configID string) (*VCHTTPResult, map[string]any, error) {
+	u := TestServerURL + "/openid4vci/offer?credential_configuration_id=" + url.QueryEscape(configID)
+	req, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	res, raw, err := doRawVCRequest(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	var parsed map[string]any
+	if res.StatusCode == http.StatusOK {
+		if err := json.Unmarshal(raw, &parsed); err != nil {
+			return res, nil, fmt.Errorf("parse offer response: %w. Body: %s", err, string(raw))
+		}
+	}
+	return res, parsed, nil
+}
+
+// GetVCIStoredOffer fetches a stored credential offer by id (the target of
+// credential_offer_uri).
+func GetVCIStoredOffer(id string) (*VCHTTPResult, map[string]any, error) {
+	req, err := http.NewRequest("GET", TestServerURL+"/openid4vci/credential-offer/"+id, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	res, raw, err := doRawVCRequest(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	var parsed map[string]any
+	if res.StatusCode == http.StatusOK {
+		if err := json.Unmarshal(raw, &parsed); err != nil {
+			return res, nil, fmt.Errorf("parse stored offer response: %w. Body: %s", err, string(raw))
+		}
+	}
+	return res, parsed, nil
+}
+
+// RequestVCINonce requests a fresh c_nonce for holder proofs.
+func RequestVCINonce() (*VCHTTPResult, string, error) {
+	req, err := http.NewRequest("POST", TestServerURL+"/openid4vci/nonce", nil)
+	if err != nil {
+		return nil, "", err
+	}
+	res, raw, err := doRawVCRequest(req)
+	if err != nil {
+		return nil, "", err
+	}
+	var parsed struct {
+		CNonce string `json:"c_nonce"`
+	}
+	if res.StatusCode == http.StatusOK {
+		if err := json.Unmarshal(raw, &parsed); err != nil {
+			return res, "", fmt.Errorf("parse nonce response: %w. Body: %s", err, string(raw))
+		}
+	}
+	return res, parsed.CNonce, nil
+}
+
+// RequestVCICredential posts a credential request. tokenScheme is "Bearer" or
+// "DPoP"; dpopProof (when non-empty) is sent in the DPoP header. body is the
+// credential request payload (any JSON-serializable value).
+func RequestVCICredential(tokenScheme, accessToken, dpopProof string, body any) (*VCHTTPResult, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal credential request: %w", err)
+	}
+	req, err := http.NewRequest("POST", TestServerURL+"/openid4vci/credential", bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if accessToken != "" {
+		if tokenScheme == "" {
+			tokenScheme = "Bearer"
+		}
+		req.Header.Set("Authorization", tokenScheme+" "+accessToken)
+	}
+	if dpopProof != "" {
+		req.Header.Set("DPoP", dpopProof)
+	}
+	res, _, err := doRawVCRequest(req)
+	return res, err
+}
+
+// OpenID4VCI holder proof and shared crypto helpers.
+
+// vciProofType is the required "typ" header of an OpenID4VCI holder proof JWT.
+const vciProofType = "openid4vci-proof+jwt"
+
+// VCIHolderProofOptions tweaks the holder proof JWT produced by
+// CreateVCIHolderProof. Zero values keep the RFC-compliant defaults.
+type VCIHolderProofOptions struct {
+	// Typ overrides the "typ" header (default openid4vci-proof+jwt).
+	Typ string
+	// OmitTyp drops the "typ" header entirely.
+	OmitTyp bool
+	// OmitJWK drops the embedded "jwk" header.
+	OmitJWK bool
+	// Aud overrides the "aud" claim (default: the supplied issuer).
+	Aud string
+	// OmitNonce drops the "nonce" claim.
+	OmitNonce bool
+	// Nonce overrides the "nonce" claim (default: the supplied nonce).
+	Nonce string
+	// IatOffset shifts the "iat" claim by the given seconds (negative = stale).
+	IatOffset int64
+}
+
+// CreateVCIHolderProof mints an OpenID4VCI holder proof JWT bound to key. The
+// proof carries the embedded holder JWK, aud=credentialIssuer and the supplied
+// c_nonce, signed with the key's algorithm (ES256).
+func CreateVCIHolderProof(key *DPoPKey, credentialIssuer, nonce string, opts VCIHolderProofOptions) (string, error) {
+	header := map[string]any{
+		"typ": vciProofType,
+		"alg": key.Alg,
+		"jwk": key.JWK,
+	}
+	if opts.Typ != "" {
+		header["typ"] = opts.Typ
+	}
+	if opts.OmitTyp {
+		delete(header, "typ")
+	}
+	if opts.OmitJWK {
+		delete(header, "jwk")
+	}
+
+	aud := credentialIssuer
+	if opts.Aud != "" {
+		aud = opts.Aud
+	}
+	payload := map[string]any{
+		"aud": aud,
+		"iat": time.Now().Unix() + opts.IatOffset,
+	}
+	nonceVal := nonce
+	if opts.Nonce != "" {
+		nonceVal = opts.Nonce
+	}
+	if !opts.OmitNonce {
+		payload["nonce"] = nonceVal
+	}
+
+	return signCompactJWS(header, payload, key.Private, key.Alg)
+}
+
+// signCompactJWS serializes header and payload, signs the signing input with the
+// given signer and algorithm, and returns the compact JWS. ECDSA signatures use
+// the fixed-length P1363 (r||s) form the server's verifier expects.
+func signCompactJWS(header, payload map[string]any, priv crypto.Signer, alg string) (string, error) {
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", err
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	signingInput := base64.RawURLEncoding.EncodeToString(headerJSON) + "." +
+		base64.RawURLEncoding.EncodeToString(payloadJSON)
+
+	sig, err := signProof(priv, alg, signingInput)
+	if err != nil {
+		return "", err
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+// ecPublicKeyFromJWK reconstructs an ECDSA P-256 public key from a JWK map with
+// base64url x and y coordinates.
+func ecPublicKeyFromJWK(jwk map[string]any) (*ecdsa.PublicKey, error) {
+	xStr, _ := jwk["x"].(string)
+	yStr, _ := jwk["y"].(string)
+	if xStr == "" || yStr == "" {
+		return nil, fmt.Errorf("jwk missing x or y coordinate")
+	}
+	xb, err := base64.RawURLEncoding.DecodeString(xStr)
+	if err != nil {
+		return nil, fmt.Errorf("decode x: %w", err)
+	}
+	yb, err := base64.RawURLEncoding.DecodeString(yStr)
+	if err != nil {
+		return nil, fmt.Errorf("decode y: %w", err)
+	}
+	return &ecdsa.PublicKey{
+		Curve: elliptic.P256(),
+		X:     new(big.Int).SetBytes(xb),
+		Y:     new(big.Int).SetBytes(yb),
+	}, nil
+}
+
+// ecdhConcatKDF implements the Concat KDF (RFC 7518 §4.6.2) using SHA-256,
+// mirroring the server's cryptolib derivation so a JWE encrypted here decrypts
+// with the same CEK. algID is the direct content-encryption algorithm (e.g.
+// "A128GCM"); apu/apv are nil for the direct ECDH-ES flow.
+func ecdhConcatKDF(z []byte, algID string, keyLen int, apu, apv []byte) []byte {
+	suppPubInfo := make([]byte, 4)
+	binary.BigEndian.PutUint32(suppPubInfo, uint32(keyLen*8))
+
+	otherInfo := lengthPrefixed([]byte(algID))
+	otherInfo = append(otherInfo, lengthPrefixed(apu)...)
+	otherInfo = append(otherInfo, lengthPrefixed(apv)...)
+	otherInfo = append(otherInfo, suppPubInfo...)
+
+	key := make([]byte, 0, keyLen)
+	for counter := uint32(1); len(key) < keyLen; counter++ {
+		h := sha256.New()
+		counterBuf := make([]byte, 4)
+		binary.BigEndian.PutUint32(counterBuf, counter)
+		h.Write(counterBuf)
+		h.Write(z)
+		h.Write(otherInfo)
+		key = append(key, h.Sum(nil)...)
+	}
+	return key[:keyLen]
+}
+
+// lengthPrefixed returns data prefixed with its 4-byte big-endian length.
+func lengthPrefixed(data []byte) []byte {
+	res := make([]byte, 4+len(data))
+	binary.BigEndian.PutUint32(res, uint32(len(data)))
+	copy(res[4:], data)
+	return res
+}
+
+// OpenID4VP wallet simulator.
+
+// vpWalletIssuer is the "iss" claim placed in the self-signed SD-JWT VC. Trust
+// is not enforced in the test definitions, so any non-empty issuer is accepted.
+const vpWalletIssuer = "https://integration-test-issuer.thunderid.local"
+
+// VPWallet is a self-contained OpenID4VP wallet. It owns a self-signed issuer
+// key/cert (placed in the SD-JWT x5c header) and a holder key (bound via cnf and
+// used to sign the Key Binding JWT).
+type VPWallet struct {
+	issuerKey     *ecdsa.PrivateKey
+	issuerCertDER []byte
+	holderKey     *DPoPKey
+}
+
+// NewVPWallet builds a wallet with a fresh self-signed ES256 issuer certificate
+// and a fresh ES256 holder key.
+func NewVPWallet() (*VPWallet, error) {
+	issuerKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate issuer key: %w", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "ThunderID Integration Test Issuer"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &issuerKey.PublicKey, issuerKey)
+	if err != nil {
+		return nil, fmt.Errorf("create issuer certificate: %w", err)
+	}
+	holderKey, err := GenerateDPoPKey("ES256")
+	if err != nil {
+		return nil, fmt.Errorf("generate holder key: %w", err)
+	}
+	return &VPWallet{issuerKey: issuerKey, issuerCertDER: der, holderKey: holderKey}, nil
+}
+
+// HolderKey exposes the wallet's holder key (for tests that need its JWK).
+func (w *VPWallet) HolderKey() *DPoPKey { return w.holderKey }
+
+// VPRequestObject is the decoded authorization request the wallet fetches from
+// /openid4vp/request. Only the fields a wallet needs are surfaced.
+type VPRequestObject struct {
+	ClientID     string
+	Nonce        string
+	State        string
+	ResponseURI  string
+	CredentialID string
+	VCT          string
+	EncKey       *ecdsa.PublicKey
+	EncAlg       string
+	Raw          map[string]any
+}
+
+// ParseVPRequestObject decodes the compact request-object JWT without verifying
+// its signature (the wallet trusts the transport) and extracts the fields needed
+// to build and encrypt a response.
+func ParseVPRequestObject(jar string) (*VPRequestObject, error) {
+	parts := strings.Split(jar, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("request object is not a compact JWS (got %d segments)", len(parts))
+	}
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("decode request object payload: %w", err)
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payloadBytes, &claims); err != nil {
+		return nil, fmt.Errorf("unmarshal request object payload: %w", err)
+	}
+
+	req := &VPRequestObject{
+		ClientID:    stringClaim(claims, "client_id"),
+		Nonce:       stringClaim(claims, "nonce"),
+		State:       stringClaim(claims, "state"),
+		ResponseURI: stringClaim(claims, "response_uri"),
+		EncAlg:      "A128GCM",
+		Raw:         claims,
+	}
+
+	// dcql_query.credentials[0]: id (vp_token key) + meta.vct_values[0] (VCT).
+	if dcql, ok := claims["dcql_query"].(map[string]any); ok {
+		if creds, ok := dcql["credentials"].([]any); ok && len(creds) > 0 {
+			if cred, ok := creds[0].(map[string]any); ok {
+				req.CredentialID = stringClaim(cred, "id")
+				if meta, ok := cred["meta"].(map[string]any); ok {
+					if vcts, ok := meta["vct_values"].([]any); ok && len(vcts) > 0 {
+						req.VCT, _ = vcts[0].(string)
+					}
+				}
+			}
+		}
+	}
+
+	// client_metadata: ephemeral encryption key + supported enc values.
+	if cm, ok := claims["client_metadata"].(map[string]any); ok {
+		if encVals, ok := cm["encrypted_response_enc_values_supported"].([]any); ok && len(encVals) > 0 {
+			if enc, ok := encVals[0].(string); ok && enc != "" {
+				req.EncAlg = enc
+			}
+		}
+		if jwks, ok := cm["jwks"].(map[string]any); ok {
+			if keys, ok := jwks["keys"].([]any); ok && len(keys) > 0 {
+				if jwk, ok := keys[0].(map[string]any); ok {
+					encKey, err := ecPublicKeyFromJWK(jwk)
+					if err != nil {
+						return nil, fmt.Errorf("parse verifier encryption key: %w", err)
+					}
+					req.EncKey = encKey
+				}
+			}
+		}
+	}
+
+	if req.CredentialID == "" || req.VCT == "" || req.EncKey == nil {
+		return nil, fmt.Errorf("request object missing credential id, vct, or encryption key")
+	}
+	return req, nil
+}
+
+// BuildPresentation issues a self-signed SD-JWT VC disclosing the given claims,
+// binds it to the wallet's holder key, appends a Key Binding JWT over the
+// request nonce and audience, and returns the combined presentation string.
+func (w *VPWallet) BuildPresentation(req *VPRequestObject, claims map[string]any) (string, error) {
+	now := time.Now()
+
+	type disclosure struct{ raw, digest string }
+	disclosures := make([]disclosure, 0, len(claims))
+	digests := make([]string, 0, len(claims))
+	for name, value := range claims {
+		saltBytes := make([]byte, 16)
+		if _, err := rand.Read(saltBytes); err != nil {
+			return "", fmt.Errorf("generate salt: %w", err)
+		}
+		salt := base64.RawURLEncoding.EncodeToString(saltBytes)
+		encoded, err := json.Marshal([]any{salt, name, value})
+		if err != nil {
+			return "", fmt.Errorf("marshal disclosure %q: %w", name, err)
+		}
+		raw := base64.RawURLEncoding.EncodeToString(encoded)
+		sum := sha256.Sum256([]byte(raw))
+		digest := base64.RawURLEncoding.EncodeToString(sum[:])
+		disclosures = append(disclosures, disclosure{raw: raw, digest: digest})
+		digests = append(digests, digest)
+	}
+	sort.Strings(digests)
+
+	header := map[string]any{
+		"alg": "ES256",
+		"typ": "dc+sd-jwt",
+		"x5c": []string{base64.StdEncoding.EncodeToString(w.issuerCertDER)},
+	}
+	payload := map[string]any{
+		"iss":     vpWalletIssuer,
+		"vct":     req.VCT,
+		"iat":     now.Unix(),
+		"exp":     now.Add(time.Hour).Unix(),
+		"cnf":     map[string]any{"jwk": w.holderKey.JWK},
+		"_sd":     digests,
+		"_sd_alg": "sha-256",
+	}
+	issuerJWT, err := signCompactJWS(header, payload, w.issuerKey, "ES256")
+	if err != nil {
+		return "", fmt.Errorf("sign issuer JWT: %w", err)
+	}
+
+	combined := issuerJWT
+	for _, d := range disclosures {
+		combined += "~" + d.raw
+	}
+	combined += "~"
+
+	sdHashSum := sha256.Sum256([]byte(combined))
+	kbHeader := map[string]any{"alg": "ES256", "typ": "kb+jwt"}
+	kbPayload := map[string]any{
+		"aud":     req.ClientID,
+		"nonce":   req.Nonce,
+		"iat":     now.Unix(),
+		"sd_hash": base64.RawURLEncoding.EncodeToString(sdHashSum[:]),
+	}
+	kbJWT, err := signCompactJWS(kbHeader, kbPayload, w.holderKey.Private, "ES256")
+	if err != nil {
+		return "", fmt.Errorf("sign key binding JWT: %w", err)
+	}
+
+	return combined + kbJWT, nil
+}
+
+// EncryptResponse builds the {state, vp_token} authorization response and
+// ECDH-ES/A128GCM encrypts it to the verifier's ephemeral key, returning the
+// compact JWE for the `response` form field.
+func (w *VPWallet) EncryptResponse(req *VPRequestObject, presentation string) (string, error) {
+	responseObj := map[string]any{
+		"state": req.State,
+		"vp_token": map[string]any{
+			req.CredentialID: []string{presentation},
+		},
+	}
+	plaintext, err := json.Marshal(responseObj)
+	if err != nil {
+		return "", fmt.Errorf("marshal authorization response: %w", err)
+	}
+
+	recipient, err := req.EncKey.ECDH()
+	if err != nil {
+		return "", fmt.Errorf("convert recipient key: %w", err)
+	}
+	ephPriv, err := ecdh.P256().GenerateKey(rand.Reader)
+	if err != nil {
+		return "", fmt.Errorf("generate ephemeral key: %w", err)
+	}
+	z, err := ephPriv.ECDH(recipient)
+	if err != nil {
+		return "", fmt.Errorf("ecdh agreement: %w", err)
+	}
+	cek := ecdhConcatKDF(z, "A128GCM", 16, nil, nil)
+
+	ephBytes := ephPriv.PublicKey().Bytes() // 0x04 || x || y
+	header := map[string]any{
+		"alg": "ECDH-ES",
+		"enc": "A128GCM",
+		"epk": map[string]any{
+			"kty": "EC",
+			"crv": "P-256",
+			"x":   base64.RawURLEncoding.EncodeToString(ephBytes[1:33]),
+			"y":   base64.RawURLEncoding.EncodeToString(ephBytes[33:65]),
+		},
+	}
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", fmt.Errorf("marshal JWE header: %w", err)
+	}
+	headerB64 := base64.RawURLEncoding.EncodeToString(headerJSON)
+
+	block, err := aes.NewCipher(cek)
+	if err != nil {
+		return "", fmt.Errorf("aes cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("gcm: %w", err)
+	}
+	iv := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(iv); err != nil {
+		return "", fmt.Errorf("generate iv: %w", err)
+	}
+	sealed := gcm.Seal(nil, iv, plaintext, []byte(headerB64))
+	ciphertext := sealed[:len(sealed)-16]
+	tag := sealed[len(sealed)-16:]
+
+	return strings.Join([]string{
+		headerB64,
+		"", // empty encrypted key for direct ECDH-ES
+		base64.RawURLEncoding.EncodeToString(iv),
+		base64.RawURLEncoding.EncodeToString(ciphertext),
+		base64.RawURLEncoding.EncodeToString(tag),
+	}, "."), nil
+}
+
+// OpenID4VP wallet/verifier endpoints are public, so these use the raw client.
+
+// InitiateVP starts a VP verification session for the given definition handle.
+func InitiateVP(definitionID string) (*VCHTTPResult, *VPInitiateResponse, error) {
+	body, _ := json.Marshal(map[string]string{"definition_id": definitionID})
+	req, err := http.NewRequest("POST", TestServerURL+"/openid4vp/initiate", bytes.NewReader(body))
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	res, raw, err := doRawVCRequest(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	var parsed VPInitiateResponse
+	if res.StatusCode == http.StatusOK {
+		if err := json.Unmarshal(raw, &parsed); err != nil {
+			return res, nil, fmt.Errorf("parse initiate response: %w. Body: %s", err, string(raw))
+		}
+	}
+	return res, &parsed, nil
+}
+
+// FetchVPRequestObject retrieves the signed request object (JAR) for a state.
+func FetchVPRequestObject(state string) (*VCHTTPResult, string, string, error) {
+	u := TestServerURL + "/openid4vp/request?state=" + url.QueryEscape(state)
+	req, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, "", "", err
+	}
+	client := GetRawHTTPClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, "", "", err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	return &VCHTTPResult{StatusCode: resp.StatusCode, Body: raw},
+		string(raw), resp.Header.Get("Content-Type"), nil
+}
+
+// SubmitVPResponse posts an encrypted VP response for a state.
+func SubmitVPResponse(state, response string) (*VCHTTPResult, error) {
+	form := url.Values{}
+	form.Set("state", state)
+	form.Set("response", response)
+
+	req, err := http.NewRequest("POST", TestServerURL+"/openid4vp/response", strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	res, _, err := doRawVCRequest(req)
+	return res, err
+}
+
+// SubmitVPError posts a wallet error to the response endpoint for a state.
+func SubmitVPError(state, errCode, errDescription string) (*VCHTTPResult, error) {
+	form := url.Values{}
+	form.Set("state", state)
+	form.Set("error", errCode)
+	if errDescription != "" {
+		form.Set("error_description", errDescription)
+	}
+
+	req, err := http.NewRequest("POST", TestServerURL+"/openid4vp/response", strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	res, _, err := doRawVCRequest(req)
+	return res, err
+}
+
+// GetVPStatus polls a verification session by transaction id.
+func GetVPStatus(txnID string) (*VCHTTPResult, *VPStatusResponse, error) {
+	req, err := http.NewRequest("GET", TestServerURL+"/openid4vp/status/"+txnID, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	res, raw, err := doRawVCRequest(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	var parsed VPStatusResponse
+	if res.StatusCode == http.StatusOK {
+		if err := json.Unmarshal(raw, &parsed); err != nil {
+			return res, nil, fmt.Errorf("parse status response: %w. Body: %s", err, string(raw))
+		}
+	}
+	return res, &parsed, nil
+}
+
+// PollVPStatusUntilTerminal polls the status endpoint until the session reaches
+// a terminal state (not PENDING) or the attempts are exhausted.
+func PollVPStatusUntilTerminal(txnID string, attempts int, interval time.Duration) (*VPStatusResponse, error) {
+	var last *VPStatusResponse
+	for i := 0; i < attempts; i++ {
+		res, parsed, err := GetVPStatus(txnID)
+		if err != nil {
+			return nil, err
+		}
+		if res.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("status endpoint returned %d: %s", res.StatusCode, string(res.Body))
+		}
+		last = parsed
+		if parsed.Status != "PENDING" {
+			return parsed, nil
+		}
+		time.Sleep(interval)
+	}
+	return last, nil
+}
+
+// Shared low-level helpers.
+
+// doRawVCRequest executes an HTTP request with the raw (unauthenticated) client
+// and returns the status/body.
+func doRawVCRequest(req *http.Request) (*VCHTTPResult, []byte, error) {
+	client := GetRawHTTPClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	return &VCHTTPResult{StatusCode: resp.StatusCode, Body: raw}, raw, nil
+}
+
+// stringClaim reads a string claim from a decoded JSON object.
+func stringClaim(m map[string]any, key string) string {
+	v, _ := m[key].(string)
+	return v
+}


### PR DESCRIPTION
### Purpose

* **Tests**
  * Added end-to-end integration coverage for OpenID4VCI credential issuance, including metadata, offers, nonce handling, successful issuance, proof validation, authentication, and error scenarios.
  * Added end-to-end OpenID4VP verification coverage, including session initiation, request retrieval, wallet responses, status transitions, encrypted presentations, trust anchors, and invalid input handling.
  * Added reusable test utilities for simulating wallets, creating presentations, issuing credentials, and validating protocol responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for OpenID4VCI credential issuance, including metadata, offers, nonce handling, successful issuance, and authentication or validation failures.
  * Added end-to-end coverage for OpenID4VP verification, including wallet initiation, request handling, successful presentations, error responses, status transitions, and trust-anchor access.
  * Added reusable test utilities for simulating wallet interactions, creating presentations, encrypting responses, and managing test configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->