### PR TITLE
Complete a timed out consent prompt without recording it.

### DIFF
--- a/backend/internal/authn/consent/service.go
+++ b/backend/internal/authn/consent/service.go
@@ -155,6 +155,9 @@ func (s *consentEnforcerService) RecordConsent(ctx context.Context, ouID, appID,
 	// Fill in any missing purposes as denied so incomplete submissions are treated as non-consented
 	fillMissingDecisions(sessionData, decisions)
 
+	// Push denials down the decision hierarchy so everything below reads the effective value
+	applyDecisionHierarchy(decisions)
+
 	// Build essential element lookup and check whether any essential attribute was denied
 	essentialElements := buildEssentialElementSet(sessionData)
 	hasEssentialDenial := hasEssentialDenials(decisions, essentialElements)
@@ -375,6 +378,24 @@ func fillMissingDecisions(session *consentSessionData, decisions *providers.Cons
 				Approved:    false,
 				Elements:    elements,
 			})
+		}
+	}
+}
+
+// applyDecisionHierarchy denies every purpose and element sitting under a denied level, so callers
+// can read the leaf Approved values directly instead of walking back up. Approval is not propagated
+// downwards: an approved parent leaves its children's own decisions untouched.
+func applyDecisionHierarchy(decisions *providers.ConsentDecisions) {
+	for i := range decisions.Purposes {
+		purpose := &decisions.Purposes[i]
+		if !decisions.Approved {
+			purpose.Approved = false
+		}
+		if purpose.Approved {
+			continue
+		}
+		for j := range purpose.Elements {
+			purpose.Elements[j].Approved = false
 		}
 	}
 }

--- a/backend/internal/authn/consent/service_test.go
+++ b/backend/internal/authn/consent/service_test.go
@@ -452,6 +452,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestVerifyAndDecodeConsentSession_Inva
 
 func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_SessionTokenInvalid() {
 	decisions := &providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "purpose1", Approved: true},
 		},
@@ -476,6 +477,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_MissingPurpose_Treat
 		{PurposeName: "purpose2", Essential: []string{"phone"}},
 	})
 	decisions := &providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "purpose1", Approved: true, Elements: []providers.ElementDecision{
 				{Name: "email", Approved: true},
@@ -517,6 +519,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_SearchFails_ClientEr
 		{PurposeName: "purpose1", Essential: []string{"email"}},
 	})
 	decisions := &providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "purpose1", Approved: true, Elements: []providers.ElementDecision{
 				{Name: "email", Approved: true},
@@ -545,6 +548,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_SearchFails_ServerEr
 		{PurposeName: "purpose1", Essential: []string{"email"}},
 	})
 	decisions := &providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "purpose1", Approved: true, Elements: []providers.ElementDecision{
 				{Name: "email", Approved: true},
@@ -574,6 +578,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_NoExisting_CreateSuc
 		{PurposeName: purposeName, Essential: []string{"email"}},
 	})
 	decisions := &providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{
 				PurposeName: purposeName,
@@ -612,11 +617,55 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_NoExisting_CreateSuc
 	s.Equal(providers.ConsentTypeAuthentication, result.Type)
 }
 
