### PR TITLE
Add integration tests for i18n management, import/export, design, server config, and inbound client

### DIFF
--- a/tests/integration/design/model.go
+++ b/tests/integration/design/model.go
@@ -105,6 +105,23 @@ type Link struct {
 	Rel  string `json:"rel"`
 }
 
+// ResourceDependency represents a single resource that references a theme or layout.
+type ResourceDependency struct {
+	ResourceType     string `json:"resourceType"`
+	ID               string `json:"id"`
+	DisplayName      string `json:"displayName"`
+	BehaviorOnDelete string `json:"behaviorOnDelete"`
+}
+
+// DependenciesResponse represents the response of the theme/layout usages endpoints. TotalResults
+// and Summary are nil when dependency data is unavailable, distinct from a confirmed-empty result.
+type DependenciesResponse struct {
+	TotalResults *int                 `json:"totalResults"`
+	Count        int                  `json:"count"`
+	Summary      map[string]int       `json:"summary"`
+	Usages       []ResourceDependency `json:"usages"`
+}
+
 // ErrorResponse represents an error response.
 type ErrorResponse struct {
 	Code        string      `json:"code"`

--- a/tests/integration/design/resolve_api_test.go
+++ b/tests/integration/design/resolve_api_test.go
@@ -4,11 +4,14 @@
 package design
 
 import (
+	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/thunder-id/thunderid/tests/integration/testutils"
 	"github.com/stretchr/testify/suite"
@@ -21,6 +24,8 @@ const (
 type ResolveAPITestSuite struct {
 	suite.Suite
 	client *http.Client
+	// ouID owns the applications created by the resolve fixtures; applications require an OU.
+	ouID string
 }
 
 func TestResolveAPITestSuite(t *testing.T) {
@@ -30,6 +35,24 @@ func TestResolveAPITestSuite(t *testing.T) {
 func (suite *ResolveAPITestSuite) SetupSuite() {
 	// Create HTTP client that skips TLS verification for testing
 	suite.client = testutils.GetHTTPClient()
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Name:        "Design Resolve OU " + suffix,
+		Handle:      "design-resolve-ou-" + suffix,
+		Description: "OU owning the applications used by design resolve tests",
+	})
+	suite.Require().NoError(err, "Failed to create OU")
+	suite.ouID = ouID
+}
+
+func (suite *ResolveAPITestSuite) TearDownSuite() {
+	if suite.ouID == "" {
+		return
+	}
+	if err := testutils.DeleteOrganizationUnit(suite.ouID); err != nil {
+		suite.T().Logf("Failed to delete OU %s: %v", suite.ouID, err)
+	}
 }
 
 // Helper function to resolve design configuration
@@ -131,25 +154,254 @@ func (suite *ResolveAPITestSuite) TestResolveDesign_ApplicationNotFound() {
 }
 
 // Test Resolve Design - Success Case
-// Note: This test requires an actual application with theme and layout configured
-// For a complete test, you would need to:
-// 1. Create a theme
-// 2. Create a layout
-// 3. Create an application with theme and layout
-// 4. Call resolve with the application ID
-// 5. Verify the merged design configuration
+// An application bound to both a theme and a layout resolves both payloads.
 func (suite *ResolveAPITestSuite) TestResolveDesign_Success() {
+	themeID := suite.createResolveTheme("resolve-both")
+	defer suite.deleteDesignResource(themeBasePath, themeID)
+	layoutID := suite.createResolveLayout("resolve-both")
+	defer suite.deleteDesignResource(layoutBasePath, layoutID)
+
+	appID := suite.createResolveApplication("Resolve Both", themeID, layoutID)
+	defer suite.deleteResolveApplication(appID)
+
+	resolved, statusCode, err := suite.resolveDesign("APP", appID)
+	suite.Require().NoError(err)
+	suite.Equal(http.StatusOK, statusCode)
+
+	// Both payloads come back as the raw JSON stored on each resource.
+	suite.Require().NotEmpty(resolved.Theme)
+	suite.Require().NotEmpty(resolved.Layout)
+	suite.JSONEq(string(testTheme), string(resolved.Theme))
+	suite.JSONEq(string(testLayout), string(resolved.Layout))
 }
 
 // Test Resolve Design - Application Without Theme and Layout
-// This test verifies behavior when an application exists but has no design configuration
+// An application with neither a theme nor a layout has no design to resolve (DSR-1005).
 func (suite *ResolveAPITestSuite) TestResolveDesign_ApplicationWithoutDesign() {
+	appID := suite.createResolveApplication("Resolve No Design", "", "")
+	defer suite.deleteResolveApplication(appID)
+
+	_, statusCode, err := suite.resolveDesign("APP", appID)
+
+	suite.Error(err)
+	suite.Equal(http.StatusNotFound, statusCode)
+	suite.Contains(err.Error(), "DSR-1005")
 }
 
 // Test Resolve Design - Only Theme Configured
 func (suite *ResolveAPITestSuite) TestResolveDesign_OnlyTheme() {
+	themeID := suite.createResolveTheme("resolve-theme-only")
+	defer suite.deleteDesignResource(themeBasePath, themeID)
+
+	appID := suite.createResolveApplication("Resolve Theme Only", themeID, "")
+	defer suite.deleteResolveApplication(appID)
+
+	resolved, statusCode, err := suite.resolveDesign("APP", appID)
+	suite.Require().NoError(err)
+	suite.Equal(http.StatusOK, statusCode)
+
+	suite.Require().NotEmpty(resolved.Theme)
+	suite.JSONEq(string(testTheme), string(resolved.Theme))
+	// No layout is bound, so the layout is omitted rather than defaulted.
+	suite.Empty(resolved.Layout)
 }
 
 // Test Resolve Design - Only Layout Configured
 func (suite *ResolveAPITestSuite) TestResolveDesign_OnlyLayout() {
+	layoutID := suite.createResolveLayout("resolve-layout-only")
+	defer suite.deleteDesignResource(layoutBasePath, layoutID)
+
+	appID := suite.createResolveApplication("Resolve Layout Only", "", layoutID)
+	defer suite.deleteResolveApplication(appID)
+
+	resolved, statusCode, err := suite.resolveDesign("APP", appID)
+	suite.Require().NoError(err)
+	suite.Equal(http.StatusOK, statusCode)
+
+	suite.Require().NotEmpty(resolved.Layout)
+	suite.JSONEq(string(testLayout), string(resolved.Layout))
+	suite.Empty(resolved.Theme)
+}
+
+// Test Resolve Design - Referenced Theme Deleted
+// Deleting a theme an application still references is allowed; resolve degrades to omitting the
+// theme (falling back to the default) instead of failing.
+func (suite *ResolveAPITestSuite) TestResolveDesign_ReferencedThemeDeleted() {
+	themeID := suite.createResolveTheme("resolve-theme-deleted")
+	layoutID := suite.createResolveLayout("resolve-theme-deleted")
+	defer suite.deleteDesignResource(layoutBasePath, layoutID)
+
+	appID := suite.createResolveApplication("Resolve Theme Deleted", themeID, layoutID)
+	defer suite.deleteResolveApplication(appID)
+
+	suite.deleteDesignResource(themeBasePath, themeID)
+
+	resolved, statusCode, err := suite.resolveDesign("APP", appID)
+	suite.Require().NoError(err)
+	suite.Equal(http.StatusOK, statusCode)
+
+	suite.Empty(resolved.Theme)
+	suite.Require().NotEmpty(resolved.Layout)
+	suite.JSONEq(string(testLayout), string(resolved.Layout))
+}
+
+// Test Resolve Design - Lowercase Type Is Accepted
+// The handler upper-cases the type parameter before matching.
+func (suite *ResolveAPITestSuite) TestResolveDesign_TypeIsCaseInsensitive() {
+	themeID := suite.createResolveTheme("resolve-lowercase-type")
+	defer suite.deleteDesignResource(themeBasePath, themeID)
+
+	appID := suite.createResolveApplication("Resolve Lowercase Type", themeID, "")
+	defer suite.deleteResolveApplication(appID)
+
+	resolved, statusCode, err := suite.resolveDesign("app", appID)
+	suite.Require().NoError(err)
+	suite.Equal(http.StatusOK, statusCode)
+	suite.JSONEq(string(testTheme), string(resolved.Theme))
+}
+
+// Test Resolve Design - Public Endpoint
+// /design/resolve/** is in the public path allow-list, so it must answer without credentials.
+func (suite *ResolveAPITestSuite) TestResolveDesign_IsPublic() {
+	themeID := suite.createResolveTheme("resolve-public")
+	defer suite.deleteDesignResource(themeBasePath, themeID)
+
+	appID := suite.createResolveApplication("Resolve Public", themeID, "")
+	defer suite.deleteResolveApplication(appID)
+
+	plainClient := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	url := fmt.Sprintf("%s%s?type=APP&id=%s", testServerURL, resolveBasePath, appID)
+	req, err := http.NewRequest("GET", url, nil)
+	suite.Require().NoError(err)
+
+	resp, err := plainClient.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusOK, resp.StatusCode)
+}
+
+// --- fixtures ---
+
+// createResolveTheme creates a theme with a handle unique to this suite and returns its ID.
+func (suite *ResolveAPITestSuite) createResolveTheme(handle string) string {
+	payload, err := json.Marshal(CreateThemeRequest{
+		Handle:      handle,
+		DisplayName: "Resolve Test Theme " + handle,
+		Theme:       testTheme,
+	})
+	suite.Require().NoError(err)
+
+	id := suite.createDesignResource(themeBasePath, payload)
+	suite.Require().NotEmpty(id)
+	return id
+}
+
+// createResolveLayout creates a layout with a handle unique to this suite and returns its ID.
+func (suite *ResolveAPITestSuite) createResolveLayout(handle string) string {
+	payload, err := json.Marshal(CreateLayoutRequest{
+		Handle:      handle,
+		DisplayName: "Resolve Test Layout " + handle,
+		Layout:      testLayout,
+	})
+	suite.Require().NoError(err)
+
+	id := suite.createDesignResource(layoutBasePath, payload)
+	suite.Require().NotEmpty(id)
+	return id
+}
+
+// createDesignResource POSTs a theme or layout payload and returns the created resource ID.
+func (suite *ResolveAPITestSuite) createDesignResource(basePath string, payload []byte) string {
+	req, err := http.NewRequest("POST", testServerURL+basePath, bytes.NewReader(payload))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := suite.client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+	suite.Require().Equal(http.StatusCreated, resp.StatusCode, "create failed: %s", bodyBytes)
+
+	var created struct {
+		ID string `json:"id"`
+	}
+	suite.Require().NoError(json.Unmarshal(bodyBytes, &created))
+	return created.ID
+}
+
+// deleteDesignResource removes a theme or layout, tolerating an already-deleted resource.
+func (suite *ResolveAPITestSuite) deleteDesignResource(basePath, id string) {
+	if id == "" {
+		return
+	}
+
+	req, err := http.NewRequest("DELETE", testServerURL+basePath+"/"+id, nil)
+	suite.Require().NoError(err)
+
+	resp, err := suite.client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		suite.Failf("delete failed", "status %d: %s", resp.StatusCode, bodyBytes)
+	}
+}
+
+// createResolveApplication creates an application optionally bound to a theme and layout. ouId and
+// type are required by the application API; only the design bindings vary per test.
+func (suite *ResolveAPITestSuite) createResolveApplication(name, themeID, layoutID string) string {
+	body := map[string]interface{}{
+		"name":        name,
+		"description": "Application for design resolve integration tests",
+		"ouId":        suite.ouID,
+		"type":        "fullstack",
+	}
+	if themeID != "" {
+		body["themeId"] = themeID
+	}
+	if layoutID != "" {
+		body["layoutId"] = layoutID
+	}
+
+	payload, err := json.Marshal(body)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testServerURL+"/applications", bytes.NewReader(payload))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := suite.client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+	suite.Require().Equal(http.StatusCreated, resp.StatusCode, "create application failed: %s", bodyBytes)
+
+	var created struct {
+		ID string `json:"id"`
+	}
+	suite.Require().NoError(json.Unmarshal(bodyBytes, &created))
+	suite.Require().NotEmpty(created.ID)
+	return created.ID
+}
+
+// deleteResolveApplication removes an application created by this suite.
+func (suite *ResolveAPITestSuite) deleteResolveApplication(id string) {
+	if id == "" {
+		return
+	}
+	if err := testutils.DeleteApplication(id); err != nil {
+		suite.T().Logf("Failed to delete application %s: %v", id, err)
+	}
 }

