### PR TITLE
Cascade resource, action and resource server deletions to role permissions

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -431,8 +431,8 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 		group:       groupService,
 		ou:          ouService,
 		resource:    resourceService,
-	}, applicationService, agentService, flowMgtService, roleAssignmentService, groupService,
-		ouService, ouUserResolver, ouGroupResolver, resourceService)
+	}, applicationService, agentService, flowMgtService, roleAssignmentService, roleService,
+		groupService, ouService, ouUserResolver, ouGroupResolver, resourceService)
 
 	// Initialize design resolve service for theme and layout resolution
 	designResolveService := resolve.Initialize(mux, themeMgtService, layoutMgtService, applicationService)

--- a/backend/internal/resource/error_constants.go
+++ b/backend/internal/resource/error_constants.go
@@ -312,4 +312,8 @@ var (
 
 	// errDefaultResourceServerLookupFailed is returned when resource server lookup fails.
 	errDefaultResourceServerLookupFailed = errors.New("failed to resolve default resource server")
+
+	// errDependencyRegistryNotSet is returned when a cascade delete is attempted before the
+	// dependency registry has been injected.
+	errDependencyRegistryNotSet = errors.New("dependency registry not set")
 )

--- a/backend/internal/resource/service.go
+++ b/backend/internal/resource/service.go
@@ -154,6 +154,26 @@ func (rs *resourceService) ensureNoBlockingDependencies(
 	return &ErrorCannotDelete
 }
 
+// cascadeDeleteDependents removes the references that other resources (such as role permissions)
+// hold on the deleted target. It is called inside the delete transaction, after the target row is
+// gone, so that providers resolving references against this service no longer see the target and
+// roll back with the delete when cleanup fails.
+func (rs *resourceService) cascadeDeleteDependents(ctx context.Context, resourceType, id string) error {
+	if rs.dependencyRegistry == nil {
+		rs.logger.Error(ctx, "Dependency registry not set; cannot cascade-delete dependents",
+			log.String("resourceType", resourceType), log.String("id", id))
+		return errDependencyRegistryNotSet
+	}
+
+	if _, err := rs.dependencyRegistry.CascadeDelete(ctx, resourceType, id); err != nil {
+		rs.logger.Error(ctx, "Failed to cascade-delete dependents",
+			log.String("resourceType", resourceType), log.String("id", id), log.Error(err))
+		return err
+	}
+
+	return nil
+}
+
 // GetResourceDependencies implements resourcedependency.Provider. A resource server is blocked from
 // deletion while it still has resources or resource-server-level actions; a resource is blocked while
 // it still has sub-resources or actions. These dependents live in the same store, so their existence
@@ -519,7 +539,7 @@ func (rs *resourceService) DeleteResourceServer(ctx context.Context, id string) 
 			rs.logger.Error(ctx, "Failed to delete resource server", log.Error(err))
 			return err
 		}
-		return nil
+		return rs.cascadeDeleteDependents(txCtx, resourcedependency.ResourceTypeResourceServer, id)
 	}); err != nil {
 		return &tidcommon.InternalServerError
 	}
@@ -854,7 +874,7 @@ func (rs *resourceService) DeleteResource(
 			rs.logger.Error(ctx, "Failed to delete resource", log.Error(err))
 			return err
 		}
-		return nil
+		return rs.cascadeDeleteDependents(txCtx, resourcedependency.ResourceTypeResource, id)
 	}); err != nil {
 		return &tidcommon.InternalServerError
 	}
@@ -1218,7 +1238,7 @@ func (rs *resourceService) DeleteAction(
 			rs.logger.Error(ctx, "Failed to delete action", log.Error(err))
 			return err
 		}
-		return nil
+		return rs.cascadeDeleteDependents(txCtx, resourcedependency.ResourceTypeAction, id)
 	}); err != nil {
 		return &tidcommon.InternalServerError
 	}

--- a/backend/internal/resource/service_test.go
+++ b/backend/internal/resource/service_test.go
@@ -72,6 +72,31 @@ func matchAction(expected providers.Action) interface{} {
 	})
 }
 
