### PR TITLE
Remove app authorization filtering from token exchange

### DIFF
--- a/backend/internal/oauth/oauth2/granthandlers/provider.go
+++ b/backend/internal/oauth/oauth2/granthandlers/provider.go
@@ -65,7 +65,7 @@ func newGrantHandlerProvider(
 	}
 	if isGrantTypeAllowed(allowedGrantTypes, providers.GrantTypeTokenExchange) {
 		grantProvider.tokenExchangeGrantHandler = newTokenExchangeGrantHandler(
-			tokenBuilder, tokenValidator, rbacAuthzService, actorProvider, resourceService, cfg)
+			tokenBuilder, tokenValidator, resourceService, cfg)
 	}
 	if isGrantTypeAllowed(allowedGrantTypes, providers.GrantTypeCIBA) {
 		grantProvider.cibaGrantHandler = newCIBAGrantHandler(cibaService, tokenBuilder, attrCacheService,

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
@@ -26,8 +26,6 @@ import (
 type tokenExchangeGrantHandler struct {
 	tokenBuilder    tokenservice.TokenBuilderInterface
 	tokenValidator  tokenservice.TokenValidatorInterface
-	authzService    providers.AuthorizationProvider
-	actorProvider   providers.ActorProvider
 	resourceService providers.ResourceServerProvider
 	cfg             oauthconfig.Config
 }
@@ -36,16 +34,12 @@ type tokenExchangeGrantHandler struct {
 func newTokenExchangeGrantHandler(
 	tokenBuilder tokenservice.TokenBuilderInterface,
 	tokenValidator tokenservice.TokenValidatorInterface,
-	authzService providers.AuthorizationProvider,
-	actorProvider providers.ActorProvider,
 	resourceService providers.ResourceServerProvider,
 	cfg oauthconfig.Config,
 ) GrantHandlerInterface {
 	return &tokenExchangeGrantHandler{
 		tokenBuilder:    tokenBuilder,
 		tokenValidator:  tokenValidator,
-		authzService:    authzService,
-		actorProvider:   actorProvider,
 		resourceService: resourceService,
 		cfg:             cfg,
 	}
@@ -255,7 +249,7 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 	}
 
 	// Retain OIDC scopes (governed by the app's scope-to-claims mapping); only permission scopes
-	// are downscoped to the target resource server and filtered by the app's authorization.
+	// are downscoped to the target resource server.
 	oidcScopes, permissionScopes := oauth2utils.SeparateOIDCAndNonOIDCScopes(
 		tokenservice.JoinScopes(finalScopes), oauthApp.ScopeClaims)
 
@@ -278,10 +272,6 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 			ctx, h.resourceService, targetRS.ID, permissionScopes)
 		if resErr != nil {
 			return nil, resErr
-		}
-		permissionScopes, errResp = h.filterScopesAuthorizedForApp(ctx, oauthApp, targetRS.ID, permissionScopes)
-		if errResp != nil {
-			return nil, errResp
 		}
 
 		finalScopes = make([]string, 0, len(oidcScopes)+len(permissionScopes))
@@ -505,56 +495,4 @@ func (h *tokenExchangeGrantHandler) getScopes(
 	}
 
 	return validRequestedScopes, nil
-}
-
-func (h *tokenExchangeGrantHandler) filterScopesAuthorizedForApp(
-	ctx context.Context,
-	oauthApp *providers.OAuthClient,
-	resourceServerID string,
-	scopes []string,
-) ([]string, *model.ErrorResponse) {
-	if len(scopes) == 0 {
-		return scopes, nil
-	}
-
-	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "TokenExchangeGrantHandler"))
-
-	if h.authzService == nil {
-		logger.Error(ctx, "Authorization provider is not configured for token exchange")
-		return nil, &model.ErrorResponse{
-			Error:            constants.ErrorServerError,
-			ErrorDescription: "Failed to generate token",
-		}
-	}
-
-	var groupIDs []string
-	if h.actorProvider != nil {
-		groups, groupErr := h.actorProvider.GetActorGroups(oauthApp.ID)
-		if groupErr != nil {
-			logger.Error(ctx, "Failed to resolve app group memberships",
-				log.String("appID", oauthApp.ID), log.String("error", groupErr.Error.DefaultValue))
-			return nil, &model.ErrorResponse{
-				Error:            constants.ErrorServerError,
-				ErrorDescription: "Failed to generate token",
-			}
-		}
-		for _, group := range groups {
-			if group.ID != "" && !slices.Contains(groupIDs, group.ID) {
-				groupIDs = append(groupIDs, group.ID)
-			}
-		}
-	}
-
-	authzResp, svcErr := h.authzService.EvaluateAccessBatch(ctx,
-		buildAccessEvaluationsRequest(oauthApp.ID, groupIDs, scopes, resourceServerID))
-	if svcErr != nil {
-		logger.Error(ctx, "Failed to get authorized permissions for app",
-			log.String("appID", oauthApp.ID), log.String("error", svcErr.Error.DefaultValue))
-		return nil, &model.ErrorResponse{
-			Error:            constants.ErrorServerError,
-			ErrorDescription: "Failed to generate token",
-		}
-	}
-
-	return filterAuthorizedScopes(scopes, authzResp.Evaluations), nil
 }

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
@@ -28,8 +28,6 @@ import (
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/revocation"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/tokenservice"
 	"github.com/thunder-id/thunderid/internal/system/config"
-	"github.com/thunder-id/thunderid/tests/mocks/actorprovidermock"
-	"github.com/thunder-id/thunderid/tests/mocks/authzmock"
 	"github.com/thunder-id/thunderid/tests/mocks/jose/jwtmock"
 	"github.com/thunder-id/thunderid/tests/mocks/oauth/oauth2/tokenservicemock"
 	"github.com/thunder-id/thunderid/tests/mocks/resourcemock"
@@ -55,8 +53,6 @@ type TokenExchangeGrantHandlerTestSuite struct {
 	mockJWTService      *jwtmock.JWTServiceInterfaceMock
 	mockTokenBuilder    *tokenservicemock.TokenBuilderInterfaceMock
 	mockTokenValidator  *tokenservicemock.TokenValidatorInterfaceMock
-	mockAuthzService    *authzmock.AuthorizationProviderMock
-	mockActorProvider   *actorprovidermock.ActorProviderMock
 	mockResourceService *resourcemock.ResourceServiceInterfaceMock
 	handler             *tokenExchangeGrantHandler
 	oauthApp            *providers.OAuthClient
@@ -80,23 +76,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) SetupTest() {
 	suite.mockJWTService = jwtmock.NewJWTServiceInterfaceMock(suite.T())
 	suite.mockTokenBuilder = tokenservicemock.NewTokenBuilderInterfaceMock(suite.T())
 	suite.mockTokenValidator = tokenservicemock.NewTokenValidatorInterfaceMock(suite.T())
-	suite.mockAuthzService = authzmock.NewAuthorizationProviderMock(suite.T())
-	suite.mockActorProvider = actorprovidermock.NewActorProviderMock(suite.T())
 	suite.mockResourceService = resourcemock.NewResourceServiceInterfaceMock(suite.T())
-	suite.mockActorProvider.On("GetActorGroups", mock.Anything).
-		Return([]providers.EntityGroup{}, nil).Maybe()
-	suite.mockAuthzService.On("EvaluateAccessBatch", mock.Anything, mock.Anything).
-		Return(func(_ context.Context,
-			request providers.AccessEvaluationsRequest,
-		) *providers.AccessEvaluationsResponse {
-			evaluations := make([]providers.AccessEvaluationResponse, 0, len(request.Evaluations))
-			for range request.Evaluations {
-				evaluations = append(evaluations, providers.AccessEvaluationResponse{
-					Decision: true,
-				})
-			}
-			return &providers.AccessEvaluationsResponse{Evaluations: evaluations}
-		}, nil).Maybe()
 	// Explicit resource parameter resolves to an RS whose identifier equals the resource URI; an
 	// empty identifier resolves to the configured default resource server, as the default-aware
 	// provider does.
@@ -117,8 +97,6 @@ func (suite *TokenExchangeGrantHandlerTestSuite) SetupTest() {
 	suite.handler = &tokenExchangeGrantHandler{
 		tokenBuilder:    suite.mockTokenBuilder,
 		tokenValidator:  suite.mockTokenValidator,
-		authzService:    suite.mockAuthzService,
-		actorProvider:   suite.mockActorProvider,
 		resourceService: suite.mockResourceService,
 	}
 
@@ -252,8 +230,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) setupSuccessfulJWTMockWithScope
 // TestNewTokenExchangeGrantHandler tests the constructor
 func (suite *TokenExchangeGrantHandlerTestSuite) TestNewTokenExchangeGrantHandler() {
 	handler := newTokenExchangeGrantHandler(suite.mockTokenBuilder, suite.mockTokenValidator,
-		suite.mockAuthzService, suite.mockActorProvider, suite.mockResourceService,
-		oauthconfig.Config{})
+		suite.mockResourceService, oauthconfig.Config{})
 	assert.NotNil(suite.T(), handler)
 	assert.Implements(suite.T(), (*GrantHandlerInterface)(nil), handler)
 }
@@ -2493,8 +2470,6 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_NoResource_NoDe
 	h := &tokenExchangeGrantHandler{
 		tokenBuilder:    suite.mockTokenBuilder,
 		tokenValidator:  suite.mockTokenValidator,
-		authzService:    suite.mockAuthzService,
-		actorProvider:   suite.mockActorProvider,
 		resourceService: rsvc,
 	}
 
@@ -2603,8 +2578,6 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_RFC8707_Resourc
 	h := &tokenExchangeGrantHandler{
 		tokenBuilder:    suite.mockTokenBuilder,
 		tokenValidator:  suite.mockTokenValidator,
-		authzService:    suite.mockAuthzService,
-		actorProvider:   suite.mockActorProvider,
 		resourceService: rsvc,
 	}
 
@@ -2660,8 +2633,6 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_RFC8707_ScopeNo
 	h := &tokenExchangeGrantHandler{
 		tokenBuilder:    suite.mockTokenBuilder,
 		tokenValidator:  suite.mockTokenValidator,
-		authzService:    suite.mockAuthzService,
-		actorProvider:   suite.mockActorProvider,
 		resourceService: rsvc,
 	}
 
@@ -2669,78 +2640,6 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_RFC8707_ScopeNo
 		Return(&tokenservice.SubjectTokenClaims{
 			Sub:            testUserID,
 			Scopes:         []string{"read", "write", "admin"},
-			UserAttributes: map[string]interface{}{},
-		}, nil)
-	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
-		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-			return tokenservice.JoinScopes(ctx.Scopes) == testScopeRead
-		})).Return(&model.TokenDTO{
-		Token:     testTokenExchangeJWT,
-		TokenType: constants.TokenTypeBearer,
-		IssuedAt:  now,
-		ExpiresIn: 7200,
-		Scopes:    []string{"read"},
-		ClientID:  testClientID,
-	}, nil)
-
-	result, errResp := h.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
-
-	assert.Nil(suite.T(), errResp)
-	assert.NotNil(suite.T(), result)
-	assert.Equal(suite.T(), []string{"read"}, result.AccessToken.Scopes)
-}
-
-func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_RFC8707_ScopesNarrowedToIssuingAppPermissions() {
-	// Subject token has [read, write], target RS defines both, but the issuing OAuth app is only
-	// authorized for [read]. The exchanged token must not carry write.
-	now := time.Now().Unix()
-	subjectToken := suite.createTestJWT(map[string]interface{}{
-		"sub":   testUserID,
-		"iss":   testCustomIssuer,
-		"exp":   float64(now + 3600),
-		"nbf":   float64(now - 60),
-		"scope": "read write",
-	})
-
-	tokenRequest := suite.createBasicTokenRequest(subjectToken)
-	tokenRequest.Resources = []string{testRS01URI}
-
-	rsvc := resourcemock.NewResourceServiceInterfaceMock(suite.T())
-	rsvc.On("GetResourceServerByIdentifier", mock.Anything, testRS01URI).
-		Return(&providers.ResourceServer{ID: testRS01URI, Identifier: testRS01URI}, nil)
-	rsvc.On("ValidatePermissions", mock.Anything, testRS01URI, []string{"read", "write"}).
-		Return([]string{}, nil)
-
-	authzSvc := authzmock.NewAuthorizationProviderMock(suite.T())
-	authzSvc.On("EvaluateAccessBatch", mock.Anything,
-		mock.MatchedBy(func(req providers.AccessEvaluationsRequest) bool {
-			if len(req.Evaluations) != 2 {
-				return false
-			}
-			return req.Evaluations[0].Subject.ID == suite.oauthApp.ID &&
-				req.Evaluations[0].ResourceServer.ID == testRS01URI &&
-				req.Evaluations[0].Permission.Name == "read" &&
-				req.Evaluations[1].Permission.Name == "write"
-		})).
-		Return(&providers.AccessEvaluationsResponse{
-			Evaluations: []providers.AccessEvaluationResponse{
-				{Decision: true},
-				{Decision: false},
-			},
-		}, nil)
-
-	h := &tokenExchangeGrantHandler{
-		tokenBuilder:    suite.mockTokenBuilder,
-		tokenValidator:  suite.mockTokenValidator,
-		authzService:    authzSvc,
-		actorProvider:   suite.mockActorProvider,
-		resourceService: rsvc,
-	}
-
-	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
-		Return(&tokenservice.SubjectTokenClaims{
-			Sub:            testUserID,
-			Scopes:         []string{"read", "write"},
 			UserAttributes: map[string]interface{}{},
 		}, nil)
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
@@ -2964,82 +2863,6 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_RFC8707_Multipl
 	suite.mockTokenBuilder.AssertNotCalled(suite.T(), "BuildAccessToken", mock.Anything, mock.Anything)
 }
 
