### PR TITLE
Fix b2c try it out for staff onboarding

### DIFF
--- a/docs/content/guides/flows/build-a-flow.mdx
+++ b/docs/content/guides/flows/build-a-flow.mdx
@@ -204,14 +204,14 @@ A flow has no effect until it is assigned to an application.
 
   To customize the user onboarding flow, you can either edit the default flow directly in the Console's Flow Builder, or create a new one via the `/flows` API. See [API Reference](../../../apis).
 
-  To set the flow as the active system-wide user onboarding flow, update `deployment.yaml`:
+  To set the flow as the active system-wide user onboarding flow, call the Server Configuration API:
 
-  ```yaml
-  flow:
-    user_onboarding_flow_handle: <your-flow-handle>
+  ```bash
+  curl -kL -X PUT https://localhost:8090/server-config/flow \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{ "userOnboardingFlow": { "defaultHandle": "<your-flow-handle>" } }'
   ```
-
-  Restart <ProductName /> for the change to take effect. All admin user creation actions, from the Console and the API, use the new flow.
 
 </details>
 

--- a/docs/content/use-cases/b2c/try-it-out/onboard-internal-users.mdx
+++ b/docs/content/use-cases/b2c/try-it-out/onboard-internal-users.mdx
@@ -22,35 +22,6 @@ Complete [Set Up Your Environment](../../build-environment) before starting this
 [Understand It](../../overview) covers the requirements story behind this use case.
 :::
 
-## Set Up Internal User Onboarding
-
-1. Invitation emails are delivered through a SMTP server. **Configure a SMTP provider** and apply the configuration in
-   `deployment.yaml`.
-
-   **Sample SMTP Configuration:**
-
-   ```yaml
-   email:
-     smtp:
-       host: '<smtp-host>'
-       port: <smtp-port>
-       username: '<smtp-username>'
-       password: '<smtp-password>'
-       from_address: '<from-address>'
-       enable_start_tls: true
-       enable_authentication: true
-   ```
-
-2. **Activate the user onboarding flow** by pointing the `user_onboarding_flow_handle` to the bundled flow in
-   `deployment.yaml`:
-
-   ```yaml
-   flow:
-     user_onboarding_flow_handle: 'wayfinder-onboarding-flow'
-   ```
-
-3. Restart <ProductName /> for the changes to take effect.
-
 ## Try the Use Case
 
 The Wayfinder onboarding flow prompts the admin to pick the staff role (Support or DestinationsAdmin), then collects the

--- a/docs/versioned_docs/version-v1.0.x/guides/flows/build-a-flow.mdx
+++ b/docs/versioned_docs/version-v1.0.x/guides/flows/build-a-flow.mdx
@@ -204,14 +204,14 @@ A flow has no effect until it is assigned to an application.
 
   To customize the user onboarding flow, you can either edit the default flow directly in the Console's Flow Builder, or create a new one via the `/flows` API. See [API Reference](../../../apis).
 
-  To set the flow as the active system-wide user onboarding flow, update `deployment.yaml`:
+  To set the flow as the active system-wide user onboarding flow, call the Server Configuration API:
 
-  ```yaml
-  flow:
-    user_onboarding_flow_handle: <your-flow-handle>
+  ```bash
+  curl -kL -X PUT https://localhost:8090/server-config/flow \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{ "userOnboardingFlow": { "defaultHandle": "<your-flow-handle>" } }'
   ```
-
-  Restart <ProductName /> for the change to take effect. All admin user creation actions, from the Console and the API, use the new flow.
 
 </details>
 

--- a/docs/versioned_docs/version-v1.0.x/use-cases/b2c/try-it-out/onboard-internal-users.mdx
+++ b/docs/versioned_docs/version-v1.0.x/use-cases/b2c/try-it-out/onboard-internal-users.mdx
@@ -22,35 +22,6 @@ Complete [Set Up Your Environment](../../build-environment) before starting this
 [Understand It](../../overview) covers the requirements story behind this use case.
 :::
 
-## Set Up Internal User Onboarding
-
-1. Invitation emails are delivered through a SMTP server. **Configure a SMTP provider** and apply the configuration in
-   `deployment.yaml`.
-
-   **Sample SMTP Configuration:**
-
-   ```yaml
-   email:
-     smtp:
-       host: '<smtp-host>'
-       port: <smtp-port>
-       username: '<smtp-username>'
-       password: '<smtp-password>'
-       from_address: '<from-address>'
-       enable_start_tls: true
-       enable_authentication: true
-   ```
-
-2. **Activate the user onboarding flow** by pointing the `user_onboarding_flow_handle` to the bundled flow in
-   `deployment.yaml`:
-
-   ```yaml
-   flow:
-     user_onboarding_flow_handle: 'wayfinder-onboarding-flow'
-   ```
-
-3. Restart <ProductName /> for the changes to take effect.
-
 ## Try the Use Case
 
 The Wayfinder onboarding flow prompts the admin to pick the staff role (Support or DestinationsAdmin), then collects the

