### PR TITLE
Add per request CSP nonces for script and style src

### DIFF
--- a/backend/cmd/server/config/resources/server_configs/csp.yaml
+++ b/backend/cmd/server/config/resources/server_configs/csp.yaml
@@ -1,59 +1,56 @@
 resource_type: server_config
 name: csp
 value:
-  # Enforcing. This policy applies only to the Console and Gate applications (/console/ and /gate/);
-  # all other responses (APIs, OAuth2 endpoints) receive no Content-Security-Policy header at all.
-  # Each path policy's directives replace the matching baseline directives for that path.
+  # Enforcing. Applies only to /console/ and /gate/; all other responses (APIs, OAuth2) get no CSP
+  # header. Each path policy's directives replace the matching baseline directive for that path.
   reportOnly: false
   paths:
     # Console application.
     - location: "/console/"
       directives:
-        # 'unsafe-inline' is TEMPORARY: it covers oxygen-ui/MUI/Emotion inline style injection until
-        # nonce-based styling is introduced. Remove 'unsafe-inline' once inline styles are nonce-tagged.
-        style-src:
+        # Governs <style> elements and stylesheet links.
+        style-src-elem:
           - "'self'"
-          - "'unsafe-inline'"
           - "https://fonts.googleapis.com"
-        # 'data:' covers inline library images; 'https:' is a TEMPORARY broad allowance for arbitrary
-        # tenant-supplied images. Tighten to a proxy or operator allowlist later.
+          - "'unsafe-inline'" # Needed for the embedded Monaco editor (Custom CSS, JWT claims, Import/Export viewers), which has no CSP nonce support (monaco-editor#271).
+        # Governs inline style="" attributes; these can't carry a nonce at all per spec.
+        style-src-attr:
+          - "'self'"
+          - "'unsafe-inline'" # Needed for React/MUI's style={{}} usage.
         img-src:
           - "'self'"
-          - "data:"
-          - "https:"
-        # 'data:' covers a bundled library font self-hosted as a base64 URI.
-        # fonts.gstatic.com serves the actual font files referenced by the fonts.googleapis.com stylesheet.
+          - "data:" # Inline library images.
+          - "https:" # TEMPORARY: arbitrary tenant-supplied images. Tighten to a proxy or operator allowlist later.
         font-src:
           - "'self'"
-          - "data:"
-          - "https://fonts.gstatic.com"
-        # The Console welcome page fetches release metadata from thunderid.dev.
-        # fonts.googleapis.com and fonts.gstatic.com are needed for the GatePreview iframe's preconnect.
+          - "data:" # Bundled library font self-hosted as a base64 URI.
+          - "https://fonts.gstatic.com" # Font files referenced by the fonts.googleapis.com stylesheet.
         connect-src:
           - "'self'"
-          - "https://thunderid.dev"
-          - "https://fonts.googleapis.com"
-          - "https://fonts.gstatic.com"
-        # The Monaco code editor instantiates web workers, which the build may emit as blob URLs.
+          - "https://thunderid.dev" # Console welcome page's release metadata fetch.
+          - "https://fonts.googleapis.com" # GatePreview iframe preconnect.
+          - "https://fonts.gstatic.com" # GatePreview iframe preconnect.
+        # Controls allowed sources for worker scripts.
         worker-src:
           - "'self'"
-          - "blob:"
+          - "blob:" # Monaco instantiates web workers, which the build may emit as blob URLs.
     # Gate application.
     - location: "/gate/"
       directives:
-        # See the Console entry above: 'unsafe-inline' is TEMPORARY (oxygen-ui/MUI/Emotion).
-        style-src:
+        # Governs <style> elements and stylesheet links.
+        style-src-elem:
           - "'self'"
-          - "'unsafe-inline'"
           - "https://fonts.googleapis.com"
-        # TEMPORARY broad allowance for arbitrary tenant-supplied images.
+          # No 'unsafe-inline': Gate doesn't embed Monaco, so it keeps the strict nonce-only policy.
+        # Governs inline style="" attributes; these can't carry a nonce at all per spec.
+        style-src-attr:
+          - "'self'"
+          - "'unsafe-inline'" # Needed for React/MUI's style={{}} usage.
         img-src:
           - "'self'"
           - "data:"
-          - "https:"
-        # 'data:' covers a bundled library font self-hosted as a base64 URI.
-        # fonts.gstatic.com serves the actual font files referenced by the fonts.googleapis.com stylesheet.
+          - "https:" # TEMPORARY: arbitrary tenant-supplied images. Tighten to a proxy or operator allowlist later.
         font-src:
           - "'self'"
-          - "data:"
-          - "https://fonts.gstatic.com"
+          - "data:" # Bundled library font self-hosted as a base64 URI.
+          - "https://fonts.gstatic.com" # Font files referenced by the fonts.googleapis.com stylesheet.

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -24,6 +25,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/cache"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/constants"
+	sysContext "github.com/thunder-id/thunderid/internal/system/context"
 	"github.com/thunder-id/thunderid/internal/system/database/provider"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
 	"github.com/thunder-id/thunderid/internal/system/kmprovider/common"
@@ -371,16 +373,23 @@ func createStaticFileHandler(routePrefix, directory string, logger *log.Logger) 
 	rootFS := root.FS()
 	fileServer := http.FileServerFS(rootFS)
 
-	// serveIndex serves index.html with no-cache headers. It reports whether index.html
-	// existed and was served.
+	// serveIndex serves index.html with no-cache headers, substituting the request's CSP nonce
+	// (see SecurityHeadersMiddleware) for the placeholder in its <meta property="csp-nonce"> tag, so
+	// the frontend can apply the same nonce to its own inline <style> tags. It reports whether
+	// index.html existed and was served.
 	serveIndex := func(w http.ResponseWriter, r *http.Request) bool {
-		if _, err := root.Stat("index.html"); err != nil {
+		content, err := fs.ReadFile(rootFS, "index.html")
+		if err != nil {
 			return false
 		}
+		nonce := sysContext.GetCSPNonce(r.Context())
+		content = bytes.ReplaceAll(content, []byte(constants.CSPNoncePlaceholder), []byte(nonce))
+
 		w.Header().Set(constants.CacheControlHeaderName, constants.CacheControlNoCacheComposite)
 		w.Header().Set(constants.PragmaHeaderName, constants.PragmaNoCache)
 		w.Header().Set(constants.ExpiresHeaderName, constants.ExpiresZero)
-		http.ServeFileFS(w, r, rootFS, "index.html")
+		w.Header().Set(constants.ContentTypeHeaderName, constants.ContentTypeHTML)
+		_, _ = w.Write(content)
 		return true
 	}
 

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/constants"
+	sysContext "github.com/thunder-id/thunderid/internal/system/context"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/tests/mocks/jose/jwtmock"
 )
@@ -441,6 +442,39 @@ func TestCreateStaticFileHandler_CacheHeaders(t *testing.T) {
 		assert.Empty(t, rr.Header().Get(constants.ExpiresHeaderName),
 			"Expires should not be set for files that contain 'index.html' but are not exactly 'index.html'")
 		assert.Equal(t, string(customIndexFile), rr.Body.String())
+	})
+}
+
+func TestCreateStaticFileHandler_CSPNonce(t *testing.T) {
+	logger := log.GetLogger()
+	tmpDir := t.TempDir()
+
+	requireWriteFile(t, filepath.Join(tmpDir, "index.html"),
+		[]byte(`<meta property="csp-nonce" content="__CSP_NONCE__" />`))
+
+	handler, err := createStaticFileHandler("/app/", tmpDir, logger)
+	require.NoError(t, err)
+
+	t.Run("substitutes the placeholder with the request's nonce", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/app/", nil)
+		req = req.WithContext(sysContext.WithCSPNonce(req.Context(), "abc123"))
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, `<meta property="csp-nonce" content="abc123" />`, rr.Body.String())
+		assert.NotContains(t, rr.Body.String(), constants.CSPNoncePlaceholder)
+		assert.Equal(t, constants.ContentTypeHTML, rr.Header().Get(constants.ContentTypeHeaderName))
+	})
+
+	t.Run("leaves the placeholder empty when no nonce is in context", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/app/", nil)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, `<meta property="csp-nonce" content="" />`, rr.Body.String())
 	})
 }
 

