### PR TITLE
Add support to encrypt attribute cache

### DIFF
--- a/backend/cmd/server/config/default.json
+++ b/backend/cmd/server/config/default.json
@@ -268,6 +268,11 @@
       }
     ]
   },
+  "attribute_cache": {
+    "encryption": {
+      "enabled": false
+    }
+  },
   "resource": {
     "default_delimiter": ":",
     "store": "composite"

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -300,7 +300,8 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	// guard created by the authn service.
 	authzen.Initialize(mux, authZService, entityProvider, resourceService, directAuthGuard)
 
-	attributeCacheService := attributecache.Initialize(runtimeStoreProvider)
+	attributeCacheService := attributecache.Initialize(runtimeStoreProvider, runtimeCryptoSvc,
+		runtime.Config.AttributeCache.Encryption.Enabled)
 
 	emailClient := initEmailClient(ctx, logger)
 

--- a/backend/internal/attributecache/attributeCacheStoreInterface_mock_test.go
+++ b/backend/internal/attributecache/attributeCacheStoreInterface_mock_test.go
@@ -38,16 +38,16 @@ func (_m *attributeCacheStoreInterfaceMock) EXPECT() *attributeCacheStoreInterfa
 }
 
 // CreateAttributeCache provides a mock function for the type attributeCacheStoreInterfaceMock
