### PR TITLE
Advertise token_endpoint_auth_signing_alg_values_supported in discovery

### DIFF
--- a/backend/internal/oauth/oauth2/discovery/discovery_test.go
+++ b/backend/internal/oauth/oauth2/discovery/discovery_test.go
@@ -204,6 +204,16 @@ func (suite *DiscoveryTestSuite) TestDPoPSigningAlgValuesAdvertised() {
 	assert.Equal(suite.T(), expected, oidcMeta.DPoPSigningAlgValuesSupported)
 }
 
+// TestTokenEndpointAuthSigningAlgValuesAdvertised verifies the discovery metadata publishes
+// token_endpoint_auth_signing_alg_values_supported with FAPI 2.0 permitted algorithms (RFC 8414).
+func (suite *DiscoveryTestSuite) TestTokenEndpointAuthSigningAlgValuesAdvertised() {
+	oauth2Meta := suite.discoveryService.GetOAuth2AuthorizationServerMetadata(context.Background())
+	assert.NotEmpty(suite.T(), oauth2Meta.TokenEndpointAuthSigningAlgValuesSupported)
+	assert.Contains(suite.T(), oauth2Meta.TokenEndpointAuthSigningAlgValuesSupported, "ES256")
+	assert.Contains(suite.T(), oauth2Meta.TokenEndpointAuthSigningAlgValuesSupported, "PS256")
+	assert.Contains(suite.T(), oauth2Meta.TokenEndpointAuthSigningAlgValuesSupported, "EdDSA")
+}
+
 func (suite *DiscoveryTestSuite) TestDPoPSigningAlgValuesOmittedWhenUnconfigured() {
 	config.ResetServerRuntime()
 	testConfig := &config.Config{

--- a/backend/internal/oauth/oauth2/discovery/model.go
+++ b/backend/internal/oauth/oauth2/discovery/model.go
@@ -20,6 +20,7 @@ type OAuth2AuthorizationServerMetadata struct {
 	ResponseTypesSupported                     []string `json:"response_types_supported"`
 	GrantTypesSupported                        []string `json:"grant_types_supported"`
 	TokenEndpointAuthMethodsSupported          []string `json:"token_endpoint_auth_methods_supported"`
+	TokenEndpointAuthSigningAlgValuesSupported []string `json:"token_endpoint_auth_signing_alg_values_supported,omitempty"` //nolint:lll
 	CodeChallengeMethodsSupported              []string `json:"code_challenge_methods_supported,omitempty"`
 	AuthorizationResponseIssParameterSupported bool     `json:"authorization_response_iss_parameter_supported"`
 	DPoPSigningAlgValuesSupported              []string `json:"dpop_signing_alg_values_supported,omitempty"`

--- a/backend/internal/oauth/oauth2/discovery/service.go
+++ b/backend/internal/oauth/oauth2/discovery/service.go
@@ -56,6 +56,7 @@ func (ds *discoveryService) GetOAuth2AuthorizationServerMetadata(
 		ResponseTypesSupported:                     ds.getSupportedResponseTypes(),
 		GrantTypesSupported:                        ds.getSupportedGrantTypes(),
 		TokenEndpointAuthMethodsSupported:          ds.getSupportedTokenEndpointAuthMethods(),
+		TokenEndpointAuthSigningAlgValuesSupported: ds.getSupportedTokenEndpointAuthSigningAlgs(),
 		CodeChallengeMethodsSupported:              ds.getSupportedCodeChallengeMethods(),
 		AuthorizationResponseIssParameterSupported: true,
 		DPoPSigningAlgValuesSupported:              ds.getSupportedDPoPSigningAlgs(),
@@ -183,6 +184,10 @@ func (ds *discoveryService) isGlobalPARRequired() bool {
 }
 
 func (ds *discoveryService) getSupportedDPoPSigningAlgs() []string {
+	return ds.cryptoProvider.GetSupportedSigningAlgorithms()
+}
+
+func (ds *discoveryService) getSupportedTokenEndpointAuthSigningAlgs() []string {
 	return ds.cryptoProvider.GetSupportedSigningAlgorithms()
 }
 

--- a/docs/content/guides/protocols/oauth-oidc/server-metadata.mdx
+++ b/docs/content/guides/protocols/oauth-oidc/server-metadata.mdx
@@ -49,6 +49,9 @@ curl https://{{productSlug}}.example.com/.well-known/openid-configuration
     "private_key_jwt",
     "none"
   ],
+  "token_endpoint_auth_signing_alg_values_supported": [
+    "RS256", "RS512", "PS256", "ES256", "ES384", "ES512", "EdDSA"
+  ],
   "dpop_signing_alg_values_supported": [
     "RS256", "RS512", "PS256", "ES256", "ES384", "ES512", "EdDSA"
   ],

--- a/tests/integration/oauth/discovery/discovery_test.go
+++ b/tests/integration/oauth/discovery/discovery_test.go
@@ -41,6 +41,7 @@ type OAuth2AuthorizationServerMetadata struct {
 	ResponseTypesSupported                     []string `json:"response_types_supported"`
 	GrantTypesSupported                        []string `json:"grant_types_supported"`
 	TokenEndpointAuthMethodsSupported          []string `json:"token_endpoint_auth_methods_supported"`
+	TokenEndpointAuthSigningAlgValuesSupported []string `json:"token_endpoint_auth_signing_alg_values_supported"`
 	CodeChallengeMethodsSupported              []string `json:"code_challenge_methods_supported,omitempty"`
 	AuthorizationResponseIssParameterSupported bool     `json:"authorization_response_iss_parameter_supported"`
 }
@@ -133,6 +134,13 @@ func (ts *DiscoveryTestSuite) TestOAuth2AuthorizationServerMetadata_GET_Success(
 	ts.Contains(metadata.TokenEndpointAuthMethodsSupported, "client_secret_basic", "Should support client_secret_basic")
 	ts.Contains(metadata.TokenEndpointAuthMethodsSupported, "client_secret_post", "Should support client_secret_post")
 	ts.Contains(metadata.TokenEndpointAuthMethodsSupported, "none", "Should support none")
+
+	// Verify token endpoint auth signing algs are advertised with FAPI 2.0 permitted algorithms (RFC 8414)
+	ts.NotEmpty(metadata.TokenEndpointAuthSigningAlgValuesSupported,
+		"token_endpoint_auth_signing_alg_values_supported should be present (FAPI 2.0)")
+	ts.Contains(metadata.TokenEndpointAuthSigningAlgValuesSupported, "PS256", "Should advertise PS256")
+	ts.Contains(metadata.TokenEndpointAuthSigningAlgValuesSupported, "ES256", "Should advertise ES256")
+	ts.Contains(metadata.TokenEndpointAuthSigningAlgValuesSupported, "EdDSA", "Should advertise EdDSA")
 
 	// Verify only S256 code challenge method is supported (plain is prohibited per OAuth 2.0 Security BCP)
 	ts.Equal([]string{"S256"}, metadata.CodeChallengeMethodsSupported,


### PR DESCRIPTION
FAPI 2.0 Security Profile (FAPI2-SP-FINAL-5.4) requires the authorization
server metadata to advertise the JWS algorithms the token endpoint uses to
verify private_key_jwt client assertions, via the RFC 8414 field
token_endpoint_auth_signing_alg_values_supported. ThunderID never emitted
this field, so it was absent from the discovery document and the conformance
test fapi2-security-profile-final-discovery-end-point-verification reported
it as not found.

Populate the field from the crypto provider's supported signing algorithms,
the same source used for dpop_signing_alg_values_supported. The advertised
list includes PS256, ES256 and EdDSA, which satisfies the profile.

Add unit and integration coverage for the new field.

Ticket for the same - https://github.com/thunder-id/thunderid/issues/4175

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4175

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth 2.0 discovery metadata now advertises supported token endpoint authentication signing algorithms, including ES256, PS256, and EdDSA.

* **Documentation**
  * Updated OAuth 2.0 server metadata examples to include supported token endpoint authentication signing algorithms.

* **Tests**
  * Added coverage to verify that supported signing algorithms are correctly reported in discovery responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->