### PR TITLE
Make the application flow mismatch error message actionable

### DIFF
--- a/frontend/apps/console/src/features/applications/api/useCreateApplication.ts
+++ b/frontend/apps/console/src/features/applications/api/useCreateApplication.ts
@@ -6,9 +6,9 @@ import {ApplicationQueryKeys} from '@thunderid/configure-applications';
 import type {Application} from '@thunderid/configure-applications';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {useThunderID} from '@thunderid/react';
-import {getErrorMessage} from '@thunderid/utils';
 import {useTranslation} from 'react-i18next';
 import type {CreateApplicationRequest} from '../models/requests';
+import getApplicationErrorMessage from '../utils/getApplicationErrorMessage';
 
 /**
  * Custom React hook to create a new application in the server.
@@ -77,7 +77,7 @@ export default function useCreateApplication(): UseMutationResult<Application, E
       showToast(t('create.success'), 'success');
     },
     onError: (error) => {
-      showToast(getErrorMessage(error, t, 'create.error'), 'error');
+      showToast(getApplicationErrorMessage(error, t, 'create.error'), 'error', 12000);
     },
   });
 }

--- a/frontend/apps/console/src/features/applications/api/useUpdateApplication.ts
+++ b/frontend/apps/console/src/features/applications/api/useUpdateApplication.ts
@@ -6,9 +6,9 @@ import {ApplicationQueryKeys} from '@thunderid/configure-applications';
 import type {Application} from '@thunderid/configure-applications';
 import {useConfig, useToast} from '@thunderid/contexts';
 import {useThunderID} from '@thunderid/react';
-import {getErrorMessage} from '@thunderid/utils';
 import {useTranslation} from 'react-i18next';
 import type {CreateApplicationRequest} from '../models/requests';
+import getApplicationErrorMessage from '../utils/getApplicationErrorMessage';
 
 /**
  * Variables for the {@link useUpdateApplication} mutation.
@@ -102,7 +102,7 @@ export default function useUpdateApplication(): UseMutationResult<Application, E
       showToast(t('update.success'), 'success');
     },
     onError: (error) => {
-      showToast(getErrorMessage(error, t, 'update.error'), 'error');
+      showToast(getApplicationErrorMessage(error, t, 'update.error'), 'error', 12000);
     },
   });
 }

--- a/frontend/apps/console/src/features/applications/utils/__tests__/getApplicationErrorMessage.test.ts
+++ b/frontend/apps/console/src/features/applications/utils/__tests__/getApplicationErrorMessage.test.ts
@@ -1,0 +1,81 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {describe, it, expect} from 'vitest';
+import getApplicationErrorMessage from '../getApplicationErrorMessage';
+
+const LABELS: Record<string, string> = {
+  'edit.flows.labels.authFlow': 'Sign-in Flow',
+  'edit.flows.labels.registrationFlow': 'Sign-up Flow',
+  'edit.flows.labels.recoveryFlow': 'Recovery Flow',
+  'edit.flows.labels.signOutFlow': 'Sign Out Flow',
+  'errors.APP-1039':
+    "The {{sourceFlowType}} references a different {{flowType}} than the one configured for this application. Update the {{sourceFlowType}} so it calls the same {{flowType}}, or change the application's {{flowType}} configuration.",
+  'update.error': 'Failed to update the application.',
+};
+
+const t = (key: string, options?: Record<string, unknown>): string => {
+  const template = LABELS[key] ?? '';
+
+  if (!options) {
+    return template;
+  }
+
+  return Object.entries(options).reduce(
+    (message, [name, value]) => message.replaceAll(`{{${name}}}`, String(value)),
+    template,
+  );
+};
+
+function apiErrorFor(code: string, params?: {sourceFlowType?: string; flowType?: string}): Error {
+  return {
+    response: {
+      data: {
+        code,
+        description: params ? {params} : undefined,
+      },
+    },
+  } as unknown as Error;
+}
+
+describe('getApplicationErrorMessage', () => {
+  it('builds an actionable message from APP-1039 params, using the Flows tab labels', () => {
+    const error = apiErrorFor('APP-1039', {sourceFlowType: 'registration', flowType: 'authentication'});
+
+    expect(getApplicationErrorMessage(error, t, 'update.error')).toBe(
+      "The Sign-up Flow references a different Sign-in Flow than the one configured for this application. Update the Sign-up Flow so it calls the same Sign-in Flow, or change the application's Sign-in Flow configuration.",
+    );
+  });
+
+  it('resolves every known flow-type value to its Flows tab label', () => {
+    const error = apiErrorFor('APP-1039', {sourceFlowType: 'recovery', flowType: 'signout'});
+
+    expect(getApplicationErrorMessage(error, t, 'update.error')).toBe(
+      "The Recovery Flow references a different Sign Out Flow than the one configured for this application. Update the Recovery Flow so it calls the same Sign Out Flow, or change the application's Sign Out Flow configuration.",
+    );
+  });
+
+  it('falls back to the generic message when APP-1039 has no params', () => {
+    const error = apiErrorFor('APP-1039');
+
+    expect(getApplicationErrorMessage(error, t, 'update.error')).toBe('Failed to update the application.');
+  });
+
+  it('falls back to the generic message when a flow-type value is unrecognized', () => {
+    const error = apiErrorFor('APP-1039', {sourceFlowType: 'user_onboarding', flowType: 'authentication'});
+
+    expect(getApplicationErrorMessage(error, t, 'update.error')).toBe('Failed to update the application.');
+  });
+
+  it('falls back to the generic message for unrelated error codes', () => {
+    const error = apiErrorFor('APP-1020');
+
+    expect(getApplicationErrorMessage(error, t, 'update.error')).toBe('Failed to update the application.');
+  });
+
+  it('falls back to the generic message when there is no response data', () => {
+    const error = new Error('Network Error');
+
+    expect(getApplicationErrorMessage(error, t, 'update.error')).toBe('Failed to update the application.');
+  });
+});

--- a/frontend/apps/console/src/features/applications/utils/getApplicationErrorMessage.ts
+++ b/frontend/apps/console/src/features/applications/utils/getApplicationErrorMessage.ts
@@ -1,0 +1,74 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {getErrorMessage} from '@thunderid/utils';
+
+/**
+ * The subset of the APP-1039 (flow mismatch) API error response this util reads.
+ */
+interface FlowMismatchApiError {
+  code: string;
+  description?: {
+    params?: {
+      sourceFlowType?: string;
+      flowType?: string;
+    };
+  };
+}
+
+const FLOW_MISMATCH_ERROR_CODE = 'APP-1039';
+
+/**
+ * Maps the raw flow-type values the backend sends in APP-1039's params
+ * to the i18n keys already used for the same flows on the application's Flows tab.
+ */
+const FLOW_TYPE_LABEL_KEYS: Record<string, string> = {
+  authentication: 'edit.flows.labels.authFlow',
+  registration: 'edit.flows.labels.registrationFlow',
+  recovery: 'edit.flows.labels.recoveryFlow',
+  signout: 'edit.flows.labels.signOutFlow',
+};
+
+/**
+ * Extracts a localized error message from an application API error response, with a dedicated,
+ * actionable message for APP-1039 (conflicting flow references).
+ *
+ * For APP-1039, builds the message from the error's `sourceFlowType`/`flowType` params,
+ * translated into the same flow labels shown on the application's Flows tab (e.g. "Sign-up Flow",
+ * "Recovery Flow"), instead of using the backend's generic description text. Falls back to
+ * {@link getErrorMessage} for every other error, and for APP-1039 responses without usable params.
+ *
+ * @param error - The error thrown by the mutation
+ * @param t - The i18next translation function scoped to the relevant namespace
+ * @param fallbackKey - i18n key to use when no specific message is found (e.g. `'create.error'`)
+ * @returns Localized error message string
+ *
+ * @public
+ */
+export default function getApplicationErrorMessage(
+  error: Error,
+  t: (key: string, options?: Record<string, unknown>) => string,
+  fallbackKey: string,
+): string {
+  const apiError = (error as {response?: {data?: FlowMismatchApiError}}).response?.data;
+
+  if (apiError?.code === FLOW_MISMATCH_ERROR_CODE) {
+    const sourceFlowType = apiError.description?.params?.sourceFlowType?.toLowerCase();
+    const flowType = apiError.description?.params?.flowType?.toLowerCase();
+    const sourceLabelKey = sourceFlowType ? FLOW_TYPE_LABEL_KEYS[sourceFlowType] : undefined;
+    const flowLabelKey = flowType ? FLOW_TYPE_LABEL_KEYS[flowType] : undefined;
+
+    if (sourceLabelKey && flowLabelKey) {
+      return t(`errors.${FLOW_MISMATCH_ERROR_CODE}`, {
+        sourceFlowType: t(sourceLabelKey),
+        flowType: t(flowLabelKey),
+      });
+    }
+
+    // Skip the generic code-based lookup: it would resolve the same errors.APP-1039 key and
+    // return its {{sourceFlowType}}/{{flowType}} placeholders unresolved.
+    return t(fallbackKey);
+  }
+
+  return getErrorMessage(error, t, fallbackKey);
+}

