### PR TITLE
Add nested groups support to the group members UI

### DIFF
--- a/frontend/apps/console/src/features/groups/components/__tests__/AddMemberDialog.test.tsx
+++ b/frontend/apps/console/src/features/groups/components/__tests__/AddMemberDialog.test.tsx
@@ -50,12 +50,16 @@ vi.mock('@wso2/oxygen-ui', async () => {
 
 const mockUseGetUsers = vi.fn();
 const mockUseGetApplications = vi.fn();
+const mockUseGetGroups = vi.fn();
 vi.mock('@thunderid/configure-users', () => ({
   useGetUsers: (...args: unknown[]): unknown => mockUseGetUsers(...args),
 }));
 vi.mock('@thunderid/configure-applications', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@thunderid/configure-applications')>()),
   useGetApplications: (...args: unknown[]): unknown => mockUseGetApplications(...args),
+}));
+vi.mock('../../api/useGetGroups', () => ({
+  default: (...args: unknown[]): unknown => mockUseGetGroups(...args),
 }));
 
 describe('AddMemberDialog', () => {
@@ -86,6 +90,19 @@ describe('AddMemberDialog', () => {
         applications: [
           {id: 'a1', name: 'Orders API', description: 'Orders backend'},
           {id: 'a2', name: 'Billing API', description: 'Billing backend'},
+        ],
+      },
+      isLoading: false,
+    });
+    mockUseGetGroups.mockReturnValue({
+      data: {
+        totalResults: 3,
+        startIndex: 0,
+        count: 3,
+        groups: [
+          {id: 'g1', name: 'Engineering', ouId: 'ou1'},
+          {id: 'g2', name: 'Support', ouId: 'ou1'},
+          {id: 'g3', name: 'Finance', ouId: 'ou2'},
         ],
       },
       isLoading: false,
@@ -193,6 +210,66 @@ describe('AddMemberDialog', () => {
     await user.click(screen.getByText('Add Selected'));
 
     expect(defaultProps.onAdd).toHaveBeenCalledWith([{id: 'a1', type: 'app'}]);
+  });
+
+  it('should render groups in the grid when Groups tab is selected', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AddMemberDialog {...defaultProps} />);
+
+    await user.click(screen.getByText('Groups'));
+
+    expect(screen.getByTestId('user-g1')).toBeInTheDocument();
+    expect(screen.getByTestId('user-g2')).toBeInTheDocument();
+    expect(screen.getByTestId('user-g3')).toBeInTheDocument();
+  });
+
+  it('should exclude the edited group from the groups grid', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AddMemberDialog {...defaultProps} excludeGroupId="g2" />);
+
+    await user.click(screen.getByText('Groups'));
+
+    expect(screen.queryByTestId('user-g2')).not.toBeInTheDocument();
+    expect(screen.getByTestId('user-g1')).toBeInTheDocument();
+    expect(screen.getByTestId('user-g3')).toBeInTheDocument();
+  });
+
+  it('should call onAdd with selected group members', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AddMemberDialog {...defaultProps} />);
+
+    await user.click(screen.getByText('Groups'));
+    await user.click(screen.getByTestId('checkbox-g1'));
+    await user.click(screen.getByText('Add Selected'));
+
+    expect(defaultProps.onAdd).toHaveBeenCalledWith([{id: 'g1', type: 'group'}]);
+  });
+
+  it('should show no results alert when no groups', async () => {
+    const user = userEvent.setup();
+    mockUseGetGroups.mockReturnValue({
+      data: {totalResults: 0, startIndex: 0, count: 0, groups: []},
+      isLoading: false,
+    });
+    renderWithProviders(<AddMemberDialog {...defaultProps} />);
+
+    await user.click(screen.getByText('Groups'));
+    expect(screen.getByText('No groups found')).toBeInTheDocument();
+  });
+
+  it('should show error alert when groups fetch fails', async () => {
+    const user = userEvent.setup();
+    mockUseGetGroups.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: new Error('Network error'),
+    });
+    renderWithProviders(<AddMemberDialog {...defaultProps} />);
+
+    await user.click(screen.getByText('Groups'));
+
+    expect(screen.getByText('Failed to load groups. Please try again.')).toBeInTheDocument();
+    expect(screen.queryByText('No groups found')).not.toBeInTheDocument();
   });
 
   it('should call onClose when cancel is clicked', async () => {

--- a/frontend/apps/console/src/features/groups/components/edit-group/members-settings/AddMemberDialog.tsx
+++ b/frontend/apps/console/src/features/groups/components/edit-group/members-settings/AddMemberDialog.tsx
@@ -23,17 +23,20 @@ import {
   Tab,
   useTheme,
 } from '@wso2/oxygen-ui';
-import {AppWindow, Bot, User as UserIcon} from '@wso2/oxygen-ui-icons-react';
+import {AppWindow, Bot, User as UserIcon, Users} from '@wso2/oxygen-ui-icons-react';
 import {useState, useMemo, useCallback, type JSX, type SyntheticEvent} from 'react';
 import {useTranslation} from 'react-i18next';
 import useGetAgents from '../../../../agents/api/useGetAgents';
 import type {BasicAgent} from '../../../../agents/models/agent';
-import type {Member} from '../../../models/group';
+import useGetGroups from '../../../api/useGetGroups';
+import type {GroupBasic, Member} from '../../../models/group';
 
 interface AddMemberDialogProps {
   open: boolean;
   onClose: () => void;
   onAdd: (members: Member[]) => void;
+  /** Group being edited, excluded from the groups tab so it cannot be made a member of itself. */
+  excludeGroupId?: string;
   /** Inline error shown in the dialog when the last add attempt failed. */
   error?: string | null;
   /** Called when the tab or a selection changes, so the parent can clear a stale error. */
@@ -43,12 +46,13 @@ interface AddMemberDialogProps {
 }
 
 /**
- * Dialog for searching and adding user or app members to a group.
+ * Dialog for searching and adding user, app, agent, or group members to a group.
  */
 export default function AddMemberDialog({
   open,
   onClose,
   onAdd,
+  excludeGroupId = undefined,
   error = null,
   onErrorDismiss = undefined,
   isSubmitting = false,
@@ -70,9 +74,17 @@ export default function AddMemberDialog({
     type: 'include',
     ids: new Set(),
   });
+  const [groupSelectionModel, setGroupSelectionModel] = useState<DataGrid.GridRowSelectionModel>({
+    type: 'include',
+    ids: new Set(),
+  });
   const [userPaginationModel, setUserPaginationModel] = useState<DataGrid.GridPaginationModel>({pageSize: 10, page: 0});
   const [appPaginationModel, setAppPaginationModel] = useState<DataGrid.GridPaginationModel>({pageSize: 10, page: 0});
   const [agentPaginationModel, setAgentPaginationModel] = useState<DataGrid.GridPaginationModel>({
+    pageSize: 10,
+    page: 0,
+  });
+  const [groupPaginationModel, setGroupPaginationModel] = useState<DataGrid.GridPaginationModel>({
     pageSize: 10,
     page: 0,
   });
@@ -98,13 +110,31 @@ export default function AddMemberDialog({
     }),
     [agentPaginationModel],
   );
+  const groupsParams = useMemo(
+    () => ({
+      limit: groupPaginationModel.pageSize,
+      offset: groupPaginationModel.page * groupPaginationModel.pageSize,
+    }),
+    [groupPaginationModel],
+  );
   const {data: usersData, isLoading: usersLoading, error: usersError} = useGetUsers(usersParams);
   const {data: appsData, isLoading: appsLoading, error: appsError} = useGetApplications(appsParams);
   const {data: agentsData, isLoading: agentsLoading, error: agentsError} = useGetAgents(agentsParams);
+  const {data: groupsData, isLoading: groupsLoading, error: groupsError} = useGetGroups(groupsParams);
 
   const users: User[] = useMemo(() => usersData?.users ?? [], [usersData]);
   const applications: BasicApplication[] = useMemo(() => appsData?.applications ?? [], [appsData]);
   const agents: BasicAgent[] = useMemo(() => agentsData?.agents ?? [], [agentsData]);
+  // The listing is server-paginated, so the edited group is dropped from the current page and the
+  // total is adjusted by one rather than being filtered out of the query itself.
+  const groups: GroupBasic[] = useMemo(
+    () => (groupsData?.groups ?? []).filter((group) => group.id !== excludeGroupId),
+    [groupsData, excludeGroupId],
+  );
+  const groupsRowCount: number = useMemo(() => {
+    const total = groupsData?.totalResults ?? 0;
+    return excludeGroupId ? Math.max(total - 1, 0) : total;
+  }, [groupsData, excludeGroupId]);
 
   const userColumns: DataGrid.GridColDef<User>[] = useMemo(
     () => [
@@ -231,6 +261,56 @@ export default function AddMemberDialog({
     [theme, t],
   );
 
+  const groupColumns: DataGrid.GridColDef<GroupBasic>[] = useMemo(
+    () => [
+      {
+        field: 'avatar',
+        headerName: '',
+        width: 70,
+        sortable: false,
+        filterable: false,
+        renderCell: (): JSX.Element => (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              height: '100%',
+            }}
+          >
+            <Avatar
+              sx={{
+                p: 0.5,
+                backgroundColor: theme.vars?.palette.grey[500],
+                width: 30,
+                height: 30,
+                fontSize: '0.875rem',
+                ...theme.applyStyles('dark', {
+                  backgroundColor: theme.vars?.palette.grey[900],
+                }),
+              }}
+            >
+              <Users size={14} />
+            </Avatar>
+          </Box>
+        ),
+      },
+      {
+        field: 'name',
+        headerName: t('groups:addMember.columns.displayName'),
+        flex: 1,
+        minWidth: 200,
+      },
+      {
+        field: 'id',
+        headerName: t('groups:edit.members.sections.manage.listing.columns.id'),
+        flex: 1,
+        minWidth: 250,
+      },
+    ],
+    [theme, t],
+  );
+
   const appColumns: DataGrid.GridColDef<BasicApplication>[] = useMemo(
     () => [
       {
@@ -286,11 +366,12 @@ export default function AddMemberDialog({
       ...[...userSelectionModel.ids].map((id) => ({id: String(id), type: 'user' as const})),
       ...[...appSelectionModel.ids].map((id) => ({id: String(id), type: 'app' as const})),
       ...[...agentSelectionModel.ids].map((id) => ({id: String(id), type: 'agent' as const})),
+      ...[...groupSelectionModel.ids].map((id) => ({id: String(id), type: 'group' as const})),
     ];
     // Selections are deliberately left as-is here: the dialog unmounts on a successful add (the
     // parent closes it), and on failure the user needs their selection intact to retry.
     onAdd(newMembers);
-  }, [userSelectionModel, appSelectionModel, agentSelectionModel, onAdd]);
+  }, [userSelectionModel, appSelectionModel, agentSelectionModel, groupSelectionModel, onAdd]);
 
   const handleClose = (): void => {
     // Also reached via Escape and backdrop clicks, so guard the in-flight case here rather than
@@ -300,10 +381,15 @@ export default function AddMemberDialog({
     setUserSelectionModel({type: 'include', ids: new Set()});
     setAppSelectionModel({type: 'include', ids: new Set()});
     setAgentSelectionModel({type: 'include', ids: new Set()});
+    setGroupSelectionModel({type: 'include', ids: new Set()});
     onClose();
   };
 
-  const totalSelected = userSelectionModel.ids.size + appSelectionModel.ids.size + agentSelectionModel.ids.size;
+  const totalSelected =
+    userSelectionModel.ids.size +
+    appSelectionModel.ids.size +
+    agentSelectionModel.ids.size +
+    groupSelectionModel.ids.size;
 
   const handleTabChange = (_event: SyntheticEvent, tab: number): void => {
     setActiveTab(tab);
@@ -318,6 +404,7 @@ export default function AddMemberDialog({
           <Tab icon={<UserIcon size={16} />} iconPosition="start" label={t('groups:addMember.tabs.users')} />
           <Tab icon={<AppWindow size={16} />} iconPosition="start" label={t('groups:addMember.tabs.apps')} />
           <Tab icon={<Bot size={16} />} iconPosition="start" label={t('groups:addMember.tabs.agents', 'Agents')} />
+          <Tab icon={<Users size={16} />} iconPosition="start" label={t('groups:addMember.tabs.groups', 'Groups')} />
         </Tabs>
 
         {activeTab === 0 && (
@@ -438,6 +525,48 @@ export default function AddMemberDialog({
                 rowCount={agentsData?.totalResults ?? 0}
                 paginationModel={agentPaginationModel}
                 onPaginationModelChange={setAgentPaginationModel}
+                pageSizeOptions={[5, 10]}
+                disableRowSelectionOnClick
+                localeText={dataGridLocaleText}
+              />
+            </Box>
+          </>
+        )}
+
+        {activeTab === 3 && (
+          <>
+            {groupsError && !groupsLoading && (
+              <Alert severity="error" sx={{mb: 2}}>
+                {getErrorMessage(
+                  groupsError,
+                  t,
+                  'groups:addMember.fetchGroupsError',
+                  'Failed to load groups. Please try again.',
+                )}
+              </Alert>
+            )}
+            {!groupsError && groups.length === 0 && !groupsLoading && (
+              <Alert severity="info" sx={{mb: 2}}>
+                {t('groups:addMember.noResultsGroups', 'No groups found')}
+              </Alert>
+            )}
+
+            <Box sx={{height: 400, width: '100%'}}>
+              <DataGrid.DataGrid
+                rows={groups}
+                columns={groupColumns}
+                loading={groupsLoading}
+                getRowId={(row): string => row.id}
+                checkboxSelection
+                rowSelectionModel={groupSelectionModel}
+                onRowSelectionModelChange={(newSelection) => {
+                  setGroupSelectionModel(newSelection);
+                  onErrorDismiss?.();
+                }}
+                paginationMode="server"
+                rowCount={groupsRowCount}
+                paginationModel={groupPaginationModel}
+                onPaginationModelChange={setGroupPaginationModel}
                 pageSizeOptions={[5, 10]}
                 disableRowSelectionOnClick
                 localeText={dataGridLocaleText}

--- a/frontend/apps/console/src/features/groups/components/edit-group/members-settings/EditMembersSettings.tsx
+++ b/frontend/apps/console/src/features/groups/components/edit-group/members-settings/EditMembersSettings.tsx
@@ -106,6 +106,7 @@ export default function EditMembersSettings({group}: EditMembersSettingsProps): 
             setAddError(null);
           }}
           onAdd={handleAddMembers}
+          excludeGroupId={group.id}
           error={addError}
           onErrorDismiss={() => setAddError(null)}
           isSubmitting={addGroupMembers.isPending}

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1581,10 +1581,12 @@ const translations = {
     'addMember.tabs.users': 'Users',
     'addMember.tabs.apps': 'Apps',
     'addMember.tabs.agents': 'Agents',
+    'addMember.tabs.groups': 'Groups',
     'addMember.search.placeholder': 'Search users...',
     'addMember.noResults': 'No users found',
     'addMember.noResultsApps': 'No apps found',
     'addMember.noResultsAgents': 'No agents found',
+    'addMember.noResultsGroups': 'No groups found',
     'addMember.add': 'Add Selected',
     'addMember.columns.displayName': 'Display Name',
     'addMember.columns.userType': 'User Type',
@@ -1593,6 +1595,7 @@ const translations = {
     'addMember.fetchError': 'Failed to load users. Please try again.',
     'addMember.fetchAppsError': 'Failed to load apps. Please try again.',
     'addMember.fetchAgentsError': 'Failed to load agents. Please try again.',
+    'addMember.fetchGroupsError': 'Failed to load groups. Please try again.',
     'removeMember.error': 'Failed to remove member. Please try again.',
 
     // Delete dialog


### PR DESCRIPTION
### Purpose

The Groups UI could not add a group as a member of another group. The add-member dialog offered only Users, Apps and Agents tabs, even though the backend has supported group-type members all along.

This adds a Groups tab to the add-member dialog on the group edit page.

### Approach

The change is frontend only. The backend needed nothing: `MemberTypeGroup` is already a first-class member type, validated on both the create and the add/update paths, and resolved recursively for effective membership. The console models already carried `'group'` in the `Member.type` union, and the member listing already rendered a `Users` icon for group members, so existing nested memberships displayed correctly before this change.

The gap was confined to `AddMemberDialog`:

- Added a fourth Groups tab, backed by the existing `useGetGroups` hook, following the same shape as the Agents tab: its own selection and pagination state, a column definition, and error and empty states.
- Selected groups are emitted as `{id, type: 'group'}` members and folded into the existing selection count and close-reset handling.
- Added a `excludeGroupId` prop, passed as the edited group's ID, so a group is not offered as a member of itself. The listing is server-paginated, so the group is dropped from the current page and the row count is reduced by one. A page can therefore show one row fewer than its page size, which seemed a fair trade against adding a backend filter parameter for this.
- Three new keys in the `en-US` locale. It is the only locale file in the repo.

Two things were deliberately left out of scope, both raised and confirmed during review:

- Already-added members are still listed and selectable. This is pre-existing behaviour shared by all four tabs, and re-adding is a no-op server side, since the insert uses `ON CONFLICT ... DO NOTHING`. Filtering correctly would need the group's full member set, and `limit` is capped at `MaxPageSize` of 100, so it is a larger change that should cover all tabs at once.
- Cycle prevention. A cycle is accepted on write but is safe on read, so it is a data-modelling wart rather than a live defect. Tracked separately.

### Related Issues
- Fixes #4525
- #4679, nested group membership does not reject cycles or self-reference. Found while working on this.
- #4680, mixed-store nested group chains are silently partially resolved. Found while working on this, and the more impactful of the two.

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for searching and selecting groups when adding members.
  * Added a dedicated Groups tab with group-specific results, pagination, and selection totals.
  * Prevented groups from adding themselves as members.
  * Added localized labels and messages for group selection, empty results, and loading errors.

* **Bug Fixes**
  * Improved handling of group-loading failures and empty search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->