### PR TITLE
Run only the Chromium E2E projects on pull requests

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -1217,10 +1217,27 @@ jobs:
       - name: 📦 Install E2E Dependencies
         run: pnpm install --frozen-lockfile
 
+      # Pull requests run the Chromium projects only, and the merge queue runs all
+      # three browsers, so nothing reaches main without the full matrix. On a pull
+      # request that is 45 of the 133 tests, and it also collapses the serial
+      # project chain (the CORS and MFA specs, which cannot overlap) from three
+      # sequential browsers to one, which is the part of the suite that no amount
+      # of workers can shorten.
       - name: 🎭 Run Playwright E2E Tests
-        run: pnpm test
+        run: |
+          if [ -n "$PLAYWRIGHT_PROJECT_FILTER" ]; then
+            echo "Running Playwright projects matching '$PLAYWRIGHT_PROJECT_FILTER'"
+            pnpm test --project="$PLAYWRIGHT_PROJECT_FILTER"
+          else
+            echo "Running every Playwright project"
+            pnpm test
+          fi
         working-directory: tests/e2e
         env:
+          # Matches the chromium and serial-chromium projects; setup comes along as
+          # their dependency. Empty on merge_group and workflow_dispatch, which run
+          # every project.
+          PLAYWRIGHT_PROJECT_FILTER: ${{ github.event_name == 'pull_request' && '*chromium*' || '' }}
           # Configuration Priority: Secret > Variable > Hardcoded Default
           BASE_URL: ${{ secrets.PLAYWRIGHT_BASE_URL || vars.PLAYWRIGHT_BASE_URL || 'https://localhost:8090' }}
           ADMIN_USERNAME: ${{ secrets.PLAYWRIGHT_ADMIN_USERNAME || 'admin' }}


### PR DESCRIPTION
### Purpose

The Playwright suite is the tail of the PR Builder critical path: 367s of the E2E job's 9.6 min on a recent run. It runs every spec in Chromium, Firefox and WebKit on every push to every pull request.

This runs the Chromium projects on pull requests and keeps all three browsers on the merge queue, so nothing reaches main without the full matrix.

Refs #4268.

### Approach

The run step passes `--project` when the event is a pull request, and passes nothing otherwise, so `merge_group` and `workflow_dispatch` continue to run every project:

```
PLAYWRIGHT_PROJECT_FILTER: ${{ github.event_name == 'pull_request' && '*chromium*' || '' }}
```

The pattern matches the `chromium` and `serial-chromium` projects, and `setup` comes along as their dependency.

Two things get shorter, not one. The obvious saving is running 45 tests instead of 133. The less obvious and more valuable one is the serial project chain: the CORS and MFA specs mutate global server state, so `serial-chromium`, `serial-firefox` and `serial-webkit` are chained to run one at a time. That chain is the part of the suite no number of workers can shorten, and on a pull request it drops from three sequential browsers to one.

### Verification

Project selection was checked against the real suite rather than assumed:

```
$ pnpm exec playwright test --list                      # every project
  37 [chromium]  37 [firefox]  37 [webkit]
   7 [serial-chromium]  7 [serial-firefox]  7 [serial-webkit]  1 [setup]
  Total: 133 tests in 9 files

$ pnpm exec playwright test --list --project="*chromium*"
  37 [chromium]  7 [serial-chromium]  1 [setup]
  Total: 45 tests in 9 files
```

Both branches of the step were run as the workflow will run them: with the variable set the command selects 45 tests, and with it empty it selects 133. Argument forwarding through the `test` script was confirmed too, since a flag that pnpm dropped would silently run the whole matrix on pull requests and look like a working optimisation:

```
$ pnpm test --project="*chromium*" --list
Total: 45 tests in 9 files
$ pnpm test --list
Total: 133 tests in 9 files
```

### Trade-off

A Firefox or WebKit specific failure now surfaces on the merge queue rather than on the pull request, which ejects the queue entry instead of failing a check earlier. Main is still protected, because the queue runs the full matrix before anything lands. The cost lands on whoever hits a browser specific bug; the saving applies to every pull request run.

If that trade turns out to be the wrong way round for this suite, reverting is a one line change to the filter expression.

### Related Issues
- Refs #4268

### Related PRs
- #4421 also edits this job, so whichever merges second needs a trivial rebase.

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
