### PR TITLE
improved thunderidengine with cors configuration

### DIFF
--- a/backend/pkg/thunderidengine/config/config.go
+++ b/backend/pkg/thunderidengine/config/config.go
@@ -5,7 +5,11 @@
 package config
 
 import (
+	"encoding/json"
+	"fmt"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 // TrustedIssuerConfig holds configuration for trusted external issuer authentication.
@@ -422,4 +426,97 @@ type LogConfig struct {
 	Level string `yaml:"level" json:"level"`
 	// Format selects the record format: "json" or "text" (default).
 	Format string `yaml:"format" json:"format"`
+}
+
+// CORSConfig holds the allowed cross-origin origins for the engine's CORS-enabled endpoints
+// (well-known discovery, JWKS, token, userinfo, and the rest of the OAuth surface). An empty
+// AllowedOrigins leaves CORS disabled: no cross-origin request is allowed to read a response.
+//
+// The field uses the camelCase "allowedOrigins" tag (rather than this file's usual snake_case) to
+// match the wire format the engine re-encodes it to internally.
+type CORSConfig struct {
+	AllowedOrigins []CORSOrigin `yaml:"allowedOrigins" json:"allowedOrigins"`
+}
+
+// CORSOrigin is one allowed-origin entry: exactly one of Origin (a literal origin, e.g.
+// "https://app.example.com") or Regex (a fully anchored pattern, e.g. "^https://.*\\.example\\.com$")
+// must be set. Decoding from YAML or JSON enforces this; a bare string decodes to Origin, and an
+// object of the shape { regex: "..." } decodes to Regex.
+type CORSOrigin struct {
+	Origin string
+	Regex  string
+}
+
+// toEntry renders the origin as its wire form: a bare string for a literal, or a { "regex": ... }
+// object for a pattern.
+func (o CORSOrigin) toEntry() (any, error) {
+	switch {
+	case o.Origin != "" && o.Regex != "":
+		return nil, fmt.Errorf("thunderidengine: CORSOrigin must set exactly one of Origin or Regex, got both")
+	case o.Regex != "":
+		return map[string]string{"regex": o.Regex}, nil
+	case o.Origin != "":
+		return o.Origin, nil
+	default:
+		return nil, fmt.Errorf("thunderidengine: CORSOrigin must set exactly one of Origin or Regex, got neither")
+	}
+}
+
+// MarshalJSON encodes the origin to its wire form.
+func (o CORSOrigin) MarshalJSON() ([]byte, error) {
+	entry, err := o.toEntry()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(entry)
+}
+
+// MarshalYAML encodes the origin to its wire form.
+func (o CORSOrigin) MarshalYAML() (any, error) {
+	return o.toEntry()
+}
+
+// UnmarshalJSON decodes a JSON string into Origin, or an object of the shape { "regex": "..." }
+// into Regex.
+func (o *CORSOrigin) UnmarshalJSON(data []byte) error {
+	var literal string
+	if err := json.Unmarshal(data, &literal); err == nil {
+		*o = CORSOrigin{Origin: literal}
+		return nil
+	}
+	var obj struct {
+		Regex string `json:"regex"`
+	}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return fmt.Errorf("thunderidengine: CORS origin entry must be a string or { regex: ... } object: %w", err)
+	}
+	if obj.Regex == "" {
+		return fmt.Errorf("thunderidengine: CORS origin entry: regex object missing 'regex' field")
+	}
+	*o = CORSOrigin{Regex: obj.Regex}
+	return nil
+}
+
+// UnmarshalYAML decodes a YAML scalar into Origin, or a mapping of the shape { regex: "..." } into
+// Regex.
+func (o *CORSOrigin) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		*o = CORSOrigin{Origin: node.Value}
+		return nil
+	case yaml.MappingNode:
+		var obj struct {
+			Regex string `yaml:"regex"`
+		}
+		if err := node.Decode(&obj); err != nil {
+			return fmt.Errorf("thunderidengine: CORS origin entry: %w", err)
+		}
+		if obj.Regex == "" {
+			return fmt.Errorf("thunderidengine: CORS origin entry: regex object missing 'regex' field")
+		}
+		*o = CORSOrigin{Regex: obj.Regex}
+		return nil
+	default:
+		return fmt.Errorf("thunderidengine: CORS origin entry must be a string or { regex: ... } object")
+	}
 }