--- a/tests/integration/design/usages_handle_api_test.go
+++ b/tests/integration/design/usages_handle_api_test.go
@@ -1,0 +1,429 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package design
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// DesignUsagesHandleAPITestSuite covers the parts of the theme and layout management APIs the
+// per-resource CRUD suites leave untested: the /usages endpoints, handle uniqueness, and handle
+// immutability on update.
+type DesignUsagesHandleAPITestSuite struct {
+	suite.Suite
+	client *http.Client
+	// ouID owns the applications created to reference a theme or layout; applications require an OU.
+	ouID string
+}
+
+func TestDesignUsagesHandleAPITestSuite(t *testing.T) {
+	suite.Run(t, new(DesignUsagesHandleAPITestSuite))
+}
+
+func (suite *DesignUsagesHandleAPITestSuite) SetupSuite() {
+	suite.client = testutils.GetHTTPClient()
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Name:        "Design Usages OU " + suffix,
+		Handle:      "design-usages-ou-" + suffix,
+		Description: "OU owning the applications used by design usages tests",
+	})
+	suite.Require().NoError(err, "Failed to create OU")
+	suite.ouID = ouID
+}
+
+func (suite *DesignUsagesHandleAPITestSuite) TearDownSuite() {
+	if suite.ouID == "" {
+		return
+	}
+	if err := testutils.DeleteOrganizationUnit(suite.ouID); err != nil {
+		suite.T().Logf("Failed to delete OU %s: %v", suite.ouID, err)
+	}
+}
+
+// --- Theme usages ---
+
+// TestThemeUsagesEmptyWhenUnreferenced asserts an unreferenced theme reports a confirmed-empty
+// usage set rather than an unknown one.
+func (suite *DesignUsagesHandleAPITestSuite) TestThemeUsagesEmptyWhenUnreferenced() {
+	themeID := suite.createTheme("usages-theme-unreferenced")
+	defer suite.deleteResource(themeBasePath, themeID)
+
+	usages := suite.getUsages(themeBasePath, themeID)
+
+	suite.Equal(0, usages.Count)
+	suite.Empty(usages.Usages)
+}
+
+// TestThemeUsagesListsReferencingApplication asserts an application that binds the theme shows up
+// in the theme's usage list.
+func (suite *DesignUsagesHandleAPITestSuite) TestThemeUsagesListsReferencingApplication() {
+	themeID := suite.createTheme("usages-theme-referenced")
+	defer suite.deleteResource(themeBasePath, themeID)
+
+	appID := suite.createApplication("Theme Usages App", themeID, "")
+	defer suite.deleteApplication(appID)
+
+	usages := suite.getUsages(themeBasePath, themeID)
+
+	suite.Equal(1, usages.Count)
+	suite.Require().Len(usages.Usages, 1)
+	suite.Equal(appID, usages.Usages[0].ID)
+	suite.Equal("Theme Usages App", usages.Usages[0].DisplayName)
+	suite.NotEmpty(usages.Usages[0].ResourceType)
+}
+
+func (suite *DesignUsagesHandleAPITestSuite) TestThemeUsagesNotFound() {
+	status, body := suite.do(http.MethodGet,
+		testServerURL+themeBasePath+"/00000000-0000-0000-0000-000000000000/usages", nil)
+
+	suite.Equal(http.StatusNotFound, status)
+	suite.Equal("THM-1003", suite.errorCode(body))
+}
+
+func (suite *DesignUsagesHandleAPITestSuite) TestThemeUsagesInvalidPagination() {
+	themeID := suite.createTheme("usages-theme-pagination")
+	defer suite.deleteResource(themeBasePath, themeID)
+
+	limitStatus, limitBody := suite.do(http.MethodGet,
+		fmt.Sprintf("%s%s/%s/usages?limit=-1", testServerURL, themeBasePath, themeID), nil)
+	suite.Equal(http.StatusBadRequest, limitStatus)
+	suite.Equal("THM-1008", suite.errorCode(limitBody))
+
+	offsetStatus, offsetBody := suite.do(http.MethodGet,
+		fmt.Sprintf("%s%s/%s/usages?offset=-1", testServerURL, themeBasePath, themeID), nil)
+	suite.Equal(http.StatusBadRequest, offsetStatus)
+	suite.Equal("THM-1009", suite.errorCode(offsetBody))
+}
+
+// TestThemeUsagesNonNumericPagination covers the handler-level strconv failures, which map to
+// different codes than the service-level range checks.
+func (suite *DesignUsagesHandleAPITestSuite) TestThemeUsagesNonNumericPagination() {
+	themeID := suite.createTheme("usages-theme-nan")
+	defer suite.deleteResource(themeBasePath, themeID)
+
+	limitStatus, limitBody := suite.do(http.MethodGet,
+		fmt.Sprintf("%s%s/%s/usages?limit=abc", testServerURL, themeBasePath, themeID), nil)
+	suite.Equal(http.StatusBadRequest, limitStatus)
+	suite.Equal("THM-1010", suite.errorCode(limitBody))
+
+	offsetStatus, offsetBody := suite.do(http.MethodGet,
+		fmt.Sprintf("%s%s/%s/usages?offset=abc", testServerURL, themeBasePath, themeID), nil)
+	suite.Equal(http.StatusBadRequest, offsetStatus)
+	suite.Equal("THM-1011", suite.errorCode(offsetBody))
+}
+
+// --- Layout usages ---
+
+func (suite *DesignUsagesHandleAPITestSuite) TestLayoutUsagesEmptyWhenUnreferenced() {
+	layoutID := suite.createLayout("usages-layout-unreferenced")
+	defer suite.deleteResource(layoutBasePath, layoutID)
+
+	usages := suite.getUsages(layoutBasePath, layoutID)
+
+	suite.Equal(0, usages.Count)
+	suite.Empty(usages.Usages)
+}
+
+func (suite *DesignUsagesHandleAPITestSuite) TestLayoutUsagesListsReferencingApplication() {
+	layoutID := suite.createLayout("usages-layout-referenced")
+	defer suite.deleteResource(layoutBasePath, layoutID)
+
+	appID := suite.createApplication("Layout Usages App", "", layoutID)
+	defer suite.deleteApplication(appID)
+
+	usages := suite.getUsages(layoutBasePath, layoutID)
+
+	suite.Equal(1, usages.Count)
+	suite.Require().Len(usages.Usages, 1)
+	suite.Equal(appID, usages.Usages[0].ID)
+	suite.Equal("Layout Usages App", usages.Usages[0].DisplayName)
+}
+
+func (suite *DesignUsagesHandleAPITestSuite) TestLayoutUsagesNotFound() {
+	status, body := suite.do(http.MethodGet,
+		testServerURL+layoutBasePath+"/00000000-0000-0000-0000-000000000000/usages", nil)
+
+	suite.Equal(http.StatusNotFound, status)
+	suite.Equal("LAY-1003", suite.errorCode(body))
+}
+
+func (suite *DesignUsagesHandleAPITestSuite) TestLayoutUsagesInvalidPagination() {
+	layoutID := suite.createLayout("usages-layout-pagination")
+	defer suite.deleteResource(layoutBasePath, layoutID)
+
+	limitStatus, limitBody := suite.do(http.MethodGet,
+		fmt.Sprintf("%s%s/%s/usages?limit=-1", testServerURL, layoutBasePath, layoutID), nil)
+	suite.Equal(http.StatusBadRequest, limitStatus)
+	suite.Equal("LAY-1009", suite.errorCode(limitBody))
+
+	offsetStatus, offsetBody := suite.do(http.MethodGet,
+		fmt.Sprintf("%s%s/%s/usages?offset=-1", testServerURL, layoutBasePath, layoutID), nil)
+	suite.Equal(http.StatusBadRequest, offsetStatus)
+	suite.Equal("LAY-1010", suite.errorCode(offsetBody))
+}
+
+// --- Handle semantics ---
+
+// TestCreateThemeMissingHandleReturnsError pins THM-1016; the existing validation tests always
+// omit displayName too, and displayName is checked first, so this branch was never reached.
+func (suite *DesignUsagesHandleAPITestSuite) TestCreateThemeMissingHandleReturnsError() {
+	payload, err := json.Marshal(CreateThemeRequest{
+		DisplayName: "Theme Without Handle",
+		Theme:       testTheme,
+	})
+	suite.Require().NoError(err)
+
+	status, body := suite.do(http.MethodPost, testServerURL+themeBasePath, payload)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("THM-1016", suite.errorCode(body))
+}
+
+func (suite *DesignUsagesHandleAPITestSuite) TestCreateLayoutMissingHandleReturnsError() {
+	payload, err := json.Marshal(CreateLayoutRequest{
+		DisplayName: "Layout Without Handle",
+		Layout:      testLayout,
+	})
+	suite.Require().NoError(err)
+
+	status, body := suite.do(http.MethodPost, testServerURL+layoutBasePath, payload)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("LAY-1017", suite.errorCode(body))
+}
+
+func (suite *DesignUsagesHandleAPITestSuite) TestCreateThemeDuplicateHandleReturnsError() {
+	handle := "duplicate-theme-handle"
+	themeID := suite.createTheme(handle)
+	defer suite.deleteResource(themeBasePath, themeID)
+
+	payload, err := json.Marshal(CreateThemeRequest{
+		Handle:      handle,
+		DisplayName: "Duplicate Handle Theme",
+		Theme:       testTheme,
+	})
+	suite.Require().NoError(err)
+
+	status, body := suite.do(http.MethodPost, testServerURL+themeBasePath, payload)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("THM-1015", suite.errorCode(body))
+}
+
+func (suite *DesignUsagesHandleAPITestSuite) TestCreateLayoutDuplicateHandleReturnsError() {
+	handle := "duplicate-layout-handle"
+	layoutID := suite.createLayout(handle)
+	defer suite.deleteResource(layoutBasePath, layoutID)
+
+	payload, err := json.Marshal(CreateLayoutRequest{
+		Handle:      handle,
+		DisplayName: "Duplicate Handle Layout",
+		Layout:      testLayout,
+	})
+	suite.Require().NoError(err)
+
+	status, body := suite.do(http.MethodPost, testServerURL+layoutBasePath, payload)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("LAY-1016", suite.errorCode(body))
+}
+
+// TestUpdateThemeHandleIsImmutable asserts a PUT that changes the handle is rejected; the existing
+// update tests always resend the same handle.
+func (suite *DesignUsagesHandleAPITestSuite) TestUpdateThemeHandleIsImmutable() {
+	themeID := suite.createTheme("immutable-theme-handle")
+	defer suite.deleteResource(themeBasePath, themeID)
+
+	payload, err := json.Marshal(UpdateThemeRequest{
+		Handle:      "immutable-theme-handle-changed",
+		DisplayName: "Renamed Handle Theme",
+		Theme:       testTheme,
+	})
+	suite.Require().NoError(err)
+
+	status, body := suite.do(http.MethodPut, testServerURL+themeBasePath+"/"+themeID, payload)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("THM-1017", suite.errorCode(body))
+}
+
+// TestUpdateThemeOmittedHandleKeepsExistingHandle asserts an update that omits the handle is
+// accepted and leaves the stored handle untouched.
+func (suite *DesignUsagesHandleAPITestSuite) TestUpdateThemeOmittedHandleKeepsExistingHandle() {
+	handle := "omitted-theme-handle"
+	themeID := suite.createTheme(handle)
+	defer suite.deleteResource(themeBasePath, themeID)
+
+	payload, err := json.Marshal(UpdateThemeRequest{
+		DisplayName: "Updated Without Handle",
+		Theme:       testTheme,
+	})
+	suite.Require().NoError(err)
+
+	status, body := suite.do(http.MethodPut, testServerURL+themeBasePath+"/"+themeID, payload)
+	suite.Require().Equal(http.StatusOK, status, "update failed: %s", body)
+
+	var updated ThemeResponse
+	suite.Require().NoError(json.Unmarshal(body, &updated))
+	suite.Equal(handle, updated.Handle)
+	suite.Equal("Updated Without Handle", updated.DisplayName)
+}
+
+func (suite *DesignUsagesHandleAPITestSuite) TestUpdateLayoutHandleIsImmutable() {
+	layoutID := suite.createLayout("immutable-layout-handle")
+	defer suite.deleteResource(layoutBasePath, layoutID)
+
+	payload, err := json.Marshal(UpdateLayoutRequest{
+		Handle:      "immutable-layout-handle-changed",
+		DisplayName: "Renamed Handle Layout",
+		Layout:      testLayout,
+	})
+	suite.Require().NoError(err)
+
+	status, body := suite.do(http.MethodPut, testServerURL+layoutBasePath+"/"+layoutID, payload)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("LAY-1018", suite.errorCode(body))
+}
+
+// --- helpers ---
+
+func (suite *DesignUsagesHandleAPITestSuite) createTheme(handle string) string {
+	payload, err := json.Marshal(CreateThemeRequest{
+		Handle:      handle,
+		DisplayName: "Usages Test Theme " + handle,
+		Theme:       testTheme,
+	})
+	suite.Require().NoError(err)
+
+	status, body := suite.do(http.MethodPost, testServerURL+themeBasePath, payload)
+	suite.Require().Equal(http.StatusCreated, status, "create theme failed: %s", body)
+
+	var created ThemeResponse
+	suite.Require().NoError(json.Unmarshal(body, &created))
+	suite.Require().NotEmpty(created.ID)
+	return created.ID
+}
+
+func (suite *DesignUsagesHandleAPITestSuite) createLayout(handle string) string {
+	payload, err := json.Marshal(CreateLayoutRequest{
+		Handle:      handle,
+		DisplayName: "Usages Test Layout " + handle,
+		Layout:      testLayout,
+	})
+	suite.Require().NoError(err)
+
+	status, body := suite.do(http.MethodPost, testServerURL+layoutBasePath, payload)
+	suite.Require().Equal(http.StatusCreated, status, "create layout failed: %s", body)
+
+	var created LayoutResponse
+	suite.Require().NoError(json.Unmarshal(body, &created))
+	suite.Require().NotEmpty(created.ID)
+	return created.ID
+}
+
+// getUsages GETs a theme or layout usages endpoint and requires a 200 response.
+func (suite *DesignUsagesHandleAPITestSuite) getUsages(basePath, id string) DependenciesResponse {
+	status, body := suite.do(http.MethodGet, testServerURL+basePath+"/"+id+"/usages", nil)
+	suite.Require().Equal(http.StatusOK, status, "usages failed: %s", body)
+
+	var usages DependenciesResponse
+	suite.Require().NoError(json.Unmarshal(body, &usages))
+	return usages
+}
+
+// createApplication creates an application optionally bound to a theme and layout. ouId and type
+// are required by the application API; only the design bindings vary per test.
+func (suite *DesignUsagesHandleAPITestSuite) createApplication(name, themeID, layoutID string) string {
+	body := map[string]interface{}{
+		"name":        name,
+		"description": "Application for design usages integration tests",
+		"ouId":        suite.ouID,
+		"type":        "fullstack",
+	}
+	if themeID != "" {
+		body["themeId"] = themeID
+	}
+	if layoutID != "" {
+		body["layoutId"] = layoutID
+	}
+
+	payload, err := json.Marshal(body)
+	suite.Require().NoError(err)
+
+	status, respBody := suite.do(http.MethodPost, testServerURL+"/applications", payload)
+	suite.Require().Equal(http.StatusCreated, status, "create application failed: %s", respBody)
+
+	var created struct {
+		ID string `json:"id"`
+	}
+	suite.Require().NoError(json.Unmarshal(respBody, &created))
+	suite.Require().NotEmpty(created.ID)
+	return created.ID
+}
+
+func (suite *DesignUsagesHandleAPITestSuite) deleteApplication(id string) {
+	if id == "" {
+		return
+	}
+	if err := testutils.DeleteApplication(id); err != nil {
+		suite.T().Logf("Failed to delete application %s: %v", id, err)
+	}
+}
+
+// deleteResource removes a theme or layout, tolerating an already-deleted resource.
+func (suite *DesignUsagesHandleAPITestSuite) deleteResource(basePath, id string) {
+	if id == "" {
+		return
+	}
+
+	status, body := suite.do(http.MethodDelete, testServerURL+basePath+"/"+id, nil)
+	if status != http.StatusNoContent && status != http.StatusNotFound {
+		suite.T().Logf("Failed to delete %s/%s: status %d: %s", basePath, id, status, body)
+	}
+}
+
+// do issues a request and returns the status code and response body.
+func (suite *DesignUsagesHandleAPITestSuite) do(method, target string, body []byte) (int, []byte) {
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequest(method, target, reader)
+	suite.Require().NoError(err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := suite.client.Do(req)
+	suite.Require().NoError(err)
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			suite.T().Logf("Failed to close response body: %v", closeErr)
+		}
+	}()
+
+	respBody, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+	return resp.StatusCode, respBody
+}
+
+// errorCode decodes the error code from an API error response body.
+func (suite *DesignUsagesHandleAPITestSuite) errorCode(body []byte) string {
+	var errResp ErrorResponse
+	suite.Require().NoError(json.Unmarshal(body, &errResp), "body: %s", body)
+	return errResp.Code
+}

