### PR TITLE
Stop the pnpm store and Turbo caches from freezing at their first write

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,7 +1,7 @@
 # TODO: Remove this action and use the individual setup-node and setup-pnpm actions directly in workflows.
 
 name: Setup Node.js and pnpm
-description: Installs Node.js and pnpm with lockfile-based caching.
+description: Installs Node.js and pnpm with a rolling cache of the pnpm store.
 
 inputs:
   node-version:
@@ -12,12 +12,17 @@ inputs:
     description: pnpm version to use
     required: false
     default: 'latest'
+  cache-store:
+    description: >-
+      Whether to cache the pnpm store. Set to false in jobs that never run
+      `pnpm install`, so they cannot publish an empty store for the rest of the
+      run to restore.
+    required: false
+    default: 'true'
 
 runs:
   using: composite
   steps:
-    # pnpm must be installed before setup-node so that `cache: pnpm` can
-    # locate the store to cache.
     - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
       with:
         run_install: false
@@ -26,5 +31,28 @@ runs:
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: ${{ inputs.node-version }}
-        cache: pnpm
-        cache-dependency-path: pnpm-lock.yaml
+
+    - name: 🗂️ Resolve the pnpm store path
+      if: inputs.cache-store == 'true'
+      shell: bash
+      run: echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+
+    # The store is cached here rather than through setup-node's `cache: pnpm`
+    # because that key is a bare lockfile hash. actions/cache never overwrites an
+    # existing key, so the first job to finish froze the store for every later job
+    # and every later run: a job that only runs `pnpm audit` published a 5 MB
+    # store, and the rest then re-downloaded everything on what the log calls a
+    # cache hit. The run id and attempt make every run, and every re-run of it,
+    # write a fresh entry, and the restore-keys fall back to the newest previous
+    # one. The attempt matters because a failed attempt still saves at post time,
+    # so without it a partial store from attempt 1 would be frozen in for the
+    # attempts that follow.
+    - name: 🗂️ Cache the pnpm store
+      if: inputs.cache-store == 'true'
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      with:
+        path: ${{ env.PNPM_STORE_PATH }}
+        key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}--${{ github.run_id }}-${{ github.run_attempt }}
+        restore-keys: |
+          pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+          pnpm-store-${{ runner.os }}-

--- a/.github/actions/setup-turbo-cache/action.yml
+++ b/.github/actions/setup-turbo-cache/action.yml
@@ -4,10 +4,22 @@ description: Restores and saves the Turborepo task output cache backed by GitHub
 runs:
   using: composite
   steps:
+    # Keyed by job and run rather than by lockfile hash alone. actions/cache never
+    # overwrites an existing key, so a bare lockfile key was written once by
+    # whichever job finished first and then never refreshed: every job restored
+    # that same 7 MB entry, against the 445 MB of task outputs a full frontend
+    # build actually produces. Including the job name keeps each job's outputs on
+    # their own lineage, and the run id with the attempt makes every run, and
+    # every re-run of it, publish a fresh entry, with the restore-keys widening
+    # from this job's newest entry out to any recent one. The attempt matters
+    # because a failed attempt still saves at post time, so without it a partial
+    # cache from attempt 1 would be frozen in for the attempts that follow.
     - name: 🗂️ Cache Turbo
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
       with:
         path: .turbo
