### PR TITLE
Add SDK quickstart sample download cards to connect-your-application guides

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -330,6 +330,18 @@ reviews:
         - Flag any new CSS added to `docs/src/css/custom.css` unless it targets Scalar API reference
           elements or other third-party components where `sx`/`styled()` cannot reach. Ask:
           **"Can this style be applied via `sx` or `styled()` instead?"**
+        - For any component rendered inside actual doc content (an `.mdx` page under `docs/content/`
+          or `docs/versioned_docs/`) that builds a URL to `fetch()` a versioned static asset (e.g. a
+          file mirrored per-version under `static/docs/<versionPath>/...` or `static/api/<versionPath>/...`):
+          flag as a **major issue** if it derives the version by hardcoding a `/docs/next/...` literal
+          and rewriting it with `useDocsUrl()` (from `@site/src/hooks/useDocsUrl`). That hook is for
+          version-*less* contexts (footer links, homepage, custom pages) that fall back through the
+          site's global active/preferred/latest version state — it is the wrong tool for a component
+          embedded in a specific doc page, since that page already has its own authoritative version.
+          Require `useDocsVersion()` (from `@docusaurus/plugin-content-docs/client`) instead, mapping
+          `version === 'current' ? 'next' : version` to get the versionPath, matching the pattern in
+          `docs/src/components/ApiVersionReference.tsx`. `useDocsUrl()` remains correct for rewriting
+          `<Link>`/`href` navigation targets; this only applies to runtime `fetch()` URLs.
 
         Review documentation changes for:
         - Technical accuracy: do code examples and parameter descriptions match the actual implementation in this PR?

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -20,3 +20,9 @@ The skill's `SKILL.md` is a dispatch table over its reference files, each coveri
 - `use-case.md`, for structuring or auditing a use-case section (`docs/content/use-cases/<pattern>/`): page order, diagram design, jargon literacy for readers unfamiliar with IAM or ThunderID, and a scoring rubric. Use for creating, restructuring, or reviewing B2C, B2B, AI Agents, or a new use-case pattern.
 
 See [docs/README.md](README.md) for the full contributor workflow with a worked example, and `.agent/skills/docs/` for each reference file's complete rules.
+
+## Versioned Fetches in `docs/src/` Components
+
+A component rendered inside actual doc content (an `.mdx` page under `docs/content/` or `docs/versioned_docs/`) that builds a URL to `fetch()` a versioned static asset (anything mirrored per-version under `static/docs/<versionPath>/...` or `static/api/<versionPath>/...`) must derive `versionPath` from `useDocsVersion()` (`@docusaurus/plugin-content-docs/client`), mapping `version === 'current' ? 'next' : version`. This is the same pattern already used in `docs/src/components/ApiVersionReference.tsx`.
+
+Do not hardcode a `/docs/next/...` literal and rewrite it with `useDocsUrl()` (`@site/src/hooks/useDocsUrl`). That hook exists for version-*less* contexts (footer links, homepage, custom pages) that fall back through the site's global active/preferred/latest version state; a component embedded in a specific doc page already has its own authoritative version and should read it directly instead. `useDocsUrl()` remains the correct tool for rewriting `<Link>`/`href` navigation targets, since this rule only applies to runtime `fetch()` URLs. Enforced in `.coderabbit.yaml` under the `docs/**` path instructions.

--- a/docs/content/getting-started/connect-your-application/android.mdx
+++ b/docs/content/getting-started/connect-your-application/android.mdx
@@ -4,7 +4,7 @@ title: Android Quickstart
 docType: quickstart
 sidebar_position: 8.5
 persona: app
