### PR TITLE
Show organization unit details in application overview

### DIFF
--- a/frontend/apps/console/src/features/applications/components/edit-application/integration-guides/IntegrationGuides.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/integration-guides/IntegrationGuides.tsx
@@ -20,6 +20,7 @@ import {
 } from '@thunderid/components';
 import type {Application, OAuth2Config} from '@thunderid/configure-applications';
 import {GatePreview} from '@thunderid/configure-design';
+import {useGetOrganizationUnit} from '@thunderid/configure-organization-units';
 import {useConfig} from '@thunderid/contexts';
 import {DefaultTheme, type Theme, useGetTheme} from '@thunderid/design';
 import {useLogger} from '@thunderid/logger/react';
@@ -197,6 +198,7 @@ export default function IntegrationGuides({
     Boolean(application.isRecoveryFlowEnabled && application.recoveryFlowId),
   );
   const {data: signOutFlowDetails} = useGetFlowById(application.signOutFlowId);
+  const {data: organizationUnit} = useGetOrganizationUnit(application.ouId);
   const {mode, systemMode} = useColorScheme();
   const productName = config.brand.product_name;
   const [promptCopied, setPromptCopied] = useState(false);
@@ -406,6 +408,18 @@ export default function IntegrationGuides({
         <CopyableField label={t('applications:edit.general.labels.applicationId')} value={application.id} />
         {oauth2Config?.clientId && (
           <CopyableField label={t('applications:edit.general.labels.clientId')} value={oauth2Config.clientId} />
+        )}
+        {application.ouId && (
+          <CopyableField
+            label={t('applications:edit.overview.appDetails.organizationUnitId', 'Organization Unit ID')}
+            value={application.ouId}
+          />
+        )}
+        {organizationUnit?.handle && (
+          <CopyableField
+            label={t('applications:edit.overview.appDetails.organizationUnitHandle', 'Organization Unit Handle')}
+            value={organizationUnit.handle}
+          />
         )}
       </Box>
     </OverviewCard>

--- a/frontend/apps/console/src/features/applications/components/edit-application/integration-guides/__tests__/IntegrationGuides.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/integration-guides/__tests__/IntegrationGuides.test.tsx
@@ -52,6 +52,12 @@ vi.mock('@thunderid/configure-design', async (importOriginal) => ({
   GatePreview: () => <div data-testid="gate-preview" />,
 }));
 
+const mockUseGetOrganizationUnit = vi.fn(() => ({data: undefined}) as unknown);
+
+vi.mock('@thunderid/configure-organization-units', () => ({
+  useGetOrganizationUnit: (...args: unknown[]): unknown => mockUseGetOrganizationUnit(...(args as [])),
+}));
+
 const mockWriteText = vi.fn();
 const mockFetch = vi.fn();
 
@@ -87,6 +93,7 @@ describe('IntegrationGuides', () => {
 
   beforeEach(() => {
     vi.useFakeTimers({shouldAdvanceTime: true});
+    mockUseGetOrganizationUnit.mockReset().mockReturnValue({data: undefined});
     mockWriteText.mockReset().mockResolvedValue(undefined);
     mockGetDocumentationLink.mockImplementation((key: string) => documentationLinks[key]);
     mockFetch.mockReset().mockImplementation((url: string) =>
@@ -117,6 +124,31 @@ describe('IntegrationGuides', () => {
     expect(screen.getByText('Application details')).toBeInTheDocument();
     expect(screen.getByText('app-123')).toBeInTheDocument();
     expect(screen.queryByRole('link', {name: /Open on StackBlitz/i})).not.toBeInTheDocument();
+  });
+
+  it('shows the organization unit ID and handle in the application details card', () => {
+    mockUseGetOrganizationUnit.mockReturnValue({data: {id: 'ou-1', handle: 'engineering'}});
+
+    renderWithProviders(<IntegrationGuides application={{...reactApplication, ouId: 'ou-1'}} />);
+
+    expect(screen.getByText('Organization Unit ID')).toBeInTheDocument();
+    expect(screen.getByText('ou-1')).toBeInTheDocument();
+    expect(screen.getByText('Organization Unit Handle')).toBeInTheDocument();
+    expect(screen.getByText('engineering')).toBeInTheDocument();
+  });
+
+  it('hides the organization unit rows when the application has no ouId', () => {
+    renderWithProviders(<IntegrationGuides application={reactApplication} />);
+
+    expect(screen.queryByText('Organization Unit ID')).not.toBeInTheDocument();
+    expect(screen.queryByText('Organization Unit Handle')).not.toBeInTheDocument();
+  });
+
+  it('shows the organization unit ID alone when the handle has not resolved yet', () => {
+    renderWithProviders(<IntegrationGuides application={{...reactApplication, ouId: 'ou-1'}} />);
+
+    expect(screen.getByText('Organization Unit ID')).toBeInTheDocument();
+    expect(screen.queryByText('Organization Unit Handle')).not.toBeInTheDocument();
   });
 
   it('shows the OIDC endpoints and sign-in preview from the canonical type before the OAuth2 config resolves', () => {


### PR DESCRIPTION
### Purpose

The **Application details** card on the application edit page's Overview tab showed only the Application ID and Client ID. The equivalent **Agent details** card on the agent edit page's Overview tab additionally shows the Organization Unit ID and Organization Unit Handle.

This left users with no way to see which OU an application belongs to. The OU is chosen during application creation and `GET /applications/{id}` already returns `ouId`, but no application edit tab surfaced it anywhere.

This PR adds **Organization Unit ID** and **Organization Unit Handle** rows to the Application details card, bringing it to parity with the Agent details card.

### Approach

Frontend-only change, scoped to `IntegrationGuides.tsx` (the component rendering the Overview tab) and its tests.

**Rendering.** Two `CopyableField` rows were added to the details card, reusing the label wording and field treatment of `AgentOverview.tsx` so the two cards read identically.

**Resolving the handle.** The one place this could not mirror the agent implementation is where the handle comes from. The agent GET response carries `ouHandle` directly (the service populates it via `populateOUHandleForGet` when `?include=display` is set), but `ApplicationGetResponse` has no `ouHandle` field. Rather than extend the application API, the handle is resolved client-side with the existing `useGetOrganizationUnit(application.ouId)` hook from `@thunderid/configure-organization-units`. This follows the pattern already used in `AgentOverview`, which resolves its owner label client-side from `useGetUsers`, and keeps the change to a single file.

**Conditional rendering.** Both rows are conditional, where the agent card renders its OU ID unconditionally. `Agent.ouId` is a required `string`, but `Application.ouId` is optional, and the handle arrives asynchronously, so an application with no OU, or one whose OU lookup has not yet resolved, shows only the rows it has values for.


### Related Issues
- https://github.com/thunder-id/thunderid/issues/4841


<img width="1823" height="950" alt="image" src="https://github.com/user-attachments/assets/010dbf7e-ca1c-4531-a501-7b3c692c0e15" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application details now display the associated organization unit’s ID and handle when available.
  * If only the organization unit ID is available, the ID is shown without the handle.
  * Organization unit details are omitted when no organization unit is associated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->