### PR TITLE
Add support for ID-JAG authorization grant profile in OIDC metadata

### DIFF
--- a/api/discovery.yaml
+++ b/api/discovery.yaml
@@ -64,6 +64,8 @@ paths:
                 code_challenge_methods_supported:
                   - S256
                 authorization_response_iss_parameter_supported: true
+                authorization_grant_profiles_supported:
+                  - "urn:ietf:params:oauth:grant-profile:id-jag"
 
   /.well-known/openid-configuration:
     get:
@@ -116,6 +118,8 @@ paths:
                   - email_verified
                 claims_parameter_supported: true
                 authorization_response_iss_parameter_supported: true
+                authorization_grant_profiles_supported:
+                  - "urn:ietf:params:oauth:grant-profile:id-jag"
         "500":
           description: Internal server error — metadata could not be generated.
 
@@ -187,6 +191,11 @@ components:
         authorization_response_iss_parameter_supported:
           type: boolean
           description: Whether the `iss` parameter is included in authorization responses (RFC 9207).
+        authorization_grant_profiles_supported:
+          type: array
+          items:
+            type: string
+          description: Authorization grant profiles supported, e.g. the ID-JAG profile (`urn:ietf:params:oauth:grant-profile:id-jag`).
 
     OIDCProviderMetadata:
       allOf:

--- a/backend/internal/oauth/oauth2/constants/constants.go
+++ b/backend/internal/oauth/oauth2/constants/constants.go
@@ -335,6 +335,11 @@ const (
 	CIBAMaxExpiresInSeconds = 600
 )
 
+const (
+	// SupportedAuthorizationGrantProfileIDJAG is the constant for supported authorization grant profile ID-JAG.
+	SupportedAuthorizationGrantProfileIDJAG = "urn:ietf:params:oauth:grant-profile:id-jag"
+)
+
 // GetSupportedResponseTypes returns all supported OAuth2 response types.
 func GetSupportedResponseTypes(oauthConfig oauthconfig.Config) []string {
 	allowedResponseTypes := oauthConfig.OAuth.AllowedResponseTypes

--- a/backend/internal/oauth/oauth2/discovery/discovery_test.go
+++ b/backend/internal/oauth/oauth2/discovery/discovery_test.go
@@ -498,4 +498,105 @@ func (suite *DiscoveryTestSuite) TestOIDCDiscovery_DeduplicatesAlgorithms() {
 	assert.Contains(suite.T(), algs, "RS256")
 }
 
+func (suite *DiscoveryTestSuite) TestAuthorizationGrantProfilesSupported_JWTBearerEnabled() {
+	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, providers.PublicKeyFilter{}).
+		Return([]providers.PublicKeyInfo{{KeyID: "k1", Algorithm: string(cryptolib.AlgorithmRS256)}}, nil)
+
+	meta, err := suite.discoveryService.GetOIDCMetadata(context.Background())
+	assert.NoError(suite.T(), err)
+
+	// Default config allows the JWT Bearer grant type, so the ID-JAG profile should be advertised.
+	assert.Contains(suite.T(), meta.GrantTypesSupported, string(providers.GrantTypeJWTBearer))
+	assert.Contains(
+		suite.T(), meta.AuthorizationGrantProfilesSupported, constants.SupportedAuthorizationGrantProfileIDJAG)
+}
+
+func (suite *DiscoveryTestSuite) TestAuthorizationGrantProfilesSupported_JWTBearerDisabled() {
+	testConfig := &config.Config{
+		Server: engineconfig.ServerConfig{Hostname: "localhost", Port: 8080},
+		JWT:    engineconfig.JWTConfig{Issuer: "https://auth.example.com"},
+		OAuth: engineconfig.OAuthConfig{
+			AllowedGrantTypes: []string{"client_credentials", "refresh_token"},
+		},
+	}
+	cryptoMock := cryptomock.NewRuntimeCryptoProviderMock(suite.T())
+	cryptoMock.EXPECT().GetSupportedSigningAlgorithms().Return(suite.oauthCfg.OAuth.DPoP.AllowedAlgs).Maybe()
+	cryptoMock.EXPECT().GetSupportedEncryptionAlgorithms().
+		Return([]string{string(cryptolib.AlgorithmRSAOAEP256)}).Maybe()
+	cryptoMock.EXPECT().GetPublicKeys(mock.Anything, providers.PublicKeyFilter{}).
+		Return([]providers.PublicKeyInfo{{KeyID: "k1", Algorithm: string(cryptolib.AlgorithmRS256)}}, nil)
+
+	svc := newDiscoveryService(cryptoMock, newTestJWEService(cryptoMock), oauthCfgFromServerConfig(testConfig))
+	meta, err := svc.GetOIDCMetadata(context.Background())
+	assert.NoError(suite.T(), err)
+
+	assert.NotContains(suite.T(), meta.GrantTypesSupported, string(providers.GrantTypeJWTBearer))
+	assert.Empty(suite.T(), meta.AuthorizationGrantProfilesSupported)
+
+	body, err := json.Marshal(meta)
+	assert.NoError(suite.T(), err)
+	assert.NotContains(suite.T(), string(body), "authorization_grant_profiles_supported")
+}
+
+func (suite *DiscoveryTestSuite) TestAuthorizationGrantProfilesSupported_AdvertisedOverHTTP() {
+	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, providers.PublicKeyFilter{}).
+		Return([]providers.PublicKeyInfo{{KeyID: "k1", Algorithm: string(cryptolib.AlgorithmRS256)}}, nil)
+
+	req := httptest.NewRequest("GET", "/.well-known/openid-configuration", nil)
+	w := httptest.NewRecorder()
+	suite.handler.HandleOIDCDiscovery(w, req)
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+
+	var metadata OIDCProviderMetadata
+	err := json.NewDecoder(w.Body).Decode(&metadata)
+	assert.NoError(suite.T(), err)
+	assert.Equal(
+		suite.T(),
+		[]string{constants.SupportedAuthorizationGrantProfileIDJAG},
+		metadata.AuthorizationGrantProfilesSupported,
+	)
+}
+
+func (suite *DiscoveryTestSuite) TestAuthorizationGrantProfilesSupported_OnOAuth2AuthorizationServerMetadata() {
+	req := httptest.NewRequest("GET", "/.well-known/oauth-authorization-server", nil)
+	w := httptest.NewRecorder()
+
+	suite.handler.HandleOAuth2AuthorizationServerMetadata(w, req)
+
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+
+	var metadata OAuth2AuthorizationServerMetadata
+	err := json.NewDecoder(w.Body).Decode(&metadata)
+	assert.NoError(suite.T(), err)
+
+	// Default config allows the JWT Bearer grant type, so the ID-JAG profile should be
+	// advertised on the OAuth 2.0 Authorization Server Metadata endpoint too.
+	assert.Contains(suite.T(), metadata.GrantTypesSupported, string(providers.GrantTypeJWTBearer))
+	assert.Equal(
+		suite.T(),
+		[]string{constants.SupportedAuthorizationGrantProfileIDJAG},
+		metadata.AuthorizationGrantProfilesSupported,
+	)
+}
+
+func (suite *DiscoveryTestSuite) TestAuthorizationGrantProfilesSupported_NotOnOAuth2ServerMetadataWhenUnsupported() {
+	testConfig := &config.Config{
+		Server: engineconfig.ServerConfig{Hostname: "localhost", Port: 8080},
+		JWT:    engineconfig.JWTConfig{Issuer: "https://auth.example.com"},
+		OAuth: engineconfig.OAuthConfig{
+			AllowedGrantTypes: []string{"client_credentials", "refresh_token"},
+		},
+	}
+	svc := newDiscoveryService(
+		suite.cryptoMock, newTestJWEService(suite.cryptoMock), oauthCfgFromServerConfig(testConfig))
+	handler := newDiscoveryHandler(svc)
+
+	req := httptest.NewRequest("GET", "/.well-known/oauth-authorization-server", nil)
+	w := httptest.NewRecorder()
+	handler.HandleOAuth2AuthorizationServerMetadata(w, req)
+
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	assert.NotContains(suite.T(), w.Body.String(), "authorization_grant_profiles_supported")
+}
+
 func boolPtr(b bool) *bool { return &b }

