### PR TITLE
Upload coverage for merge queue commits so Codecov compares against the right base

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -97,11 +97,13 @@ jobs:
 
   codecov-merge-queue-status:
     name: 📊 Codecov Merge Queue Status
-    # Codecov does not reliably process merge queue (merge_group) commits, leaving the
-    # required codecov/patch status stuck at "Expected" and timing the queue entry out.
-    # Patch coverage is already enforced on the pull request before it can enter the
-    # queue, and the queue commit carries the same diff rebased onto main, so this job
-    # marks codecov/patch as passed on the queue commit instead of re-running Codecov.
+    # Coverage is uploaded for queue commits (see the upload steps below), but Codecov
+    # does not reliably report a status back on them, which leaves codecov/patch stuck
+    # at "Expected" and times the queue entry out. Patch coverage is already enforced on
+    # the pull request before it can enter the queue, and the queue commit carries the
+    # same diff rebased onto main, so this job marks codecov/patch as passed rather than
+    # waiting for a status. It guards the queue's timing only; the uploaded report is
+    # what gives main the coverage data Codecov compares later pull requests against.
     # Tracker: https://github.com/codecov/codecov-action/issues/1796
     if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
@@ -319,10 +321,12 @@ jobs:
           set -e
           ./build.sh test_unit $(go env GOOS) $(go env GOARCH)
 
+      # Uploaded on merge queue commits too. The queue commit is what lands on
+      # main, so skipping it left main without a coverage report, and Codecov
+      # then compared every pull request against whichever older main commit it
+      # still had a report for. Its patch totals covered that wider range of
+      # commits rather than the pull request's own diff.
       - name: 📊 Upload Unit Test Coverage Report to Codecov
-        # Skipped on merge queue commits: Codecov cannot process them, and the
-        # codecov-merge-queue-status job stamps the required status instead.
-        if: github.event_name != 'merge_group'
         uses: codecov/codecov-action@v5
         timeout-minutes: 5
         continue-on-error: true
@@ -589,7 +593,6 @@ jobs:
           path: coverage/gate
 
       - name: 📊 Upload `@thunderid/console` Unit Test Coverage Report to Codecov
-        if: github.event_name != 'merge_group'
         uses: codecov/codecov-action@v5
         timeout-minutes: 5
         continue-on-error: true
@@ -602,7 +605,6 @@ jobs:
           fail_ci_if_error: false
 
       - name: 📊 Upload `@thunderid/gate` Unit Test Coverage Report to Codecov
-        if: github.event_name != 'merge_group'
         uses: codecov/codecov-action@v5
         timeout-minutes: 5
         continue-on-error: true
@@ -752,7 +754,6 @@ jobs:
           if-no-files-found: error
 
       - name: 📊 Upload Integration Test Coverage Report to Codecov
-        if: github.event_name != 'merge_group'
         uses: codecov/codecov-action@v5
         timeout-minutes: 5
         continue-on-error: true


### PR DESCRIPTION
### Purpose

Make Codecov's own patch coverage number correct, so the patch coverage gate can rely on it instead of computing patch coverage locally.

Refs #4268.

Codecov's patch total currently describes a wider range of commits than the pull request. On #4397, a CI-only change, Codecov reported 100% patch coverage: it compared head `7e9cb078` against base `ddfe60e0` instead of the branch point `586dc497`, and the two covered lines it counted came from `backend/internal/idp/{constants,utils}.go` in an unrelated commit. Across the open pull requests where the base can be checked, Codecov's comparison base matched the branch point in 0 of 6, with the same stale base reused across unrelated pull requests (`54a48822` for #4398 and #4358, `08795e4e` for #4390 and #4380).

### Root cause

All four Codecov uploads were skipped on `merge_group`, and `pr-builder.yml` is the only workflow that uploads coverage, so no coverage was ever uploaded for a main commit:

- The merge queue commit is what lands on main. Confirmed on recent queue runs: their head commits are ancestors of main.
- Skipping the upload there left main commits without a coverage report.
- Codecov needs a base that has a report, so for each pull request it walked back from the branch point to whichever older main commit still had one.
- Its patch total then spans that older base to the head, sweeping in unrelated commits.

So the wrong numbers were not a Codecov defect and not a flaw in the local computation; they were caused by our own pipeline never giving Codecov a report for main.

### Approach

The `if: github.event_name != 'merge_group'` guard is removed from the four upload steps (backend unit, console, gate, and the integration matrix). A merge queue run already executes all of those jobs, so it now produces the same six uploads a pull request does, matching `after_n_builds: 6` in codecov.yml. Every commit that lands on main gets a complete report, and Codecov's base for later pull requests becomes the branch point.

`codecov-merge-queue-status` stays. Its purpose narrows to what it actually guards: Codecov not reporting a status back on a queue commit in time. The comment is updated accordingly, since its previous wording implied queue commits cannot carry coverage data at all.

### Effect

Once main commits carry reports, Codecov compares each pull request against its branch point, its patch total describes that pull request's diff, and the gate's Codecov path becomes authoritative. The base check added in #4397 then passes instead of handing over to the local computation, so the local path returns to being a fallback for when Codecov is unavailable. This is also the precondition for retiring the custom gate entirely.

The effect is not retroactive: bases correct themselves as commits land on main with reports.

### Risk

With a real report present, Codecov may begin posting statuses on queue commits, which could race the `codecov-merge-queue-status` stamp if it later reports a different result. `codecov/patch` is currently not a required check and is not posting at all, so this is theoretical today, but it is worth watching on the first few queue entries after this merges.

### Related Issues
- Refs #4268

### Related PRs
- #4397 adds the base verification that this change makes pass.

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
