### PR TITLE
Add integration tests for OAuth authz, actor token, PKCE, refresh token, and token type hint gaps

### DIFF
--- a/tests/integration/oauth/authz/prompt_consent_test.go
+++ b/tests/integration/oauth/authz/prompt_consent_test.go
@@ -1,0 +1,316 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authz
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	promptConsentClientID   = "prompt_consent_test_client"
+	promptConsentRedirectURI = "https://localhost:3000"
+	promptConsentUsername   = "prompt_consent_test_user"
+	promptConsentPassword   = "PromptConsentPass1!"
+)
+
+var promptConsentUserType = testutils.UserType{
+	Name: "prompt-consent-person",
+	Schema: map[string]interface{}{
+		"username": map[string]interface{}{"type": "string"},
+		"password": map[string]interface{}{"type": "string", "credential": true},
+		"email":    map[string]interface{}{"type": "string"},
+	},
+}
+
+// promptConsentAuthFlow mirrors the console-generated "Consent Flow" template: credentials, then an
+// authorization check, then a consent check that prompts (via prompt_consent) only when required
+// consents are missing or a reprompt has been forced.
+var promptConsentAuthFlow = testutils.Flow{
+	Name:     "Prompt Consent Test Auth Flow",
+	FlowType: "AUTHENTICATION",
+	Handle:   "auth_flow_prompt_consent_test",
+	Nodes: []map[string]interface{}{
+		{"id": "start", "type": "START", "onSuccess": "prompt_credentials"},
+		{"id": "prompt_credentials", "type": "PROMPT", "prompts": []map[string]interface{}{
+			{
+				"inputs": []map[string]interface{}{
+					{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+					{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+				},
+				"action": map[string]interface{}{"ref": "action_001", "nextNode": "credentials_auth"},
+			},
+		}},
+		{"id": "credentials_auth", "type": "TASK_EXECUTION", "executor": map[string]interface{}{
+			"name": "CredentialsAuthExecutor",
+			"inputs": []map[string]interface{}{
+				{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+				{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+			},
+		}, "onSuccess": "authorization_check", "onIncomplete": "prompt_credentials"},
+		{"id": "authorization_check", "type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{"name": "AuthorizationExecutor"}, "onSuccess": "consent_check"},
+		{"id": "consent_check", "type": "TASK_EXECUTION", "executor": map[string]interface{}{
+			"name": "ConsentExecutor",
+			"inputs": []map[string]interface{}{
+				{"ref": "input_f3px", "identifier": "consent_decisions", "type": "CONSENT_INPUT", "required": true},
+			},
+		}, "onSuccess": "auth_assert", "onIncomplete": "prompt_consent"},
+		{"id": "prompt_consent", "type": "PROMPT", "prompts": []map[string]interface{}{
+			{
+				"inputs": []map[string]interface{}{
+					{"ref": "input_0ho7", "identifier": "consent_decisions", "type": "CONSENT_INPUT", "required": true},
+				},
+				"action": map[string]interface{}{"ref": "consent_action_allow", "nextNode": "consent_check"},
+			},
+			{
+				"inputs": []map[string]interface{}{
+					{"ref": "input_0ho7", "identifier": "consent_decisions", "type": "CONSENT_INPUT", "required": true},
+				},
+				"action": map[string]interface{}{"ref": "consent_action_deny", "nextNode": "consent_check"},
+			},
+		}},
+		{"id": "auth_assert", "type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{"name": "AuthAssertExecutor"}, "onSuccess": "end"},
+		{"id": "end", "type": "END"},
+	},
+}
+
+// consentPurposePrompt mirrors providers.ConsentPurposePrompt, just enough to build an
+// "approve everything" ConsentDecisions payload from what the server forwards to the prompt.
+type consentPurposePrompt struct {
+	PurposeName string             `json:"purposeName"`
+	Essential   []consentElementRef `json:"essential"`
+	Optional    []consentElementRef `json:"optional"`
+}
+
+type consentElementRef struct {
+	Name string `json:"name"`
+}
+
+// PromptConsentTestSuite verifies that prompt=consent forces the ConsentExecutor to re-prompt even
+// when the user already holds valid consent for the application, distinct from the default behavior
+// of skipping the prompt once consent has been granted.
+type PromptConsentTestSuite struct {
+	suite.Suite
+	client       *http.Client
+	ouID         string
+	entityTypeID string
+	authFlowID   string
+	appID        string
+	userID       string
+}
+
+// TestPromptConsentTestSuite runs the PromptConsentTestSuite.
+func TestPromptConsentTestSuite(t *testing.T) {
+	suite.Run(t, new(PromptConsentTestSuite))
+}
+
+// SetupSuite creates the shared organization unit, user type, consent-bearing auth flow, an
+// application requiring consent for its optional "email" attribute, and the test user.
+func (ts *PromptConsentTestSuite) SetupSuite() {
+	ts.client = testutils.GetHTTPClient()
+
+	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "prompt-consent-test-ou",
+		Name:        "Prompt Consent Test OU",
+		Description: "Organization unit for prompt=consent integration tests",
+	})
+	ts.Require().NoError(err)
+	ts.ouID = ouID
+
+	promptConsentUserType.OUID = ouID
+	entityTypeID, err := testutils.CreateUserType(promptConsentUserType)
+	ts.Require().NoError(err)
+	ts.entityTypeID = entityTypeID
+
+	flowID, err := testutils.CreateFlow(promptConsentAuthFlow)
+	ts.Require().NoError(err)
+	ts.authFlowID = flowID
+
+	app := map[string]interface{}{
+		"name":                      "PromptConsentTestApp",
+		"description":               "Application for prompt=consent integration testing",
+		"ouId":                      ts.ouID,
+		"type":                      "fullstack",
+		"authFlowId":                ts.authFlowID,
+		"isRegistrationFlowEnabled": false,
+		"allowedUserTypes":          []string{"prompt-consent-person"},
+		"assertion":                 map[string]interface{}{"userAttributes": []string{"email"}},
+		"loginConsent":              map[string]interface{}{"validityPeriod": 3600},
+		"inboundAuthConfig": []map[string]interface{}{
+			{"type": "oauth2", "config": map[string]interface{}{
+				"clientId":                promptConsentClientID,
+				"clientSecret":            "prompt_consent_test_secret",
+				"redirectUris":            []string{promptConsentRedirectURI},
+				"grantTypes":              []string{"authorization_code"},
+				"responseTypes":           []string{"code"},
+				"tokenEndpointAuthMethod": "client_secret_basic",
+			}},
+		},
+	}
+	appJSON, err := json.Marshal(app)
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testutils.TestServerURL+"/applications", bytes.NewBuffer(appJSON))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	ts.Require().Equal(http.StatusCreated, resp.StatusCode, string(bodyBytes))
+
+	var respData map[string]interface{}
+	ts.Require().NoError(json.Unmarshal(bodyBytes, &respData))
+	ts.appID = respData["id"].(string)
+
+	attributesJSON, err := json.Marshal(map[string]interface{}{
+		"username": promptConsentUsername,
+		"password": promptConsentPassword,
+		"email":    "prompt_consent_test@example.com",
+	})
+	ts.Require().NoError(err)
+	userID, err := testutils.CreateUser(testutils.User{
+		OUID:       ouID,
+		Type:       "prompt-consent-person",
+		Attributes: json.RawMessage(attributesJSON),
+	})
+	ts.Require().NoError(err)
+	ts.userID = userID
+}
+
+// TearDownSuite deletes the resources created in SetupSuite.
+func (ts *PromptConsentTestSuite) TearDownSuite() {
+	if ts.userID != "" {
+		_ = testutils.DeleteUser(ts.userID)
+	}
+	if ts.appID != "" {
+		_ = testutils.DeleteApplication(ts.appID)
+	}
+	if ts.authFlowID != "" {
+		_ = testutils.DeleteFlow(ts.authFlowID)
+	}
+	if ts.entityTypeID != "" {
+		_ = testutils.DeleteUserType(ts.entityTypeID)
+	}
+	if ts.ouID != "" {
+		_ = testutils.DeleteOrganizationUnit(ts.ouID)
+	}
+}
+
+// runLoginThroughCredentials initiates the authorization flow (optionally with a prompt parameter)
+// and executes it through the credentials step, returning the resulting step (which is either the
+// consent prompt or, if consent was skipped, the completed flow) along with the auth ID.
+func (ts *PromptConsentTestSuite) runLoginThroughCredentials(prompt string) (string, *testutils.FlowStep) {
+	var httpResp *http.Response
+	var err error
+	if prompt != "" {
+		httpResp, err = testutils.InitiateAuthorizationFlowWithPrompt(
+			promptConsentClientID, promptConsentRedirectURI, "code", "openid", "consent-test-state", prompt)
+	} else {
+		httpResp, err = testutils.InitiateAuthorizationFlow(
+			promptConsentClientID, promptConsentRedirectURI, "code", "openid", "consent-test-state")
+	}
+	ts.Require().NoError(err)
+	defer httpResp.Body.Close()
+	ts.Require().Equal(http.StatusFound, httpResp.StatusCode)
+
+	authID, executionID, err := testutils.ExtractAuthData(httpResp.Header.Get("Location"))
+	ts.Require().NoError(err)
+
+	initialStep, err := testutils.ExecuteAuthenticationFlow(executionID, nil, "")
+	ts.Require().NoError(err)
+
+	credsStep, err := testutils.ExecuteAuthenticationFlow(executionID, map[string]string{
+		"username": promptConsentUsername,
+		"password": promptConsentPassword,
+	}, "action_001", initialStep.ChallengeToken)
+	ts.Require().NoError(err)
+
+	return authID, credsStep
+}
+
+// approveConsent decodes the forwarded consent purposes and submits an "approve everything"
+// decision, returning the resulting (now complete) flow step.
+func (ts *PromptConsentTestSuite) approveConsent(step *testutils.FlowStep) *testutils.FlowStep {
+	ts.Require().NotNil(step.Data)
+	raw, ok := step.Data.AdditionalData["consentPrompt"].(string)
+	ts.Require().True(ok, "expected a consentPrompt entry in additionalData")
+
+	var purposes []consentPurposePrompt
+	ts.Require().NoError(json.Unmarshal([]byte(raw), &purposes))
+	ts.Require().NotEmpty(purposes, "expected at least one consent purpose to approve")
+
+	type elementDecision struct {
+		Name     string `json:"name"`
+		Approved bool   `json:"approved"`
+	}
+	type purposeDecision struct {
+		PurposeName string            `json:"purposeName"`
+		Approved    bool              `json:"approved"`
+		Elements    []elementDecision `json:"elements"`
+	}
+	type consentDecisions struct {
+		Approved bool              `json:"approved"`
+		Purposes []purposeDecision `json:"purposes"`
+	}
+
+	decisions := consentDecisions{Approved: true}
+	for _, p := range purposes {
+		pd := purposeDecision{PurposeName: p.PurposeName, Approved: true}
+		for _, e := range append(append([]consentElementRef{}, p.Essential...), p.Optional...) {
+			pd.Elements = append(pd.Elements, elementDecision{Name: e.Name, Approved: true})
+		}
+		decisions.Purposes = append(decisions.Purposes, pd)
+	}
+	decisionsJSON, err := json.Marshal(decisions)
+	ts.Require().NoError(err)
+
+	nextStep, err := testutils.ExecuteAuthenticationFlow(step.ExecutionID, map[string]string{
+		"consent_decisions": string(decisionsJSON),
+	}, "consent_action_allow", step.ChallengeToken)
+	ts.Require().NoError(err)
+	return nextStep
+}
+
+// TestPromptConsent_ForcesReconsentDespiteExistingConsent verifies the full consent lifecycle: the
+// first login requires and records consent, a second login without a prompt parameter skips the
+// consent step entirely (the default behavior), and a third login with prompt=consent is forced back
+// into the consent prompt even though valid consent already exists.
+func (ts *PromptConsentTestSuite) TestPromptConsent_ForcesReconsentDespiteExistingConsent() {
+	// Login 1: no prior consent, must be prompted.
+	authID1, step1 := ts.runLoginThroughCredentials("")
+	ts.Require().NotEqual("COMPLETE", step1.FlowStatus, "first login should require consent")
+	completed1 := ts.approveConsent(step1)
+	ts.Require().Equal("COMPLETE", completed1.FlowStatus, "flow should complete once consent is approved")
+	ts.Require().NotEmpty(completed1.Assertion)
+	_, err := testutils.CompleteAuthorization(authID1, completed1.Assertion)
+	ts.Require().NoError(err)
+
+	// Login 2: consent already granted and still valid, no prompt requested -> should skip straight
+	// through to COMPLETE without ever hitting the consent prompt again.
+	authID2, step2 := ts.runLoginThroughCredentials("")
+	ts.Require().Equal("COMPLETE", step2.FlowStatus,
+		"second login should skip the consent prompt since valid consent already exists")
+	ts.Require().NotEmpty(step2.Assertion)
+	_, err = testutils.CompleteAuthorization(authID2, step2.Assertion)
+	ts.Require().NoError(err)
+
+	// Login 3: prompt=consent forces a re-prompt despite the still-valid existing consent.
+	_, step3 := ts.runLoginThroughCredentials("consent")
+	ts.Require().NotEqual("COMPLETE", step3.FlowStatus,
+		"prompt=consent should force a re-prompt even though consent is already valid")
+	ts.Require().NotNil(step3.Data)
+	_, hasConsentPrompt := step3.Data.AdditionalData["consentPrompt"]
+	ts.Assert().True(hasConsentPrompt, "forced re-consent should forward consent purposes to prompt again")
+}

--- a/tests/integration/oauth/authz/prompt_test.go
+++ b/tests/integration/oauth/authz/prompt_test.go
@@ -70,3 +70,61 @@ func (ts *AuthzTestSuite) TestAuthorize_PromptUnsupportedValue_InvalidRequest() 
 
 	ts.Assert().Equal("invalid_request", query.Get("error"))
 }
+
+// TestAuthorize_PromptSelectAccount_AccountSelectionRequired verifies that prompt=select_account is
+// redirected back to the client with error=account_selection_required, since the server does not
+// support account selection prompts.
+func (ts *AuthzTestSuite) TestAuthorize_PromptSelectAccount_AccountSelectionRequired() {
+	resp, err := testutils.InitiateAuthorizationFlowWithPrompt(
+		clientID, redirectURI, "code", "openid", "prompt-select-account-state", "select_account")
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusFound, resp.StatusCode, "prompt=select_account should redirect back to the client")
+
+	location := resp.Header.Get("Location")
+	ts.Require().NotEmpty(location, "Location header should be present")
+
+	redirected, err := url.Parse(location)
+	ts.Require().NoError(err)
+	query := redirected.Query()
+
+	ts.Assert().Equal("account_selection_required", query.Get("error"))
+	ts.Assert().NotEmpty(query.Get("error_description"))
+	ts.Assert().Equal("prompt-select-account-state", query.Get("state"), "state must be echoed back to the client")
+}
+
+// TestAuthorize_PromptEmpty_InvalidRequest verifies that a prompt parameter present but blank
+// (prompt=, as opposed to the parameter being entirely absent) is rejected as invalid_request. The
+// shared authorization-flow helper treats an empty string as "omit this parameter", so this test
+// builds the raw request directly to represent the parameter being present with an empty value.
+func (ts *AuthzTestSuite) TestAuthorize_PromptEmpty_InvalidRequest() {
+	authorizeURL, err := url.Parse(testutils.TestServerURL + "/oauth2/authorize")
+	ts.Require().NoError(err)
+
+	query := url.Values{}
+	query.Set("client_id", clientID)
+	query.Set("redirect_uri", redirectURI)
+	query.Set("response_type", "code")
+	query.Set("scope", "openid")
+	query.Set("state", "prompt-empty-state")
+	query.Set("prompt", "")
+	authorizeURL.RawQuery = query.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, authorizeURL.String(), nil)
+	ts.Require().NoError(err)
+
+	resp, err := testutils.GetNoRedirectHTTPClient().Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusFound, resp.StatusCode, "blank prompt should redirect back to the client")
+
+	location := resp.Header.Get("Location")
+	ts.Require().NotEmpty(location, "Location header should be present")
+
+	redirected, err := url.Parse(location)
+	ts.Require().NoError(err)
+	redirectQuery := redirected.Query()
+
+	ts.Assert().Equal("invalid_request", redirectQuery.Get("error"))
+	ts.Assert().NotEmpty(redirectQuery.Get("error_description"))
+}

