### PR TITLE
Update token endpoint auth method in frontend

### DIFF
--- a/docs/content/guides/agents/manage-agents.mdx
+++ b/docs/content/guides/agents/manage-agents.mdx
@@ -87,8 +87,8 @@ The **Advanced Settings** tab configures the OAuth 2.0 protocol settings:
 
 - **Grant types**: the OAuth 2.0 flows the agent can use (for example, `client_credentials`, `authorization_code`, `urn:ietf:params:oauth:grant-type:token-exchange`).
 - **Response types**: applies to the authorization code flow.
-- **Token endpoint auth method**: how the agent authenticates at the token endpoint (`client_secret_basic`, `client_secret_post`, `private_key_jwt`, or `none`).
-- **Public client**: marks the agent as a public client (no secret). Forces the token endpoint auth method to `none`.
+- **Client authentication method**: how the agent authenticates at <ProductName />'s client-authenticated endpoints, such as token, introspection, revocation, PAR, and CIBA (`client_secret_basic`, `client_secret_post`, `private_key_jwt`, or `none`).
+- **Public client**: marks the agent as a public client (no secret). Forces the client authentication method to `none`.
 - **PKCE required**: requires PKCE on all authorization code requests.
 - **Redirect URIs**: allowed redirect URIs for authorization code flows.
 - **Certificate**: a public certificate for `private_key_jwt` authentication or signed/encrypted token verification.

