### PR TITLE
Recover the gate sign-in page from an expired flow execution

### DIFF
--- a/frontend/apps/gate/src/components/SignIn/SignInBox.tsx
+++ b/frontend/apps/gate/src/components/SignIn/SignInBox.tsx
@@ -5,7 +5,7 @@ import {useDesign, FlowComponentRenderer, AuthCardLayout} from '@thunderid/desig
 import {useTemplateLiteralResolver} from '@thunderid/hooks';
 import {EmbeddedFlowComponentType, SignIn, type EmbeddedFlowComponent} from '@thunderid/react';
 import {EMAIL_REGEX, TemplateLiteralType} from '@thunderid/utils';
-import {Box, Alert, CircularProgress} from '@wso2/oxygen-ui';
+import {Box, Alert, CircularProgress, Link, Typography} from '@wso2/oxygen-ui';
 import {useEffect, useRef, useState} from 'react';
 import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
@@ -141,8 +141,8 @@ export default function SignInBox(): JSX.Element {
       logoDisplay={!isDesignEnabled ? {xs: 'flex', md: 'none'} : {display: 'none'}}
     >
       <SignIn>
-        {({onSubmit, isLoading, components, error, isInitialized, meta: flowMeta, additionalData}) =>
-          (isLoading ?? !isInitialized) ? (
+        {({onSubmit, isLoading, components, error, meta: flowMeta, additionalData}) =>
+          isLoading && !components?.length ? (
             <Box sx={{display: 'flex', justifyContent: 'center', p: 3}}>
               <CircularProgress />
             </Box>
@@ -150,7 +150,11 @@ export default function SignInBox(): JSX.Element {
             <>
               {error && (
                 <Alert severity="error" sx={{mb: 2}}>
-                  {error.message ?? t('signin:errors.signin.failed.description')}
+                  {error.message ??
+                    t(
+                      'signin:errors.signin.failed.description',
+                      'We are sorry, something has gone wrong here. Please try again.',
+                    )}
                 </Alert>
               )}
               {(() => {
@@ -196,6 +200,30 @@ export default function SignInBox(): JSX.Element {
                         />
                       ))}
                     </Box>
+                  );
+                }
+
+                // Terminal failure with nothing to render. A spinner here would look like loading,
+                // so offer the way back to the application instead.
+                if (error) {
+                  const applicationUrl = flowMeta?.application?.url;
+                  if (!applicationUrl) {
+                    // No application URL to link back to, so at least tell the user what to do.
+                    return (
+                      <Typography sx={{textAlign: 'center', p: 1}}>
+                        {t(
+                          'signin:errors.signin.returnToApplicationUnavailable',
+                          'Please return to the application and try again.',
+                        )}
+                      </Typography>
+                    );
+                  }
+                  return (
+                    <Typography sx={{textAlign: 'center', p: 1}}>
+                      <Link href={applicationUrl}>
+                        {t('signin:errors.signin.returnToApplication', 'Return to application')}
+                      </Link>
+                    </Typography>
                   );
                 }
 

--- a/frontend/apps/gate/src/components/SignIn/__tests__/SignInBox.test.tsx
+++ b/frontend/apps/gate/src/components/SignIn/__tests__/SignInBox.test.tsx
@@ -1980,6 +1980,90 @@ describe('SignInBox', () => {
     expect(screen.getByTestId('thunderid-signin')).toBeInTheDocument();
   });
 
+  it('shows the error alert without a spinner when the flow fails with no components', () => {
+    mockSignInRenderProps = createMockSignInRenderProps({
+      components: [],
+      error: {message: 'Session expired'},
+      isLoading: false,
+    });
+    const {container} = render(<SignInBox />);
+
+    expect(screen.getByText('Session expired')).toBeInTheDocument();
+    expect(container.querySelector('.MuiCircularProgress-root')).not.toBeInTheDocument();
+  });
+
+  it('renders a return to application action when flow metadata carries the application URL', () => {
+    mockSignInRenderProps = createMockSignInRenderProps({
+      components: [],
+      error: {message: 'Session expired'},
+      isLoading: false,
+      meta: {application: {url: 'https://app.example.com'}},
+    });
+    render(<SignInBox />);
+
+    expect(screen.getByRole('link', {name: 'Return to application'})).toHaveAttribute(
+      'href',
+      'https://app.example.com',
+    );
+  });
+
+  it('guides the user back to the application when the application URL is unavailable', () => {
+    mockSignInRenderProps = createMockSignInRenderProps({
+      components: [],
+      error: {message: 'Session expired'},
+      isLoading: false,
+      meta: {},
+    });
+    const {container} = render(<SignInBox />);
+
+    expect(screen.getByText('Session expired')).toBeInTheDocument();
+    expect(screen.getByText('Please return to the application and try again.')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(container.querySelector('.MuiCircularProgress-root')).not.toBeInTheDocument();
+  });
+
+  it('shows the spinner while loading with no components and no error', () => {
+    mockSignInRenderProps = createMockSignInRenderProps({
+      components: [],
+      error: null,
+      isLoading: true,
+    });
+    const {container} = render(<SignInBox />);
+
+    expect(container.querySelector('.MuiCircularProgress-root')).toBeInTheDocument();
+  });
+
+  it('keeps the form rendered while a submission is in flight', () => {
+    mockSignInRenderProps = createMockSignInRenderProps({
+      isLoading: true,
+      components: [
+        {
+          id: 'block-1',
+          type: 'BLOCK',
+          components: [
+            {
+              id: 'username-input',
+              type: 'TEXT_INPUT',
+              ref: 'username',
+              label: 'Username',
+              required: true,
+            },
+            {
+              id: 'submit-btn',
+              type: 'ACTION',
+              eventType: 'SUBMIT',
+              label: 'Continue',
+              variant: 'PRIMARY',
+            },
+          ],
+        },
+      ],
+    });
+    render(<SignInBox />);
+
+    expect(screen.getByLabelText(/Username/)).toBeInTheDocument();
+  });
+
   it('renders block without components property', () => {
     mockSignInRenderProps = createMockSignInRenderProps({
       components: [

--- a/frontend/packages/design/src/components/flow/AuthPageLayout.tsx
+++ b/frontend/packages/design/src/components/flow/AuthPageLayout.tsx
@@ -33,7 +33,7 @@ export default function AuthPageLayout({
       className={variant ? cn(`${variant}--root`) : undefined}
       sx={[
         {
-          justifyContent: 'center',
+          justifyContent: 'safe center',
           height: 'calc((1 - var(--template-frame-height, 0)) * 100%)',
           minHeight: '100%',
           ...(background ? {backgroundColor: background} : {}),

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -3081,6 +3081,8 @@ const translations = {
     'errors.signin.failed.description': 'We are sorry, something has gone wrong here. Please try again.',
     'errors.signin.timeout': 'Time allowed to complete the step has expired.',
     'errors.signin.session.expired': 'Your session has expired. Please return to the application and sign in again.',
+    'errors.signin.returnToApplication': 'Return to application',
+    'errors.signin.returnToApplicationUnavailable': 'Please return to the application and try again.',
     'errors.passkey.failed': 'Passkey authentication failed. Please try again.',
     'redirect.to.signup': "Don't have an account? <1>Sign up</1>",
     heading: 'Sign In',


### PR DESCRIPTION
### Purpose

When a flow execution expires, the gate sign-in page rendered a spinner forever with no way out. It now shows the error and a way back to the application.

Also fixes the auth page layout clipping the top of a card taller than the viewport, which hid the heading and any error alert.

### Approach

- `SignInBox`: gate the initial spinner on `isLoading && !components?.length` so a terminal error is not mistaken for loading. On a terminal error, render a `Return to application` action when flow metadata carries the application URL, and guidance text when it does not.
- `AuthPageLayout`: use `justify-content: safe center` so an overflowing card stays scrollable from the top.

### Related Issues

- Refs #4373

### Related PRs

- N/A

### Checklist

- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks

- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in loading and error states for clearer feedback.
  * Added a return-to-application option when a destination is available.
  * Added guidance when returning to the application is unavailable.
  * Preserved sign-in form content while submissions are in progress.
  * Improved authentication page content alignment.
  * Added clearer localized messages for sign-in errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->