### PR TITLE
Introduce user group assignment policies

### DIFF
--- a/api/group.yaml
+++ b/api/group.yaml
@@ -614,6 +614,20 @@ paths:
                     description:
                       key: "error.groupservice.invalid_group_member_id_description"
                       defaultValue: "One or more group member IDs in the request do not exist"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                code: "SAZ-4030"
+                message:
+                  key: "error.sysauthz.grant_not_permitted"
+                  defaultValue: "Insufficient privileges to grant these permissions"
+                description:
+                  key: "error.sysauthz.grant_not_permitted_description"
+                  defaultValue: "The operation would grant permissions that the caller does not hold"
         "404":
           description: Group not found
           content:
@@ -727,6 +741,20 @@ paths:
                     description:
                       key: "error.groupservice.invalid_group_member_id_description"
                       defaultValue: "One or more group member IDs in the request do not exist"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                code: "SAZ-4030"
+                message:
+                  key: "error.sysauthz.grant_not_permitted"
+                  defaultValue: "Insufficient privileges to grant these permissions"
+                description:
+                  key: "error.sysauthz.grant_not_permitted_description"
+                  defaultValue: "The operation would grant permissions that the caller does not hold"
         "404":
           description: Group not found
           content:
@@ -1208,7 +1236,7 @@ components:
       properties:
         code:
           type: string
-          description: "Error code. Codes follow the GRP-XXXX convention."
+          description: "Error code. The prefix identifies the service that produced the error, for example GRP for group management or SAZ for system authorization."
           example: "GRP-1001"
         message:
           $ref: '#/components/schemas/I18nMessage'

--- a/api/role.yaml
+++ b/api/role.yaml
@@ -235,6 +235,20 @@ paths:
                     description:
                       key: "error.roleservice.cannot_create_role_in_declarative_only_mode_description"
                       defaultValue: "Role creation is not allowed when running in declarative-only mode. Roles must be defined in declarative configuration files"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                code: "SAZ-4030"
+                message:
+                  key: "error.sysauthz.grant_not_permitted"
+                  defaultValue: "Insufficient privileges to grant these permissions"
+                description:
+                  key: "error.sysauthz.grant_not_permitted_description"
+                  defaultValue: "The operation would grant permissions that the caller does not hold"
         "409":
           description: Conflict
           content:
@@ -462,6 +476,20 @@ paths:
                     description:
                       key: "error.roleservice.cannot_modify_declarative_role_description"
                       defaultValue: "The role is defined in declarative configuration and cannot be modified"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                code: "SAZ-4030"
+                message:
+                  key: "error.sysauthz.grant_not_permitted"
+                  defaultValue: "Insufficient privileges to grant these permissions"
+                description:
+                  key: "error.sysauthz.grant_not_permitted_description"
+                  defaultValue: "The operation would grant permissions that the caller does not hold"
         "404":
           description: Role not found
           content:
@@ -761,6 +789,20 @@ paths:
                     description:
                       key: "error.roleservice.empty_assignments_list_description"
                       defaultValue: "At least one assignment must be provided"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                code: "SAZ-4030"
+                message:
+                  key: "error.sysauthz.grant_not_permitted"
+                  defaultValue: "Insufficient privileges to grant these permissions"
+                description:
+                  key: "error.sysauthz.grant_not_permitted_description"
+                  defaultValue: "The operation would grant permissions that the caller does not hold"
         "404":
           description: Role not found
           content:
@@ -845,6 +887,20 @@ paths:
                     description:
                       key: "error.roleservice.empty_assignments_list_description"
                       defaultValue: "At least one assignment must be provided"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                code: "SAZ-4030"
+                message:
+                  key: "error.sysauthz.grant_not_permitted"
+                  defaultValue: "Insufficient privileges to grant these permissions"
+                description:
+                  key: "error.sysauthz.grant_not_permitted_description"
+                  defaultValue: "The operation would grant permissions that the caller does not hold"
         "404":
           description: Role not found
           content:
@@ -1175,7 +1231,7 @@ components:
       properties:
         code:
           type: string
-          description: "Error code. Codes follow the ROL-XXXX convention."
+          description: "Error code. The prefix identifies the service that produced the error, for example ROL for role management or SAZ for system authorization."
           example: "ROL-1001"
         message:
           $ref: '#/components/schemas/I18nMessage'

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -197,7 +197,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	exporters = append(exporters, resourceExporter)
 
 	roleService, roleAssignmentService, ouRoleResolver, roleExporter, err := role.Initialize(
-		mux, entityService, groupService, ouService, resourceService, entityTypeService,
+		mux, entityService, groupService, ouService, resourceService, entityTypeService, ouAuthzService,
 	)
 	fatalOnError(ctx, logger, err, "Failed to initialize RoleService")
 	exporters = append(exporters, roleExporter)
@@ -206,6 +206,12 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	ouService.SetOUUserResolver(ouUserResolver)
 	ouService.SetOUGroupResolver(ouGroupResolver)
 	ouService.SetOURoleResolver(ouRoleResolver)
+
+	// Complete the two-phase initialization of the privilege-escalation guard. The resolver spans
+	// roles, groups, and entities, so it can only be built once all three are ready. Until it is
+	// injected the guard fails closed, so this must not be skipped.
+	ouAuthzService.SetPermissionResolver(
+		role.NewEffectivePermissionResolver(roleService, groupService, entityService))
 
 	authZService := authz.Initialize(roleService)
 

--- a/backend/internal/group/GroupServiceInterface_mock_test.go
+++ b/backend/internal/group/GroupServiceInterface_mock_test.go
@@ -935,6 +935,76 @@ func (_c *GroupServiceInterfaceMock_GetResourceDependencies_Call) RunAndReturn(r
 	return _c
 }
 
