### PR TITLE
Roll back the generated sign-in flow when application creation fails

### DIFF
--- a/frontend/apps/console/src/features/applications/pages/ApplicationCreatePage.tsx
+++ b/frontend/apps/console/src/features/applications/pages/ApplicationCreatePage.tsx
@@ -21,11 +21,12 @@ import {getErrorMessage} from '@thunderid/utils';
 import {Alert, Box, Button, CircularProgress, IconButton, Typography} from '@wso2/oxygen-ui';
 import {ChevronLeft, ChevronRight, Home} from '@wso2/oxygen-ui-icons-react';
 import type {JSX} from 'react';
-import {useState, useCallback, useEffect, useMemo} from 'react';
+import {useState, useCallback, useEffect, useMemo, useRef} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useLocation, useNavigate} from 'react-router';
 import RouteConfig from '../../../configs/RouteConfig';
 import useCreateFlow from '../../flows/api/useCreateFlow';
+import useDeleteFlow from '../../flows/api/useDeleteFlow';
 import useGetFlowById from '../../flows/api/useGetFlowById';
 import type {BasicFlowDefinition} from '../../flows/models/responses';
 import {resolveApplicationMeta, resolveTemplatesDeep} from '../../flows/utils/gatePreviewTransforms';
@@ -187,7 +188,17 @@ export default function ApplicationCreatePage(): JSX.Element {
   );
 
   const createFlow = useCreateFlow();
+  const deleteFlow = useDeleteFlow();
   const {data: idpData} = useIdentityProviders();
+
+  // Tracks the generated flow for the current inputs so failed creates can roll it back
+  // and unchanged retries can reuse it without creating a duplicate.
+  const generatedFlowRef = useRef<{inputsKey: string; flowId: string} | null>(null);
+
+  // The generated flow that was pushed into selectedAuthFlow. Setting selectedAuthFlow back to null
+  // on rollback would clear the create error the user has to act on (the provider clears it whenever
+  // the form fingerprint changes), so the dead id is filtered out at submit time instead.
+  const generatedSelectionIdRef = useRef<string | null>(null);
 
   const hasEnabledIntegrations = useMemo((): boolean => Object.values(integrations).some(Boolean), [integrations]);
 
@@ -507,6 +518,28 @@ export default function ApplicationCreatePage(): JSX.Element {
     setWalletClientId(clientId);
   };
 
+  // Best-effort removal of a flow this wizard generated but never bound to an application. A failure
+  // is logged only: the application error is what the user has to act on, so it must stay on screen.
+  const rollbackGeneratedFlow = (generated: {inputsKey: string; flowId: string}): void => {
+    // Dropped up front, not on success: while the delete is in flight the flow must not be reused,
+    // or a fast retry would bind the application to a flow that is about to disappear.
+    if (generatedFlowRef.current?.flowId === generated.flowId) {
+      generatedFlowRef.current = null;
+    }
+
+    deleteFlow.mutate(generated.flowId, {
+      onError: (err: Error) => {
+        logger.error('Failed to roll back the generated sign-in flow', {error: err, flowId: generated.flowId});
+        generatedFlowRef.current ??= generated;
+      },
+    });
+  };
+
+  // True while a generated flow that selectedAuthFlow still points at is rolled back or being rolled
+  // back: the memo drops it when the delete fires and restores it only if that delete fails.
+  const isRolledBackGeneratedFlow = (flowId: string | undefined): boolean =>
+    Boolean(flowId) && generatedSelectionIdRef.current === flowId && generatedFlowRef.current?.flowId !== flowId;
+
   const handleCreateApplication = (skipOAuthConfig = false, overrideFlowId?: string): void => {
     setError(null);
 
@@ -518,7 +551,7 @@ export default function ApplicationCreatePage(): JSX.Element {
     // in the wizard.
     const finalAuthFlowId: string | undefined = ouDefaults[OrganizationUnitDefaultItem.SIGN_IN]
       ? (resolvedOrganizationUnit?.authFlowId ?? undefined)
-      : (overrideFlowId ?? selectedAuthFlow?.id);
+      : (overrideFlowId ?? (isRolledBackGeneratedFlow(selectedAuthFlow?.id) ? undefined : selectedAuthFlow?.id));
     const finalRegistrationFlowId: string | undefined = ouDefaults[OrganizationUnitDefaultItem.SIGN_UP]
       ? (resolvedOrganizationUnit?.registrationFlowId ?? undefined)
       : (registrationFlowId ?? undefined);
@@ -690,6 +723,12 @@ export default function ApplicationCreatePage(): JSX.Element {
             'Failed to create application. Please try again.',
           ),
         );
+
+        // The flow was persisted before the application, so a failure here leaves it orphaned.
+        const generated = generatedFlowRef.current;
+        if (generated) {
+          rollbackGeneratedFlow(generated);
+        }
       },
     });
   };
