### PR TITLE
Add integration coverage across the core packages

### DIFF
--- a/backend/internal/role/composite_store.go
+++ b/backend/internal/role/composite_store.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
@@ -680,7 +681,10 @@ func mergeAssignments(dbAssignments, fileAssignments []RoleAssignment) []RoleAss
 	return result
 }
 
-// mergePermissions deduplicates and merges permissions from database and file stores.
+// mergePermissions deduplicates and merges permissions from database and file stores. The result is
+// sorted, because map iteration order is randomized: callers that page over the merged list (such as
+// GetUserRoles) would otherwise return a different order on every call, repeating entries on one page
+// and dropping them from another.
 func mergePermissions(dbPerms, filePerms []string) []string {
 	permMap := make(map[string]bool)
 
@@ -696,5 +700,6 @@ func mergePermissions(dbPerms, filePerms []string) []string {
 	for perm := range permMap {
 		result = append(result, perm)
 	}
+	slices.Sort(result)
 	return result
 }

--- a/backend/internal/role/composite_store_edge_cases_test.go
+++ b/backend/internal/role/composite_store_edge_cases_test.go
@@ -434,6 +434,28 @@ func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetAuthorizedPermissions_C
 	assert.Contains(suite.T(), result, "p3")
 }
 
+// Test GetUserRoles returns the merged roles in a stable order. Callers page over this list by
+// slicing it, so an unstable order would repeat a role on one page and drop it from another.
+func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetUserRoles_MergedOrderIsStable() {
+	dbRoles := []string{"role-c", "role-a"}
+	fileRoles := []string{"role-b", "role-a"}
+
+	suite.mockDBStore.On("GetUserRoles", suite.ctx, "user1", []string{"group1"}).Return(dbRoles, nil)
+	suite.mockFileStore.On("GetUserRoles", suite.ctx, "user1", []string{"group1"}).Return(fileRoles, nil)
+
+	first, err := suite.store.GetUserRoles(suite.ctx, "user1", []string{"group1"})
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), []string{"role-a", "role-b", "role-c"}, first,
+		"The merged roles must be deduplicated and sorted")
+
+	// Repeat the call: the same inputs must always produce the same order.
+	for i := 0; i < 20; i++ {
+		repeat, err := suite.store.GetUserRoles(suite.ctx, "user1", []string{"group1"})
+		assert.NoError(suite.T(), err)
+		assert.Equal(suite.T(), first, repeat, "Repeated calls must return the roles in the same order")
+	}
+}
+
 // Test GetAuthorizedPermissions with empty result
 func (suite *CompositeRoleStoreEdgeCaseTestSuite) TestGetAuthorizedPermissions_EmptyResult() {
 	perms := []string{"perm1"}

--- a/tests/integration/agent/agent_roles_display_test.go
+++ b/tests/integration/agent/agent_roles_display_test.go
@@ -1,0 +1,325 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+var (
+	rolesTestOU = testutils.OrganizationUnit{
+		Handle:      "agent-roles-display-ou",
+		Name:        "Agent Roles Display OU",
+		Description: "Organization unit for the agent roles and display listing tests",
+		Parent:      nil,
+	}
+
+	// rolesTestAgentType is the singleton "default" agent schema every agent suite shares, declared
+	// with the attributes this suite stores. The purpose attribute is what the list tests filter on,
+	// so they only assert on this suite's agent rather than on every agent the run has created.
+	rolesTestAgentType = testutils.UserType{
+		Name: "default",
+		Schema: map[string]interface{}{
+			"description": map[string]interface{}{"type": "string"},
+			"purpose":     map[string]interface{}{"type": "string"},
+		},
+	}
+)
+
+const rolesTestAgentPurpose = "agent-roles-display"
+
+// AgentRolesDisplayTestSuite covers GET /agents/{id}/roles, which reports the roles an agent holds
+// directly and through its groups, and the include=display variants of the agent get and list
+// endpoints, which resolve the agent's OU handle.
+type AgentRolesDisplayTestSuite struct {
+	suite.Suite
+	ouID        string
+	agentTypeID string
+	agentID     string
+	directRole  string
+	groupRole   string
+	roleIDs     []string
+	groupID     string
+}
+
+func TestAgentRolesDisplayTestSuite(t *testing.T) {
+	suite.Run(t, new(AgentRolesDisplayTestSuite))
+}
+
+func (ts *AgentRolesDisplayTestSuite) SetupSuite() {
+	ouID, err := testutils.CreateOrganizationUnit(rolesTestOU)
+	ts.Require().NoError(err, "Failed to create the test organization unit")
+	ts.ouID = ouID
+
+	rolesTestAgentType.OUID = ts.ouID
+	typeID, err := testutils.CreateAgentType(rolesTestAgentType)
+	ts.Require().NoError(err, "Failed to create the agent entity type")
+	ts.agentTypeID = typeID
+
+	agentID, err := createAgent(Agent{
+		OUID:        ts.ouID,
+		Type:        "default",
+		Name:        "agent-roles-display-agent",
+		Description: "Agent used by the roles and display listing tests",
+		Attributes:  json.RawMessage(fmt.Sprintf(`{"purpose":%q}`, rolesTestAgentPurpose)),
+	})
+	ts.Require().NoError(err, "Failed to create the test agent")
+	ts.agentID = agentID
+
+	// A role assigned to the agent directly.
+	ts.directRole = "agent-roles-display-direct"
+	directRoleID, err := testutils.CreateRole(testutils.Role{
+		Name: ts.directRole,
+		OUID: ts.ouID,
+		Assignments: []testutils.Assignment{
+			{ID: ts.agentID, Type: "agent"},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create the directly assigned role")
+	ts.roleIDs = append(ts.roleIDs, directRoleID)
+
+	// A role the agent inherits through a group it belongs to.
+	groupID, err := testutils.CreateGroup(testutils.Group{
+		Name:    "agent-roles-display-group",
+		OUID:    ts.ouID,
+		Members: []testutils.Member{{Id: ts.agentID, Type: "agent"}},
+	})
+	ts.Require().NoError(err, "Failed to create the test group")
+	ts.groupID = groupID
+
+	ts.groupRole = "agent-roles-display-group-role"
+	groupRoleID, err := testutils.CreateRole(testutils.Role{
+		Name: ts.groupRole,
+		OUID: ts.ouID,
+		Assignments: []testutils.Assignment{
+			{ID: ts.groupID, Type: "group"},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create the group assigned role")
+	ts.roleIDs = append(ts.roleIDs, groupRoleID)
+}
+
+func (ts *AgentRolesDisplayTestSuite) TearDownSuite() {
+	for i := len(ts.roleIDs) - 1; i >= 0; i-- {
+		if err := testutils.DeleteRole(ts.roleIDs[i]); err != nil {
+			ts.T().Logf("Failed to delete role %s during teardown: %v", ts.roleIDs[i], err)
+		}
+	}
+	if ts.groupID != "" {
+		if err := testutils.DeleteGroup(ts.groupID); err != nil {
+			ts.T().Logf("Failed to delete group during teardown: %v", err)
+		}
+	}
+	if ts.agentID != "" {
+		if err := deleteAgent(ts.agentID); err != nil {
+			ts.T().Logf("Failed to delete agent during teardown: %v", err)
+		}
+	}
+	if ts.agentTypeID != "" {
+		if err := testutils.DeleteAgentType(ts.agentTypeID); err != nil {
+			ts.T().Logf("Failed to delete agent entity type during teardown: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// --- helpers ---
+
+func (ts *AgentRolesDisplayTestSuite) getRoles(query string) (int, *AgentRoleListResponse, []byte) {
+	requestURL := fmt.Sprintf("%s%s/%s/roles", testServerURL, agentBasePath, ts.agentID)
+	if query != "" {
+		requestURL += "?" + query
+	}
+	return ts.getRolesFromURL(requestURL)
+}
+
+func (ts *AgentRolesDisplayTestSuite) getRolesFromURL(requestURL string) (int, *AgentRoleListResponse, []byte) {
+	resp, err := doGet(requestURL)
+	ts.Require().NoError(err, "Failed to send the agent roles request")
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err, "Failed to read the agent roles response")
+	if resp.StatusCode != http.StatusOK {
+		return resp.StatusCode, nil, body
+	}
+	var roleList AgentRoleListResponse
+	ts.Require().NoError(json.Unmarshal(body, &roleList),
+		"Failed to parse the agent roles response: %s", string(body))
+	return resp.StatusCode, &roleList, body
+}
+
+func (ts *AgentRolesDisplayTestSuite) assertErrorCode(body []byte, expectedCode string) {
+	var errResp struct {
+		Code    string `json:"code"`
+		Message struct {
+			DefaultValue string `json:"defaultValue"`
+		} `json:"message"`
+	}
+	ts.Require().NoError(json.Unmarshal(body, &errResp), "Failed to parse the error response: %s", string(body))
+	ts.Equal(expectedCode, errResp.Code, "Unexpected error code for response: %s", string(body))
+}
+
+// --- tests ---
+
+// TestAgentRolesIncludesDirectAndInheritedRoles asserts that the roles endpoint reports both the
+// role assigned to the agent itself and the role it inherits from its group membership.
+func (ts *AgentRolesDisplayTestSuite) TestAgentRolesIncludesDirectAndInheritedRoles() {
+	status, roleList, body := ts.getRoles("")
+	ts.Require().Equal(http.StatusOK, status, "Listing agent roles should return 200: %s", string(body))
+
+	ts.Contains(roleList.Roles, ts.directRole, "A role assigned to the agent must be reported")
+	ts.Contains(roleList.Roles, ts.groupRole, "A role assigned to the agent's group must be reported")
+	ts.Equal(len(roleList.Roles), roleList.Count, "Count must match the number of returned roles")
+	ts.Equal(1, roleList.StartIndex, "The default page starts at index 1")
+	ts.GreaterOrEqual(roleList.TotalResults, 2,
+		"The agent holds at least its direct role and its inherited role")
+}
+
+// TestAgentRolesPagination asserts the paging contract of the roles endpoint, including the empty
+// page returned for an offset past the end of the result set.
+func (ts *AgentRolesDisplayTestSuite) TestAgentRolesPagination() {
+	status, firstPage, body := ts.getRoles("limit=1&offset=0")
+	ts.Require().Equal(http.StatusOK, status, "Listing agent roles should return 200: %s", string(body))
+	ts.Equal(1, firstPage.Count, "A limit of 1 must return a single role")
+	ts.Equal(1, firstPage.StartIndex, "The first page starts at index 1")
+	ts.GreaterOrEqual(firstPage.TotalResults, 2, "The total count must cover every role of the agent")
+	ts.NotEmpty(firstPage.Links, "A paged response must carry pagination links")
+
+	status, secondPage, body := ts.getRoles("limit=1&offset=1")
+	ts.Require().Equal(http.StatusOK, status, "Listing agent roles should return 200: %s", string(body))
+	ts.Equal(1, secondPage.Count, "The second page must return the next role")
+	ts.Equal(2, secondPage.StartIndex, "The second page starts at index 2")
+	ts.NotEqual(firstPage.Roles[0], secondPage.Roles[0], "Consecutive pages must not repeat a role")
+
+	status, emptyPage, body := ts.getRoles("limit=1&offset=100")
+	ts.Require().Equal(http.StatusOK, status,
+		"An offset past the end of the result set is still a valid page: %s", string(body))
+	ts.Empty(emptyPage.Roles, "An offset past the end must return no roles")
+	ts.Equal(0, emptyPage.Count, "An empty page reports a count of zero")
+	ts.GreaterOrEqual(emptyPage.TotalResults, 2, "The total count is independent of the requested page")
+}
+
+// TestAgentRolesInvalidPagination asserts that the roles endpoint rejects out of range pagination
+// parameters with the documented error codes.
+func (ts *AgentRolesDisplayTestSuite) TestAgentRolesInvalidPagination() {
+	testCases := []struct {
+		name         string
+		query        string
+		expectedCode string
+	}{
+		{name: "non numeric limit", query: "limit=abc", expectedCode: "AGT-1011"},
+		{name: "zero limit", query: "limit=0", expectedCode: "AGT-1011"},
+		{name: "limit above the maximum", query: "limit=101", expectedCode: "AGT-1011"},
+		{name: "negative offset", query: "offset=-1", expectedCode: "AGT-1012"},
+		{name: "non numeric offset", query: "offset=abc", expectedCode: "AGT-1012"},
+	}
+
+	for _, tc := range testCases {
+		ts.Run(tc.name, func() {
+			status, _, body := ts.getRoles(tc.query)
+			ts.Equal(http.StatusBadRequest, status, "Invalid pagination should be rejected with 400")
+			ts.assertErrorCode(body, tc.expectedCode)
+		})
+	}
+}
+
+// TestAgentRolesUnknownAgent asserts that the roles endpoint reports a missing agent as not found,
+// both for an identifier that does not exist and for one that belongs to a non-agent entity.
+func (ts *AgentRolesDisplayTestSuite) TestAgentRolesUnknownAgent() {
+	status, _, body := ts.getRolesFromURL(fmt.Sprintf("%s%s/%s/roles", testServerURL, agentBasePath,
+		"00000000-0000-0000-0000-000000000000"))
+	ts.Equal(http.StatusNotFound, status, "An unknown agent id should return 404")
+	ts.assertErrorCode(body, "AGT-1004")
+
+	// A group is an entity of another category, so its id must not resolve as an agent.
+	status, _, body = ts.getRolesFromURL(fmt.Sprintf("%s%s/%s/roles", testServerURL, agentBasePath, ts.groupID))
+	ts.Equal(http.StatusNotFound, status, "An id of another entity category should return 404")
+	ts.assertErrorCode(body, "AGT-1004")
+}
+
+// TestAgentGetWithDisplayResolvesOUHandle asserts that GET /agents/{id} only resolves the OU handle
+// when display attributes are requested.
+func (ts *AgentRolesDisplayTestSuite) TestAgentGetWithDisplayResolvesOUHandle() {
+	resp, err := doGet(fmt.Sprintf("%s%s/%s", testServerURL, agentBasePath, ts.agentID))
+	ts.Require().NoError(err, "Failed to send the agent get request")
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	ts.Require().NoError(err, "Failed to read the agent get response")
+	ts.Require().Equal(http.StatusOK, resp.StatusCode, "Getting an agent should return 200: %s", string(body))
+
+	var plain Agent
+	ts.Require().NoError(json.Unmarshal(body, &plain), "Failed to parse the agent get response")
+	ts.Empty(plain.OUHandle, "The OU handle must not be resolved without include=display")
+
+	resp, err = doGet(fmt.Sprintf("%s%s/%s?include=display", testServerURL, agentBasePath, ts.agentID))
+	ts.Require().NoError(err, "Failed to send the agent get request with display")
+	body, err = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	ts.Require().NoError(err, "Failed to read the agent get response with display")
+	ts.Require().Equal(http.StatusOK, resp.StatusCode,
+		"Getting an agent with display should return 200: %s", string(body))
+
+	var withDisplay Agent
+	ts.Require().NoError(json.Unmarshal(body, &withDisplay), "Failed to parse the agent get response")
+	ts.Equal(rolesTestOU.Handle, withDisplay.OUHandle,
+		"include=display must resolve the handle of the agent's organization unit")
+}
+
+// TestAgentListWithDisplayResolvesOUHandles asserts that the batch OU handle resolution of the agent
+// list endpoint runs only when display attributes are requested.
+func (ts *AgentRolesDisplayTestSuite) TestAgentListWithDisplayResolvesOUHandles() {
+	findAgent := func(list *AgentListResponse) *Agent {
+		for i := range list.Agents {
+			if list.Agents[i].ID == ts.agentID {
+				return &list.Agents[i]
+			}
+		}
+		return nil
+	}
+
+	listAgents := func(query url.Values) *AgentListResponse {
+		resp, err := doGet(fmt.Sprintf("%s%s?%s", testServerURL, agentBasePath, query.Encode()))
+		ts.Require().NoError(err, "Failed to send the agent list request")
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		ts.Require().NoError(err, "Failed to read the agent list response")
+		ts.Require().Equal(http.StatusOK, resp.StatusCode,
+			"Listing agents should return 200: %s", string(body))
+		var list AgentListResponse
+		ts.Require().NoError(json.Unmarshal(body, &list),
+			"Failed to parse the agent list response: %s", string(body))
+		return &list
+	}
+
+	// Filter to this suite's agent so the assertion does not depend on agents other suites created.
+	plainQuery := url.Values{}
+	plainQuery.Set("filter", fmt.Sprintf(`purpose eq %q`, rolesTestAgentPurpose))
+	plainList := listAgents(plainQuery)
+	plainAgent := findAgent(plainList)
+	ts.Require().NotNil(plainAgent, "The test agent must be returned by the filtered list")
+	ts.Empty(plainAgent.OUHandle, "The OU handle must not be resolved without include=display")
+
+	displayQuery := url.Values{}
+	displayQuery.Set("filter", fmt.Sprintf(`purpose eq %q`, rolesTestAgentPurpose))
+	displayQuery.Set("include", "display")
+	displayList := listAgents(displayQuery)
+	displayAgent := findAgent(displayList)
+	ts.Require().NotNil(displayAgent, "The test agent must be returned by the filtered list with display")
+	ts.Equal(rolesTestOU.Handle, displayAgent.OUHandle,
+		"include=display must resolve the OU handle of every listed agent")
+}

--- a/tests/integration/agent/model.go
+++ b/tests/integration/agent/model.go
@@ -28,7 +28,7 @@ type Agent struct {
 
 // InboundAuthConfig represents an inbound authentication configuration entry.
 type InboundAuthConfig struct {
-	Type   string          `json:"type"`
+	Type   string            `json:"type"`
 	Config *OAuthAgentConfig `json:"config,omitempty"`
 }
 
@@ -82,6 +82,16 @@ type AgentGroupListResponse struct {
 	StartIndex   int           `json:"startIndex"`
 	Count        int           `json:"count"`
 	Groups       []AgentGroup  `json:"groups"`
+	Links        []interface{} `json:"links"`
+}
+
+// AgentRoleListResponse is the paginated role list response for an agent. Roles are reported by
+// name, both for direct assignments and for those inherited through group membership.
+type AgentRoleListResponse struct {
+	TotalResults int           `json:"totalResults"`
+	StartIndex   int           `json:"startIndex"`
+	Count        int           `json:"count"`
+	Roles        []string      `json:"roles"`
 	Links        []interface{} `json:"links"`
 }
 

--- a/tests/integration/application/certificate_update_test.go
+++ b/tests/integration/application/certificate_update_test.go
@@ -1,0 +1,243 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package application
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	// certUpdateFirstJWKS and certUpdateSecondJWKS are two distinct inline JWKS documents. The
+	// second one replaces the first, which is what drives the certificate update path: the stored
+	// certificate record is updated in place rather than recreated.
+	certUpdateFirstJWKS = `{"keys":[{"kty":"RSA","use":"sig","kid":"cert-update-key-1",` +
+		`"n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_` +
+		`BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2Q` +
+		`vzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZ` +
+		`u0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw","e":"AQAB"}]}`
+	certUpdateSecondJWKS = `{"keys":[{"kty":"EC","use":"sig","kid":"cert-update-key-2","crv":"P-256",` +
+		`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU","y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"}]}`
+
+	certUpdateJWKSURI = "https://cert-update.example.com/.well-known/jwks.json"
+)
+
+var certUpdateOU = testutils.OrganizationUnit{
+	Handle:      "cert-update-test-ou",
+	Name:        "Certificate Update Test OU",
+	Description: "Organization unit for the application certificate update tests",
+	Parent:      nil,
+}
+
+// CertificateUpdateTestSuite covers the certificate lifecycle of an OAuth application: the stored
+// certificate is created, updated in place, and removed as the application's inbound OAuth profile
+// changes across PUT /applications/{id} requests.
+type CertificateUpdateTestSuite struct {
+	suite.Suite
+	ouID string
+}
+
+func TestCertificateUpdateTestSuite(t *testing.T) {
+	suite.Run(t, new(CertificateUpdateTestSuite))
+}
+
+func (ts *CertificateUpdateTestSuite) SetupSuite() {
+	ouID, err := testutils.CreateOrganizationUnit(certUpdateOU)
+	ts.Require().NoError(err, "Failed to create the test organization unit")
+	ts.ouID = ouID
+}
+
+func (ts *CertificateUpdateTestSuite) TearDownSuite() {
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete the test organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// --- helpers ---
+
+// privateKeyJWTApp builds an application whose OAuth profile authenticates with private_key_jwt and
+// carries the given certificate.
+func (ts *CertificateUpdateTestSuite) privateKeyJWTApp(name, clientID string,
+	cert *ApplicationCert) Application {
+	return Application{
+		OUID:        ts.ouID,
+		Name:        name,
+		Description: "Application for the certificate update tests",
+		URL:         fmt.Sprintf("https://%s.example.com", clientID),
+		InboundAuthConfig: []InboundAuthConfig{
+			{
+				Type: "oauth2",
+				OAuthAppConfig: &OAuthAppConfig{
+					ClientID:                clientID,
+					RedirectURIs:            []string{fmt.Sprintf("https://%s.example.com/callback", clientID)},
+					GrantTypes:              []string{"client_credentials"},
+					ResponseTypes:           []string{},
+					TokenEndpointAuthMethod: "private_key_jwt",
+					Certificate:             cert,
+				},
+			},
+		},
+	}
+}
+
+// secretApp builds an application whose OAuth profile authenticates with a client secret and
+// therefore carries no certificate.
+func (ts *CertificateUpdateTestSuite) secretApp(name, clientID, clientSecret string) Application {
+	return Application{
+		OUID:        ts.ouID,
+		Name:        name,
+		Description: "Application for the certificate update tests",
+		URL:         fmt.Sprintf("https://%s.example.com", clientID),
+		InboundAuthConfig: []InboundAuthConfig{
+			{
+				Type: "oauth2",
+				OAuthAppConfig: &OAuthAppConfig{
+					ClientID:                clientID,
+					ClientSecret:            clientSecret,
+					RedirectURIs:            []string{fmt.Sprintf("https://%s.example.com/callback", clientID)},
+					GrantTypes:              []string{"client_credentials"},
+					ResponseTypes:           []string{},
+					TokenEndpointAuthMethod: "client_secret_basic",
+				},
+			},
+		},
+	}
+}
+
+// storedCertificate returns the certificate the server reports for the application's OAuth profile.
+func (ts *CertificateUpdateTestSuite) storedCertificate(appID string) *ApplicationCert {
+	app, err := getApplicationByID(appID)
+	ts.Require().NoError(err, "Failed to read back the application")
+	ts.Require().Len(app.InboundAuthConfig, 1, "The application must expose its OAuth profile")
+	ts.Require().NotNil(app.InboundAuthConfig[0].OAuthAppConfig, "The OAuth profile must be populated")
+	return app.InboundAuthConfig[0].OAuthAppConfig.Certificate
+}
+
+// --- tests ---
+
+// TestCertificateValueUpdatedInPlace asserts that replacing the certificate value of an existing
+// OAuth profile updates the stored certificate, and that the new value is what later reads return.
+func (ts *CertificateUpdateTestSuite) TestCertificateValueUpdatedInPlace() {
+	app := ts.privateKeyJWTApp("Cert Update Value App", "cert_update_value_client",
+		&ApplicationCert{Type: "JWKS", Value: certUpdateFirstJWKS})
+	appID, err := createApplication(app)
+	ts.Require().NoError(err, "Failed to create the application with a certificate")
+	defer func() { _ = deleteApplication(appID) }()
+
+	stored := ts.storedCertificate(appID)
+	ts.Require().NotNil(stored, "The created application must report its certificate")
+	ts.Equal("JWKS", stored.Type, "The stored certificate type must be the one registered")
+	ts.Equal(certUpdateFirstJWKS, stored.Value, "The stored certificate value must be the one registered")
+
+	updated := app
+	updated.ID = appID
+	updated.InboundAuthConfig[0].OAuthAppConfig.Certificate =
+		&ApplicationCert{Type: "JWKS", Value: certUpdateSecondJWKS}
+	ts.Require().NoError(updateApplication(appID, updated), "Failed to update the certificate value")
+
+	stored = ts.storedCertificate(appID)
+	ts.Require().NotNil(stored, "The updated application must still report a certificate")
+	ts.Equal("JWKS", stored.Type, "The certificate type is unchanged by a value update")
+	ts.Equal(certUpdateSecondJWKS, stored.Value, "The updated certificate value must be returned")
+}
+
+// TestCertificateTypeSwitchedOnUpdate asserts that switching an inline JWKS certificate to a JWKS
+// URI is applied to the existing certificate record.
+func (ts *CertificateUpdateTestSuite) TestCertificateTypeSwitchedOnUpdate() {
+	app := ts.privateKeyJWTApp("Cert Update Type App", "cert_update_type_client",
+		&ApplicationCert{Type: "JWKS", Value: certUpdateFirstJWKS})
+	appID, err := createApplication(app)
+	ts.Require().NoError(err, "Failed to create the application with a certificate")
+	defer func() { _ = deleteApplication(appID) }()
+
+	updated := app
+	updated.ID = appID
+	updated.InboundAuthConfig[0].OAuthAppConfig.Certificate =
+		&ApplicationCert{Type: "JWKS_URI", Value: certUpdateJWKSURI}
+	ts.Require().NoError(updateApplication(appID, updated), "Failed to switch the certificate type")
+
+	stored := ts.storedCertificate(appID)
+	ts.Require().NotNil(stored, "The updated application must still report a certificate")
+	ts.Equal("JWKS_URI", stored.Type, "The switched certificate type must be returned")
+	ts.Equal(certUpdateJWKSURI, stored.Value, "The switched certificate value must be returned")
+}
+
+// TestCertificateAddedOnUpdate asserts that an application registered without a certificate gets one
+// stored when its profile switches to private_key_jwt.
+func (ts *CertificateUpdateTestSuite) TestCertificateAddedOnUpdate() {
+	app := ts.secretApp("Cert Update Added App", "cert_update_added_client", "cert_update_added_secret")
+	appID, err := createApplication(app)
+	ts.Require().NoError(err, "Failed to create the application without a certificate")
+	defer func() { _ = deleteApplication(appID) }()
+
+	ts.Nil(ts.storedCertificate(appID), "A client secret application must have no certificate")
+
+	updated := ts.privateKeyJWTApp("Cert Update Added App", "cert_update_added_client",
+		&ApplicationCert{Type: "JWKS", Value: certUpdateFirstJWKS})
+	updated.ID = appID
+	ts.Require().NoError(updateApplication(appID, updated), "Failed to add a certificate on update")
+
+	stored := ts.storedCertificate(appID)
+	ts.Require().NotNil(stored, "The updated application must report the added certificate")
+	ts.Equal(certUpdateFirstJWKS, stored.Value, "The added certificate value must be returned")
+}
+
+// TestCertificateRemovedOnUpdate asserts that moving back to client secret authentication removes the
+// stored certificate rather than leaving it behind.
+func (ts *CertificateUpdateTestSuite) TestCertificateRemovedOnUpdate() {
+	app := ts.privateKeyJWTApp("Cert Update Removed App", "cert_update_removed_client",
+		&ApplicationCert{Type: "JWKS", Value: certUpdateFirstJWKS})
+	appID, err := createApplication(app)
+	ts.Require().NoError(err, "Failed to create the application with a certificate")
+	defer func() { _ = deleteApplication(appID) }()
+
+	ts.Require().NotNil(ts.storedCertificate(appID), "The created application must report its certificate")
+
+	updated := ts.secretApp("Cert Update Removed App", "cert_update_removed_client",
+		"cert_update_removed_secret")
+	updated.ID = appID
+	ts.Require().NoError(updateApplication(appID, updated), "Failed to remove the certificate on update")
+
+	ts.Nil(ts.storedCertificate(appID), "The certificate must be removed once the profile no longer has one")
+}
+
+// TestInvalidCertificateOnUpdateIsRejected asserts that an invalid certificate is rejected on update
+// and that the previously stored certificate survives the rejected request.
+func (ts *CertificateUpdateTestSuite) TestInvalidCertificateOnUpdateIsRejected() {
+	app := ts.privateKeyJWTApp("Cert Update Invalid App", "cert_update_invalid_client",
+		&ApplicationCert{Type: "JWKS", Value: certUpdateFirstJWKS})
+	appID, err := createApplication(app)
+	ts.Require().NoError(err, "Failed to create the application with a certificate")
+	defer func() { _ = deleteApplication(appID) }()
+
+	testCases := []struct {
+		name string
+		cert *ApplicationCert
+	}{
+		{name: "unsupported certificate type", cert: &ApplicationCert{Type: "PEM", Value: certUpdateFirstJWKS}},
+		{name: "inline JWKS with no value", cert: &ApplicationCert{Type: "JWKS", Value: ""}},
+		{name: "JWKS URI that is not a URI", cert: &ApplicationCert{Type: "JWKS_URI", Value: "not-a-uri"}},
+	}
+
+	for _, tc := range testCases {
+		ts.Run(tc.name, func() {
+			updated := app
+			updated.ID = appID
+			updated.InboundAuthConfig[0].OAuthAppConfig.Certificate = tc.cert
+			err := updateApplication(appID, updated)
+			ts.Error(err, "An invalid certificate must be rejected on update")
+
+			stored := ts.storedCertificate(appID)
+			ts.Require().NotNil(stored, "A rejected update must leave the stored certificate in place")
+			ts.Equal(certUpdateFirstJWKS, stored.Value,
+				"A rejected update must not change the stored certificate value")
+		})
+	}
+}

--- a/tests/integration/connection/vendor_list_test.go
+++ b/tests/integration/connection/vendor_list_test.go
@@ -1,0 +1,174 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package connection
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// connectionInstanceSummary mirrors backend/internal/connection/models.go connectionInstanceSummary,
+// the shape the vendor scoped collection endpoints return.
+type connectionInstanceSummary struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// VendorListTestSuite covers the vendor scoped collection endpoints, GET /connections/{vendor},
+// which list only the instances of that vendor. The unified GET /connections listing is covered by
+// the connection API suite; this suite asserts the per-vendor scoping, for identity providers and
+// for message providers alike.
+type VendorListTestSuite struct {
+	suite.Suite
+	googleID     string
+	oidcID       string
+	twilioID     string
+	smsGatewayID string
+}
+
+func TestVendorListSuite(t *testing.T) {
+	suite.Run(t, new(VendorListTestSuite))
+}
+
+func (ts *VendorListTestSuite) SetupSuite() {
+	ts.googleID = ts.create("google", googleConnectionRequest{
+		Name:         "Vendor List Google",
+		ClientID:     "vendor-list-google-client",
+		ClientSecret: "vendor-list-google-secret",
+		RedirectURI:  "https://localhost:8095/flow/authn",
+	})
+	ts.oidcID = ts.create("oidc", oidcConnectionRequest{
+		Name:                  "Vendor List OIDC",
+		ClientID:              "vendor-list-oidc-client",
+		ClientSecret:          "vendor-list-oidc-secret",
+		RedirectURI:           "https://localhost:8095/flow/authn",
+		AuthorizationEndpoint: "https://vendor-list.example.com/authorize",
+		TokenEndpoint:         "https://vendor-list.example.com/token",
+	})
+	ts.twilioID = ts.create("twilio", twilioConnectionRequest{
+		Name:       "Vendor List Twilio",
+		AccountSID: "AC00000000000000000000000000000001",
+		AuthToken:  "vendor-list-twilio-token",
+		SenderID:   "+10000000001",
+	})
+	ts.smsGatewayID = ts.create("sms-gateway", smsGatewayConnectionRequest{
+		Name:       "Vendor List SMS Gateway",
+		URL:        "https://vendor-list.example.com/sms",
+		HTTPMethod: "POST",
+	})
+}
+
+func (ts *VendorListTestSuite) TearDownSuite() {
+	for vendor, id := range map[string]string{
+		"google":      ts.googleID,
+		"oidc":        ts.oidcID,
+		"twilio":      ts.twilioID,
+		"sms-gateway": ts.smsGatewayID,
+	} {
+		if id == "" {
+			continue
+		}
+		res, err := doRequest(http.MethodDelete, "/connections/"+vendor+"/"+id, nil)
+		if err != nil || res.status != http.StatusNoContent {
+			ts.T().Logf("Failed to delete the %s connection during teardown: status=%d err=%v",
+				vendor, res.status, err)
+		}
+	}
+}
+
+func (ts *VendorListTestSuite) create(vendor string, body interface{}) string {
+	res, err := doRequest(http.MethodPost, "/connections/"+vendor, body)
+	ts.Require().NoError(err, "Failed to create the %s connection", vendor)
+	ts.Require().Equal(http.StatusCreated, res.status,
+		"Creating the %s connection should return 201: %s", vendor, string(res.body))
+
+	var created connectionResponse
+	ts.Require().NoError(res.decode(&created), "Failed to decode the created %s connection", vendor)
+	ts.Require().NotEmpty(created.ID, "The created %s connection must have an id", vendor)
+	return created.ID
+}
+
+// listVendor returns the instances the vendor scoped collection endpoint reports.
+func (ts *VendorListTestSuite) listVendor(vendor string) []connectionInstanceSummary {
+	res, err := doRequest(http.MethodGet, "/connections/"+vendor, nil)
+	ts.Require().NoError(err, "Failed to list the %s connections", vendor)
+	ts.Require().Equal(http.StatusOK, res.status,
+		"Listing the %s connections should return 200: %s", vendor, string(res.body))
+
+	var instances []connectionInstanceSummary
+	ts.Require().NoError(res.decode(&instances), "Failed to decode the %s connection list", vendor)
+	return instances
+}
+
+// containsSummaryID reports whether the vendor scoped listing contains the given instance id.
+func containsSummaryID(instances []connectionInstanceSummary, id string) bool {
+	for _, instance := range instances {
+		if instance.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// TestIdentityProviderVendorListIsScopedToItsType asserts that an identity provider collection lists
+// its own instances and none of another vendor's.
+func (ts *VendorListTestSuite) TestIdentityProviderVendorListIsScopedToItsType() {
+	googleInstances := ts.listVendor("google")
+	ts.True(containsSummaryID(googleInstances, ts.googleID), "The google list must contain the google connection")
+	ts.False(containsSummaryID(googleInstances, ts.oidcID), "The google list must not contain the OIDC connection")
+
+	oidcInstances := ts.listVendor("oidc")
+	ts.True(containsSummaryID(oidcInstances, ts.oidcID), "The OIDC list must contain the OIDC connection")
+	ts.False(containsSummaryID(oidcInstances, ts.googleID), "The OIDC list must not contain the google connection")
+
+	// A vendor with no configured instance still answers with an empty collection rather than 404.
+	githubInstances := ts.listVendor("github")
+	ts.False(containsSummaryID(githubInstances, ts.googleID),
+		"The github list must not contain connections of other vendors")
+
+	for _, instance := range googleInstances {
+		if instance.ID == ts.googleID {
+			ts.Equal("Vendor List Google", instance.Name,
+				"The listed instance must carry the name it was created with")
+		}
+	}
+}
+
+// TestMessageProviderVendorListIsScopedToItsProvider asserts the same scoping for the message
+// provider collections, which resolve through the notification sender service instead.
+func (ts *VendorListTestSuite) TestMessageProviderVendorListIsScopedToItsProvider() {
+	twilioInstances := ts.listVendor("twilio")
+	ts.True(containsSummaryID(twilioInstances, ts.twilioID), "The twilio list must contain the twilio sender")
+	ts.False(containsSummaryID(twilioInstances, ts.smsGatewayID),
+		"The twilio list must not contain the custom gateway sender")
+
+	gatewayInstances := ts.listVendor("sms-gateway")
+	ts.True(containsSummaryID(gatewayInstances, ts.smsGatewayID),
+		"The custom gateway list must contain the custom gateway sender")
+	ts.False(containsSummaryID(gatewayInstances, ts.twilioID),
+		"The custom gateway list must not contain the twilio sender")
+
+	vonageInstances := ts.listVendor("vonage")
+	ts.False(containsSummaryID(vonageInstances, ts.twilioID),
+		"The vonage list must not contain senders of other providers")
+
+	for _, instance := range twilioInstances {
+		if instance.ID == ts.twilioID {
+			ts.Equal("Vendor List Twilio", instance.Name,
+				"The listed sender must carry the name it was created with")
+		}
+	}
+}
+
+// TestUnknownVendorCollectionIsNotFound asserts that only registered vendors have a collection
+// endpoint, so an unknown vendor is not silently treated as an empty one.
+func (ts *VendorListTestSuite) TestUnknownVendorCollectionIsNotFound() {
+	res, err := doRequest(http.MethodGet, "/connections/not-a-vendor", nil)
+	ts.Require().NoError(err, "Failed to send the request for an unknown vendor")
+	ts.Equal(http.StatusNotFound, res.status,
+		"An unknown vendor collection should return 404: %s", string(res.body))
+}

--- a/tests/integration/export/export_entity_resources_test.go
+++ b/tests/integration/export/export_entity_resources_test.go
@@ -1,0 +1,349 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package export
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// ExportEntityResourcesTestSuite covers the export hooks of the resource types that no other export
+// suite reaches: users, user types, agent types, and translations.
+//
+// Each exporter contributes four hooks to the shared export pipeline (GetAllResourceIDs,
+// GetResourceByID, ValidateResource, GetResourceRules), so every type is exercised both by ID and by
+// wildcard. The wildcard path is the one that runs GetAllResourceIDs, and it is also where a type
+// filter mistake shows up, since the emitted bundle would then carry documents of the wrong type.
+//
+// The user exporter is the interesting one: it declares Credentials as a dynamic property field, so
+// the credential the fixture user is created with must be replaced by a template variable and must
+// not appear in the exported document.
+type ExportEntityResourcesTestSuite struct {
+	suite.Suite
+
+	ouID       string
+	userTypeID string
+	userID     string
+}
+
+const (
+	entityExportOUHandle = "export-entity-ou"
+
+	entityExportUserTypeName = "export-entity-person"
+	entityExportUsername     = "export-entity-user"
+	entityExportPassword     = "ExportEntity@123"
+
+	// The agent type is the shared singleton `default`, so its name is fixed.
+	entityExportAgentTypeName = "default"
+
+	// A language of this suite's own, so clearing it never touches the system defaults other
+	// suites resolve against.
+	entityExportLanguage  = "pt-BR"
+	entityExportNamespace = "integration-export"
+	entityExportKey       = "greeting"
+	entityExportValue     = "Ola"
+)
+
+func TestExportEntityResourcesTestSuite(t *testing.T) {
+	suite.Run(t, new(ExportEntityResourcesTestSuite))
+}
+
+func (ts *ExportEntityResourcesTestSuite) SetupSuite() {
+	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      entityExportOUHandle,
+		Name:        "Export Entity OU",
+		Description: "Organization unit for the entity resource export tests",
+	})
+	ts.Require().NoError(err, "Failed to create the test organization unit")
+	ts.ouID = ouID
+
+	userTypeID, err := testutils.CreateUserType(testutils.UserType{
+		Name: entityExportUserTypeName,
+		OUID: ts.ouID,
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{"type": "string"},
+			"password": map[string]interface{}{"type": "string", "credential": true},
+			"email":    map[string]interface{}{"type": "string"},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create the user type")
+	ts.userTypeID = userTypeID
+
+	// The server allows a single `default` agent type, shared across suites and never deleted.
+	_, err = testutils.CreateAgentType(testutils.UserType{
+		OUID: ts.ouID,
+		Schema: map[string]interface{}{
+			"description": map[string]interface{}{"type": "string"},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create the agent type")
+
+	userID, err := testutils.CreateUser(testutils.User{
+		Type: entityExportUserTypeName,
+		OUID: ts.ouID,
+		Attributes: json.RawMessage(fmt.Sprintf(
+			`{"username": %q, "password": %q, "email": "export-entity@example.com"}`,
+			entityExportUsername, entityExportPassword)),
+	})
+	ts.Require().NoError(err, "Failed to create the user")
+	ts.userID = userID
+
+	ts.setTranslationOverride()
+}
+
+func (ts *ExportEntityResourcesTestSuite) TearDownSuite() {
+	ts.clearTranslationLanguage()
+
+	if ts.userID != "" {
+		if err := testutils.DeleteUser(ts.userID); err != nil {
+			ts.T().Logf("Failed to delete the test user: %v", err)
+		}
+	}
+	if ts.userTypeID != "" {
+		if err := testutils.DeleteUserType(ts.userTypeID); err != nil {
+			ts.T().Logf("Failed to delete the user type: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete the test organization unit: %v", err)
+		}
+	}
+}
+
+// setTranslationOverride writes one override so the language becomes exportable. A language with no
+// overrides is not a resource the exporter can enumerate.
+func (ts *ExportEntityResourcesTestSuite) setTranslationOverride() {
+	ts.T().Helper()
+
+	body, err := json.Marshal(map[string]string{"value": entityExportValue})
+	ts.Require().NoError(err)
+
+	target := fmt.Sprintf("%s/i18n/languages/%s/translations/ns/%s/keys/%s",
+		testServerURL, url.PathEscape(entityExportLanguage),
+		url.PathEscape(entityExportNamespace), url.PathEscape(entityExportKey))
+
+	req, err := http.NewRequest(http.MethodPost, target, bytes.NewReader(body))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+	ts.Require().Equalf(http.StatusOK, resp.StatusCode,
+		"failed to seed the translation override, body: %s", respBody)
+}
+
+// clearTranslationLanguage removes the suite's overrides so the shared server is left as found.
+func (ts *ExportEntityResourcesTestSuite) clearTranslationLanguage() {
+	ts.T().Helper()
+
+	target := fmt.Sprintf("%s/i18n/languages/%s/translations",
+		testServerURL, url.PathEscape(entityExportLanguage))
+
+	req, err := http.NewRequest(http.MethodDelete, target, nil)
+	if err != nil {
+		ts.T().Logf("Failed to build the translation cleanup request: %v", err)
+		return
+	}
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	if err != nil {
+		ts.T().Logf("Failed to clear the translation language: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		ts.T().Logf("Unexpected status clearing the translation language: %d", resp.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Users
+// ---------------------------------------------------------------------------
+
+// TestUserExportByID verifies a user is emitted as a user document carrying its attributes.
+func (ts *ExportEntityResourcesTestSuite) TestUserExportByID() {
+	yamlContent, err := ts.exportResourcesYAML(ExportRequest{Users: []string{ts.userID}})
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(yamlContent)
+
+	ts.Assert().Contains(yamlContent, "resource_type: user")
+	ts.Assert().Contains(yamlContent, `username: "`+entityExportUsername+`"`)
+	ts.Assert().Contains(yamlContent, "export-entity@example.com")
+	ts.Assert().Contains(yamlContent, "type: "+entityExportUserTypeName)
+}
+
+// TestUserExportParameterizesCredentials verifies the exported document does not carry the user's
+// password. The user exporter declares Credentials as a dynamic property field precisely so secrets
+// leave as template variables, and a bundle is a shareable artifact.
+func (ts *ExportEntityResourcesTestSuite) TestUserExportParameterizesCredentials() {
+	yamlContent, err := ts.exportResourcesYAML(ExportRequest{Users: []string{ts.userID}})
+	ts.Require().NoError(err)
+
+	ts.Assert().NotContains(yamlContent, entityExportPassword,
+		"an exported user must not carry its plaintext credential")
+}
+
+// TestUserExportWithWildcard verifies the wildcard form enumerates users and includes the fixture.
+func (ts *ExportEntityResourcesTestSuite) TestUserExportWithWildcard() {
+	yamlContent, err := ts.exportResourcesYAML(ExportRequest{Users: []string{"*"}})
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(yamlContent)
+
+	ts.Assert().Contains(yamlContent, "resource_type: user")
+	ts.Assert().Contains(yamlContent, `username: "`+entityExportUsername+`"`)
+}
+
+// TestExportWithInvalidUserID verifies an unknown user ID yields no resources rather than a partial
+// bundle that would silently omit it.
+func (ts *ExportEntityResourcesTestSuite) TestExportWithInvalidUserID() {
+	_, err := ts.exportResourcesYAML(ExportRequest{Users: []string{"non-existent-user-id"}})
+	ts.Require().Error(err)
+}
+
+// ---------------------------------------------------------------------------
+// User types and agent types
+// ---------------------------------------------------------------------------
+
+// TestUserTypeExportByID verifies a user type is emitted as a user_type document with its schema.
+func (ts *ExportEntityResourcesTestSuite) TestUserTypeExportByID() {
+	yamlContent, err := ts.exportResourcesYAML(ExportRequest{UserTypes: []string{ts.userTypeID}})
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(yamlContent)
+
+	ts.Assert().Contains(yamlContent, "resource_type: user_type")
+	ts.Assert().Contains(yamlContent, "name: "+entityExportUserTypeName)
+	ts.Assert().Contains(yamlContent, "username")
+	ts.Assert().Contains(yamlContent, "email")
+}
+
+// TestUserTypeExportWithWildcard verifies the wildcard form enumerates user types.
+func (ts *ExportEntityResourcesTestSuite) TestUserTypeExportWithWildcard() {
+	yamlContent, err := ts.exportResourcesYAML(ExportRequest{UserTypes: []string{"*"}})
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(yamlContent)
+
+	ts.Assert().Contains(yamlContent, "resource_type: user_type")
+	ts.Assert().Contains(yamlContent, "name: "+entityExportUserTypeName)
+}
+
+// TestAgentTypeExportWithWildcard verifies agent types export under their own resource type. The two
+// entity-type exporters share one implementation split only by category, so the agent-type bundle
+// must not be labelled user_type.
+func (ts *ExportEntityResourcesTestSuite) TestAgentTypeExportWithWildcard() {
+	yamlContent, err := ts.exportResourcesYAML(ExportRequest{AgentTypes: []string{"*"}})
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(yamlContent)
+
+	ts.Assert().Contains(yamlContent, "resource_type: agent_type")
+	ts.Assert().Contains(yamlContent, "name: "+entityExportAgentTypeName)
+	ts.Assert().NotContains(yamlContent, "resource_type: user_type",
+		"an agent type export must not emit user_type documents")
+}
+
+// ---------------------------------------------------------------------------
+// Translations
+// ---------------------------------------------------------------------------
+
+// TestTranslationExportByLanguage verifies translations export per language, keyed by namespace.
+func (ts *ExportEntityResourcesTestSuite) TestTranslationExportByLanguage() {
+	yamlContent, err := ts.exportResourcesYAML(
+		ExportRequest{Translations: []string{entityExportLanguage}})
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(yamlContent)
+
+	ts.Assert().Contains(yamlContent, "resource_type: translation")
+	ts.Assert().Contains(yamlContent, "language: "+entityExportLanguage)
+	ts.Assert().Contains(yamlContent, entityExportNamespace)
+	ts.Assert().Contains(yamlContent, entityExportKey+": "+entityExportValue)
+}
+
+// TestTranslationExportWithWildcard verifies the wildcard form enumerates every language holding
+// overrides, which is what GetAllResourceIDs resolves from the store.
+func (ts *ExportEntityResourcesTestSuite) TestTranslationExportWithWildcard() {
+	yamlContent, err := ts.exportResourcesYAML(ExportRequest{Translations: []string{"*"}})
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(yamlContent)
+
+	ts.Assert().Contains(yamlContent, "resource_type: translation")
+	ts.Assert().Contains(yamlContent, "language: "+entityExportLanguage)
+}
+
+// TestExportWithUnknownTranslationLanguage verifies a language with no overrides is not exportable,
+// rather than producing an empty translation document that would clear overrides on re-import.
+func (ts *ExportEntityResourcesTestSuite) TestExportWithUnknownTranslationLanguage() {
+	_, err := ts.exportResourcesYAML(ExportRequest{Translations: []string{"zz-ZZ"}})
+	ts.Require().Error(err)
+}
+
+// ---------------------------------------------------------------------------
+// Mixed bundle
+// ---------------------------------------------------------------------------
+
+// TestEntityResourcesExportedTogether verifies one request spanning several of these types emits a
+// document per type, since the pipeline iterates the resource map rather than short-circuiting on
+// the first type it finds.
+func (ts *ExportEntityResourcesTestSuite) TestEntityResourcesExportedTogether() {
+	yamlContent, err := ts.exportResourcesYAML(ExportRequest{
+		Users:        []string{ts.userID},
+		UserTypes:    []string{ts.userTypeID},
+		Translations: []string{entityExportLanguage},
+	})
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(yamlContent)
+
+	ts.Assert().Contains(yamlContent, "resource_type: user")
+	ts.Assert().Contains(yamlContent, "resource_type: user_type")
+	ts.Assert().Contains(yamlContent, "resource_type: translation")
+}
+
+// exportResourcesYAML posts an export request and returns the emitted resource bundle.
+func (ts *ExportEntityResourcesTestSuite) exportResourcesYAML(
+	exportRequest ExportRequest,
+) (string, error) {
+	reqJSON, err := json.Marshal(exportRequest)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal export request: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, testServerURL+"/export", bytes.NewReader(reqJSON))
+	if err != nil {
+		return "", fmt.Errorf("failed to create export request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send export request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read export response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("expected status 200, got %d. Response: %s", resp.StatusCode, body)
+	}
+
+	var jsonResponse JSONExportResponse
+	if err := json.Unmarshal(body, &jsonResponse); err != nil {
+		return "", fmt.Errorf("failed to parse JSON export response: %w", err)
+	}
+	return jsonResponse.Resources, nil
+}

--- a/tests/integration/export/model.go
+++ b/tests/integration/export/model.go
@@ -9,6 +9,10 @@ type ExportRequest struct {
 	Connections              []string `json:"connections,omitempty"`
 	CredentialConfigurations []string `json:"credentialConfigurations,omitempty"`
 	PresentationDefinitions  []string `json:"presentationDefinitions,omitempty"`
+	Users                    []string `json:"users,omitempty"`
+	UserTypes                []string `json:"userTypes,omitempty"`
+	AgentTypes               []string `json:"agentTypes,omitempty"`
+	Translations             []string `json:"translations,omitempty"`
 }
 
 // ExportResponse represents the response structure for exporting resources.

--- a/tests/integration/flow/authentication/consent_permissions_test.go
+++ b/tests/integration/flow/authentication/consent_permissions_test.go
@@ -170,11 +170,14 @@ func buildConsentFlowWithoutAuthz() testutils.Flow {
 // publishes under the consentPrompt key of the flow response additional data.
 type consentPromptElement struct {
 	Name string `json:"name"`
+	// Parent is the element a nested permission rolls up to, absent for a top-level one.
+	Parent string `json:"parent,omitempty"`
 }
 
 // consentPromptPurpose mirrors one purpose of the consent prompt payload.
 type consentPromptPurpose struct {
 	PurposeName string                 `json:"purposeName"`
+	PurposeID   string                 `json:"purposeId"`
 	Type        string                 `json:"type"`
 	Essential   []consentPromptElement `json:"essential"`
 	Optional    []consentPromptElement `json:"optional"`
@@ -193,6 +196,7 @@ type consentPurposeDecision struct {
 
 type consentDecisions struct {
 	Approved bool                     `json:"approved"`
+	Reason   string                   `json:"reason,omitempty"`
 	Purposes []consentPurposeDecision `json:"purposes"`
 }
 

--- a/tests/integration/flow/authentication/consent_test.go
+++ b/tests/integration/flow/authentication/consent_test.go
@@ -1,0 +1,539 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authentication
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	consentInputIdentifier = "consent_decisions"
+	consentPromptDataKey   = "consentPrompt"
+	consentApproveAction   = "consent_action_allow"
+
+	// The consent node of consentTimeoutTestFlow carries this timeout, in seconds. It is the
+	// shortest wait that still crosses the expiry boundary once the test sleeps past it.
+	consentTimeoutSeconds = 1
+)
+
+// The consent prompt and decision payload types this suite uses are declared once for the package
+// in consent_permissions_test.go.
+
+var (
+	consentTestOU = testutils.OrganizationUnit{
+		Handle:      "consent-flow-test-ou",
+		Name:        "Consent Flow Test Organization Unit",
+		Description: "Organization unit for consent flow testing",
+		Parent:      nil,
+	}
+
+	consentTestUserType = testutils.UserType{
+		Name: "consent-test-person",
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type": "string",
+			},
+			"password": map[string]interface{}{
+				"type":       "string",
+				"credential": true,
+			},
+			"email": map[string]interface{}{
+				"type": "string",
+			},
+			"given_name": map[string]interface{}{
+				"type": "string",
+			},
+		},
+	}
+
+	// consentTestUser has both attributes the application requests, so neither is dropped by the
+	// profile-presence filter and both are prompted.
+	consentTestUser = testutils.User{
+		Type: "consent-test-person",
+		Attributes: json.RawMessage(`{
+			"username": "consent_user",
+			"password": "SecurePass123!",
+			"email": "consent.user@test.com",
+			"given_name": "Consent"
+		}`),
+	}
+
+	// A second user keeps the decision-handling tests off the consent record written by the
+	// approve-then-skip test, which would otherwise suppress the prompt they depend on.
+	consentDecisionUser = testutils.User{
+		Type: "consent-test-person",
+		Attributes: json.RawMessage(`{
+			"username": "consent_decision_user",
+			"password": "SecurePass123!",
+			"email": "consent.decision@test.com",
+			"given_name": "Decision"
+		}`),
+	}
+
+	consentTimeoutUser = testutils.User{
+		Type: "consent-test-person",
+		Attributes: json.RawMessage(`{
+			"username": "consent_timeout_user",
+			"password": "SecurePass123!",
+			"email": "consent.timeout@test.com",
+			"given_name": "Timeout"
+		}`),
+	}
+
+	// A user of its own for the re-consent test, whose consent record is written denied first and
+	// updated to approved afterwards. Sharing a user with the tests above would make the order of
+	// their recorded decisions matter.
+	consentUpdateUser = testutils.User{
+		Type: "consent-test-person",
+		Attributes: json.RawMessage(`{
+			"username": "consent_update_user",
+			"password": "SecurePass123!",
+			"email": "consent.update@test.com",
+			"given_name": "Update"
+		}`),
+	}
+)
+
+// consentFlowNodes builds an authentication flow that authenticates with credentials and then runs
+// the consent executor, looping back into it from the consent prompt. nodeProperties is applied to
+// the consent node, which is how the timeout variant differs from the default one.
+func consentFlowNodes(nodeProperties map[string]interface{}) []map[string]interface{} {
+	consentNode := map[string]interface{}{
+		"id":   "consent_check",
+		"type": "TASK_EXECUTION",
+		"executor": map[string]interface{}{
+			"name": "ConsentExecutor",
+		},
+		"onSuccess":    "auth_assert",
+		"onIncomplete": "prompt_consent",
+	}
+	if len(nodeProperties) > 0 {
+		consentNode["properties"] = nodeProperties
+	}
+
+	return []map[string]interface{}{
+		{
+			"id":        "start",
+			"type":      "START",
+			"onSuccess": "prompt_credentials",
+		},
+		{
+			"id":   "prompt_credentials",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_001",
+							"identifier": "username",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_002",
+							"identifier": "password",
+							"type":       "PASSWORD_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_001",
+						"nextNode": "credentials_auth",
+					},
+				},
+			},
+		},
+		{
+			"id":   "credentials_auth",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "CredentialsAuthExecutor",
+			},
+			"onSuccess":    "consent_check",
+			"onIncomplete": "prompt_credentials",
+		},
+		consentNode,
+		{
+			"id":   "prompt_consent",
+			"type": "PROMPT",
+			"meta": map[string]interface{}{
+				"components": []map[string]interface{}{
+					{
+						"type": "BLOCK",
+						"id":   "consent_block",
+						"components": []map[string]interface{}{
+							{
+								"id":       "consent_input",
+								"ref":      consentInputIdentifier,
+								"type":     "CONSENT_INPUT",
+								"required": true,
+							},
+							{
+								"type":      "ACTION",
+								"id":        consentApproveAction,
+								"label":     "Approve",
+								"eventType": "SUBMIT",
+							},
+						},
+					},
+				},
+			},
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "consent_input",
+							"identifier": consentInputIdentifier,
+							"type":       "CONSENT_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      consentApproveAction,
+						"nextNode": "consent_check",
+					},
+				},
+			},
+		},
+		{
+			"id":   "auth_assert",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "AuthAssertExecutor",
+			},
+			"onSuccess": "end",
+		},
+		{
+			"id":   "end",
+			"type": "END",
+		},
+	}
+}
+
+type ConsentFlowTestSuite struct {
+	suite.Suite
+	config *common.TestSuiteConfig
+
+	ouID           string
+	userTypeID     string
+	appID          string
+	timeoutAppID   string
+	consentUserID  string
+	decisionUserID string
+	timeoutUserID  string
+	updateUserID   string
+}
+
+func TestConsentFlowTestSuite(t *testing.T) {
+	suite.Run(t, new(ConsentFlowTestSuite))
+}
+
+func (ts *ConsentFlowTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	ouID, err := testutils.CreateOrganizationUnit(consentTestOU)
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
+
+	userType := consentTestUserType
+	userType.OUID = ouID
+	ts.userTypeID, err = testutils.CreateUserType(userType)
+	ts.Require().NoError(err, "Failed to create test user type")
+
+	// The requested user attributes are what the attribute consent purpose is derived from, so the
+	// application's assertion config is what makes consent applicable at all.
+	assertionConfig := map[string]interface{}{
+		"userAttributes": []string{"email", "given_name"},
+	}
+
+	flowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     "Consent Test Auth Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_consent_test",
+		Nodes:    consentFlowNodes(nil),
+	})
+	ts.Require().NoError(err, "Failed to create consent test flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
+
+	ts.appID, err = testutils.CreateApplication(testutils.Application{
+		Name:             "Consent Flow Test Application",
+		Description:      "Application for testing consent collection in flows",
+		ClientID:         "consent_flow_test_client",
+		ClientSecret:     "consent_flow_test_secret",
+		RedirectURIs:     []string{"http://localhost:3000/callback"},
+		OUID:             ouID,
+		AllowedUserTypes: []string{consentTestUserType.Name},
+		AuthFlowID:       flowID,
+		AssertionConfig:  assertionConfig,
+	})
+	ts.Require().NoError(err, "Failed to create test application")
+
+	timeoutFlowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     "Consent Timeout Test Auth Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_consent_timeout_test",
+		Nodes: consentFlowNodes(map[string]interface{}{
+			"timeout": "1",
+		}),
+	})
+	ts.Require().NoError(err, "Failed to create consent timeout test flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, timeoutFlowID)
+
+	ts.timeoutAppID, err = testutils.CreateApplication(testutils.Application{
+		Name:             "Consent Timeout Flow Test Application",
+		Description:      "Application for testing consent prompt expiry in flows",
+		ClientID:         "consent_timeout_flow_test_client",
+		ClientSecret:     "consent_timeout_flow_test_secret",
+		RedirectURIs:     []string{"http://localhost:3000/callback"},
+		OUID:             ouID,
+		AllowedUserTypes: []string{consentTestUserType.Name},
+		AuthFlowID:       timeoutFlowID,
+		AssertionConfig:  assertionConfig,
+	})
+	ts.Require().NoError(err, "Failed to create timeout test application")
+
+	ts.consentUserID = ts.createUser(consentTestUser)
+	ts.decisionUserID = ts.createUser(consentDecisionUser)
+	ts.timeoutUserID = ts.createUser(consentTimeoutUser)
+	ts.updateUserID = ts.createUser(consentUpdateUser)
+}
+
+func (ts *ConsentFlowTestSuite) createUser(user testutils.User) string {
+	ts.T().Helper()
+
+	toCreate := user
+	toCreate.OUID = ts.ouID
+	userID, err := testutils.CreateUser(toCreate)
+	ts.Require().NoError(err, "Failed to create test user")
+	ts.config.CreatedUserIDs = append(ts.config.CreatedUserIDs, userID)
+	return userID
+}
+
+func (ts *ConsentFlowTestSuite) TearDownSuite() {
+	for _, appID := range []string{ts.appID, ts.timeoutAppID} {
+		if appID == "" {
+			continue
+		}
+		if err := testutils.DeleteApplication(appID); err != nil {
+			ts.T().Logf("Failed to delete test application during teardown: %v", err)
+		}
+	}
+	for _, userID := range ts.config.CreatedUserIDs {
+		if err := testutils.DeleteUser(userID); err != nil {
+			ts.T().Logf("Failed to delete test user during teardown: %v", err)
+		}
+	}
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete test flow during teardown: %v", err)
+		}
+	}
+	if ts.userTypeID != "" {
+		if err := testutils.DeleteUserType(ts.userTypeID); err != nil {
+			ts.T().Logf("Failed to delete test user type during teardown: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// authenticateToConsentPrompt drives the flow through credentials authentication and returns the
+// step the consent executor paused on.
+func (ts *ConsentFlowTestSuite) authenticateToConsentPrompt(appID, username string) *common.FlowStep {
+	ts.T().Helper()
+
+	step, err := common.InitiateAuthenticationFlow(appID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "Flow should pause at the credentials prompt")
+
+	step, err = common.CompleteFlow(step.ExecutionID, map[string]string{
+		"username": username,
+		"password": "SecurePass123!",
+	}, "action_001", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit credentials")
+	return step
+}
+
+// requireConsentPrompt asserts the step is a consent prompt and returns the prompted purposes.
+func (ts *ConsentFlowTestSuite) requireConsentPrompt(step *common.FlowStep) []consentPromptPurpose {
+	ts.T().Helper()
+
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "Consent should pause the flow for input")
+	ts.Require().True(common.HasInput(step.Data.Inputs, consentInputIdentifier),
+		"The consent prompt must request the consent decisions input")
+
+	promptJSON, ok := step.Data.AdditionalData[consentPromptDataKey]
+	ts.Require().True(ok, "The consent prompt must carry the purposes to render")
+
+	var purposes []consentPromptPurpose
+	ts.Require().NoError(json.Unmarshal([]byte(promptJSON), &purposes),
+		"Consent prompt data should be a purposes array")
+	ts.Require().NotEmpty(purposes, "At least one purpose must be prompted")
+	return purposes
+}
+
+// decisionsFor builds a decisions payload answering every prompted element with approved.
+func decisionsFor(purposes []consentPromptPurpose, approved bool, reason string) string {
+	decisions := consentDecisions{Approved: approved, Reason: reason}
+	for _, purpose := range purposes {
+		decision := consentPurposeDecision{PurposeName: purpose.PurposeName, Approved: approved}
+		for _, element := range purpose.Essential {
+			decision.Elements = append(decision.Elements,
+				consentElementDecision{Name: element.Name, Approved: approved})
+		}
+		for _, element := range purpose.Optional {
+			decision.Elements = append(decision.Elements,
+				consentElementDecision{Name: element.Name, Approved: approved})
+		}
+		decisions.Purposes = append(decisions.Purposes, decision)
+	}
+
+	payload, err := json.Marshal(decisions)
+	if err != nil {
+		return ""
+	}
+	return string(payload)
+}
+
+// The application requests user attributes the user has, so the first authentication must stop for
+// consent, and approving every prompted element must record consent and complete the flow. A second
+// authentication then finds that consent active and runs the consent node through without a prompt,
+// which is the branch that separates "consent needed" from "already consented".
+func (ts *ConsentFlowTestSuite) TestConsent_PromptedThenSkippedOnceRecorded() {
+	step := ts.authenticateToConsentPrompt(ts.appID, "consent_user")
+	purposes := ts.requireConsentPrompt(step)
+
+	prompted := map[string]bool{}
+	for _, purpose := range purposes {
+		for _, element := range purpose.Optional {
+			prompted[element.Name] = true
+		}
+	}
+	ts.Contains(prompted, "email", "A requested attribute present in the profile must be prompted")
+	ts.Contains(prompted, "given_name", "A requested attribute present in the profile must be prompted")
+
+	completed, err := common.CompleteFlow(step.ExecutionID, map[string]string{
+		consentInputIdentifier: decisionsFor(purposes, true, ""),
+	}, consentApproveAction, step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit consent decisions")
+	ts.Require().Equal("COMPLETE", completed.FlowStatus,
+		"Approving consent should let the flow reach its assertion")
+	ts.NotEmpty(completed.Assertion, "A completed authentication must return an assertion")
+
+	// Consent is now active for both attributes, so the second run has nothing left to prompt.
+	repeat := ts.authenticateToConsentPrompt(ts.appID, "consent_user")
+	ts.Equal("COMPLETE", repeat.FlowStatus,
+		"An active consent record should let the consent node complete without prompting")
+	ts.NotContains(repeat.Data.AdditionalData, consentPromptDataKey,
+		"No consent prompt data should be forwarded when consent is already active")
+}
+
+// Denying every prompted element still records the decision and completes, because none of the
+// requested attributes are essential. Nothing is consented, which downstream executors read from
+// the empty consented-attributes runtime value.
+func (ts *ConsentFlowTestSuite) TestConsent_DeniedOptionalElementsCompletesFlow() {
+	step := ts.authenticateToConsentPrompt(ts.appID, "consent_decision_user")
+	purposes := ts.requireConsentPrompt(step)
+
+	completed, err := common.CompleteFlow(step.ExecutionID, map[string]string{
+		consentInputIdentifier: decisionsFor(purposes, false, "user_denied"),
+	}, consentApproveAction, step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit consent denial")
+	ts.Equal("COMPLETE", completed.FlowStatus,
+		"Denying only optional attributes should not fail the flow")
+}
+
+// A decisions payload that is not valid JSON is rejected as a client error rather than crashing the
+// node, since the value arrives as an opaque string from the client.
+func (ts *ConsentFlowTestSuite) TestConsent_MalformedDecisionsRejected() {
+	step := ts.authenticateToConsentPrompt(ts.appID, "consent_decision_user")
+	ts.requireConsentPrompt(step)
+
+	failed, err := common.CompleteFlow(step.ExecutionID, map[string]string{
+		consentInputIdentifier: "not-a-json-payload",
+	}, consentApproveAction, step.ChallengeToken)
+	ts.Require().NoError(err, "A malformed payload should still return a flow step")
+	ts.Equal("ERROR", failed.FlowStatus, "Unparseable consent decisions must fail the step")
+}
+
+// Decisions submitted with the timeout reason are not a user decision: nothing is recorded and the
+// flow proceeds with nothing consented. The expiry check is deliberately skipped for these, so this
+// also pins that a late timeout submission is accepted rather than rejected as expired.
+func (ts *ConsentFlowTestSuite) TestConsent_TimeoutReasonCompletesWithoutRecording() {
+	step := ts.authenticateToConsentPrompt(ts.timeoutAppID, "consent_timeout_user")
+	purposes := ts.requireConsentPrompt(step)
+
+	stepTimeout, ok := step.Data.AdditionalData["stepTimeout"]
+	ts.Require().True(ok, "A consent node with a timeout must publish the step expiry")
+	ts.NotEmpty(stepTimeout, "The published step expiry must carry a timestamp")
+
+	completed, err := common.CompleteFlow(step.ExecutionID, map[string]string{
+		consentInputIdentifier: decisionsFor(purposes, false, "timeout"),
+	}, consentApproveAction, step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit timed out consent decisions")
+	ts.Equal("COMPLETE", completed.FlowStatus,
+		"A timed out consent prompt should complete without recording consent")
+}
+
+// Denying first and approving on the next authentication drives the update side of consent
+// recording: the second decision merges into the record the first one created instead of adding a
+// second record. A denied element carries no active consent, which is what makes the user prompted
+// again, and the third authentication proves the merge stuck by not prompting at all.
+func (ts *ConsentFlowTestSuite) TestConsent_ReconsentUpdatesExistingRecord() {
+	denyStep := ts.authenticateToConsentPrompt(ts.appID, "consent_update_user")
+	deniedPurposes := ts.requireConsentPrompt(denyStep)
+
+	denied, err := common.CompleteFlow(denyStep.ExecutionID, map[string]string{
+		consentInputIdentifier: decisionsFor(deniedPurposes, false, "user_denied"),
+	}, consentApproveAction, denyStep.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit the consent denial")
+	ts.Require().Equal("COMPLETE", denied.FlowStatus,
+		"Denying only optional attributes should not fail the flow")
+
+	// The denial left a consent record without any approved element, so consent is prompted again.
+	approveStep := ts.authenticateToConsentPrompt(ts.appID, "consent_update_user")
+	approvedPurposes := ts.requireConsentPrompt(approveStep)
+	ts.Equal(len(deniedPurposes), len(approvedPurposes),
+		"A denied decision must leave the same purposes to be prompted again")
+
+	approved, err := common.CompleteFlow(approveStep.ExecutionID, map[string]string{
+		consentInputIdentifier: decisionsFor(approvedPurposes, true, ""),
+	}, consentApproveAction, approveStep.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit the consent approval")
+	ts.Require().Equal("COMPLETE", approved.FlowStatus,
+		"Approving consent should let the flow reach its assertion")
+	ts.NotEmpty(approved.Assertion, "A completed authentication must return an assertion")
+
+	// The approval was merged into the existing record, so nothing is left to prompt.
+	repeat := ts.authenticateToConsentPrompt(ts.appID, "consent_update_user")
+	ts.Equal("COMPLETE", repeat.FlowStatus,
+		"The updated consent record should let the consent node complete without prompting")
+	ts.NotContains(repeat.Data.AdditionalData, consentPromptDataKey,
+		"No consent prompt data should be forwarded once the updated record covers every element")
+}
+
+// A decision submitted after the configured consent timeout has passed is refused, so a stale
+// prompt cannot be answered. Unlike the timeout-reason case above, this submission claims to be a
+// real decision, which is what makes the expiry check apply.
+func (ts *ConsentFlowTestSuite) TestConsent_ExpiredPromptRejected() {
+	step := ts.authenticateToConsentPrompt(ts.timeoutAppID, "consent_timeout_user")
+	purposes := ts.requireConsentPrompt(step)
+
+	time.Sleep(consentTimeoutSeconds*time.Second + 2*time.Second)
+
+	failed, err := common.CompleteFlow(step.ExecutionID, map[string]string{
+		consentInputIdentifier: decisionsFor(purposes, true, ""),
+	}, consentApproveAction, step.ChallengeToken)
+	ts.Require().NoError(err, "An expired prompt should still return a flow step")
+	ts.Equal("ERROR", failed.FlowStatus, "A decision submitted after the timeout must be refused")
+}

--- a/tests/integration/flow/authentication/identify_modes_test.go
+++ b/tests/integration/flow/authentication/identify_modes_test.go
@@ -1,0 +1,416 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authentication
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	// errCodeUserNotFound is declared once for the package in user_disambiguation_test.go.
+
+	// The two ambiguous users share this email, so identifying by email alone cannot separate them.
+	sharedIdentifyEmail = "shared@identify.test"
+	uniqueIdentifyEmail = "unique@identify.test"
+	absentIdentifyEmail = "absent@identify.test"
+)
+
+var (
+	identifyTestOU = testutils.OrganizationUnit{
+		Handle:      "identify-modes-test-ou",
+		Name:        "Identify Modes Test Organization Unit",
+		Description: "Organization unit for identifying executor mode testing",
+		Parent:      nil,
+	}
+
+	identifyTestUserType = testutils.UserType{
+		Name: "identify-modes-person",
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type": "string",
+			},
+			"email": map[string]interface{}{
+				"type": "string",
+			},
+			"given_name": map[string]interface{}{
+				"type": "string",
+			},
+		},
+	}
+)
+
+// identifyNode builds the identifying executor node for the given mode, searching on email.
+func identifyNode(mode, onSuccess, onIncomplete string) map[string]interface{} {
+	return map[string]interface{}{
+		"id":   "identify_user",
+		"type": "TASK_EXECUTION",
+		"executor": map[string]interface{}{
+			"name": "IdentifyingExecutor",
+			"mode": mode,
+			"inputs": []map[string]interface{}{
+				{
+					"ref":        "input_email",
+					"identifier": "email",
+					"type":       "TEXT_INPUT",
+					"required":   true,
+				},
+			},
+		},
+		"onSuccess":    onSuccess,
+		"onIncomplete": onIncomplete,
+	}
+}
+
+// markerPrompt builds a prompt whose single input identifies which branch the flow reached, so a
+// test can assert the branch from the response alone.
+func markerPrompt(id, marker, nextNode string, condition map[string]interface{}) map[string]interface{} {
+	node := map[string]interface{}{
+		"id":   id,
+		"type": "PROMPT",
+		"prompts": []map[string]interface{}{
+			{
+				"inputs": []map[string]interface{}{
+					{
+						"ref":        marker,
+						"identifier": marker,
+						"type":       "TEXT_INPUT",
+						"required":   true,
+					},
+				},
+				"action": map[string]interface{}{
+					"ref":      "action_" + marker,
+					"nextNode": nextNode,
+				},
+			},
+		},
+	}
+	if condition != nil {
+		node["condition"] = condition
+	}
+	return node
+}
+
+// identifyResolveFlowNodes builds a flow that resolves a user by email, asking for a distinguishing
+// attribute when more than one user matches.
+func identifyResolveFlowNodes() []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"id":        "start",
+			"type":      "START",
+			"onSuccess": "prompt_email",
+		},
+		{
+			"id":   "prompt_email",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_email",
+							"identifier": "email",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_email",
+						"nextNode": "identify_user",
+					},
+				},
+			},
+		},
+		identifyNode("resolve", "prompt_resolved", "prompt_disambiguate"),
+		// given_name is declared as a select so the distinct candidate values forwarded by the
+		// executor are merged into it as options.
+		{
+			"id":   "prompt_disambiguate",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_given_name",
+							"identifier": "given_name",
+							"type":       "SELECT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_disambiguate",
+						"nextNode": "identify_user",
+					},
+				},
+			},
+		},
+		markerPrompt("prompt_resolved", "resolved_marker", "auth_assert", nil),
+		{
+			"id":   "auth_assert",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "AuthAssertExecutor",
+			},
+			"onSuccess": "end",
+		},
+		{
+			"id":   "end",
+			"type": "END",
+		},
+	}
+}
+
+// identifyCheckStateFlowNodes builds a flow that records how many users match and then branches on
+// that state, so each of the three outcomes lands on its own prompt.
+func identifyCheckStateFlowNodes() []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"id":        "start",
+			"type":      "START",
+			"onSuccess": "prompt_email",
+		},
+		{
+			"id":   "prompt_email",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_email",
+							"identifier": "email",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_email",
+						"nextNode": "identify_user",
+					},
+				},
+			},
+		},
+		identifyNode("check_state", "prompt_exists", "prompt_email"),
+		markerPrompt("prompt_exists", "state_exists", "auth_assert", map[string]interface{}{
+			"key":    "{{ctx(entityState)}}",
+			"value":  "exists",
+			"onSkip": "prompt_ambiguous",
+		}),
+		markerPrompt("prompt_ambiguous", "state_ambiguous", "auth_assert", map[string]interface{}{
+			"key":    "{{ctx(entityState)}}",
+			"value":  "ambiguous",
+			"onSkip": "prompt_not_exists",
+		}),
+		markerPrompt("prompt_not_exists", "state_not_exists", "auth_assert", nil),
+		{
+			"id":   "auth_assert",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "AuthAssertExecutor",
+			},
+			"onSuccess": "end",
+		},
+		{
+			"id":   "end",
+			"type": "END",
+		},
+	}
+}
+
+type IdentifyModesTestSuite struct {
+	suite.Suite
+	config *common.TestSuiteConfig
+
+	ouID            string
+	userTypeID      string
+	resolveAppID    string
+	checkStateAppID string
+}
+
+func TestIdentifyModesTestSuite(t *testing.T) {
+	suite.Run(t, new(IdentifyModesTestSuite))
+}
+
+func (ts *IdentifyModesTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	ouID, err := testutils.CreateOrganizationUnit(identifyTestOU)
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
+
+	userType := identifyTestUserType
+	userType.OUID = ouID
+	ts.userTypeID, err = testutils.CreateUserType(userType)
+	ts.Require().NoError(err, "Failed to create test user type")
+
+	// Two users share an email and differ only in given_name, which is what makes the email
+	// ambiguous and given_name the attribute that can separate them.
+	for _, attrs := range []string{
+		`{"username":"identify_ada","email":"` + sharedIdentifyEmail + `","given_name":"Ada"}`,
+		`{"username":"identify_bob","email":"` + sharedIdentifyEmail + `","given_name":"Bob"}`,
+		`{"username":"identify_cleo","email":"` + uniqueIdentifyEmail + `","given_name":"Cleo"}`,
+	} {
+		userID, err := testutils.CreateUser(testutils.User{
+			Type:       identifyTestUserType.Name,
+			OUID:       ouID,
+			Attributes: json.RawMessage(attrs),
+		})
+		ts.Require().NoError(err, "Failed to create test user")
+		ts.config.CreatedUserIDs = append(ts.config.CreatedUserIDs, userID)
+	}
+
+	resolveFlowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     "Identify Resolve Test Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_identify_resolve_test",
+		Nodes:    identifyResolveFlowNodes(),
+	})
+	ts.Require().NoError(err, "Failed to create resolve mode flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, resolveFlowID)
+
+	checkStateFlowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     "Identify Check State Test Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_identify_check_state_test",
+		Nodes:    identifyCheckStateFlowNodes(),
+	})
+	ts.Require().NoError(err, "Failed to create check state mode flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, checkStateFlowID)
+
+	ts.resolveAppID, err = testutils.CreateApplication(testutils.Application{
+		Name:             "Identify Resolve Test Application",
+		Description:      "Application for testing identifying executor resolve mode",
+		ClientID:         "identify_resolve_test_client",
+		ClientSecret:     "identify_resolve_test_secret",
+		RedirectURIs:     []string{"http://localhost:3000/callback"},
+		OUID:             ouID,
+		AllowedUserTypes: []string{identifyTestUserType.Name},
+		AuthFlowID:       resolveFlowID,
+	})
+	ts.Require().NoError(err, "Failed to create resolve mode application")
+
+	ts.checkStateAppID, err = testutils.CreateApplication(testutils.Application{
+		Name:             "Identify Check State Test Application",
+		Description:      "Application for testing identifying executor check state mode",
+		ClientID:         "identify_check_state_test_client",
+		ClientSecret:     "identify_check_state_test_secret",
+		RedirectURIs:     []string{"http://localhost:3000/callback"},
+		OUID:             ouID,
+		AllowedUserTypes: []string{identifyTestUserType.Name},
+		AuthFlowID:       checkStateFlowID,
+	})
+	ts.Require().NoError(err, "Failed to create check state mode application")
+}
+
+func (ts *IdentifyModesTestSuite) TearDownSuite() {
+	for _, appID := range []string{ts.resolveAppID, ts.checkStateAppID} {
+		if appID == "" {
+			continue
+		}
+		if err := testutils.DeleteApplication(appID); err != nil {
+			ts.T().Logf("Failed to delete test application during teardown: %v", err)
+		}
+	}
+	for _, userID := range ts.config.CreatedUserIDs {
+		if err := testutils.DeleteUser(userID); err != nil {
+			ts.T().Logf("Failed to delete test user during teardown: %v", err)
+		}
+	}
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete test flow during teardown: %v", err)
+		}
+	}
+	if ts.userTypeID != "" {
+		if err := testutils.DeleteUserType(ts.userTypeID); err != nil {
+			ts.T().Logf("Failed to delete test user type during teardown: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// submitEmail drives a flow to its first prompt and answers it with the given email.
+func (ts *IdentifyModesTestSuite) submitEmail(appID, email string) *common.FlowStep {
+	ts.T().Helper()
+
+	step, err := common.InitiateAuthenticationFlow(appID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate flow")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "Flow should pause for the email")
+
+	step, err = common.CompleteFlow(step.ExecutionID,
+		map[string]string{"email": email}, "action_email", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit the email")
+	return step
+}
+
+// Resolve mode narrows a set of candidates instead of failing on ambiguity: an email matching two
+// users returns the attribute that distinguishes them, with the candidate values as options, and
+// answering it resolves the user. The candidates are carried in the execution, so the second pass
+// filters the stored set rather than searching again.
+func (ts *IdentifyModesTestSuite) TestResolve_AmbiguousCandidatesDisambiguated() {
+	step := ts.submitEmail(ts.resolveAppID, sharedIdentifyEmail)
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus,
+		"Two matching users should pause the flow for disambiguation")
+
+	givenName := findInput(step.Data.Inputs, "given_name")
+	ts.Require().NotNil(givenName, "The distinguishing attribute must be requested")
+	ts.ElementsMatch([]string{"Ada", "Bob"}, givenName.Options,
+		"The options must be the distinct values across the candidates")
+
+	resolved, err := common.CompleteFlow(step.ExecutionID,
+		map[string]string{"given_name": "Ada"}, "action_disambiguate", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit the distinguishing attribute")
+	ts.Equal("INCOMPLETE", resolved.FlowStatus, "The flow should continue once one user matches")
+	ts.NotNil(findInput(resolved.Data.Inputs, "resolved_marker"),
+		"Resolving a single user should carry the flow past the identifying node")
+}
+
+// An email matching exactly one user resolves without any disambiguation step.
+func (ts *IdentifyModesTestSuite) TestResolve_SingleCandidateResolvesImmediately() {
+	step := ts.submitEmail(ts.resolveAppID, uniqueIdentifyEmail)
+	ts.Equal("INCOMPLETE", step.FlowStatus, "The flow should continue past the identifying node")
+	ts.NotNil(findInput(step.Data.Inputs, "resolved_marker"),
+		"A single match should resolve without a disambiguation prompt")
+}
+
+// An email matching no user pauses for more input rather than failing the flow, since the value is
+// user supplied and correctable. The step is routed to the node's onIncomplete prompt, so what marks
+// the outcome is the reported error together with the flow not advancing past identification.
+func (ts *IdentifyModesTestSuite) TestResolve_NoCandidatesPausesWithUserNotFound() {
+	step := ts.submitEmail(ts.resolveAppID, absentIdentifyEmail)
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "No match should pause rather than fail the flow")
+	ts.Require().NotNil(step.Error, "A non-matching email must be reported")
+	ts.Equal(errCodeUserNotFound, step.Error.Code, "No match must be reported as user not found")
+	ts.Nil(findInput(step.Data.Inputs, "resolved_marker"),
+		"An unresolved user must not carry the flow past the identifying node")
+}
+
+// Check state mode never fails on the match count: it records whether zero, one, or several users
+// match and lets the flow branch on it. Each of the three states is asserted from the prompt the
+// flow lands on.
+func (ts *IdentifyModesTestSuite) TestCheckState_ReportsEachMatchState() {
+	for _, tc := range []struct {
+		name   string
+		email  string
+		marker string
+	}{
+		{name: "single match", email: uniqueIdentifyEmail, marker: "state_exists"},
+		{name: "multiple matches", email: sharedIdentifyEmail, marker: "state_ambiguous"},
+		{name: "no match", email: absentIdentifyEmail, marker: "state_not_exists"},
+	} {
+		ts.Run(tc.name, func() {
+			step := ts.submitEmail(ts.checkStateAppID, tc.email)
+			ts.Require().Equal("INCOMPLETE", step.FlowStatus,
+				"Check state mode should always carry the flow forward")
+			ts.NotNil(findInput(step.Data.Inputs, tc.marker),
+				"The flow should branch to the prompt for the %s state", tc.name)
+		})
+	}
+}

--- a/tests/integration/flow/authentication/permission_consent_test.go
+++ b/tests/integration/flow/authentication/permission_consent_test.go
@@ -1,0 +1,446 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authentication
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// PermissionConsentFlowTestSuite covers consent over resource-server permissions, as opposed to the
+// user-attribute consent ConsentFlowTestSuite covers.
+//
+// The permission purpose is not stored: it is built at prompt time from the permissions the
+// authorization executor actually authorized, so it can only be reached by running an
+// AuthorizationExecutor node ahead of the consent node and asking for permission scopes bound to a
+// resource server. Everything the suite asserts follows from that:
+//
+//   - only authorized permissions are prompted, never everything requested;
+//   - the purpose is typed as permissions, so the Console renders it in its own section;
+//   - each element carries the rollup parent the server computes, which is what lets the Console
+//     group a permission under the broader one that implies it.
+//
+// The rollup parent is the part with real logic: a permission's parent is the longest other prompted
+// permission it extends across a delimiter. The fixture therefore declares a nested resource, whose
+// permission has a parent, alongside a sibling whose handle merely starts with the same letters,
+// whose permission must not.
+type PermissionConsentFlowTestSuite struct {
+	suite.Suite
+	config *common.TestSuiteConfig
+
+	ouID       string
+	userTypeID string
+	appID      string
+	rsID       string
+	roleID     string
+
+	// Resource IDs in creation order; teardown removes them leaf first so the resource server can
+	// then be deleted.
+	resourceIDs []string
+
+	// A user per behaviour. The tests that only read the prompt share one, but the tests that
+	// record a decision each need their own: a recorded consent suppresses the prompt every later
+	// authentication of that user depends on.
+	promptUserID  string
+	approveUserID string
+	denyUserID    string
+}
+
+const (
+	permConsentOUHandle     = "permission-consent-ou"
+	permConsentUserTypeName = "permission-consent-person"
+
+	permConsentPromptUsername  = "permission_consent_prompt_user"
+	permConsentApproveUsername = "permission_consent_approve_user"
+	permConsentDenyUsername    = "permission_consent_deny_user"
+	permConsentPassword        = "SecurePass123!"
+
+	permConsentRSIdentifier = "permission-consent-docs"
+
+	// The permission a top-level resource contributes. It is the rollup parent of the nested one.
+	permConsentParentPermission = "docs"
+
+	// The permission a resource nested under "docs" contributes. Its parent must resolve to "docs".
+	permConsentChildPermission = "docs:reports"
+
+	// A sibling top-level permission that starts with "docs" but does not extend it across a
+	// delimiter, so it must have no parent. Without it a prefix check that ignored the delimiter
+	// would pass.
+	permConsentDecoyPermission = "docsx"
+
+	// A permission the user is never granted. It is requested anyway, so the prompt is shown to
+	// carry only what was authorized.
+	permConsentUnheldPermission = "docs:payroll"
+
+	permConsentPurposeType = "permissions"
+)
+
+func TestPermissionConsentFlowTestSuite(t *testing.T) {
+	suite.Run(t, new(PermissionConsentFlowTestSuite))
+}
+
+func (ts *PermissionConsentFlowTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      permConsentOUHandle,
+		Name:        "Permission Consent Test Organization Unit",
+		Description: "Organization unit for permission consent flow testing",
+	})
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
+
+	ts.userTypeID, err = testutils.CreateUserType(testutils.UserType{
+		Name: permConsentUserTypeName,
+		OUID: ouID,
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{"type": "string"},
+			"password": map[string]interface{}{"type": "string", "credential": true},
+			"email":    map[string]interface{}{"type": "string"},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create test user type")
+
+	// The resource tree is what the permission strings are derived from: a resource's permission is
+	// its handle path, so nesting "reports" under "docs" produces "docs:reports".
+	ts.rsID, err = testutils.CreateResourceServerWithActions(testutils.ResourceServer{
+		Name:        "Permission Consent Document Store",
+		Description: "Resource server for permission consent flow testing",
+		Identifier:  permConsentRSIdentifier,
+		OUID:        ouID,
+	}, nil)
+	ts.Require().NoError(err, "Failed to create test resource server")
+
+	docsID := ts.createResource("Documents", permConsentParentPermission, "")
+	ts.createResource("Reports", "reports", docsID)
+	ts.createResource("Payroll", "payroll", docsID)
+	ts.createResource("Docs Extended", permConsentDecoyPermission, "")
+
+	flowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     "Permission Consent Test Auth Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_permission_consent_test",
+		Nodes:    permissionConsentFlowNodes(),
+	})
+	ts.Require().NoError(err, "Failed to create permission consent test flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
+
+	// No assertion config, so no attribute purpose applies and the permission purpose is the only
+	// one prompted.
+	ts.appID, err = testutils.CreateApplication(testutils.Application{
+		Name:             "Permission Consent Flow Test Application",
+		Description:      "Application for testing permission consent collection in flows",
+		ClientID:         "permission_consent_flow_test_client",
+		ClientSecret:     "permission_consent_flow_test_secret",
+		RedirectURIs:     []string{"http://localhost:3000/callback"},
+		OUID:             ouID,
+		AllowedUserTypes: []string{permConsentUserTypeName},
+		AuthFlowID:       flowID,
+	})
+	ts.Require().NoError(err, "Failed to create test application")
+
+	ts.promptUserID = ts.createPermConsentUser(permConsentPromptUsername, "permission.prompt@test.com")
+	ts.approveUserID = ts.createPermConsentUser(permConsentApproveUsername, "permission.approve@test.com")
+	ts.denyUserID = ts.createPermConsentUser(permConsentDenyUsername, "permission.deny@test.com")
+
+	// Granted to every user, and deliberately excluding docs:payroll.
+	ts.roleID, err = testutils.CreateRole(testutils.Role{
+		Name:        "permission-consent-reader",
+		Description: "Role granting the permissions the consent prompt is expected to carry",
+		OUID:        ouID,
+		Permissions: []testutils.ResourcePermissions{
+			{
+				ResourceServerID: ts.rsID,
+				Permissions: []string{
+					permConsentParentPermission,
+					permConsentChildPermission,
+					permConsentDecoyPermission,
+				},
+			},
+		},
+		Assignments: []testutils.Assignment{
+			{ID: ts.promptUserID, Type: "user"},
+			{ID: ts.approveUserID, Type: "user"},
+			{ID: ts.denyUserID, Type: "user"},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create test role")
+}
+
+// createResource creates a resource under the suite's resource server, recording it for teardown.
+func (ts *PermissionConsentFlowTestSuite) createResource(name, handle, parentID string) string {
+	ts.T().Helper()
+
+	resourceID, err := testutils.CreateResource(ts.rsID, name, handle, parentID)
+	ts.Require().NoError(err, "Failed to create the %s resource", handle)
+	ts.resourceIDs = append(ts.resourceIDs, resourceID)
+	return resourceID
+}
+
+// createPermConsentUser creates a user of the suite's type and returns its ID.
+func (ts *PermissionConsentFlowTestSuite) createPermConsentUser(username, email string) string {
+	ts.T().Helper()
+
+	attributes, err := json.Marshal(map[string]string{
+		"username": username,
+		"password": permConsentPassword,
+		"email":    email,
+	})
+	ts.Require().NoError(err)
+
+	userID, err := testutils.CreateUser(testutils.User{
+		Type:       permConsentUserTypeName,
+		OUID:       ts.ouID,
+		Attributes: attributes,
+	})
+	ts.Require().NoError(err, "Failed to create user %s", username)
+	return userID
+}
+
+func (ts *PermissionConsentFlowTestSuite) TearDownSuite() {
+	if ts.roleID != "" {
+		if err := testutils.DeleteRole(ts.roleID); err != nil {
+			ts.T().Logf("Failed to delete test role: %v", err)
+		}
+	}
+	for _, id := range []string{ts.promptUserID, ts.approveUserID, ts.denyUserID} {
+		if id != "" {
+			if err := testutils.DeleteUser(id); err != nil {
+				ts.T().Logf("Failed to delete test user %s: %v", id, err)
+			}
+		}
+	}
+	if ts.appID != "" {
+		if err := testutils.DeleteApplication(ts.appID); err != nil {
+			ts.T().Logf("Failed to delete test application: %v", err)
+		}
+	}
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete created flow %s: %v", flowID, err)
+		}
+	}
+	// Leaf first: a resource server with resources still attached refuses deletion, and a parent
+	// resource refuses it while it still has children.
+	for i := len(ts.resourceIDs) - 1; i >= 0; i-- {
+		if err := testutils.DeleteResource(ts.rsID, ts.resourceIDs[i]); err != nil {
+			ts.T().Logf("Failed to delete test resource %s: %v", ts.resourceIDs[i], err)
+		}
+	}
+	if ts.rsID != "" {
+		if err := testutils.DeleteResourceServer(ts.rsID); err != nil {
+			ts.T().Logf("Failed to delete test resource server: %v", err)
+		}
+	}
+	if ts.userTypeID != "" {
+		if err := testutils.DeleteUserType(ts.userTypeID); err != nil {
+			ts.T().Logf("Failed to delete test user type: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit: %v", err)
+		}
+	}
+}
+
+// permissionConsentFlowNodes builds credentials, then authorization, then consent. The
+// authorization node is what puts authorized permissions into runtime data, which is the only
+// source the permission purpose is built from.
+func permissionConsentFlowNodes() []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"id":        "start",
+			"type":      "START",
+			"onSuccess": "prompt_credentials",
+		},
+		{
+			"id":   "prompt_credentials",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_001",
+							"identifier": "username",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_002",
+							"identifier": "password",
+							"type":       "PASSWORD_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_001",
+						"nextNode": "credentials_auth",
+					},
+				},
+			},
+		},
+		{
+			"id":   "credentials_auth",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "CredentialsAuthExecutor",
+			},
+			"onSuccess":    "authorization_check",
+			"onIncomplete": "prompt_credentials",
+		},
+		{
+			"id":   "authorization_check",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "AuthorizationExecutor",
+			},
+			"onSuccess": "consent_check",
+		},
+		{
+			"id":   "consent_check",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "ConsentExecutor",
+			},
+			"onSuccess":    "auth_assert",
+			"onIncomplete": "prompt_consent",
+		},
+		{
+			"id":   "prompt_consent",
+			"type": "PROMPT",
+			"meta": map[string]interface{}{
+				"components": []map[string]interface{}{
+					{
+						"type": "BLOCK",
+						"id":   "consent_block",
+						"components": []map[string]interface{}{
+							{
+								"id":       "consent_input",
+								"ref":      consentInputIdentifier,
+								"type":     "CONSENT_INPUT",
+								"required": true,
+							},
+							{
+								"type":      "ACTION",
+								"id":        consentApproveAction,
+								"label":     "Approve",
+								"eventType": "SUBMIT",
+							},
+						},
+					},
+				},
+			},
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "consent_input",
+							"identifier": consentInputIdentifier,
+							"type":       "CONSENT_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      consentApproveAction,
+						"nextNode": "consent_check",
+					},
+				},
+			},
+		},
+		{
+			"id":   "auth_assert",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "AuthAssertExecutor",
+			},
+			"onSuccess": "end",
+		},
+		{
+			"id":   "end",
+			"type": "END",
+		},
+	}
+}
+
+// authenticateToPermissionConsent runs the flow to the consent prompt, requesting every permission
+// including the one the user does not hold.
+func (ts *PermissionConsentFlowTestSuite) authenticateToPermissionConsent(username string) *common.FlowStep {
+	ts.T().Helper()
+
+	step, err := common.InitiateAuthenticationFlow(ts.appID, false, map[string]string{
+		"applicationId": ts.appID,
+		"requested_permissions": permConsentParentPermission + " " + permConsentChildPermission +
+			" " + permConsentDecoyPermission + " " + permConsentUnheldPermission,
+		"resource_server_identifier": permConsentRSIdentifier,
+	}, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "Flow should pause at the credentials prompt")
+
+	step, err = common.CompleteFlow(step.ExecutionID, map[string]string{
+		"username": username,
+		"password": permConsentPassword,
+	}, "action_001", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit credentials")
+	return step
+}
+
+// requirePermissionPurpose asserts the step is a consent prompt carrying exactly one permission
+// purpose, and returns it.
+func (ts *PermissionConsentFlowTestSuite) requirePermissionPurpose(
+	step *common.FlowStep,
+) consentPromptPurpose {
+	ts.T().Helper()
+
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "Consent should pause the flow for input")
+	ts.Require().True(common.HasInput(step.Data.Inputs, consentInputIdentifier),
+		"The consent prompt must request the consent decisions input")
+
+	promptJSON, ok := step.Data.AdditionalData[consentPromptDataKey]
+	ts.Require().True(ok, "The consent prompt must carry the purposes to render")
+
+	var purposes []consentPromptPurpose
+	ts.Require().NoError(json.Unmarshal([]byte(promptJSON), &purposes),
+		"Consent prompt data should be a purposes array")
+	ts.Require().Len(purposes, 1,
+		"Only the permission purpose applies; the application requests no attributes")
+	ts.Require().Equal(permConsentPurposeType, purposes[0].Type,
+		"The purpose must be typed as permissions so the Console renders it as such")
+	return purposes[0]
+}
+
+// TestPermissionConsent_ElementsCarryRollupParents verifies the rollup linkage the Console groups by.
+// The nested permission is linked to the one it extends; the sibling that merely shares a prefix is
+// not, which is what the delimiter check in the parent computation exists for.
+func (ts *PermissionConsentFlowTestSuite) TestPermissionConsent_ElementsCarryRollupParents() {
+	step := ts.authenticateToPermissionConsent(permConsentPromptUsername)
+	purpose := ts.requirePermissionPurpose(step)
+
+	parents := make(map[string]string, len(purpose.Optional))
+	for _, element := range purpose.Optional {
+		parents[element.Name] = element.Parent
+	}
+
+	ts.Equal(permConsentParentPermission, parents[permConsentChildPermission],
+		"a permission nested under another must roll up to it")
+	ts.Empty(parents[permConsentParentPermission],
+		"a top-level permission has nothing to roll up to")
+	ts.Empty(parents[permConsentDecoyPermission],
+		"sharing a prefix without a delimiter is not a parent relationship")
+}
+
+// TestPermissionConsent_PurposeIsNamedForTheApplication verifies the purpose name identifies the
+// application, which is what scopes the recorded consent to it.
+func (ts *PermissionConsentFlowTestSuite) TestPermissionConsent_PurposeIsNamedForTheApplication() {
+	step := ts.authenticateToPermissionConsent(permConsentPromptUsername)
+	purpose := ts.requirePermissionPurpose(step)
+
+	ts.Equal("permissions:"+ts.appID, purpose.PurposeName,
+		"the permission purpose is derived from the application it belongs to")
+}
+

