### PR TITLE
Fix Express and Nuxt authentication integration guidance

### DIFF
--- a/docs/content/getting-started/connect-your-application/express.mdx
+++ b/docs/content/getting-started/connect-your-application/express.mdx
@@ -66,7 +66,7 @@ Once it's running, the console is available at [https://localhost:8090/console](
 7. Select how you want to sign in users (e.g., email/password, social login, etc.).
 8. Select Theme settings.
 9. Leave **Sign-In Approach** set to **Redirect to <ProductName /> Gate** (the default for Express applications).
-10. In the Configuration step, add `http://localhost:3000/login` to the list of **Authorized Redirect URIs**.
+10. In the Configuration step, add `http://localhost:3000/login` to **Authorized Redirect URIs** and `http://localhost:3000/logout` to **Post-Logout Redirect URIs**. Clear **Use the same URLs for post-logout redirect** if the fields are linked.
 
 :::note Note
 Copy both the **Client ID** and **Client Secret** from the window that pops up when the application is created. The Client ID can also be found in the **General** tab.
@@ -116,6 +116,19 @@ Install the <ProductName /> Express SDK:
     pnpm add @thunderid/express
   </CodeBlock>
 </CodeGroup>
+
+## Trust the Local Certificate in Node.js
+
+Skip this step when your <ProductName /> instance uses a certificate issued by a certificate authority that Node.js already trusts. For a local self-signed certificate, export the certificate and configure Node.js to trust it:
+
+```bash
+openssl s_client -connect localhost:8090 -servername localhost </dev/null 2>/dev/null \
+  | openssl x509 > thunderid.cert
+
+export NODE_EXTRA_CA_CERTS="$PWD/thunderid.cert"
+```
+
+The browser and Node.js use separate certificate trust stores. Browser trust does not make Node.js trust the certificate. Without `NODE_EXTRA_CA_CERTS`, the authorization-code exchange can fail with `DEPTH_ZERO_SELF_SIGNED_CERT`, causing `/login` to return HTTP 500. Do not use `NODE_TLS_REJECT_UNAUTHORIZED=0` because it disables certificate verification for the entire Node.js process.
 
 ## Add Authentication Middleware and Routes
 
