### PR TITLE
Scope the E2E dependency install to the E2E package

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -858,13 +858,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: 🔧 Install Required OS Utilities
-        # jq/lsof/unzip are used by the bash setup steps below.
-        # build-essential is needed because `pnpm install --frozen-lockfile` at the workspace root
-        # triggers the better-sqlite3 postinstall, which falls back to `node-gyp rebuild` (needs
-        # make + g++) when no prebuilt binary matches the container's Node version.
+        # jq/lsof/unzip are used by the bash setup steps below. No toolchain is
+        # needed: the install below is scoped to @thunderid/e2e, so it never
+        # reaches the better-sqlite3 postinstall that would want node-gyp.
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends jq lsof unzip build-essential
+          apt-get install -y --no-install-recommends jq lsof unzip
 
       - name: 📥 Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -1214,8 +1213,11 @@ jobs:
           
           echo "Sample App started successfully!"
 
+      # Scoped to the E2E package: it has no workspace dependencies, so installing
+      # the whole monorepo here only added time and dragged in native builds from
+      # unrelated sample apps.
       - name: 📦 Install E2E Dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --filter @thunderid/e2e
 
       - name: 🎭 Run Playwright E2E Tests
         run: pnpm test


### PR DESCRIPTION
### Purpose

The E2E job is the tail of the PR Builder critical path, and it spent 101s installing the entire monorepo to test a package with no workspace dependencies.

Measured on run 30516200446 (a normal successful pull request run):

| E2E step | Time |
|---|---|
| 🎭 Run Playwright E2E Tests | 373s |
| 📦 Install E2E Dependencies | **101s** |
| 📱 Extract and Start Sample App | 27s |
| Initialize containers | 26s |
| 🔧 Install Required OS Utilities | **15s** |

Refs #4268.

### Approach

`pnpm install --frozen-lockfile` becomes `pnpm install --frozen-lockfile --filter @thunderid/e2e`.

`@thunderid/e2e` declares 12 dependencies and every one of them is external: dotenv, express, prettier, typescript, eslint and its plugins, the TypeScript types, `@playwright/test` and `@axe-core/playwright`. Nothing is `workspace:` linked, and the suite runs against the packaged server and the packaged sample app rather than against workspace packages, so the root install produced nothing this job used.

That also removes the reason `build-essential` was installed. The comment on the OS utilities step explains it: the workspace-root install triggers `better-sqlite3`'s postinstall, which falls back to `node-gyp rebuild`. That dependency belongs to `samples/apps/wayfinder-sample/backend`, which this job never touches. `jq`, `lsof` and `unzip` are still installed because the bash setup steps use them.

### Verification

The filter selector resolves to the intended package:

```
$ pnpm list --filter @thunderid/e2e --depth -1
@thunderid/e2e@1.0.0 /.../tests/e2e
```

The scoped install completes and pulls 220 packages instead of the whole workspace:

```
$ pnpm install --frozen-lockfile --filter @thunderid/e2e
Lockfile is up to date, resolution step is skipped
. | +220 ++++++++++++++++++++++
Done in 878ms
```

Playwright is fully usable afterwards, which is what the job needs:

```
$ pnpm exec playwright --version
Version 1.60.0
$ pnpm exec playwright test --list
Total: 133 tests in 9 files
```

All 133 tests across the 9 spec files still enumerate, including the serial CORS and MFA projects, so no spec is lost. Browsers continue to come from the `mcr.microsoft.com/playwright` container image and are unaffected by the install scope.

### Effect

Around 95s comes off the critical path (the install plus the toolchain package). Nothing else about the job changes: the same suite runs with the same workers against the same server and sample app.

### Related Issues
- Refs #4268

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined end-to-end test environment setup by installing only the required system utilities.
  * Reduced dependency installation for end-to-end testing to the dedicated test package, improving setup efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->