### PR TITLE
Update agent token edit section's monaco setup

### DIFF
--- a/frontend/apps/console/src/App.tsx
+++ b/frontend/apps/console/src/App.tsx
@@ -62,7 +62,9 @@ const CreateResourceServerPage = lazy(() =>
 );
 
 const AgentCreatePage = lazy(() => import('./features/agents/pages/AgentCreatePage'));
-const AgentEditPage = lazy(() => import('./features/agents/pages/AgentEditPage'));
+const AgentEditPage = lazy(() =>
+  import('./lib/monaco-setup').then(() => import('./features/agents/pages/AgentEditPage')),
+);
 const AgentsListPage = lazy(() => import('./features/agents/pages/AgentsListPage'));
 const ApplicationCreatePage = lazy(() => import('./features/applications/pages/ApplicationCreatePage'));
 const ApplicationEditPage = lazy(() =>

--- a/frontend/apps/console/src/__tests__/App.test.tsx
+++ b/frontend/apps/console/src/__tests__/App.test.tsx
@@ -54,6 +54,10 @@ vi.mock('@thunderid/configure-connections', async (importOriginal) => ({
   TrustedIssuerDetailPage: () => <div data-testid="trusted-issuer-detail-page">Trusted Issuer Detail Page</div>,
 }));
 
+vi.mock('../features/agents/pages/AgentEditPage', () => ({
+  default: () => <div data-testid="agent-edit-page">Agent Edit Page</div>,
+}));
+
 vi.mock('../features/applications/pages/ApplicationsListPage', () => ({
   default: () => <div data-testid="applications-list-page">Applications List Page</div>,
 }));
@@ -142,6 +146,14 @@ describe('App', () => {
     render(<App />);
     await waitFor(() => {
       expect(screen.getByTestId('application-edit-page')).toBeInTheDocument();
+    });
+  });
+
+  it('loads AgentEditPage lazily via the monaco-setup chain', async () => {
+    window.history.pushState({}, '', '/agents/agent-123');
+    render(<App />);
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-edit-page')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
### Purpose

The Token Preview on the Edit Agent page never loads. `AgentEditPage` was the only
Monaco-rendering route in the console whose lazy import was not chained through
`monaco-setup`, so `@monaco-editor/react` fell back to its default jsDelivr CDN loader,
which fails in offline deployments and is blocked by the `script-src 'self'` CSP baseline.

It appeared intermittent because `loader.config` is global to the SPA session: visiting an
Application edit page first ran the setup and made the agent preview work.

### Approach

Chain `AgentEditPage` through `import('./lib/monaco-setup')` in `App.tsx`, matching the
existing pattern used by `ApplicationEditPage`, `TranslationsEditPage`, `LayoutBuilderPage`,
`ExportPage`, and `ImportConfigurationSummaryPage`. Added a matching route test.

### Related Issues
- Fixes #4770

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved loading behavior for the agent editing page by deferring editor setup until needed.

* **Bug Fixes**
  * Improved navigation to agent edit pages so they load and render reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->