### PR TITLE
Resolve bindingMessage in SMS executor for CIBA flows

### DIFF
--- a/backend/internal/flow/executor/sms_executor.go
+++ b/backend/internal/flow/executor/sms_executor.go
@@ -119,21 +119,7 @@ func (e *smsExecutor) Execute(ctx *providers.NodeContext) (*providers.ExecutorRe
 	}
 	scenario := template.ScenarioType(tmplStr)
 
-	templateData := template.TemplateData{"appName": ctx.Application.Name}
-	if ctx.ForwardedData != nil {
-		if fwdTemplateData, ok := ctx.ForwardedData[common.ForwardedDataKeyTemplateData]; ok {
-			switch data := fwdTemplateData.(type) {
-			case map[string]interface{}:
-				for k, v := range data {
-					templateData[k] = fmt.Sprintf("%v", v)
-				}
-			case map[string]string:
-				for k, v := range data {
-					templateData[k] = v
-				}
-			}
-		}
-	}
+	templateData := e.resolveTemplateData(ctx)
 
 	rendered, svcErr := e.templateService.Render(ctx.Context, scenario, template.TemplateTypeSMS, templateData)
 	if svcErr != nil {
@@ -156,6 +142,34 @@ func (e *smsExecutor) Execute(ctx *providers.NodeContext) (*providers.ExecutorRe
 	execResp.AdditionalData[common.DataSMSSent] = dataValueTrue
 	execResp.Status = providers.ExecComplete
 	return execResp, nil
+}
+
+// resolveTemplateData extracts template data from RuntimeData, Context, and ForwardedData.
+func (e *smsExecutor) resolveTemplateData(ctx *providers.NodeContext) template.TemplateData {
+	templateData := template.TemplateData{}
+
+	for k, v := range ctx.RuntimeData {
+		templateData[k] = v
+	}
+
+	templateData["appName"] = ctx.Application.Name
+
+	if ctx.ForwardedData != nil {
+		if fwdTemplateData, ok := ctx.ForwardedData[common.ForwardedDataKeyTemplateData]; ok {
+			switch data := fwdTemplateData.(type) {
+			case map[string]interface{}:
+				for k, v := range data {
+					templateData[k] = fmt.Sprintf("%v", v)
+				}
+			case map[string]string:
+				for k, v := range data {
+					templateData[k] = v
+				}
+			}
+		}
+	}
+
+	return templateData
 }
 
 // resolveRecipientMobile retrieves the recipient mobile number from user inputs, runtime data,

--- a/backend/internal/flow/executor/sms_executor_test.go
+++ b/backend/internal/flow/executor/sms_executor_test.go
@@ -573,6 +573,50 @@ func (suite *SMSExecutorTestSuite) TestExecute_SendMode_TemplateRenderFailure_Re
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
+func (suite *SMSExecutorTestSuite) TestExecute_SendMode_TemplateDataIncludesRuntimeData() {
+	ctx := &providers.NodeContext{
+		ExecutionID:  "test-flow-id",
+		ExecutorMode: ExecutorModeSend,
+		Application:  providers.Application{Name: "MyApp"},
+		UserInputs: map[string]string{
+			common.AttributeMobileNumber: "+94714627887",
+		},
+		RuntimeData: map[string]string{
+			common.RuntimeKeyBindingMessage: "Approve sign-in",
+		},
+		ForwardedData: map[string]interface{}{
+			common.ForwardedDataKeyTemplateData: map[string]interface{}{
+				"inviteLink": "https://localhost:5190/gate/invite?executionId=test",
+			},
+		},
+		NodeProperties: map[string]interface{}{
+			propertyKeyNotificationSenderID: "sender-uuid-001",
+			propertyKeySMSTemplate:          string(template.ScenarioCIBANotification),
+		},
+	}
+
+	suite.mockBaseExecutor.On("GetRequiredInputs", mock.Anything).Return([]providers.Input{
+		{Identifier: common.AttributeMobileNumber, Type: providers.InputTypePhone, Required: true},
+	}).Maybe()
+	suite.mockTemplateService.On("Render", mock.Anything, template.ScenarioCIBANotification,
+		template.TemplateTypeSMS,
+		template.TemplateData{
+			common.RuntimeKeyBindingMessage: "Approve sign-in",
+			"appName":                       "MyApp",
+			"inviteLink":                    "https://localhost:5190/gate/invite?executionId=test",
+		},
+	).Return(&template.RenderedTemplate{Body: testRenderedSMSBody}, nil)
+	suite.mockSMSSenderSvc.On("Send",
+		mock.Anything, mock.Anything, "sender-uuid-001",
+		notifcm.NotificationData{Recipient: "+94714627887", Body: testRenderedSMSBody},
+	).Return(nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	suite.NoError(err)
+	suite.Equal(providers.ExecComplete, resp.Status)
+}
+
 func TestSMSExecutorSuite(t *testing.T) {
 	suite.Run(t, new(SMSExecutorTestSuite))
 }


### PR DESCRIPTION
### Purpose
CIBA SMS notifications delivered the raw `{{ctx(bindingMessage)}}` placeholder instead of the binding message. `smsExecutor` built its template data from `appName` plus `ForwardedData` only, never merging `ctx.RuntimeData`, which is where the CIBA service puts `bindingMessage`. Unresolved placeholders are returned verbatim by the template service, so the failure was silent. The email channel was unaffected because `emailExecutor` already merges `RuntimeData`.

### Approach
Extracted `resolveTemplateData` on `smsExecutor`, mirroring the email executor: merge `RuntimeData` first, then `appName`, then `ForwardedData`, so forwarded values still take precedence. `appName` stays assigned unconditionally to preserve the existing SMS behaviour when the application name is empty.

### Related Issues
- Fixes #4835 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SMS template rendering to include runtime data, application name, and forwarded template values.
  * Added support for forwarded template data supplied in multiple formats.
  * Ensured rendered SMS messages are sent with the expected content.

* **Tests**
  * Added coverage validating SMS rendering with combined template data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->