### PR TITLE
Fix broken link in CSP docs

### DIFF
--- a/docs/content/guides/users/user-type-reference.mdx
+++ b/docs/content/guides/users/user-type-reference.mdx
@@ -55,5 +55,5 @@ An admin-managed user type. Self-registration is disabled and only an administra
 | `password` | `string` | credential | Never returned in responses |
 
 :::note
-The `picture` attribute stores a URL. When a user's picture is hosted on an external origin, allow that origin in the Content Security Policy `img-src` directive. Otherwise the browser blocks the image where the Console displays it. See [Content Security Policy](../../deployment/configuration#content-security-policy).
+The `picture` attribute stores a URL. When a user's picture is hosted on an external origin, allow that origin in the Content Security Policy `img-src` directive. Otherwise the browser blocks the image where the Console displays it. See [Content Security Policy](../../../deployment/configuration#content-security-policy).
 :::

--- a/docs/versioned_docs/version-v1.0.x/guides/users/user-type-reference.mdx
+++ b/docs/versioned_docs/version-v1.0.x/guides/users/user-type-reference.mdx
@@ -56,5 +56,5 @@ An admin-managed user type. Self-registration is disabled and only an administra
 | `password` | `string` | credential | Never returned in responses |
 
 :::note
-The `picture` attribute stores a URL. When a user's picture is hosted on an external origin, allow that origin in the Content Security Policy `img-src` directive. Otherwise the browser blocks the image where the Console displays it. See [Content Security Policy](../../deployment/configuration#content-security-policy).
+The `picture` attribute stores a URL. When a user's picture is hosted on an external origin, allow that origin in the Content Security Policy `img-src` directive. Otherwise the browser blocks the image where the Console displays it. See [Content Security Policy](../../../deployment/configuration#content-security-policy).
 :::


### PR DESCRIPTION
### Purpose
The docs build fails with "Docusaurus found broken links" on the CSP note added to the user type reference page. The note linked to ../../deployment/configuration#content-security-policy, which resolves incorrectly because Docusaurus resolves relative links against the page URL, not the source file path. From guides/users/user-type-reference/, two ../ only reaches guides/, resolving to the nonexistent guides/deployment/configuration.



### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the Content Security Policy documentation link for the `picture` attribute.
  - Updated the link consistently in both current and versioned user guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->