### PR TITLE
Remove unused default entires from CSP

### DIFF
--- a/backend/cmd/server/config/resources/server_configs/csp.yaml
+++ b/backend/cmd/server/config/resources/server_configs/csp.yaml
@@ -8,42 +8,34 @@ value:
       directives:
         style-src-elem:
           - "'self'"
-          - "https://fonts.googleapis.com"
           - "'unsafe-inline'" # Needed for the embedded Monaco editor, which has no CSP nonce support.
-        # Governs inline style="" attributes; these can't carry a nonce at all per spec.
-        style-src-attr:
-          - "'self'"
-          - "'unsafe-inline'"
-        img-src:
-          - "'self'"
-          - "data:" # Inline library images.
-          - "https:" # TEMPORARY: arbitrary tenant-supplied images. Tighten to a proxy or operator allowlist later.
-        font-src:
-          - "'self'"
-          - "data:" # Bundled library font self-hosted as a base64 URI.
-          - "https://fonts.gstatic.com" # Font files referenced by the fonts.googleapis.com stylesheet.
-        connect-src:
-          - "'self'"
-          - "https://thunderid.dev" # Console welcome page's release metadata fetch.
-          - "https://fonts.googleapis.com" # GatePreview iframe preconnect.
-          - "https://fonts.gstatic.com" # GatePreview iframe preconnect.
-        worker-src:
-          - "'self'"
-          - "blob:" # Monaco instantiates web workers, which the build may emit as blob URLs.
-    - location: "/gate/"
-      directives:
-        style-src-elem:
-          - "'self'"
-          - "https://fonts.googleapis.com"
-        # Governs inline style="" attributes; these can't carry a nonce at all per spec.
+        # Governs inline style="" attributes that can't carry a nonce.
         style-src-attr:
           - "'self'"
           - "'unsafe-inline'"
         img-src:
           - "'self'"
           - "data:"
-          - "https:" # TEMPORARY: arbitrary tenant-supplied images. Tighten to a proxy or operator allowlist later.
         font-src:
           - "'self'"
-          - "data:" # Bundled library font self-hosted as a base64 URI.
-          - "https://fonts.gstatic.com" # Font files referenced by the fonts.googleapis.com stylesheet.
+          - "data:"
+        connect-src:
+          - "'self'"
+          - "https://thunderid.dev"
+        worker-src:
+          - "'self'"
+          - "blob:" # Monaco instantiated web workers.
+    - location: "/gate/"
+      directives:
+        style-src-elem:
+          - "'self'"
+        # Governs inline style="" attributes that can't carry a nonce.
+        style-src-attr:
+          - "'self'"
+          - "'unsafe-inline'"
+        img-src:
+          - "'self'"
+          - "data:"
+        font-src:
+          - "'self'"
+          - "data:"

--- a/docs/content/deployment/production-guidelines.mdx
+++ b/docs/content/deployment/production-guidelines.mdx
@@ -276,6 +276,7 @@ To change the policy without a restart, update the same section with `PUT /serve
 
 - Listing a directive replaces its baseline value, so include `'self'` when you still need same-origin resources.
 - When you add an external logo, font, or stylesheet URL in the Console, allow its origin in the matching directive. The Console shows the directive to update next to each field.
+- User profile pictures set through the `picture` attribute also load as images, including in the Console user list and profile views. Add picture host to the `img-src` directive.
 - Keep the policy as narrow as your applications allow. Avoid broad sources such as `https:` or `'unsafe-inline'` once you know the exact origins you need.
 
 See [Content Security Policy](../configuration#content-security-policy) for the full field reference and the deny-first baseline.

--- a/docs/content/guides/users/user-type-reference.mdx
+++ b/docs/content/guides/users/user-type-reference.mdx
@@ -53,3 +53,7 @@ An admin-managed user type. Self-registration is disabled and only an administra
 | `name` | `string` | - | |
 | `picture` | `string` | - | |
 | `password` | `string` | credential | Never returned in responses |
+
+:::note
+The `picture` attribute stores a URL. When a user's picture is hosted on an external origin, allow that origin in the Content Security Policy `img-src` directive. Otherwise the browser blocks the image where the Console displays it. See [Content Security Policy](../../deployment/configuration#content-security-policy).
+:::

--- a/docs/versioned_docs/version-v1.0.x/deployment/production-guidelines.mdx
+++ b/docs/versioned_docs/version-v1.0.x/deployment/production-guidelines.mdx
@@ -276,6 +276,7 @@ To change the policy without a restart, update the same section with `PUT /serve
 
 - Listing a directive replaces its baseline value, so include `'self'` when you still need same-origin resources.
 - When you add an external logo, font, or stylesheet URL in the Console, allow its origin in the matching directive. The Console shows the directive to update next to each field.
+- User profile pictures set through the `picture` attribute also load as images, including in the Console user list and profile views. Add picture host to the `img-src` directive.
 - Keep the policy as narrow as your applications allow. Avoid broad sources such as `https:` or `'unsafe-inline'` once you know the exact origins you need.
 
 See [Content Security Policy](../configuration#content-security-policy) for the full field reference and the deny-first baseline.

--- a/docs/versioned_docs/version-v1.0.x/guides/users/user-type-reference.mdx
+++ b/docs/versioned_docs/version-v1.0.x/guides/users/user-type-reference.mdx
@@ -54,3 +54,7 @@ An admin-managed user type. Self-registration is disabled and only an administra
 | `name` | `string` | - | |
 | `picture` | `string` | - | |
 | `password` | `string` | credential | Never returned in responses |
+
+:::note
+The `picture` attribute stores a URL. When a user's picture is hosted on an external origin, allow that origin in the Content Security Policy `img-src` directive. Otherwise the browser blocks the image where the Console displays it. See [Content Security Policy](../../deployment/configuration#content-security-policy).
+:::


### PR DESCRIPTION
### Purpose

Cleanup stale default entires, `fonts.googleapis.com`/`fonts.gstatic.com` as default allowlist entries (style-src-elem, font-src, and connect-src for Console) in the `csp.yaml` file. CspOriginHint operator-guidance banner explicitly directs users to add any required hosts to the `csp/yaml` themselves.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
- Remove `fonts.googleapis.com` from `style-src-elem` (console + gate)
- Remove `fonts.gstatic.com` from `font-src` (console + gate)
- Remove both stale `connect-src` Google Fonts entries (console)

### Related Issues
- Closes #4476

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Updated content security policies to remove Google Fonts access and arbitrary HTTPS image access.
  * Preserved support for approved inline styles, tenant-hosted images, data-based fonts and images, and blob workers.
  * Maintained self-hosted styling support for the gate experience.

* **Documentation**
  * Added guidance explaining that externally hosted profile pictures must be permitted by the Content Security Policy’s `img-src` directive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->