### PR TITLE
Set the SMS template on generated MFA OTP send nodes

### DIFF
--- a/frontend/apps/console/src/features/flows/utils/__tests__/generateFlowGraph.test.ts
+++ b/frontend/apps/console/src/features/flows/utils/__tests__/generateFlowGraph.test.ts
@@ -180,6 +180,7 @@ describe('generateFlowGraph', () => {
       const sendNode = request.nodes.find((n) => n.id === 'mfa_send_otp');
       expect(sendNode?.executor?.name).toBe('SMSExecutor');
       expect(sendNode?.properties?.senderId).toBe('sender-123');
+      expect(sendNode?.properties?.smsTemplate).toBe('OTP');
     });
 
     it('should branch into an independent channel-choice chain when both Email and SMS OTP MFA are enabled', () => {
@@ -203,6 +204,10 @@ describe('generateFlowGraph', () => {
       expect(emailPrompt?.prompts?.find((p) => p.action?.nextNode === 'mfa_generate_otp_email')).toBeDefined();
       const smsPrompt = request.nodes.find((n) => n.id === 'mfa_verify_prompt_sms');
       expect(smsPrompt?.prompts?.find((p) => p.action?.nextNode === 'mfa_generate_otp_sms')).toBeDefined();
+
+      const smsSendNode = request.nodes.find((n) => n.id === 'mfa_send_otp_sms');
+      expect(smsSendNode?.properties?.senderId).toBe('sender-123');
+      expect(smsSendNode?.properties?.smsTemplate).toBe('OTP');
 
       expect(request.nodes.find((n) => n.id === 'mfa_verify_otp_email')?.onSuccess).toBe('auth_assert');
       expect(request.nodes.find((n) => n.id === 'mfa_verify_otp_sms')?.onSuccess).toBe('auth_assert');

--- a/frontend/apps/console/src/features/flows/utils/generateFlowGraph.ts
+++ b/frontend/apps/console/src/features/flows/utils/generateFlowGraph.ts
@@ -83,7 +83,7 @@ function buildMfaChannelChain(
       : {
           id: sendId,
           type: FlowNodeType.TASK_EXECUTION,
-          properties: {senderId: smsOtpSenderId},
+          properties: {senderId: smsOtpSenderId, smsTemplate: 'OTP'},
           executor: {name: 'SMSExecutor'},
           onSuccess: promptId,
         },


### PR DESCRIPTION
### Purpose
Enabling SMS OTP as a second factor in the application create wizard failed with `FLM-1023`. The generated `mfa_send_otp` node carried only `senderId`, but `SMSExecutor` requires `smsTemplate` too, so flow creation was rejected.

### Approach
Set `smsTemplate: 'OTP'` on the SMS branch of `buildMfaChannelChain`, matching the email branch and the `sms_send` nodes in the flow templates. The single edit covers both the SMS-only and the Email+SMS channel-choice chains. Added the missing `smsTemplate` assertions to the generator tests.

### Related Issues
- Fixes #4716

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured SMS-based one-time passcodes use the correct OTP message template.
  * Applied the fix consistently across single-channel and dual-channel MFA flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->