### PR TITLE
[Doc] Document user type requirement/limitations for provisioning.

### DIFF
--- a/docs/content/guides/applications/application-settings.mdx
+++ b/docs/content/guides/applications/application-settings.mdx
@@ -27,6 +27,10 @@ Under **Access** on the General tab, you can configure which users can register 
 | **Application URL** | The homepage URL of your application. |
 | **Authorized Redirect URIs** | The URLs <ProductName /> sends users back to after authentication. Register every URI your application uses.
 
+:::note
+When first-time users sign in with a social identity provider, your application must allow exactly one user type with **Allow Self Registration** enabled. Sign-in fails if none or more than one of the allowed user types has this setting enabled. Existing users are unaffected. See [Connect an IdP to an Application](../../identity-providers/connect-idp-to-application).
+:::
+
 ## Use Wildcard Redirect URIs
 
 <ProductName /> supports wildcard patterns in redirect URIs, so you can register a single pattern that covers a range of valid callback URLs instead of listing every exact URI.

--- a/docs/content/guides/applications/manage-applications.mdx
+++ b/docs/content/guides/applications/manage-applications.mdx
@@ -78,8 +78,10 @@ Select the sign-in methods users will use to authenticate with this application 
 **Browser App** applications (SPAs) support only the **Redirect** approach. Because they run entirely in the browser as public clients, they cannot drive embedded (app-native) flow execution securely, so the embedded option is not offered for them. Other application types, such as **Mobile App** and **Full-stack App**, continue to support the embedded approach.
 :::
 
-**User Access** controls which user types can register with this application. Select one or more of the allowed user types (for example, **Customer** or **Person**).
+**User Access** controls which user types can register with this application. Select one or more of the allowed user types (for example, **Customer** or **Person**). The selection appears as **Allowed User Types** once the application exists.
 Learn more about user types in [User Types](../../users/user-types).