+// recordingCascadeDeleter is a dependency provider test double that records the cascade-delete
+// calls it receives, so tests can assert what a deletion cascaded to and in which order.
+type recordingCascadeDeleter struct {
+	calls []string
+	order *[]string
+	err   error
+}
+
+func (r *recordingCascadeDeleter) GetResourceDependencies(
+	_ context.Context, _, _ string) ([]resourcedependency.ResourceDependency, error) {
+	return []resourcedependency.ResourceDependency{}, nil
+}
+
+func (r *recordingCascadeDeleter) CascadeDeleteDependencies(
+	_ context.Context, resourceType, id string) (int, error) {
+	r.calls = append(r.calls, resourceType+":"+id)
+	if r.order != nil {
+		*r.order = append(*r.order, "cascade")
+	}
+	if r.err != nil {
+		return 0, r.err
+	}
+	return 1, nil
+}
+
 // Test Suite
 type ResourceServiceTestSuite struct {
 	suite.Suite
@@ -79,6 +104,14 @@ type ResourceServiceTestSuite struct {
 	mockOU            *oumock.OrganizationUnitServiceInterfaceMock
 	mockTransactioner *fakeTransactioner
 	service           ResourceServiceInterface
+}
+
+// registerCascadeDeleter re-registers the dependency registry with the given cascade deleter
+// alongside the service's own provider, and returns it for assertions.
+func (suite *ResourceServiceTestSuite) registerCascadeDeleter(
+	deleter *recordingCascadeDeleter) *recordingCascadeDeleter {
+	suite.service.SetDependencyRegistry(resourcedependency.Initialize(suite.service, deleter))
+	return deleter
 }
 
 func TestResourceServiceTestSuite(t *testing.T) {
@@ -796,6 +829,62 @@ func (suite *ResourceServiceTestSuite) TestDeleteResourceServer_Success() {
 	err := suite.service.DeleteResourceServer(context.Background(), "rs-123")
 
 	suite.Nil(err)
+}
+
+// Deleting a resource server must cascade so that references to it (such as role permissions) are
+// cleaned up instead of being left dangling.
+func (suite *ResourceServiceTestSuite) TestDeleteResourceServer_CascadesToDependents() {
+	order := []string{}
+	deleter := suite.registerCascadeDeleter(&recordingCascadeDeleter{order: &order})
+
+	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
+	suite.mockStore.On("GetResourceServer", mock.Anything,
+		"rs-123").Return(providers.ResourceServer{}, nil)
+	suite.mockStore.On("CheckResourceServerHasDependencies", mock.Anything,
+		"rs-123").Return(false, nil)
+	suite.mockStore.On("DeleteResourceServer", mock.Anything, "rs-123").Return(nil).
+		Run(func(_ mock.Arguments) { order = append(order, "delete") })
+
+	err := suite.service.DeleteResourceServer(context.Background(), "rs-123")
+
+	suite.Nil(err)
+	suite.Equal([]string{"resourceServer:rs-123"}, deleter.calls)
+	// The cascade resolves references against this service, so it must run after the target is gone.
+	suite.Equal([]string{"delete", "cascade"}, order)
+}
+
+func (suite *ResourceServiceTestSuite) TestDeleteResourceServer_CascadeFailureAbortsDelete() {
+	suite.registerCascadeDeleter(&recordingCascadeDeleter{err: errors.New("cascade error")})
+
+	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
+	suite.mockStore.On("GetResourceServer", mock.Anything,
+		"rs-123").Return(providers.ResourceServer{}, nil)
+	suite.mockStore.On("CheckResourceServerHasDependencies", mock.Anything,
+		"rs-123").Return(false, nil)
+	suite.mockStore.On("DeleteResourceServer", mock.Anything, "rs-123").Return(nil)
+
+	err := suite.service.DeleteResourceServer(context.Background(), "rs-123")
+
+	suite.NotNil(err)
+	suite.Equal(tidcommon.InternalServerError.Code, err.Code)
+}
+
+// Deletion must not silently skip cleanup when the registry was never injected, so the delete is
+// rolled back rather than leaving dependents dangling.
+func (suite *ResourceServiceTestSuite) TestDeleteResourceServer_FailsWhenRegistryMissing() {
+	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
+	suite.mockStore.On("GetResourceServer", mock.Anything,
+		"rs-123").Return(providers.ResourceServer{}, nil)
+	suite.mockStore.On("CheckResourceServerHasDependencies", mock.Anything,
+		"rs-123").Return(false, nil)
+	// Drop the registry once the blocking check has passed, isolating the cascade's own guard.
+	suite.mockStore.On("DeleteResourceServer", mock.Anything, "rs-123").Return(nil).
+		Run(func(_ mock.Arguments) { suite.service.SetDependencyRegistry(nil) })
+
+	svcErr := suite.service.DeleteResourceServer(context.Background(), "rs-123")
+
+	suite.NotNil(svcErr)
+	suite.Equal(tidcommon.InternalServerError.Code, svcErr.Code)
 }
 
 func (suite *ResourceServiceTestSuite) TestDeleteResourceServer_IdempotentWhenNotExists() {
@@ -1746,6 +1835,46 @@ func (suite *ResourceServiceTestSuite) TestDeleteResource_Success() {
 	err := suite.service.DeleteResource(context.Background(), "rs-123", "res-123")
 
 	suite.Nil(err)
+}
+
+// Deleting a resource must cascade so that role permissions granting it are cleaned up.
+func (suite *ResourceServiceTestSuite) TestDeleteResource_CascadesToDependents() {
+	order := []string{}
+	deleter := suite.registerCascadeDeleter(&recordingCascadeDeleter{order: &order})
+
+	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
+	suite.mockStore.On("GetResourceServer", mock.Anything,
+		"rs-123").Return(providers.ResourceServer{}, nil)
+	suite.mockStore.On("GetResource", mock.Anything,
+		"res-123", "rs-123").Return(providers.Resource{}, nil)
+	suite.mockStore.On("CheckResourceHasDependencies", mock.Anything,
+		"res-123").Return(false, nil)
+	suite.mockStore.On("DeleteResource", mock.Anything, "res-123", "rs-123").Return(nil).
+		Run(func(_ mock.Arguments) { order = append(order, "delete") })
+
+	err := suite.service.DeleteResource(context.Background(), "rs-123", "res-123")
+
+	suite.Nil(err)
+	suite.Equal([]string{"resource:res-123"}, deleter.calls)
+	suite.Equal([]string{"delete", "cascade"}, order)
+}
+
+func (suite *ResourceServiceTestSuite) TestDeleteResource_CascadeFailureAbortsDelete() {
+	suite.registerCascadeDeleter(&recordingCascadeDeleter{err: errors.New("cascade error")})
+
+	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
+	suite.mockStore.On("GetResourceServer", mock.Anything,
+		"rs-123").Return(providers.ResourceServer{}, nil)
+	suite.mockStore.On("GetResource", mock.Anything,
+		"res-123", "rs-123").Return(providers.Resource{}, nil)
+	suite.mockStore.On("CheckResourceHasDependencies", mock.Anything,
+		"res-123").Return(false, nil)
+	suite.mockStore.On("DeleteResource", mock.Anything, "res-123", "rs-123").Return(nil)
+
+	err := suite.service.DeleteResource(context.Background(), "rs-123", "res-123")
+
+	suite.NotNil(err)
+	suite.Equal(tidcommon.InternalServerError.Code, err.Code)
 }
 
 func (suite *ResourceServiceTestSuite) TestDeleteResource_HasDependencies() {
@@ -3384,6 +3513,44 @@ func (suite *ResourceServiceTestSuite) TestDeleteActionAtResourceServer_Success(
 	err := suite.service.DeleteAction(context.Background(), "rs-123", nil, "action-123")
 
 	suite.Nil(err)
+}
+
+// Deleting an action must cascade so that role permissions granting it are cleaned up.
+func (suite *ResourceServiceTestSuite) TestDeleteActionAtResourceServer_CascadesToDependents() {
+	order := []string{}
+	deleter := suite.registerCascadeDeleter(&recordingCascadeDeleter{order: &order})
+
+	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
+	suite.mockStore.On("GetResourceServer", mock.Anything,
+		"rs-123").Return(providers.ResourceServer{}, nil)
+	suite.mockStore.On("IsActionExist", mock.Anything,
+		"action-123", "rs-123", (*string)(nil)).Return(true, nil)
+	suite.mockStore.On("DeleteAction", mock.Anything,
+		"action-123", "rs-123", (*string)(nil)).Return(nil).
+		Run(func(_ mock.Arguments) { order = append(order, "delete") })
+
+	err := suite.service.DeleteAction(context.Background(), "rs-123", nil, "action-123")
+
+	suite.Nil(err)
+	suite.Equal([]string{"action:action-123"}, deleter.calls)
+	suite.Equal([]string{"delete", "cascade"}, order)
+}
+
+func (suite *ResourceServiceTestSuite) TestDeleteActionAtResourceServer_CascadeFailureAbortsDelete() {
+	suite.registerCascadeDeleter(&recordingCascadeDeleter{err: errors.New("cascade error")})
+
+	suite.mockStore.On("IsResourceServerDeclarative", "rs-123").Return(false)
+	suite.mockStore.On("GetResourceServer", mock.Anything,
+		"rs-123").Return(providers.ResourceServer{}, nil)
+	suite.mockStore.On("IsActionExist", mock.Anything,
+		"action-123", "rs-123", (*string)(nil)).Return(true, nil)
+	suite.mockStore.On("DeleteAction", mock.Anything,
+		"action-123", "rs-123", (*string)(nil)).Return(nil)
+
+	err := suite.service.DeleteAction(context.Background(), "rs-123", nil, "action-123")
+
+	suite.NotNil(err)
+	suite.Equal(tidcommon.InternalServerError.Code, err.Code)
 }
 
 func (suite *ResourceServiceTestSuite) TestDeleteActionAtResourceServer_MissingID() {

--- a/backend/internal/role/RoleServiceInterface_mock_test.go
+++ b/backend/internal/role/RoleServiceInterface_mock_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	mock "github.com/stretchr/testify/mock"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/internal/system/security"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 )
@@ -37,6 +38,78 @@ type RoleServiceInterfaceMock_Expecter struct {
 
 func (_m *RoleServiceInterfaceMock) EXPECT() *RoleServiceInterfaceMock_Expecter {
 	return &RoleServiceInterfaceMock_Expecter{mock: &_m.Mock}
+}
+
+// CascadeDeleteDependencies provides a mock function for the type RoleServiceInterfaceMock
+func (_mock *RoleServiceInterfaceMock) CascadeDeleteDependencies(ctx context.Context, resourceType string, id string) (int, error) {
+	ret := _mock.Called(ctx, resourceType, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CascadeDeleteDependencies")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (int, error)); ok {
+		return returnFunc(ctx, resourceType, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) int); ok {
+		r0 = returnFunc(ctx, resourceType, id)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, resourceType, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// RoleServiceInterfaceMock_CascadeDeleteDependencies_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CascadeDeleteDependencies'
+type RoleServiceInterfaceMock_CascadeDeleteDependencies_Call struct {
+	*mock.Call
+}
+
+// CascadeDeleteDependencies is a helper method to define mock.On call
+//   - ctx context.Context
+//   - resourceType string
+//   - id string
+func (_e *RoleServiceInterfaceMock_Expecter) CascadeDeleteDependencies(ctx interface{}, resourceType interface{}, id interface{}) *RoleServiceInterfaceMock_CascadeDeleteDependencies_Call {
+	return &RoleServiceInterfaceMock_CascadeDeleteDependencies_Call{Call: _e.mock.On("CascadeDeleteDependencies", ctx, resourceType, id)}
+}
+
+func (_c *RoleServiceInterfaceMock_CascadeDeleteDependencies_Call) Run(run func(ctx context.Context, resourceType string, id string)) *RoleServiceInterfaceMock_CascadeDeleteDependencies_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *RoleServiceInterfaceMock_CascadeDeleteDependencies_Call) Return(n int, err error) *RoleServiceInterfaceMock_CascadeDeleteDependencies_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *RoleServiceInterfaceMock_CascadeDeleteDependencies_Call) RunAndReturn(run func(ctx context.Context, resourceType string, id string) (int, error)) *RoleServiceInterfaceMock_CascadeDeleteDependencies_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // CreateRole provides a mock function for the type RoleServiceInterfaceMock
@@ -328,6 +401,80 @@ func (_c *RoleServiceInterfaceMock_GetAuthorizedPermissionsByResourceServer_Call
 }
 
 func (_c *RoleServiceInterfaceMock_GetAuthorizedPermissionsByResourceServer_Call) RunAndReturn(run func(ctx context.Context, entityID string, groups []string, resourceServerID string, requestedPermissions []string) ([]string, *common.ServiceError)) *RoleServiceInterfaceMock_GetAuthorizedPermissionsByResourceServer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetResourceDependencies provides a mock function for the type RoleServiceInterfaceMock
+func (_mock *RoleServiceInterfaceMock) GetResourceDependencies(ctx context.Context, resourceType string, id string) ([]resourcedependency.ResourceDependency, error) {
+	ret := _mock.Called(ctx, resourceType, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetResourceDependencies")
+	}
+
+	var r0 []resourcedependency.ResourceDependency
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) ([]resourcedependency.ResourceDependency, error)); ok {
+		return returnFunc(ctx, resourceType, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) []resourcedependency.ResourceDependency); ok {
+		r0 = returnFunc(ctx, resourceType, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]resourcedependency.ResourceDependency)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, resourceType, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// RoleServiceInterfaceMock_GetResourceDependencies_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetResourceDependencies'
+type RoleServiceInterfaceMock_GetResourceDependencies_Call struct {
+	*mock.Call
+}
+
+// GetResourceDependencies is a helper method to define mock.On call
+//   - ctx context.Context
+//   - resourceType string
+//   - id string
+func (_e *RoleServiceInterfaceMock_Expecter) GetResourceDependencies(ctx interface{}, resourceType interface{}, id interface{}) *RoleServiceInterfaceMock_GetResourceDependencies_Call {
+	return &RoleServiceInterfaceMock_GetResourceDependencies_Call{Call: _e.mock.On("GetResourceDependencies", ctx, resourceType, id)}
+}
+
+func (_c *RoleServiceInterfaceMock_GetResourceDependencies_Call) Run(run func(ctx context.Context, resourceType string, id string)) *RoleServiceInterfaceMock_GetResourceDependencies_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *RoleServiceInterfaceMock_GetResourceDependencies_Call) Return(resourceDependencys []resourcedependency.ResourceDependency, err error) *RoleServiceInterfaceMock_GetResourceDependencies_Call {
+	_c.Call.Return(resourceDependencys, err)
+	return _c
+}
+
+func (_c *RoleServiceInterfaceMock_GetResourceDependencies_Call) RunAndReturn(run func(ctx context.Context, resourceType string, id string) ([]resourcedependency.ResourceDependency, error)) *RoleServiceInterfaceMock_GetResourceDependencies_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/role/composite_store.go
+++ b/backend/internal/role/composite_store.go
@@ -358,6 +358,18 @@ func (c *compositeRoleStore) DeleteAssignmentsByAssignee(
 	return c.dbStore.DeleteAssignmentsByAssignee(ctx, assigneeType, assigneeID)
 }
 
+// GetReferencedPermissions returns the permissions referenced by database-backed roles only.
+// Declarative roles are immutable, so their permissions are never pruned.
+func (c *compositeRoleStore) GetReferencedPermissions(ctx context.Context) ([]ResourcePermissions, error) {
+	return c.dbStore.GetReferencedPermissions(ctx)
+}
+
+// DeleteRolePermission removes the permission from the database store only.
+func (c *compositeRoleStore) DeleteRolePermission(
+	ctx context.Context, resourceServerID, permission string) (int64, error) {
+	return c.dbStore.DeleteRolePermission(ctx, resourceServerID, permission)
+}
+
 // AddAssignments adds assignments to a role in the database store only.
 func (c *compositeRoleStore) AddAssignments(ctx context.Context, id string, assignments []RoleAssignment) error {
 	return c.dbStore.AddAssignments(ctx, id, assignments)

--- a/backend/internal/role/composite_store_test.go
+++ b/backend/internal/role/composite_store_test.go
@@ -338,3 +338,23 @@ func (suite *CompositeRoleStoreTestSuite) TestGetRoleAssignments_FileAssignments
 	suite.Error(err)
 	suite.Equal(testErr, err)
 }
+
+// Only database-backed role permissions are prunable, so both cascade hooks must bypass the file
+// store entirely rather than consulting or mutating declarative roles.
+func (suite *CompositeRoleStoreTestSuite) TestCascadeHooks_UseDatabaseStoreOnly() {
+	referenced := []ResourcePermissions{{ResourceServerID: "rs1", Permissions: []string{"read"}}}
+	suite.mockDBStore.On("GetReferencedPermissions", mock.Anything).Return(referenced, nil)
+	suite.mockDBStore.On("DeleteRolePermission", mock.Anything, "rs1", "read").Return(int64(2), nil)
+
+	result, err := suite.store.GetReferencedPermissions(context.Background())
+	suite.NoError(err)
+	suite.Equal(referenced, result)
+
+	deleted, err := suite.store.DeleteRolePermission(context.Background(), "rs1", "read")
+	suite.NoError(err)
+	suite.Equal(int64(2), deleted)
+
+	suite.mockFileStore.AssertNotCalled(suite.T(), "GetReferencedPermissions", mock.Anything)
+	suite.mockFileStore.AssertNotCalled(suite.T(), "DeleteRolePermission",
+		mock.Anything, mock.Anything, mock.Anything)
+}

--- a/backend/internal/role/file_based_store.go
+++ b/backend/internal/role/file_based_store.go
@@ -318,6 +318,19 @@ func (f *fileBasedStore) DeleteAssignmentsByAssignee(
 	return 0, nil
 }
 
+// GetReferencedPermissions returns no permissions for the file-based store: declarative role
+// permissions are immutable, so they are never pruned.
+func (f *fileBasedStore) GetReferencedPermissions(_ context.Context) ([]ResourcePermissions, error) {
+	return []ResourcePermissions{}, nil
+}
+
+// DeleteRolePermission is a no-op for the file-based store: declarative role permissions are
+// immutable, so there is nothing to remove.
+func (f *fileBasedStore) DeleteRolePermission(
+	_ context.Context, _, _ string) (int64, error) {
+	return 0, nil
+}
+
 // AddAssignments is not supported in file-based store.
 func (f *fileBasedStore) AddAssignments(ctx context.Context, id string, assignments []RoleAssignment) error {
 	return errors.New("AddAssignments is not supported in file-based store")

--- a/backend/internal/role/file_based_store_test.go
+++ b/backend/internal/role/file_based_store_test.go
@@ -426,3 +426,24 @@ func (suite *RoleFileBasedStoreTestSuite) TestGetAllPermissionsForAssignees_Enum
 	suite.Len(result, 1)
 	suite.Equal([]string{"system:user"}, result[0].Permissions)
 }
+
+// Declarative role permissions are immutable, so the cascade hooks report nothing and remove
+// nothing rather than attempting to mutate the file store.
+func (suite *RoleFileBasedStoreTestSuite) TestCascadeHooksAreNoOps() {
+	suite.seedRole(RoleWithPermissionsAndAssignments{
+		ID:   "declarative-role",
+		Name: "Declarative",
+		OUID: "ou1",
+		Permissions: []ResourcePermissions{
+			{ResourceServerID: "rs1", Permissions: []string{"system:user"}},
+		},
+	})
+
+	referenced, err := suite.store.GetReferencedPermissions(context.Background())
+	suite.NoError(err)
+	suite.Empty(referenced)
+
+	deleted, err := suite.store.DeleteRolePermission(context.Background(), "rs1", "system:user")
+	suite.NoError(err)
+	suite.Equal(int64(0), deleted)
+}

--- a/backend/internal/role/roleStoreInterface_mock_test.go
+++ b/backend/internal/role/roleStoreInterface_mock_test.go
@@ -499,6 +499,78 @@ func (_c *roleStoreInterfaceMock_DeleteRole_Call) RunAndReturn(run func(ctx cont
 	return _c
 }
 
+// DeleteRolePermission provides a mock function for the type roleStoreInterfaceMock
+func (_mock *roleStoreInterfaceMock) DeleteRolePermission(ctx context.Context, resourceServerID string, permission string) (int64, error) {
+	ret := _mock.Called(ctx, resourceServerID, permission)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteRolePermission")
+	}
+
+	var r0 int64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (int64, error)); ok {
+		return returnFunc(ctx, resourceServerID, permission)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) int64); ok {
+		r0 = returnFunc(ctx, resourceServerID, permission)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, resourceServerID, permission)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// roleStoreInterfaceMock_DeleteRolePermission_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteRolePermission'
+type roleStoreInterfaceMock_DeleteRolePermission_Call struct {
+	*mock.Call
+}
+
+// DeleteRolePermission is a helper method to define mock.On call
+//   - ctx context.Context
+//   - resourceServerID string
+//   - permission string
+func (_e *roleStoreInterfaceMock_Expecter) DeleteRolePermission(ctx interface{}, resourceServerID interface{}, permission interface{}) *roleStoreInterfaceMock_DeleteRolePermission_Call {
+	return &roleStoreInterfaceMock_DeleteRolePermission_Call{Call: _e.mock.On("DeleteRolePermission", ctx, resourceServerID, permission)}
+}
+
+func (_c *roleStoreInterfaceMock_DeleteRolePermission_Call) Run(run func(ctx context.Context, resourceServerID string, permission string)) *roleStoreInterfaceMock_DeleteRolePermission_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_DeleteRolePermission_Call) Return(n int64, err error) *roleStoreInterfaceMock_DeleteRolePermission_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_DeleteRolePermission_Call) RunAndReturn(run func(ctx context.Context, resourceServerID string, permission string) (int64, error)) *roleStoreInterfaceMock_DeleteRolePermission_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAllPermissionsForAssignees provides a mock function for the type roleStoreInterfaceMock
 func (_mock *roleStoreInterfaceMock) GetAllPermissionsForAssignees(ctx context.Context, entityID string, groupIDs []string) ([]ResourcePermissions, error) {
 	ret := _mock.Called(ctx, entityID, groupIDs)
@@ -729,6 +801,68 @@ func (_c *roleStoreInterfaceMock_GetEntityRoleIDs_Call) Return(strings []string,
 }
 
 func (_c *roleStoreInterfaceMock_GetEntityRoleIDs_Call) RunAndReturn(run func(ctx context.Context, entityID string, groupIDs []string) ([]string, error)) *roleStoreInterfaceMock_GetEntityRoleIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetReferencedPermissions provides a mock function for the type roleStoreInterfaceMock
+func (_mock *roleStoreInterfaceMock) GetReferencedPermissions(ctx context.Context) ([]ResourcePermissions, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetReferencedPermissions")
+	}
+
+	var r0 []ResourcePermissions
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) ([]ResourcePermissions, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) []ResourcePermissions); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]ResourcePermissions)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// roleStoreInterfaceMock_GetReferencedPermissions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetReferencedPermissions'
+type roleStoreInterfaceMock_GetReferencedPermissions_Call struct {
+	*mock.Call
+}
+
+// GetReferencedPermissions is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *roleStoreInterfaceMock_Expecter) GetReferencedPermissions(ctx interface{}) *roleStoreInterfaceMock_GetReferencedPermissions_Call {
+	return &roleStoreInterfaceMock_GetReferencedPermissions_Call{Call: _e.mock.On("GetReferencedPermissions", ctx)}
+}
+
+func (_c *roleStoreInterfaceMock_GetReferencedPermissions_Call) Run(run func(ctx context.Context)) *roleStoreInterfaceMock_GetReferencedPermissions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_GetReferencedPermissions_Call) Return(resourcePermissionss []ResourcePermissions, err error) *roleStoreInterfaceMock_GetReferencedPermissions_Call {
+	_c.Call.Return(resourcePermissionss, err)
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_GetReferencedPermissions_Call) RunAndReturn(run func(ctx context.Context) ([]ResourcePermissions, error)) *roleStoreInterfaceMock_GetReferencedPermissions_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/role/service.go
+++ b/backend/internal/role/service.go
@@ -7,6 +7,7 @@ package role
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
@@ -17,6 +18,7 @@ import (
 	resourcepkg "github.com/thunder-id/thunderid/internal/resource"
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/internal/system/security"
 	"github.com/thunder-id/thunderid/internal/system/sysauthz"
 	"github.com/thunder-id/thunderid/internal/system/utils"
@@ -46,6 +48,9 @@ type RoleServiceInterface interface {
 	ResolveRoleOUHandle(
 		ctx context.Context, role *RoleWithPermissionsAndAssignments,
 	) *tidcommon.ServiceError
+	GetResourceDependencies(
+		ctx context.Context, resourceType, id string) ([]resourcedependency.ResourceDependency, error)
+	CascadeDeleteDependencies(ctx context.Context, resourceType, id string) (int, error)
 }
 
 // roleService is the default implementation of the RoleServiceInterface.
@@ -697,4 +702,54 @@ func (rs *roleService) isRoleDeclarative(ctx context.Context, roleID string) boo
 	}
 
 	return isDeclarative
