### PR TITLE
Sanitize export template variable names

### DIFF
--- a/backend/internal/system/export/parameterizer.go
+++ b/backend/internal/system/export/parameterizer.go
@@ -640,15 +640,17 @@ func (p *parameterizer) propertyToYAMLNode(propValue reflect.Value, resourceName
 // generatePropertyVarName generates a context-aware variable name for a property
 // e.g., "Export Test IDP" + "client_id" -> "EXPORT_TEST_IDP_CLIENT_ID"
 func (p *parameterizer) generatePropertyVarName(resourceName, propertyName string) string {
-	// Convert resource name: replace spaces with underscores and convert to snake_case
-	resourcePrefix := strings.ReplaceAll(resourceName, " ", "_")
-	resourcePrefix = p.toSnakeCase(resourcePrefix)
-
 	// Convert property name to snake_case
 	propName := p.toSnakeCase(propertyName)
 
 	// Combine them
-	return resourcePrefix + "_" + propName
+	return p.sanitizeVarName(p.VarPrefix(resourceName) + "_" + propName)
+}
+
+// VarPrefix returns the variable name prefix derived from a resource name, e.g. "My App" ->
+// "MY_APP". Callers use it to detect resource names that normalize to the same prefix.
+func (p *parameterizer) VarPrefix(resourceName string) string {
+	return p.sanitizeVarName(p.toSnakeCase(strings.ReplaceAll(resourceName, " ", "_")))
 }
 
 // handleInterfaceValue handles interface{} types by JSON-encoding them.
@@ -1146,15 +1148,43 @@ func (p *parameterizer) pathToVariableName(appName, path string) string {
 	parts := strings.Split(path, ".")
 	lastPart := parts[len(parts)-1]
 
-	// Convert appName: replace spaces with underscores, convert camelCase to snake_case, then uppercase
-	appPrefix := strings.ReplaceAll(appName, " ", "_")
-	appPrefix = p.toSnakeCase(appPrefix)
-
 	// Convert field name from camelCase/PascalCase to snake_case
 	fieldName := p.toSnakeCase(lastPart)
 
 	// Prepend app prefix to field name
-	return appPrefix + "_" + fieldName
+	return p.sanitizeVarName(p.VarPrefix(appName) + "_" + fieldName)
+}
+
+// sanitizeVarName replaces characters that are not valid in a Go template field name (for
+// example the hyphen in "MY-APP") with underscores, collapsing consecutive underscores, so that
+// the exported placeholders can be parsed again on import. A leading digit is also prefixed
+// with an underscore.
+// Trailing underscores are trimmed so that a prefix keyed by varNameAllocator matches the name
+// that ends up in the placeholder: "MY_APP" and "MY_APP_" are distinct prefixes but both would
+// render as MY_APP_CLIENT_ID once joined with a property name. A leading underscore is kept,
+// since that is the escape for a name starting with a digit.
+func (p *parameterizer) sanitizeVarName(name string) string {
+	var result strings.Builder
+	lastWasUnderscore := false
+	for _, r := range name {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			result.WriteRune(r)
+			lastWasUnderscore = false
+		default:
+			if !lastWasUnderscore {
+				result.WriteRune('_')
+				lastWasUnderscore = true
+			}
+		}
+	}
+
+	sanitized := strings.TrimRight(result.String(), "_")
+	if sanitized != "" && sanitized[0] >= '0' && sanitized[0] <= '9' {
+		return "_" + sanitized
+	}
+
+	return sanitized
 }
 
 // toSnakeCase converts camelCase/PascalCase to UPPER_SNAKE_CASE

