### PR TITLE
Fix resending OTP in SMS and EmailOTP flows

### DIFF
--- a/frontend/apps/console/src/features/flows/utils/__tests__/reactFlowTransformer.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/reactFlowTransformer.test.ts
@@ -2147,5 +2147,84 @@ describe('reactFlowTransformer', () => {
         expect(viewNode.prompts?.[0].action).toEqual({ref: 'action_recovery', nextNode: 'call-1'});
       });
     });
+
+    describe('Resend Action Serialization', () => {
+      const otpInput = {
+        id: 'otp-1',
+        type: ElementTypes.OtpInput,
+        category: ElementCategories.Field,
+        ref: 'otp',
+        required: true,
+      } as unknown as Element;
+
+      const verifyAction = {
+        id: 'verify-1',
+        type: ElementTypes.Action,
+        category: ElementCategories.Action,
+        eventType: ActionEventTypes.Submit,
+      } as unknown as Element;
+
+      const resendAction = {
+        id: 'resend-1',
+        type: ElementTypes.Resend,
+        category: ElementCategories.Action,
+        eventType: ActionEventTypes.Submit,
+      } as unknown as Element;
+
+      const otpBlock = {
+        id: 'block-1',
+        type: 'BLOCK',
+        category: ElementCategories.Block,
+        components: [otpInput, verifyAction, resendAction],
+      } as unknown as Element;
+
+      const buildCanvas = () => ({
+        nodes: [
+          createNode('view-1', StepTypes.View, {x: 0, y: 0}, {components: [otpBlock]} as StepData),
+          createNode('verify-node', StepTypes.Execution),
+          createNode('generate-node', StepTypes.Execution),
+        ],
+        edges: [
+          createEdge(
+            'e-verify',
+            'view-1',
+            'verify-node',
+            `verify-1${VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX}`,
+          ),
+          createEdge(
+            'e-resend',
+            'view-1',
+            'generate-node',
+            `resend-1${VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX}`,
+          ),
+        ],
+      });
+
+      const promptsOf = (result: ReturnType<typeof transformReactFlow>) =>
+        (
+          result.nodes.find((n) => n.id === 'view-1') as unknown as {
+            prompts?: {action: {ref: string; nextNode: string}; inputs?: {identifier: string}[]}[];
+          }
+        ).prompts;
+
+      it('emits no inputs for a resend action sharing a block with a required OTP input', () => {
+        // A resend re-issues the code the OTP input is waiting for. Inheriting that required
+        // input makes the engine reject the resend for a missing `otp` and re-prompt instead.
+        const prompts = promptsOf(transformReactFlow(buildCanvas()));
+        const resendPrompt = prompts?.find((p) => p.action.ref === 'resend-1');
+
+        expect(resendPrompt).toBeDefined();
+        expect(resendPrompt?.inputs).toBeUndefined();
+        expect(resendPrompt?.action.nextNode).toBe('generate-node');
+      });
+
+      it('still gives the sibling submit action the block inputs', () => {
+        const prompts = promptsOf(transformReactFlow(buildCanvas()));
+        const verifyPrompt = prompts?.find((p) => p.action.ref === 'verify-1');
+
+        expect(verifyPrompt?.inputs).toHaveLength(1);
+        expect(verifyPrompt?.inputs?.[0].identifier).toBe('otp');
+      });
+    });
   });
 });

