### PR TITLE
Introduce CSP baseline with file based config

### DIFF
--- a/backend/cmd/server/config/resources/server_configs/csp.yaml
+++ b/backend/cmd/server/config/resources/server_configs/csp.yaml
@@ -1,0 +1,59 @@
+resource_type: server_config
+name: csp
+value:
+  # Enforcing. This policy applies only to the Console and Gate applications (/console/ and /gate/);
+  # all other responses (APIs, OAuth2 endpoints) receive no Content-Security-Policy header at all.
+  # Each path policy's directives replace the matching baseline directives for that path.
+  reportOnly: false
+  paths:
+    # Console application.
+    - location: "/console/"
+      directives:
+        # 'unsafe-inline' is TEMPORARY: it covers oxygen-ui/MUI/Emotion inline style injection until
+        # nonce-based styling is introduced. Remove 'unsafe-inline' once inline styles are nonce-tagged.
+        style-src:
+          - "'self'"
+          - "'unsafe-inline'"
+          - "https://fonts.googleapis.com"
+        # 'data:' covers inline library images; 'https:' is a TEMPORARY broad allowance for arbitrary
+        # tenant-supplied images. Tighten to a proxy or operator allowlist later.
+        img-src:
+          - "'self'"
+          - "data:"
+          - "https:"
+        # 'data:' covers a bundled library font self-hosted as a base64 URI.
+        # fonts.gstatic.com serves the actual font files referenced by the fonts.googleapis.com stylesheet.
+        font-src:
+          - "'self'"
+          - "data:"
+          - "https://fonts.gstatic.com"
+        # The Console welcome page fetches release metadata from thunderid.dev.
+        # fonts.googleapis.com and fonts.gstatic.com are needed for the GatePreview iframe's preconnect.
+        connect-src:
+          - "'self'"
+          - "https://thunderid.dev"
+          - "https://fonts.googleapis.com"
+          - "https://fonts.gstatic.com"
+        # The Monaco code editor instantiates web workers, which the build may emit as blob URLs.
+        worker-src:
+          - "'self'"
+          - "blob:"
+    # Gate application.
+    - location: "/gate/"
+      directives:
+        # See the Console entry above: 'unsafe-inline' is TEMPORARY (oxygen-ui/MUI/Emotion).
+        style-src:
+          - "'self'"
+          - "'unsafe-inline'"
+          - "https://fonts.googleapis.com"
+        # TEMPORARY broad allowance for arbitrary tenant-supplied images.
+        img-src:
+          - "'self'"
+          - "data:"
+          - "https:"
+        # 'data:' covers a bundled library font self-hosted as a base64 URI.
+        # fonts.gstatic.com serves the actual font files referenced by the fonts.googleapis.com stylesheet.
+        font-src:
+          - "'self'"
+          - "data:"
+          - "https://fonts.gstatic.com"

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -232,11 +232,12 @@ func createHTTPServer(ctx context.Context, logger *log.Logger, cfg *config.Confi
 	securityMiddleware := createSecurityMiddleware(ctx, logger, mux, jwtService, revocationEnforcer)
 
 	// Build the middleware chain with proper execution order.
-	// Request flow: CorrelationID (outermost) -> AccessLog -> Security -> Route Handler (innermost)
+	// Request flow: CorrelationID (outermost) -> SecurityHeaders -> AccessLog -> Security -> Route Handler (innermost)
 	// Note: Middlewares are wrapped in reverse order - the last added will execute first.
 	// The Gate and Console frontend paths are always excluded from the access log to keep it
 	// focused on API traffic. Additional prefixes can be excluded via log.access.exclude_paths.
 	handler := log.AccessLogHandler(logger, accessLogExcludePaths(cfg.Log.Access.ExcludePaths), securityMiddleware)
+	handler = middleware.SecurityHeadersMiddleware()(handler)
 	handler = middleware.CorrelationIDMiddleware(handler)
 
 	// Build the server address using hostname and port from the configurations.

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -72,6 +72,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/cors"
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
+	"github.com/thunder-id/thunderid/internal/system/csp"
 	dbprovider "github.com/thunder-id/thunderid/internal/system/database/provider"
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/email"
@@ -305,6 +306,7 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 		serverconfig.ConfigNameDefaultResourceServer: resource.NewDefaultResourceServerConfigHandler(resourceService),
 		serverconfig.ConfigNameSession:               flowsession.ConfigHandler{},
 		serverconfig.ConfigNameFlow:                  flowConfigHandler,
+		serverconfig.ConfigNameCSP:                   csp.PolicyHandler{},
 	}
 	serverConfigService, serverConfigExporter, err := serverconfig.Initialize(mux, cacheManager, serverConfigHandlers)
 	fatalOnError(ctx, logger, err, "Failed to initialize server config service")
@@ -318,6 +320,9 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	// and the flow executor depend only on providers.ResourceServerProvider, not on serverConfigService.
 	// The base resourceService is still used for resource-management APIs and server-config validation.
 	resourceServerProvider := resource.NewDefaultAwareResourceServerProvider(resourceService, serverConfigService)
+
+	// The security-headers middleware reads the deny-first CSP policy from the server-config csp section.
+	csp.InitializeConfigReader(serverConfigService)
 
 	flowConfig := flowconfig.FromServerRuntime()
 	// The SSO session service revokes a session's token families on sign-out. The criteria revoker is

