### PR TITLE
Include ID-token-only scope claims in issued ID tokens for code and CIBA flows

### DIFF
--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -386,7 +386,7 @@ func (as *authorizeService) initiateFlowAndStoreRequest(
 
 	effectiveAcrValues := requestvalidator.ResolveACRValues(oauthParams.AcrValues, app.AcrValues)
 	essentialAttributes, optionalAttributes := getRequiredAttributes(
-		oauthParams.StandardScopes, oauthParams.ClaimsRequest, oauthParams.ResponseType, app)
+		oauthParams.StandardScopes, oauthParams.ClaimsRequest, app)
 
 	authRequestCtx := authRequestContext{
 		OAuthParameters: *oauthParams,
@@ -805,8 +805,8 @@ func createAuthorizationCode(
 }
 
 // getRequiredAttributes determines the essential and optional user attributes required based on OIDC scopes,
-// claims parameter, response type, and app configuration.
-func getRequiredAttributes(oidcScopes []string, claimsRequest *oauth2model.ClaimsRequest, responseType string,
+// claims parameter, and app configuration.
+func getRequiredAttributes(oidcScopes []string, claimsRequest *oauth2model.ClaimsRequest,
 	app *providers.OAuthClient) (essentialAttributes, optionalAttributes string) {
 	if app == nil {
 		return "", ""
@@ -822,7 +822,7 @@ func getRequiredAttributes(oidcScopes []string, claimsRequest *oauth2model.Claim
 
 	// Process OIDC-related attributes only if openid scope is present
 	if slices.Contains(oidcScopes, oauth2const.ScopeOpenID) {
-		appendOIDCAttributes(oidcScopes, claimsRequest, responseType, app,
+		appendOIDCAttributes(oidcScopes, claimsRequest, app,
 			essentialAttributesMap, optionalAttributesMap)
 	}
 
@@ -853,7 +853,7 @@ func appendAccessTokenAttributes(app *providers.OAuthClient, attributesMap map[s
 }
 
 // appendOIDCAttributes appends OIDC-related attributes from scopes and claims parameters.
-func appendOIDCAttributes(oidcScopes []string, claimsRequest *oauth2model.ClaimsRequest, responseType string,
+func appendOIDCAttributes(oidcScopes []string, claimsRequest *oauth2model.ClaimsRequest,
 	app *providers.OAuthClient, essentialAttributes, optionalAttributes map[string]bool) {
 	var idTokenAllowedSet map[string]bool
 	if app.Token != nil {
@@ -864,7 +864,7 @@ func appendOIDCAttributes(oidcScopes []string, claimsRequest *oauth2model.Claims
 	appendAttributesFromClaimsParameter(claimsRequest, idTokenAllowedSet, userInfoAllowedSet,
 		essentialAttributes, optionalAttributes)
 
-	appendAttributesFromScopes(oidcScopes, responseType, app, idTokenAllowedSet, userInfoAllowedSet,
+	appendAttributesFromScopes(oidcScopes, app, idTokenAllowedSet, userInfoAllowedSet,
 		optionalAttributes)
 }
 
@@ -927,11 +927,11 @@ func appendAttributesFromClaimsParameter(claimsRequest *oauth2model.ClaimsReques
 }
 
 // appendAttributesFromScopes appends user attributes based on OIDC scopes and app configuration.
-func appendAttributesFromScopes(oidcScopes []string, responseType string, app *providers.OAuthClient,
+func appendAttributesFromScopes(oidcScopes []string, app *providers.OAuthClient,
 	idTokenAllowedSet, userInfoAllowedSet map[string]bool, optionalAttributes map[string]bool) {
 	for _, scope := range oidcScopes {
 		scopeAttributes := resolveScopeAttributes(scope, app.ScopeClaims)
-		appendAttributesForScope(scopeAttributes, responseType,
+		appendAttributesForScope(scopeAttributes,
 			idTokenAllowedSet, userInfoAllowedSet, optionalAttributes)
 	}
 }
@@ -953,23 +953,20 @@ func resolveScopeAttributes(scope string, scopeAttributesMapping map[string][]st
 	return nil
 }
 
-// appendAttributesForScope appends attributes for a particular scope based on response type and
-// allowed attributes in app config.
+// appendAttributesForScope appends attributes for a particular scope, allow-listed for either the
+// ID token or the UserInfo endpoint.
 // When using scopes, all attributes are treated as optional since there is no way to determine
 // which attributes are essential vs optional.
-func appendAttributesForScope(scopeAttributes []string, responseType string,
+func appendAttributesForScope(scopeAttributes []string,
 	idTokenAllowedSet, userInfoAllowedSet, optionalAttributes map[string]bool) {
 	for _, attribute := range scopeAttributes {
-		if responseType == string(providers.ResponseTypeIDToken) {
-			// If response type does not issue an access token, add claim to id token
-			if idTokenAllowedSet != nil && idTokenAllowedSet[attribute] {
-				optionalAttributes[attribute] = true
-			}
-		} else {
-			// If response type issues an access token, add claim to userinfo
-			if userInfoAllowedSet != nil && userInfoAllowedSet[attribute] {
-				optionalAttributes[attribute] = true
-			}
+		// A scope claim may be surfaced from the UserInfo endpoint or, when allow-listed for the ID
+		// token, embedded in the ID token, so cache the attributes needed by either sink.
+		if idTokenAllowedSet != nil && idTokenAllowedSet[attribute] {
+			optionalAttributes[attribute] = true
+		}
+		if userInfoAllowedSet != nil && userInfoAllowedSet[attribute] {
+			optionalAttributes[attribute] = true
 		}
 	}
 }

--- a/backend/internal/oauth/oauth2/authz/service_test.go
+++ b/backend/internal/oauth/oauth2/authz/service_test.go
@@ -1463,7 +1463,6 @@ func (suite *AuthorizeServiceTestSuite) TestGetRequiredAttributes_NilApp() {
 	essential, optional := getRequiredAttributes(
 		[]string{"openid", "profile"},
 		nil,
-		string(providers.ResponseTypeCode),
 		nil,
 	)
 
@@ -1481,7 +1480,6 @@ func (suite *AuthorizeServiceTestSuite) TestGetRequiredAttributes_NilTokenConfig
 	essential, optional := getRequiredAttributes(
 		[]string{"openid", "profile"},
 		nil,
-		string(providers.ResponseTypeCode),
 		app,
 	)
 
@@ -1503,7 +1501,6 @@ func (suite *AuthorizeServiceTestSuite) TestGetRequiredAttributes_AccessTokenOnl
 	essential, optional := getRequiredAttributes(
 		[]string{},
 		nil,
-		string(providers.ResponseTypeCode),
 		app,
 	)
 
@@ -1536,7 +1533,6 @@ func (suite *AuthorizeServiceTestSuite) TestGetRequiredAttributes_CodeFlowWithSc
 	essential, optional := getRequiredAttributes(
 		[]string{"openid", "email"},
 		nil,
-		string(providers.ResponseTypeCode),
 		app,
 	)
 
@@ -1551,13 +1547,15 @@ func (suite *AuthorizeServiceTestSuite) TestGetRequiredAttributes_CodeFlowWithSc
 	assert.Len(suite.T(), parts, 3)
 }
 
-func (suite *AuthorizeServiceTestSuite) TestGetRequiredAttributes_ImplicitFlowWithScopes() {
+func (suite *AuthorizeServiceTestSuite) TestGetRequiredAttributes_CodeFlowIDTokenOnlyScopeAttribute() {
+	// Regression: in the code flow, a scope attribute allow-listed only for the ID token (and not for
+	// UserInfo) must still be resolved and cached so it can be surfaced in the ID token.
 	app := &providers.OAuthClient{
 		ID:       "test-app",
 		ClientID: "test-client",
 		Token: &providers.OAuthTokenConfig{
 			IDToken: &providers.IDTokenConfig{
-				UserAttributes: []string{"email", "email_verified", "name"},
+				UserAttributes: []string{"email", "email_verified"},
 			},
 		},
 	}
@@ -1565,13 +1563,10 @@ func (suite *AuthorizeServiceTestSuite) TestGetRequiredAttributes_ImplicitFlowWi
 	essential, optional := getRequiredAttributes(
 		[]string{"openid", "email"},
 		nil,
-		string(providers.ResponseTypeIDToken),
 		app,
 	)
 
 	assert.Empty(suite.T(), essential)
-	// In implicit flow, email scope claims go to id_token
-	assert.NotEmpty(suite.T(), optional)
 	assert.Contains(suite.T(), optional, "email")
 	assert.Contains(suite.T(), optional, "email_verified")
 
@@ -1608,7 +1603,6 @@ func (suite *AuthorizeServiceTestSuite) TestGetRequiredAttributes_WithClaimsPara
 	essential, optional := getRequiredAttributes(
 		[]string{"openid"},
 		claimsRequest,
-		string(providers.ResponseTypeCode),
 		app,
 	)
 
@@ -1653,7 +1647,6 @@ func (suite *AuthorizeServiceTestSuite) TestGetRequiredAttributes_ClaimsParamete
 	essential, optional := getRequiredAttributes(
 		[]string{"openid"},
 		claimsRequest,
-		string(providers.ResponseTypeCode),
 		app,
 	)
 
@@ -1695,7 +1688,6 @@ func (suite *AuthorizeServiceTestSuite) TestGetRequiredAttributes_DeduplicatesCl
 	essential, optional := getRequiredAttributes(
 		[]string{"openid"},
 		claimsRequest,
-		string(providers.ResponseTypeCode),
 		app,
 	)
 
@@ -1724,7 +1716,6 @@ func (suite *AuthorizeServiceTestSuite) TestGetRequiredAttributes_CustomScopeMap
 	essential, optional := getRequiredAttributes(
 		[]string{"openid", "organization"},
 		nil,
-		string(providers.ResponseTypeCode),
 		app,
 	)
 
@@ -1769,7 +1760,6 @@ func (suite *AuthorizeServiceTestSuite) TestGetRequiredAttributes_ComplexScenari
 	essential, optional := getRequiredAttributes(
 		[]string{"openid", "custom"},
 		claimsRequest,
-		string(providers.ResponseTypeCode),
 		app,
 	)
 
@@ -1807,7 +1797,6 @@ func (suite *AuthorizeServiceTestSuite) TestGetRequiredAttributes_NoOpenIDScope(
 	essential, optional := getRequiredAttributes(
 		[]string{"profile"}, // OIDC scope but no openid
 		nil,
-		string(providers.ResponseTypeCode),
 		app,
 	)
 

--- a/backend/internal/oauth/oauth2/ciba/service_test.go
+++ b/backend/internal/oauth/oauth2/ciba/service_test.go
@@ -708,6 +708,20 @@ func (suite *CIBAServiceTestSuite) TestGetRequiredOptionalAttributes_ScopeDerive
 	suite.ElementsMatch([]string{"user_id", "email", "name"}, strings.Fields(optional))
 }
 
+func (suite *CIBAServiceTestSuite) TestGetRequiredOptionalAttributes_ScopeDerivedFromIDTokenAllowList() {
+	// Regression: a scope attribute allow-listed only for the ID token (and not for UserInfo) must
+	// still be resolved and cached so the CIBA-issued ID token can surface it.
+	app := &providers.OAuthClient{
+		Token: &providers.OAuthTokenConfig{
+			IDToken: &providers.IDTokenConfig{
+				UserAttributes: []string{"email", "email_verified"},
+			},
+		},
+	}
+	optional := getRequiredOptionalAttributes([]string{"openid", "email"}, app)
+	suite.ElementsMatch([]string{"email", "email_verified"}, strings.Fields(optional))
+}
+
 func (suite *CIBAServiceTestSuite) TestGetRequiredOptionalAttributes_ScopeDerivedSkippedWithoutOpenID() {
 	app := &providers.OAuthClient{
 		UserInfo: &providers.UserInfoConfig{

--- a/backend/internal/oauth/oauth2/ciba/utils.go
+++ b/backend/internal/oauth/oauth2/ciba/utils.go
@@ -20,9 +20,9 @@ import (
 // never carries an OIDC `claims` request parameter. Because essential attributes only originate from
 // the claims parameter, the CIBA essential set is always empty and is therefore set to "" at the
 // call site; the optional set is the access-token attributes plus the scope-derived OIDC attributes
-// filtered against the UserInfo allowed set. The output therefore matches authorization_code for the
-// same client config and scope. The format (space-separated) is what the assertion executor expects
-// via strings.Fields on the required-attribute runtime keys.
+// allow-listed for either the ID token or the UserInfo endpoint. The output therefore matches
+// authorization_code for the same client config and scope. The format (space-separated) is what the
+// assertion executor expects via strings.Fields on the required-attribute runtime keys.
 func getRequiredOptionalAttributes(scopes []string, app *providers.OAuthClient) string {
 	if app == nil {
 		return ""
@@ -37,19 +37,33 @@ func getRequiredOptionalAttributes(scopes []string, app *providers.OAuthClient) 
 	}
 
 	if slices.Contains(scopes, oauth2const.ScopeOpenID) {
+		var idTokenAllowed map[string]bool
+		if app.Token != nil {
+			idTokenAllowed = buildIDTokenAllowedSet(app.Token.IDToken)
+		}
 		userInfoAllowed := buildUserInfoAllowedSet(app.UserInfo)
-		if userInfoAllowed != nil {
-			for _, scope := range scopes {
-				for _, attr := range resolveScopeAttributes(scope, app.ScopeClaims) {
-					if userInfoAllowed[attr] {
-						optionalAttributes[attr] = true
-					}
+		for _, scope := range scopes {
+			for _, attr := range resolveScopeAttributes(scope, app.ScopeClaims) {
+				if idTokenAllowed[attr] || userInfoAllowed[attr] {
+					optionalAttributes[attr] = true
 				}
 			}
 		}
 	}
 
 	return strings.Join(slices.Collect(maps.Keys(optionalAttributes)), " ")
+}
+
+// buildIDTokenAllowedSet creates a set of attributes the ID token is allowed to carry.
+func buildIDTokenAllowedSet(idTokenConfig *providers.IDTokenConfig) map[string]bool {
+	if idTokenConfig == nil || len(idTokenConfig.UserAttributes) == 0 {
+		return nil
+	}
+	allowedSet := make(map[string]bool, len(idTokenConfig.UserAttributes))
+	for _, attr := range idTokenConfig.UserAttributes {
+		allowedSet[attr] = true
+	}
+	return allowedSet
 }
 
 // buildUserInfoAllowedSet creates a set of attributes the UserInfo endpoint is allowed to return.


### PR DESCRIPTION
### Purpose
Scope-derived OIDC claims allow-listed only for the ID token (e.g. `email` via the `email` scope) were never resolved into the attribute cache in the authorization code and CIBA flows, so they never appeared in the issued ID token. Attribute selection filtered scope claims against the UserInfo allow-list only.

### Approach
When an ID token is issued, cache scope-derived attributes allow-listed for either the ID token or UserInfo (previously UserInfo only). Since only `response_type=code` is supported, the now-dead response-type branch and its `responseType` parameter were removed from the attribute-selection chain. Applied the same fix to the CIBA mirror.
