### PR TITLE
Fix user creation for user types with boolean and number attributes

### DIFF
--- a/backend/internal/flow/executor/attribute_collector.go
+++ b/backend/internal/flow/executor/attribute_collector.go
@@ -352,7 +352,9 @@ func (a *attributeCollector) getUpdatedUserObject(ctx *providers.NodeContext,
 	return true, updatedUser, nil
 }
 
-// getInputAttributes retrieves the input attributes from the context.
+// getInputAttributes retrieves the input attributes from the context. Values are converted from the
+// engine's string representation to the type implied by the input type, so that non-string
+// attributes satisfy schema validation when the collected profile is persisted.
 func (a *attributeCollector) getInputAttributes(ctx *providers.NodeContext) map[string]interface{} {
 	attributesMap := make(map[string]interface{})
 	requiredInputAttrs := a.getInputs(ctx)
@@ -363,11 +365,12 @@ func (a *attributeCollector) getInputAttributes(ctx *providers.NodeContext) map[
 			continue
 		}
 
+		schemaType := schemaTypeForInputType(inputAttr.Type)
 		value, exists := ctx.UserInputs[inputAttr.Identifier]
 		if exists {
-			attributesMap[inputAttr.Identifier] = value
+			attributesMap[inputAttr.Identifier] = convertToSchemaType(value, schemaType)
 		} else if runtimeValue, exists := ctx.RuntimeData[inputAttr.Identifier]; exists {
-			attributesMap[inputAttr.Identifier] = runtimeValue
+			attributesMap[inputAttr.Identifier] = convertToSchemaType(runtimeValue, schemaType)
 		}
 	}
 

--- a/backend/internal/flow/executor/attribute_collector_test.go
+++ b/backend/internal/flow/executor/attribute_collector_test.go
@@ -491,6 +491,29 @@ func (suite *AttributeCollectorTestSuite) TestGetInputAttributes_FromRuntimeData
 	assert.Equal(suite.T(), "runtime@example.com", result["email"])
 }
 
