### PR TITLE
Shard console app tests across parallel jobs

### DIFF
--- a/.github/actions/merge-lcov/action.yml
+++ b/.github/actions/merge-lcov/action.yml
@@ -1,0 +1,33 @@
+name: Merge LCOV Reports
+description: Merges the LCOV tracefiles produced by a sharded test run into a single report.
+
+inputs:
+  reports-dir:
+    description: Directory searched recursively for the LCOV tracefiles to merge.
+    required: true
+  output-file:
+    description: Path of the merged LCOV tracefile to write.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: 🧩 Merge LCOV tracefiles
+      shell: bash
+      env:
+        REPORTS_DIR: ${{ inputs.reports-dir }}
+        OUTPUT_FILE: ${{ inputs.output-file }}
+      run: |
+        set -euo pipefail
+        mapfile -t reports < <(find "$REPORTS_DIR" -type f -name '*.info' | sort)
+        # Fail rather than write an empty report: a silently empty merge would
+        # read downstream as "no code covered" and sink patch coverage.
+        if [ "${#reports[@]}" -eq 0 ]; then
+          echo "❌ No LCOV tracefiles found under $REPORTS_DIR"
+          exit 1
+        fi
+        echo "Merging ${#reports[@]} tracefile(s):"
+        printf '  %s\n' "${reports[@]}"
+        mkdir -p "$(dirname "$OUTPUT_FILE")"
+        awk -f "$GITHUB_ACTION_PATH/merge-lcov.awk" "${reports[@]}" > "$OUTPUT_FILE"
+        echo "✅ Wrote $OUTPUT_FILE ($(grep -c '^SF:' "$OUTPUT_FILE") source files)"

--- a/.github/actions/merge-lcov/merge-lcov.awk
+++ b/.github/actions/merge-lcov/merge-lcov.awk
@@ -1,0 +1,95 @@
+# Merges LCOV tracefiles that describe the same sources, summing hit counts so
+# a sharded test run reports the same totals as a single run would. Vitest
+# shards each emit a report for every source file (coverage.all is on), so the
+# same DA/FNDA records repeat across shards and have to be added rather than
+# overwritten. Totals (LF/LH/FNF/FNH) are recomputed from the summed counters
+# instead of being added, since summing them would multiply by the shard count.
+# Branch records are stripped before this runs, so only line and function
+# counters are handled.
+#
+# Usage: awk -f merge-lcov.awk shard-1.info shard-2.info ... > lcov.info
+/^SF:/ {
+  sf = substr($0, 4)
+  if (!(sf in sf_seen)) {
+    sf_seen[sf] = 1
+    sf_order[++sf_count] = sf
+  }
+  next
+}
+# FN is either "FN:<line>,<name>" or "FN:<start>,<end>,<name>", so the name is
+# what follows the last comma; keep the leading fields verbatim so whichever
+# form the coverage provider emits is reproduced unchanged.
+/^FN:/ {
+  rest = substr($0, 4)
+  comma = 0
+  for (p = length(rest); p > 0; p--) {
+    if (substr(rest, p, 1) == ",") { comma = p; break }
+  }
+  if (comma == 0) next
+  name = substr(rest, comma + 1)
+  key = sf SUBSEP name
+  if (!(key in fn_prefix)) {
+    fn_prefix[key] = substr(rest, 1, comma)
+    fn_names[sf] = fn_names[sf] (fn_names[sf] == "" ? "" : RS) name
+  }
+  next
+}
+/^FNDA:/ {
+  rest = substr($0, 6)
+  comma = index(rest, ",")
+  if (comma == 0) next
+  name = substr(rest, comma + 1)
+  fn_hits[sf SUBSEP name] += substr(rest, 1, comma - 1)
+  next
+}
+/^DA:/ {
+  rest = substr($0, 4)
+  comma = index(rest, ",")
+  if (comma == 0) next
+  lineno = substr(rest, 1, comma - 1)
+  key = sf SUBSEP lineno
+  if (!(key in da_seen)) {
+    da_seen[key] = 1
+    da_order[sf] = da_order[sf] (da_order[sf] == "" ? "" : RS) lineno
+  }
+  da_hits[key] += substr(rest, comma + 1)
+  next
+}
+END {
+  for (i = 1; i <= sf_count; i++) {
+    sf = sf_order[i]
+    print "TN:"
+    print "SF:" sf
+
+    fn_found = 0
+    fn_hit = 0
+    fn_count = split(fn_names[sf], names, RS)
+    for (j = 1; j <= fn_count; j++) {
+      if (names[j] == "") continue
+      fn_found++
+      print "FN:" fn_prefix[sf SUBSEP names[j]] names[j]
+    }
+    for (j = 1; j <= fn_count; j++) {
+      if (names[j] == "") continue
+      hits = fn_hits[sf SUBSEP names[j]] + 0
+      if (hits > 0) fn_hit++
+      print "FNDA:" hits "," names[j]
+    }
+    print "FNF:" fn_found
+    print "FNH:" fn_hit
+
+    lines_found = 0
+    lines_hit = 0
+    line_count = split(da_order[sf], lines, RS)
+    for (j = 1; j <= line_count; j++) {
+      if (lines[j] == "") continue
+      lines_found++
+      hits = da_hits[sf SUBSEP lines[j]] + 0
+      if (hits > 0) lines_hit++
+      print "DA:" lines[j] "," hits
+    }
+    print "LF:" lines_found
+    print "LH:" lines_hit
+    print "end_of_record"
+  }
+}

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -453,12 +453,26 @@ jobs:
           path: frontend/apps/gate/coverage/lcov.info
           if-no-files-found: error
 