--- a/tests/integration/i18n/i18n_mgt_api_test.go
+++ b/tests/integration/i18n/i18n_mgt_api_test.go
@@ -1,0 +1,603 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package i18n
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// I18nMgtAPITestSuite covers the translation *management* endpoints: setting and clearing overrides
+// both per-key and in bulk per-language, the round-trip through the resolve endpoints, the validation
+// branches for language/namespace/key/value, and the auth gate. The resolve endpoints are public; the
+// write endpoints are not (backend/internal/system/security/permissions.go).
+type I18nMgtAPITestSuite struct {
+	suite.Suite
+	adminClient *http.Client
+	plainClient *http.Client
+}
+
+func TestI18nMgtAPITestSuite(t *testing.T) {
+	suite.Run(t, new(I18nMgtAPITestSuite))
+}
+
+func (suite *I18nMgtAPITestSuite) SetupSuite() {
+	suite.adminClient = testutils.GetHTTPClient()
+	suite.plainClient = &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+}
+
+// SetupTest clears the suite's language so each test starts from a known state.
+func (suite *I18nMgtAPITestSuite) SetupTest() {
+	suite.clearLanguage(testLanguage)
+}
+
+// TearDownSuite leaves no overrides behind for the shared server.
+func (suite *I18nMgtAPITestSuite) TearDownSuite() {
+	suite.clearLanguage(testLanguage)
+}
+
+// --- GET /i18n/languages ---
+
+func (suite *I18nMgtAPITestSuite) TestListLanguagesAlwaysIncludesSystemLanguage() {
+	status, body := suite.do(suite.adminClient, http.MethodGet, languagesURL, nil)
+
+	suite.Equal(http.StatusOK, status)
+	var resp languageListResponse
+	suite.Require().NoError(json.Unmarshal(body, &resp))
+	suite.Contains(resp.Languages, systemLanguage)
+}
+
+func (suite *I18nMgtAPITestSuite) TestListLanguagesReflectsNewlyWrittenLanguage() {
+	suite.Require().NotContains(suite.listLanguages(), testLanguage)
+
+	suite.setKeyOverride(testLanguage, testNamespace, "greeting", "Bonjour")
+
+	suite.Contains(suite.listLanguages(), testLanguage)
+}
+
+func (suite *I18nMgtAPITestSuite) TestListLanguagesIsPublic() {
+	status, _ := suite.do(suite.plainClient, http.MethodGet, languagesURL, nil)
+
+	suite.Equal(http.StatusOK, status)
+}
+
+// --- Single-key override: POST/GET/DELETE round-trip ---
+
+func (suite *I18nMgtAPITestSuite) TestSetKeyOverrideRoundTrip() {
+	setResp := suite.setKeyOverride(testLanguage, testNamespace, "greeting", "Bonjour")
+	suite.Equal(testLanguage, setResp.Language)
+	suite.Equal(testNamespace, setResp.Namespace)
+	suite.Equal("greeting", setResp.Key)
+	suite.Equal("Bonjour", setResp.Value)
+
+	resolved := suite.resolveKey(testLanguage, testNamespace, "greeting")
+	suite.Equal("Bonjour", resolved.Value)
+	suite.Equal(testNamespace, resolved.Namespace)
+	suite.Equal("greeting", resolved.Key)
+}
+
+func (suite *I18nMgtAPITestSuite) TestSetKeyOverrideIsIdempotentUpsert() {
+	suite.setKeyOverride(testLanguage, testNamespace, "greeting", "Bonjour")
+	suite.setKeyOverride(testLanguage, testNamespace, "greeting", "Salut")
+
+	// The second write updates in place rather than creating a second row.
+	suite.Equal("Salut", suite.resolveKey(testLanguage, testNamespace, "greeting").Value)
+}
+
+func (suite *I18nMgtAPITestSuite) TestClearKeyOverrideRemovesOnlyThatKey() {
+	suite.setKeyOverride(testLanguage, testNamespace, "greeting", "Bonjour")
+	suite.setKeyOverride(testLanguage, testNamespace, "farewell", "Au revoir")
+
+	status, _ := suite.do(suite.adminClient, http.MethodDelete,
+		keyURL(testLanguage, testNamespace, "greeting"), nil)
+	suite.Equal(http.StatusNoContent, status)
+
+	// The cleared key is gone; the sibling key in the same namespace survives.
+	suite.Equal(http.StatusNotFound, suite.resolveKeyStatus(testLanguage, testNamespace, "greeting"))
+	suite.Equal("Au revoir", suite.resolveKey(testLanguage, testNamespace, "farewell").Value)
+}
+
+// TestClearKeyOverrideIsIdempotent asserts deleting an override that does not exist is not an error;
+// the store delete is unconditional.
+func (suite *I18nMgtAPITestSuite) TestClearKeyOverrideIsIdempotent() {
+	status, _ := suite.do(suite.adminClient, http.MethodDelete,
+		keyURL(testLanguage, testNamespace, "never-written"), nil)
+
+	suite.Equal(http.StatusNoContent, status)
+}
+
+// --- Bulk override: POST/GET/DELETE round-trip ---
+
+func (suite *I18nMgtAPITestSuite) TestSetBulkOverridesRoundTrip() {
+	setResp := suite.setBulkOverrides(testLanguage, map[string]map[string]string{
+		testNamespace: {"greeting": "Bonjour", "farewell": "Au revoir"},
+	})
+	suite.Equal(testLanguage, setResp.Language)
+	suite.Equal(2, setResp.TotalResults)
+
+	resolved := suite.resolveLanguage(testLanguage, testNamespace)
+	suite.Equal(testLanguage, resolved.Language)
+	suite.Equal(map[string]string{"greeting": "Bonjour", "farewell": "Au revoir"},
+		resolved.Translations[testNamespace])
+}
+
+// TestSetBulkOverridesSpanMultipleNamespaces asserts one bulk write can populate more than one
+// namespace, and that a namespace-filtered resolve returns only the requested namespace.
+func (suite *I18nMgtAPITestSuite) TestSetBulkOverridesSpanMultipleNamespaces() {
+	otherNamespace := testNamespace + "-other"
+	suite.setBulkOverrides(testLanguage, map[string]map[string]string{
+		testNamespace:  {"greeting": "Bonjour"},
+		otherNamespace: {"greeting": "Coucou"},
+	})
+	defer suite.clearNamespaceKey(testLanguage, otherNamespace, "greeting")
+
+	filtered := suite.resolveLanguage(testLanguage, testNamespace)
+	suite.Equal(map[string]string{"greeting": "Bonjour"}, filtered.Translations[testNamespace])
+	suite.NotContains(filtered.Translations, otherNamespace)
+
+	all := suite.resolveLanguage(testLanguage, "")
+	suite.Equal("Bonjour", all.Translations[testNamespace]["greeting"])
+	suite.Equal("Coucou", all.Translations[otherNamespace]["greeting"])
+}
+
+// TestSetBulkOverridesReplacesLanguage asserts the bulk write replaces every existing override for the
+// language rather than merging into it.
+func (suite *I18nMgtAPITestSuite) TestSetBulkOverridesReplacesLanguage() {
+	suite.setBulkOverrides(testLanguage, map[string]map[string]string{
+		testNamespace: {"greeting": "Bonjour", "farewell": "Au revoir"},
+	})
+
+	suite.setBulkOverrides(testLanguage, map[string]map[string]string{
+		testNamespace: {"greeting": "Salut"},
+	})
+
+	resolved := suite.resolveLanguage(testLanguage, testNamespace)
+	suite.Equal(map[string]string{"greeting": "Salut"}, resolved.Translations[testNamespace])
+	suite.Equal(http.StatusNotFound, suite.resolveKeyStatus(testLanguage, testNamespace, "farewell"))
+}
+
+func (suite *I18nMgtAPITestSuite) TestClearLanguageOverridesRemovesAll() {
+	suite.setBulkOverrides(testLanguage, map[string]map[string]string{
+		testNamespace: {"greeting": "Bonjour", "farewell": "Au revoir"},
+	})
+
+	status, _ := suite.do(suite.adminClient, http.MethodDelete, translationsURL(testLanguage), nil)
+	suite.Equal(http.StatusNoContent, status)
+
+	resolved := suite.resolveLanguage(testLanguage, testNamespace)
+	suite.Empty(resolved.Translations[testNamespace])
+	suite.Equal(http.StatusNotFound, suite.resolveKeyStatus(testLanguage, testNamespace, "greeting"))
+}
+
+// TestClearLanguageOverridesLeavesOtherLanguagesIntact pins that the delete is scoped by language:
+// clearing one language leaves another language's overrides for the same key in place.
+//
+// Note the cleared language does not then resolve to 404 for that key. Resolution is BCP 47
+// best-match over whatever translations remain, so fr-CA falls back to the surviving de-DE entry
+// rather than reporting the key as missing. The bulk resolve below is the language-scoped view that
+// actually shows the override is gone.
+func (suite *I18nMgtAPITestSuite) TestClearLanguageOverridesLeavesOtherLanguagesIntact() {
+	otherLanguage := "de-DE"
+	suite.setKeyOverride(testLanguage, testNamespace, "greeting", "Bonjour")
+	suite.setKeyOverride(otherLanguage, testNamespace, "greeting", "Hallo")
+	defer suite.clearLanguage(otherLanguage)
+
+	suite.clearLanguage(testLanguage)
+
+	suite.Equal("Hallo", suite.resolveKey(otherLanguage, testNamespace, "greeting").Value)
+
+	// The cleared language no longer has its own value; what remains is the de-DE fallback.
+	suite.Equal("Hallo", suite.resolveKey(testLanguage, testNamespace, "greeting").Value)
+	suite.Equal(map[string]string{"greeting": "Hallo"},
+		suite.resolveLanguage(testLanguage, testNamespace).Translations[testNamespace])
+}
+
+// --- Overrides interact with system defaults ---
+
+// TestOverrideShadowsSystemDefault asserts a system-namespace override wins over the compiled-in
+// default for the same key, and that clearing the override restores the default.
+func (suite *I18nMgtAPITestSuite) TestOverrideShadowsSystemDefault() {
+	key := suite.anySystemDefaultKey()
+	defaultValue := suite.resolveKey(systemLanguage, systemNamespace, key).Value
+	suite.Require().NotEmpty(defaultValue)
+
+	override := defaultValue + " (overridden)"
+	suite.setKeyOverride(systemLanguage, systemNamespace, key, override)
+
+	suite.Equal(override, suite.resolveKey(systemLanguage, systemNamespace, key).Value)
+
+	suite.clearNamespaceKey(systemLanguage, systemNamespace, key)
+	suite.Equal(defaultValue, suite.resolveKey(systemLanguage, systemNamespace, key).Value)
+}
+
+// --- Validation branches ---
+
+func (suite *I18nMgtAPITestSuite) TestSetKeyOverrideInvalidLanguageReturns400() {
+	status, body := suite.do(suite.adminClient, http.MethodPost,
+		keyURL("not_a_language", testNamespace, "greeting"), setKeyBody("Bonjour"))
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("I18N-1001", suite.errorCode(body))
+}
+
+func (suite *I18nMgtAPITestSuite) TestSetKeyOverrideNonCanonicalLanguageReturns400() {
+	// ValidateLanguage requires the canonical BCP 47 form; "fr-ca" is parseable but not canonical.
+	status, body := suite.do(suite.adminClient, http.MethodPost,
+		keyURL("fr-ca", testNamespace, "greeting"), setKeyBody("Bonjour"))
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("I18N-1001", suite.errorCode(body))
+}
+
+func (suite *I18nMgtAPITestSuite) TestSetKeyOverrideInvalidNamespaceReturns400() {
+	// Namespaces allow only alphanumerics, underscores and hyphens; a dot is rejected.
+	status, body := suite.do(suite.adminClient, http.MethodPost,
+		keyURL(testLanguage, "bad.namespace", "greeting"), setKeyBody("Bonjour"))
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("I18N-1002", suite.errorCode(body))
+}
+
+func (suite *I18nMgtAPITestSuite) TestSetKeyOverrideInvalidKeyReturns400() {
+	// Keys allow only alphanumerics, dots, underscores and hyphens; a colon is rejected.
+	status, body := suite.do(suite.adminClient, http.MethodPost,
+		keyURL(testLanguage, testNamespace, "bad:key"), setKeyBody("Bonjour"))
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("I18N-1003", suite.errorCode(body))
+}
+
+func (suite *I18nMgtAPITestSuite) TestSetKeyOverrideEmptyValueReturns400() {
+	status, body := suite.do(suite.adminClient, http.MethodPost,
+		keyURL(testLanguage, testNamespace, "greeting"), setKeyBody(""))
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("I18N-1005", suite.errorCode(body))
+}
+
+func (suite *I18nMgtAPITestSuite) TestSetKeyOverrideMalformedBodyReturns400() {
+	status, body := suite.do(suite.adminClient, http.MethodPost,
+		keyURL(testLanguage, testNamespace, "greeting"), []byte(`{`))
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("I18N-1007", suite.errorCode(body))
+}
+
+func (suite *I18nMgtAPITestSuite) TestClearKeyOverrideInvalidLanguageReturns400() {
+	status, body := suite.do(suite.adminClient, http.MethodDelete,
+		keyURL("not_a_language", testNamespace, "greeting"), nil)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("I18N-1001", suite.errorCode(body))
+}
+
+func (suite *I18nMgtAPITestSuite) TestSetBulkOverridesEmptyTranslationsReturns400() {
+	status, body := suite.do(suite.adminClient, http.MethodPost,
+		translationsURL(testLanguage), setBulkBody(map[string]map[string]string{}))
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("I18N-1008", suite.errorCode(body))
+}
+
+func (suite *I18nMgtAPITestSuite) TestSetBulkOverridesInvalidLanguageReturns400() {
+	status, body := suite.do(suite.adminClient, http.MethodPost,
+		translationsURL("not_a_language"),
+		setBulkBody(map[string]map[string]string{testNamespace: {"greeting": "Bonjour"}}))
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("I18N-1001", suite.errorCode(body))
+}
+
+func (suite *I18nMgtAPITestSuite) TestSetBulkOverridesInvalidNamespaceReturns400AndDoesNotPersist() {
+	status, body := suite.do(suite.adminClient, http.MethodPost, translationsURL(testLanguage),
+		setBulkBody(map[string]map[string]string{"bad.namespace": {"greeting": "Bonjour"}}))
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("I18N-1002", suite.errorCode(body))
+
+	// Validation runs over the whole payload before any write.
+	suite.Empty(suite.resolveLanguage(testLanguage, "").Translations["bad.namespace"])
+}
+
+func (suite *I18nMgtAPITestSuite) TestSetBulkOverridesInvalidKeyReturns400() {
+	status, body := suite.do(suite.adminClient, http.MethodPost, translationsURL(testLanguage),
+		setBulkBody(map[string]map[string]string{testNamespace: {"bad:key": "Bonjour"}}))
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("I18N-1003", suite.errorCode(body))
+}
+
+func (suite *I18nMgtAPITestSuite) TestSetBulkOverridesEmptyValueReturns400() {
+	status, body := suite.do(suite.adminClient, http.MethodPost, translationsURL(testLanguage),
+		setBulkBody(map[string]map[string]string{testNamespace: {"greeting": ""}}))
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("I18N-1005", suite.errorCode(body))
+}
+
+// TestSetBulkOverridesRejectsPayloadWithOneBadEntry asserts a single invalid entry rejects the whole
+// payload; no partial write survives.
+func (suite *I18nMgtAPITestSuite) TestSetBulkOverridesRejectsPayloadWithOneBadEntry() {
+	status, body := suite.do(suite.adminClient, http.MethodPost, translationsURL(testLanguage),
+		setBulkBody(map[string]map[string]string{
+			testNamespace: {"greeting": "Bonjour", "bad:key": "Salut"},
+		}))
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("I18N-1003", suite.errorCode(body))
+	suite.Equal(http.StatusNotFound, suite.resolveKeyStatus(testLanguage, testNamespace, "greeting"))
+}
+
+func (suite *I18nMgtAPITestSuite) TestSetBulkOverridesMalformedBodyReturns400() {
+	status, body := suite.do(suite.adminClient, http.MethodPost,
+		translationsURL(testLanguage), []byte(`{`))
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("I18N-1007", suite.errorCode(body))
+}
+
+func (suite *I18nMgtAPITestSuite) TestClearLanguageOverridesInvalidLanguageReturns400() {
+	status, body := suite.do(suite.adminClient, http.MethodDelete,
+		translationsURL("not_a_language"), nil)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("I18N-1001", suite.errorCode(body))
+}
+
+// --- Resolve branches ---
+
+func (suite *I18nMgtAPITestSuite) TestResolveKeyNotFoundReturns404() {
+	status, body := suite.do(suite.adminClient, http.MethodGet,
+		resolveKeyURL(testLanguage, testNamespace, "never-written"), nil)
+
+	suite.Equal(http.StatusNotFound, status)
+	suite.Equal("I18N-1006", suite.errorCode(body))
+}
+
+func (suite *I18nMgtAPITestSuite) TestResolveKeyInvalidNamespaceReturns400() {
+	status, body := suite.do(suite.adminClient, http.MethodGet,
+		resolveKeyURL(testLanguage, "bad.namespace", "greeting"), nil)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("I18N-1002", suite.errorCode(body))
+}
+
+func (suite *I18nMgtAPITestSuite) TestResolveLanguageInvalidNamespaceReturns400() {
+	status, body := suite.do(suite.adminClient, http.MethodGet,
+		resolveURL(testLanguage)+"?namespace=bad.namespace", nil)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("I18N-1002", suite.errorCode(body))
+}
+
+// TestResolveLanguageFallsBackToSystemLanguage asserts a language with no overrides still resolves the
+// system defaults rather than returning an empty document.
+func (suite *I18nMgtAPITestSuite) TestResolveLanguageFallsBackToSystemLanguage() {
+	resolved := suite.resolveLanguage(testLanguage, systemNamespace)
+
+	suite.Equal(testLanguage, resolved.Language)
+	suite.NotEmpty(resolved.Translations[systemNamespace])
+}
+
+// --- Auth gate: resolve is public, writes are not ---
+
+func (suite *I18nMgtAPITestSuite) TestResolveEndpointsArePublic() {
+	suite.setKeyOverride(testLanguage, testNamespace, "greeting", "Bonjour")
+
+	keyStatus, _ := suite.do(suite.plainClient, http.MethodGet,
+		resolveKeyURL(testLanguage, testNamespace, "greeting"), nil)
+	suite.Equal(http.StatusOK, keyStatus)
+
+	bulkStatus, _ := suite.do(suite.plainClient, http.MethodGet, resolveURL(testLanguage), nil)
+	suite.Equal(http.StatusOK, bulkStatus)
+}
+
+func (suite *I18nMgtAPITestSuite) TestWriteEndpointsRejectUnauthenticatedRequests() {
+	setKeyStatus, setKeyBodyResp := suite.do(suite.plainClient, http.MethodPost,
+		keyURL(testLanguage, testNamespace, "greeting"), setKeyBody("Bonjour"))
+	suite.Equal(http.StatusUnauthorized, setKeyStatus)
+	suite.Equal("AUTH-4010", suite.errorCode(setKeyBodyResp))
+
+	clearKeyStatus, _ := suite.do(suite.plainClient, http.MethodDelete,
+		keyURL(testLanguage, testNamespace, "greeting"), nil)
+	suite.Equal(http.StatusUnauthorized, clearKeyStatus)
+
+	setBulkStatus, _ := suite.do(suite.plainClient, http.MethodPost, translationsURL(testLanguage),
+		setBulkBody(map[string]map[string]string{testNamespace: {"greeting": "Bonjour"}}))
+	suite.Equal(http.StatusUnauthorized, setBulkStatus)
+
+	clearBulkStatus, _ := suite.do(suite.plainClient, http.MethodDelete,
+		translationsURL(testLanguage), nil)
+	suite.Equal(http.StatusUnauthorized, clearBulkStatus)
+
+	// The rejected writes left no trace.
+	suite.Equal(http.StatusNotFound, suite.resolveKeyStatus(testLanguage, testNamespace, "greeting"))
+}
+
+// --- helpers ---
+
+func translationsURL(language string) string {
+	return languagesURL + "/" + url.PathEscape(language) + "/translations"
+}
+
+func resolveURL(language string) string {
+	return translationsURL(language) + "/resolve"
+}
+
+func keyURL(language, namespace, key string) string {
+	return translationsURL(language) + "/ns/" + url.PathEscape(namespace) + "/keys/" + url.PathEscape(key)
+}
+
+func resolveKeyURL(language, namespace, key string) string {
+	return keyURL(language, namespace, key) + "/resolve"
+}
+
+func setKeyBody(value string) []byte {
+	body, err := json.Marshal(setTranslationRequest{Value: value})
+	if err != nil {
+		panic(err)
+	}
+	return body
+}
+
+func setBulkBody(translations map[string]map[string]string) []byte {
+	body, err := json.Marshal(setTranslationsRequest{Translations: translations})
+	if err != nil {
+		panic(err)
+	}
+	return body
+}
+
+// setKeyOverride writes a single override and requires a 200 response.
+func (suite *I18nMgtAPITestSuite) setKeyOverride(
+	language, namespace, key, value string,
+) translationResponse {
+	status, body := suite.do(suite.adminClient, http.MethodPost,
+		keyURL(language, namespace, key), setKeyBody(value))
+	suite.Require().Equal(http.StatusOK, status, "set override failed: %s", body)
+
+	var resp translationResponse
+	suite.Require().NoError(json.Unmarshal(body, &resp))
+	return resp
+}
+
+// setBulkOverrides replaces a language's overrides and requires a 200 response.
+func (suite *I18nMgtAPITestSuite) setBulkOverrides(
+	language string, translations map[string]map[string]string,
+) languageTranslationsResponse {
+	status, body := suite.do(suite.adminClient, http.MethodPost,
+		translationsURL(language), setBulkBody(translations))
+	suite.Require().Equal(http.StatusOK, status, "bulk set failed: %s", body)
+
+	var resp languageTranslationsResponse
+	suite.Require().NoError(json.Unmarshal(body, &resp))
+	return resp
+}
+
+// resolveKey resolves a single translation and requires a 200 response.
+func (suite *I18nMgtAPITestSuite) resolveKey(language, namespace, key string) translationResponse {
+	status, body := suite.do(suite.adminClient, http.MethodGet,
+		resolveKeyURL(language, namespace, key), nil)
+	suite.Require().Equal(http.StatusOK, status, "resolve failed: %s", body)
+
+	var resp translationResponse
+	suite.Require().NoError(json.Unmarshal(body, &resp))
+	return resp
+}
+
+// resolveKeyStatus returns only the status code of a single-key resolve, for absence assertions.
+func (suite *I18nMgtAPITestSuite) resolveKeyStatus(language, namespace, key string) int {
+	status, _ := suite.do(suite.adminClient, http.MethodGet,
+		resolveKeyURL(language, namespace, key), nil)
+	return status
+}
+
+// resolveLanguage resolves all translations for a language, optionally filtered by namespace.
+func (suite *I18nMgtAPITestSuite) resolveLanguage(
+	language, namespace string,
+) languageTranslationsResponse {
+	target := resolveURL(language)
+	if namespace != "" {
+		target += "?namespace=" + url.QueryEscape(namespace)
+	}
+
+	status, body := suite.do(suite.adminClient, http.MethodGet, target, nil)
+	suite.Require().Equal(http.StatusOK, status, "resolve language failed: %s", body)
+
+	var resp languageTranslationsResponse
+	suite.Require().NoError(json.Unmarshal(body, &resp))
+	return resp
+}
+
+func (suite *I18nMgtAPITestSuite) listLanguages() []string {
+	status, body := suite.do(suite.adminClient, http.MethodGet, languagesURL, nil)
+	suite.Require().Equal(http.StatusOK, status)
+
+	var resp languageListResponse
+	suite.Require().NoError(json.Unmarshal(body, &resp))
+	return resp.Languages
+}
+
+// clearLanguage removes every override for a language and requires a 204 response.
+func (suite *I18nMgtAPITestSuite) clearLanguage(language string) {
+	status, body := suite.do(suite.adminClient, http.MethodDelete, translationsURL(language), nil)
+	suite.Require().Equal(http.StatusNoContent, status, "clear language failed: %s", body)
+}
+
+// clearNamespaceKey removes a single override and requires a 204 response.
+func (suite *I18nMgtAPITestSuite) clearNamespaceKey(language, namespace, key string) {
+	status, body := suite.do(suite.adminClient, http.MethodDelete,
+		keyURL(language, namespace, key), nil)
+	suite.Require().Equal(http.StatusNoContent, status, "clear key failed: %s", body)
+}
+
+// anySystemDefaultKey returns a key that the system namespace resolves a compiled-in default for, so
+// the override-shadows-default test does not hard-code a key that may be renamed.
+func (suite *I18nMgtAPITestSuite) anySystemDefaultKey() string {
+	resolved := suite.resolveLanguage(systemLanguage, systemNamespace)
+	defaults := resolved.Translations[systemNamespace]
+	suite.Require().NotEmpty(defaults, "expected system namespace to carry default translations")
+
+	// Map iteration order is random; sort for a deterministic pick.
+	keys := make([]string, 0, len(defaults))
+	for key := range defaults {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys[0]
+}
+
+// do issues a request and returns the status code and response body.
+func (suite *I18nMgtAPITestSuite) do(
+	client *http.Client, method, target string, body []byte,
+) (int, []byte) {
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequest(method, target, reader)
+	suite.Require().NoError(err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer closeBodyQuietly(suite.T(), resp.Body)
+
+	respBody, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+	return resp.StatusCode, respBody
+}
+
+// errorCode decodes the error code from an API error response body.
+func (suite *I18nMgtAPITestSuite) errorCode(body []byte) string {
+	var errResp apiErrorResponse
+	suite.Require().NoError(json.Unmarshal(body, &errResp), "body: %s", body)
+	return errResp.Code
+}
+
+func closeBodyQuietly(t *testing.T, body io.ReadCloser) {
+	if body != nil {
+		if err := body.Close(); err != nil {
+			t.Logf("Failed to close response body: %v", err)
+		}
+	}
+}

--- a/tests/integration/i18n/model.go
+++ b/tests/integration/i18n/model.go
@@ -1,0 +1,68 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package i18n
+
+import "github.com/thunder-id/thunderid/tests/integration/testutils"
+
+const (
+	testServerURL = testutils.TestServerURL
+	languagesURL  = testServerURL + "/i18n/languages"
+
+	// systemLanguage / systemNamespace mirror the server defaults
+	// (backend/internal/system/i18n/mgt/constants.go).
+	systemLanguage  = "en-US"
+	systemNamespace = "system"
+
+	// testLanguage is the language the management tests write to. It is deliberately not the system
+	// language so clearing it never removes system defaults other suites resolve against.
+	testLanguage = "fr-CA"
+
+	// testNamespace is the namespace owned by this suite; TearDown clears it.
+	testNamespace = "integration-i18n"
+)
+
+// i18nMessage mirrors the i18n message structure returned in API error responses.
+type i18nMessage struct {
+	Key          string `json:"key"`
+	DefaultValue string `json:"defaultValue"`
+}
+
+// apiErrorResponse mirrors apierror.ErrorResponse for decoding error responses.
+type apiErrorResponse struct {
+	Code        string      `json:"code"`
+	Message     i18nMessage `json:"message"`
+	Description i18nMessage `json:"description"`
+}
+
+// languageListResponse mirrors mgt.LanguageListResponse.
+type languageListResponse struct {
+	Languages []string `json:"languages"`
+}
+
+// translationResponse mirrors mgt.TranslationResponse, the single-translation payload returned by the
+// resolve and set-override endpoints.
+type translationResponse struct {
+	Language  string `json:"language"`
+	Namespace string `json:"namespace"`
+	Key       string `json:"key"`
+	Value     string `json:"value"`
+}
+
+// setTranslationRequest mirrors mgt.SetTranslationRequest.
+type setTranslationRequest struct {
+	Value string `json:"value"`
+}
+
+// setTranslationsRequest mirrors mgt.SetTranslationsRequest; translations is namespace -> key -> value.
+type setTranslationsRequest struct {
+	Translations map[string]map[string]string `json:"translations"`
+}
+
+// languageTranslationsResponse mirrors providers.LanguageTranslationsResponse, the bulk payload
+// returned by the bulk resolve and bulk set endpoints.
+type languageTranslationsResponse struct {
+	Language     string                       `json:"language"`
+	TotalResults int                          `json:"totalResults"`
+	Translations map[string]map[string]string `json:"translations"`
+}

--- a/tests/integration/importexport/import_export_error_test.go
+++ b/tests/integration/importexport/import_export_error_test.go
@@ -1,0 +1,436 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package importexport
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// ImportExportErrorSuite covers the request-level failure branches of /import, /import/delete and
+// /export. The round-trip suites in this package only ever assert success, so every IMP-*/EXP-*
+// code, the per-document failure outcome, and the continueOnError early-break are exercised here.
+type ImportExportErrorSuite struct {
+	suite.Suite
+	client      *http.Client
+	plainClient *http.Client
+}
+
+func TestImportExportErrorSuite(t *testing.T) {
+	suite.Run(t, new(ImportExportErrorSuite))
+}
+
+func (suite *ImportExportErrorSuite) SetupSuite() {
+	suite.client = testutils.GetHTTPClient()
+	suite.plainClient = &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+}
+
+// --- POST /import request validation ---
+
+func (suite *ImportExportErrorSuite) TestImportEmptyContentReturns400() {
+	status, body := suite.postJSON(suite.client, "/import", `{"content":""}`)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("IMP-1001", suite.errorCode(body))
+}
+
+func (suite *ImportExportErrorSuite) TestImportMissingContentFieldReturns400() {
+	status, body := suite.postJSON(suite.client, "/import", `{}`)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("IMP-1001", suite.errorCode(body))
+}
+
+func (suite *ImportExportErrorSuite) TestImportMalformedBodyReturns400() {
+	status, body := suite.postJSON(suite.client, "/import", `{`)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("IMP-1001", suite.errorCode(body))
+}
+
+// TestImportFileTargetReturns400 pins that the file target is rejected; only the runtime target is
+// supported through the API.
+func (suite *ImportExportErrorSuite) TestImportFileTargetReturns400() {
+	payload := suite.importBody(importRequest{
+		Content: "resource_type: organization_unit\nname: Target Test\nhandle: target-test\n",
+		Options: importOptions{Upsert: true, ContinueOnError: true, Target: "file"},
+	})
+
+	status, body := suite.postJSON(suite.client, "/import", payload)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("IMP-1001", suite.errorCode(body))
+}
+
+func (suite *ImportExportErrorSuite) TestImportInvalidYAMLReturns400() {
+	payload := suite.importBody(importRequest{
+		Content: "resource_type: organization_unit\n  name: badly indented\n\tmore: bad\n",
+		Options: runtimeOptions(),
+	})
+
+	status, body := suite.postJSON(suite.client, "/import", payload)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("IMP-1002", suite.errorCode(body))
+}
+
+// TestImportNonMappingRootReturns400 covers the parser's "root must be a YAML mapping" branch.
+func (suite *ImportExportErrorSuite) TestImportNonMappingRootReturns400() {
+	payload := suite.importBody(importRequest{
+		Content: "- just\n- a\n- sequence\n",
+		Options: runtimeOptions(),
+	})
+
+	status, body := suite.postJSON(suite.client, "/import", payload)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("IMP-1002", suite.errorCode(body))
+}
+
+// TestImportUnknownResourceTypeReturns400 covers the parser's unresolvable-resource-type branch.
+// An unknown type fails the whole request rather than producing a per-document failure.
+func (suite *ImportExportErrorSuite) TestImportUnknownResourceTypeReturns400() {
+	payload := suite.importBody(importRequest{
+		Content: "resource_type: not_a_real_type\nname: Nope\n",
+		Options: runtimeOptions(),
+	})
+
+	status, body := suite.postJSON(suite.client, "/import", payload)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("IMP-1002", suite.errorCode(body))
+}
+
+func (suite *ImportExportErrorSuite) TestImportMissingResourceTypeFieldReturns400() {
+	payload := suite.importBody(importRequest{
+		Content: "name: No Resource Type\nhandle: no-resource-type\n",
+		Options: runtimeOptions(),
+	})
+
+	status, body := suite.postJSON(suite.client, "/import", payload)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("IMP-1002", suite.errorCode(body))
+}
+
+// TestImportUnresolvedTemplateVariableReturns400 pins missingkey=error: a placeholder with no
+// matching variable is a hard failure, not an empty substitution.
+func (suite *ImportExportErrorSuite) TestImportUnresolvedTemplateVariableReturns400() {
+	payload := suite.importBody(importRequest{
+		Content: "resource_type: organization_unit\nname: {{.MISSING_VAR}}\nhandle: missing-var\n",
+		Options: runtimeOptions(),
+	})
+
+	status, body := suite.postJSON(suite.client, "/import", payload)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("IMP-1003", suite.errorCode(body))
+}
+
+func (suite *ImportExportErrorSuite) TestImportMalformedTemplateReturns400() {
+	payload := suite.importBody(importRequest{
+		Content: "resource_type: organization_unit\nname: {{ .Unclosed \nhandle: unclosed\n",
+		Options: runtimeOptions(),
+	})
+
+	status, body := suite.postJSON(suite.client, "/import", payload)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("IMP-1003", suite.errorCode(body))
+}
+
+// TestImportEmptyDocumentsSucceedsWithZeroCount asserts content that carries no YAML documents
+// (comments and blank lines only) parses to zero documents and reports an empty, successful import
+// rather than an error. Content that is literally empty is rejected earlier, by the content check.
+func (suite *ImportExportErrorSuite) TestImportEmptyDocumentsSucceedsWithZeroCount() {
+	payload := suite.importBody(importRequest{
+		Content: "# no documents here\n\n",
+		Options: runtimeOptions(),
+	})
+
+	status, body := suite.postJSON(suite.client, "/import", payload)
+	suite.Require().Equal(http.StatusOK, status, "body: %s", body)
+
+	var resp importResponse
+	suite.Require().NoError(json.Unmarshal(body, &resp))
+	suite.Equal(0, resp.Summary.TotalDocuments)
+	suite.Equal(0, resp.Summary.Imported)
+	suite.Equal(0, resp.Summary.Failed)
+	suite.Empty(resp.Results)
+}
+
+// --- Per-document failure outcomes ---
+
+// TestImportInvalidDocumentReportsFailedOutcome asserts a document that parses but fails domain
+// validation yields a 200 with a per-item failed outcome carrying a code, not a request-level error.
+func (suite *ImportExportErrorSuite) TestImportInvalidDocumentReportsFailedOutcome() {
+	// An OU document with no name/handle passes the parser and fails in the OU service.
+	payload := suite.importBody(importRequest{
+		Content: "resource_type: organization_unit\ndescription: missing name and handle\n",
+		Options: runtimeOptions(),
+	})
+
+	status, body := suite.postJSON(suite.client, "/import", payload)
+	suite.Require().Equal(http.StatusOK, status, "body: %s", body)
+
+	var resp importResponse
+	suite.Require().NoError(json.Unmarshal(body, &resp))
+	suite.Equal(1, resp.Summary.TotalDocuments)
+	suite.Equal(0, resp.Summary.Imported)
+	suite.Equal(1, resp.Summary.Failed)
+	suite.Require().Len(resp.Results, 1)
+	suite.Equal("failed", resp.Results[0].Status)
+	suite.Equal("organization_unit", resp.Results[0].ResourceType)
+	suite.NotEmpty(resp.Results[0].Code, "a failed outcome must carry an error code")
+}
+
+// TestImportContinueOnErrorFalseStopsAtFirstFailure asserts the early break: with continueOnError
+// disabled, documents after the first failure are never attempted, so len(results) is short of
+// totalDocuments.
+func (suite *ImportExportErrorSuite) TestImportContinueOnErrorFalseStopsAtFirstFailure() {
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	// The invalid OU sorts first (same resource type, original order preserved), so the valid one
+	// that follows must never be attempted.
+	content := "resource_type: organization_unit\ndescription: missing name and handle\n" +
+		"---\n" +
+		fmt.Sprintf("resource_type: organization_unit\nname: Should Not Import %s\nhandle: should-not-import-%s\n",
+			suffix, suffix)
+
+	payload := suite.importBody(importRequest{
+		Content: content,
+		Options: importOptions{Upsert: true, ContinueOnError: false, Target: "runtime"},
+	})
+
+	status, body := suite.postJSON(suite.client, "/import", payload)
+	suite.Require().Equal(http.StatusOK, status, "body: %s", body)
+
+	var resp importResponse
+	suite.Require().NoError(json.Unmarshal(body, &resp))
+	suite.Equal(2, resp.Summary.TotalDocuments)
+	suite.Equal(1, resp.Summary.Failed)
+	suite.Equal(0, resp.Summary.Imported)
+	suite.Len(resp.Results, 1, "processing must stop after the first failure")
+}
+
+// TestImportContinueOnErrorTrueProcessesRemaining is the counterpart: the same payload with
+// continueOnError enabled imports the valid document despite the earlier failure.
+func (suite *ImportExportErrorSuite) TestImportContinueOnErrorTrueProcessesRemaining() {
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	handle := "continue-on-error-" + suffix
+	content := "resource_type: organization_unit\ndescription: missing name and handle\n" +
+		"---\n" +
+		fmt.Sprintf("resource_type: organization_unit\nname: Continue On Error %s\nhandle: %s\n", suffix, handle)
+
+	payload := suite.importBody(importRequest{
+		Content: content,
+		Options: runtimeOptions(),
+	})
+
+	status, body := suite.postJSON(suite.client, "/import", payload)
+	suite.Require().Equal(http.StatusOK, status, "body: %s", body)
+
+	var resp importResponse
+	suite.Require().NoError(json.Unmarshal(body, &resp))
+	suite.Equal(2, resp.Summary.TotalDocuments)
+	suite.Equal(1, resp.Summary.Failed)
+	suite.Equal(1, resp.Summary.Imported)
+	suite.Len(resp.Results, 2)
+
+	suite.deleteImportedOU(&resp)
+}
+
+// TestImportDryRunDoesNotPersist asserts a dry run reports success without creating the resource.
+func (suite *ImportExportErrorSuite) TestImportDryRunDoesNotPersist() {
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	handle := "dry-run-ou-" + suffix
+
+	payload := suite.importBody(importRequest{
+		Content: fmt.Sprintf("resource_type: organization_unit\nname: Dry Run OU %s\nhandle: %s\n", suffix, handle),
+		DryRun:  true,
+		Options: runtimeOptions(),
+	})
+
+	status, body := suite.postJSON(suite.client, "/import", payload)
+	suite.Require().Equal(http.StatusOK, status, "body: %s", body)
+
+	var resp importResponse
+	suite.Require().NoError(json.Unmarshal(body, &resp))
+	suite.Equal(1, resp.Summary.Imported)
+	suite.Equal(0, resp.Summary.Failed)
+
+	// Nothing was written, so a real import of the same handle still creates it.
+	confirmPayload := suite.importBody(importRequest{
+		Content: fmt.Sprintf("resource_type: organization_unit\nname: Dry Run OU %s\nhandle: %s\n", suffix, handle),
+		Options: runtimeOptions(),
+	})
+	confirmStatus, confirmBody := suite.postJSON(suite.client, "/import", confirmPayload)
+	suite.Require().Equal(http.StatusOK, confirmStatus, "body: %s", confirmBody)
+
+	var confirmResp importResponse
+	suite.Require().NoError(json.Unmarshal(confirmBody, &confirmResp))
+	suite.Require().Len(confirmResp.Results, 1)
+	suite.Equal("success", confirmResp.Results[0].Status)
+	suite.Equal("create", confirmResp.Results[0].Operation,
+		"the dry run must not have persisted the OU, so this is still a create")
+
+	suite.deleteImportedOU(&confirmResp)
+}
+
+// --- POST /import/delete ---
+
+func (suite *ImportExportErrorSuite) TestImportDeleteMissingFieldsReturns400() {
+	for _, body := range []string{
+		`{}`,
+		`{"resourceType":"application"}`,
+		`{"resourceKey":"some-key"}`,
+	} {
+		status, respBody := suite.postJSON(suite.client, "/import/delete", body)
+
+		suite.Equal(http.StatusBadRequest, status, "payload: %s", body)
+		suite.Equal("IMP-1001", suite.errorCode(respBody), "payload: %s", body)
+	}
+}
+
+func (suite *ImportExportErrorSuite) TestImportDeleteMalformedBodyReturns400() {
+	status, body := suite.postJSON(suite.client, "/import/delete", `{`)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("IMP-1001", suite.errorCode(body))
+}
+
+// TestImportDeleteUnsupportedResourceTypeReturns400 pins that only file-backed resource types can
+// be deleted; group is importable but has no declarative directory mapping.
+func (suite *ImportExportErrorSuite) TestImportDeleteUnsupportedResourceTypeReturns400() {
+	status, body := suite.postJSON(suite.client, "/import/delete",
+		`{"resourceType":"group","resourceKey":"some-group"}`)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("IMP-1001", suite.errorCode(body))
+}
+
+func (suite *ImportExportErrorSuite) TestImportDeleteUnknownResourceTypeReturns400() {
+	status, body := suite.postJSON(suite.client, "/import/delete",
+		`{"resourceType":"not_a_real_type","resourceKey":"whatever"}`)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("IMP-1001", suite.errorCode(body))
+}
+
+// TestImportDeleteUnknownKeyReturns400 covers the no-matching-file branch for a supported resource
+// type (the directory may or may not exist; both branches answer IMP-1001).
+func (suite *ImportExportErrorSuite) TestImportDeleteUnknownKeyReturns400() {
+	status, body := suite.postJSON(suite.client, "/import/delete",
+		`{"resourceType":"application","resourceKey":"definitely-not-a-real-application-key"}`)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("IMP-1001", suite.errorCode(body))
+}
+
+func (suite *ImportExportErrorSuite) TestImportDeleteBlankKeyReturns400() {
+	status, body := suite.postJSON(suite.client, "/import/delete",
+		`{"resourceType":"application","resourceKey":"   "}`)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("IMP-1001", suite.errorCode(body))
+}
+
+// --- POST /export ---
+
+func (suite *ImportExportErrorSuite) TestExportMalformedBodyReturns400() {
+	status, body := suite.postJSON(suite.client, "/export", `{`)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("EXP-1001", suite.errorCode(body))
+}
+
+// TestExportUnknownIDReturnsError asserts an export naming only a non-existent resource does not
+// silently return an empty document.
+func (suite *ImportExportErrorSuite) TestExportUnknownIDReturnsError() {
+	status, body := suite.postJSON(suite.client, "/export",
+		`{"applications":["00000000-0000-0000-0000-000000000000"]}`)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("EXP-1002", suite.errorCode(body))
+}
+
+// --- Auth gate ---
+
+// TestImportEndpointsRequireAuth asserts both import routes reject unauthenticated callers. They
+// are gated on the root permission, so an anonymous request must never reach the service.
+func (suite *ImportExportErrorSuite) TestImportEndpointsRequireAuth() {
+	importStatus, _ := suite.postJSON(suite.plainClient, "/import", `{"content":""}`)
+	suite.Equal(http.StatusUnauthorized, importStatus)
+
+	deleteStatus, _ := suite.postJSON(suite.plainClient, "/import/delete",
+		`{"resourceType":"application","resourceKey":"anything"}`)
+	suite.Equal(http.StatusUnauthorized, deleteStatus)
+}
+
+// --- helpers ---
+
+// runtimeOptions returns the default runtime-target options with upsert and continueOnError on.
+func runtimeOptions() importOptions {
+	return importOptions{Upsert: true, ContinueOnError: true, Target: "runtime"}
+}
+
+// importBody marshals an import request to a JSON string.
+func (suite *ImportExportErrorSuite) importBody(req importRequest) string {
+	payload, err := json.Marshal(req)
+	suite.Require().NoError(err)
+	return string(payload)
+}
+
+// deleteImportedOU removes any OU created by an import so the shared server is not left mutated.
+func (suite *ImportExportErrorSuite) deleteImportedOU(resp *importResponse) {
+	for _, result := range resp.Results {
+		if result.Status != "success" || result.ResourceType != "organization_unit" || result.ResourceID == "" {
+			continue
+		}
+		if err := testutils.DeleteOrganizationUnit(result.ResourceID); err != nil {
+			suite.T().Logf("Failed to delete imported OU %s: %v", result.ResourceID, err)
+		}
+	}
+}
+
+// postJSON POSTs a JSON body to a path and returns the status and response body.
+func (suite *ImportExportErrorSuite) postJSON(client *http.Client, path, body string) (int, []byte) {
+	req, err := http.NewRequest(http.MethodPost, testutils.TestServerURL+path, bytes.NewReader([]byte(body)))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			suite.T().Logf("Failed to close response body: %v", closeErr)
+		}
+	}()
+
+	respBody, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+	return resp.StatusCode, respBody
+}
+
+// errorCode decodes the error code from an API error response body.
+func (suite *ImportExportErrorSuite) errorCode(body []byte) string {
+	var errResp struct {
+		Code string `json:"code"`
+	}
+	suite.Require().NoError(json.Unmarshal(body, &errResp), "body: %s", body)
+	return errResp.Code
+}