--- a/backend/internal/system/constants/server_constants.go
+++ b/backend/internal/system/constants/server_constants.go
@@ -70,6 +70,13 @@ const ContentSecurityPolicyHeaderName = "Content-Security-Policy"
 // ContentSecurityPolicyReportOnlyHeaderName is the name of the Content-Security-Policy-Report-Only header.
 const ContentSecurityPolicyReportOnlyHeaderName = "Content-Security-Policy-Report-Only"
 
+// ContentTypeHTML is the content type for HTML documents.
+const ContentTypeHTML = "text/html; charset=utf-8"
+
+// CSPNoncePlaceholder is the token in index.html that serveIndex replaces with the per-request CSP
+// nonce, so the frontend's own inline <style> tags can read it from the resulting meta tag.
+const CSPNoncePlaceholder = "__CSP_NONCE__"
+
 // CacheControlHeaderName is the name of the cache-control header used in HTTP responses.
 const CacheControlHeaderName = "Cache-Control"
 

--- a/backend/internal/system/context/context.go
+++ b/backend/internal/system/context/context.go
@@ -15,6 +15,9 @@ type contextKey string
 const (
 	// TraceIDKey is the context key for storing the trace ID (correlation ID).
 	TraceIDKey contextKey = "trace_id"
+
+	// CSPNonceKey is the context key for storing the per-request Content-Security-Policy nonce.
+	CSPNonceKey contextKey = "csp_nonce"
 )
 
 // ============================================================================
@@ -79,4 +82,27 @@ func EnsureTraceID(ctx context.Context) context.Context {
 	}
 
 	return ctx
+}
+
+// ============================================================================
+// CSP Nonce Functions
+// ============================================================================
+
+// GetCSPNonce retrieves the Content-Security-Policy nonce from the context. Returns "" if absent; it
+// does not generate one, since the nonce must be generated once per request by the middleware that
+// also emits it in the CSP header.
+func GetCSPNonce(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	nonce, _ := ctx.Value(CSPNonceKey).(string)
+	return nonce
+}
+
+// WithCSPNonce adds the Content-Security-Policy nonce to the context.
+func WithCSPNonce(ctx context.Context, nonce string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, CSPNonceKey, nonce)
 }

--- a/backend/internal/system/context/context_test.go
+++ b/backend/internal/system/context/context_test.go
@@ -241,3 +241,26 @@ func (s *ContextTestSuite) TestGenerateUUID_MultipleGenerations() {
 		seen[uuid] = true
 	}
 }
+
+func (s *ContextTestSuite) TestGetCSPNonce_WithNilContext() {
+	s.Equal("", GetCSPNonce(nil)) //nolint:staticcheck // Testing nil context handling
+}
+
+func (s *ContextTestSuite) TestGetCSPNonce_WithEmptyContext() {
+	s.Equal("", GetCSPNonce(context.Background()))
+}
+
+func (s *ContextTestSuite) TestGetCSPNonce_WithExistingNonce() {
+	ctx := WithCSPNonce(context.Background(), "abc123")
+	s.Equal("abc123", GetCSPNonce(ctx))
+}
+
+func (s *ContextTestSuite) TestGetCSPNonce_WithWrongType() {
+	ctx := context.WithValue(context.Background(), CSPNonceKey, 12345)
+	s.Equal("", GetCSPNonce(ctx))
+}
+
+func (s *ContextTestSuite) TestWithCSPNonce_NilContext() {
+	ctx := WithCSPNonce(nil, "abc123") //nolint:staticcheck // Testing nil context handling
+	s.Equal("abc123", GetCSPNonce(ctx))
+}

--- a/backend/internal/system/csp/policy.go
+++ b/backend/internal/system/csp/policy.go
@@ -99,9 +99,36 @@ func (c PolicyConfig) effectiveDirectives(path string) map[string][]string {
 	return eff
 }
 
+// nonceDirectives are the directives the per-request nonce is appended to. style-src-attr (inline
+// style="" attributes) is deliberately excluded: attributes can't carry a nonce per spec, and it needs
+// 'unsafe-inline' for React/MUI's style={{}} usage, which a nonce elsewhere wouldn't affect since it's
+// a separate directive.
+var nonceDirectives = map[string]struct{}{"script-src": {}, "style-src-elem": {}}
+
+// sourcesWithNonce appends a 'nonce-<value>' token to sources for a nonce directive, without mutating
+// the caller's slice (a config value shared across concurrent requests). Leaves sources untouched if
+// 'unsafe-inline' is already there: per spec, a nonce present in a directive makes browsers ignore
+// 'unsafe-inline' in that same directive, so appending one would defeat an operator's relaxation
+// instead of tightening it (see csp.yaml's Console entry for why that relaxation exists).
+func sourcesWithNonce(name string, sources []string, nonce string) []string {
+	if _, ok := nonceDirectives[name]; !ok || nonce == "" {
+		return sources
+	}
+	for _, source := range sources {
+		if source == "'unsafe-inline'" {
+			return sources
+		}
+	}
+	withNonce := make([]string, len(sources)+1)
+	copy(withNonce, sources)
+	withNonce[len(sources)] = "'nonce-" + nonce + "'"
+	return withNonce
+}
+
 // HeaderValue renders the effective policy for a request path, followed by a report-uri directive when
