### PR TITLE
Fix agent use case setup in the npx CLI

### DIFF
--- a/samples/apps/wayfinder-sample/ai-agent/.env.example
+++ b/samples/apps/wayfinder-sample/ai-agent/.env.example
@@ -5,7 +5,7 @@ LLM_PROVIDER=anthropic
 # LLM API key obtained from your LLM provider.
 LLM_API_KEY=your-llm-api-key
 
-# Model name override. Defaults to claude-sonnet-4-6 (Anthropic) or gemini-3.1-flash-lite (Gemini).
+# Model name override. Defaults to claude-sonnet-4-6 (Anthropic) or gemini-2.5-flash (Gemini).
 # MODEL_NAME=
 
 # --- Thunder ---

--- a/tools/cli/internal/cli/root.go
+++ b/tools/cli/internal/cli/root.go
@@ -202,7 +202,7 @@ func replLoop(version, installPath string, proc *exec.Cmd, verbose, isFirstRun b
 			if upgraded {
 				return // upgrade ran its own REPL internally
 			}
-			// Already latest or cancelled — Thunder is still running; reattach.
+			// Already latest or cancelled — ThunderID is still running; reattach.
 			continue
 		}
 

--- a/tools/cli/internal/commands/sample/sample.go
+++ b/tools/cli/internal/commands/sample/sample.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -28,6 +30,7 @@ type Options struct {
 	Config    map[string]string // key/value pairs to write into the target service's .env
 	EnvTarget string            // sample sub-dir to write the .env into (e.g. "ai-agent")
 	Features  []string          // feature tags, e.g. ["ai"] — drive optional services and frontend flags
+	Port      int               // port the running product is bound to; 0 = the default port
 }
 
 // hasFeature reports whether tag is present in opts.Features.
@@ -207,10 +210,15 @@ func runWithResult(
 		return nil, "", "", fmt.Errorf("could not read env file: %w", err)
 	}
 
-	// Stop the product.
+	// Stop the product. The REPL may have moved it off the default port after a
+	// conflict, so every port operation below follows opts.Port when it is set.
+	port := opts.Port
+	if port <= 0 {
+		port = health.DefaultPort
+	}
 	progress("Stopping " + product.Name + "...")
-	setup.KillPort(health.DefaultPort)
-	setup.WaitForPortFree(health.DefaultPort, 15*time.Second)
+	setup.KillPort(port)
+	setup.WaitForPortFree(port, 15*time.Second)
 
 	// Find ThunderID root and write resource files.
 	thunderRoot, err := setup.FindThunderRoot(installPath)
