### PR TITLE
Gate the edit page Set as default action on resource server type.

### DIFF
--- a/frontend/packages/configure-resource-servers/src/pages/ResourceServerEditPage.tsx
+++ b/frontend/packages/configure-resource-servers/src/pages/ResourceServerEditPage.tsx
@@ -33,6 +33,7 @@ import ResourceServerDeleteDialog from '../components/ResourceServerDeleteDialog
 import SetDefaultResourceServerDialog from '../components/SetDefaultResourceServerDialog';
 import {getResourceServerTypeLabel} from '../config/resource-server-types';
 import useResourceServerRoutes from '../hooks/useResourceServerRoutes';
+import {isDefaultEligibleType} from '../models/resource-server';
 
 interface TabPanelProps {
   children?: React.ReactNode;
@@ -215,6 +216,9 @@ export default function ResourceServerEditPage(): JSX.Element {
   // A declarative (read-only) default is locked; the backend rejects any write, so the
   // action can never succeed and must not be offered.
   const isDefaultLocked = isDefaultReady && Boolean(defaultConfig?.readOnly?.resourceServerId);
+  // Only API and custom servers are eligible, as in the list menu and the creation wizard. The badge
+  // above is deliberately not gated on this, so a default set outside the console still shows up.
+  const isDefaultEligible = isDefaultEligibleType(resourceServer.type);
 
   return (
     <PageContent>
@@ -285,7 +289,7 @@ export default function ResourceServerEditPage(): JSX.Element {
                 />
               </Tooltip>
             )}
-            {isDefaultReady && !isDefault && !isDefaultLocked && (
+            {isDefaultReady && !isDefault && !isDefaultLocked && isDefaultEligible && (
               <Button variant="contained" size="small" onClick={() => setDefaultDialogOpen(true)}>
                 {t('resourceServers:actions.setAsDefault', 'Set as default')}
               </Button>

--- a/frontend/packages/configure-resource-servers/src/pages/__tests__/ResourceServerEditPage.test.tsx
+++ b/frontend/packages/configure-resource-servers/src/pages/__tests__/ResourceServerEditPage.test.tsx
@@ -506,6 +506,37 @@ describe('ResourceServerEditPage', () => {
     expect(screen.queryByRole('button', {name: 'Set as default'})).not.toBeInTheDocument();
   });
 
+  it('does not offer Set as default for an MCP server, which is not an eligible type', () => {
+    mockUseGetResourceServer.mockReturnValue({
+      data: mockMcpResourceServer,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+
+    renderWithProviders(<ResourceServerEditPage />);
+
+    expect(screen.queryByRole('button', {name: 'Set as default'})).not.toBeInTheDocument();
+  });
+
+  // The backend accepts an MCP default, so this state is reachable through the API or declarative
+  // config. The console must report it rather than hide it.
+  it('still shows the badge for an MCP server that is already the default', () => {
+    mockUseGetResourceServer.mockReturnValue({
+      data: mockMcpResourceServer,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+    mockUseGetDefaultResourceServer.mockReturnValue({
+      data: {readOnly: {}, writable: {}, merged: {resourceServerId: 'rs-1'}},
+    });
+
+    renderWithProviders(<ResourceServerEditPage />);
+
+    expect(screen.getByText('Default resource server')).toBeInTheDocument();
+  });
+
   it('shows the name text field when the edit icon button is clicked', async () => {
     renderWithProviders(<ResourceServerEditPage />);
 


### PR DESCRIPTION
### Purpose

The console applied an "API and CUSTOM only" rule to the default resource server in two places and skipped it in a third, so an MCP-type resource server could be made the default from one screen while the other two refused it.

- List row ⋮ menu — action disabled with "Only API and custom resource servers can be the default."
- Creation wizard — the "make default" checkbox is hidden for MCP.
- Edit page — "Set as default" was gated only on isDefaultReady && !isDefault && !isDefaultLocked, with no type check at all.

Following the third path left the console contradicting itself: the MCP server showed the Default badge in the list while that same row's ⋮ menu still said only API and custom servers are eligible.

This PR removes the capability from the edit page so all three console paths agree.


https://github.com/user-attachments/assets/ba457d5f-e34a-434f-993e-6ab1685c663f



### Approach

Gate the edit page's action on isDefaultEligibleType(resourceServer.type) — the same helper in models/resource-server.ts that ResourceServersList.tsx and CreateResourceServerPage.tsx already use. Reusing the one helper is the point: the rule now has a single definition, so the three paths cannot drift apart again.

The edit page hides the button rather than showing it disabled with a reason. That matches the creation wizard, which hides the checkbox. The list menu is the deliberate exception — it keeps a disabled entry with an explanatory tooltip so its actions column keeps a stable shape.

Two decisions worth calling out explicitly, since both are choices rather than oversights:

The Default resource server badge is deliberately left ungated. DefaultResourceServerConfigHandler.Validate does not inspect .Type, so an MCP server can still be made the default through PUT /server-config/defaultResourceServer or a declarative defaultResourceServer.yaml. That state is reachable in production, and the console should report it rather than hide it — gating the badge too would make a real default invisible on its own page. A regression test locks this in.

No backend change. This PR makes the console self-consistent and stops the console from creating the bad state. It does not add type validation to the backend, so the API and declarative paths still accept an MCP server as the default. docs/.../configuration.mdx already describes resourceServerId without a type constraint, so the docs stay accurate and are unchanged. If we decide the restriction is a product rule rather than a console affordance, the enforcement point is DefaultResourceServerConfigHandler.Validate, which is the single choke point for both write paths — worth a follow-up rather than folding into this fix.

### Related Issues

- Fixes #4747

### Related PRs

- N/A

### Checklist

- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any) — N/A, the existing docs match the unchanged backend behaviour
  - [ ] Ran Vale and fixed all errors and warnings — N/A, no doc changes
- [x] Tests provided. (Add links if there are any)
  - [x] Unit Tests — ResourceServerEditPage.test.tsx: the action is not offered for an MCP server, and the badge still renders for an MCP server that is already the default
  - [ ] Integration Tests — N/A, no API surface changed
- [ ] Breaking changes. (Fill if applicable)
  - [ ] Breaking changes section filled.
  - [ ] breaking change label added.

Security checks
- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented ineligible resource servers from displaying the “Set as default” action.
  * Preserved the default badge for servers already configured as the default.

* **Tests**
  * Added coverage confirming correct default-server behavior for MCP resource servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->