### PR TITLE
Hide the non-functional column filter in Console list pages

### DIFF
--- a/frontend/apps/console/src/features/agents/components/AgentsList.tsx
+++ b/frontend/apps/console/src/features/agents/components/AgentsList.tsx
@@ -171,6 +171,8 @@ export default function AgentsList(): JSX.Element {
             }}
             pageSizeOptions={[5, 10, 25, 50]}
             disableRowSelectionOnClick
+            // Filtering is not wired end to end, so the column filter panel stays hidden.
+            disableColumnFilter
             localeText={dataGridLocaleText}
             sx={{
               height: 'auto',

--- a/frontend/apps/console/src/features/applications/components/ApplicationsList.tsx
+++ b/frontend/apps/console/src/features/applications/components/ApplicationsList.tsx
@@ -200,6 +200,8 @@ export default function ApplicationsList(): JSX.Element {
             }}
             pageSizeOptions={[5, 10, 25, 50]}
             disableRowSelectionOnClick
+            // Filtering is not wired end to end, so the column filter panel stays hidden.
+            disableColumnFilter
             localeText={dataGridLocaleText}
             autoHeight
             sx={{

--- a/frontend/apps/console/src/features/flows/components/FlowsList.tsx
+++ b/frontend/apps/console/src/features/flows/components/FlowsList.tsx
@@ -184,6 +184,8 @@ export default function FlowsList(): JSX.Element {
             }}
             pageSizeOptions={[5, 10, 25, 50]}
             disableRowSelectionOnClick
+            // Filtering is not wired end to end, so the column filter panel stays hidden.
+            disableColumnFilter
             localeText={dataGridLocaleText}
             autoHeight
             sx={{

--- a/frontend/packages/configure-groups/src/components/GroupsList.tsx
+++ b/frontend/packages/configure-groups/src/components/GroupsList.tsx
@@ -172,6 +172,8 @@ export default function GroupsList(): JSX.Element {
             onPaginationModelChange={setPaginationModel}
             pageSizeOptions={[5, 10, 25]}
             disableRowSelectionOnClick
+            // Filtering is not wired end to end, so the column filter panel stays hidden.
+            disableColumnFilter
             localeText={dataGridLocaleText}
             autoHeight
             sx={{

--- a/frontend/packages/configure-resource-servers/src/components/ResourceServersList.tsx
+++ b/frontend/packages/configure-resource-servers/src/components/ResourceServersList.tsx
@@ -251,6 +251,8 @@ export default function ResourceServersList(): JSX.Element {
             onPaginationModelChange={setPaginationModel}
             pageSizeOptions={[5, 10, 25]}
             disableRowSelectionOnClick
+            // Filtering is not wired end to end, so the column filter panel stays hidden.
+            disableColumnFilter
             localeText={dataGridLocaleText}
             autoHeight
             sx={{'& .MuiDataGrid-row': {cursor: 'pointer'}}}

--- a/frontend/packages/configure-roles/src/components/RolesList.tsx
+++ b/frontend/packages/configure-roles/src/components/RolesList.tsx
@@ -172,6 +172,8 @@ export default function RolesList(): JSX.Element {
             onPaginationModelChange={setPaginationModel}
             pageSizeOptions={[5, 10, 25]}
             disableRowSelectionOnClick
+            // Filtering is not wired end to end, so the column filter panel stays hidden.
+            disableColumnFilter
             localeText={dataGridLocaleText}
             autoHeight
             sx={{

--- a/frontend/packages/configure-translations/src/components/TranslationsList.tsx
+++ b/frontend/packages/configure-translations/src/components/TranslationsList.tsx
@@ -155,6 +155,8 @@ export default function TranslationsList(): JSX.Element {
             pageSizeOptions={[5, 10, 25]}
             rowHeight={56}
             disableRowSelectionOnClick
+            // Filtering is not wired end to end, so the column filter panel stays hidden.
+            disableColumnFilter
             localeText={dataGridLocaleText}
             autoHeight
             sx={{

--- a/frontend/packages/configure-user-types/src/components/UserTypesList.tsx
+++ b/frontend/packages/configure-user-types/src/components/UserTypesList.tsx
@@ -205,6 +205,8 @@ export default function UserTypesList() {
             }}
             pageSizeOptions={[5, 10, 25, 50]}
             disableRowSelectionOnClick
+            // Filtering is not wired end to end, so the column filter panel stays hidden.
+            disableColumnFilter
             localeText={dataGridLocaleText}
             autoHeight
             sx={{

--- a/frontend/packages/configure-users/src/components/UsersList.tsx
+++ b/frontend/packages/configure-users/src/components/UsersList.tsx
@@ -178,6 +178,8 @@ export default function UsersList() {
             }}
             pageSizeOptions={[5, 10, 25, 50]}
             disableRowSelectionOnClick
+            // Filtering is not wired end to end, so the column filter panel stays hidden.
+            disableColumnFilter
             localeText={dataGridLocaleText}
             autoHeight
             sx={{

--- a/frontend/packages/configure-verifiable-credentials/src/components/VerifiableCredentialsList.tsx
+++ b/frontend/packages/configure-verifiable-credentials/src/components/VerifiableCredentialsList.tsx
@@ -160,6 +160,8 @@ export default function VerifiableCredentialsList(): JSX.Element {
             }}
             pageSizeOptions={[5, 10, 25]}
             disableRowSelectionOnClick
+            // Filtering is not wired end to end, so the column filter panel stays hidden.
+            disableColumnFilter
             localeText={dataGridLocaleText}
             autoHeight
             sx={{

--- a/frontend/packages/configure-verifiable-credentials/src/components/VerifiablePresentationsList.tsx
+++ b/frontend/packages/configure-verifiable-credentials/src/components/VerifiablePresentationsList.tsx
@@ -160,6 +160,8 @@ export default function VerifiablePresentationsList(): JSX.Element {
             }}
             pageSizeOptions={[5, 10, 25]}
             disableRowSelectionOnClick
+            // Filtering is not wired end to end, so the column filter panel stays hidden.
+            disableColumnFilter
             localeText={dataGridLocaleText}
             autoHeight
             sx={{


### PR DESCRIPTION
### Purpose

The search filter on the Agent list page does not work. Selecting an attribute and operator, entering a value, and applying the filter has no effect. The operator selection does not even persist in the panel.

Investigation showed this is not specific to agents. The same filter panel is reachable from the column menu on every DataGrid backed list page in the Console, and it is non functional on all of them for the same reason.

| List page | Filter option exists | Working before this PR |
|---|---|---|
| Users | Yes (column menu) | No |
| Agents | Yes (column menu) | No |
| User Types | Yes (column menu) | No |
| Groups | Yes (column menu) | No |
| Roles | Yes (column menu) | No |
| Applications | Yes (column menu) | No |
| Resource Servers | Yes (column menu) | No |
| Flows | Yes (column menu) | No |
| Translations | Yes (column menu) | No |
| Verifiable Credentials | Yes (column menu) | No |
| Verifiable Presentations | Yes (column menu) | No |
| Connections | Yes (own search and category chips) | Yes, client side |
| Organization Units | No (tree view) | N/A |

This PR hides the non functional filter option from all 11 affected list pages so users are not presented with a control that cannot work. Connections is left untouched because its search is a separate implementation that works correctly, and Organization Units has no filter UI to hide.

### Approach

There are two independent reasons the filter could never work.

**1. The panel is structurally dead in the shared grid component.** `ListingTableDataGrid` in `@wso2/oxygen-ui` destructures `filterModel` out of props and always substitutes its own value:

```js
const filterModel = filterModelProp ?? {
  items: [],
  quickFilterValues: searchValue ? [searchValue] : []
};
```

The grid is therefore permanently in controlled filter mode with empty `items`. No list page supplies `onFilterModelChange` to lift that state, so every selection made in the panel is reverted on the next render. This is why the symptom is identical across all 11 pages rather than specific to agents.

**2. Filtering is not wired to the backend.** No list page sends a `filter` query parameter, and only 3 of 23 API specs accept one (`user.yaml`, `agent.yaml`, `ou.yaml`). For users and agents the filter resolves against the `ATTRIBUTES` JSON column, but `name`, `description`, `owner`, and `clientId` are stored in `SYSTEM_ATTRIBUTES`, while `id` and `ouId` are table columns. The columns the panel exposed (Name, ID, Organization Unit) are precisely the ones the backend cannot filter on, and such a query returns zero rows silently rather than an error.

Given that, the change is to hide the control rather than partially wire it. `disableColumnFilter` is passed on each `ListingTable.DataGrid` listing. `ListingTableDataGridProps extends Omit<DataGridProps, 'density'>`, so this is an accepted typed prop that flows through to the grid, and `GridColumnMenuFilterItem` returns `null` when it is set, removing the Filter item from the column menu. Quick filter and search remain a separate code path, so this does not block wiring real search later.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4772

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Removed unavailable column-filter panels from data grids across agents, applications, flows, groups, resource servers, roles, translations, user types, users, verifiable credentials, and presentations.
  * Simplified list interfaces by hiding filtering controls until filtering is fully supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->