### PR TITLE
Improve integration tests for group package

### DIFF
--- a/tests/integration/group/group_api_test.go
+++ b/tests/integration/group/group_api_test.go
@@ -24,7 +24,8 @@ var (
 	}
 
 	testUserType = testutils.UserType{
-		Name: "group-test-person",
+		Name:             "group-test-person",
+		SystemAttributes: &testutils.UserTypeSystemAttributes{Display: "email"},
 		Schema: map[string]interface{}{
 			"email": map[string]interface{}{
 				"type": "string",

--- a/tests/integration/group/group_authz_test.go
+++ b/tests/integration/group/group_authz_test.go
@@ -64,6 +64,21 @@ type GroupAuthzTestSuite struct {
 	memberUserOU2ID   string
 	memberSchemaOU2ID string
 
+	// An OU holding no groups, plus a manager scoped to it, to verify a listing restricted to an
+	// empty scope returns nothing instead of falling back to an unrestricted list.
+	emptyOUID        string
+	emptyOUSchemaID  string
+	emptyOUMgrUserID string
+	emptyOUMgrRoleID string
+	emptyOUMgrClient *http.Client
+
+	// A manager scoped to the declarative OU, used to verify that an OU-restricted listing reaches
+	// the file-based store and not only the database.
+	declOUSchemaID  string
+	declOUMgrUserID string
+	declOUMgrRoleID string
+	declOUMgrClient *http.Client
+
 	// HTTP client carrying the user-manager's system:group scoped token
 	groupAdminClient *http.Client
 }
@@ -88,6 +103,16 @@ const (
 	memberOU1Password = "MemberOU1@123"
 	memberOU2Username = "authz-member-ou2"
 	memberOU2Password = "MemberOU2@123"
+
+	declOUSchemaName  = "authz-decl-ou-schema"
+	declOUMgrUsername = "authz-decl-ou-manager"
+	declOUMgrPassword = "DeclOUMgr@123"
+
+	emptyOUHandle        = "authz-group-empty-ou"
+	emptyOUSchemaName    = "authz-empty-ou-schema"
+	emptyOUMgrUsername   = "authz-empty-ou-manager"
+	emptyOUMgrPassword   = "EmptyOUMgr@123"
+	groupAuthzScopedRSID = "https://authz-test.example.com/group"
 )
 
 func TestGroupAuthzTestSuite(t *testing.T) {
@@ -207,9 +232,8 @@ func (ts *GroupAuthzTestSuite) SetupSuite() {
 	// The product ships only the root "system" scope; this reproduces "system:ou:view",
 	// "system:group" and "system:group:view" so the suite can verify resource-level enforcement
 	// when configured.
-	const scopedRSIdentifier = "https://authz-test.example.com/group"
 	systemRSID, err := testutils.CreateSystemScopedResourceServer(
-		ts.groupOU1ID, "Authz Test RS (group)", scopedRSIdentifier, "ou", "group", "user")
+		ts.groupOU1ID, "Authz Test RS (group)", groupAuthzScopedRSID, "ou", "group", "user")
 	ts.Require().NoError(err, "create scoped resource server")
 	ts.scopedRSID = systemRSID
 
@@ -239,7 +263,7 @@ func (ts *GroupAuthzTestSuite) SetupSuite() {
 		groupMgrPassword,
 		true,
 		"",
-		scopedRSIdentifier,
+		groupAuthzScopedRSID,
 	)
 	ts.Require().NoError(err, "obtain group-manager token")
 	ts.Require().NotEmpty(tokenResp.AccessToken, "group-manager token must be non-empty")
@@ -284,6 +308,124 @@ func (ts *GroupAuthzTestSuite) SetupSuite() {
 	})
 	ts.Require().NoError(err, "create librarian role")
 	ts.librarianRoleID = librarianRoleID
+
+	// ---- 9. Create an OU with no groups and a manager scoped to it ----
+	emptyOUID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      emptyOUHandle,
+		Name:        "Group Authz Empty OU",
+		Description: "OU holding no groups, for empty-scope listing checks",
+	})
+	ts.Require().NoError(err, "create empty OU")
+	ts.emptyOUID = emptyOUID
+
+	emptySchemaID, err := testutils.CreateUserType(testutils.UserType{
+		Name: emptyOUSchemaName,
+		OUID: ts.emptyOUID,
+		Schema: map[string]interface{}{
+			"username":     map[string]interface{}{"type": "string"},
+			"password":     map[string]interface{}{"type": "string", "credential": true},
+			"display_name": map[string]interface{}{"type": "string"},
+		},
+	})
+	ts.Require().NoError(err, "create user type for the empty OU")
+	ts.emptyOUSchemaID = emptySchemaID
+
+	emptyMgrUserID, err := testutils.CreateUser(testutils.User{
+		Type: emptyOUSchemaName,
+		OUID: ts.emptyOUID,
+		Attributes: json.RawMessage(fmt.Sprintf(
+			`{"username": %q, "password": %q, "display_name": "Empty OU Manager"}`,
+			emptyOUMgrUsername, emptyOUMgrPassword,
+		)),
+	})
+	ts.Require().NoError(err, "create empty-OU manager user")
+	ts.emptyOUMgrUserID = emptyMgrUserID
+
+	emptyMgrRoleID, err := testutils.CreateRole(testutils.Role{
+		Name: "authz-empty-ou-manager-role",
+		OUID: ts.emptyOUID,
+		Permissions: []testutils.ResourcePermissions{
+			{
+				ResourceServerID: systemRSID,
+				Permissions:      []string{"system:ou:view", "system:group", "system:group:view"},
+			},
+		},
+		Assignments: []testutils.Assignment{
+			{ID: ts.emptyOUMgrUserID, Type: "user"},
+		},
+	})
+	ts.Require().NoError(err, "create empty-OU manager role")
+	ts.emptyOUMgrRoleID = emptyMgrRoleID
+
+	emptyMgrToken, err := testutils.ObtainAccessTokenWithPassword(
+		groupAuthzDevelopClientID,
+		groupAuthzDevelopRedirectURI,
+		"system:ou:view system:group system:group:view",
+		emptyOUMgrUsername,
+		emptyOUMgrPassword,
+		true,
+		"",
+		groupAuthzScopedRSID,
+	)
+	ts.Require().NoError(err, "obtain empty-OU manager token")
+	ts.Require().NotEmpty(emptyMgrToken.AccessToken, "empty-OU manager token must be non-empty")
+
+	ts.emptyOUMgrClient = testutils.GetHTTPClientWithToken(emptyMgrToken.AccessToken)
+
+	// ---- 10. Create a manager scoped to the declarative OU ----
+	declSchemaID, err := testutils.CreateUserType(testutils.UserType{
+		Name: declOUSchemaName,
+		OUID: declGroupOUID,
+		Schema: map[string]interface{}{
+			"username":     map[string]interface{}{"type": "string"},
+			"password":     map[string]interface{}{"type": "string", "credential": true},
+			"display_name": map[string]interface{}{"type": "string"},
+		},
+	})
+	ts.Require().NoError(err, "create user type for the declarative OU")
+	ts.declOUSchemaID = declSchemaID
+
+	declMgrUserID, err := testutils.CreateUser(testutils.User{
+		Type: declOUSchemaName,
+		OUID: declGroupOUID,
+		Attributes: json.RawMessage(fmt.Sprintf(
+			`{"username": %q, "password": %q, "display_name": "Declarative OU Manager"}`,
+			declOUMgrUsername, declOUMgrPassword,
+		)),
+	})
+	ts.Require().NoError(err, "create declarative-OU manager user")
+	ts.declOUMgrUserID = declMgrUserID
+
+	declMgrRoleID, err := testutils.CreateRole(testutils.Role{
+		Name: "authz-decl-ou-manager-role",
+		OUID: declGroupOUID,
+		Permissions: []testutils.ResourcePermissions{
+			{
+				ResourceServerID: systemRSID,
+				Permissions:      []string{"system:ou:view", "system:group", "system:group:view"},
+			},
+		},
+		Assignments: []testutils.Assignment{
+			{ID: ts.declOUMgrUserID, Type: "user"},
+		},
+	})
+	ts.Require().NoError(err, "create declarative-OU manager role")
+	ts.declOUMgrRoleID = declMgrRoleID
+
+	declMgrToken, err := testutils.ObtainAccessTokenWithPassword(
+		groupAuthzDevelopClientID,
+		groupAuthzDevelopRedirectURI,
+		"system:ou:view system:group system:group:view",
+		declOUMgrUsername,
+		declOUMgrPassword,
+		true,
+		"",
+		groupAuthzScopedRSID,
+	)
+	ts.Require().NoError(err, "obtain declarative-OU manager token")
+	ts.Require().NotEmpty(declMgrToken.AccessToken, "declarative-OU manager token must be non-empty")
+
+	ts.declOUMgrClient = testutils.GetHTTPClientWithToken(declMgrToken.AccessToken)
 }
 
 // ---------------------------------------------------------------------------
