### PR TITLE
Add authorization and credential state check on refresh grant

### DIFF
--- a/backend/internal/authnprovider/common/constants.go
+++ b/backend/internal/authnprovider/common/constants.go
@@ -11,6 +11,10 @@ const (
 	UserAttributeSub = "sub"
 )
 
+// SystemAttrCredentialUpdatedAt is the entity system-attribute key recording when the entity's
+// authentication credential last changed: a user's password, or a client secret.
+const SystemAttrCredentialUpdatedAt = "credentialUpdatedAt" // #nosec G101 -- attribute key, not a secret
+
 // Credential type keys used in the credentials map passed to the authentication providers.
 const (
 	// CredentialTypeProvisionedEntityID identifies an entity provisioned earlier in the same flow.

--- a/backend/internal/entity/service.go
+++ b/backend/internal/entity/service.go
@@ -9,7 +9,9 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
+	authnprovidercm "github.com/thunder-id/thunderid/internal/authnprovider/common"
 	"github.com/thunder-id/thunderid/internal/entitytype"
 	"github.com/thunder-id/thunderid/internal/ou"
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
@@ -246,6 +248,12 @@ func (s *entityService) UpdateEntity(
 	var updated providers.Entity
 	err = s.transactioner.Transact(ctx, func(txCtx context.Context) error {
 		entity.ID = entityID
+		preserved, prErr := s.mergeReservedAttributes(txCtx, entityID, entity.SystemAttributes)
+		if prErr != nil {
+			return prErr
+		}
+		entity.SystemAttributes = preserved
+
 		if err := s.store.UpdateEntity(txCtx, entity); err != nil {
 			return err
 		}
@@ -347,7 +355,11 @@ func (s *entityService) UpdateSystemAttributes(ctx context.Context, entityID str
 	attrs json.RawMessage) error {
 	s.logger.Debug(ctx, "Updating entity system attributes", log.MaskedString("id", entityID))
 	return s.transactioner.Transact(ctx, func(txCtx context.Context) error {
-		return s.store.UpdateSystemAttributes(txCtx, entityID, attrs)
+		preserved, err := s.mergeReservedAttributes(txCtx, entityID, attrs)
+		if err != nil {
+			return err
+		}
+		return s.store.UpdateSystemAttributes(txCtx, entityID, preserved)
 	})
 }
 
@@ -643,7 +655,18 @@ func (s *entityService) UpdateCredentials(ctx context.Context, entityID string,
 			return fmt.Errorf("failed to marshal merged credentials: %w", err)
 		}
 
-		return s.store.UpdateCredentials(txCtx, entityID, mergedJSON)
+		if err := s.store.UpdateCredentials(txCtx, entityID, mergedJSON); err != nil {
+			return err
+		}
+
+		// Record the change so the refresh grant can reject tokens established before it. Every
+		// password change lands here, and the marker shares this transaction with the write.
+		markedAttrs, err := setCredentialUpdatedAt(
+			existingWithCreds.Entity.SystemAttributes, time.Now().UTC())
+		if err != nil {
+			return err
+		}
+		return s.store.UpdateSystemAttributes(txCtx, entityID, markedAttrs)
 	})
 }
 
@@ -789,7 +812,20 @@ func (s *entityService) UpdateSystemCredentials(ctx context.Context, entityID st
 			return fmt.Errorf("failed to marshal merged credentials: %w", err)
 		}
 
-		return s.store.UpdateSystemCredentials(txCtx, entityID, mergedJSON)
+		if err := s.store.UpdateSystemCredentials(txCtx, entityID, mergedJSON); err != nil {
+			return err
+		}
+
+		// Only a client secret rotation marks the entity. A passkey adds an authentication option
+		// rather than replacing one, and the flow secret does not authenticate the client.
+		if _, rotatesClientSecret := updates[authnprovidercm.CredentialTypeClientSecret]; !rotatesClientSecret {
+			return nil
+		}
+		markedAttrs, err := setCredentialUpdatedAt(existing.Entity.SystemAttributes, time.Now().UTC())
+		if err != nil {
+			return err
+		}
+		return s.store.UpdateSystemAttributes(txCtx, entityID, markedAttrs)
 	})
 }
 
@@ -876,6 +912,70 @@ func (s *entityService) validateEntityType(
 	}
 
 	return nil
+}
+
+// mergeReservedAttributes carries the reserved, server-owned keys of an entity's stored system
+// attributes into a replacement blob. Both write paths replace the blob wholesale, and the services
+// that own an entity rebuild it from their own model, so without this a rename would drop the
+// credential-change marker this package writes and revive the tokens a credential change invalidated.
+func (s *entityService) mergeReservedAttributes(ctx context.Context, entityID string,
+	incoming json.RawMessage) (json.RawMessage, error) {
+	current, err := s.store.GetEntity(ctx, entityID)
+	if err != nil {
+		return nil, err
+	}
+	marker := credentialUpdatedAtOf(current.SystemAttributes)
+	if marker == "" {
+		return incoming, nil
+	}
+
+	attrs := map[string]interface{}{}
+	if len(incoming) > 0 {
+		if err := json.Unmarshal(incoming, &attrs); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal system attributes: %w", err)
+		}
+	}
+	attrs[authnprovidercm.SystemAttrCredentialUpdatedAt] = marker
+
+	merged, err := json.Marshal(attrs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal system attributes: %w", err)
+	}
+	return merged, nil
+}
+
+// credentialUpdatedAtOf returns the credential-change marker in the given system attributes, or empty
+// when none is recorded.
+func credentialUpdatedAtOf(systemAttributes json.RawMessage) string {
+	if len(systemAttributes) == 0 {
+		return ""
+	}
+	var attrs map[string]interface{}
+	if err := json.Unmarshal(systemAttributes, &attrs); err != nil {
+		return ""
+	}
+	marker, _ := attrs[authnprovidercm.SystemAttrCredentialUpdatedAt].(string)
+	return marker
+}
+
+// setCredentialUpdatedAt returns systemAttributes with the credential-change marker set to at. The
+// marker is merged in rather than replacing the blob, whose other keys belong to the service that
+// owns the entity. Unlike mergeCredentialJSON, an unparsable blob is an error rather than a silent
+// overwrite, since dropping those keys would go unnoticed.
+func setCredentialUpdatedAt(systemAttributes json.RawMessage, at time.Time) (json.RawMessage, error) {
+	attrs := map[string]interface{}{}
+	if len(systemAttributes) > 0 {
+		if err := json.Unmarshal(systemAttributes, &attrs); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal system attributes: %w", err)
+		}
+	}
+	attrs[authnprovidercm.SystemAttrCredentialUpdatedAt] = at.UTC().Format(time.RFC3339)
+
+	marked, err := json.Marshal(attrs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal system attributes: %w", err)
+	}
+	return marked, nil
 }
 
 // mergeCredentialJSON merges new credential JSON into existing credential JSON.

--- a/backend/internal/entity/service_test.go
+++ b/backend/internal/entity/service_test.go
@@ -8,10 +8,12 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
+	authnprovidercm "github.com/thunder-id/thunderid/internal/authnprovider/common"
 	"github.com/thunder-id/thunderid/internal/entitytype"
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
 	"github.com/thunder-id/thunderid/internal/system/transaction"