+}
+
+// GetResourceDependencies implements resourcedependency.Provider. Role permissions are cleaned up
+// via cascade rather than surfaced as blocking usages, so no dependencies are reported here.
+func (rs *roleService) GetResourceDependencies(
+	_ context.Context, _, _ string) ([]resourcedependency.ResourceDependency, error) {
+	return []resourcedependency.ResourceDependency{}, nil
+}
+
+// CascadeDeleteDependencies implements resourcedependency.CascadeDeleter. When a resource server,
+// resource or action is deleted, the permissions it contributed can no longer be resolved, so they
+// are removed from every role holding them. Permissions are stored as opaque strings scoped to a
+// resource server rather than as references to the resource that defines them, so the orphans are
+// found by re-validating the referenced permissions against the resource service. This also clears
+// any permission orphaned by an earlier deletion. Must be called after the target has been deleted,
+// so the deleted permissions no longer validate.
+func (rs *roleService) CascadeDeleteDependencies(
+	ctx context.Context, resourceType, _ string) (int, error) {
+	switch resourceType {
+	case resourcedependency.ResourceTypeResourceServer,
+		resourcedependency.ResourceTypeResource,
+		resourcedependency.ResourceTypeAction:
+	default:
+		return 0, nil
+	}
+
+	referenced, err := rs.roleStore.GetReferencedPermissions(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get permissions referenced by roles: %w", err)
+	}
+
+	deleted := 0
+	for _, resPerm := range referenced {
+		invalid, svcErr := rs.resourceService.ValidatePermissions(
+			ctx, resPerm.ResourceServerID, resPerm.Permissions)
+		if svcErr != nil {
+			return deleted, fmt.Errorf("failed to validate permissions of resource server %s: %s",
+				resPerm.ResourceServerID, svcErr.Error.DefaultValue)
+		}
+
+		for _, permission := range invalid {
+			removed, err := rs.roleStore.DeleteRolePermission(ctx, resPerm.ResourceServerID, permission)
+			if err != nil {
+				return deleted, fmt.Errorf("failed to delete orphaned role permission: %w", err)
+			}
+			deleted += int(removed)
+		}
+	}
+
+	return deleted, nil
 }

