### PR TITLE
Fix flaky CIBA id_token_hint tamper helper and unskip binding message test

### DIFF
--- a/tests/integration/oauth/ciba/ciba_test.go
+++ b/tests/integration/oauth/ciba/ciba_test.go
@@ -598,12 +598,7 @@ func (ts *CIBATestSuite) TestCIBAAuthReqIDNotTransferableAcrossClients() {
 // TestCIBABindingMessageDeliveredToUser verifies that a client-supplied binding_message reaches the
 // user's notification verbatim, and that an omitted one falls back to defaultBindingMessage's
 // generated, request-specific "Code: XXXX-XXXX" text.
-// Skipped pending https://github.com/thunder-id/thunderid/issues/4835: smsExecutor does not merge
-// ctx.RuntimeData into its template data, so bindingMessage is never substituted into the SMS body.
 func (ts *CIBATestSuite) TestCIBABindingMessageDeliveredToUser() {
-	ts.T().Skip("https://github.com/thunder-id/thunderid/issues/4835: smsExecutor does not merge " +
-		"ctx.RuntimeData, so bindingMessage never reaches the SMS template. Unskip when the issue is fixed.")
-
 	customMessage := "Approve sign-in to Acme Console"
 	form := url.Values{}
 	form.Set("login_hint", cibaTestUsername)
@@ -1307,20 +1302,23 @@ func buildFakeIDTokenHint(claims map[string]interface{}) string {
 		base64.RawURLEncoding.EncodeToString(payloadJSON) + ".fakesignature"
 }
 
-// tamperJWTSignature flips the last character of a real JWT's signature segment, invalidating it
-// while keeping the token well-formed (three base64url segments).
+// tamperJWTSignature flips a bit in the first byte of a real JWT's decoded signature, invalidating
+// it while keeping the token well-formed (three base64url segments). The mutation must operate on
+// the decoded bytes rather than the base64url characters: a character-level edit can land on the
+// trailing padding bits of the encoding (e.g. the last character of a 64- or 256-byte signature
+// carries only 2 significant bits, with the rest unused padding), in which case the "tampered"
+// token decodes to byte-identical signature bytes, still verifies successfully, and the test
+// flakes. Flipping a bit in the first byte guarantees the decoded signature actually changes.
 func tamperJWTSignature(token string) string {
 	parts := strings.Split(token, ".")
 	if len(parts) != 3 || len(parts[2]) == 0 {
 		return token
 	}
-	sig := []byte(parts[2])
-	last := sig[len(sig)-1]
-	if last == 'A' {
-		sig[len(sig)-1] = 'B'
-	} else {
-		sig[len(sig)-1] = 'A'
+	raw, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil || len(raw) == 0 {
+		return token
 	}
-	parts[2] = string(sig)
+	raw[0] ^= 0x01
+	parts[2] = base64.RawURLEncoding.EncodeToString(raw)
 	return strings.Join(parts, ".")
 }


### PR DESCRIPTION
### Purpose

Fix a flaky CIBA integration test that has been failing roughly one CI run in
four, and re-enable a test that was skipped pending a bug that is now fixed.

Example failure: https://github.com/thunder-id/thunderid/actions/runs/31515444927/job/93860820311

### Approach

**1. `tamperJWTSignature` was silently a no-op 25% of the time**

The helper mutated the last character of the base64url signature segment to
forge an invalid signature. A JWT signature is 64 bytes (ES256, EdDSA) or 256
bytes (RS256). Both leave remainder 1 mod 3, so the base64url encoding ends in a
two character group whose final character carries only 2 significant bits, with
4 bits of discarded padding.

`'A'` is `000000` and `'B'` is `000001`. They differ only in those padding bits.
So whenever the signature encoding happened to end in `'A'`, the "tampered"
token decoded to byte identical signature bytes, verified successfully, and the
server correctly returned 200 while `TestCIBAIDTokenHintResolvesUser` expected
400.

Each run mints a fresh ID token, so this was a new 1 in 4 coin flip every time.
The server behaviour was correct throughout; only the test was wrong.

The fix mutates the decoded signature bytes instead, flipping a bit in the first
byte so the change can never land in the trailing padding region.

**2. Stale skip removed**

`TestCIBABindingMessageDeliveredToUser` was skipped pending #4835. That issue was
fixed by #4843 and is present in main, so the skip is now a false signal and the
coverage was sitting inactive. The skip call and its comment are removed; the
assertions are unchanged.

### Verification

Reproduced against unmodified main to confirm the diagnosis rather than assume
it, then confirmed the fix holds across many fresh tokens:

| | Result |
|---|---|
| Before fix, 12 consecutive runs | 8 pass / **4 fail** |
| After fix, 12 consecutive runs | **12 pass** / 0 fail |

All four pre-fix failures were identical to CI: `ciba_test.go:509`, expected 400,
actual 200.

`TestCIBABindingMessageDeliveredToUser` was confirmed as PASS, not SKIP, in all
12 post-fix runs.

Repeated runs are necessary here rather than a single green run: the defect is
probabilistic, so one passing run has a 75% chance of looking healthy while the
bug is still present.

### Related Issues
- N/A

### Related PRs
- #4838 introduced the flaky helper
- #4843 fixed the bug that made the skip necessary

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Re-enabled integration coverage for binding-message authentication flows.
  - Improved detection of tampered JWT signatures by modifying the signature bytes directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->