-func (_mock *attributeCacheStoreInterfaceMock) CreateAttributeCache(ctx context.Context, cache AttributeCache) error {
-	ret := _mock.Called(ctx, cache)
+func (_mock *attributeCacheStoreInterfaceMock) CreateAttributeCache(ctx context.Context, id string, data []byte, ttlSeconds int64) error {
+	ret := _mock.Called(ctx, id, data, ttlSeconds)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateAttributeCache")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, AttributeCache) error); ok {
-		r0 = returnFunc(ctx, cache)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []byte, int64) error); ok {
+		r0 = returnFunc(ctx, id, data, ttlSeconds)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -61,24 +61,36 @@ type attributeCacheStoreInterfaceMock_CreateAttributeCache_Call struct {
 
 // CreateAttributeCache is a helper method to define mock.On call
 //   - ctx context.Context
-//   - cache AttributeCache
-func (_e *attributeCacheStoreInterfaceMock_Expecter) CreateAttributeCache(ctx interface{}, cache interface{}) *attributeCacheStoreInterfaceMock_CreateAttributeCache_Call {
-	return &attributeCacheStoreInterfaceMock_CreateAttributeCache_Call{Call: _e.mock.On("CreateAttributeCache", ctx, cache)}
+//   - id string
+//   - data []byte
+//   - ttlSeconds int64
+func (_e *attributeCacheStoreInterfaceMock_Expecter) CreateAttributeCache(ctx interface{}, id interface{}, data interface{}, ttlSeconds interface{}) *attributeCacheStoreInterfaceMock_CreateAttributeCache_Call {
+	return &attributeCacheStoreInterfaceMock_CreateAttributeCache_Call{Call: _e.mock.On("CreateAttributeCache", ctx, id, data, ttlSeconds)}
 }
 
-func (_c *attributeCacheStoreInterfaceMock_CreateAttributeCache_Call) Run(run func(ctx context.Context, cache AttributeCache)) *attributeCacheStoreInterfaceMock_CreateAttributeCache_Call {
+func (_c *attributeCacheStoreInterfaceMock_CreateAttributeCache_Call) Run(run func(ctx context.Context, id string, data []byte, ttlSeconds int64)) *attributeCacheStoreInterfaceMock_CreateAttributeCache_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 AttributeCache
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(AttributeCache)
+			arg1 = args[1].(string)
+		}
+		var arg2 []byte
+		if args[2] != nil {
+			arg2 = args[2].([]byte)
+		}
+		var arg3 int64
+		if args[3] != nil {
+			arg3 = args[3].(int64)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -89,7 +101,7 @@ func (_c *attributeCacheStoreInterfaceMock_CreateAttributeCache_Call) Return(err
 	return _c
 }
 
-func (_c *attributeCacheStoreInterfaceMock_CreateAttributeCache_Call) RunAndReturn(run func(ctx context.Context, cache AttributeCache) error) *attributeCacheStoreInterfaceMock_CreateAttributeCache_Call {
+func (_c *attributeCacheStoreInterfaceMock_CreateAttributeCache_Call) RunAndReturn(run func(ctx context.Context, id string, data []byte, ttlSeconds int64) error) *attributeCacheStoreInterfaceMock_CreateAttributeCache_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -215,22 +227,24 @@ func (_c *attributeCacheStoreInterfaceMock_ExtendAttributeCacheTTL_Call) RunAndR
 }
 
 // GetAttributeCache provides a mock function for the type attributeCacheStoreInterfaceMock
-func (_mock *attributeCacheStoreInterfaceMock) GetAttributeCache(ctx context.Context, id string) (AttributeCache, error) {
+func (_mock *attributeCacheStoreInterfaceMock) GetAttributeCache(ctx context.Context, id string) ([]byte, error) {
 	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAttributeCache")
 	}
 
-	var r0 AttributeCache
+	var r0 []byte
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (AttributeCache, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]byte, error)); ok {
 		return returnFunc(ctx, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) AttributeCache); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []byte); ok {
 		r0 = returnFunc(ctx, id)
 	} else {
-		r0 = ret.Get(0).(AttributeCache)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
 		r1 = returnFunc(ctx, id)
@@ -270,12 +284,12 @@ func (_c *attributeCacheStoreInterfaceMock_GetAttributeCache_Call) Run(run func(
 	return _c
 }
 
-func (_c *attributeCacheStoreInterfaceMock_GetAttributeCache_Call) Return(attributeCache AttributeCache, err error) *attributeCacheStoreInterfaceMock_GetAttributeCache_Call {
-	_c.Call.Return(attributeCache, err)
+func (_c *attributeCacheStoreInterfaceMock_GetAttributeCache_Call) Return(bytes []byte, err error) *attributeCacheStoreInterfaceMock_GetAttributeCache_Call {
+	_c.Call.Return(bytes, err)
 	return _c
 }
 
-func (_c *attributeCacheStoreInterfaceMock_GetAttributeCache_Call) RunAndReturn(run func(ctx context.Context, id string) (AttributeCache, error)) *attributeCacheStoreInterfaceMock_GetAttributeCache_Call {
+func (_c *attributeCacheStoreInterfaceMock_GetAttributeCache_Call) RunAndReturn(run func(ctx context.Context, id string) ([]byte, error)) *attributeCacheStoreInterfaceMock_GetAttributeCache_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/attributecache/init.go
+++ b/backend/internal/attributecache/init.go
@@ -20,10 +20,16 @@ package attributecache
 
 import (
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
+
+	"github.com/thunder-id/thunderid/internal/system/kmprovider"
 )
 
 // Initialize initializes the attribute cache service and returns an instance of AttributeCacheServiceInterface.
-func Initialize(storeProvider providers.RuntimeStoreProvider) AttributeCacheServiceInterface {
+func Initialize(
+	storeProvider providers.RuntimeStoreProvider,
+	crypto kmprovider.RuntimeCryptoProvider,
+	encryptionEnabled bool,
+) AttributeCacheServiceInterface {
 	store := newAttributeCacheStore(storeProvider)
-	return newAttributeCacheService(store)
+	return newAttributeCacheService(store, crypto, encryptionEnabled)
 }

--- a/backend/internal/attributecache/service.go
+++ b/backend/internal/attributecache/service.go
@@ -21,6 +21,7 @@ package attributecache
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"math"
 	"strings"
@@ -29,6 +30,8 @@ import (
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
+	"github.com/thunder-id/thunderid/internal/system/cryptolib"
+	"github.com/thunder-id/thunderid/internal/system/kmprovider"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/utils"
 )
@@ -59,13 +62,21 @@ type AttributeCacheServiceInterface interface {
 
 // attributeCacheService is the default implementation of the AttributeCacheServiceInterface.
 type attributeCacheService struct {
-	store attributeCacheStoreInterface
+	store             attributeCacheStoreInterface
+	crypto            kmprovider.RuntimeCryptoProvider
+	encryptionEnabled bool
 }
 
 // newAttributeCacheService creates a new instance of attributeCacheService with injected dependencies.
-func newAttributeCacheService(store attributeCacheStoreInterface) AttributeCacheServiceInterface {
+func newAttributeCacheService(
+	store attributeCacheStoreInterface,
+	crypto kmprovider.RuntimeCryptoProvider,
+	encryptionEnabled bool,
+) AttributeCacheServiceInterface {
 	return &attributeCacheService{
-		store: store,
+		store:             store,
+		crypto:            crypto,
+		encryptionEnabled: encryptionEnabled,
 	}
 }
 
@@ -95,7 +106,22 @@ func (s *attributeCacheService) CreateAttributeCache(
 		return nil, &tidcommon.InternalServerError
 	}
 
-	err = s.store.CreateAttributeCache(ctx, *cache)
+	data, err := json.Marshal(cache.Attributes)
+	if err != nil {
+		logger.Error(ctx, "Failed to marshal attributes", log.Error(err))
+		return nil, &tidcommon.InternalServerError
+	}
+	if s.encryptionEnabled {
+		ciphertext, _, encErr := s.crypto.Encrypt(ctx, nil,
+			cryptolib.AlgorithmParams{Algorithm: cryptolib.AlgorithmAESGCM}, data)
+		if encErr != nil {
+			logger.Error(ctx, "Failed to encrypt attributes", log.Error(encErr))
+			return nil, &tidcommon.InternalServerError
+		}
+		data = ciphertext
+	}
+
+	err = s.store.CreateAttributeCache(ctx, cache.ID, data, cache.TTLSeconds)
 	if err != nil {
 		logger.Error(ctx, "Failed to create attribute cache", log.Error(err), log.String("id", cache.ID))
 		return nil, &tidcommon.InternalServerError
@@ -116,7 +142,7 @@ func (s *attributeCacheService) GetAttributeCache(
 		return nil, &ErrorMissingCacheID
 	}
 
-	cache, err := s.store.GetAttributeCache(ctx, id)
+	data, err := s.store.GetAttributeCache(ctx, id)
 	if err != nil {
 		if errors.Is(err, errAttributeCacheNotFound) {
 			logger.Debug(ctx, "Attribute cache not found", log.String("id", id))
@@ -126,8 +152,26 @@ func (s *attributeCacheService) GetAttributeCache(
 		return nil, &tidcommon.InternalServerError
 	}
 
+	if s.encryptionEnabled {
+		plaintext, decErr := s.crypto.Decrypt(ctx, nil,
+			cryptolib.AlgorithmParams{Algorithm: cryptolib.AlgorithmAESGCM}, data)
+		if decErr != nil {
+			logger.Error(ctx, "Failed to decrypt attributes", log.Error(decErr), log.String("id", id))
+			return nil, &tidcommon.InternalServerError
+		}
+		data = plaintext
+	}
+	var attrs map[string]interface{}
+	if err := json.Unmarshal(data, &attrs); err != nil {
+		logger.Error(ctx, "Failed to unmarshal attributes", log.Error(err), log.String("id", id))
+		return nil, &tidcommon.InternalServerError
+	}
+
 	logger.Debug(ctx, "Successfully retrieved attribute cache", log.String("id", id))
-	return &cache, nil
+	return &AttributeCache{
+		ID:         id,
+		Attributes: attrs,
+	}, nil
 }
 
 // ExtendAttributeCacheTTL extends the TTL of an attribute cache entry.

--- a/backend/internal/attributecache/service_test.go
+++ b/backend/internal/attributecache/service_test.go
@@ -20,6 +20,7 @@ package attributecache
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -29,15 +30,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/thunder-id/thunderid/tests/mocks/crypto/cryptomock"
 )
 
 // AttributeCacheServiceTestSuite is the test suite for the attribute cache service.
 type AttributeCacheServiceTestSuite struct {
 	suite.Suite
-	service   AttributeCacheServiceInterface
-	mockStore *attributeCacheStoreInterfaceMock
-	ctx       context.Context
-	testCache AttributeCache
+	service        AttributeCacheServiceInterface
+	mockStore      *attributeCacheStoreInterfaceMock
+	mockCrypto     *cryptomock.RuntimeCryptoProviderMock
+	ctx            context.Context
+	testID         string
+	testAttributes map[string]interface{}
 }
 
 func TestAttributeCacheServiceSuite(t *testing.T) {
@@ -46,14 +51,18 @@ func TestAttributeCacheServiceSuite(t *testing.T) {
 
 func (suite *AttributeCacheServiceTestSuite) SetupTest() {
 	suite.mockStore = newAttributeCacheStoreInterfaceMock(suite.T())
-	suite.service = newAttributeCacheService(suite.mockStore)
+	suite.mockCrypto = cryptomock.NewRuntimeCryptoProviderMock(suite.T())
+	// Default service has encryption disabled; encryption-enabled cases build their own instance.
+	suite.service = newAttributeCacheService(suite.mockStore, suite.mockCrypto, false)
 	suite.ctx = context.Background()
 
-	suite.testCache = AttributeCache{
-		ID:         "test-cache-id",
-		Attributes: map[string]interface{}{"key": "value"},
-		TTLSeconds: 3600, // 1 hour
-	}
+	suite.testID = "test-cache-id"
+	suite.testAttributes = map[string]interface{}{"key": "value"}
+}
+
+// nonEmptyID matches any generated (non-empty) cache ID.
+func nonEmptyID() interface{} {
+	return mock.MatchedBy(func(id string) bool { return id != "" })
 }
 
 // Tests for CreateAttributeCache
@@ -63,10 +72,10 @@ func (suite *AttributeCacheServiceTestSuite) TestCreateAttributeCache_Success() 
 		Attributes: map[string]interface{}{"user": "john", "role": "admin"},
 		TTLSeconds: 3600,
 	}
+	expectedData, _ := json.Marshal(cache.Attributes)
 
-	suite.mockStore.On("CreateAttributeCache", suite.ctx, mock.MatchedBy(func(c AttributeCache) bool {
-		return c.ID != "" && len(c.Attributes) > 0 && c.TTLSeconds == 3600
-	})).Return(nil).Once()
+	suite.mockStore.On("CreateAttributeCache", suite.ctx, nonEmptyID(), expectedData, int64(3600)).
+		Return(nil).Once()
 
 	result, err := suite.service.CreateAttributeCache(suite.ctx, cache)
 
@@ -124,13 +133,28 @@ func (suite *AttributeCacheServiceTestSuite) TestCreateAttributeCache_NegativeTT
 	assert.Equal(suite.T(), ErrorInvalidExpiryTime.Code, err.Code)
 }
 
+// TestCreateAttributeCache_MarshalError verifies attributes that cannot be JSON-encoded surface an
+// internal error before the store is touched.
+func (suite *AttributeCacheServiceTestSuite) TestCreateAttributeCache_MarshalError() {
+	cache := &AttributeCache{
+		Attributes: map[string]interface{}{"bad": make(chan int)},
+		TTLSeconds: 3600,
+	}
+
+	result, err := suite.service.CreateAttributeCache(suite.ctx, cache)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), tidcommon.InternalServerError.Code, err.Code)
+}
+
 func (suite *AttributeCacheServiceTestSuite) TestCreateAttributeCache_StoreError() {
 	cache := &AttributeCache{
 		Attributes: map[string]interface{}{"key": "value"},
 		TTLSeconds: 3600,
 	}
 
-	suite.mockStore.On("CreateAttributeCache", suite.ctx, mock.Anything).
+	suite.mockStore.On("CreateAttributeCache", suite.ctx, nonEmptyID(), mock.Anything, int64(3600)).
 		Return(errors.New("database error")).Once()
 
 	result, err := suite.service.CreateAttributeCache(suite.ctx, cache)
@@ -140,19 +164,60 @@ func (suite *AttributeCacheServiceTestSuite) TestCreateAttributeCache_StoreError
 	assert.Equal(suite.T(), tidcommon.InternalServerError.Code, err.Code)
 }
 
-// Tests for GetAttributeCache
+// TestCreateAttributeCache_Encrypted verifies that when encryption is enabled the attributes are
+// encrypted and the ciphertext (not the plaintext JSON) is what is handed to the store.
+func (suite *AttributeCacheServiceTestSuite) TestCreateAttributeCache_Encrypted() {
+	encService := newAttributeCacheService(suite.mockStore, suite.mockCrypto, true)
+	cache := &AttributeCache{
+		Attributes: map[string]interface{}{"key": "value"},
+		TTLSeconds: 3600,
+	}
+	plaintext, _ := json.Marshal(cache.Attributes)
+	ciphertext := []byte("encrypted-blob")
 
-func (suite *AttributeCacheServiceTestSuite) TestGetAttributeCache_Success() {
-	suite.mockStore.On("GetAttributeCache", suite.ctx, suite.testCache.ID).
-		Return(suite.testCache, nil).Once()
+	suite.mockCrypto.EXPECT().Encrypt(mock.Anything, mock.Anything, mock.Anything, plaintext).
+		Return(ciphertext, nil, nil).Once()
+	suite.mockStore.On("CreateAttributeCache", suite.ctx, nonEmptyID(), ciphertext, int64(3600)).
+		Return(nil).Once()
 
-	result, err := suite.service.GetAttributeCache(suite.ctx, suite.testCache.ID)
+	result, err := encService.CreateAttributeCache(suite.ctx, cache)
 
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), result)
-	assert.Equal(suite.T(), suite.testCache.ID, result.ID)
-	assert.Equal(suite.T(), suite.testCache.Attributes, result.Attributes)
-	assert.Equal(suite.T(), suite.testCache.TTLSeconds, result.TTLSeconds)
+}
+
+// TestCreateAttributeCache_EncryptError verifies an encryption failure surfaces an internal error
+// and the store is never written.
+func (suite *AttributeCacheServiceTestSuite) TestCreateAttributeCache_EncryptError() {
+	encService := newAttributeCacheService(suite.mockStore, suite.mockCrypto, true)
+	cache := &AttributeCache{
+		Attributes: map[string]interface{}{"key": "value"},
+		TTLSeconds: 3600,
+	}
+
+	suite.mockCrypto.EXPECT().Encrypt(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil, errors.New("encrypt failed")).Once()
+
+	result, err := encService.CreateAttributeCache(suite.ctx, cache)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), tidcommon.InternalServerError.Code, err.Code)
+}
+
+// Tests for GetAttributeCache
+
+func (suite *AttributeCacheServiceTestSuite) TestGetAttributeCache_Success() {
+	data, _ := json.Marshal(suite.testAttributes)
+	suite.mockStore.On("GetAttributeCache", suite.ctx, suite.testID).
+		Return(data, nil).Once()
+
+	result, err := suite.service.GetAttributeCache(suite.ctx, suite.testID)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), suite.testID, result.ID)
+	assert.Equal(suite.T(), suite.testAttributes, result.Attributes)
 }
 
 func (suite *AttributeCacheServiceTestSuite) TestGetAttributeCache_EmptyID() {
@@ -173,7 +238,7 @@ func (suite *AttributeCacheServiceTestSuite) TestGetAttributeCache_WhitespaceID(
 
 func (suite *AttributeCacheServiceTestSuite) TestGetAttributeCache_NotFound() {
 	suite.mockStore.On("GetAttributeCache", suite.ctx, "non-existent-id").
-		Return(AttributeCache{}, errAttributeCacheNotFound).Once()
+		Return(nil, errAttributeCacheNotFound).Once()
 
 	result, err := suite.service.GetAttributeCache(suite.ctx, "non-existent-id")
 
@@ -183,10 +248,59 @@ func (suite *AttributeCacheServiceTestSuite) TestGetAttributeCache_NotFound() {
 }
 
 func (suite *AttributeCacheServiceTestSuite) TestGetAttributeCache_StoreError() {
-	suite.mockStore.On("GetAttributeCache", suite.ctx, suite.testCache.ID).
-		Return(AttributeCache{}, errors.New("database error")).Once()
+	suite.mockStore.On("GetAttributeCache", suite.ctx, suite.testID).
+		Return(nil, errors.New("database error")).Once()
 
-	result, err := suite.service.GetAttributeCache(suite.ctx, suite.testCache.ID)
+	result, err := suite.service.GetAttributeCache(suite.ctx, suite.testID)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), tidcommon.InternalServerError.Code, err.Code)
+}
+
+// TestGetAttributeCache_UnmarshalError verifies a payload that cannot be deserialized surfaces an
+// internal error rather than returning empty attributes.
+func (suite *AttributeCacheServiceTestSuite) TestGetAttributeCache_UnmarshalError() {
+	suite.mockStore.On("GetAttributeCache", suite.ctx, suite.testID).
+		Return([]byte("not-json"), nil).Once()
+
+	result, err := suite.service.GetAttributeCache(suite.ctx, suite.testID)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), tidcommon.InternalServerError.Code, err.Code)
+}
+
+// TestGetAttributeCache_Encrypted verifies that when encryption is enabled the stored ciphertext is
+// decrypted before being deserialized back into the attribute map.
+func (suite *AttributeCacheServiceTestSuite) TestGetAttributeCache_Encrypted() {
+	encService := newAttributeCacheService(suite.mockStore, suite.mockCrypto, true)
+	ciphertext := []byte("encrypted-blob")
+	plaintext, _ := json.Marshal(suite.testAttributes)
+
+	suite.mockStore.On("GetAttributeCache", suite.ctx, suite.testID).
+		Return(ciphertext, nil).Once()
+	suite.mockCrypto.EXPECT().Decrypt(mock.Anything, mock.Anything, mock.Anything, ciphertext).
+		Return(plaintext, nil).Once()
+
+	result, err := encService.GetAttributeCache(suite.ctx, suite.testID)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), suite.testAttributes, result.Attributes)
+}
+
+// TestGetAttributeCache_DecryptError verifies a decryption failure surfaces an internal error.
+func (suite *AttributeCacheServiceTestSuite) TestGetAttributeCache_DecryptError() {
+	encService := newAttributeCacheService(suite.mockStore, suite.mockCrypto, true)
+	ciphertext := []byte("encrypted-blob")
+
+	suite.mockStore.On("GetAttributeCache", suite.ctx, suite.testID).
+		Return(ciphertext, nil).Once()
+	suite.mockCrypto.EXPECT().Decrypt(mock.Anything, mock.Anything, mock.Anything, ciphertext).
+		Return(nil, errors.New("decrypt failed")).Once()
+
+	result, err := encService.GetAttributeCache(suite.ctx, suite.testID)
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
@@ -198,10 +312,10 @@ func (suite *AttributeCacheServiceTestSuite) TestGetAttributeCache_StoreError() 
 func (suite *AttributeCacheServiceTestSuite) TestExtendAttributeCacheTTL_Success() {
 	newTTL := 7200 // 2 hours
 
-	suite.mockStore.On("ExtendAttributeCacheTTL", suite.ctx, suite.testCache.ID, newTTL).
+	suite.mockStore.On("ExtendAttributeCacheTTL", suite.ctx, suite.testID, newTTL).
 		Return(nil).Once()
 
-	err := suite.service.ExtendAttributeCacheTTL(suite.ctx, suite.testCache.ID, newTTL)
+	err := suite.service.ExtendAttributeCacheTTL(suite.ctx, suite.testID, newTTL)
 
 	assert.Nil(suite.T(), err)
 }
@@ -221,14 +335,14 @@ func (suite *AttributeCacheServiceTestSuite) TestExtendAttributeCacheTTL_Whitesp
 }
 
 func (suite *AttributeCacheServiceTestSuite) TestExtendAttributeCacheTTL_ZeroTTL() {
-	err := suite.service.ExtendAttributeCacheTTL(suite.ctx, suite.testCache.ID, 0)
+	err := suite.service.ExtendAttributeCacheTTL(suite.ctx, suite.testID, 0)
 
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), ErrorInvalidExpiryTime.Code, err.Code)
 }
 
 func (suite *AttributeCacheServiceTestSuite) TestExtendAttributeCacheTTL_NegativeTTL() {
-	err := suite.service.ExtendAttributeCacheTTL(suite.ctx, suite.testCache.ID, -100)
+	err := suite.service.ExtendAttributeCacheTTL(suite.ctx, suite.testID, -100)
 
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), ErrorInvalidExpiryTime.Code, err.Code)
@@ -245,10 +359,10 @@ func (suite *AttributeCacheServiceTestSuite) TestExtendAttributeCacheTTL_NotFoun
 }
 
 func (suite *AttributeCacheServiceTestSuite) TestExtendAttributeCacheTTL_StoreUpdateError() {
-	suite.mockStore.On("ExtendAttributeCacheTTL", suite.ctx, suite.testCache.ID, 3600).
+	suite.mockStore.On("ExtendAttributeCacheTTL", suite.ctx, suite.testID, 3600).
 		Return(errors.New("database error")).Once()
 
-	err := suite.service.ExtendAttributeCacheTTL(suite.ctx, suite.testCache.ID, 3600)
+	err := suite.service.ExtendAttributeCacheTTL(suite.ctx, suite.testID, 3600)
 
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), tidcommon.InternalServerError.Code, err.Code)
@@ -257,10 +371,10 @@ func (suite *AttributeCacheServiceTestSuite) TestExtendAttributeCacheTTL_StoreUp
 // Tests for DeleteAttributeCache
 
 func (suite *AttributeCacheServiceTestSuite) TestDeleteAttributeCache_Success() {
-	suite.mockStore.On("DeleteAttributeCache", suite.ctx, suite.testCache.ID).
+	suite.mockStore.On("DeleteAttributeCache", suite.ctx, suite.testID).
 		Return(nil).Once()
 
-	err := suite.service.DeleteAttributeCache(suite.ctx, suite.testCache.ID)
+	err := suite.service.DeleteAttributeCache(suite.ctx, suite.testID)
 
 	assert.Nil(suite.T(), err)
 }
