### PR TITLE
Add integration coverage for the flow engine and SSO sessions

### DIFF
--- a/tests/integration/flow/authentication/consent_permissions_test.go
+++ b/tests/integration/flow/authentication/consent_permissions_test.go
@@ -193,6 +193,7 @@ type consentPurposeDecision struct {
 
 type consentDecisions struct {
 	Approved bool                     `json:"approved"`
+	Reason   string                   `json:"reason,omitempty"`
 	Purposes []consentPurposeDecision `json:"purposes"`
 }
 

--- a/tests/integration/flow/authentication/consent_test.go
+++ b/tests/integration/flow/authentication/consent_test.go
@@ -1,0 +1,498 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authentication
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	consentInputIdentifier = "consent_decisions"
+	consentPromptDataKey   = "consentPrompt"
+	consentApproveAction   = "consent_action_allow"
+
+	// The consent node of consentTimeoutTestFlow carries this timeout, in seconds. It is the
+	// shortest wait that still crosses the expiry boundary once the test sleeps past it.
+	consentTimeoutSeconds = 1
+)
+
+// consentPurposePrompt mirrors the purposes payload the consent executor forwards to the prompt,
+// which is what the Console renders and what the decisions submitted back must line up with.
+type consentPurposePrompt struct {
+	PurposeName string `json:"purposeName"`
+	PurposeID   string `json:"purposeId"`
+	Type        string `json:"type"`
+	Essential   []struct {
+		Name string `json:"name"`
+	} `json:"essential"`
+	Optional []struct {
+		Name string `json:"name"`
+	} `json:"optional"`
+}
+
+var (
+	consentTestOU = testutils.OrganizationUnit{
+		Handle:      "consent-flow-test-ou",
+		Name:        "Consent Flow Test Organization Unit",
+		Description: "Organization unit for consent flow testing",
+		Parent:      nil,
+	}
+
+	consentTestUserType = testutils.UserType{
+		Name: "consent-test-person",
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type": "string",
+			},
+			"password": map[string]interface{}{
+				"type":       "string",
+				"credential": true,
+			},
+			"email": map[string]interface{}{
+				"type": "string",
+			},
+			"given_name": map[string]interface{}{
+				"type": "string",
+			},
+		},
+	}
+
+	// consentTestUser has both attributes the application requests, so neither is dropped by the
+	// profile-presence filter and both are prompted.
+	consentTestUser = testutils.User{
+		Type: "consent-test-person",
+		Attributes: json.RawMessage(`{
+			"username": "consent_user",
+			"password": "SecurePass123!",
+			"email": "consent.user@test.com",
+			"given_name": "Consent"
+		}`),
+	}
+
+	// A second user keeps the decision-handling tests off the consent record written by the
+	// approve-then-skip test, which would otherwise suppress the prompt they depend on.
+	consentDecisionUser = testutils.User{
+		Type: "consent-test-person",
+		Attributes: json.RawMessage(`{
+			"username": "consent_decision_user",
+			"password": "SecurePass123!",
+			"email": "consent.decision@test.com",
+			"given_name": "Decision"
+		}`),
+	}
+
+	consentTimeoutUser = testutils.User{
+		Type: "consent-test-person",
+		Attributes: json.RawMessage(`{
+			"username": "consent_timeout_user",
+			"password": "SecurePass123!",
+			"email": "consent.timeout@test.com",
+			"given_name": "Timeout"
+		}`),
+	}
+)
+
+// consentFlowNodes builds an authentication flow that authenticates with credentials and then runs
+// the consent executor, looping back into it from the consent prompt. nodeProperties is applied to
+// the consent node, which is how the timeout variant differs from the default one.
+func consentFlowNodes(nodeProperties map[string]interface{}) []map[string]interface{} {
+	consentNode := map[string]interface{}{
+		"id":   "consent_check",
+		"type": "TASK_EXECUTION",
+		"executor": map[string]interface{}{
+			"name": "ConsentExecutor",
+		},
+		"onSuccess":    "auth_assert",
+		"onIncomplete": "prompt_consent",
+	}
+	if len(nodeProperties) > 0 {
+		consentNode["properties"] = nodeProperties
+	}
+
+	return []map[string]interface{}{
+		{
+			"id":        "start",
+			"type":      "START",
+			"onSuccess": "prompt_credentials",
+		},
+		{
+			"id":   "prompt_credentials",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_001",
+							"identifier": "username",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_002",
+							"identifier": "password",
+							"type":       "PASSWORD_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_001",
+						"nextNode": "credentials_auth",
+					},
+				},
+			},
+		},
+		{
+			"id":   "credentials_auth",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "CredentialsAuthExecutor",
+			},
+			"onSuccess":    "consent_check",
+			"onIncomplete": "prompt_credentials",
+		},
+		consentNode,
+		{
+			"id":   "prompt_consent",
+			"type": "PROMPT",
+			"meta": map[string]interface{}{
+				"components": []map[string]interface{}{
+					{
+						"type": "BLOCK",
+						"id":   "consent_block",
+						"components": []map[string]interface{}{
+							{
+								"id":       "consent_input",
+								"ref":      consentInputIdentifier,
+								"type":     "CONSENT_INPUT",
+								"required": true,
+							},
+							{
+								"type":      "ACTION",
+								"id":        consentApproveAction,
+								"label":     "Approve",
+								"eventType": "SUBMIT",
+							},
+						},
+					},
+				},
+			},
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "consent_input",
+							"identifier": consentInputIdentifier,
+							"type":       "CONSENT_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      consentApproveAction,
+						"nextNode": "consent_check",
+					},
+				},
+			},
+		},
+		{
+			"id":   "auth_assert",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "AuthAssertExecutor",
+			},
+			"onSuccess": "end",
+		},
+		{
+			"id":   "end",
+			"type": "END",
+		},
+	}
+}
+
+type ConsentFlowTestSuite struct {
+	suite.Suite
+	config *common.TestSuiteConfig
+
+	ouID           string
+	userTypeID     string
+	appID          string
+	timeoutAppID   string
+	consentUserID  string
+	decisionUserID string
+	timeoutUserID  string
+}
+
+func TestConsentFlowTestSuite(t *testing.T) {
+	suite.Run(t, new(ConsentFlowTestSuite))
+}
+
+func (ts *ConsentFlowTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	ouID, err := testutils.CreateOrganizationUnit(consentTestOU)
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
+
+	userType := consentTestUserType
+	userType.OUID = ouID
+	ts.userTypeID, err = testutils.CreateUserType(userType)
+	ts.Require().NoError(err, "Failed to create test user type")
+
+	// The requested user attributes are what the attribute consent purpose is derived from, so the
+	// application's assertion config is what makes consent applicable at all.
+	assertionConfig := map[string]interface{}{
+		"userAttributes": []string{"email", "given_name"},
+	}
+
+	flowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     "Consent Test Auth Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_consent_test",
+		Nodes:    consentFlowNodes(nil),
+	})
+	ts.Require().NoError(err, "Failed to create consent test flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
+
+	ts.appID, err = testutils.CreateApplication(testutils.Application{
+		Name:             "Consent Flow Test Application",
+		Description:      "Application for testing consent collection in flows",
+		ClientID:         "consent_flow_test_client",
+		ClientSecret:     "consent_flow_test_secret",
+		RedirectURIs:     []string{"http://localhost:3000/callback"},
+		OUID:             ouID,
+		AllowedUserTypes: []string{consentTestUserType.Name},
+		AuthFlowID:       flowID,
+		AssertionConfig:  assertionConfig,
+	})
+	ts.Require().NoError(err, "Failed to create test application")
+
+	timeoutFlowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     "Consent Timeout Test Auth Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_consent_timeout_test",
+		Nodes: consentFlowNodes(map[string]interface{}{
+			"timeout": "1",
+		}),
+	})
+	ts.Require().NoError(err, "Failed to create consent timeout test flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, timeoutFlowID)
+
+	ts.timeoutAppID, err = testutils.CreateApplication(testutils.Application{
+		Name:             "Consent Timeout Flow Test Application",
+		Description:      "Application for testing consent prompt expiry in flows",
+		ClientID:         "consent_timeout_flow_test_client",
+		ClientSecret:     "consent_timeout_flow_test_secret",
+		RedirectURIs:     []string{"http://localhost:3000/callback"},
+		OUID:             ouID,
+		AllowedUserTypes: []string{consentTestUserType.Name},
+		AuthFlowID:       timeoutFlowID,
+		AssertionConfig:  assertionConfig,
+	})
+	ts.Require().NoError(err, "Failed to create timeout test application")
+
+	ts.consentUserID = ts.createUser(consentTestUser)
+	ts.decisionUserID = ts.createUser(consentDecisionUser)
+	ts.timeoutUserID = ts.createUser(consentTimeoutUser)
+}
+
+func (ts *ConsentFlowTestSuite) createUser(user testutils.User) string {
+	ts.T().Helper()
+
+	toCreate := user
+	toCreate.OUID = ts.ouID
+	userID, err := testutils.CreateUser(toCreate)
+	ts.Require().NoError(err, "Failed to create test user")
+	ts.config.CreatedUserIDs = append(ts.config.CreatedUserIDs, userID)
+	return userID
+}
+
+func (ts *ConsentFlowTestSuite) TearDownSuite() {
+	for _, appID := range []string{ts.appID, ts.timeoutAppID} {
+		if appID == "" {
+			continue
+		}
+		if err := testutils.DeleteApplication(appID); err != nil {
+			ts.T().Logf("Failed to delete test application during teardown: %v", err)
+		}
+	}
+	for _, userID := range ts.config.CreatedUserIDs {
+		if err := testutils.DeleteUser(userID); err != nil {
+			ts.T().Logf("Failed to delete test user during teardown: %v", err)
+		}
+	}
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete test flow during teardown: %v", err)
+		}
+	}
+	if ts.userTypeID != "" {
+		if err := testutils.DeleteUserType(ts.userTypeID); err != nil {
+			ts.T().Logf("Failed to delete test user type during teardown: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// authenticateToConsentPrompt drives the flow through credentials authentication and returns the
+// step the consent executor paused on.
+func (ts *ConsentFlowTestSuite) authenticateToConsentPrompt(appID, username string) *common.FlowStep {
+	ts.T().Helper()
+
+	step, err := common.InitiateAuthenticationFlow(appID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "Flow should pause at the credentials prompt")
+
+	step, err = common.CompleteFlow(step.ExecutionID, map[string]string{
+		"username": username,
+		"password": "SecurePass123!",
+	}, "action_001", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit credentials")
+	return step
+}
+
+// requireConsentPrompt asserts the step is a consent prompt and returns the prompted purposes.
+func (ts *ConsentFlowTestSuite) requireConsentPrompt(step *common.FlowStep) []consentPurposePrompt {
+	ts.T().Helper()
+
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "Consent should pause the flow for input")
+	ts.Require().True(common.HasInput(step.Data.Inputs, consentInputIdentifier),
+		"The consent prompt must request the consent decisions input")
+
+	promptJSON, ok := step.Data.AdditionalData[consentPromptDataKey]
+	ts.Require().True(ok, "The consent prompt must carry the purposes to render")
+
+	var purposes []consentPurposePrompt
+	ts.Require().NoError(json.Unmarshal([]byte(promptJSON), &purposes),
+		"Consent prompt data should be a purposes array")
+	ts.Require().NotEmpty(purposes, "At least one purpose must be prompted")
+	return purposes
+}
+
+// decisionsFor builds a decisions payload answering every prompted element with approved.
+func decisionsFor(purposes []consentPurposePrompt, approved bool, reason string) string {
+	decisions := consentDecisions{Approved: approved, Reason: reason}
+	for _, purpose := range purposes {
+		decision := consentPurposeDecision{PurposeName: purpose.PurposeName, Approved: approved}
+		for _, element := range purpose.Essential {
+			decision.Elements = append(decision.Elements,
+				consentElementDecision{Name: element.Name, Approved: approved})
+		}
+		for _, element := range purpose.Optional {
+			decision.Elements = append(decision.Elements,
+				consentElementDecision{Name: element.Name, Approved: approved})
+		}
+		decisions.Purposes = append(decisions.Purposes, decision)
+	}
+
+	payload, err := json.Marshal(decisions)
+	if err != nil {
+		return ""
+	}
+	return string(payload)
+}
+
+// The application requests user attributes the user has, so the first authentication must stop for
+// consent, and approving every prompted element must record consent and complete the flow. A second
+// authentication then finds that consent active and runs the consent node through without a prompt,
+// which is the branch that separates "consent needed" from "already consented".
+func (ts *ConsentFlowTestSuite) TestConsent_PromptedThenSkippedOnceRecorded() {
+	step := ts.authenticateToConsentPrompt(ts.appID, "consent_user")
+	purposes := ts.requireConsentPrompt(step)
+
+	prompted := map[string]bool{}
+	for _, purpose := range purposes {
+		for _, element := range purpose.Optional {
+			prompted[element.Name] = true
+		}
+	}
+	ts.Contains(prompted, "email", "A requested attribute present in the profile must be prompted")
+	ts.Contains(prompted, "given_name", "A requested attribute present in the profile must be prompted")
+
+	completed, err := common.CompleteFlow(step.ExecutionID, map[string]string{
+		consentInputIdentifier: decisionsFor(purposes, true, ""),
+	}, consentApproveAction, step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit consent decisions")
+	ts.Require().Equal("COMPLETE", completed.FlowStatus,
+		"Approving consent should let the flow reach its assertion")
+	ts.NotEmpty(completed.Assertion, "A completed authentication must return an assertion")
+
+	// Consent is now active for both attributes, so the second run has nothing left to prompt.
+	repeat := ts.authenticateToConsentPrompt(ts.appID, "consent_user")
+	ts.Equal("COMPLETE", repeat.FlowStatus,
+		"An active consent record should let the consent node complete without prompting")
+	ts.NotContains(repeat.Data.AdditionalData, consentPromptDataKey,
+		"No consent prompt data should be forwarded when consent is already active")
+}
+
+// Denying every prompted element still records the decision and completes, because none of the
+// requested attributes are essential. Nothing is consented, which downstream executors read from
+// the empty consented-attributes runtime value.
+func (ts *ConsentFlowTestSuite) TestConsent_DeniedOptionalElementsCompletesFlow() {
+	step := ts.authenticateToConsentPrompt(ts.appID, "consent_decision_user")
+	purposes := ts.requireConsentPrompt(step)
+
+	completed, err := common.CompleteFlow(step.ExecutionID, map[string]string{
+		consentInputIdentifier: decisionsFor(purposes, false, "user_denied"),
+	}, consentApproveAction, step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit consent denial")
+	ts.Equal("COMPLETE", completed.FlowStatus,
+		"Denying only optional attributes should not fail the flow")
+}
+
+// A decisions payload that is not valid JSON is rejected as a client error rather than crashing the
+// node, since the value arrives as an opaque string from the client.
+func (ts *ConsentFlowTestSuite) TestConsent_MalformedDecisionsRejected() {
+	step := ts.authenticateToConsentPrompt(ts.appID, "consent_decision_user")
+	ts.requireConsentPrompt(step)
+
+	failed, err := common.CompleteFlow(step.ExecutionID, map[string]string{
+		consentInputIdentifier: "not-a-json-payload",
+	}, consentApproveAction, step.ChallengeToken)
+	ts.Require().NoError(err, "A malformed payload should still return a flow step")
+	ts.Equal("ERROR", failed.FlowStatus, "Unparseable consent decisions must fail the step")
+}
+
+// Decisions submitted with the timeout reason are not a user decision: nothing is recorded and the
+// flow proceeds with nothing consented. The expiry check is deliberately skipped for these, so this
+// also pins that a late timeout submission is accepted rather than rejected as expired.
+func (ts *ConsentFlowTestSuite) TestConsent_TimeoutReasonCompletesWithoutRecording() {
+	step := ts.authenticateToConsentPrompt(ts.timeoutAppID, "consent_timeout_user")
+	purposes := ts.requireConsentPrompt(step)
+
+	stepTimeout, ok := step.Data.AdditionalData["stepTimeout"]
+	ts.Require().True(ok, "A consent node with a timeout must publish the step expiry")
+	ts.NotEmpty(stepTimeout, "The published step expiry must carry a timestamp")
+
+	completed, err := common.CompleteFlow(step.ExecutionID, map[string]string{
+		consentInputIdentifier: decisionsFor(purposes, false, "timeout"),
+	}, consentApproveAction, step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit timed out consent decisions")
+	ts.Equal("COMPLETE", completed.FlowStatus,
+		"A timed out consent prompt should complete without recording consent")
+}
+
+// A decision submitted after the configured consent timeout has passed is refused, so a stale
+// prompt cannot be answered. Unlike the timeout-reason case above, this submission claims to be a
+// real decision, which is what makes the expiry check apply.
+func (ts *ConsentFlowTestSuite) TestConsent_ExpiredPromptRejected() {
+	step := ts.authenticateToConsentPrompt(ts.timeoutAppID, "consent_timeout_user")
+	purposes := ts.requireConsentPrompt(step)
+
+	time.Sleep(consentTimeoutSeconds*time.Second + 2*time.Second)
+
+	failed, err := common.CompleteFlow(step.ExecutionID, map[string]string{
+		consentInputIdentifier: decisionsFor(purposes, true, ""),
+	}, consentApproveAction, step.ChallengeToken)
+	ts.Require().NoError(err, "An expired prompt should still return a flow step")
+	ts.Equal("ERROR", failed.FlowStatus, "A decision submitted after the timeout must be refused")
+}

--- a/tests/integration/flow/authentication/identify_modes_test.go
+++ b/tests/integration/flow/authentication/identify_modes_test.go
@@ -1,0 +1,414 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authentication
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	// The two ambiguous users share this email, so identifying by email alone cannot separate them.
+	sharedIdentifyEmail = "shared@identify.test"
+	uniqueIdentifyEmail = "unique@identify.test"
+	absentIdentifyEmail = "absent@identify.test"
+)
+
+var (
+	identifyTestOU = testutils.OrganizationUnit{
+		Handle:      "identify-modes-test-ou",
+		Name:        "Identify Modes Test Organization Unit",
+		Description: "Organization unit for identifying executor mode testing",
+		Parent:      nil,
+	}
+
+	identifyTestUserType = testutils.UserType{
+		Name: "identify-modes-person",
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type": "string",
+			},
+			"email": map[string]interface{}{
+				"type": "string",
+			},
+			"given_name": map[string]interface{}{
+				"type": "string",
+			},
+		},
+	}
+)
+
+// identifyNode builds the identifying executor node for the given mode, searching on email.
+func identifyNode(mode, onSuccess, onIncomplete string) map[string]interface{} {
+	return map[string]interface{}{
+		"id":   "identify_user",
+		"type": "TASK_EXECUTION",
+		"executor": map[string]interface{}{
+			"name": "IdentifyingExecutor",
+			"mode": mode,
+			"inputs": []map[string]interface{}{
+				{
+					"ref":        "input_email",
+					"identifier": "email",
+					"type":       "TEXT_INPUT",
+					"required":   true,
+				},
+			},
+		},
+		"onSuccess":    onSuccess,
+		"onIncomplete": onIncomplete,
+	}
+}
+
+// markerPrompt builds a prompt whose single input identifies which branch the flow reached, so a
+// test can assert the branch from the response alone.
+func markerPrompt(id, marker, nextNode string, condition map[string]interface{}) map[string]interface{} {
+	node := map[string]interface{}{
+		"id":   id,
+		"type": "PROMPT",
+		"prompts": []map[string]interface{}{
+			{
+				"inputs": []map[string]interface{}{
+					{
+						"ref":        marker,
+						"identifier": marker,
+						"type":       "TEXT_INPUT",
+						"required":   true,
+					},
+				},
+				"action": map[string]interface{}{
+					"ref":      "action_" + marker,
+					"nextNode": nextNode,
+				},
+			},
+		},
+	}
+	if condition != nil {
+		node["condition"] = condition
+	}
+	return node
+}
+
+// identifyResolveFlowNodes builds a flow that resolves a user by email, asking for a distinguishing
+// attribute when more than one user matches.
+func identifyResolveFlowNodes() []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"id":        "start",
+			"type":      "START",
+			"onSuccess": "prompt_email",
+		},
+		{
+			"id":   "prompt_email",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_email",
+							"identifier": "email",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_email",
+						"nextNode": "identify_user",
+					},
+				},
+			},
+		},
+		identifyNode("resolve", "prompt_resolved", "prompt_disambiguate"),
+		// given_name is declared as a select so the distinct candidate values forwarded by the
+		// executor are merged into it as options.
+		{
+			"id":   "prompt_disambiguate",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_given_name",
+							"identifier": "given_name",
+							"type":       "SELECT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_disambiguate",
+						"nextNode": "identify_user",
+					},
+				},
+			},
+		},
+		markerPrompt("prompt_resolved", "resolved_marker", "auth_assert", nil),
+		{
+			"id":   "auth_assert",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "AuthAssertExecutor",
+			},
+			"onSuccess": "end",
+		},
+		{
+			"id":   "end",
+			"type": "END",
+		},
+	}
+}
+
+// identifyCheckStateFlowNodes builds a flow that records how many users match and then branches on
+// that state, so each of the three outcomes lands on its own prompt.
+func identifyCheckStateFlowNodes() []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"id":        "start",
+			"type":      "START",
+			"onSuccess": "prompt_email",
+		},
+		{
+			"id":   "prompt_email",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_email",
+							"identifier": "email",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_email",
+						"nextNode": "identify_user",
+					},
+				},
+			},
+		},
+		identifyNode("check_state", "prompt_exists", "prompt_email"),
+		markerPrompt("prompt_exists", "state_exists", "auth_assert", map[string]interface{}{
+			"key":    "{{ctx(entityState)}}",
+			"value":  "exists",
+			"onSkip": "prompt_ambiguous",
+		}),
+		markerPrompt("prompt_ambiguous", "state_ambiguous", "auth_assert", map[string]interface{}{
+			"key":    "{{ctx(entityState)}}",
+			"value":  "ambiguous",
+			"onSkip": "prompt_not_exists",
+		}),
+		markerPrompt("prompt_not_exists", "state_not_exists", "auth_assert", nil),
+		{
+			"id":   "auth_assert",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "AuthAssertExecutor",
+			},
+			"onSuccess": "end",
+		},
+		{
+			"id":   "end",
+			"type": "END",
+		},
+	}
+}
+
+type IdentifyModesTestSuite struct {
+	suite.Suite
+	config *common.TestSuiteConfig
+
+	ouID            string
+	userTypeID      string
+	resolveAppID    string
+	checkStateAppID string
+}
+
+func TestIdentifyModesTestSuite(t *testing.T) {
+	suite.Run(t, new(IdentifyModesTestSuite))
+}
+
+func (ts *IdentifyModesTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	ouID, err := testutils.CreateOrganizationUnit(identifyTestOU)
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
+
+	userType := identifyTestUserType
+	userType.OUID = ouID
+	ts.userTypeID, err = testutils.CreateUserType(userType)
+	ts.Require().NoError(err, "Failed to create test user type")
+
+	// Two users share an email and differ only in given_name, which is what makes the email
+	// ambiguous and given_name the attribute that can separate them.
+	for _, attrs := range []string{
+		`{"username":"identify_ada","email":"` + sharedIdentifyEmail + `","given_name":"Ada"}`,
+		`{"username":"identify_bob","email":"` + sharedIdentifyEmail + `","given_name":"Bob"}`,
+		`{"username":"identify_cleo","email":"` + uniqueIdentifyEmail + `","given_name":"Cleo"}`,
+	} {
+		userID, err := testutils.CreateUser(testutils.User{
+			Type:       identifyTestUserType.Name,
+			OUID:       ouID,
+			Attributes: json.RawMessage(attrs),
+		})
+		ts.Require().NoError(err, "Failed to create test user")
+		ts.config.CreatedUserIDs = append(ts.config.CreatedUserIDs, userID)
+	}
+
+	resolveFlowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     "Identify Resolve Test Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_identify_resolve_test",
+		Nodes:    identifyResolveFlowNodes(),
+	})
+	ts.Require().NoError(err, "Failed to create resolve mode flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, resolveFlowID)
+
+	checkStateFlowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     "Identify Check State Test Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_identify_check_state_test",
+		Nodes:    identifyCheckStateFlowNodes(),
+	})
+	ts.Require().NoError(err, "Failed to create check state mode flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, checkStateFlowID)
+
+	ts.resolveAppID, err = testutils.CreateApplication(testutils.Application{
+		Name:             "Identify Resolve Test Application",
+		Description:      "Application for testing identifying executor resolve mode",
+		ClientID:         "identify_resolve_test_client",
+		ClientSecret:     "identify_resolve_test_secret",
+		RedirectURIs:     []string{"http://localhost:3000/callback"},
+		OUID:             ouID,
+		AllowedUserTypes: []string{identifyTestUserType.Name},
+		AuthFlowID:       resolveFlowID,
+	})
+	ts.Require().NoError(err, "Failed to create resolve mode application")
+
+	ts.checkStateAppID, err = testutils.CreateApplication(testutils.Application{
+		Name:             "Identify Check State Test Application",
+		Description:      "Application for testing identifying executor check state mode",
+		ClientID:         "identify_check_state_test_client",
+		ClientSecret:     "identify_check_state_test_secret",
+		RedirectURIs:     []string{"http://localhost:3000/callback"},
+		OUID:             ouID,
+		AllowedUserTypes: []string{identifyTestUserType.Name},
+		AuthFlowID:       checkStateFlowID,
+	})
+	ts.Require().NoError(err, "Failed to create check state mode application")
+}
+
+func (ts *IdentifyModesTestSuite) TearDownSuite() {
+	for _, appID := range []string{ts.resolveAppID, ts.checkStateAppID} {
+		if appID == "" {
+			continue
+		}
+		if err := testutils.DeleteApplication(appID); err != nil {
+			ts.T().Logf("Failed to delete test application during teardown: %v", err)
+		}
+	}
+	for _, userID := range ts.config.CreatedUserIDs {
+		if err := testutils.DeleteUser(userID); err != nil {
+			ts.T().Logf("Failed to delete test user during teardown: %v", err)
+		}
+	}
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete test flow during teardown: %v", err)
+		}
+	}
+	if ts.userTypeID != "" {
+		if err := testutils.DeleteUserType(ts.userTypeID); err != nil {
+			ts.T().Logf("Failed to delete test user type during teardown: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// submitEmail drives a flow to its first prompt and answers it with the given email.
+func (ts *IdentifyModesTestSuite) submitEmail(appID, email string) *common.FlowStep {
+	ts.T().Helper()
+
+	step, err := common.InitiateAuthenticationFlow(appID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate flow")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "Flow should pause for the email")
+
+	step, err = common.CompleteFlow(step.ExecutionID,
+		map[string]string{"email": email}, "action_email", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit the email")
+	return step
+}
+
+// Resolve mode narrows a set of candidates instead of failing on ambiguity: an email matching two
+// users returns the attribute that distinguishes them, with the candidate values as options, and
+// answering it resolves the user. The candidates are carried in the execution, so the second pass
+// filters the stored set rather than searching again.
+func (ts *IdentifyModesTestSuite) TestResolve_AmbiguousCandidatesDisambiguated() {
+	step := ts.submitEmail(ts.resolveAppID, sharedIdentifyEmail)
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus,
+		"Two matching users should pause the flow for disambiguation")
+
+	givenName := findInput(step.Data.Inputs, "given_name")
+	ts.Require().NotNil(givenName, "The distinguishing attribute must be requested")
+	ts.ElementsMatch([]string{"Ada", "Bob"}, givenName.Options,
+		"The options must be the distinct values across the candidates")
+
+	resolved, err := common.CompleteFlow(step.ExecutionID,
+		map[string]string{"given_name": "Ada"}, "action_disambiguate", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit the distinguishing attribute")
+	ts.Equal("INCOMPLETE", resolved.FlowStatus, "The flow should continue once one user matches")
+	ts.NotNil(findInput(resolved.Data.Inputs, "resolved_marker"),
+		"Resolving a single user should carry the flow past the identifying node")
+}
+
+// An email matching exactly one user resolves without any disambiguation step.
+func (ts *IdentifyModesTestSuite) TestResolve_SingleCandidateResolvesImmediately() {
+	step := ts.submitEmail(ts.resolveAppID, uniqueIdentifyEmail)
+	ts.Equal("INCOMPLETE", step.FlowStatus, "The flow should continue past the identifying node")
+	ts.NotNil(findInput(step.Data.Inputs, "resolved_marker"),
+		"A single match should resolve without a disambiguation prompt")
+}
+
+// An email matching no user pauses for more input rather than failing the flow, since the value is
+// user supplied and correctable. The step is routed to the node's onIncomplete prompt, so what marks
+// the outcome is the reported error together with the flow not advancing past identification.
+func (ts *IdentifyModesTestSuite) TestResolve_NoCandidatesPausesWithUserNotFound() {
+	step := ts.submitEmail(ts.resolveAppID, absentIdentifyEmail)
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "No match should pause rather than fail the flow")
+	ts.Require().NotNil(step.Error, "A non-matching email must be reported")
+	ts.Equal(errCodeUserNotFound, step.Error.Code, "No match must be reported as user not found")
+	ts.Nil(findInput(step.Data.Inputs, "resolved_marker"),
+		"An unresolved user must not carry the flow past the identifying node")
+}
+
+// Check state mode never fails on the match count: it records whether zero, one, or several users
+// match and lets the flow branch on it. Each of the three states is asserted from the prompt the
+// flow lands on.
+func (ts *IdentifyModesTestSuite) TestCheckState_ReportsEachMatchState() {
+	for _, tc := range []struct {
+		name   string
+		email  string
+		marker string
+	}{
+		{name: "single match", email: uniqueIdentifyEmail, marker: "state_exists"},
+		{name: "multiple matches", email: sharedIdentifyEmail, marker: "state_ambiguous"},
+		{name: "no match", email: absentIdentifyEmail, marker: "state_not_exists"},
+	} {
+		ts.Run(tc.name, func() {
+			step := ts.submitEmail(ts.checkStateAppID, tc.email)
+			ts.Require().Equal("INCOMPLETE", step.FlowStatus,
+				"Check state mode should always carry the flow forward")
+			ts.NotNil(findInput(step.Data.Inputs, tc.marker),
+				"The flow should branch to the prompt for the %s state", tc.name)
+		})
+	}
+}

--- a/tests/integration/flow/execution/administration_flow_test.go
+++ b/tests/integration/flow/execution/administration_flow_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package execution
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// The shipped user deletion flow. Executing it by handle keeps the test independent of the seeded
+// flow id, which is a bootstrap detail.
+const deletionFlowHandle = "default-user-deletion-flow"
+
+// deletionSubjectInput is the input identifier the deletion executors read the target user from.
+const deletionSubjectInput = "subject"
+
+var (
+	adminFlowTestOU = testutils.OrganizationUnit{
+		Handle:      "admin_flow_test_ou",
+		Name:        "Test OU for Administration Flows",
+		Description: "Organization unit created for administration flow testing",
+		Parent:      nil,
+	}
+
+	adminFlowTestUserType = testutils.UserType{
+		Name: "admin_flow_test_user",
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{"type": "string"},
+			"password": map[string]interface{}{"type": "string", "credential": true},
+		},
+	}
+)
+
+type AdministrationFlowTestSuite struct {
+	suite.Suite
+	ouID         string
+	entityTypeID string
+	flowID       string
+}
+
+func TestAdministrationFlowTestSuite(t *testing.T) {
+	suite.Run(t, new(AdministrationFlowTestSuite))
+}
+
+func (ts *AdministrationFlowTestSuite) SetupSuite() {
+	ouID, err := testutils.CreateOrganizationUnit(adminFlowTestOU)
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
+
+	adminFlowTestUserType.OUID = ts.ouID
+	schemaID, err := testutils.CreateUserType(adminFlowTestUserType)
+	ts.Require().NoError(err, "Failed to create test user type")
+	ts.entityTypeID = schemaID
+
+	flowID, err := testutils.GetFlowIDByHandle(deletionFlowHandle, administrationFlowType)
+	ts.Require().NoError(err, "Failed to resolve the shipped user deletion flow")
+	ts.Require().NotEmpty(flowID, "The shipped user deletion flow must be present")
+	ts.flowID = flowID
+}
+
+func (ts *AdministrationFlowTestSuite) TearDownSuite() {
+	if ts.entityTypeID != "" {
+		if err := testutils.DeleteUserType(ts.entityTypeID); err != nil {
+			ts.T().Logf("Failed to delete test user type during teardown: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// executeAdministrationFlow runs a flow by id as an administrator and returns the resulting step.
+//
+// The bearer token is set directly on a raw client because the shared test clients treat
+// /flow/execute as a public endpoint and skip token injection, which would make every
+// administration request anonymous.
+func (ts *AdministrationFlowTestSuite) executeAdministrationFlow(
+	flowID string, inputs map[string]string) (int, common.FlowStep, []byte) {
+	ts.T().Helper()
+
+	token, err := testutils.GetAccessToken()
+	ts.Require().NoError(err, "Failed to obtain admin access token")
+
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"flowId": flowID,
+		"inputs": inputs,
+	})
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest(http.MethodPost, testServerURL+"/flow/execute", bytes.NewReader(reqBody))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := testutils.GetRawHTTPClient().Do(req)
+	ts.Require().NoError(err, "Failed to execute administration flow")
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+
+	var step common.FlowStep
+	_ = json.Unmarshal(body, &step)
+
+	return resp.StatusCode, step, body
+}
+
+// userExists reports whether the user record is still retrievable.
+func (ts *AdministrationFlowTestSuite) userExists(userID string) bool {
+	ts.T().Helper()
+
+	req, err := http.NewRequest(http.MethodGet, testServerURL+"/users/"+userID, nil)
+	ts.Require().NoError(err)
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err, "Failed to read user")
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	return resp.StatusCode == http.StatusOK
+}
+
+func (ts *AdministrationFlowTestSuite) createTestUser(username string) string {
+	ts.T().Helper()
+
+	attributes, err := json.Marshal(map[string]string{"username": username, "password": "Testpass1"})
+	ts.Require().NoError(err)
+
+	userID, err := testutils.CreateUser(testutils.User{
+		Type:       adminFlowTestUserType.Name,
+		OUID:       ts.ouID,
+		Attributes: attributes,
+	})
+	ts.Require().NoError(err, "Failed to create test user")
+	ts.Require().NotEmpty(userID)
+
+	return userID
+}
+
+// Running the shipped deletion flow to completion exercises the whole administration chain in one
+// execution: the permission validator, the pre-delete validation that publishes the trusted
+// revocation plan, the criteria revocation write, session termination, and the record deletion.
+func (ts *AdministrationFlowTestSuite) TestUserDeletionFlow_CompletesAndDeletesUser() {
+	userID := ts.createTestUser(common.GenerateUniqueUsername("admin_flow_delete"))
+	ts.Require().True(ts.userExists(userID), "The user should exist before deletion")
+
+	status, step, body := ts.executeAdministrationFlow(ts.flowID,
+		map[string]string{deletionSubjectInput: userID})
+
+	ts.Require().Equal(http.StatusOK, status, "Deletion flow execution failed: %s", string(body))
+	ts.Equal("COMPLETE", step.FlowStatus, "Deletion flow should run to completion: %s", string(body))
+	ts.False(ts.userExists(userID), "The user record should be gone after the deletion flow")
+}
+
+// The pre-delete validation runs before anything destructive, so a subject that does not exist is
+// refused rather than producing a completed flow that deleted nothing.
+func (ts *AdministrationFlowTestSuite) TestUserDeletionFlow_UnknownSubjectDoesNotComplete() {
+	status, step, body := ts.executeAdministrationFlow(ts.flowID,
+		map[string]string{deletionSubjectInput: "01900000-0000-7000-8000-0000000000ff"})
+
+	if status == http.StatusOK {
+		ts.NotEqual("COMPLETE", step.FlowStatus,
+			"Deleting an unknown subject must not report success: %s", string(body))
+		return
+	}
+	ts.GreaterOrEqual(status, http.StatusBadRequest,
+		"Deleting an unknown subject should be reported as an error: %s", string(body))
+}
+
+// The flow declares its subject as a required input, so omitting it must not delete anything.
+func (ts *AdministrationFlowTestSuite) TestUserDeletionFlow_MissingSubjectDoesNotComplete() {
+	status, step, body := ts.executeAdministrationFlow(ts.flowID, map[string]string{})
+
+	if status == http.StatusOK {
+		ts.NotEqual("COMPLETE", step.FlowStatus,
+			"A deletion flow with no subject must not report success: %s", string(body))
+		return
+	}
+	ts.GreaterOrEqual(status, http.StatusBadRequest,
+		"A deletion flow with no subject should be reported as an error: %s", string(body))
+}

--- a/tests/integration/flow/execution/call_depth_test.go
+++ b/tests/integration/flow/execution/call_depth_test.go
@@ -1,0 +1,181 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package execution
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// errCodeMaxCallDepth is returned when nested CALL nodes exceed the engine's frame limit.
+const errCodeMaxCallDepth = "FES-1013"
+
+// callChainLength is longer than the engine's maximum call depth of 10 frames, so executing the head
+// of the chain is guaranteed to cross the limit.
+const callChainLength = 12
+
+var callDepthTestOU = testutils.OrganizationUnit{
+	Handle:      "call_depth_test_ou",
+	Name:        "Test OU for Call Depth",
+	Description: "Organization unit created for call depth testing",
+	Parent:      nil,
+}
+
+type CallDepthTestSuite struct {
+	suite.Suite
+	ouID     string
+	appID    string
+	flowIDs  []string
+	headFlow string
+}
+
+func TestCallDepthTestSuite(t *testing.T) {
+	suite.Run(t, new(CallDepthTestSuite))
+}
+
+// SetupSuite builds a chain of authentication flows where each one calls the next, then binds an
+// application to the head of the chain. The chain is built from the tail backwards because a CALL
+// node must reference a flow that already exists.
+func (ts *CallDepthTestSuite) SetupSuite() {
+	ouID, err := testutils.CreateOrganizationUnit(callDepthTestOU)
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
+
+	// The tail is a plain authentication flow that calls nothing.
+	tailID, err := testutils.CreateFlow(ts.buildLeafFlow())
+	ts.Require().NoError(err, "Failed to create leaf flow")
+	ts.flowIDs = append(ts.flowIDs, tailID)
+
+	next := tailID
+	for i := 0; i < callChainLength; i++ {
+		flowID, err := testutils.CreateFlow(ts.buildCallingFlow(i, next))
+		ts.Require().NoError(err, "Failed to create calling flow %d", i)
+		ts.flowIDs = append(ts.flowIDs, flowID)
+		next = flowID
+	}
+	ts.headFlow = next
+
+	app := testutils.Application{
+		Name:         "Call Depth Test Application",
+		Description:  "Application bound to a deeply nested call chain",
+		ClientID:     "call_depth_test_client",
+		ClientSecret: "call_depth_test_secret", //nolint:gosec // test credential
+		RedirectURIs: []string{"http://localhost:3000/callback"},
+		OUID:         ts.ouID,
+		AuthFlowID:   ts.headFlow,
+	}
+	appID, err := testutils.CreateApplication(app)
+	ts.Require().NoError(err, "Failed to create test application")
+	ts.appID = appID
+}
+
+func (ts *CallDepthTestSuite) TearDownSuite() {
+	if ts.appID != "" {
+		if err := testutils.DeleteApplication(ts.appID); err != nil {
+			ts.T().Logf("Failed to delete test application during teardown: %v", err)
+		}
+	}
+	// Delete from the head backwards so a flow is never removed while another still references it.
+	for i := len(ts.flowIDs) - 1; i >= 0; i-- {
+		if err := testutils.DeleteFlow(ts.flowIDs[i]); err != nil {
+			ts.T().Logf("Failed to delete flow %s during teardown: %v", ts.flowIDs[i], err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// credentialsAuthNodes returns the credential prompt, the authentication executor and the assertion
+// that make up a complete authentication flow, ending at the given node.
+//
+// Every flow in the chain carries these so each one is a valid authentication flow in its own right
+// rather than a graph that only happens to be accepted today, which keeps the fixture standing as
+// flow validation gains rules.
+func credentialsAuthNodes(endNode string) []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"id":   "credentials_prompt",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+						{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_credentials",
+						"nextNode": "credentials_auth",
+					},
+				},
+			},
+		},
+		{
+			"id":        "credentials_auth",
+			"type":      "TASK_EXECUTION",
+			"executor":  map[string]interface{}{"name": "CredentialsAuthExecutor"},
+			"onSuccess": "auth_assert",
+		},
+		{
+			"id":        "auth_assert",
+			"type":      "TASK_EXECUTION",
+			"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+			"onSuccess": endNode,
+		},
+		{"id": endNode, "type": "END"},
+	}
+}
+
+// buildLeafFlow returns the flow at the end of the chain, which calls nothing and authenticates the
+// user itself.
+func (ts *CallDepthTestSuite) buildLeafFlow() testutils.Flow {
+	nodes := []map[string]interface{}{
+		{"id": "start", "type": "START", "onSuccess": "credentials_prompt"},
+	}
+	return testutils.Flow{
+		Name:     "Call Depth Leaf Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_call_depth_leaf",
+		Nodes:    append(nodes, credentialsAuthNodes("end")...),
+	}
+}
+
+// buildCallingFlow returns a flow whose only work is to call the given target flow.
+//
+// Its own authentication section sits after the CALL, so the chain still descends on the first node
+// and trips the depth limit before any prompt is reached.
+func (ts *CallDepthTestSuite) buildCallingFlow(index int, targetFlowID string) testutils.Flow {
+	nodes := []map[string]interface{}{
+		{"id": "start", "type": "START", "onSuccess": "call_next"},
+		{
+			"id":        "call_next",
+			"type":      "CALL",
+			"flow":      map[string]interface{}{"ref": targetFlowID},
+			"onSuccess": "credentials_prompt",
+		},
+	}
+	return testutils.Flow{
+		Name:     fmt.Sprintf("Call Depth Link %d Flow", index),
+		FlowType: "AUTHENTICATION",
+		Handle:   fmt.Sprintf("auth_flow_call_depth_link_%d", index),
+		Nodes:    append(nodes, credentialsAuthNodes("end")...),
+	}
+}
+
+// A chain of nested CALL nodes deeper than the engine allows must be refused rather than recursing
+// until the process runs out of stack. The limit is what stops a mutually recursive set of flows,
+// which the flow designer does not prevent an operator from authoring, from taking the server down.
+func (ts *CallDepthTestSuite) TestExecute_ExceedingCallDepthRejected() {
+	// ErrorMaxCallDepthExceeded is a client error, so the engine refuses the request with 400 and
+	// names the limit in the response rather than recursing until the process runs out of stack.
+	errResp, err := common.InitiateAuthFlowWithError(ts.appID, nil)
+	ts.Require().NoError(err, "a call chain past the depth limit must be rejected as a client error")
+	ts.Equal(errCodeMaxCallDepth, errResp.Code, "the failure must name the call depth limit")
+}

--- a/tests/integration/flow/execution/call_frames_test.go
+++ b/tests/integration/flow/execution/call_frames_test.go
@@ -1,0 +1,315 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package execution
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const callFramesPassword = "SecurePass123!"
+
+// callFramesUserType is the minimum a callee needs to authenticate someone, so the call can return
+// to its caller rather than failing.
+var callFramesUserType = testutils.UserType{
+	Name: "call-frames-person",
+	Schema: map[string]interface{}{
+		"username": map[string]interface{}{
+			"type": "string",
+		},
+		"password": map[string]interface{}{
+			"type":       "string",
+			"credential": true,
+		},
+	},
+}
+
+// callerNodes builds a flow whose first step calls another flow. onFailure is optional: without it a
+// failing callee ends the caller, with it the caller carries on at that node.
+func callerNodes(calleeFlowID, onFailure string) []map[string]interface{} {
+	callNode := map[string]interface{}{
+		"id":        "call_callee",
+		"type":      "CALL",
+		"flow":      map[string]interface{}{"ref": calleeFlowID},
+		"onSuccess": "prompt_returned",
+	}
+	if onFailure != "" {
+		callNode["onFailure"] = onFailure
+	}
+
+	nodes := []map[string]interface{}{
+		{"id": "start", "type": "START", "onSuccess": "call_callee"},
+		callNode,
+		markerPromptNode("prompt_returned", "returned_marker", "auth_assert"),
+	}
+
+	// Flow validation rejects a node nothing can reach, so the failure target exists only in the
+	// variant whose call node points at it.
+	if onFailure != "" {
+		nodes = append(nodes, markerPromptNode(onFailure, "recovered_marker", "auth_assert"))
+	}
+
+	return append(nodes,
+		map[string]interface{}{
+			"id":        "auth_assert",
+			"type":      "TASK_EXECUTION",
+			"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+			"onSuccess": "end",
+		},
+		map[string]interface{}{"id": "end", "type": "END"},
+	)
+}
+
+// markerPromptNode builds a prompt whose single input names the branch the flow reached, so a test
+// can tell where the caller resumed from the response alone.
+func markerPromptNode(id, marker, nextNode string) map[string]interface{} {
+	return map[string]interface{}{
+		"id":   id,
+		"type": "PROMPT",
+		"prompts": []map[string]interface{}{
+			{
+				"inputs": []map[string]interface{}{
+					{
+						"ref":        marker,
+						"identifier": marker,
+						"type":       "TEXT_INPUT",
+						"required":   true,
+					},
+				},
+				"action": map[string]interface{}{
+					"ref":      "action_" + marker,
+					"nextNode": nextNode,
+				},
+			},
+		},
+	}
+}
+
+type CallFramesTestSuite struct {
+	suite.Suite
+	config *common.TestSuiteConfig
+
+	ouID       string
+	userTypeID string
+	userID     string
+	username   string
+
+	pausingAppID     string
+	failingAppID     string
+	recoveringAppID  string
+	createdAppIDList []string
+}
+
+func TestCallFramesTestSuite(t *testing.T) {
+	suite.Run(t, new(CallFramesTestSuite))
+}
+
+func (ts *CallFramesTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "call_frames_test_ou",
+		Name:        "Call Frames Test OU",
+		Description: "Organization unit for call frame testing",
+		Parent:      nil,
+	})
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
+
+	userType := callFramesUserType
+	userType.OUID = ouID
+	ts.userTypeID, err = testutils.CreateUserType(userType)
+	ts.Require().NoError(err, "Failed to create test user type")
+
+	ts.username = common.GenerateUniqueUsername("call_frames")
+	ts.userID, err = testutils.CreateUser(testutils.User{
+		Type: callFramesUserType.Name,
+		OUID: ouID,
+		Attributes: json.RawMessage(`{
+			"username": "` + ts.username + `",
+			"password": "` + callFramesPassword + `"
+		}`),
+	})
+	ts.Require().NoError(err, "Failed to create test user")
+
+	// A callee that pauses for credentials and then authenticates, so the call both suspends inside
+	// the callee and later returns to its caller.
+	pausingCalleeID := ts.createFlow("Call Frames Pausing Callee", "auth_flow_call_frames_callee", []map[string]interface{}{
+		{"id": "start", "type": "START", "onSuccess": "prompt_credentials"},
+		{
+			"id":   "prompt_credentials",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_001",
+							"identifier": "username",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_002",
+							"identifier": "password",
+							"type":       "PASSWORD_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_001",
+						"nextNode": "credentials_auth",
+					},
+				},
+			},
+		},
+		{
+			"id":           "credentials_auth",
+			"type":         "TASK_EXECUTION",
+			"executor":     map[string]interface{}{"name": "CredentialsAuthExecutor"},
+			"onSuccess":    "callee_assert",
+			"onIncomplete": "prompt_credentials",
+		},
+		{
+			"id":        "callee_assert",
+			"type":      "TASK_EXECUTION",
+			"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+			"onSuccess": "end",
+		},
+		{"id": "end", "type": "END"},
+	})
+
+	// A callee that fails at its first node, because nothing has authenticated a user for it to
+	// assert.
+	failingCalleeID := ts.createFlow("Call Frames Failing Callee", "auth_flow_call_frames_failing_callee",
+		[]map[string]interface{}{
+			{"id": "start", "type": "START", "onSuccess": "callee_assert"},
+			{
+				"id":        "callee_assert",
+				"type":      "TASK_EXECUTION",
+				"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+				"onSuccess": "end",
+			},
+			{"id": "end", "type": "END"},
+		})
+
+	pausingCallerID := ts.createFlow("Call Frames Pausing Caller", "auth_flow_call_frames_caller",
+		callerNodes(pausingCalleeID, ""))
+	failingCallerID := ts.createFlow("Call Frames Failing Caller", "auth_flow_call_frames_failing_caller",
+		callerNodes(failingCalleeID, ""))
+	recoveringCallerID := ts.createFlow("Call Frames Recovering Caller",
+		"auth_flow_call_frames_recovering_caller", callerNodes(failingCalleeID, "prompt_recovered"))
+
+	ts.pausingAppID = ts.createApp("Call Frames Pausing App", "call_frames_pausing_client", pausingCallerID)
+	ts.failingAppID = ts.createApp("Call Frames Failing App", "call_frames_failing_client", failingCallerID)
+	ts.recoveringAppID = ts.createApp("Call Frames Recovering App", "call_frames_recovering_client",
+		recoveringCallerID)
+}
+
+func (ts *CallFramesTestSuite) createFlow(name, handle string, nodes []map[string]interface{}) string {
+	ts.T().Helper()
+
+	flowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     name,
+		FlowType: "AUTHENTICATION",
+		Handle:   handle,
+		Nodes:    nodes,
+	})
+	ts.Require().NoError(err, "Failed to create flow %s", handle)
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
+	return flowID
+}
+
+func (ts *CallFramesTestSuite) createApp(name, clientID, flowID string) string {
+	ts.T().Helper()
+
+	appID, err := testutils.CreateApplication(testutils.Application{
+		Name:             name,
+		Description:      "Application for call frame testing",
+		ClientID:         clientID,
+		ClientSecret:     clientID + "_secret",
+		RedirectURIs:     []string{"http://localhost:3000/callback"},
+		OUID:             ts.ouID,
+		AllowedUserTypes: []string{callFramesUserType.Name},
+		AuthFlowID:       flowID,
+	})
+	ts.Require().NoError(err, "Failed to create application %s", name)
+	ts.createdAppIDList = append(ts.createdAppIDList, appID)
+	return appID
+}
+
+func (ts *CallFramesTestSuite) TearDownSuite() {
+	for _, appID := range ts.createdAppIDList {
+		if err := testutils.DeleteApplication(appID); err != nil {
+			ts.T().Logf("teardown: failed to delete application: %v", err)
+		}
+	}
+	if ts.userID != "" {
+		if err := testutils.DeleteUser(ts.userID); err != nil {
+			ts.T().Logf("teardown: failed to delete user: %v", err)
+		}
+	}
+	// Callers reference callees, so the callers created last are removed first.
+	for i := len(ts.config.CreatedFlowIDs) - 1; i >= 0; i-- {
+		if err := testutils.DeleteFlow(ts.config.CreatedFlowIDs[i]); err != nil {
+			ts.T().Logf("teardown: failed to delete flow: %v", err)
+		}
+	}
+	if ts.userTypeID != "" {
+		if err := testutils.DeleteUserType(ts.userTypeID); err != nil {
+			ts.T().Logf("teardown: failed to delete user type: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("teardown: failed to delete organization unit: %v", err)
+		}
+	}
+}
+
+// A call that pauses inside the callee has to survive the round trip to the client: the caller's
+// frame is written into the stored context and read back on resume. Once the callee completes, the
+// call returns to its caller, which continues at the call node's success target rather than ending
+// with the callee.
+func (ts *CallFramesTestSuite) TestCall_PausesInsideCalleeAndReturnsToCaller() {
+	step, err := common.InitiateAuthenticationFlow(ts.pausingAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate flow")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "The call should pause inside the callee")
+	ts.Require().True(common.HasInput(step.Data.Inputs, "username"),
+		"The paused step must be the callee's own prompt")
+
+	returned, err := common.CompleteFlow(step.ExecutionID, map[string]string{
+		"username": ts.username,
+		"password": callFramesPassword,
+	}, "action_001", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to resume the paused call")
+	ts.Require().Equal("INCOMPLETE", returned.FlowStatus,
+		"The caller should carry on rather than end with the callee")
+	ts.True(common.HasInput(returned.Data.Inputs, "returned_marker"),
+		"A completed callee must return to the caller's success target")
+}
+
+// A callee that fails ends the caller too when the call node names no failure target, so a failing
+// call cannot silently fall through to whatever follows it.
+func (ts *CallFramesTestSuite) TestCall_CalleeFailureWithoutOnFailureEndsFlow() {
+	step, err := common.InitiateAuthenticationFlow(ts.failingAppID, false, nil, "")
+	ts.Require().NoError(err, "The flow should return a step rather than a transport error")
+	ts.Equal("ERROR", step.FlowStatus, "A failing callee must end the caller in error")
+	ts.False(common.HasInput(step.Data.Inputs, "returned_marker"),
+		"A failing callee must not reach the caller's success target")
+}
+
+// When the call node does name a failure target, the caller resumes there instead of ending, which
+// is what lets a flow offer an alternative after a called flow could not complete.
+func (ts *CallFramesTestSuite) TestCall_CalleeFailureForwardsToOnFailure() {
+	step, err := common.InitiateAuthenticationFlow(ts.recoveringAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate flow")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus,
+		"A failing callee with a failure target should keep the caller running")
+	ts.True(common.HasInput(step.Data.Inputs, "recovered_marker"),
+		"The caller must resume at the call node's failure target")
+}

--- a/tests/integration/flow/execution/flow_events_test.go
+++ b/tests/integration/flow/execution/flow_events_test.go
@@ -1,0 +1,459 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package execution
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	eventTypeFlowStarted        = "FLOW_STARTED"
+	eventTypeNodeExecStarted    = "FLOW_NODE_EXECUTION_STARTED"
+	eventTypeNodeExecCompleted  = "FLOW_NODE_EXECUTION_COMPLETED"
+	eventTypeNodeExecFailed     = "FLOW_NODE_EXECUTION_FAILED"
+	eventTypeFlowCompletedEvent = "FLOW_COMPLETED"
+
+	// The observability file adapter flushes on a fixed five second ticker, so a test that reads the
+	// sink has to wait past one tick rather than expecting an immediate write.
+	eventFlushWait = 9 * time.Second
+
+	eventsTestPassword = "SecurePass123!"
+)
+
+// Observability is off by default, so the events it publishes need the deployment section enabled
+// and a restart before any of them are written. The file sink is what makes the events assertable.
+var (
+	observabilityEnablePatch = map[string]interface{}{
+		"observability": map[string]interface{}{
+			"enabled": true,
+			"output": map[string]interface{}{
+				"file": map[string]interface{}{
+					"enabled": true,
+					"format":  "json",
+				},
+			},
+		},
+	}
+
+	observabilityDisablePatch = map[string]interface{}{
+		"observability": map[string]interface{}{
+			"enabled": false,
+		},
+	}
+)
+
+// observabilityEvent is the subset of a published event this suite asserts on.
+type observabilityEvent struct {
+	TraceID string                 `json:"trace_id"`
+	Type    string                 `json:"type"`
+	Status  string                 `json:"status"`
+	Data    map[string]interface{} `json:"data"`
+}
+
+// dataString reads a string-valued data field, which is how the flow engine writes the scalar
+// fields; non-scalar fields (such as a structured error) come back as the empty string.
+func (e observabilityEvent) dataString(key string) string {
+	if value, ok := e.Data[key].(string); ok {
+		return value
+	}
+	return ""
+}
+
+type FlowEventsTestSuite struct {
+	suite.Suite
+	config *common.TestSuiteConfig
+
+	ouID       string
+	userTypeID string
+	appID      string
+	// An application whose flow asserts an authenticated user without authenticating one, so the
+	// run fails at a node instead of pausing for input.
+	failingAppID string
+	userID       string
+	username     string
+}
+
+func TestFlowEventsTestSuite(t *testing.T) {
+	suite.Run(t, new(FlowEventsTestSuite))
+}
+
+func (ts *FlowEventsTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	ts.Require().NoError(testutils.PatchDeploymentConfig(observabilityEnablePatch),
+		"failed to enable observability")
+	ts.Require().NoError(testutils.RestartServer(),
+		"failed to restart server with observability enabled")
+	ts.Require().NoError(testutils.ObtainAdminAccessToken(),
+		"failed to re-obtain admin token after restart")
+
+	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "flow_events_test_ou",
+		Name:        "Flow Events Test OU",
+		Description: "Organization unit for flow observability event testing",
+		Parent:      nil,
+	})
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
+
+	ts.userTypeID, err = testutils.CreateUserType(testutils.UserType{
+		Name: "flow-events-person",
+		OUID: ouID,
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type": "string",
+			},
+			"password": map[string]interface{}{
+				"type":       "string",
+				"credential": true,
+			},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create test user type")
+
+	ts.username = common.GenerateUniqueUsername("flow_events")
+	ts.userID, err = testutils.CreateUser(testutils.User{
+		Type: "flow-events-person",
+		OUID: ouID,
+		Attributes: json.RawMessage(`{
+			"username": "` + ts.username + `",
+			"password": "` + eventsTestPassword + `"
+		}`),
+	})
+	ts.Require().NoError(err, "Failed to create test user")
+
+	flowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     "Flow Events Test Auth Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_events_test",
+		Nodes: []map[string]interface{}{
+			{
+				"id":        "start",
+				"type":      "START",
+				"onSuccess": "prompt_credentials",
+			},
+			{
+				"id":   "prompt_credentials",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_001",
+								"identifier": "username",
+								"type":       "TEXT_INPUT",
+								"required":   true,
+							},
+							{
+								"ref":        "input_002",
+								"identifier": "password",
+								"type":       "PASSWORD_INPUT",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_001",
+							"nextNode": "credentials_auth",
+						},
+					},
+				},
+			},
+			{
+				"id":   "credentials_auth",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "CredentialsAuthExecutor",
+				},
+				"onSuccess":    "auth_assert",
+				"onIncomplete": "prompt_credentials",
+			},
+			{
+				"id":   "auth_assert",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "AuthAssertExecutor",
+				},
+				"onSuccess": "end",
+			},
+			{
+				"id":   "end",
+				"type": "END",
+			},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create test flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
+
+	ts.appID, err = testutils.CreateApplication(testutils.Application{
+		Name:             "Flow Events Test Application",
+		Description:      "Application for flow observability event testing",
+		ClientID:         "flow_events_test_client",
+		ClientSecret:     "flow_events_test_secret",
+		RedirectURIs:     []string{"http://localhost:3000/callback"},
+		OUID:             ouID,
+		AllowedUserTypes: []string{"flow-events-person"},
+		AuthFlowID:       flowID,
+	})
+	ts.Require().NoError(err, "Failed to create test application")
+
+	failingFlowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     "Flow Events Failing Auth Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_events_failing_test",
+		Nodes: []map[string]interface{}{
+			{
+				"id":        "start",
+				"type":      "START",
+				"onSuccess": "auth_assert",
+			},
+			{
+				"id":   "auth_assert",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "AuthAssertExecutor",
+				},
+				"onSuccess": "end",
+			},
+			{
+				"id":   "end",
+				"type": "END",
+			},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create failing test flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, failingFlowID)
+
+	ts.failingAppID, err = testutils.CreateApplication(testutils.Application{
+		Name:             "Flow Events Failing Test Application",
+		Description:      "Application whose flow fails at its first node",
+		ClientID:         "flow_events_failing_test_client",
+		ClientSecret:     "flow_events_failing_test_secret",
+		RedirectURIs:     []string{"http://localhost:3000/callback"},
+		OUID:             ouID,
+		AllowedUserTypes: []string{"flow-events-person"},
+		AuthFlowID:       failingFlowID,
+	})
+	ts.Require().NoError(err, "Failed to create failing test application")
+}
+
+func (ts *FlowEventsTestSuite) TearDownSuite() {
+	for _, appID := range []string{ts.appID, ts.failingAppID} {
+		if appID == "" {
+			continue
+		}
+		if err := testutils.DeleteApplication(appID); err != nil {
+			ts.T().Logf("teardown: failed to delete application: %v", err)
+		}
+	}
+	if ts.userID != "" {
+		if err := testutils.DeleteUser(ts.userID); err != nil {
+			ts.T().Logf("teardown: failed to delete user: %v", err)
+		}
+	}
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("teardown: failed to delete flow: %v", err)
+		}
+	}
+	if ts.userTypeID != "" {
+		if err := testutils.DeleteUserType(ts.userTypeID); err != nil {
+			ts.T().Logf("teardown: failed to delete user type: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("teardown: failed to delete organization unit: %v", err)
+		}
+	}
+
+	if err := testutils.PatchDeploymentConfig(observabilityDisablePatch); err != nil {
+		ts.T().Logf("teardown: failed to restore observability config: %v", err)
+	}
+	if err := testutils.RestartServer(); err != nil {
+		ts.T().Logf("teardown: server did not restart cleanly after config restore: %v", err)
+	}
+	if err := testutils.ObtainAdminAccessToken(); err != nil {
+		ts.T().Logf("teardown: failed to re-obtain admin token after restore: %v", err)
+	}
+}
+
+// observabilityLogPath is where the file sink writes when no explicit path is configured.
+func (ts *FlowEventsTestSuite) observabilityLogPath() string {
+	return filepath.Join(testutils.GetExtractedProductHome(), "logs", "observability", "observability.log")
+}
+
+// eventsForExecution reads the sink and returns the events carrying the given execution id. The
+// adapter buffers and flushes on a fixed ticker, so the read is retried until the caller's condition
+// holds. Waiting on a precise condition rather than on any event of a type is what stops the read
+// from returning a half-flushed prefix of the run: an earlier node's event of the same type would
+// otherwise satisfy the wait while the node under test is still buffered.
+func (ts *FlowEventsTestSuite) eventsForExecution(executionID string,
+	done func([]observabilityEvent) bool) []observabilityEvent {
+	ts.T().Helper()
+
+	deadline := time.Now().Add(eventFlushWait)
+	var matched []observabilityEvent
+
+	for {
+		matched = ts.readEvents(executionID)
+		if done(matched) || time.Now().After(deadline) {
+			return matched
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+// hasType reports whether an event of the given type is present.
+func hasType(eventType string) func([]observabilityEvent) bool {
+	return func(events []observabilityEvent) bool {
+		return typesOf(events)[eventType]
+	}
+}
+
+// hasNodeEvent reports whether the given node published an event of the given type.
+func hasNodeEvent(eventType, nodeID string) func([]observabilityEvent) bool {
+	return func(events []observabilityEvent) bool {
+		return eventFor(events, eventType, nodeID) != nil
+	}
+}
+
+func (ts *FlowEventsTestSuite) readEvents(executionID string) []observabilityEvent {
+	ts.T().Helper()
+
+	file, err := os.Open(ts.observabilityLogPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		ts.Require().NoError(err, "Failed to open the observability sink")
+	}
+	defer file.Close()
+
+	var matched []observabilityEvent
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var evt observabilityEvent
+		if err := json.Unmarshal(line, &evt); err != nil {
+			continue
+		}
+		if evt.TraceID == executionID || evt.dataString("execution_id") == executionID {
+			matched = append(matched, evt)
+		}
+	}
+	return matched
+}
+
+// typesOf returns the event types present in the given events.
+func typesOf(events []observabilityEvent) map[string]bool {
+	types := make(map[string]bool, len(events))
+	for _, evt := range events {
+		types[evt.Type] = true
+	}
+	return types
+}
+
+// eventFor returns the first event of the given type touching the given node.
+func eventFor(events []observabilityEvent, eventType, nodeID string) *observabilityEvent {
+	for i := range events {
+		if events[i].Type == eventType && events[i].dataString("node_id") == nodeID {
+			return &events[i]
+		}
+	}
+	return nil
+}
+
+// A completed flow publishes the execution trail an operator needs to follow it: the flow starting,
+// each node starting and completing, and the flow completing. All of them are correlated by the
+// execution id, which is what makes a single run reconstructable from the sink.
+func (ts *FlowEventsTestSuite) TestFlowEvents_SuccessfulRunPublishesNodeTrail() {
+	step, err := common.InitiateAuthenticationFlow(ts.appID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate flow")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "Flow should pause at the credentials prompt")
+
+	completed, err := common.CompleteFlow(step.ExecutionID, map[string]string{
+		"username": ts.username,
+		"password": eventsTestPassword,
+	}, "action_001", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit credentials")
+	ts.Require().Equal("COMPLETE", completed.FlowStatus, "The flow should authenticate the user")
+
+	events := ts.eventsForExecution(step.ExecutionID, hasType(eventTypeFlowCompletedEvent))
+	ts.Require().NotEmpty(events, "The run should have published events to the sink")
+
+	present := typesOf(events)
+	ts.True(present[eventTypeFlowStarted], "the flow start should be published")
+	ts.True(present[eventTypeNodeExecStarted], "node executions should be published as they start")
+	ts.True(present[eventTypeNodeExecCompleted], "node executions should be published as they complete")
+	ts.True(present[eventTypeFlowCompletedEvent], "the flow completion should be published")
+
+	authEvent := eventFor(events, eventTypeNodeExecCompleted, "credentials_auth")
+	ts.Require().NotNil(authEvent, "the authenticating node must publish a completion event")
+	ts.Equal("success", authEvent.Status, "a node that completed must be published as a success")
+	ts.Equal("1", authEvent.dataString("attempt_number"),
+		"the first execution of a node is its first attempt")
+	ts.NotEmpty(authEvent.dataString("step_number"), "a node execution must carry its step number")
+	ts.NotEmpty(authEvent.dataString("duration_ms"), "a node execution must carry how long it took")
+}
+
+// A wrong password does not fail the node. The executor forwards back to the prompt, so the run
+// publishes the authenticating node as completed with the forwarding status and the reason, and the
+// re-presented prompt as incomplete carrying the same reason. Both are published as successes: the
+// step did not pass, but nothing broke.
+func (ts *FlowEventsTestSuite) TestFlowEvents_ForwardedNodePublishesReason() {
+	step, err := common.InitiateAuthenticationFlow(ts.appID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate flow")
+
+	retried, err := common.CompleteFlow(step.ExecutionID, map[string]string{
+		"username": ts.username,
+		"password": "WrongPassword123!",
+	}, "action_001", step.ChallengeToken)
+	ts.Require().NoError(err, "A wrong password should still return a flow step")
+	ts.Require().Equal("INCOMPLETE", retried.FlowStatus,
+		"A wrong password should re-prompt rather than end the flow")
+
+	events := ts.eventsForExecution(step.ExecutionID,
+		hasNodeEvent(eventTypeNodeExecCompleted, "credentials_auth"))
+	ts.Require().NotEmpty(events, "The run should have published events to the sink")
+
+	authEvent := eventFor(events, eventTypeNodeExecCompleted, "credentials_auth")
+	ts.Require().NotNil(authEvent, "the authenticating node must publish its execution")
+	ts.Equal("success", authEvent.Status,
+		"a node that forwarded is not a broken node, so it is published as a success")
+	ts.Equal("FORWARD", authEvent.dataString("node_status"),
+		"a node that forwards back to its prompt must be published with the forwarding status")
+	ts.NotNil(authEvent.Data["error"], "the published event must carry why the step did not pass")
+}
+
+// A node that genuinely fails is published as a failure, and the run it belongs to is published as
+// failed. Asserting an authenticated user without anything having authenticated one is the shortest
+// flow that fails at a node rather than pausing for input.
+func (ts *FlowEventsTestSuite) TestFlowEvents_FailedNodePublishesFailure() {
+	step, err := common.InitiateAuthenticationFlow(ts.failingAppID, false, nil, "")
+	ts.Require().NoError(err, "The flow should return a step rather than a transport error")
+	ts.Require().NotEmpty(step.ExecutionID, "A failed run must still report its execution id")
+
+	events := ts.eventsForExecution(step.ExecutionID, hasNodeEvent(eventTypeNodeExecFailed, "auth_assert"))
+	ts.Require().NotEmpty(events, "The run should have published events to the sink")
+
+	authEvent := eventFor(events, eventTypeNodeExecFailed, "auth_assert")
+	ts.Require().NotNil(authEvent, "a node that failed must publish a failure event")
+	ts.Equal("failure", authEvent.Status, "a failed node must be published as a failure")
+	ts.Equal("ERROR", authEvent.dataString("node_status"),
+		"a failed node must be published with the error status")
+	ts.NotNil(authEvent.Data["error"], "a failure event must carry what went wrong")
+}

--- a/tests/integration/flow/execution/flow_execution_error_test.go
+++ b/tests/integration/flow/execution/flow_execution_error_test.go
@@ -1,0 +1,343 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package execution
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// Error codes returned by the flow execution service. Asserting the code rather than the message
+// keeps these tests independent of i18n wording.
+const (
+	errCodeInvalidAppID         = "FES-1003"
+	errCodeInvalidExecutionID   = "FES-1004"
+	errCodeInvalidFlowType      = "FES-1005"
+	errCodeRegistrationDisabled = "FES-1006"
+	errCodeRecoveryDisabled     = "FES-1009"
+	errCodeAdminAuthRequired    = "FES-1017"
+	errCodeFlowIDNotPermitted   = "FES-1018"
+	// errCodeAdminPermissionNeeded (FES-1019) is not asserted yet: it needs a signed-in user whose
+	// permissions omit the system scope. See TestExecuteByFlowID_ClientCredentialsTokenRejected.
+
+	errorTestClientID     = "flow_execution_error_test_client"
+	errorTestClientSecret = "flow_execution_error_test_secret" //nolint:gosec // test credential
+)
+
+var (
+	errorTestOU = testutils.OrganizationUnit{
+		Handle:      "flow_exec_error_test_ou",
+		Name:        "Test OU for Flow Execution Errors",
+		Description: "Organization unit created for flow execution error testing",
+		Parent:      nil,
+	}
+
+	// A minimal authentication flow. These tests never complete it; they only need an application
+	// bound to a real flow so that rejections come from the branch under test rather than from
+	// missing configuration.
+	errorTestFlow = testutils.Flow{
+		Name:     "Flow Execution Error Test Auth Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_execution_error_test",
+		Nodes: []map[string]interface{}{
+			{
+				"id":        "start",
+				"type":      "START",
+				"onSuccess": "prompt_credentials",
+			},
+			{
+				"id":   "prompt_credentials",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_001",
+								"identifier": "username",
+								"type":       "TEXT_INPUT",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_001",
+							"nextNode": "auth_assert",
+						},
+					},
+				},
+			},
+			{
+				// Flow validation requires an AuthAssertExecutor on every AUTHENTICATION flow, so this
+				// node is here to make the definition valid rather than because the tests reach it.
+				"id":   "auth_assert",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "AuthAssertExecutor",
+				},
+				"onSuccess": "end",
+			},
+			{
+				"id":   "end",
+				"type": "END",
+			},
+		},
+	}
+
+	// Registration and recovery are both left disabled so their "flow disabled" branches are
+	// reachable from this one application.
+	errorTestApp = testutils.Application{
+		Name:                      "Flow Execution Error Test Application",
+		Description:               "Application for testing flow execution error branches",
+		IsRegistrationFlowEnabled: false,
+		IsRecoveryFlowEnabled:     false,
+		ClientID:                  errorTestClientID,
+		ClientSecret:              errorTestClientSecret,
+		RedirectURIs:              []string{"http://localhost:3000/callback"},
+	}
+)
+
+type FlowExecutionErrorTestSuite struct {
+	suite.Suite
+	config *common.TestSuiteConfig
+	ouID   string
+	appID  string
+	flowID string
+}
+
+func TestFlowExecutionErrorTestSuite(t *testing.T) {
+	suite.Run(t, new(FlowExecutionErrorTestSuite))
+}
+
+func (ts *FlowExecutionErrorTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	ouID, err := testutils.CreateOrganizationUnit(errorTestOU)
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
+
+	flowID, err := testutils.CreateFlow(errorTestFlow)
+	ts.Require().NoError(err, "Failed to create test flow")
+	ts.flowID = flowID
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
+
+	errorTestApp.OUID = ts.ouID
+	errorTestApp.AuthFlowID = flowID
+	appID, err := testutils.CreateApplication(errorTestApp)
+	ts.Require().NoError(err, "Failed to create test application")
+	ts.appID = appID
+}
+
+func (ts *FlowExecutionErrorTestSuite) TearDownSuite() {
+	if ts.appID != "" {
+		if err := testutils.DeleteApplication(ts.appID); err != nil {
+			ts.T().Logf("Failed to delete test application during teardown: %v", err)
+		}
+	}
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete test flow during teardown: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// executeFlow posts an arbitrary body to /flow/execute and returns the status and decoded error.
+//
+// A raw client is used deliberately. The shared test clients wrap an auth transport that treats
+// /flow/execute as a public endpoint and skips token injection entirely, so neither GetHTTPClient
+// nor GetHTTPClientWithToken can authenticate against the administration entry point. Passing an
+// empty token exercises the unauthenticated path; a non-empty one sets the header directly.
+func (ts *FlowExecutionErrorTestSuite) executeFlow(
+	body map[string]interface{}, bearerToken string) (int, common.ErrorResponse) {
+	ts.T().Helper()
+
+	reqBody, err := json.Marshal(body)
+	ts.Require().NoError(err, "Failed to marshal flow request body")
+
+	req, err := http.NewRequest(http.MethodPost, testServerURL+"/flow/execute", bytes.NewReader(reqBody))
+	ts.Require().NoError(err, "Failed to build flow request")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if bearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+bearerToken)
+	}
+
+	resp, err := testutils.GetRawHTTPClient().Do(req)
+	ts.Require().NoError(err, "Failed to send flow request")
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err, "Failed to read flow response body")
+
+	var errResp common.ErrorResponse
+	if err := json.Unmarshal(bodyBytes, &errResp); err != nil {
+		ts.T().Fatalf("Failed to decode error response (status %d): %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	return resp.StatusCode, errResp
+}
+
+// assertFlowError runs the request and asserts both the status and the error code.
+func (ts *FlowExecutionErrorTestSuite) assertFlowError(
+	body map[string]interface{}, bearerToken string, wantStatus int, wantCode string) {
+	ts.T().Helper()
+
+	status, errResp := ts.executeFlow(body, bearerToken)
+	ts.Equal(wantStatus, status, "Unexpected status for %s", wantCode)
+	ts.Equal(wantCode, errResp.Code, "Unexpected error code")
+}
+
+// adminToken returns a bearer token carrying the system permission.
+func (ts *FlowExecutionErrorTestSuite) adminToken() string {
+	ts.T().Helper()
+
+	token, err := testutils.GetAccessToken()
+	ts.Require().NoError(err, "Failed to obtain admin access token")
+	ts.Require().NotEmpty(token, "Admin access token is empty")
+
+	return token
+}
+
+// nonAdminToken returns a client-credentials token for the test application: a valid token that
+// carries no user subject and no system permission.
+func (ts *FlowExecutionErrorTestSuite) nonAdminToken() string {
+	ts.T().Helper()
+
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+
+	req, err := http.NewRequest(http.MethodPost, testServerURL+"/oauth2/token", strings.NewReader(form.Encode()))
+	ts.Require().NoError(err, "Failed to build token request")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(errorTestClientID, errorTestClientSecret)
+
+	resp, err := testutils.GetRawHTTPClient().Do(req)
+	ts.Require().NoError(err, "Failed to request client credentials token")
+	defer resp.Body.Close()
+
+	var body map[string]interface{}
+	ts.Require().NoError(json.NewDecoder(resp.Body).Decode(&body))
+	ts.Require().Equal(http.StatusOK, resp.StatusCode, "Token request failed: %v", body)
+
+	token, ok := body["access_token"].(string)
+	ts.Require().True(ok, "Token response has no access_token: %v", body)
+
+	return token
+}
+
+// A machine-to-machine client credentials token must not reach the administration entry point.
+// /flow/execute is a public path, so this check is the only thing standing between any client
+// holding a token and administration flow execution.
+//
+// The rejection is "authentication required" rather than "permission required": a client
+// credentials token establishes no user subject, so the caller check refuses it before permissions
+// are ever consulted. Reaching the permission branch (FES-1019) needs a user token whose
+// permissions omit the system scope, which requires a signed-in non-administrator user and is not
+// covered here.
+func (ts *FlowExecutionErrorTestSuite) TestExecuteByFlowID_ClientCredentialsTokenRejected() {
+	ts.assertFlowError(map[string]interface{}{
+		"flowId": ts.flowID,
+	}, ts.nonAdminToken(), http.StatusUnauthorized, errCodeAdminAuthRequired)
+}
+
+func (ts *FlowExecutionErrorTestSuite) TestInitiate_UnknownFlowTypeRejected() {
+	ts.assertFlowError(map[string]interface{}{
+		"applicationId": ts.appID,
+		"flowType":      "NOT_A_REAL_FLOW_TYPE",
+	}, "", http.StatusBadRequest, errCodeInvalidFlowType)
+}
+
+func (ts *FlowExecutionErrorTestSuite) TestInitiate_MissingFlowTypeRejected() {
+	ts.assertFlowError(map[string]interface{}{
+		"applicationId": ts.appID,
+	}, "", http.StatusBadRequest, errCodeInvalidFlowType)
+}
+
+func (ts *FlowExecutionErrorTestSuite) TestInitiate_UnknownApplicationRejected() {
+	ts.assertFlowError(map[string]interface{}{
+		"applicationId": "01900000-0000-7000-8000-00000000dead",
+		"flowType":      "AUTHENTICATION",
+	}, "", http.StatusBadRequest, errCodeInvalidAppID)
+}
+
+// Registration is disabled on the test application, so the flow type is valid but unavailable.
+func (ts *FlowExecutionErrorTestSuite) TestInitiate_RegistrationDisabledRejected() {
+	ts.assertFlowError(map[string]interface{}{
+		"applicationId": ts.appID,
+		"flowType":      "REGISTRATION",
+	}, "", http.StatusBadRequest, errCodeRegistrationDisabled)
+}
+
+func (ts *FlowExecutionErrorTestSuite) TestInitiate_RecoveryDisabledRejected() {
+	ts.assertFlowError(map[string]interface{}{
+		"applicationId": ts.appID,
+		"flowType":      "RECOVERY",
+	}, "", http.StatusBadRequest, errCodeRecoveryDisabled)
+}
+
+func (ts *FlowExecutionErrorTestSuite) TestResume_UnknownExecutionIDRejected() {
+	ts.assertFlowError(map[string]interface{}{
+		"executionId": "01900000-0000-7000-8000-00000000beef",
+		"inputs":      map[string]string{"username": "someone"},
+	}, "", http.StatusBadRequest, errCodeInvalidExecutionID)
+}
+
+func (ts *FlowExecutionErrorTestSuite) TestResume_MalformedExecutionIDRejected() {
+	ts.assertFlowError(map[string]interface{}{
+		"executionId": "not-a-uuid",
+		"inputs":      map[string]string{"username": "someone"},
+	}, "", http.StatusBadRequest, errCodeInvalidExecutionID)
+}
+
+// Initiating by flowId is the administration entry point. /flow/execute is a public path, so an
+// unauthenticated caller must be rejected before the flow is even resolved, which also stops the
+// response distinguishing a missing flow from an existing one.
+func (ts *FlowExecutionErrorTestSuite) TestExecuteByFlowID_UnauthenticatedRejected() {
+	ts.assertFlowError(map[string]interface{}{
+		"flowId": ts.flowID,
+	}, "", http.StatusUnauthorized, errCodeAdminAuthRequired)
+}
+
+func (ts *FlowExecutionErrorTestSuite) TestExecuteByFlowID_UnauthenticatedUnknownFlowRejectedIdentically() {
+	// A flow id that does not exist must produce the same rejection as a real one, so the endpoint
+	// does not leak which flows exist to an unauthenticated caller.
+	ts.assertFlowError(map[string]interface{}{
+		"flowId": "01900000-0000-7000-8000-00000000f00d",
+	}, "", http.StatusUnauthorized, errCodeAdminAuthRequired)
+}
+
+// An authenticated administrator may only execute ADMINISTRATION flows by id. Pointing the entry
+// point at an authentication flow must be refused, otherwise it becomes a way to start a login
+// flow directly and bypass the application binding that type requires.
+func (ts *FlowExecutionErrorTestSuite) TestExecuteByFlowID_NonAdministrationFlowRejected() {
+	ts.assertFlowError(map[string]interface{}{
+		"flowId": ts.flowID,
+	}, ts.adminToken(), http.StatusForbidden, errCodeFlowIDNotPermitted)
+}
+
+func (ts *FlowExecutionErrorTestSuite) TestExecuteByFlowID_UnknownFlowRejectedForAdministrator() {
+	status, errResp := ts.executeFlow(map[string]interface{}{
+		"flowId": "01900000-0000-7000-8000-00000000f00d",
+	}, ts.adminToken())
+
+	// The caller is authorized, so the response may report either that the flow does not exist or
+	// that execution by id is not permitted for it. Both are client errors; what matters is that an
+	// authorized caller is not served a 401 and never reaches execution.
+	ts.Contains([]int{http.StatusBadRequest, http.StatusForbidden, http.StatusNotFound}, status,
+		fmt.Sprintf("Unexpected status for an unknown flow id: %d", status))
+	ts.NotEmpty(errResp.Code, "Expected an error code for an unknown flow id")
+}

--- a/tests/integration/flow/execution/flow_lifecycle_test.go
+++ b/tests/integration/flow/execution/flow_lifecycle_test.go
@@ -1,0 +1,287 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package execution
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// shortFlowExpirySeconds is the smallest positive expiry the configuration accepts, so the expiry
+// test waits the shortest time it can while still crossing the boundary.
+const shortFlowExpirySeconds = 1
+
+var (
+	lifecycleTestOU = testutils.OrganizationUnit{
+		Handle:      "flow_lifecycle_test_ou",
+		Name:        "Test OU for Flow Lifecycle",
+		Description: "Organization unit created for flow lifecycle testing",
+		Parent:      nil,
+	}
+
+	// A flow that stops at a prompt, so an execution exists to resume and to let expire.
+	lifecycleTestFlow = testutils.Flow{
+		Name:     "Flow Lifecycle Test Auth Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_lifecycle_test",
+		Nodes: []map[string]interface{}{
+			{
+				"id":        "start",
+				"type":      "START",
+				"onSuccess": "prompt_credentials",
+			},
+			{
+				"id":   "prompt_credentials",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_001",
+								"identifier": "username",
+								"type":       "TEXT_INPUT",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_001",
+							"nextNode": "auth_assert",
+						},
+					},
+				},
+			},
+			{
+				"id":   "auth_assert",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "AuthAssertExecutor",
+				},
+				"onSuccess": "end",
+			},
+			{
+				"id":   "end",
+				"type": "END",
+			},
+		},
+	}
+
+	lifecycleTestApp = testutils.Application{
+		Name:         "Flow Lifecycle Test Application",
+		Description:  "Application for testing flow execution lifecycle",
+		ClientID:     "flow_lifecycle_test_client",
+		ClientSecret: "flow_lifecycle_test_secret",
+		RedirectURIs: []string{"http://localhost:3000/callback"},
+	}
+)
+
+type FlowLifecycleTestSuite struct {
+	suite.Suite
+	config *common.TestSuiteConfig
+	ouID   string
+	appID  string
+	flowID string
+}
+
+func TestFlowLifecycleTestSuite(t *testing.T) {
+	suite.Run(t, new(FlowLifecycleTestSuite))
+}
+
+func (ts *FlowLifecycleTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	ouID, err := testutils.CreateOrganizationUnit(lifecycleTestOU)
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
+
+	flowID, err := testutils.CreateFlow(lifecycleTestFlow)
+	ts.Require().NoError(err, "Failed to create test flow")
+	ts.flowID = flowID
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
+
+	lifecycleTestApp.OUID = ts.ouID
+	lifecycleTestApp.AuthFlowID = flowID
+	appID, err := testutils.CreateApplication(lifecycleTestApp)
+	ts.Require().NoError(err, "Failed to create test application")
+	ts.appID = appID
+}
+
+func (ts *FlowLifecycleTestSuite) TearDownSuite() {
+	if ts.appID != "" {
+		if err := testutils.DeleteApplication(ts.appID); err != nil {
+			ts.T().Logf("Failed to delete test application during teardown: %v", err)
+		}
+	}
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete test flow during teardown: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// patchFlowConfig applies the given keys over the writable layer of the flow section and registers
+// the restore, so a mid-test failure still returns the deployment to its original configuration.
+func (ts *FlowLifecycleTestSuite) patchFlowConfig(patch map[string]interface{}) {
+	ts.T().Helper()
+
+	original, err := testutils.MergeWritableServerConfig(flowConfigSection, patch)
+	ts.Require().NoError(err, "Failed to update flow server config")
+	ts.T().Cleanup(func() {
+		if err := testutils.PutWritableServerConfig(flowConfigSection, original); err != nil {
+			ts.T().Errorf("cleanup: failed to restore flow server config: %v", err)
+		}
+	})
+}
+
+// An execution started without inputs must be resumable by its execution id, carrying the flow
+// forward from the stored context rather than starting over.
+//
+// The assertion is that the context is found and advanced, not that the flow reaches a particular
+// terminal state: the node after the prompt asserts an authenticated user, which this test never
+// establishes. Being accepted at all is what proves resume works, since an unknown or expired
+// execution id is rejected instead (see TestExpiry_ExpiredExecutionRejected).
+func (ts *FlowLifecycleTestSuite) TestResume_ContinuesExistingExecution() {
+	step, err := common.InitiateAuthenticationFlow(ts.appID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate flow")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "Flow should pause at the prompt")
+	ts.Require().NotEmpty(step.ExecutionID, "A paused flow must return an execution id")
+
+	resumed, err := common.CompleteFlow(step.ExecutionID,
+		map[string]string{"username": "someone@example.com"}, "action_001", "")
+	ts.Require().NoError(err, "Resuming an existing execution should be accepted")
+	ts.Equal(step.ExecutionID, resumed.ExecutionID, "Resume must stay on the same execution")
+	ts.NotEmpty(resumed.FlowStatus, "Resume must report a flow status")
+}
+
+// Resuming a prompt without supplying its required input is refused rather than silently
+// re-presenting the prompt, so a caller cannot loop on an execution without making progress.
+func (ts *FlowLifecycleTestSuite) TestResume_WithoutRequiredInputFails() {
+	step, err := common.InitiateAuthenticationFlow(ts.appID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate flow")
+	ts.Require().NotEmpty(step.ExecutionID, "A paused flow must return an execution id")
+
+	resumed, err := common.ResumeFlow(step.ExecutionID)
+	ts.Require().NoError(err, "A bare resume should still return a flow step")
+	ts.Equal("ERROR", resumed.FlowStatus, "Resuming without the required input should fail the step")
+}
+
+// An application keeps pointing at its authentication flow after that flow is deleted, because
+// deleting a flow does not clear the reference. Rather than failing every sign-in for that
+// application, the engine falls back to the configured default authentication flow.
+//
+// The default handle is pointed at a flow this test creates, so the fallback is identified by the
+// prompt it lands on rather than by whatever the deployment happens to ship as its default.
+func (ts *FlowLifecycleTestSuite) TestFallback_DeletedFlowFallsBackToDefault() {
+	defaultFlowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     "Flow Lifecycle Fallback Default Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_lifecycle_fallback_default",
+		Nodes: []map[string]interface{}{
+			{"id": "start", "type": "START", "onSuccess": "prompt_fallback"},
+			{
+				"id":   "prompt_fallback",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "fallback_marker",
+								"identifier": "fallback_marker",
+								"type":       "TEXT_INPUT",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_fallback",
+							"nextNode": "auth_assert",
+						},
+					},
+				},
+			},
+			{
+				"id":        "auth_assert",
+				"type":      "TASK_EXECUTION",
+				"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+				"onSuccess": "end",
+			},
+			{"id": "end", "type": "END"},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create the fallback default flow")
+	ts.T().Cleanup(func() {
+		if err := testutils.DeleteFlow(defaultFlowID); err != nil {
+			ts.T().Logf("cleanup: failed to delete fallback default flow: %v", err)
+		}
+	})
+
+	ts.patchFlowConfig(map[string]interface{}{
+		"authFlow": map[string]interface{}{"defaultHandle": "auth_flow_lifecycle_fallback_default"},
+	})
+
+	// A flow of its own, so deleting it cannot disturb the other tests in this suite.
+	doomedFlowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     "Flow Lifecycle Doomed Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_lifecycle_doomed",
+		Nodes:    lifecycleTestFlow.Nodes,
+	})
+	ts.Require().NoError(err, "Failed to create the flow that gets deleted")
+
+	orphanedAppID, err := testutils.CreateApplication(testutils.Application{
+		Name:         "Flow Lifecycle Fallback Application",
+		Description:  "Application whose authentication flow is deleted out from under it",
+		ClientID:     "flow_lifecycle_fallback_client",
+		ClientSecret: "flow_lifecycle_fallback_secret",
+		RedirectURIs: []string{"http://localhost:3000/callback"},
+		OUID:         ts.ouID,
+		AuthFlowID:   doomedFlowID,
+	})
+	ts.Require().NoError(err, "Failed to create the application")
+	ts.T().Cleanup(func() {
+		if err := testutils.DeleteApplication(orphanedAppID); err != nil {
+			ts.T().Logf("cleanup: failed to delete fallback application: %v", err)
+		}
+	})
+
+	ts.Require().NoError(testutils.DeleteFlow(doomedFlowID),
+		"Deleting a referenced flow should be allowed, which is what creates the dangling reference")
+
+	step, err := common.InitiateAuthenticationFlow(orphanedAppID, false, nil, "")
+	ts.Require().NoError(err, "A dangling flow reference should not fail the request")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "The fallback flow should run")
+	ts.True(common.HasInput(step.Data.Inputs, "fallback_marker"),
+		"The request must be served by the configured default authentication flow")
+}
+
+// A flow context is held for the configured expiry and no longer, after which its execution id is
+// no longer usable. This is the branch that separates "unknown execution" from "expired execution",
+// and both surface as the same client error by design.
+func (ts *FlowLifecycleTestSuite) TestExpiry_ExpiredExecutionRejected() {
+	// The expiry is read from the merged server config on every execution, so this takes effect
+	// without restarting the server.
+	ts.patchFlowConfig(map[string]interface{}{
+		"authFlow": map[string]interface{}{"expirySeconds": shortFlowExpirySeconds},
+	})
+
+	step, err := common.InitiateAuthenticationFlow(ts.appID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate flow")
+	ts.Require().NotEmpty(step.ExecutionID, "A paused flow must return an execution id")
+
+	// Wait past the expiry with margin, so the context is gone rather than merely stale.
+	time.Sleep(time.Duration(shortFlowExpirySeconds)*time.Second + 2*time.Second)
+
+	errResp, err := common.CompleteAuthFlowWithError(step.ExecutionID,
+		map[string]string{"username": "someone"}, "")
+	ts.Require().NoError(err, "Expected a client error for an expired execution")
+	ts.Equal(errCodeInvalidExecutionID, errResp.Code,
+		"An expired execution must be rejected as an invalid execution id")
+}

--- a/tests/integration/flow/execution/model.go
+++ b/tests/integration/flow/execution/model.go
@@ -1,0 +1,19 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package execution holds integration tests for the flow engine itself, as opposed to the tests
+// grouped by flow type in the sibling packages. What is exercised here is behaviour the engine
+// applies to every flow: execution and resume, expiry, call frames and the call depth limit,
+// administration entry points, error branches and the events published along the way.
+package execution
+
+import "github.com/thunder-id/thunderid/tests/integration/testutils"
+
+// testServerURL is the base URL every request in this package is issued against.
+const testServerURL = testutils.TestServerURL
+
+// flowConfigSection names the flow section of the server configuration.
+const flowConfigSection = "flow"
+
+// administrationFlowType is the flow type of the shipped administration flows.
+const administrationFlowType = "ADMINISTRATION"

--- a/tests/integration/flow/execution/user_onboarding_test.go
+++ b/tests/integration/flow/execution/user_onboarding_test.go
@@ -1,0 +1,435 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package execution
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	// A user onboarding flow is app independent: it is resolved by the default handle configured in
+	// the server-config flow section rather than from an application binding.
+	onboardingFlowHandle = "user_onboarding_flow_test"
+
+	errCodeOUNotFound            = "FET-1030"
+	errCodeUserTypeNotAllowed    = "FET-1054"
+	errCodeUserTypeNotValidForOU = "FET-1058"
+)
+
+type UserOnboardingTestSuite struct {
+	suite.Suite
+	config *common.TestSuiteConfig
+
+	rootOUID      string
+	childOUID     string
+	rootTypeID    string
+	childTypeID   string
+	rootTypeName  string
+	childTypeName string
+	flowID        string
+}
+
+func TestUserOnboardingTestSuite(t *testing.T) {
+	suite.Run(t, new(UserOnboardingTestSuite))
+}
+
+// onboardingFlowNodes builds the onboarding flow: the OU is chosen first from the full tree, the
+// user type is then resolved against that OU, and the user is provisioned into it.
+func onboardingFlowNodes(allowedUserTypes []string) []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"id":        "start",
+			"type":      "START",
+			"onSuccess": "ou_resolver",
+		},
+		{
+			"id":   "ou_resolver",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "OUResolverExecutor",
+			},
+			"properties": map[string]interface{}{
+				"resolveFrom": "promptAll",
+			},
+			"onSuccess":    "user_type_resolver",
+			"onIncomplete": "prompt_ou",
+		},
+		{
+			"id":   "prompt_ou",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "ou_selection_input",
+							"identifier": "ouId",
+							"type":       "OU_SELECT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_ou",
+						"nextNode": "ou_resolver",
+					},
+				},
+			},
+		},
+		{
+			"id":   "user_type_resolver",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "UserTypeResolver",
+			},
+			"properties": map[string]interface{}{
+				"allowedUserTypes": allowedUserTypes,
+			},
+			"onSuccess":    "provisioning",
+			"onIncomplete": "prompt_usertype",
+		},
+		{
+			"id":   "prompt_usertype",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "usertype_input",
+							"identifier": "userType",
+							"type":       "SELECT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_usertype",
+						"nextNode": "user_type_resolver",
+					},
+				},
+			},
+		},
+		{
+			"id":   "provisioning",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "ProvisioningExecutor",
+				"inputs": []map[string]interface{}{
+					{
+						"ref":        "input_username",
+						"identifier": "username",
+						"type":       "TEXT_INPUT",
+						"required":   true,
+					},
+					{
+						"ref":        "input_email",
+						"identifier": "email",
+						"type":       "TEXT_INPUT",
+						"required":   true,
+					},
+				},
+			},
+			"onSuccess":    "end",
+			"onIncomplete": "prompt_user_details",
+		},
+		{
+			"id":   "prompt_user_details",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_username",
+							"identifier": "username",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_email",
+							"identifier": "email",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_details",
+						"nextNode": "provisioning",
+					},
+				},
+			},
+		},
+		{
+			"id":   "end",
+			"type": "END",
+		},
+	}
+}
+
+func onboardingUserTypeSchema(name, ouID string) testutils.UserType {
+	return testutils.UserType{
+		Name: name,
+		OUID: ouID,
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type": "string",
+			},
+			"email": map[string]interface{}{
+				"type": "string",
+			},
+		},
+	}
+}
+
+func (ts *UserOnboardingTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	rootOUID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "onboarding_root_test_ou",
+		Name:        "Onboarding Root Test OU",
+		Description: "Root organization unit for user onboarding testing",
+		Parent:      nil,
+	})
+	ts.Require().NoError(err, "Failed to create root organization unit")
+	ts.rootOUID = rootOUID
+
+	childOUID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "onboarding_child_test_ou",
+		Name:        "Onboarding Child Test OU",
+		Description: "Child organization unit for user onboarding testing",
+		Parent:      &rootOUID,
+	})
+	ts.Require().NoError(err, "Failed to create child organization unit")
+	ts.childOUID = childOUID
+
+	// One user type per OU, so which types are offered depends on the OU that was picked.
+	ts.rootTypeName = "onboarding-root-person"
+	ts.childTypeName = "onboarding-child-person"
+
+	ts.rootTypeID, err = testutils.CreateUserType(onboardingUserTypeSchema(ts.rootTypeName, rootOUID))
+	ts.Require().NoError(err, "Failed to create root user type")
+
+	ts.childTypeID, err = testutils.CreateUserType(onboardingUserTypeSchema(ts.childTypeName, childOUID))
+	ts.Require().NoError(err, "Failed to create child user type")
+
+	ts.flowID, err = testutils.CreateFlow(testutils.Flow{
+		Name:     "User Onboarding Test Flow",
+		FlowType: "USER_ONBOARDING",
+		Handle:   onboardingFlowHandle,
+		Nodes:    onboardingFlowNodes([]string{ts.rootTypeName, ts.childTypeName}),
+	})
+	ts.Require().NoError(err, "Failed to create user onboarding flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, ts.flowID)
+
+	// The onboarding flow is reached by its default handle, so the flow section has to name it.
+	ts.setOnboardingDefaultHandle(onboardingFlowHandle)
+}
+
+func (ts *UserOnboardingTestSuite) TearDownSuite() {
+	for _, userID := range ts.config.CreatedUserIDs {
+		if err := testutils.DeleteUser(userID); err != nil {
+			ts.T().Logf("Failed to delete onboarded user during teardown: %v", err)
+		}
+	}
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete test flow during teardown: %v", err)
+		}
+	}
+	for _, typeID := range []string{ts.childTypeID, ts.rootTypeID} {
+		if typeID == "" {
+			continue
+		}
+		if err := testutils.DeleteUserType(typeID); err != nil {
+			ts.T().Logf("Failed to delete test user type during teardown: %v", err)
+		}
+	}
+	for _, ouID := range []string{ts.childOUID, ts.rootOUID} {
+		if ouID == "" {
+			continue
+		}
+		if err := testutils.DeleteOrganizationUnit(ouID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// setOnboardingDefaultHandle names the onboarding flow in the writable flow section, keeping every
+// sibling key the section already carried, and registers the restore.
+//
+// The restore is registered on the suite's test cleanup rather than in TearDownSuite because
+// testify skips teardown entirely when SetupSuite fails, which would leave the handle pointing at a
+// flow this suite deletes.
+func (ts *UserOnboardingTestSuite) setOnboardingDefaultHandle(handle string) {
+	ts.T().Helper()
+
+	original, err := testutils.MergeWritableServerConfig(flowConfigSection, map[string]interface{}{
+		"userOnboardingFlow": map[string]interface{}{"defaultHandle": handle},
+	})
+	ts.Require().NoError(err, "Failed to update flow server config")
+	ts.T().Cleanup(func() {
+		if err := testutils.PutWritableServerConfig(flowConfigSection, original); err != nil {
+			ts.T().Errorf("cleanup: failed to restore flow server config: %v", err)
+		}
+	})
+}
+
+// initiateOnboarding starts a user onboarding flow. It carries no application id, which is what
+// distinguishes an app-independent system flow from every other flow type.
+func (ts *UserOnboardingTestSuite) initiateOnboarding(inputs map[string]string) *common.FlowStep {
+	ts.T().Helper()
+
+	reqBody := map[string]interface{}{"flowType": "USER_ONBOARDING"}
+	if len(inputs) > 0 {
+		reqBody["inputs"] = inputs
+	}
+
+	payload, err := json.Marshal(reqBody)
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest(http.MethodPost, testServerURL+"/flow/execute", bytes.NewReader(payload))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err, "Failed to send onboarding flow request")
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusOK, resp.StatusCode,
+		"Onboarding initiation should succeed: %s", string(body))
+
+	var step common.FlowStep
+	ts.Require().NoError(json.Unmarshal(body, &step))
+	return &step
+}
+
+// findOnboardedUser locates a provisioned user so the OU and type it landed in can be asserted,
+// and tracks it for cleanup.
+func (ts *UserOnboardingTestSuite) findOnboardedUser(username string) *testutils.User {
+	ts.T().Helper()
+
+	user, err := testutils.FindUserByAttribute("username", username)
+	ts.Require().NoError(err, "Failed to look up the onboarded user")
+	ts.Require().NotNil(user, "The onboarding flow should have created a user")
+
+	if user.ID != "" {
+		ts.config.CreatedUserIDs = append(ts.config.CreatedUserIDs, user.ID)
+	}
+	return user
+}
+
+// An onboarding flow with the promptAll strategy asks for the OU before anything else, and the
+// selected OU then decides which user types are on offer. Picking the root OU leaves only the type
+// attached to it, so the type is auto-selected and the flow goes straight to the user details.
+func (ts *UserOnboardingTestSuite) TestOnboarding_RootOUAutoSelectsItsOnlyUserType() {
+	step := ts.initiateOnboarding(nil)
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "Onboarding should pause to select an OU")
+	ts.Require().True(common.HasInput(step.Data.Inputs, "ouId"),
+		"The promptAll strategy must request an OU selection")
+
+	step, err := common.CompleteFlow(step.ExecutionID,
+		map[string]string{"ouId": ts.rootOUID}, "action_ou", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit the OU selection")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "The flow should continue after the OU is chosen")
+	ts.False(common.HasInput(step.Data.Inputs, "userType"),
+		"A single valid user type should be auto-selected rather than prompted")
+	ts.True(common.HasInput(step.Data.Inputs, "username"),
+		"The flow should move on to collecting user details")
+
+	username := common.GenerateUniqueUsername("onboard_root")
+	completed, err := common.CompleteFlow(step.ExecutionID, map[string]string{
+		"username": username,
+		"email":    username + "@onboarding.test",
+	}, "action_details", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit user details")
+	ts.Require().Equal("COMPLETE", completed.FlowStatus, "Onboarding should provision the user")
+
+	user := ts.findOnboardedUser(username)
+	ts.Equal(ts.rootOUID, user.OUID, "The user must be provisioned into the selected OU")
+	ts.Equal(ts.rootTypeName, user.Type, "The user must carry the resolved user type")
+}
+
+// Picking the child OU leaves both user types valid — the one attached to the child and the one
+// attached to its ancestor — so the flow has to ask which to use.
+func (ts *UserOnboardingTestSuite) TestOnboarding_ChildOUPromptsForUserType() {
+	step := ts.initiateOnboarding(nil)
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "Onboarding should pause to select an OU")
+
+	step, err := common.CompleteFlow(step.ExecutionID,
+		map[string]string{"ouId": ts.childOUID}, "action_ou", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit the OU selection")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "The flow should pause to select a user type")
+	ts.Require().True(common.HasInput(step.Data.Inputs, "userType"),
+		"Two valid user types must be offered for selection")
+
+	step, err = common.CompleteFlow(step.ExecutionID,
+		map[string]string{"userType": ts.childTypeName}, "action_usertype", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit the user type selection")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "The flow should move on to user details")
+
+	username := common.GenerateUniqueUsername("onboard_child")
+	completed, err := common.CompleteFlow(step.ExecutionID, map[string]string{
+		"username": username,
+		"email":    username + "@onboarding.test",
+	}, "action_details", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit user details")
+	ts.Require().Equal("COMPLETE", completed.FlowStatus, "Onboarding should provision the user")
+
+	user := ts.findOnboardedUser(username)
+	ts.Equal(ts.childOUID, user.OUID, "The user must be provisioned into the selected OU")
+	ts.Equal(ts.childTypeName, user.Type, "The selected user type must be the one applied")
+}
+
+// An OU id that does not exist is refused and the selection is asked for again, so a bad id cannot
+// carry the flow into provisioning.
+func (ts *UserOnboardingTestSuite) TestOnboarding_UnknownOURejected() {
+	step := ts.initiateOnboarding(nil)
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "Onboarding should pause to select an OU")
+
+	rejected, err := common.CompleteFlow(step.ExecutionID,
+		map[string]string{"ouId": "019ff000-0000-7000-8000-000000000000"}, "action_ou", step.ChallengeToken)
+	ts.Require().NoError(err, "An unknown OU should still return a flow step")
+	ts.Require().NotNil(rejected.Error, "An unknown OU must be reported as an error")
+	ts.Equal(errCodeOUNotFound, rejected.Error.Code, "An unknown OU must be refused as not found")
+	ts.True(common.HasInput(rejected.Data.Inputs, "ouId"),
+		"The OU selection must be requested again after a bad id")
+}
+
+// A user type outside the node's allowed list is refused even when it exists, because the node
+// property is the narrower of the two constraints.
+func (ts *UserOnboardingTestSuite) TestOnboarding_UserTypeOutsideAllowedListRejected() {
+	step := ts.initiateOnboarding(nil)
+	step, err := common.CompleteFlow(step.ExecutionID,
+		map[string]string{"ouId": ts.childOUID}, "action_ou", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit the OU selection")
+	ts.Require().True(common.HasInput(step.Data.Inputs, "userType"),
+		"Two valid user types must be offered for selection")
+
+	rejected, err := common.CompleteFlow(step.ExecutionID,
+		map[string]string{"userType": "not-an-allowed-type"}, "action_usertype", step.ChallengeToken)
+	ts.Require().NoError(err, "A disallowed user type should still return a flow step")
+	ts.Require().NotNil(rejected.Error, "A disallowed user type must be reported as an error")
+	ts.Equal(errCodeUserTypeNotAllowed, rejected.Error.Code,
+		"A user type outside the node's allowed list must be refused")
+}
+
+// A user type whose OU is not an ancestor of the selected OU is refused. Supplying both values at
+// initiation is what makes this reachable: the interactive path never offers the pairing, because
+// the type is filtered out of the prompt before the user can pick it.
+func (ts *UserOnboardingTestSuite) TestOnboarding_UserTypeNotValidForSelectedOURejected() {
+	step := ts.initiateOnboarding(map[string]string{
+		"ouId":     ts.rootOUID,
+		"userType": ts.childTypeName,
+	})
+	ts.Require().NotNil(step.Error, "A user type invalid for the selected OU must be reported")
+	ts.Equal(errCodeUserTypeNotValidForOU, step.Error.Code,
+		"A user type attached below the selected OU must be refused for it")
+}

--- a/tests/integration/flow/mgt/flow_usages_test.go
+++ b/tests/integration/flow/mgt/flow_usages_test.go
@@ -1,0 +1,138 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mgt
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// ResourceDependency is one resource reported as referencing the flow.
+type ResourceDependency struct {
+	ResourceType     string `json:"resourceType"`
+	ID               string `json:"id"`
+	DisplayName      string `json:"displayName"`
+	BehaviorOnDelete string `json:"behaviorOnDelete"`
+}
+
+// FlowUsagesResponse is the body of GET /flows/{flowId}/usages.
+//
+// TotalResults and Summary are pointers/maps that stay nil when dependency data is unavailable,
+// which the API distinguishes from a confirmed-empty result, so the tests assert on them directly
+// rather than through a zero value.
+type FlowUsagesResponse struct {
+	TotalResults *int                 `json:"totalResults"`
+	Count        int                  `json:"count"`
+	Summary      map[string]int       `json:"summary"`
+	Usages       []ResourceDependency `json:"usages"`
+}
+
+var usagesTestOU = testutils.OrganizationUnit{
+	Handle:      "flow_usages_test_ou",
+	Name:        "Test OU for Flow Usages",
+	Description: "Organization unit created for flow usages testing",
+	Parent:      nil,
+}
+
+func (suite *FlowMgtAPITestSuite) getFlowUsages(flowID string) *FlowUsagesResponse {
+	req, _ := http.NewRequest(http.MethodGet, testServerURL+flowsEndpoint+"/"+flowID+"/usages", nil)
+
+	client := testutils.GetHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	suite.Require().Equal(http.StatusOK, resp.StatusCode, "unexpected usages response: %s", string(bodyBytes))
+
+	var response FlowUsagesResponse
+	suite.Require().NoError(json.Unmarshal(bodyBytes, &response))
+
+	return &response
+}
+
+func (suite *FlowMgtAPITestSuite) getFlowUsagesExpectError(flowID string, expectedStatus int, expectedCode string) {
+	req, _ := http.NewRequest(http.MethodGet, testServerURL+flowsEndpoint+"/"+flowID+"/usages", nil)
+
+	client := testutils.GetHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(expectedStatus, resp.StatusCode)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	var errorResp ErrorResponse
+	suite.Require().NoError(json.Unmarshal(bodyBytes, &errorResp))
+	suite.Equal(expectedCode, errorResp.Code)
+}
+
+// A flow nothing references reports a confirmed-empty result rather than unknown, so TotalResults
+// must be present and zero rather than nil.
+func (suite *FlowMgtAPITestSuite) TestGetFlowUsages_UnreferencedFlow() {
+	createdFlow := suite.createFlow(cloneFlowWithUniqueHandle(testAuthFlow))
+	suite.trackFlow(createdFlow.ID)
+
+	response := suite.getFlowUsages(createdFlow.ID)
+
+	suite.Equal(0, response.Count)
+	suite.Empty(response.Usages)
+	if suite.NotNil(response.TotalResults, "an unreferenced flow should report a known total") {
+		suite.Equal(0, *response.TotalResults)
+	}
+}
+
+// An application bound to the flow must appear as a usage, which is what the Console relies on to
+// warn before a flow is deleted.
+func (suite *FlowMgtAPITestSuite) TestGetFlowUsages_ReportsBoundApplication() {
+	createdFlow := suite.createFlow(cloneFlowWithUniqueHandle(testAuthFlow))
+	suite.trackFlow(createdFlow.ID)
+
+	ouID, err := testutils.CreateOrganizationUnit(usagesTestOU)
+	suite.Require().NoError(err, "Failed to create test organization unit")
+	defer func() {
+		if err := testutils.DeleteOrganizationUnit(ouID); err != nil {
+			suite.T().Logf("Failed to delete organization unit during cleanup: %v", err)
+		}
+	}()
+
+	app := testutils.Application{
+		Name:         "Flow Usages Test Application",
+		Description:  "Application bound to the flow under test",
+		ClientID:     "flow_usages_test_client",
+		ClientSecret: "flow_usages_test_secret",
+		RedirectURIs: []string{"http://localhost:3000/callback"},
+		OUID:         ouID,
+		AuthFlowID:   createdFlow.ID,
+	}
+	appID, err := testutils.CreateApplication(app)
+	suite.Require().NoError(err, "Failed to create test application")
+	defer func() {
+		if err := testutils.DeleteApplication(appID); err != nil {
+			suite.T().Logf("Failed to delete application during cleanup: %v", err)
+		}
+	}()
+
+	response := suite.getFlowUsages(createdFlow.ID)
+
+	suite.GreaterOrEqual(response.Count, 1, "the bound application should be reported as a usage")
+
+	found := false
+	for _, usage := range response.Usages {
+		if usage.ID == appID {
+			found = true
+			suite.Equal("application", usage.ResourceType)
+			suite.NotEmpty(usage.DisplayName, "a usage should carry a display name for the Console")
+			suite.NotEmpty(usage.BehaviorOnDelete, "a usage should state what happens on delete")
+		}
+	}
+	suite.True(found, "expected application %s in the reported usages", appID)
+}
+
+func (suite *FlowMgtAPITestSuite) TestGetFlowUsages_NotFound() {
+	suite.getFlowUsagesExpectError("non-existent-id", http.StatusNotFound, "FLM-1003")
+}

--- a/tests/integration/flow/registration/ou_resolver_strategies_test.go
+++ b/tests/integration/flow/registration/ou_resolver_strategies_test.go
@@ -1,0 +1,392 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package registration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	errCodeOUResolutionFailed    = "FET-1034"
+	errCodeOUNotValidForUserType = "FET-1075"
+)
+
+// ouStrategyFlowNodes builds a registration flow that resolves the user type, then the OU with the
+// given strategy, then provisions the user. The strategy is the only thing that varies between the
+// flows this suite creates.
+func ouStrategyFlowNodes(resolveFrom string) []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"id":        "start",
+			"type":      "START",
+			"onSuccess": "user_type_resolver",
+		},
+		{
+			"id":   "user_type_resolver",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "UserTypeResolver",
+			},
+			"onSuccess": "ou_resolver",
+		},
+		{
+			"id":   "ou_resolver",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "OUResolverExecutor",
+			},
+			"properties": map[string]interface{}{
+				"resolveFrom": resolveFrom,
+			},
+			"onSuccess":    "provisioning",
+			"onIncomplete": "prompt_ou",
+		},
+		{
+			"id":   "prompt_ou",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "ou_selection_input",
+							"identifier": "ouId",
+							"type":       "OU_SELECT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_ou",
+						"nextNode": "ou_resolver",
+					},
+				},
+			},
+		},
+		{
+			"id":   "provisioning",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "ProvisioningExecutor",
+				"inputs": []map[string]interface{}{
+					{
+						"ref":        "input_username",
+						"identifier": "username",
+						"type":       "TEXT_INPUT",
+						"required":   true,
+					},
+					{
+						"ref":        "input_email",
+						"identifier": "email",
+						"type":       "TEXT_INPUT",
+						"required":   true,
+					},
+				},
+			},
+			"onSuccess":    "end",
+			"onIncomplete": "prompt_details",
+		},
+		{
+			"id":   "prompt_details",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_username",
+							"identifier": "username",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_email",
+							"identifier": "email",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_details",
+						"nextNode": "provisioning",
+					},
+				},
+			},
+		},
+		{
+			"id":   "end",
+			"type": "END",
+		},
+	}
+}
+
+func ouStrategyUserType(name, ouID string) testutils.UserType {
+	return testutils.UserType{
+		Name:                  name,
+		OUID:                  ouID,
+		AllowSelfRegistration: true,
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type": "string",
+			},
+			"email": map[string]interface{}{
+				"type": "string",
+			},
+		},
+	}
+}
+
+type OUResolverStrategiesTestSuite struct {
+	suite.Suite
+	config *common.TestSuiteConfig
+
+	parentOUID string
+	childOUID  string
+	otherOUID  string
+
+	parentTypeID   string
+	childTypeID    string
+	parentTypeName string
+	childTypeName  string
+
+	promptParentAppID string
+	promptChildAppID  string
+	callerAppID       string
+	unsupportedAppID  string
+
+	// An auth flow that references no registration flow, so binding these registration flows to an
+	// application does not collide with the default auth flow's own registration reference.
+	isolatedAuthFlowID string
+}
+
+func TestOUResolverStrategiesTestSuite(t *testing.T) {
+	suite.Run(t, new(OUResolverStrategiesTestSuite))
+}
+
+func (ts *OUResolverStrategiesTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	parentOUID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "ou_strategy_parent_test_ou",
+		Name:        "OU Strategy Parent Test OU",
+		Description: "Parent organization unit for OU resolver strategy testing",
+		Parent:      nil,
+	})
+	ts.Require().NoError(err, "Failed to create parent organization unit")
+	ts.parentOUID = parentOUID
+
+	childOUID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "ou_strategy_child_test_ou",
+		Name:        "OU Strategy Child Test OU",
+		Description: "Child organization unit for OU resolver strategy testing",
+		Parent:      &parentOUID,
+	})
+	ts.Require().NoError(err, "Failed to create child organization unit")
+	ts.childOUID = childOUID
+
+	// A second root, outside the parent's subtree, so a selection can be rejected for being
+	// somewhere the user type does not reach.
+	otherOUID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "ou_strategy_other_test_ou",
+		Name:        "OU Strategy Other Test OU",
+		Description: "Unrelated organization unit for OU resolver strategy testing",
+		Parent:      nil,
+	})
+	ts.Require().NoError(err, "Failed to create unrelated organization unit")
+	ts.otherOUID = otherOUID
+
+	ts.parentTypeName = "ou-strategy-parent-person"
+	ts.childTypeName = "ou-strategy-child-person"
+
+	ts.parentTypeID, err = testutils.CreateUserType(ouStrategyUserType(ts.parentTypeName, parentOUID))
+	ts.Require().NoError(err, "Failed to create parent user type")
+
+	ts.childTypeID, err = testutils.CreateUserType(ouStrategyUserType(ts.childTypeName, childOUID))
+	ts.Require().NoError(err, "Failed to create child user type")
+
+	ts.isolatedAuthFlowID, err = testutils.CreateIsolatedAuthFlow("ou-strategy-isolated-auth")
+	ts.Require().NoError(err, "Failed to create isolated auth flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, ts.isolatedAuthFlowID)
+
+	promptFlowID := ts.createFlow("OU Resolver Prompt Flow", "registration_flow_ou_prompt_test", "prompt")
+	callerFlowID := ts.createFlow("OU Resolver Caller Flow", "registration_flow_ou_caller_test", "caller")
+	unsupportedFlowID := ts.createFlow("OU Resolver Unsupported Flow",
+		"registration_flow_ou_unsupported_test", "notAStrategy")
+
+	// The prompt flow is bound twice: once with a user type whose OU has children, and once with a
+	// user type whose OU has none, which is what decides whether a selection is asked for.
+	ts.promptParentAppID = ts.createApp("OU Strategy Prompt Parent App", "ou_strategy_prompt_parent_client",
+		promptFlowID, ts.parentTypeName)
+	ts.promptChildAppID = ts.createApp("OU Strategy Prompt Child App", "ou_strategy_prompt_child_client",
+		promptFlowID, ts.childTypeName)
+	ts.callerAppID = ts.createApp("OU Strategy Caller App", "ou_strategy_caller_client",
+		callerFlowID, ts.parentTypeName)
+	ts.unsupportedAppID = ts.createApp("OU Strategy Unsupported App", "ou_strategy_unsupported_client",
+		unsupportedFlowID, ts.parentTypeName)
+}
+
+func (ts *OUResolverStrategiesTestSuite) createFlow(name, handle, resolveFrom string) string {
+	ts.T().Helper()
+
+	flowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     name,
+		FlowType: "REGISTRATION",
+		Handle:   handle,
+		Nodes:    ouStrategyFlowNodes(resolveFrom),
+	})
+	ts.Require().NoError(err, "Failed to create flow %s", handle)
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
+	return flowID
+}
+
+func (ts *OUResolverStrategiesTestSuite) createApp(name, clientID, flowID, userType string) string {
+	ts.T().Helper()
+
+	appID, err := testutils.CreateApplication(testutils.Application{
+		Name:                      name,
+		Description:               "Application for OU resolver strategy testing",
+		ClientID:                  clientID,
+		ClientSecret:              clientID + "_secret",
+		RedirectURIs:              []string{"http://localhost:3000/callback"},
+		OUID:                      ts.parentOUID,
+		AllowedUserTypes:          []string{userType},
+		IsRegistrationFlowEnabled: true,
+		RegistrationFlowID:        flowID,
+		AuthFlowID:                ts.isolatedAuthFlowID,
+	})
+	ts.Require().NoError(err, "Failed to create application %s", name)
+	return appID
+}
+
+func (ts *OUResolverStrategiesTestSuite) TearDownSuite() {
+	for _, appID := range []string{
+		ts.promptParentAppID, ts.promptChildAppID, ts.callerAppID, ts.unsupportedAppID,
+	} {
+		if appID == "" {
+			continue
+		}
+		if err := testutils.DeleteApplication(appID); err != nil {
+			ts.T().Logf("Failed to delete test application during teardown: %v", err)
+		}
+	}
+	for _, userID := range ts.config.CreatedUserIDs {
+		if err := testutils.DeleteUser(userID); err != nil {
+			ts.T().Logf("Failed to delete registered user during teardown: %v", err)
+		}
+	}
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete test flow during teardown: %v", err)
+		}
+	}
+	for _, typeID := range []string{ts.childTypeID, ts.parentTypeID} {
+		if typeID == "" {
+			continue
+		}
+		if err := testutils.DeleteUserType(typeID); err != nil {
+			ts.T().Logf("Failed to delete test user type during teardown: %v", err)
+		}
+	}
+	for _, ouID := range []string{ts.childOUID, ts.parentOUID, ts.otherOUID} {
+		if ouID == "" {
+			continue
+		}
+		if err := testutils.DeleteOrganizationUnit(ouID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// trackRegisteredUser records a user created by a registration flow so teardown removes it.
+func (ts *OUResolverStrategiesTestSuite) trackRegisteredUser(username string) *testutils.User {
+	ts.T().Helper()
+
+	user, err := testutils.FindUserByAttribute("username", username)
+	ts.Require().NoError(err, "Failed to look up the registered user")
+	ts.Require().NotNil(user, "The registration flow should have created a user")
+	if user.ID != "" {
+		ts.config.CreatedUserIDs = append(ts.config.CreatedUserIDs, user.ID)
+	}
+	return user
+}
+
+// The prompt strategy asks for an OU only when the user type's OU has children, and the selection is
+// accepted when it sits inside that subtree. The user is then provisioned into the chosen OU rather
+// than the user type's own OU.
+func (ts *OUResolverStrategiesTestSuite) TestPrompt_DescendantOUSelected() {
+	step, err := common.InitiateRegistrationFlow(ts.promptParentAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate registration flow")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "The flow should pause for the OU selection")
+	ts.Require().True(common.HasInput(step.Data.Inputs, "ouId"),
+		"A user type whose OU has children must prompt for a selection")
+
+	step, err = common.CompleteFlow(step.ExecutionID,
+		map[string]string{"ouId": ts.childOUID}, "action_ou", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit the OU selection")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "The flow should move on to user details")
+	ts.Require().True(common.HasInput(step.Data.Inputs, "username"),
+		"The flow should collect user details after the OU is chosen")
+
+	username := common.GenerateUniqueUsername("ou_prompt")
+	completed, err := common.CompleteFlow(step.ExecutionID, map[string]string{
+		"username": username,
+		"email":    username + "@ou-strategy.test",
+	}, "action_details", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit user details")
+	ts.Require().Equal("COMPLETE", completed.FlowStatus, "Registration should provision the user")
+
+	user := ts.trackRegisteredUser(username)
+	ts.Equal(ts.childOUID, user.OUID, "The user must be provisioned into the selected OU")
+}
+
+// An OU outside the user type's subtree is refused and the selection is asked for again, so the
+// prompt cannot be used to place a user anywhere in the tree.
+func (ts *OUResolverStrategiesTestSuite) TestPrompt_OUOutsideSubtreeRejected() {
+	step, err := common.InitiateRegistrationFlow(ts.promptParentAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate registration flow")
+	ts.Require().True(common.HasInput(step.Data.Inputs, "ouId"), "The flow should prompt for an OU")
+
+	rejected, err := common.CompleteFlow(step.ExecutionID,
+		map[string]string{"ouId": ts.otherOUID}, "action_ou", step.ChallengeToken)
+	ts.Require().NoError(err, "An out-of-subtree OU should still return a flow step")
+	ts.Require().NotNil(rejected.Error, "An out-of-subtree OU must be reported as an error")
+	ts.Equal(errCodeOUNotValidForUserType, rejected.Error.Code,
+		"An OU outside the user type's subtree must be refused for that user type")
+	ts.True(common.HasInput(rejected.Data.Inputs, "ouId"),
+		"The OU selection must be requested again after a rejected choice")
+}
+
+// When the user type's OU has no children there is nothing to choose, so the strategy resolves
+// silently and the flow goes straight to collecting user details.
+func (ts *OUResolverStrategiesTestSuite) TestPrompt_NoChildOUsSkipsSelection() {
+	step, err := common.InitiateRegistrationFlow(ts.promptChildAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate registration flow")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "The flow should pause for user details")
+	ts.False(common.HasInput(step.Data.Inputs, "ouId"),
+		"An OU with no children must not be prompted for")
+	ts.True(common.HasInput(step.Data.Inputs, "username"),
+		"The flow should move straight on to user details")
+}
+
+// The caller strategy takes the OU from the caller's security context, so it cannot work on a
+// self-service registration flow where there is no authenticated caller. It fails rather than
+// falling back to a default OU.
+func (ts *OUResolverStrategiesTestSuite) TestCaller_WithoutCallerContextFails() {
+	step, err := common.InitiateRegistrationFlow(ts.callerAppID, false, nil, "")
+	ts.Require().NoError(err, "The flow should return a step rather than a transport error")
+	ts.Require().NotNil(step.Error, "An unresolvable caller OU must be reported")
+	ts.Equal(errCodeOUResolutionFailed, step.Error.Code,
+		"A missing caller OU must fail OU resolution")
+}
+
+// An unrecognized strategy fails the node instead of being ignored, so a typo in a flow definition
+// surfaces at execution rather than silently placing users in a default OU.
+func (ts *OUResolverStrategiesTestSuite) TestUnsupportedStrategy_Fails() {
+	step, err := common.InitiateRegistrationFlow(ts.unsupportedAppID, false, nil, "")
+	ts.Require().NoError(err, "The flow should return a step rather than a transport error")
+	ts.Require().NotNil(step.Error, "An unsupported strategy must be reported")
+	ts.Equal(errCodeOUResolutionFailed, step.Error.Code,
+		"An unsupported strategy must fail OU resolution")
+}

--- a/tests/integration/oauth/sso/session_termination_test.go
+++ b/tests/integration/oauth/sso/session_termination_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sso
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	// The shipped administration flow that deletes a user, its flow type, and the input its
+	// executors read the target user from.
+	userDeletionFlowHandle = "default-user-deletion-flow"
+	administrationFlowType = "ADMINISTRATION"
+	deletionSubjectInput   = "subject"
+)
+
+// deletionFlowID resolves the shipped user deletion flow by handle.
+func (ts *SSOLogoutTestSuite) deletionFlowID() string {
+	ts.T().Helper()
+
+	flowID, err := testutils.GetFlowIDByHandle(userDeletionFlowHandle, administrationFlowType)
+	ts.Require().NoError(err, "failed to resolve the shipped user deletion flow")
+
+	return flowID
+}
+
+// deleteUserThroughFlow runs the shipped deletion flow against the given subject.
+//
+// The bearer token is set on a raw client because the shared test clients treat /flow/execute as a
+// public endpoint and skip token injection, which would make the request anonymous and be refused
+// at the administration entry point.
+func (ts *SSOLogoutTestSuite) deleteUserThroughFlow(flowID, subjectID string) {
+	ts.T().Helper()
+
+	token, err := testutils.GetAccessToken()
+	ts.Require().NoError(err, "failed to obtain admin access token")
+
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"flowId": flowID,
+		"inputs": map[string]string{deletionSubjectInput: subjectID},
+	})
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest(http.MethodPost, testutils.TestServerURL+"/flow/execute", bytes.NewReader(reqBody))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := testutils.GetRawHTTPClient().Do(req)
+	ts.Require().NoError(err, "failed to execute the deletion flow")
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusOK, resp.StatusCode, "deletion flow should run: %s", string(body))
+
+	var step testutils.FlowStep
+	ts.Require().NoError(json.Unmarshal(body, &step))
+	ts.Require().Equal("COMPLETE", step.FlowStatus, "deletion flow should complete: %s", string(body))
+}
+
+// Deleting a user tears down every SSO session that user holds, not just the record. Without this,
+// a deleted user's cookie would keep satisfying SSO_CHECK and authorize requests would continue to
+// be served for a subject that no longer exists.
+//
+// The session is proven live before the deletion by a second authorize that skips the credential
+// prompt, so the assertion afterwards is a change in behaviour rather than an absence.
+func (ts *SSOLogoutTestSuite) TestTerminateBySubject_UserDeletionEndsSSOSessions() {
+	flowID := ts.deletionFlowID()
+	ts.Require().NotEmpty(flowID, "the shipped user deletion flow should be present")
+
+	username := "sso_terminate_user"
+	userID := ts.createUser(username)
+
+	client := ts.newSessionClient()
+	ts.login(client, username, "terminate_state_1")
+	ts.Require().NotEmpty(ts.ssoCookieNames(client), "an SSO cookie should be set after login")
+
+	// The session is live: this authorize is satisfied without a credential prompt.
+	_, executionID := ts.authorize(client, "openid", "terminate_state_2")
+	reused := ts.flowExecute(client, map[string]interface{}{"executionId": executionID})
+	ts.Require().Equal("COMPLETE", reused.FlowStatus,
+		"the session must be live before the deletion for this test to mean anything")
+
+	ts.deleteUserThroughFlow(flowID, userID)
+
+	// The same cookie must no longer satisfy SSO: the flow falls back to asking for credentials.
+	_, afterExecutionID := ts.authorize(client, "openid", "terminate_state_3")
+	after := ts.flowExecute(client, map[string]interface{}{"executionId": afterExecutionID})
+	ts.NotEqual("COMPLETE", after.FlowStatus,
+		"a deleted user's SSO session must no longer satisfy an authorize request")
+}

--- a/tests/integration/oauth/sso/session_timeout_test.go
+++ b/tests/integration/oauth/sso/session_timeout_test.go
@@ -1,0 +1,189 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sso
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const sessionConfigURL = testutils.TestServerURL + "/server-config/session"
+
+// SSO session timeouts are read once, when the session service is constructed, so changing them
+// requires a server restart rather than only a configuration write. Every test here therefore
+// restores the original configuration and restarts again, so a failure cannot leave the rest of the
+// run with second-scale session lifetimes.
+func (ts *SSOLogoutTestSuite) writableSessionConfig() string {
+	req, err := http.NewRequest(http.MethodGet, sessionConfigURL, nil)
+	ts.Require().NoError(err)
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err, "failed to read session server config")
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusOK, resp.StatusCode, "failed to read session config: %s", string(body))
+
+	var layers struct {
+		Writable json.RawMessage `json:"writable"`
+	}
+	ts.Require().NoError(json.Unmarshal(body, &layers))
+
+	if len(layers.Writable) == 0 {
+		return "{}"
+	}
+	return string(layers.Writable)
+}
+
+// putSessionConfig replaces the writable layer of the session section.
+func (ts *SSOLogoutTestSuite) putSessionConfig(body string) {
+	req, err := http.NewRequest(http.MethodPut, sessionConfigURL, strings.NewReader(body))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err, "failed to update session server config")
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusOK, resp.StatusCode,
+		"failed to update session config with %s: %s", body, string(respBody))
+}
+
+// applySessionTimeouts writes the given timeouts and restarts the server so the session service
+// picks them up, registering the restore before making any change so a mid-test failure still
+// returns the deployment to its original lifetimes.
+//
+// idle must not exceed absolute, and the activity-refresh interval must be strictly less than idle;
+// both are rejected by configuration validation otherwise.
+func (ts *SSOLogoutTestSuite) applySessionTimeouts(idle, absolute, activityRefresh int64) {
+	original := ts.writableSessionConfig()
+	ts.T().Cleanup(func() {
+		ts.putSessionConfig(original)
+		if err := testutils.RestartServer(); err != nil {
+			ts.T().Logf("cleanup: server did not restart cleanly after session config restore: %v", err)
+		}
+		if err := testutils.ObtainAdminAccessToken(); err != nil {
+			ts.T().Logf("cleanup: failed to re-obtain admin token after restore: %v", err)
+		}
+	})
+
+	ts.putSessionConfig(fmt.Sprintf(
+		`{"idleTimeoutSeconds":%d,"absoluteTimeoutSeconds":%d,"activityRefreshIntervalSeconds":%d}`,
+		idle, absolute, activityRefresh))
+
+	ts.Require().NoError(testutils.RestartServer(), "failed to restart server with session timeouts")
+	ts.Require().NoError(testutils.ObtainAdminAccessToken(),
+		"failed to re-obtain admin token after restart")
+}
+
+// sessionSurvives reports whether a fresh authorize is satisfied by the existing SSO session. A
+// live session completes the flow on its initial step; an expired one falls through to the
+// credential prompt.
+func (ts *SSOLogoutTestSuite) sessionSurvives(client *http.Client, state string) bool {
+	_, executionID := ts.authorize(client, "openid", state)
+	step := ts.flowExecute(client, map[string]interface{}{"executionId": executionID})
+	return step.FlowStatus == "COMPLETE"
+}
+
+// putSessionConfigExpectingRejection writes a session configuration that validation must refuse,
+// and returns the response body for the assertion.
+func (ts *SSOLogoutTestSuite) putSessionConfigExpectingRejection(body string) string {
+	req, err := http.NewRequest(http.MethodPut, sessionConfigURL, strings.NewReader(body))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err, "failed to send session config update")
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusBadRequest, resp.StatusCode,
+		"an incoherent session configuration must be refused, got %d for %s: %s",
+		resp.StatusCode, body, string(respBody))
+
+	return string(respBody)
+}
+
+// Session timeouts are only read at startup, so an incoherent set has to be refused when it is
+// written rather than discovered at the next restart. These are the combinations that would let a
+// session behave in a way the deadlines are meant to prevent.
+func (ts *SSOLogoutTestSuite) TestSessionConfig_IncoherentTimeoutsRejected() {
+	// The write is expected to fail, but restore the original on the way out regardless, so a
+	// regression that lets one through cannot leave the rest of the run misconfigured.
+	original := ts.writableSessionConfig()
+	ts.T().Cleanup(func() {
+		ts.putSessionConfig(original)
+	})
+
+	ts.Run("negative timeout", func() {
+		ts.putSessionConfigExpectingRejection(`{"idleTimeoutSeconds":-1}`)
+	})
+
+	ts.Run("idle beyond absolute", func() {
+		// An idle deadline past the absolute cap could never be reached, so the pair is meaningless.
+		ts.putSessionConfigExpectingRejection(
+			`{"idleTimeoutSeconds":600,"absoluteTimeoutSeconds":300,"activityRefreshIntervalSeconds":60}`)
+	})
+
+	ts.Run("refresh not below idle", func() {
+		// The refresh interval bounds how stale the persisted idle deadline may be. At or above the
+		// idle window, an active session could be skipped past its own deadline.
+		ts.putSessionConfigExpectingRejection(
+			`{"idleTimeoutSeconds":60,"absoluteTimeoutSeconds":600,"activityRefreshIntervalSeconds":60}`)
+	})
+}
+
+// An SSO session left untouched past its idle timeout must not satisfy a later authorize, so an
+// abandoned browser session cannot skip authentication indefinitely.
+func (ts *SSOLogoutTestSuite) TestSSOSession_IdleTimeoutForcesReauthentication() {
+	// A generous absolute timeout isolates the idle deadline as the only thing that can expire.
+	ts.applySessionTimeouts(2, 600, 1)
+
+	client := ts.newSessionClient()
+	ts.login(client, ssoReuseUsername, "idle_timeout_state_1")
+	ts.Require().NotEmpty(ts.ssoCookieNames(client), "an SSO cookie should be set after first login")
+
+	ts.Require().True(ts.sessionSurvives(client, "idle_timeout_state_2"),
+		"the session should still be live immediately after login")
+
+	// Idle past the deadline with no activity at all.
+	time.Sleep(4 * time.Second)
+
+	ts.False(ts.sessionSurvives(client, "idle_timeout_state_3"),
+		"an idle-expired session must not skip authentication")
+}
+
+// The absolute timeout caps total session lifetime regardless of activity, so a session kept alive
+// by continued use is still retired once it is old enough.
+func (ts *SSOLogoutTestSuite) TestSSOSession_AbsoluteTimeoutForcesReauthentication() {
+	// Idle equals absolute so that refreshing activity mid-way slides the idle deadline beyond the
+	// absolute one, leaving the absolute cap as the only reason the session can expire.
+	ts.applySessionTimeouts(4, 4, 1)
+
+	client := ts.newSessionClient()
+	ts.login(client, ssoReuseUsername, "absolute_timeout_state_1")
+
+	// Use the session inside the idle window. This slides the idle deadline forward but must not move
+	// the absolute one.
+	time.Sleep(2 * time.Second)
+	ts.Require().True(ts.sessionSurvives(client, "absolute_timeout_state_2"),
+		"the session should still be live within both deadlines")
+
+	// Now past the absolute cap (about 5s since login) but inside the refreshed idle window (about 6s
+	// from the activity above), so only the absolute timeout can end the session.
+	time.Sleep(3 * time.Second)
+
+	ts.False(ts.sessionSurvives(client, "absolute_timeout_state_3"),
+		"a session past its absolute timeout must not skip authentication even when recently used")
+}

