### PR TITLE
Show specific error messages for user onboarding flow failures

### DIFF
--- a/frontend/packages/configure-users/src/pages/UserAddPage.tsx
+++ b/frontend/packages/configure-users/src/pages/UserAddPage.tsx
@@ -1106,13 +1106,18 @@ export default function UserAddPage(): JSX.Element {
             return;
           }
           logger.error('User onboarding error', {error: err});
+          // onFlowChange runs first and sees the full error envelope, including the code. The SDK
+          // flattens that envelope into a plain Error before onError, so only fill in here when
+          // onFlowChange had nothing to report (for example, a thrown network failure).
           setFlowError(
-            getUserErrorMessage(
-              err,
-              (key, options) => t(key.includes(':') ? key : `users:${key}`, options),
-              'errors.failed.description',
-              'An error occurred. Please try again.',
-            ),
+            (current) =>
+              current ??
+              getUserErrorMessage(
+                err,
+                (key, options) => t(key.includes(':') ? key : `users:${key}`, options),
+                'errors.failed.description',
+                'An error occurred. Please try again.',
+              ),
           );
         }}
         onFlowChange={(response) => {
@@ -1124,12 +1129,14 @@ export default function UserAddPage(): JSX.Element {
             setFlowError(null);
             return;
           }
-          const messageKey = (response.error as unknown as Record<string, unknown>)?.['message'] as
-            | Record<string, unknown>
-            | undefined;
-          const key = messageKey?.['key'] as string | undefined;
-          const localizedFallback = t('users:errors.failed.description', 'An error occurred. Please try again.');
-          setFlowError(key ? t(key, localizedFallback) : localizedFallback);
+          setFlowError(
+            getUserErrorMessage(
+              response as unknown as Error,
+              (key, options) => t(key.includes(':') ? key : `users:${key}`, options),
+              'errors.failed.description',
+              'An error occurred. Please try again.',
+            ),
+          );
         }}
       >
         {(renderProps: InviteUserRenderProps) => (

--- a/frontend/packages/configure-users/src/pages/__tests__/UserAddPage.test.tsx
+++ b/frontend/packages/configure-users/src/pages/__tests__/UserAddPage.test.tsx
@@ -40,6 +40,7 @@ let simulateInviteUserError = false;
 const mockInviteUserError = new Error('Invite user failed');
 
 let capturedOnFlowChange: ((response: unknown) => void) | null = null;
+let capturedOnError: ((error: Error) => void) | null = null;
 
 const defaultRenderProps: TestInviteUserRenderProps = {
   additionalData: undefined,
@@ -95,8 +96,9 @@ vi.mock('@thunderid/react', async (importOriginal) => {
       onError?: (error: Error) => void;
       onFlowChange?: (response: unknown) => void;
     }) => {
-      // Capture onFlowChange so tests can invoke it
+      // Capture onFlowChange and onError so tests can invoke them
       capturedOnFlowChange = onFlowChange ?? null;
+      capturedOnError = onError ?? null;
 
       if (simulateInviteUserError && onError) {
         setTimeout(() => {
@@ -296,6 +298,7 @@ describe('UserAddPage', () => {
     vi.clearAllMocks();
     simulateInviteUserError = false;
     capturedOnFlowChange = null;
+    capturedOnError = null;
     mockInviteUserRenderProps = {...defaultRenderProps};
     Object.assign(mockInviteUserError, {message: 'Invite user failed', response: undefined});
   });
@@ -721,6 +724,121 @@ describe('UserAddPage', () => {
       }
 
       // Re-render to reflect state change
+      rerender(<UserAddPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('An error occurred. Please try again.')).toBeInTheDocument();
+      });
+    });
+
+    it('should show the mapped message for a known flow executor error code', async () => {
+      mockInviteUserRenderProps.components = [
+        heading('Step 1'),
+        block([textInput('name', 'Name'), submitAction('Next')]),
+      ];
+
+      const {rerender} = render(<UserAddPage />);
+
+      // FET-1080 is the provisioning attribute conflict raised when a unique attribute is taken.
+      if (capturedOnFlowChange) {
+        capturedOnFlowChange({
+          flowStatus: 'ERROR',
+          error: {
+            code: 'FET-1080',
+            message: {
+              key: 'flows.executor.errors.provisioning_attribute_conflict',
+              defaultValue: 'A user with the provided attributes already exists',
+            },
+            description: {
+              key: 'flows.executor.errors.provisioning_attribute_conflict_desc',
+              defaultValue: 'User provisioning failed because one or more unique attribute values are already taken',
+            },
+          },
+        });
+      }
+      rerender(<UserAddPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('A user with the same unique attribute value already exists.')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('An error occurred. Please try again.')).not.toBeInTheDocument();
+    });
+
+    it('should name the conflicting attribute for a parameterized flow executor error', async () => {
+      mockInviteUserRenderProps.components = [
+        heading('Step 1'),
+        block([textInput('email', 'Email'), submitAction('Next')]),
+      ];
+
+      const {rerender} = render(<UserAddPage />);
+
+      // FET-1061 is raised by the uniqueness check on the invite path. It re-prompts rather than
+      // failing the flow, so it arrives through onFlowChange without an ERROR status.
+      if (capturedOnFlowChange) {
+        capturedOnFlowChange({
+          error: {
+            code: 'FET-1061',
+            message: {
+              key: 'flows.executor.errors.attribute_not_unique',
+              defaultValue: 'User already exists with the provided email',
+              params: {attribute: 'email'},
+            },
+          },
+        });
+      }
+      rerender(<UserAddPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('A user already exists with the provided email.')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('An error occurred. Please try again.')).not.toBeInTheDocument();
+    });
+
+    it('should keep the mapped message when onError follows onFlowChange for the same failure', async () => {
+      mockInviteUserRenderProps.components = [
+        heading('Step 1'),
+        block([textInput('name', 'Name'), submitAction('Next')]),
+      ];
+
+      const {rerender} = render(<UserAddPage />);
+
+      // The SDK reports a flow failure through both callbacks: onFlowChange receives the full
+      // envelope, then onError receives it flattened into a plain Error with the code stripped.
+      if (capturedOnFlowChange) {
+        capturedOnFlowChange({
+          flowStatus: 'ERROR',
+          error: {
+            code: 'FET-1080',
+            message: {
+              key: 'flows.executor.errors.provisioning_attribute_conflict',
+              defaultValue: 'A user with the provided attributes already exists',
+            },
+          },
+        });
+      }
+      if (capturedOnError) {
+        capturedOnError(new Error('A user with the provided attributes already exists'));
+      }
+      rerender(<UserAddPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('A user with the same unique attribute value already exists.')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('An error occurred. Please try again.')).not.toBeInTheDocument();
+    });
+
+    it('should fall back to the generic message when onError reports a failure on its own', async () => {
+      mockInviteUserRenderProps.components = [
+        heading('Step 1'),
+        block([textInput('name', 'Name'), submitAction('Next')]),
+      ];
+
+      const {rerender} = render(<UserAddPage />);
+
+      // A thrown network failure never reaches onFlowChange, so onError must still surface something.
+      if (capturedOnError) {
+        capturedOnError(new Error('Network request failed'));
+      }
       rerender(<UserAddPage />);
 
       await waitFor(() => {

--- a/frontend/packages/configure-users/src/utils/__tests__/getUserErrorMessage.test.ts
+++ b/frontend/packages/configure-users/src/utils/__tests__/getUserErrorMessage.test.ts
@@ -54,6 +54,34 @@ describe('getUserErrorMessage', () => {
     );
   });
 
+  it('should interpolate params carried by a flow envelope message', () => {
+    const error = Object.assign(new Error('flow failed'), {
+      error: {
+        code: 'FET-1061',
+        message: {key: 'flows.executor.errors.attribute_not_unique', params: {attribute: 'email'}},
+      },
+    });
+    const t = vi.fn((key: string, options?: {attribute?: string; defaultValue?: string}) =>
+      key === 'common:errors.FET-1061' ? `A user already exists with the provided ${options?.attribute}.` : '',
+    );
+
+    expect(getUserErrorMessage(error, t, 'create.error')).toBe('A user already exists with the provided email.');
+  });
+
+  it('should read flow envelope params from the description when the message carries none', () => {
+    const error = Object.assign(new Error('flow failed'), {
+      error: {
+        code: 'FET-1061',
+        description: {key: 'flows.executor.errors.attribute_not_unique_desc', params: {attribute: 'mobileNumber'}},
+      },
+    });
+    const t = vi.fn((key: string, options?: {attribute?: string; defaultValue?: string}) =>
+      key === 'common:errors.FET-1061' ? `A user already exists with the provided ${options?.attribute}.` : '',
+    );
+
+    expect(getUserErrorMessage(error, t, 'create.error')).toBe('A user already exists with the provided mobileNumber.');
+  });
+
   it('should resolve a flow-shaped code from the shared catalog when the feature namespace has no entry', () => {
     const error = Object.assign(new Error('flow failed'), {code: 'SSE-4030'});
     const t = vi.fn((key: string) =>

--- a/frontend/packages/configure-users/src/utils/getUserErrorMessage.ts
+++ b/frontend/packages/configure-users/src/utils/getUserErrorMessage.ts
@@ -36,6 +36,22 @@ function extractErrorCode(error: Error): string | undefined {
 }
 
 /**
+ * Reads the interpolation params the flow engine attaches to a parameterized error, so a mapped
+ * message resolves its placeholders instead of rendering them literally. Params ride on the
+ * message, with the description as a fallback.
+ */
+function extractFlowErrorParams(error: Error): Record<string, string> | undefined {
+  const candidate = error as Error & {
+    error?: {
+      description?: {params?: Record<string, string>};
+      message?: {params?: Record<string, string>};
+    };
+  };
+
+  return candidate.error?.message?.params ?? candidate.error?.description?.params;
+}
+
+/**
  * Extracts a localized error message from a user API error response, with a dedicated,
  * actionable message for USR-1027 (blocking dependencies) and normalization for the embedded
  * flow's error envelope.
@@ -80,7 +96,9 @@ export default function getUserErrorMessage(
     // The code came from a flow-shaped envelope getErrorMessage cannot see (response.data.code is
     // absent), so resolve it here instead of delegating. Mirrors getErrorMessage's two-tier lookup:
     // the feature namespace first, then the shared catalog for cross-service codes (e.g. SSE-4030).
-    const specific = t(`errors.${code}`, {defaultValue: ''}) || t(`common:errors.${code}`, {defaultValue: ''});
+    const params = extractFlowErrorParams(error);
+    const options = {...params, defaultValue: ''};
+    const specific = t(`errors.${code}`, options) || t(`common:errors.${code}`, options);
 
     if (specific) {
       return specific;

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -128,6 +128,19 @@ const translations = {
     'errors.DCR-1002': 'This resource is managed declaratively and cannot be modified.',
     'errors.DCR-1003': 'This resource is managed declaratively and cannot be deleted.',
 
+    // Backend error code translations for flow executor failures (per the flow execution error envelope).
+    'errors.FET-1002': 'Could not check whether a matching user already exists. Please try again.',
+    'errors.FET-1003': 'The provided details match more than one existing user.',
+    'errors.FET-1006': 'The user was created but could not be signed in.',
+    'errors.FET-1007': 'A user with these details already exists.',
+    'errors.FET-1020': 'Provide at least one user attribute to continue.',
+    'errors.FET-1021': 'Something went wrong while creating the user. Please try again.',
+    'errors.FET-1022': 'The user was created but group or role assignment failed.',
+    'errors.FET-1023': 'Select an organization unit before continuing.',
+    'errors.FET-1024': 'A user with these details already exists in the selected organization unit.',
+    'errors.FET-1061': 'A user already exists with the provided {{attribute}}.',
+    'errors.FET-1080': 'A user with the same unique attribute value already exists.',
+
     // External links
     learnMore: 'Learn more',
     'externalLink.title': 'You are leaving {{productName}}',


### PR DESCRIPTION
### Purpose

Backend validation failures during user creation surfaced in the Console as a generic
`An error occurred. Please try again.`, giving the admin nothing to act on.

Reproduce by creating two users with the same email using the Person schema. Both
onboarding modes in the Add User wizard were affected, each through a different backend code:

| Wizard mode | Flow node | Error code |
|---|---|---|
| Create user now | `direct_create_provisioning` | `FET-1080` (attribute conflict) |
| Invite user | `check_email_uniqueness` | `FET-1061` (attribute not unique) |

The backend was already returning usable, specific errors for both. The Console discarded
them and rendered its fallback instead.

### Approach

**Root cause.** The SDK reports a flow failure through two callbacks, and each dropped the
information the other had. `onFlowChange` receives the full envelope but read only
`error.message.key`, which has no entry in the Console catalog, so it always fell through to
the generic fallback. `onError` then overwrote that value, and because the SDK flattens the
envelope into a plain `Error`, the code was already gone by the time it ran.

**Fix, following the existing convention.** The Console already maps backend error codes to
locally authored strings via `errors.<CODE>` in the feature namespace, then
`common:errors.<CODE>` for cross-service codes (see `errors.USR-1014`, `errors.SSE-4030`,
`errors.FLM-1001`). `getUserErrorMessage` already had a branch built for flow-shaped
envelopes; it was unreachable because no caller supplied a code. The change wires that
existing path up rather than adding a new mechanism.

1. `onFlowChange` now calls `getUserErrorMessage` instead of hand-reading `message.key`.
   `extractErrorCode` picks the code off `error.code` and the two-tier lookup resolves it.
2. `onError` no longer clobbers. It runs second with strictly less information, so it only
   fills in when `onFlowChange` had nothing to report, such as a thrown network failure.
   Both handlers are needed: a re-prompt carrying an error (`ExecUserInputRequired`, which is
   how `FET-1061` arrives) never sets `flowStatus: ERROR`, so `onError` does not fire for it.
3. Added the ten `errors.FET-*` entries the wizard can produce to the `common` namespace,
   alongside the existing shared-service codes.
4. `getUserErrorMessage` now forwards the flow engine's interpolation params to i18next, so
   parameterized codes name the offending attribute. `FET-1061` ships
   `params: {attribute: "email"}`, which resolves
   `A user already exists with the provided {{attribute}}.`

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4764


<img width="1027" height="961" alt="image" src="https://github.com/user-attachments/assets/72816456-79f2-4a52-a3eb-d258bd92434f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when adding users, preserving specific flow-change messages and providing appropriate fallback messages.
  * Added support for translated error messages with dynamic details and parameters.
  * Expanded English error coverage for user lookup, duplicate users, creation, organizational unit selection, and assignment failures.
* **Tests**
  * Added coverage for mapped, parameterized, preserved, and generic error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->