### PR TITLE
Disable PAR for non-authorization code grant types in console

### DIFF
--- a/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/SecuritySection.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/SecuritySection.tsx
@@ -86,8 +86,10 @@ export default function SecuritySection({
           <FormControlLabel
             control={
               <Switch
-                checked={oauth2Config.requirePushedAuthorizationRequests ?? false}
-                disabled={!isEditable}
+                checked={
+                  flags.isParDisabledByGrants ? false : (oauth2Config.requirePushedAuthorizationRequests ?? false)
+                }
+                disabled={!isEditable || flags.isParDisabledByGrants}
                 onChange={(e) => onOAuth2ConfigChange?.({requirePushedAuthorizationRequests: e.target.checked})}
                 inputProps={{
                   'aria-label': t('agents:edit.advanced.security.par.label', 'Require Pushed Authorization Requests'),
@@ -101,9 +103,17 @@ export default function SecuritySection({
             }
           />
           <Typography variant="caption" color="text.secondary" sx={{display: 'block', ml: '52px'}}>
-            {t(
-              'agents:edit.advanced.security.par.hint',
-              'Require this agent to push its authorization request to the PAR endpoint before redirecting a user to sign in.',
+            {flags.isParDisabledByGrants ? (
+              <Trans
+                i18nKey="agents:edit.advanced.security.par.notApplicable"
+                defaults="Pushed Authorization Requests only apply to the <code>authorization_code</code> grant. Turn that on to enable this setting."
+                components={codeComponents}
+              />
+            ) : (
+              t(
+                'agents:edit.advanced.security.par.hint',
+                'Require this agent to push its authorization request to the PAR endpoint before redirecting a user to sign in.',
+              )
             )}
           </Typography>
         </Box>

--- a/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/__tests__/SecuritySection.test.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/__tests__/SecuritySection.test.tsx
@@ -85,7 +85,7 @@ describe('SecuritySection (agent)', () => {
 
     render(<SecuritySection oauth2Config={oauth2Config} />);
 
-    expect(screen.getByText(/authorization_code/)).toBeInTheDocument();
+    expect(screen.getByText(/PKCE only applies to the/)).toBeInTheDocument();
     const pkceSwitch = screen.getByLabelText('agents:edit.advanced.security.pkce.label');
     expect(pkceSwitch).toBeDisabled();
   });
@@ -130,6 +130,23 @@ describe('SecuritySection (agent)', () => {
       render(<SecuritySection oauth2Config={oauth2Config} />);
 
       expect(screen.getByLabelText('agents:edit.advanced.security.par.label')).toBeDisabled();
+    });
+
+    it('is disabled and unchecked when the authorization_code grant is off', () => {
+      render(
+        <SecuritySection
+          oauth2Config={{
+            grantTypes: ['client_credentials'],
+            responseTypes: [],
+            requirePushedAuthorizationRequests: true,
+          }}
+          onOAuth2ConfigChange={vi.fn()}
+        />,
+      );
+
+      const parSwitch = screen.getByLabelText('agents:edit.advanced.security.par.label');
+      expect(parSwitch).toBeDisabled();
+      expect(parSwitch).not.toBeChecked();
     });
   });
 });

--- a/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/OAuth2ConfigSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/OAuth2ConfigSection.tsx
@@ -180,6 +180,7 @@ export default function OAuth2ConfigSection({
     isPkceDisabledByGrants,
     isPkceForcedByPublicClient,
     isPublicClientDisabledByGrants,
+    isParDisabledByGrants,
   } = flags;
 
   return (
@@ -428,8 +429,8 @@ export default function OAuth2ConfigSection({
           <FormControlLabel
             control={
               <Switch
-                checked={oauth2Config.requirePushedAuthorizationRequests ?? false}
-                disabled={!isEditable || isParLocked}
+                checked={isParDisabledByGrants ? false : (oauth2Config.requirePushedAuthorizationRequests ?? false)}
+                disabled={!isEditable || isParLocked || isParDisabledByGrants}
                 onChange={(e) => onOAuth2ConfigChange?.({requirePushedAuthorizationRequests: e.target.checked})}
                 inputProps={{
                   'aria-label': t(
@@ -453,10 +454,15 @@ export default function OAuth2ConfigSection({
             }
           />
           <Typography variant="caption" color="text.secondary" sx={{display: 'block', ml: '52px'}}>
-            {t(
-              'applications:edit.advanced.par.hint',
-              'Require the client to use the PAR endpoint before authorization.',
-            )}
+            {isParDisabledByGrants
+              ? t(
+                  'applications:edit.advanced.par.requiresAuthorizationCode',
+                  'Available only when the authorization code grant is enabled.',
+                )
+              : t(
+                  'applications:edit.advanced.par.hint',
+                  'Require the client to use the PAR endpoint before authorization.',
+                )}
           </Typography>
         </Box>
       </Stack>

--- a/frontend/apps/console/src/features/applications/utils/__tests__/oauth2Rules.test.ts
+++ b/frontend/apps/console/src/features/applications/utils/__tests__/oauth2Rules.test.ts
@@ -35,6 +35,15 @@ describe('deriveOAuth2Flags', () => {
     expect(flags.isPublicClientDisabledByGrants).toBe(true);
   });
 
+  it('disables PAR when authorization_code is absent', () => {
+    expect(deriveOAuth2Flags(baseConfig({grantTypes: [OAuth2GrantTypes.TOKEN_EXCHANGE]})).isParDisabledByGrants).toBe(
+      true,
+    );
+    expect(
+      deriveOAuth2Flags(baseConfig({grantTypes: [OAuth2GrantTypes.AUTHORIZATION_CODE]})).isParDisabledByGrants,
+    ).toBe(false);
+  });
+
   it('disables public client when client_credentials is present', () => {
     const flags = deriveOAuth2Flags(
       baseConfig({
@@ -86,6 +95,28 @@ describe('applyGrantTypesChange', () => {
       [OAuth2GrantTypes.CLIENT_CREDENTIALS],
     );
     expect(updates.pkceRequired).toBe(false);
+  });
+
+  it('turns off PAR when authorization_code is removed', () => {
+    const updates = applyGrantTypesChange(
+      baseConfig({
+        grantTypes: [OAuth2GrantTypes.AUTHORIZATION_CODE],
+        requirePushedAuthorizationRequests: true,
+      }),
+      [OAuth2GrantTypes.TOKEN_EXCHANGE],
+    );
+    expect(updates.requirePushedAuthorizationRequests).toBe(false);
+  });
+
+  it('keeps PAR when authorization_code remains', () => {
+    const updates = applyGrantTypesChange(
+      baseConfig({
+        grantTypes: [OAuth2GrantTypes.AUTHORIZATION_CODE],
+        requirePushedAuthorizationRequests: true,
+      }),
+      [OAuth2GrantTypes.AUTHORIZATION_CODE, OAuth2GrantTypes.TOKEN_EXCHANGE],
+    );
+    expect(updates.requirePushedAuthorizationRequests).toBeUndefined();
   });
 
   it('turns off public client and reverts token method when grants become invalid', () => {

--- a/frontend/apps/console/src/features/applications/utils/oauth2Rules.ts
+++ b/frontend/apps/console/src/features/applications/utils/oauth2Rules.ts
@@ -19,6 +19,7 @@ export interface OAuth2Flags {
   isPkceDisabledByGrants: boolean;
   isPkceForcedByPublicClient: boolean;
   isPublicClientDisabledByGrants: boolean;
+  isParDisabledByGrants: boolean;
 }
 
 /**
@@ -37,6 +38,9 @@ export function deriveOAuth2Flags(config: OAuth2Config): OAuth2Flags {
     isPkceDisabledByGrants: !hasAuthorizationCodeGrant,
     isPkceForcedByPublicClient: isPublicClient,
     isPublicClientDisabledByGrants: hasClientCredentialsGrant || !hasAuthorizationCodeGrant,
+    // PAR is an authorization-endpoint feature, so it only applies when the authorization code grant
+    // is present (e.g. it has no effect on the token exchange or client credentials grants).
+    isParDisabledByGrants: !hasAuthorizationCodeGrant,
   };
 }
 
@@ -76,6 +80,7 @@ function hasTokenIssuingGrant(grants: string[]): boolean {
  * Enforces cross-field invariants:
  * - refresh_token requires a token-issuing grant (authorization_code or ciba)
  * - PKCE requires authorization_code
+ * - PAR (requirePushedAuthorizationRequests) requires authorization_code
  * - public client is incompatible with client_credentials and requires authorization_code
  * - response type 'code' is added/removed alongside the authorization_code grant
  */
@@ -92,6 +97,10 @@ export function applyGrantTypesChange(current: OAuth2Config, selected: string[])
 
   if (current.pkceRequired && !nextHasAuthzCode) {
     updates.pkceRequired = false;
+  }
+
+  if (current.requirePushedAuthorizationRequests && !nextHasAuthzCode) {
+    updates.requirePushedAuthorizationRequests = false;
   }
 
   if (current.publicClient && (nextHasCC || !nextHasAuthzCode)) {

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1210,6 +1210,8 @@ const translations = {
     'edit.advanced.security.par.label': 'Require Pushed Authorization Requests',
     'edit.advanced.security.par.hint':
       'Require this agent to push its authorization request to the PAR endpoint before redirecting a user to sign in.',
+    'edit.advanced.security.par.notApplicable':
+      'Pushed Authorization Requests only apply to the <code>authorization_code</code> grant. Turn that on to enable this setting.',
 
     // Edit page - Tokens tab
     'edit.tokens.tabs.user': 'User',
@@ -2788,6 +2790,7 @@ const translations = {
     'edit.advanced.labels.pkceRequired': 'PKCE Required',
     'edit.advanced.labels.requirePAR': 'Require Pushed Authorization Requests',
     'edit.advanced.par.hint': 'Require the client to use the PAR endpoint before authorization.',
+    'edit.advanced.par.requiresAuthorizationCode': 'Available only when the authorization code grant is enabled.',
     'edit.advanced.labels.tokenEndpointAuthMethod': 'Client Authentication Method',
     'edit.advanced.labels.certificate': 'Certificate',
     'edit.advanced.labels.certificateType': 'Certificate Type',


### PR DESCRIPTION
### Purpose

Pushed Authorization Requests (PAR) is an authorization-endpoint feature, so it has no effect on grants that never hit `/authorize` (token exchange, client credentials). The console let PAR be enabled regardless of the selected grant types, which was misleading, for example on a token exchange only application or a default (client credentials) agent.

This disables the PAR toggle and clears any stored value when the `authorization_code` grant is not selected, for both applications and agents.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3835

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pushed Authorization Requests (PAR) settings now automatically reflect the selected OAuth grants.
  * PAR is disabled and turned off when the `authorization_code` grant is unavailable.
  * Added guidance explaining that PAR requires the `authorization_code` grant.

* **Bug Fixes**
  * Prevented unsupported PAR configurations when authorization code support is removed.

* **Tests**
  * Added coverage for PAR availability, clearing, and preservation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->