--- a/backend/internal/oauth/oauth2/authz/init.go
+++ b/backend/internal/oauth/oauth2/authz/init.go
@@ -10,7 +10,6 @@ import (
 	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/par"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/revocation"
-	"github.com/thunder-id/thunderid/internal/system/constants"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
@@ -42,18 +41,11 @@ func Initialize(
 
 // registerRoutes registers the GET /oauth2/authorize route. The POST /oauth2/auth/callback
 // route is registered by the callback package which dispatches by grant type.
+//
+// Clickjacking protection (X-Frame-Options and CSP frame-ancestors, per RFC 9700 §4.16) is applied
+// globally by the security-headers middleware rather than per route, so it is not wrapped here.
 func registerRoutes(mux *http.ServeMux, authzHandler AuthorizeHandlerInterface) {
 	// CORS MUST NOT be enabled on the authorization endpoint.
 	// The client redirects the user agent to it; it is not accessed directly via XHR/fetch.
-	mux.HandleFunc("GET /oauth2/authorize",
-		withFrameProtection(authzHandler.HandleAuthorizeGetRequest))
-}
-
-// withFrameProtection wraps an HTTP handler to prevent the page from being embedded in frames.
-func withFrameProtection(handler http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(constants.XFrameOptionsHeaderName, constants.XFrameOptionsDeny)
-		w.Header().Set(constants.ContentSecurityPolicyHeaderName, constants.ContentSecurityPolicyFrameAncestorsNone)
-		handler(w, r)
-	}
+	mux.HandleFunc("GET /oauth2/authorize", authzHandler.HandleAuthorizeGetRequest)
 }

--- a/backend/internal/oauth/oauth2/authz/init_test.go
+++ b/backend/internal/oauth/oauth2/authz/init_test.go
@@ -5,7 +5,6 @@ package authz
 
 import (
 	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"testing"
 
@@ -146,20 +145,4 @@ func (suite *InitTestSuite) TestRegisterRoutes_CORSConfiguration() {
 			}
 		})
 	}
