### PR TITLE
Add the agent identity playground sample

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2673,6 +2673,8 @@ importers:
         specifier: '>=4.1.0'
         version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(jsdom@27.0.1)(vite@8.0.16(@types/node@24.7.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3))
 
+  samples/apps/agentid-playground: {}
+
   samples/apps/react-api-based-sample:
     dependencies:
       '@wso2/oxygen-ui':

--- a/samples/apps/agentid-playground/.env.example
+++ b/samples/apps/agentid-playground/.env.example
@@ -1,0 +1,12 @@
+# Copy to .env. Loaded automatically by npm start.
+
+# ThunderID backend. Overrides thunderidBaseUrl in config.json.
+THUNDERID_BASE_URL=https://localhost:8090
+
+# Which scenarios to enable, comma separated: self, obo, chain. Defaults to all three.
+# SCENARIOS=self,chain
+
+# Port for this app. Defaults to the port in config.json appBaseUrl.
+# When the obo scenario is enabled this must stay 8082, because that is the redirect URI registered
+# on the agent in thunderid-config/thunderid-config.yaml. Change both together, or drop obo from SCENARIOS.
+# PORT=8082

--- a/samples/apps/agentid-playground/.gitignore
+++ b/samples/apps/agentid-playground/.gitignore
@@ -1,0 +1,20 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+pnpm-debug.log*
+
+node_modules
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+
+# local env files
+.env
+.env.local
+
+# npm lockfile; this workspace uses pnpm
+package-lock.json

--- a/samples/apps/agentid-playground/README.md
+++ b/samples/apps/agentid-playground/README.md
@@ -1,0 +1,250 @@
+# ThunderID Agent Identity Playground
+
+A hands-on playground for ThunderID's agent identity management features. It is one app covering the
+three ways an AI agent can hold identity in ThunderID, each on its own tab, run live against your own
+instance.
+
+Nothing here is a recording or a mock-up. Every tab performs the real OAuth calls against the
+ThunderID you point it at, then decodes and explains the tokens that come back. Import the resources
+it hands you, click through a posture, and read the claims ThunderID actually issued. Change the
+roles, scopes, or agents in the resource file, reload, and watch the tokens change with them.
+
+The cast is a travel-booking one: a **Concierge** agent that recommends and books trips, a worker
+agent it hands searches to, and a customer named **John Doe**. There is no chat widget and no MCP
+server here, only the identity pieces and the claims they produce.
+
+Using one cast across all three tabs is deliberate. The overview page puts them side by side, and
+because the domain, the API, and the agent stay the same, the only thing that changes between tabs
+is who the token names and what it is allowed to do.
+
+| Tab | What the Concierge is doing | `sub` | `act` | `scope` |
+|---|---|---|---|---|
+| **Acts as itself** | Recommending flights, nobody's permission needed | the Concierge | none | `booking:read booking:recommend` |
+| **Acts for a customer** | Booking a trip John asked for | John | the Concierge | `booking:read booking:create` |
+| **Delegates to agents** | Handing flight search to a worker | the customer | worker, then Concierge | `booking:read` |
+
+Read the `scope` column downward: authority is granted by role, widened only by a user's consent,
+and narrowed at every delegation. The worker can search but never book, even though John can.
+
+Every token is decoded (without signature verification) and shown in full, with the claims that
+carry the identity story highlighted. Nothing is added: what you see is what ThunderID issued.
+
+## Self-contained resources
+
+Everything the playground imports is its own. Every id is prefixed `agent-identity-`, the resource
+servers use their own identifiers under `travel.example`, and the customer is `johndoe`, so importing
+it will not overwrite or collide with anything else already in your instance. Import is upsert by id,
+so re-importing, or importing the per-tab slices the app offers, is always safe.
+
+## Prerequisites
+
+Only one: **Node 22 or later** (built-in modules only, plus `--env-file`, so no `npm install`).
+
+You do not need to set anything up before opening the app. Every tab checks its own prerequisites
+and walks you through whatever is missing.
+
+## Run
+
+```bash
+cp .env.example .env    # optional; sets THUNDERID_BASE_URL (defaults to https://localhost:8090)
+npm start
+```
+
+Then open http://localhost:8082. The app starts and explains itself whether or not ThunderID is
+running and whether or not anything has been imported.
+
+## How each tab works
+
+Every tab has the same three parts, top to bottom:
+
+1. **The explanation.** What this posture means, drawn as a flow, with the token shape it produces.
+   Always visible, even with nothing set up.
+2. **Try it out.** Checks run live against your instance on every page load. Each tab is
+   self-contained: it never depends on another tab having been visited first, so you can walk any
+   one of them from the top.
+   - **ThunderID is running.** Any answer from the backend counts. If nothing answers, the header
+     pill turns red and the step lists what to fix.
+   - **Import the playground resources.** You complete this one, by clicking **I have imported it, mark
+     as ready**. The step offers the exact resource slice to download, so you never import more than
+     the tab needs, and **Undo** puts it back.
+
+     The app still probes your instance and reports what it saw on the same step, as `Detected: ...`
+     or `Not detected: ...`. That is information, not a gate. The **Acts for a customer** tab also
+     probes the authorize endpoint, so a missing `authorization_code` grant or a mismatched redirect
+     URI is named precisely rather than surfacing later on the gate.
+   - **Sign in as the customer.** Only on the tabs whose story starts with a person. Both the
+     Acts for a customer and Delegates to agents tabs run their own `authorization_code` flow, at
+     their own callback (`/callback` and `/chain/callback`), in their own session. Signing out of
+     one does not affect the other.
+   - **Run it.** Unlocked once the preceding steps are complete. Clicking it performs the real calls.
+
+   Detection informs, you decide. Some prerequisites cannot be proven without actually using them,
+   John's existence being the clearest case, so nothing is auto-completed on your behalf. If you
+   confirm the import and something is in fact missing, the run says so plainly: "The run failed",
+   with exactly the response ThunderID returned.
+3. **The claims.** Decoded tokens, appearing below the steps once you have run it.
+
+Nothing is cached, so reload at any time to recheck. The overview page offers the combined resource
+file if you would rather import everything up front.
+
+### Extra prerequisites for the Acts for a customer tab
+
+It is the only tab that opens a browser login, so it also needs the **Gate UI running**, since
+`authorization_code` redirects there. The normal dev stack (`make run`, or the console and gate dev
+servers) covers this.
+
+You do not need to bring your own user. The resource file creates **John Doe** for you, of the
+built-in `Person` user type, and the tab shows his credentials with a copy button:
+
+```
+username: johndoe
+password: Travel@123
+```
+
+The password is in the resource file in the clear because everything here runs locally.
+
+Every sign-in sends `prompt=consent`, so the Allow screen appears every time. Without it ThunderID
+remembers a granted consent and silently skips the prompt on later logins, which is right for
+production and wrong here.
+
+John holds two roles. `Chat User` grants `agent:access`, which the consent flow checks before it
+will show him the Allow screen, and `Booking User` grants the `booking:read` and `booking:create`
+that end up in his token. A user without `agent:access` is rejected before consent, which is the
+"Protect the Agent" behaviour from the docs.
+
+To skip that tab entirely: `SCENARIOS=self,chain npm start`.
+
+The playground connects to the local self-signed ThunderID over TLS without verifying the certificate,
+scoped to its own request agent (localhost only), so there is no global TLS warning.
+
+## Configure
+
+`config.json` holds where the app serves itself, the scopes, and the agent credentials, which must
+match `thunderid-config/thunderid-config.yaml`:
+
+```json
+{
+  "thunderidBaseUrl": "https://localhost:8090",
+  "appBaseUrl": "http://localhost:8082",
+  "scopes": "openid profile email booking:read booking:create",
+  "resources": {
+    "agent": "https://agent.travel.example",
+    "booking": "https://api.travel.example/booking"
+  },
+  "loginUser": { "username": "johndoe", "password": "Travel@123" },
+  "agents": { "concierge": {...}, "worker": {...} }
+}
+```
+
+`scopes` is what the login asks for on John's behalf. The `resources` entries are RFC 8707 resource
+indicators that bind tokens to a specific API, and each must match a resource server's `identifier`
+in the resource file. They double as readiness probes: an unregistered resource is rejected with
+`invalid_target`, which is how a tab tells whether its own slice was imported. `loginUser` is shown on the Acts for a customer tab so you can copy the
+credentials; it is display only, the real user comes from the import.
+
+The environment (`.env`, loaded automatically) overrides parts of it:
+
+| Variable | Effect |
+|---|---|
+| `THUNDERID_BASE_URL` | The ThunderID backend. Overrides `thunderidBaseUrl`. |
+| `SCENARIOS` | Comma-separated tab ids to enable: `self`, `obo`, `chain`. Defaults to all three. |
+| `PORT` | Port for this app. Defaults to the port in `appBaseUrl`. |
+
+`openid` in `scopes` is what makes ThunderID issue an ID token.
+
+Changing the port while the `obo` tab is enabled means also changing the agent's registered
+`redirectUris` in `thunderid-config/thunderid-config.yaml`, since the callback must match exactly.
+Port 8082 is the default precisely so that no change is needed.
+
+## What each tab shows
+
+### Acts as itself
+
+The Concierge authenticates with its own credentials and asks for a token bound to the booking API.
+No customer is involved, so there is no `act` claim at all.
+
+Watch three things. `sub` is the agent. `aud` is the booking API rather than the agent's own client
+id, because the request carries a `resource` (RFC 8707). And `scope` is `booking:read
+booking:recommend` and nothing more, because that is exactly what the Concierge's own `Recommender`
+role grants. It can recommend a flight; it cannot book one. The remaining highlighted rows are its
+identity claims (`name`, `owner`, `ou*`) and capability attributes (`model`, `modelProvider`,
+`function`), opted in through `token.accessToken.clientConfig.attributes`.
+
+### Acts for a customer
+
+Click **Sign in as John** to start the `authorization_code` flow. The agent is registered with
+`pkceRequired: true`, matching what the Console's Delegated mode sets. PKCE (S256) is used on the
+authorization request and state is validated on the callback. After logging in at the Gate you land
+back on the tab showing:
+
+- **ID token** because `openid` was requested. It identifies the user and never carries `act`.
+- **Access token (on-behalf-of)** carrying `sub` (the user), `act` (the agent), `scope`, plus any
+  allow-listed user attributes (`email`, `username`) the user actually has. Because the OAuth client
+  is an agent, this is an on-behalf-of token by construction, with no extra exchange needed.
+- **Refresh token** used by the action below.
+
+Then use the buttons:
+
+- **Refresh access token** calls the `refresh_token` grant. The access token is reissued (watch
+  `iat`, `jti`, and `exp` change) and still carries the agent as `act`.
+- **Narrow to booking:read for the booking API** calls the token-exchange grant (RFC 8693) with
+  John's access token as `subject_token`, the Concierge's own token as `actor_token`, and a
+  requested `scope` of `booking:read` against the booking resource. Compare `scope` and `aud` with
+  the access token above: `booking:create` is gone. That narrowing is the reason to exchange at all.
+  Without it the result would be indistinguishable from its input, since the actor is the same
+  agent that was already recorded.
+
+### Delegates to agents
+
+Three exchanges, each narrowed to `booking:read`, showing how ThunderID both nests `act` and shrinks
+authority:
+
+| Step | subject_token | actor_token | Resulting token |
+|------|---------------|-------------|-----------------|
+| Hand off the search | customer | Concierge | `{ sub: customer, act: { sub: Concierge } }` |
+| Layered actor | worker | Concierge | `{ sub: worker, act: { sub: Concierge } }` |
+| Whole path | customer | layered actor | `{ sub: customer, act: { sub: worker, act: { sub: Concierge } } }` |
+
+The deep `act` is reachable only by feeding an actor token that already carries a nested `act` (the
+layered actor step), because each exchange builds `act` solely from the `actor_token` and does not
+merge the subject token's existing actor. That is why step 2 exists.
+
+**This tab signs John in itself.** The chain starts with a person asking for something, so step 3
+runs its own login at `/chain/callback` and John consents to `openid booking:read booking:create`.
+The exchanges then narrow that to `booking:read` for the worker. Nothing is borrowed from the Acts
+for a customer tab.
+
+`npm run cli` is the exception: there is no browser, so it uses the Concierge's own token as the
+subject and labels it a stand-in. The `act` nesting is identical; only the subject differs.
+
+To see the same chain in the terminal instead:
+
+```bash
+npm run cli
+```
+
+## Layout
+
+```
+server.mjs                             router, tabs, sessions, overview page, the try-it-out steps
+config.json                            endpoints, scopes, agent credentials
+cli.mjs                                terminal run of the delegation chain
+lib/http.mjs                           OAuth token client over Node's built-in http/https
+lib/jwt.mjs                            JWT decoding for display, and act-chain flattening
+lib/readiness.mjs                      the backend and agent checks behind steps 1 and 2
+lib/resources.mjs                      slices the resource file per scenario for download
+lib/render.mjs                         the page shell, stylesheet, and shared building blocks
+scenarios/self.mjs                     acts as itself
+scenarios/obo.mjs                      acts for a user, plus the login and callback routes
+scenarios/chain.mjs                    delegates to agents
+thunderid-config/thunderid-config.yaml the declarative resources to import into ThunderID
+```
+
+A scenario is one module exporting its tab metadata, an `explain` function for the top of the page,
+a `render` function for the results, the agents it `requires`, and optionally extra `routes` and a
+`check` for prerequisites only it can verify. Adding a fourth posture means adding one file and
+listing it in `server.mjs`.
+
+The per-tab downloads are sliced out of the single `thunderid-config/thunderid-config.yaml` at
+request time by matching each document's `id`, so there is one source of truth for the agent
+definitions and no duplicated YAML.

--- a/samples/apps/agentid-playground/cli.mjs
+++ b/samples/apps/agentid-playground/cli.mjs
@@ -1,0 +1,51 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Command-line run of the delegation-chain scenario: prints the sub and act of each issued token,
+// so you can confirm the actor chain shape without a browser.
+//
+//   npm run cli
+
+import {readFileSync} from "node:fs";
+import {dirname, resolve} from "node:path";
+import {fileURLToPath} from "node:url";
+
+import {createTokenClient} from "./lib/http.mjs";
+import {decodeJwt} from "./lib/jwt.mjs";
+import {runSteps, agentSubject} from "./scenarios/chain.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const config = JSON.parse(readFileSync(resolve(__dirname, "config.json"), "utf8"));
+const baseUrl = process.env.THUNDERID_BASE_URL || config.thunderidBaseUrl;
+
+const client = createTokenClient(baseUrl);
+
+let steps;
+let subject;
+try {
+  // No browser here, so the Concierge's own token stands in for the signed-in customer. Use the
+  // Delegates to agents tab to see the chain rooted in a real one.
+  subject = await agentSubject(client, {...config, thunderidBaseUrl: baseUrl});
+  steps = await runSteps(client, {...config, thunderidBaseUrl: baseUrl}, subject);
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`Could not run the delegation chain against ${baseUrl}\n  ${message}\n`);
+  console.error(
+    /invalid_client/.test(message)
+      ? "The chain agents are missing, or their secrets no longer match config.json.\n" +
+          "Import thunderid-config/thunderid-config.yaml, or open the Delegates to agents tab, which walks you\n" +
+          "through the same checks and offers the file to download."
+      : "Start ThunderID, or point THUNDERID_BASE_URL at the right instance.",
+  );
+  process.exit(1);
+}
+
+console.log(`Delegation chain against ${baseUrl}`);
+console.log(`Subject: ${subject.who}\n`);
+for (const step of steps) {
+  const claims = decodeJwt(step.token)?.claims ?? {};
+  console.log(`${step.title}`);
+  console.log(`  sub:   ${JSON.stringify(claims.sub)}`);
+  console.log(`  act:   ${JSON.stringify(claims.act ?? null)}`);
+  console.log(`  scope: ${JSON.stringify(claims.scope ?? null)}\n`);
+}

