### PR TITLE
Provide seamless login for OIDC/github connections by defualt.

### DIFF
--- a/backend/cmd/server/bootstrap/01-default-resources.yaml
+++ b/backend/cmd/server/bootstrap/01-default-resources.yaml
@@ -10,6 +10,7 @@ id: 01900000-0000-7000-8000-000000000010
 category: user
 name: Person
 ouHandle: default
+allowSelfRegistration: true
 systemAttributes:
   display: username
 schema:
@@ -5152,6 +5153,8 @@ translations:
     forms.credentials.links.forgot_password.label: Reset
     forms.credentials.links.sign_up.prefix: Don't have an account?
     forms.credentials.links.sign_up.label: Sign up
+    forms.schema_attrs.title: Tell us about you
+    forms.schema_attrs.actions.continue.label: Continue
   signup:
     images.app_logo.alt: Application logo
     forms.credentials.title: Sign Up

--- a/backend/internal/authn/oauth/service_test.go
+++ b/backend/internal/authn/oauth/service_test.go
@@ -976,7 +976,8 @@ func (suite *OAuthAuthnServiceTestSuite) TestBuildFederatedAuthResultAppliesMapp
 		context.Background(), testIDPID, testSub, map[string]interface{}{"given_name": "Jane", "sub": testSub})
 	suite.Nil(svcErr)
 	suite.Equal("Jane", result.AuthenticatedClaims["firstName"])
-	suite.NotContains(result.AuthenticatedClaims, "given_name")
+	// Mappings copy rather than rename, so the source claim survives alongside the local attribute.
+	suite.Equal("Jane", result.AuthenticatedClaims["given_name"])
 	// No account linking configured, so the lookup falls back to sub without a query.
 	suite.Equal(testSub, result.Token["sub"])
 }

