### PR TITLE
Add integration tests for federated login and attribute mapping

### DIFF
--- a/tests/integration/composite/composite_mode_api_test.go
+++ b/tests/integration/composite/composite_mode_api_test.go
@@ -13,6 +13,7 @@ Runtime resources can be freely modified.
 package composite
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -281,6 +282,201 @@ func (suite *CompositeModeSuite) TestIdentityProviderDeclarativeVisibility() {
 
 	suite.assertMergedCollectionContainsIDs(
 		"/connections?category=identity-provider", "connections", "decl-idp-1", "identity_provider")
+}
+
+// AD4: a declarative connection's attributeConfiguration survives the file store and is returned by
+// both the vendor GET and the merged listing, and a database-backed connection created at runtime in the
+// same composite deployment returns its own. This is also the first test to execute
+// idpStore.GetIdentityProviderListCount, which the composite store calls from GetIdentityProviderList
+// and which no test had reached against a real database.
+func (suite *CompositeModeSuite) TestConnectionAttributeConfigurationInCompositeMode() {
+	client := testutils.GetHTTPClient()
+
+	resp, err := client.Get(fmt.Sprintf("%s/connections/google/decl-idp-1", testutils.TestServerURL))
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+	suite.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var declarative map[string]interface{}
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&declarative))
+
+	config, ok := declarative["attributeConfiguration"].(map[string]interface{})
+	suite.Require().True(ok, "declarative connection should return its attributeConfiguration: %v", declarative)
+
+	// The response is camelCase even though the YAML source is snake_case, because the wire format is
+	// driven by the json tags while the file is parsed with the yaml ones. See G13.
+	resolution, ok := config["userTypeResolution"].(map[string]interface{})
+	suite.Require().True(ok, "expected userTypeResolution in %v", config)
+	suite.Equal("Declarative Test Schema", resolution["default"])
+
+	linking, ok := config["accountLinking"].(map[string]interface{})
+	suite.Require().True(ok, "expected accountLinking in %v", config)
+	suite.Equal([]interface{}{"email"}, linking["attributes"])
+
+	mappings, ok := config["userTypeAttributeMappings"].([]interface{})
+	suite.Require().True(ok, "expected userTypeAttributeMappings in %v", config)
+	suite.Require().Len(mappings, 1)
+	entry, ok := mappings[0].(map[string]interface{})
+	suite.Require().True(ok)
+	suite.Equal("Declarative Test Schema", entry["userType"])
+	suite.Len(entry["attributes"], 2)
+
+	// A runtime, database-backed connection in the same deployment carries its own configuration.
+	runtimeID := suite.createRuntimeConnectionWithAttributeConfiguration()
+	defer suite.deleteRuntimeConnection(runtimeID)
+
+	resp, err = client.Get(fmt.Sprintf("%s/connections/google/%s", testutils.TestServerURL, runtimeID))
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+	suite.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var runtime map[string]interface{}
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&runtime))
+	runtimeConfig, ok := runtime["attributeConfiguration"].(map[string]interface{})
+	suite.Require().True(ok, "database-backed connection should return its attributeConfiguration")
+	runtimeLinking, ok := runtimeConfig["accountLinking"].(map[string]interface{})
+	suite.Require().True(ok)
+	suite.Equal([]interface{}{"email"}, runtimeLinking["attributes"])
+
+	// Both appear in the merged listing, which is the path that spans the two stores and therefore the
+	// one that exercises the composite count query. assertMergedCollectionContainsIDs is deliberately not
+	// used here: it asserts against suite-tracked runtime resources, and tracking this connection would
+	// leave a dangling ID for later tests once the deferred delete removes it.
+	items := suite.getCollectionItems("/connections?category=identity-provider", "connections")
+	collectionIDs := suite.extractCollectionIDs(items)
+	suite.Contains(collectionIDs, "decl-idp-1", "merged listing should include the declarative connection")
+	suite.Contains(collectionIDs, runtimeID, "merged listing should include the runtime connection")
+}
+
+// createRuntimeConnectionWithAttributeConfiguration creates a database-backed Google connection carrying
+// an explicit configuration and returns its ID.
+func (suite *CompositeModeSuite) createRuntimeConnectionWithAttributeConfiguration() string {
+	suite.T().Helper()
+	body := map[string]interface{}{
+		"name":         fmt.Sprintf("Composite Runtime IDP %d", time.Now().UnixNano()),
+		"clientId":     "composite-runtime-client",
+		"clientSecret": "composite-runtime-secret",
+		"redirectUri":  "https://localhost:8095/callback",
+		"scopes":       []string{"openid", "email", "profile"},
+		"attributeConfiguration": map[string]interface{}{
+			"userTypeResolution": map[string]interface{}{"default": "Declarative Test Schema"},
+			"userTypeAttributeMappings": []interface{}{
+				map[string]interface{}{
+					"userType": "Declarative Test Schema",
+					"attributes": []interface{}{
+						map[string]interface{}{"externalAttribute": "given_name", "localAttribute": "username"},
+					},
+				},
+			},
+			"accountLinking": map[string]interface{}{"attributes": []string{"email"}},
+		},
+	}
+	payload, err := json.Marshal(body)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testutils.TestServerURL+"/connections/google", bytes.NewReader(payload))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+	suite.Require().Equal(http.StatusCreated, resp.StatusCode, "create runtime connection: %s", string(respBody))
+
+	var created map[string]interface{}
+	suite.Require().NoError(json.Unmarshal(respBody, &created))
+	id, ok := created["id"].(string)
+	suite.Require().True(ok, "created connection should carry an id")
+	return id
+}
+
+func (suite *CompositeModeSuite) deleteRuntimeConnection(id string) {
+	suite.T().Helper()
+	req, err := http.NewRequest("DELETE",
+		fmt.Sprintf("%s/connections/google/%s", testutils.TestServerURL, id), nil)
+	suite.Require().NoError(err)
+	resp, err := testutils.GetHTTPClient().Do(req)
+	if err != nil {
+		suite.T().Logf("cleanup: failed to delete runtime connection %s: %v", id, err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		suite.T().Logf("cleanup: failed to delete runtime connection %s: status %d", id, resp.StatusCode)
+	}
+}
+
+// AD5: an attributeConfiguration on a declarative connection does not make it mutable. The read-only
+// rejection is unchanged whether the update body carries a configuration or not.
+func (suite *CompositeModeSuite) TestDeclarativeConnectionWithAttributeConfigurationStaysReadOnly() {
+	payload := map[string]interface{}{
+		"name":         "Updated",
+		"clientId":     "test-client-id",
+		"clientSecret": "test-client-secret",
+		"redirectUri":  "https://localhost:8095/callback",
+		"attributeConfiguration": map[string]interface{}{
+			"userTypeResolution": map[string]interface{}{"default": "Declarative Test Schema"},
+			"accountLinking":     map[string]interface{}{"attributes": []string{"email"}},
+		},
+	}
+	jsonPayload, err := json.Marshal(payload)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("PUT",
+		fmt.Sprintf("%s/connections/google/decl-idp-1", testutils.TestServerURL),
+		strings.NewReader(string(jsonPayload)))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	suite.Require().NoError(err)
+	suite.Equal(http.StatusBadRequest, resp.StatusCode,
+		"a declarative connection stays read-only regardless of the configuration in the request")
+	suite.Equal("IDP-1010", suite.extractErrorCode(resp))
+}
+
+// AD6: secret masking must not disturb the configuration. The masked clientSecret and the intact
+// attributeConfiguration come from the same response, so a mapper that rebuilt the response while
+// masking would surface here.
+func (suite *CompositeModeSuite) TestSecretMaskingLeavesAttributeConfigurationIntact() {
+	client := testutils.GetHTTPClient()
+	resp, err := client.Get(fmt.Sprintf("%s/connections/google/decl-idp-1", testutils.TestServerURL))
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+	suite.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&body))
+
+	suite.Equal("******", body["clientSecret"], "the declarative secret should be masked")
+	config, ok := body["attributeConfiguration"].(map[string]interface{})
+	suite.Require().True(ok, "masking must not drop the attributeConfiguration")
+
+	// Presence alone would still pass if masking emptied or rewrote the sections, so the values are
+	// compared against what the fixture declares.
+	resolution, ok := config["userTypeResolution"].(map[string]interface{})
+	suite.Require().True(ok, "expected userTypeResolution in %v", config)
+	suite.Equal("Declarative Test Schema", resolution["default"])
+
+	linking, ok := config["accountLinking"].(map[string]interface{})
+	suite.Require().True(ok, "expected accountLinking in %v", config)
+	suite.Equal([]interface{}{"email"}, linking["attributes"])
+
+	mappings, ok := config["userTypeAttributeMappings"].([]interface{})
+	suite.Require().True(ok, "expected userTypeAttributeMappings in %v", config)
+	suite.Require().Len(mappings, 1)
+	entry, ok := mappings[0].(map[string]interface{})
+	suite.Require().True(ok)
+	suite.Equal("Declarative Test Schema", entry["userType"])
+	attributes, ok := entry["attributes"].([]interface{})
+	suite.Require().True(ok)
+	suite.Require().Len(attributes, 2)
+	first, ok := attributes[0].(map[string]interface{})
+	suite.Require().True(ok)
+	suite.Equal("given_name", first["externalAttribute"])
+	suite.Equal("username", first["localAttribute"])
 }
 
 func (suite *CompositeModeSuite) TestResourceServerDeclarativeVisibility() {

--- a/tests/integration/connection/connection_api_test.go
+++ b/tests/integration/connection/connection_api_test.go
@@ -90,37 +90,43 @@ func doRequest(method, path string, body interface{}) (httpResult, error) {
 // --- Vendor request/response shapes (mirror backend/internal/connection/*.go wire format) ---
 
 type googleConnectionRequest struct {
-	Name         string   `json:"name"`
-	ClientID     string   `json:"clientId"`
-	ClientSecret string   `json:"clientSecret,omitempty"`
-	RedirectURI  string   `json:"redirectUri"`
-	Scopes       []string `json:"scopes,omitempty"`
+	Name                   string                            `json:"name"`
+	ClientID               string                            `json:"clientId"`
+	ClientSecret           string                            `json:"clientSecret,omitempty"`
+	RedirectURI            string                            `json:"redirectUri"`
+	Scopes                 []string                          `json:"scopes,omitempty"`
+	AttributeConfiguration *testutils.AttributeConfiguration `json:"attributeConfiguration,omitempty"`
 }
 
 type githubConnectionRequest struct {
-	Name         string `json:"name"`
-	ClientID     string `json:"clientId"`
-	ClientSecret string `json:"clientSecret,omitempty"`
-	RedirectURI  string `json:"redirectUri"`
+	Name                   string                            `json:"name"`
+	ClientID               string                            `json:"clientId"`
+	ClientSecret           string                            `json:"clientSecret,omitempty"`
+	RedirectURI            string                            `json:"redirectUri"`
+	AttributeConfiguration *testutils.AttributeConfiguration `json:"attributeConfiguration,omitempty"`
 }
 
 type oidcConnectionRequest struct {
-	Name                  string `json:"name"`
-	ClientID              string `json:"clientId"`
-	ClientSecret          string `json:"clientSecret,omitempty"`
-	RedirectURI           string `json:"redirectUri"`
-	AuthorizationEndpoint string `json:"authorizationEndpoint"`
-	TokenEndpoint         string `json:"tokenEndpoint"`
+	Name                   string                            `json:"name"`
+	ClientID               string                            `json:"clientId"`
+	ClientSecret           string                            `json:"clientSecret,omitempty"`
+	RedirectURI            string                            `json:"redirectUri"`
+	AuthorizationEndpoint  string                            `json:"authorizationEndpoint"`
+	TokenEndpoint          string                            `json:"tokenEndpoint"`
+	Scopes                 []string                          `json:"scopes,omitempty"`
+	AttributeConfiguration *testutils.AttributeConfiguration `json:"attributeConfiguration,omitempty"`
 }
 
 type oauthConnectionRequest struct {
-	Name                  string `json:"name"`
-	ClientID              string `json:"clientId"`
-	ClientSecret          string `json:"clientSecret,omitempty"`
-	RedirectURI           string `json:"redirectUri"`
-	AuthorizationEndpoint string `json:"authorizationEndpoint"`
-	TokenEndpoint         string `json:"tokenEndpoint"`
-	UserInfoEndpoint      string `json:"userInfoEndpoint"`
+	Name                   string                            `json:"name"`
+	ClientID               string                            `json:"clientId"`
+	ClientSecret           string                            `json:"clientSecret,omitempty"`
+	RedirectURI            string                            `json:"redirectUri"`
+	AuthorizationEndpoint  string                            `json:"authorizationEndpoint"`
+	TokenEndpoint          string                            `json:"tokenEndpoint"`
+	UserInfoEndpoint       string                            `json:"userInfoEndpoint"`
+	Scopes                 []string                          `json:"scopes,omitempty"`
+	AttributeConfiguration *testutils.AttributeConfiguration `json:"attributeConfiguration,omitempty"`
 }
 
 type twilioConnectionRequest struct {
@@ -157,16 +163,70 @@ type connectionResponse struct {
 	APISecret    string `json:"apiSecret,omitempty"`
 	SenderID     string `json:"senderId,omitempty"`
 	URL          string `json:"url,omitempty"`
+
+	Scopes                 []string                          `json:"scopes,omitempty"`
+	AttributeConfiguration *testutils.AttributeConfiguration `json:"attributeConfiguration,omitempty"`
 }
 
 const maskedSecretValue = "******"
 
 type ConnectionAPITestSuite struct {
 	suite.Suite
+	ouID         string
+	userTypeID   string
+	userTypeName string
 }
 
 func TestConnectionAPISuite(t *testing.T) {
 	suite.Run(t, new(ConnectionAPITestSuite))
+}
+
+// attributeConfigOU and attributeConfigUserType back the attributeConfiguration cases, which need a
+// real user type to validate mapping targets against. The type declares email required and unique so
+// that its presence does not suppress the deployment-wide email account-linking default: seeding reads
+// every user type and skips linking if any one of them allows duplicate emails.
+var attributeConfigOU = testutils.OrganizationUnit{
+	Handle:      "connection-attr-config-ou",
+	Name:        "Connection Attribute Config OU",
+	Description: "Organization unit for connection attributeConfiguration tests",
+	Parent:      nil,
+}
+
+var attributeConfigUserType = testutils.UserType{
+	Name: "connection_attr_person",
+	Schema: map[string]interface{}{
+		"username":  map[string]interface{}{"type": "string", "required": true, "unique": true},
+		"email":     map[string]interface{}{"type": "string", "required": true, "unique": true},
+		"firstName": map[string]interface{}{"type": "string"},
+		"lastName":  map[string]interface{}{"type": "string"},
+		"password":  map[string]interface{}{"type": "string", "credential": true},
+	},
+}
+
+func (s *ConnectionAPITestSuite) SetupSuite() {
+	ouID, err := testutils.CreateOrganizationUnit(attributeConfigOU)
+	s.Require().NoError(err, "failed to create organization unit")
+	s.ouID = ouID
+
+	userType := attributeConfigUserType
+	userType.OUID = ouID
+	userTypeID, err := testutils.CreateUserType(userType)
+	s.Require().NoError(err, "failed to create user type")
+	s.userTypeID = userTypeID
+	s.userTypeName = userType.Name
+}
+
+func (s *ConnectionAPITestSuite) TearDownSuite() {
+	if s.userTypeID != "" {
+		if err := testutils.DeleteUserType(s.userTypeID); err != nil {
+			s.T().Logf("failed to delete user type: %v", err)
+		}
+	}
+	if s.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(s.ouID); err != nil {
+			s.T().Logf("failed to delete organization unit: %v", err)
+		}
+	}
 }
 
 // createConnection posts to /connections/{vendor} and returns the decoded response.
@@ -473,4 +533,589 @@ func containsID(instances []connectionInstance, id string) bool {
 		}
 	}
 	return false
+}
+
+// --- attributeConfiguration: round-trip, validation, seeding (A1-A19) ---
+
+// doRawRequest sends an unmarshalled body so malformed-JSON cases can be exercised. doRequest marshals
+// its argument, which cannot produce an invalid payload.
+func doRawRequest(method, path, raw string) (httpResult, error) {
+	req, err := http.NewRequest(method, testServerURL+path, bytes.NewReader([]byte(raw)))
+	if err != nil {
+		return httpResult{}, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := testutils.GetHTTPClient().Do(req)
+	if err != nil {
+		return httpResult{}, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return httpResult{}, fmt.Errorf("failed to read response body: %w", err)
+	}
+	return httpResult{status: resp.StatusCode, body: body}, nil
+}
+
+// validAttributeConfig returns a configuration whose every target exists on the suite's user type.
+func (s *ConnectionAPITestSuite) validAttributeConfig() *testutils.AttributeConfiguration {
+	return &testutils.AttributeConfiguration{
+		UserTypeResolution: &testutils.UserTypeResolution{Default: s.userTypeName},
+		UserTypeAttributeMappings: []testutils.UserTypeAttributeMapping{{
+			UserType: s.userTypeName,
+			Attributes: []testutils.AttributeMapping{
+				{ExternalAttribute: "given_name", LocalAttribute: "firstName"},
+				{ExternalAttribute: "family_name", LocalAttribute: "lastName"},
+			},
+		}},
+		AccountLinking: &testutils.AccountLinking{Attributes: []string{"email"}},
+	}
+}
+
+// oauthRequestWithConfig builds a complete generic-OAuth create body carrying the given configuration.
+func (s *ConnectionAPITestSuite) oauthRequestWithConfig(
+	name string, config *testutils.AttributeConfiguration) oauthConnectionRequest {
+	return oauthConnectionRequest{
+		Name:                   name,
+		ClientID:               "attr-client",
+		ClientSecret:           "attr-secret",
+		RedirectURI:            "https://localhost:8095/callback",
+		AuthorizationEndpoint:  "https://idp.example.com/authorize",
+		TokenEndpoint:          "https://idp.example.com/token",
+		UserInfoEndpoint:       "https://idp.example.com/userinfo",
+		AttributeConfiguration: config,
+	}
+}
+
+// invalidAttributeConfig describes one rejected configuration, named for the validation class it trips.
+type invalidAttributeConfig struct {
+	name   string
+	config *testutils.AttributeConfiguration
+}
+
+// invalidAttributeConfigs enumerates one configuration per validation class the IdP service enforces.
+// Shared by the create cases (A3-A9) and the update table (A16): create and update reach validation by
+// separate paths, so a class proven on one says nothing about the other.
+func (s *ConnectionAPITestSuite) invalidAttributeConfigs() []invalidAttributeConfig {
+	mapping := func(attrs ...testutils.AttributeMapping) []testutils.UserTypeAttributeMapping {
+		return []testutils.UserTypeAttributeMapping{{UserType: s.userTypeName, Attributes: attrs}}
+	}
+
+	return []invalidAttributeConfig{
+		{
+			name: "A3_duplicate_local_target",
+			config: &testutils.AttributeConfiguration{
+				UserTypeResolution: &testutils.UserTypeResolution{Default: s.userTypeName},
+				UserTypeAttributeMappings: mapping(
+					testutils.AttributeMapping{ExternalAttribute: "given_name", LocalAttribute: "firstName"},
+					testutils.AttributeMapping{ExternalAttribute: "nickname", LocalAttribute: "firstName"},
+				),
+			},
+		},
+		{
+			name: "A4_unknown_user_type",
+			config: &testutils.AttributeConfiguration{
+				UserTypeResolution: &testutils.UserTypeResolution{Default: "no_such_user_type"},
+				UserTypeAttributeMappings: []testutils.UserTypeAttributeMapping{{
+					UserType: "no_such_user_type",
+					Attributes: []testutils.AttributeMapping{
+						{ExternalAttribute: "given_name", LocalAttribute: "firstName"},
+					},
+				}},
+			},
+		},
+		{
+			name: "A5_target_not_in_schema",
+			config: &testutils.AttributeConfiguration{
+				UserTypeResolution: &testutils.UserTypeResolution{Default: s.userTypeName},
+				UserTypeAttributeMappings: mapping(
+					testutils.AttributeMapping{ExternalAttribute: "nickname", LocalAttribute: "notAnAttribute"},
+				),
+			},
+		},
+		{
+			name: "A6_mappings_without_resolution_default",
+			config: &testutils.AttributeConfiguration{
+				UserTypeAttributeMappings: mapping(
+					testutils.AttributeMapping{ExternalAttribute: "given_name", LocalAttribute: "firstName"},
+				),
+			},
+		},
+		{
+			name: "A7_empty_external_attribute",
+			config: &testutils.AttributeConfiguration{
+				UserTypeResolution: &testutils.UserTypeResolution{Default: s.userTypeName},
+				UserTypeAttributeMappings: mapping(
+					testutils.AttributeMapping{ExternalAttribute: "", LocalAttribute: "firstName"},
+				),
+			},
+		},
+		{
+			name: "A8_duplicate_user_type_entry",
+			config: &testutils.AttributeConfiguration{
+				UserTypeResolution: &testutils.UserTypeResolution{Default: s.userTypeName},
+				UserTypeAttributeMappings: []testutils.UserTypeAttributeMapping{
+					{UserType: s.userTypeName, Attributes: []testutils.AttributeMapping{
+						{ExternalAttribute: "given_name", LocalAttribute: "firstName"},
+					}},
+					{UserType: s.userTypeName, Attributes: []testutils.AttributeMapping{
+						{ExternalAttribute: "family_name", LocalAttribute: "lastName"},
+					}},
+				},
+			},
+		},
+		{
+			name: "A9_dynamic_resolution_invalid_target",
+			config: &testutils.AttributeConfiguration{
+				UserTypeResolution: &testutils.UserTypeResolution{
+					Default:           s.userTypeName,
+					ExternalAttribute: "user_type",
+					ValueMapping:      map[string]string{"staff": "no_such_user_type"},
+				},
+			},
+		},
+	}
+}
+
+// assertEmailLinkingSeeded asserts the seeded email account-linking default.
+//
+// Seeding only applies it when email is unique on *every* user type in the deployment, so the assertion
+// first states that precondition. A type left behind by another suite, or a fixture that allows duplicate
+// emails, silently disables the default for every connection — see G15 — and naming the offending type
+// is far more useful than a bare "expected non-nil" failure. These cases remain order-sensitive; this
+// only makes the failure legible.
+func (s *ConnectionAPITestSuite) assertEmailLinkingSeeded(config *testutils.AttributeConfiguration) {
+	s.T().Helper()
+	s.Require().Empty(s.userTypeAllowingDuplicateEmails(),
+		"seeding precondition: a user type that allows duplicate emails disables the email account-linking "+
+			"default for every connection in the deployment")
+	s.Require().NotNil(config.AccountLinking, "expected seeded email account linking")
+	s.Equal([]string{"email"}, config.AccountLinking.Attributes)
+}
+
+// userTypeAllowingDuplicateEmails returns the name of the first user type that does not declare email
+// unique, or "" when every one does.
+func (s *ConnectionAPITestSuite) userTypeAllowingDuplicateEmails() string {
+	s.T().Helper()
+	userTypes, err := testutils.ListUserTypes()
+	s.Require().NoError(err, "failed to list user types")
+	s.Require().NotEmpty(userTypes, "expected at least the bootstrapped user type")
+	for _, userType := range userTypes {
+		if !userType.IsAttributeUnique("email") {
+			return userType.Name
+		}
+	}
+	return ""
+}
+
+// findMapping returns the mapping entry for the named user type, or nil.
+func findMapping(
+	config *testutils.AttributeConfiguration, userType string) *testutils.UserTypeAttributeMapping {
+	if config == nil {
+		return nil
+	}
+	for i := range config.UserTypeAttributeMappings {
+		if config.UserTypeAttributeMappings[i].UserType == userType {
+			return &config.UserTypeAttributeMappings[i]
+		}
+	}
+	return nil
+}
+
+// A1: a full configuration survives create, GET, a mapping change via PUT, and a second GET.
+func (s *ConnectionAPITestSuite) TestOAuthAttributeConfigurationRoundTrip() {
+	created := s.createConnection("oauth",
+		s.oauthRequestWithConfig("OAuth Attr Round Trip", s.validAttributeConfig()))
+	defer s.deleteConnection("oauth", created.ID)
+
+	s.Require().NotNil(created.AttributeConfiguration, "create response should echo the configuration")
+	s.Equal([]string{"email"}, created.AttributeConfiguration.AccountLinking.Attributes)
+	s.Equal(s.userTypeName, created.AttributeConfiguration.UserTypeResolution.Default)
+	s.Require().Len(created.AttributeConfiguration.UserTypeAttributeMappings, 1)
+	s.Len(created.AttributeConfiguration.UserTypeAttributeMappings[0].Attributes, 2)
+
+	res, err := doRequest(http.MethodGet, "/connections/oauth/"+created.ID, nil)
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusOK, res.status, string(res.body))
+	var fetched connectionResponse
+	s.Require().NoError(res.decode(&fetched))
+	s.Require().NotNil(fetched.AttributeConfiguration, "GET should return the stored configuration")
+	s.Equal(created.AttributeConfiguration, fetched.AttributeConfiguration)
+
+	updated := s.validAttributeConfig()
+	updated.UserTypeAttributeMappings[0].Attributes = []testutils.AttributeMapping{
+		{ExternalAttribute: "nickname", LocalAttribute: "firstName"},
+	}
+	updateRes, err := doRequest(http.MethodPut, "/connections/oauth/"+created.ID,
+		s.oauthRequestWithConfig("OAuth Attr Round Trip", updated))
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusOK, updateRes.status, string(updateRes.body))
+
+	res, err = doRequest(http.MethodGet, "/connections/oauth/"+created.ID, nil)
+	s.Require().NoError(err)
+	var afterUpdate connectionResponse
+	s.Require().NoError(res.decode(&afterUpdate))
+	s.Require().NotNil(afterUpdate.AttributeConfiguration)
+	// The targeted assertion names the change; the whole-configuration comparison is what proves nothing
+	// else moved — resolution and linking survived untouched and no extra mapping entry appeared.
+	s.Require().Len(afterUpdate.AttributeConfiguration.UserTypeAttributeMappings, 1)
+	s.Equal([]testutils.AttributeMapping{{ExternalAttribute: "nickname", LocalAttribute: "firstName"}},
+		afterUpdate.AttributeConfiguration.UserTypeAttributeMappings[0].Attributes)
+	s.Equal(updated, afterUpdate.AttributeConfiguration)
+}
+
+// A2: the same round-trip on OIDC, proving the behavior is not specific to the generic OAuth vendor.
+func (s *ConnectionAPITestSuite) TestOIDCAttributeConfigurationRoundTrip() {
+	created := s.createConnection("oidc", oidcConnectionRequest{
+		Name:                   "OIDC Attr Round Trip",
+		ClientID:               "attr-client",
+		ClientSecret:           "attr-secret",
+		RedirectURI:            "https://localhost:8095/callback",
+		AuthorizationEndpoint:  "https://idp.example.com/authorize",
+		TokenEndpoint:          "https://idp.example.com/token",
+		AttributeConfiguration: s.validAttributeConfig(),
+	})
+	defer s.deleteConnection("oidc", created.ID)
+
+	s.Require().NotNil(created.AttributeConfiguration)
+	s.Equal(s.userTypeName, created.AttributeConfiguration.UserTypeResolution.Default)
+
+	res, err := doRequest(http.MethodGet, "/connections/oidc/"+created.ID, nil)
+	s.Require().NoError(err)
+	var fetched connectionResponse
+	s.Require().NoError(res.decode(&fetched))
+	s.Require().NotNil(fetched.AttributeConfiguration)
+	s.Equal(created.AttributeConfiguration, fetched.AttributeConfiguration)
+
+	updated := s.validAttributeConfig()
+	updated.UserTypeAttributeMappings[0].Attributes = []testutils.AttributeMapping{
+		{ExternalAttribute: "nickname", LocalAttribute: "firstName"},
+	}
+	updateRes, err := doRequest(http.MethodPut, "/connections/oidc/"+created.ID, oidcConnectionRequest{
+		Name:                   "OIDC Attr Round Trip",
+		ClientID:               "attr-client",
+		RedirectURI:            "https://localhost:8095/callback",
+		AuthorizationEndpoint:  "https://idp.example.com/authorize",
+		TokenEndpoint:          "https://idp.example.com/token",
+		AttributeConfiguration: updated,
+	})
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusOK, updateRes.status, string(updateRes.body))
+
+	res, err = doRequest(http.MethodGet, "/connections/oidc/"+created.ID, nil)
+	s.Require().NoError(err)
+	var afterUpdate connectionResponse
+	s.Require().NoError(res.decode(&afterUpdate))
+	s.Equal(updated, afterUpdate.AttributeConfiguration)
+}
+
+// A3-A9: every validation class is rejected on create. The unit tests for these call the service's
+// private validator directly, so nothing previously proved the create path rejects them.
+func (s *ConnectionAPITestSuite) TestAttributeConfigurationValidationOnCreate() {
+	for _, invalid := range s.invalidAttributeConfigs() {
+		s.Run(invalid.name, func() {
+			res, err := doRequest(http.MethodPost, "/connections/oauth",
+				s.oauthRequestWithConfig("OAuth Invalid "+invalid.name, invalid.config))
+			s.Require().NoError(err)
+			s.Equal(http.StatusBadRequest, res.status,
+				"expected 400 for %s, got %d: %s", invalid.name, res.status, string(res.body))
+			s.NotEmpty(res.errorCode(), "error response should carry a code")
+		})
+	}
+}
+
+// A16: the same classes rejected on update. Create and update validate through separate call sites, so
+// A3-A9 passing says nothing about this path.
+func (s *ConnectionAPITestSuite) TestAttributeConfigurationValidationOnUpdate() {
+	created := s.createConnection("oauth",
+		s.oauthRequestWithConfig("OAuth Invalid Update Base", s.validAttributeConfig()))
+	defer s.deleteConnection("oauth", created.ID)
+
+	for _, invalid := range s.invalidAttributeConfigs() {
+		s.Run(invalid.name, func() {
+			res, err := doRequest(http.MethodPut, "/connections/oauth/"+created.ID,
+				s.oauthRequestWithConfig("OAuth Invalid Update Base", invalid.config))
+			s.Require().NoError(err)
+			s.Equal(http.StatusBadRequest, res.status,
+				"expected 400 for %s, got %d: %s", invalid.name, res.status, string(res.body))
+		})
+	}
+}
+
+// A17: a rejected update must not partially apply. The stored configuration is unchanged afterwards.
+func (s *ConnectionAPITestSuite) TestRejectedUpdateLeavesStoredConfigurationUnchanged() {
+	created := s.createConnection("oauth",
+		s.oauthRequestWithConfig("OAuth Atomic Update", s.validAttributeConfig()))
+	defer s.deleteConnection("oauth", created.ID)
+
+	invalid := s.invalidAttributeConfigs()[0]
+	res, err := doRequest(http.MethodPut, "/connections/oauth/"+created.ID,
+		s.oauthRequestWithConfig("OAuth Atomic Update", invalid.config))
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusBadRequest, res.status, string(res.body))
+
+	res, err = doRequest(http.MethodGet, "/connections/oauth/"+created.ID, nil)
+	s.Require().NoError(err)
+	var fetched connectionResponse
+	s.Require().NoError(res.decode(&fetched))
+	s.Require().NotNil(fetched.AttributeConfiguration)
+	s.Equal(created.AttributeConfiguration, fetched.AttributeConfiguration,
+		"rejected update must leave the previously stored configuration intact")
+}
+
+// A15: a malformed body on update is a client error. Only the create path was covered before.
+func (s *ConnectionAPITestSuite) TestMalformedBodyOnUpdateReturnsBadRequest() {
+	created := s.createConnection("oauth",
+		s.oauthRequestWithConfig("OAuth Malformed Update", s.validAttributeConfig()))
+	defer s.deleteConnection("oauth", created.ID)
+
+	res, err := doRawRequest(http.MethodPut, "/connections/oauth/"+created.ID, "{\"name\": ")
+	s.Require().NoError(err)
+	s.Equal(http.StatusBadRequest, res.status, string(res.body))
+}
+
+// A10: Google with an email-granting scope and no explicit configuration is seeded with email account
+// linking and a username mapping.
+func (s *ConnectionAPITestSuite) TestGoogleSeedsAttributeConfigurationDefaults() {
+	created := s.createConnection("google", googleConnectionRequest{
+		Name:         "Google Seeded Defaults",
+		ClientID:     "google-client",
+		ClientSecret: "google-secret",
+		RedirectURI:  "https://localhost:8095/callback",
+		Scopes:       []string{"openid", "email", "profile"},
+	})
+	defer s.deleteConnection("google", created.ID)
+
+	config := created.AttributeConfiguration
+	s.Require().NotNil(config, "expected seeded configuration")
+	s.Require().NotNil(config.UserTypeResolution)
+	s.NotEmpty(config.UserTypeResolution.Default, "seeding records the resolution default")
+	s.assertEmailLinkingSeeded(config)
+
+	// The default names whichever username-requiring type sorts first across the deployment, so the
+	// assertion is that our type received the mapping, not that it was chosen as the default.
+	mapping := findMapping(config, s.userTypeName)
+	s.Require().NotNil(mapping, "expected a mapping entry for %s", s.userTypeName)
+	s.Equal([]testutils.AttributeMapping{{ExternalAttribute: "email", LocalAttribute: "username"}},
+		mapping.Attributes)
+}
+
+// A11: generic OAuth is seeded with nothing, by design. scopesGrantEmail cannot infer an arbitrary
+// provider's scope semantics, so neither linking nor a username mapping is inferred.
+func (s *ConnectionAPITestSuite) TestGenericOAuthSeedsNothing() {
+	created := s.createConnection("oauth", oauthConnectionRequest{
+		Name:                  "OAuth No Seeding",
+		ClientID:              "attr-client",
+		ClientSecret:          "attr-secret",
+		RedirectURI:           "https://localhost:8095/callback",
+		AuthorizationEndpoint: "https://idp.example.com/authorize",
+		TokenEndpoint:         "https://idp.example.com/token",
+		UserInfoEndpoint:      "https://idp.example.com/userinfo",
+		Scopes:                []string{"openid", "email", "profile"},
+	})
+	defer s.deleteConnection("oauth", created.ID)
+
+	s.Nil(created.AttributeConfiguration,
+		"generic OAuth must not infer defaults: got %+v", created.AttributeConfiguration)
+}
+
+// A12: GitHub derives the username from its login claim rather than from email.
+func (s *ConnectionAPITestSuite) TestGitHubSeedsUsernameFromLoginClaim() {
+	created := s.createConnection("github", githubConnectionRequest{
+		Name:         "GitHub Seeded Defaults",
+		ClientID:     "github-client",
+		ClientSecret: "github-secret",
+		RedirectURI:  "https://localhost:8095/callback",
+	})
+	defer s.deleteConnection("github", created.ID)
+
+	config := created.AttributeConfiguration
+	s.Require().NotNil(config, "expected seeded configuration")
+	mapping := findMapping(config, s.userTypeName)
+	s.Require().NotNil(mapping, "expected a mapping entry for %s", s.userTypeName)
+	s.Equal([]testutils.AttributeMapping{{ExternalAttribute: "login", LocalAttribute: "username"}},
+		mapping.Attributes,
+		"GitHub emits no email claim by default, so the username source is its login claim")
+}
+
+// A13: an explicit configuration on create is preserved verbatim; seeding does not overwrite it.
+func (s *ConnectionAPITestSuite) TestExplicitConfigurationWinsOverSeeding() {
+	explicit := &testutils.AttributeConfiguration{
+		UserTypeResolution: &testutils.UserTypeResolution{Default: s.userTypeName},
+		UserTypeAttributeMappings: []testutils.UserTypeAttributeMapping{{
+			UserType: s.userTypeName,
+			Attributes: []testutils.AttributeMapping{
+				{ExternalAttribute: "given_name", LocalAttribute: "username"},
+			},
+		}},
+		AccountLinking: &testutils.AccountLinking{Attributes: []string{"firstName"}},
+	}
+
+	created := s.createConnection("google", googleConnectionRequest{
+		Name:                   "Google Explicit Config",
+		ClientID:               "google-client",
+		ClientSecret:           "google-secret",
+		RedirectURI:            "https://localhost:8095/callback",
+		Scopes:                 []string{"openid", "email", "profile"},
+		AttributeConfiguration: explicit,
+	})
+	defer s.deleteConnection("google", created.ID)
+
+	config := created.AttributeConfiguration
+	s.Require().NotNil(config)
+	s.Equal([]string{"firstName"}, config.AccountLinking.Attributes,
+		"explicit linking must not be replaced by the email default")
+	mapping := findMapping(config, s.userTypeName)
+	s.Require().NotNil(mapping)
+	s.Equal([]testutils.AttributeMapping{{ExternalAttribute: "given_name", LocalAttribute: "username"}},
+		mapping.Attributes, "explicit mapping must not be replaced by the seeded one")
+	// "Verbatim" is only proven by comparing the whole configuration, including the resolution section.
+	s.Equal(explicit, config)
+}
+
+// A14: seeding runs on create only. An update omitting the section removes it rather than restoring the
+// seeded value, so a section the administrator deleted stays deleted.
+func (s *ConnectionAPITestSuite) TestUpdateWithoutConfigurationRemovesSeededDefaults() {
+	created := s.createConnection("google", googleConnectionRequest{
+		Name:         "Google Remove Seeded",
+		ClientID:     "google-client",
+		ClientSecret: "google-secret",
+		RedirectURI:  "https://localhost:8095/callback",
+		Scopes:       []string{"openid", "email", "profile"},
+	})
+	defer s.deleteConnection("google", created.ID)
+	s.Require().NotNil(created.AttributeConfiguration, "precondition: create seeded a configuration")
+
+	updateRes, err := doRequest(http.MethodPut, "/connections/google/"+created.ID, googleConnectionRequest{
+		Name:        "Google Remove Seeded",
+		ClientID:    "google-client",
+		RedirectURI: "https://localhost:8095/callback",
+		Scopes:      []string{"openid", "email", "profile"},
+	})
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusOK, updateRes.status, string(updateRes.body))
+
+	res, err := doRequest(http.MethodGet, "/connections/google/"+created.ID, nil)
+	s.Require().NoError(err)
+	var fetched connectionResponse
+	s.Require().NoError(res.decode(&fetched))
+	s.Nil(fetched.AttributeConfiguration,
+		"update must not re-seed: got %+v", fetched.AttributeConfiguration)
+}
+
+// A18: the two sections seed independently. Supplying one leaves it untouched and seeds only the other.
+func (s *ConnectionAPITestSuite) TestPartialConfigurationSeedsOnlyTheMissingSection() {
+	s.Run("explicit_linking_seeds_mappings", func() {
+		created := s.createConnection("google", googleConnectionRequest{
+			Name:         "Google Partial Linking",
+			ClientID:     "google-client",
+			ClientSecret: "google-secret",
+			RedirectURI:  "https://localhost:8095/callback",
+			Scopes:       []string{"openid", "email", "profile"},
+			AttributeConfiguration: &testutils.AttributeConfiguration{
+				AccountLinking: &testutils.AccountLinking{Attributes: []string{"firstName"}},
+			},
+		})
+		defer s.deleteConnection("google", created.ID)
+
+		config := created.AttributeConfiguration
+		s.Require().NotNil(config)
+		s.Equal([]string{"firstName"}, config.AccountLinking.Attributes, "explicit linking untouched")
+		s.Require().NotNil(findMapping(config, s.userTypeName), "mappings seeded")
+	})
+
+	s.Run("explicit_mappings_seed_linking", func() {
+		created := s.createConnection("google", googleConnectionRequest{
+			Name:         "Google Partial Mappings",
+			ClientID:     "google-client",
+			ClientSecret: "google-secret",
+			RedirectURI:  "https://localhost:8095/callback",
+			Scopes:       []string{"openid", "email", "profile"},
+			AttributeConfiguration: &testutils.AttributeConfiguration{
+				UserTypeResolution: &testutils.UserTypeResolution{Default: s.userTypeName},
+				UserTypeAttributeMappings: []testutils.UserTypeAttributeMapping{{
+					UserType: s.userTypeName,
+					Attributes: []testutils.AttributeMapping{
+						{ExternalAttribute: "given_name", LocalAttribute: "firstName"},
+					},
+				}},
+			},
+		})
+		defer s.deleteConnection("google", created.ID)
+
+		config := created.AttributeConfiguration
+		s.Require().NotNil(config)
+		s.assertEmailLinkingSeeded(config)
+		mapping := findMapping(config, s.userTypeName)
+		s.Require().NotNil(mapping)
+		s.Equal([]testutils.AttributeMapping{{ExternalAttribute: "given_name", LocalAttribute: "firstName"}},
+			mapping.Attributes, "explicit mappings untouched")
+	})
+}
+
+// googleRawRequest builds a Google create body as a generic map. The typed request struct carries
+// omitempty on both configuration slices, so an empty Go slice and an absent field serialize
+// identically; a map is the only way to put an explicit [] or {} on the wire.
+func (s *ConnectionAPITestSuite) googleRawRequest(
+	name string, config map[string]interface{}) map[string]interface{} {
+	body := map[string]interface{}{
+		"name":         name,
+		"clientId":     "google-client",
+		"clientSecret": "google-secret",
+		"redirectUri":  "https://localhost:8095/callback",
+		"scopes":       []string{"openid", "email", "profile"},
+	}
+	if config != nil {
+		body["attributeConfiguration"] = config
+	}
+	return body
+}
+
+// A19: which nil-versus-empty distinctions actually survive the wire format. The section pointers carry a
+// real distinction — a present-but-empty section suppresses seeding where an absent one triggers it — while
+// the slices collapse, because omitempty makes an explicit [] indistinguishable from an absent field once
+// serialized. Every case here is sent as a raw map: building them from the typed struct would make the
+// "empty" and "omitted" requests byte-identical and the comparison vacuous.
+func (s *ConnectionAPITestSuite) TestNilVersusEmptyConfigurationSections() {
+	s.Run("present_but_empty_linking_section_suppresses_seeding", func() {
+		cases := map[string]map[string]interface{}{
+			"empty_object":     {"accountLinking": map[string]interface{}{}},
+			"empty_attributes": {"accountLinking": map[string]interface{}{"attributes": []interface{}{}}},
+		}
+
+		for label, config := range cases {
+			created := s.createConnection("google", s.googleRawRequest("Google Linking "+label, config))
+			s.Require().NotNil(created.AttributeConfiguration, label)
+			s.Require().NotNil(created.AttributeConfiguration.AccountLinking,
+				"%s: a present section must survive as non-nil rather than being treated as absent", label)
+			s.Empty(created.AttributeConfiguration.AccountLinking.Attributes,
+				"%s: a present-but-empty section suppresses the email default", label)
+			s.deleteConnection("google", created.ID)
+		}
+
+		// The contrast that makes the pointer distinction load-bearing: omitting the section entirely seeds it.
+		created := s.createConnection("google", s.googleRawRequest("Google Linking omitted", nil))
+		defer s.deleteConnection("google", created.ID)
+		s.Require().NotNil(created.AttributeConfiguration)
+		s.assertEmailLinkingSeeded(created.AttributeConfiguration)
+	})
+
+	s.Run("explicit_empty_and_omitted_mappings_collapse", func() {
+		linking := map[string]interface{}{"attributes": []string{"email"}}
+		cases := map[string]map[string]interface{}{
+			"explicit_empty_array": {
+				"accountLinking":            linking,
+				"userTypeAttributeMappings": []interface{}{},
+			},
+			"omitted": {"accountLinking": linking},
+		}
+
+		for label, config := range cases {
+			created := s.createConnection("google", s.googleRawRequest("Google Mappings "+label, config))
+			s.Require().NotNil(created.AttributeConfiguration, label)
+			s.NotNil(findMapping(created.AttributeConfiguration, s.userTypeName),
+				"%s: an explicit empty array and an absent field both take the len()==0 seeding branch", label)
+			s.deleteConnection("google", created.ID)
+		}
+	})
 }