+// GetTransitiveAncestorGroups provides a mock function for the type GroupServiceInterfaceMock
+func (_mock *GroupServiceInterfaceMock) GetTransitiveAncestorGroups(ctx context.Context, groupID string) ([]string, *common.ServiceError) {
+	ret := _mock.Called(ctx, groupID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTransitiveAncestorGroups")
+	}
+
+	var r0 []string
+	var r1 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]string, *common.ServiceError)); ok {
+		return returnFunc(ctx, groupID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []string); ok {
+		r0 = returnFunc(ctx, groupID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *common.ServiceError); ok {
+		r1 = returnFunc(ctx, groupID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// GroupServiceInterfaceMock_GetTransitiveAncestorGroups_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTransitiveAncestorGroups'
+type GroupServiceInterfaceMock_GetTransitiveAncestorGroups_Call struct {
+	*mock.Call
+}
+
+// GetTransitiveAncestorGroups is a helper method to define mock.On call
+//   - ctx context.Context
+//   - groupID string
+func (_e *GroupServiceInterfaceMock_Expecter) GetTransitiveAncestorGroups(ctx interface{}, groupID interface{}) *GroupServiceInterfaceMock_GetTransitiveAncestorGroups_Call {
+	return &GroupServiceInterfaceMock_GetTransitiveAncestorGroups_Call{Call: _e.mock.On("GetTransitiveAncestorGroups", ctx, groupID)}
+}
+
+func (_c *GroupServiceInterfaceMock_GetTransitiveAncestorGroups_Call) Run(run func(ctx context.Context, groupID string)) *GroupServiceInterfaceMock_GetTransitiveAncestorGroups_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_GetTransitiveAncestorGroups_Call) Return(strings []string, serviceError *common.ServiceError) *GroupServiceInterfaceMock_GetTransitiveAncestorGroups_Call {
+	_c.Call.Return(strings, serviceError)
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_GetTransitiveAncestorGroups_Call) RunAndReturn(run func(ctx context.Context, groupID string) ([]string, *common.ServiceError)) *GroupServiceInterfaceMock_GetTransitiveAncestorGroups_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RemoveGroupMembers provides a mock function for the type GroupServiceInterfaceMock
 func (_mock *GroupServiceInterfaceMock) RemoveGroupMembers(ctx context.Context, groupID string, members []Member) (*Group, *common.ServiceError) {
 	ret := _mock.Called(ctx, groupID, members)

--- a/backend/internal/group/ancestors_test.go
+++ b/backend/internal/group/ancestors_test.go
@@ -1,0 +1,421 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package group
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
+
+	"github.com/thunder-id/thunderid/internal/system/security"
+	"github.com/thunder-id/thunderid/internal/system/sysauthz"
+	"github.com/thunder-id/thunderid/tests/mocks/entitymock"
+	"github.com/thunder-id/thunderid/tests/mocks/sysauthzmock"
+)
+
+// ---------------------------------------------------------------------------
+// buildGetDirectGroupParentsQuery
+// ---------------------------------------------------------------------------
+
+func TestBuildGetDirectGroupParentsQuery(t *testing.T) {
+	t.Run("NoGroupIDsYieldsMatchNothingQuery", func(t *testing.T) {
+		query, args := buildGetDirectGroupParentsQuery(nil, testDeploymentID)
+
+		assert.Equal(t, "GRQ-GROUP_MGT-24", query.ID)
+		assert.Empty(t, args)
+		assert.Contains(t, query.PostgresQuery, "WHERE 1=0")
+		assert.Contains(t, query.SQLiteQuery, "WHERE 1=0")
+	})
+
+	t.Run("SingleGroupID", func(t *testing.T) {
+		query, args := buildGetDirectGroupParentsQuery([]string{"grp1"}, testDeploymentID)
+
+		assert.Contains(t, query.PostgresQuery, "MEMBER_ID IN ($1)")
+		assert.Contains(t, query.PostgresQuery, "DEPLOYMENT_ID = $2")
+		assert.Contains(t, query.SQLiteQuery, "MEMBER_ID IN (?)")
+		assert.Contains(t, query.SQLiteQuery, "DEPLOYMENT_ID = ?")
+		assert.Equal(t, []interface{}{"grp1", testDeploymentID}, args)
+	})
+
+	t.Run("MultipleGroupIDsKeepDeploymentIDLast", func(t *testing.T) {
+		query, args := buildGetDirectGroupParentsQuery([]string{"grp1", "grp2", "grp3"}, testDeploymentID)
+
+		assert.Contains(t, query.PostgresQuery, "MEMBER_ID IN ($1,$2,$3)")
+		assert.Contains(t, query.PostgresQuery, "DEPLOYMENT_ID = $4")
+		assert.Contains(t, query.SQLiteQuery, "MEMBER_ID IN (?,?,?)")
+		assert.Equal(t, []interface{}{"grp1", "grp2", "grp3", testDeploymentID}, args)
+	})
+
+	t.Run("PlaceholderCountMatchesArgCount", func(t *testing.T) {
+		for _, n := range []int{1, 2, 5, 17} {
+			groupIDs := make([]string, n)
+			for i := range groupIDs {
+				groupIDs[i] = fmt.Sprintf("grp%d", i)
+			}
+			query, args := buildGetDirectGroupParentsQuery(groupIDs, testDeploymentID)
+
+			require.Len(t, args, n+1, "arg count for %d group IDs", n)
+			assert.Equal(t, n+1, strings.Count(query.SQLiteQuery, "?"),
+				"sqlite placeholder count for %d group IDs", n)
+			assert.Contains(t, query.PostgresQuery, fmt.Sprintf("DEPLOYMENT_ID = $%d", n+1))
+		}
+	})
+
+	t.Run("OnlyGroupTypeMembershipEdgesAreFollowed", func(t *testing.T) {
+		query, _ := buildGetDirectGroupParentsQuery([]string{"grp1"}, testDeploymentID)
+
+		assert.Contains(t, query.PostgresQuery, "MEMBER_TYPE = 'group'")
+		assert.Contains(t, query.SQLiteQuery, "MEMBER_TYPE = 'group'")
+	})
+
+	// A declarative parent has no row in "GROUP", so joining it would drop that parent from the
+	// ancestor set and understate what the group confers.
+	t.Run("DoesNotJoinGroupTable", func(t *testing.T) {
+		query, _ := buildGetDirectGroupParentsQuery([]string{"grp1"}, testDeploymentID)
+
+		assert.NotContains(t, query.PostgresQuery, "JOIN")
+		assert.NotContains(t, query.SQLiteQuery, "JOIN")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// resolveTransitiveGroupAncestors
+// ---------------------------------------------------------------------------
+
+func TestResolveTransitiveGroupAncestors(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("NoParentsYieldsEmptyAncestors", func(t *testing.T) {
+		store := newGroupStoreInterfaceMock(t)
+		store.EXPECT().GetDirectGroupParents(ctx, []string{"leaf"}).Return([]string{}, nil).Once()
+
+		ancestors, err := resolveTransitiveGroupAncestors(ctx, store, "leaf")
+
+		require.NoError(t, err)
+		assert.Empty(t, ancestors)
+	})
+
+	t.Run("SingleLevel", func(t *testing.T) {
+		store := newGroupStoreInterfaceMock(t)
+		store.EXPECT().GetDirectGroupParents(ctx, []string{"child"}).Return([]string{"parent"}, nil).Once()
+		store.EXPECT().GetDirectGroupParents(ctx, []string{"parent"}).Return([]string{}, nil).Once()
+
+		ancestors, err := resolveTransitiveGroupAncestors(ctx, store, "child")
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"parent"}, ancestors)
+	})
+
+	// A group nested two levels below one that carries roles. Stopping at the first level would
+	// miss the higher ancestor entirely.
+	t.Run("TwoLevelNestReachesTheTopAncestor", func(t *testing.T) {
+		store := newGroupStoreInterfaceMock(t)
+		store.EXPECT().GetDirectGroupParents(ctx, []string{"inner"}).Return([]string{"middle"}, nil).Once()
+		store.EXPECT().GetDirectGroupParents(ctx, []string{"middle"}).Return([]string{"librarian"}, nil).Once()
+		store.EXPECT().GetDirectGroupParents(ctx, []string{"librarian"}).Return([]string{}, nil).Once()
+
+		ancestors, err := resolveTransitiveGroupAncestors(ctx, store, "inner")
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"middle", "librarian"}, ancestors)
+	})
+
+	t.Run("DiamondIsNotVisitedTwice", func(t *testing.T) {
+		store := newGroupStoreInterfaceMock(t)
+		store.EXPECT().GetDirectGroupParents(ctx, []string{"base"}).
+			Return([]string{"left", "right"}, nil).Once()
+		store.EXPECT().GetDirectGroupParents(ctx, []string{"left", "right"}).
+			Return([]string{"top", "top"}, nil).Once()
+		store.EXPECT().GetDirectGroupParents(ctx, []string{"top"}).Return([]string{}, nil).Once()
+
+		ancestors, err := resolveTransitiveGroupAncestors(ctx, store, "base")
+
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"left", "right", "top"}, ancestors)
+		assert.Len(t, ancestors, 3, "top must appear once despite two paths to it")
+	})
+
+	t.Run("DirectCycleTerminates", func(t *testing.T) {
+		store := newGroupStoreInterfaceMock(t)
+		store.EXPECT().GetDirectGroupParents(ctx, []string{"a"}).Return([]string{"b"}, nil).Once()
+		store.EXPECT().GetDirectGroupParents(ctx, []string{"b"}).Return([]string{"a"}, nil).Once()
+
+		ancestors, err := resolveTransitiveGroupAncestors(ctx, store, "a")
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"b"}, ancestors, "the seed group is never its own ancestor")
+	})
+
+	t.Run("SelfReferenceTerminates", func(t *testing.T) {
+		store := newGroupStoreInterfaceMock(t)
+		store.EXPECT().GetDirectGroupParents(ctx, []string{"a"}).Return([]string{"a"}, nil).Once()
+
+		ancestors, err := resolveTransitiveGroupAncestors(ctx, store, "a")
+
+		require.NoError(t, err)
+		assert.Empty(t, ancestors)
+	})
+
+	t.Run("SeedGroupIsExcludedFromAncestors", func(t *testing.T) {
+		store := newGroupStoreInterfaceMock(t)
+		store.EXPECT().GetDirectGroupParents(ctx, []string{"self"}).Return([]string{"parent"}, nil).Once()
+		store.EXPECT().GetDirectGroupParents(ctx, []string{"parent"}).Return([]string{}, nil).Once()
+
+		ancestors, err := resolveTransitiveGroupAncestors(ctx, store, "self")
+
+		require.NoError(t, err)
+		assert.NotContains(t, ancestors, "self")
+	})
+
+	// A store error must surface, never be reported as "no ancestors" — the caller treats an empty
+	// ancestor set as "this group confers nothing", which would let a grant through.
+	t.Run("StoreErrorPropagates", func(t *testing.T) {
+		store := newGroupStoreInterfaceMock(t)
+		store.EXPECT().GetDirectGroupParents(ctx, []string{"child"}).
+			Return(nil, errors.New("database unavailable")).Once()
+
+		ancestors, err := resolveTransitiveGroupAncestors(ctx, store, "child")
+
+		require.Error(t, err)
+		assert.Nil(t, ancestors)
+		assert.Contains(t, err.Error(), "database unavailable")
+	})
+
+	t.Run("ErrorAtDeeperLevelPropagates", func(t *testing.T) {
+		store := newGroupStoreInterfaceMock(t)
+		store.EXPECT().GetDirectGroupParents(ctx, []string{"child"}).Return([]string{"parent"}, nil).Once()
+		store.EXPECT().GetDirectGroupParents(ctx, []string{"parent"}).
+			Return(nil, errors.New("timeout")).Once()
+
+		ancestors, err := resolveTransitiveGroupAncestors(ctx, store, "child")
+
+		require.Error(t, err)
+		assert.Nil(t, ancestors)
+	})
+
+	// An unbounded chain must fail closed rather than issue queries forever.
+	t.Run("ExcessiveDepthIsAnError", func(t *testing.T) {
+		store := newGroupStoreInterfaceMock(t)
+		store.EXPECT().GetDirectGroupParents(ctx, mock.Anything).
+			RunAndReturn(func(_ context.Context, frontier []string) ([]string, error) {
+				// Every group has exactly one distinct parent, forever.
+				return []string{frontier[0] + "x"}, nil
+			})
+
+		ancestors, err := resolveTransitiveGroupAncestors(ctx, store, "g")
+
+		require.Error(t, err)
+		assert.Nil(t, ancestors)
+		assert.Contains(t, err.Error(), "maximum supported depth")
+	})
+
+	t.Run("WalkIsBatchedPerLevelNotPerGroup", func(t *testing.T) {
+		store := newGroupStoreInterfaceMock(t)
+		// Three siblings at one level must be resolved in a single call.
+		store.EXPECT().GetDirectGroupParents(ctx, []string{"base"}).
+			Return([]string{"p1", "p2", "p3"}, nil).Once()
+		store.EXPECT().GetDirectGroupParents(ctx, []string{"p1", "p2", "p3"}).
+			Return([]string{}, nil).Once()
+
+		ancestors, err := resolveTransitiveGroupAncestors(ctx, store, "base")
+
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"p1", "p2", "p3"}, ancestors)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// compositeGroupStore.GetDirectGroupParents
+// ---------------------------------------------------------------------------
+
+func TestCompositeGetDirectGroupParents(t *testing.T) {
+	ctx := context.Background()
+
+	newComposite := func(t *testing.T) (*groupStoreInterfaceMock, *groupStoreInterfaceMock, groupStoreInterface) {
+		dbStore := newGroupStoreInterfaceMock(t)
+		fileStore := newGroupStoreInterfaceMock(t)
+		return dbStore, fileStore, newCompositeGroupStore(fileStore, dbStore)
+	}
+
+	t.Run("UnionsBothStores", func(t *testing.T) {
+		dbStore, fileStore, store := newComposite(t)
+		dbStore.EXPECT().GetDirectGroupParents(ctx, []string{"g"}).Return([]string{"dbParent"}, nil).Once()
+		fileStore.EXPECT().GetDirectGroupParents(ctx, []string{"g"}).
+			Return([]string{"fileParent"}, nil).Once()
+
+		parents, err := store.GetDirectGroupParents(ctx, []string{"g"})
+
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"dbParent", "fileParent"}, parents)
+	})
+
+	t.Run("DeduplicatesAcrossStores", func(t *testing.T) {
+		dbStore, fileStore, store := newComposite(t)
+		dbStore.EXPECT().GetDirectGroupParents(ctx, []string{"g"}).Return([]string{"shared"}, nil).Once()
+		fileStore.EXPECT().GetDirectGroupParents(ctx, []string{"g"}).Return([]string{"shared"}, nil).Once()
+
+		parents, err := store.GetDirectGroupParents(ctx, []string{"g"})
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"shared"}, parents)
+	})
+
+	// Unioning at each hop is what makes a nesting chain that crosses stores resolvable. Asking
+	// either store to resolve the whole chain alone stops at the edge it cannot see.
+	t.Run("ResolvesNestingChainThatCrossesStores", func(t *testing.T) {
+		dbStore, fileStore, store := newComposite(t)
+		// dbChild is nested in a declarative group, which is itself nested in a database group.
+		dbStore.EXPECT().GetDirectGroupParents(ctx, []string{"dbChild"}).Return([]string{}, nil).Once()
+		fileStore.EXPECT().GetDirectGroupParents(ctx, []string{"dbChild"}).
+			Return([]string{"declarativeMiddle"}, nil).Once()
+		dbStore.EXPECT().GetDirectGroupParents(ctx, []string{"declarativeMiddle"}).
+			Return([]string{"dbTop"}, nil).Once()
+		fileStore.EXPECT().GetDirectGroupParents(ctx, []string{"declarativeMiddle"}).
+			Return([]string{}, nil).Once()
+		dbStore.EXPECT().GetDirectGroupParents(ctx, []string{"dbTop"}).Return([]string{}, nil).Once()
+		fileStore.EXPECT().GetDirectGroupParents(ctx, []string{"dbTop"}).Return([]string{}, nil).Once()
+
+		ancestors, err := resolveTransitiveGroupAncestors(ctx, store, "dbChild")
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"declarativeMiddle", "dbTop"}, ancestors)
+	})
+
+	t.Run("DatabaseStoreErrorPropagates", func(t *testing.T) {
+		dbStore, _, store := newComposite(t)
+		dbStore.EXPECT().GetDirectGroupParents(ctx, []string{"g"}).
+			Return(nil, errors.New("db down")).Once()
+
+		parents, err := store.GetDirectGroupParents(ctx, []string{"g"})
+
+		require.Error(t, err)
+		assert.Nil(t, parents)
+	})
+
+	t.Run("FileStoreErrorPropagates", func(t *testing.T) {
+		dbStore, fileStore, store := newComposite(t)
+		dbStore.EXPECT().GetDirectGroupParents(ctx, []string{"g"}).Return([]string{}, nil).Once()
+		fileStore.EXPECT().GetDirectGroupParents(ctx, []string{"g"}).
+			Return(nil, errors.New("file store unreadable")).Once()
+
+		parents, err := store.GetDirectGroupParents(ctx, []string{"g"})
+
+		require.Error(t, err)
+		assert.Nil(t, parents)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// modifyGroupMembers grant checks
+// ---------------------------------------------------------------------------
+
+// newGrantRefusingAuthz returns an authz mock that permits the OU access check but refuses the
+// membership grant, mirroring a caller whose permissions do not cover what the group confers.
+func newGrantRefusingAuthz(t *testing.T) *sysauthzmock.SystemAuthorizationServiceInterfaceMock {
+	mockAuthz := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
+	mockAuthz.On("IsActionAllowed", mock.Anything, mock.Anything, mock.Anything).
+		Return(true, (*tidcommon.ServiceError)(nil)).Maybe()
+	mockAuthz.On("GetAccessibleResources", mock.Anything, mock.Anything, security.ResourceTypeOU).
+		Return(&sysauthz.AccessibleResources{AllAllowed: true}, (*tidcommon.ServiceError)(nil)).Maybe()
+	mockAuthz.On("CanGrantMembership", mock.Anything, mock.Anything, mock.Anything).
+		Return(&sysauthz.ErrorGrantNotPermitted).Maybe()
+	return mockAuthz
+}
+
+func TestModifyGroupMembers_RefusesDisallowedGrant(t *testing.T) {
+	ctx := context.Background()
+	member := []Member{{ID: "bob", Type: MemberTypeUser}}
+
+	// An actor authorized to manage groups adds a member to a group conferring permissions the
+	// actor does not hold. The write must not reach the store.
+	t.Run("AddIsRefusedAndNothingIsWritten", func(t *testing.T) {
+		store := newGroupStoreInterfaceMock(t)
+		store.On("GetGroup", mock.Anything, "librarianGroup").
+			Return(GroupDAO{ID: "librarianGroup", OUID: "ou-1"}, nil)
+		svc := &groupService{
+			groupStore:    store,
+			authzService:  newGrantRefusingAuthz(t),
+			entityService: entitymock.NewEntityServiceInterfaceMock(t),
+			transactioner: &stubTransactioner{},
+		}
+
+		grp, svcErr := svc.AddGroupMembers(ctx, "librarianGroup", member)
+
+		require.NotNil(t, svcErr)
+		assert.Equal(t, sysauthz.ErrorGrantNotPermitted.Code, svcErr.Code)
+		assert.Nil(t, grp)
+		store.AssertNotCalled(t, "AddGroupMembers", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	// Removal carries the same standing requirement, so a limited administrator cannot strip
+	// members from a group more powerful than itself.
+	t.Run("RemoveIsRefusedAndNothingIsWritten", func(t *testing.T) {
+		store := newGroupStoreInterfaceMock(t)
+		store.On("GetGroup", mock.Anything, "librarianGroup").
+			Return(GroupDAO{ID: "librarianGroup", OUID: "ou-1"}, nil)
+		svc := &groupService{
+			groupStore:    store,
+			authzService:  newGrantRefusingAuthz(t),
+			entityService: entitymock.NewEntityServiceInterfaceMock(t),
+			transactioner: &stubTransactioner{},
+		}
+
+		grp, svcErr := svc.RemoveGroupMembers(ctx, "librarianGroup", member)
+
+		require.NotNil(t, svcErr)
+		assert.Equal(t, sysauthz.ErrorGrantNotPermitted.Code, svcErr.Code)
+		assert.Nil(t, grp)
+		store.AssertNotCalled(t, "RemoveGroupMembers", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	// Nesting a group the actor controls into a privileged group makes that group's members
+	// transitive members of the privileged one, so group-typed members are guarded too.
+	t.Run("NestingAGroupIntoAPrivilegedGroupIsRefused", func(t *testing.T) {
+		store := newGroupStoreInterfaceMock(t)
+		store.On("GetGroup", mock.Anything, "librarianGroup").
+			Return(GroupDAO{ID: "librarianGroup", OUID: "ou-1"}, nil)
+		svc := &groupService{
+			groupStore:    store,
+			authzService:  newGrantRefusingAuthz(t),
+			entityService: entitymock.NewEntityServiceInterfaceMock(t),
+			transactioner: &stubTransactioner{},
+		}
+
+		grp, svcErr := svc.AddGroupMembers(ctx, "librarianGroup",
+			[]Member{{ID: "actorControlledGroup", Type: MemberTypeGroup}})
+
+		require.NotNil(t, svcErr)
+		assert.Equal(t, sysauthz.ErrorGrantNotPermitted.Code, svcErr.Code)
+		assert.Nil(t, grp)
+		store.AssertNotCalled(t, "AddGroupMembers", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	// The guard runs before member validation, so a refusal does not depend on the members
+	// resolving successfully and cannot be probed for member existence.
+	t.Run("GuardRunsBeforeMemberValidation", func(t *testing.T) {
+		store := newGroupStoreInterfaceMock(t)
+		store.On("GetGroup", mock.Anything, "librarianGroup").
+			Return(GroupDAO{ID: "librarianGroup", OUID: "ou-1"}, nil)
+		entitySvc := entitymock.NewEntityServiceInterfaceMock(t)
+		svc := &groupService{
+			groupStore:    store,
+			authzService:  newGrantRefusingAuthz(t),
+			entityService: entitySvc,
+			transactioner: &stubTransactioner{},
+		}
+
+		_, svcErr := svc.AddGroupMembers(ctx, "librarianGroup", member)
+
+		require.NotNil(t, svcErr)
+		entitySvc.AssertNotCalled(t, "GetEntitiesByIDs", mock.Anything, mock.Anything)
+	})
+}

--- a/backend/internal/group/composite_store.go
+++ b/backend/internal/group/composite_store.go
@@ -406,6 +406,34 @@ func (c *compositeGroupStore) GetTransitiveGroupsForEntity(
 	return result, nil
 }
 
+// GetDirectGroupParents returns the deduplicated IDs of groups from both stores that directly
+// contain any of the given groups. Unioning at every level is what lets a caller resolve
+// mixed-store nesting, which GetTransitiveGroupsForEntity cannot do.
+func (c *compositeGroupStore) GetDirectGroupParents(
+	ctx context.Context, groupIDs []string,
+) ([]string, error) {
+	dbParents, err := c.dbStore.GetDirectGroupParents(ctx, groupIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	fileParents, err := c.fileStore.GetDirectGroupParents(ctx, groupIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]bool, len(dbParents)+len(fileParents))
+	parents := make([]string, 0, len(dbParents)+len(fileParents))
+	for _, id := range append(dbParents, fileParents...) {
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		parents = append(parents, id)
+	}
+	return parents, nil
+}
+
 // mergeMembers deduplicates and merges members from database and file stores.
 // Database members take precedence over file-based members with the same ID and type.
 func mergeMembers(dbMembers, fileMembers []Member) []Member {

--- a/backend/internal/group/file_based_store.go
+++ b/backend/internal/group/file_based_store.go
@@ -6,6 +6,7 @@ package group
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
@@ -538,6 +539,45 @@ func (f *fileBasedGroupStore) GetTransitiveGroupsForEntity(
 	}
 
 	return result, nil
+}
+
+// GetDirectGroupParents retrieves the IDs of declarative groups that directly contain any of the
+// given groups as a nested member.
+func (f *fileBasedGroupStore) GetDirectGroupParents(
+	ctx context.Context, groupIDs []string,
+) ([]string, error) {
+	if len(groupIDs) == 0 {
+		return []string{}, nil
+	}
+
+	list, err := f.GenericFileBasedStore.List()
+	if err != nil {
+		return nil, err
+	}
+
+	wanted := make(map[string]bool, len(groupIDs))
+	for _, id := range groupIDs {
+		wanted[id] = true
+	}
+
+	parents := make([]string, 0)
+	for _, item := range list {
+		grpData, err := groupFromDeclarativeData(item.ID.ID, item.Data)
+		if err != nil {
+			// Return the error rather than skipping: a skipped entry could be a parent, and this
+			// result feeds an authorization decision. GetTransitiveGroupsForEntity keeps skipping,
+			// since it feeds listings.
+			return nil, fmt.Errorf("declarative group %q could not be parsed while resolving "+
+				"group ancestors: %w", item.ID.ID, err)
+		}
+		for _, member := range grpData.Members {
+			if member.Type == MemberTypeGroup && wanted[member.ID] {
+				parents = append(parents, grpData.ID)
+				break
+			}
+		}
+	}
+	return parents, nil
 }
 
 // isGroupNotFoundError checks whether the error signals a missing entity.

--- a/backend/internal/group/file_based_store_test.go
+++ b/backend/internal/group/file_based_store_test.go
@@ -496,3 +496,38 @@ func (suite *GroupFileBasedStoreTestSuite) TestGetTransitiveGroupsForEntity_NoCy
 
 // Ensure the return type satisfies entity.GroupMembershipProvider.
 var _ entitypkg.GroupMembershipProvider = (*fileBasedGroupStore)(nil)
+
+// A malformed declarative entry must fail the ancestor lookup rather than being skipped. A skipped
+// entry could be a parent, and a short ancestor list understates what membership in a group confers.
+func (suite *GroupFileBasedStoreTestSuite) TestGetDirectGroupParents_MalformedEntryFailsClosed() {
+	parent := groupDeclarativeResource{
+		ID:      "parent-grp",
+		Name:    "Parent",
+		OUID:    "ou1",
+		Members: []Member{{ID: "child-grp", Type: MemberTypeGroup}},
+	}
+	suite.Require().NoError(suite.store.GenericFileBasedStore.Create(parent.ID, &parent))
+	// Bypass the typed Create so a malformed entry lands in the store.
+	suite.Require().NoError(suite.store.GenericFileBasedStore.Create("broken-grp", "not a group"))
+
+	parents, err := suite.store.GetDirectGroupParents(context.Background(), []string{"child-grp"})
+
+	suite.Error(err, "a malformed declarative group must not be silently skipped")
+	suite.Nil(parents)
+}
+
+// The happy path must still resolve parents when every entry parses.
+func (suite *GroupFileBasedStoreTestSuite) TestGetDirectGroupParents_ResolvesWhenAllEntriesParse() {
+	parent := groupDeclarativeResource{
+		ID:      "ok-parent",
+		Name:    "Parent",
+		OUID:    "ou1",
+		Members: []Member{{ID: "ok-child", Type: MemberTypeGroup}},
+	}
+	suite.Require().NoError(suite.store.GenericFileBasedStore.Create(parent.ID, &parent))
+
+	parents, err := suite.store.GetDirectGroupParents(context.Background(), []string{"ok-child"})
+
+	suite.NoError(err)
+	suite.Contains(parents, "ok-parent")
+}

--- a/backend/internal/group/groupStoreInterface_mock_test.go
+++ b/backend/internal/group/groupStoreInterface_mock_test.go
@@ -419,6 +419,74 @@ func (_c *groupStoreInterfaceMock_DeleteMembershipsByMember_Call) RunAndReturn(r
 	return _c
 }
 
+// GetDirectGroupParents provides a mock function for the type groupStoreInterfaceMock
+func (_mock *groupStoreInterfaceMock) GetDirectGroupParents(ctx context.Context, groupIDs []string) ([]string, error) {
+	ret := _mock.Called(ctx, groupIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetDirectGroupParents")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) ([]string, error)); ok {
+		return returnFunc(ctx, groupIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) []string); ok {
+		r0 = returnFunc(ctx, groupIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = returnFunc(ctx, groupIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// groupStoreInterfaceMock_GetDirectGroupParents_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDirectGroupParents'
+type groupStoreInterfaceMock_GetDirectGroupParents_Call struct {
+	*mock.Call
+}
+
+// GetDirectGroupParents is a helper method to define mock.On call
+//   - ctx context.Context
+//   - groupIDs []string
+func (_e *groupStoreInterfaceMock_Expecter) GetDirectGroupParents(ctx interface{}, groupIDs interface{}) *groupStoreInterfaceMock_GetDirectGroupParents_Call {
+	return &groupStoreInterfaceMock_GetDirectGroupParents_Call{Call: _e.mock.On("GetDirectGroupParents", ctx, groupIDs)}
+}
+
+func (_c *groupStoreInterfaceMock_GetDirectGroupParents_Call) Run(run func(ctx context.Context, groupIDs []string)) *groupStoreInterfaceMock_GetDirectGroupParents_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_GetDirectGroupParents_Call) Return(strings []string, err error) *groupStoreInterfaceMock_GetDirectGroupParents_Call {
+	_c.Call.Return(strings, err)
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_GetDirectGroupParents_Call) RunAndReturn(run func(ctx context.Context, groupIDs []string) ([]string, error)) *groupStoreInterfaceMock_GetDirectGroupParents_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetGroup provides a mock function for the type groupStoreInterfaceMock
 func (_mock *groupStoreInterfaceMock) GetGroup(ctx context.Context, id string) (GroupDAO, error) {
 	ret := _mock.Called(ctx, id)

--- a/backend/internal/group/handler.go
+++ b/backend/internal/group/handler.go
@@ -15,6 +15,7 @@ import (
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	"github.com/thunder-id/thunderid/internal/system/error/apierror"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/sysauthz"
 	sysutils "github.com/thunder-id/thunderid/internal/system/utils"
 )
 
@@ -406,7 +407,7 @@ func (gh *groupHandler) handleError(ctx context.Context, w http.ResponseWriter, 
 			ErrorEmptyMembers.Code, ErrorInvalidMemberType.Code,
 			ErrorInvalidMemberID.Code, ErrorInvalidGroupMemberID.Code:
 			statusCode = http.StatusBadRequest
-		case tidcommon.ErrorUnauthorized.Code:
+		case tidcommon.ErrorUnauthorized.Code, sysauthz.ErrorGrantNotPermitted.Code:
 			statusCode = http.StatusForbidden
 		default:
 			statusCode = http.StatusBadRequest

--- a/backend/internal/group/service.go
+++ b/backend/internal/group/service.go
@@ -43,6 +43,10 @@ type GroupServiceInterface interface {
 	GetGroupMembers(ctx context.Context, groupID string, limit, offset int, includeDisplay bool) (
 		*MemberListResponse, *tidcommon.ServiceError)
 	ValidateGroupIDs(ctx context.Context, groupIDs []string) *tidcommon.ServiceError
+	// GetTransitiveAncestorGroups returns the IDs of every group containing the given group,
+	// directly or through nesting, excluding the group itself. It performs no authorization check
+	// of its own: the authorization layer calls it, so gating it would be circular.
+	GetTransitiveAncestorGroups(ctx context.Context, groupID string) ([]string, *tidcommon.ServiceError)
 	GetGroupsByIDs(ctx context.Context, groupIDs []string) (map[string]*Group, *tidcommon.ServiceError)
 	AddGroupMembers(ctx context.Context, groupID string, members []Member) (*Group, *tidcommon.ServiceError)
 	RemoveGroupMembers(ctx context.Context, groupID string, members []Member) (*Group, *tidcommon.ServiceError)
@@ -846,6 +850,14 @@ func (gs *groupService) modifyGroupMembers(
 		return nil, svcErr
 	}
 
+	// Membership conveys every permission the group confers, including through its ancestors.
+	// Removal carries the same requirement.
+	if svcErr := gs.authzService.CanGrantMembership(
+		ctx, sysauthz.PrincipalTypeGroup, groupID,
+	); svcErr != nil {
+		return nil, svcErr
+	}
+
 	if svcErr := gs.validateEntityMembers(ctx, members, security.ActionUpdateGroup); svcErr != nil {
 		return nil, svcErr
 	}
@@ -886,6 +898,15 @@ func (gs *groupService) modifyGroupMembers(
 		); err != nil {
 			capturedSvcErr = err
 			return errors.New("rollback for unauthorized access")
+		}
+
+		// Re-evaluated inside the transaction, as the access check above is, since the group's
+		// assignments may change after the earlier check.
+		if svcErr := gs.authzService.CanGrantMembership(
+			txCtx, sysauthz.PrincipalTypeGroup, groupID,
+		); svcErr != nil {
+			capturedSvcErr = svcErr
+			return errors.New("rollback for disallowed grant")
 		}
 
 		if err := storeOp(txCtx, groupID, members); err != nil {
@@ -1283,6 +1304,28 @@ func validatePaginationParams(limit, offset int) *tidcommon.ServiceError {
 		return &ErrorInvalidOffset
 	}
 	return nil
+}
+
+// GetTransitiveAncestorGroups returns the IDs of every group containing the given group, directly
+// or through nesting. A failure is surfaced as an error, never an empty list, since callers read
+// an empty ancestor set as "confers nothing".
+func (gs *groupService) GetTransitiveAncestorGroups(
+	ctx context.Context, groupID string,
+) ([]string, *tidcommon.ServiceError) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
+
+	if groupID == "" {
+		return nil, &ErrorMissingGroupID
+	}
+
+	ancestors, err := resolveTransitiveGroupAncestors(ctx, gs.groupStore, groupID)
+	if err != nil {
+		logger.Error(ctx, "Failed to resolve transitive ancestor groups",
+			log.String("groupID", groupID), log.Error(err))
+		return nil, &tidcommon.InternalServerError
+	}
+
+	return ancestors, nil
 }
 
 // checkGroupAccess performs an authorization check on the group resource against the current caller.

--- a/backend/internal/group/service_test.go
+++ b/backend/internal/group/service_test.go
@@ -51,6 +51,8 @@ func newAllowAllAuthz(t *testing.T) sysauthz.SystemAuthorizationServiceInterface
 		Return(true, (*tidcommon.ServiceError)(nil)).Maybe()
 	mockAuthz.On("GetAccessibleResources", mock.Anything, mock.Anything, security.ResourceTypeOU).
 		Return(&sysauthz.AccessibleResources{AllAllowed: true}, (*tidcommon.ServiceError)(nil)).Maybe()
+	mockAuthz.On("CanGrantMembership", mock.Anything, mock.Anything, mock.Anything).
+		Return((*tidcommon.ServiceError)(nil)).Maybe()
 	return mockAuthz
 }
 
@@ -61,6 +63,8 @@ func newAuthzError(t *testing.T) sysauthz.SystemAuthorizationServiceInterface {
 		Return(false, &tidcommon.InternalServerError).Maybe()
 	mockAuthz.On("GetAccessibleResources", mock.Anything, mock.Anything, security.ResourceTypeOU).
 		Return((*sysauthz.AccessibleResources)(nil), &tidcommon.InternalServerError).Maybe()
+	mockAuthz.On("CanGrantMembership", mock.Anything, mock.Anything, mock.Anything).
+		Return(&tidcommon.InternalServerError).Maybe()
 	return mockAuthz
 }
 
@@ -2628,6 +2632,9 @@ func TestUpdateGroupMembers_OUValidationFailure(t *testing.T) {
 
 	authzSvcMock.On("IsActionAllowed", mock.Anything, security.ActionUpdateGroup, mock.Anything).
 		Return(true, (*tidcommon.ServiceError)(nil)).Once()
+
+	authzSvcMock.On("CanGrantMembership", mock.Anything, sysauthz.PrincipalTypeGroup, "group1").
+		Return((*tidcommon.ServiceError)(nil)).Once()
 
 	entitySvcMock.On("GetEntitiesByIDs", mock.Anything, []string{"user-1"}).
 		Return([]providers.Entity{

--- a/backend/internal/group/store.go
+++ b/backend/internal/group/store.go
@@ -42,6 +42,50 @@ type groupStoreInterface interface {
 	GetGroupsByIDs(ctx context.Context, groupIDs []string) ([]GroupBasicDAO, error)
 	IsGroupDeclarative(ctx context.Context, id string) (bool, error)
 	GetTransitiveGroupsForEntity(ctx context.Context, entityID string) ([]providers.EntityGroup, error)
+	GetDirectGroupParents(ctx context.Context, groupIDs []string) ([]string, error)
+}
+
+// maxGroupNestingDepth bounds the ancestor walk so a pathologically deep chain cannot turn an
+// authorization check into an unbounded sequence of queries. Cycles are handled by the visited set.
+const maxGroupNestingDepth = 32
+
+// resolveTransitiveGroupAncestors returns the IDs of all groups containing groupID, directly or
+// through further nesting. groupID itself is excluded.
+//
+// The walk proceeds one level at a time so the composite store can union both stores at each hop,
+// which is what makes a nesting chain that crosses the database and declarative stores resolvable.
+// The result must be complete, since callers rely on it for an authorization decision.
+func resolveTransitiveGroupAncestors(
+	ctx context.Context, store groupStoreInterface, groupID string,
+) ([]string, error) {
+	visited := map[string]bool{groupID: true}
+	ancestors := make([]string, 0)
+	frontier := []string{groupID}
+
+	for depth := 0; depth < maxGroupNestingDepth && len(frontier) > 0; depth++ {
+		parents, err := store.GetDirectGroupParents(ctx, frontier)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve group ancestors: %w", err)
+		}
+
+		next := make([]string, 0, len(parents))
+		for _, parentID := range parents {
+			if visited[parentID] {
+				continue
+			}
+			visited[parentID] = true
+			ancestors = append(ancestors, parentID)
+			next = append(next, parentID)
+		}
+		frontier = next
+	}
+
+	if len(frontier) > 0 {
+		return nil, fmt.Errorf("group nesting exceeds the maximum supported depth of %d",
+			maxGroupNestingDepth)
+	}
+
+	return ancestors, nil
 }
 
 // groupStore is the default implementation of groupStoreInterface.
@@ -595,6 +639,35 @@ func (s *groupStore) GetTransitiveGroupsForEntity(
 		groups = append(groups, providers.EntityGroup{ID: groupID, Name: name, OUID: ouID})
 	}
 	return groups, nil
+}
+
+// GetDirectGroupParents retrieves the IDs of database groups directly containing any of the given
+// groups.
+func (s *groupStore) GetDirectGroupParents(ctx context.Context, groupIDs []string) ([]string, error) {
+	if len(groupIDs) == 0 {
+		return []string{}, nil
+	}
+
+	dbClient, err := s.dbProvider.GetEntityDBClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get database client: %w", err)
+	}
+
+	query, args := buildGetDirectGroupParentsQuery(groupIDs, s.deploymentID)
+	results, err := dbClient.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get direct group parents: %w", err)
+	}
+
+	parents := make([]string, 0, len(results))
+	for _, row := range results {
+		parentID, ok := row["group_id"].(string)
+		if !ok {
+			return nil, fmt.Errorf("failed to parse group_id as string")
+		}
+		parents = append(parents, parentID)
+	}
+	return parents, nil
 }
 
 // buildGroupFromResultRow constructs a GroupDAO from a database result row.

--- a/backend/internal/group/store_constants.go
+++ b/backend/internal/group/store_constants.go
@@ -45,6 +45,54 @@ var (
 	}
 )
 
+// buildGetDirectGroupParentsQuery returns the query and args to retrieve the IDs of groups directly
+// containing any of the given groups. Callers walk the chain level by level (see
+// resolveTransitiveGroupAncestors) so that nesting edges spanning both stores resolve.
+//
+// It does not join "GROUP": a declarative parent has no row there, so joining would omit it.
+func buildGetDirectGroupParentsQuery(
+	groupIDs []string, deploymentID string,
+) (dbmodel.DBQuery, []interface{}) {
+	if len(groupIDs) == 0 {
+		return dbmodel.DBQuery{
+			ID:            "GRQ-GROUP_MGT-24",
+			Query:         `SELECT GROUP_ID FROM "GROUP_MEMBER_REFERENCE" WHERE 1=0`,
+			PostgresQuery: `SELECT GROUP_ID FROM "GROUP_MEMBER_REFERENCE" WHERE 1=0`,
+			SQLiteQuery:   `SELECT GROUP_ID FROM "GROUP_MEMBER_REFERENCE" WHERE 1=0`,
+		}, []interface{}{}
+	}
+
+	postgresPlaceholders := make([]string, len(groupIDs))
+	sqlitePlaceholders := make([]string, len(groupIDs))
+	for i := range groupIDs {
+		postgresPlaceholders[i] = fmt.Sprintf("$%d", i+1)
+		sqlitePlaceholders[i] = "?"
+	}
+	deploymentIDIdx := len(groupIDs) + 1
+
+	postgresQuery := fmt.Sprintf(
+		`SELECT DISTINCT GROUP_ID FROM "GROUP_MEMBER_REFERENCE" `+
+			`WHERE MEMBER_TYPE = 'group' AND MEMBER_ID IN (%s) AND DEPLOYMENT_ID = $%d`,
+		strings.Join(postgresPlaceholders, ","), deploymentIDIdx)
+	sqliteQuery := fmt.Sprintf(
+		`SELECT DISTINCT GROUP_ID FROM "GROUP_MEMBER_REFERENCE" `+
+			`WHERE MEMBER_TYPE = 'group' AND MEMBER_ID IN (%s) AND DEPLOYMENT_ID = ?`,
+		strings.Join(sqlitePlaceholders, ","))
+
+	args := make([]interface{}, 0, len(groupIDs)+1)
+	for _, id := range groupIDs {
+		args = append(args, id)
+	}
+	args = append(args, deploymentID)
+
+	return dbmodel.DBQuery{
+		ID:            "GRQ-GROUP_MGT-24",
+		Query:         postgresQuery,
+		PostgresQuery: postgresQuery,
+		SQLiteQuery:   sqliteQuery,
+	}, args
+}
+
 // buildGetGroupsCountByOUIDsQuery returns the query and args to count groups
 // belonging to the specified list of organization unit IDs.
 func buildGetGroupsCountByOUIDsQuery(

--- a/backend/internal/role/RoleServiceInterface_mock_test.go
+++ b/backend/internal/role/RoleServiceInterface_mock_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	mock "github.com/stretchr/testify/mock"
+	"github.com/thunder-id/thunderid/internal/system/security"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 )
 
@@ -163,6 +164,82 @@ func (_c *RoleServiceInterfaceMock_DeleteRole_Call) Return(serviceError *common.
 }
 
 func (_c *RoleServiceInterfaceMock_DeleteRole_Call) RunAndReturn(run func(ctx context.Context, id string) *common.ServiceError) *RoleServiceInterfaceMock_DeleteRole_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetAllPermissions provides a mock function for the type RoleServiceInterfaceMock
+func (_mock *RoleServiceInterfaceMock) GetAllPermissions(ctx context.Context, entityID string, groupIDs []string) (security.PermissionSet, *common.ServiceError) {
+	ret := _mock.Called(ctx, entityID, groupIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllPermissions")
+	}
+
+	var r0 security.PermissionSet
+	var r1 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string) (security.PermissionSet, *common.ServiceError)); ok {
+		return returnFunc(ctx, entityID, groupIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string) security.PermissionSet); ok {
+		r0 = returnFunc(ctx, entityID, groupIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(security.PermissionSet)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, []string) *common.ServiceError); ok {
+		r1 = returnFunc(ctx, entityID, groupIDs)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// RoleServiceInterfaceMock_GetAllPermissions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllPermissions'
+type RoleServiceInterfaceMock_GetAllPermissions_Call struct {
+	*mock.Call
+}
+
+// GetAllPermissions is a helper method to define mock.On call
+//   - ctx context.Context
+//   - entityID string
+//   - groupIDs []string
+func (_e *RoleServiceInterfaceMock_Expecter) GetAllPermissions(ctx interface{}, entityID interface{}, groupIDs interface{}) *RoleServiceInterfaceMock_GetAllPermissions_Call {
+	return &RoleServiceInterfaceMock_GetAllPermissions_Call{Call: _e.mock.On("GetAllPermissions", ctx, entityID, groupIDs)}
+}
+
+func (_c *RoleServiceInterfaceMock_GetAllPermissions_Call) Run(run func(ctx context.Context, entityID string, groupIDs []string)) *RoleServiceInterfaceMock_GetAllPermissions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 []string
+		if args[2] != nil {
+			arg2 = args[2].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *RoleServiceInterfaceMock_GetAllPermissions_Call) Return(permissionSet security.PermissionSet, serviceError *common.ServiceError) *RoleServiceInterfaceMock_GetAllPermissions_Call {
+	_c.Call.Return(permissionSet, serviceError)
+	return _c
+}
+
+func (_c *RoleServiceInterfaceMock_GetAllPermissions_Call) RunAndReturn(run func(ctx context.Context, entityID string, groupIDs []string) (security.PermissionSet, *common.ServiceError)) *RoleServiceInterfaceMock_GetAllPermissions_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/role/all_permissions_test.go
+++ b/backend/internal/role/all_permissions_test.go
@@ -1,0 +1,540 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package role
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/thunder-id/thunderid/internal/system/sysauthz"
+	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
+	"github.com/thunder-id/thunderid/tests/mocks/entitymock"
+	"github.com/thunder-id/thunderid/tests/mocks/groupmock"
+	"github.com/thunder-id/thunderid/tests/mocks/sysauthzmock"
+)
+
+const (
+	testRSSystem  = "01900000-0000-7000-8000-000000000020"
+	testRSPayroll = "01900000-0000-7000-8000-0000000000aa"
+)
+
+// ---------------------------------------------------------------------------
+// buildAllPermissionsForAssigneesQuery
+// ---------------------------------------------------------------------------
+
+func TestBuildAllPermissionsForAssigneesQuery(t *testing.T) {
+	const deploymentID = "test-deployment"
+
+	t.Run("NoEntityAndNoGroupsYieldsMatchNothingQuery", func(t *testing.T) {
+		query, args := buildAllPermissionsForAssigneesQuery("", nil, deploymentID)
+
+		assert.Equal(t, "RLQ-ROLE_MGT-26", query.ID)
+		assert.Empty(t, args)
+		assert.Contains(t, query.PostgresQuery, "WHERE 1=0")
+		assert.Contains(t, query.SQLiteQuery, "WHERE 1=0")
+	})
+
+	t.Run("ProjectsResourceServerAlongsidePermission", func(t *testing.T) {
+		query, _ := buildAllPermissionsForAssigneesQuery("user1", nil, deploymentID)
+
+		assert.Contains(t, query.PostgresQuery, "rp.RESOURCE_SERVER_ID")
+		assert.Contains(t, query.PostgresQuery, "rp.PERMISSION")
+	})
+
+	// The point of this query is to enumerate, so neither filter may appear.
+	t.Run("AppliesNoResourceServerOrPermissionFilter", func(t *testing.T) {
+		query, _ := buildAllPermissionsForAssigneesQuery("user1", []string{"grp1"}, deploymentID)
+
+		assert.NotContains(t, query.PostgresQuery, "rp.PERMISSION IN")
+		assert.NotContains(t, query.PostgresQuery, "rp.RESOURCE_SERVER_ID =")
+		assert.NotContains(t, query.SQLiteQuery, "rp.PERMISSION IN")
+		assert.NotContains(t, query.SQLiteQuery, "rp.RESOURCE_SERVER_ID =")
+	})
+
+	t.Run("EntityOnly", func(t *testing.T) {
+		query, args := buildAllPermissionsForAssigneesQuery("user1", nil, deploymentID)
+
+		assert.Contains(t, query.PostgresQuery, "ra.ASSIGNEE_TYPE = 'entity' AND ra.ASSIGNEE_ID = $2")
+		assert.NotContains(t, query.PostgresQuery, "ASSIGNEE_TYPE = 'group'")
+		assert.Equal(t, []interface{}{deploymentID, "user1"}, args)
+	})
+
+	t.Run("GroupsOnly", func(t *testing.T) {
+		query, args := buildAllPermissionsForAssigneesQuery("", []string{"grp1", "grp2"}, deploymentID)
+
+		assert.Contains(t, query.PostgresQuery, "ra.ASSIGNEE_ID IN ($2,$3)")
+		assert.NotContains(t, query.PostgresQuery, "ASSIGNEE_TYPE = 'entity'")
+		assert.Equal(t, []interface{}{deploymentID, "grp1", "grp2"}, args)
+	})
+
+	t.Run("EntityAndGroupsAreOred", func(t *testing.T) {
+		query, args := buildAllPermissionsForAssigneesQuery("user1", []string{"grp1", "grp2"}, deploymentID)
+
+		assert.Contains(t, query.PostgresQuery, " OR ")
+		assert.Contains(t, query.PostgresQuery, "ra.ASSIGNEE_ID = $2")
+		assert.Contains(t, query.PostgresQuery, "ra.ASSIGNEE_ID IN ($3,$4)")
+		assert.Equal(t, []interface{}{deploymentID, "user1", "grp1", "grp2"}, args)
+	})
+
+	// DEPLOYMENT_ID is $1 and occurs three times. SQLite gives the named form $1 the first free
+	// index and reuses it, so the following ? placeholders must line up with args[1:].
+	t.Run("SQLitePlaceholderCountMatchesArgsAfterDeploymentID", func(t *testing.T) {
+		for _, n := range []int{0, 1, 3, 12} {
+			groupIDs := make([]string, n)
+			for i := range groupIDs {
+				groupIDs[i] = fmt.Sprintf("grp%d", i)
+			}
+			query, args := buildAllPermissionsForAssigneesQuery("user1", groupIDs, deploymentID)
+
+			require.Len(t, args, n+2, "args for %d groups: deployment + entity + groups", n)
+			assert.Equal(t, n+1, strings.Count(query.SQLiteQuery, "?"),
+				"sqlite ? count must equal args after the deployment ID, for %d groups", n)
+			assert.Equal(t, 3, strings.Count(query.SQLiteQuery, "$1"),
+				"deployment ID must stay the first parameter, for %d groups", n)
+		}
+	})
+
+	t.Run("OrdersDeterministically", func(t *testing.T) {
+		query, _ := buildAllPermissionsForAssigneesQuery("user1", nil, deploymentID)
+
+		assert.Contains(t, query.PostgresQuery, "ORDER BY rp.RESOURCE_SERVER_ID, rp.PERMISSION")
+		assert.Contains(t, query.SQLiteQuery, "ORDER BY rp.RESOURCE_SERVER_ID, rp.PERMISSION")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// resourcePermissionsFromMap / mergeResourcePermissions
+// ---------------------------------------------------------------------------
+
+func TestResourcePermissionsFromMap(t *testing.T) {
+	t.Run("EmptyMapYieldsEmptySlice", func(t *testing.T) {
+		assert.Empty(t, resourcePermissionsFromMap(map[string][]string{}))
+	})
+
+	t.Run("DeduplicatesAndSorts", func(t *testing.T) {
+		result := resourcePermissionsFromMap(map[string][]string{
+			testRSPayroll: {"payroll:write", "payroll:read", "payroll:read"},
+			testRSSystem:  {"system:user"},
+		})
+
+		require.Len(t, result, 2)
+		// Resource servers are sorted by ID. testRSSystem ends in "...20" and testRSPayroll in
+		// "...aa", and '2' < 'a', so the system resource server comes first.
+		assert.Equal(t, testRSSystem, result[0].ResourceServerID)
+		assert.Equal(t, testRSPayroll, result[1].ResourceServerID)
+		assert.Equal(t, []string{"system:user"}, result[0].Permissions)
+		assert.Equal(t, []string{"payroll:read", "payroll:write"}, result[1].Permissions)
+	})
+}
+
+func TestMergeResourcePermissions(t *testing.T) {
+	t.Run("UnionsAcrossSources", func(t *testing.T) {
+		result := mergeResourcePermissions(
+			[]ResourcePermissions{{ResourceServerID: testRSSystem, Permissions: []string{"system:user"}}},
+			[]ResourcePermissions{{ResourceServerID: testRSSystem, Permissions: []string{"system:group"}}},
+			[]ResourcePermissions{{ResourceServerID: testRSPayroll, Permissions: []string{"payroll:read"}}},
+		)
+
+		require.Len(t, result, 2)
+		byRS := map[string][]string{}
+		for _, rp := range result {
+			byRS[rp.ResourceServerID] = rp.Permissions
+		}
+		assert.Equal(t, []string{"system:group", "system:user"}, byRS[testRSSystem])
+		assert.Equal(t, []string{"payroll:read"}, byRS[testRSPayroll])
+	})
+
+	t.Run("DeduplicatesOverlapBetweenSources", func(t *testing.T) {
+		result := mergeResourcePermissions(
+			[]ResourcePermissions{{ResourceServerID: testRSSystem, Permissions: []string{"system"}}},
+			[]ResourcePermissions{{ResourceServerID: testRSSystem, Permissions: []string{"system"}}},
+		)
+
+		require.Len(t, result, 1)
+		assert.Equal(t, []string{"system"}, result[0].Permissions)
+	})
+
+	t.Run("NoSourcesYieldsEmpty", func(t *testing.T) {
+		assert.Empty(t, mergeResourcePermissions())
+	})
+}
+
+// ---------------------------------------------------------------------------
+// compositeRoleStore.GetAllPermissionsForAssignees
+// ---------------------------------------------------------------------------
+
+func TestCompositeGetAllPermissionsForAssignees(t *testing.T) {
+	ctx := context.Background()
+
+	newComposite := func(t *testing.T) (*roleStoreInterfaceMock, *roleStoreInterfaceMock, roleStoreInterface) {
+		dbStore := newRoleStoreInterfaceMock(t)
+		fileStore := newRoleStoreInterfaceMock(t)
+		return dbStore, fileStore, newCompositeRoleStore(fileStore, dbStore)
+	}
+
+	t.Run("NoEntityAndNoGroupsShortCircuits", func(t *testing.T) {
+		_, _, store := newComposite(t)
+
+		result, err := store.GetAllPermissionsForAssignees(ctx, "", nil)
+
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("UnionsDatabaseAndDeclarativeSources", func(t *testing.T) {
+		dbStore, fileStore, store := newComposite(t)
+		dbStore.EXPECT().GetAllPermissionsForAssignees(ctx, "user1", []string{}).
+			Return([]ResourcePermissions{
+				{ResourceServerID: testRSSystem, Permissions: []string{"system:group"}},
+			}, nil).Once()
+		fileStore.EXPECT().GetAllPermissionsForAssignees(ctx, "user1", []string{}).
+			Return([]ResourcePermissions{
+				{ResourceServerID: testRSSystem, Permissions: []string{"system:user"}},
+			}, nil).Once()
+		dbStore.EXPECT().GetEntityRoleIDs(ctx, "user1", []string{}).Return([]string{}, nil).Once()
+
+		result, err := store.GetAllPermissionsForAssignees(ctx, "user1", []string{})
+
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, []string{"system:group", "system:user"}, result[0].Permissions)
+	})
+
+	// The third source: a declarative role definition whose assignment was added at runtime and
+	// therefore lives in the database. Neither store sees this on its own.
+	t.Run("IncludesCrossStoreDeclarativeRoleWithDatabaseAssignment", func(t *testing.T) {
+		dbStore, fileStore, store := newComposite(t)
+		dbStore.EXPECT().GetAllPermissionsForAssignees(ctx, "user1", []string{}).
+			Return([]ResourcePermissions{}, nil).Once()
+		fileStore.EXPECT().GetAllPermissionsForAssignees(ctx, "user1", []string{}).
+			Return([]ResourcePermissions{}, nil).Once()
+		dbStore.EXPECT().GetEntityRoleIDs(ctx, "user1", []string{}).
+			Return([]string{"declarativeRole"}, nil).Once()
+		fileStore.EXPECT().IsRoleExist(ctx, "declarativeRole").Return(true, nil).Once()
+		fileStore.EXPECT().GetRole(ctx, "declarativeRole").Return(RoleWithPermissions{
+			ID: "declarativeRole",
+			Permissions: []ResourcePermissions{
+				{ResourceServerID: testRSSystem, Permissions: []string{"system"}},
+			},
+		}, nil).Once()
+
+		result, err := store.GetAllPermissionsForAssignees(ctx, "user1", []string{})
+
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, []string{"system"}, result[0].Permissions,
+			"a declarative role assigned at runtime must still be reported")
+	})
+
+	t.Run("SkipsDatabaseOnlyRolesInCrossStorePass", func(t *testing.T) {
+		dbStore, fileStore, store := newComposite(t)
+		dbStore.EXPECT().GetAllPermissionsForAssignees(ctx, "user1", []string{}).
+			Return([]ResourcePermissions{}, nil).Once()
+		fileStore.EXPECT().GetAllPermissionsForAssignees(ctx, "user1", []string{}).
+			Return([]ResourcePermissions{}, nil).Once()
+		dbStore.EXPECT().GetEntityRoleIDs(ctx, "user1", []string{}).Return([]string{"dbRole"}, nil).Once()
+		fileStore.EXPECT().IsRoleExist(ctx, "dbRole").Return(false, nil).Once()
+
+		result, err := store.GetAllPermissionsForAssignees(ctx, "user1", []string{})
+
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("SkipsRemovedDeclarativeRole", func(t *testing.T) {
+		dbStore, fileStore, store := newComposite(t)
+		dbStore.EXPECT().GetAllPermissionsForAssignees(ctx, "user1", []string{}).
+			Return([]ResourcePermissions{}, nil).Once()
+		fileStore.EXPECT().GetAllPermissionsForAssignees(ctx, "user1", []string{}).
+			Return([]ResourcePermissions{}, nil).Once()
+		dbStore.EXPECT().GetEntityRoleIDs(ctx, "user1", []string{}).Return([]string{"gone"}, nil).Once()
+		fileStore.EXPECT().IsRoleExist(ctx, "gone").Return(true, nil).Once()
+		fileStore.EXPECT().GetRole(ctx, "gone").Return(RoleWithPermissions{}, ErrRoleNotFound).Once()
+
+		result, err := store.GetAllPermissionsForAssignees(ctx, "user1", []string{})
+
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	// A storage failure must not read as "holds nothing": the caller compares this against the
+	// permissions a grant would transfer, so an empty set would wrongly permit the grant.
+	t.Run("UnexpectedFileStoreErrorPropagates", func(t *testing.T) {
+		dbStore, fileStore, store := newComposite(t)
+		dbStore.EXPECT().GetAllPermissionsForAssignees(ctx, "user1", []string{}).
+			Return([]ResourcePermissions{}, nil).Once()
+		fileStore.EXPECT().GetAllPermissionsForAssignees(ctx, "user1", []string{}).
+			Return([]ResourcePermissions{}, nil).Once()
+		dbStore.EXPECT().GetEntityRoleIDs(ctx, "user1", []string{}).Return([]string{"r1"}, nil).Once()
+		fileStore.EXPECT().IsRoleExist(ctx, "r1").Return(true, nil).Once()
+		fileStore.EXPECT().GetRole(ctx, "r1").
+			Return(RoleWithPermissions{}, errors.New("disk failure")).Once()
+
+		result, err := store.GetAllPermissionsForAssignees(ctx, "user1", []string{})
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("DatabaseStoreErrorPropagates", func(t *testing.T) {
+		dbStore, _, store := newComposite(t)
+		dbStore.EXPECT().GetAllPermissionsForAssignees(ctx, "user1", []string{}).
+			Return(nil, errors.New("db down")).Once()
+
+		result, err := store.GetAllPermissionsForAssignees(ctx, "user1", []string{})
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// roleService.GetAllPermissions
+// ---------------------------------------------------------------------------
+
+func TestRoleServiceGetAllPermissions(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("ConvertsToPermissionSetKeyedByResourceServer", func(t *testing.T) {
+		store := newRoleStoreInterfaceMock(t)
+		store.EXPECT().GetAllPermissionsForAssignees(ctx, "user1", []string{"grp1"}).
+			Return([]ResourcePermissions{
+				{ResourceServerID: testRSSystem, Permissions: []string{"system:group"}},
+				{ResourceServerID: testRSPayroll, Permissions: []string{"payroll:read"}},
+			}, nil).Once()
+		svc := &roleService{roleStore: store}
+
+		result, svcErr := svc.GetAllPermissions(ctx, "user1", []string{"grp1"})
+
+		require.Nil(t, svcErr)
+		assert.Equal(t, []string{"system:group"}, result[testRSSystem])
+		assert.Equal(t, []string{"payroll:read"}, result[testRSPayroll])
+	})
+
+	// Unlike GetAuthorizedPermissionsByResourceServer, holding nothing is a valid answer rather
+	// than a missing-argument error.
+	t.Run("NoEntityAndNoGroupsIsAnEmptySetNotAnError", func(t *testing.T) {
+		svc := &roleService{roleStore: newRoleStoreInterfaceMock(t)}
+
+		result, svcErr := svc.GetAllPermissions(ctx, "", nil)
+
+		require.Nil(t, svcErr)
+		assert.Empty(t, result)
+	})
+
+	t.Run("NilGroupsIsNormalized", func(t *testing.T) {
+		store := newRoleStoreInterfaceMock(t)
+		store.EXPECT().GetAllPermissionsForAssignees(ctx, "user1", []string{}).
+			Return([]ResourcePermissions{}, nil).Once()
+		svc := &roleService{roleStore: store}
+
+		result, svcErr := svc.GetAllPermissions(ctx, "user1", nil)
+
+		require.Nil(t, svcErr)
+		assert.Empty(t, result)
+	})
+
+	t.Run("StoreErrorBecomesInternalServerErrorAndNilSet", func(t *testing.T) {
+		store := newRoleStoreInterfaceMock(t)
+		store.EXPECT().GetAllPermissionsForAssignees(ctx, "user1", []string{}).
+			Return(nil, errors.New("db down")).Once()
+		svc := &roleService{roleStore: store}
+
+		result, svcErr := svc.GetAllPermissions(ctx, "user1", []string{})
+
+		require.NotNil(t, svcErr)
+		assert.Nil(t, result, "a failed lookup must not be reported as an empty permission set")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Grant checks on the role paths
+// ---------------------------------------------------------------------------
+
+// newRefusingRoleAuthz returns an authz mock that refuses every grant check.
+func newRefusingRoleAuthz(t *testing.T) sysauthz.SystemAuthorizationServiceInterface {
+	mockAuthz := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
+	mockAuthz.On("CanGrantPermissions", mock.Anything, mock.Anything).
+		Return(&sysauthz.ErrorGrantNotPermitted).Maybe()
+	mockAuthz.On("CanGrantMembership", mock.Anything, mock.Anything, mock.Anything).
+		Return(&sysauthz.ErrorGrantNotPermitted).Maybe()
+	return mockAuthz
+}
+
+func TestRoleAssignmentGuard(t *testing.T) {
+	ctx := context.Background()
+	assignments := []RoleAssignment{{ID: "bob", Type: AssigneeTypeUser}}
+
+	// Assigning a role transfers its permissions, so a caller that does not hold them is refused
+	// before anything reaches the store.
+	t.Run("AddAssignmentsIsRefused", func(t *testing.T) {
+		store := newRoleStoreInterfaceMock(t)
+		txr := &fakeTransactioner{}
+		svc := &roleAssignmentService{
+			roleStore:     store,
+			transactioner: txr,
+			authzService:  newRefusingRoleAuthz(t),
+		}
+
+		svcErr := svc.AddAssignments(ctx, "librarianRole", assignments)
+
+		require.NotNil(t, svcErr)
+		assert.Equal(t, sysauthz.ErrorGrantNotPermitted.Code, svcErr.Code)
+		assert.Zero(t, txr.transactCalls, "no transaction may be opened for a refused grant")
+		store.AssertNotCalled(t, "AddAssignments", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("RemoveAssignmentsIsRefused", func(t *testing.T) {
+		store := newRoleStoreInterfaceMock(t)
+		txr := &fakeTransactioner{}
+		svc := &roleAssignmentService{
+			roleStore:     store,
+			transactioner: txr,
+			authzService:  newRefusingRoleAuthz(t),
+		}
+
+		svcErr := svc.RemoveAssignments(ctx, "librarianRole", assignments)
+
+		require.NotNil(t, svcErr)
+		assert.Equal(t, sysauthz.ErrorGrantNotPermitted.Code, svcErr.Code)
+		assert.Zero(t, txr.transactCalls)
+		store.AssertNotCalled(t, "RemoveAssignments", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	// The guard runs before assignee validation, so a refusal cannot be used to probe which
+	// principals exist.
+	t.Run("GuardRunsBeforeAssigneeValidation", func(t *testing.T) {
+		entitySvc := entitymock.NewEntityServiceInterfaceMock(t)
+		svc := &roleAssignmentService{
+			roleStore:     newRoleStoreInterfaceMock(t),
+			entityService: entitySvc,
+			transactioner: &fakeTransactioner{},
+			authzService:  newRefusingRoleAuthz(t),
+		}
+
+		svcErr := svc.AddAssignments(ctx, "librarianRole", assignments)
+
+		require.NotNil(t, svcErr)
+		entitySvc.AssertNotCalled(t, "GetEntitiesByIDs", mock.Anything, mock.Anything)
+	})
+}
+
+func TestToPermissionSet(t *testing.T) {
+	t.Run("GroupsByResourceServer", func(t *testing.T) {
+		result := toPermissionSet([]ResourcePermissions{
+			{ResourceServerID: testRSSystem, Permissions: []string{"system:user"}},
+			{ResourceServerID: testRSPayroll, Permissions: []string{"payroll:read"}},
+		})
+
+		assert.Equal(t, []string{"system:user"}, result[testRSSystem])
+		assert.Equal(t, []string{"payroll:read"}, result[testRSPayroll])
+	})
+
+	t.Run("MergesDuplicateResourceServerEntries", func(t *testing.T) {
+		result := toPermissionSet([]ResourcePermissions{
+			{ResourceServerID: testRSSystem, Permissions: []string{"system:user"}},
+			{ResourceServerID: testRSSystem, Permissions: []string{"system:group"}},
+		})
+
+		assert.ElementsMatch(t, []string{"system:user", "system:group"}, result[testRSSystem])
+	})
+
+	t.Run("EmptyInputYieldsEmptySet", func(t *testing.T) {
+		assert.Empty(t, toPermissionSet(nil))
+	})
+}
+
+// A corrupt declarative role must fail the whole enumeration rather than being skipped. Skipping
+// would understate what an assignment confers.
+func TestCrossStoreAllPermissions_CorruptRoleFailsClosed(t *testing.T) {
+	ctx := context.Background()
+	dbStore := newRoleStoreInterfaceMock(t)
+	fileStore := newRoleStoreInterfaceMock(t)
+	store := newCompositeRoleStore(fileStore, dbStore)
+
+	dbStore.EXPECT().GetAllPermissionsForAssignees(ctx, "user1", []string{}).
+		Return([]ResourcePermissions{}, nil).Once()
+	fileStore.EXPECT().GetAllPermissionsForAssignees(ctx, "user1", []string{}).
+		Return([]ResourcePermissions{}, nil).Once()
+	dbStore.EXPECT().GetEntityRoleIDs(ctx, "user1", []string{}).Return([]string{"corrupt"}, nil).Once()
+	fileStore.EXPECT().IsRoleExist(ctx, "corrupt").Return(true, nil).Once()
+	fileStore.EXPECT().GetRole(ctx, "corrupt").
+		Return(RoleWithPermissions{}, ErrRoleDataCorrupted).Once()
+
+	result, err := store.GetAllPermissionsForAssignees(ctx, "user1", []string{})
+
+	require.Error(t, err, "corruption must not be silently skipped")
+	assert.Nil(t, result)
+}
+
+// A role whose declarative definition was removed after the assignment was made genuinely confers
+// nothing, so skipping it remains correct.
+func TestCrossStoreAllPermissions_RemovedRoleIsStillSkipped(t *testing.T) {
+	ctx := context.Background()
+	dbStore := newRoleStoreInterfaceMock(t)
+	fileStore := newRoleStoreInterfaceMock(t)
+	store := newCompositeRoleStore(fileStore, dbStore)
+
+	dbStore.EXPECT().GetAllPermissionsForAssignees(ctx, "user1", []string{}).
+		Return([]ResourcePermissions{}, nil).Once()
+	fileStore.EXPECT().GetAllPermissionsForAssignees(ctx, "user1", []string{}).
+		Return([]ResourcePermissions{}, nil).Once()
+	dbStore.EXPECT().GetEntityRoleIDs(ctx, "user1", []string{}).Return([]string{"gone"}, nil).Once()
+	fileStore.EXPECT().IsRoleExist(ctx, "gone").Return(true, nil).Once()
+	fileStore.EXPECT().GetRole(ctx, "gone").Return(RoleWithPermissions{}, ErrRoleNotFound).Once()
+
+	result, err := store.GetAllPermissionsForAssignees(ctx, "user1", []string{})
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+// A role widened between the pre-transaction check and the write must not be assignable on the
+// strength of the earlier result. The second CanGrantMembership call, made inside the transaction,
+// is what closes that window.
+func TestModifyAssignments_RechecksInsideTransaction(t *testing.T) {
+	ctx := context.Background()
+	store := newRoleStoreInterfaceMock(t)
+	txr := &fakeTransactioner{}
+
+	// First call succeeds (pre-transaction), second refuses (inside the transaction), simulating a
+	// concurrent role update that widened the role in between.
+	authz := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
+	call := 0
+	authz.On("CanGrantMembership", mock.Anything, sysauthz.PrincipalTypeRole, "role1").
+		Return(func(context.Context, sysauthz.PrincipalType, string) *tidcommon.ServiceError {
+			call++
+			if call == 1 {
+				return nil
+			}
+			return &sysauthz.ErrorGrantNotPermitted
+		})
+
+	store.EXPECT().IsRoleExist(ctx, "role1").Return(true, nil).Once()
+	store.EXPECT().AddAssignments(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	groupSvc := groupmock.NewGroupServiceInterfaceMock(t)
+	groupSvc.EXPECT().ValidateGroupIDs(ctx, []string{"grp1"}).Return(nil).Once()
+
+	svc := &roleAssignmentService{
+		roleStore:     store,
+		groupService:  groupSvc,
+		transactioner: txr,
+		authzService:  authz,
+	}
+	svcErr := svc.AddAssignments(ctx, "role1", []RoleAssignment{{ID: "grp1", Type: AssigneeTypeGroup}})
+
+	require.NotNil(t, svcErr)
+	assert.Equal(t, sysauthz.ErrorGrantNotPermitted.Code, svcErr.Code,
+		"the in-transaction refusal must surface, not be masked as an internal error")
+	assert.Equal(t, 2, call, "the guard must run again inside the transaction")
+	store.AssertNotCalled(t, "AddAssignments", mock.Anything, mock.Anything, mock.Anything)
+}

--- a/backend/internal/role/assignment_service.go
+++ b/backend/internal/role/assignment_service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/group"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
+	"github.com/thunder-id/thunderid/internal/system/sysauthz"
 	"github.com/thunder-id/thunderid/internal/system/utils"
 )
 
@@ -44,6 +45,7 @@ type roleAssignmentService struct {
 	groupService      group.GroupServiceInterface
 	entityTypeService entitytype.EntityTypeServiceInterface
 	transactioner     providers.Transactioner
+	authzService      sysauthz.SystemAuthorizationServiceInterface
 }
 
 // newRoleAssignmentService creates a new instance of roleAssignmentService.
@@ -53,6 +55,7 @@ func newRoleAssignmentService(
 	groupService group.GroupServiceInterface,
 	entityTypeService entitytype.EntityTypeServiceInterface,
 	transactioner providers.Transactioner,
+	authzService sysauthz.SystemAuthorizationServiceInterface,
 ) RoleAssignmentServiceInterface {
 	return &roleAssignmentService{
 		roleStore:         roleStore,
@@ -60,6 +63,7 @@ func newRoleAssignmentService(
 		groupService:      groupService,
 		entityTypeService: entityTypeService,
 		transactioner:     transactioner,
+		authzService:      authzService,
 	}
 }
 
@@ -236,45 +240,65 @@ func (as *roleAssignmentService) getAssignmentsByEntityCategory(
 // Assignments can be added to both mutable (DB-backed) and declarative (file-backed) roles.
 func (as *roleAssignmentService) AddAssignments(
 	ctx context.Context, id string, assignments []RoleAssignment) *tidcommon.ServiceError {
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, assignmentLoggerComponentName))
-	logger.Debug(ctx, "Adding assignments to role", log.String("id", id))
-
-	normalized, svcErr := as.prepareAssignments(ctx, id, assignments)
-	if svcErr != nil {
-		return svcErr
-	}
-
-	if err := as.transactioner.Transact(ctx, func(txCtx context.Context) error {
-		return as.roleStore.AddAssignments(txCtx, id, normalized)
-	}); err != nil {
-		logger.Error(ctx, "Failed to add assignments to role", log.String("id", id), log.Error(err))
-		return &tidcommon.InternalServerError
-	}
-
-	logger.Debug(ctx, "Successfully added assignments to role", log.String("id", id))
-	return nil
+	return as.modifyAssignments(ctx, id, assignments,
+		as.roleStore.AddAssignments,
+		"add assignments to role", "added assignments to role")
 }
 
 // RemoveAssignments removes assignments from a role.
 // Assignments can be removed from both mutable (DB-backed) and declarative (file-backed) roles.
 func (as *roleAssignmentService) RemoveAssignments(
 	ctx context.Context, id string, assignments []RoleAssignment) *tidcommon.ServiceError {
+	return as.modifyAssignments(ctx, id, assignments,
+		as.roleStore.RemoveAssignments,
+		"remove assignments from role", "removed assignments from role")
+}
+
+// modifyAssignments is the shared implementation for AddAssignments and RemoveAssignments. Both
+// directions carry the same requirement, since assigning conveys the role's permissions to the
+// assignee.
+func (as *roleAssignmentService) modifyAssignments(
+	ctx context.Context,
+	id string,
+	assignments []RoleAssignment,
+	storeOp func(context.Context, string, []RoleAssignment) error,
+	action, successAction string,
+) *tidcommon.ServiceError {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, assignmentLoggerComponentName))
-	logger.Debug(ctx, "Removing assignments from role", log.String("id", id))
+	logger.Debug(ctx, "Modifying role assignments",
+		log.String("action", action), log.String("id", id))
+
+	if svcErr := as.authzService.CanGrantMembership(ctx, sysauthz.PrincipalTypeRole, id); svcErr != nil {
+		return svcErr
+	}
 
 	normalized, svcErr := as.prepareAssignments(ctx, id, assignments)
 	if svcErr != nil {
 		return svcErr
 	}
 
+	var capturedSvcErr *tidcommon.ServiceError
 	if err := as.transactioner.Transact(ctx, func(txCtx context.Context) error {
-		return as.roleStore.RemoveAssignments(txCtx, id, normalized)
+		// Re-evaluated inside the transaction, since the role's permissions may change after the
+		// earlier check.
+		if svcErr := as.authzService.CanGrantMembership(
+			txCtx, sysauthz.PrincipalTypeRole, id,
+		); svcErr != nil {
+			capturedSvcErr = svcErr
+			return errors.New("rollback for disallowed grant")
+		}
+		return storeOp(txCtx, id, normalized)
 	}); err != nil {
-		logger.Error(ctx, "Failed to remove assignments from role", log.String("id", id), log.Error(err))
+		if capturedSvcErr != nil {
+			return capturedSvcErr
+		}
+		logger.Error(ctx, "Failed to modify role assignments",
+			log.String("action", action), log.String("id", id), log.Error(err))
 		return &tidcommon.InternalServerError
 	}
 
-	logger.Debug(ctx, "Successfully removed assignments from role", log.String("id", id))
+	logger.Debug(ctx, "Successfully modified role assignments",
+		log.String("action", successAction), log.String("id", id))
 	return nil
 }
 

--- a/backend/internal/role/assignment_service_test.go
+++ b/backend/internal/role/assignment_service_test.go
@@ -49,6 +49,7 @@ func (suite *RoleAssignmentServiceTestSuite) SetupTest() {
 		suite.mockGroupService,
 		suite.mockEntityTypeService,
 		suite.transactioner,
+		newAllowAllRoleAuthz(suite.T()),
 	)
 }
 

--- a/backend/internal/role/composite_store.go
+++ b/backend/internal/role/composite_store.go
@@ -510,6 +510,79 @@ func (c *compositeRoleStore) crossStoreAuthorizedPermissions(
 	return result, nil
 }
 
+// GetAllPermissionsForAssignees returns every permission the entity and/or groups hold, unioned
+// across the three places a role-to-assignee binding can live: a database role with a database
+// assignment, a declarative role with a YAML-declared assignment, and a declarative role whose
+// assignment was added at runtime. The third case is why no single store can answer this.
+func (c *compositeRoleStore) GetAllPermissionsForAssignees(
+	ctx context.Context, entityID string, groupIDs []string,
+) ([]ResourcePermissions, error) {
+	if entityID == "" && len(groupIDs) == 0 {
+		return []ResourcePermissions{}, nil
+	}
+
+	dbPerms, err := c.dbStore.GetAllPermissionsForAssignees(ctx, entityID, groupIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	filePerms, err := c.fileStore.GetAllPermissionsForAssignees(ctx, entityID, groupIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	crossStorePerms, err := c.crossStoreAllPermissions(ctx, entityID, groupIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	return mergeResourcePermissions(dbPerms, filePerms, crossStorePerms), nil
+}
+
+// crossStoreAllPermissions resolves declarative roles whose assignment rows live in the database.
+// It differs from crossStoreAuthorizedPermissions on corruption: a removed role (ErrRoleNotFound)
+// confers nothing and is skipped, while a corrupt one is returned as an error, since its contents
+// are unknown.
+func (c *compositeRoleStore) crossStoreAllPermissions(
+	ctx context.Context, entityID string, groupIDs []string,
+) ([]ResourcePermissions, error) {
+	roleIDs, err := c.dbStore.GetEntityRoleIDs(ctx, entityID, groupIDs)
+	if err != nil {
+		return nil, err
+	}
+	if len(roleIDs) == 0 {
+		return []ResourcePermissions{}, nil
+	}
+
+	byResourceServer := make(map[string][]string)
+	for _, id := range roleIDs {
+		exists, err := c.fileStore.IsRoleExist(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			// Role is DB-only; already covered by the DB-store enumeration.
+			continue
+		}
+		role, err := c.fileStore.GetRole(ctx, id)
+		if err != nil {
+			if errors.Is(err, ErrRoleNotFound) {
+				continue
+			}
+			log.GetLogger().Error(ctx,
+				"Failed to load declarative role for cross-store permission enumeration",
+				log.String("roleID", id), log.Error(err))
+			return nil, fmt.Errorf("composite role store: load declarative role %q: %w", id, err)
+		}
+		for _, rp := range role.Permissions {
+			byResourceServer[rp.ResourceServerID] = append(
+				byResourceServer[rp.ResourceServerID], rp.Permissions...)
+		}
+	}
+
+	return resourcePermissionsFromMap(byResourceServer), nil
+}
+
 // GetEntityRoleIDs returns the IDs of roles assigned to an entity (directly or via groups).
 // Delegates to the database store since assignments are persisted there even for declarative
 // roles. The file store has no independent record of API-added assignments.

--- a/backend/internal/role/file_based_store.go
+++ b/backend/internal/role/file_based_store.go
@@ -6,6 +6,7 @@ package role
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
@@ -379,6 +380,50 @@ func (f *fileBasedStore) CheckRoleNameExistsExcludingID(
 	}
 
 	return false, nil
+}
+
+// GetAllPermissionsForAssignees returns every permission granted to the entity and/or groups by
+// declarative roles assigned to them, grouped by resource server.
+func (f *fileBasedStore) GetAllPermissionsForAssignees(
+	ctx context.Context, entityID string, groupIDs []string,
+) ([]ResourcePermissions, error) {
+	if entityID == "" && len(groupIDs) == 0 {
+		return []ResourcePermissions{}, nil
+	}
+
+	list, err := f.GenericFileBasedStore.List()
+	if err != nil {
+		return nil, err
+	}
+
+	groupSet := make(map[string]bool, len(groupIDs))
+	for _, groupID := range groupIDs {
+		groupSet[groupID] = true
+	}
+
+	byResourceServer := make(map[string][]string)
+	for _, item := range list {
+		roleData, err := roleFromDeclarativeData(item.ID.ID, item.Data)
+		if err != nil {
+			// Return the error rather than skipping: this enumeration feeds an authorization
+			// decision. GetAuthorizedPermissionsByResourceServer keeps skipping, since it filters
+			// against an explicit requested set.
+			log.GetLogger().Error(ctx, "Malformed declarative role while enumerating permissions",
+				log.String("roleID", item.ID.ID),
+				log.Error(err))
+			return nil, fmt.Errorf("declarative role %q could not be parsed while enumerating "+
+				"permissions: %w", item.ID.ID, err)
+		}
+		if !matchesAssignee(roleData.Assignments, entityID, groupSet) {
+			continue
+		}
+		for _, resourcePerms := range roleData.Permissions {
+			byResourceServer[resourcePerms.ResourceServerID] = append(
+				byResourceServer[resourcePerms.ResourceServerID], resourcePerms.Permissions...)
+		}
+	}
+
+	return resourcePermissionsFromMap(byResourceServer), nil
 }
 
 // GetAuthorizedPermissionsByResourceServer returns permissions from roles assigned to the entity or groups in

--- a/backend/internal/role/file_based_store_test.go
+++ b/backend/internal/role/file_based_store_test.go
@@ -386,3 +386,43 @@ func (suite *RoleFileBasedStoreTestSuite) TestGetEntityRoleIDs_AlwaysEmpty() {
 		})
 	}
 }
+
+// A malformed declarative role must fail the enumeration rather than being skipped. This method
+// feeds the grant checks, where an omitted role understates what is conferred.
+func (suite *RoleFileBasedStoreTestSuite) TestGetAllPermissionsForAssignees_MalformedRoleFailsClosed() {
+	suite.seedRole(RoleWithPermissionsAndAssignments{
+		ID:   "good-role",
+		Name: "Good",
+		OUID: "ou1",
+		Permissions: []ResourcePermissions{
+			{ResourceServerID: "rs1", Permissions: []string{"system:user"}},
+		},
+		Assignments: []RoleAssignment{{ID: "user1", Type: assigneeTypeEntity}},
+	})
+	// Bypass the typed Create so a malformed entry lands in the store.
+	suite.Require().NoError(suite.store.GenericFileBasedStore.Create("broken-role", "not a role"))
+
+	result, err := suite.store.GetAllPermissionsForAssignees(context.Background(), "user1", nil)
+
+	suite.Error(err, "a malformed declarative role must not be silently skipped")
+	suite.Nil(result)
+}
+
+// The happy path must still enumerate permissions when every entry parses.
+func (suite *RoleFileBasedStoreTestSuite) TestGetAllPermissionsForAssignees_EnumeratesWhenAllEntriesParse() {
+	suite.seedRole(RoleWithPermissionsAndAssignments{
+		ID:   "ok-role",
+		Name: "Ok",
+		OUID: "ou1",
+		Permissions: []ResourcePermissions{
+			{ResourceServerID: "rs1", Permissions: []string{"system:user"}},
+		},
+		Assignments: []RoleAssignment{{ID: "user2", Type: assigneeTypeEntity}},
+	})
+
+	result, err := suite.store.GetAllPermissionsForAssignees(context.Background(), "user2", nil)
+
+	suite.NoError(err)
+	suite.Len(result, 1)
+	suite.Equal([]string{"system:user"}, result[0].Permissions)
+}

--- a/backend/internal/role/handler.go
+++ b/backend/internal/role/handler.go
@@ -15,6 +15,7 @@ import (
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	"github.com/thunder-id/thunderid/internal/system/error/apierror"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/sysauthz"
 	sysutils "github.com/thunder-id/thunderid/internal/system/utils"
 )
 
@@ -309,6 +310,8 @@ func handleError(ctx context.Context, w http.ResponseWriter,
 			ErrorEmptyAssignments.Code,
 			ErrorInvalidAssignmentID.Code:
 			statusCode = http.StatusBadRequest
+		case tidcommon.ErrorUnauthorized.Code, sysauthz.ErrorGrantNotPermitted.Code:
+			statusCode = http.StatusForbidden
 		default:
 			statusCode = http.StatusBadRequest
 		}

--- a/backend/internal/role/init.go
+++ b/backend/internal/role/init.go
@@ -15,6 +15,7 @@ import (
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/middleware"
+	"github.com/thunder-id/thunderid/internal/system/sysauthz"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
 
@@ -26,6 +27,7 @@ func Initialize(
 	ouService oupkg.OrganizationUnitServiceInterface,
 	resourceService resourcepkg.ResourceServiceInterface,
 	entityTypeService entitytype.EntityTypeServiceInterface,
+	authzService sysauthz.SystemAuthorizationServiceInterface,
 ) (
 	RoleServiceInterface, RoleAssignmentServiceInterface, oupkg.OURoleResolver,
 	declarativeresource.ResourceExporter, error,
@@ -39,7 +41,7 @@ func Initialize(
 	// Step 2: Create service with store
 	roleService := newRoleService(
 		roleStore, entityService, groupService, ouService, resourceService,
-		transactioner,
+		transactioner, authzService,
 	)
 
 	// Step 3: Load declarative resources into store (if applicable)
@@ -50,7 +52,7 @@ func Initialize(
 	}
 
 	assignmentService := newRoleAssignmentService(
-		roleStore, entityService, groupService, entityTypeService, transactioner,
+		roleStore, entityService, groupService, entityTypeService, transactioner, authzService,
 	)
 	roleHandler := newRoleHandler(roleService, assignmentService)
 	registerRoutes(mux, roleHandler)

--- a/backend/internal/role/init_test.go
+++ b/backend/internal/role/init_test.go
@@ -642,7 +642,7 @@ func (suite *InitTestSuite) TestInitialize_DBClientError() {
 	}()
 
 	mux := http.NewServeMux()
-	_, _, _, _, err := Initialize(mux, nil, nil, nil, nil, nil)
+	_, _, _, _, err := Initialize(mux, nil, nil, nil, nil, nil, nil)
 
 	suite.Error(err)
 	suite.Equal("mock db client error", err.Error())
@@ -666,7 +666,7 @@ func (suite *InitTestSuite) TestInitialize_TransactionerError() {
 	}()
 
 	mux := http.NewServeMux()
-	_, _, _, _, err := Initialize(mux, nil, nil, nil, nil, nil)
+	_, _, _, _, err := Initialize(mux, nil, nil, nil, nil, nil, nil)
 
 	suite.Error(err)
 	suite.Equal("mock transactioner error", err.Error())
@@ -697,7 +697,7 @@ func (suite *InitTestSuite) TestInitialize_Success() {
 	}()
 
 	mux := http.NewServeMux()
-	svc, _, _, exporter, err := Initialize(mux, nil, nil, nil, nil, nil)
+	svc, _, _, exporter, err := Initialize(mux, nil, nil, nil, nil, nil, nil)
 
 	suite.NoError(err)
 	suite.NotNil(svc)
@@ -733,7 +733,7 @@ func (suite *InitTestSuite) TestInitialize_StoreInitError() {
 	}()
 
 	mux := http.NewServeMux()
-	svc, _, _, exporter, err := Initialize(mux, nil, nil, nil, nil, nil)
+	svc, _, _, exporter, err := Initialize(mux, nil, nil, nil, nil, nil, nil)
 
 	suite.Error(err)
 	if err != nil {

--- a/backend/internal/role/permission_resolver.go
+++ b/backend/internal/role/permission_resolver.go
@@ -1,0 +1,124 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package role
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/thunder-id/thunderid/internal/entity"
+	"github.com/thunder-id/thunderid/internal/group"
+	"github.com/thunder-id/thunderid/internal/system/security"
+)
+
+// EffectivePermissionResolver enumerates the permissions a principal effectively holds. It
+// satisfies sysauthz.PermissionResolver structurally, so no import edge to that package is needed.
+// It lives here because roles and groups are in separate databases, and this is the only package
+// with all three inputs available.
+type EffectivePermissionResolver struct {
+	roleService   RoleServiceInterface
+	groupService  group.GroupServiceInterface
+	entityService entity.EntityServiceInterface
+}
+
+// NewEffectivePermissionResolver builds a resolver over the services it needs.
+func NewEffectivePermissionResolver(
+	roleService RoleServiceInterface,
+	groupService group.GroupServiceInterface,
+	entityService entity.EntityServiceInterface,
+) *EffectivePermissionResolver {
+	return &EffectivePermissionResolver{
+		roleService:   roleService,
+		groupService:  groupService,
+		entityService: entityService,
+	}
+}
+
+// ResolveForEntity returns every permission an entity holds, directly and through its groups.
+func (r *EffectivePermissionResolver) ResolveForEntity(
+	ctx context.Context, entityID string,
+) (security.PermissionSet, error) {
+	if entityID == "" {
+		return security.PermissionSet{}, nil
+	}
+
+	entityGroups, err := r.entityService.GetTransitiveEntityGroups(ctx, entityID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve groups for entity: %w", err)
+	}
+
+	groupIDs := make([]string, 0, len(entityGroups))
+	for _, entityGroup := range entityGroups {
+		groupIDs = append(groupIDs, entityGroup.ID)
+	}
+
+	permissions, svcErr := r.roleService.GetAllPermissions(ctx, entityID, groupIDs)
+	if svcErr != nil {
+		return nil, fmt.Errorf("failed to resolve permissions for entity: %s",
+			svcErr.Error.DefaultValue)
+	}
+
+	return permissions, nil
+}
+
+// ResolveForGroup returns every permission that membership in a group confers, including the roles
+// its ancestors carry. Omitting ancestors would let a caller join a harmless group nested inside a
+// privileged one.
+func (r *EffectivePermissionResolver) ResolveForGroup(
+	ctx context.Context, groupID string,
+) (security.PermissionSet, error) {
+	if groupID == "" {
+		return security.PermissionSet{}, nil
+	}
+
+	ancestors, svcErr := r.groupService.GetTransitiveAncestorGroups(ctx, groupID)
+	if svcErr != nil {
+		return nil, fmt.Errorf("failed to resolve ancestor groups: %s", svcErr.Error.DefaultValue)
+	}
+
+	groupIDs := make([]string, 0, len(ancestors)+1)
+	groupIDs = append(groupIDs, groupID)
+	groupIDs = append(groupIDs, ancestors...)
+
+	permissions, svcErr := r.roleService.GetAllPermissions(ctx, "", groupIDs)
+	if svcErr != nil {
+		return nil, fmt.Errorf("failed to resolve permissions for group: %s",
+			svcErr.Error.DefaultValue)
+	}
+
+	return permissions, nil
+}
+
+// ResolveForRole returns the permissions a role confers on its assignees.
+func (r *EffectivePermissionResolver) ResolveForRole(
+	ctx context.Context, roleID string,
+) (security.PermissionSet, error) {
+	if roleID == "" {
+		return security.PermissionSet{}, nil
+	}
+
+	role, svcErr := r.roleService.GetRoleWithPermissions(ctx, roleID)
+	if svcErr != nil {
+		return nil, fmt.Errorf("failed to resolve permissions for role: %s",
+			svcErr.Error.DefaultValue)
+	}
+
+	permissions := make(security.PermissionSet, len(role.Permissions))
+	for _, rp := range role.Permissions {
+		permissions[rp.ResourceServerID] = append(
+			permissions[rp.ResourceServerID], rp.Permissions...)
+	}
+
+	return permissions, nil
+}
+
+// toPermissionSet converts per-resource-server slices into the map form Covers expects.
+func toPermissionSet(resourcePermissions []ResourcePermissions) security.PermissionSet {
+	permissionSet := make(security.PermissionSet, len(resourcePermissions))
+	for _, rp := range resourcePermissions {
+		permissionSet[rp.ResourceServerID] = append(
+			permissionSet[rp.ResourceServerID], rp.Permissions...)
+	}
+	return permissionSet
+}

--- a/backend/internal/role/permission_resolver_test.go
+++ b/backend/internal/role/permission_resolver_test.go
@@ -1,0 +1,240 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package role
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
+
+	"github.com/thunder-id/thunderid/internal/system/security"
+
+	"github.com/thunder-id/thunderid/tests/mocks/entitymock"
+	"github.com/thunder-id/thunderid/tests/mocks/groupmock"
+)
+
+func TestResolveForEntity(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("EmptyEntityIDYieldsEmptySet", func(t *testing.T) {
+		resolver := NewEffectivePermissionResolver(nil, nil, nil)
+
+		result, err := resolver.ResolveForEntity(ctx, "")
+
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("CombinesDirectAndGroupDerivedPermissions", func(t *testing.T) {
+		entitySvc := entitymock.NewEntityServiceInterfaceMock(t)
+		roleSvc := NewRoleServiceInterfaceMock(t)
+		entitySvc.EXPECT().GetTransitiveEntityGroups(ctx, "david").
+			Return([]providers.EntityGroup{{ID: "grpA"}, {ID: "grpB"}}, nil).Once()
+		roleSvc.EXPECT().GetAllPermissions(ctx, "david", []string{"grpA", "grpB"}).
+			Return(security.PermissionSet{testRSSystem: {"system:group"}}, nil).Once()
+		resolver := NewEffectivePermissionResolver(roleSvc, nil, entitySvc)
+
+		result, err := resolver.ResolveForEntity(ctx, "david")
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"system:group"}, result[testRSSystem])
+	})
+
+	t.Run("EntityWithNoGroups", func(t *testing.T) {
+		entitySvc := entitymock.NewEntityServiceInterfaceMock(t)
+		roleSvc := NewRoleServiceInterfaceMock(t)
+		entitySvc.EXPECT().GetTransitiveEntityGroups(ctx, "loner").
+			Return([]providers.EntityGroup{}, nil).Once()
+		roleSvc.EXPECT().GetAllPermissions(ctx, "loner", []string{}).
+			Return(security.PermissionSet{}, nil).Once()
+		resolver := NewEffectivePermissionResolver(roleSvc, nil, entitySvc)
+
+		result, err := resolver.ResolveForEntity(ctx, "loner")
+
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	// A failed lookup must surface as an error. Reporting an empty set would understate the
+	// caller's own authority and cause a false denial, or worse, be read as "holds nothing".
+	t.Run("GroupLookupErrorPropagates", func(t *testing.T) {
+		entitySvc := entitymock.NewEntityServiceInterfaceMock(t)
+		entitySvc.EXPECT().GetTransitiveEntityGroups(ctx, "david").
+			Return(nil, errors.New("entity store down")).Once()
+		resolver := NewEffectivePermissionResolver(nil, nil, entitySvc)
+
+		result, err := resolver.ResolveForEntity(ctx, "david")
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("PermissionLookupErrorPropagates", func(t *testing.T) {
+		entitySvc := entitymock.NewEntityServiceInterfaceMock(t)
+		roleSvc := NewRoleServiceInterfaceMock(t)
+		entitySvc.EXPECT().GetTransitiveEntityGroups(ctx, "david").
+			Return([]providers.EntityGroup{}, nil).Once()
+		roleSvc.EXPECT().GetAllPermissions(ctx, "david", []string{}).
+			Return(nil, &tidcommon.InternalServerError).Once()
+		resolver := NewEffectivePermissionResolver(roleSvc, nil, entitySvc)
+
+		result, err := resolver.ResolveForEntity(ctx, "david")
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+func TestResolveForGroup(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("EmptyGroupIDYieldsEmptySet", func(t *testing.T) {
+		resolver := NewEffectivePermissionResolver(nil, nil, nil)
+
+		result, err := resolver.ResolveForGroup(ctx, "")
+
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	// The group itself plus every ancestor. A group carrying no roles of its own still confers
+	// whatever its ancestors carry, because its members are transitively members of them.
+	t.Run("IncludesAncestorsAlongsideTheGroupItself", func(t *testing.T) {
+		groupSvc := groupmock.NewGroupServiceInterfaceMock(t)
+		roleSvc := NewRoleServiceInterfaceMock(t)
+		groupSvc.EXPECT().GetTransitiveAncestorGroups(ctx, "innerGroup").
+			Return([]string{"middleGroup", "librarianGroup"}, nil).Once()
+		roleSvc.EXPECT().GetAllPermissions(ctx, "",
+			[]string{"innerGroup", "middleGroup", "librarianGroup"}).
+			Return(security.PermissionSet{testRSSystem: {"system:user"}}, nil).Once()
+		resolver := NewEffectivePermissionResolver(roleSvc, groupSvc, nil)
+
+		result, err := resolver.ResolveForGroup(ctx, "innerGroup")
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"system:user"}, result[testRSSystem],
+			"a harmless group nested inside a privileged one must confer the privileged permissions")
+	})
+
+	t.Run("GroupItselfIsQueriedFirstAndAlwaysIncluded", func(t *testing.T) {
+		groupSvc := groupmock.NewGroupServiceInterfaceMock(t)
+		roleSvc := NewRoleServiceInterfaceMock(t)
+		groupSvc.EXPECT().GetTransitiveAncestorGroups(ctx, "topGroup").
+			Return([]string{}, nil).Once()
+		roleSvc.EXPECT().GetAllPermissions(ctx, "", []string{"topGroup"}).
+			Return(security.PermissionSet{testRSSystem: {"system"}}, nil).Once()
+		resolver := NewEffectivePermissionResolver(roleSvc, groupSvc, nil)
+
+		result, err := resolver.ResolveForGroup(ctx, "topGroup")
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"system"}, result[testRSSystem])
+	})
+
+	// No entity ID is passed: the question is what the group confers, not what any member holds.
+	t.Run("ResolvesWithoutAnEntityID", func(t *testing.T) {
+		groupSvc := groupmock.NewGroupServiceInterfaceMock(t)
+		roleSvc := NewRoleServiceInterfaceMock(t)
+		groupSvc.EXPECT().GetTransitiveAncestorGroups(ctx, "grp1").Return([]string{}, nil).Once()
+		roleSvc.EXPECT().GetAllPermissions(ctx, "", []string{"grp1"}).
+			Return(security.PermissionSet{}, nil).Once()
+		resolver := NewEffectivePermissionResolver(roleSvc, groupSvc, nil)
+
+		_, err := resolver.ResolveForGroup(ctx, "grp1")
+
+		require.NoError(t, err)
+	})
+
+	// If the ancestor walk fails, treating the group as conferring only its own roles would
+	// understate what it confers through the nested-group path.
+	t.Run("AncestorLookupErrorPropagates", func(t *testing.T) {
+		groupSvc := groupmock.NewGroupServiceInterfaceMock(t)
+		groupSvc.EXPECT().GetTransitiveAncestorGroups(ctx, "grp1").
+			Return(nil, &tidcommon.InternalServerError).Once()
+		resolver := NewEffectivePermissionResolver(nil, groupSvc, nil)
+
+		result, err := resolver.ResolveForGroup(ctx, "grp1")
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("PermissionLookupErrorPropagates", func(t *testing.T) {
+		groupSvc := groupmock.NewGroupServiceInterfaceMock(t)
+		roleSvc := NewRoleServiceInterfaceMock(t)
+		groupSvc.EXPECT().GetTransitiveAncestorGroups(ctx, "grp1").Return([]string{}, nil).Once()
+		roleSvc.EXPECT().GetAllPermissions(ctx, "", []string{"grp1"}).
+			Return(nil, &tidcommon.InternalServerError).Once()
+		resolver := NewEffectivePermissionResolver(roleSvc, groupSvc, nil)
+
+		result, err := resolver.ResolveForGroup(ctx, "grp1")
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+func TestResolveForRole(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("EmptyRoleIDYieldsEmptySet", func(t *testing.T) {
+		resolver := NewEffectivePermissionResolver(nil, nil, nil)
+
+		result, err := resolver.ResolveForRole(ctx, "")
+
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("GroupsPermissionsByResourceServer", func(t *testing.T) {
+		roleSvc := NewRoleServiceInterfaceMock(t)
+		roleSvc.EXPECT().GetRoleWithPermissions(ctx, "librarian").Return(&RoleWithPermissions{
+			ID: "librarian",
+			Permissions: []ResourcePermissions{
+				{ResourceServerID: testRSSystem, Permissions: []string{"system:user", "system:group"}},
+				{ResourceServerID: testRSPayroll, Permissions: []string{"payroll:read"}},
+			},
+		}, nil).Once()
+		resolver := NewEffectivePermissionResolver(roleSvc, nil, nil)
+
+		result, err := resolver.ResolveForRole(ctx, "librarian")
+
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"system:user", "system:group"}, result[testRSSystem])
+		assert.Equal(t, []string{"payroll:read"}, result[testRSPayroll])
+	})
+
+	t.Run("RoleWithNoPermissions", func(t *testing.T) {
+		roleSvc := NewRoleServiceInterfaceMock(t)
+		roleSvc.EXPECT().GetRoleWithPermissions(ctx, "empty").Return(&RoleWithPermissions{
+			ID:          "empty",
+			Permissions: []ResourcePermissions{},
+		}, nil).Once()
+		resolver := NewEffectivePermissionResolver(roleSvc, nil, nil)
+
+		result, err := resolver.ResolveForRole(ctx, "empty")
+
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	// A missing role must not read as "confers nothing", which would permit assigning it.
+	t.Run("LookupErrorPropagates", func(t *testing.T) {
+		roleSvc := NewRoleServiceInterfaceMock(t)
+		roleSvc.EXPECT().GetRoleWithPermissions(ctx, "gone").
+			Return(nil, &ErrorRoleNotFound).Once()
+		resolver := NewEffectivePermissionResolver(roleSvc, nil, nil)
+
+		result, err := resolver.ResolveForRole(ctx, "gone")
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+	})
+}

--- a/backend/internal/role/roleStoreInterface_mock_test.go
+++ b/backend/internal/role/roleStoreInterface_mock_test.go
@@ -499,6 +499,80 @@ func (_c *roleStoreInterfaceMock_DeleteRole_Call) RunAndReturn(run func(ctx cont
 	return _c
 }
 
+// GetAllPermissionsForAssignees provides a mock function for the type roleStoreInterfaceMock
+func (_mock *roleStoreInterfaceMock) GetAllPermissionsForAssignees(ctx context.Context, entityID string, groupIDs []string) ([]ResourcePermissions, error) {
+	ret := _mock.Called(ctx, entityID, groupIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllPermissionsForAssignees")
+	}
+
+	var r0 []ResourcePermissions
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string) ([]ResourcePermissions, error)); ok {
+		return returnFunc(ctx, entityID, groupIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string) []ResourcePermissions); ok {
+		r0 = returnFunc(ctx, entityID, groupIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]ResourcePermissions)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, []string) error); ok {
+		r1 = returnFunc(ctx, entityID, groupIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// roleStoreInterfaceMock_GetAllPermissionsForAssignees_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllPermissionsForAssignees'
+type roleStoreInterfaceMock_GetAllPermissionsForAssignees_Call struct {
+	*mock.Call
+}
+
+// GetAllPermissionsForAssignees is a helper method to define mock.On call
+//   - ctx context.Context
+//   - entityID string
+//   - groupIDs []string
+func (_e *roleStoreInterfaceMock_Expecter) GetAllPermissionsForAssignees(ctx interface{}, entityID interface{}, groupIDs interface{}) *roleStoreInterfaceMock_GetAllPermissionsForAssignees_Call {
+	return &roleStoreInterfaceMock_GetAllPermissionsForAssignees_Call{Call: _e.mock.On("GetAllPermissionsForAssignees", ctx, entityID, groupIDs)}
+}
+
+func (_c *roleStoreInterfaceMock_GetAllPermissionsForAssignees_Call) Run(run func(ctx context.Context, entityID string, groupIDs []string)) *roleStoreInterfaceMock_GetAllPermissionsForAssignees_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 []string
+		if args[2] != nil {
+			arg2 = args[2].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_GetAllPermissionsForAssignees_Call) Return(resourcePermissionss []ResourcePermissions, err error) *roleStoreInterfaceMock_GetAllPermissionsForAssignees_Call {
+	_c.Call.Return(resourcePermissionss, err)
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_GetAllPermissionsForAssignees_Call) RunAndReturn(run func(ctx context.Context, entityID string, groupIDs []string) ([]ResourcePermissions, error)) *roleStoreInterfaceMock_GetAllPermissionsForAssignees_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAuthorizedPermissionsByResourceServer provides a mock function for the type roleStoreInterfaceMock
 func (_mock *roleStoreInterfaceMock) GetAuthorizedPermissionsByResourceServer(ctx context.Context, entityID string, groupIDs []string, resourceServerID string, requestedPermissions []string) ([]string, error) {
 	ret := _mock.Called(ctx, entityID, groupIDs, resourceServerID, requestedPermissions)

--- a/backend/internal/role/service.go
+++ b/backend/internal/role/service.go
@@ -18,6 +18,7 @@ import (
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/security"
+	"github.com/thunder-id/thunderid/internal/system/sysauthz"
 	"github.com/thunder-id/thunderid/internal/system/utils"
 )
 
@@ -36,6 +37,11 @@ type RoleServiceInterface interface {
 	GetAuthorizedPermissionsByResourceServer(
 		ctx context.Context, entityID string, groups []string, resourceServerID string, requestedPermissions []string,
 	) ([]string, *tidcommon.ServiceError)
+	// GetAllPermissions returns every permission the entity and/or groups hold, keyed by resource
+	// server. Unlike GetAuthorizedPermissionsByResourceServer it enumerates rather than checks.
+	GetAllPermissions(
+		ctx context.Context, entityID string, groupIDs []string,
+	) (security.PermissionSet, *tidcommon.ServiceError)
 	GetUserRoles(ctx context.Context, entityID string, groupIDs []string) ([]string, *tidcommon.ServiceError)
 	ResolveRoleOUHandle(
 		ctx context.Context, role *RoleWithPermissionsAndAssignments,
@@ -50,6 +56,7 @@ type roleService struct {
 	ouService       oupkg.OrganizationUnitServiceInterface
 	resourceService resourcepkg.ResourceServiceInterface
 	transactioner   providers.Transactioner
+	authzService    sysauthz.SystemAuthorizationServiceInterface
 }
 
 // newRoleService creates a new instance of RoleService with injected dependencies.
@@ -60,6 +67,7 @@ func newRoleService(
 	ouService oupkg.OrganizationUnitServiceInterface,
 	resourceService resourcepkg.ResourceServiceInterface,
 	transactioner providers.Transactioner,
+	authzService sysauthz.SystemAuthorizationServiceInterface,
 ) RoleServiceInterface {
 	return &roleService{
 		roleStore:       roleStore,
@@ -68,6 +76,7 @@ func newRoleService(
 		ouService:       ouService,
 		resourceService: resourceService,
 		transactioner:   transactioner,
+		authzService:    authzService,
 	}
 }
 
@@ -163,6 +172,14 @@ func (rs *roleService) CreateRole(
 	// Validate permissions exist in resource management system
 	if err := rs.validatePermissions(ctx, role.Permissions); err != nil {
 		return nil, err
+	}
+
+	// Defining a role conveys its permissions to future assignees. Inline assignments need no
+	// separate check: they assign this same role, already covered above.
+	if svcErr := rs.authzService.CanGrantPermissions(
+		ctx, toPermissionSet(role.Permissions),
+	); svcErr != nil {
+		return nil, svcErr
 	}
 
 	// Validate assignment IDs (existence + category check) before normalization.
@@ -281,6 +298,13 @@ func (rs *roleService) UpdateRoleWithPermissions(
 	// Validate permissions exist in resource management system
 	if err := rs.validatePermissions(ctx, role.Permissions); err != nil {
 		return nil, err
+	}
+
+	// An update replaces the permission list, so the incoming set is what the role will confer.
+	if svcErr := rs.authzService.CanGrantPermissions(
+		ctx, toPermissionSet(role.Permissions),
+	); svcErr != nil {
+		return nil, svcErr
 	}
 
 	exists, err := rs.roleStore.IsRoleExist(ctx, id)
@@ -432,6 +456,43 @@ func (rs *roleService) GetAuthorizedPermissionsByResourceServer(
 		log.Int("authorizedCount", len(authorizedPermissions)))
 
 	return authorizedPermissions, nil
+}
+
+// GetAllPermissions retrieves every permission the entity and/or groups hold through their assigned
+// roles, keyed by resource server. Unlike GetAuthorizedPermissionsByResourceServer, no entity and no
+// groups is not an error: callers legitimately ask what a set of groups confers.
+func (rs *roleService) GetAllPermissions(
+	ctx context.Context, entityID string, groupIDs []string,
+) (security.PermissionSet, *tidcommon.ServiceError) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
+
+	if groupIDs == nil {
+		groupIDs = []string{}
+	}
+	if entityID == "" && len(groupIDs) == 0 {
+		return security.PermissionSet{}, nil
+	}
+
+	resourcePermissions, err := rs.roleStore.GetAllPermissionsForAssignees(ctx, entityID, groupIDs)
+	if err != nil {
+		logger.Error(ctx, "Failed to enumerate permissions for assignees",
+			log.MaskedString(log.LoggerKeyUserID, entityID),
+			log.Int("groupCount", len(groupIDs)),
+			log.Error(err))
+		return nil, &tidcommon.InternalServerError
+	}
+
+	permissionSet := make(security.PermissionSet, len(resourcePermissions))
+	for _, rp := range resourcePermissions {
+		permissionSet[rp.ResourceServerID] = rp.Permissions
+	}
+
+	logger.Debug(ctx, "Enumerated permissions for assignees",
+		log.MaskedString(log.LoggerKeyUserID, entityID),
+		log.Int("groupCount", len(groupIDs)),
+		log.Int("resourceServerCount", len(permissionSet)))
+
+	return permissionSet, nil
 }
 
 // GetUserRoles retrieves the names of roles assigned to an entity directly and/or through group membership.

--- a/backend/internal/role/service_test.go
+++ b/backend/internal/role/service_test.go
@@ -17,6 +17,7 @@ import (
 	oupkg "github.com/thunder-id/thunderid/internal/ou"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
+	"github.com/thunder-id/thunderid/internal/system/sysauthz"
 	"github.com/thunder-id/thunderid/internal/system/utils"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 	"github.com/thunder-id/thunderid/tests/mocks/entitymock"
@@ -24,6 +25,7 @@ import (
 	"github.com/thunder-id/thunderid/tests/mocks/groupmock"
 	"github.com/thunder-id/thunderid/tests/mocks/oumock"
 	"github.com/thunder-id/thunderid/tests/mocks/resourcemock"
+	"github.com/thunder-id/thunderid/tests/mocks/sysauthzmock"
 )
 
 const (
@@ -88,6 +90,7 @@ func (suite *RoleServiceTestSuite) SetupTest() {
 		suite.mockOUService,
 		suite.mockResourceService,
 		suite.transactioner,
+		newAllowAllRoleAuthz(suite.T()),
 	)
 }
 
@@ -1539,4 +1542,15 @@ permissions:
 	if role.OUID != "" {
 		t.Errorf("OUID = %q, want empty (resolution happens later)", role.OUID)
 	}
+}
+
+// newAllowAllRoleAuthz returns an authz mock that permits every grant check, so that
+// tests unrelated to the guard need not configure it.
+func newAllowAllRoleAuthz(t *testing.T) sysauthz.SystemAuthorizationServiceInterface {
+	mockAuthz := sysauthzmock.NewSystemAuthorizationServiceInterfaceMock(t)
+	mockAuthz.On("CanGrantPermissions", mock.Anything, mock.Anything).
+		Return((*tidcommon.ServiceError)(nil)).Maybe()
+	mockAuthz.On("CanGrantMembership", mock.Anything, mock.Anything, mock.Anything).
+		Return((*tidcommon.ServiceError)(nil)).Maybe()
+	return mockAuthz
 }

--- a/backend/internal/role/store.go
+++ b/backend/internal/role/store.go
@@ -43,6 +43,10 @@ type roleStoreInterface interface {
 	GetAuthorizedPermissionsByResourceServer(
 		ctx context.Context, entityID string, groupIDs []string, resourceServerID string,
 		requestedPermissions []string) ([]string, error)
+	// GetAllPermissionsForAssignees returns every permission the entity and/or groups hold through
+	// their assigned roles, grouped by resource server. It takes no filters: it enumerates.
+	GetAllPermissionsForAssignees(
+		ctx context.Context, entityID string, groupIDs []string) ([]ResourcePermissions, error)
 	GetUserRoles(ctx context.Context, entityID string, groupIDs []string) ([]string, error)
 	// GetEntityRoleIDs returns the set of role IDs assigned to the entity directly or via
 	// group membership. Unlike GetUserRoles this does not require the role to exist in the
@@ -585,6 +589,47 @@ func (s *roleStore) CheckRoleNameExistsExcludingID(
 
 // GetAuthorizedPermissionsByResourceServer retrieves the permissions that an entity is authorized for based on
 // their direct role assignments and group memberships, scoped to a resource server when provided.
+// GetAllPermissionsForAssignees returns every permission granted to the entity and/or groups by
+// their assigned database-backed roles, grouped by resource server.
+func (s *roleStore) GetAllPermissionsForAssignees(
+	ctx context.Context, entityID string, groupIDs []string,
+) ([]ResourcePermissions, error) {
+	if entityID == "" && len(groupIDs) == 0 {
+		return []ResourcePermissions{}, nil
+	}
+
+	dbClient, err := s.getConfigDBClient()
+	if err != nil {
+		return nil, err
+	}
+
+	if groupIDs == nil {
+		groupIDs = []string{}
+	}
+
+	query, args := buildAllPermissionsForAssigneesQuery(entityID, groupIDs, s.deploymentID)
+
+	results, err := dbClient.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get all permissions for assignees: %w", err)
+	}
+
+	byResourceServer := make(map[string][]string)
+	for _, row := range results {
+		resourceServerID, ok := row["resource_server_id"].(string)
+		if !ok {
+			return nil, fmt.Errorf("failed to parse resource_server_id as string")
+		}
+		permission, ok := row["permission"].(string)
+		if !ok {
+			return nil, fmt.Errorf("failed to parse permission as string")
+		}
+		byResourceServer[resourceServerID] = append(byResourceServer[resourceServerID], permission)
+	}
+
+	return resourcePermissionsFromMap(byResourceServer), nil
+}
+
 func (s *roleStore) GetAuthorizedPermissionsByResourceServer(
 	ctx context.Context,
 	entityID string,

--- a/backend/internal/role/store_constants.go
+++ b/backend/internal/role/store_constants.go
@@ -5,6 +5,7 @@ package role
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	dbmodel "github.com/thunder-id/thunderid/internal/system/database/model"
@@ -261,6 +262,85 @@ func buildAuthorizedPermissionsQuery(
 	return query, args
 }
 
+// buildAllPermissionsForAssigneesQuery retrieves every permission granted to an entity and/or
+// groups by their assigned roles, across all resource servers. Unlike
+// buildAuthorizedPermissionsQuery it applies no filters, since the permissions to ask about are
+// exactly what is being discovered.
+//
+// DEPLOYMENT_ID is $1 rather than the trailing parameter the db conventions call for. It occurs
+// three times, and SQLite gives the named form $1 the first free index and reuses it, so it must
+// come first for the following ? placeholders to line up with the argument order.
+// buildAuthorizedPermissionsQuery does the same.
+func buildAllPermissionsForAssigneesQuery(
+	entityID string,
+	groupIDs []string,
+	deploymentID string,
+) (dbmodel.DBQuery, []interface{}) {
+	const queryID = "RLQ-ROLE_MGT-26"
+
+	if entityID == "" && len(groupIDs) == 0 {
+		matchNothing := `SELECT RESOURCE_SERVER_ID, PERMISSION FROM "ROLE_PERMISSION" WHERE 1=0`
+		return dbmodel.DBQuery{
+			ID:            queryID,
+			Query:         matchNothing,
+			PostgresQuery: matchNothing,
+			SQLiteQuery:   matchNothing,
+		}, []interface{}{}
+	}
+
+	baseQuery := `SELECT DISTINCT rp.RESOURCE_SERVER_ID, rp.PERMISSION
+		FROM "ROLE_PERMISSION" rp
+		INNER JOIN "ROLE_ASSIGNMENT" ra ON rp.ROLE_ID = ra.ROLE_ID AND rp.DEPLOYMENT_ID = $1 AND ra.DEPLOYMENT_ID = $1
+		WHERE rp.DEPLOYMENT_ID = $1 AND `
+
+	var postgresWhere []string
+	var sqliteWhere []string
+
+	argsCapacity := 1 + len(groupIDs) // +1 for DEPLOYMENT_ID
+	if entityID != "" {
+		argsCapacity++
+	}
+	args := make([]interface{}, 0, argsCapacity)
+	args = append(args, deploymentID)
+	paramIndex := 2 // Start from $2 since $1 is DEPLOYMENT_ID.
+
+	if entityID != "" {
+		postgresWhere = append(postgresWhere,
+			fmt.Sprintf("(ra.ASSIGNEE_TYPE = 'entity' AND ra.ASSIGNEE_ID = $%d)", paramIndex))
+		sqliteWhere = append(sqliteWhere,
+			"(ra.ASSIGNEE_TYPE = 'entity' AND ra.ASSIGNEE_ID = ?)")
+		args = append(args, entityID)
+		paramIndex++
+	}
+
+	if len(groupIDs) > 0 {
+		groupPlaceholdersPostgres := make([]string, len(groupIDs))
+		groupPlaceholdersSqlite := make([]string, len(groupIDs))
+		for i, groupID := range groupIDs {
+			groupPlaceholdersPostgres[i] = fmt.Sprintf("$%d", paramIndex+i)
+			groupPlaceholdersSqlite[i] = "?"
+			args = append(args, groupID)
+		}
+		postgresWhere = append(postgresWhere,
+			fmt.Sprintf("(ra.ASSIGNEE_TYPE = 'group' AND ra.ASSIGNEE_ID IN (%s))",
+				strings.Join(groupPlaceholdersPostgres, ",")))
+		sqliteWhere = append(sqliteWhere,
+			fmt.Sprintf("(ra.ASSIGNEE_TYPE = 'group' AND ra.ASSIGNEE_ID IN (%s))",
+				strings.Join(groupPlaceholdersSqlite, ",")))
+	}
+
+	orderBy := " ORDER BY rp.RESOURCE_SERVER_ID, rp.PERMISSION"
+	postgresQuery := baseQuery + "(" + strings.Join(postgresWhere, " OR ") + ")" + orderBy
+	sqliteQuery := baseQuery + "(" + strings.Join(sqliteWhere, " OR ") + ")" + orderBy
+
+	return dbmodel.DBQuery{
+		ID:            queryID,
+		Query:         postgresQuery,
+		PostgresQuery: postgresQuery,
+		SQLiteQuery:   sqliteQuery,
+	}, args
+}
+
 // buildUserRolesQuery constructs a database-specific query to retrieve role names
 // assigned to an entity directly and/or through group membership.
 func buildUserRolesQuery(
@@ -398,4 +478,49 @@ func buildEntityRoleIDsQuery(
 	}
 
 	return query, args
+}
+
+// resourcePermissionsFromMap converts a resource-server-keyed map into []ResourcePermissions,
+// deduplicating and sorting so the order is stable.
+func resourcePermissionsFromMap(byResourceServer map[string][]string) []ResourcePermissions {
+	if len(byResourceServer) == 0 {
+		return []ResourcePermissions{}
+	}
+
+	resourceServerIDs := make([]string, 0, len(byResourceServer))
+	for resourceServerID := range byResourceServer {
+		resourceServerIDs = append(resourceServerIDs, resourceServerID)
+	}
+	sort.Strings(resourceServerIDs)
+
+	result := make([]ResourcePermissions, 0, len(resourceServerIDs))
+	for _, resourceServerID := range resourceServerIDs {
+		seen := make(map[string]bool, len(byResourceServer[resourceServerID]))
+		permissions := make([]string, 0, len(byResourceServer[resourceServerID]))
+		for _, permission := range byResourceServer[resourceServerID] {
+			if seen[permission] {
+				continue
+			}
+			seen[permission] = true
+			permissions = append(permissions, permission)
+		}
+		sort.Strings(permissions)
+		result = append(result, ResourcePermissions{
+			ResourceServerID: resourceServerID,
+			Permissions:      permissions,
+		})
+	}
+	return result
+}
+
+// mergeResourcePermissions unions permission sets from several sources.
+func mergeResourcePermissions(sources ...[]ResourcePermissions) []ResourcePermissions {
+	byResourceServer := make(map[string][]string)
+	for _, source := range sources {
+		for _, rp := range source {
+			byResourceServer[rp.ResourceServerID] = append(
+				byResourceServer[rp.ResourceServerID], rp.Permissions...)
+		}
+	}
+	return resourcePermissionsFromMap(byResourceServer)
 }

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -1023,6 +1023,8 @@ var defaultMessages = map[string]string{
 	"error.serverconfigservice.invalid_request_format_description": "The request body is malformed or contains invalid data",
 	"error.serverconfigservice.unsupported_config_name": "Unsupported configuration name",
 	"error.serverconfigservice.unsupported_config_name_description": "The requested server configuration name is not supported",
+	"error.sysauthz.grant_not_permitted": "Insufficient privileges to grant these permissions",
+	"error.sysauthz.grant_not_permitted_description": "The operation would grant permissions that the caller does not hold",
 	"error.templateservice.template_not_found": "Template not found",
 	"error.templateservice.template_not_found_description": "The requested template does not exist for the given scenario",
 	"error.themeservice.invalid_limit_value_description": "Limit must be between 1 and {{param(max)}}",

--- a/backend/internal/system/security/permissions.go
+++ b/backend/internal/system/security/permissions.go
@@ -352,6 +352,42 @@ func HasSufficientPermission(userPermissions []string, required string) bool {
 	return false
 }
 
+// ---- Permission set coverage ----
+
+// PermissionSet maps a resource server ID to the permissions granted on that resource server.
+type PermissionSet map[string][]string
+
+// Covers reports whether actor holds every permission in required, and answers "may this caller
+// confer these permissions on someone else?".
+//
+// Coverage is evaluated per resource server: a permission held on one never satisfies a
+// requirement on another. Within a resource server, matching is hierarchical, so "system:user"
+// covers "system:user:view" but not the reverse. Coverage is a partial order, not an ordering:
+// two sets can each hold what the other lacks.
+//
+// An empty required set is covered. A required permission that is empty, or keyed under an empty
+// resource server ID, is never covered, since approving a malformed grant would be unsafe.
+func Covers(actor, required PermissionSet) bool {
+	for resourceServerID, requiredPerms := range required {
+		if len(requiredPerms) == 0 {
+			continue
+		}
+		if resourceServerID == "" {
+			return false
+		}
+		heldPerms := actor[resourceServerID]
+		for _, requiredPerm := range requiredPerms {
+			if requiredPerm == "" {
+				return false
+			}
+			if !HasSufficientPermission(heldPerms, requiredPerm) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // ResolveActionPermission returns the minimum permission required to perform the given
 // action. Falls back to the root system permission for actions not listed in the action permission map.
 func ResolveActionPermission(action Action) string {

--- a/backend/internal/system/security/permissions_test.go
+++ b/backend/internal/system/security/permissions_test.go
@@ -444,3 +444,215 @@ func TestGetRequiredPermissionForAPI(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Covers
+// ---------------------------------------------------------------------------
+
+const (
+	rsSystem  = "01900000-0000-7000-8000-000000000020"
+	rsPayroll = "01900000-0000-7000-8000-0000000000aa"
+)
+
+func TestCovers(t *testing.T) {
+	InitSystemPermissions("")
+
+	tests := []struct {
+		name     string
+		actor    PermissionSet
+		required PermissionSet
+		want     bool
+	}{
+		// ---- Vacuous coverage ----
+		{
+			name:     "NilRequiredIsCovered",
+			actor:    nil,
+			required: nil,
+			want:     true,
+		},
+		{
+			name:     "EmptyRequiredIsCovered",
+			actor:    PermissionSet{},
+			required: PermissionSet{},
+			want:     true,
+		},
+		{
+			name:     "RequiredEntryWithNoPermissionsContributesNothing",
+			actor:    PermissionSet{},
+			required: PermissionSet{rsSystem: {}},
+			want:     true,
+		},
+		{
+			name:     "NilActorCannotCoverNonEmptyRequirement",
+			actor:    nil,
+			required: PermissionSet{rsSystem: {"system:user"}},
+			want:     false,
+		},
+
+		// ---- Exact and hierarchical matching within a resource server ----
+		{
+			name:     "ExactMatch",
+			actor:    PermissionSet{rsSystem: {"system:group"}},
+			required: PermissionSet{rsSystem: {"system:group"}},
+			want:     true,
+		},
+		{
+			name:     "ParentCoversChild",
+			actor:    PermissionSet{rsSystem: {"system:user"}},
+			required: PermissionSet{rsSystem: {"system:user:view"}},
+			want:     true,
+		},
+		{
+			name:     "ChildDoesNotCoverParent",
+			actor:    PermissionSet{rsSystem: {"system:user:view"}},
+			required: PermissionSet{rsSystem: {"system:user"}},
+			want:     false,
+		},
+		{
+			name:     "RootCoversEverythingBeneathIt",
+			actor:    PermissionSet{rsSystem: {"system"}},
+			required: PermissionSet{rsSystem: {"system:user", "system:group", "system:ou:view"}},
+			want:     true,
+		},
+		{
+			name:     "SiblingDoesNotCover",
+			actor:    PermissionSet{rsSystem: {"system:group"}},
+			required: PermissionSet{rsSystem: {"system:user"}},
+			want:     false,
+		},
+		{
+			name:     "PartialCoverageIsNotCoverage",
+			actor:    PermissionSet{rsSystem: {"system:group"}},
+			required: PermissionSet{rsSystem: {"system:group", "system:user"}},
+			want:     false,
+		},
+		{
+			name:     "StringPrefixIsNotScopePrefix",
+			actor:    PermissionSet{rsSystem: {"system:use"}},
+			required: PermissionSet{rsSystem: {"system:user"}},
+			want:     false,
+		},
+
+		// ---- Incomparable sets ----
+		{
+			name:     "AssistantCannotGrantLibrarian",
+			actor:    PermissionSet{rsSystem: {"system:group", "system:user:view"}},
+			required: PermissionSet{rsSystem: {"system:user", "system:group"}},
+			want:     false,
+		},
+		{
+			name:     "AssistantCanGrantWhatItAlreadyHolds",
+			actor:    PermissionSet{rsSystem: {"system:group", "system:user:view"}},
+			required: PermissionSet{rsSystem: {"system:group", "system:user:view"}},
+			want:     true,
+		},
+
+		// ---- Coverage never crosses resource servers ----
+		{
+			name:     "RootOnOneResourceServerDoesNotCoverAnother",
+			actor:    PermissionSet{rsSystem: {"system"}},
+			required: PermissionSet{rsPayroll: {"payroll:read"}},
+			want:     false,
+		},
+		{
+			name:     "IdenticalStringOnDifferentResourceServerDoesNotCover",
+			actor:    PermissionSet{rsSystem: {"system:user"}},
+			required: PermissionSet{rsPayroll: {"system:user"}},
+			want:     false,
+		},
+		{
+			name: "CoverageIsPerResourceServer",
+			actor: PermissionSet{
+				rsSystem:  {"system:group"},
+				rsPayroll: {"payroll"},
+			},
+			required: PermissionSet{
+				rsSystem:  {"system:group"},
+				rsPayroll: {"payroll:read"},
+			},
+			want: true,
+		},
+		{
+			name: "OneUncoveredResourceServerFailsTheWholeGrant",
+			actor: PermissionSet{
+				rsSystem:  {"system"},
+				rsPayroll: {"payroll:read"},
+			},
+			required: PermissionSet{
+				rsSystem:  {"system:user"},
+				rsPayroll: {"payroll:write"},
+			},
+			want: false,
+		},
+
+		// ---- Malformed requirements are never covered ----
+		{
+			name:     "EmptyRequiredPermissionStringIsNeverCovered",
+			actor:    PermissionSet{rsSystem: {"system"}},
+			required: PermissionSet{rsSystem: {""}},
+			want:     false,
+		},
+		{
+			name:     "EmptyPermissionAmongValidOnesFailsTheGrant",
+			actor:    PermissionSet{rsSystem: {"system"}},
+			required: PermissionSet{rsSystem: {"system:user", ""}},
+			want:     false,
+		},
+		{
+			name:     "EmptyResourceServerIDIsNeverCovered",
+			actor:    PermissionSet{"": {"system"}},
+			required: PermissionSet{"": {"system"}},
+			want:     false,
+		},
+
+		// ---- Extra actor permissions are harmless ----
+		{
+			name:     "ActorMayHoldMoreThanRequired",
+			actor:    PermissionSet{rsSystem: {"system:group", "system:user", "system:ou"}},
+			required: PermissionSet{rsSystem: {"system:group"}},
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, Covers(tt.actor, tt.required))
+		})
+	}
+}
+
+// TestCoversIsNotSymmetric documents that coverage is a partial order, not an equivalence:
+// incomparable sets cover each other in neither direction.
+func TestCoversIsNotSymmetric(t *testing.T) {
+	InitSystemPermissions("")
+
+	groupAdmin := PermissionSet{rsSystem: {"system:group"}}
+	userAdmin := PermissionSet{rsSystem: {"system:user"}}
+
+	assert.False(t, Covers(groupAdmin, userAdmin), "group admin must not cover user admin")
+	assert.False(t, Covers(userAdmin, groupAdmin), "user admin must not cover group admin")
+}
+
+// TestCoversHonoursConfiguredPermissionPrefix verifies that coverage is computed from the
+// permission strings themselves, so a non-empty SystemPermissionPrefix needs no special handling.
+func TestCoversHonoursConfiguredPermissionPrefix(t *testing.T) {
+	InitSystemPermissions("mgmt")
+	t.Cleanup(func() { InitSystemPermissions("") })
+
+	p := GetSystemPermissions()
+	require.Equal(t, "mgmt:system", p.Root)
+
+	assert.True(t, Covers(
+		PermissionSet{rsSystem: {p.Root}},
+		PermissionSet{rsSystem: {p.User, p.GroupView}},
+	))
+	assert.False(t, Covers(
+		PermissionSet{rsSystem: {p.UserView}},
+		PermissionSet{rsSystem: {p.User}},
+	))
+	// An unprefixed permission must not satisfy a prefixed requirement.
+	assert.False(t, Covers(
+		PermissionSet{rsSystem: {"system"}},
+		PermissionSet{rsSystem: {p.User}},
+	))
+}

--- a/backend/internal/system/sysauthz/error_constants.go
+++ b/backend/internal/system/sysauthz/error_constants.go
@@ -1,0 +1,27 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sysauthz
+
+import (
+	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
+)
+
+// Authorization errors for system-level authorization checks.
+var (
+	// ErrorGrantNotPermitted is returned when an operation would confer permissions that the caller
+	// does not itself hold. Distinct from tidcommon.ErrorUnauthorized so that clients can tell the
+	// two refusals apart; both map to 403.
+	ErrorGrantNotPermitted = tidcommon.ServiceError{
+		Type: tidcommon.ClientErrorType,
+		Code: "SAZ-4030",
+		Error: tidcommon.I18nMessage{
+			Key:          "error.sysauthz.grant_not_permitted",
+			DefaultValue: "Insufficient privileges to grant these permissions",
+		},
+		ErrorDescription: tidcommon.I18nMessage{
+			Key:          "error.sysauthz.grant_not_permitted_description",
+			DefaultValue: "The operation would grant permissions that the caller does not hold",
+		},
+	}
+)

--- a/backend/internal/system/sysauthz/grant.go
+++ b/backend/internal/system/sysauthz/grant.go
@@ -1,0 +1,193 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sysauthz
+
+import (
+	"context"
+
+	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
+
+	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/security"
+)
+
+// PrincipalType identifies the kind of container whose conferred permissions are examined.
+type PrincipalType string
+
+const (
+	// PrincipalTypeGroup identifies a group.
+	PrincipalTypeGroup PrincipalType = "group"
+	// PrincipalTypeRole identifies a role.
+	PrincipalTypeRole PrincipalType = "role"
+)
+
+// PermissionResolver enumerates the permissions a principal effectively holds, across every
+// resource server. Declared here because role imports group and group imports sysauthz, so
+// sysauthz can import neither; an implementation is injected by SetPermissionResolver at startup.
+//
+// Implementations must return a complete set. An incomplete result changes the outcome of the
+// checks below, so partial data is not an acceptable degradation.
+type PermissionResolver interface {
+	// ResolveForEntity returns the permissions an entity holds, directly and through its groups.
+	ResolveForEntity(ctx context.Context, entityID string) (security.PermissionSet, error)
+
+	// ResolveForGroup returns the permissions membership in a group confers, including those
+	// carried by its ancestor groups.
+	ResolveForGroup(ctx context.Context, groupID string) (security.PermissionSet, error)
+
+	// ResolveForRole returns the permissions a role confers on its assignees.
+	ResolveForRole(ctx context.Context, roleID string) (security.PermissionSet, error)
+}
+
+// SetPermissionResolver injects the resolver used by the grant checks. Call once at startup, after
+// the role and group packages are initialized. Until then the checks refuse.
+func (s *systemAuthorizationService) SetPermissionResolver(resolver PermissionResolver) {
+	if resolver == nil {
+		return
+	}
+	s.permissionResolver = resolver
+}
+
+// CanGrantPermissions enforces that the caller may only confer permissions it already holds. Use
+// it when the granted set is already known, such as a role's permission list; prefer
+// CanGrantMembership otherwise, since that resolves nesting for the caller.
+//
+// Any non-nil error is a refusal, including InternalServerError.
+func (s *systemAuthorizationService) CanGrantPermissions(
+	ctx context.Context, granted security.PermissionSet,
+) *tidcommon.ServiceError {
+	if decision, decided := s.shortCircuitGrant(ctx); decided {
+		return decision
+	}
+	return s.requireCoverage(ctx, granted)
+}
+
+// CanGrantMembership enforces that the caller may only add to, or remove from, a group or role
+// whose permissions it already holds. Both directions carry the same requirement.
+func (s *systemAuthorizationService) CanGrantMembership(
+	ctx context.Context, principalType PrincipalType, containerID string,
+) *tidcommon.ServiceError {
+	logger := s.logger.WithContext(ctx)
+
+	if decision, decided := s.shortCircuitGrant(ctx); decided {
+		return decision
+	}
+
+	if containerID == "" {
+		logger.Error(ctx, "Membership grant check called without a container ID",
+			log.String("principalType", string(principalType)))
+		return &tidcommon.InternalServerError
+	}
+
+	conferred, svcErr := s.resolveConferredPermissions(ctx, principalType, containerID)
+	if svcErr != nil {
+		return svcErr
+	}
+
+	return s.requireCoverage(ctx, conferred)
+}
+
+// shortCircuitGrant decides the cases that need no stored lookup. The boolean reports whether a
+// decision was reached.
+func (s *systemAuthorizationService) shortCircuitGrant(
+	ctx context.Context,
+) (*tidcommon.ServiceError, bool) {
+	logger := s.logger.WithContext(ctx)
+
+	// Internal runtime callers act without a subject, as bootstrap and the declarative loaders do.
+	if security.IsRuntimeContext(ctx) {
+		return nil, true
+	}
+
+	// Refuse rather than pass when startup wiring is incomplete.
+	if s.permissionResolver == nil {
+		logger.Error(ctx, "Grant check invoked before a permission resolver was injected")
+		return &tidcommon.InternalServerError, true
+	}
+
+	// The root permission already covers every system operation, so the comparison is redundant.
+	// Read from the token, as IsActionAllowed does.
+	if security.HasSystemPermission(security.GetPermissions(ctx)) {
+		return nil, true
+	}
+
+	return nil, false
+}
+
+// resolveConferredPermissions determines what membership in the given container confers.
+func (s *systemAuthorizationService) resolveConferredPermissions(
+	ctx context.Context, principalType PrincipalType, containerID string,
+) (security.PermissionSet, *tidcommon.ServiceError) {
+	logger := s.logger.WithContext(ctx)
+
+	var conferred security.PermissionSet
+	var err error
+
+	switch principalType {
+	case PrincipalTypeGroup:
+		conferred, err = s.permissionResolver.ResolveForGroup(ctx, containerID)
+	case PrincipalTypeRole:
+		conferred, err = s.permissionResolver.ResolveForRole(ctx, containerID)
+	default:
+		logger.Error(ctx, "Membership grant check called with an unknown principal type",
+			log.String("principalType", string(principalType)))
+		return nil, &tidcommon.InternalServerError
+	}
+
+	if err != nil {
+		// A failed lookup is not the same as an empty result, so it must not be treated as one.
+		logger.Error(ctx, "Failed to resolve permissions conferred by container",
+			log.String("principalType", string(principalType)),
+			log.String("containerID", containerID),
+			log.Error(err))
+		return nil, &tidcommon.InternalServerError
+	}
+
+	return conferred, nil
+}
+
+// requireCoverage refuses unless the caller's permissions cover every permission being granted.
+func (s *systemAuthorizationService) requireCoverage(
+	ctx context.Context, granted security.PermissionSet,
+) *tidcommon.ServiceError {
+	logger := s.logger.WithContext(ctx)
+
+	// Nothing is conferred, so the comparison is unnecessary. This is the common case.
+	if grantsNothing(granted) {
+		return nil
+	}
+
+	subject := security.GetSubject(ctx)
+	if subject == "" {
+		logger.Debug(ctx, "Grant refused: no authenticated subject")
+		return &ErrorGrantNotPermitted
+	}
+
+	// From storage, not the token: the token's claim is narrowed to one resource server and carries
+	// no resource server labels, so it cannot answer a cross-server coverage question.
+	actorPermissions, err := s.permissionResolver.ResolveForEntity(ctx, subject)
+	if err != nil {
+		logger.Error(ctx, "Failed to resolve caller permissions for grant check",
+			log.MaskedString("subject", subject), log.Error(err))
+		return &tidcommon.InternalServerError
+	}
+
+	if !security.Covers(actorPermissions, granted) {
+		logger.Debug(ctx, "Grant refused: exceeds caller permissions",
+			log.MaskedString("subject", subject))
+		return &ErrorGrantNotPermitted
+	}
+
+	return nil
+}
+
+// grantsNothing reports whether a permission set confers nothing.
+func grantsNothing(granted security.PermissionSet) bool {
+	for _, permissions := range granted {
+		if len(permissions) > 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/backend/internal/system/sysauthz/grant_test.go
+++ b/backend/internal/system/sysauthz/grant_test.go
@@ -1,0 +1,464 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sysauthz
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/security"
+	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
+)
+
+const (
+	escRSSystem  = "01900000-0000-7000-8000-000000000020"
+	escRSPayroll = "01900000-0000-7000-8000-0000000000aa"
+)
+
+// stubPermissionResolver is a configurable PermissionResolver for testing. It records how often
+// each method was called so tests can assert that short-circuits avoid unnecessary lookups.
+type stubPermissionResolver struct {
+	entityPerms security.PermissionSet
+	entityErr   error
+	entityCalls int
+
+	groupPerms security.PermissionSet
+	groupErr   error
+	groupCalls int
+
+	rolePerms security.PermissionSet
+	roleErr   error
+	roleCalls int
+}
+
+func (r *stubPermissionResolver) ResolveForEntity(
+	_ context.Context, _ string,
+) (security.PermissionSet, error) {
+	r.entityCalls++
+	return r.entityPerms, r.entityErr
+}
+
+func (r *stubPermissionResolver) ResolveForGroup(
+	_ context.Context, _ string,
+) (security.PermissionSet, error) {
+	r.groupCalls++
+	return r.groupPerms, r.groupErr
+}
+
+func (r *stubPermissionResolver) ResolveForRole(
+	_ context.Context, _ string,
+) (security.PermissionSet, error) {
+	r.roleCalls++
+	return r.rolePerms, r.roleErr
+}
+
+// newGuardService returns a service with the given resolver injected.
+func newGuardService(resolver PermissionResolver) *systemAuthorizationService {
+	svc := &systemAuthorizationService{
+		logger:   log.GetLogger().With(log.String("component", "SystemAuthorizationService")),
+		policies: &policies{membershipPolicy: &ouMembershipPolicy{}},
+	}
+	if resolver != nil {
+		svc.SetPermissionResolver(resolver)
+	}
+	return svc
+}
+
+// callerWith builds an authenticated context carrying the given token permissions.
+func callerWith(subject string, tokenPermissions ...string) context.Context {
+	authCtx := security.NewSecurityContextForTest(subject, "ou1", "token", tokenPermissions, nil)
+	return security.WithSecurityContextTest(context.Background(), authCtx)
+}
+
+// ---------------------------------------------------------------------------
+// Short-circuits
+// ---------------------------------------------------------------------------
+
+func TestCanGrantMembership_ShortCircuits(t *testing.T) {
+	// Bootstrap seeds the administrator group and role under a runtime context. Denying there
+	// would stop the server from starting.
+	t.Run("RuntimeContextIsAllowedWithoutAnyLookup", func(t *testing.T) {
+		resolver := &stubPermissionResolver{}
+		svc := newGuardService(resolver)
+
+		svcErr := svc.CanGrantMembership(security.WithRuntimeContext(context.Background()),
+			PrincipalTypeGroup, "grp1")
+
+		assert.Nil(t, svcErr)
+		assert.Zero(t, resolver.groupCalls, "runtime callers must not trigger a lookup")
+		assert.Zero(t, resolver.entityCalls)
+	})
+
+	// A wiring regression must not silently disable the guard.
+	t.Run("MissingResolverFailsClosed", func(t *testing.T) {
+		svc := newGuardService(nil)
+
+		svcErr := svc.CanGrantMembership(callerWith("user1", "system:group"), PrincipalTypeGroup, "grp1")
+
+		require.NotNil(t, svcErr)
+		assert.Equal(t, tidcommon.InternalServerError.Code, svcErr.Code)
+	})
+
+	t.Run("RootCallerIsAllowedWithoutAnyLookup", func(t *testing.T) {
+		resolver := &stubPermissionResolver{}
+		svc := newGuardService(resolver)
+
+		svcErr := svc.CanGrantMembership(callerWith("admin", "system"), PrincipalTypeGroup, "grp1")
+
+		assert.Nil(t, svcErr)
+		assert.Zero(t, resolver.groupCalls, "the root permission already covers everything, so no lookup is needed")
+		assert.Zero(t, resolver.entityCalls)
+	})
+
+	t.Run("EmptyContainerIDFailsClosed", func(t *testing.T) {
+		svc := newGuardService(&stubPermissionResolver{})
+
+		svcErr := svc.CanGrantMembership(callerWith("user1", "system:group"), PrincipalTypeGroup, "")
+
+		require.NotNil(t, svcErr)
+		assert.Equal(t, tidcommon.InternalServerError.Code, svcErr.Code)
+	})
+
+	t.Run("UnknownPrincipalTypeFailsClosed", func(t *testing.T) {
+		svc := newGuardService(&stubPermissionResolver{})
+
+		svcErr := svc.CanGrantMembership(callerWith("user1", "system:group"),
+			PrincipalType("application"), "app1")
+
+		require.NotNil(t, svcErr)
+		assert.Equal(t, tidcommon.InternalServerError.Code, svcErr.Code)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Coverage comparison
+// ---------------------------------------------------------------------------
+
+func TestCanGrantMembership_Coverage(t *testing.T) {
+	// The assistant librarian holds group write and user read. The librarian group confers user
+	// write, which the assistant does not hold, so adding anyone to it is refused.
+	t.Run("AssistantCannotAddAnyoneToLibrarianGroup", func(t *testing.T) {
+		resolver := &stubPermissionResolver{
+			groupPerms: security.PermissionSet{
+				escRSSystem: {"system:user", "system:group"},
+			},
+			entityPerms: security.PermissionSet{
+				escRSSystem: {"system:group", "system:user:view"},
+			},
+		}
+		svc := newGuardService(resolver)
+
+		svcErr := svc.CanGrantMembership(callerWith("david", "system:group"),
+			PrincipalTypeGroup, "librarianGroup")
+
+		require.NotNil(t, svcErr)
+		assert.Equal(t, ErrorGrantNotPermitted.Code, svcErr.Code)
+	})
+
+	// Self-assignment is the same comparison; the guard never branches on who benefits.
+	t.Run("AssistantCannotAddSelfEither", func(t *testing.T) {
+		resolver := &stubPermissionResolver{
+			groupPerms:  security.PermissionSet{escRSSystem: {"system:user"}},
+			entityPerms: security.PermissionSet{escRSSystem: {"system:group", "system:user:view"}},
+		}
+		svc := newGuardService(resolver)
+
+		svcErr := svc.CanGrantMembership(callerWith("david", "system:group"),
+			PrincipalTypeGroup, "librarianGroup")
+
+		require.NotNil(t, svcErr)
+		assert.Equal(t, ErrorGrantNotPermitted.Code, svcErr.Code)
+	})
+
+	t.Run("GrantOfExactlyWhatTheCallerHoldsIsAllowed", func(t *testing.T) {
+		resolver := &stubPermissionResolver{
+			groupPerms:  security.PermissionSet{escRSSystem: {"system:group"}},
+			entityPerms: security.PermissionSet{escRSSystem: {"system:group", "system:user:view"}},
+		}
+		svc := newGuardService(resolver)
+
+		svcErr := svc.CanGrantMembership(callerWith("david", "system:group"),
+			PrincipalTypeGroup, "readingGroup")
+
+		assert.Nil(t, svcErr)
+	})
+
+	t.Run("GrantOfAChildScopeOfWhatTheCallerHoldsIsAllowed", func(t *testing.T) {
+		resolver := &stubPermissionResolver{
+			groupPerms:  security.PermissionSet{escRSSystem: {"system:group:view"}},
+			entityPerms: security.PermissionSet{escRSSystem: {"system:group"}},
+		}
+		svc := newGuardService(resolver)
+
+		svcErr := svc.CanGrantMembership(callerWith("david", "system:group"),
+			PrincipalTypeGroup, "viewerGroup")
+
+		assert.Nil(t, svcErr)
+	})
+
+	// Most groups carry no roles. This is the hot path and must not resolve the caller at all.
+	t.Run("GroupConferringNothingIsAllowedWithoutResolvingTheCaller", func(t *testing.T) {
+		resolver := &stubPermissionResolver{groupPerms: security.PermissionSet{}}
+		svc := newGuardService(resolver)
+
+		svcErr := svc.CanGrantMembership(callerWith("david", "system:group"),
+			PrincipalTypeGroup, "plainGroup")
+
+		assert.Nil(t, svcErr)
+		assert.Equal(t, 1, resolver.groupCalls)
+		assert.Zero(t, resolver.entityCalls, "caller lookup is unnecessary when nothing is conferred")
+	})
+
+	t.Run("GroupWithEmptyPermissionListsCountsAsConferringNothing", func(t *testing.T) {
+		resolver := &stubPermissionResolver{
+			groupPerms: security.PermissionSet{escRSSystem: {}, escRSPayroll: {}},
+		}
+		svc := newGuardService(resolver)
+
+		svcErr := svc.CanGrantMembership(callerWith("david", "system:group"),
+			PrincipalTypeGroup, "plainGroup")
+
+		assert.Nil(t, svcErr)
+		assert.Zero(t, resolver.entityCalls)
+	})
+
+	// Coverage is per resource server. Root on the system resource server says nothing about a
+	// business resource server, so a non-root caller cannot use it to grant there.
+	t.Run("PermissionsDoNotCoverAcrossResourceServers", func(t *testing.T) {
+		resolver := &stubPermissionResolver{
+			groupPerms:  security.PermissionSet{escRSPayroll: {"payroll:read"}},
+			entityPerms: security.PermissionSet{escRSSystem: {"system:group", "system:user"}},
+		}
+		svc := newGuardService(resolver)
+
+		svcErr := svc.CanGrantMembership(callerWith("david", "system:group"),
+			PrincipalTypeGroup, "payrollGroup")
+
+		require.NotNil(t, svcErr)
+		assert.Equal(t, ErrorGrantNotPermitted.Code, svcErr.Code)
+	})
+
+	t.Run("CoverageAcrossMultipleResourceServersIsAllowedWhenAllAreHeld", func(t *testing.T) {
+		resolver := &stubPermissionResolver{
+			groupPerms: security.PermissionSet{
+				escRSSystem:  {"system:group"},
+				escRSPayroll: {"payroll:read"},
+			},
+			entityPerms: security.PermissionSet{
+				escRSSystem:  {"system:group"},
+				escRSPayroll: {"payroll"},
+			},
+		}
+		svc := newGuardService(resolver)
+
+		svcErr := svc.CanGrantMembership(callerWith("david", "system:group"),
+			PrincipalTypeGroup, "mixedGroup")
+
+		assert.Nil(t, svcErr)
+	})
+
+	t.Run("RolesUseTheSameComparison", func(t *testing.T) {
+		resolver := &stubPermissionResolver{
+			rolePerms:   security.PermissionSet{escRSSystem: {"system"}},
+			entityPerms: security.PermissionSet{escRSSystem: {"system:group"}},
+		}
+		svc := newGuardService(resolver)
+
+		svcErr := svc.CanGrantMembership(callerWith("david", "system:group"),
+			PrincipalTypeRole, "administratorRole")
+
+		require.NotNil(t, svcErr)
+		assert.Equal(t, ErrorGrantNotPermitted.Code, svcErr.Code)
+		assert.Equal(t, 1, resolver.roleCalls)
+		assert.Zero(t, resolver.groupCalls, "a role container must not be resolved as a group")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Failure handling
+// ---------------------------------------------------------------------------
+
+func TestCanGrantMembership_FailuresAreRefusals(t *testing.T) {
+	// A failed container lookup must never read as "confers nothing", which would permit exactly
+	// the grant this guard exists to refuse.
+	t.Run("ContainerLookupErrorIsRefused", func(t *testing.T) {
+		resolver := &stubPermissionResolver{groupErr: errors.New("database unavailable")}
+		svc := newGuardService(resolver)
+
+		svcErr := svc.CanGrantMembership(callerWith("david", "system:group"),
+			PrincipalTypeGroup, "grp1")
+
+		require.NotNil(t, svcErr)
+		assert.Equal(t, tidcommon.InternalServerError.Code, svcErr.Code)
+		assert.Zero(t, resolver.entityCalls)
+	})
+
+	t.Run("CallerLookupErrorIsRefused", func(t *testing.T) {
+		resolver := &stubPermissionResolver{
+			groupPerms: security.PermissionSet{escRSSystem: {"system:user"}},
+			entityErr:  errors.New("database unavailable"),
+		}
+		svc := newGuardService(resolver)
+
+		svcErr := svc.CanGrantMembership(callerWith("david", "system:group"),
+			PrincipalTypeGroup, "grp1")
+
+		require.NotNil(t, svcErr)
+		assert.Equal(t, tidcommon.InternalServerError.Code, svcErr.Code)
+	})
+
+	// A caller whose subject does not resolve to a local principal holds nothing we can verify.
+	t.Run("CallerWithNoResolvablePermissionsIsRefused", func(t *testing.T) {
+		resolver := &stubPermissionResolver{
+			groupPerms:  security.PermissionSet{escRSSystem: {"system:user"}},
+			entityPerms: security.PermissionSet{},
+		}
+		svc := newGuardService(resolver)
+
+		svcErr := svc.CanGrantMembership(callerWith("federated", "system:group"),
+			PrincipalTypeGroup, "grp1")
+
+		require.NotNil(t, svcErr)
+		assert.Equal(t, ErrorGrantNotPermitted.Code, svcErr.Code)
+	})
+
+	t.Run("UnauthenticatedCallerIsRefused", func(t *testing.T) {
+		resolver := &stubPermissionResolver{
+			groupPerms: security.PermissionSet{escRSSystem: {"system:user"}},
+		}
+		svc := newGuardService(resolver)
+
+		svcErr := svc.CanGrantMembership(context.Background(), PrincipalTypeGroup, "grp1")
+
+		require.NotNil(t, svcErr)
+		assert.Equal(t, ErrorGrantNotPermitted.Code, svcErr.Code)
+		assert.Zero(t, resolver.entityCalls)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CanGrantPermissions
+// ---------------------------------------------------------------------------
+
+func TestCanGrantPermissions(t *testing.T) {
+	t.Run("RuntimeContextIsAllowed", func(t *testing.T) {
+		svc := newGuardService(&stubPermissionResolver{})
+
+		svcErr := svc.CanGrantPermissions(security.WithRuntimeContext(context.Background()),
+			security.PermissionSet{escRSSystem: {"system"}})
+
+		assert.Nil(t, svcErr)
+	})
+
+	t.Run("MissingResolverFailsClosed", func(t *testing.T) {
+		svc := newGuardService(nil)
+
+		svcErr := svc.CanGrantPermissions(callerWith("user1", "system:group"),
+			security.PermissionSet{escRSSystem: {"system:group"}})
+
+		require.NotNil(t, svcErr)
+		assert.Equal(t, tidcommon.InternalServerError.Code, svcErr.Code)
+	})
+
+	t.Run("RootCallerMayGrantAnything", func(t *testing.T) {
+		resolver := &stubPermissionResolver{}
+		svc := newGuardService(resolver)
+
+		svcErr := svc.CanGrantPermissions(callerWith("admin", "system"),
+			security.PermissionSet{escRSPayroll: {"payroll:write"}})
+
+		assert.Nil(t, svcErr)
+		assert.Zero(t, resolver.entityCalls)
+	})
+
+	// Defining a role that grants more than the caller holds is refused on the same basis as
+	// adding someone to a group that confers it.
+	t.Run("CallerCannotDefineARoleExceedingItsOwnPermissions", func(t *testing.T) {
+		resolver := &stubPermissionResolver{
+			entityPerms: security.PermissionSet{escRSSystem: {"system:group"}},
+		}
+		svc := newGuardService(resolver)
+
+		svcErr := svc.CanGrantPermissions(callerWith("david", "system:group"),
+			security.PermissionSet{escRSSystem: {"system:user"}})
+
+		require.NotNil(t, svcErr)
+		assert.Equal(t, ErrorGrantNotPermitted.Code, svcErr.Code)
+	})
+
+	t.Run("EmptyGrantIsAllowedWithoutResolvingTheCaller", func(t *testing.T) {
+		resolver := &stubPermissionResolver{}
+		svc := newGuardService(resolver)
+
+		svcErr := svc.CanGrantPermissions(callerWith("david", "system:group"), security.PermissionSet{})
+
+		assert.Nil(t, svcErr)
+		assert.Zero(t, resolver.entityCalls)
+	})
+
+	// Covers refuses a malformed grant, and the guard must surface that as a refusal rather than
+	// letting it through.
+	t.Run("MalformedGrantIsRefused", func(t *testing.T) {
+		resolver := &stubPermissionResolver{
+			entityPerms: security.PermissionSet{escRSSystem: {"system"}},
+		}
+		svc := newGuardService(resolver)
+
+		svcErr := svc.CanGrantPermissions(callerWith("david", "system:group"),
+			security.PermissionSet{escRSSystem: {""}})
+
+		require.NotNil(t, svcErr)
+		assert.Equal(t, ErrorGrantNotPermitted.Code, svcErr.Code)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// SetPermissionResolver
+// ---------------------------------------------------------------------------
+
+func TestSetPermissionResolver(t *testing.T) {
+	t.Run("NilResolverDoesNotClearAnInjectedOne", func(t *testing.T) {
+		resolver := &stubPermissionResolver{groupPerms: security.PermissionSet{}}
+		svc := newGuardService(resolver)
+
+		svc.SetPermissionResolver(nil)
+
+		svcErr := svc.CanGrantMembership(callerWith("david", "system:group"), PrincipalTypeGroup, "grp1")
+		assert.Nil(t, svcErr)
+		assert.Equal(t, 1, resolver.groupCalls, "the previously injected resolver must still be used")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// grantsNothing
+// ---------------------------------------------------------------------------
+
+func TestGrantsNothing(t *testing.T) {
+	tests := []struct {
+		name    string
+		granted security.PermissionSet
+		want    bool
+	}{
+		{name: "Nil", granted: nil, want: true},
+		{name: "Empty", granted: security.PermissionSet{}, want: true},
+		{name: "AllEmptyLists", granted: security.PermissionSet{escRSSystem: {}}, want: true},
+		{name: "OnePermission", granted: security.PermissionSet{escRSSystem: {"system"}}, want: false},
+		{
+			name:    "OneNonEmptyAmongEmpties",
+			granted: security.PermissionSet{escRSSystem: {}, escRSPayroll: {"payroll:read"}},
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, grantsNothing(tt.granted))
+		})
+	}
+}

--- a/backend/internal/system/sysauthz/service.go
+++ b/backend/internal/system/sysauthz/service.go
@@ -36,12 +36,35 @@ type SystemAuthorizationServiceInterface interface {
 	// been initialized, completing the two-phase initialization that avoids an import cycle
 	// between sysauthz (which ou already imports) and the ou package itself.
 	SetOUHierarchyResolver(resolver OUHierarchyResolver)
+
+	// CanGrantPermissions refuses an operation that would confer permissions the caller does not
+	// itself hold. Use it where the granted permissions are already known, such as when defining a
+	// role's permission list.
+	//
+	// A nil return permits the operation. Any non-nil ServiceError is a refusal, including
+	// InternalServerError: an incomplete check is not a pass.
+	CanGrantPermissions(ctx context.Context, granted security.PermissionSet) *tidcommon.ServiceError
+
+	// CanGrantMembership refuses adding or removing a member of a group or role whose permissions
+	// the caller does not itself hold. It resolves what the container confers, including through
+	// group nesting.
+	CanGrantMembership(ctx context.Context, principalType PrincipalType,
+		containerID string) *tidcommon.ServiceError
+
+	// SetPermissionResolver injects the effective-permission resolver used by the two checks above.
+	// It must be called once at startup after the role and group packages are initialized,
+	// completing the same two-phase initialization used by SetOUHierarchyResolver. Until it is
+	// called, both checks refuse.
+	SetPermissionResolver(resolver PermissionResolver)
 }
 
 // systemAuthorizationService is the default implementation of SystemAuthorizationServiceInterface.
 type systemAuthorizationService struct {
 	logger   *log.Logger
 	policies *policies
+	// permissionResolver enumerates effective permissions for the grant checks. nil until
+	// SetPermissionResolver is called at startup, in which case those checks refuse.
+	permissionResolver PermissionResolver
 }
 
 type policies struct {

--- a/backend/tests/mocks/groupmock/GroupServiceInterface_mock.go
+++ b/backend/tests/mocks/groupmock/GroupServiceInterface_mock.go
@@ -936,6 +936,76 @@ func (_c *GroupServiceInterfaceMock_GetResourceDependencies_Call) RunAndReturn(r
 	return _c
 }
 
+// GetTransitiveAncestorGroups provides a mock function for the type GroupServiceInterfaceMock
+func (_mock *GroupServiceInterfaceMock) GetTransitiveAncestorGroups(ctx context.Context, groupID string) ([]string, *common.ServiceError) {
+	ret := _mock.Called(ctx, groupID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTransitiveAncestorGroups")
+	}
+
+	var r0 []string
+	var r1 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]string, *common.ServiceError)); ok {
+		return returnFunc(ctx, groupID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []string); ok {
+		r0 = returnFunc(ctx, groupID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) *common.ServiceError); ok {
+		r1 = returnFunc(ctx, groupID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// GroupServiceInterfaceMock_GetTransitiveAncestorGroups_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTransitiveAncestorGroups'
+type GroupServiceInterfaceMock_GetTransitiveAncestorGroups_Call struct {
+	*mock.Call
+}
+
+// GetTransitiveAncestorGroups is a helper method to define mock.On call
+//   - ctx context.Context
+//   - groupID string
+func (_e *GroupServiceInterfaceMock_Expecter) GetTransitiveAncestorGroups(ctx interface{}, groupID interface{}) *GroupServiceInterfaceMock_GetTransitiveAncestorGroups_Call {
+	return &GroupServiceInterfaceMock_GetTransitiveAncestorGroups_Call{Call: _e.mock.On("GetTransitiveAncestorGroups", ctx, groupID)}
+}
+
+func (_c *GroupServiceInterfaceMock_GetTransitiveAncestorGroups_Call) Run(run func(ctx context.Context, groupID string)) *GroupServiceInterfaceMock_GetTransitiveAncestorGroups_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_GetTransitiveAncestorGroups_Call) Return(strings []string, serviceError *common.ServiceError) *GroupServiceInterfaceMock_GetTransitiveAncestorGroups_Call {
+	_c.Call.Return(strings, serviceError)
+	return _c
+}
+
+func (_c *GroupServiceInterfaceMock_GetTransitiveAncestorGroups_Call) RunAndReturn(run func(ctx context.Context, groupID string) ([]string, *common.ServiceError)) *GroupServiceInterfaceMock_GetTransitiveAncestorGroups_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RemoveGroupMembers provides a mock function for the type GroupServiceInterfaceMock
 func (_mock *GroupServiceInterfaceMock) RemoveGroupMembers(ctx context.Context, groupID string, members []group.Member) (*group.Group, *common.ServiceError) {
 	ret := _mock.Called(ctx, groupID, members)

--- a/backend/tests/mocks/groupmock/groupStoreInterface_mock.go
+++ b/backend/tests/mocks/groupmock/groupStoreInterface_mock.go
@@ -420,6 +420,74 @@ func (_c *groupStoreInterfaceMock_DeleteMembershipsByMember_Call) RunAndReturn(r
 	return _c
 }
 
+// GetDirectGroupParents provides a mock function for the type groupStoreInterfaceMock
+func (_mock *groupStoreInterfaceMock) GetDirectGroupParents(ctx context.Context, groupIDs []string) ([]string, error) {
+	ret := _mock.Called(ctx, groupIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetDirectGroupParents")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) ([]string, error)); ok {
+		return returnFunc(ctx, groupIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) []string); ok {
+		r0 = returnFunc(ctx, groupIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = returnFunc(ctx, groupIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// groupStoreInterfaceMock_GetDirectGroupParents_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDirectGroupParents'
+type groupStoreInterfaceMock_GetDirectGroupParents_Call struct {
+	*mock.Call
+}
+
+// GetDirectGroupParents is a helper method to define mock.On call
+//   - ctx context.Context
+//   - groupIDs []string
+func (_e *groupStoreInterfaceMock_Expecter) GetDirectGroupParents(ctx interface{}, groupIDs interface{}) *groupStoreInterfaceMock_GetDirectGroupParents_Call {
+	return &groupStoreInterfaceMock_GetDirectGroupParents_Call{Call: _e.mock.On("GetDirectGroupParents", ctx, groupIDs)}
+}
+
+func (_c *groupStoreInterfaceMock_GetDirectGroupParents_Call) Run(run func(ctx context.Context, groupIDs []string)) *groupStoreInterfaceMock_GetDirectGroupParents_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_GetDirectGroupParents_Call) Return(strings []string, err error) *groupStoreInterfaceMock_GetDirectGroupParents_Call {
+	_c.Call.Return(strings, err)
+	return _c
+}
+
+func (_c *groupStoreInterfaceMock_GetDirectGroupParents_Call) RunAndReturn(run func(ctx context.Context, groupIDs []string) ([]string, error)) *groupStoreInterfaceMock_GetDirectGroupParents_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetGroup provides a mock function for the type groupStoreInterfaceMock
 func (_mock *groupStoreInterfaceMock) GetGroup(ctx context.Context, id string) (group.GroupDAO, error) {
 	ret := _mock.Called(ctx, id)

--- a/backend/tests/mocks/rolemock/RoleServiceInterface_mock.go
+++ b/backend/tests/mocks/rolemock/RoleServiceInterface_mock.go
@@ -9,6 +9,7 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 	"github.com/thunder-id/thunderid/internal/role"
+	"github.com/thunder-id/thunderid/internal/system/security"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 )
 
@@ -164,6 +165,82 @@ func (_c *RoleServiceInterfaceMock_DeleteRole_Call) Return(serviceError *common.
 }
 
 func (_c *RoleServiceInterfaceMock_DeleteRole_Call) RunAndReturn(run func(ctx context.Context, id string) *common.ServiceError) *RoleServiceInterfaceMock_DeleteRole_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetAllPermissions provides a mock function for the type RoleServiceInterfaceMock
+func (_mock *RoleServiceInterfaceMock) GetAllPermissions(ctx context.Context, entityID string, groupIDs []string) (security.PermissionSet, *common.ServiceError) {
+	ret := _mock.Called(ctx, entityID, groupIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllPermissions")
+	}
+
+	var r0 security.PermissionSet
+	var r1 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string) (security.PermissionSet, *common.ServiceError)); ok {
+		return returnFunc(ctx, entityID, groupIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string) security.PermissionSet); ok {
+		r0 = returnFunc(ctx, entityID, groupIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(security.PermissionSet)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, []string) *common.ServiceError); ok {
+		r1 = returnFunc(ctx, entityID, groupIDs)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// RoleServiceInterfaceMock_GetAllPermissions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllPermissions'
+type RoleServiceInterfaceMock_GetAllPermissions_Call struct {
+	*mock.Call
+}
+
+// GetAllPermissions is a helper method to define mock.On call
+//   - ctx context.Context
+//   - entityID string
+//   - groupIDs []string
+func (_e *RoleServiceInterfaceMock_Expecter) GetAllPermissions(ctx interface{}, entityID interface{}, groupIDs interface{}) *RoleServiceInterfaceMock_GetAllPermissions_Call {
+	return &RoleServiceInterfaceMock_GetAllPermissions_Call{Call: _e.mock.On("GetAllPermissions", ctx, entityID, groupIDs)}
+}
+
+func (_c *RoleServiceInterfaceMock_GetAllPermissions_Call) Run(run func(ctx context.Context, entityID string, groupIDs []string)) *RoleServiceInterfaceMock_GetAllPermissions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 []string
+		if args[2] != nil {
+			arg2 = args[2].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *RoleServiceInterfaceMock_GetAllPermissions_Call) Return(permissionSet security.PermissionSet, serviceError *common.ServiceError) *RoleServiceInterfaceMock_GetAllPermissions_Call {
+	_c.Call.Return(permissionSet, serviceError)
+	return _c
+}
+
+func (_c *RoleServiceInterfaceMock_GetAllPermissions_Call) RunAndReturn(run func(ctx context.Context, entityID string, groupIDs []string) (security.PermissionSet, *common.ServiceError)) *RoleServiceInterfaceMock_GetAllPermissions_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/rolemock/roleStoreInterface_mock.go
+++ b/backend/tests/mocks/rolemock/roleStoreInterface_mock.go
@@ -500,6 +500,80 @@ func (_c *roleStoreInterfaceMock_DeleteRole_Call) RunAndReturn(run func(ctx cont
 	return _c
 }
 
+// GetAllPermissionsForAssignees provides a mock function for the type roleStoreInterfaceMock
+func (_mock *roleStoreInterfaceMock) GetAllPermissionsForAssignees(ctx context.Context, entityID string, groupIDs []string) ([]role.ResourcePermissions, error) {
+	ret := _mock.Called(ctx, entityID, groupIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllPermissionsForAssignees")
+	}
+
+	var r0 []role.ResourcePermissions
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string) ([]role.ResourcePermissions, error)); ok {
+		return returnFunc(ctx, entityID, groupIDs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string) []role.ResourcePermissions); ok {
+		r0 = returnFunc(ctx, entityID, groupIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]role.ResourcePermissions)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, []string) error); ok {
+		r1 = returnFunc(ctx, entityID, groupIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// roleStoreInterfaceMock_GetAllPermissionsForAssignees_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllPermissionsForAssignees'
+type roleStoreInterfaceMock_GetAllPermissionsForAssignees_Call struct {
+	*mock.Call
+}
+
+// GetAllPermissionsForAssignees is a helper method to define mock.On call
+//   - ctx context.Context
+//   - entityID string
+//   - groupIDs []string
+func (_e *roleStoreInterfaceMock_Expecter) GetAllPermissionsForAssignees(ctx interface{}, entityID interface{}, groupIDs interface{}) *roleStoreInterfaceMock_GetAllPermissionsForAssignees_Call {
+	return &roleStoreInterfaceMock_GetAllPermissionsForAssignees_Call{Call: _e.mock.On("GetAllPermissionsForAssignees", ctx, entityID, groupIDs)}
+}
+
+func (_c *roleStoreInterfaceMock_GetAllPermissionsForAssignees_Call) Run(run func(ctx context.Context, entityID string, groupIDs []string)) *roleStoreInterfaceMock_GetAllPermissionsForAssignees_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 []string
+		if args[2] != nil {
+			arg2 = args[2].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_GetAllPermissionsForAssignees_Call) Return(resourcePermissionss []role.ResourcePermissions, err error) *roleStoreInterfaceMock_GetAllPermissionsForAssignees_Call {
+	_c.Call.Return(resourcePermissionss, err)
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_GetAllPermissionsForAssignees_Call) RunAndReturn(run func(ctx context.Context, entityID string, groupIDs []string) ([]role.ResourcePermissions, error)) *roleStoreInterfaceMock_GetAllPermissionsForAssignees_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAuthorizedPermissionsByResourceServer provides a mock function for the type roleStoreInterfaceMock
 func (_mock *roleStoreInterfaceMock) GetAuthorizedPermissionsByResourceServer(ctx context.Context, entityID string, groupIDs []string, resourceServerID string, requestedPermissions []string) ([]string, error) {
 	ret := _mock.Called(ctx, entityID, groupIDs, resourceServerID, requestedPermissions)

--- a/backend/tests/mocks/sysauthzmock/SystemAuthorizationServiceInterface_mock.go
+++ b/backend/tests/mocks/sysauthzmock/SystemAuthorizationServiceInterface_mock.go
@@ -40,6 +40,130 @@ func (_m *SystemAuthorizationServiceInterfaceMock) EXPECT() *SystemAuthorization
 	return &SystemAuthorizationServiceInterfaceMock_Expecter{mock: &_m.Mock}
 }
 
+// CanGrantMembership provides a mock function for the type SystemAuthorizationServiceInterfaceMock
+func (_mock *SystemAuthorizationServiceInterfaceMock) CanGrantMembership(ctx context.Context, principalType sysauthz.PrincipalType, containerID string) *common.ServiceError {
+	ret := _mock.Called(ctx, principalType, containerID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CanGrantMembership")
+	}
+
+	var r0 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, sysauthz.PrincipalType, string) *common.ServiceError); ok {
+		r0 = returnFunc(ctx, principalType, containerID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*common.ServiceError)
+		}
+	}
+	return r0
+}
+
+// SystemAuthorizationServiceInterfaceMock_CanGrantMembership_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CanGrantMembership'
+type SystemAuthorizationServiceInterfaceMock_CanGrantMembership_Call struct {
+	*mock.Call
+}
+
+// CanGrantMembership is a helper method to define mock.On call
+//   - ctx context.Context
+//   - principalType sysauthz.PrincipalType
+//   - containerID string
+func (_e *SystemAuthorizationServiceInterfaceMock_Expecter) CanGrantMembership(ctx interface{}, principalType interface{}, containerID interface{}) *SystemAuthorizationServiceInterfaceMock_CanGrantMembership_Call {
+	return &SystemAuthorizationServiceInterfaceMock_CanGrantMembership_Call{Call: _e.mock.On("CanGrantMembership", ctx, principalType, containerID)}
+}
+
+func (_c *SystemAuthorizationServiceInterfaceMock_CanGrantMembership_Call) Run(run func(ctx context.Context, principalType sysauthz.PrincipalType, containerID string)) *SystemAuthorizationServiceInterfaceMock_CanGrantMembership_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 sysauthz.PrincipalType
+		if args[1] != nil {
+			arg1 = args[1].(sysauthz.PrincipalType)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *SystemAuthorizationServiceInterfaceMock_CanGrantMembership_Call) Return(serviceError *common.ServiceError) *SystemAuthorizationServiceInterfaceMock_CanGrantMembership_Call {
+	_c.Call.Return(serviceError)
+	return _c
+}
+
+func (_c *SystemAuthorizationServiceInterfaceMock_CanGrantMembership_Call) RunAndReturn(run func(ctx context.Context, principalType sysauthz.PrincipalType, containerID string) *common.ServiceError) *SystemAuthorizationServiceInterfaceMock_CanGrantMembership_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CanGrantPermissions provides a mock function for the type SystemAuthorizationServiceInterfaceMock
+func (_mock *SystemAuthorizationServiceInterfaceMock) CanGrantPermissions(ctx context.Context, granted security.PermissionSet) *common.ServiceError {
+	ret := _mock.Called(ctx, granted)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CanGrantPermissions")
+	}
+
+	var r0 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, security.PermissionSet) *common.ServiceError); ok {
+		r0 = returnFunc(ctx, granted)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*common.ServiceError)
+		}
+	}
+	return r0
+}
+
+// SystemAuthorizationServiceInterfaceMock_CanGrantPermissions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CanGrantPermissions'
+type SystemAuthorizationServiceInterfaceMock_CanGrantPermissions_Call struct {
+	*mock.Call
+}
+
+// CanGrantPermissions is a helper method to define mock.On call
+//   - ctx context.Context
+//   - granted security.PermissionSet
+func (_e *SystemAuthorizationServiceInterfaceMock_Expecter) CanGrantPermissions(ctx interface{}, granted interface{}) *SystemAuthorizationServiceInterfaceMock_CanGrantPermissions_Call {
+	return &SystemAuthorizationServiceInterfaceMock_CanGrantPermissions_Call{Call: _e.mock.On("CanGrantPermissions", ctx, granted)}
+}
+
+func (_c *SystemAuthorizationServiceInterfaceMock_CanGrantPermissions_Call) Run(run func(ctx context.Context, granted security.PermissionSet)) *SystemAuthorizationServiceInterfaceMock_CanGrantPermissions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 security.PermissionSet
+		if args[1] != nil {
+			arg1 = args[1].(security.PermissionSet)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *SystemAuthorizationServiceInterfaceMock_CanGrantPermissions_Call) Return(serviceError *common.ServiceError) *SystemAuthorizationServiceInterfaceMock_CanGrantPermissions_Call {
+	_c.Call.Return(serviceError)
+	return _c
+}
+
+func (_c *SystemAuthorizationServiceInterfaceMock_CanGrantPermissions_Call) RunAndReturn(run func(ctx context.Context, granted security.PermissionSet) *common.ServiceError) *SystemAuthorizationServiceInterfaceMock_CanGrantPermissions_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAccessibleResources provides a mock function for the type SystemAuthorizationServiceInterfaceMock
 func (_mock *SystemAuthorizationServiceInterfaceMock) GetAccessibleResources(ctx context.Context, action security.Action, resourceType security.ResourceType) (*sysauthz.AccessibleResources, *common.ServiceError) {
 	ret := _mock.Called(ctx, action, resourceType)
@@ -226,6 +350,46 @@ func (_c *SystemAuthorizationServiceInterfaceMock_SetOUHierarchyResolver_Call) R
 }
 
 func (_c *SystemAuthorizationServiceInterfaceMock_SetOUHierarchyResolver_Call) RunAndReturn(run func(resolver sysauthz.OUHierarchyResolver)) *SystemAuthorizationServiceInterfaceMock_SetOUHierarchyResolver_Call {
+	_c.Run(run)
+	return _c
+}
+
+// SetPermissionResolver provides a mock function for the type SystemAuthorizationServiceInterfaceMock
+func (_mock *SystemAuthorizationServiceInterfaceMock) SetPermissionResolver(resolver sysauthz.PermissionResolver) {
+	_mock.Called(resolver)
+	return
+}
+
+// SystemAuthorizationServiceInterfaceMock_SetPermissionResolver_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetPermissionResolver'
+type SystemAuthorizationServiceInterfaceMock_SetPermissionResolver_Call struct {
+	*mock.Call
+}
+
+// SetPermissionResolver is a helper method to define mock.On call
+//   - resolver sysauthz.PermissionResolver
+func (_e *SystemAuthorizationServiceInterfaceMock_Expecter) SetPermissionResolver(resolver interface{}) *SystemAuthorizationServiceInterfaceMock_SetPermissionResolver_Call {
+	return &SystemAuthorizationServiceInterfaceMock_SetPermissionResolver_Call{Call: _e.mock.On("SetPermissionResolver", resolver)}
+}
+
+func (_c *SystemAuthorizationServiceInterfaceMock_SetPermissionResolver_Call) Run(run func(resolver sysauthz.PermissionResolver)) *SystemAuthorizationServiceInterfaceMock_SetPermissionResolver_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 sysauthz.PermissionResolver
+		if args[0] != nil {
+			arg0 = args[0].(sysauthz.PermissionResolver)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *SystemAuthorizationServiceInterfaceMock_SetPermissionResolver_Call) Return() *SystemAuthorizationServiceInterfaceMock_SetPermissionResolver_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *SystemAuthorizationServiceInterfaceMock_SetPermissionResolver_Call) RunAndReturn(run func(resolver sysauthz.PermissionResolver)) *SystemAuthorizationServiceInterfaceMock_SetPermissionResolver_Call {
 	_c.Run(run)
 	return _c
 }

--- a/docs/content/guides/users/manage-groups.mdx
+++ b/docs/content/guides/users/manage-groups.mdx
@@ -67,6 +67,16 @@ A group nesting chain must stay within a single source. Mixing declarative (YAML
 2. Locate the member you want to remove.
 3. Click **Remove** next to the member and confirm.
 
+### Permission Requirements for Membership Changes
+
+Adding a member to a group grants that member every permission the group confers, so <ProductName /> requires you to already hold those permissions yourself. The same requirement applies when you remove a member, which prevents an administrator from stripping members out of a group more privileged than their own.
+
+The check covers permissions the group inherits. A group carries the roles assigned to it and the roles assigned to every group that contains it, so joining a group that grants nothing on its own still confers whatever its parent groups grant.
+
+Both requirements apply regardless of who the member is, including your own account, and regardless of the member type. Adding a group as a member is covered too, since that makes the inner group's members part of the outer group.
+
+If the change would grant more than you hold, the API returns `403 Forbidden` with the error code `SAZ-4030`, and no member is added or removed. For the full rule, including how permissions are compared, see [Permission Requirements](../manage-roles#permission-requirements).
+
 ## Assign Roles to a Group
 
 Roles assigned to a group apply to all members of that group. This is the recommended way to grant permissions to a set of users instead of assigning roles individually.

--- a/docs/content/guides/users/manage-roles.mdx
+++ b/docs/content/guides/users/manage-roles.mdx
@@ -23,6 +23,30 @@ Before creating a role, you need:
 - An organization unit to scope the role. See [Organization Units](../../organization-units).
 - At least one resource server with defined permissions. See [Resource Servers](../../resource-servers).
 
+## Permission Requirements
+
+<ProductName /> prevents you from granting permissions you do not hold yourself. This applies whether the recipient is another principal or your own account.
+
+You can perform the following operations only if you already hold every permission involved:
+
+| Operation | Requirement |
+|-----------|-------------|
+| Create a role with permissions | You hold every permission in the new role. |
+| Update a role's permissions | You hold every permission in the updated set. |
+| Add or remove a role assignment | You hold every permission the role grants. |
+
+Permissions are compared per resource server. A permission you hold on one resource server does not satisfy a requirement on a different resource server, even when the two permission strings are identical.
+
+The comparison respects the permission hierarchy. If you hold `system:user`, you can grant `system:user:view`, because the parent permission covers its children. The reverse does not apply: holding `system:user:view` does not let you grant `system:user`.
+
+Holders of the root `system` permission are exempt, since that permission already authorizes every system operation.
+
+If an operation would grant more than you hold, the API returns `403 Forbidden` with the error code `SAZ-4030`, and no change is made.
+
+:::note
+Because you must hold a permission to grant it, an administrator whose job is to manage role assignments needs to hold the permissions they distribute. Grant such an administrator the union of the permissions they are expected to assign.
+:::
+
 ## Create a Role
 
 1. Navigate to **Roles** in the <ProductName /> Console and click **Create Role**.

--- a/tests/integration/group/group_authz_test.go
+++ b/tests/integration/group/group_authz_test.go
@@ -53,6 +53,12 @@ type GroupAuthzTestSuite struct {
 	deletableGroupOU1ID string
 	targetGroupOU2ID    string
 
+	// Privileged fixture: a group conferring system:user, which the group-manager does not hold,
+	// plus a harmless group nested inside it to exercise the ancestor walk.
+	librarianGroupID  string
+	librarianRoleID   string
+	nestedInLibraryID string
+
 	// Member users created in each OU to test membership authz
 	memberUserOU1ID   string
 	memberUserOU2ID   string
@@ -203,7 +209,7 @@ func (ts *GroupAuthzTestSuite) SetupSuite() {
 	// when configured.
 	const scopedRSIdentifier = "https://authz-test.example.com/group"
 	systemRSID, err := testutils.CreateSystemScopedResourceServer(
-		ts.groupOU1ID, "Authz Test RS (group)", scopedRSIdentifier, "ou", "group")
+		ts.groupOU1ID, "Authz Test RS (group)", scopedRSIdentifier, "ou", "group", "user")
 	ts.Require().NoError(err, "create scoped resource server")
 	ts.scopedRSID = systemRSID
 
@@ -239,6 +245,45 @@ func (ts *GroupAuthzTestSuite) SetupSuite() {
 	ts.Require().NotEmpty(tokenResp.AccessToken, "group-manager token must be non-empty")
 
 	ts.groupAdminClient = testutils.GetHTTPClientWithToken(tokenResp.AccessToken)
+
+	// ---- 8. Create a privileged group the group-manager must not be able to join ----
+	// A group carrying no roles of its own, which will be nested inside the privileged group.
+	// Joining it confers the privileged permissions transitively, so the guard must walk ancestors.
+	nestedID, err := testutils.CreateGroup(testutils.Group{
+		Name:        "authz-nested-in-library-ou1",
+		Description: "Harmless group nested inside the librarian group",
+		OUID:        ts.groupOU1ID,
+	})
+	ts.Require().NoError(err, "create nested group")
+	ts.nestedInLibraryID = nestedID
+
+	// The privileged group, created with the harmless group already nested inside it.
+	librarianID, err := testutils.CreateGroup(testutils.Group{
+		Name:        "authz-librarian-ou1",
+		Description: "Group conferring system:user",
+		OUID:        ts.groupOU1ID,
+		Members:     []testutils.Member{{Id: nestedID, Type: "group"}},
+	})
+	ts.Require().NoError(err, "create librarian group")
+	ts.librarianGroupID = librarianID
+
+	// Assigned a role conferring "system:user", which the group-manager does not hold. Adding anyone
+	// to this group would therefore transfer a permission the caller was never granted.
+	librarianRoleID, err := testutils.CreateRole(testutils.Role{
+		Name: "authz-librarian-role",
+		OUID: ts.groupOU1ID,
+		Permissions: []testutils.ResourcePermissions{
+			{
+				ResourceServerID: systemRSID,
+				Permissions:      []string{"system:user"},
+			},
+		},
+		Assignments: []testutils.Assignment{
+			{ID: librarianID, Type: "group"},
+		},
+	})
+	ts.Require().NoError(err, "create librarian role")
+	ts.librarianRoleID = librarianRoleID
 }
 
 // ---------------------------------------------------------------------------
@@ -256,7 +301,13 @@ func (ts *GroupAuthzTestSuite) TearDownSuite() {
 			ts.T().Logf("teardown: delete group-manager role: %v", err)
 		}
 	}
-	for _, id := range []string{ts.targetGroupOU1ID, ts.deletableGroupOU1ID} {
+	if ts.librarianRoleID != "" {
+		if err := testutils.DeleteRole(ts.librarianRoleID); err != nil {
+			ts.T().Logf("teardown: delete librarian role: %v", err)
+		}
+	}
+	for _, id := range []string{ts.nestedInLibraryID, ts.librarianGroupID,
+		ts.targetGroupOU1ID, ts.deletableGroupOU1ID} {
 		if id != "" {
 			if err := testutils.DeleteGroup(id); err != nil {
 				ts.T().Logf("teardown: delete group %s: %v", id, err)
@@ -519,4 +570,99 @@ func (ts *GroupAuthzTestSuite) TestRemoveMemberFromGroupInOwnOU() {
 
 	ts.Equal(http.StatusOK, resp.StatusCode,
 		"group-manager should be able to remove a user from a group in their own OU")
+}
+
+// mustMarshal encodes a JSON request body, failing the test on error.
+func (ts *GroupAuthzTestSuite) mustMarshal(v any) []byte {
+	ts.T().Helper()
+	payload, err := json.Marshal(v)
+	ts.Require().NoError(err)
+	return payload
+}
+
+// ---------------------------------------------------------------------------
+// Privilege escalation via group membership
+// ---------------------------------------------------------------------------
+
+// The reported vulnerability. The group-manager holds system:group but not system:user. The
+// librarian group confers system:user through its assigned role, so adding anyone to it — including
+// the caller — would grant a permission the caller was never given.
+func (ts *GroupAuthzTestSuite) TestAddSelfToPrivilegedGroupIsForbidden() {
+	payload := ts.mustMarshal(map[string]any{
+		"members": []map[string]string{{"id": ts.groupMgrUserID, "type": "user"}},
+	})
+
+	resp := ts.doGroup(http.MethodPost, "/groups/"+ts.librarianGroupID+"/members/add", payload)
+	defer resp.Body.Close()
+
+	ts.Equalf(http.StatusForbidden, resp.StatusCode,
+		"adding self to a group conferring system:user must be forbidden, got %d", resp.StatusCode)
+}
+
+// Escalation on behalf of someone else is the same defect; the guard is actor-relative.
+func (ts *GroupAuthzTestSuite) TestAddAnotherUserToPrivilegedGroupIsForbidden() {
+	payload := ts.mustMarshal(map[string]any{
+		"members": []map[string]string{{"id": ts.memberUserOU1ID, "type": "user"}},
+	})
+
+	resp := ts.doGroup(http.MethodPost, "/groups/"+ts.librarianGroupID+"/members/add", payload)
+	defer resp.Body.Close()
+
+	ts.Equalf(http.StatusForbidden, resp.StatusCode,
+		"adding another user to a privileged group must be forbidden, got %d", resp.StatusCode)
+}
+
+// Joining a group nested inside the privileged one confers its permissions transitively. This fails
+// unless the guard walks the ancestor chain rather than only the target group's own roles.
+func (ts *GroupAuthzTestSuite) TestAddSelfToGroupNestedInPrivilegedGroupIsForbidden() {
+	payload := ts.mustMarshal(map[string]any{
+		"members": []map[string]string{{"id": ts.groupMgrUserID, "type": "user"}},
+	})
+
+	resp := ts.doGroup(http.MethodPost, "/groups/"+ts.nestedInLibraryID+"/members/add", payload)
+	defer resp.Body.Close()
+
+	ts.Equalf(http.StatusForbidden, resp.StatusCode,
+		"joining a group nested inside a privileged group must be forbidden, got %d", resp.StatusCode)
+}
+
+// Nesting a group the caller controls into the privileged group makes that group's members
+// transitive members of it, so group-typed members are guarded too.
+func (ts *GroupAuthzTestSuite) TestNestingControlledGroupIntoPrivilegedGroupIsForbidden() {
+	payload := ts.mustMarshal(map[string]any{
+		"members": []map[string]string{{"id": ts.targetGroupOU1ID, "type": "group"}},
+	})
+
+	resp := ts.doGroup(http.MethodPost, "/groups/"+ts.librarianGroupID+"/members/add", payload)
+	defer resp.Body.Close()
+
+	ts.Equalf(http.StatusForbidden, resp.StatusCode,
+		"nesting a controlled group into a privileged group must be forbidden, got %d", resp.StatusCode)
+}
+
+// Removal carries the same standing requirement, so a limited administrator cannot strip members
+// from a group more powerful than itself.
+func (ts *GroupAuthzTestSuite) TestRemoveMemberFromPrivilegedGroupIsForbidden() {
+	payload := ts.mustMarshal(map[string]any{
+		"members": []map[string]string{{"id": ts.nestedInLibraryID, "type": "group"}},
+	})
+
+	resp := ts.doGroup(http.MethodPost, "/groups/"+ts.librarianGroupID+"/members/remove", payload)
+	defer resp.Body.Close()
+
+	ts.Equalf(http.StatusForbidden, resp.StatusCode,
+		"removing a member from a privileged group must be forbidden, got %d", resp.StatusCode)
+}
+
+// The guard must not disturb ordinary delegation: a group conferring nothing stays manageable.
+func (ts *GroupAuthzTestSuite) TestAddMemberToUnprivilegedGroupStillSucceeds() {
+	payload := ts.mustMarshal(map[string]any{
+		"members": []map[string]string{{"id": ts.memberUserOU1ID, "type": "user"}},
+	})
+
+	resp := ts.doGroup(http.MethodPost, "/groups/"+ts.targetGroupOU1ID+"/members/add", payload)
+	defer resp.Body.Close()
+
+	ts.Equalf(http.StatusOK, resp.StatusCode,
+		"managing a group that confers nothing must still succeed, got %d", resp.StatusCode)
 }


### PR DESCRIPTION
### Purpose

Adds authorization checks to the operations that convey permissions from one principal to another.

Group membership and role assignment both transfer whatever the container confers onto the member or assignee. Those operations were authorized on the management permission for the resource type alone, which says nothing about what the target group or role actually confers. `modifyGroupMembers` verified member types, group existence, OU scope, and member validity, but never compared the conveyed permissions against what the caller itself holds.

This change introduces that comparison and applies it wherever permissions are conveyed.

Three properties of the rule shaped the implementation:

- **Coverage, not ranking.** Permissions are not ordered, so a caller holding `system:group` and a container conferring `system:usertype` are incomparable rather than one being lesser. The test is whether the caller's set covers the conveyed set.
- **Evaluated against the caller, not the recipient.** The requirement applies regardless of who receives the permissions, including the caller itself.
- **Per resource server.** A permission held on one resource server does not satisfy a requirement on another, even when the permission strings are identical.

**Applicability.** On a default install the System resource server registers a single permission string, `system`, so a sub-root role cannot currently be created and these checks are inert. They become active once granular sub-resources are registered to support least-privilege delegation, which is why they are added ahead of that work.

### Approach

A shared component, so the rule is enforced wherever permissions are conveyed rather than implemented per endpoint.

**Comparison layer (`internal/system/security`)**
`PermissionSet` plus `Covers(actor, required)`. Pure, no I/O. Coverage is evaluated per resource server. Within a resource server it delegates to the existing `HasSufficientPermission`, so hierarchical matching cannot diverge from what the HTTP middleware enforces. Malformed input, meaning an empty permission string or an empty resource server ID, is never covered.

**Policy layer (`internal/system/sysauthz`)**
`CanGrantPermissions` and `CanGrantMembership`, plus a `PermissionResolver` contract injected at startup, mirroring the existing `SetOUHierarchyResolver` two-phase initialization. Evaluation order, refusing at every branch: an internal runtime context is permitted, since bootstrap and the declarative loaders depend on it; a missing resolver errors; a holder of the root permission short-circuits before any lookup, since that permission already covers every system operation; a container conferring nothing is permitted without resolving the caller; any resolution failure refuses.

**Resolver (`internal/role`)**
Satisfies the `sysauthz` contract structurally, so no new import edge is introduced. It resolves the caller's permissions from storage rather than from the token, because the token's permission claim is narrowed to a single resource server and carries no resource server labels, and therefore cannot answer a cross-resource-server coverage question.

**Group ancestry**
A batched single-level `GetDirectGroupParents` plus one shared level-by-level walk, rather than a transitive query per store. The composite store unions both stores at each level, which is what makes a nesting chain spanning the database and declarative stores resolvable. Membership is inherited upward, so what a group conveys includes what its ancestors carry; the walk must therefore return a complete set, and it returns an error rather than a partial result throughout, including on malformed declarative data.

**Enforcement points**
Group membership add and remove, covering user, app, agent, and nested group members; role create; role permission update; role assignment add and remove. Both directions of membership and assignment carry the same requirement. Refusals return `403` with error code `SAZ-4030`, distinct from `SSE-4030` so clients can tell the two refusals apart.

**Deliberate scope choices**
- `DeleteRole` is not covered. It revokes a role from every assignee, which is an availability concern rather than a conveyance of permissions, and belongs with a separate change.
- No opt-out equivalent to the Kubernetes `bind` verb. Role endpoints already require the root permission, so the strict form costs nothing today; the comparison sits behind a single function so one can be added later.
- No duplicate check at the store layer. `groupStoreInterface` is unexported and its member-write methods have a single caller, so Go visibility already makes the service the only route to the store.

**Known limitation.** The checks run before the transaction and again inside it, which narrows but does not eliminate the window in which a container's permissions change between the two. Closing it entirely would require row locking or serializable isolation in the transaction layer shared by every service, which is out of scope here.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4546

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - `docs/content/guides/users/manage-roles.mdx` - new "Permission Requirements" section
    - `docs/content/guides/users/manage-groups.mdx` - new "Permission Requirements for Membership Changes" section
    - `api/group.yaml`, `api/role.yaml` - `403` responses on the affected operations
    - [x] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
        - `backend/internal/system/security/permissions_test.go` - coverage semantics, including per-resource-server isolation and hierarchy direction
        - `backend/internal/system/sysauthz/grant_test.go` - evaluation order, short-circuits, and refusal paths
        - `backend/internal/group/ancestors_test.go` - ancestor walk, cycles, depth bound, cross-store chains, and enforcement
        - `backend/internal/role/all_permissions_test.go`, `permission_resolver_test.go` - enumeration, multi-source merge, and resolver orchestration
    - [x] Integration Tests
        - `tests/integration/group/group_authz_test.go` - a group manager holding only the group management permission is refused when adding itself, adding another user, joining a nested group, nesting a controlled group, and removing a member, and still succeeds on a group that confers nothing
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

Not marked as a breaking change: operations within the caller's own permissions are unaffected. Deployments that relied on an administrator managing membership of a group conferring more than that administrator holds will now receive `403`, which is the intended behavior of the check.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
