### PR TITLE
Add support to handle OTP length configuration in flows

### DIFF
--- a/backend/internal/flow/common/constants.go
+++ b/backend/internal/flow/common/constants.go
@@ -86,6 +86,9 @@ const (
 	DataOpenID4VPRequestURI = "openid4vpRequestUri"
 	// DataOpenID4VPWalletURI is the openid4vp:// authorization URI for the wallet.
 	DataOpenID4VPWalletURI = "openid4vpWalletUri"
+	// DataOTPLength is the character length of the OTP minted by the OTP executor in generate mode,
+	// surfaced so the client renders the matching number of input boxes.
+	DataOTPLength = "otpLength"
 )
 
 // Error assertion claims.

--- a/backend/internal/flow/executor/otp_executor.go
+++ b/backend/internal/flow/executor/otp_executor.go
@@ -164,6 +164,9 @@ func (e *otpExecutor) executeGenerate(ctx *providers.NodeContext,
 
 	execResp.RuntimeData[common.RuntimeKeyOTPSessionToken] = sessionToken
 	execResp.RuntimeData[common.RuntimeKeyOTPAttemptCount] = strconv.Itoa(attemptCount + 1)
+	// Published from the generated value rather than the configured otpLength property, since the
+	// property is clamped and may fall back to the server default.
+	execResp.AdditionalData[common.DataOTPLength] = strconv.Itoa(len(otpValue))
 	execResp.ForwardedData[common.ForwardedDataKeyTemplateData] = map[string]interface{}{
 		common.ForwardedDataKeyOTPCode:       otpValue,
 		common.ForwardedDataKeyExpiryMinutes: systemutils.SecondsToMinutes(expirySeconds),

--- a/backend/internal/flow/executor/otp_executor_test.go
+++ b/backend/internal/flow/executor/otp_executor_test.go
@@ -150,9 +150,73 @@ func (suite *OTPExecutorTestSuite) TestExecuteGenerate_Success_UserIdentifiedAnd
 	assert.Equal(suite.T(), providers.ExecComplete, resp.Status)
 	assert.Equal(suite.T(), "session-tok-1", resp.RuntimeData[common.RuntimeKeyOTPSessionToken])
 	assert.Equal(suite.T(), "1", resp.RuntimeData[common.RuntimeKeyOTPAttemptCount])
+	assert.Equal(suite.T(), "6", resp.AdditionalData[common.DataOTPLength])
 	fwdData, ok := resp.ForwardedData[common.ForwardedDataKeyTemplateData].(map[string]interface{})
 	assert.True(suite.T(), ok)
 	assert.Equal(suite.T(), "654321", fwdData[common.ForwardedDataKeyOTPCode])
+}
+
+func (suite *OTPExecutorTestSuite) TestExecuteGenerate_PublishesConfiguredOTPLength() {
+	userID := testOTPUserID
+	suite.mockEntityProvider.On("IdentifyEntity", mock.Anything).Return(&userID, nil)
+
+	suite.mockOTPService.On("GenerateOTP",
+		mock.Anything, userID, authnprovidercm.UserAttributeUserID,
+		mock.Anything).
+		Return("session-tok-len-8", "12345678", int64(300), (*tidcommon.ServiceError)(nil))
+
+	ctx := &providers.NodeContext{
+		ExecutionID:  "exec-otp-len-8",
+		FlowType:     providers.FlowTypeAuthentication,
+		ExecutorMode: ExecutorModeGenerate,
+		NodeInputs: []providers.Input{
+			{Ref: "mobile_input", Identifier: common.AttributeMobileNumber,
+				Type: providers.InputTypePhone, Required: true},
+		},
+		NodeProperties: map[string]interface{}{propertyKeyOTPLength: 8},
+		UserInputs: map[string]string{
+			common.AttributeMobileNumber: "+1234567890",
+		},
+		RuntimeData: map[string]string{},
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecComplete, resp.Status)
+	assert.Equal(suite.T(), "8", resp.AdditionalData[common.DataOTPLength])
+}
+
+// The otpLength property is clamped by the OTP service and falls back to the server default when
+// out of range, so the published length must come from the generated value rather than the property.
+func (suite *OTPExecutorTestSuite) TestExecuteGenerate_PublishedLengthFollowsGeneratedValue() {
+	userID := testOTPUserID
+	suite.mockEntityProvider.On("IdentifyEntity", mock.Anything).Return(&userID, nil)
+
+	suite.mockOTPService.On("GenerateOTP",
+		mock.Anything, userID, authnprovidercm.UserAttributeUserID,
+		mock.Anything).
+		Return("session-tok-clamped", "654321", int64(300), (*tidcommon.ServiceError)(nil))
+
+	ctx := &providers.NodeContext{
+		ExecutionID:  "exec-otp-len-clamped",
+		FlowType:     providers.FlowTypeAuthentication,
+		ExecutorMode: ExecutorModeGenerate,
+		NodeInputs: []providers.Input{
+			{Ref: "mobile_input", Identifier: common.AttributeMobileNumber,
+				Type: providers.InputTypePhone, Required: true},
+		},
+		NodeProperties: map[string]interface{}{propertyKeyOTPLength: 99},
+		UserInputs: map[string]string{
+			common.AttributeMobileNumber: "+1234567890",
+		},
+		RuntimeData: map[string]string{},
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "6", resp.AdditionalData[common.DataOTPLength])
 }
 
 func (suite *OTPExecutorTestSuite) TestExecuteGenerate_MultipleInputs_IdentifiesUserByAllAttrs() {
@@ -216,6 +280,7 @@ func (suite *OTPExecutorTestSuite) TestExecuteGenerate_UserNotFound_ReturnsFailu
 	assert.Equal(suite.T(), providers.ExecFailure, resp.Status)
 	assert.NotNil(suite.T(), resp.Error)
 	assert.Equal(suite.T(), ErrUserNotFound.Code, resp.Error.Code)
+	assert.NotContains(suite.T(), resp.AdditionalData, common.DataOTPLength)
 }
 
 func (suite *OTPExecutorTestSuite) TestExecuteGenerate_Registration_UserNotFound_UsesMobileDestValue() {
@@ -297,6 +362,7 @@ func (suite *OTPExecutorTestSuite) TestExecuteGenerate_MaxAttemptsReached_Return
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), providers.ExecFailure, resp.Status)
 	assert.NotNil(suite.T(), resp.Error)
