### PR TITLE
Return empty permissions on role creation

### DIFF
--- a/api/role.yaml
+++ b/api/role.yaml
@@ -1099,7 +1099,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ResourcePermissions'
-          description: "List of resource permissions grouped by resource server"
+          description: "List of resource permissions grouped by resource server. Always returned as an array, with an empty array when the role has no permissions."
 
     RoleWithAssignments:
       allOf:

--- a/backend/internal/role/handler.go
+++ b/backend/internal/role/handler.go
@@ -462,6 +462,10 @@ func (rh *roleHandler) toHTTPCreateRoleResponse(role *RoleWithPermissionsAndAssi
 			Type: sa.Type,
 		}
 	}
+	permissions := role.Permissions
+	if permissions == nil {
+		permissions = make([]ResourcePermissions, 0)
+	}
 
 	return &CreateRoleResponse{
 		ID:          role.ID,
@@ -469,7 +473,7 @@ func (rh *roleHandler) toHTTPCreateRoleResponse(role *RoleWithPermissionsAndAssi
 		Description: role.Description,
 		OUID:        role.OUID,
 		OUHandle:    role.OUHandle,
-		Permissions: role.Permissions,
+		Permissions: permissions,
 		Assignments: httpAssignments,
 	}
 }

--- a/backend/internal/role/handler_test.go
+++ b/backend/internal/role/handler_test.go
@@ -134,6 +134,37 @@ func (suite *RoleHandlerTestSuite) TestHandleRolePostRequest_Success() {
 	suite.Equal("Test Role", response.Name)
 }
 
+func (suite *RoleHandlerTestSuite) TestHandleRolePostRequest_WithoutPermissions_ReturnsEmptyArray() {
+	request := CreateRoleRequest{
+		Name: "Test Role",
+		OUID: "ou1",
+	}
+
+	expectedRole := &RoleWithPermissionsAndAssignments{
+		ID:   "role1",
+		Name: "Test Role",
+		OUID: "ou1",
+	}
+
+	suite.mockService.On("CreateRole", mock.Anything, mock.AnythingOfType("RoleCreationDetail")).
+		Return(expectedRole, nil)
+
+	body, _ := json.Marshal(request)
+	req := httptest.NewRequest(http.MethodPost, "/roles", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	suite.handler.HandleRolePostRequest(w, req)
+
+	suite.Equal(http.StatusCreated, w.Code)
+
+	var response CreateRoleResponse
+	err := json.NewDecoder(w.Body).Decode(&response)
+	suite.NoError(err)
+	suite.NotNil(response.Permissions)
+	suite.Empty(response.Permissions)
+}
+
 func (suite *RoleHandlerTestSuite) TestHandleRolePostRequest_InvalidJSON() {
 	req := httptest.NewRequest(http.MethodPost, "/roles", bytes.NewBufferString("invalid json"))
 	req.Header.Set("Content-Type", "application/json")


### PR DESCRIPTION
### Purpose
Fix inconsistent role API responses where creating a role without permissions returned `permissions: null`, while retrieving the same role returned `permissions: []`.

### Approach
Normalize a nil permissions slice to an empty slice when mapping the role creation service result to the HTTP response. Add a handler regression test covering role creation without permissions. Document the non-null array contract in the role OpenAPI schema.

### Related Issues
- Fixes #4708

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [x] Documentation provided in `api/role.yaml`.
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided.
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes.
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR does not commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Role creation responses now return an empty permissions list when no permissions are provided, instead of `null`.
  * Improved response consistency for roles created without permissions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->