--- a/backend/internal/connection/declarative_resource.go
+++ b/backend/internal/connection/declarative_resource.go
@@ -16,6 +16,7 @@ import (
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/declarative_resource/entity"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/security"
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
@@ -416,13 +417,27 @@ func connectionResourceID(dto interface{}) string {
 // /connections create/update API runs. Notification-sender DTOs only get a name presence check —
 // full semantic validation for senders (e.g. a custom sender's required URL) is deferred to
 // runtime use, matching the legacy declarative notification-sender behavior.
-func validateConnectionDTOWrapper(dto interface{}) error {
+//
+// idpService may be nil, in which case the schema-aware defaults the live API applies are skipped
+// and the declarative document stands entirely on its own.
+func validateConnectionDTOWrapper(dto interface{}, idpService idp.IDPServiceInterface) error {
 	switch d := dto.(type) {
 	case *providers.IDPDTO:
 		if d.Name == "" {
 			return fmt.Errorf("connection resource %q is missing a name", d.ID)
 		}
-		return idp.ValidateIDP(d)
+		if err := idp.ValidateIDP(d); err != nil {
+			return err
+		}
+		if idpService != nil {
+			// Declarative resources load at startup with no authenticated subject, so the
+			// entity-type reads the seeding performs would otherwise be authorized against nothing
+			// and return nothing. Elevate here, where the absence of a subject is a fact about the
+			// caller, rather than inside the service, where it would also bypass a real
+			// administrator's scope on the REST path.
+			idpService.ApplySchemaAwareDefaults(security.WithRuntimeContext(context.Background()), d)
+		}
+		return nil
 	case *ncommon.NotificationSenderDTO:
 		if d.Name == "" {
 			return fmt.Errorf("connection resource %q is missing a name", d.ID)
@@ -466,7 +481,7 @@ func (s *connectionDeclarativeStore) Create(id string, data interface{}) error {
 // (identity_provider.store) calls for loading, or when no connection files are present.
 // connectionDeclarativeStore.Create further gates IdP-typed documents individually so a
 // composite/declarative identity_provider.store is honored even when the global flag is off.
-func loadDeclarativeResources() error {
+func loadDeclarativeResources(idpService idp.IDPServiceInterface) error {
 	if !declarativeresource.IsDeclarativeModeEnabled() && !idp.ShouldLoadDeclarativeIDPResources() {
 		return nil
 	}
@@ -479,8 +494,10 @@ func loadDeclarativeResources() error {
 		ResourceType:  paramTypeConnection,
 		DirectoryName: "connections",
 		Parser:        parseToConnectionDTOWrapper,
-		Validator:     validateConnectionDTOWrapper,
-		IDExtractor:   connectionResourceID,
+		Validator: func(dto interface{}) error {
+			return validateConnectionDTOWrapper(dto, idpService)
+		},
+		IDExtractor: connectionResourceID,
 	}
 
 	loader := declarativeresource.NewResourceLoader(resourceConfig, storer)

--- a/backend/internal/connection/declarative_resource_test.go
+++ b/backend/internal/connection/declarative_resource_test.go
@@ -290,8 +290,8 @@ func (s *DeclarativeResourceTestSuite) TestConnectionResourceID() {
 }
 
 func (s *DeclarativeResourceTestSuite) TestValidateConnectionDTOWrapper() {
-	s.Error(validateConnectionDTOWrapper(&providers.IDPDTO{ID: "idp-1", Name: ""}))
-	s.Error(validateConnectionDTOWrapper(&providers.IDPDTO{ID: "idp-1", Name: "Google"}),
+	s.Error(validateConnectionDTOWrapper(&providers.IDPDTO{ID: "idp-1", Name: ""}, nil))
+	s.Error(validateConnectionDTOWrapper(&providers.IDPDTO{ID: "idp-1", Name: "Google"}, nil),
 		"a name-only IdP DTO must fail full validation (missing type and required properties)")
 	s.NoError(validateConnectionDTOWrapper(&providers.IDPDTO{
 		ID: "idp-1", Name: "Google", Type: providers.IDPTypeGoogle,
@@ -300,10 +300,10 @@ func (s *DeclarativeResourceTestSuite) TestValidateConnectionDTOWrapper() {
 			mustProperty(s.T(), idp.PropClientSecret, "client-secret", true),
 			mustProperty(s.T(), idp.PropRedirectURI, "https://app/cb", false),
 		},
-	}))
-	s.Error(validateConnectionDTOWrapper(&ncommon.NotificationSenderDTO{ID: "s-1", Name: ""}))
-	s.NoError(validateConnectionDTOWrapper(&ncommon.NotificationSenderDTO{ID: "s-1", Name: "Twilio"}))
-	s.NoError(validateConnectionDTOWrapper("not-a-dto"))
+	}, nil))
+	s.Error(validateConnectionDTOWrapper(&ncommon.NotificationSenderDTO{ID: "s-1", Name: ""}, nil))
+	s.NoError(validateConnectionDTOWrapper(&ncommon.NotificationSenderDTO{ID: "s-1", Name: "Twilio"}, nil))
+	s.NoError(validateConnectionDTOWrapper("not-a-dto", nil))
 }
 
 func (s *DeclarativeResourceTestSuite) TestGetResourceRulesReturnsEmptyDefault() {

--- a/backend/internal/connection/init.go
+++ b/backend/internal/connection/init.go
@@ -24,7 +24,7 @@ func Initialize(mux *http.ServeMux, idpService idp.IDPServiceInterface,
 	h := newHandler(svc)
 	registerRoutes(mux, h)
 
-	if err := loadDeclarativeResources(); err != nil {
+	if err := loadDeclarativeResources(idpService); err != nil {
 		return nil, err
 	}
 

--- a/backend/internal/idp/IDPServiceInterface_mock_test.go
+++ b/backend/internal/idp/IDPServiceInterface_mock_test.go
@@ -40,6 +40,52 @@ func (_m *IDPServiceInterfaceMock) EXPECT() *IDPServiceInterfaceMock_Expecter {
 	return &IDPServiceInterfaceMock_Expecter{mock: &_m.Mock}
 }
 
+// ApplySchemaAwareDefaults provides a mock function for the type IDPServiceInterfaceMock
+func (_mock *IDPServiceInterfaceMock) ApplySchemaAwareDefaults(ctx context.Context, idp *providers.IDPDTO) {
+	_mock.Called(ctx, idp)
+	return
+}
+
+// IDPServiceInterfaceMock_ApplySchemaAwareDefaults_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ApplySchemaAwareDefaults'
+type IDPServiceInterfaceMock_ApplySchemaAwareDefaults_Call struct {
+	*mock.Call
+}
+
+// ApplySchemaAwareDefaults is a helper method to define mock.On call
+//   - ctx context.Context
+//   - idp *providers.IDPDTO
+func (_e *IDPServiceInterfaceMock_Expecter) ApplySchemaAwareDefaults(ctx interface{}, idp interface{}) *IDPServiceInterfaceMock_ApplySchemaAwareDefaults_Call {
+	return &IDPServiceInterfaceMock_ApplySchemaAwareDefaults_Call{Call: _e.mock.On("ApplySchemaAwareDefaults", ctx, idp)}
+}
+
+func (_c *IDPServiceInterfaceMock_ApplySchemaAwareDefaults_Call) Run(run func(ctx context.Context, idp *providers.IDPDTO)) *IDPServiceInterfaceMock_ApplySchemaAwareDefaults_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *providers.IDPDTO
+		if args[1] != nil {
+			arg1 = args[1].(*providers.IDPDTO)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *IDPServiceInterfaceMock_ApplySchemaAwareDefaults_Call) Return() *IDPServiceInterfaceMock_ApplySchemaAwareDefaults_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *IDPServiceInterfaceMock_ApplySchemaAwareDefaults_Call) RunAndReturn(run func(ctx context.Context, idp *providers.IDPDTO)) *IDPServiceInterfaceMock_ApplySchemaAwareDefaults_Call {
+	_c.Run(run)
+	return _c
+}
+
 // CreateIdentityProvider provides a mock function for the type IDPServiceInterfaceMock
 func (_mock *IDPServiceInterfaceMock) CreateIdentityProvider(ctx context.Context, idp *providers.IDPDTO) (*providers.IDPDTO, *common.ServiceError) {
 	ret := _mock.Called(ctx, idp)

--- a/backend/internal/idp/constants.go
+++ b/backend/internal/idp/constants.go
@@ -24,8 +24,21 @@ const (
 	PropIDJagEnabled          = "id_jag_enabled"
 )
 
-// defaultOIDCScopes is seeded for OIDC and Google connections when no scopes are supplied.
-const defaultOIDCScopes = "openid,email,profile"
+// Claims and scopes shared by the OIDC-style providers. A claim is what the provider emits; a scope
+// only asks for it.
+const (
+	emailClaim        = "email"
+	emailScope        = "email"
+	defaultOIDCScopes = "openid,email,profile"
+)
+
+// Local attribute names, as declared by user type schemas.
+// TODO: Drop these once schemas can declare attribute types (EMAIL, MOBILE, ...) as a first class
+// concept, so the attribute carrying an email can be found rather than named here.
+const (
+	defaultAccountLinkingAttribute = "email"
+	localUsernameAttribute         = "username"
+)
 
 // Known endpoints for Google OAuth2/OIDC.
 const (
@@ -35,12 +48,17 @@ const (
 	googleJwksEndpoint          = "https://www.googleapis.com/oauth2/v3/certs"
 )
 
-// Known endpoints for GitHub OAuth.
+// Known endpoints, claims and scopes for GitHub OAuth.
 const (
 	gitHubAuthorizationEndpoint = "https://github.com/login/oauth/authorize"
 	gitHubTokenEndpoint         = "https://github.com/login/oauth/access_token" // #nosec G101
 	gitHubUserInfoEndpoint      = "https://api.github.com/user"
 	gitHubUserEmailEndpoint     = "https://api.github.com/user/emails"
+
+	gitHubLoginClaim     = "login"
+	gitHubUserScope      = "user"
+	gitHubUserEmailScope = "user:email"
+	defaultGitHubScopes  = gitHubUserEmailScope
 )
 
 // idpPropertyConfig defines the required and optional properties for an IDP type,

--- a/backend/internal/idp/service.go
+++ b/backend/internal/idp/service.go
@@ -8,11 +8,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 
 	"github.com/thunder-id/thunderid/internal/entitytype"
+	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
@@ -36,6 +38,7 @@ type IDPServiceInterface interface {
 	DeleteIdentityProvider(ctx context.Context, idpID string) *tidcommon.ServiceError
 	GetIDPUsages(ctx context.Context, idpID string) (*resourcedependency.DependenciesResponse, *tidcommon.ServiceError)
 	SetDependencyRegistry(r resourcedependency.Registry)
+	ApplySchemaAwareDefaults(ctx context.Context, idp *providers.IDPDTO)
 }
 
 // idpService is the default implementation of the IdPServiceInterface.
@@ -46,6 +49,26 @@ type idpService struct {
 	dependencyRegistry resourcedependency.Registry
 	logger             *log.Logger
 	uuidGenerator      func() (string, error)
+}
+
+// userTypeAttributes holds a user type's non-credential schema attributes.
+type userTypeAttributes struct {
+	name       string
+	attributes []entitytype.AttributeInfo
+}
+
+// isUnique reports whether the user type declares attr as unique.
+func (u userTypeAttributes) isUnique(attr string) bool {
+	return slices.ContainsFunc(u.attributes, func(a entitytype.AttributeInfo) bool {
+		return a.Attribute == attr && a.Unique
+	})
+}
+
+// isRequired reports whether the user type declares attr as required.
+func (u userTypeAttributes) isRequired(attr string) bool {
+	return slices.ContainsFunc(u.attributes, func(a entitytype.AttributeInfo) bool {
+		return a.Attribute == attr && a.Required
+	})
 }
 
 // newIDPService creates a new instance of IdPService.
@@ -71,6 +94,9 @@ func (is *idpService) CreateIdentityProvider(
 	if svcErr := validateIDP(ctx, idp, logger); svcErr != nil {
 		return nil, svcErr
 	}
+	// Seeded on create only: an update replaces the whole connection, so re-seeding there would
+	// silently restore a section the administrator removed.
+	is.ApplySchemaAwareDefaults(ctx, idp)
 	if svcErr := is.validateAttributeConfiguration(ctx, idp); svcErr != nil {
 		return nil, svcErr
 	}
@@ -219,6 +245,9 @@ func (is *idpService) UpdateIdentityProvider(
 	if svcErr := validateIDP(ctx, idp, logger); svcErr != nil {
 		return nil, svcErr
 	}
+	// Defaults are seeded on create only. An update replaces the whole connection, so an omitted
+	// account-linking or mapping section is indistinguishable from one the administrator deliberately
+	// removed; re-seeding here would silently undo that removal.
 	if svcErr := is.validateAttributeConfiguration(ctx, idp); svcErr != nil {
 		return nil, svcErr
 	}
@@ -321,6 +350,174 @@ func (is *idpService) DeleteIdentityProvider(ctx context.Context, idpID string) 
 	}
 
 	return nil
+}
+
+// ApplySchemaAwareDefaults seeds account-linking and username-mapping defaults derived from user-type
+// schemas. Explicit configuration wins, and schema lookup failures leave the connection unchanged
+// rather than blocking the operation. Entity-type reads are authorized against ctx and never elevated.
+func (is *idpService) ApplySchemaAwareDefaults(ctx context.Context, idp *providers.IDPDTO) {
+	if idp == nil || is.entityTypeService == nil {
+		return
+	}
+
+	attributeConfig := idp.AttributeConfiguration
+	needsAccountLinking := attributeConfig == nil || attributeConfig.AccountLinking == nil
+	needsAttributeMappings := attributeConfig == nil || len(attributeConfig.UserTypeAttributeMappings) == 0
+	if !needsAccountLinking && !needsAttributeMappings {
+		return
+	}
+
+	// Every user type is a candidate: the per-type criteria the seeding helpers apply (a unique email,
+	// a required username) decide what can actually be seeded. Self registration is deliberately not a
+	// filter, because attribute mappings are read on login as well as during provisioning, so a type
+	// that only ever receives manually created users still needs them.
+	candidateUserTypes := is.loadCandidateUserTypes(ctx)
+	if len(candidateUserTypes) == 0 {
+		is.logger.Debug(ctx, "No user type to seed connection defaults from")
+		return
+	}
+
+	// Linking is a flat attribute list with no user type attached, so it is seeded independently of
+	// whether the mapping target can be decided.
+	if needsAccountLinking {
+		is.seedEmailAccountLinking(ctx, idp, candidateUserTypes)
+	}
+	if needsAttributeMappings {
+		is.seedUserTypeDefaults(ctx, idp, candidateUserTypes)
+	}
+}
+
+// loadCandidateUserTypes returns every user type visible to the caller with its non-credential
+// attributes, or nil when any of it cannot be read. AttributeInfo carries both the required and the
+// unique flag, so one read per type answers everything the seeding helpers ask. A partial read yields
+// nothing rather than a subset, because seeding on an incomplete view of the deployment could pick a
+// linking attribute that another type allows duplicates of.
+func (is *idpService) loadCandidateUserTypes(ctx context.Context) []userTypeAttributes {
+	response, svcErr := is.entityTypeService.GetEntityTypeList(
+		ctx, entitytype.TypeCategoryUser, serverconst.MaxPageSize, 0, false)
+	if svcErr != nil || response == nil {
+		is.logger.Warn(ctx, "Could not list user types, skipping connection default seeding")
+		return nil
+	}
+
+	candidates := make([]userTypeAttributes, 0, len(response.Types))
+	for _, userType := range response.Types {
+		attributes, attrErr := is.entityTypeService.GetAttributes(
+			ctx, entitytype.TypeCategoryUser, userType.Name,
+			entitytype.AttributeFilter{AllowNonCredential: true})
+		if attrErr != nil {
+			is.logger.Warn(ctx, "Could not read user type attributes, skipping connection default seeding",
+				log.String("userType", userType.Name))
+			return nil
+		}
+		candidates = append(candidates, userTypeAttributes{name: userType.Name, attributes: attributes})
+	}
+	return candidates
+}
+
+// seedEmailAccountLinking configures email as the account-linking attribute when the connection's
+// scopes can yield one and email is unique on every candidate. Uniqueness on all of them matters
+// because the linking list carries no user type: the lookup must identify a single user whichever
+// type an identity provisions into.
+func (is *idpService) seedEmailAccountLinking(
+	ctx context.Context, idp *providers.IDPDTO, candidateUserTypes []userTypeAttributes,
+) {
+	scopes := utils.ParseStringArray(GetPropertyValue(idp.Properties, PropScopes), ",")
+	if !scopesGrantEmail(idp.Type, scopes) {
+		return
+	}
+
+	for _, userType := range candidateUserTypes {
+		if !userType.isUnique(defaultAccountLinkingAttribute) {
+			is.logger.Debug(ctx, "Email is not unique on a candidate user type, skipping linking default",
+				log.String("userType", userType.name))
+			return
+		}
+	}
+
+	ensureAttributeConfiguration(idp).AccountLinking = &providers.AccountLinking{
+		Attributes: []string{defaultAccountLinkingAttribute},
+	}
+}
+
+// seedUserTypeDefaults records which local user type an incoming identity resolves to, and maps a
+// provider claim onto the local username for every candidate that requires one. Without the mapping,
+// provisioning prompts for a username on every first federated sign-in, since no provider emits a
+// claim under that name. The default must name a type the mappings cover, because GetAttributeMappings
+// looks up the entry keyed to it; with nothing to map it names a type email can match instead.
+func (is *idpService) seedUserTypeDefaults(
+	ctx context.Context, idp *providers.IDPDTO, candidateUserTypes []userTypeAttributes,
+) {
+	sourceAttribute := defaultUsernameSourceAttribute(idp.Type)
+	if sourceAttribute == "" {
+		return
+	}
+
+	// Google and OIDC derive the username from the email claim, which a connection only receives when
+	// its scopes ask for one. Seeding the mapping regardless would leave an entry that resolves to
+	// nothing: provisioning would still prompt for a username while the connection looks configured.
+	if sourceAttribute == emailClaim {
+		scopes := utils.ParseStringArray(GetPropertyValue(idp.Properties, PropScopes), ",")
+		if !scopesGrantEmail(idp.Type, scopes) {
+			is.logger.Debug(ctx, "Scopes cannot yield an email, skipping username mapping default")
+			return
+		}
+	}
+
+	usernameRequiredUserTypes := make([]string, 0, len(candidateUserTypes))
+	for _, userType := range candidateUserTypes {
+		if userType.isRequired(localUsernameAttribute) {
+			usernameRequiredUserTypes = append(usernameRequiredUserTypes, userType.name)
+		}
+	}
+
+	if len(usernameRequiredUserTypes) == 0 {
+		emailMatchableUserType := firstUserTypeMatchableByEmail(candidateUserTypes)
+		if emailMatchableUserType == "" {
+			return
+		}
+		setDefaultUserType(ensureAttributeConfiguration(idp), emailMatchableUserType)
+		return
+	}
+
+	mappings := make([]providers.UserTypeAttributeMapping, 0, len(usernameRequiredUserTypes))
+	for _, userType := range usernameRequiredUserTypes {
+		mappings = append(mappings, providers.UserTypeAttributeMapping{
+			UserType: userType,
+			Attributes: []providers.AttributeMapping{
+				{ExternalAttribute: sourceAttribute, LocalAttribute: localUsernameAttribute},
+			},
+		})
+	}
+
+	attributeConfig := ensureAttributeConfiguration(idp)
+	// Candidates arrive ordered by name, so taking the first is stable across restarts. This only
+	// selects which mapping entry applies; the type provisioning targets is still decided by the flow.
+	setDefaultUserType(attributeConfig, usernameRequiredUserTypes[0])
+	attributeConfig.UserTypeAttributeMappings = mappings
+}
+
+// firstUserTypeMatchableByEmail returns the first candidate that email can identify a single user on,
+// or "" when none can. Candidates arrive ordered by name, so the choice is stable across restarts.
+func firstUserTypeMatchableByEmail(candidateUserTypes []userTypeAttributes) string {
+	for _, userType := range candidateUserTypes {
+		if userType.isUnique(defaultAccountLinkingAttribute) {
+			return userType.name
+		}
+	}
+	return ""
+}
+
+// setDefaultUserType records the resolution default, leaving a claim-driven resolution the
+// administrator already configured intact: replacing the whole value would drop their external
+// attribute and value mapping.
+func setDefaultUserType(attributeConfig *providers.AttributeConfiguration, userType string) {
+	if attributeConfig.UserTypeResolution == nil {
+		attributeConfig.UserTypeResolution = &providers.UserTypeResolution{}
+	}
+	if strings.TrimSpace(attributeConfig.UserTypeResolution.Default) == "" {
+		attributeConfig.UserTypeResolution.Default = userType
+	}
 }
 
 // SetDependencyRegistry injects the dependency registry. Called by servicemanager after the

--- a/backend/internal/idp/service_test.go
+++ b/backend/internal/idp/service_test.go
@@ -90,6 +90,12 @@ func (s *IDPServiceTestSuite) SetupTest() {
 
 	s.mockStore = newIdpStoreInterfaceMock(s.T())
 	s.mockET = entitytypemock.NewEntityTypeServiceInterfaceMock(s.T())
+	// Create and update now seed schema-aware defaults, which lists user types first. Default to a
+	// deployment with none, so the target is unresolvable and seeding is a no-op for tests that are
+	// not about it. Tests that exercise seeding build their own service with a dedicated mock.
+	s.mockET.On("GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(&entitytype.EntityTypeListResponse{}, nil).Maybe()
 	s.idpService = &idpService{
 		idpStore:           s.mockStore,
 		transactioner:      &mockTransactioner{},
@@ -1427,4 +1433,488 @@ func (s *IDPServiceTestSuite) TestValidateAttributeConfiguration_DynamicResoluti
 	s.NotNil(svcErr)
 	s.Equal(ErrorInvalidAttributeConfiguration.Code, svcErr.Code)
 	s.Contains(svcErr.ErrorDescription.DefaultValue, "invalid user type")
+}
+
+// --- ApplySchemaAwareDefaults ---
+
+const seedUserType = "Person"
+
+// newSeedingService builds a service with a dedicated entity-type mock, bypassing the suite-level
+// catch-all so each case controls exactly what the schema looks like.
+func (s *IDPServiceTestSuite) newSeedingService() (
+	*idpService, *entitytypemock.EntityTypeServiceInterfaceMock) {
+	mockET := entitytypemock.NewEntityTypeServiceInterfaceMock(s.T())
+
+	return &idpService{
+		entityTypeService: mockET,
+		logger:            log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IdPService")),
+	}, mockET
+}
+
+// seedTestIDP builds a connection carrying only the scopes, the one property seeding reads.
+func seedTestIDP(idpType providers.IDPType, scopes string) *providers.IDPDTO {
+	scopesProp, _ := cmodels.NewProperty(PropScopes, scopes, false)
+
+	return &providers.IDPDTO{
+		Name:       "Test " + string(idpType),
+		Type:       idpType,
+		Properties: []cmodels.Property{*scopesProp},
+	}
+}
+
+// expectUserTypes stubs the user-type listing seeding uses to find candidates.
+func expectUserTypes(mockET *entitytypemock.EntityTypeServiceInterfaceMock,
+	types ...entitytype.EntityTypeListItem) {
+	mockET.On("GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(&entitytype.EntityTypeListResponse{Types: types}, nil)
+}
+
+// expectSchemaFor stubs one user type's schema. Optional, because seeding stops before reading the
+// schema whenever the connection or the candidate set already rules the defaults out.
+func expectSchemaFor(mockET *entitytypemock.EntityTypeServiceInterfaceMock,
+	userType string, unique []string, required []string) {
+	uniqueSet := make(map[string]bool, len(unique))
+	for _, name := range unique {
+		uniqueSet[name] = true
+	}
+	requiredSet := make(map[string]bool, len(required))
+	for _, name := range required {
+		requiredSet[name] = true
+	}
+
+	attrs := make([]entitytype.AttributeInfo, 0, len(unique)+len(required))
+	seen := make(map[string]bool, len(unique)+len(required))
+	add := func(names []string) {
+		for _, name := range names {
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			attrs = append(attrs, entitytype.AttributeInfo{
+				Attribute: name,
+				Unique:    uniqueSet[name],
+				Required:  requiredSet[name],
+			})
+		}
+	}
+	add(unique)
+	add(required)
+
+	mockET.On("GetAttributes", mock.Anything, entitytype.TypeCategoryUser, userType,
+		entitytype.AttributeFilter{AllowNonCredential: true}).
+		Return(attrs, nil).Maybe()
+}
+
+// The whole point of the feature: a fresh Google, OIDC or GitHub connection links on email and maps
+// its provider-specific claim onto the required username without the administrator configuring either.
+func (s *IDPServiceTestSuite) TestApplySchemaAwareDefaults_SeedsLinkingAndMapping() {
+	testCases := []struct {
+		idpType        providers.IDPType
+		scopes         string
+		expectedSource string
+	}{
+		{idpType: providers.IDPTypeGoogle, scopes: "openid,email,profile", expectedSource: "email"},
+		{idpType: providers.IDPTypeOIDC, scopes: "openid,email,profile", expectedSource: "email"},
+		{idpType: providers.IDPTypeGitHub, scopes: "user:email", expectedSource: "login"},
+	}
+
+	for _, tc := range testCases {
+		s.Run(string(tc.idpType), func() {
+			service, mockET := s.newSeedingService()
+			expectUserTypes(mockET, entitytype.EntityTypeListItem{Name: seedUserType})
+			expectSchemaFor(mockET, seedUserType, []string{"username", "email"}, []string{"username", "email"})
+
+			idp := seedTestIDP(tc.idpType, tc.scopes)
+			service.ApplySchemaAwareDefaults(context.Background(), idp)
+
+			s.Require().NotNil(idp.AttributeConfiguration)
+			s.Require().NotNil(idp.AttributeConfiguration.AccountLinking)
+			s.Equal([]string{"email"}, idp.AttributeConfiguration.AccountLinking.Attributes)
+
+			s.Require().Len(idp.AttributeConfiguration.UserTypeAttributeMappings, 1)
+			entry := idp.AttributeConfiguration.UserTypeAttributeMappings[0]
+			s.Equal(seedUserType, entry.UserType)
+			s.Require().Len(entry.Attributes, 1)
+			s.Equal(tc.expectedSource, entry.Attributes[0].ExternalAttribute)
+			s.Equal("username", entry.Attributes[0].LocalAttribute)
+			// Mappings are rejected without a resolution default, so one is seeded alongside them.
+			s.Require().NotNil(idp.AttributeConfiguration.UserTypeResolution)
+			s.Equal(seedUserType, idp.AttributeConfiguration.UserTypeResolution.Default)
+		})
+	}
+}
+
+// The reported scenario: two self-registerable types, email unique on both, and only one requiring
+// a username. Linking is seeded from both, and the type requiring a username becomes the mapping
+// target, even though it is neither first nor the one with the fewest required attributes.
+func (s *IDPServiceTestSuite) TestApplySchemaAwareDefaults_ResolvesWhenOneTypeRequiresUsername() {
+	service, mockET := s.newSeedingService()
+	expectUserTypes(mockET,
+		entitytype.EntityTypeListItem{Name: "Guest", AllowSelfRegistration: true},
+		entitytype.EntityTypeListItem{Name: seedUserType, AllowSelfRegistration: true})
+	expectSchemaFor(mockET, "Guest", []string{"email"}, []string{"email"})
+	expectSchemaFor(mockET, seedUserType, []string{"email"}, []string{"username", "email"})
+
+	idp := seedTestIDP(providers.IDPTypeGoogle, "openid,email,profile")
+	service.ApplySchemaAwareDefaults(context.Background(), idp)
+
+	s.Require().NotNil(idp.AttributeConfiguration)
+	s.Require().NotNil(idp.AttributeConfiguration.AccountLinking)
+	s.Equal([]string{"email"}, idp.AttributeConfiguration.AccountLinking.Attributes)
+
+	s.Require().Len(idp.AttributeConfiguration.UserTypeAttributeMappings, 1)
+	s.Equal(seedUserType, idp.AttributeConfiguration.UserTypeAttributeMappings[0].UserType)
+	// The default must name a type that has a mapping, or GetAttributeMappings finds nothing.
+	s.Require().NotNil(idp.AttributeConfiguration.UserTypeResolution)
+	s.Equal(seedUserType, idp.AttributeConfiguration.UserTypeResolution.Default)
+}
+
+// Several types requiring a username all get a mapping, and the first is taken as the resolution
+// default. The listing is ordered by name, so the choice is stable rather than arbitrary.
+func (s *IDPServiceTestSuite) TestApplySchemaAwareDefaults_MapsEveryTypeRequiringUsername() {
+	service, mockET := s.newSeedingService()
+	expectUserTypes(mockET,
+		entitytype.EntityTypeListItem{Name: "Employee", AllowSelfRegistration: true},
+		entitytype.EntityTypeListItem{Name: "Guest", AllowSelfRegistration: true},
+		entitytype.EntityTypeListItem{Name: seedUserType, AllowSelfRegistration: true})
+	expectSchemaFor(mockET, "Employee", []string{"email"}, []string{"username", "email"})
+	expectSchemaFor(mockET, "Guest", []string{"email"}, []string{"email"})
+	expectSchemaFor(mockET, seedUserType, []string{"email"}, []string{"username", "email"})
+
+	idp := seedTestIDP(providers.IDPTypeGoogle, "openid,email,profile")
+	service.ApplySchemaAwareDefaults(context.Background(), idp)
+
+	s.Require().NotNil(idp.AttributeConfiguration)
+	s.NotNil(idp.AttributeConfiguration.AccountLinking)
+
+	mapped := make([]string, 0, 2)
+	for _, entry := range idp.AttributeConfiguration.UserTypeAttributeMappings {
+		mapped = append(mapped, entry.UserType)
+		s.Equal("email", entry.Attributes[0].ExternalAttribute)
+		s.Equal("username", entry.Attributes[0].LocalAttribute)
+	}
+	// Guest requires no username, so it is left out.
+	s.Equal([]string{"Employee", seedUserType}, mapped)
+
+	// The first requiring type becomes the default, and it must be one that has a mapping.
+	s.Require().NotNil(idp.AttributeConfiguration.UserTypeResolution)
+	s.Equal("Employee", idp.AttributeConfiguration.UserTypeResolution.Default)
+}
+
+// Email must be resolvable to a single user whichever type an identity provisions into.
+func (s *IDPServiceTestSuite) TestApplySchemaAwareDefaults_SkipsLinkingWhenACandidateLacksUniqueEmail() {
+	service, mockET := s.newSeedingService()
+	expectUserTypes(mockET,
+		entitytype.EntityTypeListItem{Name: seedUserType, AllowSelfRegistration: true},
+		entitytype.EntityTypeListItem{Name: "Guest", AllowSelfRegistration: true})
+	expectSchemaFor(mockET, seedUserType, []string{"email"}, []string{"username", "email"})
+	expectSchemaFor(mockET, "Guest", []string{"username"}, []string{"email"})
+
+	idp := seedTestIDP(providers.IDPTypeGoogle, "openid,email,profile")
+	service.ApplySchemaAwareDefaults(context.Background(), idp)
+
+	if idp.AttributeConfiguration != nil {
+		s.Nil(idp.AttributeConfiguration.AccountLinking)
+	}
+}
+
+// With nothing a federated user could be provisioned into, there is no schema to derive defaults from.
+func (s *IDPServiceTestSuite) TestApplySchemaAwareDefaults_SkipsWhenNothingQualifies() {
+	testCases := []struct {
+		name    string
+		types   []entitytype.EntityTypeListItem
+		schemas func(*entitytypemock.EntityTypeServiceInterfaceMock)
+	}{
+		{name: "no user types", types: nil},
+		{
+			name:  "no type offers a unique email or requires a username",
+			types: []entitytype.EntityTypeListItem{{Name: "Person"}, {Name: "Partner"}},
+			schemas: func(mockET *entitytypemock.EntityTypeServiceInterfaceMock) {
+				expectSchemaFor(mockET, "Person", []string{"username"}, nil)
+				expectSchemaFor(mockET, "Partner", []string{"username"}, nil)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			service, mockET := s.newSeedingService()
+			expectUserTypes(mockET, tc.types...)
+			if tc.schemas != nil {
+				tc.schemas(mockET)
+			}
+
+			idp := seedTestIDP(providers.IDPTypeGoogle, "openid,email,profile")
+			service.ApplySchemaAwareDefaults(context.Background(), idp)
+
+			s.Nil(idp.AttributeConfiguration)
+		})
+	}
+}
+
+// Mappings are read on login as well as during provisioning, so a type that does not allow self
+// registration still gets one. Its users may be created manually and still sign in federated.
+func (s *IDPServiceTestSuite) TestApplySchemaAwareDefaults_SeedsTypeWithoutSelfRegistration() {
+	service, mockET := s.newSeedingService()
+	expectUserTypes(mockET, entitytype.EntityTypeListItem{Name: seedUserType, AllowSelfRegistration: false})
+	expectSchemaFor(mockET, seedUserType, []string{"username", "email"}, []string{"username", "email"})
+
+	idp := seedTestIDP(providers.IDPTypeGoogle, "openid,email,profile")
+	service.ApplySchemaAwareDefaults(context.Background(), idp)
+
+	s.Require().NotNil(idp.AttributeConfiguration)
+	s.Require().NotNil(idp.AttributeConfiguration.AccountLinking)
+	s.Equal([]string{"email"}, idp.AttributeConfiguration.AccountLinking.Attributes)
+	s.Require().Len(idp.AttributeConfiguration.UserTypeAttributeMappings, 1)
+	s.Equal(seedUserType, idp.AttributeConfiguration.UserTypeAttributeMappings[0].UserType)
+}
+
+// Linking on a non-unique attribute cannot resolve a single user, so it is not seeded.
+func (s *IDPServiceTestSuite) TestApplySchemaAwareDefaults_SkipsLinkingWhenEmailIsNotUnique() {
+	service, mockET := s.newSeedingService()
+	expectUserTypes(mockET, entitytype.EntityTypeListItem{Name: seedUserType})
+	expectSchemaFor(mockET, seedUserType, []string{"username"}, []string{"email"})
+
+	idp := seedTestIDP(providers.IDPTypeGoogle, "openid,email,profile")
+	service.ApplySchemaAwareDefaults(context.Background(), idp)
+
+	if idp.AttributeConfiguration != nil {
+		s.Nil(idp.AttributeConfiguration.AccountLinking)
+	}
+}
+
+// Linking on an attribute the connection never returns would match nothing, so it is worse than no default.
+func (s *IDPServiceTestSuite) TestApplySchemaAwareDefaults_SkipsLinkingWhenScopesCannotYieldEmail() {
+	service, mockET := s.newSeedingService()
+	expectUserTypes(mockET, entitytype.EntityTypeListItem{Name: seedUserType})
+	expectSchemaFor(mockET, seedUserType, []string{"email"}, []string{"email"})
+
+	idp := seedTestIDP(providers.IDPTypeGoogle, "openid,profile")
+	service.ApplySchemaAwareDefaults(context.Background(), idp)
+
+	if idp.AttributeConfiguration != nil {
+		s.Nil(idp.AttributeConfiguration.AccountLinking)
+	}
+}
+
+// No username requirement means no prompt to avoid, so nothing is mapped.
+// Nothing needs a derived username, so no mapping is seeded. The identity still has to resolve to
+// a user type, and that default is taken from the types email can match so it agrees with linking.
+func (s *IDPServiceTestSuite) TestApplySchemaAwareDefaults_DefaultsToEmailTypeWhenUsernameIsOptional() {
+	service, mockET := s.newSeedingService()
+	expectUserTypes(mockET, entitytype.EntityTypeListItem{Name: seedUserType})
+	expectSchemaFor(mockET, seedUserType, []string{"email"}, []string{"email"})
+
+	idp := seedTestIDP(providers.IDPTypeGoogle, "openid,email,profile")
+	service.ApplySchemaAwareDefaults(context.Background(), idp)
+
+	s.Require().NotNil(idp.AttributeConfiguration)
+	s.Empty(idp.AttributeConfiguration.UserTypeAttributeMappings)
+	s.Require().NotNil(idp.AttributeConfiguration.AccountLinking)
+	s.Equal([]string{"email"}, idp.AttributeConfiguration.AccountLinking.Attributes)
+	s.Require().NotNil(idp.AttributeConfiguration.UserTypeResolution)
+	s.Equal(seedUserType, idp.AttributeConfiguration.UserTypeResolution.Default)
+}
+
+// The default has to name a type email can actually identify a single user on, so a candidate without
+// a unique email is passed over rather than taken just for being first.
+func (s *IDPServiceTestSuite) TestApplySchemaAwareDefaults_DefaultSkipsTypeWithoutUniqueEmail() {
+	service, mockET := s.newSeedingService()
+	expectUserTypes(mockET,
+		entitytype.EntityTypeListItem{Name: "Guest", AllowSelfRegistration: true},
+		entitytype.EntityTypeListItem{Name: seedUserType, AllowSelfRegistration: true})
+	expectSchemaFor(mockET, "Guest", []string{"phone"}, []string{"phone"})
+	expectSchemaFor(mockET, seedUserType, []string{"email"}, []string{"email"})
+
+	idp := seedTestIDP(providers.IDPTypeGoogle, "openid,email,profile")
+	service.ApplySchemaAwareDefaults(context.Background(), idp)
+
+	s.Require().NotNil(idp.AttributeConfiguration)
+	s.Empty(idp.AttributeConfiguration.UserTypeAttributeMappings)
+	// Guest has no unique email, so linking stays unseeded, but the default can still name Person.
+	s.Nil(idp.AttributeConfiguration.AccountLinking)
+	s.Require().NotNil(idp.AttributeConfiguration.UserTypeResolution)
+	s.Equal(seedUserType, idp.AttributeConfiguration.UserTypeResolution.Default)
+}
+
+// No candidate can be matched on email and none needs a username, so there is nothing to derive.
+func (s *IDPServiceTestSuite) TestApplySchemaAwareDefaults_SeedsNothingWhenNoTypeHasEmail() {
+	service, mockET := s.newSeedingService()
+	expectUserTypes(mockET, entitytype.EntityTypeListItem{Name: seedUserType})
+	expectSchemaFor(mockET, seedUserType, []string{"phone"}, []string{"phone"})
+
+	idp := seedTestIDP(providers.IDPTypeGoogle, "openid,email,profile")
+	service.ApplySchemaAwareDefaults(context.Background(), idp)
+
+	s.Nil(idp.AttributeConfiguration)
+}
+
+// The mapping's source is the email claim, which arrives only when the scopes ask for it. Seeding it
+// anyway would leave an entry resolving to nothing while the connection looked configured.
+func (s *IDPServiceTestSuite) TestApplySchemaAwareDefaults_SkipsMappingWhenScopesCannotYieldEmail() {
+	service, mockET := s.newSeedingService()
+	expectUserTypes(mockET, entitytype.EntityTypeListItem{Name: seedUserType})
+	expectSchemaFor(mockET, seedUserType, []string{"email"}, []string{"username", "email"})
+
+	idp := seedTestIDP(providers.IDPTypeGoogle, "openid,profile")
+	service.ApplySchemaAwareDefaults(context.Background(), idp)
+
+	s.Nil(idp.AttributeConfiguration)
+}
+
+// GitHub takes its username from the login claim in the profile, so no email scope is involved.
+func (s *IDPServiceTestSuite) TestApplySchemaAwareDefaults_GitHubMapsLoginWithoutEmailScope() {
+	service, mockET := s.newSeedingService()
+	expectUserTypes(mockET, entitytype.EntityTypeListItem{Name: seedUserType})
+	expectSchemaFor(mockET, seedUserType, []string{"email"}, []string{"username", "email"})
+
+	idp := seedTestIDP(providers.IDPTypeGitHub, "read:user")
+	service.ApplySchemaAwareDefaults(context.Background(), idp)
+
+	s.Require().NotNil(idp.AttributeConfiguration)
+	s.Require().Len(idp.AttributeConfiguration.UserTypeAttributeMappings, 1)
+	s.Equal("login", idp.AttributeConfiguration.UserTypeAttributeMappings[0].Attributes[0].ExternalAttribute)
+	// read:user grants no email, so linking is withheld while the login mapping still applies.
+	s.Nil(idp.AttributeConfiguration.AccountLinking)
+}
+
+// A claim-driven resolution the administrator configured must survive the default being filled in.
+func (s *IDPServiceTestSuite) TestApplySchemaAwareDefaults_PreservesClaimDrivenResolution() {
+	service, mockET := s.newSeedingService()
+	expectUserTypes(mockET, entitytype.EntityTypeListItem{Name: seedUserType})
+	expectSchemaFor(mockET, seedUserType, []string{"email"}, []string{"username", "email"})
+
+	idp := seedTestIDP(providers.IDPTypeGoogle, "openid,email,profile")
+	idp.AttributeConfiguration = &providers.AttributeConfiguration{
+		UserTypeResolution: &providers.UserTypeResolution{
+			ExternalAttribute: "org",
+			ValueMapping:      map[string]string{"acme": seedUserType},
+		},
+	}
+
+	service.ApplySchemaAwareDefaults(context.Background(), idp)
+
+	resolution := idp.AttributeConfiguration.UserTypeResolution
+	s.Require().NotNil(resolution)
+	s.Equal("org", resolution.ExternalAttribute)
+	s.Equal(map[string]string{"acme": seedUserType}, resolution.ValueMapping)
+	s.Equal(seedUserType, resolution.Default)
+}
+
+// Generic OAuth carries no scope or claim semantics ThunderID can infer.
+func (s *IDPServiceTestSuite) TestApplySchemaAwareDefaults_LeavesGenericOAuthAlone() {
+	service, mockET := s.newSeedingService()
+	expectUserTypes(mockET, entitytype.EntityTypeListItem{Name: seedUserType})
+	expectSchemaFor(mockET, seedUserType, []string{"username", "email"}, []string{"username", "email"})
+
+	idp := seedTestIDP(providers.IDPTypeOAuth, "email")
+	service.ApplySchemaAwareDefaults(context.Background(), idp)
+
+	if idp.AttributeConfiguration != nil {
+		s.Nil(idp.AttributeConfiguration.AccountLinking)
+		s.Empty(idp.AttributeConfiguration.UserTypeAttributeMappings)
+	}
+}
+
+// Fully explicit configuration is left alone, and short-circuits before any schema is read: the
+// mock carries no expectations, so any call to it fails the test.
+func (s *IDPServiceTestSuite) TestApplySchemaAwareDefaults_PreservesExplicitConfiguration() {
+	service, _ := s.newSeedingService()
+
+	idp := seedTestIDP(providers.IDPTypeGoogle, "openid,email,profile")
+	idp.AttributeConfiguration = &providers.AttributeConfiguration{
+		AccountLinking:     &providers.AccountLinking{Attributes: []string{"phone_number"}},
+		UserTypeResolution: &providers.UserTypeResolution{Default: "Employee"},
+		UserTypeAttributeMappings: []providers.UserTypeAttributeMapping{{
+			UserType:   "Employee",
+			Attributes: []providers.AttributeMapping{{ExternalAttribute: "sub", LocalAttribute: "username"}},
+		}},
+	}
+
+	service.ApplySchemaAwareDefaults(context.Background(), idp)
+
+	s.Equal([]string{"phone_number"}, idp.AttributeConfiguration.AccountLinking.Attributes)
+	s.Len(idp.AttributeConfiguration.UserTypeAttributeMappings, 1)
+	s.Equal("Employee", idp.AttributeConfiguration.UserTypeResolution.Default)
+}
+
+// A transient read failure must not block creating a connection.
+func (s *IDPServiceTestSuite) TestApplySchemaAwareDefaults_SkipsWhenUserTypesCannotBeRead() {
+	service, mockET := s.newSeedingService()
+	mockET.On("GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, &tidcommon.InternalServerError)
+
+	idp := seedTestIDP(providers.IDPTypeGoogle, "openid,email,profile")
+	service.ApplySchemaAwareDefaults(context.Background(), idp)
+
+	s.Nil(idp.AttributeConfiguration)
+}
+
+// Seeding is best-effort and runs on paths that cannot handle a panic: a nil connection or a service
+// built without an entity-type dependency must leave the connection untouched rather than crash.
+func (s *IDPServiceTestSuite) TestApplySchemaAwareDefaults_ToleratesNilInputs() {
+	service, _ := s.newSeedingService()
+	service.ApplySchemaAwareDefaults(context.Background(), nil)
+
+	bare := &idpService{logger: log.GetLogger()}
+	idp := seedTestIDP(providers.IDPTypeGoogle, "openid,email,profile")
+	bare.ApplySchemaAwareDefaults(context.Background(), idp)
+	s.Nil(idp.AttributeConfiguration)
+}
+
+// An update replaces the whole connection, so a section the administrator removed is
+// indistinguishable from one that was never configured. Seeding on update would silently restore it,
+// making the removal appear to succeed and then revert.
+func (s *IDPServiceTestSuite) TestUpdateIdentityProvider_DoesNotReSeedRemovedDefaults() {
+	idpID := mutableIDPTestID
+	existing := &providers.IDPDTO{
+		ID:         idpID,
+		Name:       "Google",
+		Type:       providers.IDPTypeGoogle,
+		Properties: createOIDCProperties(),
+		AttributeConfiguration: &providers.AttributeConfiguration{
+			AccountLinking: &providers.AccountLinking{Attributes: []string{defaultAccountLinkingAttribute}},
+		},
+	}
+
+	// The name is unchanged, so the uniqueness lookup is not reached.
+	s.mockStore.On("GetIdentityProvider", mock.Anything, idpID).Return(existing, nil)
+	s.mockStore.On("UpdateIdentityProvider", mock.Anything, mock.MatchedBy(func(dto *providers.IDPDTO) bool {
+		return dto.AttributeConfiguration == nil
+	})).Return(nil)
+
+	// A schema that would seed both defaults if the update path applied them, so this test fails if
+	// seeding is ever reintroduced here rather than passing because there was nothing to seed.
+	// Permitted but not required: if the update path reads them, seeding would populate the section
+	// and the assertion below fails.
+	mockET := entitytypemock.NewEntityTypeServiceInterfaceMock(s.T())
+	mockET.On("GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser,
+		mock.Anything, mock.Anything, mock.Anything).
+		Return(&entitytype.EntityTypeListResponse{Types: []entitytype.EntityTypeListItem{
+			{Name: seedUserType, AllowSelfRegistration: true},
+		}}, nil).Maybe()
+	expectSchemaFor(mockET, seedUserType, []string{"email"}, []string{"username", "email"})
+	service := &idpService{
+		idpStore:           s.mockStore,
+		transactioner:      &mockTransactioner{},
+		dependencyRegistry: newNoBlockingDepsRegistry(),
+		entityTypeService:  mockET,
+		logger:             log.GetLogger().With(log.String(log.LoggerKeyComponentName, "IdPService")),
+		uuidGenerator:      utils.GenerateUUIDv7,
+	}
+
+	// The administrator saves the connection with the account-linking section removed.
+	cleared := &providers.IDPDTO{
+		Name:       "Google",
+		Type:       providers.IDPTypeGoogle,
+		Properties: createOIDCProperties(),
+	}
+
+	result, err := service.UpdateIdentityProvider(context.Background(), idpID, cleared)
+
+	s.Nil(err)
+	s.Require().NotNil(result)
+	s.Nil(result.AttributeConfiguration, "a removed section must stay removed after saving")
 }

--- a/backend/internal/idp/utils.go
+++ b/backend/internal/idp/utils.go
@@ -20,9 +20,6 @@ import (
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
 
-// subClaim is the OIDC subject identifier claim, which is always preserved during attribute mapping.
-const subClaim = "sub"
-
 // GetPropertyValue returns the plain-text value for the named property from the slice,
 // or an empty string if the property is absent or its value cannot be retrieved.
 func GetPropertyValue(properties []cmodels.Property, name string) string {
@@ -105,8 +102,14 @@ func GetAttributeMappings(idp *providers.IDPDTO, claims map[string]interface{}) 
 	return nil
 }
 
-// ApplyAttributeMappings applies external→local attribute mappings. Unmapped attributes pass through;
-// mapped values take precedence on collision. Returns attrs unchanged when no mappings are configured.
+// ApplyAttributeMappings applies external→local attribute mappings. Mappings copy rather than rename:
+// every incoming attribute is preserved and the mapped value is published under the local name as
+// well. Mapped values take precedence on collision. Returns attrs unchanged when no mappings are
+// configured.
+//
+// Copying matters because one external claim can legitimately feed two local attributes, and because
+// consuming the source silently drops it. Mapping email onto a required username, for example, would
+// otherwise leave the identity with no email at all.
 func ApplyAttributeMappings(
 	attrs map[string]interface{},
 	mappings []providers.AttributeMapping,
@@ -115,20 +118,9 @@ func ApplyAttributeMappings(
 		return attrs
 	}
 
-	mappedSources := make(map[string]bool, len(mappings))
-	for _, m := range mappings {
-		// sub is always preserved as-is; it must not be consumed by a mapping.
-		if m.ExternalAttribute == subClaim {
-			continue
-		}
-		mappedSources[m.ExternalAttribute] = true
-	}
-
-	result := make(map[string]interface{}, len(attrs))
+	result := make(map[string]interface{}, len(attrs)+len(mappings))
 	for key, value := range attrs {
-		if !mappedSources[key] {
-			result[key] = value
-		}
+		result[key] = value
 	}
 	for _, m := range mappings {
 		if value, ok := getNestedValue(attrs, m.ExternalAttribute); ok {
@@ -382,7 +374,28 @@ func validateIDPProperties(ctx context.Context, idpType providers.IDPType, prope
 		}
 	}
 
+	// Seed the email scope for GitHub IDPs
+	if idpType == providers.IDPTypeGitHub {
+		if err := ensureDefaultGitHubScopes(ctx, filteredPropsMap, logger); err != nil {
+			return nil, err
+		}
+	}
+
 	return propertyMapToSlice(filteredPropsMap), nil
+}
+
+// readScopesValue reads the raw value of a scopes property. Shared by the per-provider scope defaults
+// so the failure is reported under a single i18n key rather than one per caller.
+func readScopesValue(scopesProp cmodels.Property) (string, *tidcommon.ServiceError) {
+	scopesValue, err := scopesProp.GetValue()
+	if err != nil {
+		return "", tidcommon.CustomServiceError(ErrorInvalidIDPProperty, tidcommon.I18nMessage{
+			Key:          "error.idpservice.scopes_value_get_failed_description",
+			DefaultValue: "failed to get scopes value: {{param(error)}}",
+			Params:       map[string]string{"error": err.Error()},
+		})
+	}
+	return scopesValue, nil
 }
 
 // ensureOpenIDScope ensures that the openid scope is present in the scopes property,
@@ -398,13 +411,9 @@ func ensureOpenIDScope(ctx context.Context, propertyMap map[string]cmodels.Prope
 		return nil
 	}
 
-	scopesValue, err := scopesProp.GetValue()
-	if err != nil {
-		return tidcommon.CustomServiceError(ErrorInvalidIDPProperty, tidcommon.I18nMessage{
-			Key:          "error.idpservice.scopes_value_get_failed_description",
-			DefaultValue: "failed to get scopes value: {{param(error)}}",
-			Params:       map[string]string{"error": err.Error()},
-		})
+	scopesValue, svcErr := readScopesValue(scopesProp)
+	if svcErr != nil {
+		return svcErr
 	}
 
 	scopes := sysutils.ParseStringArray(scopesValue, ",")
@@ -433,6 +442,64 @@ func ensureOpenIDScope(ctx context.Context, propertyMap map[string]cmodels.Prope
 	}
 
 	return nil
+}
+
+// ensureDefaultGitHubScopes seeds the GitHub email scope when no scopes are supplied, leaving explicitly
+// configured scopes untouched. Applied here rather than through the type's default property map,
+// because those values are rewritten as URLs by resolveEndpointDefaults.
+func ensureDefaultGitHubScopes(ctx context.Context, propertyMap map[string]cmodels.Property,
+	logger *log.Logger) *tidcommon.ServiceError {
+	scopesProp, exists := propertyMap[PropScopes]
+	if !exists {
+		return createAndAppendProperty(ctx, propertyMap, PropScopes, defaultGitHubScopes, false, logger)
+	}
+
+	scopesValue, svcErr := readScopesValue(scopesProp)
+	if svcErr != nil {
+		return svcErr
+	}
+
+	for _, scope := range sysutils.ParseStringArray(scopesValue, ",") {
+		if scope != "" {
+			return nil
+		}
+	}
+
+	return createAndAppendProperty(ctx, propertyMap, PropScopes, defaultGitHubScopes, false, logger)
+}
+
+// scopesGrantEmail reports whether the effective scopes let the connection read an email address.
+// Generic OAuth is absent by design as we cannot infer an arbitrary provider's scope semantics.
+func scopesGrantEmail(idpType providers.IDPType, scopes []string) bool {
+	switch idpType {
+	case providers.IDPTypeGoogle, providers.IDPTypeOIDC:
+		return slices.Contains(scopes, emailScope)
+	case providers.IDPTypeGitHub:
+		return slices.Contains(scopes, gitHubUserEmailScope) || slices.Contains(scopes, gitHubUserScope)
+	default:
+		return false
+	}
+}
+
+// defaultUsernameSourceAttribute returns the external claim used for the default username mapping,
+// or "" when the provider has none. Google and OIDC use email, while GitHub uses its login claim.
+func defaultUsernameSourceAttribute(idpType providers.IDPType) string {
+	switch idpType {
+	case providers.IDPTypeGoogle, providers.IDPTypeOIDC:
+		return emailClaim
+	case providers.IDPTypeGitHub:
+		return gitHubLoginClaim
+	default:
+		return ""
+	}
+}
+
+// ensureAttributeConfiguration returns the attribute configuration, creating it when absent.
+func ensureAttributeConfiguration(idp *providers.IDPDTO) *providers.AttributeConfiguration {
+	if idp.AttributeConfiguration == nil {
+		idp.AttributeConfiguration = &providers.AttributeConfiguration{}
+	}
+	return idp.AttributeConfiguration
 }
 
 // createAndAppendProperty creates a new property and appends it to the property map.

--- a/backend/internal/idp/utils_test.go
+++ b/backend/internal/idp/utils_test.go
@@ -252,6 +252,138 @@ func (s *IDPUtilsTestSuite) TestValidateIDPProperties_GitHub_WithCustomEndpoints
 	s.Equal(gitHubAuthorizationEndpoint, foundProperties[PropAuthorizationEndpoint])
 }
 
+// GitHub returns no email at all without an email scope, so a connection created without scopes gets one.
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_GitHub_DefaultsScopes() {
+	prop1, _ := cmodels.NewProperty(PropClientID, "test-client", false)
+	prop2, _ := cmodels.NewProperty(PropClientSecret, "test-secret", false)
+	prop3, _ := cmodels.NewProperty(PropRedirectURI, "http://localhost/callback", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3}
+
+	result, err := validateIDPProperties(context.Background(), providers.IDPTypeGitHub, properties, s.logger)
+
+	s.Nil(err)
+	s.Equal(defaultGitHubScopes, GetPropertyValue(result, PropScopes))
+}
+
+// A deliberately narrow scope list is a choice, not an omission, even when it cannot yield an email.
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_GitHub_PreservesExplicitScopes() {
+	prop1, _ := cmodels.NewProperty(PropClientID, "test-client", false)
+	prop2, _ := cmodels.NewProperty(PropClientSecret, "test-secret", false)
+	prop3, _ := cmodels.NewProperty(PropRedirectURI, "http://localhost/callback", false)
+	prop4, _ := cmodels.NewProperty(PropScopes, "read:user", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3, *prop4}
+
+	result, err := validateIDPProperties(context.Background(), providers.IDPTypeGitHub, properties, s.logger)
+
+	s.Nil(err)
+	s.Equal("read:user", GetPropertyValue(result, PropScopes))
+}
+
+// An explicitly empty scope string is rejected by the generic empty-value check that applies to every
+// property, so it never reaches scope defaulting.
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_GitHub_EmptyScopesRejected() {
+	prop1, _ := cmodels.NewProperty(PropClientID, "test-client", false)
+	prop2, _ := cmodels.NewProperty(PropClientSecret, "test-secret", false)
+	prop3, _ := cmodels.NewProperty(PropRedirectURI, "http://localhost/callback", false)
+	prop4, _ := cmodels.NewProperty(PropScopes, "", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3, *prop4}
+
+	result, err := validateIDPProperties(context.Background(), providers.IDPTypeGitHub, properties, s.logger)
+
+	s.NotNil(err)
+	s.Nil(result)
+	s.Equal(ErrorInvalidIDPProperty.Code, err.Code)
+}
+
+// A scope value that survives the empty-value check but parses to no scopes still defaults.
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_GitHub_BlankScopeListDefaults() {
+	prop1, _ := cmodels.NewProperty(PropClientID, "test-client", false)
+	prop2, _ := cmodels.NewProperty(PropClientSecret, "test-secret", false)
+	prop3, _ := cmodels.NewProperty(PropRedirectURI, "http://localhost/callback", false)
+	prop4, _ := cmodels.NewProperty(PropScopes, ",", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3, *prop4}
+
+	result, err := validateIDPProperties(context.Background(), providers.IDPTypeGitHub, properties, s.logger)
+
+	s.Nil(err)
+	s.Equal(defaultGitHubScopes, GetPropertyValue(result, PropScopes))
+}
+
+// An empty value reaches the defaulting step as a present-but-blank property, not a missing one.
+func (s *IDPUtilsTestSuite) TestEnsureGitHubScopes_EmptyScopesValue() {
+	prop, _ := cmodels.NewProperty(PropScopes, "", false)
+	propertyMap := map[string]cmodels.Property{
+		PropScopes: *prop,
+	}
+
+	err := ensureDefaultGitHubScopes(context.Background(), propertyMap, s.logger)
+
+	s.Nil(err)
+
+	scopesProp := propertyMap[PropScopes]
+	value, _ := scopesProp.GetValue()
+	s.Equal(defaultGitHubScopes, value)
+}
+
+// The property is created, not just populated, when the connection omits scopes entirely.
+func (s *IDPUtilsTestSuite) TestEnsureGitHubScopes_NoExistingScopes() {
+	propertyMap := map[string]cmodels.Property{}
+
+	err := ensureDefaultGitHubScopes(context.Background(), propertyMap, s.logger)
+
+	s.Nil(err)
+
+	scopesProp := propertyMap[PropScopes]
+	value, _ := scopesProp.GetValue()
+	s.Equal(defaultGitHubScopes, value)
+}
+
+// The scope default must not travel through resolveEndpointDefaults: that rewrites each value's
+// scheme and host, and "user:email" parses as a URL with scheme "user", so a base URL override would
+// corrupt it.
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_GitHub_ScopesSurviveBaseURLOverride() {
+	config.ResetServerRuntime()
+	_ = config.InitializeServerRuntime("/tmp/test", &config.Config{
+		IdentityProvider: config.IdentityProviderConfig{
+			GitHubBaseURL: "http://localhost:8092",
+		},
+	})
+	defer config.ResetServerRuntime()
+
+	prop1, _ := cmodels.NewProperty(PropClientID, "test-client", false)
+	prop2, _ := cmodels.NewProperty(PropClientSecret, "test-secret", false)
+	prop3, _ := cmodels.NewProperty(PropRedirectURI, "http://localhost/callback", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3}
+
+	result, err := validateIDPProperties(context.Background(), providers.IDPTypeGitHub, properties, s.logger)
+
+	s.Nil(err)
+	s.Equal(defaultGitHubScopes, GetPropertyValue(result, PropScopes))
+	s.Contains(GetPropertyValue(result, PropAuthorizationEndpoint), "localhost:8092")
+}
+
+// Generic OAuth has no known email scope to guess, so it keeps no scopes rather than inheriting one.
+func (s *IDPUtilsTestSuite) TestValidateIDPProperties_OAuth_NoScopeDefault() {
+	prop1, _ := cmodels.NewProperty(PropClientID, "test-client", false)
+	prop2, _ := cmodels.NewProperty(PropClientSecret, "test-secret", false)
+	prop3, _ := cmodels.NewProperty(PropRedirectURI, "http://localhost/callback", false)
+	prop4, _ := cmodels.NewProperty(PropAuthorizationEndpoint, "http://idp/auth", false)
+	prop5, _ := cmodels.NewProperty(PropTokenEndpoint, "http://idp/token", false)
+	prop6, _ := cmodels.NewProperty(PropUserInfoEndpoint, "http://idp/userinfo", false)
+
+	properties := []cmodels.Property{*prop1, *prop2, *prop3, *prop4, *prop5, *prop6}
+
+	result, err := validateIDPProperties(context.Background(), providers.IDPTypeOAuth, properties, s.logger)
+
+	s.Nil(err)
+	s.Empty(GetPropertyValue(result, PropScopes))
+}
+
 func (s *IDPUtilsTestSuite) TestValidateIDPProperties_EmptyPropertyName() {
 	prop1, _ := cmodels.NewProperty("", "test-value", false)
 
@@ -993,7 +1125,8 @@ func (s *IDPUtilsTestSuite) TestApplyAttributeMappings_EmptyMappings_NoOp() {
 	s.Equal(attrs, result)
 }
 
-func (s *IDPUtilsTestSuite) TestApplyAttributeMappings_RenamesMappedClaim() {
+// Mappings copy rather than rename, so the source claim survives alongside the local attribute.
+func (s *IDPUtilsTestSuite) TestApplyAttributeMappings_PublishesMappedClaimAndKeepsSource() {
 	attrs := map[string]interface{}{
 		"http://schemas.example.com/emailaddress": "user@example.com",
 	}
@@ -1001,8 +1134,19 @@ func (s *IDPUtilsTestSuite) TestApplyAttributeMappings_RenamesMappedClaim() {
 		{ExternalAttribute: "http://schemas.example.com/emailaddress", LocalAttribute: "email"},
 	})
 	s.Equal("user@example.com", result["email"])
-	_, present := result["http://schemas.example.com/emailaddress"]
-	s.False(present)
+	s.Equal("user@example.com", result["http://schemas.example.com/emailaddress"])
+}
+
+// The case the copy semantics exist for: mapping an email onto a required username must not leave the
+// identity without an email.
+func (s *IDPUtilsTestSuite) TestApplyAttributeMappings_EmailSurvivesAUsernameMapping() {
+	attrs := map[string]interface{}{"email": "user@example.com", "sub": "user-123"}
+	result := ApplyAttributeMappings(attrs, []providers.AttributeMapping{
+		{ExternalAttribute: "email", LocalAttribute: "username"},
+	})
+	s.Equal("user@example.com", result["username"])
+	s.Equal("user@example.com", result["email"])
+	s.Equal("user-123", result["sub"])
 }
 
 func (s *IDPUtilsTestSuite) TestApplyAttributeMappings_OneSourceToMultipleTargets() {
@@ -1024,8 +1168,7 @@ func (s *IDPUtilsTestSuite) TestApplyAttributeMappings_UnmappedPassesThrough() {
 		attrs, []providers.AttributeMapping{{ExternalAttribute: "given_name", LocalAttribute: "firstName"}})
 	s.Equal("Jane", result["firstName"])
 	s.Equal("engineering", result["department"])
-	_, present := result["given_name"]
-	s.False(present)
+	s.Equal("Jane", result["given_name"])
 }
 
 func (s *IDPUtilsTestSuite) TestApplyAttributeMappings_MappedValueOverridesCollision() {
@@ -1084,7 +1227,9 @@ func (s *IDPUtilsTestSuite) TestApplyAttributeMappings_SubPreservedWhenMappedToM
 	s.Equal("user-123", result["email"])
 }
 
-func (s *IDPUtilsTestSuite) TestApplyAttributeMappings_SubPreservedAlongsideOtherRenamedSources() {
+// sub needed a carve-out under rename semantics; under copy semantics every source is preserved and
+// it is no longer a special case.
+func (s *IDPUtilsTestSuite) TestApplyAttributeMappings_AllSourcesPreserved() {
 	attrs := map[string]interface{}{
 		"sub":        "user-123",
 		"given_name": "Jane",
@@ -1096,9 +1241,7 @@ func (s *IDPUtilsTestSuite) TestApplyAttributeMappings_SubPreservedAlongsideOthe
 	s.Equal("user-123", result["sub"])
 	s.Equal("user-123", result["picture"])
 	s.Equal("Jane", result["firstName"])
-	// Non-sub sources are still consumed by the mapping.
-	_, present := result["given_name"]
-	s.False(present)
+	s.Equal("Jane", result["given_name"])
 }
 
 func (s *IDPUtilsTestSuite) TestGetAttributeMappings_NilIDP() {

--- a/backend/internal/oauth/oauth2/tokenservice/validator_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator_test.go
@@ -261,7 +261,8 @@ func (suite *TokenValidatorTestSuite) TestExtractSubjectTokenClaims_MapsReserved
 	assert.Equal(suite.T(), "Jane", result.UserAttributes["firstName"])
 	// Reserved claims are still filtered out of the attribute set.
 	assert.NotContains(suite.T(), result.UserAttributes, "sub")
-	assert.NotContains(suite.T(), result.UserAttributes, "given_name")
+	// Mappings copy rather than rename, so the source claim survives alongside the local attribute.
+	assert.Equal(suite.T(), "Jane", result.UserAttributes["given_name"])
 }
 
 func (suite *TokenValidatorTestSuite) TestValidateSubjectToken_Error_InvalidJWTFormat() {
@@ -2782,8 +2783,8 @@ func (suite *ExternalIDPValidatorTestSuite) TestValidateSubjectToken_ExternalIDP
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
 	assert.Equal(suite.T(), "user@example.com", result.UserAttributes["email"])
-	_, originalPresent := result.UserAttributes[externalAttribute]
-	assert.False(suite.T(), originalPresent)
+	// Mappings copy rather than rename, so the source claim survives alongside the local attribute.
+	assert.Equal(suite.T(), "user@example.com", result.UserAttributes[externalAttribute])
 	suite.mockIDPService.AssertExpectations(suite.T())
 	suite.mockJWTService.AssertExpectations(suite.T())
 }

--- a/backend/tests/mocks/idp/idpmock/IDPServiceInterface_mock.go
+++ b/backend/tests/mocks/idp/idpmock/IDPServiceInterface_mock.go
@@ -41,6 +41,52 @@ func (_m *IDPServiceInterfaceMock) EXPECT() *IDPServiceInterfaceMock_Expecter {
 	return &IDPServiceInterfaceMock_Expecter{mock: &_m.Mock}
 }
 
+// ApplySchemaAwareDefaults provides a mock function for the type IDPServiceInterfaceMock
+func (_mock *IDPServiceInterfaceMock) ApplySchemaAwareDefaults(ctx context.Context, idp *providers.IDPDTO) {
+	_mock.Called(ctx, idp)
+	return
+}
+
+// IDPServiceInterfaceMock_ApplySchemaAwareDefaults_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ApplySchemaAwareDefaults'
+type IDPServiceInterfaceMock_ApplySchemaAwareDefaults_Call struct {
+	*mock.Call
+}
+
+// ApplySchemaAwareDefaults is a helper method to define mock.On call
+//   - ctx context.Context
+//   - idp *providers.IDPDTO
+func (_e *IDPServiceInterfaceMock_Expecter) ApplySchemaAwareDefaults(ctx interface{}, idp interface{}) *IDPServiceInterfaceMock_ApplySchemaAwareDefaults_Call {
+	return &IDPServiceInterfaceMock_ApplySchemaAwareDefaults_Call{Call: _e.mock.On("ApplySchemaAwareDefaults", ctx, idp)}
+}
+
+func (_c *IDPServiceInterfaceMock_ApplySchemaAwareDefaults_Call) Run(run func(ctx context.Context, idp *providers.IDPDTO)) *IDPServiceInterfaceMock_ApplySchemaAwareDefaults_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *providers.IDPDTO
+		if args[1] != nil {
+			arg1 = args[1].(*providers.IDPDTO)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *IDPServiceInterfaceMock_ApplySchemaAwareDefaults_Call) Return() *IDPServiceInterfaceMock_ApplySchemaAwareDefaults_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *IDPServiceInterfaceMock_ApplySchemaAwareDefaults_Call) RunAndReturn(run func(ctx context.Context, idp *providers.IDPDTO)) *IDPServiceInterfaceMock_ApplySchemaAwareDefaults_Call {
+	_c.Run(run)
+	return _c
+}
+
 // CreateIdentityProvider provides a mock function for the type IDPServiceInterfaceMock
 func (_mock *IDPServiceInterfaceMock) CreateIdentityProvider(ctx context.Context, idp *providers.IDPDTO) (*providers.IDPDTO, *common.ServiceError) {
 	ret := _mock.Called(ctx, idp)

--- a/frontend/apps/console/src/features/flows/data/templates.json
+++ b/frontend/apps/console/src/features/flows/data/templates.json
@@ -1688,7 +1688,8 @@
           "id": "google_auth",
           "type": "TASK_EXECUTION",
           "properties": {
-            "idpId": "{{IDP_ID}}"
+            "idpId": "{{IDP_ID}}",
+            "allowAuthenticationWithoutLocalUser": true
           },
           "executor": {
             "name": "GoogleOIDCAuthExecutor",
@@ -1701,7 +1702,7 @@
               }
             ]
           },
-          "onSuccess": "auth_assert",
+          "onSuccess": "provisioning",
           "layout": {
             "size": {
               "width": 200,
@@ -1710,6 +1711,76 @@
             "position": {
               "x": 305,
               "y": 64
+            }
+          }
+        },
+        {
+          "id": "provisioning",
+          "type": "TASK_EXECUTION",
+          "executor": {
+            "name": "ProvisioningExecutor"
+          },
+          "onSuccess": "auth_assert",
+          "layout": {
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 555,
+              "y": 64
+            }
+          },
+          "onIncomplete": "prompt_schema_attrs"
+        },
+        {
+          "id": "prompt_schema_attrs",
+          "type": "PROMPT",
+          "meta": {
+            "components": [
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "heading_schema_attrs",
+                "label": "{{ t(signin:forms.schema_attrs.title) }}",
+                "variant": "HEADING_1"
+              },
+              {
+                "type": "BLOCK",
+                "id": "block_dynamic_user_inputs",
+                "components": [
+                  {
+                    "type": "DYNAMIC_INPUT_PLACEHOLDER",
+                    "id": "dynamic_inputs"
+                  },
+                  {
+                    "type": "ACTION",
+                    "id": "action_schema_attrs",
+                    "label": "{{ t(signin:forms.schema_attrs.actions.continue.label) }}",
+                    "variant": "PRIMARY",
+                    "eventType": "SUBMIT"
+                  }
+                ]
+              }
+            ]
+          },
+          "prompts": [
+            {
+              "inputs": [],
+              "action": {
+                "ref": "action_schema_attrs",
+                "nextNode": "provisioning"
+              }
+            }
+          ],
+          "layout": {
+            "size": {
+              "width": 350,
+              "height": 400
+            },
+            "position": {
+              "x": 555,
+              "y": -496
             }
           }
         },
@@ -1726,7 +1797,7 @@
               "height": 113
             },
             "position": {
-              "x": 646,
+              "x": 1126,
               "y": 64
             }
           }
@@ -1740,7 +1811,7 @@
               "height": 34
             },
             "position": {
-              "x": 1015,
+              "x": 1495,
               "y": 105
             }
           }
@@ -1783,7 +1854,8 @@
           "id": "github_auth",
           "type": "TASK_EXECUTION",
           "properties": {
-            "idpId": "{{IDP_ID}}"
+            "idpId": "{{IDP_ID}}",
+            "allowAuthenticationWithoutLocalUser": true
           },
           "executor": {
             "name": "GithubOAuthExecutor",
@@ -1796,7 +1868,7 @@
               }
             ]
           },
-          "onSuccess": "auth_assert",
+          "onSuccess": "provisioning",
           "layout": {
             "size": {
               "width": 200,
@@ -1805,6 +1877,76 @@
             "position": {
               "x": 305,
               "y": 64
+            }
+          }
+        },
+        {
+          "id": "provisioning",
+          "type": "TASK_EXECUTION",
+          "executor": {
+            "name": "ProvisioningExecutor"
+          },
+          "onSuccess": "auth_assert",
+          "layout": {
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 555,
+              "y": 64
+            }
+          },
+          "onIncomplete": "prompt_schema_attrs"
+        },
+        {
+          "id": "prompt_schema_attrs",
+          "type": "PROMPT",
+          "meta": {
+            "components": [
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "heading_schema_attrs",
+                "label": "{{ t(signin:forms.schema_attrs.title) }}",
+                "variant": "HEADING_1"
+              },
+              {
+                "type": "BLOCK",
+                "id": "block_dynamic_user_inputs",
+                "components": [
+                  {
+                    "type": "DYNAMIC_INPUT_PLACEHOLDER",
+                    "id": "dynamic_inputs"
+                  },
+                  {
+                    "type": "ACTION",
+                    "id": "action_schema_attrs",
+                    "label": "{{ t(signin:forms.schema_attrs.actions.continue.label) }}",
+                    "variant": "PRIMARY",
+                    "eventType": "SUBMIT"
+                  }
+                ]
+              }
+            ]
+          },
+          "prompts": [
+            {
+              "inputs": [],
+              "action": {
+                "ref": "action_schema_attrs",
+                "nextNode": "provisioning"
+              }
+            }
+          ],
+          "layout": {
+            "size": {
+              "width": 350,
+              "height": 400
+            },
+            "position": {
+              "x": 555,
+              "y": -496
             }
           }
         },
@@ -1821,7 +1963,7 @@
               "height": 113
             },
             "position": {
-              "x": 646,
+              "x": 1126,
               "y": 64
             }
           }
@@ -1835,7 +1977,7 @@
               "height": 34
             },
             "position": {
-              "x": 1015,
+              "x": 1495,
               "y": 105
             }
           }
@@ -1977,7 +2119,8 @@
             }
           },
           "properties": {
-            "idpId": "{{IDP_ID}}"
+            "idpId": "{{IDP_ID}}",
+            "allowAuthenticationWithoutLocalUser": true
           },
           "executor": {
             "name": "GoogleOIDCAuthExecutor",
@@ -1990,7 +2133,7 @@
               }
             ]
           },