-// a report endpoint is set.
-func (c PolicyConfig) HeaderValue(path string) string {
+// a report endpoint is set. nonce, generated fresh per request by the middleware, is appended to each
+// directive in nonceDirectives.
+func (c PolicyConfig) HeaderValue(path string, nonce string) string {
 	overrides := c.effectiveDirectives(path)
 	baselineNames := make(map[string]struct{}, len(baseline))
 	directives := make([]string, 0, len(baseline)+len(overrides)+1)
@@ -112,6 +139,7 @@ func (c PolicyConfig) HeaderValue(path string) string {
 		if override, ok := overrides[d.name]; ok {
 			sources = override
 		}
+		sources = sourcesWithNonce(d.name, sources, nonce)
 		directives = append(directives, d.name+" "+strings.Join(sources, " "))
 	}
 
@@ -124,7 +152,8 @@ func (c PolicyConfig) HeaderValue(path string) string {
 	}
 	sort.Strings(extraNames)
 	for _, name := range extraNames {
-		directives = append(directives, name+" "+strings.Join(overrides[name], " "))
+		sources := sourcesWithNonce(name, overrides[name], nonce)
+		directives = append(directives, name+" "+strings.Join(sources, " "))
 	}
 
 	if c.ReportURI != "" {

--- a/backend/internal/system/csp/policy_test.go
+++ b/backend/internal/system/csp/policy_test.go
@@ -4,6 +4,7 @@
 package csp
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,7 +27,7 @@ func TestPolicyConfig_HeaderName(t *testing.T) {
 }
 
 func TestPolicyConfig_HeaderValue_Baseline(t *testing.T) {
-	got := PolicyConfig{}.HeaderValue("/anything")
+	got := PolicyConfig{}.HeaderValue("/anything", "")
 	assert.Equal(t,
 		"default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src 'self'; "+
 			"frame-ancestors 'none'; base-uri 'none'; form-action 'self'",
@@ -41,7 +42,7 @@ func TestPolicyConfig_HeaderValue_DefaultOverride(t *testing.T) {
 			"style-src": {"'self'", "'unsafe-inline'", "https://fonts.googleapis.com"},
 			"font-src":  {"'self'", "https://fonts.gstatic.com"},
 		},
-	}.HeaderValue("/anything")
+	}.HeaderValue("/anything", "")
 
 	// An overridden baseline directive is replaced, not appended to.
 	assert.Contains(t, got, "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com")
@@ -61,9 +62,9 @@ func TestPolicyConfig_HeaderValue_PerPath(t *testing.T) {
 		},
 	}
 
-	console := cfg.HeaderValue("/console/apps")
-	gate := cfg.HeaderValue("/gate/signin")
-	api := cfg.HeaderValue("/oauth2/token")
+	console := cfg.HeaderValue("/console/apps", "")
+	gate := cfg.HeaderValue("/gate/signin", "")
+	api := cfg.HeaderValue("/oauth2/token", "")
 
 	// Default directive applies everywhere.
 	for _, h := range []string{console, gate, api} {
@@ -84,13 +85,77 @@ func TestPolicyConfig_HeaderValue_LongestPrefixWins(t *testing.T) {
 		{Location: "/console/", Directives: map[string][]string{"img-src": {"'self'"}}},
 		{Location: "/console/design/", Directives: map[string][]string{"img-src": {"'self'", "https:"}}},
 	}}
-	assert.Contains(t, cfg.HeaderValue("/console/design/themes"), "img-src 'self' https:")
-	assert.Contains(t, cfg.HeaderValue("/console/apps"), "img-src 'self';")
+	assert.Contains(t, cfg.HeaderValue("/console/design/themes", ""), "img-src 'self' https:")
+	assert.Contains(t, cfg.HeaderValue("/console/apps", ""), "img-src 'self';")
 }
 
 func TestPolicyConfig_HeaderValue_ReportURI(t *testing.T) {
-	got := PolicyConfig{ReportURI: "https://collector.example.com/csp"}.HeaderValue("/x")
+	got := PolicyConfig{ReportURI: "https://collector.example.com/csp"}.HeaderValue("/x", "")
 	assert.Contains(t, got, "report-uri https://collector.example.com/csp")
+}
+
+func TestPolicyConfig_HeaderValue_Nonce(t *testing.T) {
+	t.Run("appended to style-src-elem when configured", func(t *testing.T) {
+		cfg := PolicyConfig{
+			Directives: map[string][]string{"style-src-elem": {"'self'", "https://fonts.googleapis.com"}},
+		}
+		got := cfg.HeaderValue("/console/apps", "abc123")
+		assert.Contains(t, got, "style-src-elem 'self' https://fonts.googleapis.com 'nonce-abc123'")
+	})
+
+	t.Run("also appended to the baseline script-src, since it never carries unsafe-inline", func(t *testing.T) {
+		cfg := PolicyConfig{Directives: map[string][]string{"style-src-elem": {"'self'"}}}
+		got := cfg.HeaderValue("/console/apps", "abc123")
+		assert.Contains(t, got, "script-src 'self' 'nonce-abc123'")
+	})
+
+	t.Run("not appended to other directives, notably plain style-src", func(t *testing.T) {
+		cfg := PolicyConfig{Directives: map[string][]string{"style-src-elem": {"'self'"}}}
+		got := cfg.HeaderValue("/console/apps", "abc123")
+		assert.NotContains(t, got, "style-src 'self' 'nonce-abc123'")
+		assert.NotContains(t, got, "img-src 'self' 'nonce-abc123'")
+	})
+
+	t.Run("empty nonce adds nothing", func(t *testing.T) {
+		cfg := PolicyConfig{Directives: map[string][]string{"style-src-elem": {"'self'"}}}
+		got := cfg.HeaderValue("/console/apps", "")
+		assert.NotContains(t, got, "nonce-")
+	})
+
+	t.Run("does not mutate the configured directive slice", func(t *testing.T) {
+		sources := []string{"'self'"}
+		cfg := PolicyConfig{Directives: map[string][]string{"style-src-elem": sources}}
+
+		cfg.HeaderValue("/console/apps", "first")
+		cfg.HeaderValue("/console/apps", "second")
+
+		assert.Equal(t, []string{"'self'"}, sources, "the caller's slice must be left untouched")
+	})
+
+	t.Run("per-path style-src-elem override also receives the nonce", func(t *testing.T) {
+		cfg := PolicyConfig{Paths: []PathPolicy{
+			{Location: "/gate/", Directives: map[string][]string{"style-src-elem": {"'self'"}}},
+		}}
+		got := cfg.HeaderValue("/gate/signin", "abc123")
+		assert.Contains(t, got, "style-src-elem 'self' 'nonce-abc123'")
+	})
+
+	t.Run("not appended when 'unsafe-inline' is already configured on the directive", func(t *testing.T) {
+		cfg := PolicyConfig{
+			Directives: map[string][]string{"style-src-elem": {"'self'", "'unsafe-inline'"}},
+		}
+		got := cfg.HeaderValue("/console/apps", "abc123")
+		directives := strings.Split(got, "; ")
+		assert.Contains(t, directives, "style-src-elem 'self' 'unsafe-inline'")
+	})
+
+	t.Run("the unsafe-inline guard is per directive: script-src still gets the nonce", func(t *testing.T) {
+		cfg := PolicyConfig{
+			Directives: map[string][]string{"style-src-elem": {"'self'", "'unsafe-inline'"}},
+		}
+		got := cfg.HeaderValue("/console/apps", "abc123")
+		assert.Contains(t, got, "script-src 'self' 'nonce-abc123'")
+	})
 }
 
 func TestPolicyConfig_Validate(t *testing.T) {

--- a/backend/internal/system/middleware/securityheaders.go
+++ b/backend/internal/system/middleware/securityheaders.go
@@ -4,10 +4,13 @@
 package middleware
 
 import (
+	"crypto/rand"
+	"encoding/base64"
 	"net/http"
 	"strings"
 
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
+	sysContext "github.com/thunder-id/thunderid/internal/system/context"
 	"github.com/thunder-id/thunderid/internal/system/csp"
 )
 
@@ -20,14 +23,20 @@ var cspAppPathPrefixes = []string{"/gate/", "/console/"}
 // Content-Security-Policy to Gate and Console responses. The effective CSP policy is resolved per
 // request from the csp server-config section, falling back to the deny-first baseline in report-only
 // mode when unset. X-Frame-Options stays global since, unlike CSP, it has no report-only mode.
+//
+// A fresh nonce is generated per request and both embedded in the CSP header's style-src-elem
+// directive and stored in the request context, so a downstream handler (serveIndex) can render it
+// into the HTML response for the frontend to apply to its own inline <style> tags.
 func SecurityHeadersMiddleware() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set(serverconst.XFrameOptionsHeaderName, serverconst.XFrameOptionsDeny)
 
 			if isCSPAppPath(r.URL.Path) {
+				nonce := generateNonce()
+				r = r.WithContext(sysContext.WithCSPNonce(r.Context(), nonce))
 				policy := csp.Resolve(r.Context())
-				w.Header().Set(policy.HeaderName(), policy.HeaderValue(r.URL.Path))
+				w.Header().Set(policy.HeaderName(), policy.HeaderValue(r.URL.Path, nonce))
 			}
 
 			next.ServeHTTP(w, r)
@@ -43,4 +52,15 @@ func isCSPAppPath(path string) bool {
 		}
 	}
 	return false
+}
+
+// generateNonce returns a fresh base64-encoded random value for the CSP nonce. It must be
+// regenerated for every response, never reused, so a leaked nonce from one response cannot
+// authorize content in another.
+func generateNonce() string {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		panic(err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf)
 }

--- a/backend/internal/system/middleware/securityheaders_test.go
+++ b/backend/internal/system/middleware/securityheaders_test.go
@@ -7,11 +7,13 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
+	sysContext "github.com/thunder-id/thunderid/internal/system/context"
 	"github.com/thunder-id/thunderid/internal/system/csp"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 )
@@ -63,7 +65,10 @@ func TestSecurityHeadersMiddleware_DefaultReportOnlyBaseline(t *testing.T) {
 	}
 	assert.NotContains(t, policy, "unsafe-inline")
 	assert.NotContains(t, policy, "unsafe-eval")
-	assert.NotContains(t, policy, "nonce-")
+	// script-src always carries a nonce, even with zero csp config, since it never carries
+	// unsafe-inline. style-src-elem isn't configured here, so style-src stays nonce-free.
+	assert.Regexp(t, `script-src 'self' 'nonce-[A-Za-z0-9_-]+'`, policy)
+	assert.NotContains(t, policy, "style-src 'self' 'nonce-")
 
 	// X-Frame-Options is always enforced.
 	assert.Equal(t, serverconst.XFrameOptionsDeny, rr.Header().Get(serverconst.XFrameOptionsHeaderName))