@@ -304,6 +446,41 @@ func (ts *GroupAuthzTestSuite) TearDownSuite() {
 	if ts.librarianRoleID != "" {
 		if err := testutils.DeleteRole(ts.librarianRoleID); err != nil {
 			ts.T().Logf("teardown: delete librarian role: %v", err)
+		}
+	}
+	if ts.declOUMgrRoleID != "" {
+		if err := testutils.DeleteRole(ts.declOUMgrRoleID); err != nil {
+			ts.T().Logf("teardown: delete declarative-OU manager role: %v", err)
+		}
+	}
+	if ts.declOUMgrUserID != "" {
+		if err := testutils.DeleteUser(ts.declOUMgrUserID); err != nil {
+			ts.T().Logf("teardown: delete declarative-OU manager user: %v", err)
+		}
+	}
+	if ts.declOUSchemaID != "" {
+		if err := testutils.DeleteUserType(ts.declOUSchemaID); err != nil {
+			ts.T().Logf("teardown: delete declarative-OU user type: %v", err)
+		}
+	}
+	if ts.emptyOUMgrRoleID != "" {
+		if err := testutils.DeleteRole(ts.emptyOUMgrRoleID); err != nil {
+			ts.T().Logf("teardown: delete empty-OU manager role: %v", err)
+		}
+	}
+	if ts.emptyOUMgrUserID != "" {
+		if err := testutils.DeleteUser(ts.emptyOUMgrUserID); err != nil {
+			ts.T().Logf("teardown: delete empty-OU manager user: %v", err)
+		}
+	}
+	if ts.emptyOUSchemaID != "" {
+		if err := testutils.DeleteUserType(ts.emptyOUSchemaID); err != nil {
+			ts.T().Logf("teardown: delete empty-OU user type: %v", err)
+		}
+	}
+	if ts.emptyOUID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.emptyOUID); err != nil {
+			ts.T().Logf("teardown: delete empty OU: %v", err)
 		}
 	}
 	for _, id := range []string{ts.nestedInLibraryID, ts.librarianGroupID,
@@ -570,6 +747,225 @@ func (ts *GroupAuthzTestSuite) TestRemoveMemberFromGroupInOwnOU() {
 
 	ts.Equal(http.StatusOK, resp.StatusCode,
 		"group-manager should be able to remove a user from a group in their own OU")
+}
+
+// ---------------------------------------------------------------------------
+// Tests — OU-scoped denials on the remaining group routes
+// ---------------------------------------------------------------------------
+
+// TestListGroupsByPathInOtherOU verifies the path-based listing is denied for a sibling OU. The
+// denial is raised by the OU lookup that resolves the handle path, before the group authorization
+// check is reached, so a caller outside the OU cannot even enumerate it.
+func (ts *GroupAuthzTestSuite) TestListGroupsByPathInOtherOU() {
+	resp := ts.doGroup(http.MethodGet, "/groups/tree/"+groupAuthzOU2Handle, nil)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusForbidden, resp.StatusCode,
+		"group-manager must not list groups under an OU it holds no group permission for")
+}
+
+// TestListGroupsByPathInOwnOU verifies the same route still works for the manager's own OU.
+func (ts *GroupAuthzTestSuite) TestListGroupsByPathInOwnOU() {
+	resp := ts.doGroup(http.MethodGet, "/groups/tree/"+groupAuthzOU1Handle, nil)
+	defer resp.Body.Close()
+
+	ts.Require().Equal(http.StatusOK, resp.StatusCode,
+		"group-manager should be able to list groups under their own OU")
+
+	var listResp GroupListResponse
+	ts.Require().NoError(json.NewDecoder(resp.Body).Decode(&listResp))
+
+	ids := make([]string, 0, len(listResp.Groups))
+	for _, g := range listResp.Groups {
+		ids = append(ids, g.Id)
+	}
+	ts.Containsf(ids, ts.targetGroupOU1ID, "tree listing must include the OU1 target group, got %v", ids)
+}
+
+// TestCreateGroupByPathInOtherOU verifies the group-manager cannot create a group under OU2 through
+// the path-based route, closing it as an alternative to the denied POST /groups route.
+func (ts *GroupAuthzTestSuite) TestCreateGroupByPathInOtherOU() {
+	payload := ts.mustMarshal(map[string]any{
+		"name":        "authz-denied-tree-group",
+		"description": "Denied Group via tree route",
+	})
+
+	resp := ts.doGroup(http.MethodPost, "/groups/tree/"+groupAuthzOU2Handle, payload)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusForbidden, resp.StatusCode,
+		"group-manager must not create a group under an OU it holds no group permission for")
+}
+
+// TestGetGroupMembersInOtherOU verifies the members of a group in OU2 are not readable.
+func (ts *GroupAuthzTestSuite) TestGetGroupMembersInOtherOU() {
+	resp := ts.doGroup(http.MethodGet, "/groups/"+ts.targetGroupOU2ID+"/members", nil)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusForbidden, resp.StatusCode,
+		"group-manager must not read the members of a group in a different OU")
+}
+
+// TestAddMemberToGroupInOtherOU verifies members cannot be added to a group in OU2.
+func (ts *GroupAuthzTestSuite) TestAddMemberToGroupInOtherOU() {
+	payload := ts.mustMarshal(MembersRequest{
+		Members: []Member{
+			{Id: ts.memberUserOU2ID, Type: MemberTypeUser},
+		},
+	})
+
+	resp := ts.doGroup(http.MethodPost, "/groups/"+ts.targetGroupOU2ID+"/members/add", payload)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusForbidden, resp.StatusCode,
+		"group-manager must not add members to a group in a different OU")
+}
+
+// TestMoveGroupToOtherOU verifies a group cannot be relocated into an OU the caller does not
+// administer, even though the caller may update the group in its current OU.
+func (ts *GroupAuthzTestSuite) TestMoveGroupToOtherOU() {
+	movableID, err := testutils.CreateGroup(testutils.Group{
+		Name:        "authz-movable-ou1",
+		Description: "Group used to verify cross-OU moves are denied",
+		OUID:        ts.groupOU1ID,
+	})
+	ts.Require().NoError(err, "create movable group in OU1")
+	defer func() {
+		if delErr := testutils.DeleteGroup(movableID); delErr != nil {
+			ts.T().Logf("cleanup: delete movable group %s: %v", movableID, delErr)
+		}
+	}()
+
+	payload := ts.mustMarshal(map[string]any{
+		"ouId":        ts.groupOU2ID,
+		"name":        "authz-movable-ou1",
+		"description": "Attempted move into OU2",
+	})
+
+	resp := ts.doGroup(http.MethodPut, "/groups/"+movableID, payload)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusForbidden, resp.StatusCode,
+		"group-manager must not move a group into an OU they do not administer")
+
+	// The group must remain in OU1 after the rejected move.
+	getResp := ts.doGroup(http.MethodGet, "/groups/"+movableID, nil)
+	defer getResp.Body.Close()
+
+	ts.Require().Equal(http.StatusOK, getResp.StatusCode)
+
+	var group Group
+	ts.Require().NoError(json.NewDecoder(getResp.Body).Decode(&group))
+	ts.Equal(ts.groupOU1ID, group.OUID, "the rejected move must not have changed the group's OU")
+}
+
+// TestListGroupsWithEmptyScopeReturnsNothing verifies a manager whose scope holds no groups gets an
+// empty listing rather than falling back to an unrestricted one.
+func (ts *GroupAuthzTestSuite) TestListGroupsWithEmptyScopeReturnsNothing() {
+	req, err := http.NewRequest(http.MethodGet, groupAuthzServerURL+"/groups?limit=100", nil)
+	ts.Require().NoError(err)
+
+	resp, err := ts.emptyOUMgrClient.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Require().Equal(http.StatusOK, resp.StatusCode, "listing should succeed for an empty scope")
+
+	var listResp GroupListResponse
+	ts.Require().NoError(json.NewDecoder(resp.Body).Decode(&listResp))
+
+	ts.Equal(0, listResp.TotalResults, "an OU holding no groups must report no results")
+	ts.Empty(listResp.Groups, "an OU holding no groups must return no groups")
+	ts.Equal(1, listResp.StartIndex)
+	ts.Empty(listResp.Links, "an empty listing carries no pagination links")
+}
+
+// TestOUScopedListingIncludesDeclarativeGroups verifies an OU-restricted listing draws from the
+// file-based store as well as the database, so a manager scoped to the declarative OU sees the
+// YAML-declared groups alongside any runtime group in the same OU.
+func (ts *GroupAuthzTestSuite) TestOUScopedListingIncludesDeclarativeGroups() {
+	runtimeGroupID, err := testutils.CreateGroup(testutils.Group{
+		Name:        "authz-runtime-in-decl-ou",
+		Description: "Runtime group in the declarative OU",
+		OUID:        declGroupOUID,
+	})
+	ts.Require().NoError(err, "create runtime group in the declarative OU")
+	defer func() {
+		if delErr := testutils.DeleteGroup(runtimeGroupID); delErr != nil {
+			ts.T().Logf("cleanup: delete runtime group %s: %v", runtimeGroupID, delErr)
+		}
+	}()
+
+	req, err := http.NewRequest(http.MethodGet, groupAuthzServerURL+"/groups?limit=100", nil)
+	ts.Require().NoError(err)
+
+	resp, err := ts.declOUMgrClient.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var listResp GroupListResponse
+	ts.Require().NoError(json.NewDecoder(resp.Body).Decode(&listResp))
+
+	ids := make([]string, 0, len(listResp.Groups))
+	for _, g := range listResp.Groups {
+		ids = append(ids, g.Id)
+	}
+
+	ts.Containsf(ids, declGroupID, "scoped listing must include the declarative group, got %v", ids)
+	ts.Containsf(ids, declNestedGroupID, "scoped listing must include the nested declarative group, got %v", ids)
+	ts.Containsf(ids, runtimeGroupID, "scoped listing must include the runtime group, got %v", ids)
+	ts.NotContainsf(ids, ts.targetGroupOU1ID, "scoped listing must exclude groups from other OUs, got %v", ids)
+}
+
+// TestOUScopedListingPaginatesAcrossBothStores verifies pagination applies to the merged result of
+// the database and file-based stores rather than to either store alone.
+func (ts *GroupAuthzTestSuite) TestOUScopedListingPaginatesAcrossBothStores() {
+	// The declarative OU holds two YAML groups; a runtime group is needed as well, otherwise the
+	// paging below never crosses a store boundary.
+	runtimeGroupID, err := testutils.CreateGroup(testutils.Group{
+		Name:        "authz-paginated-in-decl-ou",
+		Description: "Runtime group used to page across both stores",
+		OUID:        declGroupOUID,
+	})
+	ts.Require().NoError(err, "create runtime group in the declarative OU")
+	defer func() {
+		if delErr := testutils.DeleteGroup(runtimeGroupID); delErr != nil {
+			ts.T().Logf("cleanup: delete runtime group %s: %v", runtimeGroupID, delErr)
+		}
+	}()
+
+	seen := make(map[string]bool)
+	for offset := 0; offset < 3; offset++ {
+		req, err := http.NewRequest(http.MethodGet,
+			fmt.Sprintf("%s/groups?limit=1&offset=%d", groupAuthzServerURL, offset), nil)
+		ts.Require().NoError(err)
+
+		resp, err := ts.declOUMgrClient.Do(req)
+		ts.Require().NoError(err)
+
+		ts.Require().Equal(http.StatusOK, resp.StatusCode)
+
+		var listResp GroupListResponse
+		decodeErr := json.NewDecoder(resp.Body).Decode(&listResp)
+		resp.Body.Close()
+		ts.Require().NoError(decodeErr)
+
+		ts.Require().Equal(3, listResp.TotalResults,
+			"the declarative OU holds the two declared groups plus the runtime one")
+		ts.LessOrEqual(listResp.Count, 1, "a page must not exceed the requested limit")
+		ts.Equal(offset+1, listResp.StartIndex)
+
+		for _, g := range listResp.Groups {
+			ts.Falsef(seen[g.Id], "group %s must not repeat across pages", g.Id)
+			seen[g.Id] = true
+		}
+	}
+
+	ts.Len(seen, 3, "paging through the scoped listing must yield each group exactly once")
+	ts.Truef(seen[runtimeGroupID], "paging must surface the runtime group, got %v", seen)
+	ts.Truef(seen[declGroupID], "paging must surface the declarative group, got %v", seen)
 }
 
 // mustMarshal encodes a JSON request body, failing the test on error.

