### PR TITLE
Resolve patch coverage from Codecov first and name the source of every verdict

### DIFF
--- a/.github/actions/patch-coverage-gate/action.yml
+++ b/.github/actions/patch-coverage-gate/action.yml
@@ -1,23 +1,29 @@
 name: Patch Coverage Gate
 description: >-
-  Enforces patch coverage for the current diff. Uses Codecov's own patch
-  coverage number via its public API when a fully processed report is
-  available, and computes patch coverage locally with diff-cover from the
-  archived coverage artifacts otherwise, so the check always reports a result
-  and can never hang on Codecov's backend.
+  Enforces patch coverage for the current diff from the most authoritative source
+  available, and always names the source it used. It mirrors the codecov/patch
+  check run first, falls back to Codecov's compare API when that check reports no
+  verdict, and computes patch coverage locally from the archived coverage
+  artifacts when Codecov gives nothing at all, so the gate always reports a
+  result and can never hang on Codecov's backend.
 inputs:
-  fail-under:
-    description: 'Minimum patch coverage percentage required to pass'
+  codecov-config:
+    description: >-
+      Path to codecov.yml. The patch coverage threshold and the ignored paths
+      are read from it so the fallbacks enforce the same rules as Codecov.
     required: false
-    default: '79'
+    default: 'codecov.yml'
+  github-token:
+    description: 'Token used to read the codecov/patch check run'
+    required: true
   pr-number:
     description: >-
-      Pull request number used to query the Codecov API. Leave empty to skip
-      the API and compute patch coverage locally (e.g. on merge queue runs).
+      Pull request number used to query the Codecov compare API. Leave empty to
+      skip that fallback and compute locally instead.
     required: false
     default: ''
   head-sha:
-    description: 'Commit SHA whose Codecov report is polled'
+    description: 'Commit SHA whose Codecov verdict and report are read'
     required: true
   base-ref:
     description: 'Git ref or SHA the diff is compared against'
