### PR TITLE
Fix deployment.yaml override of bool config fields defaulting to true

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -149,7 +149,7 @@ func initRevocationCache(ctx context.Context, logger *log.Logger,
 	cfg *config.Config) (revocationcache.EnforcerInterface, revocationcache.Syncer) {
 	rc := cfg.Server.SecurityConfig.TokenRevocation
 	enforcer, syncer, err := revocationcache.Initialize(revocationcache.Config{
-		Enabled:      rc.Enabled,
+		Enabled:      rc.IsEnabled(),
 		Source:       rc.Source,
 		SyncInterval: time.Duration(rc.SyncIntervalSeconds) * time.Second,
 	})

--- a/backend/internal/authn/openid4vp/init.go
+++ b/backend/internal/authn/openid4vp/init.go
@@ -97,7 +97,7 @@ func Initialize(
 		ResultRedirectURIBase: cfg.ResultRedirectURI,
 		ResultTokenValidity:   resultTokenValidity,
 		VerifierInfo:          verifierInfo,
-		EnforceKeyBinding:     cfg.EnforceKeyBinding,
+		EnforceKeyBinding:     cfg.EnforceKeyBindingEnabled(),
 	}, newOpenID4VPStore(configCrypto, store), clientID,
 		cryptoProvider, providers.KeyRef{KeyID: cfg.SigningKeyID}, signingKey.Algorithm, x5c,
 		trust, defSvc, jwtService, base)

--- a/backend/internal/notification/otp_service.go
+++ b/backend/internal/notification/otp_service.go
@@ -150,7 +150,7 @@ func (s *otpService) validateOTPVerifyRequest(request common.VerifyOTPDTO) *tidc
 // An optional otpCfg override can override specific fields (length, numeric-only, validity).
 func (s *otpService) generateOTP(otpCfg *common.OTPConfig) (generatedOTP, error) {
 	mergedCfg := s.resolveOTPConfig(otpCfg)
-	charSet := s.getOTPCharset(mergedCfg.UseNumericOnly)
+	charSet := s.getOTPCharset(mergedCfg.UsesNumericOnly())
 	length := mergedCfg.Length
 
 	chars := []rune(charSet)
@@ -235,7 +235,7 @@ func (s *otpService) resolveOTPConfig(otpCfg *common.OTPConfig) config.OTPConfig
 		}
 	}
 	if otpCfg.UseNumericOnly != nil {
-		cfg.UseNumericOnly = *otpCfg.UseNumericOnly
+		cfg.UseNumericOnly = otpCfg.UseNumericOnly
 	}
 	if otpCfg.ValidityPeriodSeconds != nil {
 		if *otpCfg.ValidityPeriodSeconds >= 30 && *otpCfg.ValidityPeriodSeconds <= 600 {

--- a/backend/internal/notification/otp_service_test.go
+++ b/backend/internal/notification/otp_service_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/thunder-id/thunderid/tests/mocks/jose/jwtmock"
 )
 
+func boolPtr(b bool) *bool { return &b }
+
 // buildTestJWT builds a minimal JWT whose payload encodes the given otpSessionData.
 // The header and signature are synthetic; VerifyJWT is mocked so no real crypto is needed.
 func buildTestJWT(sessionData otpSessionData) string {
@@ -59,7 +61,7 @@ func (suite *OTPServiceTestSuite) SetupSuite() {
 		Notification: config.NotificationConfig{
 			OTP: config.OTPConfig{
 				Length:                6,
-				UseNumericOnly:        true,
+				UseNumericOnly:        boolPtr(true),
 				ValidityPeriodSeconds: 120,
 			},
 		},
@@ -73,7 +75,7 @@ func (suite *OTPServiceTestSuite) SetupSuite() {
 func (suite *OTPServiceTestSuite) SetupTest() {
 	config.GetServerRuntime().Config.Notification.OTP = config.OTPConfig{
 		Length:                6,
-		UseNumericOnly:        true,
+		UseNumericOnly:        boolPtr(true),
 		ValidityPeriodSeconds: 120,
 	}
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
@@ -335,7 +337,7 @@ func (suite *OTPServiceTestSuite) TestResolveOTPConfig_NilOverride() {
 	cfg := suite.service.resolveOTPConfig(nil)
 
 	suite.Equal(6, cfg.Length)
-	suite.True(cfg.UseNumericOnly)
+	suite.True(cfg.UsesNumericOnly())
 	suite.Equal(120, cfg.ValidityPeriodSeconds)
 }
 
@@ -385,5 +387,5 @@ func (suite *OTPServiceTestSuite) TestResolveOTPConfig_UseNumericOnly() {
 	numericOnly := false
 	cfg := suite.service.resolveOTPConfig(&common.OTPConfig{UseNumericOnly: &numericOnly})
 
-	suite.False(cfg.UseNumericOnly)
+	suite.False(cfg.UsesNumericOnly())
 }

--- a/backend/internal/oauth/init.go
+++ b/backend/internal/oauth/init.go
@@ -65,13 +65,13 @@ func Initialize(
 	discoveryService := discovery.Initialize(mux, runtimeCrypto, jweService, cfg)
 	var enforcementService revocation.EnforcementServiceInterface
 	var revocationSvc revocation.RevocationServiceInterface
-	if cfg.OAuth.TokenRevocation.Enabled {
+	if cfg.OAuth.TokenRevocation.IsEnabled() {
 		// The enforcement service (revocation read path) is built before the token service so it can be
 		// injected into the validator, which enforces the deny list as the final step of every validation.
 		tokenFamilyRevocationTTL := time.Duration(cfg.OAuth.RefreshToken.ValidityPeriod) * time.Second
 		enforcementService, revocationSvc = revocation.Initialize(
 			mux, jwtService, actorProvider, authnProvider, discoveryService, observabilitySvc,
-			tokenFamilyRevocationTTL, cfg.OAuth.Revocation.TokenFamily.OnExplicitRevoke)
+			tokenFamilyRevocationTTL, cfg.OAuth.Revocation.TokenFamily.OnExplicitRevokeEnabled())
 	}
 
 	jtiStore := jti.Initialize(runtimeStore)
@@ -105,7 +105,7 @@ func Initialize(
 		discoveryService, dpopVerifier, cfg)
 	callback.Initialize(mux, oauth2AuthzService, cibaService, cfg)
 
-	if cfg.OAuth.Logout.Enabled {
+	if cfg.OAuth.Logout.IsEnabled() {
 		oauth2logout.Initialize(mux, jwtService, actorProvider, flowExecService, runtimeStore, cfg)
 	}
 	return nil

--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -139,7 +139,7 @@ func (as *authorizeService) GetAuthorizationCodeDetails(
 // redemption to recover the tfid and drop the whole family. It is best-effort: a missing marker or a
 // failed revoke is logged and does not change the replay rejection.
 func (as *authorizeService) revokeTokenFamilyOnCodeReplay(ctx context.Context, code string) {
-	if as.criteriaRevoker == nil || !as.cfg.OAuth.Revocation.TokenFamily.OnCodeReplay {
+	if as.criteriaRevoker == nil || !as.cfg.OAuth.Revocation.TokenFamily.OnCodeReplayEnabled() {
 		return
 	}
 	tokenFamilyID, found, err := as.authCodeStore.ConsumedTokenFamily(ctx, code)

--- a/backend/internal/oauth/oauth2/authz/service_test.go
+++ b/backend/internal/oauth/oauth2/authz/service_test.go
@@ -83,6 +83,8 @@ const (
 		"eyJzdWIiOiJ0ZXN0LXVzZXIiLCJpYXQiOjE3MDE0MjEyMDAsImF1dGhvcml6YXRpb25fcmVxdWVzdF9pZCI6NDJ9."
 )
 
+func boolPtr(b bool) *bool { return &b }
+
 type AuthorizeServiceTestSuite struct {
 	suite.Suite
 	mockInboundClient   *inboundclientmock.InboundClientServiceInterfaceMock
@@ -967,7 +969,7 @@ func (suite *AuthorizeServiceTestSuite) TestGetAuthorizationCodeDetails_ReplayRe
 
 	svc := suite.newService()
 	svc.criteriaRevoker = revoker
-	svc.cfg.OAuth.Revocation.TokenFamily.OnCodeReplay = true
+	svc.cfg.OAuth.Revocation.TokenFamily.OnCodeReplay = boolPtr(true)
 
 	result, err := svc.GetAuthorizationCodeDetails(context.Background(), "client-id", "code")
 

--- a/backend/internal/oauth/oauth2/discovery/discovery_test.go
+++ b/backend/internal/oauth/oauth2/discovery/discovery_test.go
@@ -81,8 +81,8 @@ func (suite *DiscoveryTestSuite) SetupTest() {
 				},
 			},
 			DCR:             engineconfig.DCRConfig{Enabled: boolPtr(true)},
-			TokenRevocation: engineconfig.OAuthTokenRevocationConfig{Enabled: true},
-			Logout:          engineconfig.LogoutConfig{Enabled: true},
+			TokenRevocation: engineconfig.OAuthTokenRevocationConfig{Enabled: boolPtr(true)},
+			Logout:          engineconfig.LogoutConfig{Enabled: boolPtr(true)},
 		},
 	}
 	_ = config.InitializeServerRuntime("test", testConfig)

--- a/backend/internal/oauth/oauth2/discovery/service.go
+++ b/backend/internal/oauth/oauth2/discovery/service.go
@@ -66,7 +66,7 @@ func (ds *discoveryService) GetOAuth2AuthorizationServerMetadata(
 		metadata.BackchannelTokenDeliveryModesSupported = []string{"poll"}
 		metadata.BackchannelUserCodeParameterSupported = false
 	}
-	if ds.cfg.OAuth.TokenRevocation.Enabled {
+	if ds.cfg.OAuth.TokenRevocation.IsEnabled() {
 		metadata.RevocationEndpoint = ds.getRevocationEndpoint()
 	}
 	if ds.cfg.OAuth.DCR.IsEnabled() {
@@ -102,7 +102,7 @@ func (ds *discoveryService) GetOIDCMetadata(ctx context.Context) (*OIDCProviderM
 		AcrValuesSupported:                   ds.getSupportedAcrValues(),
 	}
 
-	if ds.cfg.OAuth.Logout.Enabled {
+	if ds.cfg.OAuth.Logout.IsEnabled() {
 		oidcProviderMetadata.EndSessionEndpoint = ds.getEndSessionEndpoint()
 	}
 

--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
@@ -284,7 +284,7 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 		// Single-use: revoke the consumed refresh token so it cannot be replayed (RFC 9700 §4.14.2).
 		// Fail closed — if the revocation cannot be recorded, the old token would remain usable, so the
 		// rotation is rejected and the client retries with the still-valid old token.
-		if h.refreshRevoker != nil && h.cfg.OAuth.RefreshToken.RevokePreviousOnRenew {
+		if h.refreshRevoker != nil && h.cfg.OAuth.RefreshToken.RevokePreviousOnRenewEnabled() {
 			expiryTime := time.Unix(refreshTokenClaims.Exp, 0).UTC()
 			if err := h.refreshRevoker.RevokeRefreshToken(
 				ctx, refreshTokenClaims.JTI, expiryTime); err != nil {
@@ -319,7 +319,7 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 // verified upstream, so its tfid claim is trustworthy; the payload is decoded here only to read it.
 func (h *refreshTokenGrantHandler) revokeTokenFamilyOnReplay(ctx context.Context, refreshToken string,
 	logger *log.Logger) {
-	if h.criteriaRevoker == nil || !h.cfg.OAuth.Revocation.TokenFamily.OnRefreshReplay {
+	if h.criteriaRevoker == nil || !h.cfg.OAuth.Revocation.TokenFamily.OnRefreshReplayEnabled() {
 		return
 	}
 	claims, err := jwt.DecodeJWTPayload(refreshToken)

--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token_test.go
@@ -43,6 +43,8 @@ const testRefreshTokenClientID = "test-client-id"
 const testRS01URI = "https://rs01.example.com"
 const testRS02URI = "https://rs02.example.com"
 
+func boolPtr(b bool) *bool { return &b }
+
 type RefreshTokenGrantHandlerTestSuite struct {
 	testCfg oauthconfig.Config
 	suite.Suite
@@ -165,7 +167,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestNewRefreshTokenGrantHandler(
 
 // A replayed (already-revoked) refresh token triggers a family revoke and is rejected as invalid_grant.
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ReplayRevokesTokenFamily() {
-	suite.testCfg.OAuth.Revocation.TokenFamily.OnRefreshReplay = true
+	suite.testCfg.OAuth.Revocation.TokenFamily.OnRefreshReplay = boolPtr(true)
 	suite.rebuildHandlerWithConfig()
 
 	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"jti":"jti-old","tfid":"tfid-reuse"}`))
@@ -541,7 +543,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_Success_WithRene
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RenewRevokesConsumedRefreshToken() {
 	suite.testCfg.OAuth.RefreshToken.RenewOnGrant = true
-	suite.testCfg.OAuth.RefreshToken.RevokePreviousOnRenew = true
+	suite.testCfg.OAuth.RefreshToken.RevokePreviousOnRenew = boolPtr(true)
 	suite.rebuildHandlerWithConfig()
 
 	consumedJTI := "consumed-rt-jti"
@@ -579,7 +581,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RenewRevokesCons
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RenewRevokeFailureFailsClosed() {
 	suite.testCfg.OAuth.RefreshToken.RenewOnGrant = true
-	suite.testCfg.OAuth.RefreshToken.RevokePreviousOnRenew = true
+	suite.testCfg.OAuth.RefreshToken.RevokePreviousOnRenew = boolPtr(true)
 	suite.rebuildHandlerWithConfig()
 
 	suite.mockTokenValidator.
@@ -616,7 +618,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RevokePreviousOn
 	// renew_on_grant/revoke_previous_on_renew are independently configured. The handler must
 	// skip revocation rather than dereference the nil revoker.
 	suite.testCfg.OAuth.RefreshToken.RenewOnGrant = true
-	suite.testCfg.OAuth.RefreshToken.RevokePreviousOnRenew = true
+	suite.testCfg.OAuth.RefreshToken.RevokePreviousOnRenew = boolPtr(true)
 	suite.handler = newRefreshTokenGrantHandler(
 		suite.mockJWTService,
 		suite.mockTokenBuilder,

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -104,9 +104,17 @@ func (c *NotificationConfig) Validate() error {
 
 // OTPConfig holds the OTP generation configuration details.
 type OTPConfig struct {
-	Length                int  `yaml:"length"                  json:"length"`
-	UseNumericOnly        bool `yaml:"use_numeric_only"        json:"use_numeric_only"`
-	ValidityPeriodSeconds int  `yaml:"validity_period_seconds" json:"validity_period_seconds"`
+	Length int `yaml:"length"                  json:"length"`
+	// UseNumericOnly uses a pointer so an explicit false in deployment.yaml overrides the
+	// default.json default of true; a nil pointer means "not set" and keeps the default.
+	UseNumericOnly        *bool `yaml:"use_numeric_only"        json:"use_numeric_only"`
+	ValidityPeriodSeconds int   `yaml:"validity_period_seconds" json:"validity_period_seconds"`
+}
+
+// UsesNumericOnly reports whether OTPs use a numeric-only character set,
+// defaulting to false when unset (an explicit default lives in default.json).
+func (c OTPConfig) UsesNumericOnly() bool {
+	return derefBool(c.UseNumericOnly)
 }
 
 // Validate ensures OTP configuration values are within accepted bounds.
@@ -213,7 +221,15 @@ type OpenID4VPConfig struct {
 	ResultTokenValiditySeconds int                  `yaml:"result_token_validity_seconds" json:"result_token_validity_seconds"` //nolint:lll
 	RegistrationCertFile       string               `yaml:"registration_cert_file" json:"registration_cert_file"`
 	TrustedAnchors             []TrustedAnchorEntry `yaml:"trusted_anchors" json:"trusted_anchors"` //nolint:lll
-	EnforceKeyBinding          bool                 `yaml:"enforce_key_binding" json:"enforce_key_binding"`
+	// EnforceKeyBinding uses a pointer so an explicit false in deployment.yaml overrides the
+	// default.json default of true; a nil pointer means "not set" and keeps the default.
+	EnforceKeyBinding *bool `yaml:"enforce_key_binding" json:"enforce_key_binding"`
+}
+
+// EnforceKeyBindingEnabled reports whether a Key Binding JWT is required, defaulting to false
+// when unset (an explicit default lives in default.json).
+func (c OpenID4VPConfig) EnforceKeyBindingEnabled() bool {
+	return derefBool(c.EnforceKeyBinding)
 }
 
 // TrustedAnchorEntry is a trust anchor (root CA) whose PEM certificate roots the

--- a/backend/internal/system/config/config_test.go
+++ b/backend/internal/system/config/config_test.go
@@ -824,6 +824,81 @@ func (suite *ConfigTestSuite) TestMergeStructs_PrimitiveTypes() {
 	assert.Equal(suite.T(), 2.71, base.Float64Field)         // Overridden
 }
 
+// TestMergeConfigs_BoolPointerOverride guards the fix for the bug where plain bool config fields
+// defaulting to true in default.json could not be overridden to false via deployment.yaml (a user
+// false was indistinguishable from the zero value and silently dropped). The affected fields use
+// *bool so an explicit false overrides while an absent value keeps the default.
+func (suite *ConfigTestSuite) TestMergeConfigs_BoolPointerOverride() {
+	newBase := func() *Config {
+		return &Config{
+			Notification: NotificationConfig{OTP: OTPConfig{UseNumericOnly: boolPtr(true)}},
+			OpenID4VP:    OpenID4VPConfig{EnforceKeyBinding: boolPtr(true)},
+			OAuth: engineconfig.OAuthConfig{
+				RefreshToken:    engineconfig.RefreshTokenConfig{RevokePreviousOnRenew: boolPtr(true)},
+				TokenRevocation: engineconfig.OAuthTokenRevocationConfig{Enabled: boolPtr(true)},
+				Logout:          engineconfig.LogoutConfig{Enabled: boolPtr(true)},
+				Revocation: engineconfig.RevocationConfig{TokenFamily: engineconfig.TokenFamilyRevocationConfig{
+					OnRefreshReplay:  boolPtr(true),
+					OnExplicitRevoke: boolPtr(true),
+					OnCodeReplay:     boolPtr(true),
+				}},
+			},
+			Server: engineconfig.ServerConfig{SecurityConfig: engineconfig.SecurityConfig{
+				TokenRevocation: engineconfig.TokenRevocationConfig{Enabled: boolPtr(true)},
+			}},
+		}
+	}
+
+	suite.Run("explicit false overrides the true default", func() {
+		base := newBase()
+		user := &Config{
+			Notification: NotificationConfig{OTP: OTPConfig{UseNumericOnly: boolPtr(false)}},
+			OpenID4VP:    OpenID4VPConfig{EnforceKeyBinding: boolPtr(false)},
+			OAuth: engineconfig.OAuthConfig{
+				RefreshToken:    engineconfig.RefreshTokenConfig{RevokePreviousOnRenew: boolPtr(false)},
+				TokenRevocation: engineconfig.OAuthTokenRevocationConfig{Enabled: boolPtr(false)},
+				Logout:          engineconfig.LogoutConfig{Enabled: boolPtr(false)},
+				Revocation: engineconfig.RevocationConfig{TokenFamily: engineconfig.TokenFamilyRevocationConfig{
+					OnRefreshReplay:  boolPtr(false),
+					OnExplicitRevoke: boolPtr(false),
+					OnCodeReplay:     boolPtr(false),
+				}},
+			},
+			Server: engineconfig.ServerConfig{SecurityConfig: engineconfig.SecurityConfig{
+				TokenRevocation: engineconfig.TokenRevocationConfig{Enabled: boolPtr(false)},
+			}},
+		}
+
+		mergeConfigs(base, user)
+
+		assert.False(suite.T(), base.Notification.OTP.UsesNumericOnly())
+		assert.False(suite.T(), base.OpenID4VP.EnforceKeyBindingEnabled())
+		assert.False(suite.T(), base.OAuth.RefreshToken.RevokePreviousOnRenewEnabled())
+		assert.False(suite.T(), base.OAuth.TokenRevocation.IsEnabled())
+		assert.False(suite.T(), base.OAuth.Logout.IsEnabled())
+		assert.False(suite.T(), base.OAuth.Revocation.TokenFamily.OnRefreshReplayEnabled())
+		assert.False(suite.T(), base.OAuth.Revocation.TokenFamily.OnExplicitRevokeEnabled())
+		assert.False(suite.T(), base.OAuth.Revocation.TokenFamily.OnCodeReplayEnabled())
+		assert.False(suite.T(), base.Server.SecurityConfig.TokenRevocation.IsEnabled())
+	})
+
+	suite.Run("absent value keeps the true default", func() {
+		base := newBase()
+
+		mergeConfigs(base, &Config{})
+
+		assert.True(suite.T(), base.Notification.OTP.UsesNumericOnly())
+		assert.True(suite.T(), base.OpenID4VP.EnforceKeyBindingEnabled())
+		assert.True(suite.T(), base.OAuth.RefreshToken.RevokePreviousOnRenewEnabled())
+		assert.True(suite.T(), base.OAuth.TokenRevocation.IsEnabled())
+		assert.True(suite.T(), base.OAuth.Logout.IsEnabled())
+		assert.True(suite.T(), base.OAuth.Revocation.TokenFamily.OnRefreshReplayEnabled())
+		assert.True(suite.T(), base.OAuth.Revocation.TokenFamily.OnExplicitRevokeEnabled())
+		assert.True(suite.T(), base.OAuth.Revocation.TokenFamily.OnCodeReplayEnabled())
+		assert.True(suite.T(), base.Server.SecurityConfig.TokenRevocation.IsEnabled())
+	})
+}
+
 func (suite *ConfigTestSuite) TestMergeStructs_SliceHandling() {
 	// Test non-empty slice override
 	type SliceConfig struct {
@@ -1477,7 +1552,7 @@ flow:
 func (suite *ConfigTestSuite) TestOTPConfig_Validate_Defaults() {
 	cfg := &OTPConfig{
 		Length:                6,
-		UseNumericOnly:        true,
+		UseNumericOnly:        boolPtr(true),
 		ValidityPeriodSeconds: 120,
 	}
 	assert.NoError(suite.T(), cfg.Validate())

--- a/backend/pkg/thunderidengine/config/config.go
+++ b/backend/pkg/thunderidengine/config/config.go
@@ -56,9 +56,17 @@ type SecurityConfig struct {
 // today; future values may include an endpoint or event stream. SyncIntervalSeconds bounds how stale
 // the cache may be; a non-positive value falls back to the built-in default.
 type TokenRevocationConfig struct {
-	Enabled             bool   `yaml:"enabled"               json:"enabled"`
+	// Enabled uses a pointer so an explicit false in deployment.yaml overrides the
+	// default.json default of true; a nil pointer means "not set" and keeps the default.
+	Enabled             *bool  `yaml:"enabled"               json:"enabled"`
 	Source              string `yaml:"source"                json:"source"`
 	SyncIntervalSeconds int    `yaml:"sync_interval_seconds" json:"sync_interval_seconds"`
+}
+
+// IsEnabled reports whether Resource Server token-revocation enforcement is enabled,
+// defaulting to false when unset (an explicit default lives in default.json).
+func (c TokenRevocationConfig) IsEnabled() bool {
+	return c.Enabled != nil && *c.Enabled
 }
 
 // tokenRevocationSourceDB is the operation-database sync source, the only supported
@@ -162,9 +170,17 @@ type AuthClassConfig struct {
 
 // RefreshTokenConfig holds the refresh token configuration details.
 type RefreshTokenConfig struct {
-	RenewOnGrant          bool  `yaml:"renew_on_grant"           json:"renew_on_grant"`
-	RevokePreviousOnRenew bool  `yaml:"revoke_previous_on_renew" json:"revoke_previous_on_renew"`
+	RenewOnGrant bool `yaml:"renew_on_grant"           json:"renew_on_grant"`
+	// RevokePreviousOnRenew uses a pointer so an explicit false in deployment.yaml overrides
+	// the default.json default of true; a nil pointer means "not set" and keeps the default.
+	RevokePreviousOnRenew *bool `yaml:"revoke_previous_on_renew" json:"revoke_previous_on_renew"`
 	ValidityPeriod        int64 `yaml:"validity_period"          json:"validity_period"`
+}
+
+// RevokePreviousOnRenewEnabled reports whether the previous refresh token is revoked on renewal,
+// defaulting to false when unset (an explicit default lives in default.json).
+func (c RefreshTokenConfig) RevokePreviousOnRenewEnabled() bool {
+	return c.RevokePreviousOnRenew != nil && *c.RevokePreviousOnRenew
 }
 
 // AuthorizationCodeConfig holds the authorization code configuration details.
@@ -239,14 +255,30 @@ type OAuthConfig struct {
 
 // OAuthTokenRevocationConfig holds the configuration details for the token revocation feature
 type OAuthTokenRevocationConfig struct {
-	// Enabled controls whether the OAuth token revocation endpoint is active.
-	Enabled bool `yaml:"enabled" json:"enabled"`
+	// Enabled controls whether the OAuth token revocation endpoint is active. It uses a pointer
+	// so an explicit false in deployment.yaml overrides the default.json default of true; a nil
+	// pointer means "not set" and keeps the default.
+	Enabled *bool `yaml:"enabled" json:"enabled"`
+}
+
+// IsEnabled reports whether the OAuth token revocation endpoint is active,
+// defaulting to false when unset (an explicit default lives in default.json).
+func (c OAuthTokenRevocationConfig) IsEnabled() bool {
+	return c.Enabled != nil && *c.Enabled
 }
 
 // LogoutConfig holds the configuration details for the logout endpoint
 type LogoutConfig struct {
-	// Enabled controls whether the OAuth logout endpoint is active.
-	Enabled bool `yaml:"enabled" json:"enabled"`
+	// Enabled controls whether the OAuth logout endpoint is active. It uses a pointer so an
+	// explicit false in deployment.yaml overrides the default.json default of true; a nil
+	// pointer means "not set" and keeps the default.
+	Enabled *bool `yaml:"enabled" json:"enabled"`
+}
+
+// IsEnabled reports whether the OAuth logout endpoint is active,
+// defaulting to false when unset (an explicit default lives in default.json).
+func (c LogoutConfig) IsEnabled() bool {
+	return c.Enabled != nil && *c.Enabled
 }
 
 // RevocationConfig holds grant-scoped (token family) revocation settings.
@@ -256,16 +288,36 @@ type RevocationConfig struct {
 
 // TokenFamilyRevocationConfig toggles the triggers that revoke a whole token family (one authorization
 // grant). Each defaults to on (set in default.json), matching the fail-closed security posture.
+// Each toggle uses a pointer so an explicit false in deployment.yaml overrides the default.json
+// default of true; a nil pointer means "not set" and keeps the default.
 type TokenFamilyRevocationConfig struct {
 	// OnRefreshReplay revokes the family when a rotated (already-revoked) refresh token is replayed.
 	// It has no effect unless refresh-token rotation (renew_on_grant) is enabled, since a token is only
 	// revoked, and thus only replayable, once it has been rotated.
-	OnRefreshReplay bool `yaml:"on_refresh_replay"   json:"on_refresh_replay"`
+	OnRefreshReplay *bool `yaml:"on_refresh_replay"   json:"on_refresh_replay"`
 	// OnExplicitRevoke revokes the family when a token carrying a tfid is revoked via RFC 7009, so a
 	// login's access tokens drop with its refresh token.
-	OnExplicitRevoke bool `yaml:"on_explicit_revoke" json:"on_explicit_revoke"`
+	OnExplicitRevoke *bool `yaml:"on_explicit_revoke" json:"on_explicit_revoke"`
 	// OnCodeReplay revokes the family when an authorization code is redeemed twice (replay).
-	OnCodeReplay bool `yaml:"on_code_replay"     json:"on_code_replay"`
+	OnCodeReplay *bool `yaml:"on_code_replay"     json:"on_code_replay"`
+}
+
+// OnRefreshReplayEnabled reports whether the family is revoked on refresh-token replay,
+// defaulting to false when unset (an explicit default lives in default.json).
+func (c TokenFamilyRevocationConfig) OnRefreshReplayEnabled() bool {
+	return c.OnRefreshReplay != nil && *c.OnRefreshReplay
+}
+
+// OnExplicitRevokeEnabled reports whether the family is revoked on explicit RFC 7009 revocation,
+// defaulting to false when unset (an explicit default lives in default.json).
+func (c TokenFamilyRevocationConfig) OnExplicitRevokeEnabled() bool {
+	return c.OnExplicitRevoke != nil && *c.OnExplicitRevoke
+}
+
+// OnCodeReplayEnabled reports whether the family is revoked on authorization-code replay,
+// defaulting to false when unset (an explicit default lives in default.json).
+func (c TokenFamilyRevocationConfig) OnCodeReplayEnabled() bool {
+	return c.OnCodeReplay != nil && *c.OnCodeReplay
 }
 
 // TokenExchangeConfig holds RFC 8693 token-exchange settings.

--- a/backend/pkg/thunderidengine/config/validate.go
+++ b/backend/pkg/thunderidengine/config/validate.go
@@ -29,7 +29,7 @@ func (c *SecurityConfig) Validate() error {
 // unsupported source is rejected, a negative sync interval is rejected, and a non-positive interval
 // otherwise falls back to the default.
 func (c *TokenRevocationConfig) Validate() error {
-	if !c.Enabled {
+	if !c.IsEnabled() {
 		return nil
 	}
 	if c.SyncIntervalSeconds < 0 {

--- a/backend/pkg/thunderidengine/config/validate_test.go
+++ b/backend/pkg/thunderidengine/config/validate_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/cors"
 )
 
+func boolPtr(b bool) *bool { return &b }
+
 type ValidateTestSuite struct {
 	suite.Suite
 }
@@ -133,7 +135,7 @@ func (suite *ValidateTestSuite) TestSecurityConfig_Validate() {
 
 	suite.T().Run("propagates TokenRevocation error", func(t *testing.T) {
 		c := &SecurityConfig{
-			TokenRevocation: TokenRevocationConfig{Enabled: true, SyncIntervalSeconds: -1},
+			TokenRevocation: TokenRevocationConfig{Enabled: boolPtr(true), SyncIntervalSeconds: -1},
 		}
 		assert.ErrorContains(t, c.Validate(), "sync_interval_seconds")
 	})
@@ -143,31 +145,31 @@ func (suite *ValidateTestSuite) TestSecurityConfig_Validate() {
 
 func (suite *ValidateTestSuite) TestTokenRevocationConfig_Validate() {
 	suite.T().Run("disabled skips validation", func(t *testing.T) {
-		assert.NoError(t, (&TokenRevocationConfig{Enabled: false, SyncIntervalSeconds: -1}).Validate())
+		assert.NoError(t, (&TokenRevocationConfig{Enabled: boolPtr(false), SyncIntervalSeconds: -1}).Validate())
 	})
 
 	suite.T().Run("negative interval fails when enabled", func(t *testing.T) {
 		assert.ErrorContains(t,
-			(&TokenRevocationConfig{Enabled: true, SyncIntervalSeconds: -1}).Validate(),
+			(&TokenRevocationConfig{Enabled: boolPtr(true), SyncIntervalSeconds: -1}).Validate(),
 			"sync_interval_seconds")
 	})
 
 	suite.T().Run("zero interval passes when enabled", func(t *testing.T) {
-		assert.NoError(t, (&TokenRevocationConfig{Enabled: true, SyncIntervalSeconds: 0}).Validate())
+		assert.NoError(t, (&TokenRevocationConfig{Enabled: boolPtr(true), SyncIntervalSeconds: 0}).Validate())
 	})
 
 	suite.T().Run("positive interval passes when enabled", func(t *testing.T) {
 		assert.NoError(t,
-			(&TokenRevocationConfig{Enabled: true, Source: "db", SyncIntervalSeconds: 30}).Validate())
+			(&TokenRevocationConfig{Enabled: boolPtr(true), Source: "db", SyncIntervalSeconds: 30}).Validate())
 	})
 
 	suite.T().Run("empty source passes when enabled", func(t *testing.T) {
-		assert.NoError(t, (&TokenRevocationConfig{Enabled: true, SyncIntervalSeconds: 30}).Validate())
+		assert.NoError(t, (&TokenRevocationConfig{Enabled: boolPtr(true), SyncIntervalSeconds: 30}).Validate())
 	})
 
 	suite.T().Run("unsupported source fails when enabled", func(t *testing.T) {
 		assert.ErrorContains(t,
-			(&TokenRevocationConfig{Enabled: true, Source: "events", SyncIntervalSeconds: 30}).Validate(),
+			(&TokenRevocationConfig{Enabled: boolPtr(true), Source: "events", SyncIntervalSeconds: 30}).Validate(),
 			"source")
 	})
 }


### PR DESCRIPTION
### Purpose

Fixes a bug where plain (non pointer) `bool` config fields that default to `true` in `default.json` could not be overridden to `false` via `deployment.yaml`. The override was silently dropped.

`mergeStructs`/`isZeroValue` in `backend/internal/system/config/config.go` treats `false` as the Go zero value, so a user set `false` is indistinguishable from "not set" and the default `true` wins. Log toggles were already converted to `*bool` to work around this, but the fix was not applied to the other affected fields.

Affected fields (all default to `true`):
- `server.security.token_revocation.enabled`
- `openid4vp.enforce_key_binding`
- `oauth.refresh_token.revoke_previous_on_renew`
- `oauth.token_revocation.enabled`
- `oauth.logout.enabled`
- `oauth.revocation.token_family.on_refresh_replay`
- `oauth.revocation.token_family.on_explicit_revoke`
- `oauth.revocation.token_family.on_code_replay`
- `notification.otp.use_numeric_only`

### Approach

Convert the affected fields to `*bool`, matching the existing precedent (log toggles and `DCRConfig.IsEnabled()`). A nil pointer means "not set" so the merged default is kept; a non nil pointer (including an explicit `false`) overrides. Added accessor methods (`IsEnabled()`, `UsesNumericOnly()`, etc.) at the read sites so the deref default lives in one place. The yaml/json keys are unchanged, so no config file changes are required, and the merge logic itself is untouched.

### Related Issues
- Fixes #4372

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [x] Tests provided.
    - [x] Unit Tests

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Boolean security settings now distinguish between unset values and explicitly disabled options.
  * Added consistent handling for token revocation, logout, refresh-token rotation, replay protection, OTP behavior, and key binding.

* **Bug Fixes**
  * Corrected configuration merging so explicit `false` values properly override defaults.
  * Ensured OAuth discovery metadata and token revocation behavior accurately reflect configured feature states.

* **Tests**
  * Expanded coverage for boolean configuration overrides and updated security-feature scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->