--- a/tests/integration/group/group_cascade_test.go
+++ b/tests/integration/group/group_cascade_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package group
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// This file extends GroupAPITestSuite with coverage for the dependency cascade that runs when a
+// principal is deleted. Group memberships are cleaned up rather than blocking the delete, so a
+// deleted user must not linger as a member, and a deleted group must disappear both from the groups
+// that contain it and from the roles assigned to it.
+
+// TestDeletingUserRemovesGroupMembership verifies deleting a user cascades to the memberships it
+// held, leaving no stale member behind.
+func (suite *GroupAPITestSuite) TestDeletingUserRemovesGroupMembership() {
+	tempUserID, err := testutils.CreateUser(testutils.User{
+		OUID: testOUID,
+		Type: testUserType.Name,
+		Attributes: json.RawMessage(`{
+			"email": "cascade-user@example.com",
+			"given_name": "Cascade",
+			"family_name": "User",
+			"password": "TestPassword123!"
+		}`),
+	})
+	suite.Require().NoError(err)
+	// The delete below is the action under test; this only covers the paths that abort before it.
+	defer func() { _ = testutils.DeleteUser(tempUserID) }()
+
+	groupID, err := createGroup(CreateGroupRequest{
+		Name: "Cascade Membership Group",
+		OUID: testOUID,
+		Members: []Member{
+			{Id: tempUserID, Type: MemberTypeUser},
+		},
+	})
+	suite.Require().NoError(err)
+	defer func() {
+		if deleteErr := deleteGroup(groupID); deleteErr != nil {
+			suite.T().Logf("Failed to clean up group: %v", deleteErr)
+		}
+	}()
+
+	before := suite.memberList(groupID)
+	suite.Require().Equal(1, before.TotalResults, "the group should hold one member before deletion")
+	suite.Require().Len(before.Members, 1, "the user should be a member before deletion")
+
+	suite.Require().NoError(testutils.DeleteUser(tempUserID))
+
+	// TotalResults comes from the stored member rows, while Members is the resolved view that drops
+	// members whose entity no longer exists. Both have to reach zero: asserting only on Members would
+	// pass even if the cascade left the membership row behind.
+	after := suite.memberList(groupID)
+	suite.Equal(0, after.TotalResults, "deleting a user should remove the stored membership row")
+	suite.Empty(after.Members, "the deleted user should not remain a member")
+}
+
+// TestDeletingGroupRemovesNestingAndRoleAssignment verifies deleting a group cascades to both the
+// groups that nest it and the roles assigned to it.
+func (suite *GroupAPITestSuite) TestDeletingGroupRemovesNestingAndRoleAssignment() {
+	nestedGroupID, err := createGroup(CreateGroupRequest{
+		Name:    "Cascade Nested Group",
+		OUID:    testOUID,
+		Members: []Member{},
+	})
+	suite.Require().NoError(err)
+
+	nestedGroupDeleted := false
+	defer func() {
+		if nestedGroupDeleted {
+			return
+		}
+		if deleteErr := deleteGroup(nestedGroupID); deleteErr != nil {
+			suite.T().Logf("Failed to clean up nested group: %v", deleteErr)
+		}
+	}()
+
+	parentGroupID, err := createGroup(CreateGroupRequest{
+		Name: "Cascade Parent Group",
+		OUID: testOUID,
+		Members: []Member{
+			{Id: nestedGroupID, Type: MemberTypeGroup},
+		},
+	})
+	suite.Require().NoError(err)
+	defer func() {
+		if deleteErr := deleteGroup(parentGroupID); deleteErr != nil {
+			suite.T().Logf("Failed to clean up parent group: %v", deleteErr)
+		}
+	}()
+
+	roleID, err := testutils.CreateRole(testutils.Role{
+		Name: "Cascade Test Role",
+		OUID: testOUID,
+		Assignments: []testutils.Assignment{
+			{ID: nestedGroupID, Type: "group"},
+		},
+	})
+	suite.Require().NoError(err)
+	defer func() {
+		if deleteErr := testutils.DeleteRole(roleID); deleteErr != nil {
+			suite.T().Logf("Failed to clean up role: %v", deleteErr)
+		}
+	}()
+
+	assignments, err := testutils.GetRoleAssignments(roleID)
+	suite.Require().NoError(err)
+	suite.Require().Len(assignments, 1, "the group should be assigned to the role before deletion")
+
+	suite.Require().NoError(deleteGroup(nestedGroupID))
+	nestedGroupDeleted = true
+
+	after := suite.memberList(parentGroupID)
+	suite.Equal(0, after.TotalResults, "deleting a group should remove the stored nesting row")
+	for _, member := range after.Members {
+		suite.NotEqual(nestedGroupID, member.Id,
+			"the deleted group should no longer be a member of its parent group")
+	}
+
+	assignmentsAfter, err := testutils.GetRoleAssignments(roleID)
+	suite.Require().NoError(err)
+	for _, assignment := range assignmentsAfter {
+		suite.NotEqual(nestedGroupID, assignment.ID,
+			"the deleted group should no longer hold a role assignment")
+	}
+}
+
+// memberList returns the member listing reported for the given group.
+func (suite *GroupAPITestSuite) memberList(groupID string) MemberListResponse {
+	suite.T().Helper()
+
+	req, err := http.NewRequest("GET", testServerURL+"/groups/"+groupID+"/members?limit=100", nil)
+	suite.Require().NoError(err)
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var memberList MemberListResponse
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&memberList))
+	return memberList
+}

