### PR TITLE
Set explicit minimumReleaseAge for pnpm supply chain security

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -227,6 +227,14 @@ auditConfig:
     # and add an override once image-size ships a fix.
     - GHSA-5p2g-fcmc-qvqq
 
+# JUSTIFICATION: Delays installation of newly published versions per the pnpm supply chain
+# security guidelines (https://pnpm.io/supply-chain-security#delay-dependency-updates), so a
+# compromised release has a window to be caught and yanked before it reaches this workspace.
+# Setting this explicitly also switches pnpm from its default lenient behavior (silently
+# auto-excluding an immature package and proceeding) to strict enforcement (failing the
+# install unless the package is listed in minimumReleaseAgeExclude below).
+minimumReleaseAge: 1440
+
 minimumReleaseAgeExclude:
   - '@thunderid/*'
   - nanoid@3.3.18


### PR DESCRIPTION
### Purpose
Set an explicit `minimumReleaseAge: 1440` (1 day) in `pnpm-workspace.yaml` for supply chain security. The repo already carried a `minimumReleaseAgeExclude` list, but never set the `minimumReleaseAge` value it belongs to. pnpm 11 (pinned in `package.json`) defaults `minimumReleaseAge` to 1440 minutes, so the delay was already implicitly active, but that default is undocumented in the repo and enforced leniently: pnpm silently auto-adds an immature package to `minimumReleaseAgeExclude` and proceeds with a warning instead of failing the install.

### Approach
Add `minimumReleaseAge: 1440` directly above the existing `minimumReleaseAgeExclude` block in `pnpm-workspace.yaml`, with a comment referencing the pnpm supply chain security guidelines this follows. Setting the value explicitly switches pnpm from the default lenient behavior to strict enforcement: a `pnpm add`/`pnpm update` of a package published within the last day now hard-fails with `ERR_PNPM_NO_MATURE_MATCHING_VERSION` unless the package is listed in `minimumReleaseAgeExclude`, which is the actual protection the "delay dependency updates" guideline is meant to provide.

### Related Issues
- Refs #2096

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

---
AI assistance: this change was drafted with Claude Code.

Fixes #2096

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a release-age policy that delays installation of newly published package versions by 24 hours.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->