-}
-
-func (suite *InitTestSuite) TestWithFrameProtection() {
-	// RFC 9700 §4.16: Authorization servers MUST prevent clickjacking attacks.
-	handler := withFrameProtection(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
-	req := httptest.NewRequest("GET", "/oauth2/authorize", nil)
-	rec := httptest.NewRecorder()
-
-	handler(rec, req)
-
-	assert.Equal(suite.T(), http.StatusOK, rec.Code)
-	assert.Equal(suite.T(), "DENY", rec.Header().Get("X-Frame-Options"))
-	assert.Equal(suite.T(), "frame-ancestors 'none'", rec.Header().Get("Content-Security-Policy"))
 }

--- a/backend/internal/serverconfig/constants.go
+++ b/backend/internal/serverconfig/constants.go
@@ -16,6 +16,8 @@ const (
 	ConfigNameSession ConfigName = "session"
 	// ConfigNameFlow is the configuration key for the flow defaults.
 	ConfigNameFlow ConfigName = "flow"
+	// ConfigNameCSP is the configuration key for the deny-first Content-Security-Policy baseline.
+	ConfigNameCSP ConfigName = "csp"
 )
 
 // supportedConfigNames lists all the supported server configuration names.
@@ -24,6 +26,7 @@ var supportedConfigNames = []ConfigName{
 	ConfigNameDefaultResourceServer,
 	ConfigNameSession,
 	ConfigNameFlow,
+	ConfigNameCSP,
 }
 
 // IsValid reports whether the config name is one of the supported values.

--- a/backend/internal/system/constants/server_constants.go
+++ b/backend/internal/system/constants/server_constants.go
@@ -67,8 +67,8 @@ const XFrameOptionsDeny = "DENY"
 // ContentSecurityPolicyHeaderName is the name of the Content-Security-Policy header used in HTTP responses.
 const ContentSecurityPolicyHeaderName = "Content-Security-Policy"
 
-// ContentSecurityPolicyFrameAncestorsNone is the CSP directive that prevents the page from being embedded in frames.
-const ContentSecurityPolicyFrameAncestorsNone = "frame-ancestors 'none'"
+// ContentSecurityPolicyReportOnlyHeaderName is the name of the Content-Security-Policy-Report-Only header.
+const ContentSecurityPolicyReportOnlyHeaderName = "Content-Security-Policy-Report-Only"
 
 // CacheControlHeaderName is the name of the cache-control header used in HTTP responses.
 const CacheControlHeaderName = "Cache-Control"

--- a/backend/internal/system/csp/handler.go
+++ b/backend/internal/system/csp/handler.go
@@ -1,0 +1,86 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package csp
+
+import "encoding/json"
+
+// PolicyHandler decodes, validates, and merges the "csp" server-config section. It implements the
+// section-handler contract structurally, without importing the serverconfig package.
+type PolicyHandler struct{}
+
+// Decode parses a raw JSON csp value into PolicyConfig. Empty input yields the zero value, the
+// deny-first baseline in report-only mode.
+func (PolicyHandler) Decode(raw json.RawMessage) (any, error) {
+	if len(raw) == 0 {
+		return PolicyConfig{}, nil
+	}
+	var cfg PolicyConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// Validate checks that the incoming value is an acceptable csp policy.
+func (PolicyHandler) Validate(incoming, _, _ any) error {
+	cfg, _ := incoming.(PolicyConfig)
+	return cfg.Validate()
+}
+
+// Merge overlays the writable (db) layer onto the read-only (declarative) layer: an explicit writable
+// value wins per field, directive, and path.
+func (PolicyHandler) Merge(readOnly, writable any) any {
+	ro, _ := readOnly.(PolicyConfig)
+	wr, _ := writable.(PolicyConfig)
+
+	merged := PolicyConfig{ReportOnly: ro.ReportOnly, ReportURI: ro.ReportURI}
+	if wr.ReportOnly != nil {
+		merged.ReportOnly = wr.ReportOnly
+	}
+	if wr.ReportURI != "" {
+		merged.ReportURI = wr.ReportURI
+	}
+	merged.Directives = mergeDirectives(ro.Directives, wr.Directives)
+	merged.Paths = mergePaths(ro.Paths, wr.Paths)
+	return merged
+}
+
+// mergePaths overlays writable path policies onto read-only ones by prefix: a match replaces the
+// read-only entry; entries present in only one layer are kept. Returns nil when both are empty.
+func mergePaths(readOnly, writable []PathPolicy) []PathPolicy {
+	if len(readOnly) == 0 && len(writable) == 0 {
+		return nil
+	}
+	byPrefix := make(map[string]map[string][]string, len(readOnly)+len(writable))
+	order := make([]string, 0, len(readOnly)+len(writable))
+	for _, layer := range [][]PathPolicy{readOnly, writable} {
+		for _, p := range layer {
+			if _, seen := byPrefix[p.Location]; !seen {
+				order = append(order, p.Location)
+			}
+			byPrefix[p.Location] = p.Directives
+		}
+	}
+	out := make([]PathPolicy, 0, len(order))
+	for _, prefix := range order {
+		out = append(out, PathPolicy{Location: prefix, Directives: byPrefix[prefix]})
+	}
+	return out
+}
+
+// mergeDirectives overlays writable directives onto read-only ones: a directive in the writable layer
+// replaces the read-only entry for that directive. Returns nil when both layers are empty.
+func mergeDirectives(readOnly, writable map[string][]string) map[string][]string {
+	if len(readOnly) == 0 && len(writable) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(readOnly)+len(writable))
+	for name, sources := range readOnly {
+		out[name] = sources
+	}
+	for name, sources := range writable {
+		out[name] = sources
+	}
+	return out
+}

--- a/backend/internal/system/csp/handler_test.go
+++ b/backend/internal/system/csp/handler_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package csp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPolicyHandler_Decode(t *testing.T) {
+	t.Run("empty input yields the zero policy", func(t *testing.T) {
+		v, err := PolicyHandler{}.Decode(nil)
+		require.NoError(t, err)
+		assert.Equal(t, PolicyConfig{}, v)
+	})
+
+	t.Run("valid JSON decodes", func(t *testing.T) {
+		v, err := PolicyHandler{}.Decode([]byte(`{"reportOnly":false,"reportUri":"/r","directives":{"img-src":["x"]}}`))
+		require.NoError(t, err)
+		cfg, ok := v.(PolicyConfig)
+		require.True(t, ok)
+		assert.False(t, cfg.EffectiveReportOnly())
+		assert.Equal(t, "/r", cfg.ReportURI)
+		assert.Equal(t, []string{"x"}, cfg.Directives["img-src"])
+	})
+
+	t.Run("invalid JSON errors", func(t *testing.T) {
+		_, err := PolicyHandler{}.Decode([]byte(`{bad`))
+		assert.Error(t, err)
+	})
+}
+
+func TestPolicyHandler_Validate(t *testing.T) {
+	assert.NoError(t, PolicyHandler{}.Validate(PolicyConfig{}, nil, nil))
+	// Any directive may be configured, including default-src.
+	assert.NoError(t, PolicyHandler{}.Validate(
+		PolicyConfig{Directives: map[string][]string{"default-src": {"'self'"}}}, nil, nil))
+	// An invalid directive name is rejected.
+	assert.Error(t, PolicyHandler{}.Validate(
+		PolicyConfig{Directives: map[string][]string{"bad name": {"'self'"}}}, nil, nil))
+}
+
+func TestPolicyHandler_Merge(t *testing.T) {
+	t.Run("writable report-only overrides read-only", func(t *testing.T) {
+		merged := PolicyHandler{}.Merge(
+			PolicyConfig{ReportOnly: boolPtr(true)},
+			PolicyConfig{ReportOnly: boolPtr(false)},
+		).(PolicyConfig)
+		assert.False(t, merged.EffectiveReportOnly())
+	})
+
+	t.Run("read-only report-only stands when writable is unset", func(t *testing.T) {
+		merged := PolicyHandler{}.Merge(
+			PolicyConfig{ReportOnly: boolPtr(false)},
+			PolicyConfig{},
+		).(PolicyConfig)
+		assert.False(t, merged.EffectiveReportOnly())
+	})
+
+	t.Run("writable report_uri wins when set", func(t *testing.T) {
+		merged := PolicyHandler{}.Merge(
+			PolicyConfig{ReportURI: "/ro"},
+			PolicyConfig{ReportURI: "/wr"},
+		).(PolicyConfig)
+		assert.Equal(t, "/wr", merged.ReportURI)
+	})
+
+	t.Run("writable directive replaces read-only, others are kept", func(t *testing.T) {
+		merged := PolicyHandler{}.Merge(
+			PolicyConfig{Directives: map[string][]string{"img-src": {"a", "b"}}},
+			PolicyConfig{Directives: map[string][]string{"img-src": {"c"}, "font-src": {"f"}}},
+		).(PolicyConfig)
+		assert.Equal(t, []string{"c"}, merged.Directives["img-src"])
+		assert.Equal(t, []string{"f"}, merged.Directives["font-src"])
+	})
+
+	t.Run("both layers empty yields nil directives", func(t *testing.T) {
+		merged := PolicyHandler{}.Merge(PolicyConfig{}, PolicyConfig{}).(PolicyConfig)
+		assert.Nil(t, merged.Directives)
+	})
+
+	t.Run("writable path replaces read-only path of the same prefix, others kept", func(t *testing.T) {
+		merged := PolicyHandler{}.Merge(
+			PolicyConfig{Paths: []PathPolicy{
+				{Location: "/console/", Directives: map[string][]string{"img-src": {"'self'"}}},
+				{Location: "/gate/", Directives: map[string][]string{"font-src": {"'self'"}}},
+			}},
+			PolicyConfig{Paths: []PathPolicy{
+				{Location: "/console/", Directives: map[string][]string{"img-src": {"'self'", "https:"}}},
+			}},
+		).(PolicyConfig)
+
+		require.Len(t, merged.Paths, 2)
+		byPrefix := map[string]map[string][]string{}
+		for _, p := range merged.Paths {
+			byPrefix[p.Location] = p.Directives
+		}
+		assert.Equal(t, []string{"'self'", "https:"}, byPrefix["/console/"]["img-src"])
+		assert.Equal(t, []string{"'self'"}, byPrefix["/gate/"]["font-src"])
+	})
+}
+
+// ensure PolicyConfig round-trips through JSON as the section store persists it.
+func TestPolicyConfig_JSONRoundTrip(t *testing.T) {
+	original := PolicyConfig{
+		ReportOnly: boolPtr(false),
+		ReportURI:  "/csp",
+		Directives: map[string][]string{"connect-src": {"https://api.example.com"}},
+	}
+	raw, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	decoded, err := PolicyHandler{}.Decode(raw)
+	require.NoError(t, err)
+	assert.Equal(t, original, decoded.(PolicyConfig))
+}

--- a/backend/internal/system/csp/policy.go
+++ b/backend/internal/system/csp/policy.go
@@ -1,0 +1,194 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package csp builds the deny-first Content-Security-Policy header and the "csp" server-config
+// section's value, handler, and runtime resolver.
+package csp
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+
+	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
+)
+
+// configSectionCSP duplicates the serverconfig.ConfigNameCSP literal so this package need not import
+// serverconfig, which would create an import cycle via the middleware package (CORS does the same).
+const configSectionCSP = "csp"
+
+// baselineDirective is a single deny-first directive with its default sources.
+type baselineDirective struct {
+	name    string
+	sources []string
+}
+
+// baseline is the deny-first default policy. An effective override replaces a directive's value here
+// entirely; an unlisted directive falls back to default-src 'none'.
+var baseline = []baselineDirective{
+	{"default-src", []string{"'none'"}},
+	{"script-src", []string{"'self'"}},
+	{"style-src", []string{"'self'"}},
+	{"img-src", []string{"'self'"}},
+	{"connect-src", []string{"'self'"}},
+	{"frame-ancestors", []string{"'none'"}},
+	{"base-uri", []string{"'none'"}},
+	{"form-action", []string{"'self'"}},
+}
+
+// directiveNamePattern validates a CSP directive name, guarding against header injection via a crafted
+// name rather than restricting which directives may be configured.
+var directiveNamePattern = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+
+// invalidValueChars are disallowed in a directive source or report_uri, so a configured value cannot
+// inject an extra directive into the emitted header.
+const invalidValueChars = " \t\r\n;,"
+
+// PathPolicy overrides directives for requests whose path starts with Location, applied over the
+// policy's default directives and the baseline.
+type PathPolicy struct {
+	Location   string              `json:"location" yaml:"location"`
+	Directives map[string][]string `json:"directives" yaml:"directives"`
+}
+
+// PolicyConfig is the value of the "csp" server-config section. For a request, the longest-matching
+// Paths entry's directives override Directives (the default), which override the baseline. ReportOnly
+// is a pointer so an unset value defaults to report-only rather than silently enforcing.
+type PolicyConfig struct {
+	ReportOnly *bool               `json:"reportOnly,omitempty" yaml:"reportOnly,omitempty"`
+	ReportURI  string              `json:"reportUri,omitempty"  yaml:"reportUri,omitempty"`
+	Directives map[string][]string `json:"directives,omitempty" yaml:"directives,omitempty"`
+	Paths      []PathPolicy        `json:"paths,omitempty"      yaml:"paths,omitempty"`
+}
+
+// EffectiveReportOnly defaults to true when unset, so a policy is never enforced until explicitly
+// switched.
+func (c PolicyConfig) EffectiveReportOnly() bool {
+	return c.ReportOnly == nil || *c.ReportOnly
+}
+
+// HeaderName returns the report-only or enforcing header name, per EffectiveReportOnly.
+func (c PolicyConfig) HeaderName() string {
+	if c.EffectiveReportOnly() {
+		return serverconst.ContentSecurityPolicyReportOnlyHeaderName
+	}
+	return serverconst.ContentSecurityPolicyHeaderName
+}
+
+// effectiveDirectives returns the directive overrides for a request path: Directives, with the
+// longest-matching Paths entry applied on top, per directive.
+func (c PolicyConfig) effectiveDirectives(path string) map[string][]string {
+	eff := make(map[string][]string, len(c.Directives))
+	for name, sources := range c.Directives {
+		eff[name] = sources
+	}
+	bestLen := -1
+	var best map[string][]string
+	for i := range c.Paths {
+		p := c.Paths[i]
+		if strings.HasPrefix(path, p.Location) && len(p.Location) > bestLen {
+			bestLen = len(p.Location)
+			best = p.Directives
+		}
+	}
+	for name, sources := range best {
+		eff[name] = sources
+	}
+	return eff
+}
+
+// HeaderValue renders the effective policy for a request path, followed by a report-uri directive when
+// a report endpoint is set.
+func (c PolicyConfig) HeaderValue(path string) string {
+	overrides := c.effectiveDirectives(path)
+	baselineNames := make(map[string]struct{}, len(baseline))
+	directives := make([]string, 0, len(baseline)+len(overrides)+1)
+
+	for _, d := range baseline {
+		baselineNames[d.name] = struct{}{}
+		sources := d.sources
+		if override, ok := overrides[d.name]; ok {
+			sources = override
+		}
+		directives = append(directives, d.name+" "+strings.Join(sources, " "))
+	}
+
+	// Effective directives outside the baseline, in a stable order.
+	extraNames := make([]string, 0, len(overrides))
+	for name := range overrides {
+		if _, isBaseline := baselineNames[name]; !isBaseline {
+			extraNames = append(extraNames, name)
+		}
+	}
+	sort.Strings(extraNames)
+	for _, name := range extraNames {
+		directives = append(directives, name+" "+strings.Join(overrides[name], " "))
+	}
+
+	if c.ReportURI != "" {
+		directives = append(directives, "report-uri "+c.ReportURI)
+	}
+	return strings.Join(directives, "; ")
+}
+
+// Validate reports whether the configured policy is acceptable. No directive is locked; a report_uri
+// must be a relative path or an http/https URL; each path policy needs a rooted prefix and a directive.
+func (c PolicyConfig) Validate() error {
+	if err := validateDirectives(c.Directives); err != nil {
+		return err
+	}
+	for _, p := range c.Paths {
+		if !strings.HasPrefix(p.Location, "/") {
+			return fmt.Errorf("csp: location %q must start with %q", p.Location, "/")
+		}
+		if len(p.Directives) == 0 {
+			return fmt.Errorf("csp: path %q has no directives", p.Location)
+		}
+		if err := validateDirectives(p.Directives); err != nil {
+			return fmt.Errorf("csp: path %q: %w", p.Location, err)
+		}
+	}
+
+	if c.ReportURI != "" {
+		if strings.ContainsAny(c.ReportURI, invalidValueChars) {
+			return fmt.Errorf("csp: report_uri has an invalid character")
+		}
+		parsed, err := url.Parse(c.ReportURI)
+		if err != nil {
+			return fmt.Errorf("csp: report_uri is not a valid URL: %w", err)
+		}
+		if parsed.Scheme != "" && parsed.Scheme != "http" && parsed.Scheme != "https" {
+			return fmt.Errorf("csp: report_uri must use http or https scheme (got %q)", parsed.Scheme)
+		}
+	}
+	return nil
+}
+
+// validateDirectives rejects invalid directive names and sources containing a separator or whitespace
+// character, so a configured value cannot inject additional directives into the header.
+func validateDirectives(directives map[string][]string) error {
+	names := make([]string, 0, len(directives))
+	for name := range directives {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if !directiveNamePattern.MatchString(name) {
+			return fmt.Errorf("csp: %q is not a valid directive name", name)
+		}
+		if len(directives[name]) == 0 {
+			return fmt.Errorf("csp: directive %q has no sources", name)
+		}
+		for _, source := range directives[name] {
+			if strings.TrimSpace(source) == "" {
+				return fmt.Errorf("csp: directive %q has an empty source", name)
+			}
+			if strings.ContainsAny(source, invalidValueChars) {
+				return fmt.Errorf("csp: directive %q has a source with an invalid character", name)
+			}
+		}
+	}
+	return nil
+}