--- a/frontend/packages/contexts/src/Toast/ToastContext.tsx
+++ b/frontend/packages/contexts/src/Toast/ToastContext.tsx
@@ -21,8 +21,9 @@ export interface ToastContextType {
    *
    * @param message - The text to display inside the toast
    * @param severity - The visual style of the toast. Defaults to `'success'`
+   * @param durationMs - How long the toast stays open, in milliseconds. Defaults to 6000
    */
-  showToast: (message: string, severity?: ToastSeverity) => void;
+  showToast: (message: string, severity?: ToastSeverity, durationMs?: number) => void;
 }
 
 /**

--- a/frontend/packages/contexts/src/Toast/ToastProvider.tsx
+++ b/frontend/packages/contexts/src/Toast/ToastProvider.tsx
@@ -13,7 +13,10 @@ interface ToastState {
   open: boolean;
   message: string;
   severity: ToastSeverity;
+  durationMs: number;
 }
+
+const DEFAULT_TOAST_DURATION_MS = 6000;
 
 /**
  * Props for the ToastProvider component.
@@ -70,11 +73,15 @@ export default function ToastProvider({children}: ToastProviderProps): JSX.Eleme
     open: false,
     message: '',
     severity: 'success',
+    durationMs: DEFAULT_TOAST_DURATION_MS,
   });
 
-  const showToast = useCallback((message: string, severity: ToastSeverity = 'success'): void => {
-    setToast({open: true, message, severity});
-  }, []);
+  const showToast = useCallback(
+    (message: string, severity: ToastSeverity = 'success', durationMs: number = DEFAULT_TOAST_DURATION_MS): void => {
+      setToast({open: true, message, severity, durationMs});
+    },
+    [],
+  );
 
   const handleClose = useCallback((_event?: SyntheticEvent | Event, reason?: string): void => {
     if (reason === 'clickaway') return;
@@ -88,7 +95,7 @@ export default function ToastProvider({children}: ToastProviderProps): JSX.Eleme
       {children}
       <Snackbar
         open={toast.open}
-        autoHideDuration={6000}
+        autoHideDuration={toast.durationMs}
         onClose={handleClose}
         anchorOrigin={{vertical: 'bottom', horizontal: 'right'}}
       >

--- a/frontend/packages/contexts/src/Toast/__tests__/ToastProvider.test.tsx
+++ b/frontend/packages/contexts/src/Toast/__tests__/ToastProvider.test.tsx
@@ -1,0 +1,210 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {act, useEffect} from 'react';
+import {createRoot, type Root} from 'react-dom/client';
+import {beforeEach, afterEach, describe, expect, it, vi} from 'vitest';
+import type {ToastSeverity} from '../ToastContext';
+import ToastProvider from '../ToastProvider';
+import useToast from '../useToast';
+
+const DEFAULT_DURATION_MS = 6000;
+const LONG_DURATION_MS = 12000;
+
+// Long enough for the snackbar's exit transition to finish and unmount the node.
+const EXIT_TRANSITION_MS = 300;
+
+let container: HTMLDivElement;
+let root: Root;
+let showToast: (message: string, severity?: ToastSeverity, durationMs?: number) => void;
+
+/**
+ * Captures the context's showToast so tests can drive the provider the way callers do.
+ */
+function ToastTrigger() {
+  const {showToast: contextShowToast} = useToast();
+
+  useEffect(() => {
+    showToast = contextShowToast;
+  }, [contextShowToast]);
+
+  return <span data-testid="child">child</span>;
+}
+
+function renderProvider(): void {
+  act(() => {
+    root.render(
+      <ToastProvider>
+        <ToastTrigger />
+      </ToastProvider>,
+    );
+  });
+}
+
+function show(message: string, severity?: ToastSeverity, durationMs?: number): void {
+  act(() => {
+    showToast(message, severity, durationMs);
+  });
+}
+
+function advance(ms: number): void {
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+}
+
+// The snackbar renders through a portal, so it lives outside `container`.
+function getAlert(): HTMLElement | null {
+  return document.querySelector<HTMLElement>('.MuiAlert-root');
+}
+
+/**
+ * The snackbar stays mounted while it transitions out, so presence alone does not mean
+ * the toast is still up. Once auto-hide fires, the alert is faded to `opacity: 0`.
+ */
+function isToastVisible(): boolean {
+  const alert = getAlert();
+  return alert !== null && alert.style.opacity !== '0';
+}
+
+function getAlertText(): string {
+  return document.querySelector('.MuiAlert-message')?.textContent ?? '';
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({toFake: ['setTimeout', 'clearTimeout']});
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  vi.useRealTimers();
+});
+
+describe('ToastProvider', () => {
+  it('renders its children and shows no toast until one is requested', () => {
+    renderProvider();
+
+    expect(container.querySelector('[data-testid="child"]')?.textContent).toBe('child');
+    expect(getAlert()).toBeNull();
+  });
+
+  it('shows the requested message', () => {
+    renderProvider();
+    show('Saved successfully.');
+
+    expect(getAlertText()).toBe('Saved successfully.');
+    expect(isToastVisible()).toBe(true);
+  });
+
+  it('defaults to the success severity', () => {
+    renderProvider();
+    show('Saved successfully.');
+
+    expect(getAlert()?.className).toContain('MuiAlert-colorSuccess');
+  });
+
+  it('applies the requested severity', () => {
+    renderProvider();
+    show('Something went wrong.', 'error');
+
+    expect(getAlert()?.className).toContain('MuiAlert-colorError');
+  });
+
+  it('replaces the current toast when a new one is requested', () => {
+    renderProvider();
+    show('Saved successfully.');
+    show('Something went wrong.', 'error');
+
+    expect(getAlertText()).toBe('Something went wrong.');
+    expect(getAlert()?.className).toContain('MuiAlert-colorError');
+  });
+
+  it('auto hides after the default duration when none is given', () => {
+    renderProvider();
+    show('Saved successfully.');
+
+    advance(DEFAULT_DURATION_MS - 1);
+    expect(isToastVisible()).toBe(true);
+
+    advance(1);
+    expect(isToastVisible()).toBe(false);
+  });
+
+  it('unmounts the toast once it has transitioned out', () => {
+    renderProvider();
+    show('Saved successfully.');
+
+    advance(DEFAULT_DURATION_MS);
+    // The exit transition is only scheduled once the close has been applied.
+    advance(EXIT_TRANSITION_MS);
+
+    expect(getAlert()).toBeNull();
+  });
+
+  it('keeps a longer toast up past the default duration and hides it at the requested one', () => {
+    renderProvider();
+    show('A much longer error message that needs more reading time.', 'error', LONG_DURATION_MS);
+
+    advance(DEFAULT_DURATION_MS);
+    expect(isToastVisible()).toBe(true);
+
+    advance(LONG_DURATION_MS - DEFAULT_DURATION_MS - 1);
+    expect(isToastVisible()).toBe(true);
+
+    advance(1);
+    expect(isToastVisible()).toBe(false);
+  });
+
+  it('applies the duration of the most recent toast rather than the previous one', () => {
+    renderProvider();
+    show('Long lived error.', 'error', LONG_DURATION_MS);
+    show('Short lived success.');
+
+    expect(getAlertText()).toBe('Short lived success.');
+
+    advance(DEFAULT_DURATION_MS);
+    expect(isToastVisible()).toBe(false);
+  });
+
+  it('dismisses the toast when the close button is clicked', () => {
+    renderProvider();
+    show('Saved successfully.');
+
+    const closeButton = document.querySelector<HTMLButtonElement>('.MuiAlert-action button');
+    expect(closeButton).not.toBeNull();
+
+    act(() => {
+      closeButton?.click();
+    });
+
+    expect(isToastVisible()).toBe(false);
+  });
+
+  it('keeps the toast up when the user clicks away from it', () => {
+    renderProvider();
+    show('Saved successfully.');
+
+    // The click-away listener activates on a zero-delay timer, so let that settle first.
+    advance(1);
+
+    act(() => {
+      document.body.dispatchEvent(new MouseEvent('click', {bubbles: true}));
+    });
+
+    expect(isToastVisible()).toBe(true);
+  });
+
+  it('throws when useToast is used outside a provider', () => {
+    expect(() => {
+      act(() => {
+        root.render(<ToastTrigger />);
+      });
+    }).toThrow('useToast must be used within a ToastProvider');
+  });
+});

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -2843,7 +2843,7 @@ const translations = {
     'errors.APP-1030': 'This application is managed declaratively and cannot be edited or deleted.',
     'errors.APP-1035': 'One or more user attributes are not valid for the selected user types.',
     'errors.APP-1039':
-      "A referenced flow does not match the application's flow configuration. Ensure the registration and authentication flows are consistent.",
+      "The {{sourceFlowType}} references a different {{flowType}} than the one configured for this application. Update the {{sourceFlowType}} so it calls the same {{flowType}}, or change the application's {{flowType}} configuration.",
   },
 
   // ============================================================================