-  test-frontend-console-app:
-    name: 🧪 Console App Tests with Coverage
+  # The console suite is the longest job in the pipeline (~12 min of vitest in a
+  # single run), so it is split across shards that execute concurrently. Each
+  # shard reports coverage for the whole app with only its own tests counted;
+  # test-frontend-console-app below merges the partial reports back into one
+  # LCOV file, so coverage consumers still see a single console-coverage
+  # artifact.
+  test-frontend-console-app-shards:
+    name: 🧪 Console App Tests (shard ${{ matrix.shard }})
     needs: [preflight]
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      # Report every failing shard, not just the first one, so a single run
+      # surfaces all breakages.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    env:
+      SHARD_COUNT: 3
     steps:
       - name: 📥 Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -480,9 +494,9 @@ jobs:
           pnpm build:frontend
 
       - name: 🧪 Run Console Tests with Coverage
+        working-directory: frontend/apps/console
         run: |
-          cd frontend/apps/console
-          pnpm test:coverage
+          pnpm exec vitest run --coverage --shard=${{ matrix.shard }}/${{ env.SHARD_COUNT }}
 
       # Strip branch data (BRDA/BRF/BRH) from frontend LCOV reports before uploading.
       # React Compiler (babel-plugin-react-compiler) generates phantom branch points in compiled
@@ -494,6 +508,53 @@ jobs:
           if [ -f "frontend/apps/console/coverage/lcov.info" ]; then
             sed -i '/^BRDA:/d;/^BRF:/d;/^BRH:/d' "frontend/apps/console/coverage/lcov.info"
           fi