--- a/backend/internal/system/csp/policy_test.go
+++ b/backend/internal/system/csp/policy_test.go
@@ -1,0 +1,154 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package csp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestPolicyConfig_EffectiveReportOnly(t *testing.T) {
+	assert.True(t, PolicyConfig{}.EffectiveReportOnly(), "defaults to report-only when unset")
+	assert.True(t, PolicyConfig{ReportOnly: boolPtr(true)}.EffectiveReportOnly())
+	assert.False(t, PolicyConfig{ReportOnly: boolPtr(false)}.EffectiveReportOnly())
+}
+
+func TestPolicyConfig_HeaderName(t *testing.T) {
+	assert.Equal(t, serverconst.ContentSecurityPolicyReportOnlyHeaderName, PolicyConfig{}.HeaderName())
+	assert.Equal(t, serverconst.ContentSecurityPolicyHeaderName,
+		PolicyConfig{ReportOnly: boolPtr(false)}.HeaderName())
+}
+
+func TestPolicyConfig_HeaderValue_Baseline(t *testing.T) {
+	got := PolicyConfig{}.HeaderValue("/anything")
+	assert.Equal(t,
+		"default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src 'self'; "+
+			"frame-ancestors 'none'; base-uri 'none'; form-action 'self'",
+		got)
+	assert.NotContains(t, got, "unsafe-inline")
+	assert.NotContains(t, got, "nonce-")
+}
+
+func TestPolicyConfig_HeaderValue_DefaultOverride(t *testing.T) {
+	got := PolicyConfig{
+		Directives: map[string][]string{
+			"style-src": {"'self'", "'unsafe-inline'", "https://fonts.googleapis.com"},
+			"font-src":  {"'self'", "https://fonts.gstatic.com"},
+		},
+	}.HeaderValue("/anything")
+
+	// An overridden baseline directive is replaced, not appended to.
+	assert.Contains(t, got, "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com")
+	// A configured directive not in the baseline is added, in stable order after the baseline.
+	assert.Contains(t, got, "font-src 'self' https://fonts.gstatic.com")
+	// Unlisted baseline directives keep their default.
+	assert.Contains(t, got, "default-src 'none'")
+	assert.Contains(t, got, "img-src 'self'")
+}
+
+func TestPolicyConfig_HeaderValue_PerPath(t *testing.T) {
+	cfg := PolicyConfig{
+		Directives: map[string][]string{"img-src": {"'self'", "data:"}}, // default for all paths
+		Paths: []PathPolicy{
+			{Location: "/console/", Directives: map[string][]string{"worker-src": {"'self'", "blob:"}}},
+			{Location: "/gate/", Directives: map[string][]string{"style-src": {"'self'", "'unsafe-inline'"}}},
+		},
+	}
+
+	console := cfg.HeaderValue("/console/apps")
+	gate := cfg.HeaderValue("/gate/signin")
+	api := cfg.HeaderValue("/oauth2/token")
+
+	// Default directive applies everywhere.
+	for _, h := range []string{console, gate, api} {
+		assert.Contains(t, h, "img-src 'self' data:")
+	}
+	// Path-specific directives apply only to the matching path.
+	assert.Contains(t, console, "worker-src 'self' blob:")
+	assert.NotContains(t, console, "'unsafe-inline'")
+	assert.Contains(t, gate, "style-src 'self' 'unsafe-inline'")
+	assert.NotContains(t, gate, "worker-src")
+	// A non-matching path (API) gets only the baseline plus default.
+	assert.NotContains(t, api, "worker-src")
+	assert.Contains(t, api, "style-src 'self';")
+}
+
+func TestPolicyConfig_HeaderValue_LongestPrefixWins(t *testing.T) {
+	cfg := PolicyConfig{Paths: []PathPolicy{
+		{Location: "/console/", Directives: map[string][]string{"img-src": {"'self'"}}},
+		{Location: "/console/design/", Directives: map[string][]string{"img-src": {"'self'", "https:"}}},
+	}}
+	assert.Contains(t, cfg.HeaderValue("/console/design/themes"), "img-src 'self' https:")
+	assert.Contains(t, cfg.HeaderValue("/console/apps"), "img-src 'self';")
+}
+
+func TestPolicyConfig_HeaderValue_ReportURI(t *testing.T) {
+	got := PolicyConfig{ReportURI: "https://collector.example.com/csp"}.HeaderValue("/x")
+	assert.Contains(t, got, "report-uri https://collector.example.com/csp")
+}
+
+func TestPolicyConfig_Validate(t *testing.T) {
+	t.Run("empty is valid", func(t *testing.T) {
+		assert.NoError(t, PolicyConfig{}.Validate())
+	})
+
+	t.Run("any directive may be configured, including former core directives", func(t *testing.T) {
+		for _, name := range []string{"connect-src", "default-src", "frame-ancestors", "base-uri", "form-action"} {
+			assert.NoError(t, PolicyConfig{Directives: map[string][]string{name: {"'self'"}}}.Validate(),
+				"directive %q should be configurable", name)
+		}
+	})
+
+	t.Run("invalid directive name is rejected", func(t *testing.T) {
+		for _, name := range []string{"Bad-Name", "img src", "img;src", ""} {
+			assert.Error(t, PolicyConfig{Directives: map[string][]string{name: {"'self'"}}}.Validate())
+		}
+	})
+
+	t.Run("source with a separator or whitespace is rejected", func(t *testing.T) {
+		for _, source := range []string{"https://a.com; script-src 'unsafe-inline'", "a,b", "a b"} {
+			assert.Error(t, PolicyConfig{
+				Directives: map[string][]string{"img-src": {source}},
+			}.Validate(), "source %q should be rejected", source)
+		}
+	})
+
+	t.Run("valid path policy is accepted", func(t *testing.T) {
+		assert.NoError(t, PolicyConfig{Paths: []PathPolicy{
+			{Location: "/console/", Directives: map[string][]string{"img-src": {"'self'", "data:"}}},
+		}}.Validate())
+	})
+
+	t.Run("path prefix must be rooted", func(t *testing.T) {
+		assert.ErrorContains(t, PolicyConfig{Paths: []PathPolicy{
+			{Location: "console", Directives: map[string][]string{"img-src": {"'self'"}}},
+		}}.Validate(), "must start with")
+	})
+
+	t.Run("path with no directives is rejected", func(t *testing.T) {
+		assert.ErrorContains(t, PolicyConfig{Paths: []PathPolicy{
+			{Location: "/console/"},
+		}}.Validate(), "no directives")
+	})
+
+	t.Run("invalid source inside a path is rejected", func(t *testing.T) {
+		assert.ErrorContains(t, PolicyConfig{Paths: []PathPolicy{
+			{Location: "/console/", Directives: map[string][]string{"img-src": {"a b"}}},
+		}}.Validate(), "/console/")
+	})
+
+	t.Run("non-http scheme report_uri is rejected", func(t *testing.T) {
+		assert.ErrorContains(t, PolicyConfig{ReportURI: "ftp://collector.example.com"}.Validate(), "report_uri")
+	})
+
+	t.Run("report_uri containing a separator character is rejected", func(t *testing.T) {
+		err := PolicyConfig{ReportURI: "https://example.com/csp;style-src https://evil.example"}.Validate()
+		assert.ErrorContains(t, err, "report_uri")
+	})
+}

