### PR TITLE
Add support for tracking unsaved changes in token settings

### DIFF
--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/EditTokenSettings.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/EditTokenSettings.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {zodResolver} from '@hookform/resolvers/zod';
-import type {Application, OAuth2Config, ScopeClaims} from '@thunderid/configure-applications';
+import type {Application, AssertionConfig, OAuth2Config, ScopeClaims} from '@thunderid/configure-applications';
 import type {PropertyDefinition, ApiUserType} from '@thunderid/configure-user-types';
 import {useGetUserTypes} from '@thunderid/configure-user-types';
 import {useConfig} from '@thunderid/contexts';
@@ -26,6 +26,12 @@ interface EditTokenSettingsProps {
    * The application being edited
    */
   application: Application;
+  /**
+   * Pending, unsaved changes to the application as tracked by the edit page. Fields present here
+   * take precedence over the stored ones, so successive edits to the same field accumulate instead
+   * of each being applied on top of the stored value.
+   */
+  editedApp?: Partial<Application>;
   /**
    * OAuth2 configuration containing token settings (optional)
    */
@@ -84,12 +90,19 @@ const createTokenConfigSchema = (t: (key: string) => string) => {
 
 type TokenConfigFormData = z.infer<ReturnType<typeof createTokenConfigSchema>>;
 
-const computeValidityDefaults = (config: OAuth2Config | undefined, app: Application): TokenConfigFormData => ({
-  validityPeriod: config?.token?.validityPeriod ?? app.assertion?.validityPeriod ?? 3600,
+const computeValidityDefaults = (
+  config: OAuth2Config | undefined,
+  assertion: AssertionConfig | undefined,
+): TokenConfigFormData => ({
+  validityPeriod: config?.token?.validityPeriod ?? assertion?.validityPeriod ?? 3600,
   accessTokenValidity: config?.token?.accessToken?.userConfig?.validityPeriod ?? 3600,
   idTokenValidity: config?.token?.idToken?.validityPeriod ?? 3600,
   refreshTokenValidity: config?.token?.refreshToken?.validityPeriod ?? 86400,
 });
+
+// Stable identity for the default, so an untouched application doesn't invalidate the memos below
+// on every render.
+const NO_PENDING_CHANGES: Partial<Application> = {};
 
 type TokenAttributeScope = 'shared' | 'access' | 'id' | 'userinfo';
 
@@ -136,6 +149,7 @@ const areSetsEqual = (set1: Set<string>, set2: Set<string>): boolean => {
  */
 export default function EditTokenSettings({
   application,
+  editedApp = NO_PENDING_CHANGES,
   oauth2Config = undefined,
   onFieldChange,
   onValidationChange = undefined,
@@ -183,6 +197,15 @@ export default function EditTokenSettings({
   // Determine if this is OAuth/OIDC mode (has separate token configs) or Native mode
   const isOAuthMode = useMemo(() => isOAuthTokenMode(oauth2Config), [oauth2Config]);
 
+  // In Native mode both the attribute list and the validity period live on this single config, so
+  // each is written by spreading the other's current value. Prefer the pending assertion whenever
+  // the field has been touched — including an explicit undefined — otherwise the second edit would
+  // spread the stored value and discard the first.
+  const currentAssertion = useMemo(
+    () => ('assertion' in editedApp ? editedApp.assertion : application.assertion),
+    [editedApp, application.assertion],
+  );
+
   const tokenConfigSchema = useMemo(() => createTokenConfigSchema(t), [t]);
 
   const {
@@ -193,7 +216,7 @@ export default function EditTokenSettings({
   } = useForm<TokenConfigFormData>({
     resolver: zodResolver(tokenConfigSchema),
     mode: 'onChange',
-    defaultValues: computeValidityDefaults(oauth2Config, application),
+    defaultValues: computeValidityDefaults(oauth2Config, currentAssertion),
   });
 
   const [validityPeriod, accessTokenValidity, idTokenValidity, refreshTokenValidity] = useWatch({
@@ -207,6 +230,7 @@ export default function EditTokenSettings({
 
   const oauth2ConfigRef = useRef(oauth2Config);
   const applicationRef = useRef(application);
+  const currentAssertionRef = useRef(currentAssertion);
   const isFirstRenderRef = useRef(true);
   const prevSectionResetKeyRef = useRef(sectionResetKey);
 
@@ -218,18 +242,22 @@ export default function EditTokenSettings({
     applicationRef.current = application;
   }, [application]);
 
+  useEffect(() => {
+    currentAssertionRef.current = currentAssertion;
+  }, [currentAssertion]);
+
   // Resets the Token Validity fields in place on Save/Reset — deliberately not a remount
   //  since TokenValidationSection owns its own local Access/ID/Refresh Token
   // sub-tab selection that must survive this. Also clears the pending attribute add/remove
   // highlight state below, which is edit-tracking state that should be cleared on Save/Reset.
-  // Relies on the two ref-sync effects above running first in the same commit so oauth2ConfigRef
-  // and applicationRef hold the latest values by the time this reads them — keep this effect
+  // Relies on the ref-sync effects above running first in the same commit so oauth2ConfigRef and
+  // currentAssertionRef hold the latest values by the time this reads them — keep this effect
   // declared after them.
   useEffect(() => {
     if (sectionResetKey === prevSectionResetKeyRef.current) return;
     prevSectionResetKeyRef.current = sectionResetKey;
 
-    reset(computeValidityDefaults(oauth2ConfigRef.current, applicationRef.current));
+    reset(computeValidityDefaults(oauth2ConfigRef.current, currentAssertionRef.current));
 
     setPendingAdditionsByToken(createEmptyAttributeSetState());
     setPendingRemovalsByToken(createEmptyAttributeSetState());
@@ -248,7 +276,7 @@ export default function EditTokenSettings({
       const valid = await trigger();
       if (cancelled || !valid) return;
 
-      const baseline = computeValidityDefaults(oauth2ConfigRef.current, applicationRef.current);
+      const baseline = computeValidityDefaults(oauth2ConfigRef.current, currentAssertionRef.current);
 
       if (isOAuthMode) {
         const config = oauth2ConfigRef.current;
@@ -292,7 +320,7 @@ export default function EditTokenSettings({
           return; // No changes, skip update
         }
 
-        onFieldChange('assertion', {...applicationRef.current.assertion, validityPeriod});
+        onFieldChange('assertion', {...currentAssertionRef.current, validityPeriod});
       }
     };
 
@@ -424,8 +452,8 @@ export default function EditTokenSettings({
       return [];
     }
 
-    return oauth2Config?.token?.userAttributes ?? application.assertion?.userAttributes ?? [];
-  }, [isOAuthMode, oauth2Config, application]);
+    return currentAssertion?.userAttributes ?? [];
+  }, [isOAuthMode, currentAssertion]);
 
   const currentAccessTokenAttributes = useMemo(
     () => oauth2Config?.token?.accessToken?.userConfig?.attributes ?? [],
@@ -714,7 +742,7 @@ export default function EditTokenSettings({
       });
       onFieldChange('inboundAuthConfig', updatedInboundAuth);
     } else if (scope === 'shared') {
-      onFieldChange('assertion', {...application.assertion, userAttributes: nextAttrs});
+      onFieldChange('assertion', {...currentAssertion, userAttributes: nextAttrs});
     }
   };
 

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/EditTokenSettingsTabs.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/EditTokenSettingsTabs.tsx
@@ -17,6 +17,7 @@ const USER_AUDIENCE = 'user';
 
 interface EditTokenSettingsTabsProps {
   application: Application;
+  editedApp: Partial<Application>;
   oauth2Config?: OAuth2Config;
   onFieldChange: (field: keyof Application, value: unknown) => void;
   onValidationChange?: (hasErrors: boolean) => void;
@@ -36,6 +37,7 @@ interface EditTokenSettingsTabsProps {
  */
 export default function EditTokenSettingsTabs({
   application,
+  editedApp,
   oauth2Config = undefined,
   onFieldChange,
   onValidationChange = undefined,
@@ -144,6 +146,7 @@ export default function EditTokenSettingsTabs({
       {audience === USER_AUDIENCE && userUnlocked && (
         <EditTokenSettings
           application={application}
+          editedApp={editedApp}
           oauth2Config={oauth2Config}
           sectionResetKey={sectionResetKey}
           onFieldChange={onFieldChange}

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/EditTokenSettingsNativeAttributes.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/EditTokenSettingsNativeAttributes.test.tsx
@@ -1,0 +1,153 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import type {Application} from '@thunderid/configure-applications';
+import {fireEvent, render, screen, waitFor} from '@thunderid/test-utils';
+import {useCallback, useState, type JSX} from 'react';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import EditTokenSettings from '../EditTokenSettings';
+
+// Stable mock references, created via vi.hoisted so the hoisted vi.mock factories can use them.
+// New identities on every render would re-fire the schema-fetch effect in a loop.
+const {mockHttp, mockGetServerUrl, mockLogger} = vi.hoisted(() => ({
+  mockHttp: {request: vi.fn().mockResolvedValue({data: {id: 'schema-1', name: 'default', schema: {}}})},
+  mockGetServerUrl: vi.fn().mockReturnValue('https://api.example.com'),
+  mockLogger: {error: vi.fn(), info: vi.fn(), debug: vi.fn()},
+}));
+
+vi.mock('@thunderid/configure-user-types', () => ({
+  useGetUserTypes: () => ({data: {types: [{id: 'schema-1', name: 'default'}]}, isLoading: false}),
+}));
+
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({http: mockHttp}),
+}));
+
+vi.mock('@thunderid/contexts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunderid/contexts')>();
+  return {...actual, useConfig: () => ({getServerUrl: mockGetServerUrl})};
+});
+
+vi.mock('@thunderid/logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunderid/logger')>();
+  return {...actual, useLogger: () => mockLogger};
+});
+
+const CLICKABLE = ['email', 'family_name', 'given_name'];
+
+// Stands in for the attribute chips so a click can be driven by attribute name. Also echoes the
+// list the component considers currently selected, which is what regressed.
+vi.mock('../TokenUserAttributesSection', () => ({
+  default: ({
+    sharedAttributes,
+    onAttributeClick,
+  }: {
+    sharedAttributes?: string[];
+    onAttributeClick?: (attr: string, scope: 'shared') => void;
+  }) => (
+    <div>
+      <div data-testid="shared-attributes">{(sharedAttributes ?? []).join(',')}</div>
+      {['email', 'family_name', 'given_name'].map((attr) => (
+        <button
+          key={attr}
+          type="button"
+          data-testid={`chip-${attr}`}
+          onClick={() => onAttributeClick?.(attr, 'shared')}
+        >
+          {attr}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+// Hoisted out of the harness so its identity is stable across renders — a fresh object would give
+// `allowedUserTypes` a new reference each render and re-fire the schema-fetch effect indefinitely.
+const baseApplication = {id: 'app-1', name: 'App Native App', allowedUserTypes: ['default']} as Application;
+
+/**
+ * Mirrors how ApplicationEditPage owns the pending edits: `onFieldChange` accumulates into
+ * `editedApp`, which is fed straight back to the component. Without that round trip the component
+ * has no way to see its own earlier edits, which is the regression under test.
+ */
+function Harness({assertion = undefined}: {assertion?: Application['assertion']}): JSX.Element {
+  const [editedApp, setEditedApp] = useState<Partial<Application>>({});
+
+  const onFieldChange = useCallback((field: keyof Application, value: unknown) => {
+    setEditedApp((prev) => ({...prev, [field]: value}));
+  }, []);
+
+  const application = assertion ? ({...baseApplication, assertion} as Application) : baseApplication;
+
+  return (
+    <>
+      <EditTokenSettings application={application} editedApp={editedApp} onFieldChange={onFieldChange} />
+      <div data-testid="pending-attributes">{(editedApp.assertion?.userAttributes ?? []).join(',')}</div>
+      <div data-testid="pending-validity">{String(editedApp.assertion?.validityPeriod ?? '')}</div>
+    </>
+  );
+}
+
+describe('EditTokenSettings native-mode attribute selection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('accumulates successive attribute selections instead of replacing the previous one', async () => {
+    render(<Harness />);
+
+    for (const attr of CLICKABLE) {
+      fireEvent.click(screen.getByTestId(`chip-${attr}`));
+      // Each click must observe the attributes added by the ones before it.
+      await waitFor(() => {
+        expect(screen.getByTestId('pending-attributes').textContent).toContain(attr);
+      });
+    }
+
+    expect(screen.getByTestId('pending-attributes').textContent).toBe('email,family_name,given_name');
+    expect(screen.getByTestId('shared-attributes').textContent).toBe('email,family_name,given_name');
+  });
+
+  it('keeps stored attributes when a further one is added', async () => {
+    render(<Harness assertion={{validityPeriod: 3600, userAttributes: ['email']}} />);
+
+    fireEvent.click(screen.getByTestId('chip-given_name'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pending-attributes').textContent).toBe('email,given_name');
+    });
+  });
+
+  it('deselects only the clicked attribute', async () => {
+    render(<Harness assertion={{validityPeriod: 3600, userAttributes: ['email', 'family_name', 'given_name']}} />);
+
+    fireEvent.click(screen.getByTestId('chip-family_name'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pending-attributes').textContent).toBe('email,given_name');
+    });
+  });
+
+  it('does not drop pending attributes when the validity period is then changed', async () => {
+    render(<Harness assertion={{validityPeriod: 7200, userAttributes: []}} />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('7200')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('chip-email'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pending-attributes').textContent).toBe('email');
+    });
+
+    // The validity period is written to the same assertion object, so it must merge with, rather
+    // than replace, the attribute selection made above.
+    fireEvent.change(screen.getByDisplayValue('7200'), {target: {value: '900'}});
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pending-validity').textContent).toBe('900');
+    });
+    expect(screen.getByTestId('pending-attributes').textContent).toBe('email');
+  });
+});

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/EditTokenSettingsTabs.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/EditTokenSettingsTabs.test.tsx
@@ -59,6 +59,7 @@ describe('EditTokenSettingsTabs', () => {
     render(
       <EditTokenSettingsTabs
         application={application}
+        editedApp={{}}
         oauth2Config={oauthConfig(['client_credentials'])}
         onFieldChange={onFieldChange}
       />,
@@ -76,6 +77,7 @@ describe('EditTokenSettingsTabs', () => {
     render(
       <EditTokenSettingsTabs
         application={application}
+        editedApp={{}}
         oauth2Config={oauthConfig(['client_credentials'])}
         onFieldChange={onFieldChange}
       />,
@@ -91,6 +93,7 @@ describe('EditTokenSettingsTabs', () => {
     render(
       <EditTokenSettingsTabs
         application={application}
+        editedApp={{}}
         oauth2Config={oauthConfig(['authorization_code'])}
         onFieldChange={onFieldChange}
       />,
@@ -110,6 +113,7 @@ describe('EditTokenSettingsTabs', () => {
     render(
       <EditTokenSettingsTabs
         application={application}
+        editedApp={{}}
         oauth2Config={oauthConfig(['client_credentials'])}
         onFieldChange={onFieldChange}
       />,
@@ -127,6 +131,7 @@ describe('EditTokenSettingsTabs', () => {
     render(
       <EditTokenSettingsTabs
         application={application}
+        editedApp={{}}
         oauth2Config={oauthConfig(['authorization_code'])}
         onFieldChange={onFieldChange}
       />,
@@ -140,6 +145,7 @@ describe('EditTokenSettingsTabs', () => {
     render(
       <EditTokenSettingsTabs
         application={application}
+        editedApp={{}}
         oauth2Config={oauthConfig(['authorization_code'])}
         onFieldChange={onFieldChange}
       />,
@@ -155,6 +161,7 @@ describe('EditTokenSettingsTabs', () => {
     render(
       <EditTokenSettingsTabs
         application={application}
+        editedApp={{}}
         oauth2Config={oauthConfig(['authorization_code'])}
         onFieldChange={onFieldChange}
       />,
@@ -167,7 +174,7 @@ describe('EditTokenSettingsTabs', () => {
   describe('app-native application (no OAuth2 configuration)', () => {
     it('unlocks the User tab so the assertion config can be edited', () => {
       render(
-        <EditTokenSettingsTabs application={application} oauth2Config={undefined} onFieldChange={onFieldChange} />,
+        <EditTokenSettingsTabs application={application} editedApp={{}} oauth2Config={undefined} onFieldChange={onFieldChange} />,
       );
 
       expect(screen.getByRole('tab', {name: 'User'})).toBeEnabled();
@@ -178,7 +185,7 @@ describe('EditTokenSettingsTabs', () => {
     it('opens on the User sub-tab and keeps the Application notice behind its own tab', async () => {
       const user = userEvent.setup();
       render(
-        <EditTokenSettingsTabs application={application} oauth2Config={undefined} onFieldChange={onFieldChange} />,
+        <EditTokenSettingsTabs application={application} editedApp={{}} oauth2Config={undefined} onFieldChange={onFieldChange} />,
       );
 
       expect(screen.getByRole('tab', {name: 'User'})).toHaveAttribute('aria-selected', 'true');
@@ -195,6 +202,7 @@ describe('EditTokenSettingsTabs', () => {
     const {rerender} = render(
       <EditTokenSettingsTabs
         application={application}
+        editedApp={{}}
         oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
         onFieldChange={onFieldChange}
         sectionResetKey={0}
@@ -207,6 +215,7 @@ describe('EditTokenSettingsTabs', () => {
     rerender(
       <EditTokenSettingsTabs
         application={application}
+        editedApp={{}}
         oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
         onFieldChange={onFieldChange}
         sectionResetKey={1}
@@ -222,6 +231,7 @@ describe('EditTokenSettingsTabs', () => {
     const {rerender} = render(
       <EditTokenSettingsTabs
         application={application}
+        editedApp={{}}
         oauth2Config={{grantTypes: ['authorization_code'], responseTypes: []}}
         onFieldChange={onFieldChange}
         sectionResetKey={0}
@@ -235,6 +245,7 @@ describe('EditTokenSettingsTabs', () => {
     rerender(
       <EditTokenSettingsTabs
         application={application}
+        editedApp={{}}
         oauth2Config={{grantTypes: ['authorization_code'], responseTypes: []}}
         onFieldChange={onFieldChange}
         sectionResetKey={1}

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/EditTokenSettingsTabs.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/EditTokenSettingsTabs.test.tsx
@@ -174,7 +174,12 @@ describe('EditTokenSettingsTabs', () => {
   describe('app-native application (no OAuth2 configuration)', () => {
     it('unlocks the User tab so the assertion config can be edited', () => {
       render(
-        <EditTokenSettingsTabs application={application} editedApp={{}} oauth2Config={undefined} onFieldChange={onFieldChange} />,
+        <EditTokenSettingsTabs
+          application={application}
+          editedApp={{}}
+          oauth2Config={undefined}
+          onFieldChange={onFieldChange}
+        />,
       );
 
       expect(screen.getByRole('tab', {name: 'User'})).toBeEnabled();
@@ -185,7 +190,12 @@ describe('EditTokenSettingsTabs', () => {
     it('opens on the User sub-tab and keeps the Application notice behind its own tab', async () => {
       const user = userEvent.setup();
       render(
-        <EditTokenSettingsTabs application={application} editedApp={{}} oauth2Config={undefined} onFieldChange={onFieldChange} />,
+        <EditTokenSettingsTabs
+          application={application}
+          editedApp={{}}
+          oauth2Config={undefined}
+          onFieldChange={onFieldChange}
+        />,
       );
 
       expect(screen.getByRole('tab', {name: 'User'})).toHaveAttribute('aria-selected', 'true');

--- a/frontend/apps/console/src/features/applications/pages/ApplicationEditPage.tsx
+++ b/frontend/apps/console/src/features/applications/pages/ApplicationEditPage.tsx
@@ -321,6 +321,7 @@ export default function ApplicationEditPage() {
               <EditTokenSettings
                 sectionResetKey={sectionResetKey}
                 application={application}
+                editedApp={editedApp}
                 oauth2Config={oauth2Config}
                 onFieldChange={handleFieldChange}
                 onValidationChange={setHasValidationErrors}
@@ -638,6 +639,7 @@ export default function ApplicationEditPage() {
               <EditTokenSettingsTabs
                 sectionResetKey={sectionResetKey}
                 application={application}
+                editedApp={editedApp}
                 oauth2Config={oauth2Config}
                 onFieldChange={handleFieldChange}
                 onValidationChange={setHasValidationErrors}


### PR DESCRIPTION
### Purpose

This pull request fixes an issue in the token settings form where successive edits to the same field (such as user attributes and validity period) would overwrite rather than accumulate pending changes, causing earlier edits to be lost. The changes ensure that all pending edits are merged correctly and reflected in the UI, especially in "native" mode. A regression test is also added to prevent this issue from recurring.

The most important changes are:

**Fixes to pending edits handling in token settings:**
* The `EditTokenSettings` component now accepts an `editedApp` prop containing pending, unsaved changes, and always prefers fields from `editedApp` over the stored `application` values. This ensures multiple edits accumulate correctly instead of overwriting each other. [[1]](diffhunk://#diff-663851f909704ed5af0811364a42548235b98547df8229e161c44d5db2edc08fR29-R34) [[2]](diffhunk://#diff-663851f909704ed5af0811364a42548235b98547df8229e161c44d5db2edc08fR152) [[3]](diffhunk://#diff-663851f909704ed5af0811364a42548235b98547df8229e161c44d5db2edc08fR200-R208)
* All reads and writes to assertion-related fields (like `validityPeriod` and `userAttributes`) are updated to use the merged, current assertion state, preventing loss of pending changes when switching between fields. [[1]](diffhunk://#diff-663851f909704ed5af0811364a42548235b98547df8229e161c44d5db2edc08fL87-R106) [[2]](diffhunk://#diff-663851f909704ed5af0811364a42548235b98547df8229e161c44d5db2edc08fL196-R219) [[3]](diffhunk://#diff-663851f909704ed5af0811364a42548235b98547df8229e161c44d5db2edc08fR233) [[4]](diffhunk://#diff-663851f909704ed5af0811364a42548235b98547df8229e161c44d5db2edc08fR245-R260) [[5]](diffhunk://#diff-663851f909704ed5af0811364a42548235b98547df8229e161c44d5db2edc08fL251-R279) [[6]](diffhunk://#diff-663851f909704ed5af0811364a42548235b98547df8229e161c44d5db2edc08fL295-R323) [[7]](diffhunk://#diff-663851f909704ed5af0811364a42548235b98547df8229e161c44d5db2edc08fL427-R456) [[8]](diffhunk://#diff-663851f909704ed5af0811364a42548235b98547df8229e161c44d5db2edc08fL717-R745)

**Propagating pending changes throughout the UI:**
* The `EditTokenSettingsTabs` component and all its usages/tests are updated to require and pass the new `editedApp` prop, ensuring the pending state is consistently available. [[1]](diffhunk://#diff-78e56413d0f4bcbc9a902eec8712105829493348516d8a24d6df1ea2201e3e7bR20) [[2]](diffhunk://#diff-78e56413d0f4bcbc9a902eec8712105829493348516d8a24d6df1ea2201e3e7bR40) [[3]](diffhunk://#diff-78e56413d0f4bcbc9a902eec8712105829493348516d8a24d6df1ea2201e3e7bR149) [[4]](diffhunk://#diff-515dd41d9801bab81394c6bf32b8c3d9c66186a1b99789dcb49c33aef4ca46e2R62) [[5]](diffhunk://#diff-515dd41d9801bab81394c6bf32b8c3d9c66186a1b99789dcb49c33aef4ca46e2R80) [[6]](diffhunk://#diff-515dd41d9801bab81394c6bf32b8c3d9c66186a1b99789dcb49c33aef4ca46e2R96) [[7]](diffhunk://#diff-515dd41d9801bab81394c6bf32b8c3d9c66186a1b99789dcb49c33aef4ca46e2R116) [[8]](diffhunk://#diff-515dd41d9801bab81394c6bf32b8c3d9c66186a1b99789dcb49c33aef4ca46e2R134) [[9]](diffhunk://#diff-515dd41d9801bab81394c6bf32b8c3d9c66186a1b99789dcb49c33aef4ca46e2R148) [[10]](diffhunk://#diff-515dd41d9801bab81394c6bf32b8c3d9c66186a1b99789dcb49c33aef4ca46e2R164)

**Testing and regression prevention:**
* A new test, `EditTokenSettingsNativeAttributes.test.tsx`, is added to verify that attribute selections and validity period edits accumulate as expected and that no pending changes are lost.

These changes make the edit flow more robust and prevent user edits from being accidentally discarded during multi-step updates.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4562

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Token settings now reflect pending application edits, including assertion and user-attribute changes.
  * Preserved explicit values and pending selections when token validity settings change.
  * Improved reset behavior and default handling for native token settings.
  * Pending token configuration remains consistent while switching between settings tabs.

* **Tests**
  * Added coverage for cumulative attribute selection, deselection, stored attributes, and pending changes.
  * Updated token settings scenarios to include edited application state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->