### PR TITLE
Hide existing group members from add tabs

### DIFF
--- a/frontend/packages/configure-groups/src/api/__tests__/useGetAllCandidates.test.ts
+++ b/frontend/packages/configure-groups/src/api/__tests__/useGetAllCandidates.test.ts
@@ -1,0 +1,72 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {waitFor} from '@testing-library/react';
+import {renderHook} from '@thunderid/test-utils';
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+
+const mockHttpRequest = vi.fn();
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
+    http: {request: mockHttpRequest},
+  }),
+}));
+
+const mockGetServerUrl = vi.fn<() => string>(() => 'https://localhost:8090');
+vi.mock('@thunderid/contexts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunderid/contexts')>();
+  return {
+    ...actual,
+    useConfig: () => ({getServerUrl: mockGetServerUrl}),
+  };
+});
+
+const {default: useGetAllCandidates} = await import('../useGetAllCandidates');
+
+describe('useGetAllCandidates', () => {
+  beforeEach(() => {
+    mockHttpRequest.mockReset();
+    mockGetServerUrl.mockReturnValue('https://localhost:8090');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches later pages so candidates are not lost after filtering', async () => {
+    mockHttpRequest
+      .mockResolvedValueOnce({
+        data: {
+          totalResults: 101,
+          startIndex: 1,
+          count: 100,
+          users: Array.from({length: 100}, (_, index) => ({id: `existing-${index}`})),
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          totalResults: 101,
+          startIndex: 101,
+          count: 1,
+          users: [{id: 'available-user'}],
+        },
+      });
+
+    const {result} = renderHook(() =>
+      useGetAllCandidates<{id: string}>({path: '/users', itemsKey: 'users', enabled: true}),
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toHaveLength(101);
+    });
+
+    expect(result.current.data).toContainEqual({id: 'available-user'});
+    expect(mockHttpRequest).toHaveBeenCalledTimes(2);
+    expect(mockHttpRequest).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        url: 'https://localhost:8090/users?limit=100&offset=100&include=display',
+      }),
+    );
+  });
+});