+
+      # Named without "coverage" so the patch coverage gate, which downloads
+      # every "*coverage*" artifact, only ever sees the merged report.
+      - name: 📦 Upload console shard LCOV report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: console-lcov-shard-${{ matrix.shard }}
+          path: frontend/apps/console/coverage/lcov.info
+          if-no-files-found: error
+
+  # Keeps the console suite reporting as one check and one coverage artifact
+  # regardless of how many shards run. Uses always() with an explicit result
+  # check so a failing shard fails this job too: a skipped required check counts
+  # as passing for branch protection, which would let a red shard through.
+  test-frontend-console-app:
+    name: 🧪 Console App Tests with Coverage
+    needs: [test-frontend-console-app-shards]
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: ✅ Check shard results
+        env:
+          SHARDS_RESULT: ${{ needs.test-frontend-console-app-shards.result }}
+        run: |
+          if [ "$SHARDS_RESULT" != "success" ]; then
+            echo "❌ Console test shards did not pass (result: $SHARDS_RESULT)"
+            exit 1
+          fi
+          echo "✅ All console test shards passed"
+
+      - name: 📥 Checkout Code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: 📥 Download console shard LCOV reports
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: console-lcov-shard-*
+          path: console-shards
+
+      - name: 🧩 Merge console shard LCOV reports
+        uses: ./.github/actions/merge-lcov
+        with:
+          reports-dir: console-shards
+          output-file: frontend/apps/console/coverage/lcov.info
 
       - name: 📦 Upload console coverage artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION
### Purpose

Console App Tests is the longest job in the PR Builder: ~11.7 min of vitest in a single run, against ~2.7 min of fixed setup, for a ~14.5 min job. Everything else finishes well before it, so it sets the floor for how fast a PR run can be.

This splits the suite across 3 shards that run concurrently, taking the job to roughly 6.5 min and moving it off the critical path (which becomes Build Product to Playwright E2E at ~13 min).

Phase 2 of #4268.

### Approach

`test-frontend-console-app-shards` is a 3-way matrix running `vitest run --coverage --shard=N/3`, with `fail-fast: false` so one broken shard does not mask the others.

Because each shard only sees its own tests, coverage arrives in three partial LCOV reports. `test-frontend-console-app` becomes a small aggregator that merges them back into a single `console-coverage` artifact, so `upload-frontend-coverage` and the patch coverage gate are untouched and keep consuming exactly what they do today. The merge itself is a new `merge-lcov` composite action: an awk script that sums per-line and per-function hit counts and recomputes the LF/LH/FNF/FNH totals. That follows the precedent already set by `go-cover-to-lcov.awk` in the patch coverage gate, which deliberately avoids third-party coverage converters.

Two details that are load-bearing:

- The aggregator keeps the job name `🧪 Console App Tests with Coverage`, which is a required status check. It also runs with `always()` plus an explicit shard-result check rather than relying on `needs` alone, because a skipped required check counts as passing for branch protection: without that, a failing shard would skip the aggregator and quietly satisfy the requirement.
- Shard artifacts are named `console-lcov-shard-N`, with no "coverage" in the name, so the patch coverage gate's `*coverage*` artifact download only ever picks up the merged report and never a partial one.

### Verification

The merge was validated end to end against real sharded output rather than by inspection. Running the console `flows/hooks` tests as `--shard=1/2` and `--shard=2/2` produced two genuine istanbul reports (25 files/452 lines and 19 files/450 lines); merging them yields the union of 37 files and 860 lines, and every single line's merged hit count equals the sum of its per-shard counts (0 mismatches). The merged report was then parsed with the same `diff_cover==10.4.0` the gate uses, to confirm it is inside that parser's LCOV grammar.

Two parser constraints found during that check and handled: `FNDA` must carry exactly two fields, and `FN` may carry either two or three, so the merger keeps the leading `FN` fields verbatim and takes the function name after the last comma.

### Trade-off

Runner-minutes for this job go from ~14.5 to ~20 (each shard repeats the ~2.7 min of install and frontend build). 3 shards rather than 2 is deliberate: `--shard` splits by file count, not duration, so an uneven split could otherwise leave one shard close to the old runtime.

### Related Issues
- Refs #4268

### Related PRs
- #4370 also edits this workflow; whichever merges second needs a trivial rebase.

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Frontend console tests now run in parallel across three shards, reducing CI execution time.
  * Coverage reports from all test shards are consolidated into one complete report.
  * Coverage validation now fails when any test shard fails or no coverage reports are produced.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->