-          "onSuccess": "auth_assert"
+          "onSuccess": "provisioning"
         },
         {
           "id": "github_auth",
@@ -2006,7 +2149,8 @@
             }
           },
           "properties": {
-            "idpId": "{{IDP_ID}}"
+            "idpId": "{{IDP_ID}}",
+            "allowAuthenticationWithoutLocalUser": true
           },
           "executor": {
             "name": "GithubOAuthExecutor",
@@ -2019,7 +2163,77 @@
               }
             ]
           },
-          "onSuccess": "auth_assert"
+          "onSuccess": "provisioning"
+        },
+        {
+          "id": "provisioning",
+          "type": "TASK_EXECUTION",
+          "executor": {
+            "name": "ProvisioningExecutor"
+          },
+          "onSuccess": "auth_assert",
+          "layout": {
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 1239,
+              "y": 454
+            }
+          },
+          "onIncomplete": "prompt_schema_attrs"
+        },
+        {
+          "id": "prompt_schema_attrs",
+          "type": "PROMPT",
+          "meta": {
+            "components": [
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "heading_schema_attrs",
+                "label": "{{ t(signin:forms.schema_attrs.title) }}",
+                "variant": "HEADING_1"
+              },
+              {
+                "type": "BLOCK",
+                "id": "block_dynamic_user_inputs",
+                "components": [
+                  {
+                    "type": "DYNAMIC_INPUT_PLACEHOLDER",
+                    "id": "dynamic_inputs"
+                  },
+                  {
+                    "type": "ACTION",
+                    "id": "action_schema_attrs",
+                    "label": "{{ t(signin:forms.schema_attrs.actions.continue.label) }}",
+                    "variant": "PRIMARY",
+                    "eventType": "SUBMIT"
+                  }
+                ]
+              }
+            ]
+          },
+          "prompts": [
+            {
+              "inputs": [],
+              "action": {
+                "ref": "action_schema_attrs",
+                "nextNode": "provisioning"
+              }
+            }
+          ],
+          "layout": {
+            "size": {
+              "width": 350,
+              "height": 400
+            },
+            "position": {
+              "x": 1239,
+              "y": -106
+            }
+          }
         },
         {
           "id": "auth_assert",
@@ -2030,7 +2244,7 @@
               "height": 113
             },
             "position": {
-              "x": 1329,
+              "x": 1809,
               "y": 454
             }
           },
