### PR TITLE
Make preflight checks the root of the PR builder job graph

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -33,9 +33,13 @@ jobs:
   # change detection for docs/PowerShell) so they occupy one runner slot instead
   # of four. Runner concurrency is shared across all PRs, so fewer jobs per run
   # directly reduces queue time on busy periods.
+  #
+  # This is also the root of the job graph: every other job depends on it, so a
+  # run requests one runner up front instead of eight competing for slots, and
+  # nothing expensive starts until these ~20s of checks pass.
   preflight:
     name: 🛡️ Preflight Checks
-    if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -50,7 +54,10 @@ jobs:
         with:
           persist-credentials: false
 
+      # Diff-based steps need a base/head pair from the pull_request or
+      # merge_group payload, which a manual dispatch does not carry.
       - name: 🔍 Detect Docs and PowerShell Changes
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
         with:
@@ -79,6 +86,7 @@ jobs:
           pnpm audit --ignore-registry-errors --audit-level=high
 
       - name: 🔎 Dependency Review
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:
           fail-on-severity: high
@@ -112,6 +120,7 @@ jobs:
 
   verify-mocks:
     name: 🔍 Verify Mock Files
+    needs: [preflight]
     if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -148,6 +157,7 @@ jobs:
 
   lint:
     name: 🧹 Lint Code
+    needs: [preflight]
     if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -197,6 +207,7 @@ jobs:
 
   build:
     name: 🛠️ Build Product
+    needs: [preflight]
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -272,6 +283,7 @@ jobs:
 
   test-backend-unit:
     name: 🧪 Backend Unit Tests
+    needs: [preflight]
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -331,6 +343,7 @@ jobs:
 
   test-frontend-packages:
     name: 🧪 Frontend Packages Tests
+    needs: [preflight]
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     container:
@@ -393,6 +406,7 @@ jobs:
 
   test-frontend-gate-app:
     name: 🧪 Gate App Tests with Coverage
+    needs: [preflight]
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -441,6 +455,7 @@ jobs:
 
   test-frontend-console-app:
     name: 🧪 Console App Tests with Coverage
+    needs: [preflight]
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -568,6 +583,7 @@ jobs:
 
   build_samples:
     name: 🛠️ Build Sample Apps
+    needs: [preflight]
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -1128,7 +1144,7 @@ jobs:
   build-docs:
     name: 📚 Build Documentation
     needs: [preflight]
-    if: ${{ always() && needs.preflight.outputs.docs-changed == 'true' }}
+    if: ${{ needs.preflight.outputs.docs-changed == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -1146,7 +1162,7 @@ jobs:
   validate-windows:
     name: 🪟 Validate Windows PowerShell
     needs: preflight
-    if: always() && needs.preflight.outputs.powershell-changed == 'true'
+    if: needs.preflight.outputs.powershell-changed == 'true'
     uses: ./.github/workflows/windows-powershell-validation.yml
 
   cleanup-turbo-cache:


### PR DESCRIPTION
### Purpose

Today every root job in the PR Builder is dispatchable at once, so a run asks for ~8 runners simultaneously and which one starts first is down to luck in the shared runner pool. Preflight Checks (~20s: pnpm audit, dependency review, docs/PowerShell detection) frequently sits at "Expected - Waiting for status to be reported" while the 15-minute Console App Tests is already burning a runner, and when preflight does fail, everything else has already run to completion.

This makes Preflight Checks the root of the job graph, so it both starts first and gates everything else.

Follow-up to #4269. Refs #4268.

### Approach

- `needs: [preflight]` added to the eight root jobs: verify-mocks, lint, build, test-backend-unit, test-frontend-packages, test-frontend-gate-app, test-frontend-console-app, build_samples. Everything else already reaches preflight transitively, so the only job left ungated is `codecov-merge-queue-status`, which is a merge-queue-only status stamp that must not wait behind anything.
- Preflight now also runs on `workflow_dispatch`, which keeps the gating condition on every dependent job unchanged (no `always()` or result-juggling needed: plain `needs` semantics do the right thing). Its two diff-based steps, paths-filter and dependency review, are skipped on dispatch because they need a base/head pair that a manual dispatch does not carry; the pnpm audit does run, which is a small improvement over dispatch runs skipping it entirely today.
- `build-docs` and `validate-windows` dropped their `always() &&` prefix. With it, a preflight that failed *after* the filter step could still let them run; without it, they run only when preflight succeeded and the relevant paths changed.

### Effect

- At t=0 a run requests 1 runner instead of 8, so preflight reliably gets a slot immediately and finishes in ~20s. The heavy fan-out then requests slots together. Smaller instantaneous footprint per run also plays better with the shared pool when several PRs are active.
- A failing preflight (high-severity CVE, denied license) now skips the entire pipeline instead of letting ~60 runner-minutes complete first.
- Cost: roughly 30-60s added to a green run's wall clock (preflight's ~20s plus one scheduling hop). The pipeline stays bounded by Console App Tests at ~15 min, so this does not move the critical path.

Behavior is otherwise unchanged: the trigger-pr-builder label gate, merge queue runs, and required checks all work exactly as before.

### Related Issues
- Refs #4268

### Related PRs
- Follow-up to #4269

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD Improvements**
  * Added support for manually triggered workflow runs.
  * Improved job sequencing and preflight validation for more reliable execution.
  * Prevented pull request–specific checks from running during manual dispatches.
  * Tightened documentation and Windows validation job conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->