### PR TITLE
Make the npx CLI handle port conflicts and report real failures

### DIFF
--- a/tools/cli/cmd/thunderid/main.go
+++ b/tools/cli/cmd/thunderid/main.go
@@ -19,10 +19,10 @@ import (
 func main() {
 	args := os.Args[1:]
 
-	// upgrade [--direct] — explicit upgrade with optional blue/green staging.
+	// upgrade — stop the running version, install the latest, restart on the same port.
 	if len(args) > 0 && args[0] == "upgrade" {
-		verbose, direct := parseUpgradeFlags(args[1:])
-		if _, err := upgrade.Run(cli.BaseDir(), upgrade.Opts{Direct: direct, Verbose: verbose}); err != nil {
+		verbose, _ := parseFlags(args[1:])
+		if _, err := upgrade.Run(cli.BaseDir(), upgrade.Opts{Verbose: verbose}); err != nil {
 			os.Exit(1)
 		}
 		return
@@ -38,7 +38,9 @@ func main() {
 			os.Exit(1)
 		}
 		path := cli.VersionedInstallPath(activeVersion)
-		if err := sample.Run(usecase, path, verbose, sample.Options{}); err != nil {
+		if err := sample.Run(usecase, path, verbose, sample.Options{
+			ConfirmPorts: ui.ConfirmStopPortHolders,
+		}); err != nil {
 			ui.Fatal(err.Error())
 			os.Exit(1)
 		}
@@ -65,16 +67,13 @@ func printUsage() {
 
 Commands:
   (none)               Install and start %s
-  upgrade              Upgrade to the latest release (side-by-side by default)
+  upgrade              Upgrade to the latest release
   try <usecase>        Download and launch a use-case sample app
 
 Flags:
   --verbose, -v        Show detailed output
   --setup              Force re-run setup
   --help, -h           Show this help message
-
-Upgrade flags:
-  --direct             Upgrade in-place (stop current, upgrade, restart)
 `, product.Slug, product.Name)
 }
 
@@ -85,18 +84,6 @@ func parseFlags(args []string) (verbose, forceSetup bool) {
 			verbose = true
 		case "--setup":
 			forceSetup = true
-		}
-	}
-	return
-}
-
-func parseUpgradeFlags(args []string) (verbose, direct bool) {
-	for _, a := range args {
-		switch a {
-		case "--verbose", "-v":
-			verbose = true
-		case "--direct":
-			direct = true
 		}
 	}
 	return

--- a/tools/cli/internal/cli/root.go
+++ b/tools/cli/internal/cli/root.go
@@ -5,16 +5,17 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"time"
 
 	huhspinner "charm.land/huh/v2/spinner"
-	"charm.land/lipgloss/v2"
 
 	"github.com/thunder-id/thunderid/tools/cli/internal/commands/upgrade"
 	"github.com/thunder-id/thunderid/tools/cli/internal/product"
@@ -68,16 +69,27 @@ func Run(verbose, forceSetup bool) {
 		ui.Warn(nodeWarning)
 	}
 
+	activeVersion := config.ReadActiveVersion()
+
 	fmt.Print(ui.Dim("  Fetching latest " + product.Name + " release..."))
 	latestVersion, err := release.FetchLatestVersion()
-	if err != nil {
+	switch {
+	case err == nil:
+		fmt.Printf("\r\033[2K  %s Latest %s release: v%s\n\n", ui.Green("✓"), product.Name, latestVersion)
+	case activeVersion != "":
+		// The manifest is only needed to learn about newer releases. With a version
+		// already installed, an unreachable release server must not stop the CLI from
+		// starting what is on disk.
+		fmt.Print("\r\033[2K")
+		ui.Warn("Could not reach the " + product.Name + " release server, so this run cannot check for updates.\n" +
+			"Starting the installed v" + activeVersion + ".\n" + err.Error())
+		latestVersion = activeVersion
+	default:
 		fmt.Println()
-		ui.Fatal("Could not fetch latest " + product.Name + " release: " + err.Error())
+		ui.Fatal("Could not fetch latest " + product.Name + " release: " + err.Error() +
+			"\nNo local install to fall back on, so " + product.Name + " cannot start offline.")
 		os.Exit(1)
 	}
-	fmt.Printf("\r\033[2K  %s Latest %s release: v%s\n\n", ui.Green("✓"), product.Name, latestVersion)
-
-	activeVersion := config.ReadActiveVersion()
 
 	// Always start the active version; only download when there's no installed version yet.
 	runVersion := latestVersion
@@ -102,23 +114,14 @@ func Run(verbose, forceSetup bool) {
 	alreadyInstalled := activeVersion == runVersion && config.IsSetupComplete(runVersion) && installOnDisk
 	isFirstRun := !config.IsOnboardingDone(runVersion)
 
-	// If the product is already responding on port 8090 and we have a valid local install,
-	// skip setup and attach the REPL to the running instance without starting a new process.
-	// If the install is missing or state is gone, fall through to reinstall even if something
-	// is already listening on the port.
-	if !forceSetup && alreadyInstalled && isRunning() {
-		ui.Note("Already running",
-			fmt.Sprintf("%s is already running on port %d.\nAttaching to the existing instance.",
-				product.Name, health.DefaultPort))
-		replLoop(runVersion, path, nil, verbose, isFirstRun, newVersion, nodeWarning, 0, nil)
-		return
-	}
-
-	port := health.DefaultPort
+	var port int
 	var creds *setup.AdminCredentials
 
 	if alreadyInstalled && !forceSetup {
 		ui.Note("Starting "+product.Name, fmt.Sprintf("%s v%s is ready\n%s", product.Name, runVersion, path))
+		// Setup already ran on an earlier invocation, so the port it seeded into the
+		// console application's redirect URIs is fixed: no alternate port here.
+		port = resolvePort(path, false)
 	} else if activeVersion == runVersion && installOnDisk {
 		absPath, err := filepath.Abs(path)
 		if err != nil {
@@ -134,8 +137,8 @@ func Run(verbose, forceSetup bool) {
 		} else {
 			ui.Note("First-time setup", fmt.Sprintf("Setting up %s v%s\n%s", product.Name, runVersion, path))
 		}
-		port = resolvePort(path)
-		creds = runSetupPhase(runVersion, path, verbose)
+		port = resolvePort(path, true)
+		creds = runSetupPhase(runVersion, path, verbose, port)
 	} else {
 		// If the previously-active version is no longer in the manifest we'd need
 		// to download it, so fall back to the latest available version.
@@ -154,17 +157,20 @@ func Run(verbose, forceSetup bool) {
 			os.Exit(1)
 		}
 		path = absPath
-		port = resolvePort(path)
-		creds = runSetupPhase(runVersion, path, verbose)
+		port = resolvePort(path, true)
+		creds = runSetupPhase(runVersion, path, verbose, port)
 		if err := config.WriteActiveVersion(runVersion); err != nil {
 			ui.Fatal("Failed to record active version: " + err.Error())
 			os.Exit(1)
 		}
 	}
 
+	// resolvePort has already settled any conflict on this port, so anything still
+	// listening was not approved for termination: report it instead of killing it.
 	if !setup.WaitForPortFree(port, 10*time.Second) {
-		setup.KillPort(port)
-		setup.WaitForPortFree(port, 5*time.Second)
+		ui.PrintCredentialsFallback(creds)
+		ui.Fatal(fmt.Sprintf("Port %d is still in use. Stop the process using it, then run again.", port))
+		os.Exit(1)
 	}
 
 	fmt.Print(ui.Dim("\n  Starting " + product.Name + " in the background..."))
@@ -177,7 +183,19 @@ func Run(verbose, forceSetup bool) {
 		ui.Fatal("Failed to start " + product.Name + ": " + err.Error())
 		os.Exit(1)
 	}
-	fmt.Printf("\r\033[2K  %s %s started  %s\n", ui.Green("✓"), product.Name, ui.Dim("logs: "+setup.LogDir(path)))
+
+	// Launching the script only means the launcher started. Wait for the server to
+	// answer before claiming success, so a rejected bind is reported as the failure it
+	// is instead of a started product the REPL then finds missing.
+	if err := waitForStartup(path, port, verbose); err != nil {
+		fmt.Println()
+		stopStartedInstance(proc, port)
+		ui.PrintCredentialsFallback(creds)
+		ui.FatalDetail("Failed to start " + product.Name + ": " + err.Error())
+		os.Exit(1)
+	}
+	fmt.Printf("\r\033[2K  %s %s started on port %d  %s\n",
+		ui.Green("✓"), product.Name, port, ui.Dim("logs: "+setup.LogDir(path)))
 
 	replLoop(runVersion, path, proc, verbose, isFirstRun, newVersion, nodeWarning, port, creds)
 }
@@ -195,7 +213,7 @@ func replLoop(version, installPath string, proc *exec.Cmd, verbose, isFirstRun b
 		newVersion = ""
 
 		if upgradeRequested {
-			upgraded, err := upgrade.Run(BaseDir(), upgrade.Opts{Verbose: verbose})
+			upgraded, err := upgrade.Run(BaseDir(), upgrade.Opts{Verbose: verbose, Port: port})
 			if err != nil {
 				os.Exit(1)
 			}
@@ -207,7 +225,7 @@ func replLoop(version, installPath string, proc *exec.Cmd, verbose, isFirstRun b
 		}
 
 		if switchRequested {
-			switched, err := upgrade.Switch(BaseDir(), version, verbose)
+			switched, err := upgrade.Switch(BaseDir(), version, port, verbose)
 			if err != nil {
 				os.Exit(1)
 			}
@@ -222,26 +240,53 @@ func replLoop(version, installPath string, proc *exec.Cmd, verbose, isFirstRun b
 	}
 }
 
-// resolvePort checks whether the default port is available and, if not, prompts
-// the user to either kill the occupying process or switch to a free alternate port.
-func resolvePort(installPath string) int {
-	if !setup.IsPortInUse(health.DefaultPort) {
-		return health.DefaultPort
+// resolvePort returns the port ThunderID should run on.
+//
+// Without setup in this invocation the baseline is the port configured in the install's
+// deployment.yaml — the only port the server itself honors — so a previous run that moved
+// the port is carried forward instead of health-checking a port nothing listens on. A
+// conflict there is answered by freeing the port or aborting: setup seeded the console
+// application with redirect URIs carrying its port, so a run on a different port would
+// serve a console that cannot complete a login.
+//
+// With setup in this invocation (setupWillRun) the baseline is the default port, since
+// setup re-seeds those redirect URIs from the port it runs on: a re-setup returns to the
+// default instead of inheriting a port an earlier conflict moved it to. A conflict here
+// can also be answered by moving to a free port.
+//
+// Whatever holds the port is left running until the user says otherwise. A process
+// answering on it is not necessarily this install: it may be another install, another
+// version, or an unrelated app.
+func resolvePort(installPath string, setupWillRun bool) int {
+	port := setup.ServerPort(installPath)
+	if setupWillRun {
+		port = health.DefaultPort
 	}
-	altPort := setup.FindFreePort(health.DefaultPort + 1)
-	choice, selectedPort := ui.PromptPortConflict(health.DefaultPort, altPort)
+	if !setup.IsPortInUse(port) {
+		return port
+	}
+	holders := setup.PortHolders(port)
+	if !ui.Interactive() {
+		// A scripted or CI run cannot answer the prompt, so take the port as before
+		// rather than stalling, and say what is being stopped.
+		warning := fmt.Sprintf("Port %d is in use, so the process holding it is being stopped.", port)
+		if summary := holderSummary(holders); summary != "" {
+			warning += "\n" + summary
+		}
+		ui.Warn(warning)
+		freePortOrExit(port)
+		return port
+	}
+	altPort := 0
+	if setupWillRun {
+		altPort = setup.FindFreePort(port + 1)
+	}
+	choice, selectedPort := ui.PromptPortConflict(port, altPort, holders)
 	switch choice {
 	case ui.KillAndUsePort:
-		setup.KillPort(health.DefaultPort)
-		setup.WaitForPortFree(health.DefaultPort, 5*time.Second)
-		return health.DefaultPort
+		freePortOrExit(port)
+		return port
 	case ui.UseAlternatePort:
-		if err := setup.UpdateServerPort(installPath, selectedPort); err != nil {
-			ui.Warn("Could not update port configuration: " + err.Error())
-			setup.KillPort(health.DefaultPort)
-			setup.WaitForPortFree(health.DefaultPort, 5*time.Second)
-			return health.DefaultPort
-		}
 		return selectedPort
 	default: // ui.AbortSetup
 		os.Exit(0)
@@ -249,14 +294,122 @@ func resolvePort(installPath string) int {
 	}
 }
 
-// isRunning returns true if the product is already responding on the default port.
-func isRunning() bool {
-	for _, scheme := range []string{"https", "http"} {
-		if health.CheckReady(fmt.Sprintf("%s://localhost:%d", scheme, health.DefaultPort)) {
-			return true
+// freePortOrExit stops whatever holds port and gives up when it cannot: starting
+// anyway would fail on the bind with a less useful message.
+func freePortOrExit(port int) {
+	if err := setup.FreePort(port, 10*time.Second); err != nil {
+		ui.Fatal(fmt.Sprintf("Could not free port %d: %s\nStop the process manually, then run again.", port, err))
+		os.Exit(1)
+	}
+}
+
+// holderSummary lists the processes holding a port, one per line, for the warning
+// shown where the prompt with its own list cannot run.
+func holderSummary(holders []setup.PortHolder) string {
+	lines := make([]string, 0, len(holders))
+	for _, h := range holders {
+		lines = append(lines, h.String())
+	}
+	return strings.Join(lines, "\n")
+}
+
+// startupTimeout bounds how long the CLI waits for a freshly started server to answer
+// before it reports the start as failed.
+const startupTimeout = 90 * time.Second
+
+// fatalStartupPatterns are log lines that mean the server will not come up, so the CLI
+// can report the real cause immediately instead of waiting out startupTimeout.
+var fatalStartupPatterns = []string{
+	"address already in use",
+	"is already in use",
+	"panic:",
+	"failed to start",
+}
+
+// stopStartedInstance stops what this run launched after startup verification failed, so
+// the launcher and the server it spawned do not outlive the CLI and hold the port. The
+// port check before the launch proved nothing else held it, so a listener on it now is
+// this run's own.
+func stopStartedInstance(proc *exec.Cmd, port int) {
+	if proc != nil && proc.Process != nil {
+		if runtime.GOOS == "windows" {
+			proc.Process.Kill() //nolint:errcheck
+		} else {
+			proc.Process.Signal(syscall.SIGTERM) //nolint:errcheck
 		}
 	}
-	return false
+	if setup.IsPortInUse(port) {
+		_ = setup.FreePort(port, 5*time.Second)
+	}
+}
+
+// waitForStartup waits for the server to answer, showing a spinner in non-verbose mode
+// so a slow boot does not look like a hang. Verbose runs keep the raw log output.
+func waitForStartup(installPath string, port int, verbose bool) error {
+	if verbose {
+		return awaitReady(installPath, port, startupTimeout)
+	}
+	fmt.Println()
+	var readyErr error
+	if err := huhspinner.New().
+		WithTheme(ui.SpinnerTheme()).
+		Title("Waiting for " + product.Name + " to become ready...").
+		Action(func() {
+			readyErr = awaitReady(installPath, port, startupTimeout)
+		}).
+		Run(); err != nil {
+		return fmt.Errorf("interrupted while waiting for %s: %w", product.Name, err)
+	}
+	return readyErr
+}
+
+// awaitReady blocks until the server answers on port, and otherwise returns the real
+// reason it did not: the server's own log line when it names one, or a timeout that
+// still carries the tail of that log.
+func awaitReady(installPath string, port int, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if health.IsReady(port) {
+			return nil
+		}
+		if line := fatalStartupLine(installPath); line != "" {
+			return withLogTail(installPath, errors.New(line))
+		}
+		if !time.Now().Before(deadline) {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	if setup.IsPortInUse(port) {
+		return withLogTail(installPath,
+			fmt.Errorf("port %d is in use but %s never became ready", port, product.Name))
+	}
+	return withLogTail(installPath,
+		fmt.Errorf("%s did not start listening on port %d within %s", product.Name, port, timeout))
+}
+
+// fatalStartupLine returns the log line that shows the server gave up, or "".
+func fatalStartupLine(installPath string) string {
+	tail := setup.LogTail(installPath, 40)
+	for _, line := range strings.Split(tail, "\n") {
+		lower := strings.ToLower(line)
+		for _, pattern := range fatalStartupPatterns {
+			if strings.Contains(lower, pattern) {
+				return strings.TrimSpace(line)
+			}
+		}
+	}
+	return ""
+}
+
+// withLogTail appends the tail of the server log to err, so the failure box shows what
+// the server itself reported.
+func withLogTail(installPath string, err error) error {
+	tail := setup.LogTail(installPath, 8)
+	if tail == "" {
+		return fmt.Errorf("%w\n\nlogs: %s", err, setup.LatestLogFile(installPath))
+	}
+	return fmt.Errorf("%w\n\n%s\n\nlogs: %s", err, tail, setup.LatestLogFile(installPath))
 }
 
 // downloadAndInstall downloads and extracts the product into path.
@@ -338,15 +491,16 @@ func defaultAdminPassword() string {
 	return setup.GenerateAdminPassword()
 }
 
-// runSetupPhase runs setup.sh with a spinner (non-verbose) or raw output (verbose).
-// On failure in non-verbose mode, the captured stderr is printed before the error box.
+// runSetupPhase runs setup.sh on the resolved port with a spinner (non-verbose) or
+// raw output (verbose). On failure in non-verbose mode, the captured stderr is
+// printed before the error box.
 // It returns the generated admin credentials when setup produced them, or nil.
-func runSetupPhase(version, installPath string, verbose bool) *setup.AdminCredentials {
+func runSetupPhase(version, installPath string, verbose bool, port int) *setup.AdminCredentials {
 	promptCreds := collectAdminCredentials()
 	var setupCreds *setup.AdminCredentials
 	if verbose {
 		fmt.Printf("\n  Running %s setup (v%s)...\n", product.Name, version)
-		c, err := setup.RunSetup(installPath, true)
+		c, err := setup.RunSetupOnPort(installPath, true, port)
 		if err != nil {
 			ui.Fatal("Setup failed: " + err.Error())
 			os.Exit(1)
@@ -356,34 +510,17 @@ func runSetupPhase(version, installPath string, verbose bool) *setup.AdminCreden
 		fmt.Println()
 		var setupErr error
 		if err := huhspinner.New().
-			WithTheme(huhspinner.ThemeFunc(func(bool) *huhspinner.Styles {
-				return &huhspinner.Styles{
-					Spinner: lipgloss.NewStyle().Foreground(lipgloss.Color(product.ColorElectricBlue)).PaddingLeft(2),
-					Title:   lipgloss.NewStyle(),
-				}
-			})).
+			WithTheme(ui.SpinnerTheme()).
 			Title("Setting up " + product.Name + "...").
 			Action(func() {
-				setupCreds, setupErr = setup.RunSetup(installPath, false)
+				setupCreds, setupErr = setup.RunSetupOnPort(installPath, false, port)
 			}).
 			Run(); err != nil {
 			ui.Fatal("Setup interrupted: " + err.Error())
 			os.Exit(1)
 		}
 		if setupErr != nil {
-			msg := setupErr.Error()
-			if idx := strings.Index(msg, "\n\n"); idx != -1 {
-				detail := strings.TrimSpace(msg[idx+2:])
-				if detail != "" {
-					fmt.Println()
-					for _, line := range strings.Split(detail, "\n") {
-						fmt.Println("  " + line)
-					}
-					fmt.Println()
-				}
-				msg = strings.TrimSpace(msg[:idx])
-			}
-			ui.Fatal(msg)
+			ui.FatalDetail(setupErr.Error())
 			os.Exit(1)
 		}
 	}

--- a/tools/cli/internal/cli/root_internal_test.go
+++ b/tools/cli/internal/cli/root_internal_test.go
@@ -3,7 +3,53 @@
 
 package cli
 
-import "testing"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/thunder-id/thunderid/tools/cli/internal/services/health"
+	"github.com/thunder-id/thunderid/tools/cli/internal/services/setup"
+)
+
+// A re-setup re-seeds the console application's redirect URIs, so it starts from the
+// default port instead of inheriting the port an earlier conflict moved the install to.
+func TestResolvePort_SetupStartsFromTheDefaultPort(t *testing.T) {
+	if setup.IsPortInUse(health.DefaultPort) {
+		t.Skipf("port %d is in use on this machine", health.DefaultPort)
+	}
+	dir := t.TempDir()
+	writeDeploymentPort(t, dir, 8091)
+
+	if got := resolvePort(dir, true); got != health.DefaultPort {
+		t.Fatalf("expected setup to start from port %d, got %d", health.DefaultPort, got)
+	}
+}
+
+// A plain start honors the configured port: that is the port the server binds and the
+// port setup wrote into the console application's redirect URIs.
+func TestResolvePort_StartKeepsTheConfiguredPort(t *testing.T) {
+	if setup.IsPortInUse(19991) {
+		t.Skip("port 19991 is in use on this machine")
+	}
+	dir := t.TempDir()
+	writeDeploymentPort(t, dir, 19991)
+
+	if got := resolvePort(dir, false); got != 19991 {
+		t.Fatalf("expected the configured port 19991, got %d", got)
+	}
+}
+
+func writeDeploymentPort(t *testing.T, dir string, port int) {
+	t.Helper()
+	content := fmt.Sprintf("server:\n  hostname: \"localhost\"\n  port: %d\n", port)
+	if err := os.WriteFile(filepath.Join(dir, "deployment.yaml"), []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write deployment.yaml: %v", err)
+	}
+}
 
 func TestDefaultAdminPassword_UsesPresetEnv(t *testing.T) {
 	t.Setenv("THUNDERID_ADMIN_PASSWORD", "Preset#1Pass")
@@ -34,5 +80,59 @@ func TestCollectAdminCredentials_NonInteractiveReturnsNil(t *testing.T) {
 	t.Setenv("THUNDERID_ADMIN_PASSWORD", "")
 	if creds := collectAdminCredentials(); creds != nil {
 		t.Fatalf("expected nil on non-interactive stdin, got %+v", creds)
+	}
+}
+
+// writeServerLog writes body as the install's current background log.
+func writeServerLog(t *testing.T, installPath, body string) {
+	t.Helper()
+	if err := os.MkdirAll(setup.LogDir(installPath), 0o755); err != nil {
+		t.Fatalf("create log dir: %v", err)
+	}
+	if err := os.WriteFile(setup.LogFile(installPath), []byte(body), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+}
+
+func TestAwaitReady_ReportsFatalLogLineWithoutWaitingOut(t *testing.T) {
+	dir := t.TempDir()
+	writeServerLog(t, dir, "starting up\nlisten tcp 127.0.0.1:19991: bind: address already in use\n")
+
+	start := time.Now()
+	err := awaitReady(dir, 19991, 30*time.Second)
+
+	if err == nil {
+		t.Fatal("expected a failure when the log shows the bind was rejected")
+	}
+	if !strings.Contains(err.Error(), "address already in use") {
+		t.Fatalf("expected the server's own log line, got %q", err)
+	}
+	if elapsed := time.Since(start); elapsed > 10*time.Second {
+		t.Fatalf("expected a fast failure, waited %s", elapsed)
+	}
+}
+
+func TestAwaitReady_TimeoutCarriesLogTailAndPath(t *testing.T) {
+	dir := t.TempDir()
+	writeServerLog(t, dir, "line one\nstill booting\n")
+
+	err := awaitReady(dir, 19992, 100*time.Millisecond)
+
+	if err == nil {
+		t.Fatal("expected a timeout failure")
+	}
+	for _, want := range []string{"did not start listening on port 19992", "still booting", setup.LogFile(dir)} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected %q in %q", want, err)
+		}
+	}
+}
+
+func TestFatalStartupLine_IgnoresOrdinaryOutput(t *testing.T) {
+	dir := t.TempDir()
+	writeServerLog(t, dir, "server starting\nlistening on 8090\n")
+
+	if line := fatalStartupLine(dir); line != "" {
+		t.Fatalf("expected no fatal line, got %q", line)
 	}
 }

--- a/tools/cli/internal/commands/sample/procgroup_unix.go
+++ b/tools/cli/internal/commands/sample/procgroup_unix.go
@@ -1,0 +1,45 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package sample
+
+import (
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// killGracePeriod is how long the process group gets to exit after SIGTERM
+// before it is killed outright.
+const killGracePeriod = 3 * time.Second
+
+// setProcessGroup puts cmd in its own process group so every descendant npm
+// spawns can be signaled as a unit.
+func setProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killProcessGroup terminates cmd's process group, escalating to SIGKILL if the
+// group is still alive after killGracePeriod.
+func killProcessGroup(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	// setProcessGroup made the process its own group leader, so the group id is
+	// its pid. Do not look it up with Getpgid: once npm itself has exited and
+	// been reaped, that returns ESRCH even though the group still has members.
+	pgid := cmd.Process.Pid
+	if err := syscall.Kill(-pgid, syscall.SIGTERM); err != nil {
+		return
+	}
+	deadline := time.Now().Add(killGracePeriod)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(-pgid, 0); err != nil {
+			return // group is gone
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	syscall.Kill(-pgid, syscall.SIGKILL) //nolint:errcheck
+}

--- a/tools/cli/internal/commands/sample/procgroup_windows.go
+++ b/tools/cli/internal/commands/sample/procgroup_windows.go
@@ -1,0 +1,23 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package sample
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// setProcessGroup is a no-op on Windows; process trees are terminated with
+// taskkill /T instead of a process-group signal.
+func setProcessGroup(cmd *exec.Cmd) {}
+
+// killProcessGroup terminates cmd and its whole process tree.
+func killProcessGroup(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = exec.Command("taskkill", "/T", "/F", "/PID", fmt.Sprint(cmd.Process.Pid)).Run()
+}

--- a/tools/cli/internal/commands/sample/sample.go
+++ b/tools/cli/internal/commands/sample/sample.go
@@ -6,6 +6,7 @@ package sample
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -15,6 +16,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/thunder-id/thunderid/tools/cli/internal/product"
@@ -170,6 +172,7 @@ func runWithResult(
 	if !ok {
 		return nil, "", "", fmt.Errorf("unknown sample %q — available: %s", sampleName, availableList())
 	}
+	beginRun()
 
 	if err := checkNodeVersion(); err != nil {
 		return nil, "", "", err
@@ -285,6 +288,9 @@ func runWithResult(
 	// Start sample services.
 	progress("Starting " + sampleName + " services...")
 	if err := startSampleServices(sampleDir, aiEnabled); err != nil {
+		if errors.Is(err, errStoppedDuringStart) {
+			return proc, meta.sampleURL, serverURL, err
+		}
 		return proc, meta.sampleURL, serverURL, fmt.Errorf("could not start sample: %w", err)
 	}
 
@@ -616,6 +622,91 @@ func waitForServices(checks []serviceCheck, logPath string, timeout time.Duratio
 	return nil
 }
 
+// running tracks the sample's npm process so the CLI can stop it on shutdown.
+// startSampleServices writes it from RunAsync's goroutine while the REPL reads
+// it from Update, so it is mutex-guarded.
+var running struct {
+	sync.Mutex
+	cmd       *exec.Cmd
+	aiEnabled bool
+	started   bool // a sample was started at least once, so its ports are worth sweeping
+	stopping  bool // shutdown began; a sample that starts after it must not survive
+}
+
+// errStoppedDuringStart is returned when the CLI shuts down while the sample is
+// still starting; the freshly started process is terminated before it returns.
+var errStoppedDuringStart = errors.New("sample startup stopped: shutting down")
+
+// beginRun clears the shutdown latch for a newly requested sample run.
+func beginRun() {
+	running.Lock()
+	defer running.Unlock()
+	running.stopping = false
+}
+
+// trackRunning records the started sample process for StopServices. It reports
+// false when shutdown already began, in which case the caller must stop the
+// process it just started.
+func trackRunning(cmd *exec.Cmd, aiEnabled bool) bool {
+	running.Lock()
+	defer running.Unlock()
+	if running.stopping {
+		return false
+	}
+	running.cmd = cmd
+	running.aiEnabled = aiEnabled
+	running.started = true
+	return true
+}
+
+// clearRunning drops the recorded handle if it is still cmd.
+func clearRunning(cmd *exec.Cmd) {
+	running.Lock()
+	defer running.Unlock()
+	if running.cmd == cmd {
+		running.cmd = nil
+	}
+}
+
+// stopPortTimeout bounds how long StopServices waits for each sample port to be
+// released after the processes holding it are signaled.
+const stopPortTimeout = 5 * time.Second
+
+// StopServices terminates the sample services started by this CLI process. It
+// signals the sample's process group (npm plus every service it spawned) and
+// then sweeps the sample's known ports as a backstop for anything that escaped
+// the group. It is safe to call when nothing was started, and calling it twice
+// is a no-op.
+func StopServices() {
+	running.Lock()
+	cmd, aiEnabled, started := running.cmd, running.aiEnabled, running.started
+	running.cmd = nil
+	running.started = false
+	// Latch shutdown: a sample still starting on RunAsync's goroutine registers
+	// after this point, and trackRunning must refuse it rather than leave it
+	// running past the CLI's exit.
+	running.stopping = true
+	running.Unlock()
+
+	if !started {
+		return
+	}
+	killProcessGroup(cmd)
+	sweepSamplePorts(sampleServicePorts(aiEnabled))
+}
+
+// sweepSamplePorts frees the sample's ports. It is a variable so tests can stop
+// tracked processes without signaling whatever else holds those ports on the
+// developer's machine.
+var sweepSamplePorts = func(ports []int) {
+	for _, p := range ports {
+		setup.KillPort(p)
+	}
+	for _, p := range ports {
+		setup.WaitForPortFree(p, stopPortTimeout)
+	}
+}
+
 // startSampleServices launches the sample services in the background via npm.
 // For AgentID mode (aiEnabled=true) it runs `npm run dev` (all three services);
 // otherwise it runs `npm run dev:b2c` (backend + frontend only).
@@ -645,8 +736,15 @@ func startSampleServices(sampleDir string, aiEnabled bool) error {
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile // never write to os.Stderr — it corrupts the Bubble Tea display
 	cmd.Stdin = nil
+	// Own process group, so StopServices can signal npm and every service it
+	// spawns as a unit.
+	setProcessGroup(cmd)
 	if err := cmd.Start(); err != nil {
 		return err
+	}
+	if !trackRunning(cmd, aiEnabled) {
+		killProcessGroup(cmd)
+		return errStoppedDuringStart
 	}
 
 	// Detect immediate failures (e.g. missing npm script) before returning.
@@ -654,6 +752,7 @@ func startSampleServices(sampleDir string, aiEnabled bool) error {
 	go func() { done <- cmd.Wait() }()
 	select {
 	case err := <-done:
+		clearRunning(cmd)
 		tail := tailLog(logPath, 10)
 		if err != nil {
 			return fmt.Errorf("sample services failed to start:\n%s", tail)

--- a/tools/cli/internal/commands/sample/sample.go
+++ b/tools/cli/internal/commands/sample/sample.go
@@ -33,7 +33,14 @@ type Options struct {
 	EnvTarget string            // sample sub-dir to write the .env into (e.g. "ai-agent")
 	Features  []string          // feature tags, e.g. ["ai"] — drive optional services and frontend flags
 	Port      int               // port the running product is bound to; 0 = the default port
+	// ConfirmPorts is asked before the sample's dev ports are freed, so a process that
+	// is not ours is never stopped silently. Returning false cancels the run. nil means
+	// the caller already asked, which is what the REPL does before it launches.
+	ConfirmPorts func(holders []setup.PortHolder) bool
 }
+
+// errPortsCancelled is returned when the operator declines to free the sample's ports.
+var errPortsCancelled = errors.New("cancelled: the ports the sample needs are still in use")
 
 // hasFeature reports whether tag is present in opts.Features.
 func hasFeature(opts Options, tag string) bool {
@@ -214,14 +221,16 @@ func runWithResult(
 	}
 
 	// Stop the product. The REPL may have moved it off the default port after a
-	// conflict, so every port operation below follows opts.Port when it is set.
+	// conflict, so every port operation below follows opts.Port when it is set, and
+	// otherwise the configured port — the one the server actually binds.
 	port := opts.Port
 	if port <= 0 {
-		port = health.DefaultPort
+		port = setup.ServerPort(installPath)
 	}
 	progress("Stopping " + product.Name + "...")
-	setup.KillPort(port)
-	setup.WaitForPortFree(port, 15*time.Second)
+	if err := setup.FreePort(port, 15*time.Second); err != nil {
+		return nil, "", "", fmt.Errorf("could not stop %s on port %d: %w", product.Name, port, err)
+	}
 
 	// Find ThunderID root and write resource files.
 	thunderRoot, err := setup.FindThunderRoot(installPath)
@@ -277,9 +286,15 @@ func runWithResult(
 	// Free ports held by a previous run's sample services before restarting. A
 	// stale frontend still bound to 5173, for example, would otherwise push the
 	// new dev server to another port while the browser keeps hitting the old one.
+	// The holder may just as well be an unrelated app, so confirm before signaling it.
 	ports := sampleServicePorts(aiEnabled)
+	if opts.ConfirmPorts != nil {
+		if holders := setup.PortHolders(ports...); len(holders) > 0 && !opts.ConfirmPorts(holders) {
+			return proc, meta.sampleURL, serverURL, errPortsCancelled
+		}
+	}
 	for _, p := range ports {
-		setup.KillPort(p)
+		_ = setup.KillPort(p)
 	}
 	for _, p := range ports {
 		setup.WaitForPortFree(p, 10*time.Second)
@@ -558,6 +573,12 @@ func writeEnvFile(path string, env map[string]string) error {
 	return os.WriteFile(path, []byte(b.String()), 0o644)
 }
 
+// ServicePorts returns the localhost ports the sample's dev services bind for the
+// given feature set, so a caller can check them before a run starts.
+func ServicePorts(features []string) []int {
+	return sampleServicePorts(hasFeature(Options{Features: features}, "ai"))
+}
+
 // sampleServicePorts returns the localhost ports the sample's dev services bind,
 // so a previous run's orphaned processes can be freed before restarting. The
 // ai-agent (8790) only runs in AI mode.
@@ -627,18 +648,19 @@ func waitForServices(checks []serviceCheck, logPath string, timeout time.Duratio
 // it from Update, so it is mutex-guarded.
 var running struct {
 	sync.Mutex
-	cmd       *exec.Cmd
-	aiEnabled bool
-	started   bool // a sample was started at least once, so its ports are worth sweeping
-	stopping  bool // shutdown began; a sample that starts after it must not survive
+	cmd      *exec.Cmd
+	stopping bool // shutdown began; a sample that starts after it must not survive
 }
 
 // errStoppedDuringStart is returned when the CLI shuts down while the sample is
 // still starting; the freshly started process is terminated before it returns.
 var errStoppedDuringStart = errors.New("sample startup stopped: shutting down")
 
-// beginRun clears the shutdown latch for a newly requested sample run.
+// beginRun stops a sample left running by an earlier request and clears the
+// shutdown latch for the new one. Without the stop, trackRunning would replace
+// the tracked handle and the earlier process group would never be signaled.
 func beginRun() {
+	StopServices()
 	running.Lock()
 	defer running.Unlock()
 	running.stopping = false
@@ -647,15 +669,13 @@ func beginRun() {
 // trackRunning records the started sample process for StopServices. It reports
 // false when shutdown already began, in which case the caller must stop the
 // process it just started.
-func trackRunning(cmd *exec.Cmd, aiEnabled bool) bool {
+func trackRunning(cmd *exec.Cmd) bool {
 	running.Lock()
 	defer running.Unlock()
 	if running.stopping {
 		return false
 	}
 	running.cmd = cmd
-	running.aiEnabled = aiEnabled
-	running.started = true
 	return true
 }
 
@@ -668,43 +688,22 @@ func clearRunning(cmd *exec.Cmd) {
 	}
 }
 
-// stopPortTimeout bounds how long StopServices waits for each sample port to be
-// released after the processes holding it are signaled.
-const stopPortTimeout = 5 * time.Second
-
-// StopServices terminates the sample services started by this CLI process. It
-// signals the sample's process group (npm plus every service it spawned) and
-// then sweeps the sample's known ports as a backstop for anything that escaped
-// the group. It is safe to call when nothing was started, and calling it twice
-// is a no-op.
+// StopServices terminates the sample services started by this CLI process by
+// signaling the sample's process group: npm plus every service it spawned. The
+// sample's ports are deliberately not swept, because a listener still on one of
+// them after the group is gone belongs to something we did not start. It is safe
+// to call when nothing was started, and calling it twice is a no-op.
 func StopServices() {
 	running.Lock()
-	cmd, aiEnabled, started := running.cmd, running.aiEnabled, running.started
+	cmd := running.cmd
 	running.cmd = nil
-	running.started = false
 	// Latch shutdown: a sample still starting on RunAsync's goroutine registers
 	// after this point, and trackRunning must refuse it rather than leave it
 	// running past the CLI's exit.
 	running.stopping = true
 	running.Unlock()
 
-	if !started {
-		return
-	}
 	killProcessGroup(cmd)
-	sweepSamplePorts(sampleServicePorts(aiEnabled))
-}
-
-// sweepSamplePorts frees the sample's ports. It is a variable so tests can stop
-// tracked processes without signaling whatever else holds those ports on the
-// developer's machine.
-var sweepSamplePorts = func(ports []int) {
-	for _, p := range ports {
-		setup.KillPort(p)
-	}
-	for _, p := range ports {
-		setup.WaitForPortFree(p, stopPortTimeout)
-	}
 }
 
 // startSampleServices launches the sample services in the background via npm.
@@ -742,7 +741,7 @@ func startSampleServices(sampleDir string, aiEnabled bool) error {
 	if err := cmd.Start(); err != nil {
 		return err
 	}
-	if !trackRunning(cmd, aiEnabled) {
+	if !trackRunning(cmd) {
 		killProcessGroup(cmd)
 		return errStoppedDuringStart
 	}
@@ -765,13 +764,9 @@ func startSampleServices(sampleDir string, aiEnabled bool) error {
 
 // tailLog returns the last n lines of the file at path, or a fallback message.
 func tailLog(path string, n int) string {
-	data, err := os.ReadFile(path)
-	if err != nil {
+	lines := setup.TailFile(path, n)
+	if len(lines) == 0 {
 		return "(no log available)"
-	}
-	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
-	if len(lines) > n {
-		lines = lines[len(lines)-n:]
 	}
 	return strings.Join(lines, "\n")
 }

--- a/tools/cli/internal/commands/sample/stop_test.go
+++ b/tools/cli/internal/commands/sample/stop_test.go
@@ -1,0 +1,267 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package sample
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// stubPortSweep replaces the real port sweep for the duration of the test, so
+// stopping a tracked process never signals unrelated listeners on the machine.
+func stubPortSweep(t *testing.T) *[]int {
+	t.Helper()
+	orig := sweepSamplePorts
+	var swept []int
+	sweepSamplePorts = func(ports []int) { swept = append(swept, ports...) }
+	t.Cleanup(func() { sweepSamplePorts = orig })
+	return &swept
+}
+
+// resetRunning clears the tracked-process state around a test.
+func resetRunning(t *testing.T) {
+	t.Helper()
+	clear := func() {
+		running.Lock()
+		defer running.Unlock()
+		running.cmd, running.aiEnabled, running.started, running.stopping = nil, false, false, false
+	}
+	clear()
+	t.Cleanup(clear)
+}
+
+// alive reports whether pid is a running process. A terminated process stays
+// visible to Kill(pid, 0) until its parent reaps it, so the process state has to
+// be checked too: otherwise a not-yet-reaped zombie reads as alive and the test
+// races the reaper.
+func alive(pid int) bool {
+	if syscall.Kill(pid, 0) != nil {
+		return false
+	}
+	out, err := exec.Command("ps", "-o", "stat=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return false // ps exits non-zero when the pid is gone
+	}
+	state := strings.TrimSpace(string(out))
+	return state != "" && !strings.HasPrefix(state, "Z")
+}
+
+// startTree starts a shell in its own process group that spawns a grandchild
+// and writes both PIDs to files, mirroring how npm spawns the sample's services.
+func startTree(t *testing.T) (cmd *exec.Cmd, childPID, grandchildPID int) {
+	t.Helper()
+	dir := t.TempDir()
+	grandPIDFile := filepath.Join(dir, "grandchild.pid")
+	script := "sh -c 'echo $$ > " + grandPIDFile + "; sleep 300' & sleep 300"
+
+	cmd = exec.Command("sh", "-c", script)
+	setProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(func() { killProcessGroup(cmd) })
+
+	return cmd, cmd.Process.Pid, readPID(t, grandPIDFile)
+}
+
+// readPID waits for path to hold a pid and returns it.
+func readPID(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			if pid, convErr := strconv.Atoi(strings.TrimSpace(string(data))); convErr == nil && pid > 0 {
+				return pid
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("no pid reported in %s", path)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// waitGone polls until pid is gone or the deadline passes.
+func waitGone(pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !alive(pid) {
+			return true
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return !alive(pid)
+}
+
+func TestStopServicesKillsProcessTree(t *testing.T) {
+	resetRunning(t)
+	swept := stubPortSweep(t)
+
+	cmd, childPID, grandchildPID := startTree(t)
+	go cmd.Wait() //nolint:errcheck // reap the child so it does not linger as a zombie
+	if !trackRunning(cmd, false) {
+		t.Fatal("trackRunning refused a process outside shutdown")
+	}
+
+	if !alive(grandchildPID) {
+		t.Fatalf("grandchild %d not running before StopServices", grandchildPID)
+	}
+
+	StopServices()
+
+	if !waitGone(childPID, 10*time.Second) {
+		t.Errorf("child %d still alive after StopServices", childPID)
+	}
+	if !waitGone(grandchildPID, 10*time.Second) {
+		t.Errorf("grandchild %d still alive after StopServices", grandchildPID)
+	}
+	if len(*swept) != len(sampleServicePorts(false)) {
+		t.Errorf("swept ports: got %v, want %v", *swept, sampleServicePorts(false))
+	}
+
+	// A second call must be a safe no-op: nothing is tracked any more, so it
+	// must not sweep the ports again either.
+	before := len(*swept)
+	done := make(chan struct{})
+	go func() { StopServices(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second StopServices call blocked")
+	}
+	if len(*swept) != before {
+		t.Errorf("second StopServices swept ports again: %v", *swept)
+	}
+}
+
+func TestStopServicesWithoutStart(t *testing.T) {
+	resetRunning(t)
+	swept := stubPortSweep(t)
+
+	done := make(chan struct{})
+	go func() { StopServices(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("StopServices blocked with nothing started")
+	}
+	if len(*swept) != 0 {
+		t.Errorf("StopServices swept ports with nothing started: %v", *swept)
+	}
+}
+
+func TestStopServicesSweepsAIPorts(t *testing.T) {
+	resetRunning(t)
+	swept := stubPortSweep(t)
+
+	trackRunning(nil, true)
+	StopServices()
+
+	want := sampleServicePorts(true)
+	if len(*swept) != len(want) {
+		t.Fatalf("swept ports: got %v, want %v", *swept, want)
+	}
+}
+
+// TestKillProcessGroupAfterLeaderExit covers the case where npm itself has
+// exited and been reaped while its children are still running: the group id
+// must come from the recorded pid, not from Getpgid (which returns ESRCH).
+func TestKillProcessGroupAfterLeaderExit(t *testing.T) {
+	dir := t.TempDir()
+	grandPIDFile := filepath.Join(dir, "grandchild.pid")
+
+	// The leader spawns a child and exits immediately.
+	cmd := exec.Command("sh", "-c", "sh -c 'echo $$ > "+grandPIDFile+"; sleep 300' & exit 0")
+	setProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	leaderPID := cmd.Process.Pid
+	t.Cleanup(func() { killProcessGroup(cmd) })
+
+	grandchildPID := readPID(t, grandPIDFile)
+	if err := cmd.Wait(); err != nil { // reap the leader, so Getpgid(leaderPID) now fails
+		t.Fatalf("wait: %v", err)
+	}
+	if !waitGone(leaderPID, 5*time.Second) {
+		t.Fatalf("leader %d still alive after Wait", leaderPID)
+	}
+	if !alive(grandchildPID) {
+		t.Fatalf("grandchild %d already gone, nothing to test", grandchildPID)
+	}
+
+	killProcessGroup(cmd)
+
+	if !waitGone(grandchildPID, 10*time.Second) {
+		t.Errorf("grandchild %d survived killProcessGroup after the leader exited", grandchildPID)
+	}
+}
+
+// TestTrackRunningRefusedDuringShutdown covers a sample that finishes starting
+// after StopServices already ran: it must not be recorded, and the caller
+// terminates it.
+func TestTrackRunningRefusedDuringShutdown(t *testing.T) {
+	resetRunning(t)
+	stubPortSweep(t)
+
+	StopServices() // latches shutdown
+
+	cmd, childPID, grandchildPID := startTree(t)
+	go cmd.Wait() //nolint:errcheck
+	if trackRunning(cmd, false) {
+		t.Fatal("trackRunning accepted a process after shutdown began")
+	}
+	killProcessGroup(cmd) // what startSampleServices does on refusal
+
+	if !waitGone(childPID, 10*time.Second) {
+		t.Errorf("child %d still alive", childPID)
+	}
+	if !waitGone(grandchildPID, 10*time.Second) {
+		t.Errorf("grandchild %d still alive", grandchildPID)
+	}
+
+	running.Lock()
+	got := running.cmd
+	running.Unlock()
+	if got != nil {
+		t.Errorf("a refused process was recorded: %v", got)
+	}
+}
+
+func TestBeginRunClearsShutdownLatch(t *testing.T) {
+	resetRunning(t)
+	stubPortSweep(t)
+
+	StopServices()
+	beginRun()
+
+	cmd := exec.Command("true")
+	if !trackRunning(cmd, false) {
+		t.Fatal("trackRunning still refuses after beginRun")
+	}
+}
+
+func TestClearRunningOnlyClearsMatchingCmd(t *testing.T) {
+	resetRunning(t)
+
+	current := exec.Command("true")
+	trackRunning(current, false)
+	clearRunning(exec.Command("true")) // a different, older command
+
+	running.Lock()
+	got := running.cmd
+	running.Unlock()
+	if got != current {
+		t.Errorf("clearRunning dropped a handle it did not own")
+	}
+}

--- a/tools/cli/internal/commands/sample/stop_test.go
+++ b/tools/cli/internal/commands/sample/stop_test.go
@@ -6,6 +6,7 @@
 package sample
 
 import (
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,24 +17,13 @@ import (
 	"time"
 )
 
-// stubPortSweep replaces the real port sweep for the duration of the test, so
-// stopping a tracked process never signals unrelated listeners on the machine.
-func stubPortSweep(t *testing.T) *[]int {
-	t.Helper()
-	orig := sweepSamplePorts
-	var swept []int
-	sweepSamplePorts = func(ports []int) { swept = append(swept, ports...) }
-	t.Cleanup(func() { sweepSamplePorts = orig })
-	return &swept
-}
-
 // resetRunning clears the tracked-process state around a test.
 func resetRunning(t *testing.T) {
 	t.Helper()
 	clear := func() {
 		running.Lock()
 		defer running.Unlock()
-		running.cmd, running.aiEnabled, running.started, running.stopping = nil, false, false, false
+		running.cmd, running.stopping = nil, false
 	}
 	clear()
 	t.Cleanup(clear)
@@ -105,11 +95,10 @@ func waitGone(pid int, timeout time.Duration) bool {
 
 func TestStopServicesKillsProcessTree(t *testing.T) {
 	resetRunning(t)
-	swept := stubPortSweep(t)
 
 	cmd, childPID, grandchildPID := startTree(t)
 	go cmd.Wait() //nolint:errcheck // reap the child so it does not linger as a zombie
-	if !trackRunning(cmd, false) {
+	if !trackRunning(cmd) {
 		t.Fatal("trackRunning refused a process outside shutdown")
 	}
 
@@ -125,13 +114,8 @@ func TestStopServicesKillsProcessTree(t *testing.T) {
 	if !waitGone(grandchildPID, 10*time.Second) {
 		t.Errorf("grandchild %d still alive after StopServices", grandchildPID)
 	}
-	if len(*swept) != len(sampleServicePorts(false)) {
-		t.Errorf("swept ports: got %v, want %v", *swept, sampleServicePorts(false))
-	}
 
-	// A second call must be a safe no-op: nothing is tracked any more, so it
-	// must not sweep the ports again either.
-	before := len(*swept)
+	// A second call must be a safe no-op: nothing is tracked any more.
 	done := make(chan struct{})
 	go func() { StopServices(); close(done) }()
 	select {
@@ -139,14 +123,10 @@ func TestStopServicesKillsProcessTree(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("second StopServices call blocked")
 	}
-	if len(*swept) != before {
-		t.Errorf("second StopServices swept ports again: %v", *swept)
-	}
 }
 
 func TestStopServicesWithoutStart(t *testing.T) {
 	resetRunning(t)
-	swept := stubPortSweep(t)
 
 	done := make(chan struct{})
 	go func() { StopServices(); close(done) }()
@@ -155,22 +135,44 @@ func TestStopServicesWithoutStart(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("StopServices blocked with nothing started")
 	}
-	if len(*swept) != 0 {
-		t.Errorf("StopServices swept ports with nothing started: %v", *swept)
-	}
 }
 
-func TestStopServicesSweepsAIPorts(t *testing.T) {
+// Stopping the sample must not touch a listener on one of the sample's ports
+// that this CLI did not start. A regressed port sweep would signal the process
+// holding it, which here is the test binary itself.
+func TestStopServicesLeavesForeignListenerAlone(t *testing.T) {
 	resetRunning(t)
-	swept := stubPortSweep(t)
 
-	trackRunning(nil, true)
+	var ln net.Listener
+	for _, port := range sampleServicePorts(true) {
+		l, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(port))
+		if err != nil {
+			continue // in use by something else on this machine
+		}
+		ln = l
+		break
+	}
+	if ln == nil {
+		t.Skip("no sample port free to bind")
+	}
+	defer ln.Close() //nolint:errcheck
+
+	cmd, childPID, _ := startTree(t)
+	go cmd.Wait() //nolint:errcheck
+	if !trackRunning(cmd) {
+		t.Fatal("trackRunning refused a process outside shutdown")
+	}
+
 	StopServices()
 
-	want := sampleServicePorts(true)
-	if len(*swept) != len(want) {
-		t.Fatalf("swept ports: got %v, want %v", *swept, want)
+	if !waitGone(childPID, 10*time.Second) {
+		t.Errorf("child %d still alive after StopServices", childPID)
 	}
+	conn, err := net.DialTimeout("tcp", ln.Addr().String(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("listener on %s was stopped: %v", ln.Addr(), err)
+	}
+	conn.Close() //nolint:errcheck
 }
 
 // TestKillProcessGroupAfterLeaderExit covers the case where npm itself has
@@ -212,13 +214,12 @@ func TestKillProcessGroupAfterLeaderExit(t *testing.T) {
 // terminates it.
 func TestTrackRunningRefusedDuringShutdown(t *testing.T) {
 	resetRunning(t)
-	stubPortSweep(t)
 
 	StopServices() // latches shutdown
 
 	cmd, childPID, grandchildPID := startTree(t)
 	go cmd.Wait() //nolint:errcheck
-	if trackRunning(cmd, false) {
+	if trackRunning(cmd) {
 		t.Fatal("trackRunning accepted a process after shutdown began")
 	}
 	killProcessGroup(cmd) // what startSampleServices does on refusal
@@ -240,14 +241,37 @@ func TestTrackRunningRefusedDuringShutdown(t *testing.T) {
 
 func TestBeginRunClearsShutdownLatch(t *testing.T) {
 	resetRunning(t)
-	stubPortSweep(t)
 
 	StopServices()
 	beginRun()
 
 	cmd := exec.Command("true")
-	if !trackRunning(cmd, false) {
+	if !trackRunning(cmd) {
 		t.Fatal("trackRunning still refuses after beginRun")
+	}
+}
+
+// A second sample run must stop the first one: trackRunning replaces the tracked
+// handle, so an unstopped first process group could never be signaled again.
+func TestBeginRunStopsThePreviousRun(t *testing.T) {
+	resetRunning(t)
+
+	cmd, childPID, grandchildPID := startTree(t)
+	go cmd.Wait() //nolint:errcheck
+	if !trackRunning(cmd) {
+		t.Fatal("trackRunning refused a process outside shutdown")
+	}
+
+	beginRun()
+
+	if !waitGone(childPID, 10*time.Second) {
+		t.Errorf("previous child %d still alive after beginRun", childPID)
+	}
+	if !waitGone(grandchildPID, 10*time.Second) {
+		t.Errorf("previous grandchild %d still alive after beginRun", grandchildPID)
+	}
+	if !trackRunning(exec.Command("true")) {
+		t.Fatal("beginRun left the shutdown latch set")
 	}
 }
 
@@ -255,7 +279,7 @@ func TestClearRunningOnlyClearsMatchingCmd(t *testing.T) {
 	resetRunning(t)
 
 	current := exec.Command("true")
-	trackRunning(current, false)
+	trackRunning(current)
 	clearRunning(exec.Command("true")) // a different, older command
 
 	running.Lock()

--- a/tools/cli/internal/commands/upgrade/upgrade.go
+++ b/tools/cli/internal/commands/upgrade/upgrade.go
@@ -1,7 +1,7 @@
 // Copyright 2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// Package upgrade orchestrates in-place and side-by-side version upgrades.
+// Package upgrade orchestrates in-place version upgrades and version switching.
 package upgrade
 
 import (
@@ -9,13 +9,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"syscall"
 	"time"
 
 	"charm.land/huh/v2"
 	huhspinner "charm.land/huh/v2/spinner"
-	"charm.land/lipgloss/v2"
 
 	"github.com/thunder-id/thunderid/tools/cli/internal/product"
 	"github.com/thunder-id/thunderid/tools/cli/internal/services/config"
@@ -26,12 +24,24 @@ import (
 	"github.com/thunder-id/thunderid/tools/cli/internal/ui/spinner"
 )
 
-const stagingPort = 8091
+// startupTimeout bounds how long a freshly started instance gets to answer before the
+// upgrade reports the start as failed.
+const startupTimeout = 90 * time.Second
 
 // Opts controls how the upgrade runs.
 type Opts struct {
-	Direct  bool // skip side-by-side and upgrade in-place
 	Verbose bool
+	Port    int // port the running instance serves on; 0 resolves it from config
+}
+
+// resolveLivePort returns the port the running instance serves on: the port the
+// caller already resolved, else the active install's configured port (deployment.yaml
+// is what the server reads), else the default.
+func resolveLivePort(opts Opts, activeVersion string) int {
+	if opts.Port > 0 {
+		return opts.Port
+	}
+	return setup.ServerPort(config.ReadInstallPath(activeVersion))
 }
 
 // Run executes the upgrade workflow. baseDir is the parent thunderid directory (e.g. "./thunderid").
@@ -40,9 +50,11 @@ func Run(baseDir string, opts Opts) (bool, error) {
 	fmt.Print(ui.Dim("  Fetching latest " + product.Name + " release..."))
 	latestVersion, err := release.FetchLatestVersion()
 	if err != nil {
-		fmt.Println()
-		ui.Fatal("Could not fetch latest " + product.Name + " release: " + err.Error())
-		return false, err
+		// Not being able to check for updates is not a broken upgrade: report it and
+		// leave the running instance alone, so an offline /upgrade does not end the session.
+		fmt.Print("\r\033[2K")
+		ui.Warn("Could not check for a newer " + product.Name + " release.\n" + err.Error())
+		return false, nil
 	}
 	fmt.Printf("\r\033[2K  %s Latest %s release: v%s\n\n", ui.Green("✓"), product.Name, latestVersion)
 
@@ -60,39 +72,16 @@ func Run(baseDir string, opts Opts) (bool, error) {
 		)
 	}
 
-	if opts.Direct || activeVersion == "" {
-		return true, runDirect(baseDir, activeVersion, latestVersion, opts.Verbose)
-	}
+	livePort := resolveLivePort(opts, activeVersion)
 
-	var mode string
-	if err := huh.NewSelect[string]().
-		Title("How would you like to upgrade?").
-		Options(
-			huh.NewOption(
-				fmt.Sprintf("Side-by-side — run v%s on port %d while v%s keeps serving on %d (recommended)",
-					latestVersion, stagingPort, activeVersion, health.DefaultPort),
-				"side-by-side",
-			),
-			huh.NewOption(
-				fmt.Sprintf("Direct — stop v%s, upgrade, restart on port %d", activeVersion, health.DefaultPort),
-				"direct",
-			),
-		).
-		Value(&mode).
-		Run(); err != nil {
-		return false, nil // cancelled
-	}
-
-	if mode == "direct" {
-		return true, runDirect(baseDir, activeVersion, latestVersion, opts.Verbose)
-	}
-	return true, runSideBySide(baseDir, activeVersion, latestVersion, opts.Verbose)
+	return true, runUpgrade(baseDir, activeVersion, latestVersion, opts.Verbose, livePort)
 }
 
-// Switch stops the running ThunderID instance and starts the selected installed version.
-// It shows an interactive version picker and returns false if the user cancels or no other
-// versions are installed. On success it starts the new instance and runs a REPL for it.
-func Switch(baseDir, currentVersion string, verbose bool) (bool, error) {
+// Switch stops the running ThunderID instance and starts the selected installed version
+// on the same port. It shows an interactive version picker and returns false if the user
+// cancels or no other versions are installed. On success it starts the new instance and
+// runs a REPL for it.
+func Switch(baseDir, currentVersion string, livePort int, verbose bool) (bool, error) {
 	versions := config.ListInstalledVersions(currentVersion)
 	if len(versions) == 0 {
 		ui.Warn("No other installed versions found. Use /upgrade to install a new version.")
@@ -125,59 +114,82 @@ func Switch(baseDir, currentVersion string, verbose bool) (bool, error) {
 		return false, nil
 	}
 
-	fmt.Print(ui.Dim("  Stopping " + product.Name + " v" + currentVersion + "..."))
-	setup.KillPort(health.DefaultPort)
-	setup.WaitForPortFree(health.DefaultPort, 10*time.Second)
-	fmt.Printf("\r\033[2K  %s Stopped v%s\n", ui.Green("✓"), currentVersion)
-
-	if err := config.WriteActiveVersion(selected); err != nil {
-		return false, fmt.Errorf("failed to update active version: %w", err)
+	if livePort <= 0 {
+		livePort = resolveLivePort(Opts{}, currentVersion)
 	}
 
+	fmt.Print(ui.Dim("  Stopping " + product.Name + " v" + currentVersion + "..."))
+	if err := setup.FreePort(livePort, 10*time.Second); err != nil {
+		fmt.Println()
+		ui.Fatal("Could not stop v" + currentVersion + ": " + err.Error())
+		return false, err
+	}
+	fmt.Printf("\r\033[2K  %s Stopped v%s\n", ui.Green("✓"), currentVersion)
+
 	fmt.Print(ui.Dim("\n  Starting " + product.Name + " v" + selected + "..."))
-	proc, err := setup.StartBackground(installPath, verbose)
+	proc, err := setup.StartBackgroundOnPort(installPath, verbose, livePort)
 	if err != nil {
 		fmt.Println()
 		ui.Fatal("Failed to start v" + selected + ": " + err.Error())
 		return false, err
 	}
+	if err := health.WaitReady(livePort, startupTimeout); err != nil {
+		stopStartedProcess(proc, livePort)
+		fmt.Println()
+		ui.Fatal(fmt.Sprintf("Failed to start v%s: %s", selected, startupFailure(installPath, err)))
+		return false, fmt.Errorf("failed to start v%s: %w", selected, err)
+	}
+	// Persist the active version only once the new instance is up, so a failed
+	// start does not leave the recorded version pointing at nothing.
+	if err := config.WriteActiveVersion(selected); err != nil {
+		return false, fmt.Errorf("failed to update active version: %w", err)
+	}
 	fmt.Printf("\r\033[2K  %s Switched to %s v%s  %s\n", ui.Green("✓"), product.Name, selected, ui.Dim("logs: "+setup.LogDir(installPath)))
 
-	_, _, err = ui.RunREPL(selected, proc, installPath, verbose, false, "", "", 0, nil)
+	_, _, err = ui.RunREPL(selected, proc, installPath, verbose, false, "", "", livePort, nil)
 	return true, err
 }
 
-func runDirect(baseDir, activeVersion, newVersion string, verbose bool) error {
+func runUpgrade(baseDir, activeVersion, newVersion string, verbose bool, livePort int) error {
 	label := product.Name
 	if activeVersion != "" {
 		label = product.Name + " v" + activeVersion
 	}
-	fmt.Print(ui.Dim("  Stopping " + label + "..."))
-	setup.KillPort(health.DefaultPort)
-	setup.KillPort(stagingPort)
-	setup.WaitForPortFree(health.DefaultPort, 15*time.Second)
+	// With no active version there is nothing of ours to stop: the resolved live port is
+	// only the default, and whatever listens on it belongs to something else.
 	if activeVersion != "" {
+		fmt.Print(ui.Dim("  Stopping " + label + "..."))
+		if err := setup.FreePort(livePort, 15*time.Second); err != nil {
+			fmt.Println()
+			ui.Fatal("Could not stop " + label + ": " + err.Error())
+			return err
+		}
 		fmt.Printf("\r\033[2K  %s Stopped v%s\n", ui.Green("✓"), activeVersion)
-	} else {
-		fmt.Printf("\r\033[2K\n")
 	}
 
 	newPath := versionedPath(baseDir, newVersion)
 	if err := downloadVersion(newVersion, newPath, verbose); err != nil {
 		return err
 	}
-	creds, err := runSetupWithPort(newVersion, newPath, verbose, 0)
+	creds, err := runSetupWithPort(newVersion, newPath, verbose, livePort)
 	if err != nil {
 		return err
 	}
 
 	fmt.Print(ui.Dim("\n  Starting " + product.Name + " v" + newVersion + "..."))
-	proc, err := setup.StartBackground(newPath, verbose)
+	proc, err := setup.StartBackgroundOnPort(newPath, verbose, livePort)
 	if err != nil {
 		fmt.Println()
 		ui.PrintCredentialsFallback(creds)
 		ui.Fatal("Failed to start " + product.Name + ": " + err.Error())
 		return err
+	}
+	if err := health.WaitReady(livePort, startupTimeout); err != nil {
+		stopStartedProcess(proc, livePort)
+		fmt.Println()
+		ui.PrintCredentialsFallback(creds)
+		ui.Fatal(fmt.Sprintf("Failed to start %s: %s", product.Name, startupFailure(newPath, err)))
+		return fmt.Errorf("failed to start %s: %w", product.Name, err)
 	}
 
 	// Persist both the install path and the new active version only after the
@@ -192,78 +204,37 @@ func runDirect(baseDir, activeVersion, newVersion string, verbose bool) error {
 	}
 	fmt.Printf("\r\033[2K  %s %s v%s started  %s\n", ui.Green("✓"), product.Name, newVersion, ui.Dim("logs: "+setup.LogDir(newPath)))
 
-	_, _, err = ui.RunREPL(newVersion, proc, newPath, verbose, false, "", "", 0, creds)
+	_, _, err = ui.RunREPL(newVersion, proc, newPath, verbose, false, "", "", livePort, creds)
 	return err
 }
 
-func runSideBySide(baseDir, activeVersion, newVersion string, verbose bool) error {
-	newPath := versionedPath(baseDir, newVersion)
-	if err := downloadVersion(newVersion, newPath, verbose); err != nil {
-		return err
+// startupFailure describes a failed start: the readiness error, what the server itself
+// last wrote, and where the full log is. health.WaitReady only reports a timeout, so
+// without the tail the user is left with a log path to open by hand.
+func startupFailure(installPath string, err error) string {
+	logPath := setup.LatestLogFile(installPath)
+	if tail := setup.LogTail(installPath, 8); tail != "" {
+		return fmt.Sprintf("%s\n\n%s\n\nlogs: %s", err, tail, logPath)
 	}
-	creds, err := runSetupWithPort(newVersion, newPath, verbose, stagingPort)
-	if err != nil {
-		return err
-	}
-
-	fmt.Print(ui.Dim(fmt.Sprintf("\n  Starting %s v%s on port %d (staging)...", product.Name, newVersion, stagingPort)))
-	proc, err := setup.StartBackgroundOnPort(newPath, verbose, stagingPort)
-	if err != nil {
-		fmt.Println()
-		ui.PrintCredentialsFallback(creds)
-		ui.Fatal("Failed to start staging instance: " + err.Error())
-		return err
-	}
-	fmt.Printf("\r\033[2K  %s %s v%s staging on port %d\n", ui.Green("✓"), product.Name, newVersion, stagingPort)
-	fmt.Printf("  %s v%s still serving on port %d\n\n", ui.Dim("→  Current"), activeVersion, health.DefaultPort)
-	fmt.Printf("  Type %s in the REPL to cut over to v%s and restart on port %d.\n\n",
-		ui.Cyan("/cutover"), newVersion, health.DefaultPort)
-
-	cutoverRequested, err := ui.RunStagingREPL(newVersion, proc, newPath, verbose, stagingPort, creds)
-	if err != nil {
-		return err
-	}
-	if !cutoverRequested {
-		return nil // user exited without cutting over
-	}
-	return performCutover(baseDir, activeVersion, newVersion, newPath, proc, verbose, creds)
+	return fmt.Sprintf("%s\nlogs: %s", err, logPath)
 }
 
-func performCutover(baseDir, activeVersion, newVersion, newPath string, stagingProc *exec.Cmd, verbose bool, creds *setup.AdminCredentials) error {
-	fmt.Printf("\n  %s Cutting over from v%s to v%s...\n\n", ui.Cyan("→"), activeVersion, newVersion)
-
-	if stagingProc != nil && stagingProc.Process != nil {
+// stopStartedProcess stops what this command launched on port after it failed to become
+// ready. start.sh traps SIGTERM and stops the server it backgrounded, but the trap does
+// not run when the launcher is killed outright on Windows, and it does not wait for the
+// port to be released either; freeing the port makes the stop definite. Nothing else can
+// be on that port here: it was ours to start on.
+func stopStartedProcess(proc *exec.Cmd, port int) {
+	if proc != nil && proc.Process != nil {
 		if runtime.GOOS == "windows" {
-			stagingProc.Process.Kill() //nolint:errcheck
+			_ = proc.Process.Kill()
 		} else {
-			stagingProc.Process.Signal(syscall.SIGTERM) //nolint:errcheck
+			_ = proc.Process.Signal(syscall.SIGTERM)
 		}
-		time.Sleep(time.Second)
 	}
-
-	fmt.Print(ui.Dim("  Stopping v" + activeVersion + "..."))
-	setup.KillPort(health.DefaultPort)
-	setup.WaitForPortFree(health.DefaultPort, 15*time.Second)
-	fmt.Printf("\r\033[2K  %s v%s stopped\n", ui.Green("✓"), activeVersion)
-
-	fmt.Print(ui.Dim(fmt.Sprintf("  Starting %s v%s on port %d...", product.Name, newVersion, health.DefaultPort)))
-	proc, err := setup.StartBackground(newPath, verbose)
-	if err != nil {
-		fmt.Println()
-		return fmt.Errorf("failed to start %s: %w", product.Name, err)
+	if setup.IsPortInUse(port) {
+		_ = setup.FreePort(port, 5*time.Second)
 	}
-
-	// Persist state only after the new instance is confirmed running.
-	if err := config.WriteInstallPath(newVersion, newPath); err != nil {
-		return fmt.Errorf("failed to persist install path: %w", err)
-	}
-	if err := config.WriteActiveVersion(newVersion); err != nil {
-		return fmt.Errorf("failed to update active version: %w", err)
-	}
-	fmt.Printf("\r\033[2K  %s %s v%s is now live on port %d\n", ui.Green("✓"), product.Name, newVersion, health.DefaultPort)
-
-	_, _, err = ui.RunREPL(newVersion, proc, newPath, verbose, false, "", "", 0, creds)
-	return err
 }
 
 func downloadVersion(version, destDir string, verbose bool) error {
@@ -311,12 +282,7 @@ func runSetupWithPort(version, installPath string, verbose bool, port int) (*set
 		fmt.Println()
 		var setupErr error
 		if err := huhspinner.New().
-			WithTheme(huhspinner.ThemeFunc(func(bool) *huhspinner.Styles {
-				return &huhspinner.Styles{
-					Spinner: lipgloss.NewStyle().Foreground(lipgloss.Color(product.ColorElectricBlue)).PaddingLeft(2),
-					Title:   lipgloss.NewStyle(),
-				}
-			})).
+			WithTheme(ui.SpinnerTheme()).
 			Title("Setting up " + product.Name + " v" + version + "...").
 			Action(func() {
 				creds, setupErr = setup.RunSetupOnPort(installPath, false, port)
@@ -326,19 +292,7 @@ func runSetupWithPort(version, installPath string, verbose bool, port int) (*set
 			return nil, err
 		}
 		if setupErr != nil {
-			msg := setupErr.Error()
-			if idx := strings.Index(msg, "\n\n"); idx != -1 {
-				detail := strings.TrimSpace(msg[idx+2:])
-				if detail != "" {
-					fmt.Println()
-					for _, line := range strings.Split(detail, "\n") {
-						fmt.Println("  " + line)
-					}
-					fmt.Println()
-				}
-				msg = strings.TrimSpace(msg[:idx])
-			}
-			ui.Fatal(msg)
+			ui.FatalDetail(setupErr.Error())
 			return nil, setupErr
 		}
 	}

--- a/tools/cli/internal/commands/upgrade/upgrade_internal_test.go
+++ b/tools/cli/internal/commands/upgrade/upgrade_internal_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package upgrade
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/thunder-id/thunderid/tools/cli/internal/services/config"
+	"github.com/thunder-id/thunderid/tools/cli/internal/services/health"
+)
+
+func TestResolveLivePort_PrefersCallerPort(t *testing.T) {
+	assert.Equal(t, 8095, resolveLivePort(Opts{Port: 8095}, "1.0.0"))
+}
+
+// installOnPort records an install whose deployment.yaml serves on port, with the state
+// file redirected to a temp home so the developer's own install is not read.
+func installOnPort(t *testing.T, version string, port int) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	installPath := filepath.Join(t.TempDir(), "v"+version)
+	require.NoError(t, os.MkdirAll(installPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(installPath, "deployment.yaml"),
+		[]byte("server:\n  hostname: \"localhost\"\n  port: "+strconv.Itoa(port)+"\n"), 0o644))
+	require.NoError(t, config.WriteInstallPath(version, installPath))
+}
+
+// With no caller-resolved port the upgrade has to stop and restart on the port the
+// install is configured for: stopping the default port would leave the running
+// instance up and take an unrelated listener down instead.
+func TestResolveLivePort_FallsBackToConfiguredPort(t *testing.T) {
+	installOnPort(t, "1.0.0", 9443)
+	assert.Equal(t, 9443, resolveLivePort(Opts{}, "1.0.0"))
+}
+
+// Nothing recorded for the version means nothing to read a port from, so the default
+// is all that is left.
+func TestResolveLivePort_FallsBackToDefaultWithoutAnInstall(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	assert.Equal(t, health.DefaultPort, resolveLivePort(Opts{}, "1.0.0"))
+}
+
+// health.WaitReady only reports a timeout, so the failure message has to carry what the
+// server itself wrote or the user has nothing to act on.
+func TestStartupFailure_IncludesLogTailAndPath(t *testing.T) {
+	installPath := t.TempDir()
+	logDir := filepath.Join(installPath, "logs")
+	require.NoError(t, os.MkdirAll(logDir, 0o755))
+	logPath := filepath.Join(logDir, "thunderid.log")
+	require.NoError(t, os.WriteFile(logPath,
+		[]byte("starting\nfailed to bind: address already in use\n"), 0o644))
+
+	msg := startupFailure(installPath, errors.New("did not become ready"))
+
+	assert.Contains(t, msg, "did not become ready")
+	assert.Contains(t, msg, "address already in use", "the server's own reason must be shown")
+	assert.Contains(t, msg, logPath, "the full log path must still be shown")
+}
+
+func TestStartupFailure_WithoutALogStillPointsAtTheLogPath(t *testing.T) {
+	msg := startupFailure(t.TempDir(), errors.New("did not become ready"))
+
+	assert.Contains(t, msg, "did not become ready")
+	assert.Contains(t, msg, "logs:")
+}

--- a/tools/cli/internal/services/health/health.go
+++ b/tools/cli/internal/services/health/health.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/thunder-id/thunderid/tools/cli/internal/product"
 )
 
 // DefaultPort is the port ThunderID listens on by default.
@@ -38,6 +40,25 @@ func ResolveBaseURL(port int, timeout time.Duration) (string, bool) {
 		time.Sleep(500 * time.Millisecond)
 	}
 	return "", false
+}
+
+// IsReady reports whether ThunderID answers on the given port over either scheme.
+// It is the one-shot form of ResolveBaseURL, for callers that only need a yes or no.
+func IsReady(port int) bool {
+	for _, scheme := range []string{"https", "http"} {
+		if CheckReady(fmt.Sprintf("%s://localhost:%d", scheme, port)) {
+			return true
+		}
+	}
+	return false
+}
+
+// WaitReady waits until ThunderID answers on port or timeout expires.
+func WaitReady(port int, timeout time.Duration) error {
+	if _, ok := ResolveBaseURL(port, timeout); !ok {
+		return fmt.Errorf("%s did not become ready on port %d within %s", product.Name, port, timeout)
+	}
+	return nil
 }
 
 // CheckReady returns true if ThunderID is responding on the readiness endpoint.

--- a/tools/cli/internal/services/release/release.go
+++ b/tools/cli/internal/services/release/release.go
@@ -7,6 +7,7 @@ package release
 import (
 	"archive/zip"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -78,8 +79,16 @@ func fetchJSON(url string, dest any) error {
 }
 
 func fetchReleasesData() (*releasesData, error) {
+	return fetchReleasesDataFrom(product.ReleasesURL, product.GitHubAPI)
+}
+
+// fetchReleasesDataFrom reads releases metadata from primaryURL and falls back to the
+// GitHub release API at fallbackURL. The URLs are parameters so tests can point both at
+// a local server.
+func fetchReleasesDataFrom(primaryURL, fallbackURL string) (*releasesData, error) {
 	var data releasesData
-	if err := fetchJSON(product.ReleasesURL, &data); err == nil {
+	primaryErr := fetchJSON(primaryURL, &data)
+	if primaryErr == nil {
 		return &data, nil
 	}
 
@@ -91,8 +100,10 @@ func fetchReleasesData() (*releasesData, error) {
 			BrowserDownloadURL string `json:"browser_download_url"`
 		} `json:"assets"`
 	}
-	if err := fetchJSON(product.GitHubAPI, &gh); err != nil {
-		return nil, err
+	if err := fetchJSON(fallbackURL, &gh); err != nil {
+		// Report both hosts: dropping the primary error blames the fallback for a
+		// failure that started somewhere else.
+		return nil, fmt.Errorf("%w; fallback %w", primaryErr, err)
 	}
 	if gh.TagName == "" {
 		return nil, fmt.Errorf("tag_name missing from GitHub release response")
@@ -157,7 +168,34 @@ func Download(version, destDir string, onProgress ProgressFunc) error {
 	if onProgress != nil {
 		onProgress(-1, "Extracting...")
 	}
-	return extractZip(zipPath, destDir)
+	return extractInto(zipPath, destDir)
+}
+
+// extractInto extracts zipPath into destDir and removes a half-written destDir when the
+// extraction fails, so a failed install does not leave a broken tree behind. Ownership
+// comes from creating destDir here: anything that already exists at that path, including
+// a dangling symlink or a directory another process created first, is not this run's to
+// delete.
+func extractInto(zipPath, destDir string) error {
+	if err := os.MkdirAll(filepath.Dir(destDir), 0o755); err != nil {
+		return err
+	}
+	createdByThisRun := false
+	switch err := os.Mkdir(destDir, 0o755); {
+	case err == nil:
+		createdByThisRun = true
+	case errors.Is(err, os.ErrExist):
+		// Left in place; extractZip writes into it.
+	default:
+		return err
+	}
+	if err := extractZip(zipPath, destDir); err != nil {
+		if createdByThisRun {
+			_ = os.RemoveAll(destDir)
+		}
+		return err
+	}
+	return nil
 }
 
 // SampleAssetName returns the ZIP name for a sample app.
@@ -201,7 +239,7 @@ func DownloadSample(sampleName, version, destDir string, onProgress ProgressFunc
 	if onProgress != nil {
 		onProgress(-1, "Extracting...")
 	}
-	return extractZip(zipPath, destDir)
+	return extractInto(zipPath, destDir)
 }
 
 func findAsset(data *releasesData, version, assetName string) *releaseAsset {
@@ -239,11 +277,14 @@ func downloadFile(url, destPath string, onProgress func(received, total int64)) 
 		return fmt.Errorf("HTTP %d downloading %s", resp.StatusCode, url)
 	}
 
-	f, err := os.Create(destPath)
+	f, err := os.CreateTemp(filepath.Dir(destPath), "."+filepath.Base(destPath)+"-*")
 	if err != nil {
 		return err
 	}
-	defer func() { _ = f.Close() }()
+	defer func() {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+	}()
 
 	total := resp.ContentLength
 	var received int64
@@ -266,7 +307,10 @@ func downloadFile(url, destPath string, onProgress func(received, total int64)) 
 			return err
 		}
 	}
-	return nil
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return os.Rename(f.Name(), destPath)
 }
 
 func extractZip(zipPath, destDir string) error {

--- a/tools/cli/internal/services/release/release_internal_test.go
+++ b/tools/cli/internal/services/release/release_internal_test.go
@@ -1,0 +1,237 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package release
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A download cut off mid-transfer used to leave its partial file on disk — tens of
+// megabytes nothing ever cleans up, and a truncated artifact a later run could pick up.
+func TestDownloadFile_RemovesTruncatedFile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", "1024")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("partial"))
+		// Drop the connection so the client sees a truncated body.
+		conn, _, err := http.NewResponseController(w).Hijack()
+		if err == nil {
+			_ = conn.Close()
+		}
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "release.zip")
+	err := downloadFile(srv.URL, dest, nil)
+
+	require.Error(t, err, "a truncated body must fail the download")
+	_, statErr := os.Stat(dest)
+	assert.True(t, os.IsNotExist(statErr), "the partial download should have been removed")
+	assert.Empty(t, dirEntryNames(t, filepath.Dir(dest)), "the temporary download file should be gone too")
+}
+
+// dirEntryNames lists dir so a test can assert nothing was left behind.
+func dirEntryNames(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return names
+}
+
+func TestDownloadFile_PreservesExistingFileAfterFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", "1024")
+		_, _ = w.Write([]byte("partial"))
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "release.zip")
+	require.NoError(t, os.WriteFile(dest, []byte("existing"), 0o644))
+
+	require.Error(t, downloadFile(srv.URL, dest, nil))
+	data, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	assert.Equal(t, "existing", string(data))
+	assert.Equal(t, []string{"release.zip"}, dirEntryNames(t, filepath.Dir(dest)),
+		"only the pre-existing file should remain")
+}
+
+func TestDownloadFile_KeepsCompleteFile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("complete"))
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "release.zip")
+	require.NoError(t, downloadFile(srv.URL, dest, nil))
+
+	data, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	assert.Equal(t, "complete", string(data))
+}
+
+// unreachableURL returns the address of a server that is no longer listening, so a
+// request to it fails at dial time without touching the network.
+func unreachableURL(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+	return url
+}
+
+func jsonServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// The primary release host being down must not stop a startup: the GitHub API carries the
+// same metadata under different field names.
+func TestFetchReleasesData_FallsBackWhenPrimaryUnreachable(t *testing.T) {
+	fallback := jsonServer(t, `{
+		"tag_name": "v1.2.3",
+		"assets": [{"name": "thunderid-1.2.3-linux-x64.zip", "browser_download_url": "https://example.test/a.zip"}]
+	}`)
+
+	data, err := fetchReleasesDataFrom(unreachableURL(t), fallback.URL)
+	require.NoError(t, err)
+
+	assert.Equal(t, "v1.2.3", data.LatestRelease.TagName)
+	assert.True(t, data.LatestRelease.IsLatest)
+	require.Len(t, data.LatestRelease.Assets, 1)
+	assert.Equal(t, "thunderid-1.2.3-linux-x64.zip", data.LatestRelease.Assets[0].Name)
+	assert.Equal(t, "https://example.test/a.zip", data.LatestRelease.Assets[0].DownloadURL,
+		"browser_download_url must be mapped onto the asset download URL")
+	assert.Equal(t, []releaseEntry{data.LatestRelease}, data.Releases,
+		"the fallback release must also be listed as a release")
+}
+
+// An HTTP error from the primary host is a failure like any other and must fall back too.
+func TestFetchReleasesData_FallsBackOnPrimaryHTTPError(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer primary.Close()
+	fallback := jsonServer(t, `{"tag_name": "v9.9.9"}`)
+
+	data, err := fetchReleasesDataFrom(primary.URL, fallback.URL)
+	require.NoError(t, err)
+	assert.Equal(t, "v9.9.9", data.LatestRelease.TagName)
+}
+
+func TestFetchReleasesData_UsesPrimaryWhenItWorks(t *testing.T) {
+	primary := jsonServer(t, `{"latestRelease": {"tagName": "v2.0.0", "isLatest": true}}`)
+	fallbackHits := 0
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fallbackHits++
+		_, _ = w.Write([]byte(`{"tag_name": "v0.0.0"}`))
+	}))
+	defer fallback.Close()
+
+	data, err := fetchReleasesDataFrom(primary.URL, fallback.URL)
+	require.NoError(t, err)
+	assert.Equal(t, "v2.0.0", data.LatestRelease.TagName)
+	assert.Zero(t, fallbackHits, "the fallback must not be hit when the primary answers")
+}
+
+// Blaming only the fallback hides which host actually started the failure, so both errors
+// have to survive into the message.
+func TestFetchReleasesData_ReportsBothHostsWhenAllFail(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer primary.Close()
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer fallback.Close()
+
+	data, err := fetchReleasesDataFrom(primary.URL, fallback.URL)
+
+	require.Error(t, err)
+	assert.Nil(t, data)
+	msg := err.Error()
+	assert.Contains(t, msg, primary.URL, "the primary host must be named")
+	assert.Contains(t, msg, fallback.URL, "the fallback host must be named")
+	assert.Contains(t, msg, "500", "the primary status must survive")
+	assert.Contains(t, msg, "403", "the fallback status must survive")
+}
+
+// A fallback that answers but omits the tag is a bad response, not a working one.
+func TestFetchReleasesData_RejectsFallbackWithoutTag(t *testing.T) {
+	fallback := jsonServer(t, `{"assets": []}`)
+
+	data, err := fetchReleasesDataFrom(unreachableURL(t), fallback.URL)
+	require.Error(t, err)
+	assert.Nil(t, data)
+	assert.Contains(t, err.Error(), "tag_name")
+}
+
+// A failed extraction used to leave a half-written install directory behind.
+func TestExtractInto_RemovesDirectoryItCreated(t *testing.T) {
+	badZip := filepath.Join(t.TempDir(), "broken.zip")
+	require.NoError(t, os.WriteFile(badZip, []byte("not a zip"), 0o644))
+	dest := filepath.Join(t.TempDir(), "v1.0.0")
+
+	require.Error(t, extractInto(badZip, dest))
+
+	_, statErr := os.Stat(dest)
+	assert.True(t, os.IsNotExist(statErr), "the half-written install should have been removed")
+}
+
+// os.Stat reports a dangling symlink as missing, which used to make this run
+// claim ownership of it and delete it on failure.
+func TestExtractInto_KeepsDanglingSymlink(t *testing.T) {
+	badZip := filepath.Join(t.TempDir(), "broken.zip")
+	require.NoError(t, os.WriteFile(badZip, []byte("not a zip"), 0o644))
+	dest := filepath.Join(t.TempDir(), "v1.0.0")
+
+	// Point at an existing directory first, so Windows makes a directory symlink,
+	// then remove the target to leave the link dangling.
+	target := filepath.Join(t.TempDir(), "target")
+	require.NoError(t, os.Mkdir(target, 0o755))
+	if err := os.Symlink(target, dest); err != nil {
+		t.Skipf("symlinks unavailable on this machine: %v", err) // Windows without the privilege
+	}
+	require.NoError(t, os.RemoveAll(target))
+
+	require.Error(t, extractInto(badZip, dest))
+
+	info, err := os.Lstat(dest)
+	require.NoError(t, err, "a pre-existing symlink must be left alone")
+	assert.Equal(t, os.ModeSymlink, info.Mode()&os.ModeSymlink, "it must still be the symlink")
+	link, err := os.Readlink(dest)
+	require.NoError(t, err)
+	assert.Equal(t, target, link, "it must still point where it did")
+}
+
+// A directory that was already there is not this run's to delete.
+func TestExtractInto_KeepsPreexistingDirectory(t *testing.T) {
+	badZip := filepath.Join(t.TempDir(), "broken.zip")
+	require.NoError(t, os.WriteFile(badZip, []byte("not a zip"), 0o644))
+	dest := t.TempDir()
+	keep := filepath.Join(dest, "keep.txt")
+	require.NoError(t, os.WriteFile(keep, []byte("x"), 0o644))
+
+	require.Error(t, extractInto(badZip, dest))
+
+	_, err := os.Stat(keep)
+	assert.NoError(t, err, "a pre-existing install must be left alone")
+}

--- a/tools/cli/internal/services/setup/setup.go
+++ b/tools/cli/internal/services/setup/setup.go
@@ -7,6 +7,8 @@ package setup
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding/csv"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -21,6 +23,7 @@ import (
 	"time"
 
 	"github.com/thunder-id/thunderid/tools/cli/internal/product"
+	"github.com/thunder-id/thunderid/tools/cli/internal/services/health"
 )
 
 // LogDir returns the directory where ThunderID background logs are written
@@ -110,11 +113,18 @@ func RunSetup(installPath string, verbose bool) (*AdminCredentials, error) {
 }
 
 // RunSetupOnPort executes the platform setup script with an optional custom port.
-// Pass port=0 to use the default. When the setup run generated an admin password,
-// the parsed credentials are returned; otherwise the returned credentials are nil.
+// Pass port=0 to keep the configured one. When the setup run generated an admin
+// password, the parsed credentials are returned; otherwise the returned credentials
+// are nil.
 func RunSetupOnPort(installPath string, verbose bool, port int) (*AdminCredentials, error) {
 	root, err := FindThunderRoot(installPath)
 	if err != nil {
+		return nil, err
+	}
+
+	// setup.sh derives the base URL from deployment.yaml, so the port has to be
+	// written there before it runs: there is no environment override.
+	if err := EnsureServerPort(installPath, port); err != nil {
 		return nil, err
 	}
 
@@ -133,14 +143,10 @@ func RunSetupOnPort(installPath string, verbose bool, port int) (*AdminCredentia
 	// provided, so they generate a random password rather than falling back to a
 	// fixed, predictable one.
 	adminPass := os.Getenv("THUNDERID_ADMIN_PASSWORD")
-	env := append(os.Environ(),
+	cmd.Env = append(os.Environ(),
 		"ADMIN_USERNAME="+adminUser,
 		"ADMIN_PASSWORD="+adminPass,
 	)
-	if port > 0 {
-		env = append(env, fmt.Sprintf("THUNDERID_PORT=%d", port))
-	}
-	cmd.Env = env
 	cmd.Stdin = nil // no stdin → prevents any remaining interactive prompts
 
 	if verbose {
@@ -234,11 +240,17 @@ func StartBackground(installPath string, verbose bool) (*exec.Cmd, error) {
 }
 
 // StartBackgroundOnPort starts ThunderID detached from the terminal with an optional custom port.
-// Pass port=0 to use the default. Logs go to the state directory.
+// Pass port=0 to keep the configured one. Logs go to the state directory.
 // The returned *exec.Cmd has already been started; call cmd.Process.Kill() to stop it.
 func StartBackgroundOnPort(installPath string, verbose bool, port int) (*exec.Cmd, error) {
 	root, err := FindThunderRoot(installPath)
 	if err != nil {
+		return nil, err
+	}
+
+	// The server binds the port from deployment.yaml; BACKEND_PORT below only drives
+	// start.sh's pre-flight check. Write the port first so the two agree.
+	if err := EnsureServerPort(installPath, port); err != nil {
 		return nil, err
 	}
 
@@ -372,19 +384,109 @@ func FindFreePort(start int) int {
 	return start
 }
 
-// UpdateServerPort rewrites the server.port value in the deployment.yaml found under installPath.
-func UpdateServerPort(installPath string, port int) error {
+// deploymentConfigPath returns the deployment.yaml the install reads its
+// configuration from, or "" when none is present.
+func deploymentConfigPath(installPath string) string {
 	candidates := []string{
 		filepath.Join(installPath, "deployment.yaml"),
 		filepath.Join(installPath, "backend", "cmd", "server", "deployment.yaml"),
 	}
-	var configPath string
 	for _, p := range candidates {
 		if _, err := os.Stat(p); err == nil {
-			configPath = p
-			break
+			return p
 		}
 	}
+	return ""
+}
+
+// serverPortLineIndex returns the index of the server.port line in lines, or -1.
+// Only a direct child of server: counts: a port: nested one level deeper belongs
+// to another mapping and is a different setting.
+func serverPortLineIndex(lines []string) int {
+	inServer := false
+	childIndent := -1
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if trimmed == "server:" {
+			inServer = true
+			childIndent = -1
+			continue
+		}
+		if !inServer {
+			continue
+		}
+		indent := len(line) - len(strings.TrimLeft(line, " \t"))
+		if indent == 0 {
+			inServer = false
+			continue
+		}
+		if childIndent == -1 {
+			childIndent = indent // first key under server: sets the child level
+		}
+		if indent == childIndent && strings.HasPrefix(trimmed, "port:") {
+			return i
+		}
+	}
+	return -1
+}
+
+// ReadServerPort returns the port configured in the install's deployment.yaml,
+// which is the only place the server reads its port from, or 0 when it cannot be
+// determined.
+func ReadServerPort(installPath string) int {
+	if installPath == "" {
+		return 0
+	}
+	configPath := deploymentConfigPath(installPath)
+	if configPath == "" {
+		return 0
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return 0
+	}
+	lines := strings.Split(string(data), "\n")
+	i := serverPortLineIndex(lines)
+	if i < 0 {
+		return 0
+	}
+	value := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(lines[i]), "port:"))
+	if idx := strings.Index(value, "#"); idx != -1 {
+		value = strings.TrimSpace(value[:idx])
+	}
+	port, err := strconv.Atoi(value)
+	if err != nil || port <= 0 {
+		return 0
+	}
+	return port
+}
+
+// ServerPort returns the port the install serves on: the configured one, or the
+// default when deployment.yaml does not say. This is the single answer to "which port
+// is this install on" that the start, attach, upgrade and sample paths all need.
+func ServerPort(installPath string) int {
+	if port := ReadServerPort(installPath); port > 0 {
+		return port
+	}
+	return health.DefaultPort
+}
+
+// EnsureServerPort makes port the value the server will read from deployment.yaml,
+// so the port the CLI works with and the port the server binds cannot diverge.
+// Passing port=0 leaves the configured value untouched.
+func EnsureServerPort(installPath string, port int) error {
+	if port <= 0 || ReadServerPort(installPath) == port {
+		return nil
+	}
+	return UpdateServerPort(installPath, port)
+}
+
+// UpdateServerPort rewrites the server.port value in the deployment.yaml found under installPath.
+func UpdateServerPort(installPath string, port int) error {
+	configPath := deploymentConfigPath(installPath)
 	if configPath == "" {
 		return fmt.Errorf("deployment.yaml not found in %s", installPath)
 	}
@@ -393,48 +495,281 @@ func UpdateServerPort(installPath string, port int) error {
 		return err
 	}
 	lines := strings.Split(string(data), "\n")
-	inServer := false
-	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "server:" {
-			inServer = true
-			continue
-		}
-		if inServer {
-			if len(line) > 0 && line[0] != ' ' && line[0] != '\t' {
-				inServer = false
-				continue
-			}
-			if strings.HasPrefix(trimmed, "port:") {
-				indent := line[:len(line)-len(strings.TrimLeft(line, " \t"))]
-				lines[i] = indent + fmt.Sprintf("port: %d", port)
-				return os.WriteFile(configPath, []byte(strings.Join(lines, "\n")), 0o644)
-			}
-		}
+	i := serverPortLineIndex(lines)
+	if i < 0 {
+		return fmt.Errorf("server.port not found in %s", configPath)
 	}
-	return fmt.Errorf("server.port not found in %s", configPath)
+	indent := lines[i][:len(lines[i])-len(strings.TrimLeft(lines[i], " \t"))]
+	lines[i] = indent + fmt.Sprintf("port: %d", port)
+	return os.WriteFile(configPath, []byte(strings.Join(lines, "\n")), 0o644)
 }
 
-// KillPort sends SIGTERM to all processes listening on the given TCP port.
-func KillPort(port int) {
-	if runtime.GOOS == "windows" {
-		_ = exec.Command("cmd", "/c",
-			fmt.Sprintf("for /f \"tokens=5\" %%a in ('netstat -aon ^| findstr :%d') do taskkill /f /pid %%a", port),
-		).Run()
-		return
+// listenerPIDs returns the PIDs listening on the given TCP port. An empty result with
+// a nil error means nothing is listening; an error means the listeners could not be
+// inspected at all (the lookup tool is missing), which callers must not mistake for
+// a free port.
+func listenerPIDs(port int) ([]int, error) {
+	var out []byte
+	var err error
+	if isWindows() {
+		out, err = exec.Command("cmd", "/c",
+			fmt.Sprintf("netstat -aon | findstr LISTENING | findstr :%d", port)).Output()
+	} else {
+		out, err = exec.Command("lsof", "-ti", fmt.Sprintf("tcp:%d", port)).Output()
 	}
-	cmd := exec.Command("lsof", "-ti", fmt.Sprintf("tcp:%d", port))
-	out, err := cmd.Output()
 	if err != nil {
-		return
+		// Both tools exit non-zero when nothing matches, which is not a failure.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("could not inspect the processes on port %d: %w", port, err)
 	}
-	for _, pidStr := range strings.Fields(string(out)) {
-		pid, err := strconv.Atoi(strings.TrimSpace(pidStr))
+	if isWindows() {
+		return parseNetstatPIDs(string(out), port), nil
+	}
+	return parsePIDs(strings.Fields(string(out))), nil
+}
+
+// PortHolder describes one process listening on a local TCP port.
+type PortHolder struct {
+	Port int
+	PID  int    // 0 when the process holding the port could not be identified
+	Name string // process name, empty when it could not be read
+}
+
+// String renders the holder as one prompt line, e.g. "5173  node (pid 61201)".
+func (h PortHolder) String() string {
+	switch {
+	case h.PID == 0:
+		return fmt.Sprintf("%d  unknown process", h.Port)
+	case h.Name == "":
+		return fmt.Sprintf("%d  pid %d", h.Port, h.PID)
+	default:
+		return fmt.Sprintf("%d  %s (pid %d)", h.Port, h.Name, h.PID)
+	}
+}
+
+// PortHolders returns the processes listening on the given ports, skipping the free
+// ones, so a prompt can name what it is about to stop. A port that is taken but whose
+// owner cannot be looked up yields a holder with PID 0: the conflict is real even when
+// the process behind it is not visible.
+func PortHolders(ports ...int) []PortHolder {
+	var holders []PortHolder
+	for _, port := range ports {
+		pids, err := listenerPIDs(port)
+		if err != nil || len(pids) == 0 {
+			if IsPortInUse(port) {
+				holders = append(holders, PortHolder{Port: port})
+			}
+			continue
+		}
+		// One process can hold several sockets on a port (IPv4 and IPv6), and the
+		// lookup reports each of them.
+		seen := make(map[int]bool, len(pids))
+		for _, pid := range pids {
+			if seen[pid] {
+				continue
+			}
+			seen[pid] = true
+			holders = append(holders, PortHolder{Port: port, PID: pid, Name: processName(pid)})
+		}
+	}
+	return holders
+}
+
+// processName returns the executable name of pid, or "" when it cannot be read.
+func processName(pid int) string {
+	if isWindows() {
+		out, err := exec.Command("tasklist", "/FI", fmt.Sprintf("PID eq %d", pid), "/NH", "/FO", "CSV").Output()
+		if err != nil {
+			return ""
+		}
+		return parseTasklistName(string(out))
+	}
+	out, err := exec.Command("ps", "-o", "comm=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return ""
+	}
+	// ps reports a full path for some processes; the basename is what a prompt needs.
+	return filepath.Base(strings.TrimSpace(string(out)))
+}
+
+// parseTasklistName returns the image name from a `tasklist /NH /FO CSV` row, or "".
+// A run that matched nothing still exits 0 and prints an informational line, which
+// parses as a single field; a real row also carries pid, session and memory size.
+func parseTasklistName(out string) string {
+	records, err := csv.NewReader(strings.NewReader(out)).ReadAll()
+	if err != nil || len(records) == 0 || len(records[0]) < 2 {
+		return ""
+	}
+	return records[0][0]
+}
+
+// parseNetstatPIDs extracts the PIDs from `netstat -aon` LISTENING lines whose local
+// address ends in :port, so a remote port with the same number is ignored.
+func parseNetstatPIDs(out string, port int) []int {
+	var pids []int
+	suffix := fmt.Sprintf(":%d", port)
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 4 || !strings.HasSuffix(fields[1], suffix) {
+			continue
+		}
+		pids = append(pids, parsePIDs(fields[len(fields)-1:])...)
+	}
+	return pids
+}
+
+// parsePIDs converts PID strings to positive ints, skipping anything unparseable.
+func parsePIDs(fields []string) []int {
+	var pids []int
+	for _, f := range fields {
+		pid, err := strconv.Atoi(strings.TrimSpace(f))
 		if err != nil || pid <= 0 {
 			continue
 		}
-		if p, err := os.FindProcess(pid); err == nil {
-			p.Signal(syscall.SIGTERM) //nolint:errcheck
+		pids = append(pids, pid)
+	}
+	return pids
+}
+
+// KillPort asks every process listening on the given TCP port to stop. It returns an
+// error only when the listeners could not be looked up; use FreePort when the port
+// has to be confirmed free.
+func KillPort(port int) error {
+	pids, err := listenerPIDs(port)
+	if err != nil {
+		return err
+	}
+	signalPIDs(pids, false)
+	return nil
+}
+
+// FreePort stops whatever is listening on the given TCP port and waits for the port to
+// be released, escalating from a polite stop to a forced kill. It reports why the port
+// is still taken instead of leaving the caller to assume success.
+func FreePort(port int, timeout time.Duration) error {
+	pids, err := listenerPIDs(port)
+	if err != nil {
+		return err
+	}
+	if len(pids) == 0 && !IsPortInUse(port) {
+		return nil
+	}
+	signalPIDs(pids, false)
+
+	// Give the polite stop most of the budget, then escalate with what is left.
+	if WaitForPortFree(port, timeout*3/4) {
+		return nil
+	}
+	survivors, err := listenerPIDs(port)
+	if err != nil {
+		return err
+	}
+	signalPIDs(survivors, true)
+	if WaitForPortFree(port, timeout/4) {
+		return nil
+	}
+	if len(survivors) > 0 {
+		return fmt.Errorf("port %d is still held by %s", port, formatPIDs(survivors))
+	}
+	return fmt.Errorf("port %d is still in use and the process holding it could not be identified", port)
+}
+
+// signalPIDs stops the given processes: forced kills use SIGKILL, polite ones SIGTERM.
+// Windows has no SIGTERM, so taskkill stands in for both: without /f it asks the process
+// to close, with /f it is terminated. /t covers the children too, matching the process
+// group the unix path signals — the server is started through a launcher script, so the
+// process that holds the port is usually a child.
+func signalPIDs(pids []int, force bool) {
+	for _, pid := range pids {
+		if isWindows() {
+			args := []string{"/pid", strconv.Itoa(pid), "/t"}
+			if force {
+				args = append(args, "/f")
+			}
+			_ = exec.Command("taskkill", args...).Run()
+			continue
+		}
+		p, err := os.FindProcess(pid)
+		if err != nil {
+			continue
+		}
+		sig := syscall.SIGTERM
+		if force {
+			sig = syscall.SIGKILL
+		}
+		p.Signal(sig) //nolint:errcheck
+	}
+}
+
+// formatPIDs renders PIDs as "pid 12" or "pids 12, 34".
+func formatPIDs(pids []int) string {
+	parts := make([]string, 0, len(pids))
+	for _, pid := range pids {
+		parts = append(parts, strconv.Itoa(pid))
+	}
+	if len(parts) == 1 {
+		return "pid " + parts[0]
+	}
+	return "pids " + strings.Join(parts, ", ")
+}
+
+// TailFile returns the last n lines of the file at path, trailing blank lines trimmed,
+// or nil when the file cannot be read or is empty.
+func TailFile(path string, n int) []string {
+	if n <= 0 {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\r\n"), "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, "\r")
+	}
+	if len(lines) == 1 && lines[0] == "" {
+		return nil
+	}
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return lines
+}
+
+// LogTail returns the last n lines of the current background log as one block, or ""
+// when the log cannot be read. It is how the CLI surfaces the server's own reason for
+// a failed start (a rejected bind, a bad configuration) instead of guessing.
+func LogTail(installPath string, n int) string {
+	return strings.Join(TailFile(LatestLogFile(installPath), n), "\n")
+}
+
+// LatestLogFile returns the most recently modified log file in LogDir, falling back to
+// today's LogFile. A start that crosses midnight writes to the file it truncated on the
+// previous day, so the dated path alone would point at the wrong log.
+func LatestLogFile(installPath string) string {
+	dir := LogDir(installPath)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return LogFile(installPath)
+	}
+	newest, newestTime := "", time.Time{}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".log") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if newest == "" || info.ModTime().After(newestTime) {
+			newest, newestTime = filepath.Join(dir, e.Name()), info.ModTime()
 		}
 	}
+	if newest == "" {
+		return LogFile(installPath)
+	}
+	return newest
 }

--- a/tools/cli/internal/services/setup/setup_internal_test.go
+++ b/tools/cli/internal/services/setup/setup_internal_test.go
@@ -4,10 +4,15 @@
 package setup
 
 import (
+	"net"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseAdminCredentials_ParsesBlock(t *testing.T) {
@@ -55,4 +60,107 @@ func TestGenerateAdminPassword(t *testing.T) {
 		assert.True(t, strings.ContainsAny(pw, special), "must contain a special char: %q", pw)
 	}
 	assert.NotEqual(t, GenerateAdminPassword(), GenerateAdminPassword())
+}
+
+func TestParseNetstatPIDs(t *testing.T) {
+	out := "  TCP    127.0.0.1:8090         0.0.0.0:0              LISTENING       4321\r\n" +
+		// Remote port 8090 on a local port 55000: not a listener on 8090.
+		"  TCP    127.0.0.1:55000        10.0.0.5:8090          ESTABLISHED     999\r\n" +
+		"garbage line\r\n"
+
+	assert.Equal(t, []int{4321}, parseNetstatPIDs(out, 8090))
+}
+
+func TestParsePIDsSkipsInvalid(t *testing.T) {
+	assert.Equal(t, []int{7, 9}, parsePIDs([]string{"7", "x", "0", "-3", " 9 "}))
+}
+
+func TestFormatPIDs(t *testing.T) {
+	assert.Equal(t, "pid 7", formatPIDs([]int{7}))
+	assert.Equal(t, "pids 7, 9", formatPIDs([]int{7, 9}))
+}
+
+func TestListenerPIDs_FindsOwnListener(t *testing.T) {
+	if isWindows() {
+		t.Skip("uses lsof")
+	}
+	if _, err := exec.LookPath("lsof"); err != nil {
+		t.Skip("lsof not installed")
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close() //nolint:errcheck
+
+	pids, err := listenerPIDs(ln.Addr().(*net.TCPAddr).Port)
+	require.NoError(t, err)
+	assert.Contains(t, pids, os.Getpid())
+}
+
+func TestPortHolders_ReportsThisProcess(t *testing.T) {
+	if isWindows() {
+		t.Skip("uses lsof")
+	}
+	if _, err := exec.LookPath("lsof"); err != nil {
+		t.Skip("lsof not installed")
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close() //nolint:errcheck
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	holders := PortHolders(port)
+
+	require.NotEmpty(t, holders, "expected a holder for the listening port")
+	pids := make([]int, 0, len(holders))
+	for _, h := range holders {
+		assert.Equal(t, port, h.Port)
+		pids = append(pids, h.PID)
+	}
+	assert.Contains(t, pids, os.Getpid())
+}
+
+// unboundTestPort is high enough that nothing on a developer machine or CI runner is
+// expected to listen on it, and it is never bound by these tests. Asserting on a port
+// that was just closed would instead race whatever binds it next.
+const unboundTestPort = 19997
+
+func TestPortHolders_SkipsFreePorts(t *testing.T) {
+	assert.Empty(t, PortHolders(unboundTestPort))
+}
+
+func TestPortHolderString(t *testing.T) {
+	assert.Equal(t, "5173  node (pid 61201)", PortHolder{Port: 5173, PID: 61201, Name: "node"}.String())
+	assert.Equal(t, "5173  pid 61201", PortHolder{Port: 5173, PID: 61201}.String())
+	assert.Equal(t, "5173  unknown process", PortHolder{Port: 5173}.String())
+}
+
+func TestParseTasklistName(t *testing.T) {
+	assert.Equal(t, "node.exe", parseTasklistName("\"node.exe\",\"61201\",\"Console\",\"1\",\"52,300 K\"\r\n"))
+	// tasklist exits 0 and prints this when nothing matched the filter.
+	assert.Empty(t, parseTasklistName("INFO: No tasks are running which match the specified criteria.\r\n"))
+	assert.Empty(t, parseTasklistName(""))
+}
+
+func TestProcessName_ReturnsOwnBinary(t *testing.T) {
+	if isWindows() {
+		t.Skip("uses ps")
+	}
+	name := processName(os.Getpid())
+	assert.NotEmpty(t, name)
+	assert.NotContains(t, name, " ")
+	assert.NotContains(t, name, "/")
+}
+
+func TestFreePort_NoListenerIsNoOp(t *testing.T) {
+	require.NoError(t, FreePort(unboundTestPort, 2*time.Second))
+	require.NoError(t, KillPort(unboundTestPort))
+}
+
+// An empty result is "nothing is listening", which callers must not confuse with the
+// lookup itself failing: that difference decides whether a port reports an unknown
+// holder or none at all.
+func TestListenerPIDs_NoListener(t *testing.T) {
+	pids, err := listenerPIDs(unboundTestPort)
+	require.NoError(t, err, "nothing listening is not a lookup failure")
+	assert.Empty(t, pids)
 }

--- a/tools/cli/internal/services/setup/setup_test.go
+++ b/tools/cli/internal/services/setup/setup_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/thunder-id/thunderid/tools/cli/internal/services/health"
 	"github.com/thunder-id/thunderid/tools/cli/internal/services/setup"
 )
 
@@ -47,6 +48,29 @@ func TestLogFile_ContainsDate(t *testing.T) {
 func TestLogFile_HasLogExtension(t *testing.T) {
 	f := setup.LogFile("/tmp/test")
 	assert.True(t, strings.HasSuffix(f, ".log"), "expected .log suffix, got %q", f)
+}
+
+// A start that crosses midnight keeps writing to the file it truncated the day
+// before, so startup diagnostics must follow the newest log, not today's date.
+func TestLatestLogFile_PrefersTheNewestLog(t *testing.T) {
+	installPath := t.TempDir()
+	logs := setup.LogDir(installPath)
+	require.NoError(t, os.MkdirAll(logs, 0o755))
+
+	yesterday := filepath.Join(logs, "thunderid-2026-08-12.log")
+	require.NoError(t, os.WriteFile(yesterday, []byte("address already in use\n"), 0o644))
+	stale := filepath.Join(logs, "thunderid-2026-08-11.log")
+	require.NoError(t, os.WriteFile(stale, []byte("old\n"), 0o644))
+	old := time.Now().Add(-48 * time.Hour)
+	require.NoError(t, os.Chtimes(stale, old, old))
+
+	assert.Equal(t, yesterday, setup.LatestLogFile(installPath))
+	assert.Contains(t, setup.LogTail(installPath, 5), "address already in use")
+}
+
+func TestLatestLogFile_FallsBackToTodaysPath(t *testing.T) {
+	installPath := t.TempDir()
+	assert.Equal(t, setup.LogFile(installPath), setup.LatestLogFile(installPath))
 }
 
 func TestFindThunderRoot_ScriptAtRoot(t *testing.T) {
@@ -125,4 +149,150 @@ func TestUpdateServerPort_MissingConfig(t *testing.T) {
 	err := setup.UpdateServerPort(dir, 8091)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "deployment.yaml not found")
+}
+
+// writeDeployment writes a deployment.yaml at the install root and returns its path.
+func writeDeployment(t *testing.T, dir, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, "deployment.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+func TestReadServerPort_ReadsConfiguredPort(t *testing.T) {
+	dir := t.TempDir()
+	writeDeployment(t, dir, "server:\n  hostname: \"localhost\"\n  port: 8091\n\nother:\n  port: 9000\n")
+
+	assert.Equal(t, 8091, setup.ReadServerPort(dir))
+}
+
+// A port: belonging to a mapping nested under server: is a different setting and
+// must not be mistaken for server.port, even when it comes first.
+func TestReadServerPort_IgnoresPortNestedUnderServer(t *testing.T) {
+	dir := t.TempDir()
+	writeDeployment(t, dir, "server:\n  tls:\n    enabled: true\n    port: 9443\n  port: 8093\n")
+
+	assert.Equal(t, 8093, setup.ReadServerPort(dir))
+}
+
+func TestUpdateServerPort_LeavesPortNestedUnderServer(t *testing.T) {
+	dir := t.TempDir()
+	path := writeDeployment(t, dir, "server:\n  tls:\n    port: 9443\n  port: 8090\n")
+
+	require.NoError(t, setup.UpdateServerPort(dir, 8094))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "  port: 8094")
+	assert.Contains(t, string(data), "    port: 9443", "the nested port should be unchanged")
+}
+
+func TestReadServerPort_IgnoresInlineComment(t *testing.T) {
+	dir := t.TempDir()
+	writeDeployment(t, dir, "server:\n  port: 8095 # moved after a conflict\n")
+
+	assert.Equal(t, 8095, setup.ReadServerPort(dir))
+}
+
+func TestReadServerPort_NestedConfig(t *testing.T) {
+	dir := t.TempDir()
+	serverDir := filepath.Join(dir, "backend", "cmd", "server")
+	require.NoError(t, os.MkdirAll(serverDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(serverDir, "deployment.yaml"),
+		[]byte("server:\n  port: 8092\n"), 0o644))
+
+	assert.Equal(t, 8092, setup.ReadServerPort(dir))
+}
+
+func TestReadServerPort_UnknownReturnsZero(t *testing.T) {
+	assert.Equal(t, 0, setup.ReadServerPort(t.TempDir()), "no deployment.yaml")
+	assert.Equal(t, 0, setup.ReadServerPort(""), "no install path")
+
+	dir := t.TempDir()
+	writeDeployment(t, dir, "server:\n  hostname: \"localhost\"\n")
+	assert.Equal(t, 0, setup.ReadServerPort(dir), "no server.port key")
+
+	other := t.TempDir()
+	writeDeployment(t, other, "server:\n  port: not-a-number\n")
+	assert.Equal(t, 0, setup.ReadServerPort(other), "unparseable port")
+}
+
+func TestEnsureServerPort_WritesRequestedPort(t *testing.T) {
+	dir := t.TempDir()
+	writeDeployment(t, dir, "server:\n  port: 8090\n")
+
+	require.NoError(t, setup.EnsureServerPort(dir, 8091))
+	assert.Equal(t, 8091, setup.ReadServerPort(dir))
+}
+
+func TestEnsureServerPort_NoOpWhenAlreadySet(t *testing.T) {
+	dir := t.TempDir()
+	// A comment on the port line survives only if the file is left untouched.
+	path := writeDeployment(t, dir, "server:\n  port: 8090 # keep me\n")
+
+	require.NoError(t, setup.EnsureServerPort(dir, 8090))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "# keep me")
+}
+
+func TestEnsureServerPort_ZeroKeepsConfiguredPort(t *testing.T) {
+	dir := t.TempDir()
+	writeDeployment(t, dir, "server:\n  port: 8093\n")
+
+	require.NoError(t, setup.EnsureServerPort(dir, 0))
+	assert.Equal(t, 8093, setup.ReadServerPort(dir))
+}
+
+func TestEnsureServerPort_MissingConfig(t *testing.T) {
+	err := setup.EnsureServerPort(t.TempDir(), 8091)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deployment.yaml not found")
+}
+
+func TestLogTail_ReturnsLastLines(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(setup.LogDir(dir), 0o755))
+	body := "first\nsecond\nthird\nfourth\n"
+	require.NoError(t, os.WriteFile(setup.LogFile(dir), []byte(body), 0o644))
+
+	assert.Equal(t, "third\nfourth", setup.LogTail(dir, 2), "the trailing newline must not become a blank line")
+	assert.Equal(t, "first\nsecond\nthird\nfourth", setup.LogTail(dir, 10))
+}
+
+func TestTailFile_KeepsInteriorBlankLines(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sample.log")
+	require.NoError(t, os.WriteFile(path, []byte("one\n\ntwo\r\n"), 0o644))
+
+	assert.Equal(t, []string{"one", "", "two"}, setup.TailFile(path, 10))
+}
+
+func TestTailFile_EmptyOrMissing(t *testing.T) {
+	assert.Empty(t, setup.TailFile(filepath.Join(t.TempDir(), "missing.log"), 5))
+
+	empty := filepath.Join(t.TempDir(), "empty.log")
+	require.NoError(t, os.WriteFile(empty, nil, 0o644))
+	assert.Empty(t, setup.TailFile(empty, 5))
+}
+
+func TestTailFile_NonPositiveCount(t *testing.T) {
+	assert.Nil(t, setup.TailFile(filepath.Join(t.TempDir(), "missing.log"), 0))
+	assert.Nil(t, setup.TailFile(filepath.Join(t.TempDir(), "missing.log"), -1))
+}
+
+func TestLogTail_MissingLog(t *testing.T) {
+	assert.Equal(t, "", setup.LogTail(t.TempDir(), 5))
+}
+
+func TestServerPort_PrefersConfiguredPort(t *testing.T) {
+	dir := t.TempDir()
+	writeDeployment(t, dir, "server:\n  port: 8091\n")
+
+	assert.Equal(t, 8091, setup.ServerPort(dir))
+}
+
+func TestServerPort_FallsBackToDefault(t *testing.T) {
+	assert.Equal(t, health.DefaultPort, setup.ServerPort(t.TempDir()))
+	assert.Equal(t, health.DefaultPort, setup.ServerPort(""))
 }

--- a/tools/cli/internal/ui/banner.go
+++ b/tools/cli/internal/ui/banner.go
@@ -10,7 +10,9 @@ import (
 	"strings"
 
 	"charm.land/huh/v2"
+	huhspinner "charm.land/huh/v2/spinner"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/term"
 
 	"github.com/thunder-id/thunderid/tools/cli/internal/product"
 	"github.com/thunder-id/thunderid/tools/cli/internal/services/setup"
@@ -30,6 +32,37 @@ var CyanStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(colorCyan))
 
 // YellowStyle renders text in yellow.
 var YellowStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(colorYellow))
+
+// maxBoxWidth caps the bordered boxes so they do not overflow a standard terminal, and
+// terminalWidth reports how much room there actually is.
+const maxBoxWidth = 100
+
+// terminalWidth returns the current terminal width, or fallbackWidth when stdout is not
+// a terminal (a pipe, a CI log) and has no width to report. It is a variable so tests
+// can render at a chosen width.
+var terminalWidth = func() int {
+	if w, _, err := term.GetSize(os.Stdout.Fd()); err == nil && w > 0 {
+		return w
+	}
+	return fallbackWidth
+}
+
+// fallbackWidth is the classic terminal width, used when the real one is unknown.
+const fallbackWidth = 80
+
+// boxWidth returns the width a bordered box may render at: the terminal minus the
+// border and padding it draws around its content, capped at maxBoxWidth.
+func boxWidth(horizontalChrome int) int {
+	width := terminalWidth()
+	if width > maxBoxWidth {
+		width = maxBoxWidth
+	}
+	width -= horizontalChrome
+	if width < 20 {
+		width = 20
+	}
+	return width
+}
 
 var (
 	brandStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(colorBrandBlue))
@@ -59,6 +92,19 @@ var (
 			Padding(0, 1)
 )
 
+// fitBox renders content in a bordered box sized to the terminal, wrapping long lines
+// instead of letting the border run off the edge. horizontalChrome is the width the
+// style spends on its own border and padding.
+func fitBox(style lipgloss.Style, horizontalChrome int, content string) string {
+	return style.Width(boxWidth(horizontalChrome)).Render(content)
+}
+
+// Box chrome widths: 2 border columns plus the style's horizontal padding.
+const (
+	noteChrome  = 2 + 1*2
+	introChrome = 2 + 4*2
+)
+
 var thunderLines = []string{
 	` _____ _                     _           `,
 	`|_   _| |                   | |          `,
@@ -77,9 +123,18 @@ var idLines = []string{
 	` \___/|___/  `,
 }
 
-// BannerString returns the styled ASCII art banner as a string.
+// slogan is shown under the product name in the banner.
+const slogan = "Auth for Modern Apps and Agents"
+
+// BannerString returns the styled ASCII art banner, or a compact variant when the
+// terminal is too narrow for the art and its box: the art is a fixed width, so on a
+// small terminal the border would wrap and every line would break.
 func BannerString() string {
 	logoWidth := 2 + len(thunderLines[0]) + len(idLines[0])
+	if terminalWidth() < logoWidth+introChrome {
+		return fitBox(noteBoxStyle, noteChrome,
+			brandStyle.Render("⚡ "+product.Name)+"\n"+greyStyle.Render(slogan))
+	}
 
 	var lines []string
 	for i, t := range thunderLines {
@@ -88,13 +143,13 @@ func BannerString() string {
 	}
 	banner := strings.Join(lines, "\n")
 
-	slogan := lipgloss.NewStyle().
+	centeredSlogan := lipgloss.NewStyle().
 		Foreground(lipgloss.Color(colorGrey)).
 		Width(logoWidth).
 		Align(lipgloss.Center).
-		Render("Auth for Modern Apps and Agents")
+		Render(slogan)
 
-	return introBoxStyle.Render(banner + "\n\n" + slogan)
+	return introBoxStyle.Render(banner + "\n\n" + centeredSlogan)
 }
 
 // PrintBanner writes the styled banner to stdout.
@@ -123,27 +178,55 @@ func StatusBoxString(baseURL string) string {
 // Note prints a bordered note box with title and body.
 func Note(title, body string) {
 	content := boldStyle.Render(title) + "\n" + greyStyle.Render(body)
-	fmt.Println(noteBoxStyle.Render(content))
+	fmt.Println(fitBox(noteBoxStyle, noteChrome, content))
 }
 
 // Success prints a green success box.
 func Success(msg string) {
-	fmt.Println(successBoxStyle.Render(greenStyle.Render("✓ ") + msg))
+	fmt.Println(fitBox(successBoxStyle, noteChrome, greenStyle.Render("✓ ")+msg))
 }
 
 // Outro prints a dimmed note box.
 func Outro(msg string) {
-	fmt.Println(noteBoxStyle.Render(greyStyle.Render(msg)))
+	fmt.Println(fitBox(noteBoxStyle, noteChrome, greyStyle.Render(msg)))
 }
 
 // Warn prints a yellow warning box.
 func Warn(msg string) {
-	fmt.Println(noteBoxStyle.Render(YellowStyle.Render("⚠ " + msg)))
+	fmt.Println(fitBox(noteBoxStyle, noteChrome, YellowStyle.Render("⚠ "+msg)))
 }
 
 // Fatal prints a red error box.
 func Fatal(msg string) {
-	fmt.Println(errorBoxStyle.Render(redStyle.Render("✗ ") + msg))
+	fmt.Println(fitBox(errorBoxStyle, noteChrome, redStyle.Render("✗ ")+msg))
+}
+
+// FatalDetail prints a failure whose message carries captured output (a setup
+// transcript, a log tail) after a blank line: the detail is printed as plain lines and
+// only the summary goes in the error box, which would otherwise be too wide to read.
+func FatalDetail(msg string) {
+	if idx := strings.Index(msg, "\n\n"); idx != -1 {
+		detail := strings.TrimSpace(msg[idx+2:])
+		if detail != "" {
+			fmt.Println()
+			for _, line := range strings.Split(detail, "\n") {
+				fmt.Println("  " + line)
+			}
+			fmt.Println()
+		}
+		msg = strings.TrimSpace(msg[:idx])
+	}
+	Fatal(msg)
+}
+
+// SpinnerTheme renders the blocking spinners (setup, startup) in the product colors.
+func SpinnerTheme() huhspinner.Theme {
+	return huhspinner.ThemeFunc(func(bool) *huhspinner.Styles {
+		return &huhspinner.Styles{
+			Spinner: lipgloss.NewStyle().Foreground(lipgloss.Color(colorBrandBlue)).PaddingLeft(2),
+			Title:   lipgloss.NewStyle(),
+		}
+	})
 }
 
 // Bold returns a bold-rendered string.
@@ -201,21 +284,25 @@ const (
 )
 
 // PromptPortConflict shows a port-in-use warning and asks how to proceed.
-// altPort is the next free port the caller pre-computed as an alternative.
-// Returns the chosen action and the port to use.
-func PromptPortConflict(port, altPort int) (PortConflictChoice, int) {
+// altPort is the next free port the caller pre-computed as an alternative; pass 0
+// when the install cannot move ports, and only freeing the port or aborting is
+// offered. holders, when known, are listed so the operator sees what would be
+// stopped. Returns the chosen action and the port to use.
+func PromptPortConflict(port, altPort int, holders []setup.PortHolder) (PortConflictChoice, int) {
 	title := redStyle.Render(fmt.Sprintf("Port %d is already in use", port))
 	body := greyStyle.Render(fmt.Sprintf("%s cannot start because another process is using port %d.", product.Name, port))
-	fmt.Println(noteBoxStyle.Render(title + "\n\n" + body))
+	if held := holderLines(holders); held != "" {
+		body += "\n" + held
+	}
+	if altPort <= 0 {
+		body += "\n" + greyStyle.Render(fmt.Sprintf("This install is already set up on port %d and cannot be moved.", port))
+	}
+	fmt.Println(fitBox(noteBoxStyle, noteChrome, title+"\n\n"+body))
 
 	var choice PortConflictChoice
 	if err := huh.NewSelect[PortConflictChoice]().
 		Title("How would you like to proceed?").
-		Options(
-			huh.NewOption(fmt.Sprintf("Kill the process on port %d and continue", port), KillAndUsePort),
-			huh.NewOption(fmt.Sprintf("Use port %d instead", altPort), UseAlternatePort),
-			huh.NewOption("Abort", AbortSetup),
-		).
+		Options(portConflictOptions(port, altPort)...).
 		Value(&choice).
 		Run(); err != nil {
 		return AbortSetup, port
@@ -224,6 +311,70 @@ func PromptPortConflict(port, altPort int) (PortConflictChoice, int) {
 		return choice, altPort
 	}
 	return choice, port
+}
+
+// portConflictOptions lists the answers to a port-in-use prompt. The alternate-port
+// answer appears only when the caller supplied one.
+func portConflictOptions(port, altPort int) []huh.Option[PortConflictChoice] {
+	options := []huh.Option[PortConflictChoice]{
+		huh.NewOption(fmt.Sprintf("Kill the process on port %d and continue", port), KillAndUsePort),
+	}
+	if altPort > 0 {
+		options = append(options, huh.NewOption(fmt.Sprintf("Use port %d instead", altPort), UseAlternatePort))
+	}
+	return append(options, huh.NewOption("Abort", AbortSetup))
+}
+
+// ConfirmStopPortHolders lists the processes occupying the ports a sample app needs
+// and asks whether to stop them. The sample services bind fixed ports written into
+// their generated config, so moving them is not an option: the choice is stop or
+// cancel. Returns false when the operator declines; a non-interactive run has nobody to
+// ask, so it warns and continues like the port-conflict path in cli.resolvePort.
+func ConfirmStopPortHolders(holders []setup.PortHolder) bool {
+	title := redStyle.Render("Ports needed by the sample app are in use")
+	body := greyStyle.Render("The sample services bind these fixed ports.")
+	if held := holderLines(holders); held != "" {
+		body += "\n" + held
+	}
+	fmt.Println(fitBox(noteBoxStyle, noteChrome, title+"\n\n"+body))
+
+	if !Interactive() {
+		// A scripted or CI run cannot answer, and huh would fail immediately. Continue
+		// as before rather than reporting a cancellation nobody chose; the box above
+		// already named what is being stopped.
+		Warn("Not running interactively, so the processes holding these ports are being stopped.")
+		return true
+	}
+
+	var stop bool
+	if err := huh.NewSelect[bool]().
+		Title("How would you like to proceed?").
+		Options(
+			huh.NewOption("Stop these processes and continue", true),
+			huh.NewOption("Cancel, leave them running", false),
+		).
+		Value(&stop).
+		Run(); err != nil {
+		return false
+	}
+	return stop
+}
+
+// holderLines renders one indented line per port holder, or "" when none are known.
+func holderLines(holders []setup.PortHolder) string {
+	lines := make([]string, 0, len(holders))
+	for _, h := range holders {
+		lines = append(lines, greyStyle.Render("  "+h.String()))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// Interactive reports whether stdin is a terminal, so callers can skip a prompt in
+// scripted and CI runs instead of asking a question nothing can answer. A CI run
+// usually gets /dev/null on stdin, which is a character device but no terminal, so
+// the terminal itself is what has to be tested for.
+func Interactive() bool {
+	return term.IsTerminal(os.Stdin.Fd())
 }
 
 // PromptAdminCredentials interactively collects the admin username and password
@@ -235,7 +386,7 @@ func PromptPortConflict(port, altPort int) (PortConflictChoice, int) {
 // It returns ok=false (a no-op) when stdin is not an interactive terminal, so
 // scripted and CI runs fall through to setup's own defaults.
 func PromptAdminCredentials(defaultUsername, generatedPassword string) (username, password string, usedGenerated, ok bool) {
-	if fi, err := os.Stdin.Stat(); err != nil || (fi.Mode()&os.ModeCharDevice) == 0 {
+	if !Interactive() {
 		return "", "", false, false
 	}
 	var userInput, passInput string
@@ -290,7 +441,7 @@ func PrintCredentialsFallback(creds *setup.AdminCredentials) {
 func PromptUpgrade(currentVersion, newVersion string) UpgradeChoice {
 	title := YellowStyle.Render("✦ " + product.Name + " v" + newVersion + " is available")
 	body := greyStyle.Render("You have v" + currentVersion + " installed.\nUpgrade for the latest features and security fixes.")
-	fmt.Println(noteBoxStyle.Render(title + "\n\n" + body))
+	fmt.Println(fitBox(noteBoxStyle, noteChrome, title+"\n\n"+body))
 
 	var choice UpgradeChoice
 	if err := huh.NewSelect[UpgradeChoice]().

--- a/tools/cli/internal/ui/banner_internal_test.go
+++ b/tools/cli/internal/ui/banner_internal_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ui
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"charm.land/huh/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/thunder-id/thunderid/tools/cli/internal/services/setup"
+)
+
+// withTerminalWidth renders at a fixed width for the duration of the test.
+func withTerminalWidth(t *testing.T, width int) {
+	t.Helper()
+	orig := terminalWidth
+	terminalWidth = func() int { return width }
+	t.Cleanup(func() { terminalWidth = orig })
+}
+
+// The ASCII art is a fixed width, so on a narrow terminal the box used to overflow and
+// every line wrapped. Below that width the banner must fall back to a compact form.
+func TestBannerString_CompactOnNarrowTerminal(t *testing.T) {
+	withTerminalWidth(t, 40)
+
+	out := BannerString()
+
+	if strings.Contains(out, `|_   _| |`) {
+		t.Fatalf("expected the compact banner on a 40-column terminal:\n%s", out)
+	}
+	if w := lipgloss.Width(out); w > 40 {
+		t.Fatalf("banner is %d columns wide, does not fit 40:\n%s", w, out)
+	}
+}
+
+func TestBannerString_ArtOnWideTerminal(t *testing.T) {
+	withTerminalWidth(t, 120)
+
+	out := BannerString()
+
+	if !strings.Contains(out, `|_   _| |`) {
+		t.Fatalf("expected the full banner art on a wide terminal:\n%s", out)
+	}
+}
+
+// Boxes have to stay inside the terminal: a long message wraps instead of pushing the
+// border past the right edge.
+func TestBoxes_FitNarrowTerminal(t *testing.T) {
+	withTerminalWidth(t, 48)
+	long := strings.Repeat("a very long failure message ", 6)
+
+	out := captureStdout(t, func() { Fatal(long) })
+
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if w := lipgloss.Width(line); w > 48 {
+			t.Fatalf("line is %d columns wide, does not fit 48: %q", w, line)
+		}
+	}
+}
+
+// A scripted or CI run has no terminal on stdin, so prompts must be skipped there
+// rather than asking a question nothing can answer.
+func TestInteractive_FalseWithoutATerminal(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	defer r.Close() //nolint:errcheck
+	defer w.Close() //nolint:errcheck
+	orig := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = orig })
+
+	if Interactive() {
+		t.Fatal("expected a pipe on stdin not to count as a terminal")
+	}
+}
+
+// The prompt has to name what it would stop, so the user does not kill an unrelated app.
+func TestPromptPortConflict_ListsHolders(t *testing.T) {
+	out := holderLines([]setup.PortHolder{
+		{Port: 8090, PID: 61201, Name: "thunderid"},
+		{Port: 8090, PID: 61202},
+	})
+
+	for _, want := range []string{"8090", "thunderid", "61201", "61202"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in the holder lines:\n%s", want, out)
+		}
+	}
+	if lines := strings.Split(out, "\n"); len(lines) != 2 {
+		t.Fatalf("expected one line per holder, got %d:\n%s", len(lines), out)
+	}
+}
+
+// Setup seeds the console application's redirect URIs with the port it ran on, so a run
+// that does not re-run setup must not be able to move the port.
+func TestPortConflictOptions_OmitsAlternateWithoutOne(t *testing.T) {
+	options := portConflictOptions(8090, 0)
+
+	if len(options) != 2 {
+		t.Fatalf("expected kill and abort only, got %d options", len(options))
+	}
+	for _, opt := range options {
+		if opt.Value == UseAlternatePort {
+			t.Fatalf("expected no alternate-port option, got %q", opt.Key)
+		}
+	}
+}
+
+// Setup runs in this invocation, so the seeded port is whatever is picked here.
+func TestPortConflictOptions_OffersAlternateWhenGiven(t *testing.T) {
+	options := portConflictOptions(8090, 8091)
+
+	var alt *huh.Option[PortConflictChoice]
+	for i := range options {
+		if options[i].Value == UseAlternatePort {
+			alt = &options[i]
+		}
+	}
+	if alt == nil {
+		t.Fatalf("expected an alternate-port option in %d options", len(options))
+	}
+	if !strings.Contains(alt.Key, "8091") {
+		t.Fatalf("expected the alternate port in the option label, got %q", alt.Key)
+	}
+}
+
+// A scripted run cannot answer the prompt, and reporting a cancellation nobody chose
+// would abort the sample. It continues instead, like the product-port path does.
+func TestConfirmStopPortHolders_ContinuesWithoutATerminal(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	defer r.Close() //nolint:errcheck
+	defer w.Close() //nolint:errcheck
+	orig := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = orig })
+
+	var confirmed bool
+	captureStdout(t, func() {
+		confirmed = ConfirmStopPortHolders([]setup.PortHolder{{Port: 5173, PID: 61201, Name: "node"}})
+	})
+
+	if !confirmed {
+		t.Fatal("expected a non-interactive run to continue instead of canceling")
+	}
+}
+
+func TestHolderLines_EmptyForNoHolders(t *testing.T) {
+	if out := holderLines(nil); out != "" {
+		t.Fatalf("expected no output for no holders, got %q", out)
+	}
+}

--- a/tools/cli/internal/ui/onboarding.go
+++ b/tools/cli/internal/ui/onboarding.go
@@ -119,9 +119,7 @@ func (m *ReplModel) selectOnboarding() tea.Cmd {
 		}
 	}
 
-	m.tryingOut = true
-	m.input.Blur()
-	return makeTryCmd(item.sampleName, m.installPath, m.verbose, sample.Options{
+	return m.launchTry(item.sampleName, sample.Options{
 		Features: item.sampleFeatures, Port: m.effectivePort(),
 	})
 }

--- a/tools/cli/internal/ui/repl.go
+++ b/tools/cli/internal/ui/repl.go
@@ -1054,17 +1054,22 @@ func (m ReplModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,fu
 			m.input.Placeholder = "Type / for commands, Ctrl+C to exit"
 		}
 
+	// The three exits below replace the running product, so the sample must not
+	// survive: it would keep its ports and point at a base URL that is gone.
 	case cutoverMsg:
+		sample.StopServices()
 		m.cutoverRequested = true
 		m.quitting = true
 		return m, tea.Quit
 
 	case upgradeMsg:
+		sample.StopServices()
 		m.upgradeRequested = true
 		m.quitting = true
 		return m, tea.Quit
 
 	case switchVersionMsg:
+		sample.StopServices()
 		m.switchRequested = true
 		m.quitting = true
 		return m, tea.Quit
@@ -1147,6 +1152,9 @@ func (m *ReplModel) runCommand(val string) tea.Cmd {
 }
 
 func (m *ReplModel) killThunder() {
+	// Stop the sample first: its backend talks to the product, so stopping the
+	// dependant before the product avoids error spew in the sample log.
+	sample.StopServices()
 	if m.proc == nil || m.proc.Process == nil {
 		return
 	}

--- a/tools/cli/internal/ui/repl.go
+++ b/tools/cli/internal/ui/repl.go
@@ -6,15 +6,17 @@ package ui
 import (
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
+	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/list"
 	"charm.land/bubbles/v2/spinner"
 	"charm.land/bubbles/v2/textinput"
+	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
@@ -91,7 +93,6 @@ var defaultCommands = []SlashCommand{
 // --- bubbletea messages ---
 
 type healthCheckMsg struct{ ready bool }
-type cutoverMsg struct{}
 type upgradeMsg struct{}
 type switchVersionMsg struct{}
 type thunderExitedMsg struct {
@@ -318,12 +319,17 @@ type ReplModel struct {
 	tryingOut       bool
 	quitting        bool
 	width           int
+	height          int
+
+	// body scrolls everything above the input line, so output longer than the
+	// terminal stays reachable and the input is never pushed off screen.
+	body      viewport.Model
+	bodySized bool
 
 	showOnboarding    bool
 	onboardingList    list.Model
 	onboardingCmdMode bool // true while the slash-command input overlay is active
 	checkPort         int  // non-zero overrides health.DefaultPort for health checks
-	cutoverRequested  bool // set when the /cutover command is executed
 	upgradeRequested  bool // set when the /upgrade command is executed
 	switchRequested   bool // set when the /use command is executed
 	newVersion        string
@@ -332,6 +338,14 @@ type ReplModel struct {
 	showWalkthrough  bool
 	walkthroughPanes []walkthroughPane
 	walkthroughTab   int
+
+	// Sample dev-port conflict — active when showPortConflict is true. Holds the launch
+	// waiting for the user to approve stopping the processes on the sample's ports.
+	showPortConflict bool
+	pcHolders        []setup.PortHolder
+	pcSampleName     string
+	pcOpts           sample.Options
+	pcStop           bool // highlighted answer: true stops the holders, false cancels
 
 	// Generic use-case config collection — active when showUsecaseConfig is true.
 	showUsecaseConfig bool
@@ -343,7 +357,7 @@ type ReplModel struct {
 	ucSampleName      string
 	ucEnvTarget       string
 	ucFeatures        []string
-	ucComplete        func(values map[string]string) tea.Cmd
+	ucLaunch          func(values map[string]string) (string, sample.Options)
 
 	// Step-by-step integration guide — active when showIntegrate is true.
 	showIntegrate       bool
@@ -437,15 +451,11 @@ func NewReplModel(version string, proc *exec.Cmd, installPath string, verbose bo
 		Description: "Show recent server logs",
 		Section:     "Server",
 		Action: func(_ string) ([]string, error) {
-			logPath := setup.LogFile(installPath)
-			data, err := os.ReadFile(logPath)
-			if err != nil {
-				return nil, fmt.Errorf("could not read logs: %w", err)
-			}
-			lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
 			const maxLines = 30
-			if len(lines) > maxLines {
-				lines = lines[len(lines)-maxLines:]
+			logPath := setup.LogFile(installPath)
+			lines := setup.TailFile(logPath, maxLines)
+			if len(lines) == 0 {
+				return nil, fmt.Errorf("could not read logs at %s", logPath)
 			}
 			out := make([]string, 0, len(lines)+1)
 			out = append(out, Dim(fmt.Sprintf("── last %d lines of %s ──", len(lines), logPath)))
@@ -476,6 +486,86 @@ func NewReplModel(version string, proc *exec.Cmd, installPath string, verbose bo
 		showOnboarding: isFirstRun,
 		onboardingList: newOnboardingList(80),
 		integrateInput: ii,
+		body:           newOutputViewport(),
+	}
+}
+
+// newOutputViewport builds the scrollable output region. The default key map binds
+// plain letters and space, which belong to the command input, so scrolling is bound to
+// keys the input does not use.
+func newOutputViewport() viewport.Model {
+	vp := viewport.New()
+	vp.SoftWrap = true
+	vp.KeyMap = viewport.KeyMap{
+		PageUp:   key.NewBinding(key.WithKeys("pgup")),
+		PageDown: key.NewBinding(key.WithKeys("pgdown")),
+		Up:       key.NewBinding(key.WithKeys("shift+up")),
+		Down:     key.NewBinding(key.WithKeys("shift+down")),
+	}
+	return vp
+}
+
+// scrollKeys are the keys that move the output region instead of reaching the
+// focused input or list.
+var scrollKeys = map[string]bool{"pgup": true, "pgdown": true, "shift+up": true, "shift+down": true}
+
+// syncBody re-flows the scrollable region: the viewport takes the height the pinned
+// footer leaves, and follows new output unless the user has scrolled up.
+func (m *ReplModel) syncBody() {
+	if m.width <= 0 || m.height <= 0 {
+		return
+	}
+	height := m.height - lipgloss.Height(m.footer())
+	if height < minBodyHeight {
+		height = minBodyHeight
+	}
+	follow := !m.bodySized || m.body.AtBottom()
+	m.body.SetWidth(m.width)
+	m.body.SetHeight(height)
+	m.body.SetContent(m.bodyContent())
+	m.bodySized = true
+	if follow {
+		m.body.GotoBottom()
+	}
+}
+
+// portHolders is a seam so tests can drive the port-conflict overlay without
+// depending on what happens to be listening on the developer's machine.
+var portHolders = setup.PortHolders
+
+// launchTry starts a sample run, or opens the port-conflict overlay first when
+// something already holds one of the sample's dev ports: the run frees those ports
+// before it starts, and the holder may be an unrelated app.
+func (m *ReplModel) launchTry(sampleName string, opts sample.Options) tea.Cmd {
+	if holders := portHolders(sample.ServicePorts(opts.Features)...); len(holders) > 0 {
+		// runCommand latches tryingOut before dispatching the try. Release it while the
+		// overlay waits: a cancel returns to the prompt, and a stale latch would reject
+		// every later command as setup in progress.
+		m.tryingOut = false
+		m.showPortConflict = true
+		m.pcHolders = holders
+		m.pcSampleName = sampleName
+		m.pcOpts = opts
+		m.pcStop = true
+		m.input.Blur()
+		return nil
+	}
+	m.tryingOut = true
+	m.input.Blur()
+	return makeTryCmd(sampleName, m.installPath, m.verbose, opts)
+}
+
+// closePortConflict dismisses the port-conflict overlay. refocus hands the prompt back
+// to the user, which every path except the approved launch does.
+func (m *ReplModel) closePortConflict(refocus bool) {
+	m.showPortConflict = false
+	m.pcHolders = nil
+	if !refocus {
+		return
+	}
+	m.input.Focus()
+	if m.status == statusReady {
+		m.input.Placeholder = "Type / for commands, Ctrl+C to exit"
 	}
 }
 
@@ -595,7 +685,7 @@ func (m *ReplModel) initUCStep() {
 }
 
 // advanceUCStep records value for the current step then moves to the next.
-// When all steps are done it clears the config state and invokes ucComplete.
+// When all steps are done it clears the config state and starts the run.
 func (m *ReplModel) advanceUCStep(value string) tea.Cmd {
 	m.ucValues[m.ucInputs[m.ucStep].Key] = value
 	m.ucStep++
@@ -604,19 +694,34 @@ func (m *ReplModel) advanceUCStep(value string) tea.Cmd {
 		return nil
 	}
 	m.showUsecaseConfig = false
-	m.tryingOut = true
-	m.input.Blur()
-	return m.ucComplete(m.ucValues)
+	return m.launchTry(m.ucLaunch(m.ucValues))
 }
 
-// Update implements tea.Model.
-func (m ReplModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,funlen
+// Update implements tea.Model. It delegates to update and then re-flows the
+// scrollable region, so every state change is reflected in one place.
+func (m ReplModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	next, cmd := m.update(msg)
+	updated, ok := next.(ReplModel)
+	if !ok {
+		return next, cmd
+	}
+	updated.syncBody()
+	return updated, cmd
+}
+
+func (m ReplModel) update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,funlen
 	var cmds []tea.Cmd
 
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
+		m.height = msg.Height
 		m.onboardingList.SetSize(msg.Width, onboardingListHeight)
+
+	case tea.MouseWheelMsg:
+		var vpCmd tea.Cmd
+		m.body, vpCmd = m.body.Update(msg)
+		cmds = append(cmds, vpCmd)
 
 	// Bracketed paste arrives as its own message rather than as key presses, so the
 	// overlay inputs need it routed explicitly — the command input already receives
@@ -635,8 +740,41 @@ func (m ReplModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,fu
 	case tea.KeyPressMsg:
 		if msg.String() == "ctrl+c" {
 			m.quitting = true
-			m.killThunder()
+			m.killThunderID()
 			return m, tea.Quit
+		}
+
+		// Scrolling the output must work in every mode, and must not reach the
+		// focused input or list underneath.
+		if scrollKeys[msg.String()] {
+			var vpCmd tea.Cmd
+			m.body, vpCmd = m.body.Update(msg)
+			cmds = append(cmds, vpCmd)
+			return m, tea.Batch(cmds...)
+		}
+
+		if m.showPortConflict {
+			// ── Sample dev-port conflict ───────────────────────────────────────
+			switch msg.String() {
+			case "up", "down", "left", "right", "tab":
+				m.pcStop = !m.pcStop
+			case "enter":
+				if m.pcStop {
+					sampleName, opts := m.pcSampleName, m.pcOpts
+					m.closePortConflict(false)
+					m.tryingOut = true
+					m.input.Blur()
+					cmds = append(cmds, makeTryCmd(sampleName, m.installPath, m.verbose, opts))
+					break
+				}
+				held := portsSummary(m.pcHolders)
+				m.closePortConflict(true)
+				m.messages = append(m.messages,
+					Yellow("○")+" Cancelled. The processes on "+held+" were left running.")
+			case "esc":
+				m.closePortConflict(true)
+			}
+			return m, tea.Batch(cmds...)
 		}
 
 		if m.showOnboarding && m.status == statusReady {
@@ -847,7 +985,7 @@ func (m ReplModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,fu
 		}
 
 	case sampleTryRequestMsg:
-		cmds = append(cmds, makeTryCmd(msg.sampleName, m.installPath, m.verbose, sample.Options{
+		cmds = append(cmds, m.launchTry(msg.sampleName, sample.Options{
 			Features: msg.features, Port: m.effectivePort(),
 		}))
 
@@ -857,13 +995,13 @@ func (m ReplModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,fu
 		m.ucEnvTarget = msg.envTarget
 		m.ucFeatures = msg.features
 
-		// Capture msg fields for the completion closure.
-		sampleName, ip, envTarget, features := msg.sampleName, m.installPath, msg.envTarget, msg.features
+		// Capture msg fields for the launch closure.
+		sampleName, envTarget, features := msg.sampleName, msg.envTarget, msg.features
 		port := m.effectivePort()
-		m.ucComplete = func(values map[string]string) tea.Cmd {
-			return makeTryCmd(sampleName, ip, m.verbose, sample.Options{
+		m.ucLaunch = func(values map[string]string) (string, sample.Options) {
+			return sampleName, sample.Options{
 				Config: values, EnvTarget: envTarget, Features: features, Port: port,
-			})
+			}
 		}
 
 		// Pre-populate from a previous run so the user is not re-prompted.
@@ -882,9 +1020,7 @@ func (m ReplModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,fu
 
 		if m.ucStep >= len(m.ucInputs) {
 			// All values already present — launch immediately without prompting.
-			m.tryingOut = true
-			m.input.Blur()
-			cmds = append(cmds, m.ucComplete(m.ucValues))
+			cmds = append(cmds, m.launchTry(m.ucLaunch(m.ucValues)))
 		} else {
 			m.showUsecaseConfig = true
 			m.input.Blur()
@@ -1054,14 +1190,8 @@ func (m ReplModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,fu
 			m.input.Placeholder = "Type / for commands, Ctrl+C to exit"
 		}
 
-	// The three exits below replace the running product, so the sample must not
-	// survive: it would keep its ports and point at a base URL that is gone.
-	case cutoverMsg:
-		sample.StopServices()
-		m.cutoverRequested = true
-		m.quitting = true
-		return m, tea.Quit
-
+	// Both exits below replace the running product, so the sample must not survive:
+	// it would keep its ports and point at a base URL that is gone.
 	case upgradeMsg:
 		sample.StopServices()
 		m.upgradeRequested = true
@@ -1119,7 +1249,10 @@ func (m *ReplModel) updateCompletions() {
 
 func (m *ReplModel) runCommand(val string) tea.Cmd {
 	if val == "/stop" {
-		m.killThunder()
+		if err := m.stopThunderID(true); err != nil {
+			m.messages = append(m.messages, Red("✗")+" Could not stop "+product.Name+": "+err.Error())
+			return nil
+		}
 		return tea.Quit
 	}
 	if m.tryingOut {
@@ -1151,19 +1284,56 @@ func (m *ReplModel) runCommand(val string) tea.Cmd {
 	return nil
 }
 
-func (m *ReplModel) killThunder() {
+// killThunderID stops what this CLI started and leaves an instance it merely attached to
+// running, which is what exiting the session should do.
+func (m *ReplModel) killThunderID() {
+	// This path cannot fail: it only signals a handle the CLI owns.
+	_ = m.stopThunderID(false)
+}
+
+// stopThunderID stops the sample and the product. When the CLI started the product it
+// holds a handle to the launcher and signals that. When it attached to an instance
+// started by an earlier run there is no handle, so an explicit stop falls back to the
+// process listening on the session's port — without that fallback an orphaned server
+// could never be stopped through the CLI. An undeliverable signal takes that same
+// fallback. It only runs when the product answers on the port, so an unrelated listener
+// is never terminated.
+func (m *ReplModel) stopThunderID(explicit bool) error {
 	// Stop the sample first: its backend talks to the product, so stopping the
 	// dependant before the product avoids error spew in the sample log.
 	sample.StopServices()
-	if m.proc == nil || m.proc.Process == nil {
-		return
+
+	if m.proc != nil && m.proc.Process != nil {
+		// SIGTERM lets start.sh's cleanup trap stop ThunderID cleanly before exiting.
+		// SIGKILL would bypass the trap and leave the port occupied, causing the next
+		// invocation to fail.
+		if err := m.proc.Process.Signal(syscall.SIGTERM); err == nil {
+			time.Sleep(time.Second)
+			return nil
+		}
+		// The launcher is already gone, so no trap ran for this stop and the server it
+		// backgrounded can still be listening. Reporting success here would quit the
+		// session leaving that server up, so fall through to the port stop.
 	}
-	// SIGTERM lets start.sh's cleanup trap stop ThunderID cleanly before exiting.
-	// SIGKILL would bypass the trap and leave the port occupied, causing the next
-	// invocation to fail.
-	m.proc.Process.Signal(syscall.SIGTERM) //nolint:errcheck
-	time.Sleep(time.Second)
+	if !explicit {
+		return nil
+	}
+	port := m.effectivePort()
+	if !productOnPort(port) {
+		return nil // nothing of ours is listening
+	}
+	return stopPort(port)
 }
+
+// stopTimeout bounds an explicit stop of an attached instance.
+const stopTimeout = 15 * time.Second
+
+// productOnPort and stopPort are variables so tests can exercise the attached-stop
+// path without signaling whatever holds that port on the developer's machine.
+var (
+	productOnPort = health.IsReady
+	stopPort      = func(port int) error { return setup.FreePort(port, stopTimeout) }
+)
 
 func renderCompletions(m ReplModel) string {
 	if !m.showCompletions || len(m.completions) == 0 {
@@ -1392,6 +1562,47 @@ func renderIntegrate(m ReplModel) string {
 	return b.String()
 }
 
+// renderPortConflict names the processes holding the sample's dev ports. Those ports
+// are pinned in the sample's generated config, so the only choices, rendered by
+// portConflictChoices in the pinned footer, are stopping the holders or canceling.
+func renderPortConflict(m ReplModel) string {
+	var b strings.Builder
+	b.WriteString("  " + Bold("Ports needed by the "+m.pcSampleName+" sample are in use") + "\n\n")
+	for _, h := range m.pcHolders {
+		b.WriteString("  " + Dim(h.String()) + "\n")
+	}
+	b.WriteString("\n  " + Dim("Starting the sample frees these ports, which stops whatever holds them.") + "\n")
+	return b.String()
+}
+
+// portConflictChoices renders the answer the user is about to give.
+func portConflictChoices(m ReplModel) string {
+	var b strings.Builder
+	for i, opt := range []string{"Stop these processes and continue", "Cancel, leave them running"} {
+		if (i == 0) == m.pcStop {
+			b.WriteString("  " + Cyan("> "+opt) + "\n")
+		} else {
+			b.WriteString("    " + Dim(opt) + "\n")
+		}
+	}
+	b.WriteString("\n" + Dim("  ↑/↓ select  •  Enter to confirm  •  esc cancel"))
+	return b.String()
+}
+
+// portsSummary lists the ports held by holders as a comma-separated string.
+func portsSummary(holders []setup.PortHolder) string {
+	seen := make(map[int]bool, len(holders))
+	var ports []string
+	for _, h := range holders {
+		if seen[h.Port] {
+			continue
+		}
+		seen[h.Port] = true
+		ports = append(ports, strconv.Itoa(h.Port))
+	}
+	return strings.Join(ports, ", ")
+}
+
 // credentialsBox renders a bordered box with the generated admin credentials, so
 // they stay visible on the alternate screen for the whole session. Returns an empty
 // string when no credentials were generated this run.
@@ -1417,21 +1628,38 @@ func (m ReplModel) credentialsBox() string {
 func (m ReplModel) View() tea.View {
 	v := tea.NewView(m.render())
 	v.AltScreen = true
+	// The output region scrolls, so the wheel has to reach it: the alternate screen
+	// has no scrollback of its own.
+	v.MouseMode = tea.MouseModeCellMotion
 	return v
 }
 
-// render builds the REPL view content as a string.
+// minBodyHeight keeps a usable slice of output visible on very short terminals.
+const minBodyHeight = 3
+
+// render builds the REPL view: a scrolling output region above a pinned footer that
+// always keeps the input (or the current spinner) on screen.
 func (m ReplModel) render() string {
 	if m.quitting {
 		return Dim("Stopping " + product.Name + "...\n")
 	}
+	footer := m.footer()
+	if !m.bodySized {
+		// No window size yet (first frame): render flat rather than guessing a height.
+		return m.bodyContent() + footer
+	}
+	return m.body.View() + "\n" + footer
+}
 
+// bodyContent builds the scrollable region: the banner, server status and everything
+// the session has printed so far.
+func (m ReplModel) bodyContent() string {
 	var b strings.Builder
 
 	b.WriteString(BannerString() + "\n")
 
 	if m.nodeWarning != "" {
-		b.WriteString(noteBoxStyle.Render(Yellow("⚠ "+m.nodeWarning)) + "\n\n")
+		b.WriteString(fitBox(noteBoxStyle, noteChrome, Yellow("⚠ "+m.nodeWarning)) + "\n\n")
 	}
 
 	b.WriteString(Bold("⚡ "+product.Name+" v"+m.version) + "\n")
@@ -1449,16 +1677,14 @@ func (m ReplModel) render() string {
 	b.WriteString(Dim(strings.Repeat("─", clamp(m.width-2, 20, 80))) + "\n\n")
 
 	if m.showOnboarding && m.status == statusReady {
-		if m.onboardingCmdMode {
-			// Slash-command overlay: show completions and input, no list.
-			b.WriteString(renderCompletions(m))
-			b.WriteString(m.input.View())
-			b.WriteString("\n\n" + Dim("  esc back to use-case picker"))
-		} else {
-			// List mode with custom hint replacing the list's built-in help.
+		if !m.onboardingCmdMode {
 			b.WriteString(strings.TrimRight(m.onboardingList.View(), "\n"))
-			b.WriteString("\n" + Dim("  ↑/k up  •  ↓/j down  •  / commands"))
 		}
+		return b.String()
+	}
+
+	if m.showPortConflict {
+		b.WriteString(renderPortConflict(m))
 		return b.String()
 	}
 
@@ -1471,6 +1697,47 @@ func (m ReplModel) render() string {
 		if len(inp.Instructions) > 0 {
 			b.WriteString("\n")
 		}
+		return b.String()
+	}
+
+	for _, msg := range m.messages {
+		b.WriteString("  " + msg + "\n")
+	}
+	if len(m.messages) > 0 {
+		b.WriteString("\n")
+	}
+
+	// The guides carry their own navigation hints, so they scroll with the output.
+	if m.showIntegrate {
+		b.WriteString(renderIntegrate(m))
+	} else if m.showWalkthrough {
+		b.WriteString(renderWalkthrough(m))
+	}
+	return b.String()
+}
+
+// footer builds the pinned region below the scrolling output: the completion list and
+// whatever the user types into or waits on.
+func (m ReplModel) footer() string {
+	var b strings.Builder
+
+	if m.showOnboarding && m.status == statusReady {
+		if m.onboardingCmdMode {
+			b.WriteString(renderCompletions(m))
+			b.WriteString(m.input.View())
+			b.WriteString("\n\n" + Dim("  esc back to use-case picker"))
+		} else {
+			b.WriteString("\n" + Dim("  ↑/k up  •  ↓/j down  •  / commands"))
+		}
+		return b.String()
+	}
+
+	if m.showPortConflict {
+		return portConflictChoices(m)
+	}
+
+	if m.showUsecaseConfig {
+		inp := m.ucInputs[m.ucStep]
 		if len(inp.Choices) > 0 {
 			b.WriteString(m.ucList.View())
 			b.WriteString("\n" + Dim("  ↑/↓ select  •  Enter to continue"))
@@ -1485,21 +1752,8 @@ func (m ReplModel) render() string {
 		return b.String()
 	}
 
-	for _, msg := range m.messages {
-		b.WriteString("  " + msg + "\n")
-	}
-	if len(m.messages) > 0 {
-		b.WriteString("\n")
-	}
-
-	if m.showIntegrate {
-		b.WriteString(renderIntegrate(m))
-		return b.String()
-	}
-
-	if m.showWalkthrough {
-		b.WriteString(renderWalkthrough(m))
-		return b.String()
+	if m.showIntegrate || m.showWalkthrough {
+		return Dim("  " + scrollHint)
 	}
 
 	b.WriteString(renderCompletions(m))
@@ -1513,9 +1767,13 @@ func (m ReplModel) render() string {
 		b.WriteString(m.spinner.View() + Dim(" Starting "+product.Name+"…"))
 	default:
 		b.WriteString(m.input.View())
+		b.WriteString("\n" + Dim("  "+scrollHint))
 	}
 	return b.String()
 }
+
+// scrollHint documents the keys that move the output region.
+const scrollHint = "PgUp/PgDn scroll  •  shift+↑/↓ line"
 
 func clamp(v, min, max int) int {
 	if v < min {
@@ -1548,27 +1806,4 @@ func RunREPL(
 		return rm.upgradeRequested, rm.switchRequested, runErr
 	}
 	return false, false, runErr
-}
-
-// RunStagingREPL runs the REPL connected to a staging instance on stagingPort.
-// It injects a /cutover command; when the user runs it the REPL exits and
-// cutoverRequested=true is returned so the caller can perform the cut-over.
-func RunStagingREPL(version string, proc *exec.Cmd, installPath string, verbose bool, stagingPort int, creds *setup.AdminCredentials) (cutoverRequested bool, err error) {
-	m := NewReplModel(version, proc, installPath, verbose, false, creds)
-	m.checkPort = stagingPort
-	m.commands = append([]SlashCommand{
-		{
-			Name:        "/cutover",
-			Description: "Cut over to this version and restart on the default port",
-			AsyncAction: func(_ string) tea.Cmd {
-				return func() tea.Msg { return cutoverMsg{} }
-			},
-		},
-	}, m.commands...)
-	p := tea.NewProgram(m)
-	finalModel, runErr := p.Run()
-	if rm, ok := finalModel.(ReplModel); ok {
-		return rm.cutoverRequested, runErr
-	}
-	return false, runErr
 }

--- a/tools/cli/internal/ui/repl_internal_test.go
+++ b/tools/cli/internal/ui/repl_internal_test.go
@@ -4,13 +4,18 @@
 package ui
 
 import (
+	"fmt"
 	"io"
 	"os"
+	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 
+	"github.com/thunder-id/thunderid/tools/cli/internal/commands/sample"
 	"github.com/thunder-id/thunderid/tools/cli/internal/services/setup"
 )
 
@@ -127,5 +132,388 @@ func TestPaste_IgnoredOnChoiceStep(t *testing.T) {
 	}
 	if got := next.input.Value(); got != "" {
 		t.Fatalf("paste must not leak to the command input: got %q", got)
+	}
+}
+
+// keyPress builds the key message the REPL receives for a named key.
+func keyPress(name string) tea.KeyPressMsg {
+	return tea.KeyPressMsg{Code: keyCodeFor(name), Mod: keyModFor(name)}
+}
+
+func keyCodeFor(name string) rune {
+	switch name {
+	case "pgup":
+		return tea.KeyPgUp
+	case "pgdown":
+		return tea.KeyPgDown
+	case "shift+up", "up":
+		return tea.KeyUp
+	case "shift+down", "down":
+		return tea.KeyDown
+	case "enter":
+		return tea.KeyEnter
+	case "esc":
+		return tea.KeyEscape
+	}
+	return 0
+}
+
+func keyModFor(name string) tea.KeyMod {
+	if strings.HasPrefix(name, "shift+") {
+		return tea.ModShift
+	}
+	return 0
+}
+
+// longOutputModel returns a ready REPL sized to a short terminal, holding more output
+// than fits on screen.
+func longOutputModel(t *testing.T, lines int) ReplModel {
+	t.Helper()
+	m := NewReplModel("1.0.0", nil, "/tmp/x", false, false, nil)
+	m.status = statusReady
+	m.input.Focus()
+	for i := 0; i < lines; i++ {
+		m.messages = append(m.messages, fmt.Sprintf("output line %d", i))
+	}
+	return updateModel(t, m, tea.WindowSizeMsg{Width: 100, Height: 24})
+}
+
+// Output longer than the terminal used to push the input line off screen; the view
+// must stay within the window and keep the prompt visible.
+func TestRender_LongOutputKeepsInputOnScreen(t *testing.T) {
+	m := longOutputModel(t, 200)
+	out := m.render()
+
+	if height := lipgloss.Height(out); height > 24 {
+		t.Fatalf("view is %d lines tall, does not fit a 24-line terminal:\n%s", height, out)
+	}
+	if !strings.Contains(out, m.input.Prompt) {
+		t.Fatalf("input prompt is not visible:\n%s", out)
+	}
+	if !strings.Contains(out, "output line 199") {
+		t.Fatalf("expected the newest output to be visible:\n%s", out)
+	}
+}
+
+// Earlier output stays reachable: PgUp scrolls back, PgDn returns to the newest lines.
+func TestScrollKeys_RevealEarlierOutputAndReturn(t *testing.T) {
+	m := longOutputModel(t, 200)
+
+	scrolledUp := m
+	for i := 0; i < 10; i++ {
+		scrolledUp = updateModel(t, scrolledUp, keyPress("pgup"))
+	}
+	up := scrolledUp.render()
+	if strings.Contains(up, "output line 199") {
+		t.Fatalf("PgUp did not move away from the newest output:\n%s", up)
+	}
+	if !strings.Contains(up, m.input.Prompt) {
+		t.Fatalf("input prompt must stay pinned while scrolling:\n%s", up)
+	}
+
+	back := scrolledUp
+	for i := 0; i < 20; i++ {
+		back = updateModel(t, back, keyPress("pgdown"))
+	}
+	if out := back.render(); !strings.Contains(out, "output line 199") {
+		t.Fatalf("PgDn did not return to the newest output:\n%s", out)
+	}
+}
+
+// Scroll keys must not leak into the focused command input.
+func TestScrollKeys_DoNotReachTheInput(t *testing.T) {
+	m := longOutputModel(t, 50)
+	m.input.SetValue("/try")
+
+	next := updateModel(t, m, keyPress("pgup"))
+	if got := next.input.Value(); got != "/try" {
+		t.Fatalf("scroll key changed the input value: got %q", got)
+	}
+}
+
+// New output while the user reads earlier output must not yank the view to the bottom.
+func TestNewOutput_DoesNotStealScrollPosition(t *testing.T) {
+	m := longOutputModel(t, 200)
+	for i := 0; i < 10; i++ {
+		m = updateModel(t, m, keyPress("pgup"))
+	}
+	before := m.render()
+
+	m.messages = append(m.messages, "fresh output")
+	m = updateModel(t, m, sampleProgressMsg{line: "working"})
+
+	if after := m.render(); after != before {
+		t.Fatalf("scroll position moved on new output:\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+// stubPortHolders replaces the port lookup for the duration of a test, so the overlay
+// does not depend on what is listening on the machine running the tests.
+func stubPortHolders(t *testing.T, holders []setup.PortHolder) {
+	t.Helper()
+	orig := portHolders
+	portHolders = func(_ ...int) []setup.PortHolder { return holders }
+	t.Cleanup(func() { portHolders = orig })
+}
+
+// A sample run frees the dev ports it needs, so an unrelated process holding one of
+// them must not be stopped before the user has been asked.
+func TestLaunchTry_HeldPortsOpenTheOverlayInsteadOfStarting(t *testing.T) {
+	stubPortHolders(t, []setup.PortHolder{{Port: 5173, PID: 4242, Name: "node"}})
+	m := NewReplModel("1.0.0", nil, "/tmp/x", false, false, nil)
+
+	if cmd := m.launchTry("wayfinder", sample.Options{}); cmd != nil {
+		t.Fatal("expected no launch command while the conflict is unresolved")
+	}
+	if !m.showPortConflict {
+		t.Fatal("expected the port-conflict overlay to open")
+	}
+	if m.tryingOut {
+		t.Fatal("the sample must not start before the user approves")
+	}
+	if view := renderPortConflict(m); !strings.Contains(view, "5173") || !strings.Contains(view, "4242") {
+		t.Fatalf("overlay does not name the port holder:\n%s", view)
+	}
+}
+
+func TestLaunchTry_FreePortsStartImmediately(t *testing.T) {
+	stubPortHolders(t, nil)
+	m := NewReplModel("1.0.0", nil, "/tmp/x", false, false, nil)
+
+	if cmd := m.launchTry("wayfinder", sample.Options{}); cmd == nil {
+		t.Fatal("expected the sample to start when no port is held")
+	}
+	if m.showPortConflict {
+		t.Fatal("there is no conflict to show")
+	}
+	if !m.tryingOut {
+		t.Fatal("expected tryingOut to be set")
+	}
+}
+
+func TestPortConflictOverlay_ApproveStartsTheSample(t *testing.T) {
+	stubPortHolders(t, []setup.PortHolder{{Port: 8787, PID: 51, Name: "node"}})
+	m := NewReplModel("1.0.0", nil, "/tmp/x", false, false, nil)
+	m.launchTry("wayfinder", sample.Options{})
+
+	next := updateModel(t, m, keyPress("enter"))
+
+	if next.showPortConflict {
+		t.Fatal("expected the overlay to close on Enter")
+	}
+	if !next.tryingOut {
+		t.Fatal("expected the sample to start after approval")
+	}
+}
+
+func TestPortConflictOverlay_CancelLeavesHoldersRunning(t *testing.T) {
+	stubPortHolders(t, []setup.PortHolder{{Port: 8787, PID: 51, Name: "node"}})
+	m := NewReplModel("1.0.0", nil, "/tmp/x", false, false, nil)
+	m.launchTry("wayfinder", sample.Options{})
+
+	// Move the selection off the default answer, then confirm.
+	m = updateModel(t, m, keyPress("down"))
+	if m.pcStop {
+		t.Fatal("expected the selection to move to Cancel")
+	}
+	next := updateModel(t, m, keyPress("enter"))
+
+	if next.showPortConflict {
+		t.Fatal("expected the overlay to close on Enter")
+	}
+	if next.tryingOut {
+		t.Fatal("the sample must not start after canceling")
+	}
+	if len(next.messages) == 0 || !strings.Contains(next.messages[len(next.messages)-1], "8787") {
+		t.Fatalf("expected a message naming the untouched port, got %v", next.messages)
+	}
+}
+
+// runCommand latches tryingOut before the try is dispatched. Cancelling the overlay
+// returns to the prompt, so a latch left set would reject every later command.
+func TestPortConflictOverlay_CancelReleasesTheCommandLatch(t *testing.T) {
+	stubPortHolders(t, []setup.PortHolder{{Port: 5173, PID: 61, Name: "node"}})
+	m := NewReplModel("1.0.0", nil, "/tmp/x", false, false, nil)
+	m.tryingOut = true // as runCommand sets it before dispatching the try
+	m.launchTry("wayfinder", sample.Options{})
+
+	next := updateModel(t, m, keyPress("esc"))
+
+	if next.tryingOut {
+		t.Fatal("the latch must be released when the overlay opens")
+	}
+	next.runCommand("/nope")
+	last := next.messages[len(next.messages)-1]
+	if strings.Contains(last, "setup is in progress") {
+		t.Fatalf("commands are still rejected after cancelling: %q", last)
+	}
+}
+
+func TestPortConflictOverlay_EscDismisses(t *testing.T) {
+	stubPortHolders(t, []setup.PortHolder{{Port: 2525, PID: 52}})
+	m := NewReplModel("1.0.0", nil, "/tmp/x", false, false, nil)
+	m.launchTry("wayfinder", sample.Options{})
+
+	next := updateModel(t, m, keyPress("esc"))
+
+	if next.showPortConflict || next.tryingOut {
+		t.Fatalf("esc must dismiss the overlay without starting: conflict=%v trying=%v",
+			next.showPortConflict, next.tryingOut)
+	}
+}
+
+// The use-case config flow launches once its values are collected, and must go
+// through the same approval as a direct /try.
+func TestAdvanceUCStep_LastStepChecksPorts(t *testing.T) {
+	stubPortHolders(t, []setup.PortHolder{{Port: 5173, PID: 53, Name: "node"}})
+	m := NewReplModel("1.0.0", nil, "/tmp/x", false, false, nil)
+	m.showUsecaseConfig = true
+	m.ucInputs = []ConfigInput{{Key: "LLM_API_KEY", Label: "API key"}}
+	m.ucValues = map[string]string{}
+	m.ucLaunch = func(values map[string]string) (string, sample.Options) {
+		return "wayfinder", sample.Options{Config: values, Features: []string{"ai"}}
+	}
+
+	if cmd := m.advanceUCStep("key-123"); cmd != nil {
+		t.Fatal("expected no launch command while the conflict is unresolved")
+	}
+	if !m.showPortConflict {
+		t.Fatal("expected the port-conflict overlay after the last config step")
+	}
+	if m.showUsecaseConfig {
+		t.Fatal("expected the config overlay to close")
+	}
+}
+
+// stubStopPort replaces the port-stop hooks and returns the ports it was asked to stop.
+func stubStopPort(t *testing.T, ready bool) *[]int {
+	t.Helper()
+	origReady, origStop := productOnPort, stopPort
+	stopped := []int{}
+	productOnPort = func(int) bool { return ready }
+	stopPort = func(port int) error {
+		stopped = append(stopped, port)
+		return nil
+	}
+	t.Cleanup(func() { productOnPort, stopPort = origReady, origStop })
+	return &stopped
+}
+
+// An attached session holds no process handle, so /stop used to be a no-op and an
+// orphaned server could never be stopped through the CLI.
+func TestStop_AttachedSessionStopsTheListeningServer(t *testing.T) {
+	stopped := stubStopPort(t, true)
+	m := NewReplModel("1.0.0", nil, "/tmp/x", false, false, nil)
+	m.checkPort = 8091
+
+	if err := m.stopThunderID(true); err != nil {
+		t.Fatalf("stopThunderID: %v", err)
+	}
+	if len(*stopped) != 1 || (*stopped)[0] != 8091 {
+		t.Fatalf("expected the session port to be stopped, got %v", *stopped)
+	}
+}
+
+// The fallback must not terminate an unrelated process that happens to hold the port.
+func TestStop_AttachedSessionLeavesForeignListenerAlone(t *testing.T) {
+	stopped := stubStopPort(t, false)
+	m := NewReplModel("1.0.0", nil, "/tmp/x", false, false, nil)
+	m.checkPort = 8091
+
+	if err := m.stopThunderID(true); err != nil {
+		t.Fatalf("stopThunderID: %v", err)
+	}
+	if len(*stopped) != 0 {
+		t.Fatalf("expected no stop attempt when the product does not answer, got %v", *stopped)
+	}
+}
+
+// Exiting the CLI stops only what it started: an instance it merely attached to keeps
+// running, so Ctrl+C in an onlooker session does not take the server down.
+func TestExit_AttachedSessionLeavesTheServerRunning(t *testing.T) {
+	stopped := stubStopPort(t, true)
+	m := NewReplModel("1.0.0", nil, "/tmp/x", false, false, nil)
+	m.checkPort = 8091
+
+	m.killThunderID()
+
+	if len(*stopped) != 0 {
+		t.Fatalf("exiting an attached session must not stop the server, got %v", *stopped)
+	}
+}
+
+// When the CLI owns the launcher it signals that handle instead of the port, so
+// start.sh's cleanup trap runs.
+func TestStop_OwnedProcessIsSignalledNotPortKilled(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX signal")
+	}
+	stopped := stubStopPort(t, true)
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+
+	m := NewReplModel("1.0.0", cmd, "/tmp/x", false, false, nil)
+	m.checkPort = 8091
+
+	if err := m.stopThunderID(true); err != nil {
+		t.Fatalf("stopThunderID: %v", err)
+	}
+	if len(*stopped) != 0 {
+		t.Fatalf("an owned launcher must be signaled, not port-killed, got %v", *stopped)
+	}
+}
+
+// The launcher can exit before /stop runs — start.sh's trap only stops the server it
+// backgrounded when the trap actually runs, so an undeliverable SIGTERM must not be
+// reported as a successful stop.
+func TestStop_UndeliverableSignalFallsBackToThePort(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX signal")
+	}
+	stopped := stubStopPort(t, true)
+	cmd := exec.Command("true")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+
+	m := NewReplModel("1.0.0", cmd, "/tmp/x", false, false, nil)
+	m.checkPort = 8091
+
+	if err := m.stopThunderID(true); err != nil {
+		t.Fatalf("stopThunderID: %v", err)
+	}
+	if len(*stopped) != 1 || (*stopped)[0] != 8091 {
+		t.Fatalf("expected the port stop to take over, got %v", *stopped)
+	}
+}
+
+// Exiting is not an explicit stop: the server an exited launcher left behind is not
+// this session's to take down on the way out.
+func TestExit_UndeliverableSignalLeavesThePortAlone(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX signal")
+	}
+	stopped := stubStopPort(t, true)
+	cmd := exec.Command("true")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+
+	m := NewReplModel("1.0.0", cmd, "/tmp/x", false, false, nil)
+	m.checkPort = 8091
+
+	m.killThunderID()
+
+	if len(*stopped) != 0 {
+		t.Fatalf("exiting must not port-stop, got %v", *stopped)
 	}
 }

--- a/tools/npx/README.md
+++ b/tools/npx/README.md
@@ -18,7 +18,7 @@ the cached installation and start immediately.
 | Command              | Description                                        |
 | -------------------- | -------------------------------------------------- |
 | _(none)_             | Install (if needed) and start ThunderID            |
-| `upgrade`            | Upgrade to the latest release (side-by-side)       |
+| `upgrade`            | Upgrade to the latest release                      |
 | `try <use-case>`     | Download and launch a use-case sample app          |
 | `integrate <tech>`   | Configure a technology integration _(coming soon)_ |
 
@@ -30,15 +30,9 @@ the cached installation and start immediately.
 | `--verbose`, `-v` | Show detailed output                     |
 | `--help`, `-h`    | Show help                                |
 
-### Upgrade flags
-
-| Flag       | Description                                          |
-| ---------- | ---------------------------------------------------- |
-| `--direct` | Upgrade in-place (stop current, upgrade, restart)    |
-
 ## Requirements
 
-- **Node.js** `>= 18`
+- **Node.js** `>= 22.23.1`
 
 ## Supported Platforms
 

--- a/tools/npx/package.json
+++ b/tools/npx/package.json
@@ -17,6 +17,9 @@
   "bin": {
     "thunderid": "./bin/thunderid.js"
   },
+  "engines": {
+    "node": ">=22.23.1"
+  },
   "files": [
     "bin",
     "dist"


### PR DESCRIPTION
Stacked on #4908 — this branch is based on it, so the diff carries that commit too until it merges. Review only `Make the npx CLI handle port conflicts and report real failures`; I will rebase onto `main` once #4908 lands.

Covers the remaining scenarios in #4836 (items 2–8 and the smaller issues; item 1 is #4908).

- `deployment.yaml` is the only port the server honours, so the CLI takes its port from there, writes the port it settles on before setup and start, and health-checks that port everywhere — start, attach, upgrade, cutover and sample restarts all assumed the default before.
- Port conflicts are resolved on every start path, so a run after the first install no longer terminates whatever holds the port without asking. Termination escalates from a polite stop to a forced kill and reports what survives.
- Startup waits for the server to answer before reporting success, and a failed start shows the server's own reason and log tail.
- An unreachable release server no longer blocks starting an installed version, and the release fetch reports both hosts it tried.
- REPL output scrolls under a pinned input line.
- `/stop` works in a session that attached to an instance an earlier run started.
- Smaller: boxes fit the terminal, a failed download cleans up after itself, the Windows stop path matches unix, and the documented Node.js requirement matches what the CLI checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added custom server port support across setup, upgrades, switching, and sample runs.
  - Startup now waits for readiness, displays the assigned port, and reports fatal errors promptly.
  - Added scrollable REPL output with mouse and keyboard navigation.
  - Improved cross-platform process cleanup and port-conflict confirmation.
  - Terminal messages and banners adapt to screen width.
  - Falls back to the installed active version when release information is unavailable.

- **Bug Fixes**
  - Safely cleans up incomplete downloads and extractions.
  - Preserves running instances when release checks fail.
  - Includes relevant log details in startup failures.

- **Documentation**
  - Updated the minimum Node.js requirement to 22.23.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->