### PR TITLE
Fix registration flow template

### DIFF
--- a/frontend/apps/console/src/features/flows/api/__tests__/useGetFlowsMeta.test.ts
+++ b/frontend/apps/console/src/features/flows/api/__tests__/useGetFlowsMeta.test.ts
@@ -93,6 +93,63 @@ describe('useGetFlowsMeta', () => {
       expect(result.current.data.widgets).toEqual(widgets);
     });
 
+    it('should include the required provisioning executor in registration blank template', () => {
+      const {result} = renderHook(() => useGetFlowsMeta({flowType: 'REGISTRATION'}));
+
+      const blankTemplate = result.current.data.templates.find((template) => template.type === 'BLANK');
+
+      expect(blankTemplate?.config.nodes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: 'start',
+            onSuccess: 'user_type_resolver',
+          }),
+          expect.objectContaining({
+            id: 'user_type_resolver',
+            type: 'TASK_EXECUTION',
+            executor: {name: 'UserTypeResolver'},
+            onSuccess: 'view_prompt',
+            onIncomplete: 'prompt_usertype',
+          }),
+          expect.objectContaining({
+            id: 'provisioning',
+            type: 'TASK_EXECUTION',
+            executor: {name: 'ProvisioningExecutor'},
+            onSuccess: 'END',
+          }),
+          expect.objectContaining({
+            id: 'prompt_usertype',
+            prompts: [
+              expect.objectContaining({
+                inputs: [
+                  expect.objectContaining({
+                    identifier: 'userType',
+                    type: 'SELECT',
+                    required: true,
+                  }),
+                ],
+                action: {
+                  ref: 'action_usertype',
+                  nextNode: 'user_type_resolver',
+                },
+              }),
+            ],
+          }),
+          expect.objectContaining({
+            id: 'view_prompt',
+            prompts: [
+              expect.objectContaining({
+                action: {
+                  ref: 'action_continue',
+                  nextNode: 'provisioning',
+                },
+              }),
+            ],
+          }),
+        ]),
+      );
+    });
+
     it('should return an empty executors array', () => {
       const {result} = renderHook(() => useGetFlowsMeta());
 

--- a/frontend/apps/console/src/features/flows/data/templates.json
+++ b/frontend/apps/console/src/features/flows/data/templates.json
@@ -6016,7 +6016,89 @@
               "y": 278
             }
           },
-          "onSuccess": "view_prompt"
+          "onSuccess": "user_type_resolver"
+        },
+        {
+          "id": "user_type_resolver",
+          "type": "TASK_EXECUTION",
+          "layout": {
+            "size": {
+              "width": 244,
+              "height": 113
+            },
+            "position": {
+              "x": 913,
+              "y": 238
+            }
+          },
+          "executor": {
+            "name": "UserTypeResolver"
+          },
+          "onSuccess": "view_prompt",
+          "onIncomplete": "prompt_usertype"
+        },
+        {
+          "id": "prompt_usertype",
+          "type": "PROMPT",
+          "meta": {
+            "components": [
+              {
+                "alt": "{{ t(signup:images.app_logo.alt) }}",
+                "category": "DISPLAY",
+                "height": "60",
+                "id": "image",
+                "resourceType": "ELEMENT",
+                "src": "{{ meta(application.logoUrl) }}",
+                "type": "IMAGE",
+                "width": ""
+              },
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "heading_usertype",
+                "label": "{{ t(signup:forms.user_type.title) }}",
+                "variant": "HEADING_1"
+              },
+              {
+                "type": "BLOCK",
+                "id": "block_usertype",
+                "components": [
+                  {
+                    "type": "SELECT",
+                    "id": "usertype_input",
+                    "ref": "userType",
+                    "label": "{{ t(signup:forms.user_type.fields.user_type.label) }}",
+                    "placeholder": "{{ t(signup:forms.user_type.fields.user_type.placeholder) }}",
+                    "required": true,
+                    "options": []
+                  },
+                  {
+                    "type": "ACTION",
+                    "id": "action_usertype",
+                    "label": "{{ t(signup:forms.user_type.actions.continue.label) }}",
+                    "variant": "PRIMARY",
+                    "eventType": "SUBMIT"
+                  }
+                ]
+              }
+            ]
+          },
+          "prompts": [
+            {
+              "inputs": [
+                {
+                  "ref": "usertype_input",
+                  "identifier": "userType",
+                  "type": "SELECT",
+                  "required": true
+                }
+              ],
+              "action": {
+                "ref": "action_usertype",
+                "nextNode": "user_type_resolver"
+              }
+            }
+          ]
         },
         {
           "id": "view_prompt",
@@ -6064,10 +6146,28 @@
             {
               "action": {
                 "ref": "action_continue",
-                "nextNode": "END"
+                "nextNode": "provisioning"
               }
             }
           ]
+        },
+        {
+          "id": "provisioning",
+          "type": "TASK_EXECUTION",
+          "layout": {
+            "size": {
+              "width": 200,
+              "height": 113
+            },
+            "position": {
+              "x": 1113,
+              "y": 238
+            }
+          },
+          "executor": {
+            "name": "ProvisioningExecutor"
+          },
+          "onSuccess": "END"
         },
         {
           "id": "END",


### PR DESCRIPTION
### Purpose
Fixes the blank registration flow template so newly created signup flows include the required UserTypeResolver and ProvisioningExecutor executors.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach

- Updated the existing blank signup template.
- Added the standard UserTypeResolver and user-type prompt configuration.
- Connected the signup prompt to ProvisioningExecutor, then to END.
- Added a regression test covering the required executors and flow routing.
- No breaking changes.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4686

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the blank registration flow to determine the user type before continuing.
  * Added a user-type selection prompt with retry handling.
  * Added provisioning execution before registration completion.

* **Tests**
  * Added coverage confirming the registration template includes the required steps and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->