@@ -168,7 +181,7 @@ app.listen(port, () => {
 ```
 
 :::warning Configuration
-Replace `<your-client-id>` and `<your-client-secret>` with values from your <ProductName /> application. Make sure the authorized redirect URL in your application settings is set to `http://localhost:3000/login`.
+Replace `<your-client-id>` and `<your-client-secret>` with values from your <ProductName /> application. Make sure the authorized redirect URL is `http://localhost:3000/login` and the post-logout redirect URL is `http://localhost:3000/logout`.
 :::
 
 ## Run Your App

--- a/docs/content/getting-started/connect-your-application/prompts/express/embedded.txt
+++ b/docs/content/getting-started/connect-your-application/prompts/express/embedded.txt
@@ -33,6 +33,8 @@ I have an Express application and I want to integrate {{productName}} authentica
 - Do not use `clientId`/`clientSecret` in this mode — embedded mode is driven by `applicationId`, not an OAuth2 client
 - Pass `flowSecret` in the `thunderID({...})` middleware config (or set `THUNDERID_FLOW_SECRET` in the environment, which `handleFlow()` falls back to automatically) — it authenticates this app when the flow starts, sent in the `Flow-Secret` request header. It is a separate credential from an OAuth2 client secret, never a substitute for one
 - Never ask the developer to type or paste the Flow Secret into this conversation. If it is not supplied above, set `THUNDERID_FLOW_SECRET` in a local `.env` file as a placeholder and stop with a message telling the developer to fill it in locally before running the app
+- If the local {{productName}} instance uses a self-signed certificate or a certificate from a private CA that Node.js does not trust, configure `NODE_EXTRA_CA_CERTS` with the path to the CA or server certificate before starting the app. Explain that the browser trusting the certificate does not make Node.js trust it, so server-side SDK requests can otherwise fail with `DEPTH_ZERO_SELF_SIGNED_CERT`
+- Do not use `NODE_TLS_REJECT_UNAUTHORIZED=0`. A certificate issued by a CA that Node.js already trusts requires no additional TLS configuration
 
 ## Implementation Steps
 1. Create a new project and install `express` and `cookie-parser`
@@ -41,7 +43,7 @@ I have an Express application and I want to integrate {{productName}} authentica
 4. Add `index.js` with `thunderID({ applicationId, baseUrl, mode: 'embedded', flowSecret })` middleware
 5. Add `/login` route serving a minimal HTML form, and `/flow/sign-in` using `handleFlow()`
 6. Add `/logout`, `/protected`, and `/me` routes
-7. Start the server with `node index.js`
+7. Start the server with `node index.js`, or `NODE_EXTRA_CA_CERTS=/path/to/thunderid-ca-or-server.cert node index.js` only when the local certificate is not already trusted by Node.js
 8. Validate the flow by opening `/login`, submitting the form, then `/protected` and `/me`; then request `/logout` and confirm `/protected` is no longer accessible
 
 Please provide:

--- a/docs/content/getting-started/connect-your-application/prompts/express/redirect-based.txt
+++ b/docs/content/getting-started/connect-your-application/prompts/express/redirect-based.txt
@@ -25,6 +25,8 @@ I have an Express application and I want to integrate {{productName}} authentica
 - Use CommonJS syntax (`require`) in `index.js`
 - Use these SDK imports exactly: `thunderID`, `handleSignIn`, `handleSignOut`, `protect`
 - Ensure redirect URL alignment: the app callback URL must be `http://localhost:3000/login`, and the post-logout redirect URL must be `http://localhost:3000/logout`
+- If the local {{productName}} instance uses a self-signed certificate or a certificate from a private CA that Node.js does not trust, configure `NODE_EXTRA_CA_CERTS` with the path to the CA or server certificate before starting the app. Explain that the browser trusting the certificate does not make Node.js trust it, so the server-side authorization-code exchange can otherwise fail with `DEPTH_ZERO_SELF_SIGNED_CERT` and return HTTP 500 from `/login`
+- Do not use `NODE_TLS_REJECT_UNAUTHORIZED=0`. A certificate issued by a CA that Node.js already trusts requires no additional TLS configuration
 - Do not invent unsupported SDK APIs or custom wrappers
 - Keep route names and behavior exactly as specified
 
@@ -33,7 +35,7 @@ I have an Express application and I want to integrate {{productName}} authentica
 2. Install `@thunderid/express`
 3. Add `index.js` with ThunderID middleware and auth routes
 4. Add `/protected` and `/me` routes with `protect()`
-5. Start the server with `node index.js`
+5. Start the server with `node index.js`, or `NODE_EXTRA_CA_CERTS=/path/to/thunderid-ca-or-server.cert node index.js` only when the local certificate is not already trusted by Node.js
 6. Validate the flow by opening `/protected`, then `/me`
 
 Please provide:

--- a/docs/content/getting-started/connect-your-application/prompts/nuxt/redirect-based.txt
+++ b/docs/content/getting-started/connect-your-application/prompts/nuxt/redirect-based.txt
@@ -10,7 +10,7 @@ I have a Nuxt 3 application and I want to integrate {{productName}}'s authentica
 - Wrap app.vue content with <ThunderIDRoot>
 - Implement sign-in and sign-out with auto-imported components
 - Display signed-in user's profile information
-- Optionally protect pages with the built-in thunderIDMiddleware
+- Optionally protect pages with the built-in `auth` middleware
 
 ## Configuration
 - **Client ID**: {{clientId}}
@@ -19,24 +19,27 @@ I have a Nuxt 3 application and I want to integrate {{productName}}'s authentica
 - **SDK**: @thunderid/nuxt
 
 ## IMPORTANT Configuration Rules
-- Add '@thunderid/nuxt' to the modules array in nuxt.config.ts — no other config needed there
+- Add '@thunderid/nuxt' to the modules array in nuxt.config.ts
+- For @thunderid/nuxt 1.0.3, add `vite.optimizeDeps.include: ['@thunderid/node']` in nuxt.config.ts to avoid the known client-bundling issue tracked in thunder-id/thunderid#4905. Remove this workaround only after upgrading to a release that fixes the issue
 - All configuration is read from environment variables with NUXT_PUBLIC_ prefix for public values
 - Required env vars: NUXT_PUBLIC_THUNDERID_BASE_URL, NUXT_PUBLIC_THUNDERID_CLIENT_ID, THUNDERID_CLIENT_SECRET, THUNDERID_SESSION_SECRET
 - THUNDERID_CLIENT_SECRET and THUNDERID_SESSION_SECRET must NOT have the NUXT_PUBLIC_ prefix
 - The /api/auth/callback route is auto-registered by the module — do NOT create it manually
 - Wrap <NuxtPage /> with <ThunderIDRoot> in app.vue
 - All components are auto-registered under the `ThunderID` prefix (`ThunderIDSignedIn`, `ThunderIDSignedOut`, `ThunderIDSignInButton`, `ThunderIDSignOutButton`, `ThunderIDUserDropdown`, `ThunderIDUser`), and composables are auto-imported. NEVER use bare names like `SignedIn` or `SignInButton`
-- Protect pages by adding definePageMeta({ middleware: ['thunderIDMiddleware'] })
+- Protect pages by adding definePageMeta({ middleware: ['auth'] })
+- For @thunderid/nuxt 1.0.3, configure the application with the `authorization_code` grant only. Enabling the `refresh_token` grant can produce an oversized session cookie, as tracked in thunder-id/thunderid#4904. Enable refresh tokens only after upgrading to a release that fixes the issue
+- When using a local self-signed certificate, set `NODE_EXTRA_CA_CERTS` to the certificate file before starting Nuxt. Do not use `NODE_TLS_REJECT_UNAUTHORIZED=0`. A certificate signed by a trusted certificate authority does not require this setting
 
 ## Implementation Steps
 1. Create a Nuxt 3 app: npx nuxi@latest init my-nuxt-app
 2. Navigate into the project: cd my-nuxt-app && npm install
 3. Install @thunderid/nuxt: npm install @thunderid/nuxt
-4. Add '@thunderid/nuxt' to modules in nuxt.config.ts
+4. Add '@thunderid/nuxt' to modules in nuxt.config.ts and include the version-qualified Vite workaround above
 5. Create .env with NUXT_PUBLIC_THUNDERID_BASE_URL, NUXT_PUBLIC_THUNDERID_CLIENT_ID, THUNDERID_CLIENT_SECRET, THUNDERID_SESSION_SECRET
 6. Wrap <NuxtPage /> with <ThunderIDRoot> in app.vue
 7. Create pages/index.vue with ThunderIDSignInButton, ThunderIDSignOutButton, ThunderIDSignedIn, ThunderIDSignedOut, and ThunderIDUser components
-8. Optionally add definePageMeta({ middleware: ['thunderIDMiddleware'] }) to protected pages
-9. Run: npm run dev
+8. Optionally add definePageMeta({ middleware: ['auth'] }) to protected pages
+9. Run `npm run dev`, or start Node with `NODE_EXTRA_CA_CERTS` pointing to the certificate when the local certificate is self-signed
 
 Please provide complete, working code with proper configuration for {{productName}} authentication using the @thunderid/nuxt module.

--- a/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/express.mdx
+++ b/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/express.mdx
@@ -66,7 +66,7 @@ Once it's running, the console is available at [https://localhost:8090/console](
 7. Select how you want to sign in users (e.g., email/password, social login, etc.).
 8. Select Theme settings.
 9. Leave **Sign-In Approach** set to **Redirect to <ProductName /> Gate** (the default for Express applications).
-10. In the Configuration step, add `http://localhost:3000/login` to the list of **Authorized Redirect URIs**.
+10. In the Configuration step, add `http://localhost:3000/login` to **Authorized Redirect URIs** and `http://localhost:3000/logout` to **Post-Logout Redirect URIs**. Clear **Use the same URLs for post-logout redirect** if the fields are linked.
 
 :::note Note
 Copy both the **Client ID** and **Client Secret** from the window that pops up when the application is created. The Client ID can also be found in the **General** tab.
@@ -116,6 +116,19 @@ Install the <ProductName /> Express SDK:
     pnpm add @thunderid/express
   </CodeBlock>
 </CodeGroup>
+
+## Trust the Local Certificate in Node.js
+
+Skip this step when your <ProductName /> instance uses a certificate issued by a certificate authority that Node.js already trusts. For a local self-signed certificate, export the certificate and configure Node.js to trust it:
+
+```bash
+openssl s_client -connect localhost:8090 -servername localhost </dev/null 2>/dev/null \
+  | openssl x509 > thunderid.cert
+
+export NODE_EXTRA_CA_CERTS="$PWD/thunderid.cert"
+```
+
+The browser and Node.js use separate certificate trust stores. Browser trust does not make Node.js trust the certificate. Without `NODE_EXTRA_CA_CERTS`, the authorization-code exchange can fail with `DEPTH_ZERO_SELF_SIGNED_CERT`, causing `/login` to return HTTP 500. Do not use `NODE_TLS_REJECT_UNAUTHORIZED=0` because it disables certificate verification for the entire Node.js process.
 
 ## Add Authentication Middleware and Routes
 
@@ -168,7 +181,7 @@ app.listen(port, () => {
 ```
 
 :::warning Configuration
-Replace `<your-client-id>` and `<your-client-secret>` with values from your <ProductName /> application. Make sure the authorized redirect URL in your application settings is set to `http://localhost:3000/login`.
+Replace `<your-client-id>` and `<your-client-secret>` with values from your <ProductName /> application. Make sure the authorized redirect URL is `http://localhost:3000/login` and the post-logout redirect URL is `http://localhost:3000/logout`.
 :::
 
 ## Run Your App

--- a/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/prompts/express/embedded.txt
+++ b/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/prompts/express/embedded.txt
@@ -33,6 +33,8 @@ I have an Express application and I want to integrate {{productName}} authentica
 - Do not use `clientId`/`clientSecret` in this mode — embedded mode is driven by `applicationId`, not an OAuth2 client
 - Pass `flowSecret` in the `thunderID({...})` middleware config (or set `THUNDERID_FLOW_SECRET` in the environment, which `handleFlow()` falls back to automatically) — it authenticates this app when the flow starts, sent in the `Flow-Secret` request header. It is a separate credential from an OAuth2 client secret, never a substitute for one
 - Never ask the developer to type or paste the Flow Secret into this conversation. If it is not supplied above, set `THUNDERID_FLOW_SECRET` in a local `.env` file as a placeholder and stop with a message telling the developer to fill it in locally before running the app
+- If the local {{productName}} instance uses a self-signed certificate or a certificate from a private CA that Node.js does not trust, configure `NODE_EXTRA_CA_CERTS` with the path to the CA or server certificate before starting the app. Explain that the browser trusting the certificate does not make Node.js trust it, so server-side SDK requests can otherwise fail with `DEPTH_ZERO_SELF_SIGNED_CERT`
+- Do not use `NODE_TLS_REJECT_UNAUTHORIZED=0`. A certificate issued by a CA that Node.js already trusts requires no additional TLS configuration
 
 ## Implementation Steps
 1. Create a new project and install `express` and `cookie-parser`
@@ -41,7 +43,7 @@ I have an Express application and I want to integrate {{productName}} authentica
 4. Add `index.js` with `thunderID({ applicationId, baseUrl, mode: 'embedded', flowSecret })` middleware
 5. Add `/login` route serving a minimal HTML form, and `/flow/sign-in` using `handleFlow()`
 6. Add `/logout`, `/protected`, and `/me` routes
-7. Start the server with `node index.js`
+7. Start the server with `node index.js`, or `NODE_EXTRA_CA_CERTS=/path/to/thunderid-ca-or-server.cert node index.js` only when the local certificate is not already trusted by Node.js
 8. Validate the flow by opening `/login`, submitting the form, then `/protected` and `/me`; then request `/logout` and confirm `/protected` is no longer accessible
 
 Please provide:

--- a/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/prompts/express/redirect-based.txt
+++ b/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/prompts/express/redirect-based.txt
@@ -25,6 +25,8 @@ I have an Express application and I want to integrate {{productName}} authentica
 - Use CommonJS syntax (`require`) in `index.js`
 - Use these SDK imports exactly: `thunderID`, `handleSignIn`, `handleSignOut`, `protect`
 - Ensure redirect URL alignment: the app callback URL must be `http://localhost:3000/login`, and the post-logout redirect URL must be `http://localhost:3000/logout`
+- If the local {{productName}} instance uses a self-signed certificate or a certificate from a private CA that Node.js does not trust, configure `NODE_EXTRA_CA_CERTS` with the path to the CA or server certificate before starting the app. Explain that the browser trusting the certificate does not make Node.js trust it, so the server-side authorization-code exchange can otherwise fail with `DEPTH_ZERO_SELF_SIGNED_CERT` and return HTTP 500 from `/login`
+- Do not use `NODE_TLS_REJECT_UNAUTHORIZED=0`. A certificate issued by a CA that Node.js already trusts requires no additional TLS configuration
 - Do not invent unsupported SDK APIs or custom wrappers
 - Keep route names and behavior exactly as specified
 
@@ -33,7 +35,7 @@ I have an Express application and I want to integrate {{productName}} authentica
 2. Install `@thunderid/express`
 3. Add `index.js` with ThunderID middleware and auth routes
 4. Add `/protected` and `/me` routes with `protect()`
-5. Start the server with `node index.js`
+5. Start the server with `node index.js`, or `NODE_EXTRA_CA_CERTS=/path/to/thunderid-ca-or-server.cert node index.js` only when the local certificate is not already trusted by Node.js
 6. Validate the flow by opening `/protected`, then `/me`
 
 Please provide:

--- a/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/prompts/nuxt/redirect-based.txt
+++ b/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/prompts/nuxt/redirect-based.txt
@@ -10,7 +10,7 @@ I have a Nuxt 3 application and I want to integrate {{productName}}'s authentica
 - Wrap app.vue content with <ThunderIDRoot>
 - Implement sign-in and sign-out with auto-imported components
 - Display signed-in user's profile information
-- Optionally protect pages with the built-in thunderIDMiddleware
+- Optionally protect pages with the built-in `auth` middleware
 
 ## Configuration
 - **Client ID**: {{clientId}}
@@ -19,24 +19,27 @@ I have a Nuxt 3 application and I want to integrate {{productName}}'s authentica
 - **SDK**: @thunderid/nuxt
 
 ## IMPORTANT Configuration Rules
-- Add '@thunderid/nuxt' to the modules array in nuxt.config.ts — no other config needed there
+- Add '@thunderid/nuxt' to the modules array in nuxt.config.ts
+- For @thunderid/nuxt 1.0.3, add `vite.optimizeDeps.include: ['@thunderid/node']` in nuxt.config.ts to avoid the known client-bundling issue tracked in thunder-id/thunderid#4905. Remove this workaround only after upgrading to a release that fixes the issue
 - All configuration is read from environment variables with NUXT_PUBLIC_ prefix for public values
 - Required env vars: NUXT_PUBLIC_THUNDERID_BASE_URL, NUXT_PUBLIC_THUNDERID_CLIENT_ID, THUNDERID_CLIENT_SECRET, THUNDERID_SESSION_SECRET
 - THUNDERID_CLIENT_SECRET and THUNDERID_SESSION_SECRET must NOT have the NUXT_PUBLIC_ prefix
 - The /api/auth/callback route is auto-registered by the module — do NOT create it manually
 - Wrap <NuxtPage /> with <ThunderIDRoot> in app.vue
 - All components are auto-registered under the `ThunderID` prefix (`ThunderIDSignedIn`, `ThunderIDSignedOut`, `ThunderIDSignInButton`, `ThunderIDSignOutButton`, `ThunderIDUserDropdown`, `ThunderIDUser`), and composables are auto-imported. NEVER use bare names like `SignedIn` or `SignInButton`
-- Protect pages by adding definePageMeta({ middleware: ['thunderIDMiddleware'] })
+- Protect pages by adding definePageMeta({ middleware: ['auth'] })
+- For @thunderid/nuxt 1.0.3, configure the application with the `authorization_code` grant only. Enabling the `refresh_token` grant can produce an oversized session cookie, as tracked in thunder-id/thunderid#4904. Enable refresh tokens only after upgrading to a release that fixes the issue
+- When using a local self-signed certificate, set `NODE_EXTRA_CA_CERTS` to the certificate file before starting Nuxt. Do not use `NODE_TLS_REJECT_UNAUTHORIZED=0`. A certificate signed by a trusted certificate authority does not require this setting
 
 ## Implementation Steps
 1. Create a Nuxt 3 app: npx nuxi@latest init my-nuxt-app
 2. Navigate into the project: cd my-nuxt-app && npm install
 3. Install @thunderid/nuxt: npm install @thunderid/nuxt
-4. Add '@thunderid/nuxt' to modules in nuxt.config.ts
+4. Add '@thunderid/nuxt' to modules in nuxt.config.ts and include the version-qualified Vite workaround above
 5. Create .env with NUXT_PUBLIC_THUNDERID_BASE_URL, NUXT_PUBLIC_THUNDERID_CLIENT_ID, THUNDERID_CLIENT_SECRET, THUNDERID_SESSION_SECRET
 6. Wrap <NuxtPage /> with <ThunderIDRoot> in app.vue
 7. Create pages/index.vue with ThunderIDSignInButton, ThunderIDSignOutButton, ThunderIDSignedIn, ThunderIDSignedOut, and ThunderIDUser components
-8. Optionally add definePageMeta({ middleware: ['thunderIDMiddleware'] }) to protected pages
-9. Run: npm run dev
+8. Optionally add definePageMeta({ middleware: ['auth'] }) to protected pages
+9. Run `npm run dev`, or start Node with `NODE_EXTRA_CA_CERTS` pointing to the certificate when the local certificate is self-signed
 
 Please provide complete, working code with proper configuration for {{productName}} authentication using the @thunderid/nuxt module.


### PR DESCRIPTION
### Purpose

Correct the Express and Nuxt authentication setup guidance based on manual SDK integration testing.

- Document the exact Express sign-in and post-logout redirect URIs.
- Explain how Node.js trusts a local ThunderID self-signed certificate without disabling TLS verification.
- Correct the Nuxt named route middleware from `thunderIDMiddleware` to `auth`.
- Document the current Nuxt Vite pre-bundling and refresh-token session-cookie workarounds.
- Keep the current and `v1.0.x` documentation copies synchronized.

The Nuxt embedded prompt remains unchanged because `@thunderid/nuxt@1.0.3` cannot currently implement the documented Application ID and Flow Secret path. That limitation is tracked separately in #4906.

### Approach

- Preserve the existing Express quickstart structure and add only the missing logout URI and local certificate steps.
- Add local certificate handling to both Express prompt modes.
- Update only the verified Nuxt redirect-based prompt guidance.
- Scope the changes to documentation and generated prompt source files.

### Related Issues
- Refs #4904
- Refs #4905
- Refs #4906

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided.
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided.
    - [ ] Unit Tests
    - [ ] Integration Tests
- [x] Breaking changes do not apply.

### Validation

- `git diff --check upstream/main...HEAD`
- Documentation ESLint
- Current and `v1.0.x` copy parity checks
- Documentation TypeScript was attempted but remains blocked by unrelated existing errors in Docusaurus configuration and components.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR does not commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Express setup guidance to include authorized and post-logout redirect URIs.
  * Added instructions for trusting local self-signed or private-CA certificates in Node.js using `NODE_EXTRA_CA_CERTS`.
  * Documented related certificate errors and warned against disabling TLS verification.
  * Updated Nuxt guidance to use the `auth` middleware, with relevant module, Vite, and authorization configuration steps.
  * Applied these improvements to both current and versioned documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->