### PR TITLE
Rename default connections displayNames

### DIFF
--- a/frontend/packages/configure-connections/src/components/__tests__/ConnectionCard.test.tsx
+++ b/frontend/packages/configure-connections/src/components/__tests__/ConnectionCard.test.tsx
@@ -11,7 +11,7 @@ const baseCard: ConnectionCardModel = {
   id: 'google',
   vendorKey: 'google',
   backendType: 'google',
-  displayName: 'Google',
+  displayName: 'Google Login',
   descriptionKey: 'connections:vendor.google.description',
   logo: 'logo' as unknown as JSX.Element,
   categories: ['social-login'],
@@ -26,7 +26,7 @@ describe('ConnectionCard', () => {
 
   it('renders the vendor name, status, and hashtag category tags', () => {
     render(<ConnectionCard card={baseCard} onAction={onAction} />);
-    expect(screen.getByText('Google')).toBeInTheDocument();
+    expect(screen.getByText('Google Login')).toBeInTheDocument();
     expect(screen.getByText('Not configured')).toBeInTheDocument();
     expect(screen.getByText('#social login')).toBeInTheDocument();
   });

--- a/frontend/packages/configure-connections/src/components/__tests__/ConnectionForm.test.tsx
+++ b/frontend/packages/configure-connections/src/components/__tests__/ConnectionForm.test.tsx
@@ -60,7 +60,7 @@ describe('ConnectionForm', () => {
     },
     secretReplacing: false,
     hasStoredSecret: false,
-    vendorDisplayName: 'Google',
+    vendorDisplayName: 'Google Login',
     onFieldChange: vi.fn(),
     onSecretReplacingChange: vi.fn(),
   };
@@ -102,12 +102,14 @@ describe('ConnectionForm', () => {
     expect(field).toHaveValue('https://id.acme.io/oauth/callback/google');
     expect(field).toHaveAttribute('readonly');
     expect(screen.getByTestId('connection-field-redirectUri-copy')).toBeInTheDocument();
-    expect(screen.getByText('Add this exact URI to your Google OAuth client.')).toBeInTheDocument();
+    expect(screen.getByText('Add this exact URI to your Google Login OAuth client.')).toBeInTheDocument();
     expect(screen.getByText(/Space-separated scopes to request during sign-in\. Defaults to/)).toBeInTheDocument();
   });
 
   it('shows the GitHub scopes default instead of the OIDC scopes default', () => {
-    render(<ConnectionForm {...baseProps} type="github" mode="edit" hasStoredSecret vendorDisplayName="GitHub" />);
+    render(
+      <ConnectionForm {...baseProps} type="github" mode="edit" hasStoredSecret vendorDisplayName="GitHub Login" />,
+    );
 
     expect(getConnectionField('scopes')).toHaveAttribute('placeholder', 'user:email');
     const helperText = document.getElementById('connection-field-scopes-helper-text');

--- a/frontend/packages/configure-connections/src/config/connectionVendorMeta.tsx
+++ b/frontend/packages/configure-connections/src/config/connectionVendorMeta.tsx
@@ -25,7 +25,7 @@ export const CONNECTION_VENDOR_META: ConnectionVendorMeta[] = [
   {
     key: 'google',
     backendType: ConnectionTypes.GOOGLE,
-    displayName: 'Google',
+    displayName: 'Google Login',
     descriptionKey: 'connections:vendor.google.description',
     logo: <ResourceAvatar transparent variant="rounded" size={AVATAR_SIZE} fallback={<GoogleIcon size={34} />} />,
     categories: ['social-login'],
@@ -36,7 +36,7 @@ export const CONNECTION_VENDOR_META: ConnectionVendorMeta[] = [
   {
     key: 'github',
     backendType: ConnectionTypes.GITHUB,
-    displayName: 'GitHub',
+    displayName: 'GitHub Login',
     descriptionKey: 'connections:vendor.github.description',
     logo: <ResourceAvatar transparent variant="rounded" size={AVATAR_SIZE} fallback={<GithubIcon size={34} />} />,
     categories: ['social-login'],
@@ -81,7 +81,7 @@ export const CONNECTION_VENDOR_META: ConnectionVendorMeta[] = [
   {
     key: 'twilio',
     backendType: ConnectionTypes.TWILIO,
-    displayName: 'Twilio',
+    displayName: 'Twilio SMS',
     descriptionKey: 'connections:vendor.twilio.description',
     // Twilio's brand mark isn't cleared for use yet — keep the generic icon until that's sorted.
     logo: <ResourceAvatar transparent variant="rounded" size={AVATAR_SIZE} fallback={<MessageSquare size={28} />} />,
@@ -91,7 +91,7 @@ export const CONNECTION_VENDOR_META: ConnectionVendorMeta[] = [
   {
     key: 'vonage',
     backendType: ConnectionTypes.VONAGE,
-    displayName: 'Vonage',
+    displayName: 'Vonage SMS',
     descriptionKey: 'connections:vendor.vonage.description',
     // Vonage's brand mark isn't cleared for use yet — keep the generic icon until that's sorted.
     logo: <ResourceAvatar transparent variant="rounded" size={AVATAR_SIZE} fallback={<Send size={28} />} />,

--- a/frontend/packages/configure-connections/src/pages/__tests__/ConnectionConfigureWizardPage.test.tsx
+++ b/frontend/packages/configure-connections/src/pages/__tests__/ConnectionConfigureWizardPage.test.tsx
@@ -61,7 +61,7 @@ describe('ConnectionConfigureWizardPage', () => {
 
     // Single step: the credentials form is shown with a Create button (no attribute-mapping step).
     expect(screen.getByTestId('stub-connection-form')).toBeInTheDocument();
-    expect(screen.getByText('Configure your Google connection')).toBeInTheDocument();
+    expect(screen.getByText('Configure your Google Login connection')).toBeInTheDocument();
     fireEvent.click(screen.getByTestId('wizard-create'));
 
     expect(mutateMock).toHaveBeenCalledTimes(1);
@@ -73,7 +73,7 @@ describe('ConnectionConfigureWizardPage', () => {
       attributeConfiguration?: unknown;
     };
     expect(payload).toMatchObject({
-      name: 'Google',
+      name: 'Google Login',
       clientId: 'x',
       clientSecret: 's',
       redirectUri: 'https://id.acme.io/gate/callback',
@@ -170,7 +170,7 @@ describe('ConnectionConfigureWizardPage', () => {
     expect(mutateMock).toHaveBeenCalledTimes(1);
     const payload = mutateMock.mock.calls[0][0] as Record<string, unknown>;
     expect(payload).toMatchObject({
-      name: 'Twilio',
+      name: 'Twilio SMS',
       accountSid: 'AC00000000000000000000000000000000',
       senderId: '+15005550006',
     });

--- a/frontend/packages/configure-connections/src/utils/__tests__/buildConnectionCards.test.ts
+++ b/frontend/packages/configure-connections/src/utils/__tests__/buildConnectionCards.test.ts
@@ -12,7 +12,7 @@ const VENDORS: ConnectionVendorMeta[] = [
   {
     key: 'google',
     backendType: 'google',
-    displayName: 'Google',
+    displayName: 'Google Login',
     descriptionKey: 'connections:vendor.google.description',
     logo: LOGO,
     categories: ['social-login'],
@@ -21,7 +21,7 @@ const VENDORS: ConnectionVendorMeta[] = [
   {
     key: 'github',
     backendType: 'github',
-    displayName: 'GitHub',
+    displayName: 'GitHub Login',
     descriptionKey: 'connections:vendor.github.description',
     logo: LOGO,
     categories: ['social-login'],
@@ -47,7 +47,7 @@ const VENDORS: ConnectionVendorMeta[] = [
   },
   {
     key: 'twilio',
-    displayName: 'Twilio',
+    displayName: 'Twilio SMS',
     descriptionKey: 'connections:vendor.twilio.description',
     logo: LOGO,
     categories: ['sms'],
@@ -85,7 +85,7 @@ describe('buildConnectionCards', () => {
 
     const github = cards.find((c) => c.vendorKey === 'github');
     expect(github).toMatchObject({
-      displayName: 'GitHub',
+      displayName: 'GitHub Login',
       status: 'not-configured',
       navTarget: '/connections/github/configure',
     });


### PR DESCRIPTION
This pull request updates the display names for several connection vendors in the `connectionVendorMeta.tsx` configuration file to make them more descriptive and aligned with their specific use cases (e.g., clarifying whether the connection is for login or SMS functionality).

<img width="1650" height="908" alt="image" src="https://github.com/user-attachments/assets/afe4398d-fa50-4c53-a023-1622fe290a24" />


**Display name updates for connection vendors:**

* Changed the display name for the Google connection from 'Google' to 'Google Login'.
* Changed the display name for the GitHub connection from 'GitHub' to 'GitHub Login'.
* Changed the display name for the Twilio connection from 'Twilio' to 'Twilio SMS'.
* Changed the display name for the Vonage connection from 'Vonage' to 'Vonage SMS'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated connection vendor names to clearly identify their use cases:
    * Google Login
    * GitHub Login
    * Twilio SMS
    * Vonage SMS

<!-- end of auto-generated comment: release notes by coderabbit.ai -->