@@ -2048,7 +2262,7 @@
               "height": 34
             },
             "position": {
-              "x": 1710,
+              "x": 2190,
               "y": 493
             }
           }
@@ -2266,7 +2480,8 @@
             }
           },
           "properties": {
-            "idpId": "{{IDP_ID}}"
+            "idpId": "{{IDP_ID}}",
+            "allowAuthenticationWithoutLocalUser": true
           },
           "executor": {
             "name": "GoogleOIDCAuthExecutor",
@@ -2279,7 +2494,77 @@
               }
             ]
           },
-          "onSuccess": "auth_assert"
+          "onSuccess": "provisioning"
+        },
+        {
+          "id": "provisioning",
+          "type": "TASK_EXECUTION",
+          "executor": {
+            "name": "ProvisioningExecutor"
+          },
+          "onSuccess": "auth_assert",
+          "layout": {
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 1083,
+              "y": 397
+            }
+          },
+          "onIncomplete": "prompt_schema_attrs"
+        },
+        {
+          "id": "prompt_schema_attrs",
+          "type": "PROMPT",
+          "meta": {
+            "components": [
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "heading_schema_attrs",
+                "label": "{{ t(signin:forms.schema_attrs.title) }}",
+                "variant": "HEADING_1"
+              },
+              {
+                "type": "BLOCK",
+                "id": "block_dynamic_user_inputs",
+                "components": [
+                  {
+                    "type": "DYNAMIC_INPUT_PLACEHOLDER",
+                    "id": "dynamic_inputs"
+                  },
+                  {
+                    "type": "ACTION",
+                    "id": "action_schema_attrs",
+                    "label": "{{ t(signin:forms.schema_attrs.actions.continue.label) }}",
+                    "variant": "PRIMARY",
+                    "eventType": "SUBMIT"
+                  }
+                ]
+              }
+            ]
+          },
+          "prompts": [
+            {
+              "inputs": [],
+              "action": {
+                "ref": "action_schema_attrs",
+                "nextNode": "provisioning"
+              }
+            }
+          ],
+          "layout": {
+            "size": {
+              "width": 350,
+              "height": 400
+            },
+            "position": {
+              "x": 1083,
+              "y": -163
+            }
+          }
         },
         {
           "id": "auth_assert",
@@ -2290,7 +2575,7 @@
               "height": 113
             },
             "position": {
-              "x": 1175,
+              "x": 1655,
               "y": 397
             }
           },
