### PR TITLE
Restore executor-declared outcome handles when loading a flow

### DIFF
--- a/frontend/apps/console/src/features/flows/data/executors.json
+++ b/frontend/apps/console/src/features/flows/data/executors.json
@@ -950,7 +950,8 @@
         "executor": {
           "name": "SessionSignOutExecutor"
         },
-        "onSuccess": ""
+        "onSuccess": "",
+        "onIncomplete": ""
       },
       "properties": {
         "promptOnSignOut": false
@@ -972,7 +973,9 @@
       "action": {
         "type": "EXECUTOR",
         "executor": {"name": "PreDeleteExecutor", "mode": "revoke_all"},
-        "onSuccess": ""
+        "onSuccess": "",
+        "onFailure": "",
+        "onIncomplete": ""
       }
     }
   },
@@ -1029,7 +1032,8 @@
       "action": {
         "type": "EXECUTOR",
         "executor": {"name": "UserDeleteExecutor"},
-        "onSuccess": ""
+        "onSuccess": "",
+        "onFailure": ""
       }
     }
   }

--- a/frontend/apps/console/src/features/flows/utils/__tests__/flowToCanvasTransformer.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/flowToCanvasTransformer.test.ts
@@ -142,6 +142,81 @@ describe('flowToCanvasTransformer', () => {
         expect(result.nodes[0].data.action?.onIncomplete).toBe('incomplete-node');
       });
 