+func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_TopLevelDenial_PersistsNothingApproved() {
+	purposeName := consent.AttributePurposeNamePrefix + "app1"
+	sessionToken := buildTestSessionToken([]consentSessionPurpose{
+		{PurposeName: purposeName, Optional: []string{"email", "phone"}},
+	})
+	// The purpose and its elements claim approval, but the top level denies the whole consent
+	decisions := &providers.ConsentDecisions{
+		Approved: false,
+		Purposes: []providers.PurposeDecision{
+			{
+				PurposeName: purposeName,
+				Approved:    true,
+				Elements: []providers.ElementDecision{
+					{Name: "email", Approved: true},
+					{Name: "phone", Approved: true},
+				},
+			},
+		},
+	}
+
+	s.mockJWTSvc.On("VerifyJWT", mock.Anything, sessionToken, consentSessionTokenAudience, mock.Anything).
+		Return((*tidcommon.ServiceError)(nil))
+	s.mockConsentSvc.On("SearchConsents", mock.Anything, mock.Anything).Return([]*consent.Consent{}, nil)
+	s.mockConsentSvc.On("CreateConsent", mock.Anything,
+		mock.MatchedBy(func(req *consent.ConsentRequest) bool {
+			for _, p := range req.Purposes {
+				for _, e := range p.Elements {
+					if e.IsUserApproved {
+						return false
+					}
+				}
+			}
+			return true
+		})).Return(&consent.Consent{ID: "consent-denied"}, nil)
+
+	result, svcErr := s.service.RecordConsent(context.Background(), "ou1", "app1", "user1",
+		decisions, sessionToken, 0, nil)
+
+	s.Nil(svcErr)
+	s.NotNil(result)
+	s.mockConsentSvc.AssertExpectations(s.T())
+}
+
 func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_NoExisting_CreateFails_ClientError() {
 	sessionToken := buildTestSessionToken([]consentSessionPurpose{
 		{PurposeName: "purpose1", Optional: []string{"email"}},
 	})
 	decisions := &providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "purpose1", Approved: true, Elements: []providers.ElementDecision{
 				{Name: "email", Approved: true},
@@ -647,6 +696,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_NoExisting_CreateFai
 		{PurposeName: "purpose1", Optional: []string{"email"}},
 	})
 	decisions := &providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "purpose1", Approved: true, Elements: []providers.ElementDecision{
 				{Name: "email", Approved: true},
@@ -678,6 +728,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_ExistingConsent_Upda
 		{PurposeName: purposeName, Essential: []string{"email"}, Optional: []string{"phone"}},
 	})
 	decisions := &providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{
 				PurposeName: purposeName,
@@ -736,6 +787,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_ExistingConsent_Upda
 		{PurposeName: "purpose1", Optional: []string{"email"}},
 	})
 	decisions := &providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "purpose1", Approved: true, Elements: []providers.ElementDecision{
 				{Name: "email", Approved: true},
@@ -768,6 +820,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_ExistingConsent_Upda
 		{PurposeName: "purpose1", Optional: []string{"email"}},
 	})
 	decisions := &providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "purpose1", Approved: true, Elements: []providers.ElementDecision{
 				{Name: "email", Approved: true},
@@ -800,6 +853,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_WithValidityPeriod()
 		{PurposeName: "purpose1", Optional: []string{"email"}},
 	})
 	decisions := &providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "purpose1", Approved: true, Elements: []providers.ElementDecision{
 				{Name: "email", Approved: true},
@@ -829,6 +883,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_ZeroValidityPeriod()
 		{PurposeName: "purpose1", Optional: []string{"email"}},
 	})
 	decisions := &providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "purpose1", Approved: true, Elements: []providers.ElementDecision{
 				{Name: "email", Approved: true},
@@ -858,6 +913,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_EssentialDenied_Retu
 		{PurposeName: purposeName, Essential: []string{"email"}, Optional: []string{"phone"}},
 	})
 	decisions := &providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{
 				PurposeName: purposeName,
@@ -905,6 +961,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestRecordConsent_UnpromptedElementFil
 		{PurposeName: purposeName, Optional: []string{"email"}},
 	})
 	decisions := &providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{
 				PurposeName: purposeName,
@@ -1338,6 +1395,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestBuildConsentElementApprovals_Multi
 		},
 	}
 	decisions := &providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{
 				PurposeName: "attributes:app1",
@@ -1369,6 +1427,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestBuildConsentElementApprovals_Drops
 		},
 	}
 	decisions := &providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "attributes:app1", Elements: []providers.ElementDecision{
 				{Name: "email", Approved: true},
@@ -1395,6 +1454,78 @@ func (s *ConsentEnforcerServiceTestSuite) TestPurposeElementKey() {
 	s.Equal("purpose1:email", key)
 }
 
+// applyDecisionHierarchy tests
+
+func (s *ConsentEnforcerServiceTestSuite) TestApplyDecisionHierarchy_TopLevelDenialDeniesEverything() {
+	decisions := &providers.ConsentDecisions{
+		Approved: false,
+		Purposes: []providers.PurposeDecision{
+			{PurposeName: "p1", Approved: true, Elements: []providers.ElementDecision{
+				{Name: "email", Approved: true},
+				{Name: "phone", Approved: true},
+			}},
+			{PurposeName: "p2", Approved: true, Elements: []providers.ElementDecision{
+				{Name: "address", Approved: true},
+			}},
+		},
+	}
+
+	applyDecisionHierarchy(decisions)
+
+	for _, p := range decisions.Purposes {
+		s.False(p.Approved)
+		for _, e := range p.Elements {
+			s.False(e.Approved)
+		}
+	}
+}
+
+func (s *ConsentEnforcerServiceTestSuite) TestApplyDecisionHierarchy_PurposeDenialOnlyAffectsItsElements() {
+	decisions := &providers.ConsentDecisions{
+		Approved: true,
+		Purposes: []providers.PurposeDecision{
+			{PurposeName: "denied", Approved: false, Elements: []providers.ElementDecision{
+				{Name: "email", Approved: true},
+			}},
+			{PurposeName: "approved", Approved: true, Elements: []providers.ElementDecision{
+				{Name: "phone", Approved: true},
+			}},
+		},
+	}
+
+	applyDecisionHierarchy(decisions)
+
+	s.False(decisions.Purposes[0].Approved)
+	s.False(decisions.Purposes[0].Elements[0].Approved)
+	s.True(decisions.Purposes[1].Approved)
+	s.True(decisions.Purposes[1].Elements[0].Approved)
+}
+
+func (s *ConsentEnforcerServiceTestSuite) TestApplyDecisionHierarchy_ApprovalDoesNotOverrideDeniedElements() {
+	decisions := &providers.ConsentDecisions{
+		Approved: true,
+		Purposes: []providers.PurposeDecision{
+			{PurposeName: "p1", Approved: true, Elements: []providers.ElementDecision{
+				{Name: "email", Approved: true},
+				{Name: "phone", Approved: false},
+			}},
+		},
+	}
+
+	applyDecisionHierarchy(decisions)
+
+	s.True(decisions.Purposes[0].Elements[0].Approved)
+	s.False(decisions.Purposes[0].Elements[1].Approved)
+}
+
+func (s *ConsentEnforcerServiceTestSuite) TestApplyDecisionHierarchy_NoPurposes() {
+	decisions := &providers.ConsentDecisions{Approved: false}
+
+	applyDecisionHierarchy(decisions)
+
+	s.Empty(decisions.Purposes)
+}
+
 // fillMissingDecisions tests
 
 func (s *ConsentEnforcerServiceTestSuite) TestFillMissingDecisions_AllPresent() {
@@ -1404,6 +1535,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestFillMissingDecisions_AllPresent() 
 		},
 	}
 	decisions := &providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "p1", Approved: true, Elements: []providers.ElementDecision{{Name: "email", Approved: true}}},
 		},
