### PR TITLE
Add MCP client quickstart guides and sample app

### DIFF
--- a/docs/content/getting-started/connect-your-mcp/client/_category_.json
+++ b/docs/content/getting-started/connect-your-mcp/client/_category_.json
@@ -1,0 +1,5 @@
+{
+  "position": 2,
+  "label": "Client",
+  "collapsible": true
+}

--- a/docs/content/getting-started/connect-your-mcp/client/build-a-client/_category_.json
+++ b/docs/content/getting-started/connect-your-mcp/client/build-a-client/_category_.json
@@ -1,0 +1,5 @@
+{
+  "position": 2,
+  "label": "Build an MCP Client",
+  "collapsible": true
+}

--- a/docs/content/getting-started/connect-your-mcp/client/build-a-client/python.mdx
+++ b/docs/content/getting-started/connect-your-mcp/client/build-a-client/python.mdx
@@ -1,0 +1,176 @@
+---
+toc_progress: quickstart
+title: Build an MCP Client
+docType: quickstart
+sidebar_position: 1
+persona: app
+description: Build a Python MCP client that uses OAuth 2.0 authorization to obtain access to a {{ProductName}}-protected MCP server and call scope-protected tools.
+---
+
+import {
+  FileCode,
+  KeyRound,
+  ListChecks,
+  Clock,
+  Terminal,
+} from '@wso2/oxygen-ui-icons-react';
+
+# Build an MCP Client
+
+Use this guide to build a Python MCP client that obtains authorization to call the Calculator server you secured in [Secure Your MCP Server](../../../server/python), using FastMCP's `OAuth` helper to handle discovery, registration, and token exchange for you, then calls its scope-protected tools.
+
+<TutorialHero>
+
+## What You Will Learn
+
+<TutorialHeroItem icon={<FileCode />}>Build a single-file OAuth-capable MCP client with FastMCP</TutorialHeroItem>
+<TutorialHeroItem icon={<KeyRound />}>Understand what FastMCP's <code>OAuth</code> helper automates: RFC 9728 discovery, Dynamic Client Registration, the Authorization Code flow with PKCE, a local callback server, and token caching</TutorialHeroItem>
+<TutorialHeroItem icon={<ListChecks />}>Call scope-protected tools on the Calculator server from your own client code</TutorialHeroItem>
+
+## Prerequisites
+
+<TutorialHeroItem icon={<Clock />}>About 10 minutes</TutorialHeroItem>
+<TutorialHeroItem icon={<ListChecks />}>Completed Secure Your MCP Server, with the Calculator server registered and runnable, and <code>thunderid.cert</code> exported (see "Didn't build the server yet?" below if not)</TutorialHeroItem>
+<TutorialHeroItem icon={<Terminal />}><code>uv</code>, which manages Python and dependencies automatically</TutorialHeroItem>
+
+</TutorialHero>
+
+:::info Didn't build the server yet?
+Clone <RepoLink path="/tree/main/samples/apps/mcp-calculator-sample">the Calculator MCP Sample</RepoLink>, follow the certificate export and `.env` setup in [Secure Your MCP Server](../../../server/python), then start the server with `uv run server.py` from `samples/apps/mcp-calculator-sample/server/`. Once it's listening at `http://localhost:8000/mcp`, continue below.
+:::
+
+<Stepper stepNode="h2" as="h2">
+
+## Enable Dynamic Client Registration
+
+The client you build in this guide registers itself automatically the first time it runs, using Dynamic Client Registration (DCR), so enable DCR before you create it. Add the following to `deployment.yaml` in your <ProductName /> distribution:
+
+```yaml
+oauth:
+  dcr:
+    enabled: true
+    insecure: true
+```
+
+:::warning
+`insecure: true` lets anyone who can reach the server register OAuth clients without authentication. Use it for local development only.
+:::
+
+Restart <ProductName /> after saving the file.
+
+If you want to confirm DCR is open before running the client, see the optional verification probe in [Claude Code](../../connect/claude-code#enable-dynamic-client-registration).
+
+## Create the Client
+
+This client assumes the same layout as the sample: a `client` directory next to the `server` directory that holds `server.py` and the `thunderid.cert` you exported earlier. Create a `client` directory alongside your server's directory, and create `client.py` inside it:
+
+```python title="client.py" showLineNumbers
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["fastmcp>=3.4,<4"]
+# ///
+"""OAuth-authenticated client for the Calculator MCP server."""
+
+import asyncio
+from pathlib import Path
+
+from fastmcp import Client
+from fastmcp.client.auth import FileTreeStore, OAuth
+
+MCP_URL = "http://localhost:8000/mcp"
+THUNDERID_CA_CERT = "../server/thunderid.cert"
+TOKEN_CACHE_DIR = Path(__file__).parent / ".mcp-oauth-cache"
+CALLBACK_PORT = 52360
+
+oauth = OAuth(
+    mcp_url=MCP_URL,
+    token_storage=FileTreeStore(data_directory=TOKEN_CACHE_DIR),
+    callback_port=CALLBACK_PORT,
+)
+
+
+async def main() -> None:
+    async with Client(MCP_URL, auth=oauth, verify=THUNDERID_CA_CERT) as client:
+        tools = await client.list_tools()
+        print("Tools:", sorted(tool.name for tool in tools))
+
+        result = await client.call_tool("add", {"a": 7, "b": 5})
+        print("add(7, 5) =", result.data)
+
+        result = await client.call_tool("divide", {"a": 10, "b": 4})
+        print("divide(10, 4) =", result.data)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+The `# /// script` header is inline script metadata (PEP 723), the same mechanism `server.py` uses. `uv run client.py` reads it and resolves `fastmcp` automatically, in an isolated environment, so there's no separate `pip install` step.
+
+FastMCP's `OAuth` helper does the OAuth work for you:
+
+- On the first connection, it fetches the server's RFC 9728 protected-resource metadata to discover <ProductName /> as the authorization server, then registers itself as a new OAuth application named "FastMCP Client" through Dynamic Client Registration. <ProductName /> issues client credentials as part of that registration, and FastMCP stores them in its local cache.
+- It opens the system browser for an Authorization Code flow with PKCE, using a local callback server pinned to `CALLBACK_PORT = 52360`. <ProductName /> exact-matches registered redirect URIs, so the callback port must stay the same on every run, unlike the SDK's default of a new random port per run. If port `52360` is already in use on your machine, the callback server fails to bind.
+- Neither `OAuth` nor `client.py` passes an explicit `scopes` argument. The scope comes from the Calculator server's advertised `scopes_supported`, so the authorization request ends up asking for all four calculator scopes automatically. It also carries a `resource` parameter that pins the token to this MCP server (RFC 8707).
+- `token_storage=FileTreeStore(data_directory=TOKEN_CACHE_DIR)` persists the registered client's info and the issued tokens to `client/.mcp-oauth-cache/`, so later runs reuse them instead of registering again, or asking you to sign in again while the cached token is still valid. The cache is plaintext JSON on disk, an acceptable trade-off for a local quickstart, and it's gitignored.
+- `Client(MCP_URL, auth=oauth, verify=THUNDERID_CA_CERT)` trusts <ProductName />'s self-signed certificate for every TLS call the client makes: OAuth discovery, Dynamic Client Registration, the token exchange, and the MCP calls themselves.
+
+## Run and Sign In
+
+Run the client from the `client` directory:
+
+```bash
+uv run client.py
+```
+
+Don't set `SSL_CERT_FILE`. `uv` itself honors that variable while it resolves `fastmcp` from PyPI, and it then fails to verify `pypi.org` against <ProductName />'s certificate. The client trusts <ProductName />'s certificate through `Client(..., verify=THUNDERID_CA_CERT)` instead, so no environment variable is needed.
+
+On the first run, a browser tab opens with <ProductName />'s sign-in page. Sign in with your test user, and the client completes the OAuth flow and calls the tools:
+
+```text
+Tools: ['add', 'divide', 'multiply', 'subtract']
+add(7, 5) = 12.0
+divide(10, 4) = 2.5
+```
+
+:::note Troubleshooting
+If you delete `.mcp-oauth-cache/` while the "FastMCP Client" application still exists in the Console, the next run fails with `Registration failed: 400 invalid_client_metadata "An application with the same name already exists"`; delete that application in the Console and run again.
+:::
+
+If your deployment doesn't allow Dynamic Client Registration, you can skip it by passing a pre-registered `client_id` (and optional `client_secret`) to `OAuth(...)` instead, from an MCP Client application you register the same way as [Register an MCP Client for Inspector](../../../server/python#register-an-mcp-client-for-inspector). One difference: under **Redirect URIs**, set `http://localhost:52360/callback` instead of Inspector's `http://localhost:6274/oauth/callback`, since this client's callback server is pinned to `CALLBACK_PORT = 52360`.
+
+:::tip Success
+Run `uv run client.py` a second time. It skips the browser while the cached access token is still valid, about an hour by default, because the client reuses the client registration and tokens stored in `.mcp-oauth-cache/`. Once that token expires, the client opens the browser again to sign in. To see scope enforcement in action, try the scope experiment in [Connect with MCP Inspector](../../../server/python#connect-with-mcp-inspector): remove a scope from a token and watch the matching tool disappear from the list.
+:::
+
+</Stepper>
+
+## What's Next
+
+<div style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: '1rem', marginTop: '1.5rem'}}>
+  <a href="../../connect/mcp-inspector" style={{textDecoration: 'none', color: 'inherit'}}>
+    <div style={{border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '10px', padding: '1.25rem', cursor: 'pointer'}}>
+      <div style={{fontSize: '1rem', fontWeight: '700', marginBottom: '0.4rem'}}>MCP Inspector</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-emphasis-700)', marginBottom: '0.75rem'}}>Connect MCP Inspector to the same server, and see scope enforcement from Inspector's seat.</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-primary)', fontWeight: 600}}>Connect MCP Inspector →</div>
+    </div>
+  </a>
+  <a href="../../connect/claude-code" style={{textDecoration: 'none', color: 'inherit'}}>
+    <div style={{border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '10px', padding: '1.25rem', cursor: 'pointer'}}>
+      <div style={{fontSize: '1rem', fontWeight: '700', marginBottom: '0.4rem'}}>Claude Code</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-emphasis-700)', marginBottom: '0.75rem'}}>Connect Claude Code to the same server using Dynamic Client Registration.</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-primary)', fontWeight: 600}}>Connect Claude Code →</div>
+    </div>
+  </a>
+  <a href="../../../../../use-cases/ai-agents/mcp-authorization/overview" style={{textDecoration: 'none', color: 'inherit'}}>
+    <div style={{border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '10px', padding: '1.25rem', cursor: 'pointer'}}>
+      <div style={{fontSize: '1rem', fontWeight: '700', marginBottom: '0.4rem'}}>Securing MCP</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-emphasis-700)', marginBottom: '0.75rem'}}>Authorization patterns for MCP servers, audience binding, and AuthZEN policy decisions.</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-primary)', fontWeight: 600}}>MCP Authorization →</div>
+    </div>
+  </a>
+</div>
+
+:::tip Example Source Code
+Check out the complete <RepoLink path="/tree/main/samples/apps/mcp-calculator-sample">Calculator MCP Sample</RepoLink> in the <ProductName /> repository.
+:::