+      it('should restore the branching outcomes the executor declares when the flow omits them', () => {
+        // A flow only persists an outcome that was wired to an edge, so a node saved without a
+        // failure/incomplete connection came back without the keys that drive its output handles.
+        const flowData = createBaseFlowData([
+          {
+            id: 'invite-node',
+            type: 'TASK_EXECUTION',
+            executor: {name: 'InviteExecutor', mode: 'generate'},
+            onSuccess: 'next-node',
+            layout: {position: {x: 300, y: 0}, size: {width: 200, height: 100}},
+          },
+        ]);
+
+        const result = transformFlowToCanvas(flowData);
+
+        expect(result.nodes[0].data.action).toMatchObject({
+          onSuccess: 'next-node',
+          onFailure: '',
+          onIncomplete: '',
+        });
+      });
+
+      it('should keep the persisted target over the restored default outcome', () => {
+        const flowData = createBaseFlowData([
+          {
+            id: 'invite-node',
+            type: 'TASK_EXECUTION',
+            executor: {name: 'InviteExecutor', mode: 'generate'},
+            onSuccess: 'next-node',
+            onFailure: 'failure-node',
+            layout: {position: {x: 300, y: 0}, size: {width: 200, height: 100}},
+          },
+        ]);
+
+        const result = transformFlowToCanvas(flowData);
+
+        expect(result.nodes[0].data.action?.onFailure).toBe('failure-node');
+        expect(result.nodes[0].data.action?.onIncomplete).toBe('');
+      });
+
+      it('should not restore branching outcomes for an executor that declares none', () => {
+        const flowData = createBaseFlowData([
+          {
+            id: 'revoke-node',
+            type: 'TASK_EXECUTION',
+            executor: {name: 'SessionRevocationExecutor'},
+            onSuccess: 'next-node',
+            layout: {position: {x: 300, y: 0}, size: {width: 200, height: 100}},
+          },
+        ]);
+
+        const result = transformFlowToCanvas(flowData);
+
+        expect(result.nodes[0].data.action).not.toHaveProperty('onFailure');
+        expect(result.nodes[0].data.action).not.toHaveProperty('onIncomplete');
+      });
+
+      it('should keep only the persisted outcomes for an executor missing from the catalog', () => {
+        const flowData = createBaseFlowData([
+          {
+            id: 'unknown-node',
+            type: 'TASK_EXECUTION',
+            executor: {name: 'NotACatalogExecutor'},
+            onSuccess: 'next-node',
+            onFailure: 'failure-node',
+            layout: {position: {x: 300, y: 0}, size: {width: 200, height: 100}},
+          },
+        ]);
+
+        const result = transformFlowToCanvas(flowData);
+
+        expect(result.nodes[0].data.action?.onFailure).toBe('failure-node');
+        expect(result.nodes[0].data.action).not.toHaveProperty('onIncomplete');
+      });
+
       it('should transform DECISION node correctly', () => {
         const flowData = createBaseFlowData([
           {

--- a/frontend/apps/console/src/features/flows/utils/flowToCanvasTransformer.ts
+++ b/frontend/apps/console/src/features/flows/utils/flowToCanvasTransformer.ts
@@ -4,6 +4,7 @@
 import type {Edge, Node} from '@xyflow/react';
 import {MarkerType} from '@xyflow/react';
 import VisualFlowConstants from '../constants/VisualFlowConstants';
+import executors from '../data/executors.json';
 import type {Element} from '../models/elements';
 import {ElementTypes} from '../models/elements';
 import type {FlowDefinitionResponse, FlowNode, FlowNodeAction, FlowPrompt} from '../models/responses';
@@ -66,6 +67,77 @@ const DEFAULT_LAYOUT = {
   height: 100,
   position: {x: 0, y: 0},
 };
+
+/**
+ * Branching outcomes whose presence on a node's action drives the failure/incomplete output handles
+ */
+const BRANCHING_OUTCOME_KEYS = ['onFailure', 'onIncomplete'] as const;
+
+/**
+ * Shape of an executor definition read from the resource catalog
+ */
+type ExecutorDefinition = {
+  data?: {
+    action?: {
+      executor?: {name?: string; mode?: string};
+      onFailure?: string;
+      onIncomplete?: string;
+    };
+  };
+};
+
+/**
+ * Builds the catalog lookup key for an executor. Mode is part of the key because the same executor
+ * can declare different outcomes per mode (e.g. `OTPExecutor` generate vs verify).
+ */
+function getExecutorKey(name?: string, mode?: string): string {
+  return `${name ?? ''}::${mode ?? ''}`;
+}
+
+/**
+ * Branching outcomes each executor declares, keyed by executor name and mode.
+ *
+ * Supporting an outcome is a property of the executor definition, not of whichever edges happened
+ * to be connected when the flow was saved, so this is the authoritative source on load.
+ */
+const EXECUTOR_DECLARED_OUTCOMES: Map<string, string[]> = new Map(
+  (executors as ExecutorDefinition[]).map((definition: ExecutorDefinition) => {
+    const action = definition.data?.action;
+
+    return [
+      getExecutorKey(action?.executor?.name, action?.executor?.mode),
+      BRANCHING_OUTCOME_KEYS.filter((key: string) => action?.[key as 'onFailure' | 'onIncomplete'] !== undefined),
+    ];
+  }),
+);
+
+/**
+ * Resolves the branching outcome keys for a TASK_EXECUTION node.
+ *
+ * A flow only persists an outcome key when it was wired to an edge at save time, so a node saved
+ * without a failure/incomplete connection loses the key and the canvas stops rendering its handle.
+ * Re-deriving the keys the executor declares keeps those handles available on every load, while
+ * persisted targets still win over the empty defaults. Nodes whose executor is not in the catalog
+ * keep exactly the keys the flow persisted.
+ */
+function resolveBranchingOutcomes(apiNode: FlowNode): Record<string, string> {
+  const outcomes: Record<string, string> = {};
+  const declaredOutcomes = EXECUTOR_DECLARED_OUTCOMES.get(
+    getExecutorKey(apiNode.executor?.name, apiNode.executor?.mode as string | undefined),
+  );
+
+  declaredOutcomes?.forEach((key: string) => {
+    outcomes[key] = '';
+  });
+
+  BRANCHING_OUTCOME_KEYS.forEach((key: 'onFailure' | 'onIncomplete') => {
+    if (apiNode[key] !== undefined) {
+      outcomes[key] = apiNode[key] as string;
+    }
+  });
+
+  return outcomes;
+}
 
 /**
  * Normalizes INPUT element properties to top-level format.
@@ -264,11 +336,10 @@ function transformNodeToCanvas(apiNode: FlowNode): CanvasNode {
         type: 'EXECUTOR',
         executor: apiNode.executor,
         onSuccess: apiNode.onSuccess,
-        // Only carry the branching outcomes the node actually declares. Their presence drives
-        // the failure/incomplete output handles, so a node without them stays single-outcome
-        // rather than showing a dangling handle.
-        ...(apiNode.onFailure !== undefined ? {onFailure: apiNode.onFailure} : {}),
-        ...(apiNode.onIncomplete !== undefined ? {onIncomplete: apiNode.onIncomplete} : {}),
+        // Carry the branching outcomes the executor declares, not just the ones the flow
+        // persisted. Their presence drives the failure/incomplete output handles, so an executor
+        // that supports them keeps its handles even when they were never connected.
+        ...resolveBranchingOutcomes(apiNode),
       },
     };
 


### PR DESCRIPTION
Failure/incomplete output handles render from key presence in a node's persisted `action` object, but a flow only persists `onFailure`/`onIncomplete` when they were wired to an edge. A node saved without those connections came back without the keys, so the handles disappeared permanently.

On load, the branching outcome keys are now derived from the executor catalog (by executor name and mode) rather than from whatever survived the save. Persisted targets still win over the empty defaults; a node whose executor is not in the catalog keeps exactly the keys the flow persisted.

Also adds the outcome keys missing from three catalog entries, matching the statuses those executors emit: `onIncomplete` for `SessionSignOutExecutor`, `onFailure`/`onIncomplete` for `PreDeleteExecutor` (`revoke_all`), and `onFailure` for `UserDeleteExecutor`.

Fixes #4671

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added failure and incomplete outcome handling for session sign-out and pre-delete flow steps.
  * Added failure handling for user-delete steps.
  * Flow editing now restores supported failure and incomplete branches when they are not included in saved flow data.
  * Existing branch connections are preserved, while unsupported outcomes remain hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->