### PR TITLE
Conformance Bug Fix: Token endpoint returns unauthorized_client (should be invalid_client/invalid_request)

### DIFF
--- a/backend/internal/oauth/oauth2/clientauth/clientauth.go
+++ b/backend/internal/oauth/oauth2/clientauth/clientauth.go
@@ -123,6 +123,10 @@ func authenticate(
 	}
 
 	if oauthApp.TokenEndpointAuthMethod != detectedMethod {
+		// No credentials presented for a client that requires authentication.
+		if detectedMethod == providers.TokenEndpointAuthMethodNone {
+			return nil, errClientAuthRequired
+		}
 		return nil, errUnauthorizedAuthMethod
 	}
 

--- a/backend/internal/oauth/oauth2/clientauth/clientauth_test.go
+++ b/backend/internal/oauth/oauth2/clientauth/clientauth_test.go
@@ -972,6 +972,33 @@ func (suite *ClientAuthTestSuite) TestAuthenticate_PrivateKeyJWT_InvalidJSONPayl
 	assert.Equal(suite.T(), "Invalid client assertion", authErr.ErrorDescription)
 }
 
+func (suite *ClientAuthTestSuite) TestAuthenticate_PrivateKeyJWT_MissingClientAuth() {
+	// client_id only, no assertion/secret/basic auth, for a confidential client.
+	mockApp := &providers.OAuthClient{
+		ClientID:                testClientID,
+		TokenEndpointAuthMethod: providers.TokenEndpointAuthMethodPrivateKeyJWT,
+		GrantTypes:              []providers.GrantType{providers.GrantTypeAuthorizationCode},
+	}
+	suite.mockInboundClient.On("GetOAuthClientByClientID", mock.Anything, testClientID).
+		Return(mockApp, nil).Once()
+
+	formData := url.Values{}
+	formData.Set("client_id", testClientID)
+
+	req, _ := http.NewRequest("POST", "/test", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	_ = req.ParseForm()
+
+	clientInfo, authErr := authenticate(
+		req.Context(), req,
+		suite.actorProvider(), suite.mockAuthnProvider, suite.mockJwtService, testIssuer)
+
+	assert.NotNil(suite.T(), authErr)
+	assert.Nil(suite.T(), clientInfo)
+	assert.Equal(suite.T(), errClientAuthRequired, authErr)
+	assert.Equal(suite.T(), constants.ErrorInvalidClient, authErr.ErrorCode)
+}
+
 // validateClientAssertion tests
 
 func (suite *ClientAuthTestSuite) TestValidateClientAssertion_NilCertificate() {

--- a/backend/internal/oauth/oauth2/clientauth/error.go
+++ b/backend/internal/oauth/oauth2/clientauth/error.go
@@ -62,4 +62,9 @@ var (
 		"Invalid client assertion",
 		http.StatusUnauthorized,
 	)
+	errClientAuthRequired = newAuthError(
+		constants.ErrorInvalidClient,
+		"Client authentication is required",
+		http.StatusUnauthorized,
+	)
 )

--- a/tests/integration/oauth/idjag/idjag_consumption_test.go
+++ b/tests/integration/oauth/idjag/idjag_consumption_test.go
@@ -693,12 +693,12 @@ func (ts *IDJAGConsumptionTestSuite) TestIDJAGConsumption_PublicClientConfigReje
 // TestIDJAGConsumption_UnauthenticatedClientRejected verifies that the jwt-bearer grant
 // rejects a request at the token endpoint that omits client authentication entirely for a
 // client registered as confidential (client_secret_basic): the client authentication layer
-// rejects it as unauthorized_client before the grant handler is ever reached.
+// rejects it as invalid_client before the grant handler is ever reached.
 func (ts *IDJAGConsumptionTestSuite) TestIDJAGConsumption_UnauthenticatedClientRejected() {
 	resp, statusCode, err := ts.consumeIDJAG(ts.buildIDJAGAssertion(), nil, consumptionClientID, "")
 	ts.Require().NoError(err)
-	ts.Equal(http.StatusBadRequest, statusCode)
-	ts.Equal("unauthorized_client", resp.Error)
+	ts.Equal(http.StatusUnauthorized, statusCode)
+	ts.Equal("invalid_client", resp.Error)
 }
 
 func (ts *IDJAGConsumptionTestSuite) TestIDJAGConsumption_MissingSubject() {


### PR DESCRIPTION
### Purpose
for testcase - fapi2-security-profile-final-ensure-client-assertion-in-token-endpoint

When a client registered for private_key_jwt calls the token endpoint with no client authentication (no client_assertion, no client secret, no Basic header) but with client_id in the body, ThunderID returns error: "unauthorized_client". RFC 6749 §5.2 requires invalid_client (or invalid_request) for missing client authentication. The endpoint correctly rejects the request but with the wrong error code.

ThunderID issue for same - https://github.com/thunder-id/thunderid/issues/4483

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth client authentication handling when required credentials are missing.
  * Requests now return a clearer `invalid_client` response with HTTP 401 when client authentication is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->