--- a/tests/integration/oauth/par/par_test.go
+++ b/tests/integration/oauth/par/par_test.go
@@ -391,6 +391,20 @@ func (ts *PARTestSuite) TestPAREndpointValidation() {
 			},
 			ExpectedError: "login_required",
 		},
+		{
+			// This test reflects current behavior; account selection prompts are not implemented yet.
+			Name: "Prompt Select Account Not Supported",
+			Params: map[string]string{
+				"response_type":         "code",
+				"redirect_uri":          redirectURI,
+				"scope":                 "openid",
+				"state":                 "test",
+				"prompt":                "select_account",
+				"code_challenge":        testutils.GenerateCodeChallenge("test-verifier-that-is-at-least-43-characters-long-enough"),
+				"code_challenge_method": "S256",
+			},
+			ExpectedError: "account_selection_required",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/tests/integration/oauth/token/actor_token_test.go
+++ b/tests/integration/oauth/token/actor_token_test.go
@@ -1,0 +1,557 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package token
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	actorTokenIssuerClientID     = "actor_token_issuer_client"
+	actorTokenIssuerClientSecret = "actor_token_issuer_secret"
+	actorTokenExchangeClientID   = "actor_token_exchange_client"
+	actorTokenExchangeSecret     = "actor_token_exchange_secret"
+	actorTokenRedirectURI        = "https://localhost:3000"
+	actorTokenSubjectUsername    = "actor_token_subject_user"
+	actorTokenSubjectPassword    = "ActorTokenSubjectPass1!"
+	actorTokenActorUsername      = "actor_token_actor_user"
+	actorTokenActorPassword      = "ActorTokenActorPass1!"
+)
+
+var actorTokenUserType = testutils.UserType{
+	Name: "actor-token-person",
+	Schema: map[string]interface{}{
+		"username": map[string]interface{}{"type": "string"},
+		"password": map[string]interface{}{"type": "string", "credential": true},
+	},
+}
+
+var actorTokenAuthFlow = testutils.Flow{
+	Name:     "Actor Token Auth Flow",
+	FlowType: "AUTHENTICATION",
+	Handle:   "auth_flow_actor_token_test",
+	Nodes: []map[string]interface{}{
+		{
+			"id":        "start",
+			"type":      "START",
+			"onSuccess": "prompt_credentials",
+		},
+		{
+			"id":   "prompt_credentials",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+						{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+					},
+					"action": map[string]interface{}{"ref": "action_001", "nextNode": "credentials_auth"},
+				},
+			},
+		},
+		{
+			"id":   "credentials_auth",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "CredentialsAuthExecutor",
+				"inputs": []map[string]interface{}{
+					{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+					{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+				},
+			},
+			"onSuccess": "auth_assert",
+		},
+		{
+			"id":        "auth_assert",
+			"type":      "TASK_EXECUTION",
+			"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+			"onSuccess": "end",
+		},
+		{"id": "end", "type": "END"},
+	},
+}
+
+// ActorTokenTestSuite verifies RFC 8693 actor_token handling in the token-exchange grant: the "act"
+// claim built for a valid actor_token, the actor_token/actor_token_type pairing requirement, rejection
+// of an invalid, expired, or untrusted-issuer actor_token, and nested delegation chains (an actor_token
+// that itself already carries an "act" claim from a prior exchange).
+type ActorTokenTestSuite struct {
+	suite.Suite
+	client        *http.Client
+	ouID          string
+	entityTypeID  string
+	authFlowID    string
+	issuerAppID   string
+	exchangeAppID string
+	subjectUserID string
+	actorUserID   string
+}
+
+// TestActorTokenTestSuite runs the ActorTokenTestSuite.
+func TestActorTokenTestSuite(t *testing.T) {
+	suite.Run(t, new(ActorTokenTestSuite))
+}
+
+// SetupSuite creates the shared organization unit, user type, auth flow, issuer/exchange
+// applications, and the two test users (subject and actor) for the suite.
+func (ts *ActorTokenTestSuite) SetupSuite() {
+	ts.client = testutils.GetHTTPClient()
+
+	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "actor-token-test-ou",
+		Name:        "Actor Token Test OU",
+		Description: "Organization unit for actor_token integration tests",
+	})
+	ts.Require().NoError(err)
+	ts.ouID = ouID
+
+	actorTokenUserType.OUID = ouID
+	entityTypeID, err := testutils.CreateUserType(actorTokenUserType)
+	ts.Require().NoError(err)
+	ts.entityTypeID = entityTypeID
+
+	flowID, err := testutils.CreateFlow(actorTokenAuthFlow)
+	ts.Require().NoError(err)
+	ts.authFlowID = flowID
+
+	ts.issuerAppID = ts.createApplication(map[string]interface{}{
+		"clientId":                actorTokenIssuerClientID,
+		"clientSecret":            actorTokenIssuerClientSecret,
+		"redirectUris":            []string{actorTokenRedirectURI},
+		"grantTypes":              []string{"authorization_code"},
+		"responseTypes":           []string{"code"},
+		"tokenEndpointAuthMethod": "client_secret_basic",
+	}, true)
+
+	ts.exchangeAppID = ts.createApplication(map[string]interface{}{
+		"clientId":                actorTokenExchangeClientID,
+		"clientSecret":            actorTokenExchangeSecret,
+		"grantTypes":              []string{"urn:ietf:params:oauth:grant-type:token-exchange"},
+		"tokenEndpointAuthMethod": "client_secret_basic",
+	}, false)
+
+	ts.subjectUserID = ts.createUser(actorTokenSubjectUsername, actorTokenSubjectPassword)
+	ts.actorUserID = ts.createUser(actorTokenActorUsername, actorTokenActorPassword)
+}
+
+// TearDownSuite deletes the resources created in SetupSuite.
+func (ts *ActorTokenTestSuite) TearDownSuite() {
+	if ts.subjectUserID != "" {
+		_ = testutils.DeleteUser(ts.subjectUserID)
+	}
+	if ts.actorUserID != "" {
+		_ = testutils.DeleteUser(ts.actorUserID)
+	}
+	if ts.exchangeAppID != "" {
+		_ = testutils.DeleteApplication(ts.exchangeAppID)
+	}
+	if ts.issuerAppID != "" {
+		_ = testutils.DeleteApplication(ts.issuerAppID)
+	}
+	if ts.authFlowID != "" {
+		_ = testutils.DeleteFlow(ts.authFlowID)
+	}
+	if ts.entityTypeID != "" {
+		_ = testutils.DeleteUserType(ts.entityTypeID)
+	}
+	if ts.ouID != "" {
+		_ = testutils.DeleteOrganizationUnit(ts.ouID)
+	}
+}
+
+// createApplication creates an application with the given OAuth2 inbound config, optionally
+// bound to the shared auth flow.
+func (ts *ActorTokenTestSuite) createApplication(oauthConfig map[string]interface{}, withAuthFlow bool) string {
+	app := map[string]interface{}{
+		"name":                      "ActorTokenTestApp-" + oauthConfig["clientId"].(string),
+		"description":               "Application for actor_token integration testing",
+		"ouId":                      ts.ouID,
+		"type":                      "fullstack",
+		"isRegistrationFlowEnabled": false,
+		"allowedUserTypes":          []string{"actor-token-person"},
+		"inboundAuthConfig": []map[string]interface{}{
+			{
+				"type":   "oauth2",
+				"config": oauthConfig,
+			},
+		},
+	}
+	if withAuthFlow {
+		app["authFlowId"] = ts.authFlowID
+	}
+
+	jsonData, err := json.Marshal(app)
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testutils.TestServerURL+"/applications", bytes.NewBuffer(jsonData))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	ts.Require().Equal(http.StatusCreated, resp.StatusCode, string(bodyBytes))
+
+	var respData map[string]interface{}
+	ts.Require().NoError(json.Unmarshal(bodyBytes, &respData))
+	return respData["id"].(string)
+}
+
+// createUser creates a test user of the shared actor-token-person type.
+func (ts *ActorTokenTestSuite) createUser(username, password string) string {
+	attributesJSON, err := json.Marshal(map[string]interface{}{
+		"username": username,
+		"password": password,
+	})
+	ts.Require().NoError(err)
+
+	userID, err := testutils.CreateUser(testutils.User{
+		OUID:       ts.ouID,
+		Type:       "actor-token-person",
+		Attributes: json.RawMessage(attributesJSON),
+	})
+	ts.Require().NoError(err)
+	return userID
+}
+
+// obtainAccessTokenAs runs the full authorization_code flow against the given client and returns the
+// resulting access token for the given user credentials.
+func (ts *ActorTokenTestSuite) obtainAccessTokenAs(clientID, clientSecret, username, password string) string {
+	resp, err := testutils.InitiateAuthorizationFlow(clientID, actorTokenRedirectURI, "code", "openid", "test-state")
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusFound, resp.StatusCode)
+
+	location := resp.Header.Get("Location")
+	ts.Require().NotEmpty(location)
+
+	authID, executionID, err := testutils.ExtractAuthData(location)
+	ts.Require().NoError(err)
+
+	initialStep, err := testutils.ExecuteAuthenticationFlow(executionID, nil, "")
+	ts.Require().NoError(err)
+
+	flowStep, err := testutils.ExecuteAuthenticationFlow(executionID, map[string]string{
+		"username": username,
+		"password": password,
+	}, "action_001", initialStep.ChallengeToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus)
+	ts.Require().NotEmpty(flowStep.Assertion)
+
+	authzResp, err := testutils.CompleteAuthorization(authID, flowStep.Assertion)
+	ts.Require().NoError(err)
+
+	code, err := testutils.ExtractAuthorizationCode(authzResp.RedirectURI)
+	ts.Require().NoError(err)
+
+	tokenResult, err := testutils.RequestToken(clientID, clientSecret, code, actorTokenRedirectURI, "authorization_code")
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusOK, tokenResult.StatusCode, string(tokenResult.Body))
+	ts.Require().NotNil(tokenResult.Token)
+	ts.Require().NotEmpty(tokenResult.Token.AccessToken)
+
+	return tokenResult.Token.AccessToken
+}
+
+// doExchange submits a token-exchange grant request authenticated as the shared exchange app.
+func (ts *ActorTokenTestSuite) doExchange(formData url.Values) (int, map[string]interface{}) {
+	req, err := http.NewRequest("POST", testutils.TestServerURL+"/oauth2/token", strings.NewReader(formData.Encode()))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(actorTokenExchangeClientID, actorTokenExchangeSecret)
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	var respBody map[string]interface{}
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	ts.Require().NoError(json.Unmarshal(bodyBytes, &respBody), "body: %s", string(bodyBytes))
+	return resp.StatusCode, respBody
+}
+
+// craftJWTWithIssuer builds a JWT-shaped, unsigned token carrying the given sub/iss/exp. The
+// signature segment is a dummy value: ValidateSubjectToken rejects an untrusted issuer before it
+// ever verifies a signature, so this is sufficient to exercise that error path without access to a
+// real signing key.
+func craftJWTWithIssuer(sub, iss string, exp time.Time) string {
+	header := map[string]interface{}{"alg": "RS256", "typ": "JWT"}
+	claims := map[string]interface{}{
+		"sub": sub,
+		"iss": iss,
+		"exp": exp.Unix(),
+		"iat": time.Now().Unix(),
+	}
+
+	headerJSON, _ := json.Marshal(header)
+	claimsJSON, _ := json.Marshal(claims)
+
+	headerB64 := base64.RawURLEncoding.EncodeToString(headerJSON)
+	claimsB64 := base64.RawURLEncoding.EncodeToString(claimsJSON)
+	return headerB64 + "." + claimsB64 + "." + base64.RawURLEncoding.EncodeToString([]byte("dummy-signature"))
+}
+
+// exchangeParams builds the base token-exchange form parameters for the given subject token.
+func exchangeParams(subjectToken string) url.Values {
+	form := url.Values{}
+	form.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", "urn:ietf:params:oauth:token-type:access_token")
+	return form
+}
+
+// TestActorToken_ValidActorAndSubject_ActClaimPresent verifies that a valid actor_token accompanying
+// a valid subject_token produces an "act" claim naming the actor's subject and issuer.
+func (ts *ActorTokenTestSuite) TestActorToken_ValidActorAndSubject_ActClaimPresent() {
+	subjectToken := ts.obtainAccessTokenAs(
+		actorTokenIssuerClientID, actorTokenIssuerClientSecret, actorTokenSubjectUsername, actorTokenSubjectPassword)
+	actorToken := ts.obtainAccessTokenAs(
+		actorTokenIssuerClientID, actorTokenIssuerClientSecret, actorTokenActorUsername, actorTokenActorPassword)
+
+	actorClaims, err := testutils.DecodeJWT(actorToken)
+	ts.Require().NoError(err)
+
+	form := exchangeParams(subjectToken)
+	form.Set("actor_token", actorToken)
+	form.Set("actor_token_type", "urn:ietf:params:oauth:token-type:access_token")
+
+	status, body := ts.doExchange(form)
+	ts.Require().Equal(http.StatusOK, status, "%v", body)
+
+	token, ok := body["access_token"].(string)
+	ts.Require().True(ok, "Response should contain access_token")
+
+	claims, err := testutils.DecodeJWT(token)
+	ts.Require().NoError(err)
+	ts.Equal(ts.subjectUserID, claims.Sub, "Subject should be the subject_token's own subject")
+
+	act, ok := claims.Additional["act"].(map[string]interface{})
+	ts.Require().True(ok, "Issued token should carry an act claim")
+	ts.Equal(ts.actorUserID, act["sub"], "act.sub should identify the actor")
+	ts.Equal(actorClaims.Iss, act["iss"], "act.iss should identify the actor token's issuer")
+	ts.NotContains(act, "act", "act claim should not be nested when the actor_token carries no prior act claim")
+}
+
+// TestActorToken_MissingActorTokenType_InvalidRequest verifies that supplying actor_token without
+// actor_token_type is rejected as invalid_request.
+func (ts *ActorTokenTestSuite) TestActorToken_MissingActorTokenType_InvalidRequest() {
+	subjectToken := ts.obtainAccessTokenAs(
+		actorTokenIssuerClientID, actorTokenIssuerClientSecret, actorTokenSubjectUsername, actorTokenSubjectPassword)
+	actorToken := ts.obtainAccessTokenAs(
+		actorTokenIssuerClientID, actorTokenIssuerClientSecret, actorTokenActorUsername, actorTokenActorPassword)
+
+	form := exchangeParams(subjectToken)
+	form.Set("actor_token", actorToken)
+	// actor_token_type intentionally omitted.
+
+	status, body := ts.doExchange(form)
+	ts.Require().Equal(http.StatusBadRequest, status, "%v", body)
+	ts.Equal("invalid_request", body["error"])
+	ts.Contains(body["error_description"], "actor_token_type is required")
+}
+
+// TestActorToken_TypeWithoutActorToken_InvalidRequest verifies that supplying actor_token_type
+// without actor_token is rejected as invalid_request.
+func (ts *ActorTokenTestSuite) TestActorToken_TypeWithoutActorToken_InvalidRequest() {
+	subjectToken := ts.obtainAccessTokenAs(
+		actorTokenIssuerClientID, actorTokenIssuerClientSecret, actorTokenSubjectUsername, actorTokenSubjectPassword)
+
+	form := exchangeParams(subjectToken)
+	form.Set("actor_token_type", "urn:ietf:params:oauth:token-type:access_token")
+	// actor_token intentionally omitted.
+
+	status, body := ts.doExchange(form)
+	ts.Require().Equal(http.StatusBadRequest, status, "%v", body)
+	ts.Equal("invalid_request", body["error"])
+	ts.Contains(body["error_description"], "actor_token_type must not be provided without actor_token")
+}
+
+// TestActorToken_Malformed_InvalidRequest verifies that a syntactically invalid actor_token is
+// rejected as invalid_request rather than crashing or being silently ignored.
+func (ts *ActorTokenTestSuite) TestActorToken_Malformed_InvalidRequest() {
+	subjectToken := ts.obtainAccessTokenAs(
+		actorTokenIssuerClientID, actorTokenIssuerClientSecret, actorTokenSubjectUsername, actorTokenSubjectPassword)
+
+	form := exchangeParams(subjectToken)
+	form.Set("actor_token", "not-a-valid-jwt")
+	form.Set("actor_token_type", "urn:ietf:params:oauth:token-type:access_token")
+
+	status, body := ts.doExchange(form)
+	ts.Require().Equal(http.StatusBadRequest, status, "%v", body)
+	ts.Equal("invalid_request", body["error"])
+	ts.Contains(body["error_description"], "Invalid actor_token")
+}
+
+// TestActorToken_UntrustedIssuer_InvalidRequest verifies that an actor_token issued by an issuer this
+// server does not trust is rejected as invalid_request, attributing the failure to actor_token
+// specifically (not subject_token).
+func (ts *ActorTokenTestSuite) TestActorToken_UntrustedIssuer_InvalidRequest() {
+	subjectToken := ts.obtainAccessTokenAs(
+		actorTokenIssuerClientID, actorTokenIssuerClientSecret, actorTokenSubjectUsername, actorTokenSubjectPassword)
+	untrustedActorToken := craftJWTWithIssuer(ts.actorUserID, "https://untrusted-issuer.example.com", time.Now().Add(time.Hour))
+
+	form := exchangeParams(subjectToken)
+	form.Set("actor_token", untrustedActorToken)
+	form.Set("actor_token_type", "urn:ietf:params:oauth:token-type:access_token")
+
+	status, body := ts.doExchange(form)
+	ts.Require().Equal(http.StatusBadRequest, status, "%v", body)
+	ts.Equal("invalid_request", body["error"])
+	ts.Contains(body["error_description"], "actor_token issuer is not registered")
+}
+
+// currentJWTLeeway reads the live jwt.leeway value, falling back to the default.json default (30) if
+// deployment.yaml does not currently override it.
+func currentJWTLeeway() (int64, error) {
+	raw, err := testutils.ReadDeploymentConfigKey("jwt")
+	if err != nil {
+		return 0, err
+	}
+	if m, ok := raw.(map[string]interface{}); ok {
+		if v, ok := m["leeway"].(int); ok {
+			return int64(v), nil
+		}
+	}
+	return 30, nil
+}
+
+// setJWTLeeway safely overrides jwt.leeway, preserving every other jwt setting: PatchDeploymentConfig
+// replaces a top-level key wholesale, so the full existing "jwt" section must be read and only the
+// one nested field changed before writing it back.
+func setJWTLeeway(seconds int64) error {
+	raw, err := testutils.ReadDeploymentConfigKey("jwt")
+	if err != nil {
+		return err
+	}
+	jwtSection, _ := raw.(map[string]interface{})
+	if jwtSection == nil {
+		jwtSection = make(map[string]interface{})
+	}
+	jwtSection["leeway"] = seconds
+	return testutils.PatchDeploymentConfig(map[string]interface{}{"jwt": jwtSection})
+}
+
+// TestActorToken_Expired_InvalidRequest verifies that an expired actor_token is rejected as
+// invalid_request, distinct from the generic "Invalid actor_token" and untrusted-issuer errors.
+//
+// The server tolerates jwt.leeway beyond exp before treating a token as expired, so the wait to clear
+// expiry must cover validityPeriod + leeway. The default leeway (30s) would make that wait long and
+// keep it pinned to whatever the default happens to be, so this test temporarily shrinks leeway via a
+// server restart, restoring the original value in a deferred cleanup regardless of outcome.
+func (ts *ActorTokenTestSuite) TestActorToken_Expired_InvalidRequest() {
+	const shortLeewaySeconds = int64(2)
+	originalLeeway, err := currentJWTLeeway()
+	ts.Require().NoError(err, "Failed to read current JWT leeway")
+	ts.Require().NoError(setJWTLeeway(shortLeewaySeconds), "Failed to shrink JWT leeway")
+	// Registered immediately after the config mutation succeeds, before the restart/token calls below
+	// that could fail via Require and abort the test: otherwise a failure there would leave the
+	// shrunk leeway in place for every test that runs afterward.
+	defer func() {
+		ts.Assert().NoError(setJWTLeeway(originalLeeway), "Failed to restore JWT leeway")
+		ts.Assert().NoError(testutils.RestartServer(), "Failed to restart server after leeway restore")
+		ts.Assert().NoError(testutils.ObtainAdminAccessToken(), "Failed to re-obtain admin token after restore")
+	}()
+	ts.Require().NoError(testutils.RestartServer(), "Failed to restart server with shrunk JWT leeway")
+	ts.Require().NoError(testutils.ObtainAdminAccessToken(), "Failed to re-obtain admin token after restart")
+
+	subjectToken := ts.obtainAccessTokenAs(
+		actorTokenIssuerClientID, actorTokenIssuerClientSecret, actorTokenSubjectUsername, actorTokenSubjectPassword)
+
+	const shortValidityPeriodSeconds = 2
+	shortLivedAppID := ts.createApplication(map[string]interface{}{
+		"clientId":                "actor_token_short_lived_client",
+		"clientSecret":            "actor_token_short_lived_secret",
+		"redirectUris":            []string{actorTokenRedirectURI},
+		"grantTypes":              []string{"authorization_code"},
+		"responseTypes":           []string{"code"},
+		"tokenEndpointAuthMethod": "client_secret_basic",
+		"token": map[string]interface{}{
+			"accessToken": map[string]interface{}{
+				"userConfig": map[string]interface{}{
+					"validityPeriod": shortValidityPeriodSeconds,
+				},
+			},
+		},
+	}, true)
+	defer func() { _ = testutils.DeleteApplication(shortLivedAppID) }()
+
+	expiringActorToken := ts.obtainAccessTokenAs(
+		"actor_token_short_lived_client", "actor_token_short_lived_secret",
+		actorTokenActorUsername, actorTokenActorPassword)
+
+	// Wait must clear validityPeriod + the (now shrunk) leeway, plus a small buffer.
+	time.Sleep(time.Duration(shortValidityPeriodSeconds+shortLeewaySeconds+1) * time.Second)
+
+	form := exchangeParams(subjectToken)
+	form.Set("actor_token", expiringActorToken)
+	form.Set("actor_token_type", "urn:ietf:params:oauth:token-type:access_token")
+
+	status, body := ts.doExchange(form)
+	ts.Require().Equal(http.StatusBadRequest, status, "%v", body)
+	ts.Equal("invalid_request", body["error"])
+	ts.Contains(body["error_description"], "actor_token has expired")
+}
+
+// TestActorToken_NestedDelegationChain verifies that exchanging with an actor_token that itself
+// already carries an "act" claim (from a prior exchange) produces a nested delegation chain: the new
+// token's act claim names the immediate actor and preserves that actor's own act claim underneath it.
+func (ts *ActorTokenTestSuite) TestActorToken_NestedDelegationChain() {
+	subjectToken := ts.obtainAccessTokenAs(
+		actorTokenIssuerClientID, actorTokenIssuerClientSecret, actorTokenSubjectUsername, actorTokenSubjectPassword)
+	actorToken := ts.obtainAccessTokenAs(
+		actorTokenIssuerClientID, actorTokenIssuerClientSecret, actorTokenActorUsername, actorTokenActorPassword)
+
+	// First exchange: subject acted upon by actor. The resulting token (T1) becomes the actor_token
+	// for the second exchange below.
+	firstForm := exchangeParams(subjectToken)
+	firstForm.Set("actor_token", actorToken)
+	firstForm.Set("actor_token_type", "urn:ietf:params:oauth:token-type:access_token")
+
+	status, body := ts.doExchange(firstForm)
+	ts.Require().Equal(http.StatusOK, status, "%v", body)
+	firstExchangedToken, ok := body["access_token"].(string)
+	ts.Require().True(ok)
+
+	firstClaims, err := testutils.DecodeJWT(firstExchangedToken)
+	ts.Require().NoError(err)
+	firstAct, ok := firstClaims.Additional["act"].(map[string]interface{})
+	ts.Require().True(ok, "First exchange should produce an act claim")
+	ts.Equal(ts.actorUserID, firstAct["sub"])
+
+	// Second exchange: the same subject, now acted upon by the first exchange's own token, which
+	// already carries an act claim of its own.
+	secondForm := exchangeParams(subjectToken)
+	secondForm.Set("actor_token", firstExchangedToken)
+	secondForm.Set("actor_token_type", "urn:ietf:params:oauth:token-type:access_token")
+
+	status, body = ts.doExchange(secondForm)
+	ts.Require().Equal(http.StatusOK, status, "%v", body)
+	secondExchangedToken, ok := body["access_token"].(string)
+	ts.Require().True(ok)
+
+	secondClaims, err := testutils.DecodeJWT(secondExchangedToken)
+	ts.Require().NoError(err)
+
+	secondAct, ok := secondClaims.Additional["act"].(map[string]interface{})
+	ts.Require().True(ok, "Second exchange should produce an act claim")
+	ts.Equal(ts.subjectUserID, secondAct["sub"], "act.sub should identify T1's own subject as the immediate actor")
+
+	nestedAct, ok := secondAct["act"].(map[string]interface{})
+	ts.Require().True(ok, "act claim should be nested, preserving T1's own act claim")
+	ts.Equal(ts.actorUserID, nestedAct["sub"], "nested act.act.sub should identify the original actor")
+}