+// TestGetInputAttributes_ConvertsByInputType verifies that values collected for typed inputs are
+// converted from the engine's string representation, so a boolean or number attribute satisfies
+// schema validation when the collected profile is persisted.
+func (suite *AttributeCollectorTestSuite) TestGetInputAttributes_ConvertsByInputType() {
+	ctx := &providers.NodeContext{
+		UserInputs:  map[string]string{"active": "true", "age": "42", "email": "test@example.com"},
+		RuntimeData: map[string]string{"verified": "false"},
+		NodeInputs: []providers.Input{
+			{Identifier: "active", Type: providers.InputTypeBoolean, Required: true},
+			{Identifier: "verified", Type: providers.InputTypeBoolean, Required: true},
+			{Identifier: "age", Type: providers.InputTypeNumber, Required: true},
+			{Identifier: "email", Type: providers.InputTypeText, Required: true},
+		},
+	}
+
+	result := suite.executor.getInputAttributes(ctx)
+
+	assert.Equal(suite.T(), true, result["active"])
+	assert.Equal(suite.T(), false, result["verified"])
+	assert.Equal(suite.T(), float64(42), result["age"])
+	assert.Equal(suite.T(), "test@example.com", result["email"])
+}
+
 func (suite *AttributeCollectorTestSuite) TestGetInputAttributes_SkipUserID() {
 	ctx := &providers.NodeContext{
 		UserInputs:  map[string]string{"userID": testUserID, "email": "test@example.com"},

--- a/backend/internal/flow/executor/provisioning_executor.go
+++ b/backend/internal/flow/executor/provisioning_executor.go
@@ -474,14 +474,14 @@ func (p *provisioningExecutor) buildMissingInputs(
 			}
 			input := providers.Input{
 				Identifier:  attr.Attribute,
-				Type:        providers.InputTypeText,
+				Type:        inputTypeForSchemaType(attr.Type),
 				DisplayName: attr.DisplayName,
 			}
 			if inNodeInputs {
 				input = nodeInp
 				input.Identifier = attr.Attribute
 				if input.Type == "" {
-					input.Type = providers.InputTypeText
+					input.Type = inputTypeForSchemaType(attr.Type)
 				}
 				if input.DisplayName == "" {
 					input.DisplayName = attr.DisplayName
@@ -578,7 +578,8 @@ func (p *provisioningExecutor) isAttrSatisfied(ctx *providers.NodeContext, attr 
 // returning identifying (non-credential) and credential attributes as separate maps.
 // Schema is the whitelist for both maps.
 // Credential values are resolved from non-empty UserInputs then non-empty RuntimeData only.
-// Non-credential values additionally fall back to AuthenticatedUser.Attributes.
+// Non-credential values additionally fall back to AuthenticatedUser.Attributes, and are converted
+// from the engine's string representation to the type declared by the schema attribute.
 func (p *provisioningExecutor) getAttributesForProvisioning(
 	ctx *providers.NodeContext,
 ) (identifyingAttrs map[string]interface{}, credentialAttrs map[string]interface{}, err error) {
@@ -603,9 +604,9 @@ func (p *provisioningExecutor) getAttributesForProvisioning(
 			}
 		} else {
 			if value, exists := ctx.UserInputs[a.Attribute]; exists && value != "" {
-				identifyingAttrs[a.Attribute] = value
+				identifyingAttrs[a.Attribute] = convertToSchemaType(value, a.Type)
 			} else if runtimeValue, exists := ctx.RuntimeData[a.Attribute]; exists && runtimeValue != "" {
-				identifyingAttrs[a.Attribute] = runtimeValue
+				identifyingAttrs[a.Attribute] = convertToSchemaType(runtimeValue, a.Type)
 			}
 		}
 	}

--- a/backend/internal/flow/executor/provisioning_executor_test.go
+++ b/backend/internal/flow/executor/provisioning_executor_test.go
@@ -333,6 +333,91 @@ func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_AttributesFrom
 	assert.Empty(suite.T(), execResp.Inputs)
 }
 
+// TestHasRequiredInputs_PromptsBooleanAttributeAsCheckbox verifies that a missing boolean schema
+// attribute is prompted with a boolean input type rather than as free text, so the client can
+// render a control that produces a value the schema accepts.
+func (suite *ProvisioningExecutorTestSuite) TestHasRequiredInputs_PromptsBooleanAttributeAsCheckbox() {
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType,
+		model.AttributeFilter{AllowCredential: true, AllowNonCredential: true}).
+		Return([]model.AttributeInfo{
+			{Attribute: "username", Type: model.TypeString, Required: true},
+			{Attribute: "active", Type: model.TypeBoolean, Required: true},
+			{Attribute: "age", Type: model.TypeNumber, Required: true},
+		}, nil).Once()
+
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		FlowType:    providers.FlowTypeRegistration,
+		NodeInputs:  []providers.Input{},
+		UserInputs:  map[string]string{},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+	}
+
+	execResp := &providers.ExecutorResponse{RuntimeData: make(map[string]string)}
+
+	result := suite.executor.HasRequiredInputs(ctx, execResp)
+
+	assert.False(suite.T(), result)
+	promptedTypes := make(map[string]string, len(execResp.Inputs))
+	for _, input := range execResp.Inputs {
+		promptedTypes[input.Identifier] = input.Type
+	}
+	assert.Equal(suite.T(), providers.InputTypeText, promptedTypes["username"])
+	assert.Equal(suite.T(), providers.InputTypeBoolean, promptedTypes["active"])
+	assert.Equal(suite.T(), providers.InputTypeNumber, promptedTypes["age"])
+}
+
+// TestGetAttributesForProvisioning_ConvertsToSchemaTypes verifies that collected values, which the
+// engine carries as strings, reach the store as the types the schema declares.
+func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_ConvertsToSchemaTypes() {
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType,
+		model.AttributeFilter{AllowCredential: true, AllowNonCredential: true}).
+		Return([]model.AttributeInfo{
+			{Attribute: "username", Type: model.TypeString, Required: true},
+			{Attribute: "active", Type: model.TypeBoolean, Required: true},
+			{Attribute: "verified", Type: model.TypeBoolean, Required: true},
+			{Attribute: "age", Type: model.TypeNumber, Required: true},
+		}, nil).Once()
+
+	ctx := &providers.NodeContext{
+		UserInputs: map[string]string{
+			"username": "testuser",
+			"active":   "true",
+			"age":      "42",
+		},
+		RuntimeData: map[string]string{userTypeKey: testUserType, "verified": "false"},
+		NodeInputs:  []providers.Input{},
+	}
+
+	result, _, _ := suite.executor.getAttributesForProvisioning(ctx)
+
+	assert.Equal(suite.T(), "testuser", result["username"])
+	assert.Equal(suite.T(), true, result["active"])
+	assert.Equal(suite.T(), false, result["verified"])
+	assert.Equal(suite.T(), float64(42), result["age"])
+}
+
+// TestGetAttributesForProvisioning_UnparseableBooleanIsPassedThrough verifies that a value that
+// does not parse is left as-is, so schema validation reports it instead of a zero value being
+// silently substituted.
+func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_UnparseableBooleanIsPassedThrough() {
+	suite.mockEntityTypeService.On("GetAttributes", mock.Anything, mock.Anything, testUserType,
+		model.AttributeFilter{AllowCredential: true, AllowNonCredential: true}).
+		Return([]model.AttributeInfo{
+			{Attribute: "active", Type: model.TypeBoolean, Required: true},
+		}, nil).Once()
+
+	ctx := &providers.NodeContext{
+		UserInputs:  map[string]string{"active": "affirmative"},
+		RuntimeData: map[string]string{userTypeKey: testUserType},
+		NodeInputs:  []providers.Input{},
+	}
+
+	result, _, _ := suite.executor.getAttributesForProvisioning(ctx)
+
+	assert.Equal(suite.T(), "affirmative", result["active"])
+}
+
 // TestGetAttributesForProvisioning_SchemaEmpty_ReturnsEmpty verifies that when the schema
 // is unavailable (no userTypeKey → getUserType returns ""), an empty map is returned.
 func (suite *ProvisioningExecutorTestSuite) TestGetAttributesForProvisioning_SchemaEmpty_ReturnsEmpty() {

--- a/backend/internal/flow/executor/utils.go
+++ b/backend/internal/flow/executor/utils.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	authncm "github.com/thunder-id/thunderid/internal/authn/common"
+	entitytypemodel "github.com/thunder-id/thunderid/internal/entitytype/model"
 	"github.com/thunder-id/thunderid/internal/flow/common"
 	"github.com/thunder-id/thunderid/internal/revocation"
 	systemutils "github.com/thunder-id/thunderid/internal/system/utils"
@@ -105,6 +107,50 @@ func findInputByType(inputs []providers.Input, inputType string) (providers.Inpu
 		}
 	}
 	return providers.Input{}, false
