### PR TITLE
Fix missing attestation mapping in declarative app parser

### DIFF
--- a/backend/internal/application/declarative_resource.go
+++ b/backend/internal/application/declarative_resource.go
@@ -190,6 +190,7 @@ func parseToApplicationDTO(data []byte) (*model.ApplicationDTO, error) {
 			Assertion:                 appRequest.Assertion,
 			AllowedUserTypes:          appRequest.AllowedUserTypes,
 			LoginConsent:              appRequest.LoginConsent,
+			Attestation:               appRequest.Attestation,
 		},
 		Type:       appRequest.Type,
 		Template:   appRequest.Template,

--- a/backend/internal/application/declarative_resource_internal_test.go
+++ b/backend/internal/application/declarative_resource_internal_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/application/model"
@@ -502,6 +503,26 @@ inboundAuthConfig:
 	err = json.Unmarshal(sysCredsJSON, &sysCreds)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), "oauth-client-secret", sysCreds[fieldClientSecret])
+}
+
+func (s *ParseToApplicationDTOTestSuite) TestParseToApplicationDTO_AttestationParsed() {
+	yamlData := []byte(`
+id: attested-app
+name: Attested Application
+attestation:
+  android:
+    packageName: com.example.app
+    certificateSha256Digests:
+      - AA:BB:CC
+`)
+
+	appDTO, err := parseToApplicationDTO(yamlData)
+
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), appDTO.Attestation)
+	require.NotNil(s.T(), appDTO.Attestation.Android)
+	assert.Equal(s.T(), "com.example.app", appDTO.Attestation.Android.PackageName)
+	assert.Contains(s.T(), appDTO.Attestation.Android.CertificateSha256Digests, "AA:BB:CC")
 }
 
 func (s *ParseToApplicationDTOTestSuite) TestParseToApplicationDTO_OUHandlePassedThrough() {


### PR DESCRIPTION
### Purpose
Declarative (YAML) applications with an `attestation` block silently lost that config: `parseToApplicationDTO` in `declarative_resource.go` built `InboundAuthProfile` field by field but never copied `Attestation`, so it never reached validation or persistence. The REST API path (`handler.go`) already mapped this field correctly.

### Approach
Add the missing `Attestation: appRequest.Attestation` mapping, matching the existing REST handler. Added a unit test covering attestation parsing for declarative apps.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Declarative application configuration now preserves `attestation` details when parsed from YAML, including Android package names and certificate SHA-256 digests.
* **Tests**
  * Added coverage to confirm YAML attestation sections are parsed successfully and the expected nested values are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->