### PR TITLE
Stop HTML-Escaping User Input in the Shared Backend Storage Sanitizer

### DIFF
--- a/backend/internal/flow/executor/consent_executor.go
+++ b/backend/internal/flow/executor/consent_executor.go
@@ -6,7 +6,6 @@ package executor
 import (
 	"encoding/json"
 	"errors"
-	"html"
 	"slices"
 	"strconv"
 	"strings"
@@ -211,11 +210,6 @@ func (e *consentExecutor) handleConsentDecisions(ctx *providers.NodeContext, exe
 		execResp.Error = &ErrConsentDecisionsMissing
 		return execResp, nil
 	}
-
-	// SanitizeStringMap HTML-escapes all user inputs as an XSS prevention measure.
-	// For the consent_decisions field the value is a JSON string, so HTML entities
-	// must be unescaped before parsing
-	decisionsJSON = html.UnescapeString(decisionsJSON)
 
 	var decisions providers.ConsentDecisions
 	if err := json.Unmarshal([]byte(decisionsJSON), &decisions); err != nil {

--- a/backend/internal/flow/executor/consent_executor_test.go
+++ b/backend/internal/flow/executor/consent_executor_test.go
@@ -567,23 +567,21 @@ func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_AllApproved_Success
 	assert.Contains(suite.T(), resp.RuntimeData[common.RuntimeKeyConsentedAttributes], "phone")
 }
 
-func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_HTMLEscapedJSON() {
-	// Simulate the HTML-escaped JSON that SanitizeStringMap would produce
+// Consent decisions arrive as a JSON string through SanitizeStringMap. HTML entities in a purpose
+// name must reach the enforcer verbatim; unescaping here would corrupt a legitimate "&amp;" value.
+func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_HTMLEntitiesPreserved() {
+	purposeName := `attributes:R&D <team> &amp; "core"`
 	decisions := providers.ConsentDecisions{
 		Approved: true,
 		Purposes: []providers.PurposeDecision{
-			{PurposeName: "attributes:test-app", Approved: true},
+			{PurposeName: purposeName, Approved: true},
 		},
 	}
-	decisionsJSON, _ := json.Marshal(decisions)
-	// HTML escape the JSON (simulates XSS sanitization)
-	escapedJSON := "&lt;script&gt;" // Won't appear in real flow, just to test unescape doesn't break
-	_ = escapedJSON
-	// Use actual HTML-escaped JSON with angle brackets in values
-	htmlEscaped := string(decisionsJSON) // Normal JSON shouldn't have HTML entities typically
+	decisionsJSON, err := json.Marshal(decisions)
+	assert.NoError(suite.T(), err)
 
 	ctx := buildConsentNodeContext()
-	ctx.UserInputs[userInputConsentDecisions] = htmlEscaped
+	ctx.UserInputs[userInputConsentDecisions] = string(decisionsJSON)
 	suite.setupDefaultAuthnProviderMocks()
 
 	suite.executor.Executor.(*coremock.ExecutorInterfaceMock).
@@ -596,14 +594,21 @@ func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_HTMLEscapedJSON() {
 		Purposes: []providers.ConsentPurposeItem{},
 	}
 
+	var recorded *providers.ConsentDecisions
 	suite.mockConsentEnforcer.On("RecordConsent", mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		mock.Anything, mock.AnythingOfType("*providers.ConsentDecisions"), mock.Anything,
+		mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			recorded = args.Get(4).(*providers.ConsentDecisions)
+		}).
 		Return(consentResult, nil)
 
-	resp, err := suite.executor.Execute(ctx)
+	resp, execErr := suite.executor.Execute(ctx)
 
-	assert.NoError(suite.T(), err)
+	assert.NoError(suite.T(), execErr)
 	assert.Equal(suite.T(), providers.ExecComplete, resp.Status)
+	assert.NotNil(suite.T(), recorded)
+	assert.Equal(suite.T(), purposeName, recorded.Purposes[0].PurposeName)
 }
 
 func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_EmptyDecisions() {

--- a/backend/internal/group/handler_test.go
+++ b/backend/internal/group/handler_test.go
@@ -592,14 +592,14 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostRequest() {
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
 					On("CreateGroup", mock.Anything, mock.MatchedBy(func(request CreateGroupRequest) bool {
-						return request.Name == "Team &lt;script&gt;" &&
+						return request.Name == "Team <script>" &&
 							request.Description == "desc" &&
 							request.OUID == testOUID &&
 							len(request.Members) == 1 &&
 							request.Members[0].ID == "member-1" &&
 							request.Members[0].Type == MemberTypeUser
 					})).
-					Return(&Group{ID: "grp-001", Name: "Team &lt;script&gt;",
+					Return(&Group{ID: "grp-001", Name: "Team <script>",
 						OUID: testOUID}, nil).
 					Once()
 			},
@@ -610,7 +610,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPostRequest() {
 				var body Group
 				require.NoError(suite.T(), json.Unmarshal(rr.Body.Bytes(), &body))
 				require.Equal(suite.T(), "grp-001", body.ID)
-				require.Equal(suite.T(), "Team &lt;script&gt;", body.Name)
+				require.Equal(suite.T(), "Team <script>", body.Name)
 			},
 		},
 		{
@@ -981,7 +981,7 @@ func (suite *GroupHandlerTestSuite) TestGroupHandler_HandleGroupPutRequest() {
 			setup: func(serviceMock *GroupServiceInterfaceMock) {
 				serviceMock.
 					On("UpdateGroup", mock.Anything, "grp-001", mock.MatchedBy(func(request UpdateGroupRequest) bool {
-						return request.Name == "team &lt;script&gt;" &&
+						return request.Name == "team <script>" &&
 							request.Description == "desc" &&
 							request.OUID == testOUID
 					})).

--- a/backend/internal/ou/handler_test.go
+++ b/backend/internal/ou/handler_test.go
@@ -485,10 +485,10 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUPostRequest
 					On("CreateOrganizationUnit", mock.Anything,
 						mock.MatchedBy(func(req providers.OrganizationUnitRequestWithID) bool {
 							return req.Handle == defaultOUHandle &&
-								req.Name == "Finance &lt;script&gt;" &&
+								req.Name == "Finance <script>" &&
 								req.Description == "desc"
 						})).
-					Return(providers.OrganizationUnit{ID: "ou-1", Name: "Finance &lt;script&gt;"}, nil).
+					Return(providers.OrganizationUnit{ID: "ou-1", Name: "Finance <script>"}, nil).
 					Once()
 			},
 			assert: func(recorder *httptest.ResponseRecorder) {
@@ -887,18 +887,18 @@ func (suite *OrganizationUnitHandlerTestSuite) TestOUHandler_HandleOUPutRequest(
 						defaultOURequestID,
 						mock.MatchedBy(func(req providers.OrganizationUnitRequestWithID) bool {
 							return req.Handle == defaultOUHandle &&
-								req.Name == "Finance &lt;script&gt;" &&
+								req.Name == "Finance <script>" &&
 								req.Description == "desc"
 						}),
 					).
-					Return(providers.OrganizationUnit{ID: defaultOURequestID, Name: "Finance &lt;script&gt;"}, nil).
+					Return(providers.OrganizationUnit{ID: defaultOURequestID, Name: "Finance <script>"}, nil).
 					Once()
 			},
 			assert: func(recorder *httptest.ResponseRecorder) {
 				suite.Equal(http.StatusOK, recorder.Code)
 				var resp providers.OrganizationUnit
 				suite.NoError(json.Unmarshal(recorder.Body.Bytes(), &resp))
-				suite.Equal("Finance &lt;script&gt;", resp.Name)
+				suite.Equal("Finance <script>", resp.Name)
 			},
 		},
 		{

--- a/backend/internal/role/handler_test.go
+++ b/backend/internal/role/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -773,6 +774,46 @@ func (suite *RoleHandlerTestSuite) TestSanitizeUpdateRoleRequest() {
 	suite.Equal("ou2", sanitized.OUID)
 	suite.Equal("rs2", sanitized.Permissions[0].ResourceServerID)
 	suite.Equal("perm3", sanitized.Permissions[0].Permissions[0])
+}
+
+func (suite *RoleHandlerTestSuite) TestSanitizeCreateRoleRequest_PreservesSpecialCharacters() {
+	request := &CreateRoleRequest{
+		Name:        "  Dean's Sub team  ",
+		Description: `  R&D <team> "core"  `,
+	}
+
+	sanitized := suite.handler.sanitizeCreateRoleRequest(request)
+
+	suite.Equal("Dean's Sub team", sanitized.Name)
+	suite.Equal(`R&D <team> "core"`, sanitized.Description)
+}
+
+func (suite *RoleHandlerTestSuite) TestSanitizeUpdateRoleRequest_PreservesSpecialCharacters() {
+	request := &UpdateRoleRequest{
+		Name:        "  Dean's Sub team  ",
+		Description: `  R&D <team> "core"  `,
+	}
+
+	sanitized := suite.handler.sanitizeUpdateRoleRequest(request)
+
+	suite.Equal("Dean's Sub team", sanitized.Name)
+	suite.Equal(`R&D <team> "core"`, sanitized.Description)
+}
+
+// The Console echoes the stored name back on every save. Replaying that loop must not drift the name.
+func (suite *RoleHandlerTestSuite) TestSanitizeUpdateRoleRequestIsIdempotentAcrossSaves() {
+	name := suite.handler.sanitizeCreateRoleRequest(&CreateRoleRequest{
+		Name: "Dean's Sub team",
+	}).Name
+
+	for i := 0; i < 5; i++ {
+		sanitized := suite.handler.sanitizeUpdateRoleRequest(&UpdateRoleRequest{
+			Name:        name,
+			Description: "save " + strconv.Itoa(i),
+		})
+		suite.Equal("Dean's Sub team", sanitized.Name)
+		name = sanitized.Name
+	}
 }
 
 func (suite *RoleHandlerTestSuite) TestSanitizeAssignmentsRequest() {

--- a/backend/internal/system/utils/http_util.go
+++ b/backend/internal/system/utils/http_util.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html"
 	"net/http"
 	"net/url"
 	"path"
@@ -450,7 +449,9 @@ func DecodeJSONResponse[T any](resp *http.Response) (*T, error) {
 	return &data, nil
 }
 
-// SanitizeString trims whitespace, removes control characters, and escapes HTML.
+// SanitizeString trims whitespace and removes control characters (except newline and tab).
+// It does NOT HTML-escape: escaping is an output-context concern and is applied at the
+// rendering sinks, so applying it here would corrupt the stored value.
 func SanitizeString(input string) string {
 	if input == "" {
 		return input
@@ -460,21 +461,16 @@ func SanitizeString(input string) string {
 	trimmed := strings.TrimSpace(input)
 
 	// Remove non-printable/control characters (except newline and tab)
-	cleaned := strings.Map(func(r rune) rune {
+	return strings.Map(func(r rune) rune {
 		if unicode.IsControl(r) && r != '\n' && r != '\t' {
 			return -1
 		}
 		return r
 	}, trimmed)
-
-	// Escape HTML to prevent XSS
-	safe := html.EscapeString(cleaned)
-
-	return safe
 }
 
 // SanitizeStringMap sanitizes a map of strings.
-// This function trim whitespace, removes control characters, and escapes HTML in each map entry.
+// This function trims whitespace and removes control characters in each map entry.
 func SanitizeStringMap(inputs map[string]string) map[string]string {
 	if len(inputs) == 0 {
 		return inputs

--- a/backend/internal/system/utils/http_util_test.go
+++ b/backend/internal/system/utils/http_util_test.go
@@ -439,7 +439,17 @@ func (suite *HTTPUtilTestSuite) TestSanitizeString() {
 		{
 			name:     "StringWithHTML",
 			input:    "String with <script>alert('XSS')</script> HTML",
-			expected: "String with &lt;script&gt;alert(&#39;XSS&#39;)&lt;/script&gt; HTML",
+			expected: "String with <script>alert('XSS')</script> HTML",
+		},
+		{
+			name:     "StringWithApostrophe",
+			input:    "  Dean's Sub team  ",
+			expected: "Dean's Sub team",
+		},
+		{
+			name:     "StringWithAmpersandAndQuotes",
+			input:    `R&D <team> "core"`,
+			expected: `R&D <team> "core"`,
 		},
 		{
 			name:     "StringWithControlChars",
@@ -507,7 +517,7 @@ func (suite *HTTPUtilTestSuite) TestSanitizeStringMap() {
 			},
 			expected: map[string]string{
 				"key1": "value with spaces",
-				"key2": "&lt;script&gt;alert(&#39;XSS&#39;)&lt;/script&gt;",
+				"key2": "<script>alert('XSS')</script>",
 				"key3": "ControlChar",
 			},
 		},
@@ -517,6 +527,25 @@ func (suite *HTTPUtilTestSuite) TestSanitizeStringMap() {
 		suite.T().Run(tc.name, func(t *testing.T) {
 			result := SanitizeStringMap(tc.input)
 			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+// Sanitizing an already sanitized value must be a no-op. Without this, values that survive a
+// read-modify-write cycle (e.g. a role name echoed back on update) accumulate encoding on every save.
+func (suite *HTTPUtilTestSuite) TestSanitizeStringIsIdempotent() {
+	inputs := []string{
+		"Dean's Sub team",
+		`R&D <team> "core"`,
+		"<script>alert('XSS')</script>",
+		"  padded  ",
+	}
+
+	for _, input := range inputs {
+		suite.T().Run(input, func(t *testing.T) {
+			once := SanitizeString(input)
+			assert.Equal(t, once, SanitizeString(once))
+			assert.Equal(t, once, SanitizeString(SanitizeString(once)))
 		})
 	}
 }

--- a/tests/integration/role/roleapi_test.go
+++ b/tests/integration/role/roleapi_test.go
@@ -1577,6 +1577,58 @@ func (suite *RoleAPITestSuite) TestDeleteResourceServer_CascadesToRolePermission
 	suite.Equal([]string{testPermission3}, updated.Permissions[0].Permissions)
 }
 
+// Names and descriptions must survive a create -> read -> update cycle byte for byte. The Console
+// echoes the returned name back on every save, so any encoding applied on input compounds per save.
+func (suite *RoleAPITestSuite) TestRoleRoundTrip_SpecialCharactersPreserved() {
+	const name = "Dean's Sub team"
+	const description = `R&D <team> "core"`
+
+	role, err := suite.createRole(CreateRoleRequest{
+		Name:        name,
+		Description: description,
+		OUID:        testOUID,
+		Permissions: []ResourcePermissions{
+			{
+				ResourceServerID: testResourceServer1ID,
+				Permissions:      []string{testPermission1},
+			},
+		},
+	})
+	suite.Require().NoError(err)
+	suite.Require().NotNil(role)
+	defer func() { _ = suite.deleteRole(role.ID) }()
+
+	suite.Equal(name, role.Name, "create response must echo the name verbatim")
+	suite.Equal(description, role.Description, "create response must echo the description verbatim")
+
+	fetched, err := suite.getRole(role.ID)
+	suite.Require().NoError(err)
+	suite.Equal(name, fetched.Name, "stored name must match what was sent")
+	suite.Equal(description, fetched.Description, "stored description must match what was sent")
+
+	// Replay the Console edit loop: echo the returned name back, change only the description.
+	for i := 0; i < 3; i++ {
+		updated, updateErr := suite.updateRole(role.ID, UpdateRoleRequest{
+			Name:        fetched.Name,
+			Description: description,
+			OUID:        testOUID,
+			Permissions: []ResourcePermissions{
+				{
+					ResourceServerID: testResourceServer1ID,
+					Permissions:      []string{testPermission1},
+				},
+			},
+		})
+		suite.Require().NoError(updateErr)
+		suite.Equal(name, updated.Name, "name must not drift on save %d", i+1)
+
+		fetched, err = suite.getRole(role.ID)
+		suite.Require().NoError(err)
+		suite.Equal(name, fetched.Name, "stored name must not drift after save %d", i+1)
+		suite.Equal(description, fetched.Description, "stored description must not drift after save %d", i+1)
+	}
+}
+
 // Helper methods
 
 func (suite *RoleAPITestSuite) createRole(request CreateRoleRequest) (*Role, error) {


### PR DESCRIPTION
### Purpose

Special characters in role names and descriptions were stored HTML-encoded and re-encoded on every subsequent edit: `Dean's Sub team` became `Dean&#39;s Sub team`, then `Dean&amp;#39;s Sub team`, growing with each save until the 100-character limit made the role uneditable.

`SanitizeString` applied `html.EscapeString` at the input boundary, so the entity-encoded form was what got persisted. The escape is not idempotent, and the Console echoes the stored name back on every save, so the value compounded per edit.

### Approach

Removed `html.EscapeString` from `SanitizeString`. It now trims whitespace and strips control characters (still preserving `\n` and `\t`). Escaping is an output-context transform and stays at the output sinks, which already perform it.

Also removed the compensating `html.UnescapeString` in `consent_executor.go`. It existed only to undo the sanitizer's escaping of the `consent_decisions` JSON, and with the escape gone it would corrupt a legitimate `&amp;` in a consent value.

Fixing the shared sanitizer rather than the role package alone also resolves the same defect on groups, organization units, resource servers, entity types, flows, i18n translations, and the user search filter (where an escaped filter value could not match raw stored data).

**Output escaping verified intact** — this change does not weaken it:

- **Console/gate**: the frontend has exactly four raw-HTML sinks (`RichTextAdapter.tsx:142`, `:168`, `:181`, `SimulationScreenSketch.tsx:130`) and all four wrap their input in `DOMPurify.sanitize`. The one other `.innerHTML` occurrence (`HTMLPlugin.tsx:132`) is a read, not a write. `react/no-danger` is `['error', {customComponentNames: ['*']}]`, so a new sink cannot land without an explicit disable comment. Role name and description reach only React text children and `TextField value=`, never an `href`, `src`, `style`, or JS context.
- **Server-side HTML**: the only HTML-rendering path, `system/template/service.go:81`, escapes its own `{{ctx(key)}}` placeholders when the content type is `text/html`. That path was double-escaping stored values before this change and now escapes exactly once.
- **SQL**: role writes use bound placeholders and filter values are passed as query arguments, so nothing on that path depended on the escape.

One behavior change worth noting: OU and application names are meta-template keys (`{{meta(ou.name)}}`) that `RichTextAdapter` resolves before handing the string to DOMPurify. Stored raw, benign markup such as `<b>` in one of those admin-authored values now renders as markup where it previously displayed as literal `&lt;b&gt;`. DOMPurify still strips scripts and event handlers.

Values already stored in encoded form are not repaired; affected resources need renaming.

### Related Issues
- Fixes #4707
- Fixes #4493

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved apostrophes, ampersands, angle brackets, quotes, and HTML entities in consent decisions, group names, organizational-unit names, and role details.
  * Prevented repeated updates from altering already-preserved text.
  * Continued trimming whitespace and removing control characters while retaining newlines and tabs.
* **Tests**
  * Added coverage confirming special characters remain unchanged through API creation, retrieval, and repeated updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->