### PR TITLE
Pass afterSignOutUrl to the console ThunderIDProvider

### DIFF
--- a/frontend/apps/console/src/hocs/__tests__/withConfig.test.tsx
+++ b/frontend/apps/console/src/hocs/__tests__/withConfig.test.tsx
@@ -60,6 +60,7 @@ vi.mock('@thunderid/react', () => ({
     baseUrl,
     clientId,
     afterSignInUrl,
+    afterSignOutUrl,
     scopes,
     signInOptions,
     preferences,
@@ -71,6 +72,7 @@ vi.mock('@thunderid/react', () => ({
     baseUrl?: string;
     clientId?: string;
     afterSignInUrl?: string;
+    afterSignOutUrl?: string;
     scopes?: string[];
     signInOptions?: Record<string, string>;
     preferences?: Record<string, unknown>;
@@ -81,6 +83,7 @@ vi.mock('@thunderid/react', () => ({
       baseUrl,
       clientId,
       afterSignInUrl,
+      afterSignOutUrl,
       scopes,
       signInOptions,
       preferences,
@@ -93,6 +96,7 @@ vi.mock('@thunderid/react', () => ({
         data-base-url={baseUrl}
         data-client-id={clientId}
         data-after-sign-in-url={afterSignInUrl}
+        data-after-sign-out-url={afterSignOutUrl}
         data-scopes={scopes ? JSON.stringify(scopes) : undefined}
       >
         {children}
@@ -171,6 +175,15 @@ describe('withConfig (console)', () => {
     expect(capturedProviderProps.afterSignInUrl).toBe('https://custom-client.example.com');
   });
 
+  it('passes afterSignOutUrl from useConfig to ThunderIDProvider', () => {
+    mockGetClientUrl.mockReturnValue('https://custom-client.example.com/console');
+    mockGetServerUrl.mockReturnValue('https://server.example.com');
+    mockGetClientId.mockReturnValue('client-id');
+
+    render(<WithConfigComponent />);
+    expect(capturedProviderProps.afterSignOutUrl).toBe('https://custom-client.example.com/console');
+  });
+
   it('falls back to env VITE_THUNDER_BASE_URL when getTrustedIssuerUrl returns null', () => {
     mockGetTrustedIssuerUrl.mockReturnValue(null);
     mockGetTrustedIssuerClientId.mockReturnValue('client-id');
@@ -196,6 +209,15 @@ describe('withConfig (console)', () => {
 
     render(<WithConfigComponent />);
     expect(capturedProviderProps.afterSignInUrl).toBe('https://env-signin.example.com');
+  });
+
+  it('falls back to env VITE_THUNDER_AFTER_SIGN_IN_URL for afterSignOutUrl when getClientUrl returns null', () => {
+    mockGetClientUrl.mockReturnValue(null);
+    mockGetServerUrl.mockReturnValue('https://server.example.com');
+    mockGetClientId.mockReturnValue('client-id');
+
+    render(<WithConfigComponent />);
+    expect(capturedProviderProps.afterSignOutUrl).toBe('https://env-signin.example.com');
   });
 
   it('passes scopes when getTrustedIssuerScopes returns a non-empty array', () => {
@@ -485,6 +507,14 @@ describe('withConfig (console)', () => {
 
       render(<WithConfigComponent />);
       expect(capturedProviderProps.afterSignInUrl).toBe('https://override-redirect.example.com');
+    });
+
+    it('overrides afterSignOutUrl with config.sdk.afterSignOutUrl', () => {
+      mockConfig.sdk = {afterSignOutUrl: 'https://override-signout.example.com'};
+      mockGetClientUrl.mockReturnValue('https://client.example.com');
+
+      render(<WithConfigComponent />);
+      expect(capturedProviderProps.afterSignOutUrl).toBe('https://override-signout.example.com');
     });
 
     it('overrides scopes with config.sdk.scopes', () => {

--- a/frontend/apps/console/src/hocs/withConfig.tsx
+++ b/frontend/apps/console/src/hocs/withConfig.tsx
@@ -79,6 +79,10 @@ export default function withConfig<P extends object>(WrappedComponent: Component
         baseUrl={getTrustedIssuerUrl() ?? (import.meta.env.VITE_THUNDER_BASE_URL as string)}
         clientId={getTrustedIssuerClientId() ?? (import.meta.env.VITE_THUNDER_CLIENT_ID as string)}
         afterSignInUrl={getClientUrl() ?? (import.meta.env.VITE_THUNDER_AFTER_SIGN_IN_URL as string)}
+        // Sign-out lands back on the console root, same as sign-in. Without this the SDK falls back
+        // to the page origin, which drops the client base path (e.g. `/console`) and fails the
+        // server's exact match against the application's registered post-logout redirect URIs.
+        afterSignOutUrl={getClientUrl() ?? (import.meta.env.VITE_THUNDER_AFTER_SIGN_IN_URL as string)}
         scopes={getTrustedIssuerScopes().length > 0 ? getTrustedIssuerScopes() : undefined}
         {...sdkProps}
       >


### PR DESCRIPTION
### Purpose
Signing out of the Console fails with invalid post_logout_redirect_uri.

The Console requests logout with the bare origin:

https://localhost:8090/oauth2/logout?post_logout_redirect_uri=https%3A%2F%2Flocalhost%3A8090&id_token_hint=...&state=sign_out_success

but the CONSOLE application registers https://localhost:8090/console (see postLogoutRedirectUris in backend/cmd/server/bootstrap/01-default-resources.yaml). ValidatePostLogoutRedirectURI in backend/pkg/thunderidengine/providers/oauth_client.go matches the supplied value exactly against the registered list, so the request is rejected and the user is left on an error page instead of being returned to the Console.

The root cause is on the client side. withConfig passed afterSignInUrl to ThunderIDProvider but never afterSignOutUrl, and the SDK defaults it to the page origin:

// @thunderid/react ThunderIDProvider
afterSignOutUrl: afterSignOutUrl ?? window.location.origin,

The origin drops the client base path (client.base: '/console' in the Console's config.js), which is exactly what makes the value diverge from the registered URI.

Note that the generic OIDC sign-out branch in DashboardLayout already sets post_logout_redirect_uri to getClientUrl() explicitly. Only the native ThunderID sign-out path, which delegates to the SDK's signOut(), was affected.


<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
Pass afterSignOutUrl={getClientUrl()} to ThunderIDProvider in frontend/apps/console/src/hocs/withConfig.tsx, mirroring the existing afterSignInUrl wiring. getClientUrl() already applies the configured client base path, so it resolves to https://localhost:8090/console and matches the registered post-logout redirect URI.

Key decisions:

- Fixed the client, not the registered URI. Adding the bare origin to postLogoutRedirectUris in the bootstrap resources would have silenced the error, but it widens the allowed redirect surface for every deployment and leaves the base path bug in place for any other Console deployment served under a path prefix.
- Reused the existing VITE_THUNDER_AFTER_SIGN_IN_URL fallback rather than introducing a new environment variable. Sign-in and sign-out both land on the Console root, so a second variable would add configuration surface without adding capability. Happy to split it if reviewers prefer.
- Kept the prop above {...sdkProps}, so operators can still override it through config.sdk.afterSignOutUrl, consistent with every other default in this component.


### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-sign-out redirects in the console.
  * Sign-out now returns to the configured console URL, preserving its base path and avoiding redirect validation failures.
  * Added support for overriding the sign-out destination through SDK configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->