### PR TITLE
Route registration credential failures back to the credentials prompt

### DIFF
--- a/backend/cmd/server/bootstrap/01-default-resources.yaml
+++ b/backend/cmd/server/bootstrap/01-default-resources.yaml
@@ -1049,6 +1049,7 @@ nodes:
   executor:
     name: CredentialsAuthExecutor
   onSuccess: provisioning
+  onFailure: prompt_credentials
   layout:
     size:
       width: 244
@@ -1253,6 +1254,7 @@ nodes:
   executor:
     name: CredentialsAuthExecutor
   onSuccess: provisioning
+  onFailure: prompt_registration
 - id: provisioning
   type: TASK_EXECUTION
   executor:

--- a/frontend/apps/console/src/features/flows/data/templates.json
+++ b/frontend/apps/console/src/features/flows/data/templates.json
@@ -6172,7 +6172,8 @@
           "executor": {
             "name": "CredentialsAuthExecutor"
           },
-          "onSuccess": "provisioning"
+          "onSuccess": "provisioning",
+          "onFailure": "prompt_credentials"
         },
         {
           "id": "provisioning",
@@ -8130,6 +8131,7 @@
             "name": "CredentialsAuthExecutor"
           },
           "onSuccess": "provisioning",
+          "onFailure": "choose_auth",
           "layout": {
             "size": {
               "width": 217,
@@ -8523,6 +8525,7 @@
             "name": "CredentialsAuthExecutor"
           },
           "onSuccess": "provisioning",
+          "onFailure": "choose_registration_method",
           "layout": {
             "size": {
               "width": 217,
@@ -9627,6 +9630,7 @@
             "name": "CredentialsAuthExecutor"
           },
           "onSuccess": "generate_otp",
+          "onFailure": "choose_auth",
           "onIncomplete": "choose_auth"
         },
         {
@@ -10271,6 +10275,7 @@
             "name": "CredentialsAuthExecutor"
           },
           "onSuccess": "provisioning",
+          "onFailure": "prompt_registration",
           "layout": {
             "size": {
               "width": 217,

--- a/samples/apps/vanilla-sample/thunderid-config/multi-auth/thunderid-config.yaml
+++ b/samples/apps/vanilla-sample/thunderid-config/multi-auth/thunderid-config.yaml
@@ -848,6 +848,7 @@ nodes:
   executor:
     name: CredentialsAuthExecutor
   onSuccess: provisioning
+  onFailure: choose_auth
 - id: google_auth
   type: TASK_EXECUTION
   properties:
@@ -1264,6 +1265,7 @@ nodes:
   executor:
     name: CredentialsAuthExecutor
   onSuccess: send_sms
+  onFailure: choose_auth
 - id: google_auth
   type: TASK_EXECUTION
   properties:

--- a/samples/apps/wayfinder-sample/thunderid-config/app-native/thunderid-config.yaml
+++ b/samples/apps/wayfinder-sample/thunderid-config/app-native/thunderid-config.yaml
@@ -242,6 +242,7 @@ nodes:
     executor:
       name: CredentialsAuthExecutor
     onSuccess: provisioning
+    onFailure: prompt_credentials
   - id: provisioning
     type: TASK_EXECUTION
     properties:
@@ -967,6 +968,7 @@ nodes:
     executor:
       name: CredentialsAuthExecutor
     onSuccess: provisioning
+    onFailure: prompt_credentials
   - id: provisioning
     type: TASK_EXECUTION
     properties:

--- a/samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid-config.yaml
+++ b/samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid-config.yaml
@@ -257,6 +257,7 @@ nodes:
     executor:
       name: CredentialsAuthExecutor
     onSuccess: provisioning
+    onFailure: prompt_credentials
   - id: provisioning
     type: TASK_EXECUTION
     properties:


### PR DESCRIPTION
Fixes an empty sign-up form that appears after a "user already exists" error.

In a registration flow, `CredentialsAuthExecutor` reports an existing user as a hard failure (`ExecFailure` with `FET-1007`). None of the shipped registration flows wired `onFailure` on that node, so the step ended with `flowStatus: ERROR` and an empty body while the flow context stayed alive. On the next submission the flow resumed from a stale cursor and re-rendered the credentials prompt with **no input fields and no error message**, leaving the user stuck on a form they could not fill or correct.

The failure is worse when registration is entered through a `CALL` node (the "Sign up" link on the login page). `handleCalleeFailure` pops the call frame before it checks `onFailure`, so the persisted cursor rewinds to the `CALL` node. Re-entering the call clears `CurrentAction` but deliberately preserves `UserInputs`, so the callee's credentials
prompt finds every input already satisfied and no action selected, and can only render a form containing the submit button.

### Approach

Set `onFailure` on the credentials node of every registration flow, pointing at the prompt node that collects the credentials in that same flow.

This works because `taskExecutionNode.Execute` rewrites the status when `onFailure` is present: `NodeStatusFailure` becomes `NodeStatusForward`, the error is recorded in `RuntimeData` as `failureReasonJSON`, and the node's consumed inputs are cleared. The prompt node then sees `failureReasonJSON`, clears its own inputs and the selected action,
and re-renders the complete form with the error attached. Because the status is never `NodeStatusFailure` at the engine level, the step no longer terminates as `ERROR`, the call frame is never popped, and the stale-cursor path is not reached at all.

Nodes changed (12 across 5 files):

| File | Flow | `onFailure` |
|---|---|---|
| `bootstrap/01-default-resources.yaml` | `default-flow` | `prompt_credentials` |
| `bootstrap/01-default-resources.yaml` | `console-app-flow` | `prompt_registration` |
| `vanilla-sample/multi-auth` | single-step-sms, dual-step-sms | `choose_auth` |
| `wayfinder-sample/app-native` | registration, registration-autosignin | `prompt_credentials` |
| `wayfinder-sample/redirect` | registration | `prompt_credentials` |
| Console `templates.json` | Basic Sign-up | `prompt_credentials` |
| Console `templates.json` | Basic + Social Sign-up | `choose_auth` |
| Console `templates.json` | Basic + Passkey Sign-up | `choose_registration_method` |
| Console `templates.json` | Basic + Social + SMS Sign-up | `choose_auth` |
| Console `templates.json` | Full Profile Sign-up | `prompt_registration` |

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4660


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Registration flows now handle credential authentication failures more gracefully.
  * Failed authentication returns you to the relevant credential or authentication-method prompt, allowing you to retry or choose another option.
  * Improved failure handling across basic, social, passkey, SMS, full-profile, and sample registration flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->