--- a/backend/internal/system/export/parameterizer_test.go
+++ b/backend/internal/system/export/parameterizer_test.go
@@ -274,12 +274,60 @@ func TestPathToVariableName(t *testing.T) {
 		{"TestApp", "ALLCAPS", "TEST_APP_ALLCAPS"},
 		{"My App", "ClientID", "MY_APP_CLIENT_ID"},
 		{"My Test App", "RedirectURI", "MY_TEST_APP_REDIRECT_URI"},
+		{"Wayfinder-Concierge", "ClientID", "WAYFINDER_CONCIERGE_CLIENT_ID"},
+		{"My.App+1", "ClientID", "MY_APP_1_CLIENT_ID"},
+		{"2FA App", "ClientID", "_2FA_APP_CLIENT_ID"},
+		{"My App-", "ClientID", "MY_APP_CLIENT_ID"},
+		{"My App ", "ClientID", "MY_APP_CLIENT_ID"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.appName+"_"+tt.path, func(t *testing.T) {
 			result := parameterizer.pathToVariableName(tt.appName, tt.path)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGeneratePropertyVarName(t *testing.T) {
+	parameterizer := newParameterizer(templatingRules{})
+
+	tests := []struct {
+		resourceName string
+		propertyName string
+		expected     string
+	}{
+		{"Google IDP", "client_id", "GOOGLE_IDP_CLIENT_ID"},
+		{"Google-IDP", "client_id", "GOOGLE_IDP_CLIENT_ID"},
+		{"Google IDP", "client-id", "GOOGLE_IDP_CLIENT_ID"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.resourceName+"_"+tt.propertyName, func(t *testing.T) {
+			result := parameterizer.generatePropertyVarName(tt.resourceName, tt.propertyName)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestVarPrefixMatchesGeneratedVarName asserts the invariant varNameAllocator relies on: the
+// prefix it keys resources by is exactly the prefix of the generated variable name. A resource
+// name ending in a separator used to produce a different prefix ("MY_APP_") from the name it
+// rendered as ("MY_APP_CLIENT_ID"), letting two resources share one variable.
+func TestVarPrefixMatchesGeneratedVarName(t *testing.T) {
+	parameterizer := newParameterizer(templatingRules{})
+
+	names := []string{
+		"My App", "My App-", "My App.", "My App ", "My App!",
+		"2FA App", "Wayfinder-Concierge-", "My.App+1",
+	}
+
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, parameterizer.VarPrefix(name)+"_CLIENT_ID",
+				parameterizer.pathToVariableName(name, "ClientID"))
+			assert.Equal(t, parameterizer.VarPrefix(name)+"_CLIENT_ID",
+				parameterizer.generatePropertyVarName(name, "client_id"))
 		})
 	}
 }

--- a/backend/internal/system/export/service.go
+++ b/backend/internal/system/export/service.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -49,6 +50,34 @@ type parameterizerInterface interface {
 	ToParameterizedYAML(ctx context.Context, obj interface{},
 		resourceType string, resourceName string,
 		rules *declarativeresource.ResourceRules) (string, map[string]string, error)
+	VarPrefix(resourceName string) string
+}
+
+// varNameAllocator hands out a unique template variable prefix per exported resource. Resource
+// names that normalize to the same prefix (for example "My-App", "My App" and "My_App", or an
+// application and a connection sharing a name) would otherwise share .env entries and silently
+// overwrite each other's values.
+type varNameAllocator struct {
+	parameterizer parameterizerInterface
+	taken         map[string]struct{}
+}
+
+func newVarNameAllocator(param parameterizerInterface) *varNameAllocator {
+	return &varNameAllocator{parameterizer: param, taken: make(map[string]struct{})}
+}
+
+// nameFor claims a variable prefix for the given resource name and returns the name to use for
+// variable naming, numerically suffixed when the prefix is already claimed by another resource.
+func (a *varNameAllocator) nameFor(resourceName string) string {
+	candidate := resourceName
+	for i := 2; ; i++ {
+		prefix := a.parameterizer.VarPrefix(candidate)
+		if _, claimed := a.taken[prefix]; !claimed {
+			a.taken[prefix] = struct{}{}
+			return candidate
+		}
+		candidate = resourceName + "_" + strconv.Itoa(i)
+	}
 }
 
 // ExportServiceInterface defines the interface for the export service.
@@ -104,6 +133,7 @@ func (es *exportService) ExportResources(
 	var exportErrors []declarativeresource.ExportError
 	allVariables := make(map[string]string)
 	resourceCounts := make(map[string]int)
+	varNames := newVarNameAllocator(es.parameterizer)
 
 	// Map resource types to their IDs from the request
 	resourceMap := map[string][]string{
@@ -144,7 +174,7 @@ func (es *exportService) ExportResources(
 			continue
 		}
 
-		files, vars, errors := es.exportResourcesWithExporter(ctx, exporter, resourceIDs, options)
+		files, vars, errors := es.exportResourcesWithExporter(ctx, exporter, resourceIDs, options, varNames)
 		exportFiles = append(exportFiles, files...)
 		for k, v := range vars {
 			allVariables[k] = v
@@ -239,6 +269,7 @@ func (es *exportService) exportResourcesWithExporter(
 	exporter declarativeresource.ResourceExporter,
 	resourceIDs []string,
 	options *ExportOptions,
+	varNames *varNameAllocator,
 ) ([]ExportFile, map[string]string, []declarativeresource.ExportError) {
 	logger := log.GetLogger().With(log.String("component", "ExportService"))
 	resourceType := exporter.GetResourceType()
@@ -294,7 +325,7 @@ func (es *exportService) exportResourcesWithExporter(
 		}
 
 		templateContent, vars, err := es.generateTemplateFromStruct(ctx,
-			resource, exporter.GetParameterizerType(), validatedName, exporter)
+			resource, exporter.GetParameterizerType(), varNames.nameFor(validatedName), exporter)
 		if err != nil {
 			logger.Warn(ctx, "Failed to generate template from struct",
 				log.String("resourceType", resourceType),

--- a/backend/internal/system/export/service_test.go
+++ b/backend/internal/system/export/service_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"text/template"
 
 	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
@@ -32,6 +33,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -100,6 +102,12 @@ func (suite *ExportServiceTestSuite) SetupTest() {
 
 func (suite *ExportServiceTestSuite) TearDownTest() {
 	config.ResetServerRuntime()
+}
+
+// varNames returns a variable name allocator for tests that call
+// exportResourcesWithExporter directly instead of going through ExportResources.
+func (suite *ExportServiceTestSuite) varNames() *varNameAllocator {
+	return newVarNameAllocator(suite.exportService.(*exportService).parameterizer)
 }
 
 // TestExportServiceTestSuite runs the test suite.
@@ -272,6 +280,98 @@ func (suite *ExportServiceTestSuite) TestExportResources_CompleteOAuthApplicatio
 
 	assert.Equal(suite.T(), 1, result.Summary.ResourceTypes["application"])
 	assert.Equal(suite.T(), int64(len(file.Content)), file.Size)
+}
+
+// TestExportResources_HyphenatedApplicationName tests that a resource name containing a hyphen
+// produces template variables that Go's text/template can parse and that are present in the
+// generated .env file.
+func (suite *ExportServiceTestSuite) TestExportResources_HyphenatedApplicationName() {
+	appID := "hyphen-app-id"
+	request := &ExportRequest{
+		Applications: []string{appID},
+		Options: &ExportOptions{
+			Format: "yaml",
+		},
+	}
+
+	mockApp := &providers.Application{
+		ID:   appID,
+		Name: "Wayfinder-Concierge",
+		InboundAuthConfig: []providers.InboundAuthConfigWithSecret{
+			{
+				Type: providers.OAuthInboundAuthType,
+				OAuthConfig: &providers.OAuthConfigWithSecret{
+					ClientID:     "client123",
+					RedirectURIs: []string{"http://localhost:3000/callback"},
+				},
+			},
+		},
+	}
+
+	suite.appServiceMock.EXPECT().GetApplication(mock.Anything, appID).Return(mockApp, nil)
+
+	result, err := suite.exportService.ExportResources(context.Background(), request)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	assert.Len(suite.T(), result.Files, 1)
+
+	file := result.Files[0]
+	assert.Contains(suite.T(), file.Content, "clientId: {{.WAYFINDER_CONCIERGE_CLIENT_ID}}")
+	assert.NotContains(suite.T(), file.Content, "WAYFINDER-CONCIERGE")
+	assert.NotNil(suite.T(), result.EnvFile)
+	assert.Contains(suite.T(), result.EnvFile.Content, "WAYFINDER_CONCIERGE_CLIENT_ID=client123\n")
+
+	_, parseErr := template.New("export").Parse(file.Content)
+	assert.NoError(suite.T(), parseErr)
+}
+
+// TestExportResources_CollidingNormalizedNames tests that resource names normalizing to the same
+// variable prefix get distinct template variables and .env entries. The third name ends with a
+// separator, which normalizes to the same prefix as the first two.
+func (suite *ExportServiceTestSuite) TestExportResources_CollidingNormalizedNames() {
+	request := &ExportRequest{
+		Applications: []string{testApp1ID, testApp2ID, testApp3ID},
+		Options: &ExportOptions{
+			Format: "yaml",
+		},
+	}
+
+	newApp := func(id, name, clientID string) *providers.Application {
+		return &providers.Application{
+			ID:   id,
+			Name: name,
+			InboundAuthConfig: []providers.InboundAuthConfigWithSecret{
+				{
+					Type: providers.OAuthInboundAuthType,
+					OAuthConfig: &providers.OAuthConfigWithSecret{
+						ClientID: clientID,
+					},
+				},
+			},
+		}
+	}
+
+	suite.appServiceMock.EXPECT().GetApplication(mock.Anything, testApp1ID).
+		Return(newApp(testApp1ID, "Wayfinder-Concierge", "client-one"), nil)
+	suite.appServiceMock.EXPECT().GetApplication(mock.Anything, testApp2ID).
+		Return(newApp(testApp2ID, "Wayfinder_Concierge", "client-two"), nil)
+	suite.appServiceMock.EXPECT().GetApplication(mock.Anything, testApp3ID).
+		Return(newApp(testApp3ID, "Wayfinder Concierge-", "client-three"), nil)
+
+	result, err := suite.exportService.ExportResources(context.Background(), request)
+
+	assert.Nil(suite.T(), err)
+	require.NotNil(suite.T(), result)
+	assert.Len(suite.T(), result.Files, 3)
+
+	assert.Contains(suite.T(), result.Files[0].Content, "clientId: {{.WAYFINDER_CONCIERGE_CLIENT_ID}}")
+	assert.Contains(suite.T(), result.Files[1].Content, "clientId: {{.WAYFINDER_CONCIERGE_2_CLIENT_ID}}")
+	assert.Contains(suite.T(), result.Files[2].Content, "clientId: {{.WAYFINDER_CONCIERGE_3_CLIENT_ID}}")
+	require.NotNil(suite.T(), result.EnvFile)
+	assert.Contains(suite.T(), result.EnvFile.Content, "WAYFINDER_CONCIERGE_CLIENT_ID=client-one\n")
+	assert.Contains(suite.T(), result.EnvFile.Content, "WAYFINDER_CONCIERGE_2_CLIENT_ID=client-two\n")
+	assert.Contains(suite.T(), result.EnvFile.Content, "WAYFINDER_CONCIERGE_3_CLIENT_ID=client-three\n")
 }
 
 // TestExportResources_MultipleApplications tests exporting multiple applications.
@@ -1137,6 +1237,10 @@ func (m *MockParameterizer) ToParameterizedYAML(_ context.Context, obj interface
 	return "id: test\nname: test\n", nil, nil
 }
 
+func (m *MockParameterizer) VarPrefix(resourceName string) string {
+	return newParameterizer(templatingRules{}).VarPrefix(resourceName)
+}
+
 // TestExportResources_TemplateGenerationError tests the error path in generateTemplateFromStruct.
 func (suite *ExportServiceTestSuite) TestExportResources_TemplateGenerationError() {
 	request := &ExportRequest{
@@ -1850,7 +1954,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_Success() {
 	}
 
 	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{appID}, options)
+		exporter, []string{appID}, options, suite.varNames())
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -1893,7 +1997,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_MultipleRes
 	options := &ExportOptions{Format: formatYAML}
 
 	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{app1ID, app2ID, app3ID}, options)
+		exporter, []string{app1ID, app2ID, app3ID}, options, suite.varNames())
 
 	assert.Len(suite.T(), files, 3)
 	assert.Len(suite.T(), errors, 0)
@@ -1917,7 +2021,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_ResourceNot
 	options := &ExportOptions{Format: formatYAML}
 
 	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{appID}, options)
+		exporter, []string{appID}, options, suite.varNames())
 
 	assert.Len(suite.T(), files, 0)
 	assert.Len(suite.T(), errors, 1)
@@ -1951,7 +2055,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_PartialSucc
 	options := &ExportOptions{Format: formatYAML}
 
 	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{validAppID, invalidAppID}, options)
+		exporter, []string{validAppID, invalidAppID}, options, suite.varNames())
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 1)
@@ -1992,7 +2096,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardSuc
 	options := &ExportOptions{Format: formatYAML}
 
 	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{"*"}, options)
