### PR TITLE
Retain dynamic prompt inputs when a paused prompt is re-rendered

### DIFF
--- a/backend/internal/flow/flowexec/engine.go
+++ b/backend/internal/flow/flowexec/engine.go
@@ -164,6 +164,8 @@ func (fe *flowEngine) executeNodePackage(ctx *EngineContext,
 		FlowID:      ssoFlowID(ctx),
 		FlowVersion: ctx.SSOFlowVersion,
 	})
+	fe.replayPromptInputs(ctx)
+
 	nodeCtx := &providers.NodeContext{
 		Context:           ssoCtx,
 		ExecutionID:       ctx.ExecutionID,
@@ -1026,6 +1028,7 @@ func (fe *flowEngine) switchContextToCallee(ctx *EngineContext,
 	ctx.CurrentNodeResponse = nil
 	ctx.CurrentSegmentID = ""
 	ctx.CurrentAction = ""
+	ctx.clearPausedPromptInputs()
 
 	// Set the current node to the start node of the callee graph
 	startNode, startErr := calleeGraph.GetStartNode()
@@ -1211,6 +1214,34 @@ func (fe *flowEngine) resolveStepForRedirection(ctx *EngineContext, nodeResp *co
 	return nil
 }
 
+// replayPromptInputs restores the inputs the paused prompt resolved to into ForwardedData before
+// that same node runs again. Dynamic inputs (schema attributes an executor found missing, resolver
+// options) reach a prompt through ForwardedData, which executeNodePackage clears after a single hop,
+// so a bare resume or a page refresh would otherwise render the prompt with only its static inputs.
+// Skipped when an action was selected, since the prompt then evaluates against that action's own
+// inputs, and when an executor already forwarded inputs in this traversal.
+func (fe *flowEngine) replayPromptInputs(ctx *EngineContext) {
+	if len(ctx.CurrentPromptInputs) == 0 || ctx.CurrentNode == nil {
+		return
+	}
+	if ctx.CurrentAction != "" {
+		return
+	}
+	if ctx.CurrentNode.GetID() != ctx.CurrentPromptNodeID {
+		return
+	}
+	if ctx.ForwardedData != nil {
+		if _, ok := ctx.ForwardedData[common.ForwardedDataKeyInputs]; ok {
+			return
+		}
+	}
+
+	if ctx.ForwardedData == nil {
+		ctx.ForwardedData = make(map[string]interface{})
+	}
+	ctx.ForwardedData[common.ForwardedDataKeyInputs] = ctx.CurrentPromptInputs
+}
+
 // resolveStepDetailsForPrompt resolves the step details for a user prompt response.
 func (fe *flowEngine) resolveStepDetailsForPrompt(ctx *EngineContext, nodeResp *common.NodeResponse,
 	flowStep *FlowStep) error {
@@ -1265,6 +1296,12 @@ func (fe *flowEngine) resolveStepDetailsForPrompt(ctx *EngineContext, nodeResp *
 
 	if len(nodeResp.FieldErrors) > 0 {
 		flowStep.Data.FieldErrors = nodeResp.FieldErrors
+	}
+
+	// Record how this prompt resolved so re-entering it renders the same step.
+	if ctx.CurrentNode != nil {
+		ctx.CurrentPromptInputs = flowStep.Data.Inputs
+		ctx.CurrentPromptNodeID = ctx.CurrentNode.GetID()
 	}
 
 	flowStep.Status = providers.FlowStatusIncomplete

--- a/backend/internal/flow/flowexec/engine_test.go
+++ b/backend/internal/flow/flowexec/engine_test.go
@@ -611,6 +611,150 @@ func (s *EngineTestSuite) TestResolveStepForRedirection_AppendsInputs() {
 	s.Len(flowStep.Data.Inputs, 2)
 }
 
+func (s *EngineTestSuite) TestReplayPromptInputs_RestoresInputsForPausedPrompt() {
+	t := s.T()
+	mockCurrentNode := coremock.NewNodeInterfaceMock(t)
+	mockCurrentNode.On("GetID").Return("prompt-attrs").Maybe()
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{
+		Context:             context.Background(),
+		CurrentNode:         mockCurrentNode,
+		CurrentPromptNodeID: "prompt-attrs",
+		CurrentPromptInputs: []providers.Input{{Identifier: "given_name", Required: true}},
+	}
+
+	fe.replayPromptInputs(ctx)
+
+	replayed, ok := ctx.ForwardedData[common.ForwardedDataKeyInputs].([]providers.Input)
+	s.True(ok)
+	s.Len(replayed, 1)
+	s.Equal("given_name", replayed[0].Identifier)
+}
+
+func (s *EngineTestSuite) TestReplayPromptInputs_SkipsDifferentNode() {
+	t := s.T()
+	mockCurrentNode := coremock.NewNodeInterfaceMock(t)
+	mockCurrentNode.On("GetID").Return("some-other-node").Maybe()
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{
+		Context:             context.Background(),
+		CurrentNode:         mockCurrentNode,
+		CurrentPromptNodeID: "prompt-attrs",
+		CurrentPromptInputs: []providers.Input{{Identifier: "given_name", Required: true}},
+	}
+
+	fe.replayPromptInputs(ctx)
+
+	s.Nil(ctx.ForwardedData)
+}
+
+func (s *EngineTestSuite) TestReplayPromptInputs_SkipsWhenActionSelected() {
+	t := s.T()
+	mockCurrentNode := coremock.NewNodeInterfaceMock(t)
+	mockCurrentNode.On("GetID").Return("prompt-attrs").Maybe()
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{
+		Context:             context.Background(),
+		CurrentNode:         mockCurrentNode,
+		CurrentAction:       "action_google",
+		CurrentPromptNodeID: "prompt-attrs",
+		CurrentPromptInputs: []providers.Input{{Identifier: "username", Required: true}},
+	}
+
+	fe.replayPromptInputs(ctx)
+
+	// Selecting an action advances the flow: the prompt must evaluate against that action's own
+	// inputs, so an action declaring none must not be blocked by the previous rendering.
+	s.Nil(ctx.ForwardedData)
+}
+
+func (s *EngineTestSuite) TestReplayPromptInputs_KeepsFreshForwardedInputs() {
+	t := s.T()
+	mockCurrentNode := coremock.NewNodeInterfaceMock(t)
+	mockCurrentNode.On("GetID").Return("prompt-attrs").Maybe()
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	fresh := []providers.Input{{Identifier: "family_name", Required: true}}
+	ctx := &EngineContext{
+		Context:             context.Background(),
+		CurrentNode:         mockCurrentNode,
+		CurrentPromptNodeID: "prompt-attrs",
+		CurrentPromptInputs: []providers.Input{{Identifier: "given_name", Required: true}},
+		ForwardedData:       map[string]interface{}{common.ForwardedDataKeyInputs: fresh},
+	}
+
+	fe.replayPromptInputs(ctx)
+
+	// An upstream executor ran in this traversal, so its inputs win over the recorded ones.
+	replayed, ok := ctx.ForwardedData[common.ForwardedDataKeyInputs].([]providers.Input)
+	s.True(ok)
+	s.Len(replayed, 1)
+	s.Equal("family_name", replayed[0].Identifier)
+}
+
+func (s *EngineTestSuite) TestSwitchContextToCallee_DropsCallerPausedPrompt() {
+	t := s.T()
+	mockCallNode := coremock.NewNodeInterfaceMock(t)
+	mockCallNode.On("GetID").Return("call_mfa").Maybe()
+
+	// The callee's first prompt reuses the caller's prompt ID: node IDs are graph-local, so
+	// conventional names collide across flows.
+	mockStartNode := coremock.NewNodeInterfaceMock(t)
+	mockStartNode.On("GetID").Return("prompt_credentials").Maybe()
+
+	mockCalleeGraph := coremock.NewGraphInterfaceMock(t)
+	mockCalleeGraph.On("GetType").Return(providers.FlowTypeAuthentication).Maybe()
+	mockCalleeGraph.On("GetStartNode").Return(mockStartNode, nil).Maybe()
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{
+		Context:             context.Background(),
+		CurrentNode:         mockCallNode,
+		CurrentPromptNodeID: "prompt_credentials",
+		CurrentPromptInputs: []providers.Input{{Identifier: "given_name", Required: true}},
+	}
+
+	_, svcErr := fe.switchContextToCallee(ctx, &common.NodeResponse{}, mockCalleeGraph, log.GetLogger())
+	s.Nil(svcErr)
+
+	s.Empty(ctx.CurrentPromptNodeID)
+	s.Nil(ctx.CurrentPromptInputs)
+
+	// The callee's colliding prompt must not inherit the caller's inputs.
+	ctx.CurrentNode = mockStartNode
+	fe.replayPromptInputs(ctx)
+	s.Nil(ctx.ForwardedData)
+}
+
+func (s *EngineTestSuite) TestPopFrame_DropsCalleePausedPrompt() {
+	t := s.T()
+	mockCallerNode := coremock.NewNodeInterfaceMock(t)
+	mockCallerNode.On("GetID").Return("prompt_credentials").Maybe()
+
+	fe := &flowEngine{logger: log.GetLogger()}
+	ctx := &EngineContext{
+		Context:     context.Background(),
+		CurrentNode: mockCallerNode,
+	}
+	ctx.pushFrame("call_mfa")
+
+	// The callee paused on a prompt whose ID collides with a node in the caller graph.
+	ctx.CurrentPromptNodeID = "prompt_credentials"
+	ctx.CurrentPromptInputs = []providers.Input{{Identifier: "given_name", Required: true}}
+
+	s.NotNil(ctx.popFrame())
+
+	s.Empty(ctx.CurrentPromptNodeID)
+	s.Nil(ctx.CurrentPromptInputs)
+
+	// Back in the caller, the callee's record must not replay into the colliding node.
+	fe.replayPromptInputs(ctx)
+	s.Nil(ctx.ForwardedData)
+}
+
 func (s *EngineTestSuite) TestResolveStepDetailsForPrompt_WithMeta() {
 	fe := &flowEngine{}
 
@@ -2285,9 +2429,13 @@ func (s *EngineTestSuite) TestHandleIncompleteResponse_ViewType() {
 		Type:   common.NodeResponseTypeView,
 		Inputs: []providers.Input{{Identifier: "username", Required: true}},
 	}
+	mockCurrentNode.On("GetID").Return("prompt-node").Maybe()
+
 	err := fe.handleIncompleteResponse(ctx, nodeResp, flowStep, log.GetLogger())
 	s.Nil(err)
 	s.Equal(providers.FlowStatusIncomplete, flowStep.Status)
+	s.Equal("prompt-node", ctx.CurrentPromptNodeID)
+	s.Len(ctx.CurrentPromptInputs, 1)
 }
 
 func (s *EngineTestSuite) TestHandleIncompleteResponse_RedirectionError() {

--- a/backend/internal/flow/flowexec/model.go
+++ b/backend/internal/flow/flowexec/model.go
@@ -57,6 +57,11 @@ type EngineContext struct {
 	CurrentAction       string
 	CurrentSegmentID    string
 
+	// CurrentPromptInputs holds the inputs the prompt the flow is paused on resolved to, with the id
+	// of the node that produced them. Persisted with the context and replayed by replayPromptInputs.
+	CurrentPromptInputs []providers.Input
+	CurrentPromptNodeID string
+
 	Graph       core.GraphInterface
 	Application providers.Application
 
@@ -143,7 +148,16 @@ func (e *EngineContext) popFrame() *frame {
 	e.RuntimeData = top.runtimeData
 	e.ForwardedData = top.forwardedData
 	e.AdditionalData = top.additionalData
+	e.clearPausedPromptInputs()
 	return top
+}
+
+// clearPausedPromptInputs drops the paused-prompt record. It is keyed by node ID, which is only
+// unique within a graph, so it must not outlive a caller/callee graph switch: a node in the graph
+// being entered that shares the ID would otherwise replay inputs from an unrelated prompt.
+func (e *EngineContext) clearPausedPromptInputs() {
+	e.CurrentPromptInputs = nil
+	e.CurrentPromptNodeID = ""
 }
 
 // frameDepth returns the number of saved frames (0 means root flow).
@@ -324,6 +338,8 @@ type flowContextContent struct {
 	FrameStack            *string `json:"frameStack,omitempty"`
 	SharedRuntimeData     *string `json:"sharedRuntimeData,omitempty"`
 	InitiatorRequest      *string `json:"initiatorRequest,omitempty"`
+	PromptInputs          *string `json:"promptInputs,omitempty"`
+	PromptNodeID          *string `json:"promptNodeId,omitempty"`
 }
 
 // graphResolverFunc resolves a flow graph by its flow ID. Used during context deserialization to
@@ -337,6 +353,47 @@ func (f *FlowContextDB) GetGraphID(_ context.Context) (string, error) {
 		return "", err
 	}
 	return content.GraphID, nil
+}
+
+// buildAuthenticatedUser assembles the authenticated user from the serialized context.
+func buildAuthenticatedUser(content flowContextContent, userAttributes map[string]interface{}, token string,
+	availableAttributes *providers.AttributesResponse) authncm.AuthenticatedUser {
+	authenticatedUser := authncm.AuthenticatedUser{
+		IsAuthenticated:     content.IsAuthenticated,
+		UserID:              "",
+		Attributes:          userAttributes,
+		Token:               token,
+		AvailableAttributes: availableAttributes,
+	}
+	if content.UserID != nil {
+		authenticatedUser.UserID = *content.UserID
+	}
+	if content.OUID != nil {
+		authenticatedUser.OUID = *content.OUID
+	}
+	if content.UserType != nil {
+		authenticatedUser.UserType = *content.UserType
+	}
+
+	return authenticatedUser
+}
+
+// parsePausedPrompt deserializes the inputs of the prompt the flow is paused on, together with the
+// id of the node that produced them. Both are empty when the flow is not paused on a prompt.
+func parsePausedPrompt(content flowContextContent) ([]providers.Input, string, error) {
+	var promptInputs []providers.Input
+	if content.PromptInputs != nil {
+		if err := json.Unmarshal([]byte(*content.PromptInputs), &promptInputs); err != nil {
+			return nil, "", err
+		}
+	}
+
+	var promptNodeID string
+	if content.PromptNodeID != nil {
+		promptNodeID = *content.PromptNodeID
+	}
+
+	return promptInputs, promptNodeID, nil
 }
 
 // ToEngineContext converts the database model to the flow engine context.
@@ -392,22 +449,7 @@ func (f *FlowContextDB) ToEngineContext(ctx context.Context,
 	}
 
 	// Build authenticated user
-	authenticatedUser := authncm.AuthenticatedUser{
-		IsAuthenticated:     content.IsAuthenticated,
-		UserID:              "",
-		Attributes:          userAttributes,
-		Token:               token,
-		AvailableAttributes: availableAttributes,
-	}
-	if content.UserID != nil {
-		authenticatedUser.UserID = *content.UserID
-	}
-	if content.OUID != nil {
-		authenticatedUser.OUID = *content.OUID
-	}
-	if content.UserType != nil {
-		authenticatedUser.UserType = *content.UserType
-	}
+	authenticatedUser := buildAuthenticatedUser(content, userAttributes, token, availableAttributes)
 
 	// Parse execution history
 	var executionHistory map[string]*providers.NodeExecutionRecord
@@ -471,6 +513,12 @@ func (f *FlowContextDB) ToEngineContext(ctx context.Context,
 		}
 	}
 
+	// Parse the inputs of the prompt the flow is paused on
+	promptInputs, promptNodeID, err := parsePausedPrompt(content)
+	if err != nil {
+		return EngineContext{}, err
+	}
+
 	// Parse initiator request if present
 	var initiatorRequest *providers.InitiatorRequest
 	if content.InitiatorRequest != nil {
@@ -500,6 +548,8 @@ func (f *FlowContextDB) ToEngineContext(ctx context.Context,
 		InterceptorSharedData: interceptorSharedData,
 		frameStack:            frameStack,
 		sharedRuntimeData:     sharedRuntimeData,
+		CurrentPromptInputs:   promptInputs,
+		CurrentPromptNodeID:   promptNodeID,
 	}
 	engineCtx.SetInitiatorRequest(initiatorRequest)
 
@@ -630,6 +680,19 @@ func (f *FlowContextDB) FromEngineContext(ctx EngineContext) error {
 		sharedRuntimeDataStr = &s
 	}
 
+	// Serialize the inputs of the prompt the flow is paused on
+	var promptInputsStr, promptNodeIDStr *string
+	if len(ctx.CurrentPromptInputs) > 0 && ctx.CurrentPromptNodeID != "" {
+		promptInputsJSON, err := json.Marshal(ctx.CurrentPromptInputs)
+		if err != nil {
+			return err
+		}
+		s := string(promptInputsJSON)
+		promptInputsStr = &s
+		nodeID := ctx.CurrentPromptNodeID
+		promptNodeIDStr = &nodeID
+	}
+
 	// Serialize initiator request if present
 	var initiatorRequestStr *string
 	if ctx.initiatorRequest != nil {
@@ -663,6 +726,8 @@ func (f *FlowContextDB) FromEngineContext(ctx EngineContext) error {
 		FrameStack:            frameStackStr,
 		SharedRuntimeData:     sharedRuntimeDataStr,
 		InitiatorRequest:      initiatorRequestStr,
+		PromptInputs:          promptInputsStr,
+		PromptNodeID:          promptNodeIDStr,
 	}
 
 	contextJSON, err := json.Marshal(content)

--- a/tests/integration/flow/registration/magic_link_registration_resume_test.go
+++ b/tests/integration/flow/registration/magic_link_registration_resume_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package registration
+
+import (
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// TestMagicLinkRegistration_ResumeRetainsDynamicInputs asserts that re-rendering a paused prompt
+// reproduces the step, including inputs the flow only learned about at runtime. The schema
+// attributes here are not declared on the node: ProvisioningExecutor forwards them, and forwarded
+// data lives for a single hop, so a client that resumes rather than replays that step would
+// otherwise be shown a prompt with no fields and no way to satisfy the flow.
+func (ts *MagicLinkRegistrationTestSuite) TestMagicLinkRegistration_ResumeRetainsDynamicInputs() {
+	ts.mockSMTP.ClearEmails()
+	emailAddr := common.GenerateUniqueUsername("resume") + "@example.com"
+
+	flowStep, err := common.InitiateRegistrationFlow(ts.appID, false, nil, "")
+	ts.Require().NoError(err)
+
+	step2, err := common.CompleteFlow(flowStep.ExecutionID, map[string]string{"email": emailAddr},
+		"magic_link_action", flowStep.ChallengeToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal("INCOMPLETE", step2.FlowStatus)
+
+	token := common.ExtractMagicLinkToken(ts.waitForEmail())
+	ts.Require().NotEmpty(token)
+
+	// Verifying the token pauses on the dynamic attribute prompt.
+	step3, err := common.CompleteFlow(flowStep.ExecutionID, map[string]string{"token": token}, "", "")
+	ts.Require().NoError(err)
+	ts.Require().Equal("INCOMPLETE", step3.FlowStatus)
+	ts.Require().True(common.HasInput(step3.Data.Inputs, "given_name"))
+	ts.Require().True(common.HasInput(step3.Data.Inputs, "family_name"))
+
+	// Resuming without inputs or an action must render that same prompt, fields included.
+	resumed, err := common.CompleteFlow(flowStep.ExecutionID, map[string]string{}, "", step3.ChallengeToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal("INCOMPLETE", resumed.FlowStatus)
+	ts.Require().True(common.HasInput(resumed.Data.Inputs, "given_name"),
+		"given_name must survive a resume of the paused prompt")
+	ts.Require().True(common.HasInput(resumed.Data.Inputs, "family_name"),
+		"family_name must survive a resume of the paused prompt")
+
+	// Resuming repeatedly stays stable.
+	resumedAgain, err := common.CompleteFlow(flowStep.ExecutionID, map[string]string{}, "", resumed.ChallengeToken)
+	ts.Require().NoError(err)
+	ts.Require().True(common.HasInput(resumedAgain.Data.Inputs, "given_name"))
+	ts.Require().True(common.HasInput(resumedAgain.Data.Inputs, "family_name"))
+
+	// The attributes gathered from the resumed prompt still complete the flow.
+	inputs := map[string]string{
+		"username":    common.GenerateUniqueUsername("username"),
+		"given_name":  "Test",
+		"family_name": "User",
+	}
+	final, err := common.CompleteFlow(flowStep.ExecutionID, inputs, "action_schema_attrs", resumedAgain.ChallengeToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal("COMPLETE", final.FlowStatus)
+
+	user, err := testutils.FindUserByAttribute("email", emailAddr)
+	ts.Require().NoError(err)
+	ts.Require().NotNil(user)
+	ts.config.CreatedUserIDs = append(ts.config.CreatedUserIDs, user.ID)
+}


### PR DESCRIPTION
### Purpose

Fixes the blank dynamic input page shown during magic link registration.

After the magic link is verified, the flow pauses on a prompt asking for the schema attributes `ProvisioningExecutor` found missing. Landing back on the sign-up page rendered that prompt with no fields at all, so there was nothing to fill in and Continue could never satisfy the flow.

Those attributes are not declared on the prompt node. They reach it through `ForwardedData`, which is deliberately single hop (`engine.go`, "This ensures ForwardedData is only available to the immediate next node"), and `enrichInputsFromForwardedData` is the prompt's only source of them. So the fields existed solely for the traversal that produced them, and re-entering the paused prompt rendered a degraded version of the same step.

Captured against a running server, before the fix:

| request | response |
|---|---|
| `{executionId, inputs:{token}}` | `INCOMPLETE`, inputs `[family_name, given_name]` |
| `{executionId, challengeToken}` — resume | `INCOMPLETE`, inputs **`[]`** |
| `{..., action:"action_schema_attrs"}` | `INCOMPLETE`, inputs `[family_name, given_name]` |

The alternation is why the reported symptom is "a blank page, and submitting shows the required fields again": submitting carries an action, the action routes back to `provisioning`, and the executor forwards the inputs afresh.

This is not specific to magic link. Any flow with a dynamic prompt loses its fields on a plain browser refresh, and resume is a first class operation the SDK depends on.

### Approach

Record the inputs a prompt resolved to when it pauses (`resolveStepDetailsForPrompt`), persist them with the flow context as `promptInputs` / `promptNodeId`, and replay them into `ForwardedData` before that same prompt node runs again.

The replay is deliberately narrow. It is skipped when:

- **an action was selected** — the user is advancing, not re-reading, and the prompt then evaluates against the inputs that action declares. Without this, an action declaring no inputs looks unsatisfied; it regressed `TestMultiActionInputBindingTestSuite`, where selecting a Google action returned a `VIEW` instead of the redirect.
- **an executor already forwarded inputs in this traversal** — it just ran and is the better authority.
- **the node is not the one the flow paused on.**

### Related Issues
- Fixes #4756
- Related to #4795 — the same flow has a second, client side defect, addressed in the SDK repo (see Related PRs). This PR alone does not close it.

### Related PRs
- thunder-id/javascript-sdks — "Leave the sign-up flow when it completes with an assertion"

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests — 4 cases covering `replayPromptInputs` (restores for the paused prompt, skips a different node, skips when an action is selected, keeps freshly forwarded inputs), plus an assertion added to `TestHandleIncompleteResponse_ViewType`.
    - [x] Integration Tests — `TestMagicLinkRegistration_ResumeRetainsDynamicInputs` asserts the fields survive a resume, stay stable across repeated resumes, and still complete the flow.
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

### Verification

- All `backend/internal/flow/...` unit tests pass.
- All five flow integration suites pass (`authentication`, `flowmeta`, `mgt`, `recovery`, `registration`).
- Verified manually end to end against a local instance: the blank page is gone and the attribute prompt renders its fields.

The full `make test_integration` sweep beyond the flow suites has not been run yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Paused flows now retain and restore dynamically provided prompt inputs when resumed or refreshed.
  * Inputs remain available through repeated pauses and resumes, including magic-link registration.
  * Stale prompt inputs are cleared when moving between flow contexts.

* **Tests**
  * Added coverage for prompt restoration, new input handling, node changes, selected actions, context switches, and end-to-end registration completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->