### PR TITLE
Show specific reasons for group update and create errors

### DIFF
--- a/api/group.yaml
+++ b/api/group.yaml
@@ -416,16 +416,6 @@ paths:
                     description:
                       key: "error.groupservice.missing_group_id_description"
                       defaultValue: "Group ID is required"
-                cannot-delete-group:
-                  summary: Cannot delete group
-                  value:
-                    code: "GRP-1006"
-                    message:
-                      key: "error.groupservice.cannot_delete_group"
-                      defaultValue: "Cannot delete group"
-                    description:
-                      key: "error.groupservice.cannot_delete_group_description"
-                      defaultValue: "Cannot delete group with child groups"
         "404":
           description: Group not found
           content:

--- a/backend/internal/group/error_constants.go
+++ b/backend/internal/group/error_constants.go
@@ -91,19 +91,6 @@ var (
 			DefaultValue: "Organization unit does not exists",
 		},
 	}
-	// ErrorCannotDeleteGroup is the error returned when group cannot be deleted.
-	ErrorCannotDeleteGroup = tidcommon.ServiceError{
-		Type: tidcommon.ClientErrorType,
-		Code: "GRP-1006",
-		Error: tidcommon.I18nMessage{
-			Key:          "error.groupservice.cannot_delete_group",
-			DefaultValue: "Cannot delete group",
-		},
-		ErrorDescription: tidcommon.I18nMessage{
-			Key:          "error.groupservice.cannot_delete_group_description",
-			DefaultValue: "Cannot delete group with child groups",
-		},
-	}
 	// ErrorInvalidMemberID is the error returned when a user or app member ID is invalid.
 	ErrorInvalidMemberID = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,

--- a/backend/internal/group/handler.go
+++ b/backend/internal/group/handler.go
@@ -415,7 +415,7 @@ func (gh *groupHandler) handleError(ctx context.Context, w http.ResponseWriter, 
 			statusCode = http.StatusNotFound
 		case ErrorGroupNameConflict.Code:
 			statusCode = http.StatusConflict
-		case ErrorInvalidOUID.Code, ErrorCannotDeleteGroup.Code,
+		case ErrorInvalidOUID.Code,
 			ErrorInvalidRequestFormat.Code, ErrorMissingGroupID.Code,
 			ErrorInvalidLimit.Code, ErrorInvalidOffset.Code,
 			ErrorEmptyMembers.Code, ErrorInvalidMemberType.Code,

--- a/backend/internal/group/handler_test.go
+++ b/backend/internal/group/handler_test.go
@@ -1173,25 +1173,6 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupDeleteRequest() 
 			},
 		},
 		{
-			name:           "conflict",
-			method:         http.MethodDelete,
-			url:            "/groups/grp-001",
-			pathParamKey:   "id",
-			pathParamValue: "grp-001",
-			setup: func(serviceMock *GroupServiceInterfaceMock) {
-				serviceMock.
-					On("DeleteGroup", mock.Anything, "grp-001").
-					Return(&ErrorCannotDeleteGroup).
-					Once()
-			},
-			assert: func(rr *httptest.ResponseRecorder) {
-				require.Equal(suite.T(), http.StatusBadRequest, rr.Code)
-				var body apierror.ErrorResponse
-				require.NoError(suite.T(), json.Unmarshal(rr.Body.Bytes(), &body))
-				require.Equal(suite.T(), ErrorCannotDeleteGroup.Code, body.Code)
-			},
-		},
-		{
 			name:           "internal error",
 			method:         http.MethodDelete,
 			url:            "/groups/grp-001",

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -692,8 +692,6 @@ var defaultMessages = map[string]string{
 	"error.flowmgtservice.unsupported_executor_property_description": "Node '{{param(nodeID)}}': executor '{{param(executorName)}}' does not support property '{{param(propertyKey)}}'",
 	"error.groupservice.cannot_create_group_in_declarative_only_mode": "Cannot create group in declarative-only mode",
 	"error.groupservice.cannot_create_group_in_declarative_only_mode_description": "Group creation is not allowed when running in declarative-only mode. Groups must be defined in declarative configuration files",
-	"error.groupservice.cannot_delete_group": "Cannot delete group",
-	"error.groupservice.cannot_delete_group_description": "Cannot delete group with child groups",
 	"error.groupservice.cannot_modify_declarative_group": "Cannot modify declarative group",
 	"error.groupservice.cannot_modify_declarative_group_description": "The group is defined in declarative configuration and cannot be modified",
 	"error.groupservice.create_group_by_path_request_parse_failed_description": "Failed to parse request body: {{param(error)}}",

--- a/frontend/apps/console/src/features/groups/api/useAddGroupMembers.ts
+++ b/frontend/apps/console/src/features/groups/api/useAddGroupMembers.ts
@@ -67,8 +67,5 @@ export default function useAddGroupMembers(): UseMutationResult<void, Error, Add
       });
       showToast(t('addMember.success'), 'success');
     },
