### PR TITLE
Propagate max_age from pushed authorization requests

### DIFF
--- a/backend/internal/oauth/oauth2/par/service.go
+++ b/backend/internal/oauth/oauth2/par/service.go
@@ -144,6 +144,7 @@ func (s *parService) HandlePushedAuthorizationRequest(
 		ClaimsLocales:       params[oauth2const.RequestParamClaimsLocales],
 		Nonce:               params[oauth2const.RequestParamNonce],
 		AcrValues:           params[oauth2const.RequestParamAcrValues],
+		MaxAge:              params[oauth2const.RequestParamMaxAge],
 		DPoPJkt:             resolveDPoPJkt(params[oauth2const.RequestParamDPoPJkt], dpopHeaderJkt),
 		Prompt:              params[oauth2const.RequestParamPrompt],
 	}

--- a/backend/internal/oauth/oauth2/par/service_test.go
+++ b/backend/internal/oauth/oauth2/par/service_test.go
@@ -447,6 +447,26 @@ func (s *ServiceTestSuite) TestHandlePAR_AcrValuesPropagated() {
 		captured.OAuthParameters.AcrValues)
 }
 
+func (s *ServiceTestSuite) TestHandlePAR_MaxAgePropagated() {
+	store := newParStoreInterfaceMock(s.T())
+	var captured pushedAuthorizationRequest
+	store.EXPECT().Store(mock.Anything, mock.Anything, mock.Anything).
+		Run(func(_ context.Context, req pushedAuthorizationRequest, _ int64) {
+			captured = req
+		}).Return("test-uri", nil)
+
+	svc := newPARService(store, s.newPermissiveResourceMock(), s.testCfg)
+	app := s.newTestApp()
+	params := s.newValidParams()
+	params[oauth2const.RequestParamMaxAge] = "1"
+
+	resp, errCode, _ := svc.HandlePushedAuthorizationRequest(s.ctx, params, nil, app, "")
+
+	assert.Empty(s.T(), errCode)
+	assert.NotNil(s.T(), resp)
+	assert.Equal(s.T(), "1", captured.OAuthParameters.MaxAge)
+}
+
 func (s *ServiceTestSuite) TestHandlePAR_DPoPHeaderJkt_PersistedOnRequest() {
 	var captured pushedAuthorizationRequest
 	store := newParStoreInterfaceMock(s.T())


### PR DESCRIPTION
### Purpose

Fixes #4912.

`max_age` is honoured on `GET /oauth2/authorize` but gets dropped when the same request is pushed through `POST /oauth2/par` and redeemed via `request_uri`. `HandlePushedAuthorizationRequest` builds `OAuthParameters` without setting `MaxAge`, so `runtimeData["max_age"]` is never populated and the assurance check has no constraint to enforce. A client using PAR silently loses the ability to require recent authentication, with no error to indicate it.

### Approach

- Set `MaxAge` from the pushed params in `par/service.go`, next to `AcrValues`, matching what `authz/service.go` already does on the direct path.
- Add `TestHandlePAR_MaxAgePropagated` next to the existing `AcrValues` test.

`OAuthParameters.MaxAge` and `RequestParamMaxAge` already existed, and PAR only deny-lists the client credential params, so `max_age` was already reaching the params map. It just was not being read. No interface changed, so no mocks were regenerated.

### Related Issues
- Fixes #4912

### Related PRs
- N/A

#4919 left out its `max_age` through PAR scenario because of this bug. I can add that integration test here if you would rather it went in with the fix.

### Validation

- Go 1.26.5
- `go test ./internal/oauth/...`: 25 packages pass
- Full backend unit suite: 136 packages, 0 failures
- `golangci-lint run ./internal/oauth/oauth2/par/...`: 0 issues
- `gofmt -l` and `go vet` clean
- Reverted the one line locally to confirm the new test actually catches it (`expected: "1", actual: ""`)

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authorization requests can now preserve the `max_age` parameter during OAuth flow initiation.

* **Bug Fixes**
  * Fixed an issue where the requested authentication age could be lost when creating a pushed authorization request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->