--- a/backend/internal/oauth/oauth2/discovery/model.go
+++ b/backend/internal/oauth/oauth2/discovery/model.go
@@ -23,6 +23,7 @@ type OAuth2AuthorizationServerMetadata struct {
 	CodeChallengeMethodsSupported              []string `json:"code_challenge_methods_supported,omitempty"`
 	AuthorizationResponseIssParameterSupported bool     `json:"authorization_response_iss_parameter_supported"`
 	DPoPSigningAlgValuesSupported              []string `json:"dpop_signing_alg_values_supported,omitempty"`
+	AuthorizationGrantProfilesSupported        []string `json:"authorization_grant_profiles_supported,omitempty"`
 }
 
 // OIDCProviderMetadata represents OpenID Connect Provider Metadata (OIDC Discovery 1.0)

--- a/backend/internal/oauth/oauth2/discovery/service.go
+++ b/backend/internal/oauth/oauth2/discovery/service.go
@@ -59,6 +59,7 @@ func (ds *discoveryService) GetOAuth2AuthorizationServerMetadata(
 		CodeChallengeMethodsSupported:              ds.getSupportedCodeChallengeMethods(),
 		AuthorizationResponseIssParameterSupported: true,
 		DPoPSigningAlgValuesSupported:              ds.getSupportedDPoPSigningAlgs(),
+		AuthorizationGrantProfilesSupported:        ds.getSupportedAuthorizationGrantProfiles(),
 	}
 
 	if slices.Contains(metadata.GrantTypesSupported, string(providers.GrantTypeCIBA)) {
@@ -243,4 +244,14 @@ func (ds *discoveryService) getSupportedClaims() []string {
 	}
 
 	return uniqueClaims
+}
+
+func (ds *discoveryService) getSupportedAuthorizationGrantProfiles() []string {
+	supportedProfiles := make([]string, 0)
+	// support Identity Assertion JWT Authorization Grant profile if the JWT Bearer grant type is supported
+	if slices.Contains(ds.getSupportedGrantTypes(), string(providers.GrantTypeJWTBearer)) {
+		supportedProfiles = append(supportedProfiles, string(constants.SupportedAuthorizationGrantProfileIDJAG))
+	}
+
+	return supportedProfiles
 }


### PR DESCRIPTION
### Purpose
Advertise support for the Identity Assertion JWT Authorization Grant (ID-JAG) profile in the OIDC discovery metadata when the JWT Bearer grant type is enabled.

### Approach
Adds a new `authorization_grant_profiles_supported` field to the OIDC provider metadata. The discovery service populates it with `urn:ietf:params:oauth:grant-profile:id-jag` whenever the JWT Bearer grant type is among the supported grant types; the field is omitted entirely when it isn't.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4663

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* OIDC and OAuth 2.0 discovery metadata now advertises supported authorization grant profiles.
* The Identity Assertion JWT Authorization Grant profile is advertised when JWT Bearer grants are enabled.
* Added the optional `authorization_grant_profiles_supported` discovery field, which is omitted when unsupported.

## Documentation

* Updated discovery API documentation and examples to include the supported authorization grant profiles field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->