--- a/docs/content/guides/applications/application-settings.mdx
+++ b/docs/content/guides/applications/application-settings.mdx
@@ -133,7 +133,7 @@ The **Advanced Settings** tab shows the OAuth 2.0 settings configured at creatio
 |---------|-------------|
 | **Grant Types** | The OAuth 2.0 flows this application can use. Supported values: `authorization_code`, `refresh_token`, `client_credentials`, `urn:ietf:params:oauth:grant-type:token-exchange`, `urn:ietf:params:oauth:grant-type:jwt-bearer`. Whether this application can initiate flows directly via `POST /flow/execute` depends on its [application type](../manage-applications#application-types) and, for Full-stack and Custom applications, its grant configuration. See [Direct Initiation Restriction](../../key-concepts/authentication/integration-models.mdx#app-native) for the full rule. |
 | **Response Types** | The response types the application can request (for example, `code`). |
-| **Token Endpoint Auth Method** | How the application authenticates at the token endpoint: `client_secret_basic` (default), `client_secret_post`, `private_key_jwt`, or `none` (public clients). |
+| **Client Authentication Method** | How the application authenticates at <ProductName />'s client-authenticated endpoints (token, introspection, revocation, PAR, and CIBA): `client_secret_basic` (default), `client_secret_post`, `private_key_jwt`, or `none` (public clients). See [Client Authentication Methods](../../protocols/oauth-oidc/client-authentication-methods). |
 | **Public Client** | Whether this is a public client that cannot securely store a client secret. |
 | **PKCE Required** | Whether the application must send a `code_challenge` in every authorization request. Always `Yes` for public clients. |
 

--- a/docs/content/guides/protocols/oauth-oidc/client-authentication-methods.mdx
+++ b/docs/content/guides/protocols/oauth-oidc/client-authentication-methods.mdx
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 
 # Client Authentication Methods
 
-Whenever a client calls a protected endpoint at <ProductName />, such as token, introspection, PAR, or DCR (when secured), it must prove which client it is. The `token_endpoint_auth_method` setting on the application picks **how**. The choice is fixed per application and applies uniformly to every protected endpoint.
+Whenever a client calls a protected endpoint at <ProductName />, such as token, introspection, revocation, PAR, or CIBA, it identifies itself with a `client_id`. Confidential clients must additionally authenticate by proving they hold the client's credentials; public clients (`none`) present only the `client_id` and carry no credentials. The `token_endpoint_auth_method` setting on the application picks **how** the client authenticates. The choice is fixed per application and applies uniformly to every protected endpoint.
 
 <ProductName /> supports four methods, three for confidential clients and one (`none`) for public clients. The relevant specs are [RFC 6749 §2.3](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3), [RFC 6749 §2.1](https://datatracker.ietf.org/doc/html/rfc6749#section-2.1) (public clients), and [RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523) (JWT bearer client authentication).
 
@@ -117,9 +117,11 @@ The chosen method applies uniformly to every endpoint that requires client authe
 | Endpoint | Method enforced |
 |---|---|
 | `POST /oauth2/token` | Yes |
-| `POST /oauth2/par` | Yes |
 | `POST /oauth2/introspect` | Yes |
-| `POST /oauth2/dcr/register` | Optional: DCR can be configured to require authentication |
+| `POST /oauth2/revoke` | Yes |
+| `POST /oauth2/par` | Yes |
+| `POST /oauth2/bc-authorize` (CIBA) | Yes |
+| `POST /oauth2/dcr/register` | No: DCR is not authenticated with `token_endpoint_auth_method`. When secured, it uses a separate authorization model. |
 
 ## OAuth Client Certificate
 

--- a/docs/content/guides/protocols/oauth-oidc/dynamic-client-registration.mdx
+++ b/docs/content/guides/protocols/oauth-oidc/dynamic-client-registration.mdx
@@ -74,7 +74,7 @@ A successful registration returns `201 Created` with the assigned `client_id`, `
 | `grant_types` | No | OAuth 2.1 grant types the client may use. Specify explicitly. No default is applied. Supported values: `authorization_code`, `refresh_token`, `client_credentials`, `urn:ietf:params:oauth:grant-type:token-exchange`. |
 | `ou_id` | No | The organization unit ID to associate the registered client with. If omitted, the client is registered under the root organization unit. |
 | `response_types` | No | OAuth 2.1 response types. Specify explicitly. No default is applied. Use `code`. |
-| `token_endpoint_auth_method` | No | How the client authenticates at the token endpoint. Supported values: `client_secret_basic` (default), `client_secret_post`, `private_key_jwt`, `none`. |
+| `token_endpoint_auth_method` | No | How the registered client authenticates at <ProductName />'s client-authenticated endpoints (token, introspection, revocation, PAR, and CIBA). Supported values: `client_secret_basic` (default), `client_secret_post`, `private_key_jwt`, `none`. |
 | `client_name` | No | Human-readable name of the client. |
 | `client_uri` | No | URL of the client's home page. |
 | `logo_uri` | No | URL of the client logo image. |

--- a/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/TokenEndpointAuthMethodSection.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/TokenEndpointAuthMethodSection.tsx
@@ -53,15 +53,15 @@ export default function TokenEndpointAuthMethodSection({
 
   return (
     <SettingsCard
-      title={t('agents:edit.credentials.tokenEndpointAuthMethod.title', 'Token Endpoint Auth Method')}
+      title={t('agents:edit.credentials.tokenEndpointAuthMethod.title', 'Client Authentication Method')}
       description={t(
         'agents:edit.credentials.tokenEndpointAuthMethod.description',
-        'Defines how this agent authenticates when requesting tokens.',
+        'Defines how this agent authenticates at protected endpoints.',
       )}
     >
       <FormControl fullWidth size="small">
         <FormLabel htmlFor="agent_token_endpoint_auth_method">
-          {t('agents:edit.credentials.tokenEndpointAuthMethod.title', 'Token Endpoint Auth Method')}
+          {t('agents:edit.credentials.tokenEndpointAuthMethod.title', 'Client Authentication Method')}
         </FormLabel>
         <Select
           id="agent_token_endpoint_auth_method"
@@ -97,7 +97,7 @@ export default function TokenEndpointAuthMethodSection({
               )
             : t(
                 'agents:edit.credentials.tokenEndpointAuthMethod.hint',
-                'How this agent proves its identity when it calls the token endpoint.',
+                'How this agent proves its identity at protected endpoints.',
               )}
         </Typography>
       </FormControl>

--- a/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/OAuth2ConfigSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/OAuth2ConfigSection.tsx
@@ -294,7 +294,7 @@ export default function OAuth2ConfigSection({
         {/* Token Endpoint Auth Method */}
         <FormControl fullWidth size="small">
           <FormLabel htmlFor="token_endpoint_auth_method">
-            {t('applications:edit.advanced.labels.tokenEndpointAuthMethod', 'Token Endpoint Auth Method')}
+            {t('applications:edit.advanced.labels.tokenEndpointAuthMethod', 'Client Authentication Method')}
           </FormLabel>
           <Select
             id="token_endpoint_auth_method"
@@ -335,7 +335,7 @@ export default function OAuth2ConfigSection({
                   )
               : t(
                   'applications:edit.advanced.tokenEndpointAuthMethod.hint',
-                  'Defines how the client authenticates at the token endpoint.',
+                  'Defines how the client authenticates at protected endpoints.',
                 )}
           </Typography>
         </FormControl>

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1144,12 +1144,11 @@ const translations = {
     'edit.credentials.clientSecret.regenerateHint':
       'Client secret was shown once at creation. Regenerate to issue a new one.',
     'edit.credentials.clientSecret.regenerateButton': 'Regenerate secret',
-    'edit.credentials.tokenEndpointAuthMethod.title': 'Token Endpoint Auth Method',
+    'edit.credentials.tokenEndpointAuthMethod.title': 'Client Authentication Method',
     'edit.credentials.tokenEndpointAuthMethod.description':
-      'Defines how this agent authenticates when requesting tokens.',
+      'Defines how this agent authenticates at protected endpoints.',
     'edit.credentials.tokenEndpointAuthMethod.placeholder': 'Select an auth method',
-    'edit.credentials.tokenEndpointAuthMethod.hint':
-      'How this agent proves its identity when it calls the token endpoint.',
+    'edit.credentials.tokenEndpointAuthMethod.hint': 'How this agent proves its identity at protected endpoints.',
     'edit.credentials.tokenEndpointAuthMethod.lockedHint': 'Set to "none" because this agent is a public client.',
     'edit.credentials.certificate.title': 'Certificate',
     'edit.credentials.certificate.description':
@@ -2316,7 +2315,7 @@ const translations = {
     'onboarding.configure.oauth.grantTypes.authorizationCode': 'Authorization Code',
     'onboarding.configure.oauth.grantTypes.refreshToken': 'Refresh Token',
     'onboarding.configure.oauth.grantTypes.clientCredentials': 'Client Credentials',
-    'onboarding.configure.oauth.tokenEndpointAuthMethod.label': 'Token Endpoint Authentication Method',
+    'onboarding.configure.oauth.tokenEndpointAuthMethod.label': 'Client Authentication Method',
     'onboarding.configure.oauth.tokenEndpointAuthMethod.clientSecretBasic': 'Client Secret Basic',
     'onboarding.configure.oauth.tokenEndpointAuthMethod.clientSecretPost': 'Client Secret Post',
     'onboarding.configure.oauth.tokenEndpointAuthMethod.none': 'None',
@@ -2481,7 +2480,7 @@ const translations = {
     'edit.advanced.responseTypes.notApplicable': 'Response types apply only to the authorization code flow.',
     'edit.advanced.tokenEndpointAuthMethod.placeholder': 'Select authentication method',
     'edit.advanced.tokenEndpointAuthMethod.hint':
-      'Defines how the client authenticates at the token endpoint. Use client_secret_basic or client_secret_post for confidential clients, and none for public clients.',
+      'Defines how the client authenticates at protected endpoints. Use a confidential method (for example, client_secret_basic, client_secret_post, or private_key_jwt) for confidential clients, and none for public clients.',
     'edit.advanced.tokenEndpointAuthMethod.lockedHint': 'Locked to "none" because the client is public.',
     'edit.advanced.lockedByTemplate': 'Set by template',
     'edit.advanced.certificate.intro': 'Configure certificates for client authentication and token encryption.',
@@ -2736,7 +2735,7 @@ const translations = {
     'edit.advanced.labels.pkceRequired': 'PKCE Required',
     'edit.advanced.labels.requirePAR': 'Require Pushed Authorization Requests',
     'edit.advanced.par.hint': 'Require the client to use the PAR endpoint before authorization.',
-    'edit.advanced.labels.tokenEndpointAuthMethod': 'Token Endpoint Auth Method',
+    'edit.advanced.labels.tokenEndpointAuthMethod': 'Client Authentication Method',
     'edit.advanced.labels.certificate': 'Certificate',
     'edit.advanced.labels.certificateType': 'Certificate Type',
     'edit.advanced.labels.metadata': 'Metadata',


### PR DESCRIPTION
### Purpose
Renames the OAuth2 client-auth field in the Console from "Token Endpoint Auth Method" to "Client Authentication Method" and corrects its description. The method (`client_secret_basic`, `client_secret_post`, `private_key_jwt`, `none`) is a per-client property applying to token, introspection, revocation, PAR, and CIBA, not just the token endpoint. Copy-only; no behavior or API field-name changes.

### Related Issues
- Fixes #4229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated OAuth 2.0/OIDC guidance to clarify that the configured client authentication method applies across protected endpoints (token, introspection, revocation, PAR, and CIBA).
  * Revised wording for public client behavior and updated the endpoint-method applicability table; adjusted dynamic client registration and advanced OAuth configuration docs.

* **User Interface**
  * Renamed “Token Endpoint Auth Method” to “Client Authentication Method” and updated labels, descriptions, and hints to consistently reflect protected-endpoint authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->