### PR TITLE
Restrict token introspection to parties of the token

### DIFF
--- a/backend/internal/oauth/oauth2/introspect/TokenIntrospectionServiceInterface_mock_test.go
+++ b/backend/internal/oauth/oauth2/introspect/TokenIntrospectionServiceInterface_mock_test.go
@@ -38,8 +38,8 @@ func (_m *TokenIntrospectionServiceInterfaceMock) EXPECT() *TokenIntrospectionSe
 }
 
 // IntrospectToken provides a mock function for the type TokenIntrospectionServiceInterfaceMock
-func (_mock *TokenIntrospectionServiceInterfaceMock) IntrospectToken(ctx context.Context, token string, tokenTypeHint string) (*IntrospectResponse, error) {
-	ret := _mock.Called(ctx, token, tokenTypeHint)
+func (_mock *TokenIntrospectionServiceInterfaceMock) IntrospectToken(ctx context.Context, token string, tokenTypeHint string, clientID string) (*IntrospectResponse, error) {
+	ret := _mock.Called(ctx, token, tokenTypeHint, clientID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IntrospectToken")
@@ -47,18 +47,18 @@ func (_mock *TokenIntrospectionServiceInterfaceMock) IntrospectToken(ctx context
 
 	var r0 *IntrospectResponse
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*IntrospectResponse, error)); ok {
-		return returnFunc(ctx, token, tokenTypeHint)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) (*IntrospectResponse, error)); ok {
+		return returnFunc(ctx, token, tokenTypeHint, clientID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *IntrospectResponse); ok {
-		r0 = returnFunc(ctx, token, tokenTypeHint)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) *IntrospectResponse); ok {
+		r0 = returnFunc(ctx, token, tokenTypeHint, clientID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*IntrospectResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = returnFunc(ctx, token, tokenTypeHint)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = returnFunc(ctx, token, tokenTypeHint, clientID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -74,11 +74,12 @@ type TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call struct {
 //   - ctx context.Context
 //   - token string
 //   - tokenTypeHint string
-func (_e *TokenIntrospectionServiceInterfaceMock_Expecter) IntrospectToken(ctx interface{}, token interface{}, tokenTypeHint interface{}) *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call {
-	return &TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call{Call: _e.mock.On("IntrospectToken", ctx, token, tokenTypeHint)}
+//   - clientID string
+func (_e *TokenIntrospectionServiceInterfaceMock_Expecter) IntrospectToken(ctx interface{}, token interface{}, tokenTypeHint interface{}, clientID interface{}) *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call {
+	return &TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call{Call: _e.mock.On("IntrospectToken", ctx, token, tokenTypeHint, clientID)}
 }
 
-func (_c *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call) Run(run func(ctx context.Context, token string, tokenTypeHint string)) *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call {
+func (_c *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call) Run(run func(ctx context.Context, token string, tokenTypeHint string, clientID string)) *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -92,10 +93,15 @@ func (_c *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call) Run(run f
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -106,7 +112,7 @@ func (_c *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call) Return(in
 	return _c
 }
 
-func (_c *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call) RunAndReturn(run func(ctx context.Context, token string, tokenTypeHint string) (*IntrospectResponse, error)) *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call {
+func (_c *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call) RunAndReturn(run func(ctx context.Context, token string, tokenTypeHint string, clientID string) (*IntrospectResponse, error)) *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/oauth/oauth2/introspect/handler.go
+++ b/backend/internal/oauth/oauth2/introspect/handler.go
@@ -6,6 +6,7 @@ package introspect
 import (
 	"net/http"
 
+	"github.com/thunder-id/thunderid/internal/oauth/oauth2/clientauth"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	sysutils "github.com/thunder-id/thunderid/internal/system/utils"
@@ -44,7 +45,14 @@ func (h *tokenIntrospectionHandler) HandleIntrospect(w http.ResponseWriter, r *h
 	// token_type_hint parameter is not supported due to non persistent tokens in the server
 	tokenTypeHint := r.FormValue(constants.RequestParamTokenTypeHint)
 
-	response, err := h.service.IntrospectToken(ctx, token, tokenTypeHint)
+	// ClientAuthMiddleware has already authenticated the caller; the client it resolved decides which
+	// tokens this request may introspect.
+	clientID := ""
+	if client := clientauth.GetOAuthClient(ctx); client != nil {
+		clientID = client.ClientID
+	}
+
+	response, err := h.service.IntrospectToken(ctx, token, tokenTypeHint, clientID)
 	if err != nil {
 		h.logger.Error(ctx, "Failed to introspect token", log.Error(err))
 		sysutils.WriteJSONError(ctx, w, constants.ErrorServerError,

--- a/backend/internal/oauth/oauth2/introspect/handler_test.go
+++ b/backend/internal/oauth/oauth2/introspect/handler_test.go
@@ -117,7 +117,7 @@ func (s *TokenIntrospectionHandlerTestSuite) TestHandleIntrospect_IntrospectionE
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	// Setup the mock to return an error
-	s.introspectionServiceMock.On("IntrospectToken", mock.Anything, "valid-token", "").
+	s.introspectionServiceMock.On("IntrospectToken", mock.Anything, "valid-token", "", mock.Anything).
 		Return(nil, errors.New("introspection error"))
 
 	rr := httptest.NewRecorder()
@@ -151,7 +151,7 @@ func (s *TokenIntrospectionHandlerTestSuite) TestHandleIntrospect_Success_Active
 		Iss:       "https://example.com",
 		Jti:       "token-id-123",
 	}
-	s.introspectionServiceMock.On("IntrospectToken", mock.Anything, "valid-token", "access_token").
+	s.introspectionServiceMock.On("IntrospectToken", mock.Anything, "valid-token", "access_token", mock.Anything).
 		Return(activeResponse, nil)
 
 	rr := httptest.NewRecorder()
@@ -171,7 +171,7 @@ func (s *TokenIntrospectionHandlerTestSuite) TestHandleIntrospect_IntrospectionE
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	// Setup the mock to return an error
-	s.introspectionServiceMock.On("IntrospectToken", mock.Anything, "valid-token", "").
+	s.introspectionServiceMock.On("IntrospectToken", mock.Anything, "valid-token", "", mock.Anything).
 		Return(nil, errors.New("introspection error"))
 
 	rr := httptest.NewRecorder()
@@ -191,7 +191,8 @@ func (s *TokenIntrospectionHandlerTestSuite) TestHandleIntrospect_Success_Encode
 	activeResponse := &IntrospectResponse{
 		Active: true,
 	}
-	s.introspectionServiceMock.On("IntrospectToken", mock.Anything, "valid-token", "").Return(activeResponse, nil)
+	s.introspectionServiceMock.On("IntrospectToken", mock.Anything, "valid-token", "", mock.Anything).
+		Return(activeResponse, nil)
 
 	rr := httptest.NewRecorder()
 
@@ -210,7 +211,8 @@ func (s *TokenIntrospectionHandlerTestSuite) TestHandleIntrospect_Success_Inacti
 	inactiveResponse := &IntrospectResponse{
 		Active: false,
 	}
-	s.introspectionServiceMock.On("IntrospectToken", mock.Anything, "invalid-token", "").Return(inactiveResponse, nil)
+	s.introspectionServiceMock.On("IntrospectToken", mock.Anything, "invalid-token", "", mock.Anything).
+		Return(inactiveResponse, nil)
 
 	rr := httptest.NewRecorder()
 

--- a/backend/internal/oauth/oauth2/introspect/service.go
+++ b/backend/internal/oauth/oauth2/introspect/service.go
@@ -17,7 +17,7 @@ import (
 
 // TokenIntrospectionServiceInterface defines the interface for OAuth 2.0 token introspection.
 type TokenIntrospectionServiceInterface interface {
-	IntrospectToken(ctx context.Context, token, tokenTypeHint string) (*IntrospectResponse, error)
+	IntrospectToken(ctx context.Context, token, tokenTypeHint, clientID string) (*IntrospectResponse, error)
 }
 
 // tokenIntrospectionService implements the TokenIntrospectionServiceInterface.
@@ -37,7 +37,7 @@ func newTokenIntrospectionService(
 // IntrospectToken validates and introspects the token. It only returns an error if a server error occurs.
 // All other failures are treated as inactive token as defined in the RFC 7662.
 func (s *tokenIntrospectionService) IntrospectToken(
-	ctx context.Context, token, tokenTypeHint string,
+	ctx context.Context, token, tokenTypeHint, clientID string,
 ) (*IntrospectResponse, error) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "TokenIntrospectionService"))
 
@@ -60,7 +60,56 @@ func (s *tokenIntrospectionService) IntrospectToken(
 		}, nil
 	}
 
+	if !isAuthorizedIntrospector(payload, clientID) {
+		logger.Debug(ctx, "Caller is not a party to the token; reporting it inactive")
+		return &IntrospectResponse{
+			Active: false,
+		}, nil
+	}
+
 	return s.prepareValidResponse(payload), nil
+}
+
+// isAuthorizedIntrospector reports whether the authenticated client is a party to the token and may
+// therefore introspect it. RFC 7662 section 2.1 requires the authorization server to determine whether
+// the caller is authorized for the presented token. An unauthorized caller is answered with
+// {"active": false} rather than an error, so the endpoint cannot be used to enumerate metadata about
+// tokens belonging to other clients.
+//
+// The two token types name their client differently. An access token carries the client it was issued
+// to in "client_id". A refresh token carries no "client_id" and is issued to the client as its subject,
+// so "sub" identifies the client there. A resource server the token is audienced to is also a party to
+// it, so a matching "aud" entry authorizes the caller as well.
+func isAuthorizedIntrospector(payload map[string]interface{}, clientID string) bool {
+	if clientID == "" {
+		return false
+	}
+
+	if tokenClientID, ok := payload["client_id"].(string); ok && tokenClientID != "" {
+		if tokenClientID == clientID {
+			return true
+		}
+	} else if sub, ok := payload[constants.ClaimSub].(string); ok && sub == clientID {
+		return true
+	}
+
+	return audienceContains(payload[constants.ClaimAud], clientID)
+}
+
+// audienceContains reports whether the "aud" claim, which JWT allows to be either a single string or
+// an array of strings, includes the given value.
+func audienceContains(aud interface{}, clientID string) bool {
+	switch value := aud.(type) {
+	case string:
+		return value == clientID
+	case []interface{}:
+		for _, entry := range value {
+			if entryStr, ok := entry.(string); ok && entryStr == clientID {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // prepareValidResponse prepares the response for a valid token introspection.

--- a/backend/internal/oauth/oauth2/introspect/service_test.go
+++ b/backend/internal/oauth/oauth2/introspect/service_test.go
@@ -33,7 +33,7 @@ func (s *TokenIntrospectionServiceTestSuite) SetupTest() {
 }
 
 func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_EmptyToken() {
-	response, err := s.introspectService.IntrospectToken(context.Background(), "", "")
+	response, err := s.introspectService.IntrospectToken(context.Background(), "", "", "client123")
 	assert.Error(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "token is required")
 	assert.Nil(s.T(), response)
@@ -52,7 +52,7 @@ func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_ValidToken_Acti
 	}
 	s.tokenValidatorMock.On("ValidateToken", mock.Anything, "valid-token").Return(claims, nil)
 
-	response, err := s.introspectService.IntrospectToken(context.Background(), "valid-token", "")
+	response, err := s.introspectService.IntrospectToken(context.Background(), "valid-token", "", "client123")
 
 	assert.NoError(s.T(), err)
 	assert.NotNil(s.T(), response)
@@ -74,26 +74,27 @@ func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_ArrayAudience()
 	}
 	s.tokenValidatorMock.On("ValidateToken", mock.Anything, "array-aud-token").Return(claims, nil)
 
-	response, err := s.introspectService.IntrospectToken(context.Background(), "array-aud-token", "")
+	response, err := s.introspectService.IntrospectToken(context.Background(), "array-aud-token", "", "api.example.com")
 
 	assert.NoError(s.T(), err)
 	assert.True(s.T(), response.Active)
 	assert.Equal(s.T(), []string{"api.example.com", "api2.example.com"}, response.Aud)
 }
 
-// A valid token missing optional claims is still active, with empty optional fields.
+// A valid token missing optional claims is still active, with empty optional fields. The token keeps
+// the subject that makes it attributable to the caller, since a token naming no client, subject or
+// audience belongs to nobody and is reported inactive.
 func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_MissingOptionalClaims_Active() {
 	s.tokenValidatorMock.On("ValidateToken", mock.Anything, "sparse-token").
-		Return(map[string]interface{}{}, nil)
+		Return(map[string]interface{}{"sub": "client123"}, nil)
 
-	response, err := s.introspectService.IntrospectToken(context.Background(), "sparse-token", "")
+	response, err := s.introspectService.IntrospectToken(context.Background(), "sparse-token", "", "client123")
 
 	assert.NoError(s.T(), err)
 	assert.True(s.T(), response.Active)
 	assert.Equal(s.T(), constants.TokenTypeBearer, response.TokenType)
 	assert.Empty(s.T(), response.Scope)
 	assert.Empty(s.T(), response.ClientID)
-	assert.Empty(s.T(), response.Sub)
 	assert.Empty(s.T(), response.Jti)
 }
 
@@ -102,7 +103,7 @@ func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_InvalidToken_Is
 	s.tokenValidatorMock.On("ValidateToken", mock.Anything, "invalid-token").
 		Return(nil, errors.New("token verification failed"))
 
-	response, err := s.introspectService.IntrospectToken(context.Background(), "invalid-token", "")
+	response, err := s.introspectService.IntrospectToken(context.Background(), "invalid-token", "", "client123")
 
 	assert.NoError(s.T(), err)
 	assert.NotNil(s.T(), response)
@@ -114,7 +115,7 @@ func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_RevokedToken_Is
 	s.tokenValidatorMock.On("ValidateToken", mock.Anything, "revoked-token").
 		Return(nil, revocation.ErrTokenRevoked)
 
-	response, err := s.introspectService.IntrospectToken(context.Background(), "revoked-token", "")
+	response, err := s.introspectService.IntrospectToken(context.Background(), "revoked-token", "", "client123")
 
 	assert.NoError(s.T(), err)
 	assert.NotNil(s.T(), response)
@@ -127,7 +128,7 @@ func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_EnforcementUnav
 	s.tokenValidatorMock.On("ValidateToken", mock.Anything, "some-token").
 		Return(nil, revocation.ErrEnforcementUnavailable)
 
-	response, err := s.introspectService.IntrospectToken(context.Background(), "some-token", "")
+	response, err := s.introspectService.IntrospectToken(context.Background(), "some-token", "", "client123")
 
 	assert.Error(s.T(), err)
 	assert.Nil(s.T(), response)
@@ -142,7 +143,7 @@ func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_DPoPBoundToken_
 	}
 	s.tokenValidatorMock.On("ValidateToken", mock.Anything, "dpop-token").Return(claims, nil)
 
-	response, err := s.introspectService.IntrospectToken(context.Background(), "dpop-token", "")
+	response, err := s.introspectService.IntrospectToken(context.Background(), "dpop-token", "", "client123")
 
 	assert.NoError(s.T(), err)
 	assert.NotNil(s.T(), response)
@@ -150,4 +151,119 @@ func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_DPoPBoundToken_
 	assert.Equal(s.T(), constants.TokenTypeDPoP, response.TokenType)
 	assert.NotNil(s.T(), response.Cnf)
 	assert.Equal(s.T(), "thumbprint-abc", response.Cnf.Jkt)
+}
+
+// A client that is not a party to the token gets {"active": false} rather than the token's metadata,
+// so the endpoint cannot be used to enumerate other clients' tokens.
+func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_ForeignClient_IsInactive() {
+	claims := map[string]interface{}{
+		"jti":       "token-id-123",
+		"scope":     "openid profile",
+		"client_id": "client123",
+		"sub":       "user123",
+		"aud":       "api.example.com",
+	}
+	s.tokenValidatorMock.On("ValidateToken", mock.Anything, "other-client-token").Return(claims, nil)
+
+	response, err := s.introspectService.IntrospectToken(
+		context.Background(), "other-client-token", "", "intruder-client")
+
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), response)
+	assert.False(s.T(), response.Active)
+	assert.Empty(s.T(), response.Sub)
+	assert.Empty(s.T(), response.Scope)
+	assert.Empty(s.T(), response.Jti)
+}
+
+// A refresh token carries no client_id and names the client as its subject, so the issuing client
+// still introspects it successfully.
+func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_RefreshTokenSubject_IsActive() {
+	claims := map[string]interface{}{
+		"sub":              "client123",
+		"aud":              "https://example.com",
+		"access_token_sub": "user123",
+	}
+	s.tokenValidatorMock.On("ValidateToken", mock.Anything, "refresh-token").Return(claims, nil)
+
+	response, err := s.introspectService.IntrospectToken(context.Background(), "refresh-token", "", "client123")
+
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), response.Active)
+	assert.Equal(s.T(), "client123", response.Sub)
+}
+
+// A refresh token belonging to another client is inactive for the caller.
+func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_ForeignRefreshToken_IsInactive() {
+	claims := map[string]interface{}{
+		"sub": "client123",
+		"aud": "https://example.com",
+	}
+	s.tokenValidatorMock.On("ValidateToken", mock.Anything, "foreign-refresh-token").Return(claims, nil)
+
+	response, err := s.introspectService.IntrospectToken(
+		context.Background(), "foreign-refresh-token", "", "intruder-client")
+
+	assert.NoError(s.T(), err)
+	assert.False(s.T(), response.Active)
+}
+
+// A resource server the token is audienced to is a party to it, so it may introspect even though the
+// token was issued to a different client.
+func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_AudienceMember_IsActive() {
+	claims := map[string]interface{}{
+		"client_id": "client123",
+		"sub":       "user123",
+		"aud":       "https://api.example.com",
+	}
+	s.tokenValidatorMock.On("ValidateToken", mock.Anything, "rs-token").Return(claims, nil)
+
+	response, err := s.introspectService.IntrospectToken(
+		context.Background(), "rs-token", "", "https://api.example.com")
+
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), response.Active)
+	assert.Equal(s.T(), "client123", response.ClientID)
+}
+
+// The audience check also covers a multi valued aud claim.
+func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_AudienceArrayMember_IsActive() {
+	claims := map[string]interface{}{
+		"client_id": "client123",
+		"aud":       []interface{}{"https://api.example.com", "https://api2.example.com"},
+	}
+	s.tokenValidatorMock.On("ValidateToken", mock.Anything, "multi-aud-token").Return(claims, nil)
+
+	response, err := s.introspectService.IntrospectToken(
+		context.Background(), "multi-aud-token", "", "https://api2.example.com")
+
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), response.Active)
+}
+
+// A token naming no client, subject or audience is attributable to nobody and stays inactive.
+func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_UnattributableToken_IsInactive() {
+	s.tokenValidatorMock.On("ValidateToken", mock.Anything, "anonymous-token").
+		Return(map[string]interface{}{"scope": "openid"}, nil)
+
+	response, err := s.introspectService.IntrospectToken(
+		context.Background(), "anonymous-token", "", "client123")
+
+	assert.NoError(s.T(), err)
+	assert.False(s.T(), response.Active)
+}
+
+// An unauthenticated caller reaching the service with no client identity introspects nothing.
+func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_NoCallerClientID_IsInactive() {
+	claims := map[string]interface{}{
+		"client_id": "client123",
+		"sub":       "user123",
+	}
+	s.tokenValidatorMock.On("ValidateToken", mock.Anything, "unattributed-caller-token").Return(claims, nil)
+
+	response, err := s.introspectService.IntrospectToken(
+		context.Background(), "unattributed-caller-token", "", "")
+
+	assert.NoError(s.T(), err)
+	assert.False(s.T(), response.Active)
 }

--- a/backend/tests/mocks/oauth/oauth2/introspectmock/TokenIntrospectionServiceInterface_mock.go
+++ b/backend/tests/mocks/oauth/oauth2/introspectmock/TokenIntrospectionServiceInterface_mock.go
@@ -39,8 +39,8 @@ func (_m *TokenIntrospectionServiceInterfaceMock) EXPECT() *TokenIntrospectionSe
 }
 
 // IntrospectToken provides a mock function for the type TokenIntrospectionServiceInterfaceMock
-func (_mock *TokenIntrospectionServiceInterfaceMock) IntrospectToken(ctx context.Context, token string, tokenTypeHint string) (*introspect.IntrospectResponse, error) {
-	ret := _mock.Called(ctx, token, tokenTypeHint)
+func (_mock *TokenIntrospectionServiceInterfaceMock) IntrospectToken(ctx context.Context, token string, tokenTypeHint string, clientID string) (*introspect.IntrospectResponse, error) {
+	ret := _mock.Called(ctx, token, tokenTypeHint, clientID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IntrospectToken")
@@ -48,18 +48,18 @@ func (_mock *TokenIntrospectionServiceInterfaceMock) IntrospectToken(ctx context
 
 	var r0 *introspect.IntrospectResponse
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*introspect.IntrospectResponse, error)); ok {
-		return returnFunc(ctx, token, tokenTypeHint)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) (*introspect.IntrospectResponse, error)); ok {
+		return returnFunc(ctx, token, tokenTypeHint, clientID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *introspect.IntrospectResponse); ok {
-		r0 = returnFunc(ctx, token, tokenTypeHint)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) *introspect.IntrospectResponse); ok {
+		r0 = returnFunc(ctx, token, tokenTypeHint, clientID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*introspect.IntrospectResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = returnFunc(ctx, token, tokenTypeHint)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = returnFunc(ctx, token, tokenTypeHint, clientID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -75,11 +75,12 @@ type TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call struct {
 //   - ctx context.Context
 //   - token string
 //   - tokenTypeHint string
-func (_e *TokenIntrospectionServiceInterfaceMock_Expecter) IntrospectToken(ctx interface{}, token interface{}, tokenTypeHint interface{}) *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call {
-	return &TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call{Call: _e.mock.On("IntrospectToken", ctx, token, tokenTypeHint)}
+//   - clientID string
+func (_e *TokenIntrospectionServiceInterfaceMock_Expecter) IntrospectToken(ctx interface{}, token interface{}, tokenTypeHint interface{}, clientID interface{}) *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call {
+	return &TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call{Call: _e.mock.On("IntrospectToken", ctx, token, tokenTypeHint, clientID)}
 }
 
-func (_c *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call) Run(run func(ctx context.Context, token string, tokenTypeHint string)) *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call {
+func (_c *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call) Run(run func(ctx context.Context, token string, tokenTypeHint string, clientID string)) *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -93,10 +94,15 @@ func (_c *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call) Run(run f
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -107,7 +113,7 @@ func (_c *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call) Return(in
 	return _c
 }
 
-func (_c *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call) RunAndReturn(run func(ctx context.Context, token string, tokenTypeHint string) (*introspect.IntrospectResponse, error)) *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call {
+func (_c *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call) RunAndReturn(run func(ctx context.Context, token string, tokenTypeHint string, clientID string) (*introspect.IntrospectResponse, error)) *TokenIntrospectionServiceInterfaceMock_IntrospectToken_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/docs/content/guides/protocols/oauth-oidc/token-introspection.mdx
+++ b/docs/content/guides/protocols/oauth-oidc/token-introspection.mdx
@@ -23,7 +23,7 @@ Use it when a resource server cannot or should not validate JWTs locally. For ex
 |---|---|
 | Endpoint | `POST /oauth2/introspect` |
 | Authentication | Required, same client authentication method as the token endpoint (see [Client Authentication Methods](../client-authentication-methods)) |
-| Who can call | Any registered client. Best practice: register the resource server as a confidential client and use its credentials |
+| Who can call | A client that is a party to the token. Any other authenticated client receives `{ "active": false }` (see [Who Can Introspect a Token](#who-can-introspect-a-token)) |
 | `token_type_hint` parameter | Accepted but not used internally: the server determines the token type itself |
 | Inactive token response | `{ "active": false }` with HTTP 200, never leaks reason |
 | Active token response | Standard claims (see below) |
@@ -49,6 +49,26 @@ When the token is DPoP-bound, the response also includes the `cnf.jkt` claim.
 
 </details>
 
+## Who Can Introspect a Token
+
+Client authentication tells <ProductName /> who is asking, and the caller then has to be a party to
+the token it presents. A caller that is not gets `{ "active": false }`, the same answer an expired or
+unknown token produces, so the endpoint cannot be used to discover other clients' tokens.
+
+A caller is a party to the token when any of the following holds.
+
+| The caller | Matches |
+|---|---|
+| The client the access token was issued to | the token's `client_id` claim |
+| The client a refresh token was issued to | the token's `sub` claim, since refresh tokens carry no `client_id` |
+| A resource server the token is addressed to | an entry in the token's `aud` claim |
+
+For the audience case, the client id the resource server authenticates with has to equal the audience
+value carried by the token. That is the resource server `identifier` for a token bound to a resource
+server, and the requesting client's own `defaultAudience` (falling back to its client id) otherwise.
+Register the resource server's client id to match its identifier, or set `defaultAudience`
+accordingly, so its introspection calls resolve.
+
 ## Introspection or Local JWT Validation
 
 <ProductName /> issues JWT access tokens, so resource servers have two valid options:
@@ -62,7 +82,7 @@ A common pattern is to verify the JWT locally on most calls and call introspecti
 
 ## Try It in <ProductName />
 
-Introspection is always available. To call it, register a client with permission to introspect, typically the resource server itself.
+Introspection is always available. To call it, register a client for the caller, typically the resource server itself, and make sure it is a party to the tokens it will introspect (see [Who Can Introspect a Token](#who-can-introspect-a-token)).
 
 ### Register an Introspection Client
 

--- a/tests/integration/oauth/introspect/introspect_test.go
+++ b/tests/integration/oauth/introspect/introspect_test.go
@@ -603,6 +603,44 @@ func (ts *IntrospectionTestSuite) TestIntrospect_RefreshToken_IsActive() {
 }
 
 //
+// Case 6b: a caller that is not a party to the token learns nothing about it.
+//
+
+// TestIntrospect_CrossClientAccessToken_IsInactive authenticates as a different confidential client
+// and introspects an access token issued to userClient. RFC 7662 section 2.1 requires the server to
+// decide whether the caller is authorized for the token, so the response must be
+// {"active": false} with none of the token's metadata attached, rather than the same payload the
+// owning client sees.
+func (ts *IntrospectionTestSuite) TestIntrospect_CrossClientAccessToken_IsInactive() {
+	owner := ts.introspectBasic(ts.userAccessToken, userClientID, userClientSecret)
+	ts.Require().Equalf(http.StatusOK, owner.StatusCode, "introspection body: %s", string(owner.Raw))
+	ts.Require().True(owner.active(), "the owning client must still see its own token as active")
+
+	res := ts.introspectBasic(ts.userAccessToken, ccClientID, ccClientSecret)
+
+	ts.Require().Equalf(http.StatusOK, res.StatusCode, "introspection body: %s", string(res.Raw))
+	ts.False(res.active(), "a client that is not a party to the token must not see it as active")
+	for _, claim := range []string{"scope", "client_id", "sub", "aud", "iss", "jti", "exp"} {
+		ts.NotContainsf(res.Body, claim, "an unauthorized caller must not receive the %q member", claim)
+	}
+}
+
+// TestIntrospect_CrossClientRefreshToken_IsInactive is the refresh token counterpart. A refresh token
+// carries no client_id claim and names its client in sub, so the ownership check has to read a
+// different claim for it than for an access token.
+func (ts *IntrospectionTestSuite) TestIntrospect_CrossClientRefreshToken_IsInactive() {
+	owner := ts.introspectBasic(ts.userRefreshToken, userClientID, userClientSecret)
+	ts.Require().Equalf(http.StatusOK, owner.StatusCode, "introspection body: %s", string(owner.Raw))
+	ts.Require().True(owner.active(), "the owning client must still see its own refresh token as active")
+
+	res := ts.introspectBasic(ts.userRefreshToken, ccClientID, ccClientSecret)
+
+	ts.Require().Equalf(http.StatusOK, res.StatusCode, "introspection body: %s", string(res.Raw))
+	ts.False(res.active(), "a refresh token must not be introspectable by another client")
+	ts.NotContains(res.Body, "sub", "an unauthorized caller must not receive the token subject")
+}
+
+//
 // Cases 7 and 8: token_type_hint is accepted and ignored.
 //
 


### PR DESCRIPTION
### Purpose

Fixes #4911.

`POST /oauth2/introspect` authenticated the caller but never checked whether the presented token belonged to it. The handler did not read the authenticated client back out of the request context, and `IntrospectToken` took no client argument, so no ownership comparison was possible anywhere in the call chain. Any client with valid credentials could introspect any token in the deployment, including other clients' tokens and admin tokens, recovering `sub`, `scope`, `aud`, `exp` and `jti`.

### Approach

- Read the authenticated client from the request context in the handler and pass it to the service, the same way `revocation/handler.go` already does.
- Report a token the caller is not a party to as `{"active": false}`. RFC 7662 section 2.1 puts the authorization decision on the server, and answering inactive rather than erroring keeps the endpoint from becoming a probe for which tokens exist.

The ownership check has to read two different claims, because the token types identify their client differently:

| Token | Client named in | `aud` holds |
|---|---|---|
| Access token | `client_id` | resource server identifier, or the client id via `ResolveDefaultAudience` |
| Refresh token | `sub` (no `client_id` claim) | the issuer |

Checking only `client_id` would have made every refresh token introspect as inactive and broken `TestIntrospect_RefreshToken_IsActive`.

A resource server the token is audienced to is also a party to it, so a matching `aud` entry authorizes the caller. Introspection exists primarily for resource servers, so restricting it to the issuing client alone would have broken its main use case.

One behaviour change worth calling out: a token naming no `client_id`, `sub` or `aud` is attributable to nobody and is now inactive. `TestIntrospectToken_MissingOptionalClaims_Active` therefore gives its token a subject; it still asserts what it was written to assert, that absent optional claims leave the response fields empty.

`TokenIntrospectionServiceInterface` changed, so its two mocks are regenerated with `make mockery`. The interface has no production consumer outside the package (`oauth/init.go` discards the returned service), so nothing else needed touching.

### Related Issues
- Fixes #4911

### Related PRs
- N/A

#4922 left cross client introspection deliberately untested because it was a confirmed defect. This adds the two integration tests that were waiting on the fix.

### Validation

- Go 1.26.5
- `go test ./internal/oauth/...`: 25 packages pass
- Full backend unit suite: 136 packages, 0 failures
- `golangci-lint run ./internal/oauth/...`: 0 issues
- `mockery` run from both `.mockery.public.yml` and `.mockery.private.yml`; only the two introspection mocks changed
- Disabled the new check locally to confirm the added tests fail without it: the four ownership unit tests fail, the rest still pass

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Token introspection now verifies that the requesting client is authorized to view token details.
  * Tokens belonging to another client, lacking ownership information, or queried without a client identity are reported as inactive.
  * Authorized clients can introspect eligible access and refresh tokens, including tokens identified through audience claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->