+		exporter, []string{"*"}, options, suite.varNames())
 
 	assert.Len(suite.T(), files, 2)
 	assert.Len(suite.T(), errors, 0)
@@ -2014,7 +2118,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardFai
 	options := &ExportOptions{Format: formatYAML}
 
 	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{"*"}, options)
+		exporter, []string{"*"}, options, suite.varNames())
 
 	assert.Len(suite.T(), files, 0)
 	assert.Len(suite.T(), errors, 0) // Returns empty slices on wildcard failure
@@ -2035,7 +2139,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardEmp
 	options := &ExportOptions{Format: formatYAML}
 
 	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{"*"}, options)
+		exporter, []string{"*"}, options, suite.varNames())
 
 	assert.Len(suite.T(), files, 0)
 	assert.Len(suite.T(), errors, 0)
@@ -2062,7 +2166,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WithGroupBy
 	}
 
 	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{appID}, options)
+		exporter, []string{appID}, options, suite.varNames())
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2090,7 +2194,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WithCustomF
 	}
 
 	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{appID}, options)
+		exporter, []string{appID}, options, suite.varNames())
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2116,7 +2220,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_IdentityPro
 	options := &ExportOptions{Format: formatYAML}
 
 	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{idpID}, options)
+		exporter, []string{idpID}, options, suite.varNames())
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2146,7 +2250,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_Notificatio
 	options := &ExportOptions{Format: formatYAML}
 
 	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{senderID}, options)
