### PR TITLE
Allow SELECT and RESEND elements to be dropped in the flow builder

### DIFF
--- a/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/DecoratedVisualFlow.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/visual-flow/__tests__/DecoratedVisualFlow.test.tsx
@@ -1057,6 +1057,30 @@ describe('DecoratedVisualFlow', () => {
       });
     });
 
+    it('should handle a SELECT drop on canvas as an input-on-canvas scenario', async () => {
+      renderComponent(<DecoratedVisualFlow {...defaultProps} />);
+
+      triggerCapturedDragEnd({
+        operation: {
+          source: {
+            data: {
+              dragged: {category: 'FIELD', type: 'SELECT'},
+            },
+          },
+          target: {
+            id: 'flow-builder-canvas_test',
+            data: {},
+          },
+        },
+        canceled: false,
+      });
+
+      await waitFor(() => {
+        const dialog = screen.getByTestId('form-requires-view-dialog');
+        expect(dialog).toHaveAttribute('data-scenario', 'input-on-canvas');
+      });
+    });
+
     it('should handle input-on-view drop scenario', async () => {
       renderComponent(<DecoratedVisualFlow {...defaultProps} />);
 

--- a/frontend/apps/console/src/features/flows/constants/VisualFlowConstants.ts
+++ b/frontend/apps/console/src/features/flows/constants/VisualFlowConstants.ts
@@ -64,6 +64,7 @@ class VisualFlowConstants {
     ElementTypes.OtpInput,
     ElementTypes.Checkbox,
     ElementTypes.Dropdown,
+    ElementTypes.Select,
     // Widgets are allowed for drop detection, but handled specially to show dialog
     WidgetTypes.GoogleFederation,
     WidgetTypes.IdentifierPassword,
@@ -84,6 +85,7 @@ class VisualFlowConstants {
   public static readonly FLOW_BUILDER_VIEW_ALLOWED_RESOURCE_TYPES: string[] = [
     BlockTypes.Form,
     ElementTypes.Action,
+    ElementTypes.Resend,
     ElementTypes.Icon,
     ElementTypes.Stack,
     ElementTypes.Text,
@@ -102,6 +104,7 @@ class VisualFlowConstants {
     ElementTypes.OtpInput,
     ElementTypes.Checkbox,
     ElementTypes.Dropdown,
+    ElementTypes.Select,
     WidgetTypes.GoogleFederation,
     WidgetTypes.IdentifierPassword,
     WidgetTypes.SMSOTP,
@@ -135,7 +138,9 @@ class VisualFlowConstants {
     ElementTypes.OtpInput,
     ElementTypes.Checkbox,
     ElementTypes.Dropdown,
+    ElementTypes.Select,
     ElementTypes.Action,
+    ElementTypes.Resend,
     ElementTypes.Icon,
     ElementTypes.Stack,
     ElementTypes.Text,
@@ -149,6 +154,7 @@ class VisualFlowConstants {
 
   public static readonly FLOW_BUILDER_STACK_ALLOWED_RESOURCE_TYPES: string[] = [
     ElementTypes.Action,
+    ElementTypes.Resend,
     ElementTypes.Icon,
     ElementTypes.Stack,
     ElementTypes.Text,

--- a/frontend/apps/console/src/features/flows/constants/__tests__/VisualFlowConstants.test.ts
+++ b/frontend/apps/console/src/features/flows/constants/__tests__/VisualFlowConstants.test.ts
@@ -1,0 +1,70 @@
+// Copyright 2025 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {describe, it, expect} from 'vitest';
+import {ElementTypes} from '../../models/elements';
+import VisualFlowConstants from '../VisualFlowConstants';
+
+describe('VisualFlowConstants', () => {
+  describe('SELECT droppable targets', () => {
+    it('should allow SELECT on the canvas, a view and a form', () => {
+      expect(VisualFlowConstants.FLOW_BUILDER_CANVAS_ALLOWED_RESOURCE_TYPES).toContain(ElementTypes.Select);
+      expect(VisualFlowConstants.FLOW_BUILDER_VIEW_ALLOWED_RESOURCE_TYPES).toContain(ElementTypes.Select);
+      expect(VisualFlowConstants.FLOW_BUILDER_FORM_ALLOWED_RESOURCE_TYPES).toContain(ElementTypes.Select);
+    });
+
+    it('should not allow SELECT in stack or display only containers', () => {
+      expect(VisualFlowConstants.FLOW_BUILDER_STACK_ALLOWED_RESOURCE_TYPES).not.toContain(ElementTypes.Select);
+      expect(VisualFlowConstants.FLOW_BUILDER_FLOW_COMPLETION_VIEW_ALLOWED_RESOURCE_TYPES).not.toContain(
+        ElementTypes.Select,
+      );
+      expect(VisualFlowConstants.FLOW_BUILDER_STATIC_CONTENT_ALLOWED_RESOURCE_TYPES).not.toContain(ElementTypes.Select);
+    });
+
+    it('should allow SELECT wherever DROPDOWN is allowed', () => {
+      const lists = [
+        VisualFlowConstants.FLOW_BUILDER_CANVAS_ALLOWED_RESOURCE_TYPES,
+        VisualFlowConstants.FLOW_BUILDER_VIEW_ALLOWED_RESOURCE_TYPES,
+        VisualFlowConstants.FLOW_BUILDER_FORM_ALLOWED_RESOURCE_TYPES,
+        VisualFlowConstants.FLOW_BUILDER_STACK_ALLOWED_RESOURCE_TYPES,
+        VisualFlowConstants.FLOW_BUILDER_FLOW_COMPLETION_VIEW_ALLOWED_RESOURCE_TYPES,
+        VisualFlowConstants.FLOW_BUILDER_STATIC_CONTENT_ALLOWED_RESOURCE_TYPES,
+      ];
+
+      lists.forEach((list) => {
+        expect(list.includes(ElementTypes.Select)).toBe(list.includes(ElementTypes.Dropdown));
+      });
+    });
+  });
+
+  describe('RESEND droppable targets', () => {
+    it('should allow RESEND in a view, a form and a stack', () => {
+      expect(VisualFlowConstants.FLOW_BUILDER_VIEW_ALLOWED_RESOURCE_TYPES).toContain(ElementTypes.Resend);
+      expect(VisualFlowConstants.FLOW_BUILDER_FORM_ALLOWED_RESOURCE_TYPES).toContain(ElementTypes.Resend);
+      expect(VisualFlowConstants.FLOW_BUILDER_STACK_ALLOWED_RESOURCE_TYPES).toContain(ElementTypes.Resend);
+    });
+
+    it('should not allow RESEND on the canvas or in display only containers', () => {
+      expect(VisualFlowConstants.FLOW_BUILDER_CANVAS_ALLOWED_RESOURCE_TYPES).not.toContain(ElementTypes.Resend);
+      expect(VisualFlowConstants.FLOW_BUILDER_FLOW_COMPLETION_VIEW_ALLOWED_RESOURCE_TYPES).not.toContain(
+        ElementTypes.Resend,
+      );
+      expect(VisualFlowConstants.FLOW_BUILDER_STATIC_CONTENT_ALLOWED_RESOURCE_TYPES).not.toContain(ElementTypes.Resend);
+    });
+
+    it('should allow RESEND wherever ACTION is allowed', () => {
+      const lists = [
+        VisualFlowConstants.FLOW_BUILDER_CANVAS_ALLOWED_RESOURCE_TYPES,
+        VisualFlowConstants.FLOW_BUILDER_VIEW_ALLOWED_RESOURCE_TYPES,
+        VisualFlowConstants.FLOW_BUILDER_FORM_ALLOWED_RESOURCE_TYPES,
+        VisualFlowConstants.FLOW_BUILDER_STACK_ALLOWED_RESOURCE_TYPES,
+        VisualFlowConstants.FLOW_BUILDER_FLOW_COMPLETION_VIEW_ALLOWED_RESOURCE_TYPES,
+        VisualFlowConstants.FLOW_BUILDER_STATIC_CONTENT_ALLOWED_RESOURCE_TYPES,
+      ];
+
+      lists.forEach((list) => {
+        expect(list.includes(ElementTypes.Resend)).toBe(list.includes(ElementTypes.Action));
+      });
+    });
+  });
+});

--- a/frontend/apps/console/src/features/flows/hooks/__tests__/useElementAddition.test.ts
+++ b/frontend/apps/console/src/features/flows/hooks/__tests__/useElementAddition.test.ts
@@ -34,7 +34,7 @@ vi.mock('@/features/flows/utils/generateIdsForResources', () => ({
 
 // Mock componentMutations
 vi.mock('../../utils/componentMutations', () => ({
-  INPUT_ELEMENT_TYPES: new Set(['TEXT_INPUT', 'PASSWORD_INPUT', 'EMAIL_INPUT', 'OTP_INPUT', 'CHECKBOX']),
+  INPUT_ELEMENT_TYPES: new Set(['TEXT_INPUT', 'PASSWORD_INPUT', 'EMAIL_INPUT', 'OTP_INPUT', 'CHECKBOX', 'SELECT']),
   mutateComponents: (components: Element[]) => components,
 }));
 
@@ -254,6 +254,45 @@ describe('useElementAddition', () => {
       expect(form).toBeDefined();
       expect(form.components).toHaveLength(1);
       expect(form.components[0].id).toBe('generated-text-input-1');
+    });
+
+    it('should add select element to existing form in view', () => {
+      const existingForm = createMockElement({
+        id: 'form-1',
+        type: BlockTypes.Form,
+        category: ElementCategories.Block,
+        version: '0.1.0',
+        components: [],
+      });
+
+      let capturedNodes: Node[] = [];
+      mockSetNodes = vi.fn((updater: React.SetStateAction<Node[]>) => {
+        if (typeof updater === 'function') {
+          const nodes: Node[] = [createMockViewNode({id: 'view-1', data: {components: [existingForm]}})];
+          capturedNodes = updater(nodes);
+        }
+      }) as ReturnType<typeof vi.fn> & SetNodesFn;
+
+      const {result} = renderHook(() =>
+        useElementAddition({
+          setNodes: mockSetNodes,
+          updateNodeInternals: mockUpdateNodeInternals,
+        }),
+      );
+
+      const selectElement = createMockElement({id: 'select-1', type: ElementTypes.Select});
+
+      act(() => {
+        result.current.handleAddElementToView(selectElement, 'view-1');
+      });
+
+      expect(capturedNodes.length).toBe(1);
+      const form = (capturedNodes[0].data as {components: Element[]}).components.find(
+        (c: Element) => c.type === BlockTypes.Form,
+      ) as Element & {components: Element[]};
+      expect(form).toBeDefined();
+      expect(form.components).toHaveLength(1);
+      expect(form.components[0].id).toBe('generated-select-1');
     });
 
     it('should create new form when adding input element to view without form', () => {

--- a/frontend/apps/console/src/features/flows/utils/__tests__/componentMutations.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/componentMutations.test.ts
@@ -43,6 +43,7 @@ describe('componentMutations', () => {
       expect(INPUT_ELEMENT_TYPES.has(ElementTypes.OtpInput)).toBe(true);
       expect(INPUT_ELEMENT_TYPES.has(ElementTypes.Checkbox)).toBe(true);
       expect(INPUT_ELEMENT_TYPES.has(ElementTypes.Dropdown)).toBe(true);
+      expect(INPUT_ELEMENT_TYPES.has(ElementTypes.Select)).toBe(true);
     });
 
     it('should not contain non-input element types', () => {

--- a/frontend/apps/console/src/features/flows/utils/__tests__/reactFlowTransformer.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/reactFlowTransformer.test.ts
@@ -1138,6 +1138,53 @@ describe('reactFlowTransformer', () => {
         expect(actionButton?.eventType).toBe(ActionEventTypes.Submit);
       });
 
+      it('should serialize a SELECT field as an input and promote the single button to SUBMIT', () => {
+        const components: Element[] = [
+          {
+            id: 'block-1',
+            type: 'BLOCK',
+            category: ElementCategories.Block,
+            components: [
+              {
+                id: 'select-1',
+                type: ElementTypes.Select,
+                category: ElementCategories.Field,
+                name: 'country',
+                required: true,
+              },
+              {
+                id: 'button-1',
+                type: ElementTypes.Action,
+                category: ElementCategories.Action,
+                eventType: ActionEventTypes.Trigger,
+                action: {onSuccess: 'next-node'},
+              },
+            ],
+          } as unknown as Element,
+        ];
+
+        const canvasData: ReactFlowCanvasData = {
+          nodes: [createNode('view-1', StepTypes.View, {x: 0, y: 0}, {components})],
+          edges: [createEdge('edge-1', 'view-1', 'next-node', 'button-1_NEXT')],
+        };
+
+        const result = transformReactFlow(canvasData);
+
+        expect(result.nodes[0].prompts?.[0].inputs).toEqual([
+          {
+            ref: 'select-1',
+            type: ElementTypes.Select,
+            identifier: 'country',
+            required: true,
+          },
+        ]);
+
+        const block = result.nodes[0].meta?.components?.[0] ?? {};
+        const blockChildren = block.components as Record<string, unknown>[];
+        expect(blockChildren.find((c) => c.type === ElementTypes.Select)?.ref).toBe('country');
+        expect(blockChildren.find((c) => c.type === ElementTypes.Action)?.eventType).toBe(ActionEventTypes.Submit);
+      });
+
       it('should keep TRIGGER eventType for buttons inside a block without input fields', () => {
         const components: Element[] = [
           {

--- a/frontend/apps/console/src/features/flows/utils/componentMutations.ts
+++ b/frontend/apps/console/src/features/flows/utils/componentMutations.ts
@@ -28,6 +28,7 @@ export const INPUT_ELEMENT_TYPES = new Set<string>([
   ElementTypes.OtpInput,
   ElementTypes.Checkbox,
   ElementTypes.Dropdown,
+  ElementTypes.Select,
 ]);
 
 /**

--- a/frontend/apps/console/src/features/flows/utils/flowToCanvasTransformer.ts
+++ b/frontend/apps/console/src/features/flows/utils/flowToCanvasTransformer.ts
@@ -76,7 +76,7 @@ const BRANCHING_OUTCOME_KEYS = ['onFailure', 'onIncomplete'] as const;
 /**
  * Shape of an executor definition read from the resource catalog
  */
-type ExecutorDefinition = {
+interface ExecutorDefinition {
   data?: {
     action?: {
       executor?: {name?: string; mode?: string};
@@ -84,7 +84,7 @@ type ExecutorDefinition = {
       onIncomplete?: string;
     };
   };
-};
+}
 
 /**
  * Builds the catalog lookup key for an executor. Mode is part of the key because the same executor
@@ -100,7 +100,7 @@ function getExecutorKey(name?: string, mode?: string): string {
  * Supporting an outcome is a property of the executor definition, not of whichever edges happened
  * to be connected when the flow was saved, so this is the authoritative source on load.
  */
-const EXECUTOR_DECLARED_OUTCOMES: Map<string, string[]> = new Map(
+const EXECUTOR_DECLARED_OUTCOMES = new Map<string, string[]>(
   (executors as ExecutorDefinition[]).map((definition: ExecutorDefinition) => {
     const action = definition.data?.action;
 
@@ -132,7 +132,7 @@ function resolveBranchingOutcomes(apiNode: FlowNode): Record<string, string> {
 
   BRANCHING_OUTCOME_KEYS.forEach((key: 'onFailure' | 'onIncomplete') => {
     if (apiNode[key] !== undefined) {
-      outcomes[key] = apiNode[key] as string;
+      outcomes[key] = apiNode[key];
     }
   });
 

--- a/frontend/apps/console/src/features/flows/utils/reactFlowTransformer.ts
+++ b/frontend/apps/console/src/features/flows/utils/reactFlowTransformer.ts
@@ -167,6 +167,7 @@ const INPUT_ELEMENT_TYPES = new Set<string>([
   ElementTypes.OtpInput,
   ElementTypes.Checkbox,
   ElementTypes.Dropdown,
+  ElementTypes.Select,
 ]);
 
 /**

--- a/frontend/packages/design/src/components/flow/FlowComponentRenderer.tsx
+++ b/frontend/packages/design/src/components/flow/FlowComponentRenderer.tsx
@@ -3,7 +3,7 @@
 
 import {EmbeddedFlowComponentType, EmbeddedFlowEventType, type ConsentPurpose} from '@thunderid/react';
 import type {JSX} from 'react';
-import BlockAdapter from './adapters/BlockAdapter';
+import BlockAdapter, {ResendButtonAdapter} from './adapters/BlockAdapter';
 import ConsentAdapter from './adapters/ConsentAdapter';
 import CopyableTextAdapter from './adapters/CopyableTextAdapter';
 import DividerAdapter from './adapters/DividerAdapter';
@@ -29,6 +29,7 @@ import type {FlowComponent, FlowComponentRendererProps} from '../../models/flow'
  * - `DIVIDER` → {@link DividerAdapter}
  * - `BLOCK` (form or trigger) → {@link BlockAdapter}
  * - `ACTION / TRIGGER` (standalone) → {@link StandaloneTriggerAdapter}
+ * - `RESEND` (standalone) → {@link ResendButtonAdapter}
  *
  * Consumers must wrap their submit/trigger handlers into the normalised
  * `onSubmit(action, inputs)` callback.  Setting a `key` on the rendered
@@ -166,6 +167,18 @@ export default function FlowComponentRenderer({
   // QR_CODE
   if (comp.type === 'QR_CODE') {
     return <QrCodeAdapter component={comp} additionalData={additionalData} />;
+  }
+
+  // Standalone RESEND (outside of a block, so it dispatches its own action)
+  if (comp.type === 'RESEND') {
+    return (
+      <ResendButtonAdapter
+        component={comp}
+        isLoading={isLoading}
+        resolve={resolve}
+        onClick={() => onSubmit(comp, values)}
+      />
+    );
   }
 
   // Standalone ACTION / TRIGGER (outside of a block)

--- a/frontend/packages/design/src/components/flow/__tests__/FlowComponentRenderer.test.tsx
+++ b/frontend/packages/design/src/components/flow/__tests__/FlowComponentRenderer.test.tsx
@@ -470,3 +470,80 @@ describe('FlowComponentRenderer — STACK grid layout (items)', () => {
     expect(stack.className).toContain('custom-stack');
   });
 });
+
+describe('FlowComponentRenderer — standalone RESEND routing', () => {
+  const resendComponent = {
+    id: 'action_resend',
+    type: 'RESEND',
+    category: 'ACTION',
+    eventType: 'SUBMIT',
+    label: 'Resend',
+  } as unknown as EmbeddedFlowComponent;
+
+  const renderResend = (onSubmit: (...args: unknown[]) => void = noop) =>
+    renderWithProviders(
+      <FlowComponentRenderer
+        component={resendComponent}
+        index={0}
+        values={{otp: '123456'}}
+        isLoading={false}
+        resolve={identity}
+        onInputChange={noop}
+        onSubmit={onSubmit}
+      />,
+    );
+
+  it('renders a RESEND component that sits outside a block', () => {
+    renderResend();
+
+    expect(screen.getByText('Resend')).toBeTruthy();
+  });
+
+  it('dispatches its own action when clicked', () => {
+    const onSubmit = vi.fn();
+    renderResend(onSubmit);
+
+    fireEvent.click(screen.getByText('Resend'));
+
+    expect(onSubmit).toHaveBeenCalledWith(resendComponent, {otp: '123456'});
+  });
+
+  it('renders a RESEND component nested in a stack', () => {
+    const stack = {
+      id: 'stack_actions',
+      type: 'STACK',
+      direction: 'col',
+      components: [resendComponent],
+    } as unknown as EmbeddedFlowComponent;
+
+    renderWithProviders(
+      <FlowComponentRenderer
+        component={stack}
+        index={0}
+        values={{}}
+        isLoading={false}
+        resolve={identity}
+        onInputChange={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    expect(screen.getByText('Resend')).toBeTruthy();
+  });
+
+  it('disables the button while the flow is loading', () => {
+    renderWithProviders(
+      <FlowComponentRenderer
+        component={resendComponent}
+        index={0}
+        values={{}}
+        isLoading
+        resolve={identity}
+        onInputChange={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    expect((document.getElementById('action_resend') as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/frontend/packages/design/src/components/flow/adapters/BlockAdapter.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/BlockAdapter.tsx
@@ -78,7 +78,7 @@ interface ResendButtonAdapterProps {
   onClick: () => void;
 }
 
-function ResendButtonAdapter({component, isLoading, resolve, onClick}: ResendButtonAdapterProps): JSX.Element {
+export function ResendButtonAdapter({component, isLoading, resolve, onClick}: ResendButtonAdapterProps): JSX.Element {
   const {t} = useTranslation();
 
   return (


### PR DESCRIPTION
### Purpose

SELECT and RESEND elements could not be dropped anywhere in the flow builder. They were missing from every drag and drop accept list in `VisualFlowConstants`, so no droppable was elected and the drop was silently a no-op.

### Approach

- Add `SELECT` beside `DROPDOWN` in the canvas, view and form accept lists, and `RESEND` beside `ACTION` in the view, form and stack lists. RESEND is intentionally not allowed directly on the canvas, matching ACTION.
- Add `SELECT` to `INPUT_ELEMENT_TYPES` in `componentMutations` (so the add button routes it into a form) and in `reactFlowTransformer` (so it serializes into `prompts[].inputs` with a `ref` and the lone button promotes to `SUBMIT`).
- Render a standalone RESEND in `FlowComponentRenderer`. Previously RESEND was only rendered by `BlockAdapter`, so a RESEND placed on a view or stack disappeared at runtime. It now reuses the exported `ResendButtonAdapter`, dispatching its own action.

Unit tests added for each of the above, including a guard that SELECT is allowed exactly where DROPDOWN is and RESEND exactly where ACTION is.

### Related Issues
- Fixes #3479

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Select fields in the flow builder, including forms and canvas placement.
  * Added support for Resend buttons in standalone and stacked flow components.
  * Resend buttons now submit current form values and show a loading state while processing.

* **Bug Fixes**
  * Select fields are correctly recognized as form inputs and serialized as required prompt inputs.
  * Forms with Select fields and action buttons now transform correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->