### PR TITLE
Add rate limiting doc for direct API

### DIFF
--- a/docs/content/key-concepts/authentication/integration-models.mdx
+++ b/docs/content/key-concepts/authentication/integration-models.mdx
@@ -360,6 +360,14 @@ curl -X POST https://localhost:8090/auth/credentials/authenticate \
 
 See [Security Configuration](../../../deployment/configuration#security-configuration) for details.
 
+### Rate Limiting
+
+<ProductName /> does not apply rate limiting or brute-force protection to Direct API endpoints. It enforces no per-user lockout, no per-client request quota, and no throttling on repeated failures. An endpoint such as `POST /auth/credentials/authenticate` or `POST /auth/otp/sms/verify` accepts credential and OTP attempts at whatever rate the caller sends them.
+
+:::warning
+Front the Direct API endpoints with an API gateway and apply rate limiting there before exposing them outside a trusted network. Without it, these endpoints are open to password guessing, OTP enumeration, and messaging costs driven up by repeated `POST /auth/otp/sms/send` calls.
+:::
+
 ### Step-Up Authentication
 
 Direct API authentication supports step-up authentication. Pass an existing assertion token to any supported endpoint to enrich it with the new authentication method. Each additional method strengthens the authentication context.


### PR DESCRIPTION
$

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance on rate limiting for Direct API integrations.
  - Clarified that these endpoints do not provide built-in throttling, quotas, lockouts, or brute-force protection.
  - Recommended applying gateway-level rate limiting before exposing endpoints externally.
  - Highlighted risks including password guessing, OTP enumeration, and repeated OTP-send costs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->