### PR TITLE
Add Explicit Signout Flow to Wayfinder Sample App

### DIFF
--- a/samples/apps/wayfinder-sample/thunderid-config/app-native/thunderid-config.yaml
+++ b/samples/apps/wayfinder-sample/thunderid-config/app-native/thunderid-config.yaml
@@ -478,6 +478,54 @@ nodes:
 
 ---
 resource_type: flow
+id: 0193b0a1-1001-7000-8000-000000000003
+name: Wayfinder Sign Out Flow
+handle: wayfinder-signout-flow
+flowType: SIGNOUT
+nodes:
+  - id: start
+    type: START
+    onSuccess: session_signout
+  - id: session_signout
+    type: TASK_EXECUTION
+    properties:
+      promptOnSignOut: false
+    executor:
+      name: SessionSignOutExecutor
+    onSuccess: end
+    onIncomplete: prompt_confirm
+  - id: prompt_confirm
+    type: PROMPT
+    meta:
+      components:
+        - align: center
+          type: TEXT
+          id: text_signout_title
+          label: Sign out?
+          variant: HEADING_1
+        - align: center
+          type: TEXT
+          id: text_signout_desc
+          label: You'll need to sign in again to continue.
+          variant: HEADING_6
+        - type: BLOCK
+          id: block_signout
+          components:
+            - type: ACTION
+              id: action_confirm
+              label: Sign out
+              variant: PRIMARY
+              eventType: SUBMIT
+    prompts:
+      - action:
+          ref: action_confirm
+          type: CONFIRM
+          nextNode: session_signout
+  - id: end
+    type: END
+
+---
+resource_type: flow
 id: 0193b0a1-1001-7000-8000-000000000005
 name: Wayfinder Staff Onboarding Flow
 handle: wayfinder-onboarding-flow
@@ -1101,6 +1149,7 @@ logoUrl: "emoji:✈️"
 authFlowHandle: wayfinder-app-auth-flow
 registrationFlowHandle: wayfinder-registration-flow
 recoveryFlowHandle: wayfinder-recovery-flow
+signOutFlowHandle: wayfinder-signout-flow
 isRegistrationFlowEnabled: true
 isRecoveryFlowEnabled: true
 assertion:

--- a/samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid-config.yaml
+++ b/samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid-config.yaml
@@ -477,6 +477,54 @@ nodes:
 
 ---
 resource_type: flow
+id: 0193b0a1-1001-7000-8000-000000000003
+name: Wayfinder Sign Out Flow
+handle: wayfinder-signout-flow
+flowType: SIGNOUT
+nodes:
+  - id: start
+    type: START
+    onSuccess: session_signout
+  - id: session_signout
+    type: TASK_EXECUTION
+    properties:
+      promptOnSignOut: false
+    executor:
+      name: SessionSignOutExecutor
+    onSuccess: end
+    onIncomplete: prompt_confirm
+  - id: prompt_confirm
+    type: PROMPT
+    meta:
+      components:
+        - align: center
+          type: TEXT
+          id: text_signout_title
+          label: Sign out?
+          variant: HEADING_1
+        - align: center
+          type: TEXT
+          id: text_signout_desc
+          label: You'll need to sign in again to continue.
+          variant: HEADING_6
+        - type: BLOCK
+          id: block_signout
+          components:
+            - type: ACTION
+              id: action_confirm
+              label: Sign out
+              variant: PRIMARY
+              eventType: SUBMIT
+    prompts:
+      - action:
+          ref: action_confirm
+          type: CONFIRM
+          nextNode: session_signout
+  - id: end
+    type: END
+
+---
+resource_type: flow
 id: 0193b0a1-1001-7000-8000-000000000005
 name: Wayfinder Staff Onboarding Flow
 handle: wayfinder-onboarding-flow
@@ -948,6 +996,7 @@ logoUrl: "emoji:✈️"
 authFlowHandle: wayfinder-app-auth-flow
 registrationFlowHandle: wayfinder-registration-flow
 recoveryFlowHandle: wayfinder-recovery-flow
+signOutFlowHandle: wayfinder-signout-flow
 isRegistrationFlowEnabled: true
 isRecoveryFlowEnabled: true
 assertion:

--- a/tests/e2e/tests/welcome/wayfinder-sample-setup.spec.ts
+++ b/tests/e2e/tests/welcome/wayfinder-sample-setup.spec.ts
@@ -100,6 +100,7 @@ const RESOURCE_MANIFEST: Array<{
     expected: [
       "Wayfinder Registration Flow",
       "Wayfinder Password Recovery Flow",
+      "Wayfinder Sign Out Flow",
       "Wayfinder Staff Onboarding Flow",
       "Default Wayfinder CIBA Email Notification Flow",
       "Default Wayfinder CIBA SMS Notification Flow",


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

The Wayfinder sample's `Wayfinder` application had no sign-out flow configured, so RP-initiated logout (`GET /oauth2/logout`) returned `500 { "error": "logout failed" }` (backend: `"Sign-out flow is not configured for the application"`) when the default sign-out flow was overwritten.

The app was implicitly relying on ThunderID's server-wide default sign-out flow. By design, Wayfinder should be self sufficient with its flows and ideally should not rely on default flows.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

Added a `SIGNOUT` flow, `Wayfinder Sign Out Flow` (handle: `wayfinder-signout-flow`), to both the `redirect` and `app-native` Wayfinder config bundles. It mirrors ThunderID's own bootstrap default sign-out flow.

Wired `wayfinder-app` to it via an explicit `signOutFlowHandle`, matching how the app already declares its own `authFlowHandle`, `registrationFlowHandle`, and `recoveryFlowHandle` rather than relying on implicit server/OU defaults. This removes Wayfinder's dependency on global default-flow state entirely, independent of whatever happens to that state elsewhere.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/5024

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Wayfinder sign-out flow with optional confirmation prompting.
  * Sign-out now attempts a silent session termination before requesting confirmation when necessary.
  * Configured the Wayfinder application to use the new sign-out flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->