-description: Add {{ProductName}} authentication to an Android application using the ThunderID Android SDK for Jetpack Compose.
+description: Add {{ProductName}} authentication to an Android application using the `com.github.thunder-id:android-sdks`.
 ---
 
 import {
@@ -19,7 +19,9 @@ import {
 
 # Android Quickstart
 
-Use this guide to add <ProductName /> authentication to an Android application using the <ProductName /> Android SDK for Jetpack Compose.
+Use this guide to add <ProductName /> authentication to an Android application using the `com.github.thunder-id:android-sdks`.
+
+<SdkQuickstartDownload packageId="android" icon={<AndroidLogo size={22} />} promptFlow="redirect-based" />
 
 <TutorialHero>
 
@@ -37,10 +39,6 @@ Use this guide to add <ProductName /> authentication to an Android application u
 <TutorialHeroItem icon={<FileCode />}>API 26 (Android 8.0) deployment target</TutorialHeroItem>
 
 </TutorialHero>
-
-:::tip Example Source Code
-Check out the complete <RepoLink path="/tree/main/sdks/android/samples/quickstart">Android Quickstart Sample</RepoLink> in the <ProductName /> repository.
-:::
 
 <Stepper stepNode="h2" as="h2">
 

--- a/docs/content/getting-started/connect-your-application/browser.mdx
+++ b/docs/content/getting-started/connect-your-application/browser.mdx
@@ -22,6 +22,8 @@ import {
 
 Use this guide to add <ProductName /> authentication to a browser-based application using the `@thunderid/browser` SDK. No framework required.
 
+<SdkQuickstartDownload packageId="browser" icon={<BrowserLogo size={22} />} promptFlow="redirect-based" />
+
 <TutorialHero>
 
 ## What You Will Learn
@@ -271,3 +273,4 @@ You should see the sign-in button. Click it to be redirected to the <ProductName
 
 
 </div>
+

--- a/docs/content/getting-started/connect-your-application/express.mdx
+++ b/docs/content/getting-started/connect-your-application/express.mdx
@@ -22,6 +22,8 @@ import {
 
 Use this guide to add <ProductName /> authentication to an Express app with sign-in, sign-out, and route protection.
 
+<SdkQuickstartDownload packageId="express" icon={<ExpressLogo size={22} />} promptFlow="redirect-based" />
+
 <TutorialHero>
 
 ## What You Will Learn
@@ -224,3 +226,4 @@ You should see the sign-in link. Click it to be redirected to the <ProductName /
   </a>
 
 </div>
+

--- a/docs/content/getting-started/connect-your-application/flutter.mdx
+++ b/docs/content/getting-started/connect-your-application/flutter.mdx
@@ -22,6 +22,8 @@ import {
 
 Use this guide to add <ProductName /> authentication to a Flutter application using the `thunderid_flutter` package.
 
+<SdkQuickstartDownload packageId="flutter" icon={<FlutterLogo size={22} />} promptFlow="redirect-based" />
+
 <TutorialHero>
 
 ## What You Will Learn
@@ -38,10 +40,6 @@ Use this guide to add <ProductName /> authentication to a Flutter application us
 <TutorialHeroItem icon={<FileCode />}>iOS 16+ or Android API 26+ target device or simulator</TutorialHeroItem>
 
 </TutorialHero>
-
-:::tip Example Source Code
-Check out the complete <RepoLink path="/tree/main/sdks/flutter/samples/quickstart">Flutter Quickstart Sample</RepoLink> in the <ProductName /> repository.
-:::
 
 <Stepper stepNode="h2" as="h2">
 

--- a/docs/content/getting-started/connect-your-application/ios.mdx
+++ b/docs/content/getting-started/connect-your-application/ios.mdx
@@ -4,7 +4,7 @@ title: iOS Quickstart
 docType: quickstart
 sidebar_position: 8
 persona: app
-description: Add {{ProductName}} authentication to an iOS application using the ThunderID iOS SDK for SwiftUI.
+description: Add {{ProductName}} authentication to an iOS application using the {{ProductName}} iOS SDK.
 ---
 
 import {
@@ -20,7 +20,9 @@ import {
 
 # iOS Quickstart
 
-Use this guide to add <ProductName /> authentication to an iOS application using the <ProductName /> iOS SDK for SwiftUI.
+Use this guide to add <ProductName /> authentication to an iOS application using the <code><ProductName /> iOS SDK</code>.
+
+<SdkQuickstartDownload packageId="ios" icon={<IOSLogo size={22} />} promptFlow="redirect-based" />
 
 <TutorialHero>
 
@@ -38,10 +40,6 @@ Use this guide to add <ProductName /> authentication to an iOS application using
 <TutorialHeroItem icon={<FileCode />}>iOS 16+ deployment target</TutorialHeroItem>
 
 </TutorialHero>
-
-:::tip Example Source Code
-Check out the complete <RepoLink path="/tree/main/sdks/ios/Samples/Quickstart">iOS Quickstart Sample</RepoLink> in the <ProductName /> repository.
-:::
 
 <Stepper stepNode="h2" as="h2">
 

--- a/docs/content/getting-started/connect-your-application/nextjs.mdx
+++ b/docs/content/getting-started/connect-your-application/nextjs.mdx
@@ -22,6 +22,8 @@ import {
 
 Use this guide to add <ProductName /> authentication to a Next.js application using the `@thunderid/nextjs` SDK with full App Router support.
 
+<SdkQuickstartDownload packageId="nextjs" icon={<NextLogo size={22} />} promptFlow="embedded" />
+
 <TutorialHero>
 
 ## What You Will Learn
@@ -307,3 +309,4 @@ You should see the sign-in button. Click it, you'll land on your application's o
     </div>
   </a>
 </div>
+

--- a/docs/content/getting-started/connect-your-application/node.mdx
+++ b/docs/content/getting-started/connect-your-application/node.mdx
@@ -20,7 +20,9 @@ import {
 
 # Node.js Quickstart
 
-Use this guide to authenticate a Node.js service to <ProductName /> using the `@thunderid/node` SDK. Unlike the other quickstarts in this section, there's no user and no browser sign-in: the service authenticates as **itself** with the OAuth 2.0 `client_credentials` grant, then uses the resulting access token to call another piece of business logic. Use this pattern for background jobs, cron tasks, or one backend service calling another, where there's no human in the loop to redirect through a login page.
+Use this guide to add <ProductName /> authentication to a Node.js service using the `@thunderid/node` SDK.
+
+<SdkQuickstartDownload packageId="node" icon={<NodeLogo size={22} />} promptFlow="redirect-based" />
 
 <TutorialHero>
 
@@ -39,10 +41,6 @@ Use this guide to authenticate a Node.js service to <ProductName /> using the `@
 <TutorialHeroItem icon={<FileCode />}>Your preferred code editor</TutorialHeroItem>
 
 </TutorialHero>
-
-:::tip Example Source Code
-Check out the complete <RepoLink path="/tree/main/sdks/javascript-sdks/samples/node/quickstart">Node.js Quickstart Sample</RepoLink> in the <ProductName /> repository.
-:::
 
 <Stepper stepNode="h2" as="h2">
 
@@ -229,3 +227,4 @@ The script authenticates once, prints the scope it received, then calls `getStoc
   </a>
 
 </div>
+

--- a/docs/content/getting-started/connect-your-application/nuxt.mdx
+++ b/docs/content/getting-started/connect-your-application/nuxt.mdx
@@ -22,6 +22,8 @@ import {
 
 Use this guide to add <ProductName /> authentication to a Nuxt 3 application using the `@thunderid/nuxt` module.
 
+<SdkQuickstartDownload packageId="nuxt" icon={<NuxtLogo size={22} />} promptFlow="embedded" />
+
 <TutorialHero>
 
 ## What You Will Learn
@@ -259,3 +261,4 @@ You should see the `<ThunderIDSignInButton />` button. Click it, you'll land on 
     </div>
   </a>
 </div>
+

--- a/docs/content/getting-started/connect-your-application/react.mdx
+++ b/docs/content/getting-started/connect-your-application/react.mdx
@@ -22,6 +22,8 @@ import {
 
 Use this guide to add <ProductName /> authentication to a React application using the `@thunderid/react` SDK.
 
+<SdkQuickstartDownload packageId="react" icon={<ReactLogo size={22} />} promptFlow="redirect-based" />
+
 <TutorialHero>
 
 ## What You Will Learn
@@ -238,3 +240,4 @@ You should see the `<SignInButton />`. Click it, you'll be redirected to the <Pr
     </div>
   </a>
 </div>
+

--- a/docs/content/getting-started/connect-your-application/vue.mdx
+++ b/docs/content/getting-started/connect-your-application/vue.mdx
@@ -22,6 +22,8 @@ import {
 
 Use this guide to add <ProductName /> authentication to a Vue 3 application using the `@thunderid/vue` SDK.
 
+<SdkQuickstartDownload packageId="vue" icon={<VueLogo size={22} />} promptFlow="redirect-based" />
+
 <TutorialHero>
 
 ## What You Will Learn
@@ -216,3 +218,4 @@ You should see the `<SignInButton />`. Click it to be redirected to the <Product
     </div>
   </a>
 </div>
+

--- a/docs/src/components/GradientBorderButton.tsx
+++ b/docs/src/components/GradientBorderButton.tsx
@@ -1,0 +1,79 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {styled, keyframes, Button, type ButtonProps} from '@wso2/oxygen-ui';
+import {forwardRef} from 'react';
+
+const spin = keyframes`
+  0% {
+    --gradient-angle: 0deg;
+  }
+  100% {
+    --gradient-angle: 360deg;
+  }
+`;
+
+// Register CSS @property for animatable custom property
+if (typeof window !== 'undefined' && 'CSS' in window && 'registerProperty' in CSS) {
+  try {
+    CSS.registerProperty({
+      name: '--gradient-angle',
+      syntax: '<angle>',
+      initialValue: '0deg',
+      inherits: false,
+    });
+  } catch {
+    // Property already registered
+  }
+}
+
+const StyledGradientButton = styled(Button)(() => ({
+  position: 'relative',
+  display: 'inline-flex',
+  borderRadius: '999px',
+  padding: '8px 16px',
+  border: '2px solid transparent',
+  background: 'transparent',
+  color: 'var(--mui-palette-text-primary)',
+  fontWeight: 600,
+  textTransform: 'none',
+  backgroundClip: 'padding-box',
+  isolation: 'isolate',
+  '&::before': {
+    content: '""',
+    position: 'absolute',
+    inset: 0,
+    borderRadius: '999px',
+    padding: '2px',
+    background: 'conic-gradient(from var(--gradient-angle), #667eea, #764ba2, #f093fb, #4facfe, #00f2fe, #667eea)',
+    WebkitMask: 'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
+    WebkitMaskComposite: 'xor',
+    maskComposite: 'exclude',
+    animation: `${spin} 4s linear infinite`,
+    zIndex: -1,
+  },
+  '&:hover': {
+    background: 'var(--mui-palette-action-hover)',
+    '&::before': {
+      animationPlayState: 'paused',
+    },
+  },
+  '&.Mui-disabled': {
+    '&::before': {
+      animationPlayState: 'paused',
+      opacity: 0.6,
+    },
+  },
+}));
+
+/**
+ * A button component with an animated conic-gradient border, used to flag AI-related actions
+ * (e.g. copying an LLM prompt) the same way the console's application integration guides do.
+ */
+const GradientBorderButton = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => (
+  <StyledGradientButton ref={ref} variant="text" disableRipple disableFocusRipple {...props} />
+));
+
+GradientBorderButton.displayName = 'GradientBorderButton';
+
+export default GradientBorderButton;

--- a/docs/src/components/SdkQuickstartDownload.tsx
+++ b/docs/src/components/SdkQuickstartDownload.tsx
@@ -1,0 +1,212 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {useDocsVersion} from '@docusaurus/plugin-content-docs/client';
+import {useBaseUrlUtils} from '@docusaurus/useBaseUrl';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import {Button, styled} from '@wso2/oxygen-ui';
+import {DownloadIcon, Sparkles} from '@wso2/oxygen-ui-icons-react';
+import React, {useEffect, useState} from 'react';
+import type {ReactNode} from 'react';
+import type {DocusaurusProductConfig} from '@site/docusaurus.product.config';
+import GradientBorderButton from '@site/src/components/GradientBorderButton';
+
+interface SdkReleaseAsset {
+  downloadUrl: string;
+  sizeLabel: string;
+}
+
+interface SdkReleaseEntry {
+  assets: SdkReleaseAsset[];
+  packageId: string;
+  packageName: string | null;
+}
+
+interface SdkReleasesData {
+  releases: SdkReleaseEntry[];
+}
+
+/**
+ * Props for the SdkQuickstartDownload component.
+ */
+interface SdkQuickstartDownloadProps {
+  /**
+   * The `packageId` of the SDK package, as tracked in `sdk-releases.json` (e.g. `react`, `nextjs`, `express`).
+   */
+  packageId: string;
+  /**
+   * The framework logo to show in the icon badge, e.g. `<ReactLogo size={22} />`.
+   */
+  icon?: ReactNode;
+  /**
+   * Which prewritten LLM prompt to offer for copying, matching a file under
+   * `content/getting-started/connect-your-application/prompts/<packageId>/<promptFlow>.txt`.
+   * Omit for quickstarts with no matching prompt.
+   */
+  promptFlow?: 'redirect-based' | 'embedded';
+}
+
+const Callout = styled('div')({
+  alignItems: 'center',
+  background:
+    'linear-gradient(90deg, color-mix(in srgb, var(--oxygen-palette-primary-main) 10%, transparent) 0%, transparent 70%)',
+  border: '1px solid color-mix(in srgb, var(--oxygen-palette-primary-main) 24%, transparent)',
+  borderRadius: '0.75rem',
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '1.1rem',
+  marginBottom: '1.75rem',
+  padding: '1.1rem 1.25rem',
+});
+
+const IconBadge = styled('span')({
+  alignItems: 'center',
+  background: 'rgb(var(--oxygen-palette-primary-mainChannel) / 0.12)',
+  borderRadius: '0.625rem',
+  display: 'inline-flex',
+  flexShrink: 0,
+  height: '2.375rem',
+  justifyContent: 'center',
+  width: '2.375rem',
+});
+
+const CardBody = styled('div')({
+  display: 'flex',
+  flex: '1 1 auto',
+  flexDirection: 'column',
+  gap: '0.25rem',
+  minWidth: 0,
+});
+
+const CardTitle = styled('div')({
+  color: 'var(--ifm-color-emphasis-900)',
+  fontSize: '0.95rem',
+  fontWeight: 600,
+});
+
+const CardMeta = styled('div')({
+  alignItems: 'center',
+  color: 'var(--ifm-color-emphasis-600)',
+  display: 'flex',
+  flexWrap: 'wrap',
+  fontFamily: 'var(--ifm-font-family-monospace)',
+  fontSize: '0.75rem',
+  gap: '0.5rem',
+});
+
+const Actions = styled('div')({
+  alignItems: 'center',
+  display: 'flex',
+  flexShrink: 0,
+  flexWrap: 'wrap',
+  gap: '0.75rem',
+});
+
+/**
+ * Renders a callout linking to the latest quickstart sample archive for the given SDK package, sourced
+ * from `/data/sdk-releases.json`. Renders nothing if no sample has been published yet for this package.
+ */
+export default function SdkQuickstartDownload({
+  packageId,
+  icon = undefined,
+  promptFlow = undefined,
+}: SdkQuickstartDownloadProps): React.ReactElement | null {
+  const {withBaseUrl} = useBaseUrlUtils();
+  const {version} = useDocsVersion();
+  const {siteConfig} = useDocusaurusContext();
+  const [asset, setAsset] = useState<SdkReleaseAsset | null>(null);
+  const [packageName, setPackageName] = useState('');
+  const [copyState, setCopyState] = useState<'idle' | 'copying' | 'copied'>('idle');
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch(withBaseUrl('/data/sdk-releases.json'), {signal: controller.signal})
+      .then((r) => r.json() as Promise<SdkReleasesData>)
+      .then((data) => {
+        const entry = data.releases?.find((release) => release.packageId === packageId);
+        const match = entry?.assets.find((a) => a.downloadUrl.endsWith('.zip'));
+        if (!entry || !match) return;
+        setPackageName(entry.packageName ?? '');
+        setAsset(match);
+      })
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+      });
+    return () => controller.abort();
+  }, [withBaseUrl, packageId]);
+
+  const handleCopyPrompt = async (): Promise<void> => {
+    if (!promptFlow || copyState === 'copying') return;
+    setCopyState('copying');
+    try {
+      // Docusaurus "current" version (labeled "Next") -> 'next', matching the directory
+      // convention generate-prompts.mjs mirrors these files under (static/docs/<versionPath>/...).
+      const versionPath = version === 'current' ? 'next' : version;
+      const res = await fetch(
+        withBaseUrl(
+          `/docs/${versionPath}/getting-started/connect-your-application/prompts/${packageId}/${promptFlow}.txt`,
+        ),
+      );
+      const text = await res.text();
+      const config = siteConfig.customFields?.product as DocusaurusProductConfig;
+      const filled = text
+        .replace(/\{\{productName\}\}/g, config.project.name)
+        .replace(/\{\{clientId\}\}/g, '<your-client-id>');
+      await navigator.clipboard.writeText(filled);
+      setCopyState('copied');
+      setTimeout(() => setCopyState('idle'), 1800);
+    } catch {
+      setCopyState('idle');
+    }
+  };
+
+  if (!asset) return null;
+
+  return (
+    <Callout>
+      <IconBadge aria-hidden="true">{icon}</IconBadge>
+      <CardBody>
+        <CardTitle>Skip the setup, run the quickstart app instead</CardTitle>
+        <CardMeta>
+          <span>{asset.sizeLabel}</span>
+          {packageName && (
+            <>
+              <span aria-hidden="true">&middot;</span>
+              <span>
+                prewired with <code>{packageName}</code>
+              </span>
+            </>
+          )}
+        </CardMeta>
+      </CardBody>
+      <Actions>
+        <Button
+          variant="outlined"
+          href={asset.downloadUrl}
+          target="_blank"
+          rel="noreferrer"
+          endIcon={<DownloadIcon size={16} />}
+          sx={{
+            borderRadius: '999px',
+            flexShrink: 0,
+            fontWeight: 600,
+            px: 2.5,
+            py: 1,
+            textTransform: 'none',
+          }}
+        >
+          Download app
+        </Button>
+        {promptFlow && (
+          <GradientBorderButton
+            onClick={() => void handleCopyPrompt()}
+            disabled={copyState === 'copying'}
+            startIcon={<Sparkles size={14} />}
+          >
+            {copyState === 'copied' ? 'Copied!' : 'Copy prompt'}
+          </GradientBorderButton>
+        )}
+      </Actions>
+    </Callout>
+  );
+}

--- a/docs/src/components/TutorialHero.tsx
+++ b/docs/src/components/TutorialHero.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import {Grid, Typography, List, ListItem, ListItemIcon, ListItemText, Box} from '@wso2/oxygen-ui';
+import {Grid, Typography, List, ListItem, ListItemIcon, ListItemText, Box, styled} from '@wso2/oxygen-ui';
 import {Box as Cube} from '@wso2/oxygen-ui-icons-react';
 import {ReactNode, Children, isValidElement} from 'react';
 
@@ -19,13 +19,26 @@ interface SectionData {
   content: ReactNode[];
 }
 
-const ICON_SIZE = 22;
-const ICON_CONTAINER_SIZE = 38;
+const ICON_SIZE = 18;
+const ICON_CONTAINER_SIZE = 34;
+
+const SectionCard = styled('div')({
+  background: 'var(--oxygen-palette-background-paper)',
+  border: '1px solid var(--ifm-color-emphasis-200)',
+  borderRadius: '0.875rem',
+  height: '100%',
+  padding: '1.5rem',
+  '[data-theme="dark"] &': {
+    borderColor: 'rgba(255, 255, 255, 0.09)',
+  },
+});
 
 const iconContainerSx = {
   alignItems: 'center',
-  borderRadius: 'var(--oxygen-shape-borderRadius)',
+  bgcolor: 'rgb(var(--oxygen-palette-primary-mainChannel) / 0.10)',
+  borderRadius: '0.5rem',
   display: 'flex',
+  flexShrink: 0,
   height: ICON_CONTAINER_SIZE,
   justifyContent: 'center',
   width: ICON_CONTAINER_SIZE,
@@ -43,8 +56,8 @@ const iconInnerSx = {
 // TutorialHeroItem component - used in MDX to pass custom icons
 export function TutorialHeroItem({icon = undefined, children}: TutorialHeroItemProps) {
   return (
-    <ListItem sx={{}}>
-      <ListItemIcon sx={{minWidth: ICON_CONTAINER_SIZE + 8}}>
+    <ListItem sx={{px: 0, py: 0.75}}>
+      <ListItemIcon sx={{minWidth: 'auto', mr: 1.75}}>
         <Box sx={iconContainerSx}>
           <Box sx={iconInnerSx}>
             {icon ?? <Cube />}
@@ -93,21 +106,12 @@ function renderContentWithIcons(content: ReactNode[]): ReactNode {
               if (isValidElement(listItem)) {
                 const text = extractTextFromChildren(listItem.props.children as ReactNode);
                 return (
-                  <ListItem key={listItem.key ?? text} sx={{px: 0, py: 0.5}}>
-                    <ListItemIcon sx={{minWidth: 40}}>
-                      <Box
-                        sx={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          width: 32,
-                          height: 32,
-                          borderRadius: 1,
-                          bgcolor: 'primary.lighter',
-                          color: 'primary.main',
-                        }}
-                      >
-                        <Cube />
+                  <ListItem key={listItem.key ?? text} sx={{px: 0, py: 0.75}}>
+                    <ListItemIcon sx={{minWidth: 'auto', mr: 1.75}}>
+                      <Box sx={iconContainerSx}>
+                        <Box sx={iconInnerSx}>
+                          <Cube />
+                        </Box>
                       </Box>
                     </ListItemIcon>
                     <ListItemText primary={text} />
@@ -171,21 +175,22 @@ export default function TutorialHero({children}: TutorialHeroProps) {
     <Grid container spacing={3} sx={{mb: 4}}>
       {sections.map((section) => (
         <Grid size={{xs: 12, md: 6}} key={section.title}>
-          <Box sx={{height: '100%'}}>
+          <SectionCard>
             <Typography
-              variant="h6"
-              gutterBottom
               sx={{
                 mb: 2,
-                pl: 2,
-                borderLeft: '4px solid',
-                borderColor: 'primary.main',
+                fontFamily: 'var(--ifm-font-family-monospace)',
+                fontSize: '0.6875rem',
+                fontWeight: 600,
+                textTransform: 'uppercase',
+                letterSpacing: '0.1em',
+                color: 'text.secondary',
               }}
             >
               {section.title}
             </Typography>
             {renderContentWithIcons(section.content)}
-          </Box>
+          </SectionCard>
         </Grid>
       ))}
     </Grid>

--- a/docs/src/theme/MDXComponents.tsx
+++ b/docs/src/theme/MDXComponents.tsx
@@ -74,6 +74,7 @@ import RepoLink from '@site/src/components/RepoLink';
 import RunThunderID from '@site/src/components/RunThunderID';
 import SampleDownload from '@site/src/components/SampleDownload';
 import SDKCard from '@site/src/components/SDKCard';
+import SdkQuickstartDownload from '@site/src/components/SdkQuickstartDownload';
 import {SolutionArchitectureDiagram} from '@site/src/components/SolutionArchitectureDiagram';
 import Stepper from '@site/src/components/Stepper';
 import TutorialHero, {TutorialHeroItem} from '@site/src/components/TutorialHero';
@@ -172,6 +173,7 @@ export default {
   DeveloperShortcut,
   GettingStartedJourney,
   SampleDownload,
+  SdkQuickstartDownload,
   SolutionArchitectureDiagram,
   UseCaseBranchCards,
   UseCaseStepper,

--- a/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/android.mdx
+++ b/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/android.mdx
@@ -4,7 +4,7 @@ title: Android Quickstart
 docType: quickstart
 sidebar_position: 8.5
 persona: app
-description: Add {{ProductName}} authentication to an Android application using the ThunderID Android SDK for Jetpack Compose.
+description: Add {{ProductName}} authentication to an Android application using the `com.github.thunder-id:android-sdks`.
 ---
 
 import {
@@ -19,7 +19,9 @@ import {
 
 # Android Quickstart
 
-Use this guide to add <ProductName /> authentication to an Android application using the <ProductName /> Android SDK for Jetpack Compose.
+Use this guide to add <ProductName /> authentication to an Android application using the `com.github.thunder-id:android-sdks`.
+
+<SdkQuickstartDownload packageId="android" icon={<AndroidLogo size={22} />} promptFlow="redirect-based" />
 
 <TutorialHero>
 
@@ -37,10 +39,6 @@ Use this guide to add <ProductName /> authentication to an Android application u
 <TutorialHeroItem icon={<FileCode />}>API 26 (Android 8.0) deployment target</TutorialHeroItem>
 
 </TutorialHero>
-
-:::tip Example Source Code
-Check out the complete <RepoLink path="/tree/main/sdks/android/samples/quickstart">Android Quickstart Sample</RepoLink> in the <ProductName /> repository.
-:::
 
 <Stepper stepNode="h2" as="h2">
 

--- a/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/browser.mdx
+++ b/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/browser.mdx
@@ -22,6 +22,8 @@ import {
 
 Use this guide to add <ProductName /> authentication to a browser-based application using the `@thunderid/browser` SDK. No framework required.
 
+<SdkQuickstartDownload packageId="browser" icon={<BrowserLogo size={22} />} promptFlow="redirect-based" />
+
 <TutorialHero>
 
 ## What You Will Learn

--- a/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/express.mdx
+++ b/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/express.mdx
@@ -22,6 +22,8 @@ import {
 
 Use this guide to add <ProductName /> authentication to an Express app with sign-in, sign-out, and route protection.
 
+<SdkQuickstartDownload packageId="express" icon={<ExpressLogo size={22} />} promptFlow="redirect-based" />
+
 <TutorialHero>
 
 ## What You Will Learn

--- a/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/flutter.mdx
+++ b/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/flutter.mdx
@@ -22,6 +22,8 @@ import {
 
 Use this guide to add <ProductName /> authentication to a Flutter application using the `thunderid_flutter` package.
 
+<SdkQuickstartDownload packageId="flutter" icon={<FlutterLogo size={22} />} promptFlow="redirect-based" />
+
 <TutorialHero>
 
 ## What You Will Learn
@@ -38,10 +40,6 @@ Use this guide to add <ProductName /> authentication to a Flutter application us
 <TutorialHeroItem icon={<FileCode />}>iOS 16+ or Android API 26+ target device or simulator</TutorialHeroItem>
 
 </TutorialHero>
-
-:::tip Example Source Code
-Check out the complete <RepoLink path="/tree/main/sdks/flutter/samples/quickstart">Flutter Quickstart Sample</RepoLink> in the <ProductName /> repository.
-:::
 
 <Stepper stepNode="h2" as="h2">
 

--- a/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/ios.mdx
+++ b/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/ios.mdx
@@ -4,7 +4,7 @@ title: iOS Quickstart
 docType: quickstart
 sidebar_position: 8
 persona: app
-description: Add {{ProductName}} authentication to an iOS application using the ThunderID iOS SDK for SwiftUI.
+description: Add {{ProductName}} authentication to an iOS application using the {{ProductName}} iOS SDK.
 ---
 
 import {
@@ -20,7 +20,9 @@ import {
 
 # iOS Quickstart
 
-Use this guide to add <ProductName /> authentication to an iOS application using the <ProductName /> iOS SDK for SwiftUI.
+Use this guide to add <ProductName /> authentication to an iOS application using the <code><ProductName /> iOS SDK</code>.
+
+<SdkQuickstartDownload packageId="ios" icon={<IOSLogo size={22} />} promptFlow="redirect-based" />
 
 <TutorialHero>
 
@@ -38,10 +40,6 @@ Use this guide to add <ProductName /> authentication to an iOS application using
 <TutorialHeroItem icon={<FileCode />}>iOS 16+ deployment target</TutorialHeroItem>
 
 </TutorialHero>
-
-:::tip Example Source Code
-Check out the complete <RepoLink path="/tree/main/sdks/ios/Samples/Quickstart">iOS Quickstart Sample</RepoLink> in the <ProductName /> repository.
-:::
 
 <Stepper stepNode="h2" as="h2">
 

--- a/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/nextjs.mdx
+++ b/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/nextjs.mdx
@@ -22,6 +22,8 @@ import {
 
 Use this guide to add <ProductName /> authentication to a Next.js application using the `@thunderid/nextjs` SDK with full App Router support.
 
+<SdkQuickstartDownload packageId="nextjs" icon={<NextLogo size={22} />} promptFlow="embedded" />
+
 <TutorialHero>
 
 ## What You Will Learn

--- a/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/node.mdx
+++ b/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/node.mdx
@@ -20,7 +20,9 @@ import {
 
 # Node.js Quickstart
 
-Use this guide to authenticate a Node.js service to <ProductName /> using the `@thunderid/node` SDK. Unlike the other quickstarts in this section, there's no user and no browser sign-in: the service authenticates as **itself** with the OAuth 2.0 `client_credentials` grant, then uses the resulting access token to call another piece of business logic. Use this pattern for background jobs, cron tasks, or one backend service calling another, where there's no human in the loop to redirect through a login page.
+Use this guide to add <ProductName /> authentication to a Node.js service using the `@thunderid/node` SDK.
+
+<SdkQuickstartDownload packageId="node" icon={<NodeLogo size={22} />} promptFlow="redirect-based" />
 
 <TutorialHero>
 
@@ -39,10 +41,6 @@ Use this guide to authenticate a Node.js service to <ProductName /> using the `@
 <TutorialHeroItem icon={<FileCode />}>Your preferred code editor</TutorialHeroItem>
 
 </TutorialHero>
-
-:::tip Example Source Code
-Check out the complete <RepoLink path="/tree/main/sdks/javascript-sdks/samples/node/quickstart">Node.js Quickstart Sample</RepoLink> in the <ProductName /> repository.
-:::
 
 <Stepper stepNode="h2" as="h2">
 

--- a/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/nuxt.mdx
+++ b/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/nuxt.mdx
@@ -22,6 +22,8 @@ import {
 
 Use this guide to add <ProductName /> authentication to a Nuxt 3 application using the `@thunderid/nuxt` module.
 
+<SdkQuickstartDownload packageId="nuxt" icon={<NuxtLogo size={22} />} promptFlow="embedded" />
+
 <TutorialHero>
 
 ## What You Will Learn

--- a/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/react.mdx
+++ b/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/react.mdx
@@ -22,6 +22,8 @@ import {
 
 Use this guide to add <ProductName /> authentication to a React application using the `@thunderid/react` SDK.
 
+<SdkQuickstartDownload packageId="react" icon={<ReactLogo size={22} />} promptFlow="redirect-based" />
+
 <TutorialHero>
 
 ## What You Will Learn

--- a/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/vue.mdx
+++ b/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/vue.mdx
@@ -22,6 +22,8 @@ import {
 
 Use this guide to add <ProductName /> authentication to a Vue 3 application using the `@thunderid/vue` SDK.
 
+<SdkQuickstartDownload packageId="vue" icon={<VueLogo size={22} />} promptFlow="redirect-based" />
+
 <TutorialHero>
 
 ## What You Will Learn


### PR DESCRIPTION
### Purpose
Each web and mobile quickstart under **Get Started > Application** now shows a card with the framework's prewired sample app (sourced from `sdk-releases.json`) so a reader can grab a working copy instead of following every step by hand. Where a matching prompt exists, the card also offers a button to copy an LLM prompt that scaffolds the same integration for use with an AI coding assistant.

### Approach
- Added `SdkQuickstartDownload`, a component that fetches `/data/sdk-releases.json`, finds the release matching a given `packageId`, and renders a download link plus an optional "Copy prompt" action (fetches a prewritten `.txt` prompt under `content/.../prompts/<packageId>/<promptFlow>.txt`, fills in the product name and client ID, and copies it to the clipboard).
- Added `GradientBorderButton`, a small animated-border button used to flag the AI-related "Copy prompt" action, matching the treatment already used for this pattern in the Console.
- Wired the card into all 10 `connect-your-application` quickstarts (React, Next.js, Express, Vue, Nuxt, Browser, Node.js, iOS, Android, Flutter) and ported the same change to the `v1.0.x` versioned docs.
- Removed the now-redundant `Example Source Code` callouts (Node.js, iOS, Android, Flutter) since the new card covers the same purpose.
- Refreshed `TutorialHero`'s card styling (bordered container, uppercase monospace section label) to match the new card's visual language.
- Documented in `docs/AGENTS.md` and `.coderabbit.yaml` that a component embedded in doc content and fetching a versioned static asset must derive its version from `useDocsVersion()`, not the version-less `useDocsUrl()` helper, after fixing exactly that bug in `SdkQuickstartDownload`.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
  - Verified all 10 `next` and all 10 `v1.0.x` quickstart pages render the card with no console errors on a local `docusaurus start` run.
  - Verified the "Copy prompt" flow end-to-end (correct fetch URL, correct filled clipboard content) via a headless browser.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added downloadable SDK quickstarts for Android, Browser, Express, Flutter, iOS, Next.js, Node.js, Nuxt, React, and Vue.
  - Added optional authentication prompt copying with clipboard feedback.
  - Introduced an animated gradient-border button style.

- **Documentation**
  - Updated quickstarts with current SDK references and streamlined setup guidance.
  - Removed outdated source-code tips and service-authentication details.
  - Improved version-aware handling of documentation assets.

- **Style**
  - Refined tutorial hero layouts, icons, headings, spacing, and section cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->