### PR TITLE
Fix broken quickstart documentation links in the console

### DIFF
--- a/frontend/apps/console/public/config.js
+++ b/frontend/apps/console/public/config.js
@@ -31,55 +31,55 @@ window.__THUNDERID_RUNTIME_CONFIG__ = {
         'getting-started/connect-your-application/prompts/react/redirect-based.txt',
       'applications.templates.react.llmPrompt.embedded':
         'getting-started/connect-your-application/prompts/react/embedded.txt',
-      'applications.templates.nextjs.docs': 'guides/getting-started/connect-your-application/nextjs/',
+      'applications.templates.nextjs.docs': 'getting-started/connect-your-application/nextjs/',
       'applications.templates.nextjs.playground':
         'https://stackblitz.com/fork/github/thunder-id/javascript-sdks/tree/main/samples/nextjs/quickstart?file=README.md',
       'applications.templates.nextjs.llmPrompt.redirectBased':
         'getting-started/connect-your-application/prompts/nextjs/redirect-based.txt',
       'applications.templates.nextjs.llmPrompt.embedded':
         'getting-started/connect-your-application/prompts/nextjs/embedded.txt',
-      'applications.templates.nuxt.docs': 'guides/getting-started/connect-your-application/nuxt/',
+      'applications.templates.nuxt.docs': 'getting-started/connect-your-application/nuxt/',
       'applications.templates.nuxt.playground':
         'https://stackblitz.com/fork/github/thunder-id/javascript-sdks/tree/main/samples/nuxt/quickstart?file=README.md',
       'applications.templates.nuxt.llmPrompt.redirectBased':
         'getting-started/connect-your-application/prompts/nuxt/redirect-based.txt',
       'applications.templates.nuxt.llmPrompt.embedded':
         'getting-started/connect-your-application/prompts/nuxt/embedded.txt',
-      'applications.templates.vue.docs': 'guides/getting-started/connect-your-application/vue/',
+      'applications.templates.vue.docs': 'getting-started/connect-your-application/vue/',
       'applications.templates.vue.playground':
         'https://stackblitz.com/fork/github/thunder-id/javascript-sdks/tree/main/samples/vue/quickstart?file=README.md',
       'applications.templates.vue.llmPrompt.redirectBased':
         'getting-started/connect-your-application/prompts/vue/redirect-based.txt',
       'applications.templates.vue.llmPrompt.embedded':
         'getting-started/connect-your-application/prompts/vue/embedded.txt',
-      'applications.templates.express.docs': 'guides/getting-started/connect-your-application/express/',
+      'applications.templates.express.docs': 'getting-started/connect-your-application/express/',
       'applications.templates.express.playground':
         'https://stackblitz.com/fork/github/thunder-id/javascript-sdks/tree/main/samples/express/quickstart?file=README.md',
       'applications.templates.express.llmPrompt.redirectBased':
         'getting-started/connect-your-application/prompts/express/redirect-based.txt',
       'applications.templates.express.llmPrompt.embedded':
         'getting-started/connect-your-application/prompts/express/embedded.txt',
-      'applications.templates.node.docs': 'guides/getting-started/connect-your-application/node/',
+      'applications.templates.node.docs': 'getting-started/connect-your-application/node/',
       'applications.templates.node.playground':
         'https://stackblitz.com/fork/github/thunder-id/javascript-sdks/tree/main/samples/node/quickstart?file=README.md',
       'applications.templates.node.llmPrompt.redirectBased':
         'getting-started/connect-your-application/prompts/node/redirect-based.txt',
       'applications.templates.node.llmPrompt.embedded':
         'getting-started/connect-your-application/prompts/node/embedded.txt',
-      'applications.templates.browser.docs': 'guides/getting-started/connect-your-application/browser/',
+      'applications.templates.browser.docs': 'getting-started/connect-your-application/browser/',
       'applications.templates.browser.playground':
         'https://stackblitz.com/fork/github/thunder-id/javascript-sdks/tree/main/samples/browser/quickstart?file=README.md',
       'applications.templates.browser.llmPrompt.redirectBased':
         'getting-started/connect-your-application/prompts/browser/redirect-based.txt',
       'applications.templates.browser.llmPrompt.embedded':
         'getting-started/connect-your-application/prompts/browser/embedded.txt',
-      'applications.templates.android.docs': 'guides/getting-started/connect-your-application/android/',
+      'applications.templates.android.docs': 'getting-started/connect-your-application/android/',
       'applications.templates.android.llmPrompt.redirectBased':
         'getting-started/connect-your-application/prompts/android/redirect-based.txt',
-      'applications.templates.ios.docs': 'guides/getting-started/connect-your-application/ios/',
+      'applications.templates.ios.docs': 'getting-started/connect-your-application/ios/',
       'applications.templates.ios.llmPrompt.redirectBased':
         'getting-started/connect-your-application/prompts/ios/redirect-based.txt',
-      'applications.templates.flutter.docs': 'guides/getting-started/connect-your-application/flutter/',
+      'applications.templates.flutter.docs': 'getting-started/connect-your-application/flutter/',
       'applications.templates.flutter.llmPrompt.redirectBased':
         'getting-started/connect-your-application/prompts/flutter/redirect-based.txt',
       'applications.templates.mcpClient.docs': 'getting-started/connect-your-mcp/python/',


### PR DESCRIPTION
### Purpose
Quickstart "docs" links for nine application templates in the console pointed at a
`guides/getting-started/...` path that does not exist, so every one of them 404s.

For example, the Android quickstart link resolved to:

`https://thunderid.dev/docs/v1.0.x/guides/getting-started/connect-your-application/android/`

when the page is actually served at:

`https://thunderid.dev/docs/v1.0.x/getting-started/connect-your-application/android/`

Affected templates: `nextjs`, `nuxt`, `vue`, `express`, `node`, `browser`, `android`,
`ios`, `flutter`.


### Approach
Removed the stray `guides/` prefix from the nine `applications.templates.*.docs`
entries in `frontend/apps/console/public/config.js`. The template JSON files resolve
these through `{{...}}` placeholders, so this config is the single source for the
paths and no other file needed changing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links for Next.js, Nuxt, Vue, Express, Node, browser, Android, iOS, and Flutter templates.
  * Added relevant template documentation, playground, and prompt links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->