### PR TITLE
Add integration tests for token attribute filtering, verified_claims validation, and prompt=none handling

### DIFF
--- a/tests/integration/agent/agent_client_attributes_test.go
+++ b/tests/integration/agent/agent_client_attributes_test.go
@@ -1,0 +1,255 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package agent
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	agentClientAttrsClientID     = "agent_client_attrs_test_client"
+	agentClientAttrsClientSecret = "agent_client_attrs_test_secret"
+	agentClientAttrsRSIdentifier = "https://agent-client-attrs.example.com"
+)
+
+// AgentClientAttributesTestSuite verifies that client_credentials access tokens issued for
+// an agent surface client-scoped claims (schema attributes, system attributes name/owner,
+// ouId, groups, roles) selected by the agent's token.accessToken.clientConfig.attributes
+// allow-list.
+type AgentClientAttributesTestSuite struct {
+	suite.Suite
+	client           *http.Client
+	ouID             string
+	agentSchemaID    string
+	entityTypeID     string
+	ownerUserID      string
+	resourceServerID string
+}
+
+// TestAgentClientAttributesTestSuite runs the AgentClientAttributesTestSuite.
+func TestAgentClientAttributesTestSuite(t *testing.T) {
+	suite.Run(t, new(AgentClientAttributesTestSuite))
+}
+
+// SetupSuite creates the shared organization unit, agent schema, owner user, and resource
+// server for the suite.
+func (s *AgentClientAttributesTestSuite) SetupSuite() {
+	s.client = testutils.GetHTTPClient()
+
+	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "agent-client-attrs-ou",
+		Name:        "Agent Client Attributes OU",
+		Description: "Organization unit for agent client-attribute integration tests",
+	})
+	s.Require().NoError(err)
+	s.ouID = ouID
+
+	schemaID, err := testutils.CreateAgentType(testutils.UserType{
+		Name: "default",
+		OUID: s.ouID,
+		Schema: map[string]interface{}{
+			"modelProvider": map[string]interface{}{"type": "string"},
+			"description":   map[string]interface{}{"type": "string"},
+		},
+	})
+	s.Require().NoError(err)
+	s.agentSchemaID = schemaID
+
+	entityTypeID, err := testutils.CreateUserType(testutils.UserType{
+		Name: "agent-client-attrs-owner",
+		OUID: s.ouID,
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{"type": "string"},
+			"password": map[string]interface{}{"type": "string", "credential": true},
+		},
+	})
+	s.Require().NoError(err)
+	s.entityTypeID = entityTypeID
+
+	attributesJSON, err := json.Marshal(map[string]interface{}{
+		"username": "agent-client-attrs-owner-user",
+		"password": "OwnerUserPass1!",
+	})
+	s.Require().NoError(err)
+	ownerUserID, err := testutils.CreateUser(testutils.User{
+		Type:       "agent-client-attrs-owner",
+		OUID:       s.ouID,
+		Attributes: attributesJSON,
+	})
+	s.Require().NoError(err)
+	s.ownerUserID = ownerUserID
+
+	rsID, err := testutils.CreateResourceServerWithActions(testutils.ResourceServer{
+		Name:        "Agent Client Attributes API",
+		Description: "Resource server for agent client-attribute testing",
+		Identifier:  agentClientAttrsRSIdentifier,
+		OUID:        s.ouID,
+	}, []testutils.Action{})
+	s.Require().NoError(err)
+	s.resourceServerID = rsID
+}
+
+// TearDownSuite deletes the shared resources created in SetupSuite.
+func (s *AgentClientAttributesTestSuite) TearDownSuite() {
+	if s.resourceServerID != "" {
+		_ = testutils.DeleteResourceServer(s.resourceServerID)
+	}
+	if s.ownerUserID != "" {
+		_ = testutils.DeleteUser(s.ownerUserID)
+	}
+	if s.entityTypeID != "" {
+		_ = testutils.DeleteUserType(s.entityTypeID)
+	}
+	if s.agentSchemaID != "" {
+		_ = testutils.DeleteAgentType(s.agentSchemaID)
+	}
+	if s.ouID != "" {
+		_ = testutils.DeleteOrganizationUnit(s.ouID)
+	}
+}
+
+// createAgentWithAttributes creates an agent with the given schema attributes, owner, and
+// clientConfig.attributes allow-list.
+func (s *AgentClientAttributesTestSuite) createAgentWithAttributes(
+	clientID string, clientAttributes []string, attributes json.RawMessage, owner string,
+) (string, error) {
+	return createAgent(Agent{
+		OUID:       s.ouID,
+		Type:       "default",
+		Name:       "Client Attrs Agent " + clientID,
+		Owner:      owner,
+		Attributes: attributes,
+		InboundAuthConfig: []InboundAuthConfig{
+			{
+				Type: "oauth2",
+				Config: &OAuthAgentConfig{
+					ClientID:                clientID,
+					ClientSecret:            agentClientAttrsClientSecret,
+					GrantTypes:              []string{"client_credentials"},
+					TokenEndpointAuthMethod: "client_secret_basic",
+					Token: &OAuthTokenConfig{
+						AccessToken: &AccessTokenConfig{
+							ClientConfig: &AccessTokenSubConfig{Attributes: clientAttributes},
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+// requestToken performs a client_credentials token request for the given client ID.
+func (s *AgentClientAttributesTestSuite) requestToken(clientID string) (int, map[string]interface{}) {
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("resource", agentClientAttrsRSIdentifier)
+
+	req, err := http.NewRequest("POST", testServerURL+"/oauth2/token", strings.NewReader(form.Encode()))
+	s.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(clientID, agentClientAttrsClientSecret)
+
+	resp, err := s.client.Do(req)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	var respBody map[string]interface{}
+	s.Require().NoError(json.NewDecoder(resp.Body).Decode(&respBody))
+	return resp.StatusCode, respBody
+}
+
+// TestAgentClientAttrs_SchemaAndSystemAndGroupsAndRoles verifies that an agent's schema
+// attribute (modelProvider), system attributes (name, owner), ouId, groups, and roles are
+// all present in the client_credentials access token when allow-listed.
+func (s *AgentClientAttributesTestSuite) TestAgentClientAttrs_SchemaAndSystemAndGroupsAndRoles() {
+	clientID := agentClientAttrsClientID + "_full"
+	attrs, err := json.Marshal(map[string]interface{}{"modelProvider": "anthropic", "description": "d"})
+	s.Require().NoError(err)
+
+	agentID, err := s.createAgentWithAttributes(clientID,
+		[]string{"modelProvider", "name", "owner", "ouId", "groups", "roles"}, attrs, s.ownerUserID)
+	s.Require().NoError(err)
+	defer func() { _ = deleteAgent(agentID) }()
+
+	directRoleID, err := testutils.CreateRole(testutils.Role{
+		Name:        "Agent Client Attrs Direct Role",
+		Description: "Role assigned directly to the agent",
+		OUID:        s.ouID,
+		Assignments: []testutils.Assignment{{ID: agentID, Type: "agent"}},
+	})
+	s.Require().NoError(err)
+	defer func() { _ = testutils.DeleteRole(directRoleID) }()
+
+	groupID, err := testutils.CreateGroup(testutils.Group{
+		Name:    "Agent Client Attrs Group",
+		OUID:    s.ouID,
+		Members: []testutils.Member{{Id: agentID, Type: "agent"}},
+	})
+	s.Require().NoError(err)
+	defer func() { _ = testutils.DeleteGroup(groupID) }()
+
+	groupRoleID, err := testutils.CreateRole(testutils.Role{
+		Name:        "Agent Client Attrs Group Role",
+		Description: "Role assigned to the group containing the agent",
+		OUID:        s.ouID,
+		Assignments: []testutils.Assignment{{ID: groupID, Type: "group"}},
+	})
+	s.Require().NoError(err)
+	defer func() { _ = testutils.DeleteRole(groupRoleID) }()
+
+	status, body := s.requestToken(clientID)
+	s.Require().Equal(http.StatusOK, status, "CC token request must succeed: %v", body)
+	token, ok := body["access_token"].(string)
+	s.Require().True(ok, "Response should contain access_token")
+
+	claims, err := testutils.DecodeJWT(token)
+	s.Require().NoError(err)
+
+	s.Assert().Equal("anthropic", claims.Additional["modelProvider"], "agent schema attribute should be surfaced")
+	s.Assert().Equal("Client Attrs Agent "+clientID, claims.Additional["name"], "agent system attribute name should be surfaced")
+	s.Assert().Equal(s.ownerUserID, claims.Additional["owner"], "agent system attribute owner should be surfaced")
+	s.Assert().Equal(s.ouID, claims.Additional["ouId"])
+	s.Assert().NotContains(claims.Additional, "description", "non-allow-listed schema attribute must be excluded")
+
+	groups, ok := claims.Additional["groups"].([]interface{})
+	s.Require().True(ok, "groups claim should be present as an array")
+	s.Assert().Contains(groups, "Agent Client Attrs Group")
+
+	roles, ok := claims.Additional["roles"].([]interface{})
+	s.Require().True(ok, "roles claim should be present as an array")
+	s.Assert().ElementsMatch(
+		[]interface{}{"Agent Client Attrs Direct Role", "Agent Client Attrs Group Role"}, roles)
+}
+
+// TestAgentClientAttrs_PartialAllowList verifies that only the allow-listed attributes are
+// included, even when the agent has other resolvable attributes (schema, system, OU).
+func (s *AgentClientAttributesTestSuite) TestAgentClientAttrs_PartialAllowList() {
+	clientID := agentClientAttrsClientID + "_partial"
+	attrs, err := json.Marshal(map[string]interface{}{"modelProvider": "anthropic"})
+	s.Require().NoError(err)
+
+	agentID, err := s.createAgentWithAttributes(clientID, []string{"modelProvider"}, attrs, s.ownerUserID)
+	s.Require().NoError(err)
+	defer func() { _ = deleteAgent(agentID) }()
+
+	status, body := s.requestToken(clientID)
+	s.Require().Equal(http.StatusOK, status, "CC token request must succeed: %v", body)
+	token, ok := body["access_token"].(string)
+	s.Require().True(ok)
+
+	claims, err := testutils.DecodeJWT(token)
+	s.Require().NoError(err)
+
+	s.Assert().Equal("anthropic", claims.Additional["modelProvider"])
+	s.Assert().NotContains(claims.Additional, "name", "name must be excluded when not allow-listed")
+	s.Assert().NotContains(claims.Additional, "owner", "owner must be excluded when not allow-listed")
+	s.Assert().NotContains(claims.Additional, "ouId", "ouId must be excluded when not allow-listed")
+}

--- a/tests/integration/agent/model.go
+++ b/tests/integration/agent/model.go
@@ -34,14 +34,30 @@ type InboundAuthConfig struct {
 
 // OAuthAgentConfig represents the OAuth client configuration for an agent.
 type OAuthAgentConfig struct {
-	ClientID                string   `json:"clientId,omitempty"`
-	ClientSecret            string   `json:"clientSecret,omitempty"`
-	RedirectURIs            []string `json:"redirectUris,omitempty"`
-	GrantTypes              []string `json:"grantTypes,omitempty"`
-	ResponseTypes           []string `json:"responseTypes,omitempty"`
-	TokenEndpointAuthMethod string   `json:"tokenEndpointAuthMethod,omitempty"`
-	PKCERequired            bool     `json:"pkceRequired,omitempty"`
-	PublicClient            bool     `json:"publicClient,omitempty"`
+	ClientID                string            `json:"clientId,omitempty"`
+	ClientSecret            string            `json:"clientSecret,omitempty"`
+	RedirectURIs            []string          `json:"redirectUris,omitempty"`
+	GrantTypes              []string          `json:"grantTypes,omitempty"`
+	ResponseTypes           []string          `json:"responseTypes,omitempty"`
+	TokenEndpointAuthMethod string            `json:"tokenEndpointAuthMethod,omitempty"`
+	PKCERequired            bool              `json:"pkceRequired,omitempty"`
+	PublicClient            bool              `json:"publicClient,omitempty"`
+	Token                   *OAuthTokenConfig `json:"token,omitempty"`
+}
+
+// OAuthTokenConfig represents the OAuth token configuration for an agent's inbound auth config.
+type OAuthTokenConfig struct {
+	AccessToken *AccessTokenConfig `json:"accessToken,omitempty"`
+}
+
+// AccessTokenConfig represents the access token configuration, split by token subject.
+type AccessTokenConfig struct {
+	ClientConfig *AccessTokenSubConfig `json:"clientConfig,omitempty"`
+}
+
+// AccessTokenSubConfig represents the attribute selection for one access token subject type.
+type AccessTokenSubConfig struct {
+	Attributes []string `json:"attributes,omitempty"`
 }
 
 // AgentListResponse represents the paginated list response for agents.

--- a/tests/integration/oauth/authz/prompt_none_test.go
+++ b/tests/integration/oauth/authz/prompt_none_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authz
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// TestAuthorize_PromptNone_LoginRequired verifies that prompt=none is redirected back to the client
+// with error=login_required, since the server does not support silent re-authentication via
+// server-side sessions (OIDC Core §3.1.2.1).
+func (ts *AuthzTestSuite) TestAuthorize_PromptNone_LoginRequired() {
+	resp, err := testutils.InitiateAuthorizationFlowWithPrompt(
+		clientID, redirectURI, "code", "openid", "prompt-none-state", "none")
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusFound, resp.StatusCode, "prompt=none should redirect back to the client")
+
+	location := resp.Header.Get("Location")
+	ts.Require().NotEmpty(location, "Location header should be present")
+
+	redirected, err := url.Parse(location)
+	ts.Require().NoError(err)
+	query := redirected.Query()
+
+	ts.Assert().Equal("login_required", query.Get("error"))
+	ts.Assert().NotEmpty(query.Get("error_description"))
+	ts.Assert().Equal("prompt-none-state", query.Get("state"), "state must be echoed back to the client")
+}
+
+// TestAuthorize_PromptNoneCombinedWithOtherValues_InvalidRequest verifies that combining prompt=none
+// with another prompt value is rejected as invalid_request, per OIDC Core §3.1.2.1.
+func (ts *AuthzTestSuite) TestAuthorize_PromptNoneCombinedWithOtherValues_InvalidRequest() {
+	resp, err := testutils.InitiateAuthorizationFlowWithPrompt(
+		clientID, redirectURI, "code", "openid", "prompt-combined-state", "none login")
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusFound, resp.StatusCode)
+
+	location := resp.Header.Get("Location")
+	ts.Require().NotEmpty(location)
+
+	redirected, err := url.Parse(location)
+	ts.Require().NoError(err)
+	query := redirected.Query()
+
+	ts.Assert().Equal("invalid_request", query.Get("error"))
+	ts.Assert().NotEmpty(query.Get("error_description"))
+}
+
+// TestAuthorize_PromptUnsupportedValue_InvalidRequest verifies that an unrecognized prompt value is
+// rejected as invalid_request.
+func (ts *AuthzTestSuite) TestAuthorize_PromptUnsupportedValue_InvalidRequest() {
+	resp, err := testutils.InitiateAuthorizationFlowWithPrompt(
+		clientID, redirectURI, "code", "openid", "prompt-unsupported-state", "not_a_real_prompt_value")
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusFound, resp.StatusCode)
+
+	location := resp.Header.Get("Location")
+	ts.Require().NotEmpty(location)
+
+	redirected, err := url.Parse(location)
+	ts.Require().NoError(err)
+	query := redirected.Query()
+
+	ts.Assert().Equal("invalid_request", query.Get("error"))
+}

--- a/tests/integration/oauth/ciba/ciba_attribute_filter_test.go
+++ b/tests/integration/oauth/ciba/ciba_attribute_filter_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ciba
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	cibaAttrFilterClientID     = "ciba_attr_filter_test_client"
+	cibaAttrFilterClientSecret = "ciba_attr_filter_test_secret"
+)
+
+// createCIBAAppWithAttributes creates a CIBA-enabled application bound to the shared test auth flow,
+// with the given token.accessToken.userConfig.attributes allow-list.
+func (ts *CIBATestSuite) createCIBAAppWithAttributes(clientID, clientSecret string, allowedAttributes []string) string {
+	app := map[string]interface{}{
+		"name":                      "CIBAAttrFilterTestApp",
+		"description":               "Application for CIBA attribute allow-list integration test",
+		"ouId":                      ts.ouID,
+		"type":                      "fullstack",
+		"authFlowId":                ts.flowID,
+		"isRegistrationFlowEnabled": false,
+		"allowedUserTypes":          []string{"ciba-test-person"},
+		"inboundAuthConfig": []map[string]interface{}{
+			{
+				"type": "oauth2",
+				"config": map[string]interface{}{
+					"clientId":                clientID,
+					"clientSecret":            clientSecret,
+					"redirectUris":            []string{"https://localhost:3000"},
+					"grantTypes":              []string{cibaGrantType, "refresh_token"},
+					"tokenEndpointAuthMethod": "client_secret_basic",
+					"token": map[string]interface{}{
+						"accessToken": map[string]interface{}{
+							"userConfig": map[string]interface{}{
+								"attributes": allowedAttributes,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(app)
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testutils.TestServerURL+"/applications", bytes.NewBuffer(jsonData))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		ts.T().Fatalf("Failed to create CIBA attribute-filter application. Status: %d, Response: %s",
+			resp.StatusCode, string(bodyBytes))
+	}
+
+	var respData map[string]interface{}
+	ts.Require().NoError(json.NewDecoder(resp.Body).Decode(&respData))
+	return respData["id"].(string)
+}
+
+// cibaBackchannelAuthorizeAs is cibaBackchannelAuthorize parametrized by client credentials.
+func (ts *CIBATestSuite) cibaBackchannelAuthorizeAs(
+	clientID, clientSecret, loginHint, scope string,
+) (int, cibaBackchannelResponse) {
+	form := url.Values{}
+	form.Set("login_hint", loginHint)
+	form.Set("scope", scope)
+
+	req, err := http.NewRequest("POST", testutils.TestServerURL+cibaBackchannelEndpoint,
+		strings.NewReader(form.Encode()))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(clientID, clientSecret)
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	var body cibaBackchannelResponse
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	return resp.StatusCode, body
+}
+
+// TestCIBAGrantFlow_AttributeAllowList verifies that the CIBA-issued access token only carries the
+// user attributes selected by the app's token.accessToken.userConfig.attributes allow-list, mirroring
+// the allow-list enforcement already proven for the authorization_code grant.
+func (ts *CIBATestSuite) TestCIBAGrantFlow_AttributeAllowList() {
+	appID := ts.createCIBAAppWithAttributes(cibaAttrFilterClientID, cibaAttrFilterClientSecret, []string{"email"})
+	defer func() { _ = testutils.DeleteApplication(appID) }()
+
+	status, bcResp := ts.cibaBackchannelAuthorizeAs(cibaAttrFilterClientID, cibaAttrFilterClientSecret,
+		cibaTestUsername, "openid")
+	ts.Require().Equal(http.StatusOK, status, "bc-authorize should succeed")
+	ts.Require().NotEmpty(bcResp.AuthReqID)
+
+	var executionID, inviteToken string
+	ts.Require().Eventually(func() bool {
+		msg := ts.mockServer.GetLastMessage()
+		if msg == nil {
+			return false
+		}
+		if extractCIBALinkParam(msg.Message, "auth_req_id") != bcResp.AuthReqID {
+			return false
+		}
+		executionID = extractCIBALinkParam(msg.Message, "executionId")
+		inviteToken = extractCIBALinkParam(msg.Message, "inviteToken")
+		return executionID != "" && inviteToken != ""
+	}, 5*time.Second, 100*time.Millisecond, "Expected CIBA notification carrying the executionId")
+
+	resumeStep, err := testutils.ExecuteAuthenticationFlow(executionID,
+		map[string]string{"inviteToken": inviteToken}, "")
+	ts.Require().NoError(err)
+	flowStep, err := testutils.ExecuteAuthenticationFlow(executionID, map[string]string{
+		"username": cibaTestUsername,
+		"password": cibaTestPassword,
+	}, "action_001", resumeStep.ChallengeToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus)
+	ts.Require().NotEmpty(flowStep.Assertion)
+
+	callbackStatus, _ := ts.cibaPostCallback(bcResp.AuthReqID, flowStep.Assertion)
+	ts.Require().Equal(http.StatusOK, callbackStatus)
+
+	var tokenRes cibaTokenResult
+	deadline := time.Now().Add(30 * time.Second)
+	delay := cibaPollIntervalSeconds * time.Second
+	for {
+		tokenRes = ts.cibaPollTokenAs(bcResp.AuthReqID, "", cibaAttrFilterClientID, cibaAttrFilterClientSecret)
+		if tokenRes.statusCode != http.StatusBadRequest ||
+			(tokenRes.errorCode != "slow_down" && tokenRes.errorCode != "authorization_pending") {
+			break
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(delay)
+		delay += cibaPollIntervalSeconds * time.Second
+	}
+	ts.Require().Equal(http.StatusOK, tokenRes.statusCode, "AUTHENTICATED request should issue tokens")
+	ts.Require().NotEmpty(tokenRes.accessToken)
+
+	claims, err := testutils.DecodeJWT(tokenRes.accessToken)
+	ts.Require().NoError(err)
+
+	ts.Assert().Equal("ciba_test_user@example.com", claims.Additional["email"],
+		"allow-listed attribute should be present")
+	ts.Assert().NotContains(claims.Additional, "mobile_number",
+		"non-allow-listed attribute must be excluded")
+	ts.Assert().NotContains(claims.Additional, "username",
+		"non-allow-listed attribute must be excluded")
+}

--- a/tests/integration/oauth/claims/verified_claims_test.go
+++ b/tests/integration/oauth/claims/verified_claims_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package claims
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// TestVerifiedClaims_ObjectForm_Accepted verifies that a well-formed verified_claims request
+// (OIDC Identity Assurance), given as a single object, is accepted end to end: it does not break
+// the authorization flow or token issuance, even though the requested verified claim is not
+// currently resolved into the issued token's attributes.
+func (ts *ClaimsParameterTestSuite) TestVerifiedClaims_ObjectForm_Accepted() {
+	claimsParam := `{"userinfo":{"verified_claims":{
+		"verification":{"trust_framework":{"value":"de_aml"}},
+		"claims":{"given_name":null}
+	}}}`
+
+	accessToken, _, err := ts.getTokenWithClaims("openid", claimsParam)
+	ts.Require().NoError(err, "A well-formed verified_claims request should not break token issuance")
+	ts.Require().NotEmpty(accessToken)
+}
+
+// TestVerifiedClaims_ArrayForm_Accepted verifies that the array form of verified_claims (multiple
+// verification contexts) is also accepted.
+func (ts *ClaimsParameterTestSuite) TestVerifiedClaims_ArrayForm_Accepted() {
+	claimsParam := `{"userinfo":{"verified_claims":[
+		{"verification":{"trust_framework":{"value":"de_aml"}},"claims":{"given_name":null}},
+		{"verification":{"trust_framework":null},"claims":{"family_name":null}}
+	]}}`
+
+	accessToken, _, err := ts.getTokenWithClaims("openid", claimsParam)
+	ts.Require().NoError(err, "The array form of verified_claims should be accepted")
+	ts.Require().NotEmpty(accessToken)
+}
+
+// TestVerifiedClaims_MissingVerification_InvalidRequest verifies that a verified_claims entry
+// missing the required verification member is rejected as invalid_request.
+func (ts *ClaimsParameterTestSuite) TestVerifiedClaims_MissingVerification_InvalidRequest() {
+	claimsParam := `{"userinfo":{"verified_claims":{
+		"claims":{"given_name":null}
+	}}}`
+
+	ts.assertVerifiedClaimsRejected(claimsParam)
+}
+
+// TestVerifiedClaims_MissingTrustFramework_InvalidRequest verifies that a verification element
+// missing the required trust_framework member is rejected as invalid_request.
+func (ts *ClaimsParameterTestSuite) TestVerifiedClaims_MissingTrustFramework_InvalidRequest() {
+	claimsParam := `{"userinfo":{"verified_claims":{
+		"verification":{},
+		"claims":{"given_name":null}
+	}}}`
+
+	ts.assertVerifiedClaimsRejected(claimsParam)
+}
+
+// TestVerifiedClaims_EmptyClaims_InvalidRequest verifies that a verified_claims entry with an
+// empty claims object (requesting nothing) is rejected as invalid_request.
+func (ts *ClaimsParameterTestSuite) TestVerifiedClaims_EmptyClaims_InvalidRequest() {
+	claimsParam := `{"userinfo":{"verified_claims":{
+		"verification":{"trust_framework":null},
+		"claims":{}
+	}}}`
+
+	ts.assertVerifiedClaimsRejected(claimsParam)
+}
+
+// TestVerifiedClaims_ClaimValueAndValuesConflict_InvalidRequest verifies that a nested claim
+// inside verified_claims.claims specifying both value and values (mutually exclusive per OIDC) is
+// rejected as invalid_request.
+func (ts *ClaimsParameterTestSuite) TestVerifiedClaims_ClaimValueAndValuesConflict_InvalidRequest() {
+	claimsParam := `{"userinfo":{"verified_claims":{
+		"verification":{"trust_framework":null},
+		"claims":{"given_name":{"value":"Ada","values":["Ada","Grace"]}}
+	}}}`
+
+	ts.assertVerifiedClaimsRejected(claimsParam)
+}
+
+// TestVerifiedClaims_TrustFrameworkValueAndValuesConflict_InvalidRequest verifies that a
+// constrained trust_framework specifying both value and values is rejected as invalid_request.
+func (ts *ClaimsParameterTestSuite) TestVerifiedClaims_TrustFrameworkValueAndValuesConflict_InvalidRequest() {
+	claimsParam := `{"userinfo":{"verified_claims":{
+		"verification":{"trust_framework":{"value":"de_aml","values":["de_aml","de_jlt"]}},
+		"claims":{"given_name":null}
+	}}}`
+
+	ts.assertVerifiedClaimsRejected(claimsParam)
+}
+
+// assertVerifiedClaimsRejected initiates the authorization flow with the given malformed
+// verified_claims request and asserts it is rejected as invalid_request.
+func (ts *ClaimsParameterTestSuite) assertVerifiedClaimsRejected(claimsParam string) {
+	authzResp, err := testutils.InitiateAuthorizationFlowWithClaims(
+		clientID, redirectURI, "code", "openid", "test_state", claimsParam,
+	)
+	ts.Require().NoError(err, "Failed to initiate authorization")
+	defer authzResp.Body.Close()
+
+	location := authzResp.Header.Get("Location")
+	ts.Require().NotEmpty(location, "Expected a redirect for the malformed verified_claims request")
+
+	err = testutils.ValidateOAuth2ErrorRedirect(location, "invalid_request", "")
+	assert.NoError(ts.T(), err, "Should receive invalid_request error for malformed verified_claims")
+}

--- a/tests/integration/oauth/par/par_test.go
+++ b/tests/integration/oauth/par/par_test.go
@@ -377,6 +377,20 @@ func (ts *PARTestSuite) TestPAREndpointValidation() {
 			},
 			ExpectedError: "invalid_request",
 		},
+		{
+			// This test reflects current behavior; prompt=none session checking is not implemented yet.
+			Name: "Prompt None Not Supported",
+			Params: map[string]string{
+				"response_type":         "code",
+				"redirect_uri":          redirectURI,
+				"scope":                 "openid",
+				"state":                 "test",
+				"prompt":                "none",
+				"code_challenge":        testutils.GenerateCodeChallenge("test-verifier-that-is-at-least-43-characters-long-enough"),
+				"code_challenge_method": "S256",
+			},
+			ExpectedError: "login_required",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/tests/integration/oauth/token/cc_client_attributes_test.go
+++ b/tests/integration/oauth/token/cc_client_attributes_test.go
@@ -1,0 +1,260 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package token
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	ccClientAttrsClientID                 = "cc_client_attrs_test_client"
+	ccClientAttrsClientSecret             = "cc_client_attrs_test_secret"
+	ccClientAttrsResourceServerIdentifier = "https://cc-client-attrs.example.com"
+)
+
+// CCClientAttributesTestSuite verifies that client_credentials access tokens surface
+// client-scoped claims (ouId/ouName/ouHandle, groups, roles) selected by the app's
+// token.accessToken.clientConfig.attributes allow-list.
+type CCClientAttributesTestSuite struct {
+	suite.Suite
+	client           *http.Client
+	ouID             string
+	resourceServerID string
+}
+
+// TestCCClientAttributesTestSuite runs the CCClientAttributesTestSuite.
+func TestCCClientAttributesTestSuite(t *testing.T) {
+	suite.Run(t, new(CCClientAttributesTestSuite))
+}
+
+// SetupSuite creates the shared organization unit and resource server for the suite.
+func (s *CCClientAttributesTestSuite) SetupSuite() {
+	s.client = testutils.GetHTTPClient()
+
+	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "cc-client-attrs-ou",
+		Name:        "CC Client Attributes OU",
+		Description: "Organization unit for CC client-attribute integration tests",
+	})
+	s.Require().NoError(err)
+	s.ouID = ouID
+
+	rsID, err := testutils.CreateResourceServerWithActions(testutils.ResourceServer{
+		Name:        "CC Client Attributes API",
+		Description: "Resource server for CC client-attribute testing",
+		Identifier:  ccClientAttrsResourceServerIdentifier,
+		OUID:        s.ouID,
+	}, []testutils.Action{})
+	s.Require().NoError(err)
+	s.resourceServerID = rsID
+}
+
+// TearDownSuite deletes the shared organization unit and resource server created in SetupSuite.
+func (s *CCClientAttributesTestSuite) TearDownSuite() {
+	if s.resourceServerID != "" {
+		_ = testutils.DeleteResourceServer(s.resourceServerID)
+	}
+	if s.ouID != "" {
+		_ = testutils.DeleteOrganizationUnit(s.ouID)
+	}
+}
+
+// createOAuthApp creates a client_credentials OAuth application with the given
+// clientConfig.attributes allow-list.
+func (s *CCClientAttributesTestSuite) createOAuthApp(clientID, clientSecret string, clientAttributes []string) (string, error) {
+	app := map[string]interface{}{
+		"name":                      "CC Client Attrs Test App " + clientID,
+		"description":               "Application for CC client-attribute testing",
+		"ouId":                      s.ouID,
+		"type":                      "m2m",
+		"isRegistrationFlowEnabled": false,
+		"inboundAuthConfig": []map[string]interface{}{
+			{
+				"type": "oauth2",
+				"config": map[string]interface{}{
+					"clientId":                clientID,
+					"clientSecret":            clientSecret,
+					"grantTypes":              []string{"client_credentials"},
+					"tokenEndpointAuthMethod": "client_secret_basic",
+					"token": map[string]interface{}{
+						"accessToken": map[string]interface{}{
+							"clientConfig": map[string]interface{}{
+								"attributes": clientAttributes,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(app)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequest("POST", testServerURL+"/applications", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("failed to create app: status %d, body: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	var respData map[string]interface{}
+	if err := json.Unmarshal(bodyBytes, &respData); err != nil {
+		return "", err
+	}
+	return respData["id"].(string), nil
+}
+
+// requestToken performs a client_credentials token request for the given client credentials.
+func (s *CCClientAttributesTestSuite) requestToken(clientID, clientSecret string) (int, map[string]interface{}) {
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("resource", ccClientAttrsResourceServerIdentifier)
+
+	req, err := http.NewRequest("POST", testServerURL+"/oauth2/token", strings.NewReader(form.Encode()))
+	s.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(clientID, clientSecret)
+
+	resp, err := s.client.Do(req)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	var respBody map[string]interface{}
+	s.Require().NoError(json.NewDecoder(resp.Body).Decode(&respBody))
+	return resp.StatusCode, respBody
+}
+
+// TestCCClientAttrs_OUAndGroupsAndRoles verifies that ouId/ouName/ouHandle, groups, and
+// roles (both directly assigned and group-inherited) are all present in the access token
+// when allow-listed.
+func (s *CCClientAttributesTestSuite) TestCCClientAttrs_OUAndGroupsAndRoles() {
+	clientID := ccClientAttrsClientID + "_full"
+	appID, err := s.createOAuthApp(clientID, ccClientAttrsClientSecret,
+		[]string{"ouId", "ouName", "ouHandle", "groups", "roles"})
+	s.Require().NoError(err)
+	defer func() { _ = testutils.DeleteApplication(appID) }()
+
+	directRoleID, err := testutils.CreateRole(testutils.Role{
+		Name:        "CC Client Attrs Direct Role",
+		Description: "Role assigned directly to the app",
+		OUID:        s.ouID,
+		Assignments: []testutils.Assignment{{ID: appID, Type: "app"}},
+	})
+	s.Require().NoError(err)
+	defer func() { _ = testutils.DeleteRole(directRoleID) }()
+
+	groupID, err := testutils.CreateGroup(testutils.Group{
+		Name:    "CC Client Attrs Group",
+		OUID:    s.ouID,
+		Members: []testutils.Member{{Id: appID, Type: "app"}},
+	})
+	s.Require().NoError(err)
+	defer func() { _ = testutils.DeleteGroup(groupID) }()
+
+	groupRoleID, err := testutils.CreateRole(testutils.Role{
+		Name:        "CC Client Attrs Group Role",
+		Description: "Role assigned to the group containing the app",
+		OUID:        s.ouID,
+		Assignments: []testutils.Assignment{{ID: groupID, Type: "group"}},
+	})
+	s.Require().NoError(err)
+	defer func() { _ = testutils.DeleteRole(groupRoleID) }()
+
+	status, body := s.requestToken(clientID, ccClientAttrsClientSecret)
+	s.Require().Equal(http.StatusOK, status)
+	token, ok := body["access_token"].(string)
+	s.Require().True(ok, "Response should contain access_token")
+
+	claims, err := testutils.DecodeJWT(token)
+	s.Require().NoError(err)
+
+	s.Assert().Equal(s.ouID, claims.Additional["ouId"], "ouId claim should match the app's OU")
+	s.Assert().Equal("CC Client Attributes OU", claims.Additional["ouName"])
+	s.Assert().Equal("cc-client-attrs-ou", claims.Additional["ouHandle"])
+
+	groups, ok := claims.Additional["groups"].([]interface{})
+	s.Require().True(ok, "groups claim should be present as an array")
+	s.Assert().Contains(groups, "CC Client Attrs Group")
+
+	roles, ok := claims.Additional["roles"].([]interface{})
+	s.Require().True(ok, "roles claim should be present as an array")
+	s.Assert().ElementsMatch([]interface{}{"CC Client Attrs Direct Role", "CC Client Attrs Group Role"}, roles)
+}
+
+// TestCCClientAttrs_PartialAllowList verifies that only the allow-listed attributes are
+// included, even when the app is eligible for others (OU, groups, roles all resolvable).
+func (s *CCClientAttributesTestSuite) TestCCClientAttrs_PartialAllowList() {
+	clientID := ccClientAttrsClientID + "_partial"
+	appID, err := s.createOAuthApp(clientID, ccClientAttrsClientSecret, []string{"ouId"})
+	s.Require().NoError(err)
+	defer func() { _ = testutils.DeleteApplication(appID) }()
+
+	groupID, err := testutils.CreateGroup(testutils.Group{
+		Name:    "CC Client Attrs Partial Group",
+		OUID:    s.ouID,
+		Members: []testutils.Member{{Id: appID, Type: "app"}},
+	})
+	s.Require().NoError(err)
+	defer func() { _ = testutils.DeleteGroup(groupID) }()
+
+	status, body := s.requestToken(clientID, ccClientAttrsClientSecret)
+	s.Require().Equal(http.StatusOK, status)
+	token, ok := body["access_token"].(string)
+	s.Require().True(ok)
+
+	claims, err := testutils.DecodeJWT(token)
+	s.Require().NoError(err)
+
+	s.Assert().Equal(s.ouID, claims.Additional["ouId"])
+	s.Assert().NotContains(claims.Additional, "ouName", "ouName must be excluded when not allow-listed")
+	s.Assert().NotContains(claims.Additional, "ouHandle", "ouHandle must be excluded when not allow-listed")
+	s.Assert().NotContains(claims.Additional, "groups", "groups must be excluded when not allow-listed")
+	s.Assert().NotContains(claims.Additional, "roles", "roles must be excluded when not allow-listed")
+}
+
+// TestCCClientAttrs_NoAllowListConfigured verifies that no client-scoped claims are added
+// when the app has no clientConfig.attributes configured at all.
+func (s *CCClientAttributesTestSuite) TestCCClientAttrs_NoAllowListConfigured() {
+	clientID := ccClientAttrsClientID + "_none"
+	appID, err := s.createOAuthApp(clientID, ccClientAttrsClientSecret, nil)
+	s.Require().NoError(err)
+	defer func() { _ = testutils.DeleteApplication(appID) }()
+
+	status, body := s.requestToken(clientID, ccClientAttrsClientSecret)
+	s.Require().Equal(http.StatusOK, status)
+	token, ok := body["access_token"].(string)
+	s.Require().True(ok)
+
+	claims, err := testutils.DecodeJWT(token)
+	s.Require().NoError(err)
+
+	s.Assert().NotContains(claims.Additional, "ouId")
+	s.Assert().NotContains(claims.Additional, "ouName")
+	s.Assert().NotContains(claims.Additional, "ouHandle")
+	s.Assert().NotContains(claims.Additional, "groups")
+	s.Assert().NotContains(claims.Additional, "roles")
+}

--- a/tests/integration/oauth/token/refresh_token_attribute_filter_test.go
+++ b/tests/integration/oauth/token/refresh_token_attribute_filter_test.go
@@ -1,0 +1,283 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package token
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	rtAttrFilterClientID     = "rt_attr_filter_test_client"
+	rtAttrFilterClientSecret = "rt_attr_filter_test_secret"
+	rtAttrFilterRedirectURI  = "https://localhost:3000"
+	rtAttrFilterUsername     = "rt_attr_filter_test_user"
+	rtAttrFilterPassword     = "RtAttrFilterPass1!"
+)
+
+var rtAttrFilterUserType = testutils.UserType{
+	Name: "rt-attr-filter-person",
+	Schema: map[string]interface{}{
+		"username":    map[string]interface{}{"type": "string"},
+		"password":    map[string]interface{}{"type": "string", "credential": true},
+		"given_name":  map[string]interface{}{"type": "string"},
+		"family_name": map[string]interface{}{"type": "string"},
+	},
+}
+
+var rtAttrFilterAuthFlow = testutils.Flow{
+	Name:     "Refresh Token Attribute Filter Auth Flow",
+	FlowType: "AUTHENTICATION",
+	Handle:   "auth_flow_rt_attr_filter_test",
+	Nodes: []map[string]interface{}{
+		{
+			"id":        "start",
+			"type":      "START",
+			"onSuccess": "prompt_credentials",
+		},
+		{
+			"id":   "prompt_credentials",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+						{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+					},
+					"action": map[string]interface{}{"ref": "action_001", "nextNode": "credentials_auth"},
+				},
+			},
+		},
+		{
+			"id":   "credentials_auth",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "CredentialsAuthExecutor",
+				"inputs": []map[string]interface{}{
+					{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+					{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+				},
+			},
+			"onSuccess": "auth_assert",
+		},
+		{
+			"id":        "auth_assert",
+			"type":      "TASK_EXECUTION",
+			"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+			"onSuccess": "end",
+		},
+		{"id": "end", "type": "END"},
+	},
+}
+
+// RefreshTokenAttributeFilterTestSuite verifies that a refresh_token-issued access token only
+// carries the user attributes selected by the app's token.accessToken.userConfig.attributes
+// allow-list, mirroring the allow-list enforcement already proven for the authorization_code grant.
+type RefreshTokenAttributeFilterTestSuite struct {
+	suite.Suite
+	client           *http.Client
+	ouID             string
+	entityTypeID     string
+	authFlowID       string
+	userID           string
+	applicationID    string
+	resourceServerID string
+}
+
+// TestRefreshTokenAttributeFilterTestSuite runs the RefreshTokenAttributeFilterTestSuite.
+func TestRefreshTokenAttributeFilterTestSuite(t *testing.T) {
+	suite.Run(t, new(RefreshTokenAttributeFilterTestSuite))
+}
+
+// SetupSuite creates the shared organization unit, user type, auth flow, resource server,
+// application, and test user for the suite.
+func (ts *RefreshTokenAttributeFilterTestSuite) SetupSuite() {
+	ts.client = testutils.GetHTTPClient()
+
+	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "rt-attr-filter-ou",
+		Name:        "Refresh Token Attribute Filter OU",
+		Description: "Organization unit for refresh token attribute allow-list integration tests",
+	})
+	ts.Require().NoError(err)
+	ts.ouID = ouID
+
+	rtAttrFilterUserType.OUID = ouID
+	schemaID, err := testutils.CreateUserType(rtAttrFilterUserType)
+	ts.Require().NoError(err)
+	ts.entityTypeID = schemaID
+
+	flowID, err := testutils.CreateFlow(rtAttrFilterAuthFlow)
+	ts.Require().NoError(err)
+	ts.authFlowID = flowID
+
+	rsID, err := testutils.CreateResourceServerWithActions(testutils.ResourceServer{
+		Name:        "Refresh Token Attribute Filter API",
+		Description: "Resource server for refresh token attribute allow-list testing",
+		Identifier:  "https://rt-attr-filter.example.com",
+		OUID:        ts.ouID,
+	}, []testutils.Action{})
+	ts.Require().NoError(err)
+	ts.resourceServerID = rsID
+
+	ts.applicationID = ts.createTestApplication()
+
+	attributesJSON, err := json.Marshal(map[string]interface{}{
+		"username":    rtAttrFilterUsername,
+		"password":    rtAttrFilterPassword,
+		"given_name":  "Ada",
+		"family_name": "Lovelace",
+	})
+	ts.Require().NoError(err)
+	userID, err := testutils.CreateUser(testutils.User{
+		OUID:       ouID,
+		Type:       "rt-attr-filter-person",
+		Attributes: json.RawMessage(attributesJSON),
+	})
+	ts.Require().NoError(err)
+	ts.userID = userID
+}
+
+// TearDownSuite deletes the resources created in SetupSuite.
+func (ts *RefreshTokenAttributeFilterTestSuite) TearDownSuite() {
+	if ts.userID != "" {
+		_ = testutils.DeleteUser(ts.userID)
+	}
+	if ts.applicationID != "" {
+		_ = testutils.DeleteApplication(ts.applicationID)
+	}
+	if ts.resourceServerID != "" {
+		_ = testutils.DeleteResourceServer(ts.resourceServerID)
+	}
+	if ts.authFlowID != "" {
+		_ = testutils.DeleteFlow(ts.authFlowID)
+	}
+	if ts.entityTypeID != "" {
+		_ = testutils.DeleteUserType(ts.entityTypeID)
+	}
+	if ts.ouID != "" {
+		_ = testutils.DeleteOrganizationUnit(ts.ouID)
+	}
+}
+
+// createTestApplication creates the authorization_code/refresh_token application with a
+// given_name-only userConfig.attributes allow-list.
+func (ts *RefreshTokenAttributeFilterTestSuite) createTestApplication() string {
+	app := map[string]interface{}{
+		"name":                      "RefreshTokenAttrFilterTestApp",
+		"description":               "Application for refresh token attribute allow-list testing",
+		"ouId":                      ts.ouID,
+		"type":                      "fullstack",
+		"authFlowId":                ts.authFlowID,
+		"isRegistrationFlowEnabled": false,
+		"allowedUserTypes":          []string{"rt-attr-filter-person"},
+		"inboundAuthConfig": []map[string]interface{}{
+			{
+				"type": "oauth2",
+				"config": map[string]interface{}{
+					"clientId":                rtAttrFilterClientID,
+					"clientSecret":            rtAttrFilterClientSecret,
+					"redirectUris":            []string{rtAttrFilterRedirectURI},
+					"grantTypes":              []string{"authorization_code", "refresh_token"},
+					"responseTypes":           []string{"code"},
+					"tokenEndpointAuthMethod": "client_secret_basic",
+					"token": map[string]interface{}{
+						"accessToken": map[string]interface{}{
+							"userConfig": map[string]interface{}{
+								"attributes": []string{"given_name"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(app)
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testutils.TestServerURL+"/applications", bytes.NewBuffer(jsonData))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	ts.Require().Equal(http.StatusCreated, resp.StatusCode, string(bodyBytes))
+
+	var respData map[string]interface{}
+	ts.Require().NoError(json.Unmarshal(bodyBytes, &respData))
+	return respData["id"].(string)
+}
+
+// obtainTokensViaAuthCodeFlow performs the full authorization code flow and returns the token response.
+func (ts *RefreshTokenAttributeFilterTestSuite) obtainTokensViaAuthCodeFlow() *testutils.TokenResponse {
+	resp, err := testutils.InitiateAuthorizationFlowWithResource(
+		rtAttrFilterClientID, rtAttrFilterRedirectURI, "code", "openid", "test-state",
+		"https://rt-attr-filter.example.com")
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusFound, resp.StatusCode)
+
+	location := resp.Header.Get("Location")
+	ts.Require().NotEmpty(location)
+
+	authID, executionID, err := testutils.ExtractAuthData(location)
+	ts.Require().NoError(err)
+
+	initialStep, err := testutils.ExecuteAuthenticationFlow(executionID, nil, "")
+	ts.Require().NoError(err)
+
+	flowStep, err := testutils.ExecuteAuthenticationFlow(executionID, map[string]string{
+		"username": rtAttrFilterUsername,
+		"password": rtAttrFilterPassword,
+	}, "action_001", initialStep.ChallengeToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus)
+	ts.Require().NotEmpty(flowStep.Assertion)
+
+	authzResp, err := testutils.CompleteAuthorization(authID, flowStep.Assertion)
+	ts.Require().NoError(err)
+
+	code, err := testutils.ExtractAuthorizationCode(authzResp.RedirectURI)
+	ts.Require().NoError(err)
+
+	tokenResult, err := testutils.RequestTokenWithResource(
+		rtAttrFilterClientID, rtAttrFilterClientSecret, code, rtAttrFilterRedirectURI, "authorization_code",
+		"https://rt-attr-filter.example.com")
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusOK, tokenResult.StatusCode, string(tokenResult.Body))
+	ts.Require().NotNil(tokenResult.Token)
+	ts.Require().NotEmpty(tokenResult.Token.RefreshToken)
+
+	return tokenResult.Token
+}
+
+// TestRefreshToken_AttributeAllowList verifies that only the allow-listed subject attribute
+// (given_name) is present in the refreshed access token, and non-allow-listed attributes
+// (family_name) are excluded.
+func (ts *RefreshTokenAttributeFilterTestSuite) TestRefreshToken_AttributeAllowList() {
+	tokenResponse := ts.obtainTokensViaAuthCodeFlow()
+
+	refreshResponse, err := testutils.RefreshAccessToken(
+		rtAttrFilterClientID, rtAttrFilterClientSecret, tokenResponse.RefreshToken)
+	ts.Require().NoError(err, "refresh token request should succeed")
+	ts.Require().NotNil(refreshResponse)
+	ts.Require().NotEmpty(refreshResponse.AccessToken)
+
+	claims, err := testutils.DecodeJWT(refreshResponse.AccessToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal(ts.userID, claims.Sub)
+
+	ts.Assert().Equal("Ada", claims.Additional["given_name"], "allow-listed attribute should be present")
+	ts.Assert().NotContains(claims.Additional, "family_name", "non-allow-listed attribute must be excluded")
+}

--- a/tests/integration/oauth/token/token_exchange_attribute_filter_test.go
+++ b/tests/integration/oauth/token/token_exchange_attribute_filter_test.go
@@ -1,0 +1,350 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package token
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	teAttrFilterIssuerClientID     = "te_attr_filter_issuer_client"
+	teAttrFilterIssuerClientSecret = "te_attr_filter_issuer_secret"
+	teAttrFilterExchangeClientID   = "te_attr_filter_exchange_client"
+	teAttrFilterExchangeSecret     = "te_attr_filter_exchange_secret"
+	teAttrFilterRedirectURI        = "https://localhost:3000"
+	teAttrFilterUsername           = "te_attr_filter_test_user"
+	teAttrFilterPassword           = "TeAttrFilterPass1!"
+)
+
+var teAttrFilterUserType = testutils.UserType{
+	Name: "te-attr-filter-person",
+	Schema: map[string]interface{}{
+		"username":    map[string]interface{}{"type": "string"},
+		"password":    map[string]interface{}{"type": "string", "credential": true},
+		"given_name":  map[string]interface{}{"type": "string"},
+		"family_name": map[string]interface{}{"type": "string"},
+	},
+}
+
+var teAttrFilterAuthFlow = testutils.Flow{
+	Name:     "Token Exchange Attribute Filter Auth Flow",
+	FlowType: "AUTHENTICATION",
+	Handle:   "auth_flow_te_attr_filter_test",
+	Nodes: []map[string]interface{}{
+		{
+			"id":        "start",
+			"type":      "START",
+			"onSuccess": "prompt_credentials",
+		},
+		{
+			"id":   "prompt_credentials",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+						{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+					},
+					"action": map[string]interface{}{"ref": "action_001", "nextNode": "credentials_auth"},
+				},
+			},
+		},
+		{
+			"id":   "credentials_auth",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "CredentialsAuthExecutor",
+				"inputs": []map[string]interface{}{
+					{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+					{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+				},
+			},
+			"onSuccess": "auth_assert",
+		},
+		{
+			"id":        "auth_assert",
+			"type":      "TASK_EXECUTION",
+			"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+			"onSuccess": "end",
+		},
+		{"id": "end", "type": "END"},
+	},
+}
+
+// TokenExchangeAttributeFilterTestSuite verifies that a token-exchange-issued access token only
+// carries the subject attributes selected by the exchange app's
+// token.accessToken.userConfig.attributes allow-list, mirroring the allow-list enforcement already
+// proven for the authorization_code grant. The subject_token presented for exchange is a real
+// access token (subject_token_type=access_token) minted for a separate "issuer" app so the two
+// apps' allow-lists can differ and the exchange step's own filtering can be observed independently.
+type TokenExchangeAttributeFilterTestSuite struct {
+	suite.Suite
+	client           *http.Client
+	ouID             string
+	entityTypeID     string
+	authFlowID       string
+	userID           string
+	issuerAppID      string
+	exchangeAppID    string
+	resourceServerID string
+}
+
+// TestTokenExchangeAttributeFilterTestSuite runs the TokenExchangeAttributeFilterTestSuite.
+func TestTokenExchangeAttributeFilterTestSuite(t *testing.T) {
+	suite.Run(t, new(TokenExchangeAttributeFilterTestSuite))
+}
+
+// SetupSuite creates the shared organization unit, user type, auth flow, resource server,
+// issuer/exchange applications, and test user for the suite.
+func (ts *TokenExchangeAttributeFilterTestSuite) SetupSuite() {
+	ts.client = testutils.GetHTTPClient()
+
+	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "te-attr-filter-ou",
+		Name:        "Token Exchange Attribute Filter OU",
+		Description: "Organization unit for token exchange attribute allow-list integration tests",
+	})
+	ts.Require().NoError(err)
+	ts.ouID = ouID
+
+	teAttrFilterUserType.OUID = ouID
+	entityTypeID, err := testutils.CreateUserType(teAttrFilterUserType)
+	ts.Require().NoError(err)
+	ts.entityTypeID = entityTypeID
+
+	flowID, err := testutils.CreateFlow(teAttrFilterAuthFlow)
+	ts.Require().NoError(err)
+	ts.authFlowID = flowID
+
+	rsID, err := testutils.CreateResourceServerWithActions(testutils.ResourceServer{
+		Name:        "Token Exchange Attribute Filter API",
+		Description: "Resource server for token exchange attribute allow-list testing",
+		Identifier:  "https://te-attr-filter.example.com",
+		OUID:        ts.ouID,
+	}, []testutils.Action{})
+	ts.Require().NoError(err)
+	ts.resourceServerID = rsID
+
+	ts.issuerAppID = ts.createIssuerApplication()
+	ts.exchangeAppID = ts.createExchangeApplication()
+
+	attributesJSON, err := json.Marshal(map[string]interface{}{
+		"username":    teAttrFilterUsername,
+		"password":    teAttrFilterPassword,
+		"given_name":  "Ada",
+		"family_name": "Lovelace",
+	})
+	ts.Require().NoError(err)
+	userID, err := testutils.CreateUser(testutils.User{
+		OUID:       ouID,
+		Type:       "te-attr-filter-person",
+		Attributes: json.RawMessage(attributesJSON),
+	})
+	ts.Require().NoError(err)
+	ts.userID = userID
+}
+
+// TearDownSuite deletes the resources created in SetupSuite.
+func (ts *TokenExchangeAttributeFilterTestSuite) TearDownSuite() {
+	if ts.userID != "" {
+		_ = testutils.DeleteUser(ts.userID)
+	}
+	if ts.exchangeAppID != "" {
+		_ = testutils.DeleteApplication(ts.exchangeAppID)
+	}
+	if ts.issuerAppID != "" {
+		_ = testutils.DeleteApplication(ts.issuerAppID)
+	}
+	if ts.resourceServerID != "" {
+		_ = testutils.DeleteResourceServer(ts.resourceServerID)
+	}
+	if ts.authFlowID != "" {
+		_ = testutils.DeleteFlow(ts.authFlowID)
+	}
+	if ts.entityTypeID != "" {
+		_ = testutils.DeleteUserType(ts.entityTypeID)
+	}
+	if ts.ouID != "" {
+		_ = testutils.DeleteOrganizationUnit(ts.ouID)
+	}
+}
+
+// createIssuerApplication creates the authorization_code app whose access tokens carry both
+// given_name and family_name; its issued access token is used as the token-exchange subject_token.
+func (ts *TokenExchangeAttributeFilterTestSuite) createIssuerApplication() string {
+	return ts.createApplication(map[string]interface{}{
+		"clientId":                teAttrFilterIssuerClientID,
+		"clientSecret":            teAttrFilterIssuerClientSecret,
+		"redirectUris":            []string{teAttrFilterRedirectURI},
+		"grantTypes":              []string{"authorization_code"},
+		"responseTypes":           []string{"code"},
+		"tokenEndpointAuthMethod": "client_secret_basic",
+		"token": map[string]interface{}{
+			"accessToken": map[string]interface{}{
+				"userConfig": map[string]interface{}{
+					"attributes": []string{"given_name", "family_name"},
+				},
+			},
+		},
+	}, true)
+}
+
+// createExchangeApplication creates the token-exchange app whose allow-list only permits given_name.
+func (ts *TokenExchangeAttributeFilterTestSuite) createExchangeApplication() string {
+	return ts.createApplication(map[string]interface{}{
+		"clientId":                teAttrFilterExchangeClientID,
+		"clientSecret":            teAttrFilterExchangeSecret,
+		"grantTypes":              []string{"urn:ietf:params:oauth:grant-type:token-exchange"},
+		"tokenEndpointAuthMethod": "client_secret_basic",
+		"token": map[string]interface{}{
+			"accessToken": map[string]interface{}{
+				"userConfig": map[string]interface{}{
+					"attributes": []string{"given_name"},
+				},
+			},
+		},
+	}, false)
+}
+
+// createApplication creates an application with the given OAuth2 inbound config, optionally
+// bound to the shared auth flow.
+func (ts *TokenExchangeAttributeFilterTestSuite) createApplication(
+	oauthConfig map[string]interface{}, withAuthFlow bool,
+) string {
+	app := map[string]interface{}{
+		"name":                      "TokenExchangeAttrFilterApp-" + oauthConfig["clientId"].(string),
+		"description":               "Application for token exchange attribute allow-list testing",
+		"ouId":                      ts.ouID,
+		"type":                      "fullstack",
+		"isRegistrationFlowEnabled": false,
+		"allowedUserTypes":          []string{"te-attr-filter-person"},
+		"inboundAuthConfig": []map[string]interface{}{
+			{
+				"type":   "oauth2",
+				"config": oauthConfig,
+			},
+		},
+	}
+	if withAuthFlow {
+		app["authFlowId"] = ts.authFlowID
+	}
+
+	jsonData, err := json.Marshal(app)
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testutils.TestServerURL+"/applications", bytes.NewBuffer(jsonData))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	ts.Require().Equal(http.StatusCreated, resp.StatusCode, string(bodyBytes))
+
+	var respData map[string]interface{}
+	ts.Require().NoError(json.Unmarshal(bodyBytes, &respData))
+	return respData["id"].(string)
+}
+
+// obtainIssuerAccessToken performs the full authorization code flow against the issuer app and
+// returns the resulting access token (which carries given_name and family_name).
+func (ts *TokenExchangeAttributeFilterTestSuite) obtainIssuerAccessToken() string {
+	resp, err := testutils.InitiateAuthorizationFlow(
+		teAttrFilterIssuerClientID, teAttrFilterRedirectURI, "code", "openid", "test-state")
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusFound, resp.StatusCode)
+
+	location := resp.Header.Get("Location")
+	ts.Require().NotEmpty(location)
+
+	authID, executionID, err := testutils.ExtractAuthData(location)
+	ts.Require().NoError(err)
+
+	initialStep, err := testutils.ExecuteAuthenticationFlow(executionID, nil, "")
+	ts.Require().NoError(err)
+
+	flowStep, err := testutils.ExecuteAuthenticationFlow(executionID, map[string]string{
+		"username": teAttrFilterUsername,
+		"password": teAttrFilterPassword,
+	}, "action_001", initialStep.ChallengeToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus)
+	ts.Require().NotEmpty(flowStep.Assertion)
+
+	authzResp, err := testutils.CompleteAuthorization(authID, flowStep.Assertion)
+	ts.Require().NoError(err)
+
+	code, err := testutils.ExtractAuthorizationCode(authzResp.RedirectURI)
+	ts.Require().NoError(err)
+
+	tokenResult, err := testutils.RequestToken(
+		teAttrFilterIssuerClientID, teAttrFilterIssuerClientSecret, code, teAttrFilterRedirectURI, "authorization_code")
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusOK, tokenResult.StatusCode, string(tokenResult.Body))
+	ts.Require().NotNil(tokenResult.Token)
+	ts.Require().NotEmpty(tokenResult.Token.AccessToken)
+
+	// Sanity check: the issuer app's own allow-list surfaces both attributes.
+	claims, err := testutils.DecodeJWT(tokenResult.Token.AccessToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal("Ada", claims.Additional["given_name"])
+	ts.Require().Equal("Lovelace", claims.Additional["family_name"])
+
+	return tokenResult.Token.AccessToken
+}
+
+// doTokenExchange submits a token-exchange grant request authenticated as the exchange app.
+func (ts *TokenExchangeAttributeFilterTestSuite) doTokenExchange(formData url.Values) (int, map[string]interface{}) {
+	req, err := http.NewRequest("POST", testutils.TestServerURL+"/oauth2/token", strings.NewReader(formData.Encode()))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(teAttrFilterExchangeClientID, teAttrFilterExchangeSecret)
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	var respBody map[string]interface{}
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	ts.Require().NoError(json.Unmarshal(bodyBytes, &respBody), "body: %s", string(bodyBytes))
+	return resp.StatusCode, respBody
+}
+
+// TestTokenExchange_AttributeAllowList verifies that only the allow-listed subject attribute
+// (given_name) is present in the exchanged access token, and a non-allow-listed attribute
+// (family_name) that was present on the subject_token is excluded.
+func (ts *TokenExchangeAttributeFilterTestSuite) TestTokenExchange_AttributeAllowList() {
+	issuerAccessToken := ts.obtainIssuerAccessToken()
+
+	formData := url.Values{}
+	formData.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+	formData.Set("subject_token", issuerAccessToken)
+	formData.Set("subject_token_type", "urn:ietf:params:oauth:token-type:access_token")
+	formData.Set("resource", "https://te-attr-filter.example.com")
+
+	status, body := ts.doTokenExchange(formData)
+	ts.Require().Equal(http.StatusOK, status, "%v", body)
+
+	token, ok := body["access_token"].(string)
+	ts.Require().True(ok, "Response should contain access_token")
+
+	claims, err := testutils.DecodeJWT(token)
+	ts.Require().NoError(err)
+	ts.Require().Equal(ts.userID, claims.Sub)
+
+	ts.Assert().Equal("Ada", claims.Additional["given_name"], "allow-listed attribute should be present")
+	ts.Assert().NotContains(claims.Additional, "family_name", "non-allow-listed attribute must be excluded")
+}

--- a/tests/integration/testutils/oauth2_utils.go
+++ b/tests/integration/testutils/oauth2_utils.go
@@ -42,20 +42,21 @@ func getFlowStepErrorMessage(step *FlowStep) string {
 
 // InitiateAuthorizationFlow starts the OAuth2 authorization flow
 func InitiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state string) (*http.Response, error) {
-	return initiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state, "", "", "", "", "", "")
+	return initiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state, "", "", "", "", "", "", "")
 }
 
 // InitiateAuthorizationFlowWithResource starts the OAuth2 authorization flow with resource parameter
 func InitiateAuthorizationFlowWithResource(clientID, redirectURI, responseType, scope, state,
 	resource string) (*http.Response, error) {
-	return initiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state, resource, "", "", "", "", "")
+	return initiateAuthorizationFlow(
+		clientID, redirectURI, responseType, scope, state, resource, "", "", "", "", "", "")
 }
 
 // InitiateAuthorizationFlowWithPKCE starts the OAuth2 authorization flow with PKCE parameters
 func InitiateAuthorizationFlowWithPKCE(clientID, redirectURI, responseType, scope, state, resource,
 	codeChallenge, codeChallengeMethod string) (*http.Response, error) {
 	return initiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state, resource,
-		codeChallenge, codeChallengeMethod, "", "", "")
+		codeChallenge, codeChallengeMethod, "", "", "", "")
 }
 
 // InitiateAuthorizationFlowWithClaims starts the OAuth2 authorization flow with claims parameter
@@ -63,7 +64,7 @@ func InitiateAuthorizationFlowWithClaims(
 	clientID, redirectURI, responseType, scope, state, claimsParam string,
 ) (*http.Response, error) {
 	return initiateAuthorizationFlow(
-		clientID, redirectURI, responseType, scope, state, "", "", "", claimsParam, "", "")
+		clientID, redirectURI, responseType, scope, state, "", "", "", claimsParam, "", "", "")
 }
 
 // InitiateAuthorizationFlowWithClaimsLocales starts the OAuth2 authorization flow with claims_locales parameter
@@ -71,7 +72,7 @@ func InitiateAuthorizationFlowWithClaimsLocales(
 	clientID, redirectURI, responseType, scope, state, claimsLocales string,
 ) (*http.Response, error) {
 	return initiateAuthorizationFlow(
-		clientID, redirectURI, responseType, scope, state, "", "", "", "", claimsLocales, "",
+		clientID, redirectURI, responseType, scope, state, "", "", "", "", claimsLocales, "", "",
 	)
 }
 
@@ -81,15 +82,25 @@ func InitiateAuthorizationFlowWithNonce(
 ) (*http.Response, error) {
 	return initiateAuthorizationFlow(
 		clientID, redirectURI, responseType, scope, state,
-		"", "", "", "", "", nonce,
+		"", "", "", "", "", nonce, "",
+	)
+}
+
+// InitiateAuthorizationFlowWithPrompt starts the OAuth2 authorization flow with the prompt parameter
+func InitiateAuthorizationFlowWithPrompt(
+	clientID, redirectURI, responseType, scope, state, prompt string,
+) (*http.Response, error) {
+	return initiateAuthorizationFlow(
+		clientID, redirectURI, responseType, scope, state, "", "", "", "", "", "", prompt,
 	)
 }
 
 // initiateAuthorizationFlow starts the OAuth2 authorization flow with all optional parameters.
 // clientID, redirectURI, responseType, scope, and state are required parameters.
-// resource, codeChallenge, codeChallengeMethod, claimsParam, and claimsLocales, and nonce are optional parameters.
+// resource, codeChallenge, codeChallengeMethod, claimsParam, claimsLocales, nonce, and prompt are
+// optional parameters.
 func initiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state, resource,
-	codeChallenge, codeChallengeMethod, claimsParam, claimsLocales, nonce string) (*http.Response, error) {
+	codeChallenge, codeChallengeMethod, claimsParam, claimsLocales, nonce, prompt string) (*http.Response, error) {
 	authURL := TestServerURL + "/oauth2/authorize"
 	params := url.Values{}
 	params.Set("client_id", clientID)
@@ -112,6 +123,9 @@ func initiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state
 	}
 	if nonce != "" {
 		params.Set("nonce", nonce)
+	}
+	if prompt != "" {
+		params.Set("prompt", prompt)
 	}
 
 	req, err := http.NewRequest("GET", authURL+"?"+params.Encode(), nil)


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

Adds integration tests for four previously under-covered areas for OAuth protocol & token issuance:

- Client_credentials and agent token claim content (group/role/entity/system claims, allow-list scoping)
- Nested claims support: OIDC Identity Assurance `verified_claims` request parameter validation
- Attribute allow-list filtering across the `ciba`, `refresh_token`, and `token_exchange` grant paths
- The `prompt=none` error path at `/authorize` and `/oauth2/par`

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

 - `tests/integration/oauth/token/cc_client_attributes_test.go` and `tests/integration/agent/agent_client_attributes_test.go` verify that OU, groups, roles, schema, and system claims are correctly included/excluded from issued tokens based on the configured attribute allow-list, for both client_credentials apps and agents. Added a `Token` field to `OAuthAgentConfig` in `tests/integration/agent/model.go` (mirroring the existing pattern in `tests/integration/application/model.go`) so agent tests can configure an access-token attribute allow-list.
- `tests/integration/oauth/claims/verified_claims_test.go` covers the `claims` request parameter's `verified_claims` (OIDC IDA) object and array forms, including rejection of malformed `verification`/`trust_framework` shapes and conflicting `value`/`values` constraints. Note: `verified_claims` requests are validated but not currently resolved into output token/userinfo claims, so these tests assert request acceptance/rejection rather than claim presence.
- `tests/integration/oauth/ciba/ciba_attribute_filter_test.go`, `tests/integration/oauth/token/refresh_token_attribute_filter_test.go`, and `tests/integration/oauth/token/token_exchange_attribute_filter_test.go` each verify that the subject-attribute allow-list is enforced consistently for the CIBA, refresh_token, and token_exchange grant types, not just authorization_code/client_credentials.
- `tests/integration/oauth/authz/prompt_none_test.go` and a new case in `tests/integration/oauth/par/par_test.go` cover `prompt=none` handling: `login_required` when no session exists, `invalid_request` when combined with other prompt values, and rejection of unsupported prompt values. The PAR case documents current behavior as-is (see comment in the test).
- Added a `prompt` parameter to the shared `initiateAuthorizationFlow` helper (`tests/integration/testutils/oauth2_utils.go`) plus a public `InitiateAuthorizationFlowWithPrompt` wrapper, so tests can drive the authorize endpoint with an explicit `prompt` value without changing any existing callers' behavior (all pass `""`).

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded OAuth coverage for access-token attribute filtering across client credentials, refresh tokens, token exchange, CIBA, and agent flows.
  * Added validation confirming allowed claims are retained while non-allowed claims are excluded.
  * Added OIDC Identity Assurance verified-claims coverage for valid object and array formats, plus invalid-request scenarios.
  * Added authorization coverage for `prompt=none`, unsupported values, invalid combinations, redirects, and state handling.
  * Improved authorization-flow test support for the `prompt` parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->