### PR TITLE
Fix incorrect GitHub connection scopes hint

### DIFF
--- a/frontend/packages/configure-connections/src/components/__tests__/ConnectionForm.test.tsx
+++ b/frontend/packages/configure-connections/src/components/__tests__/ConnectionForm.test.tsx
@@ -106,6 +106,17 @@ describe('ConnectionForm', () => {
     expect(screen.getByText(/Space-separated scopes to request during sign-in\. Defaults to/)).toBeInTheDocument();
   });
 
+  it('shows the GitHub scopes default instead of the OIDC scopes default', () => {
+    render(<ConnectionForm {...baseProps} type="github" mode="edit" hasStoredSecret vendorDisplayName="GitHub" />);
+
+    expect(getConnectionField('scopes')).toHaveAttribute('placeholder', 'user:email');
+    const helperText = document.getElementById('connection-field-scopes-helper-text');
+    expect(helperText).toHaveTextContent(
+      'Space-separated scopes to request during sign-in. Defaults to user:email if not set.',
+    );
+    expect(helperText).not.toHaveTextContent('openid email profile');
+  });
+
   describe('OIDC create', () => {
     const oidcCreateProps = {
       ...baseProps,

--- a/frontend/packages/configure-connections/src/config/connectionFormFields.ts
+++ b/frontend/packages/configure-connections/src/config/connectionFormFields.ts
@@ -70,7 +70,12 @@ const PROMPT_FIELD: ConnectionFieldDef = {
   visibility: 'edit',
 };
 
-const oauthFields = (namePlaceholder: string, clientIdPlaceholder: string): ConnectionFieldDef[] => [
+const oauthFields = (
+  namePlaceholder: string,
+  clientIdPlaceholder: string,
+  scopesHintKey = 'connections:form.fields.scopes.hint',
+  scopesPlaceholder = 'openid email profile',
+): ConnectionFieldDef[] => [
   NAME_FIELD(namePlaceholder),
   {
     name: 'clientId',
@@ -96,9 +101,9 @@ const oauthFields = (namePlaceholder: string, clientIdPlaceholder: string): Conn
   {
     name: 'scopes',
     labelKey: 'connections:form.fields.scopes.label',
-    hintKey: 'connections:form.fields.scopes.hint',
+    hintKey: scopesHintKey,
     kind: 'scopes',
-    placeholder: 'openid email profile',
+    placeholder: scopesPlaceholder,
     visibility: 'edit',
   },
   PROMPT_FIELD,
@@ -129,7 +134,12 @@ const TRUSTED_TOKEN_AUDIENCE_FIELD: ConnectionFieldDef = {
  */
 export const CONNECTION_FORM_FIELDS: Record<ConnectionType, ConnectionFieldDef[]> = {
   [ConnectionTypes.GOOGLE]: oauthFields('Google Workspace', '1234567890-abc.apps.googleusercontent.com'),
-  [ConnectionTypes.GITHUB]: oauthFields('GitHub OAuth', 'Iv1.0123456789abcdef'),
+  [ConnectionTypes.GITHUB]: oauthFields(
+    'GitHub OAuth',
+    'Iv1.0123456789abcdef',
+    'connections:form.fields.scopes.githubHint',
+    'user:email',
+  ),
   [ConnectionTypes.OIDC]: [
     NAME_FIELD('Acme Workforce OIDC'),
     {

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1892,6 +1892,8 @@ const translations = {
     'form.fields.scopes.label': 'Scopes',
     'form.fields.scopes.hint':
       'Space-separated scopes to request during sign-in. Defaults to <code>openid email profile</code> if not set.',
+    'form.fields.scopes.githubHint':
+      'Space-separated scopes to request during sign-in. Defaults to <code>user:email</code> if not set.',
     'form.fields.scopes.placeholder': 'openid email profile',
     'form.fields.authorizationEndpoint.label': 'Authorization endpoint',
     'form.fields.authorizationEndpoint.hint': 'Authorization endpoint used to start the OAuth2 sign-in flow.',


### PR DESCRIPTION
### Purpose

Fixes #4736.

The GitHub connection form said empty scopes default to `openid email profile`, while the backend actually applies `user:email`. This made the edit hint incorrect for GitHub connections.

### Approach

- Give the GitHub scopes field a provider-specific hint and `user:email` placeholder.
- Keep the existing OIDC and Google guidance unchanged.
- Add a browser component regression that checks the rendered helper text and placeholder.

### Related Issues
- Fixes #4736

### Related PRs
- N/A

### Validation

- Node 24.15.0 and pnpm 11.21.0
- `@thunderid/configure-connections`: 28 test files, 299 tests
- Scoped ESLint: 0 errors (5 existing warnings in untouched i18n API files)
- Scoped typecheck
- Prettier on all three changed files
- `git diff --check`

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR does not commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated GitHub OAuth configuration guidance with the correct `user:email` scopes placeholder and helper text.
  - Preserved existing default scope guidance for other OAuth providers.

- **Tests**
  - Added coverage verifying the GitHub-specific scopes guidance appears correctly in edit mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