--- a/backend/pkg/thunderidengine/config/cors_test.go
+++ b/backend/pkg/thunderidengine/config/cors_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v3"
+)
+
+func (suite *ValidateTestSuite) TestCORSOrigin_UnmarshalJSON() {
+	suite.T().Run("literal string decodes to Origin", func(t *testing.T) {
+		var o CORSOrigin
+		require.NoError(t, json.Unmarshal([]byte(`"https://app.example.com"`), &o))
+		assert.Equal(t, CORSOrigin{Origin: "https://app.example.com"}, o)
+	})
+
+	suite.T().Run("regex object decodes to Regex", func(t *testing.T) {
+		var o CORSOrigin
+		require.NoError(t, json.Unmarshal([]byte(`{"regex":"^https://.*$"}`), &o))
+		assert.Equal(t, CORSOrigin{Regex: "^https://.*$"}, o)
+	})
+
+	suite.T().Run("regex object missing regex field fails", func(t *testing.T) {
+		var o CORSOrigin
+		assert.Error(t, json.Unmarshal([]byte(`{}`), &o))
+	})
+
+	suite.T().Run("non-string non-object fails", func(t *testing.T) {
+		var o CORSOrigin
+		assert.Error(t, json.Unmarshal([]byte(`42`), &o))
+	})
+}
+
+func (suite *ValidateTestSuite) TestCORSOrigin_UnmarshalYAML() {
+	suite.T().Run("scalar decodes to Origin", func(t *testing.T) {
+		var o CORSOrigin
+		require.NoError(t, yaml.Unmarshal([]byte(`https://app.example.com`), &o))
+		assert.Equal(t, CORSOrigin{Origin: "https://app.example.com"}, o)
+	})
+
+	suite.T().Run("mapping decodes to Regex", func(t *testing.T) {
+		var o CORSOrigin
+		require.NoError(t, yaml.Unmarshal([]byte(`regex: "^https://.*$"`), &o))
+		assert.Equal(t, CORSOrigin{Regex: "^https://.*$"}, o)
+	})
+
+	suite.T().Run("mapping missing regex field fails", func(t *testing.T) {
+		var o CORSOrigin
+		assert.Error(t, yaml.Unmarshal([]byte(`{}`), &o))
+	})
+}
+
+func (suite *ValidateTestSuite) TestCORSOrigin_Marshal() {
+	suite.T().Run("literal round-trips through JSON", func(t *testing.T) {
+		o := CORSOrigin{Origin: "https://app.example.com"}
+		data, err := json.Marshal(o)
+		require.NoError(t, err)
+		assert.JSONEq(t, `"https://app.example.com"`, string(data))
+	})
+
+	suite.T().Run("regex round-trips through JSON", func(t *testing.T) {
+		o := CORSOrigin{Regex: "^https://.*$"}
+		data, err := json.Marshal(o)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"regex":"^https://.*$"}`, string(data))
+	})
+
+	suite.T().Run("both set fails to marshal", func(t *testing.T) {
+		o := CORSOrigin{Origin: "https://app.example.com", Regex: "^https://.*$"}
+		_, err := json.Marshal(o)
+		assert.Error(t, err)
+	})
+
+	suite.T().Run("neither set fails to marshal", func(t *testing.T) {
+		_, err := json.Marshal(CORSOrigin{})
+		assert.Error(t, err)
+	})
+}
+
+func (suite *ValidateTestSuite) TestCORSConfig_UnmarshalJSON() {
+	var cfg CORSConfig
+	raw := `{"allowedOrigins":["https://app.example.com",{"regex":"^https://.*\\.example\\.com$"}]}`
+	suite.Require().NoError(json.Unmarshal([]byte(raw), &cfg))
+	assert.Equal(suite.T(), []CORSOrigin{
+		{Origin: "https://app.example.com"},
+		{Regex: `^https://.*\.example\.com$`},
+	}, cfg.AllowedOrigins)
+}

--- a/backend/pkg/thunderidengine/engine.go
+++ b/backend/pkg/thunderidengine/engine.go
@@ -6,7 +6,9 @@ package thunderidengine
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -28,6 +30,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/runtimestore"
 	"github.com/thunder-id/thunderid/internal/system/cache"
 	systemconfig "github.com/thunder-id/thunderid/internal/system/config"
+	"github.com/thunder-id/thunderid/internal/system/cors"
 	"github.com/thunder-id/thunderid/internal/system/jose"
 	joseconfig "github.com/thunder-id/thunderid/internal/system/jose/config"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwe"
@@ -35,6 +38,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/kmprovider"
 	"github.com/thunder-id/thunderid/internal/system/kmprovider/defaultkm/pki"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
