### PR TITLE
Remove unused callbackType property from auth_assert nodes

### DIFF
--- a/frontend/apps/console/src/features/flows/data/templates.json
+++ b/frontend/apps/console/src/features/flows/data/templates.json
@@ -5914,9 +5914,6 @@
         {
           "id": "auth_assert",
           "type": "TASK_EXECUTION",
-          "properties": {
-            "callbackType": "urn:openid:params:grant-type:ciba"
-          },
           "executor": {
             "name": "AuthAssertExecutor"
           },

--- a/install/openchoreo/thunderid-oc-resourcetype/samples/resource.yaml
+++ b/install/openchoreo/thunderid-oc-resourcetype/samples/resource.yaml
@@ -403,8 +403,6 @@ spec:
           onSuccess: auth_assert
         - id: auth_assert
           type: TASK_EXECUTION
-          properties:
-            callbackType: "urn:openid:params:grant-type:ciba"
           executor:
             name: AuthAssertExecutor
           onSuccess: auth_success

--- a/samples/apps/wayfinder-sample/thunderid-config/app-native/thunderid-config.yaml
+++ b/samples/apps/wayfinder-sample/thunderid-config/app-native/thunderid-config.yaml
@@ -1328,8 +1328,6 @@ nodes:
           nextNode: consent_check
   - id: auth_assert
     type: TASK_EXECUTION
-    properties:
-      callbackType: "urn:openid:params:grant-type:ciba"
     executor:
       name: AuthAssertExecutor
     onSuccess: auth_success
@@ -1533,8 +1531,6 @@ nodes:
           nextNode: consent_check
   - id: auth_assert
     type: TASK_EXECUTION
-    properties:
-      callbackType: "urn:openid:params:grant-type:ciba"
     executor:
       name: AuthAssertExecutor
     onSuccess: auth_success

--- a/samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid-config.yaml
+++ b/samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid-config.yaml
@@ -1176,8 +1176,6 @@ nodes:
           nextNode: consent_check
   - id: auth_assert
     type: TASK_EXECUTION
-    properties:
-      callbackType: "urn:openid:params:grant-type:ciba"
     executor:
       name: AuthAssertExecutor
     onSuccess: auth_success
@@ -1380,8 +1378,6 @@ nodes:
           nextNode: consent_check
   - id: auth_assert
     type: TASK_EXECUTION
-    properties:
-      callbackType: "urn:openid:params:grant-type:ciba"
     executor:
       name: AuthAssertExecutor
     onSuccess: auth_success


### PR DESCRIPTION
### Purpose

This pull request removes the `callbackType` property with value `"urn:openid:params:grant-type:ciba"` from all `auth_assert` task execution nodes across several configuration and template files. This change simplifies the `auth_assert` node definitions and ensures consistency across different environments.

### Approach

* Removed the `callbackType` property from the `auth_assert` task in `frontend/apps/console/src/features/flows/data/templates.json`.
* Removed the `callbackType` property from the `auth_assert` task in `install/openchoreo/thunderid-oc-resourcetype/samples/resource.yaml`.
* Removed the `callbackType` property from all `auth_assert` nodes in `samples/apps/wayfinder-sample/thunderid-config/app-native/thunderid-config.yaml`. [[1]](diffhunk://#diff-0fc41fb19c3109fa7a2001a22d82c63bdbba8c9a4452b0c8a11648480cf2bafbL1331-L1332) [[2]](diffhunk://#diff-0fc41fb19c3109fa7a2001a22d82c63bdbba8c9a4452b0c8a11648480cf2bafbL1536-L1537)
* Removed the `callbackType` property from all `auth_assert` nodes in `samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid-config.yaml`. [[1]](diffhunk://#diff-bae15a0bff68854faae949186179e67db7e795f735af62607f730c8a8f88d8fdL1179-L1180) [[2]](diffhunk://#diff-bae15a0bff68854faae949186179e67db7e795f735af62607f730c8a8f88d8fdL1383-L1384)

### Related Issues
- N/A

### Related PRs
- https://github.com/thunder-id/thunderid/pull/4604

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated CIBA email and SMS notification flows to remove an obsolete callback type setting.
  - Standardized authentication assertion behavior across the default flow templates and sample configurations.
  - Existing authentication and success-handling steps remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->