### PR TITLE
Strip undeclared user attributes on inbound client update

### DIFF
--- a/backend/internal/inboundclient/service.go
+++ b/backend/internal/inboundclient/service.go
@@ -227,7 +227,8 @@ func (s *inboundClientService) UpdateInboundClient(ctx context.Context, client *
 	if fkErr := s.validateFKs(ctx, client); fkErr != nil {
 		return fkErr
 	}
-	if err := s.validateUserAttributesAgainstAllowedTypes(
+	// Stripping leaves only attributes the validator accepts, so no separate validation is needed here.
+	if err := s.stripUndeclaredUserAttributes(
 		ctx, client.AllowedUserTypes, client.Assertion, oauthProfile); err != nil {
 		return err
 	}
@@ -1315,19 +1316,9 @@ func (s *inboundClientService) validateUserAttributesAgainstAllowedTypes(
 		return nil
 	}
 
-	validAttrs := make(map[string]bool)
-	for _, entityTypeName := range allowedEntityTypes {
-		attrInfos, svcErr := s.entityType.GetAttributes(
-			security.WithRuntimeContext(ctx), entitytype.TypeCategoryUser, entityTypeName, false, true, false)
-		if svcErr != nil {
-			if svcErr.Type == tidcommon.ServerErrorType {
-				return ErrUserSchemaLookupFailed
-			}
-			return ErrFKInvalidUserType
-		}
-		for _, info := range attrInfos {
-			validAttrs[info.Attribute] = true
-		}
+	validAttrs, err := s.resolveValidUserAttributes(ctx, allowedEntityTypes)
+	if err != nil {
+		return err
 	}
 
 	for attr := range attrs {
@@ -1337,6 +1328,81 @@ func (s *inboundClientService) validateUserAttributesAgainstAllowedTypes(
 		if !validAttrs[attr] {
 			return ErrInvalidUserAttribute
 		}
+	}
+	return nil
+}
+
+// resolveValidUserAttributes returns the union of non-credential attribute names declared in the
+// schemas of the given allowed user types. Returns (nil, nil) when there are no allowed types or the
+// entity-type service is unavailable, signaling callers to skip attribute reconciliation.
+func (s *inboundClientService) resolveValidUserAttributes(
+	ctx context.Context,
+	allowedEntityTypes []string,
+) (map[string]bool, error) {
+	if len(allowedEntityTypes) == 0 || s.entityType == nil {
+		return nil, nil
+	}
+	validAttrs := make(map[string]bool)
+	for _, entityTypeName := range allowedEntityTypes {
+		attrInfos, svcErr := s.entityType.GetAttributes(
+			security.WithRuntimeContext(ctx), entitytype.TypeCategoryUser, entityTypeName, false, true, false)
+		if svcErr != nil {
+			if svcErr.Type == tidcommon.ServerErrorType {
+				return nil, ErrUserSchemaLookupFailed
+			}
+			return nil, ErrFKInvalidUserType
+		}
+		for _, info := range attrInfos {
+			validAttrs[info.Attribute] = true
+		}
+	}
+	return validAttrs, nil
+}
+
+// stripUndeclaredUserAttributes removes from the application's token allow-lists any user attribute
+// no longer declared in the schema of its allowed user types, keeping computed attributes. The lists
+// are left holding only attributes validateUserAttributesAgainstAllowedTypes accepts. No-op when
+// there are no allowed types or the entity-type service is unavailable (matches the validator's skip).
+func (s *inboundClientService) stripUndeclaredUserAttributes(
+	ctx context.Context,
+	allowedEntityTypes []string,
+	assertion *inboundmodel.AssertionConfig,
+	oauthProfile *providers.OAuthProfile,
+) error {
+	lists := configuredUserAttributeLists(assertion, oauthProfile)
+	configured := 0
+	for _, list := range lists {
+		configured += len(*list)
+	}
+	if configured == 0 {
+		return nil
+	}
+	validAttrs, err := s.resolveValidUserAttributes(ctx, allowedEntityTypes)
+	if err != nil || validAttrs == nil {
+		return err
+	}
+
+	dropped := make(map[string]bool)
+	for _, list := range lists {
+		kept := make([]string, 0, len(*list))
+		for _, attr := range *list {
+			if isComputedAttribute(attr) || validAttrs[attr] {
+				kept = append(kept, attr)
+				continue
+			}
+			dropped[attr] = true
+		}
+		*list = kept
+	}
+
+	if len(dropped) > 0 && s.logger.IsDebugEnabled() {
+		names := make([]string, 0, len(dropped))
+		for attr := range dropped {
+			names = append(names, attr)
+		}
+		slices.Sort(names)
+		s.logger.Debug(ctx, "Stripped user attributes no longer declared in the entity type schema",
+			log.String("droppedAttributes", strings.Join(names, ", ")))
 	}
 	return nil
 }
@@ -1363,31 +1429,38 @@ func collectConfiguredUserAttributes(
 	oauthProfile *providers.OAuthProfile,
 ) map[string]bool {
 	attrs := make(map[string]bool)
-	if assertion != nil {
-		for _, a := range assertion.UserAttributes {
-			attrs[a] = true
+	for _, list := range configuredUserAttributeLists(assertion, oauthProfile) {
+		for _, attr := range *list {
+			attrs[attr] = true
 		}
+	}
+	return attrs
+}
+
+// configuredUserAttributeLists returns pointers to the user attribute allow-lists present in the
+// assertion, access token, ID token, and userinfo configs, so callers can read or rewrite them.
+func configuredUserAttributeLists(
+	assertion *inboundmodel.AssertionConfig,
+	oauthProfile *providers.OAuthProfile,
+) []*[]string {
+	lists := make([]*[]string, 0, 4)
+	if assertion != nil {
+		lists = append(lists, &assertion.UserAttributes)
 	}
 	if oauthProfile != nil {
 		if oauthProfile.Token != nil {
 			if oauthProfile.Token.AccessToken != nil && oauthProfile.Token.AccessToken.UserConfig != nil {
-				for _, a := range oauthProfile.Token.AccessToken.UserConfig.Attributes {
-					attrs[a] = true
-				}
+				lists = append(lists, &oauthProfile.Token.AccessToken.UserConfig.Attributes)
 			}
 			if oauthProfile.Token.IDToken != nil {
-				for _, a := range oauthProfile.Token.IDToken.UserAttributes {
-					attrs[a] = true
-				}
+				lists = append(lists, &oauthProfile.Token.IDToken.UserAttributes)
 			}
 		}
 		if oauthProfile.UserInfo != nil {
-			for _, a := range oauthProfile.UserInfo.UserAttributes {
-				attrs[a] = true
-			}
+			lists = append(lists, &oauthProfile.UserInfo.UserAttributes)
 		}
 	}
-	return attrs
+	return lists
 }
 
 // applyInboundDefaults fills default values for assertion, OAuth tokens, user info, and scope claims.

--- a/backend/internal/inboundclient/service_test.go
+++ b/backend/internal/inboundclient/service_test.go
@@ -74,6 +74,26 @@ func newServiceWithCert(certService cert.CertificateServiceInterface) *inboundCl
 	return svc.(*inboundClientService)
 }
 
+func newServiceWithEntityType(et entitytypepkg.EntityTypeServiceInterface) *inboundClientService {
+	svc := newInboundClientService(
+		nil, transaction.NewNoOpTransactioner(), nil, nil, nil, nil, nil, et,
+	)
+	return svc.(*inboundClientService)
+}
+
+// userAttrProfile builds an OAuth profile with the three user attribute allow-lists populated.
+func userAttrProfile(access, id, userinfo []string) *providers.OAuthProfile {
+	return &providers.OAuthProfile{
+		Token: &providers.OAuthTokenConfig{
+			AccessToken: &providers.AccessTokenConfig{
+				UserConfig: &providers.AccessTokenSubConfig{Attributes: access},
+			},
+			IDToken: &providers.IDTokenConfig{UserAttributes: id},
+		},
+		UserInfo: &providers.UserInfoConfig{UserAttributes: userinfo},
+	}
+}
+
 func validInboundClient() inboundmodel.InboundClient {
 	return inboundmodel.InboundClient{
 		ID:                        "p1",
@@ -548,6 +568,118 @@ func (suite *InboundClientServiceTestSuite) TestUpdateInboundClient_Succeeds() {
 	svc := newInboundClientService(store, transaction.NewNoOpTransactioner(), nil, nil, nil, nil, nil, nil)
 	err := svc.UpdateInboundClient(context.Background(), ptrInboundClient(), validOAuthProfile(), true, "")
 	assert.NoError(suite.T(), err)
+}
+
+func (suite *InboundClientServiceTestSuite) TestStripUndeclaredUserAttributes_StripsFromAllLists() {
+	et := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	et.EXPECT().
+		GetAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "users", false, true, false).
+		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
+	svc := newServiceWithEntityType(et)
+
+	// "custom2" is undeclared; "groups"/"roles"/"ouId" are computed and must survive.
+	assertion := &inboundmodel.AssertionConfig{UserAttributes: []string{"email", "custom2", "groups"}}
+	profile := userAttrProfile(
+		[]string{"email", "custom2"},
+		[]string{"custom2", "roles"},
+		[]string{"email", "custom2", "ouId"},
+	)
+
+	err := svc.stripUndeclaredUserAttributes(context.Background(), []string{"users"}, assertion, profile)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), []string{"email", "groups"}, assertion.UserAttributes)
+	assert.Equal(suite.T(), []string{"email"}, profile.Token.AccessToken.UserConfig.Attributes)
+	assert.Equal(suite.T(), []string{"roles"}, profile.Token.IDToken.UserAttributes)
+	assert.Equal(suite.T(), []string{"email", "ouId"}, profile.UserInfo.UserAttributes)
+}
+
+func (suite *InboundClientServiceTestSuite) TestStripUndeclaredUserAttributes_NoOpWhenNoAllowedTypes() {
+	et := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	svc := newServiceWithEntityType(et)
+
+	assertion := &inboundmodel.AssertionConfig{UserAttributes: []string{"custom2"}}
+	err := svc.stripUndeclaredUserAttributes(context.Background(), nil, assertion, nil)
+	assert.NoError(suite.T(), err)
+	// No allowed types → skip; list untouched and no schema lookup performed.
+	assert.Equal(suite.T(), []string{"custom2"}, assertion.UserAttributes)
+}
+
+func (suite *InboundClientServiceTestSuite) TestStripUndeclaredUserAttributes_NoOpWhenEntityTypeNil() {
+	svc := newServiceWithEntityType(nil)
+
+	assertion := &inboundmodel.AssertionConfig{UserAttributes: []string{"custom2"}}
+	err := svc.stripUndeclaredUserAttributes(context.Background(), []string{"users"}, assertion, nil)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), []string{"custom2"}, assertion.UserAttributes)
+}
+
+func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_RejectsUndeclared() {
+	et := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	et.EXPECT().
+		GetAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "users", false, true, false).
+		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
+	svc := newServiceWithEntityType(et)
+
+	// Create/Validate keep rejecting undeclared attrs after the reject→strip refactor.
+	assertion := &inboundmodel.AssertionConfig{UserAttributes: []string{"custom2"}}
+	err := svc.validateUserAttributesAgainstAllowedTypes(
+		context.Background(), []string{"users"}, assertion, nil)
+	assert.ErrorIs(suite.T(), err, ErrInvalidUserAttribute)
+}
+
+func (suite *InboundClientServiceTestSuite) TestValidateUserAttributes_NoConfiguredAttrsSkipsSchemaLookup() {
+	et := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	svc := newServiceWithEntityType(et)
+
+	// No configured attributes → return early without a schema lookup (GetAttributes never expected).
+	err := svc.validateUserAttributesAgainstAllowedTypes(
+		context.Background(), []string{"users"}, nil, nil)
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *InboundClientServiceTestSuite) TestUpdateInboundClient_StripsUndeclaredUserAttributes() {
+	store := newInboundClientStoreInterfaceMock(suite.T())
+	store.EXPECT().IsDeclarative(mock.Anything, "p1").Return(false)
+	store.EXPECT().UpdateInboundClient(mock.Anything, mock.Anything).Return(nil)
+	store.EXPECT().GetOAuthProfileByEntityID(mock.Anything, "p1").Return(nil, ErrInboundClientNotFound)
+	store.EXPECT().CreateOAuthProfile(mock.Anything, "p1", mock.Anything).Return(nil)
+
+	et := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
+	et.EXPECT().
+		GetEntityTypeList(mock.Anything, entitytypepkg.TypeCategoryUser, mock.Anything, mock.Anything, false).
+		Return(&entitytypepkg.EntityTypeListResponse{
+			TotalResults: 1,
+			Types:        []entitytypepkg.EntityTypeListItem{{Name: "users"}},
+		}, nil)
+	// Exactly one schema lookup per allowed user type on the update path.
+	et.EXPECT().
+		GetAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "users", false, true, false).
+		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil).
+		Once()
+
+	svc := newInboundClientService(store, transaction.NewNoOpTransactioner(), nil, nil, nil, nil, nil, et)
+
+	client := ptrInboundClient()
+	client.AllowedUserTypes = []string{"users"}
+	client.Assertion = &inboundmodel.AssertionConfig{UserAttributes: []string{"email", "custom2"}}
+	profile := validOAuthProfile()
+	profile.Token = &providers.OAuthTokenConfig{
+		IDToken: &providers.IDTokenConfig{UserAttributes: []string{"email", "custom2"}},
+	}
+	profile.UserInfo = &providers.UserInfoConfig{UserAttributes: []string{"custom2"}}
+
+	err := svc.UpdateInboundClient(context.Background(), client, profile, true, "")
+	assert.NoError(suite.T(), err)
+
+	// The undeclared "custom2" is stripped from every allow-list; declared "email" survives.
+	assert.NotContains(suite.T(), client.Assertion.UserAttributes, "custom2")
+	assert.Contains(suite.T(), client.Assertion.UserAttributes, "email")
+	if profile.Token != nil && profile.Token.IDToken != nil {
+		assert.NotContains(suite.T(), profile.Token.IDToken.UserAttributes, "custom2")
+	}
+	if profile.UserInfo != nil {
+		assert.NotContains(suite.T(), profile.UserInfo.UserAttributes, "custom2")
+	}
 }
 
 func (suite *InboundClientServiceTestSuite) TestValidate_ValidProfile() {
@@ -2472,31 +2604,6 @@ func (suite *InboundClientServiceTestSuite) TestCreateInboundClient_RejectsInval
 	c.Assertion = &inboundmodel.AssertionConfig{UserAttributes: []string{"not_a_real_attr"}}
 
 	err := svc.CreateInboundClient(context.Background(), &c, nil, false)
-	assert.ErrorIs(suite.T(), err, ErrInvalidUserAttribute)
-}
-
-func (suite *InboundClientServiceTestSuite) TestUpdateInboundClient_RejectsInvalidUserAttribute() {
-	store := newInboundClientStoreInterfaceMock(suite.T())
-	store.EXPECT().IsDeclarative(mock.Anything, "p1").Return(false)
-
-	us := entitytypemock.NewEntityTypeServiceInterfaceMock(suite.T())
-	// validateAllowedUserTypes (called by validateFKs) checks entity type existence via GetEntityTypeList.
-	us.EXPECT().GetEntityTypeList(mock.Anything, mock.Anything, mock.Anything, 0, false).Return(
-		&entitytypepkg.EntityTypeListResponse{
-			TotalResults: 1,
-			Types:        []entitytypepkg.EntityTypeListItem{{Name: "employee"}},
-		}, nil)
-	us.EXPECT().GetAttributes(mock.Anything, entitytypepkg.TypeCategoryUser, "employee", false, true, false).
-		Return([]entitytypepkg.AttributeInfo{{Attribute: "email"}}, nil)
-
-	svc := newInboundClientService(store, transaction.NewNoOpTransactioner(), nil, nil, nil, nil, nil, us)
-
-	c := validInboundClient()
-	c.AllowedUserTypes = []string{"employee"}
-	p := validOAuthProfileData()
-	p.UserInfo = &providers.UserInfoConfig{UserAttributes: []string{"ghost"}}
-
-	err := svc.UpdateInboundClient(context.Background(), &c, p, true, "")
 	assert.ErrorIs(suite.T(), err, ErrInvalidUserAttribute)
 }
 


### PR DESCRIPTION
### Purpose
When an application is updated, user attributes that are no longer declared in the allowed user types' schema were kept in the token allow-lists, and the update failed validation. This strips such attributes on update instead of rejecting it.

### Approach
In `UpdateInboundClient`, before validation, remove from the four token allow-lists (native assertion, access token, id token, userinfo) any attribute not declared by the allowed user types' schema. Computed attributes (groups, roles, ou*, userType) are kept. The create and non-persisting validate paths are unchanged and still reject genuinely undeclared attributes.

### Related Issues
- Refs #4240

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [x] Tests provided.
    - [x] Unit Tests
    - [ ] Integration Tests

### Security checks
- [x] Followed secure coding standards.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Inbound client updates now strip undeclared, non-computed user attributes from configured assertion and OAuth profile attribute allow-lists (access token, ID token, and userinfo).
  - Computed attributes are preserved.
  - Validation now explicitly ignores computed attributes and continues to reject undeclared attributes when configured sources are present.

- **Tests**
  - Added coverage for attribute stripping (including no-op scenarios) and updated validation test placement to match the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->