### PR TITLE
Fix console lint failures in flowToCanvasTransformer

### DIFF
--- a/frontend/apps/console/src/features/flows/utils/flowToCanvasTransformer.ts
+++ b/frontend/apps/console/src/features/flows/utils/flowToCanvasTransformer.ts
@@ -76,7 +76,7 @@ const BRANCHING_OUTCOME_KEYS = ['onFailure', 'onIncomplete'] as const;
 /**
  * Shape of an executor definition read from the resource catalog
  */
-type ExecutorDefinition = {
+interface ExecutorDefinition {
   data?: {
     action?: {
       executor?: {name?: string; mode?: string};
@@ -84,7 +84,7 @@ type ExecutorDefinition = {
       onIncomplete?: string;
     };
   };
-};
+}
 
 /**
  * Builds the catalog lookup key for an executor. Mode is part of the key because the same executor
@@ -100,7 +100,7 @@ function getExecutorKey(name?: string, mode?: string): string {
  * Supporting an outcome is a property of the executor definition, not of whichever edges happened
  * to be connected when the flow was saved, so this is the authoritative source on load.
  */
-const EXECUTOR_DECLARED_OUTCOMES: Map<string, string[]> = new Map(
+const EXECUTOR_DECLARED_OUTCOMES = new Map<string, string[]>(
   (executors as ExecutorDefinition[]).map((definition: ExecutorDefinition) => {
     const action = definition.data?.action;
 
@@ -132,7 +132,7 @@ function resolveBranchingOutcomes(apiNode: FlowNode): Record<string, string> {
 
   BRANCHING_OUTCOME_KEYS.forEach((key: 'onFailure' | 'onIncomplete') => {
     if (apiNode[key] !== undefined) {
-      outcomes[key] = apiNode[key] as string;
+      outcomes[key] = apiNode[key];
     }
   });
 


### PR DESCRIPTION
### Purpose
Fix three ESLint errors in `flowToCanvasTransformer.ts` introduced by #4675 that break the console lint gate:
- `@typescript-eslint/consistent-type-definitions` — use `interface` instead of `type` for `ExecutorDefinition`.
- `@typescript-eslint/consistent-generic-constructors` — move the generic arguments onto the `new Map<string, string[]>()` constructor.
- `@typescript-eslint/no-unnecessary-type-assertion` — remove the redundant `as string` assertion.

### Approach
Small, focused lint fixes only. No behavioral change to the flow-to-canvas transformation logic. Verified with `eslint` on the file and a full `turbo run lint` across the frontend (0 errors).

### Related Issues
- N/A

### Related PRs
- Follow-up to #4675

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type definitions and handling of branching outcome values.
  * No user-visible functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->