### PR TITLE
Correct identity provider documentation

### DIFF
--- a/docs/content/guides/identity-providers/add-github.mdx
+++ b/docs/content/guides/identity-providers/add-github.mdx
@@ -39,12 +39,14 @@ This guide walks you through registering a GitHub identity provider (IdP) in <Pr
 
 ## Step 2: Configure the GitHub Connection in the Console
 
+These steps create a GitHub connection. To change an existing connection, see [Manage Identity Providers](../manage-identity-providers#update-an-identity-provider).
+
 1. Sign in to the <ProductName /> Console.
 2. Navigate to **Connections**.
-3. Click the **GitHub** card. If the card shows **Not configured**, this opens a form to create the connection. If it already shows **Configured**, this opens the existing connection instead.
+3. Click the **GitHub Login** card marked **Not configured**.
 4. The form shows a setup hint with the **Redirect URI**. Copy it and add it to your GitHub OAuth app's authorization callback URL if you have not already done so.
 5. Enter your **Client ID** and **Client secret** from the previous step.
-6. Click **Create connection**. If you opened an existing **Configured** connection instead, update the credentials and click **Save changes**.
+6. Click **Create connection**.
 
 <ProductName /> automatically uses the GitHub authorization, token, and user profile endpoints. You do not need to supply them.
 
@@ -53,7 +55,7 @@ This guide walks you through registering a GitHub identity provider (IdP) in <Pr
 To map GitHub's profile fields (for example, `login` or `avatar_url`) to local user attributes, open the connection and go to the **Attribute Configuration** tab. See [Attribute Configuration](../add-oidc-provider#attribute-configuration).
 
 :::note
-By default, the connection uses GitHub's own default scope, which does not include the user's email address. To ensure the email address is accessible, open the connection after creation and set **Scopes** to include `user:email` on its edit page.
+The connection requests the `user:email` scope by default. To request different scopes, open the connection after creation and update **Scopes** on its edit page.
 
 The GitHub connection also accepts a `prompt` field, forwarded as a query parameter on the authorization request. GitHub's OAuth flow supports `select_account` to force the account picker. Set it on the connection's edit page, or through the [Connections API](../../../apis#tag/connections).
 :::

--- a/docs/content/guides/identity-providers/add-google.mdx
+++ b/docs/content/guides/identity-providers/add-google.mdx
@@ -37,12 +37,14 @@ This guide walks you through registering a Google identity provider (IdP) in <Pr
 
 ## Step 2: Configure the Google Connection in the Console
 
+These steps create a Google connection. To change an existing connection, see [Manage Identity Providers](../manage-identity-providers#update-an-identity-provider).
+
 1. Sign in to the <ProductName /> Console.
 2. Navigate to **Connections**.
-3. Click the **Google** card. If the card shows **Not configured**, this opens a form to create the connection. If it already shows **Configured**, this opens the existing connection instead.
+3. Click the **Google Login** card marked **Not configured**.
 4. The form shows a setup hint with the **Redirect URI**. Copy it and add it to your Google OAuth client's authorized redirect URIs if you have not already done so.
 5. Enter your **Client ID** and **Client secret** from the previous step.
-6. Click **Create connection**. If you opened an existing **Configured** connection instead, update the credentials and click **Save changes**.
+6. Click **Create connection**.
 
 <ProductName /> automatically uses the Google authorization, token, userinfo, and JWKS endpoints. You do not need to supply them.
 
@@ -53,6 +55,8 @@ The connection requests the `openid email profile` scopes by default. To change 
 
 The Google connection also accepts a `prompt` field to control the Google consent screen behavior (for example, `consent` or `select_account`). Set it on the connection's edit page, or through the [Connections API](../../../apis#tag/connections).
 :::
+
+To map Google's profile fields to local user attributes, open the connection and select the **Attribute Configuration** tab. See [Attribute Configuration](../add-oidc-provider#attribute-configuration).
 
 ## Next Steps
 

--- a/docs/content/guides/identity-providers/connect-idp-to-application.mdx
+++ b/docs/content/guides/identity-providers/connect-idp-to-application.mdx
@@ -8,7 +8,7 @@ description: Wire a configured identity provider into an application's authentic
 
 # Connect an IdP to an Application
 
-This guide explains how to enable social login for an application by connecting a configured identity provider (IdP) through an authentication flow.
+Connect a configured identity provider (IdP) to an application's sign-in flow to offer federated sign-in.
 
 ## How It Works
 
@@ -27,8 +27,10 @@ Applications in <ProductName /> do not reference IdPs directly. The connection r
   - [Add an OAuth 2.0 Identity Provider](../add-oauth-provider)
 - You have created an application. See [Manage Applications](../../applications/manage-applications).
 
-:::note Federated sign-in requires a local user
-By default, federated sign-in maps the external identity to a local user, which must already exist in the user store or the sign-in step fails. To sign in a first-time federated user, enable **Allow Authentication Without Local User** (`allowAuthenticationWithoutLocalUser`) on the social login executor and add a **Provisioning** executor to create the local account. See [Federated Authentication](../../flows/advanced-configurations#federated-authentication).
+:::note Just-in-time provisioning for first-time users
+The **Continue with Google Login** and **Continue with GitHub Login** widgets enable **Allow Authentication Without Local User** and add the Provisioning steps required to create a local account.
+
+For a generic OAuth 2.0 or OIDC connection, enable **Allow Authentication Without Local User** on the executor and add the **Provisioning** widget manually. Without this configuration, the external identity must map to an existing local user. See [Federated Authentication](../../flows/advanced-configurations#federated-authentication).
 :::
 
 :::note Configure a user type for first-time social sign-in
@@ -47,31 +49,40 @@ A **User Type Resolver** step selects the user type when several are eligible, b
 2. Navigate to **Flows**.
 3. Open the authentication flow assigned to your application, or click **+ Create New Flow** to create a new one.
 
-## Step 2: Add a Social Login Executor
+## Step 2: Add the Social Login Option
 
-1. In the left panel under **Widgets**, locate the social login executor for your provider:
-   - **Continue with Google**: for Google IdPs
-   - **Continue with GitHub**: for GitHub IdPs
-   - **OAuth** executor: for OAuth 2.0 IdPs
-   - **OIDC** executor: for OIDC IdPs
-2. Click **+** next to the executor to add it to the canvas.
+Follow the instructions for your connection type.
+
+### Google or GitHub
+
+1. In the left panel, expand **Widgets**.
+2. Click **+** on **Continue with Google Login** or **Continue with GitHub Login**.
+
+The widget adds a button to an existing View or creates a View when the flow has none. It also adds the provider executor, Provisioning steps for first-time users, and an Auth Assertion Generator, then connects the generated steps.
+
+If you have exactly one matching connection, <ProductName /> assigns it automatically. If you have multiple matching connections, click the provider executor and select the required **Connection**.
+
+### OAuth 2.0 or OIDC
+
+1. In the left panel, expand **Executors**.
+2. Click **+** on **OAuth** or **OIDC Auth**.
 3. Click the executor node to open its configuration panel.
-4. In the **Connection** dropdown, select the identity provider by the name you gave it when creating it (for example, `Google` or `My OIDC Provider`).
+4. Select the required **Connection**. <ProductName /> assigns it automatically when exactly one matching connection exists.
+5. To create local accounts for first-time users:
+   1. Enable **Allow Authentication Without Local User**.
+   2. Add the **Provisioning** widget to the flow.
 
-:::tip Auto-assignment
-If you have exactly one IdP of the matching type configured, <ProductName /> selects it automatically. You do not need to choose from the dropdown.
-:::
+## Step 3: Complete a Generic OAuth 2.0 or OIDC Flow
 
-## Step 3: Wire the Executor Into the Flow
+Skip this step if you added the Google or GitHub widget.
 
-Connect the social login executor to the flow:
+1. Add a **Button** component to the sign-in View and connect its output to the OAuth or OIDC executor.
+2. If you enabled **Allow Authentication Without Local User**, add the **Provisioning** widget.
+3. Add an **Auth Assertion Generator** executor.
+4. Connect the success path from the OAuth or OIDC executor to **Provisioning**, when present, and then to **Auth Assertion Generator**.
+5. Connect **Auth Assertion Generator** to **END**.
 
-- To offer social login **alongside password**: connect the **Sign In** view node to both the **Identifier + Password** executor and the social login executor. Merge both success paths into the **Auth Assertion Generator** executor.
-- To use social login **as the only sign-in method**: connect the social login executor directly between the **Sign In** view and the **Auth Assertion Generator**.
-
-:::note
-Every executor has a **red (failure) output**. Connect failure paths back to the **Sign In** view so users see an error message and can retry. Leaving a failure path unconnected stops the flow with an error.
-:::
+Route failure outputs to an error View if you want to display the failure reason. An unconnected failure output terminates the flow with an unhandled error. Use an executor's incomplete output only when that executor requests more input. See [Always Wire Failure Outputs](../../flows/build-a-flow#always-wire-failure-outputs).
 
 ## Step 4: Save the Flow
 
@@ -81,8 +92,8 @@ Click **Save** in the top-right corner.
 
 1. Navigate to **Applications** and open the application you want to configure.
 2. Open the **Flows** tab.
-3. Under **Authentication Flow**, select the flow you just saved from the dropdown.
-4. Click **Save**.
+3. Under **Sign-in Flow**, select the flow.
+4. Save the application.
 
 ## Step 6: Verify the Integration
 

--- a/docs/content/guides/identity-providers/manage-identity-providers.mdx
+++ b/docs/content/guides/identity-providers/manage-identity-providers.mdx
@@ -47,8 +47,9 @@ Changes take effect immediately for new authentication requests.
 ## Delete an Identity Provider
 
 1. Open the connection from the Connections page.
-2. On the **General** tab, go to **Danger zone** and click **Delete connection**.
-3. Confirm the deletion in the dialog.
+2. Open the **Advanced** tab.
+3. Under **Danger zone**, click **Delete connection**.
+4. Confirm the deletion in the dialog.
 
 If an authentication flow or another resource still references this identity provider, the dialog lists the resources and blocks the deletion until you remove or update them, for example, the flow node that uses this connection.
 

--- a/docs/versioned_docs/version-v1.0.x/guides/identity-providers/add-github.mdx
+++ b/docs/versioned_docs/version-v1.0.x/guides/identity-providers/add-github.mdx
@@ -39,21 +39,23 @@ This guide walks you through registering a GitHub identity provider (IdP) in <Pr
 
 ## Step 2: Configure the GitHub Connection in the Console
 
+These steps create a GitHub connection. To change an existing connection, see [Manage Identity Providers](../manage-identity-providers#update-an-identity-provider).
+
 1. Sign in to the <ProductName /> Console.
 2. Navigate to **Connections**.
-3. Click the **GitHub** card. If the card shows **Not configured**, this opens a form to create the connection. If it already shows **Configured**, this opens the existing connection instead.
+3. Click the **GitHub Login** card marked **Not configured**.
 4. The form shows a setup hint with the **Redirect URI**. Copy it and add it to your GitHub OAuth app's authorization callback URL if you have not already done so.
 5. Enter your **Client ID** and **Client secret** from the previous step.
-6. Click **Create connection**. If you opened an existing **Configured** connection instead, update the credentials and click **Save changes**.
+6. Click **Create connection**.
 
-<ProductName /> automatically uses the GitHub authorization, token, and userinfo endpoints. You do not need to supply them.
+<ProductName /> automatically uses the GitHub authorization, token, and user profile endpoints. You do not need to supply them.
 
 </Stepper>
 
 To map GitHub's profile fields (for example, `login` or `avatar_url`) to local user attributes, open the connection and go to the **Attribute Configuration** tab. See [Attribute Configuration](../add-oidc-provider#attribute-configuration).
 
 :::note
-By default, the connection uses GitHub's own default scope, which does not include the user's email address. To ensure the email address is accessible, open the connection after creation and set **Scopes** to include `user:email` on its edit page.
+The connection requests the `user:email` scope by default. To request different scopes, open the connection after creation and update **Scopes** on its edit page.
 
 The GitHub connection also accepts a `prompt` field, forwarded as a query parameter on the authorization request. GitHub's OAuth flow supports `select_account` to force the account picker. Set it on the connection's edit page, or through the [Connections API](../../../apis#tag/connections).
 :::

--- a/docs/versioned_docs/version-v1.0.x/guides/identity-providers/add-google.mdx
+++ b/docs/versioned_docs/version-v1.0.x/guides/identity-providers/add-google.mdx
@@ -37,12 +37,14 @@ This guide walks you through registering a Google identity provider (IdP) in <Pr
 
 ## Step 2: Configure the Google Connection in the Console
 
+These steps create a Google connection. To change an existing connection, see [Manage Identity Providers](../manage-identity-providers#update-an-identity-provider).
+
 1. Sign in to the <ProductName /> Console.
 2. Navigate to **Connections**.
-3. Click the **Google** card. If the card shows **Not configured**, this opens a form to create the connection. If it already shows **Configured**, this opens the existing connection instead.
+3. Click the **Google Login** card marked **Not configured**.
 4. The form shows a setup hint with the **Redirect URI**. Copy it and add it to your Google OAuth client's authorized redirect URIs if you have not already done so.
 5. Enter your **Client ID** and **Client secret** from the previous step.
-6. Click **Create connection**. If you opened an existing **Configured** connection instead, update the credentials and click **Save changes**.
+6. Click **Create connection**.
 
 <ProductName /> automatically uses the Google authorization, token, userinfo, and JWKS endpoints. You do not need to supply them.
 
@@ -53,6 +55,8 @@ The connection requests the `openid email profile` scopes by default. To change 
 
 The Google connection also accepts a `prompt` field to control the Google consent screen behavior (for example, `consent` or `select_account`). Set it on the connection's edit page, or through the [Connections API](../../../apis#tag/connections).
 :::
+
+To map Google's profile fields to local user attributes, open the connection and select the **Attribute Configuration** tab. See [Attribute Configuration](../add-oidc-provider#attribute-configuration).
 
 ## Next Steps
 

--- a/docs/versioned_docs/version-v1.0.x/guides/identity-providers/connect-idp-to-application.mdx
+++ b/docs/versioned_docs/version-v1.0.x/guides/identity-providers/connect-idp-to-application.mdx
@@ -8,7 +8,7 @@ description: Wire a configured identity provider into an application's authentic
 
 # Connect an IdP to an Application
 
-This guide explains how to enable social login for an application by connecting a configured identity provider (IdP) through an authentication flow.
+Connect a configured identity provider (IdP) to an application's sign-in flow to offer federated sign-in.
 
 ## How It Works
 
@@ -27,8 +27,18 @@ Applications in <ProductName /> do not reference IdPs directly. The connection r
   - [Add an OAuth 2.0 Identity Provider](../add-oauth-provider)
 - You have created an application. See [Manage Applications](../../applications/manage-applications).
 
-:::note Federated sign-in requires a local user
-By default, federated sign-in maps the external identity to a local user, which must already exist in the user store or the sign-in step fails. To sign in a first-time federated user, enable **Allow Authentication Without Local User** (`allowAuthenticationWithoutLocalUser`) on the social login executor and add a **Provisioning** executor to create the local account. See [Federated Authentication](../../flows/advanced-configurations#federated-authentication).
+:::note Just-in-time provisioning for first-time users
+The **Continue with Google Login** and **Continue with GitHub Login** widgets enable **Allow Authentication Without Local User** and add the Provisioning steps required to create a local account.
+
+For a generic OAuth 2.0 or OIDC connection, enable **Allow Authentication Without Local User** on the executor and add the **Provisioning** widget manually. Without this configuration, the external identity must map to an existing local user. See [Federated Authentication](../../flows/advanced-configurations#federated-authentication).
+:::
+
+:::note Configure a user type for first-time social sign-in
+Your application must allow exactly one user type with **Allow Self Registration** enabled. Sign-in fails if none or more than one of the allowed user types has this setting enabled.
+
+Under the application's **Access** settings, select the user type you want to assign to first-time users. If you select other user types, ensure only one has **Allow Self Registration** enabled under **User Types**. Existing users are unaffected.
+
+A **User Type Resolver** step selects the user type when several are eligible, but only in registration flows, where it prompts the user to choose. In authentication flows it does not resolve a type, so adding it to a sign-in flow does not lift this requirement.
 :::
 
 <Stepper stepNode="h2" as="h2">
@@ -39,31 +49,40 @@ By default, federated sign-in maps the external identity to a local user, which 
 2. Navigate to **Flows**.
 3. Open the authentication flow assigned to your application, or click **+ Create New Flow** to create a new one.
 
-## Step 2: Add a Social Login Executor
+## Step 2: Add the Social Login Option
 
-1. In the left panel under **Widgets**, locate the social login executor for your provider:
-   - **Continue with Google**: for Google IdPs
-   - **Continue with GitHub**: for GitHub IdPs
-   - **OAuth** executor: for OAuth 2.0 IdPs
-   - **OIDC** executor: for OIDC IdPs
-2. Click **+** next to the executor to add it to the canvas.
+Follow the instructions for your connection type.
+
+### Google or GitHub
+
+1. In the left panel, expand **Widgets**.
+2. Click **+** on **Continue with Google Login** or **Continue with GitHub Login**.
+
+The widget adds a button to an existing View or creates a View when the flow has none. It also adds the provider executor, Provisioning steps for first-time users, and an Auth Assertion Generator, then connects the generated steps.
+
+If you have exactly one matching connection, <ProductName /> assigns it automatically. If you have multiple matching connections, click the provider executor and select the required **Connection**.
+
+### OAuth 2.0 or OIDC
+
+1. In the left panel, expand **Executors**.
+2. Click **+** on **OAuth** or **OIDC Auth**.
 3. Click the executor node to open its configuration panel.
-4. In the **Connection** dropdown, select the identity provider by the name you gave it when creating it (for example, `Google` or `My OIDC Provider`).
+4. Select the required **Connection**. <ProductName /> assigns it automatically when exactly one matching connection exists.
+5. To create local accounts for first-time users:
+   1. Enable **Allow Authentication Without Local User**.
+   2. Add the **Provisioning** widget to the flow.
 
-:::tip Auto-assignment
-If you have exactly one IdP of the matching type configured, <ProductName /> selects it automatically. You do not need to choose from the dropdown.
-:::
+## Step 3: Complete a Generic OAuth 2.0 or OIDC Flow
 
-## Step 3: Wire the Executor Into the Flow
+Skip this step if you added the Google or GitHub widget.
 
-Connect the social login executor to the flow:
+1. Add a **Button** component to the sign-in View and connect its output to the OAuth or OIDC executor.
+2. If you enabled **Allow Authentication Without Local User**, add the **Provisioning** widget.
+3. Add an **Auth Assertion Generator** executor.
+4. Connect the success path from the OAuth or OIDC executor to **Provisioning**, when present, and then to **Auth Assertion Generator**.
+5. Connect **Auth Assertion Generator** to **END**.
 
-- To offer social login **alongside password**: connect the **Sign In** view node to both the **Identifier + Password** executor and the social login executor. Merge both success paths into the **Auth Assertion Generator** executor.
-- To use social login **as the only sign-in method**: connect the social login executor directly between the **Sign In** view and the **Auth Assertion Generator**.
-
-:::note
-Every executor has a **red (failure) output**. Connect failure paths back to the **Sign In** view so users see an error message and can retry. Leaving a failure path unconnected stops the flow with an error.
-:::
+Route failure outputs to an error View if you want to display the failure reason. An unconnected failure output terminates the flow with an unhandled error. Use an executor's incomplete output only when that executor requests more input. See [Always Wire Failure Outputs](../../flows/build-a-flow#always-wire-failure-outputs).
 
 ## Step 4: Save the Flow
 
@@ -73,8 +92,8 @@ Click **Save** in the top-right corner.
 
 1. Navigate to **Applications** and open the application you want to configure.
 2. Open the **Flows** tab.
-3. Under **Authentication Flow**, select the flow you just saved from the dropdown.
-4. Click **Save**.
+3. Under **Sign-in Flow**, select the flow.
+4. Save the application.
 
 ## Step 6: Verify the Integration
 

--- a/docs/versioned_docs/version-v1.0.x/guides/identity-providers/manage-identity-providers.mdx
+++ b/docs/versioned_docs/version-v1.0.x/guides/identity-providers/manage-identity-providers.mdx
@@ -47,8 +47,9 @@ Changes take effect immediately for new authentication requests.
 ## Delete an Identity Provider
 
 1. Open the connection from the Connections page.
-2. On the **General** tab, go to **Danger zone** and click **Delete connection**.
-3. Confirm the deletion in the dialog.
+2. Open the **Advanced** tab.
+3. Under **Danger zone**, click **Delete connection**.
+4. Confirm the deletion in the dialog.
 
 If an authentication flow or another resource still references this identity provider, the dialog lists the resources and blocks the deletion until you remove or update them, for example, the flow node that uses this connection.
 


### PR DESCRIPTION
### Purpose
Correct the identity provider documentation inconsistencies reported in #4726 for both the current documentation and version v1.0.x.

### Approach
- Distinguish Google and GitHub widgets from the OAuth 2.0 and OIDC executors.
- Document widget-generated flow steps, connection auto-assignment, and just-in-time provisioning behavior.
- Correct generic OAuth 2.0 and OIDC flow wiring and failure-path guidance.
- Use the current Sign-in Flow label and connection management paths.
- Correct GitHub default scope guidance and add Google attribute mapping guidance.
- Keep the current and v1.0.x IDP pages aligned.

### Related Issues
- Fixes #4726

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [x] Documentation provided.
    - [x] Ran Vale and fixed all errors and warnings
- [ ] Tests provided.
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes.
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Validation
- Focused documentation lint passed for all eight updated files with zero Vale warnings or errors.
- `git diff --check` passed.
- `make build_docs` passed. The build reported existing repository-wide warnings unrelated to these changes.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR does not commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified GitHub and Google connection setup, including creating new connections and selecting **Not configured** providers.
  - Documented Google profile-field mapping and GitHub’s default `user:email` scope.
  - Expanded federated sign-in guidance for widgets and OAuth/OIDC connections, including provisioning and failure handling.
  - Updated application assignment terminology to **Sign-in Flow**.
  - Clarified identity-provider deletion steps through the **Advanced** tab and **Danger zone**, including versioned guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->