### PR TITLE
Hide the recovery flow section from the agent edit page

### DIFF
--- a/frontend/apps/console/src/features/agents/components/edit-agent/flows/EditFlowsSettings.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/flows/EditFlowsSettings.tsx
@@ -8,7 +8,6 @@ import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import SettingsLockNotice from '../../../../applications/components/common/SettingsLockNotice';
 import AuthenticationFlowSection from '../../../../applications/components/edit-application/flows-settings/AuthenticationFlowSection';
-import RecoveryFlowSection from '../../../../applications/components/edit-application/flows-settings/RecoveryFlowSection';
 import RegistrationFlowSection from '../../../../applications/components/edit-application/flows-settings/RegistrationFlowSection';
 import type {Agent, OAuthAgentConfig} from '../../../models/agent';
 
@@ -28,8 +27,8 @@ export default function EditFlowsSettings({
   const {t} = useTranslation();
   const isUnlocked = oauth2Config?.grantTypes?.includes(OAuth2GrantTypes.AUTHORIZATION_CODE) ?? false;
 
-  // Agents share the inbound-client shape with applications (auth_flow_id, registration/recovery
-  // flow config), so the same components are reused with an entity-label override. Forcing
+  // Agents share the inbound-client shape with applications (auth_flow_id, registration flow
+  // config), so the same components are reused with an entity-label override. Forcing
   // isReadOnly disables every input via their existing disabled={application.isReadOnly} wiring
   // when Delegated mode isn't on, without needing new props on the shared components.
   const appLikeAgent = {...agent, isReadOnly: (agent.isReadOnly ?? false) || !isUnlocked} as unknown as Application;
@@ -53,12 +52,6 @@ export default function EditFlowsSettings({
             entityLabel="agent"
           />
           <RegistrationFlowSection
-            application={appLikeAgent}
-            editedApp={appLikeEditedAgent}
-            onFieldChange={appHandleFieldChange}
-            entityLabel="agent"
-          />
-          <RecoveryFlowSection
             application={appLikeAgent}
             editedApp={appLikeEditedAgent}
             onFieldChange={appHandleFieldChange}

--- a/frontend/apps/console/src/features/agents/components/edit-agent/flows/__tests__/EditFlowsSettings.test.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/flows/__tests__/EditFlowsSettings.test.tsx
@@ -17,6 +17,7 @@ vi.mock('../../../../../applications/components/edit-application/flows-settings/
     <div data-testid="registration-flow" data-readonly={String(application.isReadOnly)} />
   ),
 }));
+// Mocked so the absence assertions below fail if the section is ever wired back in.
 vi.mock('../../../../../applications/components/edit-application/flows-settings/RecoveryFlowSection', () => ({
   default: ({application}: {application: Application}) => (
     <div data-testid="recovery-flow" data-readonly={String(application.isReadOnly)} />
@@ -27,7 +28,7 @@ describe('EditFlowsSettings', () => {
   const mockOnFieldChange = vi.fn();
   const baseAgent: Agent = {id: 'agent-1', ouId: 'ou-1', type: 'default', name: 'Test Agent'};
 
-  it('renders all three flow sections', () => {
+  it('renders the authentication and registration flow sections', () => {
     render(
       <EditFlowsSettings
         agent={baseAgent}
@@ -39,7 +40,32 @@ describe('EditFlowsSettings', () => {
 
     expect(screen.getByTestId('auth-flow')).toBeInTheDocument();
     expect(screen.getByTestId('registration-flow')).toBeInTheDocument();
-    expect(screen.getByTestId('recovery-flow')).toBeInTheDocument();
+  });
+
+  it('never renders the recovery flow section, since the agent API does not persist it', () => {
+    render(
+      <EditFlowsSettings
+        agent={baseAgent}
+        editedAgent={{}}
+        oauth2Config={{grantTypes: ['authorization_code'], responseTypes: ['code']}}
+        onFieldChange={mockOnFieldChange}
+      />,
+    );
+
+    expect(screen.queryByTestId('recovery-flow')).not.toBeInTheDocument();
+  });
+
+  it('keeps the recovery flow section hidden when Delegated mode is off', () => {
+    render(
+      <EditFlowsSettings
+        agent={baseAgent}
+        editedAgent={{}}
+        oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
+        onFieldChange={mockOnFieldChange}
+      />,
+    );
+
+    expect(screen.queryByTestId('recovery-flow')).not.toBeInTheDocument();
   });
 
   it('keeps flows editable and hides the lock notice when Delegated mode is on', () => {
@@ -68,7 +94,6 @@ describe('EditFlowsSettings', () => {
 
     expect(screen.getByTestId('auth-flow')).toHaveAttribute('data-readonly', 'true');
     expect(screen.getByTestId('registration-flow')).toHaveAttribute('data-readonly', 'true');
-    expect(screen.getByTestId('recovery-flow')).toHaveAttribute('data-readonly', 'true');
     expect(screen.getByText(/These settings are frozen for this agent/)).toBeInTheDocument();
   });
 

--- a/frontend/apps/console/src/features/agents/models/agent.ts
+++ b/frontend/apps/console/src/features/agents/models/agent.ts
@@ -37,8 +37,6 @@ export interface Agent {
   authFlowId?: string;
   registrationFlowId?: string;
   isRegistrationFlowEnabled?: boolean;
-  recoveryFlowId?: string;
-  isRecoveryFlowEnabled?: boolean;
   assertion?: AssertionConfig;
   loginConsent?: AgentLoginConsentConfig;
   isReadOnly?: boolean;
@@ -87,8 +85,6 @@ export interface UpdateAgentRequest {
   authFlowId?: string;
   registrationFlowId?: string;
   isRegistrationFlowEnabled?: boolean;
-  recoveryFlowId?: string;
-  isRecoveryFlowEnabled?: boolean;
 }
 
 export interface AgentGroup {


### PR DESCRIPTION
### Purpose

Removes the Recovery Flow section from the agent edit page's Flows tab, because the agent API
does not support it.

The console renders a recovery enable toggle and flow selector for agents, but
`recoveryFlowId` / `isRecoveryFlowEnabled` are silently discarded by the backend. The request is
accepted (the agent request models embed the shared `providers.InboundAuthProfile` and JSON
decoding is lenient), so the save returns success with no error, yet nothing is persisted and the
toggle reverts to disabled on reload.

### Approach

Hide the control rather than build the backend plumbing. The alternative, wiring recovery through
`buildInboundClientRecord` and its two call sites, `composeGetResponse`,
`updateNeedsInboundClient`, the API spec and flow ID validation, is a feature addition rather than
a bug fix, and it should be driven by a decision on whether agents are meant to have recovery
flows at all. Until then, showing a control that silently does nothing is worse than not showing
it.

Changes:

- **`EditFlowsSettings.tsx`**: dropped the `RecoveryFlowSection` import and its JSX. The Flows tab
  now renders authentication and registration only.
- **`agent.ts`**: removed `recoveryFlowId` and `isRecoveryFlowEnabled` from the `Agent` and
  `UpdateAgentRequest` interfaces. Nothing else set or read them, and keeping them would continue
  to advertise fields the API discards.
- **`EditFlowsSettings.test.tsx`**: the `RecoveryFlowSection` mock is kept on purpose. It is what
  makes the new absence assertions meaningful: if the section is imported again, the mock renders
  and `queryByTestId('recovery-flow')` starts matching, so the guard fails instead of passing
  vacuously. Two tests cover the hidden state with Delegated mode both on and off, and the
  existing three-section assertions were narrowed to two.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4848

<img width="1522" height="897" alt="image" src="https://github.com/user-attachments/assets/32787c2f-4d2c-457c-8a19-6f66828ab6ad" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Removed recovery-flow configuration from agent settings.
  - Recovery-flow options are no longer displayed or saved when editing an agent.
  - Authentication and registration flow settings remain available.
  - Updated behavior checks to confirm recovery-flow settings are absent in all supported modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->