### PR TITLE
Bind CIBA-issued access tokens to the DPoP proof key

### DIFF
--- a/backend/internal/oauth/oauth2/granthandlers/ciba.go
+++ b/backend/internal/oauth/oauth2/granthandlers/ciba.go
@@ -12,6 +12,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/attributecache"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/ciba"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/dpop"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/model"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/resourceindicators"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/tokenservice"
@@ -230,6 +231,7 @@ func (h *cibaGrantHandler) issueTokens(ctx context.Context, record *ciba.CIBAAut
 		GrantType:         string(providers.GrantTypeCIBA),
 		OAuthApp:          oauthApp,
 		ValidityPeriod:    userSubConfig.ValidityPeriodOrZero(),
+		DPoPJkt:           dpop.GetJkt(ctx),
 	})
 	if err != nil {
 		h.logger.Error(ctx, "Failed to generate access token", log.Error(err))

--- a/backend/internal/oauth/oauth2/granthandlers/ciba_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/ciba_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/attributecache"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/ciba"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/dpop"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/model"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/tokenservice"
 	"github.com/thunder-id/thunderid/tests/mocks/attributecachemock"
@@ -250,6 +251,42 @@ func (suite *CIBAGrantHandlerTestSuite) TestHandleGrant_Authenticated_IssuesToke
 	suite.NotNil(resp)
 	suite.Equal("access-token", resp.AccessToken.Token)
 	suite.Equal("id-token", resp.IDToken.Token)
+}
+
+// A CIBA access token is sender-constrained to the key the client proved possession of when polling
+// the token endpoint, so a stolen token cannot be replayed without the matching DPoP proof.
+func (suite *CIBAGrantHandlerTestSuite) TestHandleGrant_Authenticated_BindsDPoPJkt() {
+	record := suite.boundAuthenticatedRecord(testScopeRead)
+	suite.mockCIBAService.EXPECT().GetByAuthReqID(mock.Anything, "auth-req-1").Return(record, nil)
+	suite.expectResourceServer()
+	suite.mockTokenBuilder.EXPECT().BuildAccessToken(mock.Anything, mock.MatchedBy(
+		func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return ctx.DPoPJkt == "test-jkt"
+		})).Return(&model.TokenDTO{Token: "access-token", TokenType: "DPoP"}, nil)
+	suite.mockCIBAService.EXPECT().MarkConsumed(mock.Anything, "auth-req-1").Return(true, nil)
+
+	ctx := dpop.WithJkt(context.Background(), "test-jkt")
+	resp, errResp := suite.handler.HandleGrant(ctx, suite.tokenReq, suite.oauthApp)
+	suite.Nil(errResp)
+	suite.NotNil(resp)
+	suite.Equal("access-token", resp.AccessToken.Token)
+}
+
+// Without a verified DPoP proof the access token stays unbound, so non-DPoP clients are unaffected.
+func (suite *CIBAGrantHandlerTestSuite) TestHandleGrant_Authenticated_NoProofLeavesTokenUnbound() {
+	record := suite.boundAuthenticatedRecord(testScopeRead)
+	suite.mockCIBAService.EXPECT().GetByAuthReqID(mock.Anything, "auth-req-1").Return(record, nil)
+	suite.expectResourceServer()
+	suite.mockTokenBuilder.EXPECT().BuildAccessToken(mock.Anything, mock.MatchedBy(
+		func(ctx *tokenservice.AccessTokenBuildContext) bool {
+			return ctx.DPoPJkt == ""
+		})).Return(&model.TokenDTO{Token: "access-token", TokenType: "Bearer"}, nil)
+	suite.mockCIBAService.EXPECT().MarkConsumed(mock.Anything, "auth-req-1").Return(true, nil)
+
+	resp, errResp := suite.handler.HandleGrant(context.Background(), suite.tokenReq, suite.oauthApp)
+	suite.Nil(errResp)
+	suite.NotNil(resp)
+	suite.Equal("access-token", resp.AccessToken.Token)
 }
 
 func (suite *CIBAGrantHandlerTestSuite) TestHandleGrant_Authenticated_NoOpenIDSkipsIDToken() {


### PR DESCRIPTION
### Purpose
CIBA-issued access tokens were never sender-constrained. The DPoP proof presented when polling the token endpoint was fully validated, but the resulting key thumbprint never reached the token builder, so the access token was issued without a `cnf.jkt` claim. A client configured with `DPoPBoundAccessTokens` received a plain bearer token while appearing to be DPoP-bound, with no error surfaced. Refresh tokens were unaffected.

### Approach
`verifyDPoPProof` already runs before grant dispatch and stores the verified thumbprint in the request context. The CIBA grant handler now reads it back via `dpop.GetJkt(ctx)` when building the access token, mirroring the authorization_code handler. `GetJkt` returns an empty string when no proof was verified, so non-DPoP clients are unaffected and no schema, store, or verification changes are needed.

### Related Issues
- Fixes #4226

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CIBA-issued access tokens now correctly preserve the request’s DPoP binding.
  * Requests with valid DPoP proof receive DPoP-bound tokens, while requests without proof continue to receive bearer tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->