@@ -1420,6 +1552,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestFillMissingDecisions_MissingPurpos
 		},
 	}
 	decisions := &providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "p1", Approved: true, Elements: []providers.ElementDecision{{Name: "email", Approved: true}}},
 		},
@@ -1458,6 +1591,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestHasEssentialDenials() {
 	essentialElements := map[string]bool{"p1:email": true}
 
 	denied := &providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "p1", Elements: []providers.ElementDecision{{Name: "email", Approved: false}}},
 		},
@@ -1465,6 +1599,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestHasEssentialDenials() {
 	s.True(hasEssentialDenials(denied, essentialElements))
 
 	approved := &providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "p1", Elements: []providers.ElementDecision{{Name: "email", Approved: true}}},
 		},
@@ -1473,6 +1608,7 @@ func (s *ConsentEnforcerServiceTestSuite) TestHasEssentialDenials() {
 
 	// A denied element that is not essential does not count.
 	optionalDenied := &providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "p1", Elements: []providers.ElementDecision{{Name: "phone", Approved: false}}},
 		},

--- a/backend/internal/flow/executor/consent_executor.go
+++ b/backend/internal/flow/executor/consent_executor.go
@@ -225,6 +225,16 @@ func (e *consentExecutor) handleConsentDecisions(ctx *providers.NodeContext, exe
 		return execResp, nil
 	}
 
