### PR TITLE
Remove committed dpserver binary and ignore plane build outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,8 @@ out
 out-tsc
 backend/bin
 backend/server
+backend/cpserver
+backend/dpserver
 
 # E2E extracted distribution
 tests/e2e/distribution/


### PR DESCRIPTION
A 53 MB compiled `dpserver` executable was committed to `backend/` and is live at the branch tip. It is a build artifact and does not belong in the repository.

`.gitignore` already listed `backend/server` but never the per-plane binaries, which is how this one got through. Both `backend/cpserver` and `backend/dpserver` are now ignored.

This removes the file from the tip only. The blob stays in history, so a clone still pays for it.

## Checklist
- [x] Tested locally
- [x] No new dependencies
- [x] No CI or Makefile changes