### PR TITLE
Add missing completion screens to email self-invite flow template

### DIFF
--- a/frontend/apps/console/src/features/flows/data/templates.json
+++ b/frontend/apps/console/src/features/flows/data/templates.json
@@ -10845,7 +10845,7 @@
               }
             ]
           },
-          "onSuccess": "invite_verify",
+          "onSuccess": "invite_sent",
           "layout": {
             "size": {
               "width": 200,
@@ -10856,6 +10856,37 @@
               "y": 835
             }
           }
+        },
+        {
+          "id": "invite_sent",
+          "type": "PROMPT",
+          "meta": {
+            "components": [
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "invite_sent_icon",
+                "label": "✅",
+                "variant": "HEADING_1"
+              },
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "invite_sent_heading",
+                "label": "{{ t(onboarding:forms.invite_email_sent.title) }}",
+                "variant": "HEADING_1"
+              },
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "invite_sent_message",
+                "label": "{{ t(onboarding:forms.invite_email_sent.message) }}",
+                "variant": "HEADING_6"
+              }
+            ]
+          },
+          "message": "Invitation sent",
+          "next": "invite_verify"
         },
         {
           "id": "invite_verify",
@@ -11055,7 +11086,7 @@
           "executor": {
             "name": "ProvisioningExecutor"
           },
-          "onSuccess": "end",
+          "onSuccess": "registration_complete",
           "layout": {
             "size": {
               "width": 200,
@@ -11067,6 +11098,36 @@
             }
           },
           "onIncomplete": "prompt_schema_attrs"
+        },
+        {
+          "id": "registration_complete",
+          "type": "PROMPT",
+          "meta": {
+            "components": [
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "registration_complete_icon",
+                "label": "✅",
+                "variant": "HEADING_1"
+              },
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "registration_complete_heading",
+                "label": "{{ t(invite:complete.title) }}",
+                "variant": "HEADING_1"
+              },
+              {
+                "align": "center",
+                "type": "TEXT",
+                "id": "registration_complete_message",
+                "label": "{{ t(invite:complete.description) }}"
+              }
+            ]
+          },
+          "message": "Registration complete",
+          "next": "end"
         },
         {
           "id": "prompt_schema_attrs",


### PR DESCRIPTION
### Purpose
Fixes email-based self-invite sign-up . Two bugs, both from the same
root cause: the `EMAIL_SELF_INVITE` starter flow template is missing display
screens that its `SMS_SELF_INVITE` counterpart already has.

1. After submitting the email, the UI showed a hard "Sign up failed" error
   even though the invite email was actually sent successfully.
2. After completing the invite-link data-collection form, the account was
   created successfully but the UI stayed frozen on the same form instead
   of showing a completion screen.

### Approach
In `frontend/apps/console/src/features/flows/data/templates.json`,
`EMAIL_SELF_INVITE` template:

- `send_registration_email.onSuccess` pointed straight at `invite_verify`,
  which pauses waiting for an `inviteToken` the browser can't supply yet
  (that only arrives later via the invite link). With no display node in
  between, the frontend received an empty-component paused response and
  rendered it as an error. Added an `invite_sent` display-only node
  ("Invitation Sent") between them.
- `provisioning.onSuccess` pointed straight at `end`, with no completion
  screen. Added a `registration_complete` display-only node
  ("Welcome Aboard!") between them, matching `SMS_SELF_INVITE`'s existing
  `registration_complete` node.


### Related Issues
- Fixes #3988

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided.
- [ ] Tests provided.
- [ ] Breaking changes.

### Security checks
- [x] Followed secure coding standards.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an invitation-sent confirmation prompt before invite verification.
  * Added a registration-complete confirmation prompt after provisioning.
  * Improved the self-invite registration flow with clearer progress and completion messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->