### PR TITLE
feat(group): add MCP tools for group management

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -186,7 +186,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	exporters = append(exporters, userExporter)
 
 	groupService, ouGroupResolver, groupExporter, err := group.Initialize(
-		mux, dbprovider.GetDBProvider(), ouService, entityService, entityTypeService, ouAuthzService,
+		mux, mcpServer, dbprovider.GetDBProvider(), ouService, entityService, entityTypeService, ouAuthzService,
 	)
 	fatalOnError(ctx, logger, err, "Failed to initialize GroupService")
 	exporters = append(exporters, groupExporter)

--- a/backend/internal/group/init.go
+++ b/backend/internal/group/init.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	"github.com/thunder-id/thunderid/internal/entity"
 	"github.com/thunder-id/thunderid/internal/entitytype"
 	oupkg "github.com/thunder-id/thunderid/internal/ou"
@@ -21,6 +23,7 @@ import (
 // Initialize initializes the group service and registers its routes.
 func Initialize(
 	mux *http.ServeMux,
+	mcpServer *mcp.Server,
 	dbProvider provider.DBProviderInterface,
 	ouService oupkg.OrganizationUnitServiceInterface,
 	entityService entity.EntityServiceInterface,
@@ -55,6 +58,11 @@ func Initialize(
 	exporter := newGroupExporter(groupService)
 	groupHandler := newGroupHandler(groupService)
 	registerRoutes(mux, groupHandler)
+
+	if mcpServer != nil {
+		registerMCPTools(mcpServer, groupService)
+	}
+
 	return groupService, ouGroupResolver, exporter, nil
 }
 

--- a/backend/internal/group/tools.go
+++ b/backend/internal/group/tools.go
@@ -1,0 +1,285 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package group
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
+	"github.com/thunder-id/thunderid/internal/system/mcp/tool"
+)
+
+// groupTools provides MCP tools for managing groups.
+type groupTools struct {
+	groupService GroupServiceInterface
+}
+
+// createGroupInput represents the input for creating a group.
+type createGroupInput struct {
+	Name        string   `json:"name" jsonschema:"Name of the group"`
+	Description string   `json:"description,omitempty" jsonschema:"Description of the group"`
+	OUID        string   `json:"ouId" jsonschema:"Organization unit ID"`
+	Members     []Member `json:"members,omitempty" jsonschema:"Initial list of members"`
+}
+
+// listGroupsInput represents the input for listing groups.
+type listGroupsInput struct {
+	tool.PaginationInput
+	IncludeDisplay bool `json:"includeDisplay,omitempty" jsonschema:"Whether to include member display names"`
+}
+
+// updateGroupInput represents the input for updating a group.
+type updateGroupInput struct {
+	ID          string `json:"id" jsonschema:"The unique identifier of the group"`
+	Name        string `json:"name" jsonschema:"Name of the group"`
+	Description string `json:"description,omitempty" jsonschema:"Description of the group"`
+	OUID        string `json:"ouId" jsonschema:"Organization unit ID"`
+}
+
+// groupMemberInput represents the input for adding or removing members from a group.
+type groupMemberInput struct {
+	GroupID string   `json:"groupId" jsonschema:"The unique identifier of the group"`
+	Members []Member `json:"members" jsonschema:"List of members"`
+}
+
+// deleteGroupResult represents the output for deleting a group.
+type deleteGroupResult struct {
+	Success bool `json:"success"`
+}
+
+func getCreateGroupSchema() *jsonschema.Schema {
+	return tool.GenerateSchema[createGroupInput](
+		tool.WithRequired("", "name", "ouId"),
+		tool.WithEnum("members", "type", []string{
+			string(MemberTypeUser), string(MemberTypeApp), string(MemberTypeAgent), string(MemberTypeGroup),
+		}),
+	)
+}
+
+func getGetGroupSchema() *jsonschema.Schema {
+	return tool.GenerateSchema[tool.IDInput](
+		tool.WithRequired("", "id"),
+	)
+}
+
+func getListGroupsSchema() *jsonschema.Schema {
+	return tool.GenerateSchema[listGroupsInput]()
+}
+
+func getUpdateGroupSchema() *jsonschema.Schema {
+	return tool.GenerateSchema[updateGroupInput](
+		tool.WithRequired("", "id", "name", "ouId"),
+	)
+}
+
+func getDeleteGroupSchema() *jsonschema.Schema {
+	return tool.GenerateSchema[tool.IDInput](
+		tool.WithRequired("", "id"),
+	)
+}
+
+func getAddGroupMemberSchema() *jsonschema.Schema {
+	return tool.GenerateSchema[groupMemberInput](
+		tool.WithRequired("", "groupId", "members"),
+		tool.WithEnum("members", "type", []string{
+			string(MemberTypeUser), string(MemberTypeApp), string(MemberTypeAgent), string(MemberTypeGroup),
+		}),
+	)
+}
+
+func getRemoveGroupMemberSchema() *jsonschema.Schema {
+	return tool.GenerateSchema[groupMemberInput](
+		tool.WithRequired("", "groupId", "members"),
+		tool.WithEnum("members", "type", []string{
+			string(MemberTypeUser), string(MemberTypeApp), string(MemberTypeAgent), string(MemberTypeGroup),
+		}),
+	)
+}
+
+// registerMCPTools registers all group MCP tools with the server.
+func registerMCPTools(server *mcp.Server, groupService GroupServiceInterface) {
+	tools := &groupTools{
+		groupService: groupService,
+	}
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "thunderid_create_group",
+		Description: `Create a new group under an Organization Unit.`,
+		InputSchema: getCreateGroupSchema(),
+		Annotations: &mcp.ToolAnnotations{
+			Title:          "Create Group",
+			IdempotentHint: false,
+		},
+	}, tools.createGroup)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "thunderid_get_group",
+		Description: `Retrieve full details of a group by ID including member list.`,
+		InputSchema: getGetGroupSchema(),
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Get Group",
+			ReadOnlyHint: true,
+		},
+	}, tools.getGroup)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "thunderid_list_groups",
+		Description: `List all groups with pagination.`,
+		InputSchema: getListGroupsSchema(),
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "List Groups",
+			ReadOnlyHint: true,
+		},
+	}, tools.listGroups)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "thunderid_update_group",
+		Description: `Update an existing group's basic details.`,
+		InputSchema: getUpdateGroupSchema(),
+		Annotations: &mcp.ToolAnnotations{
+			Title:          "Update Group",
+			IdempotentHint: true,
+		},
+	}, tools.updateGroup)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "thunderid_delete_group",
+		Description: `Delete a group by ID.`,
+		InputSchema: getDeleteGroupSchema(),
+		Annotations: &mcp.ToolAnnotations{
+			Title:          "Delete Group",
+			IdempotentHint: true,
+		},
+	}, tools.deleteGroup)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "thunderid_add_group_member",
+		Description: `Add one or more members (users, apps, agents, or sub-groups) to a group.`,
+		InputSchema: getAddGroupMemberSchema(),
+		Annotations: &mcp.ToolAnnotations{
+			Title:          "Add Group Member",
+			IdempotentHint: false,
+		},
+	}, tools.addGroupMember)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "thunderid_remove_group_member",
+		Description: `Remove one or more members from a group.`,
+		InputSchema: getRemoveGroupMemberSchema(),
+		Annotations: &mcp.ToolAnnotations{
+			Title:          "Remove Group Member",
+			IdempotentHint: true,
+		},
+	}, tools.removeGroupMember)
+}
+
+// createGroup handles the create_group tool call.
+func (t *groupTools) createGroup(
+	ctx context.Context,
+	_ *mcp.CallToolRequest,
+	input createGroupInput,
+) (*mcp.CallToolResult, *Group, error) {
+	req := CreateGroupRequest{
+		Name:        input.Name,
+		Description: input.Description,
+		OUID:        input.OUID,
+		Members:     input.Members,
+	}
+	grp, svcErr := t.groupService.CreateGroup(ctx, req)
+	if svcErr != nil {
+		return nil, nil, fmt.Errorf("failed to create group: %s", svcErr.ErrorDescription)
+	}
+	return nil, grp, nil
+}
+
+// getGroup handles the get_group tool call.
+func (t *groupTools) getGroup(
+	ctx context.Context,
+	_ *mcp.CallToolRequest,
+	input tool.IDInput,
+) (*mcp.CallToolResult, *Group, error) {
+	grp, svcErr := t.groupService.GetGroup(ctx, input.ID, true)
+	if svcErr != nil {
+		return nil, nil, fmt.Errorf("failed to get group: %s", svcErr.ErrorDescription)
+	}
+	return nil, grp, nil
+}
+
+// listGroups handles the list_groups tool call.
+func (t *groupTools) listGroups(
+	ctx context.Context,
+	_ *mcp.CallToolRequest,
+	input listGroupsInput,
+) (*mcp.CallToolResult, *GroupListResponse, error) {
+	limit := input.Limit
+	if limit <= 0 {
+		limit = serverconst.MaxPageSize
+	}
+	resp, svcErr := t.groupService.GetGroupList(ctx, limit, input.Offset, input.IncludeDisplay)
+	if svcErr != nil {
+		return nil, nil, fmt.Errorf("failed to list groups: %s", svcErr.ErrorDescription)
+	}
+	return nil, resp, nil
+}
+
+// updateGroup handles the update_group tool call.
+func (t *groupTools) updateGroup(
+	ctx context.Context,
+	_ *mcp.CallToolRequest,
+	input updateGroupInput,
+) (*mcp.CallToolResult, *Group, error) {
+	req := UpdateGroupRequest{
+		Name:        input.Name,
+		Description: input.Description,
+		OUID:        input.OUID,
+	}
+	grp, svcErr := t.groupService.UpdateGroup(ctx, input.ID, req)
+	if svcErr != nil {
+		return nil, nil, fmt.Errorf("failed to update group: %s", svcErr.ErrorDescription)
+	}
+	return nil, grp, nil
+}
+
+// deleteGroup handles the delete_group tool call.
+func (t *groupTools) deleteGroup(
+	ctx context.Context,
+	_ *mcp.CallToolRequest,
+	input tool.IDInput,
+) (*mcp.CallToolResult, *deleteGroupResult, error) {
+	svcErr := t.groupService.DeleteGroup(ctx, input.ID)
+	if svcErr != nil {
+		return nil, nil, fmt.Errorf("failed to delete group: %s", svcErr.ErrorDescription)
+	}
+	return nil, &deleteGroupResult{Success: true}, nil
+}
+
+// addGroupMember handles the add_group_member tool call.
+func (t *groupTools) addGroupMember(
+	ctx context.Context,
+	_ *mcp.CallToolRequest,
+	input groupMemberInput,
+) (*mcp.CallToolResult, *Group, error) {
+	grp, svcErr := t.groupService.AddGroupMembers(ctx, input.GroupID, input.Members)
+	if svcErr != nil {
+		return nil, nil, fmt.Errorf("failed to add group members: %s", svcErr.ErrorDescription)
+	}
+	return nil, grp, nil
+}
+
+// removeGroupMember handles the remove_group_member tool call.
+func (t *groupTools) removeGroupMember(
+	ctx context.Context,
+	_ *mcp.CallToolRequest,
+	input groupMemberInput,
+) (*mcp.CallToolResult, *Group, error) {
+	grp, svcErr := t.groupService.RemoveGroupMembers(ctx, input.GroupID, input.Members)
+	if svcErr != nil {
+		return nil, nil, fmt.Errorf("failed to remove group members: %s", svcErr.ErrorDescription)
+	}
+	return nil, grp, nil
+}

