### PR TITLE
Default permission consent toggles to unselected.

### DIFF
--- a/frontend/packages/design/src/components/flow/adapters/ConsentAdapter.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/ConsentAdapter.tsx
@@ -47,8 +47,10 @@ interface ConsentAdapterProps {
   onInputChange: (name: string, value: string) => void;
 }
 
+// Permissions are opt-in: an absent form value means the user has not granted the permission. This
+// must match how the SDK compiles consent_decisions on submit, or the screen and the token disagree.
 function isPermissionChecked(formValues: Record<string, string>, purposeId: string, name: string): boolean {
-  return formValues[getConsentOptionalKey(purposeId, name)] !== 'false';
+  return formValues[getConsentOptionalKey(purposeId, name)] === 'true';
 }
 
 // collectDescendants returns the transitive set of descendants of `name` per the parent index.

--- a/frontend/packages/design/src/components/flow/adapters/__tests__/ConsentAdapter.test.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/__tests__/ConsentAdapter.test.tsx
@@ -1,0 +1,111 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {screen, cleanup, fireEvent} from '@testing-library/react';
+import {describe, it, expect, afterEach, vi} from 'vitest';
+import renderWithProviders from '../../../../test/renderWithProviders';
+import ConsentAdapter from '../ConsentAdapter';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const noop = () => undefined;
+
+// Mirrors the permission purpose the backend builds at runtime: it is never persisted, so purposeId
+// arrives as an empty string and essential arrives as null.
+const permissionsPurpose = JSON.stringify([
+  {
+    purposeName: 'permissions:app1',
+    purposeId: '',
+    type: 'permissions',
+    essential: null,
+    optional: [{name: 'system'}],
+  },
+]);
+
+const nestedPermissionsPurpose = JSON.stringify([
+  {
+    purposeName: 'permissions:app1',
+    purposeId: '',
+    type: 'permissions',
+    essential: null,
+    optional: [{name: 'users'}, {name: 'users:read', parent: 'users'}, {name: 'users:write', parent: 'users'}],
+  },
+]);
+
+const permissionKey = (name: string) => `__consent_opt____${name}`;
+
+const switchFor = (name: string) => screen.getByRole<HTMLInputElement>('switch', {name});
+
+describe('ConsentAdapter — permission default state', () => {
+  it('renders an untouched permission as unchecked', () => {
+    renderWithProviders(<ConsentAdapter consentData={permissionsPurpose} formValues={{}} onInputChange={noop} />);
+
+    expect(switchFor('system').checked).toBe(false);
+  });
+
+  it('renders a permission the user enabled as checked', () => {
+    renderWithProviders(
+      <ConsentAdapter
+        consentData={permissionsPurpose}
+        formValues={{[permissionKey('system')]: 'true'}}
+        onInputChange={noop}
+      />,
+    );
+
+    expect(switchFor('system').checked).toBe(true);
+  });
+
+  it('renders a permission the user disabled as unchecked', () => {
+    renderWithProviders(
+      <ConsentAdapter
+        consentData={permissionsPurpose}
+        formValues={{[permissionKey('system')]: 'false'}}
+        onInputChange={noop}
+      />,
+    );
+
+    expect(switchFor('system').checked).toBe(false);
+  });
+
+  it('leaves every permission in a nested tree unchecked when nothing is selected', () => {
+    renderWithProviders(<ConsentAdapter consentData={nestedPermissionsPurpose} formValues={{}} onInputChange={noop} />);
+
+    expect(switchFor('users').checked).toBe(false);
+    expect(switchFor('users:read').checked).toBe(false);
+    expect(switchFor('users:write').checked).toBe(false);
+  });
+});
+
+describe('ConsentAdapter — permission rollup', () => {
+  it('cascades a parent toggle to its descendants', () => {
+    const onInputChange = vi.fn();
+
+    renderWithProviders(
+      <ConsentAdapter consentData={nestedPermissionsPurpose} formValues={{}} onInputChange={onInputChange} />,
+    );
+
+    fireEvent.click(switchFor('users'));
+
+    expect(onInputChange).toHaveBeenCalledWith(permissionKey('users'), 'true');
+    expect(onInputChange).toHaveBeenCalledWith(permissionKey('users:read'), 'true');
+    expect(onInputChange).toHaveBeenCalledWith(permissionKey('users:write'), 'true');
+  });
+
+  it('shows the parent as checked once every descendant is checked', () => {
+    renderWithProviders(
+      <ConsentAdapter
+        consentData={nestedPermissionsPurpose}
+        formValues={{
+          [permissionKey('users:read')]: 'true',
+          [permissionKey('users:write')]: 'true',
+        }}
+        onInputChange={noop}
+      />,
+    );
+
+    expect(switchFor('users').checked).toBe(true);
+  });
+});


### PR DESCRIPTION
### Purpose
The Gate renders permission consent through its own ConsentAdapter, which treated an absent form value as granted. The SDK compiles consent_decisions using the opposite
  convention, causing untouched permissions shown as selected to be submitted as denied. Consequently, issued tokens did not include the expected scopes.

  This change aligns the displayed permission state with the submitted consent state.

  ### Approach

  - Treat permissions without an explicit form value as unselected.
  - Render permissions as selected only when their form value is explicitly set to "true".
  - Add unit tests covering:
      - Untouched permissions.
      - Explicitly enabled and disabled permissions.
      - Nested permission defaults.
      - Parent-to-descendant toggle cascading.
      - Parent rollup when all descendants are selected.

  ### Related Issues

  - Fixes #4589

  ### Related PRs

  - N/A

  ### Checklist
  - [x] Followed the contribution guidelines.
  - [ ] Manual test round performed and verified.
  - [ ] Documentation provided. Not applicable.
      - [ ] Ran Vale and fixed all errors and warnings. Not applicable.
  - [x] Tests provided.
      - [x] Unit Tests
      - [ ] Integration Tests
  - [x] Breaking changes. Not applicable.
      - [ ] Breaking changes section filled.
      - [ ] breaking change label added.

  ### Security checks
  - [x] Followed secure coding standards in WSO2 Secure Coding Guidelines
    (https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
  - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated consent permission handling so only explicitly enabled values are treated as granted.
  * Unset or unrecognized permission values now remain unchecked.

* **Tests**
  * Added coverage for default states, saved permission values, nested permissions, cascading toggles, and parent selection states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->