### PR TITLE
Enable AI agent and MCP client options on the Get Started page

### DIFF
--- a/frontend/apps/console/src/App.tsx
+++ b/frontend/apps/console/src/App.tsx
@@ -446,6 +446,15 @@ export default function App(): JSX.Element {
                   <Route path="get-started/applications/types" element={<ApplicationTemplateSelectPage />} />
                   <Route path="get-started/applications/create" element={<ApplicationCreatePage />} />
                 </Route>
+                <Route
+                  element={
+                    <AgentCreateProvider>
+                      <Outlet />
+                    </AgentCreateProvider>
+                  }
+                >
+                  <Route path="get-started/agents/create" element={<AgentCreatePage />} />
+                </Route>
                 <Route path="tryout/securing-application" element={<TryoutSecuringApplicationPage />} />
                 <Route path="tryout/ai-agents" element={<TryoutSecuringAIAgentsPage />} />
                 <Route path="tryout/mcp" element={<TryoutSecuringMCPPage />} />

--- a/frontend/apps/console/src/configs/RouteConfig.ts
+++ b/frontend/apps/console/src/configs/RouteConfig.ts
@@ -49,6 +49,7 @@ export interface ConsoleRoutePaths {
     getStarted: () => string;
     getStartedApplicationsTypes: () => string;
     getStartedApplicationsCreate: () => string;
+    getStartedAgentsCreate: () => string;
     tryoutSecuringApplication: () => string;
     tryoutAiAgents: () => string;
     tryoutMcp: () => string;
@@ -223,6 +224,7 @@ const RouteConfig: RouteConfig = {
     getStarted: () => `/${ROUTE_SEGMENTS.welcome}/get-started`,
     getStartedApplicationsTypes: () => `/${ROUTE_SEGMENTS.welcome}/get-started/applications/types`,
     getStartedApplicationsCreate: () => `/${ROUTE_SEGMENTS.welcome}/get-started/applications/create`,
+    getStartedAgentsCreate: () => `/${ROUTE_SEGMENTS.welcome}/get-started/agents/create`,
     tryoutSecuringApplication: () => `/${ROUTE_SEGMENTS.welcome}/tryout/securing-application`,
     tryoutAiAgents: () => `/${ROUTE_SEGMENTS.welcome}/tryout/ai-agents`,
     tryoutMcp: () => `/${ROUTE_SEGMENTS.welcome}/tryout/mcp`,

--- a/frontend/apps/console/src/configs/__tests__/RouteConfig.test.ts
+++ b/frontend/apps/console/src/configs/__tests__/RouteConfig.test.ts
@@ -126,6 +126,7 @@ describe('RouteConfig', () => {
     expect(RouteConfig.welcome.getStarted()).toBe('/welcome/get-started');
     expect(RouteConfig.welcome.getStartedApplicationsTypes()).toBe('/welcome/get-started/applications/types');
     expect(RouteConfig.welcome.getStartedApplicationsCreate()).toBe('/welcome/get-started/applications/create');
+    expect(RouteConfig.welcome.getStartedAgentsCreate()).toBe('/welcome/get-started/agents/create');
     expect(RouteConfig.welcome.tryoutSecuringApplication()).toBe('/welcome/tryout/securing-application');
     expect(RouteConfig.welcome.tryoutAiAgents()).toBe('/welcome/tryout/ai-agents');
     expect(RouteConfig.welcome.tryoutMcp()).toBe('/welcome/tryout/mcp');

--- a/frontend/apps/console/src/features/agents/pages/AgentCreatePage.tsx
+++ b/frontend/apps/console/src/features/agents/pages/AgentCreatePage.tsx
@@ -17,7 +17,7 @@ import {Home} from '@wso2/oxygen-ui-icons-react';
 import type {JSX} from 'react';
 import {useState, useCallback, useEffect, useMemo} from 'react';
 import {useTranslation} from 'react-i18next';
-import {useNavigate} from 'react-router';
+import {useLocation, useNavigate} from 'react-router';
 import RouteConfig from '../../../configs/RouteConfig';
 import useCreateAgent from '../api/useCreateAgent';
 import ConfigureAgentDetails from '../components/create-agent/ConfigureAgentDetails';
@@ -31,6 +31,8 @@ import {AgentCreateFlowStep} from '../models/agent-create-flow';
 export default function AgentCreatePage(): JSX.Element {
   const {t} = useTranslation();
   const navigate = useNavigate();
+  const {pathname} = useLocation();
+  const isWelcomeFlow = pathname.startsWith('/welcome');
   const logger = useLogger('AgentCreatePage');
   const createAgent = useCreateAgent();
 
@@ -140,8 +142,36 @@ export default function AgentCreatePage(): JSX.Element {
   const isLastStep = currentStep === activeSteps[activeSteps.length - 1];
 
   const handleClose = (): void => {
-    void navigate(RouteConfig.agents.list());
+    void navigate(isWelcomeFlow ? RouteConfig.home.list() : RouteConfig.agents.list());
   };
+
+  // Leaving the wizard backwards, as opposed to dismissing it: the welcome flow reached it from
+  // the Get Started page, so that's where Back belongs there.
+  const handleBackOutOfWizard = (): void => {
+    void navigate(isWelcomeFlow ? RouteConfig.welcome.getStarted() : RouteConfig.agents.list());
+  };
+
+  const prefixCrumbs = isWelcomeFlow
+    ? [
+        {key: 'welcome', label: t('common:welcome.header'), onClick: () => void navigate(RouteConfig.welcome.root())},
+        {
+          key: 'new',
+          label: t('common:welcome.createProject.breadcrumb'),
+          onClick: () => void navigate(RouteConfig.welcome.createProject()),
+        },
+        {
+          key: 'get-started',
+          label: t('common:welcome.getStarted.breadcrumb'),
+          onClick: () => void navigate(RouteConfig.welcome.getStarted()),
+        },
+      ]
+    : [
+        {
+          key: 'agents',
+          label: t('agents:listing.title', 'Agents'),
+          onClick: () => void navigate(RouteConfig.agents.list()),
+        },
+      ];
 
   // Resolves an error through the `agents` catalog. `t` defaults to the `common` namespace, so
   // this forwards explicit `ns:` prefixes unchanged and prefixes bare keys with `agents:`, per
@@ -409,7 +439,7 @@ export default function AgentCreatePage(): JSX.Element {
         )}
         value={selectedOuId ?? ''}
         onChange={handleOuIdChange}
-        onBack={handleClose}
+        onBack={handleBackOutOfWizard}
         onContinue={handleNextStep}
         backLabel={t('common:actions.back', 'Back')}
         continueLabel={t('common:actions.continue', 'Continue')}
@@ -421,11 +451,14 @@ export default function AgentCreatePage(): JSX.Element {
     <FullScreenCreationWizardLayout
       onClose={handleClose}
       progress={getStepProgress()}
-      breadcrumbItems={getBreadcrumbSteps().map((step, index, array) => ({
-        key: step,
-        label: steps[step]?.label ?? step,
-        onClick: index < array.length - 1 ? () => setCurrentStep(step) : undefined,
-      }))}
+      breadcrumbItems={[
+        ...prefixCrumbs,
+        ...getBreadcrumbSteps().map((step, index, array) => ({
+          key: step,
+          label: steps[step]?.label ?? step,
+          onClick: index < array.length - 1 ? () => setCurrentStep(step) : undefined,
+        })),
+      ]}
       footer={
         <Stack
           direction="row"

--- a/frontend/apps/console/src/features/agents/pages/__tests__/AgentCreatePage.test.tsx
+++ b/frontend/apps/console/src/features/agents/pages/__tests__/AgentCreatePage.test.tsx
@@ -24,11 +24,14 @@ const {
   mockUseAgentCreate: vi.fn(),
 }));
 
+let mockPathname = '/agents/create';
+
 vi.mock('react-router', async () => {
   const actual = await vi.importActual('react-router');
   return {
     ...actual,
     useNavigate: () => mockNavigate,
+    useLocation: () => ({pathname: mockPathname}),
   };
 });
 
@@ -44,13 +47,24 @@ vi.mock('@thunderid/configure-organization-units', () => ({
     data: id ? {id, name: 'Test Organization Unit'} : undefined,
     isLoading: false,
   }),
-  OrganizationUnitPickerScreen: ({onChange, onContinue}: {onChange: (id: string) => void; onContinue: () => void}) => (
+  OrganizationUnitPickerScreen: ({
+    onChange,
+    onContinue,
+    onBack,
+  }: {
+    onChange: (id: string) => void;
+    onContinue: () => void;
+    onBack: () => void;
+  }) => (
     <div data-testid="step-organization-unit">
       <button type="button" onClick={() => onChange('ou-2')}>
         Select OU
       </button>
       <button type="button" onClick={onContinue}>
         OU Continue
+      </button>
+      <button type="button" onClick={onBack}>
+        OU Back
       </button>
     </div>
   ),
@@ -127,6 +141,7 @@ describe('AgentCreatePage', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPathname = '/agents/create';
     agentCreateState = {
       currentStep: AgentCreateFlowStep.NAME,
       selectedSchema: {id: 'schema-1', name: 'default', ouId: 'ou-1'},
@@ -192,6 +207,62 @@ describe('AgentCreatePage', () => {
     await user.click(closeButton);
 
     expect(mockNavigate).toHaveBeenCalledWith('/agents');
+  });
+
+  it('renders the Agents breadcrumb outside the welcome flow', () => {
+    render(<AgentCreatePage />);
+
+    expect(screen.getByText('Agents')).toBeInTheDocument();
+  });
+
+  describe('welcome flow', () => {
+    beforeEach(() => {
+      mockPathname = '/welcome/get-started/agents/create';
+    });
+
+    it('renders the welcome breadcrumb trail', () => {
+      render(<AgentCreatePage />);
+
+      expect(screen.getByText('common:welcome.header')).toBeInTheDocument();
+      expect(screen.getByText('common:welcome.createProject.breadcrumb')).toBeInTheDocument();
+      expect(screen.getByText('common:welcome.getStarted.breadcrumb')).toBeInTheDocument();
+      expect(screen.queryByText('Agents')).not.toBeInTheDocument();
+    });
+
+    it('navigates to the Get Started page from the breadcrumb', async () => {
+      const user = userEvent.setup();
+      render(<AgentCreatePage />);
+
+      await user.click(screen.getByText('common:welcome.getStarted.breadcrumb'));
+
+      expect(mockNavigate).toHaveBeenCalledWith('/welcome/get-started');
+    });
+
+    it('navigates to /home when close button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<AgentCreatePage />);
+
+      const closeButton = screen.getAllByRole('button')[0];
+      await user.click(closeButton);
+
+      expect(mockNavigate).toHaveBeenCalledWith('/home');
+    });
+
+    it('goes back to the Get Started page from the organization unit step', async () => {
+      const user = userEvent.setup();
+      agentCreateState.currentStep = AgentCreateFlowStep.ORGANIZATION_UNIT;
+      mockUseGetChildOrganizationUnits.mockReturnValue({
+        data: {totalResults: 2},
+        isLoading: false,
+        error: null,
+      });
+
+      render(<AgentCreatePage />);
+
+      await user.click(screen.getByRole('button', {name: 'OU Back'}));
+
+      expect(mockNavigate).toHaveBeenCalledWith('/welcome/get-started');
+    });
   });
 
   it('disables the continue button until the step reports ready', () => {

--- a/frontend/apps/console/src/features/applications/pages/ApplicationTemplateSelectPage.tsx
+++ b/frontend/apps/console/src/features/applications/pages/ApplicationTemplateSelectPage.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import {ResourceAvatar} from '@thunderid/components';
+import {PageLoader, ResourceAvatar} from '@thunderid/components';
 import {useLogger} from '@thunderid/logger/react';
 import {
   Box,
@@ -89,7 +89,7 @@ export default function ApplicationTemplateSelectPage(): JSX.Element {
     });
   }, [selectedCategory, searchQuery, t]);
 
-  const handleTemplateSelect = (option: AnyTemplateMetadata): void => {
+  const handleTemplateSelect = (option: AnyTemplateMetadata, replace = false): void => {
     if (option.disabled) return;
 
     reset();
@@ -119,7 +119,7 @@ export default function ApplicationTemplateSelectPage(): JSX.Element {
     const wizardPath = isWelcomeFlow ? '/welcome/get-started/applications/create' : '/applications/create';
 
     (async () => {
-      await navigate(`${wizardPath}?type=${option.value}`);
+      await navigate(`${wizardPath}?type=${option.value}`, {replace});
     })().catch((error: unknown) => {
       logger.error('Failed to navigate to application creation wizard', {error, template: option.value});
     });
@@ -127,16 +127,28 @@ export default function ApplicationTemplateSelectPage(): JSX.Element {
 
   // Entry points elsewhere in the console (e.g. the home page's framework picker) deep-link here
   // with a preselected type, skipping the gallery straight to the wizard.
-  useEffect(() => {
+  const preselectedTemplate: AnyTemplateMetadata | undefined = useMemo(() => {
     const typeParam = searchParams.get('type');
-    if (!typeParam) return;
-
+    if (!typeParam) return undefined;
     const preselected = ALL_TEMPLATES.find((tmpl) => tmpl.value === typeParam);
-    if (preselected && !preselected.disabled) {
-      handleTemplateSelect(preselected);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return preselected && !preselected.disabled ? preselected : undefined;
   }, [searchParams]);
+
+  useEffect(() => {
+    if (!preselectedTemplate) return;
+    // Replaces rather than pushes, so this pass-through gallery entry doesn't sit in the history
+    // between the entry point and the wizard — going back from the wizard would otherwise land
+    // here and be bounced straight forward again.
+    handleTemplateSelect(preselectedTemplate, true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [preselectedTemplate]);
+
+  // The gallery is only passed through on a deep link, so rendering it would flash the full
+  // template grid for a frame before the effect above navigates on. Hold the loader the lazy
+  // wizard chunk shows anyway, so the hand-off reads as one continuous load.
+  if (preselectedTemplate) {
+    return <PageLoader />;
+  }
 
   return (
     <PageContent>

--- a/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationTemplateSelectPage.test.tsx
+++ b/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationTemplateSelectPage.test.tsx
@@ -130,7 +130,9 @@ describe('ApplicationTemplateSelectPage', () => {
     expect(setSelectedTemplateConfig).toHaveBeenCalled();
     // React uses the default flow whose first step is ORGANIZATION_UNIT.
     expect(setCurrentStep).toHaveBeenCalledWith(ApplicationCreateFlowStep.ORGANIZATION_UNIT);
-    expect(mockNavigate).toHaveBeenCalledWith(`/applications/create?type=${TechnologyApplicationTemplate.REACT}`);
+    expect(mockNavigate).toHaveBeenCalledWith(`/applications/create?type=${TechnologyApplicationTemplate.REACT}`, {
+      replace: false,
+    });
   });
 
   it('seeds a platform template and clears technology when a platform card is clicked', async () => {
@@ -144,7 +146,9 @@ describe('ApplicationTemplateSelectPage', () => {
 
     expect(setSelectedPlatform).toHaveBeenCalledWith(PlatformApplicationTemplate.BACKEND);
     expect(setSelectedTechnology).toHaveBeenCalledWith(null);
-    expect(mockNavigate).toHaveBeenCalledWith(`/applications/create?type=${PlatformApplicationTemplate.BACKEND}`);
+    expect(mockNavigate).toHaveBeenCalledWith(`/applications/create?type=${PlatformApplicationTemplate.BACKEND}`, {
+      replace: false,
+    });
   });
 
   it('advances to ORGANIZATION_UNIT first for the MCP client template', async () => {
@@ -157,7 +161,9 @@ describe('ApplicationTemplateSelectPage', () => {
 
     // mcp-client flow: ORGANIZATION_UNIT → DETAILS → CLIENT_TYPE → COMPLETE; first step is ORGANIZATION_UNIT.
     expect(setCurrentStep).toHaveBeenCalledWith(ApplicationCreateFlowStep.ORGANIZATION_UNIT);
-    expect(mockNavigate).toHaveBeenCalledWith(`/applications/create?type=${TechnologyApplicationTemplate.MCP_CLIENT}`);
+    expect(mockNavigate).toHaveBeenCalledWith(`/applications/create?type=${TechnologyApplicationTemplate.MCP_CLIENT}`, {
+      replace: false,
+    });
   });
 
   it('navigates back to the Get Started page when in the welcome flow', () => {
@@ -177,6 +183,7 @@ describe('ApplicationTemplateSelectPage', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith(
       `/welcome/get-started/applications/create?type=${TechnologyApplicationTemplate.REACT}`,
+      {replace: false},
     );
   });
 
@@ -194,7 +201,9 @@ describe('ApplicationTemplateSelectPage', () => {
     fireEvent.keyDown(screen.getByTestId(`template-card-${TechnologyApplicationTemplate.REACT}`), {key: 'Enter'});
 
     expect(setSelectedTechnology).toHaveBeenCalledWith(TechnologyApplicationTemplate.REACT);
-    expect(mockNavigate).toHaveBeenCalledWith(`/applications/create?type=${TechnologyApplicationTemplate.REACT}`);
+    expect(mockNavigate).toHaveBeenCalledWith(`/applications/create?type=${TechnologyApplicationTemplate.REACT}`, {
+      replace: false,
+    });
   });
 
   it('selects a template when Space is pressed on a card', () => {
@@ -205,7 +214,9 @@ describe('ApplicationTemplateSelectPage', () => {
     fireEvent.keyDown(screen.getByTestId(`template-card-${TechnologyApplicationTemplate.REACT}`), {key: ' '});
 
     expect(setSelectedTechnology).toHaveBeenCalledWith(TechnologyApplicationTemplate.REACT);
-    expect(mockNavigate).toHaveBeenCalledWith(`/applications/create?type=${TechnologyApplicationTemplate.REACT}`);
+    expect(mockNavigate).toHaveBeenCalledWith(`/applications/create?type=${TechnologyApplicationTemplate.REACT}`, {
+      replace: false,
+    });
   });
 
   it('ignores keys other than Enter and Space', () => {
@@ -227,7 +238,20 @@ describe('ApplicationTemplateSelectPage', () => {
     await vi.waitFor(() => {
       expect(setSelectedTechnology).toHaveBeenCalledWith(TechnologyApplicationTemplate.REACT);
     });
-    expect(mockNavigate).toHaveBeenCalledWith(`/applications/create?type=${TechnologyApplicationTemplate.REACT}`);
+    // Replaces the pass-through gallery entry so going back from the wizard reaches the entry
+    // point rather than bouncing forward again.
+    expect(mockNavigate).toHaveBeenCalledWith(`/applications/create?type=${TechnologyApplicationTemplate.REACT}`, {
+      replace: true,
+    });
+  });
+
+  it('does not render the template gallery while passing through on a deep link', () => {
+    mockSearchParams = new URLSearchParams({type: TechnologyApplicationTemplate.REACT});
+
+    renderPage();
+
+    expect(screen.queryByRole('heading', {name: 'Choose a type'})).not.toBeInTheDocument();
+    expect(screen.queryByTestId(`template-card-${TechnologyApplicationTemplate.REACT}`)).not.toBeInTheDocument();
   });
 
   it('ignores an unknown type query param', () => {

--- a/frontend/apps/console/src/features/welcome/pages/GetStartedPage.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/GetStartedPage.tsx
@@ -9,6 +9,7 @@ import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
 import RouteConfig from '../../../configs/RouteConfig';
+import {TechnologyApplicationTemplate} from '../../applications/models/application-templates';
 import useWelcomeClose from '../hooks/useWelcomeClose';
 
 const MotionBox = motion.create(Box);
@@ -28,25 +29,27 @@ export default function GetStartedPage(): JSX.Element {
       description: t('common:welcome.getStarted.options.onboardApp.description', {productName}),
       action: () => void navigate(RouteConfig.welcome.getStartedApplicationsTypes()),
       actionLabel: t('common:welcome.getStarted.options.onboardApp.action'),
-      disabled: false,
     },
     {
       id: 'secure-ai-agent',
       icon: <Bot size={36} />,
       title: t('common:welcome.getStarted.options.secureAiAgent.title'),
       description: t('common:welcome.getStarted.options.secureAiAgent.description'),
-      action: undefined,
-      actionLabel: t('common:welcome.getStarted.options.comingSoon'),
-      disabled: true,
+      action: () => void navigate(RouteConfig.welcome.getStartedAgentsCreate()),
+      actionLabel: t('common:welcome.getStarted.options.secureAiAgent.action'),
     },
     {
       id: 'secure-mcp',
       icon: <MCP size={36} />,
       title: t('common:welcome.getStarted.options.secureMcp.title'),
       description: t('common:welcome.getStarted.options.secureMcp.description'),
-      action: undefined,
-      actionLabel: t('common:welcome.getStarted.options.comingSoon'),
-      disabled: true,
+      // The MCP client application template drives its own creation wizard, so deep-link straight
+      // into it rather than dropping the user back on the full template gallery.
+      action: () =>
+        void navigate(
+          `${RouteConfig.welcome.getStartedApplicationsTypes()}?type=${TechnologyApplicationTemplate.MCP_CLIENT}`,
+        ),
+      actionLabel: t('common:welcome.getStarted.options.secureMcp.action'),
     },
   ];
 
@@ -145,7 +148,7 @@ export default function GetStartedPage(): JSX.Element {
                       textAlign: 'center',
                       gap: 2,
                       transition: 'all 0.2s',
-                      ...(option.disabled ? {opacity: 0.55} : {'&:hover': {boxShadow: 2, borderColor: 'primary.main'}}),
+                      '&:hover': {boxShadow: 2, borderColor: 'primary.main'},
                     }}
                   >
                     <Box
@@ -168,12 +171,7 @@ export default function GetStartedPage(): JSX.Element {
                     <Typography variant="body2" color="text.secondary" sx={{flex: 1}}>
                       {option.description}
                     </Typography>
-                    <Button
-                      variant="contained"
-                      onClick={option.action}
-                      disabled={option.disabled}
-                      sx={{mt: 1, minWidth: 160}}
-                    >
+                    <Button variant="contained" onClick={option.action} sx={{mt: 1, minWidth: 160}}>
                       {option.actionLabel}
                     </Button>
                   </Box>

--- a/frontend/apps/console/src/features/welcome/pages/__tests__/GetStartedPage.test.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/__tests__/GetStartedPage.test.tsx
@@ -125,6 +125,19 @@ describe('GetStartedPage', () => {
     expect(screen.getByText(/common:welcome\.getStarted\.options\.onboardApp\.description/i)).toBeInTheDocument();
   });
 
+  it('renders secure AI agent option as an available action', () => {
+    render(<GetStartedPage />);
+    expect(screen.getByText('common:welcome.getStarted.options.secureAiAgent.title')).toBeInTheDocument();
+    expect(screen.getByText('common:welcome.getStarted.options.secureAiAgent.action')).toBeInTheDocument();
+    expect(screen.queryByText('common:welcome.getStarted.options.comingSoon')).not.toBeInTheDocument();
+  });
+
+  it('renders secure MCP option as an available action', () => {
+    render(<GetStartedPage />);
+    expect(screen.getByText('common:welcome.getStarted.options.secureMcp.title')).toBeInTheDocument();
+    expect(screen.getByText('common:welcome.getStarted.options.secureMcp.action')).toBeInTheDocument();
+  });
+
   it('renders skip to console button', () => {
     render(<GetStartedPage />);
     expect(screen.getByText('common:welcome.getStarted.actions.skipToConsole')).toBeInTheDocument();
@@ -138,6 +151,24 @@ describe('GetStartedPage', () => {
     await user.click(actionButton);
 
     expect(mockNavigate).toHaveBeenCalledWith('/welcome/get-started/applications/types');
+  });
+
+  it('navigates to the welcome-scoped agent wizard on secure AI agent click', async () => {
+    const user = userEvent.setup();
+    render(<GetStartedPage />);
+
+    await user.click(screen.getByText('common:welcome.getStarted.options.secureAiAgent.action'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/welcome/get-started/agents/create');
+  });
+
+  it('navigates to the MCP client template on secure MCP click', async () => {
+    const user = userEvent.setup();
+    render(<GetStartedPage />);
+
+    await user.click(screen.getByText('common:welcome.getStarted.options.secureMcp.action'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/welcome/get-started/applications/types?type=MCP_CLIENT');
   });
 
   it('navigates to /home and sets session storage on skip', async () => {

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -243,9 +243,11 @@ const translations = {
     'welcome.getStarted.options.secureAiAgent.title': 'Secure an AI Agent',
     'welcome.getStarted.options.secureAiAgent.description':
       'Protect your AI agents with token-based access control and scope enforcement.',
-    'welcome.getStarted.options.secureMcp.title': 'Secure MCP Server / Client',
+    'welcome.getStarted.options.secureAiAgent.action': 'Add Agent',
+    'welcome.getStarted.options.secureMcp.title': 'Secure an MCP Client',
     'welcome.getStarted.options.secureMcp.description':
-      'Authorize MCP clients to access your MCP server with fine-grained permissions.',
+      'Register your MCP client and authorize it with fine-grained, scoped permissions.',
+    'welcome.getStarted.options.secureMcp.action': 'Add MCP Client',
     'welcome.getStarted.options.comingSoon': 'Coming Soon',
     'welcome.getStarted.options.skip.title': 'Skip for now',
     'welcome.getStarted.options.skip.description':


### PR DESCRIPTION
### Purpose

On the Get Started page (**New → Get Started**), the "Secure an AI Agent" and "Secure MCP Server / Client" options were rendered disabled with a "Coming Soon" label, even though both destinations already existed in the console. This PR makes them available, and fixes the two navigation problems that surfaced once they were wired up.

Changes:

1. **Both options are now live actions.** "Secure an AI Agent" opens the agent creation wizard; "Secure MCP Server / Client" opens the MCP client application template.
2. **The MCP card copy now matches where it leads.** It is retitled to "Secure an MCP Client", and the description no longer refers to an MCP server, since the card onboards a client.
3. **The agent wizard is now welcome flow aware.** Reached from Get Started it carries the `Welcome / New / Get started` breadcrumb trail and returns to the Get Started page, matching the application wizard. Previously it always showed only its own step crumbs and closed to the agents list, stranding the user outside the onboarding flow.
4. **Deep linking into the application wizard no longer flashes the template gallery.** Entering with a preselected `?type=` briefly painted the full template grid before redirecting, and left a history entry that trapped the browser back button.

| | Before | After |
|---|---|---|
| AI agent card | Disabled, "Coming Soon" | "Add Agent", opens the agent wizard |
| MCP card | Disabled, "Coming Soon" | "Add MCP Client", opens the mcp-client wizard |
| MCP card title | Secure MCP Server / Client | Secure an MCP Client |
| Agent wizard breadcrumbs (from Get Started) | Wizard steps only | Welcome / New / Get started / wizard steps |
| Agent wizard close (from Get Started) | `/agents` | `/home` |
| Deep link paint sequence | loader, template grid, loader, name step | loader, name step |
| Back from a deep linked wizard | Bounced forward into the wizard again | Returns to the entry point |

### Approach

**1. Enabling the two options** (`GetStartedPage.tsx`)

Both cards had `action: undefined` and `disabled: true` hardcoded. They now navigate to real destinations, and the `disabled` field is removed entirely along with its dimmed styling branch and the `Button disabled` prop, since no option is disabled anymore. Two i18n action labels were added. The `welcome.getStarted.options.comingSoon` key is retained because `TryoutSecuringApplicationPage` still uses it.

**2. Choosing the MCP destination**

An `mcp-client` application template already exists with its own creation wizard, so the card deep links straight into it rather than dropping the user on the full template gallery. The i18n key namespace stays `welcome.getStarted.options.secureMcp.*` to avoid churning the option id and its tests.

**3. Making the agent wizard welcome flow aware**

Both wizards detect their context from the path alone (`pathname.startsWith('/welcome')`). There is no query param or router state carrying that information, so the agent wizard needed a second route to be distinguishable, exactly as the application wizard already has:

| | Standalone | Welcome scoped |
|---|---|---|
| Applications | `/applications/create` | `/welcome/get-started/applications/create` |
| Agents | `/agents/create` | `/welcome/get-started/agents/create` (new) |

The new route is added to `RouteConfig` as `welcome.getStartedAgentsCreate()` and mounted inside the welcome route tree as a pathless layout route supplying `AgentCreateProvider`. It does not repeat `ProtectedRoute` or `FullScreenLayout` because the parent welcome route already provides both. The standalone route is kept unchanged, since the agents list page's "Add Agent" button uses it.

`AgentCreatePage` then mirrors `ApplicationCreatePage`: it builds `prefixCrumbs` per flow, closes to `/home` rather than `/agents` in the welcome flow, and gains a `handleBackOutOfWizard` for the organization unit step's Back button. That step previously reused `handleClose`, conflating dismissing the wizard with stepping back out of it.

Note: outside the welcome flow the agent wizard previously had no prefix crumb at all, unlike the application wizard's `Applications` crumb. Introducing `prefixCrumbs` meant writing both branches, so the standalone case now gets an `Agents` crumb linking to the list. It uses `t('agents:listing.title')`, the same key the agents list page renders as its own header, because there is no `navigation:pages.agents` key (agents are not a sidebar entry).

**4. Removing the template gallery flash** (`ApplicationTemplateSelectPage.tsx`)

The gallery cannot be skipped. `ApplicationCreatePage` reads the chosen template from `ApplicationCreateProvider` context and redirects back to the gallery when `selectedTemplateConfig` is absent, and only the gallery's `handleTemplateSelect` seeds that context (reset, technology/platform, template config, default sign-in approach, and the template's first wizard step). The Get Started page sits outside the provider and cannot seed it. So the goal was to make the pass-through invisible rather than remove it:

- The `?type=` lookup moved from inside the `useEffect` body into a `useMemo`, so the resolved template is known during render.
- When a valid preselected template is present the page returns `<PageLoader />` instead of the gallery. Effects run after paint, so the old code was guaranteed to render the full template grid for at least one frame. `PageLoader` is the same component the router already shows as the Suspense fallback while the lazy wizard chunk loads, so the hand-off now reads as one continuous load. The early return sits after every hook, so hook order is unaffected.
- `handleTemplateSelect` takes a `replace` flag, defaulting to `false` so clicking a card is unchanged. The deep link path passes `true`, so the pass-through entry never enters history. Without it, back from the wizard landed on the gallery, whose effect immediately pushed forward again.

Both fixes live in the shared destination page, so every `?type=` entry point inherits them, including the home page's `StartCoding` and `FrameworkFlipCard` pickers, which had the identical glitch. Neither of those files needed changes.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4750

<img width="1827" height="834" alt="image" src="https://github.com/user-attachments/assets/b330c548-7377-451b-8c6b-e42b911ba82d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Secure AI Agent and Secure MCP options to the Get Started page.
  * Added guided navigation for creating agents from the welcome flow.
  * Added MCP client registration with preselected application templates.
  * Improved breadcrumbs and back navigation throughout agent creation.

* **Bug Fixes**
  * Deep links to valid application templates now open the creation wizard directly without displaying the gallery first.

* **Documentation**
  * Updated welcome-page text to clarify MCP client registration and permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->