--- a/frontend/packages/configure-groups/src/api/__tests__/useGetAllGroupMembers.test.ts
+++ b/frontend/packages/configure-groups/src/api/__tests__/useGetAllGroupMembers.test.ts
@@ -1,0 +1,79 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {waitFor} from '@testing-library/react';
+import {renderHook} from '@thunderid/test-utils';
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import type {MemberListResponse} from '../../models/group';
+
+const mockHttpRequest = vi.fn();
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({
+    http: {request: mockHttpRequest},
+  }),
+}));
+
+const mockGetServerUrl = vi.fn<() => string>(() => 'https://localhost:8090');
+vi.mock('@thunderid/contexts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunderid/contexts')>();
+  return {
+    ...actual,
+    useConfig: () => ({getServerUrl: mockGetServerUrl}),
+  };
+});
+
+const {default: useGetAllGroupMembers} = await import('../useGetAllGroupMembers');
+
+describe('useGetAllGroupMembers', () => {
+  beforeEach(() => {
+    mockHttpRequest.mockReset();
+    mockGetServerUrl.mockReturnValue('https://localhost:8090');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches and combines every member page', async () => {
+    const firstPage: MemberListResponse = {
+      totalResults: 101,
+      startIndex: 1,
+      count: 100,
+      members: Array.from({length: 100}, (_, index) => ({id: `member-${index}`, type: 'user' as const})),
+    };
+    const secondPage: MemberListResponse = {
+      totalResults: 101,
+      startIndex: 101,
+      count: 1,
+      members: [{id: 'member-100', type: 'user'}],
+    };
+    mockHttpRequest.mockResolvedValueOnce({data: firstPage}).mockResolvedValueOnce({data: secondPage});
+
+    const {result} = renderHook(() => useGetAllGroupMembers('g1'));
+
+    await waitFor(() => {
+      expect(result.current.data?.members).toHaveLength(101);
+    });
+
+    expect(mockHttpRequest).toHaveBeenCalledTimes(2);
+    expect(mockHttpRequest).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        url: 'https://localhost:8090/groups/g1/members?limit=100&offset=0&include=display',
+      }),
+    );
+    expect(mockHttpRequest).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        url: 'https://localhost:8090/groups/g1/members?limit=100&offset=100&include=display',
+      }),
+    );
+  });
+
+  it('does not fetch when groupId is undefined', () => {
+    const {result} = renderHook(() => useGetAllGroupMembers(undefined));
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockHttpRequest).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/packages/configure-groups/src/api/useGetAllCandidates.ts
+++ b/frontend/packages/configure-groups/src/api/useGetAllCandidates.ts
@@ -1,0 +1,65 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {useQuery, type UseQueryResult} from '@tanstack/react-query';
+import {useConfig} from '@thunderid/contexts';
+import {useThunderID} from '@thunderid/react';
+
+interface CandidatePage<T> {
+  totalResults: number;
+  count: number;
+  [key: string]: T[] | number;
+}
+
+interface UseGetAllCandidatesOptions {
+  path: string;
+  itemsKey: string;
+  enabled: boolean;
+}
+
+export default function useGetAllCandidates<T>({
+  path,
+  itemsKey,
+  enabled,
+}: UseGetAllCandidatesOptions): UseQueryResult<T[]> {
+  const {http} = useThunderID();
+  const {getServerUrl} = useConfig();
+
+  return useQuery<T[]>({
+    queryKey: ['group-add-member-candidates', path],
+    queryFn: async (): Promise<T[]> => {
+      const serverUrl: string = getServerUrl();
+      const candidates: T[] = [];
+      const limit = 100;
+      let totalResults = 0;
+      let offset = 0;
+
+      do {
+        const queryParams: URLSearchParams = new URLSearchParams({
+          limit: limit.toString(),
+          offset: offset.toString(),
+          include: 'display',
+        });
+        const response: {data: CandidatePage<T>} = await http.request({
+          url: `${serverUrl}${path}?${queryParams.toString()}`,
+          method: 'GET',
+        } as unknown as Parameters<typeof http.request>[0]);
+        const page = response.data;
+        const pageCandidates = page[itemsKey];
+
+        if (!Array.isArray(pageCandidates)) {
+          throw new Error(`Invalid candidate response for ${itemsKey}`);
+        }
+
+        candidates.push(...pageCandidates);
+        totalResults = page.totalResults;
+        offset += page.count;
+
+        if (page.count === 0) break;
+      } while (offset < totalResults);
+
+      return candidates;
+    },
+    enabled,
+  });
+}

--- a/frontend/packages/configure-groups/src/api/useGetAllGroupMembers.ts
+++ b/frontend/packages/configure-groups/src/api/useGetAllGroupMembers.ts
@@ -1,0 +1,53 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {useQuery, type UseQueryResult} from '@tanstack/react-query';
+import {useConfig} from '@thunderid/contexts';
+import {useThunderID} from '@thunderid/react';
+import GroupQueryKeys from '../constants/group-query-keys';
+import type {Member, MemberListResponse} from '../models/group';
+
+const pageSize = 100;
+
+export default function useGetAllGroupMembers(groupId: string | undefined): UseQueryResult<MemberListResponse> {
+  const {http} = useThunderID();
+  const {getServerUrl} = useConfig();
+
+  return useQuery<MemberListResponse>({
+    queryKey: [GroupQueryKeys.GROUP_MEMBERS, groupId, 'all'],
+    queryFn: async (): Promise<MemberListResponse> => {
+      const serverUrl: string = getServerUrl();
+      const members: Member[] = [];
+      let totalResults = 0;
+      let offset = 0;
+
+      do {
+        const queryParams: URLSearchParams = new URLSearchParams({
+          limit: pageSize.toString(),
+          offset: offset.toString(),
+          include: 'display',
+        });
+        const response: {data: MemberListResponse} = await http.request({
+          url: `${serverUrl}/groups/${groupId}/members?${queryParams.toString()}`,
+          method: 'GET',
+        } as unknown as Parameters<typeof http.request>[0]);
+        const page = response.data;
+
+        members.push(...page.members);
+        totalResults = page.totalResults;
+        offset += page.count;
+
+        if (page.count === 0) break;
+      } while (offset < totalResults);
+
+      return {
+        totalResults,
+        startIndex: 1,
+        count: members.length,
+        members,
+        links: [],
+      };
+    },
+    enabled: Boolean(groupId),
+  });
+}

--- a/frontend/packages/configure-groups/src/components/__tests__/AddMemberDialog.test.tsx
+++ b/frontend/packages/configure-groups/src/components/__tests__/AddMemberDialog.test.tsx
@@ -48,18 +48,23 @@ vi.mock('@wso2/oxygen-ui', async () => {
   };
 });
 
