### PR TITLE
Flag sign-out buttons that do not lead to the session sign-out step

### DIFF
--- a/frontend/apps/console/src/features/flows/components/FlowBuilder.tsx
+++ b/frontend/apps/console/src/features/flows/components/FlowBuilder.tsx
@@ -50,8 +50,9 @@ import FlowConstants from '@/features/flows/constants/FlowConstants';
 import useFlowConfig from '@/features/flows/hooks/useFlowConfig';
 import useFlowEvents from '@/features/flows/hooks/useFlowEvents';
 import useValidationStatus from '@/features/flows/hooks/useValidationStatus';
+import {FlowType} from '@/features/flows/models/flows';
 import {ExecutionTypes, StepTypes, type StepData} from '@/features/flows/models/steps';
-import {GRAPH_VALIDATION_RULES} from '@/features/flows/validation/validation-rules';
+import {GRAPH_VALIDATION_RULES, SIGN_OUT_GRAPH_VALIDATION_RULES} from '@/features/flows/validation/validation-rules';
 
 const SMS_EXECUTORS = new Set<string>([ExecutionTypes.SMSExecutor]);
 
@@ -229,7 +230,17 @@ function FlowBuilder() {
   // The SSO pairing rules only apply to AUTHENTICATION flows; other flow
   // types run without graph-level rules.
   useEffect(() => {
-    setGraphValidationRules(flowType === 'AUTHENTICATION' ? GRAPH_VALIDATION_RULES : []);
+    if (flowType === FlowType.AUTHENTICATION) {
+      setGraphValidationRules(GRAPH_VALIDATION_RULES);
+      return;
+    }
+
+    if (flowType === FlowType.SIGNOUT) {
+      setGraphValidationRules(SIGN_OUT_GRAPH_VALIDATION_RULES);
+      return;
+    }
+
+    setGraphValidationRules([]);
   }, [flowType, setGraphValidationRules]);
 
   // Undo/redo history over the canvas graph.

--- a/frontend/apps/console/src/features/flows/components/react-flow-overrides/__tests__/BaseEdge.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/react-flow-overrides/__tests__/BaseEdge.test.tsx
@@ -141,6 +141,8 @@ describe('BaseEdge', () => {
     setFlowEdgeTypes: vi.fn(),
     flowNodes: [],
     setFlowNodes: vi.fn(),
+    flowEdges: [],
+    setFlowEdges: vi.fn(),
     graphValidationRules: [],
     setGraphValidationRules: vi.fn(),
   };

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/CommonResourceProperties.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/CommonResourceProperties.test.tsx
@@ -163,6 +163,8 @@ describe('CommonResourceProperties', () => {
       setFlowEdgeTypes: vi.fn(),
       flowNodes: [],
       setFlowNodes: vi.fn(),
+      flowEdges: [],
+      setFlowEdges: vi.fn(),
       graphValidationRules: [],
       setGraphValidationRules: vi.fn(),
     };

--- a/frontend/apps/console/src/features/flows/components/visual-flow/DecoratedVisualFlow.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/DecoratedVisualFlow.tsx
@@ -211,7 +211,7 @@ function DecoratedVisualFlow({
   const {isResourcePanelOpen, isResourcePropertiesPanelOpen, setIsResourcePanelOpen, setIsOpenResourcePropertiesPanel} =
     useUIPanelState();
   const {notifyElementAdded, onAutoLayout} = useFlowEvents();
-  const {isFlowMetadataLoading, isVerboseMode, metadata, setFlowNodes} = useFlowConfig();
+  const {isFlowMetadataLoading, isVerboseMode, metadata, setFlowNodes, setFlowEdges} = useFlowConfig();
   const {onResourceDropOnCanvas} = useInteractionState();
 
   // Sync controlled nodes to the shared FlowConfig context so that
@@ -246,6 +246,21 @@ function DecoratedVisualFlow({
       setFlowNodes(validationNodes);
     }
   }, [nodes, sourceNodes, setFlowNodes]);
+
+  // Edges are pushed alongside the nodes so graph validation rules can inspect
+  // what an element connects to. Like the nodes, these must be the real graph
+  // rather than the compact display transform, whose stack rewiring would hide
+  // an element's true target. Keyed on a structural signature rather than array
+  // identity, which also changes on hover and simulation decoration.
+  const validationEdges = sourceEdges ?? edges;
+  const edgeSignature = validationEdges
+    .map((edge) => `${edge.id}|${edge.source}|${edge.sourceHandle ?? ''}|${edge.target}`)
+    .join(';');
+
+  useEffect(() => {
+    setFlowEdges(validationEdges);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [edgeSignature, setFlowEdges]);
   const {generateStepElement} = useGenerateStepElement();
   const {t} = useTranslation();
   const navigate = useNavigate();

--- a/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/CanvasToolbar.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/CanvasToolbar.test.tsx
@@ -75,6 +75,8 @@ describe('CanvasToolbar', () => {
     setFlowEdgeTypes: vi.fn(),
     flowNodes: [],
     setFlowNodes: vi.fn(),
+    flowEdges: [],
+    setFlowEdges: vi.fn(),
     graphValidationRules: [],
     setGraphValidationRules: vi.fn(),
   };

--- a/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/DecoratedVisualFlow.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/DecoratedVisualFlow.test.tsx
@@ -45,8 +45,9 @@ vi.mock('../../../hooks/useUIPanelState', () => ({
   }),
 }));
 
-const {mockFlowConfigState} = vi.hoisted(() => ({
+const {mockFlowConfigState, mockSetFlowEdges} = vi.hoisted(() => ({
   mockFlowConfigState: {isVerboseMode: true},
+  mockSetFlowEdges: vi.fn(),
 }));
 
 vi.mock('../../../hooks/useFlowConfig', () => ({
@@ -55,6 +56,7 @@ vi.mock('../../../hooks/useFlowConfig', () => ({
     isVerboseMode: mockFlowConfigState.isVerboseMode,
     metadata: undefined,
     setFlowNodes: vi.fn(),
+    setFlowEdges: mockSetFlowEdges,
   }),
 }));
 
@@ -635,6 +637,29 @@ describe('DecoratedVisualFlow', () => {
       expect(updated[0].position).toEqual({x: 200, y: 300});
       expect(updated[1].position).toEqual({x: 200, y: 300});
       expect(updated[2].position).toEqual({x: 3, y: 3});
+    });
+  });
+
+  describe('Validation graph sync', () => {
+    it('should publish the source edges rather than the compact display edges', () => {
+      const displayEdges = [
+        {id: 'e1', source: 'view-1', sourceHandle: 'button-1_NEXT', target: 'execution-stack_exec-a'},
+      ] as Edge[];
+      const sourceEdges = [{id: 'e1', source: 'view-1', sourceHandle: 'button-1_NEXT', target: 'exec-a'}] as Edge[];
+
+      renderComponent(<DecoratedVisualFlow {...defaultProps} edges={displayEdges} sourceEdges={sourceEdges} />);
+
+      // A stack rewires an edge onto a synthetic id, which would hide the
+      // element's real target from graph validation rules.
+      expect(mockSetFlowEdges).toHaveBeenCalledWith(sourceEdges);
+    });
+
+    it('should publish the edges as-is when there is no display transform', () => {
+      const edges = [{id: 'e1', source: 'view-1', sourceHandle: 'button-1_NEXT', target: 'exec-a'}] as Edge[];
+
+      renderComponent(<DecoratedVisualFlow {...defaultProps} edges={edges} />);
+
+      expect(mockSetFlowEdges).toHaveBeenCalledWith(edges);
     });
   });
 

--- a/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/EdgeStyleSelector.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/EdgeStyleSelector.test.tsx
@@ -56,6 +56,8 @@ describe('EdgeStyleMenu', () => {
     setFlowEdgeTypes: vi.fn(),
     flowNodes: [],
     setFlowNodes: vi.fn(),
+    flowEdges: [],
+    setFlowEdges: vi.fn(),
     graphValidationRules: [],
     setGraphValidationRules: vi.fn(),
   };

--- a/frontend/apps/console/src/features/flows/context/FlowBuilderCoreProvider.tsx
+++ b/frontend/apps/console/src/features/flows/context/FlowBuilderCoreProvider.tsx
@@ -19,7 +19,7 @@
 import {I18nDefaultConstants} from '@thunderid/i18n';
 import {Stack, Typography} from '@wso2/oxygen-ui';
 import {CogIcon} from '@wso2/oxygen-ui-icons-react';
-import {type EdgeTypes, type Node, type NodeTypes, ReactFlowProvider} from '@xyflow/react';
+import {type Edge, type EdgeTypes, type Node, type NodeTypes, ReactFlowProvider} from '@xyflow/react';
 import merge from 'lodash-es/merge';
 import startCase from 'lodash-es/startCase';
 import {
@@ -136,6 +136,7 @@ function FlowContextWrapper({
   const [isVerboseMode, setIsVerboseMode] = useState<boolean>(true);
   const [edgeStyle, setEdgeStyle] = useState<EdgeStyleTypesType>(EdgeStyleTypes.SmoothStep);
   const [flowNodes, setFlowNodes] = useState<Node[]>([]);
+  const [flowEdges, setFlowEdges] = useState<Edge[]>([]);
   const [graphValidationRules, setGraphValidationRules] = useState<GraphValidationRule[]>([]);
 
   // ── I18n State ──
@@ -331,6 +332,8 @@ function FlowContextWrapper({
       publishFlow: undefined as (() => Promise<boolean>) | undefined,
       flowNodes,
       setFlowNodes,
+      flowEdges,
+      setFlowEdges,
       graphValidationRules,
       setGraphValidationRules,
     }),
@@ -345,6 +348,7 @@ function FlowContextWrapper({
       flowNodeTypes,
       flowEdgeTypes,
       flowNodes,
+      flowEdges,
       graphValidationRules,
     ],
   );

--- a/frontend/apps/console/src/features/flows/context/FlowConfigContext.tsx
+++ b/frontend/apps/console/src/features/flows/context/FlowConfigContext.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import type {EdgeTypes, Node, NodeTypes} from '@xyflow/react';
+import type {Edge, EdgeTypes, Node, NodeTypes} from '@xyflow/react';
 import type {Context, Dispatch, FunctionComponent, SetStateAction} from 'react';
 import {createContext} from 'react';
 import type {FlowCompletionConfigsInterface} from '../models/flows';
@@ -113,6 +113,15 @@ export interface FlowConfigContextProps {
    * Setter to push the latest nodes into the shared context.
    */
   setFlowNodes: Dispatch<SetStateAction<Node[]>>;
+  /**
+   * Current React Flow edges, alongside {@link flowNodes}, so graph validation
+   * rules can also check what a node or one of its elements connects to.
+   */
+  flowEdges: Edge[];
+  /**
+   * Setter to push the latest edges into the shared context.
+   */
+  setFlowEdges: Dispatch<SetStateAction<Edge[]>>;
   /**
    * Cross-node validation rules active for the current flow. Empty by
    * default; flow-type-specific hosts register the rules that apply

--- a/frontend/apps/console/src/features/flows/context/ValidationProvider.tsx
+++ b/frontend/apps/console/src/features/flows/context/ValidationProvider.tsx
@@ -46,7 +46,7 @@ function ValidationProvider({
   },
 }: PropsWithChildren<ValidationProviderProps>): ReactElement {
   const {setIsOpenResourcePropertiesPanel, registerCloseValidationPanel} = useUIPanelState();
-  const {flowNodes, graphValidationRules} = useFlowConfig();
+  const {flowNodes, flowEdges, graphValidationRules} = useFlowConfig();
   const {t} = useTranslation();
 
   // Computed validation notifications — derived from flow node data + rule registry.
@@ -55,8 +55,8 @@ function ValidationProvider({
   // Graph rules are flow-type-specific and registered by the host (e.g. the
   // SSO pairing rules for AUTHENTICATION flows).
   const computedNotifications = useMemo(
-    () => computeValidationNotifications(flowNodes, VALIDATION_RULES, t, graphValidationRules),
-    [flowNodes, graphValidationRules, t],
+    () => computeValidationNotifications(flowNodes, VALIDATION_RULES, t, graphValidationRules, flowEdges),
+    [flowNodes, flowEdges, graphValidationRules, t],
   );
 
   // Operational notifications (e.g. delete errors from ReorderableElement).

--- a/frontend/apps/console/src/features/flows/hooks/__tests__/useVisualFlowHandlers.test.tsx
+++ b/frontend/apps/console/src/features/flows/hooks/__tests__/useVisualFlowHandlers.test.tsx
@@ -95,6 +95,8 @@ describe('useVisualFlowHandlers', () => {
     setFlowEdgeTypes: vi.fn(),
     flowNodes: [],
     setFlowNodes: vi.fn(),
+    flowEdges: [],
+    setFlowEdges: vi.fn(),
     graphValidationRules: [],
     setGraphValidationRules: vi.fn(),
   };

--- a/frontend/apps/console/src/features/flows/validation/__tests__/computeValidationNotifications.test.ts
+++ b/frontend/apps/console/src/features/flows/validation/__tests__/computeValidationNotifications.test.ts
@@ -16,12 +16,12 @@
  * under the License.
  */
 
-import type {Node} from '@xyflow/react';
+import type {Edge, Node} from '@xyflow/react';
 import {describe, it, expect, vi} from 'vitest';
 import {NotificationType} from '../../models/notification';
 import type {StepData} from '../../models/steps';
 import {computeValidationNotifications} from '../computeValidationNotifications';
-import {GRAPH_VALIDATION_RULES, VALIDATION_RULES} from '../validation-rules';
+import {GRAPH_VALIDATION_RULES, SIGN_OUT_GRAPH_VALIDATION_RULES, VALIDATION_RULES} from '../validation-rules';
 
 // Simple mock t function that returns the key
 const t = vi.fn((key: string) => key) as unknown as import('i18next').TFunction;
@@ -585,6 +585,90 @@ describe('computeValidationNotifications', () => {
       const notification = result.get('session_1_SSO_ORPHAN_SESSION')!;
       expect(notification.getType()).toBe(NotificationType.ERROR);
       expect(notification.hasResource('session_1')).toBe(true);
+    });
+  });
+  describe('Sign-out confirmation action rule', () => {
+    const signOutButtonNode = (nodeId: string, buttonId: string): Node =>
+      createNode({
+        id: nodeId,
+        data: {
+          components: [
+            {
+              id: 'block_1',
+              type: 'BLOCK',
+              category: 'BLOCK',
+              components: [
+                {id: buttonId, type: 'ACTION', category: 'ACTION', eventType: 'SUBMIT', actionType: 'SIGN_OUT_CONFIRM'},
+              ],
+            },
+          ],
+        } as unknown as StepData,
+      });
+
+    const signOutExecutorNode = (nodeId: string): Node =>
+      createNode({
+        id: nodeId,
+        data: {action: {executor: {name: 'SessionSignOutExecutor'}}} as unknown as StepData,
+      });
+
+    const edge = (source: string, sourceHandle: string, target: string) =>
+      ({id: `${source}-${target}`, source, sourceHandle, target}) as Edge;
+
+    it('should accept a sign-out button wired to a session sign-out step', () => {
+      const nodes = [signOutButtonNode('prompt_1', 'action_confirm'), signOutExecutorNode('session_signout')];
+      const edges = [edge('prompt_1', 'action_confirm_NEXT', 'session_signout')];
+
+      const result = computeValidationNotifications(nodes, VALIDATION_RULES, t, SIGN_OUT_GRAPH_VALIDATION_RULES, edges);
+
+      expect(result.has('action_confirm_SIGN_OUT_CONFIRM_INVALID_TARGET')).toBe(false);
+      expect(result.has('action_confirm_SIGN_OUT_CONFIRM_NOT_CONNECTED')).toBe(false);
+    });
+
+    it('should report a sign-out button that leads somewhere else', () => {
+      const nodes = [
+        signOutButtonNode('prompt_1', 'action_confirm'),
+        signOutExecutorNode('session_signout'),
+        createNode({id: 'some_other_step'}),
+      ];
+      const edges = [edge('prompt_1', 'action_confirm_NEXT', 'some_other_step')];
+
+      const result = computeValidationNotifications(nodes, VALIDATION_RULES, t, SIGN_OUT_GRAPH_VALIDATION_RULES, edges);
+
+      const notification = result.get('action_confirm_SIGN_OUT_CONFIRM_INVALID_TARGET')!;
+      expect(notification).toBeDefined();
+      // Semantically wrong rather than structurally broken: it must not block
+      // saving, and it highlights the button itself rather than the step.
+      expect(notification.getType()).toBe(NotificationType.WARNING);
+      expect(notification.hasResource('action_confirm')).toBe(true);
+    });
+
+    it('should report a sign-out button with no outgoing connection', () => {
+      const nodes = [signOutButtonNode('prompt_1', 'action_confirm'), signOutExecutorNode('session_signout')];
+
+      const result = computeValidationNotifications(nodes, VALIDATION_RULES, t, SIGN_OUT_GRAPH_VALIDATION_RULES, []);
+
+      const notification = result.get('action_confirm_SIGN_OUT_CONFIRM_NOT_CONNECTED')!;
+      expect(notification).toBeDefined();
+      expect(notification.getType()).toBe(NotificationType.WARNING);
+      expect(notification.hasResource('action_confirm')).toBe(true);
+    });
+
+    it('should ignore buttons that do not raise the sign-out action', () => {
+      const nodes = [
+        createNode({
+          id: 'prompt_1',
+          data: {
+            components: [{id: 'action_next', type: 'ACTION', category: 'ACTION', eventType: 'SUBMIT'}],
+          } as unknown as StepData,
+        }),
+      ];
+
+      const result = computeValidationNotifications(nodes, VALIDATION_RULES, t, SIGN_OUT_GRAPH_VALIDATION_RULES, []);
+
+      // Element-level rules may still report on the button; only the sign-out
+      // rule must stay silent.
+      const signOutIds = [...result.keys()].filter((id) => id.includes('SIGN_OUT_CONFIRM'));
+      expect(signOutIds).toEqual([]);
     });
   });
 });

--- a/frontend/apps/console/src/features/flows/validation/computeValidationNotifications.ts
+++ b/frontend/apps/console/src/features/flows/validation/computeValidationNotifications.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import type {Node} from '@xyflow/react';
+import type {Edge, Node} from '@xyflow/react';
 import type {TFunction} from 'i18next';
 import get from 'lodash-es/get';
 import {createElement, type ReactElement} from 'react';
@@ -153,6 +153,8 @@ function walkElements(
  * @param graphRules - Cross-node rules applied against the whole node set.
  *                     Empty by default; the host registers the rules that
  *                     apply to the current flow type.
+ * @param edges - All React Flow edges, for graph rules that check what a node
+ *                or one of its elements connects to.
  * @returns A map of notification ID → Notification.
  */
 export function computeValidationNotifications(
@@ -160,6 +162,7 @@ export function computeValidationNotifications(
   rules: ValidationRuleDefinition[],
   t: TFunction,
   graphRules: GraphValidationRule[] = [],
+  edges: Edge[] = [],
 ): Map<string, Notification> {
   const notifications = new Map<string, Notification>();
 
@@ -176,7 +179,7 @@ export function computeValidationNotifications(
   }
 
   for (const graphRule of graphRules) {
-    for (const notification of graphRule(nodes)) {
+    for (const notification of graphRule(nodes, edges)) {
       notifications.set(notification.getId(), notification);
     }
   }

--- a/frontend/apps/console/src/features/flows/validation/validation-rules.ts
+++ b/frontend/apps/console/src/features/flows/validation/validation-rules.ts
@@ -16,15 +16,16 @@
  * under the License.
  */
 
-import type {Node} from '@xyflow/react';
+import type {Edge, Node} from '@xyflow/react';
 import {createElement} from 'react';
 import {Trans} from 'react-i18next';
-import {ActionEventTypes, BlockTypes, ElementCategories, ElementTypes} from '../models/elements';
+import {ActionEventTypes, BlockTypes, ElementCategories, ElementTypes, PromptActionTypes} from '../models/elements';
 import type {Element as FlowElement} from '../models/elements';
 import Notification, {NotificationType} from '../models/notification';
 import type {Resource} from '../models/resources';
 import {ExecutionTypes, StepTypes} from '../models/steps';
 import type {StepData} from '../models/steps';
+import VisualFlowConstants from '@/features/flows/constants/VisualFlowConstants';
 
 /**
  * A single field that must have a non-empty value on a resource.
@@ -250,10 +251,11 @@ export const VALIDATION_RULES: ValidationRuleDefinition[] = [
 // ---------------------------------------------------------------------------
 
 /**
- * A validation rule that inspects the whole node set instead of a single
- * resource, for constraints that span multiple nodes.
+ * A validation rule that inspects the whole graph instead of a single
+ * resource, for constraints that span multiple nodes. Edges are passed too, so
+ * a rule can also check what a node or one of its elements connects to.
  */
-export type GraphValidationRule = (nodes: Node[]) => Notification[];
+export type GraphValidationRule = (nodes: Node[], edges: Edge[]) => Notification[];
 
 function getNodeExecutorName(node: Node): string | undefined {
   return (node.data as StepData | undefined)?.action?.executor?.name;
@@ -268,6 +270,28 @@ function createGraphErrorNotification(errorId: string, i18nKey: string, node: No
   const notification = new Notification(errorId, message, NotificationType.ERROR);
 
   notification.addResource(node as unknown as Resource);
+
+  return notification;
+}
+
+/**
+ * Attaches the notification to an element rather than a whole step, so the
+ * canvas highlights the offending element itself.
+ */
+function createGraphElementNotification(
+  notificationId: string,
+  i18nKey: string,
+  element: FlowElement,
+  type: NotificationType,
+): Notification {
+  const message = createElement(Trans, {
+    i18nKey,
+    values: {id: element.id},
+    components: {code: createElement('code')},
+  });
+  const notification = new Notification(notificationId, message, type);
+
+  notification.addResource(element as unknown as Resource);
 
   return notification;
 }
@@ -327,4 +351,77 @@ export const ssoPairingRule: GraphValidationRule = (nodes: Node[]): Notification
   return notifications;
 };
 
+/**
+ * Collects every element in a step that raises the sign-out confirmation
+ * action, including ones nested inside containers such as a form block.
+ */
+function collectSignOutConfirmElements(elements: FlowElement[] | undefined): FlowElement[] {
+  if (!elements) {
+    return [];
+  }
+
+  return elements.flatMap((element) => [
+    ...((element as FlowElement & {actionType?: string}).actionType === PromptActionTypes.SignOutConfirm
+      ? [element]
+      : []),
+    ...collectSignOutConfirmElements(element.components),
+  ]);
+}
+
+/**
+ * A sign-out confirmation button only does anything if it leads to the session
+ * sign-out node: the prompt node forwards the action type to whatever comes
+ * next, and only that executor acts on it. Wiring the button elsewhere, or
+ * leaving it unwired, is silently inert at runtime, so it is surfaced here.
+ *
+ * Mirrors the handle convention the serializer uses, where a button's outgoing
+ * edge leaves the step from `${elementId}_NEXT`.
+ */
+export const signOutConfirmActionRule: GraphValidationRule = (nodes: Node[], edges: Edge[]): Notification[] => {
+  const notifications: Notification[] = [];
+
+  const signOutNodeIds = new Set(
+    nodes.filter((node) => getNodeExecutorName(node) === ExecutionTypes.SessionSignOut).map((node) => node.id),
+  );
+
+  for (const node of nodes) {
+    const elements = collectSignOutConfirmElements((node.data as StepData | undefined)?.components);
+
+    for (const element of elements) {
+      const handleId = `${element.id}${VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX}`;
+      const edge = edges.find((candidate) => candidate.source === node.id && candidate.sourceHandle === handleId);
+
+      if (!edge) {
+        notifications.push(
+          createGraphElementNotification(
+            `${element.id}_SIGN_OUT_CONFIRM_NOT_CONNECTED`,
+            'flows:core.validation.signOut.confirmNotConnected',
+            element,
+            NotificationType.WARNING,
+          ),
+        );
+        continue;
+      }
+
+      if (!signOutNodeIds.has(edge.target)) {
+        notifications.push(
+          createGraphElementNotification(
+            `${element.id}_SIGN_OUT_CONFIRM_INVALID_TARGET`,
+            'flows:core.validation.signOut.confirmInvalidTarget',
+            element,
+            NotificationType.WARNING,
+          ),
+        );
+      }
+    }
+  }
+
+  return notifications;
+};
+
 export const GRAPH_VALIDATION_RULES: GraphValidationRule[] = [ssoPairingRule];
+
+/**
+ * Rules that apply to sign-out flows.
+ */
+export const SIGN_OUT_GRAPH_VALIDATION_RULES: GraphValidationRule[] = [signOutConfirmActionRule];

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -3573,6 +3573,12 @@ const translations = {
     'core.validation.sso.orphanSession':
       'Session step <code>{{id}}</code> is not referenced by any SSO check. Add an SSO check that uses it, or remove the step.',
 
+    // Validation messages - sign out
+    'core.validation.signOut.confirmNotConnected':
+      'Sign-out button <code>{{id}}</code> is not connected, so it will not sign the user out. Connect it to the session sign-out step, or change its action.',
+    'core.validation.signOut.confirmInvalidTarget':
+      'Sign-out button <code>{{id}}</code> does not lead to a session sign-out step, so it will not sign the user out. Connect it to one, or change its action.',
+
     // Elements - rich text
     'core.elements.richText.placeholder': 'Enter text here...',
     'core.elements.richText.resolvedI18nValue': 'Resolved i18n value',


### PR DESCRIPTION
### Purpose

A button whose action is **Trigger Signout** (added in #4456, now merged) only does anything if it leads to the session sign-out node: the prompt node forwards the action type to whatever comes next, and only `SessionSignOutExecutor` acts on it. Wiring the button anywhere else, or leaving it unwired, is accepted silently today and is simply inert at sign-out time.

This adds a graph validation rule for sign-out flows that reports both cases:

- the sign-out button has no outgoing connection;
- the sign-out button leads to a step that is not a session sign-out.

It is reported as a **warning, not an error**, and so does not block saving. The flow is structurally valid and will run; the button simply will not do what its action says. Blocking the save would also punish the natural authoring order, where the action is picked before the connection is drawn.

The notification is attached to the **button element** rather than the step, so the offending button is highlighted on the canvas instead of only appearing in the notifications panel. Elements are already wrapped in a validation boundary keyed on their id, so this needed no new plumbing.

### Approach

**Graph rules now see edges.** `GraphValidationRule` was `(nodes) => Notification[]`, which cannot express "what does this element connect to". It becomes `(nodes, edges) => Notification[]`. The existing SSO pairing rule is unaffected — it simply ignores the second argument.

The canvas already pushed its nodes into the flow config context so `ValidationProvider` can compute notifications without reaching into the inner React Flow store; edges now travel the same path. That sync is keyed on a **structural signature** of the edges (`id|source|sourceHandle|target`) rather than array identity, because hover highlighting and simulation decoration rewrite edge objects on every interaction without changing the graph, and validation should not recompute for those.

**Rule registration is per flow type.** `FlowBuilder` registered `GRAPH_VALIDATION_RULES` only for `AUTHENTICATION`; that becomes an explicit mapping so `SIGNOUT` flows get `SIGN_OUT_GRAPH_VALIDATION_RULES`, and everything else still gets none.

The rule walks nested containers, so a confirm button inside a form block is found, and it resolves the button's edge through the same `${elementId}_NEXT` handle convention the serializer uses — the check therefore matches exactly what would be written to `prompts[].action.nextNode`.

### Notes

The inverse check — a session sign-out node with **Prompt for Confirmation** enabled but no confirm action wired back to it — is deliberately not included here. It is a reasonable follow-up, but it belongs with the executor's own properties rather than the button's action.

Rebased onto `main` after #4456 and the compact view mode (#4450) merged. The compact mode matters here: it hands the canvas a display-only graph where a collapsed executor stack rewires edges onto synthetic node ids, so the edges published for validation are the **source** edges, not the displayed ones. Otherwise a sign-out button pointing into a collapsed stack would look like it targets a node that does not exist.

### Related Issues
- Refs #4451

### Related PRs
- Follows #4456 (merged)

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for sign-out flows to ensure confirmation actions connect correctly to session sign-out steps.
  * Validation now applies flow-specific rules for authentication and sign-out flows.

* **Bug Fixes**
  * Improved flow validation accuracy by tracking graph connections, including transformed visual edges.
  * Added clear messages for missing or incorrectly connected sign-out actions.

* **Tests**
  * Added coverage for valid, invalid, missing, and unrelated sign-out connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->