--- a/frontend/apps/console/src/features/welcome/pages/TryoutSecuringApplicationPage.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/TryoutSecuringApplicationPage.tsx
@@ -13,7 +13,6 @@ import {
   Typography,
   IconButton,
   LinearProgress,
-  Alert,
   AppBreadcrumbs,
 } from '@wso2/oxygen-ui';
 import {
@@ -366,9 +365,6 @@ export default function TryoutSecuringConsumerApp(): JSX.Element {
                     <Typography variant="body2" color="text.secondary">
                       {t('common:welcome.applicationTryout.scenarios.onboard.description', {productName})}
                     </Typography>
-                    <Alert severity="info" sx={{fontSize: '0.8rem'}}>
-                      {t('common:welcome.applicationTryout.scenarios.onboard.smtpNote', {productName})}
-                    </Alert>
                     <StepList
                       steps={[
                         t('common:welcome.applicationTryout.scenarios.onboard.step1', {productName}),

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -311,8 +311,6 @@ const translations = {
 
     'welcome.applicationTryout.scenarios.onboard.description':
       'Invite and onboard two new staff members entirely from the {{productName}} Console: Sam Rivera (Support) and Maya Patel (DestinationsAdmin). The admin picks the staff role and sends the invitation, and the matching role is attached automatically when the invitee completes their profile.',
-    'welcome.applicationTryout.scenarios.onboard.smtpNote':
-      "Before trying this flow, set flow.user_onboarding_flow_handle to wayfinder-onboarding-flow in {{productName}}'s deployment.yaml and restart the server.",
     'welcome.applicationTryout.scenarios.onboard.step1': 'Sign in to the {{productName}} Console as your admin user.',
     'welcome.applicationTryout.scenarios.onboard.step2': 'Navigate to Users and select Add User.',
     'welcome.applicationTryout.scenarios.onboard.step3': 'Select Staff as the user type.',

--- a/samples/apps/wayfinder-sample/README.md
+++ b/samples/apps/wayfinder-sample/README.md
@@ -163,15 +163,6 @@ The agent's client secret defaults to `wayfinder-agent-secret` (set in `thunderi
 
 ### Manual Setup
 
-After the import, complete the following local configuration and restart the server:
-
-- Activate the Wayfinder onboarding flow. ThunderID permits only one `USER_ONBOARDING` flow at a time, selected by handle:
-
-  ```yaml
-  flow:
-    user_onboarding_flow_handle: "wayfinder-onboarding-flow"
-  ```
-
 - Configure SMTP so recovery and invitation emails can be delivered. The sample ships with a built-in local SMTP server (`smtp-server/`) that listens on `127.0.0.1:2525`. No external relay is required. The defaults below match its credentials exactly, so no further editing is needed for local development:
 
   ```yaml

--- a/samples/apps/wayfinder-sample/thunderid-config/app-native/thunderid-config.yaml
+++ b/samples/apps/wayfinder-sample/thunderid-config/app-native/thunderid-config.yaml
@@ -2002,3 +2002,11 @@ name: cors
 value:
   allowedOrigins:
     - "http://localhost:5173"
+
+---
+resource_type: server_config
+# Activates the Wayfinder staff onboarding flow.
+name: flow
+value:
+  userOnboardingFlow:
+    defaultHandle: wayfinder-onboarding-flow

--- a/samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid-config.yaml
+++ b/samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid-config.yaml
@@ -1971,3 +1971,11 @@ name: cors
 value:
   allowedOrigins:
     - "http://localhost:5173"
+
+---
+resource_type: server_config
+# Activates the Wayfinder staff onboarding flow.
+name: flow
+value:
+  userOnboardingFlow:
+    defaultHandle: wayfinder-onboarding-flow


### PR DESCRIPTION
### Purpose
This pull request updates the onboarding flow activation instructions and configuration to use the new Server Configuration API and YAML format, and removes outdated documentation and UI references to the old method. The changes affect both documentation and sample configuration files, ensuring consistency with the new onboarding flow activation process.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4387

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated onboarding flow guides to use the Server Configuration API for activation.
  * Simplified internal-user onboarding walkthroughs by removing obsolete setup, SMTP, and restart instructions.
  * Removed outdated manual flow activation steps from the Wayfinder sample README.

* **Improvements**
  * Added default onboarding flow configuration to Wayfinder sample deployments.
  * Removed obsolete SMTP messaging from the onboarding tryout experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->