--- a/tests/integration/oauth/token/pkce_negative_test.go
+++ b/tests/integration/oauth/token/pkce_negative_test.go
@@ -1,0 +1,311 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package token
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	pkceNegClientID    = "pkce_negative_test_client"
+	pkceNegRedirectURI = "https://localhost:3000"
+	pkceNegUsername    = "pkce_negative_test_user"
+	pkceNegPassword    = "PkceNegativePass1!"
+)
+
+var pkceNegUserType = testutils.UserType{
+	Name: "pkce-negative-person",
+	Schema: map[string]interface{}{
+		"username": map[string]interface{}{"type": "string"},
+		"password": map[string]interface{}{"type": "string", "credential": true},
+	},
+}
+
+var pkceNegAuthFlow = testutils.Flow{
+	Name:     "PKCE Negative Auth Flow",
+	FlowType: "AUTHENTICATION",
+	Handle:   "auth_flow_pkce_negative_test",
+	Nodes: []map[string]interface{}{
+		{
+			"id":        "start",
+			"type":      "START",
+			"onSuccess": "prompt_credentials",
+		},
+		{
+			"id":   "prompt_credentials",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+						{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+					},
+					"action": map[string]interface{}{"ref": "action_001", "nextNode": "credentials_auth"},
+				},
+			},
+		},
+		{
+			"id":   "credentials_auth",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "CredentialsAuthExecutor",
+				"inputs": []map[string]interface{}{
+					{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+					{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+				},
+			},
+			"onSuccess": "auth_assert",
+		},
+		{
+			"id":        "auth_assert",
+			"type":      "TASK_EXECUTION",
+			"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+			"onSuccess": "end",
+		},
+		{"id": "end", "type": "END"},
+	},
+}
+
+// PKCENegativeTestSuite covers PKCE negative paths not exercised by the happy-path PKCE usage already
+// proven across the PAR, declarative-authz, and ID-JAG suites: a wrong or missing code_verifier at the
+// token endpoint, an authorize request missing code_challenge on a pkceRequired application, and
+// rejection of the plain code_challenge_method (only S256 is supported).
+type PKCENegativeTestSuite struct {
+	suite.Suite
+	client       *http.Client
+	ouID         string
+	entityTypeID string
+	authFlowID   string
+	appID        string
+	pkceAppID    string
+	userID       string
+}
+
+// TestPKCENegativeTestSuite runs the PKCENegativeTestSuite.
+func TestPKCENegativeTestSuite(t *testing.T) {
+	suite.Run(t, new(PKCENegativeTestSuite))
+}
+
+// SetupSuite creates the shared organization unit, user type, auth flow, a regular app (PKCE not
+// required), a pkceRequired app, and the test user.
+func (ts *PKCENegativeTestSuite) SetupSuite() {
+	ts.client = testutils.GetHTTPClient()
+
+	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "pkce-negative-test-ou",
+		Name:        "PKCE Negative Test OU",
+		Description: "Organization unit for PKCE negative-path integration tests",
+	})
+	ts.Require().NoError(err)
+	ts.ouID = ouID
+
+	pkceNegUserType.OUID = ouID
+	entityTypeID, err := testutils.CreateUserType(pkceNegUserType)
+	ts.Require().NoError(err)
+	ts.entityTypeID = entityTypeID
+
+	flowID, err := testutils.CreateFlow(pkceNegAuthFlow)
+	ts.Require().NoError(err)
+	ts.authFlowID = flowID
+
+	ts.appID = ts.createApplication(map[string]interface{}{
+		"clientId":                pkceNegClientID,
+		"clientSecret":            "pkce_negative_test_secret",
+		"redirectUris":            []string{pkceNegRedirectURI},
+		"grantTypes":              []string{"authorization_code"},
+		"responseTypes":           []string{"code"},
+		"tokenEndpointAuthMethod": "client_secret_post",
+	})
+
+	ts.pkceAppID = ts.createApplication(map[string]interface{}{
+		"clientId":                "pkce_negative_required_client",
+		"redirectUris":            []string{pkceNegRedirectURI},
+		"grantTypes":              []string{"authorization_code"},
+		"responseTypes":           []string{"code"},
+		"tokenEndpointAuthMethod": "none",
+		"publicClient":            true,
+		"pkceRequired":            true,
+	})
+
+	attributesJSON, err := json.Marshal(map[string]interface{}{
+		"username": pkceNegUsername,
+		"password": pkceNegPassword,
+	})
+	ts.Require().NoError(err)
+	userID, err := testutils.CreateUser(testutils.User{
+		OUID:       ouID,
+		Type:       "pkce-negative-person",
+		Attributes: json.RawMessage(attributesJSON),
+	})
+	ts.Require().NoError(err)
+	ts.userID = userID
+}
+
+// TearDownSuite deletes the resources created in SetupSuite.
+func (ts *PKCENegativeTestSuite) TearDownSuite() {
+	if ts.userID != "" {
+		_ = testutils.DeleteUser(ts.userID)
+	}
+	if ts.pkceAppID != "" {
+		_ = testutils.DeleteApplication(ts.pkceAppID)
+	}
+	if ts.appID != "" {
+		_ = testutils.DeleteApplication(ts.appID)
+	}
+	if ts.authFlowID != "" {
+		_ = testutils.DeleteFlow(ts.authFlowID)
+	}
+	if ts.entityTypeID != "" {
+		_ = testutils.DeleteUserType(ts.entityTypeID)
+	}
+	if ts.ouID != "" {
+		_ = testutils.DeleteOrganizationUnit(ts.ouID)
+	}
+}
+
+// createApplication creates an application bound to the shared auth flow with the given OAuth2
+// inbound config.
+func (ts *PKCENegativeTestSuite) createApplication(oauthConfig map[string]interface{}) string {
+	clientID, _ := oauthConfig["clientId"].(string)
+	app := map[string]interface{}{
+		"name":                      "PKCENegativeApp-" + clientID,
+		"description":               "Application for PKCE negative-path integration testing",
+		"ouId":                      ts.ouID,
+		"type":                      "fullstack",
+		"authFlowId":                ts.authFlowID,
+		"isRegistrationFlowEnabled": false,
+		"allowedUserTypes":          []string{"pkce-negative-person"},
+		"inboundAuthConfig": []map[string]interface{}{
+			{"type": "oauth2", "config": oauthConfig},
+		},
+	}
+
+	jsonData, err := json.Marshal(app)
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testutils.TestServerURL+"/applications", bytes.NewBuffer(jsonData))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	ts.Require().Equal(http.StatusCreated, resp.StatusCode, string(bodyBytes))
+
+	var respData map[string]interface{}
+	ts.Require().NoError(json.Unmarshal(bodyBytes, &respData))
+	return respData["id"].(string)
+}
+
+// obtainAuthorizationCode runs the confidential app's authorization_code flow with the given PKCE
+// parameters and returns the resulting authorization code.
+func (ts *PKCENegativeTestSuite) obtainAuthorizationCode(codeChallenge, codeChallengeMethod string) string {
+	resp, err := testutils.InitiateAuthorizationFlowWithPKCE(
+		pkceNegClientID, pkceNegRedirectURI, "code", "openid", "test-state", "",
+		codeChallenge, codeChallengeMethod)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusFound, resp.StatusCode)
+
+	authID, executionID, err := testutils.ExtractAuthData(resp.Header.Get("Location"))
+	ts.Require().NoError(err)
+
+	initialStep, err := testutils.ExecuteAuthenticationFlow(executionID, nil, "")
+	ts.Require().NoError(err)
+	flowStep, err := testutils.ExecuteAuthenticationFlow(executionID, map[string]string{
+		"username": pkceNegUsername,
+		"password": pkceNegPassword,
+	}, "action_001", initialStep.ChallengeToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus)
+
+	authzResp, err := testutils.CompleteAuthorization(authID, flowStep.Assertion)
+	ts.Require().NoError(err)
+
+	code, err := testutils.ExtractAuthorizationCode(authzResp.RedirectURI)
+	ts.Require().NoError(err)
+	return code
+}
+
+// TestPKCE_WrongCodeVerifier_InvalidGrant verifies that presenting a code_verifier that does not hash
+// to the code_challenge established at authorize time is rejected as invalid_grant.
+func (ts *PKCENegativeTestSuite) TestPKCE_WrongCodeVerifier_InvalidGrant() {
+	// Fixed, distinct RFC 7636-valid verifiers rather than two random ones, so the test can't
+	// spuriously pass or fail based on whether two independent random draws happen to collide.
+	correctVerifier := strings.Repeat("a", 43)
+	wrongVerifier := strings.Repeat("b", 43)
+	codeChallenge := testutils.GenerateCodeChallenge(correctVerifier)
+
+	code := ts.obtainAuthorizationCode(codeChallenge, "S256")
+
+	result, err := testutils.RequestTokenWithPKCE(
+		pkceNegClientID, "pkce_negative_test_secret", code, pkceNegRedirectURI, "authorization_code", wrongVerifier)
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusBadRequest, result.StatusCode, string(result.Body))
+
+	var errResp map[string]interface{}
+	ts.Require().NoError(json.Unmarshal(result.Body, &errResp))
+	ts.Equal("invalid_grant", errResp["error"])
+	ts.Contains(errResp["error_description"], "Invalid code verifier")
+}
+
+// TestPKCE_MissingCodeVerifier_InvalidGrant verifies that omitting code_verifier entirely at the token
+// endpoint, when PKCE was used at authorize time, is rejected as invalid_grant.
+func (ts *PKCENegativeTestSuite) TestPKCE_MissingCodeVerifier_InvalidGrant() {
+	verifier, err := testutils.GenerateCodeVerifier()
+	ts.Require().NoError(err)
+	codeChallenge := testutils.GenerateCodeChallenge(verifier)
+
+	code := ts.obtainAuthorizationCode(codeChallenge, "S256")
+
+	result, err := testutils.RequestTokenWithPKCE(
+		pkceNegClientID, "pkce_negative_test_secret", code, pkceNegRedirectURI, "authorization_code", "")
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusBadRequest, result.StatusCode, string(result.Body))
+
+	var errResp map[string]interface{}
+	ts.Require().NoError(json.Unmarshal(result.Body, &errResp))
+	ts.Equal("invalid_grant", errResp["error"])
+	ts.Contains(errResp["error_description"], "code_verifier is required")
+}
+
+// TestPKCE_RequiredButMissing_InvalidRequest verifies that an authorize request to a pkceRequired
+// application without a code_challenge is rejected as invalid_request via an error redirect.
+func (ts *PKCENegativeTestSuite) TestPKCE_RequiredButMissing_InvalidRequest() {
+	resp, err := testutils.InitiateAuthorizationFlow(
+		"pkce_negative_required_client", pkceNegRedirectURI, "code", "openid", "test-state")
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusFound, resp.StatusCode)
+
+	err = testutils.ValidateOAuth2ErrorRedirect(
+		resp.Header.Get("Location"), "invalid_request", "code_challenge is required for this application")
+	ts.NoError(err)
+}
+
+// TestPKCE_PlainMethod_Rejected verifies that code_challenge_method=plain is rejected as
+// invalid_request; only S256 is a supported PKCE transform.
+func (ts *PKCENegativeTestSuite) TestPKCE_PlainMethod_Rejected() {
+	verifier, err := testutils.GenerateCodeVerifier()
+	ts.Require().NoError(err)
+
+	resp, err := testutils.InitiateAuthorizationFlowWithPKCE(
+		pkceNegClientID, pkceNegRedirectURI, "code", "openid", "test-state", "", verifier, "plain")
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusFound, resp.StatusCode)
+
+	err = testutils.ValidateOAuth2ErrorRedirect(resp.Header.Get("Location"), "invalid_request", "")
+	ts.NoError(err)
+}