--- a/backend/internal/role/service_test.go
+++ b/backend/internal/role/service_test.go
@@ -17,6 +17,7 @@ import (
 	oupkg "github.com/thunder-id/thunderid/internal/ou"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/internal/system/sysauthz"
 	"github.com/thunder-id/thunderid/internal/system/utils"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
@@ -1542,6 +1543,126 @@ permissions:
 	if role.OUID != "" {
 		t.Errorf("OUID = %q, want empty (resolution happens later)", role.OUID)
 	}
+}
+
+// CascadeDeleteDependencies Tests
+
+func (suite *RoleServiceTestSuite) TestGetResourceDependencies_ReportsNoUsages() {
+	deps, err := suite.service.GetResourceDependencies(
+		context.Background(), resourcedependency.ResourceTypeResource, "res1")
+
+	suite.NoError(err)
+	suite.Empty(deps)
+}
+
+func (suite *RoleServiceTestSuite) TestCascadeDeleteDependencies_IgnoresUnrelatedResourceTypes() {
+	for _, resourceType := range []string{
+		resourcedependency.ResourceTypeUser,
+		resourcedependency.ResourceTypeGroup,
+		resourcedependency.ResourceTypeApplication,
+	} {
+		deleted, err := suite.service.CascadeDeleteDependencies(context.Background(), resourceType, "id1")
+
+		suite.NoError(err)
+		suite.Equal(0, deleted)
+	}
+
+	suite.mockStore.AssertNotCalled(suite.T(), "GetReferencedPermissions", mock.Anything)
+}
+
+func (suite *RoleServiceTestSuite) TestCascadeDeleteDependencies_RemovesOrphanedPermissions() {
+	suite.mockStore.On("GetReferencedPermissions", mock.Anything).Return([]ResourcePermissions{
+		{ResourceServerID: "rs1", Permissions: []string{"read", "write"}},
+	}, nil)
+	suite.mockResourceService.On("ValidatePermissions", mock.Anything,
+		"rs1", []string{"read", "write"}).Return([]string{"write"}, nil)
+	suite.mockStore.On("DeleteRolePermission", mock.Anything, "rs1", "write").Return(int64(2), nil)
+
+	deleted, err := suite.service.CascadeDeleteDependencies(
+		context.Background(), resourcedependency.ResourceTypeAction, "action1")
+
+	suite.NoError(err)
+	suite.Equal(2, deleted)
+	suite.mockStore.AssertNotCalled(suite.T(), "DeleteRolePermission", mock.Anything, "rs1", "read")
+}
+
+func (suite *RoleServiceTestSuite) TestCascadeDeleteDependencies_KeepsValidPermissions() {
+	suite.mockStore.On("GetReferencedPermissions", mock.Anything).Return([]ResourcePermissions{
+		{ResourceServerID: "rs1", Permissions: []string{"read"}},
+	}, nil)
+	suite.mockResourceService.On("ValidatePermissions", mock.Anything,
+		"rs1", []string{"read"}).Return([]string{}, nil)
+
+	deleted, err := suite.service.CascadeDeleteDependencies(
+		context.Background(), resourcedependency.ResourceTypeResource, "res1")
+
+	suite.NoError(err)
+	suite.Equal(0, deleted)
+	suite.mockStore.AssertNotCalled(suite.T(), "DeleteRolePermission",
+		mock.Anything, mock.Anything, mock.Anything)
+}
+
+// A deleted resource server invalidates every permission scoped to it, so all of them are removed
+// while permissions of other resource servers are left alone.
+func (suite *RoleServiceTestSuite) TestCascadeDeleteDependencies_RemovesAllPermissionsOfDeletedServer() {
+	suite.mockStore.On("GetReferencedPermissions", mock.Anything).Return([]ResourcePermissions{
+		{ResourceServerID: "rs1", Permissions: []string{"read", "write"}},
+		{ResourceServerID: "rs2", Permissions: []string{"list"}},
+	}, nil)
+	suite.mockResourceService.On("ValidatePermissions", mock.Anything,
+		"rs1", []string{"read", "write"}).Return([]string{"read", "write"}, nil)
+	suite.mockResourceService.On("ValidatePermissions", mock.Anything,
+		"rs2", []string{"list"}).Return([]string{}, nil)
+	suite.mockStore.On("DeleteRolePermission", mock.Anything, "rs1", "read").Return(int64(1), nil)
+	suite.mockStore.On("DeleteRolePermission", mock.Anything, "rs1", "write").Return(int64(1), nil)
+
+	deleted, err := suite.service.CascadeDeleteDependencies(
+		context.Background(), resourcedependency.ResourceTypeResourceServer, "rs1")
+
+	suite.NoError(err)
+	suite.Equal(2, deleted)
+	suite.mockStore.AssertNotCalled(suite.T(), "DeleteRolePermission", mock.Anything, "rs2", "list")
+}
+
+func (suite *RoleServiceTestSuite) TestCascadeDeleteDependencies_StoreReadError() {
+	suite.mockStore.On("GetReferencedPermissions", mock.Anything).
+		Return([]ResourcePermissions{}, errors.New("database error"))
+
+	deleted, err := suite.service.CascadeDeleteDependencies(
+		context.Background(), resourcedependency.ResourceTypeResource, "res1")
+
+	suite.Error(err)
+	suite.Equal(0, deleted)
+}
+
+func (suite *RoleServiceTestSuite) TestCascadeDeleteDependencies_ValidationError() {
+	suite.mockStore.On("GetReferencedPermissions", mock.Anything).Return([]ResourcePermissions{
+		{ResourceServerID: "rs1", Permissions: []string{"read"}},
+	}, nil)
+	suite.mockResourceService.On("ValidatePermissions", mock.Anything,
+		"rs1", []string{"read"}).Return([]string(nil), &tidcommon.InternalServerError)
+
+	deleted, err := suite.service.CascadeDeleteDependencies(
+		context.Background(), resourcedependency.ResourceTypeResource, "res1")
+
+	suite.Error(err)
+	suite.Equal(0, deleted)
+}
+
+func (suite *RoleServiceTestSuite) TestCascadeDeleteDependencies_DeleteError() {
+	suite.mockStore.On("GetReferencedPermissions", mock.Anything).Return([]ResourcePermissions{
+		{ResourceServerID: "rs1", Permissions: []string{"read"}},
+	}, nil)
+	suite.mockResourceService.On("ValidatePermissions", mock.Anything,
+		"rs1", []string{"read"}).Return([]string{"read"}, nil)
+	suite.mockStore.On("DeleteRolePermission", mock.Anything, "rs1", "read").
+		Return(int64(0), errors.New("database error"))
+
+	deleted, err := suite.service.CascadeDeleteDependencies(
+		context.Background(), resourcedependency.ResourceTypeResource, "res1")
+
+	suite.Error(err)
+	suite.Equal(0, deleted)
 }
 
 // newAllowAllRoleAuthz returns an authz mock that permits every grant check, so that