@@ -700,7 +739,7 @@ export default function ApplicationCreatePage(): JSX.Element {
     // A selected flow only short-circuits generation when it's a genuine manual pick (no
     // integrations enabled). Otherwise it's an auto-match riding along with active toggles, and
     // must still be regenerated below so MFA settings aren't silently dropped.
-    if (selectedAuthFlow && !hasEnabledIntegrations) {
+    if (selectedAuthFlow && !hasEnabledIntegrations && !isRolledBackGeneratedFlow(selectedAuthFlow.id)) {
       handleCreateApplication(skipOAuthConfig);
       return;
     }
@@ -710,7 +749,7 @@ export default function ApplicationCreatePage(): JSX.Element {
       const googleProvider = availableIntegrations.find((idp) => idp.type === IdentityProviderTypes.GOOGLE);
       const githubProvider = availableIntegrations.find((idp) => idp.type === IdentityProviderTypes.GITHUB);
 
-      const generatedFlowRequest = generateFlowGraph({
+      const flowInputs = {
         appName,
         hasCredentialsAuth: integrations[AuthenticatorTypes.CREDENTIALS_AUTH] ?? false,
         hasPasskey: integrations[AuthenticatorTypes.PASSKEY] ?? false,
@@ -723,10 +762,32 @@ export default function ApplicationCreatePage(): JSX.Element {
         hasEmailOtpMfa: isEmailOtpMfaEnabled,
         hasSmsOtpMfa: isSmsOtpMfaEnabled,
         smsOtpSenderId,
-      });
+      };
+
+      // Generation randomizes the flow handle so retries never collide, which also means a retry
+      // always mints a duplicate. Keying the generated flow on its inputs is what makes the retry
+      // reuse it: same inputs, same flow.
+      const inputsKey = JSON.stringify(flowInputs);
+      const memoizedFlow = generatedFlowRef.current;
+
+      if (memoizedFlow?.inputsKey === inputsKey) {
+        handleCreateApplication(skipOAuthConfig, memoizedFlow.flowId);
+        return;
+      }
+
+      // The inputs changed since the last attempt (an edited application name, a toggled
+      // integration), so the flow generated then is stale and unreferenced.
+      if (memoizedFlow) {
+        rollbackGeneratedFlow(memoizedFlow);
+      }
+
+      const generatedFlowRequest = generateFlowGraph(flowInputs);
 
       createFlow.mutate(generatedFlowRequest, {
         onSuccess: (savedFlow) => {
+          generatedFlowRef.current = {inputsKey, flowId: savedFlow.id};
+          generatedSelectionIdRef.current = savedFlow.id;
+
           // We cast because BasicFlowDefinition is a subset of FlowDefinitionResponse
           setSelectedAuthFlow(savedFlow as unknown as BasicFlowDefinition);
 
@@ -1073,11 +1134,11 @@ export default function ApplicationCreatePage(): JSX.Element {
           )}
 
           <Box sx={{display: 'flex', alignItems: 'center', gap: 2}}>
-            {createFlow.isPending && <CircularProgress size={20} />}
+            {(createFlow.isPending || createApplication.isPending) && <CircularProgress size={20} />}
             <Button
               data-testid="application-wizard-next-button"
               variant="contained"
-              disabled={!stepReady[currentStep] || createFlow.isPending}
+              disabled={!stepReady[currentStep] || createFlow.isPending || createApplication.isPending}
               sx={{minWidth: 100}}
               onClick={handleNextStep}
             >

--- a/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationCreatePage.test.tsx
+++ b/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationCreatePage.test.tsx
@@ -4,7 +4,7 @@
 import userEvent from '@testing-library/user-event';
 import type {Application} from '@thunderid/configure-applications';
 import type {Theme} from '@thunderid/design';
-import {render, screen, waitFor, within} from '@thunderid/test-utils';
+import {fireEvent, render, screen, waitFor, within} from '@thunderid/test-utils';
 import type {JSX} from 'react';
 import {useEffect} from 'react';
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
@@ -52,13 +52,37 @@ vi.mock('@thunderid/design', () => ({
   DefaultTheme: {},
 }));
 
-// Mock application API
-vi.mock('../../api/useCreateApplication', () => ({
-  default: () => ({
-    mutate: mockCreateApplication,
-    isPending: false,
-  }),
-}));
+// Mock application API. isPending is backed by real state, as in the actual hook, so the wizard can
+// keep the submit button disabled until the create settles.
+vi.mock('../../api/useCreateApplication', async () => {
+  const {useState} = await vi.importActual<typeof import('react')>('react');
+
+  const useMockCreateApplication = () => {
+    const [isPending, setIsPending] = useState(false);
+
+    return {
+      isPending,
+      mutate: (
+        data: unknown,
+        options?: {onError?: (err: Error) => void; onSuccess?: (app: Application) => void},
+      ): void => {
+        setIsPending(true);
+        mockCreateApplication(data, {
+          onError: (err: Error) => {
+            setIsPending(false);
+            options?.onError?.(err);
+          },
+          onSuccess: (app: Application) => {
+            setIsPending(false);
+            options?.onSuccess?.(app);
+          },
+        });
+      },
+    };
+  };
+
+  return {default: useMockCreateApplication};
+});
 
 // Mock user types API
 vi.mock('@thunderid/configure-user-types', () => ({
@@ -88,14 +112,22 @@ vi.mock('@thunderid/configure-connections', async (importOriginal) => ({
 }));
 
 // Mock flows API
-const {mockCreateFlow, mockGenerateFlowGraph} = vi.hoisted(() => ({
+const {mockCreateFlow, mockGenerateFlowGraph, mockDeleteFlow} = vi.hoisted(() => ({
   mockCreateFlow: vi.fn(),
   mockGenerateFlowGraph: vi.fn(),
+  mockDeleteFlow: vi.fn(),
 }));
 
 vi.mock('../../../flows/api/useCreateFlow', () => ({
   default: () => ({
     mutate: mockCreateFlow,
+    isPending: false,
+  }),
+}));
+
+vi.mock('../../../flows/api/useDeleteFlow', () => ({
+  default: () => ({
+    mutate: mockDeleteFlow,
     isPending: false,
   }),
 }));
@@ -637,6 +669,11 @@ describe('ApplicationCreatePage', () => {
 
     vi.clearAllMocks();
     mockNavigate.mockResolvedValue(undefined);
+
+    // Flow cleanup succeeds unless a test says otherwise.
+    mockDeleteFlow.mockImplementation((_flowId: string, options?: {onSuccess?: () => void}) => {
+      options?.onSuccess?.();
+    });
 
     const getConfigurationTypeFromTemplate = await import('../../utils/getConfigurationTypeFromTemplate');
     vi.mocked(getConfigurationTypeFromTemplate.default).mockReturnValue('URL');
@@ -2090,6 +2127,292 @@ describe('ApplicationCreatePage', () => {
 
       await waitFor(() => {
         expect(screen.getByText('Failed to generate the authentication flow. Please try again.')).toBeInTheDocument();
+      });
+    });
+
+    describe('Rollback and reuse of the generated flow', () => {
+      const CREATE_ERROR = /failed to create application/i;
+
+      // Puts the wizard in the flow-generation state: no pre-selected flow, one integration on.
+      const setupFlowGeneration = async (): Promise<void> => {
+        const ConfigureSignInOptionsModule = await import(
+          '../../components/create-application/configure-signin-options/ConfigureSignInOptions'
+        );
+        const useApplicationCreateContextModule = await import('../../hooks/useApplicationCreateContext');
+
+        vi.mocked(ConfigureSignInOptionsModule.default).mockImplementation(
+          ({onReadyChange}: {onReadyChange?: (ready: boolean) => void}) => {
+            const {setSelectedAuthFlow, setIntegrations} = useApplicationCreateContextModule.default();
+
+            const handleSetup = () => {
+              setSelectedAuthFlow(null);
+              setIntegrations({basic_auth: true});
+              onReadyChange?.(true);
+            };
+
+            return (
+              <div data-testid="application-configure-sign-in">
+                <button type="button" data-testid="setup-flow-rollback" onClick={handleSetup}>
+                  Setup Flow Generation
+                </button>
+                <button
+                  type="button"
+                  data-testid="clear-integrations"
+                  onClick={() => {
+                    // Leaves selectedAuthFlow alone, so the generated flow stays selected with no
+                    // integrations on: the flow-only short-circuit.
+                    setIntegrations({});
+                    onReadyChange?.(true);
+                  }}
+                >
+                  Clear Integrations
+                </button>
+              </div>
+            );
+          },
+        );
+      };
+
+      // SECURITY → DESIGN → CONFIGURE → Create.
+      const submitWizard = async (): Promise<void> => {
+        await waitFor(() => {
+          expect(screen.getByRole('button', {name: /continue/i})).toBeEnabled();
+        });
+        await user.click(screen.getByRole('button', {name: /continue/i}));
+        await waitFor(() => {
+          expect(screen.getByTestId('application-configure-design')).toBeInTheDocument();
+        });
+        await user.click(screen.getByRole('button', {name: /continue/i}));
+        await waitFor(() => {
+          expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
+        });
+        // The step reports readiness a tick after it mounts, and the button is disabled until then.
+        await waitFor(() => {
+          expect(screen.getByTestId('application-wizard-next-button')).toBeEnabled();
+        });
+        await user.click(screen.getByTestId('application-wizard-next-button'));
+      };
+
+      const generateFlowAndSubmit = async (appName = 'My App'): Promise<void> => {
+        await setupFlowGeneration();
+        renderWithProviders();
+
+        await user.type(screen.getByTestId('app-name-input'), appName);
+        // DETAILS → SECURITY
+        await user.click(screen.getByRole('button', {name: /continue/i}));
+        await waitFor(() => {
+          expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
+        });
+        await user.click(screen.getByTestId('setup-flow-rollback'));
+
+        await submitWizard();
+      };
+
+      const mockFlowCreateSuccess = (): void => {
+        let created = 0;
+        mockCreateFlow.mockImplementation((_data: unknown, {onSuccess}: {onSuccess: (flow: unknown) => void}) => {
+          created += 1;
+          onSuccess({
+            id: created === 1 ? 'generated-flow-id' : `generated-flow-id-${created}`,
+            name: 'My App Sign-in Flow',
+            handle: created === 1 ? 'my-app-sign-in-a1b2c3' : `my-app-sign-in-a1b2c3-${created}`,
+          });
+        });
+      };
+
+      // The failure is delivered on a later tick, as a real request would: the flow create that
+      // precedes it commits its own render (which clears any stale error via the provider's form
+      // fingerprint) before the create error is set, so the error stays on screen.
+      const mockApplicationCreateFailure = (code?: string): void => {
+        mockCreateApplication.mockImplementation((_data: unknown, {onError}: {onError: (err: Error) => void}) => {
+          const err = new Error('Failed to create application');
+          if (code) {
+            (err as {response?: {data?: {code?: string}}}).response = {data: {code}};
+          }
+          setTimeout(() => onError(err), 0);
+        });
+      };
+
+      it('should not start a second application create while the first one is in flight', async () => {
+        mockFlowCreateSuccess();
+        // Never settles, so the create stays in flight the way a slow request does.
+        mockCreateApplication.mockImplementation(() => undefined);
+
+        await generateFlowAndSubmit();
+
+        await waitFor(() => {
+          expect(mockCreateApplication).toHaveBeenCalledTimes(1);
+        });
+
+        // A second submit would reuse the memoized flow and send the same name again. Whichever
+        // request then lost on the duplicate name would roll back the flow the winner is bound to,
+        // leaving a created application pointing at a deleted flow.
+        expect(screen.getByTestId('application-wizard-next-button')).toBeDisabled();
+        fireEvent.click(screen.getByTestId('application-wizard-next-button'));
+
+        expect(mockCreateApplication).toHaveBeenCalledTimes(1);
+        expect(mockCreateFlow).toHaveBeenCalledTimes(1);
+        expect(mockDeleteFlow).not.toHaveBeenCalled();
+      });
+
+      it('should delete the generated flow and keep the application error when the application create fails', async () => {
+        mockFlowCreateSuccess();
+        mockApplicationCreateFailure();
+
+        await generateFlowAndSubmit();
+
+        await waitFor(() => {
+          expect(mockDeleteFlow).toHaveBeenCalledWith('generated-flow-id', expect.anything());
+        });
+        expect(screen.getByText(CREATE_ERROR)).toBeInTheDocument();
+      });
+
+      it('should reuse the generated flow on retry when the rollback failed', async () => {
+        mockFlowCreateSuccess();
+        mockApplicationCreateFailure();
+        mockDeleteFlow.mockImplementation((_flowId: string, options?: {onError?: (err: Error) => void}) => {
+          options?.onError?.(new Error('Failed to delete flow'));
+        });
+
+        await generateFlowAndSubmit();
+
+        await waitFor(() => {
+          expect(mockCreateApplication).toHaveBeenCalledTimes(1);
+        });
+
+        // Retry from the same step with the same inputs.
+        await user.click(screen.getByTestId('application-wizard-next-button'));
+
+        await waitFor(() => {
+          expect(mockCreateApplication).toHaveBeenCalledTimes(2);
+        });
+        expect(mockCreateFlow).toHaveBeenCalledTimes(1);
+        expect((mockCreateApplication.mock.calls[1][0] as Application).authFlowId).toBe('generated-flow-id');
+      });
+
+      it('should not reuse the flow while its rollback is still in flight', async () => {
+        mockFlowCreateSuccess();
+        mockApplicationCreateFailure();
+        // The delete never settles, so a retry must not bind the application to a flow that is on
+        // its way out.
+        mockDeleteFlow.mockImplementation(() => undefined);
+
+        await generateFlowAndSubmit();
+
+        await waitFor(() => {
+          expect(mockDeleteFlow).toHaveBeenCalledWith('generated-flow-id', expect.anything());
+        });
+
+        await user.click(screen.getByTestId('application-wizard-next-button'));
+
+        await waitFor(() => {
+          expect(mockCreateFlow).toHaveBeenCalledTimes(2);
+        });
+        expect((mockCreateApplication.mock.calls[1][0] as Application).authFlowId).toBe('generated-flow-id-2');
+      });
+
+      it('should generate a new flow on retry when the rollback succeeded', async () => {
+        mockFlowCreateSuccess();
+        mockApplicationCreateFailure();
+
+        await generateFlowAndSubmit();
+
+        await waitFor(() => {
+          expect(mockDeleteFlow).toHaveBeenCalledWith('generated-flow-id', expect.anything());
+        });
+
+        await user.click(screen.getByTestId('application-wizard-next-button'));
+
+        await waitFor(() => {
+          expect(mockCreateFlow).toHaveBeenCalledTimes(2);
+        });
+        expect((mockCreateApplication.mock.calls[1][0] as Application).authFlowId).toBe('generated-flow-id-2');
+      });
+
+      it('should not submit a rolled back generated flow when the integrations are turned off', async () => {
+        mockFlowCreateSuccess();
+        mockApplicationCreateFailure('APP-1020');
+
+        await generateFlowAndSubmit();
+
+        await waitFor(() => {
+          expect(mockDeleteFlow).toHaveBeenCalledWith('generated-flow-id', expect.anything());
+        });
+
+        // The duplicate-name failure sends the wizard back to the details step.
+        await waitFor(() => {
+          expect(screen.getByTestId('app-name-input')).toBeInTheDocument();
+        });
+        // The name error blocks Continue until the field is edited.
+        await user.type(screen.getByTestId('app-name-input'), ' Renamed');
+        await user.click(screen.getByRole('button', {name: /continue/i}));
+        await waitFor(() => {
+          expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
+        });
+        // selectedAuthFlow still points at the deleted flow; with no integrations left, the
+        // flow-only short-circuit would otherwise submit that dead id.
+        await user.click(screen.getByTestId('clear-integrations'));
+
+        await submitWizard();
+
+        // The dead id is filtered out, so the create is blocked by the missing-flow guard instead of
+        // being submitted with a flow that no longer exists.
+        await waitFor(() => {
+          expect(screen.getByText('onboarding.configure.SignInOptions.noFlowFound')).toBeInTheDocument();
+        });
+        expect(mockCreateApplication).toHaveBeenCalledTimes(1);
+        expect(mockCreateFlow).toHaveBeenCalledTimes(1);
+      });
+
+      it('should not delete a flow the wizard did not generate', async () => {
+        mockApplicationCreateFailure();
+
+        renderWithProviders();
+
+        // The default sign-in step mock picks a pre-configured flow and clears integrations.
+        await goToDesignStep();
+        await user.click(screen.getByRole('button', {name: /continue/i}));
+        await waitFor(() => {
+          expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
+        });
+        await user.click(screen.getByTestId('application-wizard-next-button'));
+
+        await waitFor(() => {
+          expect(mockCreateApplication).toHaveBeenCalled();
+        });
+        expect(mockDeleteFlow).not.toHaveBeenCalled();
+      });
+
+      it('should delete the stale flow and generate a new one when an input changed between attempts', async () => {
+        mockFlowCreateSuccess();
+        mockApplicationCreateFailure('APP-1020');
+        // The rollback fails, so the flow survives and the memo is kept. Editing an input then makes
+        // that flow stale, and it must not be left behind when the next one is generated.
+        mockDeleteFlow.mockImplementation((_flowId: string, options?: {onError?: (err: Error) => void}) => {
+          options?.onError?.(new Error('Failed to delete flow'));
+        });
+
+        await generateFlowAndSubmit();
+
+        // The duplicate-name failure sends the wizard back to the details step.
+        await waitFor(() => {
+          expect(screen.getByTestId('app-name-input')).toBeInTheDocument();
+        });
+
+        await user.type(screen.getByTestId('app-name-input'), ' Renamed');
+        // DETAILS → SECURITY
+        await user.click(screen.getByRole('button', {name: /continue/i}));
+        await waitFor(() => {
+          expect(screen.getByTestId('application-configure-sign-in')).toBeInTheDocument();
+        });
+        await user.click(screen.getByTestId('setup-flow-rollback'));
+
+        await submitWizard();
+
+        await waitFor(() => {
+          expect(mockCreateFlow).toHaveBeenCalledTimes(2);
+        });
+        expect(mockDeleteFlow).toHaveBeenCalledWith('generated-flow-id', expect.anything());
       });
     });
   });


### PR DESCRIPTION
### Purpose
The application create wizard persists the generated `<app> Sign-in Flow` before it persists the application. When `POST /applications` fails, nothing deleted the flow, and each retry generated a new one, so a few failed attempts left several orphaned flows behind.

### Approach
- Delete the generated flow when the application create fails, per the maintainer's suggestion on the issue.
- Memoize the generated flow against the exact `generateFlowGraph` inputs. The memo is dropped when the rollback is fired and restored only if the delete failed, so a retry reuses the surviving flow instead of minting a second orphan, and never reuses a flow whose delete is in flight.
- The rollback only ever targets a flow this wizard generated. A manually picked or auto-matched flow is untouched.
- A failed rollback is logged, not surfaced: the application error is what the user has to act on.

Verified against a local pack: three failed attempts with an invalid redirect URI now leave no flow behind (previously three), and a subsequent successful create leaves exactly one flow bound to the application.

### Related Issues
- Fixes #4570

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application creation reliability by preventing duplicate authentication flows during retries.
  * Automatically removes outdated generated flows when configuration changes or integrations are cleared.
  * Preserves flows when cleanup fails, enabling safer retry behavior.
  * Rolls back generated flows when application creation fails.
  * Keeps the submit button disabled while application creation is in progress.

* **Tests**
  * Added coverage for flow reuse, deletion, rollback, retry scenarios, configuration changes, and preservation of existing flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->