### PR TITLE
Standardize product positioning & pillar wording

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Project Overview
 
-ThunderID is a lightweight user and identity management product: a Go backend (`backend/`) and React frontend (`frontend/`) in a monorepo. It provides authentication and authorization via OAuth2/OIDC, flexible orchestration flows, and individual auth mechanisms (password, passwordless, social login).
+ThunderID is a lightweight, open-source IAM stack: a Go backend (`backend/`) and React frontend (`frontend/`) in a monorepo. It provides authentication and authorization via OAuth2/OIDC, flexible orchestration flows, and individual auth mechanisms (password, passwordless, social login).
 
 - [ARCHITECTURE.md](ARCHITECTURE.md) — read only for cross-cutting changes
 - Build and run: [Makefile](Makefile) and [README.md](README.md)
@@ -36,6 +36,13 @@ The `.agent/skills/` entries above are internal guidance for **developing** Thun
 - Always use `ThunderID` (or the appropriate template placeholder for the file type). Never use the bare word `thunder`, `Thunder`, or `THUNDER` as a short form of the product name.
 - PRs that introduce bare `thunder`/`Thunder`/`THUNDER` (not part of `thunderid`, `ThunderID`, or `THUNDERID`) must not be merged until corrected.
 - Exceptions: import paths/package names (e.g., `@thunderid/...`) and code identifiers where `thunder` is a structural prefix immediately followed by `id` in any casing are allowed.
