### PR TITLE
Port inline error handling to user types and organization units

### DIFF
--- a/backend/internal/entitytype/error_constants.go
+++ b/backend/internal/entitytype/error_constants.go
@@ -89,19 +89,6 @@ var (
 			DefaultValue: "The offset parameter must be a non-negative integer",
 		},
 	}
-	// ErrorUserValidationFailed is the error returned when user attributes do not conform to the schema.
-	ErrorUserValidationFailed = tidcommon.ServiceError{
-		Type: tidcommon.ClientErrorType,
-		Code: "USRS-1007",
-		Error: tidcommon.I18nMessage{
-			Key:          "error.entitytypeservice.user_validation_failed",
-			DefaultValue: "User validation failed",
-		},
-		ErrorDescription: tidcommon.I18nMessage{
-			Key:          "error.entitytypeservice.user_validation_failed_description",
-			DefaultValue: "User attributes do not conform to the required schema",
-		},
-	}
 	// ErrorCannotModifyDeclarativeResource is the error returned when trying to modify a declarative resource.
 	ErrorCannotModifyDeclarativeResource = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -499,8 +499,6 @@ var defaultMessages = map[string]string{
 	"error.entitytypeservice.user_type_name_conflict_description": "A user type with the same name already exists",
 	"error.entitytypeservice.user_type_not_found": "User type not found",
 	"error.entitytypeservice.user_type_not_found_description": "The user type with the specified id does not exist",
-	"error.entitytypeservice.user_validation_failed": "User validation failed",
-	"error.entitytypeservice.user_validation_failed_description": "User attributes do not conform to the required schema",
 	"error.eudi.expired_state": "Expired request",
 	"error.eudi.expired_state_description": "The request associated with the supplied state value has expired",
 	"error.eudi.invalid_request": "Invalid request",

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -62,6 +62,12 @@ page to live.
   a background prefetch), a toast on its own is right, because there is nowhere natural to put it inline. React Query
   has no query `onError`, so a query hook cannot toast on its own — reaching for one means adding a render-phase or
   effect watcher on `isError`, which is a signal the error belongs inline.