@@ -26,31 +32,75 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # If this step fails, patch coverage is authoritatively below the
-    # threshold and the composite stops here. If it succeeds without
-    # resolving (Codecov unavailable or report incomplete), the local
-    # computation below takes over.
-    - name: 🔎 Enforce Codecov patch coverage via API
+    # Exports FAIL_UNDER, CODECOV_IGNORE_FILE and CODECOV_FLAG_PATHS_FILE for the
+    # steps below, all derived from codecov.yml.
+    - name: 📖 Read the patch coverage rules from codecov.yml
+      shell: bash
+      env:
+        CODECOV_CONFIG: ${{ inputs.codecov-config }}
+      run: bash "${{ github.action_path }}/read-codecov-config.sh"
+
+    # Nothing in the diff can produce coverage, so no source has anything to
+    # measure. Checked here rather than trusting Codecov's patch totals, which
+    # can report lines from outside this diff.
+    - name: 🔍 Check whether the diff can affect coverage
+      id: coverable
+      shell: bash
+      env:
+        BASE_REF: ${{ inputs.base-ref }}
+      run: |
+        set -euo pipefail
+        CHANGES=$(bash "${{ github.action_path }}/list-coverable-changes.sh")
+        if [ -z "$CHANGES" ]; then
+          echo "coverable=false" >> "$GITHUB_OUTPUT"
+          {
+            echo "✅ Patch coverage: not applicable, no percentage measured."
+            echo "   Nothing in this diff can report coverage, so no source was consulted:"
+            echo "   compared against ${BASE_REF}, it changes no file under any path that a"
+            echo "   coverage flag in codecov.yml covers, once codecov.yml's ignores are applied."
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+        echo "coverable=true" >> "$GITHUB_OUTPUT"
+        echo "$(printf '%s\n' "$CHANGES" | wc -l | tr -d ' ') file(s) in this diff can affect patch coverage:"
+        printf '%s\n' "$CHANGES" | sed 's/^/  /'
+
+    # Source 1: Codecov's own verdict. A pass or fail here is final and the
+    # composite stops; only the absence of a verdict continues to source 2.
+    - name: 1️⃣ Mirror the codecov/patch verdict
+      id: codecov-check
+      if: steps.coverable.outputs.coverable == 'true'
+      shell: bash
+      env:
+        HEAD_SHA: ${{ inputs.head-sha }}
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: bash "${{ github.action_path }}/mirror-codecov-check.sh"
+
+    # Source 2: Codecov's data through the compare API, which is a different
+    # measurement from the check run and so is only consulted when there is no
+    # verdict to mirror.
+    - name: 2️⃣ Fall back to the Codecov compare API
       id: codecov-api
-      if: inputs.pr-number != ''
+      if: steps.coverable.outputs.coverable == 'true' && steps.codecov-check.outputs.resolved != 'true'
       shell: bash
       env:
         PR_NUMBER: ${{ inputs.pr-number }}
         HEAD_SHA: ${{ inputs.head-sha }}
-        FAIL_UNDER: ${{ inputs.fail-under }}
+        BASE_REF: ${{ inputs.base-ref }}
       run: bash "${{ github.action_path }}/check-codecov-api.sh"
 
     - name: 📥 Download coverage artifacts
-      if: steps.codecov-api.outcome == 'skipped' || steps.codecov-api.outputs.resolved != 'true'
+      if: steps.coverable.outputs.coverable == 'true' && steps.codecov-check.outputs.resolved != 'true' && (steps.codecov-api.outcome == 'skipped' || steps.codecov-api.outputs.resolved != 'true')
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         pattern: "*coverage*"
         path: coverage-artifacts
 
-    - name: 🛡️ Compute patch coverage locally
-      if: steps.codecov-api.outcome == 'skipped' || steps.codecov-api.outputs.resolved != 'true'
+    # Source 3: computed here from the archived reports. Deterministic and always
+    # scoped to this diff, but not identical to Codecov, so it is the last resort.
+    - name: 3️⃣ Compute patch coverage locally
+      if: steps.coverable.outputs.coverable == 'true' && steps.codecov-check.outputs.resolved != 'true' && (steps.codecov-api.outcome == 'skipped' || steps.codecov-api.outputs.resolved != 'true')
       shell: bash
       env:
         BASE_REF: ${{ inputs.base-ref }}
-        FAIL_UNDER: ${{ inputs.fail-under }}
       run: bash "${{ github.action_path }}/compute-local-patch-coverage.sh"

--- a/.github/actions/patch-coverage-gate/check-codecov-api.sh
+++ b/.github/actions/patch-coverage-gate/check-codecov-api.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
-# Polls the Codecov API for the pull request's patch coverage and enforces it.
+# Source 2 of 3: Codecov's public compare API, used when the codecov/patch check
+# run produced no verdict.
+#
+# This is Codecov's data but not Codecov's verdict: the API's patch totals cover
+# base_commit..head, and base_commit is the newest ancestor Codecov holds a
+# report for rather than where the branch was cut, so the range can be wider
+# than the pull request. When that is the case the difference is reported rather
+# than hidden, because this source only runs when the check run gave nothing and
+# the alternative is a purely local number.
 #
 # Environment:
-#   PR_NUMBER, HEAD_SHA, FAIL_UNDER  - provided by the composite action
+#   PR_NUMBER, HEAD_SHA, BASE_REF      - provided by the composite action
+#   FAIL_UNDER                         - from read-codecov-config.sh
 #   GITHUB_REPOSITORY, GITHUB_OUTPUT, GITHUB_STEP_SUMMARY - provided by the runner
 #
-# Sets the step output resolved=true when Codecov's number was authoritative
-# (pass or fail). Exits 0 with resolved=false when Codecov cannot be trusted
-# in time, so the caller falls back to the local computation. A fetch or parse
-# failure never passes the gate.
+# Sets resolved=true when Codecov's number was authoritative (pass or fail).
+# Exits 0 with resolved=false when it cannot be trusted in time, so the caller
+# computes patch coverage locally. A fetch or parse failure never passes.
 
 set -euo pipefail
+
+SOURCE="Codecov compare API"
+SOURCE_LABEL="Codecov's compare API (fallback 1 of 2; the codecov/patch check run gave no verdict)"
 
 # Number of coverage uploads in a complete report; mirrors notify.after_n_builds
 # in codecov.yml. Codecov processes uploads incrementally, and a comparison
@@ -27,53 +38,61 @@ API="https://api.codecov.io/api/v2/github/${OWNER}/repos/${REPO}"
 
 echo "resolved=false" >> "$GITHUB_OUTPUT"
 
+if [ -z "${PR_NUMBER:-}" ]; then
+  echo "⚠️ No pull request to compare through; computing patch coverage locally." | tee -a "$GITHUB_STEP_SUMMARY"
+  exit 0
+fi
+
 for attempt in $(seq 1 "$POLL_ATTEMPTS"); do
   PROCESSED=$(curl -sf --max-time "$CURL_MAX_TIME" "${API}/commits/${HEAD_SHA}" \
     | jq -r --argjson n "$REQUIRED_SESSIONS" \
         'select((.totals.sessions // 0) >= $n) | .totals.coverage // empty' || true)
   if [ -n "$PROCESSED" ]; then
-    # The head report is fully processed; read patch coverage from the
-    # comparison. A fetch or parse failure here must NOT pass the gate:
-    # leave it unresolved so the local computation runs instead.
     COMPARE=$(curl -sf --max-time "$CURL_MAX_TIME" "${API}/compare/?pullid=${PR_NUMBER}") || COMPARE=""
     if [ -z "$COMPARE" ]; then
-      echo "⚠️ Could not fetch the Codecov comparison; falling back to local patch coverage." | tee -a "$GITHUB_STEP_SUMMARY"
+      echo "⚠️ Could not fetch the Codecov comparison; computing patch coverage locally." | tee -a "$GITHUB_STEP_SUMMARY"
       exit 0
     fi
-    # Validate the comparison is structurally complete before interpreting
-    # missing patch data: totals.patch is also null when the head report has
-    # not been incorporated yet, and an error payload has no totals at all.
-    # Only a comparison whose head totals are present can be trusted to mean
-    # "no coverable lines"; anything else falls back to the local computation.
+    # totals.patch is also null when the head report has not been incorporated
+    # yet, and an error payload has no totals at all. Only a comparison whose
+    # head totals are present can be read as "no coverable lines".
     HEAD_INCLUDED=$(printf '%s' "$COMPARE" | jq -r 'if (.totals != null) and (.totals.head != null) then "yes" else "no" end' 2>/dev/null) || HEAD_INCLUDED="no"
     if [ "$HEAD_INCLUDED" != "yes" ]; then
-      echo "⚠️ Incomplete Codecov comparison response; falling back to local patch coverage." | tee -a "$GITHUB_STEP_SUMMARY"
+      echo "⚠️ Incomplete Codecov comparison response; computing patch coverage locally." | tee -a "$GITHUB_STEP_SUMMARY"
       exit 0
     fi
+
+    # Report, but do not hide, a comparison range wider than this branch.
+    CODECOV_BASE=$(printf '%s' "$COMPARE" | jq -r '.base_commit // empty' 2>/dev/null) || CODECOV_BASE=""
+    MERGE_BASE=$(git merge-base "$BASE_REF" "$HEAD_SHA" 2>/dev/null) || MERGE_BASE=""
+    if [ -n "$CODECOV_BASE" ] && [ -n "$MERGE_BASE" ] && [ "$CODECOV_BASE" != "$MERGE_BASE" ]; then
+      echo "ℹ️ Codecov compared against ${CODECOV_BASE:0:8} while this branch was cut at ${MERGE_BASE:0:8}, so its total covers a wider range of commits." | tee -a "$GITHUB_STEP_SUMMARY"
+    fi
+
     PATCH=$(printf '%s' "$COMPARE" | jq -r '.totals.patch.coverage' 2>/dev/null) || PATCH=""
     PATCH_LINES=$(printf '%s' "$COMPARE" | jq -r '.totals.patch.lines // 0' 2>/dev/null) || PATCH_LINES="0"
-    # A diff with no coverable lines (comment/config/CI-only changes) has nothing
-    # to gate. Codecov signals this either as coverage null or as coverage 0 with
-    # zero patch lines.
+    # A diff with no coverable lines has nothing to gate. Codecov signals this
+    # either as coverage null or as coverage 0 with zero patch lines.
     if [ "$PATCH" = "null" ] || [ "$PATCH_LINES" = "0" ]; then
       echo "resolved=true" >> "$GITHUB_OUTPUT"
-      echo "✅ Codecov reports no coverable lines in this diff." | tee -a "$GITHUB_STEP_SUMMARY"
+      echo "✅ Patch coverage passed. Source: ${SOURCE_LABEL}. No coverable lines in this diff." | tee -a "$GITHUB_STEP_SUMMARY"
       exit 0
     fi
     if ! printf '%s' "$PATCH" | grep -qE '^[0-9]+(\.[0-9]+)?$'; then
-      echo "⚠️ Unexpected Codecov comparison response; falling back to local patch coverage." | tee -a "$GITHUB_STEP_SUMMARY"
+      echo "⚠️ Unexpected Codecov comparison response; computing patch coverage locally." | tee -a "$GITHUB_STEP_SUMMARY"
       exit 0
     fi
+
     echo "resolved=true" >> "$GITHUB_OUTPUT"
-    echo "Codecov patch coverage: ${PATCH}% (required: ≥ ${FAIL_UNDER}%)" | tee -a "$GITHUB_STEP_SUMMARY"
-    awk -v patch="$PATCH" -v threshold="$FAIL_UNDER" 'BEGIN{exit !(patch + 0 >= threshold + 0)}' || {
-      echo "❌ Patch coverage is below the required threshold." | tee -a "$GITHUB_STEP_SUMMARY"
-      exit 1
-    }
-    exit 0
+    if awk -v patch="$PATCH" -v threshold="$FAIL_UNDER" 'BEGIN{exit !(patch + 0 >= threshold + 0)}'; then
+      echo "✅ Patch coverage passed. Source: ${SOURCE_LABEL}. ${PATCH}% of ${PATCH_LINES} lines (required: ≥ ${FAIL_UNDER}%)" | tee -a "$GITHUB_STEP_SUMMARY"
+      exit 0
+    fi
+    echo "❌ Patch coverage failed. Source: ${SOURCE_LABEL}. ${PATCH}% of ${PATCH_LINES} lines (required: ≥ ${FAIL_UNDER}%)" | tee -a "$GITHUB_STEP_SUMMARY"
+    exit 1
   fi
-  echo "Codecov has not fully processed the report yet (attempt ${attempt}/${POLL_ATTEMPTS}); retrying in ${POLL_INTERVAL_SECONDS}s..."
+  echo "${SOURCE} has not fully processed the report yet (attempt ${attempt}/${POLL_ATTEMPTS}); retrying in ${POLL_INTERVAL_SECONDS}s..."
   sleep "$POLL_INTERVAL_SECONDS"
 done
 
-echo "⚠️ Codecov did not process the report in time; falling back to local patch coverage." | tee -a "$GITHUB_STEP_SUMMARY"
+echo "⚠️ ${SOURCE} did not process the report after ${POLL_ATTEMPTS} attempts; computing patch coverage locally." | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/patch-coverage-gate/compute-local-patch-coverage.sh
+++ b/.github/actions/patch-coverage-gate/compute-local-patch-coverage.sh
@@ -9,12 +9,15 @@
 # and no third-party converters are needed.
 #
 # Environment:
-#   BASE_REF, FAIL_UNDER  - provided by the composite action
-#   GITHUB_STEP_SUMMARY   - provided by the runner
+#   BASE_REF                                - provided by the composite action
+#   FAIL_UNDER, CODECOV_IGNORE_FILE         - from read-codecov-config.sh
+#   GITHUB_STEP_SUMMARY                     - provided by the runner
 #
 # Expects the coverage artifacts to be downloaded under coverage-artifacts/.
 
 set -euo pipefail
+
+SOURCE_LABEL="computed here by diff-cover from the coverage artifacts (fallback 2 of 2; Codecov reported nothing)"
 
 DIFF_COVER_VERSION="10.4.0"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -43,25 +46,40 @@ for app in console gate; do
 done
 
 if [ "${#FILES[@]}" -eq 0 ]; then
-  # Fail rather than pass silently when coverable code changed but no
-  # coverage data reached the gate; passing would defeat its purpose.
-  COVERABLE=$(git diff --name-only "${BASE_REF}...HEAD" \
-    | { grep -E '^(backend/.*\.go$|frontend/apps/(console|gate)/src/.*\.(ts|tsx)$)' || true; } \
-    | { grep -vE '(^backend/tests/|_test\.go$|\.test\.(ts|tsx)$|__tests__/|__mocks__/)' || true; })
-  if [ -n "$COVERABLE" ]; then
-    echo "❌ Coverable files changed but no coverage artifacts were found." | tee -a "$GITHUB_STEP_SUMMARY"
-    exit 1
-  fi
-  echo "✅ No coverage artifacts and no coverable changes; nothing to gate." | tee -a "$GITHUB_STEP_SUMMARY"
-  exit 0
+  # This source only runs when the diff was found to contain files that report
+  # coverage, so missing artifacts mean the measurement went missing rather than
+  # that there was nothing to measure. Passing here would defeat the gate.
+  echo "❌ Patch coverage failed. Source: ${SOURCE_LABEL}. Files that report coverage changed, but no coverage artifacts reached the gate." | tee -a "$GITHUB_STEP_SUMMARY"
+  exit 1
+fi
+
+# The excluded paths come from codecov.yml's ignore list, so a line that Codecov
+# would count is never dropped here.
+EXCLUDES=()
+while IFS= read -r glob; do
+  [ -n "$glob" ] || continue
+  EXCLUDES+=("$glob")
+done < "$CODECOV_IGNORE_FILE"
+# --exclude takes all of its patterns as one flag, so build the flag only when
+# there is at least one; a bare --exclude would be a usage error.
+EXCLUDE_ARGS=()
+if [ "${#EXCLUDES[@]}" -gt 0 ]; then
+  EXCLUDE_ARGS=(--exclude "${EXCLUDES[@]}")
 fi
 
 STATUS=0
 diff-cover "${FILES[@]}" \
   --compare-branch "$BASE_REF" \
   --fail-under "$FAIL_UNDER" \
-  --exclude 'backend/tests/**' '**/*_test.go' 'tests/**' 'samples/**' 'docs/**' 'api/**' \
-            '**/*.test.ts' '**/*.test.tsx' '**/__tests__/**' '**/__mocks__/**' \
+  "${EXCLUDE_ARGS[@]}" \
   --format markdown:patch-coverage.md || STATUS=$?
+
+# Named explicitly because this number is computed here rather than reported by
+# Codecov, and the two are close but not identical.
+if [ "$STATUS" -eq 0 ]; then
+  echo "✅ Patch coverage passed. Source: ${SOURCE_LABEL} (required: ≥ ${FAIL_UNDER}%)" | tee -a "$GITHUB_STEP_SUMMARY"
+else
+  echo "❌ Patch coverage failed. Source: ${SOURCE_LABEL} (required: ≥ ${FAIL_UNDER}%)" | tee -a "$GITHUB_STEP_SUMMARY"
+fi
 cat patch-coverage.md >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
 exit "$STATUS"

--- a/.github/actions/patch-coverage-gate/list-coverable-changes.sh
+++ b/.github/actions/patch-coverage-gate/list-coverable-changes.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Lists the changed files that could contribute lines to patch coverage, so the
+# gate can tell a diff worth measuring from one where no source has anything to
+# report.
+#
+# Both halves of the question come from codecov.yml rather than from a list kept
+# here: flags[].paths is the repository's own declaration of which trees upload
+# coverage, and ignore is what Codecov drops. Deriving them means a new flag or
+# a new ignore is picked up automatically instead of silently short-circuiting
+# the gate.
+#
+# Deliberately errs towards listing a file. A path that turns out to carry no
+# coverable lines (a README under a covered tree, a test file no provider
+# instruments) simply produces "no coverable lines" from whichever source runs,
+# which passes. Wrongly omitting a file would pass the gate without measuring
+# anything, so the filter stays broad.
+#
+# Environment:
+#   BASE_REF                                        - diff base
+#   CODECOV_FLAG_PATHS_FILE, CODECOV_IGNORE_FILE    - from read-codecov-config.sh
+#
+# Prints one path per line; prints nothing when the diff cannot affect coverage.
+
+set -euo pipefail
+
+for var in CODECOV_FLAG_PATHS_FILE CODECOV_IGNORE_FILE; do
+  if [ -z "${!var:-}" ]; then
+    echo "❌ $var is not set; read-codecov-config.sh must run before this script." >&2
+    exit 1
+  fi
+done
+
+git diff --name-only "${BASE_REF}...HEAD" \
+  | python3 -c '
+import fnmatch, os, sys
+
+def load(path):
+    with open(path) as handle:
+        return [line.strip() for line in handle if line.strip()]
+
+covered = load(os.environ["CODECOV_FLAG_PATHS_FILE"])
+ignored = load(os.environ["CODECOV_IGNORE_FILE"])
+
+def matches(path, pattern):
+    # Codecov path entries are either a directory prefix or a glob.
+    if fnmatch.fnmatch(path, pattern):
+        return True
+    prefix = pattern if pattern.endswith("/") else pattern + "/"
+    return path.startswith(prefix)
+
+for path in (line.strip() for line in sys.stdin):
+    if not path:
+        continue
+    if not any(matches(path, pattern) for pattern in covered):
+        continue
+    if any(matches(path, pattern) for pattern in ignored):
+        continue
+    print(path)
+'

--- a/.github/actions/patch-coverage-gate/mirror-codecov-check.sh
+++ b/.github/actions/patch-coverage-gate/mirror-codecov-check.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Source 1 of 3: the codecov/patch check run.
+#
+# Codecov reports patch coverage as a check run, and that check run is the
+# verdict Codecov gates on. It is not the same measurement as the compare API
+# used by source 2: on PR #4404 the check run reported "coverage not affected"
+# while the API reported 76.74%, and on PR #4003 the check run failed at 67.32%
+# while the API reported 87.75%. Mirroring the check run is therefore the only
+# way for this gate to agree with Codecov.
+#
+# A verdict from Codecov is final: a failure here fails the gate rather than
+# falling through to a more lenient source. Only the absence of a verdict
+# (Codecov still pending, or never reporting) hands over to source 2.
+#
+# Environment:
+#   HEAD_SHA, GH_TOKEN, GITHUB_REPOSITORY - provided by the composite action
+#   GITHUB_OUTPUT, GITHUB_STEP_SUMMARY    - provided by the runner
+
+set -euo pipefail
+
+SOURCE="codecov/patch check run"
+SOURCE_LABEL="Codecov's own verdict, read from the codecov/patch check run (primary source)"
+CHECK_NAME="codecov/patch"
+# filter=latest is the API default, but pinning it keeps a re-run from returning
+# a superseded check run for the same commit.
+POLL_ATTEMPTS=10
+POLL_INTERVAL_SECONDS=30
+
+echo "resolved=false" >> "$GITHUB_OUTPUT"
+
+for attempt in $(seq 1 "$POLL_ATTEMPTS"); do
+  RUN=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs?check_name=${CHECK_NAME}&filter=latest&per_page=1" 2>/dev/null) || RUN=""
+  STATUS=$(printf '%s' "$RUN" | jq -r '.check_runs[0].status // empty' 2>/dev/null) || STATUS=""
+
+  if [ "$STATUS" = "completed" ]; then
+    CONCLUSION=$(printf '%s' "$RUN" | jq -r '.check_runs[0].conclusion // empty' 2>/dev/null) || CONCLUSION=""
+    TITLE=$(printf '%s' "$RUN" | jq -r '.check_runs[0].output.title // empty' 2>/dev/null) || TITLE=""
+    case "$CONCLUSION" in
+      success|neutral|skipped)
+        echo "resolved=true" >> "$GITHUB_OUTPUT"
+        echo "✅ Patch coverage passed. Source: ${SOURCE_LABEL}. ${TITLE:-$CONCLUSION}" | tee -a "$GITHUB_STEP_SUMMARY"
+        exit 0
+        ;;
+      failure|timed_out|action_required)
+        echo "resolved=true" >> "$GITHUB_OUTPUT"
+        echo "❌ Patch coverage failed. Source: ${SOURCE_LABEL}. ${TITLE:-$CONCLUSION}" | tee -a "$GITHUB_STEP_SUMMARY"
+        exit 1
+        ;;
+      *)
+        # cancelled or stale: Codecov reported no verdict to mirror.
+        echo "⚠️ ${SOURCE} reported '${CONCLUSION:-unknown}' and carries no verdict; trying the Codecov compare API." | tee -a "$GITHUB_STEP_SUMMARY"
+        exit 0
+        ;;
+    esac
+  fi
+
+  echo "${SOURCE} has not reported yet (attempt ${attempt}/${POLL_ATTEMPTS}); retrying in ${POLL_INTERVAL_SECONDS}s..."
+  sleep "$POLL_INTERVAL_SECONDS"
+done
+
+echo "⚠️ ${SOURCE} did not report after ${POLL_ATTEMPTS} attempts; trying the Codecov compare API." | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/patch-coverage-gate/read-codecov-config.sh
+++ b/.github/actions/patch-coverage-gate/read-codecov-config.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Reads the patch coverage threshold and the ignored paths from codecov.yml so
+# the gate enforces exactly what Codecov is configured to enforce. Keeping the
+# numbers in one place means the gate and codecov/patch cannot drift apart when
+# either is retuned.
+#
+# Codecov passes a patch status when coverage is at least target minus
+# threshold, so that difference is the diff-cover --fail-under value.
+#
+# Environment:
+#   CODECOV_CONFIG          - path to codecov.yml (defaults to ./codecov.yml)
+#   GITHUB_ENV, RUNNER_TEMP - provided by the runner
+#
+# Exports for the later steps:
+#   FAIL_UNDER              - target minus threshold
+#   CODECOV_IGNORE_FILE     - the ignore list, normalised for fnmatch
+#   CODECOV_FLAG_PATHS_FILE - every path covered by a coverage flag
+# The two lists go to files rather than variables so the globs are never subject
+# to shell word splitting or filename expansion.
+
+set -euo pipefail
+
+CONFIG="${CODECOV_CONFIG:-codecov.yml}"
+IGNORE_FILE="${RUNNER_TEMP:-/tmp}/codecov-ignore.txt"
+FLAG_PATHS_FILE="${RUNNER_TEMP:-/tmp}/codecov-flag-paths.txt"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "❌ $CONFIG not found; cannot determine the patch coverage threshold."
+  exit 1
+fi
+
+# yq is present on GitHub-hosted runners; fall back to PyYAML so the gate does
+# not depend on a single tool being preinstalled.
+if command -v yq >/dev/null 2>&1; then
+  TARGET=$(yq eval -r '.coverage.status.patch.default.target // ""' "$CONFIG")
+  THRESHOLD=$(yq eval -r '.coverage.status.patch.default.threshold // "0"' "$CONFIG")
+  yq eval -r '.ignore[]?' "$CONFIG" > "$IGNORE_FILE"
+  # Every path any coverage flag covers, deduplicated: this is the repository's
+  # own declaration of which trees report coverage.
+  yq eval -r '[.flags[]?.paths[]?] | unique | .[]' "$CONFIG" > "$FLAG_PATHS_FILE"
+else
+  eval "$(python3 - "$CONFIG" "$IGNORE_FILE" "$FLAG_PATHS_FILE" <<'PY'
+import sys, yaml
+cfg = yaml.safe_load(open(sys.argv[1])) or {}
+patch = ((((cfg.get('coverage') or {}).get('status') or {}).get('patch') or {}).get('default')) or {}
+threshold = patch.get('threshold')
+print("TARGET=%s" % (patch.get('target') or ''))
+print("THRESHOLD=%s" % ('0' if threshold is None else threshold))
+with open(sys.argv[2], 'w') as handle:
+    for glob in (cfg.get('ignore') or []):
+        handle.write("%s\n" % glob)
+paths = []
+for flag in (cfg.get('flags') or {}).values():
+    for path in ((flag or {}).get('paths') or []):
+        if path not in paths:
+            paths.append(path)
+with open(sys.argv[3], 'w') as handle:
+    for path in paths:
+        handle.write("%s\n" % path)
+PY
+)"
+fi
+
+if [ ! -s "$FLAG_PATHS_FILE" ]; then
+  echo "❌ No flags[].paths found in $CONFIG; cannot tell which trees report coverage."
+  exit 1
+fi
+
+# Both values are written as percentages in codecov.yml (e.g. "80%", "1%").
+TARGET="${TARGET%\%}"
+THRESHOLD="${THRESHOLD%\%}"
+
+# "auto" compares against the base commit's coverage, which has no fixed
+# number to enforce locally. Fail loudly rather than invent a threshold.
+if ! printf '%s' "$TARGET" | grep -qE '^[0-9]+(\.[0-9]+)?$'; then
+  echo "❌ Unsupported coverage.status.patch.default.target in $CONFIG: '${TARGET:-<unset>}'"
+  echo "   The gate needs a numeric target (e.g. 80%) to enforce a threshold."
+  exit 1
+fi
+if ! printf '%s' "$THRESHOLD" | grep -qE '^[0-9]+(\.[0-9]+)?$'; then
+  echo "❌ Unsupported coverage.status.patch.default.threshold in $CONFIG: '$THRESHOLD'"
+  exit 1
+fi
+
+# Codecov accepts directory prefixes and regular expressions in `ignore`, while
+# diff-cover matches --exclude patterns with fnmatch. Translate the forms that
+# have an fnmatch equivalent, and say so loudly for the ones that do not: an
+# ignore that fails to apply here makes the local fallback count lines Codecov
+# would drop, which shows up as a stricter number rather than a laxer one.
+NORMALIZED="${IGNORE_FILE}.normalized"
+: > "$NORMALIZED"
+while IFS= read -r pattern; do
+  [ -n "$pattern" ] || continue
+  printf '%s\n' "$pattern" >> "$NORMALIZED"
+  case "$pattern" in
+    # "backend/" ignores everything beneath it; fnmatch needs the wildcard.
+    */) printf '%s**\n' "$pattern" >> "$NORMALIZED" ;;
+    # A bare path with no wildcard and no extension is a directory prefix to
+    # Codecov. Emitting both forms keeps files of that exact name excluded too.
+    *[*?[]*) ;;
+    *.*) ;;
+    *) printf '%s/**\n' "$pattern" >> "$NORMALIZED" ;;
+  esac
+  # The class is single-quoted, which strips the glob meaning of its contents,
+  # so the leading ^ is a literal member here and not a negation operator.
+  case "$pattern" in
+    *['^$()|+\']*)
+      echo "⚠️ codecov.yml ignores '$pattern', which looks like a regular expression."
+      echo "   diff-cover matches with fnmatch, so the local fallback cannot apply it and may report a stricter number than Codecov."
+      ;;
+  esac
+done < "$IGNORE_FILE"
+mv "$NORMALIZED" "$IGNORE_FILE"
+
+FAIL_UNDER=$(awk -v t="$TARGET" -v d="$THRESHOLD" 'BEGIN{printf "%g", t - d}')
+
+{
+  echo "FAIL_UNDER=$FAIL_UNDER"
+  echo "CODECOV_IGNORE_FILE=$IGNORE_FILE"
+  echo "CODECOV_FLAG_PATHS_FILE=$FLAG_PATHS_FILE"
+} >> "$GITHUB_ENV"
+
+echo "Patch coverage target ${TARGET}% with a ${THRESHOLD}% threshold: requiring ≥ ${FAIL_UNDER}%"
+echo "Ignoring $(wc -l < "$IGNORE_FILE" | tr -d ' ') path pattern(s), derived from the ignore list in $CONFIG:"
+sed 's/^/  /' "$IGNORE_FILE"
+echo "Coverage-reporting paths declared by flags in $CONFIG:"
+sed 's/^/  /' "$FLAG_PATHS_FILE"

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -618,8 +618,9 @@ jobs:
     name: 🛡️ Patch Coverage Gate
     # Deterministic patch coverage check that always reports, unlike the external
     # codecov/patch status which can hang at "Expected" (fork PRs, merge queue
-    # commits, Codecov processing stalls). Mirrors coverage.status.patch.default
-    # in codecov.yml (target 80%, threshold 1%). The enforcement logic lives in
+    # commits, Codecov processing stalls). The threshold and the ignored paths are
+    # read from codecov.yml, so this enforces the same rules as codecov/patch
+    # without a second copy of them here. The enforcement logic lives in
     # .github/actions/patch-coverage-gate.
     needs: [build, test-backend-unit, test-integration, test-frontend-console-app, test-frontend-gate-app, upload-frontend-coverage]
     if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.build.result == 'success' && needs.test-backend-unit.result == 'success' && needs.test-integration.result == 'success' && needs.test-frontend-console-app.result == 'success' && needs.test-frontend-gate-app.result == 'success' && needs.upload-frontend-coverage.result == 'success' }}