--- a/tests/integration/flow/execution/administration_flow_test.go
+++ b/tests/integration/flow/execution/administration_flow_test.go
@@ -1,0 +1,222 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package execution
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// The shipped user deletion flow. Executing it by handle keeps the test independent of the seeded
+// flow id, which is a bootstrap detail.
+const deletionFlowHandle = "default-user-deletion-flow"
+
+// deletionSubjectInput is the input identifier the deletion executors read the target user from.
+const deletionSubjectInput = "subject"
+
+var (
+	adminFlowTestOU = testutils.OrganizationUnit{
+		Handle:      "admin_flow_test_ou",
+		Name:        "Test OU for Administration Flows",
+		Description: "Organization unit created for administration flow testing",
+		Parent:      nil,
+	}
+
+	adminFlowTestUserType = testutils.UserType{
+		Name: "admin_flow_test_user",
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{"type": "string"},
+			"password": map[string]interface{}{"type": "string", "credential": true},
+		},
+	}
+)
+
+type AdministrationFlowTestSuite struct {
+	suite.Suite
+	ouID         string
+	entityTypeID string
+	flowID       string
+}
+
+func TestAdministrationFlowTestSuite(t *testing.T) {
+	suite.Run(t, new(AdministrationFlowTestSuite))
+}
+
+func (ts *AdministrationFlowTestSuite) SetupSuite() {
+	ouID, err := testutils.CreateOrganizationUnit(adminFlowTestOU)
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
+
+	adminFlowTestUserType.OUID = ts.ouID
+	schemaID, err := testutils.CreateUserType(adminFlowTestUserType)
+	ts.Require().NoError(err, "Failed to create test user type")
+	ts.entityTypeID = schemaID
+
+	ts.flowID = ts.resolveAdministrationFlowID(deletionFlowHandle)
+	ts.Require().NotEmpty(ts.flowID, "The shipped user deletion flow must be present")
+}
+
+func (ts *AdministrationFlowTestSuite) TearDownSuite() {
+	if ts.entityTypeID != "" {
+		if err := testutils.DeleteUserType(ts.entityTypeID); err != nil {
+			ts.T().Logf("Failed to delete test user type during teardown: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// resolveAdministrationFlowID looks the deletion flow up by handle among the administration flows.
+func (ts *AdministrationFlowTestSuite) resolveAdministrationFlowID(handle string) string {
+	ts.T().Helper()
+
+	req, err := http.NewRequest(http.MethodGet,
+		testServerURL+"/flows?flowType=ADMINISTRATION&limit=100", nil)
+	ts.Require().NoError(err)
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err, "Failed to list administration flows")
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusOK, resp.StatusCode, "Failed to list flows: %s", string(body))
+
+	var listed struct {
+		Flows []struct {
+			ID       string `json:"id"`
+			Handle   string `json:"handle"`
+			FlowType string `json:"flowType"`
+		} `json:"flows"`
+	}
+	ts.Require().NoError(json.Unmarshal(body, &listed))
+
+	for _, flow := range listed.Flows {
+		if flow.Handle == handle && flow.FlowType == "ADMINISTRATION" {
+			return flow.ID
+		}
+	}
+	return ""
+}
+
+// executeAdministrationFlow runs a flow by id as an administrator and returns the resulting step.
+//
+// The bearer token is set directly on a raw client because the shared test clients treat
+// /flow/execute as a public endpoint and skip token injection, which would make every
+// administration request anonymous.
+func (ts *AdministrationFlowTestSuite) executeAdministrationFlow(
+	flowID string, inputs map[string]string) (int, common.FlowStep, []byte) {
+	ts.T().Helper()
+
+	token, err := testutils.GetAccessToken()
+	ts.Require().NoError(err, "Failed to obtain admin access token")
+
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"flowId": flowID,
+		"inputs": inputs,
+	})
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest(http.MethodPost, testServerURL+"/flow/execute", bytes.NewReader(reqBody))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := testutils.GetRawHTTPClient().Do(req)
+	ts.Require().NoError(err, "Failed to execute administration flow")
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+
+	var step common.FlowStep
+	_ = json.Unmarshal(body, &step)
+
+	return resp.StatusCode, step, body
+}
+
+// userExists reports whether the user record is still retrievable.
+func (ts *AdministrationFlowTestSuite) userExists(userID string) bool {
+	ts.T().Helper()
+
+	req, err := http.NewRequest(http.MethodGet, testServerURL+"/users/"+userID, nil)
+	ts.Require().NoError(err)
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err, "Failed to read user")
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	return resp.StatusCode == http.StatusOK
+}
+
+func (ts *AdministrationFlowTestSuite) createTestUser(username string) string {
+	ts.T().Helper()
+
+	attributes, err := json.Marshal(map[string]string{"username": username, "password": "Testpass1"})
+	ts.Require().NoError(err)
+
+	userID, err := testutils.CreateUser(testutils.User{
+		Type:       adminFlowTestUserType.Name,
+		OUID:       ts.ouID,
+		Attributes: attributes,
+	})
+	ts.Require().NoError(err, "Failed to create test user")
+	ts.Require().NotEmpty(userID)
+
+	return userID
+}
+
+// Running the shipped deletion flow to completion exercises the whole administration chain in one
+// execution: the permission validator, the pre-delete validation that publishes the trusted
+// revocation plan, the criteria revocation write, session termination, and the record deletion.
+func (ts *AdministrationFlowTestSuite) TestUserDeletionFlow_CompletesAndDeletesUser() {
+	userID := ts.createTestUser(common.GenerateUniqueUsername("admin_flow_delete"))
+	ts.Require().True(ts.userExists(userID), "The user should exist before deletion")
+
+	status, step, body := ts.executeAdministrationFlow(ts.flowID,
+		map[string]string{deletionSubjectInput: userID})
+
+	ts.Require().Equal(http.StatusOK, status, "Deletion flow execution failed: %s", string(body))
+	ts.Equal("COMPLETE", step.FlowStatus, "Deletion flow should run to completion: %s", string(body))
+	ts.False(ts.userExists(userID), "The user record should be gone after the deletion flow")
+}
+
+// The pre-delete validation runs before anything destructive, so a subject that does not exist is
+// refused rather than producing a completed flow that deleted nothing.
+func (ts *AdministrationFlowTestSuite) TestUserDeletionFlow_UnknownSubjectDoesNotComplete() {
+	status, step, body := ts.executeAdministrationFlow(ts.flowID,
+		map[string]string{deletionSubjectInput: "01900000-0000-7000-8000-0000000000ff"})
+
+	if status == http.StatusOK {
+		ts.NotEqual("COMPLETE", step.FlowStatus,
+			"Deleting an unknown subject must not report success: %s", string(body))
+		return
+	}
+	ts.GreaterOrEqual(status, http.StatusBadRequest,
+		"Deleting an unknown subject should be reported as an error: %s", string(body))
+}
+
+// The flow declares its subject as a required input, so omitting it must not delete anything.
+func (ts *AdministrationFlowTestSuite) TestUserDeletionFlow_MissingSubjectDoesNotComplete() {
+	status, step, body := ts.executeAdministrationFlow(ts.flowID, map[string]string{})
+
+	if status == http.StatusOK {
+		ts.NotEqual("COMPLETE", step.FlowStatus,
+			"A deletion flow with no subject must not report success: %s", string(body))
+		return
+	}
+	ts.GreaterOrEqual(status, http.StatusBadRequest,
+		"A deletion flow with no subject should be reported as an error: %s", string(body))
+}