@@ -2308,7 +2593,7 @@
               "height": 34
             },
             "position": {
-              "x": 1539,
+              "x": 2019,
               "y": 436
             }
           }
@@ -2526,7 +2811,8 @@
             }
           },
           "properties": {
-            "idpId": "{{IDP_ID}}"
+            "idpId": "{{IDP_ID}}",
+            "allowAuthenticationWithoutLocalUser": true
           },
           "executor": {
             "name": "GithubOAuthExecutor",
@@ -2539,7 +2825,77 @@
               }
             ]
           },
-          "onSuccess": "auth_assert"
+          "onSuccess": "provisioning"
+        },
+        {
+          "id": "provisioning",
+          "type": "TASK_EXECUTION",
+          "executor": {
+            "name": "ProvisioningExecutor"
+          },
+          "onSuccess": "auth_assert",
+          "layout": {
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 1083,
+              "y": 397
+            }
+          },
+          "onIncomplete": "prompt_schema_attrs"
+        },
+        {
+          "id": "prompt_schema_attrs",
+          "type": "PROMPT",
+          "meta": {
+            "components": [
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "heading_schema_attrs",
+                "label": "{{ t(signin:forms.schema_attrs.title) }}",
+                "variant": "HEADING_1"
+              },
+              {
+                "type": "BLOCK",
+                "id": "block_dynamic_user_inputs",
+                "components": [
+                  {
+                    "type": "DYNAMIC_INPUT_PLACEHOLDER",
+                    "id": "dynamic_inputs"
+                  },
+                  {
+                    "type": "ACTION",
+                    "id": "action_schema_attrs",
+                    "label": "{{ t(signin:forms.schema_attrs.actions.continue.label) }}",
+                    "variant": "PRIMARY",
+                    "eventType": "SUBMIT"
+                  }
+                ]
+              }
+            ]
+          },
+          "prompts": [
+            {
+              "inputs": [],
+              "action": {
+                "ref": "action_schema_attrs",
+                "nextNode": "provisioning"
+              }
+            }
+          ],
+          "layout": {
+            "size": {
+              "width": 350,
+              "height": 400
+            },
+            "position": {
+              "x": 1083,
+              "y": -163
+            }
+          }
         },
         {
           "id": "auth_assert",
@@ -2550,7 +2906,7 @@
               "height": 113
             },
             "position": {
-              "x": 1175,
+              "x": 1655,
               "y": 397
             }
           },
