### PR TITLE
Sign out without a confirmation prompt

### DIFF
--- a/backend/cmd/server/bootstrap/01-default-resources.yaml
+++ b/backend/cmd/server/bootstrap/01-default-resources.yaml
@@ -575,7 +575,7 @@ flowType: SIGNOUT
 nodes:
 - id: start
   type: START
-  onSuccess: prompt_confirm
+  onSuccess: session_signout
   layout:
     size:
       width: 101
@@ -583,37 +583,6 @@ nodes:
     position:
       x: 62
       y: 278
-- id: prompt_confirm
-  type: PROMPT
-  layout:
-    size:
-      width: 350
-      height: 300
-    position:
-      x: 463
-      y: 150
-  meta:
-    components:
-    - type: TEXT
-      id: text_signout_title
-      label: '{{ t(signout:forms.confirm.title) }}'
-      variant: HEADING_1
-    - type: TEXT
-      id: text_signout_desc
-      label: '{{ t(signout:forms.confirm.description) }}'
-      variant: BODY_1
-    - type: BLOCK
-      id: block_signout
-      components:
-      - type: ACTION
-        id: action_confirm
-        label: '{{ t(signout:forms.confirm.actions.submit.label) }}'
-        variant: PRIMARY
-        eventType: SUBMIT
-  prompts:
-  - action:
-      ref: action_confirm
-      nextNode: session_signout
 - id: session_signout
   type: TASK_EXECUTION
   layout:
@@ -621,7 +590,7 @@ nodes:
       width: 217
       height: 113
     position:
-      x: 960
+      x: 463
       y: 240
   executor:
     name: SessionSignOutExecutor
@@ -633,7 +602,7 @@ nodes:
       width: 85
       height: 34
     position:
-      x: 1400
+      x: 900
       y: 278
 ---
 resource_type: flow

--- a/backend/internal/oauth/oauth2/logout/handler.go
+++ b/backend/internal/oauth/oauth2/logout/handler.go
@@ -70,7 +70,9 @@ func (h *logoutHandler) HandleLogout(w http.ResponseWriter, r *http.Request) {
 		PostLogoutRedirectURI: r.FormValue(constants.RequestParamPostLogoutRedirect),
 		State:                 r.FormValue(constants.RequestParamState),
 		Headers:               sysutils.SanitizeRawMultiValueStringMap(r.Header),
-		QueryParams:           sysutils.SanitizeRawMultiValueStringMap(r.URL.Query()),
+		// r.Form, not r.URL.Query(): on a POST the parameters arrive in the form body, which the query
+		// string does not carry. ParseForm merges both, so the flow sees the same set either way.
+		QueryParams: sysutils.SanitizeRawMultiValueStringMap(r.Form),
 	}
 
 	// Validate before initiating anything: the post-logout redirect URI is validated here (against the

--- a/backend/internal/oauth/oauth2/logout/handler_test.go
+++ b/backend/internal/oauth/oauth2/logout/handler_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -32,6 +33,7 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/flow/flowexec"
 	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
@@ -166,19 +168,33 @@ func (suite *LogoutHandlerTestSuite) TestHandleLogout_FlowInitiationError_MapsSt
 	}
 }
 