+
+## Product Positioning
+
+- Canonical category descriptor (prose): **open-source IAM stack**. Use it wherever the product is defined in prose (READMEs, docs, Helm charts). Do not reintroduce "IAM engine/platform/server", "identity management suite/system/product/platform/service", or "Identity Provider" as the product category.
+- Audience triplet: **humans, AI agents, and machines**, in that order. Do not use "workloads" or "resources".
+- The four product pillars, in order: **Agent-native Identity**, **Post-quantum-safe by Design**, **Decentralized Identity**, **Lightweight Runtime with GitOps Support**. Reuse these names (match each surface's casing convention).
+- Exception: the docs marketing tagline **"Auth for Modern Apps and AI Agents"** (`docs/docusaurus.product.config.ts`) is a deliberate slogan, not the prose category descriptor; leave it as-is.
 
 ## General Rules
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # ThunderID Architecture Reference
 
-Go IAM server (`github.com/thunder-id/thunderid`). Single binary serving a REST API + two React SPAs (`/gate`, `/console`).
+Open-source IAM stack (`github.com/thunder-id/thunderid`). Single Go binary serving a REST API + two React SPAs (`/gate`, `/console`).
 
 ## Structure
 

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@
 [![GitHub Release](https://img.shields.io/github/v/release/thunder-id/thunderid?color=blue)](https://github.com/thunder-id/thunderid/releases/latest)
 
 
-ThunderID is a lightweight, open-source Identity and Access Management (IAM) engine built to secure access for humans, AI agents, and machines.
+ThunderID is a lightweight, open-source IAM stack built to secure access for humans, AI agents, and machines.
 
-Designed for the agentic era, ThunderID provides a developer-first IAM platform and supporting tools for securing applications, APIs, services, and agent-driven workflows. It works across traditional and decentralized identity ecosystems, with post-quantum-ready security built in from the start.
+Designed for the agentic era, ThunderID provides a developer-first IAM stack and supporting tools for securing applications, APIs, services, and agent-driven workflows. It works across traditional and decentralized identity ecosystems, with post-quantum-ready security built in from the start.
 
 Core design goals of ThunderID include:
 - **Agent-native identity:** Manage AI agents as first-class identities with delegated authority, consent-aware access, traceability, and support for issuing verifiable credentials to agents. ThunderID also aims to expose IAM capabilities through interfaces that agents can use safely and programmatically.
+- **Post-quantum-safe by design:** Build on a crypto-agile foundation where algorithms, key types, signing methods, and token protection mechanisms can evolve over time, including support for post-quantum-safe algorithms and hybrid transition approaches across key management, credential issuance, assertions, and secure service-to-service communication.
 - **Decentralized identity:** Bridge the adoption gap for relying parties by making it practical for service providers to consume, verify, and trust decentralized identity in real-world applications, including DIDs, verifiable credentials, digital wallets, trust registries, and issuer-verifier-holder interaction models.
-- **Cloud-native IAM:** Provide a lightweight, containerized identity product that can run across on-premises and cloud environments, with declarative identity flows, policies, and configuration suitable for automation, versioning, and GitOps practices.
-- **Post-quantum-safe security:** Build on a crypto-agile foundation where algorithms, key types, signing methods, and token protection mechanisms can evolve over time, including support for post-quantum-safe algorithms and hybrid transition approaches across key management, credential issuance, assertions, and secure service-to-service communication.
+- **Lightweight runtime with GitOps support:** Provide a lightweight, containerized runtime that can run across on-premises and cloud environments, with declarative identity flows, policies, and configuration suitable for automation, versioning, and GitOps practices.
 
 
 ## Getting Started
@@ -40,7 +40,7 @@ Visit [Get ThunderID](https://thunderid.dev/docs/next/guides/getting-started/get
 ## Features
 
 * **Identity Management**
-    * Humans, AI agents, and workloads as first-class identity types
+    * Humans, AI agents, and machines as first-class identity types
     * Hierarchical organizational units (OUs) and groups
 
 * **Standards**

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,3 +1,3 @@
 # ThunderID Backend ⚡
 
-Backend workspace for **ThunderID ⚡** - a modern identity management suite. This workspace is built with Go and contains the core server implementation, API handlers, business logic, and integration with databases and other services for the ThunderID platform.
+Backend workspace for **ThunderID ⚡** - an open-source IAM stack. This workspace is built with Go and contains the core server implementation, API handlers, business logic, and integration with databases and other services for the ThunderID platform.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # ThunderID Documentation ⚡
 
-Documentation for **ThunderID** - a modern identity management suite. This documentation covers installation, configuration, development, and contribution guidelines for the ThunderID platform.
+Documentation for **ThunderID** - an open-source IAM stack. This documentation covers installation, configuration, development, and contribution guidelines for the ThunderID platform.
 
 ## Writing and reviewing docs with agent skills
 

--- a/docs/blog/2026-05-21-introducing-thunderid.mdx
+++ b/docs/blog/2026-05-21-introducing-thunderid.mdx
@@ -52,7 +52,7 @@ What this means in practice:
 
 - Crypto-agility applies across the full runtime: key management, credential issuance, signed assertions, and service-to-service communication.
 
-## Decentralized Identity Integration
+## Decentralized Identity
 
 Decentralized Identifiers (DID), verifiable credentials (VC), digital wallets, and trust registries are moving from specification into production. Among them, digital wallets are increasingly being adopted across personal and enterprise use cases, becoming an integral part of our lives. <ProductName /> is built to integrate with this ecosystem from the start, not to bolt it on later.
 
@@ -62,7 +62,7 @@ What this means in practice:
 
 - Standard APIs covering issuer-verifier-holder interaction patterns for integration with DIDs, digital wallets, and trust registries.
 
-## Lightweight, High-Performance Runtime with GitOps Support
+## Lightweight Runtime with GitOps Support
 
 <ProductName /> is written in Go: high performance, low latency, small runtime footprint. The runtime is headless and API-first, with built-in GitOps support.
 

--- a/docs/src/components/B2BIdentityJourney.tsx
+++ b/docs/src/components/B2BIdentityJourney.tsx
@@ -65,7 +65,7 @@ const journeySteps: JourneyStep[] = [
   },
   {
     title: 'Prepare for Agent Access',
-    scenario: 'Extend the same organization boundary to AI agents and workloads.',
+    scenario: 'Extend the same organization boundary to AI agents and machines.',
     thunder: 'Uses the same workspace and policy model for future agent identity and control.',
     flow: ['Organization boundary', 'Agent identity added', 'Policy-based access'],
   },

--- a/docs/src/components/Blog/BlogHeader.tsx
+++ b/docs/src/components/Blog/BlogHeader.tsx
@@ -57,8 +57,8 @@ export default function BlogHeader(): JSX.Element {
       </Typography>
 
       <Typography sx={{fontSize: '17px', lineHeight: 1.65, color: 'text.secondary', maxWidth: 560}}>
-        Deep dives, release notes, and engineering write-ups from the team building an open-source identity stack for
-        humans, AI agents, and workloads.
+        Deep dives, release notes, and engineering write-ups from the team building an open-source IAM stack for
+        humans, AI agents, and machines.
       </Typography>
     </Box>
   );

--- a/docs/src/components/HomePage/HeroSection.tsx
+++ b/docs/src/components/HomePage/HeroSection.tsx
@@ -235,7 +235,7 @@ export default function HeroSection(): JSX.Element {
                 animation: 'fadeInUp 0.7s cubic-bezier(0.16,1,0.3,1) 0.2s both',
               }}
             >
-              Authentication, authorization, and identity for humans, AI agents, and workloads.
+              Authentication, authorization, and identity for humans, AI agents, and machines.
             </Typography>
 
             <Stack

--- a/docs/src/components/HomePage/ProductOverviewSection.tsx
+++ b/docs/src/components/HomePage/ProductOverviewSection.tsx
@@ -155,9 +155,9 @@ const highlights = [
         <path d="M9 17h6" />
       </svg>
     ),
-    title: 'Native agent identity',
+    title: 'Agent-native identity',
     description:
-      'Engineered with native Agent ID and inherent agentic AI capabilities to secure end-to-end workflows among humans, agents, and resources, including full MCP and A2A authorization.',
+      'Engineered with native Agent ID and inherent agentic AI capabilities to secure end-to-end workflows among humans, AI agents, and machines, including full MCP and A2A authorization.',
   },
   {
     icon: (
@@ -176,7 +176,7 @@ const highlights = [
         <circle cx="12" cy="13" r="1" />
       </svg>
     ),
-    title: 'Post-quantum ready',
+    title: 'Post-quantum-safe by design',
     description:
       'Built upon a Post-Quantum Cryptographic (PQC) foundation to be inherently resistant to "Harvest Now, Decrypt Later" and "Trust Now, Forge Later" attacks and crypto agility by design.',
   },
@@ -201,7 +201,7 @@ const highlights = [
         <path d="M4.5 7.5l6 3M19.5 7.5l-6 3M4.5 16.5l6-3M19.5 16.5l-6-3" />
       </svg>
     ),
-    title: 'Decentralized identity integration',
+    title: 'Decentralized identity',
     description:
       'Designed for integration with decentralized identity infrastructure, including digital wallets, verifiable credentials, DIDs, and trust registries, reducing integration complexity for developers.',
   },
@@ -220,7 +220,7 @@ const highlights = [
         <path d="M13 2L4.5 13.5H11L10 22L20.5 10H14L13 2z" />
       </svg>
     ),
-    title: 'Lightweight, high-performant runtime',
+    title: 'Lightweight runtime with GitOps support',
     description:
       'Built for cloud-native delivery with a lightweight, high-performant, API-first runtime that integrates into modern CI/CD, GitOps, and containerized workflows.',
   },
@@ -414,7 +414,7 @@ const capabilities = [
         <path d="M8.56 2.75c4.37 6.03 6.02 9.42 8.03 17.72m2.54-15.38c-3.72 4.35-8.94 5.66-16.88 5.85m19.5 1.9c-3.5-.93-6.63-.82-8.94 0-2.58.92-5.01 2.86-7.44 6.32" />
       </svg>
     ),
-    title: 'Standards-first identity engine',
+    title: 'Standards-first identity',
     description:
       'Built on proven open standards including OpenID Connect, OAuth2, SCIM, and SAML and designed to evolve with next-generation standards.',
   },
