### PR TITLE
Restrict OpenID4VCI credential issuance to wallet applications

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -256,8 +256,8 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	dpopVerifier := dpop.Initialize(oauthCfg, jti.Initialize(runtimeStoreProvider), runtimeCryptoSvc)
 
 	openid4vpSvc, openid4vpDefSvc, openid4vciCredSvc, exporters :=
-		initializeVCServices(ctx, logger, mux, runtimeCryptoSvc, configCryptoSvc, jwtService, userService,
-			ouService, dpopVerifier, runtimeStoreProvider, exporters)
+		initializeVCServices(ctx, logger, mux, runtimeCryptoSvc, configCryptoSvc, jwtService,
+			ouService, runtimeStoreProvider, exporters)
 
 	defaultProvider := defaultprovider.Initialize(entityService, passkeyService,
 		otpCoreService, magicLinkService, openid4vpSvc, federatedAuths)
@@ -469,11 +469,17 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	fatalOnError(ctx, logger, err, "Failed to initialize flow execution service")
 
 	// Initialize OAuth services.
-	err = oauth.Initialize(mux, actorProvider, authnProvider, jwtService, jweService,
+	tokenValidator, err := oauth.Initialize(mux, actorProvider, authnProvider, jwtService, jweService,
 		flowExecService, observabilitySvc, runtimeCryptoSvc, ouService, attributeCacheService, authZService,
 		resourceServerProvider, i18nService, idpService, dpopVerifier,
 		runtimeStoreProvider, transactioner, oauthCfg)
 	fatalOnError(ctx, logger, err, "Failed to initialize OAuth services")
+
+	// Initialized after the OAuth services because credential issuance validates the presented
+	// access token with the OAuth token validator and resolves the wallet application behind it.
+	_, err = openid4vci.Initialize(mux, runtimeCryptoSvc, tokenValidator, userService, dpopVerifier,
+		openid4vciCredSvc, actorProvider, runtimeStoreProvider)
+	fatalOnError(ctx, logger, err, "Failed to initialize OpenID4VCI issuer service")
 
 	if oauthCfg.OAuth.DCR.IsEnabled() {
 		// Register OAuth2 DCR service.
@@ -628,14 +634,14 @@ func initializeFlowCoreAndExecutor(
 	return flowFactory, execRegistry, interceptorRegistry, graphBuilder
 }
 
-// initializeVCServices initializes the OpenID4VP verifier and OpenID4VCI issuer services,
-// appending their declarative-resource exporters to exporters.
+// initializeVCServices initializes the OpenID4VP verifier and the credential-configuration
+// service, appending their declarative-resource exporters to exporters. The OpenID4VCI issuer
+// itself is initialized later, once the application service it depends on exists.
 func initializeVCServices(
 	ctx context.Context, logger *log.Logger, mux *http.ServeMux,
 	runtimeCrypto providers.RuntimeCryptoProvider, configCrypto kmprovider.ConfigCryptoProvider,
-	jwtService jwt.JWTServiceInterface, userService user.UserServiceInterface,
+	jwtService jwt.JWTServiceInterface,
 	ouService ou.OrganizationUnitServiceInterface,
-	dpopVerifier dpop.VerifierInterface,
 	runtimeStoreProvider providers.RuntimeStoreProvider,
 	exporters []declarativeresource.ResourceExporter,
 ) (openid4vp.OpenID4VPServiceInterface, presentation.PresentationDefinitionServiceInterface,
@@ -655,10 +661,6 @@ func initializeVCServices(
 	if vciCredExp != nil {
 		exporters = append(exporters, vciCredExp)
 	}
-
-	_, err = openid4vci.Initialize(mux, runtimeCrypto, jwtService, userService, dpopVerifier, openid4vciCredSvc,
-		runtimeStoreProvider)
-	fatalOnError(ctx, logger, err, "Failed to initialize OpenID4VCI issuer service")
 
 	return openid4vpSvc, openid4vpDefSvc, openid4vciCredSvc, exporters
 }

--- a/backend/internal/oauth/init.go
+++ b/backend/internal/oauth/init.go
@@ -55,7 +55,7 @@ func Initialize(
 	runtimeStore providers.RuntimeStoreProvider,
 	transactioner providers.Transactioner,
 	cfg oauthconfig.Config,
-) error {
+) (tokenservice.TokenValidatorInterface, error) {
 	jwks.Initialize(mux, runtimeCrypto)
 	httpClient := syshttp.NewHTTPClientWithCheckRedirect(func(req *http.Request, _ []*http.Request) error {
 		return syshttp.IsSSRFSafeURL(req.URL.String())
@@ -82,7 +82,7 @@ func Initialize(
 	oauth2AuthzService, err := oauth2authz.Initialize(mux, actorProvider, resourceService,
 		jwtService, flowExecService, parService, revocationSvc, cfg, runtimeStore, transactioner)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var cibaService ciba.CIBAServiceInterface
@@ -108,5 +108,5 @@ func Initialize(
 	if cfg.OAuth.Logout.IsEnabled() {
 		oauth2logout.Initialize(mux, jwtService, actorProvider, flowExecService, runtimeStore, cfg)
 	}
-	return nil
+	return tokenValidator, nil
 }

--- a/backend/internal/openid4vci/init.go
+++ b/backend/internal/openid4vci/init.go
@@ -13,8 +13,8 @@ import (
 	"time"
 
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/dpop"
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/tokenservice"
 	"github.com/thunder-id/thunderid/internal/system/config"
-	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
 	"github.com/thunder-id/thunderid/internal/system/middleware"
 	"github.com/thunder-id/thunderid/internal/user"
 	"github.com/thunder-id/thunderid/internal/vc/credential"
@@ -23,11 +23,14 @@ import (
 
 // Initialize wires the OpenID4VCI issuer engine and the wallet-facing endpoints.
 // credSvc is the already-initialized credential-configuration service (owned by the caller).
+// tokenValidator validates the OAuth 2.0 access token presented at the credential endpoint.
+// actorProvider resolves the wallet application behind an issuance request's access token.
 // When no signing key is configured, issuance is disabled and Initialize returns nil without error.
 func Initialize(
 	mux *http.ServeMux, cryptoProvider providers.RuntimeCryptoProvider,
-	jwtService jwt.JWTServiceInterface, userService user.UserServiceInterface,
+	tokenValidator tokenservice.TokenValidatorInterface, userService user.UserServiceInterface,
 	dpopVerifier dpop.VerifierInterface, credSvc credential.CredentialConfigurationServiceInterface,
+	actorProvider providers.ActorProvider,
 	store providers.RuntimeStoreProvider,
 ) (OpenID4VCIServiceInterface, error) {
 	runtime := config.GetServerRuntime()
@@ -88,7 +91,7 @@ func Initialize(
 		EnforceScope:         cfg.EnforceScope,
 	}, cryptoProvider, providers.KeyRef{KeyID: cfg.SigningKeyID},
 		signingKey.Algorithm, signingKey.Thumbprint, x5c,
-		newOpenID4VCIStore(store), jwtService, userService, credSvc)
+		newOpenID4VCIStore(store), tokenValidator, userService, credSvc, actorProvider)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/openid4vci/init_test.go
+++ b/backend/internal/openid4vci/init_test.go
@@ -54,7 +54,7 @@ func (s *InitTestSuite) TestInitializeDisabledWithoutSigningKey() {
 	s.Require().NoError(config.InitializeServerRuntime("", &config.Config{}))
 	defer config.ResetServerRuntime()
 
-	svc, err := Initialize(http.NewServeMux(), nil, nil, nil, nil, nil, nil)
+	svc, err := Initialize(http.NewServeMux(), nil, nil, nil, nil, nil, nil, nil)
 	s.Require().NoError(err)
 	s.Nil(svc)
 }

--- a/backend/internal/openid4vci/service.go
+++ b/backend/internal/openid4vci/service.go
@@ -12,9 +12,11 @@ import (
 	"fmt"
 	"math/big"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/tokenservice"
 	"github.com/thunder-id/thunderid/internal/system/jose/jws"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
 	"github.com/thunder-id/thunderid/internal/system/jose/sdjwt"
@@ -36,6 +38,14 @@ type OpenID4VCIServiceInterface interface {
 
 var _ OpenID4VCIServiceInterface = (*openid4vciService)(nil)
 
+// templateProperty is the inbound-client property holding the application template identifier.
+// It mirrors the key the application service persists (application.propTemplate).
+const templateProperty = "template"
+
+// walletTemplates are the application template identifiers assigned to OpenID4VCI wallet
+// applications. Credential issuance is restricted to clients registered under one of these.
+var walletTemplates = []string{"wallet", "wallet-embedded"}
+
 // openid4vciService drives the OpenID4VCI issuer: it advertises issuer metadata, issues
 // c_nonces, and issues SD-JWT VCs bound to the holder key after validating the
 // access token and holder proof.
@@ -47,9 +57,10 @@ type openid4vciService struct {
 	kid            string
 	x5c            []string
 	store          openID4VCIStoreInterface
-	jwtService     jwt.JWTServiceInterface
+	tokenValidator tokenservice.TokenValidatorInterface
 	userService    user.UserServiceInterface
 	creds          credential.CredentialConfigurationServiceInterface
+	actors         providers.ActorProvider
 }
 
 // newOpenID4VCIService creates an OpenID4VCI issuer engine.
@@ -58,11 +69,12 @@ func newOpenID4VCIService(
 	cryptoProvider providers.RuntimeCryptoProvider, signingKeyRef providers.KeyRef,
 	signingAlg, kid string, x5c []string,
 	store openID4VCIStoreInterface,
-	jwtService jwt.JWTServiceInterface, userService user.UserServiceInterface,
+	tokenValidator tokenservice.TokenValidatorInterface, userService user.UserServiceInterface,
 	creds credential.CredentialConfigurationServiceInterface,
+	actors providers.ActorProvider,
 ) (OpenID4VCIServiceInterface, error) {
 	if cryptoProvider == nil || store == nil ||
-		jwtService == nil || userService == nil || creds == nil {
+		tokenValidator == nil || userService == nil || creds == nil || actors == nil {
 		return nil, fmt.Errorf("%w: required issuer dependencies are missing", ErrPolicy)
 	}
 	if cfg.CredentialIssuer == "" {
@@ -76,9 +88,10 @@ func newOpenID4VCIService(
 		kid:            kid,
 		x5c:            x5c,
 		store:          store,
-		jwtService:     jwtService,
+		tokenValidator: tokenValidator,
 		userService:    userService,
 		creds:          creds,
+		actors:         actors,
 	}, nil
 }
 
@@ -167,18 +180,17 @@ func (s *openid4vciService) IssueCredential(
 	if accessToken == "" {
 		return nil, fmt.Errorf("%w: missing access token", ErrInvalidToken)
 	}
-	if svcErr := s.jwtService.VerifyJWT(ctx, accessToken, "", ""); svcErr != nil {
-		return nil, fmt.Errorf("%w: access token verification failed", ErrInvalidToken)
-	}
-	payload, err := jwt.DecodeJWTPayload(accessToken)
+	// Validated as an OAuth 2.0 access token (RFC 9068 typ, issuer, required claims, revocation),
+	// so other server-signed JWTs such as authentication assertions cannot be used for issuance.
+	claims, err := s.tokenValidator.ValidateAccessToken(ctx, accessToken)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidToken, err)
 	}
-	subject, _ := payload["sub"].(string)
-	if subject == "" {
-		return nil, fmt.Errorf("%w: access token missing subject", ErrInvalidToken)
+	subject := claims.Sub
+	if err := s.verifyWalletClient(ctx, claims.ClientID); err != nil {
+		return nil, err
 	}
-	scopes := strings.Fields(scopeString(payload))
+	scopes := claims.Scopes
 
 	var req CredentialRequest
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -203,7 +215,7 @@ func (s *openid4vciService) IssueCredential(
 		return nil, err
 	}
 
-	claims, err := s.resolveClaims(ctx, subject, cred.SDClaims)
+	sdClaims, err := s.resolveClaims(ctx, subject, cred.SDClaims)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +243,7 @@ func (s *openid4vciService) IssueCredential(
 			VCT:             cred.VCT,
 			IssuedAt:        now,
 			ExpiresAt:       now.Add(validity),
-			SelectiveClaims: claims,
+			SelectiveClaims: sdClaims,
 			AlwaysVisible:   map[string]interface{}{"sub": subject},
 			ConfirmationJWK: holderJWK,
 		}, func(signingInput string) ([]byte, error) {
@@ -337,6 +349,25 @@ func credentialDisplay(name, description string, d *credential.CredentialDisplay
 		return nil
 	}
 	return []interface{}{entry}
+}
+
+// verifyWalletClient resolves the application registered behind the access token's client_id and
+// requires it to be a wallet application. Credential issuance is reserved for wallets, so a token
+// minted for an unrelated application cannot be replayed against the credential endpoint.
+func (s *openid4vciService) verifyWalletClient(ctx context.Context, clientID string) error {
+	oauthClient, svcErr := s.actors.GetOAuthClientByClientID(ctx, clientID)
+	if svcErr != nil || oauthClient == nil {
+		return fmt.Errorf("%w: unknown client", ErrInvalidToken)
+	}
+	inbound, svcErr := s.actors.GetInboundClientByID(ctx, oauthClient.ID)
+	if svcErr != nil || inbound == nil {
+		return fmt.Errorf("%w: unknown application for client", ErrInvalidToken)
+	}
+	template, _ := inbound.Properties[templateProperty].(string)
+	if !slices.Contains(walletTemplates, template) {
+		return fmt.Errorf("%w: client is not a wallet application", ErrInvalidToken)
+	}
+	return nil
 }
 
 // authorizedCredential resolves the credential configuration the request is

--- a/backend/internal/openid4vci/service_test.go
+++ b/backend/internal/openid4vci/service_test.go
@@ -21,14 +21,16 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/tokenservice"
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
 	"github.com/thunder-id/thunderid/internal/system/kmprovider/defaultkm"
 	"github.com/thunder-id/thunderid/internal/user"
 	"github.com/thunder-id/thunderid/internal/vc/credential"
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
+	"github.com/thunder-id/thunderid/tests/mocks/actorprovidermock"
 	"github.com/thunder-id/thunderid/tests/mocks/crypto/cryptomock"
-	"github.com/thunder-id/thunderid/tests/mocks/jose/jwtmock"
+	"github.com/thunder-id/thunderid/tests/mocks/oauth/oauth2/tokenservicemock"
 	"github.com/thunder-id/thunderid/tests/mocks/usermock"
 	"github.com/thunder-id/thunderid/tests/mocks/vc/credentialmock"
 )
@@ -44,15 +46,16 @@ func TestServiceTestSuite(t *testing.T) {
 func (s *ServiceTestSuite) TestNewOpenID4VCIService() {
 	provider := cryptomock.NewRuntimeCryptoProviderMock(s.T())
 	store := newOpenID4VCIStoreInterfaceMock(s.T())
-	jwtSvc := jwtmock.NewJWTServiceInterfaceMock(s.T())
+	tokenVal := tokenservicemock.NewTokenValidatorInterfaceMock(s.T())
 	userSvc := usermock.NewUserServiceInterfaceMock(s.T())
 	creds := credentialmock.NewCredentialConfigurationServiceInterfaceMock(s.T())
+	apps := actorprovidermock.NewActorProviderMock(s.T())
 
 	s.Run("Success", func() {
 		svc, err := newOpenID4VCIService(
 			serviceConfig{CredentialIssuer: testIssuer},
 			provider, providers.KeyRef{}, "ES256", "", nil,
-			store, jwtSvc, userSvc, creds)
+			store, tokenVal, userSvc, creds, apps)
 		s.Require().NoError(err)
 		s.Require().NotNil(svc)
 	})
@@ -61,7 +64,16 @@ func (s *ServiceTestSuite) TestNewOpenID4VCIService() {
 		svc, err := newOpenID4VCIService(
 			serviceConfig{CredentialIssuer: testIssuer},
 			nil, providers.KeyRef{}, "ES256", "", nil,
-			store, jwtSvc, userSvc, creds)
+			store, tokenVal, userSvc, creds, apps)
+		s.ErrorIs(err, ErrPolicy)
+		s.Nil(svc)
+	})
+
+	s.Run("MissingApplicationResolver", func() {
+		svc, err := newOpenID4VCIService(
+			serviceConfig{CredentialIssuer: testIssuer},
+			provider, providers.KeyRef{}, "ES256", "", nil,
+			store, tokenVal, userSvc, creds, nil)
 		s.ErrorIs(err, ErrPolicy)
 		s.Nil(svc)
 	})
@@ -70,7 +82,7 @@ func (s *ServiceTestSuite) TestNewOpenID4VCIService() {
 		svc, err := newOpenID4VCIService(
 			serviceConfig{},
 			provider, providers.KeyRef{}, "ES256", "", nil,
-			store, jwtSvc, userSvc, creds)
+			store, tokenVal, userSvc, creds, apps)
 		s.ErrorIs(err, ErrPolicy)
 		s.Nil(svc)
 	})
@@ -408,6 +420,37 @@ func newTestVerifyCryptoProvider(t *testing.T) *cryptomock.RuntimeCryptoProvider
 	return provider
 }
 
+// testWalletClientID is the client_id carried by access tokens in issuance tests.
+const testWalletClientID = "wallet-client"
+
+// testSubject is the access-token subject used across issuance tests.
+const testSubject = "u1"
+
+// stubAccessToken returns an opaque token string plus a validator that accepts it and reports
+// testSubject with the given client and scopes. Access-token shape (typ, issuer, required claims,
+// revocation) is the OAuth token validator's contract and is covered by its own tests.
+func stubAccessToken(t *testing.T, ctx context.Context, clientID string, scopes ...string,
+) (string, *tokenservicemock.TokenValidatorInterfaceMock) {
+	t.Helper()
+	const token = "access-token"
+	tv := tokenservicemock.NewTokenValidatorInterfaceMock(t)
+	tv.EXPECT().ValidateAccessToken(ctx, token).
+		Return(&tokenservice.AccessTokenClaims{Sub: testSubject, ClientID: clientID, Scopes: scopes}, nil)
+	return token, tv
+}
+
+// walletApps returns an application resolver that resolves testWalletClientID to a wallet
+// application, so issuance proceeds past the wallet-client check.
+func walletApps(t *testing.T, ctx context.Context) *actorprovidermock.ActorProviderMock {
+	t.Helper()
+	apps := actorprovidermock.NewActorProviderMock(t)
+	apps.EXPECT().GetOAuthClientByClientID(ctx, testWalletClientID).
+		Return(&providers.OAuthClient{ID: "app-1", ClientID: testWalletClientID}, nil)
+	apps.EXPECT().GetInboundClientByID(ctx, "app-1").
+		Return(&providers.InboundClient{ID: "app-1", Properties: map[string]interface{}{"template": "wallet"}}, nil)
+	return apps
+}
+
 // encodeJWT assembles a compact JWS from a header and payload, appending sig as
 // the (already base64url-encoded) signature segment. Useful for crafting proofs
 // whose header/payload exercise specific validation branches.
@@ -547,53 +590,56 @@ func (s *CredentialTestSuite) TestIssueCredentialErrors() {
 		s.ErrorIs(err, ErrInvalidToken)
 	})
 
-	s.Run("VerifyFails", func() {
-		jwtSvc := jwtmock.NewJWTServiceInterfaceMock(s.T())
-		jwtSvc.EXPECT().VerifyJWT(ctx, "tok", "", "").Return(&tidcommon.ServiceError{Code: "x"})
-		svc := &openid4vciService{cfg: serviceConfig{BatchSize: 5}, jwtService: jwtSvc}
+	// A token the OAuth validator rejects (wrong typ, wrong issuer, revoked, missing claims)
+	// never reaches issuance.
+	s.Run("ValidationFails", func() {
+		tokenVal := tokenservicemock.NewTokenValidatorInterfaceMock(s.T())
+		tokenVal.EXPECT().ValidateAccessToken(ctx, "tok").Return(nil, errors.New("invalid token type"))
+		svc := &openid4vciService{cfg: serviceConfig{BatchSize: 5}, tokenValidator: tokenVal}
 		_, err := svc.IssueCredential(ctx, "tok", nil)
 		s.ErrorIs(err, ErrInvalidToken)
 	})
 
-	s.Run("MissingSubject", func() {
-		token := makeToken(s.T(), map[string]any{})
-		jwtSvc := jwtmock.NewJWTServiceInterfaceMock(s.T())
-		jwtSvc.EXPECT().VerifyJWT(ctx, token, "", "").Return(nil)
-		svc := &openid4vciService{cfg: serviceConfig{BatchSize: 5}, jwtService: jwtSvc}
+	// Fail closed when the token carries no client to resolve a wallet application from.
+	s.Run("EmptyClientID", func() {
+		token, tokenVal := stubAccessToken(s.T(), ctx, "")
+		apps := actorprovidermock.NewActorProviderMock(s.T())
+		apps.EXPECT().GetOAuthClientByClientID(ctx, "").Return(nil, &tidcommon.ServiceError{Code: "x"})
+		svc := &openid4vciService{cfg: serviceConfig{BatchSize: 5}, tokenValidator: tokenVal, actors: apps}
 		_, err := svc.IssueCredential(ctx, token, []byte("{}"))
 		s.ErrorIs(err, ErrInvalidToken)
 	})
 
 	s.Run("BadBody", func() {
-		token := makeToken(s.T(), map[string]any{"sub": "u1"})
-		jwtSvc := jwtmock.NewJWTServiceInterfaceMock(s.T())
-		jwtSvc.EXPECT().VerifyJWT(ctx, token, "", "").Return(nil)
-		svc := &openid4vciService{cfg: serviceConfig{BatchSize: 5}, jwtService: jwtSvc}
+		token, tokenVal := stubAccessToken(s.T(), ctx, testWalletClientID)
+		svc := &openid4vciService{
+			cfg: serviceConfig{BatchSize: 5}, tokenValidator: tokenVal, actors: walletApps(s.T(), ctx),
+		}
 		_, err := svc.IssueCredential(ctx, token, []byte("not-json"))
 		s.ErrorIs(err, ErrInvalidRequest)
 	})
 
 	s.Run("MissingProof", func() {
-		token := makeToken(s.T(), map[string]any{"sub": "u1", "scope": "eudi-pid"})
-		jwtSvc := jwtmock.NewJWTServiceInterfaceMock(s.T())
-		jwtSvc.EXPECT().VerifyJWT(ctx, token, "", "").Return(nil)
+		token, tokenVal := stubAccessToken(s.T(), ctx, testWalletClientID, "eudi-pid")
 		creds := credentialmock.NewCredentialConfigurationServiceInterfaceMock(s.T())
 		creds.EXPECT().GetCredentialConfigurationByHandle(ctx, "eudi-pid").
 			Return(&credential.CredentialConfigurationDTO{Handle: "eudi-pid", VCT: "v"}, nil)
-		svc := &openid4vciService{cfg: serviceConfig{BatchSize: 5}, jwtService: jwtSvc, creds: creds}
+		svc := &openid4vciService{
+			cfg: serviceConfig{BatchSize: 5}, tokenValidator: tokenVal, creds: creds, actors: walletApps(s.T(), ctx),
+		}
 		body, _ := json.Marshal(CredentialRequest{CredentialConfigurationID: "eudi-pid"})
 		_, err := svc.IssueCredential(ctx, token, body)
 		s.ErrorIs(err, ErrInvalidProof)
 	})
 
 	s.Run("BatchSizeExceeded", func() {
-		token := makeToken(s.T(), map[string]any{"sub": "u1", "scope": "eudi-pid"})
-		jwtSvc := jwtmock.NewJWTServiceInterfaceMock(s.T())
-		jwtSvc.EXPECT().VerifyJWT(ctx, token, "", "").Return(nil)
+		token, tokenVal := stubAccessToken(s.T(), ctx, testWalletClientID, "eudi-pid")
 		creds := credentialmock.NewCredentialConfigurationServiceInterfaceMock(s.T())
 		creds.EXPECT().GetCredentialConfigurationByHandle(ctx, "eudi-pid").
 			Return(&credential.CredentialConfigurationDTO{Handle: "eudi-pid", VCT: "v"}, nil)
-		svc := &openid4vciService{cfg: serviceConfig{BatchSize: 1}, jwtService: jwtSvc, creds: creds}
+		svc := &openid4vciService{
+			cfg: serviceConfig{BatchSize: 1}, tokenValidator: tokenVal, creds: creds, actors: walletApps(s.T(), ctx),
+		}
 		body, _ := json.Marshal(CredentialRequest{
 			CredentialConfigurationID: "eudi-pid",
 			Proofs:                    &Proofs{JWT: []string{"a", "b"}},
@@ -603,25 +649,66 @@ func (s *CredentialTestSuite) TestIssueCredentialErrors() {
 	})
 }
 
-func (s *CredentialTestSuite) TestIssueCredentialBadTokenPayload() {
+// The credential endpoint is reserved for wallet applications: a token minted for any other
+// registered client must not be usable to mint a credential.
+func (s *CredentialTestSuite) TestIssueCredentialNonWalletClient() {
 	ctx := context.Background()
-	token := "e30.!!!.sig"
-	jwtSvc := jwtmock.NewJWTServiceInterfaceMock(s.T())
-	jwtSvc.EXPECT().VerifyJWT(ctx, token, "", "").Return(nil)
-	svc := &openid4vciService{cfg: serviceConfig{BatchSize: 5}, jwtService: jwtSvc}
-	_, err := svc.IssueCredential(ctx, token, []byte("{}"))
-	s.ErrorIs(err, ErrInvalidToken)
+
+	s.Run("NonWalletTemplate", func() {
+		token, tokenVal := stubAccessToken(s.T(), ctx, testWalletClientID, "eudi-pid")
+		apps := actorprovidermock.NewActorProviderMock(s.T())
+		apps.EXPECT().GetOAuthClientByClientID(ctx, testWalletClientID).
+			Return(&providers.OAuthClient{ID: "app-1", ClientID: testWalletClientID}, nil)
+		apps.EXPECT().GetInboundClientByID(ctx, "app-1").
+			Return(&providers.InboundClient{ID: "app-1", Properties: map[string]interface{}{"template": "react"}}, nil)
+		svc := &openid4vciService{cfg: serviceConfig{BatchSize: 5}, tokenValidator: tokenVal, actors: apps}
+		body, _ := json.Marshal(CredentialRequest{CredentialConfigurationID: "eudi-pid"})
+		_, err := svc.IssueCredential(ctx, token, body)
+		s.ErrorIs(err, ErrInvalidToken)
+	})
+
+	s.Run("UnknownClient", func() {
+		token, tokenVal := stubAccessToken(s.T(), ctx, testWalletClientID, "eudi-pid")
+		apps := actorprovidermock.NewActorProviderMock(s.T())
+		apps.EXPECT().GetOAuthClientByClientID(ctx, testWalletClientID).
+			Return(nil, &tidcommon.ServiceError{Code: "x"})
+		svc := &openid4vciService{cfg: serviceConfig{BatchSize: 5}, tokenValidator: tokenVal, actors: apps}
+		body, _ := json.Marshal(CredentialRequest{CredentialConfigurationID: "eudi-pid"})
+		_, err := svc.IssueCredential(ctx, token, body)
+		s.ErrorIs(err, ErrInvalidToken)
+	})
+
+	s.Run("EmbeddedWalletTemplateAccepted", func() {
+		token, tokenVal := stubAccessToken(s.T(), ctx, testWalletClientID, "eudi-pid")
+		apps := actorprovidermock.NewActorProviderMock(s.T())
+		apps.EXPECT().GetOAuthClientByClientID(ctx, testWalletClientID).
+			Return(&providers.OAuthClient{ID: "app-1", ClientID: testWalletClientID}, nil)
+		apps.EXPECT().GetInboundClientByID(ctx, "app-1").
+			Return(&providers.InboundClient{
+				ID: "app-1", Properties: map[string]interface{}{"template": "wallet-embedded"},
+			}, nil)
+		creds := credentialmock.NewCredentialConfigurationServiceInterfaceMock(s.T())
+		creds.EXPECT().GetCredentialConfigurationByHandle(ctx, "eudi-pid").
+			Return(&credential.CredentialConfigurationDTO{Handle: "eudi-pid", VCT: "v"}, nil)
+		svc := &openid4vciService{
+			cfg: serviceConfig{BatchSize: 5}, tokenValidator: tokenVal, creds: creds, actors: apps,
+		}
+		body, _ := json.Marshal(CredentialRequest{CredentialConfigurationID: "eudi-pid"})
+		_, err := svc.IssueCredential(ctx, token, body)
+		// Passes the wallet-client gate and fails later, on the absent holder proof.
+		s.ErrorIs(err, ErrInvalidProof)
+	})
 }
 
 func (s *CredentialTestSuite) TestIssueCredentialUnauthorizedCredential() {
 	ctx := context.Background()
-	token := makeToken(s.T(), map[string]any{"sub": "u1", "scope": "missing"})
-	jwtSvc := jwtmock.NewJWTServiceInterfaceMock(s.T())
-	jwtSvc.EXPECT().VerifyJWT(ctx, token, "", "").Return(nil)
+	token, tokenVal := stubAccessToken(s.T(), ctx, testWalletClientID, "missing")
 	creds := credentialmock.NewCredentialConfigurationServiceInterfaceMock(s.T())
 	creds.EXPECT().GetCredentialConfigurationByHandle(ctx, "missing").
 		Return(nil, &tidcommon.ServiceError{Code: "x"})
-	svc := &openid4vciService{cfg: serviceConfig{BatchSize: 5}, jwtService: jwtSvc, creds: creds}
+	svc := &openid4vciService{
+		cfg: serviceConfig{BatchSize: 5}, tokenValidator: tokenVal, creds: creds, actors: walletApps(s.T(), ctx),
+	}
 	body, _ := json.Marshal(CredentialRequest{CredentialConfigurationID: "missing"})
 	_, err := svc.IssueCredential(ctx, token, body)
 	s.ErrorIs(err, ErrUnsupportedCredential)
@@ -630,17 +717,16 @@ func (s *CredentialTestSuite) TestIssueCredentialUnauthorizedCredential() {
 func (s *CredentialTestSuite) TestIssueCredentialVerifyProofsError() {
 	ctx := context.Background()
 	store := newStatefulStore(s.T())
-	token := makeToken(s.T(), map[string]any{"sub": "u1", "scope": "eudi-pid"})
-	jwtSvc := jwtmock.NewJWTServiceInterfaceMock(s.T())
-	jwtSvc.EXPECT().VerifyJWT(ctx, token, "", "").Return(nil)
+	token, tokenVal := stubAccessToken(s.T(), ctx, testWalletClientID, "eudi-pid")
 	creds := credentialmock.NewCredentialConfigurationServiceInterfaceMock(s.T())
 	creds.EXPECT().GetCredentialConfigurationByHandle(ctx, "eudi-pid").
 		Return(&credential.CredentialConfigurationDTO{Handle: "eudi-pid", VCT: "v"}, nil)
 	svc := &openid4vciService{
 		cfg:            serviceConfig{CredentialIssuer: testIssuer, ProofMaxAge: time.Minute, BatchSize: 5},
 		store:          store,
-		jwtService:     jwtSvc,
+		tokenValidator: tokenVal,
 		creds:          creds,
+		actors:         walletApps(s.T(), ctx),
 		cryptoProvider: newTestVerifyCryptoProvider(s.T()),
 	}
 
@@ -659,9 +745,7 @@ func (s *CredentialTestSuite) TestIssueCredentialResolveClaimsError() {
 	store := newStatefulStore(s.T())
 	nonce := "n"
 	s.Require().NoError(store.SaveNonce(ctx, nonce, &nonceRecord{ExpiresAt: time.Now().Add(time.Minute)}))
-	token := makeToken(s.T(), map[string]any{"sub": "u1", "scope": "eudi-pid"})
-	jwtSvc := jwtmock.NewJWTServiceInterfaceMock(s.T())
-	jwtSvc.EXPECT().VerifyJWT(ctx, token, "", "").Return(nil)
+	token, tokenVal := stubAccessToken(s.T(), ctx, testWalletClientID, "eudi-pid")
 	creds := credentialmock.NewCredentialConfigurationServiceInterfaceMock(s.T())
 	creds.EXPECT().GetCredentialConfigurationByHandle(ctx, "eudi-pid").
 		Return(&credential.CredentialConfigurationDTO{Handle: "eudi-pid", VCT: "v"}, nil)
@@ -670,9 +754,10 @@ func (s *CredentialTestSuite) TestIssueCredentialResolveClaimsError() {
 	svc := &openid4vciService{
 		cfg:            serviceConfig{CredentialIssuer: testIssuer, ProofMaxAge: time.Minute, BatchSize: 5},
 		store:          store,
-		jwtService:     jwtSvc,
+		tokenValidator: tokenVal,
 		userService:    userSvc,
 		creds:          creds,
+		actors:         walletApps(s.T(), ctx),
 		cryptoProvider: newTestVerifyCryptoProvider(s.T()),
 	}
 
@@ -691,9 +776,7 @@ func (s *CredentialTestSuite) TestIssueCredentialSignError() {
 	store := newStatefulStore(s.T())
 	nonce := "n"
 	s.Require().NoError(store.SaveNonce(ctx, nonce, &nonceRecord{ExpiresAt: time.Now().Add(time.Minute)}))
-	token := makeToken(s.T(), map[string]any{"sub": "u1", "scope": "eudi-pid"})
-	jwtSvc := jwtmock.NewJWTServiceInterfaceMock(s.T())
-	jwtSvc.EXPECT().VerifyJWT(ctx, token, "", "").Return(nil)
+	token, tokenVal := stubAccessToken(s.T(), ctx, testWalletClientID, "eudi-pid")
 
 	validity := 3600
 	creds := credentialmock.NewCredentialConfigurationServiceInterfaceMock(s.T())
@@ -715,9 +798,10 @@ func (s *CredentialTestSuite) TestIssueCredentialSignError() {
 		cryptoProvider: provider,
 		signingAlg:     "ES256",
 		store:          store,
-		jwtService:     jwtSvc,
+		tokenValidator: tokenVal,
 		userService:    userSvc,
 		creds:          creds,
+		actors:         walletApps(s.T(), ctx),
 	}
 
 	holderKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -745,9 +829,7 @@ func (s *CredentialTestSuite) TestIssueCredentialSuccess() {
 	nonce := "the-nonce"
 	s.Require().NoError(store.SaveNonce(ctx, nonce, &nonceRecord{ExpiresAt: time.Now().Add(time.Minute)}))
 
-	token := makeToken(s.T(), map[string]any{"sub": "u1", "scope": "eudi-pid"})
-	jwtSvc := jwtmock.NewJWTServiceInterfaceMock(s.T())
-	jwtSvc.EXPECT().VerifyJWT(ctx, token, "", "").Return(nil)
+	token, tokenVal := stubAccessToken(s.T(), ctx, testWalletClientID, "eudi-pid")
 
 	creds := credentialmock.NewCredentialConfigurationServiceInterfaceMock(s.T())
 	creds.EXPECT().GetCredentialConfigurationByHandle(ctx, "eudi-pid").
@@ -768,9 +850,10 @@ func (s *CredentialTestSuite) TestIssueCredentialSuccess() {
 		kid:            "kid",
 		x5c:            []string{base64.StdEncoding.EncodeToString([]byte("cert"))},
 		store:          store,
-		jwtService:     jwtSvc,
+		tokenValidator: tokenVal,
 		userService:    userSvc,
 		creds:          creds,
+		actors:         walletApps(s.T(), ctx),
 	}
 
 	holderKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

--- a/backend/pkg/thunderidengine/engine.go
+++ b/backend/pkg/thunderidengine/engine.go
@@ -180,7 +180,7 @@ func New(mux *http.ServeMux, opts ...Option) *Engine {
 	// resource provider is passed undecorated. Implicit no-resource requests that carry permission
 	// scopes are rejected (the provider resolves no server for an empty identifier); OIDC-only or
 	// scopeless requests do not need resource-server binding.
-	err = oauth.Initialize(mux, engineCtx.actorProvider, authnProviderManager, engineCtx.jwtService,
+	_, err = oauth.Initialize(mux, engineCtx.actorProvider, authnProviderManager, engineCtx.jwtService,
 		engineCtx.jweService, engineCtx.flowExecService, engineCtx.observabilitySvc, engineCtx.runtimeCryptoSvc,
 		engineCtx.ouProvider, engineCtx.attributeCacheService, engineCtx.authzProvider, engineCtx.resourceProvider,
 		engineCtx.i18nProvider, engineCtx.idpProvider, engineCtx.dpopVerifier, engineCtx.runtimeStoreProvider,

--- a/tests/integration/openid4vci/issuance_test.go
+++ b/tests/integration/openid4vci/issuance_test.go
@@ -189,10 +189,12 @@ func (ts *OpenID4VCITestSuite) TearDownSuite() {
 // createApp registers the OAuth application used to obtain user access tokens.
 func (ts *OpenID4VCITestSuite) createApp() string {
 	app := map[string]any{
-		"name":                      vciAppName,
-		"description":               "OpenID4VCI integration test app",
-		"ouId":                      ts.ouID,
-		"type":                      "fullstack",
+		"name":        vciAppName,
+		"description": "OpenID4VCI integration test app",
+		"ouId":        ts.ouID,
+		"type":        "mobile",
+		// Credential issuance is restricted to wallet applications.
+		"template":                  "wallet",
 		"authFlowId":                ts.authFlowID,
 		"isRegistrationFlowEnabled": false,
 		"allowedUserTypes":          []string{"openid4vci-test-person"},


### PR DESCRIPTION
### Purpose

The OpenID4VCI credential endpoint accepted any JWT signed by the server, including
authentication assertions that carry no `client_id` and no scope. Any authenticated user
could mint a Verifiable Credential of any configured type.

`POST /openid4vci/credential` now requires an OAuth 2.0 access token (`typ: at+jwt`) carrying
a `client_id`, and that client must resolve to an application created from the **Digital
Wallet** template (`wallet` or `wallet-embedded`).

### Approach

`IssueCredential` validates the `typ` header and `client_id` claim up front, then
`verifyWalletClient` resolves the application behind `client_id` through the application
service and checks its template.

`openid4vci.Initialize` now takes `application.ApplicationServiceInterface`, so it moved in
`servicemanager.go` to after that service is constructed. It cannot be hoisted the other way:
`application` → `inboundClient` → `flowMgt` → `authnProvider` → `openid4vpSvc` cycles back
into `initializeVCServices`. OpenID4VP and the credential-configuration service stay put.

The Wayfinder sample and both bundled wallet clients already carry `template: wallet`, so the
VC walkthrough is unaffected. The integration test app is now registered as a wallet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Credential issuance now requires a valid OAuth 2.0 access token and client ID.
  * Issuance is restricted to registered wallet applications.
  * Unknown, unresolved, or non-wallet clients are rejected.
  * Mobile and embedded wallet applications are supported.
  * Access tokens are checked for the required permissions before issuance.
  * Startup now fails safely when required authentication services cannot initialize.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->