@@ -2568,7 +2924,7 @@
               "height": 34
             },
             "position": {
-              "x": 1539,
+              "x": 2019,
               "y": 436
             }
           }
@@ -2811,7 +3167,8 @@
             }
           },
           "properties": {
-            "idpId": "{{IDP_ID}}"
+            "idpId": "{{IDP_ID}}",
+            "allowAuthenticationWithoutLocalUser": true
           },
           "executor": {
             "name": "GoogleOIDCAuthExecutor",
@@ -2824,7 +3181,7 @@
               }
             ]
           },
-          "onSuccess": "auth_assert"
+          "onSuccess": "provisioning"
         },
         {
           "id": "github_auth",
@@ -2840,7 +3197,8 @@
             }
           },
           "properties": {
-            "idpId": "{{IDP_ID}}"
+            "idpId": "{{IDP_ID}}",
+            "allowAuthenticationWithoutLocalUser": true
           },
           "executor": {
             "name": "GithubOAuthExecutor",
@@ -2853,7 +3211,77 @@
               }
             ]
           },
-          "onSuccess": "auth_assert"
+          "onSuccess": "provisioning"
+        },
+        {
+          "id": "provisioning",
+          "type": "TASK_EXECUTION",
+          "executor": {
+            "name": "ProvisioningExecutor"
+          },
+          "onSuccess": "auth_assert",
+          "layout": {
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 1083,
+              "y": 485
+            }
+          },
+          "onIncomplete": "prompt_schema_attrs"
+        },
+        {
+          "id": "prompt_schema_attrs",
+          "type": "PROMPT",
+          "meta": {
+            "components": [
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "heading_schema_attrs",
+                "label": "{{ t(signin:forms.schema_attrs.title) }}",
+                "variant": "HEADING_1"
+              },
+              {
+                "type": "BLOCK",
+                "id": "block_dynamic_user_inputs",
+                "components": [
+                  {
+                    "type": "DYNAMIC_INPUT_PLACEHOLDER",
+                    "id": "dynamic_inputs"
+                  },
+                  {
+                    "type": "ACTION",
+                    "id": "action_schema_attrs",
+                    "label": "{{ t(signin:forms.schema_attrs.actions.continue.label) }}",
+                    "variant": "PRIMARY",
+                    "eventType": "SUBMIT"
+                  }
+                ]
+              }
+            ]
+          },
+          "prompts": [
+            {
+              "inputs": [],
+              "action": {
+                "ref": "action_schema_attrs",
+                "nextNode": "provisioning"
+              }
+            }
+          ],
+          "layout": {
+            "size": {
+              "width": 350,
+              "height": 400
+            },
+            "position": {
+              "x": 1083,
+              "y": -75
+            }
+          }
         },
         {
           "id": "auth_assert",
@@ -2864,7 +3292,7 @@
               "height": 113
             },
             "position": {
-              "x": 1180,
+              "x": 1660,
               "y": 485
             }
           },
