### PR TITLE
Display nested child organization unit hierarchy

### DIFF
--- a/frontend/packages/configure-organization-units/src/components/OrganizationUnitTreePicker.tsx
+++ b/frontend/packages/configure-organization-units/src/components/OrganizationUnitTreePicker.tsx
@@ -33,6 +33,7 @@ interface PickerTreeItemProps extends TreeView.TreeItemProps {
   loadingItems?: Set<string>;
   loadMoreLoadingItems?: Set<string>;
   onLoadMore?: (parentId: string) => void;
+  onItemActivate?: (itemId: string) => void;
   spacious?: boolean;
 }
 
@@ -42,6 +43,7 @@ function PickerTreeItem(allProps: PickerTreeItemProps): JSX.Element {
     loadingItems: loadingItemsProp,
     loadMoreLoadingItems: loadMoreLoadingItemsProp,
     onLoadMore: onLoadMoreProp,
+    onItemActivate: onItemActivateProp,
     spacious = false,
     itemId,
     label,
@@ -167,7 +169,24 @@ function PickerTreeItem(allProps: PickerTreeItemProps): JSX.Element {
       {...treeItemProps}
       {...(isItemLoading ? {slots: {collapseIcon: PickerLoadingIcon, expandIcon: PickerLoadingIcon}} : {})}
       label={
-        <Box sx={{display: 'flex', alignItems: 'center', gap: spacious ? 2 : 1.5}}>
+        <Box
+          role={onItemActivateProp ? 'button' : undefined}
+          tabIndex={onItemActivateProp ? 0 : undefined}
+          onClick={(event) => {
+            if (onItemActivateProp) {
+              event.stopPropagation();
+              onItemActivateProp(itemId);
+            }
+          }}
+          onKeyDown={(event) => {
+            if (onItemActivateProp && (event.key === 'Enter' || event.key === ' ')) {
+              event.preventDefault();
+              event.stopPropagation();
+              onItemActivateProp(itemId);
+            }
+          }}
+          sx={{display: 'flex', alignItems: 'center', gap: spacious ? 2 : 1.5}}
+        >
           <ResourceAvatar
             variant="rounded"
             value={itemData?.logoUrl}
@@ -194,9 +213,17 @@ interface OrganizationUnitTreePickerProps {
   id?: string;
   value: string;
   onChange: (ouId: string) => void;
+  /**
+   * Handles explicit activation of an OU row without treating expansion clicks as selection.
+   */
+  onItemActivate?: (ouId: string) => void;
   error?: boolean;
   helperText?: string;
   rootOuId?: string;
+  /**
+   * Hides the configured root OU and renders its direct children as the first visible level.
+   */
+  hideRoot?: boolean;
   maxHeight?: number;
   /**
    * Renders larger rows with softer, borderless cards and no dashed nesting guide, for standalone
@@ -214,9 +241,11 @@ export default function OrganizationUnitTreePicker({
   id = undefined,
   value,
   onChange,
+  onItemActivate = undefined,
   error = false,
   helperText = '',
   rootOuId = undefined,
+  hideRoot = false,
   maxHeight = 300,
   spacious = false,
   autoSelectFirst = false,
@@ -244,7 +273,7 @@ export default function OrganizationUnitTreePicker({
     isLoading: isRootOuLoading,
     error: rootOuError,
     refetch: refetchRootOu,
-  } = useGetOrganizationUnit(rootOuId);
+  } = useGetOrganizationUnit(rootOuId, !hideRoot);
   const {
     data: rootOuChildrenData,
     isLoading: isRootOuChildrenLoading,
@@ -304,7 +333,7 @@ export default function OrganizationUnitTreePicker({
   // change (e.g. t reference), preserving user-expanded subtrees and loaded-more items.
   // The reset effect on rootOuId change clears treeItems to [], allowing this to rebuild.
   useEffect(() => {
-    if (!rootOuId || !rootOuData || !rootOuChildrenData || treeItems.length > 0) return;
+    if (!rootOuId || (!hideRoot && !rootOuData) || !rootOuChildrenData || treeItems.length > 0) return;
 
     const childItems = buildTreeItems(rootOuChildrenData.organizationUnits);
 
@@ -316,6 +345,27 @@ export default function OrganizationUnitTreePicker({
         isPlaceholder: true,
       });
     }
+
+    if (hideRoot) {
+      const visibleItems: OrganizationUnitTreeItem[] =
+        rootOuChildrenData.organizationUnits.length > 0
+          ? childItems
+          : [
+              {
+                id: `${rootOuId}${OrganizationUnitTreeConstants.EMPTY_SUFFIX}`,
+                label: t('organizationUnits:listing.treeView.noChildren'),
+                handle: '',
+                isPlaceholder: true,
+              },
+            ];
+
+      setChildOffsets((prev) => new Map(prev).set(rootOuId, rootOuChildrenData.organizationUnits.length));
+      setTreeItems(visibleItems);
+
+      return;
+    }
+
+    if (!rootOuData) return;
 
     // If no children, show the root OU as a leaf node
     const rootChildren: OrganizationUnitTreeItem[] =
@@ -343,7 +393,7 @@ export default function OrganizationUnitTreePicker({
     setLoadedItems((prev) => new Set(prev).add(rootOuId));
     setExpandedItems([rootOuId]);
     setTreeItems([rootItem]);
-  }, [rootOuId, rootOuData, rootOuChildrenData, treeItems.length, t]);
+  }, [rootOuId, hideRoot, rootOuData, rootOuChildrenData, treeItems.length, t]);
 
   const fetchChildPage = useCallback(
     async (parentId: string, offset: number): Promise<OrganizationUnitListResponse> =>
@@ -483,7 +533,16 @@ export default function OrganizationUnitTreePicker({
         const newItems = buildChildItems(parentId, result, offset);
 
         setChildOffsets((prev) => new Map(prev).set(parentId, offset + result.organizationUnits.length));
-        setTreeItems((prev) => appendTreeItemChildren(prev, parentId, newItems));
+        setTreeItems((prev) => {
+          if (hideRoot && parentId === rootOuId) {
+            const loadMoreId = `${parentId}${OrganizationUnitTreeConstants.LOAD_MORE_SUFFIX}`;
+            const withoutLoadMore = prev.filter((item) => item.id !== loadMoreId);
+
+            return [...withoutLoadMore, ...newItems];
+          }
+
+          return appendTreeItemChildren(prev, parentId, newItems);
+        });
       } catch (_error: unknown) {
         logger.error('Failed to load more child organization units', {error: _error, parentId});
       } finally {
@@ -495,7 +554,7 @@ export default function OrganizationUnitTreePicker({
         });
       }
     },
-    [childOffsets, fetchChildPage, buildChildItems, logger, handleRootLoadMore],
+    [childOffsets, fetchChildPage, buildChildItems, hideRoot, rootOuId, logger, handleRootLoadMore],
   );
 
   const combinedLoadMoreLoadingItems = useMemo(() => {
@@ -551,8 +610,8 @@ export default function OrganizationUnitTreePicker({
     [handleLoadMore, logger],
   );
 
-  const isTreeLoading = rootOuId ? isRootOuLoading || isRootOuChildrenLoading : isLoading;
-  const activeError = rootOuId ? (rootOuError ?? rootOuChildrenError) : rootListError;
+  const isTreeLoading = rootOuId ? (!hideRoot && isRootOuLoading) || isRootOuChildrenLoading : isLoading;
+  const activeError = rootOuId ? ((!hideRoot ? rootOuError : null) ?? rootOuChildrenError) : rootListError;
 
   if (isTreeLoading) {
     return <PageLoadingAnimation />;
@@ -568,7 +627,7 @@ export default function OrganizationUnitTreePicker({
         fallbackDefaultValue="Failed to load organization unit data"
         onRetry={() => {
           if (rootOuId) {
-            if (rootOuError) void refetchRootOu();
+            if (!hideRoot && rootOuError) void refetchRootOu();
             if (rootOuChildrenError) void refetchRootOuChildren();
           } else {
             void refetchRootList();
@@ -582,6 +641,14 @@ export default function OrganizationUnitTreePicker({
     return (
       <Typography variant="body2" color="text.secondary">
         {t('organizationUnits:treePicker.empty')}
+      </Typography>
+    );
+  }
+
+  if (hideRoot && rootOuChildrenData?.organizationUnits.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary" sx={{px: 1, py: 0.75}}>
+        {t('organizationUnits:listing.treeView.noChildren')}
       </Typography>
     );
   }
@@ -602,6 +669,7 @@ export default function OrganizationUnitTreePicker({
           onItemExpansionToggle={handleItemExpansionToggle}
           selectedItems={value || null}
           onSelectedItemsChange={handleSelectedItemsChange}
+          disableSelection={Boolean(onItemActivate)}
           slots={{item: PickerTreeItem}}
           slotProps={{
             item: {
@@ -609,6 +677,7 @@ export default function OrganizationUnitTreePicker({
               loadingItems,
               loadMoreLoadingItems: combinedLoadMoreLoadingItems,
               onLoadMore: handleLoadMoreWithErrorLogging,
+              onItemActivate,
               spacious,
             } as Record<string, unknown>,
           }}

--- a/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitTreePicker.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/__tests__/OrganizationUnitTreePicker.test.tsx
@@ -27,8 +27,8 @@ vi.mock('@/api/useGetOrganizationUnits', () => ({
 
 const mockUseGetOrganizationUnit = vi.fn();
 vi.mock('@/api/useGetOrganizationUnit', () => ({
-  default: () =>
-    mockUseGetOrganizationUnit() as {
+  default: (id: string | undefined, enabled?: boolean) =>
+    mockUseGetOrganizationUnit(id, enabled) as {
       data: OrganizationUnit | undefined;
       isLoading: boolean;
       error: Error | null;
@@ -37,8 +37,8 @@ vi.mock('@/api/useGetOrganizationUnit', () => ({
 
 const mockUseGetChildOrganizationUnits = vi.fn();
 vi.mock('@/api/useGetChildOrganizationUnits', () => ({
-  default: () =>
-    mockUseGetChildOrganizationUnits() as {
+  default: (parentId: string | undefined) =>
+    mockUseGetChildOrganizationUnits(parentId) as {
       data: OrganizationUnitListResponse | undefined;
       isLoading: boolean;
       error: Error | null;
@@ -684,6 +684,188 @@ describe('OrganizationUnitTreePicker', () => {
         expect(screen.getByText('Child One')).toBeInTheDocument();
         expect(screen.getByText('Child Two')).toBeInTheDocument();
       });
+    });
+
+    it('should render only the root OU children when the root is hidden', async () => {
+      mockUseGetOrganizationUnit.mockReturnValue({data: undefined, isLoading: true, error: null});
+      mockUseGetChildOrganizationUnits.mockReturnValue({data: childOUsResponse, isLoading: false, error: null});
+
+      renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} rootOuId="root-ou-1" hideRoot />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Child One')).toBeInTheDocument();
+        expect(screen.getByText('Child Two')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('Root OU')).not.toBeInTheDocument();
+      expect(mockUseGetOrganizationUnit).toHaveBeenCalledWith('root-ou-1', false);
+      expect(mockUseGetChildOrganizationUnits).toHaveBeenCalledWith('root-ou-1');
+    });
+
+    it('should lazy-load nested children when a visible child is expanded', async () => {
+      const onItemActivate = vi.fn();
+      const nestedChildResponse: OrganizationUnitListResponse = {
+        totalResults: 1,
+        startIndex: 1,
+        count: 1,
+        organizationUnits: [
+          {
+            id: 'grandchild-1',
+            handle: 'grandchild-1-handle',
+            name: 'Grandchild One',
+            description: null,
+            parent: 'child-1',
+          },
+        ],
+      };
+      mockUseGetOrganizationUnit.mockReturnValue({data: undefined, isLoading: false, error: null});
+      mockUseGetChildOrganizationUnits.mockReturnValue({data: childOUsResponse, isLoading: false, error: null});
+      mockHttpRequest.mockResolvedValue({data: nestedChildResponse});
+
+      renderWithProviders(
+        <OrganizationUnitTreePicker {...defaultProps} rootOuId="root-ou-1" hideRoot onItemActivate={onItemActivate} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Child One')).toBeInTheDocument();
+      });
+
+      const expandIcons = document.querySelectorAll('.MuiTreeItem-iconContainer');
+      fireEvent.click(expandIcons[0]);
+
+      await waitFor(() => {
+        const request = mockHttpRequest.mock.calls[0]?.[0] as {url: string} | undefined;
+        expect(request?.url).toContain('/organization-units/child-1/ous');
+        expect(screen.getByText('Grandchild One')).toBeInTheDocument();
+      });
+      expect(onItemActivate).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByText('Grandchild One'));
+      expect(onItemActivate).toHaveBeenCalledWith('grandchild-1');
+    });
+
+    it('should activate a visible child from the keyboard', async () => {
+      const onItemActivate = vi.fn();
+      mockUseGetOrganizationUnit.mockReturnValue({data: undefined, isLoading: false, error: null});
+      mockUseGetChildOrganizationUnits.mockReturnValue({data: childOUsResponse, isLoading: false, error: null});
+
+      renderWithProviders(
+        <OrganizationUnitTreePicker {...defaultProps} rootOuId="root-ou-1" hideRoot onItemActivate={onItemActivate} />,
+      );
+
+      const childRow = (await screen.findByText('Child One')).closest('[role="button"]');
+      expect(childRow).not.toBeNull();
+
+      fireEvent.keyDown(childRow!, {key: 'Enter'});
+      fireEvent.keyDown(childRow!, {key: ' '});
+      fireEvent.keyDown(childRow!, {key: 'Escape'});
+
+      expect(onItemActivate).toHaveBeenNthCalledWith(1, 'child-1');
+      expect(onItemActivate).toHaveBeenNthCalledWith(2, 'child-1');
+      expect(onItemActivate).toHaveBeenCalledTimes(2);
+    });
+
+    it('should load more children within a nested branch', async () => {
+      const firstNestedPage: OrganizationUnitListResponse = {
+        totalResults: 3,
+        startIndex: 1,
+        count: 2,
+        organizationUnits: [
+          {
+            id: 'grandchild-1',
+            handle: 'grandchild-1-handle',
+            name: 'Grandchild One',
+            description: null,
+            parent: 'child-1',
+          },
+          {
+            id: 'grandchild-2',
+            handle: 'grandchild-2-handle',
+            name: 'Grandchild Two',
+            description: null,
+            parent: 'child-1',
+          },
+        ],
+      };
+      const secondNestedPage: OrganizationUnitListResponse = {
+        totalResults: 3,
+        startIndex: 3,
+        count: 1,
+        organizationUnits: [
+          {
+            id: 'grandchild-3',
+            handle: 'grandchild-3-handle',
+            name: 'Grandchild Three',
+            description: null,
+            parent: 'child-1',
+          },
+        ],
+      };
+      mockUseGetOrganizationUnit.mockReturnValue({data: undefined, isLoading: false, error: null});
+      mockUseGetChildOrganizationUnits.mockReturnValue({data: childOUsResponse, isLoading: false, error: null});
+      mockHttpRequest.mockResolvedValueOnce({data: firstNestedPage}).mockResolvedValueOnce({data: secondNestedPage});
+
+      renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} rootOuId="root-ou-1" hideRoot />);
+
+      await screen.findByText('Child One');
+      fireEvent.click(document.querySelectorAll('.MuiTreeItem-iconContainer')[0]);
+
+      const loadMore = await screen.findByText(t('organizationUnits:listing.treeView.loadMore'));
+      fireEvent.click(loadMore);
+
+      await waitFor(() => {
+        expect(screen.getByText('Grandchild Three')).toBeInTheDocument();
+      });
+      const request = mockHttpRequest.mock.calls[1]?.[0] as {url: string} | undefined;
+      expect(request?.url).toContain('/organization-units/child-1/ous');
+      expect(request?.url).toContain('offset=2');
+    });
+
+    it('should load more direct children when the root is hidden', async () => {
+      const paginatedChildrenResponse = {...childOUsResponse, totalResults: 3};
+      const nextPageResponse: OrganizationUnitListResponse = {
+        totalResults: 3,
+        startIndex: 3,
+        count: 1,
+        organizationUnits: [
+          {id: 'child-3', handle: 'child-3-handle', name: 'Child Three', description: null, parent: 'root-ou-1'},
+        ],
+      };
+      mockUseGetOrganizationUnit.mockReturnValue({data: undefined, isLoading: false, error: null});
+      mockUseGetChildOrganizationUnits.mockReturnValue({
+        data: paginatedChildrenResponse,
+        isLoading: false,
+        error: null,
+      });
+      mockHttpRequest.mockResolvedValue({data: nextPageResponse});
+
+      renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} rootOuId="root-ou-1" hideRoot />);
+
+      await waitFor(() => {
+        expect(screen.getByText(t('organizationUnits:listing.treeView.loadMore'))).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText(t('organizationUnits:listing.treeView.loadMore')));
+
+      await waitFor(() => {
+        expect(screen.getByText('Child Three')).toBeInTheDocument();
+      });
+      const request = mockHttpRequest.mock.calls[0]?.[0] as {url: string} | undefined;
+      expect(request?.url).toContain('/organization-units/root-ou-1/ous');
+      expect(request?.url).toContain('offset=2');
+    });
+
+    it('should show an aligned empty state when the hidden root has no children', async () => {
+      mockUseGetOrganizationUnit.mockReturnValue({data: undefined, isLoading: false, error: null});
+      mockUseGetChildOrganizationUnits.mockReturnValue({
+        data: {totalResults: 0, startIndex: 1, count: 0, organizationUnits: []},
+        isLoading: false,
+        error: null,
+      });
+
+      renderWithProviders(<OrganizationUnitTreePicker {...defaultProps} rootOuId="root-ou-1" hideRoot />);
+
+      const emptyState = await screen.findByText(t('organizationUnits:listing.treeView.noChildren'));
+      expect(emptyState).toHaveStyle({paddingLeft: '8px'});
+      expect(screen.queryByRole('tree')).not.toBeInTheDocument();
     });
 
     it('should auto-expand root OU node', async () => {

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/child-organization-unit-settings/EditChildOrganizationUnitSettings.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/child-organization-unit-settings/EditChildOrganizationUnitSettings.tsx
@@ -23,7 +23,7 @@ interface EditChildOrganizationUnitSettingsProps {
  * Child Organization Units tab content for the Organization Unit edit page.
  *
  * Displays sections for:
- * - Managing child organization units (DataGrid with navigation)
+ * - Managing child organization units (lazy-loaded hierarchy)
  *
  * @param props - Component props
  * @returns Child OUs tab content

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/child-organization-unit-settings/ManageChildOrganizationUnitSection.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/child-organization-unit-settings/ManageChildOrganizationUnitSection.tsx
@@ -1,18 +1,15 @@
 // Copyright 2025 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import {QueryErrorNotice, SettingsCard} from '@thunderid/components';
-import {useDataGridLocaleText} from '@thunderid/hooks';
+import {SettingsCard} from '@thunderid/components';
 import {useLogger} from '@thunderid/logger/react';
-import {Box, DataGrid, Avatar} from '@wso2/oxygen-ui';
-import {Building} from '@wso2/oxygen-ui-icons-react';
-import {useMemo, type JSX} from 'react';
+import {Box} from '@wso2/oxygen-ui';
+import type {JSX} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
-import useGetChildOrganizationUnits from '../../../api/useGetChildOrganizationUnits';
 import useOrganizationUnitRoutes from '../../../hooks/useOrganizationUnitRoutes';
 import type {OUNavigationState} from '../../../models/navigation';
-import type {OrganizationUnit} from '../../../models/organization-unit';
+import OrganizationUnitTreePicker from '../../OrganizationUnitTreePicker';
 
 /**
  * Props for the {@link ManageChildOrganizationUnitSection} component.
@@ -31,13 +28,8 @@ interface ManageChildOrganizationUnitSectionProps {
 /**
  * Section component for managing child organization units.
  *
- * Displays a DataGrid of child organization units with:
- * - Avatar icon
- * - Name
- * - Handle
- * - Description
- *
- * Clicking a row navigates to that child OU's detail page.
+ * Displays a lazy-loaded hierarchy rooted below the current organization unit.
+ * Clicking a row navigates to that organization unit's detail page.
  *
  * @param props - Component props
  * @returns Manage child OUs section within a SettingsCard
@@ -50,85 +42,6 @@ export default function ManageChildOrganizationUnitSection({
   const routes = useOrganizationUnitRoutes();
   const {t} = useTranslation();
   const logger = useLogger('ManageChildOrganizationUnitSection');
-  const dataGridLocaleText = useDataGridLocaleText();
-
-  const {data: childOUsData, isLoading, error, refetch} = useGetChildOrganizationUnits(organizationUnitId);
-
-  const columns: DataGrid.GridColDef<OrganizationUnit>[] = useMemo(
-    () => [
-      {
-        field: 'avatar',
-        headerName: '',
-        width: 70,
-        sortable: false,
-        filterable: false,
-        renderCell: (): JSX.Element => (
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              height: '100%',
-            }}
-          >
-            <Avatar
-              sx={{
-                p: 0.5,
-                bgcolor: 'primary.main',
-                color: 'primary.contrastText',
-                width: 30,
-                height: 30,
-                fontSize: '0.875rem',
-              }}
-            >
-              <Building size={14} />
-            </Avatar>
-          </Box>
-        ),
-      },
-      {
-        field: 'name',
-        headerName: t('organizationUnits:listing.columns.name'),
-        flex: 1,
-        minWidth: 200,
-      },
-      {
-        field: 'handle',
-        headerName: t('organizationUnits:listing.columns.handle'),
-        flex: 1,
-        minWidth: 150,
-      },
-      {
-        field: 'description',
-        headerName: t('organizationUnits:listing.columns.description'),
-        flex: 2,
-        minWidth: 250,
-        valueGetter: (_value, row): string => row.description ?? '-',
-      },
-    ],
-    [t],
-  );
-
-  if (error) {
-    return (
-      <SettingsCard
-        title={t('organizationUnits:edit.childOUs.sections.manage.title', 'Child Organization Units')}
-        description={t(
-          'organizationUnits:edit.childOUs.sections.manage.description',
-          'View and manage child organization units under this OU',
-        )}
-      >
-        <QueryErrorNotice
-          error={error}
-          t={(key, options) => t(key.includes(':') ? key : `organizationUnits:${key}`, options)}
-          variant="inline"
-          onRetry={() => void refetch()}
-          fallbackKey="organizationUnits:edit.childOUs.sections.manage.error"
-          fallbackDefaultValue="Failed to load child organization units"
-        />
-      </SettingsCard>
-    );
-  }
 
   return (
     <SettingsCard
@@ -137,22 +50,16 @@ export default function ManageChildOrganizationUnitSection({
         'organizationUnits:edit.childOUs.sections.manage.description',
         'Organization units nested under this one.',
       )}
-      slotProps={{
-        content: {
-          sx: {
-            p: 0,
-          },
-        },
-      }}
+      slotProps={{content: {sx: {p: 0}}}}
     >
-      <Box sx={{maxHeight: 400, width: '100%'}}>
-        <DataGrid.DataGrid
-          rows={childOUsData?.organizationUnits ?? []}
-          columns={columns}
-          loading={isLoading}
-          getRowId={(row): string => row.id}
-          onRowClick={(params) => {
-            const ou = params.row as OrganizationUnit;
+      <Box sx={{width: '100%', p: 2}}>
+        <OrganizationUnitTreePicker
+          rootOuId={organizationUnitId}
+          hideRoot
+          value=""
+          onChange={() => undefined}
+          maxHeight={400}
+          onItemActivate={(organizationUnitIdToOpen) => {
             const navigationState: OUNavigationState = {
               fromOU: {
                 id: organizationUnitId,
@@ -160,23 +67,13 @@ export default function ManageChildOrganizationUnitSection({
               },
             };
             (async (): Promise<void> => {
-              await navigate(routes.detail(ou.id), {state: navigationState});
+              await navigate(routes.detail(organizationUnitIdToOpen), {state: navigationState});
             })().catch((_error: unknown) => {
-              logger.error('Failed to navigate to child organization unit', {error: _error, ouId: ou.id});
+              logger.error('Failed to navigate to child organization unit', {
+                error: _error,
+                ouId: organizationUnitIdToOpen,
+              });
             });
-          }}
-          initialState={{
-            pagination: {
-              paginationModel: {pageSize: 10},
-            },
-          }}
-          pageSizeOptions={[5, 10, 25]}
-          disableRowSelectionOnClick
-          localeText={dataGridLocaleText}
-          sx={{
-            '& .MuiDataGrid-row': {
-              cursor: 'pointer',
-            },
           }}
         />
       </Box>

--- a/frontend/packages/configure-organization-units/src/components/edit-organization-unit/child-organization-unit-settings/__tests__/ManageChildOrganizationUnitSection.test.tsx
+++ b/frontend/packages/configure-organization-units/src/components/edit-organization-unit/child-organization-unit-settings/__tests__/ManageChildOrganizationUnitSection.test.tsx
@@ -1,25 +1,33 @@
 // Copyright 2025 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import {screen, fireEvent, waitFor, renderWithProviders, renderHook} from '@thunderid/test-utils';
-import {useTranslation} from 'react-i18next';
-import {describe, it, expect, vi, beforeEach, beforeAll} from 'vitest';
-import type {OrganizationUnit} from '../../../../models/organization-unit';
+import {fireEvent, renderWithProviders, screen, waitFor} from '@thunderid/test-utils';
+import {describe, expect, it, vi, beforeEach} from 'vitest';
 import ManageChildOrganizationUnitSection from '../ManageChildOrganizationUnitSection';
 
-// Mock the useGetChildOrganizationUnits hook
-const mockUseGetChildOrganizationUnits = vi.fn();
-vi.mock('@/api/useGetChildOrganizationUnits', () => ({
-  default: (id: string): unknown => mockUseGetChildOrganizationUnits(id),
+vi.mock('@/components/OrganizationUnitTreePicker', () => ({
+  default: ({
+    rootOuId,
+    hideRoot,
+    onChange,
+    onItemActivate,
+  }: {
+    rootOuId?: string;
+    hideRoot?: boolean;
+    onChange?: (organizationUnitId: string) => void;
+    onItemActivate?: (organizationUnitId: string) => void;
+  }) => (
+    <div data-root-ou-id={rootOuId} data-hide-root={String(hideRoot)}>
+      <button type="button" data-testid="organization-unit-subtree" onClick={() => onItemActivate?.('nested-ou')}>
+        Organization unit subtree
+      </button>
+      <button type="button" data-testid="organization-unit-selection" onClick={() => onChange?.('nested-ou')}>
+        Select organization unit
+      </button>
+    </div>
+  ),
 }));
 
-// Mock useDataGridLocaleText hook
-vi.mock('@thunderid/hooks', async (importOriginal) => {
-  const actual = await importOriginal();
-  return {...(actual as object), useDataGridLocaleText: () => ({})};
-});
-
-// Mock navigate function
 const mockNavigate = vi.fn();
 vi.mock('react-router', async () => {
   const actual = await vi.importActual('react-router');
@@ -29,301 +37,69 @@ vi.mock('react-router', async () => {
   };
 });
 
-// Mock logger
+const mockLoggerError = vi.fn();
 vi.mock('@thunderid/logger/react', () => ({
-  useLogger: () => ({
-    error: vi.fn(),
-  }),
+  useLogger: () => ({error: mockLoggerError}),
 }));
 
 describe('ManageChildOrganizationUnitSection', () => {
-  let t: (key: string) => string;
-
-  beforeAll(() => {
-    ({t} = renderHook(() => useTranslation()).result.current);
-  });
-  const mockChildOUs: OrganizationUnit[] = [
-    {
-      id: 'ou-child-1',
-      handle: 'frontend',
-      name: 'Frontend Team',
-      description: 'Frontend development team',
-      parent: 'ou-parent',
-    },
-    {
-      id: 'ou-child-2',
-      handle: 'backend',
-      name: 'Backend Team',
-      description: 'Backend development team',
-      parent: 'ou-parent',
-    },
-    {
-      id: 'ou-child-3',
-      handle: 'devops',
-      name: 'DevOps Team',
-      description: null,
-      parent: 'ou-parent',
-    },
-  ];
-
   beforeEach(() => {
     vi.clearAllMocks();
     mockNavigate.mockResolvedValue(undefined);
   });
 
-  it('should render the manage child OUs section', () => {
-    mockUseGetChildOrganizationUnits.mockReturnValue({
-      data: {organizationUnits: mockChildOUs},
-      isLoading: false,
-    });
-
+  it('should render the child organization unit hierarchy', () => {
     renderWithProviders(
-      <ManageChildOrganizationUnitSection organizationUnitId="ou-parent" organizationUnitName="Engineering" />,
+      <ManageChildOrganizationUnitSection organizationUnitId="parent-ou" organizationUnitName="Engineering" />,
     );
 
-    expect(screen.getByText(t('organizationUnits:edit.childOUs.sections.manage.title'))).toBeInTheDocument();
-    expect(screen.getByText(t('organizationUnits:edit.childOUs.sections.manage.description'))).toBeInTheDocument();
+    expect(screen.getByText('Child Organization Units')).toBeInTheDocument();
+    expect(screen.getByTestId('organization-unit-subtree').parentElement).toHaveAttribute(
+      'data-root-ou-id',
+      'parent-ou',
+    );
+    expect(screen.getByTestId('organization-unit-subtree').parentElement).toHaveAttribute('data-hide-root', 'true');
   });
 
-  it('should render data grid with child OUs', () => {
-    mockUseGetChildOrganizationUnits.mockReturnValue({
-      data: {organizationUnits: mockChildOUs},
-      isLoading: false,
-    });
-
+  it('should ignore tree selection events', () => {
     renderWithProviders(
-      <ManageChildOrganizationUnitSection organizationUnitId="ou-parent" organizationUnitName="Engineering" />,
+      <ManageChildOrganizationUnitSection organizationUnitId="parent-ou" organizationUnitName="Engineering" />,
     );
 
-    expect(screen.getByRole('grid')).toBeInTheDocument();
-    expect(screen.getByText('Frontend Team')).toBeInTheDocument();
-    expect(screen.getByText('Backend Team')).toBeInTheDocument();
-    expect(screen.getByText('DevOps Team')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('organization-unit-selection'));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it('should render column headers', () => {
-    mockUseGetChildOrganizationUnits.mockReturnValue({
-      data: {organizationUnits: mockChildOUs},
-      isLoading: false,
-    });
-
+  it('should navigate to a selected organization unit with back-navigation state', async () => {
     renderWithProviders(
-      <ManageChildOrganizationUnitSection organizationUnitId="ou-parent" organizationUnitName="Engineering" />,
+      <ManageChildOrganizationUnitSection organizationUnitId="parent-ou" organizationUnitName="Engineering" />,
     );
 
-    expect(screen.getByText(t('organizationUnits:listing.columns.name'))).toBeInTheDocument();
-    expect(screen.getByText(t('organizationUnits:listing.columns.handle'))).toBeInTheDocument();
-    expect(screen.getByText(t('organizationUnits:listing.columns.description'))).toBeInTheDocument();
-  });
-
-  it('should show loading state', () => {
-    mockUseGetChildOrganizationUnits.mockReturnValue({
-      data: null,
-      isLoading: true,
-    });
-
-    renderWithProviders(
-      <ManageChildOrganizationUnitSection organizationUnitId="ou-parent" organizationUnitName="Engineering" />,
-    );
-
-    const grid = screen.getByRole('grid');
-    expect(grid).toBeInTheDocument();
-    // DataGrid shows loading overlay when isLoading is true
-  });
-
-  it('should handle empty child OUs list', () => {
-    mockUseGetChildOrganizationUnits.mockReturnValue({
-      data: {organizationUnits: []},
-      isLoading: false,
-    });
-
-    renderWithProviders(
-      <ManageChildOrganizationUnitSection organizationUnitId="ou-parent" organizationUnitName="Engineering" />,
-    );
-
-    expect(screen.getByRole('grid')).toBeInTheDocument();
-    // Grid should show "No rows" message
-  });
-
-  it('should handle null child OUs data', () => {
-    mockUseGetChildOrganizationUnits.mockReturnValue({
-      data: null,
-      isLoading: false,
-    });
-
-    renderWithProviders(
-      <ManageChildOrganizationUnitSection organizationUnitId="ou-parent" organizationUnitName="Engineering" />,
-    );
-
-    expect(screen.getByRole('grid')).toBeInTheDocument();
-  });
-
-  it('should render an inline read error state instead of the grid when the query fails', () => {
-    mockUseGetChildOrganizationUnits.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      error: new Error('Network error'),
-    });
-
-    renderWithProviders(
-      <ManageChildOrganizationUnitSection organizationUnitId="ou-parent" organizationUnitName="Engineering" />,
-    );
-
-    expect(screen.getByText('Failed to load child organization units')).toBeInTheDocument();
-    expect(screen.queryByRole('grid')).not.toBeInTheDocument();
-    expect(screen.queryByText('Network error')).not.toBeInTheDocument();
-  });
-
-  it('should refetch when the retry action is clicked', () => {
-    const mockRefetch = vi.fn();
-    mockUseGetChildOrganizationUnits.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      error: new Error('Network error'),
-      refetch: mockRefetch,
-    });
-
-    renderWithProviders(
-      <ManageChildOrganizationUnitSection organizationUnitId="ou-parent" organizationUnitName="Engineering" />,
-    );
-
-    fireEvent.click(screen.getByText('Refresh'));
-
-    expect(mockRefetch).toHaveBeenCalledTimes(1);
-  });
-
-  it('should call useGetChildOrganizationUnits with correct ID', () => {
-    mockUseGetChildOrganizationUnits.mockReturnValue({
-      data: {organizationUnits: mockChildOUs},
-      isLoading: false,
-    });
-
-    renderWithProviders(
-      <ManageChildOrganizationUnitSection organizationUnitId="ou-456" organizationUnitName="Engineering" />,
-    );
-
-    expect(mockUseGetChildOrganizationUnits).toHaveBeenCalledWith('ou-456');
-  });
-
-  it('should render handles correctly', () => {
-    mockUseGetChildOrganizationUnits.mockReturnValue({
-      data: {organizationUnits: mockChildOUs},
-      isLoading: false,
-    });
-
-    renderWithProviders(
-      <ManageChildOrganizationUnitSection organizationUnitId="ou-parent" organizationUnitName="Engineering" />,
-    );
-
-    expect(screen.getByText('frontend')).toBeInTheDocument();
-    expect(screen.getByText('backend')).toBeInTheDocument();
-    expect(screen.getByText('devops')).toBeInTheDocument();
-  });
-
-  it('should render descriptions correctly', () => {
-    mockUseGetChildOrganizationUnits.mockReturnValue({
-      data: {organizationUnits: mockChildOUs},
-      isLoading: false,
-    });
-
-    renderWithProviders(
-      <ManageChildOrganizationUnitSection organizationUnitId="ou-parent" organizationUnitName="Engineering" />,
-    );
-
-    expect(screen.getByText('Frontend development team')).toBeInTheDocument();
-    expect(screen.getByText('Backend development team')).toBeInTheDocument();
-  });
-
-  it('should show "-" for null description', () => {
-    mockUseGetChildOrganizationUnits.mockReturnValue({
-      data: {organizationUnits: mockChildOUs},
-      isLoading: false,
-    });
-
-    renderWithProviders(
-      <ManageChildOrganizationUnitSection organizationUnitId="ou-parent" organizationUnitName="Engineering" />,
-    );
-
-    // The third OU has null description, should show "-"
-    const cells = screen.getAllByText('-');
-    expect(cells.length).toBeGreaterThan(0);
-  });
-
-  it('should navigate to child OU when row is clicked', async () => {
-    mockUseGetChildOrganizationUnits.mockReturnValue({
-      data: {organizationUnits: mockChildOUs},
-      isLoading: false,
-    });
-
-    renderWithProviders(
-      <ManageChildOrganizationUnitSection organizationUnitId="ou-parent" organizationUnitName="Engineering" />,
-    );
-
-    // Get the grid cell with the text "Frontend Team"
-    const cell = screen.getByText('Frontend Team');
-    fireEvent.click(cell);
+    fireEvent.click(screen.getByTestId('organization-unit-subtree'));
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(
-        '/organization-units/ou-child-1',
-        expect.objectContaining({
-          state: {
-            fromOU: {
-              id: 'ou-parent',
-              name: 'Engineering',
-            },
-          },
-        }),
-      );
+      expect(mockNavigate).toHaveBeenCalledWith('/organization-units/nested-ou', {
+        state: {fromOU: {id: 'parent-ou', name: 'Engineering'}},
+      });
     });
   });
 
-  it('should include navigation state when navigating to child OU', async () => {
-    mockUseGetChildOrganizationUnits.mockReturnValue({
-      data: {organizationUnits: mockChildOUs},
-      isLoading: false,
-    });
-
-    renderWithProviders(
-      <ManageChildOrganizationUnitSection organizationUnitId="ou-parent" organizationUnitName="Product Team" />,
-    );
-
-    const cell = screen.getByText('Backend Team');
-    fireEvent.click(cell);
-
-    await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(
-        '/organization-units/ou-child-2',
-        expect.objectContaining({
-          state: {
-            fromOU: {
-              id: 'ou-parent',
-              name: 'Product Team',
-            },
-          },
-        }),
-      );
-    });
-  });
-
-  it('should handle navigation errors gracefully', async () => {
+  it('should log navigation failures', async () => {
     mockNavigate.mockRejectedValue(new Error('Navigation failed'));
-    mockUseGetChildOrganizationUnits.mockReturnValue({
-      data: {organizationUnits: mockChildOUs},
-      isLoading: false,
-    });
 
     renderWithProviders(
-      <ManageChildOrganizationUnitSection organizationUnitId="ou-parent" organizationUnitName="Engineering" />,
+      <ManageChildOrganizationUnitSection organizationUnitId="parent-ou" organizationUnitName="Engineering" />,
     );
 
-    const cell = screen.getByText('Frontend Team');
-    fireEvent.click(cell);
+    fireEvent.click(screen.getByTestId('organization-unit-subtree'));
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalled();
+      expect(mockLoggerError).toHaveBeenCalledTimes(1);
+      const [message, details] = mockLoggerError.mock.calls[0] as [string, {error: unknown; ouId: string}];
+      expect(message).toBe('Failed to navigate to child organization unit');
+      expect(details.error).toBeInstanceOf(Error);
+      expect(details.ouId).toBe('nested-ou');
     });
-
-    // Should not throw error - error is logged
   });
 });

--- a/frontend/packages/configure-organization-units/src/pages/OrganizationUnitEditPage.tsx
+++ b/frontend/packages/configure-organization-units/src/pages/OrganizationUnitEditPage.tsx
@@ -103,7 +103,16 @@ export default function OrganizationUnitEditPage({
   const updateOrganizationUnit = useUpdateOrganizationUnit();
   const {resetTreeState} = useOrganizationUnit();
 
-  const [activeTab, setActiveTab] = useState(0);
+  const [tabState, setTabState] = useState<{organizationUnitId: string | undefined; value: number}>({
+    organizationUnitId: id,
+    value: 0,
+  });
+
+  if (tabState.organizationUnitId !== id) {
+    setTabState({organizationUnitId: id, value: 0});
+  }
+
+  const activeTab = tabState.organizationUnitId === id ? tabState.value : 0;
   const [editedOU, setEditedOU] = useState<Partial<OrganizationUnit>>({});
   const [deleteDialogOpen, setDeleteDialogOpen] = useState<boolean>(false);
   const [isEditingName, setIsEditingName] = useState(false);
@@ -125,7 +134,7 @@ export default function OrganizationUnitEditPage({
     : t('organizationUnits:edit.page.back', 'Back to Organization Units');
 
   const handleTabChange = (_event: SyntheticEvent, newValue: number): void => {
-    setActiveTab(newValue);
+    setTabState({organizationUnitId: id, value: newValue});
   };
 
   const handleFieldChange = useCallback(

--- a/frontend/packages/configure-organization-units/src/pages/__tests__/OrganizationUnitEditPage.test.tsx
+++ b/frontend/packages/configure-organization-units/src/pages/__tests__/OrganizationUnitEditPage.test.tsx
@@ -11,12 +11,13 @@ import OrganizationUnitEditPage from '../OrganizationUnitEditPage';
 // Mock navigate, useParams, and useLocation
 const mockNavigate = vi.fn();
 const mockUseLocation = vi.fn<() => {state: unknown; pathname: string; search: string; hash: string; key: string}>();
+let mockOrganizationUnitId = 'ou-123';
 vi.mock('react-router', async () => {
   const actual = await vi.importActual('react-router');
   return {
     ...actual,
     useNavigate: () => mockNavigate,
-    useParams: () => ({id: 'ou-123'}),
+    useParams: () => ({id: mockOrganizationUnitId}),
     useLocation: () => mockUseLocation(),
     Link: ({to, children = undefined, ...props}: {to: string; children?: ReactNode; [key: string]: unknown}) => (
       <a
@@ -228,6 +229,7 @@ describe('OrganizationUnitEditPage', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockOrganizationUnitId = 'ou-123';
     mockNavigate.mockReset();
     mockMutateAsync.mockReset();
     mockRefetch.mockReset();
@@ -787,6 +789,37 @@ describe('OrganizationUnitEditPage', () => {
     await waitFor(() => {
       expect(
         screen.getByRole('tab', {name: t('organizationUnits:edit.page.tabs.childOUs'), selected: true}),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('should return to the General tab after each organization unit navigation', async () => {
+    const {rerender} = renderWithProviders(<OrganizationUnitEditPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Organization Unit')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('tab', {name: t('organizationUnits:edit.page.tabs.childOUs')}));
+    expect(
+      screen.getByRole('tab', {name: t('organizationUnits:edit.page.tabs.childOUs'), selected: true}),
+    ).toBeInTheDocument();
+
+    mockOrganizationUnitId = 'ou-456';
+    rerender(<OrganizationUnitEditPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('tab', {name: t('organizationUnits:edit.page.tabs.general'), selected: true}),
+      ).toBeInTheDocument();
+    });
+
+    mockOrganizationUnitId = 'ou-123';
+    rerender(<OrganizationUnitEditPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('tab', {name: t('organizationUnits:edit.page.tabs.general'), selected: true}),
       ).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
### Purpose

Fixes #4800 by replacing the flat Child OUs list with a hierarchy that exposes nested organization units without fetching the entire subtree up front.

When navigating from a child OU row to another OU, the destination now opens on the General tab instead of preserving the Child OUs tab from the previous OU.
<img width="1512" height="982" alt="Screenshot 2026-08-16 at 17 30 46" src="https://github.com/user-attachments/assets/c768911b-c649-4e1f-85ba-9879bf8e2c50" />
<img width="1512" height="982" alt="Screenshot 2026-08-16 at 17 30 33" src="https://github.com/user-attachments/assets/72924939-2a27-4357-8be1-8de64a191feb" />

### Approach

- Render the current OU's direct children as the first visible hierarchy level.
- Fetch nested children lazily when a row is expanded.
- Keep pagination scoped to each parent and support loading more direct children.
- Preserve the "No child organization units" message for leaf nodes, with standalone empty-state alignment matching the section heading.
- Separate row activation from expansion so the chevron expands while the row opens the OU.
- Reset the selected tab to General whenever the routed OU ID changes.
- Preserve existing behavior for other consumers of the shared organization unit picker through opt-in props.

### Related Issues
- Fixes #4800

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. Not required for this UI bug fix.
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided.
    - [x] Unit Tests
    - [ ] Integration Tests
- [x] Breaking changes. None.
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Validation

- Organization unit tree picker tests: 45 passed
- Organization unit edit page and child section tests: 50 passed
- TypeScript typecheck
- ESLint
- Prettier
- Live Console verification of lazy expansion, navigation, empty states, alignment, and destination General tab

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a hierarchical organization-unit picker with lazy loading and pagination.
  * Added click and keyboard activation for organization-unit rows.
  * Added an option to hide the current root and display its children directly.
  * Child organization units can now be opened directly from the hierarchy.

* **Bug Fixes**
  * Reset the selected tab to General when navigating between organization units.
  * Improved empty, loading, and error handling for hidden-root views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->