--- a/docs/content/getting-started/connect-your-mcp/client/connect/_category_.json
+++ b/docs/content/getting-started/connect-your-mcp/client/connect/_category_.json
@@ -1,0 +1,5 @@
+{
+  "position": 1,
+  "label": "Connect an MCP Client",
+  "collapsible": true
+}

--- a/docs/content/getting-started/connect-your-mcp/client/connect/claude-code.mdx
+++ b/docs/content/getting-started/connect-your-mcp/client/connect/claude-code.mdx
@@ -1,0 +1,155 @@
+---
+toc_progress: quickstart
+title: Claude Code
+docType: quickstart
+sidebar_position: 2
+persona: app
+description: Connect Claude Code to a {{ProductName}}-protected MCP server using Dynamic Client Registration.
+---
+
+import {
+  Plug,
+  KeyRound,
+  ScanEye,
+  Clock,
+  ListChecks,
+  Bot,
+} from '@wso2/oxygen-ui-icons-react';
+
+# Claude Code
+
+Use this guide to connect Claude Code to the Calculator server you secured in [Secure Your MCP Server](../../../server/python), using Dynamic Client Registration (DCR) so Claude Code registers itself as an OAuth client automatically.
+
+<TutorialHero>
+
+## What You Will Learn
+
+<TutorialHeroItem icon={<Plug />}>Connect Claude Code to the scope-protected Calculator server</TutorialHeroItem>
+<TutorialHeroItem icon={<KeyRound />}>Enable Dynamic Client Registration so Claude Code registers its own OAuth client</TutorialHeroItem>
+<TutorialHeroItem icon={<ScanEye />}>See scope enforcement from Claude Code's seat</TutorialHeroItem>
+
+## Prerequisites
+
+<TutorialHeroItem icon={<Clock />}>About 5 minutes</TutorialHeroItem>
+<TutorialHeroItem icon={<ListChecks />}>Completed Secure Your MCP Server: the Calculator server registered and runnable, and <code>thunderid.cert</code> exported</TutorialHeroItem>
+<TutorialHeroItem icon={<Bot />}>Claude Code installed</TutorialHeroItem>
+
+</TutorialHero>
+
+<Stepper stepNode="h2" as="h2">
+
+## Run <ProductName /> and the Calculator Server
+
+This guide continues directly from [Secure Your MCP Server](../../../server/python). If <ProductName /> and the Calculator server from that guide are not already running, start them again.
+
+Run <ProductName /> with the method you chose there, then start the Calculator server from the same directory as `server.py`:
+
+```bash
+uv run server.py
+```
+
+The server listens at `http://localhost:8000/mcp`.
+
+## Enable Dynamic Client Registration
+
+MCP Inspector connected with the Client ID of an application you registered in the Console. Claude Code registers its own OAuth client automatically through Dynamic Client Registration (DCR) instead, so enable DCR before connecting it. Add the following to `deployment.yaml` in your <ProductName /> distribution:
+
+```yaml
+oauth:
+  dcr:
+    enabled: true
+    insecure: true
+```
+
+:::warning
+`insecure: true` lets anyone who can reach the server register OAuth clients without authentication. Use it for local development only.
+:::
+
+Restart <ProductName /> after saving the file.
+
+Optionally, confirm DCR is live before connecting Claude Code by registering a throwaway public client directly:
+
+```bash
+curl -sk -i -X POST https://localhost:8090/oauth2/dcr/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "client_name": "dcr-probe",
+    "redirect_uris": ["http://localhost:52344/callback"],
+    "grant_types": ["authorization_code"],
+    "response_types": ["code"],
+    "token_endpoint_auth_method": "none"
+  }'
+```
+
+```text
+HTTP/1.1 201 Created
+
+{
+  "app_id": "019fa36e-6b16-7908-9bc9-d848c00db406",
+  "client_id": "ZjWMmW04V6ZCl1xKR70FuQ",
+  "client_name": "dcr-probe",
+  "client_secret_expires_at": 0,
+  "grant_types": ["authorization_code"],
+  "redirect_uris": ["http://localhost:52344/callback"],
+  "response_types": ["code"],
+  "token_endpoint_auth_method": "none"
+}
+```
+
+A `201` response with a `client_id` and no `client_secret` confirms DCR accepted the registration. Before you set `insecure: true`, the same request returns `401 unauthorized_client`. The `dcr-probe` client this creates appears in **Applications**.
+
+Running the command again returns a `400` error because an application named `dcr-probe` already exists; delete it in the Console to repeat the check.
+
+## Connect Claude Code
+
+Add the Calculator server, from the same directory as `server.py`:
+
+```bash
+claude mcp add --transport http calculator http://localhost:8000/mcp
+```
+
+Start Claude Code, reusing the exported certificate so its Node.js runtime trusts <ProductName />'s TLS connection:
+
+```bash
+NODE_EXTRA_CA_CERTS=./thunderid.cert claude
+```
+
+1. Inside Claude Code, run `/mcp`.
+2. Choose the `calculator` server and authenticate.
+3. A browser tab opens with <ProductName />'s sign-in page. Sign in with your test user.
+4. Back in Claude Code, ask it to run both tools:
+
+   > "Add 7 and 5, then divide 10 by 4."
+
+   Claude Code calls the `add` and `divide` tools and returns the results.
+
+You never registered an application for Claude Code in the Console. DCR did that automatically the moment Claude Code first connected: open **Applications** and you find the client Claude Code registered, alongside `Calculator Inspector`.
+
+:::tip Success
+Claude Code only sees the tools your token's scopes allow, the same as Inspector. Try it: in the Console, open the `Calculator` role, remove the `divide` permission, then run `/mcp` in Claude Code again and re-authenticate. Ask Claude to divide two numbers again: it can no longer call the tool, because your token no longer carries the `divide` scope.
+:::
+
+</Stepper>
+
+## What's Next
+
+<div style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: '1rem', marginTop: '1.5rem'}}>
+  <a href="../../build-a-client/python" style={{textDecoration: 'none', color: 'inherit'}}>
+    <div style={{border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '10px', padding: '1.25rem', cursor: 'pointer'}}>
+      <div style={{fontSize: '1rem', fontWeight: '700', marginBottom: '0.4rem'}}>Build an MCP Client</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-emphasis-700)', marginBottom: '0.75rem'}}>Build your own MCP client that authenticates with <ProductName />, instead of connecting an existing one.</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-primary)', fontWeight: 600}}>Build an MCP Client →</div>
+    </div>
+  </a>
+  <a href="../../../../../use-cases/ai-agents/mcp-authorization/overview" style={{textDecoration: 'none', color: 'inherit'}}>
+    <div style={{border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '10px', padding: '1.25rem', cursor: 'pointer'}}>
+      <div style={{fontSize: '1rem', fontWeight: '700', marginBottom: '0.4rem'}}>Securing MCP</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-emphasis-700)', marginBottom: '0.75rem'}}>Authorization patterns for MCP servers, audience binding, and AuthZEN policy decisions.</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-primary)', fontWeight: 600}}>MCP Authorization →</div>
+    </div>
+  </a>
+</div>
+
+:::tip Example Source Code
+Check out the complete <RepoLink path="/tree/main/samples/apps/mcp-calculator-sample">Calculator MCP Sample</RepoLink> in the <ProductName /> repository.
+:::

