### PR TITLE
Let a data plane's replicas each hold a connection

### DIFF
--- a/backend/cmd/dpserver/main.go
+++ b/backend/cmd/dpserver/main.go
@@ -190,6 +190,7 @@ func initChannelClient(importService importer.ImportServiceInterface,
 	return channel.InitializeClient(channel.ClientConfig{
 		Enabled:          c.Enabled,
 		ID:               c.ID,
+		Instance:         c.Instance,
 		ControlPlaneURL:  c.ControlPlaneURL,
 		AuthToken:        c.AuthToken,
 		CAFile:           c.CAFile,

--- a/backend/internal/system/channel/auth.go
+++ b/backend/internal/system/channel/auth.go
@@ -28,6 +28,15 @@ import (
 // HeaderDataPlaneID is the request header the Data Plane sends its id in during the handshake.
 const HeaderDataPlaneID = "X-Data-Plane-ID"
 
+// HeaderDataPlaneInstance is the request header naming which replica of that Data Plane is
+// connecting. It is carried separately from the id rather than encoded into it, so the id stays what
+// the environment records and what the token is issued against.
+const HeaderDataPlaneInstance = "X-Data-Plane-Instance"
+
+// defaultInstance stands in when a Data Plane names no replica, which is a deployment running a
+// single one.
+const defaultInstance = "default"
+
 // Verifier authenticates an inbound Data Plane handshake request. Implementations must not mutate r.
 // Token implementations are provided; an mTLS implementation can be added later without changing the
 // channel server.

--- a/backend/internal/system/channel/client.go
+++ b/backend/internal/system/channel/client.go
@@ -57,6 +57,19 @@ const (
 	healthyConnectionThreshold = 30 * time.Second
 )
 
+// instance names this replica. The host name is the pod name under Kubernetes, which is stable across
+// this process's lifetime and distinct per replica, so a reconnect replaces this pod's own socket
+// rather than a sibling's.
+func (c *Client) instance() string {
+	if configured := strings.TrimSpace(c.cfg.Instance); configured != "" {
+		return configured
+	}
+	if host, err := os.Hostname(); err == nil && host != "" {
+		return host
+	}
+	return defaultInstance
+}
+
 // dialClient builds the HTTP client the handshake is made with. With no CA file configured it is
 // nil, which leaves coder/websocket to use its default and the system roots.
 //
@@ -184,6 +197,7 @@ func (c *Client) connectAndServe(ctx context.Context) (bool, time.Duration, erro
 	header := http.Header{}
 	header.Set("Authorization", "Bearer "+c.cfg.AuthToken)
 	header.Set(HeaderDataPlaneID, c.cfg.ID)
+	header.Set(HeaderDataPlaneInstance, c.instance())
 
 	httpClient, err := c.dialClient()
 	if err != nil {

--- a/backend/internal/system/channel/config.go
+++ b/backend/internal/system/channel/config.go
@@ -46,6 +46,10 @@ type ClientConfig struct {
 	Enabled bool
 	// ID is this Data Plane's identifier, sent in the handshake and used as the CP registry key.
 	ID string
+	// Instance names which replica of that Data Plane this process is. Every replica dials, so without
+	// it they would present one identity and each new connection would evict the last. Empty defaults
+	// to the host name, which is the pod name under Kubernetes.
+	Instance string
 	// ControlPlaneURL is the wss:// (or ws://) endpoint of the Control Plane channel server.
 	ControlPlaneURL string
 	// AuthToken is the shared bearer token presented during the handshake.

--- a/backend/internal/system/channel/registry.go
+++ b/backend/internal/system/channel/registry.go
@@ -19,13 +19,19 @@
 package channel
 
 import (
+	"sort"
 	"sync"
 	"time"
 )
 
 // ConnEntry is a registered Data Plane connection tracked by the registry.
+//
+// ID names the Data Plane, and Instance names which of its replicas this connection belongs to. A
+// Data Plane runs as several pods and every one of them dials, so the pair is what identifies a
+// socket while the id alone identifies the deployment a command is addressed to.
 type ConnEntry interface {
 	ID() string
+	Instance() string
 	LastSeen() time.Time
 	Close(reason string)
 	// CloseNow closes the connection immediately, without the close handshake. It is used to evict a
@@ -36,19 +42,33 @@ type ConnEntry interface {
 // ConnInfo is a point-in-time snapshot of a registered connection, used for observability.
 type ConnInfo struct {
 	ID       string
+	Instance string
 	LastSeen time.Time
 }
 
-// Registry tracks active Data Plane connections on the Control Plane, keyed by Data Plane id, with a
-// single-active-socket-per-id policy.
+// connKey identifies one socket: a Data Plane and which of its replicas holds it.
+type connKey struct {
+	id       string
+	instance string
+}
+
+// Registry tracks active Data Plane connections on the Control Plane.
+//
+// A Data Plane may hold several connections at once, one per replica. The single-active-socket policy
+// applies per replica rather than per Data Plane: a pod reconnecting replaces its own socket, and
+// never a sibling's. Keying by the Data Plane alone would make replicas evict each other in turn and
+// leave the connection flapping.
 type Registry[T ConnEntry] struct {
 	mu    sync.RWMutex
-	conns map[string]T
+	conns map[connKey]T
+	// next round-robins delivery across a Data Plane's replicas, so one pod does not take every
+	// command while its siblings idle.
+	next map[string]int
 }
 
 // NewRegistry creates an empty registry.
 func NewRegistry[T ConnEntry]() *Registry[T] {
-	return &Registry[T]{conns: make(map[string]T)}
+	return &Registry[T]{conns: make(map[connKey]T), next: make(map[string]int)}
 }
 
 // Register stores c under its id, evicting any existing connection for that id. Eviction uses
@@ -56,31 +76,66 @@ func NewRegistry[T ConnEntry]() *Registry[T] {
 // close handshake, and a slow or unresponsive peer must not be allowed to block the caller (Register
 // runs on the new connection's handshake path, before its read loop has started).
 func (r *Registry[T]) Register(c T) {
+	key := connKey{id: c.ID(), instance: c.Instance()}
 	r.mu.Lock()
-	old, existed := r.conns[c.ID()]
-	r.conns[c.ID()] = c
+	old, existed := r.conns[key]
+	r.conns[key] = c
 	r.mu.Unlock()
 	if existed {
 		old.CloseNow()
 	}
 }
 
-// Unregister removes the entry for id only if it is still c, avoiding a race where a newer
+// Unregister removes the entry for a connection only if it is still c, avoiding a race where a newer
 // connection replaced c between its read loop ending and this call.
 func (r *Registry[T]) Unregister(id string, c T) {
+	key := connKey{id: id, instance: c.Instance()}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if cur, ok := r.conns[id]; ok && any(cur) == any(c) {
-		delete(r.conns, id)
+	if cur, ok := r.conns[key]; ok && any(cur) == any(c) {
+		delete(r.conns, key)
 	}
 }
 
-// Get returns the active connection for id, if any.
+// Get returns one active connection for a Data Plane, if it holds any.
+//
+// A command goes to a single replica, not to all of them: the replicas share a database, so applying
+// an import on one is visible to every other, and sending it to each would apply it several times.
+// Which one is chosen rotates, so a Data Plane's replicas share the work.
 func (r *Registry[T]) Get(id string) (T, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	matches := make([]T, 0, 2)
+	for key, c := range r.conns {
+		if key.id == id {
+			matches = append(matches, c)
+		}
+	}
+	if len(matches) == 0 {
+		var zero T
+		return zero, false
+	}
+	// Ordering a map range is not stable, so sort by instance to make the rotation meaningful rather
+	// than a second source of randomness.
+	sort.Slice(matches, func(i, j int) bool { return matches[i].Instance() < matches[j].Instance() })
+
+	chosen := matches[r.next[id]%len(matches)]
+	r.next[id] = (r.next[id] + 1) % len(matches)
+	return chosen, true
+}
+
+// Instances reports how many replicas of a Data Plane are connected.
+func (r *Registry[T]) Instances(id string) int {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	c, ok := r.conns[id]
-	return c, ok
+	count := 0
+	for key := range r.conns {
+		if key.id == id {
+			count++
+		}
+	}
+	return count
 }
 
 // List returns a snapshot of all active connections.
@@ -89,7 +144,7 @@ func (r *Registry[T]) List() []ConnInfo {
 	defer r.mu.RUnlock()
 	out := make([]ConnInfo, 0, len(r.conns))
 	for _, c := range r.conns {
-		out = append(out, ConnInfo{ID: c.ID(), LastSeen: c.LastSeen()})
+		out = append(out, ConnInfo{ID: c.ID(), Instance: c.Instance(), LastSeen: c.LastSeen()})
 	}
 	return out
 }

--- a/backend/internal/system/channel/registry_test.go
+++ b/backend/internal/system/channel/registry_test.go
@@ -26,9 +26,10 @@ import (
 )
 
 type fakeConn struct {
-	id     string
-	seen   time.Time
-	closed bool
+	id       string
+	instance string
+	seen     time.Time
+	closed   bool
 
 	closeMsg string
 	// closeDelay simulates a slow graceful-close handshake, so tests can prove that eviction never
@@ -37,7 +38,16 @@ type fakeConn struct {
 	closedNow  bool
 }
 
-func (f *fakeConn) ID() string          { return f.id }
+func (f *fakeConn) ID() string { return f.id }
+
+// A connection with no instance set stands for a single-replica Data Plane.
+func (f *fakeConn) Instance() string {
+	if f.instance == "" {
+		return defaultInstance
+	}
+	return f.instance
+}
+
 func (f *fakeConn) LastSeen() time.Time { return f.seen }
 func (f *fakeConn) Close(reason string) {
 	time.Sleep(f.closeDelay)
@@ -108,4 +118,70 @@ func TestRegistryListSnapshots(t *testing.T) {
 	r.Register(&fakeConn{id: "dp-1", seen: time.Unix(10, 0)})
 	r.Register(&fakeConn{id: "dp-2", seen: time.Unix(20, 0)})
 	assert.Len(t, r.List(), 2)
+}
+
+// A Data Plane runs as several replicas and every one of them dials. Keying by the Data Plane alone
+// would make each new connection evict the last, leaving the connection flapping and commands landing
+// on whichever pod connected most recently.
+func TestReplicasOfOneDataPlaneCoexist(t *testing.T) {
+	r := NewRegistry[*fakeConn]()
+	a := &fakeConn{id: "org3:dev", instance: "pod-a"}
+	b := &fakeConn{id: "org3:dev", instance: "pod-b"}
+
+	r.Register(a)
+	r.Register(b)
+
+	assert.False(t, a.closedNow, "registering a sibling must not evict pod-a")
+	assert.Equal(t, 2, r.Instances("org3:dev"))
+}
+
+// A replica reconnecting replaces its own socket, which is what the single-socket policy is for.
+func TestAReplicaReconnectingEvictsOnlyItsOwnSocket(t *testing.T) {
+	r := NewRegistry[*fakeConn]()
+	first := &fakeConn{id: "org3:dev", instance: "pod-a"}
+	sibling := &fakeConn{id: "org3:dev", instance: "pod-b"}
+	r.Register(first)
+	r.Register(sibling)
+
+	again := &fakeConn{id: "org3:dev", instance: "pod-a"}
+	r.Register(again)
+
+	assert.True(t, first.closedNow, "pod-a's stale socket should be evicted")
+	assert.False(t, sibling.closedNow, "pod-b must be left alone")
+	assert.Equal(t, 2, r.Instances("org3:dev"))
+}
+
+// A command goes to one replica, not to all of them: they share a database, so applying an import on
+// one is visible to the others and sending it to each would apply it several times. Which one is
+// chosen rotates, so the replicas share the work.
+func TestDeliveryPicksOneReplicaAndRotates(t *testing.T) {
+	r := NewRegistry[*fakeConn]()
+	r.Register(&fakeConn{id: "org3:dev", instance: "pod-a"})
+	r.Register(&fakeConn{id: "org3:dev", instance: "pod-b"})
+
+	first, ok := r.Get("org3:dev")
+	assert.True(t, ok)
+	second, ok := r.Get("org3:dev")
+	assert.True(t, ok)
+	third, ok := r.Get("org3:dev")
+	assert.True(t, ok)
+
+	assert.NotEqual(t, first.Instance(), second.Instance(), "a second command should go to the sibling")
+	assert.Equal(t, first.Instance(), third.Instance(), "the rotation should come back around")
+}
+
+// Unregistering one replica leaves the rest serving.
+func TestUnregisteringOneReplicaLeavesTheOthers(t *testing.T) {
+	r := NewRegistry[*fakeConn]()
+	a := &fakeConn{id: "org3:dev", instance: "pod-a"}
+	b := &fakeConn{id: "org3:dev", instance: "pod-b"}
+	r.Register(a)
+	r.Register(b)
+
+	r.Unregister("org3:dev", a)
+
+	assert.Equal(t, 1, r.Instances("org3:dev"))
+	got, ok := r.Get("org3:dev")
+	assert.True(t, ok)
+	assert.Equal(t, "pod-b", got.Instance())
 }

--- a/backend/internal/system/channel/server.go
+++ b/backend/internal/system/channel/server.go
@@ -39,18 +39,22 @@ const serverLoggerComponent = "ChannelServer"
 type serverConn struct {
 	*wsConn
 	dpID         string
+	instance     string
 	lastSeenNano atomic.Int64
 	pendingMu    sync.Mutex
 	pending      map[string]chan *Response
 }
 
-func newServerConn(wc *wsConn, dpID string) *serverConn {
-	sc := &serverConn{wsConn: wc, dpID: dpID, pending: make(map[string]chan *Response)}
+func newServerConn(wc *wsConn, dpID, instance string) *serverConn {
+	sc := &serverConn{
+		wsConn: wc, dpID: dpID, instance: instance, pending: make(map[string]chan *Response),
+	}
 	sc.touch()
 	return sc
 }
 
 func (sc *serverConn) ID() string          { return sc.dpID }
+func (sc *serverConn) Instance() string    { return sc.instance }
 func (sc *serverConn) LastSeen() time.Time { return time.Unix(0, sc.lastSeenNano.Load()) }
 func (sc *serverConn) Close(reason string) {
 	_ = sc.wsConn.close(websocket.StatusNormalClosure, reason)
@@ -142,6 +146,14 @@ func (s *Server) HandleConnect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Which replica of that Data Plane this connection belongs to. A Data Plane runs as several pods
+	// and every one of them dials, so without this they would be one identity and each new connection
+	// would evict the last. An older Data Plane that sends none is treated as a single replica.
+	instance := r.Header.Get(HeaderDataPlaneInstance)
+	if instance == "" {
+		instance = defaultInstance
+	}
+
 	// sc is assigned only after Accept returns, but OnPingReceived can fire as soon as the
 	// connection is accepted, so it must tolerate a nil sc.
 	var sc *serverConn
@@ -158,15 +170,17 @@ func (s *Server) HandleConnect(w http.ResponseWriter, r *http.Request) {
 	if acceptErr != nil {
 		return // Accept has already written the error response.
 	}
-	sc = newServerConn(newWSConn(ws, s.cfg.ReadLimit), dpID)
+	sc = newServerConn(newWSConn(ws, s.cfg.ReadLimit), dpID, instance)
 	s.registry.Register(sc)
-	s.logger.Info(s.ctx, "Data plane connected", log.String("dpID", dpID))
+	s.logger.Info(s.ctx, "Data plane connected",
+		log.String("dpID", dpID), log.String("instance", instance))
 
 	defer func() {
 		s.registry.Unregister(dpID, sc)
 		sc.failAllPending()
 		_ = sc.closeNow()
-		s.logger.Info(s.ctx, "Data plane disconnected", log.String("dpID", dpID))
+		s.logger.Info(s.ctx, "Data plane disconnected",
+			log.String("dpID", dpID), log.String("instance", instance))
 	}()
 
 	for {

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -171,8 +171,12 @@ func (c *ChannelServerConfig) Validate() error {
 
 // ChannelClientConfig configures the Data Plane channel WebSocket client.
 type ChannelClientConfig struct {
-	Enabled         bool   `yaml:"enabled"                   json:"enabled"`
-	ID              string `yaml:"id"                        json:"id"`
+	Enabled bool   `yaml:"enabled"                   json:"enabled"`
+	ID      string `yaml:"id"                        json:"id"`
+	// Instance names which replica of this Data Plane the process is. Every replica dials the Control
+	// Plane, so without it they present one identity and each new connection evicts the last. Empty
+	// defaults to the host name, which is the pod name under Kubernetes.
+	Instance        string `yaml:"instance"                  json:"instance"`
 	ControlPlaneURL string `yaml:"control_plane_url"         json:"control_plane_url"`
 	AuthToken       string `yaml:"auth_token"                json:"auth_token"`
 	// CAFile is a PEM certificate to trust alongside the system roots when dialing the Control Plane,


### PR DESCRIPTION
### Purpose

A Data Plane runs as several pods, and every one of them dials the Control Plane. The registry kept one socket per Data Plane id and evicted the previous connection on each handshake, so replicas would evict each other in turn and leave the connection flapping, with commands landing on whichever pod connected most recently.

A Data Plane's replicas can now each hold a connection, and a command goes to exactly one of them.

### Approach

**The pod identity travels in its own header**, `X-Data-Plane-Instance`, rather than being encoded into the Data Plane id. The id stays what the environment records and what the token is issued against, so authentication and `target.dataPlaneId` are untouched, and there is no separator to collide with the `:` already in an id such as `org3:dev`. It defaults to the host name, which is the pod name under Kubernetes, and an older Data Plane that sends none is treated as a single replica.

**The registry keys on the pair**, which keeps the single-socket policy where it belongs: per replica rather than per Data Plane. A pod reconnecting still evicts its own stale socket, and never a sibling's. Sharing one id would have meant dropping eviction entirely and risking delivery into a dead connection.

**A command goes to one replica, not to all.** They share a database, so applying an import on one is visible to every other, and sending it to each would apply it several times. The choice rotates so the replicas share the work.

`Instances(id)` reports how many replicas are connected, for surfacing in the Console later.

### What this does not address

**The Control Plane is still effectively single-pod.** A socket lives in one Control Plane pod's memory, so an apply arriving at a different pod still reports the Data Plane offline. Distributed routing across Control Plane replicas remains a non-goal of the channel design (#4487) and needs a separate mechanism: a routing row in the configuration database with pod-to-pod forwarding, or a command queue. Nothing here changes that.

**One-replica delivery is only correct for work that lands in the shared database.** `Secret.Put` writes a file local to each pod, so a secret reaches one replica and not its siblings. That is a property of the current secret store rather than of this change, and it goes away when the store moves to a key vault.

### Related Issues
- N/A

### Related PRs
- Builds on #4487 (CP-DP phone-home WebSocket channel), #4501, #4513 and #4517

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