--- a/tests/integration/oauth/token/refresh_token_branches_test.go
+++ b/tests/integration/oauth/token/refresh_token_branches_test.go
@@ -1,0 +1,461 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package token
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	rtBranchClientID       = "rt_branches_test_client"
+	rtBranchClientSecret   = "rt_branches_test_secret"
+	rtBranchPublicClientID = "rt_branches_public_client"
+	rtBranchRedirectURI    = "https://localhost:3000"
+	rtBranchUsername       = "rt_branches_test_user"
+	rtBranchPassword       = "RtBranchesPass1!"
+	rtBranchResourceA      = "https://rt-branches-a.example.com"
+	rtBranchResourceB      = "https://rt-branches-b.example.com"
+)
+
+var rtBranchUserType = testutils.UserType{
+	Name: "rt-branches-person",
+	Schema: map[string]interface{}{
+		"username": map[string]interface{}{"type": "string"},
+		"password": map[string]interface{}{"type": "string", "credential": true},
+	},
+}
+
+var rtBranchAuthFlow = testutils.Flow{
+	Name:     "Refresh Token Branches Auth Flow",
+	FlowType: "AUTHENTICATION",
+	Handle:   "auth_flow_rt_branches_test",
+	Nodes: []map[string]interface{}{
+		{
+			"id":        "start",
+			"type":      "START",
+			"onSuccess": "prompt_credentials",
+		},
+		{
+			"id":   "prompt_credentials",
+			"type": "PROMPT",
+			"prompts": []map[string]interface{}{
+				{
+					"inputs": []map[string]interface{}{
+						{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+						{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+					},
+					"action": map[string]interface{}{"ref": "action_001", "nextNode": "credentials_auth"},
+				},
+			},
+		},
+		{
+			"id":   "credentials_auth",
+			"type": "TASK_EXECUTION",
+			"executor": map[string]interface{}{
+				"name": "CredentialsAuthExecutor",
+				"inputs": []map[string]interface{}{
+					{"ref": "input_001", "identifier": "username", "type": "TEXT_INPUT", "required": true},
+					{"ref": "input_002", "identifier": "password", "type": "PASSWORD_INPUT", "required": true},
+				},
+			},
+			"onSuccess": "auth_assert",
+		},
+		{
+			"id":        "auth_assert",
+			"type":      "TASK_EXECUTION",
+			"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+			"onSuccess": "end",
+		},
+		{"id": "end", "type": "END"},
+	},
+}
+
+// RefreshTokenBranchesTestSuite covers refresh-token grant branches beyond the happy path already
+// proven elsewhere: rejecting a resource parameter that does not match the token's bound audience,
+// refresh-token rotation and replay-detection (oauth.refresh_token.renew_on_grant is enabled
+// server-wide by default), and DPoP binding continuity across refresh for a public client.
+//
+// Reuse with rotation explicitly disabled is not covered here: oauth.refresh_token.renew_on_grant is
+// a plain bool (unlike its sibling settings, which use *bool for exactly this reason), so the config
+// merge cannot distinguish an explicit `false` in deployment.yaml from "not set" and silently keeps
+// the default enabled. A test exercising renew_on_grant: false would currently just document that
+// bug rather than the intended reuse behavior.
+type RefreshTokenBranchesTestSuite struct {
+	suite.Suite
+	client            *http.Client
+	ouID              string
+	entityTypeID      string
+	authFlowID        string
+	appID             string
+	publicAppID       string
+	resourceServerAID string
+	resourceServerBID string
+	userID            string
+}
+
+// TestRefreshTokenBranchesTestSuite runs the RefreshTokenBranchesTestSuite.
+func TestRefreshTokenBranchesTestSuite(t *testing.T) {
+	suite.Run(t, new(RefreshTokenBranchesTestSuite))
+}
+
+// SetupSuite creates the shared organization unit, user type, auth flow, two resource servers, a
+// confidential app, a public (PKCE) app, and the test user.
+func (ts *RefreshTokenBranchesTestSuite) SetupSuite() {
+	ts.client = testutils.GetHTTPClient()
+
+	ouID, err := testutils.CreateOrganizationUnit(testutils.OrganizationUnit{
+		Handle:      "rt-branches-test-ou",
+		Name:        "Refresh Token Branches Test OU",
+		Description: "Organization unit for refresh-token grant branch integration tests",
+	})
+	ts.Require().NoError(err)
+	ts.ouID = ouID
+
+	rtBranchUserType.OUID = ouID
+	entityTypeID, err := testutils.CreateUserType(rtBranchUserType)
+	ts.Require().NoError(err)
+	ts.entityTypeID = entityTypeID
+
+	flowID, err := testutils.CreateFlow(rtBranchAuthFlow)
+	ts.Require().NoError(err)
+	ts.authFlowID = flowID
+
+	rsAID, err := testutils.CreateResourceServerWithActions(testutils.ResourceServer{
+		Name:        "Refresh Token Branches RS A",
+		Identifier:  rtBranchResourceA,
+		OUID:        ts.ouID,
+	}, []testutils.Action{})
+	ts.Require().NoError(err)
+	ts.resourceServerAID = rsAID
+
+	rsBID, err := testutils.CreateResourceServerWithActions(testutils.ResourceServer{
+		Name:        "Refresh Token Branches RS B",
+		Identifier:  rtBranchResourceB,
+		OUID:        ts.ouID,
+	}, []testutils.Action{})
+	ts.Require().NoError(err)
+	ts.resourceServerBID = rsBID
+
+	ts.appID = ts.createApplication(map[string]interface{}{
+		"clientId":                rtBranchClientID,
+		"clientSecret":            rtBranchClientSecret,
+		"redirectUris":            []string{rtBranchRedirectURI},
+		"grantTypes":              []string{"authorization_code", "refresh_token"},
+		"responseTypes":           []string{"code"},
+		"tokenEndpointAuthMethod": "client_secret_basic",
+	})
+
+	ts.publicAppID = ts.createApplication(map[string]interface{}{
+		"clientId":                rtBranchPublicClientID,
+		"redirectUris":            []string{rtBranchRedirectURI},
+		"grantTypes":              []string{"authorization_code", "refresh_token"},
+		"responseTypes":           []string{"code"},
+		"tokenEndpointAuthMethod": "none",
+		"publicClient":            true,
+		"pkceRequired":            true,
+	})
+
+	attributesJSON, err := json.Marshal(map[string]interface{}{
+		"username": rtBranchUsername,
+		"password": rtBranchPassword,
+	})
+	ts.Require().NoError(err)
+	userID, err := testutils.CreateUser(testutils.User{
+		OUID:       ouID,
+		Type:       "rt-branches-person",
+		Attributes: json.RawMessage(attributesJSON),
+	})
+	ts.Require().NoError(err)
+	ts.userID = userID
+}
+
+// TearDownSuite deletes the resources created in SetupSuite.
+func (ts *RefreshTokenBranchesTestSuite) TearDownSuite() {
+	if ts.userID != "" {
+		_ = testutils.DeleteUser(ts.userID)
+	}
+	if ts.publicAppID != "" {
+		_ = testutils.DeleteApplication(ts.publicAppID)
+	}
+	if ts.appID != "" {
+		_ = testutils.DeleteApplication(ts.appID)
+	}
+	if ts.resourceServerBID != "" {
+		_ = testutils.DeleteResourceServer(ts.resourceServerBID)
+	}
+	if ts.resourceServerAID != "" {
+		_ = testutils.DeleteResourceServer(ts.resourceServerAID)
+	}
+	if ts.authFlowID != "" {
+		_ = testutils.DeleteFlow(ts.authFlowID)
+	}
+	if ts.entityTypeID != "" {
+		_ = testutils.DeleteUserType(ts.entityTypeID)
+	}
+	if ts.ouID != "" {
+		_ = testutils.DeleteOrganizationUnit(ts.ouID)
+	}
+}
+
+// createApplication creates an application bound to the shared auth flow with the given OAuth2
+// inbound config.
+func (ts *RefreshTokenBranchesTestSuite) createApplication(oauthConfig map[string]interface{}) string {
+	clientID, _ := oauthConfig["clientId"].(string)
+	app := map[string]interface{}{
+		"name":                      "RefreshTokenBranchesApp-" + clientID,
+		"description":               "Application for refresh-token grant branch integration testing",
+		"ouId":                      ts.ouID,
+		"type":                      "fullstack",
+		"authFlowId":                ts.authFlowID,
+		"isRegistrationFlowEnabled": false,
+		"allowedUserTypes":          []string{"rt-branches-person"},
+		"inboundAuthConfig": []map[string]interface{}{
+			{"type": "oauth2", "config": oauthConfig},
+		},
+	}
+
+	jsonData, err := json.Marshal(app)
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testutils.TestServerURL+"/applications", bytes.NewBuffer(jsonData))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	ts.Require().Equal(http.StatusCreated, resp.StatusCode, string(bodyBytes))
+
+	var respData map[string]interface{}
+	ts.Require().NoError(json.Unmarshal(bodyBytes, &respData))
+	return respData["id"].(string)
+}
+
+// obtainTokensForResource runs the confidential app's authorization_code flow, requesting the given
+// resource, and returns the resulting token response.
+func (ts *RefreshTokenBranchesTestSuite) obtainTokensForResource(resource string) *testutils.TokenHTTPResult {
+	resp, err := testutils.InitiateAuthorizationFlowWithResource(
+		rtBranchClientID, rtBranchRedirectURI, "code", "openid", "test-state", resource)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusFound, resp.StatusCode)
+
+	authID, executionID, err := testutils.ExtractAuthData(resp.Header.Get("Location"))
+	ts.Require().NoError(err)
+
+	initialStep, err := testutils.ExecuteAuthenticationFlow(executionID, nil, "")
+	ts.Require().NoError(err)
+
+	flowStep, err := testutils.ExecuteAuthenticationFlow(executionID, map[string]string{
+		"username": rtBranchUsername,
+		"password": rtBranchPassword,
+	}, "action_001", initialStep.ChallengeToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus)
+
+	authzResp, err := testutils.CompleteAuthorization(authID, flowStep.Assertion)
+	ts.Require().NoError(err)
+
+	code, err := testutils.ExtractAuthorizationCode(authzResp.RedirectURI)
+	ts.Require().NoError(err)
+
+	tokenResult, err := testutils.RequestTokenWithResource(
+		rtBranchClientID, rtBranchClientSecret, code, rtBranchRedirectURI, "authorization_code", resource)
+	ts.Require().NoError(err)
+	ts.Require().Equal(http.StatusOK, tokenResult.StatusCode, string(tokenResult.Body))
+	ts.Require().NotNil(tokenResult.Token)
+	ts.Require().NotEmpty(tokenResult.Token.RefreshToken)
+
+	return tokenResult
+}
+
+// refreshWithResource submits a refresh_token grant request, optionally scoping it to a resource
+// parameter, and returns the parsed response.
+func (ts *RefreshTokenBranchesTestSuite) refreshWithResource(refreshToken, resource string) (int, map[string]interface{}) {
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refreshToken)
+	if resource != "" {
+		form.Set("resource", resource)
+	}
+
+	req, err := http.NewRequest("POST", testutils.TestServerURL+"/oauth2/token",
+		bytes.NewBufferString(form.Encode()))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(rtBranchClientID, rtBranchClientSecret)
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	var body map[string]interface{}
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	ts.Require().NoError(json.Unmarshal(bodyBytes, &body), "body: %s", string(bodyBytes))
+	return resp.StatusCode, body
+}
+
+// TestRefreshToken_ResourceMismatch_InvalidTarget verifies that requesting a resource different from
+// the one the refresh token is bound to is rejected as invalid_target, and the mismatched resource
+// server's existence is irrelevant to the outcome.
+func (ts *RefreshTokenBranchesTestSuite) TestRefreshToken_ResourceMismatch_InvalidTarget() {
+	tokenResult := ts.obtainTokensForResource(rtBranchResourceA)
+
+	status, body := ts.refreshWithResource(tokenResult.Token.RefreshToken, rtBranchResourceB)
+	ts.Require().Equal(http.StatusBadRequest, status, "%v", body)
+	ts.Equal("invalid_target", body["error"])
+	ts.Contains(body["error_description"], "does not match the refresh token audience")
+}
+
+// TestRefreshToken_RotationAndReplayDetection verifies that with renew_on_grant enabled (the
+// server-wide default), a refresh consumes and revokes the presented refresh token, issuing a new one
+// in its place (rotation); and that replaying the now-revoked original token is rejected as
+// invalid_grant and additionally revokes the whole token family, so the freshly rotated token dies too
+// (RFC 9700 4.14.2).
+func (ts *RefreshTokenBranchesTestSuite) TestRefreshToken_RotationAndReplayDetection() {
+	tokenResult := ts.obtainTokensForResource(rtBranchResourceA)
+	originalRefreshToken := tokenResult.Token.RefreshToken
+
+	// Rotation: the refresh response must carry a new refresh token, distinct from the original.
+	status, body := ts.refreshWithResource(originalRefreshToken, "")
+	ts.Require().Equal(http.StatusOK, status, "%v", body)
+	rotatedRefreshToken, ok := body["refresh_token"].(string)
+	ts.Require().True(ok, "Rotation should issue a new refresh_token")
+	ts.NotEqual(originalRefreshToken, rotatedRefreshToken, "Rotated refresh token should differ from the original")
+
+	// Replay: reusing the now-revoked original token must fail.
+	status, body = ts.refreshWithResource(originalRefreshToken, "")
+	ts.Require().Equal(http.StatusBadRequest, status, "%v", body)
+	ts.Equal("invalid_grant", body["error"])
+
+	// Family revocation: the replay must have revoked the rotated token too, since it shares the
+	// same token family as the replayed original.
+	status, body = ts.refreshWithResource(rotatedRefreshToken, "")
+	ts.Require().Equal(http.StatusBadRequest, status, "%v", body)
+	ts.Equal("invalid_grant", body["error"], "Replay should revoke the whole token family, including the rotated token")
+}
+
+// requestWithDPoP submits a token request with the given form parameters and an optional DPoP proof
+// header, returning the parsed JSON response.
+func (ts *RefreshTokenBranchesTestSuite) requestWithDPoP(
+	form url.Values, dpopProof string,
+) (int, map[string]interface{}) {
+	req, err := http.NewRequest("POST", testutils.TestServerURL+"/oauth2/token",
+		bytes.NewBufferString(form.Encode()))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if dpopProof != "" {
+		req.Header.Set("DPoP", dpopProof)
+	}
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	var body map[string]interface{}
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	ts.Require().NoError(json.Unmarshal(bodyBytes, &body), "body: %s", string(bodyBytes))
+	return resp.StatusCode, body
+}
+
+// TestRefreshToken_PublicClientDPoP_RequiresMatchingProof verifies that a public client's DPoP-bound
+// refresh token requires a matching DPoP proof on every refresh: no proof and a proof from a
+// different key are both rejected, and the correct key continues to work across repeated refreshes
+// (binding continuity, not a one-off match).
+func (ts *RefreshTokenBranchesTestSuite) TestRefreshToken_PublicClientDPoP_RequiresMatchingProof() {
+	key, err := testutils.GenerateDPoPKey("ES256")
+	ts.Require().NoError(err)
+	otherKey, err := testutils.GenerateDPoPKey("ES256")
+	ts.Require().NoError(err)
+
+	codeVerifier, err := testutils.GenerateCodeVerifier()
+	ts.Require().NoError(err)
+	codeChallenge := testutils.GenerateCodeChallenge(codeVerifier)
+
+	resp, err := testutils.InitiateAuthorizationFlowWithPKCE(
+		rtBranchPublicClientID, rtBranchRedirectURI, "code", "openid", "test-state", "", codeChallenge, "S256")
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusFound, resp.StatusCode)
+
+	authID, executionID, err := testutils.ExtractAuthData(resp.Header.Get("Location"))
+	ts.Require().NoError(err)
+
+	initialStep, err := testutils.ExecuteAuthenticationFlow(executionID, nil, "")
+	ts.Require().NoError(err)
+	flowStep, err := testutils.ExecuteAuthenticationFlow(executionID, map[string]string{
+		"username": rtBranchUsername,
+		"password": rtBranchPassword,
+	}, "action_001", initialStep.ChallengeToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal("COMPLETE", flowStep.FlowStatus)
+
+	authzResp, err := testutils.CompleteAuthorization(authID, flowStep.Assertion)
+	ts.Require().NoError(err)
+	code, err := testutils.ExtractAuthorizationCode(authzResp.RedirectURI)
+	ts.Require().NoError(err)
+
+	tokenForm := url.Values{}
+	tokenForm.Set("grant_type", "authorization_code")
+	tokenForm.Set("code", code)
+	tokenForm.Set("redirect_uri", rtBranchRedirectURI)
+	tokenForm.Set("client_id", rtBranchPublicClientID)
+	tokenForm.Set("code_verifier", codeVerifier)
+
+	authCodeProof, err := key.CreateProof(http.MethodPost, testutils.TestServerURL+"/oauth2/token", testutils.DPoPProofOptions{})
+	ts.Require().NoError(err)
+
+	status, body := ts.requestWithDPoP(tokenForm, authCodeProof)
+	ts.Require().Equal(http.StatusOK, status, "%v", body)
+	refreshToken, ok := body["refresh_token"].(string)
+	ts.Require().True(ok, "Public client should receive a refresh token")
+
+	refreshForm := func() url.Values {
+		form := url.Values{}
+		form.Set("grant_type", "refresh_token")
+		form.Set("refresh_token", refreshToken)
+		form.Set("client_id", rtBranchPublicClientID)
+		return form
+	}
+
+	// No DPoP proof at all: refresh must fail, this refresh token requires proof of possession.
+	status, body = ts.requestWithDPoP(refreshForm(), "")
+	ts.Require().Equal(http.StatusBadRequest, status, "%v", body)
+	ts.Equal("invalid_grant", body["error"])
+	ts.Contains(body["error_description"], "DPoP proof required")
+
+	// A proof from a different key: refresh must fail, the key does not match the binding.
+	mismatchedProof, err := otherKey.CreateProof(http.MethodPost, testutils.TestServerURL+"/oauth2/token", testutils.DPoPProofOptions{})
+	ts.Require().NoError(err)
+	status, body = ts.requestWithDPoP(refreshForm(), mismatchedProof)
+	ts.Require().Equal(http.StatusBadRequest, status, "%v", body)
+	ts.Equal("invalid_grant", body["error"])
+	ts.Contains(body["error_description"], "does not match")
+
+	// The correct key succeeds, and continues to succeed on a second refresh with a fresh proof from
+	// the same key, proving the binding persists rather than being a one-off match. Rotation is on by
+	// default, so the first refresh issues a new refresh token; that is what the second refresh must use.
+	correctProof1, err := key.CreateProof(http.MethodPost, testutils.TestServerURL+"/oauth2/token", testutils.DPoPProofOptions{})
+	ts.Require().NoError(err)
+	status, body = ts.requestWithDPoP(refreshForm(), correctProof1)
+	ts.Require().Equal(http.StatusOK, status, "%v", body)
+	if rotated, ok := body["refresh_token"].(string); ok && rotated != "" {
+		refreshToken = rotated
+	}
+
+	correctProof2, err := key.CreateProof(http.MethodPost, testutils.TestServerURL+"/oauth2/token", testutils.DPoPProofOptions{})
+	ts.Require().NoError(err)
+	status, body = ts.requestWithDPoP(refreshForm(), correctProof2)
+	ts.Require().Equal(http.StatusOK, status, "%v", body)
+}