--- a/backend/internal/role/store.go
+++ b/backend/internal/role/store.go
@@ -48,6 +48,11 @@ type roleStoreInterface interface {
 	GetAllPermissionsForAssignees(
 		ctx context.Context, entityID string, groupIDs []string) ([]ResourcePermissions, error)
 	GetUserRoles(ctx context.Context, entityID string, groupIDs []string) ([]string, error)
+	// GetReferencedPermissions returns the distinct permissions referenced by any role, grouped by
+	// resource server. Used to detect permissions left dangling by a resource deletion.
+	GetReferencedPermissions(ctx context.Context) ([]ResourcePermissions, error)
+	// DeleteRolePermission removes the given permission from every role that holds it.
+	DeleteRolePermission(ctx context.Context, resourceServerID, permission string) (int64, error)
 	// GetEntityRoleIDs returns the set of role IDs assigned to the entity directly or via
 	// group membership. Unlike GetUserRoles this does not require the role to exist in the
 	// underlying store; it returns raw assignee->role bindings. Used by the composite store
@@ -406,6 +411,51 @@ func (s *roleStore) DeleteAssignmentsByAssignee(
 		ctx, queryDeleteRoleAssignmentsByAssignee, assigneeType, assigneeID, s.deploymentID)
 	if err != nil {
 		return 0, fmt.Errorf("failed to delete assignments for assignee: %w", err)
+	}
+	return rowsAffected, nil
+}
+
+// GetReferencedPermissions returns the distinct permissions referenced by any role, grouped by
+// resource server.
+func (s *roleStore) GetReferencedPermissions(ctx context.Context) ([]ResourcePermissions, error) {
+	dbClient, err := s.getConfigDBClient()
+	if err != nil {
+		return nil, err
+	}
+
+	results, err := dbClient.QueryContext(ctx, queryGetReferencedPermissions, s.deploymentID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get referenced permissions: %w", err)
+	}
+
+	byResourceServer := make(map[string][]string)
+	for _, row := range results {
+		resourceServerID, ok := row["resource_server_id"].(string)
+		if !ok {
+			return nil, fmt.Errorf("failed to parse resource_server_id as string")
+		}
+		permission, ok := row["permission"].(string)
+		if !ok {
+			return nil, fmt.Errorf("failed to parse permission as string")
+		}
+		byResourceServer[resourceServerID] = append(byResourceServer[resourceServerID], permission)
+	}
+
+	return resourcePermissionsFromMap(byResourceServer), nil
+}
+
+// DeleteRolePermission removes the given permission from every role that holds it.
+func (s *roleStore) DeleteRolePermission(
+	ctx context.Context, resourceServerID, permission string) (int64, error) {
+	dbClient, err := s.getConfigDBClient()
+	if err != nil {
+		return 0, err
+	}
+
+	rowsAffected, err := dbClient.ExecuteContext(
+		ctx, queryDeleteRolePermissionByValue, resourceServerID, permission, s.deploymentID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete role permission: %w", err)
 	}
 	return rowsAffected, nil
 }

