### PR TITLE
Match resource_type only as a plain key when importing sample resources

### DIFF
--- a/tools/cli/internal/commands/sample/sample.go
+++ b/tools/cli/internal/commands/sample/sample.go
@@ -372,7 +372,7 @@ func writeResources(yamlPath string, vars map[string]string, thunderRoot string)
 	content := substituteVars(string(raw), vars)
 	docs := splitYAML(content)
 
-	reResourceType := regexp.MustCompile(`(?m)^#\s*resource_type:\s*(\S+)`)
+	reResourceType := regexp.MustCompile(`(?m)^resource_type:\s*(\S+)`)
 	reID := regexp.MustCompile(`(?m)^(?:id|handle):\s*(\S+)`)
 
 	for i, doc := range docs {

--- a/tools/cli/internal/commands/sample/sample_test.go
+++ b/tools/cli/internal/commands/sample/sample_test.go
@@ -130,12 +130,14 @@ func TestSampleServicePorts(t *testing.T) {
 func TestWriteResources(t *testing.T) {
 	thunderRoot := t.TempDir()
 	yamlPath := filepath.Join(t.TempDir(), "resources.yaml")
+	// Sample configs declare resource_type as a plain key, the same form the server
+	// reads it in.
 	content := "" +
-		"# resource_type: application\n" +
+		"resource_type: application\n" +
 		"id: wayfinder-app\n" +
 		"clientId: \"{{.WAYFINDER_CLIENT_ID}}\"\n" +
 		"---\n" +
-		"# resource_type: user_type\n" +
+		"resource_type: user_type\n" +
 		"id: wayfinder-customer-type\n" +
 		"name: Customer\n"
 	if err := os.WriteFile(yamlPath, []byte(content), 0o644); err != nil {
@@ -167,5 +169,23 @@ func TestWriteResources(t *testing.T) {
 	// The legacy repository/resources path must no longer be used.
 	if _, err := os.Stat(filepath.Join(thunderRoot, "repository")); !os.IsNotExist(err) {
 		t.Errorf("resources written to legacy repository/ path")
+	}
+}
+
+// A commented-out marker is not a supported declaration and must be ignored.
+func TestWriteResourcesCommentedResourceType(t *testing.T) {
+	thunderIDRoot := t.TempDir()
+	yamlPath := filepath.Join(t.TempDir(), "resources.yaml")
+	content := "# resource_type: application\nid: legacy-app\n"
+	if err := os.WriteFile(yamlPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	if err := writeResources(yamlPath, nil, thunderIDRoot); err != nil {
+		t.Fatalf("writeResources: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(thunderIDRoot, "config", "resources")); !os.IsNotExist(err) {
+		t.Error("commented resource_type must not be written")
 	}
 }


### PR DESCRIPTION
### Purpose
`thunderid try <sample>` printed `Writing <sample> resources...` but imported nothing. The splitter in `writeResources` matched `resource_type` only in its commented-out form (`^#\s*resource_type:`), while the sample configs declare it as a plain key, the same form the server reads. Every document was skipped, so the sample's application, flows, roles and users were never registered and sign-in failed with `Invalid client_id`.

### Approach
Match `resource_type` only as a plain key. A commented-out marker is not a supported declaration, so it is ignored. Existing unit test updated to the plain key (it fails without this change) plus a case asserting a commented marker writes nothing. No sample config uses the commented form.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sample resource generation now recognizes active `resource_type` declarations in YAML.
  * Commented `resource_type` markers are ignored and no longer produce resource output.
  * Resources continue to be extracted, named, and written to the appropriate directories when valid declarations are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->