--- a/tests/integration/declarativesinglefile/single_file_mode_test.go
+++ b/tests/integration/declarativesinglefile/single_file_mode_test.go
@@ -41,6 +41,12 @@ import (
 // The {{ t(...) }} expression in the GitHub IDP description verifies that
 // non-Go-template expressions inside the file are preserved as-is and do not
 // cause parse errors during env-var substitution.
+//
+// The GitHub IDP also carries an attributeConfiguration. Its nested keys are snake_case
+// (user_type_resolution, user_type_attribute_mappings, user_type, external_attribute,
+// local_attribute) while the outer key and accountLinking are camelCase, because
+// providers.AttributeConfiguration tags them inconsistently. That is recorded as G13; camelCase
+// nested keys would silently fail to parse. Update this fixture when G13 is fixed.
 const resourcesYAML = `resource_type: organization_unit
 id: sf-decl-ou-1
 handle: sf-decl-ou-1
@@ -55,6 +61,17 @@ type: github
 clientId: {{.SF_TEST_GITHUB_CLIENT_ID}}
 clientSecret: sf-test-github-secret
 redirectUri: https://localhost:8095/callback
+attributeConfiguration:
+  user_type_resolution:
+    default: Person
+  user_type_attribute_mappings:
+    - user_type: Person
+      attributes:
+        - external_attribute: login
+          local_attribute: username
+  accountLinking:
+    attributes:
+      - email
 ---
 resource_type: connection
 id: sf-decl-idp-2
@@ -64,6 +81,17 @@ type: google
 clientId: sf-test-google-client
 clientSecret: sf-test-google-secret
 redirectUri: https://localhost:8095/callback
+---
+resource_type: connection
+id: sf-decl-idp-3
+name: Single File Empty Config IDP
+description: IDP whose attributeConfiguration is present but empty
+type: google
+clientId: sf-test-empty-client
+clientSecret: sf-test-empty-secret
+redirectUri: https://localhost:8095/callback
+attributeConfiguration:
+  accountLinking: {}
 `
 
 // envVars are set in the test process before the server starts so they are inherited
@@ -206,7 +234,7 @@ func (s *SingleFileModeSuite) TestSecondIdentityProviderLoadedFromFile() {
 	s.Equal("google", idp["type"])
 }
 
-// TestAllIDPsFromFileAppearInListing verifies that both declarative IDPs appear in the
+// TestAllIDPsFromFileAppearInListing verifies that every declarative IDP in the file appears in the
 // collection endpoint.
 func (s *SingleFileModeSuite) TestAllIDPsFromFileAppearInListing() {
 	client := testutils.GetHTTPClient()
@@ -230,6 +258,134 @@ func (s *SingleFileModeSuite) TestAllIDPsFromFileAppearInListing() {
 
 	s.Contains(idpIDs, "sf-decl-idp-1", "listing should include sf-decl-idp-1")
 	s.Contains(idpIDs, "sf-decl-idp-2", "listing should include sf-decl-idp-2")
+	s.Contains(idpIDs, "sf-decl-idp-3", "listing should include sf-decl-idp-3")
+}
+
+// AD1 verifies a full attributeConfiguration declared in the single file is parsed and returned by the
+// connection API, including the mapping entries and the account-linking list.
+func (s *SingleFileModeSuite) TestAttributeConfigurationLoadedFromFile() {
+	client := testutils.GetHTTPClient()
+	resp, err := client.Get(fmt.Sprintf("%s/connections/github/sf-decl-idp-1", testutils.TestServerURL))
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var idp map[string]interface{}
+	s.Require().NoError(json.NewDecoder(resp.Body).Decode(&idp))
+
+	config, ok := idp["attributeConfiguration"].(map[string]interface{})
+	s.Require().True(ok, "expected attributeConfiguration on the response: %v", idp)
+
+	// The response is camelCase even though the file is snake_case: the wire format follows the json
+	// tags while the file is parsed with the yaml ones. See G13.
+	resolution, ok := config["userTypeResolution"].(map[string]interface{})
+	s.Require().True(ok, "expected userTypeResolution in %v", config)
+	s.Equal("Person", resolution["default"])
+
+	linking, ok := config["accountLinking"].(map[string]interface{})
+	s.Require().True(ok, "expected accountLinking in %v", config)
+	s.Equal([]interface{}{"email"}, linking["attributes"])
+
+	mappings, ok := config["userTypeAttributeMappings"].([]interface{})
+	s.Require().True(ok, "expected userTypeAttributeMappings in %v", config)
+	s.Require().Len(mappings, 1)
+	entry, ok := mappings[0].(map[string]interface{})
+	s.Require().True(ok)
+	s.Equal("Person", entry["userType"])
+	attributes, ok := entry["attributes"].([]interface{})
+	s.Require().True(ok)
+	s.Require().Len(attributes, 1)
+	attribute, ok := attributes[0].(map[string]interface{})
+	s.Require().True(ok)
+	s.Equal("login", attribute["externalAttribute"])
+	s.Equal("username", attribute["localAttribute"])
+}
+
+// AD3 verifies that a declared-but-empty configuration section stays distinguishable from an absent one
+// after loading. Declarative connections are seeded at startup exactly as REST-created ones are, so an
+// omitted accountLinking is filled in while a present-but-empty one is left alone. sf-decl-idp-3 declares
+// `accountLinking: {}` and sf-decl-idp-2 declares nothing.
+func (s *SingleFileModeSuite) TestEmptyVersusOmittedAttributeConfigurationFromFile() {
+	client := testutils.GetHTTPClient()
+
+	resp, err := client.Get(fmt.Sprintf("%s/connections/google/sf-decl-idp-3", testutils.TestServerURL))
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var withEmpty map[string]interface{}
+	s.Require().NoError(json.NewDecoder(resp.Body).Decode(&withEmpty))
+	emptyConfig, ok := withEmpty["attributeConfiguration"].(map[string]interface{})
+	s.Require().True(ok, "a declared-but-empty configuration should survive the load: %v", withEmpty)
+	linking, ok := emptyConfig["accountLinking"].(map[string]interface{})
+	s.Require().True(ok, "the empty section must remain present rather than being treated as absent")
+	s.Empty(linking["attributes"], "a present-but-empty section is not seeded")
+
+	resp2, err := client.Get(fmt.Sprintf("%s/connections/google/sf-decl-idp-2", testutils.TestServerURL))
+	s.Require().NoError(err)
+	defer resp2.Body.Close()
+	s.Require().Equal(http.StatusOK, resp2.StatusCode)
+
+	var withNone map[string]interface{}
+	s.Require().NoError(json.NewDecoder(resp2.Body).Decode(&withNone))
+	noneConfig, ok := withNone["attributeConfiguration"].(map[string]interface{})
+	s.Require().True(ok, "an omitted configuration should be seeded, not left absent: %v", withNone)
+	seededLinking, ok := noneConfig["accountLinking"].(map[string]interface{})
+	s.Require().True(ok, "an omitted accountLinking should be seeded: %v", noneConfig)
+
+	// Seeding fills the default only for attributes every user type declares unique, so one type allowing
+	// duplicate emails disables it deployment-wide. Naming that type here keeps the cause visible instead
+	// of surfacing as an unexplained empty list on the connection.
+	userTypes, err := testutils.ListUserTypes()
+	s.Require().NoError(err, "failed to list user types")
+	for _, userType := range userTypes {
+		s.Require().True(userType.IsAttributeUnique("email"),
+			"seeding precondition: user type %q allows duplicate emails", userType.Name)
+	}
+
+	s.Equal([]interface{}{"email"}, seededLinking["attributes"],
+		"an omitted section is seeded, which is the distinction the empty one suppresses")
+}
+
+// AD6 verifies that masking the declarative clientSecret does not disturb the configuration returned
+// alongside it.
+func (s *SingleFileModeSuite) TestSecretMaskingLeavesAttributeConfigurationIntactFromFile() {
+	client := testutils.GetHTTPClient()
+	resp, err := client.Get(fmt.Sprintf("%s/connections/github/sf-decl-idp-1", testutils.TestServerURL))
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var idp map[string]interface{}
+	s.Require().NoError(json.NewDecoder(resp.Body).Decode(&idp))
+
+	s.Equal("******", idp["clientSecret"], "the declarative secret should be masked")
+	config, ok := idp["attributeConfiguration"].(map[string]interface{})
+	s.Require().True(ok, "masking must not drop the attributeConfiguration")
+
+	// Presence alone would still pass if masking emptied or rewrote the sections, so the values are
+	// compared against what the fixture declares.
+	resolution, ok := config["userTypeResolution"].(map[string]interface{})
+	s.Require().True(ok, "expected userTypeResolution in %v", config)
+	s.Equal("Person", resolution["default"])
+
+	linking, ok := config["accountLinking"].(map[string]interface{})
+	s.Require().True(ok, "expected accountLinking in %v", config)
+	s.Equal([]interface{}{"email"}, linking["attributes"])
+
+	mappings, ok := config["userTypeAttributeMappings"].([]interface{})
+	s.Require().True(ok, "expected userTypeAttributeMappings in %v", config)
+	s.Require().Len(mappings, 1)
+	entry, ok := mappings[0].(map[string]interface{})
+	s.Require().True(ok)
+	s.Equal("Person", entry["userType"])
+	attributes, ok := entry["attributes"].([]interface{})
+	s.Require().True(ok)
+	s.Require().Len(attributes, 1)
+	attribute, ok := attributes[0].(map[string]interface{})
+	s.Require().True(ok)
+	s.Equal("login", attribute["externalAttribute"])
+	s.Equal("username", attribute["localAttribute"])
 }
 
 // TestDeclarativeResourcesAreImmutable verifies that a resource loaded from the single

--- a/tests/integration/export/export_api_test.go
+++ b/tests/integration/export/export_api_test.go
@@ -6,14 +6,18 @@ package export
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	"gopkg.in/yaml.v3"
+
 	"github.com/thunder-id/thunderid/tests/integration/testutils"
 )
 
@@ -831,4 +835,138 @@ func (ts *ExportAPITestSuite) deleteIDP(idpID string) error {
 	delete(idpVendorRegistry, idpID)
 	idpVendorRegistryMu.Unlock()
 	return nil
+}
+
+// yamlValue returns the first of names present in node. The exported nested keys are snake_case today
+// while the declarative contract calls for camelCase (G13), so navigating tolerantly keeps this a
+// round-trip check rather than a characterization of the casing bug: it passes now and keeps passing once
+// G13 is fixed. Asserting on the spelling would be a tripwire test, which this plan does not use.
+func yamlValue(node map[string]interface{}, names ...string) (interface{}, bool) {
+	for _, name := range names {
+		if value, ok := node[name]; ok {
+			return value, true
+		}
+	}
+	return nil, false
+}
+
+// yamlMapping is yamlValue narrowed to a nested mapping.
+func yamlMapping(node map[string]interface{}, names ...string) (map[string]interface{}, bool) {
+	value, ok := yamlValue(node, names...)
+	if !ok {
+		return nil, false
+	}
+	mapping, ok := value.(map[string]interface{})
+	return mapping, ok
+}
+
+// exportPlaceholder matches the {{.VAR}} tokens the exporter substitutes for secrets, and the
+// {{ t(...) }} expressions it preserves verbatim.
+var exportPlaceholder = regexp.MustCompile(`{{[^}]*}}`)
+
+// findExportedConnection decodes every YAML document in an export bundle and returns the one whose id
+// matches. The bundle carries "# File:" comments and separates documents with ---, so it decodes as a
+// stream; but an exported secret is rendered as a bare {{.VAR}} token, which YAML reads as the start of
+// a flow mapping and rejects. The tokens are replaced with a plain scalar first, since this test is
+// about the attribute configuration rather than the placeholder syntax.
+func (ts *ExportAPITestSuite) findExportedConnection(bundle, id string) map[string]interface{} {
+	ts.T().Helper()
+	parseable := exportPlaceholder.ReplaceAllString(bundle, "__redacted__")
+	decoder := yaml.NewDecoder(strings.NewReader(parseable))
+	for {
+		var document map[string]interface{}
+		err := decoder.Decode(&document)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		ts.Require().NoError(err, "failed to decode exported YAML: %s", parseable)
+		if document == nil {
+			continue
+		}
+		if documentID, ok := document["id"].(string); ok && documentID == id {
+			return document
+		}
+	}
+	ts.Require().Fail("exported bundle did not contain connection "+id, parseable)
+	return nil
+}
+
+// AD2 verifies an attributeConfiguration survives export intact. The exported document is what a
+// declarative deployment consumes, so a section dropped or mangled here would silently un-configure a
+// connection on re-import. The whole structure is compared after parsing, because substring checks would
+// pass on a document whose values had been reordered, truncated or emptied.
+func (ts *ExportAPITestSuite) TestIdentityProviderExportPreservesAttributeConfiguration() {
+	// Targets resolve against the bootstrapped Person user type, so no fixture is needed here.
+	idpID, err := testutils.CreateIDP(testutils.IDP{
+		Name:        "Export Attr Config IDP",
+		Description: "Identity provider carrying an attribute configuration",
+		Type:        "GOOGLE",
+		Properties: []testutils.IDPProperty{
+			{Name: "client_id", Value: "export_attr_client"},
+			{Name: "client_secret", Value: "export_attr_secret", IsSecret: true},
+			{Name: "redirect_uri", Value: "https://localhost:8095/callback"},
+		},
+		AttributeConfiguration: &testutils.AttributeConfiguration{
+			UserTypeResolution: &testutils.UserTypeResolution{Default: "Person"},
+			UserTypeAttributeMappings: []testutils.UserTypeAttributeMapping{{
+				UserType: "Person",
+				Attributes: []testutils.AttributeMapping{
+					{ExternalAttribute: "given_name", LocalAttribute: "given_name"},
+					{ExternalAttribute: "family_name", LocalAttribute: "family_name"},
+				},
+			}},
+			AccountLinking: &testutils.AccountLinking{Attributes: []string{"email"}},
+		},
+	})
+	ts.Require().NoError(err)
+	defer func() {
+		ts.Require().NoError(testutils.DeleteIDP(idpID))
+	}()
+
+	yamlContent, err := ts.exportResourcesYAML(ExportRequest{Connections: []string{idpID}})
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(yamlContent)
+
+	document := ts.findExportedConnection(yamlContent, idpID)
+	config, ok := yamlMapping(document, "attributeConfiguration")
+	ts.Require().True(ok, "exported connection should carry an attributeConfiguration: %v", document)
+
+	resolution, ok := yamlMapping(config, "user_type_resolution", "userTypeResolution")
+	ts.Require().True(ok, "exported configuration should carry a resolution section: %v", config)
+	ts.Equal("Person", resolution["default"])
+
+	linking, ok := yamlMapping(config, "accountLinking", "account_linking")
+	ts.Require().True(ok, "exported configuration should carry an account-linking section: %v", config)
+	ts.Equal([]interface{}{"email"}, linking["attributes"],
+		"the account-linking list must survive export exactly")
+
+	rawMappings, ok := yamlValue(config, "user_type_attribute_mappings", "userTypeAttributeMappings")
+	ts.Require().True(ok, "exported configuration should carry mapping entries: %v", config)
+	mappings, ok := rawMappings.([]interface{})
+	ts.Require().True(ok)
+	ts.Require().Len(mappings, 1, "exactly the one configured mapping entry should be exported")
+
+	entry, ok := mappings[0].(map[string]interface{})
+	ts.Require().True(ok)
+	entryUserType, ok := yamlValue(entry, "user_type", "userType")
+	ts.Require().True(ok, "mapping entry should name its user type: %v", entry)
+	ts.Equal("Person", entryUserType)
+
+	rawAttributes, ok := entry["attributes"]
+	ts.Require().True(ok, "mapping entry should carry its attributes: %v", entry)
+	attributes, ok := rawAttributes.([]interface{})
+	ts.Require().True(ok)
+	ts.Require().Len(attributes, 2, "both configured pairs should be exported, in order")
+
+	expectedPairs := [][2]string{{"given_name", "given_name"}, {"family_name", "family_name"}}
+	for i, expected := range expectedPairs {
+		pair, ok := attributes[i].(map[string]interface{})
+		ts.Require().True(ok)
+		external, ok := yamlValue(pair, "external_attribute", "externalAttribute")
+		ts.Require().True(ok, "pair %d should name its external attribute: %v", i, pair)
+		local, ok := yamlValue(pair, "local_attribute", "localAttribute")
+		ts.Require().True(ok, "pair %d should name its local attribute: %v", i, pair)
+		ts.Equal(expected[0], external)
+		ts.Equal(expected[1], local)
+	}
 }

--- a/tests/integration/federated/authflow_test.go
+++ b/tests/integration/federated/authflow_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package federated
+
+import (
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+/*
+Federated authentication through a flow.
+
+Phase 3 covers mapping and resolution on the registration path, where a mapped claim populates a new
+user. On the authentication path the same mapped claims resolve an *existing* user instead, and that
+resolution-through-a-flow is exercised nowhere else: the linking scenarios use the direct
+/auth/{provider}/finish endpoints, which bypass the flow executors entirely.
+
+The mapping computation is shared between the two paths, so what these assert is the consumption. BA2
+and BA3 additionally cover the only branch in the executor that depends on the flow type at all.
+*/
+
+// authenticate drives an authentication flow for a mock identity and returns the terminal step.
+func (s *FederatedMappingSuite) authenticate(
+	appID string, config *testutils.AttributeConfiguration,
+	user *testutils.OIDCUserInfo) (*common.FlowStep, error) {
+	s.T().Helper()
+	s.applyConfig(config)
+	s.mockOIDC.AddUser(user)
+	s.activeSub = user.Sub
+
+	flowStep, err := common.InitiateAuthenticationFlow(appID, false, nil, "")
+	s.Require().NoError(err, "failed to initiate the authentication flow")
+	s.Require().Equal("REDIRECTION", flowStep.Type,
+		"expected a redirection to the identity provider, got %+v", flowStep)
+
+	code, state, err := testutils.SimulateFederatedOAuthFlow(flowStep.Data.RedirectURL)
+	s.Require().NoError(err, "failed to simulate authorization at the identity provider")
+
+	// The error is returned rather than asserted away: a flow that cannot authenticate is a valid
+	// outcome here, and how it fails is what two of these scenarios are about.
+	step, err := common.CompleteFlow(
+		flowStep.ExecutionID, map[string]string{"code": code, "state": state}, "", flowStep.ChallengeToken)
+	return step, err
+}
+
+// BA1: an identity with no matching sub resolves to an existing local user through the configured
+// linking attribute, and the assertion is issued for that user rather than a new one.
+func (s *FederatedMappingSuite) TestAuthenticationFlowLinksToExistingUserByMappedAttribute() {
+	linkEmail := s.nextSubject() + "@example.com"
+	existingID, err := testutils.CreateUser(testutils.User{
+		Type: fedPersonType.Name,
+		OUID: s.ouID,
+		Attributes: mustJSON(map[string]interface{}{
+			"username": linkEmail,
+			"email":    linkEmail,
+		}),
+	})
+	s.Require().NoError(err, "failed to create the user the identity should link to")
+	defer func() {
+		if err := testutils.DeleteUser(existingID); err != nil {
+			s.T().Logf("failed to delete the linked user: %v", err)
+		}
+	}()
+
+	// The identity's own subject matches nobody; only the mapped email can resolve it.
+	user := s.baseUser(s.nextSubject())
+	user.Email = linkEmail
+
+	config := mapping(fedPersonType.Name, pair("email", "email"))
+	config.AccountLinking = &testutils.AccountLinking{Attributes: []string{"email"}}
+
+	// The strict flow carries no provisioning step, so a completed run proves the identity resolved to
+	// the existing user rather than being created.
+	step, err := s.authenticate(s.strictAuthAppID, config, user)
+	s.Require().NoError(err, "the linked identity should authenticate cleanly")
+
+	s.Require().Equal("COMPLETE", step.FlowStatus,
+		"the identity should have linked to the existing user, got %+v", step)
+	s.Require().NotEmpty(step.Assertion, "a completed authentication should carry an assertion")
+
+	claims, err := testutils.DecodeJWT(step.Assertion)
+	s.Require().NoError(err, "failed to decode the assertion")
+	s.Equal(existingID, claims.Sub,
+		"the assertion should be issued for the pre-existing user, not a newly created one")
+}
+
+// BA2: an identity matching no local user proceeds past the federated node when the node allows
+// authentication without one. This is the only executor branch that depends on the flow type.
+func (s *FederatedMappingSuite) TestAuthenticationFlowWithoutLocalUserProceedsWhenAllowed() {
+	user := s.baseUser(s.nextSubject())
+
+	// Provisioning needs every required attribute, so the mapping supplies the username too; without it
+	// the flow would stop to collect it, which Phase 3 already covers.
+	config := mapping(fedPersonType.Name, pair("email", "email"), pair("email", "username"))
+
+	step, err := s.authenticate(s.authAppID, config, user)
+
+	s.Require().NoError(err, "an unmatched identity should be provisioned rather than failing")
+	s.Require().Equal("COMPLETE", step.FlowStatus,
+		"the identity should have been provisioned just in time, got %+v", step)
+
+	provisioned, err := testutils.FindUserByAttribute("sub", user.Sub)
+	s.Require().NoError(err, "failed to look up the provisioned user")
+	s.Require().NotNil(provisioned, "the allowance should have provisioned a user for %s", user.Sub)
+	s.config.CreatedUserIDs = append(s.config.CreatedUserIDs, provisioned.ID)
+}
+
+// BA3: the same identity against a flow whose federated node does not set the property. Without a local
+// user and without the allowance there is nothing to authenticate, so the flow cannot complete.
+func (s *FederatedMappingSuite) TestAuthenticationFlowWithoutLocalUserFailsWhenNotAllowed() {
+	user := s.baseUser(s.nextSubject())
+
+	step, err := s.authenticate(s.strictAuthAppID, mapping(fedPersonType.Name, pair("email", "email")), user)
+
+	// Asserted exactly rather than "any failure": an unrelated OIDC, state or executor fault would
+	// otherwise satisfy this test. The identity currently fails as an opaque HTTP 500 carrying
+	// SSE-5000, which is the G18 behaviour; when that is corrected to a client error this assertion
+	// fails loudly and is updated, which is the intent.
+	s.Require().Error(err, "an unmatched identity must not authenticate, got %+v", step)
+	s.Contains(err.Error(), "500", "expected the documented G18 internal error, got %v", err)
+	s.Contains(err.Error(), "SSE-5000", "expected the documented G18 error code, got %v", err)
+
+	unexpected, lookupErr := testutils.FindUserByAttribute("sub", user.Sub)
+	s.Require().NoError(lookupErr, "failed to check whether a user was created")
+	s.Nil(unexpected, "no user should be created when the flow does not allow authentication without one")
+}

--- a/tests/integration/federated/executor_test.go
+++ b/tests/integration/federated/executor_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package federated
+
+import (
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+/*
+The generic executors as flow nodes, and the state parameter they guard the callback with.
+
+Until this file, OAuthExecutor and OIDCAuthExecutor appeared in no flow graph anywhere: only the Google
+and GitHub specialisations did, and those are five-statement wrappers around this code. The state
+scenarios matter more than they look — ErrInvalidOAuthState had no coverage at any level, and the
+executor accepts a callback that returns no state at all, which is a deliberate product decision rather
+than an oversight (G3).
+*/
+
+// startFederatedFlow initiates an authentication flow and returns the step plus the authorization code
+// and state the provider issued.
+func (s *FederatedMappingSuite) startFederatedFlow(
+	appID string, user *testutils.OIDCUserInfo) (*common.FlowStep, string, string) {
+	s.T().Helper()
+	s.activeSub = user.Sub
+
+	step, err := common.InitiateAuthenticationFlow(appID, false, nil, "")
+	s.Require().NoError(err, "failed to initiate the authentication flow")
+	s.Require().Equal("REDIRECTION", step.Type, "expected a redirection, got %+v", step)
+
+	code, state, err := testutils.SimulateFederatedOAuthFlow(step.Data.RedirectURL)
+	s.Require().NoError(err, "failed to simulate authorization at the identity provider")
+	return step, code, state
+}
+
+// knownOIDCIdentity registers an identity on the OIDC mock with a local user to resolve to.
+func (s *FederatedMappingSuite) knownOIDCIdentity() *testutils.OIDCUserInfo {
+	s.T().Helper()
+	user := s.baseUser(s.nextSubject())
+	email := user.Sub + "@example.com"
+	s.createLocalUser(map[string]interface{}{"username": email, "email": email, "sub": user.Sub})
+	s.applyConfig(mapping(fedPersonType.Name, pair("email", "email")))
+	s.mockOIDC.AddUser(user)
+	return user
+}
+
+// knownOAuthIdentity is the same for the generic OAuth connection.
+func (s *FederatedMappingSuite) knownOAuthIdentity() *testutils.OIDCUserInfo {
+	s.T().Helper()
+	sub := s.nextSubject()
+	email := sub + "@example.com"
+	s.mockOAuth.AddUser(&testutils.OAuthUserInfo{Sub: sub, Email: email, Name: "OAuth User"})
+	s.createLocalUser(map[string]interface{}{"username": email, "email": email, "sub": sub})
+	s.applyConfigTo("oauth", s.oauthIDPID, mapping(fedPersonType.Name, pair("email", "email")))
+	return &testutils.OIDCUserInfo{Sub: sub, Email: email}
+}
+
+// B17: the generic OIDC executor drives an authentication flow to completion.
+func (s *FederatedMappingSuite) TestGenericOIDCExecutorAsFlowNode() {
+	user := s.knownOIDCIdentity()
+	step, code, state := s.startFederatedFlow(s.strictAuthAppID, user)
+
+	completed, err := common.CompleteFlow(
+		step.ExecutionID, map[string]string{"code": code, "state": state}, "", step.ChallengeToken)
+	s.Require().NoError(err, "the generic OIDC executor should complete the flow")
+	s.Equal("COMPLETE", completed.FlowStatus, "got %+v", completed)
+	s.NotEmpty(completed.Assertion, "a completed authentication should carry an assertion")
+}
+
+// B18: the same for the generic OAuth executor, which has no ID token and reads the profile from the
+// userinfo endpoint.
+func (s *FederatedMappingSuite) TestGenericOAuthExecutorAsFlowNode() {
+	user := s.knownOAuthIdentity()
+	step, code, state := s.startFederatedFlow(s.oauthAppID, user)
+
+	completed, err := common.CompleteFlow(
+		step.ExecutionID, map[string]string{"code": code, "state": state}, "", step.ChallengeToken)
+	s.Require().NoError(err, "the generic OAuth executor should complete the flow")
+	s.Equal("COMPLETE", completed.FlowStatus, "got %+v", completed)
+	s.NotEmpty(completed.Assertion, "a completed authentication should carry an assertion")
+}
+
+// B19: a callback returning a state the server did not issue is refused. This closed the last branch of
+// ErrInvalidOAuthState, which had no coverage at any level.
+func (s *FederatedMappingSuite) TestOIDCStateMismatchRefused() {
+	user := s.knownOIDCIdentity()
+	step, code, _ := s.startFederatedFlow(s.strictAuthAppID, user)
+
+	completed, err := common.CompleteFlow(step.ExecutionID,
+		map[string]string{"code": code, "state": "a-state-the-server-never-issued"}, "", step.ChallengeToken)
+
+	s.assertNotAuthenticated(completed, err, "a mismatched state must not authenticate")
+}
+
+// B20: the same on the generic OAuth executor, which carries its own copy of the state check.
+func (s *FederatedMappingSuite) TestOAuthStateMismatchRefused() {
+	user := s.knownOAuthIdentity()
+	step, code, _ := s.startFederatedFlow(s.oauthAppID, user)
+
+	completed, err := common.CompleteFlow(step.ExecutionID,
+		map[string]string{"code": code, "state": "a-state-the-server-never-issued"}, "", step.ChallengeToken)
+
+	s.assertNotAuthenticated(completed, err, "a mismatched state must not authenticate")
+}
+
+// B20a: a callback that returns no state at all is accepted. The check is gated on the client returning
+// one, which the code documents as deliberate for clients handling CSRF themselves. This pins that
+// decision rather than asserting it is a defect; the residual risk is G3.
+func (s *FederatedMappingSuite) TestOmittedStateIsAccepted() {
+	user := s.knownOIDCIdentity()
+	step, code, _ := s.startFederatedFlow(s.strictAuthAppID, user)
+
+	completed, err := common.CompleteFlow(
+		step.ExecutionID, map[string]string{"code": code}, "", step.ChallengeToken)
+
+	s.Require().NoError(err, "omitting the state should not fail the exchange")
+	s.Equal("COMPLETE", completed.FlowStatus,
+		"a callback with no state proceeds; the server does not require one back: %+v", completed)
+}
+
+// B20b: submitting the code on the very first interaction skips the authorize step entirely, so no state
+// was ever stored. A returned state then matches nothing and is refused.
+func (s *FederatedMappingSuite) TestStateWithoutStoredStateRefused() {
+	s.knownOIDCIdentity()
+
+	// A first request already carrying a code: HasRequiredInputs is satisfied, so the executor processes
+	// the callback without ever having built an authorize URL.
+	step, err := common.InitiateAuthenticationFlow(s.strictAuthAppID, false,
+		map[string]string{"code": "a-code-from-nowhere", "state": "a-state-from-nowhere"}, "")
+
+	s.assertNotAuthenticated(step, err, "a state with nothing stored to compare against must be refused")
+}
+
+// B20c: replaying a completed callback. A validated state is deleted once used, so the replay has
+// nothing to match — but the flow execution is also finished by then, and whichever check refuses first,
+// the replay must not authenticate a second time.
+func (s *FederatedMappingSuite) TestCallbackReplayRefused() {
+	user := s.knownOIDCIdentity()
+	step, code, state := s.startFederatedFlow(s.strictAuthAppID, user)
+	inputs := map[string]string{"code": code, "state": state}
+
+	completed, err := common.CompleteFlow(step.ExecutionID, inputs, "", step.ChallengeToken)
+	s.Require().NoError(err, "the first callback should succeed")
+	s.Require().Equal("COMPLETE", completed.FlowStatus)
+
+	replayed, err := common.CompleteFlow(step.ExecutionID, inputs, "", step.ChallengeToken)
+	s.assertNotAuthenticated(replayed, err, "replaying a completed callback must not authenticate again")
+}
+
+// assertNotAuthenticated accepts either an error from the exchange or a step that did not complete,
+// since a refusal can surface as either depending on where it is caught.
+func (s *FederatedMappingSuite) assertNotAuthenticated(
+	step *common.FlowStep, err error, message string) {
+	s.T().Helper()
+	if err != nil {
+		return
+	}
+	s.Require().NotNil(step, message)
+	s.NotEqual("COMPLETE", step.FlowStatus, "%s, got %+v", message, step)
+	s.Empty(step.Assertion, "%s: no assertion should be issued", message)
+}

--- a/tests/integration/federated/linking_test.go
+++ b/tests/integration/federated/linking_test.go
@@ -1,0 +1,370 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package federated
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+/*
+Account linking through the direct federated endpoints.
+
+Linking is observable here in a way it is not in a flow: the response carries no claims, only which
+local user the identity resolved to, so the returned id *is* the result. These use
+/auth/oauth/standard/*, which is the only direct federated route — an OIDC connection reaches it through
+the cross-type allowance in validateIDPType, which is why the existing OIDC suite uses the same path.
+*/
+
+const (
+	directAuthStart  = "/auth/oauth/standard/start"
+	directAuthFinish = "/auth/oauth/standard/finish"
+
+	// GitHub is not reachable through the standard endpoints: the cross-type allowance in
+	// validateIDPType covers OAUTH and OIDC only, so a GitHub connection there is rejected as
+	// AUTHN-1003. It has its own dedicated pair.
+	githubAuthStart  = "/auth/oauth/github/start"
+	githubAuthFinish = "/auth/oauth/github/finish"
+)
+
+// authenticateDirect drives the direct endpoints and returns the finish status, the decoded response and
+// the error code when the response carries one.
+func (s *FederatedMappingSuite) authenticateDirect(
+	config *testutils.AttributeConfiguration, user *testutils.OIDCUserInfo,
+) (int, testutils.AuthenticationResponse, string) {
+	s.T().Helper()
+	s.applyConfig(config)
+	s.mockOIDC.AddUser(user)
+	return s.authenticateDirectVia(s.idpID, user.Sub)
+}
+
+// authenticateDirectVia drives the direct endpoints against any connection, for the OAuth and GitHub
+// scenarios whose identities live on a different mock.
+func (s *FederatedMappingSuite) authenticateDirectVia(
+	idpID, sub string,
+) (int, testutils.AuthenticationResponse, string) {
+	s.T().Helper()
+	return s.authenticateVia(directAuthStart, directAuthFinish, idpID, sub)
+}
+
+// authenticateVia drives a given pair of direct endpoints, since GitHub has its own.
+func (s *FederatedMappingSuite) authenticateVia(
+	startPath, finishPath, idpID, sub string,
+) (int, testutils.AuthenticationResponse, string) {
+	s.T().Helper()
+	s.activeSub = sub
+
+	status, body := s.postJSON(startPath, map[string]interface{}{"idpId": idpID})
+	s.Require().Equal(http.StatusOK, status, "failed to start federated authentication: %s", string(body))
+
+	var start struct {
+		SessionToken string `json:"sessionToken"`
+		RedirectURL  string `json:"redirectUrl"`
+	}
+	s.Require().NoError(json.Unmarshal(body, &start))
+
+	code, _, err := testutils.SimulateFederatedOAuthFlow(start.RedirectURL)
+	s.Require().NoError(err, "failed to simulate authorization at the identity provider")
+
+	status, body = s.postJSON(finishPath, map[string]interface{}{
+		"sessionToken": start.SessionToken,
+		"code":         code,
+	})
+
+	var response testutils.AuthenticationResponse
+	var failure struct {
+		Code string `json:"code"`
+	}
+	if status == http.StatusOK {
+		s.Require().NoError(json.Unmarshal(body, &response), "failed to decode: %s", string(body))
+	} else {
+		_ = json.Unmarshal(body, &failure)
+	}
+	return status, response, failure.Code
+}
+
+func (s *FederatedMappingSuite) postJSON(path string, body interface{}) (int, []byte) {
+	s.T().Helper()
+	payload, err := json.Marshal(body)
+	s.Require().NoError(err)
+
+	req, err := http.NewRequest(http.MethodPost, testutils.TestServerURL+path, bytes.NewReader(payload))
+	s.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	return resp.StatusCode, responseBody
+}
+
+// createLocalUser creates a fed_person and registers it for cleanup after the test.
+func (s *FederatedMappingSuite) createLocalUser(attributes map[string]interface{}) string {
+	s.T().Helper()
+	userID, err := testutils.CreateUser(testutils.User{
+		Type:       fedPersonType.Name,
+		OUID:       s.ouID,
+		Attributes: mustJSON(attributes),
+	})
+	s.Require().NoError(err, "failed to create local user %v", attributes)
+	s.config.CreatedUserIDs = append(s.config.CreatedUserIDs, userID)
+	return userID
+}
+
+// linkOn builds a configuration that maps the claims a scenario needs and links on the named attributes.
+func linkOn(attributes []string, pairs ...testutils.AttributeMapping) *testutils.AttributeConfiguration {
+	config := mapping(fedPersonType.Name, pairs...)
+	config.AccountLinking = &testutils.AccountLinking{Attributes: attributes}
+	return config
+}
+
+// B10: a federated identity whose subject matches nobody resolves to an existing user through the
+// configured linking attribute.
+func (s *FederatedMappingSuite) TestLinksToExistingUserByMappedAttribute() {
+	email := s.nextSubject() + "@example.com"
+	existingID := s.createLocalUser(map[string]interface{}{"username": email, "email": email})
+
+	user := s.baseUser(s.nextSubject())
+	user.Email = email
+
+	status, response, _ := s.authenticateDirect(linkOn([]string{"email"}, pair("email", "email")), user)
+
+	s.Require().Equal(http.StatusOK, status)
+	s.Equal(existingID, response.ID, "the identity should resolve to the user sharing its email")
+}
+
+// B11: the subject is tried first, so an identity whose sub already matches a user resolves to that user
+// even when its linking attribute points at a different one.
+func (s *FederatedMappingSuite) TestSubTakesPrecedenceOverLinkingAttribute() {
+	sub := s.nextSubject()
+	subEmail := sub + "-bysub@example.com"
+	subUserID := s.createLocalUser(map[string]interface{}{
+		"username": subEmail, "email": subEmail, "sub": sub,
+	})
+
+	linkEmail := s.nextSubject() + "-bylink@example.com"
+	linkUserID := s.createLocalUser(map[string]interface{}{"username": linkEmail, "email": linkEmail})
+
+	user := s.baseUser(sub)
+	user.Email = linkEmail
+
+	status, response, _ := s.authenticateDirect(linkOn([]string{"email"}, pair("email", "email")), user)
+
+	s.Require().Equal(http.StatusOK, status)
+	s.Equal(subUserID, response.ID, "the subject match should win")
+	s.NotEqual(linkUserID, response.ID, "the linking attribute should not override a subject match")
+}
+
+// B12: linking may name the *external* claim. It is resolved to its local counterpart through the
+// configured mappings before the lookup runs.
+func (s *FederatedMappingSuite) TestLinkingAttributeNamedByExternalClaim() {
+	email := s.nextSubject() + "@example.com"
+	existingID := s.createLocalUser(map[string]interface{}{"username": email, "email": email})
+
+	user := s.baseUser(s.nextSubject())
+	user.Custom["mail"] = email
+
+	// The linking list names "mail"; the mapping says mail becomes email locally.
+	status, response, _ := s.authenticateDirect(linkOn([]string{"mail"}, pair("mail", "email")), user)
+
+	s.Require().Equal(http.StatusOK, status)
+	s.Equal(existingID, response.ID, "the external claim name should resolve to its local counterpart")
+}
+
+// B13: several linking attributes are combined, so the lookup identifies a user by all of them together.
+func (s *FederatedMappingSuite) TestMultipleLinkingAttributesCombined() {
+	email := s.nextSubject() + "@example.com"
+	existingID := s.createLocalUser(map[string]interface{}{
+		"username": email, "email": email, "costCenter": "CC-100",
+	})
+
+	user := s.baseUser(s.nextSubject())
+	user.Email = email
+	user.Custom["cost_centre"] = "CC-100"
+
+	status, response, _ := s.authenticateDirect(
+		linkOn([]string{"email", "costCenter"}, pair("email", "email"), pair("cost_centre", "costCenter")),
+		user)
+
+	s.Require().Equal(http.StatusOK, status)
+	s.Equal(existingID, response.ID, "both attributes together should resolve the user")
+}
+
+// B14a: two users share the linked value, so the lookup cannot identify one. The direct endpoint reports
+// that as a client error rather than picking arbitrarily. costCenter is used because it is the only
+// non-unique attribute — uniqueness is deployment-global, so email could not be duplicated.
+func (s *FederatedMappingSuite) TestAmbiguousLinkingAttributeIsReported() {
+	first := s.nextSubject() + "@example.com"
+	second := s.nextSubject() + "@example.com"
+	s.createLocalUser(map[string]interface{}{"username": first, "email": first, "costCenter": "CC-AMB"})
+	s.createLocalUser(map[string]interface{}{"username": second, "email": second, "costCenter": "CC-AMB"})
+
+	user := s.baseUser(s.nextSubject())
+	user.Custom["cost_centre"] = "CC-AMB"
+
+	status, response, code := s.authenticateDirect(
+		linkOn([]string{"costCenter"}, pair("cost_centre", "costCenter")), user)
+
+	// It must not pick one of them.
+	s.Empty(response.ID, "an ambiguous link must not resolve to an arbitrary user")
+
+	// The manager classifies ambiguity as a *client* error (AUTHN-MGR-1009, ClientErrorType), but
+	// mapCredentialsGetAttributesError maps only two codes and sends everything else to its default
+	// branch, so the classification is discarded and the caller sees an opaque 500. Asserted exactly,
+	// because an earlier draft asserted merely "not 200" and hid this. Recorded as G18.
+	s.Equal(http.StatusInternalServerError, status,
+		"ambiguity currently surfaces as an internal error rather than a client one")
+	s.Equal("SSE-5000", code, "the ambiguity code AUTHN-MGR-1009 does not reach the caller")
+}
+
+// B15: a linking attribute whose claim carries no value contributes nothing, so the lookup falls back to
+// the subject filter — which is the only path that does fall back.
+func (s *FederatedMappingSuite) TestLinkingAttributeAbsentFallsBackToSub() {
+	sub := s.nextSubject()
+	email := sub + "@example.com"
+	existingID := s.createLocalUser(map[string]interface{}{
+		"username": email, "email": email, "sub": sub,
+	})
+
+	// The identity carries no cost_centre claim, so the configured linking attribute has no value.
+	user := s.baseUser(sub)
+
+	status, response, _ := s.authenticateDirect(
+		linkOn([]string{"costCenter"}, pair("cost_centre", "costCenter")), user)
+
+	s.Require().Equal(http.StatusOK, status)
+	s.Equal(existingID, response.ID, "with no linking value the subject filter should still resolve")
+}
+
+// B16: with no linking configured the subject is the only thing consulted.
+func (s *FederatedMappingSuite) TestWithoutLinkingOnlySubResolves() {
+	sub := s.nextSubject()
+	email := sub + "@example.com"
+	existingID := s.createLocalUser(map[string]interface{}{
+		"username": email, "email": email, "sub": sub,
+	})
+
+	user := s.baseUser(sub)
+	status, response, _ := s.authenticateDirect(mapping(fedPersonType.Name, pair("email", "email")), user)
+
+	s.Require().Equal(http.StatusOK, status)
+	s.Equal(existingID, response.ID, "the subject alone should resolve the user")
+}
+
+// BR7: one configured linking attribute has a value and another does not. Only those with values join
+// the filter, so the present one still resolves the user.
+func (s *FederatedMappingSuite) TestPartiallyPopulatedLinkingAttributes() {
+	email := s.nextSubject() + "@example.com"
+	existingID := s.createLocalUser(map[string]interface{}{"username": email, "email": email})
+
+	user := s.baseUser(s.nextSubject())
+	user.Email = email // cost_centre is absent
+
+	status, response, _ := s.authenticateDirect(
+		linkOn([]string{"email", "costCenter"}, pair("email", "email"), pair("cost_centre", "costCenter")),
+		user)
+
+	s.Require().Equal(http.StatusOK, status)
+	s.Equal(existingID, response.ID, "an absent attribute should not prevent the present one resolving")
+}
+
+// BR8: the attributes are combined with AND, so values that individually match different users together
+// match none.
+func (s *FederatedMappingSuite) TestLinkingAttributesMatchingDifferentUsersResolveNone() {
+	emailOwner := s.nextSubject() + "@example.com"
+	s.createLocalUser(map[string]interface{}{"username": emailOwner, "email": emailOwner})
+
+	costOwner := s.nextSubject() + "@example.com"
+	s.createLocalUser(map[string]interface{}{
+		"username": costOwner, "email": costOwner, "costCenter": "CC-SPLIT",
+	})
+
+	user := s.baseUser(s.nextSubject())
+	user.Email = emailOwner
+	user.Custom["cost_centre"] = "CC-SPLIT"
+
+	status, _, _ := s.authenticateDirect(
+		linkOn([]string{"email", "costCenter"}, pair("email", "email"), pair("cost_centre", "costCenter")),
+		user)
+
+	s.NotEqual(http.StatusOK, status,
+		"values matching two different users must not resolve either of them")
+}
+
+// BR9: the filter stringifies the claim before looking it up, so a numeric claim still matches a value
+// stored as a string.
+func (s *FederatedMappingSuite) TestNumericLinkingClaimMatchesStoredString() {
+	email := s.nextSubject() + "@example.com"
+	existingID := s.createLocalUser(map[string]interface{}{
+		"username": email, "email": email, "costCenter": "4200",
+	})
+
+	user := s.baseUser(s.nextSubject())
+	user.Custom["cost_centre"] = 4200
+
+	status, response, _ := s.authenticateDirect(
+		linkOn([]string{"costCenter"}, pair("cost_centre", "costCenter")), user)
+
+	s.Require().Equal(http.StatusOK, status)
+	s.Equal(existingID, response.ID, "a numeric claim should stringify and match the stored value")
+}
+
+// BR10: linking on an email whose casing differs from the stored value.
+func (s *FederatedMappingSuite) TestEmailLinkingCaseHandling() {
+	local := s.nextSubject()
+	stored := local + "@example.com"
+	s.createLocalUser(map[string]interface{}{"username": stored, "email": stored})
+
+	user := s.baseUser(s.nextSubject())
+	user.Email = local + "@EXAMPLE.COM"
+
+	status, _, _ := s.authenticateDirect(linkOn([]string{"email"}, pair("email", "email")), user)
+
+	// Email linking is case-sensitive: the lookup compares the claim verbatim, so an address differing
+	// only in case does not link and the subject fallback finds nobody. Worth pinning because addresses
+	// are case-insensitive in practice, so the same person signing in from a provider that normalises
+	// casing differently is treated as unknown. Recorded as G19.
+	s.NotEqual(http.StatusOK, status,
+		"a differently cased address does not link, so the identity resolves to nobody")
+}
+
+// BR11: linking on a value padded with whitespace. Nothing trims the claim before the lookup.
+func (s *FederatedMappingSuite) TestWhitespaceAroundLinkingValueDoesNotMatch() {
+	email := s.nextSubject() + "@example.com"
+	s.createLocalUser(map[string]interface{}{"username": email, "email": email})
+
+	user := s.baseUser(s.nextSubject())
+	user.Custom["mail"] = "  " + email + "  "
+
+	status, _, _ := s.authenticateDirect(linkOn([]string{"mail"}, pair("mail", "email")), user)
+
+	s.NotEqual(http.StatusOK, status,
+		"a padded value is not trimmed before the lookup, so it should not match the stored address")
+}
+
+// BR12: signing in again after a first successful link resolves the same user rather than creating or
+// matching another.
+func (s *FederatedMappingSuite) TestRepeatedLoginResolvesTheSameUser() {
+	email := s.nextSubject() + "@example.com"
+	existingID := s.createLocalUser(map[string]interface{}{"username": email, "email": email})
+
+	user := s.baseUser(s.nextSubject())
+	user.Email = email
+	config := linkOn([]string{"email"}, pair("email", "email"))
+
+	firstStatus, first, _ := s.authenticateDirect(config, user)
+	s.Require().Equal(http.StatusOK, firstStatus)
+	s.Require().Equal(existingID, first.ID)
+
+	secondStatus, second, _ := s.authenticateDirect(config, user)
+	s.Require().Equal(http.StatusOK, secondStatus)
+	s.Equal(existingID, second.ID, "a repeated sign-in should resolve the same user")
+}

--- a/tests/integration/federated/mapping_test.go
+++ b/tests/integration/federated/mapping_test.go
@@ -1,0 +1,271 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package federated
+
+import "github.com/thunder-id/thunderid/tests/integration/testutils"
+
+// B1: external claims are published under their configured local names on the provisioned user.
+func (s *FederatedMappingSuite) TestCustomAttributeMappingsApplied() {
+	sub := s.nextSubject()
+	user := s.baseUser(sub)
+
+	attributes := s.register(mapping(fedPersonType.Name,
+		pair("given_name", "firstName"),
+		pair("family_name", "lastName"),
+		pair("email", "username"),
+	), user)
+
+	s.Equal("Federated", attributes["firstName"])
+	s.Equal("User", attributes["lastName"])
+	s.Equal(user.Email, attributes["username"], "the email claim should be published as the username")
+}
+
+// B2: a dot-notation external path reads through a nested claim object.
+func (s *FederatedMappingSuite) TestNestedClaimPathMapped() {
+	sub := s.nextSubject()
+	user := s.baseUser(sub)
+	user.Custom["address"] = map[string]interface{}{"locality": "Colombo", "region": "Western"}
+
+	attributes := s.register(mapping(fedPersonType.Name,
+		pair("email", "username"),
+		pair("address.locality", "city"),
+	), user)
+
+	s.Equal("Colombo", attributes["city"], "the nested claim should be read through the dotted path")
+}
+
+// B3: one external claim can feed two local attributes. Mappings copy rather than rename, so both
+// targets receive the value.
+func (s *FederatedMappingSuite) TestOneClaimMappedToTwoAttributes() {
+	sub := s.nextSubject()
+	user := s.baseUser(sub)
+
+	attributes := s.register(mapping(fedPersonType.Name,
+		pair("email", "username"),
+		pair("given_name", "firstName"),
+		pair("given_name", "lastName"),
+	), user)
+
+	s.Equal("Federated", attributes["firstName"])
+	s.Equal("Federated", attributes["lastName"], "a second target receives the same source claim")
+}
+
+// B4: mapping copies rather than consumes. The source claim survives under its own name, and claims
+// with no mapping at all are still available to provisioning.
+func (s *FederatedMappingSuite) TestUnmappedClaimsPassThroughAndSourcesSurvive() {
+	sub := s.nextSubject()
+	user := s.baseUser(sub)
+
+	attributes := s.register(mapping(fedPersonType.Name,
+		pair("email", "username"),
+		pair("given_name", "firstName"),
+	), user)
+
+	s.Equal("Federated", attributes["firstName"], "the mapped target is published")
+	s.Equal(sub, attributes["sub"],
+		"sub is not mapped anywhere yet still reaches the provisioned user")
+	s.Equal(user.Email, attributes["email"],
+		"the email claim survives under its own name even though it also feeds username")
+}
+
+// B5: the resolved user type exists but has no entry in the mappings list, so no mapping applies.
+func (s *FederatedMappingSuite) TestResolvedUserTypeWithoutMappingEntry() {
+	user := s.baseUser(s.nextSubject())
+
+	step := s.registerExpectingPrompt(&testutils.AttributeConfiguration{
+		// Resolution names fed_person, but the only profile is keyed to fed_contractor.
+		UserTypeResolution: &testutils.UserTypeResolution{Default: fedPersonType.Name},
+		UserTypeAttributeMappings: []testutils.UserTypeAttributeMapping{{
+			UserType:   fedContractorType.Name,
+			Attributes: []testutils.AttributeMapping{pair("given_name", "firstName")},
+		}},
+	}, user)
+
+	// No profile matches the resolved type, so nothing is mapped and the required username has no
+	// source: provisioning stops and asks for it.
+	s.assertPromptsFor(step, "username")
+}
+
+// BR1: the resolution default names a user type that does not exist. Nothing rejects that at
+// configuration time (G4), so the failure is silent at runtime: no profile matches and no mapping is
+// applied. This differs from B5 only in why the lookup misses.
+func (s *FederatedMappingSuite) TestResolutionToNonexistentUserTypeAppliesNoMappings() {
+	user := s.baseUser(s.nextSubject())
+
+	step := s.registerExpectingPrompt(&testutils.AttributeConfiguration{
+		UserTypeResolution: &testutils.UserTypeResolution{Default: "no_such_user_type"},
+		UserTypeAttributeMappings: []testutils.UserTypeAttributeMapping{{
+			UserType:   fedPersonType.Name,
+			Attributes: []testutils.AttributeMapping{pair("given_name", "firstName")},
+		}},
+	}, user)
+
+	// The misconfiguration surfaces only here, as an unexpected prompt during sign-up.
+	s.assertPromptsFor(step, "username")
+}
+
+// BR2: claim-driven resolution with no value mapping uses the claim value directly as the profile key,
+// so a claim naming an unknown type also silently applies nothing. Nothing constrains that value to a
+// known user type (G5).
+func (s *FederatedMappingSuite) TestDirectResolutionClaimNamingUnknownTypeAppliesNoMappings() {
+	user := s.baseUser(s.nextSubject())
+	user.Custom["profile_type"] = "no_such_user_type"
+
+	step := s.registerExpectingPrompt(&testutils.AttributeConfiguration{
+		UserTypeResolution: &testutils.UserTypeResolution{
+			Default:           fedPersonType.Name,
+			ExternalAttribute: "profile_type",
+		},
+		UserTypeAttributeMappings: []testutils.UserTypeAttributeMapping{{
+			UserType:   fedPersonType.Name,
+			Attributes: []testutils.AttributeMapping{pair("given_name", "firstName")},
+		}},
+	}, user)
+
+	// The claim value is the profile key verbatim, so an unknown type matches no profile and the
+	// configured default is never consulted as a fallback for the mappings.
+	s.assertPromptsFor(step, "username")
+}
+
+// BR13: a dotted path whose intermediate segment is a scalar cannot be traversed, so the target is
+// simply not published rather than the lookup failing loudly.
+func (s *FederatedMappingSuite) TestNestedPathThroughScalarPublishesNothing() {
+	sub := s.nextSubject()
+	user := s.baseUser(sub)
+
+	attributes := s.register(mapping(fedPersonType.Name,
+		pair("email", "username"),
+		// email is a string, so email.locality cannot resolve.
+		pair("email.locality", "city"),
+	), user)
+
+	_, published := attributes["city"]
+	s.False(published, "a path through a scalar should publish nothing")
+	s.Equal(user.Email, attributes["username"], "the other mappings are unaffected")
+}
+
+// BR14: a dotted path whose final segment is absent behaves the same way.
+func (s *FederatedMappingSuite) TestNestedPathWithMissingSegmentPublishesNothing() {
+	sub := s.nextSubject()
+	user := s.baseUser(sub)
+	user.Custom["address"] = map[string]interface{}{"locality": "Colombo"}
+
+	attributes := s.register(mapping(fedPersonType.Name,
+		pair("email", "username"),
+		pair("address.region", "city"),
+	), user)
+
+	_, published := attributes["city"]
+	s.False(published, "a missing final segment should publish nothing")
+}
+
+// BR16: claim and attribute names are matched exactly. A source whose casing differs does not resolve,
+// and a target is published under exactly the configured spelling.
+func (s *FederatedMappingSuite) TestAttributeNamesAreCaseSensitive() {
+	sub := s.nextSubject()
+	user := s.baseUser(sub)
+
+	attributes := s.register(mapping(fedPersonType.Name,
+		pair("email", "username"),
+		// The claim is given_name; Given_Name must not resolve.
+		pair("Given_Name", "firstName"),
+		pair("family_name", "lastName"),
+	), user)
+
+	_, mismatched := attributes["firstName"]
+	s.False(mismatched, "a source claim whose casing differs should not resolve")
+	s.Equal("User", attributes["lastName"], "the correctly cased mapping still applies")
+}
+
+// BR15: a claim that is present but null contributes nothing to the provisioned user.
+//
+// The two layers disagree, which is the point of testing this end to end rather than at the mapping
+// function alone. ApplyAttributeMappings does publish the target, because the claim key exists and only
+// a *missing* key is skipped. By the time the identity is provisioned the null has been dropped, so the
+// attribute is indistinguishable from one that was never mapped. A null claim therefore cannot be used
+// to satisfy an attribute, however the mapping is configured.
+func (s *FederatedMappingSuite) TestNullClaimValueContributesNothing() {
+	user := s.baseUser(s.nextSubject())
+	user.Custom["work_city"] = nil
+
+	attributes := s.register(mapping(fedPersonType.Name,
+		pair("email", "username"),
+		pair("work_city", "city"),
+	), user)
+
+	_, published := attributes["city"]
+	s.False(published, "a null claim leaves the target absent on the provisioned user")
+}
+
+// BR3: a non-string claim mapped into a string-typed schema attribute. JSON numbers arrive as float64,
+// so this is the shape a provider actually sends.
+func (s *FederatedMappingSuite) TestNonStringClaimMappedIntoTypedAttribute() {
+	user := s.baseUser(s.nextSubject())
+	user.Custom["cost_centre"] = 4200
+
+	attributes := s.register(mapping(fedPersonType.Name,
+		pair("email", "username"),
+		pair("cost_centre", "costCenter"),
+	), user)
+
+	s.Equal("4200", attributes["costCenter"],
+		"a numeric claim should reach a string attribute in its decimal form")
+}
+
+// BR4: a mapping that targets a unique attribute whose value already belongs to another user. The
+// conflict surfaces during provisioning rather than being silently overwritten.
+func (s *FederatedMappingSuite) TestMappingOntoUniqueAttributeThatCollides() {
+	existingEmail := s.nextSubject() + "@example.com"
+	existing, err := testutils.CreateUser(testutils.User{
+		Type: fedPersonType.Name,
+		OUID: s.ouID,
+		Attributes: mustJSON(map[string]interface{}{
+			"username": existingEmail,
+			"email":    existingEmail,
+		}),
+	})
+	s.Require().NoError(err, "failed to create the colliding user")
+	defer func() {
+		if err := testutils.DeleteUser(existing); err != nil {
+			s.T().Logf("failed to delete the colliding user: %v", err)
+		}
+	}()
+
+	user := s.baseUser(s.nextSubject())
+	user.Email = existingEmail
+
+	step := s.registerExpectingPrompt(mapping(fedPersonType.Name,
+		pair("email", "username"),
+	), user)
+
+	// Provisioning cannot create a second user with that unique username, so the flow does not complete.
+	s.NotEqual("COMPLETE", step.FlowStatus,
+		"a unique-attribute collision must not silently provision a duplicate: %+v", step)
+}
+
+// BR5: the profile is matched but the claim it reads is absent, so the required local attribute has no
+// source and provisioning stops to collect it.
+func (s *FederatedMappingSuite) TestRequiredAttributeLeftAbsentByMissingClaim() {
+	user := s.baseUser(s.nextSubject())
+
+	step := s.registerExpectingPrompt(mapping(fedPersonType.Name,
+		// The identity carries no work_email claim.
+		pair("work_email", "username"),
+	), user)
+
+	s.assertPromptsFor(step, "username")
+}
+
+// BR6: the claim is present but empty. An empty value is not a value for a required attribute, so this
+// behaves as if it were absent.
+func (s *FederatedMappingSuite) TestEmptyClaimValueForRequiredAttribute() {
+	user := s.baseUser(s.nextSubject())
+	user.Custom["work_email"] = ""
+
+	step := s.registerExpectingPrompt(mapping(fedPersonType.Name,
+		pair("work_email", "username"),
+	), user)
+
+	s.assertPromptsFor(step, "username")
+}

--- a/tests/integration/federated/misconfig_test.go
+++ b/tests/integration/federated/misconfig_test.go
@@ -1,0 +1,164 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package federated
+
+import (
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+/*
+Executor misconfiguration.
+
+A federated node depends on a connection it names by id, and on that connection still existing and being
+of the type the executor expects. These cover what a deployment sees when one of those assumptions is
+wrong — the failures an administrator meets while wiring a flow up, rather than anything a user does.
+*/
+
+// federatedNodeFlow builds a single-node authentication graph with the given node properties, so a
+// scenario can express exactly the misconfiguration it is about.
+func federatedNodeFlow(handle, executor string, properties map[string]interface{}) testutils.Flow {
+	return testutils.Flow{
+		Name:     "Misconfigured " + handle,
+		FlowType: "AUTHENTICATION",
+		Handle:   handle,
+		Nodes: []map[string]interface{}{
+			{"id": "start", "type": "START", "onSuccess": "federated"},
+			{
+				"id":         "federated",
+				"type":       "TASK_EXECUTION",
+				"properties": properties,
+				"executor":   map[string]interface{}{"name": executor},
+				"onSuccess":  "auth_assert",
+			},
+			{
+				"id":        "auth_assert",
+				"type":      "TASK_EXECUTION",
+				"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+				"onSuccess": "end",
+			},
+			{"id": "end", "type": "END"},
+		},
+	}
+}
+
+// BE1: the node names no connection, or names one that is not a string.
+//
+// A missing or empty idpId is caught when the flow is authored, not when it runs: flow creation rejects
+// it as FLM-1023. That is the better outcome and the one worth pinning — an administrator cannot even
+// save the broken graph. A non-string value passes that check and fails later, so the two halves assert
+// different things.
+func (s *FederatedMappingSuite) TestFederatedNodeWithoutUsableIdpID() {
+	for name, properties := range map[string]map[string]interface{}{
+		"missing": {},
+		"empty":   {"idpId": ""},
+	} {
+		s.Run(name+"_rejected_at_authoring", func() {
+			_, err := testutils.CreateFlow(
+				federatedNodeFlow("auth_flow_bad_idp_"+name, "OIDCAuthExecutor", properties))
+
+			s.Require().Error(err, "a federated node with a %s idpId should not be saveable", name)
+			s.Contains(err.Error(), "FLM-1023",
+				"expected the executor-configuration rejection, got %v", err)
+			s.Contains(err.Error(), "idpId", "the rejection should name the missing property, got %v", err)
+		})
+	}
+
+	s.Run("non_string_fails_at_runtime", func() {
+		appID := s.createScenarioApp(
+			federatedNodeFlow("auth_flow_bad_idp_non_string", "OIDCAuthExecutor",
+				map[string]interface{}{"idpId": 42}),
+			"bad-idp-non-string")
+
+		step, err := common.InitiateAuthenticationFlow(appID, false, nil, "")
+
+		// Asserted rather than tolerated: accepting any error would let an unrelated HTTP or server
+		// fault satisfy this. The executor cannot resolve a connection, so the failure is a server-side
+		// one and the flow never reaches a provider.
+		s.Require().Error(err, "a non-string idpId must not start a federated exchange")
+		s.Contains(err.Error(), "500",
+			"expected the executor's own failure to resolve the connection, got %v", err)
+		s.Nil(step, "no flow step should be returned when the node cannot be resolved")
+	})
+}
+
+// BE2: the node names a connection of a different type from the executor driving it.
+//
+// Nothing rejects the pairing. A GitHub connection carries the same property names an OIDC connection
+// does — its endpoints are defaults rather than configured values — so the OIDC executor reads them and
+// issues a perfectly ordinary redirect. The mismatch only surfaces later, when the exchange produces no
+// ID token, which means an administrator discovers it from users failing to sign in rather than from
+// anything at authoring time. Recorded as G20.
+func (s *FederatedMappingSuite) TestFederatedNodeWithMismatchedConnectionType() {
+	appID := s.createScenarioApp(
+		federatedNodeFlow("auth_flow_type_mismatch", "OIDCAuthExecutor",
+			map[string]interface{}{"idpId": s.githubIDPID}),
+		"type-mismatch")
+
+	s.activeSub = s.githubIdentity(nil, []*testutils.GithubEmail{
+		{Email: s.nextSubject() + "@example.com", Primary: true, Verified: true},
+	})
+
+	step, err := common.InitiateAuthenticationFlow(appID, false, nil, "")
+	s.Require().NoError(err, "the mismatch is not caught here: the redirect is built from properties "+
+		"a GitHub connection also has")
+	s.Require().Equal("REDIRECTION", step.Type, "expected a redirect, got %+v", step)
+
+	code, state, err := testutils.SimulateFederatedOAuthFlow(step.Data.RedirectURL)
+	s.Require().NoError(err, "failed to simulate authorization")
+
+	completed, err := common.CompleteFlow(
+		step.ExecutionID, map[string]string{"code": code, "state": state}, "", step.ChallengeToken)
+
+	s.assertNotAuthenticated(completed, err,
+		"an OIDC exchange against a GitHub connection must not authenticate")
+}
+
+// BE3: a connection cannot be deleted while a flow still references it, which is what prevents the
+// mid-session case this scenario was originally written for.
+//
+// The plan expected to delete a connection between the redirect and the callback and assert the callback
+// failed. That situation cannot arise: deletion is refused with IDP-1013 while any flow depends on the
+// connection, so an administrator cannot pull it out from under a user mid-session in the first place.
+// Asserting the guard is more useful than asserting the consequence of a state the product prevents —
+// and the redirect is issued first, so the guard is shown holding while an exchange is genuinely in
+// flight rather than merely at rest.
+func (s *FederatedMappingSuite) TestConnectionInUseCannotBeDeletedMidExchange() {
+	fixture := s.idpFixture(nil)
+	fixture.Name = "Federated Throwaway Connection " + s.nextSubject()
+	throwaway, err := testutils.CreateIDP(fixture)
+	s.Require().NoError(err, "failed to create the throwaway connection")
+
+	appID := s.createScenarioApp(
+		federatedNodeFlow("auth_flow_deleted_conn", "OIDCAuthExecutor",
+			map[string]interface{}{"idpId": throwaway}),
+		"deleted-conn")
+
+	user := s.knownOIDCIdentity()
+	s.activeSub = user.Sub
+
+	step, err := common.InitiateAuthenticationFlow(appID, false, nil, "")
+	s.Require().NoError(err, "the flow should start")
+	s.Require().Equal("REDIRECTION", step.Type, "expected a redirect, got %+v", step)
+
+	// The user is now at the provider. Removing the connection underneath them is refused.
+	err = testutils.DeleteIDP(throwaway)
+	s.Require().Error(err, "a connection a flow depends on should not be deletable")
+	s.Contains(err.Error(), "IDP-1013", "expected the blocking-dependency refusal, got %v", err)
+
+	// The exchange in flight is unaffected, which is the point of the guard.
+	code, state, err := testutils.SimulateFederatedOAuthFlow(step.Data.RedirectURL)
+	s.Require().NoError(err, "failed to simulate authorization")
+	completed, err := common.CompleteFlow(
+		step.ExecutionID, map[string]string{"code": code, "state": state}, "", step.ChallengeToken)
+	s.Require().NoError(err, "the in-flight exchange should still complete")
+	s.Equal("COMPLETE", completed.FlowStatus, "got %+v", completed)
+
+	// The connection outlives the test's application, so it is removed once the flow referencing it is.
+	s.T().Cleanup(func() {
+		if err := testutils.DeleteIDP(throwaway); err != nil {
+			s.T().Logf("failed to delete the throwaway connection: %v", err)
+		}
+	})
+}

--- a/tests/integration/federated/oauth_test.go
+++ b/tests/integration/federated/oauth_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package federated
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+/*
+Generic OAuth transport failures.
+
+A generic OAuth connection has no ID token: the profile always comes from the userinfo endpoint, so
+these cover what happens when the token or userinfo exchange misbehaves. As with the OIDC block, each
+identity is given a local user first so a well-formed exchange would authenticate — otherwise every
+assertion would hold merely because no user existed.
+*/
+
+// oauthUser registers an identity on the OAuth mock and a local user carrying its subject.
+func (s *FederatedMappingSuite) oauthUser() string {
+	s.T().Helper()
+	sub := s.nextSubject()
+	email := sub + "@example.com"
+	s.mockOAuth.AddUser(&testutils.OAuthUserInfo{Sub: sub, Email: email, Name: "OAuth User"})
+	s.createLocalUser(map[string]interface{}{"username": email, "email": email, "sub": sub})
+	return sub
+}
+
+// authenticateOAuth applies a configuration and authenticates through the OAuth connection.
+func (s *FederatedMappingSuite) authenticateOAuth(sub string) int {
+	s.T().Helper()
+	s.applyConfigTo("oauth", s.oauthIDPID, mapping(fedPersonType.Name, pair("email", "email")))
+	status, _, _ := s.authenticateDirectVia(s.oauthIDPID, sub)
+	return status
+}
+
+// BO16: the token response is well-formed JSON but carries no access token, so there is nothing to
+// fetch the profile with.
+func (s *FederatedMappingSuite) TestOAuthTokenResponseMissingAccessToken() {
+	sub := s.oauthUser()
+	defer s.mockOAuth.ClearOverrides()
+	s.mockOAuth.SetTokenResponseOverride(func() (int, string) {
+		return http.StatusOK, `{"token_type":"Bearer","expires_in":3600}`
+	})
+
+	s.authFails(s.authenticateOAuth(sub), "a token response with no access token must not authenticate")
+}
+
+// BO17: the token endpoint refuses the exchange.
+func (s *FederatedMappingSuite) TestOAuthTokenEndpointError() {
+	sub := s.oauthUser()
+	defer s.mockOAuth.ClearOverrides()
+	s.mockOAuth.SetTokenResponseOverride(func() (int, string) {
+		return http.StatusBadRequest, `{"error":"invalid_grant"}`
+	})
+
+	s.authFails(s.authenticateOAuth(sub), "a rejected token exchange must not authenticate")
+}
+
+// BO18: the token endpoint answers with something that is not JSON.
+func (s *FederatedMappingSuite) TestOAuthTokenEndpointMalformedJSON() {
+	sub := s.oauthUser()
+	defer s.mockOAuth.ClearOverrides()
+	s.mockOAuth.SetTokenResponseOverride(func() (int, string) {
+		return http.StatusOK, `{"access_token": `
+	})
+
+	s.authFails(s.authenticateOAuth(sub), "an unparseable token response must not authenticate")
+}
+
+// BO19: the profile cannot be fetched.
+func (s *FederatedMappingSuite) TestOAuthUserInfoEndpointError() {
+	sub := s.oauthUser()
+	defer s.mockOAuth.ClearOverrides()
+	s.mockOAuth.SetUserInfoResponseOverride(func() (int, string) {
+		return http.StatusUnauthorized, `{"error":"invalid_token"}`
+	})
+
+	s.authFails(s.authenticateOAuth(sub),
+		"a failed profile fetch must not authenticate: OAuth has no ID token to fall back on")
+}
+
+// BO20: the profile response is not JSON.
+func (s *FederatedMappingSuite) TestOAuthUserInfoMalformedJSON() {
+	sub := s.oauthUser()
+	defer s.mockOAuth.ClearOverrides()
+	s.mockOAuth.SetUserInfoResponseOverride(func() (int, string) {
+		return http.StatusOK, `not-json-at-all`
+	})
+
+	s.authFails(s.authenticateOAuth(sub), "an unparseable profile must not authenticate")
+}
+
+// BO21: the profile carries no usable subject. Without one there is no identity to resolve.
+func (s *FederatedMappingSuite) TestOAuthUserInfoWithoutUsableSub() {
+	bodies := map[string]string{
+		"missing":    `{"email":"nobody@example.com"}`,
+		"empty":      `{"sub":"","email":"nobody@example.com"}`,
+		"non_string": `{"sub":42,"email":"nobody@example.com"}`,
+	}
+	for name, body := range bodies {
+		s.Run(name, func() {
+			sub := s.oauthUser()
+			defer s.mockOAuth.ClearOverrides()
+			s.mockOAuth.SetUserInfoResponseOverride(func() (int, string) {
+				return http.StatusOK, body
+			})
+
+			s.authFails(s.authenticateOAuth(sub), "%s sub must not authenticate", name)
+		})
+	}
+}
+
+// BO22: the provider sends the user back with an error rather than an authorization code, which is what
+// a cancelled consent screen looks like.
+//
+// The direct endpoint understands this: it accepts error and error_description and refuses the exchange.
+// The flow executors do not — ProcessAuthFlowResponse reads only code and state, so a cancelled
+// authorization arrives as "no code", clears the authenticated user and returns without an error. The
+// provider's reason never surfaces. That asymmetry is recorded as G21; this asserts the endpoint that
+// does handle it.
+func (s *FederatedMappingSuite) TestOAuthProviderErrorCallbackRefused() {
+	status, body := s.postJSON(directAuthStart, map[string]interface{}{"idpId": s.oauthIDPID})
+	s.Require().Equal(http.StatusOK, status, string(body))
+
+	var start struct {
+		SessionToken string `json:"sessionToken"`
+	}
+	s.Require().NoError(jsonUnmarshal(body, &start))
+
+	status, body = s.postJSON(directAuthFinish, map[string]interface{}{
+		"sessionToken":      start.SessionToken,
+		"error":             "access_denied",
+		"error_description": "User denied access",
+	})
+
+	s.Equal(http.StatusBadRequest, status,
+		"a provider error callback should be refused as a client error, got %s", string(body))
+}
+
+// BO28: scope delimiters. The connection stores scopes as a comma-separated string and the authorize
+// request must carry them space-separated, as the specification requires.
+//
+// All three configurations the plan names are covered, because they exercise different code: a
+// multi-scope list is split on commas, a single scope has no delimiter to split on, and an empty value
+// must produce no scope parameter rather than an empty one.
+func (s *FederatedMappingSuite) TestOAuthScopesOnAuthorizeURL() {
+	cases := []struct {
+		name     string
+		stored   string
+		expected []string
+	}{
+		{"comma_separated", "openid,email,profile", []string{"openid", "email", "profile"}},
+		{"single_scope", "openid", []string{"openid"}},
+		{"empty", "", nil},
+	}
+
+	for _, testCase := range cases {
+		s.Run(testCase.name, func() {
+			s.setOAuthScopes(testCase.stored)
+			defer s.setOAuthScopes("openid,email,profile")
+
+			status, body := s.postJSON(directAuthStart, map[string]interface{}{"idpId": s.oauthIDPID})
+			s.Require().Equal(http.StatusOK, status, string(body))
+
+			var start struct {
+				RedirectURL string `json:"redirectUrl"`
+			}
+			s.Require().NoError(jsonUnmarshal(body, &start))
+
+			parsed, err := url.Parse(start.RedirectURL)
+			s.Require().NoError(err, "the authorize URL should parse")
+			scope := parsed.Query().Get("scope")
+
+			s.NotContains(scope, ",",
+				"%s: the stored comma-separated list must not reach the provider verbatim", testCase.name)
+			s.Equal(testCase.expected, splitScopeParam(scope),
+				"%s: unexpected scope parameter %q", testCase.name, scope)
+		})
+	}
+}
+
+// splitScopeParam returns the scope values, or nil when the parameter is absent or empty.
+func splitScopeParam(scope string) []string {
+	if strings.TrimSpace(scope) == "" {
+		return nil
+	}
+	return strings.Fields(scope)
+}

--- a/tests/integration/federated/oidc_test.go
+++ b/tests/integration/federated/oidc_test.go
@@ -1,0 +1,377 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package federated
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"time"
+)
+
+/*
+ID token and UserInfo handling on a generic OIDC connection.
+
+Every rejection here surfaces as the same opaque error, so none of these assert an error code. The cause
+is collapsed three times over: ValidateIDToken turns every verifier failure into
+ErrorInvalidIDTokenSignature, the provider manager's default branch turns that into AUTHN-MGR-1001, and
+the direct endpoint maps it again to AUTHN-FED-1001. That is G14. Each scenario is therefore distinguished
+by its setup, and asserts only that authentication did not succeed.
+*/
+
+// authenticateKnown creates a local user carrying the identity's subject and then authenticates it.
+//
+// The local user matters: on the direct endpoint there is no provisioning, so an identity that matches
+// nobody fails whatever its token contained. Without a user to resolve to, every scenario in this file
+// would pass for that reason alone rather than because the token was rejected — the assertion would be
+// vacuous. With one present, a valid token authenticates, so a failure here is the token's doing.
+func (s *FederatedMappingSuite) authenticateKnown(user *OIDCUser) int {
+	s.T().Helper()
+	email := user.Sub + "@example.com"
+	s.createLocalUser(map[string]interface{}{"username": email, "email": email, "sub": user.Sub})
+	status, _, _ := s.authenticateDirect(mapping(fedPersonType.Name, pair("email", "email")), user)
+	return status
+}
+
+// authFails asserts that an identity did not authenticate, whatever shape the failure takes. Some
+// failures arrive as a non-200 finish and some as a 500 from the mapping layers (G18), and neither is
+// the point of these scenarios.
+func (s *FederatedMappingSuite) authFails(status int, message string, args ...interface{}) {
+	s.T().Helper()
+	s.NotEqual(http.StatusOK, status, append([]interface{}{message}, args...)...)
+}
+
+// B25: an expired ID token is rejected. verifyJWTClaims requires exp and checks it with the configured
+// leeway.
+func (s *FederatedMappingSuite) TestExpiredIDTokenRejected() {
+	defer s.mockOIDC.ClearOverrides()
+	s.mockOIDC.SetIDTokenOverride(func(user *OIDCUser, nonce string) (string, error) {
+		return s.signedIDToken(map[string]interface{}{
+			"sub":   user.Sub,
+			"iss":   s.mockOIDC.GetURL(),
+			"aud":   oidcClientID,
+			"exp":   time.Now().Add(-1 * time.Hour).Unix(),
+			"iat":   time.Now().Add(-2 * time.Hour).Unix(),
+			"nonce": nonce,
+		})
+	})
+
+	status := s.authenticateKnown(s.baseUser(s.nextSubject()))
+	s.authFails(status, "an expired ID token must not authenticate")
+}
+
+// B26: an ID token whose signature does not verify against the published JWKS is rejected.
+func (s *FederatedMappingSuite) TestInvalidIDTokenSignatureRejected() {
+	defer s.mockOIDC.ClearOverrides()
+	s.mockOIDC.SetIDTokenOverride(func(user *OIDCUser, nonce string) (string, error) {
+		token, err := s.signedIDToken(map[string]interface{}{
+			"sub":   user.Sub,
+			"iss":   s.mockOIDC.GetURL(),
+			"aud":   oidcClientID,
+			"exp":   time.Now().Add(time.Hour).Unix(),
+			"iat":   time.Now().Unix(),
+			"nonce": nonce,
+		})
+		if err != nil {
+			return "", err
+		}
+		// Corrupt the signature segment while leaving the token structurally valid.
+		return token[:len(token)-4] + "AAAA", nil
+	})
+
+	status := s.authenticateKnown(s.baseUser(s.nextSubject()))
+	s.authFails(status, "a token whose signature does not verify must not authenticate")
+}
+
+// B27: the nonce in the ID token must match the one the server generated. This is validated
+// independently of signature verification, so it holds even where the signature check is skipped.
+func (s *FederatedMappingSuite) TestNonceMismatchRejected() {
+	defer s.mockOIDC.ClearOverrides()
+	s.mockOIDC.SetIDTokenOverride(func(user *OIDCUser, nonce string) (string, error) {
+		return s.signedIDToken(map[string]interface{}{
+			"sub":   user.Sub,
+			"iss":   s.mockOIDC.GetURL(),
+			"aud":   oidcClientID,
+			"exp":   time.Now().Add(time.Hour).Unix(),
+			"iat":   time.Now().Unix(),
+			"nonce": "a-nonce-the-server-never-issued",
+		})
+	})
+
+	status := s.authenticateKnown(s.baseUser(s.nextSubject()))
+	s.authFails(status, "a mismatched nonce must not authenticate")
+}
+
+// BO1: the token response carries no ID token at all.
+func (s *FederatedMappingSuite) TestMissingIDTokenRejected() {
+	defer s.mockOIDC.ClearOverrides()
+	s.mockOIDC.SetTokenResponseOverride(func() (int, string) {
+		return http.StatusOK, `{"access_token":"at","token_type":"Bearer","expires_in":3600}`
+	})
+
+	status := s.authenticateKnown(s.baseUser(s.nextSubject()))
+	s.authFails(status, "a token response without an ID token must not authenticate")
+}
+
+// BO2: the ID token is not a JWT at all.
+func (s *FederatedMappingSuite) TestMalformedIDTokenRejected() {
+	defer s.mockOIDC.ClearOverrides()
+	s.mockOIDC.SetIDTokenOverride(func(_ *OIDCUser, _ string) (string, error) {
+		return "this-is-not-a-jwt", nil
+	})
+
+	status := s.authenticateKnown(s.baseUser(s.nextSubject()))
+	s.authFails(status, "a structurally invalid ID token must not authenticate")
+}
+
+// BO3 and BO4: the subject is the identity. A token carrying none, or an empty one, identifies nobody.
+func (s *FederatedMappingSuite) TestIDTokenWithoutUsableSubRejected() {
+	for name, sub := range map[string]interface{}{"missing": nil, "empty": ""} {
+		s.Run(name, func() {
+			defer s.mockOIDC.ClearOverrides()
+			s.mockOIDC.SetIDTokenOverride(func(_ *OIDCUser, nonce string) (string, error) {
+				claims := map[string]interface{}{
+					"iss":   s.mockOIDC.GetURL(),
+					"aud":   oidcClientID,
+					"exp":   time.Now().Add(time.Hour).Unix(),
+					"iat":   time.Now().Unix(),
+					"nonce": nonce,
+				}
+				if sub != nil {
+					claims["sub"] = sub
+				}
+				return s.signedIDToken(claims)
+			})
+
+			status := s.authenticateKnown(s.baseUser(s.nextSubject()))
+			s.authFails(status, "%s sub must not authenticate", name)
+		})
+	}
+}
+
+// BO7: the JWKS endpoint cannot be reached, so the signature cannot be verified.
+func (s *FederatedMappingSuite) TestUnreachableJWKSRejected() {
+	s.useFreshJWKS()
+	defer s.mockOIDC.ClearOverrides()
+	s.mockOIDC.SetJWKSOverride(func() (int, string) {
+		return http.StatusServiceUnavailable, `{"error":"unavailable"}`
+	})
+
+	status := s.authenticateKnown(s.baseUser(s.nextSubject()))
+	s.authFails(status, "an unreachable key set must not authenticate")
+}
+
+// BO8: the JWKS document is not valid JSON.
+func (s *FederatedMappingSuite) TestMalformedJWKSRejected() {
+	s.useFreshJWKS()
+	defer s.mockOIDC.ClearOverrides()
+	s.mockOIDC.SetJWKSOverride(func() (int, string) {
+		return http.StatusOK, `{"keys": [`
+	})
+
+	status := s.authenticateKnown(s.baseUser(s.nextSubject()))
+	s.authFails(status, "an unparseable key set must not authenticate")
+}
+
+// BO9: the key set is valid but contains no key matching the token's kid.
+func (s *FederatedMappingSuite) TestUnknownKeyIDRejected() {
+	s.useFreshJWKS()
+	defer s.mockOIDC.ClearOverrides()
+	s.mockOIDC.SetJWKSOverride(func() (int, string) {
+		return http.StatusOK, `{"keys":[{"kty":"RSA","use":"sig","kid":"some-other-key",` +
+			`"alg":"RS256","n":"AQAB","e":"AQAB"}]}`
+	})
+
+	status := s.authenticateKnown(s.baseUser(s.nextSubject()))
+	s.authFails(status, "a token signed by an unpublished key must not authenticate")
+}
+
+// BO10: the token declares an algorithm the verifier does not accept.
+func (s *FederatedMappingSuite) TestUnsupportedSigningAlgorithmRejected() {
+	defer s.mockOIDC.ClearOverrides()
+	s.mockOIDC.SetIDTokenOverride(func(user *OIDCUser, nonce string) (string, error) {
+		return s.mockOIDC.SignJWT(
+			map[string]interface{}{"alg": "none", "typ": "JWT"},
+			map[string]interface{}{
+				"sub":   user.Sub,
+				"iss":   s.mockOIDC.GetURL(),
+				"aud":   oidcClientID,
+				"exp":   time.Now().Add(time.Hour).Unix(),
+				"iat":   time.Now().Unix(),
+				"nonce": nonce,
+			})
+	})
+
+	status := s.authenticateKnown(s.baseUser(s.nextSubject()))
+	s.authFails(status, "an unaccepted algorithm must not authenticate")
+}
+
+// rotatedKey is a signing key the mock knows nothing about, so a token signed with it verifies only if
+// the verifier genuinely re-fetches and uses the newly published key set.
+type rotatedKey struct {
+	private *rsa.PrivateKey
+	kid     string
+}
+
+func (s *FederatedMappingSuite) newRotatedKey(kid string) *rotatedKey {
+	s.T().Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	s.Require().NoError(err, "failed to generate a rotation key")
+	return &rotatedKey{private: key, kid: kid}
+}
+
+// jwks renders the public half as a key set the verifier can consume.
+func (k *rotatedKey) jwks() string {
+	n := base64.RawURLEncoding.EncodeToString(k.private.N.Bytes())
+	e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(k.private.E)).Bytes())
+	return fmt.Sprintf(
+		`{"keys":[{"kty":"RSA","use":"sig","kid":%q,"alg":"RS256","n":%q,"e":%q}]}`, k.kid, n, e)
+}
+
+// sign produces an RS256 token over the given claims, carrying this key's kid.
+func (k *rotatedKey) sign(claims map[string]interface{}) (string, error) {
+	header, err := json.Marshal(map[string]interface{}{"alg": "RS256", "typ": "JWT", "kid": k.kid})
+	if err != nil {
+		return "", err
+	}
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+	signingInput := base64.RawURLEncoding.EncodeToString(header) + "." +
+		base64.RawURLEncoding.EncodeToString(payload)
+	digest := sha256.Sum256([]byte(signingInput))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, k.private, crypto.SHA256, digest[:])
+	if err != nil {
+		return "", err
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}
+
+// BO11: the provider rotates its signing key and publishes the new one. A token signed with the new key
+// must verify.
+//
+// This is the positive half of rotation, and it is the half that proves the verifier actually re-fetches
+// rather than trusting whatever it cached. An earlier version published an unrelated dummy key while the
+// mock kept signing with its original one, which only re-proved BO9 — that an unpublished key is
+// rejected. Here the second token is signed with a key the mock never had, so it can only succeed if the
+// newly published set was fetched and used.
+func (s *FederatedMappingSuite) TestKeyRotationToNewlyPublishedKey() {
+	user := s.baseUser(s.nextSubject())
+
+	// Key A: the mock's own, verified against the key set it publishes.
+	status := s.authenticateKnown(user)
+	s.Require().Equal(http.StatusOK, status, "the original key should verify the token")
+
+	// Key B: generated here, published, and used to sign the next token.
+	key := s.newRotatedKey("rotated-key-b")
+	s.useFreshJWKS()
+	defer s.mockOIDC.ClearOverrides()
+	s.mockOIDC.SetJWKSOverride(func() (int, string) { return http.StatusOK, key.jwks() })
+	s.mockOIDC.SetIDTokenOverride(func(u *OIDCUser, nonce string) (string, error) {
+		return key.sign(map[string]interface{}{
+			"sub":   u.Sub,
+			"iss":   s.mockOIDC.GetURL(),
+			"aud":   oidcClientID,
+			"exp":   time.Now().Add(time.Hour).Unix(),
+			"iat":   time.Now().Unix(),
+			"nonce": nonce,
+		})
+	})
+
+	rotated := s.baseUser(s.nextSubject())
+	status = s.authenticateKnown(rotated)
+	s.Equal(http.StatusOK, status,
+		"a token signed with the newly published key should verify after rotation")
+}
+
+// BO11 (negative half): once the key set no longer contains the key a token was signed with, that token
+// stops verifying. The mock still signs with its own key while a different set is published.
+func (s *FederatedMappingSuite) TestKeyRotationInvalidatesOldSignature() {
+	key := s.newRotatedKey("rotated-key-c")
+	s.useFreshJWKS()
+	defer s.mockOIDC.ClearOverrides()
+	s.mockOIDC.SetJWKSOverride(func() (int, string) { return http.StatusOK, key.jwks() })
+
+	status := s.authenticateKnown(s.baseUser(s.nextSubject()))
+	s.authFails(status, "a token signed by a key that is no longer published must not authenticate")
+}
+
+// BO12: when UserInfo reports a different subject from the ID token, the whole merge is skipped rather
+// than mixing two identities' claims.
+//
+// Proving that needs a claim only UserInfo carries. Asserting given_name survived would not: the ID token
+// carries it too, so that holds equally when the merge runs and the ID token simply wins, which is BO15.
+// The matching-subject half runs first as a control, because an absent claim proves nothing unless the
+// same claim is known to arrive when the subjects agree — the merge is also gated on the connection
+// carrying more than one scope, so without the control this would pass on a connection that never
+// fetches UserInfo at all.
+func (s *FederatedMappingSuite) TestUserInfoSubMismatchSkipsMerge() {
+	defer s.mockOIDC.ClearOverrides()
+
+	userInfoOnly := mapping(fedPersonType.Name,
+		pair("email", "username"), pair("given_name", "firstName"), pair("locality", "city"),
+	)
+
+	matching := s.baseUser(s.nextSubject())
+	s.mockOIDC.SetUserInfoResponseOverride(func() (int, string) {
+		return http.StatusOK, `{"sub":"` + matching.Sub + `","locality":"Colombo"}`
+	})
+	attributes := s.register(userInfoOnly, matching)
+	s.Require().Equal("Colombo", attributes["city"],
+		"control: a UserInfo-only claim must merge when the subject matches, or the assertion below is vacuous")
+
+	mismatched := s.baseUser(s.nextSubject())
+	s.mockOIDC.SetUserInfoResponseOverride(func() (int, string) {
+		return http.StatusOK,
+			`{"sub":"a-different-subject","given_name":"FromUserInfo","locality":"Colombo"}`
+	})
+	attributes = s.register(userInfoOnly, mismatched)
+
+	s.Equal("Federated", attributes["firstName"],
+		"the ID token's claim should stand; a mismatched UserInfo must not contribute")
+	s.NotContains(attributes, "city",
+		"the whole merge should be skipped, so a UserInfo-only claim must not arrive either")
+}
+
+// BO14: a UserInfo request that fails does not fail the authentication. The claims already in the ID
+// token are enough.
+func (s *FederatedMappingSuite) TestUserInfoFailureIsTolerated() {
+	user := s.baseUser(s.nextSubject())
+
+	defer s.mockOIDC.ClearOverrides()
+	s.mockOIDC.SetUserInfoResponseOverride(func() (int, string) {
+		return http.StatusInternalServerError, `{"error":"boom"}`
+	})
+
+	attributes := s.register(mapping(fedPersonType.Name,
+		pair("email", "username"), pair("given_name", "firstName"),
+	), user)
+
+	s.Equal("Federated", attributes["firstName"],
+		"authentication should continue on the ID token's claims when UserInfo fails")
+}
+
+// BO15: where both carry the same claim, the ID token's value wins. UserInfo only fills gaps.
+func (s *FederatedMappingSuite) TestIDTokenClaimWinsOverUserInfo() {
+	user := s.baseUser(s.nextSubject())
+
+	defer s.mockOIDC.ClearOverrides()
+	s.mockOIDC.SetUserInfoResponseOverride(func() (int, string) {
+		return http.StatusOK, `{"sub":"` + user.Sub + `","given_name":"FromUserInfo","locale":"fr"}`
+	})
+
+	attributes := s.register(mapping(fedPersonType.Name,
+		pair("email", "username"), pair("given_name", "firstName"),
+	), user)
+
+	s.Equal("Federated", attributes["firstName"],
+		"the ID token's given_name should win over the UserInfo one")
+}

--- a/tests/integration/federated/provider_test.go
+++ b/tests/integration/federated/provider_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package federated
+
+import (
+	"net/http"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+/*
+GitHub-specific behaviour.
+
+GitHub is the one provider here whose endpoints are not configurable: a GitHub connection carries none,
+so the harness rewrites the scheme and host of the hardcoded defaults to github_base_url in
+deployment.yaml, which is pinned to the mock's port. Paths are preserved, which is why the mock mirrors
+GitHub's real ones. It also has its own direct endpoints — the cross-type allowance covers OAUTH and OIDC
+only, so the standard pair rejects it as AUTHN-1003.
+
+What is GitHub-specific in the product is the email: the profile may carry no address at all, since
+GitHub hides them by default, so the authenticator falls back to the separate email API and takes the
+primary entry. Everything downstream depends on which address that produces.
+*/
+
+// githubIdentity registers a GitHub identity and returns the login the mock is keyed by.
+func (s *FederatedMappingSuite) githubIdentity(
+	publicEmail *string, emails []*testutils.GithubEmail) string {
+	s.T().Helper()
+	login := s.nextSubject()
+	s.subCounter++
+	s.mockGitHub.AddUser(&testutils.GithubUserInfo{
+		Login: login,
+		ID:    int64(1000 + s.subCounter),
+		Name:  "GitHub Test User",
+		Email: publicEmail,
+	}, emails)
+	return login
+}
+
+// authenticateGitHub applies a configuration to the GitHub connection and authenticates the identity
+// through GitHub's own direct endpoints.
+func (s *FederatedMappingSuite) authenticateGitHub(
+	config *testutils.AttributeConfiguration, login string) (int, testutils.AuthenticationResponse) {
+	s.T().Helper()
+	s.applyConfigTo("github", s.githubIDPID, config)
+	status, response, _ := s.authenticateVia(githubAuthStart, githubAuthFinish, s.githubIDPID, login)
+	return status, response
+}
+
+// linkOnEmail is the configuration these scenarios share: whichever address the authenticator settles on
+// is what resolves the local user, which is how the selection becomes observable.
+func linkOnEmail() *testutils.AttributeConfiguration {
+	config := mapping(fedPersonType.Name, pair("email", "email"))
+	config.AccountLinking = &testutils.AccountLinking{Attributes: []string{"email"}}
+	return config
+}
+
+// BO24: the profile carries no public address, so the primary entry from the email API is used. Note it
+// is not the first entry returned, which is what makes this worth asserting.
+func (s *FederatedMappingSuite) TestGitHubPrimaryEmailUsedWhenProfileHasNone() {
+	primary := s.nextSubject() + "@example.com"
+	other := s.nextSubject() + "@example.com"
+	login := s.githubIdentity(nil, []*testutils.GithubEmail{
+		{Email: other, Primary: false, Verified: true},
+		{Email: primary, Primary: true, Verified: true},
+	})
+
+	existingID := s.createLocalUser(map[string]interface{}{"username": primary, "email": primary})
+
+	status, response := s.authenticateGitHub(linkOnEmail(), login)
+
+	s.Require().Equal(http.StatusOK, status)
+	s.Equal(existingID, response.ID,
+		"the primary entry should be selected, not simply the first one returned")
+}
+
+// BO25: no entry is marked primary, so no address is produced.
+//
+// A local user is created holding the non-primary address deliberately. Without it the scenario would
+// pass whether the implementation correctly emitted nothing or incorrectly picked the non-primary
+// address, since neither would resolve anyone. With it present, an implementation that fell back to a
+// non-primary address would resolve that user and this test would fail — which is the only way the
+// assertion means anything.
+func (s *FederatedMappingSuite) TestGitHubWithoutPrimaryEmail() {
+	nonPrimary := s.nextSubject() + "@example.com"
+	login := s.githubIdentity(nil, []*testutils.GithubEmail{
+		{Email: nonPrimary, Primary: false, Verified: true},
+	})
+	s.createLocalUser(map[string]interface{}{"username": nonPrimary, "email": nonPrimary})
+
+	status, response := s.authenticateGitHub(linkOnEmail(), login)
+
+	s.NotEqual(http.StatusOK, status,
+		"with no primary address there is nothing to link on and nobody to resolve")
+	s.Empty(response.ID, "a non-primary address must not be used as a fallback")
+}
+
+// BO26: several entries claim to be primary. The selection must be deterministic rather than depending
+// on iteration order, or the same identity would resolve to different users between runs.
+func (s *FederatedMappingSuite) TestGitHubWithMultiplePrimaryEmails() {
+	first := s.nextSubject() + "@example.com"
+	second := s.nextSubject() + "@example.com"
+	login := s.githubIdentity(nil, []*testutils.GithubEmail{
+		{Email: first, Primary: true, Verified: true},
+		{Email: second, Primary: true, Verified: true},
+	})
+
+	firstID := s.createLocalUser(map[string]interface{}{"username": first, "email": first})
+	s.createLocalUser(map[string]interface{}{"username": second, "email": second})
+
+	status, response := s.authenticateGitHub(linkOnEmail(), login)
+
+	s.Require().Equal(http.StatusOK, status)
+	s.Equal(firstID, response.ID,
+		"the first primary entry should win, so the selection is stable across runs")
+}
+
+// BO27: GitHub's human identifier is its login, not an address. Mapping it onto a local attribute and
+// linking on that is how a GitHub identity resolves without relying on email at all.
+//
+// This runs through the direct endpoint rather than a flow; GithubOAuthExecutor as a flow node is a
+// separate concern. What is proven here is the login claim's mapping and its use as a linking key.
+func (s *FederatedMappingSuite) TestGitHubLoginMappedAndUsedForLinking() {
+	primary := s.nextSubject() + "@example.com"
+	login := s.githubIdentity(nil, []*testutils.GithubEmail{
+		{Email: primary, Primary: true, Verified: true},
+	})
+
+	// The local user is identified by its username, which the login claim maps onto.
+	existingID := s.createLocalUser(map[string]interface{}{"username": login, "email": primary})
+
+	config := mapping(fedPersonType.Name, pair("login", "username"))
+	config.AccountLinking = &testutils.AccountLinking{Attributes: []string{"login"}}
+	status, response := s.authenticateGitHub(config, login)
+
+	s.Require().Equal(http.StatusOK, status)
+	s.Equal(existingID, response.ID,
+		"the login claim should map onto username and resolve the user through it")
+}

--- a/tests/integration/federated/resolution_test.go
+++ b/tests/integration/federated/resolution_test.go
@@ -1,0 +1,179 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package federated
+
+import "github.com/thunder-id/thunderid/tests/integration/testutils"
+
+/*
+User-type resolution selects which attribute-mapping profile applies. It does NOT decide which user type
+the identity provisions into — GetMappedUserType has a single consumer, GetAttributeMappings, and neither
+the provisioning executor nor the user-type resolver executor reads the connection at all. That is
+recorded as G17, because the naming invites the opposite reading.
+
+Every scenario here therefore observes *which profile was applied*, by keying the two profiles to the
+same local target with different sources: the person profile fills firstName from given_name, the
+contractor profile fills it from family_name. The value of firstName on the provisioned user names the
+profile that won.
+*/
+
+// twoProfiles builds a configuration carrying one profile per user type, distinguishable by the value
+// each writes into firstName. Both also map the username, so provisioning completes either way and a
+// failure to provision means no profile matched at all.
+func (s *FederatedMappingSuite) twoProfiles(
+	resolution *testutils.UserTypeResolution) *testutils.AttributeConfiguration {
+	return &testutils.AttributeConfiguration{
+		UserTypeResolution: resolution,
+		UserTypeAttributeMappings: []testutils.UserTypeAttributeMapping{
+			{UserType: fedPersonType.Name, Attributes: []testutils.AttributeMapping{
+				pair("email", "username"), pair("given_name", "firstName"),
+			}},
+			{UserType: fedContractorType.Name, Attributes: []testutils.AttributeMapping{
+				pair("email", "username"), pair("family_name", "firstName"),
+			}},
+		},
+	}
+}
+
+const (
+	// The claim values the two profiles write into firstName, used to identify which one applied.
+	personProfileMarker     = "Federated" // given_name
+	contractorProfileMarker = "User"      // family_name
+)
+
+// B6: a value mapping whose key matches the incoming claim selects the profile it names.
+func (s *FederatedMappingSuite) TestValueMappingHitSelectsThatProfile() {
+	user := s.baseUser(s.nextSubject())
+	user.Custom["employment"] = "staff"
+
+	attributes := s.register(s.twoProfiles(&testutils.UserTypeResolution{
+		Default:           fedPersonType.Name,
+		ExternalAttribute: "employment",
+		ValueMapping:      map[string]string{"staff": fedContractorType.Name},
+	}), user)
+
+	s.Equal(contractorProfileMarker, attributes["firstName"],
+		"the mapped profile should have been applied, not the default one")
+}
+
+// B7: a claim value absent from the value mapping falls back to the default profile.
+func (s *FederatedMappingSuite) TestValueMappingMissFallsBackToDefaultProfile() {
+	user := s.baseUser(s.nextSubject())
+	user.Custom["employment"] = "visitor"
+
+	attributes := s.register(s.twoProfiles(&testutils.UserTypeResolution{
+		Default:           fedPersonType.Name,
+		ExternalAttribute: "employment",
+		ValueMapping:      map[string]string{"staff": fedContractorType.Name},
+	}), user)
+
+	s.Equal(personProfileMarker, attributes["firstName"],
+		"an unmapped claim value should fall back to the default profile")
+}
+
+// B8: with no value mapping configured, the claim value is used directly as the profile key.
+func (s *FederatedMappingSuite) TestDirectClaimValueSelectsProfile() {
+	user := s.baseUser(s.nextSubject())
+	user.Custom["profile_type"] = fedContractorType.Name
+
+	attributes := s.register(s.twoProfiles(&testutils.UserTypeResolution{
+		Default:           fedPersonType.Name,
+		ExternalAttribute: "profile_type",
+	}), user)
+
+	s.Equal(contractorProfileMarker, attributes["firstName"],
+		"the claim value should be used directly as the profile key")
+}
+
+// B9: the external attribute may be a dot-notation path into a nested claim.
+func (s *FederatedMappingSuite) TestNestedResolutionClaimSelectsProfile() {
+	user := s.baseUser(s.nextSubject())
+	user.Custom["profile"] = map[string]interface{}{"tier": "staff"}
+
+	attributes := s.register(s.twoProfiles(&testutils.UserTypeResolution{
+		Default:           fedPersonType.Name,
+		ExternalAttribute: "profile.tier",
+		ValueMapping:      map[string]string{"staff": fedContractorType.Name},
+	}), user)
+
+	s.Equal(contractorProfileMarker, attributes["firstName"],
+		"resolution should traverse the nested claim path")
+}
+
+// BR17: the two resolution branches treat whitespace differently. Direct resolution trims the claim
+// before using it as the profile key; a value-mapping lookup uses the raw string, so a padded value
+// misses and falls back to the default.
+func (s *FederatedMappingSuite) TestResolutionWhitespaceHandlingDiffersByBranch() {
+	direct := s.baseUser(s.nextSubject())
+	direct.Custom["profile_type"] = "  " + fedContractorType.Name + "  "
+
+	attributes := s.register(s.twoProfiles(&testutils.UserTypeResolution{
+		Default:           fedPersonType.Name,
+		ExternalAttribute: "profile_type",
+	}), direct)
+	s.Equal(contractorProfileMarker, attributes["firstName"],
+		"direct resolution trims the claim value before using it")
+
+	mapped := s.baseUser(s.nextSubject())
+	mapped.Custom["employment"] = "  staff  "
+
+	attributes = s.register(s.twoProfiles(&testutils.UserTypeResolution{
+		Default:           fedPersonType.Name,
+		ExternalAttribute: "employment",
+		ValueMapping:      map[string]string{"staff": fedContractorType.Name},
+	}), mapped)
+	s.Equal(personProfileMarker, attributes["firstName"],
+		"a value-mapping lookup does not trim, so a padded value misses and falls back")
+}
+
+// BR18: neither branch case-folds. A value-mapping key must match exactly, and a directly used claim
+// value that differs in case names no profile at all — which surfaces as a prompt, because no mapping
+// then supplies the required username.
+func (s *FederatedMappingSuite) TestResolutionIsCaseSensitive() {
+	mapped := s.baseUser(s.nextSubject())
+	mapped.Custom["employment"] = "STAFF"
+
+	attributes := s.register(s.twoProfiles(&testutils.UserTypeResolution{
+		Default:           fedPersonType.Name,
+		ExternalAttribute: "employment",
+		ValueMapping:      map[string]string{"staff": fedContractorType.Name},
+	}), mapped)
+	s.Equal(personProfileMarker, attributes["firstName"],
+		"a value-mapping key is matched exactly, so different casing misses")
+
+	direct := s.baseUser(s.nextSubject())
+	direct.Custom["profile_type"] = "FED_CONTRACTOR"
+
+	step := s.registerExpectingPrompt(s.twoProfiles(&testutils.UserTypeResolution{
+		Default:           fedPersonType.Name,
+		ExternalAttribute: "profile_type",
+	}), direct)
+	s.assertPromptsFor(step, "username")
+}
+
+// BR19: a non-string claim is stringified before it is used as the profile key, so numeric and boolean
+// claims resolve rather than being ignored. JSON numbers arrive as float64, which is why that is the
+// case worth pinning.
+func (s *FederatedMappingSuite) TestNonStringResolutionClaimIsStringified() {
+	numeric := s.baseUser(s.nextSubject())
+	numeric.Custom["level"] = 3
+
+	attributes := s.register(s.twoProfiles(&testutils.UserTypeResolution{
+		Default:           fedPersonType.Name,
+		ExternalAttribute: "level",
+		ValueMapping:      map[string]string{"3": fedContractorType.Name},
+	}), numeric)
+	s.Equal(contractorProfileMarker, attributes["firstName"],
+		"a numeric claim should stringify to its decimal form and match the mapping key")
+
+	boolean := s.baseUser(s.nextSubject())
+	boolean.Custom["contractor"] = true
+
+	attributes = s.register(s.twoProfiles(&testutils.UserTypeResolution{
+		Default:           fedPersonType.Name,
+		ExternalAttribute: "contractor",
+		ValueMapping:      map[string]string{"true": fedContractorType.Name},
+	}), boolean)
+	s.Equal(contractorProfileMarker, attributes["firstName"],
+		"a boolean claim should stringify to true/false")
+}

--- a/tests/integration/federated/suite_test.go
+++ b/tests/integration/federated/suite_test.go
@@ -1,0 +1,803 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Federated attribute-mapping and user-type-resolution integration tests.
+
+These exercise a generic OIDC connection end to end: a mock IdP returns claims, a registration flow
+provisions a local user from them, and the assertions read the provisioned user back through the API.
+Mapped claim *values* are not observable on the direct /auth endpoints, whose response carries only
+{id, type, ouId, assertion}, so provisioning is the only surface that shows what a mapping produced.
+
+One connection, one flow and one application are created for the whole suite; each test PUTs the
+attributeConfiguration it needs onto that connection and drives the flow with its own mock user. That
+avoids standing up a flow per scenario, and keeps the mock claim set and the configuration under test
+next to each other in the test body.
+*/
+package federated
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// mockOIDCPort is 8100 because 8092-8099, 9091 and 9092 are already bound by other suites, and
+// 8092/8093 are additionally pinned to the GitHub and Google mocks by the deployment.yaml override in
+// testutils/test_utils.go.
+const (
+	mockOIDCPort  = 8100
+	mockOAuthPort = 8101
+
+	// The GitHub mock must bind 8092: Google and GitHub connections carry no configurable endpoints,
+	// so the harness rewrites the scheme and host of their hardcoded defaults to the base URLs in
+	// deployment.yaml, and github_base_url is pinned to this port. Paths are preserved, which is why
+	// the mock mirrors GitHub's real ones.
+	mockGitHubPort = 8092
+)
+
+const (
+	oidcClientID     = "federated-test-client"
+	oidcClientSecret = "federated-test-secret"
+)
+
+// fedPersonType is the type identities provision into. It carries every mapping target the scenarios
+// use. email is required and unique so this type does not suppress the deployment-wide email
+// account-linking default for other suites; costCenter is deliberately not unique, since a linking
+// attribute that allows duplicates is what the ambiguity scenarios need in a later phase.
+var fedPersonType = testutils.UserType{
+	Name:                  "fed_person",
+	AllowSelfRegistration: true,
+	Schema: map[string]interface{}{
+		"username":   map[string]interface{}{"type": "string", "required": true, "unique": true},
+		"email":      map[string]interface{}{"type": "string", "required": true, "unique": true},
+		"firstName":  map[string]interface{}{"type": "string"},
+		"lastName":   map[string]interface{}{"type": "string"},
+		"city":       map[string]interface{}{"type": "string"},
+		"costCenter": map[string]interface{}{"type": "string"},
+		"sub":        map[string]interface{}{"type": "string"},
+	},
+}
+
+// fedContractorType exists so a second mapping profile can be keyed to it. Nothing provisions into it:
+// userTypeResolution selects which profile applies, not which type the identity becomes (G17), so this
+// type is never a provisioning target and deliberately does not allow self registration — that also
+// keeps the flow's user-type resolution unambiguous.
+var fedContractorType = testutils.UserType{
+	Name:                  "fed_contractor",
+	AllowSelfRegistration: false,
+	Schema: map[string]interface{}{
+		"username":       map[string]interface{}{"type": "string", "required": true, "unique": true},
+		"email":          map[string]interface{}{"type": "string", "required": true, "unique": true},
+		"firstName":      map[string]interface{}{"type": "string"},
+		"employeeNumber": map[string]interface{}{"type": "string"},
+		"sub":            map[string]interface{}{"type": "string"},
+	},
+}
+
+var fedTestOU = testutils.OrganizationUnit{
+	Handle:      "federated-mapping-ou",
+	Name:        "Federated Mapping Test OU",
+	Description: "Organization unit for federated attribute mapping tests",
+	Parent:      nil,
+}
+
+// fedRegistrationFlow provisions a local user from the federated identity. The node list mirrors the
+// proven Google registration flow, with the generic OIDCAuthExecutor in place of the Google one.
+var fedRegistrationFlow = testutils.Flow{
+	Name:     "Federated Mapping Registration Flow",
+	FlowType: "REGISTRATION",
+	Handle:   "registration_flow_federated_mapping",
+	Nodes: []map[string]interface{}{
+		{"id": "start", "type": "START", "onSuccess": "user_type_resolver"},
+		{
+			// REGISTRATION flows are required to carry a UserTypeResolver. The application allows a single
+			// user type, so it resolves without input and the prompt below is never reached; it exists
+			// because onIncomplete must name a node.
+			"id":           "user_type_resolver",
+			"type":         "TASK_EXECUTION",
+			"executor":     map[string]interface{}{"name": "UserTypeResolver"},
+			"onSuccess":    "oidc_auth",
+			"onIncomplete": "prompt_usertype",
+		},
+		{
+			"id":   "prompt_usertype",
+			"type": "PROMPT",
+			"meta": map[string]interface{}{
+				"components": []map[string]interface{}{
+					{
+						"type": "BLOCK",
+						"id":   "block_usertype",
+						"components": []map[string]interface{}{
+							{
+								"type": "SELECT", "id": "usertype_input", "ref": "userType",
+								"label": "User Type", "required": true, "options": []interface{}{},
+							},
+							{
+								"type": "ACTION", "id": "action_usertype",
+								"label": "Continue", "variant": "PRIMARY", "eventType": "SUBMIT",
+							},
+						},
+					},
+				},
+			},
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{"ref": "usertype_input", "identifier": "userType", "type": "SELECT", "required": true},
+					},
+					"action": map[string]interface{}{"ref": "action_usertype", "nextNode": "user_type_resolver"},
+				},
+			},
+		},
+		{
+			"id":         "oidc_auth",
+			"type":       "TASK_EXECUTION",
+			"properties": map[string]interface{}{"idpId": "placeholder-idp-id"},
+			"executor":   map[string]interface{}{"name": "OIDCAuthExecutor"},
+			"onSuccess":  "provisioning",
+		},
+		{
+			"id":        "provisioning",
+			"type":      "TASK_EXECUTION",
+			"executor":  map[string]interface{}{"name": "ProvisioningExecutor"},
+			"onSuccess": "auth_assert",
+		},
+		{
+			"id":        "auth_assert",
+			"type":      "TASK_EXECUTION",
+			"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+			"onSuccess": "end",
+		},
+		{"id": "end", "type": "END"},
+	},
+}
+
+// fedAuthFlow authenticates an existing local user through the federated connection. The federated node
+// allows authentication without a local user, so an unmatched identity proceeds instead of failing —
+// that branch is the one piece of executor behaviour that depends on the flow type.
+var fedAuthFlow = testutils.Flow{
+	Name:     "Federated Mapping Authentication Flow",
+	FlowType: "AUTHENTICATION",
+	Handle:   "auth_flow_federated_mapping",
+	Nodes: []map[string]interface{}{
+		{"id": "start", "type": "START", "onSuccess": "oidc_auth"},
+		{
+			"id":   "oidc_auth",
+			"type": "TASK_EXECUTION",
+			"properties": map[string]interface{}{
+				"idpId":                               "placeholder-idp-id",
+				"allowAuthenticationWithoutLocalUser": true,
+			},
+			"executor":  map[string]interface{}{"name": "OIDCAuthExecutor"},
+			"onSuccess": "provisioning",
+		},
+		{
+			// The allowance only marks the identity eligible for provisioning; a flow still has to carry
+			// a provisioning step for an unmatched identity to become a user. Without one the flow reaches
+			// the assertion with nothing to assert about.
+			"id":        "provisioning",
+			"type":      "TASK_EXECUTION",
+			"executor":  map[string]interface{}{"name": "ProvisioningExecutor"},
+			"onSuccess": "auth_assert",
+		},
+		{
+			"id":        "auth_assert",
+			"type":      "TASK_EXECUTION",
+			"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+			"onSuccess": "end",
+		},
+		{"id": "end", "type": "END"},
+	},
+}
+
+// fedStrictAuthFlow is the same graph without the property, so an unmatched identity has nothing to
+// authenticate and the flow cannot complete.
+var fedStrictAuthFlow = testutils.Flow{
+	Name:     "Federated Mapping Strict Authentication Flow",
+	FlowType: "AUTHENTICATION",
+	Handle:   "auth_flow_federated_mapping_strict",
+	Nodes: []map[string]interface{}{
+		{"id": "start", "type": "START", "onSuccess": "oidc_auth"},
+		{
+			"id":         "oidc_auth",
+			"type":       "TASK_EXECUTION",
+			"properties": map[string]interface{}{"idpId": "placeholder-idp-id"},
+			"executor":   map[string]interface{}{"name": "OIDCAuthExecutor"},
+			"onSuccess":  "auth_assert",
+		},
+		{
+			"id":        "auth_assert",
+			"type":      "TASK_EXECUTION",
+			"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+			"onSuccess": "end",
+		},
+		{"id": "end", "type": "END"},
+	},
+}
+
+// fedOAuthFlow is the generic OAuth counterpart of the strict OIDC authentication flow, so the
+// OAuthExecutor is driven as a flow node rather than only through the direct endpoints.
+var fedOAuthFlow = testutils.Flow{
+	Name:     "Federated Mapping OAuth Authentication Flow",
+	FlowType: "AUTHENTICATION",
+	Handle:   "auth_flow_federated_mapping_oauth",
+	Nodes: []map[string]interface{}{
+		{"id": "start", "type": "START", "onSuccess": "oidc_auth"},
+		{
+			// The node id stays oidc_auth so the shared connection-id patcher finds it.
+			"id":         "oidc_auth",
+			"type":       "TASK_EXECUTION",
+			"properties": map[string]interface{}{"idpId": "placeholder-idp-id"},
+			"executor":   map[string]interface{}{"name": "OAuthExecutor"},
+			"onSuccess":  "auth_assert",
+		},
+		{
+			"id":        "auth_assert",
+			"type":      "TASK_EXECUTION",
+			"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+			"onSuccess": "end",
+		},
+		{"id": "end", "type": "END"},
+	},
+}
+
+var fedOAuthApp = testutils.Application{
+	Name:             "Federated OAuth Authentication Test Application",
+	Description:      "Application whose authentication flow uses the generic OAuth executor",
+	ClientID:         "federated_oauth_auth_test_client",
+	ClientSecret:     "federated_oauth_auth_test_secret",
+	RedirectURIs:     []string{"http://localhost:3000/callback"},
+	AllowedUserTypes: []string{fedPersonType.Name},
+	AssertionConfig: map[string]interface{}{
+		"userAttributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+	},
+}
+
+var fedAuthApp = testutils.Application{
+	Name:             "Federated Authentication Test Application",
+	Description:      "Application whose authentication flow allows an unmatched federated identity",
+	ClientID:         "federated_auth_test_client",
+	ClientSecret:     "federated_auth_test_secret",
+	RedirectURIs:     []string{"http://localhost:3000/callback"},
+	AllowedUserTypes: []string{fedPersonType.Name},
+	AssertionConfig: map[string]interface{}{
+		"userAttributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+	},
+}
+
+var fedStrictAuthApp = testutils.Application{
+	Name:             "Federated Strict Authentication Test Application",
+	Description:      "Application whose authentication flow requires a local user",
+	ClientID:         "federated_strict_auth_test_client",
+	ClientSecret:     "federated_strict_auth_test_secret",
+	RedirectURIs:     []string{"http://localhost:3000/callback"},
+	AllowedUserTypes: []string{fedPersonType.Name},
+	AssertionConfig: map[string]interface{}{
+		"userAttributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+	},
+}
+
+var fedTestApp = testutils.Application{
+	Name:                      "Federated Mapping Test Application",
+	Description:               "Application for federated attribute mapping tests",
+	IsRegistrationFlowEnabled: true,
+	ClientID:                  "federated_mapping_test_client",
+	ClientSecret:              "federated_mapping_test_secret",
+	RedirectURIs:              []string{"http://localhost:3000/callback"},
+	AllowedUserTypes:          []string{fedPersonType.Name},
+	AssertionConfig: map[string]interface{}{
+		"userAttributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+	},
+}
+
+type FederatedMappingSuite struct {
+	suite.Suite
+	mockOIDC        *testutils.MockOIDCServer
+	ouID            string
+	typeIDs         []string
+	idpID           string
+	appID           string
+	authAppID       string
+	strictAuthAppID string
+	config          *common.TestSuiteConfig
+	activeSub       string
+	subCounter      int
+	jwksSuffix      string
+	mockOAuth       *testutils.MockOAuthServer
+	oauthIDPID      string
+	oauthAppID      string
+	mockGitHub      *testutils.MockGithubOAuthServer
+	githubIDPID     string
+	perTestAppIDs   []string
+	perTestFlowIDs  []string
+}
+
+func TestFederatedMappingSuite(t *testing.T) {
+	suite.Run(t, new(FederatedMappingSuite))
+}
+
+func (s *FederatedMappingSuite) SetupSuite() {
+	s.config = &common.TestSuiteConfig{}
+
+	mock, err := testutils.NewMockOIDCServer(mockOIDCPort, oidcClientID, oidcClientSecret)
+	s.Require().NoError(err, "failed to create mock OIDC server")
+	s.mockOIDC = mock
+
+	// The mock authorizes whichever subject the running test selected, so each scenario controls the
+	// exact claim set it is asserting on.
+	s.mockOIDC.SetAuthorizeFunc(func(string) (string, error) {
+		if s.activeSub == "" {
+			return "", fmt.Errorf("no active subject selected by the test")
+		}
+		return s.activeSub, nil
+	})
+	s.Require().NoError(s.mockOIDC.Start(), "failed to start mock OIDC server")
+
+	ouID, err := testutils.CreateOrganizationUnit(fedTestOU)
+	s.Require().NoError(err, "failed to create organization unit")
+	s.ouID = ouID
+
+	for _, userType := range []testutils.UserType{fedPersonType, fedContractorType} {
+		userType.OUID = ouID
+		typeID, err := testutils.CreateUserType(userType)
+		s.Require().NoError(err, "failed to create user type %s", userType.Name)
+		s.typeIDs = append(s.typeIDs, typeID)
+	}
+
+	idpID, err := testutils.CreateIDP(s.idpFixture(nil))
+	s.Require().NoError(err, "failed to create OIDC connection")
+	s.idpID = idpID
+	s.config.CreatedIdpIDs = append(s.config.CreatedIdpIDs, idpID)
+
+	// Located by node id rather than index: the node list has already gained a required executor once,
+	// and an index would have silently written the connection id onto the wrong node.
+	nodes := fedRegistrationFlow.Nodes.([]map[string]interface{})
+	var patched bool
+	for _, node := range nodes {
+		if node["id"] == "oidc_auth" {
+			node["properties"].(map[string]interface{})["idpId"] = idpID
+			patched = true
+		}
+	}
+	s.Require().True(patched, "the flow must contain an oidc_auth node to carry the connection id")
+	fedRegistrationFlow.Nodes = nodes
+
+	flowID, err := testutils.CreateFlow(fedRegistrationFlow)
+	s.Require().NoError(err, "failed to create registration flow")
+	s.config.CreatedFlowIDs = append(s.config.CreatedFlowIDs, flowID)
+	fedTestApp.RegistrationFlowID = flowID
+
+	authFlowID, err := testutils.CreateIsolatedAuthFlow("federated-mapping-isolated-auth")
+	s.Require().NoError(err, "failed to create isolated auth flow")
+	s.config.CreatedFlowIDs = append(s.config.CreatedFlowIDs, authFlowID)
+	fedTestApp.AuthFlowID = authFlowID
+
+	fedTestApp.OUID = ouID
+	appID, err := testutils.CreateApplication(fedTestApp)
+	s.Require().NoError(err, "failed to create application")
+	s.appID = appID
+
+	oauthMock := testutils.NewMockOAuthServer(mockOAuthPort, oidcClientID, oidcClientSecret)
+	s.Require().NoError(oauthMock.Start(), "failed to start mock OAuth server")
+	s.mockOAuth = oauthMock
+	s.mockOAuth.SetAuthorizeFunc(func(string) (string, error) {
+		if s.activeSub == "" {
+			return "", fmt.Errorf("no active subject selected by the test")
+		}
+		return s.activeSub, nil
+	})
+
+	oauthIDPID, err := testutils.CreateIDP(testutils.IDP{
+		Name: "Federated Mapping OAuth Connection", Type: "OAUTH",
+		Properties: []testutils.IDPProperty{
+			{Name: "client_id", Value: oidcClientID},
+			{Name: "client_secret", Value: oidcClientSecret, IsSecret: true},
+			{Name: "redirect_uri", Value: "http://localhost:3000/callback"},
+			{Name: "authorization_endpoint", Value: s.mockOAuth.GetAuthorizeURL()},
+			{Name: "token_endpoint", Value: s.mockOAuth.GetTokenURL()},
+			{Name: "userinfo_endpoint", Value: s.mockOAuth.GetUserInfoURL()},
+			{Name: "scopes", Value: "openid,email,profile"},
+		},
+	})
+	s.Require().NoError(err, "failed to create OAuth connection")
+	s.oauthIDPID = oauthIDPID
+
+	githubMock := testutils.NewMockGithubOAuthServer(mockGitHubPort, oidcClientID, oidcClientSecret)
+	s.Require().NoError(githubMock.Start(), "failed to start mock GitHub server")
+	s.mockGitHub = githubMock
+	// Without this the mock authorizes whichever user it happens to hold first, so a scenario's
+	// selection is ignored and its identity never matches.
+	s.mockGitHub.SetAuthorizeFunc(func(string) (string, error) {
+		if s.activeSub == "" {
+			return "", fmt.Errorf("no active subject selected by the test")
+		}
+		return s.activeSub, nil
+	})
+
+	// No endpoints are set: a GitHub connection has none to set, and supplying them would bypass the
+	// base-URL override that points the defaults at the mock.
+	githubIDPID, err := testutils.CreateIDP(testutils.IDP{
+		Name: "Federated Mapping GitHub Connection", Type: "GITHUB",
+		Properties: []testutils.IDPProperty{
+			{Name: "client_id", Value: oidcClientID},
+			{Name: "client_secret", Value: oidcClientSecret, IsSecret: true},
+			{Name: "redirect_uri", Value: "http://localhost:3000/callback"},
+		},
+	})
+	s.Require().NoError(err, "failed to create GitHub connection")
+	s.githubIDPID = githubIDPID
+
+	s.authAppID = s.createAuthApp(&fedAuthFlow, fedAuthApp, idpID, ouID, "federated-auth-isolated-reg")
+	s.strictAuthAppID = s.createAuthApp(
+		&fedStrictAuthFlow, fedStrictAuthApp, idpID, ouID, "federated-strict-auth-isolated-reg")
+	s.oauthAppID = s.createAuthApp(
+		&fedOAuthFlow, fedOAuthApp, oauthIDPID, ouID, "federated-oauth-auth-isolated-reg")
+}
+
+// createAuthApp creates one authentication flow and the application that runs it. Both applications
+// need a registration flow of their own, because an application referencing another application's flow
+// fails cross-type reference validation.
+func (s *FederatedMappingSuite) createAuthApp(
+	flow *testutils.Flow, app testutils.Application, idpID, ouID, regFlowHandle string) string {
+	s.T().Helper()
+
+	nodes := flow.Nodes.([]map[string]interface{})
+	var patched bool
+	for _, node := range nodes {
+		if node["id"] == "oidc_auth" {
+			node["properties"].(map[string]interface{})["idpId"] = idpID
+			patched = true
+		}
+	}
+	s.Require().True(patched, "the authentication flow must contain an oidc_auth node")
+	flow.Nodes = nodes
+
+	flowID, err := testutils.CreateFlow(*flow)
+	s.Require().NoError(err, "failed to create authentication flow %s", flow.Handle)
+	s.config.CreatedFlowIDs = append(s.config.CreatedFlowIDs, flowID)
+
+	regFlowID, err := testutils.CreateIsolatedRegistrationFlow(regFlowHandle)
+	s.Require().NoError(err, "failed to create isolated registration flow %s", regFlowHandle)
+	s.config.CreatedFlowIDs = append(s.config.CreatedFlowIDs, regFlowID)
+
+	app.OUID = ouID
+	app.AuthFlowID = flowID
+	app.RegistrationFlowID = regFlowID
+	appID, err := testutils.CreateApplication(app)
+	s.Require().NoError(err, "failed to create application %s", app.Name)
+	return appID
+}
+
+// createScenarioApp creates a flow and an application that runs it, for scenarios whose whole point is a
+// graph the shared flows cannot express. Both are torn down after the test.
+func (s *FederatedMappingSuite) createScenarioApp(flow testutils.Flow, clientID string) string {
+	s.T().Helper()
+	flowID, err := testutils.CreateFlow(flow)
+	s.Require().NoError(err, "failed to create flow %s", flow.Handle)
+	s.perTestFlowIDs = append(s.perTestFlowIDs, flowID)
+
+	regFlowID, err := testutils.CreateIsolatedRegistrationFlow(clientID + "-reg")
+	s.Require().NoError(err, "failed to create the isolated registration flow")
+	s.perTestFlowIDs = append(s.perTestFlowIDs, regFlowID)
+
+	appID, err := testutils.CreateApplication(testutils.Application{
+		Name:               "Scenario App " + clientID,
+		ClientID:           clientID,
+		ClientSecret:       clientID + "-secret",
+		RedirectURIs:       []string{"http://localhost:3000/callback"},
+		AllowedUserTypes:   []string{fedPersonType.Name},
+		OUID:               s.ouID,
+		AuthFlowID:         flowID,
+		RegistrationFlowID: regFlowID,
+		AssertionConfig: map[string]interface{}{
+			"userAttributes": []string{"userType", "ouId"},
+		},
+	})
+	s.Require().NoError(err, "failed to create the scenario application")
+	s.perTestAppIDs = append(s.perTestAppIDs, appID)
+	return appID
+}
+
+func (s *FederatedMappingSuite) TearDownTest() {
+	s.jwksSuffix = ""
+	for _, appID := range s.perTestAppIDs {
+		if err := testutils.DeleteApplication(appID); err != nil {
+			s.T().Logf("failed to delete scenario application: %v", err)
+		}
+	}
+	s.perTestAppIDs = nil
+	for _, flowID := range s.perTestFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			s.T().Logf("failed to delete scenario flow: %v", err)
+		}
+	}
+	s.perTestFlowIDs = nil
+	if len(s.config.CreatedUserIDs) > 0 {
+		if err := testutils.CleanupUsers(s.config.CreatedUserIDs); err != nil {
+			s.T().Logf("failed to clean up users: %v", err)
+		}
+		s.config.CreatedUserIDs = nil
+	}
+}
+
+func (s *FederatedMappingSuite) TearDownSuite() {
+	for _, appID := range []string{s.appID, s.authAppID, s.strictAuthAppID, s.oauthAppID} {
+		if appID == "" {
+			continue
+		}
+		if err := testutils.DeleteApplication(appID); err != nil {
+			s.T().Logf("failed to delete application %s: %v", appID, err)
+		}
+	}
+	for _, flowID := range s.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			s.T().Logf("failed to delete flow %s: %v", flowID, err)
+		}
+	}
+	if s.idpID != "" {
+		if err := testutils.DeleteIDP(s.idpID); err != nil {
+			s.T().Logf("failed to delete connection: %v", err)
+		}
+	}
+	for _, typeID := range s.typeIDs {
+		if err := testutils.DeleteUserType(typeID); err != nil {
+			s.T().Logf("failed to delete user type %s: %v", typeID, err)
+		}
+	}
+	if s.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(s.ouID); err != nil {
+			s.T().Logf("failed to delete organization unit: %v", err)
+		}
+	}
+	for _, id := range []string{s.oauthIDPID, s.githubIDPID} {
+		if id == "" {
+			continue
+		}
+		if err := testutils.DeleteIDP(id); err != nil {
+			s.T().Logf("failed to delete connection %s: %v", id, err)
+		}
+	}
+	if s.mockOAuth != nil {
+		if err := s.mockOAuth.Stop(); err != nil {
+			s.T().Logf("failed to stop mock OAuth server: %v", err)
+		}
+	}
+	if s.mockGitHub != nil {
+		if err := s.mockGitHub.Stop(); err != nil {
+			s.T().Logf("failed to stop mock GitHub server: %v", err)
+		}
+	}
+	if s.mockOIDC != nil {
+		if err := s.mockOIDC.Stop(); err != nil {
+			s.T().Logf("failed to stop mock OIDC server: %v", err)
+		}
+	}
+}
+
+// idpFixture builds the connection body. The JWKS endpoint is configured so ID-token signatures are
+// actually verified rather than skipped.
+func (s *FederatedMappingSuite) idpFixture(config *testutils.AttributeConfiguration) testutils.IDP {
+	return testutils.IDP{
+		Name:        "Federated Mapping OIDC Connection",
+		Description: "Generic OIDC connection for federated attribute mapping tests",
+		Type:        "OIDC",
+		Properties: []testutils.IDPProperty{
+			{Name: "client_id", Value: oidcClientID},
+			{Name: "client_secret", Value: oidcClientSecret, IsSecret: true},
+			{Name: "redirect_uri", Value: "http://localhost:3000/callback"},
+			{Name: "authorization_endpoint", Value: s.mockOIDC.GetAuthorizeURL()},
+			{Name: "token_endpoint", Value: s.mockOIDC.GetTokenURL()},
+			{Name: "userinfo_endpoint", Value: s.mockOIDC.GetUserInfoURL()},
+			{Name: "jwks_endpoint", Value: s.mockOIDC.GetJWKSURL() + s.jwksSuffix},
+			{Name: "scopes", Value: "openid,email,profile"},
+		},
+		AttributeConfiguration: config,
+	}
+}
+
+// setOAuthScopes rewrites just the scopes on the OAuth connection, for the delimiter scenarios.
+func (s *FederatedMappingSuite) setOAuthScopes(scopes string) {
+	s.T().Helper()
+	current, err := testutils.GetIDP("oauth", s.oauthIDPID)
+	s.Require().NoError(err, "failed to read the OAuth connection")
+	s.Require().NotNil(current)
+
+	// The masked secret must not be echoed back, and the scopes property is replaced rather than appended.
+	kept := current.Properties[:0]
+	for _, property := range current.Properties {
+		if property.Name == "client_secret" || property.Name == "scopes" {
+			continue
+		}
+		kept = append(kept, property)
+	}
+	if scopes != "" {
+		kept = append(kept, testutils.IDPProperty{Name: "scopes", Value: scopes})
+	}
+	current.Properties = kept
+	s.Require().NoError(testutils.UpdateIDP(s.oauthIDPID, *current), "failed to set scopes")
+}
+
+// applyConfigTo replaces the attribute configuration of a connection, which must be addressed under its
+// own vendor path. Errors are asserted rather than swallowed: an earlier version returned silently on a
+// failed read, which turned a wrong-vendor 404 into "the configuration simply never applied" and made
+// the GitHub scenarios fail somewhere unrelated.
+func (s *FederatedMappingSuite) applyConfigTo(
+	vendor, idpID string, config *testutils.AttributeConfiguration) {
+	s.T().Helper()
+	current, err := testutils.GetIDP(vendor, idpID)
+	s.Require().NoError(err, "failed to read the %s connection", vendor)
+	s.Require().NotNil(current, "the %s connection should exist", vendor)
+	current.AttributeConfiguration = config
+
+	// The read-back carries the secret masked as ******. Sending that straight back would overwrite the
+	// stored credential with the mask and every later token exchange would fail with invalid_client —
+	// which is exactly what happened before this filter existed. The API preserves the stored secret
+	// when the field is omitted, so the masked property is dropped rather than echoed.
+	kept := current.Properties[:0]
+	for _, property := range current.Properties {
+		if property.Name == "client_secret" {
+			continue
+		}
+		kept = append(kept, property)
+	}
+	current.Properties = kept
+
+	s.Require().NoError(testutils.UpdateIDP(idpID, *current), "failed to apply the configuration")
+}
+
+// jsonUnmarshal is a thin wrapper so callers can decode without importing encoding/json twice.
+func jsonUnmarshal(data []byte, target interface{}) error {
+	return json.Unmarshal(data, target)
+}
+
+// applyConfig replaces the connection's attribute configuration. Update never re-seeds, so what is sent
+// here is exactly what the runtime reads.
+func (s *FederatedMappingSuite) applyConfig(config *testutils.AttributeConfiguration) {
+	s.T().Helper()
+	s.Require().NoError(testutils.UpdateIDP(s.idpID, s.idpFixture(config)),
+		"failed to apply the attribute configuration under test")
+}
+
+// useFreshJWKS points the connection at a JWKS URL nothing has fetched yet.
+//
+// The verifier caches key sets by URL with a TTL (jwt/service.go:381), so a suite that has already
+// authenticated once holds a warm entry and never re-fetches. Without this, a test that breaks or
+// rotates the published keys would still authenticate from the cache — which is exactly what happened
+// before this existed, and it made four scenarios pass for the wrong reason. The query string only
+// changes the cache key; the mock routes on path and ignores it.
+func (s *FederatedMappingSuite) useFreshJWKS() {
+	s.T().Helper()
+	s.subCounter++
+	s.jwksSuffix = fmt.Sprintf("?cache=%d", s.subCounter)
+}
+
+// nextSubject returns a subject unique to this test run, so provisioned users never collide on the
+// unique username and email attributes.
+func (s *FederatedMappingSuite) nextSubject() string {
+	s.subCounter++
+	return fmt.Sprintf("fed-sub-%d-%d", s.subCounter, testutils.GetServerPID())
+}
+
+// register drives the registration flow for a mock identity carrying claims, and returns the
+// attributes of the user it provisioned. It is the workhorse of this suite: every mapping and
+// resolution scenario differs only in the claims it supplies and the configuration it applies.
+func (s *FederatedMappingSuite) register(
+	config *testutils.AttributeConfiguration, user *testutils.OIDCUserInfo) map[string]interface{} {
+	s.T().Helper()
+	s.applyConfig(config)
+	s.mockOIDC.AddUser(user)
+	s.activeSub = user.Sub
+
+	flowStep, err := common.InitiateRegistrationFlow(s.appID, false, nil, "")
+	s.Require().NoError(err, "failed to initiate the registration flow")
+	s.Require().Equal("REDIRECTION", flowStep.Type,
+		"expected a redirection to the identity provider, got %+v", flowStep)
+
+	code, state, err := testutils.SimulateFederatedOAuthFlow(flowStep.Data.RedirectURL)
+	s.Require().NoError(err, "failed to simulate authorization at the identity provider")
+
+	completed, err := common.CompleteFlow(
+		flowStep.ExecutionID, map[string]string{"code": code, "state": state}, "", flowStep.ChallengeToken)
+	s.Require().NoError(err, "failed to complete the registration flow")
+	s.Require().Equal("COMPLETE", completed.FlowStatus,
+		"expected the flow to complete, got %+v", completed)
+
+	provisioned, err := testutils.FindUserByAttribute("sub", user.Sub)
+	s.Require().NoError(err, "failed to look up the provisioned user")
+	s.Require().NotNil(provisioned, "no user was provisioned for subject %s", user.Sub)
+	s.config.CreatedUserIDs = append(s.config.CreatedUserIDs, provisioned.ID)
+
+	var attributes map[string]interface{}
+	s.Require().NoError(json.Unmarshal(provisioned.Attributes, &attributes),
+		"failed to decode the provisioned user's attributes")
+	return attributes
+}
+
+// registerExpectingPrompt drives the flow for a configuration under which no mapping supplies a
+// required local attribute, and returns the step the flow stops on. That is the user-visible
+// consequence of a mapping profile not matching: provisioning has no username, because no provider
+// emits a claim under that name, so it has to ask.
+func (s *FederatedMappingSuite) registerExpectingPrompt(
+	config *testutils.AttributeConfiguration, user *testutils.OIDCUserInfo) *common.FlowStep {
+	s.T().Helper()
+	s.applyConfig(config)
+	s.mockOIDC.AddUser(user)
+	s.activeSub = user.Sub
+
+	flowStep, err := common.InitiateRegistrationFlow(s.appID, false, nil, "")
+	s.Require().NoError(err, "failed to initiate the registration flow")
+
+	code, state, err := testutils.SimulateFederatedOAuthFlow(flowStep.Data.RedirectURL)
+	s.Require().NoError(err, "failed to simulate authorization at the identity provider")
+
+	step, err := common.CompleteFlow(
+		flowStep.ExecutionID, map[string]string{"code": code, "state": state}, "", flowStep.ChallengeToken)
+	s.Require().NoError(err, "failed to advance the registration flow")
+	return step
+}
+
+// assertPromptsFor asserts the flow stopped to collect the named input.
+func (s *FederatedMappingSuite) assertPromptsFor(step *common.FlowStep, identifier string) {
+	s.T().Helper()
+	s.Require().Equal("INCOMPLETE", step.FlowStatus,
+		"expected the flow to stop for input, got %+v", step)
+	for _, input := range step.Data.Inputs {
+		if input.Identifier == identifier {
+			return
+		}
+	}
+	s.Failf("missing expected prompt", "expected the flow to ask for %q, got inputs %+v",
+		identifier, step.Data.Inputs)
+}
+
+// mustJSON marshals fixture attributes, failing the build rather than the assertion if they are invalid.
+func mustJSON(value map[string]interface{}) []byte {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return encoded
+}
+
+// mapping is shorthand for a single-profile configuration keyed to the given user type.
+func mapping(userType string, pairs ...testutils.AttributeMapping) *testutils.AttributeConfiguration {
+	return &testutils.AttributeConfiguration{
+		UserTypeResolution:        &testutils.UserTypeResolution{Default: userType},
+		UserTypeAttributeMappings: []testutils.UserTypeAttributeMapping{{UserType: userType, Attributes: pairs}},
+	}
+}
+
+// pair is shorthand for one external-to-local mapping.
+func pair(external, local string) testutils.AttributeMapping {
+	return testutils.AttributeMapping{ExternalAttribute: external, LocalAttribute: local}
+}
+
+// OIDCUser aliases the mock's user type so the ID-token override signatures stay readable.
+type OIDCUser = testutils.OIDCUserInfo
+
+// signedIDToken signs the given claims with the mock's key, using the kid the published JWKS advertises.
+// Tests use it to mint tokens the mock would never produce on its own.
+func (s *FederatedMappingSuite) signedIDToken(claims map[string]interface{}) (string, error) {
+	return s.mockOIDC.SignJWT(
+		map[string]interface{}{"alg": "RS256", "typ": "JWT", "kid": "oidc-key-1"}, claims)
+}
+
+// baseUser returns a mock identity whose claims satisfy the required local attributes, so a scenario
+// only has to add the claims it is actually testing.
+func (s *FederatedMappingSuite) baseUser(sub string) *testutils.OIDCUserInfo {
+	return &testutils.OIDCUserInfo{
+		Sub:           sub,
+		Email:         sub + "@example.com",
+		EmailVerified: true,
+		Name:          "Federated Test User",
+		GivenName:     "Federated",
+		FamilyName:    "User",
+		Custom:        map[string]interface{}{},
+	}
+}