-        key: turbo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+        key: turbo-${{ runner.os }}-${{ github.job }}-${{ hashFiles('pnpm-lock.yaml') }}--${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
+          turbo-${{ runner.os }}-${{ github.job }}-${{ hashFiles('pnpm-lock.yaml') }}-
+          turbo-${{ runner.os }}-${{ github.job }}-
           turbo-${{ runner.os }}-

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -73,10 +73,13 @@ jobs:
               - '**.ps1'
               - '.github/workflows/windows-powershell-validation.yml'
 
+      # This job only audits the lockfile, so it must not cache a pnpm store:
+      # an empty store published here is what every later job restored.
       - name: ⚙️ Set up Node.js and pnpm
         uses: ./.github/actions/setup-pnpm
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache-store: 'false'
 
       - name: 🔍 Run pnpm audit
         run: |
@@ -1285,13 +1288,29 @@ jobs:
     permissions:
       actions: write
     steps:
-      - name: 🗑️ Delete stale Turbo caches
+      - name: 🗑️ Delete superseded Turbo and pnpm store caches
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
+          CACHE_REF: ${{ github.ref }}
         run: |
-          # Keep the single most-recently-created Turbo cache per OS; delete the rest.
-          gh api "repos/${{ github.repository }}/actions/caches?per_page=100&key=turbo-Linux-" \
-            --jq '.actions_caches | sort_by(.created_at) | reverse | .[1:] | .[].id' \
+          # Both cache families end in "--<run id>-<attempt>", so each run and each
+          # re-run publishes a fresh entry, and the older ones for the same lineage
+          # (the key without that suffix) can never be reached by a restore-key
+          # again. The separator is a
+          # double dash because a hex lockfile hash cannot contain one, so trimming
+          # it can never mangle a key that predates this scheme; those are left
+          # alone and expire on their own.
+          #
+          # Scoped to this run's ref on purpose: GitHub stores caches per branch,
+          # and the previous version of this step matched every ref, so it deleted
+          # other pull requests' warm caches along with this one's stale copies.
+          gh api --paginate \
+            "repos/${{ github.repository }}/actions/caches?per_page=100&ref=${CACHE_REF}" \
+            --jq '.actions_caches[]
+                  | select(.key | test("^(turbo|pnpm-store)-"))
+                  | select(.key | test("--[0-9]+-[0-9]+$"))
+                  | {id, created_at, lineage: (.key | sub("--[0-9]+-[0-9]+$"; ""))}' \
+          | jq -s 'group_by(.lineage)[]
+                   | sort_by(.created_at) | reverse | .[1:] | .[].id' \
           | xargs -r -I{} gh api --method DELETE "repos/${{ github.repository }}/actions/caches/{}"
-


### PR DESCRIPTION
### Purpose

Both shared caches are effectively empty and have been for some time. Every job reports a cache hit, and the entry it hits is a fraction of what it should hold:

| cache | size in CI | size a real build produces |
|---|---|---|
| pnpm store | 5 MB | hundreds of MB |
| Turbo | 7 MB | 445 MB (2,476 files) |

`actions/cache` never overwrites an existing key, and both keys were a bare lockfile hash with nothing rolling in them. So the first job to finish wrote the entry, and nothing refreshed it for the rest of that lockfile's life. For the pnpm store that first writer is the preflight job, which runs `pnpm audit` and never installs, so it published an empty store that every later job then restored.

The cost is visible in the step timings: `pnpm install` takes 80 to 105s in about seven jobs where a warm store gives roughly 15s, which is 8 to 10 runner minutes per run. It also explains a regression that looked unrelated: the lint job's "Install Dependencies & Build Frontend" step went from 18s to 106s with no change to that step, because the store cache emptied out underneath it.

Refs #4268.

### Approach

**A rolling suffix on both keys.** Each key now ends in `--<run id>`, so every run publishes a fresh entry, and `restore-keys` fall back to the newest previous one. The Turbo key also includes `github.job`, which keeps each job's task outputs on their own lineage rather than having whichever job finishes first define the cache for all of them.

**Preflight no longer caches a store.** `setup-pnpm` takes a `cache-store` input, and preflight passes `false`. A job that never installs anything cannot publish a store for the rest of the run to inherit.

**The pnpm store is cached directly** rather than through `setup-node`'s `cache: pnpm`, because that key is generated by the action and cannot carry a rolling component.

**The cleanup job is now correct in two ways it was not before.** It keeps the newest entry per lineage instead of a single entry overall, and it is scoped to the run's own ref. GitHub stores caches per branch, and the previous version matched every ref, so it deleted other pull requests' warm caches along with this branch's stale ones. That is very likely part of why the caches stayed so cold.

The `--` separator is deliberate: a hex lockfile hash cannot contain one, so trimming the suffix can never mangle a key written before this change. Those keys are skipped entirely and expire on their own.

### Verification

The diagnosis was read from the run logs rather than inferred: every job reports `Cache hit for: node-cache-Linux-x64-pnpm-<hash>` at `Cache Size: ~5 MB` and `turbo-Linux-<hash>` at `~7 MB`, while `.turbo` locally holds 445 MB across 2,476 files, and Turbo does replay some tasks, so the cache is wired to the right path and is simply near-empty.

Cache scoping was confirmed against the API: entries exist per ref (`refs/pull/4404/merge`, `refs/heads/gh-readonly-queue/...`), which is what makes the unscoped delete harmful. The new cleanup selection was dry run against real cache listings for a single ref before being committed, and the `ref=` filter returns only that branch's entries.

`setup-pnpm` is also used by `nightly-build-validation`, which passes only `node-version`, so the new input is additive for it. Because scheduled runs execute on the default branch, that workflow will publish a main-scoped `pnpm-store-` entry that pull requests can restore from.

### What this does not fix

No workflow on the default branch uses the Turbo cache, so Turbo still has nothing warm to inherit and a branch's first run stays cold, with later runs on that branch benefiting. Adding the Turbo cache to a workflow that runs on main would close that gap and is worth doing separately.

### Related Issues
- Refs #4268

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved build and validation workflow caching for more reliable reuse across runs.
  - Added configurable pnpm store caching, allowing jobs that do not install packages to skip unnecessary cache activity.
  - Updated Turbo and pnpm cache handling to publish refreshed entries and restore from the most recent compatible cache.
  - Expanded automated cleanup to remove superseded cache entries and help control cache growth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->