### PR TITLE
Remove client_id binding check from ID-JAG assertion validation

### DIFF
--- a/backend/internal/oauth/oauth2/granthandlers/jwt_bearer.go
+++ b/backend/internal/oauth/oauth2/granthandlers/jwt_bearer.go
@@ -79,7 +79,7 @@ func (h *jwtBearerGrantHandler) HandleGrant(ctx context.Context, tokenRequest *m
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "JWTBearerGrantHandler"))
 
 	assertionClaims, err := h.tokenValidator.ValidateIDJAGAssertion(
-		ctx, tokenRequest.Assertion, tokenRequest.ClientID)
+		ctx, tokenRequest.Assertion)
 	if err != nil {
 		logger.Debug(ctx, "Failed to validate ID-JAG assertion", log.Error(err))
 		switch {

--- a/backend/internal/oauth/oauth2/granthandlers/jwt_bearer_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/jwt_bearer_test.go
@@ -144,7 +144,7 @@ func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_Success() {
 		Assertion: testAssertion,
 	}
 
-	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion, testClientID).
+	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion).
 		Return(&tokenservice.IDJAGAssertionClaims{
 			Sub:    testUserID,
 			Iss:    testCustomIssuer,
@@ -190,7 +190,7 @@ func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_DPoPProof_Propagate
 		Assertion: testAssertion,
 	}
 
-	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion, testClientID).
+	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion).
 		Return(&tokenservice.IDJAGAssertionClaims{
 			Sub:    testUserID,
 			Iss:    testCustomIssuer,
@@ -226,7 +226,7 @@ func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_InvalidAssertion() 
 		Assertion: testAssertion,
 	}
 
-	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion, testClientID).
+	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion).
 		Return(nil, errors.New("assertion audience does not match server issuer"))
 
 	result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
@@ -276,7 +276,7 @@ func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_AssertionRejectionR
 				ClientID:  testClientID,
 				Assertion: testAssertion,
 			}
-			suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion, testClientID).
+			suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion).
 				Return(nil, tc.validationErr)
 
 			result, errResp := suite.handler.HandleGrant(context.Background(), tokenRequest, suite.oauthApp)
@@ -302,7 +302,7 @@ func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_ScopeIntersection()
 
 	// Assertion carries [read write], request narrows to [read admin]. Only "read" survives the
 	// intersection; "write" was not requested, "admin" was not asserted.