--- a/tests/integration/resources/declarative_resources/connections/idp-declarative-1.yaml
+++ b/tests/integration/resources/declarative_resources/connections/idp-declarative-1.yaml
@@ -6,3 +6,21 @@ type: google
 clientId: test-client-id
 clientSecret: test-client-secret
 redirectUri: https://localhost:8095/callback
+# The nested keys below are snake_case while the outer key and accountLinking are camelCase. That
+# inconsistency is the implementation's, not a choice here: providers.AttributeConfiguration tags
+# user_type_resolution and user_type_attribute_mappings snake_case while tagging accountLinking, and
+# UserTypeResolution's own externalAttribute/valueMapping, camelCase. Recorded as G13; camelCase keys
+# here would silently fail to parse. Update this fixture when G13 is fixed.
+attributeConfiguration:
+  user_type_resolution:
+    default: "Declarative Test Schema"
+  user_type_attribute_mappings:
+    - user_type: "Declarative Test Schema"
+      attributes:
+        - external_attribute: given_name
+          local_attribute: username
+        - external_attribute: email
+          local_attribute: email
+  accountLinking:
+    attributes:
+      - email

--- a/tests/integration/resources/declarative_resources/user_types/usertype-declarative-1.yaml
+++ b/tests/integration/resources/declarative_resources/user_types/usertype-declarative-1.yaml
@@ -8,7 +8,8 @@ systemAttributes:
 schema: |
   {
     "email": {
-      "type": "string"
+      "type": "string",
+      "unique": true
     },
     "username": {
       "type": "string"

--- a/tests/integration/testutils/api_utils.go
+++ b/tests/integration/testutils/api_utils.go
@@ -284,6 +284,83 @@ func CreateUser(user User) (string, error) {
 	return userID, nil
 }
 
+// ListUserTypes returns every user type visible to the caller, each with its schema.
+//
+// The listing endpoint omits the schema, so each type is fetched individually. Seeding reads every user
+// type in the deployment, so tests asserting seeded defaults use this to check the precondition their
+// expectation depends on rather than assuming no other suite left a type behind.
+func ListUserTypes() ([]UserType, error) {
+	body, err := getJSON(TestServerURL + "/user-types?limit=100")
+	if err != nil {
+		return nil, err
+	}
+
+	var listing struct {
+		TotalResults int `json:"totalResults"`
+		Types        []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"types"`
+	}
+	if err := json.Unmarshal(body, &listing); err != nil {
+		return nil, fmt.Errorf("failed to parse user type listing: %w. Response: %s", err, string(body))
+	}
+	// Callers use this as a deployment-wide precondition, so a truncated page must not read as the whole
+	// deployment.
+	if listing.TotalResults > len(listing.Types) {
+		return nil, fmt.Errorf("user type listing is truncated: %d of %d returned; raise the limit",
+			len(listing.Types), listing.TotalResults)
+	}
+
+	userTypes := make([]UserType, 0, len(listing.Types))
+	for _, item := range listing.Types {
+		detail, err := getJSON(fmt.Sprintf("%s/user-types/%s", TestServerURL, item.ID))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read user type %q: %w", item.Name, err)
+		}
+		var userType UserType
+		if err := json.Unmarshal(detail, &userType); err != nil {
+			return nil, fmt.Errorf("failed to parse user type %q: %w. Response: %s", item.Name, err, string(detail))
+		}
+		userTypes = append(userTypes, userType)
+	}
+	return userTypes, nil
+}
+
+// IsAttributeUnique reports whether the named schema attribute is declared unique on this user type.
+func (u UserType) IsAttributeUnique(attribute string) bool {
+	definition, ok := u.Schema[attribute].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	unique, _ := definition["unique"].(bool)
+	return unique
+}
+
+// getJSON performs an authenticated GET and returns the raw body, failing on any non-200 status.
+func getJSON(url string) ([]byte, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	client := GetHTTPClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("expected status 200, got %d. Response: %s", resp.StatusCode, string(body))
+	}
+	return body, nil
+}
+
 // DeleteUserType deletes a user type by ID
 func DeleteUserType(schemaID string) error {
 	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/user-types/%s", TestServerURL, schemaID), nil)
@@ -681,6 +758,9 @@ func idpToConnectionBody(idp IDP) map[string]interface{} {
 			}
 		}
 	}
+	if idp.AttributeConfiguration != nil {
+		body["attributeConfiguration"] = idp.AttributeConfiguration
+	}
 	return body
 }
 
@@ -710,6 +790,16 @@ func connectionBodyToIDP(idpType string, resp map[string]interface{}) *IDP {
 			}
 		}
 		idp.Properties = append(idp.Properties, IDPProperty{Name: "scopes", Value: strings.Join(parts, ",")})
+	}
+	// Round-tripped through JSON because the response arrives as a generic map. A malformed section is
+	// left nil rather than failing the conversion, so callers assert on it instead of on a parse error.
+	if raw, ok := resp["attributeConfiguration"]; ok && raw != nil {
+		if encoded, err := json.Marshal(raw); err == nil {
+			var config AttributeConfiguration
+			if err := json.Unmarshal(encoded, &config); err == nil {
+				idp.AttributeConfiguration = &config
+			}
+		}
 	}
 	return idp
 }

--- a/tests/integration/testutils/mock_oauth_server.go
+++ b/tests/integration/testutils/mock_oauth_server.go
@@ -60,6 +60,10 @@ type MockOAuthServer struct {
 	baseURL       string
 	authorizeFunc func(userID string) (string, error)
 
+	// Response overrides drive the transport failures a well-behaved provider never produces.
+	tokenOverride    func() (int, string)
+	userInfoOverride func() (int, string)
+
 	// Configurable endpoints
 	authorizePath string
 	tokenPath     string
@@ -137,6 +141,40 @@ func (m *MockOAuthServer) SetAuthorizeFunc(fn func(userID string) (string, error
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.authorizeFunc = fn
+}
+
+// SetTokenResponseOverride replaces the whole token response with the given status and body.
+func (m *MockOAuthServer) SetTokenResponseOverride(fn func() (int, string)) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.tokenOverride = fn
+}
+
+// SetUserInfoResponseOverride replaces the whole userinfo response with the given status and body.
+func (m *MockOAuthServer) SetUserInfoResponseOverride(fn func() (int, string)) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.userInfoOverride = fn
+}
+
+// ClearOverrides restores normal behaviour on both endpoints between tests.
+func (m *MockOAuthServer) ClearOverrides() {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.tokenOverride = nil
+	m.userInfoOverride = nil
+}
+
+// writeOAuthOverride serves an override response and reports whether it handled the request.
+func writeOAuthOverride(w http.ResponseWriter, fn func() (int, string)) bool {
+	if fn == nil {
+		return false
+	}
+	status, body := fn()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(body))
+	return true
 }
 
 // AddUser adds a user to the mock server
@@ -241,6 +279,13 @@ func (m *MockOAuthServer) handleAuthorize(w http.ResponseWriter, r *http.Request
 
 // handleToken handles the OAuth token endpoint
 func (m *MockOAuthServer) handleToken(w http.ResponseWriter, r *http.Request) {
+	m.mutex.RLock()
+	override := m.tokenOverride
+	m.mutex.RUnlock()
+	if writeOAuthOverride(w, override) {
+		return
+	}
+
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -342,6 +387,13 @@ func (m *MockOAuthServer) handleToken(w http.ResponseWriter, r *http.Request) {
 
 // handleUserInfo handles the OAuth userinfo endpoint
 func (m *MockOAuthServer) handleUserInfo(w http.ResponseWriter, r *http.Request) {
+	m.mutex.RLock()
+	override := m.userInfoOverride
+	m.mutex.RUnlock()
+	if writeOAuthOverride(w, override) {
+		return
+	}
+
 	if r.Method != http.MethodGet && r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return

--- a/tests/integration/testutils/mock_oidc_server.go
+++ b/tests/integration/testutils/mock_oidc_server.go
@@ -98,6 +98,14 @@ type MockOIDCServer struct {
 	issuer        string
 	authorizeFunc func(userID string) (string, error)
 
+	// Response overrides let a test drive the failure paths a well-behaved provider never exercises:
+	// a bad or missing ID token, a token or userinfo endpoint that errors or returns nonsense, and a
+	// JWKS document that cannot be used. Each is nil by default, leaving normal behaviour untouched.
+	idTokenOverride  func(user *OIDCUserInfo, nonce string) (string, error)
+	tokenOverride    func() (int, string)
+	userInfoOverride func() (int, string)
+	jwksOverride     func() (int, string)
+
 	// Configurable endpoints
 	discoveryPath string
 	authorizePath string
@@ -199,6 +207,63 @@ func (m *MockOIDCServer) SetAuthorizeFunc(fn func(userID string) (string, error)
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.authorizeFunc = fn
+}
+
+// SetIDTokenOverride replaces the ID token the token endpoint issues. The nonce the server issued is
+// passed in, because it is validated independently of the signature: a token omitting it is rejected
+// for that reason alone, which would make a scenario about anything else pass for the wrong cause.
+// SetIDTokenOverride replaces the ID token the token endpoint issues. Returning an error makes the
+// endpoint fail; returning a string serves it verbatim, so a test can mint an expired, unsigned or
+// structurally broken token with SignJWT and have the server hand it over.
+func (m *MockOIDCServer) SetIDTokenOverride(fn func(user *OIDCUserInfo, nonce string) (string, error)) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.idTokenOverride = fn
+}
+
+// SetTokenResponseOverride replaces the whole token response with the given status and body.
+func (m *MockOIDCServer) SetTokenResponseOverride(fn func() (int, string)) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.tokenOverride = fn
+}
+
+// SetUserInfoResponseOverride replaces the whole userinfo response with the given status and body.
+func (m *MockOIDCServer) SetUserInfoResponseOverride(fn func() (int, string)) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.userInfoOverride = fn
+}
+
+// SetJWKSOverride replaces the JWKS document, so a test can serve a malformed key set, one missing the
+// signing key, or a rotated one.
+func (m *MockOIDCServer) SetJWKSOverride(fn func() (int, string)) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.jwksOverride = fn
+}
+
+// ClearOverrides restores normal behaviour on every endpoint. A suite shares one mock across its tests,
+// so this runs between them rather than leaving one scenario's injected failure to break the next.
+func (m *MockOIDCServer) ClearOverrides() {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.idTokenOverride = nil
+	m.tokenOverride = nil
+	m.userInfoOverride = nil
+	m.jwksOverride = nil
+}
+
+// writeOIDCOverride serves an override response and reports whether it handled the request.
+func writeOIDCOverride(w http.ResponseWriter, fn func() (int, string)) bool {
+	if fn == nil {
+		return false
+	}
+	status, body := fn()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(body))
+	return true
 }
 
 // AddUser adds a user to the mock server
@@ -371,6 +436,13 @@ func (m *MockOIDCServer) handleAuthorize(w http.ResponseWriter, r *http.Request)
 
 // handleToken handles token endpoint
 func (m *MockOIDCServer) handleToken(w http.ResponseWriter, r *http.Request) {
+	m.mutex.RLock()
+	override := m.tokenOverride
+	m.mutex.RUnlock()
+	if writeOIDCOverride(w, override) {
+		return
+	}
+
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -440,7 +512,17 @@ func (m *MockOIDCServer) handleToken(w http.ResponseWriter, r *http.Request) {
 	refreshToken := "refresh_" + generateOIDCRandomString(40)
 
 	// Generate ID token
-	idToken, err := m.generateIDToken(user, authCodeData.Nonce, accessToken)
+	m.mutex.RLock()
+	idTokenOverride := m.idTokenOverride
+	m.mutex.RUnlock()
+
+	var idToken string
+	var err error
+	if idTokenOverride != nil {
+		idToken, err = idTokenOverride(user, authCodeData.Nonce)
+	} else {
+		idToken, err = m.generateIDToken(user, authCodeData.Nonce, accessToken)
+	}
 	if err != nil {
 		http.Error(w, "Failed to generate ID token", http.StatusInternalServerError)
 		return
@@ -475,6 +557,13 @@ func (m *MockOIDCServer) handleToken(w http.ResponseWriter, r *http.Request) {
 
 // handleUserInfo handles userinfo endpoint
 func (m *MockOIDCServer) handleUserInfo(w http.ResponseWriter, r *http.Request) {
+	m.mutex.RLock()
+	override := m.userInfoOverride
+	m.mutex.RUnlock()
+	if writeOIDCOverride(w, override) {
+		return
+	}
+
 	if r.Method != http.MethodGet && r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -560,6 +649,13 @@ func (m *MockOIDCServer) handleUserInfo(w http.ResponseWriter, r *http.Request) 
 
 // handleJWKS handles JWKS endpoint
 func (m *MockOIDCServer) handleJWKS(w http.ResponseWriter, r *http.Request) {
+	m.mutex.RLock()
+	override := m.jwksOverride
+	m.mutex.RUnlock()
+	if writeOIDCOverride(w, override) {
+		return
+	}
+
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return

--- a/tests/integration/testutils/models.go
+++ b/tests/integration/testutils/models.go
@@ -74,13 +74,49 @@ type IDPProperty struct {
 	IsSecret bool   `json:"isSecret"`
 }
 
+// AttributeMapping maps a single external IDP claim to a local user attribute. The external name may
+// be a dot-notation path into a nested claim.
+type AttributeMapping struct {
+	ExternalAttribute string `json:"externalAttribute"`
+	LocalAttribute    string `json:"localAttribute"`
+}
+
+// UserTypeAttributeMapping holds the external-to-local mappings for one local user type.
+type UserTypeAttributeMapping struct {
+	UserType   string             `json:"userType,omitempty"`
+	Attributes []AttributeMapping `json:"attributes,omitempty"`
+}
+
+// UserTypeResolution selects the local user type for an incoming identity. Default applies when
+// claim-driven resolution is absent or does not match.
+type UserTypeResolution struct {
+	Default           string            `json:"default,omitempty"`
+	ExternalAttribute string            `json:"externalAttribute,omitempty"`
+	ValueMapping      map[string]string `json:"valueMapping,omitempty"`
+}
+
+// AccountLinking lists the external claims used to resolve a local user when the subject does not.
+type AccountLinking struct {
+	Attributes []string `json:"attributes,omitempty"`
+}
+
+// AttributeConfiguration is the connection's user-type resolution, per-user-type attribute mappings
+// and account-linking configuration. Mirrors the /connections wire format; pointers so a nil section
+// stays distinguishable from an empty one.
+type AttributeConfiguration struct {
+	UserTypeResolution        *UserTypeResolution        `json:"userTypeResolution,omitempty"`
+	UserTypeAttributeMappings []UserTypeAttributeMapping `json:"userTypeAttributeMappings,omitempty"`
+	AccountLinking            *AccountLinking            `json:"accountLinking,omitempty"`
+}
+
 // IDP represents an identity provider in the system
 type IDP struct {
-	ID          string        `json:"id,omitempty"`
-	Name        string        `json:"name"`
-	Description string        `json:"description"`
-	Type        string        `json:"type"`
-	Properties  []IDPProperty `json:"properties"`
+	ID                     string                  `json:"id,omitempty"`
+	Name                   string                  `json:"name"`
+	Description            string                  `json:"description"`
+	Type                   string                  `json:"type"`
+	Properties             []IDPProperty           `json:"properties"`
+	AttributeConfiguration *AttributeConfiguration `json:"attributeConfiguration,omitempty"`
 }
 
 // Link represents a pagination link.


### PR DESCRIPTION
### Purpose

Improve integration-test coverage for federated authentication, identity-provider connections, and account linking.

  The change adds functional coverage for:

  - IDP and connection lifecycle operations, validation, and configuration
  - Generic OAuth and OIDC authentication flows
  - Google and GitHub provider behavior
  - Federated registration, authentication, and repeated-login flows
  - External-to-local attribute mapping, including nested claim paths
  - User-type resolution
  - Local-account discovery and federated account linking
  - Declarative, composite-store, and export behavior for connections
  - Invalid configurations, deleted connections, malformed provider responses, and upstream provider failures
  - Related authentication-flow executors
  - Observable results including API responses, redirects, persisted users, linked identities, runtime attributes, and errors

  These tests exercise the components through integration boundaries and existing mock provider servers, instead of validating only isolated implementation details.

  ### Approach

  - Extend the existing connection, declarative single-file, composite-store, and export integration suites.
  - Add a dedicated federated integration-test suite covering provider configuration, authentication flows, account resolution, linking, and attribute mapping.
  - Exercise generic OAuth and OIDC executors as actual authentication-flow nodes.
  - Use the existing OAuth and OIDC mock servers to produce deterministic authorization, token, user-info, claim, and provider-error responses.
  - Verify both API-level results and resulting system state, including created users, resolved user types, mapped attributes, and linked federated identities.
  - Add negative scenarios for invalid connection properties, deleted connections, type mismatches, malformed claims, and provider failures.
  - Mark email as unique in the declarative user-type fixture so account-linking seeds and resolves email as a valid unique attribute.
  - Maintain scenario-to-test traceability for the added integration coverage.

  ### Related Issues

  - Resolves https://github.com/thunder-id/thunderid/issues/4864

  ### Related PRs

  - N/A

  ### Checklist
  - [x] Followed the contribution guidelines.
  - [x] Manual test round performed and verified.
  - [ ] Documentation provided. (Add links if there are any)
      - [ ] Ran Vale and fixed all errors and warnings
  - [x] Tests provided. (Add links if there are any)
      - [ ] Unit Tests
      - [x] Integration Tests
  - [ ] Breaking changes. (Fill if applicable)
      - [ ] Breaking changes section filled.
      - [ ] `breaking change` label added.

  ### Security checks
  - [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-
  coding-guidlines/introduction/)
  - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added federated identity-provider attribute mappings, user-type resolution, and account linking.
  * Enhanced OIDC, OAuth, and GitHub authentication with improved identity matching and user provisioning.
  * Declarative configurations and exported connection documents now preserve attribute settings, including empty configurations and masked secrets.

* **Bug Fixes**
  * Improved validation and error handling for invalid provider responses, expired or malformed tokens, key rotation, ambiguous account matches, and unsafe connection deletion.
  * Improved handling of provider scopes and authentication callback errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->