### PR TITLE
Require id_token_hint to be an ID token at the logout endpoint

### DIFF
--- a/backend/internal/oauth/oauth2/logout/service.go
+++ b/backend/internal/oauth/oauth2/logout/service.go
@@ -228,8 +228,22 @@ func (s *logoutService) clientIDFromIDTokenHint(ctx context.Context, idTokenHint
 	if svcErr := s.jwtService.VerifyJWTSignature(ctx, idTokenHint); svcErr != nil {
 		return "", errInvalidIDTokenHint
 	}
+	header, err := jwt.DecodeJWTHeader(idTokenHint)
+	if err != nil {
+		return "", errInvalidIDTokenHint
+	}
+	// The hint must be an ID token, not any other JWT this server signs. An access token issued to an
+	// application with no configured default audience carries aud=client_id, so without this check it
+	// would resolve to a client and be accepted as a hint, which suppresses the End-User sign-out
+	// confirmation.
+	if typ, _ := header["typ"].(string); typ != jwt.TokenTypeJWT {
+		return "", errInvalidIDTokenHint
+	}
 	payload, err := jwt.DecodeJWTPayload(idTokenHint)
 	if err != nil {
+		return "", errInvalidIDTokenHint
+	}
+	if _, isRefreshToken := payload[constants.ClaimAccessTokenSubject]; isRefreshToken {
 		return "", errInvalidIDTokenHint
 	}
 	if iss, _ := payload[constants.ClaimIss].(string); iss != s.issuer {

--- a/backend/internal/oauth/oauth2/logout/service_test.go
+++ b/backend/internal/oauth/oauth2/logout/service_test.go
@@ -300,6 +300,20 @@ func makeIDToken(iss, aud string) string {
 		enc(map[string]interface{}{"iss": iss, "aud": aud}) + ".sig"
 }
 
+// makeTypedToken builds a token with an arbitrary typ header and extra claims, for asserting that
+// only ID tokens are accepted as an id_token_hint.
+func makeTypedToken(typ, iss, aud string, extra map[string]interface{}) string {
+	enc := func(v interface{}) string {
+		b, _ := json.Marshal(v)
+		return base64.RawURLEncoding.EncodeToString(b)
+	}
+	claims := map[string]interface{}{"iss": iss, "aud": aud}
+	for k, v := range extra {
+		claims[k] = v
+	}
+	return enc(map[string]string{"alg": "RS256", "typ": typ}) + "." + enc(claims) + ".sig"
+}
+
 func makeIDTokenMultiAud(iss string, aud []string, azp string) string {
 	enc := func(v interface{}) string {
 		b, _ := json.Marshal(v)
@@ -432,6 +446,32 @@ func (suite *LogoutServiceTestSuite) TestResolve_IDTokenHintBadSignature() {
 	token := makeIDToken(testIssuer, "client-x")
 	jwtSvc.EXPECT().VerifyJWTSignature(mock.Anything, token).
 		Return(&tidcommon.ServiceError{Code: "bad", Type: tidcommon.ClientErrorType})
+
+	_, err := svc.Resolve(context.Background(), LogoutRequest{IDTokenHint: token})
+
+	suite.Require().ErrorIs(err, errInvalidIDTokenHint)
+}
+
+// An access token issued to an application with no configured default audience carries
+// aud=client_id, so it resolves to a valid client. It must still be rejected as an id_token_hint:
+// accepting it would let anyone holding such a token suppress the End-User sign-out confirmation.
+func (suite *LogoutServiceTestSuite) TestResolve_AccessTokenAsIDTokenHintRejected() {
+	svc, jwtSvc, _ := suite.newService()
+	token := makeTypedToken("at+jwt", testIssuer, "client-x", nil)
+	jwtSvc.EXPECT().VerifyJWTSignature(mock.Anything, token).Return(nil)
+
+	_, err := svc.Resolve(context.Background(), LogoutRequest{IDTokenHint: token})
+
+	suite.Require().ErrorIs(err, errInvalidIDTokenHint)
+}
+
+// A refresh token shares the generic JWT typ with ID tokens, so it is separated by its
+// access_token_sub claim, the same way the ID-JAG subject token check does it.
+func (suite *LogoutServiceTestSuite) TestResolve_RefreshTokenAsIDTokenHintRejected() {
+	svc, jwtSvc, _ := suite.newService()
+	token := makeTypedToken("JWT", testIssuer, "client-x",
+		map[string]interface{}{"access_token_sub": "user-1"})
+	jwtSvc.EXPECT().VerifyJWTSignature(mock.Anything, token).Return(nil)
 
 	_, err := svc.Resolve(context.Background(), LogoutRequest{IDTokenHint: token})
 


### PR DESCRIPTION
### Purpose
`clientIDFromIDTokenHint` verified only the signature and issuer of `id_token_hint`, with no token-class check. An access token issued to an application with no configured default audience carries `aud=client_id`, because `ResolveDefaultAudience` falls back to the client id, so such a token resolved to a valid client and was accepted as a hint. Expiry is intentionally not enforced per OIDC RP-Initiated Logout, so an expired access token worked too.

Prompt suppression keys on the hint being present, so anyone holding an access token for the target client could suppress the End-User sign-out confirmation. That confirmation is the mitigation for forced logout via cross-site navigation, so it must not be bypassable before deployments rely on it.

### Approach
The hint must now be an ID token. Its `typ` header must be the generic `JWT`, which rejects `at+jwt` access tokens, and an `access_token_sub` claim rejects the refresh tokens that share that `typ`. This mirrors the discrimination `ValidateIDJAGSubjectToken` already applies for the same problem.

The refresh-token check is defence in depth: a refresh token's `aud` is the issuer, so it normally fails client resolution, but `client_id` is caller-supplied on the application management API and nothing prevents registering a client whose id equals the issuer.

Signature and issuer verification are unchanged, and expiry stays unenforced so a legitimately expired ID token is still accepted.

### Related Issues
- Fixes #<issue>

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout security by rejecting access tokens and refresh tokens when provided as ID token hints.
  * Added validation to ensure ID token hints use the correct JWT type before processing.
* **Tests**
  * Added coverage for invalid token types and refresh-token claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->