--- a/tests/integration/group/group_declarative_test.go
+++ b/tests/integration/group/group_declarative_test.go
@@ -1,0 +1,363 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package group
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// GroupDeclarativeAPITestSuite validates how the group API treats YAML-declared groups while the
+// group store runs in composite mode (the product default). Declarative groups live in the
+// file-based store alongside runtime groups in the database: reads merge both stores, while every
+// write against a declarative group must be rejected as immutable. The fixture IDs live in model.go.
+const (
+	declGroupClientID    = "CONSOLE"
+	declGroupRedirectURI = "https://localhost:8095/console"
+)
+
+type GroupDeclarativeAPITestSuite struct {
+	suite.Suite
+}
+
+func TestGroupDeclarativeAPITestSuite(t *testing.T) {
+	suite.Run(t, new(GroupDeclarativeAPITestSuite))
+}
+
+// doDeclarative issues a request against the group API using the admin client.
+func (suite *GroupDeclarativeAPITestSuite) doDeclarative(method, path string, body []byte) *http.Response {
+	suite.T().Helper()
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequest(method, testServerURL+path, bodyReader)
+	suite.Require().NoError(err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	suite.Require().NoError(err)
+	return resp
+}
+
+// TestGetDeclarativeGroup verifies a YAML-declared group is served from the file-based store and
+// is flagged read-only.
+func (suite *GroupDeclarativeAPITestSuite) TestGetDeclarativeGroup() {
+	resp := suite.doDeclarative(http.MethodGet, "/groups/"+declGroupID, nil)
+	defer resp.Body.Close()
+
+	suite.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var group Group
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&group))
+
+	suite.Equal(declGroupID, group.Id)
+	suite.Equal(declGroupName, group.Name)
+	suite.Equal(declGroupOUID, group.OUID)
+	suite.True(group.IsReadOnly, "a YAML-declared group must be reported as read-only")
+}
+
+// TestListGroupsMergesDeclarativeAndDatabaseGroups verifies the composite store returns groups from
+// both the file-based store and the database in a single listing.
+func (suite *GroupDeclarativeAPITestSuite) TestListGroupsMergesDeclarativeAndDatabaseGroups() {
+	dbGroupID, err := createGroup(CreateGroupRequest{
+		Name:    "Declarative Merge Probe Group",
+		OUID:    declGroupOUID,
+		Members: []Member{},
+	})
+	suite.Require().NoError(err)
+	defer func() {
+		if deleteErr := deleteGroup(dbGroupID); deleteErr != nil {
+			suite.T().Logf("Failed to clean up probe group: %v", deleteErr)
+		}
+	}()
+
+	resp := suite.doDeclarative(http.MethodGet, "/groups?limit=100", nil)
+	defer resp.Body.Close()
+
+	suite.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var listResponse GroupListResponse
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&listResponse))
+
+	readOnlyByID := make(map[string]bool, len(listResponse.Groups))
+	ids := make([]string, 0, len(listResponse.Groups))
+	for _, g := range listResponse.Groups {
+		ids = append(ids, g.Id)
+		readOnlyByID[g.Id] = g.IsReadOnly
+	}
+
+	suite.Containsf(ids, declGroupID, "listing must include the declarative group, got %v", ids)
+	suite.Containsf(ids, dbGroupID, "listing must include the database group, got %v", ids)
+	suite.True(readOnlyByID[declGroupID], "the declarative group must be flagged read-only")
+	suite.False(readOnlyByID[dbGroupID], "a database-backed group must not be flagged read-only")
+}
+
+// TestGetDeclarativeGroupMembers verifies members declared in YAML are served through the members
+// endpoint, for both the nested group member of the outer group and the entity member of the inner.
+func (suite *GroupDeclarativeAPITestSuite) TestGetDeclarativeGroupMembers() {
+	outerResp := suite.doDeclarative(http.MethodGet, "/groups/"+declGroupID+"/members", nil)
+	defer outerResp.Body.Close()
+
+	suite.Require().Equal(http.StatusOK, outerResp.StatusCode)
+
+	var outerMembers MemberListResponse
+	suite.Require().NoError(json.NewDecoder(outerResp.Body).Decode(&outerMembers))
+
+	suite.Require().Equal(1, outerMembers.TotalResults, "the outer group declares one member")
+	suite.Require().Len(outerMembers.Members, 1, "the declared member must be returned in the listing")
+	suite.Equal(declNestedGroupID, outerMembers.Members[0].Id)
+	suite.Equal(MemberTypeGroup, outerMembers.Members[0].Type, "the nested group member must be returned")
+
+	nestedResp := suite.doDeclarative(http.MethodGet, "/groups/"+declNestedGroupID+"/members", nil)
+	defer nestedResp.Body.Close()
+
+	suite.Require().Equal(http.StatusOK, nestedResp.StatusCode)
+
+	var nestedMembers MemberListResponse
+	suite.Require().NoError(json.NewDecoder(nestedResp.Body).Decode(&nestedMembers))
+
+	suite.Require().Equal(1, nestedMembers.TotalResults, "the nested group declares one member")
+	suite.Require().Len(nestedMembers.Members, 1, "the declared member must be returned in the listing")
+	suite.Equal(declGroupMemberID, nestedMembers.Members[0].Id)
+	suite.Equal(MemberTypeUser, nestedMembers.Members[0].Type,
+		"the declared entity member must resolve to its public 'user' type")
+}
+
+// TestDeclarativeGroupMemberDisplayResolves verifies that resolving display names for a runtime
+// group's members reaches into the file-based store, so a nested declarative group is shown by name
+// rather than by ID.
+func (suite *GroupDeclarativeAPITestSuite) TestDeclarativeGroupMemberDisplayResolves() {
+	hostID, err := createGroup(CreateGroupRequest{
+		Name: "Runtime Host For Declarative Member",
+		OUID: declGroupOUID,
+		Members: []Member{
+			{Id: declNestedGroupID, Type: MemberTypeGroup},
+		},
+	})
+	suite.Require().NoError(err)
+	defer func() {
+		if deleteErr := deleteGroup(hostID); deleteErr != nil {
+			suite.T().Logf("Failed to clean up host group: %v", deleteErr)
+		}
+	}()
+
+	resp := suite.doDeclarative(http.MethodGet, "/groups/"+hostID+"/members?include=display", nil)
+	defer resp.Body.Close()
+
+	suite.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var memberList MemberListResponse
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&memberList))
+
+	suite.Require().Len(memberList.Members, 1)
+	suite.Equal(declNestedGroupID, memberList.Members[0].Id)
+	suite.Equal(declNestedGroupName, memberList.Members[0].Display,
+		"a declarative group member should display its declared name")
+}
+
+// TestExportAllGroupsIncludesDeclarativeGroups verifies the wildcard group export enumerates every
+// group the service can list, including the YAML-declared ones.
+func (suite *GroupDeclarativeAPITestSuite) TestExportAllGroupsIncludesDeclarativeGroups() {
+	payload, err := json.Marshal(map[string]any{"groups": []string{"*"}})
+	suite.Require().NoError(err)
+
+	resp := suite.doDeclarative(http.MethodPost, "/export", payload)
+	defer resp.Body.Close()
+
+	suite.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	suite.Require().NoError(err)
+
+	content := string(body)
+	suite.Contains(content, declGroupName, "wildcard export should include the declarative group")
+	suite.Contains(content, declNestedGroupName, "wildcard export should include the nested declarative group")
+}
+
+// TestUpdateDeclarativeGroupIsRejected verifies a YAML-declared group cannot be updated.
+func (suite *GroupDeclarativeAPITestSuite) TestUpdateDeclarativeGroupIsRejected() {
+	payload, err := json.Marshal(UpdateGroupRequest{
+		Name: "Renamed Declarative Group",
+		OUID: declGroupOUID,
+	})
+	suite.Require().NoError(err)
+
+	resp := suite.doDeclarative(http.MethodPut, "/groups/"+declGroupID, payload)
+	defer resp.Body.Close()
+
+	suite.Require().Equal(http.StatusBadRequest, resp.StatusCode)
+
+	var errorResp ErrorResponse
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&errorResp))
+
+	suite.Equal("GRP-1015", errorResp.Code)
+	suite.Equal("Cannot modify declarative group", errorResp.Message.DefaultValue)
+}
+
+// TestDeleteDeclarativeGroupIsRejected verifies a YAML-declared group cannot be deleted.
+func (suite *GroupDeclarativeAPITestSuite) TestDeleteDeclarativeGroupIsRejected() {
+	resp := suite.doDeclarative(http.MethodDelete, "/groups/"+declGroupID, nil)
+	defer resp.Body.Close()
+
+	suite.Require().Equal(http.StatusBadRequest, resp.StatusCode)
+
+	var errorResp ErrorResponse
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&errorResp))
+
+	suite.Equal("GRP-1015", errorResp.Code)
+	suite.Equal("Cannot modify declarative group", errorResp.Message.DefaultValue)
+
+	// The group must still be retrievable after the rejected delete.
+	getResp := suite.doDeclarative(http.MethodGet, "/groups/"+declGroupID, nil)
+	defer getResp.Body.Close()
+	suite.Equal(http.StatusOK, getResp.StatusCode)
+}
+
+// TestGetDeclarativeGroupsByPath verifies declarative groups are listed under their OU handle path.
+func (suite *GroupDeclarativeAPITestSuite) TestGetDeclarativeGroupsByPath() {
+	resp := suite.doDeclarative(http.MethodGet, "/groups/tree/"+declGroupOUHandle+"?limit=100", nil)
+	defer resp.Body.Close()
+
+	suite.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var listResponse GroupListResponse
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&listResponse))
+
+	ids := make([]string, 0, len(listResponse.Groups))
+	for _, g := range listResponse.Groups {
+		ids = append(ids, g.Id)
+	}
+
+	suite.Containsf(ids, declGroupID, "tree listing must include the declarative group, got %v", ids)
+	suite.Containsf(ids, declNestedGroupID, "tree listing must include the nested declarative group, got %v", ids)
+}
+
+// TestCreateGroupConflictingWithDeclarativeName verifies the name-conflict check spans the
+// file-based store, so a runtime group cannot shadow a declarative one in the same OU.
+func (suite *GroupDeclarativeAPITestSuite) TestCreateGroupConflictingWithDeclarativeName() {
+	payload, err := json.Marshal(CreateGroupRequest{
+		Name:    declGroupName,
+		OUID:    declGroupOUID,
+		Members: []Member{},
+	})
+	suite.Require().NoError(err)
+
+	resp := suite.doDeclarative(http.MethodPost, "/groups", payload)
+	defer resp.Body.Close()
+
+	// If the conflict check ever stops spanning the file store the group is created instead, and
+	// leaving it behind would shadow the declarative group in every later composite listing.
+	if resp.StatusCode == http.StatusCreated {
+		var created Group
+		if decodeErr := json.NewDecoder(resp.Body).Decode(&created); decodeErr == nil && created.Id != "" {
+			defer func() {
+				if deleteErr := deleteGroup(created.Id); deleteErr != nil {
+					suite.T().Logf("Failed to clean up conflicting group: %v", deleteErr)
+				}
+			}()
+		}
+	}
+
+	suite.Require().Equal(http.StatusConflict, resp.StatusCode)
+
+	var errorResp ErrorResponse
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&errorResp))
+
+	suite.Equal("GRP-1004", errorResp.Code)
+	suite.Equal("Group name conflict", errorResp.Message.DefaultValue)
+}
+
+// TestDeclarativeUserInheritsPermissionThroughNestedGroups verifies permission resolution walks the
+// declarative nesting chain: decl-user-1 is a member only of decl-group-2, which is nested inside
+// decl-group-1, and only decl-group-1 carries the role. The user therefore inherits the permission
+// transitively, which requires the file-based store to walk from the member's group up to its parent.
+func (suite *GroupDeclarativeAPITestSuite) TestDeclarativeUserInheritsPermissionThroughNestedGroups() {
+	const (
+		rsIdentifier = "https://declarative-group-test.example.com/inherit"
+		grantedScope = "system:group:view"
+	)
+
+	rsID, err := testutils.CreateSystemScopedResourceServer(
+		declGroupOUID, "Declarative Inheritance RS", rsIdentifier, "group")
+	suite.Require().NoError(err)
+	defer func() {
+		if deleteErr := testutils.DeleteResourceServer(rsID); deleteErr != nil {
+			suite.T().Logf("Failed to clean up resource server: %v", deleteErr)
+		}
+	}()
+
+	roleID, err := testutils.CreateRole(testutils.Role{
+		Name: "Declarative Inheritance Role",
+		OUID: declGroupOUID,
+		Permissions: []testutils.ResourcePermissions{
+			{ResourceServerID: rsID, Permissions: []string{grantedScope}},
+		},
+		Assignments: []testutils.Assignment{
+			{ID: declGroupID, Type: "group"},
+		},
+	})
+	suite.Require().NoError(err)
+	defer func() {
+		if deleteErr := testutils.DeleteRole(roleID); deleteErr != nil {
+			suite.T().Logf("Failed to clean up role: %v", deleteErr)
+		}
+	}()
+
+	tokenResp, err := testutils.ObtainAccessTokenWithPassword(
+		declGroupClientID,
+		declGroupRedirectURI,
+		grantedScope,
+		declGroupMemberID,
+		declGroupMemberPassword,
+		true,
+		"",
+		rsIdentifier,
+	)
+	suite.Require().NoError(err, "the declarative user should be able to authenticate")
+	suite.Require().NotEmpty(tokenResp.AccessToken)
+
+	suite.Contains(tokenResp.Scope, grantedScope,
+		"the permission held by the outer declarative group should reach a member of the nested group")
+}
+
+// TestCreateGroupWithDeclarativeGroupMember verifies a runtime group can nest a declarative group,
+// which requires group ID validation to consult the file-based store.
+func (suite *GroupDeclarativeAPITestSuite) TestCreateGroupWithDeclarativeGroupMember() {
+	payload, err := json.Marshal(CreateGroupRequest{
+		Name: "Runtime Group Nesting Declarative Group",
+		OUID: declGroupOUID,
+		Members: []Member{
+			{Id: declNestedGroupID, Type: MemberTypeGroup},
+		},
+	})
+	suite.Require().NoError(err)
+
+	resp := suite.doDeclarative(http.MethodPost, "/groups", payload)
+	defer resp.Body.Close()
+
+	suite.Require().Equal(http.StatusCreated, resp.StatusCode)
+
+	var created Group
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&created))
+	defer func() {
+		if deleteErr := deleteGroup(created.Id); deleteErr != nil {
+			suite.T().Logf("Failed to clean up group: %v", deleteErr)
+		}
+	}()
+
+	suite.Require().Len(created.Members, 1)
+	suite.Equal(declNestedGroupID, created.Members[0].Id)
+	suite.Equal(MemberTypeGroup, created.Members[0].Type)
+}

