### PR TITLE
Add customization instructions for SMS gateway request body

### DIFF
--- a/docs/content/guides/notifications/sms-providers.mdx
+++ b/docs/content/guides/notifications/sms-providers.mdx
@@ -70,6 +70,28 @@ Use the **SMS gateway** connection to connect <ProductName /> to any SMS gateway
    | **Content type** | No | Format of the request body sent to the gateway: `JSON` or `FORM`. Defaults to `JSON`. |
    | **HTTP headers** | No | Headers sent with every request, one name and value per row. A row is saved only when both parts are filled in. |
 
+#### Customize the Gateway Request Body
+
+<ProductName /> does not assemble a request payload for the gateway. It sends the rendered SMS template as the request body exactly as written. The template defines both the payload shape and the field names your gateway expects.
+
+To change the request body, edit the SMS template for the scenario your flow uses, such as `sms_otp.yaml` for the `OTP` scenario. Templates load at startup, so restart the server after editing one.
+
+For a connection with `contentType` set to `JSON`, write the template body as the JSON object your gateway accepts:
+
+```yaml
+body: '{"to":"{{ctx(mobile_number)}}","body":"Your verification code is {{ctx(otpCode)}}."}'
+```
+
+For `FORM`, write one `key=value` pair per line:
+
+```yaml
+body: |
+  to={{ctx(mobile_number)}}
+  message=Your verification code is {{ctx(otpCode)}}
+```
+
+Keep the template's `contentType` set to `text/plain`. With `text/html`, <ProductName /> escapes HTML characters in substituted values, which breaks JSON quoting.
+
 ## Update an SMS Provider
 
 1. Open the connection from the Connections page.

--- a/docs/versioned_docs/version-v1.0.x/guides/notifications/sms-providers.mdx
+++ b/docs/versioned_docs/version-v1.0.x/guides/notifications/sms-providers.mdx
@@ -86,6 +86,28 @@ curl -X POST https://localhost:8090/connections/sms-gateway \
 
 See the [Connections API Reference](../../../apis#tag/connections) for the full request and response shapes.
 
+#### Customize the Gateway Request Body
+
+<ProductName /> does not assemble a request payload for the gateway. It sends the rendered SMS template as the request body exactly as written. The template defines both the payload shape and the field names your gateway expects.
+
+To change the request body, edit the SMS template for the scenario your flow uses, such as `sms_otp.yaml` for the `OTP` scenario. Templates load at startup, so restart the server after editing one.
+
+For a connection with `contentType` set to `JSON`, write the template body as the JSON object your gateway accepts:
+
+```yaml
+body: '{"to":"{{ctx(mobile_number)}}","body":"Your verification code is {{ctx(otpCode)}}."}'
+```
+
+For `FORM`, write one `key=value` pair per line:
+
+```yaml
+body: |
+  to={{ctx(mobile_number)}}
+  message=Your verification code is {{ctx(otpCode)}}
+```
+
+Keep the template's `contentType` set to `text/plain`. With `text/html`, <ProductName /> escapes HTML characters in substituted values, which breaks JSON quoting.
+
 ## Update an SMS Provider
 
 1. Open the connection from the Connections page.


### PR DESCRIPTION
### Purpose

This pull request adds documentation explaining how to customize the request body sent to an SMS gateway using the SMS provider integration. The new section clarifies that the rendered SMS template fully determines the request payload, and provides concrete examples for both JSON and form-encoded requests.

---

### Approach

Documentation improvements:

* Added a "Customize the Gateway Request Body" section to both `docs/content/guides/notifications/sms-providers.mdx` and `docs/versioned_docs/version-v1.0.x/guides/notifications/sms-providers.mdx`, explaining that <ProductName /> sends the SMS template as the request body, and showing how to format templates for JSON and FORM content types. [[1]](diffhunk://#diff-80b42335fbc3aabe5fc0f6fc9f0bda891826af8f3247bdc920b768dfc46c38d0R73-R94) [[2]](diffhunk://#diff-0f5cb1d980635ac810c40786d054d3b8e90097ac3322807ceba59469bab6c943R89-R110)
* Included guidance to keep the template's `contentType` set to `text/plain` to avoid issues with HTML escaping when sending JSON payloads. [[1]](diffhunk://#diff-80b42335fbc3aabe5fc0f6fc9f0bda891826af8f3247bdc920b768dfc46c38d0R73-R94) [[2]](diffhunk://#diff-0f5cb1d980635ac810c40786d054d3b8e90097ac3322807ceba59469bab6c943R89-R110)

### Related Issues
- https://github.com/thunder-id/thunderid/issues/3421

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for customizing SMS gateway request bodies with JSON or form-encoded templates.
  * Included examples, content-type recommendations, and instructions for applying template changes.
  * Clarified that rendered SMS templates are sent unchanged and may require a service restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->