### PR TITLE
Keep the flow builder canvas still when a node is deleted

### DIFF
--- a/frontend/apps/console/src/features/flows/components/visual-flow/DecoratedVisualFlow.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/DecoratedVisualFlow.tsx
@@ -39,6 +39,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type MouseEvent as ReactMouseEvent,
   type ReactElement,
   type ReactNode,
   type SetStateAction,
@@ -544,7 +545,7 @@ function DecoratedVisualFlow({
   }, [edges, simulation.isSimulating, simulation.pathEdges, simulation.previewedOption]);
 
   const handleNodeClick = useCallback(
-    (_event: unknown, node: Node): void => {
+    (event: ReactMouseEvent, node: Node): void => {
       // Bring the clicked node into focus so it is comfortable to configure,
       // especially in large flows viewed zoomed-out. Honors the simulation's
       // static-view toggle — no camera jumps when the user opted out.
@@ -556,11 +557,24 @@ function DecoratedVisualFlow({
       if (node.type === EXECUTION_STACK_NODE_TYPE) {
         return;
       }
+      // The node header's actions (configure, delete) are inside the node, so
+      // their clicks arrive here too. Deleting this way used to throw the
+      // canvas to the origin: React Flow queues a fitView and runs it after the
+      // next node update, which is the deletion itself, leaving it with no node
+      // to fit. Re-centring on a button press is unwanted regardless, so the
+      // header actions never move the camera.
+      if (event.target instanceof Element && event.target.closest('button')) {
+        return;
+      }
+      // Also skip a node that has already left the canvas, for the same reason.
+      if (!getNodes().some((candidate) => candidate.id === node.id)) {
+        return;
+      }
       fitView({nodes: [{id: node.id}], padding: 0.3, maxZoom: 1.2, duration: 500}).catch(() => {
         // Ignore fitView errors - focusing is best-effort
       });
     },
-    [fitView, simulation.isSimulating, simulation.followCamera],
+    [fitView, getNodes, simulation.isSimulating, simulation.followCamera],
   );
 
   const handleEdgeMouseEnter = useCallback(

--- a/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/DecoratedVisualFlow.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/DecoratedVisualFlow.test.tsx
@@ -277,8 +277,10 @@ vi.mock('../VisualFlow', () => ({
       <button data-testid="node-drag-stop-trigger" onClick={onNodeDragStop}>
         Node Drag Stop
       </button>
-      <button
+      {/* A click on the node body: not a button, so it focuses the node. */}
+      <div
         data-testid="node-click-trigger"
+        role="presentation"
         onClick={(event) =>
           (onNodeClick as ((e: unknown, n: unknown) => void) | undefined)?.(event, {
             id: 'clicked-node',
@@ -287,6 +289,19 @@ vi.mock('../VisualFlow', () => ({
         }
       >
         Node Click
+      </div>
+      {/* A click on a node header action (configure, delete), which reaches
+          onNodeClick through the node but must not move the camera. */}
+      <button
+        data-testid="node-action-click-trigger"
+        onClick={(event) =>
+          (onNodeClick as ((e: unknown, n: unknown) => void) | undefined)?.(event, {
+            id: 'clicked-node',
+            position: {x: 0, y: 0},
+          })
+        }
+      >
+        Node Action Click
       </button>
     </div>
   ),
@@ -455,6 +470,9 @@ describe('DecoratedVisualFlow', () => {
     });
 
     it('should focus the clicked node via fitView', () => {
+      // Focusing is skipped for a node that is no longer on the canvas.
+      mockGetNodes.mockReturnValue([{id: 'clicked-node', position: {x: 0, y: 0}, data: {}}]);
+
       renderComponent(<DecoratedVisualFlow {...defaultProps} />);
 
       fireEvent.click(screen.getByTestId('node-click-trigger'));
@@ -662,6 +680,45 @@ describe('DecoratedVisualFlow', () => {
       await waitFor(() => {
         expect(mockApplyAutoLayout).toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('Node focus on click', () => {
+    it('should focus a node that is still on the canvas', () => {
+      mockGetNodes.mockReturnValue([{id: 'clicked-node', position: {x: 0, y: 0}, data: {}}]);
+
+      renderComponent(<DecoratedVisualFlow {...defaultProps} />);
+      screen.getByTestId('node-click-trigger').click();
+
+      expect(mockFitView).toHaveBeenCalledWith({
+        nodes: [{id: 'clicked-node'}],
+        padding: 0.3,
+        maxZoom: 1.2,
+        duration: 500,
+      });
+    });
+
+    it('should leave the viewport alone when a node header action is clicked', () => {
+      // Deleting from the node header queues a fitView that resolves after the
+      // node is gone, which fits nothing and snaps the canvas to the origin.
+      mockGetNodes.mockReturnValue([{id: 'clicked-node', position: {x: 0, y: 0}, data: {}}]);
+
+      renderComponent(<DecoratedVisualFlow {...defaultProps} />);
+      screen.getByTestId('node-action-click-trigger').click();
+
+      expect(mockFitView).not.toHaveBeenCalled();
+    });
+
+    it('should leave the viewport alone when the clicked node is already gone', () => {
+      // Deleting a node clicks it on the way out, and React Flow can deliver
+      // that click after the removal. Fitting to it would match nothing and
+      // snap the canvas to the origin.
+      mockGetNodes.mockReturnValue([{id: 'some-other-node', position: {x: 0, y: 0}, data: {}}]);
+
+      renderComponent(<DecoratedVisualFlow {...defaultProps} />);
+      screen.getByTestId('node-click-trigger').click();
+
+      expect(mockFitView).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
### Purpose

Fixes a flow builder canvas bug where deleting a node threw the viewport across the flow, usually landing near the origin. The camera should simply stay where it is when a node is removed.

The jump comes from the click-to-focus behaviour. React Flow does not run `fitView` immediately: it sets `fitViewQueued` and defers the fit until the next node update. When that next update is the deletion itself, the fit matches no node, and an empty fit resolves to a zero-sized rect at the origin.

Deleting from the properties panel was never affected, because that panel sits outside the canvas and its click never reaches `onNodeClick`. The node header's delete button does, since it lives inside the node, which is why the jump only showed up on that path.

### Approach

`handleNodeClick` in `DecoratedVisualFlow` now skips focusing in two cases:

1. The click originated from a control in the node header. The configure and delete actions are MUI `IconButton`s, so they render real `<button>` elements and are matched with `event.target.closest('button')`. Compact chips and stacks use `div role="button"`, so their focus behaviour is unchanged. Re-centring the camera on a button press is undesirable in its own right, so this is the correct behaviour rather than a workaround.
2. The node is already gone from the canvas, as a second layer for any other path that can deliver a stale click.

The existing test harness fired node clicks from a `<button>`, which the new guard legitimately skips, so it was split into a body-click trigger (`div role="presentation"`) and a separate header-action trigger that covers the delete-button path.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved canvas focus behavior when selecting flow nodes.
  * Clicking node action controls no longer unexpectedly changes the canvas view.
  * Removed or unavailable nodes are safely ignored when focusing the canvas.

* **Tests**
  * Added coverage for node-body clicks, header actions, and removed nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->