### PR TITLE
Fix declarative resource server actions listed as server level actions

### DIFF
--- a/backend/internal/resource/file_based_store.go
+++ b/backend/internal/resource/file_based_store.go
@@ -448,6 +448,13 @@ func (f *fileBasedResourceStore) GetActionList(
 
 	actions := []providers.Action{}
 
+	// A nil resID selects resource server level actions (actions not attached to any resource),
+	// mirroring the RESOURCE_ID IS NULL semantics of the database store. Declarative resource
+	// servers declare actions only under resources, so there are never any at the server level.
+	if resID == nil {
+		return actions, nil
+	}
+
 	// Iterate through all resource servers
 	for _, item := range list {
 		if rs, ok := item.Data.(*providers.ResourceServer); ok {
@@ -460,8 +467,8 @@ func (f *fileBasedResourceStore) GetActionList(
 			for _, res := range rs.Resources {
 				resUUID := fmt.Sprintf("%s_%s", rs.ID, res.Handle)
 
-				// If resID is specified, only get actions from that resource
-				if resID != nil && resUUID != *resID {
+				// Only get actions from the requested resource
+				if resUUID != *resID {
 					continue
 				}
 

--- a/backend/internal/resource/file_based_store_test.go
+++ b/backend/internal/resource/file_based_store_test.go
@@ -381,19 +381,33 @@ func (s *FileBasedResourceStoreTestSuite) TestGetActionListAndCounts_WithData() 
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), rootActionID, action.ID)
 
+	childID := fmt.Sprintf("%s_%s", rs.ID, rs.Resources[1].Handle)
+
+	// A nil resource ID selects resource server level actions, of which there are none because
+	// declarative resource servers declare actions only under resources.
 	actions, err := s.store.GetActionList(s.ctx, "rs-data", nil, "", 10, 0)
 	assert.NoError(s.T(), err)
-	assert.Len(s.T(), actions, 2)
+	assert.Empty(s.T(), actions)
 
 	actions, err = s.store.GetActionList(s.ctx, "rs-data", &rootID, "", 10, 0)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), actions, 1)
+	assert.Equal(s.T(), "read", actions[0].Handle)
+
+	actions, err = s.store.GetActionList(s.ctx, "rs-data", &childID, "", 10, 0)
+	assert.NoError(s.T(), err)
+	assert.Len(s.T(), actions, 1)
+	assert.Equal(s.T(), "write", actions[0].Handle)
 
 	count, err := s.store.GetActionListCount(s.ctx, "rs-data", nil, "")
 	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), 2, count)
+	assert.Equal(s.T(), 0, count)
 
 	count, err = s.store.GetActionListCount(s.ctx, "rs-data", &rootID, "")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), 1, count)
+
+	count, err = s.store.GetActionListCount(s.ctx, "rs-data", &childID, "")
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), 1, count)
 }
@@ -422,35 +436,37 @@ func (s *FileBasedResourceStoreTestSuite) TestGetActionList_FilterByKind() {
 	err := fileStore.Create("rs-mcp", rs)
 	assert.NoError(s.T(), err)
 
+	rootID := fmt.Sprintf("%s_%s", rs.ID, rs.Resources[0].Handle)
+
 	// Empty kind returns all actions.
-	all, err := s.store.GetActionList(s.ctx, "rs-mcp", nil, "", 10, 0)
+	all, err := s.store.GetActionList(s.ctx, "rs-mcp", &rootID, "", 10, 0)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), all, 2)
 
 	// Tool kind returns only the tool action.
-	tools, err := s.store.GetActionList(s.ctx, "rs-mcp", nil, providers.ActionKindTool, 10, 0)
+	tools, err := s.store.GetActionList(s.ctx, "rs-mcp", &rootID, providers.ActionKindTool, 10, 0)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), tools, 1)
 	assert.Equal(s.T(), "create_user", tools[0].Handle)
 	assert.Equal(s.T(), providers.ActionKindTool, tools[0].Kind)
 
 	// Resource kind returns only the resource action.
-	resources, err := s.store.GetActionList(s.ctx, "rs-mcp", nil, providers.ActionKindResource, 10, 0)
+	resources, err := s.store.GetActionList(s.ctx, "rs-mcp", &rootID, providers.ActionKindResource, 10, 0)
 	assert.NoError(s.T(), err)
 	assert.Len(s.T(), resources, 1)
 	assert.Equal(s.T(), "user_list", resources[0].Handle)
 	assert.Equal(s.T(), providers.ActionKindResource, resources[0].Kind)
 
 	// The count honors the kind filter and matches the filtered list length.
-	allCount, err := s.store.GetActionListCount(s.ctx, "rs-mcp", nil, "")
+	allCount, err := s.store.GetActionListCount(s.ctx, "rs-mcp", &rootID, "")
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), len(all), allCount)
 
-	toolCount, err := s.store.GetActionListCount(s.ctx, "rs-mcp", nil, providers.ActionKindTool)
+	toolCount, err := s.store.GetActionListCount(s.ctx, "rs-mcp", &rootID, providers.ActionKindTool)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), len(tools), toolCount)
 
-	resourceCount, err := s.store.GetActionListCount(s.ctx, "rs-mcp", nil, providers.ActionKindResource)
+	resourceCount, err := s.store.GetActionListCount(s.ctx, "rs-mcp", &rootID, providers.ActionKindResource)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), len(resources), resourceCount)
 }


### PR DESCRIPTION
### Purpose

Fixes the console's Resource Hierarchy listing every action of a declaratively imported resource server as a first-class (resource server level) action, in addition to showing it correctly under its own resource.

Reproduced with the Wayfinder sample: `wayfinder-booking-rs` nests 8 actions under two resources (`Booking`: read, create, cancel, recommend, upgrade; `Upgrade`: read, search, process), and the console rendered all 8 at the root as well as the `Booking` and `Upgrade` subtrees below them.

### Approach

A nil `resID` on the action store API means "actions not attached to any resource". The database store implements this as `RESOURCE_ID IS NULL`, but `fileBasedResourceStore.GetActionList` treated nil as "no filter" and returned the union of every resource's actions. The console builds its root level from two independent calls, `GET /resource-servers/{id}/resources` and `GET /resource-servers/{id}/actions` (nil `resID`), so the second call duplicated the whole action set at the root. Only declaratively imported resource servers were affected, since those are the ones served by the file store.

The file store now returns an empty list for a nil `resID`, matching the database store's semantics. This is correct for every declarative resource server, because `providers.ResourceServer` has no top-level `actions` field, only `Resources`, so a declarative server can never define a server level action. `GetActionListCount` delegates to `GetActionList`, so counts follow automatically.

Two existing file store tests had encoded the old behaviour by passing nil to fetch a resource's actions. They now pass the resource ID, and assert that the server level is empty.

### Related Issues
- Fixes https://github.com/thunder-id/thunderid/issues/4773

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected action-list results for resource-level queries.
  * Root-level requests now return only applicable actions, while resource-specific requests return actions associated with that resource.
  * Updated action counts and filtering behavior for more accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->