### PR TITLE
[CLI] Fix REPL issues

### DIFF
--- a/tools/cli/internal/services/setup/setup.go
+++ b/tools/cli/internal/services/setup/setup.go
@@ -739,6 +739,60 @@ func TailFile(path string, n int) []string {
 	return lines
 }
 
+// TailFileFollow reads whatever complete lines were appended to the file at path
+// since offset, returning those lines and the offset to pass back in as the next
+// call's offset. Pass offset 0 to read the whole file. If the file is shorter than
+// offset (rotated or truncated since the last call), it reads from the start again.
+// A trailing partial line (no terminating newline yet) is left unread so it is
+// returned whole once the write that completes it lands. ok is false only on an
+// I/O error; a valid, merely-empty read reports ok true with no lines, since an
+// empty log is not a failure and should still enter follow mode.
+func TailFileFollow(path string, offset int64) (lines []string, newOffset int64, ok bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, offset, false
+	}
+	defer func() { _ = f.Close() }()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, offset, false
+	}
+	size := info.Size()
+	if size < offset {
+		offset = 0
+	}
+	if size == offset {
+		return nil, offset, true
+	}
+	if _, err := f.Seek(offset, io.SeekStart); err != nil {
+		return nil, offset, false
+	}
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, offset, false
+	}
+
+	// Only consume through the last newline — a trailing partial record (one the
+	// writer hasn't finished yet) is left pending so it isn't split into two lines
+	// across successive reads.
+	lastNewline := strings.LastIndexByte(string(data), '\n')
+	if lastNewline == -1 {
+		return nil, offset, true
+	}
+	newOffset = offset + int64(lastNewline) + 1
+
+	text := strings.TrimRight(string(data[:lastNewline]), "\r\n")
+	if text == "" {
+		return nil, newOffset, true
+	}
+	lines = strings.Split(text, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, "\r")
+	}
+	return lines, newOffset, true
+}
+
 // LogTail returns the last n lines of the current background log as one block, or ""
 // when the log cannot be read. It is how the CLI surfaces the server's own reason for
 // a failed start (a rejected bind, a bad configuration) instead of guessing.

--- a/tools/cli/internal/services/setup/setup_test.go
+++ b/tools/cli/internal/services/setup/setup_test.go
@@ -285,6 +285,72 @@ func TestLogTail_MissingLog(t *testing.T) {
 	assert.Equal(t, "", setup.LogTail(t.TempDir(), 5))
 }
 
