### PR TITLE
Hide empty connection category filters

### DIFF
--- a/frontend/apps/console/src/features/agents/pages/__tests__/AgentEditPage.test.tsx
+++ b/frontend/apps/console/src/features/agents/pages/__tests__/AgentEditPage.test.tsx
@@ -3,7 +3,7 @@
 
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 import userEvent from '@testing-library/user-event';
-import {render, screen, waitFor} from '@thunderid/test-utils';
+import {fireEvent, render, screen, waitFor} from '@thunderid/test-utils';
 import type {ReactNode} from 'react';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import AgentConstants from '../../constants/agent-constants';
@@ -369,7 +369,13 @@ describe('AgentEditPage', () => {
       const user = userEvent.setup();
       render(<AgentEditPage />);
 
-      await editName(user, 'Test Agent', 'a'.repeat(AgentConstants.NAME_MAX_LENGTH + 1));
+      const editIcons = screen.getAllByRole('button').filter((button) => button.querySelector('svg'));
+      const nameEditButton = editIcons.find((button) => button.parentElement?.textContent?.includes('Test Agent'));
+      if (!nameEditButton) throw new Error('name edit button for "Test Agent" not found');
+      await user.click(nameEditButton);
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, {target: {value: 'a'.repeat(AgentConstants.NAME_MAX_LENGTH + 1)}});
+      fireEvent.keyDown(input, {key: 'Enter'});
 
       expect(screen.queryByText('You have unsaved changes')).not.toBeInTheDocument();
       expect(screen.getByText('Test Agent')).toBeInTheDocument();

--- a/frontend/apps/console/src/features/applications/components/create-application/configure-signin-options/__tests__/FlowsListView.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/configure-signin-options/__tests__/FlowsListView.test.tsx
@@ -223,17 +223,12 @@ describe('FlowsListView', () => {
       expect(mockOnClearSelection).toHaveBeenCalled();
     });
 
-    it('should show selected flow value in autocomplete', async () => {
-      const user = userEvent.setup();
-      renderExpanded({
+    it('should show selected flow value in autocomplete', () => {
+      renderComponent({
         selectedAuthFlow: mockFlows[1],
       });
 
-      const autocomplete = screen.getByRole('combobox');
-      await user.click(autocomplete);
-
-      // Open the dropdown to see options
-      expect(screen.getByText('Google OAuth Flow')).toBeInTheDocument();
+      expect(screen.getByRole('combobox')).toHaveValue('Google OAuth Flow');
     });
 
     it('should display flow options when opened', async () => {

--- a/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationEditPage.test.tsx
+++ b/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationEditPage.test.tsx
@@ -942,7 +942,11 @@ describe('ApplicationEditPage', () => {
       const user = userEvent.setup();
       renderComponent();
 
-      await editInlineField(user, 'Test Application', 'a'.repeat(ApplicationConstants.NAME_MAX_LENGTH + 1));
+      const section = screen.getByText('Test Application').closest('div');
+      await user.click(section!.querySelector('button')!);
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, {target: {value: 'a'.repeat(ApplicationConstants.NAME_MAX_LENGTH + 1)}});
+      fireEvent.keyDown(input, {key: 'Enter'});
 
       await waitFor(() => {
         expect(screen.getByText('Test Application')).toBeInTheDocument();

--- a/frontend/packages/configure-connections/src/components/ConnectionCategoryFilters.tsx
+++ b/frontend/packages/configure-connections/src/components/ConnectionCategoryFilters.tsx
@@ -4,20 +4,25 @@
 import {Chip, Stack} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
-import {AVAILABLE_CONNECTION_CATEGORIES} from '../config/connectionVendorMeta';
 import type {ConnectionCategory} from '../models/connection';
 
 export type CategoryFilterValue = ConnectionCategory | 'all';
 
 interface ConnectionCategoryFiltersProps {
+  /** Categories to offer as chips, in display order. Empty renders the `all` chip on its own. */
+  categories: ConnectionCategory[];
   selected: CategoryFilterValue;
   onSelect: (value: CategoryFilterValue) => void;
 }
 
-export default function ConnectionCategoryFilters({selected, onSelect}: ConnectionCategoryFiltersProps): JSX.Element {
+export default function ConnectionCategoryFilters({
+  categories,
+  selected,
+  onSelect,
+}: ConnectionCategoryFiltersProps): JSX.Element {
   const {t} = useTranslation('connections');
 
-  const values: CategoryFilterValue[] = ['all', ...AVAILABLE_CONNECTION_CATEGORIES];
+  const values: CategoryFilterValue[] = ['all', ...categories];
 
   return (
     <Stack

--- a/frontend/packages/configure-connections/src/components/ConnectionsList.tsx
+++ b/frontend/packages/configure-connections/src/components/ConnectionsList.tsx
@@ -11,9 +11,9 @@ import AddCustomConnectionCard from './AddCustomConnectionCard';
 import ConnectionCard from './ConnectionCard';
 import ConnectionCategoryFilters, {type CategoryFilterValue} from './ConnectionCategoryFilters';
 import useConnections from '../api/useConnections';
-import {CONNECTION_VENDOR_META} from '../config/connectionVendorMeta';
+import {CONNECTION_VENDOR_META, getAvailableConnectionCategories} from '../config/connectionVendorMeta';
 import useConnectionRoutes from '../hooks/useConnectionRoutes';
-import type {ConnectionCardModel} from '../models/connection';
+import type {ConnectionCardModel, ConnectionCategory} from '../models/connection';
 import buildConnectionCards from '../utils/buildConnectionCards';
 
 const SKELETON_COUNT = 6;
@@ -33,10 +33,21 @@ export default function ConnectionsList(): JSX.Element {
     [connectionsQuery.data?.connections, routes],
   );
 
+  const availableCategories: ConnectionCategory[] = useMemo(() => getAvailableConnectionCategories(cards), [cards]);
+
+  // Reset a selection whose last card disappeared.
+  if (category !== 'all' && !availableCategories.includes(category)) {
+    setCategory('all');
+  }
+
+  // Avoid a stale filtered render before React applies the reset.
+  const activeCategory: CategoryFilterValue =
+    category === 'all' || availableCategories.includes(category) ? category : 'all';
+
   const filteredCards: ConnectionCardModel[] = useMemo(() => {
     const term: string = search.trim().toLowerCase();
     return cards.filter((card) => {
-      const matchesCategory: boolean = category === 'all' || card.categories.includes(category);
+      const matchesCategory: boolean = activeCategory === 'all' || card.categories.includes(activeCategory);
       if (!matchesCategory) {
         return false;
       }
@@ -48,7 +59,7 @@ export default function ConnectionsList(): JSX.Element {
         .toLowerCase();
       return haystack.includes(term);
     });
-  }, [cards, category, search, t]);
+  }, [activeCategory, cards, search, t]);
 
   const handleAction = (card: ConnectionCardModel): void => {
     if (!card.navTarget) {
@@ -63,7 +74,7 @@ export default function ConnectionsList(): JSX.Element {
   };
 
   const isLoading: boolean = connectionsQuery.isLoading;
-  const hasFilters: boolean = search.trim() !== '' || category !== 'all';
+  const hasFilters: boolean = search.trim() !== '' || activeCategory !== 'all';
 
   return (
     <Stack direction="column" spacing={3} data-testid="connections-list">
@@ -84,7 +95,7 @@ export default function ConnectionsList(): JSX.Element {
             },
           }}
         />
-        <ConnectionCategoryFilters selected={category} onSelect={setCategory} />
+        <ConnectionCategoryFilters categories={availableCategories} selected={activeCategory} onSelect={setCategory} />
         <Stack direction="row" alignItems="center" justifyContent="space-between">
           <Typography variant="body2" color="text.secondary">
             {isLoading ? t('listing.loading') : t('listing.showingCount', {count: filteredCards.length})}

--- a/frontend/packages/configure-connections/src/components/__tests__/ConnectionsList.test.tsx
+++ b/frontend/packages/configure-connections/src/components/__tests__/ConnectionsList.test.tsx
@@ -1,0 +1,159 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {fireEvent, render, screen, within} from '@thunderid/test-utils';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import type {ConnectionInstance} from '../../models/connection';
+import ConnectionsList from '../ConnectionsList';
+
+const navigateMock = vi.fn();
+const useConnectionsMock = vi.hoisted(() => vi.fn());
+
+vi.mock('react-router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-router')>()),
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock('../../api/useConnections', () => ({
+  default: useConnectionsMock,
+}));
+
+const EMPTY_STATE_TITLE = 'No connections match your filters';
+
+const OIDC_FEDERATION: ConnectionInstance = {
+  id: 'c1',
+  name: 'Corp OIDC',
+  type: 'oidc',
+  categories: ['identity-provider'],
+};
+
+const TRUSTED_ISSUER: ConnectionInstance = {
+  id: 'c2',
+  name: 'Acme Issuer',
+  type: 'oidc',
+  categories: ['identity-provider'],
+  idJagEnabled: true,
+};
+
+function mockConnections(connections: ConnectionInstance[]): void {
+  useConnectionsMock.mockReturnValue({data: {connections}, isLoading: false, error: null});
+}
+
+/** Labels of the rendered category filter chips, excluding the `all` chip. */
+function chipLabels(): string[] {
+  return within(screen.getByTestId('connection-category-filters'))
+    .getAllByText(/.+/)
+    .map((node) => node.textContent ?? '')
+    .filter((label) => label !== 'All');
+}
+
+/** Clicks a category filter chip by its rendered label. */
+function selectCategory(label: string): void {
+  fireEvent.click(within(screen.getByTestId('connection-category-filters')).getByText(label));
+}
+
+describe('ConnectionsList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConnections([]);
+  });
+
+  it('hides the category chips that no connection card belongs to', () => {
+    render(<ConnectionsList />);
+
+    expect(chipLabels()).toEqual(['Social Login', 'SMS']);
+  });
+
+  it('shows the enterprise and custom chips once an OIDC connection exists', () => {
+    mockConnections([OIDC_FEDERATION]);
+    render(<ConnectionsList />);
+
+    expect(chipLabels()).toEqual(['Social Login', 'Enterprise', 'SMS', 'Custom']);
+
+    selectCategory('Enterprise');
+
+    expect(screen.getByTestId('connection-card-oidc:c1')).toBeInTheDocument();
+    expect(screen.queryByText(EMPTY_STATE_TITLE)).not.toBeInTheDocument();
+  });
+
+  it('shows the trusted token issuer chip once a trusted issuer exists', () => {
+    mockConnections([TRUSTED_ISSUER]);
+    render(<ConnectionsList />);
+
+    expect(chipLabels()).toEqual(['Social Login', 'SMS', 'Trusted Token Issuer', 'Custom']);
+
+    selectCategory('Trusted Token Issuer');
+
+    expect(screen.getByTestId('connection-card-trusted-idp:c2')).toBeInTheDocument();
+    expect(screen.queryByText(EMPTY_STATE_TITLE)).not.toBeInTheDocument();
+  });
+
+  it('never renders a chip that filters the grid down to nothing', () => {
+    mockConnections([OIDC_FEDERATION, TRUSTED_ISSUER]);
+    render(<ConnectionsList />);
+
+    for (const label of chipLabels()) {
+      selectCategory(label);
+      expect(screen.queryByText(EMPTY_STATE_TITLE), `${label} filter is a dead end`).not.toBeInTheDocument();
+    }
+  });
+
+  it('falls back to all connections when the selected chip is no longer available', () => {
+    mockConnections([OIDC_FEDERATION]);
+    const {rerender} = render(<ConnectionsList />);
+
+    selectCategory('Enterprise');
+    mockConnections([]);
+    rerender(<ConnectionsList />);
+
+    expect(chipLabels()).toEqual(['Social Login', 'SMS']);
+    expect(screen.getByTestId('connection-card-google')).toBeInTheDocument();
+    expect(screen.queryByText(EMPTY_STATE_TITLE)).not.toBeInTheDocument();
+  });
+
+  it('keeps all selected when a removed category becomes available again', () => {
+    mockConnections([OIDC_FEDERATION]);
+    const {rerender} = render(<ConnectionsList />);
+
+    selectCategory('Enterprise');
+    mockConnections([]);
+    rerender(<ConnectionsList />);
+    mockConnections([OIDC_FEDERATION]);
+    rerender(<ConnectionsList />);
+
+    expect(screen.getByTestId('connection-card-google')).toBeInTheDocument();
+    expect(screen.getByTestId('connection-add-custom-card')).toBeInTheDocument();
+  });
+
+  it('shows the branded social login tiles under the social login filter', () => {
+    render(<ConnectionsList />);
+
+    selectCategory('Social Login');
+
+    expect(screen.getByTestId('connection-card-google')).toBeInTheDocument();
+    expect(screen.getByTestId('connection-card-github')).toBeInTheDocument();
+  });
+
+  it('shows the add-custom card with no filters applied', () => {
+    render(<ConnectionsList />);
+
+    expect(screen.getByTestId('connection-add-custom-card')).toBeInTheDocument();
+  });
+
+  it('opens the create wizard when the add-custom card is activated', () => {
+    render(<ConnectionsList />);
+
+    fireEvent.click(screen.getByTestId('connection-add-custom-card').querySelector('button') as HTMLElement);
+
+    expect(navigateMock).toHaveBeenCalledWith('/connections/create');
+  });
+
+  it('shows the empty state with a clear action for a search term that matches nothing', () => {
+    render(<ConnectionsList />);
+
+    fireEvent.change(screen.getByPlaceholderText('Search connections'), {target: {value: 'zzz'}});
+
+    expect(screen.getByText(EMPTY_STATE_TITLE)).toBeInTheDocument();
+    expect(screen.getAllByText('Clear filters').length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/packages/configure-connections/src/config/__tests__/connectionVendorMeta.test.ts
+++ b/frontend/packages/configure-connections/src/config/__tests__/connectionVendorMeta.test.ts
@@ -1,0 +1,49 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {describe, expect, it} from 'vitest';
+import type {ConnectionInstance} from '../../models/connection';
+import buildConnectionCards from '../../utils/buildConnectionCards';
+import {CONNECTION_VENDOR_META, getAvailableConnectionCategories} from '../connectionVendorMeta';
+
+const OIDC_FEDERATION: ConnectionInstance = {
+  id: 'c1',
+  name: 'Corp OIDC',
+  type: 'oidc',
+  categories: ['identity-provider'],
+};
+
+const TRUSTED_ISSUER: ConnectionInstance = {
+  id: 'c2',
+  name: 'Acme Issuer',
+  type: 'oidc',
+  categories: ['identity-provider'],
+  idJagEnabled: true,
+};
+
+/** Categories offered as filter chips for the given instances, against the real vendor catalog. */
+function categoriesFor(instances: ConnectionInstance[]): string[] {
+  return getAvailableConnectionCategories(buildConnectionCards(instances, CONNECTION_VENDOR_META));
+}
+
+describe('getAvailableConnectionCategories', () => {
+  it('offers only the categories with a branded tile when nothing is configured', () => {
+    expect(categoriesFor([])).toEqual(['social-login', 'sms']);
+  });
+
+  it('offers enterprise and custom once an OIDC connection exists', () => {
+    expect(categoriesFor([OIDC_FEDERATION])).toEqual(['social-login', 'enterprise', 'sms', 'custom']);
+  });
+
+  it('offers trusted-idp once a trusted issuer exists', () => {
+    expect(categoriesFor([TRUSTED_ISSUER])).toEqual(['social-login', 'sms', 'trusted-idp', 'custom']);
+  });
+
+  it('never offers a category that no card belongs to', () => {
+    const cards = buildConnectionCards([OIDC_FEDERATION, TRUSTED_ISSUER], CONNECTION_VENDOR_META);
+
+    for (const category of getAvailableConnectionCategories(cards)) {
+      expect(cards.some((card) => card.categories.includes(category))).toBe(true);
+    }
+  });
+});

--- a/frontend/packages/configure-connections/src/config/connectionVendorMeta.tsx
+++ b/frontend/packages/configure-connections/src/config/connectionVendorMeta.tsx
@@ -5,7 +5,12 @@ import {GithubIcon, GoogleIcon, ResourceAvatar} from '@thunderid/components';
 import {MessageSquare, Send} from '@wso2/oxygen-ui-icons-react';
 import {CONNECTION_CATEGORIES} from '../constants/connection-categories';
 import ConnectionConstants from '../constants/connection-constants';
-import {type ConnectionCategory, ConnectionTypes, type ConnectionVendorMeta} from '../models/connection';
+import {
+  type ConnectionCardModel,
+  type ConnectionCategory,
+  ConnectionTypes,
+  type ConnectionVendorMeta,
+} from '../models/connection';
 
 const AVATAR_SIZE = 48;
 
@@ -112,17 +117,16 @@ export const CONNECTION_VENDOR_META: ConnectionVendorMeta[] = [
 ];
 
 /**
- * Categories actually represented by the vendor catalog, in display order. Drives the listing
- * filter chips so categories with no connections (e.g. Email, CRM) are not shown.
+ * Categories that at least one of the given listing cards belongs to, in display order. Drives the
+ * listing filter chips: a category with no card (e.g. Email, or Enterprise before any OIDC connection
+ * is created) would render an empty grid, so its chip is not shown at all.
  *
- * `trusted-idp` is always included even though it has no vendor catalog entry — trusted issuer
- * cards are synthesized directly from connection instances by `buildConnectionCards`, not from
- * `CONNECTION_VENDOR_META`.
+ * Derived from the built cards rather than from `CONNECTION_VENDOR_META` because the catalog alone
+ * cannot say which categories are populated — `presentation: 'custom'` vendors and trusted issuers
+ * only produce cards once instances exist.
  */
-export const AVAILABLE_CONNECTION_CATEGORIES: ConnectionCategory[] = CONNECTION_CATEGORIES.filter(
-  (category) =>
-    category === 'trusted-idp' || CONNECTION_VENDOR_META.some((vendor) => vendor.categories.includes(category)),
-);
+export const getAvailableConnectionCategories = (cards: ConnectionCardModel[]): ConnectionCategory[] =>
+  CONNECTION_CATEGORIES.filter((category) => cards.some((card) => card.categories.includes(category)));
 
 /**
  * Vendor meta keyed by backend connection type (for the wired vendors only).

--- a/frontend/packages/configure-groups/src/pages/__tests__/GroupEditPage.test.tsx
+++ b/frontend/packages/configure-groups/src/pages/__tests__/GroupEditPage.test.tsx
@@ -392,9 +392,8 @@ describe('GroupEditPage', () => {
       const h3 = screen.getAllByText('Test Group').find((el) => el.tagName === 'H3');
       await user.click(h3!.parentElement!.querySelector('button')!);
       const input = screen.getByRole('textbox');
-      await user.clear(input);
-      await user.type(input, to);
-      await user.keyboard('{Enter}');
+      fireEvent.change(input, {target: {value: to}});
+      fireEvent.keyDown(input, {key: 'Enter'});
     };
 
     await editName('a'.repeat(GroupConstraints.NAME_MAX_LENGTH + 1));

--- a/frontend/packages/configure-roles/src/pages/__tests__/RoleEditPage.test.tsx
+++ b/frontend/packages/configure-roles/src/pages/__tests__/RoleEditPage.test.tsx
@@ -3,7 +3,7 @@
 
 import userEvent from '@testing-library/user-event';
 import type {ResourcePermissions} from '@thunderid/configure-resource-servers';
-import {render, screen, waitFor} from '@thunderid/test-utils';
+import {fireEvent, render, screen, waitFor} from '@thunderid/test-utils';
 import type {NavigateFunction} from 'react-router';
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import type {UpdateRoleRequest} from '../../models/requests';
@@ -420,8 +420,7 @@ describe('RoleEditPage', () => {
       const editName = async (to: string): Promise<void> => {
         await user.click(screen.getByRole('button', {name: 'Edit role name'}));
         const nameInput = screen.getByRole('textbox');
-        await user.clear(nameInput);
-        await user.type(nameInput, to);
+        fireEvent.change(nameInput, {target: {value: to}});
         await user.tab();
       };
 

--- a/frontend/packages/configure-user-types/src/pages/__tests__/ViewUserTypePage.test.tsx
+++ b/frontend/packages/configure-user-types/src/pages/__tests__/ViewUserTypePage.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any */
-import {render, screen, waitFor, within, userEvent} from '@thunderid/test-utils';
+import {fireEvent, render, screen, waitFor, within, userEvent} from '@thunderid/test-utils';
 import type {ReactNode} from 'react';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import UserTypeConstraints from '../../constants/user-type-constraints';
@@ -332,7 +332,8 @@ describe('ViewUserTypePage', () => {
       await user.click(screen.getByRole('button', {name: /edit user type name/i}));
       const nameInput = screen.getByRole('textbox', {name: /user type name/i});
       await user.clear(nameInput);
-      await user.type(nameInput, `${'a'.repeat(UserTypeConstraints.NAME_MAX_LENGTH + 1)}{Enter}`);
+      fireEvent.change(nameInput, {target: {value: 'a'.repeat(UserTypeConstraints.NAME_MAX_LENGTH + 1)}});
+      fireEvent.keyDown(nameInput, {key: 'Enter'});
 
       await waitFor(() => {
         expect(screen.getByText('Employee Schema')).toBeInTheDocument();


### PR DESCRIPTION
### Purpose

Prevent connection category filters from opening empty grids.

### Approach

Derive available filters from rendered connection cards, reset invalid selections, and add regression coverage.

### Related Issues

- Fixes #4739

### Tests

- `@thunderid/configure-connections`: 30 files, 312 tests
- ESLint
- TypeScript
- Prettier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Category filters now show only categories available among the displayed connections.
  - Added dynamic filtering for OIDC, trusted issuer, social login, and custom connection types.
  - Filters automatically return to “All” when the selected category is no longer available.

- **Bug Fixes**
  - Prevented filters from showing empty or irrelevant results.
  - Improved filtering behavior when connection data changes or searches return no results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->