--- a/tests/integration/group/group_display_test.go
+++ b/tests/integration/group/group_display_test.go
@@ -1,0 +1,270 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package group
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// This file extends GroupAPITestSuite with coverage for the `include=display` query parameter and
+// for application-typed members. Both feed the same resolution path in the group service: OU
+// handles are resolved for group payloads, while member displays are resolved per member category
+// (user displays come from the user type's display attribute, app displays from the app name, and
+// group displays from the group name).
+
+// testUserDisplay returns the display expected for testUserID. The user type resolves displays
+// through its `email` system attribute, so the expectation is read back off the fixture itself.
+func (suite *GroupAPITestSuite) testUserDisplay() string {
+	suite.T().Helper()
+
+	var attributes struct {
+		Email string `json:"email"`
+	}
+	suite.Require().NoError(json.Unmarshal(testUser.Attributes, &attributes))
+	return attributes.Email
+}
+
+// TestListGroupsWithDisplay verifies `include=display` populates the OU handle on every listed group.
+func (suite *GroupAPITestSuite) TestListGroupsWithDisplay() {
+	client := testutils.GetHTTPClient()
+
+	req, err := http.NewRequest("GET", testServerURL+"/groups?limit=100&include=display", nil)
+	suite.Require().NoError(err)
+
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var listResponse GroupListResponse
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&listResponse))
+
+	found := false
+	for _, group := range listResponse.Groups {
+		if group.Id == createdGroupID {
+			found = true
+			suite.Equal(testOU.Handle, group.OUHandle, "OU handle should be resolved with include=display")
+		}
+	}
+	suite.True(found, "Created group should be in the list")
+}
+
+// TestListGroupsWithoutDisplayOmitsOUHandle verifies the OU handle is only resolved on request.
+func (suite *GroupAPITestSuite) TestListGroupsWithoutDisplayOmitsOUHandle() {
+	client := testutils.GetHTTPClient()
+
+	req, err := http.NewRequest("GET", testServerURL+"/groups?limit=100", nil)
+	suite.Require().NoError(err)
+
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var listResponse GroupListResponse
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&listResponse))
+
+	found := false
+	for _, group := range listResponse.Groups {
+		if group.Id == createdGroupID {
+			found = true
+		}
+		suite.Emptyf(group.OUHandle, "OU handle should be omitted without include=display for group %s", group.Id)
+	}
+	suite.True(found, "Created group should be in the list")
+}
+
+// TestGetGroupWithDisplay verifies `include=display` resolves the OU handle on the single-group
+// endpoint, and that it is omitted otherwise.
+func (suite *GroupAPITestSuite) TestGetGroupWithDisplay() {
+	client := testutils.GetHTTPClient()
+
+	req, err := http.NewRequest("GET", testServerURL+"/groups/"+createdGroupID+"?include=display", nil)
+	suite.Require().NoError(err)
+
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var group Group
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&group))
+
+	suite.Equal(testOU.Handle, group.OUHandle, "OU handle should be resolved with include=display")
+
+	plainReq, err := http.NewRequest("GET", testServerURL+"/groups/"+createdGroupID, nil)
+	suite.Require().NoError(err)
+
+	plainResp, err := client.Do(plainReq)
+	suite.Require().NoError(err)
+	defer plainResp.Body.Close()
+
+	suite.Require().Equal(http.StatusOK, plainResp.StatusCode)
+
+	var plainGroup Group
+	suite.Require().NoError(json.NewDecoder(plainResp.Body).Decode(&plainGroup))
+
+	suite.Empty(plainGroup.OUHandle, "OU handle should be omitted without include=display")
+}
+
+// TestGetGroupMembersWithDisplay verifies member displays are resolved per member category: a user
+// member resolves through its user type's display attribute, a group member through the group name.
+func (suite *GroupAPITestSuite) TestGetGroupMembersWithDisplay() {
+	memberGroupID, err := createGroup(CreateGroupRequest{
+		Name:    "Display Member Group",
+		OUID:    testOUID,
+		Members: []Member{},
+	})
+	suite.Require().NoError(err)
+	defer func() {
+		if deleteErr := deleteGroup(memberGroupID); deleteErr != nil {
+			suite.T().Logf("Failed to clean up member group: %v", deleteErr)
+		}
+	}()
+
+	parentGroupID, err := createGroup(CreateGroupRequest{
+		Name: "Display Parent Group",
+		OUID: testOUID,
+		Members: []Member{
+			{Id: testUserID, Type: MemberTypeUser},
+			{Id: memberGroupID, Type: MemberTypeGroup},
+		},
+	})
+	suite.Require().NoError(err)
+	defer func() {
+		if deleteErr := deleteGroup(parentGroupID); deleteErr != nil {
+			suite.T().Logf("Failed to clean up parent group: %v", deleteErr)
+		}
+	}()
+
+	client := testutils.GetHTTPClient()
+
+	req, err := http.NewRequest("GET", testServerURL+"/groups/"+parentGroupID+"/members?include=display", nil)
+	suite.Require().NoError(err)
+
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var memberList MemberListResponse
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&memberList))
+
+	displayByID := make(map[string]string, len(memberList.Members))
+	for _, member := range memberList.Members {
+		displayByID[member.Id] = member.Display
+	}
+
+	suite.Equal(suite.testUserDisplay(), displayByID[testUserID],
+		"user member display should come from the user type's display attribute")
+	suite.Equal("Display Member Group", displayByID[memberGroupID],
+		"group member display should be the group name")
+}
+
+// TestGetGroupMembersWithoutDisplayOmitsDisplay verifies member displays are only resolved on request.
+func (suite *GroupAPITestSuite) TestGetGroupMembersWithoutDisplayOmitsDisplay() {
+	client := testutils.GetHTTPClient()
+
+	req, err := http.NewRequest("GET", testServerURL+"/groups/"+createdGroupID+"/members", nil)
+	suite.Require().NoError(err)
+
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var memberList MemberListResponse
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&memberList))
+
+	found := false
+	for _, member := range memberList.Members {
+		if member.Id == testUserID {
+			found = true
+		}
+		suite.Emptyf(member.Display, "Display should be omitted without include=display for member %s", member.Id)
+	}
+	suite.True(found, "The test user should be a member of the group")
+}
+
+// TestGetGroupsByPathWithDisplay verifies `include=display` populates the OU handle on the
+// path-based listing.
+func (suite *GroupAPITestSuite) TestGetGroupsByPathWithDisplay() {
+	client := testutils.GetHTTPClient()
+
+	req, err := http.NewRequest("GET", testServerURL+"/groups/tree/"+testOU.Handle+"?include=display", nil)
+	suite.Require().NoError(err)
+
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var listResponse GroupListResponse
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&listResponse))
+
+	suite.Require().NotEmpty(listResponse.Groups, "The test OU should contain at least one group")
+	for _, group := range listResponse.Groups {
+		suite.Equal(testOU.Handle, group.OUHandle, "OU handle should be resolved with include=display")
+	}
+}
+
+// TestCreateGroupWithApplicationMember verifies an application can be a group member and that its
+// display name resolves to the application name rather than its ID.
+func (suite *GroupAPITestSuite) TestCreateGroupWithApplicationMember() {
+	appID, err := testutils.CreateApplication(testutils.Application{
+		Name:        "Group Member Application",
+		Description: "Application added as a group member",
+		OUID:        testOUID,
+	})
+	suite.Require().NoError(err)
+	defer func() {
+		if deleteErr := testutils.DeleteApplication(appID); deleteErr != nil {
+			suite.T().Logf("Failed to clean up application: %v", deleteErr)
+		}
+	}()
+
+	appGroupID, err := createGroup(CreateGroupRequest{
+		Name: "Group with Application Member",
+		OUID: testOUID,
+		Members: []Member{
+			{Id: appID, Type: MemberTypeApp},
+		},
+	})
+	suite.Require().NoError(err)
+	defer func() {
+		if deleteErr := deleteGroup(appGroupID); deleteErr != nil {
+			suite.T().Logf("Failed to clean up group: %v", deleteErr)
+		}
+	}()
+
+	client := testutils.GetHTTPClient()
+
+	req, err := http.NewRequest("GET", testServerURL+"/groups/"+appGroupID+"/members?include=display", nil)
+	suite.Require().NoError(err)
+
+	resp, err := client.Do(req)
+	suite.Require().NoError(err)
+	defer resp.Body.Close()
+
+	suite.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var memberList MemberListResponse
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&memberList))
+
+	suite.Require().Len(memberList.Members, 1)
+	suite.Equal(appID, memberList.Members[0].Id)
+	suite.Equal(MemberTypeApp, memberList.Members[0].Type,
+		"an application member should be returned with the public 'app' type")
+	suite.Equal("Group Member Application", memberList.Members[0].Display,
+		"application member display should be the application name")
+}