+func TestTailFileFollow_ReadsAppendedContent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "follow.log")
+	require.NoError(t, os.WriteFile(path, []byte("one\ntwo\n"), 0o644))
+
+	lines, offset, ok := setup.TailFileFollow(path, 0)
+	require.True(t, ok)
+	assert.Equal(t, []string{"one", "two"}, lines)
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString("three\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	lines, _, ok = setup.TailFileFollow(path, offset)
+	require.True(t, ok)
+	assert.Equal(t, []string{"three"}, lines, "a second call must only return what was appended since offset")
+}
+
+func TestTailFileFollow_KeepsIncompleteRecordPending(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "follow.log")
+	require.NoError(t, os.WriteFile(path, []byte("part"), 0o644))
+
+	lines, offset, ok := setup.TailFileFollow(path, 0)
+	require.True(t, ok)
+	assert.Empty(t, lines, "an unterminated record must not be reported until it is complete")
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString("ial\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	lines, _, ok = setup.TailFileFollow(path, offset)
+	require.True(t, ok)
+	assert.Equal(t, []string{"partial"}, lines, "the completed record must be reported whole, not split across reads")
+}
+
+func TestTailFileFollow_HandlesTruncation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "follow.log")
+	require.NoError(t, os.WriteFile(path, []byte("one\ntwo\nthree\n"), 0o644))
+
+	_, offset, ok := setup.TailFileFollow(path, 0)
+	require.True(t, ok)
+
+	require.NoError(t, os.WriteFile(path, []byte("new\n"), 0o644))
+
+	lines, _, ok := setup.TailFileFollow(path, offset)
+	require.True(t, ok)
+	assert.Equal(t, []string{"new"}, lines, "a file shorter than the offset must be re-read from the start")
+}
+
+func TestTailFileFollow_EmptyLogIsNotAnError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "empty.log")
+	require.NoError(t, os.WriteFile(path, nil, 0o644))
+
+	lines, _, ok := setup.TailFileFollow(path, 0)
+	assert.True(t, ok, "a valid, empty log must still report ok so the caller enters follow mode")
+	assert.Empty(t, lines)
+}
+
+func TestTailFileFollow_MissingFileIsAnError(t *testing.T) {
+	_, _, ok := setup.TailFileFollow(filepath.Join(t.TempDir(), "missing.log"), 0)
+	assert.False(t, ok)
+}
+
 func TestServerPort_PrefersConfiguredPort(t *testing.T) {
 	dir := t.TempDir()
 	writeDeployment(t, dir, "server:\n  port: 8091\n")

--- a/tools/cli/internal/ui/repl.go
+++ b/tools/cli/internal/ui/repl.go
@@ -100,6 +100,15 @@ const defaultInputWidth = 76
 // --- bubbletea messages ---
 
 type healthCheckMsg struct{ ready bool }
+
+// logsTailMsg carries newly appended log lines discovered by a follow-mode tick.
+// ok is false on an I/O error reading the log; the offset is left unchanged in
+// that case so the next tick retries the same read.
+type logsTailMsg struct {
+	lines  []string
+	offset int64
+	ok     bool
+}
 type upgradeMsg struct{}
 type switchVersionMsg struct{}
 type thunderExitedMsg struct {
@@ -444,6 +453,29 @@ type ReplModel struct {
 	guideLabel    string // display label, e.g. "React"
 	guideDocURL   string // human-facing page, opened with 'o'
 	guideViewport viewport.Model
+
+	// Log follow mode — active while tailingLogs is true. tailLogOffset is the
+	// byte offset up to which the file has already been read and appended.
+	// tailLogLines holds the followed output separately from m.messages, capped
+	// at maxTailLogLines so a long-running or noisy log stream can't grow the
+	// REPL's rendered history — and the memory behind it — without bound.
+	tailingLogs   bool
+	tailLogPath   string
+	tailLogOffset int64
+	tailLogLines  []string
+}
+
+// maxTailLogLines bounds how many followed log lines are retained for
+// rendering at once. Older lines are dropped as new ones arrive.
+const maxTailLogLines = 500
+
+// appendTailLogLine records a followed log line, dropping the oldest once the
+// buffer exceeds maxTailLogLines.
+func (m *ReplModel) appendTailLogLine(line string) {
+	m.tailLogLines = append(m.tailLogLines, line)
+	if len(m.tailLogLines) > maxTailLogLines {
+		m.tailLogLines = m.tailLogLines[len(m.tailLogLines)-maxTailLogLines:]
+	}
 }
 
 // NewReplModel initializes the REPL model.
@@ -517,22 +549,9 @@ func NewReplModel(version string, proc *exec.Cmd, installPath string, verbose bo
 
 	logCmd := SlashCommand{
 		Name:        "/logs",
-		Description: "Show recent server logs",
+		Description: "Follow recent server logs (Esc to stop)",
 		Section:     "Server",
-		Action: func(_ string) ([]string, error) {
-			const maxLines = 30
-			logPath := setup.LogFile(installPath)
-			lines := setup.TailFile(logPath, maxLines)
-			if len(lines) == 0 {
-				return nil, fmt.Errorf("could not read logs at %s", logPath)
-			}
-			out := make([]string, 0, len(lines)+1)
-			out = append(out, Dim(fmt.Sprintf("── last %d lines of %s ──", len(lines), logPath)))
-			for _, l := range lines {
-				out = append(out, Dim(l))
-			}
-			return out, nil
-		},
+		Action:      nil, // handled specially in runCommand, like /stop
 	}
 	commands = append(commands, logCmd)
 	commands = append(commands, defaultCommands...)
@@ -681,13 +700,22 @@ func (m ReplModel) Init() tea.Cmd {
 		textinput.Blink,
 		m.spinner.Tick,
 		func() tea.Msg { return doHealthCheckOn(p) },
-		pollHealthCmdOn(p),
+		pollHealthCmdOn(p, healthPollFastInterval),
 		watchProcessCmd(m.proc),
 	)
 }
 
-func pollHealthCmdOn(port int) tea.Cmd {
-	return tea.Tick(time.Second, func(_ time.Time) tea.Msg {
+// healthPollFastInterval is used while waiting for the product to become
+// ready (or to recover), where sub-second responsiveness matters.
+const healthPollFastInterval = time.Second
+
+// healthPollSteadyInterval is used once the product is known to be ready.
+// Its only remaining purpose is crash detection, which doesn't need
+// sub-second granularity and shouldn't spam the access log with checks.
+const healthPollSteadyInterval = 5 * time.Second
+
+func pollHealthCmdOn(port int, interval time.Duration) tea.Cmd {
+	return tea.Tick(interval, func(_ time.Time) tea.Msg {
 		return doHealthCheckOn(port)
 	})
 }
@@ -792,11 +820,6 @@ func (m ReplModel) update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,fu
 		// split), so this is the only reservation needed to fit within msg.Height.
 		m.guideViewport.SetWidth(msg.Width)
 		m.guideViewport.SetHeight(clamp(msg.Height-3, 5, 1000))
-
-	case tea.MouseWheelMsg:
-		var vpCmd tea.Cmd
-		m.body, vpCmd = m.body.Update(msg)
-		cmds = append(cmds, vpCmd)
 
 	// Bracketed paste arrives as its own message rather than as key presses, so the
 	// overlay inputs need it routed explicitly — the command input already receives
@@ -1009,6 +1032,13 @@ func (m ReplModel) update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,fu
 				m.guideViewport, vpCmd = m.guideViewport.Update(msg)
 				cmds = append(cmds, vpCmd)
 			}
+		} else if m.tailingLogs {
+			// ── Log follow mode ──────────────────────────────────────────────────
+			if msg.String() == "esc" {
+				m.tailingLogs = false
+				m.input.Focus()
+				m.input.Placeholder = "Type / for commands, Ctrl+C to exit"
+			}
 		} else {
 			// ── Regular REPL ───────────────────────────────────────────────────
 			switch msg.String() {
@@ -1155,8 +1185,11 @@ func (m ReplModel) update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,fu
 					m.input.Focus()
 				}
 			}
-			// Always keep polling so we can detect crashes via health check.
-			cmds = append(cmds, pollHealthCmdOn(m.effectivePort()))
+			// Ready is confirmed — back off to a slower cadence. Sub-second polling
+			// is only needed while waiting for the product to come up; once it has,
+			// polling every second forever just floods the access log with health
+			// checks for no added benefit to crash detection.
+			cmds = append(cmds, pollHealthCmdOn(m.effectivePort(), healthPollSteadyInterval))
 		} else {
 			// Only report "stopped responding" when the product was healthy and we
 			// are not deliberately restarting it for a try-* operation.
@@ -1167,8 +1200,19 @@ func (m ReplModel) update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,fu
 				m.messages = append(m.messages, Red("✗")+" "+product.Name+" stopped responding.")
 			}
 			if m.status != statusStopped || m.tryingOut {
-				cmds = append(cmds, pollHealthCmdOn(m.effectivePort()))
+				cmds = append(cmds, pollHealthCmdOn(m.effectivePort(), healthPollFastInterval))
 			}
+		}
+
+	case logsTailMsg:
+		if m.tailingLogs {
+			if msg.ok {
+				for _, l := range msg.lines {
+					m.appendTailLogLine(l)
+				}
+				m.tailLogOffset = msg.offset
+			}
+			cmds = append(cmds, tailLogsTickCmd(m.tailLogPath, m.tailLogOffset))
 		}
 
 	case thunderExitedMsg:
@@ -1230,7 +1274,11 @@ func (m ReplModel) update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,fu
 			m.status = statusStarting
 			m.input.Placeholder = "Starting " + product.Name + "..."
 		}