-    onError: () => {
-      showToast(t('addMember.error'), 'error');
-    },
   });
 }

--- a/frontend/apps/console/src/features/groups/api/useCreateGroup.ts
+++ b/frontend/apps/console/src/features/groups/api/useCreateGroup.ts
@@ -58,8 +58,5 @@ export default function useCreateGroup(): UseMutationResult<Group, Error, Create
       });
       showToast(t('create.success'), 'success');
     },
-    onError: () => {
-      showToast(t('create.error'), 'error');
-    },
   });
 }

--- a/frontend/apps/console/src/features/groups/api/useDeleteGroup.ts
+++ b/frontend/apps/console/src/features/groups/api/useDeleteGroup.ts
@@ -49,8 +49,5 @@ export default function useDeleteGroup(): UseMutationResult<void, Error, string>
       });
       showToast(t('delete.success'), 'success');
     },
-    onError: () => {
-      showToast(t('delete.error'), 'error');
-    },
   });
 }

--- a/frontend/apps/console/src/features/groups/api/useRemoveGroupMembers.ts
+++ b/frontend/apps/console/src/features/groups/api/useRemoveGroupMembers.ts
@@ -67,8 +67,5 @@ export default function useRemoveGroupMembers(): UseMutationResult<void, Error, 
       });
       showToast(t('removeMember.success'), 'success');
     },
-    onError: () => {
-      showToast(t('removeMember.error'), 'error');
-    },
   });
 }

--- a/frontend/apps/console/src/features/groups/api/useUpdateGroup.ts
+++ b/frontend/apps/console/src/features/groups/api/useUpdateGroup.ts
@@ -72,8 +72,5 @@ export default function useUpdateGroup(): UseMutationResult<Group, Error, Update
       });
       showToast(t('update.success'), 'success');
     },
-    onError: () => {
-      showToast(t('update.error'), 'error');
-    },
   });
 }