+- Render every read failure with `ReadErrorState` from `@thunderid/components` rather than a hand-rolled
+  `ListingTable.EmptyState` or `<Alert>`. Use `variant="block"` (the default) for a list, grid, or page body, and
+  `variant="inline"` for a tab section or in-card region. It takes the error and `t` and resolves the message itself —
+  there is no `description` prop, so `error.message` is not representable through it. Pass `resolveErrorMessage` for a
+  feature-specific resolver (e.g. `getUserErrorMessage`); it defaults to `getErrorMessage`. Pass `onRetry` for the
+  default refresh button, or `action` to override it (e.g. an edit page's "Back to X").
 - Clear an inline error as soon as the user acts on it. Any change to the form invalidates the message, so a
   duplicate-name error must disappear when the name is edited rather than sitting there contradicting the field. Reset
   the mutation (`mutation.reset()`) or the local error state from whatever the form's field-change path is, and on

--- a/frontend/apps/console/src/features/groups/components/GroupsList.tsx
+++ b/frontend/apps/console/src/features/groups/components/GroupsList.tsx
@@ -1,11 +1,11 @@
 // Copyright 2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import {ReadErrorState} from '@thunderid/components';
 import {useDataGridLocaleText} from '@thunderid/hooks';
 import {useLogger} from '@thunderid/logger/react';
-import {getErrorMessage} from '@thunderid/utils';
-import {Button, IconButton, Typography, Tooltip, DataGrid, ListingTable} from '@wso2/oxygen-ui';
-import {AlertCircle, Eye, Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
+import {IconButton, Typography, Tooltip, DataGrid, ListingTable} from '@wso2/oxygen-ui';
+import {Eye, Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
 import {useMemo, useCallback, useState, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
@@ -139,15 +139,12 @@ export default function GroupsList(): JSX.Element {
 
   if (error) {
     return (
-      <ListingTable.EmptyState
-        illustration={<AlertCircle size={40} />}
+      <ReadErrorState
+        error={error}
+        t={t}
+        variant="block"
         title={t('groups:listing.error', 'Failed to load groups')}
-        description={getErrorMessage(error, t, 'common:messages.somethingWentWrong', 'Something went wrong')}
-        action={
-          <Button variant="outlined" onClick={() => void refetch()}>
-            {t('common:actions.refresh', 'Refresh')}
-          </Button>
-        }
+        onRetry={() => void refetch()}
       />
     );
   }

--- a/frontend/apps/console/src/features/groups/pages/GroupEditPage.tsx
+++ b/frontend/apps/console/src/features/groups/pages/GroupEditPage.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import {PageLoadingAnimation, UnsavedChangesBar} from '@thunderid/components';
+import {PageLoadingAnimation, ReadErrorState, UnsavedChangesBar} from '@thunderid/components';
 import {useLogger} from '@thunderid/logger/react';
 import {getErrorMessage, isEqualIgnoringEmpty} from '@thunderid/utils';
 import {
@@ -16,9 +16,8 @@ import {
   Tab,
   PageContent,
   PageTitle,
-  ListingTable,
 } from '@wso2/oxygen-ui';
-import {AlertCircle, ArrowLeft, Edit} from '@wso2/oxygen-ui-icons-react';
+import {ArrowLeft, Edit} from '@wso2/oxygen-ui-icons-react';
 import {useState, useCallback, useMemo} from 'react';
 import type {ReactNode, SyntheticEvent, JSX} from 'react';
 import {useTranslation} from 'react-i18next';
@@ -130,9 +129,11 @@ export default function GroupEditPage(): JSX.Element {
   if (fetchError) {
     return (
       <PageContent>
-        <ListingTable.EmptyState
-          illustration={<AlertCircle size={40} />}
-          title={getErrorMessage(fetchError, t, 'edit.page.error', 'Failed to load group')}
+        <ReadErrorState
+          error={fetchError}
+          t={t}
+          variant="block"
+          title={t('edit.page.error', 'Failed to load group')}
           action={
             <Stack direction="row" spacing={1} justifyContent="center">
               <Button variant="outlined" onClick={() => void refetch()}>

--- a/frontend/apps/console/src/features/roles/components/RolesList.tsx
+++ b/frontend/apps/console/src/features/roles/components/RolesList.tsx
@@ -1,11 +1,11 @@
 // Copyright 2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import {ReadErrorState} from '@thunderid/components';
 import {useDataGridLocaleText} from '@thunderid/hooks';
 import {useLogger} from '@thunderid/logger/react';
-import {getErrorMessage} from '@thunderid/utils';
-import {Button, IconButton, Typography, Tooltip, DataGrid, ListingTable} from '@wso2/oxygen-ui';
-import {AlertCircle, Eye, Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
+import {IconButton, Typography, Tooltip, DataGrid, ListingTable} from '@wso2/oxygen-ui';
+import {Eye, Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
 import {useMemo, useCallback, useState, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
@@ -139,15 +139,12 @@ export default function RolesList(): JSX.Element {
 
   if (error) {
     return (
-      <ListingTable.EmptyState
-        illustration={<AlertCircle size={40} />}
+      <ReadErrorState
+        error={error}
+        t={t}
+        variant="block"
         title={t('roles:listing.error', 'Failed to load roles')}
-        description={getErrorMessage(error, t, 'common:messages.somethingWentWrong', 'Something went wrong')}
-        action={
-          <Button variant="outlined" onClick={() => void refetch()}>
-            {t('common:actions.refresh', 'Refresh')}
-          </Button>
-        }
+        onRetry={() => void refetch()}
       />
     );
   }

--- a/frontend/apps/console/src/features/roles/pages/RoleEditPage.tsx
+++ b/frontend/apps/console/src/features/roles/pages/RoleEditPage.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {useIsMutating} from '@tanstack/react-query';
-import {PageLoadingAnimation, UnsavedChangesBar} from '@thunderid/components';
+import {PageLoadingAnimation, ReadErrorState, UnsavedChangesBar} from '@thunderid/components';
 import {arePermissionsEqual, type ResourcePermissions} from '@thunderid/configure-resource-servers';
 import {useLogger} from '@thunderid/logger/react';
 import {getErrorMessage, isEqualIgnoringEmpty} from '@thunderid/utils';
@@ -18,9 +18,8 @@ import {
   Tab,
   PageContent,
   PageTitle,
-  ListingTable,
 } from '@wso2/oxygen-ui';
-import {AlertCircle, ArrowLeft, Edit} from '@wso2/oxygen-ui-icons-react';
+import {ArrowLeft, Edit} from '@wso2/oxygen-ui-icons-react';
 import {useState, useCallback, useMemo} from 'react';
 import type {ReactNode, SyntheticEvent, JSX} from 'react';
 import {useTranslation} from 'react-i18next';
@@ -147,9 +146,11 @@ export default function RoleEditPage(): JSX.Element {
   if (fetchError) {
     return (
       <PageContent>
-        <ListingTable.EmptyState
-          illustration={<AlertCircle size={40} />}
-          title={getErrorMessage(fetchError, t, 'edit.page.error', 'Failed to load role')}
+        <ReadErrorState
+          error={fetchError}
+          t={t}
+          variant="block"
+          title={t('edit.page.error', 'Failed to load role')}
           action={
             <Stack direction="row" spacing={1} justifyContent="center">
               <Button variant="outlined" onClick={() => void refetch()}>

--- a/frontend/apps/console/src/features/roles/pages/__tests__/RoleEditPage.test.tsx
+++ b/frontend/apps/console/src/features/roles/pages/__tests__/RoleEditPage.test.tsx
@@ -69,7 +69,8 @@ vi.mock('../../components/edit-role/permissions-settings/EditPermissionsSettings
   ),
 }));
 
-vi.mock('@thunderid/components', () => ({
+vi.mock('@thunderid/components', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@thunderid/components')>()),
   CopyableId: vi.fn(() => null),
   PageLoadingAnimation: vi.fn(() => <div data-testid="page-loading-animation" />),
   UnsavedChangesBar: vi.fn(

--- a/frontend/packages/components/src/ReadErrorState/ReadErrorState.tsx
+++ b/frontend/packages/components/src/ReadErrorState/ReadErrorState.tsx
@@ -1,0 +1,114 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {getErrorMessage} from '@thunderid/utils';
+import {Alert, Button, ListingTable} from '@wso2/oxygen-ui';
+import {AlertCircle} from '@wso2/oxygen-ui-icons-react';
+import type {JSX, ReactNode} from 'react';
+
+/**
+ * The subset of the i18next TFunction interface {@link ReadErrorState} needs from its caller.
+ */
+type TranslateFn = (key: string, options?: Record<string, unknown>) => string;
+
+/**
+ * Resolves a localized error message from a read failure. Matches `getErrorMessage`'s signature
+ * (`@thunderid/utils`) exactly, so feature resolvers like `getUserErrorMessage` plug in with no
+ * adapter.
+ */
+export type ReadErrorMessageResolver = (
+  error: Error,
+  t: TranslateFn,
+  fallbackKey: string,
+  fallbackDefaultValue?: string,
+) => string;
+
+/**
+ * Props for {@link ReadErrorState}.
+ *
+ * @public
+ */
+export interface ReadErrorStateProps {
+  /** The error thrown by the failed read. */
+  error: Error;
+
+  /** The i18next translation function scoped to the caller's namespace. */
+  t: TranslateFn;
+
+  /**
+   * `'block'` (default) replaces a grid, list, or page body. `'inline'` renders a plain
+   * `Alert` for a tab body or in-card section.
+   */
+  variant?: 'block' | 'inline';
+
+  /** Title shown above the resolved message. Required for `variant="block"`. */
+  title?: string;
+
+  /** i18n key used to resolve the message when no error-code-specific translation exists. */
+  fallbackKey?: string;
+
+  /** Default value for {@link fallbackKey}, per the i18n Fallback Values convention. */
+  fallbackDefaultValue?: string;
+
+  /**
+   * Resolves the localized message from `error`. Defaults to `getErrorMessage` from
+   * `@thunderid/utils`. Pass a feature resolver (e.g. `getUserErrorMessage`) to interpolate
+   * error-specific params.
+   */
+  resolveErrorMessage?: ReadErrorMessageResolver;
+
+  /** Called when the user retries. Renders a `common:actions.refresh` button. Ignored if `action` is set. */
+  onRetry?: () => void;
+
+  /** Overrides the default retry button, e.g. for an edit page's "Back to X" action. */
+  action?: ReactNode;
+
+  /** Custom illustration for `variant="block"`. Defaults to an `AlertCircle` icon. */
+  illustration?: ReactNode;
+}
+
+/**
+ * Renders a failed read (list, edit page, or tab section) in place of its content, resolving the
+ * error through {@link ReadErrorMessageResolver} rather than surfacing raw server text. See
+ * `frontend/AGENTS.md`'s Error Display section.
+ *
+ * @public
+ */
+export default function ReadErrorState({
+  error,
+  t,
+  variant = 'block',
+  title = undefined,
+  fallbackKey = 'common:messages.somethingWentWrong',
+  fallbackDefaultValue = 'Something went wrong',
+  resolveErrorMessage = getErrorMessage,
+  onRetry = undefined,
+  action = undefined,
+  illustration = undefined,
+}: ReadErrorStateProps): JSX.Element {
+  const message = resolveErrorMessage(error, t, fallbackKey, fallbackDefaultValue);
+  const resolvedAction =
+    action ??
+    (onRetry ? (
+      <Button variant="outlined" onClick={onRetry}>
+        {t('common:actions.refresh', {defaultValue: 'Refresh'})}
+      </Button>
+    ) : undefined);
+
+  if (variant === 'inline') {
+    return (
+      <Alert severity="error" action={resolvedAction}>
+        {message}
+      </Alert>
+    );
+  }
+
+  return (
+    <ListingTable.EmptyState
+      illustration={illustration ?? <AlertCircle size={40} />}
+      title={title}
+      description={message}
+      action={resolvedAction}
+    />
+  );
+}

--- a/frontend/packages/components/src/ReadErrorState/__tests__/ReadErrorState.test.tsx
+++ b/frontend/packages/components/src/ReadErrorState/__tests__/ReadErrorState.test.tsx
@@ -1,0 +1,97 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {render, screen, fireEvent} from '@testing-library/react';
+import {describe, it, expect, vi} from 'vitest';
+import ReadErrorState from '../ReadErrorState';
+
+const t = (key: string, options?: Record<string, unknown>): string =>
+  (options?.defaultValue as string | undefined) ?? key;
+
+describe('ReadErrorState', () => {
+  it('renders the block variant with a title and resolved description', () => {
+    render(
+      <ReadErrorState
+        error={new Error('boom')}
+        t={t}
+        title="Failed to load users"
+        fallbackKey="users:listing.error"
+        fallbackDefaultValue="Something went wrong loading users"
+      />,
+    );
+
+    expect(screen.getByText('Failed to load users')).toBeInTheDocument();
+    expect(screen.getByText('Something went wrong loading users')).toBeInTheDocument();
+  });
+
+  it('renders the inline variant as a plain alert with no title', () => {
+    render(
+      <ReadErrorState
+        error={new Error('boom')}
+        t={t}
+        variant="inline"
+        fallbackKey="agents:groups.error"
+        fallbackDefaultValue="Failed to load groups"
+      />,
+    );
+
+    expect(screen.getByText('Failed to load groups')).toBeInTheDocument();
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+  });
+
+  it('renders the onRetry action alongside the inline alert', () => {
+    const onRetry = vi.fn();
+    render(
+      <ReadErrorState
+        error={new Error('boom')}
+        t={t}
+        variant="inline"
+        onRetry={onRetry}
+        fallbackKey="agents:groups.error"
+        fallbackDefaultValue="Failed to load groups"
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Refresh'));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a refresh button that calls onRetry', () => {
+    const onRetry = vi.fn();
+    render(<ReadErrorState error={new Error('boom')} t={t} title="Failed" onRetry={onRetry} />);
+
+    fireEvent.click(screen.getByText('Refresh'));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('prefers a custom action over the default retry button', () => {
+    const onRetry = vi.fn();
+    render(
+      <ReadErrorState
+        error={new Error('boom')}
+        t={t}
+        title="Failed"
+        onRetry={onRetry}
+        action={<button type="button">Back to Users</button>}
+      />,
+    );
+
+    expect(screen.getByText('Back to Users')).toBeInTheDocument();
+    expect(screen.queryByText('Refresh')).not.toBeInTheDocument();
+  });
+
+  it('uses a custom resolveErrorMessage to interpolate error-specific params', () => {
+    const resolveErrorMessage = vi.fn().mockReturnValue('Custom resolved message');
+    render(<ReadErrorState error={new Error('boom')} t={t} title="Failed" resolveErrorMessage={resolveErrorMessage} />);
+
+    expect(screen.getByText('Custom resolved message')).toBeInTheDocument();
+    expect(resolveErrorMessage).toHaveBeenCalledWith(
+      expect.any(Error),
+      t,
+      'common:messages.somethingWentWrong',
+      'Something went wrong',
+    );
+  });
+});

--- a/frontend/packages/components/src/index.ts
+++ b/frontend/packages/components/src/index.ts
@@ -17,6 +17,8 @@ export type {ExternalLinkProps} from './ExternalLink/ExternalLink';
 export {default as OrganizationUnitSummaryChip} from './OrganizationUnitSummaryChip/OrganizationUnitSummaryChip';
 export type {OrganizationUnitSummaryChipProps} from './OrganizationUnitSummaryChip/OrganizationUnitSummaryChip';
 export {default as PageLoader} from './PageLoader/PageLoader';
+export {default as ReadErrorState} from './ReadErrorState/ReadErrorState';
+export type {ReadErrorStateProps, ReadErrorMessageResolver} from './ReadErrorState/ReadErrorState';
 export {default as ToggleCard} from './ToggleCard/ToggleCard';
 export type {ToggleCardProps} from './ToggleCard/ToggleCard';
 

--- a/frontend/packages/configure-organization-units/src/api/useCreateOrganizationUnit.ts
+++ b/frontend/packages/configure-organization-units/src/api/useCreateOrganizationUnit.ts
@@ -76,8 +76,5 @@ export default function useCreateOrganizationUnit(): UseMutationResult<
       });
       showToast(t('create.success'), 'success');
     },
-    onError: () => {
-      showToast(t('create.error'), 'error');
-    },
   });
 }

--- a/frontend/packages/configure-organization-units/src/api/useUpdateOrganizationUnit.ts
+++ b/frontend/packages/configure-organization-units/src/api/useUpdateOrganizationUnit.ts
@@ -85,8 +85,5 @@ export default function useUpdateOrganizationUnit(): UseMutationResult<
         });
       showToast(t('update.success'), 'success');
     },
-    onError: () => {
-      showToast(t('update.error'), 'error');
-    },
   });
 }

--- a/frontend/packages/configure-organization-units/src/components/OrganizationUnitDeleteDialog.tsx
+++ b/frontend/packages/configure-organization-units/src/components/OrganizationUnitDeleteDialog.tsx
@@ -1,11 +1,11 @@
 // Copyright 2025 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import {getErrorMessage} from '@thunderid/utils';
 import {Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button, Alert} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import useDeleteOrganizationUnit from '../api/useDeleteOrganizationUnit';
-import type {ApiError, I18nMessage} from '../models/api-error';
 
 export interface OrganizationUnitDeleteDialogProps {
   /**
@@ -24,53 +24,31 @@ export interface OrganizationUnitDeleteDialogProps {
    * Callback when the organization unit is successfully deleted
    */
   onSuccess?: () => void;
-  /**
-   * Callback when the deletion fails, receives the error message
-   */
-  onError?: (message: string) => void;
 }
 
 /**
- * Resolves a backend error field to a display string. The field may be a plain
- * string or a translatable {@link I18nMessage} object; objects are reduced to
- * their `defaultValue` so they are never rendered directly as React children.
- */
-function resolveField(value: I18nMessage | string | undefined): string | null {
-  if (typeof value === 'string') {
-    return value.trim() ? value : null;
-  }
-
-  const defaultValue = value?.defaultValue;
-
-  return defaultValue?.trim() ? defaultValue : null;
-}
-
-/**
- * Extracts a user-friendly error message from the API error response.
- */
-function getErrorMessage(err: Error, fallback: string): string {
-  const {response} = err as Error & {response?: {data?: ApiError}};
-  const description = resolveField(response?.data?.description);
-  const message = err.message?.trim() ? err.message : null;
-
-  return description ?? message ?? fallback;
-}
-
-/**
- * Dialog component for confirming organization unit deletion
+ * Dialog component for confirming organization unit deletion. Owns the delete mutation itself, so
+ * a failure renders inline here rather than closing the dialog and handing the message to a
+ * parent — the parent only learns about a successful deletion.
  */
 export default function OrganizationUnitDeleteDialog({
   open,
   organizationUnitId,
   onClose,
   onSuccess = undefined,
-  onError = undefined,
 }: OrganizationUnitDeleteDialogProps): JSX.Element {
   const {t} = useTranslation();
   const deleteOrganizationUnit = useDeleteOrganizationUnit();
 
+  // Resolves an error through the `organizationUnits` catalog. `t` defaults to the `common`
+  // namespace, so this forwards explicit `ns:` prefixes unchanged and prefixes bare keys with
+  // `organizationUnits:`, per getErrorMessage's namespace-resolution contract.
+  const tForErrors = (key: string, options?: Record<string, unknown>): string =>
+    t(key.includes(':') ? key : `organizationUnits:${key}`, options);
+
   const handleCancel = (): void => {
     if (deleteOrganizationUnit.isPending) return;
+    deleteOrganizationUnit.reset();
     onClose();
   };
 
@@ -82,13 +60,17 @@ export default function OrganizationUnitDeleteDialog({
         onClose();
         onSuccess?.();
       },
-      onError: (err: Error) => {
-        const message = getErrorMessage(err, t('organizationUnits:delete.dialog.error'));
-        onClose();
-        onError?.(message);
-      },
     });
   };
+
+  const errorMessage = deleteOrganizationUnit.error
+    ? getErrorMessage(
+        deleteOrganizationUnit.error,
+        tForErrors,
+        'delete.dialog.error',
+        'Failed to delete organization unit. Please try again.',
+      )
+    : null;
 
   return (
     <Dialog open={open} onClose={handleCancel} maxWidth="sm" fullWidth>
@@ -98,6 +80,11 @@ export default function OrganizationUnitDeleteDialog({
         <Alert severity="warning" sx={{mb: 2}}>
           {t('organizationUnits:delete.dialog.disclaimer')}
         </Alert>
+        {errorMessage && (
+          <Alert severity="error" sx={{mb: 2}}>
+            {errorMessage}
+          </Alert>
+        )}
       </DialogContent>
       <DialogActions>
         <Button onClick={handleCancel} disabled={deleteOrganizationUnit.isPending}>

--- a/frontend/packages/configure-organization-units/src/components/OrganizationUnitTreePicker.tsx
+++ b/frontend/packages/configure-organization-units/src/components/OrganizationUnitTreePicker.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {useQueryClient} from '@tanstack/react-query';
-import {PageLoadingAnimation, ResourceAvatar} from '@thunderid/components';
+import {PageLoadingAnimation, ReadErrorState, ResourceAvatar} from '@thunderid/components';
 import {useConfig} from '@thunderid/contexts';
 import {useLogger} from '@thunderid/logger/react';
 import {useThunderID} from '@thunderid/react';
@@ -227,18 +227,29 @@ export default function OrganizationUnitTreePicker({
   const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient = useQueryClient();
-  const {data, isLoading} = useGetOrganizationUnits(undefined, !rootOuId);
+  const {
+    data,
+    isLoading,
+    error: rootListError,
+    refetch: refetchRootList,
+  } = useGetOrganizationUnits(undefined, !rootOuId);
 
   useEffect((): void => {
     if (!autoSelectFirst || rootOuId || value) return;
     const firstRootOuId = data?.organizationUnits[0]?.id;
     if (firstRootOuId) onChange(firstRootOuId);
   }, [autoSelectFirst, rootOuId, value, data, onChange]);
-  const {data: rootOuData, isLoading: isRootOuLoading, error: rootOuError} = useGetOrganizationUnit(rootOuId);
+  const {
+    data: rootOuData,
+    isLoading: isRootOuLoading,
+    error: rootOuError,
+    refetch: refetchRootOu,
+  } = useGetOrganizationUnit(rootOuId);
   const {
     data: rootOuChildrenData,
     isLoading: isRootOuChildrenLoading,
     error: rootOuChildrenError,
+    refetch: refetchRootOuChildren,
   } = useGetChildOrganizationUnits(rootOuId);
 
   const [treeItems, setTreeItems] = useState<OrganizationUnitTreeItem[]>([]);
@@ -541,17 +552,29 @@ export default function OrganizationUnitTreePicker({
   );
 
   const isTreeLoading = rootOuId ? isRootOuLoading || isRootOuChildrenLoading : isLoading;
-  const rootedModeError = rootOuId ? (rootOuError ?? rootOuChildrenError) : null;
+  const activeError = rootOuId ? (rootOuError ?? rootOuChildrenError) : rootListError;
 
   if (isTreeLoading) {
     return <PageLoadingAnimation />;
   }
 
-  if (rootedModeError) {
+  if (activeError) {
     return (
-      <Typography variant="body2" color="error">
-        {rootedModeError.message ?? t('organizationUnits:treePicker.error')}
-      </Typography>
+      <ReadErrorState
+        error={activeError}
+        t={(key, options) => t(key.includes(':') ? key : `organizationUnits:${key}`, options)}
+        variant="inline"
+        fallbackKey="organizationUnits:treePicker.error"
+        fallbackDefaultValue="Failed to load organization unit data"
+        onRetry={() => {
+          if (rootOuId) {
+            if (rootOuError) void refetchRootOu();
+            if (rootOuChildrenError) void refetchRootOuChildren();
+          } else {
+            void refetchRootList();
+          }
+        }}
+      />
     );
   }
 

--- a/frontend/packages/configure-organization-units/src/components/OrganizationUnitsTreeView.tsx
+++ b/frontend/packages/configure-organization-units/src/components/OrganizationUnitsTreeView.tsx
@@ -2,22 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {useQueryClient} from '@tanstack/react-query';
-import {PageLoadingAnimation, ResourceAvatar} from '@thunderid/components';
+import {PageLoadingAnimation, ReadErrorState, ResourceAvatar} from '@thunderid/components';
 import {useConfig} from '@thunderid/contexts';
 import {useLogger} from '@thunderid/logger/react';
 import {useThunderID} from '@thunderid/react';
-import {
-  Box,
-  IconButton,
-  Typography,
-  CircularProgress,
-  TreeView,
-  Snackbar,
-  Alert,
-  useTheme,
-  Avatar,
-  Tooltip,
-} from '@wso2/oxygen-ui';
+import {Box, IconButton, Typography, CircularProgress, TreeView, useTheme, Avatar, Tooltip} from '@wso2/oxygen-ui';
 import {Eye, Pencil, Plus, Trash2} from '@wso2/oxygen-ui-icons-react';
 import {useState, useCallback, useEffect, useRef, useMemo} from 'react';
 import type {ReactNode, MouseEvent, KeyboardEvent, SyntheticEvent, JSX} from 'react';
@@ -369,7 +358,7 @@ export default function OrganizationUnitsTreeView(): JSX.Element {
   const {http} = useThunderID();
   const {getServerUrl} = useConfig();
   const queryClient = useQueryClient();
-  const {data, isLoading, error} = useGetOrganizationUnits();
+  const {data, isLoading, error, refetch} = useGetOrganizationUnits();
   const {treeItems, setTreeItems, expandedItems, setExpandedItems, loadedItems, setLoadedItems, resetTreeState} =
     useOrganizationUnit();
 
@@ -392,11 +381,6 @@ export default function OrganizationUnitsTreeView(): JSX.Element {
   const builtFromDataRef = useRef<unknown>(null);
   const [selectedOU, setSelectedOU] = useState<{id: string; name: string} | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState<boolean>(false);
-  const [snackbar, setSnackbar] = useState<{open: boolean; message: string; severity: 'success' | 'error'}>({
-    open: false,
-    message: '',
-    severity: 'success',
-  });
 
   const fetchChildPage = useCallback(
     async (parentId: string, offset: number): Promise<OrganizationUnitListResponse> =>
@@ -741,17 +725,9 @@ export default function OrganizationUnitsTreeView(): JSX.Element {
   };
 
   const handleDeleteSuccess = useCallback((): void => {
+    // useDeleteOrganizationUnit's own onSuccess already toasts the success message.
     resetTreeState();
-    setSnackbar({
-      open: true,
-      message: t('organizationUnits:edit.general.dangerZone.delete.success'),
-      severity: 'success',
-    });
-  }, [resetTreeState, t]);
-
-  const handleDeleteError = useCallback((message: string): void => {
-    setSnackbar({open: true, message, severity: 'error'});
-  }, []);
+  }, [resetTreeState]);
 
   const handleAddChildClick = useCallback(
     (_event: MouseEvent<HTMLElement>, ou: {id: string; name: string; handle: string}): void => {
@@ -804,14 +780,15 @@ export default function OrganizationUnitsTreeView(): JSX.Element {
 
   if (error) {
     return (
-      <Box sx={{textAlign: 'center', py: 8}}>
-        <Typography variant="h6" color="error" gutterBottom>
-          {t('organizationUnits:listing.error.title')}
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          {error.message ?? t('organizationUnits:listing.error.unknown')}
-        </Typography>
-      </Box>
+      <ReadErrorState
+        error={error}
+        t={(key, options) => t(key.includes(':') ? key : `organizationUnits:${key}`, options)}
+        variant="block"
+        title={t('organizationUnits:listing.error.title', 'Failed to load organization units')}
+        fallbackKey="organizationUnits:listing.error.unknown"
+        fallbackDefaultValue="An unknown error occurred"
+        onRetry={() => void refetch()}
+      />
     );
   }
 
@@ -1010,23 +987,7 @@ export default function OrganizationUnitsTreeView(): JSX.Element {
         organizationUnitId={selectedOU?.id ?? null}
         onClose={handleDeleteDialogClose}
         onSuccess={handleDeleteSuccess}
-        onError={handleDeleteError}
       />
-
-      <Snackbar
-        open={snackbar.open}
-        autoHideDuration={6000}
-        onClose={() => setSnackbar((prev) => ({...prev, open: false}))}
-        anchorOrigin={{vertical: 'bottom', horizontal: 'right'}}
-      >
-        <Alert
-          onClose={() => setSnackbar((prev) => ({...prev, open: false}))}
-          severity={snackbar.severity}
-          sx={{width: '100%'}}
-        >
-          {snackbar.message}
-        </Alert>
-      </Snackbar>
     </>
   );
 }

--- a/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitDeleteDialog.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitDeleteDialog.test.tsx
@@ -8,7 +8,13 @@ import OrganizationUnitDeleteDialog from '../OrganizationUnitDeleteDialog';
 
 // Mock the delete hook — controllable per test
 const mockMutate = vi.fn();
-const mockDeleteHook = {mutate: mockMutate, isPending: false};
+const mockReset = vi.fn();
+const mockDeleteHook: {mutate: typeof mockMutate; isPending: boolean; error: Error | null; reset: typeof mockReset} = {
+  mutate: mockMutate,
+  isPending: false,
+  error: null,
+  reset: mockReset,
+};
 vi.mock('@/api/useDeleteOrganizationUnit', () => ({
   default: () => mockDeleteHook,
 }));
@@ -30,6 +36,9 @@ describe('OrganizationUnitDeleteDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockMutate.mockReset();
+    mockReset.mockReset();
+    mockDeleteHook.error = null;
+    mockDeleteHook.isPending = false;
   });
 
   it('should render dialog when open is true', () => {
@@ -45,13 +54,14 @@ describe('OrganizationUnitDeleteDialog', () => {
     expect(screen.queryByText(t('organizationUnits:delete.dialog.title'))).not.toBeInTheDocument();
   });
 
-  it('should call onClose when cancel button is clicked', () => {
+  it('should call onClose and reset the mutation when cancel button is clicked', () => {
     const onClose = vi.fn();
     renderWithProviders(<OrganizationUnitDeleteDialog {...defaultProps} onClose={onClose} />);
 
     fireEvent.click(screen.getByText(t('common:actions.cancel')));
 
     expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockReset).toHaveBeenCalledTimes(1);
   });
 
   it('should call mutate with correct id when delete button is clicked', () => {
@@ -87,95 +97,59 @@ describe('OrganizationUnitDeleteDialog', () => {
     });
   });
 
-  it('should call onClose and onError on deletion failure', async () => {
+  it('should not close the dialog on deletion failure, and should render the error inline', async () => {
     const onClose = vi.fn();
-    const onError = vi.fn();
-    mockMutate.mockImplementation((_id: string, options: {onError: (err: Error) => void}) => {
-      options.onError(
-        Object.assign(new Error('Network error'), {
-          response: {data: {code: 'ERR', message: 'fail', description: 'Network error'}},
-        }),
-      );
+    mockMutate.mockImplementation(() => {
+      // The mutation's own error state (not an onError callback) is how the dialog learns of a failure.
+      mockDeleteHook.error = Object.assign(new Error('Network error'), {
+        response: {data: {code: 'ERR'}},
+      });
     });
 
-    renderWithProviders(<OrganizationUnitDeleteDialog {...defaultProps} onClose={onClose} onError={onError} />);
+    const {rerender} = renderWithProviders(<OrganizationUnitDeleteDialog {...defaultProps} onClose={onClose} />);
 
     fireEvent.click(screen.getByText(t('common:actions.delete')));
+    rerender(<OrganizationUnitDeleteDialog {...defaultProps} onClose={onClose} />);
 
     await waitFor(() => {
-      expect(onClose).toHaveBeenCalled();
-      expect(onError).toHaveBeenCalledWith('Network error');
+      expect(onClose).not.toHaveBeenCalled();
+      expect(screen.getByText('Failed to delete organization unit. Please try again.')).toBeInTheDocument();
     });
   });
 
-  it('should resolve object-shaped description to its defaultValue', async () => {
-    const onError = vi.fn();
-    mockMutate.mockImplementation((_id: string, options: {onError: (err: Error) => void}) => {
-      options.onError(
-        Object.assign(new Error('Organization unit has children'), {
-          response: {
-            data: {
-              code: 'OU-1006',
-              message: {
-                key: 'error.ouservice.organization_unit_has_children',
-                defaultValue: 'Organization unit has children',
-              },
-              description: {
-                key: 'error.ouservice.organization_unit_has_children_description',
-                defaultValue: 'Cannot delete organization unit with children or users/groups',
-              },
-            },
-          },
-        }),
-      );
+  it('should resolve a known error code through the catalog', async () => {
+    mockMutate.mockImplementation(() => {
+      mockDeleteHook.error = Object.assign(new Error('Organization unit has children'), {
+        response: {data: {code: 'OU-1006'}},
+      });
     });
 
-    renderWithProviders(<OrganizationUnitDeleteDialog {...defaultProps} onError={onError} />);
+    const {rerender} = renderWithProviders(<OrganizationUnitDeleteDialog {...defaultProps} />);
 
     fireEvent.click(screen.getByText(t('common:actions.delete')));
+    rerender(<OrganizationUnitDeleteDialog {...defaultProps} />);
 
     await waitFor(() => {
-      expect(onError).toHaveBeenCalledWith('Cannot delete organization unit with children or users/groups');
+      expect(
+        screen.getByText(
+          'This organization unit has child units, users, or groups and cannot be deleted while they exist.',
+        ),
+      ).toBeInTheDocument();
     });
   });
 
-  it('should fall back to error message when object-shaped description has empty defaultValue', async () => {
-    const onError = vi.fn();
-    mockMutate.mockImplementation((_id: string, options: {onError: (err: Error) => void}) => {
-      options.onError(
-        Object.assign(new Error('Something went wrong'), {
-          response: {
-            data: {
-              code: 'OU-1006',
-              message: {key: 'k', defaultValue: 'm'},
-              description: {key: 'k', defaultValue: '   '},
-            },
-          },
-        }),
-      );
+  it('should use the fallback message when the error has no known code', async () => {
+    mockMutate.mockImplementation(() => {
+      mockDeleteHook.error = new Error('boom');
     });
 
-    renderWithProviders(<OrganizationUnitDeleteDialog {...defaultProps} onError={onError} />);
+    const {rerender} = renderWithProviders(<OrganizationUnitDeleteDialog {...defaultProps} />);
 
     fireEvent.click(screen.getByText(t('common:actions.delete')));
+    rerender(<OrganizationUnitDeleteDialog {...defaultProps} />);
 
     await waitFor(() => {
-      expect(onError).toHaveBeenCalledWith('Something went wrong');
-    });
-  });
-
-  it('should use fallback error message when error has no response data', async () => {
-    const onError = vi.fn();
-    mockMutate.mockImplementation((_id: string, options: {onError: (err: Error) => void}) => {
-      options.onError(new Error());
-    });
-
-    renderWithProviders(<OrganizationUnitDeleteDialog {...defaultProps} onError={onError} />);
-
-    fireEvent.click(screen.getByText('Delete'));
-
-    await waitFor(() => {
-      expect(onError).toHaveBeenCalledWith(t('organizationUnits:delete.dialog.error'));
+      expect(screen.getByText(t('organizationUnits:delete.dialog.error'))).toBeInTheDocument();
     });
   });
 
@@ -194,60 +168,11 @@ describe('OrganizationUnitDeleteDialog', () => {
     });
   });
 
-  it('should work without onError callback', async () => {
-    const onClose = vi.fn();
-    mockMutate.mockImplementation((_id: string, options: {onError: (err: Error) => void}) => {
-      options.onError(new Error('Network error'));
-    });
-
-    renderWithProviders(<OrganizationUnitDeleteDialog {...defaultProps} onClose={onClose} onError={undefined} />);
-
-    fireEvent.click(screen.getByText(t('common:actions.delete')));
-
-    await waitFor(() => {
-      expect(onClose).toHaveBeenCalled();
-    });
-  });
-
   it('should display cancel and delete buttons', () => {
     renderWithProviders(<OrganizationUnitDeleteDialog {...defaultProps} />);
 
     expect(screen.getByText(t('common:actions.cancel'))).toBeInTheDocument();
     expect(screen.getByText(t('common:actions.delete'))).toBeInTheDocument();
-  });
-
-  it('should use error message when response has no description', async () => {
-    const onError = vi.fn();
-    mockMutate.mockImplementation((_id: string, options: {onError: (err: Error) => void}) => {
-      options.onError(
-        Object.assign(new Error('Something went wrong'), {
-          response: {data: {code: 'ERR', message: 'fail'}},
-        }),
-      );
-    });
-
-    renderWithProviders(<OrganizationUnitDeleteDialog {...defaultProps} onError={onError} />);
-
-    fireEvent.click(screen.getByText(t('common:actions.delete')));
-
-    await waitFor(() => {
-      expect(onError).toHaveBeenCalledWith('Something went wrong');
-    });
-  });
-
-  it('should use fallback when error message is only whitespace', async () => {
-    const onError = vi.fn();
-    mockMutate.mockImplementation((_id: string, options: {onError: (err: Error) => void}) => {
-      options.onError(new Error('   '));
-    });
-
-    renderWithProviders(<OrganizationUnitDeleteDialog {...defaultProps} onError={onError} />);
-
-    fireEvent.click(screen.getByText(t('common:actions.delete')));
-
-    await waitFor(() => {
-      expect(onError).toHaveBeenCalledWith(t('organizationUnits:delete.dialog.error'));
-    });
   });
 
   it('should render warning disclaimer alert', () => {
@@ -274,6 +199,8 @@ describe('OrganizationUnitDeleteDialog - pending state', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockMutate.mockReset();
+    mockReset.mockReset();
+    mockDeleteHook.error = null;
     mockDeleteHook.isPending = false;
   });
 

--- a/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitTreePicker.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitTreePicker.test.tsx
@@ -137,6 +137,35 @@ describe('OrganizationUnitTreePicker', () => {
     expect(screen.getByText(t('organizationUnits:treePicker.empty'))).toBeInTheDocument();
   });
 
+  it('should render an inline read error state, never the raw error message, when the root list fails to load', () => {
+    mockUseGetOrganizationUnits.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Network error'),
+    });
+
+    renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} />);
+
+    expect(screen.getByText('Failed to load organization unit data')).toBeInTheDocument();
+    expect(screen.queryByText('Network error')).not.toBeInTheDocument();
+  });
+
+  it('should refetch the root list when the retry action is clicked', () => {
+    const mockRefetchRootList = vi.fn();
+    mockUseGetOrganizationUnits.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Network error'),
+      refetch: mockRefetchRootList,
+    });
+
+    renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} />);
+
+    fireEvent.click(screen.getByText('Refresh'));
+
+    expect(mockRefetchRootList).toHaveBeenCalledTimes(1);
+  });
+
   it('should display handles for tree items', async () => {
     renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} />);
 
@@ -606,6 +635,42 @@ describe('OrganizationUnitTreePicker', () => {
       renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} rootOuId="root-ou-1" />);
 
       expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+
+    it('should render an inline read error state, never the raw error message, when the root OU fails to load', async () => {
+      mockUseGetOrganizationUnit.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error('Network error'),
+      });
+      mockUseGetChildOrganizationUnits.mockReturnValue({data: undefined, isLoading: false, error: null});
+
+      renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} rootOuId="root-ou-1" />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Failed to load organization unit data')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('Network error')).not.toBeInTheDocument();
+    });
+
+    it('should refetch the root OU when the retry action is clicked', async () => {
+      const mockRefetchRootOu = vi.fn();
+      mockUseGetOrganizationUnit.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error('Network error'),
+        refetch: mockRefetchRootOu,
+      });
+      mockUseGetChildOrganizationUnits.mockReturnValue({data: undefined, isLoading: false, error: null});
+
+      renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} rootOuId="root-ou-1" />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Refresh')).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText('Refresh'));
+
+      expect(mockRefetchRootOu).toHaveBeenCalledTimes(1);
     });
 
     it('should render root OU as top-level node with children', async () => {

--- a/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitsTreeView.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitsTreeView.test.tsx
@@ -1,7 +1,7 @@
 // Copyright 2025-2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import {screen, fireEvent, waitFor, within, renderWithProviders, act, renderHook} from '@thunderid/test-utils';
+import {screen, fireEvent, waitFor, within, renderWithProviders, renderHook} from '@thunderid/test-utils';
 import {useTranslation} from 'react-i18next';
 import {describe, it, expect, vi, beforeEach, beforeAll} from 'vitest';
 import type {OrganizationUnitListResponse} from '../../models/responses';
@@ -77,10 +77,18 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
 
 // Mock delete hook — controllable per test
 const mockDeleteMutate = vi.fn();
-const mockDeleteHook = {mutate: mockDeleteMutate, isPending: false};
+const mockDeleteReset = vi.fn();
+const mockDeleteHook: {
+  mutate: typeof mockDeleteMutate;
+  isPending: boolean;
+  error: Error | null;
+  reset: typeof mockDeleteReset;
+} = {mutate: mockDeleteMutate, isPending: false, error: null, reset: mockDeleteReset};
 vi.mock('@/api/useDeleteOrganizationUnit', () => ({
   default: () => mockDeleteHook,
 }));
+
+const mockRefetchOrganizationUnits = vi.fn();
 
 describe('OrganizationUnitsTreeView', () => {
   let t: (key: string) => string;
@@ -101,11 +109,16 @@ describe('OrganizationUnitsTreeView', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockNavigate.mockReset();
+    mockDeleteMutate.mockReset();
+    mockDeleteReset.mockReset();
+    mockDeleteHook.error = null;
+    mockDeleteHook.isPending = false;
     mockOrganizationUnitConfig.initialExpandedItems = [];
     mockUseGetOrganizationUnits.mockReturnValue({
       data: mockOUData,
       isLoading: false,
       error: null,
+      refetch: mockRefetchOrganizationUnits,
     });
   });
 
@@ -123,14 +136,32 @@ describe('OrganizationUnitsTreeView', () => {
       data: undefined,
       isLoading: false,
       error: new Error('Network error'),
+      refetch: mockRefetchOrganizationUnits,
     });
 
     renderWithProviders(<OrganizationUnitsTreeView />);
 
     await waitFor(() => {
       expect(screen.getByText(t('organizationUnits:listing.error.title'))).toBeInTheDocument();
-      expect(screen.getByText('Network error')).toBeInTheDocument();
+      expect(screen.getByText(t('organizationUnits:listing.error.unknown'))).toBeInTheDocument();
     });
+    expect(screen.queryByText('Network error')).not.toBeInTheDocument();
+  });
+
+  it('should retry the query when Refresh is clicked on the read error state', async () => {
+    mockUseGetOrganizationUnits.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Network error'),
+      refetch: mockRefetchOrganizationUnits,
+    });
+
+    renderWithProviders(<OrganizationUnitsTreeView />);
+
+    const refreshButton = await screen.findByRole('button', {name: /refresh/i});
+    fireEvent.click(refreshButton);
+
+    expect(mockRefetchOrganizationUnits).toHaveBeenCalled();
   });
 
   it('should show fallback error message when error has no message', async () => {
@@ -138,6 +169,7 @@ describe('OrganizationUnitsTreeView', () => {
       data: undefined,
       isLoading: false,
       error: {},
+      refetch: mockRefetchOrganizationUnits,
     });
 
     renderWithProviders(<OrganizationUnitsTreeView />);
@@ -294,7 +326,7 @@ describe('OrganizationUnitsTreeView', () => {
     });
   });
 
-  it('should show success snackbar after successful deletion', async () => {
+  it('should close the dialog and reset tree state after successful deletion', async () => {
     mockDeleteMutate.mockImplementation((_id: string, options: {onSuccess: () => void}) => {
       options.onSuccess();
     });
@@ -316,21 +348,21 @@ describe('OrganizationUnitsTreeView', () => {
     const dialog = screen.getByRole('dialog');
     fireEvent.click(within(dialog).getByText(t('common:actions.delete')));
 
+    // useDeleteOrganizationUnit's own onSuccess toast covers the success message — the dialog
+    // just closes, it does not render a second success notification of its own.
     await waitFor(() => {
-      expect(screen.getByText(t('organizationUnits:edit.general.dangerZone.delete.success'))).toBeInTheDocument();
+      expect(screen.queryByText(t('organizationUnits:delete.dialog.title'))).not.toBeInTheDocument();
     });
   });
 
-  it('should show error snackbar after failed deletion', async () => {
-    mockDeleteMutate.mockImplementation((_id: string, options: {onError: (err: Error) => void}) => {
-      options.onError(
-        Object.assign(new Error('Delete failed'), {
-          response: {data: {code: 'ERR', message: 'fail', description: 'Server error occurred'}},
-        }),
-      );
+  it('should not close the dialog and should show the resolved error inline after failed deletion', async () => {
+    mockDeleteMutate.mockImplementation(() => {
+      mockDeleteHook.error = Object.assign(new Error('Delete failed'), {
+        response: {data: {code: 'ERR'}},
+      });
     });
 
-    renderWithProviders(<OrganizationUnitsTreeView />);
+    const {rerender} = renderWithProviders(<OrganizationUnitsTreeView />);
 
     await waitFor(() => {
       expect(screen.getByText('Root Organization')).toBeInTheDocument();
@@ -346,9 +378,11 @@ describe('OrganizationUnitsTreeView', () => {
     // Use within to scope to the dialog's Delete button (avoids ambiguity with menu item)
     const dialog2 = screen.getByRole('dialog');
     fireEvent.click(within(dialog2).getByText(t('common:actions.delete')));
+    rerender(<OrganizationUnitsTreeView />);
 
     await waitFor(() => {
-      expect(screen.getByText('Server error occurred')).toBeInTheDocument();
+      expect(screen.getByText(t('organizationUnits:delete.dialog.title'))).toBeInTheDocument();
+      expect(screen.getByText('Failed to delete organization unit. Please try again.')).toBeInTheDocument();
     });
   });
 
@@ -484,45 +518,6 @@ describe('OrganizationUnitsTreeView', () => {
     await waitFor(() => {
       expect(screen.getByText('Root Organization')).toBeInTheDocument();
       expect(screen.getByText('Engineering')).toBeInTheDocument();
-    });
-  });
-
-  it('should close snackbar when close action is triggered', async () => {
-    // Trigger a success snackbar first
-    mockDeleteMutate.mockImplementation((_id: string, options: {onSuccess: () => void}) => {
-      options.onSuccess();
-    });
-
-    renderWithProviders(<OrganizationUnitsTreeView />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Root Organization')).toBeInTheDocument();
-    });
-
-    // Click row delete action to trigger snackbar
-    fireEvent.click(screen.getAllByLabelText(t('common:actions.delete'))[0]);
-
-    await waitFor(() => {
-      expect(screen.getByText(t('organizationUnits:delete.dialog.title'))).toBeInTheDocument();
-    });
-
-    // Use within to scope to the dialog's Delete button (avoids ambiguity with menu item)
-    const dialog3 = screen.getByRole('dialog');
-    fireEvent.click(within(dialog3).getByText(t('common:actions.delete')));
-
-    await waitFor(() => {
-      expect(screen.getByText(t('organizationUnits:edit.general.dangerZone.delete.success'))).toBeInTheDocument();
-    });
-
-    // Close the snackbar via the Alert close button
-    const alert = screen.getByRole('alert');
-    const alertCloseButton = alert.querySelector('button');
-    if (alertCloseButton) {
-      fireEvent.click(alertCloseButton);
-    }
-
-    await waitFor(() => {
-      expect(screen.queryByText(t('organizationUnits:edit.general.dangerZone.delete.success'))).not.toBeInTheDocument();
     });
   });
 
@@ -874,19 +869,21 @@ describe('OrganizationUnitsTreeView', () => {
     });
   });
 
-  it('should use fallback error message when error.message is missing', async () => {
+  it('should never surface the raw error message, even when the error carries one', async () => {
     const errorWithMessage = {message: 'Server unavailable'};
     mockUseGetOrganizationUnits.mockReturnValue({
       data: undefined,
       isLoading: false,
       error: errorWithMessage,
+      refetch: mockRefetchOrganizationUnits,
     });
 
     renderWithProviders(<OrganizationUnitsTreeView />);
 
     await waitFor(() => {
-      expect(screen.getByText('Server unavailable')).toBeInTheDocument();
+      expect(screen.getByText(t('organizationUnits:listing.error.unknown'))).toBeInTheDocument();
     });
+    expect(screen.queryByText('Server unavailable')).not.toBeInTheDocument();
   });
 
   it('should log error when add root navigation fails via keyboard', async () => {
@@ -1027,73 +1024,6 @@ describe('OrganizationUnitsTreeView', () => {
 
     await waitFor(() => {
       expect(stableLogger.error).toHaveBeenCalledWith('Failed to load more root organization units', expect.anything());
-    });
-  });
-
-  it('should close the snackbar automatically after the auto-hide duration', async () => {
-    mockDeleteMutate.mockImplementation((_id: string, options: {onSuccess: () => void}) => {
-      options.onSuccess();
-    });
-
-    renderWithProviders(<OrganizationUnitsTreeView />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Root Organization')).toBeInTheDocument();
-    });
-
-    fireEvent.click(screen.getAllByLabelText(t('common:actions.delete'))[0]);
-
-    await waitFor(() => {
-      expect(screen.getByText(t('organizationUnits:delete.dialog.title'))).toBeInTheDocument();
-    });
-
-    const dialog = screen.getByRole('dialog');
-    fireEvent.click(within(dialog).getByText(t('common:actions.delete')));
-
-    await waitFor(() => {
-      expect(screen.getByText(t('organizationUnits:edit.general.dangerZone.delete.success'))).toBeInTheDocument();
-    });
-
-    await waitFor(
-      () => {
-        expect(
-          screen.queryByText(t('organizationUnits:edit.general.dangerZone.delete.success')),
-        ).not.toBeInTheDocument();
-      },
-      {timeout: 7000},
-    );
-  });
-
-  it('should close the snackbar when clicking outside (clickaway)', async () => {
-    mockDeleteMutate.mockImplementation((_id: string, options: {onSuccess: () => void}) => {
-      options.onSuccess();
-    });
-
-    renderWithProviders(<OrganizationUnitsTreeView />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Root Organization')).toBeInTheDocument();
-    });
-
-    fireEvent.click(screen.getAllByLabelText(t('common:actions.delete'))[0]);
-
-    await waitFor(() => {
-      expect(screen.getByText(t('organizationUnits:delete.dialog.title'))).toBeInTheDocument();
-    });
-
-    const dialog = screen.getByRole('dialog');
-    fireEvent.click(within(dialog).getByText(t('common:actions.delete')));
-
-    await waitFor(() => {
-      expect(screen.getByText(t('organizationUnits:edit.general.dangerZone.delete.success'))).toBeInTheDocument();
-    });
-
-    act(() => {
-      fireEvent.click(document.body);
-    });
-
-    await waitFor(() => {
-      expect(screen.queryByText(t('organizationUnits:edit.general.dangerZone.delete.success'))).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/child-organization-unit-settings/ManageChildOrganizationUnitSection.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/child-organization-unit-settings/ManageChildOrganizationUnitSection.tsx
@@ -1,7 +1,7 @@
 // Copyright 2025 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import {SettingsCard} from '@thunderid/components';
+import {ReadErrorState, SettingsCard} from '@thunderid/components';
 import {useDataGridLocaleText} from '@thunderid/hooks';
 import {useLogger} from '@thunderid/logger/react';
 import {Box, DataGrid, Avatar, useTheme} from '@wso2/oxygen-ui';
@@ -53,7 +53,7 @@ export default function ManageChildOrganizationUnitSection({
   const logger = useLogger('ManageChildOrganizationUnitSection');
   const dataGridLocaleText = useDataGridLocaleText();
 
-  const {data: childOUsData, isLoading} = useGetChildOrganizationUnits(organizationUnitId);
+  const {data: childOUsData, isLoading, error, refetch} = useGetChildOrganizationUnits(organizationUnitId);
 
   const columns: DataGrid.GridColDef<OrganizationUnit>[] = useMemo(
     () => [
@@ -112,10 +112,34 @@ export default function ManageChildOrganizationUnitSection({
     [t, theme],
   );
 
+  if (error) {
+    return (
+      <SettingsCard
+        title={t('organizationUnits:edit.childOUs.sections.manage.title', 'Child Organization Units')}
+        description={t(
+          'organizationUnits:edit.childOUs.sections.manage.description',
+          'View and manage child organization units under this OU',
+        )}
+      >
+        <ReadErrorState
+          error={error}
+          t={(key, options) => t(key.includes(':') ? key : `organizationUnits:${key}`, options)}
+          variant="inline"
+          onRetry={() => void refetch()}
+          fallbackKey="organizationUnits:edit.childOUs.sections.manage.error"
+          fallbackDefaultValue="Failed to load child organization units"
+        />
+      </SettingsCard>
+    );
+  }
+
   return (
     <SettingsCard
-      title={t('organizationUnits:edit.childOUs.sections.manage.title')}
-      description={t('organizationUnits:edit.childOUs.sections.manage.description')}
+      title={t('organizationUnits:edit.childOUs.sections.manage.title', 'Child Organization Units')}
+      description={t(
+        'organizationUnits:edit.childOUs.sections.manage.description',
+        'Organization units nested under this one.',
+      )}
       slotProps={{
         content: {
           sx: {

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/child-organization-unit-settings/__tests__/ManageChildOrganizationUnitSection.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/child-organization-unit-settings/__tests__/ManageChildOrganizationUnitSection.test.tsx
@@ -158,6 +158,40 @@ describe('ManageChildOrganizationUnitSection', () => {
     expect(screen.getByRole('grid')).toBeInTheDocument();
   });
 
+  it('should render an inline read error state instead of the grid when the query fails', () => {
+    mockUseGetChildOrganizationUnits.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Network error'),
+    });
+
+    renderWithProviders(
+      <ManageChildOrganizationUnitSection organizationUnitId="ou-parent" organizationUnitName="Engineering" />,
+    );
+
+    expect(screen.getByText('Failed to load child organization units')).toBeInTheDocument();
+    expect(screen.queryByRole('grid')).not.toBeInTheDocument();
+    expect(screen.queryByText('Network error')).not.toBeInTheDocument();
+  });
+
+  it('should refetch when the retry action is clicked', () => {
+    const mockRefetch = vi.fn();
+    mockUseGetChildOrganizationUnits.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Network error'),
+      refetch: mockRefetch,
+    });
+
+    renderWithProviders(
+      <ManageChildOrganizationUnitSection organizationUnitId="ou-parent" organizationUnitName="Engineering" />,
+    );
+
+    fireEvent.click(screen.getByText('Refresh'));
+
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
+  });
+
   it('should call useGetChildOrganizationUnits with correct ID', () => {
     mockUseGetChildOrganizationUnits.mockReturnValue({
       data: {organizationUnits: mockChildOUs},

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/group-settings/ManageGroupsSection.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/group-settings/ManageGroupsSection.tsx
@@ -1,7 +1,7 @@
 // Copyright 2025 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import {SettingsCard, getInitials} from '@thunderid/components';
+import {ReadErrorState, SettingsCard, getInitials} from '@thunderid/components';
 import {useDataGridLocaleText} from '@thunderid/hooks';
 import {Box, DataGrid, Avatar} from '@wso2/oxygen-ui';
 import {useMemo, type JSX} from 'react';
@@ -34,7 +34,7 @@ export default function ManageGroupsSection({organizationUnitId}: ManageGroupsSe
   const {t} = useTranslation();
   const dataGridLocaleText = useDataGridLocaleText();
 
-  const {data: groupsData, isLoading} = useGetOrganizationUnitGroups(organizationUnitId);
+  const {data: groupsData, isLoading, error, refetch} = useGetOrganizationUnitGroups(organizationUnitId);
 
   const columns: DataGrid.GridColDef<Group>[] = useMemo(
     () => [
@@ -86,10 +86,34 @@ export default function ManageGroupsSection({organizationUnitId}: ManageGroupsSe
     [t],
   );
 
+  if (error) {
+    return (
+      <SettingsCard
+        title={t('organizationUnits:edit.groups.sections.manage.title', 'Groups')}
+        description={t(
+          'organizationUnits:edit.groups.sections.manage.description',
+          'View groups belonging to this organization unit',
+        )}
+      >
+        <ReadErrorState
+          error={error}
+          t={(key, options) => t(key.includes(':') ? key : `organizationUnits:${key}`, options)}
+          variant="inline"
+          onRetry={() => void refetch()}
+          fallbackKey="organizationUnits:edit.groups.sections.manage.error"
+          fallbackDefaultValue="Failed to load groups"
+        />
+      </SettingsCard>
+    );
+  }
+
   return (
     <SettingsCard
-      title={t('organizationUnits:edit.groups.sections.manage.title')}
-      description={t('organizationUnits:edit.groups.sections.manage.description')}
+      title={t('organizationUnits:edit.groups.sections.manage.title', 'Groups')}
+      description={t(
+        'organizationUnits:edit.groups.sections.manage.description',
+        'View groups belonging to this organization unit',
+      )}
       slotProps={{
         content: {
           sx: {

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/group-settings/__tests__/ManageGroupsSection.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/group-settings/__tests__/ManageGroupsSection.test.tsx
@@ -1,6 +1,7 @@
 // Copyright 2025 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import userEvent from '@testing-library/user-event';
 import {screen, renderWithProviders, renderHook} from '@thunderid/test-utils';
 import {useTranslation} from 'react-i18next';
 import {describe, it, expect, vi, beforeEach, beforeAll} from 'vitest';
@@ -109,6 +110,37 @@ describe('ManageGroupsSection', () => {
     renderWithProviders(<ManageGroupsSection organizationUnitId="ou-123" />);
 
     expect(screen.getByRole('grid')).toBeInTheDocument();
+  });
+
+  it('should render an inline read error state instead of the grid when the query fails', () => {
+    mockUseGetOrganizationUnitGroups.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Network error'),
+    });
+
+    renderWithProviders(<ManageGroupsSection organizationUnitId="ou-123" />);
+
+    expect(screen.getByText('Failed to load groups')).toBeInTheDocument();
+    expect(screen.queryByRole('grid')).not.toBeInTheDocument();
+    expect(screen.queryByText('Network error')).not.toBeInTheDocument();
+  });
+
+  it('should refetch when the retry action is clicked', async () => {
+    const mockRefetch = vi.fn();
+    mockUseGetOrganizationUnitGroups.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Network error'),
+      refetch: mockRefetch,
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<ManageGroupsSection organizationUnitId="ou-123" />);
+
+    await user.click(screen.getByText('Refresh'));
+
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
   });
 
   it('should call useGetOrganizationUnitGroups with correct ID', () => {

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/user-settings/ManageUsersSection.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/user-settings/ManageUsersSection.tsx
@@ -1,7 +1,7 @@
 // Copyright 2025 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import {SettingsCard, getInitials} from '@thunderid/components';
+import {ReadErrorState, SettingsCard, getInitials} from '@thunderid/components';
 import {useDataGridLocaleText} from '@thunderid/hooks';
 import type {User} from '@thunderid/types';
 import {Box, DataGrid, Avatar} from '@wso2/oxygen-ui';
@@ -35,7 +35,7 @@ export default function ManageUsersSection({organizationUnitId}: ManageUsersSect
   const {t} = useTranslation();
   const dataGridLocaleText = useDataGridLocaleText();
 
-  const {data: usersData, isLoading} = useGetOrganizationUnitUsers(organizationUnitId);
+  const {data: usersData, isLoading, error, refetch} = useGetOrganizationUnitUsers(organizationUnitId);
 
   const columns: DataGrid.GridColDef<User>[] = useMemo(
     () => [
@@ -94,10 +94,34 @@ export default function ManageUsersSection({organizationUnitId}: ManageUsersSect
     [t],
   );
 
+  if (error) {
+    return (
+      <SettingsCard
+        title={t('organizationUnits:edit.users.sections.manage.title', 'Users')}
+        description={t(
+          'organizationUnits:edit.users.sections.manage.description',
+          'View users belonging to this organization unit',
+        )}
+      >
+        <ReadErrorState
+          error={error}
+          t={(key, options) => t(key.includes(':') ? key : `organizationUnits:${key}`, options)}
+          variant="inline"
+          onRetry={() => void refetch()}
+          fallbackKey="organizationUnits:edit.users.sections.manage.error"
+          fallbackDefaultValue="Failed to load users"
+        />
+      </SettingsCard>
+    );
+  }
+
   return (
     <SettingsCard
-      title={t('organizationUnits:edit.users.sections.manage.title')}
-      description={t('organizationUnits:edit.users.sections.manage.description')}
+      title={t('organizationUnits:edit.users.sections.manage.title', 'Users')}
+      description={t(
+        'organizationUnits:edit.users.sections.manage.description',
+        'View users belonging to this organization unit',
+      )}
       slotProps={{
         content: {
           sx: {

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/user-settings/__tests__/ManageUsersSection.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/user-settings/__tests__/ManageUsersSection.test.tsx
@@ -1,6 +1,7 @@
 // Copyright 2025 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import userEvent from '@testing-library/user-event';
 import {screen, renderWithProviders, renderHook} from '@thunderid/test-utils';
 import type {User} from '@thunderid/types';
 import {useTranslation} from 'react-i18next';
@@ -125,6 +126,37 @@ describe('ManageUsersSection', () => {
     renderWithProviders(<ManageUsersSection organizationUnitId="ou-123" />);
 
     expect(screen.getByRole('grid')).toBeInTheDocument();
+  });
+
+  it('should render an inline read error state instead of the grid when the query fails', () => {
+    mockUseGetOrganizationUnitUsers.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Network error'),
+    });
+
+    renderWithProviders(<ManageUsersSection organizationUnitId="ou-123" />);
+
+    expect(screen.getByText('Failed to load users')).toBeInTheDocument();
+    expect(screen.queryByRole('grid')).not.toBeInTheDocument();
+    expect(screen.queryByText('Network error')).not.toBeInTheDocument();
+  });
+
+  it('should refetch when the retry action is clicked', async () => {
+    const mockRefetch = vi.fn();
+    mockUseGetOrganizationUnitUsers.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Network error'),
+      refetch: mockRefetch,
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<ManageUsersSection organizationUnitId="ou-123" />);
+
+    await user.click(screen.getByText('Refresh'));
+
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
   });
 
   it('should call useGetOrganizationUnitUsers with correct ID', () => {

--- a/frontend/packages/configure-organization-units/src/pages/CreateOrganizationUnitPage.tsx
+++ b/frontend/packages/configure-organization-units/src/pages/CreateOrganizationUnitPage.tsx
@@ -4,6 +4,7 @@
 import {zodResolver} from '@hookform/resolvers/zod';
 import {NameSuggestion} from '@thunderid/components';
 import {useLogger} from '@thunderid/logger/react';
+import {getErrorMessage} from '@thunderid/utils';
 import {
   Box,
   Stack,
@@ -99,6 +100,7 @@ export default function CreateOrganizationUnitPage(): JSX.Element {
   };
 
   const handleNameChange = (newName: string): void => {
+    setError(null); // a create error is stale once the form changes
     setValue('name', newName, {shouldValidate: true});
     // Auto-generate handle if user hasn't manually edited it
     if (!isHandleManuallyEditedRef.current) {
@@ -107,11 +109,18 @@ export default function CreateOrganizationUnitPage(): JSX.Element {
   };
 
   const handleHandleChange = (newHandle: string): void => {
+    setError(null); // a create error is stale once the form changes
     setValue('handle', newHandle, {shouldValidate: true});
     isHandleManuallyEditedRef.current = true;
   };
 
+  const handleDescriptionChange = (newDescription: string): void => {
+    setError(null); // a create error is stale once the form changes
+    setValue('description', newDescription);
+  };
+
   const handleNameSuggestionSelect = (suggestion: string): void => {
+    setError(null); // a create error is stale once the form changes
     setValue('name', suggestion, {shouldValidate: true});
     // Auto-generate handle from suggestion if user hasn't manually edited it
     if (!isHandleManuallyEditedRef.current) {
@@ -139,7 +148,14 @@ export default function CreateOrganizationUnitPage(): JSX.Element {
         });
       },
       onError: (err: Error) => {
-        setError(err.message ?? t('organizationUnits:create.error'));
+        setError(
+          getErrorMessage(
+            err,
+            (key, options) => t(key.includes(':') ? key : `organizationUnits:${key}`, options),
+            'create.error',
+            'Failed to create organization unit. Please try again.',
+          ),
+        );
       },
     });
   };
@@ -272,6 +288,7 @@ export default function CreateOrganizationUnitPage(): JSX.Element {
                             {...field}
                             fullWidth
                             id="ou-description-input"
+                            onChange={(e) => handleDescriptionChange(e.target.value)}
                             placeholder={t('organizationUnits:edit.general.description.placeholder')}
                             multiline
                             rows={3}

--- a/frontend/packages/configure-organization-units/src/pages/OrganizationUnitEditPage.tsx
+++ b/frontend/packages/configure-organization-units/src/pages/OrganizationUnitEditPage.tsx
@@ -1,9 +1,9 @@
 // Copyright 2025-2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import {PageLoadingAnimation, ResourceAvatar, UnsavedChangesBar} from '@thunderid/components';
+import {PageLoadingAnimation, ReadErrorState, ResourceAvatar, UnsavedChangesBar} from '@thunderid/components';
 import {useLogger} from '@thunderid/logger/react';
-import {isEqualIgnoringEmpty} from '@thunderid/utils';
+import {getErrorMessage, isEqualIgnoringEmpty} from '@thunderid/utils';
 import {
   Box,
   Stack,
@@ -14,7 +14,6 @@ import {
   IconButton,
   Tabs,
   Tab,
-  Snackbar,
   PageContent,
   PageTitle,
 } from '@wso2/oxygen-ui';
@@ -85,6 +84,15 @@ export default function OrganizationUnitEditPage({
   const {t} = useTranslation();
   const logger = useLogger('OrganizationUnitEditPage');
 
+  // Resolves an error through the `organizationUnits` catalog. `t` defaults to the `common`
+  // namespace, so this forwards explicit `ns:` prefixes unchanged and prefixes bare keys with
+  // `organizationUnits:`, per getErrorMessage's namespace-resolution contract.
+  const tForErrors = useCallback(
+    (key: string, options?: Record<string, unknown>): string =>
+      t(key.includes(':') ? key : `organizationUnits:${key}`, options),
+    [t],
+  );
+
   // Check if we came from another OU (via parent or child OU link)
   const navigationState = location.state as OUNavigationState | null;
   const fromOU = navigationState?.fromOU;
@@ -96,7 +104,6 @@ export default function OrganizationUnitEditPage({
   const [activeTab, setActiveTab] = useState(0);
   const [editedOU, setEditedOU] = useState<Partial<OrganizationUnit>>({});
   const [deleteDialogOpen, setDeleteDialogOpen] = useState<boolean>(false);
-  const [snackbar, setSnackbar] = useState<{open: boolean; message: string}>({open: false, message: ''});
   const [isEditingName, setIsEditingName] = useState(false);
   const [isEditingDescription, setIsEditingDescription] = useState(false);
   const [tempName, setTempName] = useState('');
@@ -113,15 +120,19 @@ export default function OrganizationUnitEditPage({
 
   const backButtonText = fromOU
     ? t('organizationUnits:edit.page.backToOU', {name: fromOU.name})
-    : t('organizationUnits:edit.page.back');
+    : t('organizationUnits:edit.page.back', 'Back to Organization Units');
 
   const handleTabChange = (_event: SyntheticEvent, newValue: number): void => {
     setActiveTab(newValue);
   };
 
-  const handleFieldChange = useCallback((field: keyof OrganizationUnit, value: unknown): void => {
-    setEditedOU((prev) => ({...prev, [field]: value}));
-  }, []);
+  const handleFieldChange = useCallback(
+    (field: keyof OrganizationUnit, value: unknown): void => {
+      updateOrganizationUnit.reset(); // a save error is stale once the form changes
+      setEditedOU((prev) => ({...prev, [field]: value}));
+    },
+    [updateOrganizationUnit],
+  );
 
   const commitDescription = useCallback(
     (value: string): void => {
@@ -191,10 +202,6 @@ export default function OrganizationUnitEditPage({
     });
   };
 
-  const handleDeleteError = (message: string): void => {
-    setSnackbar({open: true, message});
-  };
-
   if (isLoading) {
     return <PageLoadingAnimation />;
   }
@@ -202,19 +209,31 @@ export default function OrganizationUnitEditPage({
   if (fetchError) {
     return (
       <PageContent>
-        <Alert severity="error" sx={{mb: 2}}>
-          {fetchError.message ?? t('organizationUnits:edit.page.error')}
-        </Alert>
-        <Button
-          onClick={() => {
-            handleBack().catch((error: unknown) => {
-              logger.error('Failed to navigate back', {error});
-            });
-          }}
-          startIcon={<ArrowLeft size={16} />}
-        >
-          {t('organizationUnits:edit.page.back')}
-        </Button>
+        <ReadErrorState
+          error={fetchError}
+          t={tForErrors}
+          variant="block"
+          title={t('organizationUnits:edit.page.errorTitle', 'Failed to load organization unit')}
+          fallbackKey="organizationUnits:edit.page.error"
+          fallbackDefaultValue="Failed to load organization unit information"
+          action={
+            <Stack direction="row" spacing={1} justifyContent="center">
+              <Button variant="outlined" onClick={() => void refetch()}>
+                {t('common:actions.refresh', 'Refresh')}
+              </Button>
+              <Button
+                onClick={() => {
+                  handleBack().catch((error: unknown) => {
+                    logger.error('Failed to navigate back', {error});
+                  });
+                }}
+                startIcon={<ArrowLeft size={16} />}
+              >
+                {t('organizationUnits:edit.page.back', 'Back to Organization Units')}
+              </Button>
+            </Stack>
+          }
+        />
       </PageContent>
     );
   }
@@ -233,7 +252,7 @@ export default function OrganizationUnitEditPage({
           }}
           startIcon={<ArrowLeft size={16} />}
         >
-          {t('organizationUnits:edit.page.back')}
+          {t('organizationUnits:edit.page.back', 'Back to Organization Units')}
         </Button>
       </PageContent>
     );
@@ -260,7 +279,8 @@ export default function OrganizationUnitEditPage({
             value={editedOU.logoUrl ?? organizationUnit.logoUrl ?? undefined}
             fallback={OrganizationUnitTreeConstants.DEFAULT_AVATAR}
             editAriaLabel={t('organizationUnits:edit.page.logoUpdate.label', 'Update Logo')}
-            onSelect={(newLogoUrl: string) =>
+            onSelect={(newLogoUrl: string) => {
+              updateOrganizationUnit.reset(); // a save error is stale once the form changes
               setEditedOU((prev) => {
                 if (newLogoUrl === organizationUnit.logoUrl) {
                   const {logoUrl, ...rest} = prev;
@@ -268,8 +288,8 @@ export default function OrganizationUnitEditPage({
                   return rest;
                 }
                 return {...prev, logoUrl: newLogoUrl};
-              })
-            }
+              });
+            }}
             onSave={handleSave}
           />
         </PageTitle.Avatar>
@@ -474,19 +494,7 @@ export default function OrganizationUnitEditPage({
         organizationUnitId={id ?? null}
         onClose={() => setDeleteDialogOpen(false)}
         onSuccess={handleDeleteSuccess}
-        onError={handleDeleteError}
       />
-
-      <Snackbar
-        open={snackbar.open}
-        autoHideDuration={6000}
-        onClose={() => setSnackbar((prev) => ({...prev, open: false}))}
-        anchorOrigin={{vertical: 'bottom', horizontal: 'right'}}
-      >
-        <Alert onClose={() => setSnackbar((prev) => ({...prev, open: false}))} severity="error" sx={{width: '100%'}}>
-          {snackbar.message}
-        </Alert>
-      </Snackbar>
 
       {/* Floating Action Bar */}
       {hasChanges && (
@@ -497,7 +505,20 @@ export default function OrganizationUnitEditPage({
           savingLabel={t('organizationUnits:edit.actions.saving.label')}
           isSaving={updateOrganizationUnit.isPending}
           saveDisabled={organizationUnit.isReadOnly === true}
-          onReset={() => setEditedOU({})}
+          error={
+            updateOrganizationUnit.error
+              ? getErrorMessage(
+                  updateOrganizationUnit.error,
+                  tForErrors,
+                  'update.error',
+                  'Failed to update organization unit. Please try again.',
+                )
+              : undefined
+          }
+          onReset={() => {
+            setEditedOU({});
+            updateOrganizationUnit.reset();
+          }}
           onSave={() => {
             // Errors are handled in handleSave
             handleSave().catch(() => null);

--- a/frontend/packages/configure-organization-units/src/pages/__tests__/CreateOrganizationUnitPage.test.tsx
+++ b/frontend/packages/configure-organization-units/src/pages/__tests__/CreateOrganizationUnitPage.test.tsx
@@ -248,8 +248,9 @@ describe('CreateOrganizationUnitPage', () => {
     fireEvent.click(createButton);
 
     await waitFor(() => {
-      expect(screen.getByText('Network error')).toBeInTheDocument();
+      expect(screen.getByText('Failed to create organization unit. Please try again.')).toBeInTheDocument();
     });
+    expect(screen.queryByText('Network error')).not.toBeInTheDocument();
   });
 
   it('should close error alert when close button is clicked', async () => {
@@ -272,7 +273,7 @@ describe('CreateOrganizationUnitPage', () => {
     fireEvent.click(createButton);
 
     await waitFor(() => {
-      expect(screen.getByText('Network error')).toBeInTheDocument();
+      expect(screen.getByText('Failed to create organization unit. Please try again.')).toBeInTheDocument();
     });
 
     // Close the alert
@@ -280,8 +281,34 @@ describe('CreateOrganizationUnitPage', () => {
     fireEvent.click(alertCloseButton);
 
     await waitFor(() => {
-      expect(screen.queryByText('Network error')).not.toBeInTheDocument();
+      expect(screen.queryByText('Failed to create organization unit. Please try again.')).not.toBeInTheDocument();
     });
+  });
+
+  it('should clear the create error when a field changes', async () => {
+    mockMutate.mockImplementation((_data, options: {onError: (err: Error) => void}) => {
+      options.onError(new Error('Network error'));
+    });
+
+    renderWithProviders(<CreateOrganizationUnitPage />);
+
+    const nameInput = screen.getByLabelText(/Name/i);
+    fireEvent.change(nameInput, {target: {value: 'Test Organization'}});
+
+    await waitFor(() => {
+      const createButton = screen.getByText(t('common:actions.create'));
+      expect(createButton).not.toBeDisabled();
+    });
+
+    fireEvent.click(screen.getByText(t('common:actions.create')));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to create organization unit. Please try again.')).toBeInTheDocument();
+    });
+
+    fireEvent.change(nameInput, {target: {value: 'Test Organization Updated'}});
+
+    expect(screen.queryByText('Failed to create organization unit. Please try again.')).not.toBeInTheDocument();
   });
 
   it('should include description in request when provided', async () => {

--- a/frontend/packages/configure-organization-units/src/pages/__tests__/OrganizationUnitEditPage.test.tsx
+++ b/frontend/packages/configure-organization-units/src/pages/__tests__/OrganizationUnitEditPage.test.tsx
@@ -57,20 +57,28 @@ vi.mock('@/api/useGetOrganizationUnit', () => ({
 
 // Mock update hook
 const mockMutateAsync = vi.fn();
+const mockUpdateReset = vi.fn();
+const mockUpdateHook: {
+  mutateAsync: typeof mockMutateAsync;
+  isPending: boolean;
+  error: Error | null;
+  reset: typeof mockUpdateReset;
+} = {mutateAsync: mockMutateAsync, isPending: false, error: null, reset: mockUpdateReset};
 vi.mock('@/api/useUpdateOrganizationUnit', () => ({
-  default: () => ({
-    mutateAsync: mockMutateAsync,
-    isPending: false,
-  }),
+  default: () => mockUpdateHook,
 }));
 
 // Mock delete hook
 const mockDeleteMutate = vi.fn();
+const mockDeleteReset = vi.fn();
+const mockDeleteHook: {
+  mutate: typeof mockDeleteMutate;
+  isPending: boolean;
+  error: Error | null;
+  reset: typeof mockDeleteReset;
+} = {mutate: mockDeleteMutate, isPending: false, error: null, reset: mockDeleteReset};
 vi.mock('@/api/useDeleteOrganizationUnit', () => ({
-  default: () => ({
-    mutate: mockDeleteMutate,
-    isPending: false,
-  }),
+  default: () => mockDeleteHook,
 }));
 
 // Mock child hooks
@@ -109,9 +117,11 @@ vi.mock('@thunderid/hooks', async (importOriginal) => {
 });
 
 // Mock EmojiPicker
-vi.mock('@thunderid/components', async () => {
+vi.mock('@thunderid/components', async (importOriginal) => {
   const React = await import('react');
+  const actual = await importOriginal<typeof import('@thunderid/components')>();
   return {
+    ...actual,
     EmojiPicker: vi.fn(() => null),
     UnsavedChangesBar: vi.fn(
       ({
@@ -120,6 +130,7 @@ vi.mock('@thunderid/components', async () => {
         saveLabel,
         savingLabel,
         isSaving,
+        error = undefined,
         onReset,
         onSave,
       }: {
@@ -128,11 +139,13 @@ vi.mock('@thunderid/components', async () => {
         saveLabel: string;
         savingLabel: string;
         isSaving: boolean;
+        error?: string;
         onReset: () => void;
         onSave: () => void;
       }) => (
         <div data-testid="unsaved-changes-bar">
           <span>{message}</span>
+          {error && <span>{error}</span>}
           <button type="button" onClick={onReset}>
             {resetLabel}
           </button>
@@ -219,6 +232,12 @@ describe('OrganizationUnitEditPage', () => {
     mockMutateAsync.mockReset();
     mockRefetch.mockReset();
     mockDeleteMutate.mockReset();
+    mockUpdateReset.mockReset();
+    mockDeleteReset.mockReset();
+    mockUpdateHook.error = null;
+    mockUpdateHook.isPending = false;
+    mockDeleteHook.error = null;
+    mockDeleteHook.isPending = false;
     mockUseLocation.mockReturnValue({
       state: null,
       pathname: '/organization-units/ou-123',
@@ -304,8 +323,26 @@ describe('OrganizationUnitEditPage', () => {
     renderWithProviders(<OrganizationUnitEditPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('Network error')).toBeInTheDocument();
+      expect(screen.getByText(t('organizationUnits:edit.page.errorTitle'))).toBeInTheDocument();
+      expect(screen.getByText('Failed to load organization unit information')).toBeInTheDocument();
     });
+    expect(screen.queryByText('Network error')).not.toBeInTheDocument();
+  });
+
+  it('should retry the query when Refresh is clicked on the read error state', async () => {
+    mockUseGetOrganizationUnit.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Network error'),
+      refetch: mockRefetch,
+    });
+
+    renderWithProviders(<OrganizationUnitEditPage />);
+
+    const refreshButton = await screen.findByRole('button', {name: /refresh/i});
+    fireEvent.click(refreshButton);
+
+    expect(mockRefetch).toHaveBeenCalled();
   });
 
   it('should show not found state when OU is undefined', async () => {
@@ -705,7 +742,7 @@ describe('OrganizationUnitEditPage', () => {
     renderWithProviders(<OrganizationUnitEditPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('Network error')).toBeInTheDocument();
+      expect(screen.getByText(t('organizationUnits:edit.page.errorTitle'))).toBeInTheDocument();
     });
 
     // Click back button
@@ -827,7 +864,7 @@ describe('OrganizationUnitEditPage', () => {
     renderWithProviders(<OrganizationUnitEditPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('Network error')).toBeInTheDocument();
+      expect(screen.getByText(t('organizationUnits:edit.page.errorTitle'))).toBeInTheDocument();
     });
 
     // Click back button - should not throw
@@ -1097,14 +1134,15 @@ describe('OrganizationUnitEditPage', () => {
     });
   });
 
-  describe('Delete Error and Snackbar', () => {
-    it('should show error snackbar when delete fails', async () => {
-      // Mock delete to trigger onError
-      mockDeleteMutate.mockImplementation((_id: string, options: {onError?: (err: Error) => void}) => {
-        options.onError?.(new Error('Delete failed'));
+  describe('Delete Error', () => {
+    it('should keep the dialog open and show the resolved error inline when delete fails', async () => {
+      // The dialog owns the delete mutation itself and reads its `error` state directly,
+      // rather than a parent-forwarded onError callback.
+      mockDeleteMutate.mockImplementation(() => {
+        mockDeleteHook.error = Object.assign(new Error('Delete failed'), {response: {data: {code: 'ERR'}}});
       });
 
-      renderWithProviders(<OrganizationUnitEditPage />);
+      const {rerender} = renderWithProviders(<OrganizationUnitEditPage />);
 
       await waitFor(() => {
         expect(
@@ -1126,10 +1164,12 @@ describe('OrganizationUnitEditPage', () => {
       const confirmDeleteButton = deleteButtons.find((btn) => btn.closest('.MuiDialog-root'));
       expect(confirmDeleteButton).toBeDefined();
       fireEvent.click(confirmDeleteButton!);
+      rerender(<OrganizationUnitEditPage />);
 
-      // Snackbar should appear with error
+      // The dialog stays open and shows the resolved error inline
       await waitFor(() => {
-        expect(screen.getByRole('alert')).toBeInTheDocument();
+        expect(screen.getByText(t('organizationUnits:delete.dialog.message'))).toBeInTheDocument();
+        expect(screen.getByText('Failed to delete organization unit. Please try again.')).toBeInTheDocument();
       });
     });
   });

--- a/frontend/packages/configure-user-types/src/api/useCreateUserType.ts
+++ b/frontend/packages/configure-user-types/src/api/useCreateUserType.ts
@@ -42,8 +42,5 @@ export default function useCreateUserType(): UseMutationResult<ApiUserType, Erro
       });
       showToast(t('create.success'), 'success');
     },
-    onError: () => {
-      showToast(t('create.error'), 'error');
-    },
   });
 }

--- a/frontend/packages/configure-user-types/src/api/useDeleteUserType.ts
+++ b/frontend/packages/configure-user-types/src/api/useDeleteUserType.ts
@@ -37,8 +37,5 @@ export default function useDeleteUserType(): UseMutationResult<void, Error, stri
       });
       showToast(t('delete.success'), 'success');
     },
-    onError: () => {
-      showToast(t('delete.error'), 'error');
-    },
   });
 }

--- a/frontend/packages/configure-user-types/src/api/useUpdateUserType.ts
+++ b/frontend/packages/configure-user-types/src/api/useUpdateUserType.ts
@@ -59,8 +59,5 @@ export default function useUpdateUserType(): UseMutationResult<ApiUserType, Erro
       });
       showToast(t('update.success'), 'success');
     },
-    onError: () => {
-      showToast(t('update.error'), 'error');
-    },
   });
 }

--- a/frontend/packages/configure-user-types/src/components/UserTypesList.tsx
+++ b/frontend/packages/configure-user-types/src/components/UserTypesList.tsx
@@ -1,14 +1,15 @@
 // Copyright 2025 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import {ReadErrorState} from '@thunderid/components';
 import {useDataGridLocaleText} from '@thunderid/hooks';
 import {useLogger} from '@thunderid/logger/react';
+import {getErrorMessage} from '@thunderid/utils';
 import {
   Chip,
   IconButton,
   Tooltip,
   Typography,
-  Snackbar,
   Alert,
   ListingTable,
   Dialog,
@@ -39,27 +40,11 @@ export default function UserTypesList() {
   const routes = useUserTypeRoutes();
   const dataGridLocaleText = useDataGridLocaleText();
 
-  const {data: userTypesData, isLoading, error: userTypesRequestError} = useGetUserTypes();
+  const {data: userTypesData, isLoading, error: userTypesRequestError, refetch} = useGetUserTypes();
   const deleteUserTypeMutation = useDeleteUserType();
 
-  const error = userTypesRequestError;
-
-  const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [selectedUserTypeId, setSelectedUserTypeId] = useState<string | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-
-  // Show snackbar when error occurs
-  const [prevError, setPrevError] = useState<typeof error>(null);
-  if (prevError !== error) {
-    setPrevError(error);
-    if (error) {
-      setSnackbarOpen(true);
-    }
-  }
-
-  const handleCloseSnackbar = () => {
-    setSnackbarOpen(false);
-  };
 
   const handleDeleteClick = useCallback((userTypeId: string): void => {
     setSelectedUserTypeId(userTypeId);
@@ -190,6 +175,18 @@ export default function UserTypesList() {
     [t, handleDeleteClick, handleViewClick],
   );
 
+  if (userTypesRequestError) {
+    return (
+      <ReadErrorState
+        error={userTypesRequestError}
+        t={(key, options) => t(key.includes(':') ? key : `userTypes:${key}`, options)}
+        variant="block"
+        title={t('userTypes:listing.error', 'Failed to load user types')}
+        onRetry={() => void refetch()}
+      />
+    );
+  }
+
   return (
     <>
       <ListingTable.Provider variant="data-grid-card" loading={isLoading}>
@@ -227,7 +224,12 @@ export default function UserTypesList() {
           {deleteUserTypeMutation.error && (
             <Alert severity="error" sx={{mt: 2}}>
               <Typography variant="body2" sx={{fontWeight: 'bold'}}>
-                {deleteUserTypeMutation.error.message}
+                {getErrorMessage(
+                  deleteUserTypeMutation.error,
+                  (key, options) => t(key.includes(':') ? key : `userTypes:${key}`, options),
+                  'delete.error',
+                  'Failed to delete user type. Please try again.',
+                )}
               </Typography>
             </Alert>
           )}
@@ -250,17 +252,6 @@ export default function UserTypesList() {
           </Button>
         </DialogActions>
       </Dialog>
-
-      <Snackbar
-        open={snackbarOpen}
-        autoHideDuration={6000}
-        onClose={handleCloseSnackbar}
-        anchorOrigin={{vertical: 'bottom', horizontal: 'right'}}
-      >
-        <Alert onClose={handleCloseSnackbar} severity="error" sx={{width: '100%'}}>
-          {error?.message ?? t('common:messages.saveError')}
-        </Alert>
-      </Snackbar>
     </>
   );
 }

--- a/frontend/packages/configure-user-types/src/components/__tests__/UserTypesList.test.tsx
+++ b/frontend/packages/configure-user-types/src/components/__tests__/UserTypesList.test.tsx
@@ -17,6 +17,7 @@ const {mockLoggerError} = vi.hoisted(() => ({
 
 const mockNavigate = vi.fn();
 const mockMutateAsync = vi.fn();
+const mockRefetchUserTypes = vi.fn();
 
 type MockDataGridRow = UserTypeListItem & Record<string, unknown>;
 
@@ -114,6 +115,21 @@ vi.mock('@wso2/oxygen-ui', async () => {
         </>
       ),
       RowActions: ({children}: {children: ReactNode}): ReactElement => children as ReactElement,
+      EmptyState: ({
+        title = undefined,
+        description = undefined,
+        action = undefined,
+      }: {
+        title?: string;
+        description?: string;
+        action?: ReactNode;
+      }) => (
+        <div>
+          {title && <div>{title}</div>}
+          {description && <div>{description}</div>}
+          {action}
+        </div>
+      ),
     },
   };
 });
@@ -184,6 +200,7 @@ describe('UserTypesList', () => {
       data: mockUserTypesData,
       isLoading: false,
       error: null,
+      refetch: mockRefetchUserTypes,
     } as unknown as ReturnType<typeof useGetUserTypesHook>);
     mockUseDeleteUserType.mockReturnValue({
       mutateAsync: mockMutateAsync,
@@ -255,13 +272,14 @@ describe('UserTypesList', () => {
     expect(screen.getByTestId('listing-table-provider')).toHaveAttribute('data-loading', 'true');
   });
 
-  it('displays error in snackbar', async () => {
+  it('renders a read error state in place of the grid', async () => {
     const error = new Error('Failed to load user types');
 
     mockUseGetUserTypes.mockReturnValue({
       data: undefined,
       isLoading: false,
       error,
+      refetch: mockRefetchUserTypes,
     } as unknown as ReturnType<typeof useGetUserTypesHook>);
 
     render(<UserTypesList />);
@@ -269,6 +287,26 @@ describe('UserTypesList', () => {
     await waitFor(() => {
       expect(screen.getByText('Failed to load user types')).toBeInTheDocument();
     });
+    expect(screen.queryByTestId('data-grid')).not.toBeInTheDocument();
+  });
+
+  it('retries the query when Refresh is clicked on the read error state', async () => {
+    const user = userEvent.setup();
+    const error = new Error('Failed to load user types');
+
+    mockUseGetUserTypes.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error,
+      refetch: mockRefetchUserTypes,
+    } as unknown as ReturnType<typeof useGetUserTypesHook>);
+
+    render(<UserTypesList />);
+
+    const refreshButton = await screen.findByRole('button', {name: /refresh/i});
+    await user.click(refreshButton);
+
+    expect(mockRefetchUserTypes).toHaveBeenCalled();
   });
 
   it('renders inline delete buttons for each row', () => {
@@ -362,7 +400,7 @@ describe('UserTypesList', () => {
     await user.click(deleteButtons[0]);
 
     await waitFor(() => {
-      expect(screen.getByText('Failed to delete')).toBeInTheDocument();
+      expect(screen.getByText('Failed to delete user type. Please try again.')).toBeInTheDocument();
     });
   });
 
@@ -375,30 +413,6 @@ describe('UserTypesList', () => {
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('/user-types/schema1');
-    });
-  });
-
-  it('closes snackbar when close button is clicked', async () => {
-    const user = userEvent.setup();
-    const error = new Error('Failed to load user types');
-
-    mockUseGetUserTypes.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      error,
-    } as unknown as ReturnType<typeof useGetUserTypesHook>);
-
-    render(<UserTypesList />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Failed to load user types')).toBeInTheDocument();
-    });
-
-    const closeButton = screen.getByLabelText(/close/i);
-    await user.click(closeButton);
-
-    await waitFor(() => {
-      expect(screen.queryByText('Failed to load user types')).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/packages/configure-user-types/src/components/edit-user-type/UserTypeDeleteDialog.tsx
+++ b/frontend/packages/configure-user-types/src/components/edit-user-type/UserTypeDeleteDialog.tsx
@@ -1,6 +1,7 @@
 // Copyright 2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import {getErrorMessage} from '@thunderid/utils';
 import {Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button, Alert} from '@wso2/oxygen-ui';
 import {useState, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
@@ -43,7 +44,14 @@ export default function UserTypeDeleteDialog({
         onSuccess?.();
       },
       onError: (err: Error) => {
-        setError(err.message ?? t('userTypes:delete.error', 'Failed to delete user type'));
+        setError(
+          getErrorMessage(
+            err,
+            (key, options) => t(key.includes(':') ? key : `userTypes:${key}`, options),
+            'delete.error',
+            'Failed to delete user type. Please try again.',
+          ),
+        );
       },
     });
   };

--- a/frontend/packages/configure-user-types/src/components/edit-user-type/__tests__/UserTypeDeleteDialog.test.tsx
+++ b/frontend/packages/configure-user-types/src/components/edit-user-type/__tests__/UserTypeDeleteDialog.test.tsx
@@ -118,7 +118,7 @@ describe('UserTypeDeleteDialog', () => {
     await user.click(screen.getByRole('button', {name: /^delete$/i}));
 
     await waitFor(() => {
-      expect(screen.getByText('Delete failed')).toBeInTheDocument();
+      expect(screen.getByText('Failed to delete user type. Please try again.')).toBeInTheDocument();
     });
   });
 

--- a/frontend/packages/configure-user-types/src/pages/CreateUserTypePage.tsx
+++ b/frontend/packages/configure-user-types/src/pages/CreateUserTypePage.tsx
@@ -7,18 +7,8 @@ import {
   useHasMultipleOUs,
 } from '@thunderid/configure-organization-units';
 import {useLogger} from '@thunderid/logger/react';
-import {
-  Box,
-  Stack,
-  Button,
-  CircularProgress,
-  IconButton,
-  LinearProgress,
-  Typography,
-  Alert,
-  Snackbar,
-  AppBreadcrumbs,
-} from '@wso2/oxygen-ui';
+import {getErrorMessage} from '@thunderid/utils';
+import {Box, Stack, Button, CircularProgress, IconButton, LinearProgress, Alert, AppBreadcrumbs} from '@wso2/oxygen-ui';
 import {Home, X} from '@wso2/oxygen-ui-icons-react';
 import {useState, useCallback, useEffect, useMemo} from 'react';
 import type {JSX} from 'react';
@@ -93,9 +83,6 @@ export default function CreateUserTypePage(): JSX.Element {
     return map;
   }, [t, hasMultipleOUs]);
 
-  const [validationError, setValidationError] = useState<string | null>(null);
-  const [snackbarOpen, setSnackbarOpen] = useState(false);
-
   const [stepReady, setStepReady] = useState<Record<UserTypeCreateFlowStep, boolean>>({
     ORGANIZATION_UNIT: false,
     NAME: false,
@@ -105,6 +92,66 @@ export default function CreateUserTypePage(): JSX.Element {
   const handleClose = (): void => {
     void navigate(routes.list());
   };
+
+  // A create failure is stale once the user edits any field, so every field-change path below
+  // clears both the validation error and the mutation's own error before applying the change.
+  // Only reset the mutation once it has actually failed: resetting while it's still pending would
+  // flip isPending back to false and re-enable the submit button before the in-flight request
+  // settles, letting the user fire a second concurrent create.
+  const clearCreateError = useCallback((): void => {
+    setError(null);
+    if (createUserTypeMutation.isError) {
+      createUserTypeMutation.reset();
+    }
+  }, [setError, createUserTypeMutation]);
+
+  const handleNameChange = useCallback(
+    (newName: string): void => {
+      clearCreateError();
+      setName(newName);
+    },
+    [clearCreateError, setName],
+  );
+
+  const handleOuIdChange = useCallback(
+    (newOuId: string): void => {
+      clearCreateError();
+      setOuId(newOuId);
+    },
+    [clearCreateError, setOuId],
+  );
+
+  const handleAllowSelfRegistrationChange = useCallback(
+    (allow: boolean): void => {
+      clearCreateError();
+      setAllowSelfRegistration(allow);
+    },
+    [clearCreateError, setAllowSelfRegistration],
+  );
+
+  const handlePropertiesChange = useCallback(
+    (newProperties: typeof properties): void => {
+      clearCreateError();
+      setProperties(newProperties);
+    },
+    [clearCreateError, setProperties],
+  );
+
+  const handleEnumInputChange = useCallback(
+    (newEnumInput: typeof enumInput): void => {
+      clearCreateError();
+      setEnumInput(newEnumInput);
+    },
+    [clearCreateError, setEnumInput],
+  );
+
+  const handleDisplayAttributeChange = useCallback(
+    (newDisplayAttribute: string): void => {
+      clearCreateError();
+      setDisplayAttribute(newDisplayAttribute);
+    },
+    [clearCreateError, setDisplayAttribute],
+  );
 
   const handleStepReadyChange = useCallback((step: UserTypeCreateFlowStep, isReady: boolean): void => {
     setStepReady((prev) => ({
@@ -128,27 +175,23 @@ export default function CreateUserTypePage(): JSX.Element {
   );
 
   const handleSubmit = async (): Promise<void> => {
-    setValidationError(null);
     setError(null);
 
     // Validate
     if (!name.trim()) {
-      setValidationError(t('userTypes:validationErrors.nameRequired'));
-      setSnackbarOpen(true);
+      setError(t('userTypes:validationErrors.nameRequired', 'Please enter a user type name'));
       return;
     }
 
     const trimmedOuId = ouId.trim();
     if (!trimmedOuId) {
-      setValidationError(t('userTypes:validationErrors.ouIdRequired'));
-      setSnackbarOpen(true);
+      setError(t('userTypes:validationErrors.ouIdRequired', 'Please provide an organization unit ID'));
       return;
     }
 
     const validProperties = properties.filter((prop) => prop.name.trim());
     if (validProperties.length === 0) {
-      setValidationError(t('userTypes:validationErrors.propertiesRequired'));
-      setSnackbarOpen(true);
+      setError(t('userTypes:validationErrors.propertiesRequired', 'Please add at least one property'));
       return;
     }
 
@@ -156,8 +199,12 @@ export default function CreateUserTypePage(): JSX.Element {
     const propertyNames = validProperties.map((prop) => prop.name.trim());
     const duplicates = propertyNames.filter((propName, index) => propertyNames.indexOf(propName) !== index);
     if (duplicates.length > 0) {
-      setValidationError(t('userTypes:validationErrors.duplicateProperties', {duplicates: duplicates.join(', ')}));
-      setSnackbarOpen(true);
+      setError(
+        t('userTypes:validationErrors.duplicateProperties', {
+          duplicates: duplicates.join(', '),
+          defaultValue: 'Duplicate property names found: {{duplicates}}',
+        }),
+      );
       return;
     }
 
@@ -221,6 +268,25 @@ export default function CreateUserTypePage(): JSX.Element {
     }
   };
 
+  // Resolves an error through the `userTypes` catalog. `t` defaults to the `common` namespace, so
+  // this forwards explicit `ns:` prefixes unchanged and prefixes bare keys with `userTypes:`, per
+  // getErrorMessage's namespace-resolution contract.
+  const tForErrors = (key: string, options?: Record<string, unknown>): string =>
+    t(key.includes(':') ? key : `userTypes:${key}`, options);
+
+  // Precedence: a validation error (raised at submit time) wins over the mutation's own error, so
+  // the user always sees the most actionable message for their current attempt.
+  const displayError =
+    error ??
+    (createUserTypeMutation.error
+      ? getErrorMessage(
+          createUserTypeMutation.error,
+          tForErrors,
+          'create.error',
+          'Failed to create user type. Please try again.',
+        )
+      : null);
+
   const handleNextStep = (): void => {
     switch (currentStep) {
       case UserTypeCreateFlowStep.ORGANIZATION_UNIT:
@@ -258,7 +324,7 @@ export default function CreateUserTypePage(): JSX.Element {
         return (
           <ConfigureName
             name={name}
-            onNameChange={setName}
+            onNameChange={handleNameChange}
             onReadyChange={handleNameStepReadyChange}
             hasMultipleOUs={hasMultipleOUs}
             organizationUnitName={resolvedOrganizationUnit?.name}
@@ -266,18 +332,18 @@ export default function CreateUserTypePage(): JSX.Element {
             isOrganizationUnitLoading={isResolvedOuLoading}
             onChangeOu={() => setCurrentStep(UserTypeCreateFlowStep.ORGANIZATION_UNIT)}
             allowSelfRegistration={allowSelfRegistration}
-            onAllowSelfRegistrationChange={setAllowSelfRegistration}
+            onAllowSelfRegistrationChange={handleAllowSelfRegistrationChange}
           />
         );
       case UserTypeCreateFlowStep.PROPERTIES:
         return (
           <ConfigureProperties
             properties={properties}
-            onPropertiesChange={setProperties}
+            onPropertiesChange={handlePropertiesChange}
             enumInput={enumInput}
-            onEnumInputChange={setEnumInput}
+            onEnumInputChange={handleEnumInputChange}
             displayAttribute={displayAttribute}
-            onDisplayAttributeChange={setDisplayAttribute}
+            onDisplayAttributeChange={handleDisplayAttributeChange}
             onReadyChange={handlePropertiesStepReadyChange}
             userTypeName={name.trim()}
           />
@@ -295,10 +361,6 @@ export default function CreateUserTypePage(): JSX.Element {
   const getBreadcrumbSteps = (): UserTypeCreateFlowStep[] => {
     const currentIndex = activeSteps.indexOf(currentStep);
     return activeSteps.slice(0, currentIndex + 1);
-  };
-
-  const handleCloseSnackbar = () => {
-    setSnackbarOpen(false);
   };
 
   const isLastStep = currentStep === UserTypeCreateFlowStep.PROPERTIES;
@@ -324,7 +386,7 @@ export default function CreateUserTypePage(): JSX.Element {
           "Choose the organization unit that will own this user type. You can't change this once created.",
         )}
         value={ouId}
-        onChange={setOuId}
+        onChange={handleOuIdChange}
         onBack={handleClose}
         onContinue={handleNextStep}
         backLabel={t('common:actions.back', 'Back')}
@@ -383,18 +445,17 @@ export default function CreateUserTypePage(): JSX.Element {
                 flexDirection: 'column',
               }}
             >
-              {/* Error Alerts */}
-              {error && (
-                <Alert severity="error" sx={{my: 3}} onClose={() => setError(null)}>
-                  {error}
-                </Alert>
-              )}
-
-              {createUserTypeMutation.error && (
-                <Alert severity="error" sx={{mb: 3}}>
-                  <Typography variant="body2" sx={{fontWeight: 'bold', mb: 0.5}}>
-                    {createUserTypeMutation.error.message}
-                  </Typography>
+              {/* Error Alert — validation error takes precedence over the mutation's own error */}
+              {displayError && (
+                <Alert
+                  severity="error"
+                  sx={{my: 3}}
+                  onClose={() => {
+                    setError(null);
+                    createUserTypeMutation.reset();
+                  }}
+                >
+                  {displayError}
                 </Alert>
               )}
 
@@ -425,18 +486,6 @@ export default function CreateUserTypePage(): JSX.Element {
           </Box>
         </Box>
       </Box>
-
-      {/* Validation Error Snackbar */}
-      <Snackbar
-        open={snackbarOpen}
-        autoHideDuration={6000}
-        onClose={handleCloseSnackbar}
-        anchorOrigin={{vertical: 'top', horizontal: 'right'}}
-      >
-        <Alert onClose={handleCloseSnackbar} severity="error" sx={{width: '100%'}}>
-          {validationError}
-        </Alert>
-      </Snackbar>
     </Box>
   );
 }

--- a/frontend/packages/configure-user-types/src/pages/ViewUserTypePage.tsx
+++ b/frontend/packages/configure-user-types/src/pages/ViewUserTypePage.tsx
@@ -1,10 +1,9 @@
 // Copyright 2025-2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import {PageLoadingAnimation, UnsavedChangesBar} from '@thunderid/components';
-import {useToast} from '@thunderid/contexts';
+import {PageLoadingAnimation, ReadErrorState, UnsavedChangesBar} from '@thunderid/components';
 import {useLogger} from '@thunderid/logger/react';
-import {isEqualIgnoringEmpty} from '@thunderid/utils';
+import {getErrorMessage, isEqualIgnoringEmpty} from '@thunderid/utils';
 import {
   Box,
   Stack,
@@ -128,16 +127,27 @@ export default function ViewUserTypePage(): JSX.Element {
   const navigate = useNavigate();
   const {t} = useTranslation();
   const logger = useLogger('ViewUserTypePage');
-  const {showToast} = useToast();
   const {id} = useParams<{id: string}>();
   const routes = useUserTypeRoutes();
   const listUrl = routes.list();
 
-  const {data: userType, isLoading, error: fetchError} = useGetUserType(id);
+  const {data: userType, isLoading, error: fetchError, refetch} = useGetUserType(id);
   const updateUserTypeMutation = useUpdateUserType();
+
+  // Resolves an error through the `userTypes` catalog. `t` defaults to the `common` namespace, so
+  // this forwards explicit `ns:` prefixes unchanged and prefixes bare keys with `userTypes:`,
+  // per getErrorMessage's namespace-resolution contract.
+  const tForErrors = useCallback(
+    (key: string, options?: Record<string, unknown>): string =>
+      t(key.includes(':') ? key : `userTypes:${key}`, options),
+    [t],
+  );
 
   // Tab state
   const [activeTab, setActiveTab] = useState(0);
+
+  // Validation error from the last save attempt. Takes precedence over the mutation's own error.
+  const [validationError, setValidationError] = useState<string | null>(null);
 
   // Inline name editing
   const [isEditingName, setIsEditingName] = useState(false);
@@ -218,17 +228,28 @@ export default function ViewUserTypePage(): JSX.Element {
     setActiveTab(newValue);
   };
 
-  const handleFieldChange = useCallback((field: string, value: unknown): void => {
-    setEditedUserType((prev) => ({...prev, [field]: value}));
-  }, []);
+  const handleFieldChange = useCallback(
+    (field: string, value: unknown): void => {
+      updateUserTypeMutation.reset(); // a save error is stale once the form changes
+      setValidationError(null);
+      setEditedUserType((prev) => ({...prev, [field]: value}));
+    },
+    [updateUserTypeMutation],
+  );
 
-  const handlePropertiesChange = useCallback((newProperties: SchemaPropertyInput[]): void => {
-    setEditedProperties(newProperties);
-  }, []);
+  const handlePropertiesChange = useCallback(
+    (newProperties: SchemaPropertyInput[]): void => {
+      updateUserTypeMutation.reset(); // a save error is stale once the form changes
+      setValidationError(null);
+      setEditedProperties(newProperties);
+    },
+    [updateUserTypeMutation],
+  );
 
   const handleReset = useCallback((): void => {
     setEditedUserType({});
     setEditedProperties(null);
+    setValidationError(null);
     updateUserTypeMutation.reset();
   }, [updateUserTypeMutation]);
 
@@ -256,17 +277,17 @@ export default function ViewUserTypePage(): JSX.Element {
       setEditedProperties(null);
     } catch (err: unknown) {
       logger.error('Failed to update user type', {error: err});
-      const message = err instanceof Error ? err.message : t('userTypes:edit.saveError', 'Failed to save user type');
-      showToast(message, 'error');
     }
-  }, [id, userType, editedUserType, effectiveProperties, updateUserTypeMutation, logger, showToast, t]);
+  }, [id, userType, editedUserType, effectiveProperties, updateUserTypeMutation, logger]);
 
   const handleSave = useCallback(async (): Promise<void> => {
     if (!id || !userType) return;
 
+    setValidationError(null);
+
     const ouId = (editedUserType.ouId ?? userType.ouId).trim();
     if (!ouId) {
-      showToast(t('userTypes:validationErrors.ouIdRequired'), 'error');
+      setValidationError(t('userTypes:validationErrors.ouIdRequired', 'Please provide an organization unit ID'));
       return;
     }
 
@@ -274,9 +295,11 @@ export default function ViewUserTypePage(): JSX.Element {
     const trimmedNames = effectiveProperties.filter((p) => p.name.trim()).map((p) => p.name.trim());
     const duplicates = trimmedNames.filter((n, i) => trimmedNames.indexOf(n) !== i);
     if (duplicates.length > 0) {
-      showToast(
-        t('userTypes:validationErrors.duplicateProperties', {duplicates: [...new Set(duplicates)].join(', ')}),
-        'error',
+      setValidationError(
+        t('userTypes:validationErrors.duplicateProperties', {
+          duplicates: [...new Set(duplicates)].join(', '),
+          defaultValue: 'Duplicate property names found: {{duplicates}}',
+        }),
       );
       return;
     }
@@ -293,7 +316,7 @@ export default function ViewUserTypePage(): JSX.Element {
     }
 
     await performSave();
-  }, [id, userType, editedUserType, effectiveProperties, baseProperties, showToast, t, performSave]);
+  }, [id, userType, editedUserType, effectiveProperties, baseProperties, t, performSave]);
 
   const handleConfirmSchemaChange = useCallback((): void => {
     setShowSchemaWarning(false);
@@ -317,17 +340,29 @@ export default function ViewUserTypePage(): JSX.Element {
   if (fetchError) {
     return (
       <PageContent>
-        <Alert severity="error" sx={{mb: 2}}>
-          {fetchError.message ?? t('userTypes:edit.loadError', 'Failed to load user type information')}
-        </Alert>
-        <Button
-          onClick={() => {
-            handleBack().catch(() => null);
-          }}
-          startIcon={<ArrowLeft size={16} />}
-        >
-          {t('userTypes:edit.back', 'Back to User Types')}
-        </Button>
+        <ReadErrorState
+          error={fetchError}
+          t={tForErrors}
+          variant="block"
+          title={t('userTypes:edit.loadErrorTitle', 'Failed to load user type')}
+          fallbackKey="userTypes:edit.loadError"
+          fallbackDefaultValue="Failed to load user type information"
+          action={
+            <Stack direction="row" spacing={1} justifyContent="center">
+              <Button variant="outlined" onClick={() => void refetch()}>
+                {t('common:actions.refresh', 'Refresh')}
+              </Button>
+              <Button
+                onClick={() => {
+                  handleBack().catch(() => null);
+                }}
+                startIcon={<ArrowLeft size={16} />}
+              >
+                {t('userTypes:edit.back', 'Back to User Types')}
+              </Button>
+            </Stack>
+          }
+        />
       </PageContent>
     );
   }
@@ -505,6 +540,17 @@ export default function ViewUserTypePage(): JSX.Element {
           savingLabel={t('common:status.saving', 'Saving...')}
           isSaving={updateUserTypeMutation.isPending}
           saveDisabled={userType.isReadOnly === true}
+          error={
+            validationError ??
+            (updateUserTypeMutation.error
+              ? getErrorMessage(
+                  updateUserTypeMutation.error,
+                  tForErrors,
+                  'update.error',
+                  'Failed to update user type. Please try again.',
+                )
+              : undefined)
+          }
           onReset={handleReset}
           onSave={() => {
             handleSave().catch(() => null);

--- a/frontend/packages/configure-user-types/src/pages/__tests__/CreateUserTypePage.test.tsx
+++ b/frontend/packages/configure-user-types/src/pages/__tests__/CreateUserTypePage.test.tsx
@@ -674,7 +674,52 @@ describe('CreateUserTypePage', () => {
 
     await pickOrganizationUnit(user);
 
-    expect(screen.getByText('Failed to create user type')).toBeInTheDocument();
+    expect(screen.getByText('Failed to create user type. Please try again.')).toBeInTheDocument();
+  });
+
+  it('resets the create error as soon as a field changes', async () => {
+    const user = userEvent.setup();
+    const mockReset = vi.fn();
+    const error = new Error('Failed to create user type');
+
+    mockUseCreateUserType.mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+      error,
+      isError: true,
+      reset: mockReset,
+    } as unknown as ReturnType<typeof useCreateUserTypeHook>);
+
+    renderPage();
+
+    await pickOrganizationUnit(user);
+
+    expect(screen.getByText('Failed to create user type. Please try again.')).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(/User Type Name/i), 'A');
+
+    expect(mockReset).toHaveBeenCalled();
+  });
+
+  it('does not reset a pending create mutation when a field changes', async () => {
+    const user = userEvent.setup();
+    const mockReset = vi.fn();
+
+    mockUseCreateUserType.mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: true,
+      error: null,
+      isError: false,
+      reset: mockReset,
+    } as unknown as ReturnType<typeof useCreateUserTypeHook>);
+
+    renderPage();
+
+    await pickOrganizationUnit(user);
+
+    await user.type(screen.getByLabelText(/User Type Name/i), 'A');
+
+    expect(mockReset).not.toHaveBeenCalled();
   });
 
   it('shows loading state during submission on last step', async () => {

--- a/frontend/packages/configure-user-types/src/pages/__tests__/ViewUserTypePage.test.tsx
+++ b/frontend/packages/configure-user-types/src/pages/__tests__/ViewUserTypePage.test.tsx
@@ -61,7 +61,6 @@ const mockNavigate = vi.fn();
 const mockRefetch = vi.fn();
 const mockUpdateMutateAsync = vi.fn();
 const mockResetUpdateError = vi.fn();
-const mockShowToast = vi.fn();
 
 // Mock react-router
 vi.mock('react-router', async () => {
@@ -116,15 +115,6 @@ vi.mock('@thunderid/configure-organization-units', () => ({
     </div>
   ),
 }));
-
-// Mock shared-contexts (useToast)
-vi.mock('@thunderid/contexts', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@thunderid/contexts')>();
-  return {
-    ...actual,
-    useToast: () => ({showToast: mockShowToast}),
-  };
-});
 
 /**
  * Helper to navigate to the Schema tab.
@@ -1271,9 +1261,15 @@ describe('ViewUserTypePage', () => {
       });
     });
 
-    it('handles save error and shows toast', async () => {
+    it('shows the mutation error inline via the unsaved changes bar', async () => {
       const user = userEvent.setup();
       mockUpdateMutateAsync.mockRejectedValue(new Error('Save failed'));
+      mockUseUpdateUserType.mockReturnValue({
+        mutateAsync: mockUpdateMutateAsync,
+        error: new Error('Save failed'),
+        reset: mockResetUpdateError,
+        isPending: false,
+      });
 
       render(<ViewUserTypePage />);
 
@@ -1284,8 +1280,24 @@ describe('ViewUserTypePage', () => {
       await user.click(saveButton);
 
       await waitFor(() => {
-        expect(mockShowToast).toHaveBeenCalledWith('Save failed', 'error');
+        expect(screen.getByText('Failed to update user type. Please try again.')).toBeInTheDocument();
       });
+    });
+
+    it('resets the save error as soon as a field changes', async () => {
+      const user = userEvent.setup();
+      mockUseUpdateUserType.mockReturnValue({
+        mutateAsync: mockUpdateMutateAsync,
+        error: new Error('Save failed'),
+        reset: mockResetUpdateError,
+        isPending: false,
+      });
+
+      render(<ViewUserTypePage />);
+
+      await user.click(screen.getByTestId('select-ou-child'));
+
+      expect(mockResetUpdateError).toHaveBeenCalled();
     });
 
     it('shows validation error when saving with empty organization unit', async () => {
@@ -1321,7 +1333,7 @@ describe('ViewUserTypePage', () => {
       await user.click(saveButton);
 
       await waitFor(() => {
-        expect(mockShowToast).toHaveBeenCalledWith('Please provide an organization unit ID', 'error');
+        expect(screen.getByText('Please provide an organization unit ID')).toBeInTheDocument();
       });
 
       expect(mockUpdateMutateAsync).not.toHaveBeenCalled();
@@ -1614,7 +1626,7 @@ describe('ViewUserTypePage', () => {
   });
 
   describe('Save Error Handling', () => {
-    it('handles non-Error save rejection with fallback message', async () => {
+    it('handles a non-Error save rejection without crashing', async () => {
       const user = userEvent.setup();
       mockUpdateMutateAsync.mockRejectedValue('string error');
 
@@ -1626,8 +1638,11 @@ describe('ViewUserTypePage', () => {
       await user.click(saveButton);
 
       await waitFor(() => {
-        expect(mockShowToast).toHaveBeenCalledWith(expect.stringContaining('Failed to save user type'), 'error');
+        expect(mockUpdateMutateAsync).toHaveBeenCalled();
       });
+      // The unsaved changes bar stays up so the user can retry, since a non-Error
+      // rejection carries no message to resolve into the mutation's own error state.
+      expect(screen.getByText('You have unsaved changes')).toBeInTheDocument();
     });
   });
 

--- a/frontend/packages/configure-users/src/components/UsersList.tsx
+++ b/frontend/packages/configure-users/src/components/UsersList.tsx
@@ -1,12 +1,11 @@
 // Copyright 2025-2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import {ResourceAvatar, getInitials} from '@thunderid/components';
+import {ReadErrorState, ResourceAvatar, getInitials} from '@thunderid/components';
 import {useDataGridLocaleText} from '@thunderid/hooks';
 import {useLogger} from '@thunderid/logger/react';
-import {getErrorMessage} from '@thunderid/utils';
-import {Button, IconButton, Tooltip, Typography, ListingTable, DataGrid} from '@wso2/oxygen-ui';
-import {AlertCircle, Eye, Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
+import {IconButton, Tooltip, Typography, ListingTable, DataGrid} from '@wso2/oxygen-ui';
+import {Eye, Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
 import {useMemo, useState, useCallback} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
@@ -151,15 +150,12 @@ export default function UsersList() {
 
   if (error) {
     return (
-      <ListingTable.EmptyState
-        illustration={<AlertCircle size={40} />}
+      <ReadErrorState
+        error={error}
+        t={t}
+        variant="block"
         title={t('users:listing.error', 'Failed to load users')}
-        description={getErrorMessage(error, t, 'common:messages.somethingWentWrong', 'Something went wrong')}
-        action={
-          <Button variant="outlined" onClick={() => void refetch()}>
-            {t('common:actions.refresh', 'Refresh')}
-          </Button>
-        }
+        onRetry={() => void refetch()}
       />
     );
   }

--- a/frontend/packages/configure-users/src/pages/UserEditPage.tsx
+++ b/frontend/packages/configure-users/src/pages/UserEditPage.tsx
@@ -3,6 +3,7 @@
 
 import {
   PageLoadingAnimation,
+  ReadErrorState,
   ResourceAvatar,
   SettingsCard,
   UnsavedChangesBar,
@@ -29,9 +30,8 @@ import {
   PageTitle,
   FormControl,
   FormLabel,
-  ListingTable,
 } from '@wso2/oxygen-ui';
-import {AlertCircle, ArrowLeft, Copy, Check} from '@wso2/oxygen-ui-icons-react';
+import {ArrowLeft, Copy, Check} from '@wso2/oxygen-ui-icons-react';
 import {useState, useEffect, useMemo, useCallback, useRef, type SyntheticEvent, type ReactNode, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Link, useNavigate, useParams} from 'react-router';
@@ -96,7 +96,12 @@ export default function UserEditPage() {
   const updateUserMutation = useUpdateUser();
 
   // Get all schemas to find the schema ID from the schema name
-  const {data: userTypeList} = useGetUserTypes();
+  const {
+    data: userTypeList,
+    isLoading: isUserTypeListLoading,
+    error: userTypeListError,
+    refetch: refetchUserTypeList,
+  } = useGetUserTypes();
 
   // Find the schema ID based on the user's type (which is the schema name)
   const matchedSchema = userTypeList?.types?.find((s) => s.name === user?.type);
@@ -205,29 +210,28 @@ export default function UserEditPage() {
   };
 
   // Loading state
-  if (isUserLoading || isSchemaLoading) {
+  if (isUserLoading || isUserTypeListLoading || isSchemaLoading) {
     return <PageLoadingAnimation />;
   }
 
   // Error state
-  if (userError ?? schemaError) {
+  if (userError ?? userTypeListError ?? schemaError) {
     return (
       <PageContent>
-        <ListingTable.EmptyState
-          illustration={<AlertCircle size={40} />}
-          title={getUserErrorMessage(
-            (userError ?? schemaError)!,
-            (key, options) => t(key.includes(':') ? key : `users:${key}`, options),
-            'manageUser.loadError',
-            'Failed to load user information',
-          )}
+        <ReadErrorState
+          error={(userError ?? userTypeListError ?? schemaError)!}
+          t={(key, options) => t(key.includes(':') ? key : `users:${key}`, options)}
+          resolveErrorMessage={getUserErrorMessage}
+          variant="block"
+          title={t('users:manageUser.loadError', 'Failed to load user information')}
           action={
             <Stack direction="row" spacing={1} justifyContent="center">
               <Button
                 variant="outlined"
                 onClick={() => {
-                  // The error state covers both queries, so retry only the one that failed.
+                  // The error state covers all three queries, so retry only the one(s) that failed.
                   if (userError) void refetch();
+                  if (userTypeListError) void refetchUserTypeList();
                   if (schemaError) void refetchUserType();
                 }}
               >

--- a/frontend/packages/configure-users/src/pages/__tests__/UserEditPage.test.tsx
+++ b/frontend/packages/configure-users/src/pages/__tests__/UserEditPage.test.tsx
@@ -69,6 +69,7 @@ interface UseGetUserTypesReturn {
   data: UserTypeListResponse | undefined;
   isLoading: boolean;
   error: Error | null;
+  refetch: ReturnType<typeof vi.fn>;
 }
 
 interface UseGetUserTypeReturn {
@@ -102,6 +103,7 @@ interface UseDeleteUserReturn {
 }
 
 const mockRefetch = vi.fn();
+const mockRefetchUserTypes = vi.fn();
 const mockUseGetUser = vi.fn<() => UseGetUserReturn>();
 const mockUseGetUserTypes = vi.fn<() => UseGetUserTypesReturn>();
 const mockUseGetUserType = vi.fn<() => UseGetUserTypeReturn>();
@@ -236,6 +238,7 @@ describe('UserEditPage', () => {
       data: mockSchemasData,
       isLoading: false,
       error: null,
+      refetch: mockRefetchUserTypes,
     });
     mockUseGetUserType.mockReturnValue({
       data: mockSchemaData,
@@ -270,6 +273,50 @@ describe('UserEditPage', () => {
       render(<UserEditPage />);
 
       expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+
+    it('displays loading spinner when the user type list is loading', () => {
+      mockUseGetUserTypes.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        error: null,
+        refetch: mockRefetchUserTypes,
+      });
+
+      render(<UserEditPage />);
+
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+
+    it('displays error alert when the user type list fails to load', () => {
+      mockUseGetUserTypes.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error('User types list failed'),
+        refetch: mockRefetchUserTypes,
+      });
+
+      render(<UserEditPage />);
+
+      // Resolved through the i18n catalog, not the raw (unlocalized) error message.
+      expect(screen.getByText('Failed to load user information')).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: /back to users/i})).toBeInTheDocument();
+    });
+
+    it('retries the user type list query when Refresh is clicked', async () => {
+      const user = userEvent.setup();
+      mockUseGetUserTypes.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error('User types list failed'),
+        refetch: mockRefetchUserTypes,
+      });
+
+      render(<UserEditPage />);
+
+      await user.click(screen.getByRole('button', {name: /refresh/i}));
+
+      expect(mockRefetchUserTypes).toHaveBeenCalledTimes(1);
     });
 
     it('displays error alert when user fails to load', () => {
@@ -501,6 +548,7 @@ describe('UserEditPage', () => {
         data: {...mockSchemasData, types: [{...mockSchemasData.types[0], ouId: ''}]},
         isLoading: false,
         error: null,
+        refetch: mockRefetchUserTypes,
       });
 
       render(<UserEditPage />);
@@ -612,6 +660,7 @@ describe('UserEditPage', () => {
         data: {...mockSchemasData, types: [{...mockSchemasData.types[0], ouId: 'schema-ou'}]},
         isLoading: false,
         error: null,
+        refetch: mockRefetchUserTypes,
       });
 
       render(<UserEditPage />);
@@ -633,6 +682,7 @@ describe('UserEditPage', () => {
         data: {...mockSchemasData, types: [{...mockSchemasData.types[0], ouId: ''}]},
         isLoading: false,
         error: null,
+        refetch: mockRefetchUserTypes,
       });
 
       render(<UserEditPage />);

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -806,6 +806,7 @@ const translations = {
     'validationErrors.duplicateProperties': 'Duplicate property names found: {{duplicates}}',
     'errors.organizationUnitsFailedTitle': 'Failed to load organization units',
     noUserTypes: 'No user types found',
+    'listing.error': 'Failed to load user types',
     'listing.columns.name': 'Name',
     'listing.columns.id': 'User Type ID',
     'listing.columns.organizationUnit': 'Organization Unit',
@@ -813,6 +814,14 @@ const translations = {
     'listing.columns.actions': 'Actions',
     noOrganizationUnits: 'No organization units available',
     confirmDeleteUserType: 'Are you sure you want to delete this user type?',
+    'errors.USRS-1002': 'This user type no longer exists. It may have already been deleted.',
+    'errors.USRS-1003': 'A user type with the same name already exists.',
+    'errors.USRS-1004': 'The user type request is missing required fields or contains invalid data.',
+    'errors.USRS-1008': 'This user type is managed by the system and cannot be modified or deleted.',
+    'errors.USRS-1009': 'Too many user types matched this request. Refine your search and try again.',
+    'errors.USRS-1011': 'Display attribute must reference an attribute defined in the schema.',
+    'errors.USRS-1012': 'Display attribute must reference a string or number type.',
+    'errors.USRS-1013': 'Display attribute cannot reference a credential attribute.',
 
     // Edit page
     'manageUserType.title': 'Manage User Type',
@@ -827,6 +836,7 @@ const translations = {
     'edit.unsavedChanges': 'You have unsaved changes',
     'edit.saveError': 'Failed to save user type',
     'edit.loadError': 'Failed to load user type information',
+    'edit.loadErrorTitle': 'Failed to load user type',
     'edit.notFound': 'User type not found',
     'schemaChangeWarning.title': 'Confirm schema changes',
     'schemaChangeWarning.description':
@@ -1316,7 +1326,7 @@ const translations = {
 
     /* -------------------- Edit page -------------------- */
     // Common
-    'edit.page.error': 'Failed to load organization unit',
+    'edit.page.error': 'Failed to load organization unit information',
     'edit.page.notFound': 'Organization unit not found',
     'edit.page.logoUpdate.label': 'Update Logo',
     'edit.page.copyOuId': 'Copy Organization Unit ID',
@@ -1434,6 +1444,29 @@ const translations = {
     'update.error': 'Failed to update organization unit. Please try again.',
     'delete.success': 'Organization unit deleted successfully.',
     'delete.error': 'Failed to delete organization unit. Please try again.',
+
+    // Edit page - read error
+    'edit.page.errorTitle': 'Failed to load organization unit',
+
+    // Tab sections - read errors
+    'edit.users.sections.manage.error': 'Failed to load users',
+    'edit.groups.sections.manage.error': 'Failed to load groups',
+    'edit.childOUs.sections.manage.error': 'Failed to load child organization units',
+
+    // Backend error codes (organization unit service)
+    'errors.OU-1003': 'This organization unit no longer exists. It may have already been deleted.',
+    'errors.OU-1004': 'An organization unit with the same name already exists under the same parent.',
+    'errors.OU-1005': 'The selected parent organization unit could not be found.',
+    'errors.OU-1006':
+      'This organization unit has child units, users, or groups and cannot be deleted while they exist.',
+    'errors.OU-1007': 'This parent selection would create a circular dependency in the organization hierarchy.',
+    'errors.OU-1008': 'An organization unit with the same handle already exists under the same parent.',
+    'errors.OU-1012': 'This organization unit is managed by configuration and cannot be modified or deleted.',
+    'errors.OU-1013': 'Too many results were returned for this request. Please narrow your search and try again.',
+    'errors.OU-1015': 'The selected sign-in flow could not be found. Refresh and try again.',
+    'errors.OU-1016': 'The selected sign-up flow could not be found. Refresh and try again.',
+    'errors.OU-1017': 'The selected recovery flow could not be found. Refresh and try again.',
+    'errors.OU-1018': 'The selected sign-out flow could not be found. Refresh and try again.',
   },
 
   // ============================================================================

--- a/frontend/packages/utils/src/error/getErrorMessage.ts
+++ b/frontend/packages/utils/src/error/getErrorMessage.ts
@@ -6,7 +6,7 @@ import type {ApiError} from '@thunderid/types';
 /**
  * A minimal subset of the i18next TFunction interface used by {@link getErrorMessage}.
  */
-type TranslateFn = (key: string, options?: {defaultValue: string}) => string;
+type TranslateFn = (key: string, options?: Record<string, unknown>) => string;
 
 /**
  * Extracts a localized error message from an API error response.


### PR DESCRIPTION
### Purpose
Ports the error-handling convention established for applications/users/roles/groups to the `configure-user-types` and `configure-organization-units`. Every error resolves through the i18n catalog by backend error code instead of surfacing raw server text, each failure has exactly one surface (no duplicate toasts), and read failures render in place of the missing content with a retry action.

### Approach
- Added a shared `ReadErrorState` component (`@thunderid/components`) for read failures (list, detail, tab), with `block` and `inline` variants, and retrofitted the 6 sites already converted in the prior PR (users/roles/groups lists and edit pages) onto it.
- `configure-user-types`:
  - Merged the create wizard's four separate error surfaces (validation snackbar, local alert, raw mutation alert, hook toast) into one.
  - Removed a render-phase watcher that opened a toast while still rendering an empty grid.
  - Wired mutation errors into `UnsavedChangesBar` and cleared stale save errors on field change.
  - Mapped the console-reachable `USRS-*` error codes.
- `configure-organization-units`:
  - Deleted a local `getErrorMessage` in the delete dialog that shadowed the shared util's name and preferred raw server text over a translated one.
  - Stopped the delete dialog from closing on failure and handing its message to two different parent snackbars; it now renders inline instead.
  - Added error branches to three tab sections and the tree view that previously had none.
  - Mapped the console-reachable `OU-*` error codes.
- Removed the dead `USRS-1007` backend error code (unreferenced by any handler) and its i18n defaults.
- Widened `getErrorMessage`'s `t` parameter type to match the feature resolvers' signature exactly, so a `ReadErrorState` caller can pass either interchangeably.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4555
- https://github.com/thunder-id/thunderid/issues/4441

### Related PRs
- #4557

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent inline and full-page error states with localized messages, retry actions, and contextual recovery options.
  - Expanded translated error messages for user types and organization-unit operations.
- **Bug Fixes**
  - Prevented raw network and API error details from being shown directly.
  - Replaced disruptive error toasts and snackbars with inline guidance where appropriate.
  - Improved error handling across users, roles, groups, user types, and organization units.
- **Tests**
  - Added coverage for localized errors, retries, validation feedback, and failed deletion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->