### PR TITLE
Fix CIBA Page rendering

### DIFF
--- a/backend/internal/system/template/service.go
+++ b/backend/internal/system/template/service.go
@@ -6,6 +6,7 @@ package template
 import (
 	"context"
 	"errors"
+	"html"
 	"regexp"
 
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
@@ -65,7 +66,9 @@ func (s *templateService) Render(
 		return nil, svcErr
 	}
 
-	replacePlaceholders := func(s string) string {
+	isHTML := tmpl.ContentType == "text/html"
+
+	replacePlaceholders := func(s string, escapeHTML bool) string {
 		return ctxPlaceholderRegex.ReplaceAllStringFunc(s, func(match string) string {
 			// Extract the key from {{ctx(key)}}
 			submatches := ctxPlaceholderRegex.FindStringSubmatch(match)
@@ -74,6 +77,9 @@ func (s *templateService) Render(
 			}
 			key := submatches[1]
 			if val, ok := data[key]; ok {
+				if escapeHTML {
+					return html.EscapeString(val)
+				}
 				return val
 			}
 			return match
@@ -81,9 +87,10 @@ func (s *templateService) Render(
 	}
 
 	rendered := &RenderedTemplate{
-		Subject: replacePlaceholders(tmpl.Subject),
-		Body:    replacePlaceholders(tmpl.Body),
-		IsHTML:  tmpl.ContentType == "text/html",
+
+		Subject: replacePlaceholders(tmpl.Subject, false),
+		Body:    replacePlaceholders(tmpl.Body, isHTML),
+		IsHTML:  isHTML,
 	}
 
 	s.logger.Debug(ctx, "Template rendered successfully",

--- a/backend/internal/system/template/service_test.go
+++ b/backend/internal/system/template/service_test.go
@@ -92,6 +92,79 @@ func (suite *TemplateServiceTestSuite) TestRender_UnknownPlaceholder() {
 	suite.Equal("Unknown: {{ctx(unknownKey)}}", res.Body)
 }
 
+func (suite *TemplateServiceTestSuite) TestRender_EscapesHTMLInBody() {
+	dto := &TemplateDTO{
+		ID:          "1",
+		Scenario:    ScenarioCIBANotification,
+		Subject:     "Authentication Request from {{ctx(appName)}}",
+		ContentType: "text/html",
+		Body:        "<p>{{ctx(bindingMessage)}}</p>",
+	}
+	suite.mockStore.On("GetTemplateByScenario", mock.Anything, ScenarioCIBANotification, TemplateTypeEmail).
+		Return(dto, nil)
+
+	res, err := suite.service.Render(context.Background(), ScenarioCIBANotification, TemplateTypeEmail,
+		TemplateData{
+			"appName":        "Acme",
+			"bindingMessage": `<img src=x onerror=alert(1)>`,
+		})
+	suite.Nil(err)
+	suite.Equal("<p>&lt;img src=x onerror=alert(1)&gt;</p>", res.Body)
+}
+
+func (suite *TemplateServiceTestSuite) TestRender_DoesNotEscapeSubject() {
+	dto := &TemplateDTO{
+		ID:          "1",
+		Scenario:    ScenarioCIBANotification,
+		Subject:     "Request from {{ctx(appName)}}",
+		ContentType: "text/html",
+		Body:        "<p>body</p>",
+	}
+	suite.mockStore.On("GetTemplateByScenario", mock.Anything, ScenarioCIBANotification, TemplateTypeEmail).
+		Return(dto, nil)
+
+	res, err := suite.service.Render(context.Background(), ScenarioCIBANotification, TemplateTypeEmail,
+		TemplateData{"appName": "AT&T"})
+	suite.Nil(err)
+	suite.Equal("Request from AT&T", res.Subject)
+}
+
+func (suite *TemplateServiceTestSuite) TestRender_DoesNotEscapePlainTextBody() {
+	dto := &TemplateDTO{
+		ID:          "1",
+		Scenario:    ScenarioCIBANotification,
+		Subject:     "Code",
+		Type:        TemplateTypeSMS,
+		ContentType: "text/plain",
+		Body:        "{{ctx(appName)}}: approve?",
+	}
+	suite.mockStore.On("GetTemplateByScenario", mock.Anything, ScenarioCIBANotification, TemplateTypeSMS).
+		Return(dto, nil)
+
+	res, err := suite.service.Render(context.Background(), ScenarioCIBANotification, TemplateTypeSMS,
+		TemplateData{"appName": "AT&T"})
+	suite.Nil(err)
+	suite.Equal("AT&T: approve?", res.Body)
+	suite.False(res.IsHTML)
+}
+
+func (suite *TemplateServiceTestSuite) TestRender_PreservesURLQuerySeparators() {
+	dto := &TemplateDTO{
+		ID:          "1",
+		Scenario:    ScenarioMagicLink,
+		Subject:     "Sign in",
+		ContentType: "text/html",
+		Body:        `<a href="{{ctx(magicLink)}}">Sign in</a>`,
+	}
+	suite.mockStore.On("GetTemplateByScenario", mock.Anything, ScenarioMagicLink, TemplateTypeEmail).
+		Return(dto, nil)
+
+	res, err := suite.service.Render(context.Background(), ScenarioMagicLink, TemplateTypeEmail,
+		TemplateData{"magicLink": "https://localhost:9090/gate/magic?id=abc&token=xyz"})
+	suite.Nil(err)
+	suite.Equal(`<a href="https://localhost:9090/gate/magic?id=abc&amp;token=xyz">Sign in</a>`, res.Body)
+}
+
 func (suite *TemplateServiceTestSuite) TestRender_SubjectPlaceholderReplaced() {
 	dto := &TemplateDTO{
 		ID:          "1",


### PR DESCRIPTION
### Purpose

The template renderer substitutes `{{ctx(key)}}` placeholders as raw strings
regardless of the template's declared `contentType`. For templates with
`contentType: "text/html"`, this means a runtime value containing markup is
inserted as live HTML rather than as text, so a value like an application name
containing `&` or `<` produces malformed output instead of rendering literally.

This affects the six HTML email templates (CIBA notification, OTP, magic link,
password recovery, registration invite, user invite), all of which substitute
runtime values into the rendered body.

### Approach

`templateService.Render` now HTML-escapes substituted values when the template's
`ContentType` is `text/html`. The escaping is applied to the body only:

- **Body** is the HTML sink and is escaped.
- **Subject** is delivered as a MIME header rather than markup, so it continues
  to be substituted raw. This keeps names like `AT&T` rendering correctly in the
  subject line instead of showing entity codes.
- **`text/plain` templates** (the four SMS templates) are unaffected. The two
  non-email call sites, `sms_executor` and `authn/service`, both pass
  `TemplateTypeSMS`, and the store keys lookups on `scenario:type`, so they
  cannot resolve an HTML template.

URLs substituted into `href` attributes keep working: `&` between query
parameters becomes `&amp;`, which is correct HTML and is decoded back by mail
clients and browsers. Covered by a regression test.

### Tested Flows

- [x] CIBA
- [x] User Invite
- [x] Uni test added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HTML email bodies now safely escape placeholder values to prevent unintended markup.
  * Email subjects and plain-text message bodies retain their original formatting.
  * URLs in rendered HTML preserve query separators correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->