### PR TITLE
Fix retry button label and message pluralization on import summary

### DIFF
--- a/frontend/packages/configure-import-export/src/pages/__tests__/ImportConfigurationSummaryPage.test.tsx
+++ b/frontend/packages/configure-import-export/src/pages/__tests__/ImportConfigurationSummaryPage.test.tsx
@@ -537,7 +537,7 @@ describe('ImportConfigurationSummaryPage', () => {
       render(<ImportConfigurationSummaryPage />);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', {name: /Retry Import Test/})).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Retry'})).toBeInTheDocument();
       });
     });
 
@@ -600,7 +600,7 @@ describe('ImportConfigurationSummaryPage', () => {
       render(<ImportConfigurationSummaryPage />);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', {name: /Retry Import Test/})).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Retry'})).toBeInTheDocument();
       });
     });
   });
@@ -1022,6 +1022,35 @@ describe('ImportConfigurationSummaryPage', () => {
 
       await waitFor(() => {
         expect(mockShowToast).toHaveBeenCalledWith('Import completed with 1 failed resource.', 'warning');
+      });
+    });
+
+    it('pluralizes the success toast when more than one resource is imported', async () => {
+      mockLocationState.configContent = noTemplateState.configContent;
+      mockLocationState.envData = noTemplateState.envData;
+      mockMutateAsync
+        .mockResolvedValueOnce({
+          results: [],
+          summary: {imported: 2, totalDocuments: 2, failed: 0, importedAt: new Date(0).toISOString()},
+        })
+        .mockResolvedValueOnce({
+          results: [],
+          summary: {imported: 2, totalDocuments: 2, failed: 0, importedAt: new Date(0).toISOString()},
+        });
+
+      render(<ImportConfigurationSummaryPage />);
+
+      await userEvent.click(screen.getByText('Test'));
+
+      const importButton = await waitFor(() => {
+        const button = getImportConfigurationButton();
+        expect(button).not.toBeDisabled();
+        return button;
+      });
+      await userEvent.click(importButton);
+
+      await waitFor(() => {
+        expect(mockShowToast).toHaveBeenCalledWith('Import completed successfully. 2 resources imported.', 'success');
       });
     });
 

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -3265,25 +3265,25 @@ const translations = {
     'summary.importTest.running': 'Running pre-flight dry-run...',
     'summary.importTest.runningShort': 'Running...',
     'summary.importTest.test': 'Test',
-    'summary.importTest.retry': 'Retry Import Test',
+    'summary.importTest.retry': 'Retry',
     'summary.importTest.passed': 'Import test passed. {{imported}} of {{totalDocuments}} resources validated.',
-    'summary.importTest.failedCount': 'Import test failed for {{count}} resource',
-    'summary.importTest.failedCount_plural': 'Import test failed for {{count}} resources',
+    'summary.importTest.failedCount_one': 'Import test failed for {{count}} resource',
+    'summary.importTest.failedCount_other': 'Import test failed for {{count}} resources',
     'summary.importTest.failedWithMessage': 'Import test failed: {{message}}',
     'summary.importTest.failures': 'Import Test failures',
-    'summary.import.tooltip.missingVariables':
+    'summary.import.tooltip.missingVariables_one':
       'Cannot import: {{count}} environment variable is missing. Edit the environment variables above to fix.',
-    'summary.import.tooltip.missingVariables_plural':
+    'summary.import.tooltip.missingVariables_other':
       'Cannot import: {{count}} environment variables are missing. Edit the environment variables above to fix.',
     'summary.import.tooltip.configUnavailable':
       'Cannot import: configuration content is unavailable. Re-upload the configuration file.',
     'summary.import.tooltip.runTestFirst': 'Cannot import: run pre-flight dry-run and ensure it passes.',
     'summary.import.action': 'Import Configuration',
     'summary.import.importing': 'Importing...',
-    'summary.import.completedWithFailures': 'Import completed with {{count}} failed resource.',
-    'summary.import.completedWithFailures_plural': 'Import completed with {{count}} failed resources.',
-    'summary.import.completedSuccessfully': 'Import completed successfully. {{count}} resource imported.',
-    'summary.import.completedSuccessfully_plural': 'Import completed successfully. {{count}} resources imported.',
+    'summary.import.completedWithFailures_one': 'Import completed with {{count}} failed resource.',
+    'summary.import.completedWithFailures_other': 'Import completed with {{count}} failed resources.',
+    'summary.import.completedSuccessfully_one': 'Import completed successfully. {{count}} resource imported.',
+    'summary.import.completedSuccessfully_other': 'Import completed successfully. {{count}} resources imported.',
     'summary.import.failedRetry': 'Import failed. Please try again.',
     'summary.importTest.itemFailedGeneric': 'This resource failed to import.',
 


### PR DESCRIPTION
### Purpose

Fixes two UI polish bugs on the Import Configuration summary page reported in #4768.

1. On a failed dry-run, the retry button's label was `Retry Import Test` while the initial button in the same narrow `Alert` action slot reads `Test`. Nothing accommodated the longer text, so the label wrapped onto three lines and the button ballooned vertically.
2. Counted messages never pluralized (`N resource imported` for any `N`). The keys used the legacy i18next v3 `_plural` suffix, which i18next 25 (JSON v4 plural resolution) does not resolve, so lookups silently fell back to the singular base key.

### Approach

1. Shortened `summary.importTest.retry` to `Retry`, matching the `Test` label that occupies the same slot, so the button stays on one line without extra styling.
2. Renamed the four dead `_plural` keys to the `_one`/`_other` pairs i18next 25 resolves, matching the convention already used elsewhere in the locale file (e.g. `welcome.wayfinderFolderImport.status.resourcesImported_one`/`_other`):
   - `summary.import.completedSuccessfully`
   - `summary.import.completedWithFailures`
   - `summary.importTest.failedCount`
   - `summary.import.tooltip.missingVariables`

#### Why the keys had to be renamed, and why nothing that references them breaks

i18next 25 resolves plurals through `Intl.PluralRules` categories, which for English are `key_one` and `key_other`. The `_plural` suffix is the i18next v3 format and is never looked up in v4+, so each `_plural` entry was unreachable text and every call fell through to the singular base key. That is the bug in the issue.

Call sites never spell out the suffix. They call `t('summary.import.completedSuccessfully', {count: n})` and i18next appends the suffix at lookup time from `count`, so the key as written in code is unchanged and no consumer needs updating. The only way a rename like this could break a caller is a site that resolves one of these keys *without* `count`, which would now render the raw key. There are none: each of the four keys has exactly one reference, all four pass `count`, none is pulled in through `$t()` nesting in another string, there is no second locale file, and `TranslationResources` is a mapped type over the locale object rather than a hardcoded key list.

Strictly, only the `_plural` to `_other` half of each rename is required; i18next falls back to the base key when `_one` is absent. The base key was renamed to `_one` as well so each pair is explicit and consistent with the rest of the file instead of relying on fallback behaviour.

A fifth key from the issue, `quickTest.summary.method.social`, was left untouched. It has no references anywhere (dead since it was introduced in b65d8cae8), so renaming it would be churn rather than a fix. Its equally unused `quickTest.*` siblings mean that whole namespace deserves a separate cleanup.

Updated the two retry-button assertions in `ImportConfigurationSummaryPage.test.tsx` and added a success-toast test covering a multi-resource import. That test reproduces the bug against the old strings (`2 resource imported`) and passes with the fix (65/65 in the package).

### Related Issues
- Fixes #4768

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated import failure actions to display the shorter **“Retry”** label.
  - Improved import success messages with correct singular and plural wording when importing multiple resources.

- **Localization**
  - Updated English import-summary translations to use standardized singular and plural wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