+	assert.NotContains(suite.T(), resp.AdditionalData, common.DataOTPLength)
 }
 
 func (suite *OTPExecutorTestSuite) TestExecuteGenerate_MaxAttemptsFromNodeProperties() {

--- a/frontend/apps/console/src/features/flows/components/resources/elements/CommonElementFactory.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/elements/CommonElementFactory.tsx
@@ -95,7 +95,7 @@ function CommonElementFactory({
     return <PhoneNumberInputAdapter resource={resource} />;
   }
   if (resource.type === ElementTypes.OtpInput) {
-    return <OTPInputAdapter resource={resource} />;
+    return <OTPInputAdapter resource={resource} stepId={stepId} />;
   }
   if (
     resource.type === ElementTypes.TextInput ||

--- a/frontend/apps/console/src/features/flows/components/resources/elements/adapters/input/OTPInputAdapter.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/elements/adapters/input/OTPInputAdapter.tsx
@@ -3,11 +3,13 @@
 
 import {useTemplateLiteralResolver} from '@thunderid/hooks';
 import {Box, FormHelperText, InputLabel, OutlinedInput} from '@wso2/oxygen-ui';
+import {useEdges, useNodes} from '@xyflow/react';
 import {type CSSProperties, type ReactElement, type ReactNode} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Hint} from '../../hint';
 import TemplatePlaceholder, {containsTemplateLiteral} from '../TemplatePlaceholder';
 import type {Element as FlowElement} from '@/features/flows/models/elements';
+import resolveUpstreamOtpLength from '@/features/flows/utils/resolveUpstreamOtpLength';
 
 /**
  * OTP Input element type with properties at top level.
@@ -29,6 +31,10 @@ export interface OTPInputAdapterPropsInterface {
    * The OTP input element properties.
    */
   resource: FlowElement;
+  /**
+   * The step id the element resides on, used to locate the Generate OTP node that feeds it.
+   */
+  stepId: string;
 }
 
 /**
@@ -37,11 +43,14 @@ export interface OTPInputAdapterPropsInterface {
  * @param props - Props injected to the component.
  * @returns The OTPInputAdapter component.
  */
-function OTPInputAdapter({resource}: OTPInputAdapterPropsInterface): ReactElement {
+function OTPInputAdapter({resource, stepId}: OTPInputAdapterPropsInterface): ReactElement {
   const {t} = useTranslation();
   const {resolve} = useTemplateLiteralResolver();
+  const nodes = useNodes();
+  const edges = useEdges();
 
   const otpElement = resource as OTPInputElement;
+  const otpLength = resolveUpstreamOtpLength(stepId, nodes, edges);
 
   const rawLabel = otpElement?.label ?? '';
   const labelNode: ReactNode = containsTemplateLiteral(rawLabel) ? (
@@ -56,7 +65,7 @@ function OTPInputAdapter({resource}: OTPInputAdapterPropsInterface): ReactElemen
         {labelNode}
       </InputLabel>
       <Box display="flex" flexDirection="row" gap={1}>
-        {Array.from({length: 6}, (_, index) => (
+        {Array.from({length: otpLength}, (_, index) => (
           <OutlinedInput
             key={index}
             size="small"

--- a/frontend/apps/console/src/features/flows/components/resources/elements/adapters/input/__tests__/OTPInputAdapter.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/elements/adapters/input/__tests__/OTPInputAdapter.test.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {render, screen} from '@testing-library/react';
+import {ReactFlowProvider, type Edge, type Node} from '@xyflow/react';
 import type {ReactNode} from 'react';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import OTPInputAdapter from '../OTPInputAdapter';
@@ -35,6 +36,13 @@ describe('OTPInputAdapter', () => {
       ...overrides,
     }) as FlowElement;
 
+  const renderAdapter = (resource: FlowElement, nodes: Node[] = [], edges: Edge[] = []) =>
+    render(
+      <ReactFlowProvider initialNodes={nodes} initialEdges={edges}>
+        <OTPInputAdapter resource={resource} stepId="prompt" />
+      </ReactFlowProvider>,
+    );
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -43,7 +51,7 @@ describe('OTPInputAdapter', () => {
     it('should render InputLabel component', () => {
       const resource = createMockElement();
 
-      const {container} = render(<OTPInputAdapter resource={resource} />);
+      const {container} = renderAdapter(resource);
 
       expect(container.querySelector('.MuiInputLabel-root')).toBeInTheDocument();
     });
@@ -51,7 +59,7 @@ describe('OTPInputAdapter', () => {
     it('should render label text', () => {
       const resource = createMockElement({label: 'Verification Code'});
 
-      render(<OTPInputAdapter resource={resource} />);
+      renderAdapter(resource);
 
       expect(screen.getByText('Verification Code')).toBeInTheDocument();
     });
@@ -59,10 +67,30 @@ describe('OTPInputAdapter', () => {
     it('should render 6 input boxes for OTP', () => {
       const resource = createMockElement();
 
-      const {container} = render(<OTPInputAdapter resource={resource} />);
+      const {container} = renderAdapter(resource);
 
       const inputs = container.querySelectorAll('.MuiOutlinedInput-root');
       expect(inputs).toHaveLength(6);
+    });
+
+    it('should render the length configured on the upstream Generate OTP node', () => {
+      const resource = createMockElement();
+      const nodes: Node[] = [
+        {
+          id: 'generate',
+          position: {x: 0, y: 0},
+          data: {
+            action: {executor: {name: 'OTPExecutor', mode: 'generate'}},
+            properties: {otpLength: 8},
+          },
+        },
+        {id: 'prompt', position: {x: 0, y: 0}, data: {}},
+      ];
+      const edges: Edge[] = [{id: 'generate-prompt', source: 'generate', target: 'prompt'}];
+
+      const {container} = renderAdapter(resource, nodes, edges);
+
+      expect(container.querySelectorAll('.MuiOutlinedInput-root')).toHaveLength(8);
     });
   });
 
@@ -70,7 +98,7 @@ describe('OTPInputAdapter', () => {
     it('should show required indicator when required is true', () => {
       const resource = createMockElement({required: true});
 
-      const {container} = render(<OTPInputAdapter resource={resource} />);
+      const {container} = renderAdapter(resource);
 
       expect(container.querySelector('.MuiFormLabel-asterisk')).toBeInTheDocument();
     });
@@ -78,7 +106,7 @@ describe('OTPInputAdapter', () => {
     it('should not show required indicator when required is false', () => {
       const resource = createMockElement({required: false});
 
-      const {container} = render(<OTPInputAdapter resource={resource} />);
+      const {container} = renderAdapter(resource);
 
       expect(container.querySelector('.MuiFormLabel-asterisk')).not.toBeInTheDocument();
     });
@@ -88,7 +116,7 @@ describe('OTPInputAdapter', () => {
     it('should render hint when provided', () => {
       const resource = createMockElement({hint: 'Check your email for the code'});
 
-      render(<OTPInputAdapter resource={resource} />);
+      renderAdapter(resource);
 
       expect(screen.getByTestId('hint')).toHaveTextContent('Check your email for the code');
     });
@@ -96,7 +124,7 @@ describe('OTPInputAdapter', () => {
     it('should not render hint when not provided', () => {
       const resource = createMockElement({hint: undefined});
 
-      render(<OTPInputAdapter resource={resource} />);
+      renderAdapter(resource);
 
       expect(screen.queryByTestId('hint')).not.toBeInTheDocument();
     });
@@ -104,7 +132,7 @@ describe('OTPInputAdapter', () => {
     it('should not render hint when empty', () => {
       const resource = createMockElement({hint: ''});
 
-      render(<OTPInputAdapter resource={resource} />);
+      renderAdapter(resource);
 
       expect(screen.queryByTestId('hint')).not.toBeInTheDocument();
     });
@@ -114,7 +142,7 @@ describe('OTPInputAdapter', () => {
     it('should render placeholder on OTP inputs when provided', () => {
       const resource = createMockElement({placeholder: '0'});
 
-      const {container} = render(<OTPInputAdapter resource={resource} />);
+      const {container} = renderAdapter(resource);
 
       const inputs = container.querySelectorAll('input');
       inputs.forEach((input) => {
@@ -125,7 +153,7 @@ describe('OTPInputAdapter', () => {
     it('should render empty placeholder when not provided', () => {
       const resource = createMockElement({placeholder: undefined});
 
-      const {container} = render(<OTPInputAdapter resource={resource} />);
+      const {container} = renderAdapter(resource);
 
       const inputs = container.querySelectorAll('input');
       inputs.forEach((input) => {
@@ -138,7 +166,7 @@ describe('OTPInputAdapter', () => {
     it('should apply input type to OTP fields', () => {
       const resource = createMockElement({inputType: 'number'});
 
-      const {container} = render(<OTPInputAdapter resource={resource} />);
+      const {container} = renderAdapter(resource);
 
       const inputs = container.querySelectorAll('input');
       inputs.forEach((input) => {
@@ -151,7 +179,7 @@ describe('OTPInputAdapter', () => {
     it('should apply className when provided', () => {
       const resource = createMockElement({classes: 'custom-otp'});
 
-      const {container} = render(<OTPInputAdapter resource={resource} />);
+      const {container} = renderAdapter(resource);
 
       expect(container.firstChild).toHaveClass('custom-otp');
     });
@@ -159,7 +187,7 @@ describe('OTPInputAdapter', () => {
     it('should apply styles to inputs when provided', () => {
       const resource = createMockElement({styles: {width: '40px'}});
 
-      const {container} = render(<OTPInputAdapter resource={resource} />);
+      const {container} = renderAdapter(resource);
 
       const outlinedInputs = container.querySelectorAll('.MuiOutlinedInput-root');
       outlinedInputs.forEach((input) => {
@@ -172,7 +200,7 @@ describe('OTPInputAdapter', () => {
     it('should handle empty label', () => {
       const resource = createMockElement({label: ''});
 
-      const {container} = render(<OTPInputAdapter resource={resource} />);
+      const {container} = renderAdapter(resource);
 
       const label = container.querySelector('.MuiInputLabel-root');
       expect(label).toHaveTextContent('');
@@ -181,7 +209,7 @@ describe('OTPInputAdapter', () => {
     it('should handle undefined label', () => {
       const resource = createMockElement({label: undefined});
 
-      const {container} = render(<OTPInputAdapter resource={resource} />);
+      const {container} = renderAdapter(resource);
 
       const label = container.querySelector('.MuiInputLabel-root');
       expect(label).toHaveTextContent('');

--- a/frontend/apps/console/src/features/flows/data/executors.json
+++ b/frontend/apps/console/src/features/flows/data/executors.json
@@ -48,14 +48,15 @@
             }
           ]
         },
-        "properties": {
-          "otpLength": 6,
-          "otpUseNumericOnly": true,
-          "otpValidityPeriodSeconds": 120
-        },
         "onSuccess": "",
         "onFailure": "",
         "onIncomplete": ""
+      },
+      "properties": {
+        "otpLength": 6,
+        "otpUseNumericOnly": true,
+        "otpValidityPeriodSeconds": 120,
+        "maxAttempts": 3
       }
     }
   },
@@ -77,14 +78,15 @@
           "name": "OTPExecutor",
           "mode": "verify"
         },
-        "properties": {
-          "otpLength": 6,
-          "otpUseNumericOnly": true,
-          "otpValidityPeriodSeconds": 120
-        },
         "onSuccess": "",
         "onFailure": "",
         "onIncomplete": ""
+      },
+      "properties": {
+        "otpLength": 6,
+        "otpUseNumericOnly": true,
+        "otpValidityPeriodSeconds": 120,
+        "maxAttempts": 3
       }
     }
   },

--- a/frontend/apps/console/src/features/flows/utils/__tests__/resolveUpstreamOtpLength.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/resolveUpstreamOtpLength.test.ts
@@ -1,0 +1,95 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import type {Edge, Node} from '@xyflow/react';
+import {describe, it, expect} from 'vitest';
+import resolveUpstreamOtpLength, {DEFAULT_OTP_LENGTH} from '../resolveUpstreamOtpLength';
+
+const generateNode = (id: string, otpLength?: unknown): Node => ({
+  id,
+  position: {x: 0, y: 0},
+  data: {
+    action: {executor: {name: 'OTPExecutor', mode: 'generate'}},
+    ...(otpLength === undefined ? {} : {properties: {otpLength}}),
+  },
+});
+
+const plainNode = (id: string, executorName?: string, mode?: string): Node => ({
+  id,
+  position: {x: 0, y: 0},
+  data: executorName ? {action: {executor: {name: executorName, mode}}} : {},
+});
+
+const edge = (source: string, target: string): Edge => ({id: `${source}-${target}`, source, target});
+
+describe('resolveUpstreamOtpLength', () => {
+  it('reads the length from the generate node feeding the step', () => {
+    const nodes = [generateNode('generate', 8), plainNode('prompt')];
+    const edges = [edge('generate', 'prompt')];
+
+    expect(resolveUpstreamOtpLength('prompt', nodes, edges)).toBe(8);
+  });
+
+  it('walks through intermediate nodes to reach the generate node', () => {
+    const nodes = [generateNode('generate', 4), plainNode('send', 'SMSExecutor'), plainNode('prompt')];
+    const edges = [edge('generate', 'send'), edge('send', 'prompt')];
+
+    expect(resolveUpstreamOtpLength('prompt', nodes, edges)).toBe(4);
+  });
+
+  it('picks the nearest generate node when a flow has several OTP legs', () => {
+    const nodes = [
+      generateNode('generate_email', 4),
+      plainNode('prompt_email'),
+      generateNode('generate_sms', 8),
+      plainNode('prompt_sms'),
+    ];
+    const edges = [
+      edge('generate_email', 'prompt_email'),
+      edge('prompt_email', 'generate_sms'),
+      edge('generate_sms', 'prompt_sms'),
+    ];
+
+    expect(resolveUpstreamOtpLength('prompt_sms', nodes, edges)).toBe(8);
+    expect(resolveUpstreamOtpLength('prompt_email', nodes, edges)).toBe(4);
+  });
+
+  it('falls back to the default when the generate node has no configured length', () => {
+    const nodes = [generateNode('generate'), plainNode('prompt')];
+    const edges = [edge('generate', 'prompt')];
+
+    expect(resolveUpstreamOtpLength('prompt', nodes, edges)).toBe(DEFAULT_OTP_LENGTH);
+  });
+
+  it.each([[3], [11], ['abc'], [0], [6.5]])('falls back to the default for an unusable length %s', (otpLength) => {
+    const nodes = [generateNode('generate', otpLength), plainNode('prompt')];
+    const edges = [edge('generate', 'prompt')];
+
+    expect(resolveUpstreamOtpLength('prompt', nodes, edges)).toBe(DEFAULT_OTP_LENGTH);
+  });
+
+  it('falls back to the default when the step has no upstream generate node', () => {
+    const nodes = [plainNode('start'), plainNode('prompt')];
+    const edges = [edge('start', 'prompt')];
+
+    expect(resolveUpstreamOtpLength('prompt', nodes, edges)).toBe(DEFAULT_OTP_LENGTH);
+  });
+
+  it('falls back to the default for an unwired step', () => {
+    expect(resolveUpstreamOtpLength('prompt', [plainNode('prompt')], [])).toBe(DEFAULT_OTP_LENGTH);
+  });
+
+  it('ignores a verify mode OTP node', () => {
+    const nodes = [plainNode('verify', 'OTPExecutor', 'verify'), plainNode('prompt')];
+    const edges = [edge('verify', 'prompt')];
+
+    expect(resolveUpstreamOtpLength('prompt', nodes, edges)).toBe(DEFAULT_OTP_LENGTH);
+  });
+
+  it('terminates on a cyclic graph', () => {
+    const nodes = [plainNode('a'), plainNode('b')];
+    const edges = [edge('a', 'b'), edge('b', 'a')];
+
+    expect(resolveUpstreamOtpLength('a', nodes, edges)).toBe(DEFAULT_OTP_LENGTH);
+  });
+});

--- a/frontend/apps/console/src/features/flows/utils/resolveUpstreamOtpLength.ts
+++ b/frontend/apps/console/src/features/flows/utils/resolveUpstreamOtpLength.ts
@@ -1,0 +1,89 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import type {Edge, Node} from '@xyflow/react';
+import {ExecutionTypes, type StepData} from '@/features/flows/models/steps';
+
+/**
+ * Digit count previewed when no upstream Generate OTP node resolves a usable length.
+ * Matches the server default.
+ */
+export const DEFAULT_OTP_LENGTH = 6;
+
+/**
+ * Bounds the backend accepts for the `otpLength` executor property. A value outside this range is
+ * ignored at runtime in favour of the server default, so the preview follows suit.
+ */
+const MIN_OTP_LENGTH = 4;
+const MAX_OTP_LENGTH = 10;
+
+const OTP_GENERATE_MODE = 'generate';
+
+/**
+ * Checks whether a node is an OTP executor running in generate mode.
+ *
+ * @param node - The canvas node to inspect.
+ * @returns Whether the node mints an OTP.
+ */
+const isOtpGenerateNode = (node: Node): boolean => {
+  const executor = (node.data as StepData | undefined)?.action?.executor;
+
+  return executor?.name === ExecutionTypes.OTPExecutor && executor?.mode === OTP_GENERATE_MODE;
+};
+
+/**
+ * Reads a usable `otpLength` from a node, or undefined when it is unset or out of range.
+ *
+ * @param node - The Generate OTP node.
+ * @returns The configured length, or undefined.
+ */
+const readOtpLength = (node: Node): number | undefined => {
+  const length = Number((node.data as StepData | undefined)?.properties?.['otpLength']);
+
+  if (!Number.isInteger(length) || length < MIN_OTP_LENGTH || length > MAX_OTP_LENGTH) {
+    return undefined;
+  }
+
+  return length;
+};
+
+/**
+ * Resolves the number of OTP boxes to preview for a step by walking the flow backwards to the
+ * nearest Generate OTP node. This mirrors runtime behaviour, where the code a prompt collects is
+ * the one minted by the generate step that precedes it, so a flow with two OTP legs previews each
+ * leg with its own length.
+ *
+ * @param stepId - The step the OTP element resides on.
+ * @param nodes - All canvas nodes.
+ * @param edges - All canvas edges.
+ * @returns The configured OTP length, or {@link DEFAULT_OTP_LENGTH} when it cannot be resolved.
+ */
+const resolveUpstreamOtpLength = (stepId: string, nodes: Node[], edges: Edge[]): number => {
+  const nodesById = new Map(nodes.map((node) => [node.id, node]));
+  const visited = new Set<string>([stepId]);
+  let frontier: string[] = [stepId];
+
+  while (frontier.length > 0) {
+    const predecessors: string[] = [];
+
+    edges.forEach((edge) => {
+      if (!frontier.includes(edge.target) || visited.has(edge.source)) return;
+      visited.add(edge.source);
+      predecessors.push(edge.source);
+    });
+
+    const generateNode = predecessors
+      .map((id) => nodesById.get(id))
+      .find((node): node is Node => !!node && isOtpGenerateNode(node));
+
+    if (generateNode) {
+      return readOtpLength(generateNode) ?? DEFAULT_OTP_LENGTH;
+    }
+
+    frontier = predecessors;
+  }
+
+  return DEFAULT_OTP_LENGTH;
+};
+
+export default resolveUpstreamOtpLength;

--- a/frontend/apps/gate/src/components/SignIn/__tests__/SignInBox.test.tsx
+++ b/frontend/apps/gate/src/components/SignIn/__tests__/SignInBox.test.tsx
@@ -339,6 +339,36 @@ describe('SignInBox', () => {
     expect(screen.getAllByRole('textbox')).toHaveLength(6);
   });
 
+  it('renders OTP_INPUT with the digit count reported by the step', () => {
+    mockSignInRenderProps = createMockSignInRenderProps({
+      additionalData: {otpLength: '8'},
+      components: [
+        {
+          id: 'block-1',
+          type: 'BLOCK',
+          components: [
+            {
+              id: 'otp-input',
+              type: 'OTP_INPUT',
+              ref: 'otp',
+              label: 'Enter OTP',
+              required: true,
+            },
+            {
+              id: 'submit-btn',
+              type: 'ACTION',
+              eventType: 'SUBMIT',
+              label: 'Verify',
+              variant: 'PRIMARY',
+            },
+          ],
+        },
+      ],
+    });
+    render(<SignInBox />);
+    expect(screen.getAllByRole('textbox')).toHaveLength(8);
+  });
+
   it('renders TRIGGER action buttons for social login', () => {
     mockSignInRenderProps = createMockSignInRenderProps({
       components: [

--- a/frontend/packages/design/src/components/flow/FlowComponentRenderer.tsx
+++ b/frontend/packages/design/src/components/flow/FlowComponentRenderer.tsx
@@ -137,6 +137,7 @@ export default function FlowComponentRenderer({
             onBlur={onBlur}
             onSubmit={onSubmit}
             onValidate={onValidate}
+            additionalData={additionalData}
           />
         </>
       );
@@ -155,6 +156,7 @@ export default function FlowComponentRenderer({
         onBlur={onBlur}
         onSubmit={onSubmit}
         onValidate={onValidate}
+        additionalData={additionalData}
       />
     );
   }

--- a/frontend/packages/design/src/components/flow/adapters/BlockAdapter.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/BlockAdapter.tsx
@@ -27,6 +27,8 @@ interface BlockContext {
   onSubmit: (action: EmbeddedFlowComponent, inputs: Record<string, string>) => void;
   onValidate?: (components: EmbeddedFlowComponent[]) => boolean;
   passwordAutoComplete?: 'current-password' | 'new-password';
+  /** Additional step data from the flow response */
+  additionalData?: Record<string, unknown>;
   blockComponents?: EmbeddedFlowComponent[];
   /** When true, non-primary submit buttons use onClick instead of form submit */
   hasMultipleSubmits?: boolean;
@@ -185,6 +187,7 @@ function renderFormSubComponent(
     resolve: ctx.resolve,
     onInputChange: ctx.onInputChange,
     onBlur: ctx.onBlur,
+    additionalData: ctx.additionalData,
   };
 
   if (

--- a/frontend/packages/design/src/components/flow/adapters/OtpInputAdapter.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/OtpInputAdapter.tsx
@@ -7,7 +7,7 @@ import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import type {FlowFieldProps} from '../../../models/flow';
 
-const OTP_LENGTH = 6;
+const DEFAULT_OTP_LENGTH = 6;
 
 export default function OtpInputAdapter({
   component,
@@ -18,15 +18,21 @@ export default function OtpInputAdapter({
   resolve,
   onInputChange,
   onBlur,
+  additionalData,
 }: FlowFieldProps): JSX.Element | null {
   const {t} = useTranslation();
   const {ref} = component;
 
   if (!ref || typeof ref !== 'string') return null;
 
+  // The server reports the length of the code it generated, so the box count matches the OTP the
+  // user received. Falls back to the common six digits when the step carries no length.
+  const reportedLength = Number(additionalData?.['otpLength']);
+  const otpLength = Number.isInteger(reportedLength) && reportedLength > 0 ? reportedLength : DEFAULT_OTP_LENGTH;
+
   const hasError = !!(touched?.[ref] && fieldErrors?.[ref]);
   const otpValue = values[ref] ?? '';
-  const otpDigits = otpValue.padEnd(OTP_LENGTH, ' ').split('').slice(0, OTP_LENGTH);
+  const otpDigits = otpValue.padEnd(otpLength, ' ').split('').slice(0, otpLength);
 
   const focusDigit = (idx: number) => {
     const input = document.querySelector<HTMLInputElement>(`input[aria-label="OTP digit ${idx + 1}"]`);
@@ -64,16 +70,16 @@ export default function OtpInputAdapter({
               if (!/^\d*$/.test(value)) return;
               const newOtp = otpDigits.map((d, i) => (i === idx ? value : d));
               onInputChange(ref, newOtp.join(''));
-              if (value && idx < OTP_LENGTH - 1) focusDigit(idx + 1);
+              if (value && idx < otpLength - 1) focusDigit(idx + 1);
             }}
             onKeyDown={(e) => {
               if (e.key === 'Backspace' && !otpDigits[idx].trim() && idx > 0) focusDigit(idx - 1);
             }}
             onPaste={(e) => {
               e.preventDefault();
-              const digits = e.clipboardData.getData('text/plain').replace(/\D/g, '').slice(0, OTP_LENGTH);
+              const digits = e.clipboardData.getData('text/plain').replace(/\D/g, '').slice(0, otpLength);
               onInputChange(ref, digits);
-              focusDigit(Math.min(digits.length, OTP_LENGTH - 1));
+              focusDigit(Math.min(digits.length, otpLength - 1));
             }}
             error={hasError}
             disabled={isLoading}

--- a/frontend/packages/design/src/components/flow/adapters/__tests__/OtpInputAdapter.test.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/__tests__/OtpInputAdapter.test.tsx
@@ -1,0 +1,74 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import {fireEvent, within} from '@testing-library/react';
+import {describe, it, expect, vi} from 'vitest';
+import type {FlowFieldProps} from '../../../../models/flow';
+import renderWithProviders from '../../../../test/renderWithProviders';
+import OtpInputAdapter from '../OtpInputAdapter';
+
+const baseProps: FlowFieldProps = {
+  component: {id: 'otp', type: 'OTP_INPUT', ref: 'otp', label: 'One-time code', required: true},
+  values: {},
+  isLoading: false,
+  resolve: (s) => s,
+  onInputChange: vi.fn(),
+};
+
+const digitBoxes = (container: HTMLElement): HTMLInputElement[] =>
+  Array.from(container.querySelectorAll<HTMLInputElement>('input[aria-label^="OTP digit"]'));
+
+describe('OtpInputAdapter', () => {
+  it('renders six boxes when the step reports no OTP length', () => {
+    const {container} = renderWithProviders(<OtpInputAdapter {...baseProps} />);
+    expect(digitBoxes(container)).toHaveLength(6);
+  });
+
+  it('renders the number of boxes reported by the step', () => {
+    const {container} = renderWithProviders(<OtpInputAdapter {...baseProps} additionalData={{otpLength: '8'}} />);
+    expect(digitBoxes(container)).toHaveLength(8);
+  });
+
+  it('accepts a numeric reported length', () => {
+    const {container} = renderWithProviders(<OtpInputAdapter {...baseProps} additionalData={{otpLength: 4}} />);
+    expect(digitBoxes(container)).toHaveLength(4);
+  });
+
+  it.each([['0'], ['-1'], ['abc'], ['4.5'], ['']])('falls back to six boxes for %s', (otpLength) => {
+    const {container} = renderWithProviders(<OtpInputAdapter {...baseProps} additionalData={{otpLength}} />);
+    expect(digitBoxes(container)).toHaveLength(6);
+  });
+
+  it('renders the label', () => {
+    const {container} = renderWithProviders(<OtpInputAdapter {...baseProps} />);
+    expect(within(container).getByText('One-time code')).toBeTruthy();
+  });
+
+  it('spreads an existing value across the boxes', () => {
+    const {container} = renderWithProviders(
+      <OtpInputAdapter {...baseProps} values={{otp: '12345678'}} additionalData={{otpLength: '8'}} />,
+    );
+    expect(digitBoxes(container).map((input) => input.value)).toEqual(['1', '2', '3', '4', '5', '6', '7', '8']);
+  });
+
+  it('truncates a pasted code to the reported length', () => {
+    const onInputChange = vi.fn();
+    const {container} = renderWithProviders(
+      <OtpInputAdapter {...baseProps} onInputChange={onInputChange} additionalData={{otpLength: '8'}} />,
+    );
+
+    // Chromium ignores clipboardData supplied to a synthetic ClipboardEvent, so attach it directly.
+    const pasteEvent = new Event('paste', {bubbles: true, cancelable: true});
+    Object.defineProperty(pasteEvent, 'clipboardData', {value: {getData: () => '1234567890'}});
+    fireEvent(digitBoxes(container)[0], pasteEvent);
+
+    expect(onInputChange).toHaveBeenCalledWith('otp', '12345678');
+  });
+
+  it('returns null when ref is missing', () => {
+    const noRefProps = {...baseProps, component: {...baseProps.component, ref: undefined}};
+    const {container} = renderWithProviders(<OtpInputAdapter {...noRefProps} />);
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/frontend/packages/design/src/models/flow.ts
+++ b/frontend/packages/design/src/models/flow.ts
@@ -77,6 +77,8 @@ export interface FlowFieldProps {
   onInputChange: (field: string, value: string) => void;
   /** Blur handler for triggering validation when a field loses focus */
   onBlur?: (field: string) => void;
+  /** Additional step data from the flow response */
+  additionalData?: Record<string, unknown>;
 }
 
 /**

--- a/tests/integration/flow/authentication/sms_auth_test.go
+++ b/tests/integration/flow/authentication/sms_auth_test.go
@@ -51,6 +51,9 @@ var (
 			{
 				"id":   "generate_otp",
 				"type": "TASK_EXECUTION",
+				"properties": map[string]interface{}{
+					"otpLength": 8,
+				},
 				"executor": map[string]interface{}{
 					"name": "OTPExecutor",
 					"mode": "generate",
@@ -492,6 +495,11 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowWithMobileNumber() {
 	ts.Require().True(common.HasInput(otpFlowStep.Data.Inputs, "otp"),
 		"OTP input should be required")
 
+	// The generate node is configured with an otpLength of 8, which the OTP step must report so
+	// the client can render a matching number of input boxes.
+	ts.Require().Equal("8", otpFlowStep.Data.AdditionalData["otpLength"],
+		"OTP step should report the configured OTP length")
+
 	// Wait for SMS to be sent
 	time.Sleep(500 * time.Millisecond)
 
@@ -499,6 +507,7 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowWithMobileNumber() {
 	lastMessage := ts.mockServer.GetLastMessage()
 	ts.Require().NotNil(lastMessage, "Last message should not be nil")
 	ts.Require().NotEmpty(lastMessage.OTP, "OTP should be extracted from message")
+	ts.Require().Len(lastMessage.OTP, 8, "Generated OTP should match the configured length")
 
 	// Step 3: Complete authentication with OTP
 	otpInputs := map[string]string{


### PR DESCRIPTION
### Purpose

This pull request enhances the OTP (One-Time Password) flow by ensuring the OTP input UI dynamically matches the actual OTP length generated by the backend, rather than relying on a static or misconfigured value. It introduces a new backend field to communicate the OTP length, updates frontend logic to consume this value, and adds comprehensive tests for the new behavior.

### Approach

**Backend changes:**

- **OTP length propagation and tests:**
  * Added `DataOTPLength` constant and ensured the OTP executor publishes the actual generated OTP length in the response data, not just the configured property, to handle cases where the backend clamps or overrides the requested length. [[1]](diffhunk://#diff-9efdd475ef67a1c9e9acb315486fdf7b3fdd9de00897898495ea69c599cbf79dR87-R89) [[2]](diffhunk://#diff-401ba20fc58d4a8670e72b8bc2f90b4c5917efefeeba4b6d04f005247da99446R167-R169)
  * Added and updated tests to verify that the published OTP length matches the generated value, including cases where the configured length is overridden or when generation fails. [[1]](diffhunk://#diff-63bb209d3457d7d54371ef7b025df0a5aca83c074f9cb0bb9da990bbfde39782R153-R221) [[2]](diffhunk://#diff-63bb209d3457d7d54371ef7b025df0a5aca83c074f9cb0bb9da990bbfde39782R283) [[3]](diffhunk://#diff-63bb209d3457d7d54371ef7b025df0a5aca83c074f9cb0bb9da990bbfde39782R365)

**Frontend changes:**

- **Dynamic OTP input rendering:**
  * Modified the `OTPInputAdapter` and its usage so that the number of input boxes matches the OTP length determined by inspecting upstream flow nodes, rather than always rendering six inputs. [[1]](diffhunk://#diff-af8e5c41c679cb32cdd41d69e8871f82a7f5babe9cbced97ce1a2e8cc06cbc19L98-R98) [[2]](diffhunk://#diff-236dd2b39c5de82ec0ba49159d9987521f38bf37aa1ff31638c288dce5002726R6-R12) [[3]](diffhunk://#diff-236dd2b39c5de82ec0ba49159d9987521f38bf37aa1ff31638c288dce5002726R34-R37) [[4]](diffhunk://#diff-236dd2b39c5de82ec0ba49159d9987521f38bf37aa1ff31638c288dce5002726L40-R53) [[5]](diffhunk://#diff-236dd2b39c5de82ec0ba49159d9987521f38bf37aa1ff31638c288dce5002726L59-R68)
  * Updated and extended tests to verify that the correct number of inputs is rendered based on the upstream node configuration. [[1]](diffhunk://#diff-f95b0b7402985b9b1e9881039514d7e83283d3da4592129a8699f0979a11a73dR5) [[2]](diffhunk://#diff-f95b0b7402985b9b1e9881039514d7e83283d3da4592129a8699f0979a11a73dR39-R45) [[3]](diffhunk://#diff-f95b0b7402985b9b1e9881039514d7e83283d3da4592129a8699f0979a11a73dL46-R109)

- **Test and data improvements:**
  * Refactored test setup for `OTPInputAdapter` to support React Flow context and added tests for various input properties. [[1]](diffhunk://#diff-f95b0b7402985b9b1e9881039514d7e83283d3da4592129a8699f0979a11a73dL91-R135) [[2]](diffhunk://#diff-f95b0b7402985b9b1e9881039514d7e83283d3da4592129a8699f0979a11a73dL117-R145) [[3]](diffhunk://#diff-f95b0b7402985b9b1e9881039514d7e83283d3da4592129a8699f0979a11a73dL128-R156) [[4]](diffhunk://#diff-f95b0b7402985b9b1e9881039514d7e83283d3da4592129a8699f0979a11a73dL141-R169) [[5]](diffhunk://#diff-f95b0b7402985b9b1e9881039514d7e83283d3da4592129a8699f0979a11a73dL154-R190) [[6]](diffhunk://#diff-f95b0b7402985b9b1e9881039514d7e83283d3da4592129a8699f0979a11a73dL175-R203) [[7]](diffhunk://#diff-f95b0b7402985b9b1e9881039514d7e83283d3da4592129a8699f0979a11a73dL184-R212)
  * Updated executor sample data to include `maxAttempts` and ensure property structure consistency. [[1]](diffhunk://#diff-3c860e8fc33a7873d65790a59ff0c49f0b8ed54da10d0aa023972b36c94ecd38L51-R59) [[2]](diffhunk://#diff-3c860e8fc33a7873d65790a59ff0c49f0b8ed54da10d0aa023972b36c94ecd38L80-R89)

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4542

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * OTP inputs now dynamically match configured lengths from 4–10 digits.
  * Sign-in flows display the actual OTP length provided by the authentication service.
  * Flow responses expose OTP length information for consistent rendering across interfaces.
  * OTP generation and verification settings now allow up to three attempts.

* **Bug Fixes**
  * Invalid, missing, or indirectly configured OTP lengths now fall back to six digits.
  * OTP input behavior remains consistent when generated lengths are adjusted by the service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->