### PR TITLE
Add SSO support to the Wayfinder sample authentication flow

### DIFF
--- a/samples/apps/wayfinder-sample/thunderid-config/app-native/thunderid-config.yaml
+++ b/samples/apps/wayfinder-sample/thunderid-config/app-native/thunderid-config.yaml
@@ -995,7 +995,15 @@ flowType: AUTHENTICATION
 nodes:
   - id: start
     type: START
-    onSuccess: prompt_credentials
+    onSuccess: sso_check
+  - id: sso_check
+    type: TASK_EXECUTION
+    executor:
+      name: SSOCheckExecutor
+    properties:
+      checkpointRef: session
+    onSuccess: session
+    onFailure: prompt_credentials
   - id: prompt_credentials
     type: PROMPT
     meta:
@@ -1062,8 +1070,13 @@ nodes:
     type: TASK_EXECUTION
     executor:
       name: CredentialsAuthExecutor
-    onSuccess: authorization_check
+    onSuccess: session
     onIncomplete: prompt_credentials
+  - id: session
+    type: TASK_EXECUTION
+    executor:
+      name: SessionExecutor
+    onSuccess: authorization_check
   - id: authorization_check
     type: TASK_EXECUTION
     executor:

--- a/samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid-config.yaml
+++ b/samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid-config.yaml
@@ -843,7 +843,15 @@ flowType: AUTHENTICATION
 nodes:
   - id: start
     type: START
-    onSuccess: prompt_credentials
+    onSuccess: sso_check
+  - id: sso_check
+    type: TASK_EXECUTION
+    executor:
+      name: SSOCheckExecutor
+    properties:
+      checkpointRef: session
+    onSuccess: session
+    onFailure: prompt_credentials
   - id: prompt_credentials
     type: PROMPT
     meta:
@@ -910,8 +918,13 @@ nodes:
     type: TASK_EXECUTION
     executor:
       name: CredentialsAuthExecutor
-    onSuccess: authorization_check
+    onSuccess: session
     onIncomplete: prompt_credentials
+  - id: session
+    type: TASK_EXECUTION
+    executor:
+      name: SessionExecutor
+    onSuccess: authorization_check
   - id: authorization_check
     type: TASK_EXECUTION
     executor:


### PR DESCRIPTION
### Purpose

The Wayfinder sample's authentication flow (`wayfinder-app-auth-flow`) had no SSO
handling, so every authorization request landed on the credentials prompt even when
the user already had a valid session. This PR adds SSO support to that flow, bringing
the sample in line with the default Console app authentication flow.

Scope is limited to `wayfinder-app-auth-flow` in the two Wayfinder sample
configurations (`redirect` and `app-native`). The registration, recovery, CIBA email,
CIBA SMS, and agent authentication flows are unchanged.

### Approach

Two nodes were added to the flow:

* `sso_check` (`SSOCheckExecutor`), inserted between `start` and the credentials
  prompt. It declares `checkpointRef: session`, so on a session hit the flow jumps
  straight to the session join node, and on a miss `onFailure` falls through to
  `prompt_credentials`.
* `session` (`SessionExecutor`), inserted as the join node before
  `authorization_check`. `credentials_auth.onSuccess` now targets it instead of
  `authorization_check`, so both the SSO path and the interactive login path
  converge on the same node before authorization.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4237


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an existing-session check before requesting authentication credentials.
  * Successful session checks now proceed directly through authentication.
  * Credential-based authentication includes an intermediate session step before authorization.

* **Bug Fixes**
  * Users with incomplete or failed authentication are returned to the credential prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->