--- a/tests/integration/inboundclient/inbound_client_api_test.go
+++ b/tests/integration/inboundclient/inbound_client_api_test.go
@@ -1,0 +1,443 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package inboundclient covers the inbound-client validation layer. That package registers no HTTP
+// routes of its own, so every branch here is driven through the application API, which is the
+// surface that owns an inbound client's lifecycle.
+package inboundclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const applicationsPath = "/applications"
+
+// InboundClientValidationSuite covers the foreign-key and user-attribute validation the inbound
+// client applies when an application is created or updated: theme/layout references, allowed user
+// types, subject attribute mapping, and the deliberate create-rejects / update-strips divergence
+// for undeclared user attributes.
+type InboundClientValidationSuite struct {
+	suite.Suite
+	client *http.Client
+	ouID   string
+	// userTypeName / userTypeID identify a user type declaring only the attributes below, so an
+	// attribute outside this set is provably undeclared.
+	userTypeName string
+	userTypeID   string
+	themeID      string
+	layoutID     string
+}
+
+func TestInboundClientValidationSuite(t *testing.T) {
+	suite.Run(t, new(InboundClientValidationSuite))
+}
+
+func (suite *InboundClientValidationSuite) SetupSuite() {
+	suite.client = testutils.GetHTTPClient()
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Name:        "Inbound Client Test OU " + suffix,
+		Handle:      "inbound-client-test-ou-" + suffix,
+		Description: "OU for inbound client validation tests",
+	})
+	suite.Require().NoError(err, "Failed to create OU")
+	suite.ouID = ouID
+
+	suite.userTypeName = "inboundclient" + suffix
+	userTypeID, err := testutils.CreateUserType(testutils.UserType{
+		Name: suite.userTypeName,
+		OUID: suite.ouID,
+		Schema: map[string]interface{}{
+			"email": map[string]interface{}{
+				"type":     "string",
+				"unique":   true,
+				"required": true,
+			},
+			"username": map[string]interface{}{
+				"type": "string",
+			},
+		},
+	})
+	suite.Require().NoError(err, "Failed to create user type")
+	suite.userTypeID = userTypeID
+
+	suite.themeID = suite.createDesignResource("/design/themes", map[string]interface{}{
+		"handle":      "inbound-client-theme-" + suffix,
+		"displayName": "Inbound Client Theme",
+		"theme":       map[string]interface{}{"direction": "ltr"},
+	})
+	suite.layoutID = suite.createDesignResource("/design/layouts", map[string]interface{}{
+		"handle":      "inbound-client-layout-" + suffix,
+		"displayName": "Inbound Client Layout",
+		"layout":      map[string]interface{}{"type": "centered"},
+	})
+}
+
+func (suite *InboundClientValidationSuite) TearDownSuite() {
+	suite.deleteDesignResource("/design/themes", suite.themeID)
+	suite.deleteDesignResource("/design/layouts", suite.layoutID)
+
+	if suite.userTypeID != "" {
+		if err := testutils.DeleteUserType(suite.userTypeID); err != nil {
+			suite.T().Logf("Failed to delete user type %s: %v", suite.userTypeID, err)
+		}
+	}
+	if suite.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(suite.ouID); err != nil {
+			suite.T().Logf("Failed to delete OU %s: %v", suite.ouID, err)
+		}
+	}
+}
+
+// --- Theme / layout foreign keys ---
+
+func (suite *InboundClientValidationSuite) TestCreateWithUnknownLayoutIsRejected() {
+	status, body := suite.createApplication(map[string]interface{}{
+		"name":     suite.appName("unknown-layout"),
+		"layoutId": "00000000-0000-0000-0000-000000000000",
+	})
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("APP-1027", suite.errorCode(body))
+}
+
+func (suite *InboundClientValidationSuite) TestCreateWithValidThemeAndLayoutSucceeds() {
+	status, body := suite.createApplication(map[string]interface{}{
+		"name":     suite.appName("valid-design"),
+		"themeId":  suite.themeID,
+		"layoutId": suite.layoutID,
+	})
+	suite.Require().Equal(http.StatusCreated, status, "body: %s", body)
+
+	appID := suite.idOf(body)
+	defer suite.deleteApplication(appID)
+
+	fetched := suite.getApplication(appID)
+	suite.Equal(suite.themeID, fetched["themeId"])
+	suite.Equal(suite.layoutID, fetched["layoutId"])
+}
+
+// TestUpdateToUnknownLayoutIsRejected asserts the FK check runs on update, not only on create.
+func (suite *InboundClientValidationSuite) TestUpdateToUnknownLayoutIsRejected() {
+	status, body := suite.createApplication(map[string]interface{}{
+		"name":     suite.appName("update-unknown-layout"),
+		"layoutId": suite.layoutID,
+	})
+	suite.Require().Equal(http.StatusCreated, status, "body: %s", body)
+
+	appID := suite.idOf(body)
+	defer suite.deleteApplication(appID)
+
+	updateStatus, updateBody := suite.updateApplication(appID, map[string]interface{}{
+		"name":     suite.appName("update-unknown-layout"),
+		"layoutId": "00000000-0000-0000-0000-000000000000",
+	})
+
+	suite.Equal(http.StatusBadRequest, updateStatus)
+	suite.Equal("APP-1027", suite.errorCode(updateBody))
+}
+
+// TestDeletingReferencedLayoutThenUpdatingIsRejected pins that a dangling reference cannot be
+// re-saved: layouts may be deleted while referenced, but a later update revalidates the FK.
+func (suite *InboundClientValidationSuite) TestDeletingReferencedLayoutThenUpdatingIsRejected() {
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	throwawayLayoutID := suite.createDesignResource("/design/layouts", map[string]interface{}{
+		"handle":      "inbound-client-throwaway-" + suffix,
+		"displayName": "Throwaway Layout",
+		"layout":      map[string]interface{}{"type": "centered"},
+	})
+
+	status, body := suite.createApplication(map[string]interface{}{
+		"name":     suite.appName("dangling-layout"),
+		"layoutId": throwawayLayoutID,
+	})
+	suite.Require().Equal(http.StatusCreated, status, "body: %s", body)
+
+	appID := suite.idOf(body)
+	defer suite.deleteApplication(appID)
+
+	suite.deleteDesignResource("/design/layouts", throwawayLayoutID)
+
+	updateStatus, updateBody := suite.updateApplication(appID, map[string]interface{}{
+		"name":     suite.appName("dangling-layout"),
+		"layoutId": throwawayLayoutID,
+	})
+
+	suite.Equal(http.StatusBadRequest, updateStatus)
+	suite.Equal("APP-1027", suite.errorCode(updateBody))
+}
+
+// Allowed user type validation (APP-1025) is covered by the application suite, on create, on
+// update, and for a mixed valid/invalid list; it is deliberately not repeated here.
+
+// --- User attributes: create rejects, update strips ---
+
+// TestCreateWithUndeclaredUserAttributeIsRejected pins the create-side behaviour: an assertion
+// attribute no allowed user type declares fails the request.
+func (suite *InboundClientValidationSuite) TestCreateWithUndeclaredUserAttributeIsRejected() {
+	status, body := suite.createApplication(map[string]interface{}{
+		"name":             suite.appName("undeclared-attr-create"),
+		"allowedUserTypes": []string{suite.userTypeName},
+		"assertion": map[string]interface{}{
+			"userAttributes": []string{"email", "not_a_declared_attribute"},
+		},
+	})
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("APP-1035", suite.errorCode(body))
+}
+
+// TestUpdateWithUndeclaredUserAttributeStripsIt is the deliberate divergence from create: an
+// update silently drops undeclared attributes instead of rejecting the request.
+func (suite *InboundClientValidationSuite) TestUpdateWithUndeclaredUserAttributeStripsIt() {
+	name := suite.appName("undeclared-attr-update")
+	status, body := suite.createApplication(map[string]interface{}{
+		"name":             name,
+		"allowedUserTypes": []string{suite.userTypeName},
+		"assertion": map[string]interface{}{
+			"userAttributes": []string{"email"},
+		},
+	})
+	suite.Require().Equal(http.StatusCreated, status, "body: %s", body)
+
+	appID := suite.idOf(body)
+	defer suite.deleteApplication(appID)
+
+	updateStatus, updateBody := suite.updateApplication(appID, map[string]interface{}{
+		"name":             name,
+		"allowedUserTypes": []string{suite.userTypeName},
+		"assertion": map[string]interface{}{
+			"userAttributes": []string{"email", "not_a_declared_attribute"},
+		},
+	})
+	suite.Require().Equal(http.StatusOK, updateStatus, "body: %s", updateBody)
+
+	fetched := suite.getApplication(appID)
+	attrs := suite.assertionUserAttributes(fetched)
+	suite.Contains(attrs, "email")
+	suite.NotContains(attrs, "not_a_declared_attribute",
+		"an update must strip undeclared attributes rather than persist them")
+}
+
+// TestCreateWithDeclaredUserAttributesSucceeds is the control for the two tests above.
+func (suite *InboundClientValidationSuite) TestCreateWithDeclaredUserAttributesSucceeds() {
+	status, body := suite.createApplication(map[string]interface{}{
+		"name":             suite.appName("declared-attrs"),
+		"allowedUserTypes": []string{suite.userTypeName},
+		"assertion": map[string]interface{}{
+			"userAttributes": []string{"email", "username"},
+		},
+	})
+	suite.Require().Equal(http.StatusCreated, status, "body: %s", body)
+
+	appID := suite.idOf(body)
+	defer suite.deleteApplication(appID)
+
+	attrs := suite.assertionUserAttributes(suite.getApplication(appID))
+	suite.Contains(attrs, "email")
+	suite.Contains(attrs, "username")
+}
+
+// --- Subject attribute mapping ---
+
+// TestCreateWithUnknownSubjectAttributeIsRejected covers a mapping naming an attribute the user
+// type does not declare.
+func (suite *InboundClientValidationSuite) TestCreateWithUnknownSubjectAttributeIsRejected() {
+	status, body := suite.createApplication(map[string]interface{}{
+		"name":             suite.appName("unknown-subject-attr"),
+		"allowedUserTypes": []string{suite.userTypeName},
+		"subjectAttribute": map[string]string{suite.userTypeName: "not_a_declared_attribute"},
+	})
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("APP-1045", suite.errorCode(body))
+}
+
+// TestCreateWithNonUniqueSubjectAttributeIsRejected covers the uniqueness requirement: "username"
+// is declared but is not a unique+required attribute, so it cannot identify a subject.
+func (suite *InboundClientValidationSuite) TestCreateWithNonUniqueSubjectAttributeIsRejected() {
+	status, body := suite.createApplication(map[string]interface{}{
+		"name":             suite.appName("non-unique-subject-attr"),
+		"allowedUserTypes": []string{suite.userTypeName},
+		"subjectAttribute": map[string]string{suite.userTypeName: "username"},
+	})
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("APP-1045", suite.errorCode(body))
+}
+
+// TestCreateWithMappingForUnallowedTypeIsRejected covers a mapping keyed by a user type that is
+// not in allowedUserTypes.
+func (suite *InboundClientValidationSuite) TestCreateWithMappingForUnallowedTypeIsRejected() {
+	status, body := suite.createApplication(map[string]interface{}{
+		"name":             suite.appName("unallowed-subject-type"),
+		"allowedUserTypes": []string{suite.userTypeName},
+		"subjectAttribute": map[string]string{"some-other-type": "email"},
+	})
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("APP-1045", suite.errorCode(body))
+}
+
+// TestCreateWithValidSubjectAttributeSucceeds is the control: "email" is unique and required.
+func (suite *InboundClientValidationSuite) TestCreateWithValidSubjectAttributeSucceeds() {
+	status, body := suite.createApplication(map[string]interface{}{
+		"name":             suite.appName("valid-subject-attr"),
+		"allowedUserTypes": []string{suite.userTypeName},
+		"subjectAttribute": map[string]string{suite.userTypeName: "email"},
+	})
+	suite.Require().Equal(http.StatusCreated, status, "body: %s", body)
+
+	suite.deleteApplication(suite.idOf(body))
+}
+
+// --- helpers ---
+
+// appName builds a name unique to this suite run so parallel packages do not collide.
+func (suite *InboundClientValidationSuite) appName(label string) string {
+	return fmt.Sprintf("Inbound Client %s %d", label, time.Now().UnixNano())
+}
+
+func (suite *InboundClientValidationSuite) createApplication(body map[string]interface{}) (int, []byte) {
+	return suite.do(http.MethodPost, testutils.TestServerURL+applicationsPath, suite.withRequiredFields(body))
+}
+
+func (suite *InboundClientValidationSuite) updateApplication(
+	id string, body map[string]interface{},
+) (int, []byte) {
+	return suite.do(http.MethodPut, testutils.TestServerURL+applicationsPath+"/"+id,
+		suite.withRequiredFields(body))
+}
+
+// withRequiredFields fills in ouId and type, which the application API requires on every request,
+// so each test body only carries the fields whose validation it exercises.
+func (suite *InboundClientValidationSuite) withRequiredFields(
+	body map[string]interface{},
+) map[string]interface{} {
+	if _, ok := body["ouId"]; !ok {
+		body["ouId"] = suite.ouID
+	}
+	if _, ok := body["type"]; !ok {
+		body["type"] = "fullstack"
+	}
+	return body
+}
+
+func (suite *InboundClientValidationSuite) getApplication(id string) map[string]interface{} {
+	status, body := suite.do(http.MethodGet, testutils.TestServerURL+applicationsPath+"/"+id, nil)
+	suite.Require().Equal(http.StatusOK, status, "get application failed: %s", body)
+
+	var app map[string]interface{}
+	suite.Require().NoError(json.Unmarshal(body, &app))
+	return app
+}
+
+func (suite *InboundClientValidationSuite) deleteApplication(id string) {
+	if id == "" {
+		return
+	}
+	if err := testutils.DeleteApplication(id); err != nil {
+		suite.T().Logf("Failed to delete application %s: %v", id, err)
+	}
+}
+
+// assertionUserAttributes reads assertion.userAttributes off an application response.
+func (suite *InboundClientValidationSuite) assertionUserAttributes(app map[string]interface{}) []string {
+	assertion, ok := app["assertion"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	raw, ok := assertion["userAttributes"].([]interface{})
+	if !ok {
+		return nil
+	}
+
+	attrs := make([]string, 0, len(raw))
+	for _, item := range raw {
+		if str, ok := item.(string); ok {
+			attrs = append(attrs, str)
+		}
+	}
+	return attrs
+}
+
+// createDesignResource creates a theme or layout and returns its ID.
+func (suite *InboundClientValidationSuite) createDesignResource(
+	basePath string, body map[string]interface{},
+) string {
+	status, respBody := suite.do(http.MethodPost, testutils.TestServerURL+basePath, body)
+	suite.Require().Equal(http.StatusCreated, status, "create %s failed: %s", basePath, respBody)
+	return suite.idOf(respBody)
+}
+
+// deleteDesignResource removes a theme or layout, tolerating an already-deleted resource.
+func (suite *InboundClientValidationSuite) deleteDesignResource(basePath, id string) {
+	if id == "" {
+		return
+	}
+
+	status, body := suite.do(http.MethodDelete, testutils.TestServerURL+basePath+"/"+id, nil)
+	if status != http.StatusNoContent && status != http.StatusNotFound {
+		suite.T().Logf("Failed to delete %s/%s: status %d: %s", basePath, id, status, body)
+	}
+}
+
+// idOf extracts the id field from a created-resource response body.
+func (suite *InboundClientValidationSuite) idOf(body []byte) string {
+	var created struct {
+		ID string `json:"id"`
+	}
+	suite.Require().NoError(json.Unmarshal(body, &created), "body: %s", body)
+	suite.Require().NotEmpty(created.ID)
+	return created.ID
+}
+
+// do issues a request with an optional JSON body and returns the status and response body.
+func (suite *InboundClientValidationSuite) do(
+	method, target string, body map[string]interface{},
+) (int, []byte) {
+	var reader io.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		suite.Require().NoError(err)
+		reader = bytes.NewReader(payload)
+	}
+
+	req, err := http.NewRequest(method, target, reader)
+	suite.Require().NoError(err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := suite.client.Do(req)
+	suite.Require().NoError(err)
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			suite.T().Logf("Failed to close response body: %v", closeErr)
+		}
+	}()
+
+	respBody, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+	return resp.StatusCode, respBody
+}
+
+// errorCode decodes the error code from an API error response body.
+func (suite *InboundClientValidationSuite) errorCode(body []byte) string {
+	var errResp struct {
+		Code string `json:"code"`
+	}
+	suite.Require().NoError(json.Unmarshal(body, &errResp), "body: %s", body)
+	return errResp.Code
+}

