### PR TITLE
Fix intermittent failures in FlowsListView and useDeleteRole tests

### DIFF
--- a/frontend/apps/console/src/features/applications/components/create-application/configure-signin-options/__tests__/FlowsListView.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/configure-signin-options/__tests__/FlowsListView.test.tsx
@@ -209,16 +209,17 @@ describe('FlowsListView', () => {
 
     it('should call onClearSelection when selection is cleared', async () => {
       const user = userEvent.setup();
-      renderExpanded({
+      // The card is already expanded because selectedAuthFlow is set, so use renderComponent
+      // directly; renderExpanded would toggle it back closed.
+      renderComponent({
         selectedAuthFlow: mockFlows[0],
       });
 
       const autocomplete = screen.getByRole('combobox');
-      await user.click(autocomplete);
+      const clearButton = autocomplete.parentElement?.querySelector('[aria-label="Clear"]');
 
-      // Clear the selection by clicking outside or selecting null
-      await user.clear(autocomplete);
-      await user.tab(); // blur to trigger onChange with null
+      expect(clearButton).not.toBeNull();
+      await user.click(clearButton!);
 
       expect(mockOnClearSelection).toHaveBeenCalled();
     });

--- a/frontend/packages/configure-roles/src/api/__tests__/useDeleteRole.test.tsx
+++ b/frontend/packages/configure-roles/src/api/__tests__/useDeleteRole.test.tsx
@@ -103,9 +103,10 @@ describe('useDeleteRole', () => {
   });
 
   it('should set pending state during deletion', async () => {
+    let resolveRequest: () => void;
     mockHttpRequest.mockReturnValue(
       new Promise((resolve) => {
-        setTimeout(() => resolve(undefined), 100);
+        resolveRequest = () => resolve(undefined);
       }),
     );
 
@@ -117,12 +118,11 @@ describe('useDeleteRole', () => {
       expect(result.current.isPending).toBe(true);
     });
 
-    await waitFor(
-      () => {
-        expect(result.current.isSuccess).toBe(true);
-      },
-      {timeout: 200},
-    );
+    resolveRequest();
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
 
     expect(result.current.isPending).toBe(false);
   });


### PR DESCRIPTION
### Purpose
Fixes two intermittently failing frontend tests observed in CI.

1. `FlowsListView.test.tsx` > `should call onClearSelection when selection is cleared` occasionally failed with `Error: The element to be cleared could not be focused.` from `user.clear()` on a MUI Autocomplete combobox.
2. `useDeleteRole.test.tsx` > `should set pending state during deletion` occasionally failed with `expected false to be true` when asserting `isPending`.

### Approach
1. `user.clear()` on a MUI Autocomplete's combobox input is a known source of flakiness: it needs to focus, select all text, and delete it on an input whose displayed value is really driven by the selected option, not free text, and the refocus step can intermittently fail. The codebase already has an established, reliable pattern for clearing an Autocomplete's selection elsewhere (`AppearanceSection.test.tsx`), clicking the Autocomplete's own `[aria-label="Clear"]` icon button. Applied the same pattern here instead of `user.clear()` + tab.

2. The pending-state test raced a real `setTimeout(..., 100)` mock against `waitFor`'s polling inside a Playwright-driven browser test environment. Under CI load, that 100ms pending window could be missed entirely, causing `isPending` to already be `false` by the time it was checked. Replaced the fixed timer with a manually-controlled promise so the mutation stays pending indefinitely until the test explicitly resolves it, removing the wall-clock race.

Both fixes were verified locally by running the affected test files directly (21/21 and 15/15 passing respectively) and confirming `tsc --noEmit` is clean.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for clearing selections in sign-in configuration.
  * Replaced timing-based role deletion test behavior with explicit request completion handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->