--- a/backend/internal/group/tools_test.go
+++ b/backend/internal/group/tools_test.go
@@ -1,0 +1,485 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package group
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
+	"github.com/thunder-id/thunderid/internal/system/mcp/tool"
+)
+
+type GroupToolsTestSuite struct {
+	suite.Suite
+}
+
+func TestGroupToolsTestSuite(t *testing.T) {
+	suite.Run(t, new(GroupToolsTestSuite))
+}
+
+func (suite *GroupToolsTestSuite) TestRegisterMCPTools() {
+	mockService := NewGroupServiceInterfaceMock(suite.T())
+	server := mcp.NewServer(&mcp.Implementation{
+		Name:    "test-server",
+		Version: "1.0.0",
+	}, nil)
+
+	registerMCPTools(server, mockService)
+	assert.NotNil(suite.T(), server)
+}
+
+func (suite *GroupToolsTestSuite) TestCreateGroup_Success() {
+	mockService := NewGroupServiceInterfaceMock(suite.T())
+	tools := &groupTools{groupService: mockService}
+
+	input := createGroupInput{
+		Name:        "Engineering",
+		Description: "Engineering Team",
+		OUID:        "ou123",
+		Members: []Member{
+			{ID: "user1", Type: MemberTypeUser},
+		},
+	}
+
+	expectedGroup := &Group{
+		ID:          "grp123",
+		Name:        "Engineering",
+		Description: "Engineering Team",
+		OUID:        "ou123",
+		Members: []Member{
+			{ID: "user1", Type: MemberTypeUser},
+		},
+	}
+
+	mockService.On("CreateGroup", mock.Anything, CreateGroupRequest{
+		Name:        input.Name,
+		Description: input.Description,
+		OUID:        input.OUID,
+		Members:     input.Members,
+	}).Return(expectedGroup, nil)
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+
+	result, output, err := tools.createGroup(ctx, req, input)
+
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Equal(suite.T(), expectedGroup, output)
+
+	mockService.AssertExpectations(suite.T())
+}
+
+func (suite *GroupToolsTestSuite) TestCreateGroup_Error() {
+	mockService := NewGroupServiceInterfaceMock(suite.T())
+	tools := &groupTools{groupService: mockService}
+
+	input := createGroupInput{
+		Name: "Invalid Group",
+		OUID: "ou123",
+	}
+
+	mockService.On("CreateGroup", mock.Anything, mock.Anything).
+		Return(nil, &tidcommon.ServiceError{
+			ErrorDescription: tidcommon.I18nMessage{DefaultValue: "failed to create group error"},
+		})
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+
+	result, output, err := tools.createGroup(ctx, req, input)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Nil(suite.T(), output)
+	assert.Contains(suite.T(), err.Error(), "failed to create group")
+
+	mockService.AssertExpectations(suite.T())
+}
+
+func (suite *GroupToolsTestSuite) TestGetGroup_Success() {
+	mockService := NewGroupServiceInterfaceMock(suite.T())
+	tools := &groupTools{groupService: mockService}
+
+	input := tool.IDInput{ID: "grp123"}
+	expectedGroup := &Group{
+		ID:   "grp123",
+		Name: "Engineering",
+		OUID: "ou123",
+	}
+
+	mockService.On("GetGroup", mock.Anything, "grp123", true).Return(expectedGroup, nil)
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+
+	result, output, err := tools.getGroup(ctx, req, input)
+
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Equal(suite.T(), expectedGroup, output)
+
+	mockService.AssertExpectations(suite.T())
+}
+
+func (suite *GroupToolsTestSuite) TestGetGroup_Error() {
+	mockService := NewGroupServiceInterfaceMock(suite.T())
+	tools := &groupTools{groupService: mockService}
+
+	input := tool.IDInput{ID: "grp999"}
+
+	mockService.On("GetGroup", mock.Anything, "grp999", true).
+		Return(nil, &tidcommon.ServiceError{
+			ErrorDescription: tidcommon.I18nMessage{DefaultValue: "group not found"},
+		})
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+
+	result, output, err := tools.getGroup(ctx, req, input)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Nil(suite.T(), output)
+	assert.Contains(suite.T(), err.Error(), "failed to get group")
+
+	mockService.AssertExpectations(suite.T())
+}
+
+func (suite *GroupToolsTestSuite) TestListGroups_Success() {
+	mockService := NewGroupServiceInterfaceMock(suite.T())
+	tools := &groupTools{groupService: mockService}
+
+	input := listGroupsInput{
+		PaginationInput: tool.PaginationInput{Limit: 10, Offset: 0},
+		IncludeDisplay:  true,
+	}
+
+	expectedResp := &GroupListResponse{
+		TotalResults: 1,
+		Count:        1,
+		Groups: []GroupBasic{
+			{ID: "grp123", Name: "Engineering", OUID: "ou123"},
+		},
+	}
+
+	mockService.On("GetGroupList", mock.Anything, 10, 0, true).Return(expectedResp, nil)
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+
+	result, output, err := tools.listGroups(ctx, req, input)
+
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Equal(suite.T(), expectedResp, output)
+
+	mockService.AssertExpectations(suite.T())
+}
+
+func (suite *GroupToolsTestSuite) TestListGroups_DefaultLimit() {
+	mockService := NewGroupServiceInterfaceMock(suite.T())
+	tools := &groupTools{groupService: mockService}
+
+	input := listGroupsInput{
+		PaginationInput: tool.PaginationInput{Limit: 0, Offset: 0},
+		IncludeDisplay:  false,
+	}
+
+	expectedResp := &GroupListResponse{
+		TotalResults: 0,
+		Groups:       []GroupBasic{},
+	}
+
+	mockService.On("GetGroupList", mock.Anything, mock.AnythingOfType("int"), 0, false).Return(expectedResp, nil)
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+
+	result, output, err := tools.listGroups(ctx, req, input)
+
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Equal(suite.T(), expectedResp, output)
+
+	mockService.AssertExpectations(suite.T())
+}
+
+func (suite *GroupToolsTestSuite) TestListGroups_Error() {
+	mockService := NewGroupServiceInterfaceMock(suite.T())
+	tools := &groupTools{groupService: mockService}
+
+	input := listGroupsInput{
+		PaginationInput: tool.PaginationInput{Limit: 10, Offset: 0},
+	}
+
+	mockService.On("GetGroupList", mock.Anything, 10, 0, false).
+		Return(nil, &tidcommon.ServiceError{
+			ErrorDescription: tidcommon.I18nMessage{DefaultValue: "db error"},
+		})
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+
+	result, output, err := tools.listGroups(ctx, req, input)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Nil(suite.T(), output)
+	assert.Contains(suite.T(), err.Error(), "failed to list groups")
+
+	mockService.AssertExpectations(suite.T())
+}
+
+func (suite *GroupToolsTestSuite) TestUpdateGroup_Success() {
+	mockService := NewGroupServiceInterfaceMock(suite.T())
+	tools := &groupTools{groupService: mockService}
+
+	input := updateGroupInput{
+		ID:          "grp123",
+		Name:        "Engineering Updated",
+		Description: "Updated desc",
+		OUID:        "ou123",
+	}
+
+	expectedGroup := &Group{
+		ID:          "grp123",
+		Name:        "Engineering Updated",
+		Description: "Updated desc",
+		OUID:        "ou123",
+	}
+
+	mockService.On("UpdateGroup", mock.Anything, "grp123", UpdateGroupRequest{
+		Name:        input.Name,
+		Description: input.Description,
+		OUID:        input.OUID,
+	}).Return(expectedGroup, nil)
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+
+	result, output, err := tools.updateGroup(ctx, req, input)
+
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Equal(suite.T(), expectedGroup, output)
+
+	mockService.AssertExpectations(suite.T())
+}
+
+func (suite *GroupToolsTestSuite) TestUpdateGroup_Error() {
+	mockService := NewGroupServiceInterfaceMock(suite.T())
+	tools := &groupTools{groupService: mockService}
+
+	input := updateGroupInput{
+		ID:   "grp123",
+		Name: "Updated Name",
+		OUID: "ou123",
+	}
+
+	mockService.On("UpdateGroup", mock.Anything, "grp123", mock.Anything).
+		Return(nil, &tidcommon.ServiceError{
+			ErrorDescription: tidcommon.I18nMessage{DefaultValue: "update error"},
+		})
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+
+	result, output, err := tools.updateGroup(ctx, req, input)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Nil(suite.T(), output)
+	assert.Contains(suite.T(), err.Error(), "failed to update group")
+
+	mockService.AssertExpectations(suite.T())
+}
+
+func (suite *GroupToolsTestSuite) TestDeleteGroup_Success() {
+	mockService := NewGroupServiceInterfaceMock(suite.T())
+	tools := &groupTools{groupService: mockService}
+
+	input := tool.IDInput{ID: "grp123"}
+
+	mockService.On("DeleteGroup", mock.Anything, "grp123").Return(nil)
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+
+	result, output, err := tools.deleteGroup(ctx, req, input)
+
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), output)
+	assert.True(suite.T(), output.Success)
+
+	mockService.AssertExpectations(suite.T())
+}
+
+func (suite *GroupToolsTestSuite) TestDeleteGroup_Error() {
+	mockService := NewGroupServiceInterfaceMock(suite.T())
+	tools := &groupTools{groupService: mockService}
+
+	input := tool.IDInput{ID: "grp123"}
+
+	mockService.On("DeleteGroup", mock.Anything, "grp123").
+		Return(&tidcommon.ServiceError{
+			ErrorDescription: tidcommon.I18nMessage{DefaultValue: "delete error"},
+		})
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+
+	result, output, err := tools.deleteGroup(ctx, req, input)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Nil(suite.T(), output)
+	assert.Contains(suite.T(), err.Error(), "failed to delete group")
+
+	mockService.AssertExpectations(suite.T())
+}
+
+func (suite *GroupToolsTestSuite) TestAddGroupMember_Success() {
+	mockService := NewGroupServiceInterfaceMock(suite.T())
+	tools := &groupTools{groupService: mockService}
+
+	input := groupMemberInput{
+		GroupID: "grp123",
+		Members: []Member{
+			{ID: "user2", Type: MemberTypeUser},
+		},
+	}
+
+	expectedGroup := &Group{
+		ID:   "grp123",
+		Name: "Engineering",
+		Members: []Member{
+			{ID: "user1", Type: MemberTypeUser},
+			{ID: "user2", Type: MemberTypeUser},
+		},
+	}
+
+	mockService.On("AddGroupMembers", mock.Anything, "grp123", input.Members).
+		Return(expectedGroup, nil)
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+
+	result, output, err := tools.addGroupMember(ctx, req, input)
+
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Equal(suite.T(), expectedGroup, output)
+
+	mockService.AssertExpectations(suite.T())
+}
+
+func (suite *GroupToolsTestSuite) TestAddGroupMember_Error() {
+	mockService := NewGroupServiceInterfaceMock(suite.T())
+	tools := &groupTools{groupService: mockService}
+
+	input := groupMemberInput{
+		GroupID: "grp123",
+		Members: []Member{
+			{ID: "user2", Type: MemberTypeUser},
+		},
+	}
+
+	mockService.On("AddGroupMembers", mock.Anything, "grp123", input.Members).
+		Return(nil, &tidcommon.ServiceError{
+			ErrorDescription: tidcommon.I18nMessage{DefaultValue: "add members error"},
+		})
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+
+	result, output, err := tools.addGroupMember(ctx, req, input)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Nil(suite.T(), output)
+	assert.Contains(suite.T(), err.Error(), "failed to add group members")
+
+	mockService.AssertExpectations(suite.T())
+}
+
+func (suite *GroupToolsTestSuite) TestRemoveGroupMember_Success() {
+	mockService := NewGroupServiceInterfaceMock(suite.T())
+	tools := &groupTools{groupService: mockService}
+
+	input := groupMemberInput{
+		GroupID: "grp123",
+		Members: []Member{
+			{ID: "user2", Type: MemberTypeUser},
+		},
+	}
+
+	expectedGroup := &Group{
+		ID:   "grp123",
+		Name: "Engineering",
+		Members: []Member{
+			{ID: "user1", Type: MemberTypeUser},
+		},
+	}
+
+	mockService.On("RemoveGroupMembers", mock.Anything, "grp123", input.Members).
+		Return(expectedGroup, nil)
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+
+	result, output, err := tools.removeGroupMember(ctx, req, input)
+
+	assert.NoError(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Equal(suite.T(), expectedGroup, output)
+
+	mockService.AssertExpectations(suite.T())
+}
+
+func (suite *GroupToolsTestSuite) TestRemoveGroupMember_Error() {
+	mockService := NewGroupServiceInterfaceMock(suite.T())
+	tools := &groupTools{groupService: mockService}
+
+	input := groupMemberInput{
+		GroupID: "grp123",
+		Members: []Member{
+			{ID: "user2", Type: MemberTypeUser},
+		},
+	}
+
+	mockService.On("RemoveGroupMembers", mock.Anything, "grp123", input.Members).
+		Return(nil, &tidcommon.ServiceError{
+			ErrorDescription: tidcommon.I18nMessage{DefaultValue: "remove members error"},
+		})
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+
+	result, output, err := tools.removeGroupMember(ctx, req, input)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Nil(suite.T(), output)
+	assert.Contains(suite.T(), err.Error(), "failed to remove group members")
+
+	mockService.AssertExpectations(suite.T())
+}
+
+func (suite *GroupToolsTestSuite) TestSchemas() {
+	assert.NotNil(suite.T(), getCreateGroupSchema())
+	assert.NotNil(suite.T(), getGetGroupSchema())
+	assert.NotNil(suite.T(), getListGroupsSchema())
+	assert.NotNil(suite.T(), getUpdateGroupSchema())
+	assert.NotNil(suite.T(), getDeleteGroupSchema())
+	assert.NotNil(suite.T(), getAddGroupMemberSchema())
+	assert.NotNil(suite.T(), getRemoveGroupMemberSchema())
+}

--- a/docs/content/working-with-ai/mcp-server.mdx
+++ b/docs/content/working-with-ai/mcp-server.mdx
@@ -202,6 +202,7 @@ Once connected, your AI assistant can work with <ProductName /> resources direct
 | Toolset | Description |
 |---------|-------------|
 | `applications` | Create, configure, and manage OAuth applications with pre-built templates for SPA, Mobile, Server, and M2M |
+| `groups` | Create, retrieve, list, update, and delete groups, and manage group members |
 | `flows` | Design and modify authentication and registration flows |
 | `themes` | Browse and inspect login page themes, colors, and typography |
 | `organization_units` | List organization units |
@@ -211,10 +212,176 @@ Once connected, your AI assistant can work with <ProductName /> resources direct
 **Example prompts:**
 
 - "Create a new single-page application for my React project"
+- "Create a new group named 'Engineering' and add members to it"
 - "Show me the current authentication flow"
 - "Add a second factor step to the default login flow"
 - "What colors and typography does the default theme use?"
 - "Integrate authentication with <ProductName /> for this application"
+
+## Group Management Tools
+
+The MCP server provides seven tools for managing groups and group memberships in <ProductName />:
+
+### `thunderid_create_group`
+
+Create a new group under a specified Organization Unit (OU).
+
+- **Annotations**: Title: `Create Group`, Idempotent: `false`
+- **Input Parameters**:
+  - `name` (`string`, required): Name of the group (min 3, max 64 characters).
+  - `ouId` (`string`, required): Organization Unit ID under which the group is created.
+  - `description` (`string`, optional): Description of the group.
+  - `members` (`array`, optional): Initial list of members. Each member object requires:
+    - `id` (`string`, required): Unique identifier of the member principal.
+    - `type` (`string`, required): Type of member principal. Allowed values: `"user"`, `"app"`, `"agent"`, or `"group"`.
+
+**Example payload:**
+
+```json
+{
+  "name": "Engineering",
+  "ouId": "ou_root",
+  "description": "Software engineering team",
+  "members": [
+    {
+      "id": "usr_12345",
+      "type": "user"
+    },
+    {
+      "id": "app_67890",
+      "type": "app"
+    }
+  ]
+}
+```
+
+### `thunderid_get_group`
+
+Retrieve full details of a group by its unique ID, including its member list and Organization Unit details.
+
+- **Annotations**: Title: `Get Group`, Read-only: `true`
+- **Input Parameters**:
+  - `id` (`string`, required): The unique identifier of the group.
+
+**Example payload:**
+
+```json
+{
+  "id": "grp_12345"
+}
+```
+
+### `thunderid_list_groups`
+
+List all groups with pagination options and optional member display names.
+
+- **Annotations**: Title: `List Groups`, Read-only: `true`
+- **Input Parameters**:
+  - `limit` (`integer`, optional): Maximum number of groups to return (defaults to maximum page size).
+  - `offset` (`integer`, optional): Number of records to skip for pagination.
+  - `includeDisplay` (`boolean`, optional): Whether to include member display names in the response.
+
+**Example payload:**
+
+```json
+{
+  "limit": 20,
+  "offset": 0,
+  "includeDisplay": true
+}
+```
+
+### `thunderid_update_group`
+
+Update an existing group's basic details, such as name, description, and Organization Unit assignment.
+
+- **Annotations**: Title: `Update Group`, Idempotent: `true`
+- **Input Parameters**:
+  - `id` (`string`, required): The unique identifier of the group.
+  - `name` (`string`, required): Updated name of the group.
+  - `ouId` (`string`, required): Organization Unit ID.
+  - `description` (`string`, optional): Updated description of the group.
+
+**Example payload:**
+
+```json
+{
+  "id": "grp_12345",
+  "name": "Engineering & Product",
+  "ouId": "ou_root",
+  "description": "Combined engineering and product group"
+}
+```
+
+### `thunderid_delete_group`
+
+Delete a group by its unique ID.
+
+- **Annotations**: Title: `Delete Group`, Idempotent: `true`
+- **Input Parameters**:
+  - `id` (`string`, required): The unique identifier of the group to delete.
+
+**Example payload:**
+
+```json
+{
+  "id": "grp_12345"
+}
+```
+
+### `thunderid_add_group_member`
+
+Add one or more members (users, applications, agents, or sub-groups) to a group.
+
+- **Annotations**: Title: `Add Group Member`, Idempotent: `false`
+- **Input Parameters**:
+  - `groupId` (`string`, required): The unique identifier of the target group.
+  - `members` (`array`, required): Array of members to add to the group. Each member object requires:
+    - `id` (`string`, required): Unique identifier of the member.
+    - `type` (`string`, required): Member type (`"user"`, `"app"`, `"agent"`, or `"group"`).
+
+**Example payload:**
+
+```json
+{
+  "groupId": "grp_12345",
+  "members": [
+    {
+      "id": "usr_99999",
+      "type": "user"
+    },
+    {
+      "id": "agent_007",
+      "type": "agent"
+    }
+  ]
+}
+```
+
+### `thunderid_remove_group_member`
+
+Remove one or more members from a group.
+
+- **Annotations**: Title: `Remove Group Member`, Idempotent: `true`
+- **Input Parameters**:
+  - `groupId` (`string`, required): The unique identifier of the target group.
+  - `members` (`array`, required): Array of members to remove from the group. Each member object requires:
+    - `id` (`string`, required): Unique identifier of the member.
+    - `type` (`string`, required): Member type (`"user"`, `"app"`, `"agent"`, or `"group"`).
+
+**Example payload:**
+
+```json
+{
+  "groupId": "grp_12345",
+  "members": [
+    {
+      "id": "usr_99999",
+      "type": "user"
+    }
+  ]
+}
+```
 
 ## Use Cases
 


### PR DESCRIPTION
### Summary
This PR exposes group management capabilities in `thunder-id/thunderid` as Model Context Protocol (MCP) server tools by reusing existing service handlers.

### Changes
- Implemented MCP tool definitions, input schemas, and execution handlers in `backend/internal/group/tools.go` for:
  - `thunderid_create_group`: Create a group under an Organization Unit
  - `thunderid_get_group`: Retrieve details and members of a group by ID
  - `thunderid_list_groups`: List all groups with pagination
  - `thunderid_update_group`: Update an existing group's details
  - `thunderid_delete_group`: Delete a group by ID
  - `thunderid_add_group_member`: Add members to a group
  - `thunderid_remove_group_member`: Remove members from a group
- Registered group MCP tools in `backend/internal/group/init.go` and updated `backend/cmd/server/servicemanager.go` to pass `mcpServer` during package initialization.
- Added comprehensive unit test suite in `backend/internal/group/tools_test.go` covering tool schemas, execution logic, delegation to service handlers, and error handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP tools for creating, viewing, listing, updating, and deleting groups.
  * Added MCP tools for adding and removing group members.
  * Group listings now apply a default maximum page size.
  * Improved handling and reporting of group-management operation errors.

* **Documentation**
  * Added documentation, parameters, annotations, and example payloads for group and membership tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->