### PR TITLE
Add CIBA integration test coverage for expiry, hints, resource binding and callback guards

### DIFF
--- a/tests/integration/oauth/ciba/ciba_test.go
+++ b/tests/integration/oauth/ciba/ciba_test.go
@@ -5,6 +5,7 @@ package ciba
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -31,6 +32,12 @@ const (
 	// cibaPollIntervalSeconds mirrors oauth2const.CIBADefaultIntervalSeconds (the minimum interval
 	// between token polls while a request is pending).
 	cibaPollIntervalSeconds = 5
+	// cibaMaxExpiresInSeconds mirrors oauth2const.CIBAMaxExpiresInSeconds (the server-side cap a
+	// client-requested expiry clamps to).
+	cibaMaxExpiresInSeconds = 600
+	// cibaMaxBindingMessageLength mirrors ciba.cibaMaxBindingMessageLength (the maximum number of
+	// characters allowed in a binding_message).
+	cibaMaxBindingMessageLength = 256
 	// cibaMockNotificationServerPort is the port for this suite's mock notification server. It must
 	// not collide with other integration suites (the SMS auth suite uses 8098).
 	cibaMockNotificationServerPort = 8099
@@ -39,18 +46,43 @@ const (
 	cibaClientSecret = "ciba_test_secret_123"
 	cibaTestUsername = "ciba_test_user"
 	cibaTestPassword = "cibapass123"
+
+	// cibaSecondClientID/Secret is a second CIBA-enabled application sharing the same auth flow,
+	// used to prove an auth_req_id is not transferable across clients.
+	cibaSecondClientID     = "ciba_test_client_second"
+	cibaSecondClientSecret = "ciba_test_secret_second"
+	// cibaNoGrantClientID/Secret is an application without the CIBA grant type.
+	cibaNoGrantClientID     = "ciba_test_client_no_grant"
+	cibaNoGrantClientSecret = "ciba_test_secret_no_grant"
+	// cibaIDHintClientID/Secret is bound to a flow whose identify node resolves directly by user ID,
+	// so it can be driven purely via id_token_hint.
+	cibaIDHintClientID     = "ciba_test_client_idhint"
+	cibaIDHintClientSecret = "ciba_test_secret_idhint"
+
+	// cibaResourceServerIdentifier is the resource server bound in resource-indicator tests.
+	cibaResourceServerIdentifier = "https://ciba-test-rs.example.com"
+	// cibaMismatchResourceIdentifier is a syntactically valid resource never bound to any request,
+	// used to prove polling cannot widen or redirect an existing binding.
+	cibaMismatchResourceIdentifier = "https://ciba-mismatch-rs.example.com"
 )
 
 type CIBATestSuite struct {
 	suite.Suite
-	ouID       string
-	client     *http.Client
-	mockServer *testutils.MockNotificationServer
-	senderID   string
-	userTypeID string
-	userID     string
-	flowID     string
-	appID      string
+	ouID             string
+	client           *http.Client
+	mockServer       *testutils.MockNotificationServer
+	senderID         string
+	userTypeID       string
+	userID           string
+	flowID           string
+	appID            string
+	issuer           string
+	resourceServerID string
+	roleID           string
+	secondAppID      string
+	noGrantAppID     string
+	idHintFlowID     string
+	idHintAppID      string
 }
 
 func TestCIBATestSuite(t *testing.T) {
@@ -59,6 +91,10 @@ func TestCIBATestSuite(t *testing.T) {
 
 func (ts *CIBATestSuite) SetupSuite() {
 	ts.client = testutils.GetHTTPClient()
+
+	issuer, err := ts.fetchIssuer()
+	ts.Require().NoError(err, "Failed to fetch OIDC issuer from discovery endpoint")
+	ts.issuer = issuer
 
 	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
 		Handle:      "ciba-test-ou",
@@ -123,141 +159,72 @@ func (ts *CIBATestSuite) SetupSuite() {
 	// link carrying executionId + auth_req_id, the SMSExecutor delivers it via the mock server, and
 	// the flow then pauses at the notification-sent prompt. The resumed flow re-enters via the
 	// invite-verify node, which skips challenge validation so it can be resumed cold using only the
-	// executionId + inviteToken recovered from the notification.
+	// executionId + inviteToken recovered from the notification. An AuthorizationExecutor node
+	// evaluates any requested permission scopes against the user's roles before the assertion is
+	// minted; when no permission scopes are requested (the common case in this suite) it is a no-op.
 	flowID, err := testutils.CreateFlow(testutils.Flow{
 		Name:     "CIBA Test Auth Flow",
 		FlowType: "AUTHENTICATION",
 		Handle:   "auth_flow_ciba_test",
-		Nodes: []map[string]interface{}{
-			{
-				"id":        "start",
-				"type":      "START",
-				"onSuccess": "identify_user",
-			},
-			{
-				"id":   "identify_user",
-				"type": "TASK_EXECUTION",
-				"executor": map[string]interface{}{
-					"name": "IdentifyingExecutor",
-					"mode": "identify",
-				},
-				"properties": map[string]interface{}{
-					"loginHintAttribute": "username",
-				},
-				"onSuccess": "generate_invite",
-			},
-			{
-				"id":   "generate_invite",
-				"type": "TASK_EXECUTION",
-				"executor": map[string]interface{}{
-					"name": "InviteExecutor",
-					"mode": "generate",
-				},
-				"onSuccess": "send_ciba_notification",
-			},
-			{
-				"id":   "send_ciba_notification",
-				"type": "TASK_EXECUTION",
-				"properties": map[string]interface{}{
-					"senderId":    senderID,
-					"smsTemplate": "CIBA_NOTIFICATION",
-				},
-				"executor": map[string]interface{}{
-					"name": "SMSExecutor",
-				},
-				"onSuccess": "notification_sent",
-			},
-			{
-				// The server-initiated segment pauses here after the notification is sent; the
-				// resumed flow re-enters via the invite-verify node below, which skips challenge
-				// validation so it can be resumed cold using only the executionId + inviteToken.
-				"id":   "notification_sent",
-				"type": "PROMPT",
-				"next": "verify_invite",
-			},
-			{
-				"id":   "verify_invite",
-				"type": "TASK_EXECUTION",
-				"executor": map[string]interface{}{
-					"name": "InviteExecutor",
-					"mode": "verify",
-					"inputs": []map[string]interface{}{
-						{
-							"ref":        "input_invite_token",
-							"identifier": "inviteToken",
-							"type":       "HIDDEN",
-							"required":   true,
-						},
-					},
-				},
-				"onSuccess": "prompt_credentials",
-			},
-			{
-				"id":   "prompt_credentials",
-				"type": "PROMPT",
-				"prompts": []map[string]interface{}{
-					{
-						"inputs": []map[string]interface{}{
-							{
-								"ref":        "input_001",
-								"identifier": "username",
-								"type":       "TEXT_INPUT",
-								"required":   true,
-							},
-							{
-								"ref":        "input_002",
-								"identifier": "password",
-								"type":       "PASSWORD_INPUT",
-								"required":   true,
-							},
-						},
-						"action": map[string]interface{}{
-							"ref":      "action_001",
-							"nextNode": "credentials_auth",
-						},
-					},
-				},
-			},
-			{
-				"id":   "credentials_auth",
-				"type": "TASK_EXECUTION",
-				"executor": map[string]interface{}{
-					"name": "CredentialsAuthExecutor",
-					"inputs": []map[string]interface{}{
-						{
-							"ref":        "input_001",
-							"identifier": "username",
-							"type":       "TEXT_INPUT",
-							"required":   true,
-						},
-						{
-							"ref":        "input_002",
-							"identifier": "password",
-							"type":       "PASSWORD_INPUT",
-							"required":   true,
-						},
-					},
-				},
-				"onSuccess": "auth_assert",
-			},
-			{
-				"id":   "auth_assert",
-				"type": "TASK_EXECUTION",
-				"executor": map[string]interface{}{
-					"name": "AuthAssertExecutor",
-				},
-				"onSuccess": "end",
-			},
-			{
-				"id":   "end",
-				"type": "END",
-			},
-		},
+		Nodes:    cibaAuthFlowNodes("username", senderID, true),
 	})
 	ts.Require().NoError(err, "Failed to create CIBA auth flow")
 	ts.flowID = flowID
 
 	ts.appID = ts.createCIBATestApplication(flowID)
+
+	// Resource server + role used by the resource-indicator tests. The role grants only "read"; the
+	// resource server also exposes "write" so a request that asks for both can prove downscoping
+	// drops the permission the user was never granted.
+	rsID, err := testutils.CreateResourceServerWithActions(testutils.ResourceServer{
+		Name:        "CIBA Test Resource Server",
+		Description: "Resource server for CIBA integration tests",
+		Identifier:  cibaResourceServerIdentifier,
+		OUID:        ts.ouID,
+	}, []testutils.Action{
+		{Name: "Read", Handle: "read", Description: "Read access"},
+		{Name: "Write", Handle: "write", Description: "Write access"},
+	})
+	ts.Require().NoError(err, "Failed to create CIBA test resource server")
+	ts.resourceServerID = rsID
+
+	roleID, err := testutils.CreateRole(testutils.Role{
+		Name:        "CIBA Test Reader Role",
+		Description: "Grants read-only access on the CIBA test resource server",
+		OUID:        ts.ouID,
+		Permissions: []testutils.ResourcePermissions{
+			{ResourceServerID: rsID, Permissions: []string{"read"}},
+		},
+		Assignments: []testutils.Assignment{
+			{ID: ts.userID, Type: "user"},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create CIBA test role")
+	ts.roleID = roleID
+
+	// A second CIBA-enabled application sharing the main flow, used to prove an auth_req_id is not
+	// transferable across clients.
+	ts.secondAppID = ts.createCIBAApp("CIBASecondTestApp", cibaSecondClientID, cibaSecondClientSecret,
+		[]string{cibaGrantType, "refresh_token"}, flowID)
+
+	// An application without the CIBA grant type, used to prove bc-authorize is rejected up front.
+	ts.noGrantAppID = ts.createCIBAApp("CIBANoGrantTestApp", cibaNoGrantClientID, cibaNoGrantClientSecret,
+		[]string{"client_credentials"}, flowID)
+
+	// A dedicated flow + application for id_token_hint: the identify node resolves the login_hint
+	// value directly against the user ID (rather than the username attribute), because the CIBA
+	// service resolves id_token_hint down to the token's raw sub claim before initiating the flow.
+	idHintFlowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     "CIBA IDToken Hint Test Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_ciba_idhint_test",
+		Nodes:    cibaAuthFlowNodes("userID", senderID, false),
+	})
+	ts.Require().NoError(err, "Failed to create CIBA id_token_hint test flow")
+	ts.idHintFlowID = idHintFlowID
+
+	ts.idHintAppID = ts.createCIBAApp("CIBAIDHintTestApp", cibaIDHintClientID, cibaIDHintClientSecret,
+		[]string{cibaGrantType, "refresh_token"}, idHintFlowID)
 }
 
 // SetupTest drops notifications captured by earlier tests, so that each test recovers the executionId
@@ -269,6 +236,24 @@ func (ts *CIBATestSuite) SetupTest() {
 }
 
 func (ts *CIBATestSuite) TearDownSuite() {
+	if ts.idHintAppID != "" {
+		_ = testutils.DeleteApplication(ts.idHintAppID)
+	}
+	if ts.idHintFlowID != "" {
+		_ = testutils.DeleteFlow(ts.idHintFlowID)
+	}
+	if ts.noGrantAppID != "" {
+		_ = testutils.DeleteApplication(ts.noGrantAppID)
+	}
+	if ts.secondAppID != "" {
+		_ = testutils.DeleteApplication(ts.secondAppID)
+	}
+	if ts.roleID != "" {
+		_ = testutils.DeleteRole(ts.roleID)
+	}
+	if ts.resourceServerID != "" {
+		_ = testutils.DeleteResourceServer(ts.resourceServerID)
+	}
 	if ts.appID != "" {
 		_ = testutils.DeleteApplication(ts.appID)
 	}
@@ -310,11 +295,11 @@ func (ts *CIBATestSuite) TestCIBAGrantFlow() {
 
 	// Step 2: While pending, the token endpoint enforces the polling interval — the first poll is
 	// authorization_pending, an immediate re-poll is slow_down. Neither consumes the request.
-	pending := ts.cibaPollToken(bcResp.AuthReqID)
+	pending := ts.cibaPollToken(bcResp.AuthReqID, "")
 	ts.Require().Equal(http.StatusBadRequest, pending.statusCode)
 	ts.Require().Equal("authorization_pending", pending.errorCode)
 
-	slowDown := ts.cibaPollToken(bcResp.AuthReqID)
+	slowDown := ts.cibaPollToken(bcResp.AuthReqID, "")
 	ts.Require().Equal(http.StatusBadRequest, slowDown.statusCode)
 	ts.Require().Equal("slow_down", slowDown.errorCode)
 
@@ -347,16 +332,16 @@ func (ts *CIBATestSuite) TestCIBAGrantFlow() {
 	ts.Require().NotEmpty(flowStep.Assertion, "flow completion should yield an assertion")
 
 	// Step 5: Post the assertion to the callback to drive MarkAuthenticated (PENDING -> AUTHENTICATED).
-	ts.Require().Equal(http.StatusOK, ts.cibaPostCallback(bcResp.AuthReqID, flowStep.Assertion),
-		"CIBA callback should accept the assertion")
+	callbackStatus, _ := ts.cibaPostCallback(bcResp.AuthReqID, flowStep.Assertion)
+	ts.Require().Equal(http.StatusOK, callbackStatus, "CIBA callback should accept the assertion")
 
 	// Step 6: Poll the token endpoint to drive MarkConsumed and issue tokens. The pending polls
 	// recently stamped LastPolledAt; once AUTHENTICATED the handler skips the interval check, but
 	// retry once on slow_down for robustness against timing.
-	tokenRes := ts.cibaPollToken(bcResp.AuthReqID)
+	tokenRes := ts.cibaPollToken(bcResp.AuthReqID, "")
 	if tokenRes.statusCode == http.StatusBadRequest && tokenRes.errorCode == "slow_down" {
 		time.Sleep(cibaPollIntervalSeconds * time.Second)
-		tokenRes = ts.cibaPollToken(bcResp.AuthReqID)
+		tokenRes = ts.cibaPollToken(bcResp.AuthReqID, "")
 	}
 	ts.Require().Equal(http.StatusOK, tokenRes.statusCode, "AUTHENTICATED request should issue tokens")
 	ts.Require().NotEmpty(tokenRes.accessToken, "response should carry an access_token")
@@ -366,7 +351,7 @@ func (ts *CIBATestSuite) TestCIBAGrantFlow() {
 	ts.Require().Equal(ts.userID, claims.Sub, "token subject should be the CIBA user")
 
 	// Step 7: A second poll is rejected — the request is CONSUMED (one-time use).
-	reuse := ts.cibaPollToken(bcResp.AuthReqID)
+	reuse := ts.cibaPollToken(bcResp.AuthReqID, "")
 	ts.Require().Equal(http.StatusBadRequest, reuse.statusCode)
 	ts.Require().Equal("invalid_grant", reuse.errorCode, "a consumed request must not issue tokens again")
 }
@@ -385,7 +370,7 @@ func (ts *CIBATestSuite) TestCIBAFlowFailureDeniesRequest() {
 	ts.Require().NotEmpty(bcResp.AuthReqID, "bc-authorize response should carry auth_req_id")
 
 	// Step 2: Baseline — before the failure the client is told nothing but "keep waiting".
-	pending := ts.cibaPollToken(bcResp.AuthReqID)
+	pending := ts.cibaPollToken(bcResp.AuthReqID, "")
 	ts.Require().Equal(http.StatusBadRequest, pending.statusCode)
 	ts.Require().Equal("authorization_pending", pending.errorCode)
 
@@ -414,14 +399,14 @@ func (ts *CIBATestSuite) TestCIBAFlowFailureDeniesRequest() {
 
 	// Step 5: Relay the error assertion. The callback op itself succeeds; the outcome lives in the
 	// request state, which is why this is a 200 and not an error status.
-	ts.Require().Equal(http.StatusOK, ts.cibaPostCallback(bcResp.AuthReqID, flowStep.ErrorAssertion),
-		"CIBA callback should accept the error assertion")
+	callbackStatus, _ := ts.cibaPostCallback(bcResp.AuthReqID, flowStep.ErrorAssertion)
+	ts.Require().Equal(http.StatusOK, callbackStatus, "CIBA callback should accept the error assertion")
 
 	// Step 6: The polling client now learns the outcome instead of hanging on authorization_pending.
-	denied := ts.cibaPollToken(bcResp.AuthReqID)
+	denied := ts.cibaPollToken(bcResp.AuthReqID, "")
 	if denied.statusCode == http.StatusBadRequest && denied.errorCode == "slow_down" {
 		time.Sleep(cibaPollIntervalSeconds * time.Second)
-		denied = ts.cibaPollToken(bcResp.AuthReqID)
+		denied = ts.cibaPollToken(bcResp.AuthReqID, "")
 	}
 	ts.Require().Equal(http.StatusBadRequest, denied.statusCode)
 	ts.Require().Equal("access_denied", denied.errorCode,
@@ -429,11 +414,513 @@ func (ts *CIBATestSuite) TestCIBAFlowFailureDeniesRequest() {
 	ts.Require().Empty(denied.accessToken, "A denied request must not issue tokens")
 }
 
-// createCIBATestApplication creates an OAuth application that allows the CIBA grant and is bound to
-// the given authentication flow, returning its application ID.
+// TestCIBAExpiredRequestRejectsPolling verifies that a request whose requested_expiry has elapsed is
+// rejected by the token endpoint with expired_token (repeatedly, once the request is marked EXPIRED),
+// and that resolveExpiresIn only clamps the upper bound: a below-max value like 1 is honored verbatim,
+// while an above-max value like 9999 clamps down to the server maximum.
+func (ts *CIBATestSuite) TestCIBAExpiredRequestRejectsPolling() {
+	form := url.Values{}
+	form.Set("login_hint", cibaTestUsername)
+	form.Set("scope", "openid")
+	form.Set("requested_expiry", "1")
+	status, bcResp := ts.cibaBackchannelAuthorizeForm(form, cibaClientID, cibaClientSecret)
+	ts.Require().Equal(http.StatusOK, status)
+	ts.Require().Equal(int64(1), bcResp.ExpiresIn, "a requested_expiry below the max must be honored")
+
+	time.Sleep(2 * time.Second)
+
+	expired := ts.cibaPollToken(bcResp.AuthReqID, "")
+	ts.Require().Equal(http.StatusBadRequest, expired.statusCode)
+	ts.Require().Equal("expired_token", expired.errorCode)
+
+	expiredAgain := ts.cibaPollToken(bcResp.AuthReqID, "")
+	ts.Require().Equal(http.StatusBadRequest, expiredAgain.statusCode)
+	ts.Require().Equal("expired_token", expiredAgain.errorCode,
+		"a request already marked EXPIRED must keep returning expired_token")
+
+	clampForm := url.Values{}
+	clampForm.Set("login_hint", cibaTestUsername)
+	clampForm.Set("scope", "openid")
+	clampForm.Set("requested_expiry", "9999")
+	clampStatus, clampResp := ts.cibaBackchannelAuthorizeForm(clampForm, cibaClientID, cibaClientSecret)
+	ts.Require().Equal(http.StatusOK, clampStatus)
+	ts.Require().Equal(int64(cibaMaxExpiresInSeconds), clampResp.ExpiresIn,
+		"a requested_expiry above the server maximum must clamp to the maximum")
+}
+
+// TestCIBAUnknownLoginHintReturnsUnknownUserID verifies that a login_hint matching no user maps to
+// unknown_user_id (CIBA Core 1.0 ​§7.3), not server_error. mapFlowErrorToCIBAError switches on the
+// literal flow-engine failure string "User not found"; the unit tests mock the flow entirely, so this
+// coupling between the flow engine's wording and the CIBA error mapping is otherwise unverified.
+func (ts *CIBATestSuite) TestCIBAUnknownLoginHintReturnsUnknownUserID() {
+	status, bcResp := ts.cibaBackchannelAuthorize("no_such_ciba_user_xyz", "openid")
+	ts.Require().Equal(http.StatusBadRequest, status)
+	ts.Require().Equal("unknown_user_id", bcResp.ErrorCode,
+		"an unresolvable login_hint must map to unknown_user_id, not server_error")
+}
+
+// TestCIBAIDTokenHintResolvesUser mints a real ID token via one full CIBA cycle, then uses it as
+// id_token_hint (with no login_hint) on a second, independent request against an application whose
+// flow resolves the identify step directly by user ID. It verifies the same user is resolved end to
+// end, and that a tampered id_token_hint signature is rejected with invalid_request.
+func (ts *CIBATestSuite) TestCIBAIDTokenHintResolvesUser() {
+	// Mint a real ID token via a normal login_hint-based CIBA cycle.
+	mintStatus, mintResp := ts.cibaBackchannelAuthorize(cibaTestUsername, "openid")
+	ts.Require().Equal(http.StatusOK, mintStatus)
+	ts.completeCIBAFlow(mintResp.AuthReqID)
+
+	mintedTokens := ts.cibaPollToken(mintResp.AuthReqID, "")
+	if mintedTokens.statusCode == http.StatusBadRequest && mintedTokens.errorCode == "slow_down" {
+		time.Sleep(cibaPollIntervalSeconds * time.Second)
+		mintedTokens = ts.cibaPollToken(mintResp.AuthReqID, "")
+	}
+	ts.Require().Equal(http.StatusOK, mintedTokens.statusCode,
+		"should mint a real ID token to reuse as id_token_hint")
+	ts.Require().NotEmpty(mintedTokens.idToken)
+
+	// Use the minted ID token as id_token_hint, with no login_hint, on the id_token_hint test app.
+	hintForm := url.Values{}
+	hintForm.Set("id_token_hint", mintedTokens.idToken)
+	hintForm.Set("scope", "openid")
+	hintStatus, hintResp := ts.cibaBackchannelAuthorizeForm(hintForm, cibaIDHintClientID, cibaIDHintClientSecret)
+	ts.Require().Equal(http.StatusOK, hintStatus, "id_token_hint alone should resolve the same user")
+	ts.Require().NotEmpty(hintResp.AuthReqID)
+
+	ts.completeCIBAFlow(hintResp.AuthReqID)
+
+	finalTokens := ts.cibaPollTokenAs(hintResp.AuthReqID, "", cibaIDHintClientID, cibaIDHintClientSecret)
+	if finalTokens.statusCode == http.StatusBadRequest && finalTokens.errorCode == "slow_down" {
+		time.Sleep(cibaPollIntervalSeconds * time.Second)
+		finalTokens = ts.cibaPollTokenAs(hintResp.AuthReqID, "", cibaIDHintClientID, cibaIDHintClientSecret)
+	}
+	ts.Require().Equal(http.StatusOK, finalTokens.statusCode)
+	ts.Require().NotEmpty(finalTokens.accessToken)
+
+	claims, err := testutils.DecodeJWT(finalTokens.accessToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal(ts.userID, claims.Sub, "id_token_hint must resolve to the same user as login_hint")
+
+	// A tampered id_token_hint signature must be rejected before any flow is initiated.
+	tamperedForm := url.Values{}
+	tamperedForm.Set("id_token_hint", tamperJWTSignature(mintedTokens.idToken))
+	tamperedForm.Set("scope", "openid")
+	tamperedStatus, tamperedResp := ts.cibaBackchannelAuthorizeForm(
+		tamperedForm, cibaIDHintClientID, cibaIDHintClientSecret)
+	ts.Require().Equal(http.StatusBadRequest, tamperedStatus)
+	ts.Require().Equal("invalid_request", tamperedResp.ErrorCode,
+		"a tampered id_token_hint signature must be rejected")
+}
+
+// TestCIBAResourceBoundTokenAudienceAndScopes verifies that a resource-bound CIBA request issues an
+// access token whose audience is the resource server identifier, and whose scopes are downscoped to
+// the permissions the user actually holds: "write" is requested but never granted, so it must not
+// appear in the issued token even though it is a valid action on the resource server.
+func (ts *CIBATestSuite) TestCIBAResourceBoundTokenAudienceAndScopes() {
+	form := url.Values{}
+	form.Set("login_hint", cibaTestUsername)
+	form.Set("scope", "openid read write")
+	form.Set("resource", cibaResourceServerIdentifier)
+	status, bcResp := ts.cibaBackchannelAuthorizeForm(form, cibaClientID, cibaClientSecret)
+	ts.Require().Equal(http.StatusOK, status)
+	ts.Require().NotEmpty(bcResp.AuthReqID)
+
+	ts.completeCIBAFlow(bcResp.AuthReqID)
+
+	tokenRes := ts.cibaPollToken(bcResp.AuthReqID, cibaResourceServerIdentifier)
+	if tokenRes.statusCode == http.StatusBadRequest && tokenRes.errorCode == "slow_down" {
+		time.Sleep(cibaPollIntervalSeconds * time.Second)
+		tokenRes = ts.cibaPollToken(bcResp.AuthReqID, cibaResourceServerIdentifier)
+	}
+	ts.Require().Equal(http.StatusOK, tokenRes.statusCode, "resource-bound request should issue tokens")
+	ts.Require().NotEmpty(tokenRes.accessToken)
+
+	claims, err := testutils.DecodeJWT(tokenRes.accessToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal(cibaResourceServerIdentifier, claims.Aud,
+		"the access token audience must be the bound resource server")
+
+	scopes := strings.Fields(tokenRes.scope)
+	ts.Require().Contains(scopes, "read", "the granted permission must be present")
+	ts.Require().NotContains(scopes, "write",
+		"a requested but never-granted permission must be dropped by downscoping")
+}
+
+// TestCIBAPollingResourceMismatchRejected verifies enforceCIBAPollingResource: polling with a resource
+// different from the one bound at bc-authorize time is rejected, and so is polling an OIDC-only
+// (unbound) request with any resource — neither can widen or redirect the original binding.
+func (ts *CIBATestSuite) TestCIBAPollingResourceMismatchRejected() {
+	boundForm := url.Values{}
+	boundForm.Set("login_hint", cibaTestUsername)
+	boundForm.Set("scope", "openid read")
+	boundForm.Set("resource", cibaResourceServerIdentifier)
+	boundStatus, boundResp := ts.cibaBackchannelAuthorizeForm(boundForm, cibaClientID, cibaClientSecret)
+	ts.Require().Equal(http.StatusOK, boundStatus)
+
+	mismatch := ts.cibaPollToken(boundResp.AuthReqID, cibaMismatchResourceIdentifier)
+	ts.Require().Equal(http.StatusBadRequest, mismatch.statusCode)
+	ts.Require().Equal("invalid_target", mismatch.errorCode,
+		"polling with a resource different from the bound one must be rejected")
+
+	unboundStatus, unboundResp := ts.cibaBackchannelAuthorize(cibaTestUsername, "openid")
+	ts.Require().Equal(http.StatusOK, unboundStatus)
+
+	unboundMismatch := ts.cibaPollToken(unboundResp.AuthReqID, cibaResourceServerIdentifier)
+	ts.Require().Equal(http.StatusBadRequest, unboundMismatch.statusCode)
+	ts.Require().Equal("invalid_target", unboundMismatch.errorCode,
+		"polling an OIDC-only unbound request with a resource must be rejected")
+}
+
+// TestCIBAAuthReqIDNotTransferableAcrossClients verifies that an auth_req_id is scoped to the client
+// that created it: a second CIBA-enabled application cannot poll it (invalid_grant, even after the
+// request is fully AUTHENTICATED), and an application without the CIBA grant type is rejected before
+// any flow is initiated (unauthorized_client).
+func (ts *CIBATestSuite) TestCIBAAuthReqIDNotTransferableAcrossClients() {
+	status, bcResp := ts.cibaBackchannelAuthorize(cibaTestUsername, "openid")
+	ts.Require().Equal(http.StatusOK, status)
+
+	ts.completeCIBAFlow(bcResp.AuthReqID)
+
+	crossPoll := ts.cibaPollTokenAs(bcResp.AuthReqID, "", cibaSecondClientID, cibaSecondClientSecret)
+	ts.Require().Equal(http.StatusBadRequest, crossPoll.statusCode)
+	ts.Require().Equal("invalid_grant", crossPoll.errorCode,
+		"a second CIBA-enabled client must not be able to poll another client's auth_req_id")
+
+	noGrantForm := url.Values{}
+	noGrantForm.Set("login_hint", cibaTestUsername)
+	noGrantForm.Set("scope", "openid")
+	noGrantStatus, noGrantResp := ts.cibaBackchannelAuthorizeForm(
+		noGrantForm, cibaNoGrantClientID, cibaNoGrantClientSecret)
+	ts.Require().Equal(http.StatusBadRequest, noGrantStatus)
+	ts.Require().Equal("unauthorized_client", noGrantResp.ErrorCode,
+		"a client without the CIBA grant type must be rejected before any flow is initiated")
+}
+
+// TestCIBABindingMessageDeliveredToUser verifies that a client-supplied binding_message reaches the
+// user's notification verbatim, and that an omitted one falls back to defaultBindingMessage's
+// generated, request-specific "Code: XXXX-XXXX" text.
+// Skipped pending https://github.com/thunder-id/thunderid/issues/4835: smsExecutor does not merge
+// ctx.RuntimeData into its template data, so bindingMessage is never substituted into the SMS body.
+func (ts *CIBATestSuite) TestCIBABindingMessageDeliveredToUser() {
+	ts.T().Skip("https://github.com/thunder-id/thunderid/issues/4835: smsExecutor does not merge " +
+		"ctx.RuntimeData, so bindingMessage never reaches the SMS template. Unskip when the issue is fixed.")
+
+	customMessage := "Approve sign-in to Acme Console"
+	form := url.Values{}
+	form.Set("login_hint", cibaTestUsername)
+	form.Set("scope", "openid")
+	form.Set("binding_message", customMessage)
+	status, bcResp := ts.cibaBackchannelAuthorizeForm(form, cibaClientID, cibaClientSecret)
+	ts.Require().Equal(http.StatusOK, status)
+
+	var messageA string
+	ts.Require().Eventually(func() bool {
+		msg := ts.mockServer.GetLastMessage()
+		if msg == nil || extractCIBALinkParam(msg.Message, "auth_req_id") != bcResp.AuthReqID {
+			return false
+		}
+		messageA = msg.Message
+		return true
+	}, 5*time.Second, 100*time.Millisecond, "Expected CIBA notification for the custom binding_message request")
+	ts.Require().Contains(messageA, customMessage,
+		"a custom binding_message must be delivered verbatim in the notification")
+
+	defaultStatus, defaultResp := ts.cibaBackchannelAuthorize(cibaTestUsername, "openid")
+	ts.Require().Equal(http.StatusOK, defaultStatus)
+
+	var messageB string
+	ts.Require().Eventually(func() bool {
+		msg := ts.mockServer.GetLastMessage()
+		if msg == nil || extractCIBALinkParam(msg.Message, "auth_req_id") != defaultResp.AuthReqID {
+			return false
+		}
+		messageB = msg.Message
+		return true
+	}, 5*time.Second, 100*time.Millisecond, "Expected CIBA notification for the default binding_message request")
+	ts.Require().Regexp(regexp.MustCompile(`Code: [0-9A-F]{4}-[0-9A-F]{4}`), messageB,
+		"an omitted binding_message must fall back to the generated default with a request-specific code")
+}
+
+// TestCIBACallbackRejectsCrossBoundAssertion is a security regression test for the attack described at
+// service.go's loadPendingRequestForCallback / handleSuccessCallback: a valid, correctly signed
+// assertion completed for one CIBA request must not authorize a different, concurrently pending
+// request for the same user. It also confirms the targeted request is left untouched by the rejected
+// attempt: still pending, and still completable normally afterwards.
+func (ts *CIBATestSuite) TestCIBACallbackRejectsCrossBoundAssertion() {
+	statusA, bcRespA := ts.cibaBackchannelAuthorize(cibaTestUsername, "openid")
+	ts.Require().Equal(http.StatusOK, statusA)
+	// Drain A's notification immediately: GetLastMessage destructively pops, so this must happen
+	// before B's bc-authorize call adds a second notification to the queue.
+	executionIDA, inviteTokenA := ts.recoverCIBAInvite(bcRespA.AuthReqID)
+
+	statusB, bcRespB := ts.cibaBackchannelAuthorize(cibaTestUsername, "openid")
+	ts.Require().Equal(http.StatusOK, statusB)
+	ts.Require().NotEqual(bcRespA.AuthReqID, bcRespB.AuthReqID)
+	executionIDB, inviteTokenB := ts.recoverCIBAInvite(bcRespB.AuthReqID)
+
+	assertionA := ts.driveCIBAFlow(executionIDA, inviteTokenA, bcRespA.AuthReqID)
+
+	crossStatus, crossErr := ts.cibaPostCallback(bcRespB.AuthReqID, assertionA)
+	ts.Require().Equal(http.StatusBadRequest, crossStatus)
+	ts.Require().Equal("access_denied", crossErr,
+		"an assertion minted for a different CIBA request must be rejected")
+
+	// B must remain untouched by the rejected cross-bound callback.
+	pendingB := ts.cibaPollToken(bcRespB.AuthReqID, "")
+	ts.Require().Equal(http.StatusBadRequest, pendingB.statusCode)
+	ts.Require().Equal("authorization_pending", pendingB.errorCode,
+		"request B must still be pending after the cross-bound assertion was rejected")
+
+	// B is still completable normally afterwards.
+	ts.driveCIBAFlow(executionIDB, inviteTokenB, bcRespB.AuthReqID)
+	tokenB := ts.cibaPollToken(bcRespB.AuthReqID, "")
+	if tokenB.statusCode == http.StatusBadRequest && tokenB.errorCode == "slow_down" {
+		time.Sleep(cibaPollIntervalSeconds * time.Second)
+		tokenB = ts.cibaPollToken(bcRespB.AuthReqID, "")
+	}
+	ts.Require().Equal(http.StatusOK, tokenB.statusCode, "request B should still be completable normally")
+	ts.Require().NotEmpty(tokenB.accessToken)
+}
+
+// TestCIBACallbackNegatives table-drives the guards in loadPendingRequestForCallback (and the callback
+// dispatcher's own authId/assertion presence checks ahead of it).
+func (ts *CIBATestSuite) TestCIBACallbackNegatives() {
+	freshAuthReqID := func() string {
+		status, bcResp := ts.cibaBackchannelAuthorize(cibaTestUsername, "openid")
+		ts.Require().Equal(http.StatusOK, status)
+		return bcResp.AuthReqID
+	}
+
+	tests := []struct {
+		name          string
+		setup         func() (authReqID, assertion string)
+		wantErrorCode string
+	}{
+		{
+			name: "tampered assertion",
+			setup: func() (string, string) {
+				return freshAuthReqID(), "this-is-not-a-valid-jwt-assertion"
+			},
+			wantErrorCode: "invalid_request",
+		},
+		{
+			name: "empty assertion",
+			setup: func() (string, string) {
+				return freshAuthReqID(), ""
+			},
+			wantErrorCode: "invalid_request",
+		},
+		{
+			name: "empty auth_req_id",
+			setup: func() (string, string) {
+				return "", "some-assertion"
+			},
+			wantErrorCode: "invalid_request",
+		},
+		{
+			name: "unknown auth_req_id",
+			setup: func() (string, string) {
+				return "00000000-0000-0000-0000-000000000000", "some-assertion"
+			},
+			wantErrorCode: "invalid_request",
+		},
+		{
+			name: "already authenticated",
+			setup: func() (string, string) {
+				authReqID := freshAuthReqID()
+				assertion := ts.completeCIBAFlow(authReqID)
+				return authReqID, assertion
+			},
+			wantErrorCode: "invalid_request",
+		},
+		{
+			name: "expired request",
+			setup: func() (string, string) {
+				form := url.Values{}
+				form.Set("login_hint", cibaTestUsername)
+				form.Set("scope", "openid")
+				form.Set("requested_expiry", "1")
+				status, bcResp := ts.cibaBackchannelAuthorizeForm(form, cibaClientID, cibaClientSecret)
+				ts.Require().Equal(http.StatusOK, status)
+				time.Sleep(2 * time.Second)
+				return bcResp.AuthReqID, "some-assertion"
+			},
+			wantErrorCode: "expired_token",
+		},
+	}
+
+	for _, tc := range tests {
+		ts.Run(tc.name, func() {
+			authReqID, assertion := tc.setup()
+			status, errorCode := ts.cibaPostCallback(authReqID, assertion)
+			ts.Require().Equal(http.StatusBadRequest, status)
+			ts.Require().Equal(tc.wantErrorCode, errorCode)
+		})
+	}
+}
+
+// TestCIBABackchannelValidationNegatives table-drives the bc-authorize request-validation guards that
+// reject before any flow is initiated, so none of these rows produce a notification.
+func (ts *CIBATestSuite) TestCIBABackchannelValidationNegatives() {
+	tests := []struct {
+		name          string
+		form          url.Values
+		wantErrorCode string
+	}{
+		{
+			name:          "no hint",
+			form:          url.Values{"scope": {"openid"}},
+			wantErrorCode: "invalid_request",
+		},
+		{
+			name: "login_hint and id_token_hint both provided",
+			form: url.Values{
+				"login_hint":    {cibaTestUsername},
+				"id_token_hint": {"a.b.c"},
+				"scope":         {"openid"},
+			},
+			wantErrorCode: "invalid_request",
+		},
+		{
+			name: "login_hint_token unsupported",
+			form: url.Values{
+				"login_hint_token": {"some-token"},
+				"scope":            {"openid"},
+			},
+			wantErrorCode: "invalid_request",
+		},
+		{
+			name:          "no scope",
+			form:          url.Values{"login_hint": {cibaTestUsername}},
+			wantErrorCode: "invalid_request",
+		},
+		{
+			name: "scope without openid",
+			form: url.Values{
+				"login_hint": {cibaTestUsername},
+				"scope":      {"profile"},
+			},
+			wantErrorCode: "invalid_scope",
+		},
+		{
+			name: "binding_message over the length cap",
+			form: url.Values{
+				"login_hint":      {cibaTestUsername},
+				"scope":           {"openid"},
+				"binding_message": {strings.Repeat("a", cibaMaxBindingMessageLength+1)},
+			},
+			wantErrorCode: "invalid_binding_message",
+		},
+		{
+			name: "binding_message with a non-printable rune",
+			form: url.Values{
+				"login_hint":      {cibaTestUsername},
+				"scope":           {"openid"},
+				"binding_message": {"helloworld"},
+			},
+			wantErrorCode: "invalid_binding_message",
+		},
+		{
+			name: "id_token_hint not a JWT",
+			form: url.Values{
+				"id_token_hint": {"not-a-jwt-at-all"},
+				"scope":         {"openid"},
+			},
+			wantErrorCode: "invalid_request",
+		},
+		{
+			name: "id_token_hint foreign issuer",
+			form: url.Values{
+				"id_token_hint": {buildFakeIDTokenHint(map[string]interface{}{
+					"iss": "https://foreign-issuer.example.com",
+					"sub": "some-subject",
+					"exp": time.Now().Add(time.Hour).Unix(),
+				})},
+				"scope": {"openid"},
+			},
+			wantErrorCode: "invalid_request",
+		},
+		{
+			name: "id_token_hint missing sub",
+			form: url.Values{
+				"id_token_hint": {buildFakeIDTokenHint(map[string]interface{}{
+					"iss": ts.issuer,
+					"exp": time.Now().Add(time.Hour).Unix(),
+				})},
+				"scope": {"openid"},
+			},
+			wantErrorCode: "invalid_request",
+		},
+		{
+			name: "id_token_hint missing exp",
+			form: url.Values{
+				"id_token_hint": {buildFakeIDTokenHint(map[string]interface{}{
+					"iss": ts.issuer,
+					"sub": "some-subject",
+				})},
+				"scope": {"openid"},
+			},
+			wantErrorCode: "invalid_request",
+		},
+		{
+			name: "two resource parameters",
+			form: url.Values{
+				"login_hint": {cibaTestUsername},
+				"scope":      {"openid"},
+				"resource":   {cibaResourceServerIdentifier, cibaMismatchResourceIdentifier},
+			},
+			wantErrorCode: "invalid_target",
+		},
+		{
+			name: "unknown resource",
+			form: url.Values{
+				"login_hint": {cibaTestUsername},
+				"scope":      {"openid"},
+				"resource":   {"https://unregistered-rs.example.com"},
+			},
+			wantErrorCode: "invalid_target",
+		},
+	}
+
+	for _, tc := range tests {
+		ts.Run(tc.name, func() {
+			status, resp := ts.cibaBackchannelAuthorizeForm(tc.form, cibaClientID, cibaClientSecret)
+			ts.Require().Equal(http.StatusBadRequest, status)
+			ts.Require().Equal(tc.wantErrorCode, resp.ErrorCode)
+		})
+	}
+}
+
+// fetchIssuer reads the configured OIDC issuer from the discovery endpoint.
+func (ts *CIBATestSuite) fetchIssuer() (string, error) {
+	resp, err := ts.client.Get(testutils.TestServerURL + "/.well-known/openid-configuration")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var meta struct {
+		Issuer string `json:"issuer"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&meta); err != nil {
+		return "", err
+	}
+	return meta.Issuer, nil
+}
+
+// createCIBATestApplication creates the primary OAuth application that allows the CIBA grant and is
+// bound to the given authentication flow, returning its application ID.
 func (ts *CIBATestSuite) createCIBATestApplication(authFlowID string) string {
+	return ts.createCIBAApp("CIBATestApp", cibaClientID, cibaClientSecret,
+		[]string{cibaGrantType, "refresh_token"}, authFlowID)
+}
+
+// createCIBAApp creates an OAuth application with the given client credentials, grant types, and
+// bound authentication flow, returning its application ID.
+func (ts *CIBATestSuite) createCIBAApp(
+	name, clientID, clientSecret string, grantTypes []string, authFlowID string,
+) string {
 	app := map[string]interface{}{
-		"name":                      "CIBATestApp",
+		"name":                      name,
 		"description":               "Application for CIBA integration test",
 		"ouId":                      ts.ouID,
 		"type":                      "fullstack",
@@ -444,10 +931,10 @@ func (ts *CIBATestSuite) createCIBATestApplication(authFlowID string) string {
 			{
 				"type": "oauth2",
 				"config": map[string]interface{}{
-					"clientId":                cibaClientID,
-					"clientSecret":            cibaClientSecret,
+					"clientId":                clientID,
+					"clientSecret":            clientSecret,
 					"redirectUris":            []string{"https://localhost:3000"},
-					"grantTypes":              []string{cibaGrantType, "refresh_token"},
+					"grantTypes":              grantTypes,
 					"tokenEndpointAuthMethod": "client_secret_basic",
 				},
 			},
@@ -467,8 +954,8 @@ func (ts *CIBATestSuite) createCIBATestApplication(authFlowID string) string {
 
 	if resp.StatusCode != http.StatusCreated {
 		bodyBytes, _ := io.ReadAll(resp.Body)
-		ts.T().Fatalf("Failed to create CIBA application. Status: %d, Response: %s",
-			resp.StatusCode, string(bodyBytes))
+		ts.T().Fatalf("Failed to create CIBA application %q. Status: %d, Response: %s",
+			name, resp.StatusCode, string(bodyBytes))
 	}
 
 	var respData map[string]interface{}
@@ -476,25 +963,188 @@ func (ts *CIBATestSuite) createCIBATestApplication(authFlowID string) string {
 	return respData["id"].(string)
 }
 
-// cibaBackchannelResponse is the JSON body of a successful bc-authorize response.
+// cibaAuthFlowNodes builds the CIBA authentication flow used by this suite. loginHintAttribute
+// controls how the identify node resolves the login_hint value: "username" for ordinary login_hint
+// requests, or "userID" so an id_token_hint-derived subject (the raw user ID) resolves directly via
+// entity lookup. When withAuthzCheck is true, an AuthorizationExecutor node runs before the assertion
+// is minted, evaluating any requested permission scopes against the user's roles; it is a no-op when
+// no permission scopes are requested.
+func cibaAuthFlowNodes(loginHintAttribute, senderID string, withAuthzCheck bool) []map[string]interface{} {
+	credentialsAuthSuccess := "auth_assert"
+	if withAuthzCheck {
+		credentialsAuthSuccess = "authorization_check"
+	}
+
+	nodes := []map[string]interface{}{
+		{
+			"id":        "start",
+			"type":      "START",
+			"onSuccess": "identify_user",
+		},
+		{
+			"id":   "identify_user",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "IdentifyingExecutor",
+				"mode": "identify",
+			},
+			"properties": map[string]interface{}{
+				"loginHintAttribute": loginHintAttribute,
+			},
+			"onSuccess": "generate_invite",
+		},
+		{
+			"id":   "generate_invite",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "InviteExecutor",
+				"mode": "generate",
+			},
+			"onSuccess": "send_ciba_notification",
+		},
+		{
+			"id":   "send_ciba_notification",
+			"type": "TASK_EXECUTION",
+			"properties": map[string]interface{}{
+				"senderId":    senderID,
+				"smsTemplate": "CIBA_NOTIFICATION",
+			},
+			"executor": map[string]interface{}{
+				"name": "SMSExecutor",
+			},
+			"onSuccess": "notification_sent",
+		},
+		{
+			// The server-initiated segment pauses here after the notification is sent; the
+			// resumed flow re-enters via the invite-verify node below, which skips challenge
+			// validation so it can be resumed cold using only the executionId + inviteToken.
+			"id":   "notification_sent",
+			"type": "PROMPT",
+			"next": "verify_invite",
+		},
+		{
+			"id":   "verify_invite",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "InviteExecutor",
+				"mode": "verify",
+				"inputs": []map[string]interface{}{
+					{
+						"ref":        "input_invite_token",
+						"identifier": "inviteToken",
+						"type":       "HIDDEN",
+						"required":   true,
+					},
+				},
+			},
+			"onSuccess": "prompt_credentials",
+		},
+		{
+			"id":   "prompt_credentials",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_001",
+							"identifier": "username",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_002",
+							"identifier": "password",
+							"type":       "PASSWORD_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_001",
+						"nextNode": "credentials_auth",
+					},
+				},
+			},
+		},
+		{
+			"id":   "credentials_auth",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "CredentialsAuthExecutor",
+				"inputs": []map[string]interface{}{
+					{
+						"ref":        "input_001",
+						"identifier": "username",
+						"type":       "TEXT_INPUT",
+						"required":   true,
+					},
+					{
+						"ref":        "input_002",
+						"identifier": "password",
+						"type":       "PASSWORD_INPUT",
+						"required":   true,
+					},
+				},
+			},
+			"onSuccess": credentialsAuthSuccess,
+		},
+	}
+
+	if withAuthzCheck {
+		nodes = append(nodes, map[string]interface{}{
+			"id":   "authorization_check",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "AuthorizationExecutor",
+			},
+			"onSuccess": "auth_assert",
+		})
+	}
+
+	nodes = append(nodes,
+		map[string]interface{}{
+			"id":   "auth_assert",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "AuthAssertExecutor",
+			},
+			"onSuccess": "end",
+		},
+		map[string]interface{}{
+			"id":   "end",
+			"type": "END",
+		},
+	)
+
+	return nodes
+}
+
+// cibaBackchannelResponse is the JSON body of a bc-authorize response, success or error.
 type cibaBackchannelResponse struct {
 	AuthReqID string `json:"auth_req_id"`
 	ExpiresIn int64  `json:"expires_in"`
 	Interval  int64  `json:"interval"`
+	ErrorCode string `json:"error"`
 }
 
 // cibaBackchannelAuthorize submits a POST /oauth2/bc-authorize request with client_secret_basic
-// authentication and returns the HTTP status and parsed response.
+// authentication for the primary CIBA test client and returns the HTTP status and parsed response.
 func (ts *CIBATestSuite) cibaBackchannelAuthorize(loginHint, scope string) (int, cibaBackchannelResponse) {
 	form := url.Values{}
 	form.Set("login_hint", loginHint)
 	form.Set("scope", scope)
+	return ts.cibaBackchannelAuthorizeForm(form, cibaClientID, cibaClientSecret)
+}
 
+// cibaBackchannelAuthorizeForm submits a POST /oauth2/bc-authorize request with the given form body
+// and client_secret_basic authentication, returning the HTTP status and parsed response.
+func (ts *CIBATestSuite) cibaBackchannelAuthorizeForm(
+	form url.Values, clientID, clientSecret string,
+) (int, cibaBackchannelResponse) {
 	req, err := http.NewRequest("POST", testutils.TestServerURL+cibaBackchannelEndpoint,
 		strings.NewReader(form.Encode()))
 	ts.Require().NoError(err)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.SetBasicAuth(cibaClientID, cibaClientSecret)
+	req.SetBasicAuth(clientID, clientSecret)
 
 	resp, err := ts.client.Do(req)
 	ts.Require().NoError(err)
@@ -505,8 +1155,9 @@ func (ts *CIBATestSuite) cibaBackchannelAuthorize(loginHint, scope string) (int,
 	return resp.StatusCode, body
 }
 
-// cibaPostCallback posts the completed flow assertion to the CIBA callback and returns the status.
-func (ts *CIBATestSuite) cibaPostCallback(authID, assertion string) int {
+// cibaPostCallback posts the completed flow assertion to the CIBA callback and returns the HTTP
+// status and, on an error response, the error code.
+func (ts *CIBATestSuite) cibaPostCallback(authID, assertion string) (int, string) {
 	payload := map[string]string{
 		"authId":    authID,
 		"assertion": assertion,
@@ -522,27 +1173,43 @@ func (ts *CIBATestSuite) cibaPostCallback(authID, assertion string) int {
 	resp, err := ts.client.Do(req)
 	ts.Require().NoError(err)
 	defer resp.Body.Close()
-	return resp.StatusCode
+
+	var raw map[string]interface{}
+	_ = json.NewDecoder(resp.Body).Decode(&raw)
+	errorCode, _ := raw["error"].(string)
+	return resp.StatusCode, errorCode
 }
 
 // cibaTokenResult captures the outcome of a CIBA token poll.
 type cibaTokenResult struct {
 	statusCode  int
 	accessToken string
+	idToken     string
+	scope       string
 	errorCode   string
 }
 
-// cibaPollToken polls POST /oauth2/token with the CIBA grant and returns the parsed outcome.
-func (ts *CIBATestSuite) cibaPollToken(authReqID string) cibaTokenResult {
+// cibaPollToken polls POST /oauth2/token with the CIBA grant, using the primary CIBA test client and
+// optionally scoping the poll to a resource parameter, and returns the parsed outcome.
+func (ts *CIBATestSuite) cibaPollToken(authReqID, resource string) cibaTokenResult {
+	return ts.cibaPollTokenAs(authReqID, resource, cibaClientID, cibaClientSecret)
+}
+
+// cibaPollTokenAs polls POST /oauth2/token with the CIBA grant as an arbitrary client, optionally
+// scoping the poll to a resource parameter, and returns the parsed outcome.
+func (ts *CIBATestSuite) cibaPollTokenAs(authReqID, resource, clientID, clientSecret string) cibaTokenResult {
 	form := url.Values{}
 	form.Set("grant_type", cibaGrantType)
 	form.Set("auth_req_id", authReqID)
+	if resource != "" {
+		form.Set("resource", resource)
+	}
 
 	req, err := http.NewRequest("POST", testutils.TestServerURL+cibaTokenEndpoint,
 		strings.NewReader(form.Encode()))
 	ts.Require().NoError(err)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.SetBasicAuth(cibaClientID, cibaClientSecret)
+	req.SetBasicAuth(clientID, clientSecret)
 
 	resp, err := ts.client.Do(req)
 	ts.Require().NoError(err)
@@ -555,10 +1222,66 @@ func (ts *CIBATestSuite) cibaPollToken(authReqID string) cibaTokenResult {
 	if v, ok := raw["access_token"].(string); ok {
 		res.accessToken = v
 	}
+	if v, ok := raw["id_token"].(string); ok {
+		res.idToken = v
+	}
+	if v, ok := raw["scope"].(string); ok {
+		res.scope = v
+	}
 	if v, ok := raw["error"].(string); ok {
 		res.errorCode = v
 	}
 	return res
+}
+
+// recoverCIBAInvite recovers the executionId and inviteToken of the server-initiated flow for
+// authReqID from the captured notification. MockNotificationServer.GetLastMessage destructively
+// pops, so when more than one CIBA request is in flight this must be called immediately after the
+// corresponding bc-authorize call, before a concurrent request's notification arrives and gets
+// popped (and discarded) by a mismatched poll here.
+func (ts *CIBATestSuite) recoverCIBAInvite(authReqID string) (executionID, inviteToken string) {
+	ts.Require().Eventually(func() bool {
+		msg := ts.mockServer.GetLastMessage()
+		if msg == nil || extractCIBALinkParam(msg.Message, "auth_req_id") != authReqID {
+			return false
+		}
+		executionID = extractCIBALinkParam(msg.Message, "executionId")
+		inviteToken = extractCIBALinkParam(msg.Message, "inviteToken")
+		return executionID != "" && inviteToken != ""
+	}, 5*time.Second, 100*time.Millisecond,
+		"Expected CIBA notification carrying the executionId for auth_req_id "+authReqID)
+	return executionID, inviteToken
+}
+
+// driveCIBAFlow resumes the paused flow identified by executionID via the invite token, submits the
+// test user's credentials, posts the resulting assertion to the CIBA callback for authReqID
+// (asserting it is accepted), and returns the assertion so the caller can reuse it (for example
+// against a different auth_req_id, to test the cross-bound-assertion rejection).
+func (ts *CIBATestSuite) driveCIBAFlow(executionID, inviteToken, authReqID string) string {
+	resumeStep, err := testutils.ExecuteAuthenticationFlow(executionID,
+		map[string]string{"inviteToken": inviteToken}, "")
+	ts.Require().NoError(err, "should resume the flow with the invite token")
+
+	flowStep, err := testutils.ExecuteAuthenticationFlow(executionID, map[string]string{
+		"username": cibaTestUsername,
+		"password": cibaTestPassword,
+	}, "action_001", resumeStep.ChallengeToken)
+	ts.Require().NoError(err, "should complete the authentication flow")
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus)
+	ts.Require().NotEmpty(flowStep.Assertion, "flow completion should yield an assertion")
+
+	status, errorCode := ts.cibaPostCallback(authReqID, flowStep.Assertion)
+	ts.Require().Equal(http.StatusOK, status, "CIBA callback should accept the assertion: %s", errorCode)
+
+	return flowStep.Assertion
+}
+
+// completeCIBAFlow recovers the executionId/inviteToken of the server-initiated flow for authReqID
+// from the captured notification and drives it to completion. Only safe when at most one CIBA
+// request is in flight; see recoverCIBAInvite for the concurrent case.
+func (ts *CIBATestSuite) completeCIBAFlow(authReqID string) string {
+	executionID, inviteToken := ts.recoverCIBAInvite(authReqID)
+	return ts.driveCIBAFlow(executionID, inviteToken, authReqID)
 }
 
 // extractCIBALinkParam pulls a query parameter value out of the invite link embedded in a captured
@@ -570,4 +1293,34 @@ func extractCIBALinkParam(text, param string) string {
 		return ""
 	}
 	return m[1]
+}
+
+// buildFakeIDTokenHint builds a well-formed but unsigned JWT carrying the given claims. It is used to
+// exercise the id_token_hint validation guards that run before signature verification (issuer, sub
+// presence); guards that only run after signature verification (staleness) are unreachable this way
+// and are covered by an equivalent invalid_request outcome from the failed signature check instead.
+func buildFakeIDTokenHint(claims map[string]interface{}) string {
+	header := map[string]interface{}{"alg": "RS256", "typ": "JWT"}
+	headerJSON, _ := json.Marshal(header)
+	payloadJSON, _ := json.Marshal(claims)
+	return base64.RawURLEncoding.EncodeToString(headerJSON) + "." +
+		base64.RawURLEncoding.EncodeToString(payloadJSON) + ".fakesignature"
+}
+
+// tamperJWTSignature flips the last character of a real JWT's signature segment, invalidating it
+// while keeping the token well-formed (three base64url segments).
+func tamperJWTSignature(token string) string {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 || len(parts[2]) == 0 {
+		return token
+	}
+	sig := []byte(parts[2])
+	last := sig[len(sig)-1]
+	if last == 'A' {
+		sig[len(sig)-1] = 'B'
+	} else {
+		sig[len(sig)-1] = 'A'
+	}
+	parts[2] = string(sig)
+	return strings.Join(parts, ".")
 }

--- a/tests/integration/oauth/discovery/discovery_test.go
+++ b/tests/integration/oauth/discovery/discovery_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -18,6 +19,11 @@ const (
 	oauth2DiscoveryEndpoint = "/.well-known/oauth-authorization-server"
 	oidcDiscoveryEndpoint   = "/.well-known/openid-configuration"
 	testServerURL           = testutils.TestServerURL
+	// oidcCIBAGrantType is the OpenID Connect CIBA grant type identifier (providers.GrantTypeCIBA).
+	oidcCIBAGrantType = "urn:openid:params:grant-type:ciba"
+	// cibaBackchannelAuthEndpointPath is the backchannel authentication endpoint path
+	// (oauth2const.OAuth2BackchannelAuthEndpoint).
+	cibaBackchannelAuthEndpointPath = "/oauth2/bc-authorize"
 )
 
 // OAuth2AuthorizationServerMetadata represents OAuth2 Authorization Server Metadata (RFC 8414)
@@ -29,6 +35,9 @@ type OAuth2AuthorizationServerMetadata struct {
 	RevocationEndpoint                         string   `json:"revocation_endpoint,omitempty"`
 	IntrospectionEndpoint                      string   `json:"introspection_endpoint,omitempty"`
 	RegistrationEndpoint                       string   `json:"registration_endpoint,omitempty"`
+	BackchannelAuthenticationEndpoint          string   `json:"backchannel_authentication_endpoint,omitempty"`
+	BackchannelTokenDeliveryModesSupported     []string `json:"backchannel_token_delivery_modes_supported,omitempty"`
+	BackchannelUserCodeParameterSupported      bool     `json:"backchannel_user_code_parameter_supported"`
 	ResponseTypesSupported                     []string `json:"response_types_supported"`
 	GrantTypesSupported                        []string `json:"grant_types_supported"`
 	TokenEndpointAuthMethodsSupported          []string `json:"token_endpoint_auth_methods_supported"`
@@ -225,6 +234,34 @@ func (ts *DiscoveryTestSuite) TestOIDCDiscovery_AcrValuesSupported() {
 	}
 	ts.ElementsMatch(expectedACRs, metadata.AcrValuesSupported,
 		"acr_values_supported must contain exactly the ACR values from the ACR-AMR config")
+}
+
+// TestOIDCDiscovery_CIBAMetadata verifies the OIDC discovery document advertises CIBA support in
+// poll-only mode: the backchannel authentication endpoint, poll-only delivery mode, no user_code
+// parameter support, and the CIBA grant type in grant_types_supported. Ping/push delivery is not
+// implemented, so only "poll" must appear.
+func (ts *DiscoveryTestSuite) TestOIDCDiscovery_CIBAMetadata() {
+	req, err := http.NewRequest("GET", testServerURL+oidcDiscoveryEndpoint, nil)
+	ts.Require().NoError(err)
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusOK, resp.StatusCode)
+
+	var metadata OIDCProviderMetadata
+	err = json.NewDecoder(resp.Body).Decode(&metadata)
+	ts.Require().NoError(err)
+
+	ts.Contains(metadata.GrantTypesSupported, oidcCIBAGrantType,
+		"grant_types_supported must include the CIBA grant type")
+	ts.NotEmpty(metadata.BackchannelAuthenticationEndpoint, "BackchannelAuthenticationEndpoint should be present")
+	ts.True(strings.HasSuffix(metadata.BackchannelAuthenticationEndpoint, cibaBackchannelAuthEndpointPath),
+		"BackchannelAuthenticationEndpoint should end with the bc-authorize path")
+	ts.Equal([]string{"poll"}, metadata.BackchannelTokenDeliveryModesSupported,
+		"only poll-mode delivery is implemented")
+	ts.False(metadata.BackchannelUserCodeParameterSupported, "user_code is not supported")
 }
 
 // TestOIDCDiscovery_OPTIONS_Success tests OPTIONS request for CORS


### PR DESCRIPTION
### Purpose

Extend the CIBA integration suite from 2 tests to 12, and add the missing CIBA
discovery contract assertions.

The existing CIBA integration coverage was limited to the happy path, replay
rejection and a flow failure. Unit coverage for CIBA is already thorough, so this
PR deliberately targets only the behaviour unit tests cannot reach: the real
expiry clock, the real flow engine, real JWT signature verification, real
resource server records and real client authentication.

### Approach

New tests in `tests/integration/oauth/ciba/ciba_test.go`, weighted toward
negative cases:

- Request expiry on polling and on callback, including `requested_expiry`
  clamping
- Unresolvable `login_hint` mapping to `unknown_user_id` rather than
  `server_error`. This one matters: `mapFlowErrorToCIBAError` switches on literal
  flow engine failure strings, and unit tests mock the flow, so the coupling was
  previously unverified end to end
- `id_token_hint` resolving the same user, and a tampered signature rejected
- Resource bound token carrying the resource server audience with downscoped
  scopes
- Polling `resource` mismatch, and `resource` supplied against an unbound request
- `auth_req_id` not transferable across clients, and a non CIBA client rejected
  at `bc-authorize`
- Callback guards, including the cross bound assertion replay defence: a valid,
  correctly signed assertion for one request must not authorize a different
  concurrently pending request for the same user
- Table driven sweeps over the remaining callback and `bc-authorize` validation
  guards

Supporting refactor: the notification recovery and flow completion steps were
extracted into shared helpers, since several tests need the same sequence.

`tests/integration/oauth/discovery/discovery_test.go` gains
`TestOIDCDiscovery_CIBAMetadata`, which had no CIBA coverage at all. It locks the
poll only contract: `backchannel_token_delivery_modes_supported` is `["poll"]`
and `backchannel_user_code_parameter_supported` is `false`.

Two deliberate exclusions, so they are not mistaken for gaps:

- Ping and push delivery modes are not tested because they are not implemented.
  The discovery test asserts the poll only contract instead.
- The stale `id_token_hint` case is omitted from the validation table. It depends
  on `IDTokenHintMaxAgeDays` and would need a config change plus a server
  restart, which is disproportionate for a rule with direct unit coverage.

### Skipped test

`TestCIBABindingMessageDeliveredToUser` is committed but skipped. It uncovered a
product bug, reported as #4835: `smsExecutor` does not merge `ctx.RuntimeData`
into its template data, so `bindingMessage` is never substituted and CIBA SMS
notifications deliver the literal `{{ctx(bindingMessage)}}` to users.

The assertions are left intact beneath the skip, so removing the single skip line
restores full coverage once the bug is fixed. No product code is changed in this
PR.

### Related Issues
- #4835 (found by this work, not fixed here)

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded CIBA integration coverage for request expiry, user lookup, ID-token hints, resource binding, client isolation, binding messages, callback validation, and negative scenarios.
  * Added coverage for resource-specific token polling and downscoped access.
  * Added OIDC discovery validation for poll-only CIBA support, including its endpoint, grant type, delivery mode, and user-code setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->