--- a/backend/internal/role/store_constants.go
+++ b/backend/internal/role/store_constants.go
@@ -69,6 +69,22 @@ var (
 		Query: `DELETE FROM "ROLE_PERMISSION" WHERE ROLE_ID = $1 AND DEPLOYMENT_ID = $2`,
 	}
 
+	// queryGetReferencedPermissions retrieves the distinct permissions referenced by any role,
+	// grouped by resource server (used to detect permissions orphaned by a resource deletion).
+	queryGetReferencedPermissions = dbmodel.DBQuery{
+		ID: "RLQ-ROLE_MGT-27",
+		Query: `SELECT DISTINCT RESOURCE_SERVER_ID, PERMISSION FROM "ROLE_PERMISSION" ` +
+			`WHERE DEPLOYMENT_ID = $1`,
+	}
+
+	// queryDeleteRolePermissionByValue deletes a single permission from every role that holds it
+	// (used to cascade-delete permissions orphaned by a resource, action or resource server deletion).
+	queryDeleteRolePermissionByValue = dbmodel.DBQuery{
+		ID: "RLQ-ROLE_MGT-28",
+		Query: `DELETE FROM "ROLE_PERMISSION" ` +
+			`WHERE RESOURCE_SERVER_ID = $1 AND PERMISSION = $2 AND DEPLOYMENT_ID = $3`,
+	}
+
 	// queryCreateRoleAssignment creates a new role assignment.
 	queryCreateRoleAssignment = dbmodel.DBQuery{
 		ID: "RLQ-ROLE_MGT-10",

--- a/backend/internal/role/store_test.go
+++ b/backend/internal/role/store_test.go
@@ -2097,3 +2097,113 @@ func (suite *RoleStoreTestSuite) TestDeleteAssignmentsByAssignee() {
 		suite.Equal(int64(0), deleted)
 	})
 }
+
+func (suite *RoleStoreTestSuite) TestGetReferencedPermissions() {
+	suite.Run("groups permissions by resource server", func() {
+		suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil).Once()
+		suite.mockDBClient.On("QueryContext", mock.Anything, queryGetReferencedPermissions,
+			testDeploymentID).Return([]map[string]interface{}{
+			{"resource_server_id": "rs1", "permission": "read"},
+			{"resource_server_id": "rs1", "permission": "write"},
+			{"resource_server_id": "rs2", "permission": "list"},
+		}, nil).Once()
+
+		referenced, err := suite.store.GetReferencedPermissions(context.Background())
+
+		suite.NoError(err)
+		suite.Equal([]ResourcePermissions{
+			{ResourceServerID: "rs1", Permissions: []string{"read", "write"}},
+			{ResourceServerID: "rs2", Permissions: []string{"list"}},
+		}, referenced)
+	})
+
+	suite.Run("no rows returns empty", func() {
+		suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil).Once()
+		suite.mockDBClient.On("QueryContext", mock.Anything, queryGetReferencedPermissions,
+			testDeploymentID).Return([]map[string]interface{}{}, nil).Once()
+
+		referenced, err := suite.store.GetReferencedPermissions(context.Background())
+
+		suite.NoError(err)
+		suite.Empty(referenced)
+	})
+
+	suite.Run("db client error is propagated", func() {
+		suite.mockDBProvider.On("GetConfigDBClient").Return(nil, errors.New("client error")).Once()
+
+		referenced, err := suite.store.GetReferencedPermissions(context.Background())
+
+		suite.Error(err)
+		suite.Nil(referenced)
+	})
+
+	suite.Run("query error is propagated", func() {
+		suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil).Once()
+		suite.mockDBClient.On("QueryContext", mock.Anything, queryGetReferencedPermissions,
+			testDeploymentID).Return(nil, errors.New("db error")).Once()
+
+		referenced, err := suite.store.GetReferencedPermissions(context.Background())
+
+		suite.Error(err)
+		suite.Nil(referenced)
+	})
+
+	suite.Run("malformed resource server id errors", func() {
+		suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil).Once()
+		suite.mockDBClient.On("QueryContext", mock.Anything, queryGetReferencedPermissions,
+			testDeploymentID).Return([]map[string]interface{}{
+			{"resource_server_id": 42, "permission": "read"},
+		}, nil).Once()
+
+		referenced, err := suite.store.GetReferencedPermissions(context.Background())
+
+		suite.Error(err)
+		suite.Nil(referenced)
+	})
+
+	suite.Run("malformed permission errors", func() {
+		suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil).Once()
+		suite.mockDBClient.On("QueryContext", mock.Anything, queryGetReferencedPermissions,
+			testDeploymentID).Return([]map[string]interface{}{
+			{"resource_server_id": "rs1", "permission": 42},
+		}, nil).Once()
+
+		referenced, err := suite.store.GetReferencedPermissions(context.Background())
+
+		suite.Error(err)
+		suite.Nil(referenced)
+	})
+}
+
+func (suite *RoleStoreTestSuite) TestDeleteRolePermission() {
+	suite.Run("success returns rows affected", func() {
+		suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil).Once()
+		suite.mockDBClient.On("ExecuteContext", mock.Anything, queryDeleteRolePermissionByValue,
+			"rs1", "read", testDeploymentID).Return(int64(3), nil).Once()
+
+		deleted, err := suite.store.DeleteRolePermission(context.Background(), "rs1", "read")
+
+		suite.NoError(err)
+		suite.Equal(int64(3), deleted)
+	})
+
+	suite.Run("db client error is propagated", func() {
+		suite.mockDBProvider.On("GetConfigDBClient").Return(nil, errors.New("client error")).Once()
+
+		deleted, err := suite.store.DeleteRolePermission(context.Background(), "rs1", "read")
+
+		suite.Error(err)
+		suite.Equal(int64(0), deleted)
+	})
+
+	suite.Run("db error is propagated", func() {
+		suite.mockDBProvider.On("GetConfigDBClient").Return(suite.mockDBClient, nil).Once()
+		suite.mockDBClient.On("ExecuteContext", mock.Anything, queryDeleteRolePermissionByValue,
+			"rs1", "read", testDeploymentID).Return(int64(0), errors.New("db error")).Once()
+
+		deleted, err := suite.store.DeleteRolePermission(context.Background(), "rs1", "read")
+
+		suite.Error(err)
+		suite.Equal(int64(0), deleted)
+	})
+}

--- a/backend/internal/system/resourcedependency/registry.go
+++ b/backend/internal/system/resourcedependency/registry.go
@@ -83,6 +83,7 @@ const (
 	ResourceTypeOU                 = "organizationUnit"
 	ResourceTypeResourceServer     = "resourceServer"
 	ResourceTypeResource           = "resource"
+	ResourceTypeAction             = "action"
 )
 
 // SummarizeBlockingUsages renders a deterministic, human-readable summary of blocking dependencies

--- a/backend/tests/mocks/rolemock/RoleServiceInterface_mock.go
+++ b/backend/tests/mocks/rolemock/RoleServiceInterface_mock.go
@@ -9,6 +9,7 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 	"github.com/thunder-id/thunderid/internal/role"
+	"github.com/thunder-id/thunderid/internal/system/resourcedependency"
 	"github.com/thunder-id/thunderid/internal/system/security"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 )
