### PR TITLE
Allow translation writes in composite and mutable store modes

### DIFF
--- a/backend/internal/system/i18n/mgt/config.go
+++ b/backend/internal/system/i18n/mgt/config.go
@@ -35,3 +35,10 @@ func getI18nStoreMode(translationConfig config.TranslationConfig) serverconst.St
 
 	return serverconst.StoreModeMutable
 }
+
+// isDeclarativeModeEnabled reports whether translations run in pure declarative
+// (immutable) mode, where all write operations must be rejected. Composite and
+// mutable modes allow database-backed writes.
+func isDeclarativeModeEnabled() bool {
+	return getI18nStoreMode(config.GetServerRuntime().Config.Translation) == serverconst.StoreModeDeclarative
+}

--- a/backend/internal/system/i18n/mgt/service.go
+++ b/backend/internal/system/i18n/mgt/service.go
@@ -133,8 +133,8 @@ func (s *i18nService) ResolveTranslationsForKey(ctx context.Context,
 func (s *i18nService) SetTranslationOverrideForKey(ctx context.Context,
 	language string, namespace string, key string, value string) (
 	*TranslationResponse, *tidcommon.ServiceError) {
-	if err := declarativeresource.CheckDeclarativeUpdate(); err != nil {
-		return nil, err
+	if isDeclarativeModeEnabled() {
+		return nil, &declarativeresource.ErrorDeclarativeResourceUpdateOperation
 	}
 	if err := validate(language, namespace, key); err != nil {
 		return nil, err
@@ -169,8 +169,8 @@ func (s *i18nService) SetTranslationOverrideForKey(ctx context.Context,
 // entries is map[key]map[language]value.
 func (s *i18nService) SetTranslationOverridesForNamespace(
 	ctx context.Context, namespace string, entries map[string]map[string]string) *tidcommon.ServiceError {
-	if err := declarativeresource.CheckDeclarativeUpdate(); err != nil {
-		return err
+	if isDeclarativeModeEnabled() {
+		return &declarativeresource.ErrorDeclarativeResourceUpdateOperation
 	}
 	if !ValidateNamespace(namespace) {
 		return &ErrorInvalidNamespace
@@ -211,8 +211,8 @@ func (s *i18nService) SetTranslationOverridesForNamespace(
 // ClearTranslationOverrideForKey removes the custom override for a single translation.
 func (s *i18nService) ClearTranslationOverrideForKey(ctx context.Context,
 	language string, namespace string, key string) *tidcommon.ServiceError {
-	if err := declarativeresource.CheckDeclarativeDelete(); err != nil {
-		return err
+	if isDeclarativeModeEnabled() {
+		return &declarativeresource.ErrorDeclarativeResourceDeleteOperation
 	}
 	if err := validate(language, namespace, key); err != nil {
 		return err
@@ -306,8 +306,8 @@ func (s *i18nService) ResolveTranslations(ctx context.Context,
 func (s *i18nService) SetTranslationOverrides(ctx context.Context,
 	language string, translations map[string]map[string]string) (
 	*providers.LanguageTranslationsResponse, *tidcommon.ServiceError) {
-	if err := declarativeresource.CheckDeclarativeUpdate(); err != nil {
-		return nil, err
+	if isDeclarativeModeEnabled() {
+		return nil, &declarativeresource.ErrorDeclarativeResourceUpdateOperation
 	}
 	if language == "" {
 		return nil, &ErrorMissingLanguage
@@ -361,8 +361,8 @@ func (s *i18nService) SetTranslationOverrides(ctx context.Context,
 
 // ClearTranslationOverrides removes all custom overrides for a language.
 func (s *i18nService) ClearTranslationOverrides(ctx context.Context, language string) *tidcommon.ServiceError {
-	if err := declarativeresource.CheckDeclarativeDelete(); err != nil {
-		return err
+	if isDeclarativeModeEnabled() {
+		return &declarativeresource.ErrorDeclarativeResourceDeleteOperation
 	}
 	if language == "" {
 		return &ErrorMissingLanguage

--- a/backend/internal/system/i18n/mgt/service_test.go
+++ b/backend/internal/system/i18n/mgt/service_test.go
@@ -290,6 +290,26 @@ func (suite *I18nMgtServiceTestSuite) TestSetTranslationOverrideForKey_Declarati
 	suite.Equal(declarativeresource.ErrorDeclarativeResourceUpdateOperation.Code, err.Code)
 }
 
+func (suite *I18nMgtServiceTestSuite) TestSetTranslationOverrideForKey_CompositeAllowsWrite() {
+	// Global declarative flag is on, but the translation store is composite, so
+	// database-backed overrides must still be allowed.
+	config.GetServerRuntime().Config.DeclarativeResources.Enabled = true
+	config.GetServerRuntime().Config.Translation.Store = "composite"
+	defer func() {
+		config.GetServerRuntime().Config.DeclarativeResources.Enabled = false
+		config.GetServerRuntime().Config.Translation.Store = ""
+	}()
+
+	suite.mockStore.On("UpsertTranslation", mock.Anything).Return(nil)
+
+	result, err := suite.service.SetTranslationOverrideForKey(
+		context.Background(), "en-US", "common", "welcome", "Hello")
+
+	suite.Nil(err)
+	suite.NotNil(result)
+	suite.mockStore.AssertCalled(suite.T(), "UpsertTranslation", mock.Anything)
+}
+
 // ClearTranslationOverrideForKey Tests
 func (suite *I18nMgtServiceTestSuite) TestClearTranslationOverrideForKey_Success() {
 	suite.mockStore.On("DeleteTranslation", "en-US", "welcome", "common").Return(nil)
@@ -337,6 +357,24 @@ func (suite *I18nMgtServiceTestSuite) TestClearTranslationOverrideForKey_Declara
 
 	suite.NotNil(err)
 	suite.Equal(declarativeresource.ErrorDeclarativeResourceDeleteOperation.Code, err.Code)
+}
+
+func (suite *I18nMgtServiceTestSuite) TestClearTranslationOverrideForKey_CompositeAllowsDelete() {
+	// Global declarative flag is on, but the translation store is composite, so
+	// clearing database-backed overrides must still be allowed.
+	config.GetServerRuntime().Config.DeclarativeResources.Enabled = true
+	config.GetServerRuntime().Config.Translation.Store = "composite"
+	defer func() {
+		config.GetServerRuntime().Config.DeclarativeResources.Enabled = false
+		config.GetServerRuntime().Config.Translation.Store = ""
+	}()
+
+	suite.mockStore.On("DeleteTranslation", "en-US", "welcome", "common").Return(nil)
+
+	err := suite.service.ClearTranslationOverrideForKey(context.Background(), "en-US", "common", "welcome")
+
+	suite.Nil(err)
+	suite.mockStore.AssertCalled(suite.T(), "DeleteTranslation", "en-US", "welcome", "common")
 }
 
 // ResolveTranslations Tests


### PR DESCRIPTION
### Purpose
Fix translation write operations being incorrectly blocked when declarative resources are enabled.

The i18n write operations (`SetTranslationOverrideForKey`, `SetTranslationOverridesForNamespace`, `SetTranslationOverrides`, `ClearTranslationOverrideForKey`, `ClearTranslationOverrides`) gated on the global `DeclarativeResources.Enabled` flag via `CheckDeclarativeUpdate`/`CheckDeclarativeDelete`. As a result, every translation create, update, and delete was rejected whenever declarative resources were enabled, even when `Translation.Store` resolved to `composite` or `mutable` mode.

This broke `composite` mode, where database-backed overrides are expected to remain writable while file-based resources stay immutable. Users could never create or update a translation override.

### Approach
Gate the i18n write operations on the resolved i18n store mode instead of the global flag, mirroring the theme and layout services:

- Added `isDeclarativeModeEnabled()` in `i18n/mgt/config.go` that returns true only when the resolved store mode is `declarative`.
- Replaced the `declarativeresource.CheckDeclarative{Update,Delete}()` calls in the five write methods with this check (same `DCR-1002`/`DCR-1003` error codes, so pure declarative mode still blocks writes as before).

The change is safe because the composite store routes all upserts/deletes to the DB layer only and keeps file-based resources immutable.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [x] Tests provided.
    - [x] Unit Tests

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Translation overrides can now be added or removed when declarative resources are enabled alongside a composite translation store.
  * Prevented incorrect blocking of supported translation updates and deletions.
* **Tests**
  * Added coverage for successful translation override writes and deletions in composite store configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->