@@ -2882,7 +3310,7 @@
               "height": 34
             },
             "position": {
-              "x": 1555,
+              "x": 2035,
               "y": 313
             }
           }
@@ -4056,7 +4484,8 @@
             }
           },
           "properties": {
-            "idpId": "{{IDP_ID}}"
+            "idpId": "{{IDP_ID}}",
+            "allowAuthenticationWithoutLocalUser": true
           },
           "executor": {
             "name": "GoogleOIDCAuthExecutor",
@@ -4069,7 +4498,7 @@
               }
             ]
           },
-          "onSuccess": "generate_otp"
+          "onSuccess": "provisioning"
         },
         {
           "id": "github_auth",
@@ -4085,7 +4514,8 @@
             }
           },
           "properties": {
-            "idpId": "{{IDP_ID}}"
+            "idpId": "{{IDP_ID}}",
+            "allowAuthenticationWithoutLocalUser": true
           },
           "executor": {
             "name": "GithubOAuthExecutor",
@@ -4098,7 +4528,77 @@
               }
             ]
           },
-          "onSuccess": "generate_otp"
+          "onSuccess": "provisioning"
+        },
+        {
+          "id": "provisioning",
+          "type": "TASK_EXECUTION",
+          "executor": {
+            "name": "ProvisioningExecutor"
+          },
+          "onSuccess": "generate_otp",
+          "layout": {
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 1004,
+              "y": 546
+            }
+          },
+          "onIncomplete": "prompt_schema_attrs"
+        },
+        {
+          "id": "prompt_schema_attrs",
+          "type": "PROMPT",
+          "meta": {
+            "components": [
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "heading_schema_attrs",
+                "label": "{{ t(signin:forms.schema_attrs.title) }}",
+                "variant": "HEADING_1"
+              },
+              {
+                "type": "BLOCK",
+                "id": "block_dynamic_user_inputs",
+                "components": [
+                  {
+                    "type": "DYNAMIC_INPUT_PLACEHOLDER",
+                    "id": "dynamic_inputs"
+                  },
+                  {
+                    "type": "ACTION",
+                    "id": "action_schema_attrs",
+                    "label": "{{ t(signin:forms.schema_attrs.actions.continue.label) }}",
+                    "variant": "PRIMARY",
+                    "eventType": "SUBMIT"
+                  }
+                ]
+              }
+            ]
+          },
+          "prompts": [
+            {
+              "inputs": [],
+              "action": {
+                "ref": "action_schema_attrs",
+                "nextNode": "provisioning"
+              }
+            }
+          ],
+          "layout": {
+            "size": {
+              "width": 350,
+              "height": 400
+            },
+            "position": {
+              "x": 1004,
+              "y": -14
+            }
+          }
         },
         {
           "id": "generate_otp",
@@ -4109,7 +4609,7 @@
               "height": 113
             },
             "position": {
-              "x": 1065,
+              "x": 1545,
               "y": 546
             }
           },
@@ -4136,7 +4636,7 @@
               "height": 113
             },
             "position": {
-              "x": 1395,
+              "x": 1875,
               "y": 546
             }
           },
@@ -4158,7 +4658,7 @@
               "height": 676
             },
             "position": {
-              "x": 1407,
+              "x": 1887,
               "y": 266
             }
           },
@@ -4248,7 +4748,7 @@
               "height": 113
             },
             "position": {
-              "x": 1857,
+              "x": 2337,
               "y": 541
             }
           },
@@ -4267,7 +4767,7 @@
               "height": 113
             },
             "position": {
-              "x": 2177,
+              "x": 2657,
               "y": 542
             }
           },
@@ -4285,7 +4785,7 @@
               "height": 34
             },
             "position": {
-              "x": 2526,
+              "x": 3006,
               "y": 579
             }
           }
@@ -13542,6 +14042,14 @@
             {
               "key": "AUTH_ASSERT_EXECUTOR_ID",
               "type": "ID"
+            },
+            {
+              "key": "PROVISIONING_EXECUTOR_STEP_ID",
+              "type": "ID"
+            },
+            {
+              "key": "PROVISIONING_PROMPT_STEP_ID",
+              "type": "ID"
             }
           ]
         },
@@ -13688,12 +14196,101 @@
                 "executor": {
                   "name": "GoogleOIDCAuthExecutor"
                 },
-                "onSuccess": "{{AUTH_ASSERT_EXECUTOR_ID}}",
+                "onSuccess": "{{PROVISIONING_EXECUTOR_STEP_ID}}",
                 "onIncomplete": ""
               },
               "properties": {
-                "idpId": "{{IDP_ID}}"
+                "idpId": "{{IDP_ID}}",
+                "allowAuthenticationWithoutLocalUser": true
               }
+            }
+          },
+          {
+            "id": "{{PROVISIONING_EXECUTOR_STEP_ID}}",
+            "type": "TASK_EXECUTION",
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 668,
+              "y": 550
+            },
+            "data": {
+              "action": {
+                "type": "EXECUTOR",
+                "executor": {
+                  "name": "ProvisioningExecutor"
+                },
+                "onSuccess": "{{AUTH_ASSERT_EXECUTOR_ID}}",
+                "onFailure": "",
+                "onIncomplete": "{{PROVISIONING_PROMPT_STEP_ID}}"
+              },
+              "properties": {
+                "allowCrossOUProvisioning": false,
+                "includeOptional": false,
+                "includeOptionalCredentials": false,
+                "maxPerPrompt": 5,
+                "assignGroup": "",
+                "assignRole": ""
+              }
+            }
+          },
+          {
+            "id": "{{PROVISIONING_PROMPT_STEP_ID}}",
+            "type": "VIEW",
+            "size": {
+              "width": 360,
+              "height": 220
+            },
+            "position": {
+              "x": 708,
+              "y": 250
+            },
+            "data": {
+              "components": [
+                {
+                  "id": "{{ID}}",
+                  "category": "DISPLAY",
+                  "type": "IMAGE",
+                  "src": "{{ meta(application.logoUrl) }}",
+                  "alt": "Application logo",
+                  "height": "60",
+                  "width": ""
+                },
+                {
+                  "id": "{{ID}}",
+                  "category": "DISPLAY",
+                  "type": "TEXT",
+                  "align": "center",
+                  "variant": "HEADING_1",
+                  "label": "Complete your details"
+                },
+                {
+                  "id": "{{ID}}",
+                  "category": "BLOCK",
+                  "type": "BLOCK",
+                  "components": [
+                    {
+                      "id": "{{ID}}",
+                      "category": "DISPLAY",
+                      "type": "DYNAMIC_INPUT_PLACEHOLDER"
+                    },
+                    {
+                      "id": "{{ID}}",
+                      "category": "ACTION",
+                      "type": "ACTION",
+                      "variant": "PRIMARY",
+                      "eventType": "SUBMIT",
+                      "label": "Continue",
+                      "action": {
+                        "type": "NEXT",
+                        "onSuccess": "{{PROVISIONING_EXECUTOR_STEP_ID}}"
+                      }
+                    }
+                  ]
+                }
+              ]
             }
           },
           {
@@ -13704,7 +14301,7 @@
               "height": 113
             },
             "position": {
-              "x": 770,
+              "x": 1148,
               "y": 424
             },
             "data": {
@@ -13726,7 +14323,7 @@
               "height": 34
             },
             "position": {
-              "x": 1122,
+              "x": 1500,
               "y": 462
             },
             "config": {},

--- a/frontend/apps/console/src/features/flows/data/widgets.json
+++ b/frontend/apps/console/src/features/flows/data/widgets.json
@@ -89,6 +89,12 @@
                 "stepRef": "AUTH_ASSERT_EXECUTOR_ID",
                 "matchBy": "executorName",
                 "match": "AuthAssertExecutor"
+              },
+              {
+                "stepRef": "PROVISIONING_EXECUTOR_STEP_ID",
+                "matchBy": "executorName",
+                "match": "ProvisioningExecutor",
+                "alsoDrop": ["PROVISIONING_PROMPT_STEP_ID"]
               }
             ]
           },
@@ -100,6 +106,14 @@
             },
             {
               "key": "AUTH_ASSERT_EXECUTOR_ID",
+              "type": "ID"
+            },
+            {
+              "key": "PROVISIONING_EXECUTOR_STEP_ID",
+              "type": "ID"
+            },
+            {
+              "key": "PROVISIONING_PROMPT_STEP_ID",
               "type": "ID"
             }
           ]
@@ -152,13 +166,102 @@
                 "executor": {
                   "name": "GoogleOIDCAuthExecutor"
                 },
-                "onSuccess": "{{AUTH_ASSERT_EXECUTOR_ID}}",
+                "onSuccess": "{{PROVISIONING_EXECUTOR_STEP_ID}}",
                 "onFailure": "",
                 "onIncomplete": ""
               },
               "properties": {
-                "idpId": "{{IDP_ID}}"
+                "idpId": "{{IDP_ID}}",
+                "allowAuthenticationWithoutLocalUser": true
               }
