### PR TITLE
Add support for alphanumeric OTP input handling

### DIFF
--- a/backend/internal/flow/common/constants.go
+++ b/backend/internal/flow/common/constants.go
@@ -89,6 +89,9 @@ const (
 	// DataOTPLength is the character length of the OTP minted by the OTP executor in generate mode,
 	// surfaced so the client renders the matching number of input boxes.
 	DataOTPLength = "otpLength"
+	// DataOTPNumericOnly reports whether the OTP minted by the OTP executor in generate mode contains
+	// digits only, surfaced so the client restricts input to the characters the user has to type.
+	DataOTPNumericOnly = "otpNumericOnly"
 )
 
 // Error assertion claims.

--- a/backend/internal/flow/executor/otp_executor.go
+++ b/backend/internal/flow/executor/otp_executor.go
@@ -167,6 +167,7 @@ func (e *otpExecutor) executeGenerate(ctx *providers.NodeContext,
 	// Published from the generated value rather than the configured otpLength property, since the
 	// property is clamped and may fall back to the server default.
 	execResp.AdditionalData[common.DataOTPLength] = strconv.Itoa(len(otpValue))
+	execResp.AdditionalData[common.DataOTPNumericOnly] = strconv.FormatBool(isNumericOTP(otpValue))
 	execResp.ForwardedData[common.ForwardedDataKeyTemplateData] = map[string]interface{}{
 		common.ForwardedDataKeyOTPCode:    otpValue,
 		common.ForwardedDataKeyExpiryTime: systemutils.FormatExpiryDuration(expirySeconds),
@@ -410,6 +411,16 @@ func (e *otpExecutor) resolveOTPProperties(ctx *providers.NodeContext) *notifcom
 		return nil
 	}
 	return &cfg
+}
+
+// isNumericOTP reports whether the OTP consists solely of ASCII digits.
+func isNumericOTP(otpValue string) bool {
+	for _, r := range otpValue {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // getMaxOTPAttempts returns the maximum OTP generation attempts from NodeProperties,

--- a/backend/internal/flow/executor/otp_executor_test.go
+++ b/backend/internal/flow/executor/otp_executor_test.go
@@ -151,6 +151,7 @@ func (suite *OTPExecutorTestSuite) TestExecuteGenerate_Success_UserIdentifiedAnd
 	assert.Equal(suite.T(), "session-tok-1", resp.RuntimeData[common.RuntimeKeyOTPSessionToken])
 	assert.Equal(suite.T(), "1", resp.RuntimeData[common.RuntimeKeyOTPAttemptCount])
 	assert.Equal(suite.T(), "6", resp.AdditionalData[common.DataOTPLength])
+	assert.Equal(suite.T(), "true", resp.AdditionalData[common.DataOTPNumericOnly])
 	fwdData, ok := resp.ForwardedData[common.ForwardedDataKeyTemplateData].(map[string]interface{})
 	assert.True(suite.T(), ok)
 	assert.Equal(suite.T(), "654321", fwdData[common.ForwardedDataKeyOTPCode])
@@ -218,6 +219,40 @@ func (suite *OTPExecutorTestSuite) TestExecuteGenerate_PublishedLengthFollowsGen
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "6", resp.AdditionalData[common.DataOTPLength])
+}
+
+// The otpUseNumericOnly property is merged with the server default inside the OTP service, so the
+// published flag must come from the generated value rather than the property.
+func (suite *OTPExecutorTestSuite) TestExecuteGenerate_PublishesNumericOnlyFalseForAlphanumericOTP() {
+	userID := testOTPUserID
+	suite.mockEntityProvider.On("IdentifyEntity", mock.Anything).Return(&userID, nil)
+
+	suite.mockOTPService.On("GenerateOTP",
+		mock.Anything, userID, authnprovidercm.UserAttributeUserID,
+		mock.Anything).
+		Return("session-tok-alnum", "K7GX2M", int64(300), (*tidcommon.ServiceError)(nil))
+
+	ctx := &providers.NodeContext{
+		ExecutionID:  "exec-otp-alnum",
+		FlowType:     providers.FlowTypeAuthentication,
+		ExecutorMode: ExecutorModeGenerate,
+		NodeInputs: []providers.Input{
+			{Ref: "mobile_input", Identifier: common.AttributeMobileNumber,
+				Type: providers.InputTypePhone, Required: true},
+		},
+		NodeProperties: map[string]interface{}{propertyKeyOTPUseNumericOnly: false},
+		UserInputs: map[string]string{
+			common.AttributeMobileNumber: "+1234567890",
+		},
+		RuntimeData: map[string]string{},
+	}
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecComplete, resp.Status)
+	assert.Equal(suite.T(), "6", resp.AdditionalData[common.DataOTPLength])
+	assert.Equal(suite.T(), "false", resp.AdditionalData[common.DataOTPNumericOnly])
 }
 
 func (suite *OTPExecutorTestSuite) TestExecuteGenerate_MultipleInputs_IdentifiesUserByAllAttrs() {

--- a/frontend/packages/design/src/components/flow/adapters/OtpInputAdapter.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/OtpInputAdapter.tsx
@@ -8,6 +8,10 @@ import {useTranslation} from 'react-i18next';
 import type {FlowFieldProps} from '../../../models/flow';
 
 const DEFAULT_OTP_LENGTH = 6;
+const NUMERIC_OTP_CHARS = /^[0-9]*$/;
+const ALPHANUMERIC_OTP_CHARS = /^[0-9A-Z]*$/;
+const NON_NUMERIC_OTP_CHARS = /[^0-9]/g;
+const NON_ALPHANUMERIC_OTP_CHARS = /[^0-9A-Z]/g;
 
 export default function OtpInputAdapter({
   component,
@@ -29,6 +33,14 @@ export default function OtpInputAdapter({
   // user received. Falls back to the common six digits when the step carries no length.
   const reportedLength = Number(additionalData?.['otpLength']);
   const otpLength = Number.isInteger(reportedLength) && reportedLength > 0 ? reportedLength : DEFAULT_OTP_LENGTH;
+
+  // The server reports whether the code it generated is digits only. Anything else, including an
+  // older server that omits the flag, keeps the numeric-only behaviour.
+  const numericOnly = additionalData?.['otpNumericOnly'] !== 'false';
+  const allowedPattern = numericOnly ? NUMERIC_OTP_CHARS : ALPHANUMERIC_OTP_CHARS;
+  const disallowedPattern = numericOnly ? NON_NUMERIC_OTP_CHARS : NON_ALPHANUMERIC_OTP_CHARS;
+  // Alphanumeric codes are minted from an uppercase charset and verified case-sensitively.
+  const normalize = (input: string): string => (numericOnly ? input : input.toUpperCase());
 
   const hasError = !!(touched?.[ref] && fieldErrors?.[ref]);
   const otpValue = values[ref] ?? '';
@@ -60,14 +72,15 @@ export default function OtpInputAdapter({
             slotProps={{
               htmlInput: {
                 maxLength: 1,
+                inputMode: numericOnly ? 'numeric' : 'text',
                 style: {textAlign: 'center', fontSize: '1.5rem'},
                 'aria-label': `OTP digit ${idx + 1}`,
               },
             }}
             value={digit.trim()}
             onChange={(e) => {
-              const {value} = e.target;
-              if (!/^\d*$/.test(value)) return;
+              const value = normalize(e.target.value);
+              if (!allowedPattern.test(value)) return;
               const newOtp = otpDigits.map((d, i) => (i === idx ? value : d));
               onInputChange(ref, newOtp.join(''));
               if (value && idx < otpLength - 1) focusDigit(idx + 1);
@@ -77,7 +90,9 @@ export default function OtpInputAdapter({
             }}
             onPaste={(e) => {
               e.preventDefault();
-              const digits = e.clipboardData.getData('text/plain').replace(/\D/g, '').slice(0, otpLength);
+              const digits = normalize(e.clipboardData.getData('text/plain'))
+                .replace(disallowedPattern, '')
+                .slice(0, otpLength);
               onInputChange(ref, digits);
               focusDigit(Math.min(digits.length, otpLength - 1));
             }}

--- a/frontend/packages/design/src/components/flow/adapters/__tests__/OtpInputAdapter.test.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/__tests__/OtpInputAdapter.test.tsx
@@ -66,6 +66,84 @@ describe('OtpInputAdapter', () => {
     expect(onInputChange).toHaveBeenCalledWith('otp', '12345678');
   });
 
+  it('rejects a letter when the step reports a numeric-only code', () => {
+    const onInputChange = vi.fn();
+    const {container} = renderWithProviders(
+      <OtpInputAdapter {...baseProps} onInputChange={onInputChange} additionalData={{otpNumericOnly: 'true'}} />,
+    );
+
+    fireEvent.change(digitBoxes(container)[0], {target: {value: 'a'}});
+
+    expect(onInputChange).not.toHaveBeenCalled();
+  });
+
+  it('rejects a letter when the step reports no character set', () => {
+    const onInputChange = vi.fn();
+    const {container} = renderWithProviders(<OtpInputAdapter {...baseProps} onInputChange={onInputChange} />);
+
+    fireEvent.change(digitBoxes(container)[0], {target: {value: 'a'}});
+
+    expect(onInputChange).not.toHaveBeenCalled();
+  });
+
+  it('accepts a letter when the step reports an alphanumeric code', () => {
+    const onInputChange = vi.fn();
+    const {container} = renderWithProviders(
+      <OtpInputAdapter {...baseProps} onInputChange={onInputChange} additionalData={{otpNumericOnly: 'false'}} />,
+    );
+
+    fireEvent.change(digitBoxes(container)[0], {target: {value: 'K'}});
+
+    expect(onInputChange).toHaveBeenCalledWith('otp', 'K     ');
+  });
+
+  it('upper-cases a lowercase letter for an alphanumeric code', () => {
+    const onInputChange = vi.fn();
+    const {container} = renderWithProviders(
+      <OtpInputAdapter {...baseProps} onInputChange={onInputChange} additionalData={{otpNumericOnly: 'false'}} />,
+    );
+
+    fireEvent.change(digitBoxes(container)[0], {target: {value: 'k'}});
+
+    expect(onInputChange).toHaveBeenCalledWith('otp', 'K     ');
+  });
+
+  it('strips surrounding text when pasting a numeric code', () => {
+    const onInputChange = vi.fn();
+    const {container} = renderWithProviders(<OtpInputAdapter {...baseProps} onInputChange={onInputChange} />);
+
+    const pasteEvent = new Event('paste', {bubbles: true, cancelable: true});
+    Object.defineProperty(pasteEvent, 'clipboardData', {value: {getData: () => 'Your code is 123456'}});
+    fireEvent(digitBoxes(container)[0], pasteEvent);
+
+    expect(onInputChange).toHaveBeenCalledWith('otp', '123456');
+  });
+
+  it('upper-cases and keeps letters when pasting an alphanumeric code', () => {
+    const onInputChange = vi.fn();
+    const {container} = renderWithProviders(
+      <OtpInputAdapter {...baseProps} onInputChange={onInputChange} additionalData={{otpNumericOnly: 'false'}} />,
+    );
+
+    const pasteEvent = new Event('paste', {bubbles: true, cancelable: true});
+    Object.defineProperty(pasteEvent, 'clipboardData', {value: {getData: () => 'k7gx2m'}});
+    fireEvent(digitBoxes(container)[0], pasteEvent);
+
+    expect(onInputChange).toHaveBeenCalledWith('otp', 'K7GX2M');
+  });
+
+  it('marks the boxes numeric only when the code is digits only', () => {
+    const {container} = renderWithProviders(<OtpInputAdapter {...baseProps} />);
+    expect(digitBoxes(container)[0].getAttribute('inputmode')).toBe('numeric');
+  });
+
+  it('marks the boxes text when the code is alphanumeric', () => {
+    const {container} = renderWithProviders(
+      <OtpInputAdapter {...baseProps} additionalData={{otpNumericOnly: 'false'}} />,
+    );
+    expect(digitBoxes(container)[0].getAttribute('inputmode')).toBe('text');
+  });
+
   it('returns null when ref is missing', () => {
     const noRefProps = {...baseProps, component: {...baseProps.component, ref: undefined}};
     const {container} = renderWithProviders(<OtpInputAdapter {...noRefProps} />);

--- a/tests/integration/flow/authentication/sms_auth_test.go
+++ b/tests/integration/flow/authentication/sms_auth_test.go
@@ -500,6 +500,11 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowWithMobileNumber() {
 	ts.Require().Equal("8", otpFlowStep.Data.AdditionalData["otpLength"],
 		"OTP step should report the configured OTP length")
 
+	// The generate node leaves otpUseNumericOnly at the numeric-only server default, so the OTP step
+	// must report that the client should restrict input to digits.
+	ts.Require().Equal("true", otpFlowStep.Data.AdditionalData["otpNumericOnly"],
+		"OTP step should report the OTP character set")
+
 	// Wait for SMS to be sent
 	time.Sleep(500 * time.Millisecond)
 


### PR DESCRIPTION
### Purpose

This pull request enhances the OTP (One-Time Password) flow to support both numeric and alphanumeric OTP codes, ensuring that the client UI adapts its input restrictions based on the actual type of OTP generated by the backend. The backend now reports whether an OTP is digits-only or alphanumeric, and the frontend uses this information to enforce the correct input pattern and normalization. Comprehensive tests have been added to verify the new behavior across both backend and frontend.

---

### Approach

**Backend changes:**

* The backend now publishes a new `otpNumericOnly` flag in `AdditionalData` to indicate whether the generated OTP consists solely of digits or may include uppercase letters. [[1]](diffhunk://#diff-9efdd475ef67a1c9e9acb315486fdf7b3fdd9de00897898495ea69c599cbf79dR92-R94) [[2]](diffhunk://#diff-401ba20fc58d4a8670e72b8bc2f90b4c5917efefeeba4b6d04f005247da99446R170)
* A helper function `isNumericOTP` was added to determine if an OTP is numeric-only, and backend tests were updated and extended to verify correct publication of the flag for both numeric and alphanumeric OTPs. [[1]](diffhunk://#diff-401ba20fc58d4a8670e72b8bc2f90b4c5917efefeeba4b6d04f005247da99446R416-R425) [[2]](diffhunk://#diff-63bb209d3457d7d54371ef7b025df0a5aca83c074f9cb0bb9da990bbfde39782R154) [[3]](diffhunk://#diff-63bb209d3457d7d54371ef7b025df0a5aca83c074f9cb0bb9da990bbfde39782R223-R256)
* Integration tests were updated to assert that the `otpNumericOnly` flag is correctly set during authentication flows.

**Frontend changes:**

* The OTP input component (`OtpInputAdapter.tsx`) now reads the `otpNumericOnly` flag from the backend and restricts user input accordingly: digits only for numeric OTPs, or uppercase alphanumeric for alphanumeric OTPs. Input normalization and allowed patterns are dynamically set, and the input mode is switched between numeric and text as appropriate. [[1]](diffhunk://#diff-10fda609043201add70bf0fa7ef1f55932938a04164b509bf55f1a865ba8bb1bR33-R40) [[2]](diffhunk://#diff-10fda609043201add70bf0fa7ef1f55932938a04164b509bf55f1a865ba8bb1bR71-R79) [[3]](diffhunk://#diff-10fda609043201add70bf0fa7ef1f55932938a04164b509bf55f1a865ba8bb1bL80-R91)
* Frontend tests were added and extended to ensure that the input component enforces the correct character restrictions, normalizes input case, and handles paste events as expected for both numeric and alphanumeric OTPs.

These changes ensure a consistent and user-friendly OTP entry experience that matches the server-generated code format and improves overall security and usability.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4758

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OTP verification now supports numeric and uppercase alphanumeric codes.
  * Input behavior adapts automatically to the code format, including validation and paste handling.
  * Generated OTP responses now report whether the code contains only numbers.
  * SMS authentication responses include the numeric-only status alongside the code length.

* **Bug Fixes**
  * Alphanumeric codes are normalized to uppercase, while unsupported characters are filtered.
  * Numeric OTP entry continues to reject letters and other invalid characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->