### PR TITLE
[Docs] Fix theme glitch

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -106,6 +106,19 @@ const config: Config = {
 
   headTags: [
     {
+      tagName: 'script',
+      attributes: {},
+      // Reads the same "theme" localStorage key as Docusaurus' own no-flash script, but
+      // stamps the attribute the MUI/Oxygen-UI theme reads (colorSchemeSelector:
+      // "data-color-scheme"). Without this, a hard refresh paints MUI-styled surfaces with
+      // their light-scheme fallback for one frame before OxygenUIThemeProvider mounts and
+      // syncs to the already-correct Docusaurus theme. Docusaurus' stored value can be the
+      // literal string "system" (its tri-state toggle), which must resolve through
+      // prefers-color-scheme here rather than being stamped as-is, since Oxygen-UI's CSS
+      // only defines variables for "dark"/"light".
+      innerHTML: `(function(){try{var t=new URLSearchParams(window.location.search).get("docusaurus-theme")||window.localStorage.getItem("theme");var dark=t==="dark"||(t!=="light"&&window.matchMedia("(prefers-color-scheme: dark)").matches);document.documentElement.setAttribute("data-color-scheme",dark?"dark":"light");}catch(e){}})();`,
+    },
+    {
       tagName: 'link',
       attributes: {
         rel: 'icon',


### PR DESCRIPTION
### Purpose
On a hard refresh of the docs site, the MUI/Oxygen-UI theme (used alongside Docusaurus' own theme) briefly renders with its light-scheme fallback colors on top of the already-correct dark Docusaurus chrome, producing a washed-out flash before snapping to the right theme.

Docusaurus stamps `data-theme` on `<html>` via a blocking inline script before first paint, so its own styling is correct instantly, even on a hard refresh. The MUI/Oxygen-UI theme (`colorSchemeSelector: "data-color-scheme"`) has no equivalent blocking script — that attribute is only set later, client-side, once `OxygenUIThemeProvider` mounts and Docusaurus' `ColorModeToggle` wrapper syncs it in a `useLayoutEffect`. On a normal in-app navigation this isn't visible (the React tree stays mounted across route changes), but a hard refresh starts the DOM from scratch without it.

### Approach
Add a blocking inline `<script>` head tag (`docs/docusaurus.config.ts`) that runs before any React code, reading the same `theme` localStorage key Docusaurus' own no-flash script uses, and stamping `data-color-scheme` on `<html>` synchronously. Docusaurus' stored value can be the literal string `"system"` (its tri-state toggle), so the script resolves that through `prefers-color-scheme` rather than stamping it as-is, since Oxygen-UI's CSS only defines variables for `"dark"`/`"light"`.

https://github.com/user-attachments/assets/eac575a6-5832-46bc-8145-c238272c70ee

### Related Issues
- Fixes https://github.com/thunder-id/thunderid/issues/4975

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme synchronization during page loading.
  * Added support for system color-scheme preferences.
  * Prevented theme detection errors from disrupting the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->