### PR TITLE
Stop sample services when the CLI shuts down

### DIFF
--- a/tools/cli/internal/commands/sample/procgroup_unix.go
+++ b/tools/cli/internal/commands/sample/procgroup_unix.go
@@ -1,0 +1,45 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package sample
+
+import (
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// killGracePeriod is how long the process group gets to exit after SIGTERM
+// before it is killed outright.
+const killGracePeriod = 3 * time.Second
+
+// setProcessGroup puts cmd in its own process group so every descendant npm
+// spawns can be signaled as a unit.
+func setProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killProcessGroup terminates cmd's process group, escalating to SIGKILL if the
+// group is still alive after killGracePeriod.
+func killProcessGroup(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	// setProcessGroup made the process its own group leader, so the group id is
+	// its pid. Do not look it up with Getpgid: once npm itself has exited and
+	// been reaped, that returns ESRCH even though the group still has members.
+	pgid := cmd.Process.Pid
+	if err := syscall.Kill(-pgid, syscall.SIGTERM); err != nil {
+		return
+	}
+	deadline := time.Now().Add(killGracePeriod)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(-pgid, 0); err != nil {
+			return // group is gone
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	syscall.Kill(-pgid, syscall.SIGKILL) //nolint:errcheck
+}

--- a/tools/cli/internal/commands/sample/procgroup_windows.go
+++ b/tools/cli/internal/commands/sample/procgroup_windows.go
@@ -1,0 +1,23 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package sample
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// setProcessGroup is a no-op on Windows; process trees are terminated with
+// taskkill /T instead of a process-group signal.
+func setProcessGroup(cmd *exec.Cmd) {}
+
+// killProcessGroup terminates cmd and its whole process tree.
+func killProcessGroup(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = exec.Command("taskkill", "/T", "/F", "/PID", fmt.Sprint(cmd.Process.Pid)).Run()
+}

--- a/tools/cli/internal/commands/sample/sample.go
+++ b/tools/cli/internal/commands/sample/sample.go
@@ -6,6 +6,7 @@ package sample
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -15,6 +16,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/thunder-id/thunderid/tools/cli/internal/product"
@@ -170,6 +172,7 @@ func runWithResult(
 	if !ok {
 		return nil, "", "", fmt.Errorf("unknown sample %q — available: %s", sampleName, availableList())
 	}
+	beginRun()
 
 	if err := checkNodeVersion(); err != nil {
 		return nil, "", "", err
@@ -285,6 +288,9 @@ func runWithResult(
 	// Start sample services.
 	progress("Starting " + sampleName + " services...")
 	if err := startSampleServices(sampleDir, aiEnabled); err != nil {
+		if errors.Is(err, errStoppedDuringStart) {
+			return proc, meta.sampleURL, serverURL, err
+		}
 		return proc, meta.sampleURL, serverURL, fmt.Errorf("could not start sample: %w", err)
 	}
 
@@ -616,6 +622,91 @@ func waitForServices(checks []serviceCheck, logPath string, timeout time.Duratio
 	return nil
 }
 
+// running tracks the sample's npm process so the CLI can stop it on shutdown.
+// startSampleServices writes it from RunAsync's goroutine while the REPL reads
+// it from Update, so it is mutex-guarded.
+var running struct {
+	sync.Mutex
+	cmd       *exec.Cmd
+	aiEnabled bool
+	started   bool // a sample was started at least once, so its ports are worth sweeping
+	stopping  bool // shutdown began; a sample that starts after it must not survive
+}
+
+// errStoppedDuringStart is returned when the CLI shuts down while the sample is
+// still starting; the freshly started process is terminated before it returns.
+var errStoppedDuringStart = errors.New("sample startup stopped: shutting down")
+
+// beginRun clears the shutdown latch for a newly requested sample run.
+func beginRun() {
+	running.Lock()
+	defer running.Unlock()
+	running.stopping = false
+}
+
+// trackRunning records the started sample process for StopServices. It reports
+// false when shutdown already began, in which case the caller must stop the
+// process it just started.
+func trackRunning(cmd *exec.Cmd, aiEnabled bool) bool {
+	running.Lock()
+	defer running.Unlock()
+	if running.stopping {
+		return false
+	}
+	running.cmd = cmd
+	running.aiEnabled = aiEnabled
+	running.started = true
+	return true
+}
+
+// clearRunning drops the recorded handle if it is still cmd.
+func clearRunning(cmd *exec.Cmd) {
+	running.Lock()
+	defer running.Unlock()
+	if running.cmd == cmd {
+		running.cmd = nil
+	}
+}
+
+// stopPortTimeout bounds how long StopServices waits for each sample port to be
+// released after the processes holding it are signaled.
+const stopPortTimeout = 5 * time.Second
+
+// StopServices terminates the sample services started by this CLI process. It
+// signals the sample's process group (npm plus every service it spawned) and
+// then sweeps the sample's known ports as a backstop for anything that escaped
+// the group. It is safe to call when nothing was started, and calling it twice
+// is a no-op.
+func StopServices() {
+	running.Lock()
+	cmd, aiEnabled, started := running.cmd, running.aiEnabled, running.started
+	running.cmd = nil
+	running.started = false
+	// Latch shutdown: a sample still starting on RunAsync's goroutine registers
+	// after this point, and trackRunning must refuse it rather than leave it
+	// running past the CLI's exit.
+	running.stopping = true
+	running.Unlock()
+
+	if !started {
+		return
+	}
+	killProcessGroup(cmd)
+	sweepSamplePorts(sampleServicePorts(aiEnabled))
+}
+
+// sweepSamplePorts frees the sample's ports. It is a variable so tests can stop
+// tracked processes without signaling whatever else holds those ports on the
+// developer's machine.
+var sweepSamplePorts = func(ports []int) {
+	for _, p := range ports {
+		setup.KillPort(p)
+	}
+	for _, p := range ports {
+		setup.WaitForPortFree(p, stopPortTimeout)
+	}
+}
+
 // startSampleServices launches the sample services in the background via npm.
 // For AgentID mode (aiEnabled=true) it runs `npm run dev` (all three services);
 // otherwise it runs `npm run dev:b2c` (backend + frontend only).
@@ -645,8 +736,15 @@ func startSampleServices(sampleDir string, aiEnabled bool) error {
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile // never write to os.Stderr — it corrupts the Bubble Tea display
 	cmd.Stdin = nil
+	// Own process group, so StopServices can signal npm and every service it
+	// spawns as a unit.
+	setProcessGroup(cmd)
 	if err := cmd.Start(); err != nil {
 		return err
+	}
+	if !trackRunning(cmd, aiEnabled) {
+		killProcessGroup(cmd)
+		return errStoppedDuringStart
 	}
 
 	// Detect immediate failures (e.g. missing npm script) before returning.
@@ -654,6 +752,7 @@ func startSampleServices(sampleDir string, aiEnabled bool) error {
 	go func() { done <- cmd.Wait() }()
 	select {
 	case err := <-done:
+		clearRunning(cmd)
 		tail := tailLog(logPath, 10)
 		if err != nil {
 			return fmt.Errorf("sample services failed to start:\n%s", tail)

--- a/tools/cli/internal/commands/sample/stop_test.go
+++ b/tools/cli/internal/commands/sample/stop_test.go
@@ -1,0 +1,267 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package sample
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// stubPortSweep replaces the real port sweep for the duration of the test, so
+// stopping a tracked process never signals unrelated listeners on the machine.
+func stubPortSweep(t *testing.T) *[]int {
+	t.Helper()
+	orig := sweepSamplePorts
+	var swept []int
+	sweepSamplePorts = func(ports []int) { swept = append(swept, ports...) }
+	t.Cleanup(func() { sweepSamplePorts = orig })
+	return &swept
+}
+
+// resetRunning clears the tracked-process state around a test.
+func resetRunning(t *testing.T) {
+	t.Helper()
+	clear := func() {
+		running.Lock()
+		defer running.Unlock()
+		running.cmd, running.aiEnabled, running.started, running.stopping = nil, false, false, false
+	}
+	clear()
+	t.Cleanup(clear)
+}
+
+// alive reports whether pid is a running process. A terminated process stays
+// visible to Kill(pid, 0) until its parent reaps it, so the process state has to
+// be checked too: otherwise a not-yet-reaped zombie reads as alive and the test
+// races the reaper.
+func alive(pid int) bool {
+	if syscall.Kill(pid, 0) != nil {
+		return false
+	}
+	out, err := exec.Command("ps", "-o", "stat=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return false // ps exits non-zero when the pid is gone
+	}
+	state := strings.TrimSpace(string(out))
+	return state != "" && !strings.HasPrefix(state, "Z")
+}
+
+// startTree starts a shell in its own process group that spawns a grandchild
+// and writes both PIDs to files, mirroring how npm spawns the sample's services.
+func startTree(t *testing.T) (cmd *exec.Cmd, childPID, grandchildPID int) {
+	t.Helper()
+	dir := t.TempDir()
+	grandPIDFile := filepath.Join(dir, "grandchild.pid")
+	script := "sh -c 'echo $$ > " + grandPIDFile + "; sleep 300' & sleep 300"
+
+	cmd = exec.Command("sh", "-c", script)
+	setProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(func() { killProcessGroup(cmd) })
+
+	return cmd, cmd.Process.Pid, readPID(t, grandPIDFile)
+}
+
+// readPID waits for path to hold a pid and returns it.
+func readPID(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			if pid, convErr := strconv.Atoi(strings.TrimSpace(string(data))); convErr == nil && pid > 0 {
+				return pid
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("no pid reported in %s", path)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// waitGone polls until pid is gone or the deadline passes.
+func waitGone(pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !alive(pid) {
+			return true
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return !alive(pid)
+}
+
+func TestStopServicesKillsProcessTree(t *testing.T) {
+	resetRunning(t)
+	swept := stubPortSweep(t)
+
+	cmd, childPID, grandchildPID := startTree(t)
+	go cmd.Wait() //nolint:errcheck // reap the child so it does not linger as a zombie
+	if !trackRunning(cmd, false) {
+		t.Fatal("trackRunning refused a process outside shutdown")
+	}
+
+	if !alive(grandchildPID) {
+		t.Fatalf("grandchild %d not running before StopServices", grandchildPID)
+	}
+
+	StopServices()
+
+	if !waitGone(childPID, 10*time.Second) {
+		t.Errorf("child %d still alive after StopServices", childPID)
+	}
+	if !waitGone(grandchildPID, 10*time.Second) {
+		t.Errorf("grandchild %d still alive after StopServices", grandchildPID)
+	}
+	if len(*swept) != len(sampleServicePorts(false)) {
+		t.Errorf("swept ports: got %v, want %v", *swept, sampleServicePorts(false))
+	}
+
+	// A second call must be a safe no-op: nothing is tracked any more, so it
+	// must not sweep the ports again either.
+	before := len(*swept)
+	done := make(chan struct{})
+	go func() { StopServices(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second StopServices call blocked")
+	}
+	if len(*swept) != before {
+		t.Errorf("second StopServices swept ports again: %v", *swept)
+	}
+}
+
+func TestStopServicesWithoutStart(t *testing.T) {
+	resetRunning(t)
+	swept := stubPortSweep(t)
+
+	done := make(chan struct{})
+	go func() { StopServices(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("StopServices blocked with nothing started")
+	}
+	if len(*swept) != 0 {
+		t.Errorf("StopServices swept ports with nothing started: %v", *swept)
+	}
+}
+
+func TestStopServicesSweepsAIPorts(t *testing.T) {
+	resetRunning(t)
+	swept := stubPortSweep(t)
+
+	trackRunning(nil, true)
+	StopServices()
+
+	want := sampleServicePorts(true)
+	if len(*swept) != len(want) {
+		t.Fatalf("swept ports: got %v, want %v", *swept, want)
+	}
+}
+
+// TestKillProcessGroupAfterLeaderExit covers the case where npm itself has
+// exited and been reaped while its children are still running: the group id
+// must come from the recorded pid, not from Getpgid (which returns ESRCH).
+func TestKillProcessGroupAfterLeaderExit(t *testing.T) {
+	dir := t.TempDir()
+	grandPIDFile := filepath.Join(dir, "grandchild.pid")
+
+	// The leader spawns a child and exits immediately.
+	cmd := exec.Command("sh", "-c", "sh -c 'echo $$ > "+grandPIDFile+"; sleep 300' & exit 0")
+	setProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	leaderPID := cmd.Process.Pid
+	t.Cleanup(func() { killProcessGroup(cmd) })
+
+	grandchildPID := readPID(t, grandPIDFile)
+	if err := cmd.Wait(); err != nil { // reap the leader, so Getpgid(leaderPID) now fails
+		t.Fatalf("wait: %v", err)
+	}
+	if !waitGone(leaderPID, 5*time.Second) {
+		t.Fatalf("leader %d still alive after Wait", leaderPID)
+	}
+	if !alive(grandchildPID) {
+		t.Fatalf("grandchild %d already gone, nothing to test", grandchildPID)
+	}
+
+	killProcessGroup(cmd)
+
+	if !waitGone(grandchildPID, 10*time.Second) {
+		t.Errorf("grandchild %d survived killProcessGroup after the leader exited", grandchildPID)
+	}
+}
+
+// TestTrackRunningRefusedDuringShutdown covers a sample that finishes starting
+// after StopServices already ran: it must not be recorded, and the caller
+// terminates it.
+func TestTrackRunningRefusedDuringShutdown(t *testing.T) {
+	resetRunning(t)
+	stubPortSweep(t)
+
+	StopServices() // latches shutdown
+
+	cmd, childPID, grandchildPID := startTree(t)
+	go cmd.Wait() //nolint:errcheck
+	if trackRunning(cmd, false) {
+		t.Fatal("trackRunning accepted a process after shutdown began")
+	}
+	killProcessGroup(cmd) // what startSampleServices does on refusal
+
+	if !waitGone(childPID, 10*time.Second) {
+		t.Errorf("child %d still alive", childPID)
+	}
+	if !waitGone(grandchildPID, 10*time.Second) {
+		t.Errorf("grandchild %d still alive", grandchildPID)
+	}
+
+	running.Lock()
+	got := running.cmd
+	running.Unlock()
+	if got != nil {
+		t.Errorf("a refused process was recorded: %v", got)
+	}
+}
+
+func TestBeginRunClearsShutdownLatch(t *testing.T) {
+	resetRunning(t)
+	stubPortSweep(t)
+
+	StopServices()
+	beginRun()
+
+	cmd := exec.Command("true")
+	if !trackRunning(cmd, false) {
+		t.Fatal("trackRunning still refuses after beginRun")
+	}
+}
+
+func TestClearRunningOnlyClearsMatchingCmd(t *testing.T) {
+	resetRunning(t)
+
+	current := exec.Command("true")
+	trackRunning(current, false)
+	clearRunning(exec.Command("true")) // a different, older command
+
+	running.Lock()
+	got := running.cmd
+	running.Unlock()
+	if got != current {
+		t.Errorf("clearRunning dropped a handle it did not own")
+	}
+}

--- a/tools/cli/internal/ui/repl.go
+++ b/tools/cli/internal/ui/repl.go
@@ -1054,17 +1054,22 @@ func (m ReplModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,fu
 			m.input.Placeholder = "Type / for commands, Ctrl+C to exit"
 		}
 
+	// The three exits below replace the running product, so the sample must not
+	// survive: it would keep its ports and point at a base URL that is gone.
 	case cutoverMsg:
+		sample.StopServices()
 		m.cutoverRequested = true
 		m.quitting = true
 		return m, tea.Quit
 
 	case upgradeMsg:
+		sample.StopServices()
 		m.upgradeRequested = true
 		m.quitting = true
 		return m, tea.Quit
 
 	case switchVersionMsg:
+		sample.StopServices()
 		m.switchRequested = true
 		m.quitting = true
 		return m, tea.Quit
@@ -1147,6 +1152,9 @@ func (m *ReplModel) runCommand(val string) tea.Cmd {
 }
 
 func (m *ReplModel) killThunder() {
+	// Stop the sample first: its backend talks to the product, so stopping the
+	// dependant before the product avoids error spew in the sample log.
+	sample.StopServices()
 	if m.proc == nil || m.proc.Process == nil {
 		return
 	}


### PR DESCRIPTION
### Purpose

Stopping the CLI from the REPL left the Wayfinder sample running. `npm run dev` and every service under it survived, keeping 5173, 8787, 8788, 2525, 8795 (and 8790 in AI mode) held after the CLI exited.

The sample's `*exec.Cmd` was function-local in `startSampleServices` and discarded, and `killThunder` only signalled the product process, so nothing in the CLI ever stopped the sample.

Fixes #4882

### Approach

- Start the sample in its own process group (`Setpgid` on Unix; `taskkill /T /F` is the Windows equivalent, both behind build tags) so npm and its descendants are addressable as a unit.
- Keep the started `*exec.Cmd` in mutex-guarded package state in the `sample` package, and add an exported, idempotent `sample.StopServices()`: signal the group (SIGTERM, then SIGKILL after a short grace period), then sweep the sample's known ports with the existing `setup.KillPort` / `setup.WaitForPortFree` primitives as a backstop.
- Call it from `killThunder` (Ctrl+C and `/stop`), before signalling the product, so the dependant stops first. Also call it from the exits that replace the running product (`/cutover`, `/upgrade`, `/switch`), where the sample would otherwise survive pointing at a base URL that is gone.

Package state rather than plumbing the handle through the model: `replLoop` can re-enter `RunREPL`, and a handle stored on the model is lost at each re-entry.

Note: `switchVersionMsg` is emitted when `/switch` is typed, before the version picker, so cancelling at the picker also leaves the sample stopped. `npx thunderid try <usecase>` orphans the sample the same way; fixing that means making `try` a blocking foreground command, a user-visible semantics change, so it is left for a follow-up.

Manually verified against a locally built pack and sample: with the sample running, all five ports are held; after Ctrl+C the CLI exits and all five are free. The same run against a build without this change leaves the same PIDs holding all five ports. `/switch` verified the same way.

### Related Issues
- #4882

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown of sample services and their child processes across Unix and Windows.
  * Sample services now stop cleanly before upgrades, version switches, cutovers, and application exits.
  * Repeated shutdown requests are handled safely without disrupting other processes.
  * Known sample ports are released when services stop.
  * Prevented sample services from starting or surviving during application shutdown.

* **Tests**
  * Added coverage for process-tree termination, shutdown coordination, and port cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->