--- a/docs/content/getting-started/connect-your-mcp/client/connect/mcp-inspector.mdx
+++ b/docs/content/getting-started/connect-your-mcp/client/connect/mcp-inspector.mdx
@@ -1,0 +1,109 @@
+---
+toc_progress: quickstart
+title: MCP Inspector
+docType: quickstart
+sidebar_position: 1
+persona: app
+description: Connect MCP Inspector to a {{ProductName}}-protected MCP server using a pre-registered client application.
+---
+
+import {
+  Plug,
+  ScanEye,
+  Clock,
+  ListChecks,
+  Server,
+} from '@wso2/oxygen-ui-icons-react';
+
+# MCP Inspector
+
+Use this guide to connect MCP Inspector to the Calculator server you secured in the previous quickstart, and see <ProductName />'s scope enforcement from Inspector's seat.
+
+<TutorialHero>
+
+## What You Will Learn
+
+<TutorialHeroItem icon={<Plug />}>Connect MCP Inspector to the scope-protected Calculator server</TutorialHeroItem>
+<TutorialHeroItem icon={<ScanEye />}>Watch a tool disappear from the tool list the moment its scope is missing from the token</TutorialHeroItem>
+
+## Prerequisites
+
+<TutorialHeroItem icon={<Clock />}>About 5 minutes</TutorialHeroItem>
+<TutorialHeroItem icon={<ListChecks />}>Completed Secure Your MCP Server: the Calculator server registered and runnable, <code>thunderid.cert</code> exported, and the <code>Calculator Inspector</code> application and CORS entry created</TutorialHeroItem>
+<TutorialHeroItem icon={<Server />}>Node.js 20+ (for MCP Inspector)</TutorialHeroItem>
+
+</TutorialHero>
+
+<Stepper stepNode="h2" as="h2">
+
+## Run <ProductName /> and the Calculator Server
+
+This guide continues directly from [Secure Your MCP Server](../../../server/python). If <ProductName /> and the Calculator server from that guide are not already running, start them again.
+
+Run <ProductName /> with the method you chose there, then start the Calculator server from the same directory as `server.py`:
+
+```bash
+uv run server.py
+```
+
+The server listens at `http://localhost:8000/mcp`.
+
+## Connect with MCP Inspector
+
+You already registered the `Calculator Inspector` application and allowed its origin in CORS in [Secure Your MCP Server](../../../server/python), so reuse both here. Launch Inspector from the same directory as `server.py`, reusing the exported certificate:
+
+```bash
+NODE_EXTRA_CA_CERTS=./thunderid.cert npx @modelcontextprotocol/inspector
+```
+
+:::note Running this from a clone of the repository?
+If you launch this command from inside a clone of the <ProductName /> repository (for example, from `samples/apps/mcp-calculator-sample/server/`), it fails with `npm error code EBADDEVENGINES`, because npm walks up to the repository's root `package.json`, which pins `pnpm` as the package manager. Launch Inspector from a directory outside the repository instead, and point `NODE_EXTRA_CA_CERTS` at the absolute path of `thunderid.cert`.
+:::
+
+Inspector opens in your browser at `http://localhost:6274`.
+
+1. Set **Transport Type** to **Streamable HTTP** and **URL** to `http://localhost:8000/mcp`.
+2. Expand the **Authentication** section.
+3. Under **OAuth 2.0 Flow**, enter the **Client ID** you copied earlier. Leave **Client Secret** empty.
+4. Click **Connect**. A browser tab opens with <ProductName />'s sign-in page. Sign in with your test user.
+5. Open the **Tools** tab and click **List Tools**. You see `add`, `subtract`, `multiply`, and `divide`.
+
+Now see scope enforcement from the client's seat: click **Disconnect**, then in the Auth panel's **Scope** field, type `add subtract multiply`, leaving out `divide`, and **Connect** again. Sign in once more and list the tools. `divide` is gone, because the token Inspector requests this time never carries that scope, and the server hides any tool the token's scopes do not cover.
+
+If the sign-in page never appears, see the "Sign-in page never appears" note in the [Launch and Connect](../../../server/python#launch-and-connect) step of the server quickstart.
+
+:::tip Success
+The tools you see in Inspector are exactly the ones your token's scopes allow. Remove `divide` from the scope list, reconnect, and the tool vanishes from the list.
+:::
+
+</Stepper>
+
+## What's Next
+
+<div style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: '1rem', marginTop: '1.5rem'}}>
+  <a href="../claude-code" style={{textDecoration: 'none', color: 'inherit'}}>
+    <div style={{border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '10px', padding: '1.25rem', cursor: 'pointer'}}>
+      <div style={{fontSize: '1rem', fontWeight: '700', marginBottom: '0.4rem'}}>Claude Code</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-emphasis-700)', marginBottom: '0.75rem'}}>Connect Claude Code to the same server using Dynamic Client Registration.</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-primary)', fontWeight: 600}}>Connect Claude Code →</div>
+    </div>
+  </a>
+  <a href="../../build-a-client/python" style={{textDecoration: 'none', color: 'inherit'}}>
+    <div style={{border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '10px', padding: '1.25rem', cursor: 'pointer'}}>
+      <div style={{fontSize: '1rem', fontWeight: '700', marginBottom: '0.4rem'}}>Build an MCP Client</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-emphasis-700)', marginBottom: '0.75rem'}}>Build your own MCP client that authenticates with <ProductName />, instead of connecting an existing one.</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-primary)', fontWeight: 600}}>Build an MCP Client →</div>
+    </div>
+  </a>
+  <a href="../../../../../use-cases/ai-agents/mcp-authorization/overview" style={{textDecoration: 'none', color: 'inherit'}}>
+    <div style={{border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '10px', padding: '1.25rem', cursor: 'pointer'}}>
+      <div style={{fontSize: '1rem', fontWeight: '700', marginBottom: '0.4rem'}}>Securing MCP</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-emphasis-700)', marginBottom: '0.75rem'}}>Authorization patterns for MCP servers, audience binding, and AuthZEN policy decisions.</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-primary)', fontWeight: 600}}>MCP Authorization →</div>
+    </div>
+  </a>
+</div>
+
+:::tip Example Source Code
+Check out the complete <RepoLink path="/tree/main/samples/apps/mcp-calculator-sample">Calculator MCP Sample</RepoLink> in the <ProductName /> repository.
+:::

