### PR TITLE
Show Magic Link as an alternative first factor in generated flows

### DIFF
--- a/frontend/apps/console/src/features/flows/utils/__tests__/generateFlowGraph.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/generateFlowGraph.test.ts
@@ -9,7 +9,9 @@ interface Component {
   id: string;
   type?: string;
   label?: string;
+  ref?: string;
   src?: string;
+  variant?: string;
   components?: Component[];
 }
 
@@ -338,8 +340,8 @@ describe('generateFlowGraph', () => {
       expect(new Set(ids).size).toBe(ids.length);
     });
 
-    describe('as a second factor alongside Basic auth', () => {
-      it('should not offer Magic Link as an alternative button next to the password form', () => {
+    describe('alongside Basic auth', () => {
+      it('should offer Magic Link as an alternative button next to the password form', () => {
         const request = generateFlowGraph({
           hasCredentialsAuth: true,
           hasPasskey: false,
@@ -347,14 +349,16 @@ describe('generateFlowGraph', () => {
           hasSmsOtp: false,
         });
 
-        const components = getPromptComponents(request);
-        expect(components.find((c) => c.id === 'block_magic_link')).toBeUndefined();
+        const magicLinkBlock = getPromptComponents(request).find((c) => c.id === 'block_magic_link');
+        expect(magicLinkBlock).toBeDefined();
+        expect(magicLinkBlock?.components?.[0]?.variant).toBe('SECONDARY');
 
         const mainPrompt = request.nodes.find((n) => n.id === 'choose_auth_method');
-        expect(mainPrompt?.prompts?.find((p) => p.action?.ref === 'action_magic_link')).toBeUndefined();
+        const magicLinkAction = mainPrompt?.prompts?.find((p) => p.action?.ref === 'action_magic_link');
+        expect(magicLinkAction?.action?.nextNode).toBe('magic_link_prompt_email');
       });
 
-      it('should route credentials success through an email-collecting step instead of straight to auth_assert', () => {
+      it('should route credentials success straight to auth_assert, without an email-collecting step', () => {
         const request = generateFlowGraph({
           hasCredentialsAuth: true,
           hasPasskey: false,
@@ -362,18 +366,11 @@ describe('generateFlowGraph', () => {
           hasSmsOtp: false,
         });
 
-        expect(request.nodes.find((n) => n.id === 'credentials_auth')?.onSuccess).toBe('collect_email');
-
-        const collectEmail = request.nodes.find((n) => n.id === 'collect_email');
-        expect(collectEmail?.executor?.name).toBe('AttributeCollector');
-        expect(collectEmail?.executor?.inputs).toEqual([
-          {ref: 'input_magic_link_email', identifier: 'email', type: 'EMAIL_INPUT', required: false},
-        ]);
-        expect(collectEmail?.onSuccess).toBe('magic_link_generate');
-        expect(collectEmail?.onIncomplete).toBe('magic_link_prompt_email');
+        expect(request.nodes.find((n) => n.id === 'credentials_auth')?.onSuccess).toBe('auth_assert');
+        expect(request.nodes.find((n) => n.id === 'collect_email')).toBeUndefined();
       });
 
-      it('should route every chain failure back to the primary credentials screen instead of the email prompt', () => {
+      it('should route every chain failure back to its own email prompt', () => {
         const request = generateFlowGraph({
           hasCredentialsAuth: true,
           hasPasskey: false,
@@ -382,15 +379,15 @@ describe('generateFlowGraph', () => {
         });
 
         const generateNode = request.nodes.find((n) => n.id === 'magic_link_generate');
-        expect(generateNode?.onIncomplete).toBe('choose_auth_method');
-        expect(generateNode?.onFailure).toBe('choose_auth_method');
+        expect(generateNode?.onIncomplete).toBe('magic_link_prompt_email');
+        expect(generateNode?.onFailure).toBe('magic_link_prompt_email');
 
         const sendNode = request.nodes.find((n) => n.id === 'magic_link_send_email');
-        expect(sendNode?.onIncomplete).toBe('choose_auth_method');
-        expect(sendNode?.onFailure).toBe('choose_auth_method');
+        expect(sendNode?.onIncomplete).toBe('magic_link_prompt_email');
+        expect(sendNode?.onFailure).toBe('magic_link_prompt_email');
 
         const verifyNode = request.nodes.find((n) => n.id === 'magic_link_verify');
-        expect(verifyNode?.onFailure).toBe('choose_auth_method');
+        expect(verifyNode?.onFailure).toBe('magic_link_prompt_email');
         expect(verifyNode?.onSuccess).toBe('auth_assert');
       });
 
@@ -415,7 +412,48 @@ describe('generateFlowGraph', () => {
         });
 
         expect(request.nodes.find((n) => n.id === 'passkey_verify')?.onSuccess).toBe('auth_assert');
-        expect(request.nodes.find((n) => n.id === 'credentials_auth')?.onSuccess).toBe('collect_email');
+        expect(request.nodes.find((n) => n.id === 'credentials_auth')?.onSuccess).toBe('auth_assert');
+      });
+    });
+
+    describe('button emphasis', () => {
+      const primaryActionIds = (request: ReturnType<typeof generateFlowGraph>): string[] =>
+        getPromptComponents(request)
+          .flatMap((c) => (c.type === 'BLOCK' ? (c.components ?? []) : [c]))
+          .filter((c) => c.type === 'ACTION' && c.variant === 'PRIMARY')
+          .map((c) => c.id);
+
+      it('should make the password form the only primary action when credentials are enabled', () => {
+        const request = generateFlowGraph({
+          hasCredentialsAuth: true,
+          hasPasskey: true,
+          hasMagicLink: true,
+          hasSmsOtp: false,
+        });
+
+        expect(primaryActionIds(request)).toEqual(['action_basic']);
+      });
+
+      it('should promote Passkey to the only primary action when credentials are disabled', () => {
+        const request = generateFlowGraph({
+          hasCredentialsAuth: false,
+          hasPasskey: true,
+          hasMagicLink: true,
+          hasSmsOtp: false,
+        });
+
+        expect(primaryActionIds(request)).toEqual(['action_passkey']);
+      });
+
+      it('should promote Magic Link to the only primary action when it is the only method', () => {
+        const request = generateFlowGraph({
+          hasCredentialsAuth: false,
+          hasPasskey: false,
+          hasMagicLink: true,
+          hasSmsOtp: false,
+        });
+
+        expect(primaryActionIds(request)).toEqual(['action_magic_link']);
       });
     });
   });
@@ -499,6 +537,114 @@ describe('generateFlowGraph', () => {
       const second = generateFlowGraph(options);
 
       expect(first.handle).not.toBe(second.handle);
+    });
+  });
+
+  describe('graph integrity across every toggle combination', () => {
+    const flatten = (components: Component[]): Component[] =>
+      components.flatMap((c) => [c, ...flatten(c.components ?? [])]);
+
+    // Mirrors every option the wizard can pass, so a new combination cannot silently skip the checks.
+    const allCombinations = (): Parameters<typeof generateFlowGraph>[0][] => {
+      const combos: Parameters<typeof generateFlowGraph>[0][] = [];
+      [false, true].forEach((hasCredentialsAuth) =>
+        [false, true].forEach((hasPasskey) =>
+          [false, true].forEach((hasMagicLink) =>
+            [false, true].forEach((hasSmsOtp) =>
+              [false, true].forEach((hasEmailOtpMfa) =>
+                [undefined, 'idp-1'].forEach((socialIdpId) => {
+                  combos.push({
+                    githubIdpId: socialIdpId,
+                    googleIdpId: socialIdpId,
+                    hasCredentialsAuth,
+                    hasEmailOtpMfa,
+                    hasMagicLink,
+                    hasPasskey,
+                    hasSmsOtp,
+                  });
+                }),
+              ),
+            ),
+          ),
+        ),
+      );
+      return combos;
+    };
+
+    // The React SDK names each submitted field after the meta component's `ref`, rewriting it only
+    // when the ref matches an entry in the prompt's `inputs[].ref -> identifier` map
+    // (flowTransformer.ts createInputRefMapping). A component whose id an input points at must
+    // therefore carry that input's identifier as its ref, or the field is submitted under a name
+    // the executor never reads.
+    it('names every input component ref after the identifier its executor reads', () => {
+      const mismatched: string[] = [];
+
+      allCombinations().forEach((options) => {
+        const request = generateFlowGraph(options);
+
+        request.nodes
+          .filter((node) => node.type === FlowNodeType.PROMPT)
+          .forEach((node) => {
+            const components = flatten((node.meta?.components as Component[]) ?? []);
+
+            (node.prompts ?? [])
+              .flatMap((prompt) => prompt.inputs ?? [])
+              .forEach((input) => {
+                const component = components.find((c) => c.id === input.ref);
+                if (component && component.ref !== input.identifier) {
+                  mismatched.push(`${node.id}/${component.id} ref=${component.ref} identifier=${input.identifier}`);
+                }
+              });
+          });
+      });
+
+      expect(mismatched).toEqual([]);
+    });
+
+    it('points every edge at a node that exists', () => {
+      const dangling: string[] = [];
+
+      allCombinations().forEach((options) => {
+        const request = generateFlowGraph(options);
+        const ids = new Set(request.nodes.map((node) => node.id));
+
+        request.nodes.forEach((node) => {
+          const targets: [string, string | undefined][] = [
+            ['onSuccess', node.onSuccess],
+            ['onFailure', node.onFailure],
+            ['onIncomplete', node.onIncomplete],
+            ['next', node.next],
+            ['condition.onSkip', node.condition?.onSkip],
+            ...(node.prompts ?? []).map((prompt): [string, string | undefined] => [
+              'action.nextNode',
+              prompt.action?.nextNode,
+            ]),
+          ];
+
+          targets.forEach(([key, target]) => {
+            if (target && !ids.has(target)) {
+              dangling.push(`${node.id}.${key} -> ${target}`);
+            }
+          });
+        });
+      });
+
+      expect(dangling).toEqual([]);
+    });
+
+    it('keeps the Magic Link chain looping back to its own email prompt on failure', () => {
+      const request = generateFlowGraph({
+        hasCredentialsAuth: true,
+        hasMagicLink: true,
+        hasPasskey: false,
+        hasSmsOtp: false,
+      });
+
+      ['magic_link_generate', 'magic_link_send_email', 'magic_link_verify'].forEach((id) => {
+        const node = request.nodes.find((n) => n.id === id);
+        expect(node?.onFailure).toBe('magic_link_prompt_email');
+      });
+      expect(request.nodes.find((n) => n.id === 'magic_link_prompt_email')).toBeDefined();
     });
   });
 });

--- a/frontend/apps/console/src/features/flows/utils/__tests__/getFlowPromptComponentsSequence.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/getFlowPromptComponentsSequence.test.ts
@@ -4,6 +4,7 @@
 import {describe, it, expect} from 'vitest';
 import {FlowNodeType} from '../../models/flows';
 import type {FlowDefinitionResponse, FlowNode} from '../../models/responses';
+import generateFlowGraph from '../generateFlowGraph';
 import getFlowPromptComponentsSequence from '../getFlowPromptComponentsSequence';
 
 describe('getFlowPromptComponentsSequence', () => {
@@ -151,5 +152,19 @@ describe('getFlowPromptComponentsSequence', () => {
 
   it('returns null for a flow with no nodes', () => {
     expect(getFlowPromptComponentsSequence(createFlow([]))).toBeNull();
+  });
+
+  it('previews Magic Link on the first screen when it is enabled alongside Credentials Auth', () => {
+    const generated = generateFlowGraph({
+      hasCredentialsAuth: true,
+      hasPasskey: false,
+      hasMagicLink: true,
+      hasSmsOtp: false,
+    });
+
+    const screens = getFlowPromptComponentsSequence(createFlow(generated.nodes));
+
+    expect(screens?.[0]?.find((c) => (c as {id: string}).id === 'block_magic_link')).toBeDefined();
+    expect(screens).toHaveLength(1);
   });
 });

--- a/frontend/apps/console/src/features/flows/utils/generateFlowGraph.ts
+++ b/frontend/apps/console/src/features/flows/utils/generateFlowGraph.ts
@@ -175,25 +175,16 @@ function buildMfaChannelChain(
  * `auth_assert`, so Multi-Factor Login still layers on top of it like any other first factor.
  *
  * @param onVerified - ID of the node to continue to once the magic link is verified
- * @param onFailureNodeId - Node to fall back to when generating/sending/verifying the link fails.
- *   Defaults to the chain's own email prompt (the standalone/Magic-Link-only shape). When Magic
- *   Link runs as a second factor after Basic auth (see `Basic + Magic Link Authentication Flow` in
- *   `flows/data/templates.json`), this is the primary credentials screen instead, since that's
- *   where a user recovering from a failure needs to re-enter the flow.
- * @returns The chain's nodes, the ID of its entry node (where the "Sign in with Magic Link" button
- *   should route to for the standalone shape), and the ID of its generate step (where an
- *   already-known email can be routed straight to, skipping the manual prompt)
+ * @returns The chain's nodes. Its entry node is `magic_link_prompt_email`, where the
+ *   "Sign in with Magic Link" button routes to, and where any failure in the chain returns to.
  */
-function buildMagicLinkChain(
-  onVerified: string,
-  onFailureNodeId?: string,
-): {nodes: FlowNode[]; entryNodeId: string; generateNodeId: string} {
+function buildMagicLinkChain(onVerified: string): FlowNode[] {
   const promptId = 'magic_link_prompt_email';
   const generateId = 'magic_link_generate';
   const sendId = 'magic_link_send_email';
   const sentPromptId = 'magic_link_prompt_sent';
   const verifyId = 'magic_link_verify';
-  const failureTarget = onFailureNodeId ?? promptId;
+  const failureTarget = promptId;
 
   const nodes: FlowNode[] = [
     {
@@ -223,7 +214,7 @@ function buildMagicLinkChain(
             components: [
               {
                 id: 'input_magic_link_email',
-                ref: 'magic_link_email',
+                ref: 'email',
                 type: 'EMAIL_INPUT',
                 label: 'Email',
                 required: true,
@@ -319,7 +310,7 @@ function buildMagicLinkChain(
     },
   ];
 
-  return {nodes, entryNodeId: promptId, generateNodeId: generateId};
+  return nodes;
 }
 
 /** Horizontal gap between graph layers (stage reached from `start`), in canvas pixels. */
@@ -556,12 +547,7 @@ export default function generateFlowGraph(options: FlowGeneratorOptions): Create
   // Magic Link Block — an alternative first-factor button, routing to its own dedicated
   // email-entry screen (magic_link_prompt_email), not straight to an executor like the other
   // buttons here, since it needs its own multi-step chain (see buildMagicLinkChain).
-  //
-  // Only rendered when there's no password to pair it with. Alongside Basic auth, Magic Link
-  // instead becomes a mandatory second factor after credentials succeed (mirrors the
-  // "Basic + Magic Link Authentication Flow" template in flows/data/templates.json) — invisible
-  // on this screen, wired below in section 4 via `collect_email`.
-  if (hasMagicLink && !hasCredentialsAuth) {
+  if (hasMagicLink) {
     metaComponents.push({
       type: 'BLOCK',
       id: 'block_magic_link',
@@ -570,7 +556,7 @@ export default function generateFlowGraph(options: FlowGeneratorOptions): Create
           type: 'ACTION',
           id: 'action_magic_link',
           label: 'Sign in with Magic Link',
-          variant: hasPasskey ? 'SECONDARY' : 'PRIMARY',
+          variant: hasCredentialsAuth || hasPasskey ? 'SECONDARY' : 'PRIMARY',
           eventType: 'SUBMIT',
         },
       ],
@@ -702,9 +688,7 @@ export default function generateFlowGraph(options: FlowGeneratorOptions): Create
 
   // 4. Executor Nodes
 
-  // Credentials Auth Executor. When Magic Link is also enabled, success routes through
-  // `collect_email` (below) instead of straight to `postAuthNodeId` — Magic Link is a mandatory
-  // second factor in that combination, not an alternative.
+  // Credentials Auth Executor
   if (hasCredentialsAuth) {
     nodes.push({
       id: 'credentials_auth',
@@ -712,7 +696,7 @@ export default function generateFlowGraph(options: FlowGeneratorOptions): Create
       executor: {
         name: 'CredentialsAuthExecutor',
       },
-      onSuccess: hasMagicLink ? 'collect_email' : postAuthNodeId,
+      onSuccess: postAuthNodeId,
       onIncomplete: promptNodeId,
     });
   }
@@ -749,34 +733,7 @@ export default function generateFlowGraph(options: FlowGeneratorOptions): Create
   // Magic Link chain — built only now that postAuthNodeId is finalized, so verifying the link
   // routes into the same MFA-or-assert continuation every other first factor uses.
   if (hasMagicLink) {
-    if (hasCredentialsAuth) {
-      // Sequential second factor: try to collect the user's on-file email automatically (no
-      // prompt) once they're authenticated; only fall back to a manual prompt when it's missing.
-      // Failures anywhere in the chain return to the primary credentials screen, since that's
-      // where a user recovering from a failure re-enters this combined flow.
-      const magicLinkChain = buildMagicLinkChain(postAuthNodeId, promptNodeId);
-      nodes.push({
-        id: 'collect_email',
-        type: FlowNodeType.TASK_EXECUTION,
-        executor: {
-          name: 'AttributeCollector',
-          inputs: [
-            {
-              ref: 'input_magic_link_email',
-              identifier: 'email',
-              type: 'EMAIL_INPUT',
-              required: false,
-            },
-          ],
-        },
-        onSuccess: magicLinkChain.generateNodeId,
-        onIncomplete: magicLinkChain.entryNodeId,
-      });
-      nodes.push(...magicLinkChain.nodes);
-    } else {
-      const magicLinkChain = buildMagicLinkChain(postAuthNodeId);
-      nodes.push(...magicLinkChain.nodes);
-    }
+    nodes.push(...buildMagicLinkChain(postAuthNodeId));
   }
 
   // Google Executor


### PR DESCRIPTION
### Purpose
The generated sign-in flow hid the Magic Link button whenever Credentials Auth was also enabled, so the application onboarding preview never showed the Magic Link option. Magic Link was instead wired as a mandatory second factor through a `collect_email` node.

This also fixes a second problem in the same chain: the magic link email field was submitted under a name the executor never reads, so no email was ever sent.

### Approach
- Render `block_magic_link` whenever Magic Link is enabled, secondary when a primary first factor already owns the screen.
- Route `credentials_auth.onSuccess` straight to the post-auth node and delete the `collect_email` node, making Magic Link an alternative first factor in every combination.
- Set the email component's `ref` to `email`, matching the identifier its executor reads. The React SDK names each submitted field after the component `ref`, rewriting it only when that ref is a key in the prompt's `inputs[].ref -> identifier` map, so the previous value survived unrewritten.
- Added tests that sweep all 32 wizard toggle combinations for ref/identifier mismatches, dangling edges, and the Magic Link failure routing.

### Related Issues
- Fixes #4661

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Magic Link authentication is now available as an alternative first-step sign-in method alongside credentials.
  - Magic Link sign-in uses a dedicated email prompt for a clearer authentication experience.
  - Combined credentials and Magic Link configurations now display together in a single authentication prompt.

- **Bug Fixes**
  - Improved navigation after successful credentials authentication.
  - Magic Link failures now return users to the email prompt.
  - Authentication flows now maintain consistent inputs and valid transitions across supported option combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->