--- a/tests/integration/serverconfig/session_api_test.go
+++ b/tests/integration/serverconfig/session_api_test.go
@@ -1,0 +1,228 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package serverconfig
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const sessionConfigURL = serverConfigURL + "/session"
+
+// sessionSectionValue mirrors the session section value: SSO session lifetimes in seconds.
+type sessionSectionValue struct {
+	IdleTimeoutSeconds             int64 `json:"idleTimeoutSeconds"`
+	AbsoluteTimeoutSeconds         int64 `json:"absoluteTimeoutSeconds"`
+	ActivityRefreshIntervalSeconds int64 `json:"activityRefreshIntervalSeconds"`
+}
+
+type sessionLayers struct {
+	ReadOnly sessionSectionValue `json:"readOnly"`
+	Writable sessionSectionValue `json:"writable"`
+	Merged   sessionSectionValue `json:"merged"`
+}
+
+// SessionConfigAPITestSuite covers the session server-config section and the PUT branches the CORS
+// suite does not reach: the response body of a successful PUT, PUT against an unsupported name, and
+// a value that fails Decode rather than Validate.
+type SessionConfigAPITestSuite struct {
+	suite.Suite
+	adminClient *http.Client
+}
+
+func TestSessionConfigAPITestSuite(t *testing.T) {
+	suite.Run(t, new(SessionConfigAPITestSuite))
+}
+
+func (suite *SessionConfigAPITestSuite) SetupSuite() {
+	suite.adminClient = testutils.GetHTTPClient()
+}
+
+// SetupTest clears the writable session layer so each test starts from a known state.
+func (suite *SessionConfigAPITestSuite) SetupTest() {
+	suite.putSession(`{}`)
+}
+
+// TearDownSuite leaves the writable session layer empty so the shared server is not left mutated.
+func (suite *SessionConfigAPITestSuite) TearDownSuite() {
+	suite.putSession(`{}`)
+}
+
+func (suite *SessionConfigAPITestSuite) TestListIncludesSessionSection() {
+	status, body := suite.get(serverConfigURL)
+	suite.Require().Equal(http.StatusOK, status)
+
+	var names []string
+	suite.Require().NoError(json.Unmarshal(body, &names))
+	suite.Contains(names, "session")
+}
+
+func (suite *SessionConfigAPITestSuite) TestPutPersistsAndReadsBack() {
+	suite.putSession(`{"idleTimeoutSeconds":1800,"absoluteTimeoutSeconds":28800,` +
+		`"activityRefreshIntervalSeconds":300}`)
+
+	layers := suite.getLayers()
+	suite.Equal(int64(1800), layers.Writable.IdleTimeoutSeconds)
+	suite.Equal(int64(28800), layers.Writable.AbsoluteTimeoutSeconds)
+	suite.Equal(int64(300), layers.Writable.ActivityRefreshIntervalSeconds)
+
+	// The writable layer wins for each field it sets.
+	suite.Equal(int64(1800), layers.Merged.IdleTimeoutSeconds)
+	suite.Equal(int64(28800), layers.Merged.AbsoluteTimeoutSeconds)
+}
+
+// TestPutReturnsRecomputedLayers pins that a successful PUT answers with the new layers, not just a
+// status code. The CORS suite only checks the status, so a stale response body would go unnoticed.
+func (suite *SessionConfigAPITestSuite) TestPutReturnsRecomputedLayers() {
+	status, body := suite.put(sessionConfigURL,
+		`{"idleTimeoutSeconds":900,"absoluteTimeoutSeconds":7200,"activityRefreshIntervalSeconds":60}`)
+	suite.Require().Equal(http.StatusOK, status, "body: %s", body)
+
+	var layers sessionLayers
+	suite.Require().NoError(json.Unmarshal(body, &layers))
+	suite.Equal(int64(900), layers.Writable.IdleTimeoutSeconds)
+	suite.Equal(int64(900), layers.Merged.IdleTimeoutSeconds)
+
+	// The PUT response matches a follow-up GET.
+	suite.Equal(layers.Writable, suite.getLayers().Writable)
+}
+
+// TestPutReplacesRatherThanMerges asserts a second PUT replaces the writable layer wholesale.
+func (suite *SessionConfigAPITestSuite) TestPutReplacesRatherThanMerges() {
+	suite.putSession(`{"idleTimeoutSeconds":1800,"absoluteTimeoutSeconds":28800,` +
+		`"activityRefreshIntervalSeconds":300}`)
+	suite.putSession(`{"idleTimeoutSeconds":600,"absoluteTimeoutSeconds":3600,` +
+		`"activityRefreshIntervalSeconds":60}`)
+
+	layers := suite.getLayers()
+	suite.Equal(int64(600), layers.Writable.IdleTimeoutSeconds)
+	suite.Equal(int64(3600), layers.Writable.AbsoluteTimeoutSeconds)
+	suite.Equal(int64(60), layers.Writable.ActivityRefreshIntervalSeconds)
+}
+
+// --- Validation branches ---
+
+// TestPutIdleExceedingAbsoluteReturns400 covers a cross-field invariant: idle must not exceed the
+// absolute timeout.
+func (suite *SessionConfigAPITestSuite) TestPutIdleExceedingAbsoluteReturns400() {
+	status, body := suite.put(sessionConfigURL,
+		`{"idleTimeoutSeconds":7200,"absoluteTimeoutSeconds":3600,"activityRefreshIntervalSeconds":60}`)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("SCF-1003", suite.errorCode(body))
+	suite.Zero(suite.getLayers().Writable.IdleTimeoutSeconds, "a rejected value must not persist")
+}
+
+// TestPutActivityRefreshNotLessThanIdleReturns400 covers the resolved-duration invariant.
+func (suite *SessionConfigAPITestSuite) TestPutActivityRefreshNotLessThanIdleReturns400() {
+	status, body := suite.put(sessionConfigURL,
+		`{"idleTimeoutSeconds":600,"absoluteTimeoutSeconds":3600,"activityRefreshIntervalSeconds":600}`)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("SCF-1003", suite.errorCode(body))
+}
+
+func (suite *SessionConfigAPITestSuite) TestPutNegativeValueReturns400() {
+	status, body := suite.put(sessionConfigURL, `{"idleTimeoutSeconds":-1}`)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("SCF-1003", suite.errorCode(body))
+}
+
+// TestPutWrongFieldTypeReturns400 covers the Decode failure path, distinct from the Validate
+// failures above: the JSON is well-formed but a field has the wrong type.
+func (suite *SessionConfigAPITestSuite) TestPutWrongFieldTypeReturns400() {
+	status, body := suite.put(sessionConfigURL, `{"idleTimeoutSeconds":"not-a-number"}`)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("SCF-1003", suite.errorCode(body))
+}
+
+// TestPutWrongTopLevelShapeReturns400 covers a top-level shape mismatch: the section value is an
+// object, not an array.
+func (suite *SessionConfigAPITestSuite) TestPutWrongTopLevelShapeReturns400() {
+	status, body := suite.put(sessionConfigURL, `["not","an","object"]`)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("SCF-1003", suite.errorCode(body))
+}
+
+func (suite *SessionConfigAPITestSuite) TestPutMalformedBodyReturns400() {
+	status, body := suite.put(sessionConfigURL, `{`)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("SCF-1004", suite.errorCode(body))
+}
+
+// TestPutUnsupportedNameReturns400 is the PUT counterpart of the tested GET case.
+func (suite *SessionConfigAPITestSuite) TestPutUnsupportedNameReturns400() {
+	status, body := suite.put(serverConfigURL+"/bogus", `{}`)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("SCF-1001", suite.errorCode(body))
+}
+
+// TestPutOversizedBodyIsRejected covers the 1 MiB request-body cap.
+func (suite *SessionConfigAPITestSuite) TestPutOversizedBodyIsRejected() {
+	// A syntactically valid object whose padding field pushes it past the cap.
+	oversized := `{"idleTimeoutSeconds":1800,"padding":"` + strings.Repeat("a", 1<<20+1024) + `"}`
+
+	status, _ := suite.put(sessionConfigURL, oversized)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Zero(suite.getLayers().Writable.IdleTimeoutSeconds, "a rejected body must not persist")
+}
+
+// --- helpers ---
+
+// putSession sets the writable session layer and requires a 200 response.
+func (suite *SessionConfigAPITestSuite) putSession(body string) {
+	status, respBody := suite.put(sessionConfigURL, body)
+	suite.Require().Equal(http.StatusOK, status, "put session failed: %s", respBody)
+}
+
+func (suite *SessionConfigAPITestSuite) getLayers() sessionLayers {
+	status, body := suite.get(sessionConfigURL)
+	suite.Require().Equal(http.StatusOK, status, "body: %s", body)
+
+	var layers sessionLayers
+	suite.Require().NoError(json.Unmarshal(body, &layers))
+	return layers
+}
+
+func (suite *SessionConfigAPITestSuite) get(url string) (int, []byte) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	suite.Require().NoError(err)
+	return suite.send(req)
+}
+
+func (suite *SessionConfigAPITestSuite) put(url, body string) (int, []byte) {
+	req, err := http.NewRequest(http.MethodPut, url, bytes.NewReader([]byte(body)))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+	return suite.send(req)
+}
+
+func (suite *SessionConfigAPITestSuite) send(req *http.Request) (int, []byte) {
+	resp, err := suite.adminClient.Do(req)
+	suite.Require().NoError(err)
+	defer closeBodyQuietly(suite.T(), resp.Body)
+
+	body, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+	return resp.StatusCode, body
+}
+
+func (suite *SessionConfigAPITestSuite) errorCode(body []byte) string {
+	var errResp apiErrorResponse
+	suite.Require().NoError(json.Unmarshal(body, &errResp), "body: %s", body)
+	return errResp.Code
+}