@@ -114,6 +116,7 @@ func (s *ServiceTestSuite) TestUpdateEntity_NilEntity() {
 
 func (s *ServiceTestSuite) TestUpdateEntity_StoreFails() {
 	e := testEntity("e5")
+	s.store.On("GetEntity", mock.Anything, e.ID).Return(*e, nil).Once()
 	s.store.On("UpdateEntity", mock.Anything, e).Return(s.testErr)
 	_, err := s.svc.UpdateEntity(s.ctx, e.ID, e)
 	s.Error(err)
@@ -121,8 +124,9 @@ func (s *ServiceTestSuite) TestUpdateEntity_StoreFails() {
 
 func (s *ServiceTestSuite) TestUpdateEntity_GetAfterUpdateFails() {
 	e := testEntity("e6")
+	s.store.On("GetEntity", mock.Anything, e.ID).Return(*e, nil).Once()
 	s.store.On("UpdateEntity", mock.Anything, e).Return(nil)
-	s.store.On("GetEntity", mock.Anything, e.ID).Return(providers.Entity{}, s.testErr)
+	s.store.On("GetEntity", mock.Anything, e.ID).Return(providers.Entity{}, s.testErr).Once()
 	_, err := s.svc.UpdateEntity(s.ctx, e.ID, e)
 	s.Error(err)
 }
@@ -283,6 +287,65 @@ func (s *ServiceTestSuite) TestUpdateSystemCredentials_Delegates() {
 		Return(&entityWithCredentials{Entity: existingEntity, SchemaCredentials: nil, SystemCredentials: nil}, nil)
 	s.store.On("UpdateSystemCredentials", mock.Anything, "e1", mock.AnythingOfType("json.RawMessage")).Return(nil)
 	s.NoError(s.svc.UpdateSystemCredentials(s.ctx, "e1", creds))
+}
+
+// A password change stamps the entity so the refresh grant can reject tokens established before it.
+// The stamp merges into the existing blob: the column is written wholesale and its other keys belong
+// to the service that owns the entity.
+func (s *ServiceTestSuite) TestUpdateCredentials_StampsCredentialMarkerPreservingOtherKeys() {
+	e := testEntity("e-pw")
+	e.SystemAttributes = json.RawMessage(`{"name":"App name"}`)
+	s.store.On("GetEntity", mock.Anything, e.ID).Return(*e, nil)
+	s.store.On("GetEntityWithCredentials", mock.Anything, e.ID).
+		Return(&entityWithCredentials{Entity: e}, nil)
+	s.store.On("UpdateCredentials", mock.Anything, e.ID, mock.AnythingOfType("json.RawMessage")).Return(nil)
+
+	var written json.RawMessage
+	s.store.On("UpdateSystemAttributes", mock.Anything, e.ID, mock.AnythingOfType("json.RawMessage")).
+		Run(func(args mock.Arguments) {
+			written, _ = args.Get(2).(json.RawMessage)
+		}).Return(nil)
+
+	s.NoError(s.svc.UpdateCredentials(s.ctx, e.ID, json.RawMessage(`{"password":"new-secret"}`)))
+
+	var attrs map[string]interface{}
+	s.Require().NoError(json.Unmarshal(written, &attrs))
+	s.Equal("App name", attrs["name"], "unrelated system attributes must survive the stamp")
+	s.NotEmpty(attrs[authnprovidercm.SystemAttrCredentialUpdatedAt])
+}
+
+// A client secret rotation stamps the entity, in the same transaction as the credential write.
+func (s *ServiceTestSuite) TestUpdateSystemCredentials_StampsOnClientSecretRotation() {
+	e := testEntity("e-cs")
+	s.store.On("GetEntityWithCredentials", mock.Anything, e.ID).
+		Return(&entityWithCredentials{Entity: e}, nil)
+	s.store.On("UpdateSystemCredentials", mock.Anything, e.ID, mock.AnythingOfType("json.RawMessage")).
+		Return(nil)
+	s.store.On("UpdateSystemAttributes", mock.Anything, e.ID, mock.AnythingOfType("json.RawMessage")).
+		Return(nil)
+
+	s.NoError(s.svc.UpdateSystemCredentials(s.ctx, e.ID, json.RawMessage(`{"clientSecret":"rotated"}`)))
+
+	s.store.AssertCalled(s.T(), "UpdateSystemAttributes", mock.Anything, e.ID,
+		mock.AnythingOfType("json.RawMessage"))
+}
+
+// Enrolling a passkey adds an authentication option rather than replacing one, so it must not
+// invalidate outstanding tokens. The same holds for the flow secret, which authenticates flow
+// initiation rather than the client.
+func (s *ServiceTestSuite) TestUpdateSystemCredentials_NoStampForOtherCredentialTypes() {
+	for _, creds := range []string{`{"passkey":[{"value":"v1"}]}`, `{"flowSecret":"rotated"}`} {
+		e := testEntity("e-other")
+		s.store.On("GetEntityWithCredentials", mock.Anything, e.ID).
+			Return(&entityWithCredentials{Entity: e}, nil).Once()
+		s.store.On("UpdateSystemCredentials", mock.Anything, e.ID, mock.AnythingOfType("json.RawMessage")).
+			Return(nil).Once()
+
+		s.NoError(s.svc.UpdateSystemCredentials(s.ctx, e.ID, json.RawMessage(creds)))
+
+		s.store.AssertNotCalled(s.T(), "UpdateSystemAttributes", mock.Anything, e.ID,
+			mock.AnythingOfType("json.RawMessage"))
+	}
 }
 
 func (s *ServiceTestSuite) TestGetCredentialsByType_NoCredentials() {
@@ -470,6 +533,7 @@ func (s *ServiceTestSuite) TestUpdateEntity_NilEntity_ViaOldPath() {
 
 func (s *ServiceTestSuite) TestUpdateEntity_UpdateFails_ViaOldPath() {
 	e := testEntity("uc1")
+	s.store.On("GetEntity", mock.Anything, e.ID).Return(*e, nil).Once()
 	s.store.On("UpdateEntity", mock.Anything, e).Return(s.testErr)
 	_, err := s.svc.UpdateEntity(s.ctx, e.ID, e)
 	s.Error(err)
@@ -477,8 +541,9 @@ func (s *ServiceTestSuite) TestUpdateEntity_UpdateFails_ViaOldPath() {
 
 func (s *ServiceTestSuite) TestUpdateEntity_GetAfterUpdateFails_ViaOldPath() {
 	e := testEntity("uc3")
+	s.store.On("GetEntity", mock.Anything, e.ID).Return(*e, nil).Once()
 	s.store.On("UpdateEntity", mock.Anything, e).Return(nil)
-	s.store.On("GetEntity", mock.Anything, e.ID).Return(providers.Entity{}, s.testErr)
+	s.store.On("GetEntity", mock.Anything, e.ID).Return(providers.Entity{}, s.testErr).Once()
 	_, err := s.svc.UpdateEntity(s.ctx, e.ID, e)
 	s.Error(err)
 }
@@ -613,4 +678,72 @@ func (s *ServiceTestSuite) TestGetTransitiveEntityGroups_ProviderError() {
 	_, err := s.svc.GetTransitiveEntityGroups(s.ctx, "user1")
 
 	s.ErrorIs(err, s.testErr)
+}
+
+// A system-attribute blob the server cannot parse must fail the credential write rather than silently
+// replacing the blob, which would drop the keys belonging to whichever service owns the entity.
+func (s *ServiceTestSuite) TestSetCredentialUpdatedAt_CorruptBlobErrors() {
+	_, err := setCredentialUpdatedAt(json.RawMessage(`not json`), time.Now().UTC())
+	s.Error(err)
+}
+
+// An absent blob is normal for an entity that has never carried system attributes.
+func (s *ServiceTestSuite) TestSetCredentialUpdatedAt_EmptyBlobStartsFresh() {
+	marked, err := setCredentialUpdatedAt(nil, time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC))
+	s.Require().NoError(err)
+
+	var attrs map[string]interface{}
+	s.Require().NoError(json.Unmarshal(marked, &attrs))
+	s.Equal("2026-08-12T10:00:00Z", attrs[authnprovidercm.SystemAttrCredentialUpdatedAt])
+}
+
+// A service that rebuilds an entity's whole system-attribute blob, such as an application rename,
+// must not drop the credential-change marker this package owns.
+func (s *ServiceTestSuite) TestUpdateSystemAttributes_PreservesCredentialMarker() {
+	e := testEntity("e-preserve")
+	e.SystemAttributes = json.RawMessage(`{"name":"Old","credentialUpdatedAt":"2026-08-12T10:00:00Z"}`)
+	s.store.On("GetEntity", mock.Anything, e.ID).Return(*e, nil)
+
+	var written json.RawMessage
+	s.store.On("UpdateSystemAttributes", mock.Anything, e.ID, mock.AnythingOfType("json.RawMessage")).
+		Run(func(args mock.Arguments) { written, _ = args.Get(2).(json.RawMessage) }).Return(nil)
+
+	s.NoError(s.svc.UpdateSystemAttributes(s.ctx, e.ID, json.RawMessage(`{"name":"New"}`)))
+
+	var attrs map[string]interface{}
+	s.Require().NoError(json.Unmarshal(written, &attrs))
+	s.Equal("New", attrs["name"], "the caller's own keys are replaced")
+	s.Equal("2026-08-12T10:00:00Z", attrs[authnprovidercm.SystemAttrCredentialUpdatedAt])
+}
+
+// UpdateEntity replaces the blob too, so it carries the marker across as well.
+func (s *ServiceTestSuite) TestUpdateEntity_PreservesCredentialMarker() {
+	stored := testEntity("e-preserve-2")
+	stored.SystemAttributes = json.RawMessage(`{"credentialUpdatedAt":"2026-08-12T10:00:00Z"}`)
+	s.store.On("GetEntity", mock.Anything, stored.ID).Return(*stored, nil)
+	s.store.On("UpdateEntity", mock.Anything, mock.Anything).Return(nil)
+
+	incoming := testEntity("e-preserve-2")
+	incoming.SystemAttributes = json.RawMessage(`{"name":"Renamed"}`)
+	_, err := s.svc.UpdateEntity(s.ctx, incoming.ID, incoming)
+	s.Require().NoError(err)
+
+	var attrs map[string]interface{}
+	s.Require().NoError(json.Unmarshal(incoming.SystemAttributes, &attrs))
+	s.Equal("Renamed", attrs["name"])
+	s.Equal("2026-08-12T10:00:00Z", attrs[authnprovidercm.SystemAttrCredentialUpdatedAt])
+}
+
+// An entity with no marker recorded is written through untouched.
+func (s *ServiceTestSuite) TestUpdateSystemAttributes_NoMarkerPassesThrough() {
+	e := testEntity("e-nomarker")
+	e.SystemAttributes = json.RawMessage(`{"name":"Old"}`)
+	s.store.On("GetEntity", mock.Anything, e.ID).Return(*e, nil)
+
+	var written json.RawMessage
+	s.store.On("UpdateSystemAttributes", mock.Anything, e.ID, mock.AnythingOfType("json.RawMessage")).
+		Run(func(args mock.Arguments) { written, _ = args.Get(2).(json.RawMessage) }).Return(nil)
+
+	s.NoError(s.svc.UpdateSystemAttributes(s.ctx, e.ID, json.RawMessage(`{"name":"New"}`)))
+	s.JSONEq(`{"name":"New"}`, string(written))
 }

--- a/backend/internal/oauth/oauth2/granthandlers/provider.go
+++ b/backend/internal/oauth/oauth2/granthandlers/provider.go
@@ -61,7 +61,7 @@ func newGrantHandlerProvider(
 	if isGrantTypeAllowed(allowedGrantTypes, providers.GrantTypeRefreshToken) {
 		grantProvider.refreshTokenGrantHandler = newRefreshTokenGrantHandler(
 			jwtService, tokenBuilder, tokenValidator, attrCacheService, resourceService,
-			refreshTokenRevoker, criteriaRevoker, cfg)
+			rbacAuthzService, actorProvider, refreshTokenRevoker, criteriaRevoker, cfg)
 	}
 	if isGrantTypeAllowed(allowedGrantTypes, providers.GrantTypeTokenExchange) {
 		grantProvider.tokenExchangeGrantHandler = newTokenExchangeGrantHandler(

--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
@@ -5,6 +5,7 @@ package granthandlers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"slices"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
 	"github.com/thunder-id/thunderid/internal/attributecache"
+	authnprovidercm "github.com/thunder-id/thunderid/internal/authnprovider/common"
 	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/dpop"
@@ -34,6 +36,8 @@ type refreshTokenGrantHandler struct {
 	tokenValidator   tokenservice.TokenValidatorInterface
 	attrCacheService attributecache.AttributeCacheServiceInterface
 	resourceService  providers.ResourceServerProvider
+	authzService     providers.AuthorizationProvider
+	actorProvider    providers.ActorProvider
 	refreshRevoker   revocation.RefreshTokenRevokerInterface
 	criteriaRevoker  revocation.CriteriaRevokerInterface
 }
@@ -45,6 +49,8 @@ func newRefreshTokenGrantHandler(
 	tokenValidator tokenservice.TokenValidatorInterface,
 	attrCacheService attributecache.AttributeCacheServiceInterface,
 	resourceService providers.ResourceServerProvider,
+	authzService providers.AuthorizationProvider,
+	actorProvider providers.ActorProvider,
 	refreshRevoker revocation.RefreshTokenRevokerInterface,
 	criteriaRevoker revocation.CriteriaRevokerInterface,
 	cfg oauthconfig.Config,
@@ -56,6 +62,8 @@ func newRefreshTokenGrantHandler(
 		tokenValidator:   tokenValidator,
 		attrCacheService: attrCacheService,
 		resourceService:  resourceService,
+		authzService:     authzService,
+		actorProvider:    actorProvider,
 		refreshRevoker:   refreshRevoker,
 		criteriaRevoker:  criteriaRevoker,
 	}
@@ -125,6 +133,11 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 		return nil, errResp
 	}
 
+	subjectEntity, errResp := h.verifyCredentialsUnchanged(ctx, refreshTokenClaims, oauthApp, logger)
+	if errResp != nil {
+		return nil, errResp
+	}
+
 	newTokenScopes, scopeErr := h.validateAndApplyScopes(ctx, tokenRequest.Scope, refreshTokenClaims.Scopes, logger)
 	if scopeErr != nil {
 		return nil, scopeErr
@@ -179,9 +192,14 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 		if scopeErr != nil {
 			return nil, scopeErr
 		}
-		newTokenScopes = make([]string, 0, len(oidcScopes)+len(downscopedNonOidc))
+		authorizedNonOidc, authzErr := h.reauthorizeScopes(
+			ctx, subjectEntity, targetRS.ID, downscopedNonOidc, logger)
+		if authzErr != nil {
+			return nil, authzErr
+		}
+		newTokenScopes = make([]string, 0, len(oidcScopes)+len(authorizedNonOidc))
 		newTokenScopes = append(newTokenScopes, oidcScopes...)
-		newTokenScopes = append(newTokenScopes, downscopedNonOidc...)
+		newTokenScopes = append(newTokenScopes, authorizedNonOidc...)
 	}
 
 	// Get user attributes from attribute cache.
@@ -435,6 +453,194 @@ func (h *refreshTokenGrantHandler) extendCacheTTL(
 		}
 	}
 	return nil
+}
+
+// verifyCredentialsUnchanged rejects a refresh token established at or before the user's password or
+// the client's secret last changed. It returns the subject's entity for reauthorizeScopes to reuse.
+func (h *refreshTokenGrantHandler) verifyCredentialsUnchanged(ctx context.Context,
+	claims *tokenservice.RefreshTokenClaims, oauthApp *providers.OAuthClient,
+	logger *log.Logger) (*providers.Entity, *model.ErrorResponse) {
+	if h.actorProvider == nil {
+		return nil, nil
+	}
+
+	subjectEntity, errResp := h.resolveSubjectEntity(ctx, claims.Sub, oauthApp, logger)
+	if errResp != nil {
+		return nil, errResp
+	}
+	if credentialChangedSince(ctx, subjectEntity, claims.Iat, logger) {
+		logger.Debug(ctx, "Rejecting refresh token established before a user credential change")
+		return nil, &model.ErrorResponse{
+			Error:            constants.ErrorInvalidGrant,
+			ErrorDescription: "Invalid refresh token",
+		}
+	}
+
+	if oauthApp == nil || oauthApp.ID == "" || oauthApp.ID == claims.Sub {
+		return subjectEntity, nil
+	}
+	clientEntity, svcErr := h.actorProvider.GetActor(oauthApp.ID)
+	if svcErr != nil {
+		logger.Error(ctx, "Failed to resolve the refresh token client",
+			log.String("error", svcErr.Error.DefaultValue))
+		return nil, &model.ErrorResponse{
+			Error:            constants.ErrorServerError,
+			ErrorDescription: "Failed to verify credential state",
+		}
+	}
+	if credentialChangedSince(ctx, clientEntity, claims.Iat, logger) {
+		logger.Debug(ctx, "Rejecting refresh token established before a client secret rotation")
+		return nil, &model.ErrorResponse{
+			Error:            constants.ErrorInvalidGrant,
+			ErrorDescription: "Invalid refresh token",
+		}
+	}
+	return subjectEntity, nil
+}
+
+// resolveSubjectEntity resolves the token's subject to its entity, or nil when it does not name one.
+//
+// sub is not always an entity ID: a client can map it to a user attribute
+// (InboundClient.SubjectAttribute). An unresolvable subject is therefore ambiguous, and the client's
+// mapping settles it. A client that maps nothing can only have issued an entity ID, so the subject
+// is gone.
+func (h *refreshTokenGrantHandler) resolveSubjectEntity(ctx context.Context, subject string,
+	oauthApp *providers.OAuthClient, logger *log.Logger) (*providers.Entity, *model.ErrorResponse) {
+	if subject == "" {
+		return nil, nil
+	}
+
+	entity, svcErr := h.actorProvider.GetActor(subject)
+	if svcErr == nil {
+		return entity, nil
+	}
+	if svcErr.Type != tidcommon.ClientErrorType {
+		logger.Error(ctx, "Failed to resolve refresh token subject",
+			log.String("error", svcErr.Error.DefaultValue))
+		return nil, &model.ErrorResponse{
+			Error:            constants.ErrorServerError,
+			ErrorDescription: "Failed to resolve the refresh token subject",
+		}
+	}
+
+	mapsSubject, errResp := h.clientMapsSubject(ctx, oauthApp, logger)
+	if errResp != nil {
+		return nil, errResp
+	}
+	if mapsSubject {
+		logger.Debug(ctx, "Refresh token subject is a mapped value; skipping subject-derived checks")
+		return nil, nil
+	}
+
+	logger.Debug(ctx, "Refresh token subject no longer exists")
+	return nil, &model.ErrorResponse{
+		Error:            constants.ErrorInvalidGrant,
+		ErrorDescription: "Invalid refresh token",
+	}
+}
+
+// clientMapsSubject reports whether the client maps the token subject to a user attribute. An
+// unidentifiable client reports true, since the caller rejects on false.
+func (h *refreshTokenGrantHandler) clientMapsSubject(ctx context.Context,
+	oauthApp *providers.OAuthClient, logger *log.Logger) (bool, *model.ErrorResponse) {
+	if oauthApp == nil || oauthApp.ID == "" {
+		return true, nil
+	}
+
+	client, svcErr := h.actorProvider.GetInboundClientByID(ctx, oauthApp.ID)
+	if svcErr != nil {
+		logger.Error(ctx, "Failed to resolve the client's subject mapping",
+			log.String("error", svcErr.Error.DefaultValue))
+		return false, &model.ErrorResponse{
+			Error:            constants.ErrorServerError,
+			ErrorDescription: "Failed to resolve the refresh token subject",
+		}
+	}
+	return client != nil && len(client.SubjectAttribute) > 0, nil
+}
+
+// credentialChangedSince reports whether the entity's credential changed at or after iat, which has
+// second granularity, so a change in the same second counts. An absent marker reports false. So does
+// an unreadable one, since locking the entity out is the worse failure, but that is a data fault and
+// is logged.
+func credentialChangedSince(ctx context.Context, entity *providers.Entity, iat int64,
+	logger *log.Logger) bool {
+	if entity == nil || len(entity.SystemAttributes) == 0 {
+		return false
+	}
+	var attrs map[string]interface{}
+	if err := json.Unmarshal(entity.SystemAttributes, &attrs); err != nil {
+		logger.Error(ctx, "Failed to parse system attributes while reading the credential marker",
+			log.MaskedString(log.LoggerKeyUserID, entity.ID), log.Error(err))
+		return false
+	}
+	value, present := attrs[authnprovidercm.SystemAttrCredentialUpdatedAt]
+	if !present {
+		return false
+	}
+	raw, ok := value.(string)
+	if !ok || raw == "" {
+		logger.Error(ctx, "Credential marker is not a non-empty string",
+			log.MaskedString(log.LoggerKeyUserID, entity.ID))
+		return false
+	}
+	changedAt, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		logger.Error(ctx, "Credential marker is not a valid RFC 3339 timestamp",
+			log.MaskedString(log.LoggerKeyUserID, entity.ID), log.Error(err))
+		return false
+	}
+	return iat <= changedAt.UTC().Unix()
+}
+
+// reauthorizeScopes re-evaluates the subject's permission scopes against their current role and group
+// assignments, dropping the ones they no longer hold.
+func (h *refreshTokenGrantHandler) reauthorizeScopes(ctx context.Context, subjectEntity *providers.Entity,
+	resourceServerID string, scopes []string, logger *log.Logger) ([]string, *model.ErrorResponse) {
+	// An unresolved subject (a mapped sub) would authorize nothing and strip every scope.
+	if len(scopes) == 0 || h.authzService == nil || subjectEntity == nil || subjectEntity.ID == "" {
+		return scopes, nil
+	}
+	subject := subjectEntity.ID
+
+	// Roles reach a subject directly and through their groups, so both are evaluated together.
+	groups, groupErr := h.actorProvider.GetActorGroups(subject)
+	if groupErr != nil {
+		logger.Error(ctx, "Failed to resolve group memberships for refresh token subject",
+			log.MaskedString(log.LoggerKeyUserID, subject),
+			log.String("error", groupErr.Error.DefaultValue))
+		return nil, &model.ErrorResponse{
+			Error:            constants.ErrorServerError,
+			ErrorDescription: "Failed to generate token",
+		}
+	}
+	var groupIDs []string
+	for _, group := range groups {
+		if group.ID != "" && !slices.Contains(groupIDs, group.ID) {
+			groupIDs = append(groupIDs, group.ID)
+		}
+	}
+
+	authzResp, svcErr := h.authzService.EvaluateAccessBatch(ctx,
+		buildAccessEvaluationsRequest(subject, groupIDs, scopes, resourceServerID))
+	if svcErr != nil {
+		logger.Error(ctx, "Failed to evaluate authorized permissions for refresh token subject",
+			log.MaskedString(log.LoggerKeyUserID, subject),
+			log.String("error", svcErr.Error.DefaultValue))
+		return nil, &model.ErrorResponse{
+			Error:            constants.ErrorServerError,
+			ErrorDescription: "Failed to generate token",
+		}
+	}
+
+	authorizedScopes := filterAuthorizedScopes(scopes, authzResp.Evaluations)
+	if len(authorizedScopes) != len(scopes) {
+		logger.Debug(ctx, "Dropped permission scopes the subject is no longer authorized for",
+			log.MaskedString(log.LoggerKeyUserID, subject),
+			log.Int("grantedCount", len(scopes)),
+			log.Int("authorizedCount", len(authorizedScopes)))
+	}
+	return authorizedScopes, nil
 }
 
 // validateAndApplyScopes validates and applies OAuth2 scope downscoping logic per RFC 6749 §6.

--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token_test.go
@@ -6,6 +6,7 @@ package granthandlers
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -20,6 +21,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/attributecache"
+	authnprovidercm "github.com/thunder-id/thunderid/internal/authnprovider/common"
 	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/dpop"
@@ -28,7 +30,9 @@ import (
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/tokenservice"
 	"github.com/thunder-id/thunderid/internal/system/config"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/tests/mocks/actorprovidermock"
 	"github.com/thunder-id/thunderid/tests/mocks/attributecachemock"
+	"github.com/thunder-id/thunderid/tests/mocks/authzmock"
 	"github.com/thunder-id/thunderid/tests/mocks/jose/jwtmock"
 	"github.com/thunder-id/thunderid/tests/mocks/oauth/oauth2/revocationmock"
 	"github.com/thunder-id/thunderid/tests/mocks/oauth/oauth2/tokenservicemock"
@@ -41,6 +45,7 @@ const testRefreshTokenUserID = "test-user-id"
 const testRefreshTokenAudience = "test-audience"
 const testRefreshTokenClientID = "test-client-id"
 const testRS01URI = "https://rs01.example.com"
+const testAppEntityID = "app-entity-id"
 const testRS02URI = "https://rs02.example.com"
 
 func boolPtr(b bool) *bool { return &b }
@@ -54,6 +59,8 @@ type RefreshTokenGrantHandlerTestSuite struct {
 	mockTokenValidator   *tokenservicemock.TokenValidatorInterfaceMock
 	mockAttrCacheService *attributecachemock.AttributeCacheServiceInterfaceMock
 	mockResourceService  *resourcemock.ResourceServiceInterfaceMock
+	mockAuthzService     *authzmock.AuthorizationProviderMock
+	mockActorProvider    *actorprovidermock.ActorProviderMock
 	mockRefreshRevoker   *revocationmock.RefreshTokenRevokerInterfaceMock
 	mockCriteriaRevoker  *revocationmock.CriteriaRevokerInterfaceMock
 	oauthApp             *providers.OAuthClient
@@ -90,6 +97,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) SetupTest() {
 	suite.mockTokenValidator = tokenservicemock.NewTokenValidatorInterfaceMock(suite.T())
 	suite.mockAttrCacheService = attributecachemock.NewAttributeCacheServiceInterfaceMock(suite.T())
 	suite.mockResourceService = resourcemock.NewResourceServiceInterfaceMock(suite.T())
+	suite.mockAuthzService = authzmock.NewAuthorizationProviderMock(suite.T())
+	suite.mockActorProvider = actorprovidermock.NewActorProviderMock(suite.T())
 	suite.mockRefreshRevoker = revocationmock.NewRefreshTokenRevokerInterfaceMock(suite.T())
 	suite.mockCriteriaRevoker = revocationmock.NewCriteriaRevokerInterfaceMock(suite.T())
 
@@ -101,6 +110,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) SetupTest() {
 		}).Maybe()
 	suite.mockResourceService.On("ValidatePermissions", mock.Anything, mock.Anything, mock.Anything).
 		Return([]string{}, nil).Maybe()
+
+	suite.installPermissiveAuthzStubs()
 
 	suite.rebuildHandlerWithConfig()
 
@@ -142,6 +153,32 @@ func (suite *RefreshTokenGrantHandlerTestSuite) SetupTest() {
 	}
 }
 
+// allowAllEvaluations authorizes every permission in the evaluation request.
+func allowAllEvaluations(_ context.Context,
+	request providers.AccessEvaluationsRequest) *providers.AccessEvaluationsResponse {
+	evaluations := make([]providers.AccessEvaluationResponse, 0, len(request.Evaluations))
+	for range request.Evaluations {
+		evaluations = append(evaluations, providers.AccessEvaluationResponse{Decision: true})
+	}
+	return &providers.AccessEvaluationsResponse{Evaluations: evaluations}
+}
+
+// installPermissiveAuthzStubs defaults the subject to one that still exists, has had no credential
+// change, and still holds every permission scope on the refresh token, so tests that are not about
+// re-authorization or credential changes keep exercising the scopes they set up.
+func (suite *RefreshTokenGrantHandlerTestSuite) installPermissiveAuthzStubs() {
+	suite.mockActorProvider.On("GetActor", mock.Anything).
+		Return(func(actorID string) *providers.Entity {
+			return &providers.Entity{ID: actorID}
+		}, nil).Maybe()
+	suite.mockActorProvider.On("GetActorGroups", mock.Anything).
+		Return([]providers.EntityGroup{}, nil).Maybe()
+	suite.mockAuthzService.On("EvaluateAccessBatch", mock.Anything, mock.Anything).
+		Return(allowAllEvaluations, nil).Maybe()
+	suite.mockActorProvider.On("GetInboundClientByID", mock.Anything, mock.Anything).
+		Return(&providers.InboundClient{}, nil).Maybe()
+}
+
 func (suite *RefreshTokenGrantHandlerTestSuite) rebuildHandlerWithConfig() {
 	suite.handler = newRefreshTokenGrantHandler(
 		suite.mockJWTService,
@@ -149,6 +186,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) rebuildHandlerWithConfig() {
 		suite.mockTokenValidator,
 		suite.mockAttrCacheService,
 		suite.mockResourceService,
+		suite.mockAuthzService,
+		suite.mockActorProvider,
 		suite.mockRefreshRevoker,
 		suite.mockCriteriaRevoker,
 		suite.testCfg,
@@ -164,7 +203,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestNewRefreshTokenGrantHandler(
 		suite.mockTokenBuilder,
 		suite.mockTokenValidator,
 		suite.mockAttrCacheService,
-		suite.mockResourceService, suite.mockRefreshRevoker,
+		suite.mockResourceService, suite.mockAuthzService,
+		suite.mockActorProvider, suite.mockRefreshRevoker,
 		suite.mockCriteriaRevoker, testhelpers.OAuthConfig())
 	assert.NotNil(suite.T(), handler)
 	assert.Implements(suite.T(), (*RefreshTokenGrantHandlerInterface)(nil), handler)
@@ -405,7 +445,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_AgentClien
 
 func (suite *RefreshTokenGrantHandlerTestSuite) TestIssueRefreshToken_AppClientWithoutFlagOmitsActorSub() {
 	appApp := &providers.OAuthClient{
-		ID:                      "app-entity-id",
+		ID:                      testAppEntityID,
 		ClientID:                testRefreshTokenClientID,
 		EntityCategory:          "app",
 		IncludeActClaim:         false,
@@ -470,7 +510,7 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_NoActorSubMarker
 	// Freeze-at-issuance: a refresh token issued without the marker must not gain an act claim
 	// even if the client now opts into act claims.
 	appWithFlagOn := &providers.OAuthClient{
-		ID:                      "app-entity-id",
+		ID:                      testAppEntityID,
 		ClientID:                testRefreshTokenClientID,
 		EntityCategory:          "app",
 		IncludeActClaim:         true,
@@ -630,6 +670,8 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RevokePreviousOn
 		suite.mockTokenValidator,
 		suite.mockAttrCacheService,
 		suite.mockResourceService,
+		suite.mockAuthzService,
+		suite.mockActorProvider,
 		nil,
 		nil,
 		suite.testCfg,
@@ -2042,4 +2084,561 @@ func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_DownscopeValidat
 	assert.Nil(suite.T(), response)
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), constants.ErrorServerError, err.Error)
+}
+
+// resetAuthzMocks replaces the permissive authorization stubs installed by SetupTest, so a test can
+// assert on the evaluation itself rather than have the catch-all expectation shadow it.
+func (suite *RefreshTokenGrantHandlerTestSuite) resetAuthzMocks() {
+	suite.mockAuthzService = authzmock.NewAuthorizationProviderMock(suite.T())
+	suite.mockActorProvider = actorprovidermock.NewActorProviderMock(suite.T())
+	suite.mockActorProvider.On("GetActor", mock.Anything).
+		Return(func(actorID string) *providers.Entity {
+			return &providers.Entity{ID: actorID}
+		}, nil).Maybe()
+	suite.rebuildHandlerWithConfig()
+}
+
+// A permission scope the subject no longer holds is dropped from the refreshed access token, even
+// though it is still carried by the refresh token from the original grant.
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_DropsScopesNoLongerAuthorized() {
+	suite.resetAuthzMocks()
+	suite.refreshClaimsValid()
+
+	suite.mockActorProvider.On("GetActorGroups", testRefreshTokenUserID).
+		Return([]providers.EntityGroup{}, nil)
+	mockEvaluateAccessBatch(suite.mockAuthzService, testRefreshTokenUserID, testRefreshTokenAudience,
+		[]string{"read", "write"}, []string{"read"})
+
+	var grantedScopes []string
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.MatchedBy(
+		func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			grantedScopes = ctx.Scopes
+			return true
+		})).Return(&model.TokenDTO{
+		Token: "new.access.token", IssuedAt: time.Now().Unix(), ExpiresIn: 3600,
+	}, nil)
+
+	req := &model.TokenRequest{
+		GrantType:    string(providers.GrantTypeRefreshToken),
+		ClientID:     testRefreshTokenClientID,
+		RefreshToken: suite.validRefreshToken,
+	}
+	response, err := suite.handler.HandleGrant(context.Background(), req, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	suite.Require().NotNil(response)
+	assert.Equal(suite.T(), []string{"read"}, grantedScopes)
+	suite.mockAuthzService.AssertExpectations(suite.T())
+}
+
+// The rotated refresh token carries the narrowed scopes, so a revoked permission does not come back
+// on the next refresh.
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RotatedRefreshTokenCarriesNarrowedScopes() {
+	suite.testCfg.OAuth.RefreshToken.RenewOnGrant = true
+	suite.resetAuthzMocks()
+	suite.refreshClaimsValid()
+
+	suite.mockActorProvider.On("GetActorGroups", testRefreshTokenUserID).
+		Return([]providers.EntityGroup{}, nil)
+	mockEvaluateAccessBatch(suite.mockAuthzService, testRefreshTokenUserID, testRefreshTokenAudience,
+		[]string{"read", "write"}, []string{"read"})
+
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
+		Token: "new.access.token", IssuedAt: time.Now().Unix(), ExpiresIn: 3600,
+	}, nil)
+	var refreshScopes []string
+	suite.mockTokenBuilder.On("BuildRefreshToken", mock.Anything, mock.MatchedBy(
+		func(ctx *tokenservice.RefreshTokenBuildContext) bool {
+			refreshScopes = ctx.Scopes
+			return true
+		})).Return(&model.TokenDTO{
+		Token: "new.refresh.token", IssuedAt: time.Now().Unix(), ExpiresIn: 86400,
+	}, nil)
+
+	req := &model.TokenRequest{
+		GrantType:    string(providers.GrantTypeRefreshToken),
+		ClientID:     testRefreshTokenClientID,
+		RefreshToken: suite.validRefreshToken,
+	}
+	response, err := suite.handler.HandleGrant(context.Background(), req, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	suite.Require().NotNil(response)
+	assert.Equal(suite.T(), []string{"read"}, refreshScopes)
+}
+
+// Permissions held through a group are evaluated, so the subject's transitive group memberships are
+// resolved and passed to the authorization service.
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_EvaluatesWithSubjectGroups() {
+	suite.resetAuthzMocks()
+	suite.refreshClaimsValid()
+
+	suite.mockActorProvider.On("GetActorGroups", testRefreshTokenUserID).
+		Return([]providers.EntityGroup{{ID: "group-1"}, {ID: "group-2"}, {ID: ""}}, nil)
+
+	var evaluatedGroupIDs []string
+	suite.mockAuthzService.On("EvaluateAccessBatch", mock.Anything, mock.MatchedBy(
+		func(req providers.AccessEvaluationsRequest) bool {
+			suite.Require().NotEmpty(req.Evaluations)
+			evaluatedGroupIDs = req.Evaluations[0].Subject.GroupIDs
+			return true
+		})).Return(allowAllEvaluations, nil)
+
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
+		Token: "new.access.token", IssuedAt: time.Now().Unix(), ExpiresIn: 3600,
+	}, nil)
+
+	_, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), []string{"group-1", "group-2"}, evaluatedGroupIDs)
+}
+
+// OIDC scopes are not permission scopes, so they survive even when the subject holds no permissions
+// on the bound resource server.
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_OIDCScopesSurviveDeauthorization() {
+	suite.resetAuthzMocks()
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
+		Return(&tokenservice.RefreshTokenClaims{
+			Sub:       testRefreshTokenUserID,
+			Audiences: []string{testRefreshTokenAudience},
+			Scopes:    []string{"openid", "read"},
+			GrantType: "authorization_code",
+			Iat:       int64(suite.validClaims["iat"].(float64)),
+		}, nil)
+
+	suite.mockActorProvider.On("GetActorGroups", testRefreshTokenUserID).
+		Return([]providers.EntityGroup{}, nil)
+	mockEvaluateAccessBatch(suite.mockAuthzService, testRefreshTokenUserID, testRefreshTokenAudience,
+		[]string{"read"}, []string{})
+
+	var grantedScopes []string
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.MatchedBy(
+		func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			grantedScopes = ctx.Scopes
+			return true
+		})).Return(&model.TokenDTO{
+		Token: "new.access.token", IssuedAt: time.Now().Unix(), ExpiresIn: 3600,
+	}, nil)
+	suite.mockTokenBuilder.On("BuildIDToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
+		Token: "new.id.token", IssuedAt: time.Now().Unix(), ExpiresIn: 3600,
+	}, nil)
+
+	req := &model.TokenRequest{
+		GrantType:    string(providers.GrantTypeRefreshToken),
+		ClientID:     testRefreshTokenClientID,
+		RefreshToken: suite.validRefreshToken,
+	}
+	response, err := suite.handler.HandleGrant(context.Background(), req, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	suite.Require().NotNil(response)
+	assert.Equal(suite.T(), []string{"openid"}, grantedScopes)
+	assert.Equal(suite.T(), "new.id.token", response.IDToken.Token)
+}
+
+// A token bound to the client rather than a resource server carries no permission scopes, so there is
+// nothing to re-evaluate and the authorization service is not called.
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_NoReauthorizationWithoutResourceServer() {
+	suite.resetAuthzMocks()
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
+		Return(&tokenservice.RefreshTokenClaims{
+			Sub:       testRefreshTokenUserID,
+			Audiences: []string{testRefreshTokenClientID},
+			Scopes:    []string{"openid"},
+			GrantType: "authorization_code",
+			Iat:       int64(suite.validClaims["iat"].(float64)),
+		}, nil)
+
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
+		Token: "new.access.token", IssuedAt: time.Now().Unix(), ExpiresIn: 3600,
+	}, nil)
+	suite.mockTokenBuilder.On("BuildIDToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
+		Token: "new.id.token", IssuedAt: time.Now().Unix(), ExpiresIn: 3600,
+	}, nil)
+
+	req := &model.TokenRequest{
+		GrantType:    string(providers.GrantTypeRefreshToken),
+		ClientID:     testRefreshTokenClientID,
+		RefreshToken: suite.validRefreshToken,
+	}
+	_, err := suite.handler.HandleGrant(context.Background(), req, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	suite.mockAuthzService.AssertNotCalled(suite.T(), "EvaluateAccessBatch", mock.Anything, mock.Anything)
+}
+
+// The authorization decision cannot be skipped when it is unavailable: a failing evaluation must not
+// fall back to the scopes frozen in the refresh token.
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_AuthorizationFailureFailsClosed() {
+	suite.resetAuthzMocks()
+	suite.refreshClaimsValid()
+
+	suite.mockActorProvider.On("GetActorGroups", testRefreshTokenUserID).
+		Return([]providers.EntityGroup{}, nil)
+	suite.mockAuthzService.On("EvaluateAccessBatch", mock.Anything, mock.Anything).
+		Return(nil, &tidcommon.ServiceError{
+			Type:  tidcommon.ServerErrorType,
+			Code:  "AUTHZ-5000",
+			Error: tidcommon.I18nMessage{DefaultValue: "authorization engine unavailable"},
+		})
+
+	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), response)
+	suite.Require().NotNil(err)
+	assert.Equal(suite.T(), constants.ErrorServerError, err.Error)
+}
+
+// Group memberships feed the authorization decision, so failing to resolve them must fail closed too.
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_GroupResolutionFailureFailsClosed() {
+	suite.resetAuthzMocks()
+	suite.refreshClaimsValid()
+
+	suite.mockActorProvider.On("GetActorGroups", testRefreshTokenUserID).
+		Return(nil, &tidcommon.ServiceError{
+			Type:  tidcommon.ServerErrorType,
+			Code:  "ENTITY-5000",
+			Error: tidcommon.I18nMessage{DefaultValue: "group lookup failed"},
+		})
+
+	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), response)
+	suite.Require().NotNil(err)
+	assert.Equal(suite.T(), constants.ErrorServerError, err.Error)
+}
+
+// resetActorMocks installs fresh authorization stubs without a catch-all GetActor, so a test can
+// control what the credential-change check sees.
+func (suite *RefreshTokenGrantHandlerTestSuite) resetActorMocks() {
+	suite.mockAuthzService = authzmock.NewAuthorizationProviderMock(suite.T())
+	suite.mockActorProvider = actorprovidermock.NewActorProviderMock(suite.T())
+	suite.mockActorProvider.On("GetActorGroups", mock.Anything).
+		Return([]providers.EntityGroup{}, nil).Maybe()
+	suite.mockAuthzService.On("EvaluateAccessBatch", mock.Anything, mock.Anything).
+		Return(allowAllEvaluations, nil).Maybe()
+	suite.rebuildHandlerWithConfig()
+}
+
+// entityMarkedAt returns an entity whose credential last changed at the given time.
+func entityMarkedAt(id string, at time.Time) *providers.Entity {
+	attrs, _ := json.Marshal(map[string]interface{}{
+		authnprovidercm.SystemAttrCredentialUpdatedAt: at.UTC().Format(time.RFC3339),
+	})
+	return &providers.Entity{ID: id, SystemAttributes: attrs}
+}
+
+// A refresh token established before the user's password was reset is no longer honored.
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RejectsTokenPredatingPasswordReset() {
+	suite.resetActorMocks()
+	suite.refreshClaimsValid()
+	suite.mockActorProvider.On("GetActor", testRefreshTokenUserID).
+		Return(entityMarkedAt(testRefreshTokenUserID, time.Now()), nil)
+
+	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), response)
+	suite.Require().NotNil(err)
+	assert.Equal(suite.T(), constants.ErrorInvalidGrant, err.Error)
+}
+
+// A token established after the reset is the one the user got by re-authenticating, so it stands.
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_AllowsTokenIssuedAfterPasswordReset() {
+	suite.resetActorMocks()
+	suite.refreshClaimsValid()
+	suite.mockActorProvider.On("GetActor", testRefreshTokenUserID).
+		Return(entityMarkedAt(testRefreshTokenUserID, time.Now().Add(-2*time.Hour)), nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
+		Token: "new.access.token", IssuedAt: time.Now().Unix(), ExpiresIn: 3600,
+	}, nil)
+
+	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), response)
+}
+
+// A client secret rotation invalidates the tokens issued to that client, not just the user's.
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RejectsTokenPredatingClientSecretRotation() {
+	suite.resetActorMocks()
+	suite.refreshClaimsValid()
+	appWithID := *suite.oauthApp
+	appWithID.ID = testAppEntityID
+	suite.mockActorProvider.On("GetActor", testRefreshTokenUserID).
+		Return(&providers.Entity{ID: testRefreshTokenUserID}, nil)
+	suite.mockActorProvider.On("GetActor", appWithID.ID).
+		Return(entityMarkedAt(appWithID.ID, time.Now()), nil)
+
+	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, &appWithID)
+
+	assert.Nil(suite.T(), response)
+	suite.Require().NotNil(err)
+	assert.Equal(suite.T(), constants.ErrorInvalidGrant, err.Error)
+}
+
+// An application can map sub to a user attribute, so the token carries a value that is not an entity
+// ID. Rejecting those would break every refresh for such an application, so the subject-derived checks
+// are skipped instead.
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_SkipsChecksForMappedSubject() {
+	suite.resetActorMocks()
+	suite.refreshClaimsValid()
+	suite.mockActorProvider.On("GetActor", testRefreshTokenUserID).
+		Return(nil, &tidcommon.ServiceError{
+			Type:  tidcommon.ClientErrorType,
+			Code:  "ACP-1002",
+			Error: tidcommon.I18nMessage{DefaultValue: "Entity not found"},
+		})
+	suite.mockActorProvider.On("GetInboundClientByID", mock.Anything, mock.Anything).
+		Return(&providers.InboundClient{
+			SubjectAttribute: map[string]string{"employee": "external_id"},
+		}, nil)
+	suite.mockActorProvider.On("GetActor", testAppEntityID).
+		Return(&providers.Entity{ID: testAppEntityID}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
+		Token: "new.access.token", IssuedAt: time.Now().Unix(), ExpiresIn: 3600,
+	}, nil)
+
+	appWithID := *suite.oauthApp
+	appWithID.ID = testAppEntityID
+	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, &appWithID)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), response)
+	suite.mockAuthzService.AssertNotCalled(suite.T(), "EvaluateAccessBatch", mock.Anything, mock.Anything)
+}
+
+// When the client maps no subject, the token can only have carried an entity ID, so a missing entity
+// means the subject is gone and the grant dies with it.
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_RejectsWhenSubjectNoLongerExists() {
+	suite.resetActorMocks()
+	suite.refreshClaimsValid()
+	suite.mockActorProvider.On("GetActor", testRefreshTokenUserID).
+		Return(nil, &tidcommon.ServiceError{
+			Type:  tidcommon.ClientErrorType,
+			Code:  "ACP-1002",
+			Error: tidcommon.I18nMessage{DefaultValue: "Entity not found"},
+		})
+	suite.mockActorProvider.On("GetInboundClientByID", mock.Anything, mock.Anything).
+		Return(&providers.InboundClient{}, nil)
+	suite.mockActorProvider.On("GetActor", testAppEntityID).
+		Return(&providers.Entity{ID: testAppEntityID}, nil).Maybe()
+
+	appWithID := *suite.oauthApp
+	appWithID.ID = testAppEntityID
+	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, &appWithID)
+
+	assert.Nil(suite.T(), response)
+	suite.Require().NotNil(err)
+	assert.Equal(suite.T(), constants.ErrorInvalidGrant, err.Error)
+}
+
+// A failed lookup must not be read as "no credential change recorded".
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_CredentialLookupFailureFailsClosed() {
+	suite.resetActorMocks()
+	suite.refreshClaimsValid()
+	suite.mockActorProvider.On("GetActor", testRefreshTokenUserID).
+		Return(nil, &tidcommon.ServiceError{
+			Type:  tidcommon.ServerErrorType,
+			Code:  "ACP-5000",
+			Error: tidcommon.I18nMessage{DefaultValue: "entity store unavailable"},
+		})
+
+	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), response)
+	suite.Require().NotNil(err)
+	assert.Equal(suite.T(), constants.ErrorServerError, err.Error)
+}
+
+// A marker the server cannot read is a data fault, not a recorded change. The refresh proceeds
+// rather than locking the entity out, so these cases must not reject.
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_UnreadableCredentialMarkerAllowsRefresh() {
+	for _, systemAttributes := range []string{
+		`{"credentialUpdatedAt":"not-a-timestamp"}`,
+		`{"credentialUpdatedAt":12345}`,
+		`{"credentialUpdatedAt":""}`,
+		`not json at all`,
+	} {
+		suite.resetActorMocks()
+		suite.refreshClaimsValid()
+		suite.mockActorProvider.On("GetActor", testRefreshTokenUserID).
+			Return(&providers.Entity{
+				ID:               testRefreshTokenUserID,
+				SystemAttributes: json.RawMessage(systemAttributes),
+			}, nil)
+		suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
+			Token: "new.access.token", IssuedAt: time.Now().Unix(), ExpiresIn: 3600,
+		}, nil).Once()
+
+		response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
+
+		assert.Nil(suite.T(), err, "unreadable marker %q must not reject the refresh", systemAttributes)
+		assert.NotNil(suite.T(), response)
+	}
+}
+
+// A subject entity without an ID cannot be an authorization subject. Evaluating one would authorize
+// nothing and strip every permission scope, so the granted scopes are kept instead.
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_SkipsReauthorizationForSubjectWithoutID() {
+	suite.resetActorMocks()
+	suite.refreshClaimsValid()
+	suite.mockActorProvider.On("GetActor", testRefreshTokenUserID).
+		Return(&providers.Entity{}, nil)
+
+	var grantedScopes []string
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.MatchedBy(
+		func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			grantedScopes = ctx.Scopes
+			return true
+		})).Return(&model.TokenDTO{
+		Token: "new.access.token", IssuedAt: time.Now().Unix(), ExpiresIn: 3600,
+	}, nil)
+
+	req := &model.TokenRequest{
+		GrantType:    string(providers.GrantTypeRefreshToken),
+		ClientID:     testRefreshTokenClientID,
+		RefreshToken: suite.validRefreshToken,
+	}
+	_, err := suite.handler.HandleGrant(context.Background(), req, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), []string{"read", "write"}, grantedScopes, "scopes must be kept, not stripped")
+	suite.mockAuthzService.AssertNotCalled(suite.T(), "EvaluateAccessBatch", mock.Anything, mock.Anything)
+}
+
+// Without an actor provider there is nothing to resolve the subject or the client against, so both
+// subject-derived checks are skipped rather than failing the grant.
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_NoActorProviderSkipsSubjectChecks() {
+	suite.handler = newRefreshTokenGrantHandler(
+		suite.mockJWTService, suite.mockTokenBuilder, suite.mockTokenValidator,
+		suite.mockAttrCacheService, suite.mockResourceService, nil, nil,
+		suite.mockRefreshRevoker, suite.mockCriteriaRevoker, suite.testCfg,
+	).(*refreshTokenGrantHandler)
+	suite.refreshClaimsValid()
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
+		Token: "new.access.token", IssuedAt: time.Now().Unix(), ExpiresIn: 3600,
+	}, nil)
+
+	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), response)
+}
+
+// A token with no subject has nothing to resolve, so the checks are skipped.
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_EmptySubjectSkipsChecks() {
+	suite.resetActorMocks()
+	suite.mockTokenValidator.
+		On("ValidateRefreshToken", mock.Anything, suite.validRefreshToken, testRefreshTokenClientID).
+		Return(&tokenservice.RefreshTokenClaims{
+			Sub:       "",
+			Audiences: []string{testRefreshTokenAudience},
+			Scopes:    []string{"read"},
+			GrantType: "authorization_code",
+			Iat:       int64(suite.validClaims["iat"].(float64)),
+		}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
+		Token: "new.access.token", IssuedAt: time.Now().Unix(), ExpiresIn: 3600,
+	}, nil)
+
+	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), response)
+	suite.mockActorProvider.AssertNotCalled(suite.T(), "GetActor", mock.Anything)
+}
+
+// The client authenticated moments ago, so a failed client lookup is an outage rather than a deleted
+// client. It must not be read as "no credential change recorded".
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_ClientLookupFailureFailsClosed() {
+	suite.resetActorMocks()
+	suite.refreshClaimsValid()
+	appWithID := *suite.oauthApp
+	appWithID.ID = testAppEntityID
+	suite.mockActorProvider.On("GetActor", testRefreshTokenUserID).
+		Return(&providers.Entity{ID: testRefreshTokenUserID}, nil)
+	suite.mockActorProvider.On("GetActor", testAppEntityID).
+		Return(nil, &tidcommon.ServiceError{
+			Type:  tidcommon.ServerErrorType,
+			Code:  "ACP-5000",
+			Error: tidcommon.I18nMessage{DefaultValue: "entity store unavailable"},
+		})
+
+	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, &appWithID)
+
+	assert.Nil(suite.T(), response)
+	suite.Require().NotNil(err)
+	assert.Equal(suite.T(), constants.ErrorServerError, err.Error)
+}
+
+// Deciding whether an unresolvable subject is a mapped value or a deleted entity depends on reading
+// the client's mapping. A failed read cannot be resolved either way, so the grant fails closed.
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_SubjectMappingLookupFailureFailsClosed() {
+	suite.resetActorMocks()
+	suite.refreshClaimsValid()
+	appWithID := *suite.oauthApp
+	appWithID.ID = testAppEntityID
+	suite.mockActorProvider.On("GetActor", testRefreshTokenUserID).
+		Return(nil, &tidcommon.ServiceError{
+			Type:  tidcommon.ClientErrorType,
+			Code:  "ACP-1002",
+			Error: tidcommon.I18nMessage{DefaultValue: "Entity not found"},
+		})
+	suite.mockActorProvider.On("GetInboundClientByID", mock.Anything, testAppEntityID).
+		Return(nil, &tidcommon.ServiceError{
+			Type:  tidcommon.ServerErrorType,
+			Code:  "ACP-5000",
+			Error: tidcommon.I18nMessage{DefaultValue: "inbound client store unavailable"},
+		})
+
+	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, &appWithID)
+
+	assert.Nil(suite.T(), response)
+	suite.Require().NotNil(err)
+	assert.Equal(suite.T(), constants.ErrorServerError, err.Error)
+}
+
+// A client that cannot be identified cannot be shown to map nothing, so an unresolvable subject is
+// skipped rather than rejected.
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_UnidentifiableClientSkipsSubjectChecks() {
+	suite.resetActorMocks()
+	suite.refreshClaimsValid()
+	suite.mockActorProvider.On("GetActor", testRefreshTokenUserID).
+		Return(nil, &tidcommon.ServiceError{
+			Type:  tidcommon.ClientErrorType,
+			Code:  "ACP-1002",
+			Error: tidcommon.I18nMessage{DefaultValue: "Entity not found"},
+		})
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
+		Token: "new.access.token", IssuedAt: time.Now().Unix(), ExpiresIn: 3600,
+	}, nil)
+
+	// suite.oauthApp carries no entity ID, so the mapping cannot be read.
+	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), response)
+	suite.mockActorProvider.AssertNotCalled(suite.T(), "GetInboundClientByID", mock.Anything, mock.Anything)
+}
+
+// An entity carrying other system attributes but no marker has had no credential change recorded.
+func (suite *RefreshTokenGrantHandlerTestSuite) TestHandleGrant_SystemAttributesWithoutMarkerAllowRefresh() {
+	suite.resetActorMocks()
+	suite.refreshClaimsValid()
+	suite.mockActorProvider.On("GetActor", testRefreshTokenUserID).
+		Return(&providers.Entity{
+			ID:               testRefreshTokenUserID,
+			SystemAttributes: json.RawMessage(`{"name":"Some App","clientId":"abc"}`),
+		}, nil)
+	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything, mock.Anything).Return(&model.TokenDTO{
+		Token: "new.access.token", IssuedAt: time.Now().Unix(), ExpiresIn: 3600,
+	}, nil)
+
+	response, err := suite.handler.HandleGrant(context.Background(), suite.testTokenReq, suite.oauthApp)
+
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), response)
 }

