### PR TITLE
Fix OTP numeric-only checkbox to match backend default

### DIFF
--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/__tests__/ExecutionExtendedProperties.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/__tests__/ExecutionExtendedProperties.test.tsx
@@ -797,12 +797,32 @@ describe('ExecutionExtendedProperties', () => {
       expect(mockOnChange).toHaveBeenCalledWith('data.properties.otpLength', 10, otpResource);
     });
 
-    it('should still commit booleans immediately', () => {
+    it('should default the numeric-only checkbox to checked when the property is unset', () => {
+      render(<ExecutionExtendedProperties resource={otpResource} onChange={mockOnChange} />);
+
+      expect(screen.getByRole('checkbox')).toBeChecked();
+    });
+
+    it('should render the numeric-only checkbox unchecked when explicitly set to false', () => {
+      const alphanumericOtpResource = {
+        ...otpResource,
+        data: {
+          ...(otpResource as unknown as {data: object}).data,
+          properties: {otpLength: 6, otpValidityPeriodSeconds: 120, otpUseNumericOnly: false},
+        },
+      } as unknown as Resource;
+
+      render(<ExecutionExtendedProperties resource={alphanumericOtpResource} onChange={mockOnChange} />);
+
+      expect(screen.getByRole('checkbox')).not.toBeChecked();
+    });
+
+    it('should commit false immediately when the default-checked numeric-only box is unchecked', () => {
       render(<ExecutionExtendedProperties resource={otpResource} onChange={mockOnChange} />);
 
       fireEvent.click(screen.getByRole('checkbox'));
 
-      expect(mockOnChange).toHaveBeenCalledWith('data.properties.otpUseNumericOnly', true, otpResource);
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.otpUseNumericOnly', false, otpResource);
     });
   });
 

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/OtpProperties.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/OtpProperties.tsx
@@ -69,7 +69,7 @@ function OtpProperties({resource, onChange}: CommonResourcePropertiesPropsInterf
         <FormControlLabel
           control={
             <Checkbox
-              checked={!!properties.otpUseNumericOnly}
+              checked={(properties.otpUseNumericOnly ?? true) as boolean}
               onChange={(e) => handleBooleanPropertyChange('otpUseNumericOnly', e.target.checked)}
               size="small"
             />


### PR DESCRIPTION
### Purpose

Fixes the UI/backend mismatch reported in #4761. In the flow builder, the Generate OTP executor's **Numeric Only** checkbox rendered **unchecked** whenever a flow did not explicitly set `otpUseNumericOnly`, which misleadingly implied the OTP uses alphanumeric characters.

In reality the backend defaults OTP generation to **numeric-only** when the property is absent (`default.json` `use_numeric_only: true`; the per-flow value only overrides it when explicitly present). Template-created OTP flows always hit this path because their Generate OTP node ships without the property, so the checkbox never reflected the character set actually in use.

| Flow state | Checkbox before | Checkbox after | Backend behavior |
|---|---|---|---|
| property absent (template/new) | unchecked ❌ | **checked** ✅ | numeric-only (default) |
| explicit `true` | checked | checked | numeric-only |
| explicit `false` | unchecked | unchecked | alphanumeric |

### Approach

Mirror the backend default in the checkbox: treat an unset value as `true` (checked) while still honoring an explicit `false`.

```tsx
checked={(properties.otpUseNumericOnly ?? true) as boolean}
```

The property is only persisted when the user toggles it, so an untouched flow writes nothing and keeps relying on the backend default, keeping the two in sync. Frontend-only change: the backend default is already correct, and template data is intentionally left untouched since the UI default now covers every "unset" case.

Note: the UI mirrors the shipped default (`true`). A deployment that overrides `use_numeric_only: false` in `deployment.yaml` is not reflected by the static flow builder; that would require the builder to read server OTP config and is out of scope here.

### Related Issues
- #4761

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)

### Security checks
- [x] Followed secure coding standards in WSO2 Secure Coding Guidelines
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OTP settings so the numeric-only option is enabled by default when no preference is specified.
  * Preserved the unchecked state when numeric-only mode is explicitly disabled.
  * Changes to the checkbox now immediately save the selected setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->