+	// A timed out prompt is not a user decision, so nothing is recorded and nothing is consented.
+	// The expiry check below is skipped because such a submission is expected to arrive late.
+	if decisions.Reason == providers.ConsentDecisionReasonTimeout {
+		logger.Debug(ctx.Context, "Consent prompt timed out; completing without recording consent")
+		execResp.RuntimeData[common.RuntimeKeyConsentedAttributes] = ""
+		execResp.RuntimeData[common.RuntimeKeyConsentedPermissions] = ""
+		execResp.Status = providers.ExecComplete
+		return execResp, nil
+	}
+
 	// Check if the consent prompt has timed out
 	if expiresAtStr, ok := ctx.RuntimeData[common.RuntimeKeyStepTimeout]; ok && expiresAtStr != "" {
 		if expiresAt, err := strconv.ParseInt(expiresAtStr, 10, 64); err == nil {

--- a/backend/internal/flow/executor/consent_executor_test.go
+++ b/backend/internal/flow/executor/consent_executor_test.go
@@ -513,6 +513,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_NoInputs_EmptyTimeout() {
 
 func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_AllApproved_Success() {
 	decisions := providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{
 				PurposeName: "app:app-123:attrs",
@@ -569,6 +570,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_AllApproved_Success
 func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_HTMLEscapedJSON() {
 	// Simulate the HTML-escaped JSON that SanitizeStringMap would produce
 	decisions := providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "attributes:test-app", Approved: true},
 		},
@@ -659,6 +661,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_InvalidJSON() {
 
 func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_ConsentTimeout_Expired() {
 	decisions := providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "attributes:test-app", Approved: true},
 		},
@@ -686,8 +689,119 @@ func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_ConsentTimeout_Expi
 	assert.Equal(suite.T(), ErrConsentPromptTimedOut.Code, resp.Error.Code)
 }
 
+func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_TimeoutReason_CompletesWithoutRecording() {
+	decisions := providers.ConsentDecisions{
+		Approved: false,
+		Reason:   providers.ConsentDecisionReasonTimeout,
+		Purposes: []providers.PurposeDecision{
+			{PurposeName: "attributes:test-app", Approved: false},
+		},
+	}
+	decisionsJSON, _ := json.Marshal(decisions)
+
+	ctx := buildConsentNodeContext()
+	ctx.UserInputs[userInputConsentDecisions] = string(decisionsJSON)
+
+	// The auto submission is expected to arrive after the deadline, so the expiry must be skipped
+	pastExpiry := strconv.FormatInt(time.Now().Add(-1*time.Minute).UnixMilli(), 10)
+	ctx.RuntimeData[common.RuntimeKeyStepTimeout] = pastExpiry
+	suite.setupDefaultAuthnProviderMocks()
+
+	suite.executor.Executor.(*coremock.ExecutorInterfaceMock).
+		On("ValidatePrerequisites", ctx, mock.AnythingOfType("*providers.ExecutorResponse"), mock.Anything).Return(true)
+	suite.executor.Executor.(*coremock.ExecutorInterfaceMock).
+		On("HasRequiredInputs", ctx, mock.AnythingOfType("*providers.ExecutorResponse")).Return(true)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), providers.ExecComplete, resp.Status)
+	assert.Nil(suite.T(), resp.Error)
+
+	// Nothing is consented, and both keys must be present so auth assert knows consent ran
+	consentedAttrs, hasAttrs := resp.RuntimeData[common.RuntimeKeyConsentedAttributes]
+	assert.True(suite.T(), hasAttrs)
+	assert.Empty(suite.T(), consentedAttrs)
+	consentedPerms, hasPerms := resp.RuntimeData[common.RuntimeKeyConsentedPermissions]
+	assert.True(suite.T(), hasPerms)
+	assert.Empty(suite.T(), consentedPerms)
+
+	// A timeout is not a decision, so no consent record is created
+	assert.Empty(suite.T(), resp.RuntimeData[common.RuntimeKeyConsentID])
+	suite.mockConsentEnforcer.AssertNotCalled(suite.T(), "RecordConsent", mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_TimeoutReason_WithoutConfiguredTimeout() {
+	decisions := providers.ConsentDecisions{
+		Reason:   providers.ConsentDecisionReasonTimeout,
+		Purposes: []providers.PurposeDecision{{PurposeName: "attributes:test-app"}},
+	}
+	decisionsJSON, _ := json.Marshal(decisions)
+
+	ctx := buildConsentNodeContext()
+	ctx.UserInputs[userInputConsentDecisions] = string(decisionsJSON)
+	suite.setupDefaultAuthnProviderMocks()
+
+	suite.executor.Executor.(*coremock.ExecutorInterfaceMock).
+		On("ValidatePrerequisites", ctx, mock.AnythingOfType("*providers.ExecutorResponse"), mock.Anything).Return(true)
+	suite.executor.Executor.(*coremock.ExecutorInterfaceMock).
+		On("HasRequiredInputs", ctx, mock.AnythingOfType("*providers.ExecutorResponse")).Return(true)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecComplete, resp.Status)
+	suite.mockConsentEnforcer.AssertNotCalled(suite.T(), "RecordConsent", mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_UserDeniedReason_IsRecorded() {
+	decisions := providers.ConsentDecisions{
+		Approved: false,
+		Reason:   providers.ConsentDecisionReasonUserDenied,
+		Purposes: []providers.PurposeDecision{
+			{PurposeName: "attributes:test-app", Approved: false},
+		},
+	}
+	decisionsJSON, _ := json.Marshal(decisions)
+
+	ctx := buildConsentNodeContext()
+	ctx.UserInputs[userInputConsentDecisions] = string(decisionsJSON)
+
+	futureExpiry := strconv.FormatInt(time.Now().Add(5*time.Minute).UnixMilli(), 10)
+	ctx.RuntimeData[common.RuntimeKeyStepTimeout] = futureExpiry
+	suite.setupDefaultAuthnProviderMocks()
+
+	suite.executor.Executor.(*coremock.ExecutorInterfaceMock).
+		On("ValidatePrerequisites", ctx, mock.AnythingOfType("*providers.ExecutorResponse"), mock.Anything).Return(true)
+	suite.executor.Executor.(*coremock.ExecutorInterfaceMock).
+		On("HasRequiredInputs", ctx, mock.AnythingOfType("*providers.ExecutorResponse")).Return(true)
+
+	consentResult := &providers.Consent{
+		ID:       "consent-004",
+		Purposes: []providers.ConsentPurposeItem{},
+	}
+
+	suite.mockConsentEnforcer.On("RecordConsent", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(consentResult, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecComplete, resp.Status)
+
+	// Unlike a timeout, an explicit denial is a user decision and must be persisted
+	assert.Equal(suite.T(), "consent-004", resp.RuntimeData[common.RuntimeKeyConsentID])
+	suite.mockConsentEnforcer.AssertCalled(suite.T(), "RecordConsent", mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
 func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_ConsentTimeout_NotExpired() {
 	decisions := providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "attributes:test-app", Approved: true},
 		},
@@ -724,6 +838,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_ConsentTimeout_NotE
 
 func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_EssentialDenied() {
 	decisions := providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{
 				PurposeName: "attributes:test-app",
@@ -760,6 +875,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_EssentialDenied() {
 
 func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_RecordConsent_ClientError() {
 	decisions := providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "attributes:test-app", Approved: true},
 		},
@@ -794,6 +910,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_RecordConsent_Clien
 
 func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_RecordConsent_ServerError() {
 	decisions := providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "attributes:test-app", Approved: true},
 		},
@@ -824,6 +941,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_RecordConsent_Serve
 
 func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_NilLoginConsentConfig() {
 	decisions := providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "attributes:test-app", Approved: true},
 		},
@@ -859,6 +977,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_NilLoginConsentConf
 func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_PartialElementApproval() {
 	// Test where a purpose is approved but some elements are not approved
 	decisions := providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{
 				PurposeName: "attributes:app-123",
@@ -911,6 +1030,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_PartialElementAppro
 
 func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_AttributeAndPermissionPurposes_AllApproved() {
 	decisions := providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "attributes:app-123", Approved: true},
 			{PurposeName: "permissions:app-123", Approved: true},
@@ -967,6 +1087,7 @@ func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_AttributeAndPermiss
 
 func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_NoConsentedElements() {
 	decisions := providers.ConsentDecisions{
+		Approved: true,
 		Purposes: []providers.PurposeDecision{
 			{PurposeName: "attributes:test-app", Approved: true},
 		},

--- a/backend/pkg/thunderidengine/providers/constants.go
+++ b/backend/pkg/thunderidengine/providers/constants.go
@@ -326,6 +326,17 @@ const (
 	ConsentTypeAuthentication ConsentType = "AUTHENTICATION"
 )
 
+// ConsentDecisionReason defines the possible reasons a consent decision was submitted.
+type ConsentDecisionReason string
+
+const (
+	// ConsentDecisionReasonTimeout marks decisions submitted because the consent prompt expired
+	// rather than because the user chose anything.
+	ConsentDecisionReasonTimeout ConsentDecisionReason = "timeout"
+	// ConsentDecisionReasonUserDenied marks decisions submitted because the user denied the prompt.
+	ConsentDecisionReasonUserDenied ConsentDecisionReason = "user_denied"
+)
+
 // Namespace represents the consent namespace to scope consent elements and purposes.
 type Namespace string
 

--- a/backend/pkg/thunderidengine/providers/model.go
+++ b/backend/pkg/thunderidengine/providers/model.go
@@ -863,7 +863,15 @@ type PromptElement struct {
 }
 
 // ConsentDecisions holds the user's consent decisions.
+//
+// Approval is hierarchical: ConsentDecisions, PurposeDecision and ElementDecision each carry their
+// own Approved flag, and a denial at any level denies everything below it. Approval does not flow
+// the other way, so an approved parent still honors a denied child.
 type ConsentDecisions struct {
+	// Approved indicates whether the user approved the consent as a whole
+	Approved bool `json:"approved"`
+	// Reason optionally records why the decision was made, e.g. the prompt timed out
+	Reason ConsentDecisionReason `json:"reason,omitempty"`
 	// Purposes contains the per-purpose element approval decisions
 	Purposes []PurposeDecision `json:"purposes"`
 }

--- a/docs/content/guides/consent.mdx
+++ b/docs/content/guides/consent.mdx
@@ -52,7 +52,9 @@ To assemble the consent step manually, add and connect the individual nodes inst
 
 ### Configure optional timeout for the user input
 
-By default, the consent flow will wait indefinitely for the user to provide input. However, you can configure an optional timeout to automatically deny consent if the user does not respond within a specified time frame.
+By default, the consent flow will wait indefinitely for the user to provide input. However, you can configure an optional timeout to end the prompt if the user does not respond within a specified time frame.
+
+When the timeout expires, the prompt is submitted automatically as a denial. No consent decision is recorded, and the login completes without granting any of the requested attributes or permissions. This is not the same as denying an essential attribute, which terminates the login.
 
 To set a timeout for user input in the consent flow:
 

--- a/frontend/apps/console/src/features/flows/data/templates.json
+++ b/frontend/apps/console/src/features/flows/data/templates.json
@@ -5072,6 +5072,12 @@
                 "variant": "BODY_1"
               },
               {
+                "id": "consent_timer",
+                "category": "DISPLAY",
+                "type": "TIMER",
+                "label": "This request expires in {time}. You will then be returned to the application."
+              },
+              {
                 "type": "BLOCK",
                 "id": "consent_block",
                 "components": [

--- a/frontend/apps/console/src/features/flows/data/widgets.json
+++ b/frontend/apps/console/src/features/flows/data/widgets.json
@@ -2218,6 +2218,12 @@
                 },
                 {
                   "id": "{{ID}}",
+                  "category": "DISPLAY",
+                  "type": "TIMER",
+                  "label": "This request expires in {time}. You will then be returned to the application."
+                },
+                {
+                  "id": "{{ID}}",
                   "category": "BLOCK",
                   "type": "BLOCK",
                   "components": [

--- a/frontend/apps/gate/src/components/SignIn/SignInBox.tsx
+++ b/frontend/apps/gate/src/components/SignIn/SignInBox.tsx
@@ -148,7 +148,11 @@ export default function SignInBox(): JSX.Element {
             </Box>
           ) : (
             <>
-              {error && (
+              {/* Held back while a submission is in flight. An expired consent prompt auto-submits, and
+                  the SDK raises its expiry error against the request already on the wire, which would
+                  otherwise flash an error the user cannot act on. Errors worth showing outlive the
+                  request, since the flow clears them as each submission starts. */}
+              {error && !isLoading && (
                 <Alert severity="error" sx={{mb: 2}}>
                   {error.message ??
                     t(

--- a/frontend/apps/gate/src/components/SignIn/__tests__/SignInBox.test.tsx
+++ b/frontend/apps/gate/src/components/SignIn/__tests__/SignInBox.test.tsx
@@ -179,6 +179,20 @@ describe('SignInBox', () => {
     expect(screen.getByText('Invalid credentials')).toBeInTheDocument();
   });
 
+  // An expired consent prompt auto-submits, and the expiry error is raised against that in-flight
+  // request. Rendering it would flash an error over a submission that goes on to succeed.
+  it('holds back the error alert while a submission is in flight', () => {
+    mockSignInRenderProps = createMockSignInRenderProps({
+      components: [{id: 'text-1', type: 'TEXT', label: 'Consent', variant: 'H1'}],
+      error: {message: 'Time allowed to complete the step has expired.'},
+      isLoading: true,
+    });
+    render(<SignInBox />);
+
+    expect(screen.queryByText('Time allowed to complete the step has expired.')).not.toBeInTheDocument();
+    expect(screen.getByText('Consent')).toBeInTheDocument();
+  });
+
   it('renders TEXT component as heading', () => {
     mockSignInRenderProps = createMockSignInRenderProps({
       components: [

--- a/frontend/packages/design/src/components/flow/adapters/TimerAdapter.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/TimerAdapter.tsx
@@ -4,7 +4,7 @@
 import {FlowTimer, type FlowTimerRenderProps} from '@thunderid/react';
 import {cn} from '@thunderid/utils';
 import {Alert, Typography} from '@wso2/oxygen-ui';
-import type {JSX} from 'react';
+import {useState, type JSX} from 'react';
 
 /**
  * Props for the TimerAdapter component.
@@ -26,8 +26,17 @@ export default function TimerAdapter({
   expiresIn,
   textTemplate = 'Time remaining: {time}',
 }: TimerAdapterProps): JSX.Element {
+  // The caller derives expiresIn from the clock on every render, so it collapses to zero once the
+  // deadline passes and FlowTimer stops rendering. Hold the last active duration to keep the expired
+  // state on screen while the step it belongs to is still being submitted. A new duration replaces
+  // it, so a later step still gets its own countdown.
+  const [activeExpiresIn, setActiveExpiresIn] = useState<number>(expiresIn);
+  if (expiresIn > 0 && expiresIn !== activeExpiresIn) {
+    setActiveExpiresIn(expiresIn);
+  }
+
   return (
-    <FlowTimer expiresIn={expiresIn}>
+    <FlowTimer expiresIn={activeExpiresIn}>
       {({isExpired, formattedTime}: FlowTimerRenderProps) =>
         isExpired ? (
           <Alert className={cn('Flow--timer', 'Alert--root')} severity="warning" sx={{mt: 1}}>

--- a/frontend/packages/design/src/components/flow/adapters/__tests__/TimerAdapter.test.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/__tests__/TimerAdapter.test.tsx
@@ -1,0 +1,47 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {act, screen} from '@testing-library/react';
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import renderWithProviders from '../../../../test/renderWithProviders';
+import TimerAdapter from '../TimerAdapter';
+
+describe('TimerAdapter', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders the remaining time into the template', () => {
+    renderWithProviders(<TimerAdapter expiresIn={90} textTemplate="This request expires in {time}." />);
+    expect(screen.getByText('This request expires in 1:30.')).toBeTruthy();
+  });
+
+  it('renders nothing when no timeout is configured', () => {
+    const {container} = renderWithProviders(<TimerAdapter expiresIn={0} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  // The caller recomputes expiresIn from the clock on every render, so it arrives as zero once the
+  // deadline passes. The expired state has to survive that, because the step it belongs to is still
+  // being submitted at that point.
+  it('keeps the expired state on screen after expiresIn collapses to zero', () => {
+    vi.useFakeTimers();
+    const {rerender} = renderWithProviders(<TimerAdapter expiresIn={1} textTemplate="Expires in {time}." />);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.getByText('Timed out')).toBeTruthy();
+
+    rerender(<TimerAdapter expiresIn={0} textTemplate="Expires in {time}." />);
+    expect(screen.getByText('Timed out')).toBeTruthy();
+  });
+
+  it('starts a fresh countdown when a later step supplies a new duration', () => {
+    const {rerender} = renderWithProviders(<TimerAdapter expiresIn={30} textTemplate="Expires in {time}." />);
+    expect(screen.getByText('Expires in 0:30.')).toBeTruthy();
+
+    rerender(<TimerAdapter expiresIn={120} textTemplate="Expires in {time}." />);
+    expect(screen.getByText('Expires in 2:00.')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
### Purpose

Fixes #4600.

A consent prompt with a configured timeout had no terminal behaviour. When it expired the user was
left on a screen whose actions no longer led anywhere: the flow could neither proceed nor end, and
the only way out was to abandon the browser tab.

This makes an expired prompt resolve. The SDK auto-submits on expiry carrying a `timeout` reason,
and the server completes the step without recording anything. Nothing is consented, so the issued
assertion carries no attributes and no permissions.

It also introduces a top level `approved` flag on consent decisions, so a submission can express
"none of this" without relying on every leaf being individually false, and adds a countdown to the
consent screen so the prompt no longer expires without warning.

Requires https://github.com/thunder-id/javascript-sdks/pull/57, released as
`@thunderid/react@0.12.0`. The catalog bump ships in the same commit, deliberately: see the
breaking changes section.

---
### Approach

A timeout is not a decision, so nothing is recorded. The submission carries
reason: "timeout", and the executor short-circ Both
consented_attributes and consented_permissions are still set, to empty, because auth assert
branches on their presence to know the consentould fall through to the
full authorized set and grant everything.

The expiry check is skipped for that reason only. An auto-submission is expected to arrive
after the deadline, so validating it against tt by construction. The
submission is inert regardless: it persists nothing and consents nothing.

Denials are pushed down once, at the edge. applyDecisionHierarchy runs in RecordConsent
immediately after missing purposes are filled l check and the approval
mapping keep reading leaf values and needed no changes. The alternative, teaching every consumer to
walk back up the tree, would have left the rulft apart.

The step completes rather than fails. A timed ssful flow with an empty
assertion, not a flow error. This is a deliberate product decision and the main thing worth a second
opinion: on an application whose consent elemeuser lands signed in with a
token that cannot call anything. The alternative, failing the step, was considered and rejected.

The timer is inert by default. It renders nothing until a timeout is configured, and the shipped
widget still defaults to "timeout": "0", so noearance.

Related Issues

- Fixes #4600

Related PRs

- https://github.com/thunder-id/javascript-sdkd before this merges)

Checklist

- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if th
  - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are
  - [x] Unit Tests
  - [ ] Integration Tests
- [x] Breaking changes. (Fill if applicable)
  - [ ] Breaking changes section filled.
  - [ ] breaking change label added.

Security checks

- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines
- [x] Confirmed that this PR doesn't commit an usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consent prompts now display a countdown and explain that expiration returns users to the application.
  * Consent decisions support clear approval or denial outcomes, including timeout and user-denied reasons.
* **Bug Fixes**
  * Denials now correctly apply through related purposes and elements, while approvals remain unchanged.
  * Timed-out submissions complete without granting permissions or recording consent.
  * Expired consent errors no longer appear while sign-in submission is still processing.
* **Documentation**
  * Clarified consent timeout behavior and how it differs from denying essential attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->