--- a/docs/content/getting-started/connect-your-mcp/server/_category_.json
+++ b/docs/content/getting-started/connect-your-mcp/server/_category_.json
@@ -1,0 +1,5 @@
+{
+  "position": 1,
+  "label": "Server",
+  "collapsible": true
+}

--- a/docs/content/getting-started/connect-your-mcp/server/python.mdx
+++ b/docs/content/getting-started/connect-your-mcp/server/python.mdx
@@ -1,0 +1,343 @@
+---
+toc_progress: quickstart
+title: Secure Your MCP Server
+docType: quickstart
+sidebar_position: 1
+persona: app
+description: Protect a Python MCP server with {{ProductName}} OAuth scopes and validate tokens offline via JWKS.
+---
+
+import {
+  ShieldCheck,
+  KeyRound,
+  ListChecks,
+  Clock,
+  Terminal,
+  Server,
+  FileCode,
+} from '@wso2/oxygen-ui-icons-react';
+
+# Secure Your MCP Server
+
+Use this guide to build a Python MCP server whose tools are each protected by a <ProductName /> OAuth scope, using FastMCP, then verify the setup end to end with MCP Inspector.
+
+<TutorialHero>
+
+## What You Will Learn
+
+<TutorialHeroItem icon={<ShieldCheck />}>Turn an MCP server into an OAuth 2.0 resource server that answers unauthenticated calls with a <code>401</code> and RFC 9728 protected-resource metadata</TutorialHeroItem>
+<TutorialHeroItem icon={<KeyRound />}>Validate <ProductName /> JWTs offline (signature, issuer, audience, and expiry) against the JWKS endpoint</TutorialHeroItem>
+<TutorialHeroItem icon={<ListChecks />}>Protect each tool with its own scope, so a token missing a scope cannot see or call that tool</TutorialHeroItem>
+
+## Prerequisites
+
+<TutorialHeroItem icon={<Clock />}>About 10 minutes</TutorialHeroItem>
+<TutorialHeroItem icon={<Terminal />}><code>uv</code>, which manages Python and dependencies automatically</TutorialHeroItem>
+<TutorialHeroItem icon={<Server />}>Node.js 20+ (for MCP Inspector)</TutorialHeroItem>
+<TutorialHeroItem icon={<FileCode />}>Your preferred code editor</TutorialHeroItem>
+
+</TutorialHero>
+
+:::tip Example Source Code
+Check out the complete <RepoLink path="/tree/main/samples/apps/mcp-calculator-sample">Calculator MCP Sample</RepoLink> in the <ProductName /> repository.
+:::
+
+## How It Works
+
+Your MCP server becomes an OAuth 2.0 resource server. When a client connects without a token, the server responds with a `401` and RFC 9728 metadata that points the client to <ProductName /> for authentication. The client runs an Authorization Code + PKCE flow, gets a JWT scoped to the user's role-based permissions, and presents it on reconnect. The server validates the token offline against <ProductName />'s JWKS and filters visible tools by the token's scopes.
+
+<McpOAuthFlowDiagram />
+
+<Stepper stepNode="h2" as="h2">
+
+## Run <ProductName />
+
+Start a local <ProductName /> instance. Pick the method that works best for you:
+
+<RunThunderID />
+
+Once it's running, the console is available at <ConsoleUrl />.
+
+## Register the MCP Resource and Scopes
+
+1. Sign in to the Console.
+
+    :::info Test User
+    If you used the default setup, sign in to the Console as `admin` with the password generated during setup and printed to the setup output (unless you supplied your own).
+    :::
+
+2. Navigate to **Resource Servers** and click **Add resource server**.
+3. On the **Type** step, select **MCP**.
+4. On the **Name** step, enter:
+    - **MCP Server Name**: `Calculator MCP`
+    - **Identifier**: `http://localhost:8000/mcp`
+5. On the **Permission Delimiter** step, keep the default colon (`:`) and click **Create MCP server**. If your deployment has multiple organization units, click **Continue** instead, select one, then click **Create MCP server**.
+
+Now add each of the four calculator tools as a tool permission:
+
+6. On the **Capabilities** tab, the server has no capabilities yet. Click **Add tool permission**.
+7. Repeat for the remaining three tools: click the **+** icon in the panel header, then select **Add tool permission** from the menu.
+8. For each tool, enter the **Name**. <ProductName /> generates the **Handle** automatically from the name (lowercased), so confirm it matches the table below before clicking **Add**: the handle becomes the exact scope `require_scopes(...)` checks for in `server.py`.
+
+   | Name | Handle | Generated permission |
+   | --- | --- | --- |
+   | Add | `add` | `add` |
+   | Subtract | `subtract` | `subtract` |
+   | Multiply | `multiply` | `multiply` |
+   | Divide | `divide` | `divide` |
+
+## Create a Role for the Calculator Permissions
+
+Registering the permissions in the previous step only defines them. <ProductName /> puts a scope into an access token only when the signing-in user actually holds the matching permission through a role, and scopes the user doesn't hold are silently dropped from the token. A token missing a tool's scope means that tool never appears in the tool list, so before you connect Inspector, create a role that grants the four calculator permissions and assign it to the user you'll sign in with.
+
+1. Navigate to **Roles** and click **Add Role**.
+2. On the **Create a Role** step, enter a name (for example, `Calculator`) and click **Continue**. If prompted, select an organization unit and click **Continue** again.
+3. On the **Permissions** step, expand **Calculator MCP** and check **add**, **subtract**, **multiply**, and **divide** under **Tools**.
+4. Click **Continue** to create the role.
+5. Open the role from the **Roles** list, select the **Assignments** tab, and click **Add**.
+6. In the **Add Assignment** dialog, on the **Users** tab, select `admin` and click **Add Selected**.
+
+## Create the Server
+
+The whole server lives in a single file. Create `server.py`.
+
+FastMCP's `RemoteAuthProvider` turns the server into an OAuth 2.0 resource server: it publishes RFC 9728 protected-resource metadata and rejects requests without a valid token before any tool runs. The `JWTVerifier` validates each token offline, with no call back to <ProductName /> per request, by checking the signature against the JWKS endpoint, the issuer, the audience, and the expiry:
+
+```python title="server.py" {25-30,32-40} showLineNumbers
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["fastmcp>=3.4,<4", "python-dotenv>=1"]
+# ///
+"""Scope-protected calculator MCP server."""
+
+import os
+
+import httpx
+from dotenv import load_dotenv
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+from fastmcp.server.auth import RemoteAuthProvider, require_scopes
+from fastmcp.server.auth.providers.jwt import JWTVerifier
+
+load_dotenv(override=True)
+
+ISSUER = os.environ["THUNDERID_ISSUER"]
+JWKS_URI = os.environ["THUNDERID_JWKS_URI"]
+AUDIENCE = os.environ["MCP_AUDIENCE"]
+CA_CERT = os.environ.get("THUNDERID_CA_CERT")
+
+SCOPES = ["add", "subtract", "multiply", "divide"]
+
+verifier = JWTVerifier(
+    jwks_uri=JWKS_URI,
+    issuer=ISSUER,
+    audience=AUDIENCE,
+    http_client=httpx.AsyncClient(verify=CA_CERT) if CA_CERT else None,
+)
+
+mcp = FastMCP(
+    "Calculator",
+    auth=RemoteAuthProvider(
+        token_verifier=verifier,
+        authorization_servers=[ISSUER],
+        base_url="http://localhost:8000",
+        scopes_supported=SCOPES,
+    ),
+)
+```
+
+:::note No install step
+The `# /// script` header at the top of the file is inline script metadata (PEP 723). `uv run server.py` reads it and resolves `fastmcp` and `python-dotenv` automatically, in an isolated environment, so there's no separate `pip install` step.
+:::
+
+Append the four tools below the auth setup, still in the same `server.py` file. Each tool declares the single scope it needs with `require_scopes(...)`. A token that doesn't carry that scope can't see the tool in `tools/list` and can't call it:
+
+```python title="server.py" {1,7,13,19}
+@mcp.tool(auth=require_scopes("add"))
+def add(a: float, b: float) -> float:
+    """Add two numbers."""
+    return a + b
+
+
+@mcp.tool(auth=require_scopes("subtract"))
+def subtract(a: float, b: float) -> float:
+    """Subtract b from a."""
+    return a - b
+
+
+@mcp.tool(auth=require_scopes("multiply"))
+def multiply(a: float, b: float) -> float:
+    """Multiply two numbers."""
+    return a * b
+
+
+@mcp.tool(auth=require_scopes("divide"))
+def divide(a: float, b: float) -> float:
+    """Divide a by b."""
+    if b == 0:
+        raise ToolError("Cannot divide by zero.")
+    return a / b
+
+
+if __name__ == "__main__":
+    mcp.run(transport="http", host="localhost", port=8000)
+```
+
+## Configure the Environment
+
+A local <ProductName /> instance uses a self-signed certificate, so the server needs that certificate exported to verify the JWKS endpoint over HTTPS. With <ProductName /> running, run this from the same directory as `server.py`:
+
+```bash
+openssl s_client -connect localhost:8090 -showcerts </dev/null 2>/dev/null | openssl x509 > thunderid.cert
+```
+
+Create a `.env` file next to `server.py`:
+
+```bash title=".env"
+THUNDERID_ISSUER=https://localhost:8090
+THUNDERID_JWKS_URI=https://localhost:8090/oauth2/jwks
+MCP_AUDIENCE=http://localhost:8000/mcp
+THUNDERID_CA_CERT=./thunderid.cert
+```
+
+| Variable | Description |
+| --- | --- |
+| `THUNDERID_ISSUER` | Must exactly match the `iss` claim <ProductName /> puts in every access token. |
+| `THUNDERID_JWKS_URI` | Where the server fetches <ProductName />'s public signing keys to verify token signatures. |
+| `MCP_AUDIENCE` | The resource server identifier you registered in the previous step. `JWTVerifier` rejects tokens whose `aud` claim doesn't match. |
+| `THUNDERID_CA_CERT` | Path to the certificate you just exported. Must point to the actual file location; a relative path like `./thunderid.cert` is resolved from the directory you start the server in. |
+
+Both the issuer and the JWKS URI are discoverable from [https://localhost:8090/.well-known/openid-configuration](https://localhost:8090/.well-known/openid-configuration) if you're pointing at a non-default host or port.
+
+:::note Certificate not found at startup
+If the server fails at startup with a `FileNotFoundError`, `THUNDERID_CA_CERT` doesn't point to the exported file. Check the path, or re-export the certificate. The export only writes a local file, nothing is added to your system trust store, and it regenerates whenever <ProductName /> is reinstalled or rebuilt, so re-export after a rebuild.
+:::
+
+## Run and Verify Protection
+
+Start the server:
+
+```bash
+uv run server.py
+```
+
+It serves the MCP endpoint at `http://localhost:8000/mcp`.
+
+With no token, the server rejects the request:
+
+```bash
+curl -si -X POST http://localhost:8000/mcp
+```
+
+```text
+HTTP/1.1 401 Unauthorized
+www-authenticate: Bearer resource_metadata="http://localhost:8000/.well-known/oauth-protected-resource/mcp"
+```
+
+Fetch that metadata directly:
+
+```bash
+curl -s http://localhost:8000/.well-known/oauth-protected-resource/mcp
+```
+
+The response names <ProductName /> as the authorization server and lists the four scopes:
+
+```json
+{
+  "resource": "http://localhost:8000/mcp",
+  "authorization_servers": ["https://localhost:8090/"],
+  "scopes_supported": ["add", "subtract", "multiply", "divide"],
+  "bearer_methods_supported": ["header"]
+}
+```
+
+## Connect with MCP Inspector
+
+### Register an MCP Client for Inspector
+
+<ProductName /> has a dedicated application type for MCP clients like Inspector. In the Console:
+
+1. Go to **Applications** and click **Add Application**.
+2. Select **MCP Client**.
+3. Enter a name (for example, `Calculator Inspector`).
+4. If prompted, select an organization unit.
+5. On the **Client type** step, select **On behalf of a user**. This configures the Authorization Code flow with PKCE as a public client.
+6. Under **Redirect URIs**, add `http://localhost:6274/oauth/callback`.
+7. Click **Finish**.
+8. From the completion screen, copy the **Client ID**. No client secret is required because this is a public client.
+
+### Allow the MCP Inspector Origin
+
+MCP Inspector runs in the browser at `http://localhost:6274` and calls <ProductName /> cross-origin, so its origin must be allowed in the CORS configuration.
+
+Create or update `config/resources/server_configs/cors.yaml` in your <ProductName /> distribution, or use `PUT /server-config/cors` after startup:
+
+```yaml
+name: cors
+value:
+  allowedOrigins:
+    - "http://localhost:6274"
+```
+
+If the file already exists, append the origin to the existing `allowedOrigins` list instead of replacing it. Restart <ProductName /> after editing the file.
+
+### Launch and Connect
+
+Inspector's proxy runs on Node.js and must also trust the self-signed <ProductName /> certificate to discover the OAuth endpoints, so reuse the certificate you exported earlier. Run this from the same directory as `server.py`:
+
+```bash
+NODE_EXTRA_CA_CERTS=./thunderid.cert npx @modelcontextprotocol/inspector
+```
+
+Inspector opens in your browser at `http://localhost:6274`.
+
+1. Set **Transport Type** to **Streamable HTTP** and **URL** to `http://localhost:8000/mcp`.
+2. Expand the **Authentication** section.
+3. Under **OAuth 2.0 Flow**, enter the **Client ID** you copied earlier. Leave **Client Secret** empty.
+4. Click **Connect**. Inspector reads your server's protected-resource metadata, discovers <ProductName /> as the authorization server, and requests all four scopes by default.
+5. A browser tab opens with <ProductName />'s sign-in page. Sign in with your test user.
+6. You're redirected back to Inspector, now connected.
+7. Open the **Tools** tab and click **List Tools**. You see `add`, `subtract`, `multiply`, and `divide`.
+
+:::note Sign-in page never appears
+If the browser shows "Cannot GET /authorize" instead of the sign-in page, first confirm **Transport Type** is set to **Streamable HTTP**, since the deprecated SSE transport probes without a token and misroutes the authorize request to Inspector's own proxy. If Transport Type is already correct, Inspector was launched without `NODE_EXTRA_CA_CERTS` or the path is wrong, so it couldn't fetch <ProductName />'s OAuth discovery metadata. Relaunch with the variable pointing at the exported certificate.
+:::
+
+:::tip Success
+The tools you see in Inspector are exactly the ones your token's scopes allow. Try it: click **Disconnect**, then in the Auth panel's **Scope** field, type `add subtract multiply`, leaving out `divide`, and **Connect** again. Sign in once more and list the tools. `divide` is gone, because the token Inspector obtained this time never carries that scope, and `require_scopes("divide")` hides the tool from anyone without it.
+:::
+
+</Stepper>
+
+## What's Next
+
+<div style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: '1rem', marginTop: '1.5rem'}}>
+  <a href="../../client/connect/mcp-inspector" style={{textDecoration: 'none', color: 'inherit'}}>
+    <div style={{border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '10px', padding: '1.25rem', cursor: 'pointer'}}>
+      <div style={{fontSize: '1rem', fontWeight: '700', marginBottom: '0.4rem'}}>MCP Inspector</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-emphasis-700)', marginBottom: '0.75rem'}}>Connect MCP Inspector to the server you just secured and see scope enforcement from Inspector's seat.</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-primary)', fontWeight: 600}}>Connect MCP Inspector →</div>
+    </div>
+  </a>
+  <a href="../../client/connect/claude-code" style={{textDecoration: 'none', color: 'inherit'}}>
+    <div style={{border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '10px', padding: '1.25rem', cursor: 'pointer'}}>
+      <div style={{fontSize: '1rem', fontWeight: '700', marginBottom: '0.4rem'}}>Claude Code</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-emphasis-700)', marginBottom: '0.75rem'}}>Connect Claude Code to the server using Dynamic Client Registration and see scope enforcement from Claude's seat.</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-primary)', fontWeight: 600}}>Connect Claude Code →</div>
+    </div>
+  </a>
+  <a href="../../../../use-cases/ai-agents/mcp-authorization/overview" style={{textDecoration: 'none', color: 'inherit'}}>
+    <div style={{border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '10px', padding: '1.25rem', cursor: 'pointer'}}>
+      <div style={{fontSize: '1rem', fontWeight: '700', marginBottom: '0.4rem'}}>Securing MCP</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-emphasis-700)', marginBottom: '0.75rem'}}>Authorization patterns for MCP servers, audience binding, and AuthZEN policy decisions.</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-primary)', fontWeight: 600}}>MCP Authorization →</div>
+    </div>
+  </a>
+  <a href="../../../../working-with-ai/mcp-server" style={{textDecoration: 'none', color: 'inherit'}}>
+    <div style={{border: '1px solid var(--ifm-color-emphasis-300)', borderRadius: '10px', padding: '1.25rem', cursor: 'pointer'}}>
+      <div style={{fontSize: '1rem', fontWeight: '700', marginBottom: '0.4rem'}}><ProductName /> MCP Server</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-emphasis-700)', marginBottom: '0.75rem'}}>Manage <ProductName /> itself, applications, flows, and users, from AI tools.</div>
+      <div style={{fontSize: '0.875rem', color: 'var(--ifm-color-primary)', fontWeight: 600}}>MCP Server Guide →</div>
+    </div>
+  </a>
+</div>

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -105,7 +105,38 @@ const sidebars: SidebarsConfig = {
           className: 'connect-section connect-section--mcp',
           collapsible: true,
           items: [
-            {type: 'doc', id: 'getting-started/connect-your-mcp/python', label: 'Python', customProps: {icon: 'python'}},
+            {
+              type: 'category',
+              label: 'Server',
+              collapsible: true,
+              items: [
+                {type: 'doc', id: 'getting-started/connect-your-mcp/server/python', label: 'Python', key: 'mcp-server-python', customProps: {icon: 'python'}},
+              ],
+            },
+            {
+              type: 'category',
+              label: 'Client',
+              collapsible: true,
+              items: [
+                {
+                  type: 'category',
+                  label: 'Connect an MCP Client',
+                  collapsible: true,
+                  items: [
+                    {type: 'doc', id: 'getting-started/connect-your-mcp/client/connect/mcp-inspector', label: 'MCP Inspector'},
+                    {type: 'doc', id: 'getting-started/connect-your-mcp/client/connect/claude-code', label: 'Claude Code'},
+                  ],
+                },
+                {
+                  type: 'category',
+                  label: 'Build an MCP Client',
+                  collapsible: true,
+                  items: [
+                    {type: 'doc', id: 'getting-started/connect-your-mcp/client/build-a-client/python', label: 'Python', key: 'mcp-client-build-python', customProps: {icon: 'python'}},
+                  ],
+                },
+              ],
+            },
           ],
         },
       ],

