### PR TITLE
Clarify root organization unit hierarchy

### DIFF
--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/general-settings/ParentSettingsSection.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/general-settings/ParentSettingsSection.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {SettingsCard} from '@thunderid/components';
-import {Stack, Typography, CircularProgress, TextField, FormControl, FormLabel} from '@wso2/oxygen-ui';
+import {Stack, Typography, CircularProgress, TextField} from '@wso2/oxygen-ui';
 import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Link} from 'react-router';
@@ -45,14 +45,9 @@ export default function ParentSettingsSection({organizationUnit}: ParentSettings
   const renderParentInfo = (): JSX.Element => {
     if (!organizationUnit.parent) {
       return (
-        <TextField
-          fullWidth
-          id="parent-ou-input"
-          value={t('organizationUnits:edit.general.ou.noParent.label')}
-          InputProps={{
-            readOnly: true,
-          }}
-        />
+        <Typography variant="body2" color="text.secondary">
+          {t('organizationUnits:edit.general.ou.noParent.label', 'This is a root organization unit.')}
+        </Typography>
       );
     }
 
@@ -98,6 +93,9 @@ export default function ParentSettingsSection({organizationUnit}: ParentSettings
         fullWidth
         id="parent-ou-input"
         value={organizationUnit.parent}
+        inputProps={{
+          'aria-label': t('organizationUnits:edit.general.ou.parent.label', 'Parent Organization Unit'),
+        }}
         InputProps={{
           readOnly: true,
         }}
@@ -113,13 +111,13 @@ export default function ParentSettingsSection({organizationUnit}: ParentSettings
 
   return (
     <SettingsCard
-      title={t('organizationUnits:edit.general.sections.parentOUSettings.title')}
-      description={t('organizationUnits:edit.general.sections.parentOUSettings.description')}
+      title={t('organizationUnits:edit.general.sections.parentOUSettings.title', 'Parent Organization Unit')}
+      description={t(
+        'organizationUnits:edit.general.sections.parentOUSettings.description',
+        'The parent organization unit in the hierarchy.',
+      )}
     >
-      <FormControl fullWidth>
-        <FormLabel htmlFor="parent-ou-input">{t('organizationUnits:edit.general.ou.parent.label')}</FormLabel>
-        {renderParentInfo()}
-      </FormControl>
+      {renderParentInfo()}
     </SettingsCard>
   );
 }

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/general-settings/__tests__/ParentSettingsSection.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/general-settings/__tests__/ParentSettingsSection.test.tsx
@@ -1,9 +1,8 @@
 // Copyright 2025 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import {screen, renderWithProviders, renderHook} from '@thunderid/test-utils';
-import {useTranslation} from 'react-i18next';
-import {describe, it, expect, vi, beforeEach, beforeAll} from 'vitest';
+import {screen, renderWithProviders} from '@thunderid/test-utils';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
 import type {OrganizationUnit} from '../../../../models/organization-unit';
 import ParentSettingsSection from '../ParentSettingsSection';
 
@@ -24,11 +23,6 @@ vi.mock('react-router', async () => {
 });
 
 describe('ParentSettingsSection', () => {
-  let t: (key: string) => string;
-
-  beforeAll(() => {
-    ({t} = renderHook(() => useTranslation()).result.current);
-  });
   const mockOrganizationUnit: OrganizationUnit = {
     id: 'ou-child-123',
     handle: 'engineering-frontend',
@@ -57,15 +51,12 @@ describe('ParentSettingsSection', () => {
 
     renderWithProviders(<ParentSettingsSection organizationUnit={mockOrganizationUnit} />);
 
-    expect(
-      screen.getByRole('heading', {name: t('organizationUnits:edit.general.sections.parentOUSettings.title')}),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(t('organizationUnits:edit.general.sections.parentOUSettings.description')),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Parent Organization Unit'})).toBeInTheDocument();
+    expect(screen.getByText('The parent organization unit in the hierarchy.')).toBeInTheDocument();
+    expect(screen.getAllByText('Parent Organization Unit')).toHaveLength(1);
   });
 
-  it('should show "Root Organization Unit" when no parent exists', () => {
+  it('should identify a root organization unit when no parent exists', () => {
     const rootOU: OrganizationUnit = {
       ...mockOrganizationUnit,
       parent: null,
@@ -78,9 +69,8 @@ describe('ParentSettingsSection', () => {
 
     renderWithProviders(<ParentSettingsSection organizationUnit={rootOU} />);
 
-    const input = screen.getByDisplayValue(t('organizationUnits:edit.general.ou.noParent.label'));
-    expect(input).toBeInTheDocument();
-    expect(input).toHaveAttribute('readonly');
+    expect(screen.getByText('This is a root organization unit.')).toBeInTheDocument();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
   });
 
   it('should show loading spinner while fetching parent', () => {

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1420,7 +1420,7 @@ const translations = {
       'Deleting this organization unit is permanent and cannot be undone.',
     'edit.general.ou.id.label': 'Organization Unit ID',
     'edit.general.ou.parent.label': 'Parent Organization Unit',
-    'edit.general.ou.noParent.label': 'Root Organization Unit',
+    'edit.general.ou.noParent.label': 'This is a root organization unit.',
     'edit.general.dangerZone.delete.button.label': 'Delete Organization Unit',
     // Form fields
     'edit.general.handle.label': 'Handle',


### PR DESCRIPTION
### Purpose
Clarify the parent organization unit section for root organization units. The previous read-only field displayed Root Organization Unit beneath a Parent Organization Unit label, which made it appear that a root unit had a parent.

### Approach
- Display This is a root organization unit. as secondary text for root units.
- Remove the duplicate Parent Organization Unit field label because the settings card title already provides that context.
- Preserve the linked parent name and UUID for child units.
- Keep an accessible label on the raw parent UUID fallback.
- Add regression coverage for the root state and duplicate-label removal.
<img width="1512" height="982" alt="Screenshot 2026-08-14 at 15 04 54" src="https://github.com/user-attachments/assets/3461398e-c52a-49c6-b0e7-a9b93d6ef061" />

### Related Issues
- Fixes #4798

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] breaking change label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

### Validation
- Focused ParentSettingsSection test suite: 9 passed
- ESLint passed for changed files
- Prettier passed for changed files
- git diff check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the parent organization unit settings display for root units.
  * Replaced the read-only field with clearer explanatory text.
  * Added accessible labeling for unresolved parent identifiers.
  * Added fallback text for missing translations, including the card title and description.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->