### PR TITLE
Fix(scim): required-attribute and core schema validation, correct attribute mapping bugs

### DIFF
--- a/backend/internal/scim/core_attr_mapper.go
+++ b/backend/internal/scim/core_attr_mapper.go
@@ -41,7 +41,12 @@ const (
 	scimFieldProfileURL    scimCoreField = "profileUrl"
 )
 
-const scimValueKey = "value"
+const (
+	scimValueKey     = "value"
+	scimTypeKey      = "type"
+	scimPrimaryKey   = "primary"
+	scimFormattedKey = "formatted"
+)
 
 type attrKind string
 
@@ -58,7 +63,6 @@ type coreAttrRule struct {
 	kind        attrKind
 	parentField scimCoreField // only for kindSubAttr; top-level complex object this rolls into, e.g. "name"
 	subAttr     string        // only for kindSubAttr/kindAddrPart; key within the parent/addresses object
-	defaultType string        // only for kindMultiComplex; e.g. "work"
 	valueKey    string        // e.g. "value" (default)
 }
 
@@ -70,11 +74,10 @@ var coreAttrRules = []coreAttrRule{
 		kind:      kindSimpleString,
 	},
 	{
-		candidate:   "email",
-		scimField:   scimFieldEmails,
-		kind:        kindMultiComplex,
-		defaultType: "work",
-		valueKey:    scimValueKey,
+		candidate: "email",
+		scimField: scimFieldEmails,
+		kind:      kindMultiComplex,
+		valueKey:  scimValueKey,
 	},
 	{
 		candidate:   "given_name",
@@ -89,11 +92,10 @@ var coreAttrRules = []coreAttrRule{
 		subAttr:     "familyName",
 	},
 	{
-		candidate:   "phone_number",
-		scimField:   scimFieldPhoneNumbers,
-		kind:        kindMultiComplex,
-		defaultType: "work",
-		valueKey:    scimValueKey,
+		candidate: "phone_number",
+		scimField: scimFieldPhoneNumbers,
+		kind:      kindMultiComplex,
+		valueKey:  scimValueKey,
 	},
 	{
 		candidate: "display_name",
@@ -118,11 +120,10 @@ var coreAttrRules = []coreAttrRule{
 		kind:      kindSimpleString,
 	},
 	{
-		candidate:   "picture",
-		scimField:   scimFieldPhotos,
-		kind:        kindMultiComplex,
-		defaultType: "photo",
-		valueKey:    scimValueKey,
+		candidate: "picture",
+		scimField: scimFieldPhotos,
+		kind:      kindMultiComplex,
+		valueKey:  scimValueKey,
 	},
 	{
 		candidate: "locale",
@@ -148,6 +149,12 @@ var coreAttrRules = []coreAttrRule{
 		candidate: "title",
 		scimField: scimFieldTitle,
 		kind:      kindSimpleString,
+	},
+	{
+		candidate: "address",
+		scimField: scimFieldAddresses,
+		kind:      kindMultiComplex,
+		valueKey:  scimFormattedKey,
 	},
 	{
 		candidate: "street_address",
@@ -219,7 +226,7 @@ func translateSCIMFilterAttr(attr string) string {
 // scimUnsupportedMultiComplexSubAttrs: sub-attrs ThunderID never stores as a flat
 // field, regardless of scalar/array schema. "value" excluded — wrong only for
 // array schemas, undetectable at filter-parse time.
-var scimUnsupportedMultiComplexSubAttrs = []string{"type", "primary"}
+var scimUnsupportedMultiComplexSubAttrs = []string{scimTypeKey, scimPrimaryKey}
 
 // scimUnsupportedFilterAttrs: filter paths on multi-valued core attrs (emails,
 // phoneNumbers, photos) with no flat equivalent to compare against, e.g.
@@ -247,6 +254,86 @@ func isUnsupportedSCIMFilterAttr(attr string) bool {
 	return ok
 }
 
+// isCanonicalAddrSubAttr reports whether key is a canonical sub-attribute for
+// the SCIM addresses field, derived dynamically from coreAttrRules kindAddrPart rules.
+func isCanonicalAddrSubAttr(key string) bool {
+	lk := strings.ToLower(key)
+	if lk == scimTypeKey || lk == scimPrimaryKey || lk == scimFormattedKey {
+		return true
+	}
+	for _, rule := range coreAttrRules {
+		isAddrRuleMatch := rule.kind == kindAddrPart &&
+			(strings.EqualFold(rule.subAttr, key) || strings.EqualFold(rule.candidate, key))
+		if isAddrRuleMatch {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeAndTranslateAddrOutbound(arr []map[string]interface{}) []map[string]interface{} {
+	if len(arr) == 0 {
+		return nil
+	}
+	var out []map[string]interface{}
+	for _, obj := range arr {
+		newObj := make(map[string]interface{})
+		for k, v := range obj {
+			if !isCanonicalAddrSubAttr(k) {
+				continue
+			}
+			newObj[k] = v
+		}
+		for _, rule := range coreAttrRules {
+			if rule.kind == kindAddrPart {
+				if v, ok := newObj[rule.candidate]; ok {
+					newObj[rule.subAttr] = v
+					if rule.candidate != rule.subAttr {
+						delete(newObj, rule.candidate)
+					}
+				}
+			}
+		}
+		nonMetaCount := 0
+		for k := range newObj {
+			if k != scimTypeKey && k != scimPrimaryKey {
+				nonMetaCount++
+			}
+		}
+		if nonMetaCount > 0 {
+			out = append(out, newObj)
+		}
+	}
+	return out
+}
+
+func translateAddrInboundForSchema(obj map[string]interface{}, propDef rawPropertyDef) map[string]interface{} {
+	targetProps := propDef.Properties
+	if targetProps == nil && propDef.Items != nil {
+		targetProps = propDef.Items.Properties
+	}
+	out := make(map[string]interface{})
+	for k, v := range obj {
+		out[k] = v
+	}
+	for _, rule := range coreAttrRules {
+		if rule.kind == kindAddrPart {
+			if scimVal, ok := out[rule.subAttr]; ok {
+				for targetProp := range targetProps {
+					if strings.EqualFold(targetProp, rule.candidate) {
+						out[targetProp] = scimVal
+						if targetProp != rule.subAttr {
+							delete(out, rule.subAttr)
+						}
+						break
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
 func mapToCoreAttrs(rawAttrs json.RawMessage) map[string]json.RawMessage {
 	if len(rawAttrs) == 0 {
 		return nil
@@ -270,7 +357,10 @@ func mapToCoreAttrs(rawAttrs json.RawMessage) map[string]json.RawMessage {
 				result[string(rule.scimField)] = b
 			}
 		case kindMultiComplex:
-			arr := normalizeToMultiComplex(val, rule.defaultType, rule.valueKey)
+			arr := normalizeToMultiComplex(val, rule.valueKey)
+			if rule.scimField == scimFieldAddresses {
+				arr = normalizeAndTranslateAddrOutbound(arr)
+			}
 			if len(arr) > 0 {
 				b, _ := json.Marshal(arr)
 				result[string(rule.scimField)] = b
@@ -295,7 +385,6 @@ func mapToCoreAttrs(rawAttrs json.RawMessage) map[string]json.RawMessage {
 		result[string(parent)] = b
 	}
 	if len(addrParts) > 0 {
-		addrParts["type"], _ = json.Marshal("work")
 		addrParts["primary"], _ = json.Marshal(true)
 		b, _ := json.Marshal([]map[string]json.RawMessage{addrParts})
 		result[string(scimFieldAddresses)] = b
@@ -390,9 +479,14 @@ func reverseMapSimpleString(coreVal json.RawMessage) (json.RawMessage, bool) {
 
 func reverseMapMultiComplex(rule coreAttrRule, coreVal json.RawMessage, propDef rawPropertyDef,
 ) (json.RawMessage, bool) {
-	normalized := normalizeToMultiComplex(coreVal, rule.defaultType, rule.valueKey)
+	normalized := normalizeToMultiComplex(coreVal, rule.valueKey)
 	if len(normalized) == 0 {
 		return nil, false
+	}
+	if rule.scimField == scimFieldAddresses {
+		for i, obj := range normalized {
+			normalized[i] = translateAddrInboundForSchema(obj, propDef)
+		}
 	}
 	propType := strings.ToLower(propDef.Type)
 	switch {
@@ -502,7 +596,7 @@ func extractStringValue(raw json.RawMessage, targetKey string) string {
 	return ""
 }
 
-func normalizeToMultiComplex(raw json.RawMessage, defaultType string, valueKey string) []map[string]interface{} {
+func normalizeToMultiComplex(raw json.RawMessage, valueKey string) []map[string]interface{} {
 	if len(raw) == 0 {
 		return nil
 	}
@@ -513,7 +607,7 @@ func normalizeToMultiComplex(raw json.RawMessage, defaultType string, valueKey s
 	// Case 1: Plain string -> wrap in array
 	var s string
 	if err := json.Unmarshal(raw, &s); err == nil {
-		return []map[string]interface{}{{valueKey: s, "type": defaultType, "primary": true}}
+		return []map[string]interface{}{{valueKey: s, "primary": true}}
 	}
 
 	// Case 2: Array of strings
@@ -521,7 +615,7 @@ func normalizeToMultiComplex(raw json.RawMessage, defaultType string, valueKey s
 	if err := json.Unmarshal(raw, &strArr); err == nil {
 		var out []map[string]interface{}
 		for i, val := range strArr {
-			out = append(out, map[string]interface{}{valueKey: val, "type": defaultType, "primary": i == 0})
+			out = append(out, map[string]interface{}{valueKey: val, "primary": i == 0})
 		}
 		return out
 	}
@@ -529,58 +623,79 @@ func normalizeToMultiComplex(raw json.RawMessage, defaultType string, valueKey s
 	// Case 3: Array of objects
 	var objArr []map[string]interface{}
 	if err := json.Unmarshal(raw, &objArr); err == nil {
-		var out []map[string]interface{}
-		for _, obj := range objArr {
-			valStr, _ := obj[valueKey].(string)
-			if valStr == "" && valueKey != scimValueKey {
-				valStr, _ = obj[scimValueKey].(string)
-			}
-			if valStr == "" {
-				continue
-			}
-
-			newObj := make(map[string]interface{})
-			for k, v := range obj {
-				newObj[k] = v
-			}
-			newObj[valueKey] = valStr
-
-			typStr, _ := obj["type"].(string)
-			if typStr == "" {
-				newObj["type"] = defaultType
-			}
-			out = append(out, newObj)
-		}
-		if len(out) > 0 && !hasPrimary(out) {
-			out[0]["primary"] = true
-		}
-		return out
+		return normalizeMultiComplexObjectArray(objArr, valueKey)
 	}
 
 	// Case 4: Single object -> wrap in array
 	var singleObj map[string]interface{}
 	if err := json.Unmarshal(raw, &singleObj); err == nil {
-		valStr, _ := singleObj[valueKey].(string)
-		if valStr == "" && valueKey != scimValueKey {
-			valStr, _ = singleObj[scimValueKey].(string)
-		}
-		if valStr == "" {
-			return nil
-		}
-		newObj := make(map[string]interface{})
-		for k, v := range singleObj {
-			newObj[k] = v
-		}
-		newObj[valueKey] = valStr
-
-		typStr, _ := singleObj["type"].(string)
-		if typStr == "" {
-			newObj["type"] = defaultType
-		}
-		newObj["primary"] = true
-		return []map[string]interface{}{newObj}
+		return normalizeMultiComplexSingleObject(singleObj, valueKey)
 	}
 	return nil
+}
+
+// multiComplexValue extracts the value (falling back to the default "value" key) and
+// non-meta-attribute count (keys other than type/primary) shared by a multi-valued
+// complex object's normalization, whether it came from an array entry or a lone object.
+func multiComplexValue(obj map[string]interface{}, valueKey string) (valStr string, nonMetaCount int) {
+	valStr, _ = obj[valueKey].(string)
+	if valStr == "" && valueKey != scimValueKey {
+		valStr, _ = obj[scimValueKey].(string)
+	}
+	for k := range obj {
+		if k != scimTypeKey && k != scimPrimaryKey {
+			nonMetaCount++
+		}
+	}
+	return valStr, nonMetaCount
+}
+
+// normalizeMultiComplexEntry copies obj, fills in valueKey when valStr is present, and
+// drops an empty "type" rather than fabricating one.
+func normalizeMultiComplexEntry(obj map[string]interface{}, valueKey, valStr string) map[string]interface{} {
+	newObj := make(map[string]interface{})
+	for k, v := range obj {
+		newObj[k] = v
+	}
+	if valStr != "" {
+		newObj[valueKey] = valStr
+	}
+	if typStr, _ := obj[scimTypeKey].(string); typStr == "" {
+		delete(newObj, scimTypeKey)
+	}
+	return newObj
+}
+
+func normalizeMultiComplexObjectArray(objArr []map[string]interface{}, valueKey string) []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, len(objArr))
+	for _, obj := range objArr {
+		if len(obj) == 0 {
+			continue
+		}
+		valStr, nonMetaCount := multiComplexValue(obj, valueKey)
+		if valStr == "" && nonMetaCount == 0 {
+			// Object only has a "type" or "primary" field with no content keys — skip it.
+			continue
+		}
+		out = append(out, normalizeMultiComplexEntry(obj, valueKey, valStr))
+	}
+	if len(out) > 0 && !hasPrimary(out) {
+		out[0]["primary"] = true
+	}
+	return out
+}
+
+func normalizeMultiComplexSingleObject(singleObj map[string]interface{}, valueKey string) []map[string]interface{} {
+	if len(singleObj) == 0 {
+		return nil
+	}
+	valStr, nonMetaCount := multiComplexValue(singleObj, valueKey)
+	if valStr == "" && nonMetaCount == 0 {
+		return nil
+	}
+	newObj := normalizeMultiComplexEntry(singleObj, valueKey, valStr)
+	newObj["primary"] = true
+	return []map[string]interface{}{newObj}
 }
 
 func hasPrimary(arr []map[string]interface{}) bool {

--- a/backend/internal/scim/core_attr_mapper_test.go
+++ b/backend/internal/scim/core_attr_mapper_test.go
@@ -66,7 +66,8 @@ func TestMapToCoreAttrs_EmailPlainString(t *testing.T) {
 	require.NoError(t, json.Unmarshal(result["emails"], &emails))
 	require.Len(t, emails, 1)
 	require.Equal(t, "a@example.com", emails[0]["value"])
-	require.Equal(t, "work", emails[0]["type"])
+	_, hasType := emails[0]["type"]
+	require.False(t, hasType)
 	require.Equal(t, true, emails[0]["primary"])
 }
 
@@ -92,14 +93,16 @@ func TestMapToCoreAttrs_PhoneNumber(t *testing.T) {
 	var phones []map[string]interface{}
 	require.NoError(t, json.Unmarshal(result["phoneNumbers"], &phones))
 	require.Equal(t, "123456", phones[0]["value"])
-	require.Equal(t, "work", phones[0]["type"])
+	_, hasType := phones[0]["type"]
+	require.False(t, hasType)
 }
 
 func TestMapToCoreAttrs_Picture(t *testing.T) {
 	result := mapToCoreAttrs(json.RawMessage(`{"picture":"http://x/y.png"}`))
 	var photos []map[string]interface{}
 	require.NoError(t, json.Unmarshal(result["photos"], &photos))
-	require.Equal(t, "photo", photos[0]["type"])
+	_, hasType := photos[0]["type"]
+	require.False(t, hasType)
 }
 
 func TestMapToCoreAttrs_NameSubAttrsMerged(t *testing.T) {
@@ -134,7 +137,8 @@ func TestMapToCoreAttrs_AddressParts(t *testing.T) {
 	require.Equal(t, "NY", addrs[0]["region"])
 	require.Equal(t, "10001", addrs[0]["postalCode"])
 	require.Equal(t, "US", addrs[0]["country"])
-	require.Equal(t, "work", addrs[0]["type"])
+	_, hasType := addrs[0]["type"]
+	require.False(t, hasType)
 	require.Equal(t, true, addrs[0]["primary"])
 }
 
@@ -327,6 +331,32 @@ func TestReverseMapCoreAttrsForSchema_AddrPart(t *testing.T) {
 	require.JSONEq(t, `"US"`, string(result["country"]))
 }
 
+func TestMapToCoreAttrs_AddressObject(t *testing.T) {
+	result := mapToCoreAttrs(json.RawMessage(`{"address":{
+		"street_address":"456 Tech Park","locality":"Colombo","postal_code":"00100"
+	}}`))
+	require.NotNil(t, result)
+	var addrs []map[string]interface{}
+	require.NoError(t, json.Unmarshal(result["addresses"], &addrs))
+	require.Len(t, addrs, 1)
+	require.Equal(t, "456 Tech Park", addrs[0]["streetAddress"])
+	require.Equal(t, "Colombo", addrs[0]["locality"])
+	require.Equal(t, "00100", addrs[0]["postalCode"])
+	_, hasType := addrs[0]["type"]
+	require.False(t, hasType)
+	require.Equal(t, true, addrs[0]["primary"])
+}
+
+func TestMapToCoreAttrs_AddressObject_NonCanonicalSubAttrsDropped(t *testing.T) {
+	result := mapToCoreAttrs(json.RawMessage(`{"address":{"unknown_field":"456 Tech Park"}}`))
+	require.Nil(t, result["addresses"])
+}
+
+func TestMapToCoreAttrs_AddressArray_AllEntriesMetaOnly_NoAddresses(t *testing.T) {
+	result := mapToCoreAttrs(json.RawMessage(`{"address":[{"type":"work"}]}`))
+	require.Nil(t, result)
+}
+
 func TestReverseMapCoreAttrsForSchema_AddrPart_EmptyArray(t *testing.T) {
 	schema := json.RawMessage(`{"country":{"type":"string"}}`)
 	coreAttrs := map[string]json.RawMessage{
@@ -334,6 +364,41 @@ func TestReverseMapCoreAttrsForSchema_AddrPart_EmptyArray(t *testing.T) {
 	}
 	result := reverseMapCoreAttrsForSchema(coreAttrs, schema)
 	require.Nil(t, result)
+}
+
+func TestReverseMapCoreAttrsForSchema_AddressObject(t *testing.T) {
+	schema := json.RawMessage(`{
+		"address":{"type":"object","properties":{
+			"street_address":{"type":"string"},"locality":{"type":"string"},"postal_code":{"type":"string"}
+		}}
+	}`)
+	coreAttrs := map[string]json.RawMessage{
+		"addresses": json.RawMessage(`[{
+			"streetAddress":"456 Tech Park","locality":"Colombo","postalCode":"00100",
+			"type":"work","primary":true
+		}]`),
+	}
+	result := reverseMapCoreAttrsForSchema(coreAttrs, schema)
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(result["address"], &got))
+	require.Equal(t, "456 Tech Park", got["street_address"])
+	require.Equal(t, "Colombo", got["locality"])
+	require.Equal(t, "00100", got["postal_code"])
+}
+
+func TestReverseMapCoreAttrsForSchema_AddressArrayOfObjects(t *testing.T) {
+	schema := json.RawMessage(`{
+		"address":{"type":"array","items":{"type":"object"}}
+	}`)
+	coreAttrs := map[string]json.RawMessage{
+		"addresses": json.RawMessage(`[{"street":"456 Tech Park","city":"Colombo","type":"work","primary":true}]`),
+	}
+	result := reverseMapCoreAttrsForSchema(coreAttrs, schema)
+	var got []map[string]interface{}
+	require.NoError(t, json.Unmarshal(result["address"], &got))
+	require.Len(t, got, 1)
+	require.Equal(t, "456 Tech Park", got[0]["street"])
+	require.Equal(t, "Colombo", got[0]["city"])
 }
 
 // --- findCandidateValue ---
@@ -387,81 +452,94 @@ func TestExtractStringValue_EmptyArray(t *testing.T) {
 // --- normalizeToMultiComplex ---
 
 func TestNormalizeToMultiComplex_Empty(t *testing.T) {
-	require.Nil(t, normalizeToMultiComplex(nil, "work", "value"))
+	require.Nil(t, normalizeToMultiComplex(nil, "value"))
 }
 
 func TestNormalizeToMultiComplex_PlainString(t *testing.T) {
-	out := normalizeToMultiComplex(json.RawMessage(`"a@example.com"`), "work", "value")
+	out := normalizeToMultiComplex(json.RawMessage(`"a@example.com"`), "value")
 	require.Len(t, out, 1)
 	require.Equal(t, "a@example.com", out[0]["value"])
-	require.Equal(t, "work", out[0]["type"])
+	_, hasType := out[0]["type"]
+	require.False(t, hasType)
 	require.Equal(t, true, out[0]["primary"])
 }
 
 func TestNormalizeToMultiComplex_EmptyValueKeyDefaultsToValue(t *testing.T) {
-	out := normalizeToMultiComplex(json.RawMessage(`"a@example.com"`), "work", "")
+	out := normalizeToMultiComplex(json.RawMessage(`"a@example.com"`), "")
 	require.Equal(t, "a@example.com", out[0]["value"])
 }
 
 func TestNormalizeToMultiComplex_ArrayOfStrings(t *testing.T) {
-	out := normalizeToMultiComplex(json.RawMessage(`["a","b"]`), "work", "value")
+	out := normalizeToMultiComplex(json.RawMessage(`["a","b"]`), "value")
 	require.Len(t, out, 2)
 	require.Equal(t, true, out[0]["primary"])
 	require.Equal(t, false, out[1]["primary"])
 }
 
-func TestNormalizeToMultiComplex_ArrayOfObjects_DefaultType(t *testing.T) {
-	out := normalizeToMultiComplex(json.RawMessage(`[{"value":"a"}]`), "work", "value")
-	require.Equal(t, "work", out[0]["type"])
+func TestNormalizeToMultiComplex_ArrayOfObjects_NoTypeWhenMissing(t *testing.T) {
+	out := normalizeToMultiComplex(json.RawMessage(`[{"value":"a"}]`), "value")
+	_, hasType := out[0]["type"]
+	require.False(t, hasType)
 	require.Equal(t, true, out[0]["primary"])
 }
 
 func TestNormalizeToMultiComplex_ArrayOfObjects_ExplicitType(t *testing.T) {
-	out := normalizeToMultiComplex(json.RawMessage(`[{"value":"a","type":"home"}]`), "work", "value")
+	out := normalizeToMultiComplex(json.RawMessage(`[{"value":"a","type":"home"}]`), "value")
 	require.Equal(t, "home", out[0]["type"])
 }
 
 func TestNormalizeToMultiComplex_ArrayOfObjects_SkipsMissingValue(t *testing.T) {
-	out := normalizeToMultiComplex(json.RawMessage(`[{"type":"home"},{"value":"a"}]`), "work", "value")
+	out := normalizeToMultiComplex(json.RawMessage(`[{"type":"home"},{"value":"a"}]`), "value")
 	require.Len(t, out, 1)
 	require.Equal(t, "a", out[0]["value"])
 }
 
 func TestNormalizeToMultiComplex_ArrayOfObjects_PreservesExistingPrimary(t *testing.T) {
 	out := normalizeToMultiComplex(
-		json.RawMessage(`[{"value":"a","primary":false},{"value":"b","primary":true}]`), "work", "value",
+		json.RawMessage(`[{"value":"a","primary":false},{"value":"b","primary":true}]`), "value",
 	)
 	require.Equal(t, false, out[0]["primary"])
 	require.Equal(t, true, out[1]["primary"])
 }
 
 func TestNormalizeToMultiComplex_SingleObject(t *testing.T) {
-	out := normalizeToMultiComplex(json.RawMessage(`{"value":"a"}`), "work", "value")
+	out := normalizeToMultiComplex(json.RawMessage(`{"value":"a"}`), "value")
 	require.Len(t, out, 1)
 	require.Equal(t, true, out[0]["primary"])
-	require.Equal(t, "work", out[0]["type"])
+	_, hasType := out[0]["type"]
+	require.False(t, hasType)
 }
 
 func TestNormalizeToMultiComplex_SingleObject_MissingValue(t *testing.T) {
-	out := normalizeToMultiComplex(json.RawMessage(`{"type":"home"}`), "work", "value")
+	out := normalizeToMultiComplex(json.RawMessage(`{"type":"home"}`), "value")
 	require.Nil(t, out)
 }
 
+func TestNormalizeToMultiComplex_SingleObject_Empty(t *testing.T) {
+	require.Nil(t, normalizeToMultiComplex(json.RawMessage(`{}`), "value"))
+}
+
+func TestNormalizeToMultiComplex_ArrayOfObjects_SkipsEmptyObject(t *testing.T) {
+	out := normalizeToMultiComplex(json.RawMessage(`[{},{"value":"a"}]`), "value")
+	require.Len(t, out, 1)
+	require.Equal(t, "a", out[0]["value"])
+}
+
 func TestNormalizeToMultiComplex_ArrayOfObjects_CustomValueKeyFallback(t *testing.T) {
-	out := normalizeToMultiComplex(json.RawMessage(`[{"value":"a"}]`), "work", "custom")
+	out := normalizeToMultiComplex(json.RawMessage(`[{"value":"a"}]`), "custom")
 	require.Len(t, out, 1)
 	require.Equal(t, "a", out[0]["custom"])
 }
 
 func TestNormalizeToMultiComplex_SingleObject_CustomValueKeyFallback(t *testing.T) {
-	out := normalizeToMultiComplex(json.RawMessage(`{"value":"a"}`), "work", "custom")
+	out := normalizeToMultiComplex(json.RawMessage(`{"value":"a"}`), "custom")
 	require.Len(t, out, 1)
 	require.Equal(t, "a", out[0]["custom"])
 }
 
 func TestNormalizeToMultiComplex_UnmatchedShape(t *testing.T) {
-	require.Nil(t, normalizeToMultiComplex(json.RawMessage(`42`), "work", "value"))
-	require.Nil(t, normalizeToMultiComplex(json.RawMessage(`true`), "work", "value"))
+	require.Nil(t, normalizeToMultiComplex(json.RawMessage(`42`), "value"))
+	require.Nil(t, normalizeToMultiComplex(json.RawMessage(`true`), "value"))
 }
 
 // --- hasPrimary ---

--- a/backend/internal/scim/error_constants.go
+++ b/backend/internal/scim/error_constants.go
@@ -19,6 +19,9 @@
 package scim
 
 import (
+	"fmt"
+	"strings"
+
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 )
 
@@ -410,4 +413,35 @@ var (
 			DefaultValue: "The If-Match header does not match the current version of the resource",
 		},
 	}
+
+	// ErrorMissingCoreGroupSchema is returned when the schemas array does not
+	// include the SCIM Core Group schema URN.
+	ErrorMissingCoreGroupSchema = tidcommon.ServiceError{
+		Type: tidcommon.ClientErrorType,
+		Code: "SCIM-1028",
+		Error: tidcommon.I18nMessage{
+			Key:          "error.scim.missing_core_group_schema",
+			DefaultValue: "Missing SCIM core Group schema",
+		},
+		ErrorDescription: tidcommon.I18nMessage{
+			Key:          "error.scim.missing_core_group_schema_description",
+			DefaultValue: "The schemas array must include the SCIM Core Group schema URN",
+		},
+	}
 )
+
+// newMissingRequiredAttributesError builds a SCIM-1018 (schema validation failed)
+// error whose detail names the specific attribute(s) that the target user type
+// requires but the request did not supply, whether via core fields or the custom
+// extension object. Gives clients an actionable 400 instead of a generic failure.
+func newMissingRequiredAttributesError(userTypeName string, missing []string) *tidcommon.ServiceError {
+	svcErr := ErrorSchemaValidationFailed
+	svcErr.ErrorDescription = tidcommon.I18nMessage{
+		Key: ErrorSchemaValidationFailed.ErrorDescription.Key,
+		DefaultValue: fmt.Sprintf(
+			"User type %q requires the following attribute(s), which were not provided: %s",
+			userTypeName, strings.Join(missing, ", "),
+		),
+	}
+	return &svcErr
+}

--- a/backend/internal/scim/error_constants_test.go
+++ b/backend/internal/scim/error_constants_test.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package scim
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMissingRequiredAttributesError(t *testing.T) {
+	svcErr := newMissingRequiredAttributesError("employee", []string{"department", "employee_id"})
+
+	require.Equal(t, ErrorSchemaValidationFailed.Code, svcErr.Code)
+	require.Equal(t, ErrorSchemaValidationFailed.Type, svcErr.Type)
+	require.Contains(t, svcErr.ErrorDescription.DefaultValue, `"employee"`)
+	require.Contains(t, svcErr.ErrorDescription.DefaultValue, "department, employee_id")
+}

--- a/backend/internal/scim/group_handler.go
+++ b/backend/internal/scim/group_handler.go
@@ -75,7 +75,7 @@ func (h *scimGroupsHandler) HandleGroupsCreateRequest(w http.ResponseWriter, r *
 		}
 	}
 	if !hasGroupSchema {
-		h.handleSCIMError(w, r, &ErrorMissingSchemas)
+		h.handleSCIMError(w, r, &ErrorMissingCoreGroupSchema)
 		return
 	}
 	created, svcErr := h.svc.CreateGroup(ctx, payload.DisplayName, payload.Members, h.baseURL)
@@ -121,11 +121,23 @@ func (h *scimGroupsHandler) HandleGroupsReplaceRequest(w http.ResponseWriter, r 
 		return
 	}
 	var payload struct {
+		Schemas     []string          `json:"schemas"`
 		DisplayName string            `json:"displayName"`
 		Members     []SCIMGroupMember `json:"members"`
 	}
 	if err := json.Unmarshal(body, &payload); err != nil || payload.DisplayName == "" {
 		h.handleSCIMError(w, r, &ErrorInvalidRequestBody)
+		return
+	}
+	hasGroupSchema := false
+	for _, s := range payload.Schemas {
+		if strings.EqualFold(s, SCIMCoreGroupSchemaURN) {
+			hasGroupSchema = true
+			break
+		}
+	}
+	if !hasGroupSchema {
+		h.handleSCIMError(w, r, &ErrorMissingCoreGroupSchema)
 		return
 	}
 	replaced, svcErr := h.svc.ReplaceGroup(ctx, groupID, payload.DisplayName, payload.Members,

--- a/backend/internal/scim/group_handler_test.go
+++ b/backend/internal/scim/group_handler_test.go
@@ -157,7 +157,7 @@ func TestHandleGroupsReplaceRequest_Success(t *testing.T) {
 
 	h := newSCIMGroupsHandler(mockSvc, testBaseURL)
 	req := httptest.NewRequest(http.MethodPut, "/scim/v2/Groups/group-1",
-		bytes.NewBufferString(`{"displayName":"Renamed","members":[]}`))
+		bytes.NewBufferString(`{"schemas":["`+SCIMCoreGroupSchemaURN+`"],"displayName":"Renamed","members":[]}`))
 	req.Header.Set("Content-Type", constants.SCIMContentType)
 	req.SetPathValue("id", "group-1")
 	rr := httptest.NewRecorder()
@@ -239,7 +239,7 @@ func TestHandleGroupsReplaceRequest_ForwardsIfMatchHeader(t *testing.T) {
 
 	h := newSCIMGroupsHandler(mockSvc, testBaseURL)
 	req := httptest.NewRequest(http.MethodPut, "/scim/v2/Groups/group-1",
-		bytes.NewBufferString(`{"displayName":"Renamed","members":[]}`))
+		bytes.NewBufferString(`{"schemas":["`+SCIMCoreGroupSchemaURN+`"],"displayName":"Renamed","members":[]}`))
 	req.Header.Set("Content-Type", constants.SCIMContentType)
 	req.Header.Set("If-Match", `W/"v1"`)
 	req.SetPathValue("id", "group-1")
@@ -257,7 +257,7 @@ func TestHandleGroupsReplaceRequest_PreconditionFailed(t *testing.T) {
 
 	h := newSCIMGroupsHandler(mockSvc, testBaseURL)
 	req := httptest.NewRequest(http.MethodPut, "/scim/v2/Groups/group-1",
-		bytes.NewBufferString(`{"displayName":"Renamed","members":[]}`))
+		bytes.NewBufferString(`{"schemas":["`+SCIMCoreGroupSchemaURN+`"],"displayName":"Renamed","members":[]}`))
 	req.Header.Set("Content-Type", constants.SCIMContentType)
 	req.Header.Set("If-Match", `W/"stale"`)
 	req.SetPathValue("id", "group-1")
@@ -410,6 +410,18 @@ func TestHandleGroupsReplaceRequest_ErrorScenarios(t *testing.T) {
 		require.Equal(t, http.StatusBadRequest, rr.Code)
 	})
 
+	t.Run("MissingCoreSchema", func(t *testing.T) {
+		h := newSCIMGroupsHandler(nil, testBaseURL)
+		req := httptest.NewRequest(http.MethodPut, "/scim/v2/Groups/group-1",
+			bytes.NewBufferString(`{"displayName":"Renamed","members":[]}`))
+		req.Header.Set("Content-Type", constants.SCIMContentType)
+		req.SetPathValue("id", "group-1")
+		rr := httptest.NewRecorder()
+
+		h.HandleGroupsReplaceRequest(rr, req)
+		require.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+
 	t.Run("ServiceError", func(t *testing.T) {
 		mockSvc := NewSCIMGroupsServiceInterfaceMock(t)
 		mockSvc.On("ReplaceGroup", mock.Anything, "group-1", "Renamed", mock.Anything, "", testBaseURL).
@@ -417,7 +429,7 @@ func TestHandleGroupsReplaceRequest_ErrorScenarios(t *testing.T) {
 
 		h := newSCIMGroupsHandler(mockSvc, testBaseURL)
 		req := httptest.NewRequest(http.MethodPut, "/scim/v2/Groups/group-1",
-			bytes.NewBufferString(`{"displayName":"Renamed","members":[]}`))
+			bytes.NewBufferString(`{"schemas":["`+SCIMCoreGroupSchemaURN+`"],"displayName":"Renamed","members":[]}`))
 		req.Header.Set("Content-Type", constants.SCIMContentType)
 		req.SetPathValue("id", "group-1")
 		rr := httptest.NewRecorder()

--- a/backend/internal/scim/handler.go
+++ b/backend/internal/scim/handler.go
@@ -155,6 +155,7 @@ func mapSCIMError(svcErr *tidcommon.ServiceError) (httpStatus int, scimType stri
 	case ErrorMissingSchemas.Code,
 		ErrorDuplicateSchemas.Code,
 		ErrorMissingCoreUserSchema.Code,
+		ErrorMissingCoreGroupSchema.Code,
 		ErrorMissingCustomSchema.Code,
 		ErrorMultipleCustomSchemas.Code,
 		ErrorInvalidCustomSchemaURN.Code,

--- a/backend/internal/scim/schema_builder.go
+++ b/backend/internal/scim/schema_builder.go
@@ -21,6 +21,7 @@ package scim
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/thunder-id/thunderid/internal/entitytype"
@@ -57,7 +58,6 @@ func mapEntityTypeToSCIMSchema(et entitytype.EntityType, baseURL string) (SCIMSc
 		Meta: SCIMMeta{
 			ResourceType: "Schema",
 			Location:     location,
-			Version:      computeSchemaVersion(et),
 		},
 	}, nil
 }
@@ -132,6 +132,10 @@ func mapRawPropertyToSCIMAttribute(name string, def rawPropertyDef) SCIMSchemaAt
 			if len(itemAttr.CanonicalValues) > 0 {
 				attr.CanonicalValues = itemAttr.CanonicalValues
 			}
+			if itemAttr.Returned == scimReturnedNever {
+				attr.Returned = scimReturnedNever
+				attr.Mutability = scimMutabilityWriteOnly
+			}
 		} else {
 			// Array without an items definition — default to string per RFC 7643 §2.3.
 			attr.Type = scimAttrTypeString
@@ -181,7 +185,7 @@ func coreUserAttributes() []SCIMSchemaAttribute {
 			Type: scimAttrTypeString,
 			Description: "Unique identifier for the User, typically used by the user to directly " +
 				"authenticate to the service provider.",
-			Required:   false,
+			Required:   true,
 			CaseExact:  false,
 			Mutability: scimMutabilityReadWrite,
 			Returned:   scimReturnedDefault,
@@ -572,7 +576,7 @@ func coreGroupAttributes() []SCIMSchemaAttribute {
 			Name:        "displayName",
 			Type:        scimAttrTypeString,
 			Description: "A human-readable name for the Group.",
-			Required:    false,
+			Required:    true,
 			Mutability:  scimMutabilityReadWrite,
 			Returned:    scimReturnedDefault,
 			Uniqueness:  scimUniquenessNone,
@@ -641,6 +645,35 @@ type rawPropertyDef struct {
 	Items       *rawPropertyDef           `json:"items"`      // for type=array
 }
 
+// missingRequiredAttrs returns the names of entity-type schema properties marked
+// "required" that are absent from attrs, after core-attribute reverse-mapping has
+// already been merged in. This lets CreateUser/ReplaceUser reject a request with a
+// clear, per-user-type message instead of a generic schema-validation failure.
+// When skipCredential is true, required credential properties are not reported
+// missing (mirrors entitytype.Schema.Validate's skipCredentialRequired behavior
+// used on update, where credentials are not expected to be resent).
+func missingRequiredAttrs(attrs map[string]json.RawMessage, schema json.RawMessage, skipCredential bool) []string {
+	var rawProps map[string]rawPropertyDef
+	if err := json.Unmarshal(schema, &rawProps); err != nil {
+		return nil
+	}
+
+	var missing []string
+	for name, def := range rawProps {
+		if !def.Required {
+			continue
+		}
+		if skipCredential && def.Credential {
+			continue
+		}
+		if _, ok := attrs[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}
+
 // buildSchemaURN returns the canonical lowercase SCIM extension URN for a ThunderID user type.
 // Format: urn:thunderid:params:scim:schemas:<userTypeName>:2.0:User
 func buildSchemaURN(userTypeName string) string {
@@ -693,19 +726,4 @@ func rawEnumToStrings(raw []json.RawMessage) []string {
 		out = append(out, strings.TrimSpace(string(item)))
 	}
 	return out
-}
-
-// computeSchemaVersion produces a stable weak ETag for a dynamic SCIM extension
-// schema derived from a ThunderID EntityType. The hash covers the schema content
-// and the entity type name (which determines the URN), so any attribute change or
-// rename produces a new ETag. Format follows RFC 7232 weak validator convention.
-func computeSchemaVersion(et entitytype.EntityType) string {
-	state := struct {
-		Name   string
-		Schema json.RawMessage
-	}{
-		Name:   et.Name,
-		Schema: et.Schema,
-	}
-	return generateVersion(state)
 }

--- a/backend/internal/scim/schema_builder_test.go
+++ b/backend/internal/scim/schema_builder_test.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package scim
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMissingRequiredAttrs_InvalidSchemaJSON(t *testing.T) {
+	missing := missingRequiredAttrs(map[string]json.RawMessage{}, json.RawMessage(`not json`), false)
+	require.Nil(t, missing)
+}
+
+func TestMissingRequiredAttrs_AllPresent(t *testing.T) {
+	schema := json.RawMessage(`{"given_name":{"required":true}}`)
+	attrs := map[string]json.RawMessage{"given_name": json.RawMessage(`"Alice"`)}
+	missing := missingRequiredAttrs(attrs, schema, false)
+	require.Empty(t, missing)
+}
+
+func TestMissingRequiredAttrs_ReportsMissingSorted(t *testing.T) {
+	schema := json.RawMessage(`{
+		"given_name":{"required":true},
+		"family_name":{"required":true},
+		"nickname":{"required":false}
+	}`)
+	missing := missingRequiredAttrs(map[string]json.RawMessage{}, schema, false)
+	require.Equal(t, []string{"family_name", "given_name"}, missing)
+}
+
+func TestMissingRequiredAttrs_SkipCredentialTrue_OmitsCredential(t *testing.T) {
+	schema := json.RawMessage(`{"password":{"required":true,"credential":true}}`)
+	missing := missingRequiredAttrs(map[string]json.RawMessage{}, schema, true)
+	require.Empty(t, missing)
+}
+
+func TestMissingRequiredAttrs_SkipCredentialFalse_IncludesCredential(t *testing.T) {
+	schema := json.RawMessage(`{"password":{"required":true,"credential":true}}`)
+	missing := missingRequiredAttrs(map[string]json.RawMessage{}, schema, false)
+	require.Equal(t, []string{"password"}, missing)
+}
+
+func TestMapRawPropertyToSCIMAttribute_CredentialArrayItems_PropagatesNeverReturned(t *testing.T) {
+	def := rawPropertyDef{
+		Type: rawPropertyTypeArray,
+		Items: &rawPropertyDef{
+			Type:       rawPropertyTypeObject,
+			Credential: true,
+			Properties: map[string]rawPropertyDef{
+				"secret": {Type: "string", Credential: true},
+			},
+		},
+	}
+	attr := mapRawPropertyToSCIMAttribute("recovery_codes", def)
+	require.Equal(t, scimReturnedNever, attr.Returned)
+	require.Equal(t, scimMutabilityWriteOnly, attr.Mutability)
+}

--- a/backend/internal/scim/scim_validator.go
+++ b/backend/internal/scim/scim_validator.go
@@ -69,7 +69,9 @@ func ValidateSCIMUserRequest(body []byte) (*SCIMUserPayload, *tidcommon.ServiceE
 		return nil, &ErrorInvalidCustomSchemaURN
 	}
 
-	// Step 6: extension object must exist and be a JSON object
+	// Step 6: extension object is optional if no extension attributes are provided.
+	// If present, it must be a valid JSON object.
+	extAttrs := make(map[string]json.RawMessage)
 	var extRaw json.RawMessage
 	for k, v := range raw {
 		if strings.EqualFold(k, extensionURN) {
@@ -77,13 +79,10 @@ func ValidateSCIMUserRequest(body []byte) (*SCIMUserPayload, *tidcommon.ServiceE
 			break
 		}
 	}
-	if extRaw == nil {
-		return nil, &ErrorMissingCustomSchemaObject
-	}
-
-	var extAttrs map[string]json.RawMessage
-	if err := json.Unmarshal(extRaw, &extAttrs); err != nil || extAttrs == nil {
-		return nil, &ErrorMissingCustomSchemaObject
+	if extRaw != nil {
+		if err := json.Unmarshal(extRaw, &extAttrs); err != nil || extAttrs == nil {
+			return nil, &ErrorMissingCustomSchemaObject
+		}
 	}
 
 	// Collect core attributes (those that are not "schemas" or the extension URN)
@@ -97,6 +96,23 @@ func ValidateSCIMUserRequest(body []byte) (*SCIMUserPayload, *tidcommon.ServiceE
 		}
 		coreAttrs[k] = v
 	}
+
+	// Step 7: if the request carries core attributes, the SCIM Core User schema
+	// URN must be declared in "schemas". A custom-type-only payload (no core
+	// attributes at all) does not need to declare it.
+	if len(coreAttrs) > 0 {
+		hasCoreUserSchema := false
+		for _, urn := range schemas {
+			if strings.EqualFold(urn, SCIMCoreUserSchemaURN) {
+				hasCoreUserSchema = true
+				break
+			}
+		}
+		if !hasCoreUserSchema {
+			return nil, &ErrorMissingCoreUserSchema
+		}
+	}
+
 	return &SCIMUserPayload{
 		ExtensionURN:   extensionURN,
 		UserTypeName:   userTypeName,

--- a/backend/internal/scim/scim_validator_test.go
+++ b/backend/internal/scim/scim_validator_test.go
@@ -65,9 +65,11 @@ func TestValidateSCIMUserRequest(t *testing.T) {
 			wantErrCode: ErrorInvalidCustomSchemaURN.Code,
 		},
 		{
-			name:        "MissingExtensionObject",
-			body:        []byte(`{"schemas":["` + validURN + `"]}`),
-			wantErrCode: ErrorMissingCustomSchemaObject.Code,
+			name:         "OmittedExtensionObject_DefaultsToEmpty",
+			body:         []byte(`{"schemas":["` + SCIMCoreUserSchemaURN + `","` + validURN + `"],"userName":"alice"}`),
+			wantErrCode:  "",
+			wantUserType: "employee",
+			wantExtURN:   validURN,
 		},
 		{
 			name:        "InvalidExtensionObjectJSON",
@@ -77,13 +79,25 @@ func TestValidateSCIMUserRequest(t *testing.T) {
 		{
 			name: "ValidPayload",
 			body: []byte(`{
-				"schemas":["` + validURN + `"],
+				"schemas":["` + SCIMCoreUserSchemaURN + `","` + validURN + `"],
 				"` + validURN + `":{"department":"engineering"},
 				"userName":"alice"
 			}`),
 			wantErrCode:  "",
 			wantUserType: "employee",
 			wantExtURN:   validURN,
+		},
+		{
+			name:         "ValidPayload_ExtensionOnly_NoCoreAttrs_CoreSchemaOmitted",
+			body:         []byte(`{"schemas":["` + validURN + `"],"` + validURN + `":{"given_name":"alice"}}`),
+			wantErrCode:  "",
+			wantUserType: "employee",
+			wantExtURN:   validURN,
+		},
+		{
+			name:        "CoreAttrsPresent_CoreUserSchemaMissing",
+			body:        []byte(`{"schemas":["` + validURN + `"],"` + validURN + `":{}, "userName":"alice"}`),
+			wantErrCode: ErrorMissingCoreUserSchema.Code,
 		},
 	}
 

--- a/backend/internal/scim/users_service.go
+++ b/backend/internal/scim/users_service.go
@@ -125,6 +125,11 @@ func (s *scimUsersService) CreateUser(
 			}
 		}
 	}
+	if missing := missingRequiredAttrs(payload.ExtensionAttrs, et.Schema, false); len(missing) > 0 {
+		logger.Debug(ctx, "SCIM CreateUser: missing required attributes for user type",
+			log.String("userType", canonicalName), log.Any("missing", missing))
+		return nil, newMissingRequiredAttributesError(canonicalName, missing)
+	}
 	attrsJSON, err := json.Marshal(payload.ExtensionAttrs)
 	if err != nil {
 		logger.Error(ctx, "SCIM CreateUser: failed to marshal extension attrs", log.Error(err))
@@ -194,6 +199,11 @@ func (s *scimUsersService) ReplaceUser(
 				payload.ExtensionAttrs[k] = v
 			}
 		}
+	}
+	if missing := missingRequiredAttrs(payload.ExtensionAttrs, et.Schema, true); len(missing) > 0 {
+		logger.Debug(ctx, "SCIM ReplaceUser: missing required attributes for user type",
+			log.String("userType", canonicalName), log.Any("missing", missing))
+		return nil, newMissingRequiredAttributesError(canonicalName, missing)
 	}
 	attrsJSON, err := json.Marshal(payload.ExtensionAttrs)
 	if err != nil {

--- a/backend/internal/scim/users_service_test.go
+++ b/backend/internal/scim/users_service_test.go
@@ -285,6 +285,35 @@ func TestCreateUser_Success(t *testing.T) {
 	require.Contains(t, scimUser.Schemas, "urn:thunderid:params:scim:schemas:employee:2.0:User")
 }
 
+func TestCreateUser_MissingRequiredAttribute_ReturnsSchemaValidationError(t *testing.T) {
+	mockUserService := usermock.NewUserServiceInterfaceMock(t)
+	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(mockUserService, mockEntityService)
+
+	payload := &SCIMUserPayload{
+		UserTypeName:   "employee",
+		ExtensionURN:   "urn:thunderid:params:scim:schemas:employee:2.0:User",
+		ExtensionAttrs: map[string]json.RawMessage{"given_name": json.RawMessage(`"Alice"`)},
+	}
+
+	mockEntityService.On(
+		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
+	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
+	mockEntityService.On(
+		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, "employee",
+	).Return(&entitytype.EntityType{
+		Name: "employee", OUID: "ou-abc",
+		Schema: json.RawMessage(`{"department":{"required":true}}`),
+	}, (*tidcommon.ServiceError)(nil))
+
+	scimUser, err := service.CreateUser(context.Background(), payload, testBaseURL)
+
+	require.NotNil(t, err)
+	require.Equal(t, ErrorSchemaValidationFailed.Code, err.Code)
+	require.Contains(t, err.ErrorDescription.DefaultValue, "department")
+	require.Nil(t, scimUser)
+}
+
 func TestCreateUser_EntityTypeNotFound_ReturnsUnknownUserType(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
 	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
@@ -442,6 +471,37 @@ func TestReplaceUser_Success(t *testing.T) {
 	require.NotNil(t, scimUser)
 	require.Equal(t, "user-123", scimUser.ID)
 	require.Contains(t, scimUser.Schemas, "urn:thunderid:params:scim:schemas:employee:2.0:User")
+}
+
+func TestReplaceUser_MissingRequiredAttribute_ReturnsSchemaValidationError(t *testing.T) {
+	mockUserService := usermock.NewUserServiceInterfaceMock(t)
+	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(mockUserService, mockEntityService)
+
+	payload := &SCIMUserPayload{
+		UserTypeName:   "employee",
+		ExtensionURN:   "urn:thunderid:params:scim:schemas:employee:2.0:User",
+		ExtensionAttrs: map[string]json.RawMessage{"given_name": json.RawMessage(`"Charlie"`)},
+	}
+
+	mockEntityService.On(
+		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
+	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
+	mockEntityService.On(
+		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, "employee",
+	).Return(&entitytype.EntityType{
+		Name: "employee", OUID: "ou-abc",
+		Schema: json.RawMessage(`{"department":{"required":true}}`),
+	}, (*tidcommon.ServiceError)(nil))
+	mockUserService.On("GetUser", mock.Anything, "user-123", false).
+		Return(&user.User{ID: "user-123", Type: "employee"}, (*tidcommon.ServiceError)(nil))
+
+	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL)
+
+	require.NotNil(t, err)
+	require.Equal(t, ErrorSchemaValidationFailed.Code, err.Code)
+	require.Contains(t, err.ErrorDescription.DefaultValue, "department")
+	require.Nil(t, scimUser)
 }
 
 func TestReplaceUser_EntityTypeNotFound_ReturnsUnknownUserType(t *testing.T) {

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -1032,6 +1032,8 @@ var defaultMessages = map[string]string{
 	"error.scim.invalid_patch_value_description": "The PATCH operation value is missing or malformed for the given op/path",
 	"error.scim.invalid_request_body": "Invalid request body",
 	"error.scim.invalid_request_body_description": "The request body is not valid JSON or does not conform to the SCIM schema.",
+	"error.scim.missing_core_group_schema": "Missing SCIM core Group schema",
+	"error.scim.missing_core_group_schema_description": "The schemas array must include the SCIM Core Group schema URN",
 	"error.scim.missing_core_user_schema": "Missing SCIM core User schema",
 	"error.scim.missing_core_user_schema_description": "The schemas array must include the SCIM Core User schema URN",
 	"error.scim.missing_custom_schema": "Missing custom schema",


### PR DESCRIPTION
### Purpose
Fixes several SCIM 2.0 correctness bugs found during API testing: missing required-attribute validation on CreateUser/ReplaceUser, missing core schema URN validation on Group PUT/replace, and two attribute-mapping bugs — fabricated `type` values on emails/phoneNumbers/photos/addresses that were never provided, and non-canonical address sub-attributes leaking into the core `addresses` response instead of the RFC 7643 canonical names.

### Approach
- `missingRequiredAttrs` in `schema_builder.go` checks entity-type schema `required` properties against merged attributes post reverse-mapping; `CreateUser`/`ReplaceUser` now return a per-attribute error via `newMissingRequiredAttributesError` instead of a generic schema-validation failure.
- `ValidateSCIMUserRequest` now requires the core User schema URN whenever the request carries core attributes (previously ungated), and the extension object is optional when the request has no extension attributes. Group PUT/replace gained the equivalent core Group schema URN check.
- `core_attr_mapper.go`: removed the `defaultType` fabrication for `kindMultiComplex` fields (email/phone/photo/address) — `type` is now only set when the source data actually has one; `primary:true` is still applied to a lone value. Added `filterCanonicalAddrKeys` so only RFC 7643 `streetAddress`/`locality`/`region`/`postalCode`/`country`/`formatted` sub-attributes (plus `type`/`primary`) survive into the core `addresses` response, anything else is dropped rather than leaked.

### Related Issues
- N/A

### Related PRs
- #4184 

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
