### PR TITLE
Require id_token_hint to be an ID token at the logout endpoint

### DIFF
--- a/backend/internal/oauth/oauth2/logout/service.go
+++ b/backend/internal/oauth/oauth2/logout/service.go
@@ -221,15 +221,34 @@ func (s *logoutService) Resolve(ctx context.Context, req LogoutRequest) (*Logout
 	}, nil
 }
 
-// clientIDFromIDTokenHint verifies the id_token_hint was issued by this server (signature + issuer)
-// and returns its audience (the client id). The token's expiry is intentionally not enforced: per
-// OIDC RP-Initiated Logout, id_token_hint may be an expired ID token.
+// clientIDFromIDTokenHint verifies the id_token_hint was issued by this server (signature + issuer),
+// is an ID token rather than some other server-signed JWT, and returns its audience (the client id).
+// The token's expiry is intentionally not enforced: per OIDC RP-Initiated Logout, id_token_hint may
+// be an expired ID token.
+//
+// The token type has to be checked because an access token otherwise satisfies both the signature and
+// the issuer check, and resolves a client from its aud claim whenever the client configures no
+// defaultAudience (ResolveDefaultAudience falls back to the client id). That would let any holder of
+// an access token for the client suppress the End-User sign-out confirmation. The identification
+// mirrors ValidateIDJAGSubjectToken, which makes the same "must be an ID token" decision: the ID
+// token typ header, which access tokens ("at+jwt", RFC 9068) and ID-JAG assertions
+// ("oauth-id-jag+jwt") do not carry, plus the access_token_sub claim that marks a refresh token.
 func (s *logoutService) clientIDFromIDTokenHint(ctx context.Context, idTokenHint string) (string, error) {
 	if svcErr := s.jwtService.VerifyJWTSignature(ctx, idTokenHint); svcErr != nil {
 		return "", errInvalidIDTokenHint
 	}
+	header, err := jwt.DecodeJWTHeader(idTokenHint)
+	if err != nil {
+		return "", errInvalidIDTokenHint
+	}
+	if typ, _ := header["typ"].(string); typ != jwt.TokenTypeJWT {
+		return "", errInvalidIDTokenHint
+	}
 	payload, err := jwt.DecodeJWTPayload(idTokenHint)
 	if err != nil {
+		return "", errInvalidIDTokenHint
+	}
+	if _, isRefreshToken := payload["access_token_sub"]; isRefreshToken {
 		return "", errInvalidIDTokenHint
 	}
 	if iss, _ := payload[constants.ClaimIss].(string); iss != s.issuer {

--- a/backend/internal/oauth/oauth2/logout/service_test.go
+++ b/backend/internal/oauth/oauth2/logout/service_test.go
@@ -16,6 +16,7 @@ import (
 	flowcommon "github.com/thunder-id/thunderid/internal/flow/common"
 	"github.com/thunder-id/thunderid/internal/flow/flowexec"
 	"github.com/thunder-id/thunderid/internal/system/config"
+	"github.com/thunder-id/thunderid/internal/system/jose/jwt"
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 	"github.com/thunder-id/thunderid/tests/mocks/actorprovidermock"
@@ -309,6 +310,20 @@ func makeIDTokenMultiAud(iss string, aud []string, azp string) string {
 		enc(map[string]interface{}{"iss": iss, "aud": aud, "azp": azp}) + ".sig"
 }
 
+// makeTokenWithHeader builds an unsigned JWT carrying the given typ header (omitted when empty) and
+// claims, so the tests can present token shapes other than an ID token as id_token_hint.
+func makeTokenWithHeader(typ string, claims map[string]interface{}) string {
+	enc := func(v interface{}) string {
+		b, _ := json.Marshal(v)
+		return base64.RawURLEncoding.EncodeToString(b)
+	}
+	header := map[string]string{"alg": "RS256"}
+	if typ != "" {
+		header["typ"] = typ
+	}
+	return enc(header) + "." + enc(claims) + ".sig"
+}
+
 func (suite *LogoutServiceTestSuite) TestResolve_ClientIDWithRedirectWithoutIDTokenHint() {
 	svc, _, actor := suite.newService()
 	actor.EXPECT().GetOAuthClientByClientID(mock.Anything, "client-x").
@@ -452,6 +467,65 @@ func (suite *LogoutServiceTestSuite) TestResolve_IDTokenHintUndecodablePayload()
 	svc, jwtSvc, _ := suite.newService()
 	// Signature verification passes (mocked), but the payload segment is not valid base64url JSON.
 	token := "header.@@@notbase64@@@.sig"
+	jwtSvc.EXPECT().VerifyJWTSignature(mock.Anything, token).Return(nil)
+
+	_, err := svc.Resolve(context.Background(), LogoutRequest{IDTokenHint: token})
+
+	suite.Require().ErrorIs(err, errInvalidIDTokenHint)
+}
+
+// An access token satisfies the signature, issuer and audience checks (aud falls back to the client
+// id when no defaultAudience is configured), so only the typ header separates it from an ID token.
+func (suite *LogoutServiceTestSuite) TestResolve_IDTokenHintRejectsAccessToken() {
+	svc, jwtSvc, _ := suite.newService()
+	token := makeTokenWithHeader(jwt.TokenTypeAccessToken, map[string]interface{}{
+		"iss": testIssuer, "aud": "client-x", "client_id": "client-x",
+	})
+	jwtSvc.EXPECT().VerifyJWTSignature(mock.Anything, token).Return(nil)
+
+	_, err := svc.Resolve(context.Background(), LogoutRequest{IDTokenHint: token})
+
+	suite.Require().ErrorIs(err, errInvalidIDTokenHint)
+}
+
+func (suite *LogoutServiceTestSuite) TestResolve_IDTokenHintRejectsIDJAGAssertion() {
+	svc, jwtSvc, _ := suite.newService()
+	token := makeTokenWithHeader(jwt.TokenTypeIDJAG, map[string]interface{}{
+		"iss": testIssuer, "aud": "client-x",
+	})
+	jwtSvc.EXPECT().VerifyJWTSignature(mock.Anything, token).Return(nil)
+
+	_, err := svc.Resolve(context.Background(), LogoutRequest{IDTokenHint: token})
+
+	suite.Require().ErrorIs(err, errInvalidIDTokenHint)
+}
+
+// A refresh token carries the ID token typ, so the access_token_sub claim is what separates it.
+func (suite *LogoutServiceTestSuite) TestResolve_IDTokenHintRejectsRefreshToken() {
+	svc, jwtSvc, _ := suite.newService()
+	token := makeTokenWithHeader(jwt.TokenTypeJWT, map[string]interface{}{
+		"iss": testIssuer, "aud": "client-x", "sub": "client-x", "access_token_sub": "user-1",
+	})
+	jwtSvc.EXPECT().VerifyJWTSignature(mock.Anything, token).Return(nil)
+
+	_, err := svc.Resolve(context.Background(), LogoutRequest{IDTokenHint: token})
+
+	suite.Require().ErrorIs(err, errInvalidIDTokenHint)
+}
+
+func (suite *LogoutServiceTestSuite) TestResolve_IDTokenHintRejectsMissingTyp() {
+	svc, jwtSvc, _ := suite.newService()
+	token := makeTokenWithHeader("", map[string]interface{}{"iss": testIssuer, "aud": "client-x"})
+	jwtSvc.EXPECT().VerifyJWTSignature(mock.Anything, token).Return(nil)
+
+	_, err := svc.Resolve(context.Background(), LogoutRequest{IDTokenHint: token})
+
+	suite.Require().ErrorIs(err, errInvalidIDTokenHint)
+}
+
+func (suite *LogoutServiceTestSuite) TestResolve_IDTokenHintRejectsUndecodableHeader() {
+	svc, jwtSvc, _ := suite.newService()
+	token := "@@@notbase64@@@.payload.sig"
 	jwtSvc.EXPECT().VerifyJWTSignature(mock.Anything, token).Return(nil)
 
 	_, err := svc.Resolve(context.Background(), LogoutRequest{IDTokenHint: token})

--- a/docs/content/guides/protocols/oauth-oidc/rp-initiated-logout.mdx
+++ b/docs/content/guides/protocols/oauth-oidc/rp-initiated-logout.mdx
@@ -31,7 +31,7 @@ Whether the user is asked to confirm depends on the sign-out flow. <ProductName 
 | Endpoint | `GET`/`POST /oauth2/logout` |
 | Discovery | Advertised as `end_session_endpoint` in `/.well-known/openid-configuration`, see [Server Metadata](../server-metadata) |
 | Session termination | Runs the application's sign-out flow, which ends the SSO session and clears the per-flow cookie, see [Sessions and Single Sign-On](../../../../key-concepts/authentication/sessions) |
-| `id_token_hint` | Optional. When supplied, its signature and issuer are verified; expiry is **not** enforced, so an expired ID token is accepted. When omitted, the request is flagged as needing confirmation, which a sign-out flow can branch on |
+| `id_token_hint` | Optional. When supplied, it must be an ID token, and its signature and issuer are verified; expiry is **not** enforced, so an expired ID token is accepted. Another token issued by <ProductName />, such as an access token or a refresh token, is rejected. When omitted, the request is flagged as needing confirmation, which a sign-out flow can branch on |
 | Redirect validation | `post_logout_redirect_uri` must match one of the client's registered `postLogoutRedirectUris` exactly. Registered wildcard patterns also match when the server sets `allow_wildcard_redirect_uri` to `true`, which is off by default |
 | Sign-out flow | Resolved in order: the flow the application pins, then the default on its organization unit, then the server-level default |
 
@@ -59,6 +59,7 @@ The endpoint accepts the same request as either an HTTP `GET` or an HTTP `POST`,
 
 - `post_logout_redirect_uri` does not exactly match a URI registered on the client.
 - `id_token_hint` is present but was not signed by <ProductName /> or carries a different issuer.
+- `id_token_hint` is present but is not an ID token, for example an access token or a refresh token.
 - both `id_token_hint` and `client_id` are present and identify different clients.
 - neither `id_token_hint` nor `client_id` is supplied.
 - the client id, whether supplied as `client_id` or derived from `id_token_hint`, does not resolve to a registered client.

--- a/tests/integration/oauth/sso/logout_negative_test.go
+++ b/tests/integration/oauth/sso/logout_negative_test.go
@@ -183,6 +183,33 @@ func (ts *SSOLogoutTestSuite) TestLogoutRejectsIDTokenHintWithForeignIssuer() {
 	ts.Equal(errInvalidIDTokenHint, strings.TrimSpace(body))
 }
 
+// TestLogoutRejectsAccessTokenAsIDTokenHint isolates the token type check. The access token from a
+// real login is signed by this server and carries the correct issuer, and its aud falls back to the
+// client id because the application configures no defaultAudience, so it satisfies every other check
+// the endpoint makes. Supplying any hint suppresses the End-User sign-out confirmation, so accepting
+// a non ID token would hand that suppression to any holder of an access token for the client. The
+// id_token from the same login is the control: it is still accepted, which proves the rejection is
+// about the token type rather than the session, the client or the issuer.
+func (ts *SSOLogoutTestSuite) TestLogoutRejectsAccessTokenAsIDTokenHint() {
+	tokens := ts.loginTokens(ts.newSessionClient(), logoutUsername, "logout_hint_type_state_1")
+	ts.Require().NotEmpty(tokens.AccessToken, "the login should issue an access token")
+	ts.Require().NotEmpty(tokens.IDToken, "the login should issue an id_token")
+
+	controlParams := url.Values{}
+	controlParams.Set("id_token_hint", tokens.IDToken)
+	controlStatus, controlLocation, controlBody := ts.rawLogout(ts.newSessionClient(), http.MethodPost, controlParams)
+	ts.Require().Equal(http.StatusFound, controlStatus,
+		"the id_token from the same login proves the hint is otherwise acceptable: %s", strings.TrimSpace(controlBody))
+	ts.Require().NotEmpty(controlLocation, "the control hint should redirect to the gate sign-out page")
+
+	params := url.Values{}
+	params.Set("id_token_hint", tokens.AccessToken)
+
+	status, _, body := ts.rawLogout(ts.newSessionClient(), http.MethodPost, params)
+	ts.Equal(http.StatusBadRequest, status, "an access token must not be accepted as an id_token_hint")
+	ts.Equal(errInvalidIDTokenHint, strings.TrimSpace(body))
+}
+
 // TestLogoutRejectsRequestWithoutHintOrClientID checks the endpoint refuses a request that names no
 // client at all, rather than guessing one.
 func (ts *SSOLogoutTestSuite) TestLogoutRejectsRequestWithoutHintOrClientID() {


### PR DESCRIPTION
### Purpose

Fixes #4990.

`GET/POST /oauth2/logout` accepted any server-signed JWT as `id_token_hint`. `clientIDFromIDTokenHint` checked the signature and the issuer and then went straight to the audience, so nothing constrained the token type. An access token issued to an application with no configured `defaultAudience` carries `aud=client_id` (`ResolveDefaultAudience` falls back to the client id), so it satisfied both checks and resolved a client. Expiry is deliberately not enforced for `id_token_hint` per OIDC RP-Initiated Logout, so an expired access token was accepted as well.

Because supplying a hint suppresses the End-User sign-out confirmation, any holder of an access token for the target client could suppress it.

### Approach

The codebase already answers "is this an ID token" in `tokenservice.ValidateIDJAGSubjectToken`, which makes the same decision for `subject_token`. I mirrored it rather than inventing a second rule:

- Require the ID token `typ` header. Access tokens are typed `at+jwt` (RFC 9068) and ID-JAG assertions `oauth-id-jag+jwt`, so this rejects both.
- Reject the `access_token_sub` claim, which marks a refresh token. Refresh tokens share the ID token `typ`, so the header alone does not separate them.

Both failures return the existing `errInvalidIDTokenHint`, so the response is unchanged and the endpoint does not reveal which check refused the token.

Refresh tokens were already unreachable in practice, since their `aud` is the issuer rather than a client id and so resolved no client a step later. I rejected them explicitly anyway, because that is what the existing ID token check does and relying on a downstream accident is fragile.

### Related Issues
- Fixes #4990

### Related PRs
- N/A

### Validation

- Go 1.26.5
- `go test ./internal/oauth/...`: 25 packages pass
- Full backend unit suite: 136 packages, 0 failures
- `golangci-lint run ./internal/oauth/...`: 0 issues
- `mockery` from both configs produces no diff, since no interface changed
- Neutralised both new checks locally to confirm the added tests catch the defect: the four rejection tests fail, the rest still pass

Unit tests cover an access token, an ID-JAG assertion, a refresh token, a missing `typ` and an undecodable header. The integration test in `logout_negative_test.go` uses a real access token from a real login, with the `id_token` from that same login as the control, so the rejection is shown to be about the token type rather than the session, client or issuer.

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved logout validation to reject access tokens, refresh tokens, ID-JAG assertions, and malformed tokens used as an ID-token hint.
  - Tokens missing a valid JWT type or containing refresh-token markers now return an `invalid id_token_hint` error.
  - Valid ID tokens continue to be accepted for logout.

- **Documentation**
  - Clarified that only ID tokens are valid for the `id_token_hint` parameter.

- **Tests**
  - Added coverage for invalid token types, malformed headers, and access-token rejection in integration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->