@@ -181,6 +185,17 @@ func New(mux *http.ServeMux, opts ...Option) *Engine {
 		engineCtx.observabilitySvc, tokenFamilyRevocationTTL,
 		engineCtx.oauthConfig.Revocation.TokenFamily.OnExplicitRevokeEnabled())
 
+	// CORS origins come from the engine's static CORSConfig; unlike the full server there is no
+	// server-config store to back a dynamic matcher. An empty config leaves CORS disabled (matcher
+	// stays uninstalled, so every cross-origin request to the routes registered below is denied).
+	corsReader, err := buildCORSReader(engineCtx.corsConfig)
+	if err != nil {
+		logger.Fatal(ctx, "Invalid CORS configuration", log.Error(err))
+	}
+	if corsReader != nil {
+		cors.InitializeDynamicMatcher(corsReader)
+	}
+
 	// The embedded engine has no server-config store, so no default resource server is available: the
 	// resource provider is passed undecorated. Implicit no-resource requests that carry permission
 	// scopes are rejected (the provider resolves no server for an empty identifier); OIDC-only or
@@ -284,6 +299,45 @@ func (e *engineContext) applyCustomExecutors() error {
 	return nil
 }
 
+// buildCORSReader validates cfg and, if it carries any allowed origins, returns a
+// cors.ServerConfigReader that serves them as a static read-only layer with no writable layer.
+// An empty cfg returns a nil reader and no error: the caller then leaves the CORS dynamic matcher
+// uninstalled, which denies every cross-origin request.
+func buildCORSReader(cfg engineconfig.CORSConfig) (cors.ServerConfigReader, error) {
+	if len(cfg.AllowedOrigins) == 0 {
+		return nil, nil
+	}
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("thunderidengine: failed to encode CORS configuration: %w", err)
+	}
+	decoded, err := cors.OriginHandler{}.Decode(raw)
+	if err != nil {
+		return nil, fmt.Errorf("thunderidengine: invalid CORS configuration: %w", err)
+	}
+	if err := (cors.OriginHandler{}).Validate(decoded, nil, nil); err != nil {
+		return nil, fmt.Errorf("thunderidengine: invalid CORS configuration: %w", err)
+	}
+	return staticCORSReader{config: decoded.(cors.OriginConfig)}, nil
+}
+
+// staticCORSReader implements cors.ServerConfigReader over a fixed origin list supplied via
+// WithCORSConfig. It has no writable layer: origins can only change by restarting the engine
+// with a new CORSConfig.
+type staticCORSReader struct {
+	config cors.OriginConfig
+}
+
+// GetReadOnlyConfig returns the engine's static CORS configuration.
+func (r staticCORSReader) GetReadOnlyConfig(_ context.Context, _ string) (any, *common.ServiceError) {
+	return r.config, nil
+}
+
+// GetWritableConfig returns an empty configuration: staticCORSReader has no writable layer.
+func (r staticCORSReader) GetWritableConfig(_ context.Context, _ string) (any, *common.ServiceError) {
+	return cors.OriginConfig{}, nil
+}
+
 type engineContext struct {
 	cacheManager          cache.CacheManagerInterface
 	jwtService            jwt.JWTServiceInterface
@@ -310,6 +364,7 @@ type engineContext struct {
 	encryptionConfig       engineconfig.EncryptionConfig
 	logConfig              engineconfig.LogConfig
 	attributeCacheConfig   engineconfig.AttributeCacheConfig
+	corsConfig             engineconfig.CORSConfig
 
 	actorProvider             providers.ActorProvider
 	defaultAuthnProvider      providers.AuthnProviderInterface
@@ -359,6 +414,14 @@ func WithEncryptionConfig(encryptionConfig engineconfig.EncryptionConfig) Option
 // WithAttributeCacheConfig supplies the attribute cache configuration.
 func WithAttributeCacheConfig(config engineconfig.AttributeCacheConfig) Option {
 	return func(c *engineContext) { c.attributeCacheConfig = config }
+}
+
+// WithCORSConfig supplies the allowed cross-origin origins for the engine's CORS-enabled
+// endpoints (well-known discovery, JWKS, token, userinfo, and the rest of the OAuth surface).
+// Omitting this option leaves CORS disabled: no cross-origin request is allowed to read a
+// response from those endpoints.
+func WithCORSConfig(config engineconfig.CORSConfig) Option {
+	return func(c *engineContext) { c.corsConfig = config }
 }
 
 // WithServerConfig supplies the server configuration.

--- a/backend/pkg/thunderidengine/engine_test.go
+++ b/backend/pkg/thunderidengine/engine_test.go
@@ -4,6 +4,7 @@
 package thunderidengine
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -21,6 +22,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	systemconfig "github.com/thunder-id/thunderid/internal/system/config"
+	"github.com/thunder-id/thunderid/internal/system/cors"
 	joseconfig "github.com/thunder-id/thunderid/internal/system/jose/config"
 	"github.com/thunder-id/thunderid/internal/system/kmprovider"
 	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
@@ -523,4 +525,68 @@ func (suite *EngineTestSuite) TestWithCustomAuthnProvider_AccumulatesByName() {
 	assert.Equal(suite.T(), []string{"password"}, ctx.customAuthnProviders["acme"].Creds)
 	assert.Equal(suite.T(), []string{"otp"}, ctx.customAuthnProviders["beta"].Creds)
 	assert.NotNil(suite.T(), ctx.customAuthnProviders["acme"].Instance)
+}
+
+// mustMatch parses origin and reports whether matcher allows it.
+func mustMatch(t *testing.T, matcher *cors.Matcher, origin string) bool {
+	t.Helper()
+	parsed, err := cors.ParseOrigin(origin)
+	require.NoError(t, err)
+	allow, _ := matcher.Match(parsed)
+	return allow
+}
+
+func (suite *EngineTestSuite) TestBuildCORSReader() {
+	suite.T().Run("empty config returns nil reader", func(t *testing.T) {
+		reader, err := buildCORSReader(engineconfig.CORSConfig{})
+		require.NoError(t, err)
+		assert.Nil(t, reader)
+	})
+
+	suite.T().Run("valid config installs matching reader", func(t *testing.T) {
+		t.Cleanup(func() { cors.InitializeDynamicMatcher(nil) })
+
+		reader, err := buildCORSReader(engineconfig.CORSConfig{
+			AllowedOrigins: []engineconfig.CORSOrigin{
+				{Origin: "https://app.example.com"},
+				{Regex: `^https://[a-z0-9-]+\.staging\.example\.com$`},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+
+		cors.InitializeDynamicMatcher(reader)
+		matcher := cors.GetDynamicMatcher(context.Background())
+		require.NotNil(t, matcher)
+
+		assert.True(t, mustMatch(t, matcher, "https://app.example.com"))
+		assert.True(t, mustMatch(t, matcher, "https://foo.staging.example.com"))
+		assert.False(t, mustMatch(t, matcher, "https://other.example.com"))
+	})
+
+	suite.T().Run("wildcard literal is rejected", func(t *testing.T) {
+		reader, err := buildCORSReader(engineconfig.CORSConfig{
+			AllowedOrigins: []engineconfig.CORSOrigin{{Origin: "*"}},
+		})
+		assert.Error(t, err)
+		assert.Nil(t, reader)
+	})
+
+	suite.T().Run("invalid regex is rejected", func(t *testing.T) {
+		reader, err := buildCORSReader(engineconfig.CORSConfig{
+			AllowedOrigins: []engineconfig.CORSOrigin{{Regex: "["}},
+		})
+		assert.Error(t, err)
+		assert.Nil(t, reader)
+	})
+
+	suite.T().Run("origin and regex both set is rejected", func(t *testing.T) {
+		reader, err := buildCORSReader(engineconfig.CORSConfig{
+			AllowedOrigins: []engineconfig.CORSOrigin{
+				{Origin: "https://app.example.com", Regex: "^https://.*$"},
+			},
+		})
+		assert.Error(t, err)
+		assert.Nil(t, reader)
+	})
 }


### PR DESCRIPTION
### Purpose
The embedded ThunderID engine (`thunderidengine`) had no way to configure CORS, so cross-origin requests to its endpoints (well-known discovery, JWKS, token, userinfo, etc.) were always denied. This adds a `CORSConfig` option so embedders can allow specific origins.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
- Added `CORSConfig`/`CORSOrigin` types supporting literal origins or regex patterns (mutually exclusive), with custom JSON/YAML marshal/unmarshal.
- Added `WithCORSConfig` engine option; `buildCORSReader` validates the config and wires it into the existing `cors.DynamicMatcher` as a static, read-only `ServerConfigReader`.
- Empty config leaves CORS disabled (no matcher installed), preserving current default-deny behavior.

### Related Issues
- #4939 

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable CORS support for the embedded engine.
  * Allowed origins can now be specified as literal values or regular expressions in JSON and YAML configuration.
  * Invalid CORS settings, including wildcard or malformed patterns, are rejected during engine initialization.

* **Tests**
  * Added coverage for valid, invalid, mixed, and empty CORS configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->