### PR TITLE
Remove the Allow Cross OU provisioning property from federated Executors

### DIFF
--- a/docs/content/guides/flows/advanced-configurations.mdx
+++ b/docs/content/guides/flows/advanced-configurations.mdx
@@ -576,7 +576,6 @@ Authenticates users via a generic OAuth 2.0 provider. After the OAuth redirect, 
 | `idpId` | Connection | Yes | The identity provider ID configured in <ProductName /> |
 | `allowAuthenticationWithoutLocalUser` | Allow Authentication Without Local User | No | Allow authentication when no local user exists (creates federated link) |
 | `allowRegistrationWithExistingUser` | Allow Registration With Existing User | No | Allow registration if the account already exists |
-| `allowCrossOUProvisioning` | Allow Cross-OU Provisioning | No | Allow creating user in a different OU from the default |
 
 **Input Configuration:**
 - `code` (required): the authorization code returned by the OAuth provider after redirect. Default: `code`. If not provided, the executor redirects to the OAuth provider to start the authorization flow and get a code.
@@ -590,8 +589,7 @@ Authenticates users via a generic OAuth 2.0 provider. After the OAuth redirect, 
   "properties": {
     "idpId": "<idp-id>",
     "allowAuthenticationWithoutLocalUser": false,
-    "allowRegistrationWithExistingUser": false,
-    "allowCrossOUProvisioning": false
+    "allowRegistrationWithExistingUser": false
   },
   "executor": {
     "name": "OAuthExecutor"
@@ -627,7 +625,6 @@ Authenticates users via a generic OIDC provider. After the OIDC redirect, <Produ
 | `idpId` | Connection | Yes | The identity provider ID configured in <ProductName /> |
 | `allowAuthenticationWithoutLocalUser` | Allow Authentication Without Local User | No | Allow authentication when no local user exists (creates federated link) |
 | `allowRegistrationWithExistingUser` | Allow Registration With Existing User | No | Allow registration if the account already exists |
-| `allowCrossOUProvisioning` | Allow Cross-OU Provisioning | No | Allow creating user in a different OU from the default |
 
 **Input Configuration:**
 - `code` (required): the authorization code returned by the OIDC provider after redirect. Default: `code`. If not provided, the executor redirects to the OIDC provider to start the authorization flow and get a code.
@@ -641,8 +638,7 @@ Authenticates users via a generic OIDC provider. After the OIDC redirect, <Produ
   "properties": {
     "idpId": "<idp-id>",
     "allowAuthenticationWithoutLocalUser": false,
-    "allowRegistrationWithExistingUser": false,
-    "allowCrossOUProvisioning": false
+    "allowRegistrationWithExistingUser": false
   },
   "executor": {
     "name": "OIDCAuthExecutor"
@@ -678,7 +674,6 @@ Authenticates users via Google OIDC. After the OAuth redirect, <ProductName /> e
 | `idpId` | Connection | Yes | The identity provider ID configured in <ProductName /> |
 | `allowAuthenticationWithoutLocalUser` | Allow Authentication Without Local User | No | Allow authentication when no local user exists (creates federated link) |
 | `allowRegistrationWithExistingUser` | Allow Registration With Existing User | No | Allow registration if the account already exists |
-| `allowCrossOUProvisioning` | Allow Cross-OU Provisioning | No | Allow creating user in a different OU from the default |
 
 **Input Configuration:**
 - `code` (required): the authorization code returned by Google after user consent. Default: `code`
@@ -692,8 +687,7 @@ Authenticates users via Google OIDC. After the OAuth redirect, <ProductName /> e
   "properties": {
     "idpId": "<idp-id>",
     "allowAuthenticationWithoutLocalUser": false,
-    "allowRegistrationWithExistingUser": false,
-    "allowCrossOUProvisioning": false
+    "allowRegistrationWithExistingUser": false
   },
   "executor": {
     "name": "GoogleOIDCAuthExecutor"
@@ -729,7 +723,6 @@ Authenticates users via GitHub OAuth 2.0. After the redirect, <ProductName /> ex
 | `idpId` | Connection | Yes | The identity provider ID configured in <ProductName /> |
 | `allowAuthenticationWithoutLocalUser` | Allow Authentication Without Local User | No | Allow authentication when no local user exists (creates federated link) |
 | `allowRegistrationWithExistingUser` | Allow Registration With Existing User | No | Allow registration if the account already exists |
-| `allowCrossOUProvisioning` | Allow Cross-OU Provisioning | No | Allow creating user in a different OU from the default |
 
 **Input Configuration:**
 - `code` (required): the authorization code returned by GitHub after user authorization. Default: `code`
@@ -743,8 +736,7 @@ Authenticates users via GitHub OAuth 2.0. After the redirect, <ProductName /> ex
   "properties": {
     "idpId": "<idp-id>",
     "allowAuthenticationWithoutLocalUser": false,
-    "allowRegistrationWithExistingUser": false,
-    "allowCrossOUProvisioning": false
+    "allowRegistrationWithExistingUser": false
   },
   "executor": {
     "name": "GithubOAuthExecutor"

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/__tests__/ExecutionExtendedProperties.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/__tests__/ExecutionExtendedProperties.test.tsx
@@ -133,6 +133,27 @@ describe('ExecutionExtendedProperties', () => {
       ).not.toBeInTheDocument();
     });
 
+    // The panel may only write properties the federated executors declare as supported in their
+    // backend ExecutorMeta. Writing any other key makes the whole flow unsavable, and unchecking
+    // the box does not recover it because the validator rejects on key presence, not value.
+    it('should only write properties the federated executors support', () => {
+      mockIdentityProviders.mockReturnValue({
+        data: [{id: 'google-idp-1', name: 'Google IDP', type: IdentityProviderTypes.GOOGLE}],
+        isLoading: false,
+      });
+
+      render(<ExecutionExtendedProperties resource={googleResource} onChange={mockOnChange} />);
+
+      screen.getAllByRole('checkbox').forEach((checkbox) => fireEvent.click(checkbox));
+
+      expect(new Set(mockOnChange.mock.calls.map((call) => call[0] as string))).toEqual(
+        new Set([
+          'data.properties.allowAuthenticationWithoutLocalUser',
+          'data.properties.allowRegistrationWithExistingUser',
+        ]),
+      );
+    });
+
     it('should show available Google connections in dropdown', async () => {
       const user = userEvent.setup();
       mockIdentityProviders.mockReturnValue({

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/FederationProperties.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/FederationProperties.tsx
@@ -124,15 +124,6 @@ function FederationProperties({resource, onChange}: CommonResourcePropertiesProp
               'Allow existing users to proceed through registration flows.',
             )}
           />
-          <CheckboxWithHint
-            checked={!!properties.allowCrossOUProvisioning}
-            onChange={(checked) => handleBooleanPropertyChange('allowCrossOUProvisioning', checked)}
-            label={t('flows:core.executions.federation.allowCrossOUProvisioning.label', 'Allow Cross-OU Provisioning')}
-            hint={t(
-              'flows:core.executions.federation.allowCrossOUProvisioning.hint',
-              'Allow creating a user in a different organizational unit.',
-            )}
-          />
         </Stack>
       )}
     </Stack>

--- a/frontend/apps/console/src/features/flows/data/executors.json
+++ b/frontend/apps/console/src/features/flows/data/executors.json
@@ -112,8 +112,7 @@
       "properties": {
         "idpId": "{{IDP_ID}}",
         "allowAuthenticationWithoutLocalUser": false,
-        "allowRegistrationWithExistingUser": false,
-        "allowCrossOUProvisioning": false
+        "allowRegistrationWithExistingUser": false
       }
     }
   },
@@ -141,8 +140,7 @@
       "properties": {
         "idpId": "{{IDP_ID}}",
         "allowAuthenticationWithoutLocalUser": false,
-        "allowRegistrationWithExistingUser": false,
-        "allowCrossOUProvisioning": false
+        "allowRegistrationWithExistingUser": false
       }
     }
   },
