### PR TITLE
Fix Self Sign-Up walkthrough copy in the console application tryout

### DIFF
--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -298,9 +298,9 @@ const translations = {
     'welcome.applicationTryout.scenarios.signup.sampleFields.familyName': 'Last name',
     'welcome.applicationTryout.scenarios.signup.sampleFields.mobileNumber': 'Mobile number',
     'welcome.applicationTryout.scenarios.signup.step4':
-      'Fill in the registration form using these sample details and click Submit.',
+      'Fill in the registration form using these sample details and click Continue.',
     'welcome.applicationTryout.scenarios.signup.step5':
-      '{{productName}} will create a Customer user and assign the Traveler role. The browser shows a confirmation screen with a link to redirect back to the Wayfinder app.',
+      '{{productName}} will create a Customer user and assign the Traveler role. The browser returns to the Wayfinder app signed in as the new user.',
     'welcome.applicationTryout.scenarios.profile.description':
       'Explore the self-service profile page - view account details, edit attributes, and change your password.',
     'welcome.applicationTryout.scenarios.profile.step1': 'Sign in as John at <a>http://localhost:5173</a>.',


### PR DESCRIPTION
### Purpose

The Self Sign-Up tab of the console Wayfinder tryout said the browser shows a confirmation screen with a link back to the app. The customer branch of `wayfinder-registration-flow` ends on an `END` node right after `provisioning`, and `ProvisioningExecutor` authenticates the newly provisioned user, so the browser returns to Wayfinder already signed in. Step 4 also named the wrong action label.

### Approach

Copy-only change in `frontend/packages/i18n/src/locales/en-US.ts`:

- `signup.step5`: second sentence now reads "The browser returns to the Wayfinder app signed in as the new user.", matching the docs (`docs/content/use-cases/b2c/try-it-out/self-sign-up.mdx`).
- `signup.step4`: "click Submit" -> "click Continue", the actual label of the `prompt_schema_attrs` action.

Assumption: the console copy should describe the documented auto-login behavior rather than the sample flow gaining a confirmation prompt for the customer branch.

Verified by rendering the tab in the console against a local `make run` stack.

### Related Issues
- Fixes #4720

### Related PRs
- N/A