### PR TITLE
Use the release branch for the release builder integration tests

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -8,12 +8,18 @@ inputs:
     description: 'Whether to enable coverage collection'
     required: false
     default: false
+  ref:
+    description: 'Branch, tag or SHA to check out the test sources from. Defaults to the ref that triggered the workflow.'
+    required: false
+    default: ''
 
 runs:
   using: "composite"
   steps:
     - name: 📥 Checkout Code
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        ref: ${{ inputs.ref }}
 
     - name: ⚙️ Set up Go Environment
       uses: ./.github/actions/setup-go

--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -293,44 +293,18 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
+      # Checks out the dispatched ref, not the release branch, so the local
+      # composite action below is read from this workflow's own revision. The
+      # action then checks out RELEASE_BRANCH to supply the test sources.
       - name: 📥 Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          ref: ${{ env.RELEASE_BRANCH }}
-
-      - name: ⚙️ Set up Go Environment
-        uses: ./.github/actions/setup-go
-
-      - name: 🗄️ Cache Go Modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        id: cache-go-modules
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-modules-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-modules-
-
-      - name: 📦 Install Dependencies
-        run: |
-          cd backend
-          go mod download
-          cd ../tests/integration
-          go mod download
-
-      - name: 📝 Configure Test Database
-        run: |
-          chmod +x tests/integration/resources/scripts/setup-test-config.sh
-          ./tests/integration/resources/scripts/setup-test-config.sh
-        env:
-          DB_TYPE: ${{ matrix.database }}
 
       - name: 🧪 Run Integration Tests (${{ matrix.database }})
         uses: ./.github/actions/run-integration-tests
         with:
           database-type: ${{ matrix.database }}
           coverage-enabled: true
+          ref: ${{ env.RELEASE_BRANCH }}
 
   validate-windows:
     name: 🪟 Validate Windows PowerShell


### PR DESCRIPTION
### Purpose

The integration tests in the release builder run against the wrong source tree.

The `test-integration` job checks out the release branch, but the `run-integration-tests` composite action then performs its own `actions/checkout` with no `ref`, which resolves to `github.ref` (the branch the release was dispatched from) and overwrites the workspace. The product zip therefore comes from the release branch while the tests that run against it come from the dispatch ref.

This is what broke [release run 31869966705](https://github.com/thunder-id/thunderid/actions/runs/31869966705): the distribution was built from `1.0.0-release` while the tests came from `main`, so five OpenID4VCI/OpenID4VP export cases that only exist on `main` ran against a server without that feature and failed with `EXP-1002 No resources found` on both SQLite and PostgreSQL.

- `TestExportAPITestSuite/TestCredentialConfigurationExport`
- `TestExportAPITestSuite/TestCredentialConfigurationExportWithWildcard`
- `TestExportAPITestSuite/TestPresentationDefinitionExport`
- `TestExportAPITestSuite/TestPresentationDefinitionExportWithWildcard`
- `TestExportAPITestSuite/TestVCResourcesExportYAML`

### Approach

Add an optional `ref` input to the `run-integration-tests` composite action and pass it to its checkout, then have the release builder pass `RELEASE_BRANCH` so the tests are taken from the same branch the distribution was built from.

The input defaults to an empty string. `actions/checkout` declares `ref` with no default, so an empty value is indistinguishable from the input being omitted and falls back to the triggering ref as before. The PR builder and the PostgreSQL tests workflow do not pass `ref` and keep their current behaviour unchanged.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Integration tests can now run against a specified branch, tag, or commit.
  * Release validation uses the selected release branch when running integration tests.
  * This improves the consistency and accuracy of integration testing during release preparation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->