### PR TITLE
Add --devel flag to Helm install in getting started guide

### DIFF
--- a/docs/content/getting-started/get-thunderid.mdx
+++ b/docs/content/getting-started/get-thunderid.mdx
@@ -224,6 +224,7 @@ Install <ProductName /> using the [<ProductName /> Helm chart](https://github.co
 
 ```bash
 helm install {{productSlug}} oci://ghcr.io/thunder-id/helm-charts/{{productSlug}} \
+  --devel \
   --set configuration.database.config.postgres.hostname=postgresql \
   --set configuration.database.config.postgres.sslmode=disable \
   --set configuration.database.runtime_transient.postgres.hostname=postgresql \


### PR DESCRIPTION
## Purpose

Fixes the Helm quickstart in the "Get started" guide, which silently pins to the last stable chart instead of the alpha under test.

Fixes #4121

## Description

The Helm tab of the "Get started" guide runs `helm install thunderid oci://ghcr.io/thunder-id/helm-charts/thunderid` with no `--version` or `--devel` flag. Helm's default OCI chart resolution excludes pre-release versions, so it always resolves to the latest stable chart (`0.48.0`), never the newest alpha (`1.0.0-alpha`).

`0.48.0` predates the db-naming rename (`runtime`/`operation`/`userdb` to `runtime_transient`/`runtime_persistent`/`entitydb`), so the guide's own `--set configuration.database.runtime_transient.*` / `configuration.database.entity.*` flags don't match its schema and `helm install` fails with:

```
Error: INSTALLATION FAILED: failed pre-install: 1 error occurred:
	* job thunderid-setup failed: BackoffLimitExceeded
```

Adding `--devel` makes the quickstart track the newest published chart (stable or pre-release), matching the current schema and the `:latest` image used in the dbinit step.

## Related Issues

- Fixes #4121

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Helm installation command to include the `--devel` flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->