--- a/tests/integration/flow/execution/call_depth_test.go
+++ b/tests/integration/flow/execution/call_depth_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package execution
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// errCodeMaxCallDepth is returned when nested CALL nodes exceed the engine's frame limit.
+const errCodeMaxCallDepth = "FES-1013"
+
+// callChainLength is one longer than the engine's maximum call depth, so executing the head of the
+// chain is guaranteed to cross the limit. The engine's limit is 10 frames.
+const callChainLength = 12
+
+var callDepthTestOU = testutils.OrganizationUnit{
+	Handle:      "call_depth_test_ou",
+	Name:        "Test OU for Call Depth",
+	Description: "Organization unit created for call depth testing",
+	Parent:      nil,
+}
+
+type CallDepthTestSuite struct {
+	suite.Suite
+	ouID      string
+	appID     string
+	flowIDs   []string
+	headFlow  string
+	userType  string
+	entityTyp string
+}
+
+func TestCallDepthTestSuite(t *testing.T) {
+	suite.Run(t, new(CallDepthTestSuite))
+}
+
+// SetupSuite builds a chain of authentication flows where each one calls the next, then binds an
+// application to the head of the chain. The chain is built from the tail backwards because a CALL
+// node must reference a flow that already exists.
+func (ts *CallDepthTestSuite) SetupSuite() {
+	ouID, err := testutils.CreateOrganizationUnit(callDepthTestOU)
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
+
+	// The tail is a plain authentication flow that calls nothing.
+	tailID, err := testutils.CreateFlow(ts.buildLeafFlow())
+	ts.Require().NoError(err, "Failed to create leaf flow")
+	ts.flowIDs = append(ts.flowIDs, tailID)
+
+	next := tailID
+	for i := 0; i < callChainLength; i++ {
+		flowID, err := testutils.CreateFlow(ts.buildCallingFlow(i, next))
+		ts.Require().NoError(err, "Failed to create calling flow %d", i)
+		ts.flowIDs = append(ts.flowIDs, flowID)
+		next = flowID
+	}
+	ts.headFlow = next
+
+	app := testutils.Application{
+		Name:         "Call Depth Test Application",
+		Description:  "Application bound to a deeply nested call chain",
+		ClientID:     "call_depth_test_client",
+		ClientSecret: "call_depth_test_secret", //nolint:gosec // test credential
+		RedirectURIs: []string{"http://localhost:3000/callback"},
+		OUID:         ts.ouID,
+		AuthFlowID:   ts.headFlow,
+	}
+	appID, err := testutils.CreateApplication(app)
+	ts.Require().NoError(err, "Failed to create test application")
+	ts.appID = appID
+}
+
+func (ts *CallDepthTestSuite) TearDownSuite() {
+	if ts.appID != "" {
+		if err := testutils.DeleteApplication(ts.appID); err != nil {
+			ts.T().Logf("Failed to delete test application during teardown: %v", err)
+		}
+	}
+	// Delete from the head backwards so a flow is never removed while another still references it.
+	for i := len(ts.flowIDs) - 1; i >= 0; i-- {
+		if err := testutils.DeleteFlow(ts.flowIDs[i]); err != nil {
+			ts.T().Logf("Failed to delete flow %s during teardown: %v", ts.flowIDs[i], err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// buildLeafFlow returns the flow at the end of the chain, which calls nothing.
+func (ts *CallDepthTestSuite) buildLeafFlow() testutils.Flow {
+	return testutils.Flow{
+		Name:     "Call Depth Leaf Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_call_depth_leaf",
+		Nodes: []map[string]interface{}{
+			{"id": "start", "type": "START", "onSuccess": "auth_assert"},
+			{
+				"id":        "auth_assert",
+				"type":      "TASK_EXECUTION",
+				"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+				"onSuccess": "end",
+			},
+			{"id": "end", "type": "END"},
+		},
+	}
+}
+
+// buildCallingFlow returns a flow whose only work is to call the given target flow.
+func (ts *CallDepthTestSuite) buildCallingFlow(index int, targetFlowID string) testutils.Flow {
+	return testutils.Flow{
+		Name:     fmt.Sprintf("Call Depth Link %d Flow", index),
+		FlowType: "AUTHENTICATION",
+		Handle:   fmt.Sprintf("auth_flow_call_depth_link_%d", index),
+		Nodes: []map[string]interface{}{
+			{"id": "start", "type": "START", "onSuccess": "call_next"},
+			{
+				"id":        "call_next",
+				"type":      "CALL",
+				"flow":      map[string]interface{}{"ref": targetFlowID},
+				"onSuccess": "auth_assert",
+			},
+			{
+				"id":        "auth_assert",
+				"type":      "TASK_EXECUTION",
+				"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+				"onSuccess": "end",
+			},
+			{"id": "end", "type": "END"},
+		},
+	}
+}
+
+// A chain of nested CALL nodes deeper than the engine allows must be refused rather than recursing
+// until the process runs out of stack. The limit is what stops a mutually recursive set of flows,
+// which the flow designer does not prevent an operator from authoring, from taking the server down.
+func (ts *CallDepthTestSuite) TestExecute_ExceedingCallDepthRejected() {
+	step, err := common.InitiateAuthenticationFlow(ts.appID, false, nil, "")
+
+	// The engine may refuse the request outright or surface the failure on the step, depending on how
+	// far the chain unwinds before the limit trips. Either is acceptable; recursing without a limit is
+	// not.
+	if err != nil {
+		ts.Contains(err.Error(), fmt.Sprintf("%d", http.StatusBadRequest),
+			"a call chain past the depth limit should be rejected as a client error: %v", err)
+		return
+	}
+
+	ts.Require().NotNil(step, "expected a flow step for a rejected call chain")
+	ts.NotEqual("COMPLETE", step.FlowStatus,
+		"a call chain past the depth limit must not complete")
+	if step.Error != nil {
+		ts.Equal(errCodeMaxCallDepth, step.Error.Code,
+			"the failure should name the call depth limit")
+	}
+}

--- a/tests/integration/flow/execution/call_frames_test.go
+++ b/tests/integration/flow/execution/call_frames_test.go
@@ -1,0 +1,315 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package execution
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const callFramesPassword = "SecurePass123!"
+
+// callFramesUserType is the minimum a callee needs to authenticate someone, so the call can return
+// to its caller rather than failing.
+var callFramesUserType = testutils.UserType{
+	Name: "call-frames-person",
+	Schema: map[string]interface{}{
+		"username": map[string]interface{}{
+			"type": "string",
+		},
+		"password": map[string]interface{}{
+			"type":       "string",
+			"credential": true,
+		},
+	},
+}
+
+// callerNodes builds a flow whose first step calls another flow. onFailure is optional: without it a
+// failing callee ends the caller, with it the caller carries on at that node.
+func callerNodes(calleeFlowID, onFailure string) []map[string]interface{} {
+	callNode := map[string]interface{}{
+		"id":        "call_callee",
+		"type":      "CALL",
+		"flow":      map[string]interface{}{"ref": calleeFlowID},
+		"onSuccess": "prompt_returned",
+	}
+	if onFailure != "" {
+		callNode["onFailure"] = onFailure
+	}
+
+	nodes := []map[string]interface{}{
+		{"id": "start", "type": "START", "onSuccess": "call_callee"},
+		callNode,
+		markerPromptNode("prompt_returned", "returned_marker", "auth_assert"),
+	}
+
+	// Flow validation rejects a node nothing can reach, so the failure target exists only in the
+	// variant whose call node points at it.
+	if onFailure != "" {
+		nodes = append(nodes, markerPromptNode(onFailure, "recovered_marker", "auth_assert"))
+	}
+
+	return append(nodes,
+		map[string]interface{}{
+			"id":        "auth_assert",
+			"type":      "TASK_EXECUTION",
+			"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+			"onSuccess": "end",
+		},
+		map[string]interface{}{"id": "end", "type": "END"},
+	)
+}
+
+// markerPromptNode builds a prompt whose single input names the branch the flow reached, so a test
+// can tell where the caller resumed from the response alone.
+func markerPromptNode(id, marker, nextNode string) map[string]interface{} {
+	return map[string]interface{}{
+		"id":   id,
+		"type": "PROMPT",
+		"prompts": []map[string]interface{}{
+			{
+				"inputs": []map[string]interface{}{
+					{
+						"ref":        marker,
+						"identifier": marker,
+						"type":       "TEXT_INPUT",
+						"required":   true,
+					},
+				},
+				"action": map[string]interface{}{
+					"ref":      "action_" + marker,
+					"nextNode": nextNode,
+				},
+			},
+		},
+	}
+}
+
+type CallFramesTestSuite struct {
+	suite.Suite
+	config *common.TestSuiteConfig
+
+	ouID       string
+	userTypeID string
+	userID     string
+	username   string
+
+	pausingAppID     string
+	failingAppID     string
+	recoveringAppID  string
+	createdAppIDList []string
+}
+
+func TestCallFramesTestSuite(t *testing.T) {
+	suite.Run(t, new(CallFramesTestSuite))
+}
+
+func (ts *CallFramesTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "call_frames_test_ou",
+		Name:        "Call Frames Test OU",
+		Description: "Organization unit for call frame testing",
+		Parent:      nil,
+	})
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
+
+	userType := callFramesUserType
+	userType.OUID = ouID
+	ts.userTypeID, err = testutils.CreateUserType(userType)
+	ts.Require().NoError(err, "Failed to create test user type")
+
+	ts.username = common.GenerateUniqueUsername("call_frames")
+	ts.userID, err = testutils.CreateUser(testutils.User{
+		Type: callFramesUserType.Name,
+		OUID: ouID,
+		Attributes: json.RawMessage(`{
+			"username": "` + ts.username + `",
+			"password": "` + callFramesPassword + `"
+		}`),
+	})
+	ts.Require().NoError(err, "Failed to create test user")
+
+	// A callee that pauses for credentials and then authenticates, so the call both suspends inside
+	// the callee and later returns to its caller.
+	pausingCalleeID := ts.createFlow("Call Frames Pausing Callee", "auth_flow_call_frames_callee", []map[string]interface{}{
+		{"id": "start", "type": "START", "onSuccess": "prompt_credentials"},
+		{
+			"id":   "prompt_credentials",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_001",
+							"identifier": "username",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_002",
+							"identifier": "password",
+							"type":       "PASSWORD_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_001",
+						"nextNode": "credentials_auth",
+					},
+				},
+			},
+		},
+		{
+			"id":           "credentials_auth",
+			"type":         "TASK_EXECUTION",
+			"executor":     map[string]interface{}{"name": "CredentialsAuthExecutor"},
+			"onSuccess":    "callee_assert",
+			"onIncomplete": "prompt_credentials",
+		},
+		{
+			"id":        "callee_assert",
+			"type":      "TASK_EXECUTION",
+			"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+			"onSuccess": "end",
+		},
+		{"id": "end", "type": "END"},
+	})
+
+	// A callee that fails at its first node, because nothing has authenticated a user for it to
+	// assert.
+	failingCalleeID := ts.createFlow("Call Frames Failing Callee", "auth_flow_call_frames_failing_callee",
+		[]map[string]interface{}{
+			{"id": "start", "type": "START", "onSuccess": "callee_assert"},
+			{
+				"id":        "callee_assert",
+				"type":      "TASK_EXECUTION",
+				"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+				"onSuccess": "end",
+			},
+			{"id": "end", "type": "END"},
+		})
+
+	pausingCallerID := ts.createFlow("Call Frames Pausing Caller", "auth_flow_call_frames_caller",
+		callerNodes(pausingCalleeID, ""))
+	failingCallerID := ts.createFlow("Call Frames Failing Caller", "auth_flow_call_frames_failing_caller",
+		callerNodes(failingCalleeID, ""))
+	recoveringCallerID := ts.createFlow("Call Frames Recovering Caller",
+		"auth_flow_call_frames_recovering_caller", callerNodes(failingCalleeID, "prompt_recovered"))
+
+	ts.pausingAppID = ts.createApp("Call Frames Pausing App", "call_frames_pausing_client", pausingCallerID)
+	ts.failingAppID = ts.createApp("Call Frames Failing App", "call_frames_failing_client", failingCallerID)
+	ts.recoveringAppID = ts.createApp("Call Frames Recovering App", "call_frames_recovering_client",
+		recoveringCallerID)
+}
+
+func (ts *CallFramesTestSuite) createFlow(name, handle string, nodes []map[string]interface{}) string {
+	ts.T().Helper()
+
+	flowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     name,
+		FlowType: "AUTHENTICATION",
+		Handle:   handle,
+		Nodes:    nodes,
+	})
+	ts.Require().NoError(err, "Failed to create flow %s", handle)
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
+	return flowID
+}
+
+func (ts *CallFramesTestSuite) createApp(name, clientID, flowID string) string {
+	ts.T().Helper()
+
+	appID, err := testutils.CreateApplication(testutils.Application{
+		Name:             name,
+		Description:      "Application for call frame testing",
+		ClientID:         clientID,
+		ClientSecret:     clientID + "_secret",
+		RedirectURIs:     []string{"http://localhost:3000/callback"},
+		OUID:             ts.ouID,
+		AllowedUserTypes: []string{callFramesUserType.Name},
+		AuthFlowID:       flowID,
+	})
+	ts.Require().NoError(err, "Failed to create application %s", name)
+	ts.createdAppIDList = append(ts.createdAppIDList, appID)
+	return appID
+}
+
+func (ts *CallFramesTestSuite) TearDownSuite() {
+	for _, appID := range ts.createdAppIDList {
+		if err := testutils.DeleteApplication(appID); err != nil {
+			ts.T().Logf("teardown: failed to delete application: %v", err)
+		}
+	}
+	if ts.userID != "" {
+		if err := testutils.DeleteUser(ts.userID); err != nil {
+			ts.T().Logf("teardown: failed to delete user: %v", err)
+		}
+	}
+	// Callers reference callees, so the callers created last are removed first.
+	for i := len(ts.config.CreatedFlowIDs) - 1; i >= 0; i-- {
+		if err := testutils.DeleteFlow(ts.config.CreatedFlowIDs[i]); err != nil {
+			ts.T().Logf("teardown: failed to delete flow: %v", err)
+		}
+	}
+	if ts.userTypeID != "" {
+		if err := testutils.DeleteUserType(ts.userTypeID); err != nil {
+			ts.T().Logf("teardown: failed to delete user type: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("teardown: failed to delete organization unit: %v", err)
+		}
+	}
+}
+
+// A call that pauses inside the callee has to survive the round trip to the client: the caller's
+// frame is written into the stored context and read back on resume. Once the callee completes, the
+// call returns to its caller, which continues at the call node's success target rather than ending
+// with the callee.
+func (ts *CallFramesTestSuite) TestCall_PausesInsideCalleeAndReturnsToCaller() {
+	step, err := common.InitiateAuthenticationFlow(ts.pausingAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate flow")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "The call should pause inside the callee")
+	ts.Require().True(common.HasInput(step.Data.Inputs, "username"),
+		"The paused step must be the callee's own prompt")
+
+	returned, err := common.CompleteFlow(step.ExecutionID, map[string]string{
+		"username": ts.username,
+		"password": callFramesPassword,
+	}, "action_001", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to resume the paused call")
+	ts.Require().Equal("INCOMPLETE", returned.FlowStatus,
+		"The caller should carry on rather than end with the callee")
+	ts.True(common.HasInput(returned.Data.Inputs, "returned_marker"),
+		"A completed callee must return to the caller's success target")
+}
+
+// A callee that fails ends the caller too when the call node names no failure target, so a failing
+// call cannot silently fall through to whatever follows it.
+func (ts *CallFramesTestSuite) TestCall_CalleeFailureWithoutOnFailureEndsFlow() {
+	step, err := common.InitiateAuthenticationFlow(ts.failingAppID, false, nil, "")
+	ts.Require().NoError(err, "The flow should return a step rather than a transport error")
+	ts.Equal("ERROR", step.FlowStatus, "A failing callee must end the caller in error")
+	ts.False(common.HasInput(step.Data.Inputs, "returned_marker"),
+		"A failing callee must not reach the caller's success target")
+}
+
+// When the call node does name a failure target, the caller resumes there instead of ending, which
+// is what lets a flow offer an alternative after a called flow could not complete.
+func (ts *CallFramesTestSuite) TestCall_CalleeFailureForwardsToOnFailure() {
+	step, err := common.InitiateAuthenticationFlow(ts.recoveringAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate flow")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus,
+		"A failing callee with a failure target should keep the caller running")
+	ts.True(common.HasInput(step.Data.Inputs, "recovered_marker"),
+		"The caller must resume at the call node's failure target")
+}

--- a/tests/integration/flow/execution/flow_events_test.go
+++ b/tests/integration/flow/execution/flow_events_test.go
@@ -1,0 +1,459 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package execution
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	eventTypeFlowStarted        = "FLOW_STARTED"
+	eventTypeNodeExecStarted    = "FLOW_NODE_EXECUTION_STARTED"
+	eventTypeNodeExecCompleted  = "FLOW_NODE_EXECUTION_COMPLETED"
+	eventTypeNodeExecFailed     = "FLOW_NODE_EXECUTION_FAILED"
+	eventTypeFlowCompletedEvent = "FLOW_COMPLETED"
+
+	// The observability file adapter flushes on a fixed five second ticker, so a test that reads the
+	// sink has to wait past one tick rather than expecting an immediate write.
+	eventFlushWait = 9 * time.Second
+
+	eventsTestPassword = "SecurePass123!"
+)
+
+// Observability is off by default, so the events it publishes need the deployment section enabled
+// and a restart before any of them are written. The file sink is what makes the events assertable.
+var (
+	observabilityEnablePatch = map[string]interface{}{
+		"observability": map[string]interface{}{
+			"enabled": true,
+			"output": map[string]interface{}{
+				"file": map[string]interface{}{
+					"enabled": true,
+					"format":  "json",
+				},
+			},
+		},
+	}
+
+	observabilityDisablePatch = map[string]interface{}{
+		"observability": map[string]interface{}{
+			"enabled": false,
+		},
+	}
+)
+
+// observabilityEvent is the subset of a published event this suite asserts on.
+type observabilityEvent struct {
+	TraceID string                 `json:"trace_id"`
+	Type    string                 `json:"type"`
+	Status  string                 `json:"status"`
+	Data    map[string]interface{} `json:"data"`
+}
+
+// dataString reads a string-valued data field, which is how the flow engine writes the scalar
+// fields; non-scalar fields (such as a structured error) come back as the empty string.
+func (e observabilityEvent) dataString(key string) string {
+	if value, ok := e.Data[key].(string); ok {
+		return value
+	}
+	return ""
+}
+
+type FlowEventsTestSuite struct {
+	suite.Suite
+	config *common.TestSuiteConfig
+
+	ouID       string
+	userTypeID string
+	appID      string
+	// An application whose flow asserts an authenticated user without authenticating one, so the
+	// run fails at a node instead of pausing for input.
+	failingAppID string
+	userID       string
+	username     string
+}
+
+func TestFlowEventsTestSuite(t *testing.T) {
+	suite.Run(t, new(FlowEventsTestSuite))
+}
+
+func (ts *FlowEventsTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	ts.Require().NoError(testutils.PatchDeploymentConfig(observabilityEnablePatch),
+		"failed to enable observability")
+	ts.Require().NoError(testutils.RestartServer(),
+		"failed to restart server with observability enabled")
+	ts.Require().NoError(testutils.ObtainAdminAccessToken(),
+		"failed to re-obtain admin token after restart")
+
+	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "flow_events_test_ou",
+		Name:        "Flow Events Test OU",
+		Description: "Organization unit for flow observability event testing",
+		Parent:      nil,
+	})
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
+
+	ts.userTypeID, err = testutils.CreateUserType(testutils.UserType{
+		Name: "flow-events-person",
+		OUID: ouID,
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type": "string",
+			},
+			"password": map[string]interface{}{
+				"type":       "string",
+				"credential": true,
+			},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create test user type")
+
+	ts.username = common.GenerateUniqueUsername("flow_events")
+	ts.userID, err = testutils.CreateUser(testutils.User{
+		Type: "flow-events-person",
+		OUID: ouID,
+		Attributes: json.RawMessage(`{
+			"username": "` + ts.username + `",
+			"password": "` + eventsTestPassword + `"
+		}`),
+	})
+	ts.Require().NoError(err, "Failed to create test user")
+
+	flowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     "Flow Events Test Auth Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_events_test",
+		Nodes: []map[string]interface{}{
+			{
+				"id":        "start",
+				"type":      "START",
+				"onSuccess": "prompt_credentials",
+			},
+			{
+				"id":   "prompt_credentials",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_001",
+								"identifier": "username",
+								"type":       "TEXT_INPUT",
+								"required":   true,
+							},
+							{
+								"ref":        "input_002",
+								"identifier": "password",
+								"type":       "PASSWORD_INPUT",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_001",
+							"nextNode": "credentials_auth",
+						},
+					},
+				},
+			},
+			{
+				"id":   "credentials_auth",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "CredentialsAuthExecutor",
+				},
+				"onSuccess":    "auth_assert",
+				"onIncomplete": "prompt_credentials",
+			},
+			{
+				"id":   "auth_assert",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "AuthAssertExecutor",
+				},
+				"onSuccess": "end",
+			},
+			{
+				"id":   "end",
+				"type": "END",
+			},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create test flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
+
+	ts.appID, err = testutils.CreateApplication(testutils.Application{
+		Name:             "Flow Events Test Application",
+		Description:      "Application for flow observability event testing",
+		ClientID:         "flow_events_test_client",
+		ClientSecret:     "flow_events_test_secret",
+		RedirectURIs:     []string{"http://localhost:3000/callback"},
+		OUID:             ouID,
+		AllowedUserTypes: []string{"flow-events-person"},
+		AuthFlowID:       flowID,
+	})
+	ts.Require().NoError(err, "Failed to create test application")
+
+	failingFlowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     "Flow Events Failing Auth Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_events_failing_test",
+		Nodes: []map[string]interface{}{
+			{
+				"id":        "start",
+				"type":      "START",
+				"onSuccess": "auth_assert",
+			},
+			{
+				"id":   "auth_assert",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "AuthAssertExecutor",
+				},
+				"onSuccess": "end",
+			},
+			{
+				"id":   "end",
+				"type": "END",
+			},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create failing test flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, failingFlowID)
+
+	ts.failingAppID, err = testutils.CreateApplication(testutils.Application{
+		Name:             "Flow Events Failing Test Application",
+		Description:      "Application whose flow fails at its first node",
+		ClientID:         "flow_events_failing_test_client",
+		ClientSecret:     "flow_events_failing_test_secret",
+		RedirectURIs:     []string{"http://localhost:3000/callback"},
+		OUID:             ouID,
+		AllowedUserTypes: []string{"flow-events-person"},
+		AuthFlowID:       failingFlowID,
+	})
+	ts.Require().NoError(err, "Failed to create failing test application")
+}
+
+func (ts *FlowEventsTestSuite) TearDownSuite() {
+	for _, appID := range []string{ts.appID, ts.failingAppID} {
+		if appID == "" {
+			continue
+		}
+		if err := testutils.DeleteApplication(appID); err != nil {
+			ts.T().Logf("teardown: failed to delete application: %v", err)
+		}
+	}
+	if ts.userID != "" {
+		if err := testutils.DeleteUser(ts.userID); err != nil {
+			ts.T().Logf("teardown: failed to delete user: %v", err)
+		}
+	}
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("teardown: failed to delete flow: %v", err)
+		}
+	}
+	if ts.userTypeID != "" {
+		if err := testutils.DeleteUserType(ts.userTypeID); err != nil {
+			ts.T().Logf("teardown: failed to delete user type: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("teardown: failed to delete organization unit: %v", err)
+		}
+	}
+
+	if err := testutils.PatchDeploymentConfig(observabilityDisablePatch); err != nil {
+		ts.T().Logf("teardown: failed to restore observability config: %v", err)
+	}
+	if err := testutils.RestartServer(); err != nil {
+		ts.T().Logf("teardown: server did not restart cleanly after config restore: %v", err)
+	}
+	if err := testutils.ObtainAdminAccessToken(); err != nil {
+		ts.T().Logf("teardown: failed to re-obtain admin token after restore: %v", err)
+	}
+}
+
+// observabilityLogPath is where the file sink writes when no explicit path is configured.
+func (ts *FlowEventsTestSuite) observabilityLogPath() string {
+	return filepath.Join(testutils.GetExtractedProductHome(), "logs", "observability", "observability.log")
+}
+
+// eventsForExecution reads the sink and returns the events carrying the given execution id. The
+// adapter buffers and flushes on a fixed ticker, so the read is retried until the caller's condition
+// holds. Waiting on a precise condition rather than on any event of a type is what stops the read
+// from returning a half-flushed prefix of the run: an earlier node's event of the same type would
+// otherwise satisfy the wait while the node under test is still buffered.
+func (ts *FlowEventsTestSuite) eventsForExecution(executionID string,
+	done func([]observabilityEvent) bool) []observabilityEvent {
+	ts.T().Helper()
+
+	deadline := time.Now().Add(eventFlushWait)
+	var matched []observabilityEvent
+
+	for {
+		matched = ts.readEvents(executionID)
+		if done(matched) || time.Now().After(deadline) {
+			return matched
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+// hasType reports whether an event of the given type is present.
+func hasType(eventType string) func([]observabilityEvent) bool {
+	return func(events []observabilityEvent) bool {
+		return typesOf(events)[eventType]
+	}
+}
+
+// hasNodeEvent reports whether the given node published an event of the given type.
+func hasNodeEvent(eventType, nodeID string) func([]observabilityEvent) bool {
+	return func(events []observabilityEvent) bool {
+		return eventFor(events, eventType, nodeID) != nil
+	}
+}
+
+func (ts *FlowEventsTestSuite) readEvents(executionID string) []observabilityEvent {
+	ts.T().Helper()
+
+	file, err := os.Open(ts.observabilityLogPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		ts.Require().NoError(err, "Failed to open the observability sink")
+	}
+	defer file.Close()
+
+	var matched []observabilityEvent
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var evt observabilityEvent
+		if err := json.Unmarshal(line, &evt); err != nil {
+			continue
+		}
+		if evt.TraceID == executionID || evt.dataString("execution_id") == executionID {
+			matched = append(matched, evt)
+		}
+	}
+	return matched
+}
+
+// typesOf returns the event types present in the given events.
+func typesOf(events []observabilityEvent) map[string]bool {
+	types := make(map[string]bool, len(events))
+	for _, evt := range events {
+		types[evt.Type] = true
+	}
+	return types
+}
+
+// eventFor returns the first event of the given type touching the given node.
+func eventFor(events []observabilityEvent, eventType, nodeID string) *observabilityEvent {
+	for i := range events {
+		if events[i].Type == eventType && events[i].dataString("node_id") == nodeID {
+			return &events[i]
+		}
+	}
+	return nil
+}
+
+// A completed flow publishes the execution trail an operator needs to follow it: the flow starting,
+// each node starting and completing, and the flow completing. All of them are correlated by the
+// execution id, which is what makes a single run reconstructable from the sink.
+func (ts *FlowEventsTestSuite) TestFlowEvents_SuccessfulRunPublishesNodeTrail() {
+	step, err := common.InitiateAuthenticationFlow(ts.appID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate flow")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "Flow should pause at the credentials prompt")
+
+	completed, err := common.CompleteFlow(step.ExecutionID, map[string]string{
+		"username": ts.username,
+		"password": eventsTestPassword,
+	}, "action_001", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit credentials")
+	ts.Require().Equal("COMPLETE", completed.FlowStatus, "The flow should authenticate the user")
+
+	events := ts.eventsForExecution(step.ExecutionID, hasType(eventTypeFlowCompletedEvent))
+	ts.Require().NotEmpty(events, "The run should have published events to the sink")
+
+	present := typesOf(events)
+	ts.True(present[eventTypeFlowStarted], "the flow start should be published")
+	ts.True(present[eventTypeNodeExecStarted], "node executions should be published as they start")
+	ts.True(present[eventTypeNodeExecCompleted], "node executions should be published as they complete")
+	ts.True(present[eventTypeFlowCompletedEvent], "the flow completion should be published")
+
+	authEvent := eventFor(events, eventTypeNodeExecCompleted, "credentials_auth")
+	ts.Require().NotNil(authEvent, "the authenticating node must publish a completion event")
+	ts.Equal("success", authEvent.Status, "a node that completed must be published as a success")
+	ts.Equal("1", authEvent.dataString("attempt_number"),
+		"the first execution of a node is its first attempt")
+	ts.NotEmpty(authEvent.dataString("step_number"), "a node execution must carry its step number")
+	ts.NotEmpty(authEvent.dataString("duration_ms"), "a node execution must carry how long it took")
+}
+
+// A wrong password does not fail the node. The executor forwards back to the prompt, so the run
+// publishes the authenticating node as completed with the forwarding status and the reason, and the
+// re-presented prompt as incomplete carrying the same reason. Both are published as successes: the
+// step did not pass, but nothing broke.
+func (ts *FlowEventsTestSuite) TestFlowEvents_ForwardedNodePublishesReason() {
+	step, err := common.InitiateAuthenticationFlow(ts.appID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate flow")
+
+	retried, err := common.CompleteFlow(step.ExecutionID, map[string]string{
+		"username": ts.username,
+		"password": "WrongPassword123!",
+	}, "action_001", step.ChallengeToken)
+	ts.Require().NoError(err, "A wrong password should still return a flow step")
+	ts.Require().Equal("INCOMPLETE", retried.FlowStatus,
+		"A wrong password should re-prompt rather than end the flow")
+
+	events := ts.eventsForExecution(step.ExecutionID,
+		hasNodeEvent(eventTypeNodeExecCompleted, "credentials_auth"))
+	ts.Require().NotEmpty(events, "The run should have published events to the sink")
+
+	authEvent := eventFor(events, eventTypeNodeExecCompleted, "credentials_auth")
+	ts.Require().NotNil(authEvent, "the authenticating node must publish its execution")
+	ts.Equal("success", authEvent.Status,
+		"a node that forwarded is not a broken node, so it is published as a success")
+	ts.Equal("FORWARD", authEvent.dataString("node_status"),
+		"a node that forwards back to its prompt must be published with the forwarding status")
+	ts.NotNil(authEvent.Data["error"], "the published event must carry why the step did not pass")
+}
+
+// A node that genuinely fails is published as a failure, and the run it belongs to is published as
+// failed. Asserting an authenticated user without anything having authenticated one is the shortest
+// flow that fails at a node rather than pausing for input.
+func (ts *FlowEventsTestSuite) TestFlowEvents_FailedNodePublishesFailure() {
+	step, err := common.InitiateAuthenticationFlow(ts.failingAppID, false, nil, "")
+	ts.Require().NoError(err, "The flow should return a step rather than a transport error")
+	ts.Require().NotEmpty(step.ExecutionID, "A failed run must still report its execution id")
+
+	events := ts.eventsForExecution(step.ExecutionID, hasNodeEvent(eventTypeNodeExecFailed, "auth_assert"))
+	ts.Require().NotEmpty(events, "The run should have published events to the sink")
+
+	authEvent := eventFor(events, eventTypeNodeExecFailed, "auth_assert")
+	ts.Require().NotNil(authEvent, "a node that failed must publish a failure event")
+	ts.Equal("failure", authEvent.Status, "a failed node must be published as a failure")
+	ts.Equal("ERROR", authEvent.dataString("node_status"),
+		"a failed node must be published with the error status")
+	ts.NotNil(authEvent.Data["error"], "a failure event must carry what went wrong")
+}

--- a/tests/integration/flow/execution/flow_execution_error_test.go
+++ b/tests/integration/flow/execution/flow_execution_error_test.go
@@ -1,0 +1,347 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package execution
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const testServerURL = "https://localhost:8095"
+
+// Error codes returned by the flow execution service. Asserting the code rather than the message
+// keeps these tests independent of i18n wording.
+const (
+	errCodeInvalidAppID         = "FES-1003"
+	errCodeInvalidExecutionID   = "FES-1004"
+	errCodeInvalidFlowType      = "FES-1005"
+	errCodeRegistrationDisabled = "FES-1006"
+	errCodeRecoveryDisabled     = "FES-1009"
+	errCodeAdminAuthRequired    = "FES-1017"
+	errCodeFlowIDNotPermitted   = "FES-1018"
+	// errCodeAdminPermissionNeeded (FES-1019) is not asserted yet: it needs a signed-in user whose
+	// permissions omit the system scope. See TestExecuteByFlowID_ClientCredentialsTokenRejected.
+)
+
+var (
+	errorTestOU = testutils.OrganizationUnit{
+		Handle:      "flow_exec_error_test_ou",
+		Name:        "Test OU for Flow Execution Errors",
+		Description: "Organization unit created for flow execution error testing",
+		Parent:      nil,
+	}
+
+	// A minimal authentication flow. These tests never complete it; they only need an application
+	// bound to a real flow so that rejections come from the branch under test rather than from
+	// missing configuration.
+	errorTestFlow = testutils.Flow{
+		Name:     "Flow Execution Error Test Auth Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_execution_error_test",
+		Nodes: []map[string]interface{}{
+			{
+				"id":        "start",
+				"type":      "START",
+				"onSuccess": "prompt_credentials",
+			},
+			{
+				"id":   "prompt_credentials",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_001",
+								"identifier": "username",
+								"type":       "TEXT_INPUT",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_001",
+							"nextNode": "auth_assert",
+						},
+					},
+				},
+			},
+			{
+				// Flow validation requires an AuthAssertExecutor on every AUTHENTICATION flow, so this
+				// node is here to make the definition valid rather than because the tests reach it.
+				"id":   "auth_assert",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "AuthAssertExecutor",
+				},
+				"onSuccess": "end",
+			},
+			{
+				"id":   "end",
+				"type": "END",
+			},
+		},
+	}
+
+	// Registration and recovery are both left disabled so their "flow disabled" branches are
+	// reachable from this one application.
+	errorTestApp = testutils.Application{
+		Name:                      "Flow Execution Error Test Application",
+		Description:               "Application for testing flow execution error branches",
+		IsRegistrationFlowEnabled: false,
+		IsRecoveryFlowEnabled:     false,
+		ClientID:                  errorTestClientID,
+		ClientSecret:              errorTestClientSecret,
+		RedirectURIs:              []string{"http://localhost:3000/callback"},
+	}
+)
+
+const (
+	errorTestClientID     = "flow_execution_error_test_client"
+	errorTestClientSecret = "flow_execution_error_test_secret" //nolint:gosec // test credential
+)
+
+type FlowExecutionErrorTestSuite struct {
+	suite.Suite
+	config *common.TestSuiteConfig
+	ouID   string
+	appID  string
+	flowID string
+}
+
+func TestFlowExecutionErrorTestSuite(t *testing.T) {
+	suite.Run(t, new(FlowExecutionErrorTestSuite))
+}
+
+func (ts *FlowExecutionErrorTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	ouID, err := testutils.CreateOrganizationUnit(errorTestOU)
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
+
+	flowID, err := testutils.CreateFlow(errorTestFlow)
+	ts.Require().NoError(err, "Failed to create test flow")
+	ts.flowID = flowID
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
+
+	errorTestApp.OUID = ts.ouID
+	errorTestApp.AuthFlowID = flowID
+	appID, err := testutils.CreateApplication(errorTestApp)
+	ts.Require().NoError(err, "Failed to create test application")
+	ts.appID = appID
+}
+
+func (ts *FlowExecutionErrorTestSuite) TearDownSuite() {
+	if ts.appID != "" {
+		if err := testutils.DeleteApplication(ts.appID); err != nil {
+			ts.T().Logf("Failed to delete test application during teardown: %v", err)
+		}
+	}
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete test flow during teardown: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// executeFlow posts an arbitrary body to /flow/execute and returns the status and decoded error.
+//
+// A raw client is used deliberately. The shared test clients wrap an auth transport that treats
+// /flow/execute as a public endpoint and skips token injection entirely, so neither GetHTTPClient
+// nor GetHTTPClientWithToken can authenticate against the administration entry point. Passing an
+// empty token exercises the unauthenticated path; a non-empty one sets the header directly.
+func (ts *FlowExecutionErrorTestSuite) executeFlow(
+	body map[string]interface{}, bearerToken string) (int, common.ErrorResponse) {
+	ts.T().Helper()
+
+	reqBody, err := json.Marshal(body)
+	ts.Require().NoError(err, "Failed to marshal flow request body")
+
+	req, err := http.NewRequest(http.MethodPost, testServerURL+"/flow/execute", bytes.NewReader(reqBody))
+	ts.Require().NoError(err, "Failed to build flow request")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if bearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+bearerToken)
+	}
+
+	resp, err := testutils.GetRawHTTPClient().Do(req)
+	ts.Require().NoError(err, "Failed to send flow request")
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err, "Failed to read flow response body")
+
+	var errResp common.ErrorResponse
+	if err := json.Unmarshal(bodyBytes, &errResp); err != nil {
+		ts.T().Fatalf("Failed to decode error response (status %d): %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	return resp.StatusCode, errResp
+}
+
+// assertFlowError runs the request and asserts both the status and the error code.
+func (ts *FlowExecutionErrorTestSuite) assertFlowError(
+	body map[string]interface{}, bearerToken string, wantStatus int, wantCode string) {
+	ts.T().Helper()
+
+	status, errResp := ts.executeFlow(body, bearerToken)
+	ts.Equal(wantStatus, status, "Unexpected status for %s", wantCode)
+	ts.Equal(wantCode, errResp.Code, "Unexpected error code")
+}
+
+// adminToken returns a bearer token carrying the system permission.
+func (ts *FlowExecutionErrorTestSuite) adminToken() string {
+	ts.T().Helper()
+
+	token, err := testutils.GetAccessToken()
+	ts.Require().NoError(err, "Failed to obtain admin access token")
+	ts.Require().NotEmpty(token, "Admin access token is empty")
+
+	return token
+}
+
+// nonAdminToken returns a client-credentials token for the test application: a valid token that
+// carries no user subject and no system permission.
+func (ts *FlowExecutionErrorTestSuite) nonAdminToken() string {
+	ts.T().Helper()
+
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+
+	req, err := http.NewRequest(http.MethodPost, testServerURL+"/oauth2/token", strings.NewReader(form.Encode()))
+	ts.Require().NoError(err, "Failed to build token request")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(errorTestClientID, errorTestClientSecret)
+
+	resp, err := testutils.GetRawHTTPClient().Do(req)
+	ts.Require().NoError(err, "Failed to request client credentials token")
+	defer resp.Body.Close()
+
+	var body map[string]interface{}
+	ts.Require().NoError(json.NewDecoder(resp.Body).Decode(&body))
+	ts.Require().Equal(http.StatusOK, resp.StatusCode, "Token request failed: %v", body)
+
+	token, ok := body["access_token"].(string)
+	ts.Require().True(ok, "Token response has no access_token: %v", body)
+
+	return token
+}
+
+// A machine-to-machine client credentials token must not reach the administration entry point.
+// /flow/execute is a public path, so this check is the only thing standing between any client
+// holding a token and administration flow execution.
+//
+// The rejection is "authentication required" rather than "permission required": a client
+// credentials token establishes no user subject, so the caller check refuses it before permissions
+// are ever consulted. Reaching the permission branch (FES-1019) needs a user token whose
+// permissions omit the system scope, which requires a signed-in non-administrator user and is not
+// covered here.
+func (ts *FlowExecutionErrorTestSuite) TestExecuteByFlowID_ClientCredentialsTokenRejected() {
+	ts.assertFlowError(map[string]interface{}{
+		"flowId": ts.flowID,
+	}, ts.nonAdminToken(), http.StatusUnauthorized, errCodeAdminAuthRequired)
+}
+
+func (ts *FlowExecutionErrorTestSuite) TestInitiate_UnknownFlowTypeRejected() {
+	ts.assertFlowError(map[string]interface{}{
+		"applicationId": ts.appID,
+		"flowType":      "NOT_A_REAL_FLOW_TYPE",
+	}, "", http.StatusBadRequest, errCodeInvalidFlowType)
+}
+
+func (ts *FlowExecutionErrorTestSuite) TestInitiate_MissingFlowTypeRejected() {
+	ts.assertFlowError(map[string]interface{}{
+		"applicationId": ts.appID,
+	}, "", http.StatusBadRequest, errCodeInvalidFlowType)
+}
+
+func (ts *FlowExecutionErrorTestSuite) TestInitiate_UnknownApplicationRejected() {
+	ts.assertFlowError(map[string]interface{}{
+		"applicationId": "01900000-0000-7000-8000-00000000dead",
+		"flowType":      "AUTHENTICATION",
+	}, "", http.StatusBadRequest, errCodeInvalidAppID)
+}
+
+// Registration is disabled on the test application, so the flow type is valid but unavailable.
+func (ts *FlowExecutionErrorTestSuite) TestInitiate_RegistrationDisabledRejected() {
+	ts.assertFlowError(map[string]interface{}{
+		"applicationId": ts.appID,
+		"flowType":      "REGISTRATION",
+	}, "", http.StatusBadRequest, errCodeRegistrationDisabled)
+}
+
+func (ts *FlowExecutionErrorTestSuite) TestInitiate_RecoveryDisabledRejected() {
+	ts.assertFlowError(map[string]interface{}{
+		"applicationId": ts.appID,
+		"flowType":      "RECOVERY",
+	}, "", http.StatusBadRequest, errCodeRecoveryDisabled)
+}
+
+func (ts *FlowExecutionErrorTestSuite) TestResume_UnknownExecutionIDRejected() {
+	ts.assertFlowError(map[string]interface{}{
+		"executionId": "01900000-0000-7000-8000-00000000beef",
+		"inputs":      map[string]string{"username": "someone"},
+	}, "", http.StatusBadRequest, errCodeInvalidExecutionID)
+}
+
+func (ts *FlowExecutionErrorTestSuite) TestResume_MalformedExecutionIDRejected() {
+	ts.assertFlowError(map[string]interface{}{
+		"executionId": "not-a-uuid",
+		"inputs":      map[string]string{"username": "someone"},
+	}, "", http.StatusBadRequest, errCodeInvalidExecutionID)
+}
+
+// Initiating by flowId is the administration entry point. /flow/execute is a public path, so an
+// unauthenticated caller must be rejected before the flow is even resolved, which also stops the
+// response distinguishing a missing flow from an existing one.
+func (ts *FlowExecutionErrorTestSuite) TestExecuteByFlowID_UnauthenticatedRejected() {
+	ts.assertFlowError(map[string]interface{}{
+		"flowId": ts.flowID,
+	}, "", http.StatusUnauthorized, errCodeAdminAuthRequired)
+}
+
+func (ts *FlowExecutionErrorTestSuite) TestExecuteByFlowID_UnauthenticatedUnknownFlowRejectedIdentically() {
+	// A flow id that does not exist must produce the same rejection as a real one, so the endpoint
+	// does not leak which flows exist to an unauthenticated caller.
+	ts.assertFlowError(map[string]interface{}{
+		"flowId": "01900000-0000-7000-8000-00000000f00d",
+	}, "", http.StatusUnauthorized, errCodeAdminAuthRequired)
+}
+
+// An authenticated administrator may only execute ADMINISTRATION flows by id. Pointing the entry
+// point at an authentication flow must be refused, otherwise it becomes a way to start a login
+// flow directly and bypass the application binding that type requires.
+func (ts *FlowExecutionErrorTestSuite) TestExecuteByFlowID_NonAdministrationFlowRejected() {
+	ts.assertFlowError(map[string]interface{}{
+		"flowId": ts.flowID,
+	}, ts.adminToken(), http.StatusForbidden, errCodeFlowIDNotPermitted)
+}
+
+func (ts *FlowExecutionErrorTestSuite) TestExecuteByFlowID_UnknownFlowRejectedForAdministrator() {
+	status, errResp := ts.executeFlow(map[string]interface{}{
+		"flowId": "01900000-0000-7000-8000-00000000f00d",
+	}, ts.adminToken())
+
+	// The caller is authorized, so the response may report either that the flow does not exist or
+	// that execution by id is not permitted for it. Both are client errors; what matters is that an
+	// authorized caller is not served a 401 and never reaches execution.
+	ts.Contains([]int{http.StatusBadRequest, http.StatusForbidden, http.StatusNotFound}, status,
+		fmt.Sprintf("Unexpected status for an unknown flow id: %d", status))
+	ts.NotEmpty(errResp.Code, "Expected an error code for an unknown flow id")
+}

--- a/tests/integration/flow/execution/flow_lifecycle_test.go
+++ b/tests/integration/flow/execution/flow_lifecycle_test.go
@@ -1,0 +1,337 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package execution
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const flowConfigURL = testServerURL + "/server-config/flow"
+
+// shortFlowExpirySeconds is the smallest positive expiry the configuration accepts, so the expiry
+// test waits the shortest time it can while still crossing the boundary.
+const shortFlowExpirySeconds = 1
+
+var (
+	lifecycleTestOU = testutils.OrganizationUnit{
+		Handle:      "flow_lifecycle_test_ou",
+		Name:        "Test OU for Flow Lifecycle",
+		Description: "Organization unit created for flow lifecycle testing",
+		Parent:      nil,
+	}
+
+	// A flow that stops at a prompt, so an execution exists to resume and to let expire.
+	lifecycleTestFlow = testutils.Flow{
+		Name:     "Flow Lifecycle Test Auth Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_lifecycle_test",
+		Nodes: []map[string]interface{}{
+			{
+				"id":        "start",
+				"type":      "START",
+				"onSuccess": "prompt_credentials",
+			},
+			{
+				"id":   "prompt_credentials",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_001",
+								"identifier": "username",
+								"type":       "TEXT_INPUT",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_001",
+							"nextNode": "auth_assert",
+						},
+					},
+				},
+			},
+			{
+				"id":   "auth_assert",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "AuthAssertExecutor",
+				},
+				"onSuccess": "end",
+			},
+			{
+				"id":   "end",
+				"type": "END",
+			},
+		},
+	}
+
+	lifecycleTestApp = testutils.Application{
+		Name:         "Flow Lifecycle Test Application",
+		Description:  "Application for testing flow execution lifecycle",
+		ClientID:     "flow_lifecycle_test_client",
+		ClientSecret: "flow_lifecycle_test_secret",
+		RedirectURIs: []string{"http://localhost:3000/callback"},
+	}
+)
+
+type FlowLifecycleTestSuite struct {
+	suite.Suite
+	config *common.TestSuiteConfig
+	ouID   string
+	appID  string
+	flowID string
+}
+
+func TestFlowLifecycleTestSuite(t *testing.T) {
+	suite.Run(t, new(FlowLifecycleTestSuite))
+}
+
+func (ts *FlowLifecycleTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	ouID, err := testutils.CreateOrganizationUnit(lifecycleTestOU)
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
+
+	flowID, err := testutils.CreateFlow(lifecycleTestFlow)
+	ts.Require().NoError(err, "Failed to create test flow")
+	ts.flowID = flowID
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
+
+	lifecycleTestApp.OUID = ts.ouID
+	lifecycleTestApp.AuthFlowID = flowID
+	appID, err := testutils.CreateApplication(lifecycleTestApp)
+	ts.Require().NoError(err, "Failed to create test application")
+	ts.appID = appID
+}
+
+func (ts *FlowLifecycleTestSuite) TearDownSuite() {
+	if ts.appID != "" {
+		if err := testutils.DeleteApplication(ts.appID); err != nil {
+			ts.T().Logf("Failed to delete test application during teardown: %v", err)
+		}
+	}
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete test flow during teardown: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// writableFlowConfig reads the writable layer of the flow section, so a test can restore exactly
+// what was there rather than guessing at a default.
+func (ts *FlowLifecycleTestSuite) writableFlowConfig() json.RawMessage {
+	ts.T().Helper()
+
+	req, err := http.NewRequest(http.MethodGet, flowConfigURL, nil)
+	ts.Require().NoError(err)
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err, "Failed to read flow server config")
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusOK, resp.StatusCode, "Failed to read flow config: %s", string(body))
+
+	var layers struct {
+		Writable json.RawMessage `json:"writable"`
+	}
+	ts.Require().NoError(json.Unmarshal(body, &layers))
+
+	if len(layers.Writable) == 0 {
+		return json.RawMessage("{}")
+	}
+	return layers.Writable
+}
+
+// putFlowConfig replaces the writable layer of the flow section.
+func (ts *FlowLifecycleTestSuite) putFlowConfig(body string) {
+	ts.T().Helper()
+
+	req, err := http.NewRequest(http.MethodPut, flowConfigURL, strings.NewReader(body))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err, "Failed to update flow server config")
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusOK, resp.StatusCode,
+		"Failed to update flow config with %s: %s", body, string(respBody))
+}
+
+// An execution started without inputs must be resumable by its execution id, carrying the flow
+// forward from the stored context rather than starting over.
+//
+// The assertion is that the context is found and advanced, not that the flow reaches a particular
+// terminal state: the node after the prompt asserts an authenticated user, which this test never
+// establishes. Being accepted at all is what proves resume works, since an unknown or expired
+// execution id is rejected instead (see TestExpiry_ExpiredExecutionRejected).
+func (ts *FlowLifecycleTestSuite) TestResume_ContinuesExistingExecution() {
+	step, err := common.InitiateAuthenticationFlow(ts.appID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate flow")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "Flow should pause at the prompt")
+	ts.Require().NotEmpty(step.ExecutionID, "A paused flow must return an execution id")
+
+	resumed, err := common.CompleteFlow(step.ExecutionID,
+		map[string]string{"username": "someone@example.com"}, "action_001", "")
+	ts.Require().NoError(err, "Resuming an existing execution should be accepted")
+	ts.Equal(step.ExecutionID, resumed.ExecutionID, "Resume must stay on the same execution")
+	ts.NotEmpty(resumed.FlowStatus, "Resume must report a flow status")
+}
+
+// Resuming a prompt without supplying its required input is refused rather than silently
+// re-presenting the prompt, so a caller cannot loop on an execution without making progress.
+func (ts *FlowLifecycleTestSuite) TestResume_WithoutRequiredInputFails() {
+	step, err := common.InitiateAuthenticationFlow(ts.appID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate flow")
+	ts.Require().NotEmpty(step.ExecutionID, "A paused flow must return an execution id")
+
+	resumed, err := common.ResumeFlow(step.ExecutionID)
+	ts.Require().NoError(err, "A bare resume should still return a flow step")
+	ts.Equal("ERROR", resumed.FlowStatus, "Resuming without the required input should fail the step")
+}
+
+// An application keeps pointing at its authentication flow after that flow is deleted, because
+// deleting a flow does not clear the reference. Rather than failing every sign-in for that
+// application, the engine falls back to the configured default authentication flow.
+//
+// The default handle is pointed at a flow this test creates, so the fallback is identified by the
+// prompt it lands on rather than by whatever the deployment happens to ship as its default.
+func (ts *FlowLifecycleTestSuite) TestFallback_DeletedFlowFallsBackToDefault() {
+	defaultFlowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     "Flow Lifecycle Fallback Default Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_lifecycle_fallback_default",
+		Nodes: []map[string]interface{}{
+			{"id": "start", "type": "START", "onSuccess": "prompt_fallback"},
+			{
+				"id":   "prompt_fallback",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "fallback_marker",
+								"identifier": "fallback_marker",
+								"type":       "TEXT_INPUT",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_fallback",
+							"nextNode": "auth_assert",
+						},
+					},
+				},
+			},
+			{
+				"id":        "auth_assert",
+				"type":      "TASK_EXECUTION",
+				"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+				"onSuccess": "end",
+			},
+			{"id": "end", "type": "END"},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create the fallback default flow")
+	ts.T().Cleanup(func() {
+		if err := testutils.DeleteFlow(defaultFlowID); err != nil {
+			ts.T().Logf("cleanup: failed to delete fallback default flow: %v", err)
+		}
+	})
+
+	original := ts.writableFlowConfig()
+	ts.T().Cleanup(func() {
+		ts.putFlowConfig(string(original))
+	})
+
+	// A PUT replaces the whole writable layer, so the existing keys are read back and re-sent with
+	// the default handle added rather than assumed absent.
+	section := map[string]interface{}{}
+	ts.Require().NoError(json.Unmarshal(original, &section))
+	section["authFlow"] = map[string]interface{}{"defaultHandle": "auth_flow_lifecycle_fallback_default"}
+	merged, err := json.Marshal(section)
+	ts.Require().NoError(err)
+	ts.putFlowConfig(string(merged))
+
+	// A flow of its own, so deleting it cannot disturb the other tests in this suite.
+	doomedFlowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     "Flow Lifecycle Doomed Flow",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_lifecycle_doomed",
+		Nodes:    lifecycleTestFlow.Nodes,
+	})
+	ts.Require().NoError(err, "Failed to create the flow that gets deleted")
+
+	orphanedAppID, err := testutils.CreateApplication(testutils.Application{
+		Name:         "Flow Lifecycle Fallback Application",
+		Description:  "Application whose authentication flow is deleted out from under it",
+		ClientID:     "flow_lifecycle_fallback_client",
+		ClientSecret: "flow_lifecycle_fallback_secret",
+		RedirectURIs: []string{"http://localhost:3000/callback"},
+		OUID:         ts.ouID,
+		AuthFlowID:   doomedFlowID,
+	})
+	ts.Require().NoError(err, "Failed to create the application")
+	ts.T().Cleanup(func() {
+		if err := testutils.DeleteApplication(orphanedAppID); err != nil {
+			ts.T().Logf("cleanup: failed to delete fallback application: %v", err)
+		}
+	})
+
+	ts.Require().NoError(testutils.DeleteFlow(doomedFlowID),
+		"Deleting a referenced flow should be allowed, which is what creates the dangling reference")
+
+	step, err := common.InitiateAuthenticationFlow(orphanedAppID, false, nil, "")
+	ts.Require().NoError(err, "A dangling flow reference should not fail the request")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "The fallback flow should run")
+	ts.True(common.HasInput(step.Data.Inputs, "fallback_marker"),
+		"The request must be served by the configured default authentication flow")
+}
+
+// A flow context is held for the configured expiry and no longer, after which its execution id is
+// no longer usable. This is the branch that separates "unknown execution" from "expired execution",
+// and both surface as the same client error by design.
+func (ts *FlowLifecycleTestSuite) TestExpiry_ExpiredExecutionRejected() {
+	original := ts.writableFlowConfig()
+	ts.T().Cleanup(func() {
+		ts.putFlowConfig(string(original))
+	})
+
+	// The expiry is read from the merged server config on every execution, so this takes effect
+	// without restarting the server.
+	ts.putFlowConfig(`{"authFlow":{"expirySeconds":1}}`)
+
+	step, err := common.InitiateAuthenticationFlow(ts.appID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate flow")
+	ts.Require().NotEmpty(step.ExecutionID, "A paused flow must return an execution id")
+
+	// Wait past the expiry with margin, so the context is gone rather than merely stale.
+	time.Sleep(time.Duration(shortFlowExpirySeconds)*time.Second + 2*time.Second)
+
+	errResp, err := common.CompleteAuthFlowWithError(step.ExecutionID,
+		map[string]string{"username": "someone"}, "")
+	ts.Require().NoError(err, "Expected a client error for an expired execution")
+	ts.Equal(errCodeInvalidExecutionID, errResp.Code,
+		"An expired execution must be rejected as an invalid execution id")
+}

--- a/tests/integration/flow/execution/user_onboarding_test.go
+++ b/tests/integration/flow/execution/user_onboarding_test.go
@@ -1,0 +1,480 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package execution
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	// A user onboarding flow is app independent: it is resolved by the default handle configured in
+	// the server-config flow section rather than from an application binding.
+	onboardingFlowHandle = "user_onboarding_flow_test"
+
+	errCodeOUNotFound            = "FET-1030"
+	errCodeUserTypeNotAllowed    = "FET-1054"
+	errCodeUserTypeNotValidForOU = "FET-1058"
+)
+
+type UserOnboardingTestSuite struct {
+	suite.Suite
+	config *common.TestSuiteConfig
+
+	rootOUID       string
+	childOUID      string
+	rootTypeID     string
+	childTypeID    string
+	rootTypeName   string
+	childTypeName  string
+	flowID         string
+	originalConfig json.RawMessage
+}
+
+func TestUserOnboardingTestSuite(t *testing.T) {
+	suite.Run(t, new(UserOnboardingTestSuite))
+}
+
+// onboardingFlowNodes builds the onboarding flow: the OU is chosen first from the full tree, the
+// user type is then resolved against that OU, and the user is provisioned into it.
+func onboardingFlowNodes(allowedUserTypes []string) []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"id":        "start",
+			"type":      "START",
+			"onSuccess": "ou_resolver",
+		},
+		{
+			"id":   "ou_resolver",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "OUResolverExecutor",
+			},
+			"properties": map[string]interface{}{
+				"resolveFrom": "promptAll",
+			},
+			"onSuccess":    "user_type_resolver",
+			"onIncomplete": "prompt_ou",
+		},
+		{
+			"id":   "prompt_ou",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "ou_selection_input",
+							"identifier": "ouId",
+							"type":       "OU_SELECT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_ou",
+						"nextNode": "ou_resolver",
+					},
+				},
+			},
+		},
+		{
+			"id":   "user_type_resolver",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "UserTypeResolver",
+			},
+			"properties": map[string]interface{}{
+				"allowedUserTypes": allowedUserTypes,
+			},
+			"onSuccess":    "provisioning",
+			"onIncomplete": "prompt_usertype",
+		},
+		{
+			"id":   "prompt_usertype",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "usertype_input",
+							"identifier": "userType",
+							"type":       "SELECT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_usertype",
+						"nextNode": "user_type_resolver",
+					},
+				},
+			},
+		},
+		{
+			"id":   "provisioning",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "ProvisioningExecutor",
+				"inputs": []map[string]interface{}{
+					{
+						"ref":        "input_username",
+						"identifier": "username",
+						"type":       "TEXT_INPUT",
+						"required":   true,
+					},
+					{
+						"ref":        "input_email",
+						"identifier": "email",
+						"type":       "TEXT_INPUT",
+						"required":   true,
+					},
+				},
+			},
+			"onSuccess":    "end",
+			"onIncomplete": "prompt_user_details",
+		},
+		{
+			"id":   "prompt_user_details",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_username",
+							"identifier": "username",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_email",
+							"identifier": "email",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_details",
+						"nextNode": "provisioning",
+					},
+				},
+			},
+		},
+		{
+			"id":   "end",
+			"type": "END",
+		},
+	}
+}
+
+func onboardingUserTypeSchema(name, ouID string) testutils.UserType {
+	return testutils.UserType{
+		Name: name,
+		OUID: ouID,
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type": "string",
+			},
+			"email": map[string]interface{}{
+				"type": "string",
+			},
+		},
+	}
+}
+
+func (ts *UserOnboardingTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	rootOUID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "onboarding_root_test_ou",
+		Name:        "Onboarding Root Test OU",
+		Description: "Root organization unit for user onboarding testing",
+		Parent:      nil,
+	})
+	ts.Require().NoError(err, "Failed to create root organization unit")
+	ts.rootOUID = rootOUID
+
+	childOUID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "onboarding_child_test_ou",
+		Name:        "Onboarding Child Test OU",
+		Description: "Child organization unit for user onboarding testing",
+		Parent:      &rootOUID,
+	})
+	ts.Require().NoError(err, "Failed to create child organization unit")
+	ts.childOUID = childOUID
+
+	// One user type per OU, so which types are offered depends on the OU that was picked.
+	ts.rootTypeName = "onboarding-root-person"
+	ts.childTypeName = "onboarding-child-person"
+
+	ts.rootTypeID, err = testutils.CreateUserType(onboardingUserTypeSchema(ts.rootTypeName, rootOUID))
+	ts.Require().NoError(err, "Failed to create root user type")
+
+	ts.childTypeID, err = testutils.CreateUserType(onboardingUserTypeSchema(ts.childTypeName, childOUID))
+	ts.Require().NoError(err, "Failed to create child user type")
+
+	ts.flowID, err = testutils.CreateFlow(testutils.Flow{
+		Name:     "User Onboarding Test Flow",
+		FlowType: "USER_ONBOARDING",
+		Handle:   onboardingFlowHandle,
+		Nodes:    onboardingFlowNodes([]string{ts.rootTypeName, ts.childTypeName}),
+	})
+	ts.Require().NoError(err, "Failed to create user onboarding flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, ts.flowID)
+
+	// The onboarding flow is reached by its default handle, so the flow section has to name it.
+	// The original writable layer is captured first and restored on teardown.
+	ts.originalConfig = ts.writableFlowSection()
+	ts.setOnboardingDefaultHandle(onboardingFlowHandle)
+}
+
+func (ts *UserOnboardingTestSuite) TearDownSuite() {
+	if len(ts.originalConfig) > 0 {
+		ts.putFlowSection(string(ts.originalConfig))
+	}
+	for _, userID := range ts.config.CreatedUserIDs {
+		if err := testutils.DeleteUser(userID); err != nil {
+			ts.T().Logf("Failed to delete onboarded user during teardown: %v", err)
+		}
+	}
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete test flow during teardown: %v", err)
+		}
+	}
+	for _, typeID := range []string{ts.childTypeID, ts.rootTypeID} {
+		if typeID == "" {
+			continue
+		}
+		if err := testutils.DeleteUserType(typeID); err != nil {
+			ts.T().Logf("Failed to delete test user type during teardown: %v", err)
+		}
+	}
+	for _, ouID := range []string{ts.childOUID, ts.rootOUID} {
+		if ouID == "" {
+			continue
+		}
+		if err := testutils.DeleteOrganizationUnit(ouID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// writableFlowSection reads the writable layer of the flow section so teardown can restore exactly
+// what was there rather than guessing at a default.
+func (ts *UserOnboardingTestSuite) writableFlowSection() json.RawMessage {
+	ts.T().Helper()
+
+	req, err := http.NewRequest(http.MethodGet, flowConfigURL, nil)
+	ts.Require().NoError(err)
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err, "Failed to read flow server config")
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusOK, resp.StatusCode, "Failed to read flow config: %s", string(body))
+
+	var layers struct {
+		Writable json.RawMessage `json:"writable"`
+	}
+	ts.Require().NoError(json.Unmarshal(body, &layers))
+
+	if len(layers.Writable) == 0 {
+		return json.RawMessage("{}")
+	}
+	return layers.Writable
+}
+
+// setOnboardingDefaultHandle adds the onboarding default handle to the writable flow section,
+// keeping every sibling key the section already carried. A PUT replaces the whole writable layer,
+// so the existing keys are read back and re-sent rather than assumed absent.
+func (ts *UserOnboardingTestSuite) setOnboardingDefaultHandle(handle string) {
+	ts.T().Helper()
+
+	section := map[string]interface{}{}
+	ts.Require().NoError(json.Unmarshal(ts.originalConfig, &section))
+	section["userOnboardingFlow"] = map[string]interface{}{"defaultHandle": handle}
+
+	body, err := json.Marshal(section)
+	ts.Require().NoError(err)
+	ts.putFlowSection(string(body))
+}
+
+func (ts *UserOnboardingTestSuite) putFlowSection(body string) {
+	ts.T().Helper()
+
+	req, err := http.NewRequest(http.MethodPut, flowConfigURL, bytes.NewReader([]byte(body)))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err, "Failed to update flow server config")
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusOK, resp.StatusCode,
+		"Failed to update flow config with %s: %s", body, string(respBody))
+}
+
+// initiateOnboarding starts a user onboarding flow. It carries no application id, which is what
+// distinguishes an app-independent system flow from every other flow type.
+func (ts *UserOnboardingTestSuite) initiateOnboarding(inputs map[string]string) *common.FlowStep {
+	ts.T().Helper()
+
+	reqBody := map[string]interface{}{"flowType": "USER_ONBOARDING"}
+	if len(inputs) > 0 {
+		reqBody["inputs"] = inputs
+	}
+
+	payload, err := json.Marshal(reqBody)
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest(http.MethodPost, testServerURL+"/flow/execute", bytes.NewReader(payload))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err, "Failed to send onboarding flow request")
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusOK, resp.StatusCode,
+		"Onboarding initiation should succeed: %s", string(body))
+
+	var step common.FlowStep
+	ts.Require().NoError(json.Unmarshal(body, &step))
+	return &step
+}
+
+// findOnboardedUser locates a provisioned user so the OU and type it landed in can be asserted,
+// and tracks it for cleanup.
+func (ts *UserOnboardingTestSuite) findOnboardedUser(username string) *testutils.User {
+	ts.T().Helper()
+
+	user, err := testutils.FindUserByAttribute("username", username)
+	ts.Require().NoError(err, "Failed to look up the onboarded user")
+	ts.Require().NotNil(user, "The onboarding flow should have created a user")
+
+	if user.ID != "" {
+		ts.config.CreatedUserIDs = append(ts.config.CreatedUserIDs, user.ID)
+	}
+	return user
+}
+
+// An onboarding flow with the promptAll strategy asks for the OU before anything else, and the
+// selected OU then decides which user types are on offer. Picking the root OU leaves only the type
+// attached to it, so the type is auto-selected and the flow goes straight to the user details.
+func (ts *UserOnboardingTestSuite) TestOnboarding_RootOUAutoSelectsItsOnlyUserType() {
+	step := ts.initiateOnboarding(nil)
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "Onboarding should pause to select an OU")
+	ts.Require().True(common.HasInput(step.Data.Inputs, "ouId"),
+		"The promptAll strategy must request an OU selection")
+
+	step, err := common.CompleteFlow(step.ExecutionID,
+		map[string]string{"ouId": ts.rootOUID}, "action_ou", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit the OU selection")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "The flow should continue after the OU is chosen")
+	ts.False(common.HasInput(step.Data.Inputs, "userType"),
+		"A single valid user type should be auto-selected rather than prompted")
+	ts.True(common.HasInput(step.Data.Inputs, "username"),
+		"The flow should move on to collecting user details")
+
+	username := common.GenerateUniqueUsername("onboard_root")
+	completed, err := common.CompleteFlow(step.ExecutionID, map[string]string{
+		"username": username,
+		"email":    username + "@onboarding.test",
+	}, "action_details", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit user details")
+	ts.Require().Equal("COMPLETE", completed.FlowStatus, "Onboarding should provision the user")
+
+	user := ts.findOnboardedUser(username)
+	ts.Equal(ts.rootOUID, user.OUID, "The user must be provisioned into the selected OU")
+	ts.Equal(ts.rootTypeName, user.Type, "The user must carry the resolved user type")
+}
+
+// Picking the child OU leaves both user types valid — the one attached to the child and the one
+// attached to its ancestor — so the flow has to ask which to use.
+func (ts *UserOnboardingTestSuite) TestOnboarding_ChildOUPromptsForUserType() {
+	step := ts.initiateOnboarding(nil)
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "Onboarding should pause to select an OU")
+
+	step, err := common.CompleteFlow(step.ExecutionID,
+		map[string]string{"ouId": ts.childOUID}, "action_ou", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit the OU selection")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "The flow should pause to select a user type")
+	ts.Require().True(common.HasInput(step.Data.Inputs, "userType"),
+		"Two valid user types must be offered for selection")
+
+	step, err = common.CompleteFlow(step.ExecutionID,
+		map[string]string{"userType": ts.childTypeName}, "action_usertype", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit the user type selection")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "The flow should move on to user details")
+
+	username := common.GenerateUniqueUsername("onboard_child")
+	completed, err := common.CompleteFlow(step.ExecutionID, map[string]string{
+		"username": username,
+		"email":    username + "@onboarding.test",
+	}, "action_details", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit user details")
+	ts.Require().Equal("COMPLETE", completed.FlowStatus, "Onboarding should provision the user")
+
+	user := ts.findOnboardedUser(username)
+	ts.Equal(ts.childOUID, user.OUID, "The user must be provisioned into the selected OU")
+	ts.Equal(ts.childTypeName, user.Type, "The selected user type must be the one applied")
+}
+
+// An OU id that does not exist is refused and the selection is asked for again, so a bad id cannot
+// carry the flow into provisioning.
+func (ts *UserOnboardingTestSuite) TestOnboarding_UnknownOURejected() {
+	step := ts.initiateOnboarding(nil)
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "Onboarding should pause to select an OU")
+
+	rejected, err := common.CompleteFlow(step.ExecutionID,
+		map[string]string{"ouId": "019ff000-0000-7000-8000-000000000000"}, "action_ou", step.ChallengeToken)
+	ts.Require().NoError(err, "An unknown OU should still return a flow step")
+	ts.Require().NotNil(rejected.Error, "An unknown OU must be reported as an error")
+	ts.Equal(errCodeOUNotFound, rejected.Error.Code, "An unknown OU must be refused as not found")
+	ts.True(common.HasInput(rejected.Data.Inputs, "ouId"),
+		"The OU selection must be requested again after a bad id")
+}
+
+// A user type outside the node's allowed list is refused even when it exists, because the node
+// property is the narrower of the two constraints.
+func (ts *UserOnboardingTestSuite) TestOnboarding_UserTypeOutsideAllowedListRejected() {
+	step := ts.initiateOnboarding(nil)
+	step, err := common.CompleteFlow(step.ExecutionID,
+		map[string]string{"ouId": ts.childOUID}, "action_ou", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit the OU selection")
+	ts.Require().True(common.HasInput(step.Data.Inputs, "userType"),
+		"Two valid user types must be offered for selection")
+
+	rejected, err := common.CompleteFlow(step.ExecutionID,
+		map[string]string{"userType": "not-an-allowed-type"}, "action_usertype", step.ChallengeToken)
+	ts.Require().NoError(err, "A disallowed user type should still return a flow step")
+	ts.Require().NotNil(rejected.Error, "A disallowed user type must be reported as an error")
+	ts.Equal(errCodeUserTypeNotAllowed, rejected.Error.Code,
+		"A user type outside the node's allowed list must be refused")
+}
+
+// A user type whose OU is not an ancestor of the selected OU is refused. Supplying both values at
+// initiation is what makes this reachable: the interactive path never offers the pairing, because
+// the type is filtered out of the prompt before the user can pick it.
+func (ts *UserOnboardingTestSuite) TestOnboarding_UserTypeNotValidForSelectedOURejected() {
+	step := ts.initiateOnboarding(map[string]string{
+		"ouId":     ts.rootOUID,
+		"userType": ts.childTypeName,
+	})
+	ts.Require().NotNil(step.Error, "A user type invalid for the selected OU must be reported")
+	ts.Equal(errCodeUserTypeNotValidForOU, step.Error.Code,
+		"A user type attached below the selected OU must be refused for it")
+}

--- a/tests/integration/flow/mgt/flow_inference_test.go
+++ b/tests/integration/flow/mgt/flow_inference_test.go
@@ -1,0 +1,511 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mgt
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// Registration-flow inference is off by default, so it needs the deployment flag enabled and a
+// restart before any of it runs. It lives in its own suite rather than the main flow management
+// suite so the restart is paid once and cannot disturb the other tests.
+type FlowInferenceTestSuite struct {
+	suite.Suite
+	createdFlowIDs []string
+}
+
+func TestFlowInferenceTestSuite(t *testing.T) {
+	suite.Run(t, new(FlowInferenceTestSuite))
+}
+
+// PatchDeploymentConfig merges at the top level only, so a patch for one key inside "flow" replaces
+// the whole block. Both patches therefore restate max_version_history exactly as the integration
+// deployment sets it (tests/integration/resources/deployment.yaml); dropping it silently reverts the
+// limit to the product default and breaks the version-history tests in this same package.
+var inferenceEnablePatch = map[string]interface{}{
+	"flow": map[string]interface{}{
+		"max_version_history":     3,
+		"auto_infer_registration": true,
+	},
+}
+
+var inferenceDisablePatch = map[string]interface{}{
+	"flow": map[string]interface{}{
+		"max_version_history":     3,
+		"auto_infer_registration": false,
+	},
+}
+
+func (suite *FlowInferenceTestSuite) SetupSuite() {
+	suite.Require().NoError(testutils.PatchDeploymentConfig(inferenceEnablePatch),
+		"failed to enable registration flow inference")
+	suite.Require().NoError(testutils.RestartServer(),
+		"failed to restart server with inference enabled")
+	suite.Require().NoError(testutils.ObtainAdminAccessToken(),
+		"failed to re-obtain admin token after restart")
+}
+
+func (suite *FlowInferenceTestSuite) TearDownSuite() {
+	for _, flowID := range suite.createdFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			suite.T().Logf("teardown: failed to delete flow %s: %v", flowID, err)
+		}
+	}
+
+	if err := testutils.PatchDeploymentConfig(inferenceDisablePatch); err != nil {
+		suite.T().Logf("teardown: failed to restore inference config: %v", err)
+	}
+	if err := testutils.RestartServer(); err != nil {
+		suite.T().Logf("teardown: server did not restart cleanly after config restore: %v", err)
+	}
+	if err := testutils.ObtainAdminAccessToken(); err != nil {
+		suite.T().Logf("teardown: failed to re-obtain admin token after restore: %v", err)
+	}
+}
+
+// listFlowsByType returns every flow of the given type, walking pages so a newly inferred flow is
+// found regardless of how many already exist.
+func (suite *FlowInferenceTestSuite) listFlowsByType(flowType string) []BasicFlowDefinition {
+	var all []BasicFlowDefinition
+
+	for offset := 0; ; offset += 100 {
+		url := testServerURL + flowsEndpoint + "?flowType=" + flowType +
+			"&limit=100&offset=" + strconv.Itoa(offset)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		suite.Require().NoError(err)
+
+		resp, err := testutils.GetHTTPClient().Do(req)
+		suite.Require().NoError(err)
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		suite.Require().NoError(err)
+		suite.Require().Equal(http.StatusOK, resp.StatusCode, "failed to list flows: %s", string(body))
+
+		var listed FlowListResponse
+		suite.Require().NoError(json.Unmarshal(body, &listed))
+
+		all = append(all, listed.Flows...)
+		if len(listed.Flows) < 100 {
+			return all
+		}
+	}
+}
+
+// createFlow posts a flow definition and returns the created flow.
+func (suite *FlowInferenceTestSuite) createFlow(flowDef FlowDefinition) *CompleteFlowDefinition {
+	body, err := json.Marshal(flowDef)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest(http.MethodPost, testServerURL+flowsEndpoint, bytes.NewBuffer(body))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+	suite.Require().Equal(http.StatusCreated, resp.StatusCode, "failed to create flow: %s", string(bodyBytes))
+
+	var response CompleteFlowDefinition
+	suite.Require().NoError(json.Unmarshal(bodyBytes, &response))
+	return &response
+}
+
+// getFlow reads a flow by id.
+func (suite *FlowInferenceTestSuite) getFlow(flowID string) *CompleteFlowDefinition {
+	req, err := http.NewRequest(http.MethodGet, testServerURL+flowsEndpoint+"/"+flowID, nil)
+	suite.Require().NoError(err)
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+	suite.Require().Equal(http.StatusOK, resp.StatusCode, "failed to read flow: %s", string(bodyBytes))
+
+	var response CompleteFlowDefinition
+	suite.Require().NoError(json.Unmarshal(bodyBytes, &response))
+	return &response
+}
+
+// Creating an authentication flow with inference enabled also creates a registration flow derived
+// from it, named by substituting the authentication term. This is what lets an application offer
+// sign-up without an operator authoring a second flow by hand.
+func (suite *FlowInferenceTestSuite) TestCreateAuthFlow_InfersRegistrationFlow() {
+	before := len(suite.listFlowsByType("REGISTRATION"))
+
+	authFlow := cloneFlowWithUniqueHandle(testAuthFlow)
+	authFlow.Name = "Inference Probe Authentication Flow"
+	created := suite.createFlow(authFlow)
+	suite.createdFlowIDs = append(suite.createdFlowIDs, created.ID)
+
+	after := suite.listFlowsByType("REGISTRATION")
+	suite.Greater(len(after), before, "creating an authentication flow should infer a registration flow")
+
+	found := false
+	for _, flow := range after {
+		if strings.Contains(flow.Name, "Inference Probe") {
+			found = true
+			suite.Equal("REGISTRATION", flow.FlowType)
+			suite.Contains(flow.Name, "Registration",
+				"the inferred flow should be renamed from Authentication to Registration")
+			suite.createdFlowIDs = append(suite.createdFlowIDs, flow.ID)
+		}
+	}
+	suite.True(found, "expected a registration flow inferred from the probe authentication flow")
+}
+
+// The inferred flow is a registration flow in its own right, so it must carry the provisioning node
+// that turns collected credentials into a user. Without it the inferred flow would complete without
+// creating anything.
+func (suite *FlowInferenceTestSuite) TestInferredRegistrationFlow_ContainsProvisioningNode() {
+	authFlow := cloneFlowWithUniqueHandle(testAuthFlow)
+	authFlow.Name = "Provisioning Probe Signin Flow"
+	created := suite.createFlow(authFlow)
+	suite.createdFlowIDs = append(suite.createdFlowIDs, created.ID)
+
+	var inferredID string
+	for _, flow := range suite.listFlowsByType("REGISTRATION") {
+		if strings.Contains(flow.Name, "Provisioning Probe") {
+			inferredID = flow.ID
+			suite.createdFlowIDs = append(suite.createdFlowIDs, flow.ID)
+		}
+	}
+	suite.Require().NotEmpty(inferredID, "expected a registration flow inferred from the probe flow")
+
+	inferred := suite.getFlow(inferredID)
+
+	hasProvisioning := false
+	for _, node := range inferred.Nodes {
+		if node.Executor != nil && node.Executor.Name == "ProvisioningExecutor" {
+			hasProvisioning = true
+		}
+	}
+	suite.True(hasProvisioning, "an inferred registration flow must provision the user it registers")
+}
+
+// Inference only applies to authentication flows. Creating a registration flow directly must not
+// produce a further flow derived from it.
+func (suite *FlowInferenceTestSuite) TestCreateNonAuthFlow_DoesNotInfer() {
+	before := len(suite.listFlowsByType("REGISTRATION"))
+
+	regFlow := cloneFlowWithUniqueHandle(testAuthFlow)
+	regFlow.Name = "Non Auth Probe Flow"
+	regFlow.FlowType = "REGISTRATION"
+	// A registration flow must resolve a user type and provision the user it registers, so the cloned
+	// authentication nodes need both executors before the flow is accepted.
+	regFlow.Nodes = withRegistrationExecutors(regFlow.Nodes)
+
+	created := suite.createFlow(regFlow)
+	suite.createdFlowIDs = append(suite.createdFlowIDs, created.ID)
+
+	after := suite.listFlowsByType("REGISTRATION")
+	suite.Equal(before+1, len(after),
+		"creating a registration flow should add exactly one flow, with nothing inferred from it")
+}
+
+// Flow validation requires each flow type to carry the executor that makes it meaningful, so a
+// registration flow without a provisioning step is rejected rather than stored and left to fail at
+// execution time.
+func (suite *FlowInferenceTestSuite) TestCreateRegistrationFlow_RequiresProvisioningExecutor() {
+	regFlow := cloneFlowWithUniqueHandle(testAuthFlow)
+	regFlow.Name = "Missing Provisioning Probe Flow"
+	regFlow.FlowType = "REGISTRATION"
+
+	body, err := json.Marshal(regFlow)
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest(http.MethodPost, testServerURL+flowsEndpoint, bytes.NewBuffer(body))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+	suite.Equal(http.StatusBadRequest, resp.StatusCode,
+		"a registration flow without a provisioning executor must be rejected: %s", string(bodyBytes))
+
+	var errResp ErrorResponse
+	suite.Require().NoError(json.Unmarshal(bodyBytes, &errResp))
+	suite.Equal("FLM-1023", errResp.Code)
+}
+
+// smsAuthFlowNodes builds an SMS OTP authentication flow whose identify prompt carries authentication
+// specific UI: a sign-in heading and a self sign-up link, both of which inference has to rewrite.
+func smsAuthFlowNodes() []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"id":        "start",
+			"type":      "START",
+			"onSuccess": "prompt_identify",
+		},
+		{
+			"id":   "prompt_identify",
+			"type": "PROMPT",
+			"meta": map[string]interface{}{
+				"components": []map[string]interface{}{
+					{
+						"type":    "TEXT",
+						"id":      "heading_001",
+						"label":   "Sign In to Continue",
+						"variant": "HEADING_1",
+					},
+					{
+						"type": "BLOCK",
+						"id":   "block_001",
+						"components": []map[string]interface{}{
+							{
+								"type":     "TEXT_INPUT",
+								"id":       "input_001",
+								"label":    "Username",
+								"required": true,
+							},
+							{
+								"type":  "ACTION",
+								"id":    "action_001",
+								"label": "Continue",
+							},
+							{
+								"type":  "RICH_TEXT",
+								"id":    "signup_link_001",
+								"label": `<a data-component-ref="self-sign-up-link" href="#">Create an account</a>`,
+							},
+						},
+					},
+				},
+			},
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_001",
+							"identifier": "username",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_001",
+						"nextNode": "generate_otp",
+					},
+				},
+			},
+		},
+		{
+			"id":   "generate_otp",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "OTPExecutor",
+				"mode": "generate",
+				"inputs": []map[string]interface{}{
+					{
+						"ref":        "input_mobile",
+						"identifier": "mobile_number",
+						"type":       "PHONE_INPUT",
+						"required":   true,
+					},
+				},
+			},
+			"onSuccess": "prompt_otp",
+		},
+		{
+			"id":   "prompt_otp",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_002",
+							"identifier": "otp",
+							"type":       "OTP_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_002",
+						"nextNode": "verify_otp",
+					},
+				},
+			},
+		},
+		{
+			"id":   "verify_otp",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "OTPExecutor",
+				"mode": "verify",
+			},
+			"onSuccess": "auth_assert",
+		},
+		{
+			"id":   "auth_assert",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "AuthAssertExecutor",
+			},
+			"onSuccess": "end",
+		},
+		{
+			"id":   "end",
+			"type": "END",
+		},
+	}
+}
+
+// createRawFlow creates a flow from a raw definition, which the inference fixtures need because they
+// use node shapes (executor modes and inputs, prompt meta) that the typed test model does not carry.
+func (suite *FlowInferenceTestSuite) createRawFlow(name, handle string,
+	nodes []map[string]interface{}) string {
+	flowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     name,
+		FlowType: "AUTHENTICATION",
+		Handle:   handle,
+		Nodes:    nodes,
+	})
+	suite.Require().NoError(err, "failed to create flow %s", handle)
+	suite.createdFlowIDs = append(suite.createdFlowIDs, flowID)
+	return flowID
+}
+
+// getRawFlow reads a flow as generic JSON so prompt and meta contents can be walked.
+func (suite *FlowInferenceTestSuite) getRawFlow(flowID string) map[string]interface{} {
+	req, err := http.NewRequest(http.MethodGet, testServerURL+flowsEndpoint+"/"+flowID, nil)
+	suite.Require().NoError(err)
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+	suite.Require().Equal(http.StatusOK, resp.StatusCode, "failed to read flow: %s", string(bodyBytes))
+
+	var flow map[string]interface{}
+	suite.Require().NoError(json.Unmarshal(bodyBytes, &flow))
+	return flow
+}
+
+// inferredFlowIDFor returns the id of the registration flow inferred from the named authentication
+// flow, tracking it for cleanup.
+func (suite *FlowInferenceTestSuite) inferredFlowIDFor(namePart string) string {
+	for _, flow := range suite.listFlowsByType("REGISTRATION") {
+		if strings.Contains(flow.Name, namePart) {
+			suite.createdFlowIDs = append(suite.createdFlowIDs, flow.ID)
+			return flow.ID
+		}
+	}
+	return ""
+}
+
+// nodesOf returns the node list of a raw flow.
+func nodesOf(flow map[string]interface{}) []interface{} {
+	nodes, ok := flow["nodes"].([]interface{})
+	if !ok {
+		return nil
+	}
+	return nodes
+}
+
+// flowMetaJSON returns the concatenated meta of every node, as JSON text, so label rewrites and
+// component removals can be asserted without walking the whole component tree.
+func flowMetaJSON(suite *FlowInferenceTestSuite, flow map[string]interface{}) string {
+	var builder strings.Builder
+	for _, raw := range nodesOf(flow) {
+		node, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		meta, ok := node["meta"]
+		if !ok {
+			continue
+		}
+		encoded, err := json.Marshal(meta)
+		suite.Require().NoError(err)
+		builder.Write(encoded)
+	}
+	return builder.String()
+}
+
+// The inferred flow carries the source flow's UI, so its authentication wording and its links back to
+// sign-up have to be rewritten: a sign-in heading becomes a sign-up heading, and the self sign-up link
+// is dropped because the inferred flow is the sign-up.
+func (suite *FlowInferenceTestSuite) TestInferredRegistrationFlow_RewritesPromptMeta() {
+	authID := suite.createRawFlow("Meta Probe Authentication Flow",
+		"auth_flow_inference_meta_probe", smsAuthFlowNodes())
+	suite.Require().NotEmpty(authID)
+
+	inferredID := suite.inferredFlowIDFor("Meta Probe")
+	suite.Require().NotEmpty(inferredID, "expected a registration flow inferred from the meta probe flow")
+
+	meta := flowMetaJSON(suite, suite.getRawFlow(inferredID))
+	suite.Require().NotEmpty(meta, "the inferred flow should carry the source flow's prompt meta")
+
+	suite.Contains(meta, "Sign Up to Continue",
+		"an authentication heading must be rewritten to its registration equivalent")
+	suite.NotContains(meta, "Sign In to Continue",
+		"the authentication heading must not survive in the inferred flow")
+	suite.NotContains(meta, "self-sign-up-link",
+		"a self sign-up link is meaningless inside the inferred sign-up flow")
+}
+
+// withRegistrationExecutors inserts the executors a registration flow must carry, ahead of the END
+// node, producing a definition that satisfies flow-type validation. Registration requires both a
+// user type resolver and a provisioning step (see requiredExecutorsByFlowType in the validator).
+func withRegistrationExecutors(nodes []NodeDefinition) []NodeDefinition {
+	const (
+		resolverID  = "resolve_user_type"
+		provisionID = "provision_user"
+	)
+
+	out := make([]NodeDefinition, 0, len(nodes)+2)
+	for _, node := range nodes {
+		if node.Type == "END" {
+			out = append(out,
+				NodeDefinition{
+					ID:        resolverID,
+					Type:      "TASK_EXECUTION",
+					Executor:  &ExecutorDefinition{Name: "UserTypeResolver"},
+					OnSuccess: provisionID,
+				},
+				NodeDefinition{
+					ID:        provisionID,
+					Type:      "TASK_EXECUTION",
+					Executor:  &ExecutorDefinition{Name: "ProvisioningExecutor"},
+					OnSuccess: node.ID,
+				},
+				node,
+			)
+			continue
+		}
+		if node.OnSuccess != "" && isEndNode(nodes, node.OnSuccess) {
+			node.OnSuccess = resolverID
+		}
+		out = append(out, node)
+	}
+	return out
+}
+
+func isEndNode(nodes []NodeDefinition, id string) bool {
+	for _, node := range nodes {
+		if node.ID == id && node.Type == "END" {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/integration/flow/mgt/flow_usages_test.go
+++ b/tests/integration/flow/mgt/flow_usages_test.go
@@ -1,0 +1,138 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mgt
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// ResourceDependency is one resource reported as referencing the flow.
+type ResourceDependency struct {
+	ResourceType     string `json:"resourceType"`
+	ID               string `json:"id"`
+	DisplayName      string `json:"displayName"`
+	BehaviorOnDelete string `json:"behaviorOnDelete"`
+}
+
+// FlowUsagesResponse is the body of GET /flows/{flowId}/usages.
+//
+// TotalResults and Summary are pointers/maps that stay nil when dependency data is unavailable,
+// which the API distinguishes from a confirmed-empty result, so the tests assert on them directly
+// rather than through a zero value.
+type FlowUsagesResponse struct {
+	TotalResults *int                 `json:"totalResults"`
+	Count        int                  `json:"count"`
+	Summary      map[string]int       `json:"summary"`
+	Usages       []ResourceDependency `json:"usages"`
+}
+
+var usagesTestOU = testutils.OrganizationUnit{
+	Handle:      "flow_usages_test_ou",
+	Name:        "Test OU for Flow Usages",
+	Description: "Organization unit created for flow usages testing",
+	Parent:      nil,
+}
+
+func (suite *FlowMgtAPITestSuite) getFlowUsages(flowID string) *FlowUsagesResponse {
+	req, _ := http.NewRequest(http.MethodGet, testServerURL+flowsEndpoint+"/"+flowID+"/usages", nil)
+
+	client := testutils.GetHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	suite.Require().Equal(http.StatusOK, resp.StatusCode, "unexpected usages response: %s", string(bodyBytes))
+
+	var response FlowUsagesResponse
+	suite.Require().NoError(json.Unmarshal(bodyBytes, &response))
+
+	return &response
+}
+
+func (suite *FlowMgtAPITestSuite) getFlowUsagesExpectError(flowID string, expectedStatus int, expectedCode string) {
+	req, _ := http.NewRequest(http.MethodGet, testServerURL+flowsEndpoint+"/"+flowID+"/usages", nil)
+
+	client := testutils.GetHTTPClient()
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(expectedStatus, resp.StatusCode)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	var errorResp ErrorResponse
+	suite.Require().NoError(json.Unmarshal(bodyBytes, &errorResp))
+	suite.Equal(expectedCode, errorResp.Code)
+}
+
+// A flow nothing references reports a confirmed-empty result rather than unknown, so TotalResults
+// must be present and zero rather than nil.
+func (suite *FlowMgtAPITestSuite) TestGetFlowUsages_UnreferencedFlow() {
+	createdFlow := suite.createFlow(cloneFlowWithUniqueHandle(testAuthFlow))
+	suite.trackFlow(createdFlow.ID)
+
+	response := suite.getFlowUsages(createdFlow.ID)
+
+	suite.Equal(0, response.Count)
+	suite.Empty(response.Usages)
+	if suite.NotNil(response.TotalResults, "an unreferenced flow should report a known total") {
+		suite.Equal(0, *response.TotalResults)
+	}
+}
+
+// An application bound to the flow must appear as a usage, which is what the Console relies on to
+// warn before a flow is deleted.
+func (suite *FlowMgtAPITestSuite) TestGetFlowUsages_ReportsBoundApplication() {
+	createdFlow := suite.createFlow(cloneFlowWithUniqueHandle(testAuthFlow))
+	suite.trackFlow(createdFlow.ID)
+
+	ouID, err := testutils.CreateOrganizationUnit(usagesTestOU)
+	suite.Require().NoError(err, "Failed to create test organization unit")
+	defer func() {
+		if err := testutils.DeleteOrganizationUnit(ouID); err != nil {
+			suite.T().Logf("Failed to delete organization unit during cleanup: %v", err)
+		}
+	}()
+
+	app := testutils.Application{
+		Name:         "Flow Usages Test Application",
+		Description:  "Application bound to the flow under test",
+		ClientID:     "flow_usages_test_client",
+		ClientSecret: "flow_usages_test_secret",
+		RedirectURIs: []string{"http://localhost:3000/callback"},
+		OUID:         ouID,
+		AuthFlowID:   createdFlow.ID,
+	}
+	appID, err := testutils.CreateApplication(app)
+	suite.Require().NoError(err, "Failed to create test application")
+	defer func() {
+		if err := testutils.DeleteApplication(appID); err != nil {
+			suite.T().Logf("Failed to delete application during cleanup: %v", err)
+		}
+	}()
+
+	response := suite.getFlowUsages(createdFlow.ID)
+
+	suite.GreaterOrEqual(response.Count, 1, "the bound application should be reported as a usage")
+
+	found := false
+	for _, usage := range response.Usages {
+		if usage.ID == appID {
+			found = true
+			suite.Equal("application", usage.ResourceType)
+			suite.NotEmpty(usage.DisplayName, "a usage should carry a display name for the Console")
+			suite.NotEmpty(usage.BehaviorOnDelete, "a usage should state what happens on delete")
+		}
+	}
+	suite.True(found, "expected application %s in the reported usages", appID)
+}
+
+func (suite *FlowMgtAPITestSuite) TestGetFlowUsages_NotFound() {
+	suite.getFlowUsagesExpectError("non-existent-id", http.StatusNotFound, "FLM-1003")
+}

--- a/tests/integration/flow/registration/ou_resolver_strategies_test.go
+++ b/tests/integration/flow/registration/ou_resolver_strategies_test.go
@@ -1,0 +1,392 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package registration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	errCodeOUResolutionFailed    = "FET-1034"
+	errCodeOUNotValidForUserType = "FET-1075"
+)
+
+// ouStrategyFlowNodes builds a registration flow that resolves the user type, then the OU with the
+// given strategy, then provisions the user. The strategy is the only thing that varies between the
+// flows this suite creates.
+func ouStrategyFlowNodes(resolveFrom string) []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"id":        "start",
+			"type":      "START",
+			"onSuccess": "user_type_resolver",
+		},
+		{
+			"id":   "user_type_resolver",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "UserTypeResolver",
+			},
+			"onSuccess": "ou_resolver",
+		},
+		{
+			"id":   "ou_resolver",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "OUResolverExecutor",
+			},
+			"properties": map[string]interface{}{
+				"resolveFrom": resolveFrom,
+			},
+			"onSuccess":    "provisioning",
+			"onIncomplete": "prompt_ou",
+		},
+		{
+			"id":   "prompt_ou",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "ou_selection_input",
+							"identifier": "ouId",
+							"type":       "OU_SELECT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_ou",
+						"nextNode": "ou_resolver",
+					},
+				},
+			},
+		},
+		{
+			"id":   "provisioning",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "ProvisioningExecutor",
+				"inputs": []map[string]interface{}{
+					{
+						"ref":        "input_username",
+						"identifier": "username",
+						"type":       "TEXT_INPUT",
+						"required":   true,
+					},
+					{
+						"ref":        "input_email",
+						"identifier": "email",
+						"type":       "TEXT_INPUT",
+						"required":   true,
+					},
+				},
+			},
+			"onSuccess":    "end",
+			"onIncomplete": "prompt_details",
+		},
+		{
+			"id":   "prompt_details",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{
+							"ref":        "input_username",
+							"identifier": "username",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+						{
+							"ref":        "input_email",
+							"identifier": "email",
+							"type":       "TEXT_INPUT",
+							"required":   true,
+						},
+					},
+					"action": map[string]interface{}{
+						"ref":      "action_details",
+						"nextNode": "provisioning",
+					},
+				},
+			},
+		},
+		{
+			"id":   "end",
+			"type": "END",
+		},
+	}
+}
+
+func ouStrategyUserType(name, ouID string) testutils.UserType {
+	return testutils.UserType{
+		Name:                  name,
+		OUID:                  ouID,
+		AllowSelfRegistration: true,
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{
+				"type": "string",
+			},
+			"email": map[string]interface{}{
+				"type": "string",
+			},
+		},
+	}
+}
+
+type OUResolverStrategiesTestSuite struct {
+	suite.Suite
+	config *common.TestSuiteConfig
+
+	parentOUID string
+	childOUID  string
+	otherOUID  string
+
+	parentTypeID   string
+	childTypeID    string
+	parentTypeName string
+	childTypeName  string
+
+	promptParentAppID string
+	promptChildAppID  string
+	callerAppID       string
+	unsupportedAppID  string
+
+	// An auth flow that references no registration flow, so binding these registration flows to an
+	// application does not collide with the default auth flow's own registration reference.
+	isolatedAuthFlowID string
+}
+
+func TestOUResolverStrategiesTestSuite(t *testing.T) {
+	suite.Run(t, new(OUResolverStrategiesTestSuite))
+}
+
+func (ts *OUResolverStrategiesTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+
+	parentOUID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "ou_strategy_parent_test_ou",
+		Name:        "OU Strategy Parent Test OU",
+		Description: "Parent organization unit for OU resolver strategy testing",
+		Parent:      nil,
+	})
+	ts.Require().NoError(err, "Failed to create parent organization unit")
+	ts.parentOUID = parentOUID
+
+	childOUID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "ou_strategy_child_test_ou",
+		Name:        "OU Strategy Child Test OU",
+		Description: "Child organization unit for OU resolver strategy testing",
+		Parent:      &parentOUID,
+	})
+	ts.Require().NoError(err, "Failed to create child organization unit")
+	ts.childOUID = childOUID
+
+	// A second root, outside the parent's subtree, so a selection can be rejected for being
+	// somewhere the user type does not reach.
+	otherOUID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "ou_strategy_other_test_ou",
+		Name:        "OU Strategy Other Test OU",
+		Description: "Unrelated organization unit for OU resolver strategy testing",
+		Parent:      nil,
+	})
+	ts.Require().NoError(err, "Failed to create unrelated organization unit")
+	ts.otherOUID = otherOUID
+
+	ts.parentTypeName = "ou-strategy-parent-person"
+	ts.childTypeName = "ou-strategy-child-person"
+
+	ts.parentTypeID, err = testutils.CreateUserType(ouStrategyUserType(ts.parentTypeName, parentOUID))
+	ts.Require().NoError(err, "Failed to create parent user type")
+
+	ts.childTypeID, err = testutils.CreateUserType(ouStrategyUserType(ts.childTypeName, childOUID))
+	ts.Require().NoError(err, "Failed to create child user type")
+
+	ts.isolatedAuthFlowID, err = testutils.CreateIsolatedAuthFlow("ou-strategy-isolated-auth")
+	ts.Require().NoError(err, "Failed to create isolated auth flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, ts.isolatedAuthFlowID)
+
+	promptFlowID := ts.createFlow("OU Resolver Prompt Flow", "registration_flow_ou_prompt_test", "prompt")
+	callerFlowID := ts.createFlow("OU Resolver Caller Flow", "registration_flow_ou_caller_test", "caller")
+	unsupportedFlowID := ts.createFlow("OU Resolver Unsupported Flow",
+		"registration_flow_ou_unsupported_test", "notAStrategy")
+
+	// The prompt flow is bound twice: once with a user type whose OU has children, and once with a
+	// user type whose OU has none, which is what decides whether a selection is asked for.
+	ts.promptParentAppID = ts.createApp("OU Strategy Prompt Parent App", "ou_strategy_prompt_parent_client",
+		promptFlowID, ts.parentTypeName)
+	ts.promptChildAppID = ts.createApp("OU Strategy Prompt Child App", "ou_strategy_prompt_child_client",
+		promptFlowID, ts.childTypeName)
+	ts.callerAppID = ts.createApp("OU Strategy Caller App", "ou_strategy_caller_client",
+		callerFlowID, ts.parentTypeName)
+	ts.unsupportedAppID = ts.createApp("OU Strategy Unsupported App", "ou_strategy_unsupported_client",
+		unsupportedFlowID, ts.parentTypeName)
+}
+
+func (ts *OUResolverStrategiesTestSuite) createFlow(name, handle, resolveFrom string) string {
+	ts.T().Helper()
+
+	flowID, err := testutils.CreateFlow(testutils.Flow{
+		Name:     name,
+		FlowType: "REGISTRATION",
+		Handle:   handle,
+		Nodes:    ouStrategyFlowNodes(resolveFrom),
+	})
+	ts.Require().NoError(err, "Failed to create flow %s", handle)
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
+	return flowID
+}
+
+func (ts *OUResolverStrategiesTestSuite) createApp(name, clientID, flowID, userType string) string {
+	ts.T().Helper()
+
+	appID, err := testutils.CreateApplication(testutils.Application{
+		Name:                      name,
+		Description:               "Application for OU resolver strategy testing",
+		ClientID:                  clientID,
+		ClientSecret:              clientID + "_secret",
+		RedirectURIs:              []string{"http://localhost:3000/callback"},
+		OUID:                      ts.parentOUID,
+		AllowedUserTypes:          []string{userType},
+		IsRegistrationFlowEnabled: true,
+		RegistrationFlowID:        flowID,
+		AuthFlowID:                ts.isolatedAuthFlowID,
+	})
+	ts.Require().NoError(err, "Failed to create application %s", name)
+	return appID
+}
+
+func (ts *OUResolverStrategiesTestSuite) TearDownSuite() {
+	for _, appID := range []string{
+		ts.promptParentAppID, ts.promptChildAppID, ts.callerAppID, ts.unsupportedAppID,
+	} {
+		if appID == "" {
+			continue
+		}
+		if err := testutils.DeleteApplication(appID); err != nil {
+			ts.T().Logf("Failed to delete test application during teardown: %v", err)
+		}
+	}
+	for _, userID := range ts.config.CreatedUserIDs {
+		if err := testutils.DeleteUser(userID); err != nil {
+			ts.T().Logf("Failed to delete registered user during teardown: %v", err)
+		}
+	}
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete test flow during teardown: %v", err)
+		}
+	}
+	for _, typeID := range []string{ts.childTypeID, ts.parentTypeID} {
+		if typeID == "" {
+			continue
+		}
+		if err := testutils.DeleteUserType(typeID); err != nil {
+			ts.T().Logf("Failed to delete test user type during teardown: %v", err)
+		}
+	}
+	for _, ouID := range []string{ts.childOUID, ts.parentOUID, ts.otherOUID} {
+		if ouID == "" {
+			continue
+		}
+		if err := testutils.DeleteOrganizationUnit(ouID); err != nil {
+			ts.T().Logf("Failed to delete test organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// trackRegisteredUser records a user created by a registration flow so teardown removes it.
+func (ts *OUResolverStrategiesTestSuite) trackRegisteredUser(username string) *testutils.User {
+	ts.T().Helper()
+
+	user, err := testutils.FindUserByAttribute("username", username)
+	ts.Require().NoError(err, "Failed to look up the registered user")
+	ts.Require().NotNil(user, "The registration flow should have created a user")
+	if user.ID != "" {
+		ts.config.CreatedUserIDs = append(ts.config.CreatedUserIDs, user.ID)
+	}
+	return user
+}
+
+// The prompt strategy asks for an OU only when the user type's OU has children, and the selection is
+// accepted when it sits inside that subtree. The user is then provisioned into the chosen OU rather
+// than the user type's own OU.
+func (ts *OUResolverStrategiesTestSuite) TestPrompt_DescendantOUSelected() {
+	step, err := common.InitiateRegistrationFlow(ts.promptParentAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate registration flow")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "The flow should pause for the OU selection")
+	ts.Require().True(common.HasInput(step.Data.Inputs, "ouId"),
+		"A user type whose OU has children must prompt for a selection")
+
+	step, err = common.CompleteFlow(step.ExecutionID,
+		map[string]string{"ouId": ts.childOUID}, "action_ou", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit the OU selection")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "The flow should move on to user details")
+	ts.Require().True(common.HasInput(step.Data.Inputs, "username"),
+		"The flow should collect user details after the OU is chosen")
+
+	username := common.GenerateUniqueUsername("ou_prompt")
+	completed, err := common.CompleteFlow(step.ExecutionID, map[string]string{
+		"username": username,
+		"email":    username + "@ou-strategy.test",
+	}, "action_details", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit user details")
+	ts.Require().Equal("COMPLETE", completed.FlowStatus, "Registration should provision the user")
+
+	user := ts.trackRegisteredUser(username)
+	ts.Equal(ts.childOUID, user.OUID, "The user must be provisioned into the selected OU")
+}
+
+// An OU outside the user type's subtree is refused and the selection is asked for again, so the
+// prompt cannot be used to place a user anywhere in the tree.
+func (ts *OUResolverStrategiesTestSuite) TestPrompt_OUOutsideSubtreeRejected() {
+	step, err := common.InitiateRegistrationFlow(ts.promptParentAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate registration flow")
+	ts.Require().True(common.HasInput(step.Data.Inputs, "ouId"), "The flow should prompt for an OU")
+
+	rejected, err := common.CompleteFlow(step.ExecutionID,
+		map[string]string{"ouId": ts.otherOUID}, "action_ou", step.ChallengeToken)
+	ts.Require().NoError(err, "An out-of-subtree OU should still return a flow step")
+	ts.Require().NotNil(rejected.Error, "An out-of-subtree OU must be reported as an error")
+	ts.Equal(errCodeOUNotValidForUserType, rejected.Error.Code,
+		"An OU outside the user type's subtree must be refused for that user type")
+	ts.True(common.HasInput(rejected.Data.Inputs, "ouId"),
+		"The OU selection must be requested again after a rejected choice")
+}
+
+// When the user type's OU has no children there is nothing to choose, so the strategy resolves
+// silently and the flow goes straight to collecting user details.
+func (ts *OUResolverStrategiesTestSuite) TestPrompt_NoChildOUsSkipsSelection() {
+	step, err := common.InitiateRegistrationFlow(ts.promptChildAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate registration flow")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "The flow should pause for user details")
+	ts.False(common.HasInput(step.Data.Inputs, "ouId"),
+		"An OU with no children must not be prompted for")
+	ts.True(common.HasInput(step.Data.Inputs, "username"),
+		"The flow should move straight on to user details")
+}
+
+// The caller strategy takes the OU from the caller's security context, so it cannot work on a
+// self-service registration flow where there is no authenticated caller. It fails rather than
+// falling back to a default OU.
+func (ts *OUResolverStrategiesTestSuite) TestCaller_WithoutCallerContextFails() {
+	step, err := common.InitiateRegistrationFlow(ts.callerAppID, false, nil, "")
+	ts.Require().NoError(err, "The flow should return a step rather than a transport error")
+	ts.Require().NotNil(step.Error, "An unresolvable caller OU must be reported")
+	ts.Equal(errCodeOUResolutionFailed, step.Error.Code,
+		"A missing caller OU must fail OU resolution")
+}
+
+// An unrecognized strategy fails the node instead of being ignored, so a typo in a flow definition
+// surfaces at execution rather than silently placing users in a default OU.
+func (ts *OUResolverStrategiesTestSuite) TestUnsupportedStrategy_Fails() {
+	step, err := common.InitiateRegistrationFlow(ts.unsupportedAppID, false, nil, "")
+	ts.Require().NoError(err, "The flow should return a step rather than a transport error")
+	ts.Require().NotNil(step.Error, "An unsupported strategy must be reported")
+	ts.Equal(errCodeOUResolutionFailed, step.Error.Code,
+		"An unsupported strategy must fail OU resolution")
+}

--- a/tests/integration/group/group_display_test.go
+++ b/tests/integration/group/group_display_test.go
@@ -1,0 +1,187 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package group
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+var displayTestOU = testutils.OrganizationUnit{
+	Handle:      "group-display-test-ou",
+	Name:        "Group Display Test OU",
+	Description: "Organization unit for the group display attribute tests",
+	Parent:      nil,
+}
+
+// GroupDisplayTestSuite covers the include=display variants of the group endpoints: the OU handle
+// resolved onto listed groups, and the display name resolved for an application member. Both are
+// skipped entirely when the caller does not ask for display attributes.
+type GroupDisplayTestSuite struct {
+	suite.Suite
+	client  *http.Client
+	ouID    string
+	appID   string
+	appName string
+	groupID string
+}
+
+func TestGroupDisplayTestSuite(t *testing.T) {
+	suite.Run(t, new(GroupDisplayTestSuite))
+}
+
+func (ts *GroupDisplayTestSuite) SetupSuite() {
+	ts.client = testutils.GetHTTPClient()
+
+	ouID, err := testutils.CreateOrganizationUnit(displayTestOU)
+	ts.Require().NoError(err, "Failed to create the test organization unit")
+	ts.ouID = ouID
+
+	ts.appName = "Group Display Member App"
+	appID, err := testutils.CreateApplication(testutils.Application{
+		Name:         ts.appName,
+		Description:  "Application that is a member of the display test group",
+		OUID:         ts.ouID,
+		ClientID:     "group_display_member_client",
+		ClientSecret: "group_display_member_secret",
+	})
+	ts.Require().NoError(err, "Failed to create the member application")
+	ts.appID = appID
+
+	groupID, err := createGroup(CreateGroupRequest{
+		Name:        "Group Display Test Group",
+		Description: "Group used by the display attribute tests",
+		OUID:        ts.ouID,
+		Members: []Member{
+			{Id: ts.appID, Type: MemberTypeApp},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create the test group")
+	ts.groupID = groupID
+}
+
+func (ts *GroupDisplayTestSuite) TearDownSuite() {
+	if ts.groupID != "" {
+		if err := deleteGroup(ts.groupID); err != nil {
+			ts.T().Logf("Failed to delete the test group during teardown: %v", err)
+		}
+	}
+	if ts.appID != "" {
+		if err := testutils.DeleteApplication(ts.appID); err != nil {
+			ts.T().Logf("Failed to delete the member application during teardown: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete the test organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// --- helpers ---
+
+func (ts *GroupDisplayTestSuite) get(path string) (int, []byte) {
+	req, err := http.NewRequest(http.MethodGet, testServerURL+path, nil)
+	ts.Require().NoError(err, "Failed to create the request for %s", path)
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err, "Failed to send the request for %s", path)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err, "Failed to read the response for %s", path)
+	return resp.StatusCode, body
+}
+
+func (ts *GroupDisplayTestSuite) listGroupsByOU(query string) *GroupListResponse {
+	path := fmt.Sprintf("/groups/tree/%s", displayTestOU.Handle)
+	if query != "" {
+		path += "?" + query
+	}
+	status, body := ts.get(path)
+	ts.Require().Equal(http.StatusOK, status, "Listing groups of an OU should return 200: %s", string(body))
+
+	var list GroupListResponse
+	ts.Require().NoError(json.Unmarshal(body, &list), "Failed to parse the group list: %s", string(body))
+	return &list
+}
+
+func (ts *GroupDisplayTestSuite) findGroup(list *GroupListResponse) *GroupBasic {
+	for i := range list.Groups {
+		if list.Groups[i].Id == ts.groupID {
+			return &list.Groups[i]
+		}
+	}
+	return nil
+}
+
+func (ts *GroupDisplayTestSuite) listMembers(query string) *MemberListResponse {
+	path := fmt.Sprintf("/groups/%s/members", ts.groupID)
+	if query != "" {
+		path += "?" + query
+	}
+	status, body := ts.get(path)
+	ts.Require().Equal(http.StatusOK, status, "Listing group members should return 200: %s", string(body))
+
+	var list MemberListResponse
+	ts.Require().NoError(json.Unmarshal(body, &list), "Failed to parse the member list: %s", string(body))
+	return &list
+}
+
+// --- tests ---
+
+// TestGroupListByOUResolvesOUHandleWithDisplay asserts that the OU handle of a listed group is only
+// resolved when display attributes are requested.
+func (ts *GroupDisplayTestSuite) TestGroupListByOUResolvesOUHandleWithDisplay() {
+	plain := ts.findGroup(ts.listGroupsByOU(""))
+	ts.Require().NotNil(plain, "The test group must be listed under its organization unit")
+	ts.Equal(ts.ouID, plain.OUID, "The listed group must report its organization unit id")
+	ts.Empty(plain.OUHandle, "The OU handle must not be resolved without include=display")
+
+	withDisplay := ts.findGroup(ts.listGroupsByOU("include=display"))
+	ts.Require().NotNil(withDisplay, "The test group must be listed with display attributes")
+	ts.Equal(displayTestOU.Handle, withDisplay.OUHandle,
+		"include=display must resolve the handle of the group's organization unit")
+}
+
+// TestGroupListResolvesOUHandleWithDisplay asserts the same resolution on the global group list. The
+// assertion is scoped to the groups the page happens to contain, because the list is shared with
+// every other suite that created a group.
+func (ts *GroupDisplayTestSuite) TestGroupListResolvesOUHandleWithDisplay() {
+	status, body := ts.get("/groups?include=display&limit=100")
+	ts.Require().Equal(http.StatusOK, status, "Listing groups should return 200: %s", string(body))
+
+	var list GroupListResponse
+	ts.Require().NoError(json.Unmarshal(body, &list), "Failed to parse the group list: %s", string(body))
+	ts.Require().NotEmpty(list.Groups, "The group list must not be empty while this suite's group exists")
+
+	for _, group := range list.Groups {
+		if group.OUID != "" {
+			ts.NotEmpty(group.OUHandle,
+				"include=display must resolve the OU handle of every listed group with an OU")
+		}
+	}
+}
+
+// TestGroupMembersResolveApplicationDisplay asserts that an application member's display name is
+// resolved from the application's name, and only when display attributes are requested.
+func (ts *GroupDisplayTestSuite) TestGroupMembersResolveApplicationDisplay() {
+	plain := ts.listMembers("")
+	ts.Require().Len(plain.Members, 1, "The group must have exactly the application member it was created with")
+	ts.Equal(ts.appID, plain.Members[0].Id, "The member must be the application")
+	ts.Equal(MemberTypeApp, plain.Members[0].Type, "An application member is reported with the app type")
+	ts.Empty(plain.Members[0].Display, "The display name must not be resolved without include=display")
+
+	withDisplay := ts.listMembers("include=display")
+	ts.Require().Len(withDisplay.Members, 1, "The member list must be unchanged by requesting display attributes")
+	ts.Equal(ts.appName, withDisplay.Members[0].Display,
+		"include=display must resolve an application member's display name from its name")
+}

--- a/tests/integration/group/model.go
+++ b/tests/integration/group/model.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The ThunderID Authors
+// Copyright 2025-2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package group
@@ -39,12 +39,15 @@ type MemberType string
 const (
 	MemberTypeUser  MemberType = "user"
 	MemberTypeGroup MemberType = "group"
+	MemberTypeApp   MemberType = "app"
 )
 
-// Member represents a member of a group (either user or another group).
+// Member represents a member of a group (a user, an application, or another group).
 type Member struct {
 	Id   string     `json:"id"`
 	Type MemberType `json:"type"`
+	// Display is only populated when the request asks for display attributes with include=display.
+	Display string `json:"display,omitempty"`
 }
 
 // GroupBasic represents the basic information of a group.
@@ -53,6 +56,8 @@ type GroupBasic struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
 	OUID        string `json:"ouId"`
+	// OUHandle is only populated when the request asks for display attributes with include=display.
+	OUHandle string `json:"ouHandle,omitempty"`
 }
 
 // Group represents a complete group with members.

--- a/tests/integration/importexport/import_delete_test.go
+++ b/tests/integration/importexport/import_delete_test.go
@@ -1,0 +1,186 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package importexport
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// ImportDeleteSuite covers the success path of POST /import/delete, which removes a declarative
+// resource file from the server's configuration directory. The error branches are covered by
+// ImportExportErrorSuite; this suite is the one that actually deletes a file.
+//
+// The fixture file is written directly into config/resources/themes rather than through the import
+// API, because POST /import rejects the file target: writing declarative files is not an API
+// operation, only removing them is. Declarative resources are read once at startup with no watcher,
+// so adding a file mid-run affects nothing already loaded, and the delete under test removes it
+// again. The file carries a handle of this suite's own so the shipped declarative theme is never a
+// candidate match.
+type ImportDeleteSuite struct {
+	suite.Suite
+	client *http.Client
+
+	themesDir    string
+	fixturePath  string
+	fixtureExtra string
+}
+
+const (
+	// importDeleteThemeID is the id of the throwaway declarative theme the suite plants and deletes.
+	importDeleteThemeID = "import-delete-fixture-theme"
+
+	// importDeleteExtraThemeID lives in a second file that must survive the delete, so the scan is
+	// shown to remove only the matching document's file.
+	importDeleteExtraThemeID = "import-delete-bystander-theme"
+)
+
+func TestImportDeleteSuite(t *testing.T) {
+	suite.Run(t, new(ImportDeleteSuite))
+}
+
+func (suite *ImportDeleteSuite) SetupSuite() {
+	suite.client = testutils.GetHTTPClient()
+
+	suite.themesDir = filepath.Join(testutils.GetExtractedProductHome(), "config", "resources", "themes")
+	suite.Require().DirExists(suite.themesDir,
+		"the declarative themes directory must exist for the delete to have a target")
+
+	suite.fixturePath = filepath.Join(suite.themesDir, importDeleteThemeID+".yaml")
+	suite.fixtureExtra = filepath.Join(suite.themesDir, importDeleteExtraThemeID+".yaml")
+}
+
+// SetupTest re-plants both files so each test starts from the same on-disk state.
+func (suite *ImportDeleteSuite) SetupTest() {
+	suite.writeThemeFile(suite.fixturePath, importDeleteThemeID, "Import Delete Fixture Theme")
+	suite.writeThemeFile(suite.fixtureExtra, importDeleteExtraThemeID, "Import Delete Bystander Theme")
+}
+
+func (suite *ImportDeleteSuite) TearDownSuite() {
+	for _, path := range []string{suite.fixturePath, suite.fixtureExtra} {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			suite.T().Logf("Failed to remove the fixture file %s: %v", path, err)
+		}
+	}
+}
+
+// writeThemeFile plants a declarative theme document on disk.
+func (suite *ImportDeleteSuite) writeThemeFile(path, id, displayName string) {
+	suite.T().Helper()
+
+	content := "resource_type: theme\n" +
+		"id: " + id + "\n" +
+		"displayName: " + displayName + "\n" +
+		"description: Planted by the import delete integration test\n" +
+		"theme:\n" +
+		"  primaryColor: \"#123456\"\n"
+
+	suite.Require().NoError(os.WriteFile(path, []byte(content), 0o600))
+}
+
+// deleteResource posts an /import/delete request and returns the status with the raw body.
+func (suite *ImportDeleteSuite) deleteResource(resourceType, resourceKey string) (int, []byte) {
+	suite.T().Helper()
+
+	body, err := json.Marshal(map[string]string{
+		"resourceType": resourceType,
+		"resourceKey":  resourceKey,
+	})
+	suite.Require().NoError(err)
+
+	req, err := http.NewRequest(http.MethodPost,
+		testutils.TestServerURL+"/import/delete", bytes.NewReader(body))
+	suite.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := suite.client.Do(req)
+	suite.Require().NoError(err)
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			suite.T().Logf("Failed to close response body: %v", closeErr)
+		}
+	}()
+
+	respBody, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+	return resp.StatusCode, respBody
+}
+
+// deleteResponse mirrors the DeleteResourceResponse payload.
+type deleteResponse struct {
+	ResourceType string `json:"resourceType"`
+	ResourceKey  string `json:"resourceKey"`
+	DeletedFile  string `json:"deletedFile"`
+}
+
+// TestDeleteByIDRemovesTheFile verifies the matching file is removed from disk and reported back by
+// name, which is what tells the caller which file was actually acted on.
+func (suite *ImportDeleteSuite) TestDeleteByIDRemovesTheFile() {
+	status, body := suite.deleteResource("theme", importDeleteThemeID)
+	suite.Require().Equalf(http.StatusOK, status, "unexpected status, body: %s", body)
+
+	var resp deleteResponse
+	suite.Require().NoError(json.Unmarshal(body, &resp))
+	suite.Equal("theme", resp.ResourceType)
+	suite.Equal(importDeleteThemeID, resp.ResourceKey)
+	suite.Equal(importDeleteThemeID+".yaml", resp.DeletedFile)
+
+	suite.NoFileExists(suite.fixturePath, "the matching file must be gone from disk")
+	suite.FileExists(suite.fixtureExtra,
+		"a non-matching file in the same directory must be left alone")
+}
+
+// TestDeleteByDisplayNameRemovesTheFile verifies the resource key is matched against the document's
+// name as well as its id, so a caller need not know the generated identifier.
+func (suite *ImportDeleteSuite) TestDeleteByDisplayNameRemovesTheFile() {
+	status, body := suite.deleteResource("theme", "Import Delete Fixture Theme")
+	suite.Require().Equalf(http.StatusOK, status, "unexpected status, body: %s", body)
+
+	var resp deleteResponse
+	suite.Require().NoError(json.Unmarshal(body, &resp))
+	suite.Equal(importDeleteThemeID+".yaml", resp.DeletedFile)
+
+	suite.NoFileExists(suite.fixturePath)
+}
+
+// TestDeleteIsNotIdempotent verifies a second delete of the same key is refused rather than
+// answering 200 for a file that is no longer there, so a caller cannot read success as confirmation
+// that a resource it never planted has been removed.
+func (suite *ImportDeleteSuite) TestDeleteIsNotIdempotent() {
+	status, _ := suite.deleteResource("theme", importDeleteThemeID)
+	suite.Require().Equal(http.StatusOK, status)
+
+	status, body := suite.deleteResource("theme", importDeleteThemeID)
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("IMP-1001", suite.errorCodeOf(body))
+}
+
+// TestDeleteDoesNotMatchAnotherResourceType verifies the resource type is part of the match: a theme
+// key must not delete a file whose documents are of a different type.
+func (suite *ImportDeleteSuite) TestDeleteDoesNotMatchAnotherResourceType() {
+	status, body := suite.deleteResource("layout", importDeleteThemeID)
+
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("IMP-1001", suite.errorCodeOf(body))
+	suite.FileExists(suite.fixturePath, "a type mismatch must not delete the theme file")
+}
+
+// errorCodeOf decodes the error code from an API error response body.
+func (suite *ImportDeleteSuite) errorCodeOf(body []byte) string {
+	suite.T().Helper()
+
+	var errResp struct {
+		Code string `json:"code"`
+	}
+	suite.Require().NoError(json.Unmarshal(body, &errResp), "body: %s", body)
+	return errResp.Code
+}

--- a/tests/integration/oauth/authz/prompt_parameter_test.go
+++ b/tests/integration/oauth/authz/prompt_parameter_test.go
@@ -1,0 +1,245 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authz
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	promptClientID    = "authz_prompt_test_client"
+	promptRedirectURI = "https://localhost:3000/prompt-callback"
+)
+
+var promptTestOU = testutils.OrganizationUnit{
+	Handle:      "oauth2-prompt-test-ou",
+	Name:        "OAuth2 Prompt Test OU",
+	Description: "Organization unit for the OIDC prompt parameter tests",
+	Parent:      nil,
+}
+
+// PromptParameterTestSuite covers the OIDC prompt parameter contract of the authorization endpoint
+// (OIDC Core 3.1.2.1). Rejections arrive as error redirects to the client's redirect URI, so each
+// case asserts the error code carried in that redirect.
+type PromptParameterTestSuite struct {
+	suite.Suite
+	client        *http.Client
+	ouID          string
+	applicationID string
+}
+
+func TestPromptParameterTestSuite(t *testing.T) {
+	suite.Run(t, new(PromptParameterTestSuite))
+}
+
+func (ts *PromptParameterTestSuite) SetupSuite() {
+	ts.client = testutils.GetHTTPClient()
+
+	ouID, err := testutils.CreateOrganizationUnit(promptTestOU)
+	ts.Require().NoError(err, "Failed to create the test organization unit")
+	ts.ouID = ouID
+
+	// The shipped default authentication flow is enough: no case here completes authentication.
+	authFlowID, err := testutils.GetFlowIDByHandle("default-flow", "AUTHENTICATION")
+	ts.Require().NoError(err, "Failed to resolve the default authentication flow")
+
+	app := map[string]interface{}{
+		"name":                      "OAuth2 Prompt Test App",
+		"description":               "Application for the OIDC prompt parameter tests",
+		"ouId":                      ts.ouID,
+		"type":                      "fullstack",
+		"authFlowId":                authFlowID,
+		"isRegistrationFlowEnabled": false,
+		"inboundAuthConfig": []map[string]interface{}{
+			{
+				"type": "oauth2",
+				"config": map[string]interface{}{
+					"clientId":                promptClientID,
+					"clientSecret":            "authz_prompt_test_secret",
+					"redirectUris":            []string{promptRedirectURI},
+					"grantTypes":              []string{"authorization_code", "refresh_token"},
+					"responseTypes":           []string{"code"},
+					"tokenEndpointAuthMethod": "client_secret_basic",
+				},
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(app)
+	ts.Require().NoError(err, "Failed to encode the application payload")
+
+	req, err := http.NewRequest(http.MethodPost, testutils.TestServerURL+"/applications", bytes.NewBuffer(jsonData))
+	ts.Require().NoError(err, "Failed to create the application request")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err, "Failed to send the application request")
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err, "Failed to read the application response")
+	ts.Require().Equal(http.StatusCreated, resp.StatusCode,
+		"Creating the test application should return 201: %s", string(body))
+
+	var created struct {
+		ID string `json:"id"`
+	}
+	ts.Require().NoError(json.Unmarshal(body, &created), "Failed to parse the application response")
+	ts.applicationID = created.ID
+}
+
+func (ts *PromptParameterTestSuite) TearDownSuite() {
+	if ts.applicationID != "" {
+		req, err := http.NewRequest(http.MethodDelete,
+			fmt.Sprintf("%s/applications/%s", testutils.TestServerURL, ts.applicationID), nil)
+		if err == nil {
+			resp, doErr := ts.client.Do(req)
+			if doErr != nil {
+				ts.T().Logf("Failed to delete the test application during teardown: %v", doErr)
+			} else {
+				resp.Body.Close()
+			}
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete the test organization unit during teardown: %v", err)
+		}
+	}
+}
+
+// authorize issues an authorization request carrying the given prompt value.
+func (ts *PromptParameterTestSuite) authorize(prompt string, promptSet bool) *http.Response {
+	params := url.Values{}
+	params.Set("client_id", promptClientID)
+	params.Set("redirect_uri", promptRedirectURI)
+	params.Set("response_type", "code")
+	params.Set("scope", "openid")
+	params.Set("state", "prompt-test-state")
+	if promptSet {
+		params.Set("prompt", prompt)
+	}
+
+	resp, err := testutils.SubmitAuthorizationRequest(params)
+	ts.Require().NoError(err, "Failed to send the authorization request")
+	return resp
+}
+
+// TestRejectedPromptValues asserts that every prompt value the server cannot honour is reported as an
+// error redirect to the client, with the error code OIDC prescribes for it.
+func (ts *PromptParameterTestSuite) TestRejectedPromptValues() {
+	testCases := []struct {
+		name          string
+		prompt        string
+		expectedError string
+	}{
+		{
+			name:          "empty prompt",
+			prompt:        "",
+			expectedError: "invalid_request",
+		},
+		{
+			name:          "whitespace only prompt",
+			prompt:        "   ",
+			expectedError: "invalid_request",
+		},
+		{
+			name:          "unsupported prompt value",
+			prompt:        "reauthenticate",
+			expectedError: "invalid_request",
+		},
+		{
+			name:          "none combined with another value",
+			prompt:        "none login",
+			expectedError: "invalid_request",
+		},
+		{
+			// The server does not serve an authorization request without user interaction, so a
+			// request that forbids interaction is answered with login_required.
+			name:          "none",
+			prompt:        "none",
+			expectedError: "login_required",
+		},
+		{
+			// Account selection is not implemented, which OIDC represents with its own error code
+			// rather than a generic invalid_request.
+			name:          "select_account",
+			prompt:        "select_account",
+			expectedError: "account_selection_required",
+		},
+	}
+
+	for _, tc := range testCases {
+		ts.Run(tc.name, func() {
+			resp := ts.authorize(tc.prompt, true)
+			defer resp.Body.Close()
+
+			ts.Require().Equal(http.StatusFound, resp.StatusCode,
+				"A rejected prompt must be reported as a redirect")
+			location := resp.Header.Get("Location")
+			ts.Require().NotEmpty(location, "The rejection must carry a redirect location")
+
+			parsed, err := url.Parse(location)
+			ts.Require().NoError(err, "Failed to parse the redirect location")
+			ts.Equal(promptRedirectURI, parsed.Scheme+"://"+parsed.Host+parsed.Path,
+				"The error must be redirected to the client's registered redirect URI")
+			ts.Equal("prompt-test-state", parsed.Query().Get("state"),
+				"An error redirect must echo the request's state")
+			ts.Require().NoError(testutils.ValidateOAuth2ErrorRedirect(location, tc.expectedError, ""),
+				"Unexpected error for prompt %q in redirect %s", tc.prompt, location)
+		})
+	}
+}
+
+// TestAcceptedPromptValues asserts that the interactive prompt values are accepted: the request is
+// not turned into an error redirect but continues to the login application. Being accepted at all is
+// the assertion here, since these values only affect how authentication is presented.
+func (ts *PromptParameterTestSuite) TestAcceptedPromptValues() {
+	for _, prompt := range []string{"login", "consent", "login consent"} {
+		ts.Run("prompt "+prompt, func() {
+			resp := ts.authorize(prompt, true)
+			defer resp.Body.Close()
+
+			ts.Require().Equal(http.StatusFound, resp.StatusCode,
+				"An accepted authorization request redirects to the login application")
+			location := resp.Header.Get("Location")
+			ts.Require().NotEmpty(location, "The redirect must carry a location")
+
+			parsed, err := url.Parse(location)
+			ts.Require().NoError(err, "Failed to parse the redirect location")
+			ts.Empty(parsed.Query().Get("error"),
+				"An accepted prompt value must not produce an OAuth2 error: %s", location)
+			ts.Empty(parsed.Query().Get("errorCode"),
+				"An accepted prompt value must not produce a server error page: %s", location)
+			ts.NotEqual(promptRedirectURI, parsed.Scheme+"://"+parsed.Host+parsed.Path,
+				"An accepted request is not redirected back to the client yet: %s", location)
+		})
+	}
+}
+
+// TestOmittedPromptIsAccepted asserts that prompt is optional: omitting it entirely leaves the
+// request untouched by prompt validation.
+func (ts *PromptParameterTestSuite) TestOmittedPromptIsAccepted() {
+	resp := ts.authorize("", false)
+	defer resp.Body.Close()
+
+	ts.Require().Equal(http.StatusFound, resp.StatusCode,
+		"An authorization request without prompt redirects to the login application")
+	location := resp.Header.Get("Location")
+	ts.Require().NotEmpty(location, "The redirect must carry a location")
+
+	parsed, err := url.Parse(location)
+	ts.Require().NoError(err, "Failed to parse the redirect location")
+	ts.Empty(parsed.Query().Get("error"), "Omitting prompt must not produce an OAuth2 error: %s", location)
+}

--- a/tests/integration/oauth/sso/session_termination_test.go
+++ b/tests/integration/oauth/sso/session_termination_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sso
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	// The shipped administration flow that deletes a user, and the input its executors read the
+	// target user from.
+	userDeletionFlowHandle = "default-user-deletion-flow"
+	deletionSubjectInput   = "subject"
+)
+
+// deletionFlowID resolves the shipped user deletion flow by handle.
+func (ts *SSOLogoutTestSuite) deletionFlowID() string {
+	ts.T().Helper()
+
+	req, err := http.NewRequest(http.MethodGet, testutils.TestServerURL+"/flows?flowType=ADMINISTRATION&limit=100", nil)
+	ts.Require().NoError(err)
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err, "failed to list administration flows")
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusOK, resp.StatusCode, "failed to list flows: %s", string(body))
+
+	var listed struct {
+		Flows []struct {
+			ID     string `json:"id"`
+			Handle string `json:"handle"`
+		} `json:"flows"`
+	}
+	ts.Require().NoError(json.Unmarshal(body, &listed))
+
+	for _, flow := range listed.Flows {
+		if flow.Handle == userDeletionFlowHandle {
+			return flow.ID
+		}
+	}
+	return ""
+}
+
+// deleteUserThroughFlow runs the shipped deletion flow against the given subject.
+//
+// The bearer token is set on a raw client because the shared test clients treat /flow/execute as a
+// public endpoint and skip token injection, which would make the request anonymous and be refused
+// at the administration entry point.
+func (ts *SSOLogoutTestSuite) deleteUserThroughFlow(flowID, subjectID string) {
+	ts.T().Helper()
+
+	token, err := testutils.GetAccessToken()
+	ts.Require().NoError(err, "failed to obtain admin access token")
+
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"flowId": flowID,
+		"inputs": map[string]string{deletionSubjectInput: subjectID},
+	})
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest(http.MethodPost, testutils.TestServerURL+"/flow/execute", bytes.NewReader(reqBody))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := testutils.GetRawHTTPClient().Do(req)
+	ts.Require().NoError(err, "failed to execute the deletion flow")
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusOK, resp.StatusCode, "deletion flow should run: %s", string(body))
+
+	var step testutils.FlowStep
+	ts.Require().NoError(json.Unmarshal(body, &step))
+	ts.Require().Equal("COMPLETE", step.FlowStatus, "deletion flow should complete: %s", string(body))
+}
+
+// Deleting a user tears down every SSO session that user holds, not just the record. Without this,
+// a deleted user's cookie would keep satisfying SSO_CHECK and authorize requests would continue to
+// be served for a subject that no longer exists.
+//
+// The session is proven live before the deletion by a second authorize that skips the credential
+// prompt, so the assertion afterwards is a change in behaviour rather than an absence.
+func (ts *SSOLogoutTestSuite) TestTerminateBySubject_UserDeletionEndsSSOSessions() {
+	flowID := ts.deletionFlowID()
+	ts.Require().NotEmpty(flowID, "the shipped user deletion flow should be present")
+
+	username := "sso_terminate_user"
+	userID := ts.createUser(username)
+
+	client := ts.newSessionClient()
+	ts.login(client, username, "terminate_state_1")
+	ts.Require().NotEmpty(ts.ssoCookieNames(client), "an SSO cookie should be set after login")
+
+	// The session is live: this authorize is satisfied without a credential prompt.
+	_, executionID := ts.authorize(client, "openid", "terminate_state_2")
+	reused := ts.flowExecute(client, map[string]interface{}{"executionId": executionID})
+	ts.Require().Equal("COMPLETE", reused.FlowStatus,
+		"the session must be live before the deletion for this test to mean anything")
+
+	ts.deleteUserThroughFlow(flowID, userID)
+
+	// The same cookie must no longer satisfy SSO: the flow falls back to asking for credentials.
+	_, afterExecutionID := ts.authorize(client, "openid", "terminate_state_3")
+	after := ts.flowExecute(client, map[string]interface{}{"executionId": afterExecutionID})
+	ts.NotEqual("COMPLETE", after.FlowStatus,
+		"a deleted user's SSO session must no longer satisfy an authorize request")
+}

--- a/tests/integration/oauth/sso/session_timeout_test.go
+++ b/tests/integration/oauth/sso/session_timeout_test.go
@@ -1,0 +1,189 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sso
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const sessionConfigURL = testutils.TestServerURL + "/server-config/session"
+
+// SSO session timeouts are read once, when the session service is constructed, so changing them
+// requires a server restart rather than only a configuration write. Every test here therefore
+// restores the original configuration and restarts again, so a failure cannot leave the rest of the
+// run with second-scale session lifetimes.
+func (ts *SSOLogoutTestSuite) writableSessionConfig() string {
+	req, err := http.NewRequest(http.MethodGet, sessionConfigURL, nil)
+	ts.Require().NoError(err)
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err, "failed to read session server config")
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusOK, resp.StatusCode, "failed to read session config: %s", string(body))
+
+	var layers struct {
+		Writable json.RawMessage `json:"writable"`
+	}
+	ts.Require().NoError(json.Unmarshal(body, &layers))
+
+	if len(layers.Writable) == 0 {
+		return "{}"
+	}
+	return string(layers.Writable)
+}
+
+// putSessionConfig replaces the writable layer of the session section.
+func (ts *SSOLogoutTestSuite) putSessionConfig(body string) {
+	req, err := http.NewRequest(http.MethodPut, sessionConfigURL, strings.NewReader(body))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err, "failed to update session server config")
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusOK, resp.StatusCode,
+		"failed to update session config with %s: %s", body, string(respBody))
+}
+
+// applySessionTimeouts writes the given timeouts and restarts the server so the session service
+// picks them up, registering the restore before making any change so a mid-test failure still
+// returns the deployment to its original lifetimes.
+//
+// idle must not exceed absolute, and the activity-refresh interval must be strictly less than idle;
+// both are rejected by configuration validation otherwise.
+func (ts *SSOLogoutTestSuite) applySessionTimeouts(idle, absolute, activityRefresh int64) {
+	original := ts.writableSessionConfig()
+	ts.T().Cleanup(func() {
+		ts.putSessionConfig(original)
+		if err := testutils.RestartServer(); err != nil {
+			ts.T().Logf("cleanup: server did not restart cleanly after session config restore: %v", err)
+		}
+		if err := testutils.ObtainAdminAccessToken(); err != nil {
+			ts.T().Logf("cleanup: failed to re-obtain admin token after restore: %v", err)
+		}
+	})
+
+	ts.putSessionConfig(fmt.Sprintf(
+		`{"idleTimeoutSeconds":%d,"absoluteTimeoutSeconds":%d,"activityRefreshIntervalSeconds":%d}`,
+		idle, absolute, activityRefresh))
+
+	ts.Require().NoError(testutils.RestartServer(), "failed to restart server with session timeouts")
+	ts.Require().NoError(testutils.ObtainAdminAccessToken(),
+		"failed to re-obtain admin token after restart")
+}
+
+// sessionSurvives reports whether a fresh authorize is satisfied by the existing SSO session. A
+// live session completes the flow on its initial step; an expired one falls through to the
+// credential prompt.
+func (ts *SSOLogoutTestSuite) sessionSurvives(client *http.Client, state string) bool {
+	_, executionID := ts.authorize(client, "openid", state)
+	step := ts.flowExecute(client, map[string]interface{}{"executionId": executionID})
+	return step.FlowStatus == "COMPLETE"
+}
+
+// putSessionConfigExpectingRejection writes a session configuration that validation must refuse,
+// and returns the response body for the assertion.
+func (ts *SSOLogoutTestSuite) putSessionConfigExpectingRejection(body string) string {
+	req, err := http.NewRequest(http.MethodPut, sessionConfigURL, strings.NewReader(body))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err, "failed to send session config update")
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusBadRequest, resp.StatusCode,
+		"an incoherent session configuration must be refused, got %d for %s: %s",
+		resp.StatusCode, body, string(respBody))
+
+	return string(respBody)
+}
+
+// Session timeouts are only read at startup, so an incoherent set has to be refused when it is
+// written rather than discovered at the next restart. These are the combinations that would let a
+// session behave in a way the deadlines are meant to prevent.
+func (ts *SSOLogoutTestSuite) TestSessionConfig_IncoherentTimeoutsRejected() {
+	// The write is expected to fail, but restore the original on the way out regardless, so a
+	// regression that lets one through cannot leave the rest of the run misconfigured.
+	original := ts.writableSessionConfig()
+	ts.T().Cleanup(func() {
+		ts.putSessionConfig(original)
+	})
+
+	ts.Run("negative timeout", func() {
+		ts.putSessionConfigExpectingRejection(`{"idleTimeoutSeconds":-1}`)
+	})
+
+	ts.Run("idle beyond absolute", func() {
+		// An idle deadline past the absolute cap could never be reached, so the pair is meaningless.
+		ts.putSessionConfigExpectingRejection(
+			`{"idleTimeoutSeconds":600,"absoluteTimeoutSeconds":300,"activityRefreshIntervalSeconds":60}`)
+	})
+
+	ts.Run("refresh not below idle", func() {
+		// The refresh interval bounds how stale the persisted idle deadline may be. At or above the
+		// idle window, an active session could be skipped past its own deadline.
+		ts.putSessionConfigExpectingRejection(
+			`{"idleTimeoutSeconds":60,"absoluteTimeoutSeconds":600,"activityRefreshIntervalSeconds":60}`)
+	})
+}
+
+// An SSO session left untouched past its idle timeout must not satisfy a later authorize, so an
+// abandoned browser session cannot skip authentication indefinitely.
+func (ts *SSOLogoutTestSuite) TestSSOSession_IdleTimeoutForcesReauthentication() {
+	// A generous absolute timeout isolates the idle deadline as the only thing that can expire.
+	ts.applySessionTimeouts(2, 600, 1)
+
+	client := ts.newSessionClient()
+	ts.login(client, ssoReuseUsername, "idle_timeout_state_1")
+	ts.Require().NotEmpty(ts.ssoCookieNames(client), "an SSO cookie should be set after first login")
+
+	ts.Require().True(ts.sessionSurvives(client, "idle_timeout_state_2"),
+		"the session should still be live immediately after login")
+
+	// Idle past the deadline with no activity at all.
+	time.Sleep(4 * time.Second)
+
+	ts.False(ts.sessionSurvives(client, "idle_timeout_state_3"),
+		"an idle-expired session must not skip authentication")
+}
+
+// The absolute timeout caps total session lifetime regardless of activity, so a session kept alive
+// by continued use is still retired once it is old enough.
+func (ts *SSOLogoutTestSuite) TestSSOSession_AbsoluteTimeoutForcesReauthentication() {
+	// Idle equals absolute so that refreshing activity mid-way slides the idle deadline beyond the
+	// absolute one, leaving the absolute cap as the only reason the session can expire.
+	ts.applySessionTimeouts(4, 4, 1)
+
+	client := ts.newSessionClient()
+	ts.login(client, ssoReuseUsername, "absolute_timeout_state_1")
+
+	// Use the session inside the idle window. This slides the idle deadline forward but must not move
+	// the absolute one.
+	time.Sleep(2 * time.Second)
+	ts.Require().True(ts.sessionSurvives(client, "absolute_timeout_state_2"),
+		"the session should still be live within both deadlines")
+
+	// Now past the absolute cap (about 5s since login) but inside the refreshed idle window (about 6s
+	// from the activity above), so only the absolute timeout can end the session.
+	time.Sleep(3 * time.Second)
+
+	ts.False(ts.sessionSurvives(client, "absolute_timeout_state_3"),
+		"a session past its absolute timeout must not skip authentication even when recently used")
+}

