### PR TITLE
Run console user deletion through a configurable administration flow

### DIFF
--- a/backend/cmd/server/bootstrap/01-default-resources.yaml
+++ b/backend/cmd/server/bootstrap/01-default-resources.yaml
@@ -1882,6 +1882,96 @@ nodes:
       x: 7103
       y: 637
 ---
+resource_type: flow
+id: 01900000-0000-7000-8000-000000000077
+name: Default User Deletion Flow
+handle: default-user-deletion-flow
+flowType: ADMINISTRATION
+nodes:
+- id: start
+  type: START
+  onSuccess: permission_validator
+  layout:
+    size:
+      width: 101
+      height: 34
+    position:
+      x: 100
+      y: 200
+- id: permission_validator
+  type: TASK_EXECUTION
+  properties:
+    requiredScopes:
+    - system:user
+  executor:
+    name: PermissionValidator
+  onSuccess: pre_delete
+  layout:
+    size:
+      width: 206
+      height: 113
+    position:
+      x: 300
+      y: 175
+- id: pre_delete
+  type: TASK_EXECUTION
+  executor:
+    name: PreDeleteExecutor
+    mode: revoke_all
+  onSuccess: revoke_tokens
+  layout:
+    size:
+      width: 220
+      height: 113
+    position:
+      x: 580
+      y: 175
+- id: revoke_tokens
+  type: TASK_EXECUTION
+  executor:
+    name: CriteriaRevocationExecutor
+  onSuccess: revoke_sessions
+  layout:
+    size:
+      width: 206
+      height: 113
+    position:
+      x: 900
+      y: 175
+- id: revoke_sessions
+  type: TASK_EXECUTION
+  executor:
+    name: SessionRevocationExecutor
+  onSuccess: delete_user
+  layout:
+    size:
+      width: 206
+      height: 113
+    position:
+      x: 1180
+      y: 175
+- id: delete_user
+  type: TASK_EXECUTION
+  executor:
+    name: UserDeleteExecutor
+  onSuccess: end
+  layout:
+    size:
+      width: 206
+      height: 113
+    position:
+      x: 1460
+      y: 175
+- id: end
+  type: END
+  layout:
+    size:
+      width: 85
+      height: 34
+    position:
+      x: 1740
+      y: 200
+---
 resource_type: theme
 id: 01900000-0000-7000-8000-000000000071
 handle: acrylic-orange

--- a/backend/cmd/server/bootstrap/02-server-configurations.yaml
+++ b/backend/cmd/server/bootstrap/02-server-configurations.yaml
@@ -14,3 +14,5 @@ value:
   userOnboardingFlow:
     defaultHandle: default-flow
     expirySeconds: 86400
+  userDeletionFlow:
+    defaultHandle: default-user-deletion-flow

--- a/backend/internal/flow/config/config.go
+++ b/backend/internal/flow/config/config.go
@@ -29,12 +29,17 @@ type FlowTypeConfig struct {
 
 // FlowSectionConfig is the value of the server-config "flow" section. It carries per-type default
 // handles and context TTLs. A zero ExpirySeconds falls back to the built-in default for that type.
+//
+// UserDeletionFlow names the administration flow that carries out a user deletion. There is no
+// separate mode switch: a console deletes through the flow when one is configured and present, and
+// through DELETE /users/{id} otherwise, mirroring how user onboarding falls back to manual creation.
 type FlowSectionConfig struct {
 	AuthFlow           FlowTypeConfig `json:"authFlow"`
 	RegistrationFlow   FlowTypeConfig `json:"registrationFlow"`
 	UserOnboardingFlow FlowTypeConfig `json:"userOnboardingFlow"`
 	RecoveryFlow       FlowTypeConfig `json:"recoveryFlow"`
 	SignOutFlow        FlowTypeConfig `json:"signOutFlow"`
+	UserDeletionFlow   FlowTypeConfig `json:"userDeletionFlow"`
 }
 
 // FromServerRuntime builds flow configuration from the global server runtime.

--- a/backend/internal/flow/mgt/server_config.go
+++ b/backend/internal/flow/mgt/server_config.go
@@ -73,6 +73,7 @@ func (h *FlowConfigHandler) Validate(incoming, _, _ any) error {
 		{cfg.UserOnboardingFlow, providers.FlowTypeUserOnboarding, "userOnboardingFlow"},
 		{cfg.RecoveryFlow, providers.FlowTypeRecovery, "recoveryFlow"},
 		{cfg.SignOutFlow, providers.FlowTypeSignOut, "signOutFlow"},
+		{cfg.UserDeletionFlow, providers.FlowTypeAdministration, "userDeletionFlow"},
 	}
 	ctx := context.Background()
 
@@ -103,6 +104,7 @@ func (h *FlowConfigHandler) Merge(readOnly, writable any) any {
 		UserOnboardingFlow: mergeFlowTypeConfig(ro.UserOnboardingFlow, wr.UserOnboardingFlow),
 		RecoveryFlow:       mergeFlowTypeConfig(ro.RecoveryFlow, wr.RecoveryFlow),
 		SignOutFlow:        mergeFlowTypeConfig(ro.SignOutFlow, wr.SignOutFlow),
+		UserDeletionFlow:   mergeFlowTypeConfig(ro.UserDeletionFlow, wr.UserDeletionFlow),
 	}
 }
 

--- a/backend/internal/flow/mgt/server_config_test.go
+++ b/backend/internal/flow/mgt/server_config_test.go
@@ -163,3 +163,67 @@ func (s *FlowConfigHandlerTestSuite) TestMergeFlowTypeConfig_WritableExpiryWins(
 	s.Equal("ro", merged.DefaultHandle)
 	s.Equal(int64(900), merged.ExpirySeconds)
 }
