### PR TITLE
Restore Asgardeo as federated OAuth IDP sample in Postman collection

### DIFF
--- a/samples/api/postman/authentication/README.md
+++ b/samples/api/postman/authentication/README.md
@@ -10,7 +10,7 @@ Individual authentication endpoints that can be used independently for specific 
 - **SMS OTP Login** - Send and verify SMS OTP
 - **Google Login** - Social login with Google
 - **GitHub Login** - Social login with GitHub
-- **ThunderID Login** - OAuth-based login with ThunderID
+- **Asgardeo Login** - OAuth-based login with Asgardeo
 
 ### 2. Authenticate with Flow Native APIs
 Orchestrated authentication flows using flow execution engine:
@@ -40,7 +40,7 @@ User self-registration flows:
 │   ├── 03.02 - SMS OTP Login
 │   ├── 03.03 - Google Login
 │   ├── 03.04 - GitHub Login
-│   └── 03.05 - ThunderID Login
+│   └── 03.05 - Asgardeo Login
 ├── 04 - Authenticate with Flow Native APIs
 │   ├── 04.01 - Login With Username & Password
 │   ├── 04.02 - Login With Username & Password (Verbose)
@@ -59,7 +59,7 @@ User self-registration flows:
 3. External service credentials (for social login demos):
    - Google OAuth credentials
    - GitHub OAuth credentials
-   - ThunderID OAuth credentials (optional)
+   - Asgardeo OAuth credentials (optional)
    - SMS notification sender webhook URL (for SMS OTP demos)
 
 ## Environment Setup
@@ -70,35 +70,46 @@ Import the `environment.json` file into Postman and fill in the required values.
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `baseUrl` | ThunderID management API base URL | `https://localhost:8090` |
-| `ADMIN_USERNAME` | Admin user username | `admin` |
-| `ADMIN_PASSWORD` | Admin user password | `admin` |
+| `scheme` | Server scheme | `https` |
+| `host` | Server host | `localhost` |
+| `port` | Server port | `8090` |
+| `baseUrl` | Server base URL | `{{scheme}}://{{host}}:{{port}}` (`https://localhost:8090`) |
 
-### Service Integration Credentials (Setup Phase)
+### Management Token App (for obtaining access tokens)
 
-#### Google IDP (Optional)
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `MGT_TOKEN_APP_CLIENT_ID` | Client ID of the management app | `CONSOLE` |
+| `MGT_TOKEN_APP_REDIRECT_URI` | Redirect URI for the management app | `https://localhost:8090/console` |
+| `MGT_TOKEN_SCOPE` | OAuth scopes to request | `system` |
+| `ADMIN_USERNAME` | Admin username for authentication | `admin` |
+| `ADMIN_PASSWORD` | Admin password for authentication | `admin` |
+
+### Identity Provider Credentials
+
+#### Google IDP
 
 | Variable | Description |
 |----------|-------------|
 | `GOOGLE_CLIENT_ID` | Google OAuth client ID |
 | `GOOGLE_CLIENT_SECRET` | Google OAuth client secret |
 
-#### GitHub IDP (Optional)
+#### GitHub IDP
 
 | Variable | Description |
 |----------|-------------|
 | `GITHUB_CLIENT_ID` | GitHub OAuth client ID |
 | `GITHUB_CLIENT_SECRET` | GitHub OAuth client secret |
 
-#### ThunderID IDP (Optional)
+#### Asgardeo IDP (Optional)
 
 | Variable | Description |
 |----------|-------------|
