### PR TITLE
Add a compact view mode to the flow builder canvas

### DIFF
--- a/frontend/apps/console/src/features/flows/components/FlowBuilder.tsx
+++ b/frontend/apps/console/src/features/flows/components/FlowBuilder.tsx
@@ -18,7 +18,7 @@
 
 import {useIdentityProviders, useSMSProviders} from '@thunderid/configure-connections';
 import {Alert, Box, Snackbar, Stack} from '@wso2/oxygen-ui';
-import type {Edge, Node} from '@xyflow/react';
+import type {Edge, Node, NodeChange} from '@xyflow/react';
 import {useEdgesState, useNodesState, useUpdateNodeInternals} from '@xyflow/react';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useTranslation} from 'react-i18next';
@@ -28,6 +28,7 @@ import '@xyflow/react/dist/style.css';
 import {EXECUTOR_TO_IDP_TYPE_MAP} from '../components/resource-property-panel/extended-properties/execution-properties/constants';
 import SsoDisableConfirmDialog from '../components/SsoDisableConfirmDialog';
 import SsoToggle from '../components/SsoToggle';
+import CompactStacksContext from '../context/CompactStacksContext';
 import useEdgeGeneration from '../hooks/useEdgeGeneration';
 import useElementAddition from '../hooks/useElementAddition';
 import useFlowHistory, {computeGraphSignature} from '../hooks/useFlowHistory';
@@ -38,6 +39,8 @@ import useNodeTypes from '../hooks/useNodeTypes';
 import useSnackbarNotifications from '../hooks/useSnackbarNotifications';
 import useSsoToggle from '../hooks/useSsoToggle';
 import useTemplateAndWidgetLoading from '../hooks/useTemplateAndWidgetLoading';
+import {hasUnpositionedNodes} from '../utils/applyAutoLayout';
+import collapseExecutorChains, {getExecutionStackHeadId} from '../utils/compactGraphTransforms';
 import {mutateComponents} from '../utils/componentMutations';
 import GradientBorderButton from '@/features/applications/components/GradientBorderButton';
 import useGetFlowBuilderResources from '@/features/flows/api/useGetFlowBuilderResources';
@@ -63,6 +66,12 @@ function FlowBuilder() {
   const {triggerAutoLayout, onRestoreFromHistory, onElementAdded} = useFlowEvents();
   const {isValid: isFlowValid, setOpenValidationPanel} = useValidationStatus();
   const updateNodeInternals = useUpdateNodeInternals();
+
+  // View-mode relayouts (the compact toggle and stack expand/collapse) move
+  // nodes without the user editing anything, which would otherwise light up the
+  // Save indicator. When the flow is clean as one starts, this flag rebases the
+  // clean baseline onto whatever the relayout settles into.
+  const [isBaselineRebasePending, setIsBaselineRebasePending] = useState<boolean>(false);
 
   // Fetch the existing flow if flowId is provided (editing an existing flow)
   const {data: existingFlowData, isLoading: isLoadingExistingFlow} = useGetFlowById(flowId);
@@ -115,8 +124,8 @@ function FlowBuilder() {
   });
 
   // Auto-assign connections for executor nodes with placeholder IDP/sender IDs
