### PR TITLE
Add deny list of credentials accepted by creds auth service

### DIFF
--- a/api/authentication.yaml
+++ b/api/authentication.yaml
@@ -58,19 +58,34 @@ paths:
               schema:
                 $ref: '#/components/schemas/AuthenticationResponse'
         "400":
-          description: 'Bad Request: The request body is malformed or contains invalid data'
+          description: |
+            Bad Request: The request body is malformed or contains invalid data, or the credentials
+            contain a credential type reserved for internal authentication flows.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-              example:
-                code: "AUTH-CRED-1001"
-                message:
-                  key: "error.authnservice.empty_attributes_or_credentials"
-                  defaultValue: "Empty attributes or credentials"
-                description:
-                  key: "error.authnservice.empty_attributes_or_credentials_description"
-                  defaultValue: "The user attributes or credentials cannot be empty"
+              examples:
+                emptyAttributesOrCredentials:
+                  summary: Empty attributes or credentials
+                  value:
+                    code: "AUTH-CRED-1001"
+                    message:
+                      key: "error.authnservice.empty_attributes_or_credentials"
+                      defaultValue: "Empty attributes or credentials"
+                    description:
+                      key: "error.authnservice.empty_attributes_or_credentials_description"
+                      defaultValue: "The user attributes or credentials cannot be empty"
+                reservedCredentialType:
+                  summary: Reserved credential type
+                  value:
+                    code: "AUTH-CRED-1005"
+                    message:
+                      key: "error.authnservice.reserved_credential_type"
+                      defaultValue: "Reserved credential type"
+                    description:
+                      key: "error.authnservice.reserved_credential_type_description"
+                      defaultValue: "The provided credentials contain a credential type that is reserved for internal use"
         "401":
           description: 'Unauthorized: Authentication failed'
           content:
@@ -582,7 +597,10 @@ components:
             email: "jane.doe@example.com"
         credentials:
           type: object
-          description: Map of user credentials (e.g., password, pin)
+          description: |
+            Map of user credentials (e.g., password, pin). Credential types reserved for ThunderID's
+            internal authentication flows are rejected with `AUTH-CRED-1005`. Use the dedicated
+            endpoint or orchestration flow for those authentication methods.
           additionalProperties: true
           example:
             password: "SecurePassword123!"

--- a/backend/internal/agent/constants.go
+++ b/backend/internal/agent/constants.go
@@ -3,6 +3,10 @@
 
 package agent
 
+import (
+	authnprovidercm "github.com/thunder-id/thunderid/internal/authnprovider/common"
+)
+
 const (
 	agentBasePath = "/agents"
 )
@@ -13,7 +17,7 @@ const (
 	fieldDescription  = "description"
 	fieldOwner        = "owner"
 	fieldClientID     = "clientId"
-	fieldClientSecret = "clientSecret"
+	fieldClientSecret = authnprovidercm.CredentialTypeClientSecret
 )
 
 // propLogoURL is the inbound-client PROPERTIES key holding the agent logo.

--- a/backend/internal/application/constants.go
+++ b/backend/internal/application/constants.go
@@ -3,13 +3,17 @@
 
 package application
 
+import (
+	authnprovidercm "github.com/thunder-id/thunderid/internal/authnprovider/common"
+)
+
 // Field keys for entity system attributes.
 const (
 	fieldName         = "name"
 	fieldDescription  = "description"
 	fieldClientID     = "clientId"
-	fieldClientSecret = "clientSecret"
-	fieldFlowSecret   = "flowSecret"
+	fieldClientSecret = authnprovidercm.CredentialTypeClientSecret
+	fieldFlowSecret   = authnprovidercm.CredentialTypeFlowSecret
 )
 
 // Field keys for application config properties.

--- a/backend/internal/authn/error_constants.go
+++ b/backend/internal/authn/error_constants.go
@@ -62,6 +62,20 @@ var (
 			DefaultValue: "The provided token is invalid",
 		},
 	}
+	// ErrorReservedCredentialType is the error when the request carries a credential type that is
+	// reserved for ThunderID's internal authentication flows.
+	ErrorReservedCredentialType = tidcommon.ServiceError{
+		Type: tidcommon.ClientErrorType,
+		Code: "AUTH-CRED-1005",
+		Error: tidcommon.I18nMessage{
+			Key:          "error.authnservice.reserved_credential_type",
+			DefaultValue: "Reserved credential type",
+		},
+		ErrorDescription: tidcommon.I18nMessage{
+			Key:          "error.authnservice.reserved_credential_type_description",
+			DefaultValue: "The provided credentials contain a credential type that is reserved for internal use",
+		},
+	}
 	// ErrorOTPAuthenticationFailed is the error when the OTP authentication attempt fails.
 	ErrorOTPAuthenticationFailed = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,

--- a/backend/internal/authn/handler_test.go
+++ b/backend/internal/authn/handler_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/authn/common"
+	authnprovidercm "github.com/thunder-id/thunderid/internal/authnprovider/common"
 	"github.com/thunder-id/thunderid/internal/system/error/apierror"
 )
 