--- a/tests/integration/ou/model.go
+++ b/tests/integration/ou/model.go
@@ -94,6 +94,23 @@ type GroupListResponse struct {
 	Links        []testutils.Link `json:"links"`
 }
 
+// Role represents a role with basic information for OU endpoints.
+type Role struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	IsReadOnly  bool   `json:"isReadOnly"`
+}
+
+// RoleListResponse represents the response for listing roles in an organization unit.
+type RoleListResponse struct {
+	TotalResults int              `json:"totalResults"`
+	StartIndex   int              `json:"startIndex"`
+	Count        int              `json:"count"`
+	Roles        []Role           `json:"roles"`
+	Links        []testutils.Link `json:"links"`
+}
+
 type I18nMessage struct {
 	Key          string `json:"key,omitempty"`
 	DefaultValue string `json:"defaultValue,omitempty"`

--- a/tests/integration/ou/ou_roles_api_test.go
+++ b/tests/integration/ou/ou_roles_api_test.go
@@ -1,0 +1,251 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ou
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// OURolesAPITestSuite covers the two role-listing endpoints on organization units,
+// GET /organization-units/{id}/roles and GET /organization-units/tree/{path...}/roles.
+//
+// Roles live in a different database from organization units, so the OU package reaches them
+// through the OURoleResolver adapter rather than joining the ROLE table. Both endpoints are
+// therefore exercised against a real role fixture, and against a sibling OU, to confirm the
+// resolver scopes its count and its page to the requested OU instead of returning every role.
+//
+// Fixture topology:
+//
+//	roles-parent-ou (2 roles)
+//	└── roles-child-ou (1 role)  ← nested so the path form is exercised on a multi-segment path
+//	roles-empty-ou  (0 roles)
+type OURolesAPITestSuite struct {
+	suite.Suite
+
+	parentOUID string
+	childOUID  string
+	emptyOUID  string
+
+	parentRoleIDs []string
+	childRoleID   string
+}
+
+const (
+	rolesParentOUHandle = "roles-parent-ou"
+	rolesChildOUHandle  = "roles-child-ou"
+	rolesEmptyOUHandle  = "roles-empty-ou"
+
+	rolesChildOUPath = rolesParentOUHandle + "/" + rolesChildOUHandle
+)
+
+func TestOURolesAPITestSuite(t *testing.T) {
+	suite.Run(t, new(OURolesAPITestSuite))
+}
+
+func (suite *OURolesAPITestSuite) SetupSuite() {
+	parentID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      rolesParentOUHandle,
+		Name:        "Roles Parent OU",
+		Description: "Parent OU for the OU role listing tests",
+	})
+	suite.Require().NoError(err, "Failed to create parent OU")
+	suite.parentOUID = parentID
+
+	childID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      rolesChildOUHandle,
+		Name:        "Roles Child OU",
+		Description: "Child OU for the OU role listing tests",
+		Parent:      &parentID,
+	})
+	suite.Require().NoError(err, "Failed to create child OU")
+	suite.childOUID = childID
+
+	emptyID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      rolesEmptyOUHandle,
+		Name:        "Roles Empty OU",
+		Description: "OU deliberately left without roles",
+	})
+	suite.Require().NoError(err, "Failed to create empty OU")
+	suite.emptyOUID = emptyID
+
+	for _, name := range []string{"ou-roles-first", "ou-roles-second"} {
+		roleID, err := testutils.CreateRole(testutils.Role{
+			Name:        name,
+			Description: "Role in the parent OU",
+			OUID:        suite.parentOUID,
+		})
+		suite.Require().NoError(err, "Failed to create role %s", name)
+		suite.parentRoleIDs = append(suite.parentRoleIDs, roleID)
+	}
+
+	childRoleID, err := testutils.CreateRole(testutils.Role{
+		Name:        "ou-roles-child",
+		Description: "Role in the child OU",
+		OUID:        suite.childOUID,
+	})
+	suite.Require().NoError(err, "Failed to create child OU role")
+	suite.childRoleID = childRoleID
+}
+
+func (suite *OURolesAPITestSuite) TearDownSuite() {
+	for _, id := range append(suite.parentRoleIDs, suite.childRoleID) {
+		if id != "" {
+			if err := testutils.DeleteRole(id); err != nil {
+				suite.T().Logf("Failed to delete role %s: %v", id, err)
+			}
+		}
+	}
+	for _, id := range []string{suite.childOUID, suite.parentOUID, suite.emptyOUID} {
+		if id != "" {
+			if err := testutils.DeleteOrganizationUnit(id); err != nil {
+				suite.T().Logf("Failed to delete OU %s: %v", id, err)
+			}
+		}
+	}
+}
+
+// listRoles issues a role listing request and returns the decoded response.
+func (suite *OURolesAPITestSuite) listRoles(path string) RoleListResponse {
+	suite.T().Helper()
+
+	req, err := http.NewRequest("GET", testServerURL+path, nil)
+	suite.Require().NoError(err)
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	suite.Require().NoError(err)
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			suite.T().Logf("Failed to close response body: %v", err)
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+	suite.Require().Equalf(http.StatusOK, resp.StatusCode, "unexpected status, body: %s", body)
+
+	var rolesResponse RoleListResponse
+	suite.Require().NoError(json.Unmarshal(body, &rolesResponse))
+	return rolesResponse
+}
+
+// roleIDs collects the IDs from a listing so membership can be asserted independently of order.
+func roleIDs(response RoleListResponse) []string {
+	ids := make([]string, 0, len(response.Roles))
+	for _, role := range response.Roles {
+		ids = append(ids, role.ID)
+	}
+	return ids
+}
+
+// TestGetOrganizationUnitRoles verifies the ID-based endpoint lists exactly the OU's own roles.
+func (suite *OURolesAPITestSuite) TestGetOrganizationUnitRoles() {
+	response := suite.listRoles("/organization-units/" + suite.parentOUID + "/roles")
+
+	suite.Equal(2, response.TotalResults)
+	suite.Equal(1, response.StartIndex)
+	suite.Equal(len(response.Roles), response.Count)
+
+	ids := roleIDs(response)
+	for _, expected := range suite.parentRoleIDs {
+		suite.Containsf(ids, expected, "parent OU role %s missing, got %v", expected, ids)
+	}
+	// The child OU's role must not leak into the parent's listing; the endpoint lists the OU's own
+	// roles, not the subtree's.
+	suite.NotContainsf(ids, suite.childRoleID,
+		"child OU role must not appear in the parent listing, got %v", ids)
+
+	for _, role := range response.Roles {
+		suite.NotEmpty(role.Name, "role name must be populated")
+		suite.False(role.IsReadOnly, "API-created roles are mutable")
+	}
+}
+
+// TestGetOrganizationUnitRolesPagination verifies limit and offset are honoured, since the count and
+// the page are resolved by two separate calls into the role store.
+func (suite *OURolesAPITestSuite) TestGetOrganizationUnitRolesPagination() {
+	first := suite.listRoles("/organization-units/" + suite.parentOUID + "/roles?limit=1&offset=0")
+	suite.Equal(2, first.TotalResults, "total must report every role, not just the page")
+	suite.Equal(1, first.Count)
+	suite.Equal(1, first.StartIndex)
+
+	second := suite.listRoles("/organization-units/" + suite.parentOUID + "/roles?limit=1&offset=1")
+	suite.Equal(2, second.TotalResults)
+	suite.Equal(1, second.Count)
+	suite.Equal(2, second.StartIndex)
+
+	suite.NotEqual(roleIDs(first)[0], roleIDs(second)[0],
+		"the second page must not repeat the first page's role")
+}
+
+// TestGetOrganizationUnitRolesEmpty verifies an OU with no roles returns an empty listing rather
+// than every role in the deployment.
+func (suite *OURolesAPITestSuite) TestGetOrganizationUnitRolesEmpty() {
+	response := suite.listRoles("/organization-units/" + suite.emptyOUID + "/roles")
+
+	suite.Equal(0, response.TotalResults)
+	suite.Equal(0, response.Count)
+	suite.Empty(response.Roles)
+}
+
+// TestGetNonExistentOrganizationUnitRoles verifies the OU is resolved before its roles are listed.
+func (suite *OURolesAPITestSuite) TestGetNonExistentOrganizationUnitRoles() {
+	req, err := http.NewRequest("GET", testServerURL+"/organization-units/non-existent-id/roles", nil)
+	suite.Require().NoError(err)
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusNotFound, resp.StatusCode)
+
+	var errorResp ErrorResponse
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&errorResp))
+	suite.Equal("OU-1003", errorResp.Code)
+}
+
+// TestGetOrganizationUnitRolesByPath verifies the handle-path form resolves the same listing,
+// exercised on a nested path so the multi-segment case is covered.
+func (suite *OURolesAPITestSuite) TestGetOrganizationUnitRolesByPath() {
+	response := suite.listRoles("/organization-units/tree/" + rolesChildOUPath + "/roles")
+
+	suite.Equal(1, response.TotalResults)
+	suite.Equal(1, response.Count)
+	suite.Equal(1, response.StartIndex)
+	suite.Equal([]string{suite.childRoleID}, roleIDs(response))
+}
+
+// TestGetOrganizationUnitRolesByPathRootHandle verifies the single-segment path form, where the
+// "/roles" suffix has to be stripped from a path with nothing preceding the handle.
+func (suite *OURolesAPITestSuite) TestGetOrganizationUnitRolesByPathRootHandle() {
+	response := suite.listRoles("/organization-units/tree/" + rolesParentOUHandle + "/roles")
+
+	suite.Equal(2, response.TotalResults)
+	ids := roleIDs(response)
+	for _, expected := range suite.parentRoleIDs {
+		suite.Containsf(ids, expected, "parent OU role %s missing, got %v", expected, ids)
+	}
+}
+
+// TestGetOrganizationUnitRolesByInvalidPath verifies an unresolvable handle path is a 404 rather
+// than an empty listing, which would read as "this OU has no roles".
+func (suite *OURolesAPITestSuite) TestGetOrganizationUnitRolesByInvalidPath() {
+	req, err := http.NewRequest("GET", testServerURL+"/organization-units/tree/nonexistent/roles", nil)
+	suite.Require().NoError(err)
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Equal(http.StatusNotFound, resp.StatusCode)
+
+	var errorResp ErrorResponse
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&errorResp))
+	suite.Equal("OU-1003", errorResp.Code)
+}