@@ -627,6 +628,8 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
+      pull-requests: read
+      checks: read
     steps:
       - name: 📥 Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -634,12 +637,53 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # Codecov never processes merge queue commits, so a queue entry is compared
+      # through the pull request it was created from: the queue commit carries
+      # that same diff rebased onto main. The pull request number is embedded in
+      # the queue ref, and its head commit already has a fully processed Codecov
+      # report from the pull request run. Leaving the outputs empty makes the gate
+      # compute patch coverage locally, which is what queue runs did before.
+      # On merge queue runs the commit under test is not the commit Codecov
+      # reported on, so the codecov/patch check run is read from the head of the
+      # pull request the queue entry was created from. The queue commit carries
+      # that same diff rebased onto main, which is the premise the
+      # codecov-merge-queue-status job already relies on.
+      - name: 🔢 Resolve the commit whose codecov/patch verdict applies
+        id: codecov-target
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # refs/heads/gh-readonly-queue/<base>/pr-<number>-<base sha>
+          QUEUE_REF: ${{ github.event.merge_group.head_ref }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            echo "pr-number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+            echo "head-sha=$PR_HEAD_SHA" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PR=$(printf '%s' "$QUEUE_REF" | sed -nE 's|.*/pr-([0-9]+)-[0-9a-f]+$|\1|p')
+          if [ -z "$PR" ]; then
+            echo "⚠️ No pull request number in '$QUEUE_REF'; computing patch coverage locally."
+            exit 0
+          fi
+          SHA=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}" --jq '.head.sha' 2>/dev/null || true)
+          if [ -z "$SHA" ]; then
+            echo "⚠️ Could not resolve the head commit of PR #${PR}; computing patch coverage locally."
+            exit 0
+          fi
+          echo "Comparing through PR #${PR} (head ${SHA})"
+          echo "pr-number=$PR" >> "$GITHUB_OUTPUT"
+          echo "head-sha=$SHA" >> "$GITHUB_OUTPUT"
+
       - name: 🛡️ Enforce Patch Coverage
         uses: ./.github/actions/patch-coverage-gate
         with:
-          fail-under: "79"
-          pr-number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
-          head-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          github-token: ${{ github.token }}
+          pr-number: ${{ steps.codecov-target.outputs.pr-number }}
+          head-sha: ${{ steps.codecov-target.outputs.head-sha || github.sha }}
           base-ref: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || format('origin/{0}', github.base_ref) }}
 
   build_samples:


### PR DESCRIPTION
### Purpose

On #4404 the gate failed at 76.74% while `codecov/patch` passed with "Coverage not affected". Two verdicts for one diff is not acceptable, and the cause was that the gate read Codecov's **compare API** while `codecov/patch` reports from a **check run**. Those are different measurements:

| PR | codecov/patch check run | compare API (what the gate read) |
|---|---|---|
| 4404 | success, "Coverage not affected" | 76.74% → gate failed |
| 4003 | **failure, 67.32%** | 87.75% → gate passed |
| 4371 | success, 91.70% | 93.58% |
| 4318 | success, 94.11% | 97.05% |

Refs #4268.

### Approach

Patch coverage is now resolved from the most authoritative source available, in order, and every message names the source it came from.

**Source 1: the `codecov/patch` check run.** `mirror-codecov-check.sh` polls the check run for the commit and returns Codecov's own conclusion, echoing its summary line ("91.70% of diff hit (target 80.00%)"). When Codecov reports, the gate is identical to Codecov by construction, because it is Codecov's verdict.