+}
+
+// inputTypeForSchemaType maps an entity type schema attribute type to the flow input type used to
+// prompt for it. Types without a dedicated input type are prompted as text.
+func inputTypeForSchemaType(schemaType string) string {
+	switch schemaType {
+	case entitytypemodel.TypeBoolean:
+		return providers.InputTypeBoolean
+	case entitytypemodel.TypeNumber:
+		return providers.InputTypeNumber
+	default:
+		return providers.InputTypeText
+	}
+}
+
+// schemaTypeForInputType maps a flow input type back to the schema type its collected value should
+// be converted to, for callers whose inputs come from the flow definition rather than from a schema.
+// An empty result means the value needs no conversion.
+func schemaTypeForInputType(inputType string) string {
+	switch inputType {
+	case providers.InputTypeBoolean:
+		return entitytypemodel.TypeBoolean
+	case providers.InputTypeNumber:
+		return entitytypemodel.TypeNumber
+	default:
+		return ""
+	}
+}
+
+// convertToSchemaType converts a collected input value, which the engine always carries as a string,
+// to the type declared by its schema attribute. Values that fail to parse are returned unchanged so
+// that schema validation reports them instead of a zero value being silently substituted.
+func convertToSchemaType(value string, schemaType string) interface{} {
+	switch schemaType {
+	case entitytypemodel.TypeBoolean:
+		if parsed, err := strconv.ParseBool(value); err == nil {
+			return parsed
+		}
+	case entitytypemodel.TypeNumber:
+		if parsed, err := strconv.ParseFloat(value, 64); err == nil {
+			return parsed
+		}
+	}
+	return value
 }
 
 // isAuthenticationWithoutLocalUserAllowed returns the value of the AllowAuthenticationWithoutLocalUser

--- a/backend/internal/flow/executor/utils_test.go
+++ b/backend/internal/flow/executor/utils_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	authncm "github.com/thunder-id/thunderid/internal/authn/common"
+	entitytypemodel "github.com/thunder-id/thunderid/internal/entitytype/model"
 	"github.com/thunder-id/thunderid/internal/flow/common"
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
@@ -81,6 +82,70 @@ func (s *UtilsTestSuite) TestGetAuthnServiceName() {
 		s.Run(tt.name, func() {
 			result := getAuthnServiceName(tt.executorName)
 			s.Equal(tt.expectedName, result)
+		})
+	}
+}
+
+func (s *UtilsTestSuite) TestInputTypeForSchemaType() {
+	tests := []struct {
+		name         string
+		schemaType   string
+		expectedType string
+	}{
+		{"Boolean attribute is prompted as a checkbox", entitytypemodel.TypeBoolean, providers.InputTypeBoolean},
+		{"Number attribute is prompted as a number input", entitytypemodel.TypeNumber, providers.InputTypeNumber},
+		{"String attribute is prompted as text", entitytypemodel.TypeString, providers.InputTypeText},
+		{"Unknown type falls back to text", "geo", providers.InputTypeText},
+		{"Empty type falls back to text", "", providers.InputTypeText},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			s.Equal(tt.expectedType, inputTypeForSchemaType(tt.schemaType))
+		})
+	}
+}
+
+func (s *UtilsTestSuite) TestSchemaTypeForInputType() {
+	tests := []struct {
+		name         string
+		inputType    string
+		expectedType string
+	}{
+		{"Checkbox maps to boolean", providers.InputTypeBoolean, entitytypemodel.TypeBoolean},
+		{"Number input maps to number", providers.InputTypeNumber, entitytypemodel.TypeNumber},
+		{"Text input needs no conversion", providers.InputTypeText, ""},
+		{"Unset input type needs no conversion", "", ""},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			s.Equal(tt.expectedType, schemaTypeForInputType(tt.inputType))
+		})
+	}
+}
+
+func (s *UtilsTestSuite) TestConvertToSchemaType() {
+	tests := []struct {
+		name          string
+		value         string
+		schemaType    string
+		expectedValue interface{}
+	}{
+		{"Checked box becomes true", "true", entitytypemodel.TypeBoolean, true},
+		{"Unchecked box becomes false", "false", entitytypemodel.TypeBoolean, false},
+		{"Boolean accepts alternate spellings", "TRUE", entitytypemodel.TypeBoolean, true},
+		{"Unparseable boolean is left for schema validation to reject", "yes", entitytypemodel.TypeBoolean, "yes"},
+		{"Number becomes a float", "42", entitytypemodel.TypeNumber, float64(42)},
+		{"Fractional number becomes a float", "1.5", entitytypemodel.TypeNumber, 1.5},
+		{"Unparseable number is left for schema validation to reject", "many", entitytypemodel.TypeNumber, "many"},
+		{"String attribute is untouched", "true", entitytypemodel.TypeString, "true"},
+		{"Unknown schema type is untouched", "true", "", "true"},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			s.Equal(tt.expectedValue, convertToSchemaType(tt.value, tt.schemaType))
 		})
 	}
 }