+
+// ---------------------------------------------------------------------------
+// User deletion flow
+// ---------------------------------------------------------------------------
+
+// An unset handle is valid: it is how a deployment opts out of flow-based deletion and keeps the
+// native endpoint.
+func (s *FlowConfigHandlerTestSuite) TestValidate_UserDeletionHandleOptional() {
+	s.NoError(s.handler.Validate(flowconfig.FlowSectionConfig{}, nil, nil))
+}
+
+// The handle must name an administration flow, not merely exist.
+func (s *FlowConfigHandlerTestSuite) TestValidate_UserDeletionHandleCheckedAgainstAdministration() {
+	var gotType providers.FlowType
+	s.handler.SetHandleValidator(func(_ context.Context, _ string, flowType providers.FlowType) bool {
+		gotType = flowType
+		return true
+	})
+	cfg := flowconfig.FlowSectionConfig{
+		UserDeletionFlow: flowconfig.FlowTypeConfig{DefaultHandle: "default-user-deletion-flow"},
+	}
+
+	s.Require().NoError(s.handler.Validate(cfg, nil, nil))
+	s.Equal(providers.FlowTypeAdministration, gotType)
+}
+
+func (s *FlowConfigHandlerTestSuite) TestValidate_UserDeletionHandleRejectedWhenNotAdministration() {
+	s.handler.SetHandleValidator(func(_ context.Context, _ string, _ providers.FlowType) bool {
+		return false
+	})
+	cfg := flowconfig.FlowSectionConfig{
+		UserDeletionFlow: flowconfig.FlowTypeConfig{DefaultHandle: "not-an-admin-flow"},
+	}
+
+	err := s.handler.Validate(cfg, nil, nil)
+
+	s.Require().Error(err)
+	s.Contains(err.Error(), "userDeletionFlow.defaultHandle")
+}
+
+// An operator can repoint deletion at their own administration flow through the writable layer.
+func (s *FlowConfigHandlerTestSuite) TestMerge_WritableUserDeletionHandleWins() {
+	ro := flowconfig.FlowSectionConfig{
+		UserDeletionFlow: flowconfig.FlowTypeConfig{DefaultHandle: "default-user-deletion-flow"},
+	}
+	wr := flowconfig.FlowSectionConfig{
+		UserDeletionFlow: flowconfig.FlowTypeConfig{DefaultHandle: "acme-offboarding"},
+	}
+
+	merged, ok := s.handler.Merge(ro, wr).(flowconfig.FlowSectionConfig)
+
+	s.Require().True(ok)
+	s.Equal("acme-offboarding", merged.UserDeletionFlow.DefaultHandle)
+}
+
+func (s *FlowConfigHandlerTestSuite) TestMerge_EmptyWritableKeepsDeclarativeUserDeletionHandle() {
+	ro := flowconfig.FlowSectionConfig{
+		UserDeletionFlow: flowconfig.FlowTypeConfig{DefaultHandle: "default-user-deletion-flow"},
+	}
+
+	merged, _ := s.handler.Merge(ro, flowconfig.FlowSectionConfig{}).(flowconfig.FlowSectionConfig)
+
+	s.Equal("default-user-deletion-flow", merged.UserDeletionFlow.DefaultHandle)
+}

--- a/frontend/packages/configure-users/src/api/__tests__/useDeleteUser.test.ts
+++ b/frontend/packages/configure-users/src/api/__tests__/useDeleteUser.test.ts
@@ -32,6 +32,84 @@ vi.mock('@thunderid/contexts', async (importOriginal) => {
   };
 });
 