@@ -254,6 +255,20 @@ func (suite *AuthenticationHandlerTestSuite) TestHandleCredentialsAuthRequestSer
 			},
 			expectedStatusCode: http.StatusBadRequest,
 			expectedErrorCode:  "CUSTOM_ERROR",
+		},
+		{
+			name: "ReservedCredentialType",
+			authRequest: map[string]interface{}{
+				"identifiers": map[string]interface{}{
+					"username": "testuser",
+				},
+				"credentials": map[string]interface{}{
+					authnprovidercm.CredentialTypeProvisionedEntityID: "user123",
+				},
+			},
+			serviceError:       &ErrorReservedCredentialType,
+			expectedStatusCode: http.StatusBadRequest,
+			expectedErrorCode:  ErrorReservedCredentialType.Code,
 		},
 		{
 			name: "ServerError",

--- a/backend/internal/authn/passkey/service.go
+++ b/backend/internal/authn/passkey/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
 	"github.com/thunder-id/thunderid/internal/authn/common"
+	authnprovidercm "github.com/thunder-id/thunderid/internal/authnprovider/common"
 	"github.com/thunder-id/thunderid/internal/entity"
 	"github.com/thunder-id/thunderid/internal/system/log"
 )
@@ -25,7 +26,7 @@ const (
 	loggerComponentName = "PasskeyService"
 
 	// CredentialType is the credential type key that identifies passkey credentials in the provider chain.
-	CredentialType = "passkey"
+	CredentialType = authnprovidercm.CredentialTypePasskey
 )
 
 // PasskeyServiceInterface defines the interface for passkey authentication and registration operations.

--- a/backend/internal/authn/service.go
+++ b/backend/internal/authn/service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/authn/oidc"
 	"github.com/thunder-id/thunderid/internal/authn/otp"
 	"github.com/thunder-id/thunderid/internal/authn/passkey"
+	authnprovidercm "github.com/thunder-id/thunderid/internal/authnprovider/common"
 	authnprovidermgr "github.com/thunder-id/thunderid/internal/authnprovider/manager"
 	"github.com/thunder-id/thunderid/internal/idp"
 	"github.com/thunder-id/thunderid/internal/notification"
@@ -136,6 +137,14 @@ func (as *authenticationService) AuthenticateWithCredentials(ctx context.Context
 		return nil, &ErrorEmptyAttributesOrCredentials
 	}
 
