### PR TITLE
Make the confirmation prompt action type generic

### DIFF
--- a/backend/internal/flow/common/constants.go
+++ b/backend/internal/flow/common/constants.go
@@ -272,11 +272,12 @@ const (
 	ActionTypeSubmit ActionType = "SUBMIT"
 	// ActionTypeReject represents a reject/deny action
 	ActionTypeReject ActionType = "REJECT"
-	// ActionTypeSignOutConfirm marks the confirmation prompt's action edge in a sign-out flow. When the
-	// End-User confirms, the prompt node forwards this type to the session sign-out node (as the action
-	// type in ForwardedData), which reads it to tell a confirmed re-run apart from the initial request,
-	// so no runtime flag has to be persisted.
-	ActionTypeSignOutConfirm ActionType = "SIGN_OUT_CONFIRM"
+	// ActionTypeConfirm marks a confirmation prompt's action edge. When the End-User confirms, the
+	// prompt node forwards this type to the next node (as the action type in ForwardedData), where the
+	// executor that routed to the prompt reads it to tell a confirmed re-run apart from the initial
+	// request, so no runtime flag has to be persisted. It is deliberately not tied to one use case:
+	// the session sign-out executor is its first consumer, not its only possible one.
+	ActionTypeConfirm ActionType = "CONFIRM"
 )
 
 // ForwardedData key constants define keys used in the ForwardedData map.

--- a/backend/internal/flow/executor/session_signout_executor.go
+++ b/backend/internal/flow/executor/session_signout_executor.go
@@ -115,7 +115,7 @@ func (e *sessionSignOutExecutor) decide(ctx *providers.NodeContext) signOutOutco
 
 	actionType, _ := ctx.ForwardedData[common.ForwardedDataKeyActionType].(string)
 	switch common.ActionType(actionType) {
-	case common.ActionTypeSignOutConfirm:
+	case common.ActionTypeConfirm:
 		return signOutTerminate
 	default:
 		// The initial request forwards no action type at all, and a type this executor does not

--- a/backend/internal/flow/executor/session_signout_executor_test.go
+++ b/backend/internal/flow/executor/session_signout_executor_test.go
@@ -115,7 +115,7 @@ func (suite *SessionSignOutExecutorTestSuite) TestPromptsWhenConfirmationRequire
 }
 
 // TestTerminatesAfterConfirmation covers the re-run after the End-User confirms: the confirmation
