### PR TITLE
DO NOT MERGE — test probe for the backend integration patch coverage check

### DIFF
--- a/backend/internal/system/healthcheck/handler/healthcheckhandler.go
+++ b/backend/internal/system/healthcheck/handler/healthcheckhandler.go
@@ -29,7 +29,7 @@ func NewHealthCheckHandler(svc service.HealthCheckServiceInterface) *HealthCheck
 func (hch *HealthCheckHandler) HandleLivenessRequest(w http.ResponseWriter, r *http.Request) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "HealthCheckHandler"))
 	w.WriteHeader(http.StatusOK)
-	logger.Debug(r.Context(), "Health Check Liveness response sent")
+	logger.Debug(r.Context(), "Health Check Liveness response sent to the caller")
 }
 
 // HandleReadinessRequest handles the health check readiness request.
@@ -41,8 +41,9 @@ func (hch *HealthCheckHandler) HandleReadinessRequest(w http.ResponseWriter, r *
 
 	statusCode := http.StatusOK
 	if serverstatus.Status != model.StatusUp {
-		logger.Error(ctx, "Readiness check failed",
-			log.String("serverstatus", string(serverstatus.Status)))
+		logger.Error(ctx, "Readiness check failed for the server",
+			log.String("serverstatus", string(serverstatus.Status)),
+			log.String("probe", "readiness"))
 		statusCode = http.StatusServiceUnavailable
 	} else {
 		logger.Debug(ctx, "Readiness check passed",


### PR DESCRIPTION
## Purpose

Temporary **draft** probe to observe the new `🛡️ Backend Integration Patch Coverage` check running against real CI. Companion to #5014, which adds the check itself. **Not for merge — close once observed.**

#5014's own diff is `.github/`-only, so it correctly reports `N/A` and never exercises the measurement path. This PR carries the check *and* a backend change, so the arithmetic actually runs.

## What it changes

Two log messages in `healthcheckhandler.go`, picked from a real integration coverage profile so the result is predictable:

| Change | Coverage block | Expected |
|---|---|---|
| liveness response message | `29.94,33.2 1 **1**` | covered — the harness polls liveness |
| readiness *failure* branch | `43.43,47.3 2 **0**` | uncovered — the server is healthy in tests |

One covered, one uncovered, so the check should report a **real mid-range percentage and fail** against the 70% threshold, listing the readiness lines as missing. A 0% or 100% result would suggest the line mapping is off.

No behaviour changes — log text only, and nothing asserts on those strings.

## What to look for

- The check reports at all, and the artifact layout assumption holds (`coverage-artifacts/integration-coverage-<db>/coverage_integration.out`)
- `Total` lines is small and plausible. A large number means `fetch-depth: 0` didn't give a reachable merge base and the whole history is being treated as new
- The summary names all three databases: `Measured from integration runs only: postgres redis sqlite (union)`
- The readiness lines appear as uncovered

Requires the `trigger-pr-builder` label to start the pipeline.