--- a/backend/internal/system/csp/resolver.go
+++ b/backend/internal/system/csp/resolver.go
@@ -1,0 +1,56 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package csp
+
+import (
+	"context"
+	"sync"
+
+	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
+)
+
+// ConfigReader reads the merged (effective) value of a server-config section. The server-config
+// service satisfies it; this narrow interface keeps this package from importing serverconfig.
+type ConfigReader interface {
+	GetMergedConfig(ctx context.Context, name string) (any, *common.ServiceError)
+}
+
+var (
+	readerMu sync.RWMutex
+	reader   ConfigReader
+)
+
+// InitializeConfigReader installs the server-config reader the resolver reads the csp section from.
+// It is called once at the composition root.
+func InitializeConfigReader(r ConfigReader) {
+	readerMu.Lock()
+	defer readerMu.Unlock()
+	reader = r
+}
+
+// Resolve returns the effective csp policy. When no reader is installed or the section cannot be read,
+// it falls back to the zero PolicyConfig, which is the deny-first baseline in report-only mode, so the
+// server always emits a safe policy.
+func Resolve(ctx context.Context) PolicyConfig {
+	readerMu.RLock()
+	r := reader
+	readerMu.RUnlock()
+	if r == nil {
+		return PolicyConfig{}
+	}
+
+	value, svcErr := r.GetMergedConfig(ctx, configSectionCSP)
+	if svcErr != nil {
+		log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CSP")).Warn(ctx,
+			"Failed to read the csp server config; falling back to the deny-first report-only default",
+			log.String("code", svcErr.Code))
+		return PolicyConfig{}
+	}
+	cfg, ok := value.(PolicyConfig)
+	if !ok {
+		return PolicyConfig{}
+	}
+	return cfg
+}

