### PR TITLE
Improve the flow builder validation notifications panel design

### DIFF
--- a/frontend/apps/console/src/features/flows/components/validation-panel/ValidationNotificationsList.tsx
+++ b/frontend/apps/console/src/features/flows/components/validation-panel/ValidationNotificationsList.tsx
@@ -90,7 +90,27 @@ function ValidationNotificationsList({
             <Box sx={{color: `${type}.main`, display: 'inline-flex', flexShrink: 0, mt: '2px'}}>
               {severityIcon(type)}
             </Box>
-            <Typography variant="body2" sx={{flex: 1, textAlign: 'left'}}>
+            <Typography
+              variant="body2"
+              sx={{
+                flex: 1,
+                textAlign: 'left',
+                lineHeight: 1.5,
+                // Messages name the offending resource in a <code> tag. Left
+                // unstyled it reads as raw monospace mid-sentence; as a chip it
+                // scans as an identifier, and breaking on long ids keeps it
+                // inside the panel.
+                '& code': {
+                  fontFamily: 'monospace',
+                  fontSize: '0.8125em',
+                  px: 0.5,
+                  py: '1px',
+                  borderRadius: 0.5,
+                  bgcolor: 'action.hover',
+                  wordBreak: 'break-all',
+                },
+              }}
+            >
               {notification.getMessage()}
             </Typography>
             {isNavigable && (
@@ -101,7 +121,9 @@ function ValidationNotificationsList({
                   flexShrink: 0,
                   alignSelf: 'center',
                   color: `${type}.main`,
-                  opacity: 0,
+                  // Kept faintly visible rather than hover-only, so the row
+                  // advertises that it navigates to the resource.
+                  opacity: 0.45,
                   transition: 'opacity 0.15s ease',
                 }}
               >
@@ -111,16 +133,20 @@ function ValidationNotificationsList({
           </>
         );
 
+        // Severity is otherwise carried only by a small icon, which makes a
+        // mixed list hard to scan. A tint and a matching border give each row
+        // its severity at a glance without shouting.
         const rowSx = {
           display: 'flex',
           alignItems: 'flex-start',
-          gap: 1,
+          gap: 1.25,
           width: '100%',
           px: 1.5,
           py: 1.25,
           borderRadius: 1.5,
           border: '1px solid',
-          borderColor: 'divider',
+          borderColor: `color-mix(in srgb, var(--oxygen-palette-${type}-main) 28%, transparent)`,
+          bgcolor: `color-mix(in srgb, var(--oxygen-palette-${type}-main) 7%, transparent)`,
         } as const;
 
         if (!isNavigable) {
@@ -141,7 +167,7 @@ function ValidationNotificationsList({
               ...rowSx,
               '&:hover': {
                 borderColor: `${type}.main`,
-                bgcolor: 'action.hover',
+                bgcolor: `color-mix(in srgb, var(--oxygen-palette-${type}-main) 14%, transparent)`,
                 '& .notification-open-icon': {opacity: 1},
               },
             }}

--- a/frontend/apps/console/src/features/flows/components/validation-panel/ValidationPanel.scss
+++ b/frontend/apps/console/src/features/flows/components/validation-panel/ValidationPanel.scss
@@ -49,24 +49,6 @@
     width: 100%;
     border-radius: 8px;
 
-    &.MuiAlert-standardError {
-      background-color: rgba(var(--oxygen-palette-error-mainChannel) / 0.12);
-      border: 1px solid rgba(var(--oxygen-palette-error-mainChannel) / 0.3);
-      color: var(--oxygen-palette-error-light);
-    }
-
-    &.MuiAlert-standardWarning {
-      background-color: rgba(var(--oxygen-palette-warning-mainChannel) / 0.12);
-      border: 1px solid rgba(var(--oxygen-palette-warning-mainChannel) / 0.3);
-      color: var(--oxygen-palette-warning-light);
-    }
-
-    &.MuiAlert-standardInfo {
-      background-color: rgba(var(--oxygen-palette-info-mainChannel) / 0.12);
-      border: 1px solid rgba(var(--oxygen-palette-info-mainChannel) / 0.3);
-      color: var(--oxygen-palette-info-light);
-    }
-
     .notification-action-button {
       padding: 0;
       width: auto;

--- a/frontend/apps/console/src/features/flows/components/validation-panel/ValidationPanel.tsx
+++ b/frontend/apps/console/src/features/flows/components/validation-panel/ValidationPanel.tsx
@@ -209,7 +209,6 @@ function ValidationPanel({open = false}: ValidationPanelProps): ReactElement {
       {/* Tabs */}
       <Box
         sx={{
-          px: 2,
           borderBottom: '1px solid',
           borderColor: 'divider',
         }}


### PR DESCRIPTION
### Purpose

Polishes the flow builder's validation notifications panel, which read as a flat list of undifferentiated rows regardless of severity, and left the tab bar visually inset from the panel it belongs to.

### Approach

- Each notification row now carries a subtle severity tint derived from its own palette colour via `color-mix()`, so errors, warnings and info are distinguishable at a glance without adding weight to the list. Hover deepens the same tint rather than switching to a generic grey.
- Resource references embedded in notification messages render as inline code chips (monospace, tinted background, wrapping on long identifiers) so the offending element stands out from the surrounding sentence.
- The navigation arrow on clickable rows is now faintly visible at rest instead of fully transparent, so it is discoverable as an affordance before hovering.
- Dropped the horizontal padding around the tab bar so its bottom border runs the full width of the panel.
- Removed dead `MuiAlert-standard*` rules from `ValidationPanel.scss` that no longer match anything after the row markup changed.

Note that `ValidationPanel.scss` as a whole is not imported anywhere. I left the file in place rather than widening this PR, but it looks like a candidate for removal in a follow-up.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
