### PR TITLE
Restore the Delegated mode toggle on the agent Advanced tab

### DIFF
--- a/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/EditAdvancedSettings.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/EditAdvancedSettings.tsx
@@ -1,25 +1,20 @@
 // Copyright 2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import {SettingsCard} from '@thunderid/components';
 import {OAuth2GrantTypes} from '@thunderid/configure-applications';
 import type {OAuth2Config} from '@thunderid/configure-applications';
-import {Stack} from '@wso2/oxygen-ui';
+import {Box, FormControlLabel, Stack, Switch, Typography} from '@wso2/oxygen-ui';
 import {useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import AllowedUserTypesSection from './AllowedUserTypesSection';
 import DangerZoneSection from './DangerZoneSection';
 import OperationModesSection from './OperationModesSection';
 import OwnerSection from './OwnerSection';
-import TokenAudienceSelector, {
-  type TokenAudienceOption,
-} from '../../../../applications/components/common/TokenAudienceSelector';
 import {applyGrantTypesChange} from '../../../../applications/utils/oauth2Rules';
 import {DELEGATED_ONLY_GRANTS} from '../../../constants/delegationGrants';
 import type {Agent, AgentInboundAuthConfig, OAuthAgentConfig} from '../../../models/agent';
 import AgentDeleteDialog from '../../AgentDeleteDialog';
-
-const ON_OWN_BEHALF = 'onOwnBehalf';
-const ON_BEHALF_OF_USER = 'onBehalfOfUser';
 
 interface EditAdvancedSettingsProps {
   agent: Agent;
@@ -48,9 +43,8 @@ export default function EditAdvancedSettings({
     onFieldChange('inboundAuthConfig', updatedInboundAuth);
   };
 
-  // The "On behalf of a user" mode unlocks the delegated-only grants below and the Flows/Tokens
-  // tabs. Switching modes just flips authorization_code on/off; applyGrantTypesChange handles the
-  // dependent grants.
+  // Delegated mode unlocks the delegated-only grants below and the Flows/Tokens tabs. Toggling it
+  // just flips authorization_code on/off; applyGrantTypesChange handles the dependent grants.
   const handleDelegationToggle = (checked: boolean): void => {
     if (!oauth2Config || checked === isUnlocked) return;
     const grantTypes = oauth2Config.grantTypes ?? [];
@@ -65,55 +59,51 @@ export default function EditAdvancedSettings({
     handleOAuth2ConfigChange(updates);
   };
 
-  const mode = isUnlocked ? ON_BEHALF_OF_USER : ON_OWN_BEHALF;
-  const modeOptions: TokenAudienceOption[] = [
-    {
-      value: ON_OWN_BEHALF,
-      label: t('agents:edit.advanced.mode.onOwnBehalf.label', 'On its own behalf'),
-      description: t(
-        'agents:edit.advanced.mode.onOwnBehalf.description',
-        'This agent authenticates with its own credentials without user interaction, using Client Credentials.',
-      ),
-    },
-    {
-      value: ON_BEHALF_OF_USER,
-      label: t('agents:edit.advanced.mode.onBehalfOfUser.label', 'On behalf of a user'),
-      description: t(
-        'agents:edit.advanced.mode.onBehalfOfUser.description',
-        'This agent acts on behalf of a signed-in user, using Authorization Code with PKCE.',
-      ),
-    },
-  ];
-
-  const handleModeChange = (next: string): void => {
-    handleDelegationToggle(next === ON_BEHALF_OF_USER);
-  };
-
   return (
     <Stack spacing={3}>
-      <TokenAudienceSelector
-        title={t('agents:edit.advanced.mode.title', 'Operating Mode')}
-        options={modeOptions}
-        value={mode}
-        onChange={handleModeChange}
-        disabled={!oauth2Config || agent.isReadOnly === true}
-      >
-        <Stack spacing={3}>
-          <OwnerSection agent={agent} editedAgent={editedAgent} onFieldChange={onFieldChange} />
-          <AllowedUserTypesSection
-            agent={agent}
-            editedAgent={editedAgent}
-            oauth2Config={oauth2Config}
-            onFieldChange={onFieldChange}
+      <SettingsCard title={t('agents:edit.advanced.mode.title', 'Operating Mode')}>
+        <Box>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={isUnlocked}
+                onChange={(e) => handleDelegationToggle(e.target.checked)}
+                disabled={!oauth2Config || agent.isReadOnly === true}
+              />
+            }
+            label={
+              <Typography variant="subtitle2">
+                {t('agents:edit.advanced.delegationToggle.label', 'Delegated mode')}
+              </Typography>
+            }
           />
-          <OperationModesSection
-            oauth2Config={oauth2Config}
-            onOAuth2ConfigChange={handleOAuth2ConfigChange}
-            disabled={agent.isReadOnly}
-          />
-          {!agent.isReadOnly && <DangerZoneSection onDeleteClick={() => setDeleteDialogOpen(true)} />}
-        </Stack>
-      </TokenAudienceSelector>
+          <Typography variant="caption" color="text.secondary" sx={{display: 'block', ml: '52px'}}>
+            {isUnlocked
+              ? t(
+                  'agents:edit.advanced.mode.onBehalfOfUser.description',
+                  'This agent acts on behalf of a signed-in user, using Authorization Code with PKCE.',
+                )
+              : t(
+                  'agents:edit.advanced.mode.onOwnBehalf.description',
+                  'This agent authenticates with its own credentials without user interaction, using Client Credentials.',
+                )}
+          </Typography>
+        </Box>
+      </SettingsCard>
+
+      <OwnerSection agent={agent} editedAgent={editedAgent} onFieldChange={onFieldChange} />
+      <AllowedUserTypesSection
+        agent={agent}
+        editedAgent={editedAgent}
+        oauth2Config={oauth2Config}
+        onFieldChange={onFieldChange}
+      />
+      <OperationModesSection
+        oauth2Config={oauth2Config}
+        onOAuth2ConfigChange={handleOAuth2ConfigChange}
+        disabled={agent.isReadOnly}
+      />
+      {!agent.isReadOnly && <DangerZoneSection onDeleteClick={() => setDeleteDialogOpen(true)} />}
 
       <AgentDeleteDialog
         open={deleteDialogOpen}

--- a/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/OperationModesSection.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/OperationModesSection.tsx
@@ -143,7 +143,7 @@ export default function OperationModesSection({
             <Typography variant="caption" color="text.secondary" sx={{display: 'block', mb: 1}}>
               {t(
                 'agents:edit.advanced.oauthAccess.grantTypes.hint',
-                'The greyed-out grants unlock once you select "On behalf of a user" above.',
+                'The greyed-out grants unlock once you turn on Delegated mode at the top of this tab.',
               )}
             </Typography>
             <Select

--- a/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/__tests__/EditAdvancedSettings.test.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/__tests__/EditAdvancedSettings.test.tsx
@@ -168,8 +168,8 @@ describe('EditAdvancedSettings', () => {
     expect(mockOnFieldChange).toHaveBeenCalledWith('inboundAuthConfig', []);
   });
 
-  describe('Operating mode selector', () => {
-    it('selects "On behalf of a user" when Delegated mode is on', () => {
+  describe('Delegated mode toggle', () => {
+    it('shows the toggle checked, and the delegated description, when Delegated mode is on', () => {
       render(
         <EditAdvancedSettings
           agent={mockAgent}
@@ -179,11 +179,11 @@ describe('EditAdvancedSettings', () => {
         />,
       );
 
-      expect(screen.getByRole('tab', {name: 'On behalf of a user'})).toHaveAttribute('aria-selected', 'true');
-      expect(screen.getByRole('tab', {name: 'On its own behalf'})).toHaveAttribute('aria-selected', 'false');
+      expect(screen.getByRole('switch', {name: 'Delegated mode'})).toBeChecked();
+      expect(screen.getByText(/acts on behalf of a signed-in user/i)).toBeInTheDocument();
     });
 
-    it('selects "On its own behalf" when Delegated mode is off', () => {
+    it('shows the toggle unchecked, and the own-behalf description, when Delegated mode is off', () => {
       render(
         <EditAdvancedSettings
           agent={mockAgent}
@@ -193,8 +193,8 @@ describe('EditAdvancedSettings', () => {
         />,
       );
 
-      expect(screen.getByRole('tab', {name: 'On its own behalf'})).toHaveAttribute('aria-selected', 'true');
-      expect(screen.getByRole('tab', {name: 'On behalf of a user'})).toHaveAttribute('aria-selected', 'false');
+      expect(screen.getByRole('switch', {name: 'Delegated mode'})).not.toBeChecked();
+      expect(screen.getByText(/authenticates with its own credentials/i)).toBeInTheDocument();
     });
 
     it('turns on Delegated mode by adding authorization_code and requiring PKCE', async () => {
@@ -211,7 +211,7 @@ describe('EditAdvancedSettings', () => {
         />,
       );
 
-      await user.click(screen.getByRole('tab', {name: 'On behalf of a user'}));
+      await user.click(screen.getByRole('switch', {name: 'Delegated mode'}));
 
       expect(mockOnFieldChange).toHaveBeenCalledWith(
         'inboundAuthConfig',
@@ -246,7 +246,7 @@ describe('EditAdvancedSettings', () => {
         />,
       );
 
-      await user.click(screen.getByRole('tab', {name: 'On its own behalf'}));
+      await user.click(screen.getByRole('switch', {name: 'Delegated mode'}));
 
       expect(mockOnFieldChange).toHaveBeenCalledWith(
         'inboundAuthConfig',
@@ -259,7 +259,7 @@ describe('EditAdvancedSettings', () => {
       );
     });
 
-    it('disables the selector for read-only agents', () => {
+    it('disables the toggle for read-only agents', () => {
       render(
         <EditAdvancedSettings
           agent={{...mockAgent, isReadOnly: true}}
@@ -269,8 +269,7 @@ describe('EditAdvancedSettings', () => {
         />,
       );
 
-      expect(screen.getByRole('tab', {name: 'On behalf of a user'})).toBeDisabled();
-      expect(screen.getByRole('tab', {name: 'On its own behalf'})).toBeDisabled();
+      expect(screen.getByRole('switch', {name: 'Delegated mode'})).toBeDisabled();
     });
   });
 

--- a/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/__tests__/OperationModesSection.test.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/__tests__/OperationModesSection.test.tsx
@@ -51,7 +51,7 @@ describe('OperationModesSection', () => {
     render(<OperationModesSection oauth2Config={autonomousOnlyConfig} onOAuth2ConfigChange={vi.fn()} />);
 
     expect(
-      screen.getByText(/greyed-out grants unlock once you select "On behalf of a user" above/i),
+      screen.getByText(/greyed-out grants unlock once you turn on Delegated mode at the top of this tab/i),
     ).toBeInTheDocument();
   });
 

--- a/frontend/apps/console/src/features/agents/components/edit-agent/flows/EditFlowsSettings.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/flows/EditFlowsSettings.tsx
@@ -41,7 +41,7 @@ export default function EditFlowsSettings({
         isUnlocked={isUnlocked}
         message={t(
           'agents:edit.flows.delegationLock.message',
-          'These settings are frozen for this agent. Select "On behalf of a user" in the Advanced tab to unlock and start using them.',
+          'These settings are frozen for this agent. Turn on Delegated mode in the Advanced tab to unlock and start using them.',
         )}
       >
         <Stack spacing={3}>

--- a/frontend/apps/console/src/features/agents/components/edit-agent/tokens/EditTokensSettings.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/tokens/EditTokensSettings.tsx
@@ -92,7 +92,7 @@ export default function EditTokensSettings({
         <Alert severity="info" icon={<Lock size={20} />}>
           <Trans
             i18nKey="agents:edit.tokens.delegationLock.message"
-            defaults='This agent does not receive tokens on behalf of a user. Select "On behalf of a user" in the <advancedLink>Advanced tab</advancedLink> to configure them.'
+            defaults="This agent does not receive tokens on behalf of a user. Turn on Delegated mode in the <advancedLink>Advanced tab</advancedLink> to configure them."
             components={{
               advancedLink: <Link component="button" type="button" underline="always" onClick={onNavigateToAdvanced} />,
             }}

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1252,14 +1252,13 @@ const translations = {
     'edit.flows.allowedUserTypes.hint': 'Users of these types can sign up through this agent.',
     'edit.flows.allowedUserTypes.required': 'Select at least one user type that can sign up through this agent.',
     'edit.flows.delegationLock.message':
-      'These settings are frozen for this agent. Select "On behalf of a user" in the Advanced tab to unlock and start using them.',
+      'These settings are frozen for this agent. Turn on Delegated mode in the Advanced tab to unlock and start using them.',
 
     // Edit page - Advanced tab
     'edit.advanced.mode.title': 'Operating Mode',
-    'edit.advanced.mode.onOwnBehalf.label': 'On its own behalf',
+    'edit.advanced.delegationToggle.label': 'Delegated mode',
     'edit.advanced.mode.onOwnBehalf.description':
       'This agent authenticates with its own credentials without user interaction, using Client Credentials.',
-    'edit.advanced.mode.onBehalfOfUser.label': 'On behalf of a user',
     'edit.advanced.mode.onBehalfOfUser.description':
       'This agent acts on behalf of a signed-in user, using Authorization Code with PKCE.',
     'edit.advanced.redirectUris.title': 'Authorized redirect URIs',
@@ -1273,7 +1272,7 @@ const translations = {
     'edit.advanced.oauthAccess.description': 'Manage OAuth 2 settings for this agent.',
     'edit.advanced.oauthAccess.grantTypes.label': 'Grant Types',
     'edit.advanced.oauthAccess.grantTypes.hint':
-      'The greyed-out grants unlock once you select "On behalf of a user" above.',
+      'The greyed-out grants unlock once you turn on Delegated mode at the top of this tab.',
     'edit.advanced.security.title': 'Security',
     'edit.advanced.security.description':
       'Controls how this agent protects the authorization code exchange when a user signs in.',
@@ -1297,7 +1296,7 @@ const translations = {
     'edit.tokens.audience.user.description': 'Tokens for the agent acting on behalf of a user',
     'edit.tokens.audience.footnote': 'Attribute sets are configured independently for each audience.',
     'edit.tokens.delegationLock.message':
-      'This agent does not receive tokens on behalf of a user. Select "On behalf of a user" in the <advancedLink>Advanced tab</advancedLink> to configure them.',
+      'This agent does not receive tokens on behalf of a user. Turn on Delegated mode in the <advancedLink>Advanced tab</advancedLink> to configure them.',
     'edit.tokens.agent.attributes.title': 'Access Token Attributes',
     'edit.tokens.agent.attributes.description':
       'Extra attributes to add to the access token this agent receives for itself.',


### PR DESCRIPTION
### Purpose

The agent edit page's Advanced tab used a sidebar card selector ("On its own behalf" / "On behalf of a user") to set the agent's operating mode. This PR brings back the earlier Delegated mode toggle for that same setting, since a single on/off switch reads more clearly for a binary mode and keeps the tab in one column instead of splitting it into a selector pane and a settings pane.

Only the mode control and the copy that points at it change. The card grouping introduced by the Advanced tab redesign stays exactly as it is: Operating Mode, Owner, Allowed User Types, OAuth 2 Configuration, and Danger Zone keep their titles, order, and contents.

<img width="1919" height="977" alt="image" src="https://github.com/user-attachments/assets/58e7973f-634e-48d6-8ede-72ca126823ad" />


### Approach

- Replaced `TokenAudienceSelector` in `EditAdvancedSettings` with a `SettingsCard` titled "Operating Mode" containing a `Delegated mode` switch. Rather than the bare `FormControlLabel` the tab used before the redesign, the toggle sits in a card that matches the surrounding sections, with a caption below it describing the active mode. This also removes the two column grid, so the tab renders as a single `Stack` again.
- Left `handleDelegationToggle` untouched, so the configuration behaviour on switch is identical to the previous toggle: turning it on adds `authorization_code` and sets `pkceRequired`, with `applyGrantTypesChange` resolving the dependent grants; turning it off strips every grant in `DELEGATED_ONLY_GRANTS`.
- No changes to the show/hide rules. Redirect URIs, Allowed User Types, PKCE, and PAR already derive from whether `authorization_code` is selected, so they react to the toggle exactly as they reacted to the selector.
- Restored the old i18n keys and wording for the copy that references the mode control, since it is a toggle again: `edit.advanced.delegationToggle.label`, the grant types hint, and the Flows and Tokens lock notices. Removed the two `edit.advanced.mode.*.label` keys the selector needed, and kept `edit.advanced.mode.title` for the card title and both `edit.advanced.mode.*.description` values for the toggle caption.
- `TokenAudienceSelector` itself is unchanged. Only the agent Advanced tab stops using it; the application token settings tabs and the agent Tokens tab still do.
- Updated the unit tests to drive the switch instead of the selector tabs, and to assert that the caption tracks the toggle state.


### Related Issues
- N/A

### Related PRs
- https://github.com/thunder-id/thunderid/pull/4693

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
