### PR TITLE
Add integration tests for AuthAssertExecutor assurance guards

### DIFF
--- a/tests/integration/flow/authentication/attribute_release_test.go
+++ b/tests/integration/flow/authentication/attribute_release_test.go
@@ -1,0 +1,300 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authentication
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// This suite pins the attribute-release branch of AuthAssertExecutor. The branch key is the
+// presence of the user_attributes_cache_ttl_seconds runtime value, which the OAuth authorization
+// service injects when it starts the flow and a direct POST /flow/execute never does:
+//
+//   - App-Native (no runtime key): every resolved user attribute is inlined as a top-level
+//     assertion claim and no aci claim is minted.
+//   - OAuth-initiated (runtime key present): the resolved attributes go into the attribute cache
+//     and the assertion only carries the aci reference to them.
+//
+// The same application and the same flow drive both cases, so the initiation path is the only
+// variable. That is possible because the application is a mobile app with attestation dev mode
+// enabled: dev mode lets it initiate a flow directly, while its authorization_code OAuth profile
+// lets it go through GET /oauth2/authorize.
+
+const (
+	attrReleaseClientID    = "attr_release_branch_client"
+	attrReleaseSecret      = "attr_release_branch_secret"
+	attrReleaseRedirectURI = "https://localhost:3000/attr-release-callback"
+	attrReleaseUsername    = "attr_release_user"
+	attrReleasePassword    = "SecurePass123!"
+	attrReleaseEmail       = "attr.release@test.com"
+	attrReleaseGivenName   = "Attribute"
+	attrReleaseFamilyName  = "Release"
+)
+
+var attrReleaseOU = testutils.OrganizationUnit{
+	Handle:      "attr-release-branch-ou",
+	Name:        "Attribute Release Branch OU",
+	Description: "Organization unit for the attribute release branch tests",
+	Parent:      nil,
+}
+
+var attrReleaseUserType = testutils.UserType{
+	Name: "attr-release-person",
+	Schema: map[string]interface{}{
+		"username":    map[string]interface{}{"type": "string"},
+		"password":    map[string]interface{}{"type": "string", "credential": true},
+		"email":       map[string]interface{}{"type": "string"},
+		"given_name":  map[string]interface{}{"type": "string"},
+		"family_name": map[string]interface{}{"type": "string"},
+	},
+}
+
+var attrReleaseFlow = testutils.Flow{
+	Name:     "Attribute Release Branch Auth Flow",
+	FlowType: "AUTHENTICATION",
+	Handle:   "auth_flow_attr_release_branch",
+	Nodes: []map[string]interface{}{
+		{"id": "start", "type": "START", "onSuccess": "prompt_credentials"},
+		{
+			"id":   "prompt_credentials",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+						{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+					},
+					"action": map[string]interface{}{"ref": "action_001", "nextNode": "credentials_auth"},
+				},
+			},
+		},
+		{
+			"id":   "credentials_auth",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "CredentialsAuthExecutor",
+				"inputs": []map[string]interface{}{
+					{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+					{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+				},
+			},
+			"onSuccess": "auth_assert",
+		},
+		{
+			"id":        "auth_assert",
+			"type":      "TASK_EXECUTION",
+			"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+			"onSuccess": "end",
+		},
+		{"id": "end", "type": "END"},
+	},
+}
+
+// attrReleaseApp is a mobile application with attestation dev mode enabled so the very same
+// application can initiate a flow directly (App-Native) and through GET /oauth2/authorize.
+var attrReleaseApp = testutils.Application{
+	Name:                      "Attribute Release Branch App",
+	Description:               "Application for the attribute release branch tests",
+	Type:                      "mobile",
+	IsRegistrationFlowEnabled: false,
+	RedirectURIs:              []string{attrReleaseRedirectURI},
+	AllowedUserTypes:          []string{"attr-release-person"},
+	Attestation:               map[string]interface{}{"devMode": true},
+	AssertionConfig: map[string]interface{}{
+		"userAttributes": []string{"email", "given_name", "family_name"},
+	},
+	InboundAuthConfig: []map[string]interface{}{
+		{
+			"type": "oauth2",
+			"config": map[string]interface{}{
+				"clientId":                attrReleaseClientID,
+				"clientSecret":            attrReleaseSecret,
+				"redirectUris":            []string{attrReleaseRedirectURI},
+				"grantTypes":              []string{"authorization_code"},
+				"responseTypes":           []string{"code"},
+				"tokenEndpointAuthMethod": "client_secret_post",
+				"scopes":                  []string{"openid", "profile", "email"},
+				"token": map[string]interface{}{
+					"idToken": map[string]interface{}{
+						"userAttributes": []string{"email", "given_name", "family_name"},
+					},
+					"userInfo": map[string]interface{}{
+						"userAttributes": []string{"email", "given_name", "family_name"},
+					},
+				},
+				"scopeClaims": map[string][]string{
+					"profile": {"given_name", "family_name"},
+					"email":   {"email"},
+				},
+			},
+		},
+	},
+}
+
+type AttributeReleaseBranchTestSuite struct {
+	suite.Suite
+	ouID       string
+	userTypeID string
+	userID     string
+	flowID     string
+	appID      string
+}
+
+func TestAttributeReleaseBranchTestSuite(t *testing.T) {
+	suite.Run(t, new(AttributeReleaseBranchTestSuite))
+}
+
+func (ts *AttributeReleaseBranchTestSuite) SetupSuite() {
+	ouID, err := testutils.CreateOrganizationUnit(attrReleaseOU)
+	ts.Require().NoError(err, "Failed to create organization unit")
+	ts.ouID = ouID
+
+	attrReleaseUserType.OUID = ts.ouID
+	userTypeID, err := testutils.CreateUserType(attrReleaseUserType)
+	ts.Require().NoError(err, "Failed to create user type")
+	ts.userTypeID = userTypeID
+
+	flowID, err := testutils.CreateFlow(attrReleaseFlow)
+	ts.Require().NoError(err, "Failed to create authentication flow")
+	ts.flowID = flowID
+
+	app := attrReleaseApp
+	app.OUID = ts.ouID
+	app.AuthFlowID = flowID
+	appID, err := testutils.CreateApplication(app)
+	ts.Require().NoError(err, "Failed to create application")
+	ts.appID = appID
+
+	attributes, err := json.Marshal(map[string]interface{}{
+		"username":    attrReleaseUsername,
+		"password":    attrReleasePassword,
+		"email":       attrReleaseEmail,
+		"given_name":  attrReleaseGivenName,
+		"family_name": attrReleaseFamilyName,
+	})
+	ts.Require().NoError(err, "Failed to marshal user attributes")
+
+	userID, err := testutils.CreateUser(testutils.User{
+		Type:       attrReleaseUserType.Name,
+		OUID:       ts.ouID,
+		Attributes: json.RawMessage(attributes),
+	})
+	ts.Require().NoError(err, "Failed to create user")
+	ts.userID = userID
+}
+
+func (ts *AttributeReleaseBranchTestSuite) TearDownSuite() {
+	if ts.userID != "" {
+		if err := testutils.DeleteUser(ts.userID); err != nil {
+			ts.T().Logf("Failed to delete user during teardown: %v", err)
+		}
+	}
+	if ts.appID != "" {
+		if err := testutils.DeleteApplication(ts.appID); err != nil {
+			ts.T().Logf("Failed to delete application during teardown: %v", err)
+		}
+	}
+	if ts.flowID != "" {
+		if err := testutils.DeleteFlow(ts.flowID); err != nil {
+			ts.T().Logf("Failed to delete flow during teardown: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete organization unit during teardown: %v", err)
+		}
+	}
+	if ts.userTypeID != "" {
+		if err := testutils.DeleteUserType(ts.userTypeID); err != nil {
+			ts.T().Logf("Failed to delete user type during teardown: %v", err)
+		}
+	}
+}
+
+// authenticateAppNatively drives the flow with a direct POST /flow/execute and returns the
+// assertion. No OAuth component is involved, so user_attributes_cache_ttl_seconds is never set.
+func (ts *AttributeReleaseBranchTestSuite) authenticateAppNatively() string {
+	flowStep, err := common.InitiateAuthenticationFlow(ts.appID, false,
+		map[string]string{"applicationId": ts.appID}, "")
+	ts.Require().NoError(err, "Failed to initiate app-native flow")
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Flow should start incomplete")
+
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, map[string]string{
+		"username": attrReleaseUsername,
+		"password": attrReleasePassword,
+	}, "action_001", flowStep.ChallengeToken)
+	ts.Require().NoError(err, "Failed to complete app-native flow")
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus, "App-native flow should complete")
+	ts.Require().NotEmpty(flowStep.Assertion, "App-native flow should return an assertion")
+
+	return flowStep.Assertion
+}
+
+// authenticateThroughAuthorizeEndpoint drives the same flow through GET /oauth2/authorize and
+// returns the assertion produced at the end of the flow. The authorization service seeds
+// user_attributes_cache_ttl_seconds into the flow runtime data on this path.
+func (ts *AttributeReleaseBranchTestSuite) authenticateThroughAuthorizeEndpoint() string {
+	resp, err := testutils.InitiateAuthorizationFlow(attrReleaseClientID, attrReleaseRedirectURI,
+		"code", "openid profile email", "attr-release-state")
+	ts.Require().NoError(err, "Failed to call the authorize endpoint")
+	defer resp.Body.Close()
+
+	ts.Require().Equal(http.StatusFound, resp.StatusCode, "Authorize endpoint should redirect to the flow")
+	location := resp.Header.Get("Location")
+	ts.Require().NotEmpty(location, "Authorize response should carry a Location header")
+
+	_, executionID, err := testutils.ExtractAuthData(location)
+	ts.Require().NoError(err, "Failed to extract the execution ID from the authorize redirect")
+
+	initialStep, err := testutils.ExecuteAuthenticationFlow(executionID, nil, "")
+	ts.Require().NoError(err, "Failed to execute the initial OAuth-initiated flow step")
+
+	flowStep, err := testutils.ExecuteAuthenticationFlow(executionID, map[string]string{
+		"username": attrReleaseUsername,
+		"password": attrReleasePassword,
+	}, "action_001", initialStep.ChallengeToken)
+	ts.Require().NoError(err, "Failed to complete the OAuth-initiated flow")
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus, "OAuth-initiated flow should complete")
+	ts.Require().NotEmpty(flowStep.Assertion, "OAuth-initiated flow should return an assertion")
+
+	return flowStep.Assertion
+}
+
+// TestAppNativeFlow_InlinesUserAttributesAndOmitsACI covers case 5: with no attribute cache TTL in
+// runtime data, every resolved user attribute is a top-level assertion claim and no aci is minted.
+func (ts *AttributeReleaseBranchTestSuite) TestAppNativeFlow_InlinesUserAttributesAndOmitsACI() {
+	claims, err := testutils.DecodeJWTPayloadMap(ts.authenticateAppNatively())
+	ts.Require().NoError(err, "Failed to decode the app-native assertion")
+
+	ts.Equal(attrReleaseEmail, claims["email"], "email should be inlined in the assertion")
+	ts.Equal(attrReleaseGivenName, claims["given_name"], "given_name should be inlined in the assertion")
+	ts.Equal(attrReleaseFamilyName, claims["family_name"], "family_name should be inlined in the assertion")
+
+	_, hasACI := claims["aci"]
+	ts.False(hasACI, fmt.Sprintf("App-native assertion should not carry an aci claim, got claims %v", claims))
+}
+
+// TestOAuthInitiatedFlow_ReferencesAttributeCacheViaACI covers case 6: the same application and the
+// same flow, started through the authorize endpoint, cache the attributes and carry only the aci
+// reference in the assertion.
+func (ts *AttributeReleaseBranchTestSuite) TestOAuthInitiatedFlow_ReferencesAttributeCacheViaACI() {
+	claims, err := testutils.DecodeJWTPayloadMap(ts.authenticateThroughAuthorizeEndpoint())
+	ts.Require().NoError(err, "Failed to decode the OAuth-initiated assertion")
+
+	aci, hasACI := claims["aci"]
+	ts.Require().True(hasACI, fmt.Sprintf("OAuth-initiated assertion should carry an aci claim, got %v", claims))
+	ts.NotEmpty(aci, "aci claim should not be empty")
+
+	for _, attribute := range []string{"email", "given_name", "family_name"} {
+		_, present := claims[attribute]
+		ts.False(present, "OAuth-initiated assertion should not inline "+attribute)
+	}
+}

