### PR TITLE
Replace nested token tabs with an audience selector

### DIFF
--- a/frontend/apps/console/src/features/agents/components/edit-agent/tokens/AgentAccessTokenSection.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/tokens/AgentAccessTokenSection.tsx
@@ -64,7 +64,7 @@ export default function AgentAccessTokenSection({
         attributesTitle: t('agents:edit.tokens.agent.attributes.title', 'Access Token Attributes'),
         attributesDescription: t(
           'agents:edit.tokens.agent.attributes.description',
-          'Attributes included in the access token this agent receives for its own requests (client_credentials grant).',
+          'Extra attributes to add to the access token this agent receives for itself.',
         ),
         attributesLabel: t('agents:edit.tokens.agent.attributes.label', 'Add or Remove Attributes'),
         attributesHint: t(

--- a/frontend/apps/console/src/features/agents/components/edit-agent/tokens/EditTokensSettings.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/tokens/EditTokensSettings.tsx
@@ -3,13 +3,19 @@
 
 import {OAuth2GrantTypes} from '@thunderid/configure-applications';
 import type {Application} from '@thunderid/configure-applications';
-import {Box, Stack, Tab, Tabs} from '@wso2/oxygen-ui';
-import {useEffect, useState, type JSX, type SyntheticEvent} from 'react';
-import {useTranslation} from 'react-i18next';
+import {Alert, Link, Stack} from '@wso2/oxygen-ui';
+import {Lock} from '@wso2/oxygen-ui-icons-react';
+import {useEffect, useState, type JSX} from 'react';
+import {Trans, useTranslation} from 'react-i18next';
 import AgentAccessTokenSection from './AgentAccessTokenSection';
-import SettingsLockNotice from '../../../../applications/components/common/SettingsLockNotice';
+import TokenAudienceSelector, {
+  type TokenAudienceOption,
+} from '../../../../applications/components/common/TokenAudienceSelector';
 import EditTokenSettings from '../../../../applications/components/edit-application/token-settings/EditTokenSettings';
 import type {Agent, OAuthAgentConfig} from '../../../models/agent';
+
+const AGENT_AUDIENCE = 'agent';
+const USER_AUDIENCE = 'user';
 
 interface EditTokensSettingsProps {
   agent: Agent;
@@ -18,6 +24,8 @@ interface EditTokensSettingsProps {
   onFieldChange: (field: keyof Agent, value: unknown) => void;
   onValidationChange?: (hasErrors: boolean) => void;
   sectionResetKey?: number;
+  /** Switches the edit page to its Advanced tab, where Delegated mode is turned on. */
+  onNavigateToAdvanced?: () => void;
 }
 
 export default function EditTokensSettings({
@@ -27,69 +35,83 @@ export default function EditTokensSettings({
   onFieldChange,
   onValidationChange = undefined,
   sectionResetKey = 0,
+  onNavigateToAdvanced = undefined,
 }: EditTokensSettingsProps): JSX.Element {
   const {t} = useTranslation();
-  const [subTab, setSubTab] = useState(0);
+  const [audience, setAudience] = useState(AGENT_AUDIENCE);
   const [userTabHasError, setUserTabHasError] = useState(false);
   const [agentTabHasError, setAgentTabHasError] = useState(false);
 
   const isUnlocked = oauth2Config?.grantTypes?.includes(OAuth2GrantTypes.AUTHORIZATION_CODE) ?? false;
 
+  // The user audience is not mounted without Delegated mode, so its last reported error state must
+  // not keep blocking the save bar.
   useEffect(() => {
-    onValidationChange?.(userTabHasError || agentTabHasError);
-  }, [userTabHasError, agentTabHasError, onValidationChange]);
+    onValidationChange?.((isUnlocked && userTabHasError) || agentTabHasError);
+  }, [isUnlocked, userTabHasError, agentTabHasError, onValidationChange]);
 
-  // Forcing isReadOnly disables every input via EditTokenSettings' existing
-  // disabled={application.isReadOnly} wiring when Delegated mode isn't on.
-  const appLikeAgent = {...agent, isReadOnly: (agent.isReadOnly ?? false) || !isUnlocked} as unknown as Application;
+  const appLikeAgent = {...agent, isReadOnly: agent.isReadOnly ?? false} as unknown as Application;
   const appHandleFieldChange = onFieldChange as unknown as (field: keyof Application, value: unknown) => void;
 
-  const handleSubTabChange = (_event: SyntheticEvent, newValue: number): void => {
-    setSubTab(newValue);
-  };
+  const audienceOptions: TokenAudienceOption[] = [
+    {
+      value: AGENT_AUDIENCE,
+      label: t('agents:edit.tokens.tabs.agent', 'Agent'),
+      description: t('agents:edit.tokens.audience.agent.description', 'Tokens for the agent acting on its own'),
+    },
+    {
+      value: USER_AUDIENCE,
+      label: t('agents:edit.tokens.tabs.user', 'User'),
+      description: t('agents:edit.tokens.audience.user.description', 'Tokens for the agent acting on behalf of a user'),
+      isLocked: !isUnlocked,
+    },
+  ];
 
   return (
-    <Box>
-      <Tabs value={subTab} onChange={handleSubTabChange} aria-label="agent token settings sub-tabs">
-        <Tab label={t('agents:edit.tokens.tabs.agent', 'Agent')} sx={{textTransform: 'none'}} />
-        <Tab label={t('agents:edit.tokens.tabs.user', 'User')} sx={{textTransform: 'none'}} />
-      </Tabs>
-      <Box sx={{pt: 3}}>
-        {subTab === 0 && (
-          <AgentAccessTokenSection
-            key={sectionResetKey}
-            agent={agent}
-            editedAgent={editedAgent}
-            oauth2Config={oauth2Config}
-            onFieldChange={onFieldChange}
-            onValidationChange={setAgentTabHasError}
+    <TokenAudienceSelector
+      title={t('agents:edit.tokens.audience.title', 'Issued to')}
+      options={audienceOptions}
+      value={audience}
+      onChange={setAudience}
+      footnote={t('agents:edit.tokens.audience.footnote', 'Claim sets are configured independently for each audience.')}
+    >
+      {audience === AGENT_AUDIENCE && (
+        <AgentAccessTokenSection
+          key={sectionResetKey}
+          agent={agent}
+          editedAgent={editedAgent}
+          oauth2Config={oauth2Config}
+          onFieldChange={onFieldChange}
+          onValidationChange={setAgentTabHasError}
+        />
+      )}
+      {audience === USER_AUDIENCE && !isUnlocked && (
+        <Alert severity="info" icon={<Lock size={20} />}>
+          <Trans
+            i18nKey="agents:edit.tokens.delegationLock.message"
+            defaults="This agent does not receive tokens on behalf of a user. Turn on Delegated mode in the <advancedLink>Advanced tab</advancedLink> to configure them."
+            components={{
+              advancedLink: <Link component="button" type="button" underline="always" onClick={onNavigateToAdvanced} />,
+            }}
           />
-        )}
-        {subTab === 1 && (
-          <SettingsLockNotice
-            isUnlocked={isUnlocked}
-            message={t(
-              'agents:edit.tokens.delegationLock.message',
-              'These settings are frozen for this agent. Turn on Delegated mode in the Advanced tab to unlock and start using them.',
-            )}
-          >
-            <Stack spacing={3}>
-              <EditTokenSettings
-                application={appLikeAgent}
-                oauth2Config={oauth2Config}
-                onFieldChange={appHandleFieldChange}
-                onValidationChange={setUserTabHasError}
-                entityLabel="agent"
-                showUserInfoTab={false}
-                showActorClaim
-                actorSub={agent.id}
-                certificateLocation="Credentials"
-                sectionResetKey={sectionResetKey}
-              />
-            </Stack>
-          </SettingsLockNotice>
-        )}
-      </Box>
-    </Box>
+        </Alert>
+      )}
+      {audience === USER_AUDIENCE && isUnlocked && (
+        <Stack spacing={3}>
+          <EditTokenSettings
+            application={appLikeAgent}
+            oauth2Config={oauth2Config}
+            onFieldChange={appHandleFieldChange}
+            onValidationChange={setUserTabHasError}
+            entityLabel="agent"
+            showUserInfoTab={false}
+            showActorClaim
+            actorSub={agent.id}
+            certificateLocation="Credentials"
+            sectionResetKey={sectionResetKey}
+          />
+        </Stack>
+      )}
+    </TokenAudienceSelector>
   );
 }

--- a/frontend/apps/console/src/features/agents/components/edit-agent/tokens/__tests__/EditTokensSettings.test.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/tokens/__tests__/EditTokensSettings.test.tsx
@@ -34,11 +34,13 @@ vi.mock('../AgentAccessTokenSection', () => ({
   },
 }));
 
+const delegationLockMessage = /does not receive tokens on behalf of a user/i;
+
 describe('EditTokensSettings', () => {
   const mockOnFieldChange = vi.fn();
   const baseAgent: Agent = {id: 'agent-1', ouId: 'ou-1', type: 'default', name: 'Test Agent'};
 
-  it('shows both "Agent" and "User" secondary tabs, defaulting to Agent', () => {
+  it('shows both "Agent" and "User" audiences, defaulting to Agent', () => {
     render(
       <EditTokensSettings
         agent={baseAgent}
@@ -48,9 +50,24 @@ describe('EditTokensSettings', () => {
       />,
     );
 
-    expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual(['Agent', 'User']);
+    expect(screen.getAllByRole('tab').map((tab) => tab.getAttribute('aria-label'))).toEqual(['Agent', 'User']);
+    expect(screen.getByRole('tab', {name: 'Agent'})).toHaveAttribute('aria-selected', 'true');
     expect(screen.getByTestId('agent-access-token')).toBeInTheDocument();
     expect(screen.queryByTestId('token-settings')).not.toBeInTheDocument();
+  });
+
+  it('describes each audience next to its label', () => {
+    render(
+      <EditTokensSettings
+        agent={baseAgent}
+        editedAgent={{}}
+        oauth2Config={{grantTypes: ['authorization_code'], responseTypes: ['code']}}
+        onFieldChange={mockOnFieldChange}
+      />,
+    );
+
+    expect(screen.getByText('Tokens for the agent acting on its own')).toBeInTheDocument();
+    expect(screen.getByText('Tokens for the agent acting on behalf of a user')).toBeInTheDocument();
   });
 
   it('switches to the User tab content when clicked', async () => {
@@ -84,10 +101,10 @@ describe('EditTokensSettings', () => {
     await user.click(screen.getByRole('tab', {name: 'User'}));
 
     expect(screen.getByTestId('token-settings')).toHaveAttribute('data-readonly', 'false');
-    expect(screen.queryByText(/These settings are frozen for this agent/)).not.toBeInTheDocument();
+    expect(screen.queryByText(delegationLockMessage)).not.toBeInTheDocument();
   });
 
-  it('forces token settings read-only and shows the lock notice when Delegated mode is off', async () => {
+  it('shows only the notice in place of token settings when Delegated mode is off', async () => {
     const user = userEvent.setup();
     render(
       <EditTokensSettings
@@ -98,10 +115,32 @@ describe('EditTokensSettings', () => {
       />,
     );
 
+    // The notice belongs to the User audience, so it stays out of the way until opened.
+    expect(screen.queryByText(delegationLockMessage)).not.toBeInTheDocument();
+
     await user.click(screen.getByRole('tab', {name: 'User'}));
 
-    expect(screen.getByTestId('token-settings')).toHaveAttribute('data-readonly', 'true');
-    expect(screen.getByText(/These settings are frozen for this agent/)).toBeInTheDocument();
+    expect(screen.getByText(delegationLockMessage)).toBeInTheDocument();
+    expect(screen.queryByTestId('token-settings')).not.toBeInTheDocument();
+  });
+
+  it('sends the user to the Advanced tab from the delegation notice', async () => {
+    const user = userEvent.setup();
+    const onNavigateToAdvanced = vi.fn();
+    render(
+      <EditTokensSettings
+        agent={baseAgent}
+        editedAgent={{}}
+        oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
+        onFieldChange={mockOnFieldChange}
+        onNavigateToAdvanced={onNavigateToAdvanced}
+      />,
+    );
+
+    await user.click(screen.getByRole('tab', {name: 'User'}));
+    await user.click(screen.getByRole('button', {name: 'Advanced tab'}));
+
+    expect(onNavigateToAdvanced).toHaveBeenCalledTimes(1);
   });
 
   it('stays read-only when the agent is already read-only, even with Delegated mode on', async () => {

--- a/frontend/apps/console/src/features/agents/pages/AgentEditPage.tsx
+++ b/frontend/apps/console/src/features/agents/pages/AgentEditPage.tsx
@@ -325,6 +325,7 @@ export default function AgentEditPage(): JSX.Element {
           onFieldChange={handleFieldChange}
           onValidationChange={handleValidationChange('token')}
           sectionResetKey={sectionResetKey}
+          onNavigateToAdvanced={() => handleNavigateToTab('advanced')}
         />
       ),
     });
@@ -342,6 +343,16 @@ export default function AgentEditPage(): JSX.Element {
       ),
     });
   }
+
+  // Lets a tab's content send the user to a sibling tab, e.g. the Tokens tab pointing at where
+  // Delegated mode is turned on. Resolved by key at click time, since which tabs exist depends on
+  // the agent's configuration.
+  const handleNavigateToTab = (key: string): void => {
+    const index = tabs.findIndex((tab) => tab.key === key);
+    if (index >= 0) {
+      setActiveTab(index);
+    }
+  };
 
   const safeActiveTab = activeTab >= tabs.length ? 0 : activeTab;
 

--- a/frontend/apps/console/src/features/applications/components/common/TokenAudienceSelector.tsx
+++ b/frontend/apps/console/src/features/applications/components/common/TokenAudienceSelector.tsx
@@ -1,0 +1,139 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {Box, Grid, Paper, Tab, Tabs, Typography} from '@wso2/oxygen-ui';
+import {Lock} from '@wso2/oxygen-ui-icons-react';
+import type {ReactNode, SyntheticEvent} from 'react';
+
+const TAB_ID_PREFIX = 'token-audience-tab-';
+const PANEL_ID = 'token-audience-panel';
+const DESCRIPTION_ID_PREFIX = 'token-audience-description-';
+
+/** One selectable token audience, i.e. one subject a token can be issued to. */
+export interface TokenAudienceOption {
+  /** Stable identifier passed back to onChange. */
+  value: string;
+  /** Short name shown in the selector, e.g. "Application". */
+  label: string;
+  /** One line describing which token this audience configures. */
+  description: string;
+  /** Whether this audience's settings do not apply to the current entity. */
+  isLocked?: boolean;
+}
+
+interface TokenAudienceSelectorProps {
+  /** Heading above the audience list, and the accessible name of the tab list. */
+  title: string;
+  options: TokenAudienceOption[];
+  /** The selected option's `value`. */
+  value: string;
+  onChange: (value: string) => void;
+  /** Optional note under the list, e.g. that each audience is configured independently. */
+  footnote?: string;
+  /** Settings for the selected audience. */
+  children: ReactNode;
+}
+
+/**
+ * Two-column token settings layout: a vertical tab list of token audiences on the left, and the
+ * selected audience's settings on the right.
+ *
+ * Built on the design system's Tabs so the full tab interaction model comes for free: roving focus,
+ * arrow key navigation, and Home/End. The tabs are styled as cards to match the audience design.
+ * Each tab's accessible name stays the audience label alone, with the description referenced rather
+ * than folded into the name.
+ *
+ * Locked audiences stay selectable so their explanation is reachable without being shown to someone
+ * working on a different audience. Callers decide what a locked audience renders.
+ *
+ * Shared by the application and agent token tabs, which differ only in their audience labels and in
+ * how they present a locked audience.
+ */
+export default function TokenAudienceSelector({
+  title,
+  options,
+  value,
+  onChange,
+  footnote = undefined,
+  children,
+}: TokenAudienceSelectorProps): ReactNode {
+  const handleChange = (_event: SyntheticEvent, newValue: string): void => {
+    onChange(newValue);
+  };
+
+  return (
+    <Grid container spacing={3}>
+      <Grid size={{xs: 12, md: 4, lg: 3}}>
+        <Paper variant="outlined" sx={{p: 2}}>
+          <Typography variant="overline" color="text.secondary" sx={{display: 'block', mb: 1, letterSpacing: '0.08em'}}>
+            {title}
+          </Typography>
+          <Tabs
+            orientation="vertical"
+            value={value}
+            onChange={handleChange}
+            aria-label={title}
+            sx={{
+              '& .MuiTabs-indicator': {display: 'none'},
+              '& .MuiTabs-list, & .MuiTabs-flexContainer': {gap: 1},
+            }}
+          >
+            {options.map((option) => (
+              <Tab
+                key={option.value}
+                value={option.value}
+                id={`${TAB_ID_PREFIX}${option.value}`}
+                aria-controls={PANEL_ID}
+                aria-label={option.label}
+                aria-describedby={`${DESCRIPTION_ID_PREFIX}${option.value}`}
+                label={
+                  // Spans throughout: a tab renders a button, whose content model is phrasing only.
+                  <Box component="span" sx={{display: 'block', width: '100%'}}>
+                    <Box component="span" sx={{display: 'flex', alignItems: 'center', gap: 0.75}}>
+                      <Typography component="span" variant="body2" sx={{fontWeight: 500}}>
+                        {option.label}
+                      </Typography>
+                      {option.isLocked === true && <Lock size={12} />}
+                    </Box>
+                    <Typography
+                      id={`${DESCRIPTION_ID_PREFIX}${option.value}`}
+                      component="span"
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{display: 'block', mt: 0.25}}
+                    >
+                      {option.description}
+                    </Typography>
+                  </Box>
+                }
+                sx={{
+                  alignItems: 'flex-start',
+                  textAlign: 'left',
+                  textTransform: 'none',
+                  width: '100%',
+                  maxWidth: 'none',
+                  minHeight: 'auto',
+                  px: 1.5,
+                  py: 1.25,
+                  borderRadius: 1,
+                  border: '1px solid',
+                  borderColor: 'divider',
+                  '&:hover': {borderColor: 'text.disabled'},
+                  '&.Mui-selected': {borderColor: 'primary.main', bgcolor: 'action.selected'},
+                }}
+              />
+            ))}
+          </Tabs>
+        </Paper>
+        {footnote !== undefined && (
+          <Typography variant="caption" color="text.secondary" sx={{display: 'block', mt: 1.5, px: 0.5}}>
+            {footnote}
+          </Typography>
+        )}
+      </Grid>
+      <Grid size={{xs: 12, md: 8, lg: 9}} id={PANEL_ID} role="tabpanel" aria-labelledby={`${TAB_ID_PREFIX}${value}`}>
+        {children}
+      </Grid>
+    </Grid>
+  );
+}

--- a/frontend/apps/console/src/features/applications/components/common/__tests__/TokenAudienceSelector.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/common/__tests__/TokenAudienceSelector.test.tsx
@@ -1,0 +1,129 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import userEvent from '@testing-library/user-event';
+import {render, screen} from '@thunderid/test-utils';
+import {describe, it, expect, vi} from 'vitest';
+import TokenAudienceSelector, {type TokenAudienceOption} from '../TokenAudienceSelector';
+
+const options: TokenAudienceOption[] = [
+  {value: 'application', label: 'Application', description: 'M2M access token'},
+  {value: 'user', label: 'User', description: 'Tokens for a signed-in user', isLocked: true},
+];
+
+const renderSelector = (value = 'application', onChange = vi.fn()) => {
+  const result = render(
+    <TokenAudienceSelector
+      title="Issued to"
+      options={options}
+      value={value}
+      onChange={onChange}
+      footnote="Claim sets are configured independently for each audience."
+    >
+      <div data-testid="panel-content" />
+    </TokenAudienceSelector>,
+  );
+  return {...result, onChange};
+};
+
+describe('TokenAudienceSelector', () => {
+  it('renders a vertical tab list named after the title', () => {
+    renderSelector();
+
+    const tablist = screen.getByRole('tablist', {name: 'Issued to'});
+    expect(tablist).toHaveAttribute('aria-orientation', 'vertical');
+    expect(screen.getAllByRole('tab')).toHaveLength(2);
+  });
+
+  it('names each tab by its label alone and references the description separately', () => {
+    renderSelector();
+
+    const userTab = screen.getByRole('tab', {name: 'User'});
+    const describedBy = userTab.getAttribute('aria-describedby');
+
+    expect(describedBy).not.toBeNull();
+    expect(document.getElementById(describedBy!)).toHaveTextContent('Tokens for a signed-in user');
+  });
+
+  it('associates every tab with the panel, and the panel with the selected tab', () => {
+    renderSelector();
+
+    const panel = screen.getByRole('tabpanel');
+    const selectedTab = screen.getByRole('tab', {name: 'Application'});
+
+    screen.getAllByRole('tab').forEach((tab) => {
+      expect(tab).toHaveAttribute('aria-controls', panel.id);
+    });
+    expect(panel).toHaveAttribute('aria-labelledby', selectedTab.id);
+    expect(screen.getByTestId('panel-content')).toBeInTheDocument();
+  });
+
+  it('keeps only the selected tab in the tab sequence', async () => {
+    const user = userEvent.setup();
+    renderSelector();
+
+    const applicationTab = screen.getByRole('tab', {name: 'Application'});
+    const userTab = screen.getByRole('tab', {name: 'User'});
+
+    expect(applicationTab).toHaveAttribute('tabindex', '0');
+    expect(userTab).toHaveAttribute('tabindex', '-1');
+
+    // One Tab press reaches the widget; the next must leave it rather than land on the second tab.
+    await user.tab();
+    expect(applicationTab).toHaveFocus();
+
+    await user.tab();
+    expect(userTab).not.toHaveFocus();
+  });
+
+  it('moves focus between tabs with the arrow keys', async () => {
+    const user = userEvent.setup();
+    renderSelector();
+
+    await user.tab();
+    expect(screen.getByRole('tab', {name: 'Application'})).toHaveFocus();
+
+    await user.keyboard('{ArrowDown}');
+    expect(screen.getByRole('tab', {name: 'User'})).toHaveFocus();
+
+    await user.keyboard('{ArrowUp}');
+    expect(screen.getByRole('tab', {name: 'Application'})).toHaveFocus();
+  });
+
+  it('moves focus to the first and last tab with Home and End', async () => {
+    const user = userEvent.setup();
+    renderSelector();
+
+    await user.tab();
+
+    await user.keyboard('{End}');
+    expect(screen.getByRole('tab', {name: 'User'})).toHaveFocus();
+
+    await user.keyboard('{Home}');
+    expect(screen.getByRole('tab', {name: 'Application'})).toHaveFocus();
+  });
+
+  it('selects the focused tab on Enter, so moving focus alone does not mount another panel', async () => {
+    const user = userEvent.setup();
+    const {onChange} = renderSelector();
+
+    await user.tab();
+    await user.keyboard('{ArrowDown}');
+
+    // Manual activation: arrowing to a tab must not select it, since each panel mounts its own
+    // settings and fetches on mount.
+    expect(onChange).not.toHaveBeenCalled();
+
+    await user.keyboard('{Enter}');
+    expect(onChange).toHaveBeenCalledWith('user');
+  });
+
+  it('selects a tab on click', async () => {
+    const user = userEvent.setup();
+    const {onChange} = renderSelector();
+
+    await user.click(screen.getByRole('tab', {name: 'User'}));
+
+    expect(onChange).toHaveBeenCalledWith('user');
+  });
+});

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/ClientAccessTokenSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/ClientAccessTokenSection.tsx
@@ -129,7 +129,7 @@ export default function ClientAccessTokenSection({
     <Stack spacing={3}>
       <SettingsCard title={copy.attributesTitle} description={copy.attributesDescription}>
         <Grid container spacing={3}>
-          <Grid size={{xs: 12, md: 7}}>
+          <Grid size={{xs: 12, lg: 7}}>
             <Typography variant="body2" sx={{mb: 1}}>
               {copy.attributesLabel}
             </Typography>
@@ -167,7 +167,7 @@ export default function ClientAccessTokenSection({
               </CardContent>
             </Card>
           </Grid>
-          <Grid size={{xs: 12, md: 5}}>
+          <Grid size={{xs: 12, lg: 5}}>
             <JwtPreview payload={jwtPreview} defaultClaims={ACCESS_TOKEN_DEFAULT_CLAIMS} />
           </Grid>
         </Grid>

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/EditTokenSettings.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/EditTokenSettings.tsx
@@ -16,6 +16,7 @@ import {z} from 'zod';
 import ScopeSection from './ScopeSection';
 import TokenUserAttributesSection from './TokenUserAttributesSection';
 import TokenValidationSection from './TokenValidationSection';
+import {isOAuthTokenMode} from '../../../utils/oauth2Rules';
 
 /**
  * Props for the {@link EditTokenSettings} component.
@@ -180,10 +181,7 @@ export default function EditTokenSettings({
   }, [userTypesData, allowedUserTypes]);
 
   // Determine if this is OAuth/OIDC mode (has separate token configs) or Native mode
-  const isOAuthMode = useMemo(
-    () => oauth2Config?.token?.accessToken !== undefined || oauth2Config?.token?.idToken !== undefined,
-    [oauth2Config],
-  );
+  const isOAuthMode = useMemo(() => isOAuthTokenMode(oauth2Config), [oauth2Config]);
 
   const tokenConfigSchema = useMemo(() => createTokenConfigSchema(t), [t]);
 

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/EditTokenSettingsTabs.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/EditTokenSettingsTabs.tsx
@@ -2,14 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type {Application, OAuth2Config} from '@thunderid/configure-applications';
-import {Box, Tab, Tabs} from '@wso2/oxygen-ui';
-import {useEffect, useState, type JSX, type SyntheticEvent} from 'react';
+import {Alert} from '@wso2/oxygen-ui';
+import {Lock} from '@wso2/oxygen-ui-icons-react';
+import {useEffect, useState, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import ClientAccessTokenSection from './ClientAccessTokenSection';
 import EditTokenSettings from './EditTokenSettings';
 import TokenConstants from '../../../constants/token-constants';
-import {hasClientAccess, hasUserAccess} from '../../../utils/oauth2Rules';
-import SettingsLockNotice from '../../common/SettingsLockNotice';
+import {hasClientAccess, hasUserAccess, isOAuthTokenMode} from '../../../utils/oauth2Rules';
+import TokenAudienceSelector, {type TokenAudienceOption} from '../../common/TokenAudienceSelector';
+
+const CLIENT_AUDIENCE = 'application';
+const USER_AUDIENCE = 'user';
 
 interface EditTokenSettingsTabsProps {
   application: Application;
@@ -20,8 +24,15 @@ interface EditTokenSettingsTabsProps {
 }
 
 /**
- * Token settings split into Application (client_credentials) and User sub-tabs. Each sub-tab is
- * frozen with a lock notice when its enabling grant type is not selected.
+ * Token settings for an application, split by the audience a token is issued to: the application
+ * itself (client_credentials) or a signed-in user. Both audiences stay selectable; one whose
+ * settings do not apply shows a notice in place of them, so the notice is only ever visible to
+ * someone looking at that audience.
+ *
+ * The User audience covers both token shapes: for an OAuth application it edits the access token's
+ * user config, and for an application with no OAuth configuration (app-native sign-in) it edits the
+ * assertion config, which is the only token config such an application has. EditTokenSettings picks
+ * the right one from the same `isOAuthTokenMode` check used here.
  */
 export default function EditTokenSettingsTabs({
   application,
@@ -31,101 +42,114 @@ export default function EditTokenSettingsTabs({
   sectionResetKey = 0,
 }: EditTokenSettingsTabsProps): JSX.Element {
   const {t} = useTranslation();
-  const [subTab, setSubTab] = useState(0);
+
+  const grantTypes = oauth2Config?.grantTypes;
+  const isOAuthMode = isOAuthTokenMode(oauth2Config);
+  const clientUnlocked = hasClientAccess(grantTypes);
+  const userUnlocked = !isOAuthMode || hasUserAccess(grantTypes);
+
+  // Opens on the first audience that has settings to show, so an application whose Application
+  // audience does not apply is not greeted by a notice. Both remain selectable afterwards.
+  const [audience, setAudience] = useState(clientUnlocked ? CLIENT_AUDIENCE : USER_AUDIENCE);
   const [clientTabHasError, setClientTabHasError] = useState(false);
   const [userTabHasError, setUserTabHasError] = useState(false);
 
-  const grantTypes = oauth2Config?.grantTypes;
-  const clientUnlocked = hasClientAccess(grantTypes);
-  const userUnlocked = hasUserAccess(grantTypes);
-
+  // A locked audience is never mounted, so its last reported error state must not keep blocking the
+  // save bar.
   useEffect(() => {
-    onValidationChange?.(clientTabHasError || userTabHasError);
-  }, [clientTabHasError, userTabHasError, onValidationChange]);
+    onValidationChange?.((clientUnlocked && clientTabHasError) || (userUnlocked && userTabHasError));
+  }, [clientUnlocked, userUnlocked, clientTabHasError, userTabHasError, onValidationChange]);
 
-  // Forcing isReadOnly disables every input via EditTokenSettings' existing
-  // disabled={application.isReadOnly} wiring when the user tab is locked.
-  const userTabApplication = {
-    ...application,
-    isReadOnly: (application.isReadOnly ?? false) || !userUnlocked,
-  };
-
-  const handleSubTabChange = (_event: SyntheticEvent, newValue: number): void => {
-    setSubTab(newValue);
-  };
+  const audienceOptions: TokenAudienceOption[] = [
+    {
+      value: CLIENT_AUDIENCE,
+      label: t('applications:edit.token.tabs.application', 'Application'),
+      description: t('applications:edit.token.audience.application.description', 'M2M access token'),
+      isLocked: !clientUnlocked,
+    },
+    {
+      value: USER_AUDIENCE,
+      label: t('applications:edit.token.tabs.user', 'User'),
+      description: t('applications:edit.token.audience.user.description', 'Tokens for a signed-in user'),
+      isLocked: !userUnlocked,
+    },
+  ];
 
   return (
-    <Box>
-      <Tabs value={subTab} onChange={handleSubTabChange} aria-label="application token settings sub-tabs">
-        <Tab label={t('applications:edit.token.tabs.application', 'Application')} sx={{textTransform: 'none'}} />
-        <Tab label={t('applications:edit.token.tabs.user', 'User')} sx={{textTransform: 'none'}} />
-      </Tabs>
-      <Box sx={{pt: 3}}>
-        {subTab === 0 && (
-          <SettingsLockNotice
-            isUnlocked={clientUnlocked}
-            message={t(
-              'applications:edit.token.clientLock.message',
-              'These settings apply only when the client credentials grant is enabled. Add it in the Advanced tab to configure them.',
-            )}
-          >
-            <ClientAccessTokenSection
-              key={sectionResetKey}
-              oauth2Config={oauth2Config}
-              inboundAuthConfig={application.inboundAuthConfig}
-              onFieldChange={onFieldChange}
-              availableAttributes={[...TokenConstants.CLIENT_TOKEN_OPTIONAL_CLAIMS]}
-              disabled={(application.isReadOnly ?? false) || !clientUnlocked}
-              onValidationChange={setClientTabHasError}
-              subjectValue={application.id}
-              copy={{
-                attributesTitle: t('applications:edit.token.client.attributes.title', 'Access Token Claims'),
-                attributesDescription: t(
-                  'applications:edit.token.client.attributes.description',
-                  'Optional claims to include in the access token this application receives for its own requests (client_credentials grant).',
-                ),
-                attributesLabel: t('applications:edit.token.client.attributes.label', 'Add or Remove Claims'),
-                attributesHint: t(
-                  'applications:edit.token.client.attributes.hint',
-                  "Click a claim to include it in this application's client access token.",
-                ),
-                attributesEmpty: t('applications:edit.token.client.attributes.empty', 'No optional claims available.'),
-                validityTitle: t('applications:edit.token.client.validity.title', 'Token Validity'),
-                validityDescription: t(
-                  'applications:edit.token.client.validity.description',
-                  'How long this client access token remains valid before expiration.',
-                ),
-                validityLabel: t('applications:edit.token.client.validity.label', 'Token Validity'),
-                validityHint: t(
-                  'applications:edit.token.client.validity.hint',
-                  'Token validity period in seconds (e.g., 3600 for 1 hour).',
-                ),
-                validityError: t(
-                  'applications:edit.token.client.validity.error',
-                  'Enter a validity period of at least 1 second.',
-                ),
-              }}
-            />
-          </SettingsLockNotice>
-        )}
-        {subTab === 1 && (
-          <SettingsLockNotice
-            isUnlocked={userUnlocked}
-            message={t(
-              'applications:edit.token.userLock.message',
-              'These settings apply only when a user-facing grant is enabled. Add one in the Advanced tab to configure them.',
-            )}
-          >
-            <EditTokenSettings
-              application={userTabApplication}
-              oauth2Config={oauth2Config}
-              sectionResetKey={sectionResetKey}
-              onFieldChange={onFieldChange}
-              onValidationChange={setUserTabHasError}
-            />
-          </SettingsLockNotice>
-        )}
-      </Box>
-    </Box>
+    <TokenAudienceSelector
+      title={t('applications:edit.token.audience.title', 'Issued to')}
+      options={audienceOptions}
+      value={audience}
+      onChange={setAudience}
+      footnote={t(
+        'applications:edit.token.audience.footnote',
+        'Claim sets are configured independently for each audience.',
+      )}
+    >
+      {audience === CLIENT_AUDIENCE && !clientUnlocked && (
+        <Alert severity="info" icon={<Lock size={20} />}>
+          {t(
+            'applications:edit.token.clientLock.message',
+            'This application does not receive tokens for itself, so there is nothing to configure here.',
+          )}
+        </Alert>
+      )}
+      {audience === USER_AUDIENCE && !userUnlocked && (
+        <Alert severity="info" icon={<Lock size={20} />}>
+          {t(
+            'applications:edit.token.userLock.message',
+            'This application does not receive tokens for signed-in users, so there is nothing to configure here.',
+          )}
+        </Alert>
+      )}
+      {audience === CLIENT_AUDIENCE && clientUnlocked && (
+        <ClientAccessTokenSection
+          key={sectionResetKey}
+          oauth2Config={oauth2Config}
+          inboundAuthConfig={application.inboundAuthConfig}
+          onFieldChange={onFieldChange}
+          availableAttributes={[...TokenConstants.CLIENT_TOKEN_OPTIONAL_CLAIMS]}
+          disabled={application.isReadOnly ?? false}
+          onValidationChange={setClientTabHasError}
+          subjectValue={application.id}
+          copy={{
+            attributesTitle: t('applications:edit.token.client.attributes.title', 'Access Token Claims'),
+            attributesDescription: t(
+              'applications:edit.token.client.attributes.description',
+              'Extra claims to add to the access token this application receives for itself.',
+            ),
+            attributesLabel: t('applications:edit.token.client.attributes.label', 'Add or Remove Claims'),
+            attributesHint: t(
+              'applications:edit.token.client.attributes.hint',
+              "Click a claim to include it in this application's client access token.",
+            ),
+            attributesEmpty: t('applications:edit.token.client.attributes.empty', 'No optional claims available.'),
+            validityTitle: t('applications:edit.token.client.validity.title', 'Token Validity'),
+            validityDescription: t(
+              'applications:edit.token.client.validity.description',
+              'How long this client access token remains valid before expiration.',
+            ),
+            validityLabel: t('applications:edit.token.client.validity.label', 'Token Validity'),
+            validityHint: t(
+              'applications:edit.token.client.validity.hint',
+              'Token validity period in seconds (e.g., 3600 for 1 hour).',
+            ),
+            validityError: t(
+              'applications:edit.token.client.validity.error',
+              'Enter a validity period of at least 1 second.',
+            ),
+          }}
+        />
+      )}
+      {audience === USER_AUDIENCE && userUnlocked && (
+        <EditTokenSettings
+          application={application}
+          oauth2Config={oauth2Config}
+          sectionResetKey={sectionResetKey}
+          onFieldChange={onFieldChange}
+          onValidationChange={setUserTabHasError}
+        />
+      )}
+    </TokenAudienceSelector>
   );
 }

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/TokenUserAttributesSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/TokenUserAttributesSection.tsx
@@ -413,8 +413,8 @@ export default function TokenUserAttributesSection({
 
     return (
       <Grid container spacing={3}>
-        <Grid size={{xs: 12, md: 7}}>{renderAttributeChips(currentAttrs, tokenType)}</Grid>
-        <Grid size={{xs: 12, md: 5}}>
+        <Grid size={{xs: 12, lg: 7}}>{renderAttributeChips(currentAttrs, tokenType)}</Grid>
+        <Grid size={{xs: 12, lg: 5}}>
           {tokenType === 'access' && showActorClaim && (
             <Alert severity="info" sx={{mb: 2}}>
               {t(
@@ -430,17 +430,38 @@ export default function TokenUserAttributesSection({
     );
   };
 
-  const cardTitle = t('applications:edit.token.token_profile_card.title', 'Token Attributes & Response');
-  const cardDescription = showUserInfoTab
-    ? t(
-        'applications:edit.token.token_profile_card.description',
-        'Configure the response types and user attributes included in your tokens and user info responses',
-      )
-    : t(
-        'applications:edit.token.token_profile_card.description.noUserInfo',
-        'Configure the response types and user attributes included in the tokens issued to this {{entity}}.',
+  // Native mode issues a single token and offers no response-format controls, so it gets its own
+  // title and description rather than the multi-token, multi-response wording.
+  const resolveCardTitle = (): string => {
+    if (!isOAuthMode) {
+      return t('applications:edit.token.token_profile_card.title.native', 'Token Attributes');
+    }
+    return t('applications:edit.token.token_profile_card.title', 'Token Attributes & Response');
+  };
+
+  const resolveCardDescription = (): string => {
+    if (!isOAuthMode) {
+      return t(
+        'applications:edit.token.token_profile_card.description.native',
+        'Choose the claims included in the token issued to this {{entity}}.',
         {entity: entityLabel},
       );
+    }
+    if (showUserInfoTab) {
+      return t(
+        'applications:edit.token.token_profile_card.description',
+        'Choose the claims in each token and the user info response, and how each is returned.',
+      );
+    }
+    return t(
+      'applications:edit.token.token_profile_card.description.noUserInfo',
+      'Choose the claims in each token issued to this {{entity}}, and how each is returned.',
+      {entity: entityLabel},
+    );
+  };
+
+  const cardTitle = resolveCardTitle();
+  const cardDescription = resolveCardDescription();
   if (isOAuthMode) {
     let tabIndex = showUserInfoTab ? 2 : 0;
 
@@ -485,7 +506,7 @@ export default function TokenUserAttributesSection({
                 return (
                   <Grid container spacing={3}>
                     {/* Left Column - Attributes + Response Format */}
-                    <Grid size={{xs: 12, md: 7}}>
+                    <Grid size={{xs: 12, lg: 7}}>
                       <Stack spacing={3}>
                         {renderAttributeChips(idAttrs, 'id')}
                         <Divider />
@@ -633,7 +654,7 @@ export default function TokenUserAttributesSection({
                     </Grid>
 
                     {/* Right Column - JWT Preview */}
-                    <Grid size={{xs: 12, md: 5}}>
+                    <Grid size={{xs: 12, lg: 5}}>
                       <JwtPreview payload={jwtPreview} defaultClaims={defaultAttrs} header={buildIdTokenHeader()} />
                     </Grid>
                   </Grid>
@@ -653,7 +674,7 @@ export default function TokenUserAttributesSection({
                 return (
                   <Grid container spacing={3}>
                     {/* Left Column - Attributes + Response Format */}
-                    <Grid size={{xs: 12, md: 7}}>
+                    <Grid size={{xs: 12, lg: 7}}>
                       <Stack spacing={3}>
                         {/* User Attributes */}
                         <Box>
@@ -841,7 +862,7 @@ export default function TokenUserAttributesSection({
                     </Grid>
 
                     {/* Right Column - JWT/JSON Preview */}
-                    <Grid size={{xs: 12, md: 5}}>
+                    <Grid size={{xs: 12, lg: 5}}>
                       <JwtPreview
                         payload={jwtPreview}
                         defaultClaims={defaultAttrs}

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/EditTokenSettingsAssertionChanges.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/EditTokenSettingsAssertionChanges.test.tsx
@@ -1,0 +1,84 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import type {Application} from '@thunderid/configure-applications';
+import {render, screen, waitFor} from '@thunderid/test-utils';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import EditTokenSettings from '../EditTokenSettings';
+
+// Stable mock references, created via vi.hoisted so the hoisted vi.mock factories can use them.
+// New identities on every render would re-fire the schema-fetch effect in a loop.
+const {mockHttp, mockGetServerUrl, mockLogger} = vi.hoisted(() => ({
+  mockHttp: {request: vi.fn().mockResolvedValue({data: {id: 'schema-1', name: 'default', schema: {}}})},
+  mockGetServerUrl: vi.fn().mockReturnValue('https://api.example.com'),
+  mockLogger: {error: vi.fn(), info: vi.fn(), debug: vi.fn()},
+}));
+
+vi.mock('@thunderid/configure-user-types', () => ({
+  useGetUserTypes: () => ({data: {types: [{id: 'schema-1', name: 'default'}]}, isLoading: false}),
+}));
+
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({http: mockHttp}),
+}));
+
+vi.mock('@thunderid/contexts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunderid/contexts')>();
+  return {...actual, useConfig: () => ({getServerUrl: mockGetServerUrl})};
+});
+
+vi.mock('@thunderid/logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunderid/logger')>();
+  return {...actual, useLogger: () => mockLogger};
+});
+
+const nativeApplication = (assertion?: Application['assertion']): Application =>
+  ({id: 'app-1', name: 'App Native App', allowedUserTypes: ['default'], assertion}) as Application;
+
+/**
+ * The validity effect runs again whenever one of its dependencies changes identity, which happens in
+ * the console under StrictMode's double invocation of effects. By then the first-render guard is
+ * already spent, so the effect must decide for itself whether anything actually changed. Re-rendering
+ * with a fresh onFieldChange reproduces that second run deterministically.
+ *
+ * TokenValidationSection is left real so its react-hook-form Controllers mount and report values.
+ */
+describe('EditTokenSettings assertion change tracking', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not report an assertion change when the effect re-runs and the validity is unchanged', async () => {
+    const application = nativeApplication({validityPeriod: 7200, userAttributes: []});
+    const {rerender} = render(<EditTokenSettings application={application} onFieldChange={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('7200')).toBeInTheDocument();
+    });
+
+    const onFieldChange = vi.fn();
+    rerender(<EditTokenSettings application={application} onFieldChange={onFieldChange} />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('7200')).toBeInTheDocument();
+    });
+    expect(onFieldChange).not.toHaveBeenCalled();
+  });
+
+  it('does not report an assertion change when no validity period is stored', async () => {
+    const application = nativeApplication(undefined);
+    const {rerender} = render(<EditTokenSettings application={application} onFieldChange={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('3600')).toBeInTheDocument();
+    });
+
+    const onFieldChange = vi.fn();
+    rerender(<EditTokenSettings application={application} onFieldChange={onFieldChange} />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('3600')).toBeInTheDocument();
+    });
+    expect(onFieldChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/EditTokenSettingsTabs.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/EditTokenSettingsTabs.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import userEvent from '@testing-library/user-event';
-import type {Application} from '@thunderid/configure-applications';
+import type {Application, OAuth2Config} from '@thunderid/configure-applications';
 import {render, screen} from '@thunderid/test-utils';
 import {useState} from 'react';
 import {describe, it, expect, vi} from 'vitest';
@@ -36,63 +36,103 @@ vi.mock('../EditTokenSettings', () => ({
 }));
 
 const application: Application = {id: 'app-1', name: 'Test App'};
-const clientLockMessage = /client credentials grant is enabled/i;
-const userLockMessage = /user-facing grant is enabled/i;
+const clientLockMessage = /does not receive tokens for itself/i;
+const userLockMessage = /does not receive tokens for signed-in users/i;
+
+/**
+ * Builds an OAuth2 config shaped like one loaded from the API, where the backend has always
+ * materialized the access token and ID token blocks.
+ */
+const oauthConfig = (grantTypes: string[]): OAuth2Config => ({
+  grantTypes,
+  responseTypes: [],
+  token: {
+    accessToken: {userConfig: {validityPeriod: 3600, attributes: []}},
+    idToken: {validityPeriod: 3600, userAttributes: []},
+  },
+});
 
 describe('EditTokenSettingsTabs', () => {
   const onFieldChange = vi.fn();
 
-  it('renders Application and User sub-tabs', () => {
+  it('renders Application and User audiences in a side selector', () => {
     render(
       <EditTokenSettingsTabs
         application={application}
-        oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
+        oauth2Config={oauthConfig(['client_credentials'])}
         onFieldChange={onFieldChange}
       />,
     );
 
+    expect(screen.getByRole('tablist', {name: 'Issued to'})).toBeInTheDocument();
     expect(screen.getByRole('tab', {name: 'Application'})).toBeInTheDocument();
     expect(screen.getByRole('tab', {name: 'User'})).toBeInTheDocument();
+    expect(screen.getByText('M2M access token')).toBeInTheDocument();
+    expect(screen.getByText('Tokens for a signed-in user')).toBeInTheDocument();
+    expect(screen.getByText(/configured independently for each audience/i)).toBeInTheDocument();
   });
 
   it('unlocks the Application tab when client_credentials is granted', () => {
     render(
       <EditTokenSettingsTabs
         application={application}
-        oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
+        oauth2Config={oauthConfig(['client_credentials'])}
         onFieldChange={onFieldChange}
       />,
     );
 
+    expect(screen.getByRole('tab', {name: 'Application'})).toBeEnabled();
     expect(screen.getByTestId('client-token-section')).toBeInTheDocument();
     expect(screen.queryByText(clientLockMessage)).not.toBeInTheDocument();
   });
 
-  it('freezes the Application tab with a lock notice when client_credentials is not granted', () => {
-    render(
-      <EditTokenSettingsTabs
-        application={application}
-        oauth2Config={{grantTypes: ['authorization_code'], responseTypes: []}}
-        onFieldChange={onFieldChange}
-      />,
-    );
-
-    expect(screen.getByText(clientLockMessage)).toBeInTheDocument();
-  });
-
-  it('freezes the User tab with a lock notice when no user-facing grant is present', async () => {
+  it('shows the Application notice in place of its settings when client_credentials is not granted', async () => {
     const user = userEvent.setup();
     render(
       <EditTokenSettingsTabs
         application={application}
-        oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
+        oauth2Config={oauthConfig(['authorization_code'])}
         onFieldChange={onFieldChange}
       />,
     );
 
+    // The notice belongs to the Application sub-tab, so it stays out of the way until opened.
+    expect(screen.queryByText(clientLockMessage)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', {name: 'Application'}));
+
+    expect(screen.getByText(clientLockMessage)).toBeInTheDocument();
+    expect(screen.queryByTestId('client-token-section')).not.toBeInTheDocument();
+  });
+
+  it('shows the User notice in place of its settings when no user-facing grant is present', async () => {
+    const user = userEvent.setup();
+    render(
+      <EditTokenSettingsTabs
+        application={application}
+        oauth2Config={oauthConfig(['client_credentials'])}
+        onFieldChange={onFieldChange}
+      />,
+    );
+
+    expect(screen.queryByText(userLockMessage)).not.toBeInTheDocument();
+
     await user.click(screen.getByRole('tab', {name: 'User'}));
 
     expect(screen.getByText(userLockMessage)).toBeInTheDocument();
+    expect(screen.queryByTestId('user-token-section')).not.toBeInTheDocument();
+  });
+
+  it('keeps a sub-tab with no applicable settings selectable', () => {
+    render(
+      <EditTokenSettingsTabs
+        application={application}
+        oauth2Config={oauthConfig(['authorization_code'])}
+        onFieldChange={onFieldChange}
+      />,
+    );
+
+    expect(screen.getByRole('tab', {name: 'Application'})).toBeEnabled();
   });
 
   it('unlocks the User tab when a user-facing grant is present', async () => {
@@ -100,7 +140,7 @@ describe('EditTokenSettingsTabs', () => {
     render(
       <EditTokenSettingsTabs
         application={application}
-        oauth2Config={{grantTypes: ['authorization_code'], responseTypes: []}}
+        oauth2Config={oauthConfig(['authorization_code'])}
         onFieldChange={onFieldChange}
       />,
     );
@@ -109,6 +149,45 @@ describe('EditTokenSettingsTabs', () => {
 
     expect(screen.getByTestId('user-token-section')).toBeInTheDocument();
     expect(screen.queryByText(userLockMessage)).not.toBeInTheDocument();
+  });
+
+  it('selects the User tab by default when the Application tab is locked', () => {
+    render(
+      <EditTokenSettingsTabs
+        application={application}
+        oauth2Config={oauthConfig(['authorization_code'])}
+        onFieldChange={onFieldChange}
+      />,
+    );
+
+    expect(screen.getByRole('tab', {name: 'User'})).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByTestId('user-token-section')).toBeInTheDocument();
+  });
+
+  describe('app-native application (no OAuth2 configuration)', () => {
+    it('unlocks the User tab so the assertion config can be edited', () => {
+      render(
+        <EditTokenSettingsTabs application={application} oauth2Config={undefined} onFieldChange={onFieldChange} />,
+      );
+
+      expect(screen.getByRole('tab', {name: 'User'})).toBeEnabled();
+      expect(screen.getByTestId('user-token-section')).toBeInTheDocument();
+      expect(screen.queryByText(userLockMessage)).not.toBeInTheDocument();
+    });
+
+    it('opens on the User sub-tab and keeps the Application notice behind its own tab', async () => {
+      const user = userEvent.setup();
+      render(
+        <EditTokenSettingsTabs application={application} oauth2Config={undefined} onFieldChange={onFieldChange} />,
+      );
+
+      expect(screen.getByRole('tab', {name: 'User'})).toHaveAttribute('aria-selected', 'true');
+      expect(screen.queryByText(clientLockMessage)).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('tab', {name: 'Application'}));
+
+      expect(screen.getByText(clientLockMessage)).toBeInTheDocument();
+    });
   });
 
   it('remounts ClientAccessTokenSection when sectionResetKey changes', async () => {

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/TokenUserAttributesSection.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/TokenUserAttributesSection.test.tsx
@@ -71,9 +71,11 @@ describe('TokenUserAttributesSection', () => {
     it('renders the settings card with correct title for native mode', () => {
       render(<TokenUserAttributesSection {...baseProps} sharedAttributes={[]} />);
 
-      expect(screen.getByTestId('card-title')).toHaveTextContent('Token Attributes & Response');
+      // Native mode issues one token and has no response-format controls, so it drops the
+      // "& Response" title and the multi-token wording.
+      expect(screen.getByTestId('card-title')).toHaveTextContent('Token Attributes');
       expect(screen.getByTestId('card-description')).toHaveTextContent(
-        'Configure the response types and user attributes included in your tokens and user info responses',
+        'Choose the claims included in the token issued to this application.',
       );
     });
 
@@ -106,7 +108,7 @@ describe('TokenUserAttributesSection', () => {
       );
 
       expect(screen.getByTestId('card-description')).toHaveTextContent(
-        'Configure the response types and user attributes included in the tokens issued to this agent.',
+        'Choose the claims in each token issued to this agent, and how each is returned.',
       );
     });
   });

--- a/frontend/apps/console/src/features/applications/utils/__tests__/oauth2Rules.test.ts
+++ b/frontend/apps/console/src/features/applications/utils/__tests__/oauth2Rules.test.ts
@@ -14,6 +14,7 @@ import {
   hasClientAccess,
   hasUserAccess,
   isGrantItemDisabled,
+  isOAuthTokenMode,
 } from '../oauth2Rules';
 
 const baseConfig = (overrides: Partial<OAuth2Config> = {}): OAuth2Config => ({
@@ -261,6 +262,32 @@ describe('hasClientAccess', () => {
     expect(hasClientAccess([OAuth2GrantTypes.CLIENT_CREDENTIALS])).toBe(true);
     expect(hasClientAccess([OAuth2GrantTypes.AUTHORIZATION_CODE])).toBe(false);
     expect(hasClientAccess(undefined)).toBe(false);
+  });
+});
+
+describe('isOAuthTokenMode', () => {
+  // Either block alone flips the flag, so each case is asserted with only one of them populated.
+  const partialToken = (block: Record<string, unknown>): OAuth2Config['token'] =>
+    block as unknown as OAuth2Config['token'];
+
+  it('is true when the access token config is present', () => {
+    expect(
+      isOAuthTokenMode(baseConfig({token: partialToken({accessToken: {userConfig: {validityPeriod: 3600}}})})),
+    ).toBe(true);
+  });
+
+  it('is true when only the ID token config is present', () => {
+    expect(
+      isOAuthTokenMode(baseConfig({token: partialToken({idToken: {validityPeriod: 3600, userAttributes: []}})})),
+    ).toBe(true);
+  });
+
+  it('is false for an app-native application with no OAuth config', () => {
+    expect(isOAuthTokenMode(undefined)).toBe(false);
+  });
+
+  it('is false when an OAuth config carries no token block', () => {
+    expect(isOAuthTokenMode(baseConfig({grantTypes: [OAuth2GrantTypes.AUTHORIZATION_CODE]}))).toBe(false);
   });
 });
 

--- a/frontend/apps/console/src/features/applications/utils/oauth2Rules.ts
+++ b/frontend/apps/console/src/features/applications/utils/oauth2Rules.ts
@@ -65,6 +65,18 @@ export function hasClientAccess(grantTypes: string[] | undefined): boolean {
 }
 
 /**
+ * Returns whether the application's tokens are governed by its OAuth2 token config rather than by
+ * its assertion config. An application with no OAuth2 configuration (app-native sign-in) receives
+ * only the flow assertion, whose validity and user attributes come from `application.assertion`.
+ *
+ * The backend always materializes `token.accessToken` and `token.idToken` whenever an OAuth profile
+ * exists, so this is equivalent to "has an OAuth profile" for any config loaded from the API.
+ */
+export function isOAuthTokenMode(oauth2Config: OAuth2Config | undefined): boolean {
+  return oauth2Config?.token?.accessToken !== undefined || oauth2Config?.token?.idToken !== undefined;
+}
+
+/**
  * Returns whether the grant list contains a token-issuing grant.
  */
 function hasTokenIssuingGrant(grants: string[]): boolean {

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1214,11 +1214,15 @@ const translations = {
     // Edit page - Tokens tab
     'edit.tokens.tabs.user': 'User',
     'edit.tokens.tabs.agent': 'Agent',
+    'edit.tokens.audience.title': 'Issued to',
+    'edit.tokens.audience.agent.description': 'Tokens for the agent acting on its own',
+    'edit.tokens.audience.user.description': 'Tokens for the agent acting on behalf of a user',
+    'edit.tokens.audience.footnote': 'Claim sets are configured independently for each audience.',
     'edit.tokens.delegationLock.message':
-      'These settings are frozen for this agent. Turn on Delegated mode in the Advanced tab to unlock and start using them.',
+      'This agent does not receive tokens on behalf of a user. Turn on Delegated mode in the <advancedLink>Advanced tab</advancedLink> to configure them.',
     'edit.tokens.agent.attributes.title': 'Access Token Attributes',
     'edit.tokens.agent.attributes.description':
-      'Attributes included in the access token this agent receives for its own requests (client_credentials grant).',
+      'Extra attributes to add to the access token this agent receives for itself.',
     'edit.tokens.agent.attributes.label': 'Add or Remove Attributes',
     'edit.tokens.agent.attributes.hint': 'Click on agent attributes to add them to its access token.',
     'edit.tokens.agent.attributes.empty':
@@ -2698,8 +2702,13 @@ const translations = {
     'edit.token.validity.hint': 'Token validity period in seconds (e.g., 3600 for 1 hour)',
     'edit.token.validity.error': 'Validity period must be at least 1 second',
     'edit.token.token_profile_card.title': 'Token Attributes & Response',
+    'edit.token.token_profile_card.title.native': 'Token Attributes',
     'edit.token.token_profile_card.description':
-      'Configure the response types and user attributes included in your tokens and user info responses',
+      'Choose the claims in each token and the user info response, and how each is returned.',
+    'edit.token.token_profile_card.description.noUserInfo':
+      'Choose the claims in each token issued to this {{entity}}, and how each is returned.',
+    'edit.token.token_profile_card.description.native':
+      'Choose the claims included in the token issued to this {{entity}}.',
     'edit.token.tabs.access_token': 'Access Token',
     'edit.token.tabs.id_token': 'ID Token',
     'edit.token.tabs.refresh_token': 'Refresh Token',
@@ -2723,13 +2732,17 @@ const translations = {
     'edit.token.scopes.openid_required': 'The openid scope is required and cannot be removed',
     'edit.token.tabs.application': 'Application',
     'edit.token.tabs.user': 'User',
+    'edit.token.audience.title': 'Issued to',
+    'edit.token.audience.application.description': 'M2M access token',
+    'edit.token.audience.user.description': 'Tokens for a signed-in user',
+    'edit.token.audience.footnote': 'Claim sets are configured independently for each audience.',
     'edit.token.clientLock.message':
-      'These settings apply only when the client credentials grant is enabled. Add it in the Advanced tab to configure them.',
+      'This application does not receive tokens for itself, so there is nothing to configure here.',
     'edit.token.userLock.message':
-      'These settings apply only when a user-facing grant is enabled. Add one in the Advanced tab to configure them.',
+      'This application does not receive tokens for signed-in users, so there is nothing to configure here.',
     'edit.token.client.attributes.title': 'Access Token Claims',
     'edit.token.client.attributes.description':
-      'Optional claims to include in the access token this application receives for its own requests (client_credentials grant).',
+      'Extra claims to add to the access token this application receives for itself.',
     'edit.token.client.attributes.label': 'Add or Remove Claims',
     'edit.token.client.attributes.hint': "Click a claim to include it in this application's client access token.",
     'edit.token.client.attributes.empty': 'No optional claims available.',


### PR DESCRIPTION
### Purpose

The Token tab on the application edit page moves from nested Application/User sub-tabs to a side audience selector, per the finalized design. The same selector is applied to the agent edit Token tab, which shared the old layout.

This also fixes a bug the restructure surfaced: a mobile application registered with app-native (Bring Your Own UI) sign-in had **both** token sub-tabs frozen, with no way to unfreeze either. Such an application is created with no OAuth
configuration, so the grant-type check behind both locks could never be satisfied, and the lock notice pointed at the Advanced tab, which hides its OAuth section in exactly that state. The user pane is the one place its claims
and validity can be configured, so those settings were unreachable.

Two smaller fixes in the same area:

- Opening the user pane for an app-native application reported an unsaved change the moment it rendered, before anything was edited.
- Token copy referenced grant names and protocol vocabulary, and the shared card described ID tokens, user info responses, and response formats even in assertion mode, where none of them exist.

### Approach

**One shared selector, two lock presentations.** `TokenAudienceSelector` lives in
`applications/components/common/` and is consumed by both edit pages, following
the existing dependency direction (agents import from applications, never the
reverse). It renders the audience list and the content pane but takes no
position on what a locked audience shows, because the application and agent
lock conditions are different things: a missing grant type versus Delegated mode
being off. Each caller supplies its own notice.

**Locked audiences stay selectable.** Disabling the entry meant its explanation
had to be displayed somewhere else, which put a notice about one audience in
front of someone working on the other. Each audience now renders its own notice
in place of its settings, so the explanation is only visible to someone who
opened that audience. This replaces the previous frozen-card treatment on both
pages, including the agent's `SettingsLockNotice` usage.

**Gating on OAuth-config existence, not application type.** The user audience
unlocks when `!isOAuthTokenMode(oauth2Config) || hasUserAccess(grantTypes)`.
Application type was considered and rejected: the backend never validates grant
types against type, so a `mobile`-typed application can legitimately be
reconfigured as a confidential client, and the type is immutable. Grants and
config shape stay the authoritative signal. `isOAuthTokenMode` was extracted as
a shared helper so the lock decision and the render branch inside
`EditTokenSettings` cannot drift apart.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4435
- https://github.com/thunder-id/thunderid/issues/4357

### Related PRs
- https://github.com/thunder-id/thunderid/pull/4333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audience-based token settings for agent and application configurations.
  * Added selectable audience panels with descriptions, accessibility labels, lock indicators, and keyboard navigation.

* **Improvements**
  * Clarified token attribute and profile descriptions across native, OAuth, agent, and application flows.
  * Improved responsive layouts for larger screens.
  * Added clearer notices and Advanced-tab navigation for unavailable settings.

* **Bug Fixes**
  * Locked audience settings no longer affect validation or save-state behavior.
  * Prevented unnecessary updates when assertion validity remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->