@@ -38,6 +39,78 @@ type RoleServiceInterfaceMock_Expecter struct {
 
 func (_m *RoleServiceInterfaceMock) EXPECT() *RoleServiceInterfaceMock_Expecter {
 	return &RoleServiceInterfaceMock_Expecter{mock: &_m.Mock}
+}
+
+// CascadeDeleteDependencies provides a mock function for the type RoleServiceInterfaceMock
+func (_mock *RoleServiceInterfaceMock) CascadeDeleteDependencies(ctx context.Context, resourceType string, id string) (int, error) {
+	ret := _mock.Called(ctx, resourceType, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CascadeDeleteDependencies")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (int, error)); ok {
+		return returnFunc(ctx, resourceType, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) int); ok {
+		r0 = returnFunc(ctx, resourceType, id)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, resourceType, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// RoleServiceInterfaceMock_CascadeDeleteDependencies_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CascadeDeleteDependencies'
+type RoleServiceInterfaceMock_CascadeDeleteDependencies_Call struct {
+	*mock.Call
+}
+
+// CascadeDeleteDependencies is a helper method to define mock.On call
+//   - ctx context.Context
+//   - resourceType string
+//   - id string
+func (_e *RoleServiceInterfaceMock_Expecter) CascadeDeleteDependencies(ctx interface{}, resourceType interface{}, id interface{}) *RoleServiceInterfaceMock_CascadeDeleteDependencies_Call {
+	return &RoleServiceInterfaceMock_CascadeDeleteDependencies_Call{Call: _e.mock.On("CascadeDeleteDependencies", ctx, resourceType, id)}
+}
+
+func (_c *RoleServiceInterfaceMock_CascadeDeleteDependencies_Call) Run(run func(ctx context.Context, resourceType string, id string)) *RoleServiceInterfaceMock_CascadeDeleteDependencies_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *RoleServiceInterfaceMock_CascadeDeleteDependencies_Call) Return(n int, err error) *RoleServiceInterfaceMock_CascadeDeleteDependencies_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *RoleServiceInterfaceMock_CascadeDeleteDependencies_Call) RunAndReturn(run func(ctx context.Context, resourceType string, id string) (int, error)) *RoleServiceInterfaceMock_CascadeDeleteDependencies_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // CreateRole provides a mock function for the type RoleServiceInterfaceMock
@@ -329,6 +402,80 @@ func (_c *RoleServiceInterfaceMock_GetAuthorizedPermissionsByResourceServer_Call
 }
 
 func (_c *RoleServiceInterfaceMock_GetAuthorizedPermissionsByResourceServer_Call) RunAndReturn(run func(ctx context.Context, entityID string, groups []string, resourceServerID string, requestedPermissions []string) ([]string, *common.ServiceError)) *RoleServiceInterfaceMock_GetAuthorizedPermissionsByResourceServer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetResourceDependencies provides a mock function for the type RoleServiceInterfaceMock
+func (_mock *RoleServiceInterfaceMock) GetResourceDependencies(ctx context.Context, resourceType string, id string) ([]resourcedependency.ResourceDependency, error) {
+	ret := _mock.Called(ctx, resourceType, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetResourceDependencies")
+	}
+
+	var r0 []resourcedependency.ResourceDependency
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) ([]resourcedependency.ResourceDependency, error)); ok {
+		return returnFunc(ctx, resourceType, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) []resourcedependency.ResourceDependency); ok {
+		r0 = returnFunc(ctx, resourceType, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]resourcedependency.ResourceDependency)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, resourceType, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// RoleServiceInterfaceMock_GetResourceDependencies_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetResourceDependencies'
+type RoleServiceInterfaceMock_GetResourceDependencies_Call struct {
+	*mock.Call
+}
+
+// GetResourceDependencies is a helper method to define mock.On call
+//   - ctx context.Context
+//   - resourceType string
+//   - id string
+func (_e *RoleServiceInterfaceMock_Expecter) GetResourceDependencies(ctx interface{}, resourceType interface{}, id interface{}) *RoleServiceInterfaceMock_GetResourceDependencies_Call {
+	return &RoleServiceInterfaceMock_GetResourceDependencies_Call{Call: _e.mock.On("GetResourceDependencies", ctx, resourceType, id)}
+}
+
+func (_c *RoleServiceInterfaceMock_GetResourceDependencies_Call) Run(run func(ctx context.Context, resourceType string, id string)) *RoleServiceInterfaceMock_GetResourceDependencies_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *RoleServiceInterfaceMock_GetResourceDependencies_Call) Return(resourceDependencys []resourcedependency.ResourceDependency, err error) *RoleServiceInterfaceMock_GetResourceDependencies_Call {
+	_c.Call.Return(resourceDependencys, err)
+	return _c
+}
+
+func (_c *RoleServiceInterfaceMock_GetResourceDependencies_Call) RunAndReturn(run func(ctx context.Context, resourceType string, id string) ([]resourcedependency.ResourceDependency, error)) *RoleServiceInterfaceMock_GetResourceDependencies_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/tests/mocks/rolemock/roleStoreInterface_mock.go
+++ b/backend/tests/mocks/rolemock/roleStoreInterface_mock.go
@@ -500,6 +500,78 @@ func (_c *roleStoreInterfaceMock_DeleteRole_Call) RunAndReturn(run func(ctx cont
 	return _c
 }
 
+// DeleteRolePermission provides a mock function for the type roleStoreInterfaceMock
+func (_mock *roleStoreInterfaceMock) DeleteRolePermission(ctx context.Context, resourceServerID string, permission string) (int64, error) {
+	ret := _mock.Called(ctx, resourceServerID, permission)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteRolePermission")
+	}
+
+	var r0 int64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (int64, error)); ok {
+		return returnFunc(ctx, resourceServerID, permission)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) int64); ok {
+		r0 = returnFunc(ctx, resourceServerID, permission)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, resourceServerID, permission)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// roleStoreInterfaceMock_DeleteRolePermission_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteRolePermission'
+type roleStoreInterfaceMock_DeleteRolePermission_Call struct {
+	*mock.Call
+}
+
+// DeleteRolePermission is a helper method to define mock.On call
+//   - ctx context.Context
+//   - resourceServerID string
+//   - permission string
+func (_e *roleStoreInterfaceMock_Expecter) DeleteRolePermission(ctx interface{}, resourceServerID interface{}, permission interface{}) *roleStoreInterfaceMock_DeleteRolePermission_Call {
+	return &roleStoreInterfaceMock_DeleteRolePermission_Call{Call: _e.mock.On("DeleteRolePermission", ctx, resourceServerID, permission)}
+}
+
+func (_c *roleStoreInterfaceMock_DeleteRolePermission_Call) Run(run func(ctx context.Context, resourceServerID string, permission string)) *roleStoreInterfaceMock_DeleteRolePermission_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_DeleteRolePermission_Call) Return(n int64, err error) *roleStoreInterfaceMock_DeleteRolePermission_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_DeleteRolePermission_Call) RunAndReturn(run func(ctx context.Context, resourceServerID string, permission string) (int64, error)) *roleStoreInterfaceMock_DeleteRolePermission_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAllPermissionsForAssignees provides a mock function for the type roleStoreInterfaceMock
 func (_mock *roleStoreInterfaceMock) GetAllPermissionsForAssignees(ctx context.Context, entityID string, groupIDs []string) ([]role.ResourcePermissions, error) {
 	ret := _mock.Called(ctx, entityID, groupIDs)
@@ -730,6 +802,68 @@ func (_c *roleStoreInterfaceMock_GetEntityRoleIDs_Call) Return(strings []string,
 }
 
 func (_c *roleStoreInterfaceMock_GetEntityRoleIDs_Call) RunAndReturn(run func(ctx context.Context, entityID string, groupIDs []string) ([]string, error)) *roleStoreInterfaceMock_GetEntityRoleIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetReferencedPermissions provides a mock function for the type roleStoreInterfaceMock
+func (_mock *roleStoreInterfaceMock) GetReferencedPermissions(ctx context.Context) ([]role.ResourcePermissions, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetReferencedPermissions")
+	}
+
+	var r0 []role.ResourcePermissions
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) ([]role.ResourcePermissions, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) []role.ResourcePermissions); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]role.ResourcePermissions)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// roleStoreInterfaceMock_GetReferencedPermissions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetReferencedPermissions'
+type roleStoreInterfaceMock_GetReferencedPermissions_Call struct {
+	*mock.Call
+}
+
+// GetReferencedPermissions is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *roleStoreInterfaceMock_Expecter) GetReferencedPermissions(ctx interface{}) *roleStoreInterfaceMock_GetReferencedPermissions_Call {
+	return &roleStoreInterfaceMock_GetReferencedPermissions_Call{Call: _e.mock.On("GetReferencedPermissions", ctx)}
+}
+
+func (_c *roleStoreInterfaceMock_GetReferencedPermissions_Call) Run(run func(ctx context.Context)) *roleStoreInterfaceMock_GetReferencedPermissions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_GetReferencedPermissions_Call) Return(resourcePermissionss []role.ResourcePermissions, err error) *roleStoreInterfaceMock_GetReferencedPermissions_Call {
+	_c.Call.Return(resourcePermissionss, err)
+	return _c
+}
+
+func (_c *roleStoreInterfaceMock_GetReferencedPermissions_Call) RunAndReturn(run func(ctx context.Context) ([]role.ResourcePermissions, error)) *roleStoreInterfaceMock_GetReferencedPermissions_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/tests/integration/role/roleapi_test.go
+++ b/tests/integration/role/roleapi_test.go
@@ -1480,6 +1480,103 @@ func (suite *RoleAPITestSuite) TestAddAssignments_DeclarativeRole() {
 	suite.True(found, "Assigned user should appear in the declarative role's assignment list")
 }
 
