### PR TITLE
Fix adding users when deployed as federated login to console

### DIFF
--- a/docs/content/sdks/javascript/apis/configuration.mdx
+++ b/docs/content/sdks/javascript/apis/configuration.mdx
@@ -83,6 +83,30 @@ By default the SDK fetches `{baseUrl}/.well-known/openid-configuration` to resol
 | `endpoints.userInfo` | `string` | - | Override the userinfo endpoint |
 | `endpoints.jwks` | `string` | - | Override the JWKS endpoint |
 | `endpoints.introspection` | `string` | - | Override the token introspection endpoint |
+| `endpoints.flowExecute` | `string` | `{baseUrl}/flow/execute` | Override the flow execution endpoint (embedded sign-in, sign-up, recovery, and user onboarding flows) |
+| `endpoints.flowMeta` | `string` | `{baseUrl}/flow/meta` | Override the flow metadata endpoint |
+| `endpoints.usersMe` | `string` | `{baseUrl}/users/me` | Override the current-user profile endpoint |
+
+The `endpoints.authorization`, `endpoints.token`, `endpoints.userInfo`, `endpoints.jwks`, `endpoints.introspection`,
+and `endpoints.endSession` overrides address OIDC/OAuth endpoints, which are otherwise resolved from the discovery
+document. The `endpoints.flowExecute`, `endpoints.flowMeta`, and `endpoints.usersMe` overrides address resource-server
+endpoints, which are otherwise derived by concatenating `baseUrl` with a fixed path.
+
+Split these two groups when the OAuth authorization server and the <ProductName /> resource server are different hosts,
+for example when two <ProductName /> instances are connected as trusted issuers. Point `baseUrl` (and hence the
+OAuth/discovery endpoints) at the authorization server, and override the resource-server endpoints to target the
+resource server that owns the users and flows:
+
+```ts
+{
+  baseUrl: 'https://idp.example.com',
+  endpoints: {
+    flowExecute: 'https://rs.example.com/flow/execute',
+    flowMeta: 'https://rs.example.com/flow/meta',
+    usersMe: 'https://rs.example.com/users/me',
+  },
+}
+```
 
 ### Application Parameters
 