+		exporter, []string{senderID}, options, suite.varNames())
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2178,7 +2282,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_EntityType(
 	options := &ExportOptions{Format: formatYAML}
 
 	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{schemaID}, options)
+		exporter, []string{schemaID}, options, suite.varNames())
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2194,7 +2298,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_EmptyResour
 	options := &ExportOptions{Format: formatYAML}
 
 	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{}, options)
+		exporter, []string{}, options, suite.varNames())
 
 	assert.Len(suite.T(), files, 0)
 	assert.Len(suite.T(), errors, 0)
@@ -2218,7 +2322,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_JSONFormatF
 	}
 
 	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{appID}, options)
+		exporter, []string{appID}, options, suite.varNames())
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2264,7 +2368,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_Flow() {
 	options := &ExportOptions{Format: formatYAML}
 
 	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{flowID}, options)
+		exporter, []string{flowID}, options, suite.varNames())
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2359,7 +2463,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_FlowWithCom
 	options := &ExportOptions{Format: formatYAML}
 
 	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{flowID}, options)
+		exporter, []string{flowID}, options, suite.varNames())
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2405,7 +2509,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_MultipleFlo
 	options := &ExportOptions{Format: formatYAML}
 
 	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{testFlow1ID, testFlow2ID}, options)
+		exporter, []string{testFlow1ID, testFlow2ID}, options, suite.varNames())
 
 	assert.Len(suite.T(), files, 2)
 	assert.Len(suite.T(), errors, 0)