--- a/frontend/apps/console/src/features/groups/components/GroupDeleteDialog.tsx
+++ b/frontend/apps/console/src/features/groups/components/GroupDeleteDialog.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import {getErrorMessage} from '@thunderid/utils';
 import {Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button, Alert} from '@wso2/oxygen-ui';
 import {useState, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
@@ -37,7 +38,7 @@ export default function GroupDeleteDialog({
   onClose,
   onSuccess = undefined,
 }: GroupDeleteDialogProps): JSX.Element {
-  const {t} = useTranslation();
+  const {t} = useTranslation('groups');
   const deleteGroup = useDeleteGroup();
   const [error, setError] = useState<string | null>(null);
 
@@ -58,18 +59,20 @@ export default function GroupDeleteDialog({
         onSuccess?.();
       },
       onError: (err: Error) => {
-        setError(err.message ?? t('groups:delete.error'));
+        setError(getErrorMessage(err, t, 'delete.error'));
       },
     });
   };
 
   return (
     <Dialog open={open} onClose={handleCancel} maxWidth="sm" fullWidth>
-      <DialogTitle>{t('groups:delete.title')}</DialogTitle>
+      <DialogTitle>{t('delete.title', 'Delete Group')}</DialogTitle>
       <DialogContent>
-        <DialogContentText sx={{mb: 2}}>{t('groups:delete.message')}</DialogContentText>
+        <DialogContentText sx={{mb: 2}}>
+          {t('delete.message', 'Are you sure you want to delete this group?')}
+        </DialogContentText>
         <Alert severity="warning" sx={{mb: 2}}>
-          {t('groups:delete.disclaimer')}
+          {t('delete.disclaimer', 'This action cannot be undone. All group associations will be permanently removed.')}
         </Alert>
         {error && (
           <Alert severity="error" sx={{mt: 2}}>

--- a/frontend/apps/console/src/features/groups/components/__tests__/EditMembersSettings.test.tsx
+++ b/frontend/apps/console/src/features/groups/components/__tests__/EditMembersSettings.test.tsx
@@ -181,7 +181,31 @@ describe('EditMembersSettings', () => {
     await user.click(screen.getByText('Add'));
 
     await waitFor(() => {
-      expect(screen.getByText('Add failed')).toBeInTheDocument();
+      expect(screen.getByText('Failed to add member. Please try again.')).toBeInTheDocument();
+    });
+  });
+
+  it('should show mapped error message when a selected member no longer exists', async () => {
+    mockAddMutate.mockImplementation((_data: unknown, opts: {onError: (err: Error) => void}) => {
+      const error = new Error('Request failed') as Error & {response?: {data?: {code: string}}};
+      error.response = {data: {code: 'GRP-1007'}};
+      opts.onError(error);
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<EditMembersSettings group={mockGroup} />);
+
+    await user.click(screen.getByText('Add Member'));
+    await waitFor(() => {
+      expect(screen.getByTestId('add-member-dialog')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText('Add'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('One or more selected members no longer exist. Refresh and try again.'),
+      ).toBeInTheDocument();
     });
   });
 
@@ -212,7 +236,7 @@ describe('EditMembersSettings', () => {
     });
     await user.click(screen.getByText('Add'));
     await waitFor(() => {
-      expect(screen.getByText('Some error')).toBeInTheDocument();
+      expect(screen.getByText('Failed to add member. Please try again.')).toBeInTheDocument();
     });
 
     // Now trigger successful remove which should clear the error
@@ -223,7 +247,7 @@ describe('EditMembersSettings', () => {
     await user.click(screen.getByTestId('remove-member-btn'));
 
     await waitFor(() => {
-      expect(screen.queryByText('Some error')).not.toBeInTheDocument();
+      expect(screen.queryByText('Failed to add member. Please try again.')).not.toBeInTheDocument();
     });
   });
 
@@ -238,7 +262,7 @@ describe('EditMembersSettings', () => {
     await user.click(screen.getByTestId('remove-member-btn'));
 
     await waitFor(() => {
-      expect(screen.getByText('Remove failed')).toBeInTheDocument();
+      expect(screen.getByText('Failed to remove member. Please try again.')).toBeInTheDocument();
     });
   });
 
@@ -252,14 +276,14 @@ describe('EditMembersSettings', () => {
 
     await user.click(screen.getByTestId('remove-member-btn'));
     await waitFor(() => {
-      expect(screen.getByText('Remove failed')).toBeInTheDocument();
+      expect(screen.getByText('Failed to remove member. Please try again.')).toBeInTheDocument();
     });
 
     const closeAlertButton = screen.getByRole('button', {name: /close/i});
     await user.click(closeAlertButton);
 
     await waitFor(() => {
-      expect(screen.queryByText('Remove failed')).not.toBeInTheDocument();
+      expect(screen.queryByText('Failed to remove member. Please try again.')).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/apps/console/src/features/groups/components/__tests__/GroupDeleteDialog.test.tsx
+++ b/frontend/apps/console/src/features/groups/components/__tests__/GroupDeleteDialog.test.tsx
@@ -108,7 +108,26 @@ describe('GroupDeleteDialog', () => {
     await user.click(screen.getByText('Delete'));
 
     await waitFor(() => {
-      expect(screen.getByText('Delete failed')).toBeInTheDocument();
+      expect(screen.getByText('Failed to delete group. Please try again.')).toBeInTheDocument();
+    });
+  });
+
+  it('should display mapped error message for a declarative group', async () => {
+    mockMutate.mockImplementation((_id: string, opts: {onError: (err: Error) => void}) => {
+      const error = new Error('Request failed') as Error & {response?: {data?: {code: string}}};
+      error.response = {data: {code: 'GRP-1015'}};
+      opts.onError(error);
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<GroupDeleteDialog {...defaultProps} />);
+
+    await user.click(screen.getByText('Delete'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('This group is managed declaratively and cannot be edited or deleted.'),
+      ).toBeInTheDocument();
     });
   });
 

--- a/frontend/apps/console/src/features/groups/components/edit-group/members-settings/EditMembersSettings.tsx
+++ b/frontend/apps/console/src/features/groups/components/edit-group/members-settings/EditMembersSettings.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import {getErrorMessage} from '@thunderid/utils';
 import {Stack, Button, Alert} from '@wso2/oxygen-ui';
 import {Plus} from '@wso2/oxygen-ui-icons-react';
 import {useState, useCallback, type JSX} from 'react';
@@ -35,7 +36,7 @@ interface EditMembersSettingsProps {
  * Provides member listing, add, and remove functionality.
  */
 export default function EditMembersSettings({group}: EditMembersSettingsProps): JSX.Element {
-  const {t} = useTranslation();
+  const {t} = useTranslation('groups');
   const addGroupMembers = useAddGroupMembers();
   const removeGroupMembers = useRemoveGroupMembers();
   const [addDialogOpen, setAddDialogOpen] = useState(false);
@@ -54,7 +55,7 @@ export default function EditMembersSettings({group}: EditMembersSettingsProps): 
             setError(null);
           },
           onError: (err: Error) => {
-            setError(err.message ?? t('groups:addMember.error'));
+            setError(getErrorMessage(err, t, 'addMember.error'));
           },
         },
       );
@@ -74,7 +75,7 @@ export default function EditMembersSettings({group}: EditMembersSettingsProps): 
             setError(null);
           },
           onError: (err: Error) => {
-            setError(err.message ?? t('groups:removeMember.error'));
+            setError(getErrorMessage(err, t, 'removeMember.error'));
           },
         },
       );
@@ -102,7 +103,7 @@ export default function EditMembersSettings({group}: EditMembersSettingsProps): 
               startIcon={<Plus size={16} />}
               onClick={() => setAddDialogOpen(true)}
             >
-              {t('groups:edit.members.sections.manage.addMember')}
+              {t('edit.members.sections.manage.addMember', 'Add Member')}
             </Button>
           ) : undefined
         }

--- a/frontend/apps/console/src/features/groups/pages/CreateGroupPage.tsx
+++ b/frontend/apps/console/src/features/groups/pages/CreateGroupPage.tsx
@@ -18,6 +18,7 @@
 
 import {useHasMultipleOUs} from '@thunderid/configure-organization-units';
 import {useLogger} from '@thunderid/logger/react';
+import {getErrorMessage} from '@thunderid/utils';
 import {
   Box,
   Stack,
@@ -43,7 +44,7 @@ import type {CreateGroupRequest} from '../models/requests';
 
 export default function CreateGroupPage(): JSX.Element {
   const navigate = useNavigate();
-  const {t} = useTranslation();
+  const {t} = useTranslation('groups');
   const logger = useLogger('CreateGroupPage');
   const createGroup = useCreateGroup();
 
@@ -69,10 +70,10 @@ export default function CreateGroupPage(): JSX.Element {
 
   const steps: Partial<Record<GroupCreateFlowStep, {label: string}>> = useMemo(() => {
     const map: Partial<Record<GroupCreateFlowStep, {label: string}>> = {
-      NAME: {label: t('groups:createWizard.steps.name')},
+      NAME: {label: t('createWizard.steps.name', 'Create a Group')},
     };
     if (hasMultipleOUs) {
-      map.ORGANIZATION_UNIT = {label: t('groups:createWizard.steps.organizationUnit')};
+      map.ORGANIZATION_UNIT = {label: t('createWizard.steps.organizationUnit', 'Organization Unit')};
     }
     return map;
   }, [t, hasMultipleOUs]);
@@ -110,7 +111,7 @@ export default function CreateGroupPage(): JSX.Element {
     setError(null);
 
     if (!name.trim()) {
-      setValidationError(t('groups:create.form.name.required'));
+      setValidationError(t('create.form.name.required', 'Group name is required'));
       setSnackbarOpen(true);
       return;
     }
@@ -118,7 +119,7 @@ export default function CreateGroupPage(): JSX.Element {
     // If only one OU, use it directly
     const selectedOuId = hasMultipleOUs ? ouId : ouList[0]?.id;
     if (!selectedOuId) {
-      setValidationError(t('groups:create.form.organizationUnit.required'));
+      setValidationError(t('create.form.organizationUnit.required', 'Organization unit is required'));
       setSnackbarOpen(true);
       return;
     }
@@ -267,7 +268,7 @@ export default function CreateGroupPage(): JSX.Element {
                 {createGroup.error && (
                   <Alert severity="error" sx={{mb: 3}}>
                     <Typography variant="body2" sx={{fontWeight: 'bold', mb: 0.5}}>
-                      {createGroup.error.message}
+                      {getErrorMessage(createGroup.error, t, 'create.error')}
                     </Typography>
                   </Alert>
                 )}

--- a/frontend/apps/console/src/features/groups/pages/GroupEditPage.tsx
+++ b/frontend/apps/console/src/features/groups/pages/GroupEditPage.tsx
@@ -19,7 +19,7 @@
 import {PageLoadingAnimation} from '@thunderid/components';
 import {useToast} from '@thunderid/contexts';
 import {useLogger} from '@thunderid/logger/react';
-import {isEqualIgnoringEmpty} from '@thunderid/utils';
+import {getErrorMessage, isEqualIgnoringEmpty} from '@thunderid/utils';
 import {
   Box,
   Stack,
@@ -69,7 +69,7 @@ function TabPanel({children = null, value, index, ...other}: TabPanelProps): JSX
 export default function GroupEditPage(): JSX.Element {
   const {groupId} = useParams<{groupId: string}>();
   const navigate = useNavigate();
-  const {t} = useTranslation();
+  const {t} = useTranslation('groups');
   const logger = useLogger('GroupEditPage');
   const {showToast} = useToast();
 
@@ -115,8 +115,8 @@ export default function GroupEditPage(): JSX.Element {
       await refetch();
     } catch (err: unknown) {
       logger.error('Failed to update group', {error: err});
-      const message = err instanceof Error ? err.message : t('groups:edit.page.saveError');
-      showToast(message, 'error');
+      const error = err instanceof Error ? err : new Error(String(err));
+      showToast(getErrorMessage(error, t, 'update.error'), 'error');
     }
   }, [group, groupId, editedGroup, updateGroup, refetch, logger, showToast, t]);
 
@@ -146,7 +146,7 @@ export default function GroupEditPage(): JSX.Element {
     return (
       <PageContent>
         <Alert severity="error" sx={{mb: 2}}>
-          {fetchError.message ?? t('groups:edit.page.error')}
+          {fetchError.message ?? t('edit.page.error', 'Failed to load group')}
         </Alert>
         <Button
           onClick={() => {
@@ -156,7 +156,7 @@ export default function GroupEditPage(): JSX.Element {
           }}
           startIcon={<ArrowLeft size={16} />}
         >
-          {t('groups:edit.page.back')}
+          {t('edit.page.back', 'Back to Groups')}
         </Button>
       </PageContent>
     );
@@ -166,7 +166,7 @@ export default function GroupEditPage(): JSX.Element {
     return (
       <PageContent>
         <Alert severity="warning" sx={{mb: 2}}>
-          {t('groups:edit.page.notFound')}
+          {t('edit.page.notFound', 'Group not found')}
         </Alert>
         <Button
           onClick={() => {
@@ -176,7 +176,7 @@ export default function GroupEditPage(): JSX.Element {
           }}
           startIcon={<ArrowLeft size={16} />}
         >
-          {t('groups:edit.page.back')}
+          {t('edit.page.back', 'Back to Groups')}
         </Button>
       </PageContent>
     );
@@ -191,7 +191,9 @@ export default function GroupEditPage(): JSX.Element {
       )}
       {/* Header */}
       <PageTitle>
-        <PageTitle.BackButton component={<Link to={listUrl} />}>{t('groups:edit.page.back')}</PageTitle.BackButton>
+        <PageTitle.BackButton component={<Link to={listUrl} />}>
+          {t('edit.page.back', 'Back to Groups')}
+        </PageTitle.BackButton>
         <PageTitle.Header>
           <Stack direction="row" alignItems="center" spacing={1} mb={1}>
             {isEditingName ? (
@@ -273,7 +275,7 @@ export default function GroupEditPage(): JSX.Element {
                   }
                 }}
                 size="small"
-                placeholder={t('groups:edit.page.description.placeholder')}
+                placeholder={t('edit.page.description.placeholder', 'Add a description...')}
                 sx={{
                   maxWidth: '600px',
                   '& .MuiInputBase-root': {
@@ -284,7 +286,7 @@ export default function GroupEditPage(): JSX.Element {
             ) : (
               <>
                 <Typography variant="body2" color="text.secondary">
-                  {effectiveDescription || t('groups:edit.page.description.empty')}
+                  {effectiveDescription || t('edit.page.description.empty', 'No description')}
                 </Typography>
                 {!group.isReadOnly && (
                   <IconButton
@@ -312,13 +314,13 @@ export default function GroupEditPage(): JSX.Element {
       {/* Tabs */}
       <Tabs value={activeTab} onChange={handleTabChange} aria-label="group settings tabs">
         <Tab
-          label={t('groups:edit.page.tabs.general')}
+          label={t('edit.page.tabs.general', 'General')}
           id="group-tab-0"
           aria-controls="group-tabpanel-0"
           sx={{textTransform: 'none'}}
         />
         <Tab
-          label={t('groups:edit.page.tabs.members')}
+          label={t('edit.page.tabs.members', 'Members')}
           id="group-tab-1"
           aria-controls="group-tabpanel-1"
           sx={{textTransform: 'none'}}
@@ -385,10 +387,10 @@ export default function GroupEditPage(): JSX.Element {
               >
                 !
               </Box>
-              {t('groups:edit.page.unsavedChanges')}
+              {t('edit.page.unsavedChanges', 'You have unsaved changes')}
             </Typography>
             <Button variant="outlined" color="error" onClick={() => setEditedGroup({})}>
-              {t('groups:edit.page.reset')}
+              {t('edit.page.reset', 'Reset')}
             </Button>
             <Button
               variant="contained"
@@ -397,7 +399,7 @@ export default function GroupEditPage(): JSX.Element {
               }}
               disabled={updateGroup.isPending || group.isReadOnly === true}
             >
-              {updateGroup.isPending ? t('groups:edit.page.saving') : t('groups:edit.page.save')}
+              {updateGroup.isPending ? t('edit.page.saving', 'Saving...') : t('edit.page.save', 'Save Changes')}
             </Button>
           </Stack>
         </Paper>

--- a/frontend/apps/console/src/features/groups/pages/__tests__/GroupEditPage.test.tsx
+++ b/frontend/apps/console/src/features/groups/pages/__tests__/GroupEditPage.test.tsx
@@ -544,7 +544,7 @@ describe('GroupEditPage', () => {
     await user.click(screen.getByText('Save Changes'));
 
     await waitFor(() => {
-      expect(screen.getByText('Save failed')).toBeInTheDocument();
+      expect(screen.getByText('Failed to update group. Please try again.')).toBeInTheDocument();
     });
   });
 
@@ -620,7 +620,7 @@ describe('GroupEditPage', () => {
     await user.click(screen.getByText('Save Changes'));
 
     await waitFor(() => {
-      expect(screen.getByText('Save failed')).toBeInTheDocument();
+      expect(screen.getByText('Failed to update group. Please try again.')).toBeInTheDocument();
     });
 
     // Close the snackbar via the Alert's close button
@@ -628,7 +628,36 @@ describe('GroupEditPage', () => {
     await user.click(closeButton);
 
     await waitFor(() => {
-      expect(screen.queryByText('Save failed')).not.toBeInTheDocument();
+      expect(screen.queryByText('Failed to update group. Please try again.')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should show mapped error message when the group name conflicts on save', async () => {
+    const error = new Error('Request failed') as Error & {response?: {data?: {code: string}}};
+    error.response = {data: {code: 'GRP-1004'}};
+    mockMutateAsync.mockRejectedValue(error);
+    const user = userEvent.setup();
+    renderWithProviders(<GroupEditPage />);
+
+    // Edit the name to trigger hasChanges
+    const h3Heading = screen.getAllByText('Test Group').find((el) => el.tagName === 'H3');
+    const nameEditBtn = h3Heading!.parentElement?.querySelector('button');
+    await user.click(nameEditBtn!);
+    const nameInput = screen.getByDisplayValue('Test Group');
+    await user.clear(nameInput);
+    await user.type(nameInput, 'New Name');
+    await user.keyboard('{Enter}');
+
+    await waitFor(() => {
+      expect(screen.getByText('Save Changes')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText('Save Changes'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('A group with this name already exists in this organization unit. Choose a different name.'),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1546,6 +1546,11 @@ const translations = {
     'delete.success': 'Group deleted successfully.',
     'addMember.success': 'Member added successfully.',
     'removeMember.success': 'Member removed successfully.',
+    'errors.GRP-1003': 'This group no longer exists. It may have already been deleted.',
+    'errors.GRP-1004': 'A group with this name already exists in this organization unit. Choose a different name.',
+    'errors.GRP-1007': 'One or more selected members no longer exist. Refresh and try again.',
+    'errors.GRP-1015': 'This group is managed declaratively and cannot be edited or deleted.',
+    'errors.GRP-1016': 'New groups cannot be created while the server is running in declarative-only mode.',
   },
 
   // ============================================================================


### PR DESCRIPTION
### Purpose
The groups feature was not wired to the shared error catalog at all: every mutation (create, update, delete, add/remove member) surfaced either a generic fallback string or the raw backend error message (e.g. "Request failed with status code 409"), instead of a specific, actionable message.

### Approach
Mapped the backend `GRP-*` error codes that are actually reachable through the console UI (verified against the live create/edit/delete forms, client-side validation, and the group service) to specific messages via the existing shared `getErrorMessage` util — no new mapping mechanism was introduced.

**Codes mapped** (groups i18n namespace):

| Code | Reachability | Message |
|---|---|---|
| GRP-1004 | Guaranteed on create (duplicate name); also update rename | "A group with this name already exists in this organization unit. Choose a different name." |
| GRP-1015 | Race past the `isReadOnly` client guard (update/delete/members) | "This group is managed declaratively and cannot be edited or deleted." |
| GRP-1016 | Server declarative-only mode, not client-gated (create) | "New groups cannot be created while the server is running in declarative-only mode." |
| GRP-1003 | Race: group deleted by another session (update/delete/members) | "This group no longer exists. It may have already been deleted." |
| GRP-1007 | Race: selected member entity deleted before add completes | "One or more selected members no longer exist. Refresh and try again." |

**Full decision matrix** (all `GRP-*` codes, selected and rejected, with reasoning):

| Code | Selected? | Reason |
|---|---|---|
| GRP-1004 name conflict | ✅ | Guaranteed reachable on create; also update rename. No client uniqueness check. |
| GRP-1015 immutable declarative | ✅ | Race past `isReadOnly` client guard; server re-checks on update/delete/members. |
| GRP-1016 declarative-only create | ✅ | Not client-gated; every create fails when server is declarative-only. |
| GRP-1003 not found | ✅ | Race: group deleted by another session; hits update/delete/add/remove. |
| GRP-1007 invalid member ID | ✅ | Race: selected user/app/agent deleted before add completes. |
| GRP-1005 invalid OU | ❌ | Race-only, low frequency; OU chosen from server tree picker, edit page never changes OU. |
| GRP-1001 invalid format | ❌ | Body always well-formed JSON; empty-name triggers blocked client-side. |
| GRP-1002 missing group ID | ❌ | Edit/delete/member routes always carry an id. |
| GRP-1006 cannot delete | ❌ (removed) | No live service path emits it; dead constant. Deleted in this PR. |
| GRP-1008 invalid group member ID | ❌ | Group members can't be added via the console (dialog offers only user/app/agent). |
| GRP-1011 invalid limit | ❌ | DataGrid drives pagination; always integer. |
| GRP-1012 invalid offset | ❌ | Same. |
| GRP-1013 empty members | ❌ | Add button disabled at 0 selection; remove always sends one. |
| GRP-1014 invalid member type | ❌ | UI only sends user/app/agent, all valid types. |

**Other changes:**
- Consolidated each action to a single mapped error surface. Previously several actions (update, delete, add/remove member) showed the same failure twice, once via a generic hook-level toast and once via a raw-message inline display. The hooks no longer show an error toast; the owning component (dialog/page) is now the single mapped surface.
- Refactored the four error-surfacing components (`CreateGroupPage`, `GroupDeleteDialog`, `EditMembersSettings`, `GroupEditPage`) to `useTranslation('groups')` instead of the default namespace with manual `groups:` prefixes, so `getErrorMessage` resolves against a namespace-scoped `t` directly.
- Removed the dead backend constant `ErrorCannotDeleteGroup` (GRP-1006), which no live service path in `groupService` produces, only referenced in the handler's status-code switch and a test mock. Removed its handler case, its test case, and its stale example from `api/group.yaml`. Regenerated `backend/internal/system/i18n/core/defaults.go` accordingly.

No new translation keys duplicate existing ones, the generic per-action fallback keys (`create.error`, `update.error`, etc.) already existed and remain the `getErrorMessage` fallback for unmapped codes.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4441

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved group creation, editing, deletion, and member-management error messages with clearer, user-friendly guidance.
* Added localized messages for duplicate names, missing members or groups, and declaratively managed groups.
* Updated group dialogs and member-management screens to display standardized errors.
* Clarified restrictions for groups managed declaratively, including editing and deletion.

## Documentation

* Updated API error examples and group-related translations to reflect supported error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->