-// filterScopesAuthorizedForApp error paths.
-
-func (suite *TokenExchangeGrantHandlerTestSuite) TestFilterScopesAuthorizedForApp_NilAuthzService_ReturnsServerError() {
-	handler := &tokenExchangeGrantHandler{}
-
-	scopes, errResp := handler.filterScopesAuthorizedForApp(
-		context.Background(), suite.oauthApp, "rs-1", []string{"read"})
-
-	assert.Nil(suite.T(), scopes)
-	assert.NotNil(suite.T(), errResp)
-	assert.Equal(suite.T(), constants.ErrorServerError, errResp.Error)
-}
-
-func (suite *TokenExchangeGrantHandlerTestSuite) TestFilterScopesAuthorizedForApp_ActorGroupsError() {
-	actorProvider := actorprovidermock.NewActorProviderMock(suite.T())
-	actorProvider.On("GetActorGroups", mock.Anything).
-		Return([]providers.EntityGroup(nil), &tidcommon.ServiceError{
-			Code:  "AZ-0001",
-			Error: tidcommon.I18nMessage{DefaultValue: "group lookup failed"},
-		})
-	handler := &tokenExchangeGrantHandler{
-		authzService:  suite.mockAuthzService,
-		actorProvider: actorProvider,
-	}
-
-	scopes, errResp := handler.filterScopesAuthorizedForApp(
-		context.Background(), suite.oauthApp, "rs-1", []string{"read"})
-
-	assert.Nil(suite.T(), scopes)
-	assert.NotNil(suite.T(), errResp)
-	assert.Equal(suite.T(), constants.ErrorServerError, errResp.Error)
-}
-
-func (suite *TokenExchangeGrantHandlerTestSuite) TestFilterScopesAuthorizedForApp_EvaluateError_ReturnsServerError() {
-	authzService := authzmock.NewAuthorizationProviderMock(suite.T())
-	authzService.On("EvaluateAccessBatch", mock.Anything, mock.Anything).
-		Return((*providers.AccessEvaluationsResponse)(nil), &tidcommon.ServiceError{
-			Code:  "AZ-0002",
-			Error: tidcommon.I18nMessage{DefaultValue: "evaluation failed"},
-		})
-	// actorProvider is nil, so app group resolution is skipped and evaluation runs directly.
-	handler := &tokenExchangeGrantHandler{authzService: authzService}
-
-	scopes, errResp := handler.filterScopesAuthorizedForApp(
-		context.Background(), suite.oauthApp, "rs-1", []string{"read"})
-
-	assert.Nil(suite.T(), scopes)
-	assert.NotNil(suite.T(), errResp)
-	assert.Equal(suite.T(), constants.ErrorServerError, errResp.Error)
-}
-
-func (suite *TokenExchangeGrantHandlerTestSuite) TestFilterScopesAuthorizedForApp_WithAppGroups() {
-	actorProvider := actorprovidermock.NewActorProviderMock(suite.T())
-	actorProvider.On("GetActorGroups", mock.Anything).
-		Return([]providers.EntityGroup{{ID: "group-1"}}, nil)
-	authzService := authzmock.NewAuthorizationProviderMock(suite.T())
-	authzService.On("EvaluateAccessBatch", mock.Anything, mock.Anything).
-		Return(
-			func(_ context.Context, request providers.AccessEvaluationsRequest) *providers.AccessEvaluationsResponse {
-				evaluations := make([]providers.AccessEvaluationResponse, 0, len(request.Evaluations))
-				for range request.Evaluations {
-					evaluations = append(evaluations, providers.AccessEvaluationResponse{Decision: true})
-				}
-				return &providers.AccessEvaluationsResponse{Evaluations: evaluations}
-			},
-			nil,
-		)
-	handler := &tokenExchangeGrantHandler{authzService: authzService, actorProvider: actorProvider}
-
-	scopes, errResp := handler.filterScopesAuthorizedForApp(
-		context.Background(), suite.oauthApp, "rs-1", []string{"read"})
-
-	assert.Nil(suite.T(), errResp)
-	assert.Equal(suite.T(), []string{"read"}, scopes)
-}
-
 func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_DownscopeValidationError() {
 	now := time.Now().Unix()
 	subjectToken := suite.createTestJWT(map[string]interface{}{
@@ -3059,51 +2882,6 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_DownscopeValida
 	handler := &tokenExchangeGrantHandler{
 		tokenBuilder:    suite.mockTokenBuilder,
 		tokenValidator:  suite.mockTokenValidator,
-		authzService:    suite.mockAuthzService,
-		actorProvider:   suite.mockActorProvider,
-		resourceService: rsvc,
-	}
-	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).
-		Return(&tokenservice.SubjectTokenClaims{
-			Sub:            testUserID,
-			Scopes:         []string{"read"},
-			UserAttributes: map[string]interface{}{},
-		}, nil)
-
-	result, errResp := handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
-
-	assert.Nil(suite.T(), result)
-	assert.NotNil(suite.T(), errResp)
-	assert.Equal(suite.T(), constants.ErrorServerError, errResp.Error)
-}
-
-func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_AppAuthorizationError() {
-	now := time.Now().Unix()
-	subjectToken := suite.createTestJWT(map[string]interface{}{
-		"sub": testUserID,
-		"iss": testCustomIssuer,
-		"exp": float64(now + 3600),
-		"nbf": float64(now - 60),
-	})
-	tokenRequest := suite.createBasicTokenRequest(subjectToken)
-	tokenRequest.Resources = []string{"https://rs.example.com"}
-
-	rsvc := resourcemock.NewResourceServiceInterfaceMock(suite.T())
-	rsvc.On("GetResourceServerByIdentifier", mock.Anything, "https://rs.example.com").
-		Return(&providers.ResourceServer{ID: "rs-x", Identifier: "https://rs.example.com"}, nil)
-	rsvc.On("ValidatePermissions", mock.Anything, mock.Anything, mock.Anything).
-		Return([]string{}, nil)
-	authzService := authzmock.NewAuthorizationProviderMock(suite.T())
-	authzService.On("EvaluateAccessBatch", mock.Anything, mock.Anything).
-		Return((*providers.AccessEvaluationsResponse)(nil), &tidcommon.ServiceError{
-			Type: tidcommon.ServerErrorType,
-			Code: "AZ-5000",
-		})
-	// actorProvider nil so app group resolution is skipped and evaluation runs directly.
-	handler := &tokenExchangeGrantHandler{
-		tokenBuilder:    suite.mockTokenBuilder,
-		tokenValidator:  suite.mockTokenValidator,
-		authzService:    authzService,
 		resourceService: rsvc,
 	}
 	suite.mockTokenValidator.On("ValidateSubjectToken", mock.Anything, subjectToken, suite.oauthApp).


### PR DESCRIPTION
### Purpose

Removes the application-level authorization check from the token exchange grant handler (RFC 8693).

Previously, when an exchanged token was bound to a target resource server, thehandler gated each requested permission scope on the issuing OAuth application's RBAC entitlements. It resolved the application's transitive group memberships,then evaluated roles assigned directly to the application plus roles inherited through those groups. Scopes the application was not entitled to were silently dropped from the issued token.

That check is now gone. Permission scopes are still downscoped to the target resource server, so an issued token carries the intersection of the subject token's scopes and the scopes that resource server defines.

Behavior worth calling out: any client permitted to use the token exchange grant can now obtain any scope the target resource server defines, provided the subject token carries that scope. Authorization of the exchanged scopes is inherited from the subject token rather than re-evaluated against the client. No client code or configuration needs to change, but issued tokens may now carry scopes that were previously filtered out.

Not affected by this change:

- The `client_credentials` grant keeps its equivalent filter.
- The ID-JAG issuance path never ran this filter.
- Requests that resolve no target resource server behave exactly as before
  (OIDC scopes only, bound to the application's default audience).

### Approach

This is a surgical removal rather than a revert. `filterScopesAuthorizedForApp` was introduced in `bbc8b68ed` ("Bind OAuth tokens to one resource server with default fallback"), a commit that bundled two unrelated changes: the single-resource-server audience binding and this authorization filter. Reverting that commit would also undo the audience binding, which is staying.

**`backend/internal/oauth/oauth2/granthandlers/token_exchange.go`**

- Deleted `filterScopesAuthorizedForApp` and its call site in `HandleGrant`.
- Removed the now-unused `authzService` (`providers.AuthorizationProvider`) and
  `actorProvider` (`providers.ActorProvider`) struct fields and the matching
  constructor parameters.
- Corrected the comment claiming permission scopes are "filtered by the app's
  authorization".

`DownscopeToResourceServer` is deliberately retained, so scopes remain narrowed
to the target resource server's defined permissions.

**`backend/internal/oauth/oauth2/granthandlers/provider.go`**

- Dropped the two arguments from the `newTokenExchangeGrantHandler` call.
  `newGrantHandlerProvider`'s own parameters are unchanged, because the client
  credentials handler still consumes them.

**Tests**

Removed the tests whose entire premise was the removed filter:

- `TestHandleGrant_RFC8707_ScopesNarrowedToIssuingAppPermissions`
- `TestFilterScopesAuthorizedForApp_NilAuthzService_ReturnsServerError`
- `TestFilterScopesAuthorizedForApp_ActorGroupsError`
- `TestFilterScopesAuthorizedForApp_EvaluateError_ReturnsServerError`
- `TestFilterScopesAuthorizedForApp_WithAppGroups`
- `TestHandleGrant_AppAuthorizationError`

Along with the supporting scaffolding: the `mockAuthzService` and
`mockActorProvider` suite fields and their constructors, the `GetActorGroups`
and `EvaluateAccessBatch` stubs, the mock wiring in the remaining handler
literals, the constructor test signature, and the two mock imports left unused.

Integration tests needed no changes.
`tests/integration/oauth/token/tokenexchange_test.go` makes no scope assertions,
and its test application has no role assignments, so the filter was already
dropping its permission scopes with nothing asserting on the result.

Net diff: 3 insertions, 287 deletions.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Token exchange scope handling is now managed through the resource server.
  * OIDC scopes continue to follow application OIDC configuration.
  * Removed obsolete authorization filtering from token exchange processing.
  * Updated token exchange behavior and validation coverage to reflect the streamlined flow.
  * Scope downscoping and validation errors now follow a more consistent, resource-based process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->