A verdict is final. A failure here fails the gate rather than continuing to a more lenient source, otherwise a pull request Codecov rejected could pass on a fallback. Only the *absence* of a verdict after ten 30-second polls, or a cancelled or stale check, continues to source 2.

**Source 2: the Codecov compare API.** `check-codecov-api.sh` waits for a complete report (six sessions, matching `notify.after_n_builds`) and enforces its patch total. It is still Codecov's data, so it is preferred over computing locally, but it is a different measurement from the check run, so it is only consulted when there is no verdict to mirror. When its comparison base is not this branch's merge base, the range difference is reported in the summary rather than hidden.

**Source 3: local computation.** `compute-local-patch-coverage.sh` runs diff-cover over the archived coverage artifacts, pinned to this diff's base. Deterministic and always correctly scoped, but not identical to Codecov, so it is the last resort. It exists because Codecov does not always report at all: fork pull requests, merge queue commits and processing stalls leave the check pending indefinitely, which is why this gate was written.

**Before any source runs**, `list-coverable-changes.sh` checks whether the diff can affect coverage at all. If no file that reports coverage changed, the gate passes immediately without polling Codecov, and says so.

**Rules come from codecov.yml.** The threshold was hardcoded as `fail-under: "79"` in the workflow and the ignored paths were hardcoded again in the gate script. `read-codecov-config.sh` now derives `FAIL_UNDER` from `coverage.status.patch.default.target` minus `.threshold`, which is when Codecov passes a patch status, and feeds `ignore` to `diff-cover --exclude`. Globs travel via a file so they are never word split or filename expanded. It prefers `yq` and falls back to PyYAML, mirroring how `build.sh` reads YAML, and fails loudly on a non-numeric target such as `auto`.

