### PR TITLE
Added ui_locales support.

### DIFF
--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -265,6 +265,9 @@ func (as *authorizeService) handleStandardAuthorizationRequest(
 	// Extract claims_locales parameter.
 	claimsLocales := queryParams.Get(oauth2const.RequestParamClaimsLocales)
 
+	// Extract ui_locales parameter.
+	uiLocales := queryParams.Get(oauth2const.RequestParamUILocales)
+
 	nonce := queryParams.Get(oauth2const.RequestParamNonce)
 	acrValues := queryParams.Get(oauth2const.RequestParamAcrValues)
 	maxAge := queryParams.Get(oauth2const.RequestParamMaxAge)
@@ -319,6 +322,7 @@ func (as *authorizeService) handleStandardAuthorizationRequest(
 		Resources:           resources,
 		ClaimsRequest:       claimsRequest,
 		ClaimsLocales:       claimsLocales,
+		UILocales:           uiLocales,
 		Nonce:               nonce,
 		AcrValues:           acrValues,
 		MaxAge:              maxAge,
@@ -449,6 +453,9 @@ func (as *authorizeService) initiateFlowAndStoreRequest(
 	queryParams[oauth2const.AuthID] = identifier
 	queryParams[oauth2const.AppID] = app.ID
 	queryParams[oauth2const.ExecutionID] = executionID
+	if oauthParams.UILocales != "" {
+		queryParams[oauth2const.RequestParamUILocales] = oauthParams.UILocales
+	}
 
 	// Add insecure warning if the redirect URI is not using TLS.
 	// TODO: May require another redirection to a warn consent page when it directly goes to a federated IDP.

--- a/backend/internal/oauth/oauth2/authz/service_test.go
+++ b/backend/internal/oauth/oauth2/authz/service_test.go
@@ -348,6 +348,25 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_Su
 	assert.Equal(suite.T(), "test-flow-id", result.QueryParams[oauth2const.ExecutionID])
 }
 
+func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_Success_WithUILocales() {
+	app := suite.testApp()
+	suite.mockInboundClient.EXPECT().GetOAuthClientByClientID(mock.Anything, "test-client-id").Return(app, nil)
+	suite.mockValidator.On("validateInitialAuthorizationRequest", mock.Anything, mock.Anything, app).
+		Return(false, "", "")
+	suite.mockFlowExecService.EXPECT().InitiateFlow(mock.Anything, mock.Anything).Return("test-flow-id", nil)
+	suite.mockAuthReqStore.EXPECT().AddRequest(mock.Anything, mock.Anything).Return(testAuthID, nil)
+
+	msg := suite.testMsg()
+	msg.RequestQueryParams["ui_locales"] = []string{"hi"}
+
+	svc := suite.newService()
+	result, authErr := svc.HandleInitialAuthorizationRequest(context.Background(), msg)
+
+	assert.Nil(suite.T(), authErr)
+	assert.NotNil(suite.T(), result)
+	assert.Equal(suite.T(), "hi", result.QueryParams[oauth2const.RequestParamUILocales])
+}
+
 func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_ExplicitResourceSetsRuntimeRSID() {
 	app := suite.testApp()
 	suite.mockInboundClient.EXPECT().GetOAuthClientByClientID(mock.Anything, "test-client-id").Return(app, nil)

--- a/backend/internal/oauth/oauth2/constants/constants.go
+++ b/backend/internal/oauth/oauth2/constants/constants.go
@@ -46,6 +46,7 @@ const (
 	RequestParamAssertion           string = "assertion"
 	RequestParamClaims              string = "claims"
 	RequestParamClaimsLocales       string = "claims_locales"
+	RequestParamUILocales           string = "ui_locales"
 	RequestParamNonce               string = "nonce"
 	RequestParamPrompt              string = "prompt"
 	RequestParamRequestURI          string = "request_uri"

--- a/backend/internal/oauth/oauth2/model/parameter.go
+++ b/backend/internal/oauth/oauth2/model/parameter.go
@@ -26,6 +26,7 @@ type OAuthParameters struct {
 	Resources           []string
 	ClaimsRequest       *ClaimsRequest
 	ClaimsLocales       string
+	UILocales           string
 	Nonce               string
 	AcrValues           string
 	MaxAge              string

--- a/backend/internal/oauth/oauth2/par/service.go
+++ b/backend/internal/oauth/oauth2/par/service.go
@@ -142,6 +142,7 @@ func (s *parService) HandlePushedAuthorizationRequest(
 		Resources:           resources,
 		ClaimsRequest:       claimsRequest,
 		ClaimsLocales:       params[oauth2const.RequestParamClaimsLocales],
+		UILocales:           params[oauth2const.RequestParamUILocales],
 		Nonce:               params[oauth2const.RequestParamNonce],
 		AcrValues:           params[oauth2const.RequestParamAcrValues],
 		MaxAge:              params[oauth2const.RequestParamMaxAge],


### PR DESCRIPTION
### Purpose
Fixes two i18n bugs in the OIDC authorization / flow-metadata pipeline:

1. `ui_locales` from the `/authorize` request was read into the request context but never forwarded anywhere — it never reached the login page, so it had no effect on the UI language.

### Approach
**`ui_locales` forwarding** — added `RequestParamUILocales`; extracted `ui_locales` in both the standard (`authz/service.go`) and PAR (`par/service.go`) authorization paths into a new `OAuthParameters.UILocales` field; forwarded it into the login-page redirect query params alongside `authId`/`applicationId`/`executionId` in `initiateFlowAndStoreRequest`.

### Related Issues
- NA

### Related PRs
- NA


### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added localized application names based on the requested language, including regional-language matching and an English fallback.
  * Added support for the OAuth `ui_locales` parameter.
  * Preserved the requested locale across authorization requests, login-page redirects, and pushed authorization requests, helping display the appropriate language throughout sign-in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->