@@ -2427,7 +2531,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_FlowNotFoun
 	options := &ExportOptions{Format: formatYAML}
 
 	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{flowID}, options)
+		exporter, []string{flowID}, options, suite.varNames())
 
 	assert.Len(suite.T(), files, 0)
 	assert.Len(suite.T(), errors, 1)
@@ -2493,7 +2597,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardFlo
 	options := &ExportOptions{Format: formatYAML}
 
 	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{"*"}, options)
+		exporter, []string{"*"}, options, suite.varNames())
 
 	assert.Len(suite.T(), files, 2)
 	assert.Len(suite.T(), errors, 0)
@@ -2512,7 +2616,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardFlo
 	options := &ExportOptions{Format: formatYAML}
 
 	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{"*"}, options)
+		exporter, []string{"*"}, options, suite.varNames())
 
 	assert.Len(suite.T(), files, 0)
 	assert.Len(suite.T(), errors, 0) // Empty list on error

--- a/docs/content/guides/resource-export.mdx
+++ b/docs/content/guides/resource-export.mdx
@@ -29,6 +29,27 @@ Field behavior:
 
 If the export has no template variables, `environment_variables` is an empty string.
 
+## Template Variable Names
+
+Each parameterized field becomes a template variable named after its resource and the field, in uppercase. The `clientId` field of an application named `My App` becomes `MY_APP_CLIENT_ID`.
+
+<ProductName /> normalizes the resource name so that the generated name is valid in a template placeholder:
+
+- Every character that is not a letter or a digit becomes an underscore, and consecutive underscores collapse into one.
+- A trailing underscore is removed, so a name ending in a separator produces the same variable name as the name without it.
+- A name that starts with a digit gets a leading underscore.
+
+Normalization applies to generated variable names only. Exported file names and the `name` field inside the exported YAML keep the original resource name.
+
+| Resource name | Variable name for `clientId` |
+| --- | --- |
+| `My App` | `MY_APP_CLIENT_ID` |
+| `My-App` | `MY_APP_CLIENT_ID` |
+| `My App-` | `MY_APP_CLIENT_ID` |
+| `2FA App` | `_2FA_APP_CLIENT_ID` |
+
+Because normalization maps several names onto the same prefix, two resources in one export can compete for the same variable name. In that case, the second resource gets a numeric suffix. Exporting both `Wayfinder-Concierge` and `Wayfinder_Concierge` produces `WAYFINDER_CONCIERGE_CLIENT_ID` and `WAYFINDER_CONCIERGE_2_CLIENT_ID`, so each resource keeps its own value in the environment file. Resource types share one namespace, so an application and a connection with the same name also get distinct variable names.
+
 ## Internal API Model Reference
 
 The API reference schema also defines an internal `ExportResponse` model (see `ExportResponse.envFile`, backed by the `EnvironmentFile` schema/struct):


