### PR TITLE
Support grid layouts in the STACK flow element

### DIFF
--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/ClassesPropertyField.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/ClassesPropertyField.tsx
@@ -16,17 +16,12 @@
  * under the License.
  */
 
-import {Box, FormControl, FormLabel, IconButton, Stack, TextField, Tooltip} from '@wso2/oxygen-ui';
-import {Plus, Trash} from '@wso2/oxygen-ui-icons-react';
-import {useState, type ReactElement} from 'react';
+import {Autocomplete, Box, Chip, FormControl, FormLabel, TextField} from '@wso2/oxygen-ui';
+import {useState, type ReactElement, type SyntheticEvent} from 'react';
 import {useTranslation} from 'react-i18next';
-import PanelActionButton from './PanelActionButton';
 import type {Resource} from '../../models/resources';
 
-const parseClasses = (value: string): string[] => {
-  const classes = (value ?? '').split(/\s+/).filter(Boolean);
-  return classes.length > 0 ? classes : [''];
-};
+const parseClasses = (value: string): string[] => (value ?? '').split(/\s+/).filter(Boolean);
 
 /**
  * Props interface of {@link ClassesPropertyField}
@@ -70,24 +65,12 @@ function ClassesPropertyField({
   const {t} = useTranslation();
   const [classNames, setClassNames] = useState<string[]>(() => parseClasses(propertyValue));
 
-  const commitClasses = (updated: string[], debounce?: boolean): void => {
-    setClassNames(updated);
-    onChange(propertyKey, updated.join(' '), resource, debounce);
-  };
-
-  const handleAdd = (): void => {
-    commitClasses([...classNames, '']);
-  };
-
-  const handleRemove = (index: number): void => {
-    commitClasses(classNames.filter((_, i) => i !== index));
-  };
-
-  const handleChange = (index: number, value: string): void => {
-    commitClasses(
-      classNames.map((className, i) => (i === index ? value : className)),
-      true,
-    );
+  const commitClasses = (updated: string[]): void => {
+    // Class names are whitespace separated, so a typed value cannot contain spaces.
+    const normalized: string[] = updated.flatMap((entry: string) => entry.split(/\s+/).filter(Boolean));
+    const deduped: string[] = [...new Set(normalized)];
+    setClassNames(deduped);
+    onChange(propertyKey, deduped.join(' '), resource);
   };
 
   return (
@@ -96,33 +79,32 @@ function ClassesPropertyField({
         <FormLabel htmlFor={`${resource.id}-${propertyKey}`}>
           {t('flows:core.elements.classesPropertyField.label')}
         </FormLabel>
-
-        <Stack spacing={2} id={`${resource.id}-${propertyKey}`}>
-          {classNames.map((className, index) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <Stack key={index} direction="row" spacing={1} alignItems="flex-start">
-              <TextField
-                fullWidth
-                value={className}
-                onChange={(e) => handleChange(index, e.target.value)}
-                placeholder={t('flows:core.elements.classesPropertyField.placeholder')}
-              />
-              {classNames.length > 1 && (
-                <Tooltip title={t('common:actions.delete')}>
-                  <IconButton onClick={() => handleRemove(index)} color="error">
-                    <Trash size={20} />
-                  </IconButton>
-                </Tooltip>
-              )}
-            </Stack>
-          ))}
-
-          <Box>
-            <PanelActionButton startIcon={<Plus size={16} />} onClick={handleAdd}>
-              {t('flows:core.elements.classesPropertyField.addClass')}
-            </PanelActionButton>
-          </Box>
-        </Stack>
+        {/* One tag input rather than a stack of text fields: classes are short tokens,
+            so they read better as chips and the field stays a fixed height. */}
+        <Autocomplete
+          multiple
+          freeSolo
+          autoSelect
+          clearOnBlur
+          options={[] as string[]}
+          value={classNames}
+          onChange={(_event: SyntheticEvent, newValue: string[]) => commitClasses(newValue)}
+          renderTags={(value: string[], getTagProps) =>
+            value.map((option: string, index: number) => {
+              const {key, ...tagProps} = getTagProps({index});
+              return <Chip key={key} size="small" label={option} {...tagProps} />;
+            })
+          }
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              id={`${resource.id}-${propertyKey}`}
+              placeholder={
+                classNames.length === 0 ? t('flows:core.elements.classesPropertyField.placeholder') : undefined
+              }
+            />
+          )}
+        />
       </FormControl>
     </Box>
   );

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/CommonElementPropertyFactory.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/CommonElementPropertyFactory.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import {parseStackItems} from '@thunderid/design';
 import {useLogger} from '@thunderid/logger/react';
 import {
   Autocomplete,
@@ -39,6 +40,37 @@ import {ElementTypes} from '../../models/elements';
 import type {Resource} from '../../models/resources';
 
 const TEXT_ALIGN_VALUES = ['left', 'center', 'right', 'justify', 'inherit'] as const;
+
+// Layout properties with a known value set. Rendered as free-text autocompletes so
+// the common values are discoverable while custom CSS values stay allowed.
+const LAYOUT_PROPERTY_SUGGESTIONS: Record<string, string[]> = {
+  align: ['stretch', 'center', 'flex-start', 'flex-end', 'baseline', 'start', 'end'],
+  direction: ['row', 'column', 'row-reverse', 'column-reverse'],
+  justify: ['stretch', 'center', 'flex-start', 'flex-end', 'space-between', 'space-around', 'space-evenly'],
+};
+
+// Structural layout values map straight to CSS rather than being shown to end users,
+// so they take literal values only: no i18n or meta template insertion.
+const LAYOUT_PROPERTY_KEYS: string[] = ['align', 'direction', 'gap', 'items', 'justify'];
+
+// A grid stack uses `direction` to pick the axis its slots run along. CSS Grid has no
+// reverse auto-flow, so the reverse variants are only offered in flex mode.
+const GRID_DIRECTION_VALUES: string[] = ['row', 'column'];
+
+/**
+ * Suggestions for a layout property, narrowed to the values the resource's current
+ * layout mode actually honors.
+ */
+function getLayoutSuggestions(resource: Resource, propertyKey: string): string[] {
+  const isGridStack: boolean =
+    resource.type === ElementTypes.Stack &&
+    parseStackItems((resource as Resource & {items?: string | number}).items) !== undefined;
+
+  if (isGridStack && propertyKey === 'direction') {
+    return GRID_DIRECTION_VALUES;
+  }
+  return LAYOUT_PROPERTY_SUGGESTIONS[propertyKey];
+}
 
 // ---------------------------------------------------------------------------
 // Lazy icon loading — loaded once on first picker open, then cached.
@@ -240,6 +272,24 @@ function CommonElementPropertyFactory({
     );
   }
 
+  const isLayoutProperty: boolean = LAYOUT_PROPERTY_KEYS.includes(propertyKey);
+
+  // Own-property check: a bare index lookup also matches inherited members such as
+  // `toString`, and element config keys are arbitrary.
+  if (Object.hasOwn(LAYOUT_PROPERTY_SUGGESTIONS, propertyKey) && typeof propertyValue === 'string') {
+    return (
+      <TextPropertyField
+        resource={resource}
+        propertyKey={propertyKey}
+        propertyValue={propertyValue}
+        onChange={onChange}
+        suggestions={getLayoutSuggestions(resource, propertyKey)}
+        supportsDynamicValue={false}
+        {...rest}
+      />
+    );
+  }
+
   if (typeof propertyValue === 'boolean') {
     return (
       <CheckboxPropertyField
@@ -259,6 +309,9 @@ function CommonElementPropertyFactory({
         propertyKey={propertyKey}
         propertyValue={String(propertyValue)}
         onChange={(key, value, res) => onChange(key, value !== '' ? Number(value) : 0, res, true)}
+        supportsDynamicValue={!isLayoutProperty}
+        type="number"
+        slotProps={{htmlInput: {min: 0}}}
         {...rest}
       />
     );

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/PropertySection.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/PropertySection.tsx
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Box, Stack, Typography} from '@wso2/oxygen-ui';
+import type {ReactElement, ReactNode} from 'react';
+
+/**
+ * Props interface of {@link PropertySection}
+ */
+export interface PropertySectionPropsInterface {
+  /**
+   * Section heading.
+   */
+  title: string;
+  /**
+   * Fields belonging to the section.
+   */
+  children: ReactNode;
+}
+
+/**
+ * Groups related properties under a quiet heading so identity, content, layout and
+ * validation settings are scannable instead of being one flat list of fields.
+ *
+ * @param props - Props injected to the component.
+ * @returns The PropertySection component.
+ */
+function PropertySection({title, children}: PropertySectionPropsInterface): ReactElement {
+  return (
+    <Box component="section" sx={{'& + &': {mt: 1}}}>
+      <Typography
+        variant="overline"
+        color="text.secondary"
+        sx={{display: 'block', letterSpacing: '0.08em', lineHeight: 1.6, mb: 0.5}}
+      >
+        {title}
+      </Typography>
+      <Stack gap={2}>{children}</Stack>
+    </Box>
+  );
+}
+
+export default PropertySection;

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/ResourcePropertyPanel.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/ResourcePropertyPanel.tsx
@@ -111,7 +111,9 @@ function ResourcePropertyPanel({open = false, onComponentDelete}: ResourceProper
         <ResourceProperties />
       </Box>
       {lastInteractedResource && lastInteractedResource.deletable !== false && (
-        <Box flexShrink={0}>
+        // Footer: a destructive action should read as separate from the fields above
+        // it, not as the next item in the list.
+        <Box flexShrink={0} sx={{borderTop: '1px solid', borderColor: 'divider', pt: 2, mt: 1}}>
           <PanelActionButton accent="error" onClick={handleDelete} startIcon={<TrashIcon size={16} />}>
             {t('flows:core.propertiesPanel.delete', 'Delete')}
           </PanelActionButton>

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/TextPropertyField.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/TextPropertyField.tsx
@@ -19,6 +19,8 @@
 import {useTemplateLiteralResolver} from '@thunderid/hooks';
 import {isI18nTemplatePattern, isMetaTemplatePattern} from '@thunderid/utils';
 import {
+  Autocomplete,
+  type AutocompleteRenderInputParams,
   Box,
   FormControl,
   FormHelperText,
@@ -31,7 +33,7 @@ import {
 } from '@wso2/oxygen-ui';
 import {SquareFunction} from '@wso2/oxygen-ui-icons-react';
 import startCase from 'lodash-es/startCase';
-import {useEffect, useMemo, useState, type ChangeEvent, type ReactElement} from 'react';
+import {useEffect, useMemo, useState, type ChangeEvent, type ReactElement, type SyntheticEvent} from 'react';
 import {useTranslation} from 'react-i18next';
 import DynamicValuePopover from './DynamicValuePopover';
 import useResourceFieldError from '../../hooks/useResourceFieldError';
@@ -61,6 +63,16 @@ export interface TextPropertyFieldPropsInterface {
    */
   onChange: (propertyKey: string, newValue: string, resource: Resource, debounce?: boolean) => void;
   /**
+   * Known values offered as autocomplete suggestions. The field stays free text,
+   * so any value outside this list is still accepted.
+   */
+  suggestions?: string[];
+  /**
+   * Whether the field offers i18n/meta template insertion. Structural values such as
+   * layout properties take literal values only.
+   */
+  supportsDynamicValue?: boolean;
+  /**
    * Additional props.
    */
   [key: string]: unknown;
@@ -77,6 +89,8 @@ function TextPropertyField({
   propertyKey,
   propertyValue,
   onChange,
+  suggestions = undefined,
+  supportsDynamicValue = true,
   ...rest
 }: TextPropertyFieldPropsInterface): ReactElement {
   const {t} = useTranslation();
@@ -132,7 +146,6 @@ function TextPropertyField({
     setIsDynamicValuePopoverOpen(false);
   };
 
-  // Ids are identifiers, not display text: no dynamic/i18n value insertion.
   const isIdField = propertyKey === 'id';
 
   // A step's id is the node's identity: renaming it remounts this field, so it
@@ -140,99 +153,157 @@ function TextPropertyField({
   // resource untouched and the field falls back to the current id.
   const commitsOnBlur = isIdField && resource.resourceType === ResourceTypes.Step;
 
+  // Ids are identifiers and structural values map straight to CSS, so neither
+  // offers dynamic/i18n value insertion.
+  const offersDynamicValue = !isIdField && supportsDynamicValue;
+
+  const dynamicValueAdornment = !offersDynamicValue ? null : (
+    <InputAdornment position="end">
+      <Tooltip title={t('flows:core.elements.textPropertyField.tooltip.configureDynamicValue')}>
+        <IconButton
+          ref={setIconButtonEl}
+          onClick={handleDynamicValueToggle}
+          size="small"
+          edge="end"
+          color={isDynamic ? 'primary' : 'default'}
+        >
+          <SquareFunction size={16} />
+        </IconButton>
+      </Tooltip>
+    </InputAdornment>
+  );
+
+  const dynamicValueSx = isDynamic
+    ? {
+        '& .MuiOutlinedInput-root': {
+          backgroundColor: 'rgba(var(--mui-palette-primary-mainChannel) / 0.1)',
+          '& fieldset': {
+            borderColor: 'primary.main',
+          },
+          '&:hover fieldset': {
+            borderColor: 'primary.dark',
+          },
+          '&.Mui-focused fieldset': {
+            borderColor: 'primary.main',
+          },
+        },
+      }
+    : undefined;
+
+  const placeholder: string = t('flows:core.elements.textPropertyField.placeholder', {
+    propertyName: startCase(propertyKey),
+  });
+
+  const textField: ReactElement = (
+    <TextField
+      fullWidth
+      id={`${resource.id}-${propertyKey}`}
+      value={localValue}
+      error={!!errorMessage}
+      onChange={(e: ChangeEvent<HTMLInputElement>) => {
+        setLocalValue(e.target.value);
+        if (!commitsOnBlur) {
+          onChange(propertyKey, e.target.value, resource, true);
+        }
+      }}
+      onBlur={() => {
+        if (!commitsOnBlur || localValue === propertyValue) {
+          return;
+        }
+        onChange(propertyKey, localValue, resource);
+        // A successful rename remounts this field (its key carries the id), so
+        // this reset only takes effect when the rename is rejected — reverting
+        // the field to the actual id, since no prop change will sync it.
+        setLocalValue(propertyValue);
+      }}
+      onKeyDown={(e) => {
+        if (commitsOnBlur && e.key === 'Enter') {
+          (e.target as HTMLInputElement).blur();
+        }
+      }}
+      placeholder={placeholder}
+      sx={dynamicValueSx}
+      InputProps={dynamicValueAdornment ? {endAdornment: dynamicValueAdornment} : undefined}
+      {...rest}
+    />
+  );
+
   return (
     <Box>
       <FormControl fullWidth>
         <FormLabel htmlFor={`${resource.id}-${propertyKey}`}>{startCase(propertyKey)}</FormLabel>
-        <TextField
-          fullWidth
-          value={localValue}
-          error={!!errorMessage}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => {
-            setLocalValue(e.target.value);
-            if (!commitsOnBlur) {
-              onChange(propertyKey, e.target.value, resource, true);
-            }
-          }}
-          onBlur={() => {
-            if (!commitsOnBlur || localValue === propertyValue) {
-              return;
-            }
-            onChange(propertyKey, localValue, resource);
-            // A successful rename remounts this field (its key carries the id), so
-            // this reset only takes effect when the rename is rejected — reverting
-            // the field to the actual id, since no prop change will sync it.
-            setLocalValue(propertyValue);
-          }}
-          onKeyDown={(e) => {
-            if (commitsOnBlur && e.key === 'Enter') {
-              (e.target as HTMLInputElement).blur();
-            }
-          }}
-          placeholder={t('flows:core.elements.textPropertyField.placeholder', {propertyName: startCase(propertyKey)})}
-          sx={
-            isDynamic
-              ? {
-                  '& .MuiOutlinedInput-root': {
-                    backgroundColor: 'rgba(var(--mui-palette-primary-mainChannel) / 0.1)',
-                    '& fieldset': {
-                      borderColor: 'primary.main',
-                    },
-                    '&:hover fieldset': {
-                      borderColor: 'primary.dark',
-                    },
-                    '&.Mui-focused fieldset': {
-                      borderColor: 'primary.main',
-                    },
-                  },
-                }
-              : undefined
-          }
-          InputProps={
-            isIdField
-              ? undefined
-              : {
-                  endAdornment: (
-                    <InputAdornment position="end">
-                      <Tooltip title={t('flows:core.elements.textPropertyField.tooltip.configureDynamicValue')}>
-                        <IconButton
-                          ref={setIconButtonEl}
-                          onClick={handleDynamicValueToggle}
-                          size="small"
-                          edge="end"
-                          color={isDynamic ? 'primary' : 'default'}
-                        >
-                          <SquareFunction size={16} />
-                        </IconButton>
-                      </Tooltip>
-                    </InputAdornment>
-                  ),
-                }
-          }
-          {...rest}
-        />
+        {suggestions ? (
+          <Autocomplete
+            freeSolo
+            options={suggestions}
+            value={localValue}
+            inputValue={localValue}
+            onChange={(_event: SyntheticEvent, newValue: string | null) => {
+              const nextValue: string = newValue ?? '';
+              setLocalValue(nextValue);
+              onChange(propertyKey, nextValue, resource);
+            }}
+            onInputChange={(_event: SyntheticEvent, newValue: string, reason: string) => {
+              if (reason !== 'input' && reason !== 'clear') {
+                return;
+              }
+              setLocalValue(newValue);
+              onChange(propertyKey, newValue, resource, true);
+            }}
+            renderInput={(params: AutocompleteRenderInputParams) => {
+              const {InputProps: acInputProps, ...restParams} = params;
+              return (
+                <TextField
+                  {...restParams}
+                  fullWidth
+                  // Keep the id the FormLabel points at, otherwise the label targets
+                  // MUI's generated Autocomplete input id and loses click-to-focus
+                  // and its accessible name.
+                  id={`${resource.id}-${propertyKey}`}
+                  error={!!errorMessage}
+                  placeholder={placeholder}
+                  sx={dynamicValueSx}
+                  InputProps={{
+                    ...acInputProps,
+                    endAdornment: (
+                      <>
+                        {dynamicValueAdornment}
+                        {acInputProps?.endAdornment}
+                      </>
+                    ),
+                  }}
+                  {...rest}
+                />
+              );
+            }}
+          />
+        ) : (
+          textField
+        )}
       </FormControl>
       {errorMessage && <FormHelperText error>{errorMessage}</FormHelperText>}
       {isI18nPattern && resolvedI18nValue && (
-        <Box
-          sx={{
-            mt: 1,
-            p: 1.5,
-            backgroundColor: 'action.hover',
-            borderRadius: 1,
-            border: '1px solid',
-            borderColor: 'divider',
-          }}
-        >
-          <Typography variant="caption" color="text.secondary" sx={{display: 'block', mb: 0.5}}>
-            {t('flows:core.elements.textPropertyField.resolvedValue')}
-          </Typography>
-          <Typography variant="body2" sx={{wordBreak: 'break-word'}}>
+        // The resolved text is a preview, not a field. Keeping it to a single caption
+        // line preserves the form's vertical rhythm instead of interrupting it with a
+        // card per templated property.
+        <Tooltip title={t('flows:core.elements.textPropertyField.resolvedValue')}>
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{
+              display: 'block',
+              mt: 0.5,
+              pl: 0.25,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
             {resolvedI18nValue}
           </Typography>
-        </Box>
+        </Tooltip>
       )}
-      {!isIdField && (
+      {offersDynamicValue && (
         <DynamicValuePopover
           open={isDynamicValuePopoverOpen}
           anchorEl={iconButtonEl}

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/ClassesPropertyField.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/ClassesPropertyField.test.tsx
@@ -40,17 +40,16 @@ describe('ClassesPropertyField', () => {
     vi.clearAllMocks();
   });
 
-  it('should render a single row for an empty value', () => {
+  it('should show only the placeholder when there are no classes', () => {
     render(
       <ClassesPropertyField resource={mockResource} propertyKey="className" propertyValue="" onChange={mockOnChange} />,
     );
 
-    expect(screen.getAllByPlaceholderText('flows:core.elements.classesPropertyField.placeholder')).toHaveLength(1);
-    // Only row, no delete button should be rendered.
-    expect(screen.queryByRole('button', {name: ''})).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText('flows:core.elements.classesPropertyField.placeholder')).toBeInTheDocument();
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
   });
 
-  it('should render one row per space-separated class', () => {
+  it('should render a chip per space-separated class', () => {
     render(
       <ClassesPropertyField
         resource={mockResource}
@@ -60,13 +59,15 @@ describe('ClassesPropertyField', () => {
       />,
     );
 
-    const inputs = screen.getAllByPlaceholderText('flows:core.elements.classesPropertyField.placeholder');
-    expect(inputs).toHaveLength(2);
-    expect(inputs[0]).toHaveValue('btn');
-    expect(inputs[1]).toHaveValue('btn-primary');
+    expect(screen.getByText('btn')).toBeInTheDocument();
+    expect(screen.getByText('btn-primary')).toBeInTheDocument();
+    // With chips present the placeholder is dropped.
+    expect(
+      screen.queryByPlaceholderText('flows:core.elements.classesPropertyField.placeholder'),
+    ).not.toBeInTheDocument();
   });
 
-  it('should add a new empty row when the add button is clicked', () => {
+  it('should append a class when one is typed and committed', () => {
     render(
       <ClassesPropertyField
         resource={mockResource}
@@ -76,13 +77,26 @@ describe('ClassesPropertyField', () => {
       />,
     );
 
-    fireEvent.click(screen.getByText('flows:core.elements.classesPropertyField.addClass'));
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: 'btn-primary'}});
+    fireEvent.keyDown(input, {key: 'Enter'});
 
-    expect(screen.getAllByPlaceholderText('flows:core.elements.classesPropertyField.placeholder')).toHaveLength(2);
-    expect(mockOnChange).toHaveBeenCalledWith('className', 'btn ', mockResource, undefined);
+    expect(mockOnChange).toHaveBeenCalledWith('className', 'btn btn-primary', mockResource);
   });
 
-  it('should update a row value on change and debounce the update', () => {
+  it('should split a pasted value containing whitespace into separate classes', () => {
+    render(
+      <ClassesPropertyField resource={mockResource} propertyKey="className" propertyValue="" onChange={mockOnChange} />,
+    );
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: 'btn btn-primary'}});
+    fireEvent.keyDown(input, {key: 'Enter'});
+
+    expect(mockOnChange).toHaveBeenCalledWith('className', 'btn btn-primary', mockResource);
+  });
+
+  it('should not add the same class twice', () => {
     render(
       <ClassesPropertyField
         resource={mockResource}
@@ -92,13 +106,17 @@ describe('ClassesPropertyField', () => {
       />,
     );
 
-    const input = screen.getByPlaceholderText('flows:core.elements.classesPropertyField.placeholder');
-    fireEvent.change(input, {target: {value: 'btn-secondary'}});
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: 'btn'}});
+    fireEvent.keyDown(input, {key: 'Enter'});
 
-    expect(mockOnChange).toHaveBeenCalledWith('className', 'btn-secondary', mockResource, true);
+    // Whatever the widget emits, the persisted value never gains a duplicate.
+    const persisted: string[] = mockOnChange.mock.calls.map((call) => call[1] as string);
+    expect(persisted.every((value: string) => value === 'btn')).toBe(true);
+    expect(screen.getAllByText('btn')).toHaveLength(1);
   });
 
-  it('should remove a row when its delete button is clicked', () => {
+  it('should remove a class when its chip is deleted', () => {
     render(
       <ClassesPropertyField
         resource={mockResource}
@@ -108,12 +126,9 @@ describe('ClassesPropertyField', () => {
       />,
     );
 
-    const deleteButtons = screen.getAllByRole('button', {name: 'common:actions.delete'});
-    expect(deleteButtons).toHaveLength(2);
+    // Each chip renders a delete button; the first belongs to "btn".
+    fireEvent.click(screen.getAllByTestId('CancelIcon')[0]);
 
-    fireEvent.click(deleteButtons[0]);
-
-    expect(mockOnChange).toHaveBeenCalledWith('className', 'btn-primary', mockResource, undefined);
-    expect(screen.getAllByPlaceholderText('flows:core.elements.classesPropertyField.placeholder')).toHaveLength(1);
+    expect(mockOnChange).toHaveBeenCalledWith('className', 'btn-primary', mockResource);
   });
 });

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/CommonElementPropertyFactory.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/CommonElementPropertyFactory.test.tsx
@@ -92,11 +92,17 @@ vi.mock('../TextPropertyField', () => ({
     propertyKey,
     propertyValue,
     onChange,
+    suggestions,
+    supportsDynamicValue,
+    type,
   }: {
     resource: Resource;
     propertyKey: string;
     propertyValue: string;
     onChange: (key: string, value: string, resource: Resource) => void;
+    suggestions?: string[];
+    supportsDynamicValue?: boolean;
+    type?: string;
   }) => (
     <div data-testid="text-property-field">
       <input
@@ -104,6 +110,9 @@ vi.mock('../TextPropertyField', () => ({
         value={propertyValue}
         onChange={(e) => onChange(propertyKey, e.target.value, resource)}
         data-property-key={propertyKey}
+        data-suggestions={suggestions ? suggestions.join(',') : undefined}
+        data-supports-dynamic-value={String(supportsDynamicValue ?? true)}
+        data-type={type}
       />
     </div>
   ),
@@ -587,7 +596,7 @@ describe('CommonElementPropertyFactory', () => {
       expect(mockOnChange).toHaveBeenCalledWith('align', 'center', textResource);
     });
 
-    it('should not render align dropdown for non-Text elements', () => {
+    it('should not render the align Select for non-Text elements', () => {
       const resource: Resource = {
         id: 'resource-1',
         type: ElementTypes.TextInput,
@@ -604,9 +613,126 @@ describe('CommonElementPropertyFactory', () => {
         {wrapper: createWrapper()},
       );
 
-      // A non-Text element with align key renders a TextPropertyField, not a Select
+      // A non-Text element with align still renders the text field, not a Select
       expect(container.querySelector('select')).not.toBeInTheDocument();
       expect(screen.getByTestId('text-property-field')).toBeInTheDocument();
+    });
+  });
+
+  describe('Layout property suggestions', () => {
+    const stackResource: Resource = {
+      id: 'stack-1',
+      type: ElementTypes.Stack,
+      config: {},
+    } as Resource;
+
+    const renderLayoutField = (propertyKey: string, propertyValue: unknown) =>
+      render(
+        <CommonElementPropertyFactory
+          resource={stackResource}
+          propertyKey={propertyKey}
+          propertyValue={propertyValue}
+          onChange={mockOnChange}
+        />,
+        {wrapper: createWrapper()},
+      );
+
+    it.each([
+      ['direction', 'row,column,row-reverse,column-reverse'],
+      ['align', 'stretch,center,flex-start,flex-end,baseline,start,end'],
+      ['justify', 'stretch,center,flex-start,flex-end,space-between,space-around,space-evenly'],
+    ])('passes the known %s values as suggestions', (propertyKey, expected) => {
+      const {container} = renderLayoutField(propertyKey, '');
+
+      expect(container.querySelector(`[data-property-key="${propertyKey}"]`)).toHaveAttribute(
+        'data-suggestions',
+        expected,
+      );
+    });
+
+    it('leaves other string properties without suggestions', () => {
+      const {container} = renderLayoutField('label', 'Continue');
+
+      expect(container.querySelector('[data-property-key="label"]')).not.toHaveAttribute('data-suggestions');
+    });
+
+    it('does not treat inherited Object keys as layout properties', () => {
+      // `LAYOUT_PROPERTY_SUGGESTIONS['toString']` resolves through the prototype
+      // chain, and element config keys are arbitrary.
+      const {container} = renderLayoutField('toString', 'some value');
+
+      expect(container.querySelector('[data-property-key="toString"]')).not.toHaveAttribute('data-suggestions');
+    });
+
+    it.each(['direction', 'align', 'justify'])('does not offer dynamic values for %s', (propertyKey) => {
+      const {container} = renderLayoutField(propertyKey, '');
+
+      expect(container.querySelector(`[data-property-key="${propertyKey}"]`)).toHaveAttribute(
+        'data-supports-dynamic-value',
+        'false',
+      );
+    });
+
+    it.each(['items', 'gap'])('renders %s as a number field without dynamic values', (propertyKey) => {
+      const {container} = renderLayoutField(propertyKey, 2);
+
+      const input = container.querySelector(`[data-property-key="${propertyKey}"]`);
+      expect(input).toHaveAttribute('data-supports-dynamic-value', 'false');
+      expect(input).toHaveAttribute('data-type', 'number');
+    });
+
+    it('offers only the axis directions once a stack is a grid', () => {
+      // CSS Grid has no reverse auto-flow, so those values are flex-mode only.
+      const gridStack = {id: 'stack-2', type: ElementTypes.Stack, items: 2, config: {}} as unknown as Resource;
+
+      const {container} = render(
+        <CommonElementPropertyFactory
+          resource={gridStack}
+          propertyKey="direction"
+          propertyValue="row"
+          onChange={mockOnChange}
+        />,
+        {wrapper: createWrapper()},
+      );
+
+      expect(container.querySelector('[data-property-key="direction"]')).toHaveAttribute(
+        'data-suggestions',
+        'row,column',
+      );
+    });
+
+    it('keeps the reverse directions for a flex stack', () => {
+      const flexStack = {id: 'stack-3', type: ElementTypes.Stack, items: 1, config: {}} as unknown as Resource;
+
+      const {container} = render(
+        <CommonElementPropertyFactory
+          resource={flexStack}
+          propertyKey="direction"
+          propertyValue="row"
+          onChange={mockOnChange}
+        />,
+        {wrapper: createWrapper()},
+      );
+
+      expect(container.querySelector('[data-property-key="direction"]')).toHaveAttribute(
+        'data-suggestions',
+        'row,column,row-reverse,column-reverse',
+      );
+    });
+
+    it('keeps dynamic values available for other numeric properties', () => {
+      const {container} = renderLayoutField('size', 24);
+
+      expect(container.querySelector('[data-property-key="size"]')).toHaveAttribute(
+        'data-supports-dynamic-value',
+        'true',
+      );
+    });
+
+    it('falls through to the checkbox field when a layout key holds a boolean', () => {
+      renderLayoutField('align', true);
+
+      expect(screen.getByTestId('checkbox-property-field')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/TextPropertyField.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/TextPropertyField.test.tsx
@@ -255,9 +255,7 @@ describe('TextPropertyField', () => {
 
       // The text field should have the i18n key
       expect(screen.getByRole('textbox')).toHaveValue('{{t(common.submit)}}');
-      // The resolved value label should be displayed
-      expect(screen.getByText('flows:core.elements.textPropertyField.resolvedValue')).toBeInTheDocument();
-      // The resolved value should be displayed (mock returns the key itself)
+      // The resolved value is shown as a single caption line, labelled by tooltip.
       expect(screen.getByText('common.submit')).toBeInTheDocument();
     });
 
@@ -272,8 +270,8 @@ describe('TextPropertyField', () => {
         {wrapper: createWrapper()},
       );
 
-      // Should not have the resolved value label
-      expect(screen.queryByText('flows:core.elements.textPropertyField.resolvedValue')).not.toBeInTheDocument();
+      // Should not show a resolved value preview for a plain literal.
+      expect(screen.queryByLabelText('flows:core.elements.textPropertyField.resolvedValue')).not.toBeInTheDocument();
     });
   });
 
@@ -529,7 +527,7 @@ describe('TextPropertyField', () => {
 
       // Verify the component renders with i18n pattern
       expect(screen.getByRole('textbox')).toHaveValue('{{t(common.test)}}');
-      expect(screen.getByText('flows:core.elements.textPropertyField.resolvedValue')).toBeInTheDocument();
+      expect(screen.getByText('common.test')).toBeInTheDocument();
     });
 
     it('should not render i18n resolved value box when pattern has empty key', () => {
@@ -698,6 +696,94 @@ describe('TextPropertyField', () => {
 
       expect(screen.getByRole('textbox')).toHaveValue('{{t(app.module.feature.component.label)}}');
       expect(screen.getByText('app.module.feature.component.label')).toBeInTheDocument();
+    });
+  });
+
+  describe('Suggestions', () => {
+    const suggestions = ['row', 'column', 'row-reverse'];
+
+    const renderWithSuggestions = (propertyValue = '') =>
+      render(
+        <TextPropertyField
+          resource={mockResource}
+          propertyKey="direction"
+          propertyValue={propertyValue}
+          onChange={mockOnChange}
+          suggestions={suggestions}
+        />,
+        {wrapper: createWrapper()},
+      );
+
+    it('should offer the suggestions in a dropdown', () => {
+      renderWithSuggestions();
+
+      fireEvent.keyDown(screen.getByRole('combobox'), {key: 'ArrowDown'});
+
+      expect(screen.getAllByRole('option').map((option) => option.textContent)).toEqual(suggestions);
+    });
+
+    it('should commit a selected suggestion immediately', () => {
+      renderWithSuggestions();
+
+      fireEvent.keyDown(screen.getByRole('combobox'), {key: 'ArrowDown'});
+      fireEvent.click(screen.getAllByRole('option').find((option) => option.textContent === 'column')!);
+
+      expect(mockOnChange).toHaveBeenCalledWith('direction', 'column', mockResource);
+    });
+
+    it('should accept a custom value that is not suggested', () => {
+      renderWithSuggestions();
+
+      fireEvent.change(screen.getByRole('combobox'), {target: {value: 'safe center'}});
+
+      expect(screen.getByRole('combobox')).toHaveValue('safe center');
+      expect(mockOnChange).toHaveBeenCalledWith('direction', 'safe center', mockResource, true);
+    });
+
+    it('should keep the typed value while a debounced update is in flight', () => {
+      // The parent only echoes the value back after a debounce, so the field has to
+      // hold its own state or keystrokes get clobbered mid-typing.
+      renderWithSuggestions();
+
+      const input = screen.getByRole('combobox');
+      fireEvent.change(input, {target: {value: 'col'}});
+      fireEvent.change(input, {target: {value: 'colu'}});
+
+      expect(input).toHaveValue('colu');
+    });
+
+    it('should hide the dynamic value button for structural properties', () => {
+      // Layout values map straight to CSS, so i18n/meta templates do not apply.
+      render(
+        <TextPropertyField
+          resource={mockResource}
+          propertyKey="direction"
+          propertyValue=""
+          onChange={mockOnChange}
+          suggestions={suggestions}
+          supportsDynamicValue={false}
+        />,
+        {wrapper: createWrapper()},
+      );
+
+      // The i18n mock echoes the key back, so the tooltip label is the raw key.
+      expect(
+        screen.queryByLabelText('flows:core.elements.textPropertyField.tooltip.configureDynamicValue'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should keep the dynamic value button when the property supports it', () => {
+      renderWithSuggestions();
+
+      expect(
+        screen.getByLabelText('flows:core.elements.textPropertyField.tooltip.configureDynamicValue'),
+      ).toBeInTheDocument();
+    });
+
+    it('should render the field label above the input', () => {
+      renderWithSuggestions();
+
+      expect(screen.getByText('Direction')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/apps/console/src/features/flows/components/resources/elements/adapters/FormAdapter.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/elements/adapters/FormAdapter.tsx
@@ -17,11 +17,13 @@
  */
 
 import {CollisionPriority} from '@dnd-kit/abstract';
-import {Badge, Box, Typography} from '@wso2/oxygen-ui';
+import {Badge, Box, Button, Menu, MenuItem, Typography} from '@wso2/oxygen-ui';
+import {PlusIcon} from '@wso2/oxygen-ui-icons-react';
 import classNames from 'classnames';
-import {useMemo, type ReactElement} from 'react';
+import {useMemo, useState, type MouseEvent, type ReactElement} from 'react';
 import {useTranslation} from 'react-i18next';
 import Droppable from '../../../dnd/Droppable';
+import dashedAddButtonSx from '../../steps/view/dashedAddButtonSx';
 import ReorderableFlowElement from '../../steps/view/ReorderableElement';
 import VisualFlowConstants from '@/features/flows/constants/VisualFlowConstants';
 import useFlowPlugins from '@/features/flows/hooks/useFlowPlugins';
@@ -72,6 +74,13 @@ function FormAdapter({
 }: FormAdapterPropsInterface): ReactElement {
   const {t} = useTranslation();
   const {emitElementFilter} = useFlowPlugins();
+  const [addAnchorEl, setAddAnchorEl] = useState<null | HTMLElement>(null);
+
+  const addableElements: FlowElement[] = availableElements.filter(
+    (element: FlowElement) =>
+      VisualFlowConstants.FLOW_BUILDER_FORM_ALLOWED_RESOURCE_TYPES.includes(element.type) &&
+      element.display?.showOnResourcePanel !== false,
+  );
 
   const hasInputFields = resource?.components?.some(
     (element: FlowElement) =>
@@ -125,6 +134,46 @@ function FormAdapter({
             />
           ))}
         </Droppable>
+        {/* Rendered inside the form outline so the container encloses its own add
+            affordance, the same way a stack does. */}
+        {addableElements.length > 0 && (
+          <Box sx={{px: 2, pb: 2}}>
+            <Button
+              fullWidth
+              size="small"
+              className="nodrag"
+              data-testid="form-add-field-button"
+              startIcon={<PlusIcon size={15} />}
+              onClick={(event: MouseEvent<HTMLElement>) => {
+                event.stopPropagation();
+                setAddAnchorEl(event.currentTarget);
+              }}
+              sx={dashedAddButtonSx}
+            >
+              {t('flows:core.steps.view.addField', 'Add Field')}
+            </Button>
+          </Box>
+        )}
+        <Menu
+          anchorEl={addAnchorEl}
+          open={Boolean(addAnchorEl)}
+          onClose={() => setAddAnchorEl(null)}
+          anchorOrigin={{vertical: 'bottom', horizontal: 'right'}}
+          transformOrigin={{vertical: 'top', horizontal: 'right'}}
+        >
+          {addableElements.map((element: FlowElement) => (
+            <MenuItem
+              key={`${element.type}-${element.id}`}
+              onClick={() => {
+                setAddAnchorEl(null);
+                onAddElementToForm?.(element, resource.id);
+              }}
+              sx={{minWidth: 200}}
+            >
+              {element.display?.label ?? element.type}
+            </MenuItem>
+          ))}
+        </Menu>
       </Box>
     </Badge>
   );

--- a/frontend/apps/console/src/features/flows/components/resources/elements/adapters/StackAdapter.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/elements/adapters/StackAdapter.tsx
@@ -17,13 +17,16 @@
  */
 
 import {CollisionPriority} from '@dnd-kit/abstract';
-import {Box, Typography, type SxProps, type Theme} from '@wso2/oxygen-ui';
-import {ChevronDown, ChevronLeft, ChevronRight, ChevronUp} from '@wso2/oxygen-ui-icons-react';
+import {getStackGridSx, parseStackItems} from '@thunderid/design';
+import {Box, Button, Menu, MenuItem, Typography, type SxProps, type Theme} from '@wso2/oxygen-ui';
+import {ChevronDown, ChevronLeft, ChevronRight, ChevronUp, PlusIcon} from '@wso2/oxygen-ui-icons-react';
 import {useReactFlow, type Node} from '@xyflow/react';
 import classNames from 'classnames';
-import {useMemo, useCallback, type ReactElement} from 'react';
+import {useMemo, useCallback, useState, type MouseEvent, type ReactElement} from 'react';
+import {useTranslation} from 'react-i18next';
 import Droppable from '../../../dnd/Droppable';
 import Handle from '../../../dnd/Handle';
+import dashedAddButtonSx from '../../steps/view/dashedAddButtonSx';
 import ReorderableFlowElement from '../../steps/view/ReorderableElement';
 import VisualFlowConstants from '@/features/flows/constants/VisualFlowConstants';
 import useFlowPlugins from '@/features/flows/hooks/useFlowPlugins';
@@ -32,14 +35,15 @@ import generateResourceId from '@/features/flows/utils/generateResourceId';
 
 /**
  * Stack element type with layout configuration at top level.
- * When `columns` >= 2, the stack uses CSS Grid instead of flexbox.
+ * With a valid `items` count of two or more the stack uses CSS Grid; anything else
+ * (absent, 1, or malformed) keeps the flex layout.
  */
 export type StackElement = FlowElement & {
   direction?: 'row' | 'column';
   gap?: number;
   align?: string;
   justify?: string;
-  /** Number of equal slots. 1 = flex mode, ≥2 = grid mode with that many slots. */
+  /** Number of slots across the main axis. Absent keeps the flex layout. */
   items?: number;
 };
 
@@ -114,13 +118,31 @@ const SLOT_SX: SxProps<Theme> = {
 /**
  * sx for empty placeholder slots.
  */
+/**
+ * Chrome that outlines the stack itself, mirroring the Form adapter so a stack's
+ * children visibly belong to it.
+ */
+const CONTAINER_SX: SxProps<Theme> = {
+  borderRadius: 'calc(2 * var(--oxygen-shape-borderRadius))',
+  border: '1px dashed var(--oxygen-palette-divider)',
+  backgroundColor: 'var(--oxygen-palette-background-paper)',
+  boxSizing: 'border-box',
+  px: 2,
+  py: 1.5,
+};
+
+// An empty slot marks reserved space rather than an action, so it reads as a dashed
+// outline instead of a filled box. That keeps it distinct from the "Add Component"
+// button, which is filled and carries a label.
 const EMPTY_SLOT_SX: SxProps<Theme> = {
   ...SLOT_SX,
-  backgroundColor: 'action.hover',
-  minHeight: '44px',
+  backgroundColor: 'transparent',
+  border: '1.5px dashed',
+  borderColor: 'divider',
+  minHeight: '40px',
   padding: '8px',
-  transition: 'background-color 150ms ease',
-  '&:hover': {backgroundColor: 'action.selected'},
+  transition: 'border-color 150ms ease, background-color 150ms ease',
+  '&:hover': {borderColor: 'primary.main', backgroundColor: 'action.hover'},
 };
 
 /**
@@ -138,12 +160,18 @@ function StackAdapter({
   onAddElementToForm = undefined,
 }: StackAdapterPropsInterface): ReactElement {
   const stackElement = resource as StackElement;
-  const items = stackElement?.items ?? 1;
-  const useGrid = items >= 2;
-  const isRow = (stackElement?.direction ?? 'row') === 'row';
+  const gridSx = getStackGridSx(stackElement);
+  const items = parseStackItems(stackElement?.items);
+  const useGrid = gridSx !== null;
+  // Grid resolves any non-column direction to the row axis, so the move controls have
+  // to follow the same rule or a custom direction shows Up/Down beside a row grid.
+  const isColumnAxis = (stackElement?.direction ?? '').startsWith('column');
+  const isRow = useGrid ? !isColumnAxis : (stackElement?.direction ?? 'row') === 'row';
 
+  const {t} = useTranslation();
   const {updateNodeData} = useReactFlow();
   const {emitElementFilter} = useFlowPlugins();
+  const [addAnchorEl, setAddAnchorEl] = useState<null | HTMLElement>(null);
 
   const handleMove = useCallback(
     (componentId: string, delta: -1 | 1): void => {
@@ -178,34 +206,35 @@ function StackAdapter({
     return resource.components.filter((component: FlowElement) => emitElementFilter(component));
   }, [resource?.components, emitElementFilter]);
 
-  // In grid mode: always fill defined slots — show placeholders for every unoccupied slot.
-  // In flex mode: show a single placeholder only when there are no children.
-  let emptySlotCount: number;
-  if (useGrid) {
-    emptySlotCount = Math.max(0, items - filteredComponents.length);
-  } else {
-    emptySlotCount = filteredComponents.length === 0 ? 1 : 0;
-  }
+  // In grid mode the placeholders convey the slot structure, so every unoccupied cell
+  // gets one, including the trailing cells of a partially filled last track.
+  // A flex stack has no slots to convey, and an empty one already shows the
+  // "Add Component" button, so a placeholder there would just be a second empty box.
+  const slots = items ?? 1;
+  const occupiedTracks = Math.max(1, Math.ceil(filteredComponents.length / slots));
+  const emptySlotCount: number = useGrid ? occupiedTracks * slots - filteredComponents.length : 0;
 
-  const layoutSx: SxProps<Theme> = useGrid
-    ? {
-        display: 'grid',
-        gridTemplateColumns: `repeat(${items}, 1fr)`,
-        gap: stackElement?.gap ?? 1,
-        alignItems: stackElement?.align ?? 'start',
-        px: 2,
-      }
-    : {
-        display: 'flex',
-        flexDirection: stackElement?.direction ?? 'row',
-        flexWrap: 'wrap',
-        gap: stackElement?.gap ?? 2,
-        alignItems: stackElement?.align ?? 'center',
-        justifyContent: stackElement?.justify ?? 'center',
-        px: 2,
-      };
+  const layoutSx: SxProps<Theme> = gridSx ?? {
+    display: 'flex',
+    flexDirection: stackElement?.direction ?? 'row',
+    flexWrap: 'wrap',
+    gap: stackElement?.gap ?? 2,
+    alignItems: stackElement?.align ?? 'center',
+    justifyContent: stackElement?.justify ?? 'center',
+  };
 
-  return (
+  const addableElements: FlowElement[] = availableElements.filter(
+    (element: FlowElement) =>
+      VisualFlowConstants.FLOW_BUILDER_STACK_ALLOWED_RESOURCE_TYPES.includes(element.type) &&
+      element.display?.showOnResourcePanel !== false,
+  );
+
+  const handleAddComponent = (element: FlowElement): void => {
+    setAddAnchorEl(null);
+    onAddElementToForm?.(element, resource.id);
+  };
+
+  const droppable = (
     <Droppable
       id={generateResourceId(`${VisualFlowConstants.FLOW_BUILDER_STACK_ID}_${resource.id}`)}
       data={{droppedOn: resource, stepId}}
@@ -263,7 +292,6 @@ function StackAdapter({
             onAddElementToForm={onAddElementToForm}
             hideDrag
             hideEdit
-            hideDelete
             extraActions={moveActions}
             sx={SLOT_SX}
             dropIndicatorStyles={{
@@ -287,6 +315,43 @@ function StackAdapter({
         </Box>
       ))}
     </Droppable>
+  );
+
+  // The add affordance lives inside the container chrome so the stack's outline
+  // encloses it, the same way a form encloses its own add button.
+  return (
+    <Box sx={CONTAINER_SX}>
+      {droppable}
+      {addableElements.length > 0 && (
+        <Button
+          fullWidth
+          size="small"
+          className="nodrag"
+          data-testid="stack-add-component-button"
+          startIcon={<PlusIcon size={15} />}
+          onClick={(event: MouseEvent<HTMLElement>) => {
+            event.stopPropagation();
+            setAddAnchorEl(event.currentTarget);
+          }}
+          sx={{...dashedAddButtonSx, mt: 1.5}}
+        >
+          {t('flows:core.steps.view.addComponent', 'Add Component')}
+        </Button>
+      )}
+      <Menu
+        anchorEl={addAnchorEl}
+        open={Boolean(addAnchorEl)}
+        onClose={() => setAddAnchorEl(null)}
+        anchorOrigin={{vertical: 'bottom', horizontal: 'right'}}
+        transformOrigin={{vertical: 'top', horizontal: 'right'}}
+      >
+        {addableElements.map((element: FlowElement) => (
+          <MenuItem key={element.id} onClick={() => handleAddComponent(element)} sx={{minWidth: 200}}>
+            {element.display?.label ?? element.type}
+          </MenuItem>
+        ))}
+      </Menu>
+    </Box>
   );
 }
 

--- a/frontend/apps/console/src/features/flows/components/resources/elements/adapters/__tests__/FormAdapter.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/elements/adapters/__tests__/FormAdapter.test.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {render, screen} from '@testing-library/react';
+import {render, screen, fireEvent} from '@testing-library/react';
 import type {ReactNode} from 'react';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import FormAdapter from '../FormAdapter';
@@ -233,6 +233,50 @@ describe('FormAdapter', () => {
       // All components should render since our mock returns true
       expect(screen.getByTestId('reorderable-element-comp-1')).toBeInTheDocument();
       expect(screen.getByTestId('reorderable-element-comp-2')).toBeInTheDocument();
+    });
+  });
+
+  describe('Add field', () => {
+    const formElements = [
+      {id: 'text-input', type: 'TEXT_INPUT', display: {label: 'Text Input', showOnResourcePanel: true}},
+      {id: 'hidden', type: 'TEXT_INPUT', display: {label: 'Hidden', showOnResourcePanel: false}},
+      {id: 'captcha', type: 'CAPTCHA', display: {label: 'Captcha', showOnResourcePanel: true}},
+    ] as never[];
+
+    it('should render the add field button inside the form outline', () => {
+      render(<FormAdapter resource={createMockElement()} stepId="step-1" availableElements={formElements} />);
+
+      expect(screen.getByTestId('form-add-field-button')).toBeInTheDocument();
+    });
+
+    it('should offer only form-compatible elements shown on the resource panel', () => {
+      render(<FormAdapter resource={createMockElement()} stepId="step-1" availableElements={formElements} />);
+
+      fireEvent.click(screen.getByTestId('form-add-field-button'));
+
+      expect(screen.getByText('Text Input')).toBeInTheDocument();
+      expect(screen.queryByText('Hidden')).not.toBeInTheDocument();
+      expect(screen.queryByText('Captcha')).not.toBeInTheDocument();
+    });
+
+    it('should add the chosen field to this form', () => {
+      const onAddElementToForm = vi.fn();
+      render(
+        <FormAdapter
+          resource={createMockElement()}
+          stepId="step-1"
+          availableElements={formElements}
+          onAddElementToForm={onAddElementToForm}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId('form-add-field-button'));
+      fireEvent.click(screen.getByText('Text Input'));
+
+      expect(onAddElementToForm).toHaveBeenCalledWith(
+        expect.objectContaining({type: 'TEXT_INPUT'}),
+        createMockElement().id,
+      );
     });
   });
 });

--- a/frontend/apps/console/src/features/flows/components/resources/elements/adapters/__tests__/StackAdapter.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/elements/adapters/__tests__/StackAdapter.test.tsx
@@ -129,20 +129,20 @@ describe('StackAdapter', () => {
       expect(screen.getByTestId('reorderable-element-child-2')).toBeInTheDocument();
     });
 
-    it('should show placeholder when no children exist in flex mode', () => {
+    it('should not show a slot placeholder in flex mode, where the add button covers it', () => {
       const resource = createMockElement({components: []});
 
       render(<StackAdapter resource={resource} stepId="step-1" />);
 
-      expect(screen.getByText('Drop here')).toBeInTheDocument();
+      expect(screen.queryByText('Drop here')).not.toBeInTheDocument();
     });
 
-    it('should show placeholder when components is undefined', () => {
+    it('should not show a slot placeholder when components is undefined', () => {
       const resource = createMockElement({components: undefined});
 
       render(<StackAdapter resource={resource} stepId="step-1" />);
 
-      expect(screen.getByText('Drop here')).toBeInTheDocument();
+      expect(screen.queryByText('Drop here')).not.toBeInTheDocument();
     });
 
     it('should not show placeholder when children exist in flex mode', () => {
@@ -156,7 +156,101 @@ describe('StackAdapter', () => {
     });
   });
 
-  describe('Grid mode (items >= 2)', () => {
+  describe('Flex mode (fewer than two slots)', () => {
+    it('should keep the flex layout when items is 1', () => {
+      // Every builder-created stack is seeded with items 1, so this is the layout
+      // previously authored flows rely on.
+      const resource = createMockElement({
+        items: 1,
+        direction: 'row',
+        components: [createChildElement('child-1'), createChildElement('child-2')],
+      });
+
+      render(<StackAdapter resource={resource} stepId="step-1" />);
+
+      expect(screen.getByTestId('reorderable-element-child-1')).toBeInTheDocument();
+      expect(screen.getByTestId('reorderable-element-child-2')).toBeInTheDocument();
+      // Flex mode never pads with slot placeholders when children exist.
+      expect(screen.queryByText('Drop here')).not.toBeInTheDocument();
+    });
+
+    it('should not show a slot placeholder when items is 1 and there are no children', () => {
+      // A flex stack has no slot structure to convey, and the "Add Component" button
+      // already fills the empty state.
+      const resource = createMockElement({items: 1, direction: 'row', components: []});
+
+      render(<StackAdapter resource={resource} stepId="step-1" />);
+
+      expect(screen.queryByText('Drop here')).not.toBeInTheDocument();
+    });
+
+    it('should keep the flex layout when items is absent', () => {
+      const resource = createMockElement({
+        direction: 'row',
+        components: [],
+      });
+
+      render(<StackAdapter resource={resource} stepId="step-1" />);
+
+      expect(screen.queryByText('Drop here')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Add component', () => {
+    const stackElements: FlowElement[] = [
+      {id: 'action', type: 'ACTION', display: {label: 'Button', showOnResourcePanel: true}} as unknown as FlowElement,
+      {id: 'text', type: 'TEXT', display: {label: 'Text', showOnResourcePanel: true}} as unknown as FlowElement,
+      {
+        id: 'input',
+        type: 'TEXT_INPUT',
+        display: {label: 'Text Input', showOnResourcePanel: true},
+      } as unknown as FlowElement,
+      {id: 'hidden', type: 'TEXT', display: {label: 'Hidden', showOnResourcePanel: false}} as unknown as FlowElement,
+    ];
+
+    it('should render the add component button', () => {
+      render(<StackAdapter resource={createMockElement()} stepId="step-1" availableElements={stackElements} />);
+
+      expect(screen.getByTestId('stack-add-component-button')).toBeInTheDocument();
+    });
+
+    it('should not render the add button when nothing can be added', () => {
+      render(<StackAdapter resource={createMockElement()} stepId="step-1" availableElements={[]} />);
+
+      expect(screen.queryByTestId('stack-add-component-button')).not.toBeInTheDocument();
+    });
+
+    it('should offer only stack-compatible elements shown on the resource panel', () => {
+      render(<StackAdapter resource={createMockElement()} stepId="step-1" availableElements={stackElements} />);
+
+      fireEvent.click(screen.getByTestId('stack-add-component-button'));
+
+      expect(screen.getByText('Button')).toBeInTheDocument();
+      expect(screen.getByText('Text')).toBeInTheDocument();
+      // TEXT_INPUT is a form field, and the hidden entry opts out of the panel.
+      expect(screen.queryByText('Text Input')).not.toBeInTheDocument();
+      expect(screen.queryByText('Hidden')).not.toBeInTheDocument();
+    });
+
+    it('should add the chosen element to this stack', () => {
+      const onAddElementToForm = vi.fn();
+      render(
+        <StackAdapter
+          resource={createMockElement()}
+          stepId="step-1"
+          availableElements={stackElements}
+          onAddElementToForm={onAddElementToForm}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId('stack-add-component-button'));
+      fireEvent.click(screen.getByText('Button'));
+
+      expect(onAddElementToForm).toHaveBeenCalledWith(expect.objectContaining({type: 'ACTION'}), 'stack-1');
+    });
+  });
+
+  describe('Grid mode (multiple slots)', () => {
     it('should show empty placeholder slots for unoccupied grid positions', () => {
       const resource = createMockElement({
         items: 3,
@@ -181,7 +275,7 @@ describe('StackAdapter', () => {
       expect(screen.queryByText('Drop here')).not.toBeInTheDocument();
     });
 
-    it('should show no empty slots when more children than grid items', () => {
+    it('should show a placeholder for the trailing cell of a partially filled last row', () => {
       const resource = createMockElement({
         items: 2,
         components: [createChildElement('child-1'), createChildElement('child-2'), createChildElement('child-3')],
@@ -189,7 +283,41 @@ describe('StackAdapter', () => {
 
       render(<StackAdapter resource={resource} stepId="step-1" />);
 
+      // 3 children across 2 columns fill row 1 and half of row 2.
+      expect(screen.getAllByText('Drop here')).toHaveLength(1);
+    });
+
+    it('should show no empty slots when the last row is exactly filled', () => {
+      const resource = createMockElement({
+        items: 2,
+        components: [
+          createChildElement('child-1'),
+          createChildElement('child-2'),
+          createChildElement('child-3'),
+          createChildElement('child-4'),
+        ],
+      });
+
+      render(<StackAdapter resource={resource} stepId="step-1" />);
+
       expect(screen.queryByText('Drop here')).not.toBeInTheDocument();
+    });
+
+    it('should fill the last row when children exceed two rows', () => {
+      const resource = createMockElement({
+        items: 3,
+        components: [
+          createChildElement('child-1'),
+          createChildElement('child-2'),
+          createChildElement('child-3'),
+          createChildElement('child-4'),
+        ],
+      });
+
+      render(<StackAdapter resource={resource} stepId="step-1" />);
+
+      // 4 children across 3 columns leave 2 empty cells in row 2.
+      expect(screen.getAllByText('Drop here')).toHaveLength(2);
     });
   });
 

--- a/frontend/apps/console/src/features/flows/components/resources/steps/view/ReorderableElement.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/steps/view/ReorderableElement.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {Box, Button, Menu, MenuItem, type BoxProps} from '@wso2/oxygen-ui';
+import {Box, Menu, MenuItem, type BoxProps} from '@wso2/oxygen-ui';
 import {
   ChevronDownIcon,
   ChevronUpIcon,
@@ -28,8 +28,6 @@ import {
 import {useNodeId, useReactFlow, type Node} from '@xyflow/react';
 import classNames from 'classnames';
 import {useRef, useState, useMemo, memo, type MouseEvent, type ReactElement, type ReactNode} from 'react';
-import {useTranslation} from 'react-i18next';
-import dashedAddButtonSx from './dashedAddButtonSx';
 import Handle from '../../../dnd/Handle';
 import Sortable from '../../../dnd/Sortable';
 import type {SortableProps} from '../../../dnd/Sortable';
@@ -41,7 +39,7 @@ import useFlowPlugins from '@/features/flows/hooks/useFlowPlugins';
 import useInteractionState from '@/features/flows/hooks/useInteractionState';
 import useUIPanelState from '@/features/flows/hooks/useUIPanelState';
 import useValidationStatus from '@/features/flows/hooks/useValidationStatus';
-import {BlockTypes, ElementCategories, type Element} from '@/features/flows/models/elements';
+import {BlockTypes, ElementCategories, ElementTypes, type Element} from '@/features/flows/models/elements';
 import type {Resource} from '@/features/flows/models/resources';
 import type {StepData} from '@/features/flows/models/steps';
 
@@ -129,7 +127,6 @@ function ReorderableElement({
   slotProps = {},
   ...rest
 }: ReorderableComponentPropsInterface): ReactElement {
-  const {t} = useTranslation();
   const handleRef = useRef<HTMLButtonElement>(null);
   const stepId: string | null = useNodeId();
   const {updateNodeData} = useReactFlow();
@@ -146,6 +143,11 @@ function ReorderableElement({
   // Action-category blocks (e.g. social login trigger wrappers) share the BLOCK type
   // with forms but only group a trigger button — they must not accept extra fields.
   const isForm = element.type === BlockTypes.Form && element.category !== ElementCategories.Action;
+
+  // Stacks are containers too, so they get the same click-to-add affordance as forms
+  // rather than being drag-and-drop only.
+  const isStack = element.type === ElementTypes.Stack;
+  const isContainer = isForm || isStack;
 
   const depsRef = useRef({
     element,
@@ -315,18 +317,21 @@ function ReorderableElement({
     handleMoveDown,
   } = handlersRef.current;
 
-  // Filter available elements to only show form-compatible types that are visible on resource panel
-  const formCompatibleElements = useMemo(
-    () =>
-      isForm && depsRef.current.availableElements
-        ? depsRef.current.availableElements.filter(
-            (el: Resource) =>
-              VisualFlowConstants.FLOW_BUILDER_FORM_ALLOWED_RESOURCE_TYPES.includes(el.type) &&
-              el.display?.showOnResourcePanel !== false,
-          )
-        : [],
-    [isForm],
-  );
+  // Filter available elements to only show container-compatible types that are visible
+  // on the resource panel
+  const formCompatibleElements = useMemo(() => {
+    if (!isContainer || !availableElements) {
+      return [];
+    }
+    const allowedTypes = isStack
+      ? VisualFlowConstants.FLOW_BUILDER_STACK_ALLOWED_RESOURCE_TYPES
+      : VisualFlowConstants.FLOW_BUILDER_FORM_ALLOWED_RESOURCE_TYPES;
+    return availableElements.filter(
+      (el: Resource) => allowedTypes.includes(el.type) && el.display?.showOnResourcePanel !== false,
+    );
+    // Reads the prop rather than the ref: the container flags never change for a
+    // mounted element, so a ref-based memo would swallow a late-loaded element list.
+  }, [isContainer, isStack, availableElements]);
 
   return (
     <Sortable
@@ -404,8 +409,8 @@ function ReorderableElement({
                 </Handle>
               )}
               {extraActions}
-              {isForm && formCompatibleElements.length > 0 && (
-                <Handle label="Add Field" onClick={handleMenuOpen}>
+              {isContainer && formCompatibleElements.length > 0 && (
+                <Handle label={isStack ? 'Add Component' : 'Add Field'} onClick={handleMenuOpen}>
                   <PlusIcon size={16} />
                 </Handle>
               )}
@@ -437,28 +442,14 @@ function ReorderableElement({
               availableElements={availableElements}
               onAddElementToForm={onAddElementToForm}
             />
-            {isForm && formCompatibleElements.length > 0 && (
-              <Button
-                fullWidth
-                size="small"
-                className="nodrag"
-                data-testid="form-add-field-button"
-                startIcon={<PlusIcon size={15} />}
-                onClick={(event: MouseEvent<HTMLElement>) => {
-                  event.stopPropagation();
-                  handleMenuOpen(event);
-                }}
-                sx={dashedAddButtonSx}
-              >
-                {t('flows:core.steps.view.addField', 'Add Field')}
-              </Button>
-            )}
+            {/* Forms and stacks render their own add button inside their container
+                outline, so it is enclosed by the same border as their children. */}
           </Box>
         </Box>
       </ValidationErrorBoundary>
 
-      {/* Menu for adding fields to Form */}
-      {isForm && (
+      {/* Menu for adding elements to a container (form or stack) */}
+      {isContainer && (
         <Menu
           anchorEl={anchorEl}
           open={menuOpen}

--- a/frontend/apps/console/src/features/flows/components/resources/steps/view/__tests__/ReorderableElement.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/steps/view/__tests__/ReorderableElement.test.tsx
@@ -156,6 +156,7 @@ vi.mock('@/features/flows/hooks/useUIPanelState', () => ({
 vi.mock('@/features/flows/constants/VisualFlowConstants', () => ({
   default: {
     FLOW_BUILDER_FORM_ALLOWED_RESOURCE_TYPES: ['TEXT_INPUT', 'PASSWORD_INPUT', 'BUTTON'],
+    FLOW_BUILDER_STACK_ALLOWED_RESOURCE_TYPES: ['ACTION', 'TEXT', 'DIVIDER', 'IMAGE', 'STACK'],
     FLOW_BUILDER_PLUGIN_FUNCTION_IDENTIFIER: 'uniqueName',
   },
 }));
@@ -210,6 +211,16 @@ describe('ReorderableElement', () => {
     components: [mockTriggerButton],
     display: {label: 'Continue with Google', image: '', showOnResourcePanel: true},
   } as unknown as Resource;
+
+  const mockStackElements: Resource[] = [
+    {
+      id: 'action-button',
+      type: 'ACTION',
+      category: 'ACTION',
+      resourceType: 'ELEMENT',
+      display: {label: 'Button', image: '', showOnResourcePanel: true},
+    } as Resource,
+  ];
 
   const mockAvailableElements: Resource[] = [
     {
@@ -304,7 +315,7 @@ describe('ReorderableElement', () => {
       expect(screen.queryByTestId('handle-add field')).not.toBeInTheDocument();
     });
 
-    it('should render a persistent dashed add field button for Form elements', () => {
+    it('should not render the persistent add button, which lives inside the container', () => {
       render(
         <ReorderableElement
           id="sortable-1"
@@ -314,7 +325,72 @@ describe('ReorderableElement', () => {
         />,
       );
 
-      expect(screen.getByTestId('form-add-field-button')).toBeInTheDocument();
+      expect(screen.queryByTestId('form-add-field-button')).not.toBeInTheDocument();
+      expect(screen.getByTestId('handle-add field')).toBeInTheDocument();
+    });
+
+    it('should offer the add-component handle for Stack elements', () => {
+      const stackElement: Resource = {
+        id: 'stack-1',
+        type: 'STACK',
+        category: 'DISPLAY',
+        resourceType: 'ELEMENT',
+        components: [],
+      } as unknown as Resource;
+
+      render(
+        <ReorderableElement id="sortable-1" index={0} element={stackElement} availableElements={mockStackElements} />,
+      );
+
+      expect(screen.getByTestId('handle-add component')).toBeInTheDocument();
+      // The persistent button lives inside the stack's own container outline.
+      expect(screen.queryByTestId('form-add-field-button')).not.toBeInTheDocument();
+    });
+
+    it('should offer only stack-compatible elements inside a Stack', () => {
+      const stackElement: Resource = {
+        id: 'stack-1',
+        type: 'STACK',
+        category: 'DISPLAY',
+        resourceType: 'ELEMENT',
+        components: [],
+      } as unknown as Resource;
+
+      render(
+        <ReorderableElement
+          id="sortable-1"
+          index={0}
+          element={stackElement}
+          availableElements={[...mockAvailableElements, ...mockStackElements]}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId('handle-add component'));
+
+      // ACTION is stack-compatible; TEXT_INPUT is a form field and must not appear.
+      expect(screen.getByText('Button')).toBeInTheDocument();
+      expect(screen.queryByText('Text Input')).not.toBeInTheDocument();
+    });
+
+    it('should pick up an availableElements list that loads after the first render', () => {
+      // The list arrives asynchronously, so the memo must track the prop rather than
+      // a ref that only the container flags invalidate.
+      const {rerender} = render(
+        <ReorderableElement id="sortable-1" index={0} element={mockFormElement} availableElements={[]} />,
+      );
+
+      expect(screen.queryByTestId('handle-add field')).not.toBeInTheDocument();
+
+      rerender(
+        <ReorderableElement
+          id="sortable-1"
+          index={0}
+          element={mockFormElement}
+          availableElements={mockAvailableElements}
+        />,
+      );
+
+      expect(screen.getByTestId('handle-add field')).toBeInTheDocument();
     });
 
     it('should hide the selection chrome when hideChrome is set', () => {
@@ -374,21 +450,6 @@ describe('ReorderableElement', () => {
       );
 
       expect(screen.queryByTestId('form-add-field-button')).not.toBeInTheDocument();
-    });
-
-    it('should open the add field menu from the dashed add field button', () => {
-      render(
-        <ReorderableElement
-          id="sortable-1"
-          index={0}
-          element={mockFormElement}
-          availableElements={mockAvailableElements}
-        />,
-      );
-
-      fireEvent.click(screen.getByTestId('form-add-field-button'));
-
-      expect(screen.getByRole('menu')).toBeInTheDocument();
     });
 
     it('should open menu when Add Field button is clicked', () => {

--- a/frontend/apps/console/src/features/flows/constants/ResourcePropertyPanelConstants.ts
+++ b/frontend/apps/console/src/features/flows/constants/ResourcePropertyPanelConstants.ts
@@ -34,7 +34,27 @@ class ResourcePropertyPanelConstants {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   private constructor() {}
 
-  public static readonly EXCLUDED_PROPERTIES: string[] = ['ref', 'type', 'startIcon', 'endIcon', 'eventType'];
+  /**
+   * Ordered sections the property panel groups fields into. Keys not listed here fall
+   * into the trailing "Other" section, so a new element property still shows up.
+   */
+  public static readonly PROPERTY_SECTIONS: {title: string; keys: string[]}[] = [
+    {title: 'Content', keys: ['label', 'text', 'title', 'subtitle', 'message', 'placeholder', 'hint', 'alt', 'src']},
+    {title: 'Appearance', keys: ['variant', 'size', 'color', 'width', 'height']},
+    {title: 'Layout', keys: ['items', 'direction', 'gap', 'align', 'justify']},
+    {title: 'Validation', keys: ['required', 'minLength', 'maxLength', 'min', 'max', 'pattern']},
+  ];
+
+  // `classes` is excluded because the panel renders it through the dedicated
+  // ClassesPropertyField; leaving it here too would show the same value twice.
+  public static readonly EXCLUDED_PROPERTIES: string[] = [
+    'ref',
+    'type',
+    'startIcon',
+    'endIcon',
+    'eventType',
+    'classes',
+  ];
 }
 
 export default ResourcePropertyPanelConstants;

--- a/frontend/apps/console/src/features/flows/context/FlowBuilderCoreProvider.tsx
+++ b/frontend/apps/console/src/features/flows/context/FlowBuilderCoreProvider.tsx
@@ -194,9 +194,11 @@ function FlowContextWrapper({
     const headerText = resource?.display?.header ?? startCase(resource?.type?.toLowerCase());
 
     setResourcePropertiesPanelHeadingRef.current(
-      <Stack direction="row" className="sub-title" gap={1} alignItems="center">
-        <CogIcon />
-        <Typography variant="h5">{headerText} Properties</Typography>
+      <Stack direction="row" className="sub-title" gap={1.25} alignItems="center" sx={{minWidth: 0}}>
+        <CogIcon size={18} />
+        <Typography variant="h6" noWrap title={`${headerText} Properties`}>
+          {headerText} Properties
+        </Typography>
       </Stack>,
     );
     setLastInteractedElementInternalRef.current(resource);

--- a/frontend/apps/console/src/features/login-flow/components/resource-property-panel/ResourceProperties.tsx
+++ b/frontend/apps/console/src/features/login-flow/components/resource-property-panel/ResourceProperties.tsx
@@ -27,8 +27,10 @@ import RulesProperties from './nodes/RulesProperties';
 import ResourcePropertyFactory from './ResourcePropertyFactory';
 import ClassesPropertyField from '@/features/flows/components/resource-property-panel/ClassesPropertyField';
 import ColorSelect from '@/features/flows/components/resource-property-panel/ColorSelect';
+import PropertySection from '@/features/flows/components/resource-property-panel/PropertySection';
 import TextPropertyField from '@/features/flows/components/resource-property-panel/TextPropertyField';
 import VariantSelect from '@/features/flows/components/resource-property-panel/VariantSelect';
+import ResourcePropertyPanelConstants from '@/features/flows/constants/ResourcePropertyPanelConstants';
 import type {ResourcePropertiesProps} from '@/features/flows/context/FlowBuilderCoreProvider';
 import type {FieldKey, FieldValue} from '@/features/flows/models/base';
 import {ElementCategories, ElementTypes, type Element} from '@/features/flows/models/elements';
@@ -78,41 +80,72 @@ function ResourceProperties({
     return resource.variants.find((v: Element) => v.variant === (resource as Element).variant) as Element | undefined;
   }, [resource]);
 
-  const renderElementId = (): ReactElement => (
-    <ResourcePropertyFactory
-      key={`${resource.id}-$id`}
-      resource={resource}
-      propertyKey="id"
-      propertyValue={resource.id}
-      onChange={handleChange}
-    />
+  const renderElementId = (withClasses = false): ReactElement => (
+    <PropertySection key={`${resource.id}-general`} title={sectionTitle('General')}>
+      <ResourcePropertyFactory
+        key={`${resource.id}-$id`}
+        resource={resource}
+        propertyKey="id"
+        propertyValue={resource.id}
+        onChange={handleChange}
+      />
+      {withClasses && (
+        <ClassesPropertyField
+          key={`${resource.id}-$classes`}
+          resource={resource}
+          propertyKey="classes"
+          propertyValue={(resource as Element & {classes?: string}).classes ?? ''}
+          onChange={handleChange}
+        />
+      )}
+    </PropertySection>
   );
 
-  const renderElementClasses = (): ReactElement => (
-    <ClassesPropertyField
-      key={`${resource.id}-$classes`}
+  const sectionTitle = (title: string): string =>
+    t(`flows:core.propertiesPanel.sections.${title.toLowerCase()}`, title);
+
+  const renderProperty = ([key, value]: [FieldKey, FieldValue]): ReactElement => (
+    <ResourcePropertyFactory
+      key={`${resource.id}-${key}`}
       resource={resource}
-      propertyKey="classes"
-      propertyValue={(resource as Element & {classes?: string}).classes ?? ''}
+      propertyKey={key}
+      propertyValue={value}
+      data-componentid={`${resource.id}-${key}`}
       onChange={handleChange}
     />
   );
 
   const renderElementPropertyFactory = () => {
+    const entries: [FieldKey, FieldValue][] = properties ? Object.entries(properties) : [];
+    const grouped: string[] = ResourcePropertyPanelConstants.PROPERTY_SECTIONS.flatMap((section) => section.keys);
+    const ungrouped: [FieldKey, FieldValue][] = entries.filter(([key]) => !grouped.includes(key));
+
     return (
       <>
-        <VariantSelect resource={resource} selectedVariant={selectedVariant} onVariantChange={onVariantChange} />
-        {properties &&
-          Object.entries(properties)?.map(([key, value]: [FieldKey, FieldValue]) => (
-            <ResourcePropertyFactory
-              key={`${resource.id}-${key}`}
-              resource={resource}
-              propertyKey={key}
-              propertyValue={value}
-              data-componentid={`${resource.id}-${key}`}
-              onChange={handleChange}
-            />
-          ))}
+        {ResourcePropertyPanelConstants.PROPERTY_SECTIONS.map((section) => {
+          const sectionEntries: [FieldKey, FieldValue][] = entries.filter(([key]) => section.keys.includes(key));
+          // The variant picker is an appearance control, but it renders nothing when
+          // the element has no variants. An empty heading would be worse than none.
+          const showVariant: boolean = section.title === 'Appearance' && (resource.variants?.length ?? 0) > 0;
+          if (sectionEntries.length === 0 && !showVariant) {
+            return null;
+          }
+          return (
+            <PropertySection key={section.title} title={sectionTitle(section.title)}>
+              {showVariant && (
+                <VariantSelect
+                  resource={resource}
+                  selectedVariant={selectedVariant}
+                  onVariantChange={onVariantChange}
+                />
+              )}
+              {sectionEntries.map(renderProperty)}
+            </PropertySection>
+          );
+        })}
+        {ungrouped.length > 0 && (
+          <PropertySection title={sectionTitle('Other')}>{ungrouped.map(renderProperty)}</PropertySection>
+        )}
       </>
     );
   };
@@ -132,8 +165,7 @@ function ResourceProperties({
     case ElementCategories.Field:
       return (
         <>
-          {renderElementId()}
-          {renderElementClasses()}
+          {renderElementId(true)}
           <FieldExtendedProperties resource={resource} onChange={handleChange} />
           {renderElementPropertyFactory()}
         </>
@@ -141,8 +173,7 @@ function ResourceProperties({
     case ElementCategories.Action:
       return (
         <>
-          {renderElementId()}
-          {renderElementClasses()}
+          {renderElementId(true)}
           {resource.type === ElementTypes.Action && (
             <ButtonExtendedProperties resource={resource} onChange={handleChange} onVariantChange={onVariantChange} />
           )}
@@ -179,8 +210,7 @@ function ResourceProperties({
       if (resource.type === ElementTypes.Text) {
         return (
           <>
-            {renderElementId()}
-            {renderElementClasses()}
+            {renderElementId(true)}
             <TextPropertyField
               resource={resource}
               propertyKey="label"
@@ -213,8 +243,7 @@ function ResourceProperties({
       if (resource.type === ElementTypes.Image) {
         return (
           <>
-            {renderElementId()}
-            {renderElementClasses()}
+            {renderElementId(true)}
             <TextPropertyField
               resource={resource}
               propertyKey="src"
@@ -244,8 +273,7 @@ function ResourceProperties({
       }
       return (
         <>
-          {renderElementId()}
-          {renderElementClasses()}
+          {renderElementId(true)}
           {renderElementPropertyFactory()}
         </>
       );
@@ -253,8 +281,7 @@ function ResourceProperties({
     default:
       return (
         <>
-          {renderElementId()}
-          {renderElementClasses()}
+          {renderElementId(true)}
           {renderElementPropertyFactory()}
         </>
       );

--- a/frontend/apps/console/src/features/login-flow/hooks/useElementAddition.ts
+++ b/frontend/apps/console/src/features/login-flow/hooks/useElementAddition.ts
@@ -43,8 +43,33 @@ export interface UseElementAdditionProps {
 export interface UseElementAdditionReturn {
   /** Add an element to a view from the context menu. */
   handleAddElementToView: (element: Element, viewId: string) => void;
-  /** Add an element to a form from the context menu. */
-  handleAddElementToForm: (element: Element, formId: string) => void;
+  /** Add an element to a container (form or stack) from the context menu. */
+  handleAddElementToForm: (element: Element, containerId: string) => void;
+}
+
+/**
+ * Whether the component tree holds a container with the given id. Containers can be
+ * nested (a stack inside a form), so the search walks the whole tree.
+ */
+function containsComponent(components: Element[], containerId: string): boolean {
+  return components.some(
+    (component: Element) => component.id === containerId || containsComponent(component.components ?? [], containerId),
+  );
+}
+
+/**
+ * Appends an element to the container with the given id, at any nesting depth.
+ */
+function appendToComponent(components: Element[], containerId: string, element: Element): Element[] {
+  return components.map((component: Element) => {
+    if (component.id === containerId) {
+      return {...component, components: [...(component.components ?? []), element]};
+    }
+    if (component.components) {
+      return {...component, components: appendToComponent(component.components, containerId, element)};
+    }
+    return component;
+  });
 }
 
 /**
@@ -177,13 +202,12 @@ const useElementAddition = (props: UseElementAdditionProps): UseElementAdditionR
       let viewStepId: string | null = null;
 
       setNodes((prevNodes: Node[]) => {
-        // Find the View node that contains the form with the given formId
+        // Find the View node that contains the target container. Containers nest
+        // (a stack inside a form), so both the lookup and the insert recurse.
         const existingViewStep = prevNodes.find((node) => {
           if (node.type !== StepTypes.View) return false;
           const nodeData = node.data as {components?: Element[]} | undefined;
-          const components = nodeData?.components ?? [];
-          // Check if this view contains the form with the given formId
-          return components.some((component: Element) => component.id === formId && component.type === BlockTypes.Form);
+          return containsComponent(nodeData?.components ?? [], formId);
         });
 
         if (!existingViewStep) {
@@ -197,16 +221,8 @@ const useElementAddition = (props: UseElementAdditionProps): UseElementAdditionR
             const nodeData = node.data as {components?: Element[]} | undefined;
             const existingComponents: Element[] = cloneDeep(nodeData?.components ?? []);
 
-            // Find the form and add the element to it
-            const updatedComponents = existingComponents.map((component: Element) => {
-              if (component.id === formId && component.type === BlockTypes.Form) {
-                return {
-                  ...component,
-                  components: [...(component.components ?? []), generatedElement],
-                };
-              }
-              return component;
-            });
+            // Find the container and add the element to it
+            const updatedComponents = appendToComponent(existingComponents, formId, generatedElement);
 
             return {
               ...node,

--- a/frontend/apps/console/src/layouts/DashboardLayout.tsx
+++ b/frontend/apps/console/src/layouts/DashboardLayout.tsx
@@ -29,6 +29,7 @@ import {
   Footer,
   Header,
   Sidebar,
+  useAppShell,
   useSidebar,
   UserMenu,
 } from '@wso2/oxygen-ui';
@@ -126,6 +127,31 @@ export interface DashboardLayoutProps {
    * pages need the full screen width (e.g. the flow builder canvas).
    */
   collapseSidebar?: boolean;
+}
+
+/**
+ * Applies a route's sidebar preference to the shell.
+ *
+ * The preference is applied when it changes rather than being bound to the sidebar,
+ * so builder routes still start collapsed while the header toggle stays free to
+ * collapse and expand it afterwards.
+ */
+function SidebarPreference({collapsed}: {collapsed: boolean}): null {
+  const {actions} = useAppShell();
+  const {collapseSidebar, expandSidebar} = actions;
+
+  useEffect(() => {
+    if (collapsed) {
+      collapseSidebar();
+    } else {
+      expandSidebar();
+    }
+    // Runs on the route's preference only: re-running whenever the shell actions are
+    // re-created would undo a manual toggle on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [collapsed]);
+
+  return null;
 }
 
 export default function DashboardLayout({collapseSidebar = false}: DashboardLayoutProps): ReactNode {
@@ -339,7 +365,11 @@ export default function DashboardLayout({collapseSidebar = false}: DashboardLayo
   }, [appRoutes, activeItem]);
 
   return (
-    <AppShell>
+    // `collapseSidebar` seeds AppShell's own state rather than force-controlling the
+    // Sidebar. Passing `collapsed` to the Sidebar would override the shell's state and
+    // leave the header toggle with nothing to drive.
+    <AppShell initialCollapsed={collapseSidebar}>
+      <SidebarPreference collapsed={collapseSidebar} />
       <AppShell.Navbar>
         <Header>
           <Header.Toggle />
@@ -389,12 +419,7 @@ export default function DashboardLayout({collapseSidebar = false}: DashboardLayo
       </AppShell.Navbar>
 
       <AppShell.Sidebar>
-        <Sidebar
-          activeItem={activeItem}
-          expandedMenus={expandedMenus}
-          onToggleExpand={handleToggleExpand}
-          collapsed={collapseSidebar}
-        >
+        <Sidebar activeItem={activeItem} expandedMenus={expandedMenus} onToggleExpand={handleToggleExpand}>
           <Sidebar.Nav>
             {appRoutes.map((categoryGroup) => (
               <Sidebar.Category key={categoryGroup.category}>

--- a/frontend/packages/components/src/lab/components/BuilderLayout/BuilderStaticPanel.tsx
+++ b/frontend/packages/components/src/lab/components/BuilderLayout/BuilderStaticPanel.tsx
@@ -98,7 +98,8 @@ function BuilderStaticPanel({
           position: 'relative',
           border: 'none',
           overflow: 'scroll',
-          p: 2,
+          // Padding lives on the body rather than the paper, so the header bar and
+          // its divider run the full width of the panel.
           gap: 1,
           ...(paperSx ?? {}),
         },
@@ -108,9 +109,10 @@ function BuilderStaticPanel({
       {header !== undefined && (
         <Box
           sx={{
-            height: 40,
+            minHeight: 52,
             flexShrink: 0,
             px: 2,
+            py: 1,
             display: 'flex',
             alignItems: 'center',
             borderBottom: '1px solid',
@@ -122,7 +124,19 @@ function BuilderStaticPanel({
       )}
 
       {/* Body */}
-      <Box sx={{flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column'}}>{children}</Box>
+      <Box
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          px: 2,
+          pb: 2,
+          pt: header === undefined ? 2 : 0,
+        }}
+      >
+        {children}
+      </Box>
     </Drawer>
   );
 }

--- a/frontend/packages/design/src/components/flow/__tests__/FlowComponentRenderer.test.tsx
+++ b/frontend/packages/design/src/components/flow/__tests__/FlowComponentRenderer.test.tsx
@@ -263,4 +263,225 @@ describe('FlowComponentRenderer — BLOCK with STACK-nested actions', () => {
 
     expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({id: 'action_create'}), {});
   });
+
+  it('renders a STACK without items as a flex layout', () => {
+    renderWithProviders(
+      <FlowComponentRenderer
+        component={blockWithStackedActions}
+        index={0}
+        values={{}}
+        isLoading={false}
+        resolve={identity}
+        onInputChange={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    expect(getComputedStyle(document.getElementById('stack_actions')!).display).toBe('flex');
+  });
+});
+
+describe('FlowComponentRenderer — STACK grid layout (items)', () => {
+  const triggerAction = (id: string, label: string) => ({
+    id,
+    type: 'ACTION',
+    label,
+    variant: 'OUTLINE',
+    eventType: 'TRIGGER',
+  });
+
+  const blockWithGridTriggers = (items: unknown, count = 4): EmbeddedFlowComponent => {
+    const block = {
+      id: 'block_login_id',
+      type: 'BLOCK',
+      components: [
+        {
+          id: 'stack_login_ids',
+          type: 'STACK',
+          direction: 'col',
+          justify: 'center',
+          items,
+          components: Array.from({length: count}, (_, i) => triggerAction(`login_id_${i}`, `Option ${i}`)),
+        },
+      ],
+    } as unknown as EmbeddedFlowComponent;
+    return block;
+  };
+
+  const renderComponent = (component: EmbeddedFlowComponent, onSubmit: (...args: unknown[]) => void = noop) =>
+    renderWithProviders(
+      <FlowComponentRenderer
+        component={component}
+        index={0}
+        values={{}}
+        isLoading={false}
+        resolve={identity}
+        onInputChange={noop}
+        onSubmit={onSubmit}
+      />,
+    );
+
+  // A computed template is either the literal `repeat(n, ...)` or, once the browser
+  // resolves it, one entry per track. Counting whitespace alone gets the literal
+  // form wrong, so parse the repeat count when it is still present.
+  const trackCount = (template: string): number => {
+    const repeatMatch = /^repeat\((\d+),/.exec(template);
+    return repeatMatch ? Number(repeatMatch[1]) : template.split(' ').length;
+  };
+
+  const gridColumnCount = (id: string): number => {
+    return trackCount(getComputedStyle(document.getElementById(id)!).gridTemplateColumns);
+  };
+
+  it('renders four trigger actions in a 2-column grid when items is 2', () => {
+    renderComponent(blockWithGridTriggers(2));
+
+    const stack = document.getElementById('stack_login_ids')!;
+    expect(getComputedStyle(stack).display).toBe('grid');
+    expect(gridColumnCount('stack_login_ids')).toBe(2);
+    ['Option 0', 'Option 1', 'Option 2', 'Option 3'].forEach((label) => {
+      expect(screen.getByRole('button', {name: label})).toBeTruthy();
+    });
+  });
+
+  it('dispatches a trigger action rendered inside a grid stack', () => {
+    const onSubmit = vi.fn();
+    renderComponent(blockWithGridTriggers(2), onSubmit);
+
+    fireEvent.click(screen.getByRole('button', {name: 'Option 2'}));
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({id: 'login_id_2'}), {});
+  });
+
+  it('renders submit actions in a grid and keeps them wired', () => {
+    const onSubmit = vi.fn();
+    const block = {
+      id: 'block_submits',
+      type: 'BLOCK',
+      components: [
+        {
+          id: 'stack_submits',
+          type: 'STACK',
+          items: 2,
+          components: [
+            {id: 'action_create', type: 'ACTION', label: 'Create User', variant: 'PRIMARY', eventType: 'SUBMIT'},
+            {id: 'action_invite', type: 'ACTION', label: 'Invite User', variant: 'OUTLINED', eventType: 'SUBMIT'},
+          ],
+        },
+      ],
+    } as unknown as EmbeddedFlowComponent;
+
+    renderComponent(block, onSubmit);
+
+    expect(getComputedStyle(document.getElementById('stack_submits')!).display).toBe('grid');
+    fireEvent.click(screen.getByRole('button', {name: 'Invite User'}));
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({id: 'action_invite'}), {});
+  });
+
+  it('renders a standalone STACK with items as a grid', () => {
+    const stack = {
+      id: 'stack_standalone',
+      type: 'STACK',
+      items: 2,
+      components: [triggerAction('opt_a', 'Option A'), triggerAction('opt_b', 'Option B')],
+    } as unknown as EmbeddedFlowComponent;
+
+    renderComponent(stack);
+
+    expect(getComputedStyle(document.getElementById('stack_standalone')!).display).toBe('grid');
+    expect(gridColumnCount('stack_standalone')).toBe(2);
+  });
+
+  it('supports arbitrary column counts with auto-flowing rows', () => {
+    renderComponent(blockWithGridTriggers(3, 5));
+
+    expect(gridColumnCount('stack_login_ids')).toBe(3);
+    expect(screen.getAllByRole('button')).toHaveLength(5);
+  });
+
+  it('spreads the columns apart when justify distributes free space', () => {
+    const block = blockWithGridTriggers(2) as unknown as {components: Record<string, unknown>[]};
+    block.components[0].justify = 'space-between';
+
+    renderComponent(block as unknown as EmbeddedFlowComponent);
+
+    const stack = document.getElementById('stack_login_ids')!;
+    const buttons = Array.from(stack.querySelectorAll<HTMLButtonElement>('button'), (button: HTMLButtonElement) =>
+      button.getBoundingClientRect(),
+    );
+    const stackBox = stack.getBoundingClientRect();
+
+    // First column starts at the left edge, second column ends at the right edge.
+    expect(Math.round(buttons[0].left)).toBe(Math.round(stackBox.left));
+    expect(Math.round(buttons[1].right)).toBe(Math.round(stackBox.right));
+    // The two columns are no longer touching, which is what 1fr tracks would give.
+    expect(buttons[1].left - buttons[0].right).toBeGreaterThan(0);
+  });
+
+  it('accepts items provided as a numeric string', () => {
+    renderComponent(blockWithGridTriggers('2'));
+
+    expect(getComputedStyle(document.getElementById('stack_login_ids')!).display).toBe('grid');
+  });
+
+  it('falls back to flex when items is not a number', () => {
+    renderComponent(blockWithGridTriggers('garbage'));
+
+    expect(getComputedStyle(document.getElementById('stack_login_ids')!).display).toBe('flex');
+  });
+
+  it('falls back to flex when items is a malformed numeric string', () => {
+    renderComponent(blockWithGridTriggers('2invalid'));
+
+    expect(getComputedStyle(document.getElementById('stack_login_ids')!).display).toBe('flex');
+  });
+
+  it('keeps the flex layout when items is 1, so previously authored stacks are unchanged', () => {
+    renderComponent(blockWithGridTriggers(1));
+
+    expect(getComputedStyle(document.getElementById('stack_login_ids')!).display).toBe('flex');
+  });
+
+  it('lays four children out on two rows when items is 2', () => {
+    renderComponent(blockWithGridTriggers(2));
+
+    const stack = document.getElementById('stack_login_ids')!;
+    const tops = Array.from(stack.querySelectorAll<HTMLButtonElement>('button'), (button: HTMLButtonElement) =>
+      Math.round(button.getBoundingClientRect().top),
+    );
+    expect(new Set(tops).size).toBe(2);
+  });
+
+  it('treats items as the row count when direction is column', () => {
+    const block = blockWithGridTriggers(2) as unknown as {components: Record<string, unknown>[]};
+    block.components[0].direction = 'column';
+
+    renderComponent(block as unknown as EmbeddedFlowComponent);
+
+    const stack = document.getElementById('stack_login_ids')!;
+    const style = getComputedStyle(stack);
+    expect(style.display).toBe('grid');
+    expect(trackCount(style.gridTemplateRows)).toBe(2);
+    expect(style.gridAutoFlow).toContain('column');
+  });
+
+  it('keeps the flex layout when items is absent', () => {
+    const block = blockWithGridTriggers(2) as unknown as {components: Record<string, unknown>[]};
+    delete block.components[0].items;
+
+    renderComponent(block as unknown as EmbeddedFlowComponent);
+
+    expect(getComputedStyle(document.getElementById('stack_login_ids')!).display).toBe('flex');
+  });
+
+  it('applies custom classes on stacks nested inside blocks', () => {
+    const block = blockWithGridTriggers(2) as unknown as {components: Record<string, unknown>[]};
+    block.components[0].classes = 'custom-stack';
+
+    renderComponent(block as unknown as EmbeddedFlowComponent);
+
+    const stack = document.getElementById('stack_login_ids')!;
+    expect(stack.className).toContain('Flow--stack');
+    expect(stack.className).toContain('custom-stack');
+  });
 });

--- a/frontend/packages/design/src/components/flow/adapters/BlockAdapter.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/BlockAdapter.tsx
@@ -18,7 +18,7 @@
 
 import {EmbeddedFlowComponentType, EmbeddedFlowEventType, type EmbeddedFlowComponent} from '@thunderid/react';
 import {cn} from '@thunderid/utils';
-import {Box, Button, Stack} from '@wso2/oxygen-ui';
+import {Box, Button} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import DividerAdapter from './DividerAdapter';
@@ -26,6 +26,7 @@ import OtpInputAdapter from './OtpInputAdapter';
 import PasswordInputAdapter from './PasswordInputAdapter';
 import RichTextAdapter from './RichTextAdapter';
 import SelectAdapter from './SelectAdapter';
+import StackContainer from './StackContainer';
 import TextInputAdapter from './TextInputAdapter';
 import type {FlowComponent, FlowFieldProps} from '../../../models/flow';
 import getIntegrationIcon from '../../../utils/getIntegrationIcon';
@@ -179,19 +180,11 @@ function renderFormSubComponent(
   // in the form context so nested submit/trigger actions stay wired.
   if (sub.type === 'STACK') {
     return (
-      <Stack
-        key={sub.id ?? compIndex}
-        id={sub.id}
-        className={cn('Flow--stack')}
-        direction={sub.direction ?? 'column'}
-        spacing={sub.gap ?? 2}
-        alignItems={sub.align ?? 'center'}
-        justifyContent={sub.justify ?? 'flex-start'}
-      >
+      <StackContainer key={sub.id ?? compIndex} component={sub}>
         {(sub.components ?? []).map((nested: EmbeddedFlowComponent, nestedIndex: number) =>
           renderFormSubComponent(nested, nestedIndex, ctx),
         )}
-      </Stack>
+      </StackContainer>
     );
   }
   const fieldProps: FlowFieldProps = {
@@ -357,19 +350,11 @@ function TriggerBlockAdapter({component, index, ...ctx}: TriggerBlockAdapterProp
         const sub = actionComponent as FlowComponent;
         if (sub.type === 'STACK') {
           return (
-            <Stack
-              key={sub.id ?? actionIndex}
-              id={sub.id}
-              className={cn('Flow--stack')}
-              direction={sub.direction ?? 'column'}
-              spacing={sub.gap ?? 2}
-              alignItems={sub.align ?? 'center'}
-              justifyContent={sub.justify ?? 'flex-start'}
-            >
+            <StackContainer key={sub.id ?? actionIndex} component={sub}>
               {(sub.components ?? []).map((nested: EmbeddedFlowComponent, nestedIndex: number) =>
                 renderTriggerSub(nested, nestedIndex),
               )}
-            </Stack>
+            </StackContainer>
           );
         }
         if (

--- a/frontend/packages/design/src/components/flow/adapters/StackAdapter.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/StackAdapter.tsx
@@ -17,9 +17,8 @@
  */
 
 import type {EmbeddedFlowComponent} from '@thunderid/react';
-import {cn} from '@thunderid/utils';
-import {Stack} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
+import StackContainer from './StackContainer';
 import type {FlowComponent} from '../../../models/flow';
 import FlowComponentRenderer from '../FlowComponentRenderer';
 
@@ -51,14 +50,7 @@ export default function StackAdapter({
   const nestedComponents = (component.components ?? []) as FlowComponent[];
 
   return (
-    <Stack
-      id={component.id}
-      className={[cn('Flow--stack'), component.classes].filter(Boolean).join(' ')}
-      direction={component.direction ?? 'column'}
-      spacing={component.gap ?? 2}
-      alignItems={component.align ?? 'center'}
-      justifyContent={component.justify ?? 'flex-start'}
-    >
+    <StackContainer component={component}>
       {nestedComponents.map((nested: FlowComponent, nestedIndex: number) => (
         <FlowComponentRenderer
           key={nested.id ?? nestedIndex}
@@ -75,6 +67,6 @@ export default function StackAdapter({
           maxImageSize={STACK_IMAGE_MAX_SIZE}
         />
       ))}
-    </Stack>
+    </StackContainer>
   );
 }

--- a/frontend/packages/design/src/components/flow/adapters/StackContainer.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/StackContainer.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {cn} from '@thunderid/utils';
+import {Box, Stack} from '@wso2/oxygen-ui';
+import type {JSX, ReactNode} from 'react';
+import type {FlowComponent} from '../../../models/flow';
+import getStackGridSx from '../../../utils/getStackGridSx';
+
+interface StackContainerProps {
+  component: FlowComponent;
+  children: ReactNode;
+}
+
+/**
+ * Layout container for STACK flow elements. Renders a CSS grid when the stack sets
+ * `items` slots across its main axis, and keeps the flex stack layout otherwise.
+ */
+export default function StackContainer({component, children}: StackContainerProps): JSX.Element {
+  const className = [cn('Flow--stack'), component.classes].filter(Boolean).join(' ');
+  const gridSx = getStackGridSx(component);
+
+  if (gridSx) {
+    return (
+      <Box id={component.id} className={className} sx={gridSx}>
+        {children}
+      </Box>
+    );
+  }
+
+  return (
+    <Stack
+      id={component.id}
+      className={className}
+      direction={component.direction ?? 'column'}
+      spacing={component.gap ?? 2}
+      alignItems={component.align ?? 'center'}
+      justifyContent={component.justify ?? 'flex-start'}
+      // Wrap like the flow builder canvas and the SDK do, instead of squeezing
+      // children onto one line. `useFlexGap` keeps the spacing gap based, which is
+      // the wrap-safe mode.
+      useFlexGap
+      sx={{flexWrap: 'wrap'}}
+    >
+      {children}
+    </Stack>
+  );
+}

--- a/frontend/packages/design/src/index.ts
+++ b/frontend/packages/design/src/index.ts
@@ -99,6 +99,7 @@ export {default as TimerAdapter} from './components/flow/adapters/TimerAdapter';
 // Utils
 export {default as extractLayoutFromDesign} from './utils/extractLayoutFromDesign';
 export {default as getIntegrationIcon} from './utils/getIntegrationIcon';
+export {default as getStackGridSx, parseStackItems, type StackGridInput} from './utils/getStackGridSx';
 export {default as mapEmbeddedFlowTextColor} from './utils/mapEmbeddedFlowTextColor';
 export {default as mapEmbeddedFlowTextVariant} from './utils/mapEmbeddedFlowTextVariant';
 export {sanitizeCss, isValidStylesheetUrl, isInsecureStylesheetUrl} from './utils/cssSanitizer';

--- a/frontend/packages/design/src/utils/__tests__/getStackGridSx.test.ts
+++ b/frontend/packages/design/src/utils/__tests__/getStackGridSx.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, it, expect} from 'vitest';
+import getStackGridSx, {parseStackItems, MAX_STACK_ITEMS} from '../getStackGridSx';
+
+describe('parseStackItems', () => {
+  it('returns undefined when items is absent or empty', () => {
+    expect(parseStackItems(undefined)).toBeUndefined();
+    expect(parseStackItems('')).toBeUndefined();
+  });
+
+  it('parses numeric strings', () => {
+    expect(parseStackItems('3')).toBe(3);
+  });
+
+  it('returns undefined for malformed or non-positive values', () => {
+    expect(parseStackItems('2invalid')).toBeUndefined();
+    expect(parseStackItems('garbage')).toBeUndefined();
+    expect(parseStackItems(0)).toBeUndefined();
+    expect(parseStackItems(-2)).toBeUndefined();
+  });
+
+  it('returns undefined for a single slot so existing stacks keep their flex layout', () => {
+    expect(parseStackItems(1)).toBeUndefined();
+    expect(parseStackItems('1')).toBeUndefined();
+  });
+
+  it('floors fractional values', () => {
+    expect(parseStackItems(2.7)).toBe(2);
+  });
+
+  it('clamps absurd slot counts', () => {
+    expect(parseStackItems(5000)).toBe(MAX_STACK_ITEMS);
+  });
+});
+
+describe('getStackGridSx', () => {
+  it('returns null when the stack has no items', () => {
+    expect(getStackGridSx({direction: 'row'})).toBeNull();
+  });
+
+  it('maps items to columns for the default row direction', () => {
+    const sx = getStackGridSx({items: 2})!;
+
+    expect(sx.display).toBe('grid');
+    expect(sx.gridTemplateColumns).toBe('repeat(2, minmax(0, 1fr))');
+    expect(sx.gridAutoFlow).toBe('row');
+    expect(sx.gridTemplateRows).toBeUndefined();
+  });
+
+  it('returns null for a single slot, leaving the stack in flex mode', () => {
+    expect(getStackGridSx({items: 1, direction: 'row'})).toBeNull();
+  });
+
+  it('maps items to rows when direction is column', () => {
+    const sx = getStackGridSx({items: 3, direction: 'column'})!;
+
+    expect(sx.gridTemplateRows).toBe('repeat(3, minmax(0, 1fr))');
+    expect(sx.gridAutoFlow).toBe('column');
+    expect(sx.gridTemplateColumns).toBeUndefined();
+  });
+
+  it('falls back to the base axis for the reverse directions', () => {
+    // CSS Grid has no reverse auto-flow, so column-reverse must at least stay on
+    // the column axis rather than silently becoming a row.
+    expect(getStackGridSx({items: 2, direction: 'column-reverse'})!.gridAutoFlow).toBe('column');
+    expect(getStackGridSx({items: 2, direction: 'row-reverse'})!.gridAutoFlow).toBe('row');
+  });
+
+  it('uses content-sized tracks when justify has to distribute free space', () => {
+    // Equal 1fr tracks leave justify-content nothing to distribute.
+    expect(getStackGridSx({items: 2, justify: 'space-between'})!.gridTemplateColumns).toBe(
+      'repeat(2, minmax(0, auto))',
+    );
+    expect(getStackGridSx({items: 2, justify: 'center'})!.gridTemplateColumns).toBe('repeat(2, minmax(0, auto))');
+    expect(getStackGridSx({items: 2, direction: 'column', justify: 'center'})!.gridTemplateRows).toBe(
+      'repeat(2, minmax(0, auto))',
+    );
+  });
+
+  it('keeps equal tracks when justify is unset or stretch', () => {
+    expect(getStackGridSx({items: 2})!.gridTemplateColumns).toBe('repeat(2, minmax(0, 1fr))');
+    expect(getStackGridSx({items: 2, justify: 'stretch'})!.gridTemplateColumns).toBe('repeat(2, minmax(0, 1fr))');
+  });
+
+  it('applies gap, align and justify with defaults', () => {
+    expect(getStackGridSx({items: 2})).toMatchObject({gap: 2, alignItems: 'stretch', justifyContent: 'stretch'});
+    expect(getStackGridSx({items: 2, gap: 4, align: 'center', justify: 'space-between'})).toMatchObject({
+      gap: 4,
+      alignItems: 'center',
+      justifyContent: 'space-between',
+    });
+  });
+});

--- a/frontend/packages/design/src/utils/getStackGridSx.ts
+++ b/frontend/packages/design/src/utils/getStackGridSx.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export interface StackGridInput {
+  /** Number of slots across the main axis. Fewer than two means no grid. */
+  items?: string | number;
+  /** Main axis of the stack. `row` makes `items` columns, `column` makes it rows. */
+  direction?: string;
+  gap?: number;
+  align?: string;
+  justify?: string;
+}
+
+export interface StackGridSx {
+  display: 'grid';
+  gap: number;
+  alignItems: string;
+  justifyContent: string;
+  width: '100%';
+  boxSizing: 'border-box';
+  gridAutoFlow: 'row' | 'column';
+  gridTemplateColumns?: string;
+  gridTemplateRows?: string;
+}
+
+/** Upper bound on grid slots, so a mistyped `items` cannot render thousands of cells. */
+export const MAX_STACK_ITEMS = 12;
+
+/**
+ * Parses the `items` slot count. Returns undefined when the property is absent,
+ * malformed, or below two, which means the stack keeps its flex layout. Fractional
+ * values are floored and the result is capped at {@link MAX_STACK_ITEMS}.
+ *
+ * A single slot is not treated as a grid: the flow builder seeds `items: 1` on every
+ * stack it creates, so promoting 1 to a single-column grid would silently restack
+ * every previously authored flow.
+ */
+export function parseStackItems(items: StackGridInput['items']): number | undefined {
+  if (items === undefined || items === null || items === '') return undefined;
+  const parsed = typeof items === 'string' ? Number(items) : items;
+  if (typeof parsed !== 'number' || !Number.isFinite(parsed)) return undefined;
+  const slots = Math.floor(parsed);
+  return slots >= 2 ? Math.min(slots, MAX_STACK_ITEMS) : undefined;
+}
+
+/**
+ * Builds the CSS grid style for a STACK element, or null when the stack has fewer
+ * than two `items` and should keep its flex layout.
+ *
+ * `items` is the number of slots across the main axis and `direction` picks that
+ * axis: with `row` it is the column count (items: 2 with four children renders a
+ * 2 x 2 grid), and with `column` it is the row count and children flow into
+ * additional columns.
+ *
+ * Grid mode deliberately defaults differently from the flex layout: `direction`
+ * defaults to `row` so `items` reads as a column count, and `align`/`justify`
+ * default to `stretch` so children fill their cell. Setting `items` is therefore an
+ * explicit opt in to a grid rather than a transparent addition to a flex stack.
+ */
+export default function getStackGridSx(stack: StackGridInput): StackGridSx | null {
+  const items = parseStackItems(stack.items);
+  if (items === undefined) return null;
+
+  // CSS Grid has no reverse auto-flow, so the reverse variants fall back to their
+  // base axis rather than silently becoming a row.
+  const isColumn = (stack.direction ?? '').startsWith('column');
+  const justify = stack.justify ?? 'stretch';
+
+  // Equal `1fr` tracks fill the container, which leaves `justify-content` no free
+  // space to distribute. Sizing the tracks to their content restores it, so every
+  // justify value has a visible effect while the default stays an even split.
+  // Each track is wrapped in `minmax(0, ...)` so a wide child shrinks instead of
+  // pushing the track past the container edge.
+  const track = justify === 'stretch' ? '1fr' : 'auto';
+
+  return {
+    display: 'grid',
+    gap: stack.gap ?? 2,
+    alignItems: stack.align ?? 'stretch',
+    justifyContent: justify,
+    width: '100%',
+    // Callers add their own padding, so the width must include it.
+    boxSizing: 'border-box',
+    gridAutoFlow: isColumn ? 'column' : 'row',
+    ...(isColumn
+      ? {gridTemplateRows: `repeat(${items}, minmax(0, ${track}))`}
+      : {gridTemplateColumns: `repeat(${items}, minmax(0, ${track}))`}),
+  };
+}


### PR DESCRIPTION
### Purpose

Resolves the inability to arrange STACK children (e.g. action buttons) in a grid at runtime. A flow defining a STACK with four buttons could only render as a strict flex row or column, while the flow builder canvas already previewed grid layouts via the `items` property. This PR makes the runtime renderer honor `items` and gives the property one consistent meaning across the builder, the Gate, and the React SDK.

`items` is the number of slots across the main axis, and `direction` picks that axis:

| direction | items | 4 children render as |
|---|---|---|
| `row` (default) | 2 | 2 x 2 grid |
| `row` | 3 | 3 columns, remainder on the next row |
| `column` | 2 | 2 rows, children flow into further columns |

**Not a breaking change.** Grid mode requires `items >= 2`. Stacks with `items: 1` (which the builder seeds on every stack it creates) or no `items` at all keep their existing flex layout, so previously authored flows render exactly as before.

### Approach

- Added a shared `getStackGridSx` helper in `@thunderid/design`, used by **both** the runtime renderers and the console flow builder canvas, so the builder preview and the Gate can no longer drift apart.
- Wired it into all three runtime STACK render sites (standalone `StackAdapter`, and the form and trigger block paths in `BlockAdapter`, which previously duplicated the layout mapping inline).
- `items` is parsed defensively from the SDK's `string | number` type: malformed values (`"2invalid"`), zero, and negatives fall back to flex, and the slot count is clamped so a mistyped value cannot render thousands of cells.
- Builder placeholders now fill the trailing cells of a partially filled last row, so every grid cell is a drop target.
- Also fixes `classes` being dropped on STACKs nested inside BLOCKs.
- Property panel: `direction`, `align` and `justify` gain searchable suggestions while staying free text. This is implemented as an optional `suggestions` prop on the existing `TextPropertyField`, so those fields keep the dynamic-value (`fx`) button, inline validation errors, label placement, and debounce handling that every other property field has.
- No backend or SDK type changes needed: the backend passes element meta through verbatim, and `EmbeddedFlowComponent.items` already exists in the SDK.

A companion fix for the `@thunderid/react` SDK's own renderer (`AuthOptionFactory`) is submitted to thunder-id/javascript-sdks.

### Related Issues

- Fixes https://github.com/thunder-id/thunderid/issues/3703

### Related PRs

- Companion SDK: https://github.com/thunder-id/javascript-sdks/pull/39

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stack layout now supports CSS grid rendering when an item count is set, including row/column direction behavior and grid spacing/alignment.
  * Layout property autocomplete was added for stack direction/align/justify.
  * Added “Add Field”/“Add Component” controls for containers, including nested stack containers.

* **Bug Fixes**
  * Improved grid/flex fallback when item counts are missing/invalid/`1`, including corrected placeholder behavior.
  * Actions inside grid stacks now trigger the correct identifiers.

* **Tests**
  * Expanded coverage for grid/flex rendering, placeholder logic, autocomplete interactions, action wiring, and nested addition behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->