### PR TITLE
Authenticate each data plane with its own channel token

### DIFF
--- a/backend/cmd/cpserver/servicemanager.go
+++ b/backend/cmd/cpserver/servicemanager.go
@@ -383,11 +383,12 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	// Initialize the CP-DP channel server (phone-home WebSocket). No-op when disabled.
 	chCfg := config.GetServerRuntime().Config.Channel.Server
 	channelServer = channel.InitializeServer(mux, channel.ServerConfig{
-		Enabled:    chCfg.Enabled,
-		Path:       chCfg.Path,
-		AuthToken:  chCfg.AuthToken,
-		ReadLimit:  chCfg.ReadLimitBytes,
-		RPCTimeout: time.Duration(chCfg.RPCTimeoutSeconds) * time.Second,
+		Enabled:         chCfg.Enabled,
+		Path:            chCfg.Path,
+		AuthToken:       chCfg.AuthToken,
+		DataPlaneTokens: chCfg.DataPlaneTokens,
+		ReadLimit:       chCfg.ReadLimitBytes,
+		RPCTimeout:      time.Duration(chCfg.RPCTimeoutSeconds) * time.Second,
 	})
 
 	// Data planes are reached over the connections they hold open to this server, so the environment

--- a/backend/internal/system/channel/auth.go
+++ b/backend/internal/system/channel/auth.go
@@ -28,10 +28,20 @@ import (
 const HeaderDataPlaneID = "X-Data-Plane-ID"
 
 // Verifier authenticates an inbound Data Plane handshake request. Implementations must not mutate r.
-// A token implementation is provided; an mTLS implementation can be added later without changing the
+// Token implementations are provided; an mTLS implementation can be added later without changing the
 // channel server.
+//
+// Verify returns the Data Plane id the request proved it is, or "" when the credential says nothing
+// about identity. A shared token says nothing: every Data Plane presents the same one, so the server
+// has to take the id the client claims in its header and any holder of the token can claim any id. A
+// per-Data-Plane token does say something, and the server uses that instead.
 type Verifier interface {
-	Verify(r *http.Request) error
+	Verify(r *http.Request) (string, error)
+}
+
+// bearerToken reads the token from the Authorization header.
+func bearerToken(r *http.Request) string {
+	return strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
 }
 
 // tokenVerifier checks a shared bearer token presented in the Authorization header.
@@ -46,13 +56,57 @@ func newTokenVerifier(token string) *tokenVerifier {
 
 // Verify returns nil when the request carries the configured bearer token, errAuthNotConfigured when
 // no token is configured, and errUnauthorized otherwise. The comparison is constant-time.
-func (v *tokenVerifier) Verify(r *http.Request) error {
+//
+// The identity is empty because a shared token proves none: the caller falls back to the id the Data
+// Plane claims for itself.
+func (v *tokenVerifier) Verify(r *http.Request) (string, error) {
 	if v.token == "" {
-		return errAuthNotConfigured
+		return "", errAuthNotConfigured
 	}
-	got := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+	got := bearerToken(r)
 	if got == "" || subtle.ConstantTimeCompare([]byte(got), []byte(v.token)) != 1 {
-		return errUnauthorized
+		return "", errUnauthorized
 	}
-	return nil
+	return "", nil
+}
+
+// perDataPlaneTokenVerifier checks a token issued to one named Data Plane.
+//
+// This is what makes the handshake say who connected rather than take the client's word for it. With
+// one token shared by every Data Plane, any holder can claim another's id, evict its connection and
+// receive every command meant for it. Here a claim is only accepted when it comes with that Data
+// Plane's own token, so a compromised deployment can impersonate nothing but itself.
+type perDataPlaneTokenVerifier struct {
+	tokens map[string]string
+}
+
+// newPerDataPlaneTokenVerifier builds a Verifier over a Data-Plane-id to token mapping.
+func newPerDataPlaneTokenVerifier(tokens map[string]string) *perDataPlaneTokenVerifier {
+	copied := make(map[string]string, len(tokens))
+	for id, token := range tokens {
+		copied[id] = token
+	}
+	return &perDataPlaneTokenVerifier{tokens: copied}
+}
+
+// Verify returns the id the request authenticated as. The claimed id selects which token must be
+// presented, and proving it is what authenticates the claim, so an id with no token configured is
+// refused rather than falling back to any other.
+func (v *perDataPlaneTokenVerifier) Verify(r *http.Request) (string, error) {
+	if len(v.tokens) == 0 {
+		return "", errAuthNotConfigured
+	}
+	claimed := r.Header.Get(HeaderDataPlaneID)
+	if claimed == "" {
+		return "", errMissingDataPlaneID
+	}
+	want, ok := v.tokens[claimed]
+	got := bearerToken(r)
+	// The comparison runs whether or not the id is known, so a wrong id and a wrong token fail the
+	// same way rather than the first being distinguishable by how quickly it is rejected.
+	matched := subtle.ConstantTimeCompare([]byte(got), []byte(want)) == 1
+	if !ok || want == "" || got == "" || !matched {
+		return "", errUnauthorized
+	}
+	return claimed, nil
 }

--- a/backend/internal/system/channel/auth_test.go
+++ b/backend/internal/system/channel/auth_test.go
@@ -30,7 +30,10 @@ func TestTokenVerifierAcceptsMatchingBearer(t *testing.T) {
 	v := newTokenVerifier("s3cret")
 	r := httptest.NewRequest(http.MethodGet, "/cp/connect", nil)
 	r.Header.Set("Authorization", "Bearer s3cret")
-	assert.NoError(t, v.Verify(r))
+	id, err := v.Verify(r)
+	assert.NoError(t, err)
+	// A shared token proves no identity, so the caller falls back to the claimed header.
+	assert.Empty(t, id)
 }
 
 func TestTokenVerifierRejectsWrongOrMissingBearer(t *testing.T) {
@@ -38,15 +41,92 @@ func TestTokenVerifierRejectsWrongOrMissingBearer(t *testing.T) {
 
 	r := httptest.NewRequest(http.MethodGet, "/cp/connect", nil)
 	r.Header.Set("Authorization", "Bearer nope")
-	assert.ErrorIs(t, v.Verify(r), errUnauthorized)
+	_, err := v.Verify(r)
+	assert.ErrorIs(t, err, errUnauthorized)
 
 	r2 := httptest.NewRequest(http.MethodGet, "/cp/connect", nil)
-	assert.ErrorIs(t, v.Verify(r2), errUnauthorized)
+	_, err2 := v.Verify(r2)
+	assert.ErrorIs(t, err2, errUnauthorized)
 }
 
 func TestTokenVerifierRejectsWhenNotConfigured(t *testing.T) {
 	v := newTokenVerifier("")
 	r := httptest.NewRequest(http.MethodGet, "/cp/connect", nil)
 	r.Header.Set("Authorization", "Bearer anything")
-	assert.ErrorIs(t, v.Verify(r), errAuthNotConfigured)
+	_, err := v.Verify(r)
+	assert.ErrorIs(t, err, errAuthNotConfigured)
+}
+
+// A per-Data-Plane token is what makes the handshake know which Data Plane connected, instead of
+// believing the id in the header.
+func TestPerDataPlaneTokenAuthenticatesTheClaimedIdentity(t *testing.T) {
+	v := newPerDataPlaneTokenVerifier(map[string]string{"org1:dev": "dev-token", "org1:stage": "stage-token"})
+
+	r := httptest.NewRequest(http.MethodGet, "/cp/connect", nil)
+	r.Header.Set(HeaderDataPlaneID, "org1:dev")
+	r.Header.Set("Authorization", "Bearer dev-token")
+
+	id, err := v.Verify(r)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "org1:dev", id)
+}
+
+// With a token per Data Plane, holding one is not enough to be another: this is the impersonation a
+// single shared token allows, where any holder can evict a connection and receive its commands.
+func TestPerDataPlaneTokenRefusesAnotherDataPlanesToken(t *testing.T) {
+	v := newPerDataPlaneTokenVerifier(map[string]string{"org1:dev": "dev-token", "org1:stage": "stage-token"})
+
+	r := httptest.NewRequest(http.MethodGet, "/cp/connect", nil)
+	r.Header.Set(HeaderDataPlaneID, "org1:stage")
+	r.Header.Set("Authorization", "Bearer dev-token")
+
+	_, err := v.Verify(r)
+
+	assert.ErrorIs(t, err, errUnauthorized)
+}
+
+func TestPerDataPlaneTokenRefusesAnUnknownDataPlane(t *testing.T) {
+	v := newPerDataPlaneTokenVerifier(map[string]string{"org1:dev": "dev-token"})
+
+	r := httptest.NewRequest(http.MethodGet, "/cp/connect", nil)
+	r.Header.Set(HeaderDataPlaneID, "org9:dev")
+	r.Header.Set("Authorization", "Bearer dev-token")
+
+	_, err := v.Verify(r)
+
+	assert.ErrorIs(t, err, errUnauthorized)
+}
+
+func TestPerDataPlaneTokenRequiresAClaimedIdentity(t *testing.T) {
+	v := newPerDataPlaneTokenVerifier(map[string]string{"org1:dev": "dev-token"})
+
+	r := httptest.NewRequest(http.MethodGet, "/cp/connect", nil)
+	r.Header.Set("Authorization", "Bearer dev-token")
+
+	_, err := v.Verify(r)
+
+	assert.ErrorIs(t, err, errMissingDataPlaneID)
+}
+
+// Per-Data-Plane tokens win when both are configured: the shared token is the weaker of the two, and
+// leaving it in place would keep the impersonation the other form exists to close.
+func TestPerDataPlaneTokensWinOverTheSharedToken(t *testing.T) {
+	v := serverVerifier(ServerConfig{
+		AuthToken:       "shared",
+		DataPlaneTokens: map[string]string{"org1:dev": "dev-token"},
+	})
+
+	shared := httptest.NewRequest(http.MethodGet, "/cp/connect", nil)
+	shared.Header.Set(HeaderDataPlaneID, "org1:dev")
+	shared.Header.Set("Authorization", "Bearer shared")
+	_, err := v.Verify(shared)
+	assert.ErrorIs(t, err, errUnauthorized)
+
+	own := httptest.NewRequest(http.MethodGet, "/cp/connect", nil)
+	own.Header.Set(HeaderDataPlaneID, "org1:dev")
+	own.Header.Set("Authorization", "Bearer dev-token")
+	authenticated, err := v.Verify(own)
+	assert.NoError(t, err)
+	assert.Equal(t, "org1:dev", authenticated)
 }

--- a/backend/internal/system/channel/config.go
+++ b/backend/internal/system/channel/config.go
@@ -27,8 +27,15 @@ type ServerConfig struct {
 	Enabled bool
 	// Path is the route the WebSocket server is mounted on (for example "/cp/connect").
 	Path string
-	// AuthToken is the shared bearer token a Data Plane must present during the handshake.
+	// AuthToken is a bearer token shared by every Data Plane. It authenticates the connection but
+	// proves no identity, so the server takes the id each Data Plane claims for itself and any holder
+	// of the token can claim any id. Prefer DataPlaneTokens.
 	AuthToken string
+	// DataPlaneTokens maps a Data Plane id to the token issued to that one deployment. When set it
+	// replaces AuthToken, and the handshake then knows which Data Plane connected rather than
+	// believing the header: a claim is accepted only with that Data Plane's own token, so a
+	// compromised deployment can impersonate nothing but itself.
+	DataPlaneTokens map[string]string
 	// ReadLimit is the max single-message size in bytes. Zero uses the coder/websocket default of
 	// 32 KiB (32768 bytes); raise it for deployments that exchange larger JSON-RPC payloads.
 	ReadLimit int64

--- a/backend/internal/system/channel/init.go
+++ b/backend/internal/system/channel/init.go
@@ -37,9 +37,18 @@ func InitializeServer(mux *http.ServeMux, cfg ServerConfig) *Server {
 	if !strings.HasPrefix(cfg.Path, "/") {
 		cfg.Path = "/" + cfg.Path
 	}
-	s := NewServer(cfg, newTokenVerifier(cfg.AuthToken))
+	s := NewServer(cfg, serverVerifier(cfg))
 	mux.HandleFunc("GET "+cfg.Path, s.HandleConnect)
 	return s
+}
+
+// serverVerifier picks how a handshake is authenticated. Per-Data-Plane tokens win when configured,
+// because they are the only form that tells the server which Data Plane connected.
+func serverVerifier(cfg ServerConfig) Verifier {
+	if len(cfg.DataPlaneTokens) > 0 {
+		return newPerDataPlaneTokenVerifier(cfg.DataPlaneTokens)
+	}
+	return newTokenVerifier(cfg.AuthToken)
 }
 
 // InitializeClient builds the Data Plane channel client with the Import, Ping and secret-store

--- a/backend/internal/system/channel/server.go
+++ b/backend/internal/system/channel/server.go
@@ -125,11 +125,17 @@ func NewServer(cfg ServerConfig, verifier Verifier) *Server {
 // runs the response read loop until the connection closes or the server shuts down.
 func (s *Server) HandleConnect(w http.ResponseWriter, r *http.Request) {
 	dpID := r.Header.Get(HeaderDataPlaneID)
-	if err := s.verifier.Verify(r); err != nil {
+	authenticated, err := s.verifier.Verify(r)
+	if err != nil {
 		s.logger.Warn(r.Context(), "Rejected data plane handshake",
 			log.String("remoteAddr", r.RemoteAddr), log.String("dpID", dpID), log.Error(err))
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
+	}
+	// A credential that proves an identity decides which Data Plane this is. Only a shared token,
+	// which proves none, leaves the claim in the header to be taken at face value.
+	if authenticated != "" {
+		dpID = authenticated
 	}
 	if dpID == "" {
 		http.Error(w, errMissingDataPlaneID.Error(), http.StatusBadRequest)
@@ -139,7 +145,7 @@ func (s *Server) HandleConnect(w http.ResponseWriter, r *http.Request) {
 	// sc is assigned only after Accept returns, but OnPingReceived can fire as soon as the
 	// connection is accepted, so it must tolerate a nil sc.
 	var sc *serverConn
-	ws, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+	ws, acceptErr := websocket.Accept(w, r, &websocket.AcceptOptions{
 		// The Data Plane is a non-browser client and sends no Origin header, and coder/websocket's
 		// default origin check already passes an absent Origin header, so no override is needed here.
 		OnPingReceived: func(_ context.Context, _ []byte) bool {
@@ -149,7 +155,7 @@ func (s *Server) HandleConnect(w http.ResponseWriter, r *http.Request) {
 			return true
 		},
 	})
-	if err != nil {
+	if acceptErr != nil {
 		return // Accept has already written the error response.
 	}
 	sc = newServerConn(newWSConn(ws, s.cfg.ReadLimit), dpID)

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -149,10 +149,15 @@ type ChannelServerConfig struct {
 	// Path is the route the WebSocket server is mounted on. Changing it requires updating, in
 	// lockstep, the public-path allowlist (publicPaths in internal/system/security/permissions.go)
 	// and the Control Plane access-log exclusion list (accessLogExcludePaths in cmd/cpserver/main.go).
-	Path              string `yaml:"path"                json:"path"`
-	AuthToken         string `yaml:"auth_token"          json:"auth_token"`
-	ReadLimitBytes    int64  `yaml:"read_limit_bytes"    json:"read_limit_bytes"`
-	RPCTimeoutSeconds int    `yaml:"rpc_timeout_seconds" json:"rpc_timeout_seconds"`
+	Path      string `yaml:"path"       json:"path"`
+	AuthToken string `yaml:"auth_token" json:"auth_token"`
+	// DataPlaneTokens maps a Data Plane id to the token issued to that one deployment. It replaces
+	// auth_token when set, and is the only form that tells the server which Data Plane connected: a
+	// claim is accepted only with that Data Plane's own token, so one compromised deployment cannot
+	// take over another's connection.
+	DataPlaneTokens   map[string]string `yaml:"data_plane_tokens" json:"data_plane_tokens"`
+	ReadLimitBytes    int64             `yaml:"read_limit_bytes"    json:"read_limit_bytes"`
+	RPCTimeoutSeconds int               `yaml:"rpc_timeout_seconds" json:"rpc_timeout_seconds"`
 }
 
 // Validate ensures the Control Plane channel server configuration is usable when enabled. A disabled
@@ -161,8 +166,15 @@ func (c *ChannelServerConfig) Validate() error {
 	if !c.Enabled {
 		return nil
 	}
-	if c.AuthToken == "" {
-		return fmt.Errorf("channel.server.auth_token must be set when channel.server.enabled is true")
+	if c.AuthToken == "" && len(c.DataPlaneTokens) == 0 {
+		return fmt.Errorf(
+			"channel.server.auth_token or channel.server.data_plane_tokens must be set when " +
+				"channel.server.enabled is true")
+	}
+	for id, token := range c.DataPlaneTokens {
+		if token == "" {
+			return fmt.Errorf("channel.server.data_plane_tokens[%q] must not be empty", id)
+		}
 	}
 	return nil
 }

--- a/backend/internal/system/config/config_test.go
+++ b/backend/internal/system/config/config_test.go
@@ -1804,3 +1804,32 @@ func (suite *ConfigTestSuite) TestNotificationConfig_Validate_DelegatesToOTP() {
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "notification.otp.length")
 }
+
+// A channel server is usable with either form of token, and per-Data-Plane tokens are enough on
+// their own: requiring the shared one alongside them would keep the credential they exist to replace.
+func TestChannelServerAcceptsPerDataPlaneTokensWithoutASharedToken(t *testing.T) {
+	cfg := ChannelServerConfig{
+		Enabled:         true,
+		DataPlaneTokens: map[string]string{"org1:dev": "dev-token"},
+	}
+
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestChannelServerRejectsAnEmptyPerDataPlaneToken(t *testing.T) {
+	cfg := ChannelServerConfig{
+		Enabled:         true,
+		DataPlaneTokens: map[string]string{"org1:dev": ""},
+	}
+
+	err := cfg.Validate()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "org1:dev")
+}
+
+func TestChannelServerRejectsNoTokenAtAll(t *testing.T) {
+	cfg := ChannelServerConfig{Enabled: true}
+
+	assert.Error(t, cfg.Validate())
+}


### PR DESCRIPTION
### Purpose

A Data Plane can now be issued its own channel token instead of sharing one with every other Data Plane.

This also makes the handshake know which Data Plane connected. Until now the Control Plane took the id from the `X-Data-Plane-ID` header on trust, which the channel design (#4487) called out as the consequence of the deferred mTLS decision: with a single token, any holder can connect claiming another Data Plane's id, evict the genuine connection under the single-active-socket policy, and become the recipient of every command the Control Plane sends that id.

### Approach

**`Verifier` returns the identity it proved.** The seam the design left for this is `Verifier`, so `Verify` now returns `(dataPlaneID, error)`:

- The shared-token verifier returns `""`. A token every Data Plane holds proves no identity, so the caller still falls back to the claimed header, and the existing caveat is unchanged.
- The per-Data-Plane verifier returns the id. The claimed id selects which token must be presented, and presenting it is what authenticates the claim, so a compromised deployment can impersonate nothing but itself.

`HandleConnect` uses the returned identity when there is one and the header only when there is not, so the stronger credential decides who connected.

The comparison runs whether or not the claimed id is configured, so an unknown id and a wrong token are rejected the same way rather than the first being distinguishable by how quickly it fails.

**Configuration.** `channel.server.data_plane_tokens` maps a Data Plane id to its token and replaces `auth_token` when set:

```yaml
channel:
  server:
    enabled: true
    data_plane_tokens:
      "org1:dev": "dev-token"
      "org1:stage": "stage-token"
```

Validation accepts either form, and rejects an empty token for a named id, naming the id. Nothing that runs on `auth_token` today changes.

### What this does not fix

mTLS is still the real answer and is still deferred. These are bearer credentials held in configuration, and handshake rate limiting is still a non-goal, so a stolen token still lets an attacker hold that one Data Plane offline by reconnecting. What changes is the blast radius: one Data Plane's token is no longer a credential for impersonating all of them.

### Related Issues
- N/A

### Related PRs
- Builds on #4487 (CP-DP phone-home WebSocket channel), which left the `Verifier` seam and named per-Data-Plane tokens as the interim hardening
- Builds on #4501 (reaching data planes over the channel)

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
