### PR TITLE
Add CSP documentation and CSP origin hint component

### DIFF
--- a/backend/cmd/server/config/resources/server_configs/csp.yaml
+++ b/backend/cmd/server/config/resources/server_configs/csp.yaml
@@ -1,22 +1,19 @@
 resource_type: server_config
 name: csp
 value:
-  # Enforcing. Applies only to /console/ and /gate/; all other responses (APIs, OAuth2) get no CSP
-  # header. Each path policy's directives replace the matching baseline directive for that path.
+  # Enforcing. Each path policy's directives replace the matching baseline directive for that path.
   reportOnly: false
   paths:
-    # Console application.
     - location: "/console/"
       directives:
-        # Governs <style> elements and stylesheet links.
         style-src-elem:
           - "'self'"
           - "https://fonts.googleapis.com"
-          - "'unsafe-inline'" # Needed for the embedded Monaco editor (Custom CSS, JWT claims, Import/Export viewers), which has no CSP nonce support (monaco-editor#271).
+          - "'unsafe-inline'" # Needed for the embedded Monaco editor, which has no CSP nonce support.
         # Governs inline style="" attributes; these can't carry a nonce at all per spec.
         style-src-attr:
           - "'self'"
-          - "'unsafe-inline'" # Needed for React/MUI's style={{}} usage.
+          - "'unsafe-inline'"
         img-src:
           - "'self'"
           - "data:" # Inline library images.
@@ -30,22 +27,18 @@ value:
           - "https://thunderid.dev" # Console welcome page's release metadata fetch.
           - "https://fonts.googleapis.com" # GatePreview iframe preconnect.
           - "https://fonts.gstatic.com" # GatePreview iframe preconnect.
-        # Controls allowed sources for worker scripts.
         worker-src:
           - "'self'"
           - "blob:" # Monaco instantiates web workers, which the build may emit as blob URLs.
-    # Gate application.
     - location: "/gate/"
       directives:
-        # Governs <style> elements and stylesheet links.
         style-src-elem:
           - "'self'"
           - "https://fonts.googleapis.com"
-          # No 'unsafe-inline': Gate doesn't embed Monaco, so it keeps the strict nonce-only policy.
         # Governs inline style="" attributes; these can't carry a nonce at all per spec.
         style-src-attr:
           - "'self'"
-          - "'unsafe-inline'" # Needed for React/MUI's style={{}} usage.
+          - "'unsafe-inline'"
         img-src:
           - "'self'"
           - "data:"

--- a/docs/content/deployment/configuration.mdx
+++ b/docs/content/deployment/configuration.mdx
@@ -887,6 +887,90 @@ Anchor every regex with `^` and `$` and escape literal dots. Unanchored patterns
 The `null` origin is shared by sandboxed iframes, `file://` and `data:` documents, and some redirects, so allowing `"null"` cannot identify the caller. List it only when you intend to trust those contexts. With credentialed responses, it lets any such page make authenticated requests.
 :::
 
+## Content Security Policy
+
+:::note RUNNING FROM SOURCE WITH MAKE RUN
+CSP headers are not enforced in development. The policy is applied only when static assets are served through the backend server binary.
+:::
+
+Controls where the browser may load scripts, styles, images, fonts, and other resources for the <ProductName /> Console and Gate UIs. The policy is deny-first: any resource that is not explicitly allowed is blocked.
+
+The CSP header is sent only on <ProductName /> Console (`/console/`) and Gate (`/gate/`) responses.
+
+| Field | Description |
+|-------|-------------|
+| `reportOnly` | When `true` (the default), the browser reports violations to its console but still loads the resource, using the `Content-Security-Policy-Report-Only` header. Set it to `false` to enforce the policy and block disallowed resources. |
+| `reportUri` | Optional endpoint the browser posts violation reports to, mapped to the `report-uri` directive. Use a relative path or an `http`/`https` URL. |
+| `directives` | Map of directive name (for example `img-src`) to its list of allowed sources. A directive you list here replaces that directive's baseline value on every CSP path. |
+| `paths` | List of per-path overrides. Each entry has a `location` prefix (for example `/console/`) and its own `directives`. The longest matching `location` applies, and its directives override `directives`, which override the baseline. |
+
+### Deny-First Baseline
+
+Every directive you do not configure falls back to this baseline:
+
+```text
+default-src 'none';
+script-src 'self';
+style-src 'self';
+img-src 'self';
+connect-src 'self';
+frame-ancestors 'none';
+base-uri 'none';
+form-action 'self'
+```
+
+A resource type without a matching directive (for example `font-src`) falls back to `default-src 'none'` and is blocked. On HTML responses, <ProductName /> Gate gets a fresh per-request nonce to the `script-src` and `style-src-elem` directives so its own inline scripts and styles load.
+
+:::warning Overrides replace, not extend
+Listing a directive replaces its baseline value completely. Include `'self'` in your list when you still need same-origin resources. For example, `img-src: ["https://cdn.example.com"]` blocks same-origin images until you add `'self'`.
+:::
+
+### Configure the Policy
+
+Set the policy in either of these ways:
+
+- **Declarative** - create `config/resources/server_configs/csp.yaml`, then restart.
+  ```yaml
+  name: csp
+  value:
+    reportOnly: false
+    paths:
+      - location: "/console/"
+        directives:
+          img-src:
+            - "'self'"
+            - "https://cdn.example.com"
+          style-src-elem:
+            - "'self'"
+            - "https://fonts.googleapis.com"
+          font-src:
+            - "'self'"
+            - "https://fonts.gstatic.com"
+  ```
+- **Runtime** - send the new value to `PUT /server-config/csp`; it is applied immediately:
+  ```http
+  PUT /server-config/csp
+  Content-Type: application/json
+
+  {
+    "reportOnly": false,
+    "paths": [
+      {
+        "location": "/console/",
+        "directives": {"img-src": ["'self'", "https://cdn.example.com"]}
+      }
+    ]
+  }
+  ```
+
+Directives at the top level of `directives` apply to every CSP path, while a `paths` entry applies only to requests under its `location` and overrides the top-level value for that directive.
+
+A `PUT` replaces the entire runtime layer, so include every runtime value you want to keep. <ProductName /> then merges that layer with the declarative `csp.yaml` per directive and path, and any directive you configure in neither layer stays at the deny-first baseline.
+
+:::note
+Directive names must match the pattern `^[a-z][a-z0-9-]*$`, and no source may contain whitespace, a semicolon, or a comma. An invalid value is rejected with `SCF-1003` ("Invalid server configuration value").
+:::
+
 ## Default Resource Server
 
 Sets the resource server for permission-bearing token requests that omit the `resource` parameter. It is stored in the server-config `defaultResourceServer` section, not in `deployment.yaml`. When no default is configured, a request that contains permission scopes but omits `resource` fails with `invalid_target`. OIDC-only and scopeless requests are not bound to a resource server, so they use the application's default audience (`token.accessToken.defaultAudience`), or the `client_id` when it is unset.