### PR DESCRIPTION
### Purpose

Closes integration-test gaps across five admin-configuration areas. The largest were i18n translation management, whose CRUD endpoints had no integration coverage at all, and the importer, whose failure paths were entirely untested.

Gaps addressed:

- **i18n management** — no integration test package existed. The only end-to-end exercise of i18n was indirect, via a DCR test that happened to call bulk resolve. Every write endpoint was untouched.
- **import / export** — existing suites only ever assert success; no test anywhere asserted a non-200, an `IMP-*`/`EXP-*` code, or a non-zero `Failed` count. `POST /import/delete` had no test of any kind.
- **design** — `resolve` had four test functions with empty bodies and a comment describing what was intended. The `/usages` endpoints had zero requests made against them.
- **server config** — only 2 of 5 sections (`cors`, `defaultResourceServer`) were exercised.
- **inbound client** — no test directory. The package registers no HTTP routes, so it is reachable only through the application/agent APIs.

### Approach

Tests follow the existing testify-suite conventions per package: `testutils.GetHTTPClient()` for the authenticated admin client, a plain client where an endpoint's public/authenticated split is being asserted, and setup/teardown that leaves the shared server unmutated.

**i18n management** (`tests/integration/i18n/`, new package, 34 tests) — set/clear overrides per-key and per-language, round-trip through resolve, replace-not-merge on bulk writes, override-shadows-system-default, and each of `I18N-1001`–`I18N-1008`. Also pins the auth split: resolve is in the public path allow-list, writes are not.

