### PR TITLE
Add agent type export support

### DIFF
--- a/api/export.yaml
+++ b/api/export.yaml
@@ -154,6 +154,11 @@ components:
           items:
             type: string
           description: IDs of user types to export, or ["*"] for all.
+        agentTypes:
+          type: array
+          items:
+            type: string
+          description: IDs of agent types to export, or ["*"] for all.
         organizationUnits:
           type: array
           items:

--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -168,10 +168,11 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	fatalOnError(ctx, logger, err, "Failed to initialize HashService")
 
 	// Initialize user type service
-	entityTypeService, entityTypeExporter, err := entitytype.Initialize(
+	entityTypeService, entityTypeExporter, agentTypeExporter, err := entitytype.Initialize(
 		mux, mcpServer, cacheManager, ouService, ouAuthzService)
 	fatalOnError(ctx, logger, err, "Failed to initialize EntityTypeService")
 	exporters = append(exporters, entityTypeExporter)
+	exporters = append(exporters, agentTypeExporter)
 
 	// Initialize entity service
 	entityService, err := entity.Initialize(cacheManager, hashService, entityTypeService, ouService)

--- a/backend/internal/entitytype/declarative_resource.go
+++ b/backend/internal/entitytype/declarative_resource.go
@@ -22,54 +22,75 @@ import (
 const (
 	resourceTypeEntityType = "user_type"
 	paramTypEntityType     = "EntityType"
+	resourceTypeAgentType  = "agent_type"
+	paramTypeAgentType     = "AgentType"
 )
 
 // entityTypeExporter implements declarative_resource.ResourceExporter for entity types.
 type entityTypeExporter struct {
-	service EntityTypeServiceInterface
+	service  EntityTypeServiceInterface
+	category TypeCategory
 }
 
-// newEntityTypeExporter creates a new entity type exporter.
-func newEntityTypeExporter(service EntityTypeServiceInterface) *entityTypeExporter {
-	return &entityTypeExporter{service: service}
+// newEntityTypeExporter creates a new entity type exporter for the given category.
+func newEntityTypeExporter(service EntityTypeServiceInterface, category TypeCategory) *entityTypeExporter {
+	return &entityTypeExporter{service: service, category: category}
 }
 
 // NewEntityTypeExporterForTest creates a new entity type exporter for testing purposes.
-func NewEntityTypeExporterForTest(service EntityTypeServiceInterface) *entityTypeExporter {
-	return newEntityTypeExporter(service)
+func NewEntityTypeExporterForTest(service EntityTypeServiceInterface, category TypeCategory) *entityTypeExporter {
+	return newEntityTypeExporter(service, category)
 }
 
 // GetResourceType returns the resource type for entity types.
 func (e *entityTypeExporter) GetResourceType() string {
+	if e.category == TypeCategoryAgent {
+		return resourceTypeAgentType
+	}
 	return resourceTypeEntityType
 }
 
 // GetParameterizerType returns the parameterizer type for entity types.
 func (e *entityTypeExporter) GetParameterizerType() string {
+	if e.category == TypeCategoryAgent {
+		return paramTypeAgentType
+	}
 	return paramTypEntityType
 }
 
-// GetAllResourceIDs retrieves all user-category entity type IDs.
+// GetAllResourceIDs retrieves all entity type IDs for the exporter's category.
 // In composite mode, this excludes declarative (YAML-based) entity types.
 func (e *entityTypeExporter) GetAllResourceIDs(ctx context.Context) ([]string, *tidcommon.ServiceError) {
-	response, err := e.service.GetEntityTypeList(ctx, TypeCategoryUser, serverconst.MaxPageSize, 0, false)
-	if err != nil {
-		return nil, err
-	}
-	ids := make([]string, 0, len(response.Types))
-	for _, schema := range response.Types {
-		if !schema.IsReadOnly {
-			ids = append(ids, schema.ID)
+	offset := 0
+	limit := serverconst.MaxPageSize
+	ids := []string{}
+
+	for {
+		response, err := e.service.GetEntityTypeList(ctx, e.category, limit, offset, false)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, schema := range response.Types {
+			if !schema.IsReadOnly {
+				ids = append(ids, schema.ID)
+			}
+		}
+
+		offset += len(response.Types)
+		if len(response.Types) == 0 {
+			break
 		}
 	}
+
 	return ids, nil
 }
 
-// GetResourceByID retrieves a user-category entity type by its ID.
+// GetResourceByID retrieves an entity type of the exporter's category by its ID.
 func (e *entityTypeExporter) GetResourceByID(ctx context.Context, id string) (
 	interface{}, string, *tidcommon.ServiceError,
 ) {
-	schema, err := e.service.GetEntityType(ctx, TypeCategoryUser, id, false)
+	schema, err := e.service.GetEntityType(ctx, e.category, id, false)
 	if err != nil {
 		return nil, "", err
 	}
@@ -82,11 +103,11 @@ func (e *entityTypeExporter) ValidateResource(ctx context.Context,
 ) (string, *declarativeresource.ExportError) {
 	schema, ok := resource.(*EntityType)
 	if !ok {
-		return "", declarativeresource.CreateTypeError(resourceTypeEntityType, id)
+		return "", declarativeresource.CreateTypeError(e.GetResourceType(), id)
 	}
 
 	err := declarativeresource.ValidateResourceName(ctx,
-		schema.Name, resourceTypeEntityType, id, "SCHEMA_VALIDATION_ERROR", logger,
+		schema.Name, e.GetResourceType(), id, "SCHEMA_VALIDATION_ERROR", logger,
 	)
 	if err != nil {
 		return "", err

--- a/backend/internal/entitytype/declarative_resource_internal_test.go
+++ b/backend/internal/entitytype/declarative_resource_internal_test.go
@@ -416,7 +416,7 @@ func TestLoadDeclarativeResources(t *testing.T) {
 func TestGetAllResourceIDs_WithReadOnlyFilter(t *testing.T) {
 	mockService := NewEntityTypeServiceInterfaceMock(t)
 
-	exporter := newEntityTypeExporter(mockService)
+	exporter := newEntityTypeExporter(mockService, TypeCategoryUser)
 
 	response := &EntityTypeListResponse{
 		Types: []EntityTypeListItem{
@@ -426,7 +426,9 @@ func TestGetAllResourceIDs_WithReadOnlyFilter(t *testing.T) {
 		},
 	}
 
-	mockService.On("GetEntityTypeList", mock.Anything, mock.Anything, 100, 0, false).Return(response, nil)
+	mockService.On("GetEntityTypeList", mock.Anything, mock.Anything, 100, 0, false).Return(response, nil).Once()
+	mockService.On("GetEntityTypeList", mock.Anything, mock.Anything, 100, 3, false).
+		Return(&EntityTypeListResponse{Types: []EntityTypeListItem{}}, nil).Once()
 
 	ids, err := exporter.GetAllResourceIDs(context.Background())
 

--- a/backend/internal/entitytype/declarative_resource_test.go
+++ b/backend/internal/entitytype/declarative_resource_test.go
@@ -34,7 +34,7 @@ func TestEntityTypeExporterTestSuite(t *testing.T) {
 
 func (s *EntityTypeExporterTestSuite) SetupTest() {
 	s.mockService = entitytypemock.NewEntityTypeServiceInterfaceMock(s.T())
-	s.exporter = entitytype.NewEntityTypeExporterForTest(s.mockService)
+	s.exporter = entitytype.NewEntityTypeExporterForTest(s.mockService, entitytype.TypeCategoryUser)
 	s.logger = log.GetLogger()
 }
 
@@ -60,7 +60,10 @@ func (s *EntityTypeExporterTestSuite) TestGetAllResourceIDs_Success() {
 
 	s.mockService.EXPECT().
 		GetEntityTypeList(mock.Anything, entitytype.TypeCategoryUser, 100, 0, false).
-		Return(expectedResponse, nil)
+		Return(expectedResponse, nil).Once()
+	s.mockService.EXPECT().
+		GetEntityTypeList(mock.Anything, entitytype.TypeCategoryUser, 100, 2, false).
+		Return(&entitytype.EntityTypeListResponse{Types: []entitytype.EntityTypeListItem{}}, nil).Once()
 
 	ids, err := s.exporter.GetAllResourceIDs(context.Background())
 
@@ -202,4 +205,196 @@ func (s *EntityTypeExporterTestSuite) TestGetResourceRules() {
 	assert.NotNil(s.T(), rules)
 	// ResourceRules is currently an empty struct, but the function should return a valid pointer
 	assert.IsType(s.T(), &declarativeresource.ResourceRules{}, rules)
+}
+
+// AgentTypeExporterTestSuite tests the entityTypeExporter configured for TypeCategoryAgent.
+type AgentTypeExporterTestSuite struct {
+	suite.Suite
+	mockService *entitytypemock.EntityTypeServiceInterfaceMock
+	exporter    declarativeresource.ResourceExporter
+	logger      *log.Logger
+}
+
+func TestAgentTypeExporterTestSuite(t *testing.T) {
+	suite.Run(t, new(AgentTypeExporterTestSuite))
+}
+
+func (s *AgentTypeExporterTestSuite) SetupTest() {
+	s.mockService = entitytypemock.NewEntityTypeServiceInterfaceMock(s.T())
+	s.exporter = entitytype.NewEntityTypeExporterForTest(s.mockService, entitytype.TypeCategoryAgent)
+	s.logger = log.GetLogger()
+}
+
+func (s *AgentTypeExporterTestSuite) TestGetResourceType() {
+	assert.Equal(s.T(), "agent_type", s.exporter.GetResourceType())
+}
+
+func (s *AgentTypeExporterTestSuite) TestGetParameterizerType() {
+	assert.Equal(s.T(), "AgentType", s.exporter.GetParameterizerType())
+}
+
+func (s *AgentTypeExporterTestSuite) TestGetAllResourceIDs_Success() {
+	expectedResponse := &entitytype.EntityTypeListResponse{
+		Types: []entitytype.EntityTypeListItem{
+			{ID: "agenttype1", Name: "Agent Type 1"},
+			{ID: "agenttype2", Name: "Agent Type 2"},
+		},
+	}
+
+	s.mockService.EXPECT().
+		GetEntityTypeList(mock.Anything, entitytype.TypeCategoryAgent, 100, 0, false).
+		Return(expectedResponse, nil).Once()
+	s.mockService.EXPECT().
+		GetEntityTypeList(mock.Anything, entitytype.TypeCategoryAgent, 100, 2, false).
+		Return(&entitytype.EntityTypeListResponse{Types: []entitytype.EntityTypeListItem{}}, nil).Once()
+
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
+
+	assert.Nil(s.T(), err)
+	assert.Len(s.T(), ids, 2)
+	assert.ElementsMatch(s.T(), []string{"agenttype1", "agenttype2"}, ids)
+}
+
+func (s *AgentTypeExporterTestSuite) TestGetAllResourceIDs_Error() {
+	expectedError := &tidcommon.ServiceError{
+		Code: "ERR_CODE",
+		Error: tidcommon.I18nMessage{
+			Key:          "error.entitytypeexporter.test_error",
+			DefaultValue: "test error",
+		},
+	}
+
+	s.mockService.EXPECT().
+		GetEntityTypeList(mock.Anything, entitytype.TypeCategoryAgent, 100, 0, false).
+		Return(nil, expectedError)
+
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
+
+	assert.Nil(s.T(), ids)
+	assert.Equal(s.T(), expectedError, err)
+}
+
+func (s *AgentTypeExporterTestSuite) TestGetAllResourceIDs_EmptyList() {
+	expectedResponse := &entitytype.EntityTypeListResponse{
+		Types: []entitytype.EntityTypeListItem{},
+	}
+
+	s.mockService.EXPECT().
+		GetEntityTypeList(mock.Anything, entitytype.TypeCategoryAgent, 100, 0, false).
+		Return(expectedResponse, nil)
+
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
+
+	assert.Nil(s.T(), err)
+	assert.Len(s.T(), ids, 0)
+}
+
+func (s *AgentTypeExporterTestSuite) TestGetAllResourceIDs_Pagination() {
+	firstPage := &entitytype.EntityTypeListResponse{
+		Types: []entitytype.EntityTypeListItem{
+			{ID: "agenttype1", Name: "Agent Type 1"},
+			{ID: "agenttype2", Name: "Agent Type 2"},
+		},
+	}
+	secondPage := &entitytype.EntityTypeListResponse{Types: []entitytype.EntityTypeListItem{}}
+
+	s.mockService.EXPECT().
+		GetEntityTypeList(mock.Anything, entitytype.TypeCategoryAgent, 100, 0, false).
+		Return(firstPage, nil).Once()
+	s.mockService.EXPECT().
+		GetEntityTypeList(mock.Anything, entitytype.TypeCategoryAgent, 100, 2, false).
+		Return(secondPage, nil).Once()
+
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
+
+	assert.Nil(s.T(), err)
+	assert.Len(s.T(), ids, 2)
+	assert.ElementsMatch(s.T(), []string{"agenttype1", "agenttype2"}, ids)
+}
+
+func (s *AgentTypeExporterTestSuite) TestGetAllResourceIDs_FiltersReadOnly() {
+	response := &entitytype.EntityTypeListResponse{
+		Types: []entitytype.EntityTypeListItem{
+			{ID: "agenttype-db", IsReadOnly: false},
+			{ID: "agenttype-decl", IsReadOnly: true},
+		},
+	}
+
+	s.mockService.EXPECT().
+		GetEntityTypeList(mock.Anything, entitytype.TypeCategoryAgent, 100, 0, false).
+		Return(response, nil).Once()
+	s.mockService.EXPECT().
+		GetEntityTypeList(mock.Anything, entitytype.TypeCategoryAgent, 100, 2, false).
+		Return(&entitytype.EntityTypeListResponse{Types: []entitytype.EntityTypeListItem{}}, nil).Once()
+
+	ids, err := s.exporter.GetAllResourceIDs(context.Background())
+
+	assert.Nil(s.T(), err)
+	assert.Len(s.T(), ids, 1)
+	assert.Equal(s.T(), "agenttype-db", ids[0])
+}
+
+func (s *AgentTypeExporterTestSuite) TestGetResourceByID_Success() {
+	expectedSchema := &entitytype.EntityType{
+		ID:   "agenttype1",
+		Name: "Test Agent Type",
+	}
+
+	s.mockService.EXPECT().
+		GetEntityType(mock.Anything, entitytype.TypeCategoryAgent, "agenttype1", mock.Anything).
+		Return(expectedSchema, nil)
+
+	resource, name, err := s.exporter.GetResourceByID(context.Background(), "agenttype1")
+
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), "Test Agent Type", name)
+	assert.Equal(s.T(), expectedSchema, resource)
+}
+
+func (s *AgentTypeExporterTestSuite) TestGetResourceByID_Error() {
+	expectedError := &tidcommon.ServiceError{
+		Code: "ERR_CODE",
+		Error: tidcommon.I18nMessage{
+			Key:          "error.entitytypeexporter.test_error",
+			DefaultValue: "test error",
+		},
+	}
+
+	s.mockService.EXPECT().
+		GetEntityType(mock.Anything, entitytype.TypeCategoryAgent, "agenttype1", mock.Anything).
+		Return(nil, expectedError)
+
+	resource, name, err := s.exporter.GetResourceByID(context.Background(), "agenttype1")
+
+	assert.Nil(s.T(), resource)
+	assert.Empty(s.T(), name)
+	assert.Equal(s.T(), expectedError, err)
+}
+
+func (s *AgentTypeExporterTestSuite) TestValidateResource_InvalidType() {
+	invalidResource := "not a schema"
+
+	name, err := s.exporter.ValidateResource(context.Background(), invalidResource, "agenttype1", s.logger)
+
+	assert.Empty(s.T(), name)
+	assert.NotNil(s.T(), err)
+	assert.Equal(s.T(), "agent_type", err.ResourceType)
+	assert.Equal(s.T(), "agenttype1", err.ResourceID)
+	assert.Equal(s.T(), "INVALID_TYPE", err.Code)
+}
+
+func (s *AgentTypeExporterTestSuite) TestValidateResource_EmptyName() {
+	schema := &entitytype.EntityType{
+		ID:   "agenttype1",
+		Name: "",
+	}
+
+	name, err := s.exporter.ValidateResource(context.Background(), schema, "agenttype1", s.logger)
+
+	assert.Empty(s.T(), name)
+	assert.NotNil(s.T(), err)
+	assert.Equal(s.T(), "agent_type", err.ResourceType)
+	assert.Equal(s.T(), "agenttype1", err.ResourceID)
+	assert.Equal(s.T(), "SCHEMA_VALIDATION_ERROR", err.Code)
+	assert.Contains(s.T(), err.Error, "name is empty")
 }

--- a/backend/internal/entitytype/init.go
+++ b/backend/internal/entitytype/init.go
@@ -24,12 +24,12 @@ func Initialize(
 	cacheManager cache.CacheManagerInterface,
 	ouService oupkg.OrganizationUnitServiceInterface,
 	authzService sysauthz.SystemAuthorizationServiceInterface,
-) (EntityTypeServiceInterface, declarativeresource.ResourceExporter, error) {
+) (EntityTypeServiceInterface, declarativeresource.ResourceExporter, declarativeresource.ResourceExporter, error) {
 	// Step 1: Determine store mode and initialize store and transactioner
 	storeMode := getEntityTypeStoreMode()
 	entityTypeStore, transactioner, err := initializeStore(storeMode, cacheManager)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// Step 2: Create service with store
@@ -39,7 +39,7 @@ func Initialize(
 	// Step 3: Load declarative resources into store (if applicable)
 	if storeMode == serverconst.StoreModeComposite || storeMode == serverconst.StoreModeDeclarative {
 		if err := loadDeclarativeResources(entityTypeStore, entityTypeService); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 	}
 
@@ -52,8 +52,9 @@ func Initialize(
 		registerMCPTools(mcpServer, entityTypeService)
 	}
 
-	exporter := newEntityTypeExporter(entityTypeService)
-	return entityTypeService, exporter, nil
+	userTypeExporter := newEntityTypeExporter(entityTypeService, TypeCategoryUser)
+	agentTypeExporter := newEntityTypeExporter(entityTypeService, TypeCategoryAgent)
+	return entityTypeService, userTypeExporter, agentTypeExporter, nil
 }
 
 // Store Selection (based on entity_type.store configuration):

--- a/backend/internal/entitytype/init_test.go
+++ b/backend/internal/entitytype/init_test.go
@@ -107,7 +107,7 @@ func (suite *InitTestSuite) TestInitialize() {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(suite.T(), err)
 
-	service, _, err := Initialize(
+	service, _, _, err := Initialize(
 		suite.mux, nil, testCacheManager(), suite.mockOUService, nil)
 	assert.NoError(suite.T(), err)
 
@@ -131,7 +131,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_ListEndpoint() {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(suite.T(), err)
 
-	_, _, err = Initialize(
+	_, _, _, err = Initialize(
 		suite.mux, nil, testCacheManager(), suite.mockOUService, nil)
 	assert.NoError(suite.T(), err)
 
@@ -159,7 +159,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_CreateEndpoint() {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(suite.T(), err)
 
-	_, _, err = Initialize(
+	_, _, _, err = Initialize(
 		suite.mux, nil, testCacheManager(), suite.mockOUService, nil)
 	assert.NoError(suite.T(), err)
 
@@ -195,7 +195,7 @@ func (suite *InitTestSuite) TestInitialize_DBTransactionerError() {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(suite.T(), err)
 
-	_, _, err = Initialize(
+	_, _, _, err = Initialize(
 		suite.mux, nil, testCacheManager(), suite.mockOUService, nil)
 	assert.Error(suite.T(), err)
 	if err != nil {
@@ -219,7 +219,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_GetByIDEndpoint() {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(suite.T(), err)
 
-	_, _, err = Initialize(
+	_, _, _, err = Initialize(
 		suite.mux, nil, testCacheManager(), suite.mockOUService, nil)
 	assert.NoError(suite.T(), err)
 
@@ -247,7 +247,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_UpdateEndpoint() {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(suite.T(), err)
 
-	_, _, err = Initialize(
+	_, _, _, err = Initialize(
 		suite.mux, nil, testCacheManager(), suite.mockOUService, nil)
 	assert.NoError(suite.T(), err)
 
@@ -275,7 +275,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_DeleteEndpoint() {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(suite.T(), err)
 
-	_, _, err = Initialize(
+	_, _, _, err = Initialize(
 		suite.mux, nil, testCacheManager(), suite.mockOUService, nil)
 	assert.NoError(suite.T(), err)
 
@@ -303,7 +303,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_CORSPreflight() {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(suite.T(), err)
 
-	_, _, err = Initialize(
+	_, _, _, err = Initialize(
 		suite.mux, nil, testCacheManager(), suite.mockOUService, nil)
 	assert.NoError(suite.T(), err)
 
@@ -331,7 +331,7 @@ func (suite *InitTestSuite) TestRegisterRoutes_CORSPreflightByID() {
 	err := config.InitializeServerRuntime("", testConfig)
 	assert.NoError(suite.T(), err)
 
-	_, _, err = Initialize(
+	_, _, _, err = Initialize(
 		suite.mux, nil, testCacheManager(), suite.mockOUService, nil)
 	assert.NoError(suite.T(), err)
 
@@ -538,7 +538,7 @@ func TestInitialize_Standalone(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mockOUService := oumock.NewOrganizationUnitServiceInterfaceMock(t)
-	service, exporter, err := Initialize(mux, nil, testCacheManager(), mockOUService, nil)
+	service, exporter, _, err := Initialize(mux, nil, testCacheManager(), mockOUService, nil)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, service)
@@ -687,7 +687,7 @@ func TestInitialize_MutableMode(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mockOUService := oumock.NewOrganizationUnitServiceInterfaceMock(t)
-	service, exporter, err := Initialize(mux, nil, testCacheManager(), mockOUService, nil)
+	service, exporter, _, err := Initialize(mux, nil, testCacheManager(), mockOUService, nil)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, service)
@@ -728,7 +728,7 @@ func TestInitialize_StoreModes(t *testing.T) {
 			mockOUService.On("GetOrganizationUnit", mock.Anything, mock.Anything).
 				Return(providers.OrganizationUnit{ID: "ou-1"}, nil).
 				Maybe()
-			service, exporter, err := Initialize(mux, nil, testCacheManager(), mockOUService, nil)
+			service, exporter, _, err := Initialize(mux, nil, testCacheManager(), mockOUService, nil)
 
 			assert.NoError(t, err)
 			assert.NotNil(t, service)
@@ -1117,7 +1117,7 @@ func TestInitialize_WithDeclarativeResourcesEnabled_InvalidYAML(t *testing.T) {
 	mux := http.NewServeMux()
 	mockOUService := oumock.NewOrganizationUnitServiceInterfaceMock(t)
 	// Initialize should return an error due to invalid YAML
-	_, _, err = Initialize(mux, nil, testCacheManager(), mockOUService, nil)
+	_, _, _, err = Initialize(mux, nil, testCacheManager(), mockOUService, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load entity type resources")
 }
@@ -1175,7 +1175,7 @@ schema: |
 	mux := http.NewServeMux()
 	mockOUService := oumock.NewOrganizationUnitServiceInterfaceMock(t)
 	// Initialize should return an error due to validation failure
-	_, _, err = Initialize(mux, nil, testCacheManager(), mockOUService, nil)
+	_, _, _, err = Initialize(mux, nil, testCacheManager(), mockOUService, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load entity type resources")
 }
@@ -1247,7 +1247,7 @@ schema: |
 				DefaultValue: "The organization unit does not exist",
 			},
 		}).Once()
-	_, _, err = Initialize(mux, nil, testCacheManager(), mockOUService, nil)
+	_, _, _, err = Initialize(mux, nil, testCacheManager(), mockOUService, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load entity type resources")
 
@@ -1305,7 +1305,7 @@ schema: |
 	mux := http.NewServeMux()
 	mockOUService := oumock.NewOrganizationUnitServiceInterfaceMock(t)
 	// Initialize should return an error due to invalid JSON
-	_, _, err = Initialize(mux, nil, testCacheManager(), mockOUService, nil)
+	_, _, _, err = Initialize(mux, nil, testCacheManager(), mockOUService, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load entity type resources")
 }

--- a/backend/internal/system/export/handler_test.go
+++ b/backend/internal/system/export/handler_test.go
@@ -56,7 +56,7 @@ func (suite *HandlerTestSuite) SetupTest() {
 	exporters := []declarativeresource.ResourceExporter{
 		application.NewApplicationExporterForTest(suite.mockAppService),
 		connection.NewConnectionExporterForTest(suite.mockIDPService, suite.mockNotificationService),
-		entitytype.NewEntityTypeExporterForTest(suite.mockEntityTypeService),
+		entitytype.NewEntityTypeExporterForTest(suite.mockEntityTypeService, entitytype.TypeCategoryUser),
 	}
 	parameterizer := newParameterizer(templatingRules{})
 	suite.exportService = newExportService(exporters, parameterizer)
@@ -80,7 +80,7 @@ func TestNewExportHandler(t *testing.T) {
 	exporters := []declarativeresource.ResourceExporter{
 		application.NewApplicationExporterForTest(mockAppService),
 		connection.NewConnectionExporterForTest(mockIDPService, mockNotificationService),
-		entitytype.NewEntityTypeExporterForTest(mockEntityTypeService),
+		entitytype.NewEntityTypeExporterForTest(mockEntityTypeService, entitytype.TypeCategoryUser),
 	}
 	parameterizer := newParameterizer(templatingRules{})
 	exportService := newExportService(exporters, parameterizer)
@@ -434,7 +434,7 @@ func setupBenchmarkTest(b *testing.B) (*exportHandler, []byte) {
 	exporters := []declarativeresource.ResourceExporter{
 		application.NewApplicationExporterForTest(mockAppService),
 		connection.NewConnectionExporterForTest(mockIDPService, mockNotificationService),
-		entitytype.NewEntityTypeExporterForTest(mockEntityTypeService),
+		entitytype.NewEntityTypeExporterForTest(mockEntityTypeService, entitytype.TypeCategoryUser),
 	}
 	parameterizer := newParameterizer(templatingRules{})
 	exportService := newExportService(exporters, parameterizer)

--- a/backend/internal/system/export/init_test.go
+++ b/backend/internal/system/export/init_test.go
@@ -108,7 +108,7 @@ func createTestExporters(
 	return []declarativeresource.ResourceExporter{
 		application.NewApplicationExporterForTest(appService),
 		connection.NewConnectionExporterForTest(idpService, notificationService),
-		entitytype.NewEntityTypeExporterForTest(entityTypeService),
+		entitytype.NewEntityTypeExporterForTest(entityTypeService, entitytype.TypeCategoryUser),
 	}
 }
 

--- a/backend/internal/system/export/model.go
+++ b/backend/internal/system/export/model.go
@@ -11,6 +11,7 @@ type ExportRequest struct {
 	Applications      []string `json:"applications,omitempty"`
 	Connections       []string `json:"connections,omitempty"`
 	UserTypes         []string `json:"userTypes,omitempty"`
+	AgentTypes        []string `json:"agentTypes,omitempty"`
 	OrganizationUnits []string `json:"organizationUnits,omitempty"`
 	Users             []string `json:"users,omitempty"`
 	Groups            []string `json:"groups,omitempty"`

--- a/backend/internal/system/export/service.go
+++ b/backend/internal/system/export/service.go
@@ -30,6 +30,7 @@ const (
 	resourceTypeApplication    = "application"
 	resourceTypeConnection     = "connection"
 	resourceTypeUserType       = "user_type"
+	resourceTypeAgentType      = "agent_type"
 	resourceTypeOU             = "organization_unit"
 	resourceTypeUser           = "user"
 	resourceTypeGroup          = "group"
@@ -109,6 +110,7 @@ func (es *exportService) ExportResources(
 		resourceTypeApplication:    request.Applications,
 		resourceTypeConnection:     request.Connections,
 		resourceTypeUserType:       request.UserTypes,
+		resourceTypeAgentType:      request.AgentTypes,
 		resourceTypeOU:             request.OrganizationUnits,
 		resourceTypeUser:           request.Users,
 		resourceTypeGroup:          request.Groups,

--- a/backend/internal/system/export/service_test.go
+++ b/backend/internal/system/export/service_test.go
@@ -88,7 +88,7 @@ func (suite *ExportServiceTestSuite) SetupTest() {
 	exporters := []declarativeresource.ResourceExporter{
 		application.NewApplicationExporterForTest(suite.appServiceMock),
 		connection.NewConnectionExporterForTest(suite.idpServiceMock, suite.mockNotificationService),
-		entitytype.NewEntityTypeExporterForTest(suite.mockEntityTypeService),
+		entitytype.NewEntityTypeExporterForTest(suite.mockEntityTypeService, entitytype.TypeCategoryUser),
 		flowmgt.NewFlowGraphExporterForTest(suite.mockFlowService),
 	}
 
@@ -1169,7 +1169,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_TemplateGenerationError
 	exporters := []declarativeresource.ResourceExporter{
 		application.NewApplicationExporterForTest(suite.appServiceMock),
 		connection.NewConnectionExporterForTest(suite.idpServiceMock, suite.mockNotificationService),
-		entitytype.NewEntityTypeExporterForTest(suite.mockEntityTypeService),
+		entitytype.NewEntityTypeExporterForTest(suite.mockEntityTypeService, entitytype.TypeCategoryUser),
 	}
 
 	// Create a new export service with the mock parameterizer
@@ -1639,7 +1639,10 @@ func (suite *ExportServiceTestSuite) TestExportEntityTypes_Wildcard() {
 	}
 
 	suite.mockEntityTypeService.EXPECT().
-		GetEntityTypeList(mock.Anything, mock.Anything, 100, 0, mock.Anything).Return(mockSchemaList, nil)
+		GetEntityTypeList(mock.Anything, mock.Anything, 100, 0, mock.Anything).Return(mockSchemaList, nil).Once()
+	suite.mockEntityTypeService.EXPECT().
+		GetEntityTypeList(mock.Anything, mock.Anything, 100, 2, mock.Anything).
+		Return(&entitytype.EntityTypeListResponse{Types: []entitytype.EntityTypeListItem{}}, nil).Once()
 	suite.mockEntityTypeService.EXPECT().
 		GetEntityType(mock.Anything, mock.Anything, "schema1", mock.Anything).
 		Return(mockSchema1, nil)
@@ -1783,7 +1786,10 @@ func (suite *ExportServiceTestSuite) TestExportEntityTypes_WildcardPartialFailur
 	}
 
 	suite.mockEntityTypeService.EXPECT().
-		GetEntityTypeList(mock.Anything, mock.Anything, 100, 0, mock.Anything).Return(mockSchemaList, nil)
+		GetEntityTypeList(mock.Anything, mock.Anything, 100, 0, mock.Anything).Return(mockSchemaList, nil).Once()
+	suite.mockEntityTypeService.EXPECT().
+		GetEntityTypeList(mock.Anything, mock.Anything, 100, 3, mock.Anything).
+		Return(&entitytype.EntityTypeListResponse{Types: []entitytype.EntityTypeListItem{}}, nil).Once()
 	suite.mockEntityTypeService.EXPECT().
 		GetEntityType(mock.Anything, mock.Anything, "schema1", mock.Anything).
 		Return(mockSchema1, nil)

--- a/backend/internal/system/importer/parser.go
+++ b/backend/internal/system/importer/parser.go
@@ -15,6 +15,7 @@ import (
 const (
 	resourceTypeOrganizationUnit        = "organization_unit"
 	resourceTypeEntityType              = "user_type"
+	resourceTypeAgentType               = "agent_type"
 	resourceTypeResourceServer          = "resource_server"
 	resourceTypeRole                    = "role"
 	resourceTypeGroup                   = "group"
@@ -93,6 +94,7 @@ func isKnownResourceType(resourceType string) bool {
 	knownTypes := map[string]struct{}{
 		resourceTypeOrganizationUnit:        {},
 		resourceTypeEntityType:              {},
+		resourceTypeAgentType:               {},
 		resourceTypeResourceServer:          {},
 		resourceTypeRole:                    {},
 		resourceTypeConnection:              {},

--- a/backend/internal/system/importer/parser_resolver_test.go
+++ b/backend/internal/system/importer/parser_resolver_test.go
@@ -152,6 +152,21 @@ func TestParseDocuments_AgentWithOAuthNotClassifiedAsApplication(t *testing.T) {
 	assert.Equal(t, resourceTypeAgent, docs[0].ResourceType)
 }
 
+func TestParseDocuments_AgentTypeDocument(t *testing.T) {
+	content := strings.Join([]string{
+		"resource_type: agent_type",
+		"id: at-1",
+		"name: Test Agent Type",
+		"schema: '{}'",
+		"",
+	}, "\n")
+
+	docs, err := parseDocuments(content)
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	assert.Equal(t, resourceTypeAgentType, docs[0].ResourceType)
+}
+
 func TestParseDocuments_UsesResourceTypeField(t *testing.T) {
 	content := "resource_type: application\nname: idp-one\ntype: GOOGLE\nproperties: []\n"
 

--- a/backend/internal/system/importer/service.go
+++ b/backend/internal/system/importer/service.go
@@ -412,6 +412,8 @@ func (s *importService) importDocument(
 		return s.importOrganizationUnit(ctx, doc, options, dryRun)
 	case resourceTypeEntityType:
 		return s.importEntityType(ctx, doc, options, dryRun)
+	case resourceTypeAgentType:
+		return s.importEntityType(ctx, doc, options, dryRun)
 	case resourceTypeRole:
 		return s.importRole(ctx, doc, options, dryRun)
 	case resourceTypeGroup:
@@ -757,6 +759,7 @@ func (s *importService) importFlow(
 var resourceDependencyOrder = []string{
 	resourceTypeOrganizationUnit,
 	resourceTypeEntityType,
+	resourceTypeAgentType,
 	resourceTypeResourceServer,
 	resourceTypeConnection,
 	resourceTypeFlow,

--- a/backend/internal/system/importer/service_adapters.go
+++ b/backend/internal/system/importer/service_adapters.go
@@ -208,7 +208,11 @@ func (s *importService) importEntityType(
 
 	category := req.Category
 	if category == "" {
-		category = entitytype.TypeCategoryUser
+		if doc.ResourceType == resourceTypeAgentType {
+			category = entitytype.TypeCategoryAgent
+		} else {
+			category = entitytype.TypeCategoryUser
+		}
 	}
 	if !category.IsValid() {
 		return ImportItemOutcome{

--- a/backend/internal/system/importer/service_test.go
+++ b/backend/internal/system/importer/service_test.go
@@ -447,14 +447,15 @@ func (f *fakeLayoutService) UpdateLayout(_ context.Context,
 }
 
 type fakeEntityTypeService struct {
-	created []entitytype.CreateEntityTypeRequestWithID
-	updated []entitytype.UpdateEntityTypeRequest
-	byID    map[string]*entitytype.EntityType
-	byName  map[string]*entitytype.EntityType
+	created          []entitytype.CreateEntityTypeRequestWithID
+	updated          []entitytype.UpdateEntityTypeRequest
+	createCategories []entitytype.TypeCategory
+	byID             map[string]*entitytype.EntityType
+	byName           map[string]*entitytype.EntityType
 }
 
 func (f *fakeEntityTypeService) CreateEntityType(
-	_ context.Context, _ entitytype.TypeCategory, request entitytype.CreateEntityTypeRequestWithID,
+	_ context.Context, category entitytype.TypeCategory, request entitytype.CreateEntityTypeRequestWithID,
 ) (*entitytype.EntityType, *tidcommon.ServiceError) {
 	id := request.ID
 	if id == "" {
@@ -469,6 +470,7 @@ func (f *fakeEntityTypeService) CreateEntityType(
 		Schema:                request.Schema,
 	}
 	f.created = append(f.created, request)
+	f.createCategories = append(f.createCategories, category)
 	if f.byID == nil {
 		f.byID = map[string]*entitytype.EntityType{}
 	}
@@ -2189,6 +2191,100 @@ func TestImportResources_EntityTypeOUHandlePassedToService(t *testing.T) {
 	require.Len(t, entityTypeSvc.created, 1)
 	assert.Equal(t, "default", entityTypeSvc.created[0].OUHandle)
 	assert.Equal(t, "", entityTypeSvc.created[0].OUID)
+}
+
+func TestImportResources_AgentTypeDefaultsToAgentCategory(t *testing.T) {
+	entityTypeSvc := &fakeEntityTypeService{
+		byID:   map[string]*entitytype.EntityType{},
+		byName: map[string]*entitytype.EntityType{},
+	}
+	svc := newImportService(
+		nil, nil, nil, nil, nil, entityTypeSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+	)
+
+	content := strings.Join([]string{
+		"resource_type: agent_type",
+		"id: agtt-123",
+		"name: support-agent",
+		"ouId: ou-1",
+		"schema:",
+		"  type: object",
+		"  properties: {}",
+		"",
+	}, "\n")
+
+	resp, err := svc.ImportResources(context.Background(), &ImportRequest{Content: content})
+
+	require.Nil(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusSuccess, resp.Results[0].Status)
+	assert.Equal(t, operationCreate, resp.Results[0].Operation)
+	assert.Equal(t, "agtt-123", resp.Results[0].ResourceID)
+	require.Len(t, entityTypeSvc.created, 1)
+	assert.Equal(t, "agtt-123", entityTypeSvc.created[0].ID)
+	require.Len(t, entityTypeSvc.createCategories, 1)
+	assert.Equal(t, entitytype.TypeCategoryAgent, entityTypeSvc.createCategories[0])
+}
+
+func TestImportResources_AgentTypeExplicitCategoryTakesPrecedence(t *testing.T) {
+	entityTypeSvc := &fakeEntityTypeService{
+		byID:   map[string]*entitytype.EntityType{},
+		byName: map[string]*entitytype.EntityType{},
+	}
+	svc := newImportService(
+		nil, nil, nil, nil, nil, entityTypeSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+	)
+
+	content := strings.Join([]string{
+		"resource_type: agent_type",
+		"id: agtt-124",
+		"name: support-agent",
+		"category: user",
+		"ouId: ou-1",
+		"schema:",
+		"  type: object",
+		"  properties: {}",
+		"",
+	}, "\n")
+
+	resp, err := svc.ImportResources(context.Background(), &ImportRequest{Content: content})
+
+	require.Nil(t, err)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusSuccess, resp.Results[0].Status)
+	require.Len(t, entityTypeSvc.createCategories, 1)
+	assert.Equal(t, entitytype.TypeCategoryUser, entityTypeSvc.createCategories[0])
+}
+
+func TestImportResources_UserTypeExplicitAgentCategoryStillWorks(t *testing.T) {
+	entityTypeSvc := &fakeEntityTypeService{
+		byID:   map[string]*entitytype.EntityType{},
+		byName: map[string]*entitytype.EntityType{},
+	}
+	svc := newImportService(
+		nil, nil, nil, nil, nil, entityTypeSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+	)
+
+	content := strings.Join([]string{
+		"resource_type: user_type",
+		"id: usrs-124",
+		"name: support-agent",
+		"category: agent",
+		"ouId: ou-1",
+		"schema:",
+		"  type: object",
+		"  properties: {}",
+		"",
+	}, "\n")
+
+	resp, err := svc.ImportResources(context.Background(), &ImportRequest{Content: content})
+
+	require.Nil(t, err)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, statusSuccess, resp.Results[0].Status)
+	require.Len(t, entityTypeSvc.createCategories, 1)
+	assert.Equal(t, entitytype.TypeCategoryAgent, entityTypeSvc.createCategories[0])
 }
 
 func TestImportResources_StripsClientSecretForPublicClientWithNoneAuthMethod(t *testing.T) {

--- a/frontend/apps/console/src/features/import-export/components/ConfigureExport.tsx
+++ b/frontend/apps/console/src/features/import-export/components/ConfigureExport.tsx
@@ -87,6 +87,7 @@ export default function ConfigureExport({
   const [expandedConnections, setExpandedConnections] = useState(false);
   const [expandedOrgUnits, setExpandedOrgUnits] = useState(false);
   const [expandedSchemas, setExpandedSchemas] = useState(false);
+  const [expandedAgentTypes, setExpandedAgentTypes] = useState(false);
   const [expandedTranslations, setExpandedTranslations] = useState(false);
   const [expandedLayouts, setExpandedLayouts] = useState(false);
   const [expandedResourceServers, setExpandedResourceServers] = useState(false);
@@ -250,6 +251,8 @@ export default function ConfigureExport({
     (Array.isArray(configData?.organization_unit) ? configData.organization_unit.length : 0);
   const userTypesCount =
     resourceCounts?.user_type ?? (Array.isArray(configData?.user_type) ? configData.user_type.length : 0);
+  const agentTypesCount =
+    resourceCounts?.agent_type ?? (Array.isArray(configData?.agent_type) ? configData.agent_type.length : 0);
   const translationsCount =
     resourceCounts?.translation ?? (Array.isArray(configData?.translation) ? configData.translation.length : 0);
   const layoutsCount = resourceCounts?.layout ?? (Array.isArray(configData?.layout) ? configData.layout.length : 0);
@@ -683,6 +686,57 @@ export default function ConfigureExport({
                   size="small"
                   variant="outlined"
                   onClick={() => setExpandedSchemas(!expandedSchemas)}
+                  sx={{cursor: 'pointer'}}
+                />
+              </Box>
+            )}
+          </Stack>
+        </Box>
+      ),
+    });
+  }
+
+  // Add agent types if present
+  if (agentTypesCount > 0) {
+    const agentTypes = (configData?.agent_type as {name?: string; handle?: string}[]) ?? [];
+    const displayedAgentTypes = expandedAgentTypes ? agentTypes : agentTypes.slice(0, 5);
+    const remainingCount = agentTypes.length - 5;
+
+    items.push({
+      id: 'agent-types',
+      label: t('importExport:configureExport.labels.agentTypes', 'Agent Types'),
+      icon: <Bot size={16} />,
+      value: agentTypesCount,
+      status: 'ready',
+      dependencyCount: 0,
+      content: (
+        <Box sx={{px: 3, py: 2, bgcolor: 'background.default'}}>
+          <Stack spacing={2}>
+            <Stack spacing={2} divider={<Box sx={{borderBottom: 1, borderColor: 'divider'}} />}>
+              {displayedAgentTypes.map((agentType, idx) => (
+                <Stack key={agentType.handle ?? agentType.name ?? `agent-type-${idx}`} spacing={0.5}>
+                  <Stack direction="row" spacing={1} sx={{alignItems: 'center'}}>
+                    <Bot size={14} />
+                    <Typography variant="body2" fontWeight={600}>
+                      {agentType.name ??
+                        agentType.handle ??
+                        t('importExport:configureExport.fallback.unnamedAgentType', 'Unnamed agent type')}
+                    </Typography>
+                  </Stack>
+                </Stack>
+              ))}
+            </Stack>
+            {remainingCount > 0 && (
+              <Box sx={{pt: 1, textAlign: 'center'}}>
+                <Chip
+                  label={
+                    expandedAgentTypes
+                      ? t('importExport:configureExport.actions.showLess')
+                      : t('importExport:configureExport.actions.more', {count: remainingCount})
+                  }
+                  size="small"
+                  variant="outlined"
+                  onClick={() => setExpandedAgentTypes(!expandedAgentTypes)}
                   sx={{cursor: 'pointer'}}
                 />
               </Box>

--- a/frontend/apps/console/src/features/import-export/constants/resource-types.ts
+++ b/frontend/apps/console/src/features/import-export/constants/resource-types.ts
@@ -15,6 +15,7 @@ export const ALLOWED_RESOURCE_TYPES = [
   'connection',
   'organization_unit',
   'user_type',
+  'agent_type',
   'resource_server',
   'role',
   'agent',

--- a/frontend/apps/console/src/features/import-export/models/export-configuration.ts
+++ b/frontend/apps/console/src/features/import-export/models/export-configuration.ts
@@ -20,6 +20,10 @@ export interface ExportRequest {
    */
   userTypes?: string[];
   /**
+   * List of agent type IDs to export. Use `["*"]` to export all.
+   */
+  agentTypes?: string[];
+  /**
    * List of organization unit IDs to export. Use `["*"]` to export all.
    */
   organizationUnits?: string[];

--- a/frontend/apps/console/src/features/import-export/pages/ExportPage.tsx
+++ b/frontend/apps/console/src/features/import-export/pages/ExportPage.tsx
@@ -28,6 +28,7 @@ export default function ExportPage(): JSX.Element {
       users: ['*'],
       organizationUnits: ['*'],
       userTypes: ['*'],
+      agentTypes: ['*'],
       translations: ['*'],
       layouts: ['*'],
       resourceServers: ['*'],

--- a/frontend/apps/console/src/features/import-export/pages/ImportConfigurationSummaryPage.tsx
+++ b/frontend/apps/console/src/features/import-export/pages/ImportConfigurationSummaryPage.tsx
@@ -339,6 +339,24 @@ const RESOURCE_VIEWS: ResourceView[] = [
       ) : null,
   },
   {
+    type: 'agent_type',
+    id: 'agent-types',
+    icon: Bot,
+    getLabel: (t) => t('configureExport.labels.agentTypes'),
+    getKey: (item, idx) => item.handle ?? item.name ?? `agent-type-${idx}`,
+    getName: (item, t, idx) => item.name ?? item.handle ?? t('summary.fallback.agentType', {index: idx + 1}),
+    renderChip: (item, t) =>
+      item.allow_self_registration ? (
+        <Chip
+          label={t('configureExport.labels.selfRegistration')}
+          size="small"
+          color="success"
+          variant="outlined"
+          sx={{height: 18, fontSize: '0.65rem'}}
+        />
+      ) : null,
+  },
+  {
     type: 'agent',
     id: 'agents',
     icon: Bot,

--- a/frontend/apps/console/src/features/import-export/pages/__tests__/ImportConfigurationSummaryPage.test.tsx
+++ b/frontend/apps/console/src/features/import-export/pages/__tests__/ImportConfigurationSummaryPage.test.tsx
@@ -758,6 +758,7 @@ describe('ImportConfigurationSummaryPage', () => {
         translation: [{locale: 'fr-FR', namespace: 'common'}],
         user: [{type: 'customer', attributes: {name: 'Jane Doe', username: 'jane', email: 'jane@example.com'}}],
         user_type: [{name: 'Customer', handle: 'customer', allow_self_registration: true}],
+        agent_type: [{name: 'Enterprise Agent', handle: 'enterprise-agent', allow_self_registration: true}],
         agent: [
           {
             name: 'My Agent',
@@ -782,7 +783,8 @@ describe('ImportConfigurationSummaryPage', () => {
       expect(screen.getByText('OIDC')).toBeInTheDocument();
       expect(screen.getByText('SMTP')).toBeInTheDocument();
       expect(screen.getByText('customer')).toBeInTheDocument();
-      expect(screen.getByText('configureExport.labels.selfRegistration')).toBeInTheDocument();
+      expect(screen.getAllByText('configureExport.labels.selfRegistration')).toHaveLength(2);
+      expect(screen.getByText('Enterprise Agent')).toBeInTheDocument();
 
       // Handle detail lines shown when distinct from the name.
       expect(screen.getByText('login-flow')).toBeInTheDocument();
@@ -834,6 +836,7 @@ describe('ImportConfigurationSummaryPage', () => {
         flow: [{}],
         theme: [{}],
         user_type: [{}],
+        agent_type: [{}],
         translation: [{}],
         user: [{}],
         group: [{}],
@@ -844,6 +847,7 @@ describe('ImportConfigurationSummaryPage', () => {
       expect(screen.getByText('summary.fallback.flow')).toBeInTheDocument();
       expect(screen.getByText('summary.fallback.theme')).toBeInTheDocument();
       expect(screen.getByText('summary.fallback.schema')).toBeInTheDocument();
+      expect(screen.getByText('summary.fallback.agentType')).toBeInTheDocument();
       expect(screen.getByText('configureExport.fallback.unnamedTranslation')).toBeInTheDocument();
       expect(screen.getByText('summary.fallback.user')).toBeInTheDocument();
       expect(screen.getByText('configureExport.fallback.unnamedGroup')).toBeInTheDocument();

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -3152,6 +3152,8 @@ const translations = {
     'configureExport.fallback.unnamedCredentialConfiguration': 'Unnamed Credential Configuration',
     'configureExport.labels.agents': 'Agents',
     'configureExport.fallback.unnamedAgent': 'Unnamed Agent',
+    'configureExport.fallback.unnamedAgentType': 'Unnamed agent type',
+    'configureExport.labels.agentTypes': 'Agent Types',
     'configureExport.labels.serverConfigs': 'Server Configurations',
     'configureExport.fallback.unnamedServerConfig': 'Unnamed Server Configuration',
     'configureExport.fallback.unnamedUser': 'User {{index}}',
@@ -3182,6 +3184,7 @@ const translations = {
     'summary.fallback.theme': 'Theme {{index}}',
     'summary.fallback.user': 'User {{index}}',
     'summary.fallback.schema': 'Schema {{index}}',
+    'summary.fallback.agentType': 'Agent Type {{index}}',
     'summary.precheck.readyNoEnvRequired': 'Ready to proceed. No environment values are required for this import.',
     'summary.precheck.readyAllEnvAvailable':
       'Ready to proceed. All {{count}} referenced environment values are available.',


### PR DESCRIPTION
## Summary
- Make the entity type exporter category-aware so agent type schemas can be exported alongside user types
- Add `agentTypes` field to the export API request and wire it through the export service
- Update the Console export page to request and display agent types

### Related Issue(s)
- https://github.com/thunder-id/thunderid/issues/4645

## Test plan
- [ ] Verify `POST /export` with `{"agentTypes": ["*"]}` returns agent type schemas with `resource_type: agent_type`
- [ ] Verify the exported YAML can be re-imported via `POST /import` as mutable resources
- [ ] Verify the Console Import/Export page shows agent types in the export results
- [ ] Verify existing user type export is unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for exporting and importing agent types alongside existing configuration resources.
  * Agent types can be selected individually or exported in bulk.
  * Export summaries display agent type names, icons, counts, and expandable details.
  * Added `agent_type` to supported import/export resource types.
* **Improvements**
  * Resource discovery now retrieves complete paginated results while excluding read-only types.
  * Imports automatically categorize agent-type resources appropriately while respecting explicit categories.
  * Export configuration consistently includes selected agent types in generated exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->