+	// Credential types reserved for internal flows select an authentication mechanism by key name in
+	// the provider chain, so accepting them here would let a client pick any mechanism directly.
+	if reserved, found := authnprovidercm.FindReservedCredentialType(credentials); found {
+		logger.Debug(ctx, "Rejected reserved credential type on the credentials API",
+			log.String("credentialType", reserved))
+		return nil, &ErrorReservedCredentialType
+	}
+
 	newAuthUser, _, svcErr := as.authnProvider.AuthenticateUser(ctx, identifiers, credentials, nil, nil,
 		providers.AuthUser{})
 	if svcErr != nil {
@@ -233,7 +242,7 @@ func (as *authenticationService) VerifyOTP(ctx context.Context, sessionToken str
 	logger.Debug(ctx, "Verifying OTP for authentication")
 
 	credentials := map[string]interface{}{
-		"otp": map[string]interface{}{
+		authnprovidercm.CredentialTypeOTP: map[string]interface{}{
 			"sessionToken": sessionToken,
 			"otp":          otpCode,
 		},
@@ -368,7 +377,7 @@ func (as *authenticationService) FinishIDPAuthentication(ctx context.Context, re
 	}
 
 	credentials := map[string]interface{}{
-		"federated": &common.FederatedAuthCredential{
+		authnprovidercm.CredentialTypeFederated: &common.FederatedAuthCredential{
 			IDPID:   sessionData.IDPID,
 			IDPType: sessionData.IDPType,
 			AuthorizationData: common.AuthorizationData{

--- a/backend/internal/authn/service_test.go
+++ b/backend/internal/authn/service_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/authn/assert"
 	"github.com/thunder-id/thunderid/internal/authn/common"
 	"github.com/thunder-id/thunderid/internal/authn/passkey"
+	authnprovidercm "github.com/thunder-id/thunderid/internal/authnprovider/common"
 	authnprovidermgr "github.com/thunder-id/thunderid/internal/authnprovider/manager"
 	notifcommon "github.com/thunder-id/thunderid/internal/notification/common"
 	oauth2const "github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
@@ -269,6 +270,44 @@ func (suite *AuthenticationServiceTestSuite) TestAuthenticateWithCredentials() {
 			tc.validateAssertion(result)
 		})
 	}
+}
+
+// TestAuthenticateWithCredentialsRejectsReservedCredentialTypes asserts every reserved credential
+// type is rejected before the provider chain is reached. Iterating the exported slices covers any
+// type added to them later.
+func (suite *AuthenticationServiceTestSuite) TestAuthenticateWithCredentialsRejectsReservedCredentialTypes() {
+	identifiers := map[string]interface{}{
+		"username": "testuser",
+	}
+
+	reservedTypes := append([]string{},
+		append(authnprovidercm.InternalCredentialTypes, authnprovidercm.SystemCredentialTypes...)...)
+
+	for _, reserved := range reservedTypes {
+		suite.Run(reserved, func() {
+			result, err := suite.service.AuthenticateWithCredentials(context.Background(), identifiers,
+				map[string]interface{}{reserved: "attacker-supplied-value"}, false, "")
+
+			suite.Nil(result)
+			suite.NotNil(err)
+			suite.Equal(ErrorReservedCredentialType.Code, err.Code)
+			suite.Equal(tidcommon.ClientErrorType, err.Type)
+		})
+	}
+
+	suite.Run("alongside a valid password", func() {
+		result, err := suite.service.AuthenticateWithCredentials(context.Background(), identifiers,
+			map[string]interface{}{
+				"password": "testpass",
+				authnprovidercm.CredentialTypeProvisionedEntityID: testUserID,
+			}, false, "")
+
+		suite.Nil(result)
+		suite.NotNil(err)
+		suite.Equal(ErrorReservedCredentialType.Code, err.Code)
+	})
+
+	suite.mockAuthnProvider.AssertNotCalled(suite.T(), "AuthenticateUser")
 }
 
 func (suite *AuthenticationServiceTestSuite) TestAuthenticateWithCredentialsServiceError() {

--- a/backend/internal/authnprovider/common/constants.go
+++ b/backend/internal/authnprovider/common/constants.go
@@ -10,3 +10,61 @@ const (
 	// UserAttributeSub is the attribute key used to identify the subject (sub) claim in authentication results.
 	UserAttributeSub = "sub"
 )
+
+// Credential type keys used in the credentials map passed to the authentication providers.
+const (
+	// CredentialTypeProvisionedEntityID identifies an entity provisioned earlier in the same flow.
+	CredentialTypeProvisionedEntityID = "provisionedEntityID"
+	// CredentialTypePasskey identifies a passkey credential.
+	CredentialTypePasskey = "passkey"
+	// CredentialTypeOTP identifies a one time password.
+	CredentialTypeOTP = "otp"
+	// CredentialTypeFederated identifies an authorization code from an external identity provider.
+	CredentialTypeFederated = "federated"
+	// CredentialTypeMagicLink identifies a magic link token.
+	CredentialTypeMagicLink = "magiclink"
+	// CredentialTypeOpenID4VP identifies a verifiable presentation.
+	CredentialTypeOpenID4VP = "openid4vp"
+	// CredentialTypeClientSecret is the client secret of an application or agent.
+	CredentialTypeClientSecret = "clientSecret"
+	// CredentialTypeFlowSecret is the flow secret authenticating flow initiation.
+	CredentialTypeFlowSecret = "flowSecret"
+)
+
+// InternalCredentialTypes are the credential types providers dispatch on by key name. Every
+// dispatched type belongs here, otherwise an API client can select that authentication mechanism
+// directly and bypass the flow that owns it.
+var InternalCredentialTypes = []string{
+	CredentialTypeProvisionedEntityID,
+	CredentialTypePasskey,
+	CredentialTypeOTP,
+	CredentialTypeFederated,
+	CredentialTypeMagicLink,
+	CredentialTypeOpenID4VP,
+	// The provider manager dispatches on sub to disambiguate after a federated step.
+	UserAttributeSub,
+}
+
+// SystemCredentialTypes are machine credentials of an application or agent. The entity layer
+// verifies credentials by key name across the merged schema and system credentials, so these
+// authenticate the owning entity through any credential verification path.
+var SystemCredentialTypes = []string{
+	CredentialTypeClientSecret,
+	CredentialTypeFlowSecret,
+}
+
+// FindReservedCredentialType returns the first credential type reserved for internal use, and
+// whether one was found. Callers accepting a client supplied credentials map must reject on true.
+func FindReservedCredentialType(credentials map[string]interface{}) (string, bool) {
+	for _, reserved := range InternalCredentialTypes {
+		if _, ok := credentials[reserved]; ok {
+			return reserved, true
+		}
+	}
+	for _, reserved := range SystemCredentialTypes {
+		if _, ok := credentials[reserved]; ok {
+			return reserved, true
+		}
+	}
+	return "", false
+}

--- a/backend/internal/authnprovider/defaultprovider/default_authn_provider.go
+++ b/backend/internal/authnprovider/defaultprovider/default_authn_provider.go
@@ -58,7 +58,7 @@ func (p *defaultAuthnProvider) InitiateAuthentication(
 	metadata *providers.AuthnMetadata,
 ) (any, *tidcommon.ServiceError) {
 	switch credentialType {
-	case passkey.CredentialType:
+	case authnprovidercm.CredentialTypePasskey:
 		// Expect initData to be a PasskeyAuthenticationStartRequest struct
 		return p.initiateAuthenticationWithPasskey(ctx, initData)
 	default:
@@ -170,7 +170,7 @@ func (p *defaultAuthnProvider) InitiateEnrollment(
 	metadata *providers.AuthnMetadata) (
 	any, *tidcommon.ServiceError) {
 	switch credentialType {
-	case passkey.CredentialType:
+	case authnprovidercm.CredentialTypePasskey:
 		// Expect initData to be a PasskeyRegistrationStartRequest struct
 		return p.initiateEnrollmentWithPasskey(ctx, initData)
 	default:
@@ -241,7 +241,7 @@ func (p *defaultAuthnProvider) enrollWithCredential(
 	ctx context.Context,
 	credentials map[string]interface{},
 ) (*authncommon.AuthnResult, *tidcommon.ServiceError) {
-	if passkeyCredential, ok := credentials[passkey.CredentialType]; ok {
+	if passkeyCredential, ok := credentials[authnprovidercm.CredentialTypePasskey]; ok {
 		return p.enrollWithPasskey(ctx, passkeyCredential)
 	}
 	return nil, p.logAndReturnServerError(ctx, "Unsupported credential type for enrollment",
@@ -357,29 +357,32 @@ func (p *defaultAuthnProvider) resolveEntityFromToken(
 	return entityResult, nil
 }
 
+// authenticateWithCredential selects the authentication mechanism by credential type. Every
+// credential type dispatched here must also appear in authnprovidercm.InternalCredentialTypes,
+// otherwise the credentials authentication API would let a client select that mechanism directly.
 func (p *defaultAuthnProvider) authenticateWithCredential(
 	ctx context.Context,
 	identifiers, credentials map[string]interface{},
 ) (*authncommon.AuthnResult, *tidcommon.ServiceError) {
-	if provisioned, ok := credentials["provisionedEntityID"]; ok {
+	if provisioned, ok := credentials[authnprovidercm.CredentialTypeProvisionedEntityID]; ok {
 		return p.authenticateForProvisioning(provisioned)
 	}
-	if passkeyCredential, ok := credentials[passkey.CredentialType]; ok {
+	if passkeyCredential, ok := credentials[authnprovidercm.CredentialTypePasskey]; ok {
 		return p.authenticateWithPasskey(ctx, passkeyCredential)
 	}
-	if otpCredential, ok := credentials["otp"]; ok {
+	if otpCredential, ok := credentials[authnprovidercm.CredentialTypeOTP]; ok {
 		return p.authenticateWithOTP(ctx, otpCredential)
 	}
-	if fedCred, ok := credentials["federated"]; ok {
+	if fedCred, ok := credentials[authnprovidercm.CredentialTypeFederated]; ok {
 		return p.authenticateWithFederated(ctx, fedCred)
 	}
-	if mlCred, ok := credentials["magiclink"]; ok {
+	if mlCred, ok := credentials[authnprovidercm.CredentialTypeMagicLink]; ok {
 		return p.authenticateWithMagicLink(ctx, mlCred)
 	}
-	if vpCred, ok := credentials["openid4vp"]; ok {
+	if vpCred, ok := credentials[authnprovidercm.CredentialTypeOpenID4VP]; ok {
 		return p.authenticateWithOpenID4VP(ctx, vpCred)
 	}
-	if userID, ok := identifiers["userID"]; ok && userID != "" {
+	if userID, ok := identifiers[authnprovidercm.UserAttributeUserID]; ok && userID != "" {
 		return p.authenticateByUserID(ctx, userID, credentials)
 	}
 	return p.authenticateByIdentifiers(ctx, identifiers, credentials)

--- a/backend/internal/authnprovider/defaultprovider/default_authn_provider_test.go
+++ b/backend/internal/authnprovider/defaultprovider/default_authn_provider_test.go
@@ -7,6 +7,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"testing"
 
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
@@ -1475,4 +1478,88 @@ func (suite *DefaultAuthnProviderTestSuite) TestEnroll_UnsupportedCredential() {
 	suite.Nil(result)
 	suite.NotNil(err)
 	suite.Equal(tidcommon.ServerErrorType, err.Type)
+}
+
+// TestDispatchKeysAreInternalCredentialTypes keeps the credentials authentication API's reject list
+// in step with what this provider dispatches on. A key dispatched here but missing from
+// InternalCredentialTypes would be selectable by any API client. The dispatch is an if chain rather
+// than a table, so both sides are read from the source and compared by constant name.
+func (suite *DefaultAuthnProviderTestSuite) TestDispatchKeysAreInternalCredentialTypes() {
+	dispatched := suite.dispatchedCredentialConstants("default_authn_provider.go",
+		"authenticateWithCredential")
+	reserved := suite.listedCredentialConstants("../common/constants.go", "InternalCredentialTypes")
+
+	for _, name := range dispatched {
+		suite.Contains(reserved, name,
+			"authnprovidercm.%s is dispatched by the default provider but is not listed in "+
+				"InternalCredentialTypes, so the credentials authentication API would accept it", name)
+	}
+}
+
+// dispatchedCredentialConstants returns the authnprovidercm constant names used to index the
+// credentials map inside the named function.
+func (suite *DefaultAuthnProviderTestSuite) dispatchedCredentialConstants(
+	filename, funcName string) []string {
+	var fn *ast.FuncDecl
+	for _, decl := range suite.parseFile(filename).Decls {
+		if decl, ok := decl.(*ast.FuncDecl); ok && decl.Name.Name == funcName {
+			fn = decl
+			break
+		}
+	}
+	suite.Require().NotNil(fn, "function %s not found in %s", funcName, filename)
+
+	var names []string
+	ast.Inspect(fn, func(node ast.Node) bool {
+		index, ok := node.(*ast.IndexExpr)
+		if !ok {
+			return true
+		}
+		if operand, ok := index.X.(*ast.Ident); !ok || operand.Name != "credentials" {
+			return true
+		}
+		if key, ok := index.Index.(*ast.SelectorExpr); ok {
+			if pkg, ok := key.X.(*ast.Ident); ok && pkg.Name == "authnprovidercm" {
+				names = append(names, key.Sel.Name)
+			}
+		}
+		return true
+	})
+	suite.Require().NotEmpty(names, "no credential dispatch keys found in %s", funcName)
+	return names
+}
+
+// listedCredentialConstants returns the constant names listed in the named []string variable.
+func (suite *DefaultAuthnProviderTestSuite) listedCredentialConstants(
+	filename, varName string) []string {
+	var names []string
+	for _, decl := range suite.parseFile(filename).Decls {
+		decl, ok := decl.(*ast.GenDecl)
+		if !ok || decl.Tok != token.VAR {
+			continue
+		}
+		for _, spec := range decl.Specs {
+			spec, ok := spec.(*ast.ValueSpec)
+			if !ok || len(spec.Names) != 1 || spec.Names[0].Name != varName ||
+				len(spec.Values) != 1 {
+				continue
+			}
+			literal, ok := spec.Values[0].(*ast.CompositeLit)
+			suite.Require().True(ok, "%s is not a composite literal", varName)
+			for _, element := range literal.Elts {
+				if element, ok := element.(*ast.Ident); ok {
+					names = append(names, element.Name)
+				}
+			}
+		}
+	}
+	suite.Require().NotEmpty(names, "variable %s not found in %s", varName, filename)
+	return names
+}
+
+// parseFile parses a source file relative to this package's directory.
+func (suite *DefaultAuthnProviderTestSuite) parseFile(filename string) *ast.File {
+	file, err := parser.ParseFile(token.NewFileSet(), filename, nil, 0)
+	suite.Require().NoError(err, "failed to parse %s", filename)
+	return file
 }

--- a/backend/internal/authnprovider/manager/manager.go
+++ b/backend/internal/authnprovider/manager/manager.go
@@ -104,7 +104,7 @@ func (m *authnProviderManager) AuthenticateUser(ctx context.Context, identifiers
 		return authUser, nil, &ErrorAuthenticationFailed
 	}
 
-	if sub, ok := credentials["sub"]; ok {
+	if sub, ok := credentials[authnprovidercm.UserAttributeSub]; ok {
 		// Temporary handling of disambiguation after a federated authentication step.
 		// Only works with Thunder's default authn provider.
 		if subStr, ok := sub.(string); !ok || subStr == "" {

--- a/backend/internal/flow/executor/magic_link_executor.go
+++ b/backend/internal/flow/executor/magic_link_executor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
 	"github.com/thunder-id/thunderid/internal/authn/magiclink"
+	authnprovidercm "github.com/thunder-id/thunderid/internal/authnprovider/common"
 	authnprovidermgr "github.com/thunder-id/thunderid/internal/authnprovider/manager"
 	"github.com/thunder-id/thunderid/internal/entityprovider"
 	"github.com/thunder-id/thunderid/internal/flow/common"
@@ -315,7 +316,7 @@ func (m *magicLinkExecutor) executeVerify(ctx *providers.NodeContext) (*provider
 	}
 
 	creds := map[string]interface{}{
-		"magiclink": map[string]interface{}{
+		authnprovidercm.CredentialTypeMagicLink: map[string]interface{}{
 			"token":            token,
 			"subjectAttribute": subjectAttribute,
 		},

--- a/backend/internal/flow/executor/oauth_executor.go
+++ b/backend/internal/flow/executor/oauth_executor.go
@@ -14,6 +14,7 @@ import (
 
 	authncm "github.com/thunder-id/thunderid/internal/authn/common"
 	authnoauth "github.com/thunder-id/thunderid/internal/authn/oauth"
+	authnprovidercm "github.com/thunder-id/thunderid/internal/authnprovider/common"
 	"github.com/thunder-id/thunderid/internal/flow/common"
 	"github.com/thunder-id/thunderid/internal/flow/core"
 	"github.com/thunder-id/thunderid/internal/idp"
@@ -230,7 +231,7 @@ func (o *oAuthExecutor) ProcessAuthFlowResponse(ctx *providers.NodeContext,
 	}
 
 	credentials := map[string]interface{}{
-		"federated": &authncm.FederatedAuthCredential{
+		authnprovidercm.CredentialTypeFederated: &authncm.FederatedAuthCredential{
 			IDPID:   idpID,
 			IDPType: o.idpType,
 			AuthorizationData: authncm.AuthorizationData{

--- a/backend/internal/flow/executor/oidc_auth_executor.go
+++ b/backend/internal/flow/executor/oidc_auth_executor.go
@@ -13,6 +13,7 @@ import (
 	authncm "github.com/thunder-id/thunderid/internal/authn/common"
 	authnoauth "github.com/thunder-id/thunderid/internal/authn/oauth"
 	authnoidc "github.com/thunder-id/thunderid/internal/authn/oidc"
+	authnprovidercm "github.com/thunder-id/thunderid/internal/authnprovider/common"
 	"github.com/thunder-id/thunderid/internal/flow/common"
 	"github.com/thunder-id/thunderid/internal/flow/core"
 	"github.com/thunder-id/thunderid/internal/idp"
@@ -181,7 +182,7 @@ func (o *oidcAuthExecutor) ProcessAuthFlowResponse(ctx *providers.NodeContext,
 	}
 
 	credentials := map[string]interface{}{
-		"federated": &authncm.FederatedAuthCredential{
+		authnprovidercm.CredentialTypeFederated: &authncm.FederatedAuthCredential{
 			IDPID:   idpID,
 			IDPType: o.idpType,
 			AuthorizationData: authncm.AuthorizationData{

--- a/backend/internal/flow/executor/openid4vp_verifier.go
+++ b/backend/internal/flow/executor/openid4vp_verifier.go
@@ -6,6 +6,7 @@ package executor
 import (
 	authncommon "github.com/thunder-id/thunderid/internal/authn/common"
 	"github.com/thunder-id/thunderid/internal/authn/openid4vp"
+	authnprovidercm "github.com/thunder-id/thunderid/internal/authnprovider/common"
 	"github.com/thunder-id/thunderid/internal/flow/common"
 	"github.com/thunder-id/thunderid/internal/flow/core"
 	"github.com/thunder-id/thunderid/internal/system/log"
@@ -169,7 +170,7 @@ func (e *openid4vpVerifier) authenticate(
 		return
 	}
 	credentials := map[string]interface{}{
-		"openid4vp": &authncommon.OpenID4VPCredential{
+		authnprovidercm.CredentialTypeOpenID4VP: &authncommon.OpenID4VPCredential{
 			Subject: rs.Result.Subject,
 			Claims:  rs.Result.Claims,
 		},

--- a/backend/internal/flow/executor/otp_executor.go
+++ b/backend/internal/flow/executor/otp_executor.go
@@ -284,7 +284,7 @@ func (e *otpExecutor) getAuthenticatedUser(ctx *providers.NodeContext,
 	}
 
 	credentials := map[string]interface{}{
-		"otp": map[string]interface{}{
+		authnprovidercm.CredentialTypeOTP: map[string]interface{}{
 			"sessionToken": sessionToken,
 			"otp":          providedOTP,
 		},

--- a/backend/internal/flow/executor/provisioning_executor.go
+++ b/backend/internal/flow/executor/provisioning_executor.go
@@ -12,6 +12,7 @@ import (
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
+	authnprovidercm "github.com/thunder-id/thunderid/internal/authnprovider/common"
 	"github.com/thunder-id/thunderid/internal/entityprovider"
 	"github.com/thunder-id/thunderid/internal/entitytype"
 	"github.com/thunder-id/thunderid/internal/flow/common"
@@ -219,7 +220,7 @@ func (p *provisioningExecutor) Execute(ctx *providers.NodeContext) (*providers.E
 func (p *provisioningExecutor) authenticateProvisionedUser(ctx *providers.NodeContext, userID string,
 	execResp *providers.ExecutorResponse) {
 	credential := map[string]interface{}{
-		"provisionedEntityID": userID,
+		authnprovidercm.CredentialTypeProvisionedEntityID: userID,
 	}
 	authUser, authenticatedClaims, err := p.authnProvider.AuthenticateUser(ctx.Context, nil, credential,
 		nil, nil, execResp.AuthUser)

--- a/backend/internal/flow/flowexec/constants.go
+++ b/backend/internal/flow/flowexec/constants.go
@@ -3,6 +3,10 @@
 
 package flowexec
 
+import (
+	authnprovidercm "github.com/thunder-id/thunderid/internal/authnprovider/common"
+)
+
 const (
 	defaultAuthFlowExpiry           int64 = 3600  // 60 minutes in seconds
 	defaultRegistrationFlowExpiry   int64 = 3600  // 60 minutes in seconds
@@ -10,7 +14,7 @@ const (
 	defaultRecoveryFlowExpiry       int64 = 1800  // 30 minutes in seconds
 	defaultSignOutFlowExpiry        int64 = 1800  // 30 minutes in seconds
 
-	fieldFlowSecret = "flowSecret"
+	fieldFlowSecret = authnprovidercm.CredentialTypeFlowSecret
 
 	// applicationTypePropertyKey is the InboundClient.Properties key under which the application
 	// type is stored.

--- a/backend/internal/oauth/oauth2/clientauth/clientauth.go
+++ b/backend/internal/oauth/oauth2/clientauth/clientauth.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"strings"
 
+	authnprovidercm "github.com/thunder-id/thunderid/internal/authnprovider/common"
 	"github.com/thunder-id/thunderid/internal/cert"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
@@ -143,7 +144,7 @@ func authenticate(
 		providers.TokenEndpointAuthMethodClientSecretPost:
 		_, _, authnErr := authnProvider.AuthenticateUser(ctx,
 			map[string]interface{}{"clientId": clientID},
-			map[string]interface{}{"clientSecret": clientSecret},
+			map[string]interface{}{authnprovidercm.CredentialTypeClientSecret: clientSecret},
 			nil, nil, providers.AuthUser{})
 		if authnErr != nil {
 			logger.Debug(ctx, "Client secret authentication failed",

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -343,6 +343,8 @@ var defaultMessages = map[string]string{
 	"error.authnservice.passkey_authentication_failed_description": "The passkey authentication attempt failed",
 	"error.authnservice.passkey_enrollment_failed": "Enrollment failed",
 	"error.authnservice.passkey_enrollment_failed_description": "The passkey enrollment attempt failed",
+	"error.authnservice.reserved_credential_type": "Reserved credential type",
+	"error.authnservice.reserved_credential_type_description": "The provided credentials contain a credential type that is reserved for internal use",
 	"error.authnservice.sub_claim_not_found": "user subject not found",
 	"error.authnservice.sub_claim_not_found_description": "The 'sub' claim is not found in the ID token claims",
 	"error.authnservice.user_not_found": "User not found",

--- a/tests/integration/authn/credentials_auth_test.go
+++ b/tests/integration/authn/credentials_auth_test.go
@@ -1006,6 +1006,68 @@ func (suite *CredentialsAuthTestSuite) TestAuthenticateWithExistingAssertionEmpt
 	suite.Equal("AAL1", aal, "Single-factor authentication should result in AAL1")
 }
 
+// TestAuthenticateWithProvisionedEntityIDRejected verifies the authentication bypass is closed for a
+// real user ID. The provisionedEntityID credential type performs no verification at all, so before
+// the reject list this returned 200 with the user's identity and a signed assertion.
+func (suite *CredentialsAuthTestSuite) TestAuthenticateWithProvisionedEntityIDRejected() {
+	authRequest := map[string]interface{}{
+		"identifiers": map[string]interface{}{
+			"username": "credtest_user1",
+		},
+		"credentials": map[string]interface{}{
+			"provisionedEntityID": suite.users["username_password"],
+		},
+	}
+
+	response, statusCode, err := suite.sendAuthRequest(authRequest)
+	suite.Require().NoError(err, "Failed to send authenticate request")
+	suite.Equal(http.StatusBadRequest, statusCode, "Expected status 400 for a reserved credential type")
+	suite.Empty(response.ID, "Rejected request should not resolve a user")
+	suite.Empty(response.Assertion, "Rejected request should not mint an assertion")
+}
+
+// TestAuthenticateWithReservedCredentialTypesRejected verifies every reserved credential type is
+// rejected on the credentials API. The guard matches on key presence, so the values need not be
+// valid payloads. These names mirror InternalCredentialTypes and SystemCredentialTypes in the
+// backend's authnprovider/common package, which this module cannot import.
+func (suite *CredentialsAuthTestSuite) TestAuthenticateWithReservedCredentialTypesRejected() {
+	reservedTypes := []string{
+		"provisionedEntityID", "passkey", "otp", "federated", "magiclink", "openid4vp",
+		"sub", "clientSecret", "flowSecret",
+	}
+
+	for _, reserved := range reservedTypes {
+		suite.Run(reserved, func() {
+			suite.assertReservedCredentialTypeRejected(map[string]interface{}{
+				reserved: "attacker-supplied-value",
+			})
+		})
+	}
+
+	// The guard runs before authentication, so a reserved credential type cannot be smuggled in
+	// beside a valid one.
+	suite.Run("alongside a valid password", func() {
+		suite.assertReservedCredentialTypeRejected(map[string]interface{}{
+			"password":            "TestPassword123!",
+			"provisionedEntityID": suite.users["username_password"],
+		})
+	})
+}
+
+// assertReservedCredentialTypeRejected asserts the credentials API rejects the given credentials.
+func (suite *CredentialsAuthTestSuite) assertReservedCredentialTypeRejected(
+	credentials map[string]interface{}) {
+	errorResp, statusCode, err := suite.sendAuthRequestExpectingError(map[string]interface{}{
+		"identifiers": map[string]interface{}{
+			"username": "credtest_user1",
+		},
+		"credentials": credentials,
+	})
+	suite.Require().NoError(err, "Failed to send authenticate request")
+	suite.Equal(http.StatusBadRequest, statusCode, "Expected status 400 for a reserved credential type")
+	suite.Equal("AUTH-CRED-1005", errorResp.Code, "Expected error code AUTH-CRED-1005")
+}
+
 func (suite *CredentialsAuthTestSuite) sendAuthRequest(authRequest map[string]interface{}) (
 	*testutils.AuthenticationResponse, int, error) {
 	requestJSON, err := json.Marshal(authRequest)


### PR DESCRIPTION
### Purpose

This pull request introduces stricter handling of reserved credential types in the authentication API, refactors credential type constants to improve maintainability, and enhances test coverage for these changes.

### Approach

**Reserved credential type enforcement:**

* Added logic in `AuthenticateWithCredentials` to reject any credential type reserved for internal or system use, returning a new `AUTH-CRED-1005` error when encountered. This prevents clients from bypassing authentication flows. [[1]](diffhunk://#diff-071e2c441eeb89cbea7bd77f58e069d8d838ff0d3628479adb7fd936df2d4417R140-R147) [[2]](diffhunk://#diff-207cb174ab74c6916d257751946b2fcd14b1a84fd81ba74e19428c45522890e8R13-R70) [[3]](diffhunk://#diff-4f49337afcd5d7b894c443ff7c93e5f8c7f513064a1b670449b4fafff6cc1119R65-R78)
* Updated API documentation (`authentication.yaml`) to describe the new error and provide detailed examples for both empty credentials and reserved credential types. [[1]](diffhunk://#diff-ff064eb7fa83da8a9439430ee894d6e4925e8ef37ad8c71de4d1fcd2d96e32aeL61-R88) [[2]](diffhunk://#diff-ff064eb7fa83da8a9439430ee894d6e4925e8ef37ad8c71de4d1fcd2d96e32aeL585-R603)

**Credential type constant refactoring:**

* Centralized all credential type keys in `authnprovider/common/constants.go`, replacing string literals throughout the codebase with these constants for consistency and maintainability. [[1]](diffhunk://#diff-207cb174ab74c6916d257751946b2fcd14b1a84fd81ba74e19428c45522890e8R13-R70) [[2]](diffhunk://#diff-1ff823a2d8733f02eb70e3fa4f087a6415c3a2f5b9b797c4d9b7026b39086bb2R6-R16) F3cfa189L13R17, [[3]](diffhunk://#diff-da2c7956513c82df97a1f470c529d9e41d2ca4507a4903d99f54b3a19f2d1281R6-R9) [[4]](diffhunk://#diff-da2c7956513c82df97a1f470c529d9e41d2ca4507a4903d99f54b3a19f2d1281L16-R20) [[5]](diffhunk://#diff-531907e19c493cf9df2e91b807b7a43156929afd54f2d1afe336234d011503caR19) [[6]](diffhunk://#diff-531907e19c493cf9df2e91b807b7a43156929afd54f2d1afe336234d011503caL28-R29) [[7]](diffhunk://#diff-18bac25d3204f5716cfcca21709c5ca7a0c588810af01e722eea6767ec30ffe6L61-R61) [[8]](diffhunk://#diff-18bac25d3204f5716cfcca21709c5ca7a0c588810af01e722eea6767ec30ffe6L173-R173) [[9]](diffhunk://#diff-18bac25d3204f5716cfcca21709c5ca7a0c588810af01e722eea6767ec30ffe6L244-R244) [[10]](diffhunk://#diff-18bac25d3204f5716cfcca21709c5ca7a0c588810af01e722eea6767ec30ffe6R360-R385) [[11]](diffhunk://#diff-071e2c441eeb89cbea7bd77f58e069d8d838ff0d3628479adb7fd936df2d4417R28) [[12]](diffhunk://#diff-071e2c441eeb89cbea7bd77f58e069d8d838ff0d3628479adb7fd936df2d4417L236-R245) [[13]](diffhunk://#diff-071e2c441eeb89cbea7bd77f58e069d8d838ff0d3628479adb7fd936df2d4417L371-R380)

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Credential authentication now rejects credential types reserved for internal authentication flows.
  - Requests containing reserved credentials return a clear HTTP 400 response with error code `AUTH-CRED-1005`.
  - Reserved credentials are rejected even when combined with otherwise valid credentials, preventing unintended authentication or assertion issuance.

- **Documentation**
  - API documentation now distinguishes empty credentials from reserved credential-type errors and explains the appropriate authentication flow for reserved types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->