-  const {data: identityProviders} = useIdentityProviders();
-  const {data: smsProviders} = useSMSProviders();
+  const {data: identityProviders, isPending: isIdentityProvidersPending} = useIdentityProviders();
+  const {data: smsProviders, isPending: isSMSProvidersPending} = useSMSProviders();
   const hasAutoAssignedRef = useRef<boolean>(false);
 
   useEffect(() => {
@@ -243,15 +252,48 @@ function FlowBuilder() {
   const [savedSignature, setSavedSignature] = useState<string | null>(null);
   const isDirty = savedSignature !== null && settledSignature !== null && settledSignature !== savedSignature;
 
+  // Apply a pending rebase once the relayout settles (state adjustment during
+  // render rather than an effect, so no extra render pass).
+  const [settledSignatureAtLastRebaseCheck, setSettledSignatureAtLastRebaseCheck] = useState<string | null>(
+    settledSignature,
+  );
+  if (settledSignature !== settledSignatureAtLastRebaseCheck) {
+    setSettledSignatureAtLastRebaseCheck(settledSignature);
+    if (isBaselineRebasePending && settledSignature !== null) {
+      setIsBaselineRebasePending(false);
+      if (savedSignature !== null) {
+        setSavedSignature(settledSignature);
+      }
+    }
+  }
+
   const resetHistoryRef = useRef(resetHistory);
   useEffect(() => {
     resetHistoryRef.current = resetHistory;
   }, [resetHistory]);
 
+  // The graph keeps mutating on its own until the load has fully settled: the
+  // flow request resolves, the connection lookups that fill in a sole provider
+  // resolve, and the load-time auto-layout positions a flow stored without
+  // layout data. Freezing the clean baseline before all of that lands would
+  // make those app-driven changes look like edits, so the freeze waits.
+  const isLoadSettlingRef = useRef<boolean>(true);
+  useEffect(() => {
+    isLoadSettlingRef.current =
+      isLoadingExistingFlow || isIdentityProvidersPending || isSMSProvidersPending || hasUnpositionedNodes(nodes);
+  }, [isLoadingExistingFlow, isIdentityProvidersPending, isSMSProvidersPending, nodes]);
+
   const hasInteractedRef = useRef<boolean>(false);
   useEffect(() => {
     const freezeBaseline = (): void => {
-      if (hasInteractedRef.current) {
+      // A real interaction cancels any pending view-mode rebase, so an edit
+      // made while a relayout is still settling is never absorbed into the
+      // clean baseline.
+      setIsBaselineRebasePending(false);
+      if (hasInteractedRef.current || isLoadSettlingRef.current) {
+        // While the load is still settling the baseline is left unfrozen (and
+        // the flow stays clean); the next interaction after it settles takes
+        // the baseline instead.
         return;
       }
       hasInteractedRef.current = true;
@@ -301,7 +343,150 @@ function FlowBuilder() {
     showSuccess,
   });
 
-  const onNodesChange = defaultOnNodesChange;
+  // In compact mode, runs of consecutive non-branching executors are collapsed
+  // into synthetic stack nodes for display only; the underlying graph state is
+  // untouched. Measured dimensions of the synthetic nodes are kept in local
+  // state (fed by React Flow's dimension changes below): React Flow only
+  // renders edges once both endpoint nodes are measured, so dropping the
+  // dimension roundtrip would silently hide every edge touching a stack.
+  const [stackDimensions, setStackDimensions] = useState<Map<string, {height: number; width: number}>>(
+    () => new Map<string, {height: number; width: number}>(),
+  );
+
+  // Stacks the user opened into their individual chips. Reset when leaving
+  // compact mode so the next visit starts collapsed again (state adjustment
+  // during render, per the React "adjusting state when props change" pattern).
+  const [expandedStackIds, setExpandedStackIds] = useState<Set<string>>(() => new Set<string>());
+  const [prevVerboseForExpansion, setPrevVerboseForExpansion] = useState<boolean>(isVerboseMode);
+  if (prevVerboseForExpansion !== isVerboseMode) {
+    setPrevVerboseForExpansion(isVerboseMode);
+    if (isVerboseMode && expandedStackIds.size > 0) {
+      setExpandedStackIds(new Set<string>());
+    }
+    // Switching view mode relayouts the canvas; that is not a user edit.
+    if (!isDirty) {
+      setIsBaselineRebasePending(true);
+    }
+  }
+
+  const handleExpandStack = useCallback(
+    (stackId: string, memberIds: string[]) => {
+      setExpandedStackIds((current) => new Set(current).add(stackId));
+      // Fan the members out from the head position so the freshly split chips
+      // do not sit on top of each other while the auto-layout below settles.
+      setNodes((currentNodes) => {
+        const headNode = currentNodes.find((node) => node.id === memberIds[0]);
+        if (!headNode) {
+          return currentNodes;
+        }
+        const spacing = 64;
+        const positionById = new Map(
+          memberIds.map((memberId, index) => [
+            memberId,
+            {x: headNode.position.x + index * spacing, y: headNode.position.y},
+          ]),
+        );
+        return currentNodes.map((node) => {
+          const position = positionById.get(node.id);
+          return position ? {...node, position} : node;
+        });
+      });
+      // Re-run the compact auto-layout once the split chips are committed so
+      // the canvas makes room for them. Expanding is a view operation, so the
+      // relayout it causes must not mark the flow dirty.
+      if (!isDirty) {
+        setIsBaselineRebasePending(true);
+      }
+      requestAnimationFrame(() => triggerAutoLayout());
+    },
+    [setNodes, triggerAutoLayout, isDirty],
+  );
+
+  const handleCollapseStack = useCallback(
+    (stackId: string) => {
+      setExpandedStackIds((current) => {
+        const next = new Set(current);
+        next.delete(stackId);
+        return next;
+      });
+      if (!isDirty) {
+        setIsBaselineRebasePending(true);
+      }
+      requestAnimationFrame(() => triggerAutoLayout());
+    },
+    [triggerAutoLayout, isDirty],
+  );
+
+  const compactStacksContextValue = useMemo(
+    () => ({
+      collapseStack: handleCollapseStack,
+      expandStack: handleExpandStack,
+      expandedHeadIdToStackId: new Map(
+        [...expandedStackIds].map((stackId) => [getExecutionStackHeadId(stackId), stackId]),
+      ),
+    }),
+    [handleCollapseStack, handleExpandStack, expandedStackIds],
+  );
+
+  const compactGraph = useMemo(
+    () => (isVerboseMode ? null : collapseExecutorChains(nodes, edges, expandedStackIds)),
+    [nodes, edges, isVerboseMode, expandedStackIds],
+  );
+  const displayNodes = useMemo(() => {
+    if (!compactGraph) {
+      return nodes;
+    }
+    return compactGraph.nodes.map((node) => {
+      const dimensions = stackDimensions.get(node.id);
+      return dimensions ? {...node, measured: dimensions} : node;
+    });
+  }, [compactGraph, nodes, stackDimensions]);
+  const baseDisplayEdges = compactGraph?.edges ?? edges;
+
+  const stackMembersRef = useRef<Map<string, string[]>>(new Map<string, string[]>());
+  useEffect(() => {
+    stackMembersRef.current = compactGraph?.stackMembersById ?? new Map<string, string[]>();
+  }, [compactGraph]);
+
+  // Canvas changes that address a synthetic stack node are translated onto its
+  // member nodes so drags and deletions land on the real graph state.
+  const onNodesChange = useCallback(
+    (changes: NodeChange[]) => {
+      const stackMembers = stackMembersRef.current;
+      if (stackMembers.size === 0) {
+        defaultOnNodesChange(changes);
+        return;
+      }
+      const expandedChanges = changes.flatMap((change): NodeChange[] => {
+        const changeId = 'id' in change ? change.id : undefined;
+        const memberIds = changeId ? stackMembers.get(changeId) : undefined;
+        if (!memberIds) {
+          return [change];
+        }
+        if (change.type === 'position' || change.type === 'select' || change.type === 'remove') {
+          return memberIds.map((memberId) => ({...change, id: memberId}));
+        }
+        if (change.type === 'dimensions' && change.dimensions && changeId) {
+          // Synthetic nodes have no state counterpart; record their measured
+          // size locally so React Flow sees them as initialized and keeps
+          // rendering their edges.
+          const {dimensions} = change;
+          setStackDimensions((current) => {
+            const known = current.get(changeId);
+            if (known?.width === dimensions.width && known?.height === dimensions.height) {
+              return current;
+            }
+            const next = new Map(current);
+            next.set(changeId, {height: dimensions.height, width: dimensions.width});
+            return next;
+          });
+        }
+        return [];
+      });
+      defaultOnNodesChange(expandedChanges);
+    },
+    [defaultOnNodesChange],
+  );
 
   // Undo/redo keyboard shortcuts. Ignore edits inside text fields / rich text so
   // native text undo keeps working there.
@@ -393,36 +578,20 @@ function FlowBuilder() {
     );
   }, [edgeStyle, setEdges]);
 
-  // Filter nodes and edges based on verbose mode
-  const filteredNodes = useMemo(() => {
-    if (isVerboseMode) {
-      return nodes;
-    }
-    // Hide execution nodes in non-verbose mode
-    return nodes.filter((node) => node.type !== StepTypes.Execution);
-  }, [nodes, isVerboseMode]);
-
-  const filteredEdges = useMemo(() => {
-    if (isVerboseMode) {
-      return edges;
-    }
-    // Hide edges connected to execution nodes in non-verbose mode
-    const executionNodeIds = new Set(nodes.filter((node) => node.type === StepTypes.Execution).map((node) => node.id));
-    return edges.filter((edge) => !executionNodeIds.has(edge.source) && !executionNodeIds.has(edge.target));
-  }, [edges, nodes, isVerboseMode]);
-
   // While the SSO placement mode is active, spotlight the candidate join edges
   // and dim the rest (same visual language as the simulation path decoration).
+  // Edge ids survive the compact-mode rewiring, so the candidate lookup works
+  // on the display edges in both modes.
   const displayEdges = useMemo(() => {
     if (!sso.placement.active) {
-      return filteredEdges;
+      return baseDisplayEdges;
     }
     const candidateEdgeIds = new Set(sso.placement.candidateEdgeIds);
-    return filteredEdges.map((edge) => ({
+    return baseDisplayEdges.map((edge) => ({
       ...edge,
       className: candidateEdgeIds.has(edge.id) ? 'sso-placement-candidate' : 'sso-placement-dimmed',
     }));
-  }, [filteredEdges, sso.placement]);
+  }, [baseDisplayEdges, sso.placement]);
 
   const isReadOnlyFlow = Boolean(existingFlowData?.isReadOnly);
 
@@ -477,34 +646,38 @@ function FlowBuilder() {
           {t('common:messages.readOnlyResource', 'This resource is read-only and cannot be modified.')}
         </Alert>
       )}
-      <FlowCanvas
-        resources={resources}
-        nodeTypes={nodeTypes}
-        edgeTypes={edgeTypes}
-        mutateComponents={mutateComponents}
-        onTemplateLoad={handleTemplateLoad}
-        onWidgetLoad={handleWidgetLoad}
-        onStepLoad={handleStepLoad}
-        onResourceAdd={handleResourceAdd}
-        onSave={existingFlowData?.isReadOnly ? undefined : handleSave}
-        nodes={filteredNodes}
-        edges={displayEdges}
-        setNodes={setNodes}
-        setEdges={setEdges}
-        onNodesChange={onNodesChange}
-        onEdgesChange={onEdgesChange}
-        onEdgeClick={sso.handleEdgeClick}
-        flowTitle={flowName}
-        flowHandle={flowHandle}
-        onFlowTitleChange={handleFlowNameChange}
-        triggerAutoLayoutOnLoad={needsAutoLayout}
-        resourcePanelFooter={ssoToggleFooter}
-        onUndo={undo}
-        onRedo={redo}
-        canUndo={canUndo}
-        canRedo={canRedo}
-        isDirty={isDirty}
-      />
+      <CompactStacksContext.Provider value={compactStacksContextValue}>
+        <FlowCanvas
+          resources={resources}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          mutateComponents={mutateComponents}
+          onTemplateLoad={handleTemplateLoad}
+          onWidgetLoad={handleWidgetLoad}
+          onStepLoad={handleStepLoad}
+          onResourceAdd={handleResourceAdd}
+          onSave={existingFlowData?.isReadOnly ? undefined : handleSave}
+          nodes={displayNodes}
+          sourceNodes={nodes}
+          sourceEdges={edges}
+          edges={displayEdges}
+          setNodes={setNodes}
+          setEdges={setEdges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onEdgeClick={sso.handleEdgeClick}
+          flowTitle={flowName}
+          flowHandle={flowHandle}
+          onFlowTitleChange={handleFlowNameChange}
+          triggerAutoLayoutOnLoad={needsAutoLayout}
+          resourcePanelFooter={ssoToggleFooter}
+          onUndo={undo}
+          onRedo={redo}
+          canUndo={canUndo}
+          canRedo={canRedo}
+          isDirty={isDirty}
+        />
+      </CompactStacksContext.Provider>
       <SsoDisableConfirmDialog
         open={sso.isConfirmDialogOpen}
         checkpointCount={sso.ssoState.ssoCheckIds.length}

--- a/frontend/apps/console/src/features/flows/components/__tests__/FlowBuilder.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/__tests__/FlowBuilder.test.tsx
@@ -16,9 +16,9 @@
  * under the License.
  */
 
-import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import {act, render, screen, fireEvent, waitFor} from '@testing-library/react';
 import type {Node, Edge} from '@xyflow/react';
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import FlowBuilder from '../FlowBuilder';
 import FlowConstants from '@/features/flows/constants/FlowConstants';
 import {
@@ -145,6 +145,12 @@ vi.mock('@xyflow/react', () => ({
   MarkerType: {Arrow: 'arrow'},
 }));
 
+// Captures the onNodesChange prop handed to FlowCanvas so tests can feed
+// canvas changes through FlowBuilder's stack-aware wrapper.
+const {onNodesChangeCapture} = vi.hoisted(() => ({
+  onNodesChangeCapture: {current: null as ((changes: unknown[]) => void) | null},
+}));
+
 // Mock FlowCanvas component
 vi.mock('@/features/flows/components/FlowCanvas', () => ({
   default: ({
@@ -154,12 +160,14 @@ vi.mock('@/features/flows/components/FlowCanvas', () => ({
     onSave,
     nodes,
     edges,
+    onNodesChange,
     onResourceAdd,
     onTemplateLoad,
     onWidgetLoad,
     onStepLoad,
     triggerAutoLayoutOnLoad,
     mutateComponents,
+    isDirty,
   }: {
     flowTitle: string;
     flowHandle: string;
@@ -167,248 +175,254 @@ vi.mock('@/features/flows/components/FlowCanvas', () => ({
     onSave: (data: {nodes: Node[]; edges: Edge[]; viewport: {x: number; y: number; zoom: number}}) => void;
     nodes: Node[];
     edges: Edge[];
+    onNodesChange: (changes: unknown[]) => void;
     onResourceAdd: (resource: unknown) => void;
     onTemplateLoad: (template: unknown) => unknown;
     onWidgetLoad: (widget: unknown, target: unknown, nodes: Node[], edges: Edge[]) => unknown;
     onStepLoad: (step: unknown) => unknown;
     triggerAutoLayoutOnLoad?: boolean;
     mutateComponents: (components: Element[]) => Element[];
-  }) => (
-    <div data-testid="flow-builder">
-      <div data-testid="flow-title">{flowTitle}</div>
-      <div data-testid="flow-handle">{flowHandle}</div>
-      <div data-testid="auto-layout">{String(triggerAutoLayoutOnLoad)}</div>
-      <div data-testid="nodes-count">{nodes.length}</div>
-      <div data-testid="edges-count">{edges.length}</div>
-      <button data-testid="change-title-btn" onClick={() => onFlowTitleChange('New Flow Name')} type="button">
-        Change Title
-      </button>
-      <button
-        data-testid="save-btn"
-        onClick={() => onSave({nodes, edges, viewport: {x: 0, y: 0, zoom: 1}})}
-        type="button"
-      >
-        Save
-      </button>
-      <button
-        data-testid="add-resource-btn"
-        onClick={() => onResourceAdd({resourceType: 'ELEMENT', type: 'FORM', id: 'form-1'})}
-        type="button"
-      >
-        Add Resource
-      </button>
-      <button
-        data-testid="add-non-element-resource-btn"
-        onClick={() => onResourceAdd({resourceType: 'STEP', type: 'VIEW', id: 'step-1'})}
-        type="button"
-      >
-        Add Non-Element Resource
-      </button>
-      <button
-        data-testid="load-template-btn"
-        onClick={() => onTemplateLoad({type: 'BASIC', config: {data: {steps: []}}})}
-        type="button"
-      >
-        Load Template
-      </button>
-      <button
-        data-testid="load-template-with-end-step-btn"
-        onClick={() =>
-          onTemplateLoad({
-            type: 'BASIC',
-            config: {
-              data: {
-                steps: [
-                  {id: 'step-1', type: 'VIEW', position: {x: 0, y: 0}},
-                  {id: 'end-1', type: 'END', position: {x: 100, y: 0}, config: {redirectUrl: '/success'}},
-                ],
-              },
-            },
-          })
-        }
-        type="button"
-      >
-        Load Template With End Step
-      </button>
-      <button
-        data-testid="load-basic-federated-template-btn"
-        onClick={() =>
-          onTemplateLoad({
-            type: 'BASIC_FEDERATED',
-            config: {
-              data: {
-                steps: [
-                  {id: 'step-1', type: 'VIEW', position: {x: 0, y: 0}},
-                  {id: 'exec-1', type: 'EXECUTION', position: {x: 100, y: 0}},
-                ],
-              },
-            },
-          })
-        }
-        type="button"
-      >
-        Load Basic Federated Template
-      </button>
-      <button
-        data-testid="load-widget-btn"
-        onClick={() => onWidgetLoad({config: {data: {steps: []}}}, {id: 'target-1'}, nodes, edges)}
-        type="button"
-      >
-        Load Widget
-      </button>
-      <button
-        data-testid="load-widget-with-merge-strategy-btn"
-        onClick={() =>
-          onWidgetLoad(
-            {
+    isDirty?: boolean;
+  }) => {
+    onNodesChangeCapture.current = onNodesChange;
+    return (
+      <div data-testid="flow-builder">
+        <div data-testid="flow-title">{flowTitle}</div>
+        <div data-testid="flow-handle">{flowHandle}</div>
+        <div data-testid="auto-layout">{String(triggerAutoLayoutOnLoad)}</div>
+        <div data-testid="is-dirty">{String(Boolean(isDirty))}</div>
+        <div data-testid="nodes-count">{nodes.length}</div>
+        <div data-testid="edges-count">{edges.length}</div>
+        <button data-testid="change-title-btn" onClick={() => onFlowTitleChange('New Flow Name')} type="button">
+          Change Title
+        </button>
+        <button
+          data-testid="save-btn"
+          onClick={() => onSave({nodes, edges, viewport: {x: 0, y: 0, zoom: 1}})}
+          type="button"
+        >
+          Save
+        </button>
+        <button
+          data-testid="add-resource-btn"
+          onClick={() => onResourceAdd({resourceType: 'ELEMENT', type: 'FORM', id: 'form-1'})}
+          type="button"
+        >
+          Add Resource
+        </button>
+        <button
+          data-testid="add-non-element-resource-btn"
+          onClick={() => onResourceAdd({resourceType: 'STEP', type: 'VIEW', id: 'step-1'})}
+          type="button"
+        >
+          Add Non-Element Resource
+        </button>
+        <button
+          data-testid="load-template-btn"
+          onClick={() => onTemplateLoad({type: 'BASIC', config: {data: {steps: []}}})}
+          type="button"
+        >
+          Load Template
+        </button>
+        <button
+          data-testid="load-template-with-end-step-btn"
+          onClick={() =>
+            onTemplateLoad({
+              type: 'BASIC',
               config: {
                 data: {
                   steps: [
-                    {
-                      id: 'widget-step-1',
-                      type: 'VIEW',
-                      __generationMeta__: {strategy: 'MERGE_WITH_DROP_POINT'},
-                      data: {components: [{id: 'comp-1', type: 'BUTTON'}]},
-                    },
+                    {id: 'step-1', type: 'VIEW', position: {x: 0, y: 0}},
+                    {id: 'end-1', type: 'END', position: {x: 100, y: 0}, config: {redirectUrl: '/success'}},
                   ],
                 },
               },
-            },
-            {id: 'target-1'},
-            nodes,
-            edges,
-          )
-        }
-        type="button"
-      >
-        Load Widget With Merge Strategy
-      </button>
-      <button
-        data-testid="load-step-btn"
-        onClick={() => onStepLoad({id: 'step-1', type: 'VIEW', data: {}})}
-        type="button"
-      >
-        Load Step
-      </button>
-      <button
-        data-testid="load-step-with-components-btn"
-        onClick={() =>
-          onStepLoad({
-            id: 'step-1',
-            type: 'VIEW',
-            data: {components: [{id: 'comp-1', type: 'BUTTON'}]},
-          })
-        }
-        type="button"
-      >
-        Load Step With Components
-      </button>
-      <button
-        data-testid="load-non-view-step-btn"
-        onClick={() => onStepLoad({id: 'step-1', type: 'EXECUTION', data: {}})}
-        type="button"
-      >
-        Load Non-View Step
-      </button>
-      <button
-        data-testid="mutate-components-btn"
-        onClick={() => {
-          if (mutateComponents) {
-            mutateComponents([{id: 'test-1', type: 'FORM', resourceType: 'ELEMENT'} as Element]);
+            })
           }
-        }}
-        type="button"
-      >
-        Mutate Components
-      </button>
-      <button
-        data-testid="mutate-components-with-form-btn"
-        onClick={() => {
-          if (mutateComponents) {
-            mutateComponents([
-              {
-                id: 'form-1',
-                type: 'FORM',
-                category: 'BLOCK',
-                resourceType: 'ELEMENT',
-                components: [
-                  {id: 'password-1', type: 'PASSWORD_INPUT', config: {}},
-                  {id: 'button-1', type: 'BUTTON', variant: 'PRIMARY', config: {}},
-                ],
-              } as unknown as Element,
-            ]);
-          }
-        }}
-        type="button"
-      >
-        Mutate Components With Form
-      </button>
-      <button
-        data-testid="load-widget-with-default-selector-btn"
-        onClick={() =>
-          onWidgetLoad(
-            {
+          type="button"
+        >
+          Load Template With End Step
+        </button>
+        <button
+          data-testid="load-basic-federated-template-btn"
+          onClick={() =>
+            onTemplateLoad({
+              type: 'BASIC_FEDERATED',
               config: {
                 data: {
                   steps: [
-                    {
-                      id: '{{VIEW_STEP_ID}}',
-                      type: 'VIEW',
-                      position: {x: 0, y: 0},
-                      data: {
-                        components: [
-                          {
-                            id: '{{FORM_ID}}',
-                            type: 'FORM',
-                            components: [{id: '{{INPUT_ID}}', type: 'TEXT_INPUT'}],
-                          },
-                        ],
-                      },
-                    },
+                    {id: 'step-1', type: 'VIEW', position: {x: 0, y: 0}},
+                    {id: 'exec-1', type: 'EXECUTION', position: {x: 100, y: 0}},
                   ],
-                  __generationMeta__: {
-                    defaultPropertySelectorId: '{{INPUT_ID}}',
-                    replacers: [
-                      {placeholder: 'VIEW_STEP_ID', type: 'uuid'},
-                      {placeholder: 'FORM_ID', type: 'uuid'},
-                      {placeholder: 'INPUT_ID', type: 'uuid'},
+                },
+              },
+            })
+          }
+          type="button"
+        >
+          Load Basic Federated Template
+        </button>
+        <button
+          data-testid="load-widget-btn"
+          onClick={() => onWidgetLoad({config: {data: {steps: []}}}, {id: 'target-1'}, nodes, edges)}
+          type="button"
+        >
+          Load Widget
+        </button>
+        <button
+          data-testid="load-widget-with-merge-strategy-btn"
+          onClick={() =>
+            onWidgetLoad(
+              {
+                config: {
+                  data: {
+                    steps: [
+                      {
+                        id: 'widget-step-1',
+                        type: 'VIEW',
+                        __generationMeta__: {strategy: 'MERGE_WITH_DROP_POINT'},
+                        data: {components: [{id: 'comp-1', type: 'BUTTON'}]},
+                      },
                     ],
                   },
                 },
               },
-            },
-            {id: 'target-1'},
-            nodes,
-            edges,
-          )
-        }
-        type="button"
-      >
-        Load Widget With Default Selector
-      </button>
-      <button
-        data-testid="load-template-null-config-btn"
-        onClick={() => onTemplateLoad({type: 'BASIC', config: null})}
-        type="button"
-      >
-        Load Template Null Config
-      </button>
-      <button
-        data-testid="add-non-form-element-btn"
-        onClick={() =>
-          onResourceAdd({
-            resourceType: 'ELEMENT',
-            type: 'BUTTON',
-            id: 'button-1',
-            category: 'ACTION',
-          })
-        }
-        type="button"
-      >
-        Add Non-Form Element
-      </button>
-    </div>
-  ),
+              {id: 'target-1'},
+              nodes,
+              edges,
+            )
+          }
+          type="button"
+        >
+          Load Widget With Merge Strategy
+        </button>
+        <button
+          data-testid="load-step-btn"
+          onClick={() => onStepLoad({id: 'step-1', type: 'VIEW', data: {}})}
+          type="button"
+        >
+          Load Step
+        </button>
+        <button
+          data-testid="load-step-with-components-btn"
+          onClick={() =>
+            onStepLoad({
+              id: 'step-1',
+              type: 'VIEW',
+              data: {components: [{id: 'comp-1', type: 'BUTTON'}]},
+            })
+          }
+          type="button"
+        >
+          Load Step With Components
+        </button>
+        <button
+          data-testid="load-non-view-step-btn"
+          onClick={() => onStepLoad({id: 'step-1', type: 'EXECUTION', data: {}})}
+          type="button"
+        >
+          Load Non-View Step
+        </button>
+        <button
+          data-testid="mutate-components-btn"
+          onClick={() => {
+            if (mutateComponents) {
+              mutateComponents([{id: 'test-1', type: 'FORM', resourceType: 'ELEMENT'} as Element]);
+            }
+          }}
+          type="button"
+        >
+          Mutate Components
+        </button>
+        <button
+          data-testid="mutate-components-with-form-btn"
+          onClick={() => {
+            if (mutateComponents) {
+              mutateComponents([
+                {
+                  id: 'form-1',
+                  type: 'FORM',
+                  category: 'BLOCK',
+                  resourceType: 'ELEMENT',
+                  components: [
+                    {id: 'password-1', type: 'PASSWORD_INPUT', config: {}},
+                    {id: 'button-1', type: 'BUTTON', variant: 'PRIMARY', config: {}},
+                  ],
+                } as unknown as Element,
+              ]);
+            }
+          }}
+          type="button"
+        >
+          Mutate Components With Form
+        </button>
+        <button
+          data-testid="load-widget-with-default-selector-btn"
+          onClick={() =>
+            onWidgetLoad(
+              {
+                config: {
+                  data: {
+                    steps: [
+                      {
+                        id: '{{VIEW_STEP_ID}}',
+                        type: 'VIEW',
+                        position: {x: 0, y: 0},
+                        data: {
+                          components: [
+                            {
+                              id: '{{FORM_ID}}',
+                              type: 'FORM',
+                              components: [{id: '{{INPUT_ID}}', type: 'TEXT_INPUT'}],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                    __generationMeta__: {
+                      defaultPropertySelectorId: '{{INPUT_ID}}',
+                      replacers: [
+                        {placeholder: 'VIEW_STEP_ID', type: 'uuid'},
+                        {placeholder: 'FORM_ID', type: 'uuid'},
+                        {placeholder: 'INPUT_ID', type: 'uuid'},
+                      ],
+                    },
+                  },
+                },
+              },
+              {id: 'target-1'},
+              nodes,
+              edges,
+            )
+          }
+          type="button"
+        >
+          Load Widget With Default Selector
+        </button>
+        <button
+          data-testid="load-template-null-config-btn"
+          onClick={() => onTemplateLoad({type: 'BASIC', config: null})}
+          type="button"
+        >
+          Load Template Null Config
+        </button>
+        <button
+          data-testid="add-non-form-element-btn"
+          onClick={() =>
+            onResourceAdd({
+              resourceType: 'ELEMENT',
+              type: 'BUTTON',
+              id: 'button-1',
+              category: 'ACTION',
+            })
+          }
+          type="button"
+        >
+          Add Non-Form Element
+        </button>
+      </div>
+    );
+  },
 }));
 
 // Mock BaseEdge
@@ -1770,49 +1784,208 @@ describe('handleStepLoad Callback', () => {
   });
 });
 
-describe('Verbose Mode Node Filtering', () => {
+describe('Compact (Non-Verbose) Mode', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseParams.mockReturnValue({});
-    mockUseEdgesState.mockReturnValue([[], mockSetEdges, vi.fn()]);
     mockUseUpdateNodeInternals.mockReturnValue(vi.fn());
     mockIsFlowValid.value = true;
     mockExistingFlowData.value = null;
+    mockIsVerboseMode.value = false;
   });
 
-  it('should filter execution nodes when verbose mode is disabled', () => {
-    // Test the filtering logic directly
+  afterEach(() => {
+    mockIsVerboseMode.value = true;
+  });
+
+  it('should keep execution nodes on the canvas when verbose mode is disabled', () => {
     const nodes: Node[] = [
       {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
       {id: 'execution-1', type: 'EXECUTION', position: {x: 100, y: 0}, data: {}},
     ];
+    mockUseNodesState.mockReturnValue([nodes, mockSetNodes, vi.fn()]);
+    mockUseEdgesState.mockReturnValue([[], mockSetEdges, vi.fn()]);
 
-    const isVerboseMode = false;
-    const filtered = isVerboseMode ? nodes : nodes.filter((node) => node.type !== 'EXECUTION');
+    render(<FlowBuilder />);
 
-    expect(filtered.length).toBe(1);
-    expect(filtered[0].type).toBe('VIEW');
+    expect(screen.getByTestId('nodes-count')).toHaveTextContent('2');
   });
 
-  it('should filter edges connected to execution nodes when verbose mode is disabled', () => {
+  it('should keep edges connected to execution nodes when verbose mode is disabled', () => {
     const nodes: Node[] = [
       {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
       {id: 'execution-1', type: 'EXECUTION', position: {x: 100, y: 0}, data: {}},
+      {id: 'view-2', type: 'VIEW', position: {x: 200, y: 0}, data: {}},
     ];
     const edges: Edge[] = [
       {id: 'edge-1', source: 'view-1', target: 'execution-1'},
-      {id: 'edge-2', source: 'execution-1', target: 'view-1'},
-      {id: 'edge-3', source: 'view-1', target: 'view-1'},
+      {id: 'edge-2', source: 'execution-1', target: 'view-2'},
+      {id: 'edge-3', source: 'view-1', target: 'view-2'},
     ];
+    mockUseNodesState.mockReturnValue([nodes, mockSetNodes, vi.fn()]);
+    mockUseEdgesState.mockReturnValue([edges, mockSetEdges, vi.fn()]);
 
-    const isVerboseMode = false;
-    const executionNodeIds = new Set(nodes.filter((node) => node.type === 'EXECUTION').map((node) => node.id));
-    const filteredEdges = isVerboseMode
-      ? edges
-      : edges.filter((edge) => !executionNodeIds.has(edge.source) && !executionNodeIds.has(edge.target));
+    render(<FlowBuilder />);
 
-    expect(filteredEdges.length).toBe(1);
-    expect(filteredEdges[0].id).toBe('edge-3');
+    expect(screen.getByTestId('edges-count')).toHaveTextContent('3');
+  });
+
+  it('should collapse a run of consecutive executors into one stack display node', () => {
+    const nodes: Node[] = [
+      {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
+      {id: 'exec-a', type: 'TASK_EXECUTION', position: {x: 100, y: 0}, data: {}},
+      {id: 'exec-b', type: 'TASK_EXECUTION', position: {x: 200, y: 0}, data: {}},
+      {id: 'view-2', type: 'VIEW', position: {x: 300, y: 0}, data: {}},
+    ];
+    const edges: Edge[] = [
+      {id: 'e1', source: 'view-1', target: 'exec-a'},
+      {id: 'e2', source: 'exec-a', target: 'exec-b'},
+      {id: 'e3', source: 'exec-b', target: 'view-2'},
+    ];
+    mockUseNodesState.mockReturnValue([nodes, mockSetNodes, vi.fn()]);
+    mockUseEdgesState.mockReturnValue([edges, mockSetEdges, vi.fn()]);
+
+    render(<FlowBuilder />);
+
+    // exec-a and exec-b merge into one stack node; the interior edge is dropped
+    expect(screen.getByTestId('nodes-count')).toHaveTextContent('3');
+    expect(screen.getByTestId('edges-count')).toHaveTextContent('2');
+  });
+
+  it('should expand canvas changes on a stack onto its member nodes', () => {
+    const nodes: Node[] = [
+      {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
+      {id: 'exec-a', type: 'TASK_EXECUTION', position: {x: 100, y: 0}, data: {}},
+      {id: 'exec-b', type: 'TASK_EXECUTION', position: {x: 200, y: 0}, data: {}},
+      {id: 'view-2', type: 'VIEW', position: {x: 300, y: 0}, data: {}},
+    ];
+    const edges: Edge[] = [
+      {id: 'e1', source: 'view-1', target: 'exec-a'},
+      {id: 'e2', source: 'exec-a', target: 'exec-b'},
+      {id: 'e3', source: 'exec-b', target: 'view-2'},
+    ];
+    const defaultOnNodesChange = vi.fn();
+    mockUseNodesState.mockReturnValue([nodes, mockSetNodes, defaultOnNodesChange]);
+    mockUseEdgesState.mockReturnValue([edges, mockSetEdges, vi.fn()]);
+
+    render(<FlowBuilder />);
+
+    onNodesChangeCapture.current?.([{id: 'execution-stack_exec-a', position: {x: 9, y: 9}, type: 'position'}]);
+
+    expect(defaultOnNodesChange).toHaveBeenCalledWith([
+      {id: 'exec-a', position: {x: 9, y: 9}, type: 'position'},
+      {id: 'exec-b', position: {x: 9, y: 9}, type: 'position'},
+    ]);
+  });
+
+  it('should not mark the flow dirty when the load-time auto-layout lands after a click', async () => {
+    // A flow stored without layout data loads with every node at the origin.
+    const unpositioned: Node[] = [
+      {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
+      {id: 'exec-a', type: 'TASK_EXECUTION', position: {x: 0, y: 0}, data: {}},
+    ];
+    mockIsVerboseMode.value = true;
+    mockUseNodesState.mockReturnValue([unpositioned, mockSetNodes, vi.fn()]);
+    mockUseEdgesState.mockReturnValue([[], mockSetEdges, vi.fn()]);
+
+    const {rerender} = render(<FlowBuilder />);
+
+    // The user clicks while the layout is still pending.
+    fireEvent.pointerDown(window);
+
+    // The layout lands afterwards and positions every node.
+    mockUseNodesState.mockReturnValue([
+      unpositioned.map((node, index) => ({...node, position: {x: index * 220, y: 60}})),
+      mockSetNodes,
+      vi.fn(),
+    ]);
+    rerender(<FlowBuilder />);
+
+    await new Promise((resolve) => setTimeout(resolve, 700));
+    expect(screen.getByTestId('is-dirty')).toHaveTextContent('false');
+  });
+
+  it('should not mark the flow dirty when a view-mode toggle relayouts the canvas', async () => {
+    const nodesBefore: Node[] = [
+      {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
+      {id: 'exec-a', type: 'TASK_EXECUTION', position: {x: 100, y: 0}, data: {}},
+    ];
+    mockIsVerboseMode.value = true;
+    mockUseNodesState.mockReturnValue([nodesBefore, mockSetNodes, vi.fn()]);
+    mockUseEdgesState.mockReturnValue([[], mockSetEdges, vi.fn()]);
+
+    const {rerender} = render(<FlowBuilder />);
+
+    // Freeze the clean baseline the way a first user interaction does.
+    fireEvent.pointerDown(window);
+    await waitFor(() => expect(screen.getByTestId('is-dirty')).toHaveTextContent('false'), {timeout: 2000});
+
+    // Toggle the view mode, then let its relayout move the nodes.
+    mockIsVerboseMode.value = false;
+    rerender(<FlowBuilder />);
+    mockUseNodesState.mockReturnValue([
+      nodesBefore.map((node) => ({...node, position: {x: node.position.x + 40, y: 25}})),
+      mockSetNodes,
+      vi.fn(),
+    ]);
+    rerender(<FlowBuilder />);
+
+    // The relayout settles onto the clean baseline instead of dirtying it.
+    await new Promise((resolve) => setTimeout(resolve, 700));
+    expect(screen.getByTestId('is-dirty')).toHaveTextContent('false');
+  });
+
+  it('should still mark the flow dirty when the graph moves without a view-mode toggle', async () => {
+    const nodesBefore: Node[] = [
+      {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
+      {id: 'exec-a', type: 'TASK_EXECUTION', position: {x: 100, y: 0}, data: {}},
+    ];
+    mockIsVerboseMode.value = true;
+    mockUseNodesState.mockReturnValue([nodesBefore, mockSetNodes, vi.fn()]);
+    mockUseEdgesState.mockReturnValue([[], mockSetEdges, vi.fn()]);
+
+    const {rerender} = render(<FlowBuilder />);
+
+    fireEvent.pointerDown(window);
+    await waitFor(() => expect(screen.getByTestId('is-dirty')).toHaveTextContent('false'), {timeout: 2000});
+
+    mockUseNodesState.mockReturnValue([
+      nodesBefore.map((node) => ({...node, position: {x: node.position.x + 40, y: 25}})),
+      mockSetNodes,
+      vi.fn(),
+    ]);
+    rerender(<FlowBuilder />);
+
+    await waitFor(() => expect(screen.getByTestId('is-dirty')).toHaveTextContent('true'), {timeout: 2000});
+  });
+
+  it('should keep stack dimension changes on the display node so its edges stay rendered', () => {
+    const nodes: Node[] = [
+      {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
+      {id: 'exec-a', type: 'TASK_EXECUTION', position: {x: 100, y: 0}, data: {}},
+      {id: 'exec-b', type: 'TASK_EXECUTION', position: {x: 200, y: 0}, data: {}},
+      {id: 'view-2', type: 'VIEW', position: {x: 300, y: 0}, data: {}},
+    ];
+    const edges: Edge[] = [
+      {id: 'e1', source: 'view-1', target: 'exec-a'},
+      {id: 'e2', source: 'exec-a', target: 'exec-b'},
+      {id: 'e3', source: 'exec-b', target: 'view-2'},
+    ];
+    const defaultOnNodesChange = vi.fn();
+    mockUseNodesState.mockReturnValue([nodes, mockSetNodes, defaultOnNodesChange]);
+    mockUseEdgesState.mockReturnValue([edges, mockSetEdges, vi.fn()]);
+
+    render(<FlowBuilder />);
+
+    act(() => {
+      onNodesChangeCapture.current?.([
+        {dimensions: {height: 48, width: 88}, id: 'execution-stack_exec-a', type: 'dimensions'},
+      ]);
+    });
+
+    // The synthetic node has no state counterpart, so nothing reaches the
+    // default handler, but the display node absorbs the measured size.
+    expect(defaultOnNodesChange).toHaveBeenCalledWith([]);
   });
 });
 
@@ -2417,69 +2590,6 @@ describe('handleResourceAdd with Form Replacement', () => {
   });
 });
 
-describe('Verbose Mode Edge Filtering - Non-Verbose Mode', () => {
-  // Use vi.hoisted to create a mock that can be toggled
-  const mockIsVerboseModeValue = {value: false};
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockUseParams.mockReturnValue({});
-    mockUseUpdateNodeInternals.mockReturnValue(vi.fn());
-    mockIsFlowValid.value = true;
-    mockExistingFlowData.value = null;
-    mockIsVerboseModeValue.value = false;
-  });
-
-  it('should hide execution nodes when verbose mode is disabled', () => {
-    // Simulate the filtering logic used in the component
-    const nodes: Node[] = [
-      {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
-      {id: 'execution-1', type: 'EXECUTION', position: {x: 100, y: 0}, data: {}},
-      {id: 'view-2', type: 'VIEW', position: {x: 200, y: 0}, data: {}},
-    ];
-
-    const isVerboseMode = false;
-    const filteredNodes = isVerboseMode ? nodes : nodes.filter((node) => node.type !== 'EXECUTION');
-
-    expect(filteredNodes.length).toBe(2);
-    expect(filteredNodes.every((n) => n.type !== 'EXECUTION')).toBe(true);
-  });
-
-  it('should hide edges connected to execution nodes when verbose mode is disabled', () => {
-    const nodes: Node[] = [
-      {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
-      {id: 'execution-1', type: 'EXECUTION', position: {x: 100, y: 0}, data: {}},
-      {id: 'view-2', type: 'VIEW', position: {x: 200, y: 0}, data: {}},
-    ];
-    const edges: Edge[] = [
-      {id: 'edge-1', source: 'view-1', target: 'execution-1'}, // Should be filtered
-      {id: 'edge-2', source: 'execution-1', target: 'view-2'}, // Should be filtered
-      {id: 'edge-3', source: 'view-1', target: 'view-2'}, // Should remain
-    ];
-
-    const isVerboseMode = false;
-    const executionNodeIds = new Set(nodes.filter((node) => node.type === 'EXECUTION').map((node) => node.id));
-    const filteredEdges = isVerboseMode
-      ? edges
-      : edges.filter((edge) => !executionNodeIds.has(edge.source) && !executionNodeIds.has(edge.target));
-
-    expect(filteredEdges.length).toBe(1);
-    expect(filteredEdges[0].id).toBe('edge-3');
-  });
-
-  it('should show all nodes when verbose mode is enabled', () => {
-    const nodes: Node[] = [
-      {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
-      {id: 'execution-1', type: 'EXECUTION', position: {x: 100, y: 0}, data: {}},
-    ];
-
-    const isVerboseMode = true;
-    const filteredNodes = isVerboseMode ? nodes : nodes.filter((node) => node.type !== 'EXECUTION');
-
-    expect(filteredNodes.length).toBe(2);
-  });
-});
-
 describe('Snackbar Close Handler Functions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -2887,87 +2997,6 @@ describe('handleAddElementToView - INPUT_ELEMENT_TYPES handling', () => {
     render(<FlowBuilder />);
 
     expect(screen.getByTestId('flow-builder')).toBeInTheDocument();
-  });
-});
-
-describe('Verbose Mode - Non-Verbose Filtering Logic', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockUseParams.mockReturnValue({});
-    mockUseUpdateNodeInternals.mockReturnValue(vi.fn());
-    mockIsFlowValid.value = true;
-    mockExistingFlowData.value = null;
-  });
-
-  it('should filter out EXECUTION nodes when isVerboseMode is false', () => {
-    const nodes: Node[] = [
-      {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
-      {id: 'exec-1', type: 'EXECUTION', position: {x: 100, y: 0}, data: {}},
-      {id: 'view-2', type: 'VIEW', position: {x: 200, y: 0}, data: {}},
-    ];
-
-    // Simulate the filtering logic
-    const isVerboseMode = false;
-    const filteredNodes = isVerboseMode ? nodes : nodes.filter((node) => node.type !== 'EXECUTION');
-
-    expect(filteredNodes).toHaveLength(2);
-    expect(filteredNodes.every((n) => n.type === 'VIEW')).toBe(true);
-  });
-
-  it('should filter edges connected to EXECUTION nodes when isVerboseMode is false', () => {
-    const nodes: Node[] = [
-      {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
-      {id: 'exec-1', type: 'EXECUTION', position: {x: 100, y: 0}, data: {}},
-      {id: 'view-2', type: 'VIEW', position: {x: 200, y: 0}, data: {}},
-    ];
-
-    const edges: Edge[] = [
-      {id: 'e1', source: 'view-1', target: 'exec-1'},
-      {id: 'e2', source: 'exec-1', target: 'view-2'},
-      {id: 'e3', source: 'view-1', target: 'view-2'},
-    ];
-
-    // Simulate filtering logic
-    const isVerboseMode = false;
-    const executionNodeIds = new Set(nodes.filter((node) => node.type === 'EXECUTION').map((node) => node.id));
-    const filteredEdges = isVerboseMode
-      ? edges
-      : edges.filter((edge) => !executionNodeIds.has(edge.source) && !executionNodeIds.has(edge.target));
-
-    expect(filteredEdges).toHaveLength(1);
-    expect(filteredEdges[0].id).toBe('e3');
-  });
-
-  it('should keep all nodes when isVerboseMode is true', () => {
-    const nodes: Node[] = [
-      {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
-      {id: 'exec-1', type: 'EXECUTION', position: {x: 100, y: 0}, data: {}},
-    ];
-
-    const isVerboseMode = true;
-    const filteredNodes = isVerboseMode ? nodes : nodes.filter((node) => node.type !== 'EXECUTION');
-
-    expect(filteredNodes).toHaveLength(2);
-  });
-
-  it('should keep all edges when isVerboseMode is true', () => {
-    const nodes: Node[] = [
-      {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
-      {id: 'exec-1', type: 'EXECUTION', position: {x: 100, y: 0}, data: {}},
-    ];
-
-    const edges: Edge[] = [
-      {id: 'e1', source: 'view-1', target: 'exec-1'},
-      {id: 'e2', source: 'exec-1', target: 'view-1'},
-    ];
-
-    const isVerboseMode = true;
-    const executionNodeIds = new Set(nodes.filter((node) => node.type === 'EXECUTION').map((node) => node.id));
-    const filteredEdges = isVerboseMode
-      ? edges
-      : edges.filter((edge) => !executionNodeIds.has(edge.source) && !executionNodeIds.has(edge.target));
-
-    expect(filteredEdges).toHaveLength(2);
   });
 });
 
@@ -4351,29 +4380,6 @@ describe('Verbose Mode Filtering - Component Integration', () => {
     mockExistingFlowData.value = null;
   });
 
-  it('should correctly filter nodes based on verbose mode - logic test', () => {
-    const mockNodes: Node[] = [
-      {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
-      {id: 'exec-1', type: 'EXECUTION', position: {x: 100, y: 0}, data: {}},
-      {id: 'view-2', type: 'VIEW', position: {x: 200, y: 0}, data: {}},
-    ];
-
-    // Test filtering logic for non-verbose mode
-    const isVerboseModeFalse = false;
-    const filteredNodesNonVerbose = isVerboseModeFalse
-      ? mockNodes
-      : mockNodes.filter((node) => node.type !== 'EXECUTION');
-
-    expect(filteredNodesNonVerbose).toHaveLength(2);
-    expect(filteredNodesNonVerbose.every((n) => n.type === 'VIEW')).toBe(true);
-
-    // Test filtering logic for verbose mode
-    const isVerboseModeTrue = true;
-    const filteredNodesVerbose = isVerboseModeTrue ? mockNodes : mockNodes.filter((node) => node.type !== 'EXECUTION');
-
-    expect(filteredNodesVerbose).toHaveLength(3);
-  });
-
   it('should render component with nodes state', () => {
     const mockNodes: Node[] = [
       {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
@@ -4394,31 +4400,6 @@ describe('Verbose Mode Filtering - Component Integration', () => {
 
     // Component renders with nodes
     expect(screen.getByTestId('flow-builder')).toBeInTheDocument();
-  });
-
-  it('should correctly filter edges based on verbose mode - logic test', () => {
-    const mockNodes: Node[] = [
-      {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
-      {id: 'exec-1', type: 'EXECUTION', position: {x: 100, y: 0}, data: {}},
-      {id: 'view-2', type: 'VIEW', position: {x: 200, y: 0}, data: {}},
-    ];
-
-    const mockEdges: Edge[] = [
-      {id: 'e1', source: 'view-1', target: 'exec-1'},
-      {id: 'e2', source: 'exec-1', target: 'view-2'},
-      {id: 'e3', source: 'view-1', target: 'view-2'},
-    ];
-
-    // Test filtering logic for non-verbose mode
-    const isVerboseMode = false;
-    const executionNodeIds = new Set(mockNodes.filter((node) => node.type === 'EXECUTION').map((node) => node.id));
-    const filteredEdges = isVerboseMode
-      ? mockEdges
-      : mockEdges.filter((edge) => !executionNodeIds.has(edge.source) && !executionNodeIds.has(edge.target));
-
-    // Only edge e3 (view-1 -> view-2) should remain
-    expect(filteredEdges).toHaveLength(1);
-    expect(filteredEdges[0].id).toBe('e3');
   });
 });
 
@@ -5641,7 +5622,7 @@ describe('Verbose Mode Filtering Integration', () => {
     mockIsVerboseMode.value = true;
   });
 
-  it('should filter out EXECUTION nodes when isVerboseMode is false in rendered component', () => {
+  it('should keep EXECUTION nodes and their edges when isVerboseMode is false in rendered component', () => {
     // Set up nodes with execution type (TASK_EXECUTION is the actual type used by StepTypes.Execution)
     const nodesWithExecution: Node[] = [
       {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
@@ -5657,7 +5638,6 @@ describe('Verbose Mode Filtering Integration', () => {
     mockUseNodesState.mockReturnValue([nodesWithExecution, mockSetNodes, vi.fn()]);
     mockUseEdgesState.mockReturnValue([edgesWithExecution, mockSetEdges, vi.fn()]);
 
-    // Set verbose mode to false BEFORE render to trigger filtering
     mockIsVerboseMode.value = false;
     // Override the mock implementation
     mockUseFlowConfig.mockImplementation(() => ({
@@ -5669,10 +5649,10 @@ describe('Verbose Mode Filtering Integration', () => {
 
     render(<FlowBuilder />);
 
-    // The FlowBuilder should receive filtered nodes (2 instead of 3)
-    expect(screen.getByTestId('nodes-count')).toHaveTextContent('2');
-    // The FlowBuilder should receive filtered edges (1 instead of 3)
-    expect(screen.getByTestId('edges-count')).toHaveTextContent('1');
+    // Compact mode renders execution nodes as compact chips instead of hiding
+    // them, so the full graph is passed through to the canvas.
+    expect(screen.getByTestId('nodes-count')).toHaveTextContent('3');
+    expect(screen.getByTestId('edges-count')).toHaveTextContent('3');
   });
 
   it('should keep all nodes and edges when isVerboseMode is true', () => {
@@ -5914,7 +5894,7 @@ describe('Verbose Mode Filtering - Component Integration with Execution Nodes', 
     mockValidateFlowGraph.mockReturnValue([]);
   });
 
-  it('should filter EXECUTION nodes and their edges when isVerboseMode is false', () => {
+  it('should keep EXECUTION nodes and their edges when isVerboseMode is false', () => {
     const nodesWithExecution: Node[] = [
       {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
       {id: 'exec-1', type: 'TASK_EXECUTION', position: {x: 100, y: 0}, data: {}},
@@ -5940,10 +5920,10 @@ describe('Verbose Mode Filtering - Component Integration with Execution Nodes', 
 
     render(<FlowBuilder />);
 
-    // Execution node should be filtered out (2 VIEW nodes remain)
-    expect(screen.getByTestId('nodes-count')).toHaveTextContent('2');
-    // Edges connected to execution node should be filtered out (only e3 remains)
-    expect(screen.getByTestId('edges-count')).toHaveTextContent('1');
+    // Execution nodes render as compact chips in non-verbose mode, so the
+    // whole graph reaches the canvas.
+    expect(screen.getByTestId('nodes-count')).toHaveTextContent('3');
+    expect(screen.getByTestId('edges-count')).toHaveTextContent('3');
   });
 
   it('should keep all nodes and edges when isVerboseMode is true', () => {
@@ -5978,7 +5958,7 @@ describe('Verbose Mode Filtering - Component Integration with Execution Nodes', 
     expect(screen.getByTestId('edges-count')).toHaveTextContent('3');
   });
 
-  it('should only filter edges where source OR target is an execution node', () => {
+  it('should keep edges where source OR target is an execution node', () => {
     const nodes: Node[] = [
       {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
       {id: 'exec-1', type: 'TASK_EXECUTION', position: {x: 100, y: 0}, data: {}},
@@ -5986,10 +5966,10 @@ describe('Verbose Mode Filtering - Component Integration with Execution Nodes', 
       {id: 'view-3', type: 'VIEW', position: {x: 300, y: 0}, data: {}},
     ];
     const edges: Edge[] = [
-      {id: 'e1', source: 'view-1', target: 'exec-1'}, // filtered (target is execution)
-      {id: 'e2', source: 'exec-1', target: 'view-2'}, // filtered (source is execution)
-      {id: 'e3', source: 'view-1', target: 'view-2'}, // kept
-      {id: 'e4', source: 'view-2', target: 'view-3'}, // kept
+      {id: 'e1', source: 'view-1', target: 'exec-1'},
+      {id: 'e2', source: 'exec-1', target: 'view-2'},
+      {id: 'e3', source: 'view-1', target: 'view-2'},
+      {id: 'e4', source: 'view-2', target: 'view-3'},
     ];
 
     mockUseNodesState.mockReturnValue([nodes, mockSetNodes, vi.fn()]);
@@ -6006,10 +5986,8 @@ describe('Verbose Mode Filtering - Component Integration with Execution Nodes', 
 
     render(<FlowBuilder />);
 
-    // 3 VIEW nodes should remain
-    expect(screen.getByTestId('nodes-count')).toHaveTextContent('3');
-    // Only e3 and e4 should remain
-    expect(screen.getByTestId('edges-count')).toHaveTextContent('2');
+    expect(screen.getByTestId('nodes-count')).toHaveTextContent('4');
+    expect(screen.getByTestId('edges-count')).toHaveTextContent('4');
   });
 });
 
@@ -6180,10 +6158,9 @@ describe('Verbose Mode - Empty Arrays Edge Cases', () => {
 
     render(<FlowBuilder />);
 
-    // All nodes filtered out
-    expect(screen.getByTestId('nodes-count')).toHaveTextContent('0');
-    // All edges filtered out
-    expect(screen.getByTestId('edges-count')).toHaveTextContent('0');
+    // Execution nodes stay on the canvas as compact chips
+    expect(screen.getByTestId('nodes-count')).toHaveTextContent('2');
+    expect(screen.getByTestId('edges-count')).toHaveTextContent('1');
   });
 });
 
@@ -6306,7 +6283,7 @@ describe('Verbose Mode Node and Edge Filtering', () => {
     mockValidateFlowGraph.mockReturnValue([]);
   });
 
-  it('should filter out execution nodes and keep view nodes when verbose mode is disabled', () => {
+  it('should keep execution nodes alongside view nodes when verbose mode is disabled', () => {
     const mixedNodes: Node[] = [
       {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
       {id: 'exec-1', type: 'TASK_EXECUTION', position: {x: 100, y: 0}, data: {}},
@@ -6325,10 +6302,10 @@ describe('Verbose Mode Node and Edge Filtering', () => {
 
     render(<FlowBuilder />);
 
-    expect(screen.getByTestId('nodes-count')).toHaveTextContent('1');
+    expect(screen.getByTestId('nodes-count')).toHaveTextContent('2');
   });
 
-  it('should filter out all nodes when only execution nodes exist and verbose mode is disabled', () => {
+  it('should keep all nodes when only execution nodes exist and verbose mode is disabled', () => {
     const executionOnlyNodes: Node[] = [{id: 'exec-1', type: 'TASK_EXECUTION', position: {x: 0, y: 0}, data: {}}];
     const edges: Edge[] = [];
 
@@ -6344,10 +6321,10 @@ describe('Verbose Mode Node and Edge Filtering', () => {
 
     render(<FlowBuilder />);
 
-    expect(screen.getByTestId('nodes-count')).toHaveTextContent('0');
+    expect(screen.getByTestId('nodes-count')).toHaveTextContent('1');
   });
 
-  it('should filter edges where source node is an execution node', () => {
+  it('should keep edges where source node is an execution node', () => {
     const nodes: Node[] = [
       {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
       {id: 'exec-1', type: 'TASK_EXECUTION', position: {x: 100, y: 0}, data: {}},
@@ -6370,10 +6347,10 @@ describe('Verbose Mode Node and Edge Filtering', () => {
 
     render(<FlowBuilder />);
 
-    expect(screen.getByTestId('edges-count')).toHaveTextContent('1');
+    expect(screen.getByTestId('edges-count')).toHaveTextContent('2');
   });
 
-  it('should filter edges where target node is an execution node', () => {
+  it('should keep edges where target node is an execution node', () => {
     const nodes: Node[] = [
       {id: 'view-1', type: 'VIEW', position: {x: 0, y: 0}, data: {}},
       {id: 'exec-1', type: 'TASK_EXECUTION', position: {x: 100, y: 0}, data: {}},
@@ -6396,7 +6373,7 @@ describe('Verbose Mode Node and Edge Filtering', () => {
 
     render(<FlowBuilder />);
 
-    expect(screen.getByTestId('edges-count')).toHaveTextContent('1');
+    expect(screen.getByTestId('edges-count')).toHaveTextContent('2');
   });
 
   it('should show all nodes including execution nodes when verbose mode is enabled', () => {

--- a/frontend/apps/console/src/features/flows/components/resources/steps/call/Call.scss
+++ b/frontend/apps/console/src/features/flows/components/resources/steps/call/Call.scss
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Call steps reference another flow rather than executing logic here. They
+// share the executor header, and carry the distinguishing "reference"
+// treatment: a dashed primary-tinted outline around the node, plus a primary
+// wash and a workflow glyph in the body beside the referenced flow name.
+// Note: only the `--oxygen-palette-*` custom properties exist in this app;
+// `--mui-palette-*` is undefined and would invalidate these declarations.
+.execution-minimal-step.call-step {
+  // The dashed outline wraps the whole node (header included). It cannot be
+  // paired with `overflow: hidden` to clip the children to it, because the
+  // outcome handles are positioned outside the card.
+  border: 1.5px dashed color-mix(in srgb, var(--oxygen-palette-primary-main) 45%, transparent);
+  border-radius: 8px;
+
+  .execution-minimal-step-content {
+    background-color: color-mix(
+      in srgb,
+      var(--flow-builder-execution-step-background-color) 92%,
+      var(--oxygen-palette-primary-main)
+    );
+
+    &:hover {
+      background-color: color-mix(
+        in srgb,
+        var(--flow-builder-execution-step-background-color) 86%,
+        var(--oxygen-palette-primary-main)
+      );
+    }
+  }
+
+  .call-step-reference-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    color: var(--oxygen-palette-primary-main);
+    background-color: color-mix(in srgb, var(--oxygen-palette-primary-main) 12%, transparent);
+  }
+
+  .call-step-reference-label {
+    color: var(--oxygen-palette-primary-main);
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+}

--- a/frontend/apps/console/src/features/flows/components/resources/steps/call/Call.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/steps/call/Call.tsx
@@ -29,7 +29,12 @@ import {
   Tooltip,
   Typography,
 } from '@wso2/oxygen-ui';
-import {CogIcon, ExternalLink as ExternalLinkIcon, TrashIcon} from '@wso2/oxygen-ui-icons-react';
+import {
+  CogIcon,
+  ExternalLink as ExternalLinkIcon,
+  TrashIcon,
+  Workflow as WorkflowIcon,
+} from '@wso2/oxygen-ui-icons-react';
 import {Handle, Position, useNodeId, useReactFlow} from '@xyflow/react';
 import {memo, useMemo, useState, type ReactElement} from 'react';
 import {useTranslation} from 'react-i18next';
@@ -46,6 +51,7 @@ import {ResourceTypes} from '@/features/flows/models/resources';
 import type {BasicFlowDefinition} from '@/features/flows/models/responses';
 import {StepCategories, StepTypes, type Step, type StepData} from '@/features/flows/models/steps';
 import '../execution/ExecutionMinimal.scss';
+import './Call.scss';
 
 export type CallPropsInterface = CommonStepFactoryPropsInterface;
 
@@ -54,10 +60,12 @@ type CallStepData = StepData & {flow?: {ref?: string}};
 const CALL_NODE_WIDTH = 260;
 
 /**
- * Call Node component for cross-flow invocation. Visually mirrors ExecutionMinimal but
- * exposes a flow reference instead of an executor and exposes both `onSuccess` (right) and
- * `onFailure` (bottom) handles. The node card also carries an "open referenced flow"
- * shortcut that jumps the builder to the callee flow (with an unsaved-changes confirm).
+ * Call Node component for cross-flow invocation. It shares the executor card's header but
+ * its body carries a distinct "reference" treatment (dashed primary-tinted outline, primary
+ * wash, and a workflow glyph) so it does not read as an executor, and it exposes a flow
+ * reference instead of an executor along with both `onSuccess` (right) and `onFailure`
+ * (bottom) handles. The node card also carries an "open referenced flow" shortcut that jumps
+ * the builder to the callee flow (with an unsaved-changes confirm).
  */
 function Call({resources, data}: CallPropsInterface): ReactElement {
   const stepId: string | null = useNodeId();
@@ -175,8 +183,11 @@ function Call({resources, data}: CallPropsInterface): ReactElement {
           data-testid="call-node-content"
         >
           <Box display="flex" alignItems="center" justifyContent="space-between" gap={1}>
+            <Box className="call-step-reference-icon">
+              <WorkflowIcon size={18} />
+            </Box>
             <Box sx={{minWidth: 0, flex: 1}}>
-              <Typography variant="caption" sx={{display: 'block', opacity: 0.7}}>
+              <Typography variant="caption" className="call-step-reference-label" sx={{display: 'block'}}>
                 {t('flows:core.call.referencedFlow', 'Referenced flow')}
               </Typography>
               <Typography

--- a/frontend/apps/console/src/features/flows/components/resources/steps/execution/Execution.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/steps/execution/Execution.tsx
@@ -18,11 +18,13 @@
 
 import {useNodeId} from '@xyflow/react';
 import {memo, useMemo, type ReactElement} from 'react';
+import ExecutionCompact from './ExecutionCompact';
 import ExecutionMinimal from './ExecutionMinimal';
 import ValidationErrorBoundary from '../../../validation-panel/ValidationErrorBoundary';
 import type {CommonStepFactoryPropsInterface} from '../CommonStepFactory';
 import View from '../view/View';
 import VisualFlowConstants from '@/features/flows/constants/VisualFlowConstants';
+import useFlowConfig from '@/features/flows/hooks/useFlowConfig';
 import useInteractionState from '@/features/flows/hooks/useInteractionState';
 import type {Element} from '@/features/flows/models/elements';
 import {ResourceTypes} from '@/features/flows/models/resources';
@@ -46,6 +48,7 @@ export type ExecutionPropsInterface = CommonStepFactoryPropsInterface;
 function Execution({data, resources}: ExecutionPropsInterface): ReactElement | null {
   const stepId: string | null = useNodeId();
   const {setLastInteractedResource, setLastInteractedStepId} = useInteractionState();
+  const {isVerboseMode} = useFlowConfig();
 
   const executorName = (data?.action as StepAction | undefined)?.executor?.name ?? 'Executor';
   // Get display metadata from data (set by resolveStepMetadata)
@@ -100,7 +103,9 @@ function Execution({data, resources}: ExecutionPropsInterface): ReactElement | n
 
   return (
     <ValidationErrorBoundary resource={resource}>
-      {hasComponents ? (
+      {!isVerboseMode ? (
+        <ExecutionCompact resource={resource} />
+      ) : hasComponents ? (
         <View
           heading={executorName}
           data={data}

--- a/frontend/apps/console/src/features/flows/components/resources/steps/execution/ExecutionCompact.scss
+++ b/frontend/apps/console/src/features/flows/components/resources/steps/execution/ExecutionCompact.scss
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.execution-compact-step {
+  position: relative;
+  width: 48px;
+  height: 48px;
+
+  // Scale the handle dots down to chip proportions (the shared outcome-handle
+  // styles size them for the full card; the doubled class outweighs their
+  // important widths).
+  .react-flow__handle.react-flow__handle {
+    width: 8px !important;
+    height: 8px !important;
+    border-width: 1px !important;
+  }
+
+  .execution-compact-step-content {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background-color: var(--flow-builder-execution-step-background-color);
+    color: var(--flow-builder-execution-step-text-color);
+    cursor: pointer;
+
+    &:hover {
+      background-color: color-mix(
+        in srgb,
+        var(--flow-builder-execution-step-background-color) 92%,
+        var(--oxygen-palette-primary-main)
+      );
+    }
+  }
+
+  .execution-compact-step-fallback {
+    font-weight: 600;
+    line-height: 1;
+  }
+
+  // Restack affordance on the head chip of an expanded group.
+  .execution-compact-step-restack {
+    position: absolute;
+    top: -10px;
+    right: -10px;
+    z-index: 1;
+    width: 22px;
+    height: 22px;
+    background-color: var(--flow-builder-execution-step-background-color);
+    color: var(--flow-builder-execution-step-text-color);
+    border: 2px solid var(--oxygen-palette-background-default);
+
+    &:hover {
+      background-color: color-mix(
+        in srgb,
+        var(--flow-builder-execution-step-background-color) 80%,
+        var(--oxygen-palette-primary-main)
+      );
+    }
+  }
+}
+
+.react-flow__node.selected .execution-compact-step .execution-compact-step-content {
+  outline: 2px solid var(--oxygen-palette-primary-main);
+  outline-offset: 2px;
+}
+
+// The validation boundary wraps the node, so round it to match the chip:
+// its default rounded-rectangle (and the pulse that follows the same radius)
+// would otherwise box a circular chip. The `.padded` variant is listed too so
+// this wins on specificity regardless of stylesheet order.
+.validation-error-boundary:has(.execution-compact-step),
+.validation-error-boundary.padded:has(.execution-compact-step) {
+  border-radius: 50%;
+}
+
+html[data-color-scheme='light'] .execution-compact-step .execution-compact-step-content {
+  box-shadow:
+    0 10px 22px 0 rgba(6, 6, 14, 0.1),
+    0 24px 48px 0 rgba(199, 211, 234, 0.05) inset,
+    0 1px 1px 0 rgba(199, 211, 234, 0.12) inset;
+}
+
+html[data-color-scheme='dark'] .execution-compact-step .execution-compact-step-content {
+  box-shadow:
+    0 24px 32px 0 rgba(6, 6, 14, 0.7),
+    0 24px 48px 0 rgba(199, 211, 234, 0.05) inset,
+    0 1px 1px 0 rgba(199, 211, 234, 0.12) inset;
+}

--- a/frontend/apps/console/src/features/flows/components/resources/steps/execution/ExecutionCompact.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/steps/execution/ExecutionCompact.tsx
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Box, IconButton, Stack, Tooltip, Typography} from '@wso2/oxygen-ui';
+import {Layers} from '@wso2/oxygen-ui-icons-react';
+import {Handle, Position, useNodeId} from '@xyflow/react';
+import {useContext, type KeyboardEvent, type MouseEvent, type ReactElement} from 'react';
+import {useTranslation} from 'react-i18next';
+import ResourceDisplayImage from '@/features/flows/components/ResourceDisplayImage';
+import VisualFlowConstants from '@/features/flows/constants/VisualFlowConstants';
+import CompactStacksContext from '@/features/flows/context/CompactStacksContext';
+import useInteractionState from '@/features/flows/hooks/useInteractionState';
+import useUIPanelState from '@/features/flows/hooks/useUIPanelState';
+import type {Step, StepData} from '@/features/flows/models/steps';
+import './ExecutionCompact.scss';
+
+/**
+ * Props interface of {@link ExecutionCompact}
+ */
+export interface ExecutionCompactPropsInterface {
+  /**
+   * Resource object of the execution step.
+   */
+  resource: Step;
+}
+
+/**
+ * Execution (Compact) Node component. Rendered in place of the full executor
+ * card when the canvas is in compact (non-verbose) mode: an icon-only chip
+ * that keeps the executor's branching handles on the canvas.
+ *
+ * @param props - Props injected to the component.
+ * @returns Execution (Compact) node component.
+ */
+function ExecutionCompact({resource}: ExecutionCompactPropsInterface): ReactElement {
+  const {setLastInteractedResource, setLastInteractedStepId} = useInteractionState();
+  const {setIsOpenResourcePropertiesPanel} = useUIPanelState();
+  const {collapseStack, expandedHeadIdToStackId} = useContext(CompactStacksContext);
+  const stepId: string | null = useNodeId();
+
+  const {t} = useTranslation();
+
+  // The head chip of an expanded group offers restacking it.
+  const restackableStackId = stepId ? expandedHeadIdToStackId.get(stepId) : undefined;
+
+  const displayLabel = resource.display?.label ?? resource.data?.action?.executor?.name ?? 'Executor';
+  const displayDescription = resource.display?.description;
+
+  // Same branching detection as ExecutionMinimal: the presence of the
+  // onFailure/onIncomplete fields (even empty) marks handle support.
+  const stepData = resource.data as StepData | undefined;
+  const hasBranchingSupport = stepData?.action && 'onFailure' in stepData.action;
+  const hasIncompleteSupport = stepData?.action && 'onIncomplete' in stepData.action;
+
+  const outcomeLabels = resource.display?.outcomes;
+  const successLabel = outcomeLabels?.success ?? t('flows:core.executions.handles.success', 'Success');
+  const failureLabel = outcomeLabels?.failure ?? t('flows:core.executions.handles.failure', 'Failure');
+  const incompleteLabel = outcomeLabels?.incomplete ?? t('flows:core.executions.handles.incomplete', 'Incomplete');
+
+  const handleOpenProperties = (): void => {
+    if (stepId !== null) {
+      setLastInteractedStepId(stepId);
+    }
+    setLastInteractedResource({
+      ...resource,
+      config: {
+        ...(resource?.config || {}),
+        ...(typeof resource.data?.config === 'object' && resource.data?.config !== null ? resource.data.config : {}),
+      },
+    });
+    setIsOpenResourcePropertiesPanel(true);
+  };
+
+  return (
+    <Box className="execution-compact-step">
+      <Tooltip
+        placement="top"
+        title={
+          <Stack>
+            <Typography variant="subtitle2">{displayLabel}</Typography>
+            {displayDescription && <Typography variant="caption">{displayDescription}</Typography>}
+          </Stack>
+        }
+      >
+        <Box
+          className="execution-compact-step-content"
+          role="button"
+          tabIndex={0}
+          aria-label={displayLabel}
+          onClick={handleOpenProperties}
+          // A div with role="button" gets no native Enter/Space activation, and
+          // in compact mode this chip is the only way into the executor.
+          onKeyDown={(event: KeyboardEvent<HTMLElement>) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              handleOpenProperties();
+            }
+          }}
+        >
+          {resource.display?.image ? (
+            <ResourceDisplayImage
+              image={resource.display.image}
+              label={displayLabel}
+              size={24}
+              preserveColor={resource.display?.preserveImageColor}
+            />
+          ) : (
+            <Typography variant="subtitle1" className="execution-compact-step-fallback">
+              {displayLabel.charAt(0).toUpperCase()}
+            </Typography>
+          )}
+        </Box>
+      </Tooltip>
+      {restackableStackId && (
+        <Tooltip title={t('flows:core.executions.stack.restack', 'Restack executors')} placement="top">
+          <IconButton
+            size="small"
+            className="execution-compact-step-restack"
+            aria-label={t('flows:core.executions.stack.restack', 'Restack executors')}
+            onClick={(event: MouseEvent<HTMLElement>) => {
+              event.stopPropagation();
+              collapseStack(restackableStackId);
+            }}
+          >
+            <Layers size={12} />
+          </IconButton>
+        </Tooltip>
+      )}
+      <Handle type="target" position={Position.Left} />
+      {/* Success handle - always shown on the right */}
+      {hasBranchingSupport ? (
+        <Tooltip title={successLabel} placement="right">
+          <Box className="handle-wrapper success-wrapper">
+            <Handle
+              type="source"
+              position={Position.Right}
+              id={`${resource.id}${VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX}`}
+              className="execution-handle-success"
+            />
+          </Box>
+        </Tooltip>
+      ) : (
+        <Handle
+          type="source"
+          position={Position.Right}
+          id={`${resource.id}${VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX}`}
+        />
+      )}
+      {/* Failure handle - shown at the bottom when the action supports branching (has onFailure property) */}
+      {hasBranchingSupport && (
+        <Tooltip title={failureLabel} placement="bottom">
+          <Box className="handle-wrapper failure-wrapper">
+            <Handle type="source" position={Position.Bottom} id="failure" className="execution-handle-failure" />
+          </Box>
+        </Tooltip>
+      )}
+      {/* Incomplete handle - shown at the top when the action supports incomplete (has onIncomplete property) */}
+      {hasIncompleteSupport && (
+        <Tooltip title={incompleteLabel} placement="top">
+          <Box className="handle-wrapper incomplete-wrapper">
+            <Handle
+              type="source"
+              position={Position.Top}
+              id={`${resource.id}${VisualFlowConstants.FLOW_BUILDER_INCOMPLETE_HANDLE_SUFFIX}`}
+              className="execution-handle-incomplete"
+            />
+          </Box>
+        </Tooltip>
+      )}
+    </Box>
+  );
+}
+
+export default ExecutionCompact;

--- a/frontend/apps/console/src/features/flows/components/resources/steps/execution/ExecutionMinimal.scss
+++ b/frontend/apps/console/src/features/flows/components/resources/steps/execution/ExecutionMinimal.scss
@@ -41,10 +41,11 @@ html[data-color-scheme='dark'] {
   --flow-builder-execution-disallowed-droppable-area-highlight: #442222;
 }
 
-.execution-minimal-step {
-  border-radius: 8px;
-  position: relative;
-
+// Handle wrapper positioning and outcome-handle colors are shared between the
+// full (minimal) executor card and the compact chip so edges anchor identically
+// in both modes.
+.execution-minimal-step,
+.execution-compact-step {
   // Handle wrapper for tooltip functionality
   .handle-wrapper {
     position: absolute;
@@ -106,6 +107,11 @@ html[data-color-scheme='dark'] {
     left: auto !important;
     transform: none !important;
   }
+}
+
+.execution-minimal-step {
+  border-radius: 8px;
+  position: relative;
 
   // When branching is active, ensure proper spacing
   &.has-branching {

--- a/frontend/apps/console/src/features/flows/components/resources/steps/execution/ExecutionStack.scss
+++ b/frontend/apps/console/src/features/flows/components/resources/steps/execution/ExecutionStack.scss
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.execution-stack-step {
+  position: relative;
+  height: 48px;
+
+  // Scale the handle dots down to chip proportions.
+  .react-flow__handle.react-flow__handle {
+    width: 8px !important;
+    height: 8px !important;
+    border-width: 1px !important;
+  }
+
+  .execution-stack-step-content {
+    position: relative;
+    height: 48px;
+    cursor: pointer;
+  }
+
+  // Card-deck layers peeking out behind the chip, one per extra member
+  // (capped), suggesting the collapsed run at a glance. On hover the real
+  // member chips push out past them, so they fade away.
+  .execution-stack-layer {
+    position: absolute;
+    top: 0;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background-color: color-mix(in srgb, var(--flow-builder-execution-step-background-color) 70%, transparent);
+    transition: opacity 0.2s ease;
+  }
+
+  .execution-stack-step-content:hover .execution-stack-layer {
+    opacity: 0;
+  }
+
+  .execution-stack-layer-1 {
+    left: 4px;
+  }
+
+  .execution-stack-layer-2 {
+    left: 8px;
+  }
+
+  .execution-stack-chip {
+    position: relative;
+    z-index: 1;
+    width: 48px;
+    height: 48px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1px;
+    border-radius: 50%;
+    background-color: var(--flow-builder-execution-step-background-color);
+    color: var(--flow-builder-execution-step-text-color);
+    border: 2px solid var(--oxygen-palette-background-default);
+  }
+
+  .execution-stack-step-content:hover .execution-stack-chip {
+    background-color: color-mix(
+      in srgb,
+      var(--flow-builder-execution-step-background-color) 92%,
+      var(--oxygen-palette-primary-main)
+    );
+  }
+
+  .execution-stack-chip-fallback {
+    font-weight: 600;
+    line-height: 1;
+  }
+
+  // The "+N" count sits inside the circle, under the first executor's icon.
+  .execution-stack-badge {
+    font-size: 10px;
+    font-weight: 600;
+    line-height: 1;
+    opacity: 0.85;
+  }
+
+  // Hover preview: the stacked members stay stacked but each is pushed a bit
+  // further right from underneath the one above it, like cards nudged out of a
+  // deck. They sit behind the main chip (no z-index of their own, so the
+  // chip's z-index 1 keeps it on top) and only their right sliver shows. Pure
+  // decoration; pointer events stay off so neighboring nodes and edges remain
+  // interactive. The main chip never moves: its only hover change is the
+  // background color above.
+  .execution-stack-fan-chip {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 44px;
+    height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background-color: color-mix(in srgb, var(--flow-builder-execution-step-background-color) 92%, transparent);
+    color: var(--flow-builder-execution-step-text-color);
+    border: 2px solid var(--oxygen-palette-background-default);
+    opacity: 0;
+    transform: translateX(0);
+    transition:
+      transform 0.25s ease,
+      opacity 0.2s ease;
+    transition-delay: calc(var(--fan-index) * 40ms);
+    pointer-events: none;
+  }
+
+  // 32px per step is the smallest push that clears the icon of the chip above
+  // it (icon half-width + the top chip's right edge), so every icon stays
+  // centered in its own circle and fully visible while the circles still
+  // overlap enough to read as a stack.
+  .execution-stack-step-content:hover .execution-stack-fan-chip {
+    opacity: 1;
+    transform: translateX(calc((var(--fan-index) + 1) * 32px));
+  }
+}
+
+// While the fan preview is out, lift the hovered stack above neighboring nodes
+// and edges so the pushed-out chips render on top of them. The canvas puts the
+// edge layer at z-index 9999 (see DecoratedVisualFlow), and `.react-flow__nodes`
+// creates no stacking context, so the node competes with that layer directly
+// and has to clear it.
+.react-flow__node:has(.execution-stack-step-content:hover) {
+  z-index: 10000 !important;
+}
+
+.react-flow__node.selected .execution-stack-step .execution-stack-chip {
+  outline: 2px solid var(--oxygen-palette-primary-main);
+  outline-offset: 2px;
+}
+
+// Round the validation boundary to match the chip. A stack is wider than it is
+// tall, so a pill radius (rather than 50%, which would ellipse it) follows the
+// rounded ends of the deck.
+.validation-error-boundary:has(.execution-stack-step),
+.validation-error-boundary.padded:has(.execution-stack-step) {
+  border-radius: 999px;
+}
+
+html[data-color-scheme='light'] .execution-stack-step .execution-stack-chip {
+  box-shadow:
+    0 10px 22px 0 rgba(6, 6, 14, 0.1),
+    0 24px 48px 0 rgba(199, 211, 234, 0.05) inset,
+    0 1px 1px 0 rgba(199, 211, 234, 0.12) inset;
+}
+
+html[data-color-scheme='dark'] .execution-stack-step .execution-stack-chip {
+  box-shadow:
+    0 24px 32px 0 rgba(6, 6, 14, 0.7),
+    0 24px 48px 0 rgba(199, 211, 234, 0.05) inset,
+    0 1px 1px 0 rgba(199, 211, 234, 0.12) inset;
+}

--- a/frontend/apps/console/src/features/flows/components/resources/steps/execution/ExecutionStack.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/steps/execution/ExecutionStack.tsx
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Box, Typography} from '@wso2/oxygen-ui';
+import {Handle, Position, useNodeId, type NodeProps} from '@xyflow/react';
+import {useContext, useMemo, type CSSProperties, type KeyboardEvent, type ReactElement} from 'react';
+import {useTranslation} from 'react-i18next';
+import ResourceDisplayImage from '@/features/flows/components/ResourceDisplayImage';
+import ValidationErrorBoundary from '@/features/flows/components/validation-panel/ValidationErrorBoundary';
+import VisualFlowConstants from '@/features/flows/constants/VisualFlowConstants';
+import CompactStacksContext from '@/features/flows/context/CompactStacksContext';
+import useValidationStatus from '@/features/flows/hooks/useValidationStatus';
+import type {Resource} from '@/features/flows/models/resources';
+import type {StepData} from '@/features/flows/models/steps';
+import {
+  EXECUTION_STACK_MAX_LAYERS,
+  type ExecutionStackData,
+  type ExecutionStackMember,
+} from '@/features/flows/utils/compactGraphTransforms';
+import './ExecutionStack.scss';
+
+interface MemberDisplay {
+  description?: string;
+  image?: string;
+  label: string;
+  preserveImageColor?: boolean;
+}
+
+const resolveMemberDisplay = (member: ExecutionStackMember): MemberDisplay => {
+  const data = member.data as StepData | undefined;
+  const display = data?.display as MemberDisplay | undefined;
+  const executorName = (data?.action as {executor?: {name?: string}} | undefined)?.executor?.name;
+  return {
+    description: display?.description,
+    image: display?.image,
+    label: display?.label ?? executorName ?? 'Executor',
+    preserveImageColor: display?.preserveImageColor,
+  };
+};
+
+/**
+ * Execution (Stack) Node component. Rendered in compact (non-verbose) mode in
+ * place of a run of consecutive non-branching executors: one chip showing the
+ * first executor's icon with a "+N" count inside, a card-deck effect behind,
+ * and a hover preview fanning the stacked members out to the right. Clicking
+ * expands the stack into its individual member chips. A single in/out edge
+ * anchor pair is kept.
+ *
+ * @param props - Props injected to the component.
+ * @returns Execution (Stack) node component.
+ */
+function ExecutionStack({data}: NodeProps): ReactElement {
+  const {expandStack} = useContext(CompactStacksContext);
+  const {notifications} = useValidationStatus();
+  const stackId: string | null = useNodeId();
+  const {t} = useTranslation();
+
+  const stackData = data as ExecutionStackData | undefined;
+  const members = useMemo(() => stackData?.members ?? [], [stackData]);
+
+  // Collapsing hides the members' own error boundaries, so the stack surfaces
+  // the first member that has a notification. Expanding it then shows exactly
+  // which executor is at fault.
+  const notifiedMemberId = useMemo(
+    () => members.find((member) => notifications.some((notification) => notification.hasResource(member.id)))?.id,
+    [members, notifications],
+  );
+  const headMember = members.at(0);
+  const headDisplay = headMember ? resolveMemberDisplay(headMember) : undefined;
+  const stackedCount = Math.max(members.length - 1, 0);
+  const layerCount = Math.min(stackedCount, EXECUTION_STACK_MAX_LAYERS);
+
+  const handleExpand = (): void => {
+    if (stackId) {
+      expandStack(
+        stackId,
+        members.map((member) => member.id),
+      );
+    }
+  };
+
+  return (
+    <ValidationErrorBoundary resource={{id: notifiedMemberId ?? stackId ?? ''} as Resource}>
+      <Box className="execution-stack-step">
+        <Box
+          className="execution-stack-step-content"
+          role="button"
+          tabIndex={0}
+          aria-label={members.map((member) => resolveMemberDisplay(member).label).join(', ')}
+          aria-expanded={false}
+          title={t('flows:core.executions.stack.expandHint', 'Click to expand')}
+          onClick={handleExpand}
+          // A div with role="button" gets no native Enter/Space activation, so
+          // the stack would be focusable but impossible to expand by keyboard.
+          onKeyDown={(event: KeyboardEvent<HTMLElement>) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              handleExpand();
+            }
+          }}
+        >
+          {Array.from({length: layerCount}, (_, index) => (
+            <Box key={index} className={`execution-stack-layer execution-stack-layer-${index + 1}`} />
+          ))}
+          {/* Hover preview: the stacked members slide out of the deck to the
+            right. The main chip itself stays put; only its color changes. */}
+          {members.slice(1).map((member, index) => {
+            const display = resolveMemberDisplay(member);
+            return (
+              <Box key={member.id} className="execution-stack-fan-chip" style={{'--fan-index': index} as CSSProperties}>
+                {display.image ? (
+                  <ResourceDisplayImage
+                    image={display.image}
+                    label={display.label}
+                    size={16}
+                    preserveColor={display.preserveImageColor}
+                  />
+                ) : (
+                  <Typography variant="caption" className="execution-stack-chip-fallback">
+                    {display.label.charAt(0).toUpperCase()}
+                  </Typography>
+                )}
+              </Box>
+            );
+          })}
+          <Box className="execution-stack-chip">
+            {headDisplay?.image ? (
+              <ResourceDisplayImage
+                image={headDisplay.image}
+                label={headDisplay.label}
+                size={stackedCount > 0 ? 18 : 24}
+                preserveColor={headDisplay.preserveImageColor}
+              />
+            ) : (
+              <Typography variant="subtitle1" className="execution-stack-chip-fallback">
+                {(headDisplay?.label ?? 'Executor').charAt(0).toUpperCase()}
+              </Typography>
+            )}
+            {stackedCount > 0 && (
+              <Typography variant="caption" className="execution-stack-badge" data-testid="execution-stack-badge">
+                +{stackedCount}
+              </Typography>
+            )}
+          </Box>
+        </Box>
+        <Handle type="target" position={Position.Left} />
+        <Handle
+          type="source"
+          position={Position.Right}
+          id={`${stackId ?? ''}${VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX}`}
+        />
+      </Box>
+    </ValidationErrorBoundary>
+  );
+}
+
+export default ExecutionStack;

--- a/frontend/apps/console/src/features/flows/components/resources/steps/execution/__tests__/Execution.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/steps/execution/__tests__/Execution.test.tsx
@@ -39,8 +39,15 @@ vi.mock('@/features/flows/hooks/useInteractionState', () => ({
   }),
 }));
 
+// Mock useFlowConfig (verbose by default; compact-mode tests flip it)
+const mockUseFlowConfig = vi.fn(() => ({isVerboseMode: true}));
+
+vi.mock('@/features/flows/hooks/useFlowConfig', () => ({
+  default: () => mockUseFlowConfig(),
+}));
+
 // Mock ValidationErrorBoundary
-vi.mock('../../../validation-panel/ValidationErrorBoundary', () => ({
+vi.mock('../../../../validation-panel/ValidationErrorBoundary', () => ({
   default: ({children, resource}: {children: React.ReactNode; resource: unknown}) => (
     <div data-testid="validation-error-boundary" data-resource={JSON.stringify(resource)}>
       {children}
@@ -84,6 +91,15 @@ vi.mock('../../view/View', () => ({
   },
 }));
 
+// Mock ExecutionCompact component
+vi.mock('../ExecutionCompact', () => ({
+  default: ({resource}: {resource: {display?: {label?: string}}}) => (
+    <div data-testid="execution-compact" data-label={resource?.display?.label}>
+      Execution Compact: {resource?.display?.label}
+    </div>
+  ),
+}));
+
 // Mock ExecutionMinimal component
 vi.mock('../ExecutionMinimal', () => ({
   default: ({resource}: {resource: {display?: {label?: string; description?: string; outcomes?: unknown}}}) => (
@@ -122,6 +138,75 @@ describe('Execution', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseNodeId.mockReturnValue('execution-node-id');
+    mockUseFlowConfig.mockReturnValue({isVerboseMode: true});
+  });
+
+  describe('Compact Mode', () => {
+    beforeEach(() => {
+      mockUseFlowConfig.mockReturnValue({isVerboseMode: false});
+    });
+
+    it('should render ExecutionCompact instead of ExecutionMinimal when verbose mode is off', () => {
+      render(
+        <Execution
+          {...createMockProps({
+            data: {
+              action: {executor: {name: 'Simple Executor'}},
+              components: [],
+            },
+          })}
+        />,
+      );
+
+      expect(screen.getByTestId('execution-compact')).toBeInTheDocument();
+      expect(screen.queryByTestId('execution-minimal')).not.toBeInTheDocument();
+    });
+
+    it('should render ExecutionCompact instead of View when verbose mode is off and data has components', () => {
+      render(
+        <Execution
+          {...createMockProps({
+            data: {
+              action: {executor: {name: 'Google OAuth'}},
+              components: [{id: 'comp-1', type: 'BUTTON'}],
+            },
+          })}
+        />,
+      );
+
+      expect(screen.getByTestId('execution-compact')).toBeInTheDocument();
+      expect(screen.queryByTestId('view-component')).not.toBeInTheDocument();
+    });
+
+    it('should keep the compact node wrapped in ValidationErrorBoundary', () => {
+      render(
+        <Execution
+          {...createMockProps({
+            data: {
+              action: {executor: {name: 'Compact Executor'}},
+            },
+          })}
+        />,
+      );
+
+      const boundary = screen.getByTestId('validation-error-boundary');
+      expect(boundary).toContainElement(screen.getByTestId('execution-compact'));
+    });
+
+    it('should pass the resolved display label to ExecutionCompact', () => {
+      render(
+        <Execution
+          {...createMockProps({
+            data: {
+              action: {executor: {name: 'Default Name'}},
+              display: {label: 'Custom Label'},
+            },
+          })}
+        />,
+      );
+
+      expect(screen.getByTestId('execution-compact')).toHaveAttribute('data-label', 'Custom Label');
+    });
   });
 
   describe('Rendering with Components', () => {

--- a/frontend/apps/console/src/features/flows/components/resources/steps/execution/__tests__/ExecutionCompact.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/steps/execution/__tests__/ExecutionCompact.test.tsx
@@ -1,0 +1,391 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen, fireEvent} from '@testing-library/react';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import ExecutionCompact from '../ExecutionCompact';
+import CompactStacksContext from '@/features/flows/context/CompactStacksContext';
+import type {Step} from '@/features/flows/models/steps';
+
+// Mock @xyflow/react
+const mockUseNodeId = vi.fn((): string | null => 'execution-node-id');
+
+vi.mock('@xyflow/react', () => ({
+  useNodeId: () => mockUseNodeId(),
+  Handle: ({
+    type,
+    position,
+    id = '',
+    className = '',
+  }: {
+    type: string;
+    position: string;
+    id?: string;
+    className?: string;
+  }) => (
+    <div
+      data-testid={`handle-${type}${className ? `-${className}` : ''}`}
+      data-position={position}
+      data-id={id}
+      data-classname={className}
+    />
+  ),
+  Position: {
+    Left: 'left',
+    Right: 'right',
+    Top: 'top',
+    Bottom: 'bottom',
+  },
+}));
+
+// Mock useInteractionState
+const mockSetLastInteractedResource = vi.fn();
+const mockSetLastInteractedStepId = vi.fn();
+
+vi.mock('@/features/flows/hooks/useInteractionState', () => ({
+  default: () => ({
+    setLastInteractedResource: mockSetLastInteractedResource,
+    setLastInteractedStepId: mockSetLastInteractedStepId,
+  }),
+}));
+
+// Mock useUIPanelState
+const mockSetIsOpenResourcePropertiesPanel = vi.fn();
+
+vi.mock('@/features/flows/hooks/useUIPanelState', () => ({
+  default: () => ({
+    setIsOpenResourcePropertiesPanel: mockSetIsOpenResourcePropertiesPanel,
+  }),
+}));
+
+// Mock react-i18next
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+
+// Mock ResourceDisplayImage
+vi.mock('@/features/flows/components/ResourceDisplayImage', () => ({
+  default: ({image, label}: {image?: string; label?: string}) => (
+    <div data-testid="resource-display-image" data-image={image} data-label={label} />
+  ),
+}));
+
+// Mock VisualFlowConstants
+vi.mock('@/features/flows/constants/VisualFlowConstants', () => ({
+  default: {
+    FLOW_BUILDER_NEXT_HANDLE_SUFFIX: '-next',
+    FLOW_BUILDER_INCOMPLETE_HANDLE_SUFFIX: '-incomplete',
+  },
+}));
+
+// Create mock resource
+const createMockResource = (overrides: Partial<Step> = {}): Step =>
+  ({
+    id: 'execution-1',
+    type: 'TASK_EXECUTION',
+    position: {x: 0, y: 0},
+    size: {width: 48, height: 48},
+    display: {
+      label: 'Test Executor',
+      image: 'test-image.svg',
+      showOnResourcePanel: true,
+    },
+    data: {
+      action: {
+        executor: {
+          name: 'TestExecutor',
+        },
+      },
+      config: {
+        testConfig: 'value',
+      },
+    },
+    config: {},
+    ...overrides,
+  }) as Step;
+
+describe('ExecutionCompact', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseNodeId.mockReturnValue('execution-node-id');
+  });
+
+  describe('Rendering', () => {
+    it('should render the chip with the display label as accessible name', () => {
+      const resource = createMockResource();
+      render(<ExecutionCompact resource={resource} />);
+
+      expect(screen.getByRole('button', {name: 'Test Executor'})).toBeInTheDocument();
+    });
+
+    it('should render the executor icon when display.image is set', () => {
+      const resource = createMockResource();
+      render(<ExecutionCompact resource={resource} />);
+
+      const image = screen.getByTestId('resource-display-image');
+      expect(image).toHaveAttribute('data-image', 'test-image.svg');
+    });
+
+    it('should render the first letter of the label when there is no display image', () => {
+      const resource = createMockResource({
+        display: {label: 'Passkey Challenge', image: '', showOnResourcePanel: true},
+      });
+      render(<ExecutionCompact resource={resource} />);
+
+      expect(screen.queryByTestId('resource-display-image')).not.toBeInTheDocument();
+      expect(screen.getByText('P')).toBeInTheDocument();
+    });
+
+    it('should fallback to executor name when display.label is not provided', () => {
+      const resource = createMockResource({
+        display: undefined,
+        data: {action: {executor: {name: 'FallbackExecutor'}}},
+      });
+      render(<ExecutionCompact resource={resource} />);
+
+      expect(screen.getByRole('button', {name: 'FallbackExecutor'})).toBeInTheDocument();
+    });
+
+    it('should fallback to "Executor" when both display.label and executor name are missing', () => {
+      const resource = createMockResource({display: undefined, data: {}});
+      render(<ExecutionCompact resource={resource} />);
+
+      expect(screen.getByRole('button', {name: 'Executor'})).toBeInTheDocument();
+    });
+
+    it('should reveal label and description in a tooltip on hover', async () => {
+      const resource = createMockResource({
+        display: {
+          label: 'Check SSO Session',
+          description: 'Can the following authentication be skipped?',
+          image: '',
+          showOnResourcePanel: true,
+        },
+      });
+      render(<ExecutionCompact resource={resource} />);
+
+      fireEvent.mouseOver(screen.getByRole('button', {name: 'Check SSO Session'}));
+
+      expect(await screen.findByText('Check SSO Session')).toBeInTheDocument();
+      expect(await screen.findByText('Can the following authentication be skipped?')).toBeInTheDocument();
+    });
+  });
+
+  describe('Handles', () => {
+    it('should render target handle on the left without an id', () => {
+      const resource = createMockResource();
+      render(<ExecutionCompact resource={resource} />);
+
+      const targetHandle = screen.getByTestId('handle-target');
+      expect(targetHandle).toHaveAttribute('data-position', 'left');
+      expect(targetHandle).toHaveAttribute('data-id', '');
+    });
+
+    it('should render source handle on the right with the next-suffixed id', () => {
+      const resource = createMockResource({id: 'test-execution'});
+      render(<ExecutionCompact resource={resource} />);
+
+      const sourceHandle = screen.getByTestId('handle-source');
+      expect(sourceHandle).toHaveAttribute('data-position', 'right');
+      expect(sourceHandle).toHaveAttribute('data-id', 'test-execution-next');
+    });
+
+    it('should render success and failure handles when onFailure property exists', () => {
+      const resource = createMockResource({
+        data: {
+          action: {executor: {name: 'TestExecutor'}, onSuccess: '', onFailure: ''},
+        },
+      });
+      render(<ExecutionCompact resource={resource} />);
+
+      expect(screen.getByTestId('handle-source-execution-handle-success')).toBeInTheDocument();
+      const failureHandle = screen.getByTestId('handle-source-execution-handle-failure');
+      expect(failureHandle).toHaveAttribute('data-position', 'bottom');
+      expect(failureHandle).toHaveAttribute('data-id', 'failure');
+    });
+
+    it('should not render failure handle when onFailure is not present', () => {
+      const resource = createMockResource({
+        data: {action: {executor: {name: 'TestExecutor'}, onSuccess: ''}},
+      });
+      render(<ExecutionCompact resource={resource} />);
+
+      expect(screen.queryByTestId('handle-source-execution-handle-failure')).not.toBeInTheDocument();
+    });
+
+    it('should render incomplete handle on top with the incomplete-suffixed id when onIncomplete exists', () => {
+      const resource = createMockResource({
+        id: 'test-execution',
+        data: {action: {executor: {name: 'TestExecutor'}, onIncomplete: ''}},
+      });
+      render(<ExecutionCompact resource={resource} />);
+
+      const incompleteHandle = screen.getByTestId('handle-source-execution-handle-incomplete');
+      expect(incompleteHandle).toHaveAttribute('data-position', 'top');
+      expect(incompleteHandle).toHaveAttribute('data-id', 'test-execution-incomplete');
+    });
+
+    it('should not render incomplete handle when onIncomplete is missing', () => {
+      const resource = createMockResource({
+        data: {action: {executor: {name: 'TestExecutor'}, onSuccess: ''}},
+      });
+      render(<ExecutionCompact resource={resource} />);
+
+      expect(screen.queryByTestId('handle-source-execution-handle-incomplete')).not.toBeInTheDocument();
+    });
+
+    it('should use custom outcome labels from display.outcomes', () => {
+      const resource = createMockResource({
+        display: {
+          label: 'SSO Check',
+          image: '',
+          showOnResourcePanel: true,
+          outcomes: {success: 'Available', failure: 'Unavailable'},
+        },
+        data: {
+          action: {executor: {name: 'SSOCheckExecutor'}, onSuccess: '', onFailure: ''},
+        },
+      });
+      render(<ExecutionCompact resource={resource} />);
+
+      expect(screen.getByLabelText('Available')).toBeInTheDocument();
+      expect(screen.getByLabelText('Unavailable')).toBeInTheDocument();
+    });
+  });
+
+  describe('Chip Click', () => {
+    it('should set last interacted step id when the chip is clicked', () => {
+      const resource = createMockResource();
+      render(<ExecutionCompact resource={resource} />);
+
+      fireEvent.click(screen.getByRole('button', {name: 'Test Executor'}));
+
+      expect(mockSetLastInteractedStepId).toHaveBeenCalledWith('execution-node-id');
+    });
+
+    it('should set last interacted resource with merged config when the chip is clicked', () => {
+      const resource = createMockResource({
+        config: {field: {name: 'test', type: 'TEXT'}, styles: {}} as unknown as Step['config'],
+        data: {
+          action: {executor: {name: 'Test'}},
+          config: {dataConfig: 'dataValue'},
+        },
+      });
+      render(<ExecutionCompact resource={resource} />);
+
+      fireEvent.click(screen.getByRole('button', {name: 'Test Executor'}));
+
+      expect(mockSetLastInteractedResource).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({
+            dataConfig: 'dataValue',
+            field: {name: 'test', type: 'TEXT'},
+          }) as Record<string, unknown>,
+        }),
+      );
+    });
+
+    it('should open the resource properties panel when the chip is clicked', () => {
+      const resource = createMockResource();
+      render(<ExecutionCompact resource={resource} />);
+
+      fireEvent.click(screen.getByRole('button', {name: 'Test Executor'}));
+
+      expect(mockSetIsOpenResourcePropertiesPanel).toHaveBeenCalledWith(true);
+    });
+
+    it('should open the properties panel on Enter and Space', () => {
+      const resource = createMockResource();
+      render(<ExecutionCompact resource={resource} />);
+      const chip = screen.getByRole('button', {name: 'Test Executor'});
+
+      // The chip is a div with role="button", so it has no native activation.
+      fireEvent.keyDown(chip, {key: 'Enter'});
+      expect(mockSetIsOpenResourcePropertiesPanel).toHaveBeenCalledTimes(1);
+
+      fireEvent.keyDown(chip, {key: ' '});
+      expect(mockSetIsOpenResourcePropertiesPanel).toHaveBeenCalledTimes(2);
+    });
+
+    it('should ignore other keys', () => {
+      const resource = createMockResource();
+      render(<ExecutionCompact resource={resource} />);
+
+      fireEvent.keyDown(screen.getByRole('button', {name: 'Test Executor'}), {key: 'a'});
+
+      expect(mockSetIsOpenResourcePropertiesPanel).not.toHaveBeenCalled();
+    });
+
+    it('should not set step id when useNodeId returns null', () => {
+      mockUseNodeId.mockReturnValue(null);
+      const resource = createMockResource();
+      render(<ExecutionCompact resource={resource} />);
+
+      fireEvent.click(screen.getByRole('button', {name: 'Test Executor'}));
+
+      expect(mockSetLastInteractedStepId).not.toHaveBeenCalled();
+      expect(mockSetIsOpenResourcePropertiesPanel).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('Restack Affordance', () => {
+    const mockCollapseStack = vi.fn();
+
+    const renderWithExpandedGroup = (headId: string) =>
+      render(
+        <CompactStacksContext.Provider
+          value={{
+            collapseStack: mockCollapseStack,
+            expandStack: vi.fn(),
+            expandedHeadIdToStackId: new Map([[headId, `execution-stack_${headId}`]]),
+          }}
+        >
+          <ExecutionCompact resource={createMockResource()} />
+        </CompactStacksContext.Provider>,
+      );
+
+    it('should not show the restack button outside an expanded group', () => {
+      render(<ExecutionCompact resource={createMockResource()} />);
+
+      expect(screen.queryByRole('button', {name: 'Restack executors'})).not.toBeInTheDocument();
+    });
+
+    it('should show the restack button on the head chip of an expanded group', () => {
+      renderWithExpandedGroup('execution-node-id');
+
+      expect(screen.getByRole('button', {name: 'Restack executors'})).toBeInTheDocument();
+    });
+
+    it('should collapse the stack without opening the properties panel when restack is clicked', () => {
+      renderWithExpandedGroup('execution-node-id');
+
+      fireEvent.click(screen.getByRole('button', {name: 'Restack executors'}));
+
+      expect(mockCollapseStack).toHaveBeenCalledWith('execution-stack_execution-node-id');
+      expect(mockSetIsOpenResourcePropertiesPanel).not.toHaveBeenCalled();
+    });
+
+    it('should not show the restack button on non-head chips', () => {
+      renderWithExpandedGroup('some-other-node');
+
+      expect(screen.queryByRole('button', {name: 'Restack executors'})).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/apps/console/src/features/flows/components/resources/steps/execution/__tests__/ExecutionStack.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/steps/execution/__tests__/ExecutionStack.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {render, screen, fireEvent} from '@testing-library/react';
+import type {NodeProps} from '@xyflow/react';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import ExecutionStack from '../ExecutionStack';
+import CompactStacksContext from '@/features/flows/context/CompactStacksContext';
+
+// Mock @xyflow/react
+const mockUseNodeId = vi.fn((): string | null => 'execution-stack_exec-a');
+
+vi.mock('@xyflow/react', () => ({
+  useNodeId: () => mockUseNodeId(),
+  Handle: ({type, position, id = ''}: {type: string; position: string; id?: string}) => (
+    <div data-testid={`handle-${type}`} data-position={position} data-id={id} />
+  ),
+  Position: {
+    Left: 'left',
+    Right: 'right',
+    Top: 'top',
+    Bottom: 'bottom',
+  },
+}));
+
+// Mock react-i18next
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}));
+
+// Mock ResourceDisplayImage
+vi.mock('@/features/flows/components/ResourceDisplayImage', () => ({
+  default: ({image, label}: {image?: string; label?: string}) => (
+    <div data-testid="resource-display-image" data-image={image} data-label={label} />
+  ),
+}));
+
+// Mock VisualFlowConstants
+vi.mock('@/features/flows/constants/VisualFlowConstants', () => ({
+  default: {
+    FLOW_BUILDER_COMPACT_EXECUTION_NODE_SIZE: 48,
+    FLOW_BUILDER_NEXT_HANDLE_SUFFIX: '-next',
+    FLOW_BUILDER_INCOMPLETE_HANDLE_SUFFIX: '-incomplete',
+    FLOW_BUILDER_PREVIOUS_HANDLE_SUFFIX: '-previous',
+  },
+}));
+
+// Mock useValidationStatus with a settable notification list
+const mockNotifications: {hasResource: (id: string) => boolean; getType: () => string}[] = [];
+
+vi.mock('@/features/flows/hooks/useValidationStatus', () => ({
+  default: () => ({notifications: mockNotifications}),
+}));
+
+// Mock ValidationErrorBoundary so the resource it receives is observable
+vi.mock('@/features/flows/components/validation-panel/ValidationErrorBoundary', () => ({
+  default: ({children, resource}: {children: React.ReactNode; resource: {id: string}}) => (
+    <div data-testid="validation-error-boundary" data-resource-id={resource.id}>
+      {children}
+    </div>
+  ),
+}));
+
+const mockExpandStack = vi.fn();
+const mockCollapseStack = vi.fn();
+
+const member = (id: string, label: string, extras: Record<string, unknown> = {}) => ({
+  data: {
+    action: {executor: {name: `${id}-executor`}},
+    display: {label},
+    ...extras,
+  },
+  id,
+});
+
+const renderStack = (members: ReturnType<typeof member>[]) =>
+  render(
+    <CompactStacksContext.Provider
+      value={{
+        collapseStack: mockCollapseStack,
+        expandStack: mockExpandStack,
+        expandedHeadIdToStackId: new Map<string, string>(),
+      }}
+    >
+      <ExecutionStack {...({data: {memberIds: members.map((m) => m.id), members}} as unknown as NodeProps)} />
+    </CompactStacksContext.Provider>,
+  );
+
+describe('ExecutionStack', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseNodeId.mockReturnValue('execution-stack_exec-a');
+    mockNotifications.length = 0;
+  });
+
+  describe('Validation', () => {
+    it('should surface a stacked member that has a notification', () => {
+      mockNotifications.push({getType: () => 'ERROR', hasResource: (id: string) => id === 'exec-b'});
+
+      renderStack([member('exec-a', 'One'), member('exec-b', 'Two')]);
+
+      // The hidden member's error is raised onto the collapsed stack.
+      expect(screen.getByTestId('validation-error-boundary')).toHaveAttribute('data-resource-id', 'exec-b');
+    });
+
+    it('should fall back to the stack id when no member has a notification', () => {
+      renderStack([member('exec-a', 'One'), member('exec-b', 'Two')]);
+
+      expect(screen.getByTestId('validation-error-boundary')).toHaveAttribute(
+        'data-resource-id',
+        'execution-stack_exec-a',
+      );
+    });
+  });
+
+  it('should render one chip with the member labels as accessible name', () => {
+    renderStack([member('exec-a', 'Attribute Collector'), member('exec-b', 'Send OTP')]);
+
+    expect(screen.getByRole('button', {name: 'Attribute Collector, Send OTP'})).toBeInTheDocument();
+  });
+
+  it('should render only the first member icon on the main chip', () => {
+    const {container} = renderStack([
+      member('exec-a', 'Attribute Collector', {display: {label: 'Attribute Collector', image: 'collector.svg'}}),
+      member('exec-b', 'Send OTP', {display: {label: 'Send OTP', image: 'otp.svg'}}),
+    ]);
+
+    const chipImages = [...container.querySelectorAll('.execution-stack-chip [data-testid="resource-display-image"]')];
+    expect(chipImages).toHaveLength(1);
+    expect(chipImages[0]).toHaveAttribute('data-image', 'collector.svg');
+  });
+
+  it('should show a +N badge counting the stacked members after the first', () => {
+    renderStack([member('a', 'One'), member('b', 'Two'), member('c', 'Three')]);
+
+    expect(screen.getByTestId('execution-stack-badge')).toHaveTextContent('+2');
+  });
+
+  it('should not show a badge for a single member', () => {
+    renderStack([member('a', 'One')]);
+
+    expect(screen.queryByTestId('execution-stack-badge')).not.toBeInTheDocument();
+  });
+
+  it('should cap the deck layers while the badge keeps the full count', () => {
+    const {container} = renderStack([
+      member('a', 'One'),
+      member('b', 'Two'),
+      member('c', 'Three'),
+      member('d', 'Four'),
+      member('e', 'Five'),
+    ]);
+
+    expect(container.querySelectorAll('.execution-stack-layer')).toHaveLength(2);
+    expect(screen.getByTestId('execution-stack-badge')).toHaveTextContent('+4');
+  });
+
+  it('should render a hover fan chip for every stacked member after the first', () => {
+    const {container} = renderStack([member('a', 'One'), member('b', 'Two'), member('c', 'Three')]);
+
+    expect(container.querySelectorAll('.execution-stack-fan-chip')).toHaveLength(2);
+  });
+
+  it('should expand the stack on click', () => {
+    renderStack([member('exec-a', 'Attribute Collector'), member('exec-b', 'Send OTP')]);
+
+    fireEvent.click(screen.getByRole('button', {name: 'Attribute Collector, Send OTP'}));
+
+    expect(mockExpandStack).toHaveBeenCalledWith('execution-stack_exec-a', ['exec-a', 'exec-b']);
+  });
+
+  it('should expand on Enter and Space', () => {
+    renderStack([member('exec-a', 'Attribute Collector'), member('exec-b', 'Send OTP')]);
+    const chip = screen.getByRole('button', {name: 'Attribute Collector, Send OTP'});
+
+    // The chip is a div with role="button", so it has no native activation.
+    fireEvent.keyDown(chip, {key: 'Enter'});
+    expect(mockExpandStack).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(chip, {key: ' '});
+    expect(mockExpandStack).toHaveBeenCalledTimes(2);
+  });
+
+  it('should ignore other keys', () => {
+    renderStack([member('exec-a', 'Attribute Collector'), member('exec-b', 'Send OTP')]);
+
+    fireEvent.keyDown(screen.getByRole('button', {name: 'Attribute Collector, Send OTP'}), {key: 'a'});
+
+    expect(mockExpandStack).not.toHaveBeenCalled();
+  });
+
+  it('should not expand when the node id is unavailable', () => {
+    mockUseNodeId.mockReturnValue(null);
+    renderStack([member('exec-a', 'Attribute Collector'), member('exec-b', 'Send OTP')]);
+
+    fireEvent.click(screen.getByRole('button', {name: 'Attribute Collector, Send OTP'}));
+
+    expect(mockExpandStack).not.toHaveBeenCalled();
+  });
+
+  it('should render target and next-suffixed source handles', () => {
+    renderStack([member('exec-a', 'One'), member('exec-b', 'Two')]);
+
+    expect(screen.getByTestId('handle-target')).toHaveAttribute('data-position', 'left');
+    const sourceHandle = screen.getByTestId('handle-source');
+    expect(sourceHandle).toHaveAttribute('data-position', 'right');
+    expect(sourceHandle).toHaveAttribute('data-id', 'execution-stack_exec-a-next');
+  });
+});

--- a/frontend/apps/console/src/features/flows/components/visual-flow/CanvasToolbar.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/CanvasToolbar.tsx
@@ -17,7 +17,7 @@
  */
 
 import {Box, IconButton, Tooltip} from '@wso2/oxygen-ui';
-import {LayoutGrid, Maximize, Minus, Plus, Redo2, Undo2} from '@wso2/oxygen-ui-icons-react';
+import {Expand, LayoutGrid, Maximize, Minus, Plus, Redo2, Shrink, Undo2} from '@wso2/oxygen-ui-icons-react';
 import {useReactFlow} from '@xyflow/react';
 import {type ReactElement} from 'react';
 import {useTranslation} from 'react-i18next';
@@ -51,7 +51,7 @@ export default function CanvasToolbar({
 }: CanvasToolbarProps): ReactElement {
   const {t} = useTranslation();
   const {fitView, zoomIn, zoomOut} = useReactFlow();
-  const {edgeStyle} = useFlowConfig();
+  const {edgeStyle, isVerboseMode, setIsVerboseMode} = useFlowConfig();
   const {anchorEl, handleClick: handleEdgeStyleClick, handleClose: handleEdgeStyleClose} = useEdgeStyleSelector();
 
   const showHistoryControls = Boolean(onUndo ?? onRedo);
@@ -131,6 +131,29 @@ export default function CanvasToolbar({
             aria-expanded={Boolean(anchorEl)}
           >
             {getEdgeStyleIcon(edgeStyle)}
+          </IconButton>
+        </Tooltip>
+
+        <ToolbarDivider />
+
+        <Tooltip
+          title={
+            isVerboseMode
+              ? t('flows:core.headerPanel.compactViewTooltip', 'Switch to compact view')
+              : t('flows:core.headerPanel.detailedViewTooltip', 'Switch to detailed view')
+          }
+        >
+          <IconButton
+            size="small"
+            onClick={() => setIsVerboseMode((prev) => !prev)}
+            sx={{borderRadius: 1, color: 'text.secondary'}}
+            // The name stays fixed because `aria-pressed` already carries the
+            // state; an action name that flips with it would announce
+            // "switch to detailed view, pressed" while compact view is on.
+            aria-label={t('flows:core.headerPanel.compactView', 'Compact view')}
+            aria-pressed={!isVerboseMode}
+          >
+            {isVerboseMode ? <Shrink size={16} /> : <Expand size={16} />}
           </IconButton>
         </Tooltip>
 

--- a/frontend/apps/console/src/features/flows/components/visual-flow/DecoratedVisualFlow.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/DecoratedVisualFlow.tsx
@@ -74,10 +74,11 @@ import {BlockTypes, type Element} from '../../models/elements';
 import type {MetadataInterface} from '../../models/metadata';
 import Notification, {NotificationType} from '../../models/notification';
 import {ResourceTypes, type Resource, type Resources} from '../../models/resources';
-import {type Step, type StepData} from '../../models/steps';
+import {StepTypes, type Step, type StepData} from '../../models/steps';
 import {type Template} from '../../models/templates';
 import type {Widget} from '../../models/widget';
-import applyAutoLayout from '../../utils/applyAutoLayout';
+import applyAutoLayout, {hasUnpositionedNodes} from '../../utils/applyAutoLayout';
+import {EXECUTION_STACK_NODE_TYPE, getExecutionStackWidth} from '../../utils/compactGraphTransforms';
 import computeExecutorConnections from '../../utils/computeExecutorConnections';
 import generateResourceId from '../../utils/generateResourceId';
 import {resolveCollisions} from '../../utils/resolveCollisions';
@@ -105,6 +106,17 @@ export interface DecoratedVisualFlowPropsInterface extends Omit<VisualFlowPropsI
   initialEdges?: Edge[];
   nodes: Node[];
   edges: Edge[];
+  /**
+   * The untransformed graph nodes when `nodes` carries a display-only
+   * transform (compact-mode executor stacks). Used for validation syncing and
+   * persistence so hidden stack members are never lost. Defaults to `nodes`.
+   */
+  sourceNodes?: Node[];
+  /**
+   * The untransformed graph edges accompanying `sourceNodes`. Defaults to
+   * `edges`.
+   */
+  sourceEdges?: Edge[];
   mutateComponents: (components: Element[]) => Element[];
   onTemplateLoad: (template: Template) => [Node[], Edge[], Resource?, string?];
   onWidgetLoad: (
@@ -164,6 +176,8 @@ function DecoratedVisualFlow({
   resources,
   nodes,
   edges,
+  sourceNodes = undefined,
+  sourceEdges = undefined,
   setNodes,
   setEdges,
   onNodesChange,
@@ -197,7 +211,7 @@ function DecoratedVisualFlow({
   const {isResourcePanelOpen, isResourcePropertiesPanelOpen, setIsResourcePanelOpen, setIsOpenResourcePropertiesPanel} =
     useUIPanelState();
   const {notifyElementAdded, onAutoLayout} = useFlowEvents();
-  const {isFlowMetadataLoading, metadata, setFlowNodes} = useFlowConfig();
+  const {isFlowMetadataLoading, isVerboseMode, metadata, setFlowNodes} = useFlowConfig();
   const {onResourceDropOnCanvas} = useInteractionState();
 
   // Sync controlled nodes to the shared FlowConfig context so that
@@ -209,10 +223,13 @@ function DecoratedVisualFlow({
   const prevNodeDataRefsRef = useRef<Map<string, unknown>>(new Map());
 
   useEffect(() => {
-    let dataChanged = nodes.length !== prevNodeDataRefsRef.current.size;
+    // Validation must see the real graph, not the compact display transform
+    // (which hides stacked executor members).
+    const validationNodes = sourceNodes ?? nodes;
+    let dataChanged = validationNodes.length !== prevNodeDataRefsRef.current.size;
 
     if (!dataChanged) {
-      for (const node of nodes) {
+      for (const node of validationNodes) {
         if (prevNodeDataRefsRef.current.get(node.id) !== node.data) {
           dataChanged = true;
           break;
@@ -222,13 +239,13 @@ function DecoratedVisualFlow({
 
     if (dataChanged) {
       const newRefs = new Map<string, unknown>();
-      for (const node of nodes) {
+      for (const node of validationNodes) {
         newRefs.set(node.id, node.data);
       }
       prevNodeDataRefsRef.current = newRefs;
-      setFlowNodes(nodes);
+      setFlowNodes(validationNodes);
     }
-  }, [nodes, setFlowNodes]);
+  }, [nodes, sourceNodes, setFlowNodes]);
   const {generateStepElement} = useGenerateStepElement();
   const {t} = useTranslation();
   const navigate = useNavigate();
@@ -327,25 +344,58 @@ function DecoratedVisualFlow({
   // styling so it is never persisted into the flow's layout data.
   const persistCanvas = useCallback((): void => {
     const {viewport} = toObject();
+    // Persist the real graph: in compact mode the canvas holds a display-only
+    // transform (executor stacks) that must never reach the flow definition.
     const canvasData = {
-      nodes: stripSimulationNodeClasses(getNodes()),
-      edges: stripSimulationEdgeClasses(getEdges()),
+      nodes: sourceNodes ?? stripSimulationNodeClasses(getNodes()),
+      edges: sourceEdges ?? stripSimulationEdgeClasses(getEdges()),
       viewport,
     };
     onSave?.(canvasData);
-  }, [toObject, getNodes, getEdges, onSave]);
+  }, [toObject, getNodes, getEdges, onSave, sourceNodes, sourceEdges]);
 
+  // The one auto-layout path for both the toolbar button and the compact
+  // toggle. It is mode-aware: compact mode uses tighter spacing and feeds the
+  // layout engine the known chip/stack sizes (which may not be measured yet
+  // right after a toggle), so re-running it in compact mode reproduces the
+  // same tight layout instead of rearranging with detailed-mode metrics.
   const handleAutoLayout = useCallback((): void => {
     const currentNodes = stripSimulationNodeClasses(getNodes());
     const currentEdges = getEdges();
-    applyAutoLayout(currentNodes, currentEdges, {
-      nodeSpacing: 100,
-      rankSpacing: 160,
-      offsetX: 50,
-      offsetY: 50,
-    })
+
+    const chipSize = VisualFlowConstants.FLOW_BUILDER_COMPACT_EXECUTION_NODE_SIZE;
+    const layoutNodes = isVerboseMode
+      ? currentNodes
+      : currentNodes.map((node) => {
+          if (node.type === StepTypes.Execution) {
+            return {...node, measured: {height: chipSize, width: chipSize}};
+          }
+          if (node.type === EXECUTION_STACK_NODE_TYPE) {
+            const memberCount = (node.data as {memberIds?: string[]} | undefined)?.memberIds?.length ?? 1;
+            return {...node, measured: {height: chipSize, width: getExecutionStackWidth(memberCount)}};
+          }
+          return node;
+        });
+
+    const spacing = isVerboseMode ? {nodeSpacing: 100, rankSpacing: 160} : {nodeSpacing: 60, rankSpacing: 80};
+
+    applyAutoLayout(layoutNodes, currentEdges, {...spacing, offsetX: 50, offsetY: 50})
       .then((layoutedNodes) => {
-        setNodes(layoutedNodes);
+        // Map positions back onto the graph state by id. Synthetic stack
+        // nodes expand onto their members so the state graph follows the
+        // display layout without ever absorbing display-only nodes.
+        const positionById = new Map<string, {x: number; y: number}>();
+        layoutedNodes.forEach((node) => {
+          positionById.set(node.id, node.position);
+          const memberIds = (node.data as {memberIds?: string[]} | undefined)?.memberIds;
+          memberIds?.forEach((memberId) => positionById.set(memberId, node.position));
+        });
+        setNodes((nodesNow) =>
+          nodesNow.map((node) => {
+            const position = positionById.get(node.id);
+            return position ? {...node, position} : node;
+          }),
+        );
         requestAnimationFrame(() => {
           fitView({padding: 0.2, duration: 300}).catch(() => {
             // Ignore fitView errors - layout is still applied
@@ -355,7 +405,27 @@ function DecoratedVisualFlow({
       .catch(() => {
         // Layout failed, keep original positions
       });
-  }, [getNodes, getEdges, setNodes, fitView]);
+  }, [getNodes, getEdges, setNodes, fitView, isVerboseMode]);
+
+  // Every compact/detailed toggle re-runs the shared auto-layout path above
+  // so the canvas always fits the size the nodes render at in the new mode.
+  // Two frames are awaited so the swapped node components are committed and
+  // re-measured before the layout reads their sizes (compact feeds explicit
+  // chip sizes; detailed relies on the fresh measurements).
+  const prevVerboseModeRef = useRef<boolean>(isVerboseMode);
+
+  useEffect(() => {
+    if (prevVerboseModeRef.current === isVerboseMode) {
+      return;
+    }
+    prevVerboseModeRef.current = isVerboseMode;
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        handleAutoLayout();
+      });
+    });
+  }, [isVerboseMode, handleAutoLayout]);
 
   // Track whether auto-layout has been triggered to prevent multiple triggers
   const autoLayoutTriggeredRef = useRef<boolean>(false);
@@ -376,14 +446,10 @@ function DecoratedVisualFlow({
       return;
     }
 
-    // Check if nodes need auto-layout by detecting if multiple nodes are at the same position
-    // (which happens when layout data is missing and all default to {x: 0, y: 0})
-    const nodesAtOrigin = currentNodes.filter((node) => node.position.x === 0 && node.position.y === 0);
-
-    // If more than one node is at the origin, we need auto-layout
-    const needsAutoLayout = nodesAtOrigin.length > 1;
-
-    if (needsAutoLayout) {
+    // Nodes need a layout when several sit at the origin, i.e. the flow was
+    // stored without layout data. FlowBuilder uses the same check to know the
+    // load-time layout is still pending, so it must stay shared.
+    if (hasUnpositionedNodes(currentNodes)) {
       autoLayoutTriggeredRef.current = true;
       // Delay slightly to ensure nodes are fully rendered with their measured dimensions
       requestAnimationFrame(() => {
@@ -483,6 +549,11 @@ function DecoratedVisualFlow({
       // especially in large flows viewed zoomed-out. Honors the simulation's
       // static-view toggle — no camera jumps when the user opted out.
       if (simulation.isSimulating && !simulation.followCamera) {
+        return;
+      }
+      // Clicking a stack expands it: the node disappears mid-animation, so
+      // focusing it would strand the viewport (the expansion re-layouts).
+      if (node.type === EXECUTION_STACK_NODE_TYPE) {
         return;
       }
       fitView({nodes: [{id: node.id}], padding: 0.3, maxZoom: 1.2, duration: 500}).catch(() => {
@@ -938,11 +1009,18 @@ function DecoratedVisualFlow({
                     // the filled Save button so it stays visible.
                     border: `2px solid ${theme.palette.background.default}`,
                     boxShadow: `0 0 0 1px ${theme.palette.primary.main}`,
+                  },
+                  // The pulse animates `transform`, and an animation outranks the
+                  // `scale(0)` MUI hides a badge with — running it unconditionally
+                  // would keep the dot on screen for a clean flow. It is scoped to
+                  // the visible state, and its keyframes carry MUI's own translate
+                  // so the dot stays anchored to the button's corner.
+                  '& .MuiBadge-badge:not(.MuiBadge-invisible)': {
                     animation: 'save-dirty-pulse 1.8s ease-in-out infinite',
                   },
                   '@keyframes save-dirty-pulse': {
-                    '0%, 100%': {transform: 'scale(1)', opacity: 1},
-                    '50%': {transform: 'scale(1.25)', opacity: 0.75},
+                    '0%, 100%': {transform: 'scale(1) translate(50%, -50%)', opacity: 1},
+                    '50%': {transform: 'scale(1.25) translate(50%, -50%)', opacity: 0.75},
                   },
                 })}
               >

--- a/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/CanvasToolbar.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/CanvasToolbar.test.tsx
@@ -205,4 +205,40 @@ describe('CanvasToolbar', () => {
     expect(onUndo).toHaveBeenCalledTimes(1);
     expect(onRedo).toHaveBeenCalledTimes(1);
   });
+
+  describe('Verbose mode toggle', () => {
+    const renderWithConfig = (overrides: Partial<FlowConfigContextProps>) =>
+      render(
+        <FlowConfigContext.Provider value={{...defaultFlowConfigValue, ...overrides}}>
+          <CanvasToolbar onAutoLayout={mockOnAutoLayout} />
+        </FlowConfigContext.Provider>,
+      );
+
+    it('should report the compact view as unpressed while in detailed (verbose) mode', () => {
+      renderWithConfig({isVerboseMode: true});
+
+      const toggle = screen.getByRole('button', {name: 'Compact view'});
+      expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('should report the compact view as pressed while in compact mode', () => {
+      renderWithConfig({isVerboseMode: false});
+
+      // The name stays put so the state is not announced twice, and inverted.
+      const toggle = screen.getByRole('button', {name: 'Compact view'});
+      expect(toggle).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('should flip the verbose mode when the toggle is clicked', () => {
+      const setIsVerboseMode = vi.fn();
+      renderWithConfig({isVerboseMode: true, setIsVerboseMode});
+
+      fireEvent.click(screen.getByRole('button', {name: 'Compact view'}));
+
+      expect(setIsVerboseMode).toHaveBeenCalledTimes(1);
+      const updater = setIsVerboseMode.mock.calls[0][0] as (prev: boolean) => boolean;
+      expect(updater(true)).toBe(false);
+      expect(updater(false)).toBe(true);
+    });
+  });
 });

--- a/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/DecoratedVisualFlow.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/DecoratedVisualFlow.test.tsx
@@ -45,9 +45,14 @@ vi.mock('../../../hooks/useUIPanelState', () => ({
   }),
 }));
 
+const {mockFlowConfigState} = vi.hoisted(() => ({
+  mockFlowConfigState: {isVerboseMode: true},
+}));
+
 vi.mock('../../../hooks/useFlowConfig', () => ({
   default: () => ({
     isFlowMetadataLoading: false,
+    isVerboseMode: mockFlowConfigState.isVerboseMode,
     metadata: undefined,
     setFlowNodes: vi.fn(),
   }),
@@ -130,7 +135,8 @@ const {mockApplyAutoLayout} = vi.hoisted(() => ({
   mockApplyAutoLayout: vi.fn().mockResolvedValue([]),
 }));
 
-vi.mock('../../../utils/applyAutoLayout', () => ({
+vi.mock('../../../utils/applyAutoLayout', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../utils/applyAutoLayout')>()),
   default: mockApplyAutoLayout,
 }));
 
@@ -375,6 +381,7 @@ describe('DecoratedVisualFlow', () => {
     vi.clearAllMocks();
     mockGetNodes.mockReturnValue([]);
     mockGetEdges.mockReturnValue([]);
+    mockFlowConfigState.isVerboseMode = true;
     // Reset applyAutoLayout to return a resolved promise by default
     mockApplyAutoLayout.mockResolvedValue([]);
     // Reset fitView to return a resolved promise by default
@@ -557,6 +564,100 @@ describe('DecoratedVisualFlow', () => {
 
       const autoLayoutButton = screen.getByTestId('auto-layout-trigger');
       fireEvent.click(autoLayoutButton);
+
+      await waitFor(() => {
+        expect(mockApplyAutoLayout).toHaveBeenCalled();
+      });
+    });
+
+    it('should use detailed spacing and measured sizes in verbose mode', async () => {
+      mockGetNodes.mockReturnValue([
+        {id: 'exec-1', type: 'TASK_EXECUTION', position: {x: 0, y: 0}, data: {}, measured: {width: 350, height: 140}},
+      ]);
+
+      renderComponent(<DecoratedVisualFlow {...defaultProps} />);
+      fireEvent.click(screen.getByTestId('auto-layout-trigger'));
+
+      await waitFor(() => {
+        expect(mockApplyAutoLayout).toHaveBeenCalled();
+      });
+      const [layoutNodes, , options] = mockApplyAutoLayout.mock.calls[0] as [Node[], Edge[], Record<string, number>];
+      expect(layoutNodes[0].measured).toEqual({width: 350, height: 140});
+      expect(options).toMatchObject({nodeSpacing: 100, rankSpacing: 160});
+    });
+
+    it('should use tight spacing and chip sizes in compact mode', async () => {
+      mockFlowConfigState.isVerboseMode = false;
+      mockGetNodes.mockReturnValue([
+        {id: 'exec-1', type: 'TASK_EXECUTION', position: {x: 0, y: 0}, data: {}, measured: {width: 350, height: 140}},
+        {
+          id: 'stack-1',
+          type: 'EXECUTION_STACK',
+          position: {x: 0, y: 0},
+          data: {memberIds: ['a', 'b', 'c'], members: []},
+        },
+      ]);
+
+      renderComponent(<DecoratedVisualFlow {...defaultProps} />);
+      fireEvent.click(screen.getByTestId('auto-layout-trigger'));
+
+      await waitFor(() => {
+        expect(mockApplyAutoLayout).toHaveBeenCalled();
+      });
+      const [layoutNodes, , options] = mockApplyAutoLayout.mock.calls[0] as [Node[], Edge[], Record<string, number>];
+      expect(layoutNodes[0].measured).toEqual({width: 48, height: 48});
+      // 3 members: 48 chip + 2 deck-layer offsets of 4
+      expect(layoutNodes[1].measured).toEqual({width: 56, height: 48});
+      expect(options).toMatchObject({nodeSpacing: 60, rankSpacing: 80});
+    });
+
+    it('should map stack positions back onto member nodes', async () => {
+      const setNodes = vi.fn();
+      mockGetNodes.mockReturnValue([
+        {id: 'stack-1', type: 'EXECUTION_STACK', position: {x: 0, y: 0}, data: {memberIds: ['a', 'b'], members: []}},
+      ]);
+      mockApplyAutoLayout.mockResolvedValue([
+        {id: 'stack-1', position: {x: 200, y: 300}, data: {memberIds: ['a', 'b'], members: []}},
+      ]);
+
+      renderComponent(<DecoratedVisualFlow {...defaultProps} setNodes={setNodes} />);
+      fireEvent.click(screen.getByTestId('auto-layout-trigger'));
+
+      await waitFor(() => {
+        expect(setNodes).toHaveBeenCalled();
+      });
+      const updater = setNodes.mock.calls[0][0] as (nodes: Node[]) => Node[];
+      const updated = updater([
+        {id: 'a', position: {x: 1, y: 1}, data: {}},
+        {id: 'b', position: {x: 2, y: 2}, data: {}},
+        {id: 'other', position: {x: 3, y: 3}, data: {}},
+      ]);
+      expect(updated[0].position).toEqual({x: 200, y: 300});
+      expect(updated[1].position).toEqual({x: 200, y: 300});
+      expect(updated[2].position).toEqual({x: 3, y: 3});
+    });
+  });
+
+  describe('Compact Mode Toggle', () => {
+    it('should run the shared auto layout when switching to compact mode', async () => {
+      const {rerender} = renderComponent(<DecoratedVisualFlow {...defaultProps} />);
+      expect(mockApplyAutoLayout).not.toHaveBeenCalled();
+
+      mockFlowConfigState.isVerboseMode = false;
+      rerender(<DecoratedVisualFlow {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(mockApplyAutoLayout).toHaveBeenCalled();
+      });
+    });
+
+    it('should run the shared auto layout when switching back to detailed mode', async () => {
+      mockFlowConfigState.isVerboseMode = false;
+      const {rerender} = renderComponent(<DecoratedVisualFlow {...defaultProps} />);
+      expect(mockApplyAutoLayout).not.toHaveBeenCalled();
+
+      mockFlowConfigState.isVerboseMode = true;
+      rerender(<DecoratedVisualFlow {...defaultProps} />);
 
       await waitFor(() => {
         expect(mockApplyAutoLayout).toHaveBeenCalled();

--- a/frontend/apps/console/src/features/flows/constants/VisualFlowConstants.ts
+++ b/frontend/apps/console/src/features/flows/constants/VisualFlowConstants.ts
@@ -54,6 +54,11 @@ class VisualFlowConstants {
 
   public static readonly FLOW_BUILDER_INCOMPLETE_HANDLE_SUFFIX: string = `_${ActionTypes.Incomplete}`;
 
+  // Rendered size of the circular executor chip in compact (non-verbose) mode.
+  // Must match the dimensions in ExecutionCompact.scss; used to feed the
+  // auto-layout engine the post-toggle node size before it is measured.
+  public static readonly FLOW_BUILDER_COMPACT_EXECUTION_NODE_SIZE: number = 48;
+
   public static readonly FLOW_BUILDER_CANVAS_ALLOWED_RESOURCE_TYPES: string[] = [
     StepTypes.View,
     StepTypes.Rule,

--- a/frontend/apps/console/src/features/flows/context/CompactStacksContext.ts
+++ b/frontend/apps/console/src/features/flows/context/CompactStacksContext.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {createContext, type Context} from 'react';
+
+/**
+ * Wiring between the compact-mode canvas nodes and FlowBuilder's per-stack
+ * expansion state: stack chips expand into their member chips, and the head
+ * member chip of an expanded group offers restacking.
+ */
+export interface CompactStacksContextValue {
+  /**
+   * Collapse an expanded group back into its stack chip.
+   */
+  collapseStack: (stackId: string) => void;
+  /**
+   * Expand a stack chip into its individual member chips.
+   */
+  expandStack: (stackId: string, memberIds: string[]) => void;
+  /**
+   * Lookup from the head member node id of each expanded group to its stack
+   * id, used by the head chip to offer the restack affordance.
+   */
+  expandedHeadIdToStackId: ReadonlyMap<string, string>;
+}
+
+const CompactStacksContext: Context<CompactStacksContextValue> = createContext<CompactStacksContextValue>({
+  collapseStack: () => undefined,
+  expandStack: () => undefined,
+  expandedHeadIdToStackId: new Map<string, string>(),
+});
+
+CompactStacksContext.displayName = 'CompactStacksContext';
+
+export default CompactStacksContext;

--- a/frontend/apps/console/src/features/flows/hooks/__tests__/useSsoToggle.test.tsx
+++ b/frontend/apps/console/src/features/flows/hooks/__tests__/useSsoToggle.test.tsx
@@ -159,15 +159,16 @@ describe('useSsoToggle', () => {
     expect(hook.result.current.focusRequest?.ssoCheckId).toMatch(/^sso_check_/);
   });
 
-  it('should force verbose mode on before inserting when it is off', () => {
+  it('should not force verbose mode when enabling while compact mode is on', () => {
     mockFlowConfig.isVerboseMode = false;
-    const {hook} = renderSsoToggle();
+    const {hook, setNodes} = renderSsoToggle();
 
     act(() => {
       hook.result.current.handleEnable();
     });
 
-    expect(mockSetIsVerboseMode).toHaveBeenCalledWith(true);
+    expect(setNodes).toHaveBeenCalledTimes(1);
+    expect(mockSetIsVerboseMode).not.toHaveBeenCalled();
   });
 
   it('should clear the focus request', () => {

--- a/frontend/apps/console/src/features/flows/hooks/useNodeTypes.tsx
+++ b/frontend/apps/console/src/features/flows/hooks/useNodeTypes.tsx
@@ -21,10 +21,12 @@ import {useEffect, useMemo, useRef} from 'react';
 import StepFactory from '../components/resources/steps/StepFactory';
 import BaseEdge from '@/features/flows/components/react-flow-overrides/BaseEdge';
 import {CommonStaticStepFactory} from '@/features/flows/components/resources/steps/CommonStaticStepFactory';
+import ExecutionStack from '@/features/flows/components/resources/steps/execution/ExecutionStack';
 import FlowConstants from '@/features/flows/constants/FlowConstants';
 import type {Element} from '@/features/flows/models/elements';
 import type {Resources} from '@/features/flows/models/resources';
 import {StaticStepTypes, type Step} from '@/features/flows/models/steps';
+import {EXECUTION_STACK_NODE_TYPE} from '@/features/flows/utils/compactGraphTransforms';
 
 /**
  * Props for the useNodeTypes hook.
@@ -122,6 +124,8 @@ const useNodeTypes = (props: UseNodeTypesProps): UseNodeTypesReturn => {
     return {
       ...staticStepNodes,
       ...stepNodes,
+      // Synthetic display node for collapsed executor runs in compact mode.
+      [EXECUTION_STACK_NODE_TYPE]: (nodeProps: NodeProps) => <ExecutionStack {...nodeProps} />,
     };
     // IMPORTANT: Only depend on the step types array, not resources
     // The actual data is accessed via refs at render time

--- a/frontend/apps/console/src/features/flows/hooks/useSsoToggle.ts
+++ b/frontend/apps/console/src/features/flows/hooks/useSsoToggle.ts
@@ -118,7 +118,7 @@ const useSsoToggle = ({
   showSuccess,
 }: UseSsoToggleProps): UseSsoToggleReturn => {
   const {t} = useTranslation();
-  const {edgeStyle, isVerboseMode, setIsVerboseMode} = useFlowConfig();
+  const {edgeStyle} = useFlowConfig();
   const {lastInteractedResource, lastInteractedStepId} = useInteractionState();
   const {setIsOpenResourcePropertiesPanel} = useUIPanelState();
 
@@ -174,11 +174,6 @@ const useSsoToggle = ({
         return;
       }
 
-      // Execution nodes are hidden in non-verbose mode; never mutate the graph invisibly.
-      if (!isVerboseMode) {
-        setIsVerboseMode(true);
-      }
-
       const resolvedNodes = resolveCollisions(result.nodes, {
         margin: 50,
         maxIterations: 10,
@@ -204,7 +199,7 @@ const useSsoToggle = ({
         ),
       );
     },
-    [ssoResources, edgeStyle, isVerboseMode, setIsVerboseMode, setNodes, setEdges, showInfo, t],
+    [ssoResources, edgeStyle, setNodes, setEdges, showInfo, t],
   );
 
   const handleEnable = useCallback((): void => {
@@ -218,15 +213,10 @@ const useSsoToggle = ({
     }
 
     if (joinResolution.status === 'ambiguous') {
-      // The candidate edges enter execution nodes, which non-verbose mode
-      // hides; force verbose mode so the highlights are actually visible.
-      if (!isVerboseMode) {
-        setIsVerboseMode(true);
-      }
       // Don't guess the join point; let the user click one of the candidate edges.
       setPlacement({active: true, candidateEdgeIds: joinResolution.candidateEdgeIds});
     }
-  }, [ssoState.enabled, joinResolution, applyEnable, isVerboseMode, setIsVerboseMode]);
+  }, [ssoState.enabled, joinResolution, applyEnable]);
 
   const handleDisableRequest = useCallback((): void => {
     if (ssoState.enabled) {

--- a/frontend/apps/console/src/features/flows/utils/__tests__/compactGraphTransforms.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/compactGraphTransforms.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {Edge, Node} from '@xyflow/react';
+import {describe, expect, it} from 'vitest';
+import collapseExecutorChains, {
+  EXECUTION_STACK_NODE_TYPE,
+  getExecutionStackWidth,
+  type ExecutionStackData,
+} from '../compactGraphTransforms';
+
+const view = (id: string, x = 0): Node => ({data: {}, id, position: {x, y: 0}, type: 'VIEW'});
+const executor = (id: string, x = 0): Node => ({
+  data: {action: {executor: {name: `${id}-executor`}}, display: {label: `${id} label`}},
+  id,
+  position: {x, y: 0},
+  type: 'TASK_EXECUTION',
+});
+const successEdge = (id: string, source: string, target: string): Edge => ({
+  id,
+  source,
+  sourceHandle: `${source}_NEXT`,
+  target,
+});
+
+describe('collapseExecutorChains', () => {
+  it('should collapse a run of two executors into a stack with rewired edges', () => {
+    const nodes = [view('view-1'), executor('exec-a', 100), executor('exec-b', 200), view('view-2', 300)];
+    const edges = [
+      successEdge('e1', 'view-1', 'exec-a'),
+      successEdge('e2', 'exec-a', 'exec-b'),
+      successEdge('e3', 'exec-b', 'view-2'),
+    ];
+
+    const result = collapseExecutorChains(nodes, edges);
+
+    const stack = result.nodes.find((node) => node.type === EXECUTION_STACK_NODE_TYPE);
+    expect(stack).toBeDefined();
+    expect((stack?.data as ExecutionStackData).memberIds).toEqual(['exec-a', 'exec-b']);
+    // Stack replaces the head at its position; members are gone
+    expect(stack?.position).toEqual({x: 100, y: 0});
+    expect(result.nodes.map((node) => node.id)).toEqual(['view-1', stack?.id, 'view-2']);
+
+    // Interior edge dropped; boundary edges rewired but keep their ids
+    expect(result.edges.map((edge) => edge.id)).toEqual(['e1', 'e3']);
+    const incoming = result.edges.find((edge) => edge.id === 'e1');
+    expect(incoming?.target).toBe(stack?.id);
+    const outgoing = result.edges.find((edge) => edge.id === 'e3');
+    expect(outgoing?.source).toBe(stack?.id);
+    expect(outgoing?.sourceHandle).toBe(`${stack?.id}_NEXT`);
+    expect(outgoing?.target).toBe('view-2');
+
+    expect(result.stackMembersById.get(stack?.id ?? '')).toEqual(['exec-a', 'exec-b']);
+  });
+
+  it('should make the stack non-connectable and non-deletable', () => {
+    const nodes = [view('view-1'), executor('exec-a'), executor('exec-b'), view('view-2')];
+    const edges = [
+      successEdge('e1', 'view-1', 'exec-a'),
+      successEdge('e2', 'exec-a', 'exec-b'),
+      successEdge('e3', 'exec-b', 'view-2'),
+    ];
+
+    const result = collapseExecutorChains(nodes, edges);
+
+    // A stack id has no counterpart in the real graph, so connecting to or
+    // deleting one would leave edges pointing at a node that does not exist.
+    const stack = result.nodes.find((node) => node.type === EXECUTION_STACK_NODE_TYPE);
+    expect(stack?.connectable).toBe(false);
+    expect(stack?.deletable).toBe(false);
+  });
+
+  it('should collapse chains longer than two members', () => {
+    const nodes = [view('view-1'), executor('a'), executor('b'), executor('c'), view('view-2')];
+    const edges = [
+      successEdge('e1', 'view-1', 'a'),
+      successEdge('e2', 'a', 'b'),
+      successEdge('e3', 'b', 'c'),
+      successEdge('e4', 'c', 'view-2'),
+    ];
+
+    const result = collapseExecutorChains(nodes, edges);
+
+    const stack = result.nodes.find((node) => node.type === EXECUTION_STACK_NODE_TYPE);
+    expect((stack?.data as ExecutionStackData).memberIds).toEqual(['a', 'b', 'c']);
+    expect(result.edges).toHaveLength(2);
+  });
+
+  it('should not collapse a single executor', () => {
+    const nodes = [view('view-1'), executor('exec-a'), view('view-2')];
+    const edges = [successEdge('e1', 'view-1', 'exec-a'), successEdge('e2', 'exec-a', 'view-2')];
+
+    const result = collapseExecutorChains(nodes, edges);
+
+    expect(result.nodes).toEqual(nodes);
+    expect(result.edges).toEqual(edges);
+    expect(result.stackMembersById.size).toBe(0);
+  });
+
+  it('should not stack executors that have a failure branch', () => {
+    const nodes = [view('view-1'), executor('exec-a'), executor('exec-b'), view('view-2'), view('view-err')];
+    const edges = [
+      successEdge('e1', 'view-1', 'exec-a'),
+      successEdge('e2', 'exec-a', 'exec-b'),
+      successEdge('e3', 'exec-b', 'view-2'),
+      {id: 'e-fail', source: 'exec-a', sourceHandle: 'failure', target: 'view-err'},
+    ];
+
+    const result = collapseExecutorChains(nodes, edges);
+
+    expect(result.nodes.some((node) => node.type === EXECUTION_STACK_NODE_TYPE)).toBe(false);
+  });
+
+  it('should not absorb a member that has a second incoming edge', () => {
+    // exec-b is also reachable from view-2, so exec-a -> exec-b must not merge
+    const nodes = [view('view-1'), executor('exec-a'), executor('exec-b'), view('view-2'), view('view-3')];
+    const edges = [
+      successEdge('e1', 'view-1', 'exec-a'),
+      successEdge('e2', 'exec-a', 'exec-b'),
+      successEdge('e3', 'exec-b', 'view-3'),
+      successEdge('e4', 'view-2', 'exec-b'),
+    ];
+
+    const result = collapseExecutorChains(nodes, edges);
+
+    expect(result.nodes.some((node) => node.type === EXECUTION_STACK_NODE_TYPE)).toBe(false);
+  });
+
+  it('should keep multiple incoming edges on the chain head', () => {
+    const nodes = [view('view-1'), view('view-2'), executor('exec-a'), executor('exec-b'), view('view-3')];
+    const edges = [
+      successEdge('e1', 'view-1', 'exec-a'),
+      successEdge('e2', 'view-2', 'exec-a'),
+      successEdge('e3', 'exec-a', 'exec-b'),
+      successEdge('e4', 'exec-b', 'view-3'),
+    ];
+
+    const result = collapseExecutorChains(nodes, edges);
+
+    const stack = result.nodes.find((node) => node.type === EXECUTION_STACK_NODE_TYPE);
+    expect(stack).toBeDefined();
+    const retargeted = result.edges.filter((edge) => edge.target === stack?.id);
+    expect(retargeted.map((edge) => edge.id).sort()).toEqual(['e1', 'e2']);
+  });
+
+  it('should leave a chain uncollapsed when its stack id is expanded', () => {
+    const nodes = [view('view-1'), executor('exec-a'), executor('exec-b'), view('view-2')];
+    const edges = [
+      successEdge('e1', 'view-1', 'exec-a'),
+      successEdge('e2', 'exec-a', 'exec-b'),
+      successEdge('e3', 'exec-b', 'view-2'),
+    ];
+
+    const result = collapseExecutorChains(nodes, edges, new Set(['execution-stack_exec-a']));
+
+    expect(result.nodes).toEqual(nodes);
+    expect(result.edges).toEqual(edges);
+    expect(result.stackMembersById.size).toBe(0);
+  });
+
+  it('should mark the stack selected only when every member is selected', () => {
+    const nodes = [
+      view('view-1'),
+      {...executor('exec-a'), selected: true},
+      {...executor('exec-b'), selected: true},
+      view('view-2'),
+    ];
+    const edges = [
+      successEdge('e1', 'view-1', 'exec-a'),
+      successEdge('e2', 'exec-a', 'exec-b'),
+      successEdge('e3', 'exec-b', 'view-2'),
+    ];
+
+    const result = collapseExecutorChains(nodes, edges);
+    const stack = result.nodes.find((node) => node.type === EXECUTION_STACK_NODE_TYPE);
+    expect(stack?.selected).toBe(true);
+  });
+});
+
+describe('getExecutionStackWidth', () => {
+  it('should grow by the layer offset per extra member', () => {
+    expect(getExecutionStackWidth(1)).toBe(48);
+    expect(getExecutionStackWidth(2)).toBe(52);
+    expect(getExecutionStackWidth(3)).toBe(56);
+  });
+
+  it('should cap at the max deck layers', () => {
+    expect(getExecutionStackWidth(4)).toBe(56);
+    expect(getExecutionStackWidth(10)).toBe(56);
+  });
+});

--- a/frontend/apps/console/src/features/flows/utils/applyAutoLayout.ts
+++ b/frontend/apps/console/src/features/flows/utils/applyAutoLayout.ts
@@ -45,6 +45,15 @@ export interface AutoLayoutOptions {
   offsetY?: number;
 }
 
+/**
+ * Whether a freshly loaded graph still has to be laid out: flows saved without
+ * layout data come back with every node at the origin, so more than one node
+ * sitting there means the load-time auto-layout has not run yet.
+ */
+export function hasUnpositionedNodes(nodes: Node[]): boolean {
+  return nodes.filter((node) => node.position?.x === 0 && node.position?.y === 0).length > 1;
+}
+
 // ELK (the layout engine) is ~1.5MB. It is only needed when a layout is actually
 // requested (toolbar button, or opening a flow with no stored positions), so it is
 // dynamically imported and cached rather than bundled into the builder's entry chunk.

--- a/frontend/apps/console/src/features/flows/utils/compactGraphTransforms.ts
+++ b/frontend/apps/console/src/features/flows/utils/compactGraphTransforms.ts
@@ -1,0 +1,254 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {Edge, Node} from '@xyflow/react';
+import VisualFlowConstants from '../constants/VisualFlowConstants';
+import {StepTypes} from '../models/steps';
+
+/**
+ * Node type of the synthetic display node that represents a collapsed run of
+ * consecutive executors in compact (non-verbose) mode.
+ */
+export const EXECUTION_STACK_NODE_TYPE = 'EXECUTION_STACK';
+
+const EXECUTION_STACK_ID_PREFIX = 'execution-stack_';
+
+/**
+ * The head (first member) node id a stack id was derived from.
+ */
+export function getExecutionStackHeadId(stackId: string): string {
+  return stackId.startsWith(EXECUTION_STACK_ID_PREFIX) ? stackId.slice(EXECUTION_STACK_ID_PREFIX.length) : stackId;
+}
+
+/**
+ * Horizontal offset of each background "deck" layer peeking out behind the
+ * stack chip.
+ */
+export const EXECUTION_STACK_LAYER_OFFSET = 4;
+
+/**
+ * How many background deck layers a stack renders at most.
+ */
+export const EXECUTION_STACK_MAX_LAYERS = 2;
+
+/**
+ * A member of a collapsed executor stack: the original node id plus its data,
+ * enough to render the member chip and open its properties panel.
+ */
+export interface ExecutionStackMember {
+  id: string;
+  data: Node['data'];
+}
+
+/**
+ * Data payload of an EXECUTION_STACK display node.
+ */
+export interface ExecutionStackData extends Record<string, unknown> {
+  memberIds: string[];
+  members: ExecutionStackMember[];
+}
+
+/**
+ * Result of {@link collapseExecutorChains}: the display graph plus a lookup
+ * from each synthetic stack id to its member node ids (used to translate
+ * canvas changes on a stack back onto the underlying state nodes).
+ */
+export interface CollapsedExecutorGraph {
+  edges: Edge[];
+  nodes: Node[];
+  stackMembersById: Map<string, string[]>;
+}
+
+/**
+ * Rendered width of a stack chip: one chip showing the first executor's icon
+ * plus the background deck layers peeking out behind it (one per additional
+ * member, capped). Kept next to the transform so the layout engine and the
+ * component agree.
+ */
+export function getExecutionStackWidth(memberCount: number): number {
+  const layers = Math.min(Math.max(memberCount - 1, 0), EXECUTION_STACK_MAX_LAYERS);
+  return VisualFlowConstants.FLOW_BUILDER_COMPACT_EXECUTION_NODE_SIZE + layers * EXECUTION_STACK_LAYER_OFFSET;
+}
+
+const isSuccessHandle = (sourceHandle: string | null | undefined): boolean =>
+  sourceHandle !== 'failure' &&
+  !sourceHandle?.endsWith(VisualFlowConstants.FLOW_BUILDER_INCOMPLETE_HANDLE_SUFFIX) &&
+  !sourceHandle?.endsWith(VisualFlowConstants.FLOW_BUILDER_PREVIOUS_HANDLE_SUFFIX);
+
+/**
+ * Collapses maximal runs of two or more consecutive executor nodes into a
+ * single EXECUTION_STACK display node.
+ *
+ * A run member must be an EXECUTION node whose entire outgoing connectivity is
+ * one success edge (no failure/incomplete edges anywhere), and every member
+ * after the first must have exactly one incoming edge (the chain link), so
+ * collapsing the run hides no branch anchors. Edges into the first member are
+ * retargeted to the stack; the last member's outgoing success edge is
+ * re-sourced from the stack. Interior chain edges are dropped.
+ *
+ * This is a pure display transform: the underlying graph state is never
+ * mutated, and edge ids are preserved so decorations keyed by edge id (SSO
+ * placement, simulation paths) keep working on the rewired edges.
+ *
+ * Chains whose stack id is in `expandedStackIds` are left uncollapsed, so the
+ * user can open a group into its individual chips without leaving compact
+ * mode.
+ */
+export default function collapseExecutorChains(
+  nodes: Node[],
+  edges: Edge[],
+  expandedStackIds?: ReadonlySet<string>,
+): CollapsedExecutorGraph {
+  const outgoingByNode = new Map<string, Edge[]>();
+  const incomingByNode = new Map<string, Edge[]>();
+  for (const edge of edges) {
+    outgoingByNode.set(edge.source, [...(outgoingByNode.get(edge.source) ?? []), edge]);
+    incomingByNode.set(edge.target, [...(incomingByNode.get(edge.target) ?? []), edge]);
+  }
+
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+
+  // A node qualifies for stacking when it is an executor whose only outgoing
+  // edge is a success edge: no failure/incomplete branches leave it.
+  const isStackable = (node: Node | undefined): node is Node => {
+    if (node?.type !== StepTypes.Execution) {
+      return false;
+    }
+    const outgoing = outgoingByNode.get(node.id) ?? [];
+    return outgoing.length === 1 && isSuccessHandle(outgoing[0].sourceHandle);
+  };
+
+  // A chain link A -> B holds when both ends are stackable executors and B's
+  // only incoming edge is that link.
+  const linksTo = (from: Node): Node | null => {
+    const [edge] = outgoingByNode.get(from.id) ?? [];
+    const target = nodeById.get(edge?.target ?? '');
+    if (!isStackable(target) || (incomingByNode.get(target.id) ?? []).length !== 1) {
+      return null;
+    }
+    return target;
+  };
+
+  // Heads are stackable nodes that are not themselves the tail of a link.
+  const linkedTargets = new Set<string>();
+  for (const node of nodes) {
+    if (isStackable(node)) {
+      const next = linksTo(node);
+      if (next) {
+        linkedTargets.add(next.id);
+      }
+    }
+  }
+
+  const stackByHeadId = new Map<string, Node[]>();
+  for (const node of nodes) {
+    if (!isStackable(node) || linkedTargets.has(node.id)) {
+      continue;
+    }
+    const chain: Node[] = [node];
+    let current = node;
+    for (let next = linksTo(current); next; next = linksTo(current)) {
+      chain.push(next);
+      current = next;
+    }
+    if (chain.length >= 2 && !expandedStackIds?.has(`${EXECUTION_STACK_ID_PREFIX}${node.id}`)) {
+      stackByHeadId.set(node.id, chain);
+    }
+  }
+
+  if (stackByHeadId.size === 0) {
+    return {edges, nodes, stackMembersById: new Map()};
+  }
+
+  const memberToStackId = new Map<string, string>();
+  const tailIds = new Set<string>();
+  const interiorEdgeIds = new Set<string>();
+  const stackMembersById = new Map<string, string[]>();
+
+  for (const [headId, chain] of stackByHeadId) {
+    const stackId = `${EXECUTION_STACK_ID_PREFIX}${headId}`;
+    stackMembersById.set(
+      stackId,
+      chain.map((member) => member.id),
+    );
+    chain.forEach((member, index) => {
+      memberToStackId.set(member.id, stackId);
+      if (index < chain.length - 1) {
+        const [linkEdge] = outgoingByNode.get(member.id) ?? [];
+        if (linkEdge) {
+          interiorEdgeIds.add(linkEdge.id);
+        }
+      } else {
+        tailIds.add(member.id);
+      }
+    });
+  }
+
+  const displayNodes: Node[] = [];
+  for (const node of nodes) {
+    const stackId = memberToStackId.get(node.id);
+    if (!stackId) {
+      displayNodes.push(node);
+      continue;
+    }
+    const chain = stackByHeadId.get(node.id);
+    if (!chain) {
+      // Non-head member: dropped, represented by the head's stack node.
+      continue;
+    }
+    displayNodes.push({
+      // A stack id exists only on the canvas, so connecting or deleting one
+      // would write an endpoint the real graph has no node for. Both are
+      // disabled; the run has to be expanded before its members can be
+      // rewired or removed. Handles still render, so existing edges anchor.
+      connectable: false,
+      data: {
+        memberIds: chain.map((member) => member.id),
+        members: chain.map((member) => ({data: member.data, id: member.id})),
+      } satisfies ExecutionStackData,
+      deletable: false,
+      id: stackId,
+      position: node.position,
+      selected: chain.every((member) => member.selected === true),
+      type: EXECUTION_STACK_NODE_TYPE,
+    });
+  }
+
+  const displayEdges: Edge[] = [];
+  for (const edge of edges) {
+    if (interiorEdgeIds.has(edge.id)) {
+      continue;
+    }
+    let displayEdge = edge;
+    const targetStackId = memberToStackId.get(edge.target);
+    if (targetStackId) {
+      displayEdge = {...displayEdge, target: targetStackId, targetHandle: null};
+    }
+    const sourceStackId = memberToStackId.get(edge.source);
+    if (sourceStackId && tailIds.has(edge.source)) {
+      displayEdge = {
+        ...displayEdge,
+        source: sourceStackId,
+        sourceHandle: `${sourceStackId}${VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX}`,
+      };
+    }
+    displayEdges.push(displayEdge);
+  }
+
+  return {edges: displayEdges, nodes: displayNodes, stackMembersById};
+}

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -3481,6 +3481,8 @@ const translations = {
     'core.executions.landing.message': 'This {{executor}} step will redirect users to a landing page.',
 
     // Execution steps - branching handles
+    'core.executions.stack.expandHint': 'Click to expand',
+    'core.executions.stack.restack': 'Restack executors',
     'core.executions.handles.success': 'onSuccess',
     'core.executions.handles.failure': 'onFailure',
     'core.executions.handles.incomplete': 'onIncomplete',
@@ -3734,6 +3736,9 @@ const translations = {
     'core.headerPanel.saveTitle': 'Save flow name',
     'core.headerPanel.cancelEdit': 'Cancel',
     'core.headerPanel.edgeStyleTooltip': 'Change edge style',
+    'core.headerPanel.compactView': 'Compact view',
+    'core.headerPanel.compactViewTooltip': 'Switch to compact view',
+    'core.headerPanel.detailedViewTooltip': 'Switch to detailed view',
     'core.headerPanel.simulate': 'Preview',
     'core.headerPanel.stopSimulation': 'Stop preview',
     'core.headerPanel.saveDisabledDuringPreview': 'Stop the preview before saving',


### PR DESCRIPTION
### Purpose

Complex flows are hard to read in the flow builder because every executor renders as a full card, so the diagram is dominated by nodes that are not the screens a user actually sees.

This adds a **compact view mode** to the canvas, toggled from the canvas toolbar:

- Prompt (view) nodes keep rendering in full.
- Executors collapse into 48px icon chips, keeping their success / failure / incomplete handles so branches stay anchored.
- Runs of consecutive non-branching executors collapse further into a **single stacked chip** with a `+N` count. Hovering nudges the members out of the deck; clicking expands the group into individual chips, and a restack button on the head chip collapses it again.

Executors are collapsed rather than hidden, so no part of the graph silently disappears.

### Approach

**Display-only transform.** `collapseExecutorChains` rewrites nodes and edges purely for rendering; the stored graph is never touched. A run only collapses when doing so hides no branch anchor (every member's outgoing connectivity is a single success edge, and every member after the head has exactly one incoming edge). Edge IDs are preserved through the rewiring so decorations keyed by edge ID (SSO placement, simulation paths) keep working.

The canvas receives the transformed graph, while `sourceNodes` / `sourceEdges` carry the real graph so **saving and validation never see the synthetic nodes**. Canvas changes addressed to a stack are expanded onto its members, so drags, selections and deletions land on real state. A collapsed stack also surfaces the validation state of the members it hides, so an error inside a stack is still visible.

**One auto layout, mode aware.** The toolbar button and the view toggle share `handleAutoLayout`, which now uses tighter spacing in compact mode and feeds the layout engine the known chip/stack sizes (they are not measured yet right after a toggle). Re-running Auto Layout in compact mode therefore reproduces the same tight layout instead of rearranging with detailed-mode metrics.

**Fixes found while building this**

- **Save indicator showed on every flow.** Its pulse animation animates `transform`, and a CSS animation outranks the `transform: scale(0)` MUI uses to hide a badge, so the dot painted even when the flow was clean (and leaving the flow correctly never prompted). The animation is now scoped to the visible state and its keyframes carry MUI's own translate, which also fixes the dot's anchoring.
- **Untouched flows could be marked as modified.** Node positions are part of the change signature, so the load-time auto layout (flows stored without layout data) and view-mode relayouts could dirty a flow nobody edited. The clean baseline now waits for the load to settle, and view-mode relayouts rebase it instead of dirtying it.
- **Call steps read as executors.** They reused the executor card styling; their body now carries a distinct reference treatment (dashed primary-tinted outline, primary wash, workflow glyph).
- **Dead CSS variables.** Compact chip borders and selected outlines referenced `--mui-palette-*`, which is undefined in the console and voids the whole declaration. Switched to `--oxygen-palette-*`.

Removed the previous non-verbose behaviour, which hid executors and every edge touching them, leaving the graph visually disconnected. `useSsoToggle` no longer force-enables verbose mode, since that guard only existed because executors used to be hidden.

### Related Issues
- Fixes #4451

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compact and detailed viewing modes for visual flows.
  * Consecutive execution steps can now collapse into expandable stacks, with preserved connections and sizing.
  * Added toolbar controls for switching view modes.
  * Improved compact execution-step visuals, interactions, tooltips, and call-step styling.
* **Bug Fixes**
  * Prevented automatic layout and view toggles from incorrectly marking flows as modified.
  * Improved initialization while provider data and node positioning are still loading.
  * SSO interactions now work without unexpectedly switching view modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->