### PR TITLE
Include roles in the consent prompt attribute list

### DIFF
--- a/backend/internal/flow/executor/consent_executor.go
+++ b/backend/internal/flow/executor/consent_executor.go
@@ -326,7 +326,7 @@ func (e *consentExecutor) getRequiredAttributes(ctx *providers.NodeContext) (
 }
 
 // buildAugmentedAvailableAttributes returns an AttributesResponse value augmented with
-// special attribute keys (groups, userType, ouId, ouName, ouHandle) that are present by
+// special attribute keys (groups, roles, userType, ouId, ouName, ouHandle) that are present by
 // construction in the authenticated user context but are never included in AttributesResponse
 // by authentication providers.
 //
@@ -366,6 +366,7 @@ func (e *consentExecutor) buildAugmentedAvailableAttributes(
 	}
 	if entityRef.EntityID != "" {
 		augmented[oauth2const.UserAttributeGroups] = &providers.AttributeResponse{}
+		augmented[oauth2const.UserAttributeRoles] = &providers.AttributeResponse{}
 	}
 
 	return &providers.AttributesResponse{

--- a/backend/internal/flow/executor/consent_executor_test.go
+++ b/backend/internal/flow/executor/consent_executor_test.go
@@ -1451,7 +1451,8 @@ func (suite *ConsentExecutorTestSuite) TestBuildAugmentedAvailableAttributes_Emp
 	assert.Contains(suite.T(), result.Attributes, "ouName")
 	assert.Contains(suite.T(), result.Attributes, "ouHandle")
 	assert.Contains(suite.T(), result.Attributes, "groups")
-	assert.Len(suite.T(), result.Attributes, 5)
+	assert.Contains(suite.T(), result.Attributes, "roles")
+	assert.Len(suite.T(), result.Attributes, 6)
 }
 
 func (suite *ConsentExecutorTestSuite) TestBuildAugmentedAvailableAttributes_NoSpecialContext() {
@@ -1473,6 +1474,7 @@ func (suite *ConsentExecutorTestSuite) TestBuildAugmentedAvailableAttributes_NoS
 	assert.True(suite.T(), result.Attributes["phone"] == nil)
 	assert.NotContains(suite.T(), result.Attributes, "userType")
 	assert.NotContains(suite.T(), result.Attributes, "groups")
+	assert.NotContains(suite.T(), result.Attributes, "roles")
 	assert.NotContains(suite.T(), result.Attributes, "ouId")
 }
 
@@ -1491,13 +1493,19 @@ func (suite *ConsentExecutorTestSuite) TestBuildAugmentedAvailableAttributes_Wit
 			name:             "EntityType only",
 			entityType:       testUserTypeInternal,
 			expectedContains: []string{"userType", "email"},
-			expectedAbsent:   []string{"ouId", "ouName", "ouHandle", "groups"},
+			expectedAbsent:   []string{"ouId", "ouName", "ouHandle", "groups", "roles"},
 		},
 		{
 			name:             "OUID only",
 			ouID:             "ou-456",
 			expectedContains: []string{"ouId", "ouName", "ouHandle", "email"},
-			expectedAbsent:   []string{"userType", "groups"},
+			expectedAbsent:   []string{"userType", "groups", "roles"},
+		},
+		{
+			name:             "EntityID only",
+			entityID:         testUserID,
+			expectedContains: []string{"groups", "roles", "email"},
+			expectedAbsent:   []string{"userType", "ouId", "ouName", "ouHandle"},
 		},
 	}
 
@@ -1527,7 +1535,7 @@ func (suite *ConsentExecutorTestSuite) TestBuildAugmentedAvailableAttributes_Wit
 	}
 }
 
-func (suite *ConsentExecutorTestSuite) TestBuildAugmentedAvailableAttributes_WithGroups() {
+func (suite *ConsentExecutorTestSuite) TestBuildAugmentedAvailableAttributes_WithGroupsAndRoles() {
 	availableAttrs := &providers.AttributesResponse{
 		Attributes: map[string]*providers.AttributeResponse{
 			"email": nil,
@@ -1541,6 +1549,7 @@ func (suite *ConsentExecutorTestSuite) TestBuildAugmentedAvailableAttributes_Wit
 
 	assert.NotNil(suite.T(), result)
 	assert.Contains(suite.T(), result.Attributes, "groups")
+	assert.Contains(suite.T(), result.Attributes, "roles")
 	assert.NotContains(suite.T(), result.Attributes, "userType")
 	assert.NotContains(suite.T(), result.Attributes, "ouId")
 	assert.Contains(suite.T(), result.Attributes, "email")
@@ -1567,8 +1576,9 @@ func (suite *ConsentExecutorTestSuite) TestBuildAugmentedAvailableAttributes_All
 	assert.Contains(suite.T(), result.Attributes, "ouName")
 	assert.Contains(suite.T(), result.Attributes, "ouHandle")
 	assert.Contains(suite.T(), result.Attributes, "groups")
-	// Total: 1 original + 5 special
-	assert.Len(suite.T(), result.Attributes, 6)
+	assert.Contains(suite.T(), result.Attributes, "roles")
+	// Total: 1 original + 6 special
+	assert.Len(suite.T(), result.Attributes, 7)
 }
 
 func (suite *ConsentExecutorTestSuite) TestBuildAugmentedAvailableAttributes_DoesNotMutateOriginal() {
@@ -1591,6 +1601,7 @@ func (suite *ConsentExecutorTestSuite) TestBuildAugmentedAvailableAttributes_Doe
 	assert.Len(suite.T(), availableAttrs.Attributes, originalLen)
 	assert.NotContains(suite.T(), availableAttrs.Attributes, "userType")
 	assert.NotContains(suite.T(), availableAttrs.Attributes, "groups")
+	assert.NotContains(suite.T(), availableAttrs.Attributes, "roles")
 	assert.NotContains(suite.T(), availableAttrs.Attributes, "ouId")
 }
 
@@ -1700,6 +1711,7 @@ func (suite *ConsentExecutorTestSuite) TestBuildAugmentedAvailableAttributes_Wit
 	assert.Contains(suite.T(), result.Attributes, "email")
 	assert.Contains(suite.T(), result.Attributes, "phone")
 	assert.Contains(suite.T(), result.Attributes, "groups")
+	assert.Contains(suite.T(), result.Attributes, "roles")
 }
 
 func (suite *ConsentExecutorTestSuite) TestBuildAugmentedAvailableAttributes_NilAvailableAttrs_ReturnsNil() {


### PR DESCRIPTION
### Purpose
When a flow includes the ConsentExecutor, `roles` was never shown on the consent screen, so it was treated as not consented and silently dropped from the access token, ID token, and UserInfo response.

The consent enforcer filters the prompt against the attributes available on the user. That set comes from the authn providers, which never carry computed attributes, so `groups`, `roles`, `userType`, and the OU claims must be injected explicitly. Every computed attribute except `roles` was injected.

### Approach
Inject `roles` alongside `groups` in `buildAugmentedAvailableAttributes`, under the same `EntityID` guard. Both are computed from the entity ID and its transitive group memberships, so they have identical availability preconditions.

Note: the list of computed attributes is currently duplicated across four call sites, which is what allowed this drift. Consolidating it is left to a follow-up.

### Related Issues
- Fixes #4873

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Consent flows now include authenticated users’ roles in the available attributes.
  * Roles are documented alongside other injected special attributes.

* **Tests**
  * Added coverage verifying roles are included correctly while existing attributes remain unchanged.
  * Expanded scenarios for entity IDs, groups, and roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->