### PR TITLE
feat(scim): Default SCIM user creation to sole configured user type, advertise pagination support

### DIFF
--- a/backend/internal/scim/config/config.go
+++ b/backend/internal/scim/config/config.go
@@ -21,6 +21,7 @@ package scimconfig
 
 import (
 	"github.com/thunder-id/thunderid/internal/system/config"
+	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 )
 
@@ -51,7 +52,7 @@ const (
 
 	// FilterMaxResults caps the number of resources returned in a single
 	// filtered query, guarding against excessively large result sets.
-	FilterMaxResults = 200
+	FilterMaxResults = serverconst.MaxPageSize
 
 	// ChangePasswordSupported indicates that the SCIM change-password
 	// operation is not yet supported.
@@ -64,6 +65,27 @@ const (
 	// ETagSupported indicates that ETag / versioning is supported
 	// per RFC 7644 §3.14.
 	ETagSupported = true
+
+	// PaginationCursorSupported indicates whether cursor-based pagination
+	// (RFC 9865) is supported. Not implemented; this server only supports
+	// index-based pagination.
+	PaginationCursorSupported = false
+
+	// PaginationIndexSupported indicates whether index-based pagination
+	// (startIndex/count, RFC 7644 §3.4.2.4) is supported.
+	PaginationIndexSupported = true
+
+	// PaginationDefaultMethod is the pagination method used when a client
+	// does not specify a preference. Must be "cursor" or "index" per RFC 9865.
+	PaginationDefaultMethod = "index"
+
+	// PaginationDefaultPageSize is the default number of resources returned
+	// per page when a client does not specify "count".
+	PaginationDefaultPageSize = serverconst.DefaultPageSize
+
+	// PaginationMaxPageSize is the maximum number of resources returned
+	// per page, regardless of the requested "count".
+	PaginationMaxPageSize = serverconst.MaxPageSize
 )
 
 // SCIMConfig holds the SCIM service configuration resolved from the

--- a/backend/internal/scim/error_constants.go
+++ b/backend/internal/scim/error_constants.go
@@ -492,6 +492,22 @@ var (
 			DefaultValue: "The request does not carry a valid authenticated subject",
 		},
 	}
+	// ErrorUndeclaredCustomSchemaObject is returned when the request body
+	// contains a ThunderID extension object key that is not declared in
+	// "schemas".
+	ErrorUndeclaredCustomSchemaObject = tidcommon.ServiceError{
+		Type: tidcommon.ClientErrorType,
+		Code: "SCIM-1033",
+		Error: tidcommon.I18nMessage{
+			Key:          "error.scim.undeclared_custom_schema_object",
+			DefaultValue: "Undeclared custom schema object",
+		},
+		ErrorDescription: tidcommon.I18nMessage{
+			Key: "error.scim.undeclared_custom_schema_object_description",
+			DefaultValue: "The request body includes a ThunderID extension object whose schema URN " +
+				"is not declared in the schemas array",
+		},
+	}
 )
 
 // newMissingRequiredAttributesError builds a SCIM-1018 (schema validation failed)

--- a/backend/internal/scim/model.go
+++ b/backend/internal/scim/model.go
@@ -52,6 +52,15 @@ type SCIMMeta struct {
 	Version      string `json:"version,omitempty"`
 }
 
