### PR TITLE
Stop the attributes tab from looping renders

### DIFF
--- a/frontend/apps/console/src/features/agents/components/edit-agent/attributes/EditAgentAttributes.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/attributes/EditAgentAttributes.tsx
@@ -74,14 +74,21 @@ export default function EditAgentAttributes({
   // baseline every subsequent watched value is compared against to detect a real edit.
   const baselineRef = useRef(filterAttributes(attributes));
 
+  // Staging re-renders the page, which can recreate onFieldChange. Keying the effect on the
+  // callback would restage and loop, so keep it keyed on the watched values only.
+  const onFieldChangeRef = useRef(onFieldChange);
+  useEffect(() => {
+    onFieldChangeRef.current = onFieldChange;
+  }, [onFieldChange]);
+
   useEffect(() => {
     const filtered = filterAttributes(watchedValues);
     // react-hook-form's useWatch fires again shortly after mount as each dynamically-rendered
     // field registers, even without any user interaction — only propagate once the values
     // actually diverge from the baseline, or the Save/Reset bar would show up unprompted.
     if (areAttributesEqual(filtered, baselineRef.current)) return;
-    onFieldChange('attributes', filtered);
-  }, [watchedValues, onFieldChange]);
+    onFieldChangeRef.current('attributes', filtered);
+  }, [watchedValues]);
 
   if (isLoading) {
     return (

--- a/frontend/apps/console/src/features/agents/components/edit-agent/attributes/__tests__/EditAgentAttributes.test.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/attributes/__tests__/EditAgentAttributes.test.tsx
@@ -4,6 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 import userEvent from '@testing-library/user-event';
 import {render, screen, waitFor} from '@thunderid/test-utils';
+import {useCallback, useState, type JSX} from 'react';
 import {Controller, type Control} from 'react-hook-form';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import type {Agent} from '../../../../models/agent';
@@ -40,6 +41,12 @@ vi.mock('@thunderid/configure-users', () => ({
 vi.mock('@thunderid/hooks', () => ({
   useResolveDisplayName: () => ({resolveDisplayName: (v: string) => v}),
 }));
+
+// Mirrors useMutation: a fresh object every render, so a callback memoized on it churns.
+const freshMutationResult = (): {isError: boolean; reset: () => void} => ({
+  isError: false,
+  reset: () => undefined,
+});
 
 describe('EditAgentAttributes', () => {
   const mockOnFieldChange = vi.fn();
@@ -150,6 +157,44 @@ describe('EditAgentAttributes', () => {
         expect.objectContaining({email: 'new@b.com', count: 5}),
       );
     });
+  });
+
+  it('stages a bounded number of times after an edit when the parent recreates onFieldChange', async () => {
+    // The baseline guard above only covers mount, so past the first real edit staging re-rendered
+    // the page, produced a new onFieldChange, and refired this effect. Capped so a regression
+    // fails instead of hanging the test runner.
+    const CALL_CAP = 25;
+    const staged = vi.fn();
+    const identities = new Set<unknown>();
+
+    function Harness(): JSX.Element {
+      const [editedAgent, setEditedAgent] = useState<Partial<Agent>>({});
+      const mutation = freshMutationResult();
+      const onFieldChange = useCallback(
+        (field: keyof Agent, value: unknown) => {
+          if (mutation.isError) mutation.reset();
+          staged(field, value);
+          if (staged.mock.calls.length > CALL_CAP) return;
+          setEditedAgent((prev) => ({...prev, [field]: value}));
+        },
+        [mutation],
+      );
+
+      identities.add(onFieldChange);
+      return <EditAgentAttributes agent={baseAgent} editedAgent={editedAgent} onFieldChange={onFieldChange} />;
+    }
+
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.type(await screen.findByLabelText('email-input'), 'x');
+
+    await waitFor(() => {
+      expect(staged).toHaveBeenCalled();
+    });
+    // Guards the harness: without churn this test would pass vacuously.
+    expect(identities.size).toBeGreaterThan(1);
+    expect(staged.mock.calls.length).toBeLessThanOrEqual(3);
   });
 
   it('uses editedAgent.attributes over agent.attributes as the starting values', () => {

--- a/frontend/apps/console/src/features/agents/pages/AgentEditPage.tsx
+++ b/frontend/apps/console/src/features/agents/pages/AgentEditPage.tsx
@@ -121,14 +121,18 @@ export default function AgentEditPage(): JSX.Element {
     setActiveTab(newValue);
   };
 
+  // useMutation returns a fresh object every render, so depending on the mutation itself gave
+  // this callback a new identity every render, which looped consumers that stage from an effect.
+  const {isError: isUpdateAgentError, reset: resetUpdateAgent} = updateAgent;
+
   const handleFieldChange = useCallback(
     (field: keyof Agent, value: unknown) => {
-      if (updateAgent.isError) {
-        updateAgent.reset(); // a save error is stale once the form changes
+      if (isUpdateAgentError) {
+        resetUpdateAgent(); // a save error is stale once the form changes
       }
       setEditedAgent((prev) => ({...prev, [field]: value}));
     },
-    [updateAgent],
+    [isUpdateAgentError, resetUpdateAgent],
   );
 
   const handleSave = useCallback(async () => {

--- a/frontend/apps/console/src/features/agents/pages/__tests__/AgentEditPage.test.tsx
+++ b/frontend/apps/console/src/features/agents/pages/__tests__/AgentEditPage.test.tsx
@@ -17,7 +17,10 @@ const {
   mockUseGetAgentTypes,
   mockUseGetAgentType,
   mockUseLocation,
+  stagingCallbackIdentities,
 } = vi.hoisted(() => ({
+  // Every distinct onFieldChange the Attributes tab is handed.
+  stagingCallbackIdentities: new Set<unknown>(),
   mockNavigate: vi.fn(),
   mockRefetch: vi.fn(),
   mockUseGetAgent: vi.fn(),
@@ -73,13 +76,16 @@ vi.mock('../../components/edit-agent/overview/AgentOverview', () => ({
 }));
 
 vi.mock('../../components/edit-agent/attributes/EditAgentAttributes', () => ({
-  default: ({onFieldChange}: {onFieldChange: (field: string, value: unknown) => void}) => (
-    <div data-testid="edit-attributes">
-      <button type="button" onClick={() => onFieldChange('attributes', {department: 'sales'})}>
-        Edit an attribute
-      </button>
-    </div>
-  ),
+  default: ({onFieldChange}: {onFieldChange: (field: string, value: unknown) => void}) => {
+    stagingCallbackIdentities.add(onFieldChange);
+    return (
+      <div data-testid="edit-attributes">
+        <button type="button" onClick={() => onFieldChange('attributes', {department: 'sales'})}>
+          Edit an attribute
+        </button>
+      </div>
+    );
+  },
 }));
 
 vi.mock('../../components/edit-agent/credentials/EditCredentialsSettings', () => ({
@@ -146,6 +152,7 @@ describe('AgentEditPage', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stagingCallbackIdentities.clear();
     mockUseGetAgent.mockReturnValue({
       data: baseAgent,
       isLoading: false,
@@ -153,10 +160,11 @@ describe('AgentEditPage', () => {
       isError: false,
       refetch: mockRefetch,
     });
-    mockUseUpdateAgent.mockReturnValue({
+    // A fresh object per call, like useMutation. A stable stand-in hides identity churn.
+    mockUseUpdateAgent.mockImplementation(() => ({
       mutateAsync: mockMutateAsync,
       isPending: false,
-    });
+    }));
     mockMutateAsync.mockResolvedValue(undefined);
     mockRefetch.mockResolvedValue({});
     mockUseGetAgentTypes.mockReturnValue({
@@ -439,6 +447,18 @@ describe('AgentEditPage', () => {
       });
       expect(mockRefetch).not.toHaveBeenCalled();
       expect(screen.getByText('You have unsaved changes')).toBeInTheDocument();
+    });
+
+    it('hands the Attributes tab one stable onFieldChange across re-renders', async () => {
+      // A new callback per render refired the tab's staging effect after any real edit, until
+      // React stopped committing renders at all.
+      const user = userEvent.setup();
+      render(<AgentEditPage />);
+
+      await user.click(screen.getByRole('tab', {name: 'Attributes'}));
+      await user.click(screen.getByText('Edit an attribute'));
+
+      expect(stagingCallbackIdentities.size).toBe(1);
     });
 
     it('surfaces the resolved save error inline on the unsaved-changes bar', async () => {

--- a/frontend/packages/configure-users/src/components/edit-user/EditUserAttributes.tsx
+++ b/frontend/packages/configure-users/src/components/edit-user/EditUserAttributes.tsx
@@ -5,7 +5,7 @@ import {SettingsCard} from '@thunderid/components';
 import {useResolveDisplayName} from '@thunderid/hooks';
 import type {User} from '@thunderid/types';
 import {Box, CircularProgress, Typography} from '@wso2/oxygen-ui';
-import {useEffect, type JSX} from 'react';
+import {useEffect, useRef, type JSX} from 'react';
 import {useForm, useWatch} from 'react-hook-form';
 import {useTranslation} from 'react-i18next';
 import AttributesSummarySection from './AttributesSummarySection';
@@ -50,9 +50,16 @@ export default function EditUserAttributes({user, editedUser, onFieldChange}: Ed
 
   const watchedValues = useWatch({control});
 
+  // Staging re-renders the page, which can recreate onFieldChange. Keying the effect on the
+  // callback would restage and loop, so keep it keyed on the watched values only.
+  const onFieldChangeRef = useRef(onFieldChange);
   useEffect(() => {
-    onFieldChange('attributes', filterAttributes(watchedValues));
-  }, [watchedValues, onFieldChange]);
+    onFieldChangeRef.current = onFieldChange;
+  }, [onFieldChange]);
+
+  useEffect(() => {
+    onFieldChangeRef.current('attributes', filterAttributes(watchedValues));
+  }, [watchedValues]);
 
   if (isLoading) {
     return (

--- a/frontend/packages/configure-users/src/components/edit-user/__tests__/EditUserAttributes.test.tsx
+++ b/frontend/packages/configure-users/src/components/edit-user/__tests__/EditUserAttributes.test.tsx
@@ -5,6 +5,7 @@
 import {render, screen, userEvent, waitFor} from '@thunderid/test-utils';
 import type {User} from '@thunderid/types';
 import {isEqualIgnoringEmpty} from '@thunderid/utils';
+import {useCallback, useState, type JSX} from 'react';
 import {Controller, type Control} from 'react-hook-form';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import EditUserAttributes from '../EditUserAttributes';
@@ -37,6 +38,12 @@ vi.mock('@/utils/renderSchemaField', () => ({
     </div>
   ),
 }));
+
+// Mirrors useMutation: a fresh object every render, so a callback memoized on it churns.
+const freshMutationResult = (): {isError: boolean; reset: () => void} => ({
+  isError: false,
+  reset: () => undefined,
+});
 
 describe('EditUserAttributes', () => {
   const mockOnFieldChange = vi.fn();
@@ -110,6 +117,43 @@ describe('EditUserAttributes', () => {
     expect(mockOnFieldChange.mock.calls.every(([, value]) => isEqualIgnoringEmpty(value, baseUser.attributes))).toBe(
       true,
     );
+  });
+
+  it('stages a bounded number of times when the parent recreates onFieldChange on every render', async () => {
+    // The loop that wedged the React root and broke navigation: staging re-rendered the page,
+    // which produced a new onFieldChange, which refired this effect. Capped so a regression
+    // fails instead of hanging the test browser.
+    const CALL_CAP = 25;
+    const staged = vi.fn();
+    const identities = new Set<unknown>();
+
+    function Harness(): JSX.Element {
+      const [editedUser, setEditedUser] = useState<Partial<User>>({});
+      const mutation = freshMutationResult();
+      const onFieldChange = useCallback(
+        (field: keyof User, value: unknown) => {
+          if (mutation.isError) mutation.reset();
+          staged(field, value);
+          if (staged.mock.calls.length > CALL_CAP) return;
+          setEditedUser((prev) => ({...prev, [field]: value}));
+        },
+        [mutation],
+      );
+
+      identities.add(onFieldChange);
+      return <EditUserAttributes user={baseUser} editedUser={editedUser} onFieldChange={onFieldChange} />;
+    }
+
+    render(<Harness />);
+
+    await screen.findByTestId('field-email');
+    await waitFor(() => {
+      expect(staged).toHaveBeenCalled();
+    });
+
+    // Guards the harness: without churn this test would pass vacuously.
+    expect(identities.size).toBeGreaterThan(1);
+    expect(staged.mock.calls.length).toBeLessThanOrEqual(3);
   });
 
   it('stages the merged attributes into the shared editedUser state as the user types', async () => {

--- a/frontend/packages/configure-users/src/pages/UserEditPage.tsx
+++ b/frontend/packages/configure-users/src/pages/UserEditPage.tsx
@@ -157,18 +157,19 @@ export default function UserEditPage() {
     setActiveTab(newValue);
   };
 
+  // useMutation returns a fresh object every render, so depending on the mutation itself gave
+  // this callback a new identity every render, which looped consumers that stage from an effect.
+  const {isError: isUpdateUserError, reset: resetUpdateUser} = updateUserMutation;
+
   const handleFieldChange = useCallback(
     (field: keyof User, value: unknown) => {
-      // A save error is stale once the form changes. Only reset when there's actually an error to
-      // clear: unconditionally calling reset() churns the mutation object's identity on every
-      // field change, which recreates this callback and can retrigger consumers that depend on it
-      // (e.g. a child's useEffect), looping indefinitely.
-      if (updateUserMutation.isError) {
-        updateUserMutation.reset();
+      // A save error is stale once the form changes.
+      if (isUpdateUserError) {
+        resetUpdateUser();
       }
       setEditedUser((prev) => ({...prev, [field]: value}));
     },
-    [updateUserMutation],
+    [isUpdateUserError, resetUpdateUser],
   );
 
   const handleSave = useCallback(async () => {

--- a/frontend/packages/configure-users/src/pages/__tests__/UserEditPage.test.tsx
+++ b/frontend/packages/configure-users/src/pages/__tests__/UserEditPage.test.tsx
@@ -8,8 +8,10 @@ import {describe, it, expect, vi, beforeEach} from 'vitest';
 import type {ApiUserType, UserTypeListResponse} from '../../models/users';
 import UserEditPage from '../UserEditPage';
 
-const {mockLoggerError} = vi.hoisted(() => ({
+const {mockLoggerError, stagingCallbackIdentities} = vi.hoisted(() => ({
   mockLoggerError: vi.fn(),
+  // Every distinct onFieldChange the Attributes tab is handed.
+  stagingCallbackIdentities: new Set<unknown>(),
 }));
 
 vi.mock('@thunderid/components', async (importOriginal) => {
@@ -141,22 +143,25 @@ vi.mock('@/components/edit-user/AttributesSummarySection', () => ({
 }));
 
 vi.mock('@/components/edit-user/EditUserAttributes', () => ({
-  default: ({onFieldChange}: {onFieldChange: (field: string, value: unknown) => void}) => (
-    <div data-testid="edit-user-attributes">
-      <button type="button" onClick={() => onFieldChange('attributes', {department: 'sales'})}>
-        Edit an attribute
-      </button>
-      {/* Emits the original saved attributes, so the page treats it as no change. */}
-      <button
-        type="button"
-        onClick={() =>
-          onFieldChange('attributes', {username: 'john_doe', email: 'john@example.com', age: 30, active: true})
-        }
-      >
-        Revert attributes
-      </button>
-    </div>
-  ),
+  default: ({onFieldChange}: {onFieldChange: (field: string, value: unknown) => void}) => {
+    stagingCallbackIdentities.add(onFieldChange);
+    return (
+      <div data-testid="edit-user-attributes">
+        <button type="button" onClick={() => onFieldChange('attributes', {department: 'sales'})}>
+          Edit an attribute
+        </button>
+        {/* Emits the original saved attributes, so the page treats it as no change. */}
+        <button
+          type="button"
+          onClick={() =>
+            onFieldChange('attributes', {username: 'john_doe', email: 'john@example.com', age: 30, active: true})
+          }
+        >
+          Revert attributes
+        </button>
+      </div>
+    );
+  },
 }));
 
 vi.mock('@/components/edit-user/CredentialsTabPanel', () => ({
@@ -222,6 +227,7 @@ describe('UserEditPage', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stagingCallbackIdentities.clear();
     mockNavigate.mockResolvedValue(undefined);
     mockUpdateMutateAsync.mockResolvedValue(mockUserData);
     mockRefetch.mockResolvedValue({});
@@ -245,7 +251,8 @@ describe('UserEditPage', () => {
       isLoading: false,
       error: null,
     });
-    mockUseUpdateUser.mockReturnValue({...defaultUpdateReturn});
+    // A fresh object per call, like useMutation. A stable stand-in hides identity churn.
+    mockUseUpdateUser.mockImplementation(() => ({...defaultUpdateReturn}));
     mockUseDeleteUser.mockReturnValue({...defaultDeleteReturn});
   });
 
@@ -699,6 +706,36 @@ describe('UserEditPage', () => {
         const callArgs = mockUpdateMutateAsync.mock.calls[0][0] as {data: {ouId: string}};
         expect(callArgs.data.ouId).toBe('test-ou');
       });
+    });
+
+    it('hands the Attributes tab one stable onFieldChange across re-renders', async () => {
+      // A new callback per render refired the tab's staging effect until React stopped
+      // committing renders at all, which is what broke navigation.
+      const user = userEvent.setup();
+      render(<UserEditPage />);
+
+      await user.click(screen.getByRole('tab', {name: 'Attributes'}));
+      await user.click(screen.getByText('Edit an attribute'));
+
+      expect(stagingCallbackIdentities.size).toBe(1);
+    });
+
+    it('resets a failed save mutation as soon as another field changes', async () => {
+      const user = userEvent.setup();
+      const mockReset = vi.fn();
+      mockUseUpdateUser.mockImplementation(() => ({
+        ...defaultUpdateReturn,
+        error: new Error('Boom'),
+        isError: true,
+        reset: mockReset,
+      }));
+
+      render(<UserEditPage />);
+
+      await user.click(screen.getByRole('tab', {name: 'Attributes'}));
+      await user.click(screen.getByText('Edit an attribute'));
+
+      expect(mockReset).toHaveBeenCalled();
     });
 
     it('hides the unsaved-changes bar after a successful save', async () => {


### PR DESCRIPTION
### Purpose
The Attributes tab of the user edit page loops renders until React throws `Maximum update depth exceeded`. The React root stops committing, so navigation afterwards only changes the URL.

`useMutation` returns a fresh object on every render, so memoizing `handleFieldChange` on it gave the tab a new callback each render. The tab stages from a `useEffect` that depended on that callback, so staging refired itself.

The agent edit page has the same pair. It is clean on mount thanks to its baseline guard, but loops after any real attribute edit.

### Approach
- Depend on the mutation's `isError` and `reset` instead of the mutation object. `reset` is bound once by the mutation observer and `isError` is a boolean, so both are stable.
- Key the staging effects on the watched form values only, reading the latest callback from a ref.
- Regression tests on both pairs: the page hands out one stable callback across re-renders, and each attributes component stages a bounded number of times under a parent whose callback churns. All were confirmed red first. The `useUpdateUser` / `useUpdateAgent` mocks now return a fresh object per call, since a stable stand-in hid the churn.

Verified in a running console: no `Maximum update depth exceeded`, edits stage, save persists, and navigating away actually changes the view. With the change reverted the same steps reproduce the error.

### Related Issues
- Fixes #4737


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented repeated attribute updates and excessive re-rendering while editing agents and users.
  - Improved editing stability when form callbacks or mutation state refresh.
  - Cleared stale save errors when users edit another field after a failed update.

- **Tests**
  - Added regression coverage for stable editing behavior, bounded updates, and error recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->