+            }
+          },
+          {
+            "id": "{{PROVISIONING_EXECUTOR_STEP_ID}}",
+            "type": "TASK_EXECUTION",
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 1070,
+              "y": 350
+            },
+            "data": {
+              "action": {
+                "type": "EXECUTOR",
+                "executor": {
+                  "name": "ProvisioningExecutor"
+                },
+                "onSuccess": "{{AUTH_ASSERT_EXECUTOR_ID}}",
+                "onFailure": "",
+                "onIncomplete": "{{PROVISIONING_PROMPT_STEP_ID}}"
+              },
+              "properties": {
+                "allowCrossOUProvisioning": false,
+                "includeOptional": false,
+                "includeOptionalCredentials": false,
+                "maxPerPrompt": 5,
+                "assignGroup": "",
+                "assignRole": ""
+              }
+            }
+          },
+          {
+            "id": "{{PROVISIONING_PROMPT_STEP_ID}}",
+            "type": "VIEW",
+            "size": {
+              "width": 360,
+              "height": 220
+            },
+            "position": {
+              "x": 1110,
+              "y": 50
+            },
+            "data": {
+              "components": [
+                {
+                  "id": "{{ID}}",
+                  "category": "DISPLAY",
+                  "type": "IMAGE",
+                  "src": "{{ meta(application.logoUrl) }}",
+                  "alt": "Application logo",
+                  "height": "60",
+                  "width": ""
+                },
+                {
+                  "id": "{{ID}}",
+                  "category": "DISPLAY",
+                  "type": "TEXT",
+                  "align": "center",
+                  "variant": "HEADING_1",
+                  "label": "Complete your details"
+                },
+                {
+                  "id": "{{ID}}",
+                  "category": "BLOCK",
+                  "type": "BLOCK",
+                  "components": [
+                    {
+                      "id": "{{ID}}",
+                      "category": "DISPLAY",
+                      "type": "DYNAMIC_INPUT_PLACEHOLDER"
+                    },
+                    {
+                      "id": "{{ID}}",
+                      "category": "ACTION",
+                      "type": "ACTION",
+                      "variant": "PRIMARY",
+                      "eventType": "SUBMIT",
+                      "label": "Continue",
+                      "action": {
+                        "type": "NEXT",
+                        "onSuccess": "{{PROVISIONING_EXECUTOR_STEP_ID}}"
+                      }
+                    }
+                  ]
+                }
+              ]
             }
           },
           {
@@ -169,7 +272,7 @@
               "height": 113
             },
             "position": {
-              "x": 1234,
+              "x": 1550,
               "y": 230
             },
             "data": {
@@ -206,6 +309,12 @@
                 "stepRef": "AUTH_ASSERT_EXECUTOR_ID",
                 "matchBy": "executorName",
                 "match": "AuthAssertExecutor"
+              },
+              {
+                "stepRef": "PROVISIONING_EXECUTOR_STEP_ID",
+                "matchBy": "executorName",
+                "match": "ProvisioningExecutor",
+                "alsoDrop": ["PROVISIONING_PROMPT_STEP_ID"]
               }
             ]
           },
@@ -217,6 +326,14 @@
             },
             {
               "key": "AUTH_ASSERT_EXECUTOR_ID",
+              "type": "ID"
+            },
+            {
+              "key": "PROVISIONING_EXECUTOR_STEP_ID",
+              "type": "ID"
+            },
+            {
+              "key": "PROVISIONING_PROMPT_STEP_ID",
               "type": "ID"
             }
           ]
@@ -269,13 +386,102 @@
                 "executor": {
                   "name": "GithubOAuthExecutor"
                 },
-                "onSuccess": "{{AUTH_ASSERT_EXECUTOR_ID}}",
+                "onSuccess": "{{PROVISIONING_EXECUTOR_STEP_ID}}",
                 "onFailure": "",
                 "onIncomplete": ""
               },
               "properties": {
-                "idpId": "{{IDP_ID}}"
+                "idpId": "{{IDP_ID}}",
+                "allowAuthenticationWithoutLocalUser": true
               }
+            }
+          },
+          {
+            "id": "{{PROVISIONING_EXECUTOR_STEP_ID}}",
+            "type": "TASK_EXECUTION",
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 1070,
+              "y": 350
+            },
+            "data": {
+              "action": {
+                "type": "EXECUTOR",
+                "executor": {
+                  "name": "ProvisioningExecutor"
+                },
+                "onSuccess": "{{AUTH_ASSERT_EXECUTOR_ID}}",
+                "onFailure": "",
+                "onIncomplete": "{{PROVISIONING_PROMPT_STEP_ID}}"
+              },
+              "properties": {
+                "allowCrossOUProvisioning": false,
+                "includeOptional": false,
+                "includeOptionalCredentials": false,
+                "maxPerPrompt": 5,
+                "assignGroup": "",
+                "assignRole": ""
+              }
+            }
+          },
+          {
+            "id": "{{PROVISIONING_PROMPT_STEP_ID}}",
+            "type": "VIEW",
+            "size": {
+              "width": 360,
+              "height": 220
+            },
+            "position": {
+              "x": 1110,
+              "y": 50
+            },
+            "data": {
+              "components": [
+                {
+                  "id": "{{ID}}",
+                  "category": "DISPLAY",
+                  "type": "IMAGE",
+                  "src": "{{ meta(application.logoUrl) }}",
+                  "alt": "Application logo",
+                  "height": "60",
+                  "width": ""
+                },
+                {
+                  "id": "{{ID}}",
+                  "category": "DISPLAY",
+                  "type": "TEXT",
+                  "align": "center",
+                  "variant": "HEADING_1",
+                  "label": "Complete your details"
+                },
+                {
+                  "id": "{{ID}}",
+                  "category": "BLOCK",
+                  "type": "BLOCK",
+                  "components": [
+                    {
+                      "id": "{{ID}}",
+                      "category": "DISPLAY",
+                      "type": "DYNAMIC_INPUT_PLACEHOLDER"
+                    },
+                    {
+                      "id": "{{ID}}",
+                      "category": "ACTION",
+                      "type": "ACTION",
+                      "variant": "PRIMARY",
+                      "eventType": "SUBMIT",
+                      "label": "Continue",
+                      "action": {
+                        "type": "NEXT",
+                        "onSuccess": "{{PROVISIONING_EXECUTOR_STEP_ID}}"
+                      }
+                    }
+                  ]
+                }
+              ]
             }
           },
           {
@@ -286,7 +492,7 @@
               "height": 113
             },
             "position": {
-              "x": 1234,
+              "x": 1550,
               "y": 230
             },
             "data": {

--- a/frontend/apps/console/src/features/flows/utils/__tests__/autoWireWidget.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/autoWireWidget.test.ts
@@ -216,6 +216,72 @@ describe('autoWireWidget', () => {
       expect(onSuccessOf(nodes, 'google')).toBe('auth_assert');
     });
 
+    // Dropping a second federated widget must converge on the provisioning node the first one
+    // brought, not add a parallel one. The bundled prompt is dropped with it via alsoDrop, since a
+    // VIEW node cannot be matched by executor name and would otherwise survive as an orphan.
+    it('reuses an existing provisioning node and drops its bundled prompt', () => {
+      const autoWire: AutoWireMeta = {
+        reuse: [
+          {stepRef: 'AUTH_ASSERT_EXECUTOR_ID', matchBy: 'executorName', match: 'AuthAssertExecutor'},
+          {
+            stepRef: 'PROVISIONING_EXECUTOR_STEP_ID',
+            matchBy: 'executorName',
+            match: 'ProvisioningExecutor',
+            alsoDrop: ['PROVISIONING_PROMPT_STEP_ID'],
+          },
+        ],
+      };
+      const resolvedRefs = new Map([
+        ['AUTH_ASSERT_EXECUTOR_ID', 'bundled_auth'],
+        ['PROVISIONING_EXECUTOR_STEP_ID', 'bundled_prov'],
+        ['PROVISIONING_PROMPT_STEP_ID', 'bundled_prompt'],
+      ]);
+
+      // The canvas already holds a Google widget: google -> provisioning -> auth_assert -> end.
+      const preExisting: Node[] = [
+        executorNode('google', 'GoogleOIDCAuthExecutor', 'provisioning'),
+        executorNode('provisioning', 'ProvisioningExecutor', 'auth_assert'),
+        viewNode('prov_prompt'),
+        executorNode('auth_assert', 'AuthAssertExecutor', 'END'),
+        endNode('end'),
+      ];
+      // A GitHub widget is dropped, bringing its own provisioning, prompt and assertion.
+      const cluster: Node[] = [
+        executorNode('github', 'GithubOAuthExecutor', 'bundled_prov'),
+        executorNode('bundled_prov', 'ProvisioningExecutor', 'bundled_auth'),
+        viewNode('bundled_prompt'),
+        executorNode('bundled_auth', 'AuthAssertExecutor', 'END'),
+      ];
+      const resultNodes: Node[] = [...preExisting, ...cluster];
+      const resultEdges: Edge[] = [
+        edge('google', 'provisioning'),
+        edge('provisioning', 'auth_assert'),
+        edge('auth_assert', 'end'),
+        edge('github', 'bundled_prov'),
+        edge('bundled_prov', 'bundled_auth'),
+        edge('bundled_prompt', 'bundled_prov'),
+      ];
+
+      const {nodes, edges} = autoWireWidget(preExisting, resultNodes, resultEdges, autoWire, resolvedRefs, EDGE_STYLE);
+
+      const provisioningNodes = nodes.filter(
+        (n: Node) =>
+          (n as {data?: {action?: {executor?: {name?: string}}}}).data?.action?.executor?.name ===
+          'ProvisioningExecutor',
+      );
+
+      expect(provisioningNodes).toHaveLength(1);
+      expect(provisioningNodes[0].id).toBe('provisioning');
+      expect(nodes.some((n: Node) => n.id === 'bundled_prompt')).toBe(false);
+      expect(nodes.some((n: Node) => n.id === 'bundled_prov')).toBe(false);
+      // GitHub converges on the pre-existing provisioning node, by edge and by action.onSuccess.
+      expect(has(edges, 'github', 'provisioning')).toBe(true);
+      expect(onSuccessOf(nodes, 'github')).toBe('provisioning');
+      // The reused provisioning keeps its own prompt and onward wiring.
+      expect(nodes.some((n: Node) => n.id === 'prov_prompt')).toBe(true);
+      expect(has(edges, 'provisioning', 'auth_assert')).toBe(true);
+    });
+
     it('keeps the bundled AuthAssert on a blank canvas and wires it to the END node by type', () => {
       const preExisting: Node[] = [viewNode('v'), endNode('end')];
       const cluster: Node[] = [

--- a/frontend/apps/console/src/features/flows/utils/autoWireWidget.ts
+++ b/frontend/apps/console/src/features/flows/utils/autoWireWidget.ts
@@ -52,6 +52,11 @@ export interface AutoWireMeta {
     stepRef: string;
     matchBy: 'executorName';
     match: string;
+    /**
+     * Companion steps to remove when the primary step is replaced by an existing node. This is used
+     * for steps such as a prompt view associated with an executor.
+     */
+    alsoDrop?: string[];
   }[];
 }
 
@@ -148,10 +153,13 @@ const autoWireWidget = (
     const existing: Node | undefined = preExistingNodes.find((node: Node) => executorName(node) === rule.match);
 
     if (dupNode && existing) {
+      const companionIds: string[] = (rule.alsoDrop ?? []).map(resolve);
+      const discardedIds = new Set<string>([dupId, ...companionIds]);
+
       edges = edges
-        .filter((edge: Edge) => edge.source !== dupId)
+        .filter((edge: Edge) => !discardedIds.has(edge.source))
         .map((edge: Edge) => (edge.target === dupId ? {...edge, id: `${edge.id}__reuse`, target: existing.id} : edge));
-      nodesToDrop.add(dupId);
+      discardedIds.forEach((id: string) => nodesToDrop.add(id));
       remapTarget.set(dupId, existing.id);
     }
   });


### PR DESCRIPTION
### Purpose

  Fixes the default Google, GitHub, and OIDC sign-in experience so users can authenticate and be provisioned without requiring administrators to manually configure account
  linking, attribute mappings, scopes, and provisioning behavior.

  This PR:

  - Enables self-registration for the default Person user type.
  - Applies provider-specific scope and account-linking defaults.
  - Adds schema-aware username mappings where required for provisioning.
  - Enables authentication without an existing local user for Google, GitHub, and OIDC executors.
  - Adds provisioning to the corresponding flow-builder widgets and default flow templates.
  - Reuses an existing provisioning executor when applicable.

  ### Approach

  The implementation applies defaults in the backend so connections created through the Console, REST APIs, and declarative resources behave consistently.

  Key changes include:

  - Default GitHub connections to the user:email scope when scopes are not provided.
  - Default account linking to a unique email attribute when the effective provider scopes support email.
  - Inspect eligible user-type schemas and create provider-specific username mappings when username is required.
  - Preserve explicitly configured scopes, account-linking attributes, and attribute mappings.
  - Enable allowAuthenticationWithoutLocalUser by default for Google, GitHub, and OIDC flow executors.
  - Bundle a provisioning executor and missing-attribute prompt with Google and GitHub flow-builder widgets.
  - Update affected flow templates so federated authentication paths reach provisioning before assertion generation.
  - Reuse an existing provisioning executor and remove the redundant bundled provisioning prompt when multiple federated widgets converge on the same provisioning path.
  - Preserve generic OAuth behavior because ThunderID cannot infer arbitrary OAuth provider scope and claim semantics.

  ### Related Issues

  - Fixes #4101 (https://github.com/thunder-id/thunderid/issues/4101)

  ### Related PRs

  - N/A

  ### Checklist
  - [x] Followed the contribution guidelines.
  - [x] Manual test round performed and verified.
  - [ ] Documentation provided. (Add links if there are any)
      - [ ] Ran Vale and fixed all errors and warnings
  - [x] Tests provided.
      - [x] Unit Tests
      - [ ] Integration Tests
  - [x] Breaking changes not applicable.
      - [ ] Breaking changes section filled.
      - [ ] breaking change label added.

  ### Security checks
  - [x] Followed secure coding standards in WSO2 Secure Coding Guidelines
    (https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
  - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled self-registration for default users.
  * Added automatic identity-provider defaults for email linking, usernames, and provider scopes.
  * Improved Google and GitHub login flows with local-user provisioning and prompts for missing profile information.
  * Preserved original authentication claims alongside mapped local attributes.
  * Added English prompts for required schema attributes.
* **Bug Fixes**
  * Improved social-login flow wiring and duplicate provisioning-step handling.
  * Added default GitHub email scopes when none are configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->