+const FLOW_ID = '01900000-0000-7000-8000-000000000077';
+const FLOW_HANDLE = 'default-user-deletion-flow';
+
+const flowConfiguredConfig = {merged: {userDeletionFlow: {defaultHandle: FLOW_HANDLE}}};
+const noFlowConfiguredConfig = {merged: {}};
+const administrationFlows = {flows: [{flowType: 'ADMINISTRATION', handle: FLOW_HANDLE, id: FLOW_ID}]};
+
+/**
+ * The request shape the hook issues, as far as these tests inspect it.
+ */
+interface RecordedRequest {
+  url: string;
+  method: string;
+  data?: unknown;
+}
+
+/**
+ * Answers the mocked client by URL rather than by call order.
+ *
+ * A deletion issues up to three requests (read the mode, resolve the flow handle, then delete), so a
+ * positional mock would attach a response to the wrong call. A route value may be an `Error` to
+ * reject, or a function returning a promise when a test needs per-call behaviour.
+ */
+function routeHttp(routes: Record<string, unknown>): void {
+  mockHttpRequest.mockImplementation((config: unknown): Promise<{data?: unknown}> => {
+    const {url} = config as RecordedRequest;
+    const key = Object.keys(routes).find((candidate) => url.includes(candidate));
+
+    if (key === undefined) {
+      return Promise.reject(new Error(`unexpected request: ${url}`));
+    }
+
+    const value = routes[key];
+
+    if (value instanceof Error) {
+      return Promise.reject(value);
+    }
+    if (typeof value === 'function') {
+      return (value as () => Promise<{data?: unknown}>)();
+    }
+
+    return Promise.resolve({data: value});
+  });
+}
+
+/**
+ * Arranges a successful flow deletion, which is what the shipped configuration produces.
+ */
+function mockFlowDeletion(overrides: Record<string, unknown> = {}): void {
+  routeHttp({
+    '/server-config/flow': flowConfiguredConfig,
+    '/flows': administrationFlows,
+    '/flow/execute': {flowStatus: 'COMPLETE'},
+    ...overrides,
+  });
+}
+
+/**
+ * Arranges a successful native deletion, as a deployment with no deletion flow configured gets.
+ */
+function mockNativeDeletion(overrides: Record<string, unknown> = {}): void {
+  routeHttp({
+    '/server-config/flow': noFlowConfiguredConfig,
+    '/users/': {},
+    ...overrides,
+  });
+}
+
+/**
+ * The requests whose URL contains the given fragment, so assertions can ignore the lookups that
+ * precede the deletion itself.
+ */
+function requestsTo(fragment: string): RecordedRequest[] {
+  return mockHttpRequest.mock.calls
+    .map(([config]) => config as RecordedRequest)
+    .filter((config) => config.url.includes(fragment));
+}
+
 describe('useDeleteUser', () => {
   beforeEach(() => {
     mockHttpRequest.mockReset();
@@ -44,7 +122,7 @@ describe('useDeleteUser', () => {
   });
 
   it('should show a success toast on successful deletion', async () => {
-    mockHttpRequest.mockResolvedValueOnce(undefined);
+    mockFlowDeletion();
 
     const {result} = renderHook(() => useDeleteUser());
 
@@ -58,7 +136,7 @@ describe('useDeleteUser', () => {
   });
 
   it('should not show a toast on error', async () => {
-    mockHttpRequest.mockRejectedValueOnce(new Error('Failed to delete user'));
+    mockFlowDeletion({'/flow/execute': new Error('Failed to delete user')});
 
     const {result} = renderHook(() => useDeleteUser());
 
@@ -85,7 +163,7 @@ describe('useDeleteUser', () => {
   });
 
   it('should successfully delete a user', async () => {
-    mockHttpRequest.mockResolvedValueOnce(undefined);
+    mockFlowDeletion();
 
     const userId = 'user-1';
     const {result} = renderHook(() => useDeleteUser());
@@ -102,7 +180,28 @@ describe('useDeleteUser', () => {
   });
 
   it('should make correct API call with user ID', async () => {
-    mockHttpRequest.mockResolvedValueOnce(undefined);
+    mockFlowDeletion();
+
+    const userId = 'user-1';
+    const {result} = renderHook(() => useDeleteUser());
+
+    result.current.mutate(userId);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockHttpRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://api.test.com/flow/execute',
+        method: 'POST',
+        data: {flowId: FLOW_ID, inputs: {subject: userId}},
+      }),
+    );
+  });
+
+  it('should call the native endpoint when no deletion flow is configured', async () => {
+    mockNativeDeletion();
 
     const userId = 'user-1';
     const {result} = renderHook(() => useDeleteUser());
@@ -122,14 +221,16 @@ describe('useDeleteUser', () => {
         },
       }),
     );
+    expect(requestsTo('/flow/execute')).toHaveLength(0);
   });
 
   it('should set pending state during deletion', async () => {
-    mockHttpRequest.mockReturnValue(
-      new Promise((resolve) => {
-        setTimeout(() => resolve(undefined), 100);
-      }),
-    );
+    mockFlowDeletion({
+      '/flow/execute': () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve({data: {flowStatus: 'COMPLETE'}}), 100);
+        }),
+    });
 
     const userId = 'user-1';
     const {result} = renderHook(() => useDeleteUser());
@@ -144,7 +245,7 @@ describe('useDeleteUser', () => {
       () => {
         expect(result.current.isSuccess).toBe(true);
       },
-      {timeout: 200},
+      {timeout: 500},
     );
 
     expect(result.current.isPending).toBe(false);
@@ -152,7 +253,7 @@ describe('useDeleteUser', () => {
 
   it('should handle API error', async () => {
     const apiError = new Error('Failed to delete user');
-    mockHttpRequest.mockRejectedValueOnce(apiError);
+    mockFlowDeletion({'/flow/execute': apiError});
 
     const userId = 'user-1';
     const {result} = renderHook(() => useDeleteUser());
@@ -170,7 +271,7 @@ describe('useDeleteUser', () => {
 
   it('should handle network error', async () => {
     const networkError = new Error('Network request failed');
-    mockHttpRequest.mockRejectedValueOnce(networkError);
+    mockFlowDeletion({'/flow/execute': networkError});
 
     const userId = 'user-1';
     const {result} = renderHook(() => useDeleteUser());
@@ -185,8 +286,25 @@ describe('useDeleteUser', () => {
     expect(result.current.isPending).toBe(false);
   });
 
+  // The flow reports a refusal in its own envelope rather than as a rejected request, so the hook has
+  // to treat a non-COMPLETE terminal status as a failure.
+  it('should fail when the flow reports an error status', async () => {
+    mockFlowDeletion({'/flow/execute': {failureReason: 'user has dependencies', flowStatus: 'ERROR'}});
+
+    const {result} = renderHook(() => useDeleteUser());
+
+    result.current.mutate('user-1');
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error?.message).toBe('user has dependencies');
+    expect(mockShowToast).not.toHaveBeenCalled();
+  });
+
   it('should remove user from cache on successful deletion', async () => {
-    mockHttpRequest.mockResolvedValueOnce(undefined);
+    mockFlowDeletion();
 
     const userId = 'user-1';
     const {result, queryClient} = renderHook(() => useDeleteUser());
@@ -216,7 +334,7 @@ describe('useDeleteUser', () => {
   });
 
   it('should invalidate users list on successful deletion', async () => {
-    mockHttpRequest.mockResolvedValueOnce(undefined);
+    mockFlowDeletion();
 
     const userId = 'user-1';
     const {result, queryClient} = renderHook(() => useDeleteUser());
@@ -252,7 +370,7 @@ describe('useDeleteUser', () => {
   });
 
   it('should handle invalidateQueries rejection gracefully', async () => {
-    mockHttpRequest.mockResolvedValueOnce(undefined);
+    mockFlowDeletion();
 
     const userId = 'user-1';
     const {result, queryClient} = renderHook(() => useDeleteUser());
@@ -269,7 +387,7 @@ describe('useDeleteUser', () => {
   });
 
   it('should handle sequential deletions', async () => {
-    mockHttpRequest.mockResolvedValue(undefined);
+    mockFlowDeletion();
 
     const user1Id = 'user-1';
     const user2Id = 'user-2';
@@ -290,23 +408,14 @@ describe('useDeleteUser', () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
-    expect(mockHttpRequest).toHaveBeenCalledTimes(2);
-    expect(mockHttpRequest).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        url: `https://api.test.com/users/${user1Id}`,
-      }),
-    );
-    expect(mockHttpRequest).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        url: `https://api.test.com/users/${user2Id}`,
-      }),
-    );
+    const executions = requestsTo('/flow/execute');
+    expect(executions).toHaveLength(2);
+    expect(executions[0]?.data).toEqual({flowId: FLOW_ID, inputs: {subject: user1Id}});
+    expect(executions[1]?.data).toEqual({flowId: FLOW_ID, inputs: {subject: user2Id}});
   });
 
   it('should use mutateAsync for promise-based deletion', async () => {
-    mockHttpRequest.mockResolvedValueOnce(undefined);
+    mockFlowDeletion();
 
     const userId = 'user-1';
     const {result} = renderHook(() => useDeleteUser());
@@ -322,7 +431,7 @@ describe('useDeleteUser', () => {
 
   it('should reject mutateAsync on error', async () => {
     const apiError = new Error('Deletion failed');
-    mockHttpRequest.mockRejectedValueOnce(apiError);
+    mockFlowDeletion({'/flow/execute': apiError});
 
     const userId = 'user-1';
     const {result} = renderHook(() => useDeleteUser());
@@ -338,7 +447,14 @@ describe('useDeleteUser', () => {
 
   it('should clear error state on successful retry', async () => {
     const apiError = new Error('Temporary error');
-    mockHttpRequest.mockRejectedValueOnce(apiError).mockResolvedValueOnce(undefined);
+    let attempt = 0;
+
+    mockFlowDeletion({
+      '/flow/execute': () => {
+        attempt += 1;
+        return attempt === 1 ? Promise.reject(apiError) : Promise.resolve({data: {flowStatus: 'COMPLETE'}});
+      },
+    });
 
     const userId = 'user-1';
     const {result} = renderHook(() => useDeleteUser());
@@ -360,11 +476,11 @@ describe('useDeleteUser', () => {
     });
 
     expect(result.current.error).toBeNull();
-    expect(mockHttpRequest).toHaveBeenCalledTimes(2);
+    expect(requestsTo('/flow/execute')).toHaveLength(2);
   });
 
   it('should not affect other cached users on deletion', async () => {
-    mockHttpRequest.mockResolvedValueOnce(undefined);
+    mockFlowDeletion();
 
     const user1Id = 'user-1';
     const user2Id = 'user-2';
@@ -394,8 +510,7 @@ describe('useDeleteUser', () => {
     const customServerUrl = 'https://custom-server.com:9090';
 
     mockGetServerUrl.mockReturnValue(customServerUrl);
-
-    mockHttpRequest.mockResolvedValueOnce(undefined);
+    mockFlowDeletion();
 
     const userId = 'user-1';
     const {result} = renderHook(() => useDeleteUser());
@@ -406,20 +521,13 @@ describe('useDeleteUser', () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
-    expect(mockHttpRequest).toHaveBeenCalledWith(
-      expect.objectContaining({
-        url: `${customServerUrl}/users/${userId}`,
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      }),
-    );
+    expect(requestsTo('/server-config/flow')[0]?.url).toBe(`${customServerUrl}/server-config/flow`);
+    expect(requestsTo('/flow/execute')[0]?.url).toBe(`${customServerUrl}/flow/execute`);
   });
 
   it('should pass through server error messages', async () => {
     const serverError = new Error('User has active sessions and cannot be deleted');
-    mockHttpRequest.mockRejectedValueOnce(serverError);
+    mockFlowDeletion({'/flow/execute': serverError});
 
     const userId = 'user-1';
     const {result} = renderHook(() => useDeleteUser());

--- a/frontend/packages/configure-users/src/api/useDeleteUser.ts
+++ b/frontend/packages/configure-users/src/api/useDeleteUser.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 The ThunderID Authors
+// Copyright 2025-2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
 import {useMutation, useQueryClient, type UseMutationResult} from '@tanstack/react-query';
@@ -6,9 +6,14 @@ import {useConfig, useToast} from '@thunderid/contexts';
 import {useThunderID} from '@thunderid/react';
 import {useTranslation} from 'react-i18next';
 import UserQueryKeys from '../constants/user-query-keys';
+import deleteUser, {type HttpLike} from '../utils/deleteUserViaFlow';
 
 /**
  * Custom hook to delete a user by ID.
+ *
+ * Deletion runs either through the native endpoint or through the configured administration flow,
+ * selected by the `userDeletionFlow.mode` server configuration. The flow path additionally revokes
+ * the user's grants and terminates their sessions before the record is removed.
  *
  * @returns TanStack Query mutation object for deleting users
  */
@@ -21,15 +26,7 @@ export default function useDeleteUser(): UseMutationResult<void, Error, string> 
 
   return useMutation<void, Error, string>({
     mutationFn: async (userId: string): Promise<void> => {
-      const serverUrl: string = getServerUrl();
-
-      await http.request({
-        url: `${serverUrl}/users/${userId}`,
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      } as unknown as Parameters<typeof http.request>[0]);
+      await deleteUser(http as unknown as HttpLike, getServerUrl(), userId);
     },
     onSuccess: (_data, userId) => {
       queryClient.removeQueries({queryKey: [UserQueryKeys.USER, userId]});

--- a/frontend/packages/configure-users/src/models/user-deletion.ts
+++ b/frontend/packages/configure-users/src/models/user-deletion.ts
@@ -1,0 +1,81 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The `userDeletionFlow` entry of the `flow` server-config section.
+ *
+ * There is no mode switch. Deletion runs through the flow when `defaultHandle` names an
+ * administration flow that exists, and through `DELETE /users/{id}` otherwise, mirroring how user
+ * onboarding falls back to manual creation when its flow is unavailable.
+ */
+export interface UserDeletionFlowConfig {
+  defaultHandle?: string;
+  expirySeconds?: number;
+}
+
+/**
+ * The subset of the `flow` server-config section this package reads.
+ */
+export interface FlowSectionConfig {
+  userDeletionFlow?: UserDeletionFlowConfig;
+}
+
+/**
+ * `GET /server-config/{name}` returns the declarative and writable layers alongside the effective
+ * value. Only the merged layer describes what the server actually applies.
+ */
+export interface ServerConfigLayers<T> {
+  readOnly?: T;
+  writable?: T;
+  merged?: T;
+}
+
+/**
+ * One entry of `GET /flows`, narrowed to the fields needed to resolve a handle to an id.
+ */
+export interface BasicFlowSummary {
+  id: string;
+  handle: string;
+  flowType: string;
+}
+
+/**
+ * The `GET /flows` response, narrowed.
+ */
+export interface FlowListResponse {
+  flows?: BasicFlowSummary[];
+}
+
+/**
+ * The `POST /flow/execute` response, narrowed to what the deletion path inspects.
+ */
+export interface FlowExecutionResponse {
+  flowStatus?: string;
+  executionId?: string;
+  failureReason?: string;
+}
+
+/**
+ * Terminal status of a completed flow execution.
+ */
+export const FlowStatus = {
+  COMPLETE: 'COMPLETE',
+  ERROR: 'ERROR',
+  INCOMPLETE: 'INCOMPLETE',
+} as const;
+
+/**
+ * Flow type of the administration flows that can carry out a deletion.
+ */
+export const ADMINISTRATION_FLOW_TYPE = 'ADMINISTRATION';
+
+/**
+ * Identifier of the input the deletion flow expects, matching the executor's declared input.
+ */
+export const DELETION_SUBJECT_INPUT = 'subject';
+
+/**
+ * Page size used when walking the flow listing to resolve a handle. Matches the server's maximum
+ * page size, so the common case of a handful of administration flows resolves in one request.
+ */
+export const FLOW_PAGE_SIZE = 100;

--- a/frontend/packages/configure-users/src/utils/__tests__/deleteUserViaFlow.test.ts
+++ b/frontend/packages/configure-users/src/utils/__tests__/deleteUserViaFlow.test.ts
@@ -1,0 +1,220 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {describe, expect, it, vi} from 'vitest';
+import {FLOW_PAGE_SIZE} from '../../models/user-deletion';
+import deleteUser, {
+  executeDeletionFlow,
+  findAdministrationFlowId,
+  resolveDeletionFlowHandle,
+  type HttpLike,
+} from '../deleteUserViaFlow';
+
+const SERVER = 'https://localhost:8090';
+const USER_ID = '019fd0e4-de6c-7ea5-9541-7982f40beeb9';
+const FLOW_ID = '01900000-0000-7000-8000-000000000077';
+const HANDLE = 'default-user-deletion-flow';
+
+/**
+ * The request shape the deletion module issues.
+ */
+interface RecordedRequest {
+  url: string;
+  method: string;
+  data?: unknown;
+}
+
+/**
+ * Builds an http double that answers by URL, so each test states only the responses it cares about.
+ */
+function makeHttp(routes: Record<string, unknown>, onRequest?: (config: RecordedRequest) => void): HttpLike {
+  return {
+    request: vi.fn((config: unknown): Promise<{data?: unknown}> => {
+      const request = config as RecordedRequest;
+      onRequest?.(request);
+      const match = Object.keys(routes).find((key) => request.url.includes(key));
+      if (!match) {
+        return Promise.reject(new Error(`unexpected request: ${request.method} ${request.url}`));
+      }
+      const value = routes[match];
+      if (value instanceof Error) {
+        return Promise.reject(value);
+      }
+      return Promise.resolve({data: value});
+    }),
+  };
+}
+
+describe('resolveDeletionFlowHandle', () => {
+  it('should read the configured handle', async () => {
+    const http = makeHttp({'/server-config/flow': {merged: {userDeletionFlow: {defaultHandle: HANDLE}}}});
+
+    await expect(resolveDeletionFlowHandle(http, SERVER)).resolves.toBe(HANDLE);
+  });
+
+  it('should return an empty handle when the section is absent', async () => {
+    const http = makeHttp({'/server-config/flow': {merged: {}}});
+
+    await expect(resolveDeletionFlowHandle(http, SERVER)).resolves.toBe('');
+  });
+
+  // Treating a failed read as "no flow configured" would perform a deletion that skips revocation and
+  // report it as a success, hiding the failure entirely.
+  it('should propagate a failed config read rather than assuming no flow', async () => {
+    const http = makeHttp({'/server-config/flow': new Error('boom')});
+
+    await expect(resolveDeletionFlowHandle(http, SERVER)).rejects.toThrow('boom');
+  });
+
+  // The endpoint wraps the section in readOnly/writable/merged layers. Reading the envelope directly
+  // would silently yield undefined and fall back to native, which is what this pins against.
+  it('should read the merged layer, not the envelope', async () => {
+    const http = makeHttp({
+      '/server-config/flow': {
+        merged: {userDeletionFlow: {defaultHandle: HANDLE}},
+        readOnly: {userDeletionFlow: {}},
+        writable: {userDeletionFlow: {defaultHandle: HANDLE}},
+      },
+    });
+
+    await expect(resolveDeletionFlowHandle(http, SERVER)).resolves.toBe(HANDLE);
+  });
+});
+
+describe('findAdministrationFlowId', () => {
+  it('should resolve a handle to its flow id', async () => {
+    const http = makeHttp({
+      '/flows': {
+        flows: [
+          {flowType: 'ADMINISTRATION', handle: 'other', id: 'wrong'},
+          {flowType: 'ADMINISTRATION', handle: HANDLE, id: FLOW_ID},
+        ],
+      },
+    });
+
+    await expect(findAdministrationFlowId(http, SERVER, HANDLE)).resolves.toBe(FLOW_ID);
+  });
+
+  it('should return null when no administration flow carries the handle', async () => {
+    const http = makeHttp({'/flows': {flows: []}});
+
+    await expect(findAdministrationFlowId(http, SERVER, 'missing')).resolves.toBeNull();
+  });
+
+  // The listing is ordered newest first, so the bootstrap deletion flow sits on the last page once a
+  // deployment accumulates administration flows. Stopping at the first page would stop finding it.
+  it('should walk pages until the handle is found', async () => {
+    const firstPage = Array.from({length: FLOW_PAGE_SIZE}, (_unused, index) => ({
+      flowType: 'ADMINISTRATION',
+      handle: `filler-${index}`,
+      id: `filler-${index}`,
+    }));
+    const requested: string[] = [];
+    const http: HttpLike = {
+      request: vi.fn((config: unknown): Promise<{data?: unknown}> => {
+        const {url} = config as RecordedRequest;
+        requested.push(url);
+        const flows = url.includes('offset=0')
+          ? firstPage
+          : [{flowType: 'ADMINISTRATION', handle: HANDLE, id: FLOW_ID}];
+        return Promise.resolve({data: {flows}});
+      }),
+    };
+
+    await expect(findAdministrationFlowId(http, SERVER, HANDLE)).resolves.toBe(FLOW_ID);
+    expect(requested).toHaveLength(2);
+    expect(requested[1]).toContain(`offset=${FLOW_PAGE_SIZE}`);
+  });
+});
+
+describe('executeDeletionFlow', () => {
+  it('should send the flow id and subject and accept a completed flow', async () => {
+    let sent: RecordedRequest | undefined;
+    const http = makeHttp({'/flow/execute': {flowStatus: 'COMPLETE'}}, (config) => {
+      sent = config;
+    });
+
+    await expect(executeDeletionFlow(http, SERVER, FLOW_ID, USER_ID)).resolves.toBeUndefined();
+    expect(sent?.data).toEqual({flowId: FLOW_ID, inputs: {subject: USER_ID}});
+  });
+
+  // Every required input is supplied up front, so a pause means the flow asks for something this
+  // caller cannot provide. Reporting it beats leaving the user silently undeleted.
+  it('should throw when the flow pauses for input', async () => {
+    const http = makeHttp({'/flow/execute': {executionId: 'exec-1', flowStatus: 'INCOMPLETE'}});
+
+    await expect(executeDeletionFlow(http, SERVER, FLOW_ID, USER_ID)).rejects.toThrow('additional input');
+  });
+
+  it('should surface the failure reason when the flow errors', async () => {
+    const http = makeHttp({'/flow/execute': {failureReason: 'user has dependencies', flowStatus: 'ERROR'}});
+
+    await expect(executeDeletionFlow(http, SERVER, FLOW_ID, USER_ID)).rejects.toThrow('user has dependencies');
+  });
+});
+
+describe('deleteUser', () => {
+  it('should run the flow when one is configured and exists', async () => {
+    const calls: RecordedRequest[] = [];
+    const http = makeHttp(
+      {
+        '/flow/execute': {flowStatus: 'COMPLETE'},
+        '/flows': {flows: [{flowType: 'ADMINISTRATION', handle: HANDLE, id: FLOW_ID}]},
+        '/server-config/flow': {merged: {userDeletionFlow: {defaultHandle: HANDLE}}},
+      },
+      (config) => calls.push(config),
+    );
+
+    await deleteUser(http, SERVER, USER_ID);
+
+    expect(calls.some((c) => c.url.includes('/flow/execute'))).toBe(true);
+    expect(calls.some((c) => c.method === 'DELETE')).toBe(false);
+  });
+
+  it('should call the native endpoint when no flow is configured', async () => {
+    const calls: RecordedRequest[] = [];
+    const http = makeHttp({'/server-config/flow': {merged: {}}, '/users/': {}}, (config) => calls.push(config));
+
+    await deleteUser(http, SERVER, USER_ID);
+
+    const deleteCall = calls.find((c) => c.method === 'DELETE');
+    expect(deleteCall?.url).toBe(`${SERVER}/users/${USER_ID}`);
+    expect(calls.some((c) => c.url.includes('/flow/execute'))).toBe(false);
+  });
+
+  // The configured flow may have been deleted or renamed. Falling back keeps deletion working, the
+  // same way user onboarding falls back to manual creation when its flow is missing.
+  it('should fall back to the native endpoint when the configured flow does not exist', async () => {
+    const calls: RecordedRequest[] = [];
+    const http = makeHttp(
+      {
+        '/flows': {flows: []},
+        '/server-config/flow': {merged: {userDeletionFlow: {defaultHandle: 'was-deleted'}}},
+        '/users/': {},
+      },
+      (config) => calls.push(config),
+    );
+
+    await deleteUser(http, SERVER, USER_ID);
+
+    expect(calls.some((c) => c.method === 'DELETE')).toBe(true);
+    expect(calls.some((c) => c.url.includes('/flow/execute'))).toBe(false);
+  });
+
+  // A flow that exists but refuses must not be downgraded to a deletion that skips revocation.
+  it('should not fall back when the existing flow fails', async () => {
+    const calls: RecordedRequest[] = [];
+    const http = makeHttp(
+      {
+        '/flow/execute': {failureReason: 'user has dependencies', flowStatus: 'ERROR'},
+        '/flows': {flows: [{flowType: 'ADMINISTRATION', handle: HANDLE, id: FLOW_ID}]},
+        '/server-config/flow': {merged: {userDeletionFlow: {defaultHandle: HANDLE}}},
+        '/users/': {},
+      },
+      (config) => calls.push(config),
+    );
+
+    await expect(deleteUser(http, SERVER, USER_ID)).rejects.toThrow('user has dependencies');
+    expect(calls.some((c) => c.method === 'DELETE')).toBe(false);
+  });
+});

--- a/frontend/packages/configure-users/src/utils/deleteUserViaFlow.ts
+++ b/frontend/packages/configure-users/src/utils/deleteUserViaFlow.ts
@@ -1,0 +1,144 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  ADMINISTRATION_FLOW_TYPE,
+  DELETION_SUBJECT_INPUT,
+  FLOW_PAGE_SIZE,
+  FlowStatus,
+  type FlowExecutionResponse,
+  type FlowListResponse,
+  type FlowSectionConfig,
+  type ServerConfigLayers,
+} from '../models/user-deletion';
+
+/**
+ * Minimal shape of the HTTP client this module needs, so it can be exercised without a React tree.
+ */
+export interface HttpLike {
+  request: (config: unknown) => Promise<{data?: unknown}>;
+}
+
+/**
+ * Reads the handle of the configured user deletion flow, or an empty string when none is configured.
+ *
+ * Read failures propagate. Treating them as "no flow configured" would silently perform a deletion
+ * that skips grant revocation and session termination, and report it as a success.
+ */
+export async function resolveDeletionFlowHandle(http: HttpLike, serverUrl: string): Promise<string> {
+  const response = await http.request({
+    url: `${serverUrl}/server-config/flow`,
+    method: 'GET',
+  });
+  // The endpoint returns the declarative, writable and merged layers. Only the merged layer is the
+  // effective configuration, so reading the envelope directly would always miss the value.
+  const layers = (response?.data ?? {}) as ServerConfigLayers<FlowSectionConfig>;
+
+  return layers.merged?.userDeletionFlow?.defaultHandle ?? '';
+}
+
+/**
+ * Finds the identifier of the administration flow carrying the given handle, or null when no such
+ * flow exists.
+ *
+ * `/flow/execute` addresses a flow by id while the server config names it by handle, so the handle
+ * is looked up against the administration flows rather than assumed.
+ *
+ * The listing is paginated and ordered newest first, which puts the bootstrap deletion flow last, so
+ * a single page would stop finding it once a deployment accumulates enough administration flows.
+ * Pages are therefore walked until the handle is found or the listing is exhausted.
+ */
+export async function findAdministrationFlowId(
+  http: HttpLike,
+  serverUrl: string,
+  handle: string,
+): Promise<string | null> {
+  for (let offset = 0; ; offset += FLOW_PAGE_SIZE) {
+    const response = await http.request({
+      url: `${serverUrl}/flows?flowType=${ADMINISTRATION_FLOW_TYPE}&limit=${FLOW_PAGE_SIZE}&offset=${offset}`,
+      method: 'GET',
+    });
+    const flows = ((response?.data ?? {}) as FlowListResponse).flows ?? [];
+    const match = flows.find((flow) => flow.handle === handle && flow.flowType === ADMINISTRATION_FLOW_TYPE);
+
+    if (match) {
+      return match.id;
+    }
+    // A short page is the last page, so the handle is genuinely absent rather than further along.
+    if (flows.length < FLOW_PAGE_SIZE) {
+      return null;
+    }
+  }
+}
+
+/**
+ * Runs the deletion flow to completion in a single call.
+ *
+ * Every input the flow requires is supplied up front, so it should reach a terminal state without
+ * pausing. An INCOMPLETE result therefore means the configured flow asks for something this caller
+ * cannot provide, and is surfaced as an error rather than silently leaving the user undeleted.
+ */
+export async function executeDeletionFlow(
+  http: HttpLike,
+  serverUrl: string,
+  flowId: string,
+  userId: string,
+): Promise<void> {
+  const response = await http.request({
+    url: `${serverUrl}/flow/execute`,
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    data: {
+      flowId,
+      inputs: {[DELETION_SUBJECT_INPUT]: userId},
+    },
+  });
+  const result = (response?.data ?? {}) as FlowExecutionResponse;
+
+  if (result.flowStatus === FlowStatus.COMPLETE) {
+    return;
+  }
+
+  if (result.flowStatus === FlowStatus.INCOMPLETE) {
+    throw new Error('The user deletion flow requires additional input and could not be completed');
+  }
+
+  throw new Error(result.failureReason ?? 'The user deletion flow did not complete');
+}
+
+/**
+ * Deletes a user through the native endpoint.
+ */
+export async function deleteUserNatively(http: HttpLike, serverUrl: string, userId: string): Promise<void> {
+  await http.request({
+    url: `${serverUrl}/users/${userId}`,
+    method: 'DELETE',
+    headers: {'Content-Type': 'application/json'},
+  });
+}
+
+/**
+ * Deletes a user through the configured deletion flow, falling back to the native endpoint.
+ *
+ * The presence of a usable flow is the switch: deletion runs through the flow when one is configured
+ * and exists, and through the endpoint otherwise. This mirrors user onboarding, which falls back to
+ * manual creation when its flow is unavailable, and means a deployment carrying no flow configuration
+ * keeps deleting users.
+ *
+ * Only a missing flow triggers the fallback. Failures from the flow itself propagate, so a flow that
+ * exists but refuses or errors is never quietly downgraded to a deletion that skips revocation.
+ */
+export default async function deleteUser(http: HttpLike, serverUrl: string, userId: string): Promise<void> {
+  const handle = await resolveDeletionFlowHandle(http, serverUrl);
+
+  if (handle) {
+    const flowId = await findAdministrationFlowId(http, serverUrl, handle);
+
+    if (flowId) {
+      await executeDeletionFlow(http, serverUrl, flowId, userId);
+      return;
+    }
+  }
+
+  await deleteUserNatively(http, serverUrl, userId);
+}


### PR DESCRIPTION
### Purpose

Console user deletion calls `DELETE /users/{id}`, which removes the user record but leaves their issued grants and active sessions in place. This routes deletion through a configurable administration flow that revokes the subject's grants and terminates their sessions before removing the record.

Both delete entry points are affected, since they share `UserDeleteDialog`: the row action in the users list and the button in the user profile danger zone.

### Behaviour change on upgrade

No API contract changes, but existing deployments do get different deletion behaviour without any action on their part. The shipped configuration points `userDeletionFlow.defaultHandle` at a default deletion flow, so deleting a user from the console now also revokes that user's grants and terminates their sessions. Previously only the record was removed. This is not reversible per deletion.

Operators who want the previous behaviour can clear the configured handle, which needs no restart:

```
PUT /server-config/flow
{"userDeletionFlow": {"defaultHandle": ""}}
```

Deleting the `default-user-deletion-flow` administration flow has the same effect.

### Approach

**Configuration.** Adds a `userDeletionFlow` entry to the `flow` server config, shaped exactly like the existing per-type entries (`defaultHandle`, `expirySeconds`). There is deliberately **no mode switch**: the presence of a usable flow is the switch, so deletion runs through the flow when `defaultHandle` names an administration flow that exists, and through `DELETE /users/{id}` otherwise. This mirrors user onboarding, which falls back to manual creation when its flow is unavailable.

Validation confirms at write time that a non-empty handle resolves to a flow that is actually of type `ADMINISTRATION`. Merge semantics let an operator repoint deletion at their own flow through `PUT /server-config/flow` without editing the declarative pack or restarting.

**Default flow.** Ships `Default User Deletion Flow` (handle `default-user-deletion-flow`), wiring existing executors:

`PermissionValidator` (`system:user`) → `PreDeleteExecutor` (`revoke_all`) → `CriteriaRevocationExecutor` → `SessionRevocationExecutor` → `UserDeleteExecutor`

**Console.** Reads the configured handle, resolves it to a flow id, and runs the flow to completion in a single `POST /flow/execute` with the subject supplied up front. Authorization is unchanged in strength: `validateAdministrationCaller` gates flow-id execution in code, and the flow's `PermissionValidator` node requires the same `system:user` permission as `DELETE /users/**`.

Only a **missing** flow triggers the native fallback. A flow that exists but errors or refuses propagates its failure, so a deletion that skips revocation is never silently reported as a success.

### Known Limitations

Raised deliberately for reviewer input rather than fixed here:

1. **A partial failure leaves the user degraded.** The flow revokes grants and sessions before deleting, and declares no failure edges. If `delete_user` fails, the user still exists but is locked out, with no signal that a retry is needed. Native deletion has no equivalent intermediate state. Fixing it means either reordering to delete-first or adding failure handling to the flow, both of which are deletion-semantics decisions worth agreeing before implementing.

2. **Nothing verifies a custom flow actually deletes.** Validation checks only that the configured handle names an `ADMINISTRATION` flow. Pointing `defaultHandle` at an administration flow without a `UserDeleteExecutor` passes validation, completes successfully, and reports success to the operator while the user remains.

3. **The `USR-1027` blocking-dependencies message is lost on the flow path.** `PreDeleteExecutor` collapses `ValidateDeleteUser` failures into a generic error, and the flow envelope carries no error code, so `getUserErrorMessage` falls through to its generic fallback. The dialog's usages pre-check hides this in the common case.

A follow-up worth considering: the console still reads server configuration and resolves the handle itself. Doing that resolution server-side, as `getSystemFlowGraph` already does for user onboarding, would drop two of the three requests a deletion now makes and keep the `USR-1027` envelope intact.

### Related Issues
- N/A

### Related PRs
- Builds on #4591 (criteria-based revocation administration flows), which added the executors this flow composes.

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable user deletion through administrative flows.
  - User deletion now performs flow-based cleanup, including revoking sessions and user criteria.
  - Added fallback to native deletion when no configured administrative flow is available.
  - Added support for custom server URLs and reliable handling of paginated flow listings.

- **Bug Fixes**
  - Prevented fallback deletion when a configured flow fails or ends unsuccessfully.

- **Tests**
  - Expanded coverage for configuration resolution, flow execution states, retries, routing, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->