### PR TITLE
Map WebAuthn browser errors to clean messages in the passkey service

### DIFF
--- a/samples/apps/react-vanilla-sample/src/components/PasskeyAuthPrompt.tsx
+++ b/samples/apps/react-vanilla-sample/src/components/PasskeyAuthPrompt.tsx
@@ -57,32 +57,9 @@ const PasskeyAuthPrompt = ({
 
             onAuthenticated(assertion);
         } catch (err) {
-            let displayError: string;
-            
-            if (err instanceof DOMException) {
-                switch (err.name) {
-                    case 'NotAllowedError':
-                        displayError = 'Passkey authentication was cancelled or not allowed. Please try again.';
-                        break;
-                    case 'SecurityError':
-                        displayError = 'Security error. Please ensure you are on a secure (HTTPS) connection.';
-                        break;
-                    case 'NotSupportedError':
-                        displayError = 'Passkeys are not supported on this device.';
-                        break;
-                    case 'InvalidStateError':
-                        displayError = 'No matching passkey found. Please register a passkey first.';
-                        break;
-                    default:
-                        displayError = err.message || 'Failed to authenticate with passkey';
-                }
-            } else if (err instanceof Error) {
-                displayError = err.message;
-            } else {
-                displayError = 'Failed to authenticate with passkey';
-            }
-
-            onError(displayError);
+            // authenticateWithPasskey maps WebAuthn/browser errors to clean messages,
+            // so the error message can be surfaced directly.
+            onError(err instanceof Error ? err.message : 'Failed to authenticate with passkey');
         } finally {
             setAuthenticating(false);
         }

--- a/samples/apps/react-vanilla-sample/src/components/PasskeyRegPrompt.tsx
+++ b/samples/apps/react-vanilla-sample/src/components/PasskeyRegPrompt.tsx
@@ -55,29 +55,9 @@ const PasskeyRegPrompt = ({
             const credential = await createPasskeyCredential(options);
             onCredentialCreated(credential);
         } catch (err) {
-            let displayError: string;
-            
-            if (err instanceof DOMException) {
-                switch (err.name) {
-                    case 'NotAllowedError':
-                        displayError = 'Passkey creation was cancelled or not allowed. Please try again.';
-                        break;
-                    case 'SecurityError':
-                        displayError = 'Security error. Please ensure you are on a secure (HTTPS) connection.';
-                        break;
-                    case 'NotSupportedError':
-                        displayError = 'Passkeys are not supported on this device.';
-                        break;
-                    default:
-                        displayError = err.message || 'Failed to create passkey';
-                }
-            } else if (err instanceof Error) {
-                displayError = err.message;
-            } else {
-                displayError = 'Failed to create passkey';
-            }
-
-            onError(displayError);
+            // createPasskeyCredential maps WebAuthn/browser errors to clean messages,
+            // so the error message can be surfaced directly.
+            onError(err instanceof Error ? err.message : 'Failed to create passkey');
         } finally {
             setCreating(false);
         }

--- a/samples/apps/react-vanilla-sample/src/services/authService.ts
+++ b/samples/apps/react-vanilla-sample/src/services/authService.ts
@@ -97,8 +97,50 @@ export const base64UrlToBuffer = (base64url: string): ArrayBuffer => {
 };
 
 /**
+ * Maps a WebAuthn API error (typically a DOMException thrown by
+ * navigator.credentials.create/get) to a clean, user-facing message, so that raw
+ * browser/spec text such as "The operation either timed out or was not allowed. See:
+ * https://www.w3.org/..." is never shown to the user. This mirrors the message pattern
+ * used for server responses, which surface the localized message.defaultValue.
+ *
+ * @param {unknown} error - The error thrown by the WebAuthn API.
+ * @param {'registration' | 'authentication'} ceremony - The ceremony being performed.
+ * @returns {string} - A clean, user-facing message.
+ */
+const getPasskeyErrorMessage = (
+    error: unknown,
+    ceremony: 'registration' | 'authentication'
+): string => {
+    const action = ceremony === 'registration'
+        ? 'register your passkey'
+        : 'sign in with your passkey';
+
+    if (error instanceof DOMException) {
+        switch (error.name) {
+            case 'NotAllowedError':
+                return `Could not ${action}. The request was cancelled or timed out. Please try again.`;
+            case 'InvalidStateError':
+                return ceremony === 'registration'
+                    ? 'A passkey is already registered on this device for this account.'
+                    : 'No matching passkey was found on this device.';
+            case 'NotSupportedError':
+                return 'Passkeys are not supported on this device or browser.';
+            case 'SecurityError':
+                return `Could not ${action} because of a security restriction on this site.`;
+            case 'AbortError':
+                return `The passkey ${ceremony} request was cancelled.`;
+            case 'ConstraintError':
+                return 'Your device could not satisfy the passkey requirements for this request.';
+            default:
+                return `Could not ${action}. Please try again.`;
+        }
+    }
+    return `Could not ${action}. Please try again.`;
+};
+
+/**
  * Creates a passkey credential using the WebAuthn API.
- * 
+ *
  * @param {PasskeyCreationOptions} options - The passkey creation options from the server.
  * @returns {Promise<PasskeyCredentialResponse>} - The encoded credential response.
  */
@@ -128,13 +170,18 @@ export const createPasskeyCredential = async (
     };
 
     // Call WebAuthn API
-    const credential = await navigator.credentials.create({
-        publicKey: publicKeyOptions,
-    }) as PublicKeyCredential | null;
+    let credential: PublicKeyCredential | null;
+    try {
+        credential = await navigator.credentials.create({
+            publicKey: publicKeyOptions,
+        }) as PublicKeyCredential | null;
+    } catch (error) {
+        throw new Error(getPasskeyErrorMessage(error, 'registration'));
+    }
 
     // Check if credential creation was successful
     if (!credential) {
-        throw new Error('Passkey creation was cancelled or failed. No credential was returned.');
+        throw new Error(getPasskeyErrorMessage(null, 'registration'));
     }
 
     const response = credential.response as AuthenticatorAttestationResponse;
@@ -193,13 +240,18 @@ export const authenticateWithPasskey = async (
     };
 
     // Call WebAuthn API for assertion
-    const credential = await navigator.credentials.get({
-        publicKey: publicKeyOptions,
-    }) as PublicKeyCredential | null;
+    let credential: PublicKeyCredential | null;
+    try {
+        credential = await navigator.credentials.get({
+            publicKey: publicKeyOptions,
+        }) as PublicKeyCredential | null;
+    } catch (error) {
+        throw new Error(getPasskeyErrorMessage(error, 'authentication'));
+    }
 
     // Check if credential retrieval was successful
     if (!credential) {
-        throw new Error('Passkey authentication was cancelled or failed. No credential was returned.');
+        throw new Error(getPasskeyErrorMessage(null, 'authentication'));
     }
 
     const response = credential.response as AuthenticatorAssertionResponse;


### PR DESCRIPTION
### Purpose
Stop raw browser WebAuthn errors from being shown to users during passkey sign-in/registration. For example, a cancelled or timed-out ceremony surfaced the raw `DOMException` message:

> The operation either timed out or was not allowed. See: https://www.w3.org/TR/webauthn-2/#sctn-privacy-considerations-client.

### Approach
The `navigator.credentials.create/get` calls reject with a browser `DOMException` whose `.message` is a raw spec string. That message propagated untouched to the UI, and the two passkey prompt components each **duplicated** their own `DOMException` handling, with unmapped cases falling through to the raw message.

- Centralize the mapping in the passkey service, `authService.ts`: `createPasskeyCredential` and `authenticateWithPasskey` now catch the WebAuthn API rejection and translate each `DOMException` category (`NotAllowedError`, `InvalidStateError`, `NotSupportedError`, `SecurityError`, `AbortError`, `ConstraintError`) into a clean, ceremony-aware message via a single `getPasskeyErrorMessage` helper. This mirrors the pattern already used for server responses (which surface the localized `message.defaultValue`).
- Simplify `PasskeyAuthPrompt` and `PasskeyRegPrompt` to surface the resulting message directly, removing the duplicated `switch` blocks.

Scope: `samples/apps/react-vanilla-sample` (the only in-repo passkey ceremony). Verified with `tsc --noEmit` and `eslint` (both clean).

### Notes / out of scope
- The nested `Sign in failed: Authorization request failed: Internal server error` message originates in the `@thunderid/browser` / `@thunderid/javascript` SDKs (only their built `dist` is vendored here; the source lives in a separate SDK repo), so it can't be fixed from this repo.
- The backend passkey service already returns clean i18n `ServiceError`s; that side is handled separately.

### Related Issues
- thunder-id/thunderid#1647

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified. (tsc + eslint clean)
- [ ] Tests provided. (sample app; no unit test harness for WebAuthn ceremony)

### Security checks
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)