--- a/docs/src/components/DeveloperShortcut.tsx
+++ b/docs/src/components/DeveloperShortcut.tsx
@@ -19,7 +19,7 @@
 import Link from '@docusaurus/Link';
 import {useWindowSize} from '@docusaurus/theme-common';
 import {Box, Chip, Typography} from '@wso2/oxygen-ui';
-import {Bot, Check, Download, MonitorSmartphone, Server, Zap} from '@wso2/oxygen-ui-icons-react';
+import {AppWindow, Bot, Check, Download, MonitorSmartphone, Server, Zap} from '@wso2/oxygen-ui-icons-react';
 import React, {useCallback} from 'react';
 import AndroidLogo from './icons/AndroidLogo';
 import ExpressLogo from './icons/ExpressLogo';
@@ -30,7 +30,6 @@ import LangChainLogo from './icons/LangChainLogo';
 import NextLogo from './icons/NextLogo';
 import NodeLogo from './icons/NodeLogo';
 import NuxtLogo from './icons/NuxtLogo';
-import PythonLogo from './icons/PythonLogo';
 import ReactLogo from './icons/ReactLogo';
 import VueLogo from './icons/VueLogo';
 import {applyConnectType, useConnectType} from '../utils/connectType';
@@ -55,7 +54,8 @@ const AGENT_QUICKSTARTS = [
 ];
 
 const MCP_QUICKSTARTS = [
-  {Logo: PythonLogo, href: '/docs/next/getting-started/connect-your-mcp/python', label: 'Python'},
+  {Logo: Server, href: '/docs/next/getting-started/connect-your-mcp/server/python', label: 'Server'},
+  {Logo: AppWindow, href: '/docs/next/getting-started/connect-your-mcp/client/connect/mcp-inspector', label: 'Client'},
 ];
 
 const CATEGORIES: {id: ConnectType; icon: React.ReactElement; label: string; description: string; comingSoon: boolean}[] = [

--- a/samples/apps/mcp-calculator-sample/.gitignore
+++ b/samples/apps/mcp-calculator-sample/.gitignore
@@ -1,0 +1,3 @@
+server/.env
+server/thunderid.cert
+client/.mcp-oauth-cache/

--- a/samples/apps/mcp-calculator-sample/README.md
+++ b/samples/apps/mcp-calculator-sample/README.md
@@ -1,0 +1,90 @@
+# MCP Calculator Sample
+
+A scope-protected MCP server and an OAuth-authenticated MCP client, both secured with ThunderID. The server exposes four calculator tools, each gated behind its own OAuth scope, and the client signs in, registers itself, and calls the tools with a token that only carries the scopes the signed-in user's role grants.
+
+This sample is the companion code for the ThunderID MCP quickstarts:
+
+- [Secure Your MCP Server](https://thunderid.dev/docs/next/getting-started/connect-your-mcp/server/python/): build `server.py` and register the resource server, scopes, and role in ThunderID.
+- [MCP Inspector](https://thunderid.dev/docs/next/getting-started/connect-your-mcp/client/connect/mcp-inspector/): connect MCP Inspector to the server.
+- [Claude Code](https://thunderid.dev/docs/next/getting-started/connect-your-mcp/client/connect/claude-code/): connect Claude Code to the server using Dynamic Client Registration.
+- [Build an MCP Client](https://thunderid.dev/docs/next/getting-started/connect-your-mcp/client/build-a-client/python/): build `client.py`, the OAuth-authenticated client in this sample.
+
+## Project Structure
+
+```text
+mcp-calculator-sample/
+├── README.md              This file
+├── .gitignore             Ignores local secrets and caches
+├── server/
+│   ├── server.py          FastMCP resource server: add, subtract, multiply, divide
+│   ├── .env.example       Template for the server's environment variables
+│   ├── .env               Created locally, gitignored: your copy of .env.example
+│   └── thunderid.cert     Created locally, gitignored: exported ThunderID certificate
+└── client/
+    ├── client.py          OAuth-authenticated FastMCP client
+    └── .mcp-oauth-cache/  Created locally, gitignored: cached DCR registration and tokens
+```
+
+## Prerequisites
+
+- A running ThunderID instance, reachable at `https://localhost:8090`.
+- [`uv`](https://docs.astral.sh/uv/), which manages Python and dependencies for both `server.py` and `client.py` automatically.
+- The Calculator MCP resource server, its four tool scopes, and a role that grants them to your test user, registered in ThunderID Console. Follow **Register the MCP Resource and Scopes** and **Create a Role for the Calculator Permissions** in [Secure Your MCP Server](https://thunderid.dev/docs/next/getting-started/connect-your-mcp/server/python/).
+
+## Run the Server
+
+From `server/`:
+
+1. Copy the environment template:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Export ThunderID's self-signed certificate so the server can verify the JWKS endpoint over HTTPS. With ThunderID running, run this from the `server/` directory:
+
+   ```bash
+   openssl s_client -connect localhost:8090 -showcerts </dev/null 2>/dev/null | openssl x509 > thunderid.cert
+   ```
+
+3. Start the server:
+
+   ```bash
+   uv run server.py
+   ```
+
+The server listens at `http://localhost:8000/mcp` and rejects any request without a valid, appropriately scoped ThunderID access token. See [Configure the Environment](https://thunderid.dev/docs/next/getting-started/connect-your-mcp/server/python/#configure-the-environment) for what each `.env` variable does.
+
+## Run the Client
+
+From `client/`, with the server already running:
+
+```bash
+uv run client.py
+```
+
+`client.py` registers itself with ThunderID via Dynamic Client Registration (DCR) the first time it runs, so DCR must be enabled in your ThunderID deployment first. See [Enable Dynamic Client Registration](https://thunderid.dev/docs/next/getting-started/connect-your-mcp/client/build-a-client/python/#enable-dynamic-client-registration) for the `deployment.yaml` block to add.
+
+On the first run, a browser tab opens with ThunderID's sign-in page. Sign in with your test user, and the client completes the OAuth flow and calls the tools:
+
+```text
+Tools: ['add', 'divide', 'multiply', 'subtract']
+add(7, 5) = 12.0
+divide(10, 4) = 2.5
+```
+
+The client persists its DCR registration and issued tokens under `client/.mcp-oauth-cache/` (gitignored). On later runs, it reuses that cache: no re-registration and no browser, as long as the cached token is still valid.
+
+## Troubleshooting
+
+- **`Registration failed: 400 invalid_client_metadata "An application with the same name already exists"`**: this happens when `client/.mcp-oauth-cache/` is deleted but the "FastMCP Client" application still exists in ThunderID. Delete that application in the Console, or restore the cache, then run again.
+- **`npm error code EBADDEVENGINES`** when launching MCP Inspector with `NODE_EXTRA_CA_CERTS=./thunderid.cert npx @modelcontextprotocol/inspector` from `server/`: npm walked up to this repository's root `package.json`, which pins `pnpm` as the package manager, and refuses to run under plain `npm`. Launch Inspector from a directory outside the repository instead, pointing `NODE_EXTRA_CA_CERTS` at the absolute path of `thunderid.cert`.
+- **Redirect to `/gate/error?errorCode=invalid_request&errorMessage=Invalid+redirect+URI`**: the registered redirect URI no longer matches the client's callback port. Delete the "FastMCP Client" application in the Console and run again so the client re-registers with the current port.
+
+## Learn More
+
+- [Secure Your MCP Server](https://thunderid.dev/docs/next/getting-started/connect-your-mcp/server/python/)
+- [MCP Inspector](https://thunderid.dev/docs/next/getting-started/connect-your-mcp/client/connect/mcp-inspector/)
+- [Claude Code](https://thunderid.dev/docs/next/getting-started/connect-your-mcp/client/connect/claude-code/)
+- [Build an MCP Client](https://thunderid.dev/docs/next/getting-started/connect-your-mcp/client/build-a-client/python/)
+- [Securing MCP](https://thunderid.dev/docs/next/use-cases/ai-agents/mcp-authorization/overview/)

--- a/samples/apps/mcp-calculator-sample/client/client.py
+++ b/samples/apps/mcp-calculator-sample/client/client.py
@@ -1,0 +1,38 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["fastmcp>=3.4,<4"]
+# ///
+"""OAuth-authenticated client for the Calculator MCP server."""
+
+import asyncio
+from pathlib import Path
+
+from fastmcp import Client
+from fastmcp.client.auth import FileTreeStore, OAuth
+
+MCP_URL = "http://localhost:8000/mcp"
+THUNDERID_CA_CERT = "../server/thunderid.cert"
+TOKEN_CACHE_DIR = Path(__file__).parent / ".mcp-oauth-cache"
+CALLBACK_PORT = 52360
+
+oauth = OAuth(
+    mcp_url=MCP_URL,
+    token_storage=FileTreeStore(data_directory=TOKEN_CACHE_DIR),
+    callback_port=CALLBACK_PORT,
+)
+
+
+async def main() -> None:
+    async with Client(MCP_URL, auth=oauth, verify=THUNDERID_CA_CERT) as client:
+        tools = await client.list_tools()
+        print("Tools:", sorted(tool.name for tool in tools))
+
+        result = await client.call_tool("add", {"a": 7, "b": 5})
+        print("add(7, 5) =", result.data)
+
+        result = await client.call_tool("divide", {"a": 10, "b": 4})
+        print("divide(10, 4) =", result.data)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/samples/apps/mcp-calculator-sample/server/.env.example
+++ b/samples/apps/mcp-calculator-sample/server/.env.example
@@ -1,0 +1,4 @@
+THUNDERID_ISSUER=https://localhost:8090
+THUNDERID_JWKS_URI=https://localhost:8090/oauth2/jwks
+MCP_AUDIENCE=http://localhost:8000/mcp
+THUNDERID_CA_CERT=./thunderid.cert

--- a/samples/apps/mcp-calculator-sample/server/server.py
+++ b/samples/apps/mcp-calculator-sample/server/server.py
@@ -1,0 +1,70 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["fastmcp>=3.4,<4", "python-dotenv>=1"]
+# ///
+"""Scope-protected calculator MCP server."""
+
+import os
+
+import httpx
+from dotenv import load_dotenv
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+from fastmcp.server.auth import RemoteAuthProvider, require_scopes
+from fastmcp.server.auth.providers.jwt import JWTVerifier
+
+load_dotenv(override=True)
+
+ISSUER = os.environ["THUNDERID_ISSUER"]
+JWKS_URI = os.environ["THUNDERID_JWKS_URI"]
+AUDIENCE = os.environ["MCP_AUDIENCE"]
+CA_CERT = os.environ.get("THUNDERID_CA_CERT")
+
+SCOPES = ["add", "subtract", "multiply", "divide"]
+
+verifier = JWTVerifier(
+    jwks_uri=JWKS_URI,
+    issuer=ISSUER,
+    audience=AUDIENCE,
+    http_client=httpx.AsyncClient(verify=CA_CERT) if CA_CERT else None,
+)
+
+mcp = FastMCP(
+    "Calculator",
+    auth=RemoteAuthProvider(
+        token_verifier=verifier,
+        authorization_servers=[ISSUER],
+        base_url="http://localhost:8000",
+        scopes_supported=SCOPES,
+    ),
+)
+
+
+@mcp.tool(auth=require_scopes("add"))
+def add(a: float, b: float) -> float:
+    """Add two numbers."""
+    return a + b
+
+
+@mcp.tool(auth=require_scopes("subtract"))
+def subtract(a: float, b: float) -> float:
+    """Subtract b from a."""
+    return a - b
+
+
+@mcp.tool(auth=require_scopes("multiply"))
+def multiply(a: float, b: float) -> float:
+    """Multiply two numbers."""
+    return a * b
+
+
+@mcp.tool(auth=require_scopes("divide"))
+def divide(a: float, b: float) -> float:
+    """Divide a by b."""
+    if b == 0:
+        raise ToolError("Cannot divide by zero.")
+    return a / b
+
+
+if __name__ == "__main__":
+    mcp.run(transport="http", host="localhost", port=8000)


### PR DESCRIPTION
## Summary

- Add **Connect an MCP Client** page: step-by-step guides for connecting MCP Inspector and Claude Code (via DCR) to a ThunderID-secured MCP server.
- Add **Build an MCP Client** page: build a Python FastMCP OAuth client from scratch, with persistent token storage and pinned callback port.
- Add **Calculator MCP sample** (`samples/apps/mcp-calculator-sample/`): runnable server and client code matching the guides, with PEP 723 inline metadata for zero-install `uv run`.
- Update the existing **Secure Your MCP Server** page (`python.mdx`): add sample code link, What's Next card, fix sign-in wording and Inspector UI labels.
- Register both new pages in the sidebar.

All doc claims were verified against a live ThunderID + Calculator MCP server stack. `make build_docs` passes. Vale is clean.

### Related Issue(s)
- https://github.com/thunder-id/thunderid/issues/4446

## Test plan

- [ ] `make build_docs` passes with no new broken-anchor warnings
- [ ] Sidebar renders both new pages after the Python entry in the MCP category
- [ ] connect-a-client.mdx: follow the Inspector path end to end (requires a registered app from the server guide)
- [ ] connect-a-client.mdx: follow the Claude Code path end to end (requires DCR enabled)
- [ ] build-a-client.mdx: `uv run client.py` completes the OAuth flow and prints tool results
- [ ] python.mdx: sample code tip and What's Next card render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Calculator MCP sample with an OAuth-authenticated, scope-protected Python server and a matching Python OAuth client.
  * Updated the developer shortcuts to show separate “Server” and “Client” popular quickstarts.

* **Documentation**
  * Restructured MCP getting-started content into collapsible “Server” and “Client” sections.
  * Added/expanded quickstarts for securing a Python server, building a Python client, and connecting MCP Inspector and Claude Code to protected servers.

* **Chores**
  * Updated the sample README, gitignore, and example environment variables for certificates and OAuth cache.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->