### PR TITLE
Cap JSON request body size to prevent memory exhaustion

### DIFF
--- a/backend/internal/oauth/oauth2/logout/handler.go
+++ b/backend/internal/oauth/oauth2/logout/handler.go
@@ -21,6 +21,11 @@ import (
 // paramLogoutID is the gate query/callback parameter carrying the stored logout-request id.
 const paramLogoutID = "logoutId"
 
+// logoutCallbackRequest is the request body posted by the Gate UI to the sign-out callback endpoint.
+type logoutCallbackRequest struct {
+	LogoutID string `json:"logoutId" native:"required"`
+}
+
 // logoutHandler serves the RP-initiated logout endpoint. It validates the request, persists the
 // validated post-logout target server-side, initiates the application's sign-out flow, and redirects the
 // browser to the gate sign-out page to run the flow (confirmation + session termination). The gate
@@ -103,10 +108,8 @@ func (h *logoutHandler) HandleLogout(w http.ResponseWriter, r *http.Request) {
 // sign-out flow finishes; the server consumes the stored request (running any protocol-level actions)
 // and returns the post-logout redirect URI for the browser to land on.
 func (h *logoutHandler) HandleLogoutCallback(w http.ResponseWriter, r *http.Request) {
-	var body struct {
-		LogoutID string `json:"logoutId"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.LogoutID == "" {
+	body, err := sysutils.DecodeJSONBody[logoutCallbackRequest](r)
+	if err != nil {
 		http.Error(w, "invalid request", http.StatusBadRequest)
 		return
 	}

--- a/backend/internal/system/utils/http_util.go
+++ b/backend/internal/system/utils/http_util.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"html"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -78,10 +79,14 @@ type ValidationError struct {
 
 func (e *ValidationError) Error() string { return "Validation Failed" }
 
+// maxJSONBodyBytes bounds JSON request bodies decoded via DecodeJSONBody to prevent unbounded
+// memory use from oversized or streamed (chunked) request bodies.
+const maxJSONBodyBytes = 1 << 20 // 1 MiB
+
 // DecodeJSONBody decodes JSON from the request body into any struct type T.
 func DecodeJSONBody[T any](r *http.Request) (*T, error) {
 	var data T
-	if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxJSONBodyBytes)).Decode(&data); err != nil {
 		return nil, errors.New("failed to decode JSON: " + err.Error())
 	}
 	if fieldErrors := validateStructNatively(data); fieldErrors != nil {


### PR DESCRIPTION
### Purpose
DecodeJSONBody and the sign-out callback decoder read request bodies with no size limit, letting a client force the server to buffer an arbitrarily large body in memory before decoding.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