--- a/tests/integration/group/group_error_test.go
+++ b/tests/integration/group/group_error_test.go
@@ -1,0 +1,432 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package group
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// This file extends GroupAPITestSuite with the rejection paths of the group API: member validation,
+// CRUD conflicts and lookups that fail, malformed or invalid request bodies, pagination parameters
+// that are not numbers, and handle paths that do not resolve to a usable OU.
+
+// doGroupRequest issues a request against the group API using the admin client.
+func (suite *GroupAPITestSuite) doGroupRequest(method, path string, body []byte) *http.Response {
+	suite.T().Helper()
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequest(method, testServerURL+path, bodyReader)
+	suite.Require().NoError(err)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	suite.Require().NoError(err)
+	return resp
+}
+
+// expectErrorWithJSONBody asserts the response carries the given status and error code, and returns the body.
+func (suite *GroupAPITestSuite) expectErrorWithJSONBody(resp *http.Response, status int, code string) ErrorResponse {
+	suite.T().Helper()
+
+	var errorResp ErrorResponse
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&errorResp))
+	suite.Equal(status, resp.StatusCode)
+	suite.Equal(code, errorResp.Code)
+	return errorResp
+}
+
+// marshal encodes a request body, failing the test on error.
+func (suite *GroupAPITestSuite) marshal(v any) []byte {
+	suite.T().Helper()
+	payload, err := json.Marshal(v)
+	suite.Require().NoError(err)
+	return payload
+}
+
+// ---------------------------------------------------------------------------
+// Member validation
+// ---------------------------------------------------------------------------
+
+// TestAddMemberWithMismatchedType verifies a member whose claimed type disagrees with the actual
+// entity category is rejected, so a user cannot be smuggled in as an application.
+func (suite *GroupAPITestSuite) TestAddMemberWithMismatchedType() {
+	payload := suite.marshal(MembersRequest{
+		Members: []Member{
+			{Id: testUserID, Type: MemberTypeApp},
+		},
+	})
+
+	resp := suite.doGroupRequest(http.MethodPost, "/groups/"+createdGroupID+"/members/add", payload)
+	defer resp.Body.Close()
+
+	errorResp := suite.expectErrorWithJSONBody(resp, http.StatusBadRequest, "GRP-1007")
+	suite.Equal("Invalid member ID", errorResp.Message.DefaultValue)
+}
+
+// TestCreateGroupWithConflictingMemberTypes verifies the same member ID cannot be listed twice under
+// two different types in one request.
+func (suite *GroupAPITestSuite) TestCreateGroupWithConflictingMemberTypes() {
+	payload := suite.marshal(CreateGroupRequest{
+		Name: "Group with Conflicting Member Types",
+		OUID: testOUID,
+		Members: []Member{
+			{Id: testUserID, Type: MemberTypeUser},
+			{Id: testUserID, Type: MemberTypeApp},
+		},
+	})
+
+	resp := suite.doGroupRequest(http.MethodPost, "/groups", payload)
+	defer resp.Body.Close()
+
+	errorResp := suite.expectErrorWithJSONBody(resp, http.StatusBadRequest, "GRP-1007")
+	suite.Equal("Invalid member ID", errorResp.Message.DefaultValue)
+}
+
+// TestAddMemberWithEmptyID verifies a member entry carrying no ID is rejected.
+func (suite *GroupAPITestSuite) TestAddMemberWithEmptyID() {
+	payload := suite.marshal(MembersRequest{
+		Members: []Member{
+			{Id: "", Type: MemberTypeUser},
+		},
+	})
+
+	resp := suite.doGroupRequest(http.MethodPost, "/groups/"+createdGroupID+"/members/add", payload)
+	defer resp.Body.Close()
+
+	suite.expectErrorWithJSONBody(resp, http.StatusBadRequest, "GRP-1001")
+}
+
+// TestAddMemberWithUnknownType verifies a member type outside user/app/agent/group is rejected.
+func (suite *GroupAPITestSuite) TestAddMemberWithUnknownType() {
+	payload := suite.marshal(map[string]any{
+		"members": []map[string]string{{"id": testUserID, "type": "robot"}},
+	})
+
+	resp := suite.doGroupRequest(http.MethodPost, "/groups/"+createdGroupID+"/members/add", payload)
+	defer resp.Body.Close()
+
+	errorResp := suite.expectErrorWithJSONBody(resp, http.StatusBadRequest, "GRP-1014")
+	suite.Equal("Invalid member type", errorResp.Message.DefaultValue)
+}
+
+// ---------------------------------------------------------------------------
+// CRUD conflicts and failed lookups
+// ---------------------------------------------------------------------------
+
+// TestCreateGroupWithDuplicateName verifies two groups cannot share a name within one OU.
+func (suite *GroupAPITestSuite) TestCreateGroupWithDuplicateName() {
+	existingID, err := createGroup(CreateGroupRequest{
+		Name:    "Duplicate Name Group",
+		OUID:    testOUID,
+		Members: []Member{},
+	})
+	suite.Require().NoError(err)
+	defer func() {
+		if deleteErr := deleteGroup(existingID); deleteErr != nil {
+			suite.T().Logf("Failed to clean up group: %v", deleteErr)
+		}
+	}()
+
+	payload := suite.marshal(CreateGroupRequest{
+		Name:    "Duplicate Name Group",
+		OUID:    testOUID,
+		Members: []Member{},
+	})
+
+	resp := suite.doGroupRequest(http.MethodPost, "/groups", payload)
+	defer resp.Body.Close()
+
+	errorResp := suite.expectErrorWithJSONBody(resp, http.StatusConflict, "GRP-1004")
+	suite.Equal("Group name conflict", errorResp.Message.DefaultValue)
+}
+
+// TestUpdateGroupToDuplicateName verifies a rename cannot collide with a sibling group's name.
+func (suite *GroupAPITestSuite) TestUpdateGroupToDuplicateName() {
+	occupantID, err := createGroup(CreateGroupRequest{
+		Name:    "Occupied Name Group",
+		OUID:    testOUID,
+		Members: []Member{},
+	})
+	suite.Require().NoError(err)
+	defer func() {
+		if deleteErr := deleteGroup(occupantID); deleteErr != nil {
+			suite.T().Logf("Failed to clean up occupant group: %v", deleteErr)
+		}
+	}()
+
+	renamableID, err := createGroup(CreateGroupRequest{
+		Name:    "Renamable Group",
+		OUID:    testOUID,
+		Members: []Member{},
+	})
+	suite.Require().NoError(err)
+	defer func() {
+		if deleteErr := deleteGroup(renamableID); deleteErr != nil {
+			suite.T().Logf("Failed to clean up renamable group: %v", deleteErr)
+		}
+	}()
+
+	payload := suite.marshal(UpdateGroupRequest{
+		Name: "Occupied Name Group",
+		OUID: testOUID,
+	})
+
+	resp := suite.doGroupRequest(http.MethodPut, "/groups/"+renamableID, payload)
+	defer resp.Body.Close()
+
+	errorResp := suite.expectErrorWithJSONBody(resp, http.StatusConflict, "GRP-1004")
+	suite.Equal("Group name conflict", errorResp.Message.DefaultValue)
+}
+
+// TestUpdateNonExistentGroup verifies updating an unknown group reports it as not found.
+func (suite *GroupAPITestSuite) TestUpdateNonExistentGroup() {
+	payload := suite.marshal(UpdateGroupRequest{
+		Name: "Ghost Group",
+		OUID: testOUID,
+	})
+
+	resp := suite.doGroupRequest(http.MethodPut, "/groups/non-existent-group-id", payload)
+	defer resp.Body.Close()
+
+	errorResp := suite.expectErrorWithJSONBody(resp, http.StatusNotFound, "GRP-1003")
+	suite.Equal("Group not found", errorResp.Message.DefaultValue)
+}
+
+// TestDeleteNonExistentGroup verifies deleting an unknown group reports it as not found.
+func (suite *GroupAPITestSuite) TestDeleteNonExistentGroup() {
+	resp := suite.doGroupRequest(http.MethodDelete, "/groups/non-existent-group-id", nil)
+	defer resp.Body.Close()
+
+	errorResp := suite.expectErrorWithJSONBody(resp, http.StatusNotFound, "GRP-1003")
+	suite.Equal("Group not found", errorResp.Message.DefaultValue)
+}
+
+// TestCreateGroupWithUnknownOU verifies a group cannot be created under an OU that does not exist.
+func (suite *GroupAPITestSuite) TestCreateGroupWithUnknownOU() {
+	payload := suite.marshal(CreateGroupRequest{
+		Name:    "Group in Unknown OU",
+		OUID:    "non-existent-ou-id",
+		Members: []Member{},
+	})
+
+	resp := suite.doGroupRequest(http.MethodPost, "/groups", payload)
+	defer resp.Body.Close()
+
+	errorResp := suite.expectErrorWithJSONBody(resp, http.StatusBadRequest, "GRP-1005")
+	suite.Equal("Invalid OU ID", errorResp.Message.DefaultValue)
+}
+
+// TestUpdateGroupToUnknownOU verifies a group cannot be moved into an OU that does not exist.
+func (suite *GroupAPITestSuite) TestUpdateGroupToUnknownOU() {
+	groupID, err := createGroup(CreateGroupRequest{
+		Name:    "Group for Unknown OU Move",
+		OUID:    testOUID,
+		Members: []Member{},
+	})
+	suite.Require().NoError(err)
+	defer func() {
+		if deleteErr := deleteGroup(groupID); deleteErr != nil {
+			suite.T().Logf("Failed to clean up group: %v", deleteErr)
+		}
+	}()
+
+	payload := suite.marshal(UpdateGroupRequest{
+		Name: "Group for Unknown OU Move",
+		OUID: "non-existent-ou-id",
+	})
+
+	resp := suite.doGroupRequest(http.MethodPut, "/groups/"+groupID, payload)
+	defer resp.Body.Close()
+
+	errorResp := suite.expectErrorWithJSONBody(resp, http.StatusBadRequest, "GRP-1005")
+	suite.Equal("Invalid OU ID", errorResp.Message.DefaultValue)
+}
+
+// TestUpdateGroupMovesItToAnotherOU verifies a group can be relocated to a different OU the caller
+// administers, and that the new OU is reflected on the group afterwards.
+func (suite *GroupAPITestSuite) TestUpdateGroupMovesItToAnotherOU() {
+	targetOUID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "test-group-move-target-ou",
+		Name:        "Group Move Target OU",
+		Description: "Destination OU for the group move test",
+	})
+	suite.Require().NoError(err)
+	defer func() {
+		if deleteErr := testutils.DeleteOrganizationUnit(targetOUID); deleteErr != nil {
+			suite.T().Logf("Failed to clean up target OU: %v", deleteErr)
+		}
+	}()
+
+	groupID, err := createGroup(CreateGroupRequest{
+		Name:    "Movable Group",
+		OUID:    testOUID,
+		Members: []Member{},
+	})
+	suite.Require().NoError(err)
+	defer func() {
+		if deleteErr := deleteGroup(groupID); deleteErr != nil {
+			suite.T().Logf("Failed to clean up group: %v", deleteErr)
+		}
+	}()
+
+	payload := suite.marshal(UpdateGroupRequest{
+		Name: "Movable Group",
+		OUID: targetOUID,
+	})
+
+	resp := suite.doGroupRequest(http.MethodPut, "/groups/"+groupID, payload)
+	defer resp.Body.Close()
+
+	suite.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var updated Group
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&updated))
+	suite.Equal(targetOUID, updated.OUID, "the update response should carry the new OU")
+
+	getResp := suite.doGroupRequest(http.MethodGet, "/groups/"+groupID, nil)
+	defer getResp.Body.Close()
+
+	suite.Require().Equal(http.StatusOK, getResp.StatusCode)
+
+	var fetched Group
+	suite.Require().NoError(json.NewDecoder(getResp.Body).Decode(&fetched))
+	suite.Equal(targetOUID, fetched.OUID, "the group should be persisted under the new OU")
+}
+
+// ---------------------------------------------------------------------------
+// Malformed and invalid request bodies
+// ---------------------------------------------------------------------------
+
+// TestCreateGroupWithMalformedJSON verifies an unparsable create body is reported as a bad request.
+func (suite *GroupAPITestSuite) TestCreateGroupWithMalformedJSON() {
+	resp := suite.doGroupRequest(http.MethodPost, "/groups", []byte(`{"name": "Broken",`))
+	defer resp.Body.Close()
+
+	suite.expectErrorWithJSONBody(resp, http.StatusBadRequest, "GRP-1001")
+}
+
+// TestUpdateGroupWithMalformedJSON verifies an unparsable update body is reported as a bad request.
+func (suite *GroupAPITestSuite) TestUpdateGroupWithMalformedJSON() {
+	resp := suite.doGroupRequest(http.MethodPut, "/groups/"+createdGroupID, []byte(`{"name": "Broken",`))
+	defer resp.Body.Close()
+
+	suite.expectErrorWithJSONBody(resp, http.StatusBadRequest, "GRP-1001")
+}
+
+// TestUpdateGroupWithMissingName verifies the update body is validated against its declared
+// constraints before reaching the service.
+func (suite *GroupAPITestSuite) TestUpdateGroupWithMissingName() {
+	payload := suite.marshal(map[string]any{"ouId": testOUID})
+
+	resp := suite.doGroupRequest(http.MethodPut, "/groups/"+createdGroupID, payload)
+	defer resp.Body.Close()
+
+	suite.expectErrorWithJSONBody(resp, http.StatusBadRequest, "INVALID_INPUT_METADATA")
+}
+
+// TestAddMembersWithMalformedJSON verifies an unparsable add-members body is rejected.
+func (suite *GroupAPITestSuite) TestAddMembersWithMalformedJSON() {
+	resp := suite.doGroupRequest(http.MethodPost,
+		"/groups/"+createdGroupID+"/members/add", []byte(`{"members": [`))
+	defer resp.Body.Close()
+
+	suite.expectErrorWithJSONBody(resp, http.StatusBadRequest, "GRP-1001")
+}
+
+// TestRemoveMembersWithMalformedJSON verifies an unparsable remove-members body is rejected.
+func (suite *GroupAPITestSuite) TestRemoveMembersWithMalformedJSON() {
+	resp := suite.doGroupRequest(http.MethodPost,
+		"/groups/"+createdGroupID+"/members/remove", []byte(`{"members": [`))
+	defer resp.Body.Close()
+
+	suite.expectErrorWithJSONBody(resp, http.StatusBadRequest, "GRP-1001")
+}
+
+// ---------------------------------------------------------------------------
+// Pagination parameters that are not numbers
+// ---------------------------------------------------------------------------
+
+// TestListGroupsWithNonNumericPagination verifies non-numeric pagination values are reported
+// separately for limit and offset rather than silently falling back to defaults.
+func (suite *GroupAPITestSuite) TestListGroupsWithNonNumericPagination() {
+	limitResp := suite.doGroupRequest(http.MethodGet, "/groups?limit=abc", nil)
+	defer limitResp.Body.Close()
+
+	limitErr := suite.expectErrorWithJSONBody(limitResp, http.StatusBadRequest, "GRP-1011")
+	suite.Equal("Invalid limit parameter", limitErr.Message.DefaultValue)
+
+	offsetResp := suite.doGroupRequest(http.MethodGet, "/groups?offset=xyz", nil)
+	defer offsetResp.Body.Close()
+
+	offsetErr := suite.expectErrorWithJSONBody(offsetResp, http.StatusBadRequest, "GRP-1012")
+	suite.Equal("Invalid offset parameter", offsetErr.Message.DefaultValue)
+}
+
+// TestGetGroupMembersWithNonNumericPagination verifies the members route validates pagination too.
+func (suite *GroupAPITestSuite) TestGetGroupMembersWithNonNumericPagination() {
+	resp := suite.doGroupRequest(http.MethodGet, "/groups/"+createdGroupID+"/members?limit=abc", nil)
+	defer resp.Body.Close()
+
+	suite.expectErrorWithJSONBody(resp, http.StatusBadRequest, "GRP-1011")
+}
+
+// TestGetGroupsByPathWithNonNumericPagination verifies the path-based route validates pagination
+// before resolving the handle path.
+func (suite *GroupAPITestSuite) TestGetGroupsByPathWithNonNumericPagination() {
+	resp := suite.doGroupRequest(http.MethodGet, "/groups/tree/"+testOU.Handle+"?limit=abc", nil)
+	defer resp.Body.Close()
+
+	suite.expectErrorWithJSONBody(resp, http.StatusBadRequest, "GRP-1011")
+}
+
+// TestGetGroupsByPathWithOversizedLimit verifies the path-based route enforces the maximum page size.
+func (suite *GroupAPITestSuite) TestGetGroupsByPathWithOversizedLimit() {
+	resp := suite.doGroupRequest(http.MethodGet, "/groups/tree/"+testOU.Handle+"?limit=101", nil)
+	defer resp.Body.Close()
+
+	suite.expectErrorWithJSONBody(resp, http.StatusBadRequest, "GRP-1011")
+}
+
+// TestGetGroupWithoutID verifies requesting the group collection with a trailing slash is treated as
+// a missing group ID rather than as a listing.
+func (suite *GroupAPITestSuite) TestGetGroupWithoutID() {
+	resp := suite.doGroupRequest(http.MethodGet, "/groups/", nil)
+	defer resp.Body.Close()
+
+	suite.expectErrorWithJSONBody(resp, http.StatusBadRequest, "GRP-1002")
+}
+
+// ---------------------------------------------------------------------------
+// Handle paths that do not resolve
+// ---------------------------------------------------------------------------
+
+// TestGetGroupsByBlankPath verifies a path made only of whitespace is rejected as malformed rather
+// than being looked up as an OU handle.
+func (suite *GroupAPITestSuite) TestGetGroupsByBlankPath() {
+	resp := suite.doGroupRequest(http.MethodGet, "/groups/tree/%20", nil)
+	defer resp.Body.Close()
+
+	suite.expectErrorWithJSONBody(resp, http.StatusBadRequest, "GRP-1001")
+}
+
+// TestGetGroupsByPathWithBlankSegment verifies a path carrying a blank segment between two handles
+// is rejected as malformed. The segment has to sit in the middle: leading and trailing whitespace is
+// stripped from the path as a whole before it is split.
+func (suite *GroupAPITestSuite) TestGetGroupsByPathWithBlankSegment() {
+	resp := suite.doGroupRequest(http.MethodGet, "/groups/tree/"+testOU.Handle+"/%20/child", nil)
+	defer resp.Body.Close()
+
+	suite.expectErrorWithJSONBody(resp, http.StatusBadRequest, "GRP-1001")
+}