+// Deleting an action that a role grants must remove that permission from the role, rather than
+// leaving a reference that can no longer be resolved. Refs #4806.
+func (suite *RoleAPITestSuite) TestDeleteAction_CascadesToRolePermissions() {
+	rs := testutils.ResourceServer{
+		Name:        "Cascade Action Test System",
+		Description: "Resource server for action cascade testing",
+		Identifier:  "cascade-action-test-system",
+		OUID:        testOUID,
+	}
+	rsID, err := testutils.CreateResourceServerWithActions(rs, nil)
+	suite.Require().NoError(err)
+	defer func() { _ = testutils.DeleteResourceServer(rsID) }()
+
+	_, err = testutils.CreateAction(rsID, testutils.Action{
+		Name:   "Kept Action",
+		Handle: "kept",
+	})
+	suite.Require().NoError(err)
+	deletedActionID, err := testutils.CreateAction(rsID, testutils.Action{
+		Name:   "Deleted Action",
+		Handle: "deleted",
+	})
+	suite.Require().NoError(err)
+
+	role, err := suite.createRole(CreateRoleRequest{
+		Name:        "Cascade Action Role",
+		Description: "Role holding a permission that gets deleted",
+		OUID:        testOUID,
+		Permissions: []ResourcePermissions{
+			{ResourceServerID: rsID, Permissions: []string{"kept", "deleted"}},
+		},
+	})
+	suite.Require().NoError(err)
+	defer func() { _ = suite.deleteRole(role.ID) }()
+
+	suite.Require().NoError(testutils.DeleteAction(rsID, deletedActionID))
+
+	// The deleted action's permission must be gone, the surviving one untouched.
+	updated, err := suite.getRole(role.ID)
+	suite.Require().NoError(err)
+	suite.Require().Len(updated.Permissions, 1)
+	suite.Equal(rsID, updated.Permissions[0].ResourceServerID)
+	suite.Equal([]string{"kept"}, updated.Permissions[0].Permissions)
+
+	// The role must remain editable. The Console edits a role by sending back the permissions it
+	// read, so re-sending the fetched set must not trip permission validation.
+	_, err = suite.updateRole(role.ID, UpdateRoleRequest{
+		Name:        "Cascade Action Role Updated",
+		Description: "Role updated after its permission was deleted",
+		OUID:        testOUID,
+		Permissions: updated.Permissions,
+	})
+	suite.NoError(err, "Role permissions should be updatable after an assigned action is deleted")
+}
+
+// Deleting a resource server must remove every role permission scoped to it, so that viewing the
+// role afterwards does not fail to resolve the missing resource server. Refs #4806.
+func (suite *RoleAPITestSuite) TestDeleteResourceServer_CascadesToRolePermissions() {
+	rs := testutils.ResourceServer{
+		Name:        "Cascade Server Test System",
+		Description: "Resource server for server cascade testing",
+		Identifier:  "cascade-server-test-system",
+		OUID:        testOUID,
+	}
+	rsID, err := testutils.CreateResourceServerWithActions(rs, []testutils.Action{
+		{Name: "Doomed Action", Handle: "doomed"},
+	})
+	suite.Require().NoError(err)
+
+	role, err := suite.createRole(CreateRoleRequest{
+		Name:        "Cascade Server Role",
+		Description: "Role scoped to a resource server that gets deleted",
+		OUID:        testOUID,
+		Permissions: []ResourcePermissions{
+			{ResourceServerID: rsID, Permissions: []string{"doomed"}},
+			{ResourceServerID: testResourceServer2ID, Permissions: []string{testPermission3}},
+		},
+	})
+	suite.Require().NoError(err)
+	defer func() { _ = suite.deleteRole(role.ID) }()
+
+	// Actions must go before the resource server, matching the reported reproduction steps.
+	actions, err := testutils.GetActionsByResourceServer(rsID)
+	suite.Require().NoError(err)
+	for _, actionID := range actions {
+		suite.Require().NoError(testutils.DeleteAction(rsID, actionID))
+	}
+	suite.Require().NoError(testutils.DeleteResourceServer(rsID))
+
+	// Viewing the role must succeed and retain only the surviving resource server's permissions.
+	updated, err := suite.getRole(role.ID)
+	suite.Require().NoError(err, "Role should be viewable after its resource server is deleted")
+	suite.Require().Len(updated.Permissions, 1)
+	suite.Equal(testResourceServer2ID, updated.Permissions[0].ResourceServerID)
+	suite.Equal([]string{testPermission3}, updated.Permissions[0].Permissions)
+}
+
 // Helper methods
 
 func (suite *RoleAPITestSuite) createRole(request CreateRoleRequest) (*Role, error) {

--- a/tests/integration/testutils/api_utils.go
+++ b/tests/integration/testutils/api_utils.go
@@ -1381,6 +1381,71 @@ func DeleteResourceServer(rsID string) error {
 	return nil
 }
 
+// CreateAction creates an action on a resource server and returns the action ID.
+func CreateAction(resourceServerID string, action Action) (string, error) {
+	return createAction(resourceServerID, action)
+}
+
+// GetActionsByResourceServer returns the IDs of the actions defined on a resource server.
+func GetActionsByResourceServer(resourceServerID string) ([]string, error) {
+	client := GetHTTPClient()
+
+	url := fmt.Sprintf("%s/resource-servers/%s/actions", TestServerURL, resourceServerID)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create list-actions request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list actions: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("expected status 200, got %d. Response: %s", resp.StatusCode, string(body))
+	}
+
+	var listResp struct {
+		Actions []struct {
+			ID string `json:"id"`
+		} `json:"actions"`
+	}
+	if err := json.Unmarshal(body, &listResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal actions response: %w", err)
+	}
+
+	actionIDs := make([]string, 0, len(listResp.Actions))
+	for _, action := range listResp.Actions {
+		actionIDs = append(actionIDs, action.ID)
+	}
+	return actionIDs, nil
+}
+
+// DeleteAction deletes an action from a resource server.
+func DeleteAction(resourceServerID, actionID string) error {
+	client := GetHTTPClient()
+
+	url := fmt.Sprintf("%s/resource-servers/%s/actions/%s", TestServerURL, resourceServerID, actionID)
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create delete request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to delete action: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("expected status 204, got %d. Response: %s", resp.StatusCode, string(bodyBytes))
+	}
+	return nil
+}
+
 func PutDefaultResourceServer(resourceServerID string) error {
 	client := GetHTTPClient()
 


### PR DESCRIPTION
### Purpose
Deleting a resource, action or resource server left the permissions it contributed assigned to every role that held them. The stale references caused three problems: roles kept permissions that no longer existed, viewing a role's permissions failed with "resource server not found" once the server was deleted, and the role could no longer be updated because the stale permission failed validation.

### Approach
Resource deletions now participate in the existing dependency registry, which already handles cascade cleanup for user, group, application and agent deletions.

- `resourceService.DeleteResourceServer`, `DeleteResource` and `DeleteAction` call `CascadeDelete` inside their delete transaction, after the row is removed, so cleanup failures roll back with the delete.
- `roleService` is registered as a dependency provider and implements `CascadeDeleter`. Role permissions are stored as opaque strings scoped to a resource server rather than as references to the resource defining them, so orphans are found by re-validating referenced permissions through `resourceService.ValidatePermissions` instead of matching the deleted resource ID. This also clears permissions orphaned by earlier deletions, and keeps declarative resource servers correct since validation is composite-aware.
- Added a `ResourceTypeAction` dependency type.

Declarative role permissions are immutable and are never pruned.

### Related Issues
- Fixes #4806

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Deleting resource servers, resources, or actions now automatically removes related role permissions.
  - Unrelated and still-valid permissions are preserved.
  - Cleanup failures now return an error instead of leaving partially cleaned-up permissions.
  - Deletions now fail safely when cleanup services are unavailable.

- **Tests**
  - Added coverage for dependency cleanup, failure handling, and role permission preservation during deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->