### PR TITLE
Fix attribute library property names and drop phone_number from the default Person schema

### DIFF
--- a/backend/cmd/server/bootstrap/01-default-resources.yaml
+++ b/backend/cmd/server/bootstrap/01-default-resources.yaml
@@ -36,10 +36,6 @@ schema:
     type: string
     displayName: Mobile Number
     required: false
-  phone_number:
-    type: string
-    displayName: Phone Number
-    required: false
   sub:
     type: string
     displayName: Subject
@@ -4979,7 +4975,7 @@ attributes:
   name: Administrator
   given_name: Admin
   family_name: User
-  phone_number: "+12345678920"
+  mobile_number: "+12345678920"
 credentials:
   password: "{{ .ADMIN_PASSWORD }}"
 ---

--- a/docs/content/guides/users/user-type-reference.mdx
+++ b/docs/content/guides/users/user-type-reference.mdx
@@ -49,7 +49,6 @@ An admin-managed user type. Self-registration is disabled and only an administra
 | `given_name` | `string` | - | |
 | `family_name` | `string` | - | |
 | `mobile_number` | `string` | - | |
-| `phone_number` | `string` | - | |
 | `sub` | `string` | - | |
 | `name` | `string` | - | |
 | `picture` | `string` | - | |

--- a/frontend/packages/configure-user-types/src/constants/attributes.ts
+++ b/frontend/packages/configure-user-types/src/constants/attributes.ts
@@ -51,16 +51,6 @@ const ATTRIBUTES: LibraryAttribute[] = [
     regex: '',
   },
   {
-    name: 'phone',
-    displayName: 'Phone Number',
-    type: 'string',
-    required: false,
-    unique: false,
-    credential: false,
-    enum: [],
-    regex: '',
-  },
-  {
     name: 'password',
     displayName: 'Password',
     type: 'string',
@@ -241,7 +231,7 @@ const ATTRIBUTES: LibraryAttribute[] = [
     regex: '',
   },
   {
-    name: 'locality',
+    name: 'city',
     displayName: 'City',
     type: 'string',
     required: false,


### PR DESCRIPTION
### Purpose

In the user type schema builder, picking **City** from the Available Properties library seeded a schema property named `locality`, not `city`. This PR corrects that, drops a library entry that can never produce a claim, and removes the duplicate phone number attribute from the default Person schema.

### Approach

- Rename the City entry's property name from `locality` to `city`, matching the label. `locality` is an OIDC `address` sub claim; as a top level property it satisfies no standard scope, so nothing at runtime depends on the old name.
- Remove the `phone` library entry. The `phone` scope requires `phone_number`, so a property named `phone` is never emitted as a claim.
- Drop `phone_number` from the default Person schema and its reference table. `mobile_number` already covers the phone number attribute there, and it is the attribute flows (SMS OTP, identifying executor) and the default indexed attributes use.

The attribute library is a static, front end only suggestion list, so existing user types and stored schemas are unaffected.

### Related Issues
- Fixes #4567
- Fixes #4621

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated the default user profile fields to use **Mobile number** instead of **Phone number**.
  * Removed the predefined **Phone** attribute from user type configuration.
  * Renamed the predefined location field from **Locality** to **City**.
* **Documentation**
  * Updated the user type reference to reflect the new **Mobile number** attribute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->