### PR TITLE
Offer the default resource server from the wizard and the list

### DIFF
--- a/frontend/packages/configure-resource-servers/src/components/ResourceServersList.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/ResourceServersList.tsx
@@ -4,17 +4,18 @@
 import {QueryErrorNotice} from '@thunderid/components';
 import {useDataGridLocaleText} from '@thunderid/hooks';
 import {useLogger} from '@thunderid/logger/react';
-import {Box, Chip, DataGrid, IconButton, ListingTable, Tooltip, Typography} from '@wso2/oxygen-ui';
-import {Eye, Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
+import {Box, Chip, DataGrid, IconButton, ListingTable, Menu, MenuItem, Tooltip, Typography} from '@wso2/oxygen-ui';
+import {EllipsisVertical, Eye, Pencil, Trash2} from '@wso2/oxygen-ui-icons-react';
 import {useCallback, useMemo, useState, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
 import ResourceServerDeleteDialog from './ResourceServerDeleteDialog';
+import SetDefaultResourceServerDialog from './SetDefaultResourceServerDialog';
 import useGetDefaultResourceServer from '../api/useGetDefaultResourceServer';
 import useGetResourceServers from '../api/useGetResourceServers';
 import {getResourceServerTypeLabel} from '../config/resource-server-types';
 import useResourceServerRoutes from '../hooks/useResourceServerRoutes';
-import type {ResourceServer} from '../models/resource-server';
+import {isDefaultEligibleType, type ResourceServer} from '../models/resource-server';
 
 export default function ResourceServersList(): JSX.Element {
   const navigate = useNavigate();
@@ -34,13 +35,60 @@ export default function ResourceServersList(): JSX.Element {
 
   const [paginationModel, setPaginationModel] = useState<DataGrid.GridPaginationModel>({pageSize: 10, page: 0});
   const [deleteTarget, setDeleteTarget] = useState<ResourceServer | null>(null);
+  const [setDefaultTarget, setSetDefaultTarget] = useState<ResourceServer | null>(null);
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  const [menuTarget, setMenuTarget] = useState<ResourceServer | null>(null);
 
   const {data, isLoading, error, refetch} = useGetResourceServers({
     limit: paginationModel.pageSize,
     offset: paginationModel.page * paginationModel.pageSize,
   });
-  const {data: defaultConfig} = useGetDefaultResourceServer();
+  const {data: defaultConfig, isLoading: isDefaultLoading, error: defaultError} = useGetDefaultResourceServer();
   const defaultId = defaultConfig?.merged?.resourceServerId;
+  // A declarative (read-only) default is locked: the backend rejects any write to it.
+  const isDefaultReady = !isDefaultLoading && !defaultError;
+  const isDefaultLocked = Boolean(defaultConfig?.readOnly?.resourceServerId);
+
+  // Why the action cannot apply to this row, or undefined when it can. It stays visible either way
+  // so the actions column keeps its shape, and the reason is shown so a disabled entry is not a
+  // mystery.
+  const makeDefaultBlockedReason = useCallback(
+    (resourceServer: ResourceServer): string | undefined => {
+      if (!isDefaultReady) {
+        return t('resourceServers:setDefault.unavailableReason', 'Checking the current default resource server.');
+      }
+      if (isDefaultLocked) {
+        return t(
+          'resourceServers:setDefault.lockedReason',
+          'The default resource server is fixed by the deployment configuration.',
+        );
+      }
+      if (resourceServer.id === defaultId) {
+        return t('resourceServers:setDefault.alreadyDefaultReason', 'This is already the default resource server.');
+      }
+      if (!isDefaultEligibleType(resourceServer.type)) {
+        return t(
+          'resourceServers:setDefault.ineligibleTypeReason',
+          'Only API and custom resource servers can be the default.',
+        );
+      }
+      return undefined;
+    },
+    [t, isDefaultReady, isDefaultLocked, defaultId],
+  );
+
+  const handleMenuOpen = useCallback((event: React.MouseEvent<HTMLElement>, resourceServer: ResourceServer): void => {
+    event.stopPropagation();
+    setMenuAnchor(event.currentTarget);
+    setMenuTarget(resourceServer);
+  }, []);
+
+  const menuBlockedReason = menuTarget ? makeDefaultBlockedReason(menuTarget) : undefined;
+
+  const handleMenuClose = useCallback((): void => {
+    setMenuAnchor(null);
+    setMenuTarget(null);
+  }, []);
 
   const columns: DataGrid.GridColDef<ResourceServer>[] = useMemo(
     () => [
@@ -152,13 +200,22 @@ export default function ResourceServersList(): JSX.Element {
                     <Trash2 size={16} />
                   </IconButton>
                 </Tooltip>
+                <Tooltip title={t('resourceServers:listing.actions.more', 'More actions')}>
+                  <IconButton
+                    size="small"
+                    aria-label={t('resourceServers:listing.actions.more', 'More actions')}
+                    onClick={(e) => handleMenuOpen(e, params.row)}
+                  >
+                    <EllipsisVertical size={16} />
+                  </IconButton>
+                </Tooltip>
               </>
             )}
           </ListingTable.RowActions>
         ),
       },
     ],
-    [t, navigate, routes, logger, defaultId],
+    [t, navigate, routes, logger, defaultId, handleMenuOpen],
   );
 
   if (error) {
@@ -201,11 +258,48 @@ export default function ResourceServersList(): JSX.Element {
         </ListingTable.Container>
       </ListingTable.Provider>
 
+      <Menu
+        anchorEl={menuAnchor}
+        open={menuAnchor !== null}
+        onClose={handleMenuClose}
+        anchorOrigin={{vertical: 'bottom', horizontal: 'right'}}
+        transformOrigin={{vertical: 'top', horizontal: 'right'}}
+      >
+        <MenuItem
+          disabled={menuBlockedReason !== undefined}
+          onClick={() => {
+            // A disabled MenuItem is a list item, so it keeps its handler and is only kept inert by
+            // pointer-events. Guard here too, whatever dispatches the click.
+            if (menuBlockedReason !== undefined) return;
+            setSetDefaultTarget(menuTarget);
+            handleMenuClose();
+          }}
+        >
+          <Box>
+            <Typography variant="body2">
+              {t('resourceServers:setDefault.action', 'Make default resource server')}
+            </Typography>
+            {menuBlockedReason !== undefined && (
+              <Typography variant="caption" color="text.secondary" display="block">
+                {menuBlockedReason}
+              </Typography>
+            )}
+          </Box>
+        </MenuItem>
+      </Menu>
+
       <ResourceServerDeleteDialog
         open={deleteTarget !== null}
         resourceServer={deleteTarget}
         onClose={() => setDeleteTarget(null)}
         onSuccess={() => setDeleteTarget(null)}
+      />
+
+      <SetDefaultResourceServerDialog
+        open={setDefaultTarget !== null}
+        resourceServer={setDefaultTarget}
+        onClose={() => setSetDefaultTarget(null)}
+        onSuccess={() => setSetDefaultTarget(null)}
       />
     </>
   );

--- a/frontend/packages/configure-resource-servers/src/components/SetDefaultResourceServerDialog.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/SetDefaultResourceServerDialog.tsx
@@ -4,20 +4,9 @@
 import {useToast} from '@thunderid/contexts';
 import {useLogger} from '@thunderid/logger/react';
 import {getErrorMessage} from '@thunderid/utils';
-import {
-  Alert,
-  Box,
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  Stack,
-  Typography,
-} from '@wso2/oxygen-ui';
-import {Star} from '@wso2/oxygen-ui-icons-react';
+import {Alert, Button, Dialog, DialogActions, DialogContent, DialogTitle, Typography} from '@wso2/oxygen-ui';
 import {useCallback, useState, type JSX} from 'react';
-import {useTranslation} from 'react-i18next';
+import {Trans, useTranslation} from 'react-i18next';
 import useSetDefaultResourceServer from '../api/useSetDefaultResourceServer';
 import type {ResourceServer} from '../models/resource-server';
 
@@ -82,32 +71,20 @@ export default function SetDefaultResourceServerDialog({
 
   return (
     <Dialog open={open} onClose={handleClose} maxWidth="xs" fullWidth>
-      <DialogTitle>
-        <Stack direction="row" alignItems="center" spacing={1.5}>
-          <Box
-            sx={{
-              width: 40,
-              height: 40,
-              borderRadius: 2,
-              flexShrink: 0,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              color: 'primary.main',
-              bgcolor: 'primary.light',
-            }}
-          >
-            <Star size={20} />
-          </Box>
-          <span>{t('resourceServers:setDefault.title', 'Set default resource server')}</span>
-        </Stack>
-      </DialogTitle>
+      <DialogTitle>{t('resourceServers:setDefault.title', 'Set default resource server')}</DialogTitle>
       <DialogContent>
         <Typography variant="body2" color="text.secondary">
-          <strong>{resourceServer?.name}</strong>{' '}
+          <Trans
+            i18nKey="resourceServers:setDefault.message"
+            defaults="<bold>{{name}}</bold> will become the default resource server."
+            values={{name: resourceServer?.name}}
+            components={{bold: <strong />}}
+          />
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{mt: 1}}>
           {t(
-            'resourceServers:setDefault.message',
-            'will become the default resource server. Requests without a resource parameter will fall back to it.',
+            'resourceServers:setDefault.explanation',
+            'When an application requests a token without naming a resource server, its permissions come from this one. Only one resource server can be the default at a time.',
           )}
         </Typography>
         {error && (

--- a/frontend/packages/configure-resource-servers/src/components/__tests__/ResourceServersList.test.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/__tests__/ResourceServersList.test.tsx
@@ -37,6 +37,11 @@ vi.mock('../ResourceServerDeleteDialog', () => ({
   default: () => null,
 }));
 
+vi.mock('../SetDefaultResourceServerDialog', () => ({
+  default: ({open, resourceServer}: {open: boolean; resourceServer: {name: string} | null}) =>
+    open ? <div data-testid="set-default-dialog">{resourceServer?.name}</div> : null,
+}));
+
 const mockUseGetResourceServers = vi.fn();
 const mockRefetch = vi.fn();
 
@@ -169,5 +174,137 @@ describe('ResourceServersList', () => {
     fireEvent.click(screen.getByRole('button', {name: /Refresh/i}));
 
     expect(mockRefetch).toHaveBeenCalled();
+  });
+});
+
+describe('ResourceServersList make default action', () => {
+  const eligibleRow = {
+    id: 'rs-eligible',
+    name: 'Billing API',
+    identifier: 'https://billing.example.com',
+    ouId: 'ou-1',
+    delimiter: ':',
+    type: 'API' as const,
+  };
+
+  const listWith = (...resourceServers: ResourceServerListResponse['resourceServers']): ResourceServerListResponse => ({
+    totalResults: resourceServers.length,
+    startIndex: 0,
+    count: resourceServers.length,
+    resourceServers,
+  });
+
+  const renderWithDefault = (
+    rows: ResourceServerListResponse,
+    defaultConfig: DefaultResourceServerConfigResponse | undefined,
+    defaultQueryState: {isLoading?: boolean; error?: Error | null} = {},
+  ): void => {
+    mockUseGetResourceServers.mockReturnValue({data: rows, isLoading: false, error: null, refetch: mockRefetch});
+    mockUseGetDefaultResourceServer.mockReturnValue({
+      data: defaultConfig,
+      isLoading: defaultQueryState.isLoading ?? false,
+      error: defaultQueryState.error ?? null,
+    });
+    renderWithProviders(<ResourceServersList />);
+  };
+
+  const noDefault: DefaultResourceServerConfigResponse = {readOnly: {}, writable: {}, merged: {}};
+  const moreButton = () => screen.queryByRole('button', {name: /more actions/i});
+
+  const openMakeDefaultItem = (): HTMLElement => {
+    fireEvent.click(moreButton()!);
+    return screen.getByRole('menuitem', {name: /make default resource server/i});
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps the actions menu available on every editable row', () => {
+    renderWithDefault(listWith(eligibleRow), noDefault);
+
+    expect(moreButton()).toBeInTheDocument();
+  });
+
+  it('enables the action for a resource server that could become the default', () => {
+    renderWithDefault(listWith(eligibleRow), noDefault);
+
+    expect(openMakeDefaultItem()).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('disables the action for the resource server that is already the default', () => {
+    renderWithDefault(listWith(eligibleRow), {
+      readOnly: {},
+      writable: {resourceServerId: eligibleRow.id},
+      merged: {resourceServerId: eligibleRow.id},
+    });
+
+    const item = openMakeDefaultItem();
+
+    expect(item).toHaveAttribute('aria-disabled', 'true');
+    expect(item).toHaveTextContent(/already the default/i);
+  });
+
+  it('disables the action for an MCP server', () => {
+    renderWithDefault(listWith({...eligibleRow, type: 'MCP'}), noDefault);
+
+    const item = openMakeDefaultItem();
+
+    expect(item).toHaveAttribute('aria-disabled', 'true');
+    expect(item).toHaveTextContent(/only api and custom/i);
+  });
+
+  it('disables the action when a declarative default has locked it', () => {
+    renderWithDefault(listWith(eligibleRow), {
+      readOnly: {resourceServerId: 'rs-locked'},
+      writable: {},
+      merged: {resourceServerId: 'rs-locked'},
+    });
+
+    const item = openMakeDefaultItem();
+
+    expect(item).toHaveAttribute('aria-disabled', 'true');
+    expect(item).toHaveTextContent(/deployment configuration/i);
+  });
+
+  it('does not offer any actions for a read-only resource server', () => {
+    renderWithDefault(listWith({...eligibleRow, isReadOnly: true}), noDefault);
+
+    expect(moreButton()).toBeNull();
+  });
+
+  it('opens the set default dialog for the chosen resource server', () => {
+    renderWithDefault(listWith(eligibleRow), noDefault);
+
+    fireEvent.click(openMakeDefaultItem());
+
+    expect(screen.getByTestId('set-default-dialog')).toHaveTextContent('Billing API');
+  });
+
+  it('does not open the set default dialog when the action is disabled', () => {
+    renderWithDefault(listWith(eligibleRow), {
+      readOnly: {resourceServerId: 'rs-locked'},
+      writable: {},
+      merged: {resourceServerId: 'rs-locked'},
+    });
+
+    fireEvent.click(openMakeDefaultItem());
+
+    expect(screen.queryByTestId('set-default-dialog')).toBeNull();
+  });
+
+  it('disables the action while the default configuration is still loading', () => {
+    renderWithDefault(listWith(eligibleRow), undefined, {isLoading: true});
+
+    const item = openMakeDefaultItem();
+
+    expect(item).toHaveAttribute('aria-disabled', 'true');
+    expect(item).toHaveTextContent(/checking the current default/i);
+  });
+
+  it('disables the action when the default configuration failed to load', () => {
+    renderWithDefault(listWith(eligibleRow), undefined, {error: new Error('boom')});
+
+    expect(openMakeDefaultItem()).toHaveAttribute('aria-disabled', 'true');
   });
 });

--- a/frontend/packages/configure-resource-servers/src/components/__tests__/SetDefaultResourceServerDialog.test.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/__tests__/SetDefaultResourceServerDialog.test.tsx
@@ -44,7 +44,12 @@ describe('SetDefaultResourceServerDialog', () => {
     renderWithProviders(<SetDefaultResourceServerDialog open resourceServer={resourceServer} onClose={vi.fn()} />);
 
     expect(screen.getByText('Set default resource server')).toBeInTheDocument();
-    expect(screen.getByText('Payments API')).toBeInTheDocument();
+    // Emphasised inside the translated sentence, not concatenated around it, so translators can
+    // reorder it.
+    expect(screen.getByText('Payments API').tagName).toBe('STRONG');
+    expect(screen.getByText(/will become the default resource server/)).toHaveTextContent(
+      'Payments API will become the default resource server.',
+    );
   });
 
   it('does not render when closed', () => {

--- a/frontend/packages/configure-resource-servers/src/components/create-resource-server/ConfigureName.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/create-resource-server/ConfigureName.tsx
@@ -2,28 +2,39 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {NameSuggestion} from '@thunderid/components';
-import {FormControl, FormLabel, Stack, TextField, Typography} from '@wso2/oxygen-ui';
+import {Checkbox, FormControl, FormControlLabel, FormLabel, Stack, TextField, Typography} from '@wso2/oxygen-ui';
 import {useEffect, type ChangeEvent, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
-import type {ResourceServerType} from '../../models/resource-server';
+import {isDefaultEligibleType, type ResourceServerType} from '../../models/resource-server';
 
 interface ConfigureNameProps {
   name: string;
   identifier: string;
   /** The resource server type selected in the previous step, used to tailor copy for MCP servers. */
   selectedType?: ResourceServerType;
+  /**
+   * Whether the default resource server choice can be offered at all. False while the server config
+   * is still loading and when a declarative default has locked it, since the backend rejects writes.
+   */
+  canSetDefault?: boolean;
+  /** Whether the server being created should become the default resource server. */
+  makeDefault?: boolean;
   onNameChange: (name: string) => void;
   onIdentifierChange: (identifier: string) => void;
   onReadyChange?: (isReady: boolean) => void;
+  onMakeDefaultChange?: (makeDefault: boolean) => void;
 }
 
 export default function ConfigureName({
   name,
   identifier,
   selectedType = undefined,
+  canSetDefault = false,
+  makeDefault = false,
   onNameChange,
   onIdentifierChange,
   onReadyChange = undefined,
+  onMakeDefaultChange = undefined,
 }: ConfigureNameProps): JSX.Element {
   const {t} = useTranslation();
 
@@ -40,6 +51,12 @@ export default function ConfigureName({
   const handleIdentifierChange = (e: ChangeEvent<HTMLInputElement>): void => {
     onIdentifierChange(e.target.value);
   };
+
+  const handleMakeDefaultChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    onMakeDefaultChange?.(e.target.checked);
+  };
+
+  const isDefaultEligible = canSetDefault && isDefaultEligibleType(selectedType);
 
   return (
     <Stack direction="column" spacing={4}>
@@ -93,6 +110,27 @@ export default function ConfigureName({
           }
         />
       </FormControl>
+
+      {isDefaultEligible && (
+        <FormControl fullWidth>
+          <FormControlLabel
+            control={
+              <Checkbox
+                id="resource-server-make-default-input"
+                checked={makeDefault}
+                onChange={handleMakeDefaultChange}
+              />
+            }
+            label={t('resourceServers:create.name.makeDefaultLabel', 'Make this the default resource server')}
+          />
+          <Typography variant="body2" color="text.secondary">
+            {t(
+              'resourceServers:setDefault.explanation',
+              'When an application requests a token without naming a resource server, its permissions come from this one. Only one resource server can be the default at a time.',
+            )}
+          </Typography>
+        </FormControl>
+      )}
     </Stack>
   );
 }

--- a/frontend/packages/configure-resource-servers/src/components/create-resource-server/__tests__/ConfigureName.test.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/create-resource-server/__tests__/ConfigureName.test.tsx
@@ -139,3 +139,78 @@ describe('ConfigureName', () => {
     ).toBeInTheDocument();
   });
 });
+
+describe('ConfigureName default resource server checkbox', () => {
+  beforeEach(() => {
+    vi.mocked(generateRandomHumanReadableIdentifiers).mockReturnValue(mockSuggestions);
+  });
+
+  const renderWithDefault = (props: Partial<Parameters<typeof ConfigureName>[0]> = {}) =>
+    render(
+      <ConfigureName
+        name="Test"
+        identifier="https://api.example.com"
+        selectedType="API"
+        canSetDefault
+        onNameChange={vi.fn()}
+        onIdentifierChange={vi.fn()}
+        {...props}
+      />,
+    );
+
+  const defaultCheckbox = () => screen.queryByRole('checkbox', {name: /make this the default resource server/i});
+
+  it('offers the choice for an API resource server', () => {
+    renderWithDefault();
+
+    expect(defaultCheckbox()).toBeInTheDocument();
+  });
+
+  it('offers the choice for a custom resource server', () => {
+    renderWithDefault({selectedType: 'CUSTOM'});
+
+    expect(defaultCheckbox()).not.toBeNull();
+  });
+
+  it('does not offer the choice for an MCP server', () => {
+    renderWithDefault({selectedType: 'MCP'});
+
+    expect(defaultCheckbox()).toBeNull();
+  });
+
+  it('does not offer the choice while the default config is unavailable', () => {
+    renderWithDefault({canSetDefault: false});
+
+    expect(defaultCheckbox()).toBeNull();
+  });
+
+  it('reflects the ticked state it is given', () => {
+    renderWithDefault({makeDefault: true});
+
+    expect(defaultCheckbox()).toBeChecked();
+  });
+
+  it('reflects the unticked state it is given', () => {
+    renderWithDefault({makeDefault: false});
+
+    expect(defaultCheckbox()).not.toBeChecked();
+  });
+
+  it('reports a tick to the caller', () => {
+    const onMakeDefaultChange = vi.fn();
+    renderWithDefault({makeDefault: false, onMakeDefaultChange});
+
+    fireEvent.click(defaultCheckbox()!);
+
+    expect(onMakeDefaultChange).toHaveBeenCalledWith(true);
+  });
+
+  it('reports an untick to the caller', () => {
+    const onMakeDefaultChange = vi.fn();
+    renderWithDefault({makeDefault: true, onMakeDefaultChange});
+
+    fireEvent.click(defaultCheckbox()!);
+
+    expect(onMakeDefaultChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/frontend/packages/configure-resource-servers/src/models/resource-server.ts
+++ b/frontend/packages/configure-resource-servers/src/models/resource-server.ts
@@ -5,6 +5,13 @@ import type {PermissionDelimiter} from './permissions';
 
 export type ResourceServerType = 'API' | 'MCP' | 'CUSTOM';
 
+const DEFAULT_ELIGIBLE_TYPES: readonly ResourceServerType[] = ['API', 'CUSTOM'];
+
+// MCP servers are always addressed by their own identifier, so they never act as the fallback.
+export function isDefaultEligibleType(type: ResourceServerType | undefined): boolean {
+  return type !== undefined && DEFAULT_ELIGIBLE_TYPES.includes(type);
+}
+
 export interface ResourceServer {
   id: string;
   name: string;

--- a/frontend/packages/configure-resource-servers/src/pages/CreateResourceServerPage.tsx
+++ b/frontend/packages/configure-resource-servers/src/pages/CreateResourceServerPage.tsx
@@ -21,6 +21,8 @@ import {useCallback, useMemo, useState, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
 import useCreateResourceServer from '../api/useCreateResourceServer';
+import useGetDefaultResourceServer from '../api/useGetDefaultResourceServer';
+import useSetDefaultResourceServer from '../api/useSetDefaultResourceServer';
 import ConfigureName from '../components/create-resource-server/ConfigureName';
 import ConfigureOrgUnit from '../components/create-resource-server/ConfigureOrgUnit';
 import ConfigureSeparator from '../components/create-resource-server/ConfigureSeparator';
@@ -28,7 +30,7 @@ import ConfigureType from '../components/create-resource-server/ConfigureType';
 import {DEFAULT_PERMISSION_DELIMITER} from '../constants/permission-constants';
 import useResourceServerRoutes from '../hooks/useResourceServerRoutes';
 import type {PermissionDelimiter} from '../models/permissions';
-import type {ResourceServerType} from '../models/resource-server';
+import {isDefaultEligibleType, type ResourceServerType} from '../models/resource-server';
 
 const ResourceServerCreateStep = {
   TYPE: 'TYPE',
@@ -46,8 +48,17 @@ export default function CreateResourceServerPage(): JSX.Element {
   const {showToast} = useToast();
   const logger = useLogger('CreateResourceServerPage');
   const createResourceServer = useCreateResourceServer();
+  const setDefaultResourceServer = useSetDefaultResourceServer();
+  const {data: defaultConfig, isLoading: isDefaultLoading, error: defaultError} = useGetDefaultResourceServer();
 
   const {hasMultipleOUs, isLoading: isOuLoading, ouList} = useHasMultipleOUs();
+
+  // Only trust the config once it has resolved, so the checkbox does not flicker from unticked to
+  // ticked. A declarative (read-only) default is locked: the backend rejects any write to it.
+  const isDefaultReady = !isDefaultLoading && !defaultError;
+  const isDefaultLocked = Boolean(defaultConfig?.readOnly?.resourceServerId);
+  const canSetDefault = isDefaultReady && !isDefaultLocked;
+  const hasExistingDefault = Boolean(defaultConfig?.merged?.resourceServerId);
 
   const [currentStep, setCurrentStep] = useState<ResourceServerCreateStep>(ResourceServerCreateStep.TYPE);
   const [selectedType, setSelectedType] = useState<ResourceServerType | undefined>(undefined);
@@ -56,6 +67,11 @@ export default function CreateResourceServerPage(): JSX.Element {
   const [delimiter, setDelimiter] = useState<PermissionDelimiter>(DEFAULT_PERMISSION_DELIMITER);
   const [ouId, setOuId] = useState('');
   const [error, setError] = useState<string | null>(null);
+  // Only the user's explicit choice is stored. Until they make one it derives from the config, which
+  // resolves after the first render: offer to make this the default only when the deployment has
+  // none. Deriving avoids seeding state from an effect once the config arrives.
+  const [makeDefaultOverride, setMakeDefaultOverride] = useState<boolean | undefined>(undefined);
+  const makeDefault = makeDefaultOverride ?? !hasExistingDefault;
 
   const [stepReady, setStepReady] = useState<Record<ResourceServerCreateStep, boolean>>({
     TYPE: false,
@@ -113,6 +129,14 @@ export default function CreateResourceServerPage(): JSX.Element {
     (newDelimiter: PermissionDelimiter): void => {
       clearCreateError();
       setDelimiter(newDelimiter);
+    },
+    [clearCreateError],
+  );
+
+  const handleMakeDefaultChange = useCallback(
+    (newMakeDefault: boolean): void => {
+      clearCreateError();
+      setMakeDefaultOverride(newMakeDefault);
     },
     [clearCreateError],
   );
@@ -198,6 +222,10 @@ export default function CreateResourceServerPage(): JSX.Element {
       delimiter,
     };
 
+    // Guard on the same conditions the checkbox renders under, so a type change after ticking it
+    // cannot carry a stale choice into the request.
+    const shouldMakeDefault = makeDefault && canSetDefault && isDefaultEligibleType(selectedType);
+
     createResourceServer.mutate(payload, {
       onSuccess: (created) => {
         showToast(
@@ -206,11 +234,39 @@ export default function CreateResourceServerPage(): JSX.Element {
             : t('resourceServers:create.success', 'Resource server created successfully.'),
           'success',
         );
-        (async (): Promise<void> => {
-          await navigate(`${routes.detail(created.id)}?tab=resources`);
-        })().catch((err: unknown) => {
-          logger.error('Failed to navigate after create', {error: err});
-        });
+
+        const goToCreated = (): void => {
+          (async (): Promise<void> => {
+            await navigate(`${routes.detail(created.id)}?tab=resources`);
+          })().catch((err: unknown) => {
+            logger.error('Failed to navigate after create', {error: err});
+          });
+        };
+
+        if (!shouldMakeDefault) {
+          goToCreated();
+          return;
+        }
+
+        // The server already exists by now, so a failure here must not read as a create failure.
+        // Warn and continue to the created server; the default can be set from its page.
+        setDefaultResourceServer.mutate(
+          {resourceServerId: created.id},
+          {
+            onSuccess: () => goToCreated(),
+            onError: (err: Error) => {
+              logger.error('Failed to set the new resource server as default', {error: err});
+              showToast(
+                t(
+                  'resourceServers:create.setDefaultError',
+                  'Resource server created, but it could not be made the default.',
+                ),
+                'warning',
+              );
+              goToCreated();
+            },
+          },
+        );
       },
       onError: (err: Error) => {
         logger.error('Failed to create resource server', {error: err});
@@ -231,7 +287,14 @@ export default function CreateResourceServerPage(): JSX.Element {
     }
   };
 
-  const isNextDisabled = createResourceServer.isPending || !stepReady[currentStep] || (isLastStep && isOuLoading);
+  // The wizard is spent once the create succeeds: the follow-up default request and the navigation
+  // away both still have to run, and re-enabling in between would let the user create a duplicate.
+  // Keyed off isSuccess rather than the two pending flags so it never depends on the two mutations'
+  // state changes landing in the same render.
+  const isSubmitting =
+    createResourceServer.isPending || createResourceServer.isSuccess || setDefaultResourceServer.isPending;
+
+  const isNextDisabled = isSubmitting || !stepReady[currentStep] || (isLastStep && isOuLoading);
 
   const getProgress = (): number => {
     const totalSteps = hasMultipleOUs ? 4 : 3;
@@ -260,9 +323,12 @@ export default function CreateResourceServerPage(): JSX.Element {
             name={name}
             identifier={identifier}
             selectedType={selectedType}
+            canSetDefault={canSetDefault}
+            makeDefault={makeDefault}
             onNameChange={handleNameChange}
             onIdentifierChange={handleIdentifierChange}
             onReadyChange={handleNameReadyChange}
+            onMakeDefaultChange={handleMakeDefaultChange}
           />
         );
       case ResourceServerCreateStep.SEPARATOR:
@@ -349,21 +415,16 @@ export default function CreateResourceServerPage(): JSX.Element {
                   }}
                 >
                   {currentStep !== ResourceServerCreateStep.TYPE && (
-                    <Button
-                      variant="outlined"
-                      onClick={handleBack}
-                      sx={{minWidth: 100}}
-                      disabled={createResourceServer.isPending}
-                    >
+                    <Button variant="outlined" onClick={handleBack} sx={{minWidth: 100}} disabled={isSubmitting}>
                       {t('common:actions.back', 'Back')}
                     </Button>
                   )}
 
                   <Box sx={{display: 'flex', alignItems: 'center', gap: 2}}>
-                    {createResourceServer.isPending && <CircularProgress size={20} />}
+                    {isSubmitting && <CircularProgress size={20} />}
                     <Button variant="contained" disabled={isNextDisabled} sx={{minWidth: 100}} onClick={handleNext}>
                       {isLastStep
-                        ? createResourceServer.isPending
+                        ? isSubmitting
                           ? t('resourceServers:create.creating', 'Creating…')
                           : selectedType === 'MCP'
                             ? t('resourceServers:create.submitMcp', 'Create MCP server')

--- a/frontend/packages/configure-resource-servers/src/pages/__tests__/CreateResourceServerPage.test.tsx
+++ b/frontend/packages/configure-resource-servers/src/pages/__tests__/CreateResourceServerPage.test.tsx
@@ -60,6 +60,23 @@ vi.mock('../../api/useCreateResourceServer', () => ({
   default: () => mockUseCreateResourceServer(),
 }));
 
+const mockSetDefaultMutate = vi.fn();
+const mockDefaultConfig = vi.fn(() => ({
+  data: {readOnly: {}, writable: {}, merged: {}},
+  isLoading: false,
+  error: null,
+}));
+
+vi.mock('../../api/useGetDefaultResourceServer', () => ({
+  default: () => mockDefaultConfig(),
+}));
+
+const mockUseSetDefaultResourceServer = vi.fn(() => ({mutate: mockSetDefaultMutate, isPending: false}));
+
+vi.mock('../../api/useSetDefaultResourceServer', () => ({
+  default: () => mockUseSetDefaultResourceServer(),
+}));
+
 vi.mock('@thunderid/configure-organization-units', () => ({
   useHasMultipleOUs: () => ({
     hasMultipleOUs: false,
@@ -78,6 +95,12 @@ describe('CreateResourceServerPage', () => {
       isError: false,
       reset: mockCreateResourceServerReset,
     });
+    mockDefaultConfig.mockReturnValue({
+      data: {readOnly: {}, writable: {}, merged: {}},
+      isLoading: false,
+      error: null,
+    });
+    mockUseSetDefaultResourceServer.mockReturnValue({mutate: mockSetDefaultMutate, isPending: false});
   });
 
   it('renders the Type step initially', () => {
@@ -381,5 +404,212 @@ describe('CreateResourceServerPage', () => {
     fireEvent.click(screen.getByRole('button', {name: /API/i}));
 
     expect(mockCreateResourceServerReset).not.toHaveBeenCalled();
+  });
+});
+
+describe('CreateResourceServerPage default resource server', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseCreateResourceServer.mockReturnValue({
+      mutate: mockCreateResourceServerMutate,
+      isPending: false,
+      isError: false,
+      reset: mockCreateResourceServerReset,
+    });
+    mockDefaultConfig.mockReturnValue({
+      data: {readOnly: {}, writable: {}, merged: {}},
+      isLoading: false,
+      error: null,
+    });
+    mockUseSetDefaultResourceServer.mockReturnValue({mutate: mockSetDefaultMutate, isPending: false});
+  });
+
+  const defaultCheckbox = () => screen.queryByRole('checkbox', {name: /make this the default resource server/i});
+
+  const goToLastStep = async (): Promise<void> => {
+    renderWithProviders(<CreateResourceServerPage />);
+
+    fireEvent.click(screen.getByRole('button', {name: /API/i}));
+    fireEvent.click(screen.getByRole('button', {name: /Continue/i}));
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', {name: /resource server name/i})).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByRole('textbox', {name: /resource server name/i}), {
+      target: {value: 'Payments API'},
+    });
+    fireEvent.change(screen.getByRole('textbox', {name: /identifier/i}), {
+      target: {value: 'https://api.example.com'},
+    });
+  };
+
+  const submit = async (): Promise<void> => {
+    fireEvent.click(screen.getByRole('button', {name: /Continue/i}));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: /Create resource server/i})).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', {name: /Create resource server/i}));
+  };
+
+  const createSucceedsWith = (id: string): void => {
+    mockCreateResourceServerMutate.mockImplementationOnce(
+      (_payload: unknown, options: {onSuccess: (created: ResourceServer) => void}) => {
+        options.onSuccess({id} as ResourceServer);
+      },
+    );
+  };
+
+  it('ticks the choice when the deployment has no default yet', async () => {
+    await goToLastStep();
+
+    expect(defaultCheckbox()).toBeChecked();
+  });
+
+  it('leaves the choice unticked when a default already exists', async () => {
+    mockDefaultConfig.mockReturnValue({
+      data: {readOnly: {}, writable: {resourceServerId: 'rs-existing'}, merged: {resourceServerId: 'rs-existing'}},
+      isLoading: false,
+      error: null,
+    });
+
+    await goToLastStep();
+
+    expect(defaultCheckbox()).not.toBeChecked();
+  });
+
+  it('does not offer the choice when a declarative default has locked it', async () => {
+    mockDefaultConfig.mockReturnValue({
+      data: {readOnly: {resourceServerId: 'rs-locked'}, writable: {}, merged: {resourceServerId: 'rs-locked'}},
+      isLoading: false,
+      error: null,
+    });
+
+    await goToLastStep();
+
+    expect(defaultCheckbox()).toBeNull();
+  });
+
+  it('does not offer the choice while the default config is still loading', async () => {
+    mockDefaultConfig.mockReturnValue({data: undefined, isLoading: true, error: null});
+
+    await goToLastStep();
+
+    expect(defaultCheckbox()).toBeNull();
+  });
+
+  it('makes the created resource server the default when the choice is ticked', async () => {
+    createSucceedsWith('rs-new');
+
+    await goToLastStep();
+    await submit();
+
+    expect(mockSetDefaultMutate).toHaveBeenCalledWith({resourceServerId: 'rs-new'}, expect.any(Object));
+  });
+
+  it('leaves the default alone when the choice is unticked', async () => {
+    createSucceedsWith('rs-new');
+
+    await goToLastStep();
+    fireEvent.click(defaultCheckbox()!);
+    await submit();
+
+    expect(mockCreateResourceServerMutate).toHaveBeenCalled();
+    expect(mockSetDefaultMutate).not.toHaveBeenCalled();
+  });
+
+  it('still navigates to the created resource server when making it the default fails', async () => {
+    createSucceedsWith('rs-new');
+    mockSetDefaultMutate.mockImplementationOnce((_payload: unknown, options: {onError: (err: Error) => void}) => {
+      options.onError(new Error('locked'));
+    });
+
+    await goToLastStep();
+    await submit();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining('rs-new'));
+    });
+    expect(mockShowToast).toHaveBeenCalledWith(expect.stringMatching(/could not be made the default/i), 'warning');
+  });
+});
+
+describe('CreateResourceServerPage submit locking', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseCreateResourceServer.mockReturnValue({
+      mutate: mockCreateResourceServerMutate,
+      isPending: false,
+      isError: false,
+      reset: mockCreateResourceServerReset,
+    });
+    mockDefaultConfig.mockReturnValue({
+      data: {readOnly: {}, writable: {}, merged: {}},
+      isLoading: false,
+      error: null,
+    });
+    mockUseSetDefaultResourceServer.mockReturnValue({mutate: mockSetDefaultMutate, isPending: false});
+  });
+
+  const goToLastStep = async (): Promise<void> => {
+    fireEvent.click(screen.getByRole('button', {name: /API/i}));
+    fireEvent.click(screen.getByRole('button', {name: /Continue/i}));
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', {name: /resource server name/i})).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByRole('textbox', {name: /resource server name/i}), {
+      target: {value: 'Payments API'},
+    });
+    fireEvent.change(screen.getByRole('textbox', {name: /identifier/i}), {
+      target: {value: 'https://api.example.com'},
+    });
+    fireEvent.click(screen.getByRole('button', {name: /Continue/i}));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: /Create resource server/i})).toBeInTheDocument();
+    });
+  };
+
+  const submitButton = (): HTMLElement => screen.getByRole('button', {name: /Create resource server|Creating/i});
+
+  it('keeps the submit button disabled while the follow-up default request is still in flight', async () => {
+    const {rerender} = renderWithProviders(<CreateResourceServerPage />);
+    await goToLastStep();
+
+    expect(submitButton()).toBeEnabled();
+
+    // The create has resolved but its follow-up default request has not, so navigation is still
+    // pending. Re-submitting here would create a duplicate resource server.
+    mockUseCreateResourceServer.mockReturnValue({
+      mutate: mockCreateResourceServerMutate,
+      isPending: false,
+      isSuccess: true,
+      isError: false,
+      reset: mockCreateResourceServerReset,
+    });
+    mockUseSetDefaultResourceServer.mockReturnValue({mutate: mockSetDefaultMutate, isPending: true});
+    rerender(<CreateResourceServerPage />);
+
+    expect(submitButton()).toBeDisabled();
+  });
+
+  it('keeps the submit button disabled after a create succeeds even before the default request starts', async () => {
+    const {rerender} = renderWithProviders(<CreateResourceServerPage />);
+    await goToLastStep();
+
+    mockUseCreateResourceServer.mockReturnValue({
+      mutate: mockCreateResourceServerMutate,
+      isPending: false,
+      isSuccess: true,
+      isError: false,
+      reset: mockCreateResourceServerReset,
+    });
+    rerender(<CreateResourceServerPage />);
+
+    expect(submitButton()).toBeDisabled();
   });
 });

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -4624,13 +4624,20 @@ const translations = {
     'listing.columns.type': 'Type',
     'listing.columns.identifier': 'Identifier',
     'listing.columns.actions': 'Actions',
+    'listing.actions.more': 'More actions',
     'listing.systemResourceServer': 'System resource server',
     'listing.default': 'Default',
     'listing.error': 'Failed to load resource servers',
     'actions.setAsDefault': 'Set as default',
     'setDefault.title': 'Set default resource server',
-    'setDefault.message':
-      'will become the default resource server. Requests without a resource parameter will fall back to it.',
+    'setDefault.message': '<bold>{{name}}</bold> will become the default resource server.',
+    'setDefault.unavailableReason': 'Checking the current default resource server.',
+    'setDefault.lockedReason': 'The default resource server is fixed by the deployment configuration.',
+    'setDefault.alreadyDefaultReason': 'This is already the default resource server.',
+    'setDefault.ineligibleTypeReason': 'Only API and custom resource servers can be the default.',
+    'setDefault.explanation':
+      'When an application requests a token without naming a resource server, its permissions come from this one. Only one resource server can be the default at a time.',
+    'setDefault.action': 'Make default resource server',
     'setDefault.confirm': 'Set as default',
     'setDefault.setting': 'Setting…',
     'setDefault.success': '{{name}} is now the default resource server.',
@@ -4716,6 +4723,8 @@ const translations = {
       'A unique identifier for this resource server. When set as an absolute URI, it becomes the token audience for RFC 8707 resource indicators.',
     'create.name.identifierHintMcp':
       'A unique identifier for this MCP server. When set as an absolute URI, it becomes the token audience for RFC 8707 resource indicators.',
+    'create.name.makeDefaultLabel': 'Make this the default resource server',
+    'create.setDefaultError': 'Resource server created, but it could not be made the default.',
     'create.separator.title': 'Choose your permission delimiter',
     'create.separator.subtitle':
       'The delimiter character joins parts of a permission string. This cannot be changed after creation.',


### PR DESCRIPTION
### Purpose

  Resource servers could previously be made the deployment default only after creation and from limited management surfaces. This change makes default-resource-server configuration
  available directly from the creation wizard and resource server list.

  The creation wizard now displays a preselected “Make this the default resource server” option for eligible API and custom resource servers when the deployment does not already
  have a default. The option is hidden while configuration is loading and when a declarative default prevents updates.

  The resource server list also provides a “Make default resource server” action for eligible rows.

  ### Approach
  - Added a shared helper defining API and custom resource servers as eligible default types.
  - Added the default-resource-server checkbox to the Details step of the creation wizard.
  - Preselected the checkbox when no default resource server exists.
  - Hid default actions while configuration is loading, after a configuration failure, or when a declarative default locks updates.
  - After successful creation, used the existing default-resource-server mutation to make the new resource server the default.
  - Kept the wizard locked while creation, default assignment, or navigation is in progress to prevent duplicate submissions.
  - Added a three-dot menu to eligible resource server rows that opens the existing set-default dialog.
  - Consolidated the default-resource-server explanation into one shared translation used by the wizard and dialog.
  - Added unit tests covering eligibility, default selection, loading and locked states, mutation sequencing, failure handling, menu visibility, and submission locking.

  ### Related Issues
  - Fixes #4634

  ### Related PRs
  - N/A

  ### Checklist

  - [x] Followed the contribution guidelines.
  - [x] Manual test round performed and verified.
  - [ ] Documentation provided. Not applicable.
      - [ ] Ran Vale and fixed all errors and warnings. Not applicable.
  - [x] Tests provided.
      - [x] Unit Tests
      - [ ] Integration Tests
  - [x] Breaking changes. Not applicable.
      - [ ] Breaking changes section filled.
      - [ ] breaking change label added.

  ### Security checks
  - [x] Followed secure coding standards in WSO2 Secure Coding Guidelines
    (https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
  - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Choose to make an eligible resource server the default during creation.
  * Set an existing eligible resource server as default from its overflow menu.
  * View guidance about token fallback behavior and the single-default limitation.

* **Bug Fixes**
  * Default-setting controls are hidden or disabled for unsupported, read-only, locked, or unavailable resource servers.
  * Creation remains safely locked while default settings are being applied.
  * A warning is shown if applying the new default fails, while navigation still completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->