### PR TITLE
Update js-yaml override versions to patch CVE-2026-59870

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -385,8 +385,8 @@ overrides:
   immutable@>=5.0.0-beta.1 <5.1.8: 5.1.8
   brace-expansion: 5.0.9
   lodash: 4.18.1
-  js-yaml@>=4.0.0 <4.3.0: 4.3.0
-  js-yaml@<3.15.0: 3.15.0
+  js-yaml@>=4.0.0 <4.3.1: 4.3.1
+  js-yaml@<3.15.1: 3.15.1
   http-proxy-middleware: 2.0.10
   devalue: 5.8.1
   tmp: '>=0.2.7'
@@ -10215,12 +10215,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@27.0.1:
@@ -15682,7 +15682,7 @@ snapshots:
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.5
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
@@ -16272,7 +16272,7 @@ snapshots:
       '@docusaurus/utils-common': 3.9.2(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.23))(html-minifier-terser@7.2.0)(postcss@8.5.23)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       fs-extra: 11.3.5
       joi: 18.2.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -16306,7 +16306,7 @@ snapshots:
       globby: 11.1.0
       gray-matter: 4.0.3
       jiti: 1.21.7
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       micromatch: 4.0.8
       p-queue: 6.6.2
@@ -16605,7 +16605,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5(patch_hash=a89e21ec562a8b6f9518efbabebe9ff551bb3eb5ac4bda0a9319af165e2a9ccf)
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -16619,7 +16619,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5(patch_hash=a89e21ec562a8b6f9518efbabebe9ff551bb3eb5ac4bda0a9319af165e2a9ccf)
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -20693,7 +20693,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -22266,7 +22266,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -23088,12 +23088,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -24261,7 +24261,7 @@ snapshots:
       async: 3.2.4
       commander: 2.20.3
       graphlib: 2.1.8
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       json-schema-merge-allof: 0.8.1
       lodash: 4.18.1
       neotraverse: 0.6.14

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -130,10 +130,12 @@ overrides:
   # 5.0.9 additionally fixes GHSA-rgw5-rvv9-x895 — DoS via unbounded intermediate arrays.
   brace-expansion: 5.0.9
   lodash: 4.18.1
-  # JUSTIFICATION: Fixes GHSA-52cp-r559-cp3m — YAML merge-key chains forcing quadratic CPU consumption.
-  js-yaml@>=4.0.0 <4.3.0: 4.3.0
-  # JUSTIFICATION: Fixes GHSA-h67p-54hq-rp68 — quadratic-complexity DoS in js-yaml merge key handling.
-  js-yaml@<3.15.0: 3.15.0
+  # JUSTIFICATION: Fixes GHSA-52cp-r559-cp3m — YAML merge-key chains forcing quadratic CPU consumption,
+  # and GHSA-5p4m-2wfm-xmqj (CVE-2026-59870) — quadratic CPU consumption in !!omap resolution.
+  js-yaml@>=4.0.0 <4.3.1: 4.3.1
+  # JUSTIFICATION: Fixes GHSA-h67p-54hq-rp68 — quadratic-complexity DoS in js-yaml merge key handling,
+  # and GHSA-5p4m-2wfm-xmqj (CVE-2026-59870) — quadratic CPU consumption in !!omap resolution.
+  js-yaml@<3.15.1: 3.15.1
   # JUSTIFICATION: Fixes GHSA-64mm-vxmg-q3vj — http-proxy-middleware router host+path substring match bypass.
   http-proxy-middleware: 2.0.10
   # TODO: Remove once `nuxt` bumps `devalue` to 5.8.1 or later.


### PR DESCRIPTION
### Purpose
Fixes the two **high** severity `js-yaml` vulnerabilities (CVE-2026-59870 / [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj), quadratic CPU consumption in `!!omap` resolution) that were failing the PR builder `pnpm audit --audit-level=high` gate.

The workspace already carried `js-yaml` overrides, but they pinned to `4.3.0` and `3.15.0`, which the new advisory now flags as vulnerable. This PR bumps the pins to the patched versions:

- `js-yaml@>=4.0.0 <4.3.0: 4.3.0` → `js-yaml@>=4.0.0 <4.3.1: 4.3.1`
- `js-yaml@<3.15.0: 3.15.0` → `js-yaml@<3.15.1: 3.15.1`

All transitive `js-yaml` instances now resolve to `3.15.1` / `4.3.1`, and `pnpm audit --audit-level=high` exits `0`.

### Approach
Updated the `js-yaml` entries under `overrides` in `pnpm-workspace.yaml` and regenerated `pnpm-lock.yaml` with `pnpm install --lockfile-only`.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated YAML processing components to patched versions.
  * Addressed a vulnerability that could cause excessive CPU consumption when resolving certain YAML structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->