### PR TITLE
Fix Magic Link widget connection

### DIFF
--- a/frontend/apps/console/src/features/flows/data/templates.json
+++ b/frontend/apps/console/src/features/flows/data/templates.json
@@ -15898,22 +15898,9 @@
               "y": 450
             },
             "data": {
-              "prompts": [
-                {
-                  "inputs": [
-                    {
-                      "ref": "magic_link_token_input",
-                      "identifier": "magicLinkToken",
-                      "type": "HIDDEN",
-                      "required": true
-                    }
-                  ],
-                  "action": {
-                    "ref": "magic_link_action",
-                    "nextNode": "{{VERIFY_LINK_ID}}"
-                  }
-                }
-              ],
+              "action": {
+                "onSuccess": "{{VERIFY_LINK_ID}}"
+              },
               "components": [
                 {
                   "alt": "{{ t(signin:images.app_logo.alt) }}",

--- a/frontend/apps/console/src/features/flows/data/widgets.json
+++ b/frontend/apps/console/src/features/flows/data/widgets.json
@@ -1882,22 +1882,9 @@
               "y": 600
             },
             "data": {
-              "prompts": [
-                {
-                  "inputs": [
-                    {
-                      "ref": "magic_link_token_input",
-                      "identifier": "magicLinkToken",
-                      "type": "HIDDEN",
-                      "required": true
-                    }
-                  ],
-                  "action": {
-                    "ref": "magic_link_action",
-                    "nextNode": "{{MAGIC_VERIFY_EXECUTOR}}"
-                  }
-                }
-              ],
+              "action": {
+                "onSuccess": "{{MAGIC_VERIFY_EXECUTOR}}"
+              },
               "components": [
                 {
                   "alt": "{{ t(signin:images.app_logo.alt) }}",

--- a/frontend/packages/configure-user-types/src/pages/__tests__/CreateUserTypePage.test.tsx
+++ b/frontend/packages/configure-user-types/src/pages/__tests__/CreateUserTypePage.test.tsx
@@ -1,7 +1,7 @@
 // Copyright 2025 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import {render, screen, waitFor, userEvent, within} from '@thunderid/test-utils';
+import {fireEvent, render, screen, waitFor, userEvent, within} from '@thunderid/test-utils';
 import type {ReactNode} from 'react';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import type useCreateUserTypeHook from '../../api/useCreateUserType';
@@ -354,7 +354,9 @@ describe('CreateUserTypePage', () => {
     renderPage();
 
     await pickOrganizationUnit(user);
-    await user.type(screen.getByLabelText(/User Type Name/i), 'a'.repeat(UserTypeConstraints.NAME_MAX_LENGTH + 1));
+    fireEvent.change(screen.getByLabelText(/User Type Name/i), {
+      target: {value: 'a'.repeat(UserTypeConstraints.NAME_MAX_LENGTH + 1)},
+    });
 
     expect(screen.getByText('User type name cannot exceed 100 characters')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: /Continue/i})).toBeDisabled();


### PR DESCRIPTION
### Purpose

Fix Magic Link widget insertion so the email-sent view connects to the verification executor and the saved flow contains `next`.

### Approach

Replace stale `data.prompts` metadata in both canvas fixtures with `data.action.onSuccess`, which existing widget and template loaders convert into an edge.

Removing the prompt block is safe because it was not runtime token wiring. `magic_link_token_input` remains declared and consumed by `MagicLinkExecutor`. The email-sent view contains display components only, canvas loaders ignore `data.prompts`, and its canonical saved form uses `next`.

### Related Issues

- Fixes #4789

### Checks

- Focused flow tests: 196 passed
- JSON parse and Prettier checks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Magic Link authentication flow transitions after an email is sent.
  - Users are now directed directly to link verification when the email-sent step succeeds.
  - Removed the outdated prompt and input interaction from the email-sent view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->