--- a/docs/content/guides/applications/application-settings.mdx
+++ b/docs/content/guides/applications/application-settings.mdx
@@ -123,7 +123,7 @@ Client secrets are only present on confidential clients: Full-stack App and Back
 If you need to invalidate the current client secret, open the General tab and click **Regenerate Client Secret** in the **Danger Zone**.
 
 :::warning
-The current client secret is immediately invalidated. Any running clients using the old secret will lose access. Update your application configuration right away.
+The current client secret is immediately invalidated. Any running clients using the old secret will lose access. Refresh tokens issued before the rotation are rejected, so their users must sign in again. Update your application configuration right away.
 :::
 
 ## Review OAuth 2.0 Configuration

--- a/docs/content/guides/applications/manage-applications.mdx
+++ b/docs/content/guides/applications/manage-applications.mdx
@@ -117,7 +117,7 @@ To update an application:
 2. Update the relevant settings. Learn more about each setting in [Application Settings](../application-settings).
 3. Click **Save**.
 
-Changes take effect immediately for new authentication requests. Active sessions and issued tokens are not affected until they expire.
+Changes take effect immediately for new authentication requests. Active sessions and issued access tokens are not affected until they expire. Rotating the client secret is the exception: it also rejects refresh tokens issued before the rotation.
 
 ## Delete an Application
 