@@ -224,13 +232,13 @@ func runWithResult(
 
 	// Start the product.
 	progress("Starting " + product.Name + "...")
-	proc, err := setup.StartBackground(installPath, false)
+	proc, err := setup.StartBackgroundOnPort(installPath, false, opts.Port)
 	if err != nil {
 		return nil, "", "", fmt.Errorf("could not start %s: %w", product.Name, err)
 	}
 
 	// Wait for the product to be ready.
-	serverURL, ready := health.ResolveBaseURL(health.DefaultPort, 60*time.Second)
+	serverURL, ready := health.ResolveBaseURL(port, 60*time.Second)
 	if !ready {
 		return proc, meta.sampleURL, "",
 			fmt.Errorf("%s did not become ready within 60 seconds — check logs at %s",
@@ -251,8 +259,11 @@ func runWithResult(
 
 	// Write service .env files so each process starts with the right credentials.
 	aiEnabled := hasFeature(opts, "ai")
-	if err := writeFrontendEnv(sampleDir, serverURL, aiEnabled); err != nil {
+	if err := writeFrontendEnv(sampleDir, serverURL, vars, aiEnabled); err != nil {
 		return proc, meta.sampleURL, serverURL, fmt.Errorf("could not write frontend env: %w", err)
+	}
+	if err := writeBaseURLEnvs(sampleDir, serverURL); err != nil {
+		return proc, meta.sampleURL, serverURL, fmt.Errorf("could not write service env: %w", err)
 	}
 	if aiEnabled && opts.EnvTarget != "" {
 		if err := writeServiceEnv(sampleDir, serverURL, vars, opts); err != nil {
@@ -275,6 +286,14 @@ func runWithResult(
 	progress("Starting " + sampleName + " services...")
 	if err := startSampleServices(sampleDir, aiEnabled); err != nil {
 		return proc, meta.sampleURL, serverURL, fmt.Errorf("could not start sample: %w", err)
+	}
+
+	// `npm run dev` keeps running when a single workspace exits, so a crashed
+	// service is invisible to the parent process. Confirm each one is accepting
+	// connections before reporting the sample as ready.
+	progress("Waiting for " + sampleName + " services...")
+	if err := waitForSampleServices(sampleDir, aiEnabled, sampleReadyTimeout); err != nil {
+		return proc, meta.sampleURL, serverURL, err
 	}
 
 	return proc, meta.sampleURL, serverURL, nil
@@ -341,22 +360,11 @@ func SampleDir(installPath, sampleName string) string {
 	return filepath.Join(filepath.Dir(installPath), "samples", sampleName)
 }
 
-// ReadServiceEnv reads key/value pairs from <sampleDir>/<envTarget>/.env.
-// Returns an empty map if the file does not exist.
-// Provider-specific API keys (ANTHROPIC_API_KEY, GOOGLE_API_KEY) are reverse-mapped
-// to the generic LLM_API_KEY so the REPL can pre-populate the prompt on subsequent runs.
+// ReadServiceEnv reads key/value pairs from <sampleDir>/<envTarget>/.env so the
+// REPL can pre-populate its prompts on subsequent runs. Returns an empty map if
+// the file does not exist.
 func ReadServiceEnv(sampleDir, envTarget string) map[string]string {
 	vals, _ := parseEnvFile(filepath.Join(sampleDir, envTarget, ".env"))
-	if _, ok := vals["LLM_API_KEY"]; !ok {
-		provider := strings.ToLower(vals["LLM_PROVIDER"])
-		if provider == "gemini" || provider == "google" {
-			if v := vals["GOOGLE_API_KEY"]; v != "" {
-				vals["LLM_API_KEY"] = v
-			}
-		} else if v := vals["ANTHROPIC_API_KEY"]; v != "" {
-			vals["LLM_API_KEY"] = v
-		}
-	}
 	return vals
 }
 
@@ -443,44 +451,105 @@ func splitYAML(content string) []string {
 	return docs
 }
 
-// writeFrontendEnv writes frontend/.env with Thunder client config and the
+// writeFrontendEnv updates frontend/.env with ThunderID client config and the
 // VITE_AI_FEATURES_ENABLED flag so the React dev server picks up the right mode.
-func writeFrontendEnv(sampleDir, thunderURL string, aiEnabled bool) error {
-	enabled := "false"
-	if aiEnabled {
-		enabled = "true"
+// Keys the sample ships (VITE_THUNDER_APP_ID, VITE_AUTH_IS_REDIRECT_BASED, ...)
+// are preserved.
+func writeFrontendEnv(sampleDir, baseURL string, vars map[string]string, aiEnabled bool) error {
+	path := filepath.Join(sampleDir, "frontend", ".env")
+	env, err := parseEnvFile(path)
+	if err != nil {
+		return err
 	}
-	content := "VITE_THUNDER_CLIENT_ID=WAYFINDER\n" +
-		"VITE_THUNDER_BASE_URL=" + thunderURL + "\n" +
-		"VITE_AI_FEATURES_ENABLED=" + enabled + "\n"
-	return os.WriteFile(filepath.Join(sampleDir, "frontend", ".env"), []byte(content), 0o644)
+	clientID := vars["WAYFINDER_CLIENT_ID"]
+	if clientID == "" {
+		clientID = "WAYFINDER"
+	}
+	env["VITE_THUNDER_CLIENT_ID"] = clientID
+	env["VITE_THUNDER_BASE_URL"] = baseURL
+	env["VITE_AI_FEATURES_ENABLED"] = strconv.FormatBool(aiEnabled)
+	return writeEnvFile(path, env)
 }
 
-// writeServiceEnv writes <opts.EnvTarget>/.env combining standard Thunder
-// credentials (from the thunderid.env vars map) with every key/value in opts.Config.
-func writeServiceEnv(sampleDir, thunderURL string, vars map[string]string, opts Options) error {
-	var b strings.Builder
-	b.WriteString("THUNDER_BASE_URL=" + thunderURL + "\n")
-	if v := vars["AGENT_CLIENT_ID"]; v != "" {
-		b.WriteString("AGENT_ID=" + v + "\n")
-	}
-	if v := vars["AGENT_CLIENT_SECRET"]; v != "" {
-		b.WriteString("AGENT_SECRET=" + v + "\n")
-	}
-	b.WriteString("AGENT_REDIRECT_URI=http://localhost:5173/agent-callback\n")
-	b.WriteString("AGENT_ACCESS_SCOPE=agent:access\n")
-	for k, v := range opts.Config {
-		if k == "LLM_API_KEY" {
-			provider := strings.ToLower(opts.Config["LLM_PROVIDER"])
-			if provider == "gemini" || provider == "google" {
-				k = "GOOGLE_API_KEY"
-			} else {
-				k = "ANTHROPIC_API_KEY"
-			}
+// baseURLServices are sample services whose .env ships with the default
+// ThunderID URL baked in. They need rewriting whenever the product runs on a
+// different port, or their token validation points at the wrong server.
+var baseURLServices = []string{"backend", "lounge"}
+
+// writeBaseURLEnvs points every such service at the URL the product actually
+// came up on. Services the sample does not ship are skipped.
+func writeBaseURLEnvs(sampleDir, baseURL string) error {
+	for _, service := range baseURLServices {
+		path := filepath.Join(sampleDir, service, ".env")
+		if _, err := os.Stat(path); err != nil {
+			continue
 		}
-		b.WriteString(k + "=" + v + "\n")
+		env, err := parseEnvFile(path)
+		if err != nil {
+			return err
+		}
+		env["THUNDER_BASE_URL"] = baseURL
+		if err := writeEnvFile(path, env); err != nil {
+			return err
+		}
 	}
-	return os.WriteFile(filepath.Join(sampleDir, opts.EnvTarget, ".env"), []byte(b.String()), 0o644)
+	return nil
+}
+
+// writeServiceEnv updates <opts.EnvTarget>/.env with the ThunderID credentials from
+// the thunderid.env vars map plus every key/value in opts.Config. Keys are written
+// under the names the sample reads; keys already in the file that the CLI has no
+// value for (MCP_SERVER_URL, UPGRADE_SCHEDULER_ENABLED, ...) are preserved.
+func writeServiceEnv(sampleDir, baseURL string, vars map[string]string, opts Options) error {
+	path := filepath.Join(sampleDir, opts.EnvTarget, ".env")
+	env, err := parseEnvFile(path)
+	if err != nil {
+		return err
+	}
+
+	env["THUNDER_BASE_URL"] = baseURL
+	setIfNotEmpty(env, "AGENT_ID", vars["AGENT_CLIENT_ID"])
+	setIfNotEmpty(env, "AGENT_SECRET", vars["AGENT_CLIENT_SECRET"])
+	setIfNotEmpty(env, "UPGRADE_AGENT_ID", vars["UPGRADE_AGENT_CLIENT_ID"])
+	setIfNotEmpty(env, "UPGRADE_AGENT_SECRET", vars["UPGRADE_AGENT_CLIENT_SECRET"])
+	env["AGENT_REDIRECT_URI"] = "http://localhost:5173/agent-callback"
+	env["AGENT_ACCESS_SCOPE"] = "agent:access"
+
+	// The upgrade scheduler polls for pending upgrades over CIBA, which needs the
+	// email or SMS flow configured. A try-out has neither, so it stays off unless
+	// the operator turned it on themselves.
+	if _, ok := env["UPGRADE_SCHEDULER_ENABLED"]; !ok {
+		env["UPGRADE_SCHEDULER_ENABLED"] = "false"
+	}
+
+	for k, v := range opts.Config {
+		env[k] = v
+	}
+	return writeEnvFile(path, env)
+}
+
+// setIfNotEmpty assigns value to key only when the source variable was populated,
+// so a missing entry in thunderid.env leaves any existing value alone.
+func setIfNotEmpty(env map[string]string, key, value string) {
+	if value != "" {
+		env[key] = value
+	}
+}
+
+// writeEnvFile writes KEY=VALUE lines sorted by key, so repeated runs produce an
+// identical file instead of reshuffling with Go's map iteration order.
+func writeEnvFile(path string, env map[string]string) error {
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString(k + "=" + env[k] + "\n")
+	}
+	return os.WriteFile(path, []byte(b.String()), 0o644)
 }
 
 // sampleServicePorts returns the localhost ports the sample's dev services bind,
@@ -498,6 +567,53 @@ func sampleServicePorts(aiEnabled bool) []int {
 		ports = append(ports, 8790) // ai-agent
 	}
 	return ports
+}
+
+// sampleReadyTimeout bounds how long the sample's services get to bind their
+// ports. A cold `npm run dev` builds the frontend first, so this is generous.
+const sampleReadyTimeout = 120 * time.Second
+
+// serviceCheck is one readiness probe: the port a service binds and the name to
+// report when it never opens.
+type serviceCheck struct {
+	port int
+	name string
+}
+
+// readinessChecks returns the services that must be up for the sample's
+// walkthroughs to work. The SMTP inbox and lounge kiosk are optional extras, so
+// they are started but not gated on.
+func readinessChecks(aiEnabled bool) []serviceCheck {
+	checks := []serviceCheck{
+		{port: 5173, name: "frontend"},
+		{port: 8787, name: "backend API"},
+	}
+	if aiEnabled {
+		checks = append(checks, serviceCheck{port: 8790, name: "ai-agent"})
+	}
+	return checks
+}
+
+// waitForSampleServices blocks until every required service accepts connections.
+func waitForSampleServices(sampleDir string, aiEnabled bool, timeout time.Duration) error {
+	logPath := filepath.Join(sampleDir, "logs", "sample.log")
+	return waitForServices(readinessChecks(aiEnabled), logPath, timeout)
+}
+
+// waitForServices polls each check until its port opens, and reports the offending
+// service with the tail of its log once the shared deadline passes.
+func waitForServices(checks []serviceCheck, logPath string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for _, check := range checks {
+		for !setup.IsPortInUse(check.port) {
+			if time.Now().After(deadline) {
+				return fmt.Errorf("%s did not start on port %d — see %s\n%s",
+					check.name, check.port, logPath, tailLog(logPath, 20))
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
+	}
+	return nil
 }
 
 // startSampleServices launches the sample services in the background via npm.
@@ -561,9 +677,9 @@ func tailLog(path string, n int) string {
 	return strings.Join(lines, "\n")
 }
 
-func printSummary(sampleName, thunderURL, sampleURL string, features []string) {
+func printSummary(sampleName, baseURL, sampleURL string, features []string) {
 	fmt.Println()
-	fmt.Printf("  ✓ %s is ready at %s\n", product.Name, thunderURL)
+	fmt.Printf("  ✓ %s is ready at %s\n", product.Name, baseURL)
 	fmt.Printf("  ✓ Wayfinder is running at %s\n", sampleURL)
 	fmt.Println()
 

--- a/tools/cli/internal/commands/sample/sample_test.go
+++ b/tools/cli/internal/commands/sample/sample_test.go
@@ -4,11 +4,13 @@
 package sample
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/thunder-id/thunderid/tools/cli/internal/product"
 )
@@ -187,5 +189,256 @@ func TestWriteResourcesCommentedResourceType(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(thunderIDRoot, "config", "resources")); !os.IsNotExist(err) {
 		t.Error("commented resource_type must not be written")
+	}
+}
+
+// serviceDir creates <root>/<service> and returns the path of its .env.
+func serviceDir(t *testing.T, root, service string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, service), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", service, err)
+	}
+	return filepath.Join(root, service, ".env")
+}
+
+// readEnv parses a written .env back into a map.
+func readEnv(t *testing.T, path string) map[string]string {
+	t.Helper()
+	vals, err := parseEnvFile(path)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return vals
+}
+
+// sampleVars mirrors the variables the wayfinder thunderid.env supplies.
+var sampleVars = map[string]string{
+	"WAYFINDER_CLIENT_ID":         "WAYFINDER",
+	"AGENT_CLIENT_ID":             "WAYFINDER-CONCIERGE",
+	"AGENT_CLIENT_SECRET":         "agent-secret",
+	"UPGRADE_AGENT_CLIENT_ID":     "WAYFINDER-UPGRADE-AGENT",
+	"UPGRADE_AGENT_CLIENT_SECRET": "upgrade-secret",
+}
+
+// The agent reads its API key from LLM_API_KEY for every provider. Renaming it to
+// a provider-specific variable leaves the agent without a key and it exits at
+// startup, so the name must survive verbatim.
+func TestWriteServiceEnvUsesSampleKeyNames(t *testing.T) {
+	for _, provider := range []string{"anthropic", "gemini", "google"} {
+		t.Run(provider, func(t *testing.T) {
+			sampleDir := t.TempDir()
+			envPath := serviceDir(t, sampleDir, "ai-agent")
+			opts := Options{
+				EnvTarget: "ai-agent",
+				Config:    map[string]string{"LLM_PROVIDER": provider, "LLM_API_KEY": "secret-key"},
+			}
+
+			if err := writeServiceEnv(sampleDir, "https://localhost:8090", sampleVars, opts); err != nil {
+				t.Fatalf("writeServiceEnv: %v", err)
+			}
+
+			env := readEnv(t, envPath)
+			if env["LLM_API_KEY"] != "secret-key" {
+				t.Errorf("LLM_API_KEY: got %q, want %q", env["LLM_API_KEY"], "secret-key")
+			}
+			for _, renamed := range []string{"GOOGLE_API_KEY", "ANTHROPIC_API_KEY"} {
+				if _, ok := env[renamed]; ok {
+					t.Errorf("%s must not be written — the sample reads LLM_API_KEY", renamed)
+				}
+			}
+			if env["LLM_PROVIDER"] != provider {
+				t.Errorf("LLM_PROVIDER: got %q, want %q", env["LLM_PROVIDER"], provider)
+			}
+		})
+	}
+}
+
+// The upgrade scheduler authenticates with its own CIBA-only client, which the
+// sample reads from UPGRADE_AGENT_ID / UPGRADE_AGENT_SECRET.
+func TestWriteServiceEnvWritesAgentCredentials(t *testing.T) {
+	sampleDir := t.TempDir()
+	envPath := serviceDir(t, sampleDir, "ai-agent")
+	opts := Options{EnvTarget: "ai-agent"}
+
+	if err := writeServiceEnv(sampleDir, "https://localhost:9443", sampleVars, opts); err != nil {
+		t.Fatalf("writeServiceEnv: %v", err)
+	}
+
+	env := readEnv(t, envPath)
+	want := map[string]string{
+		"THUNDER_BASE_URL":     "https://localhost:9443",
+		"AGENT_ID":             "WAYFINDER-CONCIERGE",
+		"AGENT_SECRET":         "agent-secret",
+		"UPGRADE_AGENT_ID":     "WAYFINDER-UPGRADE-AGENT",
+		"UPGRADE_AGENT_SECRET": "upgrade-secret",
+		"AGENT_ACCESS_SCOPE":   "agent:access",
+	}
+	for k, v := range want {
+		if env[k] != v {
+			t.Errorf("%s: got %q, want %q", k, env[k], v)
+		}
+	}
+}
+
+// A try-out has no CIBA email or SMS flow configured, so the upgrade scheduler
+// must be off unless the operator turned it on themselves.
+func TestWriteServiceEnvDisablesUpgradeScheduler(t *testing.T) {
+	t.Run("absent", func(t *testing.T) {
+		sampleDir := t.TempDir()
+		envPath := serviceDir(t, sampleDir, "ai-agent")
+
+		if err := writeServiceEnv(sampleDir, "https://localhost:8090", sampleVars, Options{EnvTarget: "ai-agent"}); err != nil {
+			t.Fatalf("writeServiceEnv: %v", err)
+		}
+
+		if got := readEnv(t, envPath)["UPGRADE_SCHEDULER_ENABLED"]; got != "false" {
+			t.Errorf("UPGRADE_SCHEDULER_ENABLED: got %q, want false", got)
+		}
+	})
+
+	t.Run("operator opted in", func(t *testing.T) {
+		sampleDir := t.TempDir()
+		envPath := serviceDir(t, sampleDir, "ai-agent")
+		if err := os.WriteFile(envPath, []byte("UPGRADE_SCHEDULER_ENABLED=true\n"), 0o644); err != nil {
+			t.Fatalf("write env: %v", err)
+		}
+
+		if err := writeServiceEnv(sampleDir, "https://localhost:8090", sampleVars, Options{EnvTarget: "ai-agent"}); err != nil {
+			t.Fatalf("writeServiceEnv: %v", err)
+		}
+
+		if got := readEnv(t, envPath)["UPGRADE_SCHEDULER_ENABLED"]; got != "true" {
+			t.Errorf("an explicit opt-in must be preserved: got %q", got)
+		}
+	})
+}
+
+// Keys the sample ships defaults for must survive the rewrite; keys the CLI owns
+// must be refreshed rather than kept from an earlier run.
+func TestWriteServiceEnvPreservesShippedKeys(t *testing.T) {
+	sampleDir := t.TempDir()
+	envPath := serviceDir(t, sampleDir, "ai-agent")
+	shipped := "MCP_SERVER_URL=http://localhost:8787/mcp\n" +
+		"UPGRADE_SCHEDULER_ENABLED=false\n" +
+		"THUNDER_BASE_URL=https://localhost:8090\n"
+	if err := os.WriteFile(envPath, []byte(shipped), 0o644); err != nil {
+		t.Fatalf("write env: %v", err)
+	}
+
+	opts := Options{EnvTarget: "ai-agent"}
+	if err := writeServiceEnv(sampleDir, "https://localhost:9443", sampleVars, opts); err != nil {
+		t.Fatalf("writeServiceEnv: %v", err)
+	}
+
+	env := readEnv(t, envPath)
+	if env["MCP_SERVER_URL"] != "http://localhost:8787/mcp" {
+		t.Errorf("MCP_SERVER_URL was dropped: %q", env["MCP_SERVER_URL"])
+	}
+	if env["UPGRADE_SCHEDULER_ENABLED"] != "false" {
+		t.Errorf("UPGRADE_SCHEDULER_ENABLED was dropped: %q", env["UPGRADE_SCHEDULER_ENABLED"])
+	}
+	if env["THUNDER_BASE_URL"] != "https://localhost:9443" {
+		t.Errorf("THUNDER_BASE_URL: got %q, want the current URL", env["THUNDER_BASE_URL"])
+	}
+}
+
+func TestWriteFrontendEnv(t *testing.T) {
+	sampleDir := t.TempDir()
+	envPath := serviceDir(t, sampleDir, "frontend")
+	if err := os.WriteFile(envPath, []byte("VITE_THUNDER_APP_ID=wayfinder-app\n"), 0o644); err != nil {
+		t.Fatalf("write env: %v", err)
+	}
+
+	if err := writeFrontendEnv(sampleDir, "https://localhost:9443", sampleVars, true); err != nil {
+		t.Fatalf("writeFrontendEnv: %v", err)
+	}
+
+	env := readEnv(t, envPath)
+	if env["VITE_THUNDER_CLIENT_ID"] != "WAYFINDER" {
+		t.Errorf("client id: got %q, want the id from thunderid.env", env["VITE_THUNDER_CLIENT_ID"])
+	}
+	if env["VITE_THUNDER_BASE_URL"] != "https://localhost:9443" {
+		t.Errorf("base URL: got %q", env["VITE_THUNDER_BASE_URL"])
+	}
+	if env["VITE_AI_FEATURES_ENABLED"] != "true" {
+		t.Errorf("AI flag: got %q, want true", env["VITE_AI_FEATURES_ENABLED"])
+	}
+	if env["VITE_THUNDER_APP_ID"] != "wayfinder-app" {
+		t.Errorf("VITE_THUNDER_APP_ID was dropped: %q", env["VITE_THUNDER_APP_ID"])
+	}
+
+	if err := writeFrontendEnv(sampleDir, "https://localhost:9443", nil, false); err != nil {
+		t.Fatalf("writeFrontendEnv without vars: %v", err)
+	}
+	env = readEnv(t, envPath)
+	if env["VITE_THUNDER_CLIENT_ID"] != "WAYFINDER" {
+		t.Errorf("client id fallback: got %q", env["VITE_THUNDER_CLIENT_ID"])
+	}
+	if env["VITE_AI_FEATURES_ENABLED"] != "false" {
+		t.Errorf("AI flag: got %q, want false", env["VITE_AI_FEATURES_ENABLED"])
+	}
+}
+
+// The backend validates tokens against THUNDER_BASE_URL, which ships with the
+// default port baked in — it has to follow the port the product actually uses.
+func TestWriteBaseURLEnvs(t *testing.T) {
+	sampleDir := t.TempDir()
+	backendEnv := serviceDir(t, sampleDir, "backend")
+	if err := os.WriteFile(backendEnv, []byte("THUNDER_BASE_URL=https://localhost:8090\nAUTHORIZATION_MODE=scope\n"), 0o644); err != nil {
+		t.Fatalf("write env: %v", err)
+	}
+
+	if err := writeBaseURLEnvs(sampleDir, "https://localhost:9443"); err != nil {
+		t.Fatalf("writeBaseURLEnvs: %v", err)
+	}
+
+	env := readEnv(t, backendEnv)
+	if env["THUNDER_BASE_URL"] != "https://localhost:9443" {
+		t.Errorf("THUNDER_BASE_URL: got %q, want the resolved URL", env["THUNDER_BASE_URL"])
+	}
+	if env["AUTHORIZATION_MODE"] != "scope" {
+		t.Errorf("AUTHORIZATION_MODE was dropped: %q", env["AUTHORIZATION_MODE"])
+	}
+	// The lounge is absent here — a missing service must not fail the run.
+	if _, err := os.Stat(filepath.Join(sampleDir, "lounge", ".env")); !os.IsNotExist(err) {
+		t.Error("lounge env must not be created when the service is absent")
+	}
+}
+
+// `npm run dev` survives a single workspace crashing, so readiness is decided by
+// the ports rather than by the parent process.
+func TestWaitForServices(t *testing.T) {
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+	openPort := listener.Addr().(*net.TCPAddr).Port
+
+	if err := waitForServices([]serviceCheck{{port: openPort, name: "frontend"}}, "", time.Second); err != nil {
+		t.Fatalf("open port must be reported ready: %v", err)
+	}
+
+	closed, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	deadPort := closed.Addr().(*net.TCPAddr).Port
+	_ = closed.Close()
+
+	logPath := filepath.Join(t.TempDir(), "sample.log")
+	if err := os.WriteFile(logPath, []byte("Error: Please set an API key\n"), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	err = waitForServices([]serviceCheck{{port: deadPort, name: "ai-agent"}}, logPath, 100*time.Millisecond)
+	if err == nil {
+		t.Fatal("a service that never binds its port must fail the run")
+	}
+	if !strings.Contains(err.Error(), "ai-agent") {
+		t.Errorf("error must name the service: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Please set an API key") {
+		t.Errorf("error must include the log tail: %v", err)
 	}
 }

--- a/tools/cli/internal/services/health/health.go
+++ b/tools/cli/internal/services/health/health.go
@@ -14,7 +14,7 @@ import (
 // DefaultPort is the port ThunderID listens on by default.
 const DefaultPort = 8090
 
-// ResolveBaseURL polls until Thunder responds on https or http, returning the
+// ResolveBaseURL polls until ThunderID responds on https or http, returning the
 // confirmed base URL and true. Returns ("", false) if neither scheme responds
 // within timeout. Each individual probe is capped to min(2s, remaining budget)
 // so the function never overruns its deadline.
@@ -40,7 +40,7 @@ func ResolveBaseURL(port int, timeout time.Duration) (string, bool) {
 	return "", false
 }
 
-// CheckReady returns true if Thunder is responding on the readiness endpoint.
+// CheckReady returns true if ThunderID is responding on the readiness endpoint.
 func CheckReady(baseURL string) bool {
 	return checkReadyIn(baseURL, 2*time.Second)
 }

--- a/tools/cli/internal/services/release/release.go
+++ b/tools/cli/internal/services/release/release.go
@@ -140,14 +140,14 @@ func Download(version, destDir string, onProgress ProgressFunc) error {
 	}
 
 	if onProgress != nil {
-		onProgress(-1, fmt.Sprintf("Downloading Thunder v%s for %s/%s", version, runtime.GOOS, runtime.GOARCH))
+		onProgress(-1, fmt.Sprintf("Downloading "+product.Name+" v%s for %s/%s", version, runtime.GOOS, runtime.GOARCH))
 	}
 
 	zipPath := filepath.Join(os.TempDir(), assetName)
 	if err := downloadFile(found.DownloadURL, zipPath, func(received, total int64) {
 		if total > 0 && onProgress != nil {
 			pct := int(float64(received) / float64(total) * 100)
-			onProgress(pct, fmt.Sprintf("Downloading Thunder v%s", version))
+			onProgress(pct, fmt.Sprintf("Downloading "+product.Name+" v%s", version))
 		}
 	}); err != nil {
 		return err

--- a/tools/cli/internal/services/setup/setup.go
+++ b/tools/cli/internal/services/setup/setup.go
@@ -23,7 +23,7 @@ import (
 	"github.com/thunder-id/thunderid/tools/cli/internal/product"
 )
 
-// LogDir returns the directory where Thunder background logs are written
+// LogDir returns the directory where ThunderID background logs are written
 // (e.g. ./thunderid/v0.41.0/logs/).
 func LogDir(installPath string) string {
 	return filepath.Join(installPath, "logs")
@@ -228,12 +228,12 @@ func parseAdminCredentials(output string) *AdminCredentials {
 	return creds
 }
 
-// StartBackground starts Thunder detached from the terminal on the default port.
+// StartBackground starts ThunderID detached from the terminal on the default port.
 func StartBackground(installPath string, verbose bool) (*exec.Cmd, error) {
 	return StartBackgroundOnPort(installPath, verbose, 0)
 }
 
-// StartBackgroundOnPort starts Thunder detached from the terminal with an optional custom port.
+// StartBackgroundOnPort starts ThunderID detached from the terminal with an optional custom port.
 // Pass port=0 to use the default. Logs go to the state directory.
 // The returned *exec.Cmd has already been started; call cmd.Process.Kill() to stop it.
 func StartBackgroundOnPort(installPath string, verbose bool, port int) (*exec.Cmd, error) {
@@ -268,7 +268,7 @@ func StartBackgroundOnPort(installPath string, verbose bool, port int) (*exec.Cm
 		} else {
 			binary := filepath.Join(root, "thunder")
 			if _, err := os.Stat(binary); err != nil {
-				return nil, fmt.Errorf("no start.sh or thunder binary found in %s", root)
+				return nil, fmt.Errorf("no start.sh or "+product.Name+" binary found in %s", root)
 			}
 			cmd = exec.Command(binary)
 		}
@@ -293,7 +293,7 @@ func StartBackgroundOnPort(installPath string, verbose bool, port int) (*exec.Cm
 	return cmd, nil
 }
 
-// Start finds and runs the Thunder start script or binary with inherited stdio.
+// Start finds and runs the ThunderID start script or binary with inherited stdio.
 func Start(installPath string, args []string) error {
 	root, err := FindThunderRoot(installPath)
 	if err != nil {
@@ -323,7 +323,7 @@ func Start(installPath string, args []string) error {
 		} else {
 			binary := filepath.Join(root, "thunder")
 			if _, err := os.Stat(binary); err != nil {
-				return fmt.Errorf("no start.sh or thunder binary found in %s", root)
+				return fmt.Errorf("no start.sh or "+product.Name+" binary found in %s", root)
 			}
 			cmd = exec.Command(binary, args...)
 			cmd.Dir = root

--- a/tools/cli/internal/ui/onboarding.go
+++ b/tools/cli/internal/ui/onboarding.go
@@ -121,5 +121,7 @@ func (m *ReplModel) selectOnboarding() tea.Cmd {
 
 	m.tryingOut = true
 	m.input.Blur()
-	return makeTryCmd(item.sampleName, m.installPath, m.verbose, sample.Options{})
+	return makeTryCmd(item.sampleName, m.installPath, m.verbose, sample.Options{
+		Features: item.sampleFeatures, Port: m.effectivePort(),
+	})
 }

--- a/tools/cli/internal/ui/repl.go
+++ b/tools/cli/internal/ui/repl.go
@@ -139,6 +139,14 @@ type usecaseConfigRequestMsg struct {
 	features   []string
 }
 
+// sampleTryRequestMsg starts a use case that needs no configuration. The slash
+// commands are built before the REPL knows which port the product ended up on,
+// so the run is dispatched from Update, where the model can supply it.
+type sampleTryRequestMsg struct {
+	sampleName string
+	features   []string
+}
+
 // walkthroughPane is one tab in the post-sample walkthrough overlay.
 type walkthroughPane struct {
 	Title string
@@ -361,7 +369,6 @@ func NewReplModel(version string, proc *exec.Cmd, installPath string, verbose bo
 	var commands []SlashCommand
 	for _, u := range Usecases {
 		u := u
-		ip := installPath
 		if u.ComingSoon {
 			commands = append(commands, SlashCommand{
 				Name:        u.Command,
@@ -394,7 +401,12 @@ func NewReplModel(version string, proc *exec.Cmd, installPath string, verbose bo
 				Description: u.Title,
 				Section:     "Try",
 				AsyncAction: func(_ string) tea.Cmd {
-					return makeTryCmd(u.SampleName, ip, verbose, sample.Options{})
+					return func() tea.Msg {
+						return sampleTryRequestMsg{
+							sampleName: u.SampleName,
+							features:   u.SampleFeatures,
+						}
+					}
 				},
 			})
 		}
@@ -605,6 +617,20 @@ func (m ReplModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,fu
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.onboardingList.SetSize(msg.Width, onboardingListHeight)
+
+	// Bracketed paste arrives as its own message rather than as key presses, so the
+	// overlay inputs need it routed explicitly — the command input already receives
+	// it from the catch-all at the end of Update. Without this, pasting into the API
+	// key prompt does nothing, and the value is too long to retype comfortably.
+	case tea.PasteMsg:
+		var tiCmd tea.Cmd
+		switch {
+		case m.showUsecaseConfig && m.ucStep < len(m.ucInputs) && len(m.ucInputs[m.ucStep].Choices) == 0:
+			m.ucText, tiCmd = m.ucText.Update(msg)
+		case m.integrateCollecting:
+			m.integrateInput, tiCmd = m.integrateInput.Update(msg)
+		}
+		cmds = append(cmds, tiCmd)
 
 	case tea.KeyPressMsg:
 		if msg.String() == "ctrl+c" {
@@ -820,6 +846,11 @@ func (m ReplModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,fu
 			}
 		}
 
+	case sampleTryRequestMsg:
+		cmds = append(cmds, makeTryCmd(msg.sampleName, m.installPath, m.verbose, sample.Options{
+			Features: msg.features, Port: m.effectivePort(),
+		}))
+
 	case usecaseConfigRequestMsg:
 		m.ucInputs = msg.inputs
 		m.ucSampleName = msg.sampleName
@@ -828,9 +859,10 @@ func (m ReplModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,fu
 
 		// Capture msg fields for the completion closure.
 		sampleName, ip, envTarget, features := msg.sampleName, m.installPath, msg.envTarget, msg.features
+		port := m.effectivePort()
 		m.ucComplete = func(values map[string]string) tea.Cmd {
 			return makeTryCmd(sampleName, ip, m.verbose, sample.Options{
-				Config: values, EnvTarget: envTarget, Features: features,
+				Config: values, EnvTarget: envTarget, Features: features, Port: port,
 			})
 		}
 

--- a/tools/cli/internal/ui/repl_internal_test.go
+++ b/tools/cli/internal/ui/repl_internal_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
+
 	"github.com/thunder-id/thunderid/tools/cli/internal/services/setup"
 )
 
@@ -67,5 +69,63 @@ func TestRender_IncludesCredentials(t *testing.T) {
 	out := m.render()
 	if !strings.Contains(out, "admin") || !strings.Contains(out, "s3cr3t#Pass") {
 		t.Fatalf("render output missing credentials:\n%s", out)
+	}
+}
+
+// updateModel applies msg and returns the resulting model.
+func updateModel(t *testing.T, m ReplModel, msg tea.Msg) ReplModel {
+	t.Helper()
+	updated, _ := m.Update(msg)
+	next, ok := updated.(ReplModel)
+	if !ok {
+		t.Fatalf("Update returned %T, want ReplModel", updated)
+	}
+	return next
+}
+
+// Bracketed paste is delivered as its own message, not as key presses. An API key
+// is too long to retype, so the config prompt has to accept a pasted value.
+func TestPaste_ReachesUsecaseConfigInput(t *testing.T) {
+	m := NewReplModel("1.0.0", nil, "/tmp/x", false, false, nil)
+	m.showUsecaseConfig = true
+	m.ucInputs = []ConfigInput{{Key: "LLM_API_KEY", Label: "API key", Secret: true}}
+	m.ucStep = 0
+	m.initUCStep()
+
+	next := updateModel(t, m, tea.PasteMsg{Content: "pasted-api-key"})
+	if got := next.ucText.Value(); got != "pasted-api-key" {
+		t.Fatalf("pasted value did not reach the config input: got %q", got)
+	}
+}
+
+func TestPaste_ReachesCommandInput(t *testing.T) {
+	m := NewReplModel("1.0.0", nil, "/tmp/x", false, false, nil)
+	m.input.Focus()
+
+	next := updateModel(t, m, tea.PasteMsg{Content: "/try-agentid"})
+	if got := next.input.Value(); got != "/try-agentid" {
+		t.Fatalf("pasted value did not reach the command input: got %q", got)
+	}
+}
+
+// A list step has no text input to paste into, so the paste must be ignored
+// rather than routed at the wrong widget.
+func TestPaste_IgnoredOnChoiceStep(t *testing.T) {
+	m := NewReplModel("1.0.0", nil, "/tmp/x", false, false, nil)
+	m.showUsecaseConfig = true
+	m.ucInputs = []ConfigInput{{
+		Key:     "LLM_PROVIDER",
+		Label:   "Provider",
+		Choices: []Choice{{Value: "anthropic", Label: "Anthropic"}},
+	}}
+	m.ucStep = 0
+	m.initUCStep()
+
+	next := updateModel(t, m, tea.PasteMsg{Content: "anthropic"})
+	if got := next.ucText.Value(); got != "" {
+		t.Fatalf("paste must not reach the text input on a choice step: got %q", got)
+	}
+	if got := next.input.Value(); got != "" {
+		t.Fatalf("paste must not leak to the command input: got %q", got)
 	}
 }


### PR DESCRIPTION
### Purpose
The **Agent Login (AgentID)** use case was broken end to end when launched through `npx thunderid`. Sending any message to the AI concierge failed in the browser with `net::ERR_CONNECTION_REFUSED`, because the `ai-agent` service had already exited at startup — while the CLI reported `✓ Wayfinder is live`.

Root cause: the CLI wrote the collected API key as `GOOGLE_API_KEY`/`ANTHROPIC_API_KEY`, but the sample reads `LLM_API_KEY` and passes it straight into the model constructor. An explicit empty string suppresses LangChain's own env fallback, so the agent threw `Please set an API key for Google GenerativeAI...` even though a key was present in the file. This affected **both** providers, so the use case failed for every user.

Tracing that path surfaced several adjacent defects, all fixed here:

- **API key name mismatch** — the agent never received the key it was given.
- **Upgrade agent credentials never written** — `UPGRADE_AGENT_ID`/`UPGRADE_AGENT_SECRET` were absent, so the CIBA upgrade scheduler could not authenticate.
- **Silent service crashes** — `npm run dev` stays alive when a single workspace exits, so a dead service was reported as a successful start and only surfaced later in the browser.
- **Alternate port ignored** — after a port conflict the REPL moves the server off 8090, but the try flow still killed, probed, and restarted on the default port, and the sample's backend kept validating tokens against `https://localhost:8090`.
- **Paste discarded in prompts** — under bubbletea v2 bracketed paste is its own message type, which the REPL never routed, so an API key could not be pasted and had to be retyped by hand.
- **Env keys dropped on rewrite** — regenerating `frontend/.env` discarded `VITE_THUNDER_APP_ID`, and `SampleFeatures` were dropped entirely on the no-config try path.
- **Hardcoded client id** and a stale Gemini default model name in `ai-agent/.env.example`.

### Approach
**Write the names the sample reads.** `writeServiceEnv` no longer renames `LLM_API_KEY` to a provider-specific variable, and the reverse-mapping in `ReadServiceEnv` is removed with it rather than left as a shim. `UPGRADE_AGENT_ID`/`UPGRADE_AGENT_SECRET` are now mapped from the sample's `thunderid.env`, and `UPGRADE_SCHEDULER_ENABLED` defaults to `false` when the key is absent — a try-out has no CIBA email or SMS flow configured, and writing the upgrade credentials removed the accidental backstop that used to keep the scheduler off. An explicit opt-in in the file is preserved.

**Merge instead of regenerate.** The env writers now parse the existing file, override only the keys the CLI owns, and write back sorted by key. This preserves keys the sample ships defaults for (`MCP_SERVER_URL`, `UPGRADE_SCHEDULER_ENABLED`, `VITE_THUNDER_APP_ID`) and makes repeated runs produce an identical file instead of reshuffling with Go's map iteration order.

**Gate readiness on ports, not on the parent process.** The sample's `dev` script runs `concurrently` without `--kill-others-on-fail`, so the parent survives any single workspace exiting and a 2-second start check can never observe it. `waitForSampleServices` now polls the frontend (5173), backend API (8787), and — in AgentID mode — the ai-agent (8790), and fails the run with the offending service name, the log path, and the last 20 lines of `logs/sample.log`. The SMTP inbox and lounge kiosk are started but not gated on, since the documented walkthroughs do not need them. Probes dial `localhost` rather than `127.0.0.1` because the ai-agent binds IPv6 only.

**Thread the active port through the try flow.** `sample.Options` gains a `Port` field used for `KillPort`, `WaitForPortFree`, `StartBackgroundOnPort`, and `ResolveBaseURL`, and `backend/.env` plus `lounge/.env` are rewritten to the URL the server actually came up on. The slash-command path needed one indirection: those closures are built in `NewReplModel`, but both `RunREPL` and `RunStagingREPL` assign `checkPort` *after* construction — and staging assigns a different value — so a captured port would be zero or plain wrong. The closure now emits `sampleTryRequestMsg` and `Update` supplies `m.effectivePort()` at dispatch time, matching the existing `usecaseConfigRequestMsg` pattern.

**Route paste to the overlay inputs.** A `tea.PasteMsg` case forwards to the use-case config input or the integrate input; the command input already receives it from the catch-all at the end of `Update`, so it is deliberately not handled twice.

**Naming.** CLI comments, download progress output, and error messages now say ThunderID. The `THUNDER_BASE_URL` and `VITE_THUNDER_*` variables and the `thunder` binary filename are left alone — they are contracts shared with the sample and the release artifact, and need a coordinated change.


### Related Issues
- https://github.com/thunder-id/thunderid/issues/4780

### Related PRs
- https://github.com/thunder-id/thunderid/pull/3784

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sample applications now support configurable product ports and improved service startup readiness checks.
  * Environment configuration is preserved and populated with resolved URLs, credentials, client IDs, and AI settings.
  * Onboarding and REPL sample launches now honor selected features and configured ports.
  * Pasted text is handled correctly in use-case and integration setup flows.

* **Bug Fixes**
  * Improved startup failures with timeout details and recent service logs.
  * Download, setup, and health messages now consistently use the configured product name.
  * Updated the documented default Google AI model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->