+// SCIMPaginationConfig captures pagination capability flags per RFC 9865.
+type SCIMPaginationConfig struct {
+	Cursor                  bool   `json:"cursor"`
+	Index                   bool   `json:"index"`
+	DefaultPaginationMethod string `json:"defaultPaginationMethod,omitempty"`
+	DefaultPageSize         int    `json:"defaultPageSize,omitempty"`
+	MaxPageSize             int    `json:"maxPageSize,omitempty"`
+}
+
 // SCIMServiceProviderConfig is the response body for GET /scim/v2/ServiceProviderConfig.
 type SCIMServiceProviderConfig struct {
 	Schemas               []string                   `json:"schemas"`
@@ -61,6 +70,7 @@ type SCIMServiceProviderConfig struct {
 	ChangePassword        SCIMSupportedFeature       `json:"changePassword"`
 	Sort                  SCIMSupportedFeature       `json:"sort"`
 	ETag                  SCIMSupportedFeature       `json:"etag"`
+	Pagination            SCIMPaginationConfig       `json:"pagination"`
 	AuthenticationSchemes []SCIMAuthenticationScheme `json:"authenticationSchemes"`
 	Meta                  SCIMMeta                   `json:"meta"`
 }

--- a/backend/internal/scim/scim_validator.go
+++ b/backend/internal/scim/scim_validator.go
@@ -21,13 +21,46 @@ type SCIMUserPayload struct {
 
 // ValidateSCIMUserRequest parses and validates a SCIM user payload.
 func ValidateSCIMUserRequest(body []byte) (*SCIMUserPayload, *tidcommon.ServiceError) {
-	// Step 1: Parse the request body as JSON.
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(body, &raw); err != nil {
 		return nil, &ErrorInvalidRequestBody
 	}
 
-	// Step 2: Validate the presence of the "schemas" array and extract URNs.
+	schemas, svcErr := parseSCIMSchemas(raw)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	extensionURN, userTypeName, svcErr := resolveThunderExtensionURN(raw, schemas)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	extAttrs, svcErr := extractExtensionAttrs(raw, extensionURN)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	coreAttrs := extractCoreAttrs(raw, extensionURN)
+	if extensionURN == "" && len(coreAttrs) == 0 {
+		return nil, &ErrorMissingCustomSchema
+	}
+
+	if svcErr := validateCoreUserSchemaDeclared(schemas, coreAttrs); svcErr != nil {
+		return nil, svcErr
+	}
+
+	return &SCIMUserPayload{
+		ExtensionURN:   extensionURN,
+		UserTypeName:   userTypeName,
+		CoreAttrs:      coreAttrs,
+		ExtensionAttrs: extAttrs,
+	}, nil
+}
+
+// parseSCIMSchemas validates the presence of the "schemas" array, unmarshals it,
+// and rejects duplicate URNs within it.
+func parseSCIMSchemas(raw map[string]json.RawMessage) ([]string, *tidcommon.ServiceError) {
 	schemasRaw, ok := raw["schemas"]
 	if !ok {
 		return nil, &ErrorMissingSchemas
@@ -37,7 +70,6 @@ func ValidateSCIMUserRequest(body []byte) (*SCIMUserPayload, *tidcommon.ServiceE
 		return nil, &ErrorMissingSchemas
 	}
 
-	// Step 3: Check for duplicate URNs in the "schemas" array.
 	seen := make(map[string]struct{}, len(schemas))
 	for _, urn := range schemas {
 		lower := strings.ToLower(strings.TrimSpace(urn))
@@ -46,8 +78,18 @@ func ValidateSCIMUserRequest(body []byte) (*SCIMUserPayload, *tidcommon.ServiceE
 		}
 		seen[lower] = struct{}{}
 	}
+	return schemas, nil
+}
 
-	// Step 4: exactly one ThunderID extension URN .
+// resolveThunderExtensionURN finds the single ThunderID extension URN declared in
+// "schemas", if any. At most one is allowed; zero is allowed only when the payload
+// carries SCIM core attributes only (no custom type declared), in which case the
+// service layer falls back to the sole configured user type. When zero URNs are
+// declared, any body key that is itself a ThunderID extension URN is rejected,
+// since SCIM requires extension objects to be declared in "schemas".
+func resolveThunderExtensionURN(
+	raw map[string]json.RawMessage, schemas []string,
+) (extensionURN, userTypeName string, svcErr *tidcommon.ServiceError) {
 	thunderPrefix := strings.ToLower(ThunderIDURNPrefix)
 	var thunderURNs []string
 	for _, urn := range schemas {
@@ -55,23 +97,37 @@ func ValidateSCIMUserRequest(body []byte) (*SCIMUserPayload, *tidcommon.ServiceE
 			thunderURNs = append(thunderURNs, urn)
 		}
 	}
-	if len(thunderURNs) == 0 {
-		return nil, &ErrorMissingCustomSchema
-	}
 	if len(thunderURNs) > 1 {
-		return nil, &ErrorMultipleCustomSchemas
+		return "", "", &ErrorMultipleCustomSchemas
 	}
-	extensionURN := thunderURNs[0]
+	if len(thunderURNs) == 0 {
+		for k := range raw {
+			if strings.HasPrefix(strings.ToLower(strings.TrimSpace(k)), thunderPrefix) {
+				return "", "", &ErrorUndeclaredCustomSchemaObject
+			}
+		}
+		return "", "", nil
+	}
 
-	// step 5: ThunderID URN well-formed
+	extensionURN = thunderURNs[0]
 	userTypeName, ok := parseUserTypeFromSchemaURN(extensionURN)
 	if !ok || strings.TrimSpace(userTypeName) == "" {
-		return nil, &ErrorInvalidCustomSchemaURN
+		return "", "", &ErrorInvalidCustomSchemaURN
+	}
+	return extensionURN, userTypeName, nil
+}
+
+// extractExtensionAttrs pulls the extension object keyed by extensionURN out of the
+// request body. The extension object is optional if no extension attributes are
+// provided; if present, it must be a valid JSON object.
+func extractExtensionAttrs(
+	raw map[string]json.RawMessage, extensionURN string,
+) (map[string]json.RawMessage, *tidcommon.ServiceError) {
+	extAttrs := make(map[string]json.RawMessage)
+	if extensionURN == "" {
+		return extAttrs, nil
 	}
 
-	// Step 6: extension object is optional if no extension attributes are provided.
-	// If present, it must be a valid JSON object.
-	extAttrs := make(map[string]json.RawMessage)
 	var extRaw json.RawMessage
 	for k, v := range raw {
 		if strings.EqualFold(k, extensionURN) {
@@ -79,44 +135,42 @@ func ValidateSCIMUserRequest(body []byte) (*SCIMUserPayload, *tidcommon.ServiceE
 			break
 		}
 	}
-	if extRaw != nil {
-		if err := json.Unmarshal(extRaw, &extAttrs); err != nil || extAttrs == nil {
-			return nil, &ErrorMissingCustomSchemaObject
-		}
+	if extRaw == nil {
+		return extAttrs, nil
 	}
+	if err := json.Unmarshal(extRaw, &extAttrs); err != nil || extAttrs == nil {
+		return nil, &ErrorMissingCustomSchemaObject
+	}
+	return extAttrs, nil
+}
 
-	// Collect core attributes (those that are not "schemas" or the extension URN)
+// extractCoreAttrs collects the top-level request fields that are not "schemas"
+// and not the extension URN object.
+func extractCoreAttrs(raw map[string]json.RawMessage, extensionURN string) map[string]json.RawMessage {
 	coreAttrs := make(map[string]json.RawMessage)
 	for k, v := range raw {
 		if strings.EqualFold(k, "schemas") {
 			continue
 		}
-		if strings.EqualFold(k, extensionURN) {
+		if extensionURN != "" && strings.EqualFold(k, extensionURN) {
 			continue
 		}
 		coreAttrs[k] = v
 	}
+	return coreAttrs
+}
 
-	// Step 7: if the request carries core attributes, the SCIM Core User schema
-	// URN must be declared in "schemas". A custom-type-only payload (no core
-	// attributes at all) does not need to declare it.
-	if len(coreAttrs) > 0 {
-		hasCoreUserSchema := false
-		for _, urn := range schemas {
-			if strings.EqualFold(urn, SCIMCoreUserSchemaURN) {
-				hasCoreUserSchema = true
-				break
-			}
-		}
-		if !hasCoreUserSchema {
-			return nil, &ErrorMissingCoreUserSchema
+// validateCoreUserSchemaDeclared ensures that, when the request carries core
+// attributes, the SCIM Core User schema URN is declared in "schemas". A
+// custom-type-only payload (no core attributes at all) does not need to declare it.
+func validateCoreUserSchemaDeclared(schemas []string, coreAttrs map[string]json.RawMessage) *tidcommon.ServiceError {
+	if len(coreAttrs) == 0 {
+		return nil
+	}
+	for _, urn := range schemas {
+		if strings.EqualFold(urn, SCIMCoreUserSchemaURN) {
+			return nil
 		}
 	}
-
-	return &SCIMUserPayload{
-		ExtensionURN:   extensionURN,
-		UserTypeName:   userTypeName,
-		CoreAttrs:      coreAttrs,
-		ExtensionAttrs: extAttrs,
-	}, nil
+	return &ErrorMissingCoreUserSchema
 }

--- a/backend/internal/scim/scim_validator_test.go
+++ b/backend/internal/scim/scim_validator_test.go
@@ -42,6 +42,13 @@ func TestValidateSCIMUserRequest(t *testing.T) {
 			wantErrCode: ErrorMissingCustomSchema.Code,
 		},
 		{
+			name:         "CoreOnly_NoThunderIDURN_ParsesWithEmptyUserType",
+			body:         []byte(`{"schemas":["` + SCIMCoreUserSchemaURN + `"],"userName":"alice"}`),
+			wantErrCode:  "",
+			wantUserType: "",
+			wantExtURN:   "",
+		},
+		{
 			name: "MultipleThunderIDURNs",
 			body: []byte(`{` +
 				`"schemas":["urn:thunderid:params:scim:schemas:employee:2.0:User",` +
@@ -98,6 +105,12 @@ func TestValidateSCIMUserRequest(t *testing.T) {
 			name:        "CoreAttrsPresent_CoreUserSchemaMissing",
 			body:        []byte(`{"schemas":["` + validURN + `"],"` + validURN + `":{}, "userName":"alice"}`),
 			wantErrCode: ErrorMissingCoreUserSchema.Code,
+		},
+		{
+			name: "UndeclaredThunderIDExtensionKey_NoThunderIDURNInSchemas",
+			body: []byte(`{"schemas":["` + SCIMCoreUserSchemaURN + `"],` +
+				`"` + validURN + `":{"department":"engineering"},"userName":"alice"}`),
+			wantErrCode: ErrorUndeclaredCustomSchemaObject.Code,
 		},
 	}
 

--- a/backend/internal/scim/service.go
+++ b/backend/internal/scim/service.go
@@ -89,27 +89,38 @@ func newSCIMService(
 func computeSCIMConfigVersion(cfg scimconfig.SCIMConfig) string {
 	state := struct {
 		scimconfig.SCIMConfig
-		PatchSupported          bool
-		BulkSupported           bool
-		BulkMaxOperations       int
-		BulkMaxPayloadSize      int
-		FilterSupported         bool
-		FilterMaxResults        int
-		ChangePasswordSupported bool
-		SortSupported           bool
-		ETagSupported           bool
+		PatchSupported            bool
+		BulkSupported             bool
+		BulkMaxOperations         int
+		BulkMaxPayloadSize        int
+		FilterSupported           bool
+		FilterMaxResults          int
+		ChangePasswordSupported   bool
+		SortSupported             bool
+		ETagSupported             bool
+		PaginationCursorSupported bool
+		PaginationIndexSupported  bool
+		PaginationDefaultMethod   string
+		PaginationDefaultPageSize int
+		PaginationMaxPageSize     int
 	}{
-		SCIMConfig:              cfg,
-		PatchSupported:          scimconfig.PatchSupported,
-		BulkSupported:           scimconfig.BulkSupported,
-		BulkMaxOperations:       scimconfig.BulkMaxOperations,
-		BulkMaxPayloadSize:      scimconfig.BulkMaxPayloadSize,
-		FilterSupported:         scimconfig.FilterSupported,
-		FilterMaxResults:        scimconfig.FilterMaxResults,
-		ChangePasswordSupported: scimconfig.ChangePasswordSupported,
-		SortSupported:           scimconfig.SortSupported,
-		ETagSupported:           scimconfig.ETagSupported,
+		SCIMConfig:                cfg,
+		PatchSupported:            scimconfig.PatchSupported,
+		BulkSupported:             scimconfig.BulkSupported,
+		BulkMaxOperations:         scimconfig.BulkMaxOperations,
+		BulkMaxPayloadSize:        scimconfig.BulkMaxPayloadSize,
+		FilterSupported:           scimconfig.FilterSupported,
+		FilterMaxResults:          scimconfig.FilterMaxResults,
+		ChangePasswordSupported:   scimconfig.ChangePasswordSupported,
+		SortSupported:             scimconfig.SortSupported,
+		ETagSupported:             scimconfig.ETagSupported,
+		PaginationCursorSupported: scimconfig.PaginationCursorSupported,
+		PaginationIndexSupported:  scimconfig.PaginationIndexSupported,
+		PaginationDefaultMethod:   scimconfig.PaginationDefaultMethod,
+		PaginationDefaultPageSize: scimconfig.PaginationDefaultPageSize,
+		PaginationMaxPageSize:     scimconfig.PaginationMaxPageSize,
 	}
+
 	b, err := json.Marshal(state)
 	if err != nil {
 		panic(fmt.Sprintf("scim: failed to marshal SCIM config for ETag generation: %v", err))
@@ -151,6 +162,13 @@ func (s *scimService) GetServiceProviderConfig(_ context.Context, baseURL string
 		ChangePassword: SCIMSupportedFeature{Supported: scimconfig.ChangePasswordSupported},
 		Sort:           SCIMSupportedFeature{Supported: scimconfig.SortSupported},
 		ETag:           SCIMSupportedFeature{Supported: scimconfig.ETagSupported},
+		Pagination: SCIMPaginationConfig{
+			Cursor:                  scimconfig.PaginationCursorSupported,
+			Index:                   scimconfig.PaginationIndexSupported,
+			DefaultPaginationMethod: scimconfig.PaginationDefaultMethod,
+			DefaultPageSize:         scimconfig.PaginationDefaultPageSize,
+			MaxPageSize:             scimconfig.PaginationMaxPageSize,
+		},
 		AuthenticationSchemes: []SCIMAuthenticationScheme{
 			{
 				Type:        "oauthbearertoken",
@@ -462,4 +480,25 @@ func resolveEntityTypeNameForSchemaURN(
 			return "", nil
 		}
 	}
+}
+
+// resolveDefaultEntityTypeName returns the sole configured user entity type's
+// canonical name, for SCIM payloads that carry only core attributes and omit
+// the ThunderID extension URN. Errors if zero or more than one user type is
+// configured, since the default type is then ambiguous.
+func resolveDefaultEntityTypeName(
+	ctx context.Context, entityTypeService entitytype.EntityTypeServiceInterface,
+) (string, *tidcommon.ServiceError) {
+	page, svcErr := entityTypeService.GetEntityTypeList(
+		ctx, entitytype.TypeCategoryUser, serverconst.MaxPageSize, 0, false)
+	if svcErr != nil {
+		if svcErr.Type == tidcommon.ServerErrorType {
+			return "", &ErrorInternalServer
+		}
+		return "", &ErrorMissingCustomSchema
+	}
+	if page.TotalResults != 1 || len(page.Types) != 1 {
+		return "", &ErrorMissingCustomSchema
+	}
+	return page.Types[0].Name, nil
 }

--- a/backend/internal/scim/service_test.go
+++ b/backend/internal/scim/service_test.go
@@ -86,6 +86,11 @@ func TestGetServiceProviderConfig_CapabilitiesMatchConstants(t *testing.T) {
 	require.Equal(t, scimconfig.ChangePasswordSupported, result.ChangePassword.Supported)
 	require.Equal(t, scimconfig.SortSupported, result.Sort.Supported)
 	require.Equal(t, scimconfig.ETagSupported, result.ETag.Supported)
+	require.Equal(t, scimconfig.PaginationCursorSupported, result.Pagination.Cursor)
+	require.Equal(t, scimconfig.PaginationIndexSupported, result.Pagination.Index)
+	require.Equal(t, scimconfig.PaginationDefaultMethod, result.Pagination.DefaultPaginationMethod)
+	require.Equal(t, scimconfig.PaginationDefaultPageSize, result.Pagination.DefaultPageSize)
+	require.Equal(t, scimconfig.PaginationMaxPageSize, result.Pagination.MaxPageSize)
 
 	if scimconfig.ETagSupported {
 		require.NotEmpty(t, result.Meta.Version)

--- a/backend/internal/scim/users_service.go
+++ b/backend/internal/scim/users_service.go
@@ -105,11 +105,21 @@ func (s *scimUsersService) CreateUser(
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 
 	runtimeCtx := security.WithRuntimeContext(ctx)
-	canonicalName, svcErr := resolveEntityTypeNameForSchemaURN(runtimeCtx, s.entityTypeService, payload.UserTypeName)
-	if svcErr != nil || canonicalName == "" {
-		logger.Error(ctx, "SCIM CreateUser: entity type not found",
-			log.String("userTypeName", payload.UserTypeName), log.Any("error", svcErr))
-		return nil, &ErrorUnknownUserType
+	var canonicalName string
+	var svcErr *tidcommon.ServiceError
+	if payload.UserTypeName == "" {
+		canonicalName, svcErr = resolveDefaultEntityTypeName(runtimeCtx, s.entityTypeService)
+		if svcErr != nil {
+			logger.Error(ctx, "SCIM CreateUser: no default user type available", log.Any("error", svcErr))
+			return nil, svcErr
+		}
+	} else {
+		canonicalName, svcErr = resolveEntityTypeNameForSchemaURN(runtimeCtx, s.entityTypeService, payload.UserTypeName)
+		if svcErr != nil || canonicalName == "" {
+			logger.Error(ctx, "SCIM CreateUser: entity type not found",
+				log.String("userTypeName", payload.UserTypeName), log.Any("error", svcErr))
+			return nil, &ErrorUnknownUserType
+		}
 	}
 
 	et, svcErr := s.entityTypeService.GetEntityTypeByName(runtimeCtx, entitytype.TypeCategoryUser, canonicalName)
@@ -183,12 +193,6 @@ func (s *scimUsersService) ReplaceUser(
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
 
 	runtimeCtx := security.WithRuntimeContext(ctx)
-	canonicalName, svcErr := resolveEntityTypeNameForSchemaURN(runtimeCtx, s.entityTypeService, payload.UserTypeName)
-	if svcErr != nil || canonicalName == "" {
-		logger.Error(runtimeCtx, "SCIM ReplaceUser: entity type not found",
-			log.String("userTypeName", payload.UserTypeName), log.Any("error", svcErr))
-		return nil, &ErrorUnknownUserType
-	}
 
 	existingUser, svcErr := s.userService.GetUser(ctx, userID, false)
 	if svcErr != nil {
@@ -203,11 +207,23 @@ func (s *scimUsersService) ReplaceUser(
 		}
 	}
 
-	if existingUser.Type != canonicalName {
-		logger.Error(ctx, "SCIM ReplaceUser: user type mismatch",
-			log.String("userID", userID), log.String("existingType", existingUser.Type),
-			log.String("requestedType", canonicalName))
-		return nil, &ErrorImmutableUserType
+	// The user's type is immutable, so an omitted extension URN defaults to the
+	// existing type rather than being treated as ambiguous. A supplied URN must
+	// still match the existing type.
+	canonicalName := existingUser.Type
+	if payload.UserTypeName != "" {
+		resolvedName, svcErr := resolveEntityTypeNameForSchemaURN(runtimeCtx, s.entityTypeService, payload.UserTypeName)
+		if svcErr != nil || resolvedName == "" {
+			logger.Error(runtimeCtx, "SCIM ReplaceUser: entity type not found",
+				log.String("userTypeName", payload.UserTypeName), log.Any("error", svcErr))
+			return nil, &ErrorUnknownUserType
+		}
+		if resolvedName != existingUser.Type {
+			logger.Error(ctx, "SCIM ReplaceUser: user type mismatch",
+				log.String("userID", userID), log.String("existingType", existingUser.Type),
+				log.String("requestedType", resolvedName))
+			return nil, &ErrorImmutableUserType
+		}
 	}
 
 	et, svcErr := s.entityTypeService.GetEntityTypeByName(runtimeCtx, entitytype.TypeCategoryUser, canonicalName)

--- a/backend/internal/scim/users_service_test.go
+++ b/backend/internal/scim/users_service_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 const testUserTypeEmployee = "employee"
+const testOUID = "ou-abc"
 
 func TestGetUser_Success(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
@@ -240,7 +241,7 @@ func makeEntityTypeListPage() *entitytype.EntityTypeListResponse {
 	return &entitytype.EntityTypeListResponse{
 		TotalResults: 1,
 		Types: []entitytype.EntityTypeListItem{
-			{Name: testUserTypeEmployee, OUID: "ou-abc"},
+			{Name: testUserTypeEmployee, OUID: testOUID},
 		},
 	}
 }
@@ -260,7 +261,7 @@ func TestCreateUser_Success(t *testing.T) {
 	createdUser := &user.User{
 		ID:         "user-new",
 		Type:       testUserTypeEmployee,
-		OUID:       "ou-abc",
+		OUID:       testOUID,
 		Attributes: []byte(`{"given_name":"Alice"}`),
 	}
 
@@ -272,10 +273,10 @@ func TestCreateUser_Success(t *testing.T) {
 	// GetEntityTypeByName after resolution
 	mockEntityService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
-	).Return(&entitytype.EntityType{Name: testUserTypeEmployee, OUID: "ou-abc"}, (*tidcommon.ServiceError)(nil))
+	).Return(&entitytype.EntityType{Name: testUserTypeEmployee, OUID: testOUID}, (*tidcommon.ServiceError)(nil))
 
 	mockUserService.On("CreateUser", mock.Anything, mock.MatchedBy(func(u *user.User) bool {
-		return u.Type == testUserTypeEmployee && u.OUID == "ou-abc"
+		return u.Type == testUserTypeEmployee && u.OUID == testOUID
 	})).Return(createdUser, (*tidcommon.ServiceError)(nil))
 	mockEntityService.On(
 		"GetAttributes", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee, true, false, false,
@@ -306,7 +307,7 @@ func TestCreateUser_MissingRequiredAttribute_ReturnsSchemaValidationError(t *tes
 	mockEntityService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return(&entitytype.EntityType{
-		Name: testUserTypeEmployee, OUID: "ou-abc",
+		Name: testUserTypeEmployee, OUID: testOUID,
 		Schema: json.RawMessage(`{"department":{"required":true}}`),
 	}, (*tidcommon.ServiceError)(nil))
 
@@ -338,7 +339,7 @@ func TestCreateUser_UndeclaredAttribute_ReturnsSchemaValidationError(t *testing.
 	mockEntityService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return(&entitytype.EntityType{
-		Name: testUserTypeEmployee, OUID: "ou-abc",
+		Name: testUserTypeEmployee, OUID: testOUID,
 		Schema: json.RawMessage(`{"department":{"required":true}}`),
 	}, (*tidcommon.ServiceError)(nil))
 
@@ -369,7 +370,7 @@ func TestCreateUser_MalformedSchemaJSON_ReturnsInternalServerError(t *testing.T)
 	mockEntityService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return(&entitytype.EntityType{
-		Name: testUserTypeEmployee, OUID: "ou-abc",
+		Name: testUserTypeEmployee, OUID: testOUID,
 		Schema: json.RawMessage(`invalid json`),
 	}, (*tidcommon.ServiceError)(nil))
 
@@ -399,7 +400,7 @@ func TestReplaceUser_MalformedSchemaJSON_ReturnsInternalServerError(t *testing.T
 	mockEntityService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return(&entitytype.EntityType{
-		Name: testUserTypeEmployee, OUID: "ou-abc",
+		Name: testUserTypeEmployee, OUID: testOUID,
 		Schema: json.RawMessage(`invalid json`),
 	}, (*tidcommon.ServiceError)(nil))
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).
@@ -446,7 +447,7 @@ func TestCreateUser_SchemaAttributeErrors(t *testing.T) {
 			mockEntityService.On(
 				"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 			).Return(&entitytype.EntityType{
-				Name: testUserTypeEmployee, OUID: "ou-abc",
+				Name: testUserTypeEmployee, OUID: testOUID,
 				Schema: json.RawMessage(tt.schema),
 			}, (*tidcommon.ServiceError)(nil))
 
@@ -474,7 +475,7 @@ func TestCreateUser_MatchingCoreAndCustomValue_Succeeds(t *testing.T) {
 	createdUser := &user.User{
 		ID:         "user-new",
 		Type:       testUserTypeEmployee,
-		OUID:       "ou-abc",
+		OUID:       testOUID,
 		Attributes: []byte(`{"username":"alice"}`),
 	}
 
@@ -484,11 +485,11 @@ func TestCreateUser_MatchingCoreAndCustomValue_Succeeds(t *testing.T) {
 	mockEntityService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return(&entitytype.EntityType{
-		Name: testUserTypeEmployee, OUID: "ou-abc",
+		Name: testUserTypeEmployee, OUID: testOUID,
 		Schema: json.RawMessage(`{"username":{"type":"string"}}`),
 	}, (*tidcommon.ServiceError)(nil))
 	mockUserService.On("CreateUser", mock.Anything, mock.MatchedBy(func(u *user.User) bool {
-		return u.Type == testUserTypeEmployee && u.OUID == "ou-abc"
+		return u.Type == testUserTypeEmployee && u.OUID == testOUID
 	})).Return(createdUser, (*tidcommon.ServiceError)(nil))
 	mockEntityService.On(
 		"GetAttributes", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee, true, false, false,
@@ -499,6 +500,97 @@ func TestCreateUser_MatchingCoreAndCustomValue_Succeeds(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, scimUser)
 	require.Equal(t, "user-new", scimUser.ID)
+}
+
+func TestCreateUser_CoreOnly_SingleUserType_DefaultsToType(t *testing.T) {
+	mockUserService := usermock.NewUserServiceInterfaceMock(t)
+	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(mockUserService, mockEntityService)
+
+	// No UserTypeName/ExtensionURN: the request carried only core attributes.
+	payload := &SCIMUserPayload{
+		CoreAttrs:      map[string]json.RawMessage{"userName": json.RawMessage(`"alice"`)},
+		ExtensionAttrs: map[string]json.RawMessage{},
+	}
+	createdUser := &user.User{
+		ID:         "user-new",
+		Type:       testUserTypeEmployee,
+		OUID:       testOUID,
+		Attributes: []byte(`{"username":"alice"}`),
+	}
+
+	// resolveDefaultEntityTypeName pages GetEntityTypeList and, finding
+	// exactly one configured user type, defaults to it.
+	mockEntityService.On(
+		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
+	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
+	mockEntityService.On(
+		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
+	).Return(&entitytype.EntityType{
+		Name: testUserTypeEmployee, OUID: testOUID,
+		Schema: json.RawMessage(`{"username":{"type":"string"}}`),
+	}, (*tidcommon.ServiceError)(nil))
+	mockUserService.On("CreateUser", mock.Anything, mock.MatchedBy(func(u *user.User) bool {
+		return u.Type == testUserTypeEmployee && u.OUID == testOUID
+	})).Return(createdUser, (*tidcommon.ServiceError)(nil))
+	mockEntityService.On(
+		"GetAttributes", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee, true, false, false,
+	).Return([]entitytype.AttributeInfo{}, (*tidcommon.ServiceError)(nil))
+
+	scimUser, err := service.CreateUser(context.Background(), payload, testBaseURL)
+
+	require.Nil(t, err)
+	require.NotNil(t, scimUser)
+	require.Equal(t, "user-new", scimUser.ID)
+	require.Contains(t, scimUser.Schemas, "urn:thunderid:params:scim:schemas:employee:2.0:User")
+}
+
+func TestCreateUser_CoreOnly_MultipleUserTypes_ReturnsMissingCustomSchema(t *testing.T) {
+	mockUserService := usermock.NewUserServiceInterfaceMock(t)
+	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(mockUserService, mockEntityService)
+
+	payload := &SCIMUserPayload{
+		CoreAttrs: map[string]json.RawMessage{"userName": json.RawMessage(`"alice"`)},
+	}
+
+	// Two configured user types: which one to default to is ambiguous.
+	mockEntityService.On(
+		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
+	).Return(&entitytype.EntityTypeListResponse{
+		TotalResults: 2,
+		Types: []entitytype.EntityTypeListItem{
+			{Name: testUserTypeEmployee, OUID: testOUID},
+			{Name: "person", OUID: "ou-def"},
+		},
+	}, (*tidcommon.ServiceError)(nil))
+
+	scimUser, err := service.CreateUser(context.Background(), payload, testBaseURL)
+
+	require.NotNil(t, err)
+	require.Equal(t, ErrorMissingCustomSchema.Code, err.Code)
+	require.Nil(t, scimUser)
+}
+
+func TestCreateUser_CoreOnly_ZeroUserTypes_ReturnsMissingCustomSchema(t *testing.T) {
+	mockUserService := usermock.NewUserServiceInterfaceMock(t)
+	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(mockUserService, mockEntityService)
+
+	payload := &SCIMUserPayload{
+		CoreAttrs: map[string]json.RawMessage{"userName": json.RawMessage(`"alice"`)},
+	}
+
+	mockEntityService.On(
+		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
+	).Return(&entitytype.EntityTypeListResponse{TotalResults: 0, Types: []entitytype.EntityTypeListItem{}},
+		(*tidcommon.ServiceError)(nil))
+
+	scimUser, err := service.CreateUser(context.Background(), payload, testBaseURL)
+
+	require.NotNil(t, err)
+	require.Equal(t, ErrorMissingCustomSchema.Code, err.Code)
+	require.Nil(t, scimUser)
 }
 
 func TestCreateUser_EntityTypeNotFound_ReturnsUnknownUserType(t *testing.T) {
@@ -605,7 +697,7 @@ func TestCreateUser_Error_Scenarios(t *testing.T) {
 			).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
 			mockEntityService.On(
 				"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
-			).Return(&entitytype.EntityType{Name: testUserTypeEmployee, OUID: "ou-abc"}, (*tidcommon.ServiceError)(nil))
+			).Return(&entitytype.EntityType{Name: testUserTypeEmployee, OUID: testOUID}, (*tidcommon.ServiceError)(nil))
 			mockUserService.On("CreateUser", mock.Anything, mock.Anything).
 				Return((*user.User)(nil), tc.mockError)
 
@@ -633,7 +725,7 @@ func TestReplaceUser_Success(t *testing.T) {
 	updatedUser := &user.User{
 		ID:         "user-123",
 		Type:       testUserTypeEmployee,
-		OUID:       "ou-abc",
+		OUID:       testOUID,
 		Attributes: []byte(`{"given_name":"Charlie"}`),
 	}
 
@@ -642,7 +734,7 @@ func TestReplaceUser_Success(t *testing.T) {
 	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
 	mockEntityService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
-	).Return(&entitytype.EntityType{Name: testUserTypeEmployee, OUID: "ou-abc"}, (*tidcommon.ServiceError)(nil))
+	).Return(&entitytype.EntityType{Name: testUserTypeEmployee, OUID: testOUID}, (*tidcommon.ServiceError)(nil))
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).
 		Return(&user.User{ID: "user-123", Type: testUserTypeEmployee}, (*tidcommon.ServiceError)(nil))
 	mockUserService.On("UpdateUser", mock.Anything, "user-123", mock.MatchedBy(func(u *user.User) bool {
@@ -658,6 +750,43 @@ func TestReplaceUser_Success(t *testing.T) {
 	require.NotNil(t, scimUser)
 	require.Equal(t, "user-123", scimUser.ID)
 	require.Contains(t, scimUser.Schemas, "urn:thunderid:params:scim:schemas:employee:2.0:User")
+}
+
+func TestReplaceUser_CoreOnly_NoExtensionURN_DefaultsToExistingType(t *testing.T) {
+	mockUserService := usermock.NewUserServiceInterfaceMock(t)
+	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(mockUserService, mockEntityService)
+
+	// The user's type is immutable, so an omitted extension URN resolves to
+	// the existing user's type instead of requiring the client to echo it.
+	payload := &SCIMUserPayload{
+		CoreAttrs:      map[string]json.RawMessage{"userName": json.RawMessage(`"alice"`)},
+		ExtensionAttrs: map[string]json.RawMessage{},
+	}
+	updatedUser := &user.User{
+		ID:         "user-123",
+		Type:       testUserTypeEmployee,
+		OUID:       testOUID,
+		Attributes: []byte(`{}`),
+	}
+
+	mockEntityService.On(
+		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
+	).Return(&entitytype.EntityType{Name: testUserTypeEmployee, OUID: testOUID}, (*tidcommon.ServiceError)(nil))
+	mockUserService.On("GetUser", mock.Anything, "user-123", false).
+		Return(&user.User{ID: "user-123", Type: testUserTypeEmployee}, (*tidcommon.ServiceError)(nil))
+	mockUserService.On("UpdateUser", mock.Anything, "user-123", mock.MatchedBy(func(u *user.User) bool {
+		return u.ID == "user-123" && u.Type == testUserTypeEmployee
+	})).Return(updatedUser, (*tidcommon.ServiceError)(nil))
+	mockEntityService.On(
+		"GetAttributes", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee, true, false, false,
+	).Return([]entitytype.AttributeInfo{}, (*tidcommon.ServiceError)(nil))
+
+	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL)
+
+	require.Nil(t, err)
+	require.NotNil(t, scimUser)
+	require.Equal(t, "user-123", scimUser.ID)
 }
 
 func TestReplaceUser_MissingRequiredAttribute_ReturnsSchemaValidationError(t *testing.T) {
@@ -677,7 +806,7 @@ func TestReplaceUser_MissingRequiredAttribute_ReturnsSchemaValidationError(t *te
 	mockEntityService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return(&entitytype.EntityType{
-		Name: testUserTypeEmployee, OUID: "ou-abc",
+		Name: testUserTypeEmployee, OUID: testOUID,
 		Schema: json.RawMessage(`{"department":{"required":true}}`),
 	}, (*tidcommon.ServiceError)(nil))
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).
@@ -711,7 +840,7 @@ func TestReplaceUser_UndeclaredAttribute_ReturnsSchemaValidationError(t *testing
 	mockEntityService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return(&entitytype.EntityType{
-		Name: testUserTypeEmployee, OUID: "ou-abc",
+		Name: testUserTypeEmployee, OUID: testOUID,
 		Schema: json.RawMessage(`{"department":{"required":true}}`),
 	}, (*tidcommon.ServiceError)(nil))
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).
@@ -743,7 +872,7 @@ func TestReplaceUser_ConflictingCoreAndCustomValue_ReturnsConflictError(t *testi
 	mockEntityService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return(&entitytype.EntityType{
-		Name: testUserTypeEmployee, OUID: "ou-abc",
+		Name: testUserTypeEmployee, OUID: testOUID,
 		Schema: json.RawMessage(`{"username":{"type":"string"}}`),
 	}, (*tidcommon.ServiceError)(nil))
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).
@@ -771,6 +900,8 @@ func TestReplaceUser_EntityTypeNotFound_ReturnsUnknownUserType(t *testing.T) {
 		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 	).Return(&entitytype.EntityTypeListResponse{TotalResults: 0, Types: []entitytype.EntityTypeListItem{}},
 		(*tidcommon.ServiceError)(nil))
+	mockUserService.On("GetUser", mock.Anything, "user-123", false).
+		Return(&user.User{ID: "user-123", Type: testUserTypeEmployee}, (*tidcommon.ServiceError)(nil))
 
 	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL)
 
@@ -818,18 +949,17 @@ func TestReplaceUser_Error_Scenarios(t *testing.T) {
 				ExtensionAttrs: map[string]json.RawMessage{},
 			}
 
-			mockEntityService.On(
-				"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
-			).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
-
 			if tc.name == "UserNotFound_Returns404" {
 				mockUserService.On("GetUser", mock.Anything, tc.userID, false).
 					Return((*user.User)(nil), tc.mockError)
 			} else {
 				mockEntityService.On(
+					"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
+				).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
+				mockEntityService.On(
 					"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 				).Return(&entitytype.EntityType{
-					Name: testUserTypeEmployee, OUID: "ou-abc",
+					Name: testUserTypeEmployee, OUID: testOUID,
 				}, (*tidcommon.ServiceError)(nil))
 				mockUserService.On("GetUser", mock.Anything, tc.userID, false).
 					Return(&user.User{ID: tc.userID, Type: testUserTypeEmployee}, (*tidcommon.ServiceError)(nil))
@@ -864,7 +994,7 @@ func TestReplaceUser_IfMatch_Match(t *testing.T) {
 	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
 	mockEntityService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
-	).Return(&entitytype.EntityType{Name: testUserTypeEmployee, OUID: "ou-abc"}, (*tidcommon.ServiceError)(nil))
+	).Return(&entitytype.EntityType{Name: testUserTypeEmployee, OUID: testOUID}, (*tidcommon.ServiceError)(nil))
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).
 		Return(existingUser, (*tidcommon.ServiceError)(nil))
 	mockUserService.On("UpdateUser", mock.Anything, "user-123", mock.Anything).
@@ -891,9 +1021,6 @@ func TestReplaceUser_IfMatch_Mismatch(t *testing.T) {
 		ExtensionAttrs: map[string]json.RawMessage{},
 	}
 
-	mockEntityService.On(
-		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
-	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).
 		Return(&user.User{ID: "user-123", Type: testUserTypeEmployee, Attributes: []byte(`{"given_name":"Bob"}`)},
 			(*tidcommon.ServiceError)(nil))
@@ -1017,7 +1144,7 @@ func TestCreateUser_MarshalExtensionAttrsError(t *testing.T) {
 
 	mockEntityService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
-	).Return(&entitytype.EntityType{Name: testUserTypeEmployee, OUID: "ou-abc"}, (*tidcommon.ServiceError)(nil))
+	).Return(&entitytype.EntityType{Name: testUserTypeEmployee, OUID: testOUID}, (*tidcommon.ServiceError)(nil))
 
 	scimUser, err := service.CreateUser(context.Background(), payload, testBaseURL)
 
@@ -1045,7 +1172,7 @@ func TestReplaceUser_MarshalExtensionAttrsError(t *testing.T) {
 
 	mockEntityService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
-	).Return(&entitytype.EntityType{Name: testUserTypeEmployee, OUID: "ou-abc"}, (*tidcommon.ServiceError)(nil))
+	).Return(&entitytype.EntityType{Name: testUserTypeEmployee, OUID: testOUID}, (*tidcommon.ServiceError)(nil))
 
 	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL)
 

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -1064,6 +1064,8 @@ var defaultMessages = map[string]string{
 	"error.scim.sort_not_supported_description": "Sorting via sortBy or sortOrder is not supported in this implementation",
 	"error.scim.unauthenticated": "Unauthenticated",
 	"error.scim.unauthenticated_description": "The request does not carry a valid authenticated subject",
+	"error.scim.undeclared_custom_schema_object": "Undeclared custom schema object",
+	"error.scim.undeclared_custom_schema_object_description": "The request body includes a ThunderID extension object whose schema URN is not declared in the schemas array",
 	"error.scim.uniqueness_conflict": "Uniqueness conflict",
 	"error.scim.uniqueness_conflict_description": "A user with the same unique attribute value already exists",
 	"error.scim.unknown_user_type": "Unknown user type",


### PR DESCRIPTION
### Purpose
POST /Users required the ThunderID extension schema URN even when the request only carried core SCIM attributes, forcing clients to know a custom type URN just to create a user. This PR lets CreateUser omit the extension URN and fall back to the sole configured user type. It also advertises RFC 9865 pagination capabilities on GET /ServiceProviderConfig, which was previously missing from the response.

### Approach
- `scim_validator.go`: relaxed validation so zero ThunderID extension URNs is allowed, but only when the payload carries core attributes (empty payloads still rejected via `ErrorMissingCustomSchema`). More than one extension URN remains rejected as before.
- `service.go`: added `resolveDefaultEntityTypeName`, which looks up configured user entity types and returns the sole one's canonical name. Errors with `ErrorMissingCustomSchema` if zero or more than one type is configured (default would be ambiguous).
- `users_service.go`: `CreateUser` now calls `resolveDefaultEntityTypeName` when `UserTypeName` is empty, instead of failing. `ReplaceUser` (and `/Me` PUT) keep the extension URN mandatory, no fallback on update, since an update should be explicit about which type it targets.
- `config.go` / `model.go`: added `PaginationCursorSupported` (false), `PaginationIndexSupported` (true), default method/page size constants, and the `SCIMPaginationConfig` response struct, wired into `GetServiceProviderConfig`.
- Added unit tests for core-only create with single/multiple/zero configured types, and for replace still rejecting a missing extension URN.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided.
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