@@ -170,8 +168,7 @@
       "properties": {
         "idpId": "{{IDP_ID}}",
         "allowAuthenticationWithoutLocalUser": false,
-        "allowRegistrationWithExistingUser": false,
-        "allowCrossOUProvisioning": false
+        "allowRegistrationWithExistingUser": false
       }
     }
   },
@@ -200,8 +197,7 @@
       "properties": {
         "idpId": "{{IDP_ID}}",
         "allowAuthenticationWithoutLocalUser": false,
-        "allowRegistrationWithExistingUser": false,
-        "allowCrossOUProvisioning": false
+        "allowRegistrationWithExistingUser": false
       }
     }
   },


### PR DESCRIPTION
### Purpose

  Remove the unsupported Allow Cross-OU Provisioning property from federated executors. The property has no usages in these executors and causes flow validation to fail
  when included in the executor configuration.

  ### Approach

  Removed allowCrossOUProvisioning from:

  - The federated executor configuration UI.
  - Default OAuth, OIDC, Google, and GitHub executor definitions.
  - Related documentation and configuration examples.

  This option was removed because federated executors do not support or use the property. Retaining it in the Console allowed unsupported configuration to be written,
  making the flow unsavable even after the option was disabled.

  Added a unit test to ensure the federated executor panel only writes properties supported by the backend executor metadata.

  ### Related Issues

  - Resolves https://github.com/thunder-id/thunderid/issues/4502

  ### Related PRs

  - N/A

  ### Checklist
  - [x] Followed the contribution guidelines.
  - [x] Manual test round performed and verified.
  - [x] Documentation provided.
      - [ ] Ran Vale and fixed all errors and warnings
  - [x] Tests provided.
      - [x] Unit Tests
      - [ ] Integration Tests
  - [x] No breaking changes.

  ### Security checks
  - [x] Followed secure coding standards in WSO2 Secure Coding Guidelines
    (https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
  - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the unsupported cross-organizational-unit provisioning option from federated authentication settings.
  - Updated OAuth, OIDC, Google, and GitHub configuration options to show only supported federation properties.
  - Prevented the removed setting from being saved when editing Google Federation configurations.

- **Documentation**
  - Updated advanced configuration guidance to remove references to the retired provisioning option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->