-// prompt forwards its sign-out confirm action type, so the executor terminates the session instead of
+// prompt forwards its confirm action type, so the executor terminates the session instead of
 // prompting again.
 func (suite *SessionSignOutExecutorTestSuite) TestTerminatesAfterConfirmation() {
 	sso := sessionmock.NewServiceMock(suite.T())
@@ -127,7 +127,7 @@ func (suite *SessionSignOutExecutorTestSuite) TestTerminatesAfterConfirmation() 
 	ctx.NodeProperties = map[string]interface{}{propertyKeyPromptOnSignOut: true}
 	ctx.RuntimeData = map[string]string{common.RuntimeKeyLogoutPromptRequired: dataValueTrue}
 	ctx.ForwardedData = map[string]interface{}{
-		common.ForwardedDataKeyActionType: string(common.ActionTypeSignOutConfirm),
+		common.ForwardedDataKeyActionType: string(common.ActionTypeConfirm),
 	}
 
 	resp, err := exec.Execute(ctx)

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/CommonResourceProperties.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/CommonResourceProperties.test.tsx
@@ -95,7 +95,7 @@ describe('CommonResourceProperties', () => {
         <button type="button" onClick={() => onChange('label', 'New Label', resource)}>
           Change Label
         </button>
-        <button type="button" onClick={() => onChange('actionType', 'SIGN_OUT_CONFIRM', resource)}>
+        <button type="button" onClick={() => onChange('actionType', 'CONFIRM', resource)}>
           Change Action Type
         </button>
         <button
@@ -245,7 +245,7 @@ describe('CommonResourceProperties', () => {
       // generic field.
       const resourceWithActionType: Base = {
         ...mockBaseResource,
-        actionType: 'SIGN_OUT_CONFIRM',
+        actionType: 'CONFIRM',
       } as Base & {actionType: string};
 
       render(<CommonResourceProperties />, {
@@ -409,7 +409,7 @@ describe('CommonResourceProperties', () => {
       const updated = mockSetLastInteractedResource.mock.calls.at(-1)?.[0] as Record<string, unknown> & {
         data?: Record<string, unknown>;
       };
-      expect(updated.actionType).toBe('SIGN_OUT_CONFIRM');
+      expect(updated.actionType).toBe('CONFIRM');
       expect(updated.data?.actionType).toBeUndefined();
     });
 

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/ButtonExtendedProperties.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/ButtonExtendedProperties.tsx
@@ -10,12 +10,14 @@ import {ActionEventTypes, PromptActionTypes} from '@/features/flows/models/eleme
 
 /**
  * The options offered by the Action selector. `Submit` and `Trigger` are the
- * button's `eventType`; `SignOut` is a submit button that additionally raises
- * the `SIGN_OUT_CONFIRM` prompt action, so one selection maps onto two fields.
+ * button's `eventType`; `Confirm` is a submit button that additionally raises
+ * the `CONFIRM` prompt action, so one selection maps onto two fields.
  *
- * `SignOut` deliberately carries the same literal that is persisted as
+ * `Confirm` deliberately carries the same literal that is persisted as
  * `prompts[].action.type`, so the value selected here and the value in the flow
- * definition are one vocabulary rather than a UI-only alias.
+ * definition are one vocabulary rather than a UI-only alias. It is not specific
+ * to signing out: the session sign-out executor reads it today, but any executor
+ * that routes to a confirmation prompt can.
  *
  * The remaining `ActionEventTypes` (navigate, cancel, reset, back) are handled
  * by the SDK renderers but deliberately not offered here.
@@ -23,7 +25,7 @@ import {ActionEventTypes, PromptActionTypes} from '@/features/flows/models/eleme
 const ACTION_OPTIONS = {
   Submit: 'SUBMIT',
   Trigger: 'TRIGGER',
-  SignOut: PromptActionTypes.SignOutConfirm,
+  Confirm: PromptActionTypes.Confirm,
 } as const;
 
 type ActionOption = (typeof ACTION_OPTIONS)[keyof typeof ACTION_OPTIONS];
@@ -46,28 +48,28 @@ function ButtonExtendedProperties({resource, onChange}: ButtonExtendedProperties
   const element = resource as Element & {eventType?: string};
   const eventTypeValue = element?.eventType ?? ActionEventTypes.Trigger;
 
-  // Sign out is a submit button carrying an extra prompt action type, so it
+  // Confirm is a submit button carrying an extra prompt action type, so it
   // takes precedence over the plain event type when deriving the selection.
   const actionValue: ActionOption =
-    element?.actionType === PromptActionTypes.SignOutConfirm
-      ? ACTION_OPTIONS.SignOut
+    element?.actionType === PromptActionTypes.Confirm
+      ? ACTION_OPTIONS.Confirm
       : eventTypeValue === ActionEventTypes.Submit
         ? ACTION_OPTIONS.Submit
         : ACTION_OPTIONS.Trigger;
 
   const handleActionChange = (nextAction: ActionOption): void => {
-    if (nextAction === ACTION_OPTIONS.SignOut) {
+    if (nextAction === ACTION_OPTIONS.Confirm) {
       onChange('eventType', ActionEventTypes.Submit, resource);
-      onChange('actionType', PromptActionTypes.SignOutConfirm, resource);
+      onChange('actionType', PromptActionTypes.Confirm, resource);
       return;
     }
 
     onChange('eventType', nextAction, resource);
-    // Clearing keeps the button from silently staying a sign-out confirmation
+    // Clearing keeps the button from silently staying a confirmation action
     // after the author picks a plain action. Only the type this selector owns is
     // cleared, so an action type it does not model (e.g. REJECT, authored in the
     // flow definition directly) is left untouched rather than discarded.
-    if (element?.actionType === PromptActionTypes.SignOutConfirm) {
+    if (element?.actionType === PromptActionTypes.Confirm) {
       onChange('actionType', '', resource);
     }
   };
@@ -125,8 +127,8 @@ function ButtonExtendedProperties({resource, onChange}: ButtonExtendedProperties
           <MenuItem value={ACTION_OPTIONS.Trigger}>
             {t('flows:core.buttonExtendedProperties.action.trigger', 'Trigger Action')}
           </MenuItem>
-          <MenuItem value={ACTION_OPTIONS.SignOut}>
-            {t('flows:core.buttonExtendedProperties.action.signOut', 'Sign Out Action')}
+          <MenuItem value={ACTION_OPTIONS.Confirm}>
+            {t('flows:core.buttonExtendedProperties.action.confirm', 'Confirm Action')}
           </MenuItem>
         </Select>
         <FormHelperText>

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/__tests__/ButtonExtendedProperties.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/__tests__/ButtonExtendedProperties.test.tsx
@@ -218,37 +218,37 @@ describe('ButtonExtendedProperties', () => {
       expect(select).toHaveTextContent('flows:core.buttonExtendedProperties.action.submit');
     });
 
-    it('should display Sign out when the button carries the sign-out confirm action', () => {
-      // A sign-out button is a submit button plus the prompt action type, so
+    it('should display Confirm when the button carries the confirm action', () => {
+      // A confirmation button is a submit button plus the prompt action type, so
       // the action type has to win over the plain event type.
       const resource = createMockResource({
-        actionType: 'SIGN_OUT_CONFIRM',
+        actionType: 'CONFIRM',
         eventType: 'SUBMIT',
       } as Partial<Resource>);
 
       const {container} = render(<ButtonExtendedProperties resource={resource} onChange={mockOnChange} />);
 
       const select = container.querySelector('#event-type-select');
-      expect(select).toHaveTextContent('flows:core.buttonExtendedProperties.action.signOut');
+      expect(select).toHaveTextContent('flows:core.buttonExtendedProperties.action.confirm');
     });
 
-    it('should write both the event type and the action type when Sign out is picked', async () => {
+    it('should write both the event type and the action type when Confirm is picked', async () => {
       const user = userEvent.setup();
       const resource = createMockResource({eventType: 'TRIGGER'} as Partial<Resource>);
 
       render(<ButtonExtendedProperties resource={resource} onChange={mockOnChange} />);
 
       await user.click(screen.getByRole('combobox'));
-      await user.click(screen.getByRole('option', {name: 'flows:core.buttonExtendedProperties.action.signOut'}));
+      await user.click(screen.getByRole('option', {name: 'flows:core.buttonExtendedProperties.action.confirm'}));
 
       expect(mockOnChange).toHaveBeenCalledWith('eventType', 'SUBMIT', resource);
-      expect(mockOnChange).toHaveBeenCalledWith('actionType', 'SIGN_OUT_CONFIRM', resource);
+      expect(mockOnChange).toHaveBeenCalledWith('actionType', 'CONFIRM', resource);
     });
 
-    it('should clear the action type when moving from Sign out back to a plain action', async () => {
+    it('should clear the action type when moving from Confirm back to a plain action', async () => {
       const user = userEvent.setup();
       const resource = createMockResource({
-        actionType: 'SIGN_OUT_CONFIRM',
+        actionType: 'CONFIRM',
         eventType: 'SUBMIT',
       } as Partial<Resource>);
 

--- a/frontend/apps/console/src/features/flows/data/templates.json
+++ b/frontend/apps/console/src/features/flows/data/templates.json
@@ -13177,7 +13177,7 @@
                 "category": "BLOCK",
                 "components": [
                   {
-                    "actionType": "SIGN_OUT_CONFIRM",
+                    "actionType": "CONFIRM",
                     "category": "ACTION",
                     "eventType": "SUBMIT",
                     "id": "action_confirm",
@@ -13197,7 +13197,7 @@
             {
               "action": {
                 "ref": "action_confirm",
-                "type": "SIGN_OUT_CONFIRM",
+                "type": "CONFIRM",
                 "nextNode": "session_signout"
               }
             }

--- a/frontend/apps/console/src/features/flows/models/elements.ts
+++ b/frontend/apps/console/src/features/flows/models/elements.ts
@@ -135,9 +135,13 @@ export type ActionEventTypes = (typeof ActionEventTypes)[keyof typeof ActionEven
  * executor as edge metadata. Distinct from {@link ActionEventTypes}, which
  * describes how the button behaves in the rendered form, and from
  * `action.type` on the element, which carries canvas navigation semantics.
+ *
+ * The values are deliberately not tied to a single use case: `Confirm` is read
+ * by the session sign-out executor today, but any executor that routes to a
+ * confirmation prompt can consume it.
  */
 export const PromptActionTypes = {
-  SignOutConfirm: 'SIGN_OUT_CONFIRM',
+  Confirm: 'CONFIRM',
 } as const;
 
 export type PromptActionTypes = (typeof PromptActionTypes)[keyof typeof PromptActionTypes];

--- a/frontend/apps/console/src/features/flows/models/responses.ts
+++ b/frontend/apps/console/src/features/flows/models/responses.ts
@@ -138,8 +138,8 @@ export interface FlowNodeAction {
   nextNode: string;
   /**
    * Semantic action type forwarded to the next node's executor (e.g. `SUBMIT`, `REJECT`,
-   * `SIGN_OUT_CONFIRM`). Restored onto the element as `actionType` on load so a definition
-   * authored outside the builder keeps its type when the flow is saved again.
+   * `CONFIRM`). Restored onto the element as `actionType` on load so a definition authored
+   * outside the builder keeps its type when the flow is saved again.
    */
   type?: string;
   /**

--- a/frontend/apps/console/src/features/flows/utils/__tests__/flowToCanvasTransformer.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/flowToCanvasTransformer.test.ts
@@ -458,7 +458,7 @@ describe('flowToCanvasTransformer', () => {
             meta: {
               components: [{id: 'action_confirm', type: 'ACTION', label: 'Sign out'}],
             },
-            prompts: [{action: {ref: 'action_confirm', type: 'SIGN_OUT_CONFIRM', nextNode: 'next-node'}}],
+            prompts: [{action: {ref: 'action_confirm', type: 'CONFIRM', nextNode: 'next-node'}}],
             layout: {position: {x: 0, y: 0}, size: {width: 300, height: 200}},
           },
         ]);
@@ -466,7 +466,7 @@ describe('flowToCanvasTransformer', () => {
         const result = transformFlowToCanvas(flowData);
 
         const component = result.nodes[0].data.components?.[0] as Record<string, unknown> | undefined;
-        expect(component?.actionType).toBe('SIGN_OUT_CONFIRM');
+        expect(component?.actionType).toBe('CONFIRM');
       });
 
       it('should restore the type when the element carries a cleared action type', () => {
@@ -480,7 +480,7 @@ describe('flowToCanvasTransformer', () => {
             meta: {
               components: [{id: 'action_confirm', type: 'ACTION', actionType: '', label: 'Sign out'}],
             },
-            prompts: [{action: {ref: 'action_confirm', type: 'SIGN_OUT_CONFIRM', nextNode: 'next-node'}}],
+            prompts: [{action: {ref: 'action_confirm', type: 'CONFIRM', nextNode: 'next-node'}}],
             layout: {position: {x: 0, y: 0}, size: {width: 300, height: 200}},
           },
         ]);
@@ -488,7 +488,7 @@ describe('flowToCanvasTransformer', () => {
         const result = transformFlowToCanvas(flowData);
 
         const component = result.nodes[0].data.components?.[0] as Record<string, unknown> | undefined;
-        expect(component?.actionType).toBe('SIGN_OUT_CONFIRM');
+        expect(component?.actionType).toBe('CONFIRM');
       });
 
       it('should keep an action type already on the element over the prompt action', () => {
@@ -501,7 +501,7 @@ describe('flowToCanvasTransformer', () => {
             meta: {
               components: [{id: 'action_confirm', type: 'ACTION', actionType: 'REJECT', label: 'No'}],
             },
-            prompts: [{action: {ref: 'action_confirm', type: 'SIGN_OUT_CONFIRM', nextNode: 'next-node'}}],
+            prompts: [{action: {ref: 'action_confirm', type: 'CONFIRM', nextNode: 'next-node'}}],
             layout: {position: {x: 0, y: 0}, size: {width: 300, height: 200}},
           },
         ]);
@@ -758,7 +758,7 @@ describe('flowToCanvasTransformer', () => {
             meta: {
               components: [{id: 'action_confirm', type: 'ACTION', label: 'Sign out'}],
             },
-            prompts: [{action: {ref: 'action_confirm', type: 'SIGN_OUT_CONFIRM', nextNode: 'session_signout'}}],
+            prompts: [{action: {ref: 'action_confirm', type: 'CONFIRM', nextNode: 'session_signout'}}],
             layout: {position: {x: 0, y: 0}, size: {width: 300, height: 200}},
           },
           {
@@ -781,7 +781,7 @@ describe('flowToCanvasTransformer', () => {
         expect(prompt?.prompts?.[0].action).toMatchObject({
           ref: 'action_confirm',
           nextNode: 'session_signout',
-          type: 'SIGN_OUT_CONFIRM',
+          type: 'CONFIRM',
         });
       });
     });

--- a/frontend/apps/console/src/features/flows/utils/__tests__/reactFlowTransformer.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/reactFlowTransformer.test.ts
@@ -248,7 +248,7 @@ describe('reactFlowTransformer', () => {
             type: ElementTypes.Action,
             category: ElementCategories.Action,
             eventType: 'SUBMIT',
-            actionType: 'SIGN_OUT_CONFIRM',
+            actionType: 'CONFIRM',
           } as Element & {eventType: string},
         ];
 
@@ -262,7 +262,7 @@ describe('reactFlowTransformer', () => {
         expect(result.nodes[0].prompts?.[0].action).toEqual({
           ref: 'button-1',
           nextNode: 'session_signout',
-          type: 'SIGN_OUT_CONFIRM',
+          type: 'CONFIRM',
         });
       });
 

--- a/frontend/apps/console/src/features/flows/utils/reactFlowTransformer.ts
+++ b/frontend/apps/console/src/features/flows/utils/reactFlowTransformer.ts
@@ -81,8 +81,8 @@ interface FlowAction {
   nextNode: string;
   /**
    * Semantic action type forwarded by the prompt node to the next executor
-   * (e.g. `SIGN_OUT_CONFIRM`, which tells the session sign-out executor the
-   * End-User has confirmed).
+   * (e.g. `CONFIRM`, which tells the session sign-out executor the End-User
+   * has confirmed).
    */
   type?: string;
   executor?: {

--- a/frontend/apps/console/src/features/flows/validation/__tests__/computeValidationNotifications.test.ts
+++ b/frontend/apps/console/src/features/flows/validation/__tests__/computeValidationNotifications.test.ts
@@ -583,7 +583,7 @@ describe('computeValidationNotifications', () => {
               type: 'BLOCK',
               category: 'BLOCK',
               components: [
-                {id: buttonId, type: 'ACTION', category: 'ACTION', eventType: 'SUBMIT', actionType: 'SIGN_OUT_CONFIRM'},
+                {id: buttonId, type: 'ACTION', category: 'ACTION', eventType: 'SUBMIT', actionType: 'CONFIRM'},
               ],
             },
           ],

--- a/frontend/apps/console/src/features/flows/validation/validation-rules.ts
+++ b/frontend/apps/console/src/features/flows/validation/validation-rules.ts
@@ -346,9 +346,7 @@ function collectSignOutConfirmElements(elements: FlowElement[] | undefined): Flo
   }
 
   return elements.flatMap((element) => [
-    ...((element as FlowElement & {actionType?: string}).actionType === PromptActionTypes.SignOutConfirm
-      ? [element]
-      : []),
+    ...((element as FlowElement & {actionType?: string}).actionType === PromptActionTypes.Confirm ? [element] : []),
     ...collectSignOutConfirmElements(element.components),
   ]);
 }

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -3846,7 +3846,7 @@ const translations = {
     'core.buttonExtendedProperties.action.label': 'Action',
     'core.buttonExtendedProperties.action.submit': 'Submit Form',
     'core.buttonExtendedProperties.action.trigger': 'Trigger Action',
-    'core.buttonExtendedProperties.action.signOut': 'Sign Out Action',
+    'core.buttonExtendedProperties.action.confirm': 'Confirm Action',
     'core.buttonExtendedProperties.action.hint': 'What happens when the button is activated',
     'core.buttonExtendedProperties.startIcon.label': 'Start Icon',
     'core.buttonExtendedProperties.startIcon.placeholder': 'Enter icon path (e.g., assets/images/icons/icon.svg)',


### PR DESCRIPTION
### Purpose
Follow-up to @ThaminduDilshan's review comment on #4480: `SIGN_OUT_CONFIRM` ties the prompt action type to a single use case. This renames it to `CONFIRM` in the backend constant, the console's `PromptActionTypes`, the Conditional Sign Out Flow template, and the flow editor's Action selector option and its i18n key.

Forwarding a prompt action's type to the next node's executor is a generic mechanism, so naming the value after one use case would push every executor that routes to a confirmation prompt to add a near-identical constant of its own (`DELETE_ACCOUNT_CONFIRM`, `CONSENT_CONFIRM`, and so on). `CONFIRM` is the vocabulary; the session sign-out executor is its first consumer, not its only possible one.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
A rename: `common.ActionTypeSignOutConfirm` becomes `common.ActionTypeConfirm` with the value `CONFIRM`, `PromptActionTypes.SignOutConfirm` becomes `PromptActionTypes.Confirm`, and both occurrences in the sign-out template are updated. The doc comments now state that the value is deliberately not tied to one use case. What the executor does, and what the console persists, are unchanged; the only user-visible change is the selector option's label.

### Related Issues
- N/A

### Related PRs
- https://github.com/thunder-id/thunderid/pull/4480
- https://github.com/thunder-id/thunderid/pull/4481

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced the sign-out-specific action with a reusable **Confirm** action for flow buttons and prompts.
  * Updated confirmation controls, labels, templates, and validation to use the new action.
* **Bug Fixes**
  * Confirmation selections now correctly preserve required submit settings and clear when switching to a standard action.
* **Documentation**
  * Updated action descriptions and examples to reflect broader confirmation use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->