--- a/backend/internal/system/csp/resolver_test.go
+++ b/backend/internal/system/csp/resolver_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package csp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
+)
+
+type stubReader struct {
+	value any
+	err   *common.ServiceError
+}
+
+func (s stubReader) GetMergedConfig(_ context.Context, _ string) (any, *common.ServiceError) {
+	return s.value, s.err
+}
+
+func TestResolve(t *testing.T) {
+	t.Cleanup(func() { InitializeConfigReader(nil) })
+
+	t.Run("nil reader falls back to the default report-only policy", func(t *testing.T) {
+		InitializeConfigReader(nil)
+		assert.Equal(t, PolicyConfig{}, Resolve(context.Background()))
+	})
+
+	t.Run("returns the reader's merged policy", func(t *testing.T) {
+		want := PolicyConfig{ReportOnly: boolPtr(false), ReportURI: "/r"}
+		InitializeConfigReader(stubReader{value: want})
+		assert.Equal(t, want, Resolve(context.Background()))
+	})
+
+	t.Run("service error falls back to the default", func(t *testing.T) {
+		InitializeConfigReader(stubReader{err: &common.InternalServerError})
+		assert.Equal(t, PolicyConfig{}, Resolve(context.Background()))
+	})
+
+	t.Run("unexpected value type falls back to the default", func(t *testing.T) {
+		InitializeConfigReader(stubReader{value: "not a policy"})
+		assert.Equal(t, PolicyConfig{}, Resolve(context.Background()))
+	})
+}

