### PR TITLE
Fix groups listing pagination

### DIFF
--- a/frontend/packages/configure-groups/src/api/__tests__/useGetGroups.test.ts
+++ b/frontend/packages/configure-groups/src/api/__tests__/useGetGroups.test.ts
@@ -90,4 +90,61 @@ describe('useGetGroups', () => {
       expect(result.current.error?.message).toBe('Network error');
     });
   });
+
+  it('should keep the previous page data while fetching a new page', async () => {
+    const nextPageData: GroupListResponse = {
+      totalResults: 2,
+      startIndex: 11,
+      count: 2,
+      groups: [
+        {id: 'g3', name: 'Group Three', ouId: 'ou1'},
+        {id: 'g4', name: 'Group Four', ouId: 'ou2'},
+      ],
+    };
+    let resolveNextPage: ((value: {data: GroupListResponse}) => void) | undefined;
+    mockHttpRequest.mockImplementation((request: {url: string}) => {
+      if (request.url.includes('offset=0')) {
+        return Promise.resolve({data: mockGroupsData});
+      }
+
+      if (request.url.includes('offset=10')) {
+        return new Promise((resolve) => {
+          resolveNextPage = resolve;
+        });
+      }
+
+      throw new Error(`Unexpected groups request: ${request.url}`);
+    });
+
+    const {result, rerender} = renderHook(({offset}: {offset: number}) => useGetGroups({limit: 10, offset}), {
+      initialProps: {offset: 0},
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockGroupsData);
+    });
+
+    rerender({offset: 10});
+
+    expect(result.current.data).toEqual(mockGroupsData);
+    expect(result.current.isFetching).toBe(true);
+    await waitFor(() => {
+      expect(mockHttpRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://localhost:8090/groups?limit=10&offset=10&include=display',
+        }),
+      );
+      expect(resolveNextPage).toBeDefined();
+    });
+
+    if (!resolveNextPage) {
+      throw new Error('The next-page request was not captured');
+    }
+    resolveNextPage({data: nextPageData});
+
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false);
+      expect(result.current.data).toEqual(nextPageData);
+    });
+  });
 });

--- a/frontend/packages/configure-groups/src/api/useGetGroups.ts
+++ b/frontend/packages/configure-groups/src/api/useGetGroups.ts
@@ -1,7 +1,7 @@
 // Copyright 2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import {useQuery, type UseQueryResult} from '@tanstack/react-query';
