### PR TITLE
Wire rich text links nested inside flow blocks

### DIFF
--- a/frontend/packages/design/src/components/flow/adapters/BlockAdapter.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/BlockAdapter.tsx
@@ -215,7 +215,15 @@ function renderFormSubComponent(
   }
 
   if (sub.type === 'RICH_TEXT') {
-    return <RichTextAdapter key={sub.id ?? compIndex} component={sub} resolve={ctx.resolve} />;
+    return (
+      <RichTextAdapter
+        key={sub.id ?? compIndex}
+        component={sub}
+        resolve={ctx.resolve}
+        values={ctx.values}
+        onSubmit={ctx.onSubmit}
+      />
+    );
   }
 
   if (
@@ -356,6 +364,17 @@ function TriggerBlockAdapter({component, index, ...ctx}: TriggerBlockAdapterProp
               resolve={ctx.resolve}
               onSubmit={ctx.onSubmit}
               values={ctx.values}
+            />
+          );
+        }
+        if (sub.type === 'RICH_TEXT') {
+          return (
+            <RichTextAdapter
+              key={sub.id ?? actionIndex}
+              component={sub}
+              resolve={ctx.resolve}
+              values={ctx.values}
+              onSubmit={ctx.onSubmit}
             />
           );
         }

--- a/frontend/packages/design/src/components/flow/adapters/__tests__/BlockAdapter.test.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/__tests__/BlockAdapter.test.tsx
@@ -1,0 +1,167 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import {screen, cleanup, fireEvent} from '@testing-library/react';
+import type {EmbeddedFlowComponent} from '@thunderid/react';
+import {describe, it, expect, afterEach, vi} from 'vitest';
+import renderWithProviders from '../../../../test/renderWithProviders';
+import BlockAdapter from '../BlockAdapter';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const noop = () => undefined;
+
+const RECOVERY_LABEL =
+  '<p data-component-ref="recovery-link"><a href="#" data-action-ref="action_forgot_password">Forgot password?</a></p>';
+
+/** Resolves the recovery meta switch; every other template passes through. */
+const resolveWithRecovery = (enabled: boolean) => (template: string | undefined) =>
+  template?.includes('isRecoveryFlowEnabled') ? String(enabled) : template;
+
+const recoveryRichText = {
+  id: 'rich_text_forgot_password',
+  type: 'RICH_TEXT',
+  label: RECOVERY_LABEL,
+  action: {ref: 'action_forgot_password'},
+};
+
+const usernameInput = {id: 'input_001', type: 'TEXT_INPUT', identifier: 'username', label: 'Username'};
+const passwordInput = {id: 'input_002', type: 'PASSWORD_INPUT', identifier: 'password', label: 'Password'};
+const submitAction = {id: 'action_001', type: 'ACTION', eventType: 'SUBMIT', variant: 'PRIMARY', label: 'Sign in'};
+const socialTrigger = {id: 'action_google', type: 'ACTION', eventType: 'TRIGGER', label: 'Continue with Google'};
+
+const BLOCK_VALUES = {username: 'alice', password: 's3cret'};
+
+const renderBlock = (
+  component: unknown,
+  {
+    onSubmit = noop,
+    recoveryEnabled = true,
+    values = BLOCK_VALUES,
+  }: {onSubmit?: (...args: unknown[]) => void; recoveryEnabled?: boolean; values?: Record<string, string>} = {},
+) =>
+  renderWithProviders(
+    <BlockAdapter
+      component={component as EmbeddedFlowComponent}
+      index={0}
+      values={values}
+      isLoading={false}
+      resolve={resolveWithRecovery(recoveryEnabled)}
+      onInputChange={noop}
+      onSubmit={onSubmit}
+    />,
+  );
+
+describe('BlockAdapter: RICH_TEXT inside a form block', () => {
+  const formBlock = {
+    id: 'block_001',
+    type: 'BLOCK',
+    components: [usernameInput, passwordInput, recoveryRichText, submitAction],
+  };
+
+  it('dispatches the wired action when the nested recovery link is clicked', () => {
+    const onSubmit = vi.fn();
+    renderBlock(formBlock, {onSubmit});
+
+    fireEvent.click(screen.getByRole('link', {name: 'Forgot password?'}));
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({id: 'action_forgot_password'}), BLOCK_VALUES);
+  });
+
+  it('carries the block values into the dispatched action', () => {
+    const onSubmit = vi.fn();
+    renderBlock(formBlock, {onSubmit, values: {username: 'bob'}});
+
+    fireEvent.click(screen.getByRole('link', {name: 'Forgot password?'}));
+
+    expect(onSubmit.mock.calls[0][1]).toEqual({username: 'bob'});
+  });
+
+  it('does not render the recovery link when the recovery flow is disabled', () => {
+    renderBlock(formBlock, {recoveryEnabled: false});
+
+    expect(screen.queryByRole('link', {name: 'Forgot password?'})).toBeNull();
+    expect(screen.getByRole('button', {name: 'Sign in'})).toBeTruthy();
+  });
+
+  it('still dispatches the primary submit action', () => {
+    const onSubmit = vi.fn();
+    renderBlock(formBlock, {onSubmit});
+
+    fireEvent.click(screen.getByRole('button', {name: 'Sign in'}));
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({id: 'action_001'}), BLOCK_VALUES);
+  });
+
+  it('renders a rich text without a wired action as plain content', () => {
+    const onSubmit = vi.fn();
+    renderBlock({
+      id: 'block_plain',
+      type: 'BLOCK',
+      components: [{id: 'rich_plain', type: 'RICH_TEXT', label: '<p>Sign in to continue</p>'}, submitAction],
+    });
+
+    expect(screen.getByText('Sign in to continue')).toBeTruthy();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('dispatches a recovery link nested inside a stack', () => {
+    const onSubmit = vi.fn();
+    renderBlock(
+      {
+        id: 'block_stacked',
+        type: 'BLOCK',
+        components: [usernameInput, {id: 'stack_links', type: 'STACK', components: [recoveryRichText]}, submitAction],
+      },
+      {onSubmit},
+    );
+
+    fireEvent.click(screen.getByRole('link', {name: 'Forgot password?'}));
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({id: 'action_forgot_password'}), BLOCK_VALUES);
+  });
+});
+
+describe('BlockAdapter: RICH_TEXT inside a trigger-only block', () => {
+  const triggerBlock = {
+    id: 'block_social',
+    type: 'BLOCK',
+    components: [socialTrigger, recoveryRichText],
+  };
+
+  it('renders and dispatches the recovery link', () => {
+    const onSubmit = vi.fn();
+    renderBlock(triggerBlock, {onSubmit});
+
+    fireEvent.click(screen.getByRole('link', {name: 'Forgot password?'}));
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({id: 'action_forgot_password'}), BLOCK_VALUES);
+  });
+
+  it('does not render the recovery link when the recovery flow is disabled', () => {
+    renderBlock(triggerBlock, {recoveryEnabled: false});
+
+    expect(screen.queryByRole('link', {name: 'Forgot password?'})).toBeNull();
+    expect(screen.getByRole('button', {name: 'Continue with Google'})).toBeTruthy();
+  });
+
+  it('dispatches a recovery link nested inside a stack', () => {
+    const onSubmit = vi.fn();
+    renderBlock(
+      {
+        id: 'block_social_stacked',
+        type: 'BLOCK',
+        components: [socialTrigger, {id: 'stack_links', type: 'STACK', components: [recoveryRichText]}],
+      },
+      {onSubmit},
+    );
+
+    fireEvent.click(screen.getByRole('link', {name: 'Forgot password?'}));
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({id: 'action_forgot_password'}), BLOCK_VALUES);
+  });
+});