--- a/tests/integration/testutils/api_utils.go
+++ b/tests/integration/testutils/api_utils.go
@@ -1570,6 +1570,101 @@ func PutDefaultResourceServer(resourceServerID string) error {
 	return nil
 }
 
+// GetWritableServerConfig returns the writable layer of the named server-config section, so a
+// caller can restore exactly what was there rather than guessing at a default. An absent layer is
+// reported as an empty object.
+func GetWritableServerConfig(section string) (json.RawMessage, error) {
+	url := fmt.Sprintf("%s/server-config/%s", TestServerURL, section)
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create %s server config request: %w", section, err)
+	}
+
+	resp, err := GetHTTPClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s server config: %w", section, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s server config response: %w", section, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("expected status 200 reading %s server config, got %d. Response: %s",
+			section, resp.StatusCode, string(body))
+	}
+
+	var layers struct {
+		Writable json.RawMessage `json:"writable"`
+	}
+	if err := json.Unmarshal(body, &layers); err != nil {
+		return nil, fmt.Errorf("failed to parse %s server config: %w", section, err)
+	}
+
+	if len(layers.Writable) == 0 {
+		return json.RawMessage("{}"), nil
+	}
+	return layers.Writable, nil
+}
+
+// PutWritableServerConfig replaces the writable layer of the named server-config section.
+func PutWritableServerConfig(section string, body []byte) error {
+	url := fmt.Sprintf("%s/server-config/%s", TestServerURL, section)
+
+	req, err := http.NewRequest(http.MethodPut, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create %s server config request: %w", section, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := GetHTTPClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to update %s server config: %w", section, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read %s server config response: %w", section, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("expected status 200 updating %s server config with %s, got %d. Response: %s",
+			section, string(body), resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+// MergeWritableServerConfig applies the given top-level keys over the current writable layer of the
+// section and writes the result back, returning the layer as it was beforehand.
+//
+// Merging rather than replacing keeps sibling keys that the caller did not set, which a bare PUT
+// would drop. The returned value is what the caller restores when it is done.
+func MergeWritableServerConfig(section string, patch map[string]interface{}) (json.RawMessage, error) {
+	original, err := GetWritableServerConfig(section)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := make(map[string]interface{})
+	if err := json.Unmarshal(original, &merged); err != nil {
+		return nil, fmt.Errorf("failed to parse writable %s server config: %w", section, err)
+	}
+	for key, value := range patch {
+		merged[key] = value
+	}
+
+	body, err := json.Marshal(merged)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal %s server config: %w", section, err)
+	}
+	if err := PutWritableServerConfig(section, body); err != nil {
+		return nil, err
+	}
+	return original, nil
+}
+
 // createAction creates an action on a resource server via API and returns the action ID
 func createAction(resourceServerID string, action Action) (string, error) {
 	client := GetHTTPClient()


### PR DESCRIPTION
### Purpose

Integration coverage for the flow engine and SSO sessions sat well below the 85% bar, with the gaps concentrated in error, resume, timeout and administration paths that unit tests cover only in isolation.

This adds 50 integration tests across fifteen areas. Measured statement coverage from the instrumented build (`target/coverage_integration.out`):

| Package | Before | After | Δ |
|---|---|---|---|
| `flow/executor` | 50.5% | **63.9%** | **+13.4** |
| `flow/session` | 57.4% | **70.5%** | **+13.1** |
| `flow/flowexec` | 65.2% | **74.8%** | **+9.6** |
| `flow/mgt` | 61.4% | **70.7%** | **+9.3** |
| `flow/core` | 66.3% | 66.8% | +0.5 |

859 statements newly covered.

### Approach

**Flow execution error branches** (`tests/integration/flow/execution/flow_execution_error_test.go`)

Six flow-execution error branches had no integration assertion at all. The three administration gates matter most, since `/flow/execute` is a public path and these checks are the only thing between any caller and administration flow execution:

- unknown and missing flow type, unknown application
- registration and recovery disabled on the application
- unknown and malformed execution id
- unauthenticated execution by flow id, and the same rejection for a flow id that does not exist, so the endpoint does not leak which flows are present
- an administrator executing a non-administration flow by id
- a client credentials token refused at the administration entry point

**Nested call depth** (`tests/integration/flow/execution/call_depth_test.go`)

A chain of flows each calling the next, one longer than the engine allows, must be refused rather than recursing. The limit is what stops a mutually recursive set of flows, which the designer does not prevent an operator authoring, from exhausting the stack.

**Registration flow inference** (`tests/integration/flow/mgt/flow_inference_test.go`)

Creating an authentication flow with `flow.auto_infer_registration` enabled derives a registration flow from it, renamed and carrying the provisioning step that turns collected credentials into a user. The flag is off by default, so these tests patch the deployment configuration and restart, restoring on teardown. Also covers the flow-type executor requirements: a registration flow without a provisioning executor is rejected rather than stored.

**Flow usages** (`tests/integration/flow/mgt/flow_usages_test.go`)

`GET /flows/{flowId}/usages` had no test. Covers an unreferenced flow reporting a known-empty result, an application binding appearing as a usage with the fields the Console renders, and the not-found case.

**Execution lifecycle** (`tests/integration/flow/execution/flow_lifecycle_test.go`)

Resume of an existing execution, refusal to resume without the required input, and context expiry. Expiry is driven by writing `authFlow.expirySeconds` and needs no restart, because the flow section is read from merged server config on every execution. The original writable layer is restored on cleanup.

**Administration flow** (`tests/integration/flow/execution/administration_flow_test.go`)

One execution of the shipped `default-user-deletion-flow` drives the whole chain: permission validation, pre-delete validation publishing the trusted revocation plan, criteria revocation, session termination, and record deletion. Plus the unknown-subject and missing-subject cases. This is the first integration coverage of the criteria-based revocation path.

**SSO session timeouts** (`tests/integration/oauth/sso/session_timeout_test.go`)

Session timeouts are read once when the session service is constructed, so these tests write the session configuration and restart the server, restoring and restarting again on cleanup. The restore is registered before any change, so a mid-test failure cannot leave the run with second-scale session lifetimes.

The absolute-timeout test sets idle equal to absolute and uses the session mid-window. That slides the idle deadline past the absolute one, leaving the absolute cap as the only thing that can end the session, which is what distinguishes the two deadlines.

**Consent** (`tests/integration/flow/authentication/consent_test.go`)

The consent executor had no integration coverage at all. Covers the prompt being raised for the attributes an application requests, approval recording consent so a second sign-in skips the prompt entirely, denial of optional attributes completing the flow with nothing consented, an unparseable decisions payload, a submission carrying the timeout reason (recorded as no decision), and a decision arriving after the configured step timeout.

**Identifying executor modes** (`tests/integration/flow/authentication/identify_modes_test.go`)

`resolve` narrows a candidate set instead of failing on ambiguity: two users sharing an email return the attribute that separates them with the candidate values as options, and answering it resolves the user from the stored candidates rather than a second search. `check_state` records whether zero, one or several users match and lets the flow branch on it; each of the three outcomes is asserted from the prompt the flow lands on, which also exercises the engine's condition-skip path.

**User onboarding** (`tests/integration/flow/execution/user_onboarding_test.go`)

`USER_ONBOARDING` is app-independent: it carries no `applicationId` and is resolved through `flow.userOnboardingFlow.defaultHandle`. The OU is chosen first from the full tree, and the selected OU then decides which user types are on offer, so picking the root auto-selects its only type while picking a child prompts between the two. Also covers an unknown OU, a type outside the node's allowed list, and a type whose OU is not an ancestor of the selected one.

**OU resolver strategies** (`tests/integration/flow/registration/ou_resolver_strategies_test.go`)

`prompt` asks for an OU only when the user type's OU has children and accepts only selections inside that subtree; `caller` fails on a self-service registration flow because there is no authenticated caller to take an OU from; an unrecognized strategy fails the node rather than being ignored.

**Attribute uniqueness** (`tests/integration/flow/registration/attribute_uniqueness_test.go`)

A value already held by another user is reported against the attribute that conflicts and the details are asked for again, before provisioning runs. Covers a conflict on either unique attribute and the free-value path through to provisioning.

**Flow observability events** (`tests/integration/flow/execution/flow_events_test.go`)

Enables the `observability` section with the file sink and asserts what the engine publishes: the full node trail of a successful run correlated by execution id, a node that forwards back to its prompt (published as completed with the forwarding status and the reason), and a node that genuinely fails. The sink flushes on a fixed ticker, so the reads wait on the specific event rather than on any event of the type, which would otherwise return a half-flushed prefix of the run.

**Call frames** (`tests/integration/flow/execution/call_frames_test.go`)

A call that pauses inside the callee has its caller frame written into the stored context and read back on resume, then returns to the caller's success target. A failing callee ends the caller when the call node names no failure target, and resumes at that target when it does.

**Session termination and configuration** (`tests/integration/oauth/sso/`)

Deleting a user through the shipped administration flow tears down the SSO sessions that user holds; the session is proven live beforehand by an authorize that skips the credential prompt, so the assertion afterwards is a change in behaviour rather than an absence. Session configuration validation refuses negative timeouts, an idle deadline beyond the absolute cap, and a refresh interval not below the idle window.

**Default flow fallback** (`tests/integration/flow/execution/flow_lifecycle_test.go`)

Deleting a flow an application references is allowed, so the reference dangles. Rather than failing every sign-in for that application, the engine falls back to the configured default authentication flow.

**Inference prompt meta** (`tests/integration/flow/mgt/flow_inference_test.go`)

The inferred registration flow carries the source flow's UI, so its authentication wording is rewritten to its registration equivalent and the self sign-up link is dropped, because the inferred flow is the sign-up.

### Notes for reviewers

Behaviours worth knowing, each of which cost a test run to discover:

- An `AUTHENTICATION` flow must contain an `AuthAssertExecutor` (`FLM-1023`), so even a fixture flow that is never completed needs one.
- The shared test HTTP clients treat `/flow/execute` as a public endpoint and **skip token injection**. Any test of the administration entry point has to set the bearer header itself on a raw client. This is documented in the helper.
- Resuming a prompt without its required input returns `ERROR` rather than re-presenting the prompt. That is now pinned by its own test.
- A `REGISTRATION` flow must carry both a `UserTypeResolver` and a `ProvisioningExecutor`; the full table is `requiredExecutorsByFlowType` in the validator, alongside a `companionExecutors` map that pairs executors which must appear together.
- **An application binding a registration flow needs an isolated auth flow.** Otherwise the default authentication flow's own registration reference collides with it and application creation fails with `APP-1039`. `testutils.CreateIsolatedAuthFlow` exists for this.
- **A node nothing can reach is rejected at create time** (`FLM-1020`), so a fixture's failure-target node has to exist only in the variant whose call node points at it.
- **A wrong password is not a node failure.** The credentials executor returns `ExecUserInputRequired`, so the published event is a completed node execution carrying the forwarding status and the reason, not a failure.
- **`PatchDeploymentConfig` merges at the top level only.** Patching one key inside a nested block replaces the whole block, silently dropping its siblings. Doing that to `flow` dropped `max_version_history` and broke two unrelated version-history tests in the same package, which no scoped test run could reveal. Both patches here restate the block exactly as `tests/integration/resources/deployment.yaml` sets it.

### Known gaps

- **`FES-1019` (administration permission required) is not covered.** A client credentials token is rejected as unauthenticated before permissions are consulted, because it establishes no user subject. Reaching that branch needs a signed-in non-administrator user. Recorded in the test file.
- **`flow/interceptor` and `flow/graphbuilder` are unchanged**, and deliberately so. `CaptchaValidationProvider` is an engine SDK extension point with no implementation or configuration in the server, so the captcha interceptor cannot execute in this deployment. The graph builder's error branches require a nil or node-less flow, or a structural build failure, both of which create-time validation rejects first. Both files already have unit tests, which is the right vehicle for defensive paths and SDK extension points.
- **`federated_auth_resolver` is not covered.** Reaching it needs stored candidates from the identifying executor together with a verified federated subject, but the OIDC executor writes the federated attributes only on success and returns before them when the local user is ambiguous. Whether that composition is reachable at all is unresolved, so it was left rather than guessed at.
- **85% is not reached, and per-package 85% does not look reachable through integration tests.** Three separate causes, in order of size:
  - `flow/executor`'s remaining gap is dominated by `passkey` (200 statements, needing a WebAuthn virtual authenticator) and `openid4vp` (67, needing a wallet). Both are test-harness components rather than tests, and are separate work.
  - **Some of the uncovered code has no production call site.** In `flow/core`, `graph.ToJSON`, `graph.RemoveEdge`, `factory.CloneNode`, `factory.CloneNodes` and the graph setters are declared on their interfaces and called from nowhere in the server: roughly 111 statements no integration test can execute. In `flow/mgt`, `insertPhoneInputPromptIfNeeded` and its helper `createInputPromptNode` (42 statements) are invoked only by their own unit tests; a test written against the behaviour they describe fails, because nothing calls them. Both look like dead code and are worth a separate issue.
  - The rest is largely defensive: nil-guards on paths that always pre-initialize, row-scan and decode error branches, and the `InterceptorRunnerContext` helpers, which are reachable only through an interceptor and the sole implementation (captcha) cannot execute in this deployment.
- **`publishFlowFailedEvent` never fires on a node failure.** Across 198 events published during a run, `FLOW_FAILED` appeared zero times: the paths that publish it are gated on `flowStep.Status == FlowStatusError`, which a node-level failure does not set. The node itself is published as `FLOW_NODE_EXECUTION_FAILED`, so the failure is observable, but the run-level event is not. Possibly intended, flagging it either way.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded integration coverage for authentication flows, including consent, user identification, onboarding, registration, nested calls, lifecycle handling, and execution errors.
  - Added validation for administration user deletion, including termination of active SSO sessions.
  - Added coverage for flow usage reporting, observability events, call-depth limits, and fallback behavior.
  - Added tests for SSO idle and absolute session timeouts.
  - Improved test utilities for safely managing writable server configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