### PR DESCRIPTION
### Purpose

Makes the console's `APP-1039` "Conflicting flow references" error message specific and actionable.

`APP-1039` is returned when one of an application's configured flows reaches, via a `CALL` node, a different flow of some type than the one bound on the application itself. A common trigger is a sign-in flow whose "forgot password" link calls a recovery flow other than the one configured on the application.

The console showed one hardcoded sentence for every occurrence:

> A referenced flow does not match the application's flow configuration. Ensure the registration and authentication flows are consistent.

That names registration and authentication regardless of which flows actually conflict, so it is misleading whenever the conflict involves the recovery or sign-out flow, and it gives the user no next step.

The message now names the exact two flows involved, using the same labels shown on the application's Flows tab:

> The Sign-in Flow references a different Recovery Flow than the one configured for this application. Update the Sign-in Flow so it calls the same Recovery Flow, or change the application's Recovery Flow configuration.

### Approach

The backend already reports which two flow types conflict as machine readable params on the error description, alongside the pre-interpolated `defaultValue`:

```json
{
  "code": "APP-1039",
  "message": {
    "key": "error.applicationservice.application_flow_mismatch",
    "defaultValue": "Conflicting flow references"
  },
  "description": {
    "key": "error.applicationservice.application_flow_mismatch_description",
    "defaultValue": "The registration flow references a different authentication flow than the one configured on the application. Both must point to the same authentication flow.",
    "params": {"sourceFlowType": "registration", "flowType": "authentication"}
  }
}
```