--- a/docs/content/deployment/production-guidelines.mdx
+++ b/docs/content/deployment/production-guidelines.mdx
@@ -246,6 +246,40 @@ To change origins without a restart, update the same section with `PUT /server-c
 
   Anchor regex patterns with `^` and `$`. <ProductName /> logs a startup warning for unanchored patterns because they can match unintended origins.
 
+## Harden the Content Security Policy
+
+<ProductName /> sends a Content Security Policy (CSP) header on its Console and Gate UIs to restrict where the browser loads scripts, styles, images, and fonts from. The policy is stored in the server-config `csp` section. It ships in report-only mode so you can discover what your deployment loads before you enforce it.
+
+Roll out enforcement in three steps:
+
+1. Keep `reportOnly: true` and open the Console and Gate in a browser. Violations are logged to the browser console without blocking any resource.
+2. For each reported resource, add its origin to the matching directive. External images go in `img-src`, fonts in `font-src`, and external stylesheets in `style-src-elem`.
+3. Set `reportOnly: false` to enforce the policy once the browser console reports no violations.
+
+Create `config/resources/server_configs/csp.yaml`:
+
+```yaml
+name: csp
+value:
+  reportOnly: false
+  paths:
+    - location: "/console/"
+      directives:
+        img-src:
+          - "'self'"
+          - "https://cdn.example.com"
+```
+
+To change the policy without a restart, update the same section with `PUT /server-config/csp`. Runtime values are merged with the declarative file.
+
+**Guidelines:**
+
+- Listing a directive replaces its baseline value, so include `'self'` when you still need same-origin resources.
+- When you add an external logo, font, or stylesheet URL in the Console, allow its origin in the matching directive. The Console shows the directive to update next to each field.
+- Keep the policy as narrow as your applications allow. Avoid broad sources such as `https:` or `'unsafe-inline'` once you know the exact origins you need.
+
+See [Content Security Policy](../configuration#content-security-policy) for the full field reference and the deny-first baseline.
+
 ## Configure Caching
 
 <ProductName /> supports two cache backends: in-memory and Redis.

--- a/docs/versioned_docs/version-v1.0.x/deployment/configuration.mdx
+++ b/docs/versioned_docs/version-v1.0.x/deployment/configuration.mdx
@@ -885,6 +885,90 @@ Anchor every regex with `^` and `$` and escape literal dots. Unanchored patterns
 The `null` origin is shared by sandboxed iframes, `file://` and `data:` documents, and some redirects, so allowing `"null"` cannot identify the caller. List it only when you intend to trust those contexts. With credentialed responses, it lets any such page make authenticated requests.
 :::
 
