### PR TITLE
Fix Groups/Roles/VC production crash from un-externalized logger subpath

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -119,6 +119,32 @@ reviews:
           `:paramName` segment) — only the domain's own top-level path needs to trace back to
           `RouteConfig`.
 
+    - path: "frontend/packages/**/rolldown.config.js"
+      instructions: |
+        This file's `external` array is built from `Object.keys(pkg.dependencies)` and
+        `Object.keys(pkg.peerDependencies)`, which only matches a dependency's bare specifier. rolldown
+        matches `external` entries by exact string, so an import of a subpath of that dependency (e.g.
+        `@thunderid/logger/react`, `@hookform/resolvers/zod`) is NOT covered by the bare name and gets
+        inlined into this package's own `dist` output instead of staying external. For a dependency
+        backed by a React context, this silently creates a second `createContext()` instance inside this
+        package's bundle, causing a `use<Thing> must be used within a <Thing>Provider` crash that only
+        reproduces in production (dev aliases workspace packages to source, masking the bug).
+
+        Cross-reference this package's `package.json` `dependencies`/`peerDependencies` against every
+        subpath import actually used in `src/` (e.g. `grep -r "from '@thunderid/" src` or similar for
+        other scoped packages). For each dependency subpath imported, check that the exact subpath string
+        (e.g. `'@thunderid/logger/react'`) is listed as its own literal entry in the `external` array,
+        following the `// Peer dep subpaths are not matched by exact string - add them explicitly.`
+        convention established in `frontend/packages/configure-resource-servers/rolldown.config.js`.
+
+        Flag a missing subpath entry as a **major issue**:
+
+        "🔴 **Un-externalized dependency subpath**: `<subpath>` is imported in this package's source but
+        is not listed as an explicit string in `external`. Only the bare `<package>` name is covered by
+        the dependency-keys spread above, so this subpath will be inlined into this package's dist
+        output — for a context-providing dependency this creates a duplicate context instance and breaks
+        at runtime in production only. Add `'<subpath>'` to the `external` array."
+
     - path: "frontend/packages/configure-*/**/*.{ts,tsx}"
       instructions: |
         Route destination guidance for reusable packages. A `@thunderid/configure-*` package must

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -17,6 +17,23 @@ Gate consumes ThunderID's published SDK packages — `@thunderid/react` and `@th
 [javascript-sdks](https://github.com/thunder-id/javascript-sdks) repository. Clone that repository only to develop or
 debug the SDK itself, or to test against unreleased SDK changes.
 
+### rolldown External Subpaths
+
+Every package's `rolldown.config.js` builds `external` from `Object.keys(pkg.dependencies)` and
+`Object.keys(pkg.peerDependencies)`, which only matches a dependency's bare specifier (e.g. `@thunderid/logger`).
+rolldown matches `external` by exact string, so an import of a **subpath** of that dependency (e.g.
+`@thunderid/logger/react`, `@hookform/resolvers/zod`) is not covered and gets inlined into this package's own `dist`
+output instead of staying external. For a dependency backed by a React context (e.g. `@thunderid/logger`), this silently
+creates a second `createContext()` instance in this package's bundle, so the copy's `useContext` never sees the value
+the host app's provider supplies — a `use<Thing> must be used within a <Thing>Provider` crash that reproduces in
+production only (dev aliases workspace packages to source, masking it) and never in tests.
+
+When scaffolding a new `frontend/packages/*` package, or adding an import of a subpath (`somepkg/subpath`) from an
+existing dependency: add that exact subpath as a string literal to the package's `rolldown.config.js` `external` array,
+next to the existing `// Peer dep subpaths are not matched by exact string - add them explicitly.` entries (see
+`packages/configure-resource-servers/rolldown.config.js`). Do this for every subpath actually imported by the package's
+source, not just `@thunderid/logger/react`.
+
 ## Route Configuration — Never Hardcode a Path
 
 Every route destination is centralized in a per-app `RouteConfig` (`frontend/apps/console/src/configs/RouteConfig.ts`,

--- a/frontend/packages/configure-groups/rolldown.config.js
+++ b/frontend/packages/configure-groups/rolldown.config.js
@@ -13,6 +13,8 @@ const external = [
   'react/jsx-runtime',
   // Needed to avoid hook ordering issues.
   /^@mui\//,
+  // Peer dep subpaths are not matched by exact string - add them explicitly.
+  '@thunderid/logger/react',
 ];
 
 const commonOptions = {

--- a/frontend/packages/configure-roles/rolldown.config.js
+++ b/frontend/packages/configure-roles/rolldown.config.js
@@ -13,6 +13,8 @@ const external = [
   'react/jsx-runtime',
   // Needed to avoid hook ordering issues.
   /^@mui\//,
+  // Peer dep subpaths are not matched by exact string - add them explicitly.
+  '@thunderid/logger/react',
 ];
 
 const commonOptions = {

--- a/frontend/packages/configure-verifiable-credentials/rolldown.config.js
+++ b/frontend/packages/configure-verifiable-credentials/rolldown.config.js
@@ -13,6 +13,8 @@ const external = [
   'react/jsx-runtime',
   // Needed to avoid hook ordering issues.
   /^@mui\//,
+  // Peer dep subpaths are not matched by exact string - add them explicitly.
+  '@thunderid/logger/react',
 ];
 
 const commonOptions = {


### PR DESCRIPTION
### Purpose
In production builds, navigating to Groups, Roles, or Verifiable Credentials threw `Uncaught Error: useLogger must be used within a LoggerProvider`, even though `LoggerProvider` correctly wraps the app in `main.tsx`. The bug did not reproduce in development.

### Approach
Each of `configure-groups`, `configure-roles`, and `configure-verifiable-credentials`'s `rolldown.config.js` builds its `external` array from the bare keys of `package.json` `dependencies`/`peerDependencies`. rolldown matches `external` entries by exact string, so this only covers the bare specifier `@thunderid/logger`, not the subpath `@thunderid/logger/react` that these packages actually import. The subpath's entire module tree, including `LoggerContext`, was getting inlined into each package's own `dist` output, producing a second `createContext(null)` instance per package. At runtime, the app's `LoggerProvider` populated the app's own logger context, but the lazy-loaded Groups/Roles/VC chunks read from their own private, unpopulated context copy, so `useLogger` saw `null` and threw.

This was invisible in development because a build plugin resolves workspace `@thunderid/*` imports to source (not `dist`) only when running the dev server, so dev shares a single module graph.

Fixed by adding `'@thunderid/logger/react'` as an explicit string literal to each affected package's `external` array, following the same convention already used in `configure-resource-servers/rolldown.config.js`. Also added documentation (`frontend/AGENTS.md`) and a CodeRabbit path instruction (`.coderabbit.yaml`) so future `rolldown.config.js` changes and new packages catch this class of bug during scaffolding/review.

Verified locally by rebuilding all three packages and confirming the built `dist/pages/*.js` files import `useLogger` from `@thunderid/logger/react` directly, with no inlined logger copy in `dist/`.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved frontend package builds by ensuring shared React-related dependencies are handled consistently.
  - Reduced the risk of production-only issues caused by duplicated dependency instances.

- **Documentation**
  - Added guidance for maintaining dependency handling across frontend package builds.
  - Added automated review checks to help prevent missing dependency configuration in future changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->