### PR TITLE
Clear resource permissions when a child action is unselected

### DIFF
--- a/frontend/packages/configure-resource-servers/src/components/permission-catalog/McpServerSectionContent.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/permission-catalog/McpServerSectionContent.tsx
@@ -16,6 +16,7 @@ interface CatalogSubsectionProps {
   resourceServerId: string;
   selected: ResourcePermissions[];
   readOnly: boolean;
+  delimiter: string;
   onChange: (selected: ResourcePermissions[]) => void;
 }
 
@@ -25,6 +26,7 @@ function CatalogSubsection({
   resourceServerId,
   selected,
   readOnly,
+  delimiter,
   onChange,
 }: CatalogSubsectionProps): JSX.Element | null {
   if (actions.length === 0) return null;
@@ -52,7 +54,7 @@ function CatalogSubsection({
           depth={1}
           checked={isPermissionSelected(selected, resourceServerId, action.permission)}
           disabled={readOnly}
-          onToggle={() => onChange(togglePermission(selected, resourceServerId, action.permission))}
+          onToggle={() => onChange(togglePermission(selected, resourceServerId, action.permission, delimiter))}
         />
       ))}
     </>
@@ -110,6 +112,7 @@ export default function McpServerSectionContent({
         resourceServerId={server.id}
         selected={selected}
         readOnly={readOnly}
+        delimiter={delimiter}
         onChange={onChange}
       />
       <CatalogSubsection
@@ -118,6 +121,7 @@ export default function McpServerSectionContent({
         resourceServerId={server.id}
         selected={selected}
         readOnly={readOnly}
+        delimiter={delimiter}
         onChange={onChange}
       />
       {resources.map((resource) => (

--- a/frontend/packages/configure-resource-servers/src/components/permission-catalog/PermissionCatalog.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/permission-catalog/PermissionCatalog.tsx
@@ -185,7 +185,7 @@ export function CatalogResourceNode({
             depth={depth + 1}
             checked={isPermissionSelected(selected, resourceServerId, action.permission)}
             disabled={readOnly}
-            onToggle={() => onChange(togglePermission(selected, resourceServerId, action.permission))}
+            onToggle={() => onChange(togglePermission(selected, resourceServerId, action.permission, delimiter))}
           />
         ))}
         {childResources.map((child) => (
@@ -271,7 +271,7 @@ function DefaultServerSectionContent({
           depth={1}
           checked={isPermissionSelected(selected, server.id, action.permission)}
           disabled={readOnly}
-          onToggle={() => onChange(togglePermission(selected, server.id, action.permission))}
+          onToggle={() => onChange(togglePermission(selected, server.id, action.permission, delimiter))}
         />
       ))}
       {resources.map((resource) => (
@@ -444,7 +444,8 @@ function UnknownServerGroups({
               depth={1}
               checked
               disabled={readOnly}
-              onToggle={() => onChange(togglePermission(selected, entry.resourceServerId, permission))}
+              // The server is gone, so its delimiter is unknowable and no ancestor can be derived.
+              onToggle={() => onChange(togglePermission(selected, entry.resourceServerId, permission, ''))}
             />
           ))}
         </Box>

--- a/frontend/packages/configure-resource-servers/src/components/permission-catalog/__tests__/PermissionCatalog.test.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/permission-catalog/__tests__/PermissionCatalog.test.tsx
@@ -232,6 +232,43 @@ describe('PermissionCatalog', () => {
     });
   });
 
+  it('unticking an action also drops the resource scopes that would still confer it', async () => {
+    const user = userEvent.setup();
+    // The state a cascade leaves behind: the resource scopes plus every action.
+    const onChange = renderCatalog({
+      selected: [
+        {
+          resourceServerId: 'rs-1',
+          permissions: ['bookings', 'bookings:reservations', 'bookings:reservations:update'],
+        },
+      ],
+    });
+    await user.click(screen.getByRole('button', {name: 'Booking API'}));
+    await waitFor(() => expect(screen.getByText('Bookings')).toBeInTheDocument());
+    // Drill down to the Update action on the nested Reservations resource.
+    await user.click(screen.getByRole('button', {name: 'bookings'}));
+    await user.click(await screen.findByRole('button', {name: 'reservations'}));
+    await user.click(await screen.findByRole('checkbox', {name: 'bookings:reservations:update'}));
+    // Both 'bookings:reservations' and 'bookings' cover the action, so neither may survive.
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith([]);
+    });
+  });
+
+  it('unticking an action leaves sibling permissions untouched', async () => {
+    const user = userEvent.setup();
+    const onChange = renderCatalog({
+      selected: [{resourceServerId: 'rs-1', permissions: ['bookings', 'bookings:create', 'health:ping']}],
+    });
+    await user.click(screen.getByRole('button', {name: 'Booking API'}));
+    await waitFor(() => expect(screen.getByText('Bookings')).toBeInTheDocument());
+    await user.click(screen.getByRole('button', {name: 'bookings'}));
+    await user.click(await screen.findByRole('checkbox', {name: 'bookings:create'}));
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith([{resourceServerId: 'rs-1', permissions: ['health:ping']}]);
+    });
+  });
+
   it('clicking a fully-selected resource checkbox clears the subtree', async () => {
     const user = userEvent.setup();
     const fullySelected: ResourcePermissions[] = [

--- a/frontend/packages/configure-resource-servers/src/utils/__tests__/permissionSelection.test.ts
+++ b/frontend/packages/configure-resource-servers/src/utils/__tests__/permissionSelection.test.ts
@@ -8,6 +8,7 @@ import {
   togglePermission,
   mergePermissions,
   removePermissions,
+  ancestorPermissions,
   getSubtreeSelectionState,
   arePermissionsEqual,
 } from '../permissionSelection';
@@ -29,14 +30,33 @@ describe('permissionSelection utils', () => {
     });
   });
 
+  describe('ancestorPermissions', () => {
+    it('lists every enclosing resource permission', () => {
+      expect(ancestorPermissions('bookings:reservations:update', ':')).toEqual(['bookings', 'bookings:reservations']);
+    });
+
+    it('returns nothing for a flat permission', () => {
+      expect(ancestorPermissions('list', ':')).toEqual([]);
+    });
+
+    it('honours the resource server delimiter', () => {
+      expect(ancestorPermissions('flights-delete', '-')).toEqual(['flights']);
+      expect(ancestorPermissions('flights-delete', ':')).toEqual([]);
+    });
+
+    it('returns nothing when the delimiter is unknown', () => {
+      expect(ancestorPermissions('bookings:create', '')).toEqual([]);
+    });
+  });
+
   describe('togglePermission', () => {
     it('adds a permission for a new server', () => {
-      const result = togglePermission([], 'rs-1', 'bookings');
+      const result = togglePermission([], 'rs-1', 'bookings', ':');
       expect(result).toEqual([{resourceServerId: 'rs-1', permissions: ['bookings']}]);
     });
 
     it('adds a permission to an existing server entry', () => {
-      const result = togglePermission(base, 'rs-2', 'payments:charge');
+      const result = togglePermission(base, 'rs-2', 'payments:charge', ':');
       expect(result.find((e) => e.resourceServerId === 'rs-2')?.permissions).toEqual([
         'payments:refund',
         'payments:charge',
@@ -44,19 +64,48 @@ describe('permissionSelection utils', () => {
     });
 
     it('removes a permission that is already selected', () => {
-      const result = togglePermission(base, 'rs-1', 'bookings');
+      const result = togglePermission(base, 'rs-1', 'bookings', ':');
       expect(result.find((e) => e.resourceServerId === 'rs-1')?.permissions).toEqual(['bookings:create']);
     });
 
+    it('also removes the resource permissions that would still confer it', () => {
+      const list = [
+        {
+          resourceServerId: 'rs-1',
+          permissions: ['bookings', 'bookings:reservations', 'bookings:reservations:update', 'payments:refund'],
+        },
+      ];
+      const result = togglePermission(list, 'rs-1', 'bookings:reservations:update', ':');
+      expect(result[0].permissions).toEqual(['payments:refund']);
+    });
+
+    it('strips ancestors under a non-colon delimiter', () => {
+      const list = [{resourceServerId: 'rs-1', permissions: ['flights', 'flights-create', 'flights-delete']}];
+      const result = togglePermission(list, 'rs-1', 'flights-delete', '-');
+      expect(result[0].permissions).toEqual(['flights-create']);
+    });
+
+    it('leaves resources whose permission merely shares a prefix', () => {
+      const list = [{resourceServerId: 'rs-1', permissions: ['bookings-archive', 'bookings:create']}];
+      const result = togglePermission(list, 'rs-1', 'bookings:create', ':');
+      expect(result[0].permissions).toEqual(['bookings-archive']);
+    });
+
+    it('does not strip ancestors when adding a permission', () => {
+      const list = [{resourceServerId: 'rs-1', permissions: ['bookings']}];
+      const result = togglePermission(list, 'rs-1', 'bookings:create', ':');
+      expect(result[0].permissions).toEqual(['bookings', 'bookings:create']);
+    });
+
     it('drops the server entry entirely when its last permission is removed', () => {
-      const result = togglePermission(base, 'rs-2', 'payments:refund');
+      const result = togglePermission(base, 'rs-2', 'payments:refund', ':');
       expect(result.find((e) => e.resourceServerId === 'rs-2')).toBeUndefined();
       expect(result).toHaveLength(1);
     });
 
     it('does not mutate the input', () => {
       const snapshot: ResourcePermissions[] = JSON.parse(JSON.stringify(base)) as ResourcePermissions[];
-      togglePermission(base, 'rs-1', 'bookings');
+      togglePermission(base, 'rs-1', 'bookings', ':');
       expect(base).toEqual(snapshot);
     });
   });

--- a/frontend/packages/configure-resource-servers/src/utils/permissionSelection.ts
+++ b/frontend/packages/configure-resource-servers/src/utils/permissionSelection.ts
@@ -13,18 +13,33 @@ export function isPermissionSelected(
   return list.some((entry) => entry.resourceServerId === resourceServerId && entry.permissions.includes(permission));
 }
 
+/**
+ * Lists the permissions of the resources a permission sits under, nearest first. Permission strings
+ * are built as `parent + delimiter + handle` and handles may not contain the delimiter, so every
+ * prefix of a permission is exactly one of its ancestors.
+ */
+export function ancestorPermissions(permission: string, delimiter: string): string[] {
+  if (!delimiter) return [];
+  const segments = permission.split(delimiter);
+  return segments.slice(0, -1).map((_, index) => segments.slice(0, index + 1).join(delimiter));
+}
+
 export function togglePermission(
   list: ResourcePermissions[],
   resourceServerId: string,
   permission: string,
+  delimiter: string,
 ): ResourcePermissions[] {
   const existing = list.find((entry) => entry.resourceServerId === resourceServerId);
   if (!existing) {
     return [...list, {resourceServerId, permissions: [permission]}];
   }
 
+  // An ancestor confers every permission beneath it, so dropping only the permission itself would
+  // leave the role still holding it through the ancestor.
+  const removed = new Set([permission, ...ancestorPermissions(permission, delimiter)]);
   const updatedPermissions = existing.permissions.includes(permission)
-    ? existing.permissions.filter((p) => p !== permission)
+    ? existing.permissions.filter((p) => !removed.has(p))
     : [...existing.permissions, permission];
 
   if (updatedPermissions.length === 0) {


### PR DESCRIPTION
### Purpose
Unselecting a child action in the role Permissions tab left the resource-level scope
behind. The role kept holding a scope that still confers the action just revoked, so
requesting the parent scope re-granted it. Fixes #4752.

https://github.com/user-attachments/assets/c3fa5f66-b8ae-4184-9101-643b628bfaf7


### Approach
`togglePermission` now takes the resource server's delimiter. When removing a
permission it also removes every ancestor that would still confer it, derived by
splitting on the delimiter — permission strings are built as
`parent + delimiter + handle` and handles may not contain the delimiter, so every
prefix is exactly one ancestor.

Unselecting `bookings:reservations:update` now also drops `bookings:reservations`
and `bookings`.

Backend unchanged: via the API both permissions together are a legitimate grant, and
the server cannot tell a deliberate resource-level grant from a stale one.

Not addressed here: selecting a resource still grants the resource scope plus its
actions redundantly, and there is no way to grant the resource scope alone. Both
pre-date this change.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4752

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission removal behavior for nested actions and resource scopes.
  * Deselecting a permission now also removes related ancestor permissions when appropriate.
  * Preserved unrelated sibling permissions and correctly supports custom permission delimiters.
* **Tests**
  * Added coverage for nested permissions, ancestor handling, unknown delimiters, and resource server actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->