### PR TITLE
Change flowAutoInferRegistration to false

### DIFF
--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -439,7 +439,7 @@ configuration:
   # Flow configuration
   flow:
     maxVersionHistory: 3
-    autoInferRegistration: true
+    autoInferRegistration: false
     # Optional whitelist of built-in executor names to register at startup.
     # Leave empty to register all built-in executors.
     executors: []


### PR DESCRIPTION
## Description

Change the default value of `configuration.flow.autoInferRegistration` from `true` to `false` in the Helm chart values.

## Related Issues

N/A

## Checklist
- [x] I have tested this change.
- [x] This PR contains a single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)