### PR TITLE
Keep the execution node when a button targeting it is deleted

### DIFF
--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/ResourcePropertyPanel.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/ResourcePropertyPanel.tsx
@@ -9,6 +9,7 @@ import {memo, useCallback, type ReactElement} from 'react';
 import {useTranslation} from 'react-i18next';
 import CommonResourceProperties from './CommonResourceProperties';
 import PanelActionButton from './PanelActionButton';
+import useFlowPlugins from '../../hooks/useFlowPlugins';
 import useInteractionState from '../../hooks/useInteractionState';
 import useUIPanelState from '../../hooks/useUIPanelState';
 import {type Element} from '../../models/elements';
@@ -34,6 +35,7 @@ function ResourcePropertyPanel({open = false, onComponentDelete}: ResourceProper
 
   const {resourcePropertiesPanelHeading, setIsOpenResourcePropertiesPanel} = useUIPanelState();
   const {lastInteractedStepId, lastInteractedResource} = useInteractionState();
+  const {emitNodeElementDelete} = useFlowPlugins();
 
   const handleClose = useCallback(() => {
     setIsOpenResourcePropertiesPanel(false);
@@ -47,11 +49,15 @@ function ResourcePropertyPanel({open = false, onComponentDelete}: ResourceProper
         // Deletion may fail silently if the node doesn't exist or is protected
       });
     } else {
+      // Same order as the widget toolbar delete: plugins react to the element first,
+      // then the element is removed from the step.
+      emitNodeElementDelete(lastInteractedStepId ?? '', lastInteractedResource as Element);
       onComponentDelete(lastInteractedStepId, lastInteractedResource as Element);
     }
     setIsOpenResourcePropertiesPanel(false);
   }, [
     deleteElements,
+    emitNodeElementDelete,
     lastInteractedResource,
     lastInteractedStepId,
     onComponentDelete,

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/ResourcePropertyPanel.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/ResourcePropertyPanel.test.tsx
@@ -5,6 +5,7 @@ import {render, screen, fireEvent} from '@testing-library/react';
 import {ReactFlowProvider} from '@xyflow/react';
 import type {ReactNode} from 'react';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
+import FlowPluginContext, {type FlowPluginContextProps} from '../../../context/FlowPluginContext';
 import InteractionContext from '../../../context/InteractionContext';
 import UIPanelContext from '../../../context/UIPanelContext';
 import type {Base} from '../../../models/base';
@@ -38,6 +39,7 @@ vi.mock('../CommonResourceProperties', () => ({
 describe('ResourcePropertyPanel', () => {
   const mockSetIsOpenResourcePropertiesPanel = vi.fn();
   const mockOnComponentDelete = vi.fn();
+  const mockEmitNodeElementDelete = vi.fn().mockReturnValue(true);
 
   const mockBaseResource: Base = {
     id: 'resource-1',
@@ -90,9 +92,13 @@ describe('ResourcePropertyPanel', () => {
     function Wrapper({children}: {children: ReactNode}) {
       return (
         <ReactFlowProvider>
-          <UIPanelContext.Provider value={uiPanelValue}>
-            <InteractionContext.Provider value={interactionValue}>{children}</InteractionContext.Provider>
-          </UIPanelContext.Provider>
+          <FlowPluginContext.Provider
+            value={{emitNodeElementDelete: mockEmitNodeElementDelete} as unknown as FlowPluginContextProps}
+          >
+            <UIPanelContext.Provider value={uiPanelValue}>
+              <InteractionContext.Provider value={interactionValue}>{children}</InteractionContext.Provider>
+            </UIPanelContext.Provider>
+          </FlowPluginContext.Provider>
         </ReactFlowProvider>
       );
     }
@@ -174,6 +180,32 @@ describe('ResourcePropertyPanel', () => {
 
       expect(mockOnComponentDelete).toHaveBeenCalledWith('step-1', mockBaseResource);
       expect(mockSetIsOpenResourcePropertiesPanel).toHaveBeenCalledWith(false);
+    });
+
+    it('should emit onNodeElementDelete before removing the component', () => {
+      render(<ResourcePropertyPanel open onComponentDelete={mockOnComponentDelete} />, {wrapper: createWrapper()});
+
+      fireEvent.click(screen.getByRole('button', {name: 'Delete', hidden: true}));
+
+      expect(mockEmitNodeElementDelete).toHaveBeenCalledWith('step-1', mockBaseResource);
+      expect(mockEmitNodeElementDelete.mock.invocationCallOrder[0]).toBeLessThan(
+        mockOnComponentDelete.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('should not emit onNodeElementDelete when resource is a Step', () => {
+      const stepResource: Base = {
+        ...mockBaseResource,
+        resourceType: ResourceTypes.Step,
+      };
+
+      render(<ResourcePropertyPanel open onComponentDelete={mockOnComponentDelete} />, {
+        wrapper: createWrapper({}, {lastInteractedResource: stepResource}),
+      });
+
+      fireEvent.click(screen.getByRole('button', {name: 'Delete', hidden: true}));
+
+      expect(mockEmitNodeElementDelete).not.toHaveBeenCalled();
     });
 
     it('should not render delete button when lastInteractedResource is null', () => {

--- a/frontend/apps/console/src/features/flows/hooks/__tests__/useDeleteExecutionResource.test.tsx
+++ b/frontend/apps/console/src/features/flows/hooks/__tests__/useDeleteExecutionResource.test.tsx
@@ -16,7 +16,6 @@ const {
   mockGetEdges,
   mockGetNodes,
   mockUpdateNodeData,
-  mockSetNodes,
   mockSetIsOpenResourcePropertiesPanel,
   registeredHandlers,
   mockUnsubscribes,
@@ -24,7 +23,6 @@ const {
   mockGetEdges: vi.fn().mockReturnValue([]),
   mockGetNodes: vi.fn().mockReturnValue([]),
   mockUpdateNodeData: vi.fn(),
-  mockSetNodes: vi.fn(),
   mockSetIsOpenResourcePropertiesPanel: vi.fn(),
   registeredHandlers: {} as Record<string, ((...args: unknown[]) => Promise<boolean>)[]>,
   mockUnsubscribes: {} as Record<string, ReturnType<typeof vi.fn>[]>,
@@ -39,14 +37,7 @@ const mockOnNodeDelete = vi.fn().mockImplementation((handler: (...args: unknown[
   return unsub;
 });
 
-const mockOnNodeElementDelete = vi.fn().mockImplementation((handler: (...args: unknown[]) => Promise<boolean>) => {
-  if (!registeredHandlers.onNodeElementDelete) registeredHandlers.onNodeElementDelete = [];
-  registeredHandlers.onNodeElementDelete.push(handler);
-  const unsub = vi.fn();
-  if (!mockUnsubscribes.onNodeElementDelete) mockUnsubscribes.onNodeElementDelete = [];
-  mockUnsubscribes.onNodeElementDelete.push(unsub);
-  return unsub;
-});
+const mockOnNodeElementDelete = vi.fn().mockReturnValue(vi.fn());
 
 const mockFlowPlugins = {
   onPropertyChange: vi.fn().mockReturnValue(vi.fn()),
@@ -74,7 +65,6 @@ vi.mock('@xyflow/react', async () => {
       getEdges: mockGetEdges,
       getNodes: mockGetNodes,
       updateNodeData: mockUpdateNodeData,
-      setNodes: mockSetNodes,
     }),
   };
 });
@@ -126,14 +116,7 @@ describe('useDeleteExecutionResource', () => {
       mockUnsubscribes.onNodeDelete.push(unsub);
       return unsub;
     });
-    mockOnNodeElementDelete.mockImplementation((handler: (...args: unknown[]) => Promise<boolean>) => {
-      if (!registeredHandlers.onNodeElementDelete) registeredHandlers.onNodeElementDelete = [];
-      registeredHandlers.onNodeElementDelete.push(handler);
-      const unsub = vi.fn();
-      if (!mockUnsubscribes.onNodeElementDelete) mockUnsubscribes.onNodeElementDelete = [];
-      mockUnsubscribes.onNodeElementDelete.push(unsub);
-      return unsub;
-    });
+    mockOnNodeElementDelete.mockReturnValue(vi.fn());
   });
 
   describe('Plugin Registration', () => {
@@ -144,7 +127,17 @@ describe('useDeleteExecutionResource', () => {
 
       // Check that handlers are registered
       expect(mockOnNodeDelete).toHaveBeenCalledWith(expect.any(Function));
-      expect(mockOnNodeElementDelete).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it('should not subscribe to element deletion', () => {
+      renderHook(() => useDeleteExecutionResource(), {
+        wrapper: createWrapper(),
+      });
+
+      // Deleting a button never removes the execution node it points to, so the hook
+      // has no element-deletion handler. Guards against reintroducing the shared-node
+      // deletion (a button and an upstream step can target the same execution node).
+      expect(mockOnNodeElementDelete).not.toHaveBeenCalled();
     });
 
     it('should call unsubscribe functions on unmount', () => {
@@ -156,7 +149,6 @@ describe('useDeleteExecutionResource', () => {
 
       // Check that unsubscribe functions are called
       mockUnsubscribes.onNodeDelete?.forEach((unsub) => expect(unsub).toHaveBeenCalled());
-      mockUnsubscribes.onNodeElementDelete?.forEach((unsub) => expect(unsub).toHaveBeenCalled());
     });
   });
 
@@ -202,16 +194,6 @@ describe('useDeleteExecutionResource', () => {
     });
   });
 
-  describe('deleteExecutionNode', () => {
-    it('should register the handler for element deletion', () => {
-      renderHook(() => useDeleteExecutionResource(), {
-        wrapper: createWrapper(),
-      });
-
-      expect(mockOnNodeElementDelete).toHaveBeenCalledWith(expect.any(Function));
-    });
-  });
-
   describe('Context Integration', () => {
     it('should use setIsOpenResourcePropertiesPanel from context', () => {
       renderHook(() => useDeleteExecutionResource(), {
@@ -220,7 +202,6 @@ describe('useDeleteExecutionResource', () => {
 
       // The hook should have access to context
       expect(mockOnNodeDelete).toHaveBeenCalledTimes(1);
-      expect(mockOnNodeElementDelete).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -312,82 +293,6 @@ describe('useDeleteExecutionResource', () => {
     });
   });
 
-  describe('deleteExecutionNode Handler', () => {
-    it('should return true for non-action elements', async () => {
-      mockGetNodes.mockReturnValue([]);
-
-      renderHook(() => useDeleteExecutionResource(), {
-        wrapper: createWrapper(),
-      });
-
-      const deleteElementHandler = registeredHandlers.onNodeElementDelete?.[0];
-      expect(deleteElementHandler).toBeDefined();
-
-      const element = {
-        id: 'input-1',
-        type: 'INPUT',
-        category: 'FIELD',
-      };
-
-      const result = await deleteElementHandler('step-1', element);
-      expect(result).toBe(true);
-    });
-
-    it('should delete execution node when action element with next type is deleted', async () => {
-      const executionNode: Node = {
-        id: 'execution-1',
-        type: 'TASK_EXECUTION',
-        position: {x: 100, y: 0},
-        data: {},
-      };
-
-      mockGetNodes.mockReturnValue([executionNode]);
-
-      renderHook(() => useDeleteExecutionResource(), {
-        wrapper: createWrapper(),
-      });
-
-      const deleteElementHandler = registeredHandlers.onNodeElementDelete?.[0];
-      expect(deleteElementHandler).toBeDefined();
-
-      const element = {
-        id: 'button-1',
-        type: 'ACTION',
-        category: 'ACTION',
-        action: {
-          type: 'NEXT',
-          onSuccess: 'execution-1',
-        },
-      };
-
-      const result = await deleteElementHandler('step-1', element);
-      expect(result).toBe(true);
-      expect(mockSetNodes).toHaveBeenCalled();
-    });
-
-    it('should not delete execution node when action has different type', async () => {
-      mockGetNodes.mockReturnValue([]);
-
-      renderHook(() => useDeleteExecutionResource(), {
-        wrapper: createWrapper(),
-      });
-
-      const deleteElementHandler = registeredHandlers.onNodeElementDelete?.[0];
-
-      const element = {
-        id: 'button-1',
-        type: 'ACTION',
-        category: 'ACTION',
-        action: {
-          type: 'SUBMIT',
-        },
-      };
-
-      const result = await deleteElementHandler('step-1', element);
-      expect(result).toBe(true);
-    });
-  });
-
   describe('deleteExecutionActionNode Handler - Callback Execution', () => {
     it('should execute updateNodeData callback to filter action components', async () => {
       const executionNode: Node = {
@@ -475,107 +380,6 @@ describe('useDeleteExecutionResource', () => {
       await deleteNodeHandler([executionNode]);
 
       expect(mockSetIsOpenResourcePropertiesPanel).toHaveBeenCalledWith(false);
-    });
-  });
-
-  describe('deleteExecutionNode Handler - Callback Execution', () => {
-    it('should execute setNodes callback to filter execution nodes', async () => {
-      const executionNode: Node = {
-        id: 'execution-1',
-        type: 'TASK_EXECUTION',
-        position: {x: 100, y: 0},
-        data: {},
-      };
-
-      const viewNode: Node = {
-        id: 'view-1',
-        type: 'VIEW',
-        position: {x: 0, y: 0},
-        data: {},
-      };
-
-      mockGetNodes.mockReturnValue([viewNode, executionNode]);
-
-      // Capture the callback passed to setNodes
-      let capturedCallback: ((nodes: Node[]) => Node[]) | null = null;
-      mockSetNodes.mockImplementation((callback: (nodes: Node[]) => Node[]) => {
-        capturedCallback = callback;
-      });
-
-      renderHook(() => useDeleteExecutionResource(), {
-        wrapper: createWrapper(),
-      });
-
-      const deleteElementHandler = registeredHandlers.onNodeElementDelete?.[0];
-
-      const element = {
-        id: 'button-1',
-        type: 'ACTION',
-        category: 'ACTION',
-        action: {
-          type: 'NEXT',
-          onSuccess: 'execution-1',
-        },
-      };
-
-      await deleteElementHandler('step-1', element);
-
-      expect(mockSetNodes).toHaveBeenCalled();
-      expect(capturedCallback).not.toBeNull();
-
-      // Execute the callback
-      const result = capturedCallback!([viewNode, executionNode]);
-
-      // Should filter out the execution node with matching id and type
-      expect(result).toHaveLength(1);
-      expect(result[0]).toEqual(viewNode);
-    });
-
-    it('should keep nodes that do not match both id and type', async () => {
-      const executionNode: Node = {
-        id: 'execution-1',
-        type: 'TASK_EXECUTION',
-        position: {x: 100, y: 0},
-        data: {},
-      };
-
-      const otherExecutionNode: Node = {
-        id: 'execution-2',
-        type: 'TASK_EXECUTION',
-        position: {x: 200, y: 0},
-        data: {},
-      };
-
-      mockGetNodes.mockReturnValue([executionNode, otherExecutionNode]);
-
-      let capturedCallback: ((nodes: Node[]) => Node[]) | null = null;
-      mockSetNodes.mockImplementation((callback: (nodes: Node[]) => Node[]) => {
-        capturedCallback = callback;
-      });
-
-      renderHook(() => useDeleteExecutionResource(), {
-        wrapper: createWrapper(),
-      });
-
-      const deleteElementHandler = registeredHandlers.onNodeElementDelete?.[0];
-
-      const element = {
-        id: 'button-1',
-        type: 'ACTION',
-        category: 'ACTION',
-        action: {
-          type: 'NEXT',
-          onSuccess: 'execution-1',
-        },
-      };
-
-      await deleteElementHandler('step-1', element);
-
-      const result = capturedCallback!([executionNode, otherExecutionNode]);
-
-      // Should only filter out execution-1, keep execution-2
-      expect(result).toHaveLength(1);
-      expect(result[0].id).toBe('execution-2');
     });
   });
 });

--- a/frontend/apps/console/src/features/flows/hooks/useDeleteExecutionResource.ts
+++ b/frontend/apps/console/src/features/flows/hooks/useDeleteExecutionResource.ts
@@ -6,8 +6,7 @@ import {useEffect} from 'react';
 import useFlowPlugins from './useFlowPlugins';
 import useUIPanelState from './useUIPanelState';
 import VisualFlowConstants from '../constants/VisualFlowConstants';
-import {ActionTypes} from '../models/actions';
-import {type Element, ElementCategories} from '../models/elements';
+import {type Element} from '../models/elements';
 import {StepTypes} from '../models/steps';
 
 /**
@@ -18,8 +17,8 @@ import {StepTypes} from '../models/steps';
  */
 const useDeleteExecutionResource = (): void => {
   const {setIsOpenResourcePropertiesPanel} = useUIPanelState();
-  const {getEdges, getNodes, updateNodeData, setNodes} = useReactFlow();
-  const {onNodeDelete, onNodeElementDelete} = useFlowPlugins();
+  const {getEdges, getNodes, updateNodeData} = useReactFlow();
+  const {onNodeDelete} = useFlowPlugins();
 
   /**
    * Deletes associated execution components when execution nodes are removed.
@@ -82,29 +81,8 @@ const useDeleteExecutionResource = (): void => {
     return true;
   }
 
-  /**
-   * Deletes the execution node when a execution action is removed.
-   *
-   * @param _stepId - The ID of the step from which the element is being deleted.
-   * @param element - The element being deleted, which is expected to be a execution action.
-   * @returns Returns true if the deletion was successful.
-   */
-  function deleteExecutionNode(_stepId: string, element: Element): boolean {
-    const action = element.action as {type?: string; onSuccess?: string} | undefined;
-
-    if (element.category === ElementCategories.Action && action?.type === ActionTypes.Next) {
-      setNodes((nodes: Node[]) =>
-        nodes?.filter((node: Node) => node.id !== action?.onSuccess || node.type !== StepTypes.Execution),
-      );
-    }
-
-    return true;
-  }
-
   // eslint-disable-next-line react-hooks/exhaustive-deps -- handlers use state-getter pattern (getNodes, getEdges) so they're safe with empty deps
   useEffect(() => onNodeDelete(deleteExecutionActionNode), [onNodeDelete]);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => onNodeElementDelete(deleteExecutionNode), [onNodeElementDelete]);
 };
 
 export default useDeleteExecutionResource;


### PR DESCRIPTION
### Purpose

Deleting a button from the widget toolbar also removed the `TASK_EXECUTION` node named by its `action.onSuccess`, even when the rest of the flow still referenced that node. The OTP widgets point their `RESEND` element at the send-OTP executor, which is also the flow's upstream send step, so deleting the Resend button broke the flow. Any two buttons, or a button and an upstream step, targeting the same execution node hit this.

### Approach

Deleting a button now only deletes the button: the execution-node cleanup in `useDeleteExecutionResource` is removed rather than reference-counted.

The properties panel previously never emitted `onNodeElementDelete`, so it skipped every plugin subscriber and left an orphan confirm-password field behind when a password field was deleted. It now emits the event before removing the element, so the panel and the widget toolbar run the same subscribers.

An execution node left with no inbound reference stays on the canvas, and the backend reachability check reports it at save time. That already matches the panel's behavior, which the issue describes as expected.

### Related Issues
- Fixes #4690

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deletion behavior for non-step flow components by emitting the appropriate deletion event before cleanup.
  * Preserved step deletion behavior without triggering component-level deletion events.
  * Refined execution resource cleanup to respond only to node deletions, preventing unintended element-level handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->