+import {keepPreviousData, useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import {useThunderID} from '@thunderid/react';
 import GroupQueryKeys from '../constants/group-query-keys';
@@ -21,6 +21,7 @@ export default function useGetGroups(params?: GroupListParams): UseQueryResult<G
 
   return useQuery<GroupListResponse>({
     queryKey: [GroupQueryKeys.GROUPS, {limit, offset}],
+    placeholderData: keepPreviousData,
     queryFn: async (): Promise<GroupListResponse> => {
       const serverUrl: string = getServerUrl();
       const queryParams: URLSearchParams = new URLSearchParams({

--- a/frontend/packages/configure-resource-servers/src/api/__tests__/useGetResourceServers.test.tsx
+++ b/frontend/packages/configure-resource-servers/src/api/__tests__/useGetResourceServers.test.tsx
@@ -1,0 +1,122 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {waitFor} from '@testing-library/react';
+import {renderHook} from '@thunderid/test-utils';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import type {ResourceServerListResponse} from '../../models/resource-server';
+import useGetResourceServers from '../useGetResourceServers';
+
+const mockHttpRequest = vi.fn();
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({http: {request: mockHttpRequest}}),
+}));
+
+const mockGetServerUrl = vi.fn<() => string>(() => 'https://localhost:8090');
+vi.mock('@thunderid/contexts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunderid/contexts')>();
+  return {
+    ...actual,
+    useConfig: () => ({getServerUrl: mockGetServerUrl}),
+  };
+});
+
+describe('useGetResourceServers', () => {
+  const firstPageData: ResourceServerListResponse = {
+    totalResults: 12,
+    startIndex: 0,
+    count: 10,
+    resourceServers: [
+      {id: 'rs-1', name: 'API One', identifier: 'https://api.one', ouId: 'ou-1', delimiter: ':', type: 'API'},
+      {id: 'rs-2', name: 'API Two', identifier: 'https://api.two', ouId: 'ou-1', delimiter: ':', type: 'API'},
+      ...Array.from({length: 8}, (_, index) => ({
+        id: `rs-${index + 3}`,
+        name: `API ${index + 3}`,
+        identifier: `https://api.${index + 3}`,
+        ouId: 'ou-1',
+        delimiter: ':',
+        type: 'API' as const,
+      })),
+    ],
+  };
+
+  beforeEach(() => {
+    mockHttpRequest.mockReset();
+    mockGetServerUrl.mockReturnValue('https://localhost:8090');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should keep previous page data while fetching the next page', async () => {
+    const nextPageData: ResourceServerListResponse = {
+      totalResults: 12,
+      startIndex: 10,
+      count: 2,
+      resourceServers: [
+        {
+          id: 'rs-11',
+          name: 'API Eleven',
+          identifier: 'https://api.eleven',
+          ouId: 'ou-1',
+          delimiter: ':',
+          type: 'API',
+        },
+        {
+          id: 'rs-12',
+          name: 'API Twelve',
+          identifier: 'https://api.twelve',
+          ouId: 'ou-1',
+          delimiter: ':',
+          type: 'API',
+        },
+      ],
+    };
+    let resolveNextPage: ((value: {data: ResourceServerListResponse}) => void) | undefined;
+    mockHttpRequest.mockImplementation((request: {url: string}): unknown => {
+      if (request.url.includes('offset=0')) {
+        return Promise.resolve({data: firstPageData});
+      }
+
+      if (request.url.includes('offset=10')) {
+        return new Promise((resolve) => {
+          resolveNextPage = resolve;
+        });
+      }
+
+      throw new Error(`Unexpected resource-server request: ${request.url}`);
+    });
+
+    const {result, rerender} = renderHook(({offset}: {offset: number}) => useGetResourceServers({limit: 10, offset}), {
+      initialProps: {offset: 0},
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(firstPageData);
+    });
+
+    rerender({offset: 10});
+
+    expect(result.current.data).toEqual(firstPageData);
+    expect(result.current.isFetching).toBe(true);
+    await waitFor(() => {
+      expect(mockHttpRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://localhost:8090/resource-servers?limit=10&offset=10',
+        }),
+      );
+      expect(resolveNextPage).toBeDefined();
+    });
+
+    if (!resolveNextPage) {
+      throw new Error('The next-page request was not captured');
+    }
+    resolveNextPage({data: nextPageData});
+
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false);
+      expect(result.current.data).toEqual(nextPageData);
+    });
+  });
+});

--- a/frontend/packages/configure-resource-servers/src/api/useGetResourceServers.ts
+++ b/frontend/packages/configure-resource-servers/src/api/useGetResourceServers.ts
@@ -1,7 +1,7 @@
 // Copyright 2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import {useQuery, type UseQueryResult} from '@tanstack/react-query';
