### PR TITLE
Fix laggy typing in flow builder executor property fields

### DIFF
--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/CommonResourceProperties.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/CommonResourceProperties.tsx
@@ -362,9 +362,21 @@ function CommonResourceProperties(): ReactElement {
     handlePropertyChangeDebouncedRef.current = debouncedFn;
 
     return () => {
-      debouncedFn.cancel();
+      // Commit rather than discard: closing the panel within the debounce window would
+      // otherwise silently drop the last thing the user typed.
+      debouncedFn.flush();
     };
   }, []);
+
+  // A pending edit resolves the target step from refs at fire time, so selecting another
+  // resource first would write it to the newly selected one. Cleanup runs before the refs
+  // are re-synced below, so the flush still lands on the resource it was typed into.
+  useEffect(
+    () => () => {
+      (handlePropertyChangeDebouncedRef.current as ReturnType<typeof debounce> | null)?.flush();
+    },
+    [lastInteractedResource?.id, lastInteractedStepId],
+  );
 
   /**
    * Unified property change handler.

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/CommonResourceProperties.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/CommonResourceProperties.test.tsx
@@ -16,9 +16,9 @@
  * under the License.
  */
 
-import {render, screen} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 import {ReactFlowProvider} from '@xyflow/react';
-import type {ReactNode} from 'react';
+import {useState, type ReactNode} from 'react';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import FlowConfigContext, {type FlowConfigContextProps} from '../../../context/FlowConfigContext';
 import InteractionContext, {type InteractionContextProps} from '../../../context/InteractionContext';
@@ -2159,6 +2159,99 @@ describe('CommonResourceProperties', () => {
       });
 
       expect(mockUpdateNodeData).toHaveBeenCalled();
