### PR TITLE
Allow declarative flows to be opened from the flow listing.

### DIFF
--- a/frontend/apps/console/src/features/flows/components/FlowsList.tsx
+++ b/frontend/apps/console/src/features/flows/components/FlowsList.tsx
@@ -43,7 +43,7 @@ export default function FlowsList(): JSX.Element {
     setSelectedFlow(null);
   };
 
-  const handleEditClick = useCallback(
+  const handleOpenClick = useCallback(
     (flow: BasicFlowDefinition): void => {
       (async (): Promise<void> => {
         await navigate(flowRoutes.flows.detail(flow.id));
@@ -106,8 +106,14 @@ export default function FlowsList(): JSX.Element {
           return (
             <ListingTable.RowActions>
               {params.row.isReadOnly ? (
-                <Tooltip title={t('common:status.readOnly', 'Read Only')}>
-                  <IconButton size="small" disableRipple sx={{cursor: 'default'}}>
+                <Tooltip title={t('common:actions.view', 'View')}>
+                  <IconButton
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleOpenClick(params.row);
+                    }}
+                  >
                     <Eye size={16} />
                   </IconButton>
                 </Tooltip>
@@ -118,7 +124,7 @@ export default function FlowsList(): JSX.Element {
                       size="small"
                       onClick={(e) => {
                         e.stopPropagation();
-                        handleEditClick(params.row);
+                        handleOpenClick(params.row);
                       }}
                     >
                       <Pencil size={16} />
@@ -143,7 +149,7 @@ export default function FlowsList(): JSX.Element {
         },
       },
     ],
-    [handleDeleteClick, handleEditClick, t],
+    [handleDeleteClick, handleOpenClick, t],
   );
 
   if (error) {
@@ -168,13 +174,8 @@ export default function FlowsList(): JSX.Element {
             rows={data?.flows ?? []}
             columns={columns}
             getRowId={(row): string => (row as BasicFlowDefinition).id}
-            getRowClassName={(params) =>
-              (params.row as BasicFlowDefinition).isReadOnly ? 'row-not-clickable' : 'row-clickable'
-            }
             onRowClick={(params) => {
-              if (!(params.row as BasicFlowDefinition).isReadOnly) {
-                handleEditClick(params.row as BasicFlowDefinition);
-              }
+              handleOpenClick(params.row as BasicFlowDefinition);
             }}
             initialState={{
               pagination: {
@@ -186,11 +187,8 @@ export default function FlowsList(): JSX.Element {
             localeText={dataGridLocaleText}
             autoHeight
             sx={{
-              '& .MuiDataGrid-row.row-clickable': {
+              '& .MuiDataGrid-row': {
                 cursor: 'pointer',
-              },
-              '& .MuiDataGrid-row.row-not-clickable': {
-                cursor: 'default',
               },
             }}
           />

--- a/frontend/apps/console/src/features/flows/components/__tests__/FlowsList.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/__tests__/FlowsList.test.tsx
@@ -381,6 +381,27 @@ describe('FlowsList', () => {
         expect(mockNavigate).toHaveBeenCalledWith('/flows/flow-2');
       });
     });
+
+    it('should navigate when a read-only flow row is clicked', async () => {
+      mockUseGetFlowsReturn = {
+        data: {flows: [{...mockFlowsData.flows[0], isReadOnly: true}]},
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      };
+
+      render(
+        <MemoryRouter>
+          <FlowsList />
+        </MemoryRouter>,
+      );
+
+      fireEvent.click(screen.getByTestId('row-flow-1'));
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/flows/flow-1');
+      });
+    });
   });
 
   describe('Empty State', () => {
@@ -442,6 +463,32 @@ describe('FlowsList', () => {
         actionsColumn!.renderCell!({row: mockFlowsData.flows[1]} as DataGrid.GridRenderCellParams<BasicFlowDefinition>),
       );
       expect(regContainer.querySelectorAll('button').length).toBeGreaterThan(0);
+    });
+
+    it('should render a read-only flow with a single view action that navigates', async () => {
+      render(
+        <MemoryRouter>
+          <FlowsList />
+        </MemoryRouter>,
+      );
+
+      const actionsColumn = capturedColumns.value.find((col) => col.field === 'actions');
+
+      const {container} = render(
+        actionsColumn!.renderCell!({
+          row: {...mockFlowsData.flows[0], isReadOnly: true},
+        } as DataGrid.GridRenderCellParams<BasicFlowDefinition>),
+      );
+
+      // Read-only flows expose view only: no edit, no delete.
+      const buttons = container.querySelectorAll('button');
+      expect(buttons.length).toBe(1);
+
+      fireEvent.click(buttons[0]);
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/flows/flow-1');
+      });
     });
   });
 


### PR DESCRIPTION
### Purpose

  Fixes an issue where declaratively managed flows could not be opened from the Console flow listing.

  Although the flow builder supports displaying read-only flows, the listing prevented navigation when a flow had isReadOnly enabled. The read-only Eye action was also non-
  interactive.

  ### Approach

  - Allow read-only flow rows to navigate to the flow builder.
  - Make the Eye action open declarative flows in view mode.
  - Retain the existing read-only behavior that prevents saving or deleting declaratively managed flows.
  - Rename the navigation handler to reflect that it opens both mutable and read-only flows.
  - Add unit tests covering navigation through:
      - A read-only flow row.
      - The read-only flow Eye action.

  ### Related Issues

  - Fixes #4642

  ### Related PRs

  - N/A

  ### Checklist

  - [x] Followed the contribution guidelines.
  - [x] Manual test round performed and verified.
  - [ ] Documentation provided. (Not applicable)
      - [ ] Ran Vale and fixed all errors and warnings
  - [x] Tests provided.
      - [x] Unit Tests
      - [ ] Integration Tests
  - [ ] Breaking changes. (Not applicable)
      - [ ] Breaking changes section filled.
      - [ ] breaking change label added.

  ### Security checks

  - [x] Followed secure coding standards in WSO2 Secure Coding Guidelines
    (https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
  - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Read-only flows now provide a clickable **View** action.
  * Clicking any flow row navigates to its flow page.

* **Bug Fixes**
  * Improved navigation consistency across read-only and editable flow actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->