### PR TITLE
Enforce jti single-use for ID-JAG assertions

### DIFF
--- a/backend/internal/oauth/init.go
+++ b/backend/internal/oauth/init.go
@@ -20,6 +20,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/dpop"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/granthandlers"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/introspect"
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/jti"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/jwksresolver"
 	oauth2logout "github.com/thunder-id/thunderid/internal/oauth/oauth2/logout"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/par"
@@ -73,8 +74,9 @@ func Initialize(
 			tokenFamilyRevocationTTL, cfg.OAuth.Revocation.TokenFamily.OnExplicitRevoke)
 	}
 
+	jtiStore := jti.Initialize(runtimeStore)
 	tokenBuilder, tokenValidator := tokenservice.Initialize(
-		cfg, jwtService, jweService, resolver, idpService, enforcementService)
+		cfg, jwtService, jweService, resolver, idpService, enforcementService, jtiStore)
 	parService := par.Initialize(mux, actorProvider, authnProvider, jwtService, discoveryService,
 		resourceService, dpopVerifier, cfg, runtimeStore)
 	oauth2AuthzService, err := oauth2authz.Initialize(mux, actorProvider, resourceService,

--- a/backend/internal/oauth/oauth2/tokenservice/error_constants.go
+++ b/backend/internal/oauth/oauth2/tokenservice/error_constants.go
@@ -17,4 +17,7 @@ var (
 	// ErrAudienceNotAccepted indicates the token's aud claim names none of the audiences the grant
 	// accepts, such as this server's issuer or an identity provider's trusted token audience.
 	ErrAudienceNotAccepted = errors.New("token audience is not accepted")
+
+	// ErrAssertionReplayed indicates the assertion's jti has already been recorded in the replay cache.
+	ErrAssertionReplayed = errors.New("assertion has already been used")
 )

--- a/backend/internal/oauth/oauth2/tokenservice/init.go
+++ b/backend/internal/oauth/oauth2/tokenservice/init.go
@@ -5,6 +5,7 @@ package tokenservice
 
 import (
 	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/jti"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/jwksresolver"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/revocation"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwe"
@@ -21,8 +22,9 @@ func Initialize(
 	resolver *jwksresolver.Resolver,
 	idpService providers.IDPProvider,
 	enforcementService revocation.EnforcementServiceInterface,
+	jtiStore jti.JTIStoreInterface,
 ) (TokenBuilderInterface, TokenValidatorInterface) {
 	tokenBuilder := newTokenBuilder(cfg, jwtService, jweService, resolver)
-	tokenValidator := newTokenValidator(cfg, jwtService, idpService, enforcementService)
+	tokenValidator := newTokenValidator(cfg, jwtService, idpService, enforcementService, jtiStore)
 	return tokenBuilder, tokenValidator
 }

--- a/backend/internal/oauth/oauth2/tokenservice/init_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/init_test.go
@@ -27,7 +27,7 @@ func (suite *InitTestSuite) SetupTest() {
 }
 
 func (suite *InitTestSuite) TestInitialize() {
-	tokenBuilder, tokenValidator := Initialize(testhelpers.OAuthConfig(), suite.mockJWTService, nil, nil, nil, nil)
+	tokenBuilder, tokenValidator := Initialize(testhelpers.OAuthConfig(), suite.mockJWTService, nil, nil, nil, nil, nil)
 
 	assert.NotNil(suite.T(), tokenBuilder)
 	assert.Implements(suite.T(), (*TokenBuilderInterface)(nil), tokenBuilder)

--- a/backend/internal/oauth/oauth2/tokenservice/model.go
+++ b/backend/internal/oauth/oauth2/tokenservice/model.go
@@ -156,8 +156,8 @@ type IDJAGAssertionClaims struct {
 	// Resources holds the RFC 8707 `resource` claim values carried by the assertion, when present.
 	// Empty when the assertion carries no resource claim.
 	Resources []string
-	// JTI is the assertion's unique identifier. It is required by the draft and validated for presence;
-	// one-time-use (replay) caching keyed on it is deferred to a future version.
+	// JTI is the assertion's unique identifier, required by the draft. Enforced as single-use via
+	// the JTI replay cache; a replayed assertion is rejected.
 	JTI string
 }
 

--- a/backend/internal/oauth/oauth2/tokenservice/validator.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator.go
@@ -13,12 +13,19 @@ import (
 	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/dpop"
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/jti"
 	oauth2model "github.com/thunder-id/thunderid/internal/oauth/oauth2/model"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/revocation"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/utils"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
+
+// idjagJTINamespace identifies ID-JAG assertions in the shared JTI replay store.
+const idjagJTINamespace = "idjag"
+
+// maxIDJAGJTILength is the maximum accepted length of an ID-JAG assertion's jti claim.
+const maxIDJAGJTILength = 256
 
 // TokenValidatorInterface defines the interface for validating tokens. Every method verifies the
 // token and then enforces the revocation deny list as a final step, so a caller cannot obtain claims
@@ -51,6 +58,7 @@ type tokenValidator struct {
 	jwtService         jwt.JWTServiceInterface
 	idpService         providers.IDPProvider
 	enforcementService revocation.EnforcementServiceInterface
+	jtiStore           jti.JTIStoreInterface
 }
 
 // NewTokenValidator creates a new TokenValidator instance.
@@ -59,12 +67,14 @@ func newTokenValidator(
 	jwtService jwt.JWTServiceInterface,
 	idpService providers.IDPProvider,
 	enforcementService revocation.EnforcementServiceInterface,
+	jtiStore jti.JTIStoreInterface,
 ) TokenValidatorInterface {
 	return &tokenValidator{
 		cfg:                cfg,
 		jwtService:         jwtService,
 		idpService:         idpService,
 		enforcementService: enforcementService,
+		jtiStore:           jtiStore,
 	}
 }
 
@@ -376,16 +386,15 @@ func (tv *tokenValidator) ValidateIDJAGAssertion(
 		return nil, err
 	}
 
-	// The draft lists jti, iat, and exp as REQUIRED; exp is enforced by validateTimeClaims above.
-	// Require a non-empty jti and an iat here. One-time-use (replay) caching keyed on jti is
-	// intentionally deferred to a future version, so this remains a presence check for forward
-	// compatibility.
 	if _, iatErr := extractInt64Claim(claims, "iat"); iatErr != nil {
 		return nil, fmt.Errorf("assertion is missing 'iat' claim: %w", iatErr)
 	}
 	jti, jtiErr := extractStringClaim(claims, "jti")
 	if jtiErr != nil {
 		return nil, fmt.Errorf("assertion is missing 'jti' claim: %w", jtiErr)
+	}
+	if len(jti) > maxIDJAGJTILength {
+		return nil, fmt.Errorf("assertion 'jti' exceeds maximum length")
 	}
 
 	serverIssuer := tv.cfg.JWT.Issuer
@@ -413,6 +422,16 @@ func (tv *tokenValidator) ValidateIDJAGAssertion(
 	sub, err := extractStringClaim(claims, "sub")
 	if err != nil {
 		return nil, fmt.Errorf("assertion is missing 'sub' claim: %w", err)
+	}
+
+	exp, _ := extractInt64Claim(claims, "exp")
+	expiry := time.Unix(exp+tv.cfg.JWT.Leeway, 0)
+	inserted, recordErr := tv.jtiStore.RecordJTI(ctx, idjagJTINamespace, jti, expiry)
+	if recordErr != nil {
+		return nil, fmt.Errorf("failed to record assertion jti: %w", recordErr)
+	}
+	if !inserted {
+		return nil, ErrAssertionReplayed
 	}
 
 	return &IDJAGAssertionClaims{

--- a/backend/internal/oauth/oauth2/tokenservice/validator_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
 	"github.com/thunder-id/thunderid/tests/mocks/idp/idpmock"
 	"github.com/thunder-id/thunderid/tests/mocks/jose/jwtmock"
+	"github.com/thunder-id/thunderid/tests/mocks/oauth/oauth2/jtimock"
 	"github.com/thunder-id/thunderid/tests/mocks/oauth/oauth2/revocationmock"
 )
 
@@ -2925,6 +2927,7 @@ type IDJAGValidatorTestSuite struct {
 	mockJWTService         *jwtmock.JWTServiceInterfaceMock
 	mockIDPService         *idpmock.IDPServiceInterfaceMock
 	mockEnforcementService *revocationmock.EnforcementServiceInterfaceMock
+	mockJTIStore           *jtimock.JTIStoreInterfaceMock
 	validator              *tokenValidator
 }
 
@@ -2948,6 +2951,7 @@ func (suite *IDJAGValidatorTestSuite) SetupTest() {
 	suite.mockIDPService = idpmock.NewIDPServiceInterfaceMock(suite.T())
 	suite.mockEnforcementService = revocationmock.NewEnforcementServiceInterfaceMock(suite.T())
 	suite.mockEnforcementService.On("EnsureNotRevoked", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	suite.mockJTIStore = jtimock.NewJTIStoreInterfaceMock(suite.T())
 	suite.validator = &tokenValidator{
 		cfg: oauthconfig.Config{
 			JWT: engineconfig.JWTConfig{
@@ -2960,6 +2964,7 @@ func (suite *IDJAGValidatorTestSuite) SetupTest() {
 		jwtService:         suite.mockJWTService,
 		idpService:         suite.mockIDPService,
 		enforcementService: suite.mockEnforcementService,
+		jtiStore:           suite.mockJTIStore,
 	}
 }
 
@@ -2991,6 +2996,8 @@ func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_Success() {
 	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
 		idp.PropIssuer, testExternalIssuer).Return(buildIDJAGIDPDTOs(), nil)
 	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", mock.Anything, assertion, testExternalJWKS).Return(nil)
+	suite.mockJTIStore.On("RecordJTI", mock.Anything, idjagJTINamespace, testIDJAGAssertionJTI,
+		mock.AnythingOfType("time.Time")).Return(true, nil)
 
 	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
 
@@ -3012,6 +3019,8 @@ func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_SingleResourceC
 	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
 		idp.PropIssuer, testExternalIssuer).Return(buildIDJAGIDPDTOs(), nil)
 	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", mock.Anything, assertion, testExternalJWKS).Return(nil)
+	suite.mockJTIStore.On("RecordJTI", mock.Anything, idjagJTINamespace, testIDJAGAssertionJTI,
+		mock.AnythingOfType("time.Time")).Return(true, nil)
 
 	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
 
@@ -3028,6 +3037,8 @@ func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_MultipleResourc
 	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
 		idp.PropIssuer, testExternalIssuer).Return(buildIDJAGIDPDTOs(), nil)
 	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", mock.Anything, assertion, testExternalJWKS).Return(nil)
+	suite.mockJTIStore.On("RecordJTI", mock.Anything, idjagJTINamespace, testIDJAGAssertionJTI,
+		mock.AnythingOfType("time.Time")).Return(true, nil)
 
 	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
 
@@ -3042,6 +3053,8 @@ func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_NoResourceClaim
 	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
 		idp.PropIssuer, testExternalIssuer).Return(buildIDJAGIDPDTOs(), nil)
 	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", mock.Anything, assertion, testExternalJWKS).Return(nil)
+	suite.mockJTIStore.On("RecordJTI", mock.Anything, idjagJTINamespace, testIDJAGAssertionJTI,
+		mock.AnythingOfType("time.Time")).Return(true, nil)
 
 	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
 
@@ -3206,6 +3219,8 @@ func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_SingleElementAu
 	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
 		idp.PropIssuer, testExternalIssuer).Return(buildIDJAGIDPDTOs(), nil)
 	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", mock.Anything, assertion, testExternalJWKS).Return(nil)
+	suite.mockJTIStore.On("RecordJTI", mock.Anything, idjagJTINamespace, testIDJAGAssertionJTI,
+		mock.AnythingOfType("time.Time")).Return(true, nil)
 
 	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
 
@@ -3214,4 +3229,44 @@ func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_SingleElementAu
 	assert.Equal(suite.T(), "ext-user-123", result.Sub)
 	suite.mockIDPService.AssertExpectations(suite.T())
 	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_ReplayedJTI() {
+	claims := suite.idjagClaims()
+	assertion := suite.createAssertion(jwt.TokenTypeIDJAG, claims)
+
+	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
+		idp.PropIssuer, testExternalIssuer).Return(buildIDJAGIDPDTOs(), nil)
+	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", mock.Anything, assertion, testExternalJWKS).Return(nil)
+	suite.mockJTIStore.On("RecordJTI", mock.Anything, idjagJTINamespace, testIDJAGAssertionJTI,
+		mock.AnythingOfType("time.Time")).Return(false, nil)
+
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.ErrorIs(suite.T(), err, ErrAssertionReplayed)
+}
+
+func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_JTIStoreError() {
+	claims := suite.idjagClaims()
+	assertion := suite.createAssertion(jwt.TokenTypeIDJAG, claims)
+
+	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
+		idp.PropIssuer, testExternalIssuer).Return(buildIDJAGIDPDTOs(), nil)
+	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", mock.Anything, assertion, testExternalJWKS).Return(nil)
+	suite.mockJTIStore.On("RecordJTI", mock.Anything, idjagJTINamespace, testIDJAGAssertionJTI,
+		mock.AnythingOfType("time.Time")).Return(false, fmt.Errorf("store unavailable"))
+
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), result)
+	assert.Contains(suite.T(), err.Error(), "failed to record assertion jti")
+}
+
+func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_JTIExceedsMaxLength() {
+	claims := suite.idjagClaims()
+	claims["jti"] = strings.Repeat("a", 257)
+	suite.assertRejectsSignedAssertion(claims, "assertion 'jti' exceeds maximum length")
 }


### PR DESCRIPTION
## Summary

- Wire the existing JTI replay cache (`jti.JTIStoreInterface`) into `ValidateIDJAGAssertion` to enforce single-use semantics for ID-JAG assertions
- Record each assertion's `jti` with a TTL of `exp + leeway`, rejecting replayed assertions with `ErrAssertionReplayed`
- Add a 256-character length limit on the `jti` claim, matching the DPoP verifier's constraint

## Test plan

- [x] Unit tests pass (`make test_unit` — 87.6% coverage, zero failures)
- [x] `go vet ./...` clean
- [x] 3 new test cases: replayed JTI rejected, JTI store error handled, JTI exceeding max length rejected
- [x] All 16 existing ID-JAG validator tests updated with JTI store expectations and passing

Fixes #4500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * ID-JAG assertions are now single-use, preventing replay of previously accepted assertions.
  * Oversized assertion identifiers are rejected.
  * Replay-cache failures are surfaced as validation errors.
* **Error Handling**
  * Added a dedicated error for detecting reused assertions.
* **Validation**
  * Expanded coverage for replay attempts, storage failures, and invalid identifier lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->