-// A POST to the end_session_endpoint initiates the flow and redirects to the gate, exactly like GET.
-func (suite *LogoutHandlerTestSuite) TestHandleLogout_POSTInitiatesAndRedirects() {
+// A POST to the end_session_endpoint carries its parameters in the form body rather than the query
+// string. The handler must read them from there and forward them to the sign-out flow, so that a POST
+// behaves exactly like a GET.
+func (suite *LogoutHandlerTestSuite) TestHandleLogout_POSTReadsFormBodyAndRedirects() {
 	actor := actorprovidermock.NewActorProviderMock(suite.T())
-	actor.EXPECT().GetOAuthClientByClientID(mock.Anything, "client-x").Return(clientWithPostLogout(), nil)
+	actor.EXPECT().GetOAuthClientByClientID(mock.Anything, "client-x").
+		Return(clientWithPostLogout("https://rp.example/after"), nil)
 	flowSvc := flowexecmock.NewFlowExecServiceInterfaceMock(suite.T())
-	flowSvc.EXPECT().InitiateFlow(mock.Anything, mock.Anything).Return("exec-2", nil)
+	var capturedParams map[string][]string
+	flowSvc.EXPECT().InitiateFlow(mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, ic *flowexec.FlowInitContext) (string, *tidcommon.ServiceError) {
+			capturedParams = ic.InitiatorRequest.QueryParams
+			return "exec-2", nil
+		})
 	store := newLogoutRequestStoreInterfaceMock(suite.T())
 	store.EXPECT().AddRequest(mock.Anything, mock.Anything).Return("logout-1", nil)
 	svc := newLogoutService(jwtmock.NewJWTServiceInterfaceMock(suite.T()), actor, flowSvc,
 		store, testIssuer)
 	handler := newLogoutHandler(svc, gateConfig())
 
-	req := httptest.NewRequest(http.MethodPost, "/oauth2/logout?client_id=client-x", nil)
+	body := url.Values{
+		"client_id":                {"client-x"},
+		"post_logout_redirect_uri": {"https://rp.example/after"},
+		"state":                    {"xyz"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/oauth2/logout", strings.NewReader(body.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 
 	handler.HandleLogout(rec, req)
@@ -187,6 +203,8 @@ func (suite *LogoutHandlerTestSuite) TestHandleLogout_POSTInitiatesAndRedirects(
 	location := rec.Header().Get("Location")
 	suite.Contains(location, "https://gate.example:9443/signout")
 	suite.Contains(location, "executionId=exec-2")
+	suite.Equal([]string{"xyz"}, capturedParams[constants.RequestParamState],
+		"body parameters must reach the sign-out flow the same way query parameters do")
 }
 
 // The completion callback consumes the stored logout request and returns the post-logout redirect URI.

--- a/frontend/apps/console/src/features/flows/data/templates.json
+++ b/frontend/apps/console/src/features/flows/data/templates.json
@@ -12898,6 +12898,72 @@
   {
     "resourceType": "TEMPLATE",
     "category": "STARTER",
+    "type": "DIRECT",
+    "flowType": "SIGNOUT",
+    "display": {
+      "label": "Silent Sign Out",
+      "description": "Terminate the user's SSO session immediately, with no confirmation step",
+      "image": "assets/images/icons/arrowhead-right-outline.svg",
+      "showOnResourcePanel": true
+    },
+    "config": {
+      "name": "Silent Sign Out Flow",
+      "handle": "silent-signout-flow",
+      "nodes": [
+        {
+          "id": "start",
+          "type": "START",
+          "layout": {
+            "size": {
+              "width": 101,
+              "height": 34
+            },
+            "position": {
+              "x": 62,
+              "y": 278
+            }
+          },
+          "onSuccess": "session_signout"
+        },
+        {
+          "id": "session_signout",
+          "type": "TASK_EXECUTION",
+          "layout": {
+            "size": {
+              "width": 217,
+              "height": 113
+            },
+            "position": {
+              "x": 463,
+              "y": 240
+            }
+          },
+          "executor": {
+            "name": "SessionSignOutExecutor"
+          },
+          "onSuccess": "end"
+        },
+        {
+          "id": "end",
+          "type": "END",
+          "layout": {
+            "size": {
+              "width": 85,
+              "height": 34
+            },
+            "position": {
+              "x": 900,
+              "y": 278
+            }
+          }
+        }
+      ]
+    },
+    "nodes": []
+  },
+  {
+    "resourceType": "TEMPLATE",
+    "category": "STARTER",
     "type": "BASIC",
     "flowType": "SIGNOUT",
     "display": {
@@ -13028,8 +13094,8 @@
     "type": "BASIC_CONDITIONAL",
     "flowType": "SIGNOUT",
     "display": {
-      "label": "Confirm Sign Out Without a Hint",
-      "description": "Ask the user to confirm only when no valid id_token_hint was provided, otherwise sign out directly",
+      "label": "Conditional Confirmation",
+      "description": "Ask the user to confirm only when the request has no ID token hint, otherwise sign out immediately",
       "image": "assets/images/icons/arrowhead-right-outline.svg",
       "showOnResourcePanel": true
     },

--- a/frontend/apps/console/src/hocs/__tests__/withConfig.test.tsx
+++ b/frontend/apps/console/src/hocs/__tests__/withConfig.test.tsx
@@ -65,6 +65,7 @@ vi.mock('@thunderid/react', () => ({
     signInOptions,
     preferences,
     sendCookiesInRequests,
+    sendIdTokenInLogoutRequest,
     discovery,
     /* eslint-enable react/require-default-props */
   }: {
@@ -77,6 +78,7 @@ vi.mock('@thunderid/react', () => ({
     signInOptions?: Record<string, string>;
     preferences?: Record<string, unknown>;
     sendCookiesInRequests?: boolean;
+    sendIdTokenInLogoutRequest?: boolean;
     discovery?: Record<string, unknown>;
   }) => {
     capturedProviderProps = {
@@ -88,6 +90,7 @@ vi.mock('@thunderid/react', () => ({
       signInOptions,
       preferences,
       sendCookiesInRequests,
+      sendIdTokenInLogoutRequest,
       discovery,
     };
     return (
@@ -366,6 +369,17 @@ describe('withConfig (console)', () => {
 
       render(<WithConfigComponent />);
       expect(capturedProviderProps.sendCookiesInRequests).toBe(false);
+    });
+  });
+
+  // --- RP-initiated logout ---
+
+  describe('rp-initiated logout', () => {
+    it('sets sendIdTokenInLogoutRequest=false so the ID token stays out of the sign-out URL', () => {
+      mockGetClientUrl.mockReturnValue('https://client.example.com');
+
+      render(<WithConfigComponent />);
+      expect(capturedProviderProps.sendIdTokenInLogoutRequest).toBe(false);
     });
   });
 

--- a/frontend/apps/console/src/hocs/withConfig.tsx
+++ b/frontend/apps/console/src/hocs/withConfig.tsx
@@ -46,6 +46,7 @@ export default function withConfig<P extends object>(WrappedComponent: Component
     const sdkDefaults: Partial<ThunderIDProviderProps> = {
       discovery: {wellKnown: {enabled: true}},
       ...(resourceIdentifier ? {signInOptions: {resource: resourceIdentifier}} : {}),
+      sendIdTokenInLogoutRequest: false,
       // When the trusted issuer is a generic OIDC provider, suppress the SDK's
       // product-specific bootstrap calls that would otherwise 404 / be CORS-blocked
       // at the external authorization server: flow metadata (`{baseUrl}/flow/meta`).


### PR DESCRIPTION
### Purpose
Signing out of the console required an extra confirmation click, and the RP-initiated logout request carried the user's ID token in the URL query string, where reverse proxies, load balancers, browser history and `Referer` headers all record it. This PR removes the confirmation step from the default sign-out experience, keeps the ID token out of logout URLs, and fixes a bug that made a `POST` to the `end_session_endpoint` behave differently from a `GET`.

1. **Default Sign Out Flow no longer prompts.** The flow graph went from `start -> prompt_confirm -> session_signout -> end` to `start -> session_signout -> end`. The prompt was unconditional, so this is what actually removes the click. Applies to every application on the `default-flow` sign-out handle, not just the console.
2. **Console stops sending `id_token_hint`.** `sendIdTokenInLogoutRequest: false` in the console's SDK defaults makes the SDK send `client_id` instead. It sits in `sdkDefaults`, so operators can still override it through `config.sdk`.
3. **Logout handler reads the form body.** `handler.go` built its parameter map from `r.URL.Query()`. On a POST the parameters arrive in the body, so the map was empty and the sign-out flow's `InitiatorRequest.QueryParams` received nothing. Now sourced from `r.Form`, which `ParseForm` populates from both the query string and the body.
4. **New "Silent Sign Out" template** that goes straight to `SessionSignOutExecutor`, mirroring the new default. The existing "Confirm & Sign Out" and "Conditional Confirmation" templates are unchanged.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
**Why drop `id_token_hint` rather than keep it.** The hint is optional in OIDC RP-Initiated Logout, and across the use cases we have seen it earns very little. ThunderID resolves the session to terminate from the per-flow SSO cookie, not from the hint. All the hint does is resolve the client id, which `client_id` does directly, and the `post_logout_redirect_uri` is validated against the client's registered list either way. That leaves a signed token carrying identity claims sitting in a URL for no practical gain, so the console stops sending it. Having the SDK issue the sign-out as a POST is a worthwhile improvement in its own right and the backend already accepts both methods, but it is not a prerequisite for this change.

**Consequence worth reviewing.** The one thing the hint bought is attribution. Per OIDC RP-Initiated Logout the OP must ask the End-User to confirm when no `id_token_hint` is supplied, precisely because the request is then unattributable. With the prompt removed as well, `/oauth2/logout?client_id=CONSOLE&post_logout_redirect_uri=...` is a complete unauthenticated sign-out request: any page can navigate a signed-in user's browser to it and terminate their SSO session. The impact is nuisance-grade (forced logout, no data exposure), but reviewers should know it now applies to every application on the default flow.

**What was deliberately left alone.** The `promptOnSignOut` executor property and the `logoutPromptRequired` runtime key are untouched, so the conditional sign-out path still works for anyone who opts into it. Note that this conditional path is only reachable through `/oauth2/logout`: the flag has a single writer in the OAuth logout layer, so a `SIGNOUT` flow initiated directly through `POST /flow/execute` never prompts.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Silent Sign Out Flow" template for direct sign-out without confirmation prompts.

* **Bug Fixes**
  * Fixed logout flow to properly forward form-encoded body parameters alongside query parameters.

* **Updates**
  * Updated sign-out template display labels and descriptions for clarity.
  * Adjusted ID token handling during logout requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->