### PR TITLE
Conformance Bug Fix : Token endpoint returns invalid_request (should be invalid_grant)

### DIFF
--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
@@ -254,7 +254,7 @@ func (h *authorizationCodeGrantHandler) retrieveAndValidateAuthCode(
 	if oauthApp.RequiresPKCE() || authCode.CodeChallenge != "" {
 		if tokenRequest.CodeVerifier == "" {
 			return nil, &model.ErrorResponse{
-				Error:            constants.ErrorInvalidRequest,
+				Error:            constants.ErrorInvalidGrant,
 				ErrorDescription: "code_verifier is required",
 			}
 		}

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
@@ -1275,7 +1275,7 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) TestRetrieveAndValidateAuth
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
-	assert.Equal(suite.T(), constants.ErrorInvalidRequest, err.Error)
+	assert.Equal(suite.T(), constants.ErrorInvalidGrant, err.Error)
 	assert.Contains(suite.T(), err.ErrorDescription, "code_verifier is required")
 
 	suite.mockAuthzService.AssertExpectations(suite.T())


### PR DESCRIPTION
### Purpose
for testcase - fapi2-security-profile-final-ensure-pkce-code-verifier-required

When a client exchanges an authorization code that was bound to a PKCE code_challenge but omits the code_verifier parameter, ThunderID's token endpoint returns error: "invalid_request". RFC 7636 §4.6 and the FAPI 2.0 profile require error: "invalid_grant" in this case. The endpoint does reject the request, but with the wrong error code.

issue desc on esignet - https://github.com/mosip/esignet/issues/2259
issue desc on thunderid - https://github.com/thunder-id/thunderid/issues/4454
<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--


---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach

Change of error code from invalid_request to invalid_grant

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the error returned when a required PKCE code verifier is missing during authorization-code token requests.
  * Preserved the existing error description and validation behavior for other PKCE scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->