--- a/backend/internal/system/middleware/securityheaders.go
+++ b/backend/internal/system/middleware/securityheaders.go
@@ -1,0 +1,46 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
+	"github.com/thunder-id/thunderid/internal/system/csp"
+)
+
+// cspAppPathPrefixes are the only paths CSP is emitted for: the Gate and Console apps, the only
+// responses that render as documents a browser enforces CSP against. Everything else (API, OAuth2) is
+// JSON or a redirect, where a CSP header would be inert.
+var cspAppPathPrefixes = []string{"/gate/", "/console/"}
+
+// SecurityHeadersMiddleware applies X-Frame-Options: DENY to every response and the deny-first
+// Content-Security-Policy to Gate and Console responses. The effective CSP policy is resolved per
+// request from the csp server-config section, falling back to the deny-first baseline in report-only
+// mode when unset. X-Frame-Options stays global since, unlike CSP, it has no report-only mode.
+func SecurityHeadersMiddleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set(serverconst.XFrameOptionsHeaderName, serverconst.XFrameOptionsDeny)
+
+			if isCSPAppPath(r.URL.Path) {
+				policy := csp.Resolve(r.Context())
+				w.Header().Set(policy.HeaderName(), policy.HeaderValue(r.URL.Path))
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// isCSPAppPath reports whether path belongs to the Gate or Console application.
+func isCSPAppPath(path string) bool {
+	for _, prefix := range cspAppPathPrefixes {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/system/middleware/securityheaders_test.go
+++ b/backend/internal/system/middleware/securityheaders_test.go
@@ -1,0 +1,136 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
+	"github.com/thunder-id/thunderid/internal/system/csp"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
+)
+
+// fakeCSPReader serves a fixed merged csp policy to the resolver.
+type fakeCSPReader struct {
+	cfg csp.PolicyConfig
+}
+
+func (f fakeCSPReader) GetMergedConfig(_ context.Context, _ string) (any, *common.ServiceError) {
+	return f.cfg, nil
+}
+
+// serve runs the middleware against a single GET request for path and returns the recorder.
+func serve(path string) *httptest.ResponseRecorder {
+	handler := SecurityHeadersMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, path, nil))
+	return rr
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestSecurityHeadersMiddleware_DefaultReportOnlyBaseline(t *testing.T) {
+	csp.InitializeConfigReader(nil)
+	t.Cleanup(func() { csp.InitializeConfigReader(nil) })
+
+	rr := serve("/console/apps")
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	// With no configured section the default is report-only.
+	policy := rr.Header().Get(serverconst.ContentSecurityPolicyReportOnlyHeaderName)
+	assert.NotEmpty(t, policy)
+	assert.Empty(t, rr.Header().Get(serverconst.ContentSecurityPolicyHeaderName))
+
+	for _, directive := range []string{
+		"default-src 'none'",
+		"script-src 'self'",
+		"style-src 'self'",
+		"img-src 'self'",
+		"connect-src 'self'",
+		"frame-ancestors 'none'",
+		"base-uri 'none'",
+		"form-action 'self'",
+	} {
+		assert.Contains(t, policy, directive)
+	}
+	assert.NotContains(t, policy, "unsafe-inline")
+	assert.NotContains(t, policy, "unsafe-eval")
+	assert.NotContains(t, policy, "nonce-")
+
+	// X-Frame-Options is always enforced.
+	assert.Equal(t, serverconst.XFrameOptionsDeny, rr.Header().Get(serverconst.XFrameOptionsHeaderName))
+}
+
+func TestSecurityHeadersMiddleware_Enforcing(t *testing.T) {
+	csp.InitializeConfigReader(fakeCSPReader{cfg: csp.PolicyConfig{ReportOnly: boolPtr(false)}})
+	t.Cleanup(func() { csp.InitializeConfigReader(nil) })
+
+	rr := serve("/console/apps")
+
+	assert.NotEmpty(t, rr.Header().Get(serverconst.ContentSecurityPolicyHeaderName))
+	assert.Empty(t, rr.Header().Get(serverconst.ContentSecurityPolicyReportOnlyHeaderName))
+}
+
+func TestSecurityHeadersMiddleware_OverrideAndReportURI(t *testing.T) {
+	csp.InitializeConfigReader(fakeCSPReader{cfg: csp.PolicyConfig{
+		ReportURI:  "/csp-report",
+		Directives: map[string][]string{"img-src": {"'self'", "https://avatars.example.com"}},
+	}})
+	t.Cleanup(func() { csp.InitializeConfigReader(nil) })
+
+	rr := serve("/console/apps")
+
+	policy := rr.Header().Get(serverconst.ContentSecurityPolicyReportOnlyHeaderName)
+	assert.Contains(t, policy, "img-src 'self' https://avatars.example.com")
+	assert.Contains(t, policy, "report-uri /csp-report")
+}
+
+func TestSecurityHeadersMiddleware_PerPath(t *testing.T) {
+	csp.InitializeConfigReader(fakeCSPReader{cfg: csp.PolicyConfig{
+		ReportOnly: boolPtr(false),
+		Paths: []csp.PathPolicy{
+			{Location: "/gate/", Directives: map[string][]string{"style-src": {"'self'", "'unsafe-inline'"}}},
+		},
+	}})
+	t.Cleanup(func() { csp.InitializeConfigReader(nil) })
+
+	// The matching path gets its relaxation.
+	gate := serve("/gate/signin").Header().Get(serverconst.ContentSecurityPolicyHeaderName)
+	assert.Contains(t, gate, "style-src 'self' 'unsafe-inline'")
+
+	// Console still gets a policy (the default, unrelaxed here), just not the gate-specific override.
+	console := serve("/console/apps").Header().Get(serverconst.ContentSecurityPolicyHeaderName)
+	assert.NotContains(t, console, "unsafe-inline")
+	assert.Contains(t, console, "style-src 'self';")
+}
+
+func TestSecurityHeadersMiddleware_ScopedToConsoleAndGate(t *testing.T) {
+	csp.InitializeConfigReader(fakeCSPReader{cfg: csp.PolicyConfig{ReportOnly: boolPtr(false)}})
+	t.Cleanup(func() { csp.InitializeConfigReader(nil) })
+
+	for _, path := range []string{"/console/", "/console/apps", "/gate/", "/gate/signin"} {
+		rr := serve(path)
+		assert.NotEmpty(t, rr.Header().Get(serverconst.ContentSecurityPolicyHeaderName), "path %q should get CSP", path)
+	}
+
+	// API, OAuth2, and other non-app responses get no CSP header at all: they are JSON or redirects,
+	// never a rendered document, so CSP on them would be inert.
+	for _, path := range []string{"/oauth2/token", "/oauth2/authorize", "/server-config/cors", "/health", "/"} {
+		rr := serve(path)
+		assert.Empty(t, rr.Header().Get(serverconst.ContentSecurityPolicyHeaderName),
+			"path %q should not get CSP", path)
+		assert.Empty(t, rr.Header().Get(serverconst.ContentSecurityPolicyReportOnlyHeaderName),
+			"path %q should not get report-only CSP either", path)
+		// X-Frame-Options is unaffected by the CSP scoping.
+		assert.Equal(t, serverconst.XFrameOptionsDeny, rr.Header().Get(serverconst.XFrameOptionsHeaderName),
+			"path %q should still get X-Frame-Options", path)
+	}
+}


### PR DESCRIPTION
### Purpose
ThunderID currently emits no Content-Security-Policy. This PR introduces a deny-first CSP baseline for the Console and Gate applications, addressing the sub issues  #4474 and #4475 , with the policy fully configurable through a server-config section.


<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
- A CSP header for requests under `/console/` and `/gate/`.
- A global security-headers middleware emits `X-Frame-Options: DENY` on every response, (including the API and OAuth2 responses) The pre-existing per-route clickjacking guard on `/oauth2/authorize` is folded into this same global `X-Frame-Options` handling.
- The policy is a new `csp` server-config section, following the exact pattern already used for CORS: a declarative file (`config/resources/server_configs/csp.yaml`) plus the runtime management API (`PUT /server-config/csp`), merged the same way (writable overrides read-only, per field).
- Any directive can be configured; none are locked. A directive set in config *replaces* its baseline value entirely (not additive), so an app's policy is fully explicit rather than accumulating relaxations.
- The policy supports per-application overrides: a default set of directives plus a `paths` list keyed by longest-matching prefix, so Console and Gate each carry only the relaxations they actually need (e.g. Console alone gets `worker-src` for its code editor and a `connect-src` entry for its releases feed; both share the Google Fonts and temporary `unsafe-inline` entries for their current styling stack).
- Ships **enforcing** (not report-only) with the initial reviewed relaxations already in `csp.yaml`, including a temporary `style-src 'unsafe-inline'` covering current inline-style injection (oxygen-ui/MUI/Emotion). Per-request nonce support, which would let this temporary allowance be removed, will be tracked as a follow-up, since a nonce in the header would cause browsers to ignore `unsafe-inline` before the frontend is wired to consume nonces.


### Related Issues
- Closes #4474 
-  #4475

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Content Security Policy protection for Console and Gate pages.
  * Added configurable enforcing or report-only modes, directives, path-specific policies, and reporting endpoints.
  * Added global clickjacking protection with `X-Frame-Options: DENY`.
* **Security**
  * CSP policies provide secure defaults and restrict content sources, connections, images, and workers.
  * Policies apply only to supported application routes; other responses remain unchanged.
  * Added validation for unsafe or malformed policy configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->