### PR TITLE
Turn the button Type selector into an Action selector with a sign-out option

### DIFF
--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/CommonResourceProperties.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/CommonResourceProperties.tsx
@@ -89,6 +89,10 @@ const TOP_LEVEL_EDITABLE_PROPS = [
   'startIcon',
   'endIcon',
   'eventType',
+  // Paired with eventType by the button's Action selector. Without it here the
+  // change is written into `data` instead of onto the element, so the selector
+  // cannot read its own value back and cannot clear it again.
+  'actionType',
   'items',
   'direction',
   'gap',
@@ -279,6 +283,7 @@ function CommonResourceProperties(): ReactElement {
         if (element.id === lastInteractedResourceIdRef.current && currentResource) {
           const updatedResource: Resource = cloneDeep(currentResource);
           set(updatedResource as unknown as Record<string, unknown>, propertyKey, newValue);
+          lastInteractedResourceRef.current = updatedResource;
           setLastInteractedResourceRef.current(updatedResource);
         }
         return;
@@ -338,6 +343,11 @@ function CommonResourceProperties(): ReactElement {
         } else {
           set(updatedResource.data as Record<string, unknown>, propertyKey, newValue);
         }
+        // The ref otherwise only catches up on the next render, so a second
+        // change applied in the same tick (a control that writes a pair of
+        // properties, such as the button's Action selector) would rebase on the
+        // pre-change resource and drop the first one.
+        lastInteractedResourceRef.current = updatedResource;
         setLastInteractedResourceRef.current(updatedResource);
       }
     };

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/CommonResourceProperties.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/CommonResourceProperties.test.tsx
@@ -110,6 +110,18 @@ describe('CommonResourceProperties', () => {
         <button type="button" onClick={() => onChange('label', 'New Label', resource)}>
           Change Label
         </button>
+        <button type="button" onClick={() => onChange('actionType', 'SIGN_OUT_CONFIRM', resource)}>
+          Change Action Type
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            onChange('eventType', 'SUBMIT', resource);
+            onChange('actionType', '', resource);
+          }}
+        >
+          Change Pair
+        </button>
         <button type="button" onClick={() => onVariantChange?.('variant-1')}>
           Change Variant
         </button>
