### PR TITLE
Update Nuxt application template to default `tokenEndpointAuthMethod` to `client_secret_basic`

### DIFF
--- a/frontend/apps/console/src/features/applications/data/application-templates/technology-based/nuxt.json
+++ b/frontend/apps/console/src/features/applications/data/application-templates/technology-based/nuxt.json
@@ -22,7 +22,7 @@
           "responseTypes": ["code"],
           "redirectUris": ["http://localhost:3000/api/auth/callback"],
           "pkceRequired": true,
-          "tokenEndpointAuthMethod": "client_secret_post",
+          "tokenEndpointAuthMethod": "client_secret_basic",
           "publicClient": false
         }
       }
@@ -40,8 +40,7 @@
         "value": true
       },
       "tokenEndpointAuthMethod": {
-        "readOnly": true,
-        "value": "client_secret_post"
+        "readOnly": false
       }
     }
   },


### PR DESCRIPTION
### Purpose
Previously, the Nuxt application template (`nuxt.json`) defaulted `tokenEndpointAuthMethod` to `client_secret_post` and locked the configuration field (`readOnly: true`). This caused token exchange failures when integrating `@thunderid/nuxt` applications, as the default method in `@thunderid/javascript` core is `client_secret_basic`.

This PR updates the Nuxt application template in ThunderID Console to default to `client_secret_basic` and unlocks the configuration menu, aligning Nuxt with Next.js and other framework application templates.

### Approach
- Updated `defaults.inboundAuthConfig[0].config.tokenEndpointAuthMethod` from `client_secret_post` to `client_secret_basic`.
- Set `fieldConstraints.oauth2.tokenEndpointAuthMethod.readOnly` to `false` in `nuxt.json` to enable the Client Authentication Method dropdown in ThunderID Console.

### Related Issues
- fixes #4568 

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Nuxt OAuth configuration to use the `client_secret_basic` authentication method.
  * Made the OAuth client authentication setting editable instead of enforcing a fixed value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->