+    });
+  });
+
+  describe('Flushing pending debounced changes', () => {
+    const DebouncedChangeComponent = ({
+      resource,
+      onChange,
+    }: {
+      resource: Resource;
+      onChange: (key: string, value: string, resource: Resource, debounce?: boolean) => void;
+    }) => (
+      <button type="button" onClick={() => onChange('data.properties.template', 'typed', resource, true)}>
+        Type
+      </button>
+    );
+
+    it('should commit a pending change when the panel unmounts', () => {
+      const context = createContextValue({
+        ResourceProperties: DebouncedChangeComponent as unknown as FlowConfigContextProps['ResourceProperties'],
+      });
+
+      const {unmount} = render(<CommonResourceProperties />, {wrapper: createWrapper(context)});
+
+      fireEvent.click(screen.getByText('Type'));
+      expect(mockUpdateNodeData).not.toHaveBeenCalled();
+
+      // Closing the panel inside the debounce window must not discard the edit.
+      unmount();
+
+      expect(mockUpdateNodeData).toHaveBeenCalledWith('step-1', expect.any(Function));
+    });
+
+    it('should commit a pending change to the resource it was typed into when the selection moves', () => {
+      const resourceB = {...mockBaseResource, id: 'resource-2'} as Base;
+
+      function SelectionHarness() {
+        const [selection, setSelection] = useState<{resource: Base; stepId: string}>({
+          resource: mockBaseResource,
+          stepId: 'step-1',
+        });
+
+        const interactionValue: InteractionContextProps = {
+          lastInteractedResource: selection.resource,
+          lastInteractedStepId: selection.stepId,
+          setLastInteractedResource: mockSetLastInteractedResource,
+          setLastInteractedStepId: vi.fn(),
+          onResourceDropOnCanvas: vi.fn(),
+          selectedAttributes: {},
+          setSelectedAttributes: vi.fn(),
+        };
+
+        const flowConfigValue = {
+          ElementFactory: () => null,
+          ResourceProperties: DebouncedChangeComponent,
+          flowCompletionConfigs: {},
+          setFlowCompletionConfigs: vi.fn(),
+          isVerboseMode: false,
+          setIsVerboseMode: vi.fn(),
+          edgeStyle: EdgeStyleTypes.SmoothStep,
+          setEdgeStyle: vi.fn(),
+          flowNodeTypes: {},
+          flowEdgeTypes: {},
+          setFlowNodeTypes: vi.fn(),
+          setFlowEdgeTypes: vi.fn(),
+          flowNodes: [],
+          setFlowNodes: vi.fn(),
+          graphValidationRules: [],
+          setGraphValidationRules: vi.fn(),
+        } as unknown as FlowConfigContextProps;
+
+        return (
+          <ReactFlowProvider>
+            <InteractionContext.Provider value={interactionValue}>
+              <FlowConfigContext.Provider value={flowConfigValue}>
+                <button type="button" onClick={() => setSelection({resource: resourceB, stepId: 'step-2'})}>
+                  Select Other Step
+                </button>
+                <CommonResourceProperties />
+              </FlowConfigContext.Provider>
+            </InteractionContext.Provider>
+          </ReactFlowProvider>
+        );
+      }
+
+      render(<SelectionHarness />);
+
+      fireEvent.click(screen.getByText('Type'));
+      fireEvent.click(screen.getByText('Select Other Step'));
+
+      // The pending edit resolves its target step when it fires, so selecting another
+      // step first must not redirect the write to that step.
+      expect(mockUpdateNodeData).toHaveBeenCalledWith('step-1', expect.any(Function));
+      expect(mockUpdateNodeData).not.toHaveBeenCalledWith('step-2', expect.any(Function));
     });
   });
 });

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/__tests__/ExecutionExtendedProperties.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/__tests__/ExecutionExtendedProperties.test.tsx
@@ -52,6 +52,12 @@ vi.mock('react-i18next', () => ({
         'flows:core.executions.passkey.relyingPartyName.label': 'Relying Party Name',
         'flows:core.executions.passkey.relyingPartyName.placeholder': 'Enter relying party name',
         'flows:core.executions.passkey.relyingPartyName.hint': 'Relying party name hint',
+        'flows:core.executions.templateScenarios.userInvite': 'User Invite',
+        'flows:core.executions.templateScenarios.magicLink': 'Magic Link',
+        'flows:core.executions.templateScenarios.selfRegistration': 'Self Registration',
+        'flows:core.executions.templateScenarios.otp': 'OTP Verification',
+        'flows:core.executions.templateScenarios.passwordRecovery': 'Password Recovery',
+        'flows:core.executions.templateScenarios.cibaNotification': 'CIBA Notification',
         'flows:core.executions.consent.description': 'Configure the consent executor settings.',
         'flows:core.executions.consent.timeout.label': 'Consent Timeout (seconds)',
         'flows:core.executions.consent.timeout.placeholder': '0',
@@ -528,24 +534,23 @@ describe('ExecutionExtendedProperties', () => {
 
       render(<ExecutionExtendedProperties resource={resourceWithChallengeMode} onChange={mockOnChange} />);
 
-      fireEvent.change(screen.getByLabelText('Relying Party ID'), {
-        target: {value: 'localhost'},
-      });
-      fireEvent.change(screen.getByLabelText('Relying Party Name'), {
-        target: {value: 'ThunderID'},
-      });
+      const relyingPartyIdInput = screen.getByLabelText('Relying Party ID');
+      const relyingPartyNameInput = screen.getByLabelText('Relying Party Name');
+
+      fireEvent.change(relyingPartyIdInput, {target: {value: 'localhost'}});
+      fireEvent.blur(relyingPartyIdInput);
+      fireEvent.change(relyingPartyNameInput, {target: {value: 'ThunderID'}});
+      fireEvent.blur(relyingPartyNameInput);
 
       expect(mockOnChange).toHaveBeenCalledWith(
         'data.properties.relyingPartyId',
         'localhost',
         resourceWithChallengeMode,
-        true,
       );
       expect(mockOnChange).toHaveBeenCalledWith(
         'data.properties.relyingPartyName',
         'ThunderID',
         resourceWithChallengeMode,
-        true,
       );
     });
 
@@ -629,7 +634,7 @@ describe('ExecutionExtendedProperties', () => {
       expect(screen.getByLabelText('Consent Timeout (seconds)')).toHaveValue(0);
     });
 
-    it('should call onChange when timeout changes', () => {
+    it('should commit the timeout on blur', () => {
       const consentResourceWithTimeout = {
         ...consentResource,
         data: {
@@ -646,35 +651,152 @@ describe('ExecutionExtendedProperties', () => {
       fireEvent.change(timeoutInput, {
         target: {value: '45'},
       });
+      fireEvent.blur(timeoutInput);
 
-      expect(mockOnChange).toHaveBeenLastCalledWith('data.properties.timeout', '45', consentResourceWithTimeout, true);
+      expect(mockOnChange).toHaveBeenLastCalledWith('data.properties.timeout', '45', consentResourceWithTimeout);
     });
 
-    it('should normalize empty timeout to 0', () => {
+    it('should not commit the timeout while typing', () => {
       render(<ExecutionExtendedProperties resource={consentResource} onChange={mockOnChange} />);
+
+      const timeoutInput = screen.getByLabelText('Consent Timeout (seconds)');
+      fireEvent.change(timeoutInput, {target: {value: '45'}});
+
+      expect(mockOnChange).not.toHaveBeenCalled();
+      expect(timeoutInput).toHaveValue(45);
+    });
+
+    it('should normalize empty timeout to 0 on blur', () => {
+      const consentResourceWithTimeout = {
+        ...consentResource,
+        data: {
+          ...(consentResource as unknown as {data: object}).data,
+          properties: {timeout: '20'},
+        },
+      } as unknown as Resource;
+
+      render(<ExecutionExtendedProperties resource={consentResourceWithTimeout} onChange={mockOnChange} />);
 
       const timeoutInput = screen.getByLabelText('Consent Timeout (seconds)');
       fireEvent.change(timeoutInput, {target: {value: ''}});
+      fireEvent.blur(timeoutInput);
 
-      expect(mockOnChange).toHaveBeenLastCalledWith('data.properties.timeout', '0', consentResource, true);
+      expect(mockOnChange).toHaveBeenLastCalledWith('data.properties.timeout', '0', consentResourceWithTimeout);
     });
 
-    it('should clamp negative timeout to 0', () => {
-      render(<ExecutionExtendedProperties resource={consentResource} onChange={mockOnChange} />);
+    it('should clamp negative timeout to 0 on blur', () => {
+      const consentResourceWithTimeout = {
+        ...consentResource,
+        data: {
+          ...(consentResource as unknown as {data: object}).data,
+          properties: {timeout: '20'},
+        },
+      } as unknown as Resource;
+
+      render(<ExecutionExtendedProperties resource={consentResourceWithTimeout} onChange={mockOnChange} />);
 
       const timeoutInput = screen.getByLabelText('Consent Timeout (seconds)');
       fireEvent.change(timeoutInput, {target: {value: '-5'}});
+      fireEvent.blur(timeoutInput);
 
-      expect(mockOnChange).toHaveBeenLastCalledWith('data.properties.timeout', '0', consentResource, true);
+      expect(mockOnChange).toHaveBeenLastCalledWith('data.properties.timeout', '0', consentResourceWithTimeout);
     });
 
-    it('should floor decimal timeout to integer', () => {
+    it('should floor decimal timeout to integer on blur', () => {
       render(<ExecutionExtendedProperties resource={consentResource} onChange={mockOnChange} />);
 
       const timeoutInput = screen.getByLabelText('Consent Timeout (seconds)');
       fireEvent.change(timeoutInput, {target: {value: '3.7'}});
+      fireEvent.blur(timeoutInput);
 
-      expect(mockOnChange).toHaveBeenLastCalledWith('data.properties.timeout', '3', consentResource, true);
+      expect(mockOnChange).toHaveBeenLastCalledWith('data.properties.timeout', '3', consentResource);
+    });
+
+    it('should commit the timeout on Enter', () => {
+      render(<ExecutionExtendedProperties resource={consentResource} onChange={mockOnChange} />);
+
+      const timeoutInput = screen.getByLabelText('Consent Timeout (seconds)');
+      fireEvent.change(timeoutInput, {target: {value: '15'}});
+      fireEvent.keyDown(timeoutInput, {key: 'Enter'});
+
+      expect(mockOnChange).toHaveBeenLastCalledWith('data.properties.timeout', '15', consentResource);
+    });
+  });
+
+  describe('OTP Executor', () => {
+    const otpResource = {
+      id: 'otp-executor-1',
+      data: {
+        action: {
+          executor: {
+            name: ExecutionTypes.OTPExecutor,
+          },
+        },
+        properties: {
+          otpLength: 6,
+          otpValidityPeriodSeconds: 120,
+        },
+      },
+    } as unknown as Resource;
+
+    // The executor resolves these through a numeric conversion that rejects strings, so
+    // committing them as text would leave the configured value ignored at runtime.
+    it('should commit otpLength as a number', () => {
+      render(<ExecutionExtendedProperties resource={otpResource} onChange={mockOnChange} />);
+
+      const otpLengthInput = screen.getByLabelText('flows:core.executions.otp.otpLength.label');
+      fireEvent.change(otpLengthInput, {target: {value: '8'}});
+      fireEvent.blur(otpLengthInput);
+
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.otpLength', 8, otpResource);
+    });
+
+    it('should commit otpValidityPeriodSeconds as a number', () => {
+      render(<ExecutionExtendedProperties resource={otpResource} onChange={mockOnChange} />);
+
+      const validityInput = screen.getByLabelText('flows:core.executions.otp.otpValidityPeriodSeconds.label');
+      fireEvent.change(validityInput, {target: {value: '300'}});
+      fireEvent.blur(validityInput);
+
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.otpValidityPeriodSeconds', 300, otpResource);
+    });
+
+    it('should commit maxAttempts as a number', () => {
+      render(<ExecutionExtendedProperties resource={otpResource} onChange={mockOnChange} />);
+
+      const maxAttemptsInput = screen.getByLabelText('flows:core.executions.otp.maxAttempts.label');
+      fireEvent.change(maxAttemptsInput, {target: {value: '5'}});
+      fireEvent.blur(maxAttemptsInput);
+
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.maxAttempts', 5, otpResource);
+    });
+
+    it('should not commit otpLength while typing', () => {
+      render(<ExecutionExtendedProperties resource={otpResource} onChange={mockOnChange} />);
+
+      const otpLengthInput = screen.getByLabelText('flows:core.executions.otp.otpLength.label');
+      fireEvent.change(otpLengthInput, {target: {value: '8'}});
+
+      expect(mockOnChange).not.toHaveBeenCalled();
+      expect(otpLengthInput).toHaveValue(8);
+    });
+
+    it('should clamp otpLength to the supported range on blur', () => {
+      render(<ExecutionExtendedProperties resource={otpResource} onChange={mockOnChange} />);
+
+      const otpLengthInput = screen.getByLabelText('flows:core.executions.otp.otpLength.label');
+      fireEvent.change(otpLengthInput, {target: {value: '25'}});
+      fireEvent.blur(otpLengthInput);
+
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.otpLength', 10, otpResource);
+    });
+
+    it('should still commit booleans immediately', () => {
+      render(<ExecutionExtendedProperties resource={otpResource} onChange={mockOnChange} />);
+
+      fireEvent.click(screen.getByRole('checkbox'));
+
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.otpUseNumericOnly', true, otpResource);
     });
   });
 
@@ -701,28 +823,64 @@ describe('ExecutionExtendedProperties', () => {
       expect(screen.getByLabelText('flows:core.executions.email.emailTemplate.label')).toBeInTheDocument();
     });
 
-    it('should call onChange with debounce when email template changes', () => {
+    it('should offer the supported template scenarios with readable labels', async () => {
       render(<ExecutionExtendedProperties resource={emailResource} onChange={mockOnChange} />);
 
-      fireEvent.change(screen.getByLabelText('flows:core.executions.email.emailTemplate.label'), {
-        target: {value: 'welcome-email'},
-      });
+      await userEvent.click(screen.getByLabelText('flows:core.executions.email.emailTemplate.label'));
 
-      expect(mockOnChange).toHaveBeenCalledWith('data.properties.emailTemplate', 'welcome-email', emailResource, true);
+      expect(screen.getByRole('option', {name: 'OTP Verification'})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'User Invite'})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'Password Recovery'})).toBeInTheDocument();
     });
 
-    it('should display existing email template value', () => {
+    it('should commit the raw scenario value for the selected label', async () => {
+      render(<ExecutionExtendedProperties resource={emailResource} onChange={mockOnChange} />);
+
+      await userEvent.click(screen.getByLabelText('flows:core.executions.email.emailTemplate.label'));
+      await userEvent.click(screen.getByRole('option', {name: 'Magic Link'}));
+
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.emailTemplate', 'MAGIC_LINK', emailResource);
+    });
+
+    it('should find a scenario by searching its readable label', async () => {
+      render(<ExecutionExtendedProperties resource={emailResource} onChange={mockOnChange} />);
+
+      await userEvent.type(screen.getByLabelText('flows:core.executions.email.emailTemplate.label'), 'recov');
+
+      expect(screen.getByRole('option', {name: 'Password Recovery'})).toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: 'User Invite'})).not.toBeInTheDocument();
+    });
+
+    it('should display the label for the existing email template value', () => {
       const resourceWithTemplate = {
         ...emailResource,
         data: {
           ...(emailResource as unknown as {data: object}).data,
-          properties: {emailTemplate: 'reset-password'},
+          properties: {emailTemplate: 'PASSWORD_RECOVERY'},
         },
       } as unknown as Resource;
 
       render(<ExecutionExtendedProperties resource={resourceWithTemplate} onChange={mockOnChange} />);
 
-      expect(screen.getByLabelText('flows:core.executions.email.emailTemplate.label')).toHaveValue('reset-password');
+      expect(screen.getByLabelText('flows:core.executions.email.emailTemplate.label')).toHaveValue('Password Recovery');
+    });
+
+    it('should preserve a template scenario it does not know about', async () => {
+      const resourceWithUnknownTemplate = {
+        ...emailResource,
+        data: {
+          ...(emailResource as unknown as {data: object}).data,
+          properties: {emailTemplate: 'CUSTOM_SCENARIO'},
+        },
+      } as unknown as Resource;
+
+      render(<ExecutionExtendedProperties resource={resourceWithUnknownTemplate} onChange={mockOnChange} />);
+
+      const input = screen.getByLabelText('flows:core.executions.email.emailTemplate.label');
+      expect(input).toHaveValue('CUSTOM_SCENARIO');
+
+      await userEvent.click(input);
+      expect(screen.getByRole('option', {name: 'CUSTOM_SCENARIO'})).toBeInTheDocument();
     });
   });
 
@@ -756,7 +914,7 @@ describe('ExecutionExtendedProperties', () => {
       expect(screen.getByText('Sender')).toBeInTheDocument();
     });
 
-    it('should call onChange with debounce when SMS template changes', () => {
+    it('should commit the selected SMS template immediately', async () => {
       mockSMSProviders.mockReturnValue({
         data: [],
         isLoading: false,
@@ -764,11 +922,10 @@ describe('ExecutionExtendedProperties', () => {
 
       render(<ExecutionExtendedProperties resource={smsResource} onChange={mockOnChange} />);
 
-      fireEvent.change(screen.getByLabelText('flows:core.executions.sms.smsTemplate.label'), {
-        target: {value: 'otp-message'},
-      });
+      await userEvent.click(screen.getByLabelText('flows:core.executions.sms.smsTemplate.label'));
+      await userEvent.click(screen.getByRole('option', {name: 'OTP Verification'}));
 
-      expect(mockOnChange).toHaveBeenCalledWith('data.properties.smsTemplate', 'otp-message', smsResource, true);
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.smsTemplate', 'OTP', smsResource);
     });
 
     it('should show warning when no senders are available', () => {
@@ -1017,14 +1174,14 @@ describe('ExecutionExtendedProperties', () => {
       );
     });
 
-    it('should call onChange with debounce when maxPerPrompt changes', () => {
+    it('should commit maxPerPrompt as a number on blur', () => {
       render(<ExecutionExtendedProperties resource={provisioningResource} onChange={mockOnChange} />);
 
-      fireEvent.change(screen.getByLabelText('flows:core.executions.provisioning.maxPerPrompt.label'), {
-        target: {value: '3'},
-      });
+      const maxPerPromptInput = screen.getByLabelText('flows:core.executions.provisioning.maxPerPrompt.label');
+      fireEvent.change(maxPerPromptInput, {target: {value: '3'}});
+      fireEvent.blur(maxPerPromptInput);
 
-      expect(mockOnChange).toHaveBeenCalledWith('data.properties.maxPerPrompt', 3, provisioningResource, true);
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.maxPerPrompt', 3, provisioningResource);
     });
 
     it('should fall back to 0 for malformed persisted maxPerPrompt values', () => {
@@ -1061,34 +1218,24 @@ describe('ExecutionExtendedProperties', () => {
       expect(screen.getByLabelText('flows:core.executions.provisioning.maxPerPrompt.label')).toHaveValue(0);
     });
 
-    it('should call onChange with debounce when assignGroup changes', () => {
+    it('should commit assignGroup on blur', () => {
       render(<ExecutionExtendedProperties resource={provisioningResource} onChange={mockOnChange} />);
 
-      fireEvent.change(screen.getByLabelText('flows:core.executions.provisioning.assignGroup.label'), {
-        target: {value: 'admin-group'},
-      });
+      const assignGroupInput = screen.getByLabelText('flows:core.executions.provisioning.assignGroup.label');
+      fireEvent.change(assignGroupInput, {target: {value: 'admin-group'}});
+      fireEvent.blur(assignGroupInput);
 
-      expect(mockOnChange).toHaveBeenCalledWith(
-        'data.properties.assignGroup',
-        'admin-group',
-        provisioningResource,
-        true,
-      );
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.assignGroup', 'admin-group', provisioningResource);
     });
 
-    it('should call onChange with debounce when assignRole changes', () => {
+    it('should commit assignRole on blur', () => {
       render(<ExecutionExtendedProperties resource={provisioningResource} onChange={mockOnChange} />);
 
-      fireEvent.change(screen.getByLabelText('flows:core.executions.provisioning.assignRole.label'), {
-        target: {value: 'editor-role'},
-      });
+      const assignRoleInput = screen.getByLabelText('flows:core.executions.provisioning.assignRole.label');
+      fireEvent.change(assignRoleInput, {target: {value: 'editor-role'}});
+      fireEvent.blur(assignRoleInput);
 
-      expect(mockOnChange).toHaveBeenCalledWith(
-        'data.properties.assignRole',
-        'editor-role',
-        provisioningResource,
-        true,
-      );
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.assignRole', 'editor-role', provisioningResource);
     });
   });
 
@@ -1146,14 +1293,14 @@ describe('ExecutionExtendedProperties', () => {
       expect(screen.getByLabelText('flows:core.executions.ouExecutor.parentOuId.label')).toBeInTheDocument();
     });
 
-    it('should call onChange with debounce when parentOuId changes', () => {
+    it('should commit parentOuId on blur', () => {
       render(<ExecutionExtendedProperties resource={ouResource} onChange={mockOnChange} />);
 
-      fireEvent.change(screen.getByLabelText('flows:core.executions.ouExecutor.parentOuId.label'), {
-        target: {value: 'ou-123'},
-      });
+      const parentOuIdInput = screen.getByLabelText('flows:core.executions.ouExecutor.parentOuId.label');
+      fireEvent.change(parentOuIdInput, {target: {value: 'ou-123'}});
+      fireEvent.blur(parentOuIdInput);
 
-      expect(mockOnChange).toHaveBeenCalledWith('data.properties.parentOuId', 'ou-123', ouResource, true);
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.parentOuId', 'ou-123', ouResource);
     });
 
     it('should display existing parentOuId value', () => {
@@ -1262,14 +1409,24 @@ describe('ExecutionExtendedProperties', () => {
       expect(screen.getByLabelText('flows:core.executions.httpRequest.timeout.label')).toBeInTheDocument();
     });
 
-    it('should call onChange with debounce when URL changes', () => {
+    it('should commit the URL on blur', () => {
       render(<ExecutionExtendedProperties resource={httpResource} onChange={mockOnChange} />);
 
-      fireEvent.change(screen.getByLabelText('flows:core.executions.httpRequest.url.label'), {
-        target: {value: 'https://api.example.com'},
-      });
+      const urlInput = screen.getByLabelText('flows:core.executions.httpRequest.url.label');
+      fireEvent.change(urlInput, {target: {value: 'https://api.example.com'}});
+      fireEvent.blur(urlInput);
 
-      expect(mockOnChange).toHaveBeenCalledWith('data.properties.url', 'https://api.example.com', httpResource, true);
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.url', 'https://api.example.com', httpResource);
+    });
+
+    it('should not commit the URL while typing', () => {
+      render(<ExecutionExtendedProperties resource={httpResource} onChange={mockOnChange} />);
+
+      const urlInput = screen.getByLabelText('flows:core.executions.httpRequest.url.label');
+      fireEvent.change(urlInput, {target: {value: 'https://api.example.com'}});
+
+      expect(mockOnChange).not.toHaveBeenCalled();
+      expect(urlInput).toHaveValue('https://api.example.com');
     });
 
     it('should call onChange without debounce when method changes', async () => {
@@ -1297,73 +1454,92 @@ describe('ExecutionExtendedProperties', () => {
       );
     });
 
-    it('should call onChange with debounce when timeout changes', () => {
+    it('should commit the timeout on blur', () => {
       render(<ExecutionExtendedProperties resource={httpResource} onChange={mockOnChange} />);
 
-      fireEvent.change(screen.getByLabelText('flows:core.executions.httpRequest.timeout.label'), {
-        target: {value: '15'},
-      });
+      const timeoutInput = screen.getByLabelText('flows:core.executions.httpRequest.timeout.label');
+      fireEvent.change(timeoutInput, {target: {value: '15'}});
+      fireEvent.blur(timeoutInput);
 
       expect(mockOnChange).toHaveBeenCalledWith('data.properties.timeout', 15, httpResource);
     });
 
-    it('should clamp timeout to max 20', () => {
+    it('should clamp timeout to max 20 on blur', () => {
       render(<ExecutionExtendedProperties resource={httpResource} onChange={mockOnChange} />);
 
-      fireEvent.change(screen.getByLabelText('flows:core.executions.httpRequest.timeout.label'), {
-        target: {value: '99'},
-      });
+      const timeoutInput = screen.getByLabelText('flows:core.executions.httpRequest.timeout.label');
+      fireEvent.change(timeoutInput, {target: {value: '99'}});
+      fireEvent.blur(timeoutInput);
 
       expect(mockOnChange).toHaveBeenCalledWith('data.properties.timeout', 20, httpResource);
+      expect(timeoutInput).toHaveValue(20);
     });
 
-    it('should call onChange with debounce when body changes', () => {
+    it('should commit a raw body on blur', () => {
       render(<ExecutionExtendedProperties resource={httpResource} onChange={mockOnChange} />);
 
-      fireEvent.change(screen.getByLabelText('flows:core.executions.httpRequest.body.label'), {
-        target: {value: 'raw body text'},
-      });
+      const bodyInput = screen.getByLabelText('flows:core.executions.httpRequest.body.label');
+      fireEvent.change(bodyInput, {target: {value: 'raw body text'}});
+      fireEvent.blur(bodyInput);
 
       expect(mockOnChange).toHaveBeenCalledWith('data.properties.body', 'raw body text', httpResource);
     });
 
-    it('should parse valid JSON body', () => {
+    it('should parse valid JSON body on blur', () => {
       render(<ExecutionExtendedProperties resource={httpResource} onChange={mockOnChange} />);
 
-      fireEvent.change(screen.getByLabelText('flows:core.executions.httpRequest.body.label'), {
-        target: {value: '{"key":"value"}'},
-      });
+      const bodyInput = screen.getByLabelText('flows:core.executions.httpRequest.body.label');
+      fireEvent.change(bodyInput, {target: {value: '{"key":"value"}'}});
+      fireEvent.blur(bodyInput);
 
       expect(mockOnChange).toHaveBeenCalledWith('data.properties.body', {key: 'value'}, httpResource);
     });
 
-    it('should call onChange with debounce when retryCount changes', () => {
+    it('should not store a half-typed body while typing JSON', () => {
       render(<ExecutionExtendedProperties resource={httpResource} onChange={mockOnChange} />);
 
-      fireEvent.change(screen.getByLabelText('flows:core.executions.httpRequest.errorHandling.retryCount.label'), {
-        target: {value: '3'},
-      });
+      const bodyInput = screen.getByLabelText('flows:core.executions.httpRequest.body.label');
+      fireEvent.change(bodyInput, {target: {value: '{"key"'}});
+      fireEvent.change(bodyInput, {target: {value: '{"key":"value"}'}});
+
+      expect(mockOnChange).not.toHaveBeenCalled();
+    });
+
+    it('should keep Enter as a newline in the multiline body', () => {
+      render(<ExecutionExtendedProperties resource={httpResource} onChange={mockOnChange} />);
+
+      const bodyInput = screen.getByLabelText('flows:core.executions.httpRequest.body.label');
+      fireEvent.change(bodyInput, {target: {value: 'line one'}});
+      fireEvent.keyDown(bodyInput, {key: 'Enter'});
+
+      expect(mockOnChange).not.toHaveBeenCalled();
+    });
+
+    it('should commit retryCount on blur', () => {
+      render(<ExecutionExtendedProperties resource={httpResource} onChange={mockOnChange} />);
+
+      const retryCountInput = screen.getByLabelText('flows:core.executions.httpRequest.errorHandling.retryCount.label');
+      fireEvent.change(retryCountInput, {target: {value: '3'}});
+      fireEvent.blur(retryCountInput);
 
       expect(mockOnChange).toHaveBeenCalledWith(
         'data.properties.errorHandling',
         expect.objectContaining({retryCount: 3}),
         httpResource,
-        true,
       );
     });
 
-    it('should call onChange with debounce when retryDelay changes', () => {
+    it('should commit retryDelay on blur', () => {
       render(<ExecutionExtendedProperties resource={httpResource} onChange={mockOnChange} />);
 
-      fireEvent.change(screen.getByLabelText('flows:core.executions.httpRequest.errorHandling.retryDelay.label'), {
-        target: {value: '1000'},
-      });
+      const retryDelayInput = screen.getByLabelText('flows:core.executions.httpRequest.errorHandling.retryDelay.label');
+      fireEvent.change(retryDelayInput, {target: {value: '1000'}});
+      fireEvent.blur(retryDelayInput);
 
       expect(mockOnChange).toHaveBeenCalledWith(
         'data.properties.errorHandling',
         expect.objectContaining({retryDelay: 1000}),
         httpResource,
-        true,
       );
     });
   });

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/ConsentProperties.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/ConsentProperties.tsx
@@ -16,10 +16,12 @@
  * under the License.
  */
 
-import {FormHelperText, FormLabel, Stack, TextField, Typography} from '@wso2/oxygen-ui';
+import {FormHelperText, FormLabel, Stack, Typography} from '@wso2/oxygen-ui';
 import {useMemo, type ReactNode} from 'react';
 import {useTranslation} from 'react-i18next';
+import DraftTextField from './DraftTextField';
 import type {CommonResourcePropertiesPropsInterface} from './types';
+import {clampToInteger} from './utils';
 import type {StepData} from '@/features/flows/models/steps';
 
 function ConsentProperties({resource, onChange}: CommonResourcePropertiesPropsInterface): ReactNode {
@@ -30,21 +32,6 @@ function ConsentProperties({resource, onChange}: CommonResourcePropertiesPropsIn
     return (stepData?.properties as {timeout?: string})?.timeout ?? '0';
   }, [resource]);
 
-  const handleTimeoutChange = (value: string): void => {
-    if (value === '') {
-      onChange('data.properties.timeout', '0', resource, true);
-      return;
-    }
-
-    const num = Number(value);
-    if (Number.isNaN(num)) {
-      return;
-    }
-
-    const parsed = Math.max(0, Math.floor(num));
-    onChange('data.properties.timeout', String(parsed), resource, true);
-  };
-
   return (
     <Stack gap={2}>
       <Typography variant="body2" color="text.secondary">
@@ -53,10 +40,12 @@ function ConsentProperties({resource, onChange}: CommonResourcePropertiesPropsIn
 
       <div>
         <FormLabel htmlFor="consent-timeout">{t('flows:core.executions.consent.timeout.label')}</FormLabel>
-        <TextField
+        <DraftTextField
           id="consent-timeout"
           value={currentTimeout}
-          onChange={(e) => handleTimeoutChange(e.target.value)}
+          // The executor parses this property as a string, so it is stored as one.
+          onCommit={(value) => onChange('data.properties.timeout', value, resource)}
+          normalize={(raw) => clampToInteger(raw, 0)}
           placeholder={t('flows:core.executions.consent.timeout.placeholder')}
           fullWidth
           size="small"

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/DraftTextField.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/DraftTextField.tsx
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {TextField, type TextFieldProps} from '@wso2/oxygen-ui';
+import {useEffect, useRef, useState, type ChangeEvent, type KeyboardEvent, type ReactElement} from 'react';
+
+/**
+ * Props interface of {@link DraftTextField}
+ */
+export type DraftTextFieldPropsInterface = Omit<TextFieldProps, 'value' | 'onChange' | 'onBlur' | 'onKeyDown'> & {
+  /**
+   * The committed property value.
+   */
+  value: string;
+  /**
+   * Commits the edited value. Called on blur and on Enter, never per keystroke.
+   */
+  onCommit: (value: string) => void;
+  /**
+   * Coerces a raw draft into the value to commit (clamping, rounding, defaults).
+   * Returning `null` rejects the edit and restores {@link value}.
+   */
+  normalize?: (raw: string) => string | null;
+};
+
+/**
+ * Text field for executor properties that keeps the in-progress edit in local state
+ * and commits it once the user is done.
+ *
+ * Committing a property is expensive — it clones the step's component tree, writes to
+ * the React Flow store and re-renders the property panel — and these fields have no
+ * canvas preview that needs to follow the keystrokes. Holding the draft locally keeps
+ * typing at native speed, and committing on blur/Enter avoids the mid-typing commits
+ * that would otherwise reset the caret.
+ *
+ * @param props - Props injected to the component.
+ * @returns The DraftTextField component.
+ */
+function DraftTextField({value, onCommit, normalize = undefined, ...rest}: DraftTextFieldPropsInterface): ReactElement {
+  const [draft, setDraft] = useState<string>(value);
+  // The last `value` prop this field has seen, so an external change is distinguishable
+  // from a parent that simply has not echoed a commit back yet.
+  const [syncedValue, setSyncedValue] = useState<string>(value);
+  // What this field has already handed upwards. Pressing Enter and then blurring both
+  // reach `commit`, so this is what makes the second one a no-op.
+  const [committed, setCommitted] = useState<string>(value);
+
+  // Re-sync when the value changes outside this field — a different resource is selected,
+  // or an undo/redo or plugin rewrote the property. Adjusting during render rather than in
+  // an effect avoids rendering the stale value first.
+  if (value !== syncedValue) {
+    setSyncedValue(value);
+    setDraft(value);
+    setCommitted(value);
+  }
+
+  // Resolves what the draft should store, or null when the edit is rejected outright.
+  const resolve = (): string | null => (normalize ? normalize(draft) : draft);
+
+  const commit = (): void => {
+    const next: string | null = resolve();
+
+    if (next === null) {
+      setDraft(committed);
+      return;
+    }
+
+    // Normalization can rewrite the draft without changing the stored value (typing
+    // `99` into a field that clamps at 20 when 20 is already stored), so the field is
+    // reset to the normalized text whether or not a commit follows.
+    setDraft(next);
+
+    if (next !== committed) {
+      setCommitted(next);
+      onCommit(next);
+    }
+  };
+
+  // Removing a focused input does not reliably fire blur, so a field that unmounts while
+  // being edited — the panel closing, or a mode change hiding the field — would otherwise
+  // drop the edit. The cleanup only commits; it never touches state after unmount.
+  const pendingCommitRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    pendingCommitRef.current = (): void => {
+      const next: string | null = resolve();
+
+      if (next !== null && next !== committed) {
+        onCommit(next);
+      }
+    };
+  });
+
+  useEffect(
+    () => () => {
+      pendingCommitRef.current?.();
+    },
+    [],
+  );
+
+  return (
+    <TextField
+      {...rest}
+      value={draft}
+      onChange={(e: ChangeEvent<HTMLInputElement>) => setDraft(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e: KeyboardEvent<HTMLDivElement>) => {
+        // Multiline fields take Enter as a newline.
+        if (e.key === 'Enter' && !rest.multiline) {
+          commit();
+        }
+      }}
+    />
+  );
+}
+
+export default DraftTextField;

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/EmailProperties.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/EmailProperties.tsx
@@ -16,10 +16,19 @@
  * under the License.
  */
 
-import {FormHelperText, FormLabel, Stack, TextField, Typography} from '@wso2/oxygen-ui';
-import {useMemo, type ReactNode} from 'react';
+import {
+  Autocomplete,
+  FormHelperText,
+  FormLabel,
+  Stack,
+  TextField,
+  Typography,
+  type AutocompleteRenderInputParams,
+} from '@wso2/oxygen-ui';
+import {useMemo, type ReactNode, type SyntheticEvent} from 'react';
 import {useTranslation} from 'react-i18next';
 import type {CommonResourcePropertiesPropsInterface} from './types';
+import {getTemplateScenarioLabel, getTemplateScenarioOptions} from './utils';
 import type {StepData} from '@/features/flows/models/steps';
 
 function EmailProperties({resource, onChange}: CommonResourcePropertiesPropsInterface): ReactNode {
@@ -30,6 +39,10 @@ function EmailProperties({resource, onChange}: CommonResourcePropertiesPropsInte
     return stepData?.properties ?? {};
   }, [resource]);
 
+  const emailTemplate = (properties.emailTemplate as string) || '';
+
+  const options = useMemo((): string[] => getTemplateScenarioOptions(emailTemplate), [emailTemplate]);
+
   return (
     <Stack gap={2}>
       <Typography variant="body2" color="text.secondary">
@@ -38,11 +51,21 @@ function EmailProperties({resource, onChange}: CommonResourcePropertiesPropsInte
 
       <div>
         <FormLabel htmlFor="email-template">{t('flows:core.executions.email.emailTemplate.label')}</FormLabel>
-        <TextField
+        <Autocomplete
           id="email-template"
-          value={(properties.emailTemplate as string) || ''}
-          onChange={(e) => onChange('data.properties.emailTemplate', e.target.value, resource, true)}
-          placeholder={t('flows:core.executions.email.emailTemplate.placeholder')}
+          options={options}
+          value={emailTemplate || null}
+          getOptionLabel={(option: string) => getTemplateScenarioLabel(option, t)}
+          onChange={(_event: SyntheticEvent, newValue: string | null) =>
+            onChange('data.properties.emailTemplate', newValue ?? '', resource)
+          }
+          renderInput={(params: AutocompleteRenderInputParams) => (
+            <TextField
+              {...params}
+              placeholder={t('flows:core.executions.email.emailTemplate.placeholder', 'Select an email template')}
+              size="small"
+            />
+          )}
           fullWidth
           size="small"
         />

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/HttpRequestProperties.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/HttpRequestProperties.tsx
@@ -24,14 +24,15 @@ import {
   MenuItem,
   Select,
   Stack,
-  TextField,
   Typography,
 } from '@wso2/oxygen-ui';
 import {useCallback, useMemo, type ReactNode} from 'react';
 import {useTranslation} from 'react-i18next';
 import {HTTP_METHODS} from './constants';
+import DraftTextField from './DraftTextField';
 import KeyValueEditor from './KeyValueEditor';
 import type {CommonResourcePropertiesPropsInterface} from './types';
+import {clampToInteger} from './utils';
 import type {StepData} from '@/features/flows/models/steps';
 
 function HttpRequestProperties({resource, onChange}: CommonResourcePropertiesPropsInterface): ReactNode {
@@ -55,24 +56,14 @@ function HttpRequestProperties({resource, onChange}: CommonResourcePropertiesPro
 
   const handleStringPropertyChange = useCallback(
     (propertyName: string, value: string): void => {
-      onChange(`data.properties.${propertyName}`, value, resource, true);
+      onChange(`data.properties.${propertyName}`, value, resource);
     },
     [resource, onChange],
   );
 
   const handleNumberPropertyChange = useCallback(
-    (propertyName: string, value: string, min: number, max: number): void => {
-      if (value === '') {
-        onChange(`data.properties.${propertyName}`, min, resource);
-        return;
-      }
-
-      const num = Number(value);
-      if (Number.isNaN(num)) {
-        return;
-      }
-
-      onChange(`data.properties.${propertyName}`, Math.min(max, Math.max(min, Math.floor(num))), resource);
+    (propertyName: string, value: string): void => {
+      onChange(`data.properties.${propertyName}`, Number(value), resource);
     },
     [resource, onChange],
   );
@@ -95,10 +86,10 @@ function HttpRequestProperties({resource, onChange}: CommonResourcePropertiesPro
 
       <div>
         <FormLabel htmlFor="http-url">{t('flows:core.executions.httpRequest.url.label')}</FormLabel>
-        <TextField
+        <DraftTextField
           id="http-url"
           value={(properties.url as string) || ''}
-          onChange={(e) => handleStringPropertyChange('url', e.target.value)}
+          onCommit={(value) => handleStringPropertyChange('url', value)}
           placeholder={t('flows:core.executions.httpRequest.url.placeholder')}
           fullWidth
           size="small"
@@ -140,15 +131,17 @@ function HttpRequestProperties({resource, onChange}: CommonResourcePropertiesPro
 
       <div>
         <FormLabel htmlFor="http-body">{t('flows:core.executions.httpRequest.body.label')}</FormLabel>
-        <TextField
+        <DraftTextField
           id="http-body"
           value={typeof properties.body === 'string' ? properties.body : JSON.stringify(properties.body ?? {}, null, 2)}
-          onChange={(e) => {
+          // Committing on blur also means a half-typed body is not repeatedly parsed and
+          // stored as a raw string on the way to becoming valid JSON.
+          onCommit={(value) => {
             try {
-              const parsed: unknown = JSON.parse(e.target.value);
+              const parsed: unknown = JSON.parse(value);
               onChange('data.properties.body', parsed, resource);
             } catch {
-              onChange('data.properties.body', e.target.value, resource);
+              onChange('data.properties.body', value, resource);
             }
           }}
           placeholder={t('flows:core.executions.httpRequest.body.placeholder')}
@@ -161,10 +154,11 @@ function HttpRequestProperties({resource, onChange}: CommonResourcePropertiesPro
 
       <div>
         <FormLabel htmlFor="http-timeout">{t('flows:core.executions.httpRequest.timeout.label')}</FormLabel>
-        <TextField
+        <DraftTextField
           id="http-timeout"
-          value={properties.timeout ?? 10}
-          onChange={(e) => handleNumberPropertyChange('timeout', e.target.value, 1, 20)}
+          value={String((properties.timeout as number | string | undefined) ?? 10)}
+          onCommit={(value) => handleNumberPropertyChange('timeout', value)}
+          normalize={(raw) => clampToInteger(raw, 1, 20)}
           placeholder={t('flows:core.executions.httpRequest.timeout.placeholder')}
           fullWidth
           size="small"
@@ -215,13 +209,13 @@ function HttpRequestProperties({resource, onChange}: CommonResourcePropertiesPro
             <FormLabel htmlFor="retry-count">
               {t('flows:core.executions.httpRequest.errorHandling.retryCount.label')}
             </FormLabel>
-            <TextField
+            <DraftTextField
               id="retry-count"
-              value={errorHandling.retryCount ?? 0}
-              onChange={(e) => {
-                const val = Math.min(5, Math.max(0, Math.floor(Number(e.target.value) || 0)));
-                onChange('data.properties.errorHandling', {...errorHandling, retryCount: val}, resource, true);
-              }}
+              value={String(errorHandling.retryCount ?? 0)}
+              onCommit={(value) =>
+                onChange('data.properties.errorHandling', {...errorHandling, retryCount: Number(value)}, resource)
+              }
+              normalize={(raw) => clampToInteger(raw, 0, 5)}
               placeholder={t('flows:core.executions.httpRequest.errorHandling.retryCount.placeholder')}
               fullWidth
               size="small"
@@ -235,13 +229,13 @@ function HttpRequestProperties({resource, onChange}: CommonResourcePropertiesPro
             <FormLabel htmlFor="retry-delay">
               {t('flows:core.executions.httpRequest.errorHandling.retryDelay.label')}
             </FormLabel>
-            <TextField
+            <DraftTextField
               id="retry-delay"
-              value={errorHandling.retryDelay ?? 0}
-              onChange={(e) => {
-                const val = Math.min(5000, Math.max(0, Math.floor(Number(e.target.value) || 0)));
-                onChange('data.properties.errorHandling', {...errorHandling, retryDelay: val}, resource, true);
-              }}
+              value={String(errorHandling.retryDelay ?? 0)}
+              onCommit={(value) =>
+                onChange('data.properties.errorHandling', {...errorHandling, retryDelay: Number(value)}, resource)
+              }
+              normalize={(raw) => clampToInteger(raw, 0, 5000)}
               placeholder={t('flows:core.executions.httpRequest.errorHandling.retryDelay.placeholder')}
               fullWidth
               size="small"

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/OUExecutorProperties.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/OUExecutorProperties.tsx
@@ -16,9 +16,10 @@
  * under the License.
  */
 
-import {FormHelperText, FormLabel, Stack, TextField, Typography} from '@wso2/oxygen-ui';
+import {FormHelperText, FormLabel, Stack, Typography} from '@wso2/oxygen-ui';
 import {useMemo, type ReactNode} from 'react';
 import {useTranslation} from 'react-i18next';
+import DraftTextField from './DraftTextField';
 import type {CommonResourcePropertiesPropsInterface} from './types';
 import type {StepData} from '@/features/flows/models/steps';
 
@@ -38,10 +39,10 @@ function OUExecutorProperties({resource, onChange}: CommonResourcePropertiesProp
 
       <div>
         <FormLabel htmlFor="parent-ou-id">{t('flows:core.executions.ouExecutor.parentOuId.label')}</FormLabel>
-        <TextField
+        <DraftTextField
           id="parent-ou-id"
           value={(properties.parentOuId as string) || ''}
-          onChange={(e) => onChange('data.properties.parentOuId', e.target.value, resource, true)}
+          onCommit={(value) => onChange('data.properties.parentOuId', value, resource)}
           placeholder={t('flows:core.executions.ouExecutor.parentOuId.placeholder')}
           fullWidth
           size="small"

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/OtpProperties.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/OtpProperties.tsx
@@ -16,10 +16,12 @@
  * under the License.
  */
 
-import {Checkbox, FormControlLabel, FormHelperText, FormLabel, Stack, TextField, Typography} from '@wso2/oxygen-ui';
+import {Checkbox, FormControlLabel, FormHelperText, FormLabel, Stack, Typography} from '@wso2/oxygen-ui';
 import {useMemo, type ReactNode} from 'react';
 import {useTranslation} from 'react-i18next';
+import DraftTextField from './DraftTextField';
 import type {CommonResourcePropertiesPropsInterface} from './types';
+import {clampToInteger} from './utils';
 import type {StepData} from '@/features/flows/models/steps';
 
 function OtpProperties({resource, onChange}: CommonResourcePropertiesPropsInterface): ReactNode {
@@ -34,6 +36,12 @@ function OtpProperties({resource, onChange}: CommonResourcePropertiesPropsInterf
     onChange(`data.properties.${propertyName}`, value, resource);
   };
 
+  // The executor reads these through a numeric conversion that rejects strings, so a
+  // string would leave the configured value silently ignored at runtime.
+  const handleNumberPropertyChange = (propertyName: string, value: string): void => {
+    onChange(`data.properties.${propertyName}`, Number(value), resource);
+  };
+
   return (
     <Stack gap={2}>
       <Typography variant="body2" color="text.secondary">
@@ -42,11 +50,12 @@ function OtpProperties({resource, onChange}: CommonResourcePropertiesPropsInterf
 
       <div>
         <FormLabel htmlFor="otp-length">{t('flows:core.executions.otp.otpLength.label')}</FormLabel>
-        <TextField
+        <DraftTextField
           id="otp-length"
           type="number"
-          value={(properties.otpLength as string) ?? ''}
-          onChange={(e) => onChange('data.properties.otpLength', e.target.value, resource, true)}
+          value={String((properties.otpLength as number | string | undefined) ?? '')}
+          onCommit={(value) => handleNumberPropertyChange('otpLength', value)}
+          normalize={(raw) => clampToInteger(raw, 4, 10)}
           placeholder={t('flows:core.executions.otp.otpLength.placeholder')}
           fullWidth
           size="small"
@@ -57,11 +66,12 @@ function OtpProperties({resource, onChange}: CommonResourcePropertiesPropsInterf
 
       <div>
         <FormLabel htmlFor="otp-validity">{t('flows:core.executions.otp.otpValidityPeriodSeconds.label')}</FormLabel>
-        <TextField
+        <DraftTextField
           id="otp-validity"
           type="number"
-          value={(properties.otpValidityPeriodSeconds as string) ?? ''}
-          onChange={(e) => onChange('data.properties.otpValidityPeriodSeconds', e.target.value, resource, true)}
+          value={String((properties.otpValidityPeriodSeconds as number | string | undefined) ?? '')}
+          onCommit={(value) => handleNumberPropertyChange('otpValidityPeriodSeconds', value)}
+          normalize={(raw) => clampToInteger(raw, 30, 600)}
           placeholder={t('flows:core.executions.otp.otpValidityPeriodSeconds.placeholder')}
           fullWidth
           size="small"
@@ -86,11 +96,12 @@ function OtpProperties({resource, onChange}: CommonResourcePropertiesPropsInterf
 
       <div>
         <FormLabel htmlFor="otp-max-attempts">{t('flows:core.executions.otp.maxAttempts.label')}</FormLabel>
-        <TextField
+        <DraftTextField
           id="otp-max-attempts"
           type="number"
-          value={(properties.maxAttempts as string) || ''}
-          onChange={(e) => onChange('data.properties.maxAttempts', e.target.value, resource, true)}
+          value={String((properties.maxAttempts as number | string | undefined) ?? '')}
+          onCommit={(value) => handleNumberPropertyChange('maxAttempts', value)}
+          normalize={(raw) => clampToInteger(raw, 1)}
           placeholder={t('flows:core.executions.otp.maxAttempts.placeholder')}
           fullWidth
           size="small"

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/PasskeyProperties.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/PasskeyProperties.tsx
@@ -16,10 +16,11 @@
  * under the License.
  */
 
-import {FormHelperText, FormLabel, MenuItem, Select, Stack, TextField, Typography} from '@wso2/oxygen-ui';
+import {FormHelperText, FormLabel, MenuItem, Select, Stack, Typography} from '@wso2/oxygen-ui';
 import {useMemo, type ReactNode} from 'react';
 import {useTranslation} from 'react-i18next';
 import {PASSKEY_MODES, PASSKEY_MODES_WITH_RELYING_PARTY} from './constants';
+import DraftTextField from './DraftTextField';
 import type {CommonResourcePropertiesPropsInterface} from './types';
 import type {StepData} from '@/features/flows/models/steps';
 
@@ -96,10 +97,10 @@ function PasskeyProperties({resource, onChange}: CommonResourcePropertiesPropsIn
         <>
           <div>
             <FormLabel htmlFor="relying-party-id">{t('flows:core.executions.passkey.relyingPartyId.label')}</FormLabel>
-            <TextField
+            <DraftTextField
               id="relying-party-id"
               value={currentRelyingPartyId}
-              onChange={(e) => onChange('data.properties.relyingPartyId', e.target.value, resource, true)}
+              onCommit={(value) => onChange('data.properties.relyingPartyId', value, resource)}
               placeholder={t('flows:core.executions.passkey.relyingPartyId.placeholder')}
               fullWidth
               size="small"
@@ -111,10 +112,10 @@ function PasskeyProperties({resource, onChange}: CommonResourcePropertiesPropsIn
             <FormLabel htmlFor="relying-party-name">
               {t('flows:core.executions.passkey.relyingPartyName.label')}
             </FormLabel>
-            <TextField
+            <DraftTextField
               id="relying-party-name"
               value={currentRelyingPartyName}
-              onChange={(e) => onChange('data.properties.relyingPartyName', e.target.value, resource, true)}
+              onCommit={(value) => onChange('data.properties.relyingPartyName', value, resource)}
               placeholder={t('flows:core.executions.passkey.relyingPartyName.placeholder')}
               fullWidth
               size="small"

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/ProvisioningProperties.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/ProvisioningProperties.tsx
@@ -16,10 +16,12 @@
  * under the License.
  */
 
-import {Checkbox, FormControlLabel, FormHelperText, FormLabel, Stack, TextField, Typography} from '@wso2/oxygen-ui';
+import {Checkbox, FormControlLabel, FormHelperText, FormLabel, Stack, Typography} from '@wso2/oxygen-ui';
 import {useCallback, useMemo, type ReactNode} from 'react';
 import {useTranslation} from 'react-i18next';
+import DraftTextField from './DraftTextField';
 import type {CommonResourcePropertiesPropsInterface} from './types';
+import {clampToInteger} from './utils';
 import type {StepData} from '@/features/flows/models/steps';
 
 function ProvisioningProperties({resource, onChange}: CommonResourcePropertiesPropsInterface): ReactNode {
@@ -39,25 +41,14 @@ function ProvisioningProperties({resource, onChange}: CommonResourcePropertiesPr
 
   const handleStringPropertyChange = useCallback(
     (propertyName: string, value: string): void => {
-      onChange(`data.properties.${propertyName}`, value, resource, true);
+      onChange(`data.properties.${propertyName}`, value, resource);
     },
     [resource, onChange],
   );
 
   const handleNumberPropertyChange = useCallback(
     (propertyName: string, value: string): void => {
-      if (value === '') {
-        onChange(`data.properties.${propertyName}`, 0, resource, true);
-        return;
-      }
-
-      const numericValue = Number(value);
-
-      if (!Number.isFinite(numericValue)) {
-        return;
-      }
-
-      onChange(`data.properties.${propertyName}`, Math.max(0, Math.floor(numericValue)), resource, true);
+      onChange(`data.properties.${propertyName}`, Number(value), resource);
     },
     [resource, onChange],
   );
@@ -113,11 +104,12 @@ function ProvisioningProperties({resource, onChange}: CommonResourcePropertiesPr
 
       <div>
         <FormLabel htmlFor="max-per-prompt">{t('flows:core.executions.provisioning.maxPerPrompt.label')}</FormLabel>
-        <TextField
+        <DraftTextField
           id="max-per-prompt"
           type="number"
-          value={maxPerPromptValue}
-          onChange={(e) => handleNumberPropertyChange('maxPerPrompt', e.target.value)}
+          value={String(maxPerPromptValue)}
+          onCommit={(value) => handleNumberPropertyChange('maxPerPrompt', value)}
+          normalize={(raw) => clampToInteger(raw, 0)}
           placeholder={t('flows:core.executions.provisioning.maxPerPrompt.placeholder')}
           fullWidth
           size="small"
@@ -132,10 +124,10 @@ function ProvisioningProperties({resource, onChange}: CommonResourcePropertiesPr
 
       <div>
         <FormLabel htmlFor="assign-group">{t('flows:core.executions.provisioning.assignGroup.label')}</FormLabel>
-        <TextField
+        <DraftTextField
           id="assign-group"
           value={(properties.assignGroup as string) || ''}
-          onChange={(e) => handleStringPropertyChange('assignGroup', e.target.value)}
+          onCommit={(value) => handleStringPropertyChange('assignGroup', value)}
           placeholder={t('flows:core.executions.provisioning.assignGroup.placeholder')}
           fullWidth
           size="small"
@@ -144,10 +136,10 @@ function ProvisioningProperties({resource, onChange}: CommonResourcePropertiesPr
 
       <div>
         <FormLabel htmlFor="assign-role">{t('flows:core.executions.provisioning.assignRole.label')}</FormLabel>
-        <TextField
+        <DraftTextField
           id="assign-role"
           value={(properties.assignRole as string) || ''}
-          onChange={(e) => handleStringPropertyChange('assignRole', e.target.value)}
+          onCommit={(value) => handleStringPropertyChange('assignRole', value)}
           placeholder={t('flows:core.executions.provisioning.assignRole.placeholder')}
           fullWidth
           size="small"

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/SmsProperties.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/SmsProperties.tsx
@@ -17,10 +17,22 @@
  */
 
 import {useSMSProviders} from '@thunderid/configure-connections';
-import {Alert, FormHelperText, FormLabel, MenuItem, Select, Stack, TextField, Typography} from '@wso2/oxygen-ui';
-import {useMemo, type ReactNode} from 'react';
+import {
+  Alert,
+  Autocomplete,
+  FormHelperText,
+  FormLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+  type AutocompleteRenderInputParams,
+} from '@wso2/oxygen-ui';
+import {useMemo, type ReactNode, type SyntheticEvent} from 'react';
 import {useTranslation} from 'react-i18next';
 import type {CommonResourcePropertiesPropsInterface} from './types';
+import {getTemplateScenarioLabel, getTemplateScenarioOptions} from './utils';
 import type {StepData} from '@/features/flows/models/steps';
 
 function SmsProperties({resource, onChange}: CommonResourcePropertiesPropsInterface): ReactNode {
@@ -36,6 +48,10 @@ function SmsProperties({resource, onChange}: CommonResourcePropertiesPropsInterf
   const smsSenderId = (properties.senderId as string) || '';
   const isSenderPlaceholder = smsSenderId === '' || smsSenderId === '{{SENDER_ID}}';
 
+  const smsTemplate = (properties.smsTemplate as string) || '';
+
+  const templateOptions = useMemo((): string[] => getTemplateScenarioOptions(smsTemplate), [smsTemplate]);
+
   return (
     <Stack gap={2}>
       <Typography variant="body2" color="text.secondary">
@@ -44,11 +60,21 @@ function SmsProperties({resource, onChange}: CommonResourcePropertiesPropsInterf
 
       <div>
         <FormLabel htmlFor="sms-template">{t('flows:core.executions.sms.smsTemplate.label')}</FormLabel>
-        <TextField
+        <Autocomplete
           id="sms-template"
-          value={(properties.smsTemplate as string) || ''}
-          onChange={(e) => onChange('data.properties.smsTemplate', e.target.value, resource, true)}
-          placeholder={t('flows:core.executions.sms.smsTemplate.placeholder')}
+          options={templateOptions}
+          value={smsTemplate || null}
+          getOptionLabel={(option: string) => getTemplateScenarioLabel(option, t)}
+          onChange={(_event: SyntheticEvent, newValue: string | null) =>
+            onChange('data.properties.smsTemplate', newValue ?? '', resource)
+          }
+          renderInput={(params: AutocompleteRenderInputParams) => (
+            <TextField
+              {...params}
+              placeholder={t('flows:core.executions.sms.smsTemplate.placeholder', 'Select an SMS template')}
+              size="small"
+            />
+          )}
           fullWidth
           size="small"
         />

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/__tests__/DraftTextField.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/__tests__/DraftTextField.test.tsx
@@ -1,0 +1,259 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {fireEvent, render, screen} from '@testing-library/react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import DraftTextField from '../DraftTextField';
+import {clampToInteger} from '../utils';
+
+describe('DraftTextField', () => {
+  const mockOnCommit = vi.fn();
+
+  beforeEach(() => {
+    mockOnCommit.mockClear();
+  });
+
+  it('should render the committed value', () => {
+    render(<DraftTextField value="initial" onCommit={mockOnCommit} inputProps={{'aria-label': 'field'}} />);
+
+    expect(screen.getByLabelText('field')).toHaveValue('initial');
+  });
+
+  it('should show keystrokes without committing them', () => {
+    render(<DraftTextField value="" onCommit={mockOnCommit} inputProps={{'aria-label': 'field'}} />);
+
+    const input = screen.getByLabelText('field');
+    fireEvent.change(input, {target: {value: 'a'}});
+    fireEvent.change(input, {target: {value: 'ab'}});
+    fireEvent.change(input, {target: {value: 'abc'}});
+
+    expect(input).toHaveValue('abc');
+    expect(mockOnCommit).not.toHaveBeenCalled();
+  });
+
+  it('should commit on blur', () => {
+    render(<DraftTextField value="" onCommit={mockOnCommit} inputProps={{'aria-label': 'field'}} />);
+
+    const input = screen.getByLabelText('field');
+    fireEvent.change(input, {target: {value: 'abc'}});
+    fireEvent.blur(input);
+
+    expect(mockOnCommit).toHaveBeenCalledExactlyOnceWith('abc');
+  });
+
+  it('should commit on Enter', () => {
+    render(<DraftTextField value="" onCommit={mockOnCommit} inputProps={{'aria-label': 'field'}} />);
+
+    const input = screen.getByLabelText('field');
+    fireEvent.change(input, {target: {value: 'abc'}});
+    fireEvent.keyDown(input, {key: 'Enter'});
+
+    expect(mockOnCommit).toHaveBeenCalledExactlyOnceWith('abc');
+  });
+
+  it('should not commit on Enter for a multiline field', () => {
+    render(<DraftTextField value="" onCommit={mockOnCommit} multiline inputProps={{'aria-label': 'field'}} />);
+
+    const input = screen.getByLabelText('field');
+    fireEvent.change(input, {target: {value: 'abc'}});
+    fireEvent.keyDown(input, {key: 'Enter'});
+
+    expect(mockOnCommit).not.toHaveBeenCalled();
+  });
+
+  it('should not commit an unchanged value on blur', () => {
+    render(<DraftTextField value="initial" onCommit={mockOnCommit} inputProps={{'aria-label': 'field'}} />);
+
+    fireEvent.blur(screen.getByLabelText('field'));
+
+    expect(mockOnCommit).not.toHaveBeenCalled();
+  });
+
+  it('should not commit twice when Enter is followed by blur', () => {
+    render(<DraftTextField value="" onCommit={mockOnCommit} inputProps={{'aria-label': 'field'}} />);
+
+    const input = screen.getByLabelText('field');
+    fireEvent.change(input, {target: {value: 'abc'}});
+    fireEvent.keyDown(input, {key: 'Enter'});
+    fireEvent.blur(input);
+
+    expect(mockOnCommit).toHaveBeenCalledExactlyOnceWith('abc');
+  });
+
+  it('should commit a pending edit when the field unmounts while focused', () => {
+    const {unmount} = render(<DraftTextField value="" onCommit={mockOnCommit} inputProps={{'aria-label': 'field'}} />);
+
+    // No blur: removing a focused input does not reliably fire one.
+    fireEvent.change(screen.getByLabelText('field'), {target: {value: 'abc'}});
+    unmount();
+
+    expect(mockOnCommit).toHaveBeenCalledExactlyOnceWith('abc');
+  });
+
+  it('should not commit on unmount when the draft is unchanged', () => {
+    const {unmount} = render(
+      <DraftTextField value="initial" onCommit={mockOnCommit} inputProps={{'aria-label': 'field'}} />,
+    );
+
+    unmount();
+
+    expect(mockOnCommit).not.toHaveBeenCalled();
+  });
+
+  it('should not commit again on unmount after a blur commit', () => {
+    const {unmount} = render(<DraftTextField value="" onCommit={mockOnCommit} inputProps={{'aria-label': 'field'}} />);
+
+    const input = screen.getByLabelText('field');
+    fireEvent.change(input, {target: {value: 'abc'}});
+    fireEvent.blur(input);
+    unmount();
+
+    expect(mockOnCommit).toHaveBeenCalledExactlyOnceWith('abc');
+  });
+
+  it('should not commit a rejected draft on unmount', () => {
+    const {unmount} = render(
+      <DraftTextField
+        value="10"
+        onCommit={mockOnCommit}
+        normalize={(raw) => clampToInteger(raw, 1, 20)}
+        inputProps={{'aria-label': 'field'}}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('field'), {target: {value: 'abc'}});
+    unmount();
+
+    expect(mockOnCommit).not.toHaveBeenCalled();
+  });
+
+  it('should commit the normalized value on unmount', () => {
+    const {unmount} = render(
+      <DraftTextField
+        value="10"
+        onCommit={mockOnCommit}
+        normalize={(raw) => clampToInteger(raw, 1, 20)}
+        inputProps={{'aria-label': 'field'}}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('field'), {target: {value: '99'}});
+    unmount();
+
+    expect(mockOnCommit).toHaveBeenCalledExactlyOnceWith('20');
+  });
+
+  it('should re-sync when the committed value changes externally', () => {
+    const {rerender} = render(
+      <DraftTextField value="first" onCommit={mockOnCommit} inputProps={{'aria-label': 'field'}} />,
+    );
+
+    rerender(<DraftTextField value="second" onCommit={mockOnCommit} inputProps={{'aria-label': 'field'}} />);
+
+    expect(screen.getByLabelText('field')).toHaveValue('second');
+  });
+
+  it('should discard an uncommitted draft when the committed value changes externally', () => {
+    const {rerender} = render(
+      <DraftTextField value="first" onCommit={mockOnCommit} inputProps={{'aria-label': 'field'}} />,
+    );
+
+    fireEvent.change(screen.getByLabelText('field'), {target: {value: 'typing'}});
+    rerender(<DraftTextField value="second" onCommit={mockOnCommit} inputProps={{'aria-label': 'field'}} />);
+
+    expect(screen.getByLabelText('field')).toHaveValue('second');
+    expect(mockOnCommit).not.toHaveBeenCalled();
+  });
+
+  describe('normalize', () => {
+    it('should commit the normalized value', () => {
+      render(
+        <DraftTextField
+          value="10"
+          onCommit={mockOnCommit}
+          normalize={(raw) => clampToInteger(raw, 1, 20)}
+          inputProps={{'aria-label': 'field'}}
+        />,
+      );
+
+      const input = screen.getByLabelText('field');
+      fireEvent.change(input, {target: {value: '3.7'}});
+      fireEvent.blur(input);
+
+      expect(mockOnCommit).toHaveBeenCalledExactlyOnceWith('3');
+      expect(input).toHaveValue('3');
+    });
+
+    it('should not clamp while typing', () => {
+      render(
+        <DraftTextField
+          value="10"
+          onCommit={mockOnCommit}
+          normalize={(raw) => clampToInteger(raw, 1, 20)}
+          inputProps={{'aria-label': 'field'}}
+        />,
+      );
+
+      // Reaching 15 passes through 1, which the field would otherwise clamp away.
+      const input = screen.getByLabelText('field');
+      fireEvent.change(input, {target: {value: '1'}});
+      fireEvent.change(input, {target: {value: '15'}});
+
+      expect(input).toHaveValue('15');
+      expect(mockOnCommit).not.toHaveBeenCalled();
+    });
+
+    it('should reset the field when normalization does not change the stored value', () => {
+      render(
+        <DraftTextField
+          value="20"
+          onCommit={mockOnCommit}
+          normalize={(raw) => clampToInteger(raw, 1, 20)}
+          inputProps={{'aria-label': 'field'}}
+        />,
+      );
+
+      const input = screen.getByLabelText('field');
+      fireEvent.change(input, {target: {value: '99'}});
+      fireEvent.blur(input);
+
+      // 99 clamps back to the stored 20, so nothing is committed, but the field must
+      // not be left showing a value that was never stored.
+      expect(mockOnCommit).not.toHaveBeenCalled();
+      expect(input).toHaveValue('20');
+    });
+
+    it('should restore the committed value when normalization rejects the draft', () => {
+      render(
+        <DraftTextField
+          value="10"
+          onCommit={mockOnCommit}
+          normalize={(raw) => clampToInteger(raw, 1, 20)}
+          inputProps={{'aria-label': 'field'}}
+        />,
+      );
+
+      const input = screen.getByLabelText('field');
+      fireEvent.change(input, {target: {value: 'abc'}});
+      fireEvent.blur(input);
+
+      expect(mockOnCommit).not.toHaveBeenCalled();
+      expect(input).toHaveValue('10');
+    });
+  });
+});

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/__tests__/HttpRequestProperties.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/__tests__/HttpRequestProperties.test.tsx
@@ -77,6 +77,7 @@ describe('HttpRequestProperties', () => {
 
       const timeoutInput = screen.getByLabelText('Timeout');
       fireEvent.change(timeoutInput, {target: {value: ''}});
+      fireEvent.blur(timeoutInput);
 
       expect(mockOnChange).toHaveBeenCalledWith('data.properties.timeout', 1, resource);
     });

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/__tests__/utils.test.ts
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/__tests__/utils.test.ts
@@ -17,7 +17,7 @@
  */
 
 import {describe, it, expect} from 'vitest';
-import {parseCommaSeparated} from '../utils';
+import {clampToInteger, getTemplateScenarioLabel, getTemplateScenarioOptions, parseCommaSeparated} from '../utils';
 
 describe('parseCommaSeparated', () => {
   it('should parse comma-separated values', () => {
@@ -50,5 +50,87 @@ describe('parseCommaSeparated', () => {
 
   it('should handle whitespace-only values as empty', () => {
     expect(parseCommaSeparated('a,   , b')).toEqual(['a', 'b']);
+  });
+});
+
+describe('clampToInteger', () => {
+  it('should pass through a value within bounds', () => {
+    expect(clampToInteger('15', 1, 20)).toBe('15');
+  });
+
+  it('should clamp to the minimum', () => {
+    expect(clampToInteger('-5', 0)).toBe('0');
+  });
+
+  it('should clamp to the maximum', () => {
+    expect(clampToInteger('99', 1, 20)).toBe('20');
+  });
+
+  it('should floor decimals', () => {
+    expect(clampToInteger('3.7', 0)).toBe('3');
+  });
+
+  it('should fall back to the minimum for an empty value', () => {
+    expect(clampToInteger('', 4, 10)).toBe('4');
+  });
+
+  it('should fall back to the minimum for a whitespace-only value', () => {
+    expect(clampToInteger('   ', 30)).toBe('30');
+  });
+
+  it('should reject a non-numeric value', () => {
+    expect(clampToInteger('abc', 0)).toBeNull();
+  });
+
+  it('should leave the value unbounded above when no maximum is given', () => {
+    expect(clampToInteger('9999', 1)).toBe('9999');
+  });
+});
+
+describe('getTemplateScenarioOptions', () => {
+  it('should offer the supported scenarios', () => {
+    expect(getTemplateScenarioOptions('')).toEqual([
+      'USER_INVITE',
+      'MAGIC_LINK',
+      'SELF_REGISTRATION',
+      'OTP',
+      'PASSWORD_RECOVERY',
+      'CIBA_NOTIFICATION',
+    ]);
+  });
+
+  it('should not duplicate a known current value', () => {
+    expect(getTemplateScenarioOptions('OTP')).toHaveLength(6);
+  });
+
+  it('should keep an unknown current value so it is not blanked', () => {
+    expect(getTemplateScenarioOptions('CUSTOM_SCENARIO')).toContain('CUSTOM_SCENARIO');
+  });
+});
+
+describe('getTemplateScenarioLabel', () => {
+  const translate = (key: string): string => `translated:${key}`;
+
+  // Mirrors i18next resolving a missing key to the supplied default.
+  const translateMissing = (_key: string, defaultValue: string): string => defaultValue;
+
+  it('should translate a known scenario', () => {
+    expect(getTemplateScenarioLabel('USER_INVITE', translate)).toBe(
+      'translated:flows:core.executions.templateScenarios.userInvite',
+    );
+  });
+
+  it('should fall back to the readable label when the key has no translation', () => {
+    expect(getTemplateScenarioLabel('USER_INVITE', translateMissing)).toBe('User Invite');
+    expect(getTemplateScenarioLabel('OTP', translateMissing)).toBe('OTP Verification');
+    expect(getTemplateScenarioLabel('CIBA_NOTIFICATION', translateMissing)).toBe('CIBA Notification');
+  });
+
+  it('should fall back to the raw value for an unknown scenario', () => {
+    expect(getTemplateScenarioLabel('CUSTOM_SCENARIO', translate)).toBe('CUSTOM_SCENARIO');
+  });
+
+  it('should fall back to an empty label for an empty value', () => {
+    expect(getTemplateScenarioLabel('', translate)).toBe('');
   });
 });

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/constants.ts
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/constants.ts
@@ -117,6 +117,44 @@ export const HTTP_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'] as const;
 export const PASSKEY_MODES_WITH_RELYING_PARTY = ['challenge', 'register_start'] as const;
 
 /**
+ * Template scenarios the Email and SMS executors can render.
+ * The values mirror the supported scenarios in backend/internal/system/template/model.go —
+ * the backend rejects anything outside this set, so the pickers offer no other value.
+ */
+export const TEMPLATE_SCENARIOS = [
+  {
+    value: 'USER_INVITE',
+    translationKey: 'flows:core.executions.templateScenarios.userInvite',
+    displayLabel: 'User Invite',
+  },
+  {
+    value: 'MAGIC_LINK',
+    translationKey: 'flows:core.executions.templateScenarios.magicLink',
+    displayLabel: 'Magic Link',
+  },
+  {
+    value: 'SELF_REGISTRATION',
+    translationKey: 'flows:core.executions.templateScenarios.selfRegistration',
+    displayLabel: 'Self Registration',
+  },
+  {
+    value: 'OTP',
+    translationKey: 'flows:core.executions.templateScenarios.otp',
+    displayLabel: 'OTP Verification',
+  },
+  {
+    value: 'PASSWORD_RECOVERY',
+    translationKey: 'flows:core.executions.templateScenarios.passwordRecovery',
+    displayLabel: 'Password Recovery',
+  },
+  {
+    value: 'CIBA_NOTIFICATION',
+    translationKey: 'flows:core.executions.templateScenarios.cibaNotification',
+    displayLabel: 'CIBA Notification',
+  },
+] as const;
+
+/**
  * Available input types for executor input configuration.
  * These correspond to the backend input type constants defined in common/constants.go.
  */

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/utils.ts
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/utils.ts
@@ -16,6 +16,39 @@
  * under the License.
  */
 
+import {TEMPLATE_SCENARIOS} from './constants';
+
+/**
+ * Builds the template scenario options for a picker, keeping the current value in the list
+ * even when it is not one this build knows about — a flow authored elsewhere should not have
+ * its template silently blanked.
+ *
+ * @param currentValue - The scenario currently stored on the executor.
+ * @returns The scenario values to offer.
+ */
+export const getTemplateScenarioOptions = (currentValue: string): string[] => {
+  const scenarios: string[] = TEMPLATE_SCENARIOS.map((scenario) => scenario.value);
+
+  return currentValue && !scenarios.includes(currentValue) ? [...scenarios, currentValue] : scenarios;
+};
+
+/**
+ * Resolves the display label for a template scenario. Scenarios this build does not know
+ * about have no translation, so they fall back to the raw value.
+ *
+ * @param scenario - The scenario value.
+ * @param translate - Translation function.
+ * @returns The human-readable label.
+ */
+export const getTemplateScenarioLabel = (
+  scenario: string,
+  translate: (key: string, defaultValue: string) => string,
+): string => {
+  const known = TEMPLATE_SCENARIOS.find((candidate) => candidate.value === scenario);
+
+  return known ? translate(known.translationKey, known.displayLabel) : scenario;
+};
+
 /**
  * Parses a comma-separated string into a trimmed, non-empty string array.
  */
@@ -24,3 +57,30 @@ export const parseCommaSeparated = (value: string): string[] =>
     .split(',')
     .map((s) => s.trim())
     .filter(Boolean);
+
+/**
+ * Coerces a raw field value into a whole number within the given bounds.
+ *
+ * Intended as a {@link DraftTextField} `normalize` callback, so it runs once the user is
+ * done editing rather than per keystroke — a field that clamps mid-typing fights anyone
+ * entering a value digit by digit.
+ *
+ * @param raw - The raw field text.
+ * @param min - Lower bound, and the value an empty field falls back to.
+ * @param max - Upper bound, if the property has one.
+ * @returns The clamped value as text, or `null` when the input is not a number.
+ */
+export const clampToInteger = (raw: string, min: number, max?: number): string | null => {
+  if (raw.trim() === '') {
+    return String(min);
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  const floored = Math.max(min, Math.floor(parsed));
+
+  return String(max === undefined ? floored : Math.min(max, floored));
+};

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -3303,14 +3303,22 @@ const translations = {
     // Email executor
     'core.executions.email.description': 'Configure the email executor settings.',
     'core.executions.email.emailTemplate.label': 'Email Template',
-    'core.executions.email.emailTemplate.placeholder': 'e.g., UserInvite',
+    'core.executions.email.emailTemplate.placeholder': 'Select an email template',
     'core.executions.email.emailTemplate.hint': 'The email template scenario to use when sending the email.',
 
     // SMS executor
     'core.executions.sms.description': 'Configure the SMS executor settings.',
     'core.executions.sms.smsTemplate.label': 'SMS Template',
-    'core.executions.sms.smsTemplate.placeholder': 'e.g., OTPVerification',
+    'core.executions.sms.smsTemplate.placeholder': 'Select an SMS template',
     'core.executions.sms.smsTemplate.hint': 'The SMS template scenario to use when sending the message.',
+
+    // Template scenarios shared by the Email and SMS executors
+    'core.executions.templateScenarios.userInvite': 'User Invite',
+    'core.executions.templateScenarios.magicLink': 'Magic Link',
+    'core.executions.templateScenarios.selfRegistration': 'Self Registration',
+    'core.executions.templateScenarios.otp': 'OTP Verification',
+    'core.executions.templateScenarios.passwordRecovery': 'Password Recovery',
+    'core.executions.templateScenarios.cibaNotification': 'CIBA Notification',
 
     // OpenID4VP verifier executor
     'core.executions.openid4vp.description':


### PR DESCRIPTION
### Purpose

Fixes the Email and SMS template fields becoming slow and unresponsive while typing, and replaces them with searchable template pickers.

The fields rendered a fully controlled `TextField` whose `value` was read straight from `resource.data.properties.*`, while committing through the 300ms debounce. Nothing buffered the keystroke in between, so the field could not show a character until the debounced commit landed — and that commit re-rendered the property panel and the canvas node, resetting the caret and dropping anything typed inside the window. Six sibling executor property files had the same defect, which is why the issue was reached via an OTP step.

Three further problems surfaced while fixing this:

- The template placeholders (`e.g., UserInvite`, `e.g., OTPVerification`) were not valid scenarios, so a user who typed what they suggested produced a flow that failed only at execution time.
- `otpLength` and `otpValidityPeriodSeconds` were committed as strings, but `resolveOTPProperties` reads them via `systemutils.ToInt64`, which rejects strings. Editing OTP length in the console silently left the default in effect at runtime.
- The debounce dropped pending edits on unmount, and resolved its target step at fire time — so closing the panel discarded the last edit, and switching steps within the window wrote it to the newly selected step.

### Approach

**Commit on blur/Enter instead of debouncing.** A commit clones the step's component tree, writes to the React Flow store and re-renders the panel — but these fields have no canvas preview that needs to follow keystrokes, so there is nothing to debounce for. A new `DraftTextField` holds the draft in local state and commits once the user is done, which removes the timing window entirely rather than shrinking it. This follows the existing `commitsOnBlur` pattern already used for step-id renames in `TextPropertyField`.

Numeric fields normalize at commit time via a `normalize` callback, so a field bounded at 20 no longer clamps `1` away from someone typing `15` digit by digit.

**Searchable template pickers.** Both template fields are now `Autocomplete`s over the scenarios in `backend/internal/system/template/model.go`, committed immediately like the existing sender picker. Options are labelled with translated names (User Invite, Magic Link, …) while the raw scenario is stored, so the flow JSON and backend contract are unchanged. A value this build does not recognise is kept in the option list and displayed raw, so flows authored elsewhere are not blanked.

**Debounce hardening** for the element fields that legitimately still debounce (label, placeholder, src — these do drive a live canvas preview): flush instead of cancel on unmount, and flush when the selection changes, before the refs are re-synced to the new step.

Scope note: this covers the whole executor property family rather than only the two template fields, since leaving half the panel on the old commit path would have been incoherent. `url`, `body` and `timeout` on the HTTP executor are included — they committed per keystroke without the debounce flag, with `body` running `JSON.parse` on every character and storing half-typed JSON as a raw string.

### Related Issues
- Fixes #4349

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved flow executor property editing to commit changes on blur and (where appropriate) on Enter, with draft-local typing.
  * Added safer numeric input normalization (clamping/flooring) and commit-time validation.
  * Replaced free-text email/SMS template inputs with labeled, searchable selectors.
  * Updated timeout and JSON body editing to commit on blur and handle partial/invalid input gracefully.
* **Bug Fixes**
  * Prevented pending debounced edits from being dropped or applied to the wrong step/resource when selections change or the panel closes.
* **Documentation**
  * Refreshed English UI strings for template scenario labels and placeholders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->