### PR TITLE
Rename default connections displayNames

### DIFF
--- a/frontend/packages/configure-connections/src/config/connectionVendorMeta.tsx
+++ b/frontend/packages/configure-connections/src/config/connectionVendorMeta.tsx
@@ -25,7 +25,7 @@ export const CONNECTION_VENDOR_META: ConnectionVendorMeta[] = [
   {
     key: 'google',
     backendType: ConnectionTypes.GOOGLE,
-    displayName: 'Google',
+    displayName: 'Google Login',
     descriptionKey: 'connections:vendor.google.description',
     logo: <ResourceAvatar transparent variant="rounded" size={AVATAR_SIZE} fallback={<GoogleIcon size={34} />} />,
     categories: ['social-login'],
@@ -36,7 +36,7 @@ export const CONNECTION_VENDOR_META: ConnectionVendorMeta[] = [
   {
     key: 'github',
     backendType: ConnectionTypes.GITHUB,
-    displayName: 'GitHub',
+    displayName: 'GitHub Login',
     descriptionKey: 'connections:vendor.github.description',
     logo: <ResourceAvatar transparent variant="rounded" size={AVATAR_SIZE} fallback={<GithubIcon size={34} />} />,
     categories: ['social-login'],
@@ -81,7 +81,7 @@ export const CONNECTION_VENDOR_META: ConnectionVendorMeta[] = [
   {
     key: 'twilio',
     backendType: ConnectionTypes.TWILIO,
-    displayName: 'Twilio',
+    displayName: 'Twilio SMS',
     descriptionKey: 'connections:vendor.twilio.description',
     // Twilio's brand mark isn't cleared for use yet — keep the generic icon until that's sorted.
     logo: <ResourceAvatar transparent variant="rounded" size={AVATAR_SIZE} fallback={<MessageSquare size={28} />} />,
@@ -91,7 +91,7 @@ export const CONNECTION_VENDOR_META: ConnectionVendorMeta[] = [
   {
     key: 'vonage',
     backendType: ConnectionTypes.VONAGE,
-    displayName: 'Vonage',
+    displayName: 'Vonage SMS',
     descriptionKey: 'connections:vendor.vonage.description',
     // Vonage's brand mark isn't cleared for use yet — keep the generic icon until that's sorted.
     logo: <ResourceAvatar transparent variant="rounded" size={AVATAR_SIZE} fallback={<Send size={28} />} />,


### PR DESCRIPTION
This pull request updates the display names for several connection vendors in the `connectionVendorMeta.tsx` configuration file to make them more descriptive and aligned with their specific use cases (e.g., clarifying whether the connection is for login or SMS functionality).

<img width="1650" height="908" alt="image" src="https://github.com/user-attachments/assets/afe4398d-fa50-4c53-a023-1622fe290a24" />

**Display name updates for connection vendors:**

* Changed the display name for the Google connection from 'Google' to 'Google Login'.
* Changed the display name for the GitHub connection from 'GitHub' to 'GitHub Login'.
* Changed the display name for the Twilio connection from 'Twilio' to 'Twilio SMS'.
* Changed the display name for the Vonage connection from 'Vonage' to 'Vonage SMS'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated connection vendor names to clearly identify their use cases:
    * Google Login
    * GitHub Login
    * Twilio SMS
    * Vonage SMS

<!-- end of auto-generated comment: release notes by coderabbit.ai -->