--- a/samples/apps/agentid-playground/config.json
+++ b/samples/apps/agentid-playground/config.json
@@ -1,0 +1,23 @@
+{
+  "thunderidBaseUrl": "https://localhost:8090",
+  "appBaseUrl": "http://localhost:8082",
+  "scopes": "openid profile email booking:read booking:create",
+  "resources": {
+    "agent": "https://agent.travel.example",
+    "booking": "https://api.travel.example/booking"
+  },
+  "loginUser": {
+    "username": "johndoe",
+    "password": "Travel@123"
+  },
+  "agents": {
+    "concierge": {
+      "clientId": "agent-identity-concierge-id",
+      "clientSecret": "agent-identity-concierge-secret"
+    },
+    "worker": {
+      "clientId": "agent-identity-flight-search-id",
+      "clientSecret": "agent-identity-flight-search-secret"
+    }
+  }
+}

--- a/samples/apps/agentid-playground/lib/http.mjs
+++ b/samples/apps/agentid-playground/lib/http.mjs
@@ -1,0 +1,134 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Minimal OAuth token client over Node's built-in http/https. No dependencies.
+
+import {request as httpsRequest, Agent as HttpsAgent} from "node:https";
+import {request as httpRequest, Agent as HttpAgent} from "node:http";
+
+export const JWT_TYPE = "urn:ietf:params:oauth:token-type:jwt";
+export const ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
+export const EXCHANGE_GRANT = "urn:ietf:params:oauth:grant-type:token-exchange";
+
+const basicAuth = ({clientId, clientSecret}) =>
+  "Basic " + Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+
+// An instance that accepts the socket but never answers would otherwise leave the page loading
+// forever, and because maxSockets is 1 it would block every later request on the same agent.
+const TIMEOUT_MS = 10000;
+
+// Destroying the request emits `error` with this reason, which rejects the pending promise.
+const failOnTimeout = (req, method, path) =>
+  req.on("timeout", () =>
+    req.destroy(new Error(`${method} ${path} timed out after ${TIMEOUT_MS}ms`)));
+
+export function createTokenClient(baseUrl) {
+  // ThunderID serves a self-signed cert on localhost. Skip verification for local hosts only,
+  // scoped to this agent rather than the whole process (so there is no global NODE_TLS warning).
+  const isLocal = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?(\/|$)/.test(baseUrl);
+  // A single shared keep-alive connection (maxSockets: 1) serializes outbound requests over one
+  // reused socket, and identity encoding disables gzip.
+  const httpsAgent = new HttpsAgent({keepAlive: true, maxSockets: 1, rejectUnauthorized: !isLocal});
+  const httpAgent = new HttpAgent({keepAlive: true, maxSockets: 1});
+
+  function postForm(path, headers, body) {
+    return new Promise((resolveP, rejectP) => {
+      const u = new URL(`${baseUrl}${path}`);
+      const isHttp = u.protocol === "http:";
+      const requester = isHttp ? httpRequest : httpsRequest;
+      const req = requester(
+        {
+          hostname: u.hostname,
+          port: u.port,
+          path: u.pathname + u.search,
+          method: "POST",
+          agent: isHttp ? httpAgent : httpsAgent,
+          timeout: TIMEOUT_MS,
+          headers: {"Accept-Encoding": "identity", ...headers},
+        },
+        (res) => {
+          const chunks = [];
+          res.on("data", (c) => chunks.push(c));
+          res.on("end", () =>
+            resolveP({status: res.statusCode ?? 0, text: Buffer.concat(chunks).toString("utf8")}));
+        },
+      );
+      failOnTimeout(req, "POST", path);
+      req.on("error", rejectP);
+      req.write(body);
+      req.end();
+    });
+  }
+
+  // Plain GET, redirects NOT followed, so readiness checks can read the Location header.
+  function get(path) {
+    return new Promise((resolveP, rejectP) => {
+      const u = new URL(`${baseUrl}${path}`);
+      const isHttp = u.protocol === "http:";
+      const requester = isHttp ? httpRequest : httpsRequest;
+      const req = requester(
+        {
+          hostname: u.hostname,
+          port: u.port,
+          path: u.pathname + u.search,
+          method: "GET",
+          agent: isHttp ? httpAgent : httpsAgent,
+          timeout: TIMEOUT_MS,
+          headers: {"Accept-Encoding": "identity"},
+        },
+        (res) => {
+          const chunks = [];
+          res.on("data", (c) => chunks.push(c));
+          res.on("end", () =>
+            resolveP({
+              status: res.statusCode ?? 0,
+              headers: res.headers,
+              text: Buffer.concat(chunks).toString("utf8"),
+            }));
+        },
+      );
+      failOnTimeout(req, "GET", path);
+      req.on("error", rejectP);
+      req.end();
+    });
+  }
+
+  // POST /oauth2/token authenticated as `credentials`, returning the parsed token response.
+  async function tokenResponse(credentials, params) {
+    const r = await postForm(
+      "/oauth2/token",
+      {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Authorization: basicAuth(credentials),
+        Accept: "application/json",
+      },
+      new URLSearchParams(params).toString(),
+    );
+    if (r.status !== 200) throw new Error(`token request failed (${r.status}): ${r.text.slice(0, 300)}`);
+    return JSON.parse(r.text);
+  }
+
+  const accessToken = async (credentials, params) => (await tokenResponse(credentials, params)).access_token;
+
+  return {
+    baseUrl,
+    get,
+    tokenResponse,
+    accessToken,
+
+    // The agent authenticates with its own credentials and receives a token whose subject is itself.
+    clientCredentials: (credentials) => accessToken(credentials, {grant_type: "client_credentials"}),
+
+    // RFC 8693. `act` is built solely from the actor token, so omitting it omits the actor claim.
+    // `scope` narrows the issued token; ThunderID rejects anything the subject token does not hold.
+    exchange: (credentials, subjectToken, actorToken, {scope, resource} = {}) =>
+      accessToken(credentials, {
+        grant_type: EXCHANGE_GRANT,
+        subject_token: subjectToken,
+        subject_token_type: JWT_TYPE,
+        ...(actorToken ? {actor_token: actorToken, actor_token_type: JWT_TYPE} : {}),
+        ...(scope ? {scope} : {}),
+        ...(resource ? {resource} : {}),
+      }),
+  };
+}