--- a/tests/integration/oauth/token/token_type_hint_test.go
+++ b/tests/integration/oauth/token/token_type_hint_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package token
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// introspectWithHint introspects the given token with an explicit token_type_hint and returns whether
+// the token is reported active.
+func (ts *TfidTestSuite) introspectWithHint(token, hint string) bool {
+	form := url.Values{}
+	form.Set("token", token)
+	if hint != "" {
+		form.Set("token_type_hint", hint)
+	}
+
+	req, err := http.NewRequest("POST", testutils.TestServerURL+"/oauth2/introspect",
+		strings.NewReader(form.Encode()))
+	ts.Require().NoError(err, "Failed to build introspection request")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(tfidTestClientID, tfidTestClientSecret)
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err, "Introspection request failed")
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusOK, resp.StatusCode, "Introspection should return 200")
+
+	var result struct {
+		Active bool `json:"active"`
+	}
+	ts.Require().NoError(json.NewDecoder(resp.Body).Decode(&result), "Failed to parse introspection response")
+	return result.Active
+}
+
+// revokeWithHint revokes the given token with an explicit token_type_hint and returns the HTTP status.
+func (ts *TfidTestSuite) revokeWithHint(token, hint string) int {
+	form := url.Values{}
+	form.Set("token", token)
+	if hint != "" {
+		form.Set("token_type_hint", hint)
+	}
+
+	req, err := http.NewRequest("POST", testutils.TestServerURL+"/oauth2/revoke",
+		strings.NewReader(form.Encode()))
+	ts.Require().NoError(err, "Failed to build revocation request")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(tfidTestClientID, tfidTestClientSecret)
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err, "Revocation request failed")
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// TestIntrospection_TokenTypeHint_Mismatched_StillCorrect verifies that token_type_hint at
+// /oauth2/introspect does not affect the outcome: an access token introspected with a mismatched hint
+// (or none at all) still correctly reports active/inactive based on the token itself.
+func (ts *TfidTestSuite) TestIntrospection_TokenTypeHint_Mismatched_StillCorrect() {
+	tokens := ts.obtainTokens()
+
+	ts.True(ts.introspectWithHint(tokens.AccessToken, ""),
+		"Access token should be active with no hint")
+	ts.True(ts.introspectWithHint(tokens.AccessToken, "refresh_token"),
+		"Access token should still be reported active with a mismatched refresh_token hint")
+	ts.True(ts.introspectWithHint(tokens.AccessToken, "access_token"),
+		"Access token should be active with the matching hint")
+
+	ts.revokeWithHint(tokens.RefreshToken, "refresh_token")
+
+	ts.False(ts.introspectWithHint(tokens.AccessToken, "access_token"),
+		"Access token should be inactive after its login's refresh token is revoked, regardless of hint")
+	ts.False(ts.introspectWithHint(tokens.AccessToken, ""),
+		"Access token should be inactive after its login's refresh token is revoked, with no hint")
+	ts.False(ts.introspectWithHint(tokens.AccessToken, "refresh_token"),
+		"Access token should be inactive after its login's refresh token is revoked, even with a mismatched refresh_token hint")
+}
+
+// TestRevocation_TokenTypeHint_Mismatched_StillRevokes verifies that token_type_hint at /oauth2/revoke
+// does not gate or misdirect revocation: revoking an access token with a mismatched refresh_token hint
+// still succeeds and still revokes the presented token.
+func (ts *TfidTestSuite) TestRevocation_TokenTypeHint_Mismatched_StillRevokes() {
+	tokens := ts.obtainTokens()
+	ts.Require().True(ts.introspectWithHint(tokens.AccessToken, ""), "Access token should start active")
+
+	status := ts.revokeWithHint(tokens.AccessToken, "refresh_token")
+	ts.Require().Equal(http.StatusOK, status, "Revocation should succeed despite the mismatched hint")
+
+	ts.False(ts.introspectWithHint(tokens.AccessToken, ""),
+		"The access token itself should be revoked even though the hint claimed it was a refresh token")
+}


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