-const mockUseGetUsers = vi.fn();
-const mockUseGetApplications = vi.fn();
-const mockUseGetGroups = vi.fn();
-vi.mock('@thunderid/configure-users', () => ({
-  useGetUsers: (...args: unknown[]): unknown => mockUseGetUsers(...args),
+interface MockQueryResult {
+  data?: Record<string, unknown> | null;
+  isLoading?: boolean;
+  error?: Error;
+}
+
+const mockUseGetUsers = vi.fn<() => MockQueryResult>();
+const mockUseGetApplications = vi.fn<() => MockQueryResult>();
+const mockUseGetAgents = vi.fn<() => MockQueryResult>();
+const mockUseGetAllCandidates = vi.fn();
+const mockUseGetAllGroupMembers = vi.fn();
+const mockUseGetGroups = vi.fn<() => MockQueryResult>();
+vi.mock('../../api/useGetAllCandidates', () => ({
+  default: (...args: unknown[]): unknown => mockUseGetAllCandidates(...args),
 }));
-vi.mock('@thunderid/configure-applications', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@thunderid/configure-applications')>()),
-  useGetApplications: (...args: unknown[]): unknown => mockUseGetApplications(...args),
-}));
-vi.mock('../../api/useGetGroups', () => ({
-  default: (...args: unknown[]): unknown => mockUseGetGroups(...args),
+vi.mock('../../api/useGetAllGroupMembers', () => ({
+  default: (...args: unknown[]): unknown => mockUseGetAllGroupMembers(...args),
 }));
 
 describe('AddMemberDialog', () => {
@@ -71,6 +76,20 @@ describe('AddMemberDialog', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseGetAllCandidates.mockImplementation(({itemsKey}: {itemsKey: string}) => {
+      const responses: Record<string, MockQueryResult> = {
+        users: mockUseGetUsers(),
+        applications: mockUseGetApplications(),
+        agents: mockUseGetAgents(),
+        groups: mockUseGetGroups(),
+      };
+      const response = responses[itemsKey];
+      return {
+        data: response?.data?.[itemsKey] ?? [],
+        isLoading: response?.isLoading ?? false,
+        error: response?.error,
+      };
+    });
     mockUseGetUsers.mockReturnValue({
       data: {
         totalResults: 2,
@@ -94,6 +113,17 @@ describe('AddMemberDialog', () => {
       },
       isLoading: false,
     });
+    mockUseGetAgents.mockReturnValue({
+      data: {
+        totalResults: 2,
+        count: 2,
+        agents: [
+          {id: 'agent-1', name: 'Automation Agent'},
+          {id: 'agent-2', name: 'Support Agent'},
+        ],
+      },
+      isLoading: false,
+    });
     mockUseGetGroups.mockReturnValue({
       data: {
         totalResults: 3,
@@ -106,6 +136,11 @@ describe('AddMemberDialog', () => {
         ],
       },
       isLoading: false,
+    });
+    mockUseGetAllGroupMembers.mockReturnValue({
+      data: {totalResults: 0, startIndex: 1, count: 0, members: [], links: []},
+      isLoading: false,
+      refetch: vi.fn(),
     });
   });
 
@@ -130,6 +165,61 @@ describe('AddMemberDialog', () => {
 
     expect(screen.getByTestId('user-u1')).toBeInTheDocument();
     expect(screen.getByTestId('user-u2')).toBeInTheDocument();
+  });
+
+  it('should hide members that are already assigned to the group in every tab', async () => {
+    const user = userEvent.setup();
+    mockUseGetAllGroupMembers.mockReturnValue({
+      data: {
+        totalResults: 4,
+        startIndex: 1,
+        count: 4,
+        members: [
+          {id: 'u1', type: 'user'},
+          {id: 'a1', type: 'app'},
+          {id: 'agent-1', type: 'agent'},
+          {id: 'g1', type: 'group'},
+        ],
+        links: [],
+      },
+      isLoading: false,
+    });
+
+    renderWithProviders(<AddMemberDialog {...defaultProps} groupId="g1" />);
+
+    expect(screen.queryByTestId('user-u1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('user-u2')).toBeInTheDocument();
+
+    await user.click(screen.getByText('Apps'));
+    expect(screen.queryByTestId('user-a1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('user-a2')).toBeInTheDocument();
+
+    await user.click(screen.getByText('Agents'));
+    expect(screen.queryByTestId('user-agent-1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('user-agent-2')).toBeInTheDocument();
+
+    await user.click(screen.getByText('Groups'));
+    expect(screen.queryByTestId('user-g1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('user-g2')).toBeInTheDocument();
+  });
+
+  it('should block additions and show retry when current members cannot be loaded', async () => {
+    const user = userEvent.setup();
+    const refetchMembers = vi.fn();
+    mockUseGetAllGroupMembers.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Network error'),
+      refetch: refetchMembers,
+    });
+
+    renderWithProviders(<AddMemberDialog {...defaultProps} groupId="g1" />);
+
+    expect(screen.getByText('Failed to load current group members. Please try again.')).toBeInTheDocument();
+    expect(screen.getByText('Add Selected').closest('button')).toBeDisabled();
+
+    await user.click(screen.getByText('Refresh'));
+    expect(refetchMembers).toHaveBeenCalledTimes(1);
   });
 
   it('should render apps in the grid when Apps tab is selected', async () => {
@@ -281,11 +371,17 @@ describe('AddMemberDialog', () => {
     expect(defaultProps.onClose).toHaveBeenCalled();
   });
 
-  it('should call useGetUsers with pagination params', () => {
+  it('should load all candidate collections with only the active tab enabled', () => {
     renderWithProviders(<AddMemberDialog {...defaultProps} />);
 
-    expect(mockUseGetUsers).toHaveBeenCalledWith({limit: 10, offset: 0});
-    expect(mockUseGetApplications).toHaveBeenCalledWith({limit: 10, offset: 0});
+    expect(mockUseGetAllCandidates).toHaveBeenCalledWith({path: '/users', itemsKey: 'users', enabled: true});
+    expect(mockUseGetAllCandidates).toHaveBeenCalledWith({
+      path: '/applications',
+      itemsKey: 'applications',
+      enabled: false,
+    });
+    expect(mockUseGetAllCandidates).toHaveBeenCalledWith({path: '/agents', itemsKey: 'agents', enabled: false});
+    expect(mockUseGetAllCandidates).toHaveBeenCalledWith({path: '/groups', itemsKey: 'groups', enabled: false});
   });
 
   it('should show error alert when users fetch fails', () => {

--- a/frontend/packages/configure-groups/src/components/edit-group/members-settings/AddMemberDialog.tsx
+++ b/frontend/packages/configure-groups/src/components/edit-group/members-settings/AddMemberDialog.tsx
@@ -1,12 +1,10 @@
 // Copyright 2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import {useGetApplications} from '@thunderid/configure-applications';
+import {QueryErrorNotice} from '@thunderid/components';
 import type {BasicApplication} from '@thunderid/configure-applications';
-import {useGetUsers} from '@thunderid/configure-users';
 import {useDataGridLocaleText} from '@thunderid/hooks';
 import type {User} from '@thunderid/types';
-import {getErrorMessage} from '@thunderid/utils';
 import {
   Dialog,
   DialogTitle,
@@ -26,9 +24,9 @@ import {
 import {AppWindow, Bot, User as UserIcon, Users} from '@wso2/oxygen-ui-icons-react';
 import {useState, useMemo, useCallback, type JSX, type SyntheticEvent} from 'react';
 import {useTranslation} from 'react-i18next';
-import useGetGroups from '../../../api/useGetGroups';
+import useGetAllCandidates from '../../../api/useGetAllCandidates';
+import useGetAllGroupMembers from '../../../api/useGetAllGroupMembers';
 import type {BasicAgent} from '../../../internal/agent';
-import useGetAgents from '../../../internal/useGetAgents';
 import type {GroupBasic, Member} from '../../../models/group';
 
 interface AddMemberDialogProps {
@@ -43,6 +41,8 @@ interface AddMemberDialogProps {
   onErrorDismiss?: () => void;
   /** Whether the add mutation is in flight, so the confirm button can show progress. */
   isSubmitting?: boolean;
+  /** Group ID used to hide members that are already assigned. */
+  groupId?: string;
 }
 
 /**
@@ -56,6 +56,7 @@ export default function AddMemberDialog({
   error = null,
   onErrorDismiss = undefined,
   isSubmitting = false,
+  groupId = undefined,
 }: AddMemberDialogProps): JSX.Element {
   const {t} = useTranslation();
   const theme = useTheme();
@@ -89,52 +90,62 @@ export default function AddMemberDialog({
     page: 0,
   });
 
-  const usersParams = useMemo(
-    () => ({
-      limit: userPaginationModel.pageSize,
-      offset: userPaginationModel.page * userPaginationModel.pageSize,
-    }),
-    [userPaginationModel],
-  );
-  const appsParams = useMemo(
-    () => ({
-      limit: appPaginationModel.pageSize,
-      offset: appPaginationModel.page * appPaginationModel.pageSize,
-    }),
-    [appPaginationModel],
-  );
-  const agentsParams = useMemo(
-    () => ({
-      limit: agentPaginationModel.pageSize,
-      offset: agentPaginationModel.page * agentPaginationModel.pageSize,
-    }),
-    [agentPaginationModel],
-  );
-  const groupsParams = useMemo(
-    () => ({
-      limit: groupPaginationModel.pageSize,
-      offset: groupPaginationModel.page * groupPaginationModel.pageSize,
-    }),
-    [groupPaginationModel],
-  );
-  const {data: usersData, isLoading: usersLoading, error: usersError} = useGetUsers(usersParams);
-  const {data: appsData, isLoading: appsLoading, error: appsError} = useGetApplications(appsParams);
-  const {data: agentsData, isLoading: agentsLoading, error: agentsError} = useGetAgents(agentsParams);
-  const {data: groupsData, isLoading: groupsLoading, error: groupsError} = useGetGroups(groupsParams);
+  const {
+    data: users = [],
+    isLoading: usersLoading,
+    error: usersError,
+    refetch: refetchUsers,
+  } = useGetAllCandidates<User>({path: '/users', itemsKey: 'users', enabled: activeTab === 0});
+  const {
+    data: applications = [],
+    isLoading: appsLoading,
+    error: appsError,
+    refetch: refetchApplications,
+  } = useGetAllCandidates<BasicApplication>({
+    path: '/applications',
+    itemsKey: 'applications',
+    enabled: activeTab === 1,
+  });
+  const {
+    data: agents = [],
+    isLoading: agentsLoading,
+    error: agentsError,
+    refetch: refetchAgents,
+  } = useGetAllCandidates<BasicAgent>({path: '/agents', itemsKey: 'agents', enabled: activeTab === 2});
+  const {
+    data: allGroups = [],
+    isLoading: groupsLoading,
+    error: groupsError,
+    refetch: refetchGroups,
+  } = useGetAllCandidates<GroupBasic>({path: '/groups', itemsKey: 'groups', enabled: activeTab === 3});
+  const {
+    data: membersData,
+    isLoading: membersLoading,
+    error: membersError,
+    refetch: refetchMembers,
+  } = useGetAllGroupMembers(groupId);
+  const membershipUnavailable = Boolean(groupId) && (membersLoading || Boolean(membersError));
 
-  const users: User[] = useMemo(() => usersData?.users ?? [], [usersData]);
-  const applications: BasicApplication[] = useMemo(() => appsData?.applications ?? [], [appsData]);
-  const agents: BasicAgent[] = useMemo(() => agentsData?.agents ?? [], [agentsData]);
-  // The listing is server-paginated, so the edited group is dropped from the current page and the
-  // total is adjusted by one rather than being filtered out of the query itself.
-  const groups: GroupBasic[] = useMemo(
-    () => (groupsData?.groups ?? []).filter((group) => group.id !== excludeGroupId),
-    [groupsData, excludeGroupId],
+  const existingMemberKeys = useMemo(
+    () => new Set((membersData?.members ?? []).map((member) => `${member.type}:${member.id}`)),
+    [membersData],
   );
-  const groupsRowCount: number = useMemo(() => {
-    const total = groupsData?.totalResults ?? 0;
-    return excludeGroupId ? Math.max(total - 1, 0) : total;
-  }, [groupsData, excludeGroupId]);
+  const filteredUsers = useMemo(
+    () => users.filter((user) => !existingMemberKeys.has(`user:${user.id}`)),
+    [users, existingMemberKeys],
+  );
+  const filteredApplications = useMemo(
+    () => applications.filter((application) => !existingMemberKeys.has(`app:${application.id}`)),
+    [applications, existingMemberKeys],
+  );
+  const filteredAgents = useMemo(
+    () => agents.filter((agent) => !existingMemberKeys.has(`agent:${agent.id}`)),
+    [agents, existingMemberKeys],
+  );
+  const groups: GroupBasic[] = useMemo(
+    () => allGroups.filter((group) => group.id !== excludeGroupId && !existingMemberKeys.has(`group:${group.id}`)),
+    [allGroups, excludeGroupId, existingMemberKeys],
+  );
 
   const userColumns: DataGrid.GridColDef<User>[] = useMemo(
     () => [
@@ -407,27 +418,38 @@ export default function AddMemberDialog({
           <Tab icon={<Users size={16} />} iconPosition="start" label={t('groups:addMember.tabs.groups', 'Groups')} />
         </Tabs>
 
-        {activeTab === 0 && (
+        {membersError && (
+          <QueryErrorNotice
+            error={membersError}
+            t={t}
+            variant="inline"
+            fallbackKey="groups:addMember.membersFetchError"
+            fallbackDefaultValue="Failed to load current group members. Please try again."
+            onRetry={() => void refetchMembers()}
+          />
+        )}
+
+        {activeTab === 0 && !membersLoading && !membersError && (
           <>
-            {usersError && !usersLoading && (
-              <Alert severity="error" sx={{mb: 2}}>
-                {getErrorMessage(
-                  usersError,
-                  t,
-                  'groups:addMember.fetchError',
-                  'Failed to load users. Please try again.',
-                )}
-              </Alert>
+            {usersError && (
+              <QueryErrorNotice
+                error={usersError}
+                t={t}
+                variant="inline"
+                fallbackKey="groups:addMember.fetchError"
+                fallbackDefaultValue="Failed to load users. Please try again."
+                onRetry={() => void refetchUsers()}
+              />
             )}
-            {!usersError && users.length === 0 && !usersLoading && (
+            {!usersError && filteredUsers.length === 0 && !usersLoading && !membersLoading && (
               <Alert severity="info" sx={{mb: 2}}>
-                {t('groups:addMember.noResults')}
+                {t('groups:addMember.noResults', 'No users found')}
               </Alert>
             )}
 
             <Box sx={{height: 400, width: '100%'}}>
               <DataGrid.DataGrid
-                rows={users}
+                rows={filteredUsers}
                 columns={userColumns}
                 loading={usersLoading}
                 getRowId={(row): string => row.id}
@@ -437,8 +459,6 @@ export default function AddMemberDialog({
                   setUserSelectionModel(newSelection);
                   onErrorDismiss?.();
                 }}
-                paginationMode="server"
-                rowCount={usersData?.totalResults ?? 0}
                 paginationModel={userPaginationModel}
                 onPaginationModelChange={setUserPaginationModel}
                 pageSizeOptions={[5, 10]}
@@ -449,27 +469,27 @@ export default function AddMemberDialog({
           </>
         )}
 
-        {activeTab === 1 && (
+        {activeTab === 1 && !membersLoading && !membersError && (
           <>
-            {appsError && !appsLoading && (
-              <Alert severity="error" sx={{mb: 2}}>
-                {getErrorMessage(
-                  appsError,
-                  t,
-                  'groups:addMember.fetchAppsError',
-                  'Failed to load apps. Please try again.',
-                )}
-              </Alert>
+            {appsError && (
+              <QueryErrorNotice
+                error={appsError}
+                t={t}
+                variant="inline"
+                fallbackKey="groups:addMember.fetchAppsError"
+                fallbackDefaultValue="Failed to load apps. Please try again."
+                onRetry={() => void refetchApplications()}
+              />
             )}
-            {!appsError && applications.length === 0 && !appsLoading && (
+            {!appsError && filteredApplications.length === 0 && !appsLoading && !membersLoading && (
               <Alert severity="info" sx={{mb: 2}}>
-                {t('groups:addMember.noResultsApps')}
+                {t('groups:addMember.noResultsApps', 'No apps found')}
               </Alert>
             )}
 
             <Box sx={{height: 400, width: '100%'}}>
               <DataGrid.DataGrid
-                rows={applications}
+                rows={filteredApplications}
                 columns={appColumns}
                 loading={appsLoading}
                 getRowId={(row): string => row.id}
@@ -479,8 +499,6 @@ export default function AddMemberDialog({
                   setAppSelectionModel(newSelection);
                   onErrorDismiss?.();
                 }}
-                paginationMode="server"
-                rowCount={appsData?.totalResults ?? 0}
                 paginationModel={appPaginationModel}
                 onPaginationModelChange={setAppPaginationModel}
                 pageSizeOptions={[5, 10]}
@@ -491,19 +509,19 @@ export default function AddMemberDialog({
           </>
         )}
 
-        {activeTab === 2 && (
+        {activeTab === 2 && !membersLoading && !membersError && (
           <>
-            {agentsError && !agentsLoading && (
-              <Alert severity="error" sx={{mb: 2}}>
-                {getErrorMessage(
-                  agentsError,
-                  t,
-                  'groups:addMember.fetchAgentsError',
-                  'Failed to load agents. Please try again.',
-                )}
-              </Alert>
+            {agentsError && (
+              <QueryErrorNotice
+                error={agentsError}
+                t={t}
+                variant="inline"
+                fallbackKey="groups:addMember.fetchAgentsError"
+                fallbackDefaultValue="Failed to load agents. Please try again."
+                onRetry={() => void refetchAgents()}
+              />
             )}
-            {!agentsError && agents.length === 0 && !agentsLoading && (
+            {!agentsError && filteredAgents.length === 0 && !agentsLoading && !membersLoading && (
               <Alert severity="info" sx={{mb: 2}}>
                 {t('groups:addMember.noResultsAgents', 'No agents found')}
               </Alert>
@@ -511,7 +529,7 @@ export default function AddMemberDialog({
 
             <Box sx={{height: 400, width: '100%'}}>
               <DataGrid.DataGrid
-                rows={agents}
+                rows={filteredAgents}
                 columns={agentColumns}
                 loading={agentsLoading}
                 getRowId={(row): string => row.id}
@@ -521,8 +539,6 @@ export default function AddMemberDialog({
                   setAgentSelectionModel(newSelection);
                   onErrorDismiss?.();
                 }}
-                paginationMode="server"
-                rowCount={agentsData?.totalResults ?? 0}
                 paginationModel={agentPaginationModel}
                 onPaginationModelChange={setAgentPaginationModel}
                 pageSizeOptions={[5, 10]}
@@ -533,19 +549,19 @@ export default function AddMemberDialog({
           </>
         )}
 
-        {activeTab === 3 && (
+        {activeTab === 3 && !membersLoading && !membersError && (
           <>
-            {groupsError && !groupsLoading && (
-              <Alert severity="error" sx={{mb: 2}}>
-                {getErrorMessage(
-                  groupsError,
-                  t,
-                  'groups:addMember.fetchGroupsError',
-                  'Failed to load groups. Please try again.',
-                )}
-              </Alert>
+            {groupsError && (
+              <QueryErrorNotice
+                error={groupsError}
+                t={t}
+                variant="inline"
+                fallbackKey="groups:addMember.fetchGroupsError"
+                fallbackDefaultValue="Failed to load groups. Please try again."
+                onRetry={() => void refetchGroups()}
+              />
             )}
-            {!groupsError && groups.length === 0 && !groupsLoading && (
+            {!groupsError && groups.length === 0 && !groupsLoading && !membersLoading && (
               <Alert severity="info" sx={{mb: 2}}>
                 {t('groups:addMember.noResultsGroups', 'No groups found')}
               </Alert>
@@ -563,8 +579,6 @@ export default function AddMemberDialog({
                   setGroupSelectionModel(newSelection);
                   onErrorDismiss?.();
                 }}
-                paginationMode="server"
-                rowCount={groupsRowCount}
                 paginationModel={groupPaginationModel}
                 onPaginationModelChange={setGroupPaginationModel}
                 pageSizeOptions={[5, 10]}
@@ -584,7 +598,11 @@ export default function AddMemberDialog({
         <Button onClick={handleClose} disabled={isSubmitting}>
           {t('common:actions.cancel', 'Cancel')}
         </Button>
-        <Button variant="contained" onClick={handleAdd} disabled={totalSelected === 0 || isSubmitting}>
+        <Button
+          variant="contained"
+          onClick={handleAdd}
+          disabled={totalSelected === 0 || isSubmitting || membershipUnavailable}
+        >
           {t('groups:addMember.add', 'Add Selected')}
         </Button>
       </DialogActions>

--- a/frontend/packages/configure-groups/src/components/edit-group/members-settings/EditMembersSettings.tsx
+++ b/frontend/packages/configure-groups/src/components/edit-group/members-settings/EditMembersSettings.tsx
@@ -106,6 +106,7 @@ export default function EditMembersSettings({group}: EditMembersSettingsProps): 
             setAddError(null);
           }}
           onAdd={handleAddMembers}
+          groupId={group.id}
           excludeGroupId={group.id}
           error={addError}
           onErrorDismiss={() => setAddError(null)}


### PR DESCRIPTION
### Purpose
Prevent users, applications, agents, and groups that are already members of a group from appearing in the Add Member dialog. This avoids duplicate add attempts.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach

- Pass the current group ID to the Add Member dialog.
- Fetch the group’s existing members.
- Filter existing members by member type and ID from the Users, Apps, Agents, and Groups tabs.
- Keep the existing backend deduplicates duplicate requests as a safeguard.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4719

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prevents adding users, applications, agents, or groups already assigned to the current group.
  * Loads all existing group members and available candidates across paginated results.
  * Disables member additions until membership data is available.
  * Provides inline retry options when member or candidate loading fails.
  * Updates tabs and empty states to reflect available, filtered results.

* **Tests**
  * Added coverage for pagination, request behavior, filtering, loading failures, and retry handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->