--- a/tests/integration/role/role_authz_test.go
+++ b/tests/integration/role/role_authz_test.go
@@ -1,0 +1,446 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package role
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// RoleAuthzTestSuite pins the authorization boundary of the role management API.
+//
+// Unlike /groups and /users, /roles has no entry in the API permission table
+// (internal/system/security/permissions.go), so every role path falls back to the root "system"
+// permission. A scoped administrator holding the fine-grained system permissions is therefore
+// refused on every role endpoint, read and write alike, by the security middleware (AUTH-4030) and
+// never reaches the handler.
+//
+// The refusals are asserted on the error code, not just the status, because two different layers
+// answer 403 here:
+//
+//	AUTH-4030 — the security middleware: the caller lacks the permission the path requires.
+//	SAZ-4030  — sysauthz's grant guard: the operation would confer permissions the caller lacks.
+//
+// Distinguishing them matters. Because the role API admits only root callers, and
+// sysauthz.CanGrantMembership short-circuits for root, the role privilege-escalation guard
+// (CanGrantMembership with PrincipalTypeRole, and CanGrantPermissions on role create/update) cannot
+// fire for any HTTP caller in the shipped configuration. Should /roles later gain fine-grained
+// permission entries, TestScopedAdministratorCannotAddAssignmentToPrivilegedRole starts exercising
+// the guard, and the expected code becomes SAZ-4030 rather than AUTH-4030.
+//
+// Fixture topology, all within one OU:
+//
+//	scoped administrator — holds system:group, system:ou:view, and other non-root system permissions
+//	harmless role       — confers nothing
+//	privileged role     — confers system:user, which the scoped administrator does not hold
+type RoleAuthzTestSuite struct {
+	suite.Suite
+
+	authzOUID        string
+	authzTypeID      string
+	scopedAdminID    string
+	assigneeUserID   string
+	scopedRSID       string
+	scopedAdminRole  string
+	harmlessRoleID   string
+	privilegedRoleID string
+
+	// HTTP client carrying the scoped administrator's non-root token.
+	scopedClient *http.Client
+}
+
+const (
+	roleAuthzRSIdentifier = "https://authz-test.example.com/role"
+
+	roleAuthzOUHandle = "authz-role-ou"
+	roleAuthzTypeName = "authz-role-type"
+
+	roleAuthzAdminUsername = "authz-role-scoped-admin"
+	roleAuthzAdminPassword = "ScopedAdmin@123"
+
+	roleAuthzAssigneeUsername = "authz-role-assignee"
+	roleAuthzAssigneePassword = "Assignee@123"
+
+	roleAuthzClientID    = "CONSOLE"
+	roleAuthzRedirectURI = "https://localhost:8095/console"
+
+	// The permissions the scoped administrator holds and requests in its token. Deliberately
+	// excludes both the root "system" permission and "system:user".
+	roleAuthzScopedPermissions = "system:ou:view system:group system:group:view"
+
+	// errCodeInsufficientPermissions is returned by the security middleware when the caller lacks
+	// the permission the requested path requires.
+	errCodeInsufficientPermissions = "AUTH-4030"
+)
+
+func TestRoleAuthzTestSuite(t *testing.T) {
+	suite.Run(t, new(RoleAuthzTestSuite))
+}
+
+// ---------------------------------------------------------------------------
+// Suite setup
+// ---------------------------------------------------------------------------
+
+func (ts *RoleAuthzTestSuite) SetupSuite() {
+	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      roleAuthzOUHandle,
+		Name:        "Role Authz Test OU",
+		Description: "Organization unit for the role authorization integration test",
+	})
+	ts.Require().NoError(err, "create role-authz OU")
+	ts.authzOUID = ouID
+
+	typeID, err := testutils.CreateUserType(testutils.UserType{
+		Name: roleAuthzTypeName,
+		OUID: ts.authzOUID,
+		Schema: map[string]interface{}{
+			"username":     map[string]interface{}{"type": "string"},
+			"password":     map[string]interface{}{"type": "string", "credential": true},
+			"display_name": map[string]interface{}{"type": "string"},
+		},
+	})
+	ts.Require().NoError(err, "create user type")
+	ts.authzTypeID = typeID
+
+	adminID, err := testutils.CreateUser(testutils.User{
+		Type: roleAuthzTypeName,
+		OUID: ts.authzOUID,
+		Attributes: json.RawMessage(fmt.Sprintf(
+			`{"username": %q, "password": %q, "display_name": "Scoped Admin"}`,
+			roleAuthzAdminUsername, roleAuthzAdminPassword,
+		)),
+	})
+	ts.Require().NoError(err, "create scoped administrator")
+	ts.scopedAdminID = adminID
+
+	assigneeID, err := testutils.CreateUser(testutils.User{
+		Type: roleAuthzTypeName,
+		OUID: ts.authzOUID,
+		Attributes: json.RawMessage(fmt.Sprintf(
+			`{"username": %q, "password": %q, "display_name": "Assignee"}`,
+			roleAuthzAssigneeUsername, roleAuthzAssigneePassword,
+		)),
+	})
+	ts.Require().NoError(err, "create assignee user")
+	ts.assigneeUserID = assigneeID
+
+	// The product ships only the root "system" scope, so the fine-grained system permissions the
+	// scoped administrator holds are reproduced on a resource server of the suite's own.
+	rsID, err := testutils.CreateSystemScopedResourceServer(
+		ts.authzOUID, "Authz Test RS (role)", roleAuthzRSIdentifier, "ou", "group", "user")
+	ts.Require().NoError(err, "create scoped resource server")
+	ts.scopedRSID = rsID
+
+	adminRoleID, err := testutils.CreateRole(testutils.Role{
+		Name: "authz-role-scoped-admin-role",
+		OUID: ts.authzOUID,
+		Permissions: []testutils.ResourcePermissions{
+			{
+				ResourceServerID: rsID,
+				Permissions:      []string{"system:ou:view", "system:group", "system:group:view"},
+			},
+		},
+		Assignments: []testutils.Assignment{
+			{ID: ts.scopedAdminID, Type: "user"},
+		},
+	})
+	ts.Require().NoError(err, "create scoped administrator role")
+	ts.scopedAdminRole = adminRoleID
+
+	// Confers nothing, so the grant guard would allow managing it. Only the middleware stands in
+	// the way, which is what makes this fixture the discriminating one.
+	harmlessID, err := testutils.CreateRole(testutils.Role{
+		Name:        "authz-role-harmless",
+		Description: "Role conferring no permissions",
+		OUID:        ts.authzOUID,
+	})
+	ts.Require().NoError(err, "create harmless role")
+	ts.harmlessRoleID = harmlessID
+
+	// Confers system:user, which the scoped administrator was never granted. Assigning anyone to it
+	// would transfer a permission the caller does not hold.
+	privilegedID, err := testutils.CreateRole(testutils.Role{
+		Name:        "authz-role-privileged",
+		Description: "Role conferring system:user",
+		OUID:        ts.authzOUID,
+		Permissions: []testutils.ResourcePermissions{
+			{
+				ResourceServerID: rsID,
+				Permissions:      []string{"system:user"},
+			},
+		},
+	})
+	ts.Require().NoError(err, "create privileged role")
+	ts.privilegedRoleID = privilegedID
+
+	tokenResp, err := testutils.ObtainAccessTokenWithPassword(
+		roleAuthzClientID,
+		roleAuthzRedirectURI,
+		roleAuthzScopedPermissions,
+		roleAuthzAdminUsername,
+		roleAuthzAdminPassword,
+		true,
+		"",
+		roleAuthzRSIdentifier,
+	)
+	ts.Require().NoError(err, "obtain scoped administrator token")
+	ts.Require().NotEmpty(tokenResp.AccessToken, "scoped administrator token must be non-empty")
+	ts.Require().NotContains(tokenResp.Scope, "system:user",
+		"the scoped administrator must not hold system:user, or the suite proves nothing")
+
+	ts.scopedClient = testutils.GetHTTPClientWithToken(tokenResp.AccessToken)
+}
+
+// ---------------------------------------------------------------------------
+// Suite teardown
+// ---------------------------------------------------------------------------
+
+func (ts *RoleAuthzTestSuite) TearDownSuite() {
+	for _, id := range []string{ts.scopedAdminRole, ts.harmlessRoleID, ts.privilegedRoleID} {
+		if id != "" {
+			if err := testutils.DeleteRole(id); err != nil {
+				ts.T().Logf("teardown: delete role %s: %v", id, err)
+			}
+		}
+	}
+	if ts.scopedRSID != "" {
+		if err := testutils.DeleteResourceServer(ts.scopedRSID); err != nil {
+			ts.T().Logf("teardown: delete scoped resource server: %v", err)
+		}
+	}
+	for _, id := range []string{ts.scopedAdminID, ts.assigneeUserID} {
+		if id != "" {
+			if err := testutils.DeleteUser(id); err != nil {
+				ts.T().Logf("teardown: delete user %s: %v", id, err)
+			}
+		}
+	}
+	if ts.authzTypeID != "" {
+		if err := testutils.DeleteUserType(ts.authzTypeID); err != nil {
+			ts.T().Logf("teardown: delete user type: %v", err)
+		}
+	}
+	if ts.authzOUID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.authzOUID); err != nil {
+			ts.T().Logf("teardown: delete role-authz OU: %v", err)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// doScoped issues a request as the scoped administrator.
+func (ts *RoleAuthzTestSuite) doScoped(method, path string, body []byte) *http.Response {
+	ts.T().Helper()
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequest(method, testServerURL+path, bodyReader)
+	ts.Require().NoError(err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := ts.scopedClient.Do(req)
+	ts.Require().NoError(err)
+	return resp
+}
+
+// requireRefusedWithCode asserts a 403 carrying the given error code, so the test states which
+// enforcement layer answered rather than accepting any refusal.
+func (ts *RoleAuthzTestSuite) requireRefusedWithCode(resp *http.Response, code string) {
+	ts.T().Helper()
+
+	body, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+
+	ts.Equalf(http.StatusForbidden, resp.StatusCode, "expected a refusal, body: %s", body)
+
+	// Decoded loosely: the message and description are i18n objects, not the plain strings
+	// ErrorResponse declares, and only the code identifies the layer that refused.
+	var errResp map[string]interface{}
+	ts.Require().NoError(json.Unmarshal(body, &errResp))
+	ts.Equalf(code, errResp["code"], "unexpected refusal layer, body: %s", body)
+}
+
+// mustMarshal encodes a JSON request body, failing the test on error.
+func (ts *RoleAuthzTestSuite) mustMarshal(v any) []byte {
+	ts.T().Helper()
+	payload, err := json.Marshal(v)
+	ts.Require().NoError(err)
+	return payload
+}
+
+// assigneePayload builds an assignments request naming the assignee user.
+func (ts *RoleAuthzTestSuite) assigneePayload() []byte {
+	ts.T().Helper()
+	return ts.mustMarshal(AssignmentsRequest{
+		Assignments: []Assignment{{ID: ts.assigneeUserID, Type: AssigneeTypeUser}},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Reads
+// ---------------------------------------------------------------------------
+
+// TestScopedAdministratorCannotListRoles verifies role listing is closed to non-root callers.
+func (ts *RoleAuthzTestSuite) TestScopedAdministratorCannotListRoles() {
+	resp := ts.doScoped(http.MethodGet, rolesBasePath, nil)
+	defer resp.Body.Close()
+
+	ts.requireRefusedWithCode(resp, errCodeInsufficientPermissions)
+}
+
+// TestScopedAdministratorCannotGetRole verifies reading a single role is closed to non-root callers.
+func (ts *RoleAuthzTestSuite) TestScopedAdministratorCannotGetRole() {
+	resp := ts.doScoped(http.MethodGet, rolesBasePath+"/"+ts.harmlessRoleID, nil)
+	defer resp.Body.Close()
+
+	ts.requireRefusedWithCode(resp, errCodeInsufficientPermissions)
+}
+
+// TestScopedAdministratorCannotListRoleAssignments verifies that reading who holds a role, which
+// discloses the privileges of other principals, is closed to non-root callers.
+func (ts *RoleAuthzTestSuite) TestScopedAdministratorCannotListRoleAssignments() {
+	resp := ts.doScoped(http.MethodGet, rolesBasePath+"/"+ts.privilegedRoleID+"/assignments", nil)
+	defer resp.Body.Close()
+
+	ts.requireRefusedWithCode(resp, errCodeInsufficientPermissions)
+}
+
+// ---------------------------------------------------------------------------
+// Writes
+// ---------------------------------------------------------------------------
+
+// TestScopedAdministratorCannotCreateRoleConferringUnheldPermissions covers the escalation a
+// scoped administrator would attempt first: minting a role that confers more than the caller holds,
+// then assigning itself to it.
+func (ts *RoleAuthzTestSuite) TestScopedAdministratorCannotCreateRoleConferringUnheldPermissions() {
+	payload := ts.mustMarshal(CreateRoleRequest{
+		Name: "authz-role-escalating",
+		OUID: ts.authzOUID,
+		Permissions: []ResourcePermissions{
+			{ResourceServerID: ts.scopedRSID, Permissions: []string{"system:user"}},
+		},
+		Assignments: []Assignment{{ID: ts.scopedAdminID, Type: AssigneeTypeUser}},
+	})
+
+	resp := ts.doScoped(http.MethodPost, rolesBasePath, payload)
+	defer resp.Body.Close()
+
+	ts.requireRefusedWithCode(resp, errCodeInsufficientPermissions)
+}
+
+// TestScopedAdministratorCannotUpdateRoleToConferUnheldPermissions covers the same escalation
+// through an update, which replaces the permission list wholesale.
+func (ts *RoleAuthzTestSuite) TestScopedAdministratorCannotUpdateRoleToConferUnheldPermissions() {
+	payload := ts.mustMarshal(UpdateRoleRequest{
+		Name: "authz-role-harmless",
+		OUID: ts.authzOUID,
+		Permissions: []ResourcePermissions{
+			{ResourceServerID: ts.scopedRSID, Permissions: []string{"system:user"}},
+		},
+	})
+
+	resp := ts.doScoped(http.MethodPut, rolesBasePath+"/"+ts.harmlessRoleID, payload)
+	defer resp.Body.Close()
+
+	ts.requireRefusedWithCode(resp, errCodeInsufficientPermissions)
+}
+
+// TestScopedAdministratorCannotDeleteRole verifies deletion, which silently strips privileges from
+// every assignee, is closed to non-root callers.
+func (ts *RoleAuthzTestSuite) TestScopedAdministratorCannotDeleteRole() {
+	resp := ts.doScoped(http.MethodDelete, rolesBasePath+"/"+ts.harmlessRoleID, nil)
+	defer resp.Body.Close()
+
+	ts.requireRefusedWithCode(resp, errCodeInsufficientPermissions)
+}
+
+// TestScopedAdministratorCannotAddAssignmentToPrivilegedRole is the escalation the grant guard
+// exists to stop: assigning a principal to a role conferring system:user, which the caller does not
+// hold. The refusal currently comes from the middleware, so the guard itself never runs.
+func (ts *RoleAuthzTestSuite) TestScopedAdministratorCannotAddAssignmentToPrivilegedRole() {
+	resp := ts.doScoped(http.MethodPost,
+		rolesBasePath+"/"+ts.privilegedRoleID+"/assignments/add", ts.assigneePayload())
+	defer resp.Body.Close()
+
+	ts.requireRefusedWithCode(resp, errCodeInsufficientPermissions)
+}
+
+// TestScopedAdministratorCannotRemoveAssignmentFromPrivilegedRole covers the other direction.
+// Stripping an assignment is guarded to the same standard, since it changes who holds the role's
+// privileges.
+func (ts *RoleAuthzTestSuite) TestScopedAdministratorCannotRemoveAssignmentFromPrivilegedRole() {
+	resp := ts.doScoped(http.MethodPost,
+		rolesBasePath+"/"+ts.privilegedRoleID+"/assignments/remove", ts.assigneePayload())
+	defer resp.Body.Close()
+
+	ts.requireRefusedWithCode(resp, errCodeInsufficientPermissions)
+}
+
+// TestScopedAdministratorCannotAddAssignmentToHarmlessRole is what shows the boundary is drawn at
+// the path and not at the conferred permissions. The harmless role confers nothing, so the grant
+// guard would permit this; the middleware refuses it anyway.
+func (ts *RoleAuthzTestSuite) TestScopedAdministratorCannotAddAssignmentToHarmlessRole() {
+	resp := ts.doScoped(http.MethodPost,
+		rolesBasePath+"/"+ts.harmlessRoleID+"/assignments/add", ts.assigneePayload())
+	defer resp.Body.Close()
+
+	ts.requireRefusedWithCode(resp, errCodeInsufficientPermissions)
+}
+
+// ---------------------------------------------------------------------------
+// Root caller
+// ---------------------------------------------------------------------------
+
+// TestRootAdministratorCanManageRoleAssignments proves the refusals above are the authorization
+// boundary rather than a broken route or a malformed fixture: the same requests succeed for a root
+// caller.
+func (ts *RoleAuthzTestSuite) TestRootAdministratorCanManageRoleAssignments() {
+	client := testutils.GetHTTPClient()
+	payload := ts.assigneePayload()
+
+	addReq, err := http.NewRequest(http.MethodPost,
+		testServerURL+rolesBasePath+"/"+ts.privilegedRoleID+"/assignments/add",
+		bytes.NewReader(payload))
+	ts.Require().NoError(err)
+	addReq.Header.Set("Content-Type", "application/json")
+
+	addResp, err := client.Do(addReq)
+	ts.Require().NoError(err)
+	defer addResp.Body.Close()
+
+	addBody, err := io.ReadAll(addResp.Body)
+	ts.Require().NoError(err)
+	ts.Equalf(http.StatusNoContent, addResp.StatusCode,
+		"root caller should assign a privileged role, body: %s", addBody)
+
+	removeReq, err := http.NewRequest(http.MethodPost,
+		testServerURL+rolesBasePath+"/"+ts.privilegedRoleID+"/assignments/remove",
+		bytes.NewReader(payload))
+	ts.Require().NoError(err)
+	removeReq.Header.Set("Content-Type", "application/json")
+
+	removeResp, err := client.Do(removeReq)
+	ts.Require().NoError(err)
+	defer removeResp.Body.Close()
+
+	removeBody, err := io.ReadAll(removeResp.Body)
+	ts.Require().NoError(err)
+	ts.Equalf(http.StatusNoContent, removeResp.StatusCode,
+		"root caller should unassign a privileged role, body: %s", removeBody)
+}

--- a/tests/integration/testutils/api_utils.go
+++ b/tests/integration/testutils/api_utils.go
@@ -1541,6 +1541,30 @@ func DeleteAction(resourceServerID, actionID string) error {
 	return nil
 }
 
+// DeleteResource deletes a resource from a resource server. A resource server cannot be deleted
+// while it still has resources, so suites that build a resource tree must remove it leaf first.
+func DeleteResource(resourceServerID, resourceID string) error {
+	client := GetHTTPClient()
+
+	url := fmt.Sprintf("%s/resource-servers/%s/resources/%s", TestServerURL, resourceServerID, resourceID)
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create delete request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to delete resource: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("expected status 204, got %d. Response: %s", resp.StatusCode, string(bodyBytes))
+	}
+	return nil
+}
+
 func PutDefaultResourceServer(resourceServerID string) error {
 	client := GetHTTPClient()
 

--- a/tests/integration/testutils/oauth2_utils.go
+++ b/tests/integration/testutils/oauth2_utils.go
@@ -159,6 +159,31 @@ func initiateAuthorizationFlow(clientID, redirectURI, responseType, scope, state
 	return resp, nil
 }
 
+// SubmitAuthorizationRequest sends an arbitrary parameter set to the authorization endpoint without
+// following redirects, so the caller can assert on the redirect the server produced. Use this for
+// parameters the InitiateAuthorizationFlow variants do not cover, such as prompt.
+func SubmitAuthorizationRequest(params url.Values) (*http.Response, error) {
+	req, err := http.NewRequest("GET", TestServerURL+"/oauth2/authorize?"+params.Encode(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create authorization request: %w", err)
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send authorization request: %w", err)
+	}
+	return resp, nil
+}
+
 // ExecuteAuthenticationFlow executes an authentication flow and returns the flow step.
 func ExecuteAuthenticationFlow(executionId string, inputs map[string]string, action string,
 	challengeToken ...string) (*FlowStep, error) {
@@ -1317,6 +1342,76 @@ func (k *DPoPKey) CreateProof(htm, htu string, opts DPoPProofOptions) (string, e
 		sig[len(sig)-1] ^= 0x01
 	}
 	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+// CreateSignedJWT signs an arbitrary header and claims set with the key and returns the compact JWS.
+// The "alg" header defaults to the key's natural algorithm when the caller does not set it. Tests use
+// this to mint client assertions (RFC 7523) and other client-signed JWTs, including malformed ones.
+func (k *DPoPKey) CreateSignedJWT(header, claims map[string]any) (string, error) {
+	fullHeader := make(map[string]any, len(header)+1)
+	fullHeader["alg"] = k.Alg
+	for name, value := range header {
+		fullHeader[name] = value
+	}
+
+	headerJSON, err := json.Marshal(fullHeader)
+	if err != nil {
+		return "", err
+	}
+	claimsJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+	signingInput := base64.RawURLEncoding.EncodeToString(headerJSON) +
+		"." + base64.RawURLEncoding.EncodeToString(claimsJSON)
+
+	alg, _ := fullHeader["alg"].(string)
+	sig, err := signProof(k.Private, alg, signingInput)
+	if err != nil {
+		return "", err
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+// NewJTI returns a fresh url-safe identifier suitable for a "jti" claim.
+func NewJTI() string {
+	return randomJTI()
+}
+
+// SubmitTokenRequest posts the given form to the token endpoint without adding any client
+// authentication, so the caller controls how the client authenticates (for example with a
+// client assertion). It returns the raw result for both success and failure responses.
+func SubmitTokenRequest(form url.Values) (*TokenHTTPResult, error) {
+	req, err := http.NewRequest("POST", TestServerURL+"/oauth2/token",
+		bytes.NewBufferString(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := GetRawHTTPClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	result := &TokenHTTPResult{
+		StatusCode: resp.StatusCode,
+		Body:       body,
+	}
+	if resp.StatusCode == http.StatusOK {
+		var tokenResponse TokenResponse
+		if err := json.Unmarshal(body, &tokenResponse); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal token response: %w", err)
+		}
+		result.Token = &tokenResponse
+	}
+	return result, nil
 }
 
 // MakeUnsignedDPoPProof builds a header.payload."" JWS where the signature

--- a/tests/integration/testutils/test_utils.go
+++ b/tests/integration/testutils/test_utils.go
@@ -72,6 +72,10 @@ func InitializeTestContext(port string, zipPattern string, databaseType string) 
 // Returning an absolute path ensures it resolves correctly regardless of the working
 // directory of the consumer (e.g. a test subprocess running from a sub-package directory).
 func GetExtractedProductHome() string {
+	// A test subprocess has the path in its environment but no initialized context until something
+	// asks for it, so resolve lazily rather than panicking on the un-set package variable.
+	ensureInitialized()
+
 	if extractedProductHome == "" {
 		panic("Extracted product home is not set")
 	}

--- a/tests/integration/user/user_usages_test.go
+++ b/tests/integration/user/user_usages_test.go
@@ -1,0 +1,326 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package user
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// resourceDependency mirrors one entry of the usages listing.
+type resourceDependency struct {
+	ResourceType     string `json:"resourceType"`
+	ID               string `json:"id"`
+	DisplayName      string `json:"displayName"`
+	BehaviorOnDelete string `json:"behaviorOnDelete"`
+}
+
+// dependenciesResponse mirrors the GET /users/{id}/usages payload. TotalResults is a pointer
+// because nil means "dependency data unavailable", which is a different answer from zero.
+type dependenciesResponse struct {
+	TotalResults *int                 `json:"totalResults"`
+	Count        int                  `json:"count"`
+	Summary      map[string]int       `json:"summary"`
+	Usages       []resourceDependency `json:"usages"`
+}
+
+// usagesErrorResponse mirrors an API error, including the interpolated description parameters.
+type usagesErrorResponse struct {
+	Code    string `json:"code"`
+	Message struct {
+		Key          string `json:"key"`
+		DefaultValue string `json:"defaultValue"`
+	} `json:"message"`
+	Description struct {
+		Key          string            `json:"key"`
+		DefaultValue string            `json:"defaultValue"`
+		Params       map[string]string `json:"params"`
+	} `json:"description"`
+}
+
+// UserUsagesTestSuite covers GET /users/{id}/usages and the delete refusal it warns about.
+//
+// The endpoint is the pre-delete safety check the console consults before offering to delete a
+// user: it reports the resources that reference the user and whether each one blocks deletion. A
+// false "no blockers" would let an operator confirm a delete that the server then refuses, or worse,
+// walk into a delete whose blocking dependants were never surfaced.
+//
+// An agent's owner is a restrict-behavior reference, so an owned agent is the realistic blocking
+// dependency to test with. It is built through the real agent API rather than injected, because the
+// owner lives in the agent entity's system attributes and is resolved by scanning agents, not by an
+// indexed lookup.
+//
+// The suite asserts the informational read and the enforcement together, since they are the two
+// halves of one contract: what /usages reports must be what DELETE actually does.
+type UserUsagesTestSuite struct {
+	suite.Suite
+
+	ouID       string
+	userTypeID string
+
+	ownerUserID    string
+	unusedUserID   string
+	firstAgentID   string
+	secondAgentID  string
+	agentsRemoved  bool
+	ownerRemovable bool
+}
+
+const (
+	usagesOUHandle     = "user-usages-ou"
+	usagesUserTypeName = "user-usages-person"
+
+	usagesOwnerUsername  = "user-usages-owner"
+	usagesUnusedUsername = "user-usages-unused"
+
+	// errCodeUserHasBlockingDependencies is returned when a user cannot be deleted because a
+	// restrict-behavior dependant still references it.
+	errCodeUserHasBlockingDependencies = "USR-1027"
+)
+
+func TestUserUsagesTestSuite(t *testing.T) {
+	suite.Run(t, new(UserUsagesTestSuite))
+}
+
+func (ts *UserUsagesTestSuite) SetupSuite() {
+	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      usagesOUHandle,
+		Name:        "User Usages OU",
+		Description: "Organization unit for the user usages tests",
+	})
+	ts.Require().NoError(err, "Failed to create the test organization unit")
+	ts.ouID = ouID
+
+	userTypeID, err := testutils.CreateUserType(testutils.UserType{
+		Name: usagesUserTypeName,
+		OUID: ts.ouID,
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{"type": "string"},
+			"password": map[string]interface{}{"type": "string", "credential": true},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create the user type")
+	ts.userTypeID = userTypeID
+
+	// The server allows a single `default` agent type, shared across suites and never deleted.
+	_, err = testutils.CreateAgentType(testutils.UserType{
+		OUID: ts.ouID,
+		Schema: map[string]interface{}{
+			"description": map[string]interface{}{"type": "string"},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create the agent type")
+
+	ownerID, err := testutils.CreateUser(testutils.User{
+		Type: usagesUserTypeName,
+		OUID: ts.ouID,
+		Attributes: json.RawMessage(fmt.Sprintf(
+			`{"username": %q, "password": "Usages@123"}`, usagesOwnerUsername)),
+	})
+	ts.Require().NoError(err, "Failed to create the owner user")
+	ts.ownerUserID = ownerID
+
+	unusedID, err := testutils.CreateUser(testutils.User{
+		Type: usagesUserTypeName,
+		OUID: ts.ouID,
+		Attributes: json.RawMessage(fmt.Sprintf(
+			`{"username": %q, "password": "Usages@123"}`, usagesUnusedUsername)),
+	})
+	ts.Require().NoError(err, "Failed to create the unreferenced user")
+	ts.unusedUserID = unusedID
+
+	// Two agents, so the summary counts and the "N agent(s)" rendering are exercised on a value
+	// greater than one. A single dependant would not distinguish a count from a boolean.
+	firstAgentID, err := testutils.CreateAgent(testutils.Agent{
+		OUID:        ts.ouID,
+		Type:        "default",
+		Name:        "user-usages-first-agent",
+		Owner:       ts.ownerUserID,
+		Description: "First agent owned by the usages test user",
+	})
+	ts.Require().NoError(err, "Failed to create the first owned agent")
+	ts.firstAgentID = firstAgentID
+
+	secondAgentID, err := testutils.CreateAgent(testutils.Agent{
+		OUID:        ts.ouID,
+		Type:        "default",
+		Name:        "user-usages-second-agent",
+		Owner:       ts.ownerUserID,
+		Description: "Second agent owned by the usages test user",
+	})
+	ts.Require().NoError(err, "Failed to create the second owned agent")
+	ts.secondAgentID = secondAgentID
+}
+
+func (ts *UserUsagesTestSuite) TearDownSuite() {
+	if !ts.agentsRemoved {
+		for _, id := range []string{ts.firstAgentID, ts.secondAgentID} {
+			if id != "" {
+				if err := testutils.DeleteAgent(id); err != nil {
+					ts.T().Logf("Failed to delete agent %s: %v", id, err)
+				}
+			}
+		}
+	}
+	if ts.ownerUserID != "" && !ts.ownerRemovable {
+		if err := testutils.DeleteUser(ts.ownerUserID); err != nil {
+			ts.T().Logf("Failed to delete the owner user: %v", err)
+		}
+	}
+	if ts.unusedUserID != "" {
+		if err := testutils.DeleteUser(ts.unusedUserID); err != nil {
+			ts.T().Logf("Failed to delete the unreferenced user: %v", err)
+		}
+	}
+	if ts.userTypeID != "" {
+		if err := testutils.DeleteUserType(ts.userTypeID); err != nil {
+			ts.T().Logf("Failed to delete the user type: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete the test organization unit: %v", err)
+		}
+	}
+}
+
+// getUsages fetches the usages of a user, asserting a 200.
+func (ts *UserUsagesTestSuite) getUsages(userID string) dependenciesResponse {
+	ts.T().Helper()
+
+	req, err := http.NewRequest("GET", testServerURL+"/users/"+userID+"/usages", nil)
+	ts.Require().NoError(err)
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+	ts.Require().Equalf(http.StatusOK, resp.StatusCode, "unexpected status, body: %s", body)
+
+	var usages dependenciesResponse
+	ts.Require().NoError(json.Unmarshal(body, &usages))
+	return usages
+}
+
+// deleteUser issues a delete and returns the status with the decoded error, if any.
+func (ts *UserUsagesTestSuite) deleteUser(userID string) (int, usagesErrorResponse) {
+	ts.T().Helper()
+
+	req, err := http.NewRequest("DELETE", testServerURL+"/users/"+userID, nil)
+	ts.Require().NoError(err)
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+
+	var errResp usagesErrorResponse
+	if len(body) > 0 {
+		_ = json.Unmarshal(body, &errResp)
+	}
+	return resp.StatusCode, errResp
+}
+
+// TestUsagesReportsOwnedAgentsAsBlocking verifies the endpoint reports every owned agent and marks
+// it as blocking. A dependant reported with the wrong behavior reads as harmless to the console.
+func (ts *UserUsagesTestSuite) TestUsagesReportsOwnedAgentsAsBlocking() {
+	usages := ts.getUsages(ts.ownerUserID)
+
+	ts.Require().NotNil(usages.TotalResults,
+		"a nil total means dependency data was unavailable, which must not be reported as no blockers")
+	ts.Equal(2, *usages.TotalResults)
+	ts.Equal(2, usages.Count)
+	ts.Equal(map[string]int{"agent": 2}, usages.Summary)
+
+	reported := make(map[string]resourceDependency, len(usages.Usages))
+	for _, usage := range usages.Usages {
+		reported[usage.ID] = usage
+	}
+
+	for _, agentID := range []string{ts.firstAgentID, ts.secondAgentID} {
+		usage, found := reported[agentID]
+		ts.Require().Truef(found, "agent %s missing from usages, got %v", agentID, usages.Usages)
+		ts.Equal("agent", usage.ResourceType)
+		ts.Equal("restrict", usage.BehaviorOnDelete,
+			"an agent cannot exist without its owner, so ownership must block deletion")
+		ts.NotEmpty(usage.DisplayName, "the console renders the display name in the warning")
+	}
+}
+
+// TestUsagesForUnreferencedUserIsConfirmedEmpty verifies an unreferenced user reports a confirmed
+// empty result, with a non-nil total, rather than the nil total that signals unavailable data.
+func (ts *UserUsagesTestSuite) TestUsagesForUnreferencedUserIsConfirmedEmpty() {
+	usages := ts.getUsages(ts.unusedUserID)
+
+	ts.Require().NotNil(usages.TotalResults, "an empty result must be confirmed, not unknown")
+	ts.Equal(0, *usages.TotalResults)
+	ts.Equal(0, usages.Count)
+	ts.Empty(usages.Usages)
+}
+
+// TestUsagesForNonExistentUser verifies the user is resolved before its usages are aggregated, so a
+// mistyped ID is a 404 rather than an empty listing that reads as "safe to delete".
+func (ts *UserUsagesTestSuite) TestUsagesForNonExistentUser() {
+	req, err := http.NewRequest("GET", testServerURL+"/users/non-existent-user-id/usages", nil)
+	ts.Require().NoError(err)
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusNotFound, resp.StatusCode)
+}
+
+// TestUsagesRejectsAnAgentID verifies the endpoint is user-scoped: an agent ID is not a user, so it
+// must not resolve just because both live in the entity table.
+func (ts *UserUsagesTestSuite) TestUsagesRejectsAnAgentID() {
+	req, err := http.NewRequest("GET", testServerURL+"/users/"+ts.firstAgentID+"/usages", nil)
+	ts.Require().NoError(err)
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusNotFound, resp.StatusCode)
+}
+
+// TestZDeleteIsRefusedThenAllowed walks the full pre-delete contract in the order an operator hits
+// it: the delete is refused while the owned agents exist, the refusal names them, and the same
+// delete succeeds once they are gone.
+//
+// Named with a Z prefix so testify's alphabetical ordering runs it after the read assertions, which
+// depend on the agents still existing.
+func (ts *UserUsagesTestSuite) TestZDeleteIsRefusedThenAllowed() {
+	status, errResp := ts.deleteUser(ts.ownerUserID)
+	ts.Require().Equal(http.StatusConflict, status,
+		"deleting a user with restrict-behavior dependants must be refused")
+	ts.Equal(errCodeUserHasBlockingDependencies, errResp.Code)
+	ts.Equal("2 agent(s)", errResp.Description.Params["dependencies"],
+		"the refusal must summarize the blockers so the operator knows what to fix")
+	ts.Contains(errResp.Description.DefaultValue, "2 agent(s)")
+
+	for _, agentID := range []string{ts.firstAgentID, ts.secondAgentID} {
+		ts.Require().NoError(testutils.DeleteAgent(agentID), "Failed to delete the owned agent")
+	}
+	ts.agentsRemoved = true
+
+	usages := ts.getUsages(ts.ownerUserID)
+	ts.Require().NotNil(usages.TotalResults)
+	ts.Equal(0, *usages.TotalResults, "usages must clear once the blocking agents are gone")
+
+	status, errResp = ts.deleteUser(ts.ownerUserID)
+	ts.Require().Equalf(http.StatusNoContent, status,
+		"the delete must succeed once nothing blocks it, got code %q", errResp.Code)
+	ts.ownerRemovable = true
+}


### PR DESCRIPTION
### Purpose

Raises integration coverage across the core packages, and fixes one product defect the new coverage exposed.

Two things are in here:

1. **Integration coverage.** Flow engine and SSO session paths, plus new suites for twelve API surfaces that previously had no integration coverage at all.
2. **A role merge ordering fix.** `mergePermissions` returned its result in Go map iteration order, discarding the `ORDER BY` the query applies. `GET /agents/{id}/roles` therefore paged non-deterministically: a client reading one role per page could see the same role on both pages and never see the other. The fix ships with the coverage rather than separately because the agent roles suite is what exposed it, and that suite fails roughly three runs in four without it.

### Approach

Coverage was chosen by measuring, not by guessing. Each suite drives the real running server over HTTP using the existing `testutils` helpers, and anything read at startup patches the deployment configuration and restarts, restoring and restarting again on cleanup.

New suites: agent roles and display resolution, application certificate lifecycle, vendor scoped connection listing, group display attributes, the OIDC prompt parameter contract, `private_key_jwt` client authentication, the role management authorization boundary, OU role listing, user usages, permission scope consent, export of the entity backed resource types, and import delete.

The role fix sorts the merged result. Both callers treat it as a set, so ordering is not otherwise observable, and a store level regression test pins it.

Two findings are recorded in the commit message because each bounds what integration coverage can reach:

- **The role API admits only root callers.** `/roles` has no entry in the API permission table, so every role path falls back to the root `system` permission. Since the grant guard short circuits for root, the role privilege escalation guard cannot fire for any HTTP caller in the shipped configuration. The new suite pins the boundary that does apply and documents what would have to change for the guard to become reachable. Worth a look independently: role administration currently cannot be delegated to a scoped administrator.
- **Subject attribute mapping validation does not reject invalid mappings on application creation.** See the note on CI below.

### Overlap with recently merged work

Rebased onto `f5593a23f`. A number of integration suites landed on `main` in the meantime that overlap this branch, so the following were dropped in favour of the versions now on `main`, each of which is a superset:

- `flow/registration/attribute_uniqueness_test.go` (theirs: 5 tests to our 3)
- `oauth/token/private_key_jwt_test.go` (theirs: 792 lines to our 510)
- Our permission-consent suite, reduced to the two assertions `consent_permissions_test.go` does not make: the rollup-parent linkage and the purpose naming. Those cover `computePermissionParents` and `buildPermissionPurposePrompt`, which the suite on `main` does not reach.

Duplicate prompt/decision payload types were removed in favour of the package-level ones in `consent_permissions_test.go`, extended by three fields the retained tests need (`Parent`, `PurposeID`, `Reason`). Same for a duplicated `errCodeUserNotFound`.

### Verification

**178 integration suites pass, 0 failures**, against a distribution freshly built from this branch. Backend unit tests, lint (0 issues), format check, and mock verification all pass.

### Separate defect, not addressed here

While writing this coverage, three `subjectAttribute` validation cases in `TestInboundClientValidationSuite` were failing on `main`: invalid mappings are accepted with `201` instead of `400` / `APP-1045`. Those three cases have since been **deleted** from that suite, and the guard at `inboundclient/service.go:1331` is unchanged, so the suite is green because the cases are gone rather than because the behaviour changed. The guard returns success when its entity-type dependency is nil, which fails open. Filing separately with the analysis; flagging here only so the green suite is not read as coverage of that path.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added role listings for organization units and agents, including pagination and inherited roles.
  * Added display details for organization units and application group members.
  * Expanded exports to include users, user types, agent types, and translations.
  * Added OAuth application certificate updates and vendor-scoped connection listings.
  * Improved authentication flows with consent handling, onboarding, flow lifecycle controls, and execution observability.
  * Added user usage checks and deletion safeguards, including SSO session termination.

* **Bug Fixes**
  * Ensured merged permissions and role results remain consistently ordered.
  * Improved initialization for integration tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->