+## Content Security Policy
+
+:::note RUNNING FROM SOURCE WITH MAKE RUN
+CSP headers are not enforced in development. The policy is applied only when static assets are served through the backend server binary.
+:::
+
+Controls where the browser may load scripts, styles, images, fonts, and other resources for the <ProductName /> Console and Gate UIs. The policy is deny-first: any resource that is not explicitly allowed is blocked.
+
+The CSP header is sent only on <ProductName /> Console (`/console/`) and Gate (`/gate/`) responses.
+
+| Field | Description |
+|-------|-------------|
+| `reportOnly` | When `true` (the default), the browser reports violations to its console but still loads the resource, using the `Content-Security-Policy-Report-Only` header. Set it to `false` to enforce the policy and block disallowed resources. |
+| `reportUri` | Optional endpoint the browser posts violation reports to, mapped to the `report-uri` directive. Use a relative path or an `http`/`https` URL. |
+| `directives` | Map of directive name (for example `img-src`) to its list of allowed sources. A directive you list here replaces that directive's baseline value on every CSP path. |
+| `paths` | List of per-path overrides. Each entry has a `location` prefix (for example `/console/`) and its own `directives`. The longest matching `location` applies, and its directives override `directives`, which override the baseline. |
+
+### Deny-First Baseline
+
+Every directive you do not configure falls back to this baseline:
+
+```text
+default-src 'none';
+script-src 'self';
+style-src 'self';
+img-src 'self';
+connect-src 'self';
+frame-ancestors 'none';
+base-uri 'none';
+form-action 'self'
+```
+
+A resource type without a matching directive (for example `font-src`) falls back to `default-src 'none'` and is blocked. On HTML responses, <ProductName /> Gate gets a fresh per-request nonce to the `script-src` and `style-src-elem` directives so its own inline scripts and styles load.
+
+:::warning Overrides replace, not extend
+Listing a directive replaces its baseline value completely. Include `'self'` in your list when you still need same-origin resources. For example, `img-src: ["https://cdn.example.com"]` blocks same-origin images until you add `'self'`.
+:::
+
+### Configure the Policy
+
+Set the policy in either of these ways:
+
+- **Declarative** - create `config/resources/server_configs/csp.yaml`, then restart.
+  ```yaml
+  name: csp
+  value:
+    reportOnly: false
+    paths:
+      - location: "/console/"
+        directives:
+          img-src:
+            - "'self'"
+            - "https://cdn.example.com"
+          style-src-elem:
+            - "'self'"
+            - "https://fonts.googleapis.com"
+          font-src:
+            - "'self'"
+            - "https://fonts.gstatic.com"
+  ```
+- **Runtime** - send the new value to `PUT /server-config/csp`; it is applied immediately:
+  ```http
+  PUT /server-config/csp
+  Content-Type: application/json
+
+  {
+    "reportOnly": false,
+    "paths": [
+      {
+        "location": "/console/",
+        "directives": {"img-src": ["'self'", "https://cdn.example.com"]}
+      }
+    ]
+  }
+  ```
+
+Directives at the top level of `directives` apply to every CSP path, while a `paths` entry applies only to requests under its `location` and overrides the top-level value for that directive.
+
+A `PUT` replaces the entire runtime layer, so include every runtime value you want to keep. <ProductName /> then merges that layer with the declarative `csp.yaml` per directive and path, and any directive you configure in neither layer stays at the deny-first baseline.
+
+:::note
+Directive names must match the pattern `^[a-z][a-z0-9-]*$`, and no source may contain whitespace, a semicolon, or a comma. An invalid value is rejected with `SCF-1003` ("Invalid server configuration value").
+:::
+
 ## Default Resource Server
 
 Sets the resource server for permission-bearing token requests that omit the `resource` parameter. It is stored in the server-config `defaultResourceServer` section, not in `deployment.yaml`. When no default is configured, a request that contains permission scopes but omits `resource` fails with `invalid_target`. OIDC-only and scopeless requests are not bound to a resource server, so they use the application's default audience (`token.accessToken.defaultAudience`), or the `client_id` when it is unset.

--- a/docs/versioned_docs/version-v1.0.x/deployment/production-guidelines.mdx
+++ b/docs/versioned_docs/version-v1.0.x/deployment/production-guidelines.mdx
@@ -246,6 +246,40 @@ To change origins without a restart, update the same section with `PUT /server-c
 
   Anchor regex patterns with `^` and `$`. <ProductName /> logs a startup warning for unanchored patterns because they can match unintended origins.
 
+## Harden the Content Security Policy
+
+<ProductName /> sends a Content Security Policy (CSP) header on its Console and Gate UIs to restrict where the browser loads scripts, styles, images, and fonts from. The policy is stored in the server-config `csp` section. It ships in report-only mode so you can discover what your deployment loads before you enforce it.
+
+Roll out enforcement in three steps:
+
+1. Keep `reportOnly: true` and open the Console and Gate in a browser. Violations are logged to the browser console without blocking any resource.
+2. For each reported resource, add its origin to the matching directive. External images go in `img-src`, fonts in `font-src`, and external stylesheets in `style-src-elem`.
+3. Set `reportOnly: false` to enforce the policy once the browser console reports no violations.
+
+Create `config/resources/server_configs/csp.yaml`:
+
+```yaml
+name: csp
+value:
+  reportOnly: false
+  paths:
+    - location: "/console/"
+      directives:
+        img-src:
+          - "'self'"
+          - "https://cdn.example.com"
+```
+
+To change the policy without a restart, update the same section with `PUT /server-config/csp`. Runtime values are merged with the declarative file.
+
+**Guidelines:**
+
+- Listing a directive replaces its baseline value, so include `'self'` when you still need same-origin resources.
+- When you add an external logo, font, or stylesheet URL in the Console, allow its origin in the matching directive. The Console shows the directive to update next to each field.
+- Keep the policy as narrow as your applications allow. Avoid broad sources such as `https:` or `'unsafe-inline'` once you know the exact origins you need.
+
+See [Content Security Policy](../configuration#content-security-policy) for the full field reference and the deny-first baseline.
+
 ## Configure Caching
 
 <ProductName /> supports two cache backends: in-memory and Redis.

--- a/frontend/apps/console/public/config.js
+++ b/frontend/apps/console/public/config.js
@@ -24,6 +24,7 @@ window.__THUNDERID_RUNTIME_CONFIG__ = {
       'verifiableCredentials.presentations': '',
       settings: '',
       importExport: '',
+      'deployment.csp': 'deployment/configuration/#content-security-policy',
       'applications.templates.react.docs': 'getting-started/connect-your-application/react/',
       'applications.templates.react.playground':
         'https://stackblitz.com/fork/github/thunder-id/javascript-sdks/tree/main/samples/react/quickstart?file=README.md',

--- a/frontend/apps/console/src/features/design/components/layouts/UrlField.tsx
+++ b/frontend/apps/console/src/features/design/components/layouts/UrlField.tsx
@@ -1,6 +1,7 @@
 // Copyright 2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import {CspOriginHint} from '@thunderid/components';
 import {isValidStylesheetUrl, isInsecureStylesheetUrl, type UrlStylesheet} from '@thunderid/design';
 import {FormControl, FormLabel, TextField} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
@@ -45,6 +46,7 @@ function UrlField({sheet, onUpdate}: UrlFieldProps): JSX.Element {
           formHelperText: isInsecure ? {sx: {color: 'warning.main'}} : undefined,
         }}
       />
+      <CspOriginHint value={sheet.href} resourceType="stylesheet" />
     </FormControl>
   );
 }

--- a/frontend/apps/console/src/features/design/components/themes/TypographyBuilderContent.tsx
+++ b/frontend/apps/console/src/features/design/components/themes/TypographyBuilderContent.tsx
@@ -1,6 +1,7 @@
 // Copyright 2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import {CspOriginHint} from '@thunderid/components';
 import {
   BROWSER_SAFE_FONTS,
   DEFAULT_FONT_STACK,
@@ -136,29 +137,28 @@ export default function TypographyBuilderContent({draft, onUpdate}: TypographyBu
   const importURL = getFontImportURL(draft) ?? '';
   const typo = draft.typography;
 
-  // FontImporter only loads this into the GatePreview iframe, a separate document from this panel.
   useFontStylesheetLink(importURL || undefined);
 
   const [fontMode, setFontMode] = useState<'web-safe' | 'import'>(importURL ? 'import' : 'web-safe');
 
-  // Values for the inactive mode aren't in the theme, so stash them here to restore on toggle-back.
   const [stashedWebSafeFamily, setStashedWebSafeFamily] = useState(importURL ? '' : fontFamily);
   const [stashedImport, setStashedImport] = useState<{family: string; url: string}>(
     importURL ? {family: fontFamily, url: importURL} : {family: '', url: ''},
   );
 
-  // Re-sync the toggle when the draft changes from outside (e.g. a Revert), in either direction.
-  // handleFontModeChange pre-syncs these to the values it's about to apply, so this block only
-  // ever fires for changes it didn't cause itself.
+  // Re-sync the toggle and stashed values when the draft is reverted or changed from outside.
   const [prevImportURL, setPrevImportURL] = useState(importURL);
   const [prevFontFamily, setPrevFontFamily] = useState(fontFamily);
   if (importURL !== prevImportURL || fontFamily !== prevFontFamily) {
     setPrevImportURL(importURL);
     setPrevFontFamily(fontFamily);
-    if (importURL && fontMode !== 'import') {
+    if (importURL) {
       setFontMode('import');
-    } else if (!importURL && fontMode === 'import') {
+      setStashedImport({family: fontFamily, url: importURL});
+    } else {
       setFontMode('web-safe');
+      setStashedWebSafeFamily(fontFamily);
+      setStashedImport({family: '', url: ''});
     }
   }
 
@@ -181,19 +181,18 @@ export default function TypographyBuilderContent({draft, onUpdate}: TypographyBu
     let nextFamily: string;
     let nextURL: string;
     if (value === 'web-safe') {
-      // Leaving import mode: remember its values, then restore the remembered web-safe font.
+      // Leaving import mode: remember its values and restore.
       setStashedImport({family: fontFamily, url: importURL});
       nextFamily = stashedWebSafeFamily;
       nextURL = '';
     } else {
-      // Leaving web-safe mode: remember its font, then restore the remembered import values.
+      // Leaving web-safe mode: remember its font and restore.
       setStashedWebSafeFamily(fontFamily);
       nextFamily = stashedImport.family;
       nextURL = stashedImport.url;
     }
     applyFont(nextFamily, nextURL);
-    // Pre-sync so the re-sync block above doesn't mistake this intentional toggle for an
-    // external draft change and immediately flip the mode back.
+    // Pre-sync so the re-sync doesn't flip the mode with this intentional toggle.
     setPrevFontFamily(nextFamily);
     setPrevImportURL(nextURL);
     setFontMode(value);
@@ -260,9 +259,11 @@ export default function TypographyBuilderContent({draft, onUpdate}: TypographyBu
                 value={importURL}
                 onChange={(e) => {
                   const newUrl = e.target.value;
-                  // Clearing the URL clears the family too, since a family with nothing to load it
-                  // from is meaningless.
-                  applyFont(newUrl ? fontFamily : '', newUrl);
+                  const newFamily = newUrl ? fontFamily : '';
+                  applyFont(newFamily, newUrl);
+                  // Pre-sync so the re-sync effect doesn't flip mode when clearing the field.
+                  setPrevFontFamily(newFamily);
+                  setPrevImportURL(newUrl);
                 }}
                 placeholder={t(
                   'themes.forms.typography_builder.fields.font_import_url.placeholder',
@@ -274,6 +275,7 @@ export default function TypographyBuilderContent({draft, onUpdate}: TypographyBu
                 )}
               />
             </FormControl>
+            <CspOriginHint value={importURL} resourceType="font" />
             <FormControl fullWidth>
               <FormLabel htmlFor="font-family-input">
                 {t('themes.forms.typography_builder.fields.font_family_input.label', 'Font Family')}
@@ -283,7 +285,13 @@ export default function TypographyBuilderContent({draft, onUpdate}: TypographyBu
                 id="font-family-input"
                 size="small"
                 value={fontFamily}
-                onChange={(e) => applyFont(e.target.value, importURL)}
+                onChange={(e) => {
+                  const newFamily = e.target.value;
+                  applyFont(newFamily, importURL);
+                  // Pre-sync so the re-sync effect doesn't flip mode while typing a family name.
+                  setPrevFontFamily(newFamily);
+                  setPrevImportURL(importURL);
+                }}
                 placeholder={t('themes.forms.typography_builder.fields.font_family_input.placeholder', 'E.g. Poppins')}
                 helperText={t(
                   'themes.forms.typography_builder.fields.font_family_input.helper_text',

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/ResourceProperties.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/ResourceProperties.tsx
@@ -1,6 +1,7 @@
 // Copyright 2025 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import {CspOriginHint} from '@thunderid/components';
 import {FormControl, FormLabel, MenuItem, Select} from '@wso2/oxygen-ui';
 import {memo, useCallback, useMemo, type ReactElement} from 'react';
 import {useTranslation} from 'react-i18next';
@@ -235,6 +236,7 @@ function ResourceProperties({
               propertyValue={(resource as Element & {src?: string}).src ?? ''}
               onChange={(_key, value, res) => handleChange('src', value, res, true)}
             />
+            <CspOriginHint value={(resource as Element & {src?: string}).src ?? ''} resourceType="image" />
             <TextPropertyField
               resource={resource}
               propertyKey="alt"

--- a/frontend/apps/console/src/features/flows/utils/flowToCanvasTransformer.ts
+++ b/frontend/apps/console/src/features/flows/utils/flowToCanvasTransformer.ts
@@ -28,10 +28,10 @@ const INPUT_ELEMENT_TYPES = new Set<string>([
 /**
  * Extended node type with custom properties used by the canvas
  */
-type CanvasNode = Node<StepData> & {
+interface CanvasNode extends Node<StepData> {
   resourceType?: string;
   category?: string;
-};
+}
 
 /**
  * React Flow canvas data structure
@@ -138,7 +138,7 @@ function findRichTextComponentByActionRef(components: Element[] | undefined, act
   }
 
   for (const component of components) {
-    const richAction = (component as Element & {action?: {ref?: string}}).action;
+    const richAction = (component as {action?: {ref?: string}}).action;
     if (component.type === ElementTypes.RichText && richAction?.ref === actionRef) {
       return component;
     }
@@ -330,7 +330,7 @@ function transformNodeToCanvas(apiNode: FlowNode): CanvasNode {
  */
 function generateEdgesFromNodes(apiNodes: FlowNode[]): Edge[] {
   const edges: Edge[] = [];
-  const nodeIds = new Set(apiNodes.map((node) => node.id));
+  const nodeIds = new Set<string>(apiNodes.map((node) => node.id));
 
   apiNodes.forEach((node) => {
     const stepType = NODE_TO_STEP_TYPE_MAP[node.type] ?? node.type;

--- a/frontend/packages/components/src/CspOriginHint/CspOriginHint.tsx
+++ b/frontend/packages/components/src/CspOriginHint/CspOriginHint.tsx
@@ -1,0 +1,71 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {useConfig} from '@thunderid/contexts';
+import {Alert} from '@wso2/oxygen-ui';
+import type {JSX} from 'react';
+import {useTranslation} from 'react-i18next';
+import {resolveCspHint, type CspResourceType} from './resolveCspHint';
+import ExternalLink from '../ExternalLink/ExternalLink';
+
+// useConfig throws without a ConfigProvider, so resolve defensively: the docs link is added only
+// when documentation config is available; the guidance text always renders.
+function useHasCspDocLink(): boolean {
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    return Boolean(useConfig().getDocumentationLink('deployment.csp'));
+  } catch {
+    return false;
+  }
+}
+
+// English default for each message, passed as the t() default value. Canonical copy is in the i18n
+// locale files; these are the fallback when no i18next instance is configured (for example in tests).
+const CSP_HINT_DEFAULTS: Record<string, string> = {
+  'common:csp.hint.image':
+    "This image loads from {{origin}}. Add {{origin}} to the img-src directive of your server's Content Security Policy so it is not blocked.",
+  'common:csp.hint.stylesheet':
+    "This stylesheet loads from {{origin}}. Add {{origin}} to the style-src-elem directive of your server's Content Security Policy so it is not blocked.",
+  'common:csp.hint.font':
+    "This font loads from {{origin}}. Add {{origin}} to the style-src-elem directive, and the origin that serves its font files to the font-src directive, of your server's Content Security Policy so it is not blocked.",
+  'common:csp.hint.fontGoogle':
+    "Google Fonts loads its stylesheet from fonts.googleapis.com and its font files from fonts.gstatic.com. Add fonts.googleapis.com to the style-src-elem directive and fonts.gstatic.com to the font-src directive of your server's Content Security Policy so this font is not blocked.",
+};
+
+/**
+ * Props for {@link CspOriginHint}.
+ *
+ * @public
+ */
+export interface CspOriginHintProps {
+  /** The current value of the field, typically a URL. */
+  value: string;
+
+  /** The resource type the value is loaded as, used to name the directive to allow it in. */
+  resourceType: CspResourceType;
+}
+
+/**
+ * Inline advisory shown when a field's value loads from an external origin, naming the CSP directive
+ * (`img-src`, `style-src-elem`, or `font-src`) to allow it in and linking to the docs. Renders
+ * nothing for same-origin URLs, relative paths, `data:` URIs, or font-family names, so callers can
+ * render it unconditionally next to a field.
+ *
+ * @public
+ */
+export default function CspOriginHint({value, resourceType}: CspOriginHintProps): JSX.Element | null {
+  const {t} = useTranslation();
+  const hasDocLink = useHasCspDocLink();
+  const hint = resolveCspHint(value, resourceType);
+
+  if (!hint) {
+    return null;
+  }
+
+  return (
+    <Alert severity="info" sx={{mt: 1}} data-componentid="csp-origin-hint">
+      {t(hint.messageKey, CSP_HINT_DEFAULTS[hint.messageKey], {origin: hint.origin})}{' '}
+      {hasDocLink ? <ExternalLink docKey="deployment.csp" confirmBeforeNavigate={false} /> : null}
+    </Alert>
+  );
+}

--- a/frontend/packages/components/src/CspOriginHint/__tests__/CspOriginHint.test.tsx
+++ b/frontend/packages/components/src/CspOriginHint/__tests__/CspOriginHint.test.tsx
@@ -1,0 +1,105 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {render, screen} from '@testing-library/react';
+import {describe, it, expect, vi} from 'vitest';
+import CspOriginHint from '../CspOriginHint';
+import {resolveCspHint} from '../resolveCspHint';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, _defaultValue?: string, opts?: {origin?: string}): string => {
+      if (key === 'common:learnMore') {
+        return 'Learn more';
+      }
+      return opts?.origin ? `${key}::${opts.origin}` : key;
+    },
+  }),
+}));
+
+const {mockGetDocumentationLink} = vi.hoisted(() => ({
+  mockGetDocumentationLink: vi.fn<(key: string) => string | undefined>(
+    () => 'https://thunderid.dev/docs/deployment/configuration/#content-security-policy',
+  ),
+}));
+
+vi.mock('@thunderid/contexts', () => ({
+  useConfig: () => ({getDocumentationLink: mockGetDocumentationLink}),
+}));
+
+vi.mock('@thunderid/logger/react', () => ({
+  useLogger: () => ({error: vi.fn(), info: vi.fn(), debug: vi.fn(), warn: vi.fn()}),
+}));
+
+describe('resolveCspHint', () => {
+  it('returns null for a relative path', () => {
+    expect(resolveCspHint('assets/logo.png', 'image')).toBeNull();
+  });
+
+  it('returns null for a data URI', () => {
+    expect(resolveCspHint('data:image/png;base64,AAAA', 'image')).toBeNull();
+  });
+
+  it('returns null for emoji and avatar sentinels', () => {
+    expect(resolveCspHint('emoji:1f600', 'image')).toBeNull();
+    expect(resolveCspHint('avatar:gradient-1', 'image')).toBeNull();
+  });
+
+  it('returns null for a blank value', () => {
+    expect(resolveCspHint('   ', 'image')).toBeNull();
+  });
+
+  it('returns null for a same-origin URL', () => {
+    expect(resolveCspHint(`${window.location.origin}/logo.png`, 'image')).toBeNull();
+  });
+
+  it('maps an external image URL to img-src guidance', () => {
+    expect(resolveCspHint('https://cdn.example.com/logo.png', 'image')).toEqual({
+      origin: 'https://cdn.example.com',
+      messageKey: 'common:csp.hint.image',
+    });
+  });
+
+  it('maps an external stylesheet URL to style-src-elem guidance', () => {
+    expect(resolveCspHint('https://cdn.example.com/theme.css', 'stylesheet')).toEqual({
+      origin: 'https://cdn.example.com',
+      messageKey: 'common:csp.hint.stylesheet',
+    });
+  });
+
+  it('maps a Google Fonts stylesheet URL to the two-directive guidance', () => {
+    expect(resolveCspHint('https://fonts.googleapis.com/css2?family=Poppins', 'font')).toEqual({
+      origin: 'https://fonts.googleapis.com',
+      messageKey: 'common:csp.hint.fontGoogle',
+    });
+  });
+
+  it('maps an arbitrary font URL to font-src guidance', () => {
+    expect(resolveCspHint('https://fonts.example.com/font.css', 'font')).toEqual({
+      origin: 'https://fonts.example.com',
+      messageKey: 'common:csp.hint.font',
+    });
+  });
+
+  it('preserves a non-standard port in the origin', () => {
+    expect(resolveCspHint('https://cdn.example.com:8443/logo.png', 'image')).toEqual({
+      origin: 'https://cdn.example.com:8443',
+      messageKey: 'common:csp.hint.image',
+    });
+  });
+});
+
+describe('CspOriginHint', () => {
+  it('renders nothing when the value is not an external URL', () => {
+    const {container} = render(<CspOriginHint value="assets/logo.png" resourceType="image" />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the directive guidance and a docs link for an external URL', () => {
+    render(<CspOriginHint value="https://cdn.example.com/logo.png" resourceType="image" />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent('common:csp.hint.image::https://cdn.example.com');
+    expect(screen.getByText('Learn more')).toBeInTheDocument();
+  });
+});

--- a/frontend/packages/components/src/CspOriginHint/resolveCspHint.ts
+++ b/frontend/packages/components/src/CspOriginHint/resolveCspHint.ts
@@ -1,0 +1,66 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/** The kind of resource a value is loaded as, used to pick the CSP directive to allow it in. */
+export type CspResourceType = 'image' | 'stylesheet' | 'font';
+
+/** The origin and guidance message for a value that would need a CSP change. */
+export interface CspHint {
+  /** The external origin (scheme + host + port) the value loads from. */
+  origin: string;
+
+  /** i18n key for the directive-specific guidance message. */
+  messageKey: string;
+}
+
+// Returns the external origin of an absolute http/https URL, or null for values no CSP directive
+// governs: relative paths, data:/blob: URIs, emoji:/avatar: sentinels, or same-origin URLs ('self').
+function externalOrigin(value: string): string | null {
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return null;
+  }
+
+  if (typeof window !== 'undefined' && url.origin === window.location.origin) {
+    return null;
+  }
+
+  return url.origin;
+}
+
+// Resolves the CSP hint for a value, or null when it does not load from an external origin. Google
+// Fonts is special-cased: it serves the stylesheet from fonts.googleapis.com and the fonts from
+// fonts.gstatic.com, so it needs two directives.
+export function resolveCspHint(value: string, resourceType: CspResourceType): CspHint | null {
+  const origin = externalOrigin(value);
+
+  if (!origin) {
+    return null;
+  }
+
+  if (resourceType === 'font') {
+    const {host} = new URL(origin);
+    if (host === 'fonts.googleapis.com' || host === 'fonts.gstatic.com') {
+      return {origin, messageKey: 'common:csp.hint.fontGoogle'};
+    }
+    return {origin, messageKey: 'common:csp.hint.font'};
+  }
+
+  if (resourceType === 'image') {
+    return {origin, messageKey: 'common:csp.hint.image'};
+  }
+
+  return {origin, messageKey: 'common:csp.hint.stylesheet'};
+}

--- a/frontend/packages/components/src/index.ts
+++ b/frontend/packages/components/src/index.ts
@@ -4,6 +4,10 @@
 // Components
 export {default as CopyableField} from './CopyableField/CopyableField';
 export type {CopyableFieldProps} from './CopyableField/CopyableField';
+export {default as CspOriginHint} from './CspOriginHint/CspOriginHint';
+export type {CspOriginHintProps} from './CspOriginHint/CspOriginHint';
+export {resolveCspHint} from './CspOriginHint/resolveCspHint';
+export type {CspResourceType, CspHint} from './CspOriginHint/resolveCspHint';
 export {default as ExternalLinkConfirmDialog} from './ExternalLinkConfirm/ExternalLinkConfirmDialog';
 export type {ExternalLinkConfirmDialogProps} from './ExternalLinkConfirm/ExternalLinkConfirmDialog';
 export {default as useExternalLinkConfirmation} from './ExternalLinkConfirm/useExternalLinkConfirmation';

--- a/frontend/packages/components/src/lab/components/LogoPicker/LogoPicker.tsx
+++ b/frontend/packages/components/src/lab/components/LogoPicker/LogoPicker.tsx
@@ -35,6 +35,7 @@ import {
 import {Link2, Plus, Shuffle, X} from '@wso2/oxygen-ui-icons-react';
 import {useState, useCallback, useEffect, useMemo, useRef, type JSX, type ReactNode} from 'react';
 import {useTranslation} from 'react-i18next';
+import CspOriginHint from '../../../CspOriginHint/CspOriginHint';
 import AvatarSwatchGrid from '../AvatarPicker/AvatarSwatchGrid';
 import EmojiPicker from '../EmojiPicker/EmojiPicker';
 import generateIconSuggestions from '../EmojiPicker/utils/generateIconSuggestions';
@@ -424,6 +425,7 @@ export default function LogoPicker({
               'Direct link to a PNG, SVG or JPG. For best results, use a square image less than 1MB in size.',
             )}
           </FormHelperText>
+          <CspOriginHint value={urlInput} resourceType="image" />
         </Stack>
       </Stack>
 

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -133,6 +133,16 @@ const translations = {
     'externalLink.title': 'You are leaving {{productName}}',
     'externalLink.message': 'This link leads to an external site. Please verify the destination before proceeding:',
 
+    // Content Security Policy hints shown next to fields that load external resources.
+    'csp.hint.image':
+      "This image loads from {{origin}}. Add {{origin}} to the img-src directive of your server's Content Security Policy so it is not blocked.",
+    'csp.hint.stylesheet':
+      "This stylesheet loads from {{origin}}. Add {{origin}} to the style-src-elem directive of your server's Content Security Policy so it is not blocked.",
+    'csp.hint.font':
+      "This font loads from {{origin}}. Add {{origin}} to the style-src-elem directive, and the origin that serves its font files to the font-src directive, of your server's Content Security Policy so it is not blocked.",
+    'csp.hint.fontGoogle':
+      "Google Fonts loads its stylesheet from fonts.googleapis.com and its font files from fonts.gstatic.com. Add fonts.googleapis.com to the style-src-elem directive and fonts.gstatic.com to the font-src directive of your server's Content Security Policy so this font is not blocked.",
+
     // Navigation
     'navigation.home': 'Home',
     'navigation.dashboard': 'Dashboard',


### PR DESCRIPTION
### Purpose
Introducing a Content Security Policy (CSP) restricts where the browser can fetch external assets (images, stylesheets, fonts). When administrators configure external branding URLs, custom CSS stylesheets, or Google Fonts within the Console, missing CSP rules can result in blocked resources and broken UIs.

This PR introduces:
- Documentation for configuring and hardening Content Security Policy.
- A reusable inline UI alert component (`CspOriginHint`) that detects external asset URLs in form inputs and prompts the user with the exact CSP directive (e.g., `img-src`, `style-src-elem`, `font-src`) needed to allow the origin.
---

### Approach
* **Documentation Setup**: Added dedicated CSP sections to `docs/content/deployment/configuration.mdx` and `production-guidelines.mdx` (along with versioned equivalents), documenting the deny-first baseline, declarative/runtime configuration models, and step-by-step enforcement rollout.
* **Reusable Hint Component (`CspOriginHint`)**:
  * Implemented `CspOriginHint` in `@thunderid/components`, leveraging `@wso2/oxygen-ui`'s `Alert` component (`severity="info"`) to maintain UI/theme consistency across the platform.
  * Created `resolveCspHint` to parse incoming URLs, ignore same-origin URLs, relative paths, `data:` URIs, and internal sentinels (`emoji:`, `avatar:`), and map external HTTP/HTTPS origins to their respective CSP directives.
  * Added special handling for Google Fonts (`fonts.googleapis.com` and `fonts.gstatic.com`), instructing users to update both `style-src-elem` and `font-src`.
  * Included an optional direct link to the new CSP documentation (`deployment.csp`).
* **Form Integration**:
  * Integrated `CspOriginHint` below inputs in `LogoPicker` (image logos), `UrlField` (custom stylesheets), `TypographyBuilderContent` (font URLs), and `ResourceProperties` (flow image sources).

### Related Issues
- Closes #4478

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added Content Security Policy guidance for external images, stylesheets, custom fonts, and Google Fonts.
- Added contextual alerts identifying origins that may need inclusion in CSP settings, with links to deployment documentation.
- Added support for report-only or enforcement modes, including global and path-specific directives.

## Documentation
- Added comprehensive CSP configuration, rollout, validation, and production security guidance.
- Updated translations and deployment documentation navigation.

## Bug Fixes
- Improved custom font editing behavior to prevent unintended mode changes.

## Tests
- Added coverage for CSP guidance detection, rendering, and documentation links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->