The message is built on the client from `params` rather than by surfacing the backend's `defaultValue`, so the copy stays translatable and stays in the console's own vocabulary.

Key decisions:

- **Map flow types to existing Flows tab labels.** `sourceFlowType` and `flowType` arrive as lowercased `providers.FlowType` values (`authentication`, `registration`, `recovery`, `signout`). Each maps to the i18n key already used for that section on the application's Flows tab, so the error names the exact sections the user needs to reconcile rather than introducing new vocabulary.
- **A feature-scoped util, not a change to the shared `getErrorMessage`.** `getApplicationErrorMessage` special cases `APP-1039` and delegates to the shared `getErrorMessage` for everything else. The shared util resolves a static string per error code and has no interpolation support; teaching it about per-code params would push application-specific knowledge into a generic helper used across the console.
- **Type the params shape locally.** The shared `ApiError` type in `@thunderid/types` declares `message`/`description` as flat strings, while the backend sends `I18nMessage` objects. Widening the shared type reaches unrelated consumers, so only the fields this util reads are typed here. `configure-organization-units` already models the richer shape locally in the same way.
- **Fall back rather than render a half-built message.** When `APP-1039` arrives without usable params, or with a flow type outside the mapped set (for example a future `USER_ONBOARDING`), the util returns the generic fallback. It deliberately skips the shared code-based lookup in that path, since that would resolve the same `errors.APP-1039` key and emit its `{{sourceFlowType}}`/`{{flowType}}` placeholders unresolved.
- **Optional per-toast duration.** `showToast` gained an optional third argument so the longer message has time to be read. The application create and update error toasts pass 12s; every other caller in the console is untouched and keeps the existing 6s default.

Note that the error toast duration is raised for all errors from these two mutations, not only `APP-1039`, so a short message such as "The JWKS URL must use HTTPS." also stays up for 12s.

### Related Issues
- N/A

### Related PRs
- #4428 — earlier pass that wired the applications feature to the shared error catalog.

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toast notifications can remain visible for a configurable duration.
  * Application creation and update errors now provide clearer, flow-specific guidance.

* **Bug Fixes**
  * Improved handling of application flow mismatch errors, including helpful fallback messages when details are unavailable.
  * Updated English messages to identify referenced and configured flow types.

* **Tests**
  * Added coverage for flow-specific errors, missing details, unknown values, fallback scenarios, and toast behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->