### PR TITLE
Fix home page add button

### DIFF
--- a/frontend/apps/console/src/configs/RouteConfig.ts
+++ b/frontend/apps/console/src/configs/RouteConfig.ts
@@ -174,7 +174,6 @@ const RouteConfig: RouteConfig = {
     detail: (userId) => `/${ROUTE_SEGMENTS.users}/${userId}`,
     add: () => `/${ROUTE_SEGMENTS.users}/add`,
     addCreate: () => `/${ROUTE_SEGMENTS.users}/add/create`,
-    addInvite: () => `/${ROUTE_SEGMENTS.users}/add/invite`,
   },
   userTypes: {
     list: () => `/${ROUTE_SEGMENTS.userTypes}`,

--- a/frontend/apps/console/src/configs/__tests__/RouteConfig.test.ts
+++ b/frontend/apps/console/src/configs/__tests__/RouteConfig.test.ts
@@ -31,7 +31,6 @@ describe('RouteConfig', () => {
     expect(RouteConfig.users.detail('user-1')).toBe('/users/user-1');
     expect(RouteConfig.users.add()).toBe('/users/add');
     expect(RouteConfig.users.addCreate()).toBe('/users/add/create');
-    expect(RouteConfig.users.addInvite()).toBe('/users/add/invite');
   });
 
   it('userTypes builds paths from the segment', () => {

--- a/frontend/apps/console/src/features/home/components/cards/InviteMembersCard.tsx
+++ b/frontend/apps/console/src/features/home/components/cards/InviteMembersCard.tsx
@@ -23,6 +23,7 @@ import {UsersRound} from '@wso2/oxygen-ui-icons-react';
 import {motion} from 'framer-motion';
 import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
+import RouteConfig from '../../../../configs/RouteConfig';
 import HomeNextStepCard from './HomeNextStepCard';
 
 const AVATAR_LIMIT = 5;
@@ -125,15 +126,13 @@ export default function InviteMembersCard(): JSX.Element {
   return (
     <HomeNextStepCard
       icon={<UsersRound size={24} />}
-      title={t('next_steps.invite_members.title', 'Invite Members')}
+      title={t('next_steps.invite_members.title', 'Add Users')}
       description={t(
         'next_steps.invite_members.description',
-        'Add collaborators to help manage your organization and act as a backup.',
+        'Add or invite collaborators to help manage your organization.',
       )}
       primaryLabel={t('next_steps.invite_members.actions.primary.label', 'Add User')}
-      primaryRoute="/users/add"
-      secondaryLabel={t('next_steps.invite_members.actions.secondary.label', 'Invite User')}
-      secondaryRoute="/users/add/invite"
+      primaryRoute={RouteConfig.users.add()}
       preview={preview}
     />
   );

--- a/frontend/apps/console/src/features/home/components/cards/__tests__/InviteMembersCard.test.tsx
+++ b/frontend/apps/console/src/features/home/components/cards/__tests__/InviteMembersCard.test.tsx
@@ -137,16 +137,10 @@ describe('InviteMembersCard', () => {
       mockUseGetUsers.mockReturnValue({isLoading: false, data: {totalResults: 3, users: []}});
     });
 
-    it('renders the primary "Add User" button', () => {
+    it('renders the "Add User" button', () => {
       render(<InviteMembersCard />);
 
       expect(screen.getByRole('button', {name: 'Add User'})).toBeInTheDocument();
-    });
-
-    it('renders the secondary "Invite User" button', () => {
-      render(<InviteMembersCard />);
-
-      expect(screen.getByRole('button', {name: 'Invite User'})).toBeInTheDocument();
     });
 
     it('navigates to /users/add when Add User is clicked', () => {
@@ -155,14 +149,6 @@ describe('InviteMembersCard', () => {
       fireEvent.click(screen.getByRole('button', {name: 'Add User'}));
 
       expect(mockNavigate).toHaveBeenCalledWith('/users/add');
-    });
-
-    it('navigates to /users/add/invite when Invite User is clicked', () => {
-      render(<InviteMembersCard />);
-
-      fireEvent.click(screen.getByRole('button', {name: 'Invite User'}));
-
-      expect(mockNavigate).toHaveBeenCalledWith('/users/add/invite');
     });
   });
 });

--- a/frontend/packages/configure-users/src/hooks/useUserRoutes.ts
+++ b/frontend/packages/configure-users/src/hooks/useUserRoutes.ts
@@ -33,7 +33,6 @@ export interface UserRoutePaths {
     detail: (userId: string) => string;
     add: () => string;
     addCreate: () => string;
-    addInvite: () => string;
   };
 }
 
@@ -48,7 +47,6 @@ export const defaultUserRoutePaths: UserRoutePaths = {
     detail: (userId) => `/users/${userId}`,
     add: () => '/users/add',
     addCreate: () => '/users/add/create',
-    addInvite: () => '/users/add/invite',
   },
 };
 

--- a/frontend/packages/configure-users/src/pages/UserAddPage.tsx
+++ b/frontend/packages/configure-users/src/pages/UserAddPage.tsx
@@ -927,10 +927,10 @@ export default function UserAddPage(): JSX.Element {
   const [hasOuStep, setHasOuStep] = useState(false);
 
   const handleClose = useCallback(() => {
-    Promise.resolve(navigate(routes.list())).catch((error: unknown) => {
-      logger.error('Failed to navigate to users page', {error});
+    Promise.resolve(navigate(-1)).catch((error: unknown) => {
+      logger.error('Failed to navigate back', {error});
     });
-  }, [navigate, routes, logger]);
+  }, [navigate, logger]);
 
   const handleManualCreateFallback = useCallback(() => {
     logger.info('Falling back to manual user creation because the onboarding flow is unavailable');

--- a/frontend/packages/configure-users/src/pages/__tests__/UserAddPage.test.tsx
+++ b/frontend/packages/configure-users/src/pages/__tests__/UserAddPage.test.tsx
@@ -342,7 +342,7 @@ describe('UserAddPage', () => {
       const closeButton = screen.getByRole('button', {name: /close/i});
       await userEvent.click(closeButton);
 
-      expect(mockNavigate).toHaveBeenCalledWith('/users');
+      expect(mockNavigate).toHaveBeenCalledWith(-1);
     });
 
     it('should reset flow when Add User breadcrumb is clicked', async () => {
@@ -569,7 +569,7 @@ describe('UserAddPage', () => {
       const closeButtons = screen.getAllByRole('button', {name: /close/i});
       await userEvent.click(closeButtons[closeButtons.length - 1]);
 
-      expect(mockNavigate).toHaveBeenCalledWith('/users');
+      expect(mockNavigate).toHaveBeenCalledWith(-1);
     });
 
     it('should render COPYABLE_TEXT component with value from additionalData', () => {

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -4148,10 +4148,9 @@ const translations = {
     'next_steps.section.title': 'Quick Links',
 
     // Invite Members card
-    'next_steps.invite_members.title': 'Invite Members',
-    'next_steps.invite_members.description': 'Add collaborators to help manage your organization and act as a backup.',
+    'next_steps.invite_members.title': 'Add Users',
+    'next_steps.invite_members.description': 'Add or invite collaborators to help manage your organization.',
     'next_steps.invite_members.actions.primary.label': 'Add User',
-    'next_steps.invite_members.actions.secondary.label': 'Invite User',
     'next_steps.invite_members.status.count': '{{count}} member',
     'next_steps.invite_members.status.count_other': '{{count}} members',
     'next_steps.invite_members.status.empty': 'No members yet — add collaborators',


### PR DESCRIPTION
This pull request removes the "Invite User" option from the user management flows and updates related UI and test code to reflect this change. It also updates the "Invite Members" card to use the terminology "Add Users" and simplifies navigation logic in the user add page.

**User Management Route and UI Updates:**

* Removed the `addInvite` route and references from `RouteConfig`, `useUserRoutes`, and their respective tests to eliminate the `/users/add/invite` path. [[1]](diffhunk://#diff-ce665c616571cc125b4cba9d887a88fb28ecd0e0203e09f06ff597e2e6d684b2L177) [[2]](diffhunk://#diff-8d376ac83e65550c642946ffcd0ec7bce796665422a445bdec14240e3f7528e8L36) [[3]](diffhunk://#diff-8d376ac83e65550c642946ffcd0ec7bce796665422a445bdec14240e3f7528e8L51) [[4]](diffhunk://#diff-38af0170a31224634e57eeac369fe75a76e077d349cb32010ca42ab71cd14a00L34)
* Updated the `InviteMembersCard` component and its tests to remove the secondary "Invite User" action and route, leaving only "Add User". [[1]](diffhunk://#diff-ecf33bd2b4338bce9981cd2393262008ef8af5c94f5925d5b17898d378ef376dL128-L136) [[2]](diffhunk://#diff-162d7190986a8b0ab1bbf8cf5efc03a1ee5cd22632272bf87dacdf2844698170L159-L166)

<img width="764" height="359" alt="image" src="https://github.com/user-attachments/assets/dca811d6-0ad6-421e-b69c-7ed0df11fcab" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the homepage onboarding card to focus on adding users, with refreshed wording.
  * Added support for the user creation route.

* **Changes**
  * Removed the separate “Invite User” action from the onboarding card.
  * Closing the user creation page now returns to the previous page instead of always returning to the users list.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->