--- a/docs/content/guides/protocols/oauth-oidc/refresh-token.mdx
+++ b/docs/content/guides/protocols/oauth-oidc/refresh-token.mdx
@@ -41,6 +41,23 @@ Response (rotation enabled):
 }
 ```
 
+## Authorization on Refresh
+
+Each refresh re-evaluates the subject's authorization rather than replaying the decision made when the refresh token was issued.
+
+| Change since the refresh token was issued | Effect on the refresh |
+|---|---|
+| A role is unassigned from the subject, deleted, or stripped of a permission | The affected permission scopes are dropped from the new access token |
+| The subject loses a group membership that granted a role | The affected permission scopes are dropped from the new access token |
+| A permission is removed from the resource server | The scope is dropped from the new access token |
+| The user's password is reset | The refresh fails with `invalid_grant` |
+| The client secret is rotated | The refresh fails with `invalid_grant` |
+| The user is deleted | The refresh fails with `invalid_grant` |
+
+OIDC scopes such as `openid`, `profile`, and `email` are not permission scopes, so authorization changes never remove them.
+
+Access tokens issued earlier are unaffected and remain valid until they expire. Clients must handle a refreshed access token that carries fewer scopes than the previous one, and an `invalid_grant` response that requires the user to sign in again.
+
 <details>
 <summary>How <ProductName /> Implements It</summary>
 
@@ -53,6 +70,8 @@ Response (rotation enabled):
 | Audience preservation | The new access token keeps the refresh token's single audience when `resource` is omitted |
 | Resource validation | When supplied, `resource` must match the refresh token's audience. A mismatch returns `invalid_target` |
 | Scope narrowing | The `scope` parameter may request a subset of the originally granted scopes. Asking for a wider scope returns `invalid_scope` |
+| Authorization re-evaluation | Permission scopes are re-evaluated against the subject's current role and group assignments on every refresh. Scopes the subject no longer holds are dropped |
+| Credential changes | Each entity records when its password or client secret last changed. A refresh token established at or before that instant is rejected with `invalid_grant` |
 | DPoP binding | A DPoP-bound refresh token continues to require a DPoP proof on refresh; the new access token inherits the `cnf.jkt` binding |
 
 ### What Changes Between the Original and Refreshed Token
@@ -62,7 +81,7 @@ Response (rotation enabled):
 | `sub` | Unchanged |
 | `iss` | Unchanged |
 | `aud` | Preserved. A supplied `resource` must match this value |
-| `scope` | Preserved by default; narrowed when `scope` is supplied |
+| `scope` | Preserved by default. Narrowed when `scope` is supplied, and narrowed further to the permissions the subject currently holds |
 | `exp` / `iat` | New values |
 | `cnf.jkt` (DPoP) | Preserved |
 | `auth_time` | Not carried into refreshed tokens |

--- a/docs/content/key-concepts/tokens.mdx
+++ b/docs/content/key-concepts/tokens.mdx
@@ -38,6 +38,8 @@ Refresh tokens allow a client to get a new access token without requiring the us
 
 When refreshing, the client can include the `resource` parameter only for the resource server already bound to the refresh token. See [Resource Indicators: Resource on Refresh](../../guides/protocols/oauth-oidc/resource-indicators#resource-on-refresh).
 
+A refresh does not replay the authorization decision made when the refresh token was issued. Permission scopes are re-evaluated against the subject's current roles and groups, so a refreshed access token can carry fewer scopes than the previous one. A password reset or a client secret rotation rejects the refresh with `invalid_grant`. See [Refresh Token: Authorization on Refresh](../../guides/protocols/oauth-oidc/refresh-token#authorization-on-refresh).
+
 ## ID Tokens
 
 ID tokens are JWTs issued alongside access tokens in OpenID Connect flows. The `aud` claim of an ID token always contains the requesting application's client ID, regardless of resource indicators. ID tokens identify the authenticated user to the client application and are not intended for resource server authorization.

--- a/tests/integration/oauth/token/refresh_token_test.go
+++ b/tests/integration/oauth/token/refresh_token_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -395,4 +396,428 @@ func (ts *RefreshTokenTestSuite) TestRefreshTokenGrantWithoutOpenIDScope() {
 		"Refresh response should contain an access token")
 	ts.Empty(refreshResponse.IDToken,
 		"Refresh response should not contain an ID token without openid scope")
+}
+
+// This suite covers what happens to an already-issued refresh token when the authorization behind it
+// changes: role and permission edits must narrow the scopes it can mint, and a credential change must
+// stop it minting at all. Each scenario runs end to end, from an authorization code flow through the
+// mutation to a refresh.
+//
+// Every scenario owns the state it mutates (its own user, role, or application), so the mutations
+// cannot leak into another scenario's expectations.
+
+const (
+	refreshSecClientID     = "refresh_security_test_client"
+	refreshSecClientSecret = "refresh_security_test_secret"
+	refreshSecRedirectURI  = "https://localhost:3000"
+	refreshSecPassword     = "testpass123"
+	refreshSecResource     = "https://refresh-security.example.com"
+	refreshSecUserType     = "refresh-security-person"
+)
+
+type RefreshSecurityTestSuite struct {
+	suite.Suite
+	ouID             string
+	entityTypeID     string
+	authFlowID       string
+	resourceServerID string
+	applicationID    string
+	createdUserIDs   []string
+	createdRoleIDs   []string
+	createdAppIDs    []string
+}
+
+func TestRefreshSecurityTestSuite(t *testing.T) {
+	suite.Run(t, new(RefreshSecurityTestSuite))
+}
+
+func (ts *RefreshSecurityTestSuite) SetupSuite() {
+	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "refresh-security-test-ou",
+		Name:        "Refresh Security Test OU",
+		Description: "Organization unit for refresh token security integration testing",
+	})
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
+
+	userType := refreshTokenTestUserType
+	userType.Name = refreshSecUserType
+	userType.OUID = ouID
+	entityTypeID, err := testutils.CreateUserType(userType)
+	ts.Require().NoError(err, "Failed to create test user type")
+	ts.entityTypeID = entityTypeID
+
+	// Reuse the authentication flow shape from the refresh token suite: it already runs the
+	// AuthorizationExecutor, which is what resolves permission scopes at the authorization endpoint.
+	flow := refreshTokenTestAuthFlow
+	flow.Name = "Refresh Security Test Auth Flow"
+	flow.Handle = "auth_flow_refresh_security_test"
+	flowID, err := testutils.CreateFlow(flow)
+	ts.Require().NoError(err, "Failed to create test authentication flow")
+	ts.authFlowID = flowID
+
+	resourceServerID, err := testutils.CreateResourceServerWithActions(testutils.ResourceServer{
+		Name:        "Refresh Security Resource Server",
+		Description: "Resource server for refresh token security integration tests",
+		Identifier:  refreshSecResource,
+		OUID:        ouID,
+	}, []testutils.Action{
+		{Name: "Read Documents", Handle: "read", Description: "Permission to read documents"},
+		{Name: "Write Documents", Handle: "write", Description: "Permission to write documents"},
+	})
+	ts.Require().NoError(err, "Failed to create resource server")
+	ts.resourceServerID = resourceServerID
+
+	ts.applicationID = ts.createApplication("RefreshSecurityTestApp", refreshSecClientID, refreshSecClientSecret)
+}
+
+func (ts *RefreshSecurityTestSuite) TearDownSuite() {
+	for _, appID := range ts.createdAppIDs {
+		_ = testutils.DeleteApplication(appID)
+	}
+	for _, roleID := range ts.createdRoleIDs {
+		_ = testutils.DeleteRole(roleID)
+	}
+	for _, userID := range ts.createdUserIDs {
+		_ = testutils.DeleteUser(userID)
+	}
+	if ts.resourceServerID != "" {
+		_ = testutils.DeleteResourceServer(ts.resourceServerID)
+	}
+	if ts.authFlowID != "" {
+		_ = testutils.DeleteFlow(ts.authFlowID)
+	}
+	if ts.entityTypeID != "" {
+		_ = testutils.DeleteUserType(ts.entityTypeID)
+	}
+	if ts.ouID != "" {
+		_ = testutils.DeleteOrganizationUnit(ts.ouID)
+	}
+}
+
+// createApplication registers an application wired to the suite's flow, with the grants the refresh
+// scenarios need.
+func (ts *RefreshSecurityTestSuite) createApplication(name, clientID, clientSecret string) string {
+	appID, err := testutils.CreateApplication(testutils.Application{
+		Name:                      name,
+		Description:               "Application for refresh token security integration tests",
+		OUID:                      ts.ouID,
+		Type:                      "fullstack",
+		AuthFlowID:                ts.authFlowID,
+		IsRegistrationFlowEnabled: false,
+		AllowedUserTypes:          []string{refreshSecUserType},
+		InboundAuthConfig: []map[string]interface{}{
+			{
+				"type": "oauth2",
+				"config": map[string]interface{}{
+					"clientId":                clientID,
+					"clientSecret":            clientSecret,
+					"redirectUris":            []string{refreshSecRedirectURI},
+					"grantTypes":              []string{"authorization_code", "refresh_token"},
+					"responseTypes":           []string{"code"},
+					"tokenEndpointAuthMethod": "client_secret_basic",
+				},
+			},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create application")
+	ts.createdAppIDs = append(ts.createdAppIDs, appID)
+	return appID
+}
+
+// updateApplication replaces the application, optionally rotating its client secret. An empty secret
+// leaves the stored one intact, so the update touches only the system attributes.
+func (ts *RefreshSecurityTestSuite) updateApplication(appID, name, clientID, clientSecret string) error {
+	oauthConfig := map[string]interface{}{
+		"clientId":                clientID,
+		"redirectUris":            []string{refreshSecRedirectURI},
+		"grantTypes":              []string{"authorization_code", "refresh_token"},
+		"responseTypes":           []string{"code"},
+		"tokenEndpointAuthMethod": "client_secret_basic",
+	}
+	if clientSecret != "" {
+		oauthConfig["clientSecret"] = clientSecret
+	}
+	return testutils.UpdateApplication(appID, testutils.Application{
+		ID:                        appID,
+		Name:                      name,
+		Description:               "Application for refresh token security integration tests",
+		OUID:                      ts.ouID,
+		Type:                      "fullstack",
+		AuthFlowID:                ts.authFlowID,
+		IsRegistrationFlowEnabled: false,
+		AllowedUserTypes:          []string{refreshSecUserType},
+		InboundAuthConfig: []map[string]interface{}{
+			{"type": "oauth2", "config": oauthConfig},
+		},
+	})
+}
+
+// createUser registers a user of the suite's type and tracks it for cleanup.
+func (ts *RefreshSecurityTestSuite) createUser(username string) string {
+	userID, err := testutils.CreateUser(testutils.User{
+		OUID: ts.ouID,
+		Type: refreshSecUserType,
+		Attributes: json.RawMessage(fmt.Sprintf(`{
+			"username": "%s",
+			"password": "%s",
+			"email": "%s@example.com",
+			"given_name": "Refresh",
+			"family_name": "Security"
+		}`, username, refreshSecPassword, username)),
+	})
+	ts.Require().NoError(err, "Failed to create test user")
+	ts.createdUserIDs = append(ts.createdUserIDs, userID)
+	return userID
+}
+
+// createRole grants the given permissions on the suite's resource server to the given user.
+func (ts *RefreshSecurityTestSuite) createRole(name, userID string, permissions []string) string {
+	roleID, err := testutils.CreateRole(testutils.Role{
+		Name:        name,
+		Description: "Role for refresh token security integration tests",
+		OUID:        ts.ouID,
+		Permissions: []testutils.ResourcePermissions{
+			{ResourceServerID: ts.resourceServerID, Permissions: permissions},
+		},
+		Assignments: []testutils.Assignment{{ID: userID, Type: "user"}},
+	})
+	ts.Require().NoError(err, "Failed to create test role")
+	ts.createdRoleIDs = append(ts.createdRoleIDs, roleID)
+	return roleID
+}
+
+// obtainTokens runs the full authorization code flow and returns the token response.
+func (ts *RefreshSecurityTestSuite) obtainTokens(
+	clientID, clientSecret, username, scope string,
+) *testutils.TokenResponse {
+	resp, err := testutils.InitiateAuthorizationFlowWithResource(
+		clientID, refreshSecRedirectURI, "code", scope, "test-state", refreshSecResource)
+	ts.Require().NoError(err, "Failed to initiate authorization flow")
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusFound, resp.StatusCode, "Expected redirect from authorization endpoint")
+
+	authID, executionID, err := testutils.ExtractAuthData(resp.Header.Get("Location"))
+	ts.Require().NoError(err, "Failed to extract auth data")
+
+	initialStep, err := testutils.ExecuteAuthenticationFlow(executionID, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+
+	flowStep, err := testutils.ExecuteAuthenticationFlow(executionID, map[string]string{
+		"username": username,
+		"password": refreshSecPassword,
+	}, "action_001", initialStep.ChallengeToken)
+	ts.Require().NoError(err, "Failed to execute authentication flow")
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus, "Authentication flow should complete")
+
+	authzResp, err := testutils.CompleteAuthorization(authID, flowStep.Assertion)
+	ts.Require().NoError(err, "Failed to complete authorization")
+
+	code, err := testutils.ExtractAuthorizationCode(authzResp.RedirectURI)
+	ts.Require().NoError(err, "Failed to extract authorization code")
+
+	result, err := testutils.RequestTokenWithResource(
+		clientID, clientSecret, code, refreshSecRedirectURI, "authorization_code", refreshSecResource)
+	ts.Require().NoError(err, "Failed to exchange code for tokens")
+	ts.Require().Equal(http.StatusOK, result.StatusCode,
+		"Token request should succeed. Response: %s", string(result.Body))
+	ts.Require().NotEmpty(result.Token.RefreshToken, "Refresh token should not be empty")
+
+	return result.Token
+}
+
+// accessTokenScopes returns the scopes carried by the given access token.
+func (ts *RefreshSecurityTestSuite) accessTokenScopes(accessToken string) []string {
+	claims, err := testutils.DecodeJWT(accessToken)
+	ts.Require().NoError(err, "Failed to decode access token")
+
+	scopeRaw, ok := claims.Additional["scope"]
+	if !ok {
+		return nil
+	}
+	scopeStr, ok := scopeRaw.(string)
+	ts.Require().True(ok, "scope claim should be a string")
+	if scopeStr == "" {
+		return nil
+	}
+	return strings.Split(scopeStr, " ")
+}
+
+// Baseline: with the grant untouched, a refresh keeps minting the permission scopes. Without this the
+// negative cases below could pass for the wrong reason.
+func (ts *RefreshSecurityTestSuite) TestRefresh_NoChange_KeepsPermissionScopes() {
+	userID := ts.createUser("refresh_sec_baseline")
+	ts.createRole("RefreshSec_Baseline", userID, []string{"read", "write"})
+
+	tokens := ts.obtainTokens(refreshSecClientID, refreshSecClientSecret, "refresh_sec_baseline", "openid read write")
+	ts.Require().Contains(ts.accessTokenScopes(tokens.AccessToken), "read", "initial token should carry read")
+
+	refreshed, err := testutils.RefreshAccessToken(refreshSecClientID, refreshSecClientSecret, tokens.RefreshToken)
+	ts.Require().NoError(err, "Refresh should succeed")
+
+	scopes := ts.accessTokenScopes(refreshed.AccessToken)
+	ts.Assert().Contains(scopes, "read", "refreshed token should retain read")
+	ts.Assert().Contains(scopes, "write", "refreshed token should retain write")
+}
+
+// Unassigning the role must stop the refresh token minting the permissions it granted.
+func (ts *RefreshSecurityTestSuite) TestRefresh_RoleUnassigned_DropsPermissionScopes() {
+	userID := ts.createUser("refresh_sec_unassign")
+	roleID := ts.createRole("RefreshSec_Unassign", userID, []string{"read", "write"})
+
+	tokens := ts.obtainTokens(refreshSecClientID, refreshSecClientSecret, "refresh_sec_unassign", "openid read write")
+	ts.Require().Contains(ts.accessTokenScopes(tokens.AccessToken), "read", "initial token should carry read")
+
+	ts.Require().NoError(testutils.RemoveRoleAssignments(roleID, []testutils.Assignment{
+		{ID: userID, Type: "user"},
+	}), "Failed to unassign role")
+
+	refreshed, err := testutils.RefreshAccessToken(refreshSecClientID, refreshSecClientSecret, tokens.RefreshToken)
+	ts.Require().NoError(err, "Refresh should still succeed, with narrowed scopes")
+
+	scopes := ts.accessTokenScopes(refreshed.AccessToken)
+	ts.Assert().NotContains(scopes, "read", "refreshed token must not carry read after unassignment")
+	ts.Assert().NotContains(scopes, "write", "refreshed token must not carry write after unassignment")
+	ts.Assert().Contains(scopes, "openid", "OIDC scopes are not permissions and must survive")
+}
+
+// Deleting the role entirely has the same effect as unassigning it.
+func (ts *RefreshSecurityTestSuite) TestRefresh_RoleDeleted_DropsPermissionScopes() {
+	userID := ts.createUser("refresh_sec_roledelete")
+	roleID := ts.createRole("RefreshSec_RoleDelete", userID, []string{"read", "write"})
+
+	tokens := ts.obtainTokens(refreshSecClientID, refreshSecClientSecret, "refresh_sec_roledelete", "openid read write")
+	ts.Require().Contains(ts.accessTokenScopes(tokens.AccessToken), "read", "initial token should carry read")
+
+	ts.Require().NoError(testutils.DeleteRole(roleID), "Failed to delete role")
+
+	refreshed, err := testutils.RefreshAccessToken(refreshSecClientID, refreshSecClientSecret, tokens.RefreshToken)
+	ts.Require().NoError(err, "Refresh should still succeed, with narrowed scopes")
+
+	scopes := ts.accessTokenScopes(refreshed.AccessToken)
+	ts.Assert().NotContains(scopes, "read", "refreshed token must not carry read after role deletion")
+	ts.Assert().NotContains(scopes, "write", "refreshed token must not carry write after role deletion")
+}
+
+// Stripping one permission from the role narrows the refreshed token to the permissions that remain.
+func (ts *RefreshSecurityTestSuite) TestRefresh_RolePermissionRemoved_DropsThatScopeOnly() {
+	userID := ts.createUser("refresh_sec_permstrip")
+	roleID := ts.createRole("RefreshSec_PermStrip", userID, []string{"read", "write"})
+
+	tokens := ts.obtainTokens(refreshSecClientID, refreshSecClientSecret, "refresh_sec_permstrip", "openid read write")
+	ts.Require().Contains(ts.accessTokenScopes(tokens.AccessToken), "write", "initial token should carry write")
+
+	ts.Require().NoError(testutils.UpdateRole(roleID, testutils.Role{
+		Name:        "RefreshSec_PermStrip",
+		Description: "Role for refresh token security integration tests",
+		OUID:        ts.ouID,
+		Permissions: []testutils.ResourcePermissions{
+			{ResourceServerID: ts.resourceServerID, Permissions: []string{"read"}},
+		},
+		Assignments: []testutils.Assignment{{ID: userID, Type: "user"}},
+	}), "Failed to strip permission from role")
+
+	refreshed, err := testutils.RefreshAccessToken(refreshSecClientID, refreshSecClientSecret, tokens.RefreshToken)
+	ts.Require().NoError(err, "Refresh should still succeed, with narrowed scopes")
+
+	scopes := ts.accessTokenScopes(refreshed.AccessToken)
+	ts.Assert().Contains(scopes, "read", "the retained permission must still be minted")
+	ts.Assert().NotContains(scopes, "write", "the removed permission must not be minted")
+}
+
+// A password reset must stop the refresh tokens established before it.
+func (ts *RefreshSecurityTestSuite) TestRefresh_PasswordReset_RejectsToken() {
+	userID := ts.createUser("refresh_sec_password")
+	ts.createRole("RefreshSec_Password", userID, []string{"read"})
+
+	tokens := ts.obtainTokens(refreshSecClientID, refreshSecClientSecret, "refresh_sec_password", "openid read")
+
+	ts.Require().NoError(testutils.UpdateUserCredentials(userID, map[string]string{
+		"password": "new-testpass456",
+	}), "Failed to reset user password")
+
+	_, err := testutils.RefreshAccessToken(refreshSecClientID, refreshSecClientSecret, tokens.RefreshToken)
+	ts.Require().Error(err, "Refresh must be rejected after a password reset")
+	ts.Assert().Contains(err.Error(), "invalid_grant", "Rejection should be invalid_grant")
+}
+
+// A client secret rotation must stop the refresh tokens issued under the old secret.
+func (ts *RefreshSecurityTestSuite) TestRefresh_ClientSecretRotated_RejectsToken() {
+	const (
+		rotateClientID     = "refresh_security_rotate_client"
+		rotateClientSecret = "refresh_security_rotate_secret"
+	)
+	appID := ts.createApplication("RefreshSecurityRotateApp", rotateClientID, rotateClientSecret)
+	userID := ts.createUser("refresh_sec_rotate")
+	ts.createRole("RefreshSec_Rotate", userID, []string{"read"})
+
+	tokens := ts.obtainTokens(rotateClientID, rotateClientSecret, "refresh_sec_rotate", "openid read")
+
+	ts.Require().NoError(testutils.UpdateApplication(appID, testutils.Application{
+		ID:                        appID,
+		Name:                      "RefreshSecurityRotateApp",
+		Description:               "Application for refresh token security integration tests",
+		OUID:                      ts.ouID,
+		Type:                      "fullstack",
+		AuthFlowID:                ts.authFlowID,
+		IsRegistrationFlowEnabled: false,
+		AllowedUserTypes:          []string{refreshSecUserType},
+		InboundAuthConfig: []map[string]interface{}{
+			{
+				"type": "oauth2",
+				"config": map[string]interface{}{
+					"clientId":                rotateClientID,
+					"clientSecret":            "rotated-secret-value",
+					"redirectUris":            []string{refreshSecRedirectURI},
+					"grantTypes":              []string{"authorization_code", "refresh_token"},
+					"responseTypes":           []string{"code"},
+					"tokenEndpointAuthMethod": "client_secret_basic",
+				},
+			},
+		},
+	}), "Failed to rotate client secret")
+
+	_, err := testutils.RefreshAccessToken(rotateClientID, "rotated-secret-value", tokens.RefreshToken)
+	ts.Require().Error(err, "Refresh must be rejected after a client secret rotation")
+	ts.Assert().Contains(err.Error(), "invalid_grant", "Rejection should be invalid_grant")
+}
+
+// An unrelated application edit rebuilds the whole system-attribute blob, so the marker written by a
+// secret rotation must survive it. Losing it would revive the refresh tokens the rotation invalidated.
+func (ts *RefreshSecurityTestSuite) TestRefresh_ClientSecretRotatedThenAppRenamed_StillRejectsToken() {
+	const (
+		renameClientID = "refresh_security_rename_client"
+		renameSecret   = "refresh_security_rename_secret"
+		rotatedSecret  = "rotated-secret-after-rename"
+	)
+	appID := ts.createApplication("RefreshSecurityRenameApp", renameClientID, renameSecret)
+	userID := ts.createUser("refresh_sec_rename")
+	ts.createRole("RefreshSec_Rename", userID, []string{"read"})
+
+	tokens := ts.obtainTokens(renameClientID, renameSecret, "refresh_sec_rename", "openid read")
+
+	ts.Require().NoError(ts.updateApplication(appID, "RefreshSecurityRenameApp", renameClientID, rotatedSecret),
+		"Failed to rotate client secret")
+	// The rename supplies no secret, so it only rewrites the system attributes.
+	ts.Require().NoError(ts.updateApplication(appID, "RefreshSecurityRenamedApp", renameClientID, ""),
+		"Failed to rename application")
+
+	_, err := testutils.RefreshAccessToken(renameClientID, rotatedSecret, tokens.RefreshToken)
+	ts.Require().Error(err, "Refresh must stay rejected after an unrelated application edit")
+	ts.Assert().Contains(err.Error(), "invalid_grant", "Rejection should be invalid_grant")
+}
+
+// A deleted user cannot hold a valid grant. The application maps no subject, so the token can only
+// have carried an entity ID, and a missing entity means the subject is gone.
+func (ts *RefreshSecurityTestSuite) TestRefresh_UserDeleted_RejectsToken() {
+	userID := ts.createUser("refresh_sec_userdelete")
+	ts.createRole("RefreshSec_UserDelete", userID, []string{"read"})
+
+	tokens := ts.obtainTokens(refreshSecClientID, refreshSecClientSecret, "refresh_sec_userdelete", "openid read")
+
+	ts.Require().NoError(testutils.DeleteUser(userID), "Failed to delete user")
+
+	_, err := testutils.RefreshAccessToken(refreshSecClientID, refreshSecClientSecret, tokens.RefreshToken)
+	ts.Require().Error(err, "Refresh must be rejected after the user is deleted")
+	ts.Assert().Contains(err.Error(), "invalid_grant", "Rejection should be invalid_grant")
 }

--- a/tests/integration/testutils/api_utils.go
+++ b/tests/integration/testutils/api_utils.go
@@ -2075,3 +2075,95 @@ func GetAgent(agentID string) (*Agent, error) {
 	}
 	return &a, nil
 }
+
+// UpdateRole replaces a role by ID. Used to change a role's permissions or assignments after tokens
+// have been issued against them.
+func UpdateRole(roleID string, role Role) error {
+	roleJSON, err := json.Marshal(role)
+	if err != nil {
+		return fmt.Errorf("failed to marshal role: %w", err)
+	}
+
+	req, err := http.NewRequest("PUT", TestServerURL+"/roles/"+roleID, bytes.NewReader(roleJSON))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := GetHTTPClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to update role: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("failed to update role, status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// UpdateUserCredentials sets new credentials (e.g. a password) for a user, the way an administrative
+// password reset does.
+func UpdateUserCredentials(userID string, credentials map[string]string) error {
+	credsJSON, err := json.Marshal(credentials)
+	if err != nil {
+		return fmt.Errorf("failed to marshal credentials: %w", err)
+	}
+	payload, err := json.Marshal(map[string]json.RawMessage{"credentials": credsJSON})
+	if err != nil {
+		return fmt.Errorf("failed to marshal credential update request: %w", err)
+	}
+
+	req, err := http.NewRequest("POST",
+		TestServerURL+"/users/"+userID+"/update-credentials", bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := GetHTTPClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to update user credentials: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("failed to update user credentials, status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// UpdateApplication replaces an application by ID. Supplying a new client secret on the OAuth inbound
+// auth config rotates it.
+func UpdateApplication(appID string, app Application) error {
+	appJSON, err := json.Marshal(app)
+	if err != nil {
+		return fmt.Errorf("failed to marshal application: %w", err)
+	}
+
+	req, err := http.NewRequest("PUT", TestServerURL+"/applications/"+appID, bytes.NewReader(appJSON))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := GetHTTPClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to update application: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("failed to update application, status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// RemoveRoleAssignments unassigns the given subjects from a role, the way an administrator revoking a
+// user's role does. Assignments are a sub-resource of the role, so a role update does not carry them.
+func RemoveRoleAssignments(roleID string, assignments []Assignment) error {
+	return removeRoleAssignments(roleID, assignments, GetHTTPClient())
+}


### PR DESCRIPTION
### Purpose
A refresh re-minted tokens carrying stale scopes: unassigning a role, deleting it, or stripping its permissions had no effect until the refresh token expired. A password reset or a client secret rotation also left existing refresh tokens usable.

### Approach
- Re-evaluate permission scopes against the subject's current role and group assignments on every refresh, dropping the ones they no longer hold. OIDC scopes are not affected.
- Record `credentialUpdatedAt` in the entity's system attributes when a password or client secret changes, and reject a refresh token established at or before that instant. The marker is written in the same transaction as the credential, and carried across by the application, agent, and user paths that rebuild the blob.
- Reject the refresh when the subject no longer resolves to an entity and the client maps no subject attribute.

Scoped to the refresh grant, so other grants are unaffected. Already-issued access tokens still live out their TTL, and applications that map `sub` to a user attribute skip the subject-derived checks.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [x] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Refresh-token requests now re-evaluate current permissions and may reduce authorization scopes.
  - Refresh tokens are rejected after password resets, client-secret rotations, or user deletion.
  - Credential changes are tracked to reliably invalidate earlier refresh tokens.

- **Documentation**
  - Updated OAuth, token, and application guides to explain scope reduction and refresh-token invalidation.

- **Tests**
  - Added comprehensive coverage for permission changes, credential updates, deleted users, and client-secret rotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->