--- a/backend/pkg/thunderidengine/providers/constants.go
+++ b/backend/pkg/thunderidengine/providers/constants.go
@@ -398,6 +398,8 @@ const (
 	InputTypeNumber = "NUMBER_INPUT"
 	// InputTypeDate represents a date input type.
 	InputTypeDate = "DATE_INPUT"
+	// InputTypeBoolean represents a boolean (checkbox) input type.
+	InputTypeBoolean = "BOOLEAN_INPUT"
 
 	// TODO: Add support for other sensitive input types:
 	// - Passkey credential fields (credentialId, clientDataJSON, authenticatorData, signature, userHandle)
@@ -419,6 +421,7 @@ var ValidInputTypes = map[string]bool{
 	InputTypeOUSelect: true,
 	InputTypeNumber:   true,
 	InputTypeDate:     true,
+	InputTypeBoolean:  true,
 }
 
 // ExecutorType defines the type of an executor in the flow execution.

--- a/frontend/packages/configure-users/src/pages/UserAddPage.tsx
+++ b/frontend/packages/configure-users/src/pages/UserAddPage.tsx
@@ -24,7 +24,9 @@ import {
   Alert,
   AlertTitle,
   TextField,
+  Checkbox,
   FormControl,
+  FormControlLabel,
   FormLabel,
   Select,
   MenuItem,
@@ -210,6 +212,8 @@ function InviteUserStepContent({
                 comp.type === 'PHONE_INPUT' ||
                 comp.type === 'PASSWORD_INPUT' ||
                 comp.type === 'SELECT' ||
+                comp.type === 'BOOLEAN_INPUT' ||
+                comp.type === 'NUMBER_INPUT' ||
                 comp.type === 'OU_SELECT') &&
               comp.ref
             ) {
@@ -224,6 +228,11 @@ function InviteUserStepContent({
               }
 
               const labelText = typeof comp.label === 'string' ? comp.label : comp.ref;
+              if (comp.type === 'BOOLEAN_INPUT') {
+                // A required boolean is satisfied by either answer, so it carries no min-length rule.
+                shape[comp.ref] = fieldSchema;
+                return;
+              }
               if (comp.required) {
                 fieldSchema = (fieldSchema as z.ZodString).min(
                   1,
@@ -263,7 +272,11 @@ function InviteUserStepContent({
     const labelText = typeof label === 'string' ? label : '';
     const placeholderText = typeof placeholder === 'string' ? placeholder : '';
 
-    if (String(type) === String(EmbeddedFlowComponentType.TextInput) || type === 'TEXT_INPUT') {
+    if (
+      String(type) === String(EmbeddedFlowComponentType.TextInput) ||
+      type === 'TEXT_INPUT' ||
+      type === 'NUMBER_INPUT'
+    ) {
       return (
         <FormControl key={component.id ?? index} required={required}>
           <FormLabel htmlFor={ref}>{resolve(labelText) ?? labelText}</FormLabel>
@@ -277,7 +290,7 @@ function InviteUserStepContent({
                 fullWidth
                 size="small"
                 id={ref}
-                type="text"
+                type={type === 'NUMBER_INPUT' ? 'number' : 'text'}
                 placeholder={resolve(placeholderText) ?? placeholderText}
                 autoComplete="off"
                 required={required}
@@ -403,6 +416,40 @@ function InviteUserStepContent({
       );
     }
 
+    if (type === 'BOOLEAN_INPUT') {
+      return (
+        <FormControl key={component.id ?? index} required={required}>
+          <Controller
+            name={ref}
+            control={formControl}
+            render={({field}) => (
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    id={ref}
+                    size="small"
+                    disabled={isFormLoading}
+                    checked={field.value === 'true'}
+                    onChange={(e) => {
+                      const next = String(e.target.checked);
+                      field.onChange(next);
+                      handleInputChangeFn(ref, next);
+                    }}
+                  />
+                }
+                label={resolve(labelText) ?? labelText}
+              />
+            )}
+          />
+          {hint && (
+            <Typography variant="caption" color="text.secondary">
+              {hint}
+            </Typography>
+          )}
+        </FormControl>
+      );
+    }
+
     if (type === 'OU_SELECT') {
       return (
         <FormControl key={component.id ?? index} fullWidth required={required}>
@@ -512,6 +559,29 @@ function InviteUserStepContent({
       reset({});
     }
   }, [components, values, reset]);
+
+  // Seed boolean fields with their unchecked value. A boolean answer is meaningful even when the
+  // user never touches the field, and without a seeded value a required boolean attribute is
+  // absent from the submission and can never be satisfied.
+  useEffect(() => {
+    if (!components?.length) return;
+
+    const findBooleanRefs = (comps: EmbeddedFlowComponent[]): string[] => {
+      const refs: string[] = [];
+      for (const comp of comps) {
+        if (comp.type === 'BOOLEAN_INPUT' && comp.ref) refs.push(comp.ref);
+        if (comp.components) refs.push(...findBooleanRefs(comp.components));
+      }
+      return refs;
+    };
+
+    findBooleanRefs(components as EmbeddedFlowComponent[]).forEach((booleanRef) => {
+      if (values?.[booleanRef] === undefined) {
+        setValue(booleanRef, 'false', {shouldValidate: true});
+        handleInputChange(booleanRef, 'false');
+      }
+    });
+  }, [components, values, setValue, handleInputChange]);
 
   // Pre-select the root OU (user type's OU) when the OU_SELECT step renders.
   useEffect(() => {

--- a/frontend/packages/configure-users/src/pages/UserCreatePage.tsx
+++ b/frontend/packages/configure-users/src/pages/UserCreatePage.tsx
@@ -18,7 +18,9 @@ import {
   Typography,
   Button,
   TextField,
+  Checkbox,
   FormControl,
+  FormControlLabel,
   FormLabel,
   Select,
   MenuItem,
@@ -41,6 +43,19 @@ type FlowSubComponent = EmbeddedFlowComponent & {
   required?: boolean;
   variant?: string;
 };
+
+/** Collects the refs of every boolean field in a component tree. */
+function collectBooleanRefs(comps: EmbeddedFlowComponent[]): string[] {
+  const refs: string[] = [];
+  comps.forEach((comp) => {
+    if (comp.type === 'BOOLEAN_INPUT' && typeof comp.ref === 'string') {
+      refs.push(comp.ref);
+    }
+    const nested = (comp as FlowSubComponent).components;
+    if (nested) refs.push(...collectBooleanRefs(nested));
+  });
+  return refs;
+}
 
 function UserCreateStepContent({
   renderProps,
@@ -92,6 +107,20 @@ function UserCreateStepContent({
     [rawHandleInputChange, onFieldChange],
   );
 
+  // Seed boolean fields with their unchecked value. A boolean answer is meaningful even when the
+  // user never touches the field, and without a seeded value a required boolean attribute is absent
+  // from the submission and can never be satisfied. Seeding goes through the raw handler so it does
+  // not clear a create error the user has not acted on yet.
+  useEffect(() => {
+    if (!components?.length) return;
+    const current = values as Record<string, unknown> | undefined;
+    collectBooleanRefs(components).forEach((ref) => {
+      if (current?.[ref] === undefined) {
+        rawHandleInputChange(ref, 'false');
+      }
+    });
+  }, [components, values, rawHandleInputChange]);
+
   const renderComponent = (component: EmbeddedFlowComponent, index: number): JSX.Element | null => {
     // Render text components
     if (String(component.type) === String(EmbeddedFlowComponentType.Text) || component.type === 'TEXT') {
@@ -118,6 +147,7 @@ function UserCreateStepContent({
       component.type === 'EMAIL_INPUT' ||
       component.type === 'TEXT_INPUT' ||
       component.type === 'PHONE_INPUT' ||
+      component.type === 'NUMBER_INPUT' ||
       component.type === 'PASSWORD_INPUT'
     ) {
       const ref = component.ref;
@@ -133,6 +163,7 @@ function UserCreateStepContent({
       if (component.type === 'EMAIL_INPUT') inputType = 'email';
       if (component.type === 'PASSWORD_INPUT') inputType = 'password';
       if (component.type === 'PHONE_INPUT') inputType = 'tel';
+      if (component.type === 'NUMBER_INPUT') inputType = 'number';
 
       return (
         <FormControl key={component.id ?? index} fullWidth required={required}>
@@ -187,6 +218,33 @@ function UserCreateStepContent({
               );
             })}
           </Select>
+        </FormControl>
+      );
+    }
+
+    // Render BOOLEAN_INPUT
+    if (component.type === 'BOOLEAN_INPUT') {
+      const ref = component.ref;
+      const label = typeof component.label === 'string' ? component.label : '';
+      const required = (component as FlowSubComponent).required ?? false;
+
+      if (!ref) return null;
+
+      const checked = (values as Record<string, unknown>)?.[ref] === 'true';
+
+      return (
+        <FormControl key={component.id ?? index} required={required}>
+          <FormControlLabel
+            control={
+              <Checkbox
+                id={ref}
+                size="small"
+                checked={checked}
+                onChange={(e) => handleInputChange(ref, String(e.target.checked))}
+              />
+            }
+            label={t(resolve(label) ?? label)}
+          />
         </FormControl>
       );
     }

--- a/frontend/packages/configure-users/src/pages/__tests__/UserAddPage.test.tsx
+++ b/frontend/packages/configure-users/src/pages/__tests__/UserAddPage.test.tsx
@@ -236,6 +236,26 @@ const ouSelect = (ref: string, label: string, opts?: {required?: boolean; id?: s
     id: opts?.id ?? `ou-${ref}`,
   }) as unknown as EmbeddedFlowComponent;
 
+/** Build a numeric input component */
+const numberInput = (ref: string, label: string, opts?: {required?: boolean; id?: string}): EmbeddedFlowComponent =>
+  ({
+    type: 'NUMBER_INPUT',
+    ref,
+    label,
+    required: opts?.required ?? false,
+    id: opts?.id ?? `number-${ref}`,
+  }) as unknown as EmbeddedFlowComponent;
+
+/** Build a boolean (checkbox) component */
+const booleanInput = (ref: string, label: string, opts?: {required?: boolean; id?: string}): EmbeddedFlowComponent =>
+  ({
+    type: 'BOOLEAN_INPUT',
+    ref,
+    label,
+    required: opts?.required ?? false,
+    id: opts?.id ?? `boolean-${ref}`,
+  }) as unknown as EmbeddedFlowComponent;
+
 /** Build a submit action component */
 const submitAction = (label: string, opts?: {variant?: string; id?: string}): EmbeddedFlowComponent =>
   ({
@@ -498,6 +518,56 @@ describe('UserAddPage', () => {
       expect(headings.length).toBeGreaterThanOrEqual(1);
       // The text input should NOT render because the block has no submit action
       expect(screen.queryByLabelText(/name/i)).not.toBeInTheDocument();
+    });
+
+    it('should render a NUMBER_INPUT field as a numeric input', () => {
+      mockInviteUserRenderProps.components = [
+        heading('Number Step'),
+        block([numberInput('age', 'Age', {required: true}), submitAction('Next')]),
+      ];
+
+      render(<UserAddPage />);
+
+      const input = screen.getByLabelText(/age/i);
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveAttribute('type', 'number');
+    });
+
+    it('should render a BOOLEAN_INPUT field as a checkbox', () => {
+      mockInviteUserRenderProps.components = [
+        heading('Boolean Step'),
+        block([booleanInput('active', 'Active', {required: true}), submitAction('Next')]),
+      ];
+
+      render(<UserAddPage />);
+
+      expect(screen.getByRole('checkbox', {name: 'Active'})).toBeInTheDocument();
+    });
+
+    it('should seed a BOOLEAN_INPUT field with its unchecked value', async () => {
+      mockInviteUserRenderProps.components = [
+        heading('Boolean Step'),
+        block([booleanInput('active', 'Active', {required: true}), submitAction('Next')]),
+      ];
+
+      render(<UserAddPage />);
+
+      await waitFor(() => {
+        expect(mockHandleInputChange).toHaveBeenCalledWith('active', 'false');
+      });
+    });
+
+    it('should report a checked BOOLEAN_INPUT field as true', async () => {
+      mockInviteUserRenderProps.components = [
+        heading('Boolean Step'),
+        block([booleanInput('active', 'Active', {required: true}), submitAction('Next')]),
+      ];
+
+      render(<UserAddPage />);
+
+      await userEvent.click(screen.getByRole('checkbox', {name: 'Active'}));
+
+      expect(mockHandleInputChange).toHaveBeenCalledWith('active', 'true');
     });
   });
 

--- a/frontend/packages/configure-users/src/pages/__tests__/UserCreatePage.test.tsx
+++ b/frontend/packages/configure-users/src/pages/__tests__/UserCreatePage.test.tsx
@@ -9,6 +9,10 @@ import UserCreatePage from '../UserCreatePage';
 
 const mockNavigate = vi.fn();
 const mockHandleSubmit = vi.fn();
+const mockHandleInputChange = vi.fn();
+
+// Mutable form values the InviteUser mock reads at render time
+let mockValues: Record<string, string> = {};
 
 // Mock react-router
 vi.mock('react-router', async () => {
@@ -66,6 +70,15 @@ vi.mock('@thunderid/react', async (importOriginal) => {
           actions: undefined,
         },
         {
+          id: 'active-field',
+          type: 'BOOLEAN_INPUT',
+          label: 'Active',
+          ref: 'active',
+          required: true,
+          components: undefined,
+          actions: undefined,
+        },
+        {
           id: 'submit-btn',
           type: 'ACTION',
           label: 'Create User',
@@ -74,16 +87,16 @@ vi.mock('@thunderid/react', async (importOriginal) => {
           components: undefined,
           actions: undefined,
         },
-      ];
+      ] as EmbeddedFlowComponent[];
 
       const renderProps: InviteUserRenderProps = {
         components: mockComponents,
-        values: {},
+        values: mockValues,
         fieldErrors: {},
         touched: {},
         error: null,
         isLoading: false,
-        handleInputChange: vi.fn(),
+        handleInputChange: mockHandleInputChange,
         handleInputBlur: vi.fn(),
         handleSubmit: mockHandleSubmit,
         resetFlow: vi.fn(),
@@ -100,6 +113,7 @@ vi.mock('@thunderid/react', async (importOriginal) => {
 describe('UserCreatePage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockValues = {};
     mockNavigate.mockResolvedValue(undefined);
     mockHandleSubmit.mockResolvedValue(undefined);
   });
@@ -202,5 +216,38 @@ describe('UserCreatePage', () => {
 
     // Email label should be translated and visible
     expect(screen.getByLabelText('Email')).toBeInTheDocument();
+  });
+
+  describe('boolean attributes', () => {
+    it('renders a boolean attribute as a checkbox rather than a text field', () => {
+      render(<UserCreatePage />);
+
+      expect(screen.getByRole('checkbox', {name: 'Active'})).toBeInTheDocument();
+    });
+
+    it('seeds a boolean attribute with its unchecked value', async () => {
+      render(<UserCreatePage />);
+
+      await waitFor(() => {
+        expect(mockHandleInputChange).toHaveBeenCalledWith('active', 'false');
+      });
+    });
+
+    it('reports a checked boolean attribute as true', async () => {
+      const user = userEvent.setup();
+      mockValues = {active: 'false'};
+      render(<UserCreatePage />);
+
+      await user.click(screen.getByRole('checkbox', {name: 'Active'}));
+
+      expect(mockHandleInputChange).toHaveBeenCalledWith('active', 'true');
+    });
+
+    it('reflects a boolean attribute that is already true', () => {
+      mockValues = {active: 'true'};
+      render(<UserCreatePage />);
+
+      expect(screen.getByRole('checkbox', {name: 'Active'})).toBeChecked();
+    });
   });
 });

--- a/frontend/packages/design/src/components/flow/adapters/BlockAdapter.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/BlockAdapter.tsx
@@ -6,6 +6,7 @@ import {cn} from '@thunderid/utils';
 import {Box, Button} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
+import CheckboxAdapter from './CheckboxAdapter';
 import DividerAdapter from './DividerAdapter';
 import OtpInputAdapter from './OtpInputAdapter';
 import PasswordInputAdapter from './PasswordInputAdapter';
@@ -194,7 +195,8 @@ function renderFormSubComponent(
     (sub.type as EmbeddedFlowComponentType) === EmbeddedFlowComponentType.TextInput ||
     sub.type === 'TEXT_INPUT' ||
     sub.type === 'EMAIL_INPUT' ||
-    sub.type === 'PHONE_INPUT'
+    sub.type === 'PHONE_INPUT' ||
+    sub.type === 'NUMBER_INPUT'
   ) {
     return <TextInputAdapter key={sub.id ?? compIndex} {...fieldProps} />;
   }
@@ -218,6 +220,10 @@ function renderFormSubComponent(
 
   if (sub.type === 'SELECT') {
     return <SelectAdapter key={sub.id ?? compIndex} {...fieldProps} />;
+  }
+
+  if (sub.type === 'BOOLEAN_INPUT') {
+    return <CheckboxAdapter key={sub.id ?? compIndex} {...fieldProps} />;
   }
 
   if (sub.type === 'RICH_TEXT') {

--- a/frontend/packages/design/src/components/flow/adapters/CheckboxAdapter.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/CheckboxAdapter.tsx
@@ -1,0 +1,64 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {cn} from '@thunderid/utils';
+import {Checkbox, FormControl, FormControlLabel, Typography} from '@wso2/oxygen-ui';
+import type {JSX} from 'react';
+import {useEffect} from 'react';
+import {useTranslation} from 'react-i18next';
+import type {FlowFieldProps} from '../../../models/flow';
+
+export default function CheckboxAdapter({
+  component,
+  values,
+  touched,
+  fieldErrors,
+  isLoading,
+  resolve,
+  onInputChange,
+  onBlur,
+}: FlowFieldProps): JSX.Element | null {
+  const {t} = useTranslation();
+  const {ref} = component;
+  const isBound = typeof ref === 'string' && !!ref;
+  const currentValue = isBound ? values[ref] : undefined;
+
+  // A boolean field carries a value even when the user never touches it, so seed the unchecked
+  // state. Without this the attribute is absent from the submission and a required boolean can
+  // never be satisfied.
+  useEffect(() => {
+    if (isBound && currentValue === undefined) {
+      onInputChange(ref, 'false');
+    }
+  }, [isBound, ref, currentValue, onInputChange]);
+
+  if (!isBound) return null;
+
+  const hasError = !!(touched?.[ref] && fieldErrors?.[ref]);
+
+  return (
+    <FormControl required={component.required} className={cn('Flow--checkbox', 'FormControl--root')} error={hasError}>
+      <FormControlLabel
+        className={cn('FormControlLabel--root')}
+        control={
+          <Checkbox
+            className={cn('Checkbox--root')}
+            id={ref}
+            name={ref}
+            size="small"
+            disabled={isLoading}
+            checked={currentValue === 'true'}
+            onChange={(e) => onInputChange(ref, String(e.target.checked))}
+            onBlur={() => onBlur?.(ref)}
+          />
+        }
+        label={t(resolve(component.label)!)}
+      />
+      {hasError && (
+        <Typography variant="caption" color="error.main">
+          {fieldErrors?.[ref]}
+        </Typography>
+      )}
+    </FormControl>
+  );
+}

--- a/frontend/packages/design/src/components/flow/adapters/TextInputAdapter.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/TextInputAdapter.tsx
@@ -7,12 +7,13 @@ import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import type {FlowFieldProps} from '../../../models/flow';
 
-type TextInputVariant = 'TEXT_INPUT' | 'EMAIL_INPUT' | 'PHONE_INPUT';
+type TextInputVariant = 'TEXT_INPUT' | 'EMAIL_INPUT' | 'PHONE_INPUT' | 'NUMBER_INPUT';
 
 const HTML_INPUT_TYPE: Record<TextInputVariant, string> = {
   TEXT_INPUT: 'text',
   EMAIL_INPUT: 'email',
   PHONE_INPUT: 'tel',
+  NUMBER_INPUT: 'number',
 };
 
 const AUTO_COMPLETE_MAP: Record<TextInputVariant, (ref: string) => string> = {
@@ -23,11 +24,13 @@ const AUTO_COMPLETE_MAP: Record<TextInputVariant, (ref: string) => string> = {
   },
   EMAIL_INPUT: () => 'email',
   PHONE_INPUT: () => 'tel',
+  NUMBER_INPUT: () => 'off',
 };
 
 function resolveTextVariant(type: string): TextInputVariant {
   if (type === 'EMAIL_INPUT') return 'EMAIL_INPUT';
   if (type === 'PHONE_INPUT') return 'PHONE_INPUT';
+  if (type === 'NUMBER_INPUT') return 'NUMBER_INPUT';
   return 'TEXT_INPUT';
 }
 

--- a/frontend/packages/design/src/components/flow/adapters/__tests__/BlockAdapter.test.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/__tests__/BlockAdapter.test.tsx
@@ -339,3 +339,26 @@ describe('BlockAdapter: RESEND inside a form block', () => {
     expect(screen.getByRole('button', {name: 'Verify'})).toBeTruthy();
   });
 });
+
+describe('BlockAdapter: BOOLEAN_INPUT inside a form block', () => {
+  const activeCheckbox = {id: 'input_003', type: 'BOOLEAN_INPUT', ref: 'active', label: 'Active'};
+  const booleanBlock = {
+    id: 'block_002',
+    type: 'BLOCK',
+    components: [usernameInput, activeCheckbox, submitAction],
+  };
+
+  it('renders a boolean attribute as a checkbox rather than a text field', () => {
+    renderBlock(booleanBlock, {values: {...BLOCK_VALUES, active: 'false'}});
+
+    const checkbox: HTMLInputElement = screen.getByRole('checkbox', {name: 'Active'});
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it('reflects a checked boolean value', () => {
+    renderBlock(booleanBlock, {values: {...BLOCK_VALUES, active: 'true'}});
+
+    const checkbox: HTMLInputElement = screen.getByRole('checkbox', {name: 'Active'});
+    expect(checkbox.checked).toBe(true);
+  });
+});

--- a/frontend/packages/design/src/components/flow/adapters/__tests__/CheckboxAdapter.test.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/__tests__/CheckboxAdapter.test.tsx
@@ -1,0 +1,66 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import {fireEvent, screen} from '@testing-library/react';
+import {TEST_CN_PREFIX} from '@thunderid/test-utils';
+import {describe, it, expect, vi} from 'vitest';
+import type {FlowFieldProps} from '../../../../models/flow';
+import renderWithProviders from '../../../../test/renderWithProviders';
+import CheckboxAdapter from '../CheckboxAdapter';
+
+const baseProps: FlowFieldProps = {
+  component: {id: 'active', type: 'BOOLEAN_INPUT', ref: 'active', label: 'Active', required: true},
+  values: {active: 'false'},
+  isLoading: false,
+  resolve: (s) => s,
+  onInputChange: vi.fn(),
+};
+
+describe('CheckboxAdapter', () => {
+  it('renders the label', () => {
+    renderWithProviders(<CheckboxAdapter {...baseProps} />);
+    expect(screen.getByText('Active')).toBeTruthy();
+  });
+
+  it('renders a checkbox reflecting the current value', () => {
+    const {container} = renderWithProviders(<CheckboxAdapter {...baseProps} values={{active: 'true'}} />);
+    const input = container.querySelector<HTMLInputElement>('input[name="active"]')!;
+    expect(input).toBeTruthy();
+    expect(input.getAttribute('type')).toBe('checkbox');
+    expect(input.checked).toBe(true);
+  });
+
+  it('reports the checked state as a boolean string', () => {
+    const onInputChange = vi.fn();
+    const {container} = renderWithProviders(<CheckboxAdapter {...baseProps} onInputChange={onInputChange} />);
+    const input = container.querySelector<HTMLInputElement>('input[name="active"]')!;
+    fireEvent.click(input);
+    expect(onInputChange).toHaveBeenCalledWith('active', 'true');
+  });
+
+  it('seeds the unchecked value so a required boolean is present in the submission', () => {
+    const onInputChange = vi.fn();
+    renderWithProviders(<CheckboxAdapter {...baseProps} values={{}} onInputChange={onInputChange} />);
+    expect(onInputChange).toHaveBeenCalledWith('active', 'false');
+  });
+
+  it('does not overwrite a value that is already set', () => {
+    const onInputChange = vi.fn();
+    renderWithProviders(<CheckboxAdapter {...baseProps} values={{active: 'true'}} onInputChange={onInputChange} />);
+    expect(onInputChange).not.toHaveBeenCalled();
+  });
+
+  it('applies product prefix CSS class names', () => {
+    renderWithProviders(<CheckboxAdapter {...baseProps} />);
+    const formControl = document.querySelector(`.${TEST_CN_PREFIX}Flow--checkbox`);
+    expect(formControl).toBeTruthy();
+    expect(formControl?.classList.contains(`${TEST_CN_PREFIX}FormControl--root`)).toBe(true);
+  });
+
+  it('returns null when ref is missing', () => {
+    const noRefProps = {...baseProps, component: {...baseProps.component, ref: undefined}};
+    const {container} = renderWithProviders(<CheckboxAdapter {...noRefProps} />);
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/frontend/packages/design/src/components/flow/adapters/__tests__/TextInputAdapter.test.tsx
+++ b/frontend/packages/design/src/components/flow/adapters/__tests__/TextInputAdapter.test.tsx
@@ -40,6 +40,16 @@ describe('TextInputAdapter', () => {
     expect(input?.getAttribute('type')).toBe('email');
   });
 
+  it('renders number type for NUMBER_INPUT', () => {
+    const numberProps = {
+      ...baseProps,
+      component: {...baseProps.component, type: 'NUMBER_INPUT', ref: 'age', label: 'Age'},
+    };
+    renderWithProviders(<TextInputAdapter {...numberProps} />);
+    const input = document.querySelector('input[name="age"]');
+    expect(input?.getAttribute('type')).toBe('number');
+  });
+
   it('applies product prefix CSS class names', () => {
     renderWithProviders(<TextInputAdapter {...baseProps} />);
     const formControl = document.querySelector(`.${TEST_CN_PREFIX}Flow--textInput`);


### PR DESCRIPTION
### Purpose
Fixes user creation for user types whose schema contains a required boolean attribute. The attribute was prompted as a plain text field and its value submitted as a string, which entity schema validation correctly rejected, leaving no way to complete the flow. Required `number` attributes failed the same way and are fixed too.

https://github.com/user-attachments/assets/93db7a94-7772-4b8d-a57c-2ed9f133a70e

### Approach
The attribute's declared type was dropped at both ends of the round trip:

- **Prompt**: the provisioning executor hardcoded `TEXT_INPUT` for every schema attribute, ignoring `AttributeInfo.Type`. It now derives the input type from the schema, and a new `BOOLEAN_INPUT` type was added to the engine.
- **Submission**: the engine carries user inputs as strings, and those strings were written straight into the entity attributes. Values are now converted to their schema type at the point where they stop being form values and become stored attributes. Values that fail to parse pass through unchanged, so schema validation reports them rather than a zero value being silently substituted. The same conversion was applied to the attribute collector, which had the identical passthrough for profile updates.
- **Rendering**: added a checkbox adapter for `BOOLEAN_INPUT` and wired `NUMBER_INPUT` into the existing text input paths, across the gate adapters and both console pages. Boolean fields seed `false` on mount so a required boolean is never absent from the submission.

`object` and `array` attributes are unchanged: they cannot be filled from a single input at all and need new controls rather than a parser.

### Related Issues
- Fixes #4805



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added boolean and number input support to user forms and flow components.
  * Boolean fields now render as checkboxes with appropriate default and checked states.
  * Number fields now use numeric input controls.
  * Input values are converted to their declared schema types during provisioning.

* **Bug Fixes**
  * Improved handling of missing, invalid, and schema-defined input values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->