### PR TITLE
Fix some UI inconsistencies

### DIFF
--- a/frontend/packages/configure-connections/src/components/AttributeMappingSection.tsx
+++ b/frontend/packages/configure-connections/src/components/AttributeMappingSection.tsx
@@ -19,7 +19,7 @@ import {
   TextField,
   Typography,
 } from '@wso2/oxygen-ui';
-import {Plus, Trash2, User} from '@wso2/oxygen-ui-icons-react';
+import {Plus, Trash2, UserRound} from '@wso2/oxygen-ui-icons-react';
 import {type JSX, useEffect, useMemo, useRef, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import type {AttributeConfiguration} from '../models/connection';
@@ -471,7 +471,7 @@ export default function AttributeMappingSection({
         <SettingsCard
           title={t('attributeMapping.resolution.title')}
           description={t('attributeMapping.resolution.description')}
-          titleIcon={iconBox(<User size={16} />)}
+          titleIcon={iconBox(<UserRound size={16} />)}
         >
           <Stack direction="column" spacing={3.5}>
             {canResolveDynamic && (

--- a/frontend/packages/configure-groups/src/components/edit-group/members-settings/AddMemberDialog.tsx
+++ b/frontend/packages/configure-groups/src/components/edit-group/members-settings/AddMemberDialog.tsx
@@ -19,9 +19,8 @@ import {
   Typography,
   Tabs,
   Tab,
-  useTheme,
 } from '@wso2/oxygen-ui';
-import {AppWindow, Bot, User as UserIcon, Users} from '@wso2/oxygen-ui-icons-react';
+import {AppWindow, Bot, UserRound, UsersRound} from '@wso2/oxygen-ui-icons-react';
 import {useState, useMemo, useCallback, type JSX, type SyntheticEvent} from 'react';
 import {useTranslation} from 'react-i18next';
 import useGetAllCandidates from '../../../api/useGetAllCandidates';
@@ -59,7 +58,6 @@ export default function AddMemberDialog({
   groupId = undefined,
 }: AddMemberDialogProps): JSX.Element {
   const {t} = useTranslation();
-  const theme = useTheme();
   const dataGridLocaleText = useDataGridLocaleText();
 
   const [activeTab, setActiveTab] = useState(0);
@@ -167,16 +165,14 @@ export default function AddMemberDialog({
             <Avatar
               sx={{
                 p: 0.5,
-                backgroundColor: theme.vars?.palette.grey[500],
                 width: 30,
                 height: 30,
                 fontSize: '0.875rem',
-                ...theme.applyStyles('dark', {
-                  backgroundColor: theme.vars?.palette.grey[900],
-                }),
+                bgcolor: 'primary.main',
+                color: 'primary.contrastText',
               }}
             >
-              <UserIcon size={14} />
+              <UserRound size={14} />
             </Avatar>
           </Box>
         ),
@@ -219,7 +215,7 @@ export default function AddMemberDialog({
         ),
       },
     ],
-    [theme, t],
+    [t],
   );
 
   const agentColumns: DataGrid.GridColDef<BasicAgent>[] = useMemo(
@@ -242,13 +238,11 @@ export default function AddMemberDialog({
             <Avatar
               sx={{
                 p: 0.5,
-                backgroundColor: theme.vars?.palette.grey[500],
                 width: 30,
                 height: 30,
                 fontSize: '0.875rem',
-                ...theme.applyStyles('dark', {
-                  backgroundColor: theme.vars?.palette.grey[900],
-                }),
+                bgcolor: 'primary.main',
+                color: 'primary.contrastText',
               }}
             >
               <Bot size={14} />
@@ -269,7 +263,7 @@ export default function AddMemberDialog({
         minWidth: 250,
       },
     ],
-    [theme, t],
+    [t],
   );
 
   const groupColumns: DataGrid.GridColDef<GroupBasic>[] = useMemo(
@@ -292,16 +286,14 @@ export default function AddMemberDialog({
             <Avatar
               sx={{
                 p: 0.5,
-                backgroundColor: theme.vars?.palette.grey[500],
                 width: 30,
                 height: 30,
                 fontSize: '0.875rem',
-                ...theme.applyStyles('dark', {
-                  backgroundColor: theme.vars?.palette.grey[900],
-                }),
+                bgcolor: 'primary.main',
+                color: 'primary.contrastText',
               }}
             >
-              <Users size={14} />
+              <UsersRound size={14} />
             </Avatar>
           </Box>
         ),
@@ -319,7 +311,7 @@ export default function AddMemberDialog({
         minWidth: 250,
       },
     ],
-    [theme, t],
+    [t],
   );
 
   const appColumns: DataGrid.GridColDef<BasicApplication>[] = useMemo(
@@ -342,13 +334,11 @@ export default function AddMemberDialog({
             <Avatar
               sx={{
                 p: 0.5,
-                backgroundColor: theme.vars?.palette.grey[500],
                 width: 30,
                 height: 30,
                 fontSize: '0.875rem',
-                ...theme.applyStyles('dark', {
-                  backgroundColor: theme.vars?.palette.grey[900],
-                }),
+                bgcolor: 'primary.main',
+                color: 'primary.contrastText',
               }}
             >
               <AppWindow size={14} />
@@ -369,7 +359,7 @@ export default function AddMemberDialog({
         minWidth: 250,
       },
     ],
-    [theme, t],
+    [t],
   );
 
   const handleAdd = useCallback(() => {
@@ -412,10 +402,14 @@ export default function AddMemberDialog({
       <DialogTitle>{t('groups:addMember.title')}</DialogTitle>
       <DialogContent>
         <Tabs value={activeTab} onChange={handleTabChange} sx={{mb: 2}}>
-          <Tab icon={<UserIcon size={16} />} iconPosition="start" label={t('groups:addMember.tabs.users')} />
+          <Tab icon={<UserRound size={16} />} iconPosition="start" label={t('groups:addMember.tabs.users')} />
           <Tab icon={<AppWindow size={16} />} iconPosition="start" label={t('groups:addMember.tabs.apps')} />
           <Tab icon={<Bot size={16} />} iconPosition="start" label={t('groups:addMember.tabs.agents', 'Agents')} />
-          <Tab icon={<Users size={16} />} iconPosition="start" label={t('groups:addMember.tabs.groups', 'Groups')} />
+          <Tab
+            icon={<UsersRound size={16} />}
+            iconPosition="start"
+            label={t('groups:addMember.tabs.groups', 'Groups')}
+          />
         </Tabs>
 
         {membersError && (

--- a/frontend/packages/configure-groups/src/components/edit-group/members-settings/ManageMembersSection.tsx
+++ b/frontend/packages/configure-groups/src/components/edit-group/members-settings/ManageMembersSection.tsx
@@ -4,7 +4,7 @@
 import {SettingsCard, getInitials} from '@thunderid/components';
 import {useDataGridLocaleText} from '@thunderid/hooks';
 import {Box, Avatar, DataGrid, IconButton} from '@wso2/oxygen-ui';
-import {AppWindow, Bot, Trash2, User, Users} from '@wso2/oxygen-ui-icons-react';
+import {AppWindow, Bot, Trash2, UserRound, UsersRound} from '@wso2/oxygen-ui-icons-react';
 import {useState, useMemo, type JSX, type ReactNode} from 'react';
 import {useTranslation} from 'react-i18next';
 import useGetGroupMembers from '../../../api/useGetGroupMembers';
@@ -61,11 +61,12 @@ export default function ManageMembersSection({
                 width: 30,
                 height: 30,
                 bgcolor: 'primary.main',
+                color: 'primary.contrastText',
                 fontSize: '0.875rem',
               }}
             >
-              {params.row.type === 'user' && <User size={14} />}
-              {params.row.type === 'group' && <Users size={14} />}
+              {params.row.type === 'user' && <UserRound size={14} />}
+              {params.row.type === 'group' && <UsersRound size={14} />}
               {params.row.type === 'app' && <AppWindow size={14} />}
               {params.row.type === 'agent' && <Bot size={14} />}
               {!['user', 'group', 'app', 'agent'].includes(params.row.type) &&

--- a/frontend/packages/configure-import-export/src/components/__tests__/ResourceSummaryTable.test.tsx
+++ b/frontend/packages/configure-import-export/src/components/__tests__/ResourceSummaryTable.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {render, screen, userEvent, waitFor} from '@thunderid/test-utils';
-import {Users} from '@wso2/oxygen-ui-icons-react';
+import {UsersRound} from '@wso2/oxygen-ui-icons-react';
 import {describe, expect, it, vi} from 'vitest';
 import type {ConfigSummaryItem} from '../../models/import-configuration';
 import ResourceSummaryTable from '../ResourceSummaryTable';
@@ -30,13 +30,13 @@ describe('ResourceSummaryTable', () => {
       id: 'users',
       label: 'Users',
       value: 10,
-      icon: <Users size={16} />,
+      icon: <UsersRound size={16} />,
     },
     {
       id: 'groups',
       label: 'Groups',
       value: 5,
-      icon: <Users size={16} />,
+      icon: <UsersRound size={16} />,
     },
   ];
 
@@ -71,7 +71,7 @@ describe('ResourceSummaryTable', () => {
           id: 'users',
           label: 'Users',
           value: 10,
-          icon: <Users size={16} />,
+          icon: <UsersRound size={16} />,
           content: <div>User details content</div>,
         },
       ];
@@ -90,7 +90,7 @@ describe('ResourceSummaryTable', () => {
           id: 'users',
           label: 'Users',
           value: 10,
-          icon: <Users size={16} />,
+          icon: <UsersRound size={16} />,
           content: <div>User details content</div>,
         },
       ];
@@ -123,14 +123,14 @@ describe('ResourceSummaryTable', () => {
           id: 'users',
           label: 'Users',
           value: 10,
-          icon: <Users size={16} />,
+          icon: <UsersRound size={16} />,
           content: <div>User details</div>,
         },
         {
           id: 'groups',
           label: 'Groups',
           value: 5,
-          icon: <Users size={16} />,
+          icon: <UsersRound size={16} />,
           content: <div>Group details</div>,
         },
       ];
@@ -161,7 +161,7 @@ describe('ResourceSummaryTable', () => {
           id: 'users',
           label: 'Users',
           value: 10,
-          icon: <Users size={16} />,
+          icon: <UsersRound size={16} />,
           status: 'ready',
         },
       ];
@@ -177,7 +177,7 @@ describe('ResourceSummaryTable', () => {
           id: 'users',
           label: 'Users',
           value: 10,
-          icon: <Users size={16} />,
+          icon: <UsersRound size={16} />,
           status: 'warning',
         },
       ];
@@ -207,7 +207,7 @@ describe('ResourceSummaryTable', () => {
           id: 'users',
           label: 'Users',
           value: 10,
-          icon: <Users size={16} />,
+          icon: <UsersRound size={16} />,
           dependencyCount: 3,
         },
       ];
@@ -223,7 +223,7 @@ describe('ResourceSummaryTable', () => {
           id: 'users',
           label: 'Users',
           value: 10,
-          icon: <Users size={16} />,
+          icon: <UsersRound size={16} />,
           dependencyCount: 0,
         },
       ];
@@ -239,7 +239,7 @@ describe('ResourceSummaryTable', () => {
           id: 'users',
           label: 'Users',
           value: 10,
-          icon: <Users size={16} />,
+          icon: <UsersRound size={16} />,
         },
       ];
 
@@ -286,7 +286,7 @@ describe('ResourceSummaryTable', () => {
           id: 'users',
           label: 'Users',
           value: 10,
-          icon: <Users size={16} />,
+          icon: <UsersRound size={16} />,
           status: 'ready',
         },
       ];
@@ -319,7 +319,7 @@ describe('ResourceSummaryTable', () => {
           id: 'users',
           label: 'Users',
           value: 999999,
-          icon: <Users size={16} />,
+          icon: <UsersRound size={16} />,
         },
       ];
 
@@ -334,7 +334,7 @@ describe('ResourceSummaryTable', () => {
           id: 'users',
           label: 'Users',
           value: 0,
-          icon: <Users size={16} />,
+          icon: <UsersRound size={16} />,
         },
       ];
 
@@ -349,7 +349,7 @@ describe('ResourceSummaryTable', () => {
           id: 'long-label',
           label: 'Very Long Resource Type Name That Might Cause Layout Issues',
           value: 5,
-          icon: <Users size={16} />,
+          icon: <UsersRound size={16} />,
         },
       ];
 

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/child-organization-unit-settings/ManageChildOrganizationUnitSection.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/child-organization-unit-settings/ManageChildOrganizationUnitSection.tsx
@@ -4,7 +4,7 @@
 import {QueryErrorNotice, SettingsCard} from '@thunderid/components';
 import {useDataGridLocaleText} from '@thunderid/hooks';
 import {useLogger} from '@thunderid/logger/react';
-import {Box, DataGrid, Avatar, useTheme} from '@wso2/oxygen-ui';
+import {Box, DataGrid, Avatar} from '@wso2/oxygen-ui';
 import {Building} from '@wso2/oxygen-ui-icons-react';
 import {useMemo, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
@@ -49,7 +49,6 @@ export default function ManageChildOrganizationUnitSection({
   const navigate = useNavigate();
   const routes = useOrganizationUnitRoutes();
   const {t} = useTranslation();
-  const theme = useTheme();
   const logger = useLogger('ManageChildOrganizationUnitSection');
   const dataGridLocaleText = useDataGridLocaleText();
 
@@ -75,13 +74,11 @@ export default function ManageChildOrganizationUnitSection({
             <Avatar
               sx={{
                 p: 0.5,
-                backgroundColor: theme.vars?.palette.grey[500],
+                bgcolor: 'primary.main',
+                color: 'primary.contrastText',
                 width: 30,
                 height: 30,
                 fontSize: '0.875rem',
-                ...theme.applyStyles('dark', {
-                  backgroundColor: theme.vars?.palette.grey[900],
-                }),
               }}
             >
               <Building size={14} />
@@ -109,7 +106,7 @@ export default function ManageChildOrganizationUnitSection({
         valueGetter: (_value, row): string => row.description ?? '-',
       },
     ],
-    [t, theme],
+    [t],
   );
 
   if (error) {

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/group-settings/ManageGroupsSection.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/group-settings/ManageGroupsSection.tsx
@@ -61,6 +61,7 @@ export default function ManageGroupsSection({organizationUnitId}: ManageGroupsSe
                   width: 30,
                   height: 30,
                   bgcolor: 'primary.main',
+                  color: 'primary.contrastText',
                   fontSize: '0.875rem',
                 }}
               >

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/user-settings/ManageUsersSection.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/user-settings/ManageUsersSection.tsx
@@ -62,6 +62,7 @@ export default function ManageUsersSection({organizationUnitId}: ManageUsersSect
                   width: 30,
                   height: 30,
                   bgcolor: 'primary.main',
+                  color: 'primary.contrastText',
                   fontSize: '0.875rem',
                 }}
               >

--- a/frontend/packages/configure-roles/src/components/edit-role/assignments-settings/AddAssignmentDialog.tsx
+++ b/frontend/packages/configure-roles/src/components/edit-role/assignments-settings/AddAssignmentDialog.tsx
@@ -23,9 +23,8 @@ import {
   Typography,
   Tabs,
   Tab,
-  useTheme,
 } from '@wso2/oxygen-ui';
-import {AppWindow, Bot, User as UserIcon, Users} from '@wso2/oxygen-ui-icons-react';
+import {AppWindow, Bot, UserRound, UsersRound} from '@wso2/oxygen-ui-icons-react';
 import {useState, useMemo, useCallback, type JSX, type SyntheticEvent} from 'react';
 import {useTranslation} from 'react-i18next';
 import useGetRoleAssignments from '../../../api/useGetRoleAssignments';
@@ -61,7 +60,6 @@ export default function AddAssignmentDialog({
   initialTab = 0,
 }: AddAssignmentDialogProps): JSX.Element {
   const {t} = useTranslation();
-  const theme = useTheme();
   const dataGridLocaleText = useDataGridLocaleText();
 
   const [activeTab, setActiveTab] = useState(initialTab);
@@ -194,14 +192,14 @@ export default function AddAssignmentDialog({
             <Avatar
               sx={{
                 p: 0.5,
-                backgroundColor: theme.vars?.palette.grey[500],
+                bgcolor: 'primary.main',
+                color: 'primary.contrastText',
                 width: 30,
                 height: 30,
                 fontSize: '0.875rem',
-                ...theme.applyStyles('dark', {backgroundColor: theme.vars?.palette.grey[900]}),
               }}
             >
-              <UserIcon size={14} />
+              <UserRound size={14} />
             </Avatar>
           </Box>
         ),
@@ -247,7 +245,7 @@ export default function AddAssignmentDialog({
         ),
       },
     ],
-    [theme, t],
+    [t],
   );
 
   const groupColumns: DataGrid.GridColDef<GroupBasic>[] = useMemo(
@@ -263,14 +261,14 @@ export default function AddAssignmentDialog({
             <Avatar
               sx={{
                 p: 0.5,
-                backgroundColor: theme.vars?.palette.grey[500],
+                bgcolor: 'primary.main',
+                color: 'primary.contrastText',
                 width: 30,
                 height: 30,
                 fontSize: '0.875rem',
-                ...theme.applyStyles('dark', {backgroundColor: theme.vars?.palette.grey[900]}),
               }}
             >
-              <Users size={14} />
+              <UsersRound size={14} />
             </Avatar>
           </Box>
         ),
@@ -289,7 +287,7 @@ export default function AddAssignmentDialog({
         valueGetter: (_value, row): string => row.description ?? '-',
       },
     ],
-    [theme, t],
+    [t],
   );
   const agentColumns: DataGrid.GridColDef<BasicAgent>[] = useMemo(
     () => [
@@ -304,11 +302,11 @@ export default function AddAssignmentDialog({
             <Avatar
               sx={{
                 p: 0.5,
-                backgroundColor: theme.vars?.palette.grey[500],
+                bgcolor: 'primary.main',
+                color: 'primary.contrastText',
                 width: 30,
                 height: 30,
                 fontSize: '0.875rem',
-                ...theme.applyStyles('dark', {backgroundColor: theme.vars?.palette.grey[900]}),
               }}
             >
               <Bot size={14} />
@@ -330,7 +328,7 @@ export default function AddAssignmentDialog({
         valueGetter: (_value, row): string => row.description ?? '-',
       },
     ],
-    [theme, t],
+    [t],
   );
 
   const appColumns: DataGrid.GridColDef<BasicApplication>[] = useMemo(
@@ -346,11 +344,11 @@ export default function AddAssignmentDialog({
             <Avatar
               sx={{
                 p: 0.5,
-                backgroundColor: theme.vars?.palette.grey[500],
+                bgcolor: 'primary.main',
+                color: 'primary.contrastText',
                 width: 30,
                 height: 30,
                 fontSize: '0.875rem',
-                ...theme.applyStyles('dark', {backgroundColor: theme.vars?.palette.grey[900]}),
               }}
             >
               <AppWindow size={14} />
@@ -372,7 +370,7 @@ export default function AddAssignmentDialog({
         valueGetter: (_value, row): string => row.description ?? '-',
       },
     ],
-    [theme, t],
+    [t],
   );
 
   const handleAdd = useCallback(() => {

--- a/frontend/packages/configure-roles/src/components/edit-role/assignments-settings/ManageAssignmentsSection.tsx
+++ b/frontend/packages/configure-roles/src/components/edit-role/assignments-settings/ManageAssignmentsSection.tsx
@@ -4,7 +4,7 @@
 import {SettingsCard} from '@thunderid/components';
 import {useDataGridLocaleText} from '@thunderid/hooks';
 import {Box, Avatar, DataGrid, IconButton, Tabs, Tab} from '@wso2/oxygen-ui';
-import {AppWindow, Bot, Trash2, User, Users} from '@wso2/oxygen-ui-icons-react';
+import {AppWindow, Bot, Trash2, UserRound, UsersRound} from '@wso2/oxygen-ui-icons-react';
 import {useState, useMemo, type JSX, type ReactNode, type SyntheticEvent} from 'react';
 import {useTranslation} from 'react-i18next';
 import useGetRoleAssignments from '../../../api/useGetRoleAssignments';
@@ -149,7 +149,9 @@ export default function ManageAssignmentsSection({
         filterable: false,
         renderCell: (params: DataGrid.GridRenderCellParams<RoleAssignment>): JSX.Element => (
           <Box sx={{display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%'}}>
-            <Avatar sx={{width: 30, height: 30, bgcolor: 'primary.main', fontSize: '0.875rem'}}>
+            <Avatar
+              sx={{width: 30, height: 30, bgcolor: 'primary.main', color: 'primary.contrastText', fontSize: '0.875rem'}}
+            >
               {(params.row.display ?? params.row.id).charAt(0).toUpperCase()}
             </Avatar>
           </Box>
@@ -170,7 +172,9 @@ export default function ManageAssignmentsSection({
         filterable: false,
         renderCell: (params: DataGrid.GridRenderCellParams<RoleAssignment>): JSX.Element => (
           <Box sx={{display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%'}}>
-            <Avatar sx={{width: 30, height: 30, bgcolor: 'primary.main', fontSize: '0.875rem'}}>
+            <Avatar
+              sx={{width: 30, height: 30, bgcolor: 'primary.main', color: 'primary.contrastText', fontSize: '0.875rem'}}
+            >
               {(params.row.display ?? params.row.id).charAt(0).toUpperCase()}
             </Avatar>
           </Box>
@@ -190,7 +194,9 @@ export default function ManageAssignmentsSection({
         filterable: false,
         renderCell: (): JSX.Element => (
           <Box sx={{display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%'}}>
-            <Avatar sx={{width: 30, height: 30, bgcolor: 'primary.main', fontSize: '0.875rem'}}>
+            <Avatar
+              sx={{width: 30, height: 30, bgcolor: 'primary.main', color: 'primary.contrastText', fontSize: '0.875rem'}}
+            >
               <AppWindow size={14} />
             </Avatar>
           </Box>
@@ -210,7 +216,9 @@ export default function ManageAssignmentsSection({
         filterable: false,
         renderCell: (): JSX.Element => (
           <Box sx={{display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%'}}>
-            <Avatar sx={{width: 30, height: 30, bgcolor: 'primary.main', fontSize: '0.875rem'}}>
+            <Avatar
+              sx={{width: 30, height: 30, bgcolor: 'primary.main', color: 'primary.contrastText', fontSize: '0.875rem'}}
+            >
               <Bot size={14} />
             </Avatar>
           </Box>
@@ -235,13 +243,13 @@ export default function ManageAssignmentsSection({
       <Box sx={{borderBottom: 1, borderColor: 'divider', px: 2}}>
         <Tabs value={activeAssignmentTab} onChange={handleTabChange}>
           <Tab
-            icon={<User size={16} />}
+            icon={<UserRound size={16} />}
             iconPosition="start"
             label={t('roles:edit.assignments.sections.manage.tabs.users')}
             sx={{textTransform: 'none'}}
           />
           <Tab
-            icon={<Users size={16} />}
+            icon={<UsersRound size={16} />}
             iconPosition="start"
             label={t('roles:edit.assignments.sections.manage.tabs.groups')}
             sx={{textTransform: 'none'}}

--- a/frontend/packages/design/src/themes/DefaultTheme.ts
+++ b/frontend/packages/design/src/themes/DefaultTheme.ts
@@ -190,6 +190,13 @@ export const DefaultThemeConfig = {
         root: {
           transition: 'all 0.3s ease-in-out',
         },
+        sizeSmall: {
+          padding: '4px 10px',
+          gap: '4px',
+          '& .MuiButton-startIcon': {
+            marginRight: '0',
+          },
+        },
         contained: ({ownerState}: {theme: OxygenThemeType; ownerState: {color?: string}}) => {
           if (ownerState.color && ownerState.color !== 'primary') {
             return {};


### PR DESCRIPTION
This pull request updates icon usage across several components to standardize and modernize the UI, replacing older icons with their "Round" variants and simplifying avatar styling. It also removes unnecessary theme usage for avatar backgrounds, opting for direct color assignments using the theme's palette.

Fix some issues reported here: https://github.com/thunder-id/thunderid/issues/4885

<img width="1650" height="396" alt="image" src="https://github.com/user-attachments/assets/ec5f292a-810d-4ad3-a0a1-aff54c72226e" />

<img width="1650" height="916" alt="image" src="https://github.com/user-attachments/assets/bf1a9e9d-c721-4453-8c36-51ab87f568d6" />

**Icon Updates and Standardization:**

* Replaced `User` and `Users` icons with `UserRound` and `UsersRound` in multiple files, including `AttributeMappingSection.tsx`, `AddMemberDialog.tsx`, `ManageMembersSection.tsx`, and related tests, to ensure consistent and updated iconography throughout the application. [[1]](diffhunk://#diff-31b28a043bde6934fcd02bc0fbf98efd12dc7600b05db2d465ad98e1af23f6d1L22-R22) [[2]](diffhunk://#diff-269562471d713d4a3ccfceaea0bac1dc42b3f872f64281629b56d987b44032e0L22-R23) [[3]](diffhunk://#diff-7201d6fb6fe9ab55ffad16ace5d7328f1d81f31a13415df364cd390a72912760L7-R7) [[4]](diffhunk://#diff-041f27ae1d8a83d2933a03a53a5b498acd2102eb6db31f896e4af3565c2e7795L5-R5)
* Updated all usages of the old icons in UI elements, such as tabs and avatars, to use the new "Round" icons. [[1]](diffhunk://#diff-269562471d713d4a3ccfceaea0bac1dc42b3f872f64281629b56d987b44032e0L415-R412) [[2]](diffhunk://#diff-7201d6fb6fe9ab55ffad16ace5d7328f1d81f31a13415df364cd390a72912760R64-R69) [[3]](diffhunk://#diff-041f27ae1d8a83d2933a03a53a5b498acd2102eb6db31f896e4af3565c2e7795L33-R39) [[4]](diffhunk://#diff-041f27ae1d8a83d2933a03a53a5b498acd2102eb6db31f896e4af3565c2e7795L74-R74) [[5]](diffhunk://#diff-041f27ae1d8a83d2933a03a53a5b498acd2102eb6db31f896e4af3565c2e7795L93-R93) [[6]](diffhunk://#diff-041f27ae1d8a83d2933a03a53a5b498acd2102eb6db31f896e4af3565c2e7795L126-R133) [[7]](diffhunk://#diff-041f27ae1d8a83d2933a03a53a5b498acd2102eb6db31f896e4af3565c2e7795L164-R164) [[8]](diffhunk://#diff-041f27ae1d8a83d2933a03a53a5b498acd2102eb6db31f896e4af3565c2e7795L180-R180) [[9]](diffhunk://#diff-041f27ae1d8a83d2933a03a53a5b498acd2102eb6db31f896e4af3565c2e7795L210-R210) [[10]](diffhunk://#diff-041f27ae1d8a83d2933a03a53a5b498acd2102eb6db31f896e4af3565c2e7795L226-R226) [[11]](diffhunk://#diff-041f27ae1d8a83d2933a03a53a5b498acd2102eb6db31f896e4af3565c2e7795L242-R242) [[12]](diffhunk://#diff-041f27ae1d8a83d2933a03a53a5b498acd2102eb6db31f896e4af3565c2e7795L289-R289) [[13]](diffhunk://#diff-041f27ae1d8a83d2933a03a53a5b498acd2102eb6db31f896e4af3565c2e7795L322-R322) [[14]](diffhunk://#diff-041f27ae1d8a83d2933a03a53a5b498acd2102eb6db31f896e4af3565c2e7795L337-R337) [[15]](diffhunk://#diff-041f27ae1d8a83d2933a03a53a5b498acd2102eb6db31f896e4af3565c2e7795L352-R352)

**Avatar Styling Simplification:**

* Removed usage of `useTheme` and related dynamic background color logic for avatars in favor of directly using `'primary.main'` for background and `'primary.contrastText'` for text color, simplifying the code and ensuring consistent appearance in both light and dark modes. [[1]](diffhunk://#diff-269562471d713d4a3ccfceaea0bac1dc42b3f872f64281629b56d987b44032e0L62) [[2]](diffhunk://#diff-269562471d713d4a3ccfceaea0bac1dc42b3f872f64281629b56d987b44032e0L170-R175) [[3]](diffhunk://#diff-269562471d713d4a3ccfceaea0bac1dc42b3f872f64281629b56d987b44032e0L222-R218) [[4]](diffhunk://#diff-269562471d713d4a3ccfceaea0bac1dc42b3f872f64281629b56d987b44032e0L245-R245) [[5]](diffhunk://#diff-269562471d713d4a3ccfceaea0bac1dc42b3f872f64281629b56d987b44032e0L272-R266) [[6]](diffhunk://#diff-269562471d713d4a3ccfceaea0bac1dc42b3f872f64281629b56d987b44032e0L295-R296) [[7]](diffhunk://#diff-269562471d713d4a3ccfceaea0bac1dc42b3f872f64281629b56d987b44032e0L322-R314) [[8]](diffhunk://#diff-269562471d713d4a3ccfceaea0bac1dc42b3f872f64281629b56d987b44032e0L345-R341) [[9]](diffhunk://#diff-269562471d713d4a3ccfceaea0bac1dc42b3f872f64281629b56d987b44032e0L372-R362) [[10]](diffhunk://#diff-79e621b7318f85d0d11a541016f76398ca0cc02df8bd209b34b5bd0df32d5edbL7-R7) [[11]](diffhunk://#diff-79e621b7318f85d0d11a541016f76398ca0cc02df8bd209b34b5bd0df32d5edbL52)

These changes improve UI consistency and maintainability by adopting a unified icon set and simplifying avatar styles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated user and group icons throughout configuration screens for a clearer, more consistent appearance.
  - Improved avatar colors and contrast across member, organization, and role management views, including better readability across themes.
  - Refined the appearance of small buttons with more compact spacing and improved icon alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->