--- a/frontend/apps/console/src/hocs/withConfig.tsx
+++ b/frontend/apps/console/src/hocs/withConfig.tsx
@@ -41,11 +41,26 @@ export default function withConfig<P extends object>(WrappedComponent: Component
     // configured resource identifier.
     const resourceIdentifier = config.trusted_issuer ? getServerUrl() : getResourceIdentifier();
 
+    // In the trusted-issuer (federated) model `baseUrl` points at the authorization server (IdP),
+    // so the SDK would otherwise send resource-server calls (flow execution, flow metadata, and the
+    // user profile) to the IdP instead of the resource server that owns the users and flows. Point
+    // those endpoints back at the resource server URL.
+    const resourceServerUrl = config.trusted_issuer ? getServerUrl().replace(/\/+$/, '') : undefined;
+
     // Behavioral defaults derived from app config and runtime heuristics.
     // config.sdk values are deep-merged on top, so operators can override any of these.
     const sdkDefaults: Partial<ThunderIDProviderProps> = {
       discovery: {wellKnown: {enabled: true}},
       ...(resourceIdentifier ? {signInOptions: {resource: resourceIdentifier}} : {}),
+      ...(resourceServerUrl
+        ? {
+            endpoints: {
+              flowExecute: `${resourceServerUrl}/flow/execute`,
+              flowMeta: `${resourceServerUrl}/flow/meta`,
+              usersMe: `${resourceServerUrl}/users/me`,
+            },
+          }
+        : {}),
       sendIdTokenInLogoutRequest: false,
       // When the trusted issuer is a generic OIDC provider, suppress the SDK's
       // product-specific bootstrap calls that would otherwise 404 / be CORS-blocked

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,11 +242,11 @@ catalogs:
       specifier: 14.6.1
       version: 14.6.1
     '@thunderid/react':
-      specifier: 0.11.1
-      version: 0.11.1
+      specifier: 0.11.3
+      version: 0.11.3
     '@thunderid/react-router':
-      specifier: 0.10.1
-      version: 0.10.1
+      specifier: 0.10.2
+      version: 0.10.2
     '@types/lodash-es':
       specifier: 4.17.12
       version: 4.17.12
@@ -663,10 +663,10 @@ importers:
         version: link:../../packages/logger
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.11.3(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@thunderid/react-router':
         specifier: 'catalog:'
-        version: 0.10.1(@thunderid/react@0.11.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@8.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 0.10.2(@thunderid/react@0.11.3(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@8.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@thunderid/utils':
         specifier: workspace:^
         version: link:../../packages/utils
@@ -853,10 +853,10 @@ importers:
         version: link:../../packages/logger
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.11.3(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@thunderid/react-router':
         specifier: 'catalog:'
-        version: 0.10.1(@thunderid/react@0.11.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@8.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 0.10.2(@thunderid/react@0.11.3(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@8.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@thunderid/utils':
         specifier: workspace:^
         version: link:../../packages/utils
@@ -1001,7 +1001,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.11.3(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.13.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.13.0(react@19.2.3))(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1101,7 +1101,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.11.3(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.13.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.13.0(react@19.2.3))(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1222,7 +1222,7 @@ importers:
         version: link:../prettier-config
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.11.3(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@thunderid/test-utils':
         specifier: workspace:^
         version: link:../test-utils
@@ -1273,7 +1273,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.11.3(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.13.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.13.0(react@19.2.3))(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1373,7 +1373,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.11.3(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.13.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.13.0(react@19.2.3))(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1491,7 +1491,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.11.3(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.13.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.13.0(react@19.2.3))(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1606,7 +1606,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.11.3(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.13.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.13.0(react@19.2.3))(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1706,7 +1706,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.11.3(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.13.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.13.0(react@19.2.3))(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1824,7 +1824,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.11.3(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.13.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.13.0(react@19.2.3))(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1960,7 +1960,7 @@ importers:
         version: link:../prettier-config
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.11.3(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@thunderid/test-utils':
         specifier: workspace:^
         version: link:../test-utils
@@ -2136,7 +2136,7 @@ importers:
         version: link:../logger
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.11.3(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@thunderid/utils':
         specifier: workspace:^
         version: link:../utils
@@ -2397,7 +2397,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.11.3(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       i18next:
         specifier: 25.6.0
         version: 25.6.0(typescript@5.9.3)
@@ -2727,7 +2727,7 @@ importers:
     dependencies:
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.11.3(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.13.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.13.0(react@19.2.3))(dayjs@1.11.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -6407,17 +6407,17 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@thunderid/browser@0.11.1':
-    resolution: {integrity: sha512-PAU9ZPelIAfLKzTOVhw8ioYDQfqpHJ4nRDVZRO1MVsLzaLyMZYVENijyN/ck3FVoC1fyUtNmtjt75Qlf9F5giw==}
+  '@thunderid/browser@0.11.3':
+    resolution: {integrity: sha512-2k6iiAeu7ODSL/G/0xf46tdFQMyn+qg+aHW/HNDE8xIYXudWvXqOk/t8+JkSdQiQagFPomGc67LobF9ojHBqGQ==}
 
   '@thunderid/javascript@0.0.5':
     resolution: {integrity: sha512-lMjbHCsNgYWclUiPlN3CA6vjKSyjIBIxVGSnuJwiC9eVakVsWmRuxkO8KX6AWlA4SRHgpGLMnD4ZE5lpM+gi9g==}
 
-  '@thunderid/javascript@0.11.0':
-    resolution: {integrity: sha512-aw64EkafIBRzRfeQI8rFqd6cyCa24U/t7gswkjCNNCvkbT+SmiYfsZQ6vHt6RLT6Z0xYYlVAGSj6htYu0YPubw==}
+  '@thunderid/javascript@0.11.2':
+    resolution: {integrity: sha512-26k2Aq3B077BNPoE50JvjiFJVepV4dKFD6s80EwVf9BVtAm2GwVCkRDh9WtOgSxMLd7IGPR9yRPenDhRpN3YAQ==}
 
-  '@thunderid/react-router@0.10.1':
-    resolution: {integrity: sha512-9PNi24+SYqPUKS6rpYz9lwS+Jz8d6LbO5XvOkCRGVN1BO1cm6P0VOvMgYaB5My5BI+zvx2YAPPcs+/ZDwZEhvw==}
+  '@thunderid/react-router@0.10.2':
+    resolution: {integrity: sha512-0S7mv7dXGmSWEDJLnddaLjhCoR9Benvt4VNz+5gogER1HOXUwaPjEL+KWAAHwAlE5xt0+Hht+4DI1ANsNBu/ww==}
     peerDependencies:
       '@thunderid/react': '>=0.1.0'
       react: '>=16.8.0'
@@ -6425,6 +6425,13 @@ packages:
 
   '@thunderid/react@0.11.1':
     resolution: {integrity: sha512-CPojY09ryY/if6V/oKZuJ+GHlpzQ9ECFTASo3zxC1kiYEDxu/iZ6dKrrrG0hD1UE/mG4eKIm9j5s0vUeDjJm0w==}
+    peerDependencies:
+      '@types/react': '>=16.8.0'
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@thunderid/react@0.11.3':
+    resolution: {integrity: sha512-AATKSGoi/KRyieyvfplmbwH9XJ8FJ/VEInQSPKvpwzPo0QpBQpPaVO3b9M1bsLO45jZExiLzJ6KCEN5Ej31o/A==}
     peerDependencies:
       '@types/react': '>=16.8.0'
       react: '>=16.8.0'
@@ -6933,7 +6940,7 @@ packages:
     peerDependencies:
       '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
       babel-plugin-react-compiler: ^1.0.0
-      vite: 8.0.16
+      vite: '>=8.0.16'
     peerDependenciesMeta:
       '@rolldown/plugin-babel':
         optional: true
@@ -18055,9 +18062,9 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@thunderid/browser@0.11.1':
+  '@thunderid/browser@0.11.3':
     dependencies:
-      '@thunderid/javascript': 0.11.0
+      '@thunderid/javascript': 0.11.2
       base64url: 3.0.1
       buffer: 6.0.3
       core-js: 3.42.0
@@ -18073,14 +18080,14 @@ snapshots:
       jose: 5.2.0
       tslib: 2.8.1
 
-  '@thunderid/javascript@0.11.0':
+  '@thunderid/javascript@0.11.2':
     dependencies:
       jose: 6.2.3
       tslib: 2.8.1
 
-  '@thunderid/react-router@0.10.1(@thunderid/react@0.11.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@8.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@thunderid/react-router@0.10.2(@thunderid/react@0.11.3(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@8.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@thunderid/react': 0.11.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@thunderid/react': 0.11.3(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-router: 8.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tslib: 2.8.1
@@ -18089,7 +18096,20 @@ snapshots:
     dependencies:
       '@emotion/css': 11.13.5
       '@floating-ui/react': 0.27.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@thunderid/browser': 0.11.1
+      '@thunderid/browser': 0.11.3
+      '@types/react': 19.2.14
+      dompurify: 3.4.12
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@thunderid/react@0.11.3(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@emotion/css': 11.13.5
+      '@floating-ui/react': 0.27.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@thunderid/browser': 0.11.3
       '@types/react': 19.2.14
       dompurify: 3.4.12
       react: 19.2.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,8 +38,8 @@ catalog:
   '@testing-library/jest-dom': 6.9.1
   '@testing-library/react': 16.3.0
   '@testing-library/user-event': 14.6.1
-  '@thunderid/react': 0.11.1
-  '@thunderid/react-router': 0.10.1
+  '@thunderid/react': 0.11.3
+  '@thunderid/react-router': 0.10.2
   '@types/lodash-es': 4.17.12
   '@types/node': 24.7.2
   '@types/react': 19.2.14


### PR DESCRIPTION
### Purpose

Fix user creation on a resource-server instance that is federated to an authorization server (trusted issuer).

In the trusted-issuer model the Console's `baseUrl` points at the authorization server (IdP), so the SDK was sending the resource-server calls (user onboarding via `/flow/execute`, `/flow/meta`, `/users/me`) to the IdP instead of the resource server that owns the users. Creating a user therefore failed.

### Approach

The `@thunderid/javascript` SDK now supports overriding the resource-server endpoints independently of the OAuth/discovery endpoints (via `config.endpoints.flowExecute` / `flowMeta` / `usersMe`). This PR wires that up on the Console side:

- `frontend/apps/console/src/hocs/withConfig.tsx` — when `config.trusted_issuer` is set, derive the resource-server URL from `getServerUrl()` and pass `endpoints: { flowExecute, flowMeta, usersMe }` pointing at the resource server, while `baseUrl` continues to target the authorization server for OAuth/discovery.
- `pnpm-workspace.yaml` / `pnpm-lock.yaml` — bump the SDK catalog to the released versions that include the endpoint-override support and the `InviteUser` onboarding fix (`@thunderid/react` `0.11.3`, `@thunderid/react-router` `0.10.2`).
- `docs/content/sdks/javascript/apis/configuration.mdx` — document the resource-server endpoint overrides and the trusted-issuer scenario.

The change is additive: without `trusted_issuer`, `getServerUrl()` resolves to the served origin and behavior is unchanged.

### Related Issues
- Fixes thunder-id/thunderid#4465

### Related PRs
- thunder-id/javascript-sdks#46 (SDK support for separate resource-server endpoints)

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (`docs/content/sdks/javascript/apis/configuration.mdx`)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring separate authentication and resource-server endpoint hosts.
  * Trusted-issuer deployments now automatically use configured resource-server endpoints for flow execution, flow metadata, and current-user profile requests.
* **Documentation**
  * Documented endpoint configuration options and the distinction between OIDC/OAuth and resource-server endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->