### PR TITLE
Fix PowerShell script invocation and Ctrl+C port cleanup on Windows

### DIFF
--- a/tools/cli/internal/services/setup/setup.go
+++ b/tools/cli/internal/services/setup/setup.go
@@ -64,6 +64,17 @@ func isWindows() bool {
 	return runtime.GOOS == "windows"
 }
 
+// powershellExecutable returns the PowerShell binary to run setup.ps1/start.ps1 with.
+// Those scripts require PowerShell 7 (Core), so pwsh.exe is preferred; the legacy
+// Windows PowerShell 5.1 (powershell.exe) is used only as a fallback so the script's
+// own version check can produce the upgrade message.
+func powershellExecutable() string {
+	if _, err := exec.LookPath("pwsh.exe"); err == nil {
+		return "pwsh.exe"
+	}
+	return "powershell.exe"
+}
+
 func findScript(installPath, name string) string {
 	root := filepath.Join(installPath, name)
 	if _, err := os.Stat(root); err == nil {
@@ -130,7 +141,7 @@ func RunSetupOnPort(installPath string, verbose bool, port int) (*AdminCredentia
 
 	var cmd *exec.Cmd
 	if isWindows() {
-		cmd = exec.Command("powershell.exe", "-ExecutionPolicy", "Bypass", "-File", "setup.ps1")
+		cmd = exec.Command(powershellExecutable(), "-ExecutionPolicy", "Bypass", "-File", "setup.ps1")
 	} else {
 		cmd = exec.Command("bash", "setup.sh")
 	}
@@ -265,7 +276,7 @@ func StartBackgroundOnPort(installPath string, verbose bool, port int) (*exec.Cm
 	if isWindows() {
 		startPs1 := filepath.Join(root, "start.ps1")
 		if _, err := os.Stat(startPs1); err == nil {
-			cmd = exec.Command("powershell.exe", "-ExecutionPolicy", "Bypass", "-File", "start.ps1")
+			cmd = exec.Command(powershellExecutable(), "-ExecutionPolicy", "Bypass", "-File", "start.ps1")
 		} else {
 			binary := filepath.Join(root, product.Slug+".exe")
 			if _, err := os.Stat(binary); err != nil {
@@ -317,7 +328,7 @@ func Start(installPath string, args []string) error {
 	if isWindows() {
 		startPs1 := filepath.Join(root, "start.ps1")
 		if _, err := os.Stat(startPs1); err == nil {
-			cmd = exec.Command("powershell.exe", append([]string{"-ExecutionPolicy", "Bypass", "-File", "start.ps1"}, args...)...)
+			cmd = exec.Command(powershellExecutable(), append([]string{"-ExecutionPolicy", "Bypass", "-File", "start.ps1"}, args...)...)
 			cmd.Dir = root
 		} else {
 			binary := filepath.Join(root, product.Slug+".exe")

--- a/tools/cli/internal/ui/repl.go
+++ b/tools/cli/internal/ui/repl.go
@@ -1311,11 +1311,12 @@ func (m *ReplModel) stopThunderID(explicit bool) error {
 			time.Sleep(time.Second)
 			return nil
 		}
-		// The launcher is already gone, so no trap ran for this stop and the server it
+		// The signal was undeliverable (SIGTERM is unsupported on Windows, or the
+		// launcher is already gone), so no trap ran for this stop and the server it
 		// backgrounded can still be listening. Reporting success here would quit the
-		// session leaving that server up, so fall through to the port stop.
-	}
-	if !explicit {
+		// session leaving that server up, so fall through to the port stop regardless
+		// of explicit: we own this process, an implicit exit still has to clean it up.
+	} else if !explicit {
 		return nil
 	}
 	port := m.effectivePort()


### PR DESCRIPTION
### Purpose
Two Windows-only bugs in the `thunderid` CLI (`tools/cli`) that block a clean local run via `npx`/`pnpm dlx`:

1. **Setup/start always fails with "UNSUPPORTED POWERSHELL VERSION" even with PowerShell 7 installed.** `setup.go` hardcoded `powershell.exe` (legacy Windows PowerShell 5.1) to run `setup.ps1`/`start.ps1`, which themselves require PowerShell 7 (Core). Since `powershell.exe` always resolves to 5.1 regardless of which shell invoked the CLI, the scripts' own version guard rejected every run.
2. **Ctrl+C in the REPL doesn't stop the background server; the port stays held.** `stopThunderID()` in `repl.go` signals the launcher process with `syscall.SIGTERM` and, on failure, only falls back to a port-based kill when the stop was explicit (`/stop` command). `os.Process.Signal` on Windows only supports `Kill`/`Interrupt` — `SIGTERM` always fails there — so the implicit Ctrl+C exit path never reached the fallback, leaving `thunderid.exe` bound to the port (e.g. 8090) after exit.

### Approach
1. Added `powershellExecutable()` in `setup.go`, which prefers `pwsh.exe` (PowerShell 7) via `exec.LookPath`, falling back to `powershell.exe` only when `pwsh` isn't on PATH so the script's own upgrade message still surfaces. Used at all three call sites that invoke `setup.ps1`/`start.ps1`.
2. Reworked the early-return in `stopThunderID()` so the `explicit` gate only applies when there's no process handle at all (an attached, not-started-by-us instance). When we hold a handle but the signal is undeliverable, the port-based fallback now always runs, matching the function's own documented intent ("An undeliverable signal takes that same fallback").

### Related Issues
- #4961 

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows PowerShell compatibility by preferring PowerShell 7 when available and falling back to Windows PowerShell.
  * Updated setup and service startup commands to use the selected PowerShell executable.

* **Documentation**
  * Clarified shutdown behavior when process termination signals are unavailable or unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->