### PR TITLE
Remove b2c try it out coming soon tiles

### DIFF
--- a/frontend/apps/console/src/features/welcome/pages/TryoutSecuringApplicationPage.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/TryoutSecuringApplicationPage.tsx
@@ -15,17 +15,7 @@ import {
   LinearProgress,
   AppBreadcrumbs,
 } from '@wso2/oxygen-ui';
-import {
-  AppWindow,
-  X,
-  BookOpen,
-  KeyRound,
-  LogIn,
-  Share2,
-  ShieldCheck,
-  UserCheck,
-  UserPlus,
-} from '@wso2/oxygen-ui-icons-react';
+import {AppWindow, X, BookOpen, KeyRound, LogIn, UserCheck, UserPlus} from '@wso2/oxygen-ui-icons-react';
 import {motion} from 'framer-motion';
 import {useState, type JSX} from 'react';
 import {Trans, useTranslation} from 'react-i18next';
@@ -42,7 +32,7 @@ import useWelcomeClose from '../hooks/useWelcomeClose';
 
 const MotionBox = motion.create(Box);
 
-type ScenarioTab = 'login' | 'signup' | 'recovery' | 'onboard' | 'mfa' | 'social';
+type ScenarioTab = 'login' | 'signup' | 'recovery' | 'onboard';
 
 export default function TryoutSecuringConsumerApp(): JSX.Element {
   const {t} = useTranslation(['common']);
@@ -66,18 +56,6 @@ export default function TryoutSecuringConsumerApp(): JSX.Element {
       value: 'onboard',
       label: t('common:welcome.applicationTryout.scenarios.tabs.onboard'),
       icon: <UserCheck size={15} />,
-    },
-    {
-      value: 'mfa',
-      label: t('common:welcome.applicationTryout.scenarios.tabs.mfa'),
-      icon: <ShieldCheck size={15} />,
-      disabled: true,
-    },
-    {
-      value: 'social',
-      label: t('common:welcome.applicationTryout.scenarios.tabs.social'),
-      icon: <Share2 size={15} />,
-      disabled: true,
     },
   ];
 

--- a/frontend/apps/console/src/features/welcome/pages/__tests__/TryoutSecuringApplicationPage.test.tsx
+++ b/frontend/apps/console/src/features/welcome/pages/__tests__/TryoutSecuringApplicationPage.test.tsx
@@ -155,12 +155,6 @@ describe('TryoutSecuringApplicationPage', () => {
     expect(screen.getByText('common:welcome.applicationTryout.scenarios.tabs.onboard')).toBeInTheDocument();
   });
 
-  it('renders coming soon chip on disabled tabs', () => {
-    render(<TryoutSecuringApplicationPage />);
-    const chips = screen.getAllByText('common:welcome.getStarted.options.comingSoon');
-    expect(chips.length).toBeGreaterThanOrEqual(2);
-  });
-
   it('shows login scenario by default', () => {
     render(<TryoutSecuringApplicationPage />);
     expect(

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -293,8 +293,6 @@ const translations = {
     'welcome.applicationTryout.scenarios.tabs.profile': 'View Profile',
     'welcome.applicationTryout.scenarios.tabs.recovery': 'Account Recovery',
     'welcome.applicationTryout.scenarios.tabs.onboard': 'Staff Sign-Up',
-    'welcome.applicationTryout.scenarios.tabs.mfa': 'Multi-Factor Authentication',
-    'welcome.applicationTryout.scenarios.tabs.social': 'Social Login',
 
     'welcome.applicationTryout.scenarios.login.description':
       'Sign in with the test user account to explore {{productName}} Sign in experience.',


### PR DESCRIPTION
### Purpose
This pull request simplifies the "Tryout Securing Application" page in the welcome flow by removing the "Multi-Factor Authentication" and "Social Login" scenario tabs, which were previously disabled and marked as "coming soon." The related icons, translations, and tests for these tabs have also been removed to clean up the codebase and user interface.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Simplified the application security tryout scenarios by removing Multi-Factor Authentication and Social Login options.
  * Retained Login, Signup, Recovery, and Onboarding scenarios.
  * Removed related “coming soon” messaging and unused translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->