### PR TITLE
Fix cursor positioning in the Import Configuration environment variable editor

### DIFF
--- a/frontend/apps/console/src/lib/monaco-setup.ts
+++ b/frontend/apps/console/src/lib/monaco-setup.ts
@@ -19,3 +19,42 @@ self.MonacoEnvironment = {
 };
 
 loader.config({monaco});
+
+// Monaco's native EditContext input layer ships its own stylesheet
+// (nativeEditContext.css), but it is not pulled into the bundle through the main
+// monaco entry here. Without it, `.native-edit-context` and `.ime-text-area` stay
+// `position: static`, so they take up flow space at the top of the editor and push
+// the text layer down. Monaco then bakes that offset into the coordinates it uses
+// for click-to-cursor mapping, so clicks land on the wrong line and values cannot be
+// edited by placing the cursor (issue #4569). Inject the rules at runtime so they are
+// guaranteed present before any editor initializes, independent of CSS bundling.
+const NATIVE_EDIT_CONTEXT_STYLE_ID = 'monaco-native-edit-context-fix';
+if (typeof document !== 'undefined' && !document.getElementById(NATIVE_EDIT_CONTEXT_STYLE_ID)) {
+  const style = document.createElement('style');
+  style.id = NATIVE_EDIT_CONTEXT_STYLE_ID;
+  style.textContent = `
+.monaco-editor .native-edit-context {
+  margin: 0;
+  padding: 0;
+  position: absolute;
+  overflow-y: scroll;
+  scrollbar-width: none;
+  z-index: -10;
+  white-space: pre-wrap;
+}
+.monaco-editor .ime-text-area {
+  min-width: 0;
+  min-height: 0;
+  margin: 0;
+  padding: 0;
+  position: absolute;
+  outline: none !important;
+  resize: none;
+  border: none;
+  overflow: hidden;
+  color: transparent;
+  background-color: transparent;
+  z-index: -10;
+}`;
+  document.head.appendChild(style);
+}


### PR DESCRIPTION
### Purpose
Fixes the broken "Environment Variables" editor in Import Configuration. Clicking to position the cursor landed on the wrong line, so users could not reliably edit environment variable values (issue #4569).

### Approach
Root cause: Monaco 0.55's native EditContext input layer ships its own stylesheet (`nativeEditContext.css`) that was not being pulled into the bundle through the main monaco entry. Without it, `.native-edit-context` and `.ime-text-area` stayed `position: static`, took up flow space at the top of the editor, and pushed the text layer down by ~59px. Monaco then baked that offset into the coordinates it uses for click to cursor mapping, so clicks resolved to the wrong line.

Fix: inject the required rules at runtime in `monaco-setup.ts` before any editor initializes, so the input layer is correctly positioned regardless of CSS bundling. Because the fix lives in the shared Monaco setup, it also protects the other Monaco editors in the Console (config viewer, application edit, layout builder, translations).

Verified manually on the running Console: clicking a value now places the cursor at the exact click point on the correct line, and typing inserts there (confirmed on multiple lines).

### Related Issues
- Fixes #4569

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cursor placement and editor layout when using the Monaco editor.
  * Prevented hidden input elements from causing unexpected offsets or visual artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->