@@ -110,6 +115,59 @@ func TestSecurityHeadersMiddleware_PerPath(t *testing.T) {
 	console := serve("/console/apps").Header().Get(serverconst.ContentSecurityPolicyHeaderName)
 	assert.NotContains(t, console, "unsafe-inline")
 	assert.Contains(t, console, "style-src 'self';")
+}
+
+// cspNoncePattern matches the 'nonce-<value>' token this package emits into style-src-elem.
+var cspNoncePattern = regexp.MustCompile(`'nonce-([A-Za-z0-9_-]+)'`)
+
+func TestSecurityHeadersMiddleware_Nonce(t *testing.T) {
+	csp.InitializeConfigReader(fakeCSPReader{cfg: csp.PolicyConfig{
+		ReportOnly: boolPtr(false),
+		Directives: map[string][]string{"style-src-elem": {"'self'"}},
+	}})
+	t.Cleanup(func() { csp.InitializeConfigReader(nil) })
+
+	t.Run("header carries a nonce token on style-src-elem", func(t *testing.T) {
+		policy := serve("/console/apps").Header().Get(serverconst.ContentSecurityPolicyHeaderName)
+		match := cspNoncePattern.FindStringSubmatch(policy)
+		assert.NotNil(t, match, "expected a 'nonce-<value>' token in: %s", policy)
+		assert.NotEmpty(t, match[1])
+	})
+
+	t.Run("nonce is unique per request", func(t *testing.T) {
+		first := cspNoncePattern.FindStringSubmatch(
+			serve("/console/apps").Header().Get(serverconst.ContentSecurityPolicyHeaderName))
+		second := cspNoncePattern.FindStringSubmatch(
+			serve("/console/apps").Header().Get(serverconst.ContentSecurityPolicyHeaderName))
+		assert.NotEqual(t, first[1], second[1])
+	})
+
+	t.Run("the same nonce reaches both the header and the request context", func(t *testing.T) {
+		var fromContext string
+		handler := SecurityHeadersMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fromContext = sysContext.GetCSPNonce(r.Context())
+			w.WriteHeader(http.StatusOK)
+		}))
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/console/apps", nil))
+
+		policy := rr.Header().Get(serverconst.ContentSecurityPolicyHeaderName)
+		match := cspNoncePattern.FindStringSubmatch(policy)
+		assert.NotNil(t, match)
+		assert.Equal(t, match[1], fromContext)
+		assert.NotEmpty(t, fromContext)
+	})
+
+	t.Run("non-app paths get no nonce in context", func(t *testing.T) {
+		var fromContext string
+		handler := SecurityHeadersMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fromContext = sysContext.GetCSPNonce(r.Context())
+			w.WriteHeader(http.StatusOK)
+		}))
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/oauth2/token", nil))
+		assert.Empty(t, fromContext)
+	})
 }
 
 func TestSecurityHeadersMiddleware_ScopedToConsoleAndGate(t *testing.T) {

--- a/frontend/apps/console/index.html
+++ b/frontend/apps/console/index.html
@@ -9,6 +9,10 @@
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
 
+    <!-- Content-Security-Policy nonce for this response, substituted by the server. Read by the
+         frontend to authorize its own inline <style> tags under a nonce-based style-src-elem. -->
+    <meta property="csp-nonce" content="__CSP_NONCE__" />
+
     <!-- Start of loading application configurations -->
     <script type="text/javascript" src="/config.js"></script>
     <!-- End of loading application configurations -->

--- a/frontend/apps/console/src/components/GatePreview/GatePreview.tsx
+++ b/frontend/apps/console/src/components/GatePreview/GatePreview.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import type {ColorSchemeOption, Stylesheet, Theme} from '@thunderid/design';
+import {getCspNonce, type ColorSchemeOption, type Stylesheet, type Theme} from '@thunderid/design';
 import type {EmbeddedFlowComponent} from '@thunderid/react';
 import {Box, CircularProgress, IconButton, Tooltip, Typography, useColorScheme} from '@wso2/oxygen-ui';
 import {useCallback, useLayoutEffect, useRef, useState, type JSX, type ReactNode} from 'react';
@@ -34,14 +34,18 @@ const MIN_CONTENT_WIDTH = 520;
 const MIN_CONTENT_HEIGHT = 700;
 
 /**
- * Initial HTML written into the preview iframe. Sets up the full height chain
- * so AuthPageLayout's minHeight: 100% resolves correctly.
+ * Initial HTML written into the preview iframe. Sets up the full height chain so AuthPageLayout's
+ * minHeight: 100% resolves correctly. Its <style> tag carries the parent document's CSP nonce: this
+ * iframe has no src (an about:blank doc written to directly), so it inherits the parent's CSP,
+ * including this exact nonce value, rather than carrying its own.
  */
-const IFRAME_INITIAL_HTML = [
-  '<!DOCTYPE html><html style="height:100%"><head>',
-  '<style>body{margin:0;height:100%}#root,#root>*{height:100%}</style>',
-  '</head><body><div id="root"></div></body></html>',
-].join('');
+function buildIframeInitialHTML(nonce: string | undefined): string {
+  return [
+    '<!DOCTYPE html><html style="height:100%"><head>',
+    `<style${nonce ? ` nonce="${nonce}"` : ''}>body{margin:0;height:100%}#root,#root>*{height:100%}</style>`,
+    '</head><body><div id="root"></div></body></html>',
+  ].join('');
+}
 
 // ── Types & Props ────────────────────────────────────────────────────────────
 
@@ -181,7 +185,7 @@ export default function GatePreview({
       return;
     }
     doc.open();
-    doc.write(IFRAME_INITIAL_HTML);
+    doc.write(buildIframeInitialHTML(getCspNonce()));
     doc.close();
     setIframeDoc(doc);
   }, []);