Continues the OAuth T1 (protocol & token issuance) integration test coverage effort from the earlier PR, closing a few more gaps identified in the original gap analysis: forced re-consent, actor token delegation, PKCE negative paths, refresh token grant branches, token_type_hint mismatch handling, and a PAR prompt-validation case.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

Added new integration test suites under `tests/integration/oauth/{authz,token,par}`:
- `prompt_consent_test.go` — verifies `prompt=consent` forces re-consent even when the user already has an active consent grant.
- `actor_token_test.go` — verifies RFC 8693 actor token delegation, including the `act` claim (and nested delegation chains) on the issued token.
- `pkce_negative_test.go` — PKCE rejection paths (missing/mismatched code_verifier, unsupported challenge method), kept separate from the existing PKCE happy-path coverage.
- `refresh_token_branches_test.go` — resource-parameter mismatch, refresh token rotation with replay detection and token-family revocation, and DPoP proof binding continuity across repeated refreshes for a public client.
- `token_type_hint_test.go` — confirms a mismatched `token_type_hint` on introspection/revocation doesn't cause misclassification (the hint is an optimization, never authoritative, per RFC 7662).
- `prompt_test.go` — merged the existing `prompt_none_test.go` and `prompt_other_test.go` into one file for cohesion; no behavioral change.
- `par_test.go` — added a case asserting PAR rejects `prompt=select_account` as unsupported.

All new tests were validated with `go vet` and full local runs (`make test_integration`), including a rerun after pulling in the latest upstream changes to confirm nothing regressed.


### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded OAuth integration coverage for consent prompts, account selection, and invalid prompt parameters.
  - Added validation for actor-token exchange, including malformed, expired, untrusted, and nested delegation scenarios.
  - Added coverage for PKCE failures, refresh-token rotation and replay detection, DPoP proof matching, and resource mismatches.
  - Confirmed token introspection and revocation remain reliable with mismatched token type hints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->