### PR TITLE
Improvements and bug fixes in connections UI

### DIFF
--- a/docs/content/guides/identity-providers/add-github.mdx
+++ b/docs/content/guides/identity-providers/add-github.mdx
@@ -55,7 +55,7 @@ To map GitHub's profile fields (for example, `login` or `avatar_url`) to local u
 :::note
 By default, the connection uses GitHub's own default scope, which does not include the user's email address. To ensure the email address is accessible, open the connection after creation and set **Scopes** to include `user:email` on its edit page.
 
-The GitHub connection also accepts a `prompt` field, forwarded as a query parameter on the authorization request. GitHub's OAuth flow supports `select_account` to force the account picker; other values have no effect. This field is not available in the Console and can only be set through the [Connections API](../../../apis#tag/connections).
+The GitHub connection also accepts a `prompt` field, forwarded as a query parameter on the authorization request. GitHub's OAuth flow supports `select_account` to force the account picker. Set it on the connection's edit page, or through the [Connections API](../../../apis#tag/connections).
 :::
 
 ## Next Steps

--- a/docs/content/guides/identity-providers/add-google.mdx
+++ b/docs/content/guides/identity-providers/add-google.mdx
@@ -51,7 +51,7 @@ This guide walks you through registering a Google identity provider (IdP) in <Pr
 :::note
 The connection requests the `openid email profile` scopes by default. To change this, open the connection after creation and set **Scopes** on its edit page.
 
-The Google connection also accepts a `prompt` field to control the Google consent screen behavior (for example, `consent` or `select_account`). This field is not available in the Console and can only be set through the [Connections API](../../../apis#tag/connections).
+The Google connection also accepts a `prompt` field to control the Google consent screen behavior (for example, `consent` or `select_account`). Set it on the connection's edit page, or through the [Connections API](../../../apis#tag/connections).
 :::
 
 ## Next Steps

--- a/docs/content/guides/identity-providers/add-oauth-provider.mdx
+++ b/docs/content/guides/identity-providers/add-oauth-provider.mdx
@@ -53,11 +53,15 @@ Enter the following fields, then click **Create connection**:
 
 </Stepper>
 
-After creation, open the connection and set **Scopes** on its edit page to request space-separated OAuth scopes beyond the provider's default.
+After creation, open the connection. Configure the following on its edit page:
 
-:::note
-The connection also accepts `logoutEndpoint` and `prompt` fields, and an `attributeConfiguration` field to map this provider's claims to local user attributes. These are not available in the Console and can only be set through the [Connections API](../../../apis#tag/connections). See [Attribute Configuration](../add-oidc-provider#attribute-configuration) for the mapping concepts, which apply the same way to OAuth 2.0 connections.
-:::
+| Field | Description |
+|-------|-------------|
+| **Scopes** | Space-separated OAuth scopes to request, beyond the provider's default. |
+| **Logout endpoint** | The provider's logout endpoint, used to end the user session on logout. |
+| **Prompt** | Optional prompt value forwarded to the provider's authorization request, for example `select_account` or `consent`. |
+
+To map this provider's claims to local user attributes, go to the **Attribute Configuration** tab. See [Attribute Configuration](../add-oidc-provider#attribute-configuration) for the mapping concepts, which apply the same way to OAuth 2.0 connections.
 
 ## Next Steps
 

--- a/docs/content/guides/identity-providers/add-oidc-provider.mdx
+++ b/docs/content/guides/identity-providers/add-oidc-provider.mdx
@@ -67,14 +67,12 @@ Optional settings are not part of the creation wizard. After creation, open the 
 |-------|-------------|
 | **UserInfo endpoint** | The provider's userinfo endpoint. Used to fetch additional profile claims. |
 | **JWKS endpoint** | The URL of the provider's JSON Web Key Set. Required when **Enable token exchange** is on. |
+| **Logout endpoint** | The provider's logout endpoint, used to end the user session on logout. |
 | **Issuer** | The provider's issuer identifier, expected in tokens from this provider. Required when **Enable token exchange** is on. |
 | **Scopes** | Space-separated OIDC scopes to request. Defaults to `openid email profile` if left blank. |
+| **Prompt** | Optional prompt value forwarded to the provider's authorization request, for example `select_account` or `consent`. |
 
 Under **Federation**, turn on **Enable token exchange** to accept subject tokens from this provider for token exchange. This makes **Issuer** and **JWKS endpoint** required, and reveals an optional **Trusted token audience** field, the accepted audience value for external tokens during token exchange.
-
-:::note
-The connection also accepts `logoutEndpoint` and `prompt` fields. These are not available in the Console and can only be set through the [Connections API](../../../apis#tag/connections).
-:::
 
 ## Attribute Configuration
 

--- a/frontend/packages/configure-connections/src/components/AttributeMappingSection.tsx
+++ b/frontend/packages/configure-connections/src/components/AttributeMappingSection.tsx
@@ -351,6 +351,14 @@ export default function AttributeMappingSection({
   const valid: boolean =
     !groupUserTypeMissing && !groupRowIncomplete && !defaultMissing && !externalMissing && !valueEntryIncomplete;
 
+  // Keep the latest onChange without making the report-up effect depend on its identity: a caller
+  // passing an inline handler (e.g. ConnectionDetailPage) would otherwise re-trigger the effect on
+  // every parent render, and since the effect derives a fresh config object each time, that loops forever.
+  const onChangeRef = useRef(onChange);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  });
+
   useEffect(() => {
     const hasContent: boolean =
       anyGroupHasContent || effectiveResolveDynamic || linking.some((entry) => entry.value.trim() !== '');
@@ -370,7 +378,7 @@ export default function AttributeMappingSection({
       })),
       linking: linking.map((entry) => entry.value),
     });
-    onChange(config, valid);
+    onChangeRef.current(config, valid);
   }, [
     defaultUserType,
     effectiveResolveDynamic,
@@ -382,7 +390,6 @@ export default function AttributeMappingSection({
     anyGroupHasContent,
     userTypeList,
     wasUnconfigured,
-    onChange,
   ]);
 
   const defaultOptions: string[] = useMemo(

--- a/frontend/packages/configure-connections/src/components/ConnectionForm.tsx
+++ b/frontend/packages/configure-connections/src/components/ConnectionForm.tsx
@@ -182,14 +182,7 @@ export default function ConnectionForm({
           const required: boolean = isRequiredNow(field);
           fieldContent = (
             <FormControl fullWidth required={required} error={Boolean(error)}>
-              <FormLabel htmlFor={`connection-field-${field.name}`}>
-                {label}
-                {field.optional && !required && (
-                  <Typography component="span" variant="caption" color="text.secondary" sx={{ml: 1}}>
-                    {t('form.optional')}
-                  </Typography>
-                )}
-              </FormLabel>
+              <FormLabel htmlFor={`connection-field-${field.name}`}>{label}</FormLabel>
               <TextField
                 id={`connection-field-${field.name}`}
                 fullWidth

--- a/frontend/packages/configure-connections/src/components/TrustedIssuerCreateForm.tsx
+++ b/frontend/packages/configure-connections/src/components/TrustedIssuerCreateForm.tsx
@@ -149,12 +149,11 @@ export default function TrustedIssuerCreateForm({
               value={issuer}
               error={Boolean(touched['issuer'] && errors.issuer)}
               helperText={
-                touched['issuer']
-                  ? fieldErrorMessage(errors.issuer)
-                  : t(
-                      'trustedIssuers:create.form.issuer.hint',
-                      "The issuer URI from the external IdP's OpenID Connect discovery document.",
-                    )
+                (touched['issuer'] ? fieldErrorMessage(errors.issuer) : undefined) ??
+                t(
+                  'trustedIssuers:create.form.issuer.hint',
+                  "The issuer URI from the external IdP's OpenID Connect discovery document.",
+                )
               }
               onChange={(e) => setIssuer(e.target.value)}
               onBlur={() => setTouchedField('issuer')}
@@ -172,12 +171,11 @@ export default function TrustedIssuerCreateForm({
               value={jwksEndpoint}
               error={Boolean(touched['jwksEndpoint'] && errors.jwksEndpoint)}
               helperText={
-                touched['jwksEndpoint']
-                  ? fieldErrorMessage(errors.jwksEndpoint)
-                  : t(
-                      'trustedIssuers:create.form.jwksEndpoint.hint',
-                      'The JWKS endpoint used to validate the signature of incoming identity assertions.',
-                    )
+                (touched['jwksEndpoint'] ? fieldErrorMessage(errors.jwksEndpoint) : undefined) ??
+                t(
+                  'trustedIssuers:create.form.jwksEndpoint.hint',
+                  'The JWKS endpoint used to validate the signature of incoming identity assertions.',
+                )
               }
               onChange={(e) => setJwksEndpoint(e.target.value)}
               onBlur={() => setTouchedField('jwksEndpoint')}

--- a/frontend/packages/configure-connections/src/components/__tests__/AttributeMappingSection.test.tsx
+++ b/frontend/packages/configure-connections/src/components/__tests__/AttributeMappingSection.test.tsx
@@ -17,9 +17,17 @@
  */
 
 import {fireEvent, render, screen, within} from '@testing-library/react';
+import {useState} from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import type {AttributeConfiguration} from '../../models/connection';
 import AttributeMappingSection from '../AttributeMappingSection';
+
+// Mirrors ConnectionDetailPage's real usage: an inline (identity-unstable) onChange handler, so a
+// regression of the report-up effect depending on onChange's identity would loop here too.
+function Harness({initialConfig = undefined}: {initialConfig?: AttributeConfiguration}): JSX.Element {
+  const [, setConfig] = useState<AttributeConfiguration | undefined>(undefined);
+  return <AttributeMappingSection initialConfig={initialConfig} onChange={(config) => setConfig(config)} />;
+}
 
 // The package's test setup renders real translations, so assert on the resolved English strings.
 const RESOLUTION_TITLE = 'User type resolution';
@@ -97,6 +105,17 @@ describe('AttributeMappingSection', () => {
     };
     render(<AttributeMappingSection initialConfig={initial} onChange={onChange} />);
     expect(onChange).toHaveBeenLastCalledWith(initial, true);
+  });
+
+  it('does not loop when an inline onChange stores an existing mapping config (regression)', () => {
+    const initial: AttributeConfiguration = {
+      userTypeResolution: {default: 'Person'},
+      userTypeAttributeMappings: [
+        {userType: 'Person', attributes: [{externalAttribute: 'given_name', localAttribute: 'firstName'}]},
+      ],
+    };
+    expect(() => render(<Harness initialConfig={initial} />)).not.toThrow();
+    expect(screen.getByTestId('attribute-mapping-section')).toBeInTheDocument();
   });
 
   it('pre-enables the value mapping toggle and shows existing entries on edit prefill', () => {

--- a/frontend/packages/configure-connections/src/config/__tests__/connectionFormFields.test.ts
+++ b/frontend/packages/configure-connections/src/config/__tests__/connectionFormFields.test.ts
@@ -33,6 +33,7 @@ describe('fieldsForMode', () => {
       'clientSecret',
       'redirectUri',
       'scopes',
+      'prompt',
     ]);
   });
 
@@ -53,8 +54,10 @@ describe('fieldsForMode', () => {
       'issuer',
       'userInfoEndpoint',
       'jwksEndpoint',
+      'logoutEndpoint',
       'redirectUri',
       'scopes',
+      'prompt',
       'tokenExchangeEnabled',
       'trustedTokenAudience',
     ]);
@@ -76,8 +79,10 @@ describe('fieldsForMode', () => {
       'authorizationEndpoint',
       'tokenEndpoint',
       'userInfoEndpoint',
+      'logoutEndpoint',
       'redirectUri',
       'scopes',
+      'prompt',
     ]);
   });
 

--- a/frontend/packages/configure-connections/src/config/connectionFormFields.ts
+++ b/frontend/packages/configure-connections/src/config/connectionFormFields.ts
@@ -32,8 +32,6 @@ export interface ConnectionFieldDef {
   kind: ConnectionFieldKind;
   /** Required on create. Secret fields are required on create but optional (omit-to-keep) on edit. */
   required?: boolean;
-  /** Render an "Optional" tag next to the label. */
-  optional?: boolean;
   placeholder?: string;
   /** Format the value must match (checked only when non-empty). Mirrors backend validation. */
   pattern?: RegExp;
@@ -57,6 +55,24 @@ const NAME_FIELD = (placeholder: string): ConnectionFieldDef => ({
   required: true,
   placeholder,
 });
+
+const PROMPT_FIELD: ConnectionFieldDef = {
+  name: 'prompt',
+  labelKey: 'connections:form.fields.prompt.label',
+  hintKey: 'connections:form.fields.prompt.hint',
+  kind: 'text',
+  placeholder: 'select_account',
+  visibility: 'edit',
+};
+
+const LOGOUT_ENDPOINT_FIELD: ConnectionFieldDef = {
+  name: 'logoutEndpoint',
+  labelKey: 'connections:form.fields.logoutEndpoint.label',
+  hintKey: 'connections:form.fields.logoutEndpoint.hint',
+  kind: 'url',
+  placeholder: 'https://idp.example.com/logout',
+  visibility: 'edit',
+};
 
 const oauthFields = (namePlaceholder: string, clientIdPlaceholder: string): ConnectionFieldDef[] => [
   NAME_FIELD(namePlaceholder),
@@ -89,6 +105,7 @@ const oauthFields = (namePlaceholder: string, clientIdPlaceholder: string): Conn
     placeholder: 'openid email profile',
     visibility: 'edit',
   },
+  PROMPT_FIELD,
 ];
 
 const TOKEN_EXCHANGE_ENABLED_FIELD: ConnectionFieldDef = {
@@ -105,7 +122,6 @@ const TRUSTED_TOKEN_AUDIENCE_FIELD: ConnectionFieldDef = {
   labelKey: 'connections:form.fields.trustedTokenAudience.label',
   hintKey: 'connections:form.fields.trustedTokenAudience.hint',
   kind: 'text',
-  optional: true,
   placeholder: 'my-external-client-id',
   revealedBy: 'tokenExchangeEnabled',
   visibility: 'edit',
@@ -165,7 +181,6 @@ export const CONNECTION_FORM_FIELDS: Record<ConnectionType, ConnectionFieldDef[]
       labelKey: 'connections:form.fields.userInfoEndpoint.label',
       hintKey: 'connections:form.fields.userInfoEndpoint.hint',
       kind: 'url',
-      optional: true,
       placeholder: 'https://idp.example.com/userinfo',
       visibility: 'edit',
     },
@@ -174,11 +189,11 @@ export const CONNECTION_FORM_FIELDS: Record<ConnectionType, ConnectionFieldDef[]
       labelKey: 'connections:form.fields.jwksEndpoint.label',
       hintKey: 'connections:form.fields.jwksEndpoint.hint',
       kind: 'url',
-      optional: true,
       placeholder: 'https://idp.example.com/.well-known/jwks.json',
       requiredWhen: 'tokenExchangeEnabled',
       visibility: 'edit',
     },
+    LOGOUT_ENDPOINT_FIELD,
     {
       name: 'redirectUri',
       labelKey: 'connections:form.fields.redirectUri.label',
@@ -193,6 +208,7 @@ export const CONNECTION_FORM_FIELDS: Record<ConnectionType, ConnectionFieldDef[]
       placeholder: 'openid email profile',
       visibility: 'edit',
     },
+    PROMPT_FIELD,
     TOKEN_EXCHANGE_ENABLED_FIELD,
     TRUSTED_TOKEN_AUDIENCE_FIELD,
   ],
@@ -237,6 +253,7 @@ export const CONNECTION_FORM_FIELDS: Record<ConnectionType, ConnectionFieldDef[]
       required: true,
       placeholder: 'https://idp.example.com/userinfo',
     },
+    LOGOUT_ENDPOINT_FIELD,
     {
       name: 'redirectUri',
       labelKey: 'connections:form.fields.redirectUri.label',
@@ -251,6 +268,7 @@ export const CONNECTION_FORM_FIELDS: Record<ConnectionType, ConnectionFieldDef[]
       placeholder: 'read:user email',
       visibility: 'edit',
     },
+    PROMPT_FIELD,
   ],
   [ConnectionTypes.TWILIO]: [
     NAME_FIELD('Twilio SMS'),

--- a/frontend/packages/configure-connections/src/config/connectionVendorMeta.tsx
+++ b/frontend/packages/configure-connections/src/config/connectionVendorMeta.tsx
@@ -68,6 +68,7 @@ export const CONNECTION_VENDOR_META: ConnectionVendorMeta[] = [
     logo: <KeyRound />,
     categories: ['enterprise', 'custom'],
     presentation: 'custom',
+    supportsAttributeMapping: true,
   },
   {
     key: 'twilio',

--- a/frontend/packages/configure-connections/src/pages/ConnectionConfigureWizardPage.tsx
+++ b/frontend/packages/configure-connections/src/pages/ConnectionConfigureWizardPage.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useConfig} from '@thunderid/contexts';
+import {useConfig, useToast} from '@thunderid/contexts';
 import {AppBreadcrumbs, Box, Button, Paper, Stack, Typography} from '@wso2/oxygen-ui';
 import {type JSX, useEffect, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
@@ -46,6 +46,7 @@ export default function ConnectionConfigureWizardPage(): JSX.Element | null {
   const navigate = useNavigate();
   const routes = useConnectionRoutes();
   const {getGateCallbackUrl} = useConfig();
+  const {showToast} = useToast();
   const {type} = useParams<{type: string}>();
 
   const connectionType = type as ConnectionType;
@@ -54,7 +55,6 @@ export default function ConnectionConfigureWizardPage(): JSX.Element | null {
   const createMutation = useCreateConnection(connectionType);
 
   const [editedValues, setEditedValues] = useState<ConnectionFormValues>({});
-  const [nameError, setNameError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!meta) {
@@ -83,7 +83,6 @@ export default function ConnectionConfigureWizardPage(): JSX.Element | null {
     if (!formValid) {
       return;
     }
-    setNameError(null);
     const payload = {
       ...formValuesToRequest(values, fields, {mode: 'create', secretReplaced: true}),
       name: meta.displayName,
@@ -92,7 +91,7 @@ export default function ConnectionConfigureWizardPage(): JSX.Element | null {
       onSuccess: (created: ConnectionResponse) => void navigate(routes.connections.detail(connectionType, created.id)),
       onError: (error: Error) => {
         if (isConflictError(error)) {
-          setNameError(t('error.duplicateName'));
+          showToast(t('error.duplicateName', 'A connection with this name already exists.'), 'error');
         }
       },
     });
@@ -139,7 +138,6 @@ export default function ConnectionConfigureWizardPage(): JSX.Element | null {
             secretReplacing={false}
             hasStoredSecret={false}
             vendorDisplayName={meta.displayName}
-            nameError={nameError}
             showNameField={false}
             onFieldChange={(name, value) => setEditedValues((prev) => ({...prev, [name]: value}))}
             onSecretReplacingChange={() => undefined}

--- a/frontend/packages/configure-connections/src/pages/ConnectionCreateWizardPage.tsx
+++ b/frontend/packages/configure-connections/src/pages/ConnectionCreateWizardPage.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import {useConfig} from '@thunderid/contexts';
+import {useConfig, useToast} from '@thunderid/contexts';
 import {AppBreadcrumbs, Box, Button, Paper, Stack, Typography} from '@wso2/oxygen-ui';
 import {ChevronLeft} from '@wso2/oxygen-ui-icons-react';
 import {type JSX, useMemo, useState} from 'react';
@@ -57,6 +57,7 @@ export default function ConnectionCreateWizardPage(): JSX.Element {
   const navigate = useNavigate();
   const routes = useConnectionRoutes();
   const {getGateCallbackUrl} = useConfig();
+  const {showToast} = useToast();
 
   const [step, setStep] = useState<Step>(Step.TYPE);
   const [selectedType, setSelectedType] = useState<SelectableConnectionType | null>(null);
@@ -89,7 +90,9 @@ export default function ConnectionCreateWizardPage(): JSX.Element {
   const progress: number = ((ALL_STEPS.indexOf(step) + 1) / ALL_STEPS.length) * 100;
 
   const bounceToNameStep = (): void => {
-    setNameError(t('error.duplicateName'));
+    const duplicateNameError = t('error.duplicateName', 'A connection with this name already exists.');
+    setNameError(duplicateNameError);
+    showToast(duplicateNameError, 'error');
     setStep(Step.NAME);
   };
 

--- a/frontend/packages/configure-connections/src/pages/ConnectionDetailPage.tsx
+++ b/frontend/packages/configure-connections/src/pages/ConnectionDetailPage.tsx
@@ -41,6 +41,7 @@ import {
   responseToFormValues,
   validateConnectionForm,
 } from '../utils/connectionFormMapping';
+import isConflictError from '../utils/isConflictError';
 
 interface TabPanelProps {
   children: ReactNode;
@@ -101,6 +102,7 @@ export default function ConnectionDetailPage(): JSX.Element | null {
   const [attrValid, setAttrValid] = useState(true);
   const [attrsKey, setAttrsKey] = useState(0);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [nameError, setNameError] = useState<string | null>(null);
 
   const updateMutation = useUpdateConnection(connectionType, resolvedId ?? '');
   const deleteMutation = useDeleteConnection(connectionType);
@@ -136,6 +138,7 @@ export default function ConnectionDetailPage(): JSX.Element | null {
     setEditedAttr(null);
     setAttrValid(true);
     setAttrsKey((k) => k + 1);
+    setNameError(null);
   };
 
   const formDirty: boolean = JSON.stringify(values) !== JSON.stringify(baseline) || secretReplacing;
@@ -147,6 +150,7 @@ export default function ConnectionDetailPage(): JSX.Element | null {
     if (!valid || !resolvedId) {
       return;
     }
+    setNameError(null);
     const payload = {
       ...formValuesToRequest(values, fields, {mode: 'edit', secretReplaced: secretReplacing}),
       ...(supportsAttributes ? {attributeConfiguration: editedAttr ?? baselineAttr} : {}),
@@ -155,8 +159,10 @@ export default function ConnectionDetailPage(): JSX.Element | null {
       .mutateAsync(payload)
       .then(() => connectionQuery.refetch())
       .then(() => resetEdits())
-      .catch(() => {
-        // Errors (including the 409 duplicate-name) are surfaced by the mutation hook.
+      .catch((error: unknown) => {
+        if (isConflictError(error)) {
+          setNameError(t('error.duplicateName', 'A connection with this name already exists.'));
+        }
       });
   };
 
@@ -251,8 +257,14 @@ export default function ConnectionDetailPage(): JSX.Element | null {
                   secretReplacing={secretReplacing}
                   hasStoredSecret
                   vendorDisplayName={meta.displayName}
+                  nameError={nameError}
                   showNameField={isCustom}
-                  onFieldChange={(name, value) => setEditedValues((prev) => ({...prev, [name]: value}))}
+                  onFieldChange={(name, value) => {
+                    setEditedValues((prev) => ({...prev, [name]: value}));
+                    if (name === 'name') {
+                      setNameError(null);
+                    }
+                  }}
                   onSecretReplacingChange={setSecretReplacing}
                 />
               </SettingsCard>

--- a/frontend/packages/configure-connections/src/pages/TrustedIssuerDetailPage.tsx
+++ b/frontend/packages/configure-connections/src/pages/TrustedIssuerDetailPage.tsx
@@ -203,7 +203,13 @@ export default function TrustedIssuerDetailPage(): JSX.Element {
                     fullWidth
                     value={values.issuer}
                     error={Boolean(touched['issuer'] && errors.issuer)}
-                    helperText={touched['issuer'] ? fieldErrorMessage(errors.issuer) : undefined}
+                    helperText={
+                      (touched['issuer'] ? fieldErrorMessage(errors.issuer) : undefined) ??
+                      t(
+                        'trustedIssuers:create.form.issuer.hint',
+                        "The issuer URI from the external IdP's OpenID Connect discovery document.",
+                      )
+                    }
                     onChange={(e) => setField('issuer', e.target.value)}
                     onBlur={() => setTouchedField('issuer')}
                   />
@@ -218,7 +224,13 @@ export default function TrustedIssuerDetailPage(): JSX.Element {
                     fullWidth
                     value={values.jwksEndpoint}
                     error={Boolean(touched['jwksEndpoint'] && errors.jwksEndpoint)}
-                    helperText={touched['jwksEndpoint'] ? fieldErrorMessage(errors.jwksEndpoint) : undefined}
+                    helperText={
+                      (touched['jwksEndpoint'] ? fieldErrorMessage(errors.jwksEndpoint) : undefined) ??
+                      t(
+                        'trustedIssuers:create.form.jwksEndpoint.hint',
+                        'The JWKS endpoint used to validate the signature of incoming identity assertions.',
+                      )
+                    }
                     onChange={(e) => setField('jwksEndpoint', e.target.value)}
                     onBlur={() => setTouchedField('jwksEndpoint')}
                   />

--- a/frontend/packages/configure-connections/src/pages/__tests__/ConnectionConfigureWizardPage.test.tsx
+++ b/frontend/packages/configure-connections/src/pages/__tests__/ConnectionConfigureWizardPage.test.tsx
@@ -23,6 +23,7 @@ import ConnectionConfigureWizardPage from '../ConnectionConfigureWizardPage';
 
 const mutateMock = vi.fn();
 const navigateMock = vi.fn();
+const showToastMock = vi.fn();
 const mockParams = {type: 'google'};
 
 vi.mock('react-router', async (importOriginal) => ({
@@ -33,7 +34,7 @@ vi.mock('react-router', async (importOriginal) => ({
 vi.mock('@thunderid/contexts', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@thunderid/contexts')>()),
   useConfig: () => ({getGateCallbackUrl: () => 'https://id.acme.io/gate/callback'}),
-  useToast: () => ({showToast: vi.fn()}),
+  useToast: () => ({showToast: showToastMock}),
 }));
 vi.mock('../../api/useCreateConnection', () => ({default: () => ({mutate: mutateMock, isPending: false})}));
 
@@ -102,6 +103,17 @@ describe('ConnectionConfigureWizardPage', () => {
     onSuccess({id: 'conn-1'});
 
     expect(navigateMock).toHaveBeenCalledWith('/connections/google/conn-1');
+  });
+
+  it('shows a toast with the duplicate-name error on a 409 create conflict', () => {
+    render(<ConnectionConfigureWizardPage />);
+
+    fireEvent.click(screen.getByTestId('wizard-create'));
+
+    const {onError} = mutateMock.mock.calls[0][1] as {onError: (error: unknown) => void};
+    onError({response: {status: 409}});
+
+    expect(showToastMock).toHaveBeenCalledWith('A connection with this name already exists.', 'error');
   });
 
   it('SMS vendor: single configure step creates without attribute mapping', () => {

--- a/frontend/packages/configure-connections/src/pages/__tests__/ConnectionCreateWizardPage.test.tsx
+++ b/frontend/packages/configure-connections/src/pages/__tests__/ConnectionCreateWizardPage.test.tsx
@@ -23,6 +23,7 @@ import ConnectionCreateWizardPage from '../ConnectionCreateWizardPage';
 
 const mutateMock = vi.fn();
 const navigateMock = vi.fn();
+const showToastMock = vi.fn();
 
 vi.mock('react-router', async (importOriginal) => ({
   ...(await importOriginal<typeof import('react-router')>()),
@@ -34,7 +35,7 @@ vi.mock('@thunderid/contexts', async (importOriginal) => ({
     getGateCallbackUrl: () => 'https://id.acme.io/gate/callback',
     config: {brand: {product_name: 'ThunderID'}},
   }),
-  useToast: () => ({showToast: vi.fn()}),
+  useToast: () => ({showToast: showToastMock}),
 }));
 vi.mock('../../api/useCreateConnection', () => ({default: () => ({mutate: mutateMock, isPending: false})}));
 
@@ -173,6 +174,7 @@ describe('ConnectionCreateWizardPage', () => {
 
     expect(screen.getByTestId('connection-name-step')).toBeInTheDocument();
     expect(screen.getByText('A connection with this name already exists.')).toBeInTheDocument();
+    expect(showToastMock).toHaveBeenCalledWith('A connection with this name already exists.', 'error');
   });
 
   it('renders the baked-in trusted-idp step instead of the generic ConnectionForm', () => {
@@ -193,6 +195,7 @@ describe('ConnectionCreateWizardPage', () => {
 
     expect(screen.getByTestId('connection-name-step')).toBeInTheDocument();
     expect(screen.getByText('A connection with this name already exists.')).toBeInTheDocument();
+    expect(showToastMock).toHaveBeenCalledWith('A connection with this name already exists.', 'error');
   });
 
   it('returns to the name step when Back is clicked from the trusted-idp step', () => {

--- a/frontend/packages/configure-connections/src/pages/__tests__/ConnectionDetailPage.test.tsx
+++ b/frontend/packages/configure-connections/src/pages/__tests__/ConnectionDetailPage.test.tsx
@@ -53,6 +53,17 @@ const TWILIO_CONNECTION = {
   senderId: '+15005550006',
 };
 
+const OIDC_CONNECTION = {
+  id: 'oidc1',
+  type: 'oidc',
+  name: 'Acme Workforce OIDC',
+  clientId: 'cid',
+  clientSecret: '******',
+  authorizationEndpoint: 'https://idp.example.com/authorize',
+  tokenEndpoint: 'https://idp.example.com/token',
+  redirectUri: 'https://id.acme.io/oauth/callback/oidc',
+};
+
 const mockParams: {type: string; id: string} = {type: 'google', id: 'g1'};
 const mockConn: {data: Record<string, unknown>} = {data: CONNECTION};
 
@@ -88,12 +99,22 @@ vi.mock('../../api/useGetConnectionUsages', () => ({
 }));
 
 vi.mock('../../components/ConnectionForm', () => ({
-  default: function StubConnectionForm({onFieldChange}: {onFieldChange: (name: string, value: string) => void}) {
+  default: function StubConnectionForm({
+    onFieldChange,
+    nameError,
+  }: {
+    onFieldChange: (name: string, value: string) => void;
+    nameError?: string | null;
+  }) {
     return (
       <div data-testid="stub-connection-form">
         <button type="button" data-testid="edit-client-id" onClick={() => onFieldChange('clientId', 'changed')}>
           edit
         </button>
+        <button type="button" data-testid="edit-name" onClick={() => onFieldChange('name', 'Renamed')}>
+          edit name
+        </button>
+        {nameError && <div data-testid="stub-name-error">{nameError}</div>}
       </div>
     );
   },
@@ -153,6 +174,23 @@ describe('ConnectionDetailPage', () => {
 
     await waitFor(() => expect(refetchMock).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(screen.queryByTestId('save-bar')).not.toBeInTheDocument());
+  });
+
+  it('shows an inline name error on a 409 update conflict, and clears it when the name is edited', async () => {
+    mockParams.type = 'oidc';
+    mockParams.id = 'oidc1';
+    mockConn.data = OIDC_CONNECTION;
+    updateMock.mockRejectedValueOnce({response: {status: 409}});
+    render(<ConnectionDetailPage />);
+    fireEvent.click(screen.getByTestId('edit-client-id'));
+    fireEvent.click(screen.getByTestId('save-bar'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('stub-name-error')).toHaveTextContent('A connection with this name already exists.'),
+    );
+
+    fireEvent.click(screen.getByTestId('edit-name'));
+    expect(screen.queryByTestId('stub-name-error')).not.toBeInTheDocument();
   });
 
   it('deletes the connection and returns to the list', () => {

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1736,6 +1736,10 @@ const translations = {
     'form.fields.jwksEndpoint.label': 'JWKS endpoint',
     'form.fields.jwksEndpoint.hint': 'Endpoint that exposes signing keys for verifying identity tokens.',
     'form.fields.logoutEndpoint.label': 'Logout endpoint',
+    'form.fields.logoutEndpoint.hint': 'Endpoint the provider uses to end the user session on logout.',
+    'form.fields.prompt.label': 'Prompt',
+    'form.fields.prompt.hint':
+      "Optional prompt value forwarded to the provider's authorization request, e.g. select_account or consent.",
     'form.fields.issuer.label': 'Issuer',
     'form.fields.issuer.hint': 'Issuer identifier expected in tokens from this provider.',
     'form.fields.tokenExchangeEnabled.label': 'Enable token exchange',
@@ -1754,7 +1758,6 @@ const translations = {
     'form.fields.senderId.label': 'Sender ID',
     'form.fields.senderId.hint': 'Phone number or alphanumeric sender ID messages are sent from.',
     'form.sections.federation': 'Federation',
-    'form.optional': 'Optional',
     'form.secret.update': 'Update',
     'form.secret.keepHelp': 'Leave unchanged to keep the stored secret.',
     'form.copy': 'Copy',


### PR DESCRIPTION
### Purpose
Fix a handful of UX issues in the connections UI:

- Trusted issuer field hints (Issuer URI, JWKS endpoint) disappeared once a valid value was entered, on both the create and edit pages.
- Duplicate-name (409) conflicts were invisible on the branded connection setup page and the connection edit page, and only partially surfaced (no toast) on the create wizard.
- `prompt`, `logout endpoint`, and (for OAuth 2.0) attribute mapping were documented as API-only even though the `/connections` API already supported them; they are now exposed in the Console.
- Opening the attribute configuration tab entered an infinite render loop (`Maximum update depth exceeded`) once an attribute mapping existed or was being added.

### Approach
- **Hint fallback**: changed the `helperText` logic on the trusted issuer forms to fall back to the hint whenever there is no error to show (`error ?? hint`), matching the pattern already used by the shared Google/OIDC `ConnectionForm`.
- **409 handling**: added a toast on the branded connection setup page (its name field is hidden, so an inline error can't be shown), an inline name error on the connection edit page, and a toast alongside the existing name-step bounce-back on the create wizard.
- **New optional fields**: added `prompt` and `logoutEndpoint` field definitions to the connection form config, and enabled attribute mapping for OAuth 2.0 connections. Updated the four identity provider docs that described these as API-only.
- **Optional label**: removed the dead `optional` flag and its rendering from the shared connection form, since it served no purpose beyond the label.
- **Infinite loop fix**: `AttributeMappingSection`'s report-up effect depended on the `onChange` prop's identity. `ConnectionDetailPage` passes an inline `onChange` (a new function every render) that calls `setEditedAttr`, so once a mapping existed (making the derived config a fresh object rather than a stable `undefined`), each effect run triggered a state update that re-rendered the parent, which re-triggered the effect, forever. Fixed by keeping the latest `onChange` in a ref and dropping it from the effect's dependency array, so the effect only re-runs when the derived config or validity actually changes.

### Related Issues
- Fixes #3886
- Fixes https://github.com/thunder-id/thunderid/issues/4180
- https://github.com/thunder-id/thunderid/issues/3908

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [x] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Console configuration for OAuth/OIDC logout endpoint and prompt settings.
  * Enabled OAuth attribute mapping support in the Console.
* **Bug Fixes**
  * Improved validation/helper text behavior for Trusted Issuer fields.
  * Enhanced duplicate connection-name conflict handling with clearer inline and toast notifications.
  * Fixed an infinite render loop when opening the attribute configuration tab with an existing mapping.
* **Documentation**
  * Updated GitHub, Google, OAuth, and OIDC identity provider setup guides to reflect Console-configurable prompt and logout endpoint options.
* **UI Improvements**
  * Updated connection form fields to include new settings and refined field labeling (removing optional captions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->