@@ -280,10 +394,10 @@ func (suite *AttributeCacheServiceTestSuite) TestDeleteAttributeCache_Whitespace
 }
 
 func (suite *AttributeCacheServiceTestSuite) TestDeleteAttributeCache_StoreError() {
-	suite.mockStore.On("DeleteAttributeCache", suite.ctx, suite.testCache.ID).
+	suite.mockStore.On("DeleteAttributeCache", suite.ctx, suite.testID).
 		Return(errors.New("database error")).Once()
 
-	err := suite.service.DeleteAttributeCache(suite.ctx, suite.testCache.ID)
+	err := suite.service.DeleteAttributeCache(suite.ctx, suite.testID)
 
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), tidcommon.InternalServerError.Code, err.Code)

--- a/backend/internal/attributecache/store.go
+++ b/backend/internal/attributecache/store.go
@@ -20,7 +20,6 @@ package attributecache
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
@@ -29,10 +28,10 @@ import (
 // attributeCacheStoreInterface defines the interface for the attribute cache store.
 type attributeCacheStoreInterface interface {
 	// CreateAttributeCache creates a new attribute cache entry in the store.
-	CreateAttributeCache(ctx context.Context, cache AttributeCache) error
+	CreateAttributeCache(ctx context.Context, id string, data []byte, ttlSeconds int64) error
 
 	// GetAttributeCache retrieves an attribute cache entry by ID from the store.
-	GetAttributeCache(ctx context.Context, id string) (AttributeCache, error)
+	GetAttributeCache(ctx context.Context, id string) ([]byte, error)
 
 	// ExtendAttributeCacheTTL extends the TTL of an attribute cache entry in the store.
 	ExtendAttributeCacheTTL(ctx context.Context, id string, ttlSeconds int) error
@@ -54,33 +53,21 @@ func newAttributeCacheStore(store providers.RuntimeStoreProvider) attributeCache
 }
 
 // CreateAttributeCache creates a new attribute cache entry in the database.
-func (s *attributeCacheStore) CreateAttributeCache(ctx context.Context, cache AttributeCache) error {
-	data, err := json.Marshal(cache.Attributes)
-	if err != nil {
-		return fmt.Errorf("failed to marshal attributes: %w", err)
-	}
-	return s.store.Put(ctx, providers.NamespaceAttributeCache, cache.ID, data, cache.TTLSeconds)
+func (s *attributeCacheStore) CreateAttributeCache(
+	ctx context.Context, id string, data []byte, ttlSeconds int64) error {
+	return s.store.Put(ctx, providers.NamespaceAttributeCache, id, data, ttlSeconds)
 }
 
 // GetAttributeCache retrieves an attribute cache entry by ID from the database.
-func (s *attributeCacheStore) GetAttributeCache(ctx context.Context, id string) (AttributeCache, error) {
+func (s *attributeCacheStore) GetAttributeCache(ctx context.Context, id string) ([]byte, error) {
 	data, err := s.store.Get(ctx, providers.NamespaceAttributeCache, id)
 	if err != nil {
-		return AttributeCache{}, fmt.Errorf("failed to get attribute cache: %w", err)
+		return nil, fmt.Errorf("failed to get attribute cache: %w", err)
 	}
 	if data == nil {
-		return AttributeCache{}, errAttributeCacheNotFound
+		return nil, errAttributeCacheNotFound
 	}
-
-	var attributes map[string]interface{}
-	if err := json.Unmarshal(data, &attributes); err != nil {
-		return AttributeCache{}, fmt.Errorf("failed to unmarshal attributes: %w", err)
-	}
-
-	return AttributeCache{
-		ID:         id,
-		Attributes: attributes,
-	}, nil
+	return data, nil
 }
 
 // ExtendAttributeCacheTTL extends the TTL of an attribute cache entry in the database.

--- a/backend/internal/attributecache/store_test.go
+++ b/backend/internal/attributecache/store_test.go
@@ -30,12 +30,14 @@ import (
 )
 
 // AttributeCacheStoreTestSuite exercises the attributeCacheStore adapter against a real in-memory
-// runtime store, verifying the marshal/namespace/key round-trip and the not-found semantics.
+// runtime store, verifying the namespace/key/TTL round-trip and the not-found semantics. The store
+// persists opaque bytes; serialization and encryption live in the service layer.
 type AttributeCacheStoreTestSuite struct {
 	suite.Suite
-	store     attributeCacheStoreInterface
-	ctx       context.Context
-	testCache AttributeCache
+	store    attributeCacheStoreInterface
+	ctx      context.Context
+	testID   string
+	testData []byte
 }
 
 func TestAttributeCacheStoreSuite(t *testing.T) {
@@ -45,36 +47,19 @@ func TestAttributeCacheStoreSuite(t *testing.T) {
 func (suite *AttributeCacheStoreTestSuite) SetupTest() {
 	suite.store = newAttributeCacheStore(inmemory.Initialize("test-deployment"))
 	suite.ctx = context.Background()
-
-	suite.testCache = AttributeCache{
-		ID:         "test-cache-id",
-		Attributes: map[string]interface{}{"key": "value"},
-		TTLSeconds: 3600, // 1 hour
-	}
+	suite.testID = "test-cache-id"
+	suite.testData = []byte(`{"key":"value"}`)
 }
 
 // Tests for CreateAttributeCache
 
 func (suite *AttributeCacheStoreTestSuite) TestCreateAttributeCache_Success() {
-	err := suite.store.CreateAttributeCache(suite.ctx, suite.testCache)
+	err := suite.store.CreateAttributeCache(suite.ctx, suite.testID, suite.testData, 3600)
 	suite.Require().NoError(err)
 
-	got, err := suite.store.GetAttributeCache(suite.ctx, suite.testCache.ID)
+	got, err := suite.store.GetAttributeCache(suite.ctx, suite.testID)
 	suite.Require().NoError(err)
-	suite.Equal(suite.testCache.ID, got.ID)
-	suite.Equal(suite.testCache.Attributes, got.Attributes)
-}
-
-func (suite *AttributeCacheStoreTestSuite) TestCreateAttributeCache_MarshalError() {
-	cache := AttributeCache{
-		ID:         suite.testCache.ID,
-		Attributes: map[string]interface{}{"key": make(chan int)},
-		TTLSeconds: suite.testCache.TTLSeconds,
-	}
-
-	err := suite.store.CreateAttributeCache(suite.ctx, cache)
-
-	suite.Error(err)
+	suite.Equal(suite.testData, got)
 }
 
 // Tests for GetAttributeCache
@@ -83,20 +68,20 @@ func (suite *AttributeCacheStoreTestSuite) TestGetAttributeCache_NotFound() {
 	got, err := suite.store.GetAttributeCache(suite.ctx, "missing")
 
 	suite.ErrorIs(err, errAttributeCacheNotFound)
-	suite.Equal(AttributeCache{}, got)
+	suite.Nil(got)
 }
 
 // Tests for ExtendAttributeCacheTTL
 
 func (suite *AttributeCacheStoreTestSuite) TestExtendAttributeCacheTTL_Success() {
-	suite.Require().NoError(suite.store.CreateAttributeCache(suite.ctx, suite.testCache))
+	suite.Require().NoError(suite.store.CreateAttributeCache(suite.ctx, suite.testID, suite.testData, 3600))
 
-	err := suite.store.ExtendAttributeCacheTTL(suite.ctx, suite.testCache.ID, 7200)
+	err := suite.store.ExtendAttributeCacheTTL(suite.ctx, suite.testID, 7200)
 	suite.Require().NoError(err)
 
-	got, err := suite.store.GetAttributeCache(suite.ctx, suite.testCache.ID)
+	got, err := suite.store.GetAttributeCache(suite.ctx, suite.testID)
 	suite.Require().NoError(err)
-	suite.Equal(suite.testCache.Attributes, got.Attributes)
+	suite.Equal(suite.testData, got)
 }
 
 func (suite *AttributeCacheStoreTestSuite) TestExtendAttributeCacheTTL_NotFound() {
@@ -108,10 +93,10 @@ func (suite *AttributeCacheStoreTestSuite) TestExtendAttributeCacheTTL_NotFound(
 // Tests for DeleteAttributeCache
 
 func (suite *AttributeCacheStoreTestSuite) TestDeleteAttributeCache_Success() {
-	suite.Require().NoError(suite.store.CreateAttributeCache(suite.ctx, suite.testCache))
-	suite.Require().NoError(suite.store.DeleteAttributeCache(suite.ctx, suite.testCache.ID))
+	suite.Require().NoError(suite.store.CreateAttributeCache(suite.ctx, suite.testID, suite.testData, 3600))
+	suite.Require().NoError(suite.store.DeleteAttributeCache(suite.ctx, suite.testID))
 
-	_, err := suite.store.GetAttributeCache(suite.ctx, suite.testCache.ID)
+	_, err := suite.store.GetAttributeCache(suite.ctx, suite.testID)
 	suite.ErrorIs(err, errAttributeCacheNotFound)
 }
 
@@ -119,20 +104,6 @@ func (suite *AttributeCacheStoreTestSuite) TestDeleteAttributeCache_NotFound() {
 	err := suite.store.DeleteAttributeCache(suite.ctx, "missing")
 
 	suite.NoError(err)
-}
-
-// TestUnmarshalError verifies GetAttributeCache surfaces a non-not-found error when the stored
-// payload cannot be deserialized.
-func (suite *AttributeCacheStoreTestSuite) TestGetAttributeCache_UnmarshalError() {
-	store := inmemory.Initialize("test-deployment")
-	suite.Require().NoError(store.Put(suite.ctx, providers.NamespaceAttributeCache, suite.testCache.ID,
-		[]byte("not-json"), 60))
-
-	s := newAttributeCacheStore(store)
-	_, err := s.GetAttributeCache(suite.ctx, suite.testCache.ID)
-
-	suite.Error(err)
-	suite.False(errors.Is(err, errAttributeCacheNotFound))
 }
 
 // erroringRuntimeStore wraps a RuntimeStoreProvider and forces Get to fail, so that
@@ -149,7 +120,7 @@ func (e *erroringRuntimeStore) Get(_ context.Context, _ providers.RuntimeStoreNa
 func (suite *AttributeCacheStoreTestSuite) TestGetAttributeCache_StoreError() {
 	s := newAttributeCacheStore(&erroringRuntimeStore{RuntimeStoreProvider: inmemory.Initialize("test-deployment")})
 
-	_, err := s.GetAttributeCache(suite.ctx, suite.testCache.ID)
+	_, err := s.GetAttributeCache(suite.ctx, suite.testID)
 
 	suite.Error(err)
 	suite.Contains(err.Error(), "failed to get attribute cache")

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -572,40 +572,41 @@ type LogTimeRotationConfig struct {
 
 // Config holds the complete configuration details of the server.
 type Config struct {
-	Server               engineconfig.ServerConfig        `yaml:"server"                json:"server"`
-	Log                  LogConfig                        `yaml:"log"                   json:"log"`
-	GateClient           engineconfig.GateClientConfig    `yaml:"gate_client"           json:"gate_client"`
-	TLS                  TLSConfig                        `yaml:"tls"                   json:"tls"`
-	Database             DatabaseConfig                   `yaml:"database"              json:"database"`
-	Cache                engineconfig.CacheConfig         `yaml:"cache"                 json:"cache"`
-	JWT                  engineconfig.JWTConfig           `yaml:"jwt"                   json:"jwt"`
-	OAuth                engineconfig.OAuthConfig         `yaml:"oauth"                 json:"oauth"`
-	Flow                 engineconfig.FlowConfig          `yaml:"flow"                  json:"flow"`
-	Crypto               CryptoConfig                     `yaml:"crypto"                json:"crypto"`
-	User                 UserConfig                       `yaml:"user"                  json:"user"`
-	DeclarativeResources DeclarativeResources             `yaml:"declarative_resources" json:"declarative_resources"`
-	Resource             engineconfig.ResourceConfig      `yaml:"resource"              json:"resource"`
-	OrganizationUnit     OrganizationUnitConfig           `yaml:"organization_unit"     json:"organization_unit"`
-	IdentityProvider     IdentityProviderConfig           `yaml:"identity_provider"     json:"identity_provider"`
-	Application          ApplicationConfig                `yaml:"application"           json:"application"`
-	ServerConfig         ServerConfigConfig               `yaml:"server_config" json:"server_config"`
-	Agent                AgentConfig                      `yaml:"agent"                 json:"agent"`
-	EntityType           EntityTypeConfig                 `yaml:"user_type"             json:"user_type"`
-	Observability        engineconfig.ObservabilityConfig `yaml:"observability"         json:"observability"`
-	Passkey              PasskeyConfig                    `yaml:"passkey"               json:"passkey"`
-	Attestation          AttestationConfig                `yaml:"attestation"           json:"attestation"`
-	OpenID4VP            OpenID4VPConfig                  `yaml:"openid4vp"             json:"openid4vp"`
-	OpenID4VCI           OpenID4VCIConfig                 `yaml:"openid4vci"            json:"openid4vci"`
-	AuthnProvider        AuthnProviderConfig              `yaml:"authn_provider"        json:"authn_provider"`
-	UserProvider         UserProviderConfig               `yaml:"user_provider"         json:"user_provider"`
-	EntityProvider       EntityProviderConfig             `yaml:"entity_provider"       json:"entity_provider"`
-	Group                GroupConfig                      `yaml:"group"                 json:"group"`
-	Role                 RoleConfig                       `yaml:"role"                  json:"role"`
-	Theme                ThemeConfig                      `yaml:"theme"                 json:"theme"`
-	Layout               LayoutConfig                     `yaml:"layout"                json:"layout"`
-	Translation          TranslationConfig                `yaml:"translation"           json:"translation"`
-	Email                EmailConfig                      `yaml:"email"                 json:"email"`
-	Notification         NotificationConfig               `yaml:"notification"          json:"notification"`
+	Server               engineconfig.ServerConfig         `yaml:"server"                json:"server"`
+	Log                  LogConfig                         `yaml:"log"                   json:"log"`
+	GateClient           engineconfig.GateClientConfig     `yaml:"gate_client"           json:"gate_client"`
+	TLS                  TLSConfig                         `yaml:"tls"                   json:"tls"`
+	Database             DatabaseConfig                    `yaml:"database"              json:"database"`
+	Cache                engineconfig.CacheConfig          `yaml:"cache"                 json:"cache"`
+	JWT                  engineconfig.JWTConfig            `yaml:"jwt"                   json:"jwt"`
+	OAuth                engineconfig.OAuthConfig          `yaml:"oauth"                 json:"oauth"`
+	Flow                 engineconfig.FlowConfig           `yaml:"flow"                  json:"flow"`
+	Crypto               CryptoConfig                      `yaml:"crypto"                json:"crypto"`
+	User                 UserConfig                        `yaml:"user"                  json:"user"`
+	DeclarativeResources DeclarativeResources              `yaml:"declarative_resources" json:"declarative_resources"`
+	Resource             engineconfig.ResourceConfig       `yaml:"resource"              json:"resource"`
+	OrganizationUnit     OrganizationUnitConfig            `yaml:"organization_unit"     json:"organization_unit"`
+	IdentityProvider     IdentityProviderConfig            `yaml:"identity_provider"     json:"identity_provider"`
+	Application          ApplicationConfig                 `yaml:"application"           json:"application"`
+	ServerConfig         ServerConfigConfig                `yaml:"server_config" json:"server_config"`
+	Agent                AgentConfig                       `yaml:"agent"                 json:"agent"`
+	EntityType           EntityTypeConfig                  `yaml:"user_type"             json:"user_type"`
+	Observability        engineconfig.ObservabilityConfig  `yaml:"observability"         json:"observability"`
+	Passkey              PasskeyConfig                     `yaml:"passkey"               json:"passkey"`
+	Attestation          AttestationConfig                 `yaml:"attestation"           json:"attestation"`
+	OpenID4VP            OpenID4VPConfig                   `yaml:"openid4vp"             json:"openid4vp"`
+	OpenID4VCI           OpenID4VCIConfig                  `yaml:"openid4vci"            json:"openid4vci"`
+	AuthnProvider        AuthnProviderConfig               `yaml:"authn_provider"        json:"authn_provider"`
+	UserProvider         UserProviderConfig                `yaml:"user_provider"         json:"user_provider"`
+	EntityProvider       EntityProviderConfig              `yaml:"entity_provider"       json:"entity_provider"`
+	Group                GroupConfig                       `yaml:"group"                 json:"group"`
+	Role                 RoleConfig                        `yaml:"role"                  json:"role"`
+	Theme                ThemeConfig                       `yaml:"theme"                 json:"theme"`
+	Layout               LayoutConfig                      `yaml:"layout"                json:"layout"`
+	Translation          TranslationConfig                 `yaml:"translation"           json:"translation"`
+	Email                EmailConfig                       `yaml:"email"                 json:"email"`
+	Notification         NotificationConfig                `yaml:"notification"          json:"notification"`
+	AttributeCache       engineconfig.AttributeCacheConfig `yaml:"attribute_cache" json:"attribute_cache"`
 }
 
 // LoadConfig loads the configurations from the specified YAML file and applies defaults.

--- a/backend/pkg/thunderidengine/config/config.go
+++ b/backend/pkg/thunderidengine/config/config.go
@@ -150,6 +150,16 @@ type EncryptionConfig struct {
 	Key string `yaml:"key" json:"key"`
 }
 
+// AttributeCacheConfig holds the attribute cache configuration details.
+type AttributeCacheConfig struct {
+	Encryption AttributeCacheEncryptionConfig `yaml:"encryption" json:"encryption"`
+}
+
+// AttributeCacheEncryptionConfig holds the attribute cache encryption configuration details.
+type AttributeCacheEncryptionConfig struct {
+	Enabled bool `yaml:"enabled" json:"enabled"`
+}
+
 // JWTConfig holds the JWT configuration details.
 type JWTConfig struct {
 	Issuer         string `yaml:"issuer"           json:"issuer"`

--- a/backend/pkg/thunderidengine/engine.go
+++ b/backend/pkg/thunderidengine/engine.go
@@ -83,6 +83,7 @@ func New(mux *http.ServeMux, opts ...Option) *Engine {
 			Keys:       engineCtx.keyConfigs,
 			Encryption: engineCtx.encryptionConfig,
 		},
+		AttributeCache: engineCtx.attributeCacheConfig,
 	}
 
 	err = systemconfig.InitializeServerRuntime(engineCtx.serverHome, &sysConfig)
@@ -118,7 +119,8 @@ func New(mux *http.ServeMux, opts ...Option) *Engine {
 		}
 	}
 
-	engineCtx.attributeCacheService = attributecache.Initialize(engineCtx.runtimeStoreProvider)
+	engineCtx.attributeCacheService = attributecache.Initialize(engineCtx.runtimeStoreProvider,
+		engineCtx.runtimeCryptoSvc, systemconfig.GetServerRuntime().Config.AttributeCache.Encryption.Enabled)
 	engineCtx.authAssertGen = assert.Initialize()
 
 	authnProviderManager, err := authnprovidermgr.Initialize(
@@ -317,6 +319,7 @@ type engineContext struct {
 	keyConfigs             []engineconfig.KeyConfig
 	encryptionConfig       engineconfig.EncryptionConfig
 	logConfig              engineconfig.LogConfig
+	attributeCacheConfig   engineconfig.AttributeCacheConfig
 
 	actorProvider             providers.ActorProvider
 	defaultAuthnProvider      providers.AuthnProviderInterface
@@ -360,6 +363,11 @@ func WithKeyConfigs(keyConfigs []engineconfig.KeyConfig) Option {
 // WithEncryptionConfig supplies the encryption configs.
 func WithEncryptionConfig(encryptionConfig engineconfig.EncryptionConfig) Option {
 	return func(c *engineContext) { c.encryptionConfig = encryptionConfig }
+}
+
+// WithAttributeCacheConfig supplies the attribute cache configuration.
+func WithAttributeCacheConfig(config engineconfig.AttributeCacheConfig) Option {
+	return func(c *engineContext) { c.attributeCacheConfig = config }
 }
 
 // WithServerConfig supplies the server configuration.

--- a/backend/tests/mocks/attributecachemock/attributeCacheStoreInterface_mock.go
+++ b/backend/tests/mocks/attributecachemock/attributeCacheStoreInterface_mock.go
@@ -8,7 +8,6 @@ import (
 	"context"
 
 	mock "github.com/stretchr/testify/mock"
-	"github.com/thunder-id/thunderid/internal/attributecache"
 )
 
 // newAttributeCacheStoreInterfaceMock creates a new instance of attributeCacheStoreInterfaceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
@@ -39,16 +38,16 @@ func (_m *attributeCacheStoreInterfaceMock) EXPECT() *attributeCacheStoreInterfa
 }
 
 // CreateAttributeCache provides a mock function for the type attributeCacheStoreInterfaceMock
-func (_mock *attributeCacheStoreInterfaceMock) CreateAttributeCache(ctx context.Context, cache attributecache.AttributeCache) error {
-	ret := _mock.Called(ctx, cache)
+func (_mock *attributeCacheStoreInterfaceMock) CreateAttributeCache(ctx context.Context, id string, data []byte, ttlSeconds int64) error {
+	ret := _mock.Called(ctx, id, data, ttlSeconds)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateAttributeCache")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, attributecache.AttributeCache) error); ok {
-		r0 = returnFunc(ctx, cache)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []byte, int64) error); ok {
+		r0 = returnFunc(ctx, id, data, ttlSeconds)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -62,24 +61,36 @@ type attributeCacheStoreInterfaceMock_CreateAttributeCache_Call struct {
 
 // CreateAttributeCache is a helper method to define mock.On call
 //   - ctx context.Context
-//   - cache attributecache.AttributeCache
-func (_e *attributeCacheStoreInterfaceMock_Expecter) CreateAttributeCache(ctx interface{}, cache interface{}) *attributeCacheStoreInterfaceMock_CreateAttributeCache_Call {
-	return &attributeCacheStoreInterfaceMock_CreateAttributeCache_Call{Call: _e.mock.On("CreateAttributeCache", ctx, cache)}
+//   - id string
+//   - data []byte
+//   - ttlSeconds int64
+func (_e *attributeCacheStoreInterfaceMock_Expecter) CreateAttributeCache(ctx interface{}, id interface{}, data interface{}, ttlSeconds interface{}) *attributeCacheStoreInterfaceMock_CreateAttributeCache_Call {
+	return &attributeCacheStoreInterfaceMock_CreateAttributeCache_Call{Call: _e.mock.On("CreateAttributeCache", ctx, id, data, ttlSeconds)}
 }
 
-func (_c *attributeCacheStoreInterfaceMock_CreateAttributeCache_Call) Run(run func(ctx context.Context, cache attributecache.AttributeCache)) *attributeCacheStoreInterfaceMock_CreateAttributeCache_Call {
+func (_c *attributeCacheStoreInterfaceMock_CreateAttributeCache_Call) Run(run func(ctx context.Context, id string, data []byte, ttlSeconds int64)) *attributeCacheStoreInterfaceMock_CreateAttributeCache_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 attributecache.AttributeCache
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(attributecache.AttributeCache)
+			arg1 = args[1].(string)
+		}
+		var arg2 []byte
+		if args[2] != nil {
+			arg2 = args[2].([]byte)
+		}
+		var arg3 int64
+		if args[3] != nil {
+			arg3 = args[3].(int64)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -90,7 +101,7 @@ func (_c *attributeCacheStoreInterfaceMock_CreateAttributeCache_Call) Return(err
 	return _c
 }
 
-func (_c *attributeCacheStoreInterfaceMock_CreateAttributeCache_Call) RunAndReturn(run func(ctx context.Context, cache attributecache.AttributeCache) error) *attributeCacheStoreInterfaceMock_CreateAttributeCache_Call {
+func (_c *attributeCacheStoreInterfaceMock_CreateAttributeCache_Call) RunAndReturn(run func(ctx context.Context, id string, data []byte, ttlSeconds int64) error) *attributeCacheStoreInterfaceMock_CreateAttributeCache_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -216,22 +227,24 @@ func (_c *attributeCacheStoreInterfaceMock_ExtendAttributeCacheTTL_Call) RunAndR
 }
 
 // GetAttributeCache provides a mock function for the type attributeCacheStoreInterfaceMock
-func (_mock *attributeCacheStoreInterfaceMock) GetAttributeCache(ctx context.Context, id string) (attributecache.AttributeCache, error) {
+func (_mock *attributeCacheStoreInterfaceMock) GetAttributeCache(ctx context.Context, id string) ([]byte, error) {
 	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAttributeCache")
 	}
 
-	var r0 attributecache.AttributeCache
+	var r0 []byte
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (attributecache.AttributeCache, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]byte, error)); ok {
 		return returnFunc(ctx, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) attributecache.AttributeCache); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []byte); ok {
 		r0 = returnFunc(ctx, id)
 	} else {
-		r0 = ret.Get(0).(attributecache.AttributeCache)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
 		r1 = returnFunc(ctx, id)
@@ -271,12 +284,12 @@ func (_c *attributeCacheStoreInterfaceMock_GetAttributeCache_Call) Run(run func(
 	return _c
 }
 
-func (_c *attributeCacheStoreInterfaceMock_GetAttributeCache_Call) Return(attributeCache attributecache.AttributeCache, err error) *attributeCacheStoreInterfaceMock_GetAttributeCache_Call {
-	_c.Call.Return(attributeCache, err)
+func (_c *attributeCacheStoreInterfaceMock_GetAttributeCache_Call) Return(bytes []byte, err error) *attributeCacheStoreInterfaceMock_GetAttributeCache_Call {
+	_c.Call.Return(bytes, err)
 	return _c
 }
 
-func (_c *attributeCacheStoreInterfaceMock_GetAttributeCache_Call) RunAndReturn(run func(ctx context.Context, id string) (attributecache.AttributeCache, error)) *attributeCacheStoreInterfaceMock_GetAttributeCache_Call {
+func (_c *attributeCacheStoreInterfaceMock_GetAttributeCache_Call) RunAndReturn(run func(ctx context.Context, id string) ([]byte, error)) *attributeCacheStoreInterfaceMock_GetAttributeCache_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/docs/content/deployment/configuration.mdx
+++ b/docs/content/deployment/configuration.mdx
@@ -783,6 +783,18 @@ Signing keys are configured as an array. Each key has the following properties:
 
 The key type under `crypto.keys` determines the algorithm in `id_token_signing_alg_values_supported` in the OIDC discovery document. RSA keys advertise `RS256`; ECDSA `P-256`, `P-384`, and `P-521` keys advertise `ES256`, `ES384`, and `ES512`; Ed25519 keys advertise `EdDSA`. If multiple keys are configured, all resulting algorithms are included without duplicates.
 
+## Attribute Cache Configuration
+
+During an authorization flow, <ProductName /> caches the resolved user attributes in the runtime store and references them from tokens through the `aci` claim. These attributes are stored as plaintext by default. Enable encryption to store them encrypted at rest using the key from `crypto.encryption.key`.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `attribute_cache.encryption.enabled` | `false` | When `true`, cached user attributes are encrypted (AES-GCM) before being written to the runtime store and decrypted on read. Requires `crypto.encryption.key` to be configured. |
+
+:::warning
+Treat `attribute_cache.encryption.enabled` as a set-once value. It is applied on both write and read with no format detection, so changing it while cached entries still exist causes failures: after enabling it, entries written as plaintext can no longer be decrypted; after disabling it, encrypted entries are read without decryption. Before changing it, clear the attribute cache (or wait for all entries to expire), then restart.
+:::
+
 ## Email Configuration
 
 <ProductName /> sends emails through an SMTP server for features such as magic link authentication and user invitations. This configuration is optional. Without a configured SMTP server, email-dependent features remain unavailable. Add the following configuration to `deployment.yaml` to configure an SMTP server.

--- a/install/helm/conf/deployment.yaml
+++ b/install/helm/conf/deployment.yaml
@@ -98,6 +98,10 @@ crypto:
       key_file: {{ .keyFile | quote }}
   {{- end }}
 
+attribute_cache:
+  encryption:
+    enabled: {{ .Values.configuration.attributeCache.encryption.enabled }}
+
 database:
   config:
     type: {{ .Values.configuration.database.config.type | quote }}

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -258,6 +258,11 @@ configuration:
         certFile: "config/certs/ecdsa-signing.cert"
         keyFile: "config/certs/ecdsa-signing.key"
 
+  # Attribute cache configuration
+  attributeCache:
+    encryption:
+      enabled: false
+
   # Database configuration
   database:
     config:

--- a/tests/integration/oauth/attributecache/attribute_cache_test.go
+++ b/tests/integration/oauth/attributecache/attribute_cache_test.go
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package attributecache verifies the OAuth attribute-cache round-trip: during an authorization_code
+// flow the resolved user attributes are cached and referenced from tokens via the aci claim, then
+// resolved back into the id token, a refreshed access token, and the userinfo response. It runs the
+// round-trip in both attribute-cache modes: plaintext (the default) and encrypted (AES-GCM
+// encrypt-on-write / decrypt-on-read, gated by attribute_cache.encryption.enabled). Both modes must
+// yield identical claims, so the encrypted case flips the toggle for the duration of its test and
+// restores the default before returning, keeping the shared server pristine for other packages.
+package attributecache
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	testServerURL            = "https://localhost:8095"
+	clientID                 = "attr_cache_client"
+	clientSecret             = "attr_cache_secret"
+	appName                  = "AttributeCacheTestApp"
+	redirectURI              = "https://localhost:3000"
+	resourceServerIdentifier = "https://attr-cache.example.com"
+
+	testUsername  = "attr_cache_user"
+	testPassword  = "SecurePass123!"
+	testEmail     = "attr_cache@example.com"
+	testGivenName = "AttrCache"
+	testFamily    = "RoundTrip"
+)
+
+var testUserType = testutils.UserType{
+	Name: "attr-cache-person",
+	Schema: map[string]interface{}{
+		"username":    map[string]interface{}{"type": "string"},
+		"password":    map[string]interface{}{"type": "string", "credential": true},
+		"email":       map[string]interface{}{"type": "string"},
+		"given_name":  map[string]interface{}{"type": "string"},
+		"family_name": map[string]interface{}{"type": "string"},
+	},
+}
+
+// encryptionPatch builds a deployment-config patch that toggles attribute-cache encryption. The
+// integration fixture omits the section (default disabled), so restoring to disabled matches the
+// pristine config other suites rely on.
+func encryptionPatch(enabled bool) map[string]interface{} {
+	return map[string]interface{}{
+		"attribute_cache": map[string]interface{}{
+			"encryption": map[string]interface{}{"enabled": enabled},
+		},
+	}
+}
+
+type AttributeCacheTestSuite struct {
+	suite.Suite
+	client           *http.Client
+	ouID             string
+	entityTypeID     string
+	userID           string
+	flowID           string
+	applicationID    string
+	resourceServerID string
+}
+
+func TestAttributeCacheTestSuite(t *testing.T) {
+	suite.Run(t, new(AttributeCacheTestSuite))
+}
+
+func (ts *AttributeCacheTestSuite) SetupSuite() {
+	ts.client = testutils.GetHTTPClient()
+
+	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "attr-cache-ou",
+		Name:        "Attribute Cache OU",
+		Description: "Organization unit for attribute cache integration testing",
+		Parent:      nil,
+	})
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
+
+	testUserType.OUID = ts.ouID
+	entityTypeID, err := testutils.CreateUserType(testUserType)
+	ts.Require().NoError(err, "Failed to create test user type")
+	ts.entityTypeID = entityTypeID
+
+	ts.userID = ts.createTestUser()
+
+	resourceServerID, err := testutils.CreateResourceServerWithActions(testutils.ResourceServer{
+		Name:        "Attribute Cache Resource Server",
+		Description: "Resource server for attribute cache integration tests",
+		Identifier:  resourceServerIdentifier,
+		OUID:        ts.ouID,
+	}, []testutils.Action{})
+	ts.Require().NoError(err, "Failed to create resource server")
+	ts.resourceServerID = resourceServerID
+
+	ts.flowID = ts.createTestAuthenticationFlow()
+	ts.applicationID = ts.createTestApplication(ts.flowID)
+}
+
+func (ts *AttributeCacheTestSuite) TearDownSuite() {
+	if ts.applicationID != "" {
+		ts.deleteApplication(ts.applicationID)
+	}
+	if ts.resourceServerID != "" {
+		if err := testutils.DeleteResourceServer(ts.resourceServerID); err != nil {
+			ts.T().Logf("Failed to delete resource server: %v", err)
+		}
+	}
+	if ts.flowID != "" {
+		if err := testutils.DeleteFlow(ts.flowID); err != nil {
+			ts.T().Logf("Failed to delete authentication flow during teardown: %v", err)
+		}
+	}
+	if ts.userID != "" {
+		testutils.DeleteUser(ts.userID)
+	}
+	if ts.ouID != "" {
+		testutils.DeleteOrganizationUnit(ts.ouID)
+	}
+	if ts.entityTypeID != "" {
+		if err := testutils.DeleteUserType(ts.entityTypeID); err != nil {
+			ts.T().Logf("Failed to delete user type during teardown: %v", err)
+		}
+	}
+}
+
+func (ts *AttributeCacheTestSuite) createTestUser() string {
+	attributes := map[string]interface{}{
+		"username":    testUsername,
+		"password":    testPassword,
+		"email":       testEmail,
+		"given_name":  testGivenName,
+		"family_name": testFamily,
+	}
+	attributesJSON, err := json.Marshal(attributes)
+	ts.Require().NoError(err, "Failed to marshal user attributes")
+
+	userID, err := testutils.CreateUser(testutils.User{
+		Type:       testUserType.Name,
+		OUID:       ts.ouID,
+		Attributes: json.RawMessage(attributesJSON),
+	})
+	ts.Require().NoError(err, "Failed to create test user")
+	return userID
+}
+
+func (ts *AttributeCacheTestSuite) createTestAuthenticationFlow() string {
+	flow := testutils.Flow{
+		Name:     "Attribute Cache Auth Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "attr_cache_auth_flow",
+		Nodes: []map[string]interface{}{
+			{"id": "start", "type": "START", "onSuccess": "prompt_credentials"},
+			{
+				"id":   "prompt_credentials",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+							{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+						},
+						"action": map[string]interface{}{"ref": "action_001", "nextNode": "credentials_auth"},
+					},
+				},
+			},
+			{
+				"id":   "credentials_auth",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "CredentialsAuthExecutor",
+					"inputs": []map[string]interface{}{
+						{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+						{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+					},
+				},
+				"onSuccess": "auth_assert",
+			},
+			{
+				"id":        "auth_assert",
+				"type":      "TASK_EXECUTION",
+				"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+				"onSuccess": "end",
+			},
+			{"id": "end", "type": "END"},
+		},
+	}
+
+	flowID, err := testutils.CreateFlow(flow)
+	ts.Require().NoError(err, "Failed to create test authentication flow")
+	return flowID
+}
+
+func (ts *AttributeCacheTestSuite) createTestApplication(authFlowID string) string {
+	app := map[string]interface{}{
+		"name":                      appName,
+		"description":               "Application for attribute cache integration tests",
+		"ouId":                      ts.ouID,
+		"type":                      "fullstack",
+		"authFlowId":                authFlowID,
+		"isRegistrationFlowEnabled": false,
+		"allowedUserTypes":          []string{testUserType.Name},
+		"inboundAuthConfig": []map[string]interface{}{
+			{
+				"type": "oauth2",
+				"config": map[string]interface{}{
+					"clientId":                clientID,
+					"clientSecret":            clientSecret,
+					"redirectUris":            []string{redirectURI},
+					"grantTypes":              []string{"authorization_code", "refresh_token"},
+					"responseTypes":           []string{"code"},
+					"tokenEndpointAuthMethod": "client_secret_post",
+					"scopes":                  []string{"openid", "profile", "email"},
+					"token": map[string]interface{}{
+						"idToken": map[string]interface{}{
+							"userAttributes": []string{"email", "given_name", "family_name"},
+						},
+						"userInfo": map[string]interface{}{
+							"userAttributes": []string{"email", "given_name", "family_name"},
+						},
+					},
+					"scopeClaims": map[string][]string{
+						"profile": {"given_name", "family_name", "name"},
+						"email":   {"email"},
+					},
+				},
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(app)
+	ts.Require().NoError(err, "Failed to marshal application data")
+
+	req, err := http.NewRequest("POST", testServerURL+"/applications", bytes.NewBuffer(jsonData))
+	ts.Require().NoError(err, "Failed to create request")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err, "Failed to create application")
+	defer resp.Body.Close()
+
+	ts.Require().Equal(http.StatusCreated, resp.StatusCode, "Failed to create application")
+
+	var respData map[string]interface{}
+	ts.Require().NoError(json.NewDecoder(resp.Body).Decode(&respData), "Failed to parse response")
+	return respData["id"].(string)
+}
+
+func (ts *AttributeCacheTestSuite) deleteApplication(appID string) {
+	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/applications/%s", testServerURL, appID), nil)
+	if err != nil {
+		ts.T().Errorf("Failed to create delete request: %v", err)
+		return
+	}
+	resp, err := ts.client.Do(req)
+	if err != nil {
+		ts.T().Errorf("Failed to delete application: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		ts.T().Errorf("Failed to delete application. Status: %d, Response: %s", resp.StatusCode, string(bodyBytes))
+	}
+}
+
+func (ts *AttributeCacheTestSuite) callUserInfo(accessToken string) map[string]interface{} {
+	req, err := http.NewRequest("GET", testServerURL+"/oauth2/userinfo", nil)
+	ts.Require().NoError(err, "Failed to create userinfo request")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err, "Failed to call UserInfo endpoint")
+	defer resp.Body.Close()
+
+	ts.Require().Equal(http.StatusOK, resp.StatusCode, "UserInfo should return 200")
+
+	var userInfo map[string]interface{}
+	ts.Require().NoError(json.NewDecoder(resp.Body).Decode(&userInfo), "Failed to parse UserInfo response")
+	return userInfo
+}
+
+// assertUserClaims asserts the three cached user attributes are present with their expected values
+// in the given claims/userinfo map. where labels the source for failure messages.
+func (ts *AttributeCacheTestSuite) assertUserClaims(claims map[string]interface{}, where string) {
+	ts.Equal(testEmail, claims["email"], where+" email should match")
+	ts.Equal(testGivenName, claims["given_name"], where+" given_name should match")
+	ts.Equal(testFamily, claims["family_name"], where+" family_name should match")
+}
+
+// assertRoundTrip drives the full attribute-cache round-trip and asserts the cached user attributes
+// surface identically in (1) the id token, (2) the userinfo response, and (3) the userinfo response
+// after a refresh_token grant, while the access token only references the cache via the aci claim.
+// It is mode-agnostic: the caller runs it with encryption on or off and expects the same result.
+func (ts *AttributeCacheTestSuite) assertRoundTrip() {
+	tokens, err := testutils.ObtainAccessTokenWithPassword(clientID, redirectURI, "openid profile email",
+		testUsername, testPassword, false, clientSecret, resourceServerIdentifier)
+	ts.Require().NoError(err, "failed to obtain tokens via authorization_code flow")
+	ts.Require().NotEmpty(tokens.AccessToken, "access token should not be empty")
+	ts.Require().NotEmpty(tokens.IDToken, "id token should not be empty")
+	ts.Require().NotEmpty(tokens.RefreshToken, "refresh token should not be empty")
+
+	// (1) id token carries the user attributes resolved from the cache.
+	idClaims, err := testutils.DecodeJWT(tokens.IDToken)
+	ts.Require().NoError(err, "failed to decode id token")
+	ts.assertUserClaims(idClaims.Additional, "id token")
+
+	// The access token references the cache via aci; attributes are not embedded directly.
+	atClaims, err := testutils.DecodeJWT(tokens.AccessToken)
+	ts.Require().NoError(err, "failed to decode access token")
+	ts.NotEmpty(atClaims.Additional["aci"], "access token should carry the aci claim")
+
+	// (2) userinfo resolves the same attributes from the cache.
+	ts.assertUserClaims(ts.callUserInfo(tokens.AccessToken), "userinfo")
+
+	// (3) a refreshed access token still resolves the cached attributes.
+	refreshed, err := testutils.RefreshAccessTokenWithClientCredentialsInBody(clientID, clientSecret, tokens.RefreshToken)
+	ts.Require().NoError(err, "failed to refresh access token")
+	ts.Require().NotEmpty(refreshed.AccessToken, "refreshed access token should not be empty")
+	ts.assertUserClaims(ts.callUserInfo(refreshed.AccessToken), "userinfo after refresh")
+}
+
+// TestAttributeCache_Plaintext runs the round-trip with encryption disabled (the default), where the
+// attributes are cached as plaintext.
+func (ts *AttributeCacheTestSuite) TestAttributeCache_Plaintext() {
+	ts.assertRoundTrip()
+}
+
+// TestAttributeCache_Encrypted runs the same round-trip with encryption enabled, proving the AES-GCM
+// encrypt-on-write / decrypt-on-read path yields identical attributes. It flips the toggle for the
+// duration of the test and restores the default (disabled) config before returning, so the shared
+// server stays pristine for the other packages.
+func (ts *AttributeCacheTestSuite) TestAttributeCache_Encrypted() {
+	ts.Require().NoError(testutils.PatchDeploymentConfig(encryptionPatch(true)),
+		"Failed to enable attribute cache encryption")
+	ts.Require().NoError(testutils.RestartServer(), "Failed to restart server with encryption enabled")
+	ts.Require().NoError(testutils.ObtainAdminAccessToken(), "Failed to re-obtain admin token after restart")
+	// Restore steps use non-fatal assertions so a failure in one still lets the rest run, leaving the
+	// shared server in the default (disabled) state for the other packages.
+	defer func() {
+		ts.Assert().NoError(testutils.PatchDeploymentConfig(encryptionPatch(false)),
+			"Failed to restore attribute cache encryption config")
+		ts.Assert().NoError(testutils.RestartServer(), "Failed to restart server after config restore")
+		ts.Assert().NoError(testutils.ObtainAdminAccessToken(), "Failed to re-obtain admin token after restore")
+	}()
+
+	ts.assertRoundTrip()
+}


### PR DESCRIPTION
### Purpose

Protect cached user attributes (PII) at rest. During an OAuth authorization flow, resolved user attributes are stored in the runtime store (DB/Redis) keyed by the aci claim, then read back by the grant handlers and userinfo endpoint. Today they're stored as plaintext; this change lets operators encrypt them.

### Approach

  - Add a config toggle attribute_cache.encryption.enabled (default off).
  - In the attributecache service, when enabled, AES-GCM encrypt attributes before writing and decrypt on read, reusing the existing crypto.encryption.key via kmprovider.RuntimeCryptoProvider.
  - Reduce the store to a thin byte persister (serialization/crypto moved up to the service), mirroring the flow-context pattern.
  - Both encrypt and decrypt are gated purely on the toggle (no envelope sniffing).

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4406

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable encryption for cached user attributes.
  * Cached attributes can now be encrypted at rest using the configured encryption key.
  * Added deployment settings to enable or disable attribute-cache encryption.

* **Documentation**
  * Documented encryption behavior, default settings, and cache clearing requirements when changing the setting.

* **Tests**
  * Added coverage for encrypted and unencrypted OAuth attribute-cache flows, including tokens, userinfo, refresh, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->