--- a/frontend/packages/design/src/components/flow/adapters/__tests__/RichTextAdapter.test.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/__tests__/RichTextAdapter.test.tsx
@@ -6,7 +6,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 
-import {cleanup} from '@testing-library/react';
+import {cleanup, fireEvent} from '@testing-library/react';
 import {describe, it, expect, vi, afterEach} from 'vitest';
 import type {FlowComponent} from '../../../../models/flow';
 import renderWithProviders from '../../../../test/renderWithProviders';
@@ -18,10 +18,13 @@ afterEach(() => {
 
 vi.mock('@wso2/oxygen-ui', () => ({
   Alert: ({children}: any) => children,
-  Box: ({sx, dangerouslySetInnerHTML}: any) => (
+  Box: ({id, sx, onClick, dangerouslySetInnerHTML}: any) => (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
     <div
       data-testid="rich-text-box"
+      id={id}
       data-align={sx?.textAlign}
+      onClick={onClick}
       // eslint-disable-next-line react/no-danger
       dangerouslySetInnerHTML={dangerouslySetInnerHTML}
     />
@@ -148,6 +151,60 @@ describe('RichTextAdapter', () => {
       const box = getByTestId('rich-text-box');
       expect(box).toBeInTheDocument();
       expect(box.innerHTML).toContain('Sign up');
+    });
+  });
+
+  describe('recovery URL handling', () => {
+    const recoveryLabel =
+      '<p data-component-ref="recovery-link"><a href="#" data-action-ref="action_forgot_password">Forgot password?</a></p>';
+    const recoveryComponent: FlowComponent = {
+      id: 'recovery-richtext',
+      type: 'RICH_TEXT',
+      label: recoveryLabel,
+      action: {ref: 'action_forgot_password'},
+    };
+    const resolveRecovery = (enabled: boolean) => (template: string | undefined) =>
+      template?.includes('isRecoveryFlowEnabled') ? String(enabled) : template;
+
+    it('returns null when the recovery flow is disabled', () => {
+      const {queryByTestId} = renderWithProviders(
+        <RichTextAdapter component={recoveryComponent} resolve={resolveRecovery(false)} />,
+      );
+      expect(queryByTestId('rich-text-box')).not.toBeInTheDocument();
+    });
+
+    it('renders the recovery link when the recovery flow is enabled', () => {
+      const {getByTestId} = renderWithProviders(
+        <RichTextAdapter component={recoveryComponent} resolve={resolveRecovery(true)} />,
+      );
+      expect(getByTestId('rich-text-box').innerHTML).toContain('Forgot password?');
+    });
+
+    it('dispatches the synthesized action with the supplied values on click', () => {
+      const onSubmit = vi.fn();
+      const {getByTestId} = renderWithProviders(
+        <RichTextAdapter
+          component={recoveryComponent}
+          resolve={resolveRecovery(true)}
+          values={{username: 'alice'}}
+          onSubmit={onSubmit}
+        />,
+      );
+
+      fireEvent.click(getByTestId('rich-text-box').querySelector('a')!);
+
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({id: 'action_forgot_password', ref: 'action_forgot_password'}),
+        {username: 'alice'},
+      );
+    });
+
+    it('does not throw when clicked without an onSubmit handler', () => {
+      const {getByTestId} = renderWithProviders(
+        <RichTextAdapter component={recoveryComponent} resolve={resolveRecovery(true)} />,
+      );
+
+      expect(() => fireEvent.click(getByTestId('rich-text-box').querySelector('a')!)).not.toThrow();
     });
   });
 


### PR DESCRIPTION
### Purpose
A rich text link nested inside a flow block did nothing when clicked. In a form block the component was rendered without `values` and `onSubmit`, so the adapter prevented the anchor's default navigation and then bailed out before dispatching. In a trigger block there was no `RICH_TEXT` branch at all, so the link never rendered.

### Approach
Pass the block context's `values` and `onSubmit` through to `RichTextAdapter` in `renderFormSubComponent`, matching the sibling submit/trigger button wiring and the top-level `FlowComponentRenderer` path, and add the missing `RICH_TEXT` branch to the trigger block. Stack nesting is covered for free, since both switches recurse with the same context.

### Related Issues
- Fixes #4529

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rich-text content now works within form and trigger flows.
  * Rich-text actions can submit form values and support recovery-link interactions.
  * Link visibility and click behavior now adapt to the flow configuration.

* **Bug Fixes**
  * Improved handling of rich-text actions when submission callbacks are unavailable.
  * Ensured nested rich-text components render and behave consistently across flow layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->