### PR TITLE
Document flow execute back behaviour

### DIFF
--- a/docs/content/guides/flows/flow-concepts.mdx
+++ b/docs/content/guides/flows/flow-concepts.mdx
@@ -128,6 +128,14 @@ Always connect both the success and failure ports on every TASK EXECUTION node. 
 
 See [View and Executor Pairings](../advanced-configurations#view-and-executor-pairings) for guidance on pairing PROMPT nodes with the correct executors.
 
+## Flow Execution
+
+At runtime, a flow only moves forward, never backward. When a user submits a PROMPT screen, <ProductName /> validates the input and executes the connected path. The response is the next step in the flow: another PROMPT screen, the same screen re-displayed with an error when the input is rejected, or a terminal result that completes the flow. The engine keeps flow state on the server and does not expose a way to return to a step the user has already passed.
+
+:::warning
+Flow execution does not support going back to a previous step, either through a dedicated back control or the browser's back button.
+:::
+
 ## Interceptors
 
 A flow definition can declare an optional `interceptors` array to attach cross-cutting operations that run at defined lifecycle points (before or after a request, or around individual nodes). Interceptors are declared at the flow level and apply across nodes based on their mode and scope.

--- a/docs/content/key-concepts/authentication/integration-models.mdx
+++ b/docs/content/key-concepts/authentication/integration-models.mdx
@@ -84,6 +84,10 @@ Whether an application may initiate one of these flows directly depends on its [
 
 See the [API Reference](../../../apis#tag/flow-execution) for endpoint specifications.
 
+:::note[No Backward Navigation]
+Flow execution does not support going back to a previous step, either through a dedicated back control or the browser's back button.
+:::
+
 ### Flow Secret
 
 A confidential server-side application (one with no OAuth 2.0 configuration, or one that is confidential and does not use the `authorization_code` grant) authenticates at flow initiation with a **Flow Secret**. <ProductName /> issues this secret once, when the application is created, and never returns it again; the [Console](../../guides/applications/application-settings.mdx) can regenerate it if it's lost. Keep it server-side only, since a browser SPA has nowhere safe to hold it, which is why the `browser` application type is never issued one (see [Direct Initiation Restriction](#direct-initiation-restriction) above).


### PR DESCRIPTION
### Purpose
This pull request adds documentation clarifying that flow execution does not support backward navigation—users cannot return to a previous step, either via a back button in the UI or the browser's back button. The information is now included in both the flow concepts and authentication integration model guides.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- Fixes https://github.com/thunder-id/thunderid/issues/4880

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on flow execution, including server-managed state, input validation, and forward-only node progression.
  * Clarified that flows do not support backward navigation through back controls or the browser’s back button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->