### PR TITLE
Fix rich-text link wiring in the flow builder

### DIFF
--- a/frontend/apps/console/src/features/flows/components/FlowBuilder.tsx
+++ b/frontend/apps/console/src/features/flows/components/FlowBuilder.tsx
@@ -38,7 +38,11 @@ import useFlowEvents from '@/features/flows/hooks/useFlowEvents';
 import useValidationStatus from '@/features/flows/hooks/useValidationStatus';
 import {FlowType} from '@/features/flows/models/flows';
 import {ExecutionTypes, StepTypes, type StepData} from '@/features/flows/models/steps';
-import {GRAPH_VALIDATION_RULES, SIGN_OUT_GRAPH_VALIDATION_RULES} from '@/features/flows/validation/validation-rules';
+import {
+  COMMON_GRAPH_VALIDATION_RULES,
+  GRAPH_VALIDATION_RULES,
+  SIGN_OUT_GRAPH_VALIDATION_RULES,
+} from '@/features/flows/validation/validation-rules';
 
 const SMS_EXECUTORS = new Set<string>([ExecutionTypes.SMSExecutor]);
 
@@ -226,8 +230,8 @@ function FlowBuilder() {
 
   const flowType = (existingFlowData as {flowType?: string} | undefined)?.flowType ?? 'AUTHENTICATION';
 
-  // The SSO pairing rules only apply to AUTHENTICATION flows; other flow
-  // types run without graph-level rules.
+  // SSO pairing is AUTHENTICATION-only and the confirm-action rule SIGNOUT-only.
+  // Every flow type still gets the common rules.
   useEffect(() => {
     if (flowType === FlowType.AUTHENTICATION) {
       setGraphValidationRules(GRAPH_VALIDATION_RULES);
@@ -239,7 +243,7 @@ function FlowBuilder() {
       return;
     }
 
-    setGraphValidationRules([]);
+    setGraphValidationRules(COMMON_GRAPH_VALIDATION_RULES);
   }, [flowType, setGraphValidationRules]);
 
   // Undo/redo history over the canvas graph.

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/CommonResourceProperties.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/CommonResourceProperties.tsx
@@ -105,6 +105,11 @@ function CommonResourceProperties(): ReactElement {
   const {renameStep} = useRenameStep();
   const renameStepRef = useRef(renameStep);
 
+  // Set while a pending edit is being flushed because the selection changed. The flush must
+  // still commit the edit to the node it was made on, but must not re-select that resource,
+  // which would bounce the panel back from whatever the user just clicked.
+  const isFlushingOnSelectionChangeRef = useRef<boolean>(false);
+
   useEffect(() => {
     renameStepRef.current = renameStep;
   }, [renameStep]);
@@ -269,7 +274,9 @@ function CommonResourceProperties(): ReactElement {
           const updatedResource: Resource = cloneDeep(currentResource);
           set(updatedResource as unknown as Record<string, unknown>, propertyKey, newValue);
           lastInteractedResourceRef.current = updatedResource;
-          setLastInteractedResourceRef.current(updatedResource);
+          if (!isFlushingOnSelectionChangeRef.current) {
+            setLastInteractedResourceRef.current(updatedResource);
+          }
         }
         return;
       }
@@ -333,7 +340,9 @@ function CommonResourceProperties(): ReactElement {
         // properties, such as the button's Action selector) would rebase on the
         // pre-change resource and drop the first one.
         lastInteractedResourceRef.current = updatedResource;
-        setLastInteractedResourceRef.current(updatedResource);
+        if (!isFlushingOnSelectionChangeRef.current) {
+          setLastInteractedResourceRef.current(updatedResource);
+        }
       }
     };
   }, [emitPropertyChange]);