-	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion, testClientID).
+	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion).
 		Return(&tokenservice.IDJAGAssertionClaims{
 			Sub:    testUserID,
 			Iss:    testCustomIssuer,
@@ -342,7 +342,7 @@ func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_EmptyAppScopes_Asse
 		Assertion: testAssertion,
 	}
 
-	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion, testClientID).
+	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion).
 		Return(&tokenservice.IDJAGAssertionClaims{
 			Sub:    testUserID,
 			Iss:    testCustomIssuer,
@@ -381,7 +381,7 @@ func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_AssertionResource_A
 		Assertion: testAssertion,
 	}
 
-	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion, testClientID).
+	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion).
 		Return(&tokenservice.IDJAGAssertionClaims{
 			Sub:       testUserID,
 			Iss:       testCustomIssuer,
@@ -433,7 +433,7 @@ func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_AssertionNoResource
 		Assertion: testAssertion,
 	}
 
-	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion, testClientID).
+	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion).
 		Return(&tokenservice.IDJAGAssertionClaims{
 			Sub:    testUserID,
 			Iss:    testCustomIssuer,
@@ -459,7 +459,7 @@ func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_RequestResourceNarr
 		Resources: []string{testRS01URI},
 	}
 
-	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion, testClientID).
+	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion).
 		Return(&tokenservice.IDJAGAssertionClaims{
 			Sub:       testUserID,
 			Iss:       testCustomIssuer,
@@ -499,7 +499,7 @@ func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_RequestResourceNotI
 		Resources: []string{"https://not-granted.example.com"},
 	}
 
-	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion, testClientID).
+	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion).
 		Return(&tokenservice.IDJAGAssertionClaims{
 			Sub:       testUserID,
 			Iss:       testCustomIssuer,
@@ -521,7 +521,7 @@ func (suite *JWTBearerGrantHandlerTestSuite) TestHandleGrant_TokenBuildError() {
 		Assertion: testAssertion,
 	}
 
-	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion, testClientID).
+	suite.mockTokenValidator.On("ValidateIDJAGAssertion", mock.Anything, testAssertion).
 		Return(&tokenservice.IDJAGAssertionClaims{
 			Sub:    testUserID,
 			Iss:    testCustomIssuer,

--- a/backend/internal/oauth/oauth2/tokenservice/validator.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator.go
@@ -44,9 +44,8 @@ type TokenValidatorInterface interface {
 	// refresh token into an ID-JAG.
 	ValidateIDJAGSubjectToken(ctx context.Context, token string, oauthApp *providers.OAuthClient) (
 		*SubjectTokenClaims, error)
-	// ValidateIDJAGAssertion validates an ID-JAG assertion presented on the jwt-bearer grant,
-	// binding it to the authenticated client via its client_id claim.
-	ValidateIDJAGAssertion(ctx context.Context, assertion, clientID string) (*IDJAGAssertionClaims, error)
+	// ValidateIDJAGAssertion validates an ID-JAG assertion presented on the jwt-bearer grant.
+	ValidateIDJAGAssertion(ctx context.Context, assertion string) (*IDJAGAssertionClaims, error)
 }
 
 // TokenValidator implements TokenValidatorInterface.
@@ -326,12 +325,11 @@ func (tv *tokenValidator) ValidateIDJAGSubjectToken(
 // ValidateIDJAGAssertion validates an ID-JAG assertion presented on the jwt-bearer grant
 // (draft-ietf-oauth-identity-assertion-authz-grant). It requires the oauth-id-jag+jwt typ header,
 // resolves the assertion's issuer to a trusted external IdP with ID-JAG enabled, verifies the
-// signature against that IdP's JWKS, validates the time claims, requires the audience to equal this
-// server's issuer, and binds the assertion to the authenticated client via the client_id claim.
+// signature against that IdP's JWKS, validates the time claims, and requires the audience to equal
+// this server's issuer.
 func (tv *tokenValidator) ValidateIDJAGAssertion(
 	ctx context.Context,
 	assertion string,
-	clientID string,
 ) (*IDJAGAssertionClaims, error) {
 	header, err := jwt.DecodeJWTHeader(assertion)
 	if err != nil {
@@ -389,12 +387,8 @@ func (tv *tokenValidator) ValidateIDJAGAssertion(
 			ErrAudienceNotAccepted, serverIssuer)
 	}
 
-	assertionClientID, err := extractStringClaim(claims, "client_id")
-	if err != nil {
+	if _, err := extractStringClaim(claims, "client_id"); err != nil {
 		return nil, fmt.Errorf("assertion is missing 'client_id' claim: %w", err)
-	}
-	if assertionClientID != clientID {
-		return nil, fmt.Errorf("assertion 'client_id' does not match the authenticated client")
 	}
 
 	sub, err := extractStringClaim(claims, "sub")

--- a/backend/internal/oauth/oauth2/tokenservice/validator_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/validator_test.go
@@ -2985,7 +2985,7 @@ func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_Success() {
 	suite.mockJTIStore.On("RecordJTI", mock.Anything, idjagJTINamespace, testIDJAGAssertionJTI,
 		mock.AnythingOfType("time.Time")).Return(true, nil)
 
-	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -3008,7 +3008,7 @@ func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_SingleResourceC
 	suite.mockJTIStore.On("RecordJTI", mock.Anything, idjagJTINamespace, testIDJAGAssertionJTI,
 		mock.AnythingOfType("time.Time")).Return(true, nil)
 
-	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -3026,7 +3026,7 @@ func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_MultipleResourc
 	suite.mockJTIStore.On("RecordJTI", mock.Anything, idjagJTINamespace, testIDJAGAssertionJTI,
 		mock.AnythingOfType("time.Time")).Return(true, nil)
 
-	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -3042,7 +3042,7 @@ func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_NoResourceClaim
 	suite.mockJTIStore.On("RecordJTI", mock.Anything, idjagJTINamespace, testIDJAGAssertionJTI,
 		mock.AnythingOfType("time.Time")).Return(true, nil)
 
-	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -3052,7 +3052,7 @@ func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_NoResourceClaim
 func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_WrongTyp() {
 	assertion := suite.createAssertion(jwt.TokenTypeJWT, suite.idjagClaims())
 
-	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -3065,7 +3065,7 @@ func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_UntrustedIssuer
 	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
 		idp.PropIssuer, testExternalIssuer).Return([]providers.IDPDTO{}, nil)
 
-	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -3086,7 +3086,7 @@ func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_IDJagNotEnabled
 	suite.mockIDPService.On("GetIdentityProvidersByProperty", context.Background(),
 		idp.PropIssuer, testExternalIssuer).Return(idpDTOs, nil)
 
-	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -3109,7 +3109,7 @@ func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_InvalidSignatur
 			},
 		})
 
-	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -3128,7 +3128,7 @@ func (suite *IDJAGValidatorTestSuite) assertRejectsSignedAssertion(
 		idp.PropIssuer, testExternalIssuer).Return(buildIDJAGIDPDTOs(), nil)
 	suite.mockJWTService.On("VerifyJWTSignatureWithJWKS", mock.Anything, assertion, testExternalJWKS).Return(nil)
 
-	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -3176,12 +3176,6 @@ func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_AudMismatch() {
 	suite.assertRejectsSignedAssertion(claims, "assertion audience does not match server issuer")
 }
 
-func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_ClientIDMismatch() {
-	claims := suite.idjagClaims()
-	claims["client_id"] = "a-different-client"
-	suite.assertRejectsSignedAssertion(claims, "does not match the authenticated client")
-}
-
 func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_MissingClientIDClaim() {
 	claims := suite.idjagClaims()
 	delete(claims, "client_id")
@@ -3208,7 +3202,7 @@ func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_SingleElementAu
 	suite.mockJTIStore.On("RecordJTI", mock.Anything, idjagJTINamespace, testIDJAGAssertionJTI,
 		mock.AnythingOfType("time.Time")).Return(true, nil)
 
-	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion)
 
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
@@ -3227,7 +3221,7 @@ func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_ReplayedJTI() {
 	suite.mockJTIStore.On("RecordJTI", mock.Anything, idjagJTINamespace, testIDJAGAssertionJTI,
 		mock.AnythingOfType("time.Time")).Return(false, nil)
 
-	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)
@@ -3244,7 +3238,7 @@ func (suite *IDJAGValidatorTestSuite) TestValidateIDJAGAssertion_JTIStoreError()
 	suite.mockJTIStore.On("RecordJTI", mock.Anything, idjagJTINamespace, testIDJAGAssertionJTI,
 		mock.AnythingOfType("time.Time")).Return(false, fmt.Errorf("store unavailable"))
 
-	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion, testClientID)
+	result, err := suite.validator.ValidateIDJAGAssertion(context.Background(), assertion)
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), result)

--- a/backend/tests/mocks/oauth/oauth2/tokenservicemock/TokenValidatorInterface_mock.go
+++ b/backend/tests/mocks/oauth/oauth2/tokenservicemock/TokenValidatorInterface_mock.go
@@ -108,8 +108,8 @@ func (_c *TokenValidatorInterfaceMock_ValidateAccessToken_Call) RunAndReturn(run
 }
 
 // ValidateIDJAGAssertion provides a mock function for the type TokenValidatorInterfaceMock
-func (_mock *TokenValidatorInterfaceMock) ValidateIDJAGAssertion(ctx context.Context, assertion string, clientID string) (*tokenservice.IDJAGAssertionClaims, error) {
-	ret := _mock.Called(ctx, assertion, clientID)
+func (_mock *TokenValidatorInterfaceMock) ValidateIDJAGAssertion(ctx context.Context, assertion string) (*tokenservice.IDJAGAssertionClaims, error) {
+	ret := _mock.Called(ctx, assertion)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ValidateIDJAGAssertion")
@@ -117,18 +117,18 @@ func (_mock *TokenValidatorInterfaceMock) ValidateIDJAGAssertion(ctx context.Con
 
 	var r0 *tokenservice.IDJAGAssertionClaims
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*tokenservice.IDJAGAssertionClaims, error)); ok {
-		return returnFunc(ctx, assertion, clientID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*tokenservice.IDJAGAssertionClaims, error)); ok {
+		return returnFunc(ctx, assertion)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *tokenservice.IDJAGAssertionClaims); ok {
-		r0 = returnFunc(ctx, assertion, clientID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *tokenservice.IDJAGAssertionClaims); ok {
+		r0 = returnFunc(ctx, assertion)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*tokenservice.IDJAGAssertionClaims)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = returnFunc(ctx, assertion, clientID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, assertion)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -143,12 +143,11 @@ type TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call struct {
 // ValidateIDJAGAssertion is a helper method to define mock.On call
 //   - ctx context.Context
 //   - assertion string
-//   - clientID string
-func (_e *TokenValidatorInterfaceMock_Expecter) ValidateIDJAGAssertion(ctx interface{}, assertion interface{}, clientID interface{}) *TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call {
-	return &TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call{Call: _e.mock.On("ValidateIDJAGAssertion", ctx, assertion, clientID)}
+func (_e *TokenValidatorInterfaceMock_Expecter) ValidateIDJAGAssertion(ctx interface{}, assertion interface{}) *TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call {
+	return &TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call{Call: _e.mock.On("ValidateIDJAGAssertion", ctx, assertion)}
 }
 
-func (_c *TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call) Run(run func(ctx context.Context, assertion string, clientID string)) *TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call {
+func (_c *TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call) Run(run func(ctx context.Context, assertion string)) *TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -158,14 +157,9 @@ func (_c *TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call) Run(run func(
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
 		run(
 			arg0,
 			arg1,
-			arg2,
 		)
 	})
 	return _c
@@ -176,7 +170,7 @@ func (_c *TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call) Return(iDJAGA
 	return _c
 }
 
-func (_c *TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call) RunAndReturn(run func(ctx context.Context, assertion string, clientID string) (*tokenservice.IDJAGAssertionClaims, error)) *TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call {
+func (_c *TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call) RunAndReturn(run func(ctx context.Context, assertion string) (*tokenservice.IDJAGAssertionClaims, error)) *TokenValidatorInterfaceMock_ValidateIDJAGAssertion_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/tests/integration/oauth/idjag/idjag_consumption_test.go
+++ b/tests/integration/oauth/idjag/idjag_consumption_test.go
@@ -592,15 +592,16 @@ func (ts *IDJAGConsumptionTestSuite) TestIDJAGConsumption_AudienceMismatch() {
 	ts.Equal("invalid_grant", resp.Error)
 }
 
-func (ts *IDJAGConsumptionTestSuite) TestIDJAGConsumption_ClientIDMismatch() {
+func (ts *IDJAGConsumptionTestSuite) TestIDJAGConsumption_CrossClientExchange() {
 	assertion := ts.buildIDJAGAssertion(func(h, c map[string]interface{}) {
-		c["client_id"] = "wrong-client-id"
+		c["client_id"] = "external-source-client"
 	})
 
 	resp, statusCode, err := ts.consumeIDJAG(assertion, nil, consumptionClientID, consumptionClientSecret)
 	ts.Require().NoError(err)
-	ts.Equal(http.StatusBadRequest, statusCode)
-	ts.Equal("invalid_grant", resp.Error)
+	ts.Equal(http.StatusOK, statusCode)
+	ts.NotEmpty(resp.AccessToken)
+	ts.Equal("Bearer", resp.TokenType)
 }
 
 func (ts *IDJAGConsumptionTestSuite) TestIDJAGConsumption_WrongTypHeader() {


### PR DESCRIPTION
### Purpose

Fixes the ID-JAG assertion validation in `ValidateIDJAGAssertion` which incorrectly required the assertion's `client_id` claim to match the presenting client's ID. This blocked cross-client/cross-IdP token exchange — the primary use case for the jwt-bearer grant with ID-JAG assertions, where an external IdP issues an ID-JAG token with its own `client_id` and a different local client presents it.

### Approach

Removed the `clientID` parameter from the `ValidateIDJAGAssertion` interface and implementation, and changed the `client_id` claim validation from an equality check to a presence-only check. The claim is still required per the spec (`draft-ietf-oauth-identity-assertion-authz-grant`), but its value no longer needs to match the authenticated client.

**Changes:**
- `validator.go`: Removed `clientID` param from interface and method; replaced equality check with presence-only validation
- `jwt_bearer.go`: Updated call site to no longer pass `tokenRequest.ClientID`
- `jwt_bearer_test.go`: Updated 12 mock expectations
- `validator_test.go`: Updated 17 call sites; removed the `ClientIDMismatch` test case; kept the `MissingClientIDClaim` test
- Regenerated `TokenValidatorInterface_mock.go` via `make mockery`

### Related Issues
- Fixes #4967

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ID-JAG assertions can now be exchanged across clients when the assertion contains a valid `client_id` claim.
  * Cross-client token exchanges now support successful bearer-token issuance.
* **Bug Fixes**
  * Continued validation for missing or invalid client ID claims.
* **Tests**
  * Expanded coverage for cross-client exchanges and updated validation scenarios, including success, errors, scopes, resources, and token creation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->