### PR TITLE
Introduce support to add custom SMS providers

### DIFF
--- a/frontend/packages/configure-connections/src/components/ConnectionForm.tsx
+++ b/frontend/packages/configure-connections/src/components/ConnectionForm.tsx
@@ -7,7 +7,10 @@ import {
   Divider,
   FormControl,
   FormControlLabel,
+  FormHelperText,
   FormLabel,
+  MenuItem,
+  Select,
   Stack,
   Switch,
   TextField,
@@ -148,6 +151,30 @@ export default function ConnectionForm({
               error={fieldError(field.name)}
               hint={field.hintKey ? t(field.hintKey) : undefined}
             />
+          );
+        } else if (field.kind === 'select') {
+          const error: string | undefined = fieldError(field.name);
+          fieldContent = (
+            <FormControl fullWidth required={isRequiredNow(field)} error={Boolean(error)}>
+              <FormLabel htmlFor={`connection-field-${field.name}`}>{label}</FormLabel>
+              <Select
+                id={`connection-field-${field.name}`}
+                value={values[field.name] ?? ''}
+                onChange={(e) => setField(field.name, e.target.value)}
+                data-testid={`connection-field-select-${field.name}`}
+              >
+                {(field.options ?? []).map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </Select>
+              {error ? (
+                <FormHelperText>{error}</FormHelperText>
+              ) : (
+                field.hintKey && <FormHelperText>{t(field.hintKey)}</FormHelperText>
+              )}
+            </FormControl>
           );
         } else if (field.kind === 'readonly-copy') {
           fieldContent = (

--- a/frontend/packages/configure-connections/src/components/ConnectionForm.tsx
+++ b/frontend/packages/configure-connections/src/components/ConnectionForm.tsx
@@ -18,6 +18,7 @@ import {
 } from '@wso2/oxygen-ui';
 import {type JSX, type ReactNode, useMemo, useState} from 'react';
 import {Trans, useTranslation} from 'react-i18next';
+import KeyValuePairsField from './KeyValuePairsField';
 import MaskedSecretField from './MaskedSecretField';
 import ReadOnlyCopyField from './ReadOnlyCopyField';
 import {fieldsForMode, type ConnectionFieldDef} from '../config/connectionFormFields';
@@ -150,6 +151,18 @@ export default function ConnectionForm({
               required={mode === 'create' && field.required}
               error={fieldError(field.name)}
               hint={field.hintKey ? t(field.hintKey) : undefined}
+            />
+          );
+        } else if (field.kind === 'key-value') {
+          fieldContent = (
+            <KeyValuePairsField
+              id={`connection-field-${field.name}`}
+              label={label}
+              value={values[field.name] ?? ''}
+              onChange={(next) => setField(field.name, next)}
+              hint={field.hintKey ? renderHint(field.hintKey) : undefined}
+              namePlaceholder={field.placeholder}
+              addLabel={field.addLabelKey ? t(field.addLabelKey) : t('form.keyValue.add')}
             />
           );
         } else if (field.kind === 'select') {

--- a/frontend/packages/configure-connections/src/components/KeyValuePairsField.tsx
+++ b/frontend/packages/configure-connections/src/components/KeyValuePairsField.tsx
@@ -1,0 +1,175 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {Box, Button, FormLabel, IconButton, Stack, TextField, Typography} from '@wso2/oxygen-ui';
+import {Plus, Trash2} from '@wso2/oxygen-ui-icons-react';
+import {type JSX, type ReactNode, useState} from 'react';
+import {useTranslation} from 'react-i18next';
+import {
+  parseKeyValuePairs,
+  sanitizeKeyValuePart,
+  serializeKeyValuePairs,
+  type KeyValuePair,
+} from '../utils/keyValuePairs';
+
+interface KeyedPair extends KeyValuePair {
+  /** Stable React key, so editing one row never remounts the others. */
+  key: number;
+}
+
+interface KeyValuePairsFieldProps {
+  id: string;
+  label: string;
+  /** Stored wire value ("Key: value, Other: value"). */
+  value: string;
+  onChange: (value: string) => void;
+  hint?: ReactNode;
+  namePlaceholder?: string;
+  addLabel: string;
+}
+
+interface RowsState {
+  rows: KeyedPair[];
+  /** Highest key handed out so far, carried in state so new rows never reuse one. */
+  seq: number;
+  /** Wire value these rows were built from, so a change made outside re-derives them. */
+  synced: string;
+}
+
+/** Rows for the given wire value, always keeping one blank row to type into. */
+function buildRows(raw: string, fromSeq: number): RowsState {
+  const parsed: KeyValuePair[] = parseKeyValuePairs(raw);
+  const pairs: KeyValuePair[] = parsed.length > 0 ? parsed : [{name: '', value: ''}];
+  return {
+    rows: pairs.map((pair, index) => ({key: fromSeq + index + 1, ...pair})),
+    seq: fromSeq + pairs.length,
+    synced: raw,
+  };
+}
+
+/**
+ * Row-per-pair editor for a field the API stores as a single "Key: value" string. Rows are local
+ * state (a row being typed has no name yet, so it cannot round-trip through the serialized value),
+ * synced back out on every edit and re-derived when the value changes from outside, e.g. a reset.
+ */
+export default function KeyValuePairsField({
+  id,
+  label,
+  value,
+  onChange,
+  hint = undefined,
+  namePlaceholder = undefined,
+  addLabel,
+}: KeyValuePairsFieldProps): JSX.Element {
+  const {t} = useTranslation('connections');
+
+  const [state, setState] = useState<RowsState>(() => buildRows(value, 0));
+
+  // Re-derive when the value changes from outside the editor, e.g. the detail page's Reset. Rows
+  // cannot simply be computed from the value on every render: a row being typed has no name yet,
+  // so it would not survive the round trip through the serialized form.
+  if (value !== state.synced) {
+    setState(buildRows(value, state.seq));
+  }
+
+  const {rows} = state;
+
+  const commit = (next: KeyedPair[], seq: number): void => {
+    const serialized: string = serializeKeyValuePairs(next);
+    setState({rows: next, seq, synced: serialized});
+    onChange(serialized);
+  };
+
+  const updateRow = (key: number, part: 'name' | 'value', text: string): void => {
+    const next: KeyedPair[] = rows.map((row) =>
+      row.key === key ? {...row, [part]: sanitizeKeyValuePart(text, part)} : row,
+    );
+    commit(next, state.seq);
+  };
+
+  const removeRow = (key: number): void => {
+    const remaining: KeyedPair[] = rows.filter((row) => row.key !== key);
+    if (remaining.length > 0) {
+      commit(remaining, state.seq);
+      return;
+    }
+    commit([{key: state.seq + 1, name: '', value: ''}], state.seq + 1);
+  };
+
+  // Adding a blank row does not change the serialized value, so the parent is not notified.
+  const addRow = (): void =>
+    setState((prev) => ({...prev, rows: [...prev.rows, {key: prev.seq + 1, name: '', value: ''}], seq: prev.seq + 1}));
+
+  const lastRowIsEmpty: boolean =
+    rows.length > 0 && rows[rows.length - 1].name.trim() === '' && rows[rows.length - 1].value.trim() === '';
+
+  return (
+    <Box>
+      <FormLabel htmlFor={`${id}-name-1`}>{label}</FormLabel>
+      <Stack direction="column" spacing={1.5} sx={{mt: 1}} data-testid={`${id}-rows`}>
+        <Stack direction="row" spacing={1.5}>
+          <Typography variant="caption" color="text.secondary" fontWeight={600} sx={{flex: 1}}>
+            {t('form.keyValue.name')}
+          </Typography>
+          <Typography variant="caption" color="text.secondary" fontWeight={600} sx={{flex: 1}}>
+            {t('form.keyValue.value')}
+          </Typography>
+          <Box sx={{width: 40}} />
+        </Stack>
+
+        {rows.map((row, index) => {
+          const isOnlyEmptyRow: boolean = rows.length === 1 && row.name === '' && row.value === '';
+          return (
+            <Stack key={row.key} direction="row" spacing={1.5} alignItems="center">
+              <TextField
+                fullWidth
+                id={`${id}-name-${index + 1}`}
+                value={row.name}
+                placeholder={namePlaceholder}
+                onChange={(e) => updateRow(row.key, 'name', e.target.value)}
+                slotProps={{input: {'aria-label': t('form.keyValue.name')}}}
+              />
+              <TextField
+                fullWidth
+                id={`${id}-value-${index + 1}`}
+                value={row.value}
+                onChange={(e) => updateRow(row.key, 'value', e.target.value)}
+                slotProps={{input: {'aria-label': t('form.keyValue.value')}}}
+              />
+              {isOnlyEmptyRow ? (
+                <Box sx={{width: 40}} />
+              ) : (
+                <IconButton
+                  onClick={() => removeRow(row.key)}
+                  aria-label={t('form.keyValue.remove')}
+                  data-testid={`${id}-remove-${index + 1}`}
+                >
+                  <Trash2 size={16} />
+                </IconButton>
+              )}
+            </Stack>
+          );
+        })}
+
+        <Box>
+          <Button
+            variant="text"
+            size="small"
+            startIcon={<Plus size={16} />}
+            onClick={addRow}
+            disabled={lastRowIsEmpty}
+            data-testid={`${id}-add`}
+          >
+            {addLabel}
+          </Button>
+        </Box>
+
+        {hint && (
+          <Typography variant="caption" color="text.secondary">
+            {hint}
+          </Typography>
+        )}
+      </Stack>
+    </Box>
+  );
+}

--- a/frontend/packages/configure-connections/src/components/__tests__/ConnectionForm.test.tsx
+++ b/frontend/packages/configure-connections/src/components/__tests__/ConnectionForm.test.tsx
@@ -185,4 +185,40 @@ describe('ConnectionForm', () => {
       expect(isFieldMarkedRequired('jwksEndpoint')).toBe(true);
     });
   });
+
+  describe('SMS gateway create', () => {
+    const smsGatewayProps = {
+      ...baseProps,
+      type: 'sms-gateway' as const,
+      vendorDisplayName: 'SMS Gateway',
+      values: {
+        name: '',
+        url: '',
+        httpMethod: 'POST',
+        contentType: 'JSON',
+        httpHeaders: '',
+      },
+    };
+
+    it('renders the gateway fields, with the transport options as selects', () => {
+      render(<ConnectionForm {...smsGatewayProps} />);
+
+      expect(getConnectionField('url')).toBeInTheDocument();
+      expect(getConnectionField('httpHeaders')).toBeInTheDocument();
+      expect(screen.getByTestId('connection-field-select-httpMethod')).toHaveTextContent('POST');
+      expect(screen.getByTestId('connection-field-select-contentType')).toHaveTextContent('JSON');
+      expect(isFieldMarkedRequired('url')).toBe(true);
+      expect(isFieldMarkedRequired('httpHeaders')).toBe(false);
+    });
+
+    it('reports a select change through onFieldChange', async () => {
+      const onFieldChange = vi.fn();
+      render(<ConnectionForm {...smsGatewayProps} onFieldChange={onFieldChange} />);
+
+      fireEvent.mouseDown(getConnectionField('contentType'));
+      fireEvent.click(await screen.findByRole('option', {name: 'FORM'}));
+
+      expect(onFieldChange).toHaveBeenCalledWith('contentType', 'FORM');
+    });
+  });
 });

--- a/frontend/packages/configure-connections/src/components/__tests__/ConnectionForm.test.tsx
+++ b/frontend/packages/configure-connections/src/components/__tests__/ConnectionForm.test.tsx
@@ -234,6 +234,16 @@ describe('ConnectionForm', () => {
       expect(isFieldMarkedRequired('url')).toBe(true);
     });
 
+    it('marks only the gateway URL required, leaving the defaulted transport fields unmarked', () => {
+      render(<ConnectionForm {...smsGatewayProps} showNameField />);
+
+      expect(isFieldMarkedRequired('name')).toBe(true);
+      expect(isFieldMarkedRequired('url')).toBe(true);
+      expect(isFieldMarkedRequired('httpMethod')).toBe(false);
+      expect(isFieldMarkedRequired('contentType')).toBe(false);
+      expect(isFieldMarkedRequired('httpHeaders')).toBe(false);
+    });
+
     it('reports a select change through onFieldChange', async () => {
       const onFieldChange = vi.fn();
       render(<ConnectionForm {...smsGatewayProps} onFieldChange={onFieldChange} />);

--- a/frontend/packages/configure-connections/src/components/__tests__/ConnectionForm.test.tsx
+++ b/frontend/packages/configure-connections/src/components/__tests__/ConnectionForm.test.tsx
@@ -299,6 +299,26 @@ describe('ConnectionForm', () => {
       expect(getConnectionField('httpHeaders-name-1')).toHaveValue('Accept');
     });
 
+    it('omits a header row whose value is empty, keeping the row on screen to finish', () => {
+      const onFieldChange = vi.fn();
+      render(<ControlledConnectionForm {...smsGatewayProps} onFieldChange={onFieldChange} />);
+
+      fireEvent.change(getConnectionField('httpHeaders-name-1'), {target: {value: 'Content-Type'}});
+      fireEvent.change(getConnectionField('httpHeaders-value-1'), {target: {value: 'application/json'}});
+      fireEvent.click(screen.getByTestId('connection-field-httpHeaders-add'));
+      fireEvent.change(getConnectionField('httpHeaders-name-2'), {target: {value: 'Accept'}});
+
+      expect(onFieldChange).toHaveBeenLastCalledWith('httpHeaders', 'Content-Type: application/json');
+      expect(getConnectionField('httpHeaders-name-2')).toHaveValue('Accept');
+
+      fireEvent.change(getConnectionField('httpHeaders-value-2'), {target: {value: 'text/plain'}});
+
+      expect(onFieldChange).toHaveBeenLastCalledWith(
+        'httpHeaders',
+        'Content-Type: application/json, Accept: text/plain',
+      );
+    });
+
     it('re-derives rows when the value changes outside the editor, as the detail page Reset does', () => {
       const {rerender} = render(
         <ConnectionForm {...smsGatewayProps} values={{...smsGatewayProps.values, httpHeaders: 'X-API-Key: abc123'}} />,

--- a/frontend/packages/configure-connections/src/components/__tests__/ConnectionForm.test.tsx
+++ b/frontend/packages/configure-connections/src/components/__tests__/ConnectionForm.test.tsx
@@ -2,8 +2,32 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {fireEvent, render, screen} from '@thunderid/test-utils';
+import {type ComponentProps, useState} from 'react';
 import {describe, expect, it, vi} from 'vitest';
 import ConnectionForm from '../ConnectionForm';
+
+/**
+ * ConnectionForm is controlled: edits only show up if the parent feeds them back through `values`,
+ * as ConnectionCreateWizardPage and ConnectionDetailPage do. Tests that assert on what a field
+ * displays after an edit render through this harness rather than static props.
+ */
+function ControlledConnectionForm({
+  values: initialValues,
+  onFieldChange,
+  ...rest
+}: ComponentProps<typeof ConnectionForm>): ReturnType<typeof ConnectionForm> {
+  const [values, setValues] = useState(initialValues);
+  return (
+    <ConnectionForm
+      {...rest}
+      values={values}
+      onFieldChange={(name, value) => {
+        onFieldChange(name, value);
+        setValues((prev) => ({...prev, [name]: value}));
+      }}
+    />
+  );
+}
 
 vi.mock('@thunderid/contexts', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@thunderid/contexts')>()),
@@ -204,11 +228,10 @@ describe('ConnectionForm', () => {
       render(<ConnectionForm {...smsGatewayProps} />);
 
       expect(getConnectionField('url')).toBeInTheDocument();
-      expect(getConnectionField('httpHeaders')).toBeInTheDocument();
+      expect(screen.getByTestId('connection-field-httpHeaders-rows')).toBeInTheDocument();
       expect(screen.getByTestId('connection-field-select-httpMethod')).toHaveTextContent('POST');
       expect(screen.getByTestId('connection-field-select-contentType')).toHaveTextContent('JSON');
       expect(isFieldMarkedRequired('url')).toBe(true);
-      expect(isFieldMarkedRequired('httpHeaders')).toBe(false);
     });
 
     it('reports a select change through onFieldChange', async () => {
@@ -219,6 +242,84 @@ describe('ConnectionForm', () => {
       fireEvent.click(await screen.findByRole('option', {name: 'FORM'}));
 
       expect(onFieldChange).toHaveBeenCalledWith('contentType', 'FORM');
+    });
+
+    it('renders one header row per stored pair, plus no blank row', () => {
+      render(
+        <ConnectionForm
+          {...smsGatewayProps}
+          values={{...smsGatewayProps.values, httpHeaders: 'X-API-Key: abc123, Accept: application/json'}}
+        />,
+      );
+
+      expect(getConnectionField('httpHeaders-name-1')).toHaveValue('X-API-Key');
+      expect(getConnectionField('httpHeaders-value-1')).toHaveValue('abc123');
+      expect(getConnectionField('httpHeaders-name-2')).toHaveValue('Accept');
+      expect(getConnectionField('httpHeaders-value-2')).toHaveValue('application/json');
+      expect(document.getElementById('connection-field-httpHeaders-name-3')).not.toBeInTheDocument();
+    });
+
+    it('starts with a single blank row when no headers are stored', () => {
+      render(<ConnectionForm {...smsGatewayProps} />);
+
+      expect(getConnectionField('httpHeaders-name-1')).toHaveValue('');
+      expect(document.getElementById('connection-field-httpHeaders-name-2')).not.toBeInTheDocument();
+      expect(screen.getByTestId('connection-field-httpHeaders-add')).toBeDisabled();
+    });
+
+    it('serializes edited rows into the stored comma-separated format', () => {
+      const onFieldChange = vi.fn();
+      render(<ControlledConnectionForm {...smsGatewayProps} onFieldChange={onFieldChange} />);
+
+      fireEvent.change(getConnectionField('httpHeaders-name-1'), {target: {value: 'X-API-Key'}});
+      fireEvent.change(getConnectionField('httpHeaders-value-1'), {target: {value: 'abc123'}});
+
+      expect(onFieldChange).toHaveBeenLastCalledWith('httpHeaders', 'X-API-Key: abc123');
+
+      fireEvent.click(screen.getByTestId('connection-field-httpHeaders-add'));
+      fireEvent.change(getConnectionField('httpHeaders-name-2'), {target: {value: 'Accept'}});
+      fireEvent.change(getConnectionField('httpHeaders-value-2'), {target: {value: 'application/json'}});
+
+      expect(onFieldChange).toHaveBeenLastCalledWith('httpHeaders', 'X-API-Key: abc123, Accept: application/json');
+    });
+
+    it('removes a header row and re-serializes without it', () => {
+      const onFieldChange = vi.fn();
+      render(
+        <ControlledConnectionForm
+          {...smsGatewayProps}
+          values={{...smsGatewayProps.values, httpHeaders: 'X-API-Key: abc123, Accept: application/json'}}
+          onFieldChange={onFieldChange}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId('connection-field-httpHeaders-remove-1'));
+
+      expect(onFieldChange).toHaveBeenLastCalledWith('httpHeaders', 'Accept: application/json');
+      expect(getConnectionField('httpHeaders-name-1')).toHaveValue('Accept');
+    });
+
+    it('re-derives rows when the value changes outside the editor, as the detail page Reset does', () => {
+      const {rerender} = render(
+        <ConnectionForm {...smsGatewayProps} values={{...smsGatewayProps.values, httpHeaders: 'X-API-Key: abc123'}} />,
+      );
+      expect(getConnectionField('httpHeaders-name-1')).toHaveValue('X-API-Key');
+
+      rerender(<ConnectionForm {...smsGatewayProps} values={{...smsGatewayProps.values, httpHeaders: ''}} />);
+
+      expect(getConnectionField('httpHeaders-name-1')).toHaveValue('');
+      expect(document.getElementById('connection-field-httpHeaders-name-2')).not.toBeInTheDocument();
+    });
+
+    it('strips characters the stored format cannot represent', () => {
+      const onFieldChange = vi.fn();
+      render(<ControlledConnectionForm {...smsGatewayProps} onFieldChange={onFieldChange} />);
+
+      fireEvent.change(getConnectionField('httpHeaders-name-1'), {target: {value: 'X-A:B,C'}});
+      fireEvent.change(getConnectionField('httpHeaders-value-1'), {target: {value: 'text/html, application/json'}});
+
+      expect(getConnectionField('httpHeaders-name-1')).toHaveValue('X-ABC');
+      expect(onFieldChange).toHaveBeenLastCalledWith('httpHeaders', 'X-ABC: text/html application/json');
     });
   });
 });

--- a/frontend/packages/configure-connections/src/components/create-connection/SelectConnectionType.tsx
+++ b/frontend/packages/configure-connections/src/components/create-connection/SelectConnectionType.tsx
@@ -2,7 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {Box, Card, CardActionArea, CardContent, Chip, Stack, Typography} from '@wso2/oxygen-ui';
-import {ArrowLeftRight, CircleCheck, KeyRound, LogIn, Send, ShieldCheck, Webhook} from '@wso2/oxygen-ui-icons-react';
+import {
+  ArrowLeftRight,
+  CircleCheck,
+  KeyRound,
+  LogIn,
+  MessagesSquare,
+  Send,
+  ShieldCheck,
+} from '@wso2/oxygen-ui-icons-react';
 import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {type ConnectionType, ConnectionTypes} from '../../models/connection';
@@ -62,15 +70,13 @@ export default function SelectConnectionType({selectedType, onSelect}: SelectCon
       comingSoon: false,
     },
     {
-      // Backend support (/connections/sms-gateway) is wired; the console wizard for this
-      // card is a follow-up, so it stays comingSoon here.
-      type: 'custom-sms' as ConnectionType,
+      type: ConnectionTypes.SMS_GATEWAY,
       labelKey: 'wizard.type.sms.label',
       descriptionKey: 'wizard.type.sms.description',
       tagKey: 'wizard.type.sms.tag',
-      icon: <Webhook size={28} />,
+      icon: <MessagesSquare size={28} />,
       tagIcon: <Send size={14} />,
-      comingSoon: true,
+      comingSoon: false,
     },
   ];
 

--- a/frontend/packages/configure-connections/src/components/create-connection/__tests__/SelectConnectionType.test.tsx
+++ b/frontend/packages/configure-connections/src/components/create-connection/__tests__/SelectConnectionType.test.tsx
@@ -16,7 +16,7 @@ describe('SelectConnectionType', () => {
     expect(screen.getByTestId('connection-type-option-oidc')).toBeInTheDocument();
     expect(screen.getByTestId('connection-type-option-oauth')).toBeInTheDocument();
     expect(screen.getByTestId('connection-type-option-trusted-idp')).toBeInTheDocument();
-    expect(screen.getByTestId('connection-type-option-custom-sms')).toBeInTheDocument();
+    expect(screen.getByTestId('connection-type-option-sms-gateway')).toBeInTheDocument();
   });
 
   it('selects the OIDC type when clicked', () => {
@@ -31,10 +31,10 @@ describe('SelectConnectionType', () => {
     expect(onSelect).toHaveBeenCalledWith('oauth');
   });
 
-  it('does not select the disabled Custom SMS gateway option', () => {
+  it('selects the SMS gateway type when clicked', () => {
     render(<SelectConnectionType selectedType={null} onSelect={onSelect} />);
-    fireEvent.click(screen.getByTestId('connection-type-option-custom-sms'));
-    expect(onSelect).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId('connection-type-option-sms-gateway'));
+    expect(onSelect).toHaveBeenCalledWith('sms-gateway');
   });
 
   it('selects the Trusted Token Issuer type when clicked', () => {
@@ -43,12 +43,12 @@ describe('SelectConnectionType', () => {
     expect(onSelect).toHaveBeenCalledWith('trusted-idp');
   });
 
-  it('renders the Trusted Token Issuer option before the coming-soon SMS gateway option', () => {
+  it('renders the Trusted Token Issuer option before the SMS gateway option', () => {
     render(<SelectConnectionType selectedType={null} onSelect={onSelect} />);
 
     const optionIds = screen.getAllByTestId(/^connection-type-option-/).map((el) => el.getAttribute('data-testid'));
     expect(optionIds.indexOf('connection-type-option-trusted-idp')).toBeLessThan(
-      optionIds.indexOf('connection-type-option-custom-sms'),
+      optionIds.indexOf('connection-type-option-sms-gateway'),
     );
   });
 });

--- a/frontend/packages/configure-connections/src/config/__tests__/connectionFormFields.test.ts
+++ b/frontend/packages/configure-connections/src/config/__tests__/connectionFormFields.test.ts
@@ -89,10 +89,18 @@ describe('fieldsForMode', () => {
     const httpMethod = fields.find((field) => field.name === 'httpMethod');
     const contentType = fields.find((field) => field.name === 'contentType');
 
-    expect(httpMethod).toMatchObject({kind: 'select', required: true, defaultValue: 'POST'});
+    expect(httpMethod).toMatchObject({kind: 'select', defaultValue: 'POST'});
     expect(httpMethod?.options?.map((option) => option.value)).toEqual(['POST', 'GET']);
-    expect(contentType).toMatchObject({kind: 'select', required: true, defaultValue: 'JSON'});
+    expect(contentType).toMatchObject({kind: 'select', defaultValue: 'JSON'});
     expect(contentType?.options?.map((option) => option.value)).toEqual(['JSON', 'FORM']);
+  });
+
+  it('marks only name and the gateway URL required, matching the API contract', () => {
+    const required: string[] = fieldsForMode(ConnectionTypes.SMS_GATEWAY, 'create')
+      .filter((field) => field.required)
+      .map((field) => field.name);
+
+    expect(required).toEqual(['name', 'url']);
   });
 
   it('edits SMS gateway headers as key-value rows rather than one packed string', () => {

--- a/frontend/packages/configure-connections/src/config/__tests__/connectionFormFields.test.ts
+++ b/frontend/packages/configure-connections/src/config/__tests__/connectionFormFields.test.ts
@@ -94,4 +94,11 @@ describe('fieldsForMode', () => {
     expect(contentType).toMatchObject({kind: 'select', required: true, defaultValue: 'JSON'});
     expect(contentType?.options?.map((option) => option.value)).toEqual(['JSON', 'FORM']);
   });
+
+  it('edits SMS gateway headers as key-value rows rather than one packed string', () => {
+    const headers = fieldsForMode(ConnectionTypes.SMS_GATEWAY, 'create').find((field) => field.name === 'httpHeaders');
+
+    expect(headers).toMatchObject({kind: 'key-value', addLabelKey: 'connections:form.fields.httpHeaders.add'});
+    expect(headers?.required).toBeUndefined();
+  });
 });

--- a/frontend/packages/configure-connections/src/config/__tests__/connectionFormFields.test.ts
+++ b/frontend/packages/configure-connections/src/config/__tests__/connectionFormFields.test.ts
@@ -74,5 +74,24 @@ describe('fieldsForMode', () => {
   it('does not hide any SMS vendor fields on create', () => {
     expect(fieldNames(ConnectionTypes.TWILIO, 'create')).toEqual(fieldNames(ConnectionTypes.TWILIO, 'edit'));
     expect(fieldNames(ConnectionTypes.VONAGE, 'create')).toEqual(fieldNames(ConnectionTypes.VONAGE, 'edit'));
+    expect(fieldNames(ConnectionTypes.SMS_GATEWAY, 'create')).toEqual([
+      'name',
+      'url',
+      'httpMethod',
+      'contentType',
+      'httpHeaders',
+    ]);
+    expect(fieldNames(ConnectionTypes.SMS_GATEWAY, 'create')).toEqual(fieldNames(ConnectionTypes.SMS_GATEWAY, 'edit'));
+  });
+
+  it('offers the SMS gateway method and content type as selects with the API-accepted values', () => {
+    const fields = fieldsForMode(ConnectionTypes.SMS_GATEWAY, 'create');
+    const httpMethod = fields.find((field) => field.name === 'httpMethod');
+    const contentType = fields.find((field) => field.name === 'contentType');
+
+    expect(httpMethod).toMatchObject({kind: 'select', required: true, defaultValue: 'POST'});
+    expect(httpMethod?.options?.map((option) => option.value)).toEqual(['POST', 'GET']);
+    expect(contentType).toMatchObject({kind: 'select', required: true, defaultValue: 'JSON'});
+    expect(contentType?.options?.map((option) => option.value)).toEqual(['JSON', 'FORM']);
   });
 });

--- a/frontend/packages/configure-connections/src/config/connectionFormFields.ts
+++ b/frontend/packages/configure-connections/src/config/connectionFormFields.ts
@@ -3,10 +3,16 @@
 
 import {type ConnectionType, ConnectionTypes} from '../models/connection';
 
-export type ConnectionFieldKind = 'text' | 'url' | 'secret' | 'scopes' | 'readonly-copy' | 'switch';
+export type ConnectionFieldKind = 'text' | 'url' | 'secret' | 'scopes' | 'readonly-copy' | 'switch' | 'select';
 
 /** Which form mode renders a field. Defaults to 'both' when unset. */
 export type ConnectionFieldVisibility = 'create' | 'edit' | 'both';
+
+/** One choice of a 'select' field. Values are sent to the API verbatim. */
+export interface ConnectionFieldOption {
+  value: string;
+  label: string;
+}
 
 export interface ConnectionFieldDef {
   /** Request payload property this field maps to. */
@@ -18,6 +24,10 @@ export interface ConnectionFieldDef {
   /** Required on create. Secret fields are required on create but optional (omit-to-keep) on edit. */
   required?: boolean;
   placeholder?: string;
+  /** Choices of a 'select' field. */
+  options?: ConnectionFieldOption[];
+  /** Value prefilled on create (and used when the API returns none). */
+  defaultValue?: string;
   /** Format the value must match (checked only when non-empty). Mirrors backend validation. */
   pattern?: RegExp;
   /** i18n key for the error shown when {@link pattern} does not match. */
@@ -307,6 +317,48 @@ export const CONNECTION_FORM_FIELDS: Record<ConnectionType, ConnectionFieldDef[]
       kind: 'text',
       required: true,
       placeholder: '+15005550006',
+    },
+  ],
+  [ConnectionTypes.SMS_GATEWAY]: [
+    NAME_FIELD('Custom SMS Sender'),
+    {
+      name: 'url',
+      labelKey: 'connections:form.fields.smsGatewayUrl.label',
+      hintKey: 'connections:form.fields.smsGatewayUrl.hint',
+      kind: 'url',
+      required: true,
+      placeholder: 'https://sms.example.com/send',
+    },
+    {
+      name: 'httpMethod',
+      labelKey: 'connections:form.fields.httpMethod.label',
+      hintKey: 'connections:form.fields.httpMethod.hint',
+      kind: 'select',
+      required: true,
+      defaultValue: 'POST',
+      options: [
+        {value: 'POST', label: 'POST'},
+        {value: 'GET', label: 'GET'},
+      ],
+    },
+    {
+      name: 'contentType',
+      labelKey: 'connections:form.fields.contentType.label',
+      hintKey: 'connections:form.fields.contentType.hint',
+      kind: 'select',
+      required: true,
+      defaultValue: 'JSON',
+      options: [
+        {value: 'JSON', label: 'JSON'},
+        {value: 'FORM', label: 'FORM'},
+      ],
+    },
+    {
+      name: 'httpHeaders',
+      labelKey: 'connections:form.fields.httpHeaders.label',
+      hintKey: 'connections:form.fields.httpHeaders.hint',
+      kind: 'text',
+      placeholder: 'X-API-Key: abc123',
     },
   ],
 };

--- a/frontend/packages/configure-connections/src/config/connectionFormFields.ts
+++ b/frontend/packages/configure-connections/src/config/connectionFormFields.ts
@@ -344,7 +344,6 @@ export const CONNECTION_FORM_FIELDS: Record<ConnectionType, ConnectionFieldDef[]
       labelKey: 'connections:form.fields.httpMethod.label',
       hintKey: 'connections:form.fields.httpMethod.hint',
       kind: 'select',
-      required: true,
       defaultValue: 'POST',
       options: [
         {value: 'POST', label: 'POST'},
@@ -356,7 +355,6 @@ export const CONNECTION_FORM_FIELDS: Record<ConnectionType, ConnectionFieldDef[]
       labelKey: 'connections:form.fields.contentType.label',
       hintKey: 'connections:form.fields.contentType.hint',
       kind: 'select',
-      required: true,
       defaultValue: 'JSON',
       options: [
         {value: 'JSON', label: 'JSON'},

--- a/frontend/packages/configure-connections/src/config/connectionFormFields.ts
+++ b/frontend/packages/configure-connections/src/config/connectionFormFields.ts
@@ -3,7 +3,15 @@
 
 import {type ConnectionType, ConnectionTypes} from '../models/connection';
 
-export type ConnectionFieldKind = 'text' | 'url' | 'secret' | 'scopes' | 'readonly-copy' | 'switch' | 'select';
+export type ConnectionFieldKind =
+  | 'text'
+  | 'url'
+  | 'secret'
+  | 'scopes'
+  | 'readonly-copy'
+  | 'switch'
+  | 'select'
+  | 'key-value';
 
 /** Which form mode renders a field. Defaults to 'both' when unset. */
 export type ConnectionFieldVisibility = 'create' | 'edit' | 'both';
@@ -26,6 +34,8 @@ export interface ConnectionFieldDef {
   placeholder?: string;
   /** Choices of a 'select' field. */
   options?: ConnectionFieldOption[];
+  /** i18n key for the add-row button of a 'key-value' field. */
+  addLabelKey?: string;
   /** Value prefilled on create (and used when the API returns none). */
   defaultValue?: string;
   /** Format the value must match (checked only when non-empty). Mirrors backend validation. */
@@ -357,8 +367,9 @@ export const CONNECTION_FORM_FIELDS: Record<ConnectionType, ConnectionFieldDef[]
       name: 'httpHeaders',
       labelKey: 'connections:form.fields.httpHeaders.label',
       hintKey: 'connections:form.fields.httpHeaders.hint',
-      kind: 'text',
-      placeholder: 'X-API-Key: abc123',
+      kind: 'key-value',
+      placeholder: 'X-API-Key',
+      addLabelKey: 'connections:form.fields.httpHeaders.add',
     },
   ],
 };

--- a/frontend/packages/configure-connections/src/config/connectionVendorMeta.tsx
+++ b/frontend/packages/configure-connections/src/config/connectionVendorMeta.tsx
@@ -1,7 +1,7 @@
 // Copyright 2025 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import {GitHub, Google, KeyRound, MessageSquare, Send, ShieldCheck} from '@wso2/oxygen-ui-icons-react';
+import {GitHub, Google, KeyRound, MessageSquare, MessagesSquare, Send, ShieldCheck} from '@wso2/oxygen-ui-icons-react';
 import {CONNECTION_CATEGORIES} from '../constants/connection-categories';
 import {type ConnectionCategory, ConnectionTypes, type ConnectionVendorMeta} from '../models/connection';
 
@@ -72,6 +72,15 @@ export const CONNECTION_VENDOR_META: ConnectionVendorMeta[] = [
     logo: <Send />,
     categories: ['sms'],
     presentation: 'branded',
+  },
+  {
+    key: 'sms-gateway',
+    backendType: ConnectionTypes.SMS_GATEWAY,
+    displayName: 'SMS Gateway',
+    descriptionKey: 'connections:vendor.sms-gateway.description',
+    logo: <MessagesSquare />,
+    categories: ['sms', 'custom'],
+    presentation: 'custom',
   },
 ];
 

--- a/frontend/packages/configure-connections/src/index.ts
+++ b/frontend/packages/configure-connections/src/index.ts
@@ -23,6 +23,7 @@ export {default as ConnectionDeleteDialog} from './components/ConnectionDeleteDi
 export {default as ConnectionForm} from './components/ConnectionForm';
 export {default as ConnectionFullPageLayout} from './components/ConnectionFullPageLayout';
 export {default as ConnectionsList} from './components/ConnectionsList';
+export {default as KeyValuePairsField} from './components/KeyValuePairsField';
 export {default as MaskedSecretField} from './components/MaskedSecretField';
 export {default as ReadOnlyCopyField} from './components/ReadOnlyCopyField';
 export {default as SelectConnectionType} from './components/create-connection/SelectConnectionType';
@@ -60,3 +61,4 @@ export {default as buildConnectionCards} from './utils/buildConnectionCards';
 export * from './utils/connectionFormMapping';
 export {default as getConnectionIcon} from './utils/getConnectionIcon';
 export {default as isConflictError} from './utils/isConflictError';
+export * from './utils/keyValuePairs';

--- a/frontend/packages/configure-connections/src/models/connection.ts
+++ b/frontend/packages/configure-connections/src/models/connection.ts
@@ -13,6 +13,7 @@ export const ConnectionTypes = {
   OAUTH: 'oauth',
   TWILIO: 'twilio',
   VONAGE: 'vonage',
+  SMS_GATEWAY: 'sms-gateway',
 } as const;
 
 export type ConnectionType = (typeof ConnectionTypes)[keyof typeof ConnectionTypes];
@@ -45,19 +46,13 @@ export type ConnectionInstanceCategory =
   (typeof ConnectionInstanceCategories)[keyof typeof ConnectionInstanceCategories];
 
 /**
- * Instance vendor type — ConnectionType plus 'sms-gateway' (the generic HTTP webhook SMS
- * sender vendor).
- */
-export type ConnectionInstanceType = ConnectionType | 'sms-gateway';
-
-/**
  * One entry of GET /connections — a configured connection instance.
  */
 export interface ConnectionInstance {
   id: string;
   name: string;
   description?: string;
-  type: ConnectionInstanceType;
+  type: ConnectionType;
   categories: ConnectionInstanceCategory[];
   /**
    * Present only for trust-only OIDC instances (trusted issuers); absent for plain federation
@@ -231,12 +226,28 @@ export interface VonageConnectionRequest {
   senderId: string;
 }
 
+/**
+ * Request payload for a generic HTTP SMS gateway connection — a webhook ThunderID calls to
+ * deliver the message, for SMS providers without a dedicated vendor integration.
+ */
+export interface SMSGatewayConnectionRequest {
+  name: string;
+  description?: string;
+  /** The HTTP endpoint called to send an SMS. */
+  url: string;
+  httpMethod: string;
+  contentType: string;
+  /** Comma-separated "Key: value" pairs sent with every request. */
+  httpHeaders?: string;
+}
+
 export type ConnectionRequest =
   | OAuthConnectionRequest
   | OIDCConnectionRequest
   | OAuth2ConnectionRequest
   | TwilioConnectionRequest
-  | VonageConnectionRequest;
+  | VonageConnectionRequest
+  | SMSGatewayConnectionRequest;
 
 /**
  * Vendor response — secrets returned masked as "******". A superset carrying every vendor's
@@ -253,6 +264,11 @@ export interface ConnectionResponse extends OIDCConnectionRequest {
   apiSecret?: string;
   /** SMS (shared) field. */
   senderId?: string;
+  /** SMS gateway fields. */
+  url?: string;
+  httpMethod?: string;
+  contentType?: string;
+  httpHeaders?: string;
 }
 
 /**
@@ -268,7 +284,7 @@ export type ConnectionPresentation = 'branded' | 'custom' | 'coming-soon';
  * Frontend-owned presentation metadata for a vendor.
  */
 export interface ConnectionVendorMeta {
-  /** Stable map key (matches backendType for real vendors, e.g. "google", or "custom-sms"). */
+  /** Stable map key (matches backendType for real vendors, e.g. "google"). */
   key: string;
   /** The backend /connections type, when this vendor maps to one. */
   backendType?: ConnectionType;

--- a/frontend/packages/configure-connections/src/pages/ConnectionCreateWizardPage.tsx
+++ b/frontend/packages/configure-connections/src/pages/ConnectionCreateWizardPage.tsx
@@ -52,9 +52,9 @@ export default function ConnectionCreateWizardPage(): JSX.Element {
 
   const isTrustedIdp: boolean = selectedType === 'trusted-idp';
 
-  // Defaults to OIDC before the user picks a type on the first step; the SMS placeholder is
-  // disabled and unselectable, and the trusted-idp pseudo-type renders via TrustedIssuerCreateForm
-  // instead, so this is only read when rendering the generic configure step.
+  // Defaults to OIDC before the user picks a type on the first step; the trusted-idp pseudo-type
+  // renders via TrustedIssuerCreateForm instead, so this is only read when rendering the generic
+  // configure step.
   const activeType: ConnectionType =
     selectedType && selectedType !== 'trusted-idp' ? selectedType : ConnectionTypes.OIDC;
   const createMutation = useCreateConnection(activeType);
@@ -63,6 +63,9 @@ export default function ConnectionCreateWizardPage(): JSX.Element {
   const createFields = useMemo(() => fieldsForMode(activeType, 'create'), [activeType]);
   const redirectUri = getGateCallbackUrl();
   const emptyValues = useMemo(() => emptyFormValues(fields, redirectUri), [fields, redirectUri]);
+
+  // Only federated login providers carry a redirect URI to register with the provider.
+  const usesRedirectUri: boolean = fields.some((field) => field.name === 'redirectUri');
 
   const trimmedName: string = connectionName.trim();
   const values: ConnectionFormValues = {...emptyValues, ...editedValues, name: trimmedName};
@@ -174,13 +177,15 @@ export default function ConnectionCreateWizardPage(): JSX.Element {
             </Typography>
           </Stack>
 
-          <ConnectionCreateHint
-            instruction={t(
-              'wizard.configure.redirectHint',
-              'Register the redirect URI below with your identity provider as an allowed callback URL, then enter the credentials and endpoints it gives you.',
-            )}
-            redirectUri={redirectUri}
-          />
+          {usesRedirectUri && (
+            <ConnectionCreateHint
+              instruction={t(
+                'wizard.configure.redirectHint',
+                'Register the redirect URI below with your identity provider as an allowed callback URL, then enter the credentials and endpoints it gives you.',
+              )}
+              redirectUri={redirectUri}
+            />
+          )}
 
           <Paper variant="outlined" sx={{p: 3}}>
             <ConnectionForm

--- a/frontend/packages/configure-connections/src/pages/__tests__/ConnectionCreateWizardPage.test.tsx
+++ b/frontend/packages/configure-connections/src/pages/__tests__/ConnectionCreateWizardPage.test.tsx
@@ -27,12 +27,14 @@ vi.mock('../../api/useCreateConnection', () => ({default: () => ({mutate: mutate
 vi.mock('../../components/ConnectionForm', () => ({
   default: function StubConnectionForm({onFieldChange}: {onFieldChange: (name: string, value: string) => void}) {
     useEffect(() => {
-      // Populate the fields required by every connection type used in these tests (oidc, oauth).
+      // Populate the fields required by every connection type used in these tests
+      // (oidc, oauth, sms-gateway).
       onFieldChange('clientId', 'x');
       onFieldChange('clientSecret', 's');
       onFieldChange('authorizationEndpoint', 'https://idp.example.com/authorize');
       onFieldChange('tokenEndpoint', 'https://idp.example.com/token');
       onFieldChange('userInfoEndpoint', 'https://idp.example.com/userinfo');
+      onFieldChange('url', 'https://sms.example.com/send');
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
     return <div data-testid="stub-connection-form" />;
@@ -146,6 +148,35 @@ describe('ConnectionCreateWizardPage', () => {
     onSuccess({id: 'conn-1'});
 
     expect(navigateMock).toHaveBeenCalledWith('/connections/oidc/conn-1');
+  });
+
+  it('creates an SMS gateway connection with the selected transport defaults', () => {
+    render(<ConnectionCreateWizardPage />);
+
+    selectTypeAndName('connection-type-option-sms-gateway', 'Custom SMS Sender');
+    fireEvent.click(screen.getByTestId('wizard-create'));
+
+    expect(mutateMock).toHaveBeenCalledTimes(1);
+    expect(mutateMock.mock.calls[0][0]).toEqual({
+      name: 'Custom SMS Sender',
+      url: 'https://sms.example.com/send',
+      httpMethod: 'POST',
+      contentType: 'JSON',
+    });
+
+    const {onSuccess} = mutateMock.mock.calls[0][1] as {onSuccess: (data: {id: string}) => void};
+    onSuccess({id: 'sms-1'});
+
+    expect(navigateMock).toHaveBeenCalledWith('/connections/sms-gateway/sms-1');
+  });
+
+  it('hides the redirect-URI hint for connection types that do not use one', () => {
+    render(<ConnectionCreateWizardPage />);
+
+    selectTypeAndName('connection-type-option-sms-gateway');
+
+    expect(screen.getByTestId('stub-connection-form')).toBeInTheDocument();
+    expect(screen.queryByTestId('connection-create-hint')).not.toBeInTheDocument();
   });
 
   it('returns to the name step with a duplicate-name error on a 409 create conflict', () => {

--- a/frontend/packages/configure-connections/src/utils/__tests__/buildConnectionCards.test.ts
+++ b/frontend/packages/configure-connections/src/utils/__tests__/buildConnectionCards.test.ts
@@ -37,6 +37,15 @@ const VENDORS: ConnectionVendorMeta[] = [
     presentation: 'custom',
   },
   {
+    key: 'sms-gateway',
+    backendType: 'sms-gateway',
+    displayName: 'SMS Gateway',
+    descriptionKey: 'connections:vendor.sms-gateway.description',
+    logo: LOGO,
+    categories: ['sms', 'custom'],
+    presentation: 'custom',
+  },
+  {
     key: 'twilio',
     displayName: 'Twilio',
     descriptionKey: 'connections:vendor.twilio.description',
@@ -100,6 +109,21 @@ describe('buildConnectionCards', () => {
     expect(oidcCards[1].navTarget).toBe('/connections/oidc/b2');
   });
 
+  it('renders one card per SMS gateway instance', () => {
+    const instances: ConnectionInstance[] = [
+      {id: 's1', name: 'Prod SMS Gateway', type: 'sms-gateway', categories: ['sms-provider']},
+    ];
+    const cards = buildConnectionCards(instances, VENDORS);
+
+    expect(cards.filter((c) => c.vendorKey === 'sms-gateway')).toHaveLength(1);
+    expect(cards.find((c) => c.vendorKey === 'sms-gateway')).toMatchObject({
+      id: 'sms-gateway:s1',
+      displayName: 'Prod SMS Gateway',
+      status: 'configured',
+      navTarget: '/connections/sms-gateway/s1',
+    });
+  });
+
   it('renders no custom cards when there are no instances', () => {
     const cards = buildConnectionCards([], VENDORS);
     expect(cards.filter((c) => c.vendorKey === 'oidc')).toHaveLength(0);
@@ -107,7 +131,7 @@ describe('buildConnectionCards', () => {
 
   it('ignores instances whose type has no vendor meta', () => {
     const instances: ConnectionInstance[] = [
-      {id: 's1', name: 'Custom Gateway', type: 'sms-gateway', categories: ['sms-provider']},
+      {id: 's1', name: 'Custom Gateway', type: 'vonage', categories: ['sms-provider']},
     ];
     const cards = buildConnectionCards(instances, VENDORS);
     expect(cards.some((c) => c.displayName === 'Custom Gateway')).toBe(false);

--- a/frontend/packages/configure-connections/src/utils/__tests__/connectionFormMapping.test.ts
+++ b/frontend/packages/configure-connections/src/utils/__tests__/connectionFormMapping.test.ts
@@ -123,6 +123,22 @@ describe('formValuesToRequest', () => {
     });
   });
 
+  it('still sends the SMS gateway transport defaults now that neither field is required', () => {
+    const values = {
+      ...emptyFormValues(SMS_GATEWAY_FIELDS, REDIRECT),
+      name: 'Custom SMS Sender',
+      url: 'https://sms.example.com/send',
+    };
+
+    expect(validateConnectionForm(values, SMS_GATEWAY_FIELDS, 'create')).toEqual({});
+    expect(formValuesToRequest(values, SMS_GATEWAY_FIELDS, {mode: 'create'})).toEqual({
+      name: 'Custom SMS Sender',
+      url: 'https://sms.example.com/send',
+      httpMethod: 'POST',
+      contentType: 'JSON',
+    });
+  });
+
   it('omits the secret on edit when not replacing (keep stored value)', () => {
     const payload = formValuesToRequest(base, GOOGLE_FIELDS, {
       mode: 'edit',

--- a/frontend/packages/configure-connections/src/utils/__tests__/connectionFormMapping.test.ts
+++ b/frontend/packages/configure-connections/src/utils/__tests__/connectionFormMapping.test.ts
@@ -14,6 +14,7 @@ import {
 const GOOGLE_FIELDS = CONNECTION_FORM_FIELDS.google;
 const OIDC_FIELDS = CONNECTION_FORM_FIELDS.oidc;
 const TWILIO_FIELDS = CONNECTION_FORM_FIELDS.twilio;
+const SMS_GATEWAY_FIELDS = CONNECTION_FORM_FIELDS['sms-gateway'];
 const REDIRECT = 'https://id.acme.io/oauth/callback/google';
 const VALID_ACCOUNT_SID = `AC${'a1b2c3d4e5f6'.repeat(2)}01234567`;
 
@@ -24,6 +25,14 @@ describe('emptyFormValues', () => {
     expect(values.name).toBe('');
     expect(values.clientId).toBe('');
     expect(values.clientSecret).toBe('');
+  });
+
+  it('prefills fields that declare a default value', () => {
+    const values = emptyFormValues(SMS_GATEWAY_FIELDS, REDIRECT);
+    expect(values.httpMethod).toBe('POST');
+    expect(values.contentType).toBe('JSON');
+    expect(values.url).toBe('');
+    expect(values.httpHeaders).toBe('');
   });
 });
 
@@ -97,6 +106,21 @@ describe('formValuesToRequest', () => {
       {mode: 'create'},
     ) as unknown as Record<string, unknown>;
     expect(payload.trustedTokenAudience).toBe('my-external-client-id');
+  });
+
+  it('sends the SMS gateway transport fields and omits empty optional headers', () => {
+    const payload = formValuesToRequest(
+      {name: 'Custom SMS Sender', url: 'https://sms.example.com/send', httpMethod: 'POST', contentType: 'JSON'},
+      SMS_GATEWAY_FIELDS,
+      {mode: 'create'},
+    ) as unknown as Record<string, unknown>;
+
+    expect(payload).toEqual({
+      name: 'Custom SMS Sender',
+      url: 'https://sms.example.com/send',
+      httpMethod: 'POST',
+      contentType: 'JSON',
+    });
   });
 
   it('omits the secret on edit when not replacing (keep stored value)', () => {

--- a/frontend/packages/configure-connections/src/utils/__tests__/keyValuePairs.test.ts
+++ b/frontend/packages/configure-connections/src/utils/__tests__/keyValuePairs.test.ts
@@ -36,7 +36,7 @@ describe('serializeKeyValuePairs', () => {
     ).toBe('X-API-Key: abc123, Accept: application/json');
   });
 
-  it('drops rows with no name so a half-filled row never reaches the API', () => {
+  it('drops half-filled rows so they never reach the API', () => {
     expect(
       serializeKeyValuePairs([
         {name: '', value: 'orphan'},
@@ -46,8 +46,14 @@ describe('serializeKeyValuePairs', () => {
     ).toBe('X-Real: v');
   });
 
-  it('keeps a named row with an empty value, which the backend accepts', () => {
-    expect(serializeKeyValuePairs([{name: 'X-Flag', value: ''}])).toBe('X-Flag: ');
+  it('drops a named row whose value is empty, name included', () => {
+    expect(serializeKeyValuePairs([{name: 'X-Flag', value: ''}])).toBe('');
+    expect(
+      serializeKeyValuePairs([
+        {name: 'Content-Type', value: 'application/json'},
+        {name: 'Accept', value: '   '},
+      ]),
+    ).toBe('Content-Type: application/json');
   });
 
   it('round-trips a parsed value unchanged', () => {

--- a/frontend/packages/configure-connections/src/utils/__tests__/keyValuePairs.test.ts
+++ b/frontend/packages/configure-connections/src/utils/__tests__/keyValuePairs.test.ts
@@ -1,0 +1,69 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {describe, expect, it} from 'vitest';
+import {parseKeyValuePairs, sanitizeKeyValuePart, serializeKeyValuePairs} from '../keyValuePairs';
+
+describe('parseKeyValuePairs', () => {
+  it('splits comma-separated pairs and trims both parts', () => {
+    expect(parseKeyValuePairs('X-API-Key: abc123,  Accept : application/json ')).toEqual([
+      {name: 'X-API-Key', value: 'abc123'},
+      {name: 'Accept', value: 'application/json'},
+    ]);
+  });
+
+  it('returns no rows for an empty or blank value', () => {
+    expect(parseKeyValuePairs('')).toEqual([]);
+    expect(parseKeyValuePairs('  ,  ')).toEqual([]);
+  });
+
+  it('keeps only the first colon as the separator, so values may contain colons', () => {
+    expect(parseKeyValuePairs('Authorization: Bearer a:b:c')).toEqual([{name: 'Authorization', value: 'Bearer a:b:c'}]);
+  });
+
+  it('keeps a segment with no colon as a name so it stays visible and fixable', () => {
+    expect(parseKeyValuePairs('BrokenHeader')).toEqual([{name: 'BrokenHeader', value: ''}]);
+  });
+});
+
+describe('serializeKeyValuePairs', () => {
+  it('joins pairs in the format the backend parses', () => {
+    expect(
+      serializeKeyValuePairs([
+        {name: 'X-API-Key', value: 'abc123'},
+        {name: 'Accept', value: 'application/json'},
+      ]),
+    ).toBe('X-API-Key: abc123, Accept: application/json');
+  });
+
+  it('drops rows with no name so a half-filled row never reaches the API', () => {
+    expect(
+      serializeKeyValuePairs([
+        {name: '', value: 'orphan'},
+        {name: '  ', value: ''},
+        {name: 'X-Real', value: 'v'},
+      ]),
+    ).toBe('X-Real: v');
+  });
+
+  it('keeps a named row with an empty value, which the backend accepts', () => {
+    expect(serializeKeyValuePairs([{name: 'X-Flag', value: ''}])).toBe('X-Flag: ');
+  });
+
+  it('round-trips a parsed value unchanged', () => {
+    const wire = 'X-API-Key: abc123, Accept: application/json';
+    expect(serializeKeyValuePairs(parseKeyValuePairs(wire))).toBe(wire);
+  });
+});
+
+describe('sanitizeKeyValuePart', () => {
+  it('strips commas from both parts, since commas separate pairs on the wire', () => {
+    expect(sanitizeKeyValuePart('a,b', 'name')).toBe('ab');
+    expect(sanitizeKeyValuePart('text/html, application/json', 'value')).toBe('text/html application/json');
+  });
+
+  it('strips colons from names only', () => {
+    expect(sanitizeKeyValuePart('X-A:B', 'name')).toBe('X-AB');
+    expect(sanitizeKeyValuePart('Bearer a:b', 'value')).toBe('Bearer a:b');
+  });
+});

--- a/frontend/packages/configure-connections/src/utils/buildConnectionCards.tsx
+++ b/frontend/packages/configure-connections/src/utils/buildConnectionCards.tsx
@@ -37,7 +37,7 @@ function isTrustedIdpInstance(instance: ConnectionInstance): boolean {
  * - custom vendors with no instances → no card (creation goes through the custom-connection
  *   wizard entry point).
  * - coming-soon vendors → one static, non-interactive card.
- * - instances whose type has no vendor meta (e.g. custom SMS gateway senders) are not rendered.
+ * - instances whose type has no vendor meta are not rendered.
  *
  * Pure function — no i18n, no hooks — so it is trivially unit-testable. The card carries a
  * `descriptionKey`; the rendering component resolves it.

--- a/frontend/packages/configure-connections/src/utils/connectionFormMapping.ts
+++ b/frontend/packages/configure-connections/src/utils/connectionFormMapping.ts
@@ -11,12 +11,13 @@ export const MASKED_SECRET = '******';
 export type ConnectionFormValues = Record<string, string>;
 
 /**
- * Build empty form values for a create form (all fields blank except the derived redirect URI).
+ * Build empty form values for a create form (all fields blank except the derived redirect URI
+ * and fields carrying a default value).
  */
 export function emptyFormValues(fields: ConnectionFieldDef[], redirectUri: string): ConnectionFormValues {
   const values: ConnectionFormValues = {};
   for (const field of fields) {
-    values[field.name] = field.name === 'redirectUri' ? redirectUri : '';
+    values[field.name] = field.name === 'redirectUri' ? redirectUri : (field.defaultValue ?? '');
   }
   return values;
 }
@@ -24,7 +25,8 @@ export function emptyFormValues(fields: ConnectionFieldDef[], redirectUri: strin
 /**
  * Map a fetched connection response into editable form values. Secrets are never prefilled
  * (the masked "******" is display-only and handled by the secret field's "stored" state).
- * The redirect URI falls back to the derived value if the API didn't store one.
+ * The redirect URI falls back to the derived value if the API didn't store one; other fields
+ * fall back to their default value.
  */
 export function responseToFormValues(
   response: ConnectionResponse,
@@ -50,7 +52,7 @@ export function responseToFormValues(
       values[field.name] = raw === true ? 'true' : 'false';
       continue;
     }
-    values[field.name] = typeof raw === 'string' ? raw : '';
+    values[field.name] = typeof raw === 'string' && raw !== '' ? raw : (field.defaultValue ?? '');
   }
   return values;
 }

--- a/frontend/packages/configure-connections/src/utils/keyValuePairs.ts
+++ b/frontend/packages/configure-connections/src/utils/keyValuePairs.ts
@@ -1,0 +1,49 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/** One editable row of a key-value field (e.g. an HTTP header). */
+export interface KeyValuePair {
+  name: string;
+  value: string;
+}
+
+/**
+ * Parse the stored wire format ("Key: value, Other: value") into editable rows.
+ *
+ * Mirrors the backend parser, which splits on "," and then on the first ":". A segment with no
+ * colon keeps its whole text as the name rather than being dropped, so a hand-written value that
+ * the backend would reject stays visible and fixable in the form.
+ */
+export function parseKeyValuePairs(raw: string): KeyValuePair[] {
+  return raw
+    .split(',')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment !== '')
+    .map((segment) => {
+      const separator: number = segment.indexOf(':');
+      if (separator === -1) {
+        return {name: segment, value: ''};
+      }
+      return {name: segment.slice(0, separator).trim(), value: segment.slice(separator + 1).trim()};
+    });
+}
+
+/**
+ * Serialize rows back to the wire format, dropping rows with no name so a half-filled row never
+ * produces a segment the backend would reject.
+ */
+export function serializeKeyValuePairs(pairs: KeyValuePair[]): string {
+  return pairs
+    .filter((pair) => pair.name.trim() !== '')
+    .map((pair) => `${pair.name.trim()}: ${pair.value.trim()}`)
+    .join(', ');
+}
+
+/**
+ * Strip characters the wire format cannot represent: commas separate pairs, so they are removed
+ * from both parts, and the first colon separates name from value, so it is removed from names.
+ */
+export function sanitizeKeyValuePart(text: string, part: 'name' | 'value'): string {
+  const withoutCommas: string = text.replace(/,/g, '');
+  return part === 'name' ? withoutCommas.replace(/:/g, '') : withoutCommas;
+}

--- a/frontend/packages/configure-connections/src/utils/keyValuePairs.ts
+++ b/frontend/packages/configure-connections/src/utils/keyValuePairs.ts
@@ -29,12 +29,13 @@ export function parseKeyValuePairs(raw: string): KeyValuePair[] {
 }
 
 /**
- * Serialize rows back to the wire format, dropping rows with no name so a half-filled row never
- * produces a segment the backend would reject.
+ * Serialize rows back to the wire format. A row is only included when both parts are filled in, so
+ * a half-typed row never reaches the API as a segment the backend would reject or as a header with
+ * an empty value.
  */
 export function serializeKeyValuePairs(pairs: KeyValuePair[]): string {
   return pairs
-    .filter((pair) => pair.name.trim() !== '')
+    .filter((pair) => pair.name.trim() !== '' && pair.value.trim() !== '')
     .map((pair) => `${pair.name.trim()}: ${pair.value.trim()}`)
     .join(', ');
 }

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1718,7 +1718,7 @@ const translations = {
     'vendor.oauth.description': 'Connect any OAuth 2.0 identity provider.',
     'vendor.twilio.description': 'Send SMS one-time passcodes via Twilio.',
     'vendor.vonage.description': 'Deliver SMS and email passcodes through Vonage.',
-    'vendor.custom-sms.description': 'Route SMS through your own HTTP gateway.',
+    'vendor.sms-gateway.description': 'Route SMS through your own HTTP gateway.',
     'vendor.trustedIdp.description': 'Trusted token issuer for token exchange and ID-JAG.',
 
     // Add custom connection wizard
@@ -1827,6 +1827,15 @@ const translations = {
     'form.fields.apiSecret.hint': 'Vonage API secret used to authenticate API requests.',
     'form.fields.senderId.label': 'Sender ID',
     'form.fields.senderId.hint': 'Phone number or alphanumeric sender ID messages are sent from.',
+    'form.fields.smsGatewayUrl.label': 'Gateway URL',
+    'form.fields.smsGatewayUrl.hint': 'HTTP endpoint ThunderID calls to send an SMS.',
+    'form.fields.httpMethod.label': 'HTTP method',
+    'form.fields.httpMethod.hint': 'Method used to call the gateway URL.',
+    'form.fields.contentType.label': 'Content type',
+    'form.fields.contentType.hint': 'Format of the request body sent to the gateway.',
+    'form.fields.httpHeaders.label': 'HTTP headers',
+    'form.fields.httpHeaders.hint':
+      'Optional headers sent with every request, as comma-separated <code>Key: value</code> pairs.',
     'form.sections.federation': 'Federation',
     'form.secret.update': 'Update',
     'form.secret.keepHelp': 'Leave unchanged to keep the stored secret.',

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1835,7 +1835,12 @@ const translations = {
     'form.fields.contentType.hint': 'Format of the request body sent to the gateway.',
     'form.fields.httpHeaders.label': 'HTTP headers',
     'form.fields.httpHeaders.hint':
-      'Optional headers sent with every request, as comma-separated <code>Key: value</code> pairs.',
+      'Optional headers sent with every request. Commas are not supported in a name or value.',
+    'form.fields.httpHeaders.add': 'Add header',
+    'form.keyValue.name': 'Name',
+    'form.keyValue.value': 'Value',
+    'form.keyValue.add': 'Add',
+    'form.keyValue.remove': 'Remove',
     'form.sections.federation': 'Federation',
     'form.secret.update': 'Update',
     'form.secret.keepHelp': 'Leave unchanged to keep the stored secret.',


### PR DESCRIPTION
### Purpose

This pull request adds full support for a generic "SMS Gateway" connection type, enabling users to configure any HTTP-based SMS provider via a new form in the UI. The main changes include adding the new type and its fields, updating the UI to allow selection and configuration, and extending tests and models to cover the new functionality.

### Preview

https://github.com/user-attachments/assets/964d9574-4bfc-42cf-9850-d81e9072ff53

### Approach

**SMS Gateway connection type support:**

* Added `SMS_GATEWAY` to `ConnectionTypes` and updated all relevant type definitions and request/response models to support the new connection type (`sms-gateway`). [[1]](diffhunk://#diff-6ae3faaa95d07304de4852a62ad16bdba97fd7db908658f848bee94e03fe5ae1R16) [[2]](diffhunk://#diff-6ae3faaa95d07304de4852a62ad16bdba97fd7db908658f848bee94e03fe5ae1L47-R55) [[3]](diffhunk://#diff-6ae3faaa95d07304de4852a62ad16bdba97fd7db908658f848bee94e03fe5ae1R229-R250) [[4]](diffhunk://#diff-6ae3faaa95d07304de4852a62ad16bdba97fd7db908658f848bee94e03fe5ae1R267-R271)
* Defined the SMS Gateway vendor in `CONNECTION_VENDOR_META` with appropriate icon and metadata.

**Form and field configuration:**

* Added a new entry for `SMS_GATEWAY` in `CONNECTION_FORM_FIELDS`, specifying fields for URL, HTTP method, content type, and headers. Introduced the `'select'` field kind and related types/options. [[1]](diffhunk://#diff-68645af12da94eb9274bc9d104385a9ac28bce30a3fcaa0e70780700d9c6223cL6-R16) [[2]](diffhunk://#diff-68645af12da94eb9274bc9d104385a9ac28bce30a3fcaa0e70780700d9c6223cR27-R30) [[3]](diffhunk://#diff-68645af12da94eb9274bc9d104385a9ac28bce30a3fcaa0e70780700d9c6223cR322-R363)
* Updated `ConnectionForm` to render `'select'` fields using Material UI `Select` and `MenuItem` components, handling validation and option rendering. [[1]](diffhunk://#diff-84a61482565bcceaa2360ae25e20aa36762381be30dbc3770979a9e6612400f4R10-R13) [[2]](diffhunk://#diff-84a61482565bcceaa2360ae25e20aa36762381be30dbc3770979a9e6612400f4R155-R178)

**UI integration:**

* Made the SMS Gateway connection selectable in the connection type wizard, with a new icon and test coverage for selection and ordering. [[1]](diffhunk://#diff-a5895dc41c6fef96817c513c08c07e5116c452a4c891caca14a573714ffa7079L5-R13) [[2]](diffhunk://#diff-a5895dc41c6fef96817c513c08c07e5116c452a4c891caca14a573714ffa7079L65-R79) [[3]](diffhunk://#diff-a045641d6321049a90f4572dc6f1ff502cb93017e930461d335faf19131eafb6L19-R19) [[4]](diffhunk://#diff-a045641d6321049a90f4572dc6f1ff502cb93017e930461d335faf19131eafb6L34-R37) [[5]](diffhunk://#diff-a045641d6321049a90f4572dc6f1ff502cb93017e930461d335faf19131eafb6L46-R51)
* Adjusted the create wizard page to support SMS Gateway and only show redirect URI hints for providers that require them. [[1]](diffhunk://#diff-85ba51b5f5d98b4382fcb2a8b6cfc31d86c13724c26bfd24c3b3412aead26831L55-R57) [[2]](diffhunk://#diff-85ba51b5f5d98b4382fcb2a8b6cfc31d86c13724c26bfd24c3b3412aead26831R67-R69) [[3]](diffhunk://#diff-85ba51b5f5d98b4382fcb2a8b6cfc31d86c13724c26bfd24c3b3412aead26831R180-R188)

**Testing:**

* Added and updated tests to ensure SMS Gateway fields are rendered, selectable, and validated correctly, and that select field changes propagate as expected. [[1]](diffhunk://#diff-5043b7e0be7655f62d73867f2788b6cda00cb45bad6eaee4596b535bd62287baR188-R223) [[2]](diffhunk://#diff-6dc6b3c6d690473670d01c35bde38bf58356eda60a0e68b2748dc614b4298fdfR77-R95) [[3]](diffhunk://#diff-3f7e4ad44081a70635c5fd7e0d8e98f5c2b83f022344443620b9e6bff30ca0a4L30-R37)

These changes collectively enable users to configure and use any HTTP-based SMS provider through a flexible and tested UI.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4522

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added support for configuring SMS Gateway connections.
- SMS Gateway setup now includes URL, HTTP method, content type, and optional HTTP headers.
- Added editable key-value controls for managing headers.
- Added selectable dropdown fields with defaults, validation, and helpful hints.
- SMS Gateway is now available directly in the connection-type selector.
- Added localized labels and descriptions for SMS Gateway settings.

## Bug Fixes

- Redirect-URI guidance now appears only for applicable connection types.
- Form defaults are preserved when responses omit optional fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->