+import {keepPreviousData, useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import {useThunderID} from '@thunderid/react';
 import ResourceServerQueryKeys from '../constants/resource-server-query-keys';
@@ -17,6 +17,7 @@ export default function useGetResourceServers(params?: {
 
   return useQuery<ResourceServerListResponse>({
     queryKey: [ResourceServerQueryKeys.RESOURCE_SERVERS, {limit, offset}],
+    placeholderData: keepPreviousData,
     queryFn: async (): Promise<ResourceServerListResponse> => {
       const serverUrl = getServerUrl();
       const queryParams = new URLSearchParams({

--- a/frontend/packages/configure-roles/src/api/__tests__/useGetRoles.test.tsx
+++ b/frontend/packages/configure-roles/src/api/__tests__/useGetRoles.test.tsx
@@ -28,9 +28,9 @@ describe('useGetRoles', () => {
   let mockGetServerUrl: ReturnType<typeof vi.fn>;
 
   const mockRoleListResponse: RoleListResponse = {
-    totalResults: 2,
+    totalResults: 12,
     startIndex: 0,
-    count: 2,
+    count: 10,
     roles: [
       {
         id: 'role-1',
@@ -44,6 +44,11 @@ describe('useGetRoles', () => {
         description: 'Read-only role',
         ouId: 'ou-2',
       },
+      ...Array.from({length: 8}, (_, index) => ({
+        id: `role-${index + 3}`,
+        name: `Role ${index + 3}`,
+        ouId: 'ou-1',
+      })),
     ],
   };
 
@@ -92,9 +97,9 @@ describe('useGetRoles', () => {
     });
 
     expect(result.current.data).toEqual(mockRoleListResponse);
-    expect(result.current.data?.roles).toHaveLength(2);
-    expect(result.current.data?.totalResults).toBe(2);
-    expect(result.current.data?.count).toBe(2);
+    expect(result.current.data?.roles).toHaveLength(10);
+    expect(result.current.data?.totalResults).toBe(12);
+    expect(result.current.data?.count).toBe(10);
   });
 
   it('should use default pagination parameters (limit=30, offset=0)', async () => {
@@ -331,5 +336,62 @@ describe('useGetRoles', () => {
     await result.current.refetch();
 
     expect(mockHttpRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('should keep previous page data while fetching the next page', async () => {
+    const nextPageData: RoleListResponse = {
+      totalResults: 12,
+      startIndex: 10,
+      count: 2,
+      roles: [
+        {id: 'role-11', name: 'Editor Role', ouId: 'ou-1'},
+        {id: 'role-12', name: 'Auditor Role', ouId: 'ou-2'},
+      ],
+    };
+    let resolveNextPage: ((value: {data: RoleListResponse}) => void) | undefined;
+    mockHttpRequest.mockImplementation((request: {url: string}): unknown => {
+      if (request.url.includes('offset=0')) {
+        return Promise.resolve({data: mockRoleListResponse});
+      }
+
+      if (request.url.includes('offset=10')) {
+        return new Promise((resolve) => {
+          resolveNextPage = resolve;
+        });
+      }
+
+      throw new Error(`Unexpected roles request: ${request.url}`);
+    });
+
+    const {result, rerender} = renderHook(({offset}: {offset: number}) => useGetRoles({limit: 10, offset}), {
+      initialProps: {offset: 0},
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockRoleListResponse);
+    });
+
+    rerender({offset: 10});
+
+    expect(result.current.data).toEqual(mockRoleListResponse);
+    expect(result.current.isFetching).toBe(true);
+    await waitFor(() => {
+      expect(mockHttpRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://api.test.com/roles?limit=10&offset=10&include=display',
+        }),
+      );
+      expect(resolveNextPage).toBeDefined();
+    });
+
+    if (!resolveNextPage) {
+      throw new Error('The next-page request was not captured');
+    }
+    resolveNextPage({data: nextPageData});
+
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false);
+      expect(result.current.data).toEqual(nextPageData);
+    });
   });
 });

--- a/frontend/packages/configure-roles/src/api/useGetRoles.ts
+++ b/frontend/packages/configure-roles/src/api/useGetRoles.ts
@@ -1,7 +1,7 @@
 // Copyright 2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import {useQuery, type UseQueryResult} from '@tanstack/react-query';
+import {keepPreviousData, useQuery, type UseQueryResult} from '@tanstack/react-query';
 import {useConfig} from '@thunderid/contexts';
 import {useThunderID} from '@thunderid/react';
 import RoleQueryKeys from '../constants/role-query-keys';
@@ -21,6 +21,7 @@ export default function useGetRoles(params?: RoleListParams): UseQueryResult<Rol
 
   return useQuery<RoleListResponse>({
     queryKey: [RoleQueryKeys.ROLES, {limit, offset}],
+    placeholderData: keepPreviousData,
     queryFn: async (): Promise<RoleListResponse> => {
       const serverUrl: string = getServerUrl();
       const queryParams: URLSearchParams = new URLSearchParams({


### PR DESCRIPTION
### Purpose
Fixes https://github.com/thunder-id/thunderid/issues/4767

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
The Groups, Roles, and Resource Servers listings use server-side pagination. When the page changes, the new query temporarily had no data, causing the DataGrid row count to become zero and reset the page to the first page.

This change uses `keepPreviousData` behavior for all three list queries. The previous page remains available while the next page loads, so the DataGrid keeps its pagination state and requests the correct offset on the first click.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4767

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination for groups, resource servers, and roles by keeping the current results visible while the next page loads.
  * Added loading-state feedback during page changes for a smoother browsing experience.
  * Updated results automatically once the requested page finishes loading.
  * Improved consistency of pagination behavior across configuration screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->