--- a/samples/apps/agentid-playground/lib/jwt.mjs
+++ b/samples/apps/agentid-playground/lib/jwt.mjs
@@ -1,0 +1,31 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// JWT decoding for display only. Signatures are never verified: the playground shows what ThunderID
+// put in the token, they do not consume it as a relying party would.
+
+// Decode only the header and claims segments. The third segment is the binary signature, not JSON.
+export function decodeJwt(token) {
+  try {
+    const [header, claims] = token
+      .split(".")
+      .slice(0, 2)
+      .map((seg) => JSON.parse(Buffer.from(seg.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8")));
+    if (!claims) return null;
+    return {header, claims};
+  } catch {
+    return null;
+  }
+}
+
+// Flatten sub plus the nested act chain into [subject, actor1, actor2, ...], most recent actor
+// first. A token with no act claim yields just the subject.
+export function actorChain(claims) {
+  const out = [{role: "subject", sub: claims.sub}];
+  let a = claims.act;
+  while (a && typeof a === "object") {
+    out.push({role: "actor", sub: a.sub});
+    a = a.act;
+  }
+  return out;
+}

--- a/samples/apps/agentid-playground/lib/login.mjs
+++ b/samples/apps/agentid-playground/lib/login.mjs
@@ -1,0 +1,157 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// A browser sign-in, reusable by any tab that needs one.
+//
+// Each tab that signs a user in owns its own session slot, its own callback path, and its own
+// registered redirect URI, so no tab depends on another having been visited first. Walking a tab
+// from the top always performs the whole flow.
+
+import {randomBytes, createHash} from "node:crypto";
+
+const base64url = (buf) => buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+
+function pkce() {
+  const verifier = base64url(randomBytes(32));
+  return {verifier, challenge: base64url(createHash("sha256").update(verifier).digest())};
+}
+
+// Built once per scenario. `slot` names the session key, `callbackPath` must match a redirect URI
+// registered on the agent, and `returnPath` is the tab to land back on.
+export function createLogin({slot, callbackPath, returnPath, scopes}) {
+  const state = (session) => (session[slot] ??= {});
+  const redirectUri = (config) => `${config.appBaseUrl}${callbackPath}`;
+
+  function authorizeUrl(config, s) {
+    const {verifier, challenge} = pkce();
+    s.state = base64url(randomBytes(16));
+    s.codeVerifier = verifier;
+    return (
+      `${config.thunderidBaseUrl}/oauth2/authorize?` +
+      new URLSearchParams({
+        client_id: config.agents.concierge.clientId,
+        redirect_uri: redirectUri(config),
+        response_type: "code",
+        scope: scopes(config),
+        // Required (RFC 8707). The booking scopes belong to a resource server, and ThunderID
+        // rejects the request with invalid_target if nothing says which one.
+        resource: config.resources.booking,
+        // Consent is remembered once granted, so without this the screen appears only on the very
+        // first sign-in, and this playground exists to show it every time.
+        prompt: "consent",
+        state: s.state,
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      }).toString()
+    );
+  }
+
+  // A tab that signs someone in must verify its own redirect URI, resource, and grant, or step 2
+  // reports ready and the sign-in button then fails on the gate. Living next to the login itself
+  // means adding a new signed-in tab cannot forget it.
+  //
+  // The probe deliberately omits code_challenge. A PKCE-required client answers "code_challenge is
+  // required", which already proves everything else was accepted, and stops before an
+  // authorization session is created.
+  async function probe(client, config) {
+    const params = new URLSearchParams({
+      client_id: config.agents.concierge.clientId,
+      redirect_uri: redirectUri(config),
+      response_type: "code",
+      scope: scopes(config),
+      resource: config.resources.booking,
+      state: "readiness-probe",
+    });
+
+    let location;
+    try {
+      location = (await client.get(`/oauth2/authorize?${params}`)).headers.location ?? "";
+    } catch (err) {
+      return {ok: false, detail: err instanceof Error ? err.message : String(err)};
+    }
+
+    // Two shapes come back: a redirect to our callback carrying error/error_description, or a
+    // redirect to the gate's own error page carrying errorCode/errorMessage. Read both, or a gate
+    // error reads as success.
+    const query = new URLSearchParams(location.split("?")[1] ?? "");
+    const error = query.get("error") ?? query.get("errorCode");
+    const description = query.get("error_description") ?? query.get("errorMessage") ?? "";
+    const verified = `${callbackPath} accepted, with its scopes and resource.`;
+
+    if (!error) return {ok: true, detail: verified};
+    if (/code_challenge/i.test(description)) return {ok: true, detail: `${verified} PKCE enforced.`};
+    if (error === "unauthorized_client") {
+      return {
+        ok: false,
+        detail:
+          "The Concierge rejects authorization_code. Re-import this tab's resource file so its " +
+          "grantTypes include it.",
+      };
+    }
+    if (/redirect/i.test(description) || /Invalid redirect URI/i.test(location)) {
+      return {
+        ok: false,
+        detail:
+          `${redirectUri(config)} is not registered on the Concierge, so signing in would fail. ` +
+          "Re-import this tab's resource file, which lists it under redirectUris.",
+      };
+    }
+    if (/invalid_target/.test(error)) {
+      return {
+        ok: false,
+        detail: `${config.resources.booking} is not a registered resource server, so the sign-in would fail with invalid_target.`,
+      };
+    }
+    return {ok: false, detail: `${error}: ${description}`};
+  }
+
+  return {
+    slot,
+    state,
+    redirectUri,
+    scopes,
+    probe,
+    isSignedIn: (session) => Boolean(state(session).tokens),
+    reset: (session) => {
+      session[slot] = {};
+    },
+
+    routes: (errorPage) => ({
+      [`GET ${returnPath}/login`]: ({res, session, config, redirect}) =>
+        redirect(res, authorizeUrl(config, state(session))),
+
+      [`GET ${callbackPath}`]: async ({res, url, session, config, client, redirect, sendPage}) => {
+        const s = state(session);
+        const err = url.searchParams.get("error");
+        if (err) {
+          return sendPage(
+            errorPage(`Authorization failed: ${err} ${url.searchParams.get("error_description") ?? ""}`),
+            400,
+          );
+        }
+        const code = url.searchParams.get("code");
+        const returned = url.searchParams.get("state");
+        if (!code || !returned || returned !== s.state) {
+          return sendPage(errorPage("Invalid callback: missing code or state mismatch."), 400);
+        }
+        s.tokens = await client.tokenResponse(config.agents.concierge, {
+          grant_type: "authorization_code",
+          code,
+          redirect_uri: redirectUri(config),
+          code_verifier: s.codeVerifier ?? "",
+        });
+        s.state = undefined;
+        s.codeVerifier = undefined;
+        s.refreshed = false;
+        s.exchange = undefined;
+        s.note = undefined;
+        return redirect(res, returnPath);
+      },
+
+      [`GET ${returnPath}/logout`]: ({res, session, redirect}) => {
+        session[slot] = {};
+        return redirect(res, returnPath);
+      },
+    }),
+  };
+}

--- a/samples/apps/agentid-playground/lib/readiness.mjs
+++ b/samples/apps/agentid-playground/lib/readiness.mjs
@@ -1,0 +1,84 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {decodeJwt} from "./jwt.mjs";
+
+// Readiness checks behind the "Try it out" steps.
+//
+// The app has to be useful before anything is imported, so every tab checks its own prerequisites
+// and says exactly which one is missing instead of failing with a raw token error.
+
+// Node raises an AggregateError with an empty message when every address for a host refuses the
+// connection, which is the usual "ThunderID is not running" case, so read the causes instead.
+function connectionError(err) {
+  if (err?.errors?.length) {
+    const causes = [...new Set(err.errors.map((e) => e.message || e.code).filter(Boolean))];
+    if (causes.length) return causes.join("; ");
+  }
+  return err?.message || err?.code || String(err);
+}
+
+// Authenticating proves the agent exists; it proves nothing about what the agent may do. ThunderID
+// issues a scopeless token rather than an error when you ask for scopes the principal has not been
+// granted, so a tab whose whole point is the scope claim has to check the claim itself.
+export async function checkScopes(client, credentials, {scope, resource, expect, role}) {
+  let token;
+  try {
+    token = await client.accessToken(credentials, {grant_type: "client_credentials", scope, resource});
+  } catch (err) {
+    return {ok: false, detail: err instanceof Error ? err.message : String(err)};
+  }
+
+  const granted = String(decodeJwt(token)?.claims?.scope ?? "").split(" ").filter(Boolean);
+  if (!granted.length) {
+    return {
+      ok: false,
+      detail:
+        `the agent authenticates, but its token carries no scope at all, so this tab would show ` +
+        `nothing to narrow. The ${role} role that grants ${expect.join(" and ")} is missing: ` +
+        `re-import this tab's resource file.`,
+    };
+  }
+  const missing = expect.filter((s) => !granted.includes(s));
+  if (missing.length) {
+    return {ok: false, detail: `token is missing ${missing.join(", ")}. Granted: ${granted.join(" ")}`};
+  }
+  return {ok: true, detail: `scopes granted: ${granted.join(" ")}`};
+}
+
+// Step 1. Any HTTP answer means the server is up; only a connection-level failure means it is not.
+export async function checkBackend(client) {
+  try {
+    const r = await client.get("/health/liveness");
+    return {ok: true, detail: `answered ${r.status} on /health/liveness`};
+  } catch (err) {
+    return {ok: false, detail: connectionError(err)};
+  }
+}
+
+// Step 2. An agent that can mint its own token exists and its secret matches config.json.
+// invalid_client means the import has not happened (or the credentials drifted).
+export async function checkAgents(client, required, agents) {
+  const results = [];
+  for (const {key, id} of required) {
+    const credentials = agents[key];
+    if (!credentials) {
+      results.push({id, ok: false, detail: `no "${key}" entry in config.json`});
+      continue;
+    }
+    try {
+      await client.clientCredentials(credentials);
+      results.push({id, ok: true, detail: "found"});
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      results.push({
+        id,
+        ok: false,
+        detail: /invalid_client/.test(message)
+          ? "not found, or its clientSecret does not match config.json"
+          : message,
+      });
+    }
+  }
+  return {ok: results.every((r) => r.ok), results};
+}

--- a/samples/apps/agentid-playground/lib/render.mjs
+++ b/samples/apps/agentid-playground/lib/render.mjs
@@ -1,0 +1,413 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Shared HTML rendering: one page shell, one stylesheet, one set of building blocks that every
+// scenario reuses. Scenarios return fragments; the shell wraps them.
+//
+// Drop-in replacement for lib/render.mjs. Same exports and same class names, restyled:
+//   - light/dark theme with a header toggle (persisted in localStorage)
+//   - staged entrance animation on the flow diagram, replayable
+//   - claim rows can be flagged as changed, for the refresh diff
+//
+// Strings passed as `label`, `note`, and `subtitle` are author-written literals and may contain
+// markup (a <code> span, a <br/> in a flow edge). Anything derived from a token is escaped.
+
+import {decodeJwt, actorChain} from "./jwt.mjs";
+
+// The ThunderID mark, from docs/static/assets/images/logo-mini.svg, shown in the dashboard header
+// only. Inlined so the page stays self-contained, with the dark path driven by a variable so it
+// flips white in dark mode exactly as the shipped logo-mini-inverted.svg does.
+const LOGO = `<svg viewBox="0 0 207 257" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M55.4763 26.4391L58.8866 0H0V26.4391H55.4763Z" fill="var(--logo-ink)"/><path d="M39.8438 147.407L49.5455 72.2839H4.9909e-05V256.743H60.5602L80.048 147.407H39.8438Z" fill="#3688FF"/><path d="M192.42 59.361C182.782 40.2307 168.929 25.5705 150.903 15.3381C145.501 12.2662 139.761 9.6605 133.703 7.5208L115.401 103.702H159.757L76.2987 256.743H83.3735C109.449 256.743 131.69 251.574 150.14 241.236C168.569 230.897 182.634 216.131 192.356 196.959C202.058 177.765 206.909 154.8 206.909 128.043C206.909 101.286 202.079 78.5123 192.441 59.3821L192.42 59.361Z" fill="#3688FF"/></svg>`;
+
+// Quotes are escaped too, because esc is also used inside double-quoted attributes (the copy
+// button's data-copy), where an unescaped quote would end the attribute early.
+export const esc = (s) =>
+  String(s).replace(
+    /[&<>"']/g,
+    (c) => ({"&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"})[c],
+  );
+
+const STYLES = `
+  :root {
+    --bg:#f6f5f2; --panel:#fff; --panel2:#faf9f6; --line:#e5e2db; --line2:#efece5;
+    --ink:#141413; --ink2:#57564f; --ink3:#8b8981;
+    --brand:#5b3df5; --brand-soft:#efeaff;
+    --subject:#2563eb; --subject-soft:#e8efff;
+    --actor:#c2700a; --actor-soft:#fdf1de;
+    --resource:#08805a; --resource-soft:#e3f5ee;
+    --hl:#fff7dd; --ok-bg:#e6f5ec; --ok-ink:#14683a;
+    --warn-bg:#fdf4d9; --warn-ink:#7a5606; --err-bg:#fdeceb; --err-ink:#a8201c;
+    --code-bg:#f2f1ec; --logo-ink:#05213F;
+    --shadow:0 1px 2px rgba(20,20,19,.05), 0 10px 28px -16px rgba(20,20,19,.28);
+  }
+  html[data-theme="dark"] {
+    --bg:#0c0e11; --panel:#14171c; --panel2:#191d23; --line:#262b33; --line2:#1e232a;
+    --ink:#e9eaec; --ink2:#a5aab3; --ink3:#737985;
+    --brand:#9d8bff; --brand-soft:#201c3a;
+    --subject:#6ba5fb; --subject-soft:#12243c;
+    --actor:#f0b445; --actor-soft:#2d2211;
+    --resource:#3ddba0; --resource-soft:#0d2a21;
+    --hl:#2b2513; --ok-bg:#0f2a1c; --ok-ink:#6fe3a6;
+    --warn-bg:#2d2410; --warn-ink:#f0cb70; --err-bg:#2d1416; --err-ink:#ff9a95;
+    --code-bg:#1b1f26; --logo-ink:#fff;
+    --shadow:0 1px 2px rgba(0,0,0,.5), 0 14px 34px -18px rgba(0,0,0,.8);
+  }
+  * { box-sizing: border-box; }
+  html { background: var(--bg); }
+  body {
+    margin: 0; background: var(--bg); color: var(--ink);
+    font-family: "IBM Plex Sans", system-ui, -apple-system, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  code, pre { font-family: "IBM Plex Mono", ui-monospace, monospace; }
+  a { color: var(--brand); text-decoration: none; }
+  a:hover { color: var(--ink); }
+
+  .topbar { position: sticky; top: 0; z-index: 20; background: var(--panel); border-bottom: 1px solid var(--line); }
+  .topbar .row { max-width: 1120px; margin: 0 auto; padding: 14px 28px; display: flex; align-items: center; gap: 18px; }
+  .brand { display: flex; align-items: center; gap: 10px; margin-right: auto; }
+  .brand .mark { display: block; width: 22px; height: 27px; }
+  .brand .mark svg { display: block; width: 100%; height: 100%; }
+  .brand .name { font-size: 14px; font-weight: 600; letter-spacing: -.01em; display: block; }
+  .brand .host { font-size: 11px; color: var(--ink3); }
+  .status { display: flex; align-items: center; gap: 7px; font-size: 12px; font-family: "IBM Plex Mono", monospace; color: var(--ink2); background: var(--panel2); border: 1px solid var(--line); border-radius: 999px; padding: 6px 12px; }
+  .status .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--resource); animation: pulseDot 2s ease-in-out infinite; }
+  .theme-toggle { font: inherit; font-size: 13px; width: 34px; height: 34px; display: grid; place-items: center; background: var(--panel2); border: 1px solid var(--line); border-radius: 10px; cursor: pointer; color: var(--ink2); }
+  .theme-toggle:hover { border-color: var(--ink3); color: var(--ink); }
+
+  main { max-width: 1120px; margin: 0 auto; padding: 36px 28px 96px; }
+  h1 { margin: 0 0 10px; font-size: 34px; line-height: 1.12; letter-spacing: -.025em; font-weight: 600; max-width: 20ch; }
+  .lead { margin: 0; font-size: 15px; line-height: 1.6; color: var(--ink2); max-width: 68ch; text-wrap: pretty; }
+  .eyebrow { margin: 0 0 8px; font-size: 11px; font-weight: 600; letter-spacing: .09em; text-transform: uppercase; color: var(--brand); }
+  .muted { color: var(--ink3); font-size: 12px; }
+
+  nav.tabs { max-width: 1120px; margin: 0 auto; padding: 0 28px; display: flex; gap: 2px; flex-wrap: wrap; }
+  nav.tabs a { font-size: 13px; color: var(--ink3); border-bottom: 2px solid transparent; padding: 10px 14px 12px; white-space: nowrap; }
+  nav.tabs a:hover { color: var(--ink); }
+  nav.tabs a.active { color: var(--ink); font-weight: 600; border-bottom-color: var(--brand); }
+
+  section { background: var(--panel); border: 1px solid var(--line); border-radius: 14px; padding: 20px 24px 22px; margin: 18px 0 0; box-shadow: var(--shadow); animation: riseIn .45s ease both; }
+  section h2 { margin: 0 0 6px; font-size: 16px; font-weight: 600; letter-spacing: -.015em; }
+  section .sub { margin: 0 0 16px; font-size: 13px; line-height: 1.6; color: var(--ink2); max-width: 82ch; text-wrap: pretty; }
+  h3 { margin: 18px 0 8px; font-size: 11px; text-transform: uppercase; letter-spacing: .07em; color: var(--ink3); font-weight: 600; }
+
+  table { width: 100%; border-collapse: collapse; border: 1px solid var(--line2); border-radius: 10px; overflow: hidden; }
+  th { text-align: left; font-size: 11px; letter-spacing: .07em; text-transform: uppercase; color: var(--ink3); font-weight: 600; padding: 8px 12px; border-bottom: 1px solid var(--line); background: var(--panel2); }
+  td { padding: 7px 12px; border-bottom: 1px solid var(--line2); font-family: "IBM Plex Mono", monospace; font-size: 12px; vertical-align: top; word-break: break-word; color: var(--ink); }
+  td:first-child { width: 190px; color: var(--ink2); }
+  tr.hl { background: var(--hl); }
+  tr.hl td:first-child { color: var(--ink); }
+  tr.changed { background: var(--brand-soft); animation: flashRow 1.6s ease 1.1s forwards; }
+  tr.changed td:first-child::after { content: "changed"; float: right; font-size: 10px; text-transform: uppercase; letter-spacing: .05em; color: var(--brand); }
+
+  pre { margin: 0; background: var(--code-bg); border-radius: 10px; padding: 13px 15px; font-size: 12px; line-height: 1.6; overflow-x: auto; color: var(--ink); }
+  pre.tok { white-space: pre-wrap; word-break: break-all; font-size: 11.5px; line-height: 1.7; color: var(--ink2); }
+
+  .cards { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; margin: 32px 0 0; }
+  @media (max-width: 860px) { .cards { grid-template-columns: 1fr; } }
+  .card { background: var(--panel); border: 1px solid var(--line); border-radius: 14px; padding: 20px; color: var(--ink); box-shadow: var(--shadow); display: flex; flex-direction: column; gap: 10px; animation: riseIn .5s ease both; }
+  .card:hover { border-color: var(--brand); transform: translateY(-2px); color: var(--ink); }
+  .card .card-icon { font-size: 26px; line-height: 1; }
+  .card h3 { margin: 0; font-size: 16px; font-weight: 600; letter-spacing: -.01em; text-transform: none; color: var(--ink); }
+  .card p { margin: 0; font-size: 13px; line-height: 1.55; color: var(--ink2); text-wrap: pretty; }
+  .card .shape { display: flex; flex-wrap: wrap; gap: 6px; margin-top: auto; padding-top: 6px; }
+  .card .shape code { font-size: 11px; background: var(--subject-soft); color: var(--subject); padding: 3px 8px; border-radius: 6px; }
+
+  .story { background: var(--panel2); border: 1px solid var(--line); border-radius: 14px; padding: 20px 22px; margin: 28px 0 0; }
+  .story h2 { margin: 0 0 16px; font-size: 14px; font-weight: 600; }
+  .flow { display: flex; align-items: stretch; gap: 4px; flex-wrap: wrap; }
+  .node { flex: 1 1 130px; min-width: 122px; background: var(--panel); border: 1px solid var(--line); border-radius: 12px; padding: 14px 10px; text-align: center; box-shadow: var(--shadow); animation: popIn .45s cubic-bezier(.2,.9,.3,1.2) both; }
+  .node.subject { border-color: var(--subject); } .node.subject .node-role { color: var(--subject); }
+  .node.actor { border-color: var(--actor); } .node.actor .node-role { color: var(--actor); }
+  .node.resource { border-color: var(--resource); } .node.resource .node-role { color: var(--resource); }
+  .node-icon { font-size: 24px; line-height: 1; }
+  .node-name { font-weight: 600; font-size: 12.5px; margin-top: 8px; letter-spacing: -.01em; }
+  .node-role { font-size: 10px; color: var(--ink3); text-transform: uppercase; letter-spacing: .05em; margin-top: 4px; font-weight: 500; }
+  .edge { flex: 0 1 78px; min-width: 62px; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 3px; color: var(--ink3); animation: drawEdge .45s ease both; }
+  .edge .edge-label { font-size: 10px; line-height: 1.25; text-align: center; }
+  .edge .arrow { font-size: 15px; line-height: 1; }
+  .token-chip { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin: 16px 0 8px; }
+  .token-chip .k { font-size: 11px; text-transform: uppercase; letter-spacing: .06em; color: var(--ink3); }
+  .token-chip code { font-size: 11.5px; background: var(--subject-soft); color: var(--subject); padding: 4px 9px; border-radius: 7px; }
+  .story-note { margin: 0; font-size: 12.5px; line-height: 1.65; color: var(--ink2); max-width: 84ch; text-wrap: pretty; }
+  .replay { font: inherit; font-size: 11px; color: var(--ink2); background: var(--panel); border: 1px solid var(--line); border-radius: 7px; padding: 4px 10px; cursor: pointer; float: right; }
+  .replay:hover { border-color: var(--brand); color: var(--brand); }
+
+  ol.chain { margin: 0 0 4px; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 6px; }
+  ol.chain li { display: flex; align-items: center; gap: 10px; background: var(--panel2); border: 1px solid var(--line2); border-left: 2px solid var(--actor); border-radius: 8px; padding: 8px 12px; font-family: "IBM Plex Mono", monospace; font-size: 12.5px; color: var(--actor); }
+  ol.chain li:first-child { border-left-color: var(--subject); color: var(--subject); }
+  .badge { min-width: 128px; font-family: "IBM Plex Sans", sans-serif; font-size: 10.5px; text-transform: uppercase; letter-spacing: .05em; color: var(--ink3); }
+
+  .actions { display: flex; gap: 8px; flex-wrap: wrap; }
+  button, .btn { font: inherit; font-size: 13px; padding: 9px 15px; border-radius: 9px; border: 1px solid var(--line); background: var(--panel2); color: var(--ink); cursor: pointer; }
+  button:hover, .btn:hover { border-color: var(--brand); color: var(--brand); }
+  .btn.primary { background: var(--brand); color: #fff; border-color: var(--brand); font-size: 14px; padding: 11px 20px; border-radius: 10px; }
+  .btn.primary:hover { color: #fff; filter: brightness(1.08); transform: translateY(-1px); }
+
+  .obo, .banner, .ok, .warn, .error { border-radius: 10px; padding: 11px 13px; font-size: 12.5px; line-height: 1.55; margin: 0 0 18px; }
+  .obo { background: var(--subject-soft); color: var(--subject); }
+  .banner, .ok { background: var(--ok-bg); color: var(--ok-ink); }
+  .warn { background: var(--warn-bg); color: var(--warn-ink); }
+  .error { background: var(--err-bg); color: var(--err-ink); font-family: "IBM Plex Mono", monospace; font-size: 12px; }
+  .obo code, .banner code, .ok code, .warn code { background: rgba(127,127,127,.14); padding: 1px 5px; border-radius: 4px; }
+
+  .status.down .dot { background: var(--err-ink); }
+
+  section.blocked { border-left: 3px solid var(--err-ink); }
+  .steps { display: flex; flex-direction: column; }
+  .step { display: flex; gap: 14px; padding: 16px 0; border-top: 1px solid var(--line2); }
+  .step:first-child { border-top: 0; padding-top: 4px; }
+  .step:last-child { padding-bottom: 0; }
+  .step-num { flex: 0 0 26px; width: 26px; height: 26px; border-radius: 50%; display: grid; place-items: center; font-size: 12px; font-weight: 600; background: var(--panel2); border: 1px solid var(--line); color: var(--ink3); }
+  .step.done .step-num { background: var(--resource); border-color: var(--resource); color: #fff; }
+  .step.active .step-num { background: var(--brand); border-color: var(--brand); color: #fff; }
+  .step-body { flex: 1 1 auto; min-width: 0; }
+  .step-head { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }
+  .step-title { font-size: 14px; font-weight: 600; letter-spacing: -.01em; }
+  .step-note { margin: 6px 0 0; font-size: 12.5px; line-height: 1.6; color: var(--ink2); max-width: 80ch; text-wrap: pretty; }
+  .step-note code { background: var(--code-bg); padding: 1px 5px; border-radius: 4px; font-size: 11.5px; }
+  .step-detail { margin: 8px 0 0; font-family: "IBM Plex Mono", monospace; font-size: 11.5px; line-height: 1.6; color: var(--ink3); word-break: break-word; }
+  .step.failed .step-detail { background: var(--err-bg); color: var(--err-ink); border-radius: 8px; padding: 9px 11px; }
+  .step.unverified .step-num { background: var(--warn-bg); border-color: var(--warn-ink); color: var(--warn-ink); }
+  .step.unverified .step-detail { background: var(--warn-bg); color: var(--warn-ink); border-radius: 8px; padding: 9px 11px; }
+  .step-actions { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; margin: 12px 0 0; }
+  .tag { font-size: 10px; text-transform: uppercase; letter-spacing: .06em; font-weight: 600; padding: 3px 8px; border-radius: 6px; background: var(--panel2); border: 1px solid var(--line); color: var(--ink3); }
+  .tag.ok { background: var(--ok-bg); border-color: transparent; color: var(--ok-ink); }
+  .tag.bad { background: var(--err-bg); border-color: transparent; color: var(--err-ink); }
+  .tag.warn { background: var(--warn-bg); border-color: transparent; color: var(--warn-ink); }
+  button[disabled], .btn[disabled] { opacity: .45; cursor: not-allowed; }
+  button[disabled]:hover, .btn[disabled]:hover { border-color: var(--line); color: var(--ink); }
+  ul.fixes { margin: 10px 0 0; padding-left: 18px; display: flex; flex-direction: column; gap: 6px; }
+  ul.fixes li { font-size: 12.5px; line-height: 1.6; color: var(--ink2); }
+
+  .step-actions .creds { flex: 1 1 100%; margin: 4px 0 0; }
+  .creds { margin: 12px 0 0; background: var(--panel2); border: 1px solid var(--line); border-radius: 10px; padding: 12px 14px; }
+  .creds-title { font-size: 11px; text-transform: uppercase; letter-spacing: .06em; color: var(--ink3); font-weight: 600; }
+  .creds-note { margin: 4px 0 10px; font-size: 12.5px; line-height: 1.55; color: var(--ink2); }
+  .cred { display: flex; align-items: center; gap: 10px; padding: 5px 0; }
+  .cred-k { flex: 0 0 78px; font-size: 11.5px; color: var(--ink3); }
+  .cred-v { flex: 1 1 auto; font-family: "IBM Plex Mono", monospace; font-size: 12.5px; background: var(--code-bg); padding: 4px 9px; border-radius: 6px; word-break: break-all; }
+  button.copy { font: inherit; font-size: 11px; padding: 4px 10px; border-radius: 6px; border: 1px solid var(--line); background: var(--panel); color: var(--ink2); cursor: pointer; flex: 0 0 auto; }
+  button.copy:hover { border-color: var(--brand); color: var(--brand); }
+  button.copy.copied { border-color: var(--resource); color: var(--resource); }
+
+  @keyframes riseIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: none; } }
+  @keyframes popIn { from { opacity: 0; transform: scale(.94); } to { opacity: 1; transform: none; } }
+  @keyframes drawEdge { from { opacity: 0; transform: translateX(-8px); } to { opacity: 1; transform: none; } }
+  @keyframes flashRow { to { background: var(--hl); } }
+  @keyframes pulseDot { 0%, 100% { opacity: 1; } 50% { opacity: .35; } }
+  @media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+`;
+
+// Theme persistence plus a replay button for the flow animation. Small enough to inline.
+const SCRIPT = `
+(function () {
+  var root = document.documentElement;
+  var saved = localStorage.getItem("aid-theme");
+  if (saved) root.dataset.theme = saved;
+  else if (window.matchMedia && matchMedia("(prefers-color-scheme: dark)").matches) root.dataset.theme = "dark";
+  function icon() { return root.dataset.theme === "dark" ? "\\u2600" : "\\u263e"; }
+  document.addEventListener("DOMContentLoaded", function () {
+    var btn = document.querySelector(".theme-toggle");
+    if (btn) {
+      btn.textContent = icon();
+      btn.addEventListener("click", function () {
+        root.dataset.theme = root.dataset.theme === "dark" ? "light" : "dark";
+        localStorage.setItem("aid-theme", root.dataset.theme);
+        btn.textContent = icon();
+      });
+    }
+    document.addEventListener("click", function (e) {
+      var btn = e.target.closest && e.target.closest("button.copy");
+      if (!btn) return;
+      navigator.clipboard.writeText(btn.dataset.copy).then(function () {
+        var was = btn.textContent;
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        setTimeout(function () { btn.textContent = was; btn.classList.remove("copied"); }, 1400);
+      });
+    });
+    var replay = document.querySelector(".replay");
+    var flow = document.querySelector(".flow");
+    if (replay && flow) replay.addEventListener("click", function () {
+      var clone = flow.cloneNode(true);
+      flow.parentNode.replaceChild(clone, flow);
+      flow = clone;
+    });
+  });
+})();
+`;
+
+// A step: {n, title, state: "done"|"active"|"todo"|"failed", tag, note, detail, actions}.
+// `note`, `detail`, and `actions` are author-written literals and may contain markup.
+export function steps(items) {
+  return (
+    `<div class="steps">` +
+    items
+      .map((s) => {
+        const failed = s.state === "failed";
+        const cls = failed ? "failed" : s.state;
+        return `<div class="step ${cls}">
+  <div class="step-num">${failed ? "!" : s.state === "done" ? "&#10003;" : s.n}</div>
+  <div class="step-body">
+    <div class="step-head"><span class="step-title">${esc(s.title)}</span>${
+      s.tag ? `<span class="tag ${s.tagKind ?? ""}">${esc(s.tag)}</span>` : ""
+    }</div>
+    ${s.note ? `<p class="step-note">${s.note}</p>` : ""}
+    ${s.detail ? `<p class="step-detail">${s.detail}</p>` : ""}
+    ${s.actions ? `<div class="step-actions">${s.actions}</div>` : ""}
+  </div>
+</div>`;
+      })
+      .join("") +
+    `</div>`
+  );
+}
+
+// A labelled value with a copy button, for credentials the reader has to type somewhere else.
+export function credentials({title, note, fields}) {
+  const rows = fields
+    .map(
+      ({label, value}) => `<div class="cred">
+  <span class="cred-k">${esc(label)}</span>
+  <code class="cred-v">${esc(value)}</code>
+  <button class="copy" type="button" data-copy="${esc(value)}">Copy</button>
+</div>`,
+    )
+    .join("");
+  return `<div class="creds">
+  <div class="creds-title">${esc(title)}</div>
+  ${note ? `<p class="creds-note">${note}</p>` : ""}
+  ${rows}
+</div>`;
+}
+
+export function page({title, heading, lead, nav = "", body, eyebrow = "", host = "", hostOk = true, appName = ""}) {
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>${esc(title)}</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+<style>${STYLES}</style><script>${SCRIPT}</script></head><body>
+<header class="topbar">
+  <div class="row">
+    <div class="brand">
+      <span class="mark">${LOGO}</span>
+      <div><span class="name">${esc(appName)}</span><span class="host">ThunderID</span></div>
+    </div>
+    <div class="status${hostOk ? "" : " down"}"><span class="dot"></span><span>${esc(hostOk ? host : "unreachable")}</span></div>
+    <button class="theme-toggle" type="button" aria-label="Toggle theme">&#9790;</button>
+  </div>
+  ${nav}
+</header>
+<main>
+  ${eyebrow ? `<p class="eyebrow">${esc(eyebrow)}</p>` : ""}
+  <h1>${esc(heading)}</h1>
+  <p class="lead">${lead}</p>
+  ${body}
+</main>
+</body></html>`;
+}
+
+export function tabs(scenarios, activeId) {
+  const link = (href, label, id) =>
+    `<a href="${href}"${id === activeId ? ' class="active"' : ""}>${esc(label)}</a>`;
+  return `<nav class="tabs">${link("/", "Overview", "overview")}${scenarios
+    .map((s) => link(`/${s.id}`, `${s.icon} ${s.nav}`, s.id))
+    .join("")}</nav>`;
+}
+
+// items: {icon, name, role, kind} for a node, or {edge: "label"} for the arrow between two nodes.
+// Each item enters in sequence, so the flow reads as something that happens rather than a picture.
+export function flow(items) {
+  let delay = 0;
+  return (
+    `<div class="flow">` +
+    items
+      .map((it) => {
+        delay += 0.14;
+        const style = ` style="animation-delay:${delay.toFixed(2)}s"`;
+        return it.edge !== undefined
+          ? `<div class="edge"${style}><span class="edge-label">${it.edge}</span><span class="arrow">&rarr;</span></div>`
+          : `<div class="node${it.kind ? ` ${it.kind}` : ""}"${style}><div class="node-icon">${it.icon}</div>` +
+              `<div class="node-name">${esc(it.name)}</div><div class="node-role">${esc(it.role)}</div></div>`;
+      })
+      .join("") +
+    `</div>`
+  );
+}
+
+export function story({heading, items, chipLabel, chipValues = [], note}) {
+  return `
+<div class="story">
+  <h2>${esc(heading)}<button class="replay" type="button">Replay &#9656;</button></h2>
+  ${flow(items)}
+  <p class="token-chip"><span class="k">${esc(chipLabel)}</span> ${chipValues.map((v) => `<code>${esc(v)}</code>`).join(" ")}</p>
+  <p class="story-note">${note}</p>
+</div>`;
+}
+
+// `changed` marks the claims that differ from the previously issued token (the refresh diff).
+export function claimsTable(claims, highlight = [], changed = []) {
+  const rows = Object.entries(claims)
+    .map(([k, v]) => {
+      const cls = changed.includes(k) ? " class=\"changed\"" : highlight.includes(k) ? ' class="hl"' : "";
+      return `<tr${cls}><td>${esc(k)}</td><td><code>${esc(JSON.stringify(v))}</code></td></tr>`;
+    })
+    .join("");
+  return `<table><thead><tr><th>Claim</th><th>Value</th></tr></thead><tbody>${rows}</tbody></table>`;
+}
+
+export function section({title, subtitle = "", body}) {
+  return `<section><h2>${esc(title)}</h2>${subtitle ? `<p class="sub">${subtitle}</p>` : ""}${body}</section>`;
+}
+
+// Renders the delegation chain of a token as a list: subject first, then each actor.
+export function chainList(claims) {
+  const items = actorChain(claims)
+    .map((n, i) => {
+      const label = n.role === "subject" ? "subject (sub)" : i === 1 ? "actor (act)" : "delegated by (act.act)";
+      return `<li><span class="badge">${label}</span> <code>${esc(n.sub)}</code></li>`;
+    })
+    .join("");
+  return `<ol class="chain">${items}</ol>`;
+}
+
+// `notice` renders above the claims, `extra` below them, both optional.
+// `changed` highlights claims that were reissued, used after a refresh.
+export function tokenSection({title, subtitle = "", token, highlight = [], changed = [], notice = "", extra = "", showHeader = false}) {
+  if (!token) return section({title, subtitle, body: `<p class="muted">not issued</p>`});
+
+  const decoded = decodeJwt(token);
+  if (!decoded) {
+    return section({
+      title,
+      subtitle,
+      body: `${notice}<h3>Raw token (opaque, not a JWT)</h3><pre class="tok">${esc(token)}</pre>`,
+    });
+  }
+  return section({
+    title,
+    subtitle,
+    body: `${notice}
+${showHeader ? `<h3>Decoded header</h3><pre>${esc(JSON.stringify(decoded.header, null, 2))}</pre>` : ""}
+<h3>Decoded claims</h3>
+${claimsTable(decoded.claims, highlight, changed)}
+${extra}
+<h3>Raw token</h3>
+<pre class="tok">${esc(token)}</pre>`,
+  });
+}
+
+// A run that was attempted and rejected, as opposed to a prerequisite that was never met. Shown
+// when the user skipped the readiness check, or when the check passed but reality disagreed.
+export function runError(err, hint = "") {
+  return section({
+    title: "The run failed",
+    subtitle: "The request was sent and ThunderID rejected it. Its exact response is below.",
+    body: errorBox(err) + (hint ? `<p class="step-note">${hint}</p>` : ""),
+  });
+}
+
+export const errorBox = (err) => `<div class="error">${esc(err instanceof Error ? err.message : String(err))}</div>`;

--- a/samples/apps/agentid-playground/lib/resources.mjs
+++ b/samples/apps/agentid-playground/lib/resources.mjs
@@ -1,0 +1,65 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Serves slices of ../thunderid-config/thunderid-config.yaml so each tab can offer exactly the
+// agents it needs.
+//
+// The file is multi-document YAML separated by `---`, and every document declares a top-level
+// `id:`, so selecting documents needs nothing more than a split and a regex. One source of truth,
+// no YAML parser, no duplicated agent definitions.
+
+import {readFileSync} from "node:fs";
+import {dirname, resolve} from "node:path";
+import {fileURLToPath} from "node:url";
+
+const FILE = resolve(dirname(fileURLToPath(import.meta.url)), "..", "thunderid-config", "thunderid-config.yaml");
+
+// Each document keeps its own explanatory comment block, which starts with a `# --- ` marker. Drop
+// anything before that so a slice does not carry the whole file's header.
+function trimToMarker(doc) {
+  const lines = doc.split("\n");
+  const start = lines.findIndex((l) => l.startsWith("# --- "));
+  return (start === -1 ? lines : lines.slice(start)).join("\n").trim();
+}
+
+function documents() {
+  return readFileSync(FILE, "utf8")
+    .split(/^---$/m)
+    .map((doc) => ({id: /^id:\s*(\S+)/m.exec(doc)?.[1], body: trimToMarker(doc)}))
+    .filter((d) => d.id);
+}
+
+// An agent that names an authFlowHandle cannot be created before the flow declaring that handle
+// exists, so a slice containing the agent must contain the flow too. Resolving it here means a
+// scenario cannot forget, which is exactly how the self slice once shipped a broken import.
+function withFlowDependencies(all, selected) {
+  const handles = selected.flatMap((d) =>
+    [...d.body.matchAll(/^authFlowHandle:\s*(\S+)\s*$/gm)].map((m) => m[1]));
+  if (!handles.length) return selected;
+
+  const declaresHandle = (doc) => handles.some((h) => new RegExp(`^handle:\\s*${h}\\s*$`, "m").test(doc.body));
+  // Filter `all` rather than appending, so the flow keeps its position ahead of the agent.
+  return all.filter((d) => selected.includes(d) || declaresHandle(d));
+}
+
+// Returns the YAML text declaring exactly `ids` plus anything they depend on, in file order.
+export function resourceSlice(ids, {title, note}) {
+  const all = documents();
+  const docs = withFlowDependencies(all, all.filter((d) => ids.includes(d.id)));
+  const header = [
+    // Slices are files the reader downloads and keeps, so they carry the licence header the source
+    // file has. trimToMarker drops the source's own header along with each document's preamble.
+    "# Copyright 2026 The ThunderID Authors",
+    "# SPDX-License-Identifier: Apache-2.0",
+    "",
+    `# ThunderID declarative resources: ${title}`,
+    "#",
+    `# ${note}`,
+    "#",
+    "# Import into a running ThunderID instance (Console -> Import, or POST /import).",
+    "",
+  ].join("\n");
+  return header + docs.map((d) => d.body).join("\n\n---\n") + "\n";
+}
+
+export const allResourceIds = () => documents().map((d) => d.id);

--- a/samples/apps/agentid-playground/package.json
+++ b/samples/apps/agentid-playground/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@thunderid/agentid-playground",
+  "private": true,
+  "version": "0.48.0",
+  "description": "Agent identity playground demonstrating the three ways an AI agent can hold identity in ThunderID.",
+  "type": "module",
+  "scripts": {
+    "start": "node --env-file-if-exists=.env server.mjs",
+    "dev": "node --env-file-if-exists=.env server.mjs",
+    "cli": "node --env-file-if-exists=.env cli.mjs"
+  }
+}

--- a/samples/apps/agentid-playground/scenarios/chain.mjs
+++ b/samples/apps/agentid-playground/scenarios/chain.mjs
@@ -1,0 +1,260 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Scenario: the Concierge delegates a sub-task to a worker agent.
+//
+// This is the multi-agent scenario from the docs: a travel-planning agent holds a token scoped to
+// search, read, and book, and hands the search sub-task to a flight-search worker that gets only
+// the search scope. Two things happen at every hop, and both are visible below: the token narrows,
+// and the `act` (actor) claim records who carried the work.
+
+import {story, tokenSection, chainList, section, credentials, errorBox, esc, runError} from "../lib/render.mjs";
+import {checkScopes} from "../lib/readiness.mjs";
+import {decodeJwt} from "../lib/jwt.mjs";
+import {createLogin} from "../lib/login.mjs";
+
+// What the Concierge holds on its own behalf, and what the worker's sub-task actually needs.
+const CONCIERGE_SCOPES = "booking:read booking:recommend";
+const WORKER_SCOPE = "booking:read";
+// What John consents to here. The whole point is that the chain narrows it away.
+const CUSTOMER_SCOPES = "openid booking:read booking:create";
+
+// This tab signs John in itself, at its own callback and in its own session slot, so it can be
+// walked from the top without visiting any other tab first.
+export const login = createLogin({
+  slot: "chain",
+  callbackPath: "/chain/callback",
+  returnPath: "/chain",
+  scopes: () => CUSTOMER_SCOPES,
+});
+
+// For the terminal run, where there is no browser to sign a customer in. The act nesting is
+// identical; only the subject differs, and cli.mjs says so.
+export async function agentSubject(client, config) {
+  return {
+    token: await client.accessToken(config.agents.concierge, {
+      grant_type: "client_credentials",
+      scope: CONCIERGE_SCOPES,
+      resource: config.resources.booking,
+    }),
+    who: "the Concierge (stand-in, no browser)",
+  };
+}
+
+// The delegation chain is rooted in the customer who asked for the trip.
+export function subjectFrom(session) {
+  const token = login.state(session).tokens?.access_token;
+  return token ? {token, who: "John Doe"} : null;
+}
+
+// Runs the three exchanges and returns the issued tokens. Shared with cli.mjs.
+export async function runSteps(client, config, subject) {
+  const {agents, resources} = config;
+  const conciergeTok = await client.accessToken(agents.concierge, {
+    grant_type: "client_credentials",
+    scope: CONCIERGE_SCOPES,
+    resource: resources.booking,
+  });
+  const workerTok = await client.accessToken(agents.worker, {
+    grant_type: "client_credentials",
+    scope: WORKER_SCOPE,
+    resource: resources.booking,
+  });
+
+  const narrow = {scope: WORKER_SCOPE, resource: resources.booking};
+  const singleHop = await client.exchange(agents.worker, subject.token, conciergeTok, narrow);
+  const layeredActor = await client.exchange(agents.worker, workerTok, conciergeTok, narrow);
+  const nestedChain = await client.exchange(agents.worker, subject.token, layeredActor, narrow);
+
+  return [
+    {
+      title: "1 · The Concierge hands off the search",
+      subtitle:
+        `Exchange with subject = ${subject.who}, actor = the Concierge, narrowed to ` +
+        `<code>${WORKER_SCOPE}</code>. One actor is recorded, and the booking scope is gone.`,
+      token: singleHop,
+    },
+    {
+      title: "2 · A layered actor token",
+      subtitle:
+        "Exchange with subject = the worker, actor = the Concierge. This is not a delegation " +
+        "anyone performs for its own sake: it builds a token whose <code>act</code> already nests, " +
+        "to be presented as the actor in the next step.",
+      token: layeredActor,
+    },
+    {
+      title: "3 · The whole path preserved",
+      subtitle:
+        `Exchange with subject = ${subject.who}, actor = the layered token. The customer stays the ` +
+        "subject and both agents appear in the nested <code>act</code>.",
+      token: nestedChain,
+    },
+  ];
+}
+
+const explain = () =>
+  story({
+    heading: "How the Concierge delegates a sub-task",
+    items: [
+      {icon: "👤", name: "John Doe", role: "customer · subject", kind: "subject"},
+      {edge: "asks for a trip"},
+      {icon: "🧭", name: "Concierge", role: "primary agent", kind: "actor"},
+      {edge: "delegates search<br/>(token exchange)"},
+      {icon: "✈️", name: "Flight Search Agent", role: "worker agent", kind: "actor"},
+      {edge: "calls"},
+      {icon: "🗄️", name: "Booking API", role: "resource", kind: "resource"},
+    ],
+    chipLabel: "Final token",
+    chipValues: ["sub = John", "act = Flight Search → Concierge", "scope = booking:read"],
+    note:
+      "The subject stays the customer through every hop, and each delegation records an actor, so " +
+      "the final token's nested <code>act</code> carries the whole path. Authority only shrinks: " +
+      "the worker's token holds <code>booking:read</code> and nothing else, so a compromised " +
+      "worker cannot book a flight even though the customer could. Each exchange builds " +
+      "<code>act</code> solely from the <code>actor_token</code> and never merges the subject " +
+      "token's existing actor, which is why step 2 exists.",
+  });
+
+export default {
+  id: "chain",
+  nav: "Delegates to agents",
+  icon: "✈️",
+  title: "The Concierge delegates to a worker",
+  blurb: "A sub-task handed to a specialist agent, with authority shrinking at the hop.",
+  shape: ["sub = customer", "act = nested agents"],
+  compare: {
+    sub: "the customer",
+    act: "the worker, then the Concierge",
+    grant: "token-exchange (RFC 8693)",
+  },
+  lead:
+    "Complex trips decompose. The Concierge takes the goal and hands the flight search to a " +
+    "specialist worker agent. Each hand-off is a token exchange that narrows what the worker may " +
+    "do while recording who carried the work. Walk the steps below to watch the chain build up.",
+
+  requires: [
+    {key: "concierge", id: "agent-identity-concierge"},
+    {key: "worker", id: "agent-identity-flight-search"},
+  ],
+  resourceIds: [
+    "agent-identity-agent-rs",
+    "agent-identity-booking-rs",
+    "agent-identity-john",
+    "agent-identity-concierge",
+    "agent-identity-flight-search",
+    "agent-identity-chat-user",
+    "agent-identity-booking-user",
+    "agent-identity-recommender",
+    "agent-identity-flight-searcher",
+  ],
+  resource: {
+    title: "the Concierge delegating to a worker",
+    note:
+      "Both resource servers, the consent flow, John Doe, both agents, and the roles that make the" +
+      " worker's authority narrower than his.",
+  },
+  importNote: (config) =>
+    credentials({
+      title: "Sign in as",
+      note: "The resource file creates John Doe for you. You will need these at step 3.",
+      fields: [
+        {label: "Username", value: config.loginUser.username},
+        {label: "Password", value: config.loginUser.password},
+      ],
+    }),
+  run: {
+    n: 4,
+    label: "Run the delegation chain",
+    note:
+      "Mints each agent's own token, then performs the hand-off, the layered actor, and the full " +
+      "chain, each narrowed to <code>booking:read</code>.",
+  },
+
+  async check({client, config}) {
+    const concierge = await checkScopes(client, config.agents.concierge, {
+      scope: CONCIERGE_SCOPES,
+      resource: config.resources.booking,
+      expect: ["booking:read", "booking:recommend"],
+      role: "Recommender",
+    });
+    if (!concierge.ok) return {ok: false, detail: `Concierge: ${concierge.detail}`};
+
+    const worker = await checkScopes(client, config.agents.worker, {
+      scope: WORKER_SCOPE,
+      resource: config.resources.booking,
+      expect: ["booking:read"],
+      role: "Flight Searcher",
+    });
+    if (!worker.ok) return {ok: false, detail: `Flight Search Agent: ${worker.detail}`};
+
+    // This tab signs a customer in at its own callback, so that has to be registered too.
+    const signIn = await login.probe(client, config);
+    if (!signIn.ok) return signIn;
+
+    return {ok: true, detail: `Concierge ${concierge.detail}; worker ${worker.detail}; ${signIn.detail}`};
+  },
+
+  explain,
+
+  routes: login.routes(errorBox),
+
+  // The chain must be rooted in a real customer, so signing in is a step of its own rather than
+  // something borrowed from another tab.
+  gate: ({session}) => {
+    const subject = subjectFrom(session);
+    return {
+      ok: Boolean(subject),
+      step: {
+        n: 3,
+        state: subject ? "done" : "active",
+        title: "Sign in as the customer",
+        tag: subject ? "signed in" : "needed",
+        tagKind: subject ? "ok" : "",
+        note:
+          "The chain starts with a person asking for something, so John signs in and consents " +
+          `to <code>${CUSTOMER_SCOPES}</code> first. The exchanges below then narrow that down to ` +
+          `<code>${WORKER_SCOPE}</code> for the worker.`,
+        actions: subject
+          ? `<span class="muted">Signed in as John Doe.</span><a class="btn" href="/chain/logout">Sign out</a>`
+          : `<a class="btn primary" href="/chain/login">Sign in as John</a>`,
+      },
+    };
+  },
+
+  async render({client, config, session}) {
+    const subject = subjectFrom(session);
+    if (!subject) return "";
+
+    let steps;
+    try {
+      steps = await runSteps(client, config, subject);
+    } catch (err) {
+      return runError(err, "If you skipped the readiness check, this is what it would have warned about. Import this tab's resource file and try again.");
+    }
+
+    const origin = section({
+      title: "Chain rooted in John Doe",
+      subtitle:
+        "The subject below is the customer who signed in on this tab, so this is the full shape a " +
+        "production deployment produces.",
+      body: `<div class="ok">Every token that follows keeps John as <code>sub</code>. Only the actor chain and the scope change.</div>`,
+    });
+
+    return (
+      origin +
+      steps
+        .map((step) => {
+          const claims = decodeJwt(step.token)?.claims ?? {};
+          return tokenSection({
+            title: step.title,
+            subtitle: step.subtitle,
+            token: step.token,
+            highlight: ["sub", "act", "scope", "aud"],
+            notice: `<h3>Delegation chain</h3>${chainList(claims)}`,
+            extra: `<h3>act claim</h3><pre>${esc(JSON.stringify(claims.act ?? null, null, 2))}</pre>`,
+          });
+        })
+        .join("")
+    );
+  },
+};

--- a/samples/apps/agentid-playground/scenarios/obo.mjs
+++ b/samples/apps/agentid-playground/scenarios/obo.mjs
@@ -1,0 +1,272 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Scenario: the Concierge acts on behalf of John Doe.
+//
+// The OAuth client is an agent, so every access token issued from a user login names the user as
+// `sub` and the agent as `act` (actor). That makes it an on-behalf-of token by construction, with no
+// extra exchange required. The refresh and token-exchange actions then show the actor being carried
+// and the authority being narrowed.
+//
+// This is the only scenario that needs a browser round trip, so it owns the extra routes below.
+// `/callback` stays at the root because it must match the agent's registered redirect URI exactly.
+
+import {story, tokenSection, section, credentials, errorBox, esc, runError} from "../lib/render.mjs";
+import {ACCESS_TOKEN_TYPE, JWT_TYPE, EXCHANGE_GRANT} from "../lib/http.mjs";
+import {decodeJwt} from "../lib/jwt.mjs";
+import {createLogin} from "../lib/login.mjs";
+
+// This tab signs John in at /callback, the redirect URI registered on the Concierge.
+const login = createLogin({
+  slot: "obo",
+  callbackPath: "/callback",
+  returnPath: "/obo",
+  scopes: (config) => config.scopes,
+});
+const state = login.state;
+const redirectUri = login.redirectUri;
+
+const tokenRequest = (client, config, params) => client.tokenResponse(config.agents.concierge, params);
+
+// What the exchange narrows the customer's token down to. The login asks for read and create; the
+// exchange keeps only read, which is what makes the result visibly different from its input.
+const EXCHANGE_SCOPE = "booking:read";
+
+function renderStory() {
+  return story({
+    heading: "How the Concierge acts for a customer",
+    items: [
+      {icon: "👤", name: "John Doe", role: "customer · subject", kind: "subject"},
+      {edge: "signs in and consents<br/>(authorization_code)"},
+      {icon: "🧭", name: "Concierge", role: "agent · actor", kind: "actor"},
+      {edge: "on-behalf-of token"},
+      {icon: "🗄️", name: "Booking API", role: "resource", kind: "resource"},
+    ],
+    chipLabel: "Access token",
+    chipValues: ["sub = John", "act = the Concierge", "scope = booking:read booking:create"],
+    note:
+      "Booking a trip needs the customer's permission, so John signs in and approves on the " +
+      "consent screen. The token names John as subject (<code>sub</code>) and the Concierge as " +
+      "actor (<code>act</code>), so the booking API sees both who authorized the trip and which " +
+      "agent carried it out. Compare it with the Concierge's own token on the first tab: same " +
+      "agent, different grant, and <code>booking:create</code> appears only here.",
+  });
+}
+
+// When the token carries an `act` claim, summarize the on-behalf-of relationship: the user is the
+// subject and the agent is the actor. This is what makes an agent token an on-behalf-of token.
+function oboSummary(claims) {
+  const act = claims.act;
+  if (!act || typeof act !== "object") return "";
+  return `<div class="obo">On behalf of, subject (user): <code>${esc(String(claims.sub ?? ""))}</code> &nbsp;·&nbsp; actor (agent): <code>${esc(String(act.sub ?? ""))}</code></div>`;
+}
+
+function dashboard(s) {
+  const t = s.tokens;
+  const banners =
+    (s.refreshed
+      ? `<div class="banner">Refreshed, the access token below is newly issued (compare <code>iat</code>/<code>jti</code>). The actor (<code>act</code>) is preserved.</div>`
+      : "") + (s.note ? `<div class="error">${esc(s.note)}</div>` : "");
+
+  const sessionSection = section({
+    title: "Session",
+    subtitle: `Granted scope: <code>${esc(t.scope ?? "")}</code> · token_type: <code>${esc(t.token_type ?? "")}</code> · expires_in: <code>${esc(t.expires_in ?? "")}</code>`,
+    body: `<div class="actions">
+  <form method="post" action="/obo/refresh" style="margin:0"><button type="submit">Refresh access token</button></form>
+  <form method="post" action="/obo/exchange" style="margin:0"><button type="submit">Narrow to booking:read for the booking API</button></form>
+  <a class="btn" href="/obo/logout">Log out</a>
+</div>`,
+  });
+
+  // After a refresh these three claims are the ones that actually differ, so the table marks them
+  // rather than leaving the reader to compare two long payloads by eye.
+  const changedByRefresh = s.refreshed ? ["iat", "exp", "jti"] : [];
+
+  const withSummary = (token, highlight, title, subtitle, changed = []) => {
+    const claims = token ? decodeJwt(token)?.claims : null;
+    const notice = claims ? oboSummary(claims) : "";
+    return tokenSection({title, subtitle, token, highlight, changed, notice, showHeader: true});
+  };
+
+  return (
+    banners +
+    sessionSection +
+    withSummary(
+      t.id_token,
+      ["sub", "email"],
+      "ID token",
+      "Issued because the openid scope was requested. Identifies the authenticated user. ID tokens never carry an act claim.",
+    ) +
+    withSummary(
+      t.access_token,
+      ["sub", "act", "scope", "aud", "email", "username"],
+      "Access token (on-behalf-of)",
+      "Because the client is an agent, this bearer token names John as sub and the Concierge as act (actor). It carries the booking scopes John's Booking User role grants, and the user attributes userConfig.attributes allow-lists.",
+      changedByRefresh,
+    ) +
+    tokenSection({
+      title: "Refresh token",
+      subtitle: "Used by the refresh_token grant to obtain fresh access tokens without re-login.",
+      token: t.refresh_token,
+    }) +
+    (s.exchange
+      ? withSummary(
+          s.exchange.access_token,
+          ["sub", "act", "scope", "aud"],
+          "Token exchange result (on-behalf-of)",
+          `Exchanged John's access token, presenting the Concierge's own token as <code>actor_token</code> and asking for <code>${EXCHANGE_SCOPE}</code> against the booking API. Compare <code>scope</code> and <code>aud</code> with the access token above: <code>booking:create</code> is gone, so this token can search but no longer book. issued_token_type: <code>${esc(s.exchange.issued_token_type ?? "")}</code>`,
+        )
+      : "")
+  );
+}
+
+export default {
+  id: "obo",
+  nav: "Acts for a customer",
+  icon: "👤",
+  title: "The Concierge acts for a customer",
+  blurb: "John signs in, consents, and the token names both him and the agent.",
+  shape: ["sub = customer", "act = agent"],
+  compare: {
+    sub: "the signed-in customer",
+    act: "the Concierge",
+    grant: "authorization_code, refresh_token, token-exchange",
+  },
+  lead:
+    "Booking a trip spends John's money, so it needs John's permission. He signs in and approves " +
+    "the Concierge on a consent screen, and because the OAuth client is an <strong>agent</strong>, " +
+    "the token names him as <code>sub</code> and the Concierge as <code>act</code> automatically. " +
+    "Walk the steps below to sign in as John and see it.",
+
+  requires: [{key: "concierge", id: "agent-identity-concierge"}],
+  resourceIds: [
+    "agent-identity-agent-rs",
+    "agent-identity-booking-rs",
+    "0193b0a1-2001-7000-8000-000000000001",
+    "agent-identity-john",
+    "agent-identity-concierge",
+    "agent-identity-chat-user",
+    "agent-identity-booking-user",
+  ],
+  resource: {
+    title: "the Concierge acting for a customer",
+    note:
+      "Both resource servers, the consent flow, John Doe, the Concierge, and the two roles that let"
+      + " John reach the agent and grant it his booking permissions.",
+  },
+  importNote: (config) =>
+    credentials({
+      title: "Sign in as",
+      note:
+        "The resource file creates John Doe for you. Use these on the ThunderID gate after you " +
+        "click the button below. He holds <code>Chat User</code>, which the consent flow checks " +
+        "before it will even show him the Allow screen.",
+      fields: [
+        {label: "Username", value: config.loginUser.username},
+        {label: "Password", value: config.loginUser.password},
+      ],
+    }),
+  run: {
+    label: "Sign in as John",
+    href: "/obo/login",
+    note:
+      "Starts the <code>authorization_code</code> flow with PKCE (S256). You land on the ThunderID " +
+      "gate branded with the Concierge's logo, enter John's credentials, and approve the consent " +
+      "screen before coming back holding the tokens.",
+  },
+
+  explain: renderStory,
+
+  // An agent that exists but is registered wrong is the common failure here, so probe the authorize
+  // endpoint and name the problem rather than letting the user discover it on the gate.
+  //
+  // The probe deliberately omits code_challenge. A PKCE-required client then answers
+  // "code_challenge is required", which already proves the client, redirect URI, and grant were all
+  // accepted, and it stops before an authorization session is created.
+  // An agent that exists but is registered wrong is the common failure here, so probe the real
+  // authorize request and name the problem rather than letting the user find it on the gate.
+  async check({client, config}) {
+    // The Concierge and the booking API ship in every tab's slice, so finding them proves nothing
+    // about THIS tab. The agent resource server is unique to this slice, and it travels with John
+    // and his roles, so it is the one thing that distinguishes "obo imported" from "some other tab
+    // imported". Without it the step would go green and the sign-in would then fail on the gate.
+    for (const [label, resource] of [
+      ["agent", config.resources.agent],
+      ["booking", config.resources.booking],
+    ]) {
+      try {
+        await client.accessToken(config.agents.concierge, {grant_type: "client_credentials", resource});
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          ok: false,
+          detail: /invalid_target/.test(message)
+            ? `${resource} is not registered, so this tab's resources are not imported yet. The ` +
+              `${label} resource server ships in this tab's file, along with John and his roles.`
+            : message,
+        };
+      }
+    }
+
+    const result = await login.probe(client, config);
+    return result.ok
+      ? {ok: true, detail: `${result.detail} John and his roles are only proven by signing in.`}
+      : result;
+  },
+
+  hasResult: ({session}) => Boolean(state(session).tokens),
+
+  async render({session}) {
+    const s = state(session);
+    return s.tokens ? dashboard(s) : "";
+  },
+
+  routes: {
+    ...login.routes(errorBox),
+
+    "POST /obo/refresh": async ({res, session, config, client, redirect}) => {
+      const s = state(session);
+      if (!s.tokens?.refresh_token) return redirect(res, "/obo");
+      try {
+        const refreshed = await tokenRequest(client, config, {
+          grant_type: "refresh_token",
+          refresh_token: s.tokens.refresh_token,
+        });
+        // Keep the prior refresh token if the server didn't issue a new one.
+        s.tokens = {...s.tokens, ...refreshed, refresh_token: refreshed.refresh_token ?? s.tokens.refresh_token};
+        s.refreshed = true;
+        s.note = undefined;
+      } catch (e) {
+        s.note = `Refresh failed: ${e instanceof Error ? e.message : String(e)}`;
+      }
+      return redirect(res, "/obo");
+    },
+
+    "POST /obo/exchange": async ({res, session, config, client, redirect}) => {
+      const s = state(session);
+      if (!s.tokens?.access_token) return redirect(res, "/obo");
+      try {
+        // The agent mints its own token to present as the actor, so the exchanged token records the
+        // agent in its act claim. Without an actor_token, token exchange omits act.
+        const agentToken = await tokenRequest(client, config, {grant_type: "client_credentials"});
+        s.exchange = await tokenRequest(client, config, {
+          grant_type: EXCHANGE_GRANT,
+          subject_token: s.tokens.access_token,
+          subject_token_type: JWT_TYPE,
+          actor_token: agentToken.access_token,
+          actor_token_type: JWT_TYPE,
+          requested_token_type: ACCESS_TOKEN_TYPE,
+          // Narrowing is the reason to exchange at all. Without it the result would be
+          // indistinguishable from the token it came from, since the actor is the same agent.
+          scope: EXCHANGE_SCOPE,
+          resource: config.resources.booking,
+        });
+        s.note = undefined;
+      } catch (e) {
+        s.note = `Token exchange failed: ${e instanceof Error ? e.message : String(e)}`;
+      }
+      return redirect(res, "/obo");
+    },
+
+  },
+};

--- a/samples/apps/agentid-playground/scenarios/self.mjs
+++ b/samples/apps/agentid-playground/scenarios/self.mjs
@@ -1,0 +1,107 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Scenario: the Concierge acts as itself.
+//
+// The agent authenticates with its own credentials via the client_credentials grant and asks for a
+// token bound to the booking API. No user is involved, so the subject is the agent and there is no
+// `act` (actor) claim. The scopes it gets back are the ones its Recommender role grants.
+
+import {story, tokenSection, errorBox, runError} from "../lib/render.mjs";
+import {checkScopes} from "../lib/readiness.mjs";
+import {decodeJwt} from "../lib/jwt.mjs";
+
+// The agent's own subject and identity claims, plus the two claims that show the token is bound.
+const HIGHLIGHT = ["sub", "aud", "scope", "name", "owner", "ouId", "ouName", "ouHandle", "model", "modelProvider", "function"];
+
+// What the Concierge asks for on its own behalf. booking:create is deliberately absent: browsing
+// and recommending needs no user, but making a booking does.
+const SCOPES = "booking:read booking:recommend";
+
+export default {
+  id: "self",
+  nav: "Acts as itself",
+  icon: "🧭",
+  title: "The Concierge acts as itself",
+  blurb: "The agent's own token, with no customer anywhere in the picture.",
+  shape: ["sub = agent", "no act"],
+  compare: {sub: "the Concierge", act: "none", grant: "client_credentials"},
+  lead:
+    "Some of what the Concierge does needs nobody's permission: browsing routes, surfacing flight " +
+    "recommendations. For that it uses its own identity, and the token it receives names the agent " +
+    "as the subject with no actor at all. Walk the steps below to run it against your ThunderID.",
+
+  requires: [{key: "concierge", id: "agent-identity-concierge"}],
+  resourceIds: ["agent-identity-booking-rs", "agent-identity-concierge", "agent-identity-recommender"],
+  resource: {
+    title: "the Concierge acting as itself",
+    note: "The booking API, the Concierge, and the Recommender role that grants it booking:recommend.",
+  },
+  run: {
+    label: "Request the Concierge's own token",
+    note:
+      `Calls <code>POST /oauth2/token</code> with <code>grant_type=client_credentials</code>, ` +
+      `<code>scope=${SCOPES}</code>, and a <code>resource</code> naming the booking API.`,
+  },
+
+  check: ({client, config}) =>
+    checkScopes(client, config.agents.concierge, {
+      scope: SCOPES,
+      resource: config.resources.booking,
+      expect: ["booking:read", "booking:recommend"],
+      role: "Recommender",
+    }),
+
+  explain: () =>
+    story({
+      heading: "How the Concierge acts as itself",
+      items: [
+        {icon: "🧭", name: "Concierge", role: "agent · subject", kind: "subject"},
+        {edge: "client_credentials"},
+        {icon: "🔐", name: "ThunderID", role: "authorization server"},
+        {edge: "access token"},
+        {icon: "🗄️", name: "Booking API", role: "resource", kind: "resource"},
+      ],
+      chipLabel: "Token",
+      chipValues: ["sub = the Concierge", "act = none", "scope = booking:read booking:recommend"],
+      note:
+        "The agent authenticates with its own credentials. No customer is involved, so the token's " +
+        "subject is the agent and there is no actor (<code>act</code>) claim. Because the request " +
+        "names a <code>resource</code> (RFC 8707), the token's <code>aud</code> is the booking API " +
+        "rather than the agent itself, and it carries only the scopes the Concierge's own " +
+        "Recommender role grants. It can recommend a flight, but it cannot book one.",
+    }),
+
+  async render({client, config}) {
+    let token;
+    try {
+      token = await client.accessToken(config.agents.concierge, {
+        grant_type: "client_credentials",
+        scope: SCOPES,
+        resource: config.resources.booking,
+      });
+    } catch (err) {
+      return runError(err, "If you skipped the readiness check, this is what it would have warned about. Import this tab's resource file and try again.");
+    }
+
+    const claims = decodeJwt(token)?.claims ?? {};
+    const scope = String(claims.scope ?? "");
+    const notice =
+      claims.act !== undefined
+        ? `<div class="warn">This token unexpectedly carries an <code>act</code> claim. For a pure client_credentials token there should be no actor.</div>`
+        : `<div class="ok">No customer and no <code>act</code> claim: the token represents the agent itself.` +
+          (scope.includes("create")
+            ? ` But it carries <code>booking:create</code>, which the Recommender role should not grant.`
+            : ` Note that <code>booking:create</code> is absent: the Concierge cannot book on its own.`) +
+          `</div>`;
+
+    return tokenSection({
+      title: "Concierge access token (client_credentials)",
+      subtitle:
+        "The agent authenticated with its own credentials and received a token whose subject is the agent, bound to the booking API.",
+      token,
+      highlight: HIGHLIGHT,
+      notice,
+    });
+  },
+};

--- a/samples/apps/agentid-playground/server.mjs
+++ b/samples/apps/agentid-playground/server.mjs
@@ -1,0 +1,442 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// ThunderID Agent Identity Playground.
+//
+// One app, three agent authentication postures, each on its own tab:
+//
+//   /self   the Concierge acts as itself       sub = agent,    no act
+//   /obo    the Concierge acts for John         sub = John,     act = Concierge
+//   /chain  the Concierge delegates to a worker sub = customer, act = worker -> Concierge
+//
+// The cast is a travel-booking one: a Concierge agent, a worker it delegates to, and a customer.
+//
+//   npm start
+//   open http://localhost:8082
+//
+// Set SCENARIOS to run a subset (for example SCENARIOS=self,chain), which is useful when you have
+// only imported some of the resources or want a single posture on screen. Everything else lives in
+// config.json and the environment (see .env.example). No dependencies: Node's built-in modules only.
+
+import {createServer} from "node:http";
+import {readFileSync} from "node:fs";
+import {randomUUID} from "node:crypto";
+import {dirname, resolve} from "node:path";
+import {fileURLToPath} from "node:url";
+
+import {createTokenClient} from "./lib/http.mjs";
+import {checkBackend, checkAgents} from "./lib/readiness.mjs";
+import {resourceSlice, allResourceIds} from "./lib/resources.mjs";
+import {page, tabs, steps, esc, errorBox} from "./lib/render.mjs";
+import self from "./scenarios/self.mjs";
+import obo from "./scenarios/obo.mjs";
+import chain from "./scenarios/chain.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const ALL_SCENARIOS = [self, obo, chain];
+
+const APP_TITLE = "Agent Identity Playground";
+
+// --- config ----------------------------------------------------------------
+
+const file = JSON.parse(readFileSync(resolve(__dirname, "config.json"), "utf8"));
+// THUNDERID_BASE_URL from the environment (see .env.example) overrides config.json.
+const config = {...file, thunderidBaseUrl: process.env.THUNDERID_BASE_URL || file.thunderidBaseUrl};
+const PORT = Number(process.env.PORT) || Number(new URL(config.appBaseUrl).port) || 8082;
+
+const requested = (process.env.SCENARIOS || ALL_SCENARIOS.map((s) => s.id).join(","))
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+const unknown = requested.filter((id) => !ALL_SCENARIOS.some((s) => s.id === id));
+if (unknown.length) {
+  console.error(
+    `[agentid-playground] unknown scenario(s): ${unknown.join(", ")}. ` +
+      `Valid ids: ${ALL_SCENARIOS.map((s) => s.id).join(", ")}`,
+  );
+  process.exit(1);
+}
+const scenarios = ALL_SCENARIOS.filter((s) => requested.includes(s.id));
+
+// The obo login sends the browser to appBaseUrl/callback, which has to match the redirect URI
+// registered on the agent. Serving on a different port silently breaks that, so say so up front.
+const configuredPort = Number(new URL(config.appBaseUrl).port);
+if (scenarios.includes(obo) && configuredPort && PORT !== configuredPort) {
+  console.warn(
+    `[agentid-playground] PORT=${PORT} does not match appBaseUrl (${config.appBaseUrl}). ` +
+      `The obo login will still use ${config.appBaseUrl}/callback as its redirect URI, so it will ` +
+      `fail. Update appBaseUrl and the agent's redirectUris together, or drop obo from SCENARIOS.`,
+  );
+}
+
+// Every agent a scenario needs must have credentials in config.json, and every document it offers
+// for download must exist in the resource file. Both drift silently when the cast is renamed, so
+// fail at startup with the missing name rather than at request time with a property access.
+const configuredIds = new Set(allResourceIds());
+const wiring = scenarios.flatMap((s) => [
+  ...s.requires.filter((r) => !config.agents[r.key]).map((r) => `${s.id}: no "${r.key}" in config.json agents`),
+  ...s.resourceIds.filter((id) => !configuredIds.has(id)).map((id) => `${s.id}: no "${id}" in thunderid-config/thunderid-config.yaml`),
+]);
+if (wiring.length) {
+  console.error(`[agentid-playground] configuration is out of sync:\n  ${wiring.join("\n  ")}`);
+  process.exit(1);
+}
+
+const client = createTokenClient(config.thunderidBaseUrl);
+
+// --- sessions --------------------------------------------------------------
+//
+// In-memory and cookie-keyed, enough to run locally. Only the obo scenario uses one.
+
+const sessions = new Map();
+
+// Every request without a recognised cookie creates a session, including favicon and 404s, so a
+// client that does not keep cookies would otherwise grow this map for the life of the process.
+const SESSION_TTL_MS = 60 * 60 * 1000;
+
+function getSession(req, res) {
+  const now = Date.now();
+  for (const [id, existing] of sessions) {
+    if (now - existing.lastSeen > SESSION_TTL_MS) sessions.delete(id);
+  }
+
+  const sid = /(?:^|;\s*)sid=([^;]+)/.exec(req.headers.cookie ?? "")?.[1];
+  const known = sid ? sessions.get(sid) : undefined;
+  if (known) {
+    known.lastSeen = now;
+    return known;
+  }
+
+  const fresh = randomUUID();
+  sessions.set(fresh, {lastSeen: now});
+  res.setHeader("Set-Cookie", `sid=${fresh}; HttpOnly; Path=/; SameSite=Lax`);
+  return sessions.get(fresh);
+}
+
+// --- pages -----------------------------------------------------------------
+
+function scenarioPage(scenario, body, hostOk = true) {
+  return page({
+    title: `${APP_TITLE} · ${scenario.title}`,
+    eyebrow: scenario.nav,
+    heading: scenario.title,
+    lead: scenario.lead,
+    host: config.thunderidBaseUrl,
+    hostOk,
+    appName: APP_TITLE,
+    nav: tabs(scenarios, scenario.id),
+    body,
+  });
+}
+
+// --- try it out ------------------------------------------------------------
+//
+// The app has to be worth opening before anything is imported, so each tab checks its own
+// prerequisites, names the missing one, and only then offers the run button.
+
+async function readiness(scenario, ctx) {
+  const backend = await checkBackend(client);
+  if (!backend.ok) return {backend, agents: null, extra: null, ready: false};
+
+  const agents = await checkAgents(client, scenario.requires, config.agents);
+  // A throwing check should fail its own step, not blank the page it was meant to explain.
+  let extra = null;
+  if (agents.ok && scenario.check) {
+    try {
+      extra = await scenario.check(ctx);
+    } catch (err) {
+      extra = {ok: false, detail: err instanceof Error ? err.message : String(err)};
+    }
+  }
+  return {backend, agents, extra, ready: agents.ok && (!extra || extra.ok)};
+}
+
+// Step 2 is completed by the reader, never by the app. The automatic detection still runs and is
+// reported here, but only as information: some prerequisites cannot be proven without using them
+// (John's existence, for one), so the reader is the one who says the import is done.
+function importStep(scenario, state, override) {
+  const download = `<a class="btn${override ? "" : " primary"}" href="/resources/${scenario.id}.yaml" download>Download ${scenario.id}.yaml</a>`;
+  const confirm = `<a class="btn" href="/${scenario.id}/skip-check">I have imported it, mark as ready</a>`;
+  const undo = `<a class="btn" href="/${scenario.id}/recheck">Undo</a>`;
+  const note =
+    "Import the resource file into ThunderID (Console -> Import, or <code>POST /import</code>). It " +
+    "declares everything this tab uses, with the client IDs and secrets already in " +
+    "<code>config.json</code>. Import is upsert by id, so the tabs' overlapping slices are safe to " +
+    "import one after another. Mark this done when you have imported it.";
+  const extraNote = scenario.importNote ? scenario.importNote(config) : "";
+
+  // What detection found, phrased as an observation rather than a verdict.
+  let detail;
+  if (!state.backend.ok) {
+    detail = "Nothing detected yet: ThunderID has to answer first.";
+  } else if (state.agents.ok && (!state.extra || state.extra.ok)) {
+    const found = esc(state.agents.results.map((r) => r.id).join(", "));
+    detail = `Detected: ${found}${state.extra?.detail ? ` · ${esc(state.extra.detail)}` : ""}`;
+  } else {
+    const failures = state.agents?.results?.filter((r) => !r.ok) ?? [];
+    detail =
+      "Not detected: " +
+      (failures.length
+        ? failures.map((r) => `${esc(r.id)}: ${esc(r.detail)}`).join("<br/>")
+        : esc(state.extra?.detail ?? ""));
+  }
+
+  return {
+    n: 2,
+    state: override ? "done" : state.backend.ok ? "active" : "todo",
+    title: "Import the playground resources",
+    tag: override ? "confirmed" : "not confirmed",
+    tagKind: override ? "ok" : "",
+    note,
+    detail,
+    actions: (override ? download + undo : download + confirm) + extraNote,
+  };
+}
+
+function runStep(scenario, state, hasResult, unlocked) {
+  const href = scenario.run.href ?? `/${scenario.id}?run=1`;
+  const enabled = unlocked;
+  const button = enabled
+    ? `<a class="btn primary" href="${href}">${esc(scenario.run.label)}</a>`
+    : `<span class="btn" disabled>${esc(scenario.run.label)}</span>`;
+  return {
+    n: scenario.run.n ?? 3,
+    state: hasResult ? "done" : enabled ? "active" : "todo",
+    title: "Run it",
+    tag: hasResult ? "done" : enabled ? "ready" : "blocked",
+    tagKind: hasResult ? "ok" : enabled ? "ok" : "",
+    note: scenario.run.note,
+    actions: hasResult ? `${button}<span class="muted">Claims are below.</span>` : button,
+  };
+}
+
+function tryItOut(scenario, state, hasResult, gate, override, unlocked) {
+  const connection = state.backend.ok
+    ? {
+        n: 1,
+        state: "done",
+        title: "ThunderID is running",
+        tag: "connected",
+        tagKind: "ok",
+        note: `Reached <code>${esc(config.thunderidBaseUrl)}</code>.`,
+        detail: esc(state.backend.detail),
+      }
+    : {
+        n: 1,
+        state: "failed",
+        title: "ThunderID is running",
+        tag: "unreachable",
+        tagKind: "bad",
+        note: `Nothing answered at <code>${esc(config.thunderidBaseUrl)}</code>.`,
+        detail: esc(state.backend.detail),
+        actions:
+          `<a class="btn primary" href="/${scenario.id}">Check again</a>` +
+          `<ul class="fixes">
+  <li>Start ThunderID and confirm it answers on ${esc(config.thunderidBaseUrl)}.</li>
+  <li>Point the app somewhere else with <code>THUNDERID_BASE_URL</code> in <code>.env</code>.</li>
+</ul>`,
+      };
+
+  // A tab needing its own sign-in contributes an extra step between importing and running.
+  const gateStep = gate ? [gate.step] : [];
+  const count = 2 + gateStep.length + 1;
+  return `<section${unlocked ? "" : ' class="blocked"'}>
+  <h2>Try it out</h2>
+  <p class="sub">${count} steps, checked live against your instance. Nothing is cached, so reload any time to recheck.</p>
+  ${steps([
+    connection,
+    importStep(scenario, state, override),
+    ...gateStep,
+    runStep(scenario, state, hasResult, unlocked && (!gate || gate.ok)),
+  ])}
+</section>`;
+}
+
+function overviewPage(backend) {
+  const cards = scenarios
+    .map(
+      (s) => `<a class="card" href="/${s.id}">
+  <div class="card-icon">${s.icon}</div>
+  <h3>${esc(s.title)}</h3>
+  <p>${esc(s.blurb)}</p>
+  <div class="shape">${s.shape.map((v) => `<code>${esc(v)}</code>`).join("")}</div>
+</a>`,
+    )
+    .join("");
+
+  const rows = scenarios
+    .map(
+      (s) => `<tr>
+  <td><a href="/${s.id}">${esc(s.title)}</a></td>
+  <td><code>${esc(s.compare.sub)}</code></td>
+  <td><code>${esc(s.compare.act)}</code></td>
+  <td><code>${esc(s.compare.grant)}</code></td>
+</tr>`,
+    )
+    .join("");
+
+  return page({
+    title: APP_TITLE,
+    eyebrow: "Overview",
+    heading: APP_TITLE,
+    lead:
+      `Three ways an AI agent can hold identity, against <code>${esc(config.thunderidBaseUrl)}</code>. ` +
+      "Each tab runs the real flow and decodes the tokens ThunderID issues, nothing is added. The " +
+      "difference between the three is entirely in who the token names.",
+    host: config.thunderidBaseUrl,
+    hostOk: backend.ok,
+    appName: APP_TITLE,
+    nav: tabs(scenarios, "overview"),
+    body: `<div class="cards">${cards}</div>
+<section>
+  <h2>Who the token names</h2>
+  <p class="sub">The subject (<code>sub</code>) is the principal the work is for. The actor (<code>act</code>) is whoever is carrying it out on the subject's behalf.</p>
+  <table>
+    <thead><tr><th>Scenario</th><th>sub</th><th>act</th><th>Grant</th></tr></thead>
+    <tbody>${rows}</tbody>
+  </table>
+</section>
+<section${backend.ok ? "" : ' class="blocked"'}>
+  <h2>Before you start</h2>
+  <p class="sub">Each tab checks its own prerequisites and walks you through them. If you would rather set everything up in one go, import the whole resource file.</p>
+  ${steps([
+    backend.ok
+      ? {n: 1, state: "done", title: "ThunderID is running", tag: "connected", tagKind: "ok", note: `Reached <code>${esc(config.thunderidBaseUrl)}</code>.`, detail: esc(backend.detail)}
+      : {n: 1, state: "failed", title: "ThunderID is running", tag: "unreachable", tagKind: "bad", note: `Nothing answered at <code>${esc(config.thunderidBaseUrl)}</code>.`, detail: esc(backend.detail), actions: `<a class="btn primary" href="/">Check again</a>`},
+    {
+      n: 2,
+      state: "active",
+      title: "Import everything at once",
+      note: "Declares all five agents the three tabs use. Import it into ThunderID (Console -> Import, or <code>POST /import</code>), then pick a tab.",
+      actions: `<a class="btn" href="/resources/all.yaml" download>Download thunderid-config.yaml</a>`,
+    },
+  ])}
+</section>
+<p class="muted" style="margin: 18px 2px 0;">Every token on these tabs is decoded from a live response. Nothing is added, nothing is faked.</p>`,
+  });
+}
+
+// --- resource downloads ----------------------------------------------------
+
+function resourceDownload(res, name) {
+  const scenario = scenarios.find((s) => s.id === name);
+  const yaml =
+    name === "all"
+      ? resourceSlice(scenarios.flatMap((s) => s.resourceIds), {
+          title: "every Agent Identity Playground scenario",
+          note: "All agents used by the self, obo, and chain tabs.",
+        })
+      : resourceSlice(scenario.resourceIds, scenario.resource);
+  const filename = name === "all" ? "thunderid-config.yaml" : `${name}.yaml`;
+  res.writeHead(200, {
+    "Content-Type": "application/yaml; charset=utf-8",
+    "Content-Disposition": `attachment; filename="${filename}"`,
+  });
+  res.end(yaml);
+}
+
+// --- routing ---------------------------------------------------------------
+
+const routes = new Map();
+for (const scenario of scenarios) {
+  for (const [key, handler] of Object.entries(scenario.routes ?? {})) {
+    routes.set(key, {scenario, handler});
+  }
+}
+
+// no-store because every page re-runs the readiness checks: a cached page would report stale state
+// after an import, which is exactly the moment the user hits reload.
+const send = (res, status, html) => {
+  res.writeHead(status, {"Content-Type": "text/html", "Cache-Control": "no-store"});
+  res.end(html);
+};
+
+const redirect = (res, location) => {
+  res.writeHead(302, {Location: location});
+  res.end();
+};
+
+async function handleRequest(req, res) {
+  const session = getSession(req, res);
+  const url = new URL(req.url ?? "/", config.appBaseUrl);
+  req.resume(); // drain any request body we don't read
+
+  const route = routes.get(`${req.method} ${url.pathname}`);
+  const scenario = route?.scenario ?? scenarios.find((s) => url.pathname === `/${s.id}`);
+  const ctx = {
+    req,
+    res,
+    url,
+    session,
+    config,
+    client,
+    send,
+    redirect,
+    sendPage: (body, status = 200) => send(res, status, scenarioPage(scenario, body)),
+  };
+
+  try {
+    if (route) return await route.handler(ctx);
+
+    // The page declares no icon, so browsers ask for this on every load. Answering it here keeps
+    // that request from falling through to the 404 page, which would probe the backend each time.
+    if (url.pathname === "/favicon.ico") {
+      res.writeHead(204);
+      return res.end();
+    }
+
+    const toggle = /^\/([a-z]+)\/(skip-check|recheck)$/.exec(url.pathname);
+    if (toggle && scenarios.some((s) => s.id === toggle[1])) {
+      session.overrides ??= {};
+      if (toggle[2] === "skip-check") session.overrides[toggle[1]] = true;
+      else delete session.overrides[toggle[1]];
+      return redirect(res, `/${toggle[1]}`);
+    }
+
+    const download = /^\/resources\/([a-z]+)\.yaml$/.exec(url.pathname)?.[1];
+    if (download && (download === "all" || scenarios.some((s) => s.id === download))) {
+      return resourceDownload(res, download);
+    }
+
+    if (scenario) {
+      const state = await readiness(scenario, ctx);
+      // state.ready is detection, which informs step 2 but never completes it.
+      const override = Boolean(session.overrides?.[scenario.id]);
+      const unlocked = override;
+      const hasResult = scenario.hasResult
+        ? scenario.hasResult(ctx)
+        : url.searchParams.get("run") === "1";
+      const gate = unlocked && scenario.gate ? scenario.gate(ctx) : null;
+      const canRun = unlocked && (!gate || gate.ok);
+      const results = canRun && hasResult ? await scenario.render(ctx) : "";
+      const body =
+        scenario.explain() +
+        tryItOut(scenario, state, hasResult, gate, override, unlocked) +
+        results;
+      return send(res, 200, scenarioPage(scenario, body, state.backend.ok));
+    }
+
+    const backend = await checkBackend(client);
+    if (url.pathname === "/") return send(res, 200, overviewPage(backend));
+    return send(res, 404, overviewPage(backend));
+  } catch (err) {
+    const body = errorBox(err);
+    return send(res, 500, scenario ? scenarioPage(scenario, body) : page({
+      title: APP_TITLE,
+      heading: APP_TITLE,
+      lead: "Something went wrong handling this request.",
+      host: config.thunderidBaseUrl,
+      appName: APP_TITLE,
+      nav: tabs(scenarios, "overview"),
+      body,
+    }));
+  }
+}
+
+createServer(handleRequest).listen(PORT, () => {
+  console.log(
+    `[agentid-playground] listening on http://localhost:${PORT} -> ${config.thunderidBaseUrl}\n` +
+      `[agentid-playground] scenarios: ${scenarios.map((s) => s.id).join(", ")}`,
+  );
+});

--- a/samples/apps/agentid-playground/thunderid-config/thunderid-config.yaml
+++ b/samples/apps/agentid-playground/thunderid-config/thunderid-config.yaml
@@ -1,0 +1,391 @@
+# Copyright 2026 The ThunderID Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# ThunderID declarative resources for the ThunderID Agent Identity Playground.
+#
+# Import this file into a running ThunderID instance (Console -> Import, or POST /import).
+# Import is upsert by id, so re-importing, or importing the per-tab slices the app offers, is safe.
+#
+# The cast is a travel-booking one: a Concierge agent, a worker agent it delegates to, and a
+# customer named John Doe. Everything here is prefixed `agent-identity-` and uses its own resource
+# identifiers, so it never collides with anything else in the same instance.
+#
+#   self  : the Concierge recommends flights on its own      sub = agent, no act
+#   obo   : John asks the Concierge to book a trip           sub = John,  act = Concierge
+#   chain : the Concierge delegates flight search to a worker sub = John, act = worker -> Concierge
+#
+# Scopes are narrowed to what these three tabs need.
+
+# --- resource servers ------------------------------------------------------
+#
+# Two protected APIs. `agent:access` decides who may use the Concierge at all, and the booking
+# scopes decide what may be done with it. Registering them is what makes scopes real: a token can
+# only carry a scope that some resource server defines and that the principal has been granted.
+
+resource_type: resource_server
+id: agent-identity-agent-rs
+name: Agent Access
+description: Controls who may use the Concierge
+identifier: https://agent.travel.example
+ouHandle: default
+delimiter: ":"
+resources:
+  - name: Agent
+    handle: agent
+    actions:
+      - name: Access
+        handle: access
+        description: Grants access to the Concierge
+
+---
+# --- booking resource server -----------------------------------------------
+
+resource_type: resource_server
+id: agent-identity-booking-rs
+name: Booking API
+description: The booking API the Concierge and its worker agents call
+identifier: https://api.travel.example/booking
+ouHandle: default
+delimiter: ":"
+resources:
+  - name: Booking
+    handle: booking
+    actions:
+      - name: Read
+        handle: read
+        description: Search flights and read bookings
+      - name: Create
+        handle: create
+        description: Make a booking
+      - name: Recommend
+        handle: recommend
+        description: Surface flight recommendations
+
+---
+# --- the consent flow ------------------------------------------------------
+#
+# The login the Concierge sends John through:
+#
+#   credentials -> authorization_check (agent:access) -> consent_check -> Allow / Deny -> assert
+#
+# The authorization_check is why John, who holds Chat User, gets in. A user without agent:access is
+# rejected before the consent screen, which is the "Protect the Agent" behaviour from the docs.
+
+resource_type: flow
+id: 0193b0a1-2001-7000-8000-000000000001
+name: Agent Identity Playground Authentication Flow
+handle: agent-identity-agent-auth-flow
+flowType: AUTHENTICATION
+nodes:
+  - id: start
+    type: START
+    onSuccess: prompt_credentials
+  - id: prompt_credentials
+    type: PROMPT
+    meta:
+      components:
+        - alt: "{{ t(signin:images.app_logo.alt) }}"
+          category: DISPLAY
+          height: "60"
+          id: image
+          resourceType: ELEMENT
+          src: "{{ meta(application.logoUrl) }}"
+          type: IMAGE
+          width: ""
+        - align: center
+          type: TEXT
+          id: text_001
+          label: "{{ t(signin:forms.credentials.title) }}"
+          variant: HEADING_1
+        - type: BLOCK
+          id: block_001
+          components:
+            - id: input_001
+              ref: username
+              type: TEXT_INPUT
+              label: "{{ t(signin:forms.credentials.fields.username.label) }}"
+              required: true
+              placeholder: "{{ t(signin:forms.credentials.fields.username.placeholder) }}"
+            - id: input_002
+              ref: password
+              type: PASSWORD_INPUT
+              label: "{{ t(signin:forms.credentials.fields.password.label) }}"
+              required: true
+              placeholder: "{{ t(signin:forms.credentials.fields.password.placeholder) }}"
+            - type: ACTION
+              id: action_001
+              label: "{{ t(signin:forms.credentials.actions.submit.label) }}"
+              variant: PRIMARY
+              eventType: SUBMIT
+    prompts:
+      - inputs:
+          - ref: input_001
+            identifier: username
+            type: TEXT_INPUT
+            required: true
+          - ref: input_002
+            identifier: password
+            type: PASSWORD_INPUT
+            required: true
+        action:
+          ref: action_001
+          nextNode: basic_auth
+  - id: basic_auth
+    type: TASK_EXECUTION
+    executor:
+      name: CredentialsAuthExecutor
+    onSuccess: authorization_check
+    onIncomplete: prompt_credentials
+  - id: authorization_check
+    type: TASK_EXECUTION
+    executor:
+      name: AuthorizationExecutor
+    onSuccess: consent_check
+  - id: consent_check
+    type: TASK_EXECUTION
+    executor:
+      name: ConsentExecutor
+    onSuccess: auth_assert
+    onIncomplete: prompt_consent
+  - id: prompt_consent
+    type: PROMPT
+    meta:
+      components:
+        - alt: "{{ t(signin:images.app_logo.alt) }}"
+          category: DISPLAY
+          height: "60"
+          id: consent_image
+          resourceType: ELEMENT
+          src: "{{ meta(application.logoUrl) }}"
+          type: IMAGE
+          width: ""
+        - align: center
+          type: TEXT
+          id: consent_heading
+          label: "{{ meta(application.name) }} is requesting access"
+          variant: HEADING_1
+        - type: BLOCK
+          id: consent_block
+          components:
+            - id: consent_input
+              ref: consent_decisions
+              type: CONSENT_INPUT
+              required: true
+            - type: ACTION
+              id: consent_action_deny
+              label: Deny
+              variant: SECONDARY
+              eventType: SUBMIT
+            - type: ACTION
+              id: consent_action_allow
+              label: Allow
+              variant: PRIMARY
+              eventType: SUBMIT
+    prompts:
+      - inputs:
+          - ref: consent_input
+            identifier: consent_decisions
+            type: CONSENT_INPUT
+            required: true
+        action:
+          ref: consent_action_allow
+          nextNode: consent_check
+      - inputs:
+          - ref: consent_input
+            identifier: consent_decisions
+            type: CONSENT_INPUT
+            required: true
+        action:
+          ref: consent_action_deny
+          nextNode: consent_check
+  - id: auth_assert
+    type: TASK_EXECUTION
+    executor:
+      name: AuthAssertExecutor
+    onSuccess: end
+  - id: end
+    type: END
+
+---
+# --- the customer ----------------------------------------------------------
+#
+# The customer the Concierge works for. He belongs to the built-in `Person` user type, so no user
+# type has to be created. His password is here in the clear because this runs locally.
+
+resource_type: user
+id: agent-identity-john
+type: Person
+ouHandle: default
+attributes:
+  username: johndoe
+  email: john.doe@travel.example
+  given_name: John
+  family_name: Doe
+credentials:
+  password: "Travel@123"
+
+---
+# --- the Concierge ---------------------------------------------------------
+#
+# One agent covers two of the three tabs, which is the point: the same principal produces a
+# different token shape depending on the grant it uses.
+#
+#   client_credentials : its own token, subject = the Concierge, no actor   (the "self" tab)
+#   authorization_code : John's token, subject = John, actor = Concierge    (the "obo" tab)
+#   refresh_token      : reissues that token, actor preserved
+#   token-exchange     : narrows it, and feeds the delegation chain         (the "chain" tab)
+#
+# authFlowHandle points at the consent flow above, so signing in prompts for credentials, checks
+# the user holds agent:access, and then asks John to allow or deny.
+
+resource_type: agent
+id: agent-identity-concierge
+name: Concierge
+description: The in-app travel assistant that books trips for customers
+ouHandle: default
+type: default
+logoUrl: "emoji:🧭"
+authFlowHandle: agent-identity-agent-auth-flow
+attributes:
+  model: claude-sonnet-5
+  modelProvider: anthropic
+  function: assistant
+# Only these user types may sign in through the Concierge. Required: an empty list makes the login
+# flow fail with "auth not available".
+allowedUserTypes:
+  - Person
+inboundAuthConfig:
+  - type: oauth2
+    config:
+      clientId: agent-identity-concierge-id
+      clientSecret: agent-identity-concierge-secret
+      # One per tab that signs a customer in. Each tab owns its own callback so it can be walked
+      # from the top without depending on another tab having been visited first.
+      redirectUris:
+        - http://localhost:8082/callback
+        - http://localhost:8082/chain/callback
+      grantTypes:
+        - client_credentials
+        - authorization_code
+        - refresh_token
+        - urn:ietf:params:oauth:grant-type:token-exchange
+      responseTypes:
+        - code
+      tokenEndpointAuthMethod: client_secret_basic
+      publicClient: false
+      # The Console's Delegated mode turns PKCE on, and the app always sends S256, so require it.
+      pkceRequired: true
+      token:
+        accessToken:
+          clientConfig:
+            validityPeriod: 3600
+            attributes:
+              - name
+              - owner
+              - ouId
+              - ouName
+              - ouHandle
+              - model
+              - modelProvider
+              - function
+          userConfig:
+            validityPeriod: 3600
+            attributes:
+              - email
+              - username
+        idToken:
+          validityPeriod: 3600
+        refreshToken:
+          validityPeriod: 86400
+
+---
+# --- the worker agent ------------------------------------------------------
+#
+# The specialist the Concierge hands the flight-search sub-task to. It holds only booking:read, so
+# a token delegated to it can never carry booking:create no matter what the Concierge asks for.
+
+resource_type: agent
+id: agent-identity-flight-search
+name: Flight Search Agent
+description: Worker agent that runs the delegated flight-search sub-task
+ouHandle: default
+type: default
+logoUrl: "emoji:✈️"
+attributes:
+  model: claude-sonnet-5
+  modelProvider: anthropic
+  function: sub-agent
+inboundAuthConfig:
+  - type: oauth2
+    config:
+      clientId: agent-identity-flight-search-id
+      clientSecret: agent-identity-flight-search-secret
+      grantTypes:
+        - client_credentials
+        - urn:ietf:params:oauth:grant-type:token-exchange
+      tokenEndpointAuthMethod: client_secret_basic
+      publicClient: false
+
+---
+# --- roles -----------------------------------------------------------------
+#
+# Roles are what turn a requested scope into an issued one. A token carries a scope only if the
+# principal holds a role granting it, so these are what make the downscoping on the chain tab real
+# rather than cosmetic.
+
+resource_type: role
+id: agent-identity-chat-user
+name: Chat User
+description: Grants access to use the Concierge at all
+ouHandle: default
+permissions:
+  - resourceServerId: agent-identity-agent-rs
+    permissions:
+      - agent:access
+assignments:
+  - id: agent-identity-john
+    type: user
+
+---
+resource_type: role
+id: agent-identity-booking-user
+name: Booking User
+description: Grants John the booking permissions the Concierge acts with on his behalf
+ouHandle: default
+permissions:
+  - resourceServerId: agent-identity-booking-rs
+    permissions:
+      - booking:read
+      - booking:create
+assignments:
+  - id: agent-identity-john
+    type: user
+
+---
+resource_type: role
+id: agent-identity-recommender
+name: Recommender
+description: What the Concierge may do on its own behalf, with no user involved
+ouHandle: default
+permissions:
+  - resourceServerId: agent-identity-booking-rs
+    permissions:
+      - booking:read
+      - booking:recommend
+assignments:
+  - id: agent-identity-concierge
+    type: agent
+
+---
+resource_type: role
+id: agent-identity-flight-searcher
+name: Flight Searcher
+description: The worker's entire authority, deliberately narrower than the Concierge's
+ouHandle: default
+permissions:
+  - resourceServerId: agent-identity-booking-rs
+    permissions:
+      - booking:read
+assignments:
+  - id: agent-identity-flight-search
+    type: agent


### PR DESCRIPTION
### Purpose

Adds a new sample, `agent-identity-playground-sample`, covering the three ways an AI
agent can hold identity in ThunderID. Each posture gets its own tab, and every tab runs
real OAuth calls against a local instance and decodes the tokens that come back, so the
`sub`, `act`, and `scope` claims are shown from actual responses rather than described.

| Tab | Grant | `sub` | `act` | `scope` |
|---|---|---|---|---|
| Acts as itself | `client_credentials` | the agent | none | `booking:read booking:recommend` |
| Acts for a customer | `authorization_code` | the user | the agent | `booking:read booking:create` |
| Delegates to agents | RFC 8693 exchange | the user | worker, then agent | `booking:read` |

One travel booking cast is shared across all three tabs (a Concierge agent, a worker
agent it delegates to, and a customer), so the only thing that changes between tabs is
who the token names and what it is allowed to do.

Also wires the sample into `build.sh` and `build.ps1` so it is packaged from source
alongside the existing four samples.

### Approach

**Zero dependencies.** The app is Node built-ins only (`node:http`, `node:https`,
`node:crypto`), so there is no install step and nothing to keep patched. `package.json`
declares no dependencies at all, which keeps its lockfile footprint to a single empty
importer entry.

**One resource file, sliced per tab.** `thunderid-config/thunderid-config.yaml` is the
single source of truth. Each tab's download is produced at request time by
`lib/resources.mjs`, which splits the multi document YAML and selects by each document's
`id`. Slices also resolve their own dependencies: any slice containing an agent with an
`authFlowHandle` automatically carries the flow declaring that handle, so a per tab
import cannot be incomplete. This avoids duplicating agent definitions across four files.

**Self contained resources.** Every id is prefixed `agent-identity-`, the resource servers
use identifiers under `travel.example`, and the user is `johndoe`, so importing cannot
collide with anything already in an instance. Import is upsert by id, so re importing, or
importing overlapping per tab slices, is safe.

**One module per posture.** A scenario exports its tab metadata, an `explain` function, a
`render` function, the agents it `requires`, and optionally extra `routes` and a `check`.
Adding a fourth posture means adding one file and listing it in `server.mjs`. Startup
validates that every agent a scenario needs has credentials in `config.json` and that
every document it offers exists in the resource file, so a renamed resource fails fast
with the missing name rather than at request time.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4069




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Agent Identity Playground demonstrating self-acting agents, delegated agent chains, and acting on behalf of a user.
  * Added interactive OAuth sign-in, token exchange, refresh flows, scope narrowing, and delegation-chain visualizations.
  * Added readiness checks, token claim displays, error guidance, theme support, and clipboard copying.
  * Added a command-line flow for inspecting issued token claims.
* **Documentation**
  * Added setup instructions, configuration guidance, scenario explanations, and extension conventions.
* **Configuration**
  * Added a complete local travel-booking demonstration environment with agents, resources, roles, and permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->