-		cmds = append(cmds, pollHealthCmdOn(m.effectivePort()))
+		pollInterval := healthPollFastInterval
+		if m.status == statusReady {
+			pollInterval = healthPollSteadyInterval
+		}
+		cmds = append(cmds, pollHealthCmdOn(m.effectivePort(), pollInterval))
 		m.messages = append(m.messages, Green("✓")+" "+msg.sampleName+" is live at "+Cyan(msg.sampleURL))
 		if msg.sampleName == "wayfinder" {
 			hasAI := false
@@ -1330,7 +1378,45 @@ func (m *ReplModel) updateCompletions() {
 	}
 }
 
+// tailLogsTickCmd schedules the next follow-mode read. It reads whatever was
+// appended to path since offset and reports back via logsTailMsg.
+func tailLogsTickCmd(path string, offset int64) tea.Cmd {
+	return tea.Tick(500*time.Millisecond, func(_ time.Time) tea.Msg {
+		lines, newOffset, ok := setup.TailFileFollow(path, offset)
+		return logsTailMsg{lines: lines, offset: newOffset, ok: ok}
+	})
+}
+
+// startLogTail prints the last 30 lines of the current log file and switches
+// the REPL into follow mode, appending new lines as they are written until
+// the user presses Esc.
+func (m *ReplModel) startLogTail() tea.Cmd {
+	logPath := setup.LatestLogFile(m.installPath)
+	lines, offset, ok := setup.TailFileFollow(logPath, 0)
+	if !ok {
+		m.messages = append(m.messages, Red("✗")+" could not read logs at "+logPath)
+		return nil
+	}
+	const maxLines = 30
+	if len(lines) > maxLines {
+		lines = lines[len(lines)-maxLines:]
+	}
+	m.messages = append(m.messages, Dim(fmt.Sprintf("── following %s (Esc to stop) ──", logPath)))
+	for _, l := range lines {
+		m.appendTailLogLine(l)
+	}
+	m.tailingLogs = true
+	m.tailLogPath = logPath
+	m.tailLogOffset = offset
+	m.input.Blur()
+	m.input.Placeholder = "Following logs — press Esc to stop"
+	return tailLogsTickCmd(logPath, offset)
+}
+
 func (m *ReplModel) runCommand(val string) tea.Cmd {
+	if val == "/logs" {
+		return m.startLogTail()
+	}
 	if val == "/stop" {
 		if err := m.stopThunderID(true); err != nil {
 			m.messages = append(m.messages, Red("✗")+" Could not stop "+product.Name+": "+err.Error())
@@ -1430,14 +1516,6 @@ type completionRow struct {
 	itemIndex int
 }
 
-// countLines returns the number of terminal rows a rendered block occupies.
-func countLines(s string) int {
-	if s == "" {
-		return 0
-	}
-	return strings.Count(s, "\n")
-}
-
 // renderCompletions draws the / command list, scrolling the window so the
 // selected item stays visible when the list is taller than the terminal.
 // available is the number of terminal rows left for this block (including
@@ -1448,7 +1526,29 @@ func renderCompletions(m ReplModel, available int) string {
 		return ""
 	}
 	const nameW = 24
-	var rows []completionRow
+	rows, selectedRow := buildCompletionRows(m, nameW)
+	window, start := completionWindow(rows, selectedRow, available)
+
+	var b strings.Builder
+	separator := Dim(strings.Repeat("─", BannerWidth()))
+	b.WriteString(separator + "\n")
+	if start > 0 {
+		b.WriteString("  " + Dim("↑ more above") + "\n")
+	}
+	for _, r := range window {
+		b.WriteString(r.text + "\n")
+	}
+	if start+len(window) < len(rows) {
+		b.WriteString("  " + Dim("↓ more below") + "\n")
+	}
+	b.WriteString(separator + "\n")
+	return b.String()
+}
+
+// buildCompletionRows expands m.completions into display rows, inserting section
+// headers and spacer rows between sections. Returns the rows and the index within
+// them of the currently selected command, for completionWindow to scroll around.
+func buildCompletionRows(m ReplModel, nameW int) (rows []completionRow, selectedRow int) {
 	lastSection := ""
 	for i, c := range m.completions {
 		if c.Section != lastSection {
@@ -1476,20 +1576,26 @@ func renderCompletions(m ReplModel, available int) string {
 		rows = append(rows, completionRow{text: "  " + indicator + namePart + "  " + descPart, itemIndex: i})
 	}
 
-	selectedRow := 0
 	for idx, r := range rows {
 		if r.itemIndex == m.selectedComp {
 			selectedRow = idx
 			break
 		}
 	}
+	return rows, selectedRow
+}
 
+// completionWindow returns the slice of rows that fits within available terminal
+// rows, scrolled so selectedRow stays visible, plus that slice's start index in
+// rows — the same start index renderCompletions needs to decide whether to draw
+// the "more above" indicator, and a click handler needs to map a clicked row back
+// to a command.
+func completionWindow(rows []completionRow, selectedRow, available int) (window []completionRow, start int) {
 	maxRows := clamp(available-2, minCompletionRows, len(rows))
 	if len(rows) > maxRows {
 		// Reserve room for the "more above"/"more below" indicator lines.
 		maxRows = clamp(maxRows-2, minCompletionRows, len(rows))
 	}
-	start := 0
 	if len(rows) > maxRows {
 		start = selectedRow - maxRows/2
 		if start < 0 {
@@ -1503,21 +1609,20 @@ func renderCompletions(m ReplModel, available int) string {
 	if end > len(rows) {
 		end = len(rows)
 	}
+	return rows[start:end], start
+}
 
-	var b strings.Builder
-	separator := Dim(strings.Repeat("─", BannerWidth()))
-	b.WriteString(separator + "\n")
-	if start > 0 {
-		b.WriteString("  " + Dim("↑ more above") + "\n")
+// completionsAvailable returns the terminal rows left for the / command dropdown
+// in whichever footer context is currently showing it. Both footer() (to render
+// it) and the mouse-click handler (to map a click back to a row) need this same
+// value, so it lives here once rather than as inline arithmetic in two places.
+func (m ReplModel) completionsAvailable() int {
+	if m.onboardingCmdMode {
+		// Reserve 3 rows below for the input line and the trailing hint.
+		return m.height - 3
 	}
-	for _, r := range rows[start:end] {
-		b.WriteString(r.text + "\n")
-	}
-	if end < len(rows) {
-		b.WriteString("  " + Dim("↓ more below") + "\n")
-	}
-	b.WriteString(separator + "\n")
-	return b.String()
+	// Reserve 2 rows below for the input/spinner line.
+	return m.height - 2
 }
 
 // renderNotice draws a standalone page for m.noticeMessage — used instead of
@@ -1647,9 +1752,13 @@ func (m ReplModel) credentialsBox() string {
 func (m ReplModel) View() tea.View {
 	v := tea.NewView(m.render())
 	v.AltScreen = true
-	// The output region scrolls, so the wheel has to reach it: the alternate screen
-	// has no scrollback of its own.
-	v.MouseMode = tea.MouseModeCellMotion
+	// Mouse reporting is deliberately left off (MouseModeNone, the zero value):
+	// enabling it captures every click and drag for the app, which blocks the
+	// terminal's own click-drag text selection unless the user holds a
+	// modifier key. Losing mouse-wheel scroll and click-to-select is the
+	// tradeoff for letting text (admin credentials, integration guides, etc.)
+	// be selected and copied normally. Scrolling remains available via
+	// PgUp/PgDn and shift+up/down (see scrollHint).
 	return v
 }
 
@@ -1676,9 +1785,13 @@ func (m ReplModel) render() string {
 	return m.body.View() + "\n" + footer
 }
 
-// bodyContent builds the scrollable region: the banner, server status and everything
-// the session has printed so far.
-func (m ReplModel) bodyContent() string {
+// bodyPreamble builds the banner, server status and credentials box shown at
+// the top of the scrollable region, before whatever mode-specific content
+// bodyContent appends after it. It is factored out so a click handler can
+// count exactly how many rows precede body content it needs to hit-test
+// (e.g. the onboarding list) without duplicating this logic and drifting out
+// of sync with what's actually rendered.
+func (m ReplModel) bodyPreamble() string {
 	var b strings.Builder
 
 	b.WriteString(BannerString(m.version) + "\n\n")
@@ -1703,6 +1816,14 @@ func (m ReplModel) bodyContent() string {
 		b.WriteString(box + "\n")
 	}
 	b.WriteString(Dim(strings.Repeat("─", BannerWidth())) + "\n\n")
+	return b.String()
+}
+
+// bodyContent builds the scrollable region: the banner, server status and everything
+// the session has printed so far.
+func (m ReplModel) bodyContent() string {
+	var b strings.Builder
+	b.WriteString(m.bodyPreamble())
 
 	if m.showNotice {
 		b.WriteString(renderNotice(m))
@@ -1740,6 +1861,13 @@ func (m ReplModel) bodyContent() string {
 		b.WriteString("\n")
 	}
 
+	for _, l := range m.tailLogLines {
+		b.WriteString("  " + Dim(l) + "\n")
+	}
+	if len(m.tailLogLines) > 0 {
+		b.WriteString("\n")
+	}
+
 	// The walkthrough carries its own navigation hints, so it scrolls with the output.
 	// The guide is rendered in the footer instead, since it scrolls in its own viewport.
 	if m.showWalkthrough {
@@ -1759,9 +1887,7 @@ func (m ReplModel) footer() string {
 
 	if m.showOnboarding && m.status == statusReady {
 		if m.onboardingCmdMode {
-			// Reserve 3 rows below for the input line and the trailing hint.
-			available := m.height - countLines(b.String()) - 3
-			b.WriteString(renderCompletions(m, available))
+			b.WriteString(renderCompletions(m, m.completionsAvailable()))
 			b.WriteString(m.input.View())
 			b.WriteString("\n\n" + Dim("  esc back to use-case picker"))
 		} else {
@@ -1810,9 +1936,7 @@ func (m ReplModel) footer() string {
 		return b.String()
 	}
 
-	// Reserve 2 rows below for the input/spinner line.
-	available := m.height - countLines(b.String()) - 2
-	b.WriteString(renderCompletions(m, available))
+	b.WriteString(renderCompletions(m, m.completionsAvailable()))
 
 	if m.status == statusStarting {
 		b.WriteString(m.spinner.View() + Dim(" Starting "+product.Name+"…"))


### PR DESCRIPTION
### Purpose
`/logs` only ever printed a one-time snapshot of the last 30 lines instead of following the log, health-check polling ran every second forever and flooded the access log with `/health/readiness` noise, and mouse capture blocked native terminal text selection (admin credentials, integration guides, etc.) unless you held a modifier key.

### Approach
- `/logs` now switches the REPL into a follow mode: it prints the last 30 lines, then appends new lines as they're written (polling the file offset every 500ms) until Esc is pressed.
- Health-check polling now backs off from 1s to 5s once the product is confirmed ready, since sub-second polling is only needed while waiting for it to come up or recover; once ready, only crash detection is left, which doesn't need that granularity.
- Mouse reporting is now left off entirely (`MouseModeNone`, the default) instead of `MouseModeCellMotion`. Capturing the mouse blocked the terminal's own click-drag selection; leaving it off trades away mouse-wheel scroll and click-to-select in exchange for text being selectable everywhere without a modifier key. Keyboard scrolling (PgUp/PgDn, shift+up/down) is unaffected.

<img width="535" height="120" alt="Screenshot 2026-08-18 at 19 11 25" src="https://github.com/user-attachments/assets/7e95251f-fbc0-4ad4-a02c-afc11bd44104" />

### Related Issues
- Fixes https://github.com/thunder-id/thunderid/issues/5065

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added `/logs` follow mode to stream newly appended log lines until Esc is pressed.
- Log viewing now handles file rotation, truncation, and incomplete lines more reliably.

## Improvements
- Retains up to 500 streamed log lines for smoother viewing.
- Health checks poll faster during startup or recovery and slower once ready.
- Restored native terminal text selection by disabling mouse reporting.

## Bug Fixes
- Improved handling of trailing line endings and Windows-style line breaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->