-| `THUNDERID_CLIENT_ID` | ThunderID OAuth client ID |
-| `THUNDERID_CLIENT_SECRET` | ThunderID OAuth client secret |
-| `THUNDERID_BASE_URI` | ThunderID organization base URI (Ex: https://localhost:8090) |
+| `ASGARDEO_CLIENT_ID` | Asgardeo OAuth client ID |
+| `ASGARDEO_CLIENT_SECRET` | Asgardeo OAuth client secret |
+| `THUNDERID_BASE_URI` | Asgardeo organization base URI (Ex: https://localhost:8090) |
 
-Note: Replace `your-org` with your actual organization name.
+Note: Replace `your-org` with your actual Asgardeo organization name.
 
 #### Federated IDP Configuration (Common for all IDPs)
 
@@ -144,12 +155,12 @@ Note: Replace `your-org` with your actual organization name.
 | `demoGithubUserSub` | GitHub user subject identifier (unique id from GitHub) |
 | `demoGithubUserEmail` | GitHub user email |
 
-#### ThunderID User
+#### Asgardeo User
 
 | Variable | Description |
 |----------|-------------|
-| `demoThunderIDUserSub` | ThunderID user subject identifier (unique id from ThunderID) |
-| `demoThunderIDUserEmail` | ThunderID user email |
+| `demoAsgardeoUserSub` | Asgardeo user subject identifier (unique id from Asgardeo) |
+| `demoAsgardeoUserEmail` | Asgardeo user email |
 
 ### Resource IDs (for the Created Resources)
 
@@ -163,7 +174,7 @@ These variables will be auto-populated during the resource setup phase:
 | `demoSchemaName` | Created demo user schema name |
 | `googleIDPId` | Created Google IDP ID |
 | `githubIDPId` | Created GitHub IDP ID |
-| `thunderidIDPId` | Created ThunderID IDP ID |
+| `thunderidIDPId` | Created Asgardeo IDP ID |
 | `messageNotificationSenderId` | Created SMS notification sender ID |
 | `loginApplicationId` | Created demo application ID |
 | `basicAuthFlowGraphId` | Created basic authentication flow graph ID |
@@ -194,7 +205,7 @@ These variables are automatically populated during the demo execution:
 | `first_factor_assertion` | First factor authentication assertion for MFA flows |
 | `google_session_token` | Google authentication session token |
 | `github_session_token` | GitHub authentication session token |
-| `thunderid_session_token` | ThunderID authentication session token |
+| `thunderid_session_token` | Asgardeo authentication session token |
 | `exec_flow_id` | Flow execution ID for flow-native APIs |
 | `exec_challenge_token` | Challenge token for flow execution |
 | `auth_std_auth_id` | OAuth standard flow auth ID |
@@ -226,7 +237,7 @@ Run the requests in `02 - Setup Resources` folder to create:
 - Demo organization unit
 - User schema
 - Notification sender (for SMS OTP)
-- Identity providers (Google, GitHub, ThunderID)
+- Identity providers (Google, GitHub, Asgardeo)
 - Demo users
 - Demo application
 - Authentication and registration flows
@@ -242,6 +253,6 @@ Choose any of the authentication demo folders:
 ## Notes
 
 - The collection includes a pre-request script that automatically refreshes the access token when it's about to expire.
-- For social login demos (Google, GitHub, ThunderID), you'll need to complete the OAuth flow in a browser and provide the authorization code manually.
+- For social login demos (Google, GitHub, Asgardeo), you'll need to complete the OAuth flow in a browser and provide the authorization code manually.
 - SMS OTP demos require a webhook endpoint to receive OTP messages. You can use services like [webhook.site](https://webhook.site/) for testing.
 - Some requests may return `201` (created) or `409` (already exists) depending on whether resources already exist

--- a/samples/api/postman/authentication/authentication_demo.json
+++ b/samples/api/postman/authentication/authentication_demo.json
@@ -548,7 +548,7 @@
           "response": []
         },
         {
-          "name": "06 - Create ThunderID OAuth IDP",
+          "name": "06 - Create Asgardeo OAuth IDP",
           "event": [
             {
               "listen": "test",
@@ -561,7 +561,7 @@
                   "    // Store the IDP id",
                   "    pm.environment.set(\"thunderidIDPId\", response.id);",
                   "    ",
-                  "    console.log(\"✓ ThunderID IDP created\");",
+                  "    console.log(\"\u2713 Asgardeo IDP created\");",
                   "    console.log(\"  ID:\", response.id);",
                   "    console.log(\"  Name:\", response.name);",
                   "} else if (pm.response.code === 409) {",
@@ -594,7 +594,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"name\": \"ThunderID OAuth\",\n    \"description\": \"Login with ThunderID\",\n    \"clientId\": \"{{THUNDERID_CLIENT_ID}}\",\n    \"clientSecret\": \"{{THUNDERID_CLIENT_SECRET}}\",\n    \"redirectUri\": \"{{FED_IDP_REDIRECT_URI}}\",\n    \"scopes\": [\"openid\", \"custom\", \"email\", \"groups\", \"profile\"],\n    \"authorizationEndpoint\": \"{{THUNDERID_BASE_URI}}/oauth2/authorize\",\n    \"tokenEndpoint\": \"{{THUNDERID_BASE_URI}}/oauth2/token\",\n    \"userInfoEndpoint\": \"{{THUNDERID_BASE_URI}}/oauth2/userinfo\"\n}",
+              "raw": "{\n    \"name\": \"Asgardeo Prod\",\n    \"description\": \"Login with Asgardeo\",\n    \"clientId\": \"{{ASGARDEO_CLIENT_ID}}\",\n    \"clientSecret\": \"{{ASGARDEO_CLIENT_SECRET}}\",\n    \"redirectUri\": \"{{FED_IDP_REDIRECT_URI}}\",\n    \"scopes\": [\"openid\", \"custom\", \"email\", \"groups\", \"profile\"],\n    \"authorizationEndpoint\": \"{{THUNDERID_BASE_URI}}/oauth2/authorize\",\n    \"tokenEndpoint\": \"{{THUNDERID_BASE_URI}}/oauth2/token\",\n    \"userInfoEndpoint\": \"{{THUNDERID_BASE_URI}}/oauth2/userinfo\",\n    \"logoutEndpoint\": \"{{THUNDERID_BASE_URI}}/oidc/logout\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -720,7 +720,7 @@
           "response": []
         },
         {
-          "name": "10 - Create ThunderID User",
+          "name": "10 - Create Asgardeo User",
           "request": {
             "method": "POST",
             "header": [
@@ -735,7 +735,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"ouId\": \"{{demoOuId}}\",\n    \"type\": \"{{demoSchemaName}}\",\n    \"attributes\": {\n        \"sub\": \"{{demoThunderIDUserSub}}\",\n        \"email\": \"{{demoThunderIDUserEmail}}\",\n        \"userSource\": \"ThunderID\"\n    }\n}",
+              "raw": "{\n    \"ouId\": \"{{demoOuId}}\",\n    \"type\": \"{{demoSchemaName}}\",\n    \"attributes\": {\n        \"sub\": \"{{demoAsgardeoUserSub}}\",\n        \"email\": \"{{demoAsgardeoUserEmail}}\",\n        \"userSource\": \"Asgardeo\"\n    }\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -1636,7 +1636,7 @@
           ]
         },
         {
-          "name": "03.05 - ThunderID Login",
+          "name": "03.05 - Asgardeo Login",
           "item": [
             {
               "name": "01 - Start",

--- a/samples/api/postman/authentication/environment.json
+++ b/samples/api/postman/authentication/environment.json
@@ -177,13 +177,13 @@
       "enabled": true
     },
     {
-      "key": "THUNDERID_CLIENT_ID",
+      "key": "ASGARDEO_CLIENT_ID",
       "value": "",
       "type": "secret",
       "enabled": true
     },
     {
-      "key": "THUNDERID_CLIENT_SECRET",
+      "key": "ASGARDEO_CLIENT_SECRET",
       "value": "",
       "type": "secret",
       "enabled": true
@@ -225,13 +225,13 @@
       "enabled": true
     },
     {
-      "key": "demoThunderIDUserSub",
+      "key": "demoAsgardeoUserSub",
       "value": "",
       "type": "secret",
       "enabled": true
     },
     {
-      "key": "demoThunderIDUserEmail",
+      "key": "demoAsgardeoUserEmail",
       "value": "",
       "type": "default",
       "enabled": true


### PR DESCRIPTION
### Purpose

Restore `Asgardeo` references in the Postman authentication sample collection (`samples/api/postman/authentication/`). In these sample requests, Asgardeo represents a third-party federated Identity Provider (alongside Google and GitHub) rather than the primary IAM product identity. 

### Approach

- **Postman Collection & Environment**: Restored `Asgardeo Login` (`03.05`), `Create Asgardeo OAuth IDP` (`06`), `ASGARDEO_CLIENT_ID`, `ASGARDEO_CLIENT_SECRET`, and `demoAsgardeoUserSub` across `samples/api/postman/authentication/README.md`, `environment.json`, and `authentication_demo.json`.

### Related Issues
- N/A

### Related PRs
- https://github.com/thunder-id/thunderid/pull/4753

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication demo documentation to use Asgardeo terminology and configuration.
  * Clarified setup steps, prerequisites, login scenarios, identity-provider settings, and environment variables.

* **Chores**
  * Updated the Postman authentication collection and environment with Asgardeo-specific names, credentials, user fields, and login examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->