@@ -239,6 +251,24 @@ describe('CommonResourceProperties', () => {
       expect(properties.hint).toBe('Test Hint');
       expect(properties.placeholder).toBe('Test Placeholder');
       expect(properties.required).toBe(true);
+    });
+
+    it('should keep actionType out of the generic property list', () => {
+      // The button's Action selector owns it, so it must not also render as a
+      // generic field.
+      const resourceWithActionType: Base = {
+        ...mockBaseResource,
+        actionType: 'SIGN_OUT_CONFIRM',
+      } as Base & {actionType: string};
+
+      render(<CommonResourceProperties />, {
+        wrapper: createWrapper(createContextValue({lastInteractedResource: resourceWithActionType})),
+      });
+
+      const propertiesDiv = screen.getByTestId('properties');
+      const properties = JSON.parse(propertiesDiv.textContent ?? '{}') as Record<string, unknown>;
+
+      expect(properties).not.toHaveProperty('actionType');
     });
 
     it('should expose step data.properties under data.properties.* keys', () => {
@@ -378,6 +408,41 @@ describe('CommonResourceProperties', () => {
   });
 
   describe('Property Change Handler', () => {
+    it('should write actionType onto the element rather than into its data', async () => {
+      render(<CommonResourceProperties />, {wrapper: createWrapper()});
+
+      screen.getByText('Change Action Type').click();
+
+      await new Promise((resolve) => {
+        setTimeout(resolve, 400);
+      });
+
+      // Landing under `data` would leave the Action selector unable to read its
+      // own value back, so it could neither show Sign out nor clear it again.
+      const updated = mockSetLastInteractedResource.mock.calls.at(-1)?.[0] as Record<string, unknown> & {
+        data?: Record<string, unknown>;
+      };
+      expect(updated.actionType).toBe('SIGN_OUT_CONFIRM');
+      expect(updated.data?.actionType).toBeUndefined();
+    });
+
+    it('should keep both properties when two changes are applied in the same tick', async () => {
+      render(<CommonResourceProperties />, {wrapper: createWrapper()});
+
+      // The button's Action selector writes eventType and actionType together.
+      // Rebasing the second change on the pre-change resource would drop the
+      // first, leaving the selector showing the previous action.
+      screen.getByText('Change Pair').click();
+
+      await new Promise((resolve) => {
+        setTimeout(resolve, 400);
+      });
+
+      const updated = mockSetLastInteractedResource.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+      expect(updated.eventType).toBe('SUBMIT');
+      expect(updated.actionType).toBe('');
+    });
+
     it('should trigger onChange callback when property changes', () => {
       render(<CommonResourceProperties />, {wrapper: createWrapper()});
 

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/ButtonExtendedProperties.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/ButtonExtendedProperties.tsx
@@ -21,7 +21,23 @@ import {useState, type ReactNode, type ChangeEvent} from 'react';
 import {useTranslation} from 'react-i18next';
 import type {CommonResourcePropertiesPropsInterface} from '@/features/flows/components/resource-property-panel/CommonResourceProperties';
 import type {Element} from '@/features/flows/models/elements';
-import {ActionEventTypes} from '@/features/flows/models/elements';
+import {ActionEventTypes, PromptActionTypes} from '@/features/flows/models/elements';
+
+/**
+ * The options offered by the Action selector. `Submit` and `Trigger` are the
+ * button's `eventType`; `SignOut` is a submit button that additionally raises
+ * the `SIGN_OUT_CONFIRM` prompt action, so one selection maps onto two fields.
+ *
+ * The remaining `ActionEventTypes` (navigate, cancel, reset, back) are handled
+ * by the SDK renderers but deliberately not offered here.
+ */
+const ACTION_OPTIONS = {
+  Submit: 'SUBMIT',
+  Trigger: 'TRIGGER',
+  SignOut: 'SIGN_OUT',
+} as const;
+
+type ActionOption = (typeof ACTION_OPTIONS)[keyof typeof ACTION_OPTIONS];
 
 /**
  * Props interface of {@link ButtonExtendedProperties}
@@ -38,7 +54,32 @@ export type ButtonExtendedPropertiesPropsInterface = CommonResourcePropertiesPro
 function ButtonExtendedProperties({resource, onChange}: ButtonExtendedPropertiesPropsInterface): ReactNode {
   const {t} = useTranslation();
 
-  const eventTypeValue = (resource as Element & {eventType?: string})?.eventType ?? ActionEventTypes.Trigger;
+  const element = resource as Element & {eventType?: string};
+  const eventTypeValue = element?.eventType ?? ActionEventTypes.Trigger;
+
+  // Sign out is a submit button carrying an extra prompt action type, so it
+  // takes precedence over the plain event type when deriving the selection.
+  const actionValue: ActionOption =
+    element?.actionType === PromptActionTypes.SignOutConfirm
+      ? ACTION_OPTIONS.SignOut
+      : eventTypeValue === ActionEventTypes.Submit
+        ? ACTION_OPTIONS.Submit
+        : ACTION_OPTIONS.Trigger;
+
+  const handleActionChange = (nextAction: ActionOption): void => {
+    if (nextAction === ACTION_OPTIONS.SignOut) {
+      onChange('eventType', ActionEventTypes.Submit, resource);
+      onChange('actionType', PromptActionTypes.SignOutConfirm, resource);
+      return;
+    }
+
+    onChange('eventType', nextAction, resource);
+    // Clearing keeps the button from silently staying a sign-out confirmation
+    // after the author picks a plain action.
+    if (element?.actionType) {
+      onChange('actionType', '', resource);
+    }
+  };
 
   // Use local state for text inputs — provides immediate keystroke feedback while onChange is debounced
   const [startIconValue, setStartIconValue] = useState(() => {
@@ -77,17 +118,29 @@ function ButtonExtendedProperties({resource, onChange}: ButtonExtendedProperties
       <Divider sx={{marginY: 2}} />
 
       <div>
-        <FormLabel htmlFor="event-type-select">{t('flows:core.buttonExtendedProperties.type.label')}</FormLabel>
+        <FormLabel htmlFor="event-type-select">
+          {t('flows:core.buttonExtendedProperties.action.label', 'Action')}
+        </FormLabel>
         <Select
           id="event-type-select"
-          value={eventTypeValue}
-          onChange={(e) => onChange('eventType', e.target.value, resource)}
+          value={actionValue}
+          onChange={(e) => handleActionChange(e.target.value as ActionOption)}
           fullWidth
           size="small"
         >
-          <MenuItem value={ActionEventTypes.Submit}>{t('flows:core.buttonExtendedProperties.type.submit')}</MenuItem>
-          <MenuItem value={ActionEventTypes.Trigger}>{t('flows:core.buttonExtendedProperties.type.trigger')}</MenuItem>
+          <MenuItem value={ACTION_OPTIONS.Submit}>
+            {t('flows:core.buttonExtendedProperties.action.submit', 'Submit Form')}
+          </MenuItem>
+          <MenuItem value={ACTION_OPTIONS.Trigger}>
+            {t('flows:core.buttonExtendedProperties.action.trigger', 'Trigger Action')}
+          </MenuItem>
+          <MenuItem value={ACTION_OPTIONS.SignOut}>
+            {t('flows:core.buttonExtendedProperties.action.signOut', 'Trigger Signout')}
+          </MenuItem>
         </Select>
+        <FormHelperText>
+          {t('flows:core.buttonExtendedProperties.action.hint', 'What happens when the button is activated')}
+        </FormHelperText>
       </div>
 
       <div>

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/__tests__/ButtonExtendedProperties.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/__tests__/ButtonExtendedProperties.test.tsx
@@ -17,6 +17,7 @@
  */
 
 import {render, screen, fireEvent} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import ButtonExtendedProperties from '../ButtonExtendedProperties';
 import type {Resource} from '@/features/flows/models/resources';
@@ -205,13 +206,13 @@ describe('ButtonExtendedProperties', () => {
     });
   });
 
-  describe('Event Type', () => {
-    it('should render the event type label', () => {
+  describe('Action', () => {
+    it('should render the action label', () => {
       const resource = createMockResource();
 
       render(<ButtonExtendedProperties resource={resource} onChange={mockOnChange} />);
 
-      expect(screen.getByText('flows:core.buttonExtendedProperties.type.label')).toBeInTheDocument();
+      expect(screen.getByText('flows:core.buttonExtendedProperties.action.label')).toBeInTheDocument();
     });
 
     it('should default to TRIGGER when eventType is not set', () => {
@@ -220,7 +221,7 @@ describe('ButtonExtendedProperties', () => {
       const {container} = render(<ButtonExtendedProperties resource={resource} onChange={mockOnChange} />);
 
       const select = container.querySelector('#event-type-select');
-      expect(select).toHaveTextContent('flows:core.buttonExtendedProperties.type.trigger');
+      expect(select).toHaveTextContent('flows:core.buttonExtendedProperties.action.trigger');
     });
 
     it('should display SUBMIT when eventType is SUBMIT', () => {
@@ -229,7 +230,63 @@ describe('ButtonExtendedProperties', () => {
       const {container} = render(<ButtonExtendedProperties resource={resource} onChange={mockOnChange} />);
 
       const select = container.querySelector('#event-type-select');
-      expect(select).toHaveTextContent('flows:core.buttonExtendedProperties.type.submit');
+      expect(select).toHaveTextContent('flows:core.buttonExtendedProperties.action.submit');
+    });
+
+    it('should display Sign out when the button carries the sign-out confirm action', () => {
+      // A sign-out button is a submit button plus the prompt action type, so
+      // the action type has to win over the plain event type.
+      const resource = createMockResource({
+        actionType: 'SIGN_OUT_CONFIRM',
+        eventType: 'SUBMIT',
+      } as Partial<Resource>);
+
+      const {container} = render(<ButtonExtendedProperties resource={resource} onChange={mockOnChange} />);
+
+      const select = container.querySelector('#event-type-select');
+      expect(select).toHaveTextContent('flows:core.buttonExtendedProperties.action.signOut');
+    });
+
+    it('should write both the event type and the action type when Sign out is picked', async () => {
+      const user = userEvent.setup();
+      const resource = createMockResource({eventType: 'TRIGGER'} as Partial<Resource>);
+
+      render(<ButtonExtendedProperties resource={resource} onChange={mockOnChange} />);
+
+      await user.click(screen.getByRole('combobox'));
+      await user.click(screen.getByRole('option', {name: 'flows:core.buttonExtendedProperties.action.signOut'}));
+
+      expect(mockOnChange).toHaveBeenCalledWith('eventType', 'SUBMIT', resource);
+      expect(mockOnChange).toHaveBeenCalledWith('actionType', 'SIGN_OUT_CONFIRM', resource);
+    });
+
+    it('should clear the action type when moving from Sign out back to a plain action', async () => {
+      const user = userEvent.setup();
+      const resource = createMockResource({
+        actionType: 'SIGN_OUT_CONFIRM',
+        eventType: 'SUBMIT',
+      } as Partial<Resource>);
+
+      render(<ButtonExtendedProperties resource={resource} onChange={mockOnChange} />);
+
+      await user.click(screen.getByRole('combobox'));
+      await user.click(screen.getByRole('option', {name: 'flows:core.buttonExtendedProperties.action.trigger'}));
+
+      expect(mockOnChange).toHaveBeenCalledWith('eventType', 'TRIGGER', resource);
+      expect(mockOnChange).toHaveBeenCalledWith('actionType', '', resource);
+    });
+
+    it('should not clear the action type when it was never set', async () => {
+      const user = userEvent.setup();
+      const resource = createMockResource({eventType: 'TRIGGER'} as Partial<Resource>);
+
+      render(<ButtonExtendedProperties resource={resource} onChange={mockOnChange} />);
+
+      await user.click(screen.getByRole('combobox'));
+      await user.click(screen.getByRole('option', {name: 'flows:core.buttonExtendedProperties.action.submit'}));
+
+      expect(mockOnChange).toHaveBeenCalledWith('eventType', 'SUBMIT', resource);
+      expect(mockOnChange).not.toHaveBeenCalledWith('actionType', '', resource);
     });
   });
 

--- a/frontend/apps/console/src/features/flows/constants/ResourcePropertyPanelConstants.ts
+++ b/frontend/apps/console/src/features/flows/constants/ResourcePropertyPanelConstants.ts
@@ -53,6 +53,7 @@ class ResourcePropertyPanelConstants {
     'startIcon',
     'endIcon',
     'eventType',
+    'actionType',
     'classes',
   ];
 }

--- a/frontend/apps/console/src/features/flows/models/elements.ts
+++ b/frontend/apps/console/src/features/flows/models/elements.ts
@@ -32,6 +32,12 @@ export interface Element<T = unknown> extends Base<T> {
     [key: string]: unknown;
   };
   /**
+   * Semantic prompt action this element raises (see {@link PromptActionTypes}).
+   * Lives on the element rather than the edge so the choice survives redrawing
+   * the connection, and round-trips for free through `meta.components`.
+   */
+  actionType?: string;
+  /**
    * Space-separated list of CSS class names to apply to the rendered element.
    */
   classes?: string;
@@ -137,3 +143,16 @@ export const ActionEventTypes = {
 } as const;
 
 export type ActionEventTypes = (typeof ActionEventTypes)[keyof typeof ActionEventTypes];
+
+/**
+ * Semantic type of the prompt action a button raises, serialized as
+ * `prompts[].action.type` and forwarded by the prompt node to the next
+ * executor as edge metadata. Distinct from {@link ActionEventTypes}, which
+ * describes how the button behaves in the rendered form, and from
+ * `action.type` on the element, which carries canvas navigation semantics.
+ */
+export const PromptActionTypes = {
+  SignOutConfirm: 'SIGN_OUT_CONFIRM',
+} as const;
+
+export type PromptActionTypes = (typeof PromptActionTypes)[keyof typeof PromptActionTypes];

--- a/frontend/apps/console/src/features/flows/utils/__tests__/reactFlowTransformer.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/reactFlowTransformer.test.ts
@@ -256,6 +256,51 @@ describe('reactFlowTransformer', () => {
         });
       });
 
+      it("should carry a button's action type into the prompt action", () => {
+        const components: Element[] = [
+          {
+            id: 'button-1',
+            type: ElementTypes.Action,
+            category: ElementCategories.Action,
+            eventType: 'SUBMIT',
+            actionType: 'SIGN_OUT_CONFIRM',
+          } as Element & {eventType: string},
+        ];
+
+        const canvasData: ReactFlowCanvasData = {
+          nodes: [createNode('view-1', StepTypes.View, {x: 0, y: 0}, {components})],
+          edges: [createEdge('edge-1', 'view-1', 'session_signout', 'button-1_NEXT')],
+        };
+
+        const result = transformReactFlow(canvasData);
+
+        expect(result.nodes[0].prompts?.[0].action).toEqual({
+          ref: 'button-1',
+          nextNode: 'session_signout',
+          type: 'SIGN_OUT_CONFIRM',
+        });
+      });
+
+      it('should omit the action type when the button does not declare one', () => {
+        const components: Element[] = [
+          {
+            id: 'button-1',
+            type: ElementTypes.Action,
+            category: ElementCategories.Action,
+            eventType: 'SUBMIT',
+          } as Element & {eventType: string},
+        ];
+
+        const canvasData: ReactFlowCanvasData = {
+          nodes: [createNode('view-1', StepTypes.View, {x: 0, y: 0}, {components})],
+          edges: [createEdge('edge-1', 'view-1', 'next-node', 'button-1_NEXT')],
+        };
+
+        const result = transformReactFlow(canvasData);
+
+        expect(result.nodes[0].prompts?.[0].action).not.toHaveProperty('type');
+      });
+
       it('should handle nested components in forms', () => {
         const formComponent: Element = {
           id: 'form-1',

--- a/frontend/apps/console/src/features/flows/utils/reactFlowTransformer.ts
+++ b/frontend/apps/console/src/features/flows/utils/reactFlowTransformer.ts
@@ -94,6 +94,12 @@ interface FlowInput {
 interface FlowAction {
   ref: string;
   nextNode: string;
+  /**
+   * Semantic action type forwarded by the prompt node to the next executor
+   * (e.g. `SIGN_OUT_CONFIRM`, which tells the session sign-out executor the
+   * End-User has confirmed).
+   */
+  type?: string;
   executor?: {
     name: string;
     [key: string]: unknown;
@@ -373,6 +379,13 @@ function extractPrompts(components: Element[], nodeId: string, edges: Edge[]): F
 
       if (component.action?.executor) {
         action.executor = component.action.executor as {name: string; [key: string]: unknown};
+      }
+
+      // Authored on the button itself, so it survives the connection being
+      // redrawn; a prompt action only exists once the button is wired, which
+      // the `nextNode` guard below enforces.
+      if (component.actionType) {
+        action.type = component.actionType;
       }
 
       return action.nextNode ? action : undefined;

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -3813,9 +3813,11 @@ const translations = {
     'core.fieldExtendedProperties.selectAttribute': 'Select an attribute',
 
     // Button extended properties
-    'core.buttonExtendedProperties.type.label': 'Type',
-    'core.buttonExtendedProperties.type.submit': 'Submit',
-    'core.buttonExtendedProperties.type.trigger': 'Trigger',
+    'core.buttonExtendedProperties.action.label': 'Action',
+    'core.buttonExtendedProperties.action.submit': 'Submit Form',
+    'core.buttonExtendedProperties.action.trigger': 'Trigger Action',
+    'core.buttonExtendedProperties.action.signOut': 'Trigger Signout',
+    'core.buttonExtendedProperties.action.hint': 'What happens when the button is activated',
     'core.buttonExtendedProperties.startIcon.label': 'Start Icon',
     'core.buttonExtendedProperties.startIcon.placeholder': 'Enter icon path (e.g., assets/images/icons/icon.svg)',
     'core.buttonExtendedProperties.startIcon.hint': 'Optional icon displayed before the button label',


### PR DESCRIPTION
### Purpose

The button property panel exposed a **Type** dropdown that only ever set the element's `eventType`, with two options. This renames it to **Action** and adds a third option for the confirmation button of a sign-out flow:

| Option | `eventType` | prompt `action.type` |
|---|---|---|
| Submit Form | `SUBMIT` | — |
| Trigger Action | `TRIGGER` | — |
| Trigger Signout | `SUBMIT` | `SIGN_OUT_CONFIRM` |

Submit and Trigger behave exactly as before; nothing changes under the hood for them. Sign out is a composite: the button stays a submit, and additionally carries the `SIGN_OUT_CONFIRM` prompt action type, which the prompt node forwards to the session sign-out executor so it can tell a confirmed re-run from the initial request.

Authoring a sign-out confirmation previously required hand-editing the flow JSON.

### Approach

**The type lives on the element, not the edge.** `prompts[].action` is conceptually an edge (`ref` → `nextNode`), so storing the type on the connection is tempting, but it makes the authored value fragile: redrawing the connection creates a fresh edge and would silently downgrade the button back to a plain submit, and a control in the button's panel mutating an edge is surprising for undo/redo. Keeping it on the element means the choice survives rewiring and round-trips for free through `meta.components`, with no load-path transform needed. It is projected into `prompts[].action.type` during serialization, which only happens once the button is wired — matching how prompt actions already behave.

`actionType` is deliberately a new field rather than a reuse of `element.action.type`, which already carries the canvas navigation semantics (`NEXT` and the handle suffixes) and would collide.

**Two supporting registrations.** `actionType` is added to the panel's top-level editable properties, because otherwise the change is written into the element's `data` instead of onto the element, and the selector can neither read its own value back (so Sign out never appears selected) nor clear it again (so `SIGN_OUT_CONFIRM` sticks after switching away). It is also excluded from the generic property list, since the selector owns it — the same treatment `eventType` gets.

**Scope.** The remaining `ActionEventTypes` (`NAVIGATE`, `CANCEL`, `RESET`, `BACK`) stay unexposed. The SDK renderers already map `Reset`, `Cancel` and `Back` to real behaviour, so a flow importing them renders correctly; they simply have no authoring UI, and this change does not add one. `NAVIGATE` is declared on both sides but implemented on neither.

This is the console-side change only. The backend `SIGN_OUT_CONFIRM` action type and the executor that consumes it are handled separately.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added button actions for Submit Form, Trigger Action, and Trigger Sign Out.
  * Added support for sign-out confirmation prompts.
  * Button action settings now persist and appear correctly in flows.

* **Bug Fixes**
  * Fixed inconsistent storage and display of button action selections.
  * Prevented action-specific settings from appearing as generic properties.

* **Documentation**
  * Updated labels and guidance for button activation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->