### PR TITLE
Set composite as the default store for OpenID4VCI and OpenID4VP

### DIFF
--- a/backend/cmd/server/config/default.json
+++ b/backend/cmd/server/config/default.json
@@ -345,7 +345,8 @@
     "key_binding_max_age_seconds": 300,
     "result_token_validity_seconds": 300,
     "enforce_key_binding": true,
-    "trusted_anchors": []
+    "trusted_anchors": [],
+    "store": "composite"
   },
   "openid4vci": {
     "signing_key_id": "ecdsa-key",
@@ -353,7 +354,8 @@
     "proof_max_age_seconds": 300,
     "credential_validity_seconds": 2592000,
     "batch_size": 5,
-    "enforce_scope": false
+    "enforce_scope": false,
+    "store": "composite"
   },
   "attestation": {
     "apple": {

--- a/tests/integration/resources/scripts/setup-test-config.ps1
+++ b/tests/integration/resources/scripts/setup-test-config.ps1
@@ -131,12 +131,6 @@ flow:
 server_config:
   store: composite
 
-openid4vci:
-  store: composite
-
-openid4vp:
-  store: composite
-
 oauth:
   allow_wildcard_redirect_uri: true
   send_server_errors_to_client: true

--- a/tests/integration/resources/scripts/setup-test-config.sh
+++ b/tests/integration/resources/scripts/setup-test-config.sh
@@ -121,12 +121,6 @@ flow:
 server_config:
   store: composite
 
-openid4vci:
-  store: composite
-
-openid4vp:
-  store: composite
-
 oauth:
   allow_wildcard_redirect_uri: true
   send_server_errors_to_client: true


### PR DESCRIPTION
### Purpose
Verifiable credential data (OpenID4VCI and OpenID4VP) was not persisted by default because the `openid4vci` and `openid4vp` sections in `default.json` had no `store` setting, so they fell back to the in-memory store. This meant VC issuance and presentation state was lost on restart in a default deployment, and every environment that wanted persistence had to override the setting explicitly.

This PR sets `composite` as the default store for both sections.

### Approach
- Added `"store": "composite"` to the `openid4vp` and `openid4vci` sections in `backend/cmd/server/config/default.json`, matching how `server_config` already defaults.
- Removed the now redundant `openid4vci.store` and `openid4vp.store` overrides from the integration test config setup scripts (`setup-test-config.sh` and `setup-test-config.ps1`), since the default now provides the same value.

No code changes, configuration defaults only.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [x] Integration Tests: existing OpenID4VCI/OpenID4VP integration tests now exercise the composite store through the default config instead of a test-only override.
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenID4VP and OpenID4VCI now use composite storage by default, improving flexibility for deployments that combine multiple storage backends.
* **Configuration**
  * Updated the default service configuration to enable composite storage while preserving existing trust-anchor and scope-enforcement settings.
* **Tests**
  * Updated integration test setup to align with the new default storage configuration and avoid redundant deployment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->