+
+When first-time users sign in with a social identity provider, ensure exactly one selected user type has **Allow Self Registration** enabled. See [Control Who Can Register](../application-settings#control-who-can-register).
 
 ### Step 6: Configure Application
 

--- a/docs/content/guides/flows/advanced-configurations.mdx
+++ b/docs/content/guides/flows/advanced-configurations.mdx
@@ -559,6 +559,8 @@ Sets credentials (e.g., password) for an existing user. Typically used in regist
 
 After a successful federated authentication, these executors set the `entityState` runtime key from the account-linking result: `exists` when the federated identity resolves to a unique existing local user. A later node can branch on `{{ctx(entityState)}}`.
 
+To sign in a first-time federated user who has no local account, enable `allowAuthenticationWithoutLocalUser` on the executor and place a [Provisioning](#user-provisioning-and-attributes) executor downstream. The application must allow exactly one user type with self-registration enabled.
+
 <details>
 <summary>OAuth</summary>
 
@@ -1113,11 +1115,13 @@ Validates the magic link token the user received and authenticates them. Runs in
 
 Creates a new user record in the user store. This executor persists the user's identity during registration flows. The executor follows the user type schema: required attributes are determined by the user type resolved earlier in the flow.
 
-**When to use:** Registration flows, after the User Type Resolver has run.
+**When to use:** Registration flows, after the User Type Resolver has run. Also authentication flows, after a federated executor with `allowAuthenticationWithoutLocalUser` enabled, to create the local account for a first-time user.
 
-**Prerequisites:**
+**Prerequisites (registration and user onboarding flows):**
 - `userType` (required): must be present in runtime data. Set by User Type Resolver or by a previous operation. Defines which attributes are required for the new user.
 - `defaultOUID` or `ouId` (required): must be present in runtime data. Set by User Type Resolver or OU Resolver. Determines which OU the new user belongs to.
+
+**Authentication flows:** The executor uses `userType` and the OU ID from runtime data when they are present. The User Type Resolver does not set `userType` in authentication flows, so the executor falls back to the application's allowed user types. It takes the only one with self-registration enabled, and provisioning fails when none or more than one is eligible.
 
 **How attribute collection works:** The executor fetches required and optional attributes from the user type schema. Attributes already present in user inputs or federated accounts are considered satisfied. Only missing required attributes are prompted. Optional attributes are only prompted if `includeOptional` is enabled in node properties.
 
@@ -1166,6 +1170,7 @@ Creates a new user record in the user store. This executor persists the user's i
 
 **Failure conditions:**
 - `userType` or OU ID not available (User Type Resolver did not run)
+- In authentication flows, none or more than one of the application's allowed user types has self-registration enabled
 - User already exists with a conflicting unique attribute (in registration flows, prompts for a different value)
 - Required attribute validation failure
 - User store error
@@ -1391,7 +1396,7 @@ Determines the user type and default OU for the flow. The resolved values are us
 | Flow type | Behavior |
 |---|---|
 | Registration | Resolves from the application's allowed user types, checking self-registration eligibility. Auto-selects if only one eligible type; prompts with a SELECT input if multiple are available. |
-| Authentication | Validates that the application has at least one allowed user type configured; completes without further action. |
+| Authentication | Validates that the application has at least one allowed user type, but does not select one. A downstream Provisioning executor uses the application's allowed user types. |
 | User Onboarding | Lists all user types in the system, optionally filtered by node properties or by a prior resolved OU. |
 
 **Executor properties:**

--- a/docs/content/guides/identity-providers/connect-idp-to-application.mdx
+++ b/docs/content/guides/identity-providers/connect-idp-to-application.mdx
@@ -31,6 +31,14 @@ Applications in <ProductName /> do not reference IdPs directly. The connection r
 By default, federated sign-in maps the external identity to a local user, which must already exist in the user store or the sign-in step fails. To sign in a first-time federated user, enable **Allow Authentication Without Local User** (`allowAuthenticationWithoutLocalUser`) on the social login executor and add a **Provisioning** executor to create the local account. See [Federated Authentication](../../flows/advanced-configurations#federated-authentication).
 :::
 
+:::note Configure a user type for first-time social sign-in
+Your application must allow exactly one user type with **Allow Self Registration** enabled. Sign-in fails if none or more than one of the allowed user types has this setting enabled.
+
+Under the application's **Access** settings, select the user type you want to assign to first-time users. If you select other user types, ensure only one has **Allow Self Registration** enabled under **User Types**. Existing users are unaffected.
+
+A **User Type Resolver** step selects the user type when several are eligible, but only in registration flows, where it prompts the user to choose. In authentication flows it does not resolve a type, so adding it to a sign-in flow does not lift this requirement.
+:::
+
 <Stepper stepNode="h2" as="h2">
 
 ## Step 1: Open the Flow Designer

--- a/docs/content/guides/users/user-type-reference.mdx
+++ b/docs/content/guides/users/user-type-reference.mdx
@@ -40,7 +40,7 @@ Modifiers add validation and behavior rules to an attribute. You can combine mul
 
 ### Person
 
-An admin-managed user type. Self-registration is disabled and only an administrator can create these users.
+The general-purpose user type. Self-registration is enabled, so users of this type can sign up through the registration flow of any application that lists it under [Allowed User Types](../../applications/application-settings#control-who-can-register). Administrators can also create users of this type.
 
 | Attribute | Type | Constraints | Notes |
 |-----------|------|-------------|-------|

--- a/docs/content/guides/users/user-types.mdx
+++ b/docs/content/guides/users/user-types.mdx
@@ -28,17 +28,21 @@ Each user type belongs to a single OU. Users of that type can only exist under t
 
 | User Type | Description | Organization Unit | Self-Registration |
 |-----------|-------------|-------------------|-------------------|
-| **Person** | Internal or admin-managed users, such as staff or service accounts. | Default | Not allowed |
+| **Person** | The general-purpose user type used by the default sign-in and registration flows. | Default | Allowed |
 
 
 ## Create a User Type
 
 1. Navigate to **User Types** in the <ProductName /> Console and click **Create User Type**.
 2. Enter a **Name** for the user type. The name is used as the type identifier and must be unique.
-3. Select the **Organization Unit** this user type should belong. A user of this type can only be created under this OU or one of its descendants in the hierarchy. See [Organization Units](../../organization-units/) for more information.
-4. Select whether to allow self-registration. Enabling this allows users of this type to sign up through the registration flow assigned to your application.
+3. Select the **Organization Unit** this user type should belong to. A user of this type can only be created under this OU or one of its descendants in the hierarchy. See [Organization Units](../../organization-units/) for more information.
+4. Configure **Allow Self Registration**. When enabled, users of this type can sign up through the registration flow assigned to your application.
 5. Set the attributes that the user type should have, including data types and constraint modifiers. See [User Type Reference](../user-type-reference) for details on available settings and attribute options.
-7. Click **Create User Attribute**. 
+6. Click **Create User Type**.
+
+:::note
+**Allow Self Registration** applies to every application that allows the user type. When first-time users sign in with a social identity provider, an application must allow exactly one user type with this setting enabled. The default **Person** type already has it enabled. See [Application Settings](../../applications/application-settings#control-who-can-register).
+:::
 
 ## Update a User Type
 


### PR DESCRIPTION
### Purpose

  Clarify the user type configuration required when first-time users sign in with a social identity provider.

  Previously, the documentation did not explain that exactly one allowed user type must have **Allow Self Registration** enabled. If none or multiple allowed user
  types have this setting enabled, first-time social sign-in fails.

  This PR also corrects the documented self-registration behavior of the default **Person** user type.

  ### Approach

  - Documented the required user type configuration in the application, identity provider, flow, and user type guides.
  - Added guidance for configuring first-time social sign-in.
  - Clarified that existing users are unaffected by this restriction.
  - Updated the default **Person** user type documentation to reflect that self-registration is enabled.
  - Kept user-facing guidance concise while retaining technical details in the advanced flow reference.

  ### Related Issues

  - Fixes #4814

  ### Related PRs

  - N/A

  ### Checklist

  - [x] Followed the contribution guidelines.
  - [ ] Manual test round performed and verified.
  - [x] Documentation provided.
      - [ ] Ran Vale and fixed all errors and warnings
  - [ ] Tests provided.
      - [ ] Unit Tests
      - [ ] Integration Tests
  - [ ] Breaking changes.
      - [ ] Breaking changes section filled.
      - [ ] `breaking change` label added.

  ### Security checks

  - [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-
  guidelines/secure-coding-guidlines/introduction/)
  - [x] Confirmed that this PR does not commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified requirements for first-time social and federated sign-ins.
  * Documented that exactly one allowed user type must have self-registration enabled.
  * Added guidance for configuring user access, provisioning, and registration settings.
  * Clarified that user type resolution applies to registration flows, not authentication.
  * Explained that existing users remain unaffected by these requirements.
  * Updated default Person user type documentation to describe sign-in and registration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->