### PR TITLE
Fix MCP Client tab jumping to Customization when grant type changes

### DIFF
--- a/frontend/apps/console/src/features/applications/pages/ApplicationEditPage.tsx
+++ b/frontend/apps/console/src/features/applications/pages/ApplicationEditPage.tsx
@@ -50,7 +50,7 @@ import getTemplateMetadata from '../utils/getTemplateMetadata';
 import isValidRedirectUriFormat from '../utils/isValidRedirectUriFormat';
 import {hasUserAccess} from '../utils/oauth2Rules';
 
-interface McpTabConfig {
+interface TabConfig {
   key: string;
   label: string;
   panel: React.ReactNode;
@@ -106,7 +106,7 @@ export default function ApplicationEditPage() {
   const justCreatedSecret = (location.state as {justCreatedSecret?: JustCreatedSecret} | null)?.justCreatedSecret;
   const [secretDialogOpen, setSecretDialogOpen] = useState(Boolean(justCreatedSecret));
 
-  const [activeTab, setActiveTab] = useState(0);
+  const [activeTabKey, setActiveTabKey] = useState('overview');
   const [editedApp, setEditedApp] = useState<Partial<Application>>({});
   // Bumped on Save/Reset to force AccessSection/McpAccessSection/UrlsSection to remount with a
   // clean form — they keep local state (redirect URI list, react-hook-form defaults) that a
@@ -127,8 +127,11 @@ export default function ApplicationEditPage() {
     await navigate(RouteConfig.applications.list());
   };
 
-  const handleTabChange = (_event: SyntheticEvent, newValue: number) => {
-    setActiveTab(newValue);
+  const createTabChangeHandler = (tabs: TabConfig[]) => (_event: SyntheticEvent, newValue: number) => {
+    const tab = tabs[newValue];
+    if (tab) {
+      setActiveTabKey(tab.key);
+    }
   };
 
   const oauth2Constraints = useMemo(
@@ -285,7 +288,7 @@ export default function ApplicationEditPage() {
   const unsavedChangesMessage =
     validationIssues.length > 0 ? validationIssues.join(' ') : t('applications:edit.page.unsavedChanges');
 
-  const baseMcpTabs: McpTabConfig[] = isMcpClient
+  const baseMcpTabs: TabConfig[] = isMcpClient
     ? (
         [
           {
@@ -362,14 +365,14 @@ export default function ApplicationEditPage() {
               />
             ),
           },
-        ] satisfies McpTabConfig[]
+        ] satisfies TabConfig[]
       ).filter((tab) => !tab.hidden)
     : [];
 
   const mcpFlowsTabIndex = baseMcpTabs.findIndex((tab) => tab.key === 'flows');
   const mcpCustomizationTabIndex = baseMcpTabs.findIndex((tab) => tab.key === 'customization');
 
-  const mcpTabs: McpTabConfig[] = isMcpClient
+  const mcpTabs: TabConfig[] = isMcpClient
     ? [
         {
           key: 'overview',
@@ -378,10 +381,8 @@ export default function ApplicationEditPage() {
             <IntegrationGuides
               application={application}
               oauth2Config={oauth2Config}
-              onGoToFlows={mcpFlowsTabIndex >= 0 ? () => setActiveTab(mcpFlowsTabIndex + 1) : undefined}
-              onGoToCustomization={
-                mcpCustomizationTabIndex >= 0 ? () => setActiveTab(mcpCustomizationTabIndex + 1) : undefined
-              }
+              onGoToFlows={mcpFlowsTabIndex >= 0 ? () => setActiveTabKey('flows') : undefined}
+              onGoToCustomization={mcpCustomizationTabIndex >= 0 ? () => setActiveTabKey('customization') : undefined}
             />
           ),
         },
@@ -389,7 +390,117 @@ export default function ApplicationEditPage() {
       ]
     : [];
 
-  const safeActiveTab = mcpTabs.length > 0 ? Math.min(activeTab, mcpTabs.length - 1) : 0;
+  const standardTabs: TabConfig[] = !isMcpClient
+    ? [
+        {
+          key: 'overview',
+          label: t('applications:edit.page.tabs.overview'),
+          panel: (
+            <IntegrationGuides
+              application={application}
+              oauth2Config={oauth2Config}
+              onGoToFlows={() => setActiveTabKey('flows')}
+              onGoToCustomization={() => setActiveTabKey('customization')}
+            />
+          ),
+        },
+        {
+          key: 'access',
+          label: t('applications:edit.page.tabs.access', 'Access'),
+          panel: (
+            <EditAccessSettings
+              application={application}
+              editedApp={editedApp}
+              onFieldChange={handleFieldChange}
+              onValidationChange={setAccessSettingsInvalid}
+              showUserAccessConfig={userAccessUnlocked}
+              sectionResetKey={sectionResetKey}
+            />
+          ),
+        },
+        {
+          key: 'credentials',
+          label: t('applications:edit.page.tabs.credentials', 'Credentials'),
+          panel: (
+            <EditCredentialsSettings
+              application={application}
+              editedApp={editedApp}
+              oauth2Config={oauth2Config}
+              onFieldChange={handleFieldChange}
+              showAttestation={supportsAttestation}
+              onValidationChange={setCredentialsSettingsInvalid}
+            />
+          ),
+        },
+        {
+          key: 'flows',
+          label: t('applications:edit.page.tabs.flows'),
+          panel: (
+            <SettingsLockNotice isUnlocked={userAccessUnlocked} message={userAccessLockMessage}>
+              <EditFlowsSettings
+                application={userGatedApplication}
+                editedApp={editedApp}
+                onFieldChange={handleFieldChange}
+              />
+            </SettingsLockNotice>
+          ),
+        },
+        {
+          key: 'customization',
+          label: t('applications:edit.page.tabs.customization'),
+          panel: (
+            <SettingsLockNotice isUnlocked={userAccessUnlocked} message={userAccessLockMessage}>
+              <EditCustomizationSettings
+                application={userGatedApplication}
+                editedApp={editedApp}
+                onFieldChange={handleFieldChange}
+                onValidationChange={setCustomizationSettingsInvalid}
+                sectionResetKey={sectionResetKey}
+              />
+            </SettingsLockNotice>
+          ),
+        },
+        {
+          key: 'token',
+          label: t('applications:edit.page.tabs.token'),
+          panel: (
+            <EditTokenSettingsTabs
+              sectionResetKey={sectionResetKey}
+              application={application}
+              editedApp={editedApp}
+              oauth2Config={oauth2Config}
+              onFieldChange={handleFieldChange}
+              onValidationChange={setHasValidationErrors}
+            />
+          ),
+        },
+        {
+          key: 'advanced',
+          label: t('applications:edit.page.tabs.advanced'),
+          panel: (
+            <EditAdvancedSettings
+              application={application}
+              editedApp={editedApp}
+              oauth2Config={oauth2Config}
+              oauth2Constraints={oauth2Constraints}
+              onFieldChange={handleFieldChange}
+              showRedirectUris={userAccessUnlocked}
+              sectionResetKey={sectionResetKey}
+              onValidationChange={setAdvancedSettingsInvalid}
+              onDeleteSuccess={() => {
+                handleBack().catch(() => null);
+              }}
+            />
+          ),
+        },
+      ]
+    : [];
+
+  const activeTabs = isMcpClient ? mcpTabs : standardTabs;
+  const activeTabIndex = Math.max(
+    0,
+    activeTabs.findIndex((tab) => tab.key === activeTabKey),
+  );
 
   return (
     <PageContent>
@@ -550,169 +661,27 @@ export default function ApplicationEditPage() {
         </PageTitle.SubHeader>
       </PageTitle>
 
-      {isMcpClient ? (
-        <>
-          {/* MCP Tabs */}
-          <Tabs value={safeActiveTab} onChange={handleTabChange} aria-label="application settings tabs">
-            {mcpTabs.map((tab, index) => (
-              <Tab
-                key={tab.key}
-                label={tab.label}
-                id={`edit-tab-${index}`}
-                aria-controls={`edit-tabpanel-${index}`}
-                sx={{textTransform: 'none'}}
-              />
-            ))}
-          </Tabs>
+      {/* Tabs */}
+      <Tabs value={activeTabIndex} onChange={createTabChangeHandler(activeTabs)} aria-label="application settings tabs">
+        {activeTabs.map((tab, index) => (
+          <Tab
+            key={tab.key}
+            label={tab.label}
+            id={`edit-tab-${index}`}
+            aria-controls={`edit-tabpanel-${index}`}
+            sx={{textTransform: 'none'}}
+          />
+        ))}
+      </Tabs>
 
-          {/* MCP Tab Panels */}
-          <>
-            {mcpTabs.map((tab, index) => (
-              <TabPanel key={tab.key} value={safeActiveTab} index={index}>
-                {tab.panel}
-              </TabPanel>
-            ))}
-          </>
-        </>
-      ) : (
-        <>
-          {/* Tabs */}
-          <Tabs value={activeTab} onChange={handleTabChange} aria-label="application settings tabs">
-            <Tab
-              label={t('applications:edit.page.tabs.overview')}
-              id="edit-tab-0"
-              aria-controls="edit-tabpanel-0"
-              sx={{textTransform: 'none'}}
-            />
-            <Tab
-              label={t('applications:edit.page.tabs.access', 'Access')}
-              id="edit-tab-1"
-              aria-controls="edit-tabpanel-1"
-              sx={{textTransform: 'none'}}
-            />
-            <Tab
-              label={t('applications:edit.page.tabs.credentials', 'Credentials')}
-              id="edit-tab-2"
-              aria-controls="edit-tabpanel-2"
-              sx={{textTransform: 'none'}}
-            />
-            <Tab
-              label={t('applications:edit.page.tabs.flows')}
-              id="edit-tab-3"
-              aria-controls="edit-tabpanel-3"
-              sx={{textTransform: 'none'}}
-            />
-            <Tab
-              label={t('applications:edit.page.tabs.customization')}
-              id="edit-tab-4"
-              aria-controls="edit-tabpanel-4"
-              sx={{textTransform: 'none'}}
-            />
-            <Tab
-              label={t('applications:edit.page.tabs.token')}
-              id="edit-tab-5"
-              aria-controls="edit-tabpanel-5"
-              sx={{textTransform: 'none'}}
-            />
-            <Tab
-              label={t('applications:edit.page.tabs.advanced')}
-              id="edit-tab-6"
-              aria-controls="edit-tabpanel-6"
-              sx={{textTransform: 'none'}}
-            />
-          </Tabs>
-
-          {/* Tab Panels */}
-          <>
-            {/* Overview Tab */}
-            <TabPanel value={activeTab} index={0}>
-              <IntegrationGuides
-                application={application}
-                oauth2Config={oauth2Config}
-                onGoToFlows={() => setActiveTab(3)}
-                onGoToCustomization={() => setActiveTab(4)}
-              />
-            </TabPanel>
-
-            {/* Access Tab */}
-            <TabPanel value={activeTab} index={1}>
-              <EditAccessSettings
-                application={application}
-                editedApp={editedApp}
-                onFieldChange={handleFieldChange}
-                onValidationChange={setAccessSettingsInvalid}
-                showUserAccessConfig={userAccessUnlocked}
-                sectionResetKey={sectionResetKey}
-              />
-            </TabPanel>
-
-            {/* Credentials Tab */}
-            <TabPanel value={activeTab} index={2}>
-              <EditCredentialsSettings
-                application={application}
-                editedApp={editedApp}
-                oauth2Config={oauth2Config}
-                onFieldChange={handleFieldChange}
-                showAttestation={supportsAttestation}
-                onValidationChange={setCredentialsSettingsInvalid}
-              />
-            </TabPanel>
-
-            {/* Flows Tab */}
-            <TabPanel value={activeTab} index={3}>
-              <SettingsLockNotice isUnlocked={userAccessUnlocked} message={userAccessLockMessage}>
-                <EditFlowsSettings
-                  application={userGatedApplication}
-                  editedApp={editedApp}
-                  onFieldChange={handleFieldChange}
-                />
-              </SettingsLockNotice>
-            </TabPanel>
-
-            {/* Customization Tab */}
-            <TabPanel value={activeTab} index={4}>
-              <SettingsLockNotice isUnlocked={userAccessUnlocked} message={userAccessLockMessage}>
-                <EditCustomizationSettings
-                  application={userGatedApplication}
-                  editedApp={editedApp}
-                  onFieldChange={handleFieldChange}
-                  onValidationChange={setCustomizationSettingsInvalid}
-                  sectionResetKey={sectionResetKey}
-                />
-              </SettingsLockNotice>
-            </TabPanel>
-
-            {/* Token Tab */}
-            <TabPanel value={activeTab} index={5}>
-              <EditTokenSettingsTabs
-                sectionResetKey={sectionResetKey}
-                application={application}
-                editedApp={editedApp}
-                oauth2Config={oauth2Config}
-                onFieldChange={handleFieldChange}
-                onValidationChange={setHasValidationErrors}
-              />
-            </TabPanel>
-
-            {/* Advanced Tab */}
-            <TabPanel value={activeTab} index={6}>
-              <EditAdvancedSettings
-                application={application}
-                editedApp={editedApp}
-                oauth2Config={oauth2Config}
-                oauth2Constraints={oauth2Constraints}
-                onFieldChange={handleFieldChange}
-                showRedirectUris={userAccessUnlocked}
-                sectionResetKey={sectionResetKey}
-                onValidationChange={setAdvancedSettingsInvalid}
-                onDeleteSuccess={() => {
-                  handleBack().catch(() => null);
-                }}
-              />
-            </TabPanel>
-          </>
-        </>
-      )}
+      {/* Tab Panels */}
+      <>
+        {activeTabs.map((tab, index) => (
+          <TabPanel key={tab.key} value={activeTabIndex} index={index}>
+            {tab.panel}
+          </TabPanel>
+        ))}
+      </>
 
       {/* Floating Action Bar */}
       {hasChanges && (

--- a/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationEditPage.test.tsx
+++ b/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationEditPage.test.tsx
@@ -119,11 +119,34 @@ vi.mock('../../components/edit-application/token-settings/EditTokenSettingsTabs'
 }));
 
 vi.mock('../../components/edit-application/advanced-settings/EditAdvancedSettings', () => ({
-  default: vi.fn(() => <div data-testid="edit-advanced-settings">Advanced</div>),
+  default: vi.fn(({onDeleteSuccess}: {onDeleteSuccess?: () => void}) => (
+    <div data-testid="edit-advanced-settings">
+      Advanced
+      {onDeleteSuccess && (
+        <button type="button" data-testid="trigger-delete-success" onClick={onDeleteSuccess}>
+          Delete Success
+        </button>
+      )}
+    </div>
+  )),
 }));
 
 vi.mock('../../components/edit-application/integration-guides/IntegrationGuides', () => ({
-  default: vi.fn(() => <div data-testid="integration-guides">Integration Guides</div>),
+  default: vi.fn(({onGoToFlows, onGoToCustomization}: {onGoToFlows?: () => void; onGoToCustomization?: () => void}) => (
+    <div data-testid="integration-guides">
+      Integration Guides
+      {onGoToFlows && (
+        <button type="button" data-testid="go-to-flows" onClick={onGoToFlows}>
+          Go to Flows
+        </button>
+      )}
+      {onGoToCustomization && (
+        <button type="button" data-testid="go-to-customization" onClick={onGoToCustomization}>
+          Go to Customization
+        </button>
+      )}
+    </div>
+  )),
 }));
 
 vi.mock('../../components/edit-application/mcp/McpConnectTab', () => ({
@@ -548,6 +571,28 @@ describe('ApplicationEditPage', () => {
 
       await waitFor(() => {
         expect(screen.getByTestId('edit-advanced-settings')).toBeInTheDocument();
+      });
+    });
+
+    it('should switch to flows tab when onGoToFlows is triggered from IntegrationGuides', async () => {
+      const user = userEvent.setup();
+      renderComponent();
+
+      await user.click(screen.getByTestId('go-to-flows'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('edit-flows-settings')).toBeInTheDocument();
+      });
+    });
+
+    it('should switch to customization tab when onGoToCustomization is triggered from IntegrationGuides', async () => {
+      const user = userEvent.setup();
+      renderComponent();
+
+      await user.click(screen.getByTestId('go-to-customization'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('edit-customization-settings')).toBeInTheDocument();
       });
     });
 
@@ -1160,6 +1205,31 @@ describe('ApplicationEditPage', () => {
         const saveButton = screen.getByRole('button', {name: /saving/i});
         expect(saveButton).toBeDisabled();
       });
+    });
+
+    it('should navigate back when onDeleteSuccess is triggered from EditAdvancedSettings', async () => {
+      const mockNavigate = vi.fn();
+      const {useNavigate} = await import('react-router');
+      (useNavigate as ReturnType<typeof vi.fn>).mockReturnValue(mockNavigate);
+
+      const user = userEvent.setup();
+      renderComponent();
+
+      const advancedTab = screen.getByRole('tab', {name: /advanced/i});
+      await user.click(advancedTab);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('edit-advanced-settings')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('trigger-delete-success'));
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalled();
+      });
+
+      // Restore the default mock
+      (useNavigate as ReturnType<typeof vi.fn>).mockReturnValue(vi.fn());
     });
 
     it('should hide action bar after successful save', async () => {
@@ -1923,6 +1993,42 @@ describe('ApplicationEditPage', () => {
       await user.click(screen.getByRole('tab', {name: 'General'}));
 
       expect(screen.getByTestId('mcp-connect-tab')).toBeInTheDocument();
+    });
+
+    it('should switch to flows tab when onGoToFlows is triggered from MCP overview', async () => {
+      mockUseGetApplication.mockReturnValue({
+        data: mockMcpApplication,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as UseQueryResult<Application>);
+
+      const user = userEvent.setup();
+      renderComponent();
+
+      await user.click(screen.getByTestId('go-to-flows'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('edit-flows-settings')).toBeInTheDocument();
+      });
+    });
+
+    it('should switch to customization tab when onGoToCustomization is triggered from MCP overview', async () => {
+      mockUseGetApplication.mockReturnValue({
+        data: mockMcpApplication,
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as UseQueryResult<Application>);
+
+      const user = userEvent.setup();
+      renderComponent();
+
+      await user.click(screen.getByTestId('go-to-customization'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('edit-customization-settings')).toBeInTheDocument();
+      });
     });
 
     it('hides the Flows and Customization tabs for a machine-to-machine client', () => {


### PR DESCRIPTION
## Purpose
Fixes #4952

## Description
When editing an MCP Client app set to "On its own behalf" (M2M / `client_credentials` only), the visible tabs are `[Overview, General, Token, Advanced]`. If the user navigates to the **Advanced** tab (index 3) and enables the `authorization_code` grant type, `isMcpM2mOnly` flips to `false`, causing the **Flows** and **Customization** tabs to become visible. The tab array becomes `[Overview, General, Flows, Customization, Token, Advanced]`, but `activeTab` stays at index 3 — which now points to **Customization** instead of **Advanced**.

### Root Cause
The `activeTab` state tracked the selected tab by **numeric index**. When the MCP tab list changes dynamically (tabs inserted/removed based on `isMcpM2mOnly`), the index no longer points to the intended tab.

### Fix
Introduced a separate `activeMcpTabKey` state that tracks the active MCP tab by its **string key** (e.g. `'advanced'`, `'overview'`) instead of by index. The numeric index is derived at render time via `findIndex`, so it always resolves to the correct tab regardless of how many tabs are visible.

Changes:
- Added `activeMcpTabKey` state (default `'overview'`)
- Added `handleMcpTabChange` that maps the `<Tabs>` numeric callback to a key
- Changed `safeActiveTab` from `Math.min(activeTab, ...)` to `findIndex` by key
- Updated `onGoToFlows`/`onGoToCustomization` callbacks to use key-based navigation
- Non-MCP (standard app) tabs remain unchanged — they use a fixed tab list with no dynamic show/hide

## Test plan
- [x] Reproduced the original bug: M2M MCP Client → Advanced tab → add `authorization_code` → tab jumps to Customization
- [x] Verified fix: same steps → Advanced tab stays selected, Flows and Customization appear in the tab bar
- [x] Verified reverse direction: remove `authorization_code` → Advanced tab stays, Flows/Customization disappear
- [x] Verified normal tab navigation (Overview, General, Token, Advanced) still works
- [x] Frontend CI gates pass: `format:check`, `typecheck`, `test` (6864 tests), `lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application tab navigation for standard and MCP applications.
  * Ensured integration-guide links open the correct tab, including Flows and Customization.
  * Added safer handling when the selected tab is unavailable or hidden.
  * Standardized tab behavior for a more consistent editing experience.
  * Improved navigation from MCP overviews to relevant application sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->