--- a/frontend/apps/console/src/components/GatePreview/IframeContent.tsx
+++ b/frontend/apps/console/src/components/GatePreview/IframeContent.tsx
@@ -10,6 +10,7 @@ import {
   AuthCardLayout,
   FontImporter,
   getFontImportURL,
+  getCspNonce,
   type Theme,
   type DesignResolveResponse,
   type Stylesheet,
@@ -124,8 +125,11 @@ export default function IframeContent({
     [resolveAll],
   );
 
-  // Create an emotion cache that injects styles into the iframe's <head>.
-  const cache = useMemo(() => createCache({key: 'preview', container: iframeDoc.head}), [iframeDoc]);
+  // Create an emotion cache that injects styles into the iframe's <head>. The nonce comes from the
+  // parent document: this iframe has no src (an about:blank doc written to directly), so it inherits
+  // the parent page's CSP, including this exact nonce value, rather than carrying its own.
+  const nonce = getCspNonce();
+  const cache = useMemo(() => createCache({key: 'preview', nonce, container: iframeDoc.head}), [iframeDoc, nonce]);
 
   // Whether an actual theme is configured — mirrors the gate's isDesignEnabled
   // check, where an empty theme object counts as "no design".
@@ -151,6 +155,10 @@ export default function IframeContent({
       if (sheet.type === 'inline') {
         const style = iframeDoc.createElement('style');
         style.id = elementId;
+        const nonce = getCspNonce();
+        if (nonce) {
+          style.setAttribute('nonce', nonce);
+        }
         style.textContent = sheet.content;
         iframeDoc.head.appendChild(style);
         injectedIds.push(elementId);

--- a/frontend/apps/console/src/components/GatePreview/__tests__/GatePreview.test.tsx
+++ b/frontend/apps/console/src/components/GatePreview/__tests__/GatePreview.test.tsx
@@ -5,7 +5,7 @@ import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type {Theme} from '@thunderid/design';
 import {OxygenUIThemeProvider} from '@wso2/oxygen-ui';
-import {describe, it, expect, vi} from 'vitest';
+import {describe, it, expect, vi, afterEach} from 'vitest';
 import GatePreview from '../GatePreview';
 
 // Mock shared-design to stub DesignProvider (which internally needs ConfigProvider)
@@ -18,6 +18,7 @@ vi.mock('@thunderid/design', () => ({
   FontImporter: () => null,
   getFontImportURL: () => undefined,
   AcrylicOrangeTheme: {},
+  getCspNonce: () => document.querySelector('meta[property="csp-nonce"]')?.getAttribute('content') ?? undefined,
 }));
 
 vi.mock('@emotion/cache', async (importActual) => {
@@ -122,6 +123,33 @@ describe('GatePreview', () => {
       renderWithThemeProvider(<GatePreview theme={mockTheme} syncColorSchemeWithSystem />);
 
       expect(screen.getByTitle('Gate Preview')).toBeInTheDocument();
+    });
+  });
+
+  describe('CSP nonce', () => {
+    afterEach(() => {
+      document.querySelector('meta[property="csp-nonce"]')?.remove();
+    });
+
+    it("tags the iframe's initial inline <style> with the parent document's csp nonce", () => {
+      const meta = document.createElement('meta');
+      meta.setAttribute('property', 'csp-nonce');
+      meta.setAttribute('content', 'abc123');
+      document.head.appendChild(meta);
+
+      renderWithThemeProvider(<GatePreview theme={mockTheme} />);
+
+      const iframe = screen.getByTitle<HTMLIFrameElement>('Gate Preview');
+      const style = iframe.contentDocument?.querySelector('style');
+      expect(style?.getAttribute('nonce')).toBe('abc123');
+    });
+
+    it('renders the iframe without a nonce attribute when none is available', () => {
+      renderWithThemeProvider(<GatePreview theme={mockTheme} />);
+
+      const iframe = screen.getByTitle<HTMLIFrameElement>('Gate Preview');
+      const style = iframe.contentDocument?.querySelector('style');
+      expect(style?.hasAttribute('nonce')).toBe(false);
     });
   });
 

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/JwtPreview.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/JwtPreview.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import Editor, {type OnMount} from '@monaco-editor/react';
+import {getCspNonce} from '@thunderid/design';
 import {Box, Stack, Typography} from '@wso2/oxygen-ui';
 import type {editor as MonacoEditor, IDisposable, IRange} from 'monaco-editor';
 import {useRef, useEffect} from 'react';
@@ -326,7 +327,9 @@ export default function JwtPreview({payload, defaultClaims = [], header = undefi
     >
       {/* Styling for default claim annotations */}
       {!isJson && (
-        <style>{`.jwt-default-claim { color: #C586C0 !important; text-decoration: underline dotted; text-decoration-color: #C586C0; cursor: help; }`}</style>
+        <style nonce={getCspNonce()}>
+          {`.jwt-default-claim { color: #C586C0 !important; text-decoration: underline dotted; text-decoration-color: #C586C0; cursor: help; }`}
+        </style>
       )}
       <Stack spacing={2}>
         <Stack direction="row" spacing={1} alignItems="center">

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/JwtPreview.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/JwtPreview.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {render, screen} from '@testing-library/react';
-import {describe, expect, it, vi} from 'vitest';
+import {afterEach, describe, expect, it, vi} from 'vitest';
 import JwtPreview from '../JwtPreview';
 
 vi.mock('@monaco-editor/react', () => ({
@@ -66,5 +66,28 @@ describe('JwtPreview', () => {
 
     expect(screen.queryByText('Decoded Header')).not.toBeInTheDocument();
     expect(screen.queryByText('Decoded Payload')).not.toBeInTheDocument();
+  });
+
+  describe('default claim styling', () => {
+    afterEach(() => {
+      document.querySelector('meta[property="csp-nonce"]')?.remove();
+    });
+
+    it("tags the default-claim <style> tag with the page's csp nonce", () => {
+      const meta = document.createElement('meta');
+      meta.setAttribute('property', 'csp-nonce');
+      meta.setAttribute('content', 'abc123');
+      document.head.appendChild(meta);
+
+      const {container} = render(<JwtPreview payload={{sub: 'user-123'}} />);
+
+      expect(container.querySelector('style')).toHaveAttribute('nonce', 'abc123');
+    });
+
+    it('renders the <style> tag without a nonce attribute when none is available', () => {
+      const {container} = render(<JwtPreview payload={{sub: 'user-123'}} />);
+
+      expect(container.querySelector('style')).not.toHaveAttribute('nonce');
+    });
   });
 });

--- a/frontend/apps/console/src/hocs/__tests__/withTheme.test.tsx
+++ b/frontend/apps/console/src/hocs/__tests__/withTheme.test.tsx
@@ -15,6 +15,7 @@ vi.mock('../../components/Head', () => ({
 
 let capturedThemes: unknown;
 let capturedInitialTheme: unknown;
+let capturedNonce: unknown;
 
 function MockChild() {
   return <div data-testid="mock-child">Child</div>;
@@ -30,13 +31,16 @@ vi.mock('@wso2/oxygen-ui', async (importOriginal) => {
       children,
       themes = undefined,
       initialTheme = undefined,
+      nonce = undefined,
     }: {
       children: React.ReactNode;
       themes?: unknown;
       initialTheme?: unknown;
+      nonce?: unknown;
     }) => {
       capturedThemes = themes;
       capturedInitialTheme = initialTheme;
+      capturedNonce = nonce;
       return <div data-testid="theme-provider">{children}</div>;
     },
   };
@@ -50,6 +54,8 @@ describe('withTheme (console)', () => {
     vi.clearAllMocks();
     capturedThemes = undefined;
     capturedInitialTheme = undefined;
+    capturedNonce = undefined;
+    document.querySelector('meta[property="csp-nonce"]')?.remove();
     mockUseConfig.mockReturnValue({
       config: {
         brand: {
@@ -111,6 +117,21 @@ describe('withTheme (console)', () => {
   it('renders Head', () => {
     render(<WithThemeComponent />);
     expect(screen.getByTestId('head')).toBeInTheDocument();
+  });
+
+  it('passes undefined nonce to OxygenUIThemeProvider when no csp-nonce meta tag is present', () => {
+    render(<WithThemeComponent />);
+    expect(capturedNonce).toBeUndefined();
+  });
+
+  it("forwards the page's csp-nonce meta tag to OxygenUIThemeProvider", () => {
+    const meta = document.createElement('meta');
+    meta.setAttribute('property', 'csp-nonce');
+    meta.setAttribute('content', 'abc123');
+    document.head.appendChild(meta);
+
+    render(<WithThemeComponent />);
+    expect(capturedNonce).toBe('abc123');
   });
 
   it('includes custom object themes from config in the theme list', () => {

--- a/frontend/apps/console/src/hocs/withTheme.tsx
+++ b/frontend/apps/console/src/hocs/withTheme.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {useConfig} from '@thunderid/contexts';
-import {DefaultTheme} from '@thunderid/design';
+import {DefaultTheme, getCspNonce} from '@thunderid/design';
 import {createOxygenTheme, OxygenUIThemeProvider, HighContrastTheme} from '@wso2/oxygen-ui';
 import type {JSX, ComponentType} from 'react';
 import Head from '../components/Head';
@@ -13,6 +13,7 @@ export default function withTheme<P extends object>(WrappedComponent: ComponentT
 
     return (
       <OxygenUIThemeProvider
+        nonce={getCspNonce()}
         themes={[
           {key: 'highContrast', label: 'High Contrast Theme', theme: HighContrastTheme},
           {key: 'default', label: 'Default Theme', theme: DefaultTheme},

--- a/frontend/apps/console/src/main.tsx
+++ b/frontend/apps/console/src/main.tsx
@@ -51,7 +51,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       >
         <QueryClientProvider client={queryClient}>
           <AppWithDecorators />
-          <ReactQueryDevtools initialIsOpen={false} />
+          {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
         </QueryClientProvider>
       </LoggerProvider>
     </ConfigProvider>

--- a/frontend/apps/gate/index.html
+++ b/frontend/apps/gate/index.html
@@ -9,6 +9,10 @@
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
 
+    <!-- Content-Security-Policy nonce for this response, substituted by the server. Read by the
+         frontend to authorize its own inline <style> tags under a nonce-based style-src-elem. -->
+    <meta property="csp-nonce" content="__CSP_NONCE__" />
+
     <title>Gate</title>
 
     <!-- Start of loading application configurations -->

--- a/frontend/apps/gate/src/hocs/__tests__/withTheme.test.tsx
+++ b/frontend/apps/gate/src/hocs/__tests__/withTheme.test.tsx
@@ -22,6 +22,7 @@ vi.mock('@thunder/contexts', () => ({
 
 // Create mock for useDesign
 const mockUseDesign = vi.fn();
+const mockGetCspNonce = vi.fn<() => string | undefined>();
 vi.mock('@thunderid/design', () => ({
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   useDesign: () => mockUseDesign(),
@@ -29,6 +30,7 @@ vi.mock('@thunderid/design', () => ({
   FontImporter: () => null,
   getFontImportURL: () => undefined,
   DefaultTheme: {},
+  getCspNonce: () => mockGetCspNonce(),
 }));
 
 const mockUseConfig = vi.hoisted(() => vi.fn());
@@ -104,6 +106,7 @@ describe('withTheme', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     capturedThemeProviderProps = undefined;
+    mockGetCspNonce.mockReturnValue(undefined);
     mockUseDesign.mockReturnValue({
       transformedTheme: null,
       isLoading: false,
@@ -283,6 +286,18 @@ describe('withTheme', () => {
   it('renders Head', () => {
     render(<WithThemeComponent />);
     expect(screen.getByTestId('head')).toBeInTheDocument();
+  });
+
+  it('forwards the csp nonce to OxygenUIThemeProvider', () => {
+    mockGetCspNonce.mockReturnValue('abc123');
+
+    render(<WithThemeComponent />);
+    expect(capturedThemeProviderProps?.nonce).toBe('abc123');
+  });
+
+  it('passes undefined nonce to OxygenUIThemeProvider when none is available', () => {
+    render(<WithThemeComponent />);
+    expect(capturedThemeProviderProps?.nonce).toBeUndefined();
   });
 
   it('includes custom object themes from config in the theme list', () => {

--- a/frontend/apps/gate/src/hocs/withConfig.tsx
+++ b/frontend/apps/gate/src/hocs/withConfig.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {useConfig} from '@thunderid/contexts';
+import {getCspNonce} from '@thunderid/design';
 import {ThunderIDProvider} from '@thunderid/react';
 import type {ThunderIDProviderProps} from '@thunderid/react';
 import type {JSX, ComponentType} from 'react';
@@ -18,6 +19,7 @@ export default function withConfig<P extends object>(WrappedComponent: Component
         baseUrl={getServerUrl() ?? (import.meta.env.VITE_THUNDER_BASE_URL as string)}
         applicationId={applicationId!}
         {...sdkProps}
+        cspNonce={getCspNonce()}
       >
         <WrappedComponent {...props} />
       </ThunderIDProvider>

--- a/frontend/apps/gate/src/hocs/withTheme.tsx
+++ b/frontend/apps/gate/src/hocs/withTheme.tsx
@@ -8,6 +8,7 @@ import {
   StylesheetInjector,
   DefaultTheme,
   getFontImportURL,
+  getCspNonce,
   type Theme,
 } from '@thunderid/design';
 import {LanguageSwitcher} from '@thunderid/react';
@@ -35,6 +36,7 @@ export default function withTheme<P extends object>(WrappedComponent: ComponentT
 
     return (
       <OxygenUIThemeProvider
+        nonce={getCspNonce()}
         themes={[
           {key: 'highContrast', label: 'High Contrast Theme', theme: HighContrastTheme},
           {key: 'default', label: 'Default Theme', theme: theme ?? DefaultTheme},

--- a/frontend/apps/gate/src/main.tsx
+++ b/frontend/apps/gate/src/main.tsx
@@ -47,7 +47,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       >
         <QueryClientProvider client={queryClient}>
           <AppWithDecorators />
-          <ReactQueryDevtools initialIsOpen={false} />
+          {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
         </QueryClientProvider>
       </LoggerProvider>
     </ConfigProvider>

--- a/frontend/packages/design/src/components/FontImporter.tsx
+++ b/frontend/packages/design/src/components/FontImporter.tsx
@@ -5,6 +5,7 @@ import {useConfig} from '@thunderid/contexts';
 import {useEffect} from 'react';
 import useFontStylesheetLink from './useFontStylesheetLink';
 import {DEFAULT_FONT_STACK} from '../constants/fonts';
+import getCspNonce from '../utils/getCspNonce';
 
 /** CSS variable set by the ThunderID SDK when design data includes a custom font. */
 const THUNDERID_FONT_CSS_VAR = '--thunderid-typography-fontFamily';
@@ -56,6 +57,10 @@ export default function FontImporter({
 
     const style = doc.createElement('style');
     style.id = fontOverrideId;
+    const nonce = getCspNonce();
+    if (nonce) {
+      style.setAttribute('nonce', nonce);
+    }
     style.textContent = `${MUI_FONT_SELECTORS} { font-family: ${family} !important; }`;
 
     doc.getElementById(fontOverrideId)?.remove();

--- a/frontend/packages/design/src/components/StylesheetInjector.tsx
+++ b/frontend/packages/design/src/components/StylesheetInjector.tsx
@@ -7,6 +7,7 @@ import {useEffect} from 'react';
 import useDesign from '../contexts/Design/useDesign';
 import type {Stylesheet} from '../models/layout';
 import {sanitizeCss, isValidStylesheetUrl} from '../utils/cssSanitizer';
+import getCspNonce from '../utils/getCspNonce';
 
 const logger = createLogger({component: 'StylesheetInjector'});
 
@@ -55,6 +56,10 @@ export default function StylesheetInjector({stylesheets = undefined}: Stylesheet
         const style = document.createElement('style');
         style.id = elementId;
         style.setAttribute(dataAttr, 'true');
+        const nonce = getCspNonce();
+        if (nonce) {
+          style.setAttribute('nonce', nonce);
+        }
         style.textContent = sanitizeCss(stylesheet.content);
         document.head.appendChild(style);
         injectedIds.push(elementId);

--- a/frontend/packages/design/src/components/__tests__/FontImporter.test.tsx
+++ b/frontend/packages/design/src/components/__tests__/FontImporter.test.tsx
@@ -15,6 +15,7 @@ const IMPORT_ID = 'thunderid-font-import';
 
 afterEach(() => {
   cleanup();
+  document.querySelector('meta[property="csp-nonce"]')?.remove();
 });
 
 describe('FontImporter', () => {
@@ -57,5 +58,24 @@ describe('FontImporter', () => {
     unmount();
     expect(document.getElementById(OVERRIDE_ID)).toBeNull();
     expect(document.getElementById(IMPORT_ID)).toBeNull();
+  });
+
+  it("tags its injected <style> element with the page's csp nonce", () => {
+    const meta = document.createElement('meta');
+    meta.setAttribute('property', 'csp-nonce');
+    meta.setAttribute('content', 'abc123');
+    document.head.appendChild(meta);
+
+    render(<FontImporter fontFamily="Poppins" />);
+
+    const style = document.getElementById(OVERRIDE_ID);
+    expect(style?.getAttribute('nonce')).toBe('abc123');
+  });
+
+  it('renders the <style> element without a nonce attribute when none is available', () => {
+    render(<FontImporter fontFamily="Poppins" />);
+
+    const style = document.getElementById(OVERRIDE_ID);
+    expect(style?.hasAttribute('nonce')).toBe(false);
   });
 });

--- a/frontend/packages/design/src/components/__tests__/StylesheetInjector.test.tsx
+++ b/frontend/packages/design/src/components/__tests__/StylesheetInjector.test.tsx
@@ -1,0 +1,44 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {render} from '@testing-library/react';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import StylesheetInjector from '../StylesheetInjector';
+
+vi.mock('@thunderid/contexts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunderid/contexts')>();
+  return {
+    ...actual,
+    useConfig: () => ({config: {brand: {product_name: 'ThunderID'}}}),
+  };
+});
+
+vi.mock('../../contexts/Design/useDesign', () => ({
+  default: () => ({layout: undefined}),
+}));
+
+describe('StylesheetInjector', () => {
+  afterEach(() => {
+    document.querySelector('meta[property="csp-nonce"]')?.remove();
+    document.getElementById('thunderid-stylesheet-inline-1')?.remove();
+  });
+
+  it("tags an injected inline stylesheet with the page's csp nonce", () => {
+    const meta = document.createElement('meta');
+    meta.setAttribute('property', 'csp-nonce');
+    meta.setAttribute('content', 'abc123');
+    document.head.appendChild(meta);
+
+    render(<StylesheetInjector stylesheets={[{id: 'inline-1', type: 'inline', content: 'body { color: red; }'}]} />);
+
+    const style = document.getElementById('thunderid-stylesheet-inline-1');
+    expect(style?.getAttribute('nonce')).toBe('abc123');
+  });
+
+  it('injects the inline stylesheet without a nonce attribute when none is available', () => {
+    render(<StylesheetInjector stylesheets={[{id: 'inline-1', type: 'inline', content: 'body { color: red; }'}]} />);
+
+    const style = document.getElementById('thunderid-stylesheet-inline-1');
+    expect(style?.hasAttribute('nonce')).toBe(false);
+  });
+});

--- a/frontend/packages/design/src/index.ts
+++ b/frontend/packages/design/src/index.ts
@@ -90,3 +90,4 @@ export {default as getStackGridSx, parseStackItems, type StackGridInput} from '.
 export {default as mapEmbeddedFlowTextColor} from './utils/mapEmbeddedFlowTextColor';
 export {default as mapEmbeddedFlowTextVariant} from './utils/mapEmbeddedFlowTextVariant';
 export {sanitizeCss, isValidStylesheetUrl, isInsecureStylesheetUrl} from './utils/cssSanitizer';
+export {default as getCspNonce} from './utils/getCspNonce';

--- a/frontend/packages/design/src/utils/__tests__/getCspNonce.test.ts
+++ b/frontend/packages/design/src/utils/__tests__/getCspNonce.test.ts
@@ -1,0 +1,42 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {afterEach, describe, expect, it} from 'vitest';
+import getCspNonce from '../getCspNonce';
+
+describe('getCspNonce', () => {
+  afterEach(() => {
+    document.querySelector('meta[property="csp-nonce"]')?.remove();
+  });
+
+  it('returns the meta tag content when present', () => {
+    const meta = document.createElement('meta');
+    meta.setAttribute('property', 'csp-nonce');
+    meta.setAttribute('content', 'abc123');
+    document.head.appendChild(meta);
+
+    expect(getCspNonce()).toBe('abc123');
+  });
+
+  it('returns undefined when the meta tag is absent', () => {
+    expect(getCspNonce()).toBeUndefined();
+  });
+
+  it('returns undefined when the meta tag content is empty', () => {
+    const meta = document.createElement('meta');
+    meta.setAttribute('property', 'csp-nonce');
+    meta.setAttribute('content', '');
+    document.head.appendChild(meta);
+
+    expect(getCspNonce()).toBeUndefined();
+  });
+
+  it('returns undefined when the placeholder was never substituted (e.g. a dev server bypassing the Go backend)', () => {
+    const meta = document.createElement('meta');
+    meta.setAttribute('property', 'csp-nonce');
+    meta.setAttribute('content', '__CSP_NONCE__');
+    document.head.appendChild(meta);
+
+    expect(getCspNonce()).toBeUndefined();
+  });
+});

--- a/frontend/packages/design/src/utils/getCspNonce.ts
+++ b/frontend/packages/design/src/utils/getCspNonce.ts
@@ -1,0 +1,23 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Placeholder the server substitutes with the real nonce (see backend constants.CSPNoncePlaceholder).
+ * A local dev server that serves index.html directly, without the Go backend, leaves it unsubstituted.
+ */
+const UNSUBSTITUTED_PLACEHOLDER = '__CSP_NONCE__';
+
+/**
+ * Reads the per-request Content-Security-Policy nonce from the page's <meta property="csp-nonce">
+ * tag (set by the server; see backend internal/system/csp). Always reads from the top-level document,
+ * even for callers injecting styles into an iframe: an about:blank iframe inherits its creator's CSP,
+ * including this exact nonce value, not one of its own.
+ *
+ * @returns The nonce, or undefined when absent or unsubstituted (e.g. unit tests, or a dev server not
+ * fronted by the Go backend), so nonce-dependent props can be safely omitted rather than passed as an
+ * empty string or the literal placeholder text.
+ */
+export default function getCspNonce(): string | undefined {
+  const content = document.querySelector('meta[property="csp-nonce"]')?.getAttribute('content');
+  return content && content !== UNSUBSTITUTED_PLACEHOLDER ? content : undefined;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,8 +242,8 @@ catalogs:
       specifier: 14.6.1
       version: 14.6.1
     '@thunderid/react':
-      specifier: 0.11.4
-      version: 0.11.4
+      specifier: 0.13.0
+      version: 0.13.0
     '@thunderid/react-router':
       specifier: 0.10.4
       version: 0.10.4
@@ -502,7 +502,7 @@ importers:
         version: link:../frontend/packages/prettier-config
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.13.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@thunderid/utils':
         specifier: workspace:^
         version: link:../frontend/packages/utils
@@ -695,10 +695,10 @@ importers:
         version: link:../../packages/logger
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.13.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@thunderid/react-router':
         specifier: 'catalog:'
-        version: 0.10.4(@thunderid/browser@0.11.4)(@thunderid/react@0.11.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@8.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 0.10.4(@thunderid/browser@0.13.0)(@thunderid/react@0.13.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@8.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@thunderid/utils':
         specifier: workspace:^
         version: link:../../packages/utils
@@ -882,10 +882,10 @@ importers:
         version: link:../../packages/logger
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.13.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@thunderid/react-router':
         specifier: 'catalog:'
-        version: 0.10.4(@thunderid/browser@0.11.4)(@thunderid/react@0.11.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@8.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 0.10.4(@thunderid/browser@0.13.0)(@thunderid/react@0.13.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@8.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@thunderid/utils':
         specifier: workspace:^
         version: link:../../packages/utils
@@ -1030,7 +1030,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.13.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.13.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.13.0(react@19.2.3))(dayjs@1.11.21)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1130,7 +1130,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.13.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.13.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.13.0(react@19.2.3))(dayjs@1.11.21)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1251,7 +1251,7 @@ importers:
         version: link:../prettier-config
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.13.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@thunderid/test-utils':
         specifier: workspace:^
         version: link:../test-utils
@@ -1302,7 +1302,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.13.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.13.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.13.0(react@19.2.3))(dayjs@1.11.21)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1402,7 +1402,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.13.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.13.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.13.0(react@19.2.3))(dayjs@1.11.21)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1520,7 +1520,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.13.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.13.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.13.0(react@19.2.3))(dayjs@1.11.21)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1635,7 +1635,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.13.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.13.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.13.0(react@19.2.3))(dayjs@1.11.21)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1738,7 +1738,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.13.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.13.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.13.0(react@19.2.3))(dayjs@1.11.21)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1856,7 +1856,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.13.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.13.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.13.0(react@19.2.3))(dayjs@1.11.21)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1992,7 +1992,7 @@ importers:
         version: link:../prettier-config
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.13.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@thunderid/test-utils':
         specifier: workspace:^
         version: link:../test-utils
@@ -2168,7 +2168,7 @@ importers:
         version: link:../logger
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.13.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@thunderid/utils':
         specifier: workspace:^
         version: link:../utils
@@ -2429,7 +2429,7 @@ importers:
         version: 5.90.5(react@19.2.3)
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.13.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       i18next:
         specifier: 25.6.0
         version: 25.6.0(typescript@5.9.3)
@@ -2761,7 +2761,7 @@ importers:
     dependencies:
       '@thunderid/react':
         specifier: 'catalog:'
-        version: 0.11.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.13.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@wso2/oxygen-ui':
         specifier: 'catalog:'
         version: 0.13.0(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(@wso2/oxygen-ui-icons-react@0.13.0(react@19.2.3))(dayjs@1.11.21)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -2925,8 +2925,8 @@ importers:
   samples/apps/wayfinder-sample/frontend:
     dependencies:
       '@thunderid/react':
-        specifier: 0.11.1
-        version: 0.11.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: 0.13.0
+        version: 0.13.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       lucide-react:
         specifier: ^0.511.0
         version: 0.511.0(react@19.2.3)
@@ -6681,20 +6681,14 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@thunderid/browser@0.11.3':
-    resolution: {integrity: sha512-2k6iiAeu7ODSL/G/0xf46tdFQMyn+qg+aHW/HNDE8xIYXudWvXqOk/t8+JkSdQiQagFPomGc67LobF9ojHBqGQ==}
-
-  '@thunderid/browser@0.11.4':
-    resolution: {integrity: sha512-CKD0bVf6LTARGEs+IErNhX1FM2KPJkbML2zgEVJ2hVCwwVgK8GLSzrm8uA6nA0xOFZeHmemDUrlnmoKTchtaFg==}
+  '@thunderid/browser@0.13.0':
+    resolution: {integrity: sha512-C4dICYO+/LtW8FuqTyXhFqSOCmLG+7zSoYk077JJ9eZtukyiQja44q4rhMLx17oZbwtOqr+aBMLZbBrg7dPTWQ==}
 
   '@thunderid/javascript@0.0.5':
     resolution: {integrity: sha512-lMjbHCsNgYWclUiPlN3CA6vjKSyjIBIxVGSnuJwiC9eVakVsWmRuxkO8KX6AWlA4SRHgpGLMnD4ZE5lpM+gi9g==}
 
-  '@thunderid/javascript@0.11.2':
-    resolution: {integrity: sha512-26k2Aq3B077BNPoE50JvjiFJVepV4dKFD6s80EwVf9BVtAm2GwVCkRDh9WtOgSxMLd7IGPR9yRPenDhRpN3YAQ==}
-
-  '@thunderid/javascript@0.11.3':
-    resolution: {integrity: sha512-/Qj7x6ySNDCCWonfwWU9YIhCU5VR8NeYm85MFxrn4A0kdJrN8Iswqs5wtI5j4oygKis4xjjDY9Xaw43x4jiDHQ==}
+  '@thunderid/javascript@0.13.0':
+    resolution: {integrity: sha512-ZLDf9CnjP0HHxtB8urwyZRdzl3hINTDGJW9dtUnbNY+cHhikMLPR71Evv3x2OrATl3WEx0aHjAs1msmPxgFfXg==}
 
   '@thunderid/react-router@0.10.4':
     resolution: {integrity: sha512-Onus9iMQW2nWy31bbX5XLbxJd69a3yxYT1vM5NScwABaae6En2iIQFYKgsXJNys/tUgVkm4pPiSqgKCNdu0z2Q==}
@@ -6704,15 +6698,8 @@ packages:
       react: '>=16.8.0'
       react-router: '>=6.30.1'
 
-  '@thunderid/react@0.11.1':
-    resolution: {integrity: sha512-CPojY09ryY/if6V/oKZuJ+GHlpzQ9ECFTASo3zxC1kiYEDxu/iZ6dKrrrG0hD1UE/mG4eKIm9j5s0vUeDjJm0w==}
-    peerDependencies:
-      '@types/react': '>=16.8.0'
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-
-  '@thunderid/react@0.11.4':
-    resolution: {integrity: sha512-V5Tg5aKQUcLP9+c8Son2VqWo1OFfZQXiqIsd8JoR3xkBY9CoBc84z8PaX99CmCdAzI8T3lVc5UzzE2JCBoM9Ag==}
+  '@thunderid/react@0.13.0':
+    resolution: {integrity: sha512-yTYe0gWPO5DaKfAV/gk8EIJw3udZlQled474zzTnJA6aMD653SIAY1NxnFrfJWkb7hGvFtSO2MI8FPr8jzbmxQ==}
     peerDependencies:
       '@types/react': '>=16.8.0'
       react: '>=16.8.0'
@@ -18824,22 +18811,9 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@thunderid/browser@0.11.3':
+  '@thunderid/browser@0.13.0':
     dependencies:
-      '@thunderid/javascript': 0.11.2
-      base64url: 3.0.1
-      buffer: 6.0.3
-      core-js: 3.42.0
-      fast-sha256: 1.3.0
-      jose: 6.2.3
-      process: 0.11.10
-      randombytes: 2.1.0
-      stream-browserify: 3.0.0
-      tslib: 2.8.1
-
-  '@thunderid/browser@0.11.4':
-    dependencies:
-      '@thunderid/javascript': 0.11.3
+      '@thunderid/javascript': 0.13.0
       base64url: 3.0.1
       buffer: 6.0.3
       core-js: 3.42.0
@@ -18855,42 +18829,24 @@ snapshots:
       jose: 5.2.0
       tslib: 2.8.1
 
-  '@thunderid/javascript@0.11.2':
+  '@thunderid/javascript@0.13.0':
     dependencies:
       jose: 6.2.3
       tslib: 2.8.1
 
-  '@thunderid/javascript@0.11.3':
+  '@thunderid/react-router@0.10.4(@thunderid/browser@0.13.0)(@thunderid/react@0.13.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@8.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     dependencies:
-      jose: 6.2.3
-      tslib: 2.8.1
-
-  '@thunderid/react-router@0.10.4(@thunderid/browser@0.11.4)(@thunderid/react@0.11.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@8.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@thunderid/browser': 0.11.4
-      '@thunderid/react': 0.11.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@thunderid/browser': 0.13.0
+      '@thunderid/react': 0.13.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-router: 8.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tslib: 2.8.1
 
-  '@thunderid/react@0.11.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@thunderid/react@0.13.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@emotion/css': 11.13.5
       '@floating-ui/react': 0.27.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@thunderid/browser': 0.11.3
-      '@types/react': 19.2.14
-      dompurify: 3.4.12
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@thunderid/react@0.11.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@emotion/css': 11.13.5
-      '@floating-ui/react': 0.27.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@thunderid/browser': 0.11.4
+      '@thunderid/browser': 0.13.0
       '@types/react': 19.2.14
       dompurify: 3.4.12
       react: 19.2.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,7 +36,7 @@ catalog:
   '@testing-library/jest-dom': 6.9.1
   '@testing-library/react': 16.3.0
   '@testing-library/user-event': 14.6.1
-  '@thunderid/react': 0.11.4
+  '@thunderid/react': 0.13.0
   '@thunderid/react-router': 0.10.4
   '@types/lodash-es': 4.17.12
   '@types/node': 24.7.2

--- a/samples/apps/wayfinder-sample/frontend/package.json
+++ b/samples/apps/wayfinder-sample/frontend/package.json
@@ -12,7 +12,7 @@
     "dompurify": "3.4.12"
   },
   "dependencies": {
-    "@thunderid/react": "0.11.1",
+    "@thunderid/react": "0.13.0",
     "lucide-react": "^0.511.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.1.0",


### PR DESCRIPTION
### Purpose

Adds per-request CSP nonces for `script-src` and `style-src-elem`, closing the remaining `'unsafe-inline'` gaps in the deny-first CSP baseline for both the Console and Gate apps.

- The backend generates a cryptographically random nonce per request (`crypto/rand`, base64 URL-encoded), stores it on the request context, and injects it into both the CSP response header and a substituted `<meta property="csp-nonce">` tag in the served HTML.
- The frontend reads the nonce via a new `getCspNonce()` utility and tags every runtime-created `<style>` element (`StylesheetInjector`, `FontImporter`, `JwtPreview`'s token viewer, `GatePreview`'s iframe bootstrap) and the oxygen-ui/emotion cache accordingly.
- Console keeps `'unsafe-inline'` on `style-src-elem` because the embedded Monaco editor has no nonce support; Gate has no such dependency and stays nonce-only.

### Approach

`sourcesWithNonce` appends the nonce to `script-src`/`style-src-elem` sources, but skips a directive whenever `'unsafe-inline'` is already configured on it, since per the CSP spec a nonce-source present in a directive causes browsers to ignore `'unsafe-inline'` in that same directive. This lets Console's `style-src-elem` keep `'unsafe-inline'` (for Monaco) while Gate's same directive gets the nonce, without a special case per app, since the two apps' generated `csp.yaml` configs simply differ in whether `'unsafe-inline'` is present on that directive to begin with. Gate is treated as the app that must stay maximally strict, since it is the one most commonly embedded and exposed to end users.

### Related Issues
- Closes #4477
- Closes #4475

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Security Enhancements**
  * Added per-request CSP nonces for scripts and styles in Console and Gate.
  * Applied nonce support to previews, themes, fonts, and dynamically injected styles.
  * Improved handling of inline style elements and attributes.

* **Bug Fixes**
  * Static HTML responses now correctly substitute CSP nonces and use the proper content type.
  * React Query Devtools are excluded from production builds.

* **Tests**
  * Added coverage for nonce generation, propagation, substitution, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->