### PR TITLE
Rename the Working with AI docs section to Build with AI

### DIFF
--- a/.agent/skills/docs/new-page.md
+++ b/.agent/skills/docs/new-page.md
@@ -86,7 +86,7 @@ For `docsSidebar`:
 | File path starts with | Section |
 |---|---|
 | `getting-started/` | **Get Started** |
-| `working-with-ai/` | **Working with AI** |
+| `working-with-ai/` | **Build with AI** |
 | `use-cases/` | **Use Cases** |
 | `guides/` | **Guides** |
 | `key-concepts/` | **Key Concepts** |

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -142,16 +142,16 @@ const sidebars: SidebarsConfig = {
       ],
     },
 
-    // Working with AI Section
+    // Build with AI Section
     {
       type: 'html',
       value:
-        '<div class="sidebar-section-label sidebar-section-label--ai"><svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"/><path d="M5 3v4"/><path d="M19 17v4"/><path d="M3 5h4"/><path d="M17 19h4"/></svg><span>Working with AI</span></div>',
+        '<div class="sidebar-section-label sidebar-section-label--ai"><svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"/><path d="M5 3v4"/><path d="M19 17v4"/><path d="M3 5h4"/><path d="M17 19h4"/></svg><span>Build with AI</span></div>',
       className: 'sidebar-html-section-header sidebar-persona-iam sidebar-persona-not-devops',
     },
     {
       type: 'category',
-      label: 'Working with AI',
+      label: 'Build with AI',
       collapsed: false,
       collapsible: false,
       className: 'sidebar-section sidebar-persona-iam sidebar-persona-not-devops',


### PR DESCRIPTION
### Purpose

Renames the **Working with AI** documentation section to **Build with AI**.

The section holds two pages, `working-with-ai/skills` and `working-with-ai/mcp-server`. Both cover driving ThunderID from an AI developer tool such as Claude Code, Codex, Copilot or MCP Inspector. Neither is about issuing identities to agents, but the old name read that way, which is a misleading signal in an IAM product's docs.

### Approach

Label-only change in four places:

| File | Change |
|---|---|
| `docs/sidebars.ts` | Section comment |
| `docs/sidebars.ts` | Visible `<span>` inside the HTML section header |
| `docs/sidebars.ts` | Category `label` |
| `.agent/skills/docs/new-page.md` | Directory-to-section mapping table, so new pages get filed under the correct name |

The SVG markup and the `sidebar-section-label--ai` class name are untouched. The `docs/content/working-with-ai/` directory, doc IDs, URLs and cross-links are all unchanged, so no redirects are required and no existing links break.

On the naming choice: "Build with AI" uses the preposition to mark AI as the instrument the reader is using rather than the audience being served, which is the ambiguity the rename is meant to remove. It also matches the convention used by comparable developer documentation for this same content shape (agent skills plus an MCP server). It leaves "AI Agents" free as a section name should agent identity documentation land later.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Renamed the sidebar section “Working with AI” to “Build with AI” for clearer navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->