@@ -368,7 +377,12 @@ function CommonResourceProperties(): ReactElement {
   // are re-synced below, so the flush still lands on the resource it was typed into.
   useEffect(
     () => () => {
-      (handlePropertyChangeDebouncedRef.current as ReturnType<typeof debounce> | null)?.flush();
+      isFlushingOnSelectionChangeRef.current = true;
+      try {
+        (handlePropertyChangeDebouncedRef.current as ReturnType<typeof debounce> | null)?.flush();
+      } finally {
+        isFlushingOnSelectionChangeRef.current = false;
+      }
     },
     [lastInteractedResource?.id, lastInteractedStepId],
   );

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/DraftTextField.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/DraftTextField.tsx
@@ -83,6 +83,13 @@ function DraftTextField({value, onCommit, normalize = undefined, ...rest}: Draft
 
   useEffect(() => {
     pendingCommitRef.current = (): void => {
+      // Only an edit in progress may be flushed. Normalization can turn an untouched draft
+      // into a different value (an empty field falling back to its minimum), so an unedited
+      // field is left alone rather than storing a value the user never entered.
+      if (draft === committed) {
+        return;
+      }
+
       const next: string | null = resolve();
 
       if (next !== null && next !== committed) {

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/__tests__/DraftTextField.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/__tests__/DraftTextField.test.tsx
@@ -223,6 +223,24 @@ describe('DraftTextField', () => {
       expect(input).toHaveValue('20');
     });
 
+    it('should not commit the minimum when an empty field unmounts untouched', () => {
+      // `clampToInteger('')` resolves to the minimum, so flushing an unedited field would
+      // store a value the author never entered — and, before the selection-change fix, store
+      // it against whichever component the panel had just switched to.
+      const {unmount} = render(
+        <DraftTextField
+          value=""
+          onCommit={mockOnCommit}
+          normalize={(raw) => clampToInteger(raw, 1, 20)}
+          inputProps={{'aria-label': 'field'}}
+        />,
+      );
+
+      unmount();
+
+      expect(mockOnCommit).not.toHaveBeenCalled();
+    });
+
     it('should restore the committed value when normalization rejects the draft', () => {
       render(
         <DraftTextField

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/rich-text/RichTextActionFields.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/rich-text/RichTextActionFields.tsx
@@ -26,6 +26,29 @@ export interface RichTextActionInterface {
 }
 
 /**
+ * Matches a `data-action-ref` attribute and captures its value. The leading whitespace is an
+ * attribute boundary, matching `syncLabelActionRef` and the adapter's own matcher, so an
+ * attribute merely ending in `data-action-ref` cannot be mistaken for the sentinel.
+ */
+const ACTION_REF_SENTINEL = /\sdata-action-ref\s*=\s*(?:"([^"]*)"|'([^']*)')/gi;
+
+/**
+ * Reads the `data-action-ref` sentinels out of a rich text's label HTML, in document order.
+ *
+ * @param label - The rich text's label, which may be HTML.
+ * @returns The sentinel values, empty when the label carries none.
+ */
+function getAnchorActionRefs(label: string | undefined): string[] {
+  if (!label) {
+    return [];
+  }
+
+  return Array.from(label.matchAll(ACTION_REF_SENTINEL))
+    .map((match: RegExpMatchArray) => match[1] ?? match[2])
+    .filter((ref: string) => ref !== '');
+}
+
+/**
  * RichTextActionFields is a React component that renders the action configuration fields for a rich-text resource.
  *
  * @param param0 - The props for the component, including the resource and onChange handler.
@@ -64,10 +87,21 @@ function RichTextActionFields({resource, onChange}: RichTextActionFieldsPropsInt
   const handleToggle = (enabled: boolean): void => {
     setIsEnabled(enabled);
     if (enabled) {
-      // Preserve the widget's predefined ref if there is one (e.g. Self Sign Up Link
-      // ships with `action_signup`). Otherwise seed an empty ref — the connect handler
-      // will fill it in with the target node's id once the author draws an edge.
-      onChange('action', {ref: action?.ref ?? ''}, resource);
+      // The ref must equal the anchor's `data-action-ref` in the label HTML, otherwise the
+      // rendered link dispatches nothing. Keep the existing ref only when an anchor still
+      // carries it — `action` writes never rebroadcast (see isEnabled), so after a toggle
+      // off and on again it can hold a value the label has since moved away from. Otherwise
+      // take the label's first sentinel, and fall back to the component id when there is
+      // none (a label with no sentinel dispatches on any anchor click).
+      const labelRefs = getAnchorActionRefs((resource as Resource & {label?: string}).label);
+      const existingRef = action?.ref === '' ? undefined : action?.ref;
+      const derivedRef =
+        (existingRef !== undefined && labelRefs.includes(existingRef) ? existingRef : undefined) ??
+        labelRefs[0] ??
+        existingRef ??
+        resource.id;
+
+      onChange('action', {ref: derivedRef}, resource);
     } else {
       // Drop any edges the author drew from this rich-text's source handle — the
       // handle is about to disappear, so orphaned edges would dangle otherwise.

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/rich-text/__tests__/RichTextActionFields.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/rich-text/__tests__/RichTextActionFields.test.tsx
@@ -48,11 +48,51 @@ describe('RichTextActionFields', () => {
     expect(screen.queryByTestId('rich-text-action-ref')).not.toBeInTheDocument();
   });
 
-  it('turning the toggle on writes an empty action ref via onChange', () => {
+  it('turning the toggle on falls back to the component id when the label has no sentinel', () => {
+    // A label with no data-action-ref dispatches on any anchor click, so the component id is a
+    // safe ref. An empty one would serialise as `{"ref": ""}` and never dispatch.
     render(<RichTextActionFields resource={makeResource()} onChange={onChange} />);
     const toggle = screen.getByTestId('rich-text-action-enabled').querySelector('input') as HTMLInputElement;
     fireEvent.click(toggle);
-    expect(onChange).toHaveBeenCalledWith('action', {ref: ''}, expect.anything());
+    expect(onChange).toHaveBeenCalledWith('action', {ref: 'rt-1'}, expect.anything());
+  });
+
+  it("turning the toggle on adopts the label anchor's sentinel", () => {
+    const resource = makeResource({
+      label: '<p><a href="#" data-action-ref="action_recovery">Forgot password?</a></p>',
+    } as unknown as Partial<Resource>);
+    render(<RichTextActionFields resource={resource} onChange={onChange} />);
+    const toggle = screen.getByTestId('rich-text-action-enabled').querySelector('input') as HTMLInputElement;
+    fireEvent.click(toggle);
+    expect(onChange).toHaveBeenCalledWith('action', {ref: 'action_recovery'}, resource);
+  });
+
+  it('turning the toggle back on drops a ref no anchor carries', () => {
+    // Flows saved before the ref and the sentinel were kept in sync hold a target node id in
+    // `action.ref`. Re-seeding it would keep the link dead; the label is authoritative.
+    const resource = makeResource({
+      action: {ref: 'recovery_call_g0v6'},
+      label: '<p><a href="#" data-action-ref="action_recovery">Forgot password?</a></p>',
+    } as unknown as Partial<Resource>);
+    render(<RichTextActionFields resource={resource} onChange={onChange} />);
+    const toggle = screen.getByTestId('rich-text-action-enabled').querySelector('input') as HTMLInputElement;
+    fireEvent.click(toggle);
+    fireEvent.click(toggle);
+    expect(onChange).toHaveBeenLastCalledWith('action', {ref: 'action_recovery'}, resource);
+  });
+
+  it('keeps a ref that matches a later anchor in a multi-link label', () => {
+    const resource = makeResource({
+      action: {ref: 'action_signup'},
+      label:
+        '<p><a href="#" data-action-ref="action_recovery">Forgot password?</a>' +
+        '<a href="#" data-action-ref="action_signup">Sign up</a></p>',
+    } as unknown as Partial<Resource>);
+    render(<RichTextActionFields resource={resource} onChange={onChange} />);
+    const toggle = screen.getByTestId('rich-text-action-enabled').querySelector('input') as HTMLInputElement;
+    fireEvent.click(toggle);
+    fireEvent.click(toggle);
+    expect(onChange).toHaveBeenLastCalledWith('action', {ref: 'action_signup'}, resource);
   });
 
   it('preserves an existing action ref when the toggle is turned back on', () => {

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/rich-text/helper-plugins/HTMLPlugin.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/rich-text/helper-plugins/HTMLPlugin.tsx
@@ -38,12 +38,113 @@ const CLASS_NAME_PLACEHOLDER = '{{className}}';
 const ADDITIONAL_CLASSES = `class="${CLASS_NAME_PLACEHOLDER}"`;
 const EMPTY_CONTENT = '<p class="rich-text-paragraph"><br></p>';
 
+/** Identifies an anchor across an editor round trip by what the author sees and clicks. */
+function anchorIdentity(anchor: HTMLAnchorElement): string {
+  return `${anchor.getAttribute('href') ?? ''}|${anchor.textContent?.trim() ?? ''}`;
+}
+
+/**
+ * Restores the `data-component-ref` and `data-action-ref` sentinels that Lexical drops.
+ *
+ * Lexical only round-trips the attributes its registered node classes declare, so both
+ * sentinels are lost on every export. Both carry behaviour: the renderer hides a link whose
+ * component ref is disabled for the application, and dispatches only the anchor whose action
+ * ref matches the component's `action.ref`.
+ *
+ * Anchors are matched on href plus text so a link keeps its own ref when surrounding content is
+ * edited, including when another link is inserted ahead of it. Position is the fallback, used
+ * only when the identity is ambiguous or the link itself was edited, and then only while the
+ * anchor count is unchanged — a shifted index would move the ref onto the wrong link.
+ *
+ * TODO(#4658): drop once the editor node classes declare these attributes.
+ *
+ * @param html - The exported HTML.
+ * @param sourceLabel - The label the editor was seeded with.
+ * @returns The HTML with its sentinels restored.
+ */
+function restoreActionSentinels(html: string, sourceLabel: string): string {
+  if (!sourceLabel.includes('data-component-ref') && !sourceLabel.includes('data-action-ref')) {
+    return html;
+  }
+
+  const parser: DOMParser = new DOMParser();
+  const source: Document = parser.parseFromString(sourceLabel, 'text/html');
+  const target: Document = parser.parseFromString(html, 'text/html');
+
+  const componentRef: string | null =
+    source.body.querySelector('[data-component-ref]')?.getAttribute('data-component-ref') ?? null;
+  const firstBlock: globalThis.Element | null = target.body.firstElementChild;
+
+  if (componentRef && firstBlock && !firstBlock.hasAttribute('data-component-ref')) {
+    firstBlock.setAttribute('data-component-ref', componentRef);
+  }
+
+  const sourceAnchors: HTMLAnchorElement[] = Array.from(source.body.querySelectorAll('a'));
+  const targetAnchors: HTMLAnchorElement[] = Array.from(target.body.querySelectorAll('a'));
+  const countsMatch: boolean = sourceAnchors.length === targetAnchors.length;
+
+  // Identities shared by more than one source anchor are mapped to null: neither ref can be
+  // attributed with confidence, so those fall through to the positional pass. Anchors carrying
+  // no ref are recorded too, otherwise a wired anchor twinned with an unwired one would read as
+  // unambiguous and its ref would be copied onto both.
+  const refsByIdentity: Map<string, string | null> = new Map<string, string | null>();
+
+  sourceAnchors.forEach((anchor: HTMLAnchorElement) => {
+    const attribute: string | null = anchor.getAttribute('data-action-ref');
+    const actionRef: string | null = attribute !== null && attribute !== '' ? attribute : null;
+    const identity: string = anchorIdentity(anchor);
+
+    refsByIdentity.set(identity, refsByIdentity.has(identity) ? null : actionRef);
+  });
+
+  const claimedIdentities: Set<string> = new Set<string>();
+
+  targetAnchors.forEach((anchor: HTMLAnchorElement, index: number) => {
+    if (anchor.hasAttribute('data-action-ref')) {
+      // An anchor that kept its ref still owns its identity, so a duplicate of it below
+      // cannot be handed the same ref.
+      if (anchor.getAttribute('data-action-ref')) {
+        claimedIdentities.add(anchorIdentity(anchor));
+      }
+
+      return;
+    }
+
+    const identity: string = anchorIdentity(anchor);
+    const identityRef: string | null = claimedIdentities.has(identity) ? null : (refsByIdentity.get(identity) ?? null);
+
+    if (identityRef) {
+      anchor.setAttribute('data-action-ref', identityRef);
+      claimedIdentities.add(identity);
+
+      return;
+    }
+
+    const positionalRef: string | null = countsMatch
+      ? (sourceAnchors[index]?.getAttribute('data-action-ref') ?? null)
+      : null;
+
+    if (positionalRef) {
+      anchor.setAttribute('data-action-ref', positionalRef);
+    }
+  });
+
+  return target.body.innerHTML;
+}
+
 /**
  * Convert nodes tree to HTML string.
  */
 function HTMLPlugin({onChange, resource, disabled = false}: HTMLPluginProps): ReactElement | null {
   const [editor] = useLexicalComposerContext();
   const updateType = useRef<UpdateType>(UPDATE_TYPES.NONE);
+  // The label the editor currently holds, read at export time to restore the sentinels Lexical
+  // drops. Kept in a ref so the update listener does not re-register on every resource identity.
+  const sourceLabelRef = useRef<string>('');
+
+  useEffect(() => {
+    sourceLabelRef.current = (resource as Resource & {label?: string})?.label ?? '';
+  }, [resource]);
 
   /**
    * Pre-process the HTML string to add additional classes and styles.
@@ -164,7 +265,7 @@ function HTMLPlugin({onChange, resource, disabled = false}: HTMLPluginProps): Re
 
         const processedHTML: string = preProcessHTML(htmlString);
 
-        onChange(processedHTML === EMPTY_CONTENT ? '' : processedHTML);
+        onChange(processedHTML === EMPTY_CONTENT ? '' : restoreActionSentinels(processedHTML, sourceLabelRef.current));
       });
     });
   }, [editor, onChange, preProcessHTML]);

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/rich-text/helper-plugins/__tests__/HTMLPlugin.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/rich-text/helper-plugins/__tests__/HTMLPlugin.test.tsx
@@ -860,6 +860,126 @@ describe('HTMLPlugin', () => {
     });
   });
 
+  describe('Action Sentinel Restore', () => {
+    // Lexical drops `data-component-ref` and `data-action-ref` on export because no registered
+    // node declares them. The plugin copies them back from the label the editor was seeded with.
+    const exportWith = (label: string, exportedHtml: string): string => {
+      mockGenerateHtmlFromNodes.mockReturnValue(exportedHtml);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let capturedCallback: any;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockRegisterUpdateListener.mockImplementation((callback: any) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        capturedCallback = callback;
+        return vi.fn();
+      });
+
+      render(<HTMLPlugin onChange={mockOnChange} resource={createMockResource({label})} />);
+
+      // The first invocation is the EXTERNAL update from seeding the editor; it is skipped.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      capturedCallback({editorState: {read: (cb: () => void) => cb()}});
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      capturedCallback({editorState: {read: (cb: () => void) => cb()}});
+
+      return mockOnChange.mock.lastCall?.[0] as string;
+    };
+
+    it('restores both sentinels onto the exported HTML', () => {
+      const result = exportWith(
+        '<p data-component-ref="recovery-link"><a href="#" data-action-ref="action_recovery">Reset</a></p>',
+        '<p><a href="#">Reset</a></p>',
+      );
+
+      expect(result).toBe(
+        '<p data-component-ref="recovery-link"><a href="#" data-action-ref="action_recovery">Reset</a></p>',
+      );
+    });
+
+    it('keeps the sentinel on its own anchor when a link is inserted ahead of it', () => {
+      // Positional matching would move the ref onto the new link and kill the real one.
+      const result = exportWith(
+        '<p><a href="#" data-action-ref="action_recovery">Reset</a></p>',
+        '<p><a href="https://example.com">Help</a><a href="#">Reset</a></p>',
+      );
+
+      expect(result).toBe(
+        '<p><a href="https://example.com">Help</a><a href="#" data-action-ref="action_recovery">Reset</a></p>',
+      );
+    });
+
+    it('falls back to position when the link itself was edited', () => {
+      const result = exportWith(
+        '<p><a href="#" data-action-ref="action_recovery">Reset</a></p>',
+        '<p><a href="#">Reset password</a></p>',
+      );
+
+      expect(result).toBe('<p><a href="#" data-action-ref="action_recovery">Reset password</a></p>');
+    });
+
+    it('does not give a duplicated link the original ref', () => {
+      // Two anchors dispatching the same action is ambiguous at runtime; only one may carry it.
+      const result = exportWith(
+        '<p><a href="#" data-action-ref="action_recovery">Reset</a></p>',
+        '<p><a href="#">Reset</a><a href="#">Reset</a></p>',
+      );
+
+      expect(result).toBe('<p><a href="#" data-action-ref="action_recovery">Reset</a><a href="#">Reset</a></p>');
+    });
+
+    it('does not copy a ref onto a duplicate of an anchor that kept it', () => {
+      // Should an export ever retain the sentinel, the anchor holding it owns its identity;
+      // giving its twin the same ref would make both anchors dispatch the one action.
+      const result = exportWith(
+        '<p><a href="#" data-action-ref="action_recovery">Reset</a></p>',
+        '<p><a href="#" data-action-ref="action_recovery">Reset</a><a href="#">Reset</a></p>',
+      );
+
+      expect(result).toBe('<p><a href="#" data-action-ref="action_recovery">Reset</a><a href="#">Reset</a></p>');
+    });
+
+    it('does not give an unwired duplicate the ref of its twin', () => {
+      // The label's first anchor never carried a ref; only its identical twin below did.
+      // Identity cannot tell the two apart, so both must fall through to position.
+      const result = exportWith(
+        '<p><a href="#">Reset</a><a href="#" data-action-ref="action_recovery">Reset</a></p>',
+        '<p><a href="#">Reset</a><a href="#">Reset</a></p>',
+      );
+
+      expect(result).toBe('<p><a href="#">Reset</a><a href="#" data-action-ref="action_recovery">Reset</a></p>');
+    });
+
+    it('leaves HTML untouched when the label carries no sentinel', () => {
+      const result = exportWith('<p><a href="#">Reset</a></p>', '<p><a href="#">Reset</a></p>');
+
+      expect(result).toBe('<p><a href="#">Reset</a></p>');
+    });
+
+    it('re-serialises a shipped widget label without altering anything but the sentinels', () => {
+      // The restore round-trips through DOMParser, so this pins what that costs: restored
+      // attributes are appended rather than kept in their authored position, and nothing else
+      // (classes, entities, non-breaking spaces) is rewritten.
+      const result = exportWith(
+        '<p data-component-ref="self-sign-up-link" class="rich-text-paragraph">' +
+          '<span class="rich-text-pre-wrap">Don\'t have an account?&nbsp;</span>' +
+          '<a href="#" data-action-ref="action_signup_ab12" class="rich-text-link">' +
+          '<span class="rich-text-pre-wrap">Sign up</span></a></p>',
+        '<p class="rich-text-paragraph">' +
+          '<span class="rich-text-pre-wrap">Don\'t have an account?&nbsp;</span>' +
+          '<a href="#" class="rich-text-link">' +
+          '<span class="rich-text-pre-wrap">Sign up</span></a></p>',
+      );
+
+      expect(result).toBe(
+        '<p class="rich-text-paragraph" data-component-ref="self-sign-up-link">' +
+          '<span class="rich-text-pre-wrap">Don\'t have an account?&nbsp;</span>' +
+          '<a href="#" class="rich-text-link" data-action-ref="action_signup_ab12">' +
+          '<span class="rich-text-pre-wrap">Sign up</span></a></p>',
+      );
+    });
+  });
+
   describe('EXTERNAL Update Type Skip', () => {
     it('should skip onChange when updateType is EXTERNAL and reset to NONE', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/frontend/apps/console/src/features/flows/data/widgets.json
+++ b/frontend/apps/console/src/features/flows/data/widgets.json
@@ -2279,11 +2279,17 @@
       "data": {
         "__generationMeta__": {
           "strategy": "MERGE_WITH_DROP_POINT",
+          "defaultPropertySelectorId": "{{SELF_SIGN_UP_CALL_STEP_ID}}",
           "replacers": [
             {
               "key": "SELF_SIGN_UP_CALL_STEP_ID",
               "type": "ID",
               "prefix": "self_sign_up_call"
+            },
+            {
+              "key": "SELF_SIGN_UP_ACTION_REF",
+              "type": "ID",
+              "prefix": "action_signup"
             }
           ]
         },
@@ -2300,10 +2306,10 @@
                   "type": "RICH_TEXT",
                   "id": "{{ID}}",
                   "action": {
-                    "ref": "action_signup",
+                    "ref": "{{SELF_SIGN_UP_ACTION_REF}}",
                     "onSuccess": "{{SELF_SIGN_UP_CALL_STEP_ID}}"
                   },
-                  "label": "<p data-component-ref=\"self-sign-up-link\" class=\"rich-text-paragraph\"><span class=\"rich-text-pre-wrap\">Don't have an account? </span><a href=\"#\" data-action-ref=\"action_signup\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Sign up</span></a></p>"
+                  "label": "<p data-component-ref=\"self-sign-up-link\" class=\"rich-text-paragraph\"><span class=\"rich-text-pre-wrap\">Don't have an account? </span><a href=\"#\" data-action-ref=\"{{SELF_SIGN_UP_ACTION_REF}}\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Sign up</span></a></p>"
                 }
               ]
             }
@@ -2352,11 +2358,17 @@
       "data": {
         "__generationMeta__": {
           "strategy": "MERGE_WITH_DROP_POINT",
+          "defaultPropertySelectorId": "{{SIGN_IN_CALL_STEP_ID}}",
           "replacers": [
             {
               "key": "SIGN_IN_CALL_STEP_ID",
               "type": "ID",
               "prefix": "sign_in_call"
+            },
+            {
+              "key": "SIGN_IN_ACTION_REF",
+              "type": "ID",
+              "prefix": "action_signin"
             }
           ]
         },
@@ -2373,10 +2385,10 @@
                   "type": "RICH_TEXT",
                   "id": "{{ID}}",
                   "action": {
-                    "ref": "action_signin",
+                    "ref": "{{SIGN_IN_ACTION_REF}}",
                     "onSuccess": "{{SIGN_IN_CALL_STEP_ID}}"
                   },
-                  "label": "<p data-component-ref=\"sign-in-link\" class=\"rich-text-paragraph\"><span class=\"rich-text-pre-wrap\">Already have an account? </span><a href=\"#\" data-action-ref=\"action_signin\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Sign in</span></a></p>"
+                  "label": "<p data-component-ref=\"sign-in-link\" class=\"rich-text-paragraph\"><span class=\"rich-text-pre-wrap\">Already have an account? </span><a href=\"#\" data-action-ref=\"{{SIGN_IN_ACTION_REF}}\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Sign in</span></a></p>"
                 }
               ]
             }
@@ -2425,11 +2437,17 @@
       "data": {
         "__generationMeta__": {
           "strategy": "MERGE_WITH_DROP_POINT",
+          "defaultPropertySelectorId": "{{RECOVERY_CALL_STEP_ID}}",
           "replacers": [
             {
               "key": "RECOVERY_CALL_STEP_ID",
               "type": "ID",
               "prefix": "recovery_call"
+            },
+            {
+              "key": "RECOVERY_ACTION_REF",
+              "type": "ID",
+              "prefix": "action_recovery"
             }
           ]
         },
@@ -2446,10 +2464,10 @@
                   "type": "RICH_TEXT",
                   "id": "{{ID}}",
                   "action": {
-                    "ref": "action_recovery",
+                    "ref": "{{RECOVERY_ACTION_REF}}",
                     "onSuccess": "{{RECOVERY_CALL_STEP_ID}}"
                   },
-                  "label": "<p data-component-ref=\"recovery-link\" class=\"rich-text-paragraph\"><a href=\"#\" data-action-ref=\"action_recovery\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Forgot password?</span></a></p>"
+                  "label": "<p data-component-ref=\"recovery-link\" class=\"rich-text-paragraph\"><a href=\"#\" data-action-ref=\"{{RECOVERY_ACTION_REF}}\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Forgot password?</span></a></p>"
                 }
               ]
             }

--- a/frontend/apps/console/src/features/flows/hooks/__tests__/useVisualFlowHandlers.test.tsx
+++ b/frontend/apps/console/src/features/flows/hooks/__tests__/useVisualFlowHandlers.test.tsx
@@ -407,6 +407,139 @@ describe('useVisualFlowHandlers', () => {
         expect(updated.components[0].action).toEqual({ref: 'existing'});
         expect(updated.components[1].action).toEqual({ref: 'target-1'});
       });
+
+      describe('label sentinel sync', () => {
+        interface SyncedComponent {
+          action: {ref: string};
+          label?: string;
+        }
+
+        const connectTo = (target: string, node: {id: string; data: unknown}): SyncedComponent => {
+          mockGetNodes.mockReturnValue([node, {id: target}]);
+
+          const {result} = renderHook(() => useVisualFlowHandlers({setEdges: mockSetEdges}), {
+            wrapper: createWrapper(),
+          });
+
+          act(() => {
+            result.current.handleConnect({
+              source: 'view-1',
+              target,
+              sourceHandle: `${richTextComponentId}${nextSuffix}`,
+              targetHandle: null,
+            });
+          });
+
+          const [, updater] = mockUpdateNodeData.mock.calls[0];
+          const updated = updater({data: node.data}) as {components: SyncedComponent[]};
+
+          return updated.components[0];
+        };
+
+        const buildLabelledNode = (actionRef: string, label: string) => ({
+          id: 'view-1',
+          data: {
+            components: [{id: richTextComponentId, type: 'RICH_TEXT', action: {ref: actionRef}, label}],
+          },
+        });
+
+        it('rewrites the sentinel alongside the ref', () => {
+          const component = connectTo(
+            'target-1',
+            buildLabelledNode('action_recovery', '<p><a href="#" data-action-ref="action_recovery">Reset</a></p>'),
+          );
+
+          expect(component.action).toEqual({ref: 'target-1'});
+          expect(component.label).toBe('<p><a href="#" data-action-ref="target-1">Reset</a></p>');
+        });
+
+        it('rewrites a lone sentinel that has drifted from the ref', () => {
+          // Flows saved before the two moved together carry a target node id in `action.ref`
+          // while the label kept the authored name. Redrawing the edge has to heal that.
+          const component = connectTo(
+            'target-1',
+            buildLabelledNode('recovery_call_g0v6', '<p><a href="#" data-action-ref="action_recovery">Reset</a></p>'),
+          );
+
+          expect(component.label).toBe('<p><a href="#" data-action-ref="target-1">Reset</a></p>');
+        });
+
+        it('leaves a foreign sentinel alone when the label has several', () => {
+          const component = connectTo(
+            'target-1',
+            buildLabelledNode(
+              'action_recovery',
+              '<p><a href="#" data-action-ref="action_recovery">Reset</a>' +
+                '<a href="#" data-action-ref="action_signup">Sign up</a></p>',
+            ),
+          );
+
+          expect(component.label).toBe(
+            '<p><a href="#" data-action-ref="target-1">Reset</a>' +
+              '<a href="#" data-action-ref="action_signup">Sign up</a></p>',
+          );
+        });
+
+        it('rewrites only the first sentinel when the ref is empty and the label has several', () => {
+          // With no ref to match on, the anchor the properties panel derives the ref from is the
+          // first. Rewriting them all would point the unrelated link at this action too.
+          const component = connectTo(
+            'target-1',
+            buildLabelledNode(
+              '',
+              '<p><a href="#" data-action-ref="action_recovery">Reset</a>' +
+                '<a href="#" data-action-ref="action_signup">Sign up</a></p>',
+            ),
+          );
+
+          expect(component.action).toEqual({ref: 'target-1'});
+          expect(component.label).toBe(
+            '<p><a href="#" data-action-ref="target-1">Reset</a>' +
+              '<a href="#" data-action-ref="action_signup">Sign up</a></p>',
+          );
+        });
+
+        it('leaves a label with no sentinel untouched', () => {
+          const label = '<p><a href="#">Reset</a></p>';
+          const component = connectTo('target-1', buildLabelledNode('action_recovery', label));
+
+          expect(component.action).toEqual({ref: 'target-1'});
+          expect(component.label).toBe(label);
+        });
+
+        it('heals a drifted sentinel when reconnected to the step the ref already names', () => {
+          // Redrawing the edge to the same step is the most direct repair gesture. Keying the
+          // update off the ref alone would make it a no-op and leave the link dead.
+          const component = connectTo(
+            'target-1',
+            buildLabelledNode('target-1', '<p><a href="#" data-action-ref="action_recovery">Reset</a></p>'),
+          );
+
+          expect(component.label).toBe('<p><a href="#" data-action-ref="target-1">Reset</a></p>');
+        });
+
+        it('does not touch the node when the ref and the sentinel already match the target', () => {
+          mockGetNodes.mockReturnValue([
+            buildLabelledNode('target-1', '<p><a href="#" data-action-ref="target-1">Reset</a></p>'),
+            {id: 'target-1'},
+          ]);
+
+          const {result} = renderHook(() => useVisualFlowHandlers({setEdges: mockSetEdges}), {
+            wrapper: createWrapper(),
+          });
+
+          act(() => {
+            result.current.handleConnect({
+              source: 'view-1',
+              target: 'target-1',
+              sourceHandle: `${richTextComponentId}${nextSuffix}`,
+              targetHandle: null,
+            });
+          });
+
+          expect(mockUpdateNodeData).not.toHaveBeenCalled();
+        });
+      });
     });
 
     it('should use current edgeStyle from context', () => {

--- a/frontend/apps/console/src/features/flows/hooks/useVisualFlowHandlers.ts
+++ b/frontend/apps/console/src/features/flows/hooks/useVisualFlowHandlers.ts
@@ -23,6 +23,56 @@ import type {Element} from '../models/elements';
 import {ElementTypes} from '../models/elements';
 import type {StepData} from '../models/steps';
 
+/** Matches a `data-action-ref` attribute and captures its delimiter and value. */
+const ACTION_REF_SENTINEL = /(\sdata-action-ref\s*=\s*)(?:"([^"]*)"|'([^']*)')/gi;
+
+/**
+ * Rewrites the `data-action-ref` sentinels inside a rich text's label so they keep matching the
+ * component's `action.ref`. The adapter only dispatches when the clicked anchor's sentinel equals
+ * the ref, so the two values must always move together.
+ *
+ * A label with no sentinel at all is returned unchanged: the adapter dispatches on any anchor
+ * click in that case. In a label with several sentinels, one carrying some other ref belongs to a
+ * different link and is left alone. A lone sentinel is unambiguously this component's, so it is
+ * rewritten even when it does not match `previousRef` — that is how a label left divergent by an
+ * earlier build, where the ref moved without the sentinel, heals.
+ *
+ * With several sentinels and no ref to match them against, only the first is rewritten: it is the
+ * anchor the properties panel derives the ref from, and rewriting them all would point unrelated
+ * links at this action.
+ *
+ * @param label - The rich text's label, which may be HTML.
+ * @param previousRef - The ref the label's sentinels are expected to carry, if any.
+ * @param nextRef - The ref to write.
+ * @returns The label with its matching sentinels rewritten.
+ */
+const syncLabelActionRef = (label: string, previousRef: string | undefined, nextRef: string): string => {
+  const isAmbiguous = (label.match(ACTION_REF_SENTINEL)?.length ?? 0) > 1;
+  const hasPreviousRef = previousRef !== undefined && previousRef !== '';
+  let seen = 0;
+
+  return label.replace(
+    ACTION_REF_SENTINEL,
+    (match: string, prefix: string, doubleQuoted?: string, singleQuoted?: string) => {
+      const currentRef = doubleQuoted ?? singleQuoted;
+
+      seen += 1;
+
+      if (isAmbiguous) {
+        if (!hasPreviousRef) {
+          return seen === 1 ? `${prefix}"${nextRef}"` : match;
+        }
+
+        if (currentRef !== previousRef) {
+          return match;
+        }
+      }
+
+      return `${prefix}"${nextRef}"`;
+    },
+  );
+};
+
 /**
  * Props interface for useVisualFlowHandlers hook
  */
@@ -83,9 +133,10 @@ const useVisualFlowHandlers = (props: UseVisualFlowHandlersProps): UseVisualFlow
 
       const currentNodes = getNodes();
 
-      // If the edge originates from a rich-text action handle, copy the target node's id
-      // into the rich-text component's `action.ref`. Author-facing UX: they draw the edge
-      // and the "Connected step" field auto-populates.
+      // If the edge originates from a rich-text action handle, name the action after the target
+      // node. The ref is a lookup key the runtime matches against the clicked anchor's
+      // `data-action-ref`, so the label's sentinel is rewritten in the same pass. Changing one
+      // without the other leaves a link that renders but dispatches nothing.
       const nextSuffix = VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX;
       if (
         connection.sourceHandle &&
@@ -104,10 +155,28 @@ const useVisualFlowHandlers = (props: UseVisualFlowHandlersProps): UseVisualFlow
             let localChanged = false;
             const next = elements.map((el) => {
               if (el.id === componentId && el.type === ElementTypes.RichText) {
-                const withAction = el as Element & {action?: {ref?: string}};
-                if (withAction.action !== undefined && withAction.action.ref !== targetId) {
-                  localChanged = true;
-                  return {...el, action: {...withAction.action, ref: targetId}} as Element;
+                const withAction = el as Element & {action?: {ref?: string} | null; label?: string};
+                // A toggled-off link stores `action: null`, which has no ref to move.
+                if (withAction.action !== undefined && withAction.action !== null) {
+                  const nextLabel: string | undefined =
+                    typeof withAction.label === 'string'
+                      ? syncLabelActionRef(withAction.label, withAction.action.ref, targetId)
+                      : undefined;
+
+                  // Reconnecting to the step the ref already names must still heal a label whose
+                  // sentinel has drifted, otherwise the most direct repair gesture is a no-op.
+                  if (
+                    withAction.action.ref !== targetId ||
+                    (nextLabel !== undefined && nextLabel !== withAction.label)
+                  ) {
+                    localChanged = true;
+
+                    return {
+                      ...el,
+                      action: {...withAction.action, ref: targetId},
+                      ...(nextLabel !== undefined ? {label: nextLabel} : {}),
+                    } as Element;
+                  }
                 }
               }
 

--- a/frontend/apps/console/src/features/flows/utils/__tests__/reactFlowTransformer.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/reactFlowTransformer.test.ts
@@ -2055,5 +2055,97 @@ describe('reactFlowTransformer', () => {
       expect(callNode.onSuccess).toBe('success-1');
       expect(callNode.onFailure).toBe('failure-1');
     });
+
+    describe('Rich Text Action Serialization', () => {
+      const richText = (action: unknown): Element =>
+        ({
+          id: 'rt-1',
+          type: ElementTypes.RichText,
+          category: ElementCategories.Display,
+          action,
+          label: '<p><a href="#" data-action-ref="action_recovery">Reset</a></p>',
+        }) as unknown as Element;
+
+      it('serialises a rich text whose action was toggled off', () => {
+        // The panel writes an explicit `null` when the toggle goes off. Reading `ref` off it
+        // threw and took the whole save down with it.
+        const canvasData = {
+          nodes: [createNode('view-1', StepTypes.View, {x: 0, y: 0}, {components: [richText(null)]} as StepData)],
+          edges: [],
+        };
+
+        const result = transformReactFlow(canvasData);
+        const viewNode = result.nodes.find((n) => n.id === 'view-1') as unknown as {
+          meta?: {components?: Record<string, unknown>[]};
+          prompts?: unknown[];
+        };
+
+        expect(viewNode.meta?.components?.[0].action).toBeUndefined();
+        expect(viewNode.prompts ?? []).toEqual([]);
+      });
+
+      it('serialises an empty ref as the label sentinel, on both the component and the prompt', () => {
+        // The runtime matches the clicked anchor's sentinel against the component's `action.ref`
+        // and looks the prompt up by the same value, so all three must agree.
+        const canvasData = {
+          nodes: [
+            createNode('view-1', StepTypes.View, {x: 0, y: 0}, {components: [richText({ref: ''})]} as StepData),
+            createNode('call-1', StepTypes.Call),
+          ],
+          edges: [createEdge('e-1', 'view-1', 'call-1', `rt-1${VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX}`)],
+        };
+
+        const result = transformReactFlow(canvasData);
+        const viewNode = result.nodes.find((n) => n.id === 'view-1') as unknown as {
+          meta?: {components?: Record<string, unknown>[]};
+          prompts?: {action: {ref: string; nextNode: string}}[];
+        };
+
+        expect(viewNode.meta?.components?.[0].action).toEqual({ref: 'action_recovery'});
+        expect(viewNode.prompts?.[0].action).toEqual({ref: 'action_recovery', nextNode: 'call-1'});
+        expect(viewNode.meta?.components?.[0].label).toContain('data-action-ref="action_recovery"');
+      });
+
+      it('falls back to the component id when the label carries no sentinel', () => {
+        const withoutSentinel = {...richText({ref: ''}), label: '<p><a href="#">Reset</a></p>'} as unknown as Element;
+        const canvasData = {
+          nodes: [
+            createNode('view-1', StepTypes.View, {x: 0, y: 0}, {components: [withoutSentinel]} as StepData),
+            createNode('call-1', StepTypes.Call),
+          ],
+          edges: [createEdge('e-1', 'view-1', 'call-1', `rt-1${VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX}`)],
+        };
+
+        const result = transformReactFlow(canvasData);
+        const viewNode = result.nodes.find((n) => n.id === 'view-1') as unknown as {
+          meta?: {components?: Record<string, unknown>[]};
+          prompts?: {action: {ref: string; nextNode: string}}[];
+        };
+
+        expect(viewNode.meta?.components?.[0].action).toEqual({ref: 'rt-1'});
+        expect(viewNode.prompts?.[0].action).toEqual({ref: 'rt-1', nextNode: 'call-1'});
+      });
+
+      it('serialises an action object that carries no ref of its own', () => {
+        // A prompt is emitted for any present action, so the component has to be given the
+        // same resolved ref, otherwise the prompt is unreachable at runtime.
+        const canvasData = {
+          nodes: [
+            createNode('view-1', StepTypes.View, {x: 0, y: 0}, {components: [richText({})]} as StepData),
+            createNode('call-1', StepTypes.Call),
+          ],
+          edges: [createEdge('e-1', 'view-1', 'call-1', `rt-1${VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX}`)],
+        };
+
+        const result = transformReactFlow(canvasData);
+        const viewNode = result.nodes.find((n) => n.id === 'view-1') as unknown as {
+          meta?: {components?: Record<string, unknown>[]};
+          prompts?: {action: {ref: string; nextNode: string}}[];
+        };
+
+        expect(viewNode.meta?.components?.[0].action).toEqual({ref: 'action_recovery'});
+        expect(viewNode.prompts?.[0].action).toEqual({ref: 'action_recovery', nextNode: 'call-1'});
+      });
+    });
   });
 });

--- a/frontend/apps/console/src/features/flows/utils/__tests__/updateTemplatePlaceholderReferences.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/updateTemplatePlaceholderReferences.test.ts
@@ -49,6 +49,34 @@ describe('updateTemplatePlaceholderReferences', () => {
 
       expect(result.field).toBe('{{NAME}}');
     });
+
+    it('should replace a placeholder embedded in a longer string', () => {
+      const obj = {label: '<p><a href="#" data-action-ref="{{RECOVERY_ACTION_REF}}">Reset</a></p>'};
+      const replacers = [{key: 'RECOVERY_ACTION_REF', value: 'action_recovery'}];
+
+      const [result] = updateTemplatePlaceholderReferences(obj, replacers);
+
+      expect(result.label).toBe('<p><a href="#" data-action-ref="action_recovery">Reset</a></p>');
+    });
+
+    it('should leave a literal that reads like a replacer key unchanged', () => {
+      const obj = {key: 'ID', title: 'Set the ID'};
+      const replacers = [{key: 'ID', value: 'generated-id'}];
+
+      const [result] = updateTemplatePlaceholderReferences(obj, replacers);
+
+      expect(result.key).toBe('ID');
+      expect(result.title).toBe('Set the ID');
+    });
+
+    it('should leave a runtime template literal unchanged', () => {
+      const obj = {placeholder: '{{ t(signin:forms.credentials.fields.username.placeholder) }}'};
+      const replacers = [{key: 'username', value: 'replaced'}];
+
+      const [result] = updateTemplatePlaceholderReferences(obj, replacers);
+
+      expect(result.placeholder).toBe('{{ t(signin:forms.credentials.fields.username.placeholder) }}');
+    });
   });
 
   describe('ID Type Replacer', () => {

--- a/frontend/apps/console/src/features/flows/utils/reactFlowTransformer.ts
+++ b/frontend/apps/console/src/features/flows/utils/reactFlowTransformer.ts
@@ -188,6 +188,33 @@ export function shouldPromoteToSubmit(components: Element[]): boolean {
   return hasInputs && actionCount === 1;
 }
 
+/** Matches the first `data-action-ref` attribute in a rich text's label and captures its value. */
+const LABEL_ACTION_REF = /\sdata-action-ref\s*=\s*(?:"([^"]*)"|'([^']*)')/i;
+
+/**
+ * Resolves the ref a rich text's action is serialized with. An empty ref reaches here from a link
+ * that was never authored; the label's own sentinel is then preferred, so the serialized action,
+ * the prompt and the label all carry one value the runtime can match. The component id is the
+ * last resort, used when the label has no sentinel either.
+ *
+ * TODO(#4658): drop once the ref is no longer duplicated into the label HTML.
+ *
+ * @param component - The rich text component.
+ * @param ref - The authored ref, if any.
+ * @returns The ref to serialize.
+ */
+function resolveRichTextActionRef(component: Element, ref: string | undefined): string {
+  if (ref !== undefined && ref !== '') {
+    return ref;
+  }
+
+  const label = (component as Element & {label?: string}).label;
+  const sentinel = typeof label === 'string' ? LABEL_ACTION_REF.exec(label) : null;
+  const labelRef = sentinel?.[1] ?? sentinel?.[2];
+
+  return labelRef !== undefined && labelRef !== '' ? labelRef : component.id;
+}
+
 /**
  * Removes internal properties (variants, display, config, action) from components recursively.
  * These transformations prepare the component for the API payload.
@@ -218,11 +245,14 @@ function cleanComponents(components: Element[], promoteSubmit = false): Record<s
     // renderer can dispatch the anchor click as a flow action. Only `ref` survives —
     // `onSuccess` is a canvas-only hint used by the widget-drop edge generator, and the
     // nextNode wiring lives in `prompts.action.nextNode` from `extractActionFromComponent`.
-    if (component.type === ElementTypes.RichText && action !== undefined) {
+    // `action` is `null`, not `undefined`, once the author toggles the link off — the panel
+    // writes an explicit disabled sentinel — so both have to be excluded before reading `ref`.
+    // A present action is always serialized, even with no `ref` of its own: `extractPrompts`
+    // emits a prompt for it, and the resolved ref has to be on the component too or the
+    // runtime has a prompt it can never reach.
+    if (component.type === ElementTypes.RichText && action !== undefined && action !== null) {
       const richTextAction = action as {ref?: string};
-      if (richTextAction.ref !== undefined) {
-        cleanedComponent.action = {ref: richTextAction.ref};
-      }
+      cleanedComponent.action = {ref: resolveRichTextActionRef(component, richTextAction.ref)};
     }
 
     // For input field components, ensure ref property is set
@@ -393,7 +423,7 @@ function extractPrompts(components: Element[], nodeId: string, edges: Edge[]): F
       if (!connectedEdge) {
         return undefined;
       }
-      return {ref: richTextAction.ref ?? component.id, nextNode: connectedEdge.target};
+      return {ref: resolveRichTextActionRef(component, richTextAction.ref), nextNode: connectedEdge.target};
     }
 
     return undefined;
@@ -406,9 +436,12 @@ function extractPrompts(components: Element[], nodeId: string, edges: Edge[]): F
     // Check if this component is an action
     const action = extractActionFromComponent(component);
     if (action) {
-      // This action gets the parent's inputs (all accumulated up to this point)
+      // This action gets the parent's inputs (all accumulated up to this point). A rich-text
+      // link navigates rather than submitting the surrounding form, so it must not inherit
+      // them: the runtime validates the selected action's inputs, and a link sitting inside a
+      // credentials block would otherwise demand a username and password before it could fire.
       const prompt: FlowPrompt = {action};
-      if (parentInputs.length > 0) {
+      if (parentInputs.length > 0 && component.type !== ElementTypes.RichText) {
         prompt.inputs = parentInputs;
       }
       prompts.push(prompt);

--- a/frontend/apps/console/src/features/flows/utils/updateTemplatePlaceholderReferences.ts
+++ b/frontend/apps/console/src/features/flows/utils/updateTemplatePlaceholderReferences.ts
@@ -18,49 +18,62 @@ interface Replacer {
   [key: string]: unknown;
 }
 
+/**
+ * Matches a `{{KEY}}` placeholder, whether it is the whole string or embedded in a longer one,
+ * e.g. the `data-action-ref` sentinel inside a rich text's HTML label. Deliberately restricted to
+ * identifier characters so the runtime template literals (`{{ t(...) }}`,
+ * `{{meta(application.url)}}`) never match.
+ */
+const PLACEHOLDER = /\{\{([A-Za-z0-9_]+)\}\}/g;
+
 const updateTemplatePlaceholderReferences = <T = JsonValue>(
   obj: T,
   replacers: Replacer[],
 ): [T, Map<string, string>] => {
   const placeholderCache = new Map<string, string>();
 
+  // Resolves one placeholder key to its replacement, minting generated ids at most once so
+  // every occurrence of a key (the `action.ref` and the label's `data-action-ref`, say) ends
+  // up with the same value. Returns undefined when the key has no replacement to apply, which
+  // leaves the placeholder as authored.
+  const resolvePlaceholder = (placeholderKey: string): string | undefined => {
+    if (placeholderCache.has(placeholderKey)) {
+      return placeholderCache.get(placeholderKey);
+    }
+
+    const replacer = replacers?.find((r) => r.key === placeholderKey || r.placeholder === placeholderKey);
+
+    if (!replacer) {
+      return undefined;
+    }
+
+    let replacementValue: string;
+
+    if (replacer.type === 'ID') {
+      replacementValue = generateResourceId(replacer.prefix ?? replacer.type);
+    } else if (replacer.value !== undefined) {
+      replacementValue = replacer.value;
+    } else {
+      return undefined;
+    }
+
+    placeholderCache.set(placeholderKey, replacementValue);
+
+    return replacementValue;
+  };
+
   const replacePlaceholders = (input: JsonValue): JsonValue => {
+    if (typeof input === 'string') {
+      // Only a written-out `{{KEY}}` is substituted, so a literal that happens to read like a
+      // replacer key, such as the key of a replacer definition itself, is left alone.
+      return input.replace(PLACEHOLDER, (match, placeholderKey: string) => resolvePlaceholder(placeholderKey) ?? match);
+    }
     if (Array.isArray(input)) {
       return input.map((value) => replacePlaceholders(value)) as JsonArray;
     }
     if (typeof input === 'object' && input !== null) {
       return Object.fromEntries(
-        Object.entries(input).map(([key, value]) => {
-          if (typeof value === 'string') {
-            // Extract placeholder key (remove {{ }})
-            const placeholderKey = value.replace(/[{}]/g, '');
-
-            // Check if we already replaced this placeholder
-            if (placeholderCache.has(placeholderKey)) {
-              return [key, placeholderCache.get(placeholderKey)];
-            }
-
-            // Find the matching replacer
-            const replacer = replacers?.find((r) => r.key === placeholderKey || r.placeholder === placeholderKey);
-
-            if (replacer) {
-              let replacementValue: string;
-
-              if (replacer.type === 'ID') {
-                replacementValue = generateResourceId(replacer.prefix ?? replacer.type);
-              } else {
-                replacementValue = replacer.value ?? value; // Default to original if no value
-              }
-
-              // Store the replacement in the cache
-              placeholderCache.set(placeholderKey, replacementValue);
-
-              return [key, replacementValue];
-            }
-          }
-
-          return [key, replacePlaceholders(value)];
-        }),
+        Object.entries(input).map(([key, value]) => [key, replacePlaceholders(value)]),
       ) as JsonObject;
     }
 

--- a/frontend/apps/console/src/features/flows/validation/__tests__/computeValidationNotifications.test.ts
+++ b/frontend/apps/console/src/features/flows/validation/__tests__/computeValidationNotifications.test.ts
@@ -6,7 +6,12 @@ import {describe, it, expect, vi} from 'vitest';
 import {NotificationType} from '../../models/notification';
 import type {StepData} from '../../models/steps';
 import {computeValidationNotifications} from '../computeValidationNotifications';
-import {GRAPH_VALIDATION_RULES, SIGN_OUT_GRAPH_VALIDATION_RULES, VALIDATION_RULES} from '../validation-rules';
+import {
+  COMMON_GRAPH_VALIDATION_RULES,
+  GRAPH_VALIDATION_RULES,
+  SIGN_OUT_GRAPH_VALIDATION_RULES,
+  VALIDATION_RULES,
+} from '../validation-rules';
 
 // Simple mock t function that returns the key
 const t = vi.fn((key: string) => key) as unknown as import('i18next').TFunction;
@@ -654,6 +659,59 @@ describe('computeValidationNotifications', () => {
       // rule must stay silent.
       const signOutIds = [...result.keys()].filter((id) => id.includes('SIGN_OUT_CONFIRM'));
       expect(signOutIds).toEqual([]);
+    });
+  });
+
+  describe('Rich text action wiring rule', () => {
+    const NOTIFICATION_ID = 'rt_1_RICH_TEXT_ACTION_NOT_CONNECTED';
+
+    const richText = (action: unknown): Record<string, unknown> => ({
+      id: 'rt_1',
+      type: 'RICH_TEXT',
+      category: 'DISPLAY',
+      action,
+      label: '<p><a href="#" data-action-ref="action_recovery">Reset</a></p>',
+    });
+
+    const compute = (nodes: Node[], edges: Edge[] = []) =>
+      computeValidationNotifications(nodes, VALIDATION_RULES, t, COMMON_GRAPH_VALIDATION_RULES, edges);
+
+    it('should accept a link wired to a step', () => {
+      const nodes = [createElementNode('prompt_1', [richText({ref: 'action_recovery'})]), createNode({id: 'call_1'})];
+      const edges = [{id: 'e-1', source: 'prompt_1', sourceHandle: 'rt_1_NEXT', target: 'call_1'} as Edge];
+
+      expect(compute(nodes, edges).has(NOTIFICATION_ID)).toBe(false);
+    });
+
+    it('should report a link whose target step was deleted', () => {
+      // React Flow drops the edge and leaves `action.ref` in place, so the link keeps
+      // dispatching a ref that no longer resolves to a prompt.
+      const result = compute([createElementNode('prompt_1', [richText({ref: 'action_recovery'})])]);
+
+      const notification = result.get(NOTIFICATION_ID)!;
+      expect(notification).toBeDefined();
+      // Must not block saving: saving is how the author fixes the rest of the flow.
+      expect(notification.getType()).toBe(NotificationType.WARNING);
+      expect(notification.hasResource('rt_1')).toBe(true);
+    });
+
+    it('should report a link nested inside a block', () => {
+      const nodes = [
+        createElementNode('prompt_1', [
+          {id: 'block_1', type: 'BLOCK', category: 'BLOCK', components: [richText({ref: 'action_recovery'})]},
+        ]),
+      ];
+
+      expect(compute(nodes).has(NOTIFICATION_ID)).toBe(true);
+    });
+
+    it('should ignore a rich text whose action was toggled off', () => {
+      expect(compute([createElementNode('prompt_1', [richText(null)])]).has(NOTIFICATION_ID)).toBe(false);
+    });
+
+    it('should ignore a plain rich text and one carrying an empty ref', () => {
+      expect(compute([createElementNode('prompt_1', [richText(undefined)])]).has(NOTIFICATION_ID)).toBe(false);
+      expect(compute([createElementNode('prompt_1', [richText({ref: ''})])]).has(NOTIFICATION_ID)).toBe(false);
     });
   });
 });

--- a/frontend/apps/console/src/features/flows/validation/validation-rules.ts
+++ b/frontend/apps/console/src/features/flows/validation/validation-rules.ts
@@ -402,9 +402,76 @@ export const signOutConfirmActionRule: GraphValidationRule = (nodes: Node[], edg
   return notifications;
 };
 
-export const GRAPH_VALIDATION_RULES: GraphValidationRule[] = [ssoPairingRule];
+/**
+ * Collects every rich text that is wired as an interactive link, including ones
+ * nested inside containers such as a form block.
+ */
+function collectWiredRichTextElements(elements: FlowElement[] | undefined): FlowElement[] {
+  if (!elements) {
+    return [];
+  }
+
+  return elements.flatMap((element) => {
+    const actionRef = (element as FlowElement & {action?: {ref?: string} | null}).action?.ref;
+    const isWiredLink = element.type === ElementTypes.RichText && actionRef !== undefined && actionRef !== '';
+
+    return [...(isWiredLink ? [element] : []), ...collectWiredRichTextElements(element.components)];
+  });
+}
+
+/**
+ * A rich-text link's `action.ref` is a lookup key, resolved at runtime against the step's
+ * prompts. The prompt only exists while an edge leaves the link's own handle, so an unwired
+ * link serialises with a ref that resolves to nothing: the anchor still renders and still
+ * dispatches, and the backend then fails the step with `ErrInvalidActionProvided`, which the
+ * user sees as an empty sign in page.
+ *
+ * Deleting the step a link pointed at is the usual way in. React Flow drops the edge without
+ * touching the ref, so nothing on the canvas shows that the link is now broken.
+ *
+ * A warning rather than an error, matching `signOutConfirmActionRule` for the same "action
+ * element left unwired" shape: an existing flow with this defect must stay saveable, since
+ * saving is how the author fixes the rest of it.
+ */
+export const richTextActionWiringRule: GraphValidationRule = (nodes: Node[], edges: Edge[]): Notification[] => {
+  const notifications: Notification[] = [];
+
+  for (const node of nodes) {
+    const elements = collectWiredRichTextElements((node.data as StepData | undefined)?.components);
+
+    for (const element of elements) {
+      const handleId = `${element.id}${VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX}`;
+      const isConnected = edges.some(
+        (candidate) => candidate.source === node.id && candidate.sourceHandle === handleId,
+      );
+
+      if (!isConnected) {
+        notifications.push(
+          createGraphElementNotification(
+            `${element.id}_RICH_TEXT_ACTION_NOT_CONNECTED`,
+            'flows:core.validation.richText.actionNotConnected',
+            element,
+            NotificationType.WARNING,
+          ),
+        );
+      }
+    }
+  }
+
+  return notifications;
+};
+
+/**
+ * Rules that apply to every flow type.
+ */
+export const COMMON_GRAPH_VALIDATION_RULES: GraphValidationRule[] = [richTextActionWiringRule];
+
+export const GRAPH_VALIDATION_RULES: GraphValidationRule[] = [ssoPairingRule, ...COMMON_GRAPH_VALIDATION_RULES];
 
 /**
  * Rules that apply to sign-out flows.
  */
-export const SIGN_OUT_GRAPH_VALIDATION_RULES: GraphValidationRule[] = [signOutConfirmActionRule];
+export const SIGN_OUT_GRAPH_VALIDATION_RULES: GraphValidationRule[] = [
+  signOutConfirmActionRule,
+  ...COMMON_GRAPH_VALIDATION_RULES,
+];

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -3786,6 +3786,10 @@ const translations = {
     'core.validation.signOut.confirmInvalidTarget':
       'Sign-out button <code>{{id}}</code> does not lead to a session sign-out step, so it will not sign the user out. Connect it to one, or change its action.',
 
+    // Validation messages - rich text links
+    'core.validation.richText.actionNotConnected':
+      'Link <code>{{id}}</code> is not connected to a step, so clicking it will fail at runtime. Connect it to the step it should open, or turn off "Use as an interactive link".',
+
     // Elements - rich text
     'core.elements.richText.placeholder': 'Enter text here...',
     'core.elements.richText.resolvedI18nValue': 'Resolved i18n value',


### PR DESCRIPTION
### Purpose

A rich-text link in the flow builder could render but do nothing, or fail the step and land the user on an empty sign in page.

A link is wired by two values that must agree: the component's `action.ref` and the `data-action-ref` on the `<a>` in its label HTML. The renderer only dispatches when the clicked anchor's sentinel equals the ref. Several paths moved one without the other, and one path shipped the same ref for every dropped widget.

Also fixes the properties panel bouncing back to the previously selected component, which made edits land on the wrong one.

### Approach

- Connecting an edge now rewrites the label's sentinel alongside `action.ref`, and heals a lone sentinel that has already drifted.
- Each dropped link widget mints its own ref, used in both `action.ref` and the label, via a new embedded `{{KEY}}` substitution in the placeholder engine. The three link widgets also gained `defaultPropertySelectorId`.
- Toggling a link on seeds a ref the label can actually dispatch instead of an empty string, and toggling one off no longer throws during save.
- A rich-text action no longer inherits the surrounding block's required inputs, so a link inside a credentials form does not demand a username and password before it can fire.
- The editor restores the `data-*` sentinels Lexical drops, matching anchors on href plus text so an inserted link cannot steal another link's ref.
- A new validation rule warns when a link is not connected to a step, on every flow type.
- The properties panel flushes a pending edit without re-selecting the resource it was typed into, and an untouched field no longer commits a normalized value on unmount.

### Related Issues
- Fixes #4530
- Fixes #4559
- Fixes #4613
- Fixes #4644

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Rich-text links now preserve and synchronize action references when edited, connected, or exported.
  - Added validation warnings for interactive links that are not connected to a flow step.
  - Template placeholders can now be embedded within larger strings.
  - Common flow validation rules now apply consistently across flow types.

- **Bug Fixes**
  - Prevented stale resource selections and unintended draft commits during property editing.
  - Improved handling of empty, missing, and duplicate rich-text action references.
  - Added unique references for sign-up, sign-in, and recovery link widgets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->