--- a/frontend/apps/console/src/features/flows/utils/reactFlowTransformer.ts
+++ b/frontend/apps/console/src/features/flows/utils/reactFlowTransformer.ts
@@ -144,6 +144,17 @@ const STEP_TO_NODE_TYPE_MAP: Record<string, string> = {
 };
 
 /**
+ * Action element types whose prompt takes no inputs, regardless of the inputs their
+ * container block holds. The runtime validates the selected action's inputs, so an
+ * action that does not submit the surrounding form must not inherit them:
+ * - A RESEND re-issues the very code its container's input is waiting for, so
+ *   inheriting that input would block the resend on an empty field.
+ * - A RICH_TEXT link navigates rather than submitting, so one sitting inside a
+ *   credentials block would otherwise demand a username and password to fire.
+ */
+const INPUTLESS_ACTION_TYPES = new Set<string>([ElementTypes.Resend, ElementTypes.RichText]);
+
+/**
  * Set of input element types for quick lookup
  */
 const INPUT_ELEMENT_TYPES = new Set<string>([
@@ -436,12 +447,11 @@ function extractPrompts(components: Element[], nodeId: string, edges: Edge[]): F
     // Check if this component is an action
     const action = extractActionFromComponent(component);
     if (action) {
-      // This action gets the parent's inputs (all accumulated up to this point). A rich-text
-      // link navigates rather than submitting the surrounding form, so it must not inherit
-      // them: the runtime validates the selected action's inputs, and a link sitting inside a
-      // credentials block would otherwise demand a username and password before it could fire.
+      // This action gets the parent's inputs (all accumulated up to this point), unless it is
+      // one of the action types that never submits the surrounding form (see
+      // INPUTLESS_ACTION_TYPES).
       const prompt: FlowPrompt = {action};
-      if (parentInputs.length > 0 && component.type !== ElementTypes.RichText) {
+      if (parentInputs.length > 0 && !INPUTLESS_ACTION_TYPES.has(component.type)) {
         prompt.inputs = parentInputs;
       }
       prompts.push(prompt);

--- a/frontend/packages/design/src/components/flow/adapters/BlockAdapter.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/BlockAdapter.tsx
@@ -74,19 +74,22 @@ interface ResendButtonAdapterProps {
   component: FlowComponent;
   isLoading: boolean;
   resolve: (template: string | undefined) => string | undefined;
+  /** Fires the resend action directly, bypassing the form's field validation */
+  onClick: () => void;
 }
 
-function ResendButtonAdapter({component, isLoading, resolve}: ResendButtonAdapterProps): JSX.Element {
+function ResendButtonAdapter({component, isLoading, resolve, onClick}: ResendButtonAdapterProps): JSX.Element {
   const {t} = useTranslation();
 
   return (
     <Button
       id={component.id}
-      type="submit"
+      type="button"
       fullWidth
       className={cn('Flow--resendButton', 'Button--root')}
       variant="text"
       disabled={isLoading}
+      onClick={onClick}
       sx={{mt: 1}}
     >
       {t(resolve(component.label)!)}
@@ -250,7 +253,13 @@ function renderFormSubComponent(
 
   if (sub.type === 'RESEND' && sub.eventType === EmbeddedFlowEventType.Submit) {
     return (
-      <ResendButtonAdapter key={sub.id ?? compIndex} component={sub} isLoading={ctx.isLoading} resolve={ctx.resolve} />
+      <ResendButtonAdapter
+        key={sub.id ?? compIndex}
+        component={sub}
+        isLoading={ctx.isLoading}
+        resolve={ctx.resolve}
+        onClick={() => ctx.onSubmit(sub, ctx.values)}
+      />
     );
   }
 

--- a/frontend/packages/design/src/components/flow/adapters/__tests__/BlockAdapter.test.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/__tests__/BlockAdapter.test.tsx
@@ -49,7 +49,13 @@ const renderBlock = (
     onSubmit = noop,
     recoveryEnabled = true,
     values = BLOCK_VALUES,
-  }: {onSubmit?: (...args: unknown[]) => void; recoveryEnabled?: boolean; values?: Record<string, string>} = {},
+    onValidate = undefined,
+  }: {
+    onSubmit?: (...args: unknown[]) => void;
+    recoveryEnabled?: boolean;
+    values?: Record<string, string>;
+    onValidate?: (components: EmbeddedFlowComponent[]) => boolean;
+  } = {},
 ) =>
   renderWithProviders(
     <BlockAdapter
@@ -60,6 +66,7 @@ const renderBlock = (
       resolve={resolveWithRecovery(recoveryEnabled)}
       onInputChange={noop}
       onSubmit={onSubmit}
+      onValidate={onValidate}
     />,
   );
 
@@ -213,5 +220,122 @@ describe('BlockAdapter: RICH_TEXT inside a trigger-only block', () => {
     fireEvent.click(screen.getByRole('link', {name: 'Forgot password?'}));
 
     expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({id: 'action_forgot_password'}), BLOCK_VALUES);
+  });
+});
+
+describe('BlockAdapter: RESEND inside a form block', () => {
+  const otpInput = {
+    id: 'input_otp',
+    type: 'OTP_INPUT',
+    ref: 'otp',
+    identifier: 'otp',
+    label: 'One-time code',
+    required: true,
+  };
+  const verifyAction = {id: 'action_verify', type: 'ACTION', eventType: 'SUBMIT', variant: 'PRIMARY', label: 'Verify'};
+  const resendAction = {id: 'action_resend', type: 'RESEND', eventType: 'SUBMIT', label: 'Resend code'};
+
+  const otpBlock = {
+    id: 'block_otp',
+    type: 'BLOCK',
+    components: [otpInput, verifyAction, resendAction],
+  };
+
+  const EMPTY_OTP = {otp: ''};
+
+  it('dispatches the resend action rather than the primary submit action', () => {
+    const onSubmit = vi.fn();
+    renderBlock(otpBlock, {onSubmit, values: EMPTY_OTP});
+
+    fireEvent.click(screen.getByRole('button', {name: 'Resend code'}));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({id: 'action_resend'}), EMPTY_OTP);
+  });
+
+  it('dispatches the resend without running field validation on the empty code', () => {
+    const onSubmit = vi.fn();
+    const onValidate = vi.fn(() => false);
+    renderBlock(otpBlock, {onSubmit, onValidate, values: EMPTY_OTP});
+
+    fireEvent.click(screen.getByRole('button', {name: 'Resend code'}));
+
+    expect(onValidate).not.toHaveBeenCalled();
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({id: 'action_resend'}), EMPTY_OTP);
+  });
+
+  it('does not submit the enclosing form when the resend button is clicked', () => {
+    const onSubmit = vi.fn();
+    renderBlock(otpBlock, {onSubmit, values: EMPTY_OTP});
+
+    expect(screen.getByRole('button', {name: 'Resend code'}).getAttribute('type')).toBe('button');
+    expect(screen.getByRole('button', {name: 'Verify'}).getAttribute('type')).toBe('submit');
+  });
+
+  it('still gates the primary submit action behind field validation', () => {
+    const onSubmit = vi.fn();
+    const onValidate = vi.fn(() => false);
+    renderBlock(otpBlock, {onSubmit, onValidate, values: EMPTY_OTP});
+
+    fireEvent.click(screen.getByRole('button', {name: 'Verify'}));
+
+    expect(onValidate).toHaveBeenCalled();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('carries the current block values into the dispatched resend action', () => {
+    const onSubmit = vi.fn();
+    renderBlock(otpBlock, {onSubmit, values: {otp: '12'}});
+
+    fireEvent.click(screen.getByRole('button', {name: 'Resend code'}));
+
+    expect(onSubmit.mock.calls[0][1]).toEqual({otp: '12'});
+  });
+
+  it('dispatches a resend button nested inside a stack', () => {
+    const onSubmit = vi.fn();
+    renderBlock(
+      {
+        id: 'block_otp_stacked',
+        type: 'BLOCK',
+        components: [otpInput, verifyAction, {id: 'stack_resend', type: 'STACK', components: [resendAction]}],
+      },
+      {onSubmit, values: EMPTY_OTP},
+    );
+
+    fireEvent.click(screen.getByRole('button', {name: 'Resend code'}));
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({id: 'action_resend'}), EMPTY_OTP);
+  });
+
+  it('dispatches a resend button that has no id', () => {
+    // No id means the renderer falls back to the component index for the key.
+    const onSubmit = vi.fn();
+    renderBlock(
+      {
+        id: 'block_otp_no_resend_id',
+        type: 'BLOCK',
+        components: [otpInput, verifyAction, {type: 'RESEND', eventType: 'SUBMIT', label: 'Resend code'}],
+      },
+      {onSubmit, values: EMPTY_OTP},
+    );
+
+    fireEvent.click(screen.getByRole('button', {name: 'Resend code'}));
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({type: 'RESEND'}), EMPTY_OTP);
+  });
+
+  it('does not render a RESEND whose eventType is not SUBMIT', () => {
+    renderBlock(
+      {
+        id: 'block_otp_trigger_resend',
+        type: 'BLOCK',
+        components: [otpInput, verifyAction, {...resendAction, eventType: 'TRIGGER'}],
+      },
+      {values: EMPTY_OTP},
+    );
+
+    expect(screen.queryByRole('button', {name: 'Resend code'})).toBeNull();
+    expect(screen.getByRole('button', {name: 'Verify'})).toBeTruthy();
   });
 });


### PR DESCRIPTION
### Purpose

Fixes the "Resend code" button in SMS OTP and Email OTP flows. Clicking it never requested a new code. The form reported that the OTP field was required instead, so a user whose code did not arrive had no way to recover.

Fixes #4605

Two independent defects were involved.

**1. The resend button submitted the enclosing form** (`frontend/packages/design`)

`ResendButtonAdapter` rendered a bare `type="submit"` button with no click handler of its own, so clicking it fired the form's `handleSubmit`. That runs the gate's field validation across the whole block, including the required OTP input, which is empty by definition when the user is asking for a new code. Validation failed and no request was sent. Even with a code typed in, `handleSubmit` dispatches the *primary* submit action, so the flow would have attempted to verify rather than resend.

**2. The saved flow definition required the OTP for the resend action** (`frontend/apps/console`)

`extractPrompts` gives every action in a block all of the inputs held by its container, so a RESEND button inherited the required `otp` input:

```json
{"action": {"ref": "resend_xxxx", "nextNode": "<sms_send>"},
 "inputs": [{"ref": "otp_input_xxxx", "identifier": "otp", "required": true}]}
```

The engine validates only the selected action's inputs (`promptNode.hasRequiredInputs`), so the resend request was rejected server side for a missing `otp`, and the engine re-rendered the OTP view instead of routing to the resend node.

### Approach

- **`BlockAdapter.tsx`**: the resend button renders as `type="button"` and dispatches its own action through `onClick`, so it no longer triggers the form and no longer runs field validation. The resend action's own id is sent rather than the primary submit action's.
- **`reactFlowTransformer.ts`**: `RESEND` is declared in a new `INPUTLESS_ACTION_TYPES` set, so `extractPrompts` emits no inputs for it. It sits beside the existing `INPUT_ELEMENT_TYPES` declaration to keep the shared `processComponent` traversal free of per element special casing.

No backend change is required. The resend request body carries empty `inputs` by design: the SMS recipient is resolved from the persisted flow context, where `mobile_number` remains from the earlier step and is never cleared, since only sensitive and one time use inputs are dropped.

Scope of the second change: `RESEND` is absent from every drop target allowlist in `VisualFlowConstants`, so it cannot be placed on the canvas by an author. It only ever ships pre composed inside templates, widgets, and steps, and in all six such places its only sibling input is the `OTP_INPUT` it re-issues. No flow can lose an input that its resend action actually needed.

**Note for reviewers:** the second change affects serialization at save time. Flows already stored keep the old prompt definition and must be re-saved before the fix takes effect for them.

### Related Issues
- Fixes #4605

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resend actions now work independently of form validation.
  * Clicking Resend no longer unintentionally submits the surrounding form.
  * Resend and rich-text actions no longer inherit unrelated container inputs.
  * Other action types retain their existing input behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->