### PR TITLE
Show the seeded admin in the home Add Users card

### DIFF
--- a/frontend/apps/console/src/features/home/components/cards/InviteMembersCard.tsx
+++ b/frontend/apps/console/src/features/home/components/cards/InviteMembersCard.tsx
@@ -121,8 +121,7 @@ export default function InviteMembersCard(): JSX.Element {
   const totalResults = data?.totalResults ?? 0;
   const users = data?.users ?? [];
   const extraCount = totalResults > AVATAR_LIMIT ? totalResults - AVATAR_LIMIT : 0;
-  // totalResults <= 1 means only the admin — treat as empty
-  const isEmpty = !isLoading && totalResults <= 1;
+  const isEmpty = !isLoading && users.length === 0;
 
   const preview = (
     <Box sx={{minHeight: 32, display: 'flex', alignItems: 'center'}}>

--- a/frontend/apps/console/src/features/home/components/cards/__tests__/InviteMembersCard.test.tsx
+++ b/frontend/apps/console/src/features/home/components/cards/__tests__/InviteMembersCard.test.tsx
@@ -62,13 +62,17 @@ describe('InviteMembersCard', () => {
     });
   });
 
-  describe('Empty state (admin only)', () => {
-    it('renders empty state message when only the admin exists (totalResults = 1)', () => {
-      mockUseGetUsers.mockReturnValue({isLoading: false, data: {totalResults: 1, users: []}});
+  describe('Empty state', () => {
+    it('renders the admin avatar when the seeded admin is the only user', () => {
+      mockUseGetUsers.mockReturnValue({
+        isLoading: false,
+        data: {totalResults: 1, users: [{id: 'admin', display: 'Administrator'}]},
+      });
 
       render(<InviteMembersCard />);
 
-      expect(screen.getByText('No members yet')).toBeInTheDocument();
+      expect(getRenderedInitials(screen.getByRole<HTMLImageElement>('img'))).toBe('AD');
+      expect(screen.queryByText('No members yet')).not.toBeInTheDocument();
     });
 
     it('renders empty state message when totalResults is 0', () => {
@@ -147,7 +151,17 @@ describe('InviteMembersCard', () => {
 
   describe('Action buttons', () => {
     beforeEach(() => {
-      mockUseGetUsers.mockReturnValue({isLoading: false, data: {totalResults: 3, users: []}});
+      mockUseGetUsers.mockReturnValue({
+        isLoading: false,
+        data: {
+          totalResults: 3,
+          users: [
+            {id: 'u1', display: 'Alice Smith'},
+            {id: 'u2', display: 'Bob Jones'},
+            {id: 'u3', display: 'Carol Doe'},
+          ],
+        },
+      });
     });
 
     it('renders the "Add User" button', () => {


### PR DESCRIPTION
### Purpose

The home page "Add Users" card showed `No members yet` on a fresh install, even though the seeded admin user exists and is already returned by `GET /users`. The card discounted the seeded admin by treating `totalResults <= 1` as empty, so the admin's avatar only appeared once a second user was added.

### Approach

`InviteMembersCard` now derives emptiness from the list it actually renders (`users.length === 0`) instead of the total count. `totalResults` still drives the `+N` overflow badge. The existing test that asserted the old behaviour (`totalResults = 1` renders the empty caption) is replaced with a regression test using the real fresh-install payload, and the `Action buttons` fixture is corrected to carry users matching its `totalResults`.

No i18n or backend change: the backend already returns the admin in the payload.

### Related Issues
- Fixes #4727

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the member invitation card’s empty-state behavior when no users are available.
  * Existing seeded users now appear correctly as member avatars instead of triggering an empty state.
  * Invitation actions now display correctly when members are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->