### PR TITLE
Validate access token typ header in token exchange grant

### DIFF
--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"slices"
+	"strings"
 
 	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
@@ -31,6 +32,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/revocation"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/tokenservice"
 	oauth2utils "github.com/thunder-id/thunderid/internal/oauth/oauth2/utils"
+	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
@@ -204,6 +206,13 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 		}
 	}
 
+	// Enforce RFC 9068: a token presented as subject_token_type=access_token must carry the at+jwt typ
+	// header.
+	if errResp := h.validateAccessTokenType(tokenRequest.SubjectToken,
+		tokenRequest.SubjectTokenType, "subject_token"); errResp != nil {
+		return nil, errResp
+	}
+
 	// Enforce subject_token DPoP binding. The proof's jkt is verified earlier in the
 	// token service and propagated via context.
 	if errResp := dpop.VerifyProofBinding(ctx, subjectClaims.CnfJkt, "subject_token"); errResp != nil {
@@ -245,6 +254,12 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 					ErrorDescription: "Invalid actor_token",
 				}
 			}
+		}
+
+		// Apply the same RFC 9068 access-token typ enforcement to the actor_token.
+		if errResp := h.validateAccessTokenType(tokenRequest.ActorToken,
+			tokenRequest.ActorTokenType, "actor_token"); errResp != nil {
+			return nil, errResp
 		}
 	}
 