--- a/tests/integration/group/model.go
+++ b/tests/integration/group/model.go
@@ -33,18 +33,40 @@ const (
 	testServerURL = "https://localhost:8095"
 )
 
+// Fixtures declared in tests/integration/resources/declarative_resources:
+//
+//	decl-group-1 ("Declarative Test Group")   ← holds decl-group-2 as its only member
+//	decl-group-2 ("Declarative Nested Group") ← holds decl-user-1 as its only member
+//
+// Both groups belong to the declarative organization unit decl-ou-1. The nesting means decl-user-1
+// belongs to decl-group-1 only transitively, which the permission-inheritance test relies on.
+const (
+	declGroupID         = "decl-group-1"
+	declGroupName       = "Declarative Test Group"
+	declNestedGroupID   = "decl-group-2"
+	declNestedGroupName = "Declarative Nested Group"
+	declGroupOUID       = "decl-ou-1"
+	declGroupOUHandle   = "decl-ou-1"
+	declGroupMemberID   = "decl-user-1"
+
+	// Credentials of the declarative user, as declared in the users fixture.
+	declGroupMemberPassword = "TempPassword123!"
+)
+
 // MemberType represents the type of member entity.
 type MemberType string
 
 const (
 	MemberTypeUser  MemberType = "user"
+	MemberTypeApp   MemberType = "app"
 	MemberTypeGroup MemberType = "group"
 )
 
 // Member represents a member of a group (either user or another group).
 type Member struct {
-	Id   string     `json:"id"`
-	Type MemberType `json:"type"`
+	Id      string     `json:"id"`
+	Type    MemberType `json:"type"`
+	Display string     `json:"display,omitempty"`
 }
 
 // GroupBasic represents the basic information of a group.
