### PR TITLE
Add missing onFailure field to BASIC_FEDERATED template executors

### DIFF
--- a/frontend/apps/console/src/features/flows/api/__tests__/useGetFlowBuilderResources.test.ts
+++ b/frontend/apps/console/src/features/flows/api/__tests__/useGetFlowBuilderResources.test.ts
@@ -246,7 +246,7 @@ describe('useGetFlowBuilderResources', () => {
   });
 
   describe('BASIC_FEDERATED Template Executor Action Fields', () => {
-    it('should define onFailure for BasicAuthExecutor and GoogleOIDCAuthExecutor task-execution steps', () => {
+    it('should define onFailure for CredentialsAuthExecutor and GoogleOIDCAuthExecutor task-execution steps', () => {
       const {result} = renderHook(() => useGetFlowBuilderResources());
 
       const {data} = result.current;
@@ -259,9 +259,13 @@ describe('useGetFlowBuilderResources', () => {
           ['CredentialsAuthExecutor', 'GoogleOIDCAuthExecutor'].includes(step.data?.action?.executor?.name ?? ''),
       );
       expect(executorSteps).toHaveLength(2);
+      expect(executorSteps.map((step) => step.data?.action?.executor?.name).sort()).toEqual([
+        'CredentialsAuthExecutor',
+        'GoogleOIDCAuthExecutor',
+      ]);
 
       executorSteps.forEach((step) => {
-        expect(step.data?.action).toHaveProperty('onFailure');
+        expect(step.data?.action).toHaveProperty('onFailure', '');
       });
     });
   });

--- a/frontend/apps/console/src/features/flows/api/__tests__/useGetFlowBuilderResources.test.ts
+++ b/frontend/apps/console/src/features/flows/api/__tests__/useGetFlowBuilderResources.test.ts
@@ -245,6 +245,27 @@ describe('useGetFlowBuilderResources', () => {
     });
   });
 
+  describe('BASIC_FEDERATED Template Executor Action Fields', () => {
+    it('should define onFailure for BasicAuthExecutor and GoogleOIDCAuthExecutor task-execution steps', () => {
+      const {result} = renderHook(() => useGetFlowBuilderResources());
+
+      const {data} = result.current;
+      const basicFederatedTemplate = data.templates.find((template) => template.type === 'BASIC_FEDERATED');
+      expect(basicFederatedTemplate).toBeDefined();
+
+      const executorSteps = basicFederatedTemplate!.config.data.steps.filter(
+        (step) =>
+          step.type === 'TASK_EXECUTION' &&
+          ['CredentialsAuthExecutor', 'GoogleOIDCAuthExecutor'].includes(step.data?.action?.executor?.name ?? ''),
+      );
+      expect(executorSteps).toHaveLength(2);
+
+      executorSteps.forEach((step) => {
+        expect(step.data?.action).toHaveProperty('onFailure');
+      });
+    });
+  });
+
   describe('Consistency', () => {
     it('should return consistent data across multiple hook instances', () => {
       const {result: result1} = renderHook(() => useGetFlowBuilderResources());

--- a/frontend/apps/console/src/features/flows/data/templates.json
+++ b/frontend/apps/console/src/features/flows/data/templates.json
@@ -14669,6 +14669,7 @@
                   "name": "CredentialsAuthExecutor"
                 },
                 "onSuccess": "{{AUTH_ASSERT_EXECUTOR_ID}}",
+                "onFailure": "",
                 "onIncomplete": ""
               }
             }
@@ -14691,6 +14692,7 @@
                   "name": "GoogleOIDCAuthExecutor"
                 },
                 "onSuccess": "{{PROVISIONING_EXECUTOR_STEP_ID}}",
+                "onFailure": "",
                 "onIncomplete": ""
               },
               "properties": {


### PR DESCRIPTION
### Purpose
The `BASIC_FEDERATED` flow-builder template in `frontend/apps/console/src/features/flows/data/templates.json` defines two `TASK_EXECUTION` nodes, `CredentialsAuthExecutor` and `GoogleOIDCAuthExecutor`, that carry `onSuccess` and `onIncomplete` but are missing `onFailure`. The flow builder decides whether to render a failure-path handle on a node purely from whether the `onFailure` key is present on its action object (see `hasBranchingSupport` in `ExecutionCompact.tsx` and `ExecutionMinimal.tsx`), so these two nodes silently render without a failure handle in this template while every sibling template (`BASIC`, `BASIC_SMS_OTP_MFA`, `SMS_OTP`, `PASSKEY_LOGIN`) shows one for the equivalent executor.

This is the "Immediate fix" item from the linked issue; the issue's other finding, `AuthAssertExecutor` nodes missing `onIncomplete`, was confirmed intentional by a maintainer comment on the issue and is left untouched here.

### Approach
Added `"onFailure": ""` to both nodes, matching the `onSuccess`/`onFailure`/`onIncomplete` field order already used by the equivalent `CredentialsAuthExecutor` node in the `BASIC` template.

### Related Issues
- Fixes #1475

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

---
AI assistance: this change was drafted with Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password-or-Google login flow handling by explicitly defining failure transitions for credential and Google sign-in steps.

* **Tests**
  * Added coverage to verify the login template includes both authentication steps and their failure handling configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->