**Merge queue runs** read the verdict from the head of the pull request the queue entry came from, taken out of the queue ref, because the queue commit is not what Codecov reported on. That is the premise `codecov-merge-queue-status` already relies on.

### How #4404 behaves now

Its `codecov/patch` check run is `success` with "Coverage not affected when comparing 54a4882...045dbe1". Source 1 mirrors that and the gate passes, matching Codecov instead of contradicting it.

Worth being explicit about the consequence: parity means inheriting Codecov's leniency. #4404 adds 578 lines and Codecov considers coverage unaffected, so the gate now passes it where the old compare-API number would have failed it. If untested new code should be blocked, that is a stricter policy than parity with `codecov/patch` and needs a separate decision.

### Verification

The source chain was simulated against the composite's real `if` expressions: no coverable files runs nothing; a source 1 verdict runs source 1 only; a silent source 1 continues to source 2; a silent source 2 downloads artifacts and computes locally. A failing verdict from source 1 or 2 exits non-zero and stops the composite.

The query source 1 issues was run against #4404's head commit and returns `success` with Codecov's title, so the gate would pass that pull request. Against the real `codecov.yml` the reader derives `FAIL_UNDER=79` (80 − 1) and the same six globs that were hardcoded, so the fallback's rules are unchanged; `target: auto` and a missing file exit 1 with a clear message, and a missing `threshold` defaults to 0. The chain was exercised against `diff-cover==10.4.0` in a scratch repository: the globs arrive as one `--exclude` flag with the patterns intact, the derived threshold is enforced, and a change under `docs/` is ignored.

On the accuracy of source 3: replaying PR 4371's six real coverage artifacts through the gate's own conversion and diff-cover invocation, against that pull request's actual merge base, gives 93.08% (242 of 260 lines) where `codecov/patch` reports 91.70%. The uncovered count matches Codecov exactly (35 lines = 25 misses + 10 partials) when scoped to Codecov's own base, so the coverage math agrees; the residual gap is in which lines reach the denominator, most likely partial-line handling. That gap is the reason source 3 is last, and the reason the summary always names the source.

### Related Issues
- Refs #4268

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