--- a/tests/integration/flow/authentication/consent_permissions_test.go
+++ b/tests/integration/flow/authentication/consent_permissions_test.go
@@ -1,0 +1,568 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authentication
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// This suite pins the consent side of AuthAssertExecutor.resolvePermissionsForClaim. The claim is
+// resolved from a precedence chain:
+//
+//   1. consent ran and an authorization step ran: the consented set intersected with the currently
+//      authorized set, so a stale consent record cannot re-grant a revoked permission.
+//   2. consent ran without an authorization step: the consented set is used verbatim.
+//   3. consent did not run: the authorized set is used (covered by FlowAuthzTestSuite).
+//
+// Each scenario uses its own user because consent records are keyed by (application, user) and an
+// element that already has active consent is not prompted again, which would change the branch
+// under test on a second run.
+
+const (
+	consentPermsResourceServer = "consent-perms-mgmt"
+	consentPermsPassword       = "SecurePass123!"
+)
+
+var consentPermsOU = testutils.OrganizationUnit{
+	Handle:      "consent-perms-test-ou",
+	Name:        "Consent Permissions Test OU",
+	Description: "Organization unit for consent permission claim tests",
+	Parent:      nil,
+}
+
+var consentPermsUserType = testutils.UserType{
+	Name: "consent-perms-person",
+	Schema: map[string]interface{}{
+		"username":    map[string]interface{}{"type": "string"},
+		"password":    map[string]interface{}{"type": "string", "credential": true},
+		"email":       map[string]interface{}{"type": "string"},
+		"given_name":  map[string]interface{}{"type": "string"},
+		"family_name": map[string]interface{}{"type": "string"},
+	},
+}
+
+// consentPromptNodes are the consent executor node and its prompt view, shared by both test flows.
+// The consent executor forwards the prompt on onIncomplete and is re-entered by both the approve
+// and the deny action, exactly as the sample application flows wire it.
+func consentPromptNodes(nextNodeAfterConsent string) []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"id":           "consent_check",
+			"type":         "TASK_EXECUTION",
+			"executor":     map[string]interface{}{"name": "ConsentExecutor"},
+			"onSuccess":    nextNodeAfterConsent,
+			"onIncomplete": "prompt_consent",
+		},
+		{
+			"id":   "prompt_consent",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "consent_input",
+							"identifier": "consent_decisions",
+							"type":       "CONSENT_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{"ref": "consent_action_allow", "nextNode": "consent_check"},
+				},
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "consent_input",
+							"identifier": "consent_decisions",
+							"type":       "CONSENT_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{"ref": "consent_action_deny", "nextNode": "consent_check"},
+				},
+			},
+		},
+	}
+}
+
+// credentialsNodes are the start and password authentication nodes shared by both test flows.
+func credentialsNodes(nextNodeAfterAuth string) []map[string]interface{} {
+	return []map[string]interface{}{
+		{"id": "start", "type": "START", "onSuccess": "prompt_credentials"},
+		{
+			"id":   "prompt_credentials",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+						{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+					},
+					"action": map[string]interface{}{"ref": "action_001", "nextNode": "credentials_auth"},
+				},
+			},
+		},
+		{
+			"id":   "credentials_auth",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "CredentialsAuthExecutor",
+				"inputs": []map[string]interface{}{
+					{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+					{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+				},
+			},
+			"onSuccess": nextNodeAfterAuth,
+		},
+	}
+}
+
+func assertAndConsentNodes() []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"id":        "auth_assert",
+			"type":      "TASK_EXECUTION",
+			"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+			"onSuccess": "end",
+		},
+		{"id": "end", "type": "END"},
+	}
+}
+
+func buildConsentFlowWithAuthz() testutils.Flow {
+	nodes := credentialsNodes("authorization_check")
+	nodes = append(nodes, map[string]interface{}{
+		"id":        "authorization_check",
+		"type":      "TASK_EXECUTION",
+		"executor":  map[string]interface{}{"name": "AuthorizationExecutor"},
+		"onSuccess": "consent_check",
+	})
+	nodes = append(nodes, consentPromptNodes("auth_assert")...)
+	nodes = append(nodes, assertAndConsentNodes()...)
+
+	return testutils.Flow{
+		Name:     "Consent Permissions Auth Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_consent_perms",
+		Nodes:    nodes,
+	}
+}
+
+func buildConsentFlowWithoutAuthz() testutils.Flow {
+	nodes := credentialsNodes("consent_check")
+	nodes = append(nodes, consentPromptNodes("auth_assert")...)
+	nodes = append(nodes, assertAndConsentNodes()...)
+
+	return testutils.Flow{
+		Name:     "Consent Without Authorization Auth Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_consent_no_authz",
+		Nodes:    nodes,
+	}
+}
+
+// consentPromptElement mirrors the element entries of the consent prompt payload the executor
+// publishes under the consentPrompt key of the flow response additional data.
+type consentPromptElement struct {
+	Name string `json:"name"`
+}
+
+// consentPromptPurpose mirrors one purpose of the consent prompt payload.
+type consentPromptPurpose struct {
+	PurposeName string                 `json:"purposeName"`
+	Type        string                 `json:"type"`
+	Essential   []consentPromptElement `json:"essential"`
+	Optional    []consentPromptElement `json:"optional"`
+}
+
+type consentElementDecision struct {
+	Name     string `json:"name"`
+	Approved bool   `json:"approved"`
+}
+
+type consentPurposeDecision struct {
+	PurposeName string                   `json:"purposeName"`
+	Approved    bool                     `json:"approved"`
+	Elements    []consentElementDecision `json:"elements"`
+}
+
+type consentDecisions struct {
+	Approved bool                     `json:"approved"`
+	Purposes []consentPurposeDecision `json:"purposes"`
+}
+
+type ConsentPermissionsTestSuite struct {
+	suite.Suite
+	ouID             string
+	userTypeID       string
+	resourceServerID string
+	authzFlowID      string
+	noAuthzFlowID    string
+	authzAppID       string
+	noAuthzAppID     string
+	subsetRoleID     string
+	staleRoleID      string
+	subsetUserID     string
+	staleUserID      string
+	denyAllUserID    string
+	noAuthzUserID    string
+}
+
+func TestConsentPermissionsTestSuite(t *testing.T) {
+	suite.Run(t, new(ConsentPermissionsTestSuite))
+}
+
+func (ts *ConsentPermissionsTestSuite) SetupSuite() {
+	ouID, err := testutils.CreateOrganizationUnit(consentPermsOU)
+	ts.Require().NoError(err, "Failed to create organization unit")
+	ts.ouID = ouID
+
+	consentPermsUserType.OUID = ts.ouID
+	userTypeID, err := testutils.CreateUserType(consentPermsUserType)
+	ts.Require().NoError(err, "Failed to create user type")
+	ts.userTypeID = userTypeID
+
+	resourceServerID, err := testutils.CreateResourceServerWithActions(testutils.ResourceServer{
+		Name:        "Consent Permissions Document Store",
+		Description: "Resource server for consent permission claim tests",
+		Identifier:  consentPermsResourceServer,
+		OUID:        ts.ouID,
+	}, []testutils.Action{
+		{Name: "Read Documents", Handle: "read", Description: "Permission to read documents"},
+		{Name: "Write Documents", Handle: "write", Description: "Permission to write documents"},
+		{Name: "Delete Documents", Handle: "delete", Description: "Permission to delete documents"},
+	})
+	ts.Require().NoError(err, "Failed to create resource server")
+	ts.resourceServerID = resourceServerID
+
+	authzFlowID, err := testutils.CreateFlow(buildConsentFlowWithAuthz())
+	ts.Require().NoError(err, "Failed to create the consent flow with an authorization step")
+	ts.authzFlowID = authzFlowID
+
+	noAuthzFlowID, err := testutils.CreateFlow(buildConsentFlowWithoutAuthz())
+	ts.Require().NoError(err, "Failed to create the consent flow without an authorization step")
+	ts.noAuthzFlowID = noAuthzFlowID
+
+	// The application driving the permission scenarios releases no user attributes, so the consent
+	// prompt contains only the permissions purpose.
+	authzAppID, err := testutils.CreateApplication(testutils.Application{
+		Name:             "Consent Permissions App",
+		Description:      "Application for the consent permission claim tests",
+		OUID:             ts.ouID,
+		AuthFlowID:       authzFlowID,
+		AllowedUserTypes: []string{consentPermsUserType.Name},
+		Embedded:         true,
+	})
+	ts.Require().NoError(err, "Failed to create the consent permissions application")
+	ts.authzAppID = authzAppID
+
+	// The application driving the no-authorization scenario releases user attributes so the consent
+	// prompt has an attribute purpose to show. Without a purpose to prompt, consent is skipped
+	// entirely and the consented-permissions branch is never reached.
+	noAuthzAppID, err := testutils.CreateApplication(testutils.Application{
+		Name:             "Consent Without Authorization App",
+		Description:      "Application for the consent without authorization test",
+		OUID:             ts.ouID,
+		AuthFlowID:       noAuthzFlowID,
+		AllowedUserTypes: []string{consentPermsUserType.Name},
+		Embedded:         true,
+		AssertionConfig: map[string]interface{}{
+			"userAttributes": []string{"email", "given_name", "family_name"},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create the consent without authorization application")
+	ts.noAuthzAppID = noAuthzAppID
+
+	ts.subsetUserID = ts.createUser("consent_subset_user")
+	ts.staleUserID = ts.createUser("consent_stale_user")
+	ts.denyAllUserID = ts.createUser("consent_deny_all_user")
+	ts.noAuthzUserID = ts.createUser("consent_no_authz_user")
+
+	subsetRoleID, err := testutils.CreateRole(testutils.Role{
+		Name:        "ConsentSubsetEditor",
+		Description: "Grants read, write and delete on the consent permissions resource server",
+		OUID:        ts.ouID,
+		Permissions: []testutils.ResourcePermissions{
+			{ResourceServerID: ts.resourceServerID, Permissions: []string{"read", "write", "delete"}},
+		},
+		Assignments: []testutils.Assignment{
+			{ID: ts.subsetUserID, Type: "user"},
+			{ID: ts.denyAllUserID, Type: "user"},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create the subset role")
+	ts.subsetRoleID = subsetRoleID
+
+	staleRoleID, err := testutils.CreateRole(testutils.Role{
+		Name:        "ConsentStaleEditor",
+		Description: "Grants the permissions that are later revoked to create a stale consent record",
+		OUID:        ts.ouID,
+		Permissions: []testutils.ResourcePermissions{
+			{ResourceServerID: ts.resourceServerID, Permissions: []string{"read", "write"}},
+		},
+		Assignments: []testutils.Assignment{
+			{ID: ts.staleUserID, Type: "user"},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create the stale consent role")
+	ts.staleRoleID = staleRoleID
+}
+
+func (ts *ConsentPermissionsTestSuite) TearDownSuite() {
+	for _, roleID := range []string{ts.subsetRoleID, ts.staleRoleID} {
+		if roleID == "" {
+			continue
+		}
+		if err := testutils.DeleteRole(roleID); err != nil {
+			ts.T().Logf("Failed to delete role during teardown: %v", err)
+		}
+	}
+	for _, userID := range []string{ts.subsetUserID, ts.staleUserID, ts.denyAllUserID, ts.noAuthzUserID} {
+		if userID == "" {
+			continue
+		}
+		if err := testutils.DeleteUser(userID); err != nil {
+			ts.T().Logf("Failed to delete user during teardown: %v", err)
+		}
+	}
+	for _, appID := range []string{ts.authzAppID, ts.noAuthzAppID} {
+		if appID == "" {
+			continue
+		}
+		if err := testutils.DeleteApplication(appID); err != nil {
+			ts.T().Logf("Failed to delete application during teardown: %v", err)
+		}
+	}
+	for _, flowID := range []string{ts.authzFlowID, ts.noAuthzFlowID} {
+		if flowID == "" {
+			continue
+		}
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete flow during teardown: %v", err)
+		}
+	}
+	if ts.resourceServerID != "" {
+		// A resource server that still defines actions is not deletable, so the actions go first.
+		actionIDs, err := testutils.GetActionsByResourceServer(ts.resourceServerID)
+		if err != nil {
+			ts.T().Logf("Failed to list resource server actions during teardown: %v", err)
+		}
+		for _, actionID := range actionIDs {
+			if err := testutils.DeleteAction(ts.resourceServerID, actionID); err != nil {
+				ts.T().Logf("Failed to delete resource server action during teardown: %v", err)
+			}
+		}
+		if err := testutils.DeleteResourceServer(ts.resourceServerID); err != nil {
+			ts.T().Logf("Failed to delete resource server during teardown: %v", err)
+		}
+	}
+	if ts.userTypeID != "" {
+		if err := testutils.DeleteUserType(ts.userTypeID); err != nil {
+			ts.T().Logf("Failed to delete user type during teardown: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete organization unit during teardown: %v", err)
+		}
+	}
+}
+
+func (ts *ConsentPermissionsTestSuite) createUser(username string) string {
+	attributes, err := json.Marshal(map[string]interface{}{
+		"username":    username,
+		"password":    consentPermsPassword,
+		"email":       username + "@test.com",
+		"given_name":  "Consent",
+		"family_name": "Tester",
+	})
+	ts.Require().NoError(err, "Failed to marshal user attributes")
+
+	userID, err := testutils.CreateUser(testutils.User{
+		Type:       consentPermsUserType.Name,
+		OUID:       ts.ouID,
+		Attributes: json.RawMessage(attributes),
+	})
+	ts.Require().NoError(err, "Failed to create user "+username)
+	return userID
+}
+
+// authenticateUpToConsent drives the flow to the consent prompt and returns the flow step together
+// with the parsed consent prompt purposes.
+func (ts *ConsentPermissionsTestSuite) authenticateUpToConsent(
+	appID, username string, requestedPermissions string,
+) (*common.FlowStep, []consentPromptPurpose) {
+	inputs := map[string]string{"applicationId": appID}
+	if requestedPermissions != "" {
+		inputs["requested_permissions"] = requestedPermissions
+		inputs["resource_server_identifier"] = consentPermsResourceServer
+	}
+
+	flowStep, err := common.InitiateAuthenticationFlow(appID, false, inputs, "")
+	ts.Require().NoError(err, "Failed to initiate the flow")
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus, "Flow should start incomplete")
+
+	flowStep, err = common.CompleteFlow(flowStep.ExecutionID, map[string]string{
+		"username": username,
+		"password": consentPermsPassword,
+	}, "action_001", flowStep.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit credentials")
+	ts.Require().Equal("INCOMPLETE", flowStep.FlowStatus,
+		"Flow should pause on the consent prompt, got assertion %q", flowStep.Assertion)
+
+	promptJSON, ok := flowStep.Data.AdditionalData["consentPrompt"]
+	ts.Require().True(ok, "Consent prompt data should be present, got additional data %v",
+		flowStep.Data.AdditionalData)
+
+	var purposes []consentPromptPurpose
+	ts.Require().NoError(json.Unmarshal([]byte(promptJSON), &purposes), "Failed to parse the consent prompt")
+	ts.Require().NotEmpty(purposes, "Consent prompt should carry at least one purpose")
+
+	return flowStep, purposes
+}
+
+// submitConsent answers the consent prompt, approving exactly the elements named in approved, and
+// returns the resulting flow step. A nil approved map denies everything.
+func (ts *ConsentPermissionsTestSuite) submitConsent(
+	flowStep *common.FlowStep, purposes []consentPromptPurpose, approved map[string]bool,
+) *common.FlowStep {
+	decisions := consentDecisions{Approved: approved != nil}
+	for _, purpose := range purposes {
+		decision := consentPurposeDecision{PurposeName: purpose.PurposeName, Approved: approved != nil}
+		for _, element := range append(append([]consentPromptElement{},
+			purpose.Essential...), purpose.Optional...) {
+			decision.Elements = append(decision.Elements, consentElementDecision{
+				Name:     element.Name,
+				Approved: approved[element.Name],
+			})
+		}
+		decisions.Purposes = append(decisions.Purposes, decision)
+	}
+
+	decisionsJSON, err := json.Marshal(decisions)
+	ts.Require().NoError(err, "Failed to marshal the consent decisions")
+
+	action := "consent_action_allow"
+	if approved == nil {
+		action = "consent_action_deny"
+	}
+
+	completed, err := common.CompleteFlow(flowStep.ExecutionID,
+		map[string]string{"consent_decisions": string(decisionsJSON)}, action, flowStep.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit the consent decisions")
+	return completed
+}
+
+// permissionsClaim returns the authorized_permissions claim of the assertion and whether it is present.
+func (ts *ConsentPermissionsTestSuite) permissionsClaim(assertion string) (string, bool) {
+	ts.Require().NotEmpty(assertion, "Flow should return an assertion")
+
+	claims, err := testutils.DecodeJWTPayloadMap(assertion)
+	ts.Require().NoError(err, "Failed to decode the assertion")
+
+	raw, ok := claims["authorized_permissions"]
+	if !ok {
+		return "", false
+	}
+	value, isString := raw.(string)
+	ts.Require().True(isString, "authorized_permissions claim should be a string")
+	return value, true
+}
+
+// TestConsentedSubsetOfAuthorizedPermissions covers case 1: consenting to a subset of the authorized
+// permissions narrows the claim to that subset, in the order the user consented to them.
+func (ts *ConsentPermissionsTestSuite) TestConsentedSubsetOfAuthorizedPermissions() {
+	flowStep, purposes := ts.authenticateUpToConsent(ts.authzAppID, "consent_subset_user", "read write delete")
+
+	completed := ts.submitConsent(flowStep, purposes, map[string]bool{"read": true, "delete": true})
+	ts.Require().Equal("COMPLETE", completed.FlowStatus, "Flow should complete after consent")
+
+	permissions, present := ts.permissionsClaim(completed.Assertion)
+	ts.Require().True(present, "authorized_permissions claim should be present")
+	ts.Equal("read delete", permissions, "Claim should be exactly the consented subset, in order")
+}
+
+// TestStaleConsentIsIntersectedWithAuthorizedPermissions covers case 2: a permission that stays in
+// the consent record after the user loses it is dropped from the claim, because the consented set is
+// intersected with the currently authorized set. The second run also withholds consent for a
+// permission the user is authorized for, so neither set on its own can produce the expected claim.
+func (ts *ConsentPermissionsTestSuite) TestStaleConsentIsIntersectedWithAuthorizedPermissions() {
+	// First run: the user holds read and write and consents to both.
+	flowStep, purposes := ts.authenticateUpToConsent(ts.authzAppID, "consent_stale_user", "read write")
+	completed := ts.submitConsent(flowStep, purposes, map[string]bool{"read": true, "write": true})
+	ts.Require().Equal("COMPLETE", completed.FlowStatus, "First run should complete after consent")
+
+	permissions, present := ts.permissionsClaim(completed.Assertion)
+	ts.Require().True(present, "First run should carry the consented permissions")
+	ts.Equal("read write", permissions, "First run should carry both consented permissions")
+
+	// Revoke write and grant delete, leaving write approved in the consent record but no longer
+	// authorized. Granting delete keeps a non-consented permission in the prompt so the consent step
+	// still records a decision on the second run.
+	ts.Require().NoError(testutils.UpdateRole(ts.staleRoleID, testutils.Role{
+		Name:        "ConsentStaleEditor",
+		Description: "Grants the permissions that are later revoked to create a stale consent record",
+		OUID:        ts.ouID,
+		Permissions: []testutils.ResourcePermissions{
+			{ResourceServerID: ts.resourceServerID, Permissions: []string{"read", "delete"}},
+		},
+		Assignments: []testutils.Assignment{
+			{ID: ts.staleUserID, Type: "user"},
+		},
+	}), "Failed to revoke the write permission")
+
+	// Second run: the user is authorized for read and delete, and the consent record holds read and
+	// the now revoked write. Denying delete leaves the consented and the authorized sets differing in
+	// both directions, so only their intersection, read, can satisfy the assertion.
+	flowStep, purposes = ts.authenticateUpToConsent(ts.authzAppID, "consent_stale_user", "read write delete")
+	completed = ts.submitConsent(flowStep, purposes, map[string]bool{})
+	ts.Require().Equal("COMPLETE", completed.FlowStatus, "Second run should complete after consent")
+
+	permissions, present = ts.permissionsClaim(completed.Assertion)
+	ts.Require().True(present, "Second run should carry the intersected permissions")
+	ts.Equal("read", permissions,
+		"Claim should be the intersection: stale write is not authorized and delete was not consented")
+}
+
+// TestConsentDeniedForAllPermissions covers case 3: denying every permission leaves the claim out of
+// the assertion even though the user is authorized for all of them.
+func (ts *ConsentPermissionsTestSuite) TestConsentDeniedForAllPermissions() {
+	flowStep, purposes := ts.authenticateUpToConsent(ts.authzAppID, "consent_deny_all_user", "read write delete")
+
+	completed := ts.submitConsent(flowStep, purposes, nil)
+	ts.Require().Equal("COMPLETE", completed.FlowStatus, "Flow should complete after the denial")
+
+	permissions, present := ts.permissionsClaim(completed.Assertion)
+	ts.False(present, "authorized_permissions claim should be absent, got %q", permissions)
+}
+
+// TestConsentWithoutAuthorizationStep covers case 4: when consent runs in a flow that has no
+// authorization step there is no authorized set to intersect against, so the consented set is used
+// verbatim. No permission can be consented to in such a flow (the permissions purpose is built from
+// the authorized set), so the consented set is empty and the claim is omitted, while the consented
+// attributes still reach the assertion, proving the consent step did run.
+func (ts *ConsentPermissionsTestSuite) TestConsentWithoutAuthorizationStep() {
+	flowStep, purposes := ts.authenticateUpToConsent(ts.noAuthzAppID, "consent_no_authz_user", "")
+
+	for _, purpose := range purposes {
+		ts.NotEqual("permissions", purpose.Type,
+			"A flow without an authorization step cannot prompt for permissions")
+	}
+
+	completed := ts.submitConsent(flowStep, purposes, map[string]bool{
+		"email": true, "given_name": true, "family_name": true,
+	})
+	ts.Require().Equal("COMPLETE", completed.FlowStatus, "Flow should complete after consent")
+
+	claims, err := testutils.DecodeJWTPayloadMap(completed.Assertion)
+	ts.Require().NoError(err, "Failed to decode the assertion")
+	ts.Equal("consent_no_authz_user@test.com", claims["email"], "Consented attributes should be released")
+
+	_, present := claims["authorized_permissions"]
+	ts.False(present, "authorized_permissions claim should be absent, got claims %v", claims)
+}

--- a/tests/integration/oauth/authz/callback_negative_test.go
+++ b/tests/integration/oauth/authz/callback_negative_test.go
@@ -1,0 +1,403 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authz
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	cbNegClientID     = "authz_callback_neg_client"
+	cbNegClientSecret = "authz_callback_neg_secret" //nolint:gosec // test credential
+	cbNegRedirectURI  = "https://localhost:3000"
+	cbNegUsername     = "callback_neg_user"
+	cbNegPassword     = "testpass123"
+	cbNegUserType     = "authz-callback-neg-person"
+
+	// callbackPath is the single flow-callback endpoint every grant type is dispatched through.
+	callbackPath = "/oauth2/auth/callback"
+)
+
+// CallbackNegativeTestSuite covers the rejection paths of the flow-callback dispatcher, the endpoint
+// the Gate UI posts a terminal flow assertion to. Its happy path is exercised by every other
+// authorization-code suite, so what is pinned here is the opposite: requests that are structurally
+// invalid, name an unknown callback type, carry an assertion the server did not sign, or replay an
+// authId that was already spent. None of them may yield an authorization code.
+type CallbackNegativeTestSuite struct {
+	suite.Suite
+	ouID         string
+	entityTypeID string
+	userID       string
+	flowID       string
+	appID        string
+	client       *http.Client
+}
+
+func TestCallbackNegativeTestSuite(t *testing.T) {
+	suite.Run(t, new(CallbackNegativeTestSuite))
+}
+
+func (ts *CallbackNegativeTestSuite) SetupSuite() {
+	ts.client = testutils.GetHTTPClient()
+
+	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "authz-callback-neg-ou",
+		Name:        "Authz Callback Negative OU",
+		Description: "Organization unit for the flow callback dispatcher negative tests",
+		Parent:      nil,
+	})
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
+
+	entityTypeID, err := testutils.CreateUserType(testutils.UserType{
+		Name: cbNegUserType,
+		OUID: ouID,
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{"type": "string"},
+			"password": map[string]interface{}{"type": "string", "credential": true},
+			"email":    map[string]interface{}{"type": "string"},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create test user type")
+	ts.entityTypeID = entityTypeID
+
+	userID, err := testutils.CreateUser(testutils.User{
+		OUID: ouID,
+		Type: cbNegUserType,
+		Attributes: json.RawMessage(fmt.Sprintf(`{
+			"username": "%s",
+			"password": "%s",
+			"email": "%s@example.com"
+		}`, cbNegUsername, cbNegPassword, cbNegUsername)),
+	})
+	ts.Require().NoError(err, "Failed to create test user")
+	ts.userID = userID
+
+	flowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     "Authz Callback Negative Auth Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_authz_callback_negative",
+		Nodes: []map[string]interface{}{
+			{"id": "start", "type": "START", "onSuccess": "prompt_credentials"},
+			{
+				"id":   "prompt_credentials",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+							{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+						},
+						"action": map[string]interface{}{"ref": "action_001", "nextNode": "credentials_auth"},
+					},
+				},
+			},
+			{
+				"id":   "credentials_auth",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "CredentialsAuthExecutor",
+					"inputs": []map[string]interface{}{
+						{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+						{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+					},
+				},
+				"onSuccess":    "authorization_check",
+				"onIncomplete": "prompt_credentials",
+			},
+			{
+				"id":        "authorization_check",
+				"type":      "TASK_EXECUTION",
+				"executor":  map[string]interface{}{"name": "AuthorizationExecutor"},
+				"onSuccess": "auth_assert",
+			},
+			{
+				"id":        "auth_assert",
+				"type":      "TASK_EXECUTION",
+				"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+				"onSuccess": "end",
+			},
+			{"id": "end", "type": "END"},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create callback negative flow")
+	ts.flowID = flowID
+
+	ts.appID = ts.createCallbackNegativeApplication(flowID)
+}
+
+func (ts *CallbackNegativeTestSuite) TearDownSuite() {
+	if ts.appID != "" {
+		_ = testutils.DeleteApplication(ts.appID)
+	}
+	if ts.flowID != "" {
+		_ = testutils.DeleteFlow(ts.flowID)
+	}
+	if ts.userID != "" {
+		if err := testutils.DeleteUser(ts.userID); err != nil {
+			ts.T().Logf("Failed to delete test user: %v", err)
+		}
+	}
+	if ts.entityTypeID != "" {
+		if err := testutils.DeleteUserType(ts.entityTypeID); err != nil {
+			ts.T().Logf("Failed to delete test user type: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit: %v", err)
+		}
+	}
+}
+
+// TestCallback_MissingAuthIDIsRejected verifies the dispatcher rejects a body with no authId before
+// it looks at anything else, so an assertion can never be processed without a request to bind it to.
+func (ts *CallbackNegativeTestSuite) TestCallback_MissingAuthIDIsRejected() {
+	status, body := ts.postCallbackJSON(map[string]interface{}{"assertion": "some.assertion.value"})
+
+	ts.Require().Equal(http.StatusBadRequest, status, "a body without authId must be rejected")
+	ts.Equal("invalid_request", body["error"])
+	ts.Equal("authId is required", body["error_description"])
+}
+
+// TestCallback_MissingAssertionIsRejected verifies that an authId alone is not enough: without an
+// assertion there is nothing signed to authorize the request, so it is rejected.
+func (ts *CallbackNegativeTestSuite) TestCallback_MissingAssertionIsRejected() {
+	status, body := ts.postCallbackJSON(map[string]interface{}{"authId": "some-auth-id"})
+
+	ts.Require().Equal(http.StatusBadRequest, status, "a body without an assertion must be rejected")
+	ts.Equal("invalid_request", body["error"])
+	ts.Equal("assertion is required", body["error_description"])
+}
+
+// TestCallback_MalformedJSONBodyIsRejected verifies that a body which is not valid JSON is reported as
+// an invalid request rather than surfacing a decoder failure as a server error.
+func (ts *CallbackNegativeTestSuite) TestCallback_MalformedJSONBodyIsRejected() {
+	status, body := ts.postCallbackRaw([]byte(`{"authId": "abc", "assertion":`))
+
+	ts.Require().Equal(http.StatusBadRequest, status, "an unparseable body must be rejected")
+	ts.Equal("invalid_request", body["error"])
+	ts.NotEmpty(body["error_description"], "the rejection should describe why the body was refused")
+}
+
+// TestCallback_UnsupportedTypeIsRejected verifies that the dispatcher only routes callback types it
+// has a handler for. An unknown type falls through to the default branch instead of being silently
+// treated as the authorization_code default.
+func (ts *CallbackNegativeTestSuite) TestCallback_UnsupportedTypeIsRejected() {
+	status, body := ts.postCallbackJSON(map[string]interface{}{
+		"authId":    "some-auth-id",
+		"assertion": "some.assertion.value",
+		"type":      "urn:unsupported",
+	})
+
+	ts.Require().Equal(http.StatusBadRequest, status, "an unknown callback type must be rejected")
+	ts.Equal("invalid_request", body["error"])
+	ts.Equal("Unsupported callback type", body["error_description"])
+}
+
+// TestCallback_ForeignSignedAssertionIsRejected verifies that a well-formed assertion carrying the
+// right claims but signed with a key the server does not trust is refused. Signature verification
+// runs before the authorization request is loaded, so no authorization code is issued.
+func (ts *CallbackNegativeTestSuite) TestCallback_ForeignSignedAssertionIsRejected() {
+	authID, _ := ts.initiateAuthorization("cb_neg_foreign_state")
+
+	forged := ts.signForeignAssertion(authID)
+
+	status, body := ts.postCallbackJSON(map[string]interface{}{"authId": authID, "assertion": forged})
+	ts.Require().Equal(http.StatusOK, status, "the dispatcher answers with a redirect target: %v", body)
+
+	redirect, ok := body["redirect_uri"].(string)
+	ts.Require().True(ok, "the response should carry a redirect target, got %v", body)
+
+	query := ts.redirectQuery(redirect)
+	ts.Equal("invalid_request", query.Get("errorCode"),
+		"an assertion the server did not sign must be reported as an invalid request")
+	ts.Empty(query.Get("code"), "no authorization code may be issued for an untrusted assertion")
+}
+
+// TestCallback_ReplayedAuthIDIsRejected verifies that an authId is single-use: once it has been
+// exchanged for an authorization code, posting the same authId and assertion again is refused and
+// yields no second code.
+func (ts *CallbackNegativeTestSuite) TestCallback_ReplayedAuthIDIsRejected() {
+	authID, executionID := ts.initiateAuthorization("cb_neg_replay_state")
+
+	initialStep, err := testutils.ExecuteAuthenticationFlow(executionID, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+
+	step, err := testutils.ExecuteAuthenticationFlow(executionID,
+		map[string]string{"username": cbNegUsername, "password": cbNegPassword},
+		"action_001", initialStep.ChallengeToken)
+	ts.Require().NoError(err, "Failed to complete authentication flow")
+	ts.Require().Equal("COMPLETE", step.FlowStatus, "credential login should complete the flow")
+	ts.Require().NotEmpty(step.Assertion, "login should yield an assertion")
+
+	// First callback: the genuine exchange, which spends the authId.
+	first, err := testutils.CompleteAuthorization(authID, step.Assertion)
+	ts.Require().NoError(err, "the first callback should succeed")
+	code, err := testutils.ExtractAuthorizationCode(first.RedirectURI)
+	ts.Require().NoError(err, "the first callback should issue an authorization code")
+	ts.Require().NotEmpty(code)
+
+	// Second callback: the exact same request replayed.
+	status, body := ts.postCallbackJSON(map[string]interface{}{"authId": authID, "assertion": step.Assertion})
+	ts.Require().Equal(http.StatusOK, status, "the dispatcher answers with a redirect target: %v", body)
+
+	redirect, ok := body["redirect_uri"].(string)
+	ts.Require().True(ok, "the response should carry a redirect target, got %v", body)
+
+	query := ts.redirectQuery(redirect)
+	ts.Equal("invalid_request", query.Get("errorCode"),
+		"a spent authId must be reported as an invalid authorization request")
+	ts.Empty(query.Get("code"), "replaying a spent authId must not issue a second authorization code")
+}
+
+// initiateAuthorization starts an authorization code request and returns the authId and executionId
+// handed to the gate.
+func (ts *CallbackNegativeTestSuite) initiateAuthorization(state string) (string, string) {
+	resp, err := testutils.InitiateAuthorizationFlow(cbNegClientID, cbNegRedirectURI, "code", "openid", state)
+	ts.Require().NoError(err, "Failed to initiate authorization flow")
+	defer resp.Body.Close()
+
+	ts.Require().Equal(http.StatusFound, resp.StatusCode, "authorize should redirect to the gate")
+	authID, executionID, err := testutils.ExtractAuthData(resp.Header.Get("Location"))
+	ts.Require().NoError(err, "Failed to extract auth data from redirect")
+	return authID, executionID
+}
+
+// signForeignAssertion mints an RS256 JWT with the claim shape of a genuine authentication assertion,
+// signed by a throwaway key that is not in the server's trust set.
+func (ts *CallbackNegativeTestSuite) signForeignAssertion(authID string) string {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	ts.Require().NoError(err, "Failed to generate the foreign signing key")
+
+	now := time.Now().UTC()
+	header := map[string]interface{}{"alg": "RS256", "typ": "JWT", "kid": "foreign-key-1"}
+	claims := map[string]interface{}{
+		"sub":                      ts.userID,
+		"aud":                      cbNegClientID,
+		"iss":                      "https://foreign-issuer.example.com",
+		"iat":                      now.Unix(),
+		"nbf":                      now.Unix(),
+		"exp":                      now.Add(5 * time.Minute).Unix(),
+		"authorization_request_id": authID,
+		"auth_time":                now.Unix(),
+	}
+
+	headerJSON, err := json.Marshal(header)
+	ts.Require().NoError(err)
+	claimsJSON, err := json.Marshal(claims)
+	ts.Require().NoError(err)
+
+	signingInput := base64.RawURLEncoding.EncodeToString(headerJSON) + "." +
+		base64.RawURLEncoding.EncodeToString(claimsJSON)
+	digest := sha256.Sum256([]byte(signingInput))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, digest[:])
+	ts.Require().NoError(err, "Failed to sign the foreign assertion")
+
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature)
+}
+
+// redirectQuery parses the query parameters of a redirect target returned by the dispatcher.
+func (ts *CallbackNegativeTestSuite) redirectQuery(redirectURI string) url.Values {
+	parsed, err := url.Parse(redirectURI)
+	ts.Require().NoError(err, "Failed to parse the redirect target")
+	return parsed.Query()
+}
+
+// postCallbackJSON posts a JSON-encoded body to the flow callback endpoint.
+func (ts *CallbackNegativeTestSuite) postCallbackJSON(payload map[string]interface{}) (
+	int, map[string]interface{}) {
+	raw, err := json.Marshal(payload)
+	ts.Require().NoError(err, "Failed to marshal the callback body")
+	return ts.postCallbackRaw(raw)
+}
+
+// postCallbackRaw posts an arbitrary byte body to the flow callback endpoint and returns the status
+// along with the decoded response. A plain client is used so the request carries exactly what the
+// test sets, matching what the Gate UI would send.
+func (ts *CallbackNegativeTestSuite) postCallbackRaw(raw []byte) (int, map[string]interface{}) {
+	req, err := http.NewRequest("POST", testutils.TestServerURL+callbackPath, bytes.NewReader(raw))
+	ts.Require().NoError(err, "Failed to build the callback request")
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+	}
+	resp, err := client.Do(req)
+	ts.Require().NoError(err, "Callback request failed")
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err, "Failed to read the callback response")
+
+	var decoded map[string]interface{}
+	ts.Require().NoError(json.Unmarshal(respBody, &decoded),
+		"Failed to decode the callback response %q", string(respBody))
+	return resp.StatusCode, decoded
+}
+
+// createCallbackNegativeApplication registers the OAuth application bound to the callback flow.
+func (ts *CallbackNegativeTestSuite) createCallbackNegativeApplication(authFlowID string) string {
+	app := map[string]interface{}{
+		"name":                      "AuthzCallbackNegativeApp",
+		"description":               "Application for the flow callback dispatcher negative tests",
+		"ouId":                      ts.ouID,
+		"type":                      "browser",
+		"authFlowId":                authFlowID,
+		"isRegistrationFlowEnabled": false,
+		"allowedUserTypes":          []string{cbNegUserType},
+		"inboundAuthConfig": []map[string]interface{}{
+			{
+				"type": "oauth2",
+				"config": map[string]interface{}{
+					"clientId":                cbNegClientID,
+					"clientSecret":            cbNegClientSecret,
+					"redirectUris":            []string{cbNegRedirectURI},
+					"grantTypes":              []string{"authorization_code"},
+					"responseTypes":           []string{"code"},
+					"tokenEndpointAuthMethod": "client_secret_basic",
+					"scopes":                  []string{"openid"},
+				},
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(app)
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testutils.TestServerURL+"/applications", bytes.NewBuffer(jsonData))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		ts.T().Fatalf("Failed to create application. Status: %d, Response: %s",
+			resp.StatusCode, string(bodyBytes))
+	}
+
+	var respData map[string]interface{}
+	ts.Require().NoError(json.NewDecoder(resp.Body).Decode(&respData))
+	return respData["id"].(string)
+}

--- a/tests/integration/oauth/sso/max_age_test.go
+++ b/tests/integration/oauth/sso/max_age_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sso
+
+import "time"
+
+// The OIDC max_age parameter is enforced by the AuthAssertExecutor's assurance check, which only has
+// an authentication timestamp to compare against when an SSO checkpoint was loaded. On a first-time
+// login the subject authenticates during the execution itself, so the constraint is trivially met.
+// These tests therefore always establish a session first and then re-authorize over it, which is the
+// only path where max_age can actually bite.
+//
+// Every test builds its own cookie jar via newSessionClient so its session, and therefore its
+// authentication time, is fresh and unambiguous regardless of the order tests run in.
+
+// TestMaxAge_WithinWindowReusesSession verifies that a generous max_age leaves SSO reuse intact: the
+// session was established moments ago, so the assurance check passes and the re-authorize completes
+// on its first step without a credential prompt.
+func (ts *SSOLogoutTestSuite) TestMaxAge_WithinWindowReusesSession() {
+	client := ts.newSessionClient()
+	ts.login(client, ssoMaxAgeUsername, "max_age_within_1")
+	ts.Require().NotEmpty(ts.ssoCookieNames(client), "an SSO cookie should be set after first login")
+
+	_, executionID := ts.authorizeWithMaxAge(client, "openid", "max_age_within_2", "3600")
+	step := ts.flowExecute(client, map[string]interface{}{"executionId": executionID})
+
+	ts.Equal("COMPLETE", step.FlowStatus, "a session inside the max_age window should still satisfy the request")
+	ts.NotEmpty(step.Assertion, "the SSO-satisfied flow should yield an assertion")
+	ts.Nil(step.Error, "no assurance error should be reported")
+}
+
+// TestMaxAge_ExpiredSessionRequiresInteraction verifies that a session older than max_age fails the
+// assurance check: the flow terminates in-band with FET-1082 (interaction required) and mints no
+// assertion, so no authorization code can be issued.
+//
+// Only the flow-level outcome is asserted. Mapping this failure onto an OAuth2 authorize error is an
+// open TODO in the product, so the downstream error code is deliberately left unpinned.
+func (ts *SSOLogoutTestSuite) TestMaxAge_ExpiredSessionRequiresInteraction() {
+	client := ts.newSessionClient()
+	ts.login(client, ssoMaxAgeUsername, "max_age_expired_1")
+	ts.Require().NotEmpty(ts.ssoCookieNames(client), "an SSO cookie should be set after first login")
+
+	// Age the session past the one second window requested below.
+	time.Sleep(3 * time.Second)
+
+	_, executionID := ts.authorizeWithMaxAge(client, "openid", "max_age_expired_2", "1")
+	step := ts.flowExecute(client, map[string]interface{}{"executionId": executionID})
+
+	ts.Require().Equal("ERROR", step.FlowStatus, "a session older than max_age must not satisfy the request")
+	ts.Require().NotNil(step.Error, "the failed flow should carry a structured error")
+	ts.Equal("FET-1082", step.Error.Code, "re-authentication should be reported as interaction required")
+	ts.Empty(step.Assertion, "no authentication assertion may be minted for an expired session")
+}
+
+// TestMaxAge_MalformedValueIsIgnored verifies that a non-numeric max_age is treated as no constraint
+// rather than as a zero-second window, so SSO reuse is unaffected.
+func (ts *SSOLogoutTestSuite) TestMaxAge_MalformedValueIsIgnored() {
+	client := ts.newSessionClient()
+	ts.login(client, ssoMaxAgeUsername, "max_age_malformed_1")
+	ts.Require().NotEmpty(ts.ssoCookieNames(client), "an SSO cookie should be set after first login")
+
+	_, executionID := ts.authorizeWithMaxAge(client, "openid", "max_age_malformed_2", "abc")
+	step := ts.flowExecute(client, map[string]interface{}{"executionId": executionID})
+
+	ts.Equal("COMPLETE", step.FlowStatus, "an unparseable max_age should impose no constraint")
+	ts.NotEmpty(step.Assertion, "the SSO-satisfied flow should yield an assertion")
+	ts.Nil(step.Error, "no assurance error should be reported")
+}
+
+// TestMaxAge_NegativeValueIsIgnored verifies that a negative max_age is treated as no constraint. A
+// literal reading would reject every session, so this pins the lenient behaviour.
+func (ts *SSOLogoutTestSuite) TestMaxAge_NegativeValueIsIgnored() {
+	client := ts.newSessionClient()
+	ts.login(client, ssoMaxAgeUsername, "max_age_negative_1")
+	ts.Require().NotEmpty(ts.ssoCookieNames(client), "an SSO cookie should be set after first login")
+
+	_, executionID := ts.authorizeWithMaxAge(client, "openid", "max_age_negative_2", "-5")
+	step := ts.flowExecute(client, map[string]interface{}{"executionId": executionID})
+
+	ts.Equal("COMPLETE", step.FlowStatus, "a negative max_age should impose no constraint")
+	ts.NotEmpty(step.Assertion, "the SSO-satisfied flow should yield an assertion")
+	ts.Nil(step.Error, "no assurance error should be reported")
+}

--- a/tests/integration/oauth/sso/suite_test.go
+++ b/tests/integration/oauth/sso/suite_test.go
@@ -37,10 +37,11 @@ const (
 	postLogoutRedirectURI = "https://localhost:3000/logged-out"
 	resourceIdentifier    = "https://sso-logout.example.com"
 
-	testPassword     = "testpass123"
-	ssoReuseUsername = "sso_reuse_user"
-	logoutUsername   = "sso_logout_user"
-	ssoScopeUsername = "sso_scope_user"
+	testPassword      = "testpass123"
+	ssoReuseUsername  = "sso_reuse_user"
+	logoutUsername    = "sso_logout_user"
+	ssoScopeUsername  = "sso_scope_user"
+	ssoMaxAgeUsername = "sso_max_age_user"
 
 	// Two resource servers defining the same permission string, used by the cross-resource-server
 	// SSO regression: the scope user is granted "read" on rs-A only.
@@ -231,7 +232,7 @@ func (ts *SSOLogoutTestSuite) SetupSuite() {
 
 	ts.applicationID = ts.createApplication()
 
-	for _, username := range []string{ssoReuseUsername, logoutUsername} {
+	for _, username := range []string{ssoReuseUsername, logoutUsername, ssoMaxAgeUsername} {
 		ts.createUser(username)
 	}
 
@@ -438,12 +439,23 @@ func (ts *SSOLogoutTestSuite) ssoCookieNames(client *http.Client) []string {
 // authorize starts an authorization code flow and returns the authId and executionId issued at the
 // gate redirect.
 func (ts *SSOLogoutTestSuite) authorize(client *http.Client, scope, state string) (string, string) {
+	return ts.authorizeWithMaxAge(client, scope, state, "")
+}
+
+// authorizeWithMaxAge starts an authorization code flow, optionally carrying the OIDC max_age
+// request parameter, and returns the authId and executionId issued at the gate redirect. An empty
+// maxAge omits the parameter entirely.
+func (ts *SSOLogoutTestSuite) authorizeWithMaxAge(client *http.Client, scope, state, maxAge string) (
+	string, string) {
 	params := url.Values{}
 	params.Set("client_id", clientID)
 	params.Set("redirect_uri", redirectURI)
 	params.Set("response_type", "code")
 	params.Set("scope", scope)
 	params.Set("state", state)
+	if maxAge != "" {
+		params.Set("max_age", maxAge)
+	}
 
 	req, err := http.NewRequest("GET", testutils.TestServerURL+"/oauth2/authorize?"+params.Encode(), nil)
 	ts.Require().NoError(err)


### PR DESCRIPTION
### Purpose

`AuthAssertExecutor` runs in around thirty integration suites, so the executor itself is
well exercised, but three of its guard branches had no integration coverage at all:

- the `max_age` assurance check
- the intersection of consented permissions with authorized permissions
- the App Native branch that inlines user attributes instead of caching them

The flow callback dispatcher (`POST /oauth2/auth/callback`) was in a similar position: its
success path is exercised by every authorization code suite, but only one test covered a
failure, and only for `server_error`.

This PR adds 16 integration tests covering those gaps.

### Approach

**max_age** (`tests/integration/oauth/sso/max_age_test.go`). The assurance check only has an
authentication timestamp to compare against when an SSO checkpoint was loaded, so `max_age`
can only bite on the SSO reuse path. Each test establishes its own session with its own
cookie jar so its authentication time is unambiguous regardless of test order. The suite
helper gained an `authorizeWithMaxAge` variant; the existing `authorize` delegates to it, so
no caller changed.

The expired case asserts the flow level outcome only: `flowStatus: ERROR` with code
`FET-1082`, and no assertion minted. Mapping that failure onto an OAuth2 authorize error is
an open `TODO(sso)` in the product, so the downstream error code is deliberately not pinned.
Note that `FET-1082` arrives as HTTP 200 with `flowStatus: ERROR`, not as a 4xx, so these
tests use the suite's `flowExecute` helper rather than `ExecuteAuthenticationFlowExpectingError`,
which handles the separate engine failure channel.

**Consented permissions** (`tests/integration/flow/authentication/consent_permissions_test.go`).
`ConsentExecutor` appeared in no integration flow anywhere in the repository, so the flow
definition is derived from the executor source: a `ConsentExecutor` task node with
`onIncomplete` pointing at a prompt node whose actions carry a `CONSENT_INPUT`. The prompt
payload arrives in `additionalData.consentPrompt` and decisions are echoed back as
`consent_decisions`.

The stale consent case is deliberately constructed so that neither input set alone produces
the expected claim: consented is `{read, write}`, authorized is `{read, delete}`, and the
claim must be exactly `read`. Only the intersection yields that, so the test cannot pass by
accident if the intersection were dropped.

Each scenario uses its own user, because consent resolution skips elements that already hold
active consent and a shared user would silently move later tests onto a different branch.

**Attribute release** (`tests/integration/flow/authentication/attribute_release_test.go`).
The same application and flow are driven both app natively and through the authorize
endpoint, so the initiation path is the only variable. Both directions are asserted: the app
native assertion inlines the attributes and carries no `aci`, and the OAuth initiated
assertion carries `aci` and inlines nothing.

**Callback negatives** (`tests/integration/oauth/authz/callback_negative_test.go`). Covers a
missing `authId`, a missing assertion, a malformed body, an unsupported callback type, an
assertion signed by an untrusted key, and a replayed `authId`. The untrusted assertion test
uses a genuine, freshly issued `authId`, so signature verification is the only thing that can
reject it.

#### Known limitation

The fourth consent case, consent without an authorization step, cannot assert a non empty
verbatim consented set. A permissions consent purpose is only ever built from
`authorized_permissions`, and no API persists one, so that branch always resolves to an
empty string and is black box indistinguishable from the branch below it. The test pins what
it can genuinely prove, that consent ran and consented attributes were released, and
documents the limitation in its doc comment.

#### Deliberately out of scope

Two scenarios from the original scope are excluded because they would encode confirmed buggy
behaviour:

- acr_values step up, blocked by #4910
- `max_age` through PAR, blocked by #4912

### Related Issues
- Related to #4910, #4912

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Reliability**
  * Improved validation of OAuth authorization callbacks, including malformed, unsupported, untrusted, and replayed requests.
  * Strengthened consent-based permission handling so granted permissions stay aligned with current authorization.
  * Ensured consistent attribute release across app-native and OAuth-initiated authentication flows.
  * Improved OIDC `max_age` handling for session reuse, expired sessions, and invalid values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->