**Import/export error branches** (`import_export_error_test.go`, 24 tests) — every `IMP-100x`/`EXP-100x` code; `/import/delete` end to end; per-document failure outcomes (a document that parses but fails domain validation returns **200** with a failed item, not a request-level error); dry-run non-persistence; and the `continueOnError` pair, where disabling it stops processing and leaves `len(results)` deliberately short of `totalDocuments`.

**Design** (`resolve_api_test.go`, `usages_handle_api_test.go`, 17 new + 4 stubs filled) — filled the four empty resolve stubs (theme+layout, theme-only, layout-only, no-design → `DSR-1005`), plus deleted-theme graceful fallback and case-insensitive type. Added `/usages` coverage and handle semantics: duplicate, missing, and immutability on update. That last one had never fired, because every pre-existing update test resends the same handle.

**Server config** (`session_api_test.go`, 12 tests) — the `session` section, plus three PUT branches the CORS suite misses: the recomputed-layers response body, PUT against an unsupported name, and the 1 MiB body cap.

**Inbound client** (`tests/integration/inboundclient/`, new package, 11 tests) — driven through `/applications`. Covers theme/layout FK validation on create and update, subject attribute mapping, and pins the deliberate divergence where **create rejects an undeclared user attribute but update silently strips it**.

Deliberately not duplicated: allowed-user-type validation (`APP-1025`) is already asserted three times in the application suite, so the inbound-client suite skips it and carries a comment saying so.

#### Coverage

Integration coverage, measured per package:

| Package | Before | After |
|---|---|---|
| `system/i18n/mgt` | 17.5% | **52.5%** |
| `design/resolve` | 53.6% | **90.5%** |
| `design/theme/mgt` | 46.5% | **70.5%** |
| `design/layout/mgt` | 47.6% | **71.6%** |
| `system/importer` | 46.4% | **63.3%** |
| `inboundclient` | 45.3% | **54.1%** |
| `system/export` | 51.5% | **54.0%** |
| `serverconfig` | 64.0% | **65.1%** |

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added comprehensive integration coverage for design resource resolution, usage tracking, and handle validation.
  - Added i18n translation management tests covering overrides, fallback, validation, bulk operations, and authentication.
  - Added import/export error-handling and dry-run coverage.
  - Added inbound-client validation tests for references, attributes, and subject mappings.
  - Added session configuration tests for persistence, replacement, validation, and request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->