@@ -530,8 +530,8 @@ export default function ProductOverviewSection(): JSX.Element {
               color: 'text.secondary',
             }}
           >
-            {productName} is an open source IAM stack built in Go, focused on open standards and designed to handle
-            identity for humans, AI agents, and workloads with fully orchestratable identity flows.
+            {productName} is an open-source IAM stack built in Go, focused on open standards and designed to handle
+            identity for humans, AI agents, and machines with fully orchestratable identity flows.
           </Typography>
         </Box>
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,4 +1,4 @@
 # ThunderID Frontend ⚡
 
-Frontend workspace for **ThunderID ⚡** - a modern identity management suite. This workspace is built with
+Frontend workspace for **ThunderID ⚡** - an open-source IAM stack. This workspace is built with
 [Turborepo](https://turbo.build) and contains React applications and shared packages for the platform.

--- a/frontend/apps/console/src/features/applications/models/auth-flow-graphs.ts
+++ b/frontend/apps/console/src/features/applications/models/auth-flow-graphs.ts
@@ -55,7 +55,7 @@ export const AUTH_FLOW_GRAPHS = {
 
 /**
  * Registration flow graph identifiers that define the available user registration flows
- * supported by the identity management platform.
+ * supported by the IAM stack.
  *
  * These graph IDs correspond to pre-configured registration flow definitions in the backend
  * that orchestrate the user onboarding process based on the selected registration methods

--- a/frontend/apps/gate/src/components/SignIn/SignInSlogan.tsx
+++ b/frontend/apps/gate/src/components/SignIn/SignInSlogan.tsx
@@ -13,23 +13,24 @@ const items: {
 }[] = [
   {
     icon: <Bot className="text-muted-foreground" />,
-    title: 'Native Agent Identity',
-    description: 'Engineered with native Agent ID to secure end-to-end workflows among humans, agents, and resources.',
+    title: 'Agent-native Identity',
+    description:
+      'Engineered with native Agent ID to secure end-to-end workflows among humans, AI agents, and machines.',
   },
   {
     icon: <Wallet className="text-muted-foreground" />,
-    title: 'Verifiable Credentials',
+    title: 'Decentralized Identity',
     description:
-      'Standards-based issuance and verification of wallet-held digital credentials for user-controlled identity.',
+      'Standards-based support for DIDs, verifiable credentials, and digital wallets for user-controlled identity.',
   },
   {
     icon: <ShieldCheck className="text-muted-foreground" />,
-    title: 'Post-Quantum Ready',
+    title: 'Post-quantum-safe by Design',
     description: 'Built on a post-quantum cryptographic foundation to be inherently resistant to attacks by design.',
   },
   {
     icon: <Zap className="text-muted-foreground" />,
-    title: 'Lightweight, High-Performant Runtime',
+    title: 'Lightweight Runtime with GitOps Support',
     description:
       'Cloud-native, API-first runtime that integrates into modern CI/CD, GitOps, and containerized workflows.',
   },

--- a/frontend/apps/gate/src/components/SignIn/__tests__/SignInSlogan.test.tsx
+++ b/frontend/apps/gate/src/components/SignIn/__tests__/SignInSlogan.test.tsx
@@ -17,9 +17,9 @@ describe('SignInSlogan', () => {
 
   it('renders all slogan items', () => {
     render(<SignInSlogan />);
-    expect(screen.getByText('Native Agent Identity')).toBeInTheDocument();
-    expect(screen.getByText('Post-Quantum Ready')).toBeInTheDocument();
-    expect(screen.getByText('Lightweight, High-Performant Runtime')).toBeInTheDocument();
+    expect(screen.getByText('Agent-native Identity')).toBeInTheDocument();
+    expect(screen.getByText('Post-quantum-safe by Design')).toBeInTheDocument();
+    expect(screen.getByText('Lightweight Runtime with GitOps Support')).toBeInTheDocument();
   });
 
   it('renders item descriptions', () => {

--- a/install/helm/Chart.yaml
+++ b/install/helm/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: thunderid
-description: A Helm chart for ThunderID - Lightweight user and identity management system
+description: A Helm chart for ThunderID - Open-source IAM stack
 type: application
 version: 0.48.0
 appVersion: "0.48.0"

--- a/install/helm/README.md
+++ b/install/helm/README.md
@@ -1,6 +1,6 @@
 # ThunderID Helm Chart
 
-This repository contains the Helm chart for ThunderID, a lightweight user and identity management system designed for modern application development.
+This repository contains the Helm chart for ThunderID, an open-source IAM stack designed for modern application development.
 
 ## Configuration Value Types
 

--- a/install/openchoreo/helm/Chart.yaml
+++ b/install/openchoreo/helm/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 name: thunderid
 description: |
-  Umbrella Helm chart for the ThunderID Identity Provider on OpenChoreo.
+  Umbrella Helm chart for ThunderID, an open-source IAM stack, on OpenChoreo.
 
   Sub-charts:
     thunderid-oc-componenttype  — Registers the ComponentType (or ClusterComponentType) once

--- a/install/openchoreo/helm/README.md
+++ b/install/openchoreo/helm/README.md
@@ -1,6 +1,6 @@
 # ThunderID Helm Chart
 
-This Helm chart deploys ThunderID Identity Management Service on the OpenChoreo platform. ThunderID provides OAuth2, OpenID Connect, and other identity protocols.
+This Helm chart deploys ThunderID, an open-source IAM stack, on the OpenChoreo platform. ThunderID provides OAuth2, OpenID Connect, and other identity protocols.
 
 ## Overview
 

--- a/install/openchoreo/helm/charts/thunderid-component/Chart.yaml
+++ b/install/openchoreo/helm/charts/thunderid-component/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 name: thunderid-component
 description: |
-  ThunderID Identity Provider component resources for OpenChoreo.
+  Component resources for ThunderID, an open-source IAM stack, on OpenChoreo.
   Deploys the Component, Workload, ComponentRelease, ReleaseBinding,
   and supporting platform resources. Requires the thunderid-oc-componenttype
   chart (or an equivalent ClusterComponentType) to be installed first.

--- a/install/openchoreo/helm/charts/thunderid-component/templates/thunderid-component.yaml
+++ b/install/openchoreo/helm/charts/thunderid-component/templates/thunderid-component.yaml
@@ -7,7 +7,7 @@ kind: Component
 metadata:
   name: {{ .Values.componentName }}
   annotations:
-    openchoreo.dev/description: "ThunderID Identity Management Service"
+    openchoreo.dev/description: "ThunderID, an open-source IAM stack"
     openchoreo.dev/display-name: "ThunderID"
 spec:
   owner:

--- a/install/openchoreo/helm/charts/thunderid-oc-componenttype/Chart.yaml
+++ b/install/openchoreo/helm/charts/thunderid-oc-componenttype/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 name: thunderid-oc-componenttype
 description: |
-  ComponentType definition for the ThunderID Identity Provider.
+  ComponentType definition for ThunderID, an open-source IAM stack.
   Install this once per cluster (or namespace) to register the thunderid
   component type. The thunderid-component chart depends on this type being present.
 type: application

--- a/install/openchoreo/thunderid-oc-resourcetype/README.md
+++ b/install/openchoreo/thunderid-oc-resourcetype/README.md
@@ -1,7 +1,7 @@
 # ThunderID OpenChoreo ResourceType
 
 This Helm chart registers a `ClusterResourceType` (or namespace-scoped
-`ResourceType`) that runs the ThunderID Identity Provider as an
+`ResourceType`) that runs ThunderID, an open-source IAM stack, as an
 OpenChoreo-managed platform Resource. It runs on the **SQLite databases
 bundled in the image** by default (zero prerequisites, development only) or
 an **externally hosted PostgreSQL database** (e.g. AWS RDS) for production.

--- a/install/openchoreo/thunderid-oc-resourcetype/templates/thunderid-resourcetype.yaml
+++ b/install/openchoreo/thunderid-oc-resourcetype/templates/thunderid-resourcetype.yaml
@@ -8,7 +8,7 @@ metadata:
   name: thunderid
   annotations:
     openchoreo.dev/description: >-
-      ThunderID Identity Provider, provisioned fully declaratively: all
+      ThunderID, an open-source IAM stack, provisioned fully declaratively: all
       resources (organization units, user types, applications, flows, users)
       come from the declarativeResources parameter. Runs on the bundled
       SQLite databases by default (ephemeral, development only) or an


### PR DESCRIPTION
### Purpose

ThunderID described itself inconsistently across the README, docs site, install charts, and product UI (login/console). 
- The category noun appeared in ~14 forms ("IAM engine", "IAM platform", "IAM server", "identity management
suite/system/service", "Identity Provider", "identity stack", ...)
- The audience triplet varied ("machines" vs "workloads" vs "resources", inconsistent even within a single README)
- The four product differentiators were named three different ways across the blog, README, login screen, and docs homepage (with one pillar silently swapped for another).

This PR converges all product self-description on one canonical set of strings so the product tells a single story everywhere:

- Category descriptor (prose): **open-source IAM stack**
- Audience triplet: **humans, AI agents, and machines**
- Four pillars (fixed names and order): 
                                  1. **Agent-native Identity**,
                                  2. **Post-quantum-safe by Design**
                                  3. **Decentralized Identity**
                                  4. **Lightweight runtime with GitOps support**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated product, architecture, deployment, and component descriptions to consistently present ThunderID as an open-source IAM stack.
  * Refined positioning, feature terminology, and audience language across documentation and product messaging.
  * Clarified support for humans, AI agents, and machines as identity types.
  * Simplified descriptions of agent-native identity, post-quantum security, decentralized identity, lightweight runtime, and GitOps.
  * Updated blog, homepage, journey, and sign-in messaging for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->