### PR DESCRIPTION
### Purpose

Exporting a resource whose name contains a hyphen produced a template variable that is not valid Go template syntax, which broke the export/import round trip:

- The exported YAML contained `{{.WAYFINDER-CONCIERGE_CLIENT_ID}}`. Go's `text/template` rejects the whole file at the first invalid character, so import failed with `IMP-1003` before any resource was processed. One hyphenated resource broke the import of every resource in the file.
- The env file generator scans the rendered content for `[A-Z0-9_]` names, so it never matched the hyphenated placeholder. The collected value was silently dropped, and the entry was missing from the env viewer and the downloaded `.env` even though the placeholder required it.

Fixes #4743

### Approach

`sanitizeVarName` is applied to every generated variable name (scalar, array, and dynamic property variables all route through it). It maps any character outside `[A-Za-z0-9]` to `_`, collapses consecutive underscores, and prefixes a leading digit, since `{{.2FA_APP_CLIENT_ID}}` is also a parse error ("bad number syntax"). Because the same generator produces both the placeholder and the key of the collected value map, the `.env` entries now match the placeholders and are emitted.

Sanitizing alone would let two names normalize to the same prefix, so `varNameAllocator` claims a variable prefix per exported resource and suffixes duplicates. `Wayfinder-Concierge` and `Wayfinder_Concierge` in one export now produce `WAYFINDER_CONCIERGE_CLIENT_ID` and `WAYFINDER_CONCIERGE_2_CLIENT_ID` rather than sharing one `.env` entry and overwriting each other's client ID and secret. This also covers two resource types sharing a name (an application and a connection both named `Github`), which had the same silent-overwrite behaviour before. The allocator is shared across all resource types in a single export, and iteration is deterministic (resource types are sorted, IDs follow request order), so re-exporting the same set produces identical names. It affects variable naming only: file names and the `name:` field in the exported YAML are unchanged.

Note that files exported by an earlier build still contain hyphenated placeholders and need to be re-exported.

### Related Issues
- Fixes #4743

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exported configuration variable names by sanitizing spaces, punctuation, and hyphens.
  * Prevented variable names from starting with digits.
  * Ensured unique variable names when different resources normalize to the same value.

* **Documentation**
  * Documented variable naming, normalization, numeric-prefix handling, collision suffixes, and shared naming rules.

* **Tests**
  * Added coverage for special characters, numeric prefixes, and naming collisions across exported resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->