@@ -434,6 +449,37 @@ func (h *tokenExchangeGrantHandler) handleIDJAGGrant(ctx context.Context, tokenR
 	return &model.TokenResponseDTO{
 		AccessToken: *idjag,
 	}, nil
+}
+
+// validateAccessTokenType enforces the RFC 9068 typ header for a token presented as an access token.
+// When the declared token type is urn:ietf:params:oauth:token-type:access_token, the token's typ
+// header must be at+jwt.
+func (h *tokenExchangeGrantHandler) validateAccessTokenType(
+	token string,
+	tokenType string,
+	tokenLabel string,
+) *model.ErrorResponse {
+	if constants.TokenTypeIdentifier(tokenType) != constants.TokenTypeIdentifierAccessToken {
+		return nil
+	}
+
+	header, err := jwt.DecodeJWTHeader(token)
+	if err != nil {
+		return &model.ErrorResponse{
+			Error:            constants.ErrorInvalidRequest,
+			ErrorDescription: "Invalid " + tokenLabel,
+		}
+	}
+
+	if typ, _ := header["typ"].(string); !strings.EqualFold(typ, jwt.TokenTypeAccessToken) &&
+		!strings.EqualFold(typ, jwt.TokenTypeAccessTokenWithPrefix) {
+		return &model.ErrorResponse{
+			Error:            constants.ErrorInvalidRequest,
+			ErrorDescription: "The " + tokenLabel + " is not an access token (missing at+jwt typ header)",
+		}
+	}
+
+	return nil
 }
 
 // getScopes validates and determines the scopes for the new token.

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
@@ -172,9 +172,14 @@ func (suite *TokenExchangeGrantHandlerTestSuite) getDefaultAudience() string {
 
 // Helper function to create a test JWT token
 func (suite *TokenExchangeGrantHandlerTestSuite) createTestJWT(claims map[string]interface{}) string {
+	return suite.createTestJWTWithTyp("at+jwt", claims)
+}
+
+func (suite *TokenExchangeGrantHandlerTestSuite) createTestJWTWithTyp(
+	typ string, claims map[string]interface{}) string {
 	header := map[string]interface{}{
 		"alg": "RS256",
-		"typ": "JWT",
+		"typ": typ,
 	}
 
 	headerJSON, _ := json.Marshal(header)
@@ -1288,6 +1293,171 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_InvalidScope() 
 	assert.Nil(suite.T(), errResp)
 	assert.NotNil(suite.T(), result)
 	assert.Equal(suite.T(), []string{"read", "write"}, result.AccessToken.Scopes)
+}
+
+// An id_token (typ "JWT") presented as subject_token_type=access_token is rejected per RFC 9068: an
+// access token must carry the at+jwt typ header. This is the reported confusion vector where an
+// id_token is exchanged under the access_token type.
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_IDTokenAsAccessTokenRejected() {
+	now := time.Now().Unix()
+	// createTestJWTWithTyp stamps "JWT" (an id token), but the request declares access_token.
+	subjectToken := suite.createTestJWTWithTyp("JWT", map[string]interface{}{
+		"sub":   "user123",
+		"iss":   testCustomIssuer,
+		"exp":   float64(now + 3600),
+		"nbf":   float64(now - 60),
+		"scope": "read",
+	})
+
+	tokenRequest := &model.TokenRequest{
+		GrantType:        string(providers.GrantTypeTokenExchange),
+		ClientID:         testClientID,
+		SubjectToken:     subjectToken,
+		SubjectTokenType: string(constants.TokenTypeIdentifierAccessToken),
+	}
+
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub: testUserID, Iss: testCustomIssuer, Scopes: []string{"read"},
+		}, nil).Maybe()
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errResp.Error)
+	assert.Contains(suite.T(), errResp.ErrorDescription, "at+jwt")
+}
+
+// A token with no typ header presented as subject_token_type=access_token is rejected. This is the
+// exact reported scenario: an external id_token (no typ) exchanged under the access_token type.
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_NoTypAsAccessTokenRejected() {
+	now := time.Now().Unix()
+	// A JWT with only alg/kid in the header, no typ (as issued by some external IdPs for id tokens).
+	claims := map[string]interface{}{
+		"sub":   "user123",
+		"iss":   testCustomIssuer,
+		"exp":   float64(now + 3600),
+		"nbf":   float64(now - 60),
+		"scope": "read",
+	}
+	headerJSON, _ := json.Marshal(map[string]interface{}{"alg": "RS256", "kid": "abc"})
+	claimsJSON, _ := json.Marshal(claims)
+	subjectToken := fmt.Sprintf("%s.%s.signature",
+		base64.RawURLEncoding.EncodeToString(headerJSON),
+		base64.RawURLEncoding.EncodeToString(claimsJSON))
+
+	tokenRequest := &model.TokenRequest{
+		GrantType:        string(providers.GrantTypeTokenExchange),
+		ClientID:         testClientID,
+		SubjectToken:     subjectToken,
+		SubjectTokenType: string(constants.TokenTypeIdentifierAccessToken),
+	}
+
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub: testUserID, Iss: testCustomIssuer, Scopes: []string{"read"},
+		}, nil).Maybe()
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errResp.Error)
+	assert.Contains(suite.T(), errResp.ErrorDescription, "at+jwt")
+}
+
+// A subject token whose typ header is not access-token-constrained is accepted for exchange:
+// subject_token_type=jwt is never typ-constrained (a plain "JWT" external token is fine), and an
+// access token presented with the RFC 9068 media-type form "application/at+jwt" is also accepted.
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AcceptedSubjectTokenTypes() {
+	cases := []struct {
+		name             string
+		typ              string
+		subjectTokenType constants.TokenTypeIdentifier
+	}{
+		{"plain JWT under jwt type", "JWT", constants.TokenTypeIdentifierJWT},
+		{"media-type access token", "application/at+jwt", constants.TokenTypeIdentifierAccessToken},
+		{"uppercase access token typ", "AT+JWT", constants.TokenTypeIdentifierAccessToken},
+		{"uppercase media-type access token", "application/AT+JWT", constants.TokenTypeIdentifierAccessToken},
+	}
+
+	for _, tc := range cases {
+		suite.Run(tc.name, func() {
+			now := time.Now().Unix()
+			subjectToken := suite.createTestJWTWithTyp(tc.typ, map[string]interface{}{
+				"sub":   "user123",
+				"iss":   testCustomIssuer,
+				"exp":   float64(now + 3600),
+				"nbf":   float64(now - 60),
+				"scope": "read",
+			})
+
+			tokenRequest := &model.TokenRequest{
+				GrantType:        string(providers.GrantTypeTokenExchange),
+				ClientID:         testClientID,
+				SubjectToken:     subjectToken,
+				SubjectTokenType: string(tc.subjectTokenType),
+			}
+
+			suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
+				Return(&tokenservice.SubjectTokenClaims{
+					Sub:    testUserID,
+					Iss:    testCustomIssuer,
+					Scopes: []string{"read"},
+				}, nil)
+			suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).
+				Return(&model.TokenDTO{
+					Token:     testTokenExchangeJWT,
+					TokenType: constants.TokenTypeBearer,
+					IssuedAt:  now,
+					ExpiresIn: 7200,
+					Scopes:    []string{"read"},
+					ClientID:  testClientID,
+				}, nil)
+
+			result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+			assert.Nil(suite.T(), errResp)
+			assert.NotNil(suite.T(), result)
+		})
+	}
+}
+
+// The RFC 9068 access-token typ enforcement applies to the actor_token as well: an id_token (typ
+// "JWT") presented as actor_token_type=access_token is rejected.
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_ActorTokenIDTokenAsAccessTokenRejected() {
+	now := time.Now().Unix()
+	subjectToken := suite.createTestJWT(map[string]interface{}{
+		"sub": "user123", "iss": testCustomIssuer,
+		"exp": float64(now + 3600), "nbf": float64(now - 60), "scope": "read",
+	})
+	// Actor token is an id token (typ "JWT") but declared as an access token.
+	actorToken := suite.createTestJWTWithTyp("JWT", map[string]interface{}{
+		"sub": "svc123", "iss": testCustomIssuer,
+		"exp": float64(now + 3600), "nbf": float64(now - 60),
+	})
+
+	tokenRequest := suite.createBasicTokenRequest(subjectToken)
+	tokenRequest.ActorToken = actorToken
+	tokenRequest.ActorTokenType = string(constants.TokenTypeIdentifierAccessToken)
+
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub: testUserID, Iss: testCustomIssuer, Scopes: []string{"read"},
+		}, nil).Maybe()
+	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, actorToken, suite.oauthApp).
+		Return(&tokenservice.SubjectTokenClaims{
+			Sub: "svc123", Iss: testCustomIssuer,
+		}, nil).Maybe()
+
+	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), errResp)
+	assert.Equal(suite.T(), constants.ErrorInvalidRequest, errResp.Error)
+	assert.Contains(suite.T(), errResp.ErrorDescription, "actor_token")
+	assert.Contains(suite.T(), errResp.ErrorDescription, "at+jwt")
 }
 
 func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_ScopeEscalationPrevention() {

--- a/backend/internal/system/jose/jwt/constants.go
+++ b/backend/internal/system/jose/jwt/constants.go
@@ -25,6 +25,10 @@ const (
 	// TokenTypeAccessToken is the JWT type header value for access tokens as defined in RFC 9068.
 	TokenTypeAccessToken = "at+jwt"
 
+	// TokenTypeAccessTokenWithPrefix is the media-type form of the access token typ header. RFC 9068
+	// requires validators to accept both this and TokenTypeAccessToken.
+	TokenTypeAccessTokenWithPrefix = "application/at+jwt"
+
 	// TokenTypeIDJAG is the JWT type header value for an Identity Assertion Authorization Grant
 	// (draft-ietf-oauth-identity-assertion-authz-grant).
 	TokenTypeIDJAG = "oauth-id-jag+jwt" //nolint:gosec // JWT typ header value, not a credential


### PR DESCRIPTION
### Purpose
The token exchange grant accepted any JWT presented as `subject_token_type` (or `actor_token_type`) `=access_token`, so an id_token could be exchanged as an access token. This enforces the RFC 9068 `at+jwt` typ header for tokens declared as access tokens.

Fixes #3835 (token typ validation item)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Enforced RFC 9068 compliance for token exchange requests that use access tokens.
  * When exchanging an access token, the JWT `typ` header is now validated to match the expected `at+jwt` media-type form.
  * Token exchange requests are rejected when the required `typ` is invalid or missing for both subject and actor tokens.
  * Support remains for plain JWT exchanges that do not apply `typ` constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->