@@ -53,6 +75,8 @@ type GroupBasic struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
 	OUID        string `json:"ouId"`
+	OUHandle    string `json:"ouHandle,omitempty"`
+	IsReadOnly  bool   `json:"isReadOnly"`
 }
 
 // Group represents a complete group with members.

--- a/tests/integration/resources/declarative_resources/groups/group-declarative-1.yaml
+++ b/tests/integration/resources/declarative_resources/groups/group-declarative-1.yaml
@@ -1,0 +1,8 @@
+resource_type: group
+id: decl-group-1
+name: Declarative Test Group
+description: A declarative test group for integration testing
+ouId: decl-ou-1
+members:
+  - id: decl-group-2
+    type: group

--- a/tests/integration/resources/declarative_resources/groups/group-declarative-2.yaml
+++ b/tests/integration/resources/declarative_resources/groups/group-declarative-2.yaml
@@ -1,0 +1,8 @@
+resource_type: group
+id: decl-group-2
+name: Declarative Nested Group
+description: A declarative group nested inside decl-group-1
+ouId: decl-ou-1
+members:
+  - id: decl-user-1
+    type: user

--- a/tests/integration/testutils/models.go
+++ b/tests/integration/testutils/models.go
@@ -10,11 +10,18 @@ import (
 
 // UserType represents a user type definition
 type UserType struct {
-	ID                    string                 `json:"id,omitempty"`
-	Name                  string                 `json:"name"`
-	OUID                  string                 `json:"ouId"`
-	AllowSelfRegistration bool                   `json:"allowSelfRegistration,omitempty"`
-	Schema                map[string]interface{} `json:"schema"`
+	ID                    string                    `json:"id,omitempty"`
+	Name                  string                    `json:"name"`
+	OUID                  string                    `json:"ouId"`
+	AllowSelfRegistration bool                      `json:"allowSelfRegistration,omitempty"`
+	SystemAttributes      *UserTypeSystemAttributes `json:"systemAttributes,omitempty"`
+	Schema                map[string]interface{}    `json:"schema"`
+}
+
+// UserTypeSystemAttributes carries the system-level settings of a user type, such as the
+// attribute used to render a human-readable display name.
+type UserTypeSystemAttributes struct {
+	Display string `json:"display,omitempty"`
 }
 
 // User represents a user in the system

--- a/tests/integration/testutils/test_utils.go
+++ b/tests/integration/testutils/test_utils.go
@@ -411,6 +411,7 @@ func CopyDeclarativeResources(zipFilePattern string) error {
 		"connections",
 		"credential_configurations",
 		"flows",
+		"groups",
 		"layouts",
 		"organization_units",
 		"presentation_definitions",


### PR DESCRIPTION
### Purpose

Improves integration test coverage for the group package. The suite previously left the declarative (file based) group paths almost entirely untested, and covered few of the API error paths, display resolution options, deletion cascades, and OU scoped authorization routes.

Integration test coverage for `backend/internal/group` moves from **65.5%** to **79.6%** of statements (1206 to 1467 of 1842).

| File | Before | After | Delta |
|---|---|---|---|
| declarative_resource.go | 35.7% | 78.6% | +42.9 |
| file_based_store.go | 32.8% | 75.5% | +42.7 |
| handler.go | 77.4% | 91.4% | +14.0 |
| service.go | 66.8% | 77.2% | +10.4 |
| composite_store.go | 76.2% | 85.6% | +9.4 |
| store.go | 75.1% | 75.7% | +0.6 |
| **Total** | **65.5%** | **79.6%** | **+14.1** |

Measured with `make build_with_coverage_only` followed by `make test_integration PACKAGE="./group/..."`, against a cleared coverage directory so the numbers reflect the group suite alone.

### Approach

New test files, all extending the existing suites in `tests/integration/group`:

- **`group_declarative_test.go`** plus two YAML fixtures under `tests/integration/resources/declarative_resources/groups`. A new `GroupDeclarativeAPITestSuite` covers the composite store: reading a YAML declared group and its read only flag, list merging across the file and database stores, declarative members and their display resolution, wildcard export, update and delete both rejected as immutable, listing by OU handle path, name conflict checks spanning both stores, permission inheritance through nested declarative groups, and a runtime group nesting a declarative one. This accounts for most of the gain in `file_based_store.go` and `declarative_resource.go`, which had no declarative groups deployed to exercise them before.
- **`group_error_test.go`** covers the API error paths: member type mismatches, duplicate and conflicting member entries, empty member IDs, unknown member types, duplicate group names on create and rename, unknown groups on update and delete, unknown OUs on create and move, malformed JSON on every write route, missing required fields, invalid pagination on all three list routes, and malformed path handling.
- **`group_display_test.go`** covers `include=display`: OU handle resolution on list, get, and path based listing, per category member display resolution, and confirmation that displays are omitted when not requested. Also covers an application as a group member.
- **`group_cascade_test.go`** covers the deletion cascade: deleting a user clears its membership rows, and deleting a group clears it from containing groups and from role assignments. Membership assertions check both `totalResults` and the resolved member list, so a stale row left behind cannot pass.

Extensions to existing files:

- **`group_authz_test.go`** adds OU scoped denials for the routes that were not covered (list and create by path, get members, add members, and moving a group into an unadministered OU), plus three listing tests: an empty scope must return nothing rather than falling back to an unrestricted list, an OU scoped listing must include declarative groups, and pagination must apply to the merged result of both stores without repeating or dropping a group.
- **`model.go`** adds the `app` member type and the `display`, `ouHandle`, and `isReadOnly` response fields.
- **`testutils`** adds `UserTypeSystemAttributes` so a user type can declare its display attribute, and adds `groups` to the declarative resource directories copied into the test distribution.

No product code is changed.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for group authorization across organizational units, including path-based access, cross-unit membership, pagination, and merged listings.
  * Added validation for declarative groups, nested memberships, permission inheritance, display names, exports, and read-only behavior.
  * Added coverage for membership cleanup when users or groups are deleted.
  * Improved testing of invalid requests, duplicate names, missing resources, pagination errors, and application-based group members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->