### PR TITLE
Prompt for mobile number before generating SMS OTP in signup and signin

### DIFF
--- a/frontend/apps/console/src/features/flows/data/templates.json
+++ b/frontend/apps/console/src/features/flows/data/templates.json
@@ -4673,7 +4673,7 @@
               }
             ]
           },
-          "onSuccess": "generate_otp",
+          "onSuccess": "attribute_collect",
           "onIncomplete": "choose_auth"
         },
         {
@@ -4742,7 +4742,7 @@
           "executor": {
             "name": "ProvisioningExecutor"
           },
-          "onSuccess": "generate_otp",
+          "onSuccess": "attribute_collect",
           "layout": {
             "size": {
               "width": 200,
@@ -4805,6 +4805,115 @@
               "y": -14
             }
           }
+        },
+        {
+          "id": "attribute_collect",
+          "type": "TASK_EXECUTION",
+          "layout": {
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 1275,
+              "y": 546
+            }
+          },
+          "executor": {
+            "name": "AttributeCollector",
+            "inputs": [
+              {
+                "ref": "input_mobile",
+                "type": "PHONE_INPUT",
+                "identifier": "mobile_number",
+                "required": true
+              }
+            ]
+          },
+          "onSuccess": "generate_otp",
+          "onIncomplete": "prompt_mobile"
+        },
+        {
+          "id": "prompt_mobile",
+          "type": "PROMPT",
+          "layout": {
+            "size": {
+              "width": 350,
+              "height": 603
+            },
+            "position": {
+              "x": 1275,
+              "y": 750
+            }
+          },
+          "meta": {
+            "components": [
+              {
+                "alt": "{{ t(signin:images.app_logo.alt) }}",
+                "category": "DISPLAY",
+                "height": "60",
+                "id": "image_logo_phone_signin",
+                "resourceType": "ELEMENT",
+                "src": "{{ meta(application.logoUrl) }}",
+                "type": "IMAGE",
+                "width": ""
+              },
+              {
+                "align": "center",
+                "category": "DISPLAY",
+                "id": "display_phone_heading_signin",
+                "label": "{{ t(signin:forms.phone.title) }}",
+                "resourceType": "ELEMENT",
+                "type": "TEXT",
+                "variant": "HEADING_1"
+              },
+              {
+                "category": "BLOCK",
+                "components": [
+                  {
+                    "category": "FIELD",
+                    "hint": "",
+                    "id": "input_phone_signin",
+                    "inputType": "tel",
+                    "label": "{{ t(signin:forms.phone.fields.phone.label) }}",
+                    "placeholder": "{{ t(signin:forms.phone.fields.phone.placeholder) }}",
+                    "ref": "mobile_number",
+                    "required": true,
+                    "resourceType": "ELEMENT",
+                    "type": "TEXT_INPUT"
+                  },
+                  {
+                    "category": "ACTION",
+                    "eventType": "SUBMIT",
+                    "id": "action_phone_signin",
+                    "label": "{{ t(signin:forms.phone.actions.submit.label) }}",
+                    "resourceType": "ELEMENT",
+                    "type": "ACTION",
+                    "variant": "PRIMARY"
+                  }
+                ],
+                "id": "block_phone_signin",
+                "resourceType": "ELEMENT",
+                "type": "BLOCK"
+              }
+            ]
+          },
+          "prompts": [
+            {
+              "inputs": [
+                {
+                  "ref": "input_phone_signin",
+                  "type": "PHONE_INPUT",
+                  "identifier": "mobile_number",
+                  "required": true
+                }
+              ],
+              "action": {
+                "ref": "action_phone_signin",
+                "nextNode": "attribute_collect"
+              }
+            }
+          ]
         },
         {
           "id": "generate_otp",
@@ -9948,7 +10057,7 @@
           "executor": {
             "name": "CredentialsAuthExecutor"
           },
-          "onSuccess": "generate_otp",
+          "onSuccess": "prompt_mobile",
           "onFailure": "choose_auth",
           "onIncomplete": "choose_auth"
         },
@@ -14745,6 +14854,10 @@
               "type": "ID"
             },
             {
+              "key": "MOBILE_PROMPT_STEP_ID",
+              "type": "ID"
+            },
+            {
               "key": "SMS_SEND_EXECUTOR_ID",
               "type": "ID"
             },
@@ -14856,6 +14969,37 @@
                 "executor": {
                   "name": "CredentialsAuthExecutor"
                 },
+                "onSuccess": "{{MOBILE_PROMPT_STEP_ID}}",
+                "onFailure": "",
+                "onIncomplete": ""
+              }
+            }
+          },
+          {
+            "id": "{{MOBILE_PROMPT_STEP_ID}}",
+            "type": "TASK_EXECUTION",
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 1010,
+              "y": 291
+            },
+            "data": {
+              "action": {
+                "type": "EXECUTOR",
+                "executor": {
+                  "name": "AttributeCollector",
+                  "inputs": [
+                    {
+                      "ref": "mobile_number",
+                      "type": "PHONE_INPUT",
+                      "identifier": "mobile_number",
+                      "required": true
+                    }
+                  ]
+                },
                 "onSuccess": "{{SMS_SEND_EXECUTOR_ID}}",
                 "onFailure": "",
                 "onIncomplete": ""
@@ -14878,7 +15022,15 @@
                 "type": "EXECUTOR",
                 "executor": {
                   "name": "OTPExecutor",
-                  "mode": "generate"
+                  "mode": "generate",
+                  "inputs": [
+                    {
+                      "ref": "mobile_number",
+                      "type": "PHONE_INPUT",
+                      "identifier": "mobile_number",
+                      "required": true
+                    }
+                  ]
                 },
                 "onSuccess": "{{SMS_EXECUTOR_ID}}",
                 "onFailure": "",


### PR DESCRIPTION
### Purpose
The `Basic + Google + GitHub + SMS` sign-up flow template connected the password, Google, and GitHub branches straight to OTP generation without collecting the user's phone number first. OTP generation had nothing to send the code to, so the flow errored out mid-signup asking for a phone number with no node in the graph to handle the answer, an unrecoverable dead end.

The sign-in counterpart of the same template had a related gap: for any account with no stored phone number (e.g. one created before this fix, or JIT-provisioned via Google/GitHub), OTP generation and SMS sending would fail outright (`FET-1039`, `SMS recipient is required`) with no way to recover.

### Approach
- **Registration template**: route `credentials_auth`, `google_auth`, and `github_auth` through the existing `prompt_mobile` node before `generate_otp`, instead of skipping straight to it.
- **Sign-in template**: insert an `AttributeCollector` step (requiring `mobile_number`) before `generate_otp`. It checks the authenticated user's existing profile first, if the phone number is already on file it completes silently with no visible prompt; only accounts missing it get a one-time prompt, and the value is saved to the profile so it's never asked again.
  - `credentials_auth` routes straight to `attribute_collect` (a local account always exists for password sign-in).
  - `google_auth`/`github_auth` route through the existing JIT-provisioning step (`provisioning` → `prompt_schema_attrs`) first, unchanged, then into `attribute_collect`, so newly auto-provisioned federated accounts also get their phone number collected before OTP.
- Applied the same `credentials_auth → prompt_mobile → generate_otp` fix to the standalone `Password + SMS OTP` sign-in template, which had the identical bug.

### Related Issues
- #4657

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Social SMS authentication and registration now require a mobile number before sending a one-time password (OTP).
- Social registration includes a dedicated mobile-number entry step.
- Password-plus-SMS sign-in collects the mobile number and uses it for OTP delivery.
- Authentication and account-provisioning flows now offer a consistent mobile-number collection experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->