### PR TITLE
Theme builder fixes

### DIFF
--- a/frontend/packages/configure-design/src/GatePreview/GatePreview.tsx
+++ b/frontend/packages/configure-design/src/GatePreview/GatePreview.tsx
@@ -42,7 +42,7 @@ const MIN_CONTENT_HEIGHT = 700;
 function buildIframeInitialHTML(nonce: string | undefined): string {
   return [
     '<!DOCTYPE html><html style="height:100%"><head>',
-    `<style${nonce ? ` nonce="${nonce}"` : ''}>body{margin:0;height:100%}#root,#root>*{height:100%}</style>`,
+    `<style${nonce ? ` nonce="${nonce}"` : ''}>*,*::before,*::after{box-sizing:border-box}body{margin:0;height:100%}#root,#root>*{height:100%}</style>`,
     '</head><body><div id="root"></div></body></html>',
   ].join('');
 }

--- a/frontend/packages/configure-design/src/GatePreview/IframeContent.tsx
+++ b/frontend/packages/configure-design/src/GatePreview/IframeContent.tsx
@@ -23,6 +23,7 @@ import {useEffect, useMemo, type JSX} from 'react';
 import PreviewThemeProvider from './PreviewThemeProvider';
 import {resolveAnchorActionRef, resolveHoverTarget} from './richTextClickResolution';
 import ElementInspector from '../components/layouts/ElementInspector';
+import {applyBorderStylesToTheme} from '../utils/applyBorderStylesToTheme';
 
 /**
  * MUI's extendTheme only accepts 'light' or 'dark' for defaultColorScheme.
@@ -57,6 +58,19 @@ function IframeBodyBackground({iframeDoc}: {iframeDoc: Document}): null {
     const {body} = iframeDoc;
     body.style.setProperty('background', background ?? '');
   }, [iframeDoc, muiTheme]);
+
+  return null;
+}
+
+/**
+ * Sets the document direction (RTL/LTR) on the iframe based on theme direction.
+ */
+function IframeDirection({iframeDoc, theme}: {iframeDoc: Document; theme: Theme | undefined}): null {
+  useEffect(() => {
+    const themeRecord = theme as unknown as Record<string, unknown>;
+    const direction = theme ? ((themeRecord['direction'] as string) ?? 'ltr') : 'ltr';
+    iframeDoc.documentElement.setAttribute('dir', direction);
+  }, [iframeDoc, theme]);
 
   return null;
 }
@@ -136,6 +150,9 @@ export default function IframeContent({
   const hasTheme = Boolean(theme && Object.keys(theme).length > 0);
   const showThemelessBranding = themelessBranding && !hasTheme;
 
+  // Apply border styles from theme.border to component overrides
+  const themeWithBorders = useMemo(() => applyBorderStylesToTheme(theme), [theme]);
+
   const themeTypography = (hasTheme ? theme : baseTheme)?.typography as {fontFamily?: string} | undefined;
   const fontFamily = themeTypography?.fontFamily;
   const fontImportURL = getFontImportURL(hasTheme ? theme : baseTheme);
@@ -188,7 +205,7 @@ export default function IframeContent({
       <FontImporter fontFamily={fontFamily} importURL={fontImportURL} targetDocument={iframeDoc} />
       <DesignProvider
         shouldResolveDesignInternally={false}
-        design={hasTheme ? ({theme: sanitizeThemeForMui(theme!)} as DesignResolveResponse) : undefined}
+        design={hasTheme ? ({theme: sanitizeThemeForMui(themeWithBorders!)} as DesignResolveResponse) : undefined}
       >
         <PreviewThemeProvider
           colorScheme={colorScheme}
@@ -196,6 +213,7 @@ export default function IframeContent({
           baseTheme={baseTheme}
         >
           <IframeBodyBackground iframeDoc={iframeDoc} />
+          <IframeDirection iframeDoc={iframeDoc} theme={themeWithBorders} />
           <ElementInspector enabled={inspectorEnabled} onSelectSelector={onSelectSelector}>
             <AuthPageLayout isLoading={false} variant="SignIn" background={pageBackground}>
               {showThemelessBranding && <ParticleBackground opacity={0.5} />}

--- a/frontend/packages/configure-design/src/GatePreview/__tests__/IframeContent.test.tsx
+++ b/frontend/packages/configure-design/src/GatePreview/__tests__/IframeContent.test.tsx
@@ -288,4 +288,86 @@ describe('IframeContent', () => {
       expect(onSubmit).not.toHaveBeenCalledWith(expect.objectContaining({eventType: EmbeddedFlowEventType.Trigger}));
     });
   });
+
+  describe('theme and background handling', () => {
+    it('renders without a theme when theme is undefined', () => {
+      const {iframeDoc} = renderIframeContent({theme: undefined});
+      expect(iframeDoc.getElementById('root')?.children.length).toBeGreaterThan(0);
+    });
+
+    it('applies page background when provided', () => {
+      const {iframeDoc} = renderIframeContent({pageBackground: '#f0f0f0'});
+      const authPageLayout = iframeDoc.querySelector('[data-testid="auth-page-layout"]');
+      expect(authPageLayout).not.toBeNull();
+    });
+
+    it('renders themeless branding when enabled and no theme is present', () => {
+      const {iframeDoc} = renderIframeContent({theme: undefined, themelessBranding: true});
+      // ParticleBackground should be rendered when themelessBranding is true and no theme
+      const authPageLayout = iframeDoc.querySelector('[data-testid="auth-page-layout"]');
+      expect(authPageLayout).not.toBeNull();
+    });
+
+    it('does not render themeless branding when theme is present', () => {
+      const {iframeDoc} = renderIframeContent({theme: mockTheme, themelessBranding: true});
+      // ParticleBackground should not be rendered when theme is present
+      expect(iframeDoc.querySelector('[data-testid="auth-page-layout"]')).not.toBeNull();
+    });
+
+    it('passes additional data to flow component renderer', () => {
+      const additionalData = {consentPrompt: 'test-prompt'};
+      const {iframeDoc} = renderIframeContent({additionalData});
+      // Component should render without error when additionalData is passed
+      expect(iframeDoc.getElementById('btn-comp-1')).not.toBeNull();
+    });
+  });
+
+  describe('iframe direction setting', () => {
+    it('sets iframe document dir attribute to ltr when no theme direction is specified', () => {
+      const {iframeDoc} = renderIframeContent({theme: mockTheme});
+      expect(iframeDoc.documentElement.getAttribute('dir')).toBe('ltr');
+    });
+
+    it('sets iframe document dir attribute based on theme direction', () => {
+      const themeWithRtl = {
+        ...mockTheme,
+        direction: 'rtl',
+      } as unknown as Theme;
+      const {iframeDoc} = renderIframeContent({theme: themeWithRtl});
+      expect(iframeDoc.documentElement.getAttribute('dir')).toBe('rtl');
+    });
+
+    it('resets to ltr when theme direction is not set', () => {
+      const {iframeDoc, rerender} = renderIframeContent({theme: mockTheme});
+      expect(iframeDoc.documentElement.getAttribute('dir')).toBe('ltr');
+
+      const themeWithRtl = {...mockTheme, direction: 'rtl'} as unknown as Theme;
+      rerender(
+        <OxygenUIThemeProvider>
+          <IframeContent
+            iframeDoc={iframeDoc}
+            colorScheme="light"
+            theme={themeWithRtl}
+            stylesheets={[]}
+            pageBackground={undefined}
+            mock={[mockComponent]}
+            inspectorEnabled={false}
+          />
+        </OxygenUIThemeProvider>,
+      );
+      expect(iframeDoc.documentElement.getAttribute('dir')).toBe('rtl');
+    });
+  });
+
+  describe('border styles application', () => {
+    it('applies border styles from theme.border to components', () => {
+      const themeWithBorder = {
+        ...mockTheme,
+        border: {width: '2px', style: 'solid'},
+      } as unknown as Theme;
+      const {iframeDoc} = renderIframeContent({theme: themeWithBorder});
+      // Component should render without error when border is applied
+      expect(iframeDoc.getElementById('btn-comp-1')).not.toBeNull();
+    });
+  });
 });

--- a/frontend/packages/configure-design/src/utils/__tests__/applyBorderStylesToTheme.test.ts
+++ b/frontend/packages/configure-design/src/utils/__tests__/applyBorderStylesToTheme.test.ts
@@ -1,0 +1,531 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import type {Theme} from '@thunderid/design';
+import {describe, it, expect} from 'vitest';
+import {applyBorderStylesToTheme} from '../applyBorderStylesToTheme';
+
+function makeBaseTheme(overrides: Partial<Record<string, unknown>> = {}): Theme {
+  return {
+    shape: {borderRadius: 8},
+    colorSchemes: {
+      light: {palette: {primary: {main: '#3688FF'}}},
+      dark: {palette: {primary: {main: '#3688FF'}}},
+    },
+    ...overrides,
+  } as unknown as Theme;
+}
+
+describe('applyBorderStylesToTheme', () => {
+  describe('handles undefined and null', () => {
+    it('returns undefined when theme is undefined', () => {
+      expect(applyBorderStylesToTheme(undefined)).toBeUndefined();
+    });
+
+    it('returns theme unchanged when border property is missing', () => {
+      const theme = makeBaseTheme();
+      const result = applyBorderStylesToTheme(theme);
+      expect(result).toBe(theme);
+    });
+
+    it('returns theme unchanged when border object is empty', () => {
+      const theme = makeBaseTheme({border: {}});
+      const result = applyBorderStylesToTheme(theme);
+      expect(result).toBe(theme);
+    });
+  });
+
+  describe('stores border in shape property', () => {
+    it('adds borderWidth to theme.shape', () => {
+      const theme = makeBaseTheme({border: {width: '2px', style: 'solid'}});
+      const result = applyBorderStylesToTheme(theme);
+      expect((result?.shape as unknown as Record<string, unknown>)?.['borderWidth']).toBe('2px');
+    });
+
+    it('adds borderStyle to theme.shape', () => {
+      const theme = makeBaseTheme({border: {width: '1px', style: 'dashed'}});
+      const result = applyBorderStylesToTheme(theme);
+      expect((result?.shape as unknown as Record<string, unknown>)?.['borderStyle']).toBe('dashed');
+    });
+
+    it('preserves existing borderRadius in shape', () => {
+      const theme = makeBaseTheme({
+        shape: {borderRadius: 12},
+        border: {width: '2px', style: 'dotted'},
+      });
+      const result = applyBorderStylesToTheme(theme);
+      expect((result?.shape as unknown as Record<string, unknown>)?.['borderRadius']).toBe(12);
+    });
+
+    it('only stores provided border properties', () => {
+      const theme = makeBaseTheme({border: {width: '3px'}});
+      const result = applyBorderStylesToTheme(theme);
+      const shape = result?.shape as unknown as Record<string, unknown>;
+      expect(shape?.['borderWidth']).toBe('3px');
+      expect(shape?.['borderStyle']).toBeUndefined();
+    });
+  });
+
+  describe('applies border to MuiButton', () => {
+    it('applies border to outlined variant (object override)', () => {
+      const theme = makeBaseTheme({
+        border: {width: '2px', style: 'solid'},
+        components: {
+          MuiButton: {
+            styleOverrides: {
+              outlined: {color: 'red'},
+            },
+          },
+        },
+      });
+      const result = applyBorderStylesToTheme(theme);
+      const components = result?.components as Record<string, unknown>;
+      const buttonOverrides = (components?.['MuiButton'] as Record<string, unknown>)?.['styleOverrides'] as Record<
+        string,
+        unknown
+      >;
+      const outlinedOverride = buttonOverrides?.['outlined'] as Record<string, unknown>;
+      expect(outlinedOverride?.['border']).toBe('2px solid');
+      expect(outlinedOverride?.['color']).toBe('red');
+    });
+
+    it('applies border to outlinedPrimary variant (object override)', () => {
+      const theme = makeBaseTheme({
+        border: {width: '1px', style: 'dashed'},
+        components: {
+          MuiButton: {
+            styleOverrides: {
+              outlinedPrimary: {color: 'blue'},
+            },
+          },
+        },
+      });
+      const result = applyBorderStylesToTheme(theme);
+      const components = result?.components as Record<string, unknown>;
+      const buttonOverrides = (components?.['MuiButton'] as Record<string, unknown>)?.['styleOverrides'] as Record<
+        string,
+        unknown
+      >;
+      const outlinedPrimaryOverride = buttonOverrides?.['outlinedPrimary'] as Record<string, unknown>;
+      expect(outlinedPrimaryOverride?.['border']).toBe('1px dashed');
+      expect(outlinedPrimaryOverride?.['color']).toBe('blue');
+    });
+
+    it('applies border to outlinedSecondary variant (object override)', () => {
+      const theme = makeBaseTheme({
+        border: {width: '3px', style: 'dotted'},
+        components: {
+          MuiButton: {
+            styleOverrides: {
+              outlinedSecondary: {color: 'green'},
+            },
+          },
+        },
+      });
+      const result = applyBorderStylesToTheme(theme);
+      const components = result?.components as Record<string, unknown>;
+      const buttonOverrides = (components?.['MuiButton'] as Record<string, unknown>)?.['styleOverrides'] as Record<
+        string,
+        unknown
+      >;
+      const outlinedSecondaryOverride = buttonOverrides?.['outlinedSecondary'] as Record<string, unknown>;
+      expect(outlinedSecondaryOverride?.['border']).toBe('3px dotted');
+      expect(outlinedSecondaryOverride?.['color']).toBe('green');
+    });
+
+    it('handles function-based button overrides', () => {
+      const theme = makeBaseTheme({
+        border: {width: '2px', style: 'solid'},
+        components: {
+          MuiButton: {
+            styleOverrides: {
+              outlined: () => ({color: 'red'}),
+            },
+          },
+        },
+      });
+      const result = applyBorderStylesToTheme(theme);
+      const components = result?.components as Record<string, unknown>;
+      const buttonOverrides = (components?.['MuiButton'] as Record<string, unknown>)?.['styleOverrides'] as Record<
+        string,
+        unknown
+      >;
+      const outlinedOverride = buttonOverrides?.['outlined'] as (props: unknown) => Record<string, unknown>;
+      const overrideResult = outlinedOverride({});
+      expect(overrideResult['border']).toBe('2px solid');
+      expect(overrideResult['color']).toBe('red');
+    });
+
+    it('creates outlined override when absent', () => {
+      const theme = makeBaseTheme({border: {width: '2px', style: 'solid'}});
+      const result = applyBorderStylesToTheme(theme);
+      const components = result?.components as Record<string, unknown>;
+      const buttonOverrides = (components?.['MuiButton'] as Record<string, unknown>)?.['styleOverrides'] as Record<
+        string,
+        unknown
+      >;
+      const outlinedOverride = buttonOverrides?.['outlined'] as Record<string, unknown>;
+      expect(outlinedOverride?.['borderWidth']).toBe('2px');
+      expect(outlinedOverride?.['borderStyle']).toBe('solid');
+    });
+
+    it('creates outlinedPrimary override when absent', () => {
+      const theme = makeBaseTheme({border: {width: '1px', style: 'dashed'}});
+      const result = applyBorderStylesToTheme(theme);
+      const components = result?.components as Record<string, unknown>;
+      const buttonOverrides = (components?.['MuiButton'] as Record<string, unknown>)?.['styleOverrides'] as Record<
+        string,
+        unknown
+      >;
+      const outlinedPrimaryOverride = buttonOverrides?.['outlinedPrimary'] as Record<string, unknown>;
+      expect(outlinedPrimaryOverride?.['borderWidth']).toBe('1px');
+      expect(outlinedPrimaryOverride?.['borderStyle']).toBe('dashed');
+    });
+
+    it('creates outlinedSecondary override when absent', () => {
+      const theme = makeBaseTheme({border: {width: '3px', style: 'dotted'}});
+      const result = applyBorderStylesToTheme(theme);
+      const components = result?.components as Record<string, unknown>;
+      const buttonOverrides = (components?.['MuiButton'] as Record<string, unknown>)?.['styleOverrides'] as Record<
+        string,
+        unknown
+      >;
+      const outlinedSecondaryOverride = buttonOverrides?.['outlinedSecondary'] as Record<string, unknown>;
+      expect(outlinedSecondaryOverride?.['borderWidth']).toBe('3px');
+      expect(outlinedSecondaryOverride?.['borderStyle']).toBe('dotted');
+    });
+  });
+
+  describe('applies border to MuiOutlinedInput', () => {
+    it('applies borderWidth and borderStyle to notchedOutline', () => {
+      const theme = makeBaseTheme({border: {width: '2px', style: 'dashed'}});
+      const result = applyBorderStylesToTheme(theme);
+      const components = result?.components as Record<string, unknown>;
+      const inputOverrides = (components?.['MuiOutlinedInput'] as Record<string, unknown>)?.[
+        'styleOverrides'
+      ] as Record<string, unknown>;
+      const notchedOutline = inputOverrides?.['notchedOutline'] as Record<string, unknown>;
+      expect(notchedOutline?.['borderWidth']).toBe('2px');
+      expect(notchedOutline?.['borderStyle']).toBe('dashed');
+    });
+
+    it('preserves existing notchedOutline overrides', () => {
+      const theme = makeBaseTheme({
+        border: {width: '1px', style: 'solid'},
+        components: {
+          MuiOutlinedInput: {
+            styleOverrides: {
+              notchedOutline: {borderColor: 'blue'},
+            },
+          },
+        },
+      });
+      const result = applyBorderStylesToTheme(theme);
+      const components = result?.components as Record<string, unknown>;
+      const inputOverrides = (components?.['MuiOutlinedInput'] as Record<string, unknown>)?.[
+        'styleOverrides'
+      ] as Record<string, unknown>;
+      const notchedOutline = inputOverrides?.['notchedOutline'] as Record<string, unknown>;
+      expect(notchedOutline?.['borderColor']).toBe('blue');
+      expect(notchedOutline?.['borderWidth']).toBe('1px');
+    });
+
+    it('preserves callback-based notchedOutline overrides', () => {
+      const theme = makeBaseTheme({
+        border: {width: '2px', style: 'dashed'},
+        components: {
+          MuiOutlinedInput: {
+            styleOverrides: {
+              notchedOutline: () => ({borderColor: 'orange'}),
+            },
+          },
+        },
+      });
+      const result = applyBorderStylesToTheme(theme);
+      const components = result?.components as Record<string, unknown>;
+      const inputOverrides = (components?.['MuiOutlinedInput'] as Record<string, unknown>)?.[
+        'styleOverrides'
+      ] as Record<string, unknown>;
+      const notchedOutline = inputOverrides?.['notchedOutline'] as (props: unknown) => Record<string, unknown>;
+      const overrideResult = notchedOutline({});
+      expect(overrideResult['borderColor']).toBe('orange');
+      expect(overrideResult['borderWidth']).toBe('2px');
+      expect(overrideResult['borderStyle']).toBe('dashed');
+    });
+  });
+
+  describe('applies border to MuiChip', () => {
+    it('applies borderWidth and borderStyle to outlined variant', () => {
+      const theme = makeBaseTheme({border: {width: '2px', style: 'dotted'}});
+      const result = applyBorderStylesToTheme(theme);
+      const components = result?.components as Record<string, unknown>;
+      const chipOverrides = (components?.['MuiChip'] as Record<string, unknown>)?.['styleOverrides'] as Record<
+        string,
+        unknown
+      >;
+      const outlined = chipOverrides?.['outlined'] as Record<string, unknown>;
+      expect(outlined?.['borderWidth']).toBe('2px');
+      expect(outlined?.['borderStyle']).toBe('dotted');
+    });
+
+    it('preserves existing outlined overrides', () => {
+      const theme = makeBaseTheme({
+        border: {width: '1px', style: 'solid'},
+        components: {
+          MuiChip: {
+            styleOverrides: {
+              outlined: {borderColor: 'green'},
+            },
+          },
+        },
+      });
+      const result = applyBorderStylesToTheme(theme);
+      const components = result?.components as Record<string, unknown>;
+      const chipOverrides = (components?.['MuiChip'] as Record<string, unknown>)?.['styleOverrides'] as Record<
+        string,
+        unknown
+      >;
+      const outlined = chipOverrides?.['outlined'] as Record<string, unknown>;
+      expect(outlined?.['borderColor']).toBe('green');
+      expect(outlined?.['borderWidth']).toBe('1px');
+    });
+
+    it('preserves callback-based outlined overrides', () => {
+      const theme = makeBaseTheme({
+        border: {width: '2px', style: 'dotted'},
+        components: {
+          MuiChip: {
+            styleOverrides: {
+              outlined: () => ({borderColor: 'purple'}),
+            },
+          },
+        },
+      });
+      const result = applyBorderStylesToTheme(theme);
+      const components = result?.components as Record<string, unknown>;
+      const chipOverrides = (components?.['MuiChip'] as Record<string, unknown>)?.['styleOverrides'] as Record<
+        string,
+        unknown
+      >;
+      const outlined = chipOverrides?.['outlined'] as (props: unknown) => Record<string, unknown>;
+      const overrideResult = outlined({});
+      expect(overrideResult['borderColor']).toBe('purple');
+      expect(overrideResult['borderWidth']).toBe('2px');
+      expect(overrideResult['borderStyle']).toBe('dotted');
+    });
+  });
+
+  describe('uses default values', () => {
+    it('uses 1px as default borderWidth', () => {
+      const theme = makeBaseTheme({border: {style: 'solid'}});
+      const result = applyBorderStylesToTheme(theme);
+      // Default is applied in component overrides, not in shape
+      const components = result?.components as Record<string, unknown>;
+      const inputOverrides = (components?.['MuiOutlinedInput'] as Record<string, unknown>)?.[
+        'styleOverrides'
+      ] as Record<string, unknown>;
+      const notchedOutline = inputOverrides?.['notchedOutline'] as Record<string, unknown>;
+      expect(notchedOutline?.['borderWidth']).toBe('1px');
+    });
+
+    it('uses solid as default borderStyle', () => {
+      const theme = makeBaseTheme({border: {width: '2px'}});
+      const result = applyBorderStylesToTheme(theme);
+      const components = result?.components as Record<string, unknown>;
+      const inputOverrides = (components?.['MuiOutlinedInput'] as Record<string, unknown>)?.[
+        'styleOverrides'
+      ] as Record<string, unknown>;
+      const notchedOutline = inputOverrides?.['notchedOutline'] as Record<string, unknown>;
+      expect(notchedOutline?.['borderStyle']).toBe('solid');
+    });
+  });
+
+  describe('immutability', () => {
+    it('modifies the theme in-place (as intended)', () => {
+      const theme = makeBaseTheme({border: {width: '2px', style: 'dashed'}});
+      const result = applyBorderStylesToTheme(theme);
+      expect(result).toBe(theme);
+    });
+
+    it('replaces outlined override object with new one', () => {
+      const theme = makeBaseTheme({
+        border: {width: '2px', style: 'solid'},
+        components: {
+          MuiButton: {
+            styleOverrides: {
+              outlined: {color: 'red'},
+            },
+          },
+        },
+      });
+      const originalOverride = (
+        (theme.components as Record<string, unknown>)?.['MuiButton'] as Record<string, unknown>
+      )?.['styleOverrides'] as Record<string, unknown>;
+      const originalOutlined = originalOverride?.['outlined'];
+
+      const result = applyBorderStylesToTheme(theme);
+      const resultOverride = (
+        (result?.components as Record<string, unknown>)?.['MuiButton'] as Record<string, unknown>
+      )?.['styleOverrides'] as Record<string, unknown>;
+      const resultOutlined = resultOverride?.['outlined'];
+
+      // The outlined override object should have border property added
+      expect(typeof resultOutlined).toBe('object');
+      expect((resultOutlined as Record<string, unknown>)?.['border']).toBe('2px solid');
+      expect(resultOutlined).not.toBe(originalOutlined);
+    });
+  });
+
+  describe('edge cases and branch coverage', () => {
+    it('handles border with only width (no style)', () => {
+      const theme = makeBaseTheme({border: {width: '2px'}});
+      const result = applyBorderStylesToTheme(theme);
+      const components = result?.components as Record<string, unknown>;
+      const buttonOverrides = (components?.['MuiButton'] as Record<string, unknown>)?.['styleOverrides'] as Record<
+        string,
+        unknown
+      >;
+      const outlinedOverride = buttonOverrides?.['outlined'] as Record<string, unknown>;
+      expect(outlinedOverride?.['borderWidth']).toBe('2px');
+      expect(outlinedOverride?.['borderStyle']).toBe('solid');
+    });
+
+    it('handles border with only style (no width)', () => {
+      const theme = makeBaseTheme({border: {style: 'dashed'}});
+      const result = applyBorderStylesToTheme(theme);
+      const components = result?.components as Record<string, unknown>;
+      const buttonOverrides = (components?.['MuiButton'] as Record<string, unknown>)?.['styleOverrides'] as Record<
+        string,
+        unknown
+      >;
+      const outlinedOverride = buttonOverrides?.['outlined'] as Record<string, unknown>;
+      expect(outlinedOverride?.['borderWidth']).toBe('1px');
+      expect(outlinedOverride?.['borderStyle']).toBe('dashed');
+    });
+
+    it('applies all three button variants independently', () => {
+      const theme = makeBaseTheme({
+        border: {width: '2px', style: 'solid'},
+        components: {
+          MuiButton: {
+            styleOverrides: {
+              outlined: {color: 'red'},
+              outlinedPrimary: {color: 'blue'},
+              outlinedSecondary: {color: 'green'},
+            },
+          },
+        },
+      });
+      const result = applyBorderStylesToTheme(theme);
+      const components = result?.components as Record<string, unknown>;
+      const buttonOverrides = (components?.['MuiButton'] as Record<string, unknown>)?.['styleOverrides'] as Record<
+        string,
+        unknown
+      >;
+      const outlined = buttonOverrides?.['outlined'] as Record<string, unknown>;
+      const outlinedPrimary = buttonOverrides?.['outlinedPrimary'] as Record<string, unknown>;
+      const outlinedSecondary = buttonOverrides?.['outlinedSecondary'] as Record<string, unknown>;
+
+      expect(outlined?.['border']).toBe('2px solid');
+      expect(outlinedPrimary?.['border']).toBe('2px solid');
+      expect(outlinedSecondary?.['border']).toBe('2px solid');
+    });
+
+    it('applies border to MuiChip outlined variant', () => {
+      const theme = makeBaseTheme({
+        border: {width: '1px', style: 'solid'},
+        components: {
+          MuiChip: {
+            styleOverrides: {
+              outlined: {borderColor: 'red'},
+            },
+          },
+        },
+      });
+      const result = applyBorderStylesToTheme(theme);
+      const components = result?.components as Record<string, unknown>;
+      const chipOverrides = (components?.['MuiChip'] as Record<string, unknown>)?.['styleOverrides'] as Record<
+        string,
+        unknown
+      >;
+      const outlined = chipOverrides?.['outlined'] as Record<string, unknown>;
+      expect(outlined?.['borderColor']).toBe('red');
+      expect(outlined?.['borderWidth']).toBe('1px');
+      expect(outlined?.['borderStyle']).toBe('solid');
+    });
+
+    it('handles function-based MuiButton outlinedPrimary overrides', () => {
+      const theme = makeBaseTheme({
+        border: {width: '1px', style: 'dashed'},
+        components: {
+          MuiButton: {
+            styleOverrides: {
+              outlinedPrimary: () => ({color: 'blue'}),
+            },
+          },
+        },
+      });
+      const result = applyBorderStylesToTheme(theme);
+      const components = result?.components as Record<string, unknown>;
+      const buttonOverrides = (components?.['MuiButton'] as Record<string, unknown>)?.['styleOverrides'] as Record<
+        string,
+        unknown
+      >;
+      const outlinedPrimaryOverride = buttonOverrides?.['outlinedPrimary'] as (
+        props: unknown,
+      ) => Record<string, unknown>;
+      const overrideResult = outlinedPrimaryOverride({});
+      expect(overrideResult['border']).toBe('1px dashed');
+      expect(overrideResult['color']).toBe('blue');
+    });
+
+    it('handles function-based MuiButton outlinedSecondary overrides', () => {
+      const theme = makeBaseTheme({
+        border: {width: '3px', style: 'dotted'},
+        components: {
+          MuiButton: {
+            styleOverrides: {
+              outlinedSecondary: () => ({color: 'green'}),
+            },
+          },
+        },
+      });
+      const result = applyBorderStylesToTheme(theme);
+      const components = result?.components as Record<string, unknown>;
+      const buttonOverrides = (components?.['MuiButton'] as Record<string, unknown>)?.['styleOverrides'] as Record<
+        string,
+        unknown
+      >;
+      const outlinedSecondaryOverride = buttonOverrides?.['outlinedSecondary'] as (
+        props: unknown,
+      ) => Record<string, unknown>;
+      const overrideResult = outlinedSecondaryOverride({});
+      expect(overrideResult['border']).toBe('3px dotted');
+      expect(overrideResult['color']).toBe('green');
+    });
+
+    it('handles function-based MuiChip outlined overrides', () => {
+      const theme = makeBaseTheme({
+        border: {width: '1px', style: 'solid'},
+        components: {
+          MuiChip: {
+            styleOverrides: {
+              outlined: () => ({borderColor: 'red'}),
+            },
+          },
+        },
+      });
+      const result = applyBorderStylesToTheme(theme);
+      const components = result?.components as Record<string, unknown>;
+      const chipOverrides = (components?.['MuiChip'] as Record<string, unknown>)?.['styleOverrides'] as Record<
+        string,
+        unknown
+      >;
+      const outlinedOverride = chipOverrides?.['outlined'] as (props: unknown) => Record<string, unknown>;
+      const overrideResult = outlinedOverride({});
+      expect(overrideResult['borderColor']).toBe('red');
+      expect(overrideResult['borderWidth']).toBe('1px');
+      expect(overrideResult['borderStyle']).toBe('solid');
+    });
+  });
+});

--- a/frontend/packages/configure-design/src/utils/applyBorderStylesToTheme.ts
+++ b/frontend/packages/configure-design/src/utils/applyBorderStylesToTheme.ts
@@ -1,0 +1,130 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import type {Theme} from '@thunderid/design';
+
+/**
+ * Applies border width and style from theme.border to the theme's shape property
+ * and component overrides. This mirrors how borderRadius is stored and used.
+ *
+ * The border settings get propagated to MUI components through the shape property
+ * and explicit component overrides where needed.
+ */
+export function applyBorderStylesToTheme(theme: Theme | undefined): Theme | undefined {
+  if (!theme) {
+    return theme;
+  }
+
+  const themeRecord = theme as unknown as Record<string, unknown>;
+  const borderObj = themeRecord['border'] as Record<string, unknown> | undefined;
+
+  if (!borderObj) {
+    return theme;
+  }
+
+  const borderWidth = borderObj['width'] as string | undefined;
+  const borderStyle = borderObj['style'] as string | undefined;
+
+  if (!borderWidth && !borderStyle) {
+    return theme;
+  }
+
+  // Store border settings in shape property, alongside borderRadius
+  // This keeps all shape-related properties together
+  themeRecord['shape'] ??= {};
+  const shape = themeRecord['shape'] as Record<string, unknown>;
+  if (borderWidth) {
+    shape['borderWidth'] = borderWidth;
+  }
+  if (borderStyle) {
+    shape['borderStyle'] = borderStyle;
+  }
+
+  const borderStr = `${borderWidth ?? '1px'} ${borderStyle ?? 'solid'}`;
+
+  // Ensure components object exists
+  themeRecord['components'] ??= {};
+
+  const components = themeRecord['components'] as Record<string, unknown>;
+
+  // Helper to apply border to overrides
+  const applyBorderToOverride = (override: unknown) => {
+    if (typeof override === 'function') {
+      return (props: unknown) => {
+        const result = (override as (props: unknown) => Record<string, unknown>)(props);
+        return {...result, border: borderStr};
+      };
+    }
+    if (override && typeof override === 'object') {
+      return {...(override as Record<string, unknown>), border: borderStr};
+    }
+    return {border: borderStr};
+  };
+
+  // Apply to MuiButton outlined variants
+  components['MuiButton'] ??= {styleOverrides: {}};
+
+  const muiButton = components['MuiButton'] as Record<string, unknown>;
+  muiButton['styleOverrides'] ??= {};
+
+  const buttonOverrides = muiButton['styleOverrides'] as Record<string, unknown>;
+
+  const outlinedOverride = buttonOverrides['outlined'];
+  buttonOverrides['outlined'] = outlinedOverride
+    ? applyBorderToOverride(outlinedOverride)
+    : {borderWidth: borderWidth ?? '1px', borderStyle: borderStyle ?? 'solid'};
+
+  const outlinedPrimaryOverride = buttonOverrides['outlinedPrimary'];
+  buttonOverrides['outlinedPrimary'] = outlinedPrimaryOverride
+    ? applyBorderToOverride(outlinedPrimaryOverride)
+    : {borderWidth: borderWidth ?? '1px', borderStyle: borderStyle ?? 'solid'};
+
+  const outlinedSecondaryOverride = buttonOverrides['outlinedSecondary'];
+  buttonOverrides['outlinedSecondary'] = outlinedSecondaryOverride
+    ? applyBorderToOverride(outlinedSecondaryOverride)
+    : {borderWidth: borderWidth ?? '1px', borderStyle: borderStyle ?? 'solid'};
+
+  // Apply to MuiOutlinedInput notchedOutline
+  components['MuiOutlinedInput'] ??= {styleOverrides: {}};
+  const muiInput = components['MuiOutlinedInput'] as Record<string, unknown>;
+  muiInput['styleOverrides'] ??= {};
+  const inputOverrides = muiInput['styleOverrides'] as Record<string, unknown>;
+  const notchedOverride = inputOverrides['notchedOutline'];
+
+  if (typeof notchedOverride === 'function') {
+    inputOverrides['notchedOutline'] = (props: unknown) => ({
+      ...(notchedOverride as (props: unknown) => Record<string, unknown>)(props),
+      borderWidth: borderWidth ?? '1px',
+      borderStyle: borderStyle ?? 'solid',
+    });
+  } else {
+    inputOverrides['notchedOutline'] = {
+      ...(notchedOverride as Record<string, unknown> | undefined),
+      borderWidth: borderWidth ?? '1px',
+      borderStyle: borderStyle ?? 'solid',
+    };
+  }
+
+  // Apply to MuiChip outlined
+  components['MuiChip'] ??= {styleOverrides: {}};
+  const muiChip = components['MuiChip'] as Record<string, unknown>;
+  muiChip['styleOverrides'] ??= {};
+  const chipOverrides = muiChip['styleOverrides'] as Record<string, unknown>;
+  const chipOutlined = chipOverrides['outlined'];
+
+  if (typeof chipOutlined === 'function') {
+    chipOverrides['outlined'] = (props: unknown) => ({
+      ...(chipOutlined as (props: unknown) => Record<string, unknown>)(props),
+      borderWidth: borderWidth ?? '1px',
+      borderStyle: borderStyle ?? 'solid',
+    });
+  } else {
+    chipOverrides['outlined'] = {
+      ...(chipOutlined as Record<string, unknown> | undefined),
+      borderWidth: borderWidth ?? '1px',
+      borderStyle: borderStyle ?? 'solid',
+    };
+  }
+
+  return theme;
+}


### PR DESCRIPTION
This pull request introduces a new utility for applying border styles from the design theme to MUI components and updates the preview rendering logic to use these theme borders. It also improves the iframe preview's CSS reset and adds support for setting the document direction (RTL/LTR) based on the theme. Comprehensive tests for the new border utility are included.

Fix thunder-id#4729, thunder-id#4732, thunder-id#4725

**Theme border support and propagation:**

* Added a new utility function `applyBorderStylesToTheme` that propagates `theme.border` settings to the theme's `shape` property and to MUI component overrides (`MuiButton`, `MuiOutlinedInput`, `MuiChip`) to ensure consistent border styling across the design system.
* Updated `IframeContent.tsx` to use the new `applyBorderStylesToTheme` utility, ensuring that border styles from the theme are applied in the preview. [[1]](diffhunk://#diff-5e80812f215147679bf14774b31422e005d86810898175c4771a766e57c28998R26) [[2]](diffhunk://#diff-5e80812f215147679bf14774b31422e005d86810898175c4771a766e57c28998R155-R157) [[3]](diffhunk://#diff-5e80812f215147679bf14774b31422e005d86810898175c4771a766e57c28998L191-R218)

**Preview rendering improvements:**

* Added a new `IframeDirection` component to set the `dir` (direction) attribute on the iframe's document element based on the theme, supporting RTL/LTR layouts.
* Enhanced the iframe CSS reset to include `box-sizing: border-box` for all elements, improving layout consistency.

**Testing:**

* Added comprehensive tests for the `applyBorderStylesToTheme` utility, covering border propagation to theme shape and MUI component overrides, handling of edge cases, and immutability expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview frames now synchronize with the selected theme’s text direction (RTL or LTR).
  * Theme border settings are applied consistently to buttons, inputs, chips, and shape styling.
  * Preview styling uses consistent border-box sizing, including pseudo-elements.

* **Bug Fixes**
  * Existing component styles are preserved when applying configured border settings.

* **Tests**
  * Added comprehensive coverage for border styling and preview direction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->