### PR TITLE
Add concept-first MCP guides and link them from the MCP use case

### DIFF
--- a/docs/content/guides/mcp/mcp-clients/dynamic-client-registration.mdx
+++ b/docs/content/guides/mcp/mcp-clients/dynamic-client-registration.mdx
@@ -1,0 +1,100 @@
+---
+title: Enable Dynamic Client Registration
+docType: guide
+persona: iam
+sidebar_position: 3
+description: Enable Dynamic Client Registration so MCP clients register themselves with {{ProductName}} instead of you pre-registering them in the Console.
+---
+
+# Enable Dynamic Client Registration
+
+Enable Dynamic Client Registration (DCR) so an MCP client registers its own OAuth 2.1 client at connection time, instead of you creating an application for it in the Console first.
+
+:::note
+The MCP specification's current revision [deprecates Dynamic Client Registration](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization/client-registration) in favor of Client ID Metadata Documents, keeping DCR only for backward compatibility with authorization servers that do not support them. <ProductName /> supports Dynamic Client Registration today.
+:::
+
+## When DCR Is the Right Choice
+
+Pre-registering a client in the Console, covered in [Register an MCP Client in the Console](../register-a-client), works when you know the client and its redirect URI ahead of time. DCR is the better fit when:
+
+- You cannot enumerate the clients ahead of time, such as a self-hosted MCP client your users install individually.
+- The client picks a random callback port each time it starts, so there is no fixed redirect URI to register.
+- The client expects DCR as part of connecting, with no manual setup step. Claude Code is the canonical example: it registers itself automatically the first time it connects to an MCP server, with no application created for it beforehand.
+
+<Stepper stepNode="h2" as="h2">
+
+## Add the DCR Configuration
+
+Add the following to `deployment.yaml` in your <ProductName /> distribution:
+
+```yaml
+oauth:
+  dcr:
+    enabled: true
+    insecure: true
+```
+
+:::warning
+`insecure: true` lets anyone who can reach the server register OAuth clients without authentication. Use it for local development only.
+
+Without `insecure: true`, <ProductName /> requires the registration request to carry a valid access token whose permissions include the root `system` permission, the same requirement other <ProductName /> management APIs enforce. A request without one gets a `401`.
+:::
+
+## Restart <ProductName />
+
+Restart <ProductName /> for the configuration change to take effect.
+
+</Stepper>
+
+## Verifying DCR Is Live
+
+Confirm DCR accepts registrations by registering a throwaway public client directly:
+
+```bash
+curl -sk -i -X POST https://localhost:8090/oauth2/dcr/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "client_name": "dcr-probe",
+    "redirect_uris": ["http://localhost:52344/callback"],
+    "grant_types": ["authorization_code"],
+    "response_types": ["code"],
+    "token_endpoint_auth_method": "none"
+  }'
+```
+
+```text
+HTTP/1.1 201 Created
+
+{
+  "app_id": "019fa36e-6b16-7908-9bc9-d848c00db406",
+  "client_id": "ZjWMmW04V6ZCl1xKR70FuQ",
+  "client_name": "dcr-probe",
+  "client_secret_expires_at": 0,
+  "grant_types": ["authorization_code"],
+  "redirect_uris": ["http://localhost:52344/callback"],
+  "response_types": ["code"],
+  "token_endpoint_auth_method": "none"
+}
+```
+
+A `201` response with a `client_id` and no `client_secret` confirms DCR accepted the registration, since `token_endpoint_auth_method: none` registers a public client. Before you set `insecure: true`, the same request returns `401 unauthorized_client` instead.
+
+## Where DCR-Registered Clients Show Up
+
+A client registered through DCR appears in the Console under **Applications**, alongside applications you registered manually. <ProductName /> has no concept of an MCP client in the DCR request itself, so it registers every DCR client as a **Custom App**, regardless of what kind of client sent the request.
+
+## Gotchas and Lifecycle
+
+**Duplicate names return a 400.** Registering a client whose `client_name` matches an existing application returns a `400` error. Delete the existing application in the Console before repeating the same registration, such as when you are testing a client's DCR flow repeatedly.
+
+**Redirect URIs still match exactly.** DCR removes the need to pre-register a client, not the redirect URI rule itself. If your client is user-delegated, its registered redirect URI must still exactly match, port included, the one it presents when it starts the Authorization Code flow. See [Redirect URI Rules](../register-a-client#redirect-uri-rules) for the accepted formats.
+
+**DCR-created clients accumulate.** Every successful registration creates a new application that <ProductName /> never removes on its own. A client that re-registers on each run under a different name, or a client tested repeatedly during development, leaves behind applications you no longer need. Review them periodically under **Applications** and delete the ones you no longer use, the same way you would delete any other application.
+
+## Next Steps
+
+- [Dynamic Client Registration](../../../protocols/oauth-oidc/dynamic-client-registration): The protocol-level reference for the DCR endpoint, request fields, and response shape.
+- [Register an MCP Client in the Console](../register-a-client): Pre-register a client instead, when you know its redirect URI ahead of time.
+- [Secure Your MCP Server](../../mcp-server/secure-your-mcp-server): Protect the MCP server these clients connect to.
+- [Connect a Python MCP Server](../../../../getting-started/connect-your-mcp/python): A runnable quickstart that connects Claude Code through DCR, end to end.

--- a/docs/content/guides/mcp/mcp-clients/index.mdx
+++ b/docs/content/guides/mcp/mcp-clients/index.mdx
@@ -1,0 +1,63 @@
+---
+title: MCP Client Identity
+docType: concept
+persona: iam
+sidebar_position: 1
+description: Why an MCP client connecting over HTTP is an OAuth 2.1 client, the two ways it authenticates, and how to register one in {{ProductName}}.
+---
+
+# MCP Client Identity
+
+An MCP client that connects to a remote MCP server over HTTP acts as an OAuth 2.1 client. It cannot call a protected MCP server without credentials and a token, the same as any other client calling a protected API. An MCP client connecting to a server launched locally over stdio is outside the MCP authorization specification; it takes credentials from the environment instead.
+
+## Public vs. Confidential Clients
+
+An OAuth client is either public, unable to hold a secret in confidence, or confidential, able to authenticate with one. Most MCP clients, desktop AI hosts, CLI tools, and debug UIs among them, run entirely on the user's machine or in a context where a bundled secret could be extracted. That makes them public clients, and a public client requesting a token on a user's behalf must use PKCE (Proof Key for Code Exchange) to protect the authorization code from interception.
+
+## User-Delegated vs. Machine-to-Machine Clients
+
+An MCP client authenticates in one of two shapes:
+
+- **User-delegated**: a human is the subject. The client runs Authorization Code with PKCE, and the token it receives carries the signed-in user's access.
+- **Machine-to-machine**: the client itself is the subject, with no user involved. The client runs Client Credentials, and the token carries the client's own access.
+
+## Redirect URIs for Local Clients
+
+A user-delegated client needs a redirect URI to receive the authorization code. Local MCP clients complicate this in ways a typical web app redirect URI does not:
+
+- Redirect URIs match exactly, port included, with no wildcards.
+- Local clients typically use a loopback callback (`http://localhost:PORT/callback` or `127.0.0.1`), rather than a public HTTPS redirect URI.
+- Some clients pick a random port each time they start, so there is no fixed redirect URI to register ahead of time.
+
+That last case is why static registration alone does not cover every MCP client.
+
+## Static vs. Dynamic Registration
+
+Registering a client ahead of time, giving it a client ID and a fixed redirect URI before it ever connects, works when you know the client in advance. It does not work for an MCP server that any client might connect to: the server's operator cannot enumerate every client that will ever show up, and a client that picks a random callback port has no fixed redirect URI to register in the first place.
+
+[RFC 7591 Dynamic Client Registration](../../protocols/oauth-oidc/dynamic-client-registration) (DCR) solves this by letting a client register itself against a registration endpoint at connection time, supplying its own redirect URI and receiving a client ID back immediately. This is why DCR shows up so often in MCP deployments: the client population is open-ended in a way most OAuth deployments are not. See that page for the protocol details; this page covers only the choice between the two approaches.
+
+The MCP specification's current revision deprecates DCR in favor of Client ID Metadata Documents, keeping DCR only for backward compatibility, so treat it as the fallback path rather than the default going forward.
+
+## How <ProductName /> Fits
+
+<ProductName /> represents an MCP client as the **MCP Client** application type, configured as either user-delegated or machine-to-machine. There are exactly two ways to give a client OAuth credentials: register it yourself in the Console, or let it register itself the first time it connects.
+
+### Register in the Console vs. Dynamic Client Registration
+
+| | Register in the Console | Dynamic Client Registration |
+|---|---|---|
+| **How it works** | You create the application ahead of time and set its redirect URI. | The client registers itself against the DCR endpoint the first time it connects. |
+| **Best for** | A fixed set of known clients, such as MCP Inspector or your own agent. | Clients you cannot enumerate in advance, or that expect DCR, such as Claude Code. |
+| **What you control** | The client's name, redirect URI, and client type, set up front in the Console. | Whether Dynamic Client Registration is enabled, and whether it requires authentication. |
+
+### Which Should You Pick?
+
+Register the client in the Console when you know it ahead of time and can set its redirect URI yourself. You get a client ID before the client ever connects, and the client type step configures the correct grant type for you. Reach for Dynamic Client Registration when you cannot enumerate every client in advance, such as a third-party AI host, or when the client itself expects DCR and has no way to accept a pre-issued client ID, such as Claude Code.
+
+The choice is not exclusive at the deployment level. You can pre-register some clients in the Console while leaving Dynamic Client Registration enabled for others.
+
+## Related
+
+- [Register an MCP Client in the Console](./register-a-client): create an application for a known client.
+- [Enable Dynamic Client Registration](./dynamic-client-registration): let clients register themselves on first connect.

--- a/docs/content/guides/mcp/mcp-clients/register-a-client.mdx
+++ b/docs/content/guides/mcp/mcp-clients/register-a-client.mdx
@@ -1,0 +1,108 @@
+---
+title: Register an MCP Client in the Console
+docType: guide
+persona: iam
+sidebar_position: 2
+description: Register an MCP client application in the Console and choose between the user-delegated and machine-to-machine client types.
+---
+
+# Register an MCP Client in the Console
+
+Register an MCP client in the Console when you know its redirect URI ahead of time, such as MCP Inspector or a client you built yourself. This gives you a stable Client ID before the client ever connects.
+
+## Prerequisites
+
+- <ProductName /> is running. See [Get Started](../../../../getting-started/get-thunderid).
+- You can sign in to the <ProductName /> Console.
+- The redirect URI your MCP client uses for its OAuth callback, if it acts on behalf of a user.
+
+<Stepper stepNode="h2" as="h2">
+
+## Step 1: Start the Application Wizard
+
+1. Sign in to the <ProductName /> Console.
+2. Navigate to **Applications** and click **Add Application**.
+3. Select **MCP Client**.
+4. Enter a name for the client.
+5. If prompted, select an organization unit.
+
+## Step 2: Choose the Client Type
+
+The **Client type** step is the most important choice on this page: it decides how the client obtains tokens and whether it acts for a signed-in user.
+
+### On Behalf of a User
+
+Select **On behalf of a user** for an MCP client running inside a host app, such as an IDE, desktop app, or chat client, that a person signs in to interactively. MCP Inspector is this type.
+
+This option configures the Authorization Code flow with PKCE and registers the client as a public client with no client secret. PKCE is locked on: the form shows it as read-only because a user-delegated MCP client always requires it. Selecting this type also embeds the redirect URI editor directly in this step, so add at least one redirect URI here before continuing.
+
+### Machine-to-Machine
+
+Select **On its own behalf** for a client that authenticates with its own credentials and has no signed-in user, such as an autonomous agent or a background service calling MCP servers directly.
+
+This option configures the Client Credentials flow and registers the client as a confidential client. <ProductName /> issues a client secret, and no redirect URI is collected because this client type never redirects a user anywhere.
+
+## Step 3: Finish
+
+Click **Finish**. <ProductName /> creates the application and opens its detail page directly, with no separate completion screen. Open the **General** tab: its **Connection** card shows the **Client ID**. For a machine-to-machine client, generate the **Client Secret** here, since <ProductName /> does not display it automatically after creation (see [Where Credentials Live](#where-credentials-live)).
+
+</Stepper>
+
+## Redirect URI Rules
+
+For a user-delegated client, each redirect URI must satisfy one of two rules:
+
+- A loopback address over `http:`: the host must be `localhost`, `127.0.0.1`, or `[::1]`, with an optional port (for example, `http://localhost:6274/oauth/callback`).
+- Any address over `https:`.
+
+Any other scheme is rejected, including plain `http://` on a non-loopback host. Wildcards (`*`) are rejected anywhere in the URI. The backend's create-time validation independently rejects a wildcard in a redirect URI's port unconditionally, and rejects a wildcard host unless the deployment has explicitly opted in to wildcard redirect URIs, so a wildcard MCP redirect URI is never accepted through the Console.
+
+Ports must match exactly. If your client picks a random callback port each time it starts, such as a local CLI tool that binds to an ephemeral port, you cannot register that exact port ahead of time. [Dynamic Client Registration](../dynamic-client-registration) exists for this case: the client registers its own redirect URI, including whatever port it happened to bind, at connection time instead of you pre-registering it.
+
+## Where Credentials Live
+
+The application's **General** tab holds a **Connection** card with:
+
+- **Application ID**: the <ProductName /> application identifier.
+- **Client ID**: the OAuth 2.1 client ID, for both client types.
+- **Client Secret**: shown only for the machine-to-machine type, since that is the only confidential MCP client type. The field displays a masked placeholder, never the actual value. Click **Generate** to issue a new secret, which <ProductName /> shows once in a dialog. Copy it immediately: closing the dialog without copying means generating another one, which invalidates the previous secret for any client already using it.
+
+## Access Control
+
+For a user-delegated client, the **General** tab also shows an **Access** card:
+
+- **Allowed User Types**: which user schemas may authorize this client. Leave it empty to allow every user type.
+- **Client URI**: an optional public homepage for the client.
+- **Authorized redirect URIs**: the same redirect URIs configured during creation, editable here. At least one is required, and each one follows the [redirect URI rules](#redirect-uri-rules) above.
+
+A machine-to-machine client has no signed-in user, so the Console does not show this card for it.
+
+## Browser-Based Clients Need a CORS Origin
+
+If your MCP client runs in a browser, such as a web-based inspector or dashboard, and calls <ProductName /> cross-origin, its origin must be explicitly allowed. This is a deployment-wide CORS setting, not a per-application one, so it is configured separately from the steps above.
+
+Add the origin to `config/resources/server_configs/cors.yaml` in your <ProductName /> distribution:
+
+```yaml
+name: cors
+value:
+  allowedOrigins:
+    - "http://localhost:6274"
+```
+
+If the file already exists, append to the existing `allowedOrigins` list instead of replacing it. You can also update this at runtime with `PUT /server-config/cors`. Restart <ProductName /> after editing the file.
+
+## Manage the Client
+
+To update a client's configuration, open it from the **Applications** list, change the relevant setting on the **General** tab, and click **Save**. Changes take effect immediately for new authentication requests; active sessions and issued tokens are unaffected until they expire.
+
+To rotate credentials for a machine-to-machine client, click **Generate** next to **Client Secret** on the **General** tab. This immediately invalidates the previous secret.
+
+To delete a client, open it from the **Applications** list and click **Delete Application** in the danger zone. This is permanent: any caller using the client's Client ID immediately loses the ability to authenticate, though issued tokens remain valid until they expire.
+
+## Next Steps
+
+- [Dynamic Client Registration](../dynamic-client-registration): Let clients register themselves instead of pre-registering them here.
+- [Secure Your MCP Server](../../mcp-server/secure-your-mcp-server): Protect the MCP server this client connects to.
+- [Manage Applications](../../../applications/manage-applications): General application management, covering all application types.
+- [Connect a Python MCP Server](../../../../getting-started/connect-your-mcp/python): A runnable quickstart that registers an MCP Inspector client this way, end to end.

--- a/docs/content/guides/mcp/mcp-server/index.mdx
+++ b/docs/content/guides/mcp/mcp-server/index.mdx
@@ -1,0 +1,58 @@
+---
+title: MCP Server Authorization
+docType: concept
+persona: iam
+sidebar_position: 1
+description: Why an MCP server is an OAuth 2.1 resource server, how it enforces scopes at the tool boundary, and how {{ProductName}} fits.
+---
+
+# MCP Server Authorization
+
+An MCP server reached over HTTP is an OAuth 2.1 resource server. It holds no authorization policy of its own. It enforces decisions made by the authorization server that issued the token.
+
+## What the Server Must Publish
+
+A protected MCP server publishes [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) protected-resource metadata naming its authorization server. When a client connects without a valid token, the server rejects the request with a `401` and a `WWW-Authenticate` header pointing at that metadata, so the client can discover where to get one.
+
+## Scope Granularity Is a Design Decision
+
+A scope is the unit an access token carries and a tool checks. How finely you divide scopes is a trade-off, not a fixed rule:
+
+- **One scope per tool**: the most precise. A caller granted `send-message` cannot use `delete-conversation`, even if both live on the same server.
+- **One scope per tool group**: a common middle ground, where related tools such as `read-*` operations share one scope.
+- **One scope per server**: the simplest to manage, but coarse. Any caller with access to the server can use every tool it exposes.
+
+The enforcement logic at the tool boundary is identical regardless of which granularity you choose. Only the scope vocabulary the server checks against changes.
+
+## Enforcement at the Tool Boundary
+
+The server checks the required scope before it invokes a tool's handler, not after. That ordering matters: a caller whose token is missing a scope fails cleanly at the protocol layer, before any part of the handler runs, instead of the handler starting and producing a partial side effect that then has to be checked or rolled back. Servers commonly extend this further by filtering the tool list itself to what the caller's scopes allow, so a tool the caller cannot use never appears as an option.
+
+## Token Validation
+
+A server validates a token one of two ways:
+
+- **Offline JWT validation**: the server fetches the authorization server's JWKS, finds the signing key by `kid`, and checks the signature, issuer, audience, and expiry locally, with no callback to the authorization server on each request. This is the common case for MCP servers, since it keeps every tool call fast.
+- **Token introspection**: the server calls the authorization server on each request to ask whether a token is still valid. This applies when tokens must be revocable before they expire, at the cost of a network call per request.
+
+## Audience Binding
+
+When several MCP servers share one authorization server, a token issued for one of them must not work against another, even though both trust the same issuer. Binding the token to a specific audience or resource identifier at issuance is what makes that guarantee hold. Without it, a token obtained for a low-risk server could be replayed against a more sensitive one.
+
+## Runtime Policy Decisions
+
+Scopes alone answer whether a caller may use a tool at all, not whether a specific call with specific arguments should be allowed, such as whether this transfer amount from this account is permitted. Some deployments address that by asking an external policy decision point (PDP) per tool call instead of relying only on the token's scopes. [AuthZEN](https://openid.github.io/authzen/) is the standard for that interaction: the server acts as a policy enforcement point and sends the subject, resource, action, and call-specific context to a PDP, which returns an allow or deny decision computed at request time.
+
+## How <ProductName /> Fits
+
+Register your MCP server as a resource server in <ProductName />, and define one permission per tool: the permission's handle becomes the scope your server checks. Bundle those permissions into roles, and assign the roles to the clients or users that should hold them. <ProductName /> issues access tokens carrying only the scopes a role actually grants, bound to the resource server's identifier as the audience.
+
+Your MCP server validates tokens offline against <ProductName />'s JWKS endpoint. For decisions that depend on call arguments rather than just on who is calling, your server can call <ProductName />'s AuthZEN policy decision point instead of relying on scopes alone.
+
+## Related
+
+- [Secure Your MCP Server](./secure-your-mcp-server): configure a resource server, tool permissions, and token validation in <ProductName />.
+- [Connect a Python MCP Server](../../../getting-started/connect-your-mcp/python): a runnable quickstart with a sample MCP server.
+- [Manage Resource Servers](../../resource-servers): general resource server, resource, and permission management.
+- [JWKS](../../protocols/oauth-oidc/jwks): the endpoint your server validates tokens against.
+- [Policy Decision Point](../../protocols/authzen/pdp): the AuthZEN PDP endpoints for runtime tool authorization.

--- a/docs/content/guides/mcp/mcp-server/secure-your-mcp-server.mdx
+++ b/docs/content/guides/mcp/mcp-server/secure-your-mcp-server.mdx
@@ -1,0 +1,137 @@
+---
+title: Secure Your MCP Server
+docType: guide
+persona: iam
+sidebar_position: 2
+description: Turn your MCP server into an OAuth 2.1 resource server protected by {{ProductName}}, with a scope per tool and offline token validation, in any language.
+---
+
+# Secure Your MCP Server
+
+For the generic pattern behind this guide, MCP servers as OAuth resource servers, scope granularity, and token validation, see [MCP Server Authorization](..).
+
+Turn your MCP server, reached over HTTP, into an OAuth 2.1 resource server protected by <ProductName />, whatever language it is written in. Register the server as a resource server, define a scope per tool, grant those scopes through a role, and validate tokens at the tool boundary before any tool runs.
+
+:::tip Runnable Example
+This guide covers the pattern, not a specific stack. For a complete, working implementation using FastMCP, see [Secure Your MCP Server (Python)](../../../../getting-started/connect-your-mcp/python).
+:::
+
+## Prerequisites
+
+- <ProductName /> is running. See [Get Started](../../../../getting-started/get-thunderid).
+- You can sign in to the <ProductName /> Console.
+- An MCP server you control, able to validate JWTs offline and publish RFC 9728 protected-resource metadata, through your language's MCP SDK or your own middleware.
+- The list of tools your MCP server exposes, since you define one permission per tool.
+
+## How It Works
+
+Your MCP server becomes an OAuth 2.1 resource server. When a client connects without a token, the server responds with a `401` and RFC 9728 protected-resource metadata that points the client at <ProductName /> as its authorization server. The client runs an OAuth 2.1 flow, typically Authorization Code with PKCE, and gets back a JWT scoped to whichever tool permissions the signing-in user's or client's roles actually grant. On the next request, the server validates that JWT offline against <ProductName />'s JWKS endpoint, with no callback to <ProductName /> per request, and enforces the scope each tool requires before it runs.
+
+<McpOAuthFlowDiagram />
+
+<Stepper stepNode="h2" as="h2">
+
+## Step 1: Register the MCP Server as a Resource Server
+
+In the Console:
+
+1. Navigate to **Resource Servers** and click **Add resource server**.
+2. On the **Type** step, select **MCP**.
+3. On the **Name** step, enter an **MCP Server Name** and an **Identifier**. Set the identifier to the MCP server's own URL, for example `https://mcp.example.com`: it becomes the access token audience for [Resource Indicators](../../../protocols/oauth-oidc/resource-indicators) (RFC 8707).
+4. On the **Permission Delimiter** step, choose the character that separates parts of a permission string, for example the default colon (`:`). If your deployment has multiple organization units, select one first, then click **Create MCP server**.
+
+:::note
+The delimiter cannot be changed after creation, so plan it before you click **Create MCP server**.
+:::
+
+## Step 2: Define Tool Permissions
+
+On the **Capabilities** tab of the resource server you just created, add one tool permission per MCP tool:
+
+1. Click **Add tool permission**. Once the panel has at least one capability, add more by clicking the **+** icon in the panel header and selecting **Add tool permission** from the menu instead.
+2. Enter a **Name** for the tool. <ProductName /> derives the **Handle** from the name automatically: it lowercases the words and joins them with a hyphen, or with an underscore if you chose a hyphen as the resource server's permission delimiter, to avoid a handle that collides with it.
+3. Confirm the handle before clicking **Add**. For a top-level tool permission, the handle *is* the permission, with no resource server prefix, so it becomes the exact scope string your server must check for that tool.
+4. Repeat for every tool the MCP server exposes.
+
+For example, a tool named `Send Message` produces the handle `send-message` and the permission `send-message`. If your server's scope check instead looks for `send_message` or `sendMessage`, the mismatch means the token never satisfies it, and the tool never appears to a caller, the same way it would not appear if the caller held no matching permission at all.
+
+The same panel also lets you add resource permissions, for MCP resources rather than tools, following the same name-to-handle pattern.
+
+## Step 3: Grant the Permissions Through a Role
+
+Registering a tool permission in the previous step only defines it. <ProductName /> puts a scope into an access token only when the signing-in user or client actually holds the matching permission through a role, and a scope they do not hold is not rejected, it is silently dropped from the issued token. A missing scope does not make its tool error: the tool simply does not appear, which looks identical to the tool never having existed. This is the most common reason a freshly registered tool does not show up for a test user, so create and assign the role before you try to connect a client.
+
+1. Navigate to **Roles** and click **Add Role**.
+2. Enter a name and, if prompted, select an organization unit.
+3. On the **Permissions** step, expand your MCP server's entry and, under **Tools**, select the permissions this role should grant.
+4. Create the role.
+5. Open the role, select the **Assignments** tab, and click **Add**.
+6. On the **Users**, **Groups**, **Applications**, or **Agents** tab, depending on who should hold this role, select the principals and click **Add Selected**.
+
+:::warning
+A user or client that authenticates without this role gets a token missing every tool-scoped permission, even though the resource server correctly lists them as capabilities. If a tool disappears for one caller but not another, check role assignments before you check your server's scope-checking code.
+:::
+
+## Step 4: Point Clients at <ProductName />
+
+Your MCP server's SDK, or your own middleware, publishes the RFC 9728 protected-resource metadata that names <ProductName /> as its authorization server. When it rejects an unauthenticated request, it returns a `401` with a `WWW-Authenticate` header pointing at that metadata:
+
+```text
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource"
+```
+
+Fetching that URL returns the metadata document:
+
+```json
+{
+  "resource": "https://mcp.example.com",
+  "authorization_servers": ["https://your-thunderid-instance.example.com/"],
+  "scopes_supported": ["send-message", "list-conversations"],
+  "bearer_methods_supported": ["header"]
+}
+```
+
+The client resolves the `authorization_servers` entry against <ProductName />'s own [Server Metadata](../../../protocols/oauth-oidc/server-metadata) document to discover the authorization, token, and JWKS endpoints, then runs an OAuth flow to get a token. How the client itself gets OAuth credentials, as a pre-registered application or through Dynamic Client Registration, is covered in [MCP Client Identity](../../mcp-clients).
+
+## Step 5: Validate Tokens at the Tool Boundary
+
+<ProductName /> issues the token. Enforcing it is your MCP server's job, on every request:
+
+1. **Validate the JWT offline.** Fetch <ProductName />'s [JWKS](../../../protocols/oauth-oidc/jwks) endpoint, find the signing key by `kid`, and verify the signature, `iss`, and `exp`. Most JWT libraries handle this given a `jwks_uri`. Cache the response and refresh it once on an unknown `kid`, not on every request.
+2. **Check the audience.** The `aud` claim must equal the resource server identifier you registered in Step 1. [Resource Indicators](../../../protocols/oauth-oidc/resource-indicators) is what binds a token to that specific identifier, so a token issued for a different resource server on the same <ProductName /> deployment fails this check even though its signature is valid.
+3. **Enforce the per-tool scope before the tool runs.** Compare the `scope` claim against the permission handle you defined for that tool in Step 2. Prefer excluding a tool the token cannot satisfy from what the client sees over letting the client call it and failing at that point: a missing scope should make a tool disappear from the tool list, the same way it disappears when a role never granted it.
+
+A validated access token's payload looks like this:
+
+```json
+{
+  "sub": "0197c3f0-6b16-7908-9bc9-d848c00db406",
+  "iss": "https://your-thunderid-instance.example.com",
+  "aud": "https://mcp.example.com",
+  "scope": "send-message list-conversations",
+  "exp": 1782000000
+}
+```
+
+See [Token Formats](../../../protocols/oauth-oidc/token-formats) for how <ProductName /> signs access tokens, and [Claims & Scopes](../../../protocols/oauth-oidc/claims-and-scopes) for how requested scopes become the scopes a token actually carries.
+
+</Stepper>
+
+## Consent
+
+If your MCP client also requests OIDC scopes, such as `profile` or `email`, to identify the user it is acting for, what it receives can be narrower than what it asked for. <ProductName /> triggers its consent flow based on the user attributes the MCP client's application is configured to require, not simply on the scopes present in the request: the signing-in user can deny individual attributes, and any attribute they deny does not reach the ID token or UserInfo response, even though the client requested a scope that would normally include it.
+
+This is a separate mechanism from the role-based scope filtering in Step 3. A tool scope is dropped because the user's role does not grant it, silently and with no prompt. An attribute is dropped because the user chose not to share it, in an interactive prompt. See [Consent](../../../consent) for how to configure attribute consent for an application.
+
+## Fine-Grained Authorization with AuthZEN
+
+Scopes are coarse-grained: a `transfer` scope says the caller may use the `transfer` tool at all, not that they may transfer this specific amount from that specific account. When a tool needs a decision that depends on the call's arguments, not just on who is calling, scopes alone are not enough.
+
+For those cases, have your MCP server call <ProductName /> as an AuthZEN policy decision point (PDP) before it runs the tool handler, instead of relying only on the token's scope. Your server authenticates to the PDP with its own server-level secret, separate from the caller's token, and sends the subject (from the validated token), the resource, the action, and any request context specific to that call. <ProductName /> evaluates the request against resource servers, resources, actions, roles, and role assignments, and returns an allow or deny decision computed at request time, not baked into the token. See [AuthZEN](../../../protocols/authzen) for the protocol and [Policy Decision Point](../../../protocols/authzen/pdp) for the PDP endpoints, and walk through a working example in [AuthZEN-Based MCP Authorization](../../../../use-cases/ai-agents/mcp-authorization/try-it-out/authzen-authorization).
+
+## Next Steps
+
+- [Secure Your MCP Server (Python)](../../../../getting-started/connect-your-mcp/python): a complete, runnable version of this guide using FastMCP.
+- [MCP Client Identity](../../mcp-clients): register the clients that connect to your MCP server, or let them self-register through Dynamic Client Registration.
+- [Securing MCP](../../../../use-cases/ai-agents/mcp-authorization/overview): the broader pattern for securing MCP servers and governing MCP clients.

--- a/docs/content/guides/mcp/overview.mdx
+++ b/docs/content/guides/mcp/overview.mdx
@@ -1,0 +1,88 @@
+---
+title: MCP Authorization
+docType: concept
+persona: iam
+sidebar_position: 0
+description: How the MCP Authorization specification protects tool calls, and the two roles {{ProductName}} plays in an MCP deployment.
+---
+
+# MCP Authorization
+
+The Model Context Protocol (MCP) gives AI assistants and agents a standard way to call tools and read data through MCP servers. An MCP deployment has three parties: an MCP host or client that a user or agent interacts with, an MCP server that exposes tools and resources, and an authorization server that decides who may call which tool.
+
+## Why MCP Tools Need Authorization
+
+An MCP server's tools are not always low-risk. They can read files, query databases, send email, or modify infrastructure. Without access control, every client that can reach the server can invoke every tool it exposes, with no boundary between a low-risk read and a destructive write.
+
+:::note
+Everything on this page applies to an MCP server reached over HTTP. An MCP server launched locally over stdio is outside the MCP authorization specification; its client takes credentials from the environment instead of running an OAuth flow.
+:::
+
+## How the MCP Authorization Specification Solves It
+
+The [MCP Authorization specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization) treats an MCP server as an OAuth 2.1 resource server and separates it from the authorization server that issues tokens.
+
+A client that connects without a token gets a `401` response carrying a `WWW-Authenticate` header. That header points at [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) protected-resource metadata, a document the MCP server publishes that names its authorization server. The client resolves that authorization server's own metadata through [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) discovery, which lists the authorization, token, and JWKS endpoints.
+
+The client then runs one of two OAuth flows, depending on who it acts for:
+
+- **Authorization Code with PKCE**, when a signed-in user delegates access to the client.
+- **Client Credentials**, when the client authenticates on its own behalf, with no user involved.
+
+The token the client gets back is bound to the specific MCP server it requested, through an audience or resource identifier. That binding stops a token issued for one MCP server from being replayed against another, even when both trust the same authorization server.
+
+The MCP server enforces this at the tool boundary: it checks the token's scope before a tool handler runs, not after, so a caller without the right scope never reaches the tool's side effects.
+
+```mermaid
+sequenceDiagram
+    participant C as MCP client
+    participant S as MCP server
+    participant A as Authorization server
+
+    C->>S: Connect without a token
+    S-->>C: 401 with RFC 9728 metadata naming the authorization server
+    C->>A: RFC 8414 discovery of the authorization, token, and JWKS endpoints
+    C->>A: Authorization Code with PKCE, or Client Credentials
+    A-->>C: Token scoped to the user's or client's access, bound to this server
+    C->>S: Retry with the token
+    S->>S: Validate the token and check the tool's scope
+    S-->>C: Tool result, filtered to the token's scopes
+```
+
+## How <ProductName /> Fits
+
+<ProductName /> plays two roles in an MCP deployment.
+
+### Authorization Server for Your MCP Servers
+
+You register your MCP server as a resource server and define one permission per tool. <ProductName /> issues access tokens scoped to only the permissions the signed-in user or client actually holds, and your MCP server's tools validate those scopes before they run.
+
+### Identity Home for MCP Clients
+
+Every MCP client needs OAuth credentials from <ProductName /> before it can request a token, whether it is an AI assistant, an autonomous agent, or a debugging tool such as MCP Inspector. You either register the client as an application in the Console ahead of time, or let it register itself the first time it connects, through Dynamic Client Registration.
+
+## What <ProductName /> Provides
+
+| Capability | What It Gives You |
+|---|---|
+| **MCP Client application type** | Register a client as user-delegated (Authorization Code with PKCE) or machine-to-machine (Client Credentials). |
+| **Resource server registration** | Register your MCP server and turn each tool into a permission. The permission's handle becomes the scope tools validate. |
+| **Dynamic Client Registration** | Let a client such as Claude Code register its own OAuth credentials the first time it connects. |
+| **Consent** | Show a consent screen so a user approves the scopes a client requests on their behalf. |
+| **AuthZEN-based tool authorization** | Ask <ProductName /> for a runtime authorization decision on a tool call, instead of relying on the token's scopes alone. |
+| **Enterprise-Managed Authorization** | Accept or issue Identity Assertion Authorization Grants (ID-JAG) so an enterprise identity provider centralizes MCP access decisions. |
+
+## Enterprise-Managed Authorization
+
+Enterprises that already centralize access decisions in an identity provider can extend that model to MCP through the Identity Assertion Authorization Grant (ID-JAG). <ProductName /> can accept ID-JAGs issued by an external identity provider, or issue them itself as the enterprise identity provider for a downstream MCP authorization server. See [Enterprise-Managed Authorization](../../../use-cases/ai-agents/mcp-authorization/enterprise-managed-authorization) for the pattern, and [Identity Assertion Authorization Grant (ID-JAG)](../../protocols/oauth-oidc/identity-assertion-grant) for the protocol reference.
+
+## <ProductName />'s Own MCP Server
+
+Separately from securing your own MCP servers, <ProductName /> ships an admin MCP server at the `/mcp` endpoint. It lets MCP clients manage <ProductName /> applications, flows, users, and themes directly, in natural language, instead of through the Console UI. See [MCP Server](../../../working-with-ai/mcp-server) for setup and the available tools.
+
+## Related
+
+- [MCP Client Identity](../mcp-clients): how an MCP client gets OAuth credentials, and how to choose in <ProductName />.
+- [MCP Server Authorization](../mcp-server): how an MCP server enforces access, and how to configure it in <ProductName />.
+- [Connect a Python MCP Server](../../../getting-started/connect-your-mcp/python): a runnable quickstart with a sample MCP server.
+- [Securing MCP](../../../use-cases/ai-agents/mcp-authorization/overview): authorization patterns for MCP servers and clients.

--- a/docs/content/use-cases/ai-agents/mcp-authorization/configure-it-yourself.mdx
+++ b/docs/content/use-cases/ai-agents/mcp-authorization/configure-it-yourself.mdx
@@ -26,12 +26,12 @@ Navigate to **Applications** → **Add Application** and choose **Browser App** 
 | Allowed user types   | `Customer`                                                                                                                        |
 | Authentication flow  | `wayfinder-agent-auth-flow` (the same flow the Wayfinder Concierge uses, so the consent screen surfaces each `booking:*` permission as a toggle)        |
 
-See [Manage Applications](../../../../guides/applications/manage-applications).
+See [Manage Applications](../../../../guides/applications/manage-applications), or [Register an MCP Client in the Console](../../../../guides/mcp/mcp-clients/register-a-client) for the MCP-specific version of this task.
 
 The walkthrough relies on the consent screen at sign-in to narrow what the external client gets. `john.doe` keeps his existing `Booking User` role unchanged, and picks which `booking:*` permissions to release the first time he signs in through Inspector.
 
 :::info[Alternative: Dynamic Client Registration]
-If you don't want to register every MCP client up-front, <ProductName /> also supports [Dynamic Client Registration](../../../../guides/protocols/oauth-oidc/dynamic-client-registration). An MCP client that supports DCR can discover <ProductName /> through the MCP server's protected-resource metadata and register itself, after which it uses its issued credentials for the same authorization-code flow. The tryout uses static registration for predictability. DCR is the right choice when you can't enumerate every client in advance.
+If you don't want to register every MCP client up-front, <ProductName /> also supports [Dynamic Client Registration](../../../../guides/protocols/oauth-oidc/dynamic-client-registration). An MCP client that supports DCR can discover <ProductName /> through the MCP server's protected-resource metadata and register itself, after which it uses its issued credentials for the same authorization-code flow. The tryout uses static registration for predictability. DCR is the right choice when you can't enumerate every client in advance. See [Enable Dynamic Client Registration](../../../../guides/mcp/mcp-clients/dynamic-client-registration) for how to turn this on for your own MCP server.
 :::
 
 ## Configure the Direct Auth Secret

--- a/docs/content/use-cases/ai-agents/mcp-authorization/identity-concepts.mdx
+++ b/docs/content/use-cases/ai-agents/mcp-authorization/identity-concepts.mdx
@@ -20,7 +20,7 @@ The application registers redirect URIs for MCP Inspector:
 
 `EXTERNAL-MCP-CLIENT` is wired to the same authentication flow as the Wayfinder Concierge, so the OAuth consent screen surfaces each requested `booking:*` permission as an individual toggle at sign-in time.
 
-See [Manage Applications](../../../../guides/applications/manage-applications).
+See [Manage Applications](../../../../guides/applications/manage-applications), or [Register an MCP Client in the Console](../../../../guides/mcp/mcp-clients/register-a-client) for the MCP-specific version of this task.
 
 ## Consent at Sign-In
 
@@ -44,7 +44,7 @@ Each MCP tool checks for the same scope its REST counterpart checks for:
 | `create_booking` | `POST /api/bookings` | `booking:create` |
 | `delete_all_bookings` | `DELETE /api/bookings/flights` | `booking:cancel` |
 
-See [Resource Servers](../../../../guides/resource-servers).
+See [Resource Servers](../../../../guides/resource-servers), or [Secure Your MCP Server](../../../../guides/mcp/mcp-server/secure-your-mcp-server) for the MCP-specific version of this task.
 
 ## AuthZEN Authorization Mode
 

--- a/docs/content/use-cases/ai-agents/mcp-authorization/overview.mdx
+++ b/docs/content/use-cases/ai-agents/mcp-authorization/overview.mdx
@@ -44,7 +44,7 @@ For example, a research MCP server exposes browsing tools, an `export` tool, and
 - Enforce the per-tool scope before invoking the tool handler.
 - Centralize the authorization decision in <ProductName />; the MCP server only enforces.
 
-See it running: [Try It Out - Protect Your MCP Server](../try-it-out).
+See it running: [Try It Out - Protect Your MCP Server](../try-it-out). For the hands-on guide, see [Secure Your MCP Server](../../../../guides/mcp/mcp-server/secure-your-mcp-server); for the concept behind it, see [MCP Server Authorization](../../../../guides/mcp/mcp-server).
 
 ### Govern MCP Clients
 
@@ -62,7 +62,7 @@ For example, your in-product agent is registered as an agent and granted access 
 - Run the consent flow when the MCP client acts on a user's behalf, so the user approves the requested scopes.
 - Revoke a client's credentials when it is decommissioned or compromised: all tokens it issued stop being accepted.
 
-See it running: [Try It Out - Govern MCP Clients](../try-it-out).
+See it running: [Try It Out - Govern MCP Clients](../try-it-out). For the hands-on guides, see [Register an MCP Client in the Console](../../../../guides/mcp/mcp-clients/register-a-client) and [Enable Dynamic Client Registration](../../../../guides/mcp/mcp-clients/dynamic-client-registration); for the concept behind it, see [MCP Client Identity](../../../../guides/mcp/mcp-clients).
 
 ## Cross-Cutting Capabilities
 
@@ -86,7 +86,7 @@ Enterprises that already centralize access decisions in their identity provider 
 
 ## Next Steps
 
-Once you know which patterns apply, the next decision is how to integrate. See **[Solution Patterns](../solution-patterns)** to compare server-side and client-side options.
+Once you know which patterns apply, the next decision is how to integrate. See **[Solution Patterns](../solution-patterns)** to compare server-side and client-side options, or go straight to the **[MCP Authorization guides](../../../../guides/mcp/overview)** for step-by-step setup.
 
 ## Related Capabilities
 

--- a/docs/content/use-cases/ai-agents/mcp-authorization/solution-patterns.mdx
+++ b/docs/content/use-cases/ai-agents/mcp-authorization/solution-patterns.mdx
@@ -19,11 +19,15 @@ This is what gives <ProductName /> the vocabulary to issue scope-bearing tokens 
 
 A practical choice that sits inside this pattern: how finely to scope. One scope per tool gives the most precise control (you can grant read-only without write); one scope per tool group is a common middle ground; one scope per server is simplest but coarse. The MCP server's enforcement logic stays the same regardless: only the scope vocabulary changes.
 
+See [Secure Your MCP Server](../../../../guides/mcp/mcp-server/secure-your-mcp-server) for the step-by-step guide.
+
 ### Token Validation at the Tool Boundary
 
 The MCP server validates the incoming token on every MCP request and checks for the required scope before invoking the tool handler. <ProductName /> handles issuance; the MCP server handles enforcement. Keeping these split puts the policy in one place (<ProductName />) and the check at the component closest to the call. A missing scope then fails cleanly at the protocol layer, rather than producing partial side effects.
 
 If your environment runs more than one MCP server behind the same authorization server, scope the issued tokens to the target server so a token meant for one cannot be replayed against another. <ProductName /> handles this automatically when the client requests a target during the token exchange.
+
+See [Secure Your MCP Server](../../../../guides/mcp/mcp-server/secure-your-mcp-server) for how to enforce this at the tool boundary.
 
 ## MCP Client Patterns
 
@@ -35,17 +39,21 @@ Register the MCP client as an application in <ProductName /> up-front. Configure
 
 Fits known clients you control or have explicitly decided to support: internal admin tools, off-the-shelf MCP clients on your allow-list, anything you can configure once and rarely revisit. The trade-off is operational: any new MCP client type needs to be registered before it can connect.
 
+See [Register an MCP Client in the Console](../../../../guides/mcp/mcp-clients/register-a-client) for the step-by-step guide.
+
 ### Registered Agent
 
 When the MCP client is one of your own AI agents, register it as an agent in <ProductName /> rather than as an application. The agent identity is portable: the same agent can reach multiple MCP servers under one auditable identity, with one Client ID and one credential lifecycle to manage.
 
-This is the same identity primitive used in the [Securing AI Agents](../../overview) patterns. Choose this when the MCP client *is* an agent in your system, not just an OAuth client.
+This is the same identity primitive used in the [Securing AI Agents](../../overview) patterns. Choose this when the MCP client *is* an agent in your system, not just an OAuth client. See [MCP Client Identity](../../../../guides/mcp/mcp-clients) for how this identity model applies across MCP clients.
 
 ### Dynamic Client Registration
 
 Some MCP clients can register themselves. The client reads the MCP server's protected-resource metadata, discovers <ProductName /> as the authorization server, and registers via <ProductName />'s dynamic registration endpoint. <ProductName /> issues credentials the client then uses for token requests.
 
 Fits ecosystems where MCP clients can't all be enumerated in advance: third-party AI hosts, marketplace tools, integrations built by customers. The trade-off is governance: review and role assignment have to happen on first use rather than at registration time.
+
+See [Enable Dynamic Client Registration](../../../../guides/mcp/mcp-clients/dynamic-client-registration) for the step-by-step guide.
 
 ## Cross-Cutting Choices
 
@@ -56,4 +64,4 @@ These apply regardless of which server-side or client-side pattern you pick.
 
 ## Next Steps
 
-Pick the server-side and client-side patterns that fit your environment, then see them running in **[Try It Out](../try-it-out)**.
+Pick the server-side and client-side patterns that fit your environment, then see them running in **[Try It Out](../try-it-out)**, or go straight to the **[MCP Authorization guides](../../../../guides/mcp/overview)** for step-by-step setup.

--- a/docs/content/use-cases/ai-agents/mcp-authorization/try-it-out.mdx
+++ b/docs/content/use-cases/ai-agents/mcp-authorization/try-it-out.mdx
@@ -88,3 +88,4 @@ Pick a walkthrough to begin. Each one starts from the setup above.
 - Curious how the MCP-specific application and consent step map to <ProductName /> concepts? See [Identity Concepts](../identity-concepts).
 - Prefer to register the application manually? See [Configure It Yourself](../configure-it-yourself).
 - Want to compare server-side and client-side patterns before going to production? See [Solution Patterns](../solution-patterns).
+- Ready to apply this to your own MCP server instead of the Wayfinder sample? See the [MCP Authorization guides](../../../../guides/mcp/overview).

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -475,6 +475,65 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'category',
+          label: 'MCP',
+          key: 'guides-mcp',
+          collapsed: true,
+          collapsible: true,
+          items: [
+            {
+              type: 'doc',
+              id: 'guides/mcp/overview',
+              label: 'Overview',
+              key: 'guides-mcp-overview',
+            },
+            {
+              type: 'category',
+              label: 'MCP Clients',
+              collapsed: true,
+              collapsible: true,
+              items: [
+                {
+                  type: 'doc',
+                  id: 'guides/mcp/mcp-clients/index',
+                  label: 'Overview',
+                  key: 'guides-mcp-clients-overview',
+                },
+                {
+                  type: 'doc',
+                  id: 'guides/mcp/mcp-clients/register-a-client',
+                  label: 'Register in the Console',
+                },
+                {
+                  type: 'doc',
+                  id: 'guides/mcp/mcp-clients/dynamic-client-registration',
+                  label: 'Dynamic Client Registration',
+                  key: 'guides-mcp-dynamic-client-registration',
+                },
+              ],
+            },
+            {
+              type: 'category',
+              label: 'MCP Server',
+              collapsed: true,
+              collapsible: true,
+              items: [
+                {
+                  type: 'doc',
+                  id: 'guides/mcp/mcp-server/index',
+                  label: 'Overview',
+                  key: 'guides-mcp-server-overview',
+                },
+                {
+                  type: 'doc',
+                  id: 'guides/mcp/mcp-server/secure-your-mcp-server',
+                  label: 'Secure Your MCP Server',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'category',
           label: 'Integrations',
           collapsed: true,
           collapsible: true,

--- a/docs/versioned_docs/version-v1.0.x/guides/mcp/mcp-clients/dynamic-client-registration.mdx
+++ b/docs/versioned_docs/version-v1.0.x/guides/mcp/mcp-clients/dynamic-client-registration.mdx
@@ -1,0 +1,100 @@
+---
+title: Enable Dynamic Client Registration
+docType: guide
+persona: iam
+sidebar_position: 3
+description: Enable Dynamic Client Registration so MCP clients register themselves with {{ProductName}} instead of you pre-registering them in the Console.
+---
+
+# Enable Dynamic Client Registration
+
+Enable Dynamic Client Registration (DCR) so an MCP client registers its own OAuth 2.1 client at connection time, instead of you creating an application for it in the Console first.
+
+:::note
+The MCP specification's current revision [deprecates Dynamic Client Registration](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization/client-registration) in favor of Client ID Metadata Documents, keeping DCR only for backward compatibility with authorization servers that do not support them. <ProductName /> supports Dynamic Client Registration today.
+:::
+
+## When DCR Is the Right Choice
+
+Pre-registering a client in the Console, covered in [Register an MCP Client in the Console](../register-a-client), works when you know the client and its redirect URI ahead of time. DCR is the better fit when:
+
+- You cannot enumerate the clients ahead of time, such as a self-hosted MCP client your users install individually.
+- The client picks a random callback port each time it starts, so there is no fixed redirect URI to register.
+- The client expects DCR as part of connecting, with no manual setup step. Claude Code is the canonical example: it registers itself automatically the first time it connects to an MCP server, with no application created for it beforehand.
+
+<Stepper stepNode="h2" as="h2">
+
+## Add the DCR Configuration
+
+Add the following to `deployment.yaml` in your <ProductName /> distribution:
+
+```yaml
+oauth:
+  dcr:
+    enabled: true
+    insecure: true
+```
+
+:::warning
+`insecure: true` lets anyone who can reach the server register OAuth clients without authentication. Use it for local development only.
+
+Without `insecure: true`, <ProductName /> requires the registration request to carry a valid access token whose permissions include the root `system` permission, the same requirement other <ProductName /> management APIs enforce. A request without one gets a `401`.
+:::
+
+## Restart <ProductName />
+
+Restart <ProductName /> for the configuration change to take effect.
+
+</Stepper>
+
+## Verifying DCR Is Live
+
+Confirm DCR accepts registrations by registering a throwaway public client directly:
+
+```bash
+curl -sk -i -X POST https://localhost:8090/oauth2/dcr/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "client_name": "dcr-probe",
+    "redirect_uris": ["http://localhost:52344/callback"],
+    "grant_types": ["authorization_code"],
+    "response_types": ["code"],
+    "token_endpoint_auth_method": "none"
+  }'
+```
+
+```text
+HTTP/1.1 201 Created
+
+{
+  "app_id": "019fa36e-6b16-7908-9bc9-d848c00db406",
+  "client_id": "ZjWMmW04V6ZCl1xKR70FuQ",
+  "client_name": "dcr-probe",
+  "client_secret_expires_at": 0,
+  "grant_types": ["authorization_code"],
+  "redirect_uris": ["http://localhost:52344/callback"],
+  "response_types": ["code"],
+  "token_endpoint_auth_method": "none"
+}
+```
+
+A `201` response with a `client_id` and no `client_secret` confirms DCR accepted the registration, since `token_endpoint_auth_method: none` registers a public client. Before you set `insecure: true`, the same request returns `401 unauthorized_client` instead.
+
+## Where DCR-Registered Clients Show Up
+
+A client registered through DCR appears in the Console under **Applications**, alongside applications you registered manually. <ProductName /> has no concept of an MCP client in the DCR request itself, so it registers every DCR client as a **Custom App**, regardless of what kind of client sent the request.
+
+## Gotchas and Lifecycle
+
+**Duplicate names return a 400.** Registering a client whose `client_name` matches an existing application returns a `400` error. Delete the existing application in the Console before repeating the same registration, such as when you are testing a client's DCR flow repeatedly.
+
+**Redirect URIs still match exactly.** DCR removes the need to pre-register a client, not the redirect URI rule itself. If your client is user-delegated, its registered redirect URI must still exactly match, port included, the one it presents when it starts the Authorization Code flow. See [Redirect URI Rules](../register-a-client#redirect-uri-rules) for the accepted formats.
+
+**DCR-created clients accumulate.** Every successful registration creates a new application that <ProductName /> never removes on its own. A client that re-registers on each run under a different name, or a client tested repeatedly during development, leaves behind applications you no longer need. Review them periodically under **Applications** and delete the ones you no longer use, the same way you would delete any other application.
+
+## Next Steps
+
+- [Dynamic Client Registration](../../../protocols/oauth-oidc/dynamic-client-registration): The protocol-level reference for the DCR endpoint, request fields, and response shape.
+- [Register an MCP Client in the Console](../register-a-client): Pre-register a client instead, when you know its redirect URI ahead of time.
+- [Secure Your MCP Server](../../mcp-server/secure-your-mcp-server): Protect the MCP server these clients connect to.
+- [Connect a Python MCP Server](../../../../getting-started/connect-your-mcp/python): A runnable quickstart that connects Claude Code through DCR, end to end.

--- a/docs/versioned_docs/version-v1.0.x/guides/mcp/mcp-clients/index.mdx
+++ b/docs/versioned_docs/version-v1.0.x/guides/mcp/mcp-clients/index.mdx
@@ -1,0 +1,63 @@
+---
+title: MCP Client Identity
+docType: concept
+persona: iam
+sidebar_position: 1
+description: Why an MCP client connecting over HTTP is an OAuth 2.1 client, the two ways it authenticates, and how to register one in {{ProductName}}.
+---
+
+# MCP Client Identity
+
+An MCP client that connects to a remote MCP server over HTTP acts as an OAuth 2.1 client. It cannot call a protected MCP server without credentials and a token, the same as any other client calling a protected API. An MCP client connecting to a server launched locally over stdio is outside the MCP authorization specification; it takes credentials from the environment instead.
+
+## Public vs. Confidential Clients
+
+An OAuth client is either public, unable to hold a secret in confidence, or confidential, able to authenticate with one. Most MCP clients, desktop AI hosts, CLI tools, and debug UIs among them, run entirely on the user's machine or in a context where a bundled secret could be extracted. That makes them public clients, and a public client requesting a token on a user's behalf must use PKCE (Proof Key for Code Exchange) to protect the authorization code from interception.
+
+## User-Delegated vs. Machine-to-Machine Clients
+
+An MCP client authenticates in one of two shapes:
+
+- **User-delegated**: a human is the subject. The client runs Authorization Code with PKCE, and the token it receives carries the signed-in user's access.
+- **Machine-to-machine**: the client itself is the subject, with no user involved. The client runs Client Credentials, and the token carries the client's own access.
+
+## Redirect URIs for Local Clients
+
+A user-delegated client needs a redirect URI to receive the authorization code. Local MCP clients complicate this in ways a typical web app redirect URI does not:
+
+- Redirect URIs match exactly, port included, with no wildcards.
+- Local clients typically use a loopback callback (`http://localhost:PORT/callback` or `127.0.0.1`), rather than a public HTTPS redirect URI.
+- Some clients pick a random port each time they start, so there is no fixed redirect URI to register ahead of time.
+
+That last case is why static registration alone does not cover every MCP client.
+
+## Static vs. Dynamic Registration
+
+Registering a client ahead of time, giving it a client ID and a fixed redirect URI before it ever connects, works when you know the client in advance. It does not work for an MCP server that any client might connect to: the server's operator cannot enumerate every client that will ever show up, and a client that picks a random callback port has no fixed redirect URI to register in the first place.
+
+[RFC 7591 Dynamic Client Registration](../../protocols/oauth-oidc/dynamic-client-registration) (DCR) solves this by letting a client register itself against a registration endpoint at connection time, supplying its own redirect URI and receiving a client ID back immediately. This is why DCR shows up so often in MCP deployments: the client population is open-ended in a way most OAuth deployments are not. See that page for the protocol details; this page covers only the choice between the two approaches.
+
+The MCP specification's current revision deprecates DCR in favor of Client ID Metadata Documents, keeping DCR only for backward compatibility, so treat it as the fallback path rather than the default going forward.
+
+## How <ProductName /> Fits
+
+<ProductName /> represents an MCP client as the **MCP Client** application type, configured as either user-delegated or machine-to-machine. There are exactly two ways to give a client OAuth credentials: register it yourself in the Console, or let it register itself the first time it connects.
+
+### Register in the Console vs. Dynamic Client Registration
+
+| | Register in the Console | Dynamic Client Registration |
+|---|---|---|
+| **How it works** | You create the application ahead of time and set its redirect URI. | The client registers itself against the DCR endpoint the first time it connects. |
+| **Best for** | A fixed set of known clients, such as MCP Inspector or your own agent. | Clients you cannot enumerate in advance, or that expect DCR, such as Claude Code. |
+| **What you control** | The client's name, redirect URI, and client type, set up front in the Console. | Whether Dynamic Client Registration is enabled, and whether it requires authentication. |
+
+### Which Should You Pick?
+
+Register the client in the Console when you know it ahead of time and can set its redirect URI yourself. You get a client ID before the client ever connects, and the client type step configures the correct grant type for you. Reach for Dynamic Client Registration when you cannot enumerate every client in advance, such as a third-party AI host, or when the client itself expects DCR and has no way to accept a pre-issued client ID, such as Claude Code.
+
+The choice is not exclusive at the deployment level. You can pre-register some clients in the Console while leaving Dynamic Client Registration enabled for others.
+
+## Related
+
+- [Register an MCP Client in the Console](./register-a-client): create an application for a known client.
+- [Enable Dynamic Client Registration](./dynamic-client-registration): let clients register themselves on first connect.

--- a/docs/versioned_docs/version-v1.0.x/guides/mcp/mcp-clients/register-a-client.mdx
+++ b/docs/versioned_docs/version-v1.0.x/guides/mcp/mcp-clients/register-a-client.mdx
@@ -1,0 +1,108 @@
+---
+title: Register an MCP Client in the Console
+docType: guide
+persona: iam
+sidebar_position: 2
+description: Register an MCP client application in the Console and choose between the user-delegated and machine-to-machine client types.
+---
+
+# Register an MCP Client in the Console
+
+Register an MCP client in the Console when you know its redirect URI ahead of time, such as MCP Inspector or a client you built yourself. This gives you a stable Client ID before the client ever connects.
+
+## Prerequisites
+
+- <ProductName /> is running. See [Get Started](../../../../getting-started/get-thunderid).
+- You can sign in to the <ProductName /> Console.
+- The redirect URI your MCP client uses for its OAuth callback, if it acts on behalf of a user.
+
+<Stepper stepNode="h2" as="h2">
+
+## Step 1: Start the Application Wizard
+
+1. Sign in to the <ProductName /> Console.
+2. Navigate to **Applications** and click **Add Application**.
+3. Select **MCP Client**.
+4. Enter a name for the client.
+5. If prompted, select an organization unit.
+
+## Step 2: Choose the Client Type
+
+The **Client type** step is the most important choice on this page: it decides how the client obtains tokens and whether it acts for a signed-in user.
+
+### On Behalf of a User
+
+Select **On behalf of a user** for an MCP client running inside a host app, such as an IDE, desktop app, or chat client, that a person signs in to interactively. MCP Inspector is this type.
+
+This option configures the Authorization Code flow with PKCE and registers the client as a public client with no client secret. PKCE is locked on: the form shows it as read-only because a user-delegated MCP client always requires it. Selecting this type also embeds the redirect URI editor directly in this step, so add at least one redirect URI here before continuing.
+
+### Machine-to-Machine
+
+Select **On its own behalf** for a client that authenticates with its own credentials and has no signed-in user, such as an autonomous agent or a background service calling MCP servers directly.
+
+This option configures the Client Credentials flow and registers the client as a confidential client. <ProductName /> issues a client secret, and no redirect URI is collected because this client type never redirects a user anywhere.
+
+## Step 3: Finish
+
+Click **Finish**. <ProductName /> creates the application and opens its detail page directly, with no separate completion screen. Open the **General** tab: its **Connection** card shows the **Client ID**. For a machine-to-machine client, generate the **Client Secret** here, since <ProductName /> does not display it automatically after creation (see [Where Credentials Live](#where-credentials-live)).
+
+</Stepper>
+
+## Redirect URI Rules
+
+For a user-delegated client, each redirect URI must satisfy one of two rules:
+
+- A loopback address over `http:`: the host must be `localhost`, `127.0.0.1`, or `[::1]`, with an optional port (for example, `http://localhost:6274/oauth/callback`).
+- Any address over `https:`.
+
+Any other scheme is rejected, including plain `http://` on a non-loopback host. Wildcards (`*`) are rejected anywhere in the URI. The backend's create-time validation independently rejects a wildcard in a redirect URI's port unconditionally, and rejects a wildcard host unless the deployment has explicitly opted in to wildcard redirect URIs, so a wildcard MCP redirect URI is never accepted through the Console.
+
+Ports must match exactly. If your client picks a random callback port each time it starts, such as a local CLI tool that binds to an ephemeral port, you cannot register that exact port ahead of time. [Dynamic Client Registration](../dynamic-client-registration) exists for this case: the client registers its own redirect URI, including whatever port it happened to bind, at connection time instead of you pre-registering it.
+
+## Where Credentials Live
+
+The application's **General** tab holds a **Connection** card with:
+
+- **Application ID**: the <ProductName /> application identifier.
+- **Client ID**: the OAuth 2.1 client ID, for both client types.
+- **Client Secret**: shown only for the machine-to-machine type, since that is the only confidential MCP client type. The field displays a masked placeholder, never the actual value. Click **Generate** to issue a new secret, which <ProductName /> shows once in a dialog. Copy it immediately: closing the dialog without copying means generating another one, which invalidates the previous secret for any client already using it.
+
+## Access Control
+
+For a user-delegated client, the **General** tab also shows an **Access** card:
+
+- **Allowed User Types**: which user schemas may authorize this client. Leave it empty to allow every user type.
+- **Client URI**: an optional public homepage for the client.
+- **Authorized redirect URIs**: the same redirect URIs configured during creation, editable here. At least one is required, and each one follows the [redirect URI rules](#redirect-uri-rules) above.
+
+A machine-to-machine client has no signed-in user, so the Console does not show this card for it.
+
+## Browser-Based Clients Need a CORS Origin
+
+If your MCP client runs in a browser, such as a web-based inspector or dashboard, and calls <ProductName /> cross-origin, its origin must be explicitly allowed. This is a deployment-wide CORS setting, not a per-application one, so it is configured separately from the steps above.
+
+Add the origin to `config/resources/server_configs/cors.yaml` in your <ProductName /> distribution:
+
+```yaml
+name: cors
+value:
+  allowedOrigins:
+    - "http://localhost:6274"
+```
+
+If the file already exists, append to the existing `allowedOrigins` list instead of replacing it. You can also update this at runtime with `PUT /server-config/cors`. Restart <ProductName /> after editing the file.
+
+## Manage the Client
+
+To update a client's configuration, open it from the **Applications** list, change the relevant setting on the **General** tab, and click **Save**. Changes take effect immediately for new authentication requests; active sessions and issued tokens are unaffected until they expire.
+
+To rotate credentials for a machine-to-machine client, click **Generate** next to **Client Secret** on the **General** tab. This immediately invalidates the previous secret.
+
+To delete a client, open it from the **Applications** list and click **Delete Application** in the danger zone. This is permanent: any caller using the client's Client ID immediately loses the ability to authenticate, though issued tokens remain valid until they expire.
+
+## Next Steps
+
+- [Dynamic Client Registration](../dynamic-client-registration): Let clients register themselves instead of pre-registering them here.
+- [Secure Your MCP Server](../../mcp-server/secure-your-mcp-server): Protect the MCP server this client connects to.
+- [Manage Applications](../../../applications/manage-applications): General application management, covering all application types.
+- [Connect a Python MCP Server](../../../../getting-started/connect-your-mcp/python): A runnable quickstart that registers an MCP Inspector client this way, end to end.

--- a/docs/versioned_docs/version-v1.0.x/guides/mcp/mcp-server/index.mdx
+++ b/docs/versioned_docs/version-v1.0.x/guides/mcp/mcp-server/index.mdx
@@ -1,0 +1,58 @@
+---
+title: MCP Server Authorization
+docType: concept
+persona: iam
+sidebar_position: 1
+description: Why an MCP server is an OAuth 2.1 resource server, how it enforces scopes at the tool boundary, and how {{ProductName}} fits.
+---
+
+# MCP Server Authorization
+
+An MCP server reached over HTTP is an OAuth 2.1 resource server. It holds no authorization policy of its own. It enforces decisions made by the authorization server that issued the token.
+
+## What the Server Must Publish
+
+A protected MCP server publishes [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) protected-resource metadata naming its authorization server. When a client connects without a valid token, the server rejects the request with a `401` and a `WWW-Authenticate` header pointing at that metadata, so the client can discover where to get one.
+
+## Scope Granularity Is a Design Decision
+
+A scope is the unit an access token carries and a tool checks. How finely you divide scopes is a trade-off, not a fixed rule:
+
+- **One scope per tool**: the most precise. A caller granted `send-message` cannot use `delete-conversation`, even if both live on the same server.
+- **One scope per tool group**: a common middle ground, where related tools such as `read-*` operations share one scope.
+- **One scope per server**: the simplest to manage, but coarse. Any caller with access to the server can use every tool it exposes.
+
+The enforcement logic at the tool boundary is identical regardless of which granularity you choose. Only the scope vocabulary the server checks against changes.
+
+## Enforcement at the Tool Boundary
+
+The server checks the required scope before it invokes a tool's handler, not after. That ordering matters: a caller whose token is missing a scope fails cleanly at the protocol layer, before any part of the handler runs, instead of the handler starting and producing a partial side effect that then has to be checked or rolled back. Servers commonly extend this further by filtering the tool list itself to what the caller's scopes allow, so a tool the caller cannot use never appears as an option.
+
+## Token Validation
+
+A server validates a token one of two ways:
+
+- **Offline JWT validation**: the server fetches the authorization server's JWKS, finds the signing key by `kid`, and checks the signature, issuer, audience, and expiry locally, with no callback to the authorization server on each request. This is the common case for MCP servers, since it keeps every tool call fast.
+- **Token introspection**: the server calls the authorization server on each request to ask whether a token is still valid. This applies when tokens must be revocable before they expire, at the cost of a network call per request.
+
+## Audience Binding
+
+When several MCP servers share one authorization server, a token issued for one of them must not work against another, even though both trust the same issuer. Binding the token to a specific audience or resource identifier at issuance is what makes that guarantee hold. Without it, a token obtained for a low-risk server could be replayed against a more sensitive one.
+
+## Runtime Policy Decisions
+
+Scopes alone answer whether a caller may use a tool at all, not whether a specific call with specific arguments should be allowed, such as whether this transfer amount from this account is permitted. Some deployments address that by asking an external policy decision point (PDP) per tool call instead of relying only on the token's scopes. [AuthZEN](https://openid.github.io/authzen/) is the standard for that interaction: the server acts as a policy enforcement point and sends the subject, resource, action, and call-specific context to a PDP, which returns an allow or deny decision computed at request time.
+
+## How <ProductName /> Fits
+
+Register your MCP server as a resource server in <ProductName />, and define one permission per tool: the permission's handle becomes the scope your server checks. Bundle those permissions into roles, and assign the roles to the clients or users that should hold them. <ProductName /> issues access tokens carrying only the scopes a role actually grants, bound to the resource server's identifier as the audience.
+
+Your MCP server validates tokens offline against <ProductName />'s JWKS endpoint. For decisions that depend on call arguments rather than just on who is calling, your server can call <ProductName />'s AuthZEN policy decision point instead of relying on scopes alone.
+
+## Related
+
+- [Secure Your MCP Server](./secure-your-mcp-server): configure a resource server, tool permissions, and token validation in <ProductName />.
+- [Connect a Python MCP Server](../../../getting-started/connect-your-mcp/python): a runnable quickstart with a sample MCP server.
+- [Manage Resource Servers](../../resource-servers): general resource server, resource, and permission management.
+- [JWKS](../../protocols/oauth-oidc/jwks): the endpoint your server validates tokens against.
+- [Policy Decision Point](../../protocols/authzen/pdp): the AuthZEN PDP endpoints for runtime tool authorization.

--- a/docs/versioned_docs/version-v1.0.x/guides/mcp/mcp-server/secure-your-mcp-server.mdx
+++ b/docs/versioned_docs/version-v1.0.x/guides/mcp/mcp-server/secure-your-mcp-server.mdx
@@ -1,0 +1,137 @@
+---
+title: Secure Your MCP Server
+docType: guide
+persona: iam
+sidebar_position: 2
+description: Turn your MCP server into an OAuth 2.1 resource server protected by {{ProductName}}, with a scope per tool and offline token validation, in any language.
+---
+
+# Secure Your MCP Server
+
+For the generic pattern behind this guide, MCP servers as OAuth resource servers, scope granularity, and token validation, see [MCP Server Authorization](..).
+
+Turn your MCP server, reached over HTTP, into an OAuth 2.1 resource server protected by <ProductName />, whatever language it is written in. Register the server as a resource server, define a scope per tool, grant those scopes through a role, and validate tokens at the tool boundary before any tool runs.
+
+:::tip Runnable Example
+This guide covers the pattern, not a specific stack. For a complete, working implementation using FastMCP, see [Secure Your MCP Server (Python)](../../../../getting-started/connect-your-mcp/python).
+:::
+
+## Prerequisites
+
+- <ProductName /> is running. See [Get Started](../../../../getting-started/get-thunderid).
+- You can sign in to the <ProductName /> Console.
+- An MCP server you control, able to validate JWTs offline and publish RFC 9728 protected-resource metadata, through your language's MCP SDK or your own middleware.
+- The list of tools your MCP server exposes, since you define one permission per tool.
+
+## How It Works
+
+Your MCP server becomes an OAuth 2.1 resource server. When a client connects without a token, the server responds with a `401` and RFC 9728 protected-resource metadata that points the client at <ProductName /> as its authorization server. The client runs an OAuth 2.1 flow, typically Authorization Code with PKCE, and gets back a JWT scoped to whichever tool permissions the signing-in user's or client's roles actually grant. On the next request, the server validates that JWT offline against <ProductName />'s JWKS endpoint, with no callback to <ProductName /> per request, and enforces the scope each tool requires before it runs.
+
+<McpOAuthFlowDiagram />
+
+<Stepper stepNode="h2" as="h2">
+
+## Step 1: Register the MCP Server as a Resource Server
+
+In the Console:
+
+1. Navigate to **Resource Servers** and click **Add resource server**.
+2. On the **Type** step, select **MCP**.
+3. On the **Name** step, enter an **MCP Server Name** and an **Identifier**. Set the identifier to the MCP server's own URL, for example `https://mcp.example.com`: it becomes the access token audience for [Resource Indicators](../../../protocols/oauth-oidc/resource-indicators) (RFC 8707).
+4. On the **Permission Delimiter** step, choose the character that separates parts of a permission string, for example the default colon (`:`). If your deployment has multiple organization units, select one first, then click **Create MCP server**.
+
+:::note
+The delimiter cannot be changed after creation, so plan it before you click **Create MCP server**.
+:::
+
+## Step 2: Define Tool Permissions
+
+On the **Capabilities** tab of the resource server you just created, add one tool permission per MCP tool:
+
+1. Click **Add tool permission**. Once the panel has at least one capability, add more by clicking the **+** icon in the panel header and selecting **Add tool permission** from the menu instead.
+2. Enter a **Name** for the tool. <ProductName /> derives the **Handle** from the name automatically: it lowercases the words and joins them with a hyphen, or with an underscore if you chose a hyphen as the resource server's permission delimiter, to avoid a handle that collides with it.
+3. Confirm the handle before clicking **Add**. For a top-level tool permission, the handle *is* the permission, with no resource server prefix, so it becomes the exact scope string your server must check for that tool.
+4. Repeat for every tool the MCP server exposes.
+
+For example, a tool named `Send Message` produces the handle `send-message` and the permission `send-message`. If your server's scope check instead looks for `send_message` or `sendMessage`, the mismatch means the token never satisfies it, and the tool never appears to a caller, the same way it would not appear if the caller held no matching permission at all.
+
+The same panel also lets you add resource permissions, for MCP resources rather than tools, following the same name-to-handle pattern.
+
+## Step 3: Grant the Permissions Through a Role
+
+Registering a tool permission in the previous step only defines it. <ProductName /> puts a scope into an access token only when the signing-in user or client actually holds the matching permission through a role, and a scope they do not hold is not rejected, it is silently dropped from the issued token. A missing scope does not make its tool error: the tool simply does not appear, which looks identical to the tool never having existed. This is the most common reason a freshly registered tool does not show up for a test user, so create and assign the role before you try to connect a client.
+
+1. Navigate to **Roles** and click **Add Role**.
+2. Enter a name and, if prompted, select an organization unit.
+3. On the **Permissions** step, expand your MCP server's entry and, under **Tools**, select the permissions this role should grant.
+4. Create the role.
+5. Open the role, select the **Assignments** tab, and click **Add**.
+6. On the **Users**, **Groups**, **Applications**, or **Agents** tab, depending on who should hold this role, select the principals and click **Add Selected**.
+
+:::warning
+A user or client that authenticates without this role gets a token missing every tool-scoped permission, even though the resource server correctly lists them as capabilities. If a tool disappears for one caller but not another, check role assignments before you check your server's scope-checking code.
+:::
+
+## Step 4: Point Clients at <ProductName />
+
+Your MCP server's SDK, or your own middleware, publishes the RFC 9728 protected-resource metadata that names <ProductName /> as its authorization server. When it rejects an unauthenticated request, it returns a `401` with a `WWW-Authenticate` header pointing at that metadata:
+
+```text
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource"
+```
+
+Fetching that URL returns the metadata document:
+
+```json
+{
+  "resource": "https://mcp.example.com",
+  "authorization_servers": ["https://your-thunderid-instance.example.com/"],
+  "scopes_supported": ["send-message", "list-conversations"],
+  "bearer_methods_supported": ["header"]
+}
+```
+
+The client resolves the `authorization_servers` entry against <ProductName />'s own [Server Metadata](../../../protocols/oauth-oidc/server-metadata) document to discover the authorization, token, and JWKS endpoints, then runs an OAuth flow to get a token. How the client itself gets OAuth credentials, as a pre-registered application or through Dynamic Client Registration, is covered in [MCP Client Identity](../../mcp-clients).
+
+## Step 5: Validate Tokens at the Tool Boundary
+
+<ProductName /> issues the token. Enforcing it is your MCP server's job, on every request:
+
+1. **Validate the JWT offline.** Fetch <ProductName />'s [JWKS](../../../protocols/oauth-oidc/jwks) endpoint, find the signing key by `kid`, and verify the signature, `iss`, and `exp`. Most JWT libraries handle this given a `jwks_uri`. Cache the response and refresh it once on an unknown `kid`, not on every request.
+2. **Check the audience.** The `aud` claim must equal the resource server identifier you registered in Step 1. [Resource Indicators](../../../protocols/oauth-oidc/resource-indicators) is what binds a token to that specific identifier, so a token issued for a different resource server on the same <ProductName /> deployment fails this check even though its signature is valid.
+3. **Enforce the per-tool scope before the tool runs.** Compare the `scope` claim against the permission handle you defined for that tool in Step 2. Prefer excluding a tool the token cannot satisfy from what the client sees over letting the client call it and failing at that point: a missing scope should make a tool disappear from the tool list, the same way it disappears when a role never granted it.
+
+A validated access token's payload looks like this:
+
+```json
+{
+  "sub": "0197c3f0-6b16-7908-9bc9-d848c00db406",
+  "iss": "https://your-thunderid-instance.example.com",
+  "aud": "https://mcp.example.com",
+  "scope": "send-message list-conversations",
+  "exp": 1782000000
+}
+```
+
+See [Token Formats](../../../protocols/oauth-oidc/token-formats) for how <ProductName /> signs access tokens, and [Claims & Scopes](../../../protocols/oauth-oidc/claims-and-scopes) for how requested scopes become the scopes a token actually carries.
+
+</Stepper>
+
+## Consent
+
+If your MCP client also requests OIDC scopes, such as `profile` or `email`, to identify the user it is acting for, what it receives can be narrower than what it asked for. <ProductName /> triggers its consent flow based on the user attributes the MCP client's application is configured to require, not simply on the scopes present in the request: the signing-in user can deny individual attributes, and any attribute they deny does not reach the ID token or UserInfo response, even though the client requested a scope that would normally include it.
+
+This is a separate mechanism from the role-based scope filtering in Step 3. A tool scope is dropped because the user's role does not grant it, silently and with no prompt. An attribute is dropped because the user chose not to share it, in an interactive prompt. See [Consent](../../../consent) for how to configure attribute consent for an application.
+
+## Fine-Grained Authorization with AuthZEN
+
+Scopes are coarse-grained: a `transfer` scope says the caller may use the `transfer` tool at all, not that they may transfer this specific amount from that specific account. When a tool needs a decision that depends on the call's arguments, not just on who is calling, scopes alone are not enough.
+
+For those cases, have your MCP server call <ProductName /> as an AuthZEN policy decision point (PDP) before it runs the tool handler, instead of relying only on the token's scope. Your server authenticates to the PDP with its own server-level secret, separate from the caller's token, and sends the subject (from the validated token), the resource, the action, and any request context specific to that call. <ProductName /> evaluates the request against resource servers, resources, actions, roles, and role assignments, and returns an allow or deny decision computed at request time, not baked into the token. See [AuthZEN](../../../protocols/authzen) for the protocol and [Policy Decision Point](../../../protocols/authzen/pdp) for the PDP endpoints, and walk through a working example in [AuthZEN-Based MCP Authorization](../../../../use-cases/ai-agents/mcp-authorization/try-it-out/authzen-authorization).
+
+## Next Steps
+
+- [Secure Your MCP Server (Python)](../../../../getting-started/connect-your-mcp/python): a complete, runnable version of this guide using FastMCP.
+- [MCP Client Identity](../../mcp-clients): register the clients that connect to your MCP server, or let them self-register through Dynamic Client Registration.
+- [Securing MCP](../../../../use-cases/ai-agents/mcp-authorization/overview): the broader pattern for securing MCP servers and governing MCP clients.

--- a/docs/versioned_docs/version-v1.0.x/guides/mcp/overview.mdx
+++ b/docs/versioned_docs/version-v1.0.x/guides/mcp/overview.mdx
@@ -1,0 +1,88 @@
+---
+title: MCP Authorization
+docType: concept
+persona: iam
+sidebar_position: 0
+description: How the MCP Authorization specification protects tool calls, and the two roles {{ProductName}} plays in an MCP deployment.
+---
+
+# MCP Authorization
+
+The Model Context Protocol (MCP) gives AI assistants and agents a standard way to call tools and read data through MCP servers. An MCP deployment has three parties: an MCP host or client that a user or agent interacts with, an MCP server that exposes tools and resources, and an authorization server that decides who may call which tool.
+
+## Why MCP Tools Need Authorization
+
+An MCP server's tools are not always low-risk. They can read files, query databases, send email, or modify infrastructure. Without access control, every client that can reach the server can invoke every tool it exposes, with no boundary between a low-risk read and a destructive write.
+
+:::note
+Everything on this page applies to an MCP server reached over HTTP. An MCP server launched locally over stdio is outside the MCP authorization specification; its client takes credentials from the environment instead of running an OAuth flow.
+:::
+
+## How the MCP Authorization Specification Solves It
+
+The [MCP Authorization specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization) treats an MCP server as an OAuth 2.1 resource server and separates it from the authorization server that issues tokens.
+
+A client that connects without a token gets a `401` response carrying a `WWW-Authenticate` header. That header points at [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) protected-resource metadata, a document the MCP server publishes that names its authorization server. The client resolves that authorization server's own metadata through [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) discovery, which lists the authorization, token, and JWKS endpoints.
+
+The client then runs one of two OAuth flows, depending on who it acts for:
+
+- **Authorization Code with PKCE**, when a signed-in user delegates access to the client.
+- **Client Credentials**, when the client authenticates on its own behalf, with no user involved.
+
+The token the client gets back is bound to the specific MCP server it requested, through an audience or resource identifier. That binding stops a token issued for one MCP server from being replayed against another, even when both trust the same authorization server.
+
+The MCP server enforces this at the tool boundary: it checks the token's scope before a tool handler runs, not after, so a caller without the right scope never reaches the tool's side effects.
+
+```mermaid
+sequenceDiagram
+    participant C as MCP client
+    participant S as MCP server
+    participant A as Authorization server
+
+    C->>S: Connect without a token
+    S-->>C: 401 with RFC 9728 metadata naming the authorization server
+    C->>A: RFC 8414 discovery of the authorization, token, and JWKS endpoints
+    C->>A: Authorization Code with PKCE, or Client Credentials
+    A-->>C: Token scoped to the user's or client's access, bound to this server
+    C->>S: Retry with the token
+    S->>S: Validate the token and check the tool's scope
+    S-->>C: Tool result, filtered to the token's scopes
+```
+
+## How <ProductName /> Fits
+
+<ProductName /> plays two roles in an MCP deployment.
+
+### Authorization Server for Your MCP Servers
+
+You register your MCP server as a resource server and define one permission per tool. <ProductName /> issues access tokens scoped to only the permissions the signed-in user or client actually holds, and your MCP server's tools validate those scopes before they run.
+
+### Identity Home for MCP Clients
+
+Every MCP client needs OAuth credentials from <ProductName /> before it can request a token, whether it is an AI assistant, an autonomous agent, or a debugging tool such as MCP Inspector. You either register the client as an application in the Console ahead of time, or let it register itself the first time it connects, through Dynamic Client Registration.
+
+## What <ProductName /> Provides
+
+| Capability | What It Gives You |
+|---|---|
+| **MCP Client application type** | Register a client as user-delegated (Authorization Code with PKCE) or machine-to-machine (Client Credentials). |
+| **Resource server registration** | Register your MCP server and turn each tool into a permission. The permission's handle becomes the scope tools validate. |
+| **Dynamic Client Registration** | Let a client such as Claude Code register its own OAuth credentials the first time it connects. |
+| **Consent** | Show a consent screen so a user approves the scopes a client requests on their behalf. |
+| **AuthZEN-based tool authorization** | Ask <ProductName /> for a runtime authorization decision on a tool call, instead of relying on the token's scopes alone. |
+| **Enterprise-Managed Authorization** | Accept or issue Identity Assertion Authorization Grants (ID-JAG) so an enterprise identity provider centralizes MCP access decisions. |
+
+## Enterprise-Managed Authorization
+
+Enterprises that already centralize access decisions in an identity provider can extend that model to MCP through the Identity Assertion Authorization Grant (ID-JAG). <ProductName /> can accept ID-JAGs issued by an external identity provider, or issue them itself as the enterprise identity provider for a downstream MCP authorization server. See [Enterprise-Managed Authorization](../../../use-cases/ai-agents/mcp-authorization/enterprise-managed-authorization) for the pattern, and [Identity Assertion Authorization Grant (ID-JAG)](../../protocols/oauth-oidc/identity-assertion-grant) for the protocol reference.
+
+## <ProductName />'s Own MCP Server
+
+Separately from securing your own MCP servers, <ProductName /> ships an admin MCP server at the `/mcp` endpoint. It lets MCP clients manage <ProductName /> applications, flows, users, and themes directly, in natural language, instead of through the Console UI. See [MCP Server](../../../working-with-ai/mcp-server) for setup and the available tools.
+
+## Related
+
+- [MCP Client Identity](../mcp-clients): how an MCP client gets OAuth credentials, and how to choose in <ProductName />.
+- [MCP Server Authorization](../mcp-server): how an MCP server enforces access, and how to configure it in <ProductName />.
+- [Connect a Python MCP Server](../../../getting-started/connect-your-mcp/python): a runnable quickstart with a sample MCP server.
+- [Securing MCP](../../../use-cases/ai-agents/mcp-authorization/overview): authorization patterns for MCP servers and clients.

--- a/docs/versioned_docs/version-v1.0.x/use-cases/ai-agents/mcp-authorization/configure-it-yourself.mdx
+++ b/docs/versioned_docs/version-v1.0.x/use-cases/ai-agents/mcp-authorization/configure-it-yourself.mdx
@@ -26,12 +26,12 @@ Navigate to **Applications** → **Add Application** and choose **Browser App** 
 | Allowed user types   | `Customer`                                                                                                                        |
 | Authentication flow  | `wayfinder-agent-auth-flow` (the same flow the Wayfinder Concierge uses, so the consent screen surfaces each `booking:*` permission as a toggle)        |
 
-See [Manage Applications](../../../../guides/applications/manage-applications).
+See [Manage Applications](../../../../guides/applications/manage-applications), or [Register an MCP Client in the Console](../../../../guides/mcp/mcp-clients/register-a-client) for the MCP-specific version of this task.
 
 The walkthrough relies on the consent screen at sign-in to narrow what the external client gets. `john.doe` keeps his existing `Booking User` role unchanged, and picks which `booking:*` permissions to release the first time he signs in through Inspector.
 
 :::info[Alternative: Dynamic Client Registration]
-If you don't want to register every MCP client up-front, <ProductName /> also supports [Dynamic Client Registration](../../../../guides/protocols/oauth-oidc/dynamic-client-registration). An MCP client that supports DCR can discover <ProductName /> through the MCP server's protected-resource metadata and register itself, after which it uses its issued credentials for the same authorization-code flow. The tryout uses static registration for predictability. DCR is the right choice when you can't enumerate every client in advance.
+If you don't want to register every MCP client up-front, <ProductName /> also supports [Dynamic Client Registration](../../../../guides/protocols/oauth-oidc/dynamic-client-registration). An MCP client that supports DCR can discover <ProductName /> through the MCP server's protected-resource metadata and register itself, after which it uses its issued credentials for the same authorization-code flow. The tryout uses static registration for predictability. DCR is the right choice when you can't enumerate every client in advance. See [Enable Dynamic Client Registration](../../../../guides/mcp/mcp-clients/dynamic-client-registration) for how to turn this on for your own MCP server.
 :::
 
 ## Configure the Direct Auth Secret

--- a/docs/versioned_docs/version-v1.0.x/use-cases/ai-agents/mcp-authorization/identity-concepts.mdx
+++ b/docs/versioned_docs/version-v1.0.x/use-cases/ai-agents/mcp-authorization/identity-concepts.mdx
@@ -20,7 +20,7 @@ The application registers redirect URIs for MCP Inspector:
 
 `EXTERNAL-MCP-CLIENT` is wired to the same authentication flow as the Wayfinder Concierge, so the OAuth consent screen surfaces each requested `booking:*` permission as an individual toggle at sign-in time.
 
-See [Manage Applications](../../../../guides/applications/manage-applications).
+See [Manage Applications](../../../../guides/applications/manage-applications), or [Register an MCP Client in the Console](../../../../guides/mcp/mcp-clients/register-a-client) for the MCP-specific version of this task.
 
 ## Consent at Sign-In
 
@@ -44,7 +44,7 @@ Each MCP tool checks for the same scope its REST counterpart checks for:
 | `create_booking` | `POST /api/bookings` | `booking:create` |
 | `delete_all_bookings` | `DELETE /api/bookings/flights` | `booking:cancel` |
 
-See [Resource Servers](../../../../guides/resource-servers).
+See [Resource Servers](../../../../guides/resource-servers), or [Secure Your MCP Server](../../../../guides/mcp/mcp-server/secure-your-mcp-server) for the MCP-specific version of this task.
 
 ## AuthZEN Authorization Mode
 

--- a/docs/versioned_docs/version-v1.0.x/use-cases/ai-agents/mcp-authorization/overview.mdx
+++ b/docs/versioned_docs/version-v1.0.x/use-cases/ai-agents/mcp-authorization/overview.mdx
@@ -44,7 +44,7 @@ For example, a research MCP server exposes browsing tools, an `export` tool, and
 - Enforce the per-tool scope before invoking the tool handler.
 - Centralize the authorization decision in <ProductName />; the MCP server only enforces.
 
-See it running: [Try It Out - Protect Your MCP Server](../try-it-out).
+See it running: [Try It Out - Protect Your MCP Server](../try-it-out). For the hands-on guide, see [Secure Your MCP Server](../../../../guides/mcp/mcp-server/secure-your-mcp-server); for the concept behind it, see [MCP Server Authorization](../../../../guides/mcp/mcp-server).
 
 ### Govern MCP Clients
 
@@ -62,7 +62,7 @@ For example, your in-product agent is registered as an agent and granted access 
 - Run the consent flow when the MCP client acts on a user's behalf, so the user approves the requested scopes.
 - Revoke a client's credentials when it is decommissioned or compromised: all tokens it issued stop being accepted.
 
-See it running: [Try It Out - Govern MCP Clients](../try-it-out).
+See it running: [Try It Out - Govern MCP Clients](../try-it-out). For the hands-on guides, see [Register an MCP Client in the Console](../../../../guides/mcp/mcp-clients/register-a-client) and [Enable Dynamic Client Registration](../../../../guides/mcp/mcp-clients/dynamic-client-registration); for the concept behind it, see [MCP Client Identity](../../../../guides/mcp/mcp-clients).
 
 ## Cross-Cutting Capabilities
 
@@ -86,7 +86,7 @@ Enterprises that already centralize access decisions in their identity provider 
 
 ## Next Steps
 
-Once you know which patterns apply, the next decision is how to integrate. See **[Solution Patterns](../solution-patterns)** to compare server-side and client-side options.
+Once you know which patterns apply, the next decision is how to integrate. See **[Solution Patterns](../solution-patterns)** to compare server-side and client-side options, or go straight to the **[MCP Authorization guides](../../../../guides/mcp/overview)** for step-by-step setup.
 
 ## Related Capabilities
 

--- a/docs/versioned_docs/version-v1.0.x/use-cases/ai-agents/mcp-authorization/solution-patterns.mdx
+++ b/docs/versioned_docs/version-v1.0.x/use-cases/ai-agents/mcp-authorization/solution-patterns.mdx
@@ -19,11 +19,15 @@ This is what gives <ProductName /> the vocabulary to issue scope-bearing tokens 
 
 A practical choice that sits inside this pattern: how finely to scope. One scope per tool gives the most precise control (you can grant read-only without write); one scope per tool group is a common middle ground; one scope per server is simplest but coarse. The MCP server's enforcement logic stays the same regardless: only the scope vocabulary changes.
 
+See [Secure Your MCP Server](../../../../guides/mcp/mcp-server/secure-your-mcp-server) for the step-by-step guide.
+
 ### Token Validation at the Tool Boundary
 
 The MCP server validates the incoming token on every MCP request and checks for the required scope before invoking the tool handler. <ProductName /> handles issuance; the MCP server handles enforcement. Keeping these split puts the policy in one place (<ProductName />) and the check at the component closest to the call. A missing scope then fails cleanly at the protocol layer, rather than producing partial side effects.
 
 If your environment runs more than one MCP server behind the same authorization server, scope the issued tokens to the target server so a token meant for one cannot be replayed against another. <ProductName /> handles this automatically when the client requests a target during the token exchange.
+
+See [Secure Your MCP Server](../../../../guides/mcp/mcp-server/secure-your-mcp-server) for how to enforce this at the tool boundary.
 
 ## MCP Client Patterns
 
@@ -35,17 +39,21 @@ Register the MCP client as an application in <ProductName /> up-front. Configure
 
 Fits known clients you control or have explicitly decided to support: internal admin tools, off-the-shelf MCP clients on your allow-list, anything you can configure once and rarely revisit. The trade-off is operational: any new MCP client type needs to be registered before it can connect.
 
+See [Register an MCP Client in the Console](../../../../guides/mcp/mcp-clients/register-a-client) for the step-by-step guide.
+
 ### Registered Agent
 
 When the MCP client is one of your own AI agents, register it as an agent in <ProductName /> rather than as an application. The agent identity is portable: the same agent can reach multiple MCP servers under one auditable identity, with one Client ID and one credential lifecycle to manage.
 
-This is the same identity primitive used in the [Securing AI Agents](../../overview) patterns. Choose this when the MCP client *is* an agent in your system, not just an OAuth client.
+This is the same identity primitive used in the [Securing AI Agents](../../overview) patterns. Choose this when the MCP client *is* an agent in your system, not just an OAuth client. See [MCP Client Identity](../../../../guides/mcp/mcp-clients) for how this identity model applies across MCP clients.
 
 ### Dynamic Client Registration
 
 Some MCP clients can register themselves. The client reads the MCP server's protected-resource metadata, discovers <ProductName /> as the authorization server, and registers via <ProductName />'s dynamic registration endpoint. <ProductName /> issues credentials the client then uses for token requests.
 
 Fits ecosystems where MCP clients can't all be enumerated in advance: third-party AI hosts, marketplace tools, integrations built by customers. The trade-off is governance: review and role assignment have to happen on first use rather than at registration time.
+
+See [Enable Dynamic Client Registration](../../../../guides/mcp/mcp-clients/dynamic-client-registration) for the step-by-step guide.
 
 ## Cross-Cutting Choices
 
@@ -56,4 +64,4 @@ These apply regardless of which server-side or client-side pattern you pick.
 
 ## Next Steps
 
-Pick the server-side and client-side patterns that fit your environment, then see them running in **[Try It Out](../try-it-out)**.
+Pick the server-side and client-side patterns that fit your environment, then see them running in **[Try It Out](../try-it-out)**, or go straight to the **[MCP Authorization guides](../../../../guides/mcp/overview)** for step-by-step setup.

--- a/docs/versioned_docs/version-v1.0.x/use-cases/ai-agents/mcp-authorization/try-it-out.mdx
+++ b/docs/versioned_docs/version-v1.0.x/use-cases/ai-agents/mcp-authorization/try-it-out.mdx
@@ -88,3 +88,4 @@ Pick a walkthrough to begin. Each one starts from the setup above.
 - Curious how the MCP-specific application and consent step map to <ProductName /> concepts? See [Identity Concepts](../identity-concepts).
 - Prefer to register the application manually? See [Configure It Yourself](../configure-it-yourself).
 - Want to compare server-side and client-side patterns before going to production? See [Solution Patterns](../solution-patterns).
+- Ready to apply this to your own MCP server instead of the Wayfinder sample? See the [MCP Authorization guides](../../../../guides/mcp/overview).

--- a/docs/versioned_sidebars/version-v1.0.x-sidebars.json
+++ b/docs/versioned_sidebars/version-v1.0.x-sidebars.json
@@ -708,6 +708,65 @@
         },
         {
           "type": "category",
+          "label": "MCP",
+          "key": "guides-mcp",
+          "collapsed": true,
+          "collapsible": true,
+          "items": [
+            {
+              "type": "doc",
+              "id": "guides/mcp/overview",
+              "label": "Overview",
+              "key": "guides-mcp-overview"
+            },
+            {
+              "type": "category",
+              "label": "MCP Clients",
+              "collapsed": true,
+              "collapsible": true,
+              "items": [
+                {
+                  "type": "doc",
+                  "id": "guides/mcp/mcp-clients/index",
+                  "label": "Overview",
+                  "key": "guides-mcp-clients-overview"
+                },
+                {
+                  "type": "doc",
+                  "id": "guides/mcp/mcp-clients/register-a-client",
+                  "label": "Register in the Console"
+                },
+                {
+                  "type": "doc",
+                  "id": "guides/mcp/mcp-clients/dynamic-client-registration",
+                  "label": "Dynamic Client Registration",
+                  "key": "guides-mcp-dynamic-client-registration"
+                }
+              ]
+            },
+            {
+              "type": "category",
+              "label": "MCP Server",
+              "collapsed": true,
+              "collapsible": true,
+              "items": [
+                {
+                  "type": "doc",
+                  "id": "guides/mcp/mcp-server/index",
+                  "label": "Overview",
+                  "key": "guides-mcp-server-overview"
+                },
+                {
+                  "type": "doc",
+                  "id": "guides/mcp/mcp-server/secure-your-mcp-server",
+                  "label": "Secure Your MCP Server"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "category",
           "label": "Integrations",
           "collapsed": true,
           "collapsible": true,


### PR DESCRIPTION
### Purpose

The MCP documentation had no guide section. A reader could find the `Securing MCP` use case and the MCP quickstarts, but there were no task-oriented guides between them, and the use case linked only to the generic application and resource server guides, so it never routed anyone to the MCP-specific material.

This PR adds a `guides/mcp` section built to the documentation rule agreed with the doc owner: each topic leads with a concept page explaining the concept itself, followed by the page showing how to configure it in ThunderID.

```
guides/mcp/
  overview.mdx                        concept  MCP Authorization
  mcp-clients/
    index.mdx                         concept  MCP Client Identity
    register-a-client.mdx             guide    Register in the Console
    dynamic-client-registration.mdx   guide    Enable Dynamic Client Registration
  mcp-server/
    index.mdx                         concept  MCP Server Authorization
    secure-your-mcp-server.mdx        guide    Secure Your MCP Server
```

It also corrects two factual problems in the drafted content:

- The pages described the MCP client and server as OAuth 2.0 participants. The MCP Authorization specification mandates OAuth 2.1, and the existing `guides/protocols/oauth-oidc/dynamic-client-registration` reference already says OAuth 2.1, so the new pages contradicted it. Occurrences that name an RFC (RFC 6749, RFC 8707, RFC 9207) are genuinely OAuth 2.0 and were left alone.
- The pages stated without qualification that an MCP client is an OAuth client. The MCP Authorization specification applies only to HTTP transports and explicitly excludes stdio, so the guidance is now scoped to HTTP and the stdio exclusion is stated.

### Approach

Each concept page is written product-neutral first and only introduces ThunderID afterward:

- **MCP Authorization**: the MCP roles, why tools need access control, then the specification's mechanism (401 with `WWW-Authenticate`, RFC 9728 protected-resource metadata, RFC 8414 discovery, Authorization Code with PKCE or Client Credentials, audience binding, enforcement at the tool boundary). Then a `How ThunderID Fits` section carrying the existing capability mapping.
- **MCP Client Identity**: public versus confidential clients, user-delegated versus machine-to-machine, redirect URI handling for local and random-port clients, and static versus dynamic registration as a concept. It links out to the existing RFC 7591 protocol reference rather than duplicating it, which is why there is no separate `what-is-dcr` page.
- **MCP Server Authorization**: the resource server model, scope granularity trade-offs, offline JWKS validation versus introspection, audience binding, and AuthZEN as the runtime-decision alternative.

The five `Securing MCP` use case pages now link into these guides, so each solution pattern points at the guide that implements it. Those edits are link-only and do not restructure the use case.

Because documentation versioning is enabled, every page and sidebar entry is duplicated into `versioned_docs/version-v1.0.x` and `versioned_sidebars/version-v1.0.x-sidebars.json`. `diff -rq` confirms `content/` and the v1.0.x tree are a verbatim mirror apart from one pre-existing unrelated drift in `guides/flows/advanced-configurations.mdx`.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [x] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

Verification: `pnpm build` from `docs/` exits 0 with zero broken links, and all six pages render under both `/docs/next/` and `/docs/v1.0.x/`. Vale reports no errors or warnings on the changed files. This is documentation only, so no unit or integration tests apply.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive MCP authorization guidance for clients, servers, OAuth 2.1 flows, scopes, consent, and token validation.
  * Added instructions for Console-based client registration and enabling Dynamic Client Registration.
  * Added MCP server security guidance, including permissions, audience enforcement, and fine-grained authorization.
  * Organized MCP guides in the documentation sidebar and added related links throughout AI agent authorization content.
  * Updated current and versioned documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->