### PR TITLE
Expose createdAt and updatedAt on user API responses

### DIFF
--- a/api/user.yaml
+++ b/api/user.yaml
@@ -64,6 +64,8 @@ paths:
                       contactPreferences:
                         - email
                         - sms
+                    createdAt: "2026-08-17T09:12:03Z"
+                    updatedAt: "2026-08-17T10:44:51Z"
                   - id: "039bda67-a80d-4b7b-ac0f-36db85332089"
                     ouId: "456e8400-e29b-41d4-a716-446655440001"
                     type: "customer"
@@ -76,6 +78,8 @@ paths:
                         zip: "94301"
                       contactPreferences:
                         - sms
+                    createdAt: "2026-08-16T14:03:22Z"
+                    updatedAt: "2026-08-16T14:03:22Z"
                   - id: "e1b6ba6c-deb2-4d24-87b0-bbf79fa4487c"
                     ouId: "26eec421-f1bb-4deb-a5d3-9ab6554c2ae6"
                     type: "employee"
@@ -85,6 +89,8 @@ paths:
                       lastname: "Wu"
                       department: "Engineering"
                       email: "alice.wu@company.inc"
+                    createdAt: "2026-08-15T08:20:10Z"
+                    updatedAt: "2026-08-17T11:05:44Z"
                 links:
                   - href: "users?offset=3&limit=3"
                     rel: "next"
@@ -171,6 +177,8 @@ paths:
                   contactPreferences:
                     - email
                     - sms
+                createdAt: "2026-08-17T09:12:03Z"
+                updatedAt: "2026-08-17T09:12:03Z"
         "400":
           description: Bad request
           content:
@@ -303,6 +311,8 @@ paths:
                   contactPreferences:
                     - email
                     - sms
+                createdAt: "2026-08-17T09:12:03Z"
+                updatedAt: "2026-08-17T10:44:51Z"
         "404":
           description: User not found
         "500":
@@ -357,6 +367,8 @@ paths:
                     zip: "94040"
                   contactPreferences:
                     - email
+                createdAt: "2026-08-17T09:12:03Z"
+                updatedAt: "2026-08-17T12:30:09Z"
         "400":
           description: Bad request
           content:
@@ -958,6 +970,8 @@ paths:
                   lastname: "Doe"
                   email: "john.doe@company.com"
                   department: "Engineering"
+                createdAt: "2026-08-17T09:12:03Z"
+                updatedAt: "2026-08-17T09:12:03Z"
         "400":
           description: Bad request
           content:
@@ -1090,6 +1104,8 @@ paths:
                   firstname: "Alice"
                   lastname: "Wu"
                   email: "alice.wu@company.inc"
+                createdAt: "2026-08-15T08:20:10Z"
+                updatedAt: "2026-08-17T11:05:44Z"
         "401":
           description: Unauthorized - missing or invalid authentication token
           content:
@@ -1166,6 +1182,8 @@ paths:
                   firstname: "Alice"
                   lastname: "Wu"
                   email: "alice.wu@company.io"
+                createdAt: "2026-08-15T08:20:10Z"
+                updatedAt: "2026-08-17T13:41:26Z"
         "400":
           description: Bad request
           content:
@@ -2057,6 +2075,18 @@ components:
           type: boolean
           readOnly: true
           description: "Whether the user is declarative and cannot be modified or deleted by clients."
+        createdAt:
+          type: string
+          format: date-time
+          readOnly: true
+          example: "2026-08-17T09:12:03Z"
+          description: "Timestamp when the user was created (RFC 3339, UTC). Omitted for declarative users."
+        updatedAt:
+          type: string
+          format: date-time
+          readOnly: true
+          example: "2026-08-17T10:44:51Z"
+          description: "Timestamp when the user was last modified (RFC 3339, UTC). Omitted for declarative users."
 
     Link:
       type: object

--- a/backend/internal/entity/cache_backed_store.go
+++ b/backend/internal/entity/cache_backed_store.go
@@ -52,7 +52,9 @@ func (s *cacheBackedEntityStore) CreateEntity(ctx context.Context, entity provid
 	if err := s.store.CreateEntity(ctx, entity, credentials, systemCredentials); err != nil {
 		return err
 	}
-	s.cacheEntityByID(ctx, &entity)
+	// The caller's struct lacks the store-generated timestamps, so drop any cached entry
+	// and let the next read populate the cache from the database.
+	s.invalidateEntityByID(ctx, entity.ID)
 	s.cacheEntityIDByIdentifiers(ctx, &entity)
 	return nil
 }
@@ -96,7 +98,7 @@ func (s *cacheBackedEntityStore) UpdateEntity(ctx context.Context, entity *provi
 		return err
 	}
 
-	s.cacheEntityByID(ctx, entity)
+	s.invalidateEntityByID(ctx, entity.ID)
 	s.cacheEntityIDByIdentifiers(ctx, entity)
 	return nil
 }

--- a/backend/internal/entity/cache_backed_store_test.go
+++ b/backend/internal/entity/cache_backed_store_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -390,7 +391,7 @@ func (s *CacheBackedEntityStoreTestSuite) TestDeleteEntity_StoreError() {
 
 // CreateEntity tests
 
-func (s *CacheBackedEntityStoreTestSuite) TestCreateEntity_CachesEntityByID() {
+func (s *CacheBackedEntityStoreTestSuite) TestCreateEntity_DoesNotCacheCallerEntityByID() {
 	entity := s.makeEntity(testEntityID, "client-1")
 	s.mockStore.On("CreateEntity", mock.Anything, entity, json.RawMessage(nil),
 		json.RawMessage(nil)).Return(nil).Once()
@@ -399,14 +400,35 @@ func (s *CacheBackedEntityStoreTestSuite) TestCreateEntity_CachesEntityByID() {
 	s.Nil(err)
 	s.mockStore.AssertExpectations(s.T())
 
-	cached, ok := s.entityByIDCache.Get(context.Background(), cache.CacheKey{Key: entity.ID})
-	s.True(ok)
-	s.Equal(entity.ID, cached.ID)
+	// The caller's struct carries no store-generated timestamps, so it must not be cached.
+	_, ok := s.entityByIDCache.Get(context.Background(), cache.CacheKey{Key: entity.ID})
+	s.False(ok)
 
 	cachedID, ok := s.entityIDByIdentifierCache.Get(context.Background(),
 		cache.CacheKey{Key: "clientId:client-1"})
 	s.True(ok)
 	s.Equal(entity.ID, *cachedID)
+}
+
+// TestCreateEntity_GetEntityReadsThroughToStore is a regression test: a create must not leave a
+// timestamp-less struct in the by-ID cache for subsequent reads to serve.
+func (s *CacheBackedEntityStoreTestSuite) TestCreateEntity_GetEntityReadsThroughToStore() {
+	entity := s.makeEntity(testEntityID, "client-1")
+	stored := entity
+	stored.CreatedAt = time.Date(2026, 8, 17, 9, 12, 3, 0, time.UTC)
+	stored.UpdatedAt = stored.CreatedAt
+
+	s.mockStore.On("CreateEntity", mock.Anything, entity, json.RawMessage(nil),
+		json.RawMessage(nil)).Return(nil).Once()
+	s.mockStore.On("GetEntity", mock.Anything, entity.ID).Return(stored, nil).Once()
+
+	s.Nil(s.cachedStore.CreateEntity(context.Background(), entity, nil, nil))
+
+	got, err := s.cachedStore.GetEntity(context.Background(), entity.ID)
+	s.NoError(err)
+	s.Equal(stored.CreatedAt, got.CreatedAt)
+	s.Equal(stored.UpdatedAt, got.UpdatedAt)
+	s.mockStore.AssertExpectations(s.T())
 }
 
 func (s *CacheBackedEntityStoreTestSuite) TestCreateEntity_StoreError_DoesNotCache() {
@@ -428,7 +450,7 @@ func (s *CacheBackedEntityStoreTestSuite) TestCreateEntity_StoreError_DoesNotCac
 
 // UpdateEntity tests
 
-func (s *CacheBackedEntityStoreTestSuite) TestUpdateEntity_InvalidatesAndRecachesEntity() {
+func (s *CacheBackedEntityStoreTestSuite) TestUpdateEntity_InvalidatesEntityByIDCache() {
 	entity := s.makeEntity(testEntityID, "client-1")
 	s.entityByIDData[entity.ID] = &entity
 
@@ -438,10 +460,9 @@ func (s *CacheBackedEntityStoreTestSuite) TestUpdateEntity_InvalidatesAndRecache
 	s.Nil(err)
 	s.mockStore.AssertExpectations(s.T())
 
-	// Updated entity must be present in the by-ID cache.
-	cached, ok := s.entityByIDCache.Get(context.Background(), cache.CacheKey{Key: entity.ID})
-	s.True(ok)
-	s.Equal(entity.ID, cached.ID)
+	// The caller's struct carries no store-refreshed timestamps, so the entry must be dropped.
+	_, ok := s.entityByIDCache.Get(context.Background(), cache.CacheKey{Key: entity.ID})
+	s.False(ok)
 }
 
 // IdentifyEntity cache tests

--- a/backend/internal/entity/store.go
+++ b/backend/internal/entity/store.go
@@ -15,6 +15,7 @@ import (
 	dbmodel "github.com/thunder-id/thunderid/internal/system/database/model"
 	"github.com/thunder-id/thunderid/internal/system/database/provider"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	sysutils "github.com/thunder-id/thunderid/internal/system/utils"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
 
@@ -843,16 +844,31 @@ func buildEntityFromResultRow(row map[string]interface{}) (providers.Entity, err
 		return providers.Entity{}, fmt.Errorf("failed to parse attributes as string")
 	}
 
-	entity := providers.Entity{
-		ID:       entityID,
-		Category: providers.EntityCategory(category),
-		Type:     entityType,
-		State:    providers.EntityState(state),
-		OUID:     ouID,
+	createdAt, err := sysutils.ParseDBTimeField(row["created_at"], "created_at")
+	if err != nil {
+		return providers.Entity{}, fmt.Errorf("failed to parse created_at: %w", err)
 	}
 
-	if err := json.Unmarshal([]byte(attributes), &entity.Attributes); err != nil {
-		return providers.Entity{}, fmt.Errorf("failed to unmarshal attributes")
+	updatedAt, err := sysutils.ParseDBTimeField(row["updated_at"], "updated_at")
+	if err != nil {
+		return providers.Entity{}, fmt.Errorf("failed to parse updated_at: %w", err)
+	}
+
+	entity := providers.Entity{
+		ID:        entityID,
+		Category:  providers.EntityCategory(category),
+		Type:      entityType,
+		State:     providers.EntityState(state),
+		OUID:      ouID,
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
+	}
+
+	// An entity stored without attributes holds the JSON null literal, so treat it as absent.
+	if attributes != "" && attributes != "null" {
+		if err := json.Unmarshal([]byte(attributes), &entity.Attributes); err != nil {
+			return providers.Entity{}, fmt.Errorf("failed to unmarshal attributes")
+		}
 	}
 
 	entity.SystemAttributes = parseJSONColumn(row, "system_attributes")

--- a/backend/internal/entity/store_constants.go
+++ b/backend/internal/entity/store_constants.go
@@ -32,13 +32,15 @@ var (
 	// QueryGetEntityList is the query to get a list of entities by category.
 	QueryGetEntityList = model.DBQuery{
 		ID: "ASQ-ENTITY_MGT-02",
-		Query: `SELECT ID, OU_ID, CATEGORY, TYPE, STATE, ATTRIBUTES, SYSTEM_ATTRIBUTES FROM "ENTITY" ` +
+		Query: `SELECT ID, OU_ID, CATEGORY, TYPE, STATE, ATTRIBUTES, SYSTEM_ATTRIBUTES, ` +
+			`CREATED_AT, UPDATED_AT FROM "ENTITY" ` +
 			`WHERE CATEGORY = $4 AND DEPLOYMENT_ID = $3 ORDER BY ID LIMIT $1 OFFSET $2`,
 	}
 	// QuerySearchEntityList is the query to search entities across all categories.
 	QuerySearchEntityList = model.DBQuery{
 		ID: "ASQ-ENTITY_MGT-03",
-		Query: `SELECT ID, OU_ID, CATEGORY, TYPE, STATE, ATTRIBUTES, SYSTEM_ATTRIBUTES FROM "ENTITY" ` +
+		Query: `SELECT ID, OU_ID, CATEGORY, TYPE, STATE, ATTRIBUTES, SYSTEM_ATTRIBUTES, ` +
+			`CREATED_AT, UPDATED_AT FROM "ENTITY" ` +
 			`WHERE DEPLOYMENT_ID = $3 ORDER BY ID LIMIT $1 OFFSET $2`,
 	}
 	// QueryCreateEntity is the query to create a new entity.
@@ -52,7 +54,7 @@ var (
 	// QueryGetEntityByID is the query to get an entity by ID.
 	QueryGetEntityByID = model.DBQuery{
 		ID: "ASQ-ENTITY_MGT-05",
-		Query: `SELECT ID, OU_ID, CATEGORY, TYPE, STATE, ATTRIBUTES, SYSTEM_ATTRIBUTES ` +
+		Query: `SELECT ID, OU_ID, CATEGORY, TYPE, STATE, ATTRIBUTES, SYSTEM_ATTRIBUTES, CREATED_AT, UPDATED_AT ` +
 			`FROM "ENTITY" WHERE ID = $1 AND DEPLOYMENT_ID = $2`,
 	}
 	// QueryUpdateEntity is the query to fully update an entity including system attributes.
@@ -90,7 +92,7 @@ var (
 	QueryGetEntityWithCredentials = model.DBQuery{
 		ID: "ASQ-ENTITY_MGT-12",
 		Query: `SELECT ID, OU_ID, CATEGORY, TYPE, STATE, ATTRIBUTES, ` +
-			`SYSTEM_ATTRIBUTES, CREDENTIALS, SYSTEM_CREDENTIALS ` +
+			`SYSTEM_ATTRIBUTES, CREDENTIALS, SYSTEM_CREDENTIALS, CREATED_AT, UPDATED_AT ` +
 			`FROM "ENTITY" WHERE ID = $1 AND DEPLOYMENT_ID = $2`,
 	}
 	// QueryGetGroupCountForEntity is the query to get the count of groups for a given entity.
@@ -204,7 +206,7 @@ func buildEntityListQueryByOUIDs(
 	category string, ouIDs []string, filters map[string]interface{}, limit, offset int, deploymentID string,
 ) (model.DBQuery, []interface{}, error) {
 	queryID := "ASQ-ENTITY_MGT-21"
-	baseQuery := `SELECT ID, OU_ID, CATEGORY, TYPE, STATE, ATTRIBUTES, SYSTEM_ATTRIBUTES ` +
+	baseQuery := `SELECT ID, OU_ID, CATEGORY, TYPE, STATE, ATTRIBUTES, SYSTEM_ATTRIBUTES, CREATED_AT, UPDATED_AT ` +
 		`FROM "ENTITY" WHERE CATEGORY = $1`
 	args := []interface{}{category}
 	var query model.DBQuery
@@ -383,7 +385,8 @@ func buildBulkEntityExistsQueryInOUs(
 func buildEntityListQuery(
 	category string, filters map[string]interface{}, limit, offset int, deploymentID string,
 ) (model.DBQuery, []interface{}, error) {
-	baseQuery := `SELECT ID, OU_ID, CATEGORY, TYPE, STATE, ATTRIBUTES, SYSTEM_ATTRIBUTES FROM "ENTITY"`
+	baseQuery := `SELECT ID, OU_ID, CATEGORY, TYPE, STATE, ATTRIBUTES, SYSTEM_ATTRIBUTES, ` +
+		`CREATED_AT, UPDATED_AT FROM "ENTITY"`
 	queryID := "ASQ-ENTITY_MGT-25"
 
 	if len(filters) > 0 {
@@ -594,7 +597,7 @@ func buildIdentifyQueryHybrid(
 func buildGetEntitiesByIDsQuery(entityIDs []string, deploymentID string) (model.DBQuery, []interface{}, error) {
 	return buildEntityINClauseQuery(
 		"ASQ-ENTITY_MGT-29",
-		`SELECT ID, OU_ID, CATEGORY, TYPE, STATE, ATTRIBUTES, SYSTEM_ATTRIBUTES `+
+		`SELECT ID, OU_ID, CATEGORY, TYPE, STATE, ATTRIBUTES, SYSTEM_ATTRIBUTES, CREATED_AT, UPDATED_AT `+
 			`FROM "ENTITY" WHERE ID IN (%s) AND DEPLOYMENT_ID = %s`,
 		entityIDs, deploymentID,
 	)

--- a/backend/internal/entity/store_test.go
+++ b/backend/internal/entity/store_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -16,6 +17,11 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 	"github.com/thunder-id/thunderid/tests/mocks/database/providermock"
+)
+
+var (
+	testCreatedAt = time.Date(2026, 8, 17, 9, 12, 3, 0, time.UTC)
+	testUpdatedAt = time.Date(2026, 8, 17, 10, 44, 51, 0, time.UTC)
 )
 
 type DBStoreTestSuite struct {
@@ -82,6 +88,8 @@ func dbEntityRow() map[string]interface{} {
 		"state":             "ACTIVE",
 		"attributes":        `{"email":"a@b.com"}`,
 		"system_attributes": nil,
+		"created_at":        testCreatedAt,
+		"updated_at":        testUpdatedAt,
 	}
 }
 
@@ -682,6 +690,8 @@ func goodRow() map[string]interface{} {
 		"state":             "ACTIVE",
 		"attributes":        `{"email":"a@b.com"}`,
 		"system_attributes": `{"key":"val"}`,
+		"created_at":        testCreatedAt,
+		"updated_at":        testUpdatedAt,
 	}
 }
 
@@ -695,6 +705,39 @@ func (s *StoreHelpersTestSuite) TestBuildEntityFromResultRow_Success() {
 	s.Equal("ou-1", e.OUID)
 	s.NotNil(e.Attributes)
 	s.NotNil(e.SystemAttributes)
+	s.Equal(testCreatedAt, e.CreatedAt)
+	s.Equal(testUpdatedAt, e.UpdatedAt)
+}
+
+func (s *StoreHelpersTestSuite) TestBuildEntityFromResultRow_SQLiteTimestamps() {
+	row := goodRow()
+	row["created_at"] = "2026-08-17 09:12:03.123456"
+	row["updated_at"] = "2026-08-17 10:44:51"
+	e, err := buildEntityFromResultRow(row)
+	s.NoError(err)
+	s.Equal(time.Date(2026, 8, 17, 9, 12, 3, 123456000, time.UTC), e.CreatedAt)
+	s.Equal(testUpdatedAt, e.UpdatedAt)
+}
+
+func (s *StoreHelpersTestSuite) TestBuildEntityFromResultRow_MissingCreatedAt() {
+	row := goodRow()
+	delete(row, "created_at")
+	_, err := buildEntityFromResultRow(row)
+	s.Error(err)
+}
+
+func (s *StoreHelpersTestSuite) TestBuildEntityFromResultRow_NullUpdatedAt() {
+	row := goodRow()
+	row["updated_at"] = nil
+	_, err := buildEntityFromResultRow(row)
+	s.Error(err)
+}
+
+func (s *StoreHelpersTestSuite) TestBuildEntityFromResultRow_UnparseableTimestamp() {
+	row := goodRow()
+	row["created_at"] = "not-a-timestamp"
+	_, err := buildEntityFromResultRow(row)
+	s.Error(err)
 }
 
 func (s *StoreHelpersTestSuite) TestBuildEntityFromResultRow_AttributesAsBytes() {
@@ -704,6 +747,22 @@ func (s *StoreHelpersTestSuite) TestBuildEntityFromResultRow_AttributesAsBytes()
 	e, err := buildEntityFromResultRow(row)
 	s.NoError(err)
 	s.Equal("entity-1", e.ID)
+}
+
+func (s *StoreHelpersTestSuite) TestBuildEntityFromResultRow_NullAttributes() {
+	row := goodRow()
+	row["attributes"] = `null`
+	e, err := buildEntityFromResultRow(row)
+	s.NoError(err)
+	s.Nil(e.Attributes)
+}
+
+func (s *StoreHelpersTestSuite) TestBuildEntityFromResultRow_EmptyAttributes() {
+	row := goodRow()
+	row["attributes"] = ``
+	e, err := buildEntityFromResultRow(row)
+	s.NoError(err)
+	s.Nil(e.Attributes)
 }
 
 func (s *StoreHelpersTestSuite) TestBuildEntityFromResultRow_MissingID() {

--- a/backend/internal/user/model.go
+++ b/backend/internal/user/model.go
@@ -5,6 +5,7 @@ package user
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
 	"github.com/thunder-id/thunderid/internal/system/utils"
@@ -20,6 +21,8 @@ type User struct {
 	Attributes json.RawMessage `json:"attributes,omitempty"`
 	Display    string          `json:"display,omitempty"`
 	IsReadOnly bool            `json:"isReadOnly"`
+	CreatedAt  string          `json:"createdAt,omitempty"`
+	UpdatedAt  string          `json:"updatedAt,omitempty"`
 }
 
 // Credential represents the credentials of a user.
@@ -95,12 +98,28 @@ type CreateUserByPathRequest struct {
 
 // entityToUser converts an Entity to a User.
 func entityToUser(e *providers.Entity) User {
-	return User{
+	user := User{
 		ID:         e.ID,
 		OUID:       e.OUID,
 		Type:       e.Type,
 		Attributes: e.Attributes,
 		IsReadOnly: e.IsReadOnly,
+	}
+	applyEntityTimestamps(&user, e)
+	return user
+}
+
+// applyEntityTimestamps copies the store-owned timestamps onto the user as RFC 3339 strings.
+// Declarative users have no stored row, so their zero timestamps stay empty and are omitted.
+func applyEntityTimestamps(u *User, e *providers.Entity) {
+	if e == nil {
+		return
+	}
+	if !e.CreatedAt.IsZero() {
+		u.CreatedAt = e.CreatedAt.UTC().Format(time.RFC3339)
+	}
+	if !e.UpdatedAt.IsZero() {
+		u.UpdatedAt = e.UpdatedAt.UTC().Format(time.RFC3339)
 	}
 }
 

--- a/backend/internal/user/model.go
+++ b/backend/internal/user/model.go
@@ -5,6 +5,7 @@ package user
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
 	"github.com/thunder-id/thunderid/internal/system/utils"
@@ -84,12 +85,28 @@ type CreateUserByPathRequest struct {
 
 // entityToUser converts an Entity to a User.
 func entityToUser(e *providers.Entity) providers.User {
-	return providers.User{
+	user := providers.User{
 		ID:         e.ID,
 		OUID:       e.OUID,
 		Type:       e.Type,
 		Attributes: e.Attributes,
 		IsReadOnly: e.IsReadOnly,
+	}
+	applyEntityTimestamps(&user, e)
+	return user
+}
+
+// applyEntityTimestamps copies the store-owned timestamps onto the user as RFC 3339 strings.
+// Declarative users have no stored row, so their zero timestamps stay empty and are omitted.
+func applyEntityTimestamps(u *providers.User, e *providers.Entity) {
+	if e == nil {
+		return
+	}
+	if !e.CreatedAt.IsZero() {
+		u.CreatedAt = e.CreatedAt.UTC().Format(time.RFC3339)
+	}
+	if !e.UpdatedAt.IsZero() {
+		u.UpdatedAt = e.UpdatedAt.UTC().Format(time.RFC3339)
 	}
 }
 

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -333,6 +333,7 @@ func (us *userService) CreateUser(ctx context.Context, user *User) (*User, *tidc
 
 	// Sync cleaned attributes back — entity service removed credential fields from Attributes.
 	user.Attributes = created.Attributes
+	applyEntityTimestamps(user, created)
 
 	logger.Debug(ctx, "Successfully created user", log.MaskedString(log.LoggerKeyUserID, user.ID))
 	return user, nil
@@ -596,6 +597,7 @@ func (us *userService) UpdateUser(
 
 	// Sync cleaned attributes back — entity service removed credential fields from Attributes.
 	user.Attributes = updated.Attributes
+	applyEntityTimestamps(user, updated)
 	logger.Debug(ctx, "Successfully updated user", log.MaskedString(log.LoggerKeyUserID, userID))
 	return user, nil
 }
@@ -677,6 +679,14 @@ func (us *userService) UpdateUserAttributes(
 		}
 		return nil, logErrorAndReturnServerError(ctx, logger, "Failed to update user attributes", err,
 			log.MaskedString(log.LoggerKeyUserID, userID))
+	}
+
+	// Re-read so the response carries the post-update timestamps.
+	if updatedEntity, err := us.entityService.GetEntity(ctx, userID); err != nil {
+		logger.Warn(ctx, "Failed to reload user after attribute update, returning stale timestamps",
+			log.MaskedString(log.LoggerKeyUserID, userID), log.Error(err))
+	} else {
+		applyEntityTimestamps(&existingUser, updatedEntity)
 	}
 
 	logger.Debug(ctx, "Successfully updated user attributes", log.MaskedString(log.LoggerKeyUserID, userID))

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -337,6 +337,7 @@ func (us *userService) CreateUser(
 
 	// Sync cleaned attributes back — entity service removed credential fields from Attributes.
 	user.Attributes = created.Attributes
+	applyEntityTimestamps(user, created)
 
 	logger.Debug(ctx, "Successfully created user", log.MaskedString(log.LoggerKeyUserID, user.ID))
 	return user, nil
@@ -600,6 +601,7 @@ func (us *userService) UpdateUser(
 
 	// Sync cleaned attributes back — entity service removed credential fields from Attributes.
 	user.Attributes = updated.Attributes
+	applyEntityTimestamps(user, updated)
 	logger.Debug(ctx, "Successfully updated user", log.MaskedString(log.LoggerKeyUserID, userID))
 	return user, nil
 }
@@ -681,6 +683,14 @@ func (us *userService) UpdateUserAttributes(
 		}
 		return nil, logErrorAndReturnServerError(ctx, logger, "Failed to update user attributes", err,
 			log.MaskedString(log.LoggerKeyUserID, userID))
+	}
+
+	// Re-read so the response carries the post-update timestamps.
+	if updatedEntity, err := us.entityService.GetEntity(ctx, userID); err != nil {
+		logger.Warn(ctx, "Failed to reload user after attribute update, returning stale timestamps",
+			log.MaskedString(log.LoggerKeyUserID, userID), log.Error(err))
+	} else {
+		applyEntityTimestamps(&existingUser, updatedEntity)
 	}
 
 	logger.Debug(ctx, "Successfully updated user attributes", log.MaskedString(log.LoggerKeyUserID, userID))

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 
@@ -3922,4 +3923,203 @@ func TestGetUserMetadata_GetEntityTypeSchemaError(t *testing.T) {
 	require.Nil(t, schema)
 	require.NotNil(t, svcErr)
 	require.Equal(t, entitytype.ErrorEntityTypeNotFound.Code, svcErr.Code)
+}
+
+// Timestamp exposure tests.
+
+var (
+	svcTestCreatedAt = time.Date(2026, 8, 17, 9, 12, 3, 0, time.UTC)
+	svcTestUpdatedAt = time.Date(2026, 8, 17, 10, 44, 51, 0, time.UTC)
+)
+
+func TestEntityToUser_MapsTimestamps(t *testing.T) {
+	user := entityToUser(&providers.Entity{
+		ID: svcTestUserID1, CreatedAt: svcTestCreatedAt, UpdatedAt: svcTestUpdatedAt,
+	})
+	require.Equal(t, "2026-08-17T09:12:03Z", user.CreatedAt)
+	require.Equal(t, "2026-08-17T10:44:51Z", user.UpdatedAt)
+}
+
+func TestEntityToUser_DeclarativeUserOmitsTimestamps(t *testing.T) {
+	user := entityToUser(&providers.Entity{ID: svcTestDeclarativeUserID1, IsReadOnly: true})
+	require.Empty(t, user.CreatedAt)
+	require.Empty(t, user.UpdatedAt)
+
+	encoded, err := json.Marshal(user)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "createdAt")
+	require.NotContains(t, string(encoded), "updatedAt")
+}
+
+func TestUserService_GetUser_ReturnsTimestamps(t *testing.T) {
+	storeMock := entitymock.NewEntityServiceInterfaceMock(t)
+	storeMock.On("GetEntity", mock.Anything, svcTestUserID1).Return(&providers.Entity{
+		Category: providers.EntityCategoryUser, ID: svcTestUserID1, OUID: testOrgID,
+		CreatedAt: svcTestCreatedAt, UpdatedAt: svcTestUpdatedAt,
+	}, nil).Once()
+
+	service := &userService{entityService: storeMock, authzService: newAllowAllAuthz(t)}
+
+	user, err := service.GetUser(context.Background(), svcTestUserID1, false)
+	require.Nil(t, err)
+	require.Equal(t, "2026-08-17T09:12:03Z", user.CreatedAt)
+	require.Equal(t, "2026-08-17T10:44:51Z", user.UpdatedAt)
+}
+
+func TestUserService_GetUserList_ReturnsTimestamps(t *testing.T) {
+	limit, offset := 10, 0
+	filters := map[string]interface{}{}
+
+	storeMock := entitymock.NewEntityServiceInterfaceMock(t)
+	storeMock.On("GetEntityListCount", mock.Anything, providers.EntityCategoryUser, filters).
+		Return(1, nil).Once()
+	storeMock.On("GetEntityList", mock.Anything, providers.EntityCategoryUser, limit, offset, filters).
+		Return([]providers.Entity{{
+			ID: svcTestUserID1, CreatedAt: svcTestCreatedAt, UpdatedAt: svcTestUpdatedAt,
+		}}, nil).Once()
+
+	service := &userService{entityService: storeMock, authzService: newAllowAllAuthz(t)}
+
+	resp, err := service.GetUserList(context.Background(), limit, offset, filters, false)
+	require.Nil(t, err)
+	require.Len(t, resp.Users, 1)
+	require.Equal(t, "2026-08-17T09:12:03Z", resp.Users[0].CreatedAt)
+	require.Equal(t, "2026-08-17T10:44:51Z", resp.Users[0].UpdatedAt)
+}
+
+func TestUserService_CreateUser_ReturnsTimestamps(t *testing.T) {
+	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+	ouServiceMock.On("IsOrganizationUnitExists", mock.Anything, testOrgID).
+		Return(true, (*tidcommon.ServiceError)(nil)).Once()
+
+	entityTypeMock := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	entityTypeMock.On("GetEntityTypeByName", mock.Anything, mock.Anything, testUserType).
+		Return(&entitytype.EntityType{OUID: testOrgID}, (*tidcommon.ServiceError)(nil)).Once()
+
+	storeMock := entitymock.NewEntityServiceInterfaceMock(t)
+	storeMock.On("CreateEntity", mock.Anything, mock.Anything, mock.Anything).
+		Return(&providers.Entity{
+			OUID: testOrgID, Type: testUserType, Attributes: json.RawMessage(`{}`),
+			CreatedAt: svcTestCreatedAt, UpdatedAt: svcTestCreatedAt,
+		}, nil).Once()
+
+	service := &userService{
+		entityService:     storeMock,
+		ouService:         ouServiceMock,
+		entityTypeService: entityTypeMock,
+		authzService:      newAllowAllAuthz(t),
+		uuidGenerator:     utils.GenerateUUIDv7,
+	}
+
+	created, err := service.CreateUser(context.Background(), &User{
+		Type: testUserType, OUID: testOrgID, Attributes: json.RawMessage(`{}`),
+	})
+	require.Nil(t, err)
+	require.Equal(t, "2026-08-17T09:12:03Z", created.CreatedAt)
+	require.Equal(t, created.CreatedAt, created.UpdatedAt)
+}
+
+func TestUserService_UpdateUser_ReturnsTimestamps(t *testing.T) {
+	userID := svcTestUserID1
+
+	storeMock := entitymock.NewEntityServiceInterfaceMock(t)
+	storeMock.On("IsEntityDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
+	storeMock.On("GetEntity", mock.Anything, userID).Return(&providers.Entity{
+		Category: providers.EntityCategoryUser, ID: userID, OUID: testOrgID, Type: testUserType,
+		CreatedAt: svcTestCreatedAt, UpdatedAt: svcTestCreatedAt,
+	}, nil).Once()
+	storeMock.On("UpdateEntity", mock.Anything, userID, mock.Anything).Return(&providers.Entity{
+		ID: userID, Attributes: json.RawMessage(`{"updated":"true"}`),
+		CreatedAt: svcTestCreatedAt, UpdatedAt: svcTestUpdatedAt,
+	}, nil).Once()
+
+	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+	ouServiceMock.On("IsOrganizationUnitExists", mock.Anything, testOrgID).
+		Return(true, (*tidcommon.ServiceError)(nil)).Once()
+
+	entityTypeMock := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	entityTypeMock.On("GetEntityTypeByName", mock.Anything, mock.Anything, testUserType).
+		Return(&entitytype.EntityType{OUID: testOrgID}, (*tidcommon.ServiceError)(nil)).Once()
+	entityTypeMock.On("GetAttributes", mock.Anything, mock.Anything, testUserType,
+		entitytype.AttributeFilter{AllowCredential: true}).
+		Return([]entitytype.AttributeInfo{}, (*tidcommon.ServiceError)(nil)).Once()
+
+	service := &userService{
+		entityService:     storeMock,
+		ouService:         ouServiceMock,
+		entityTypeService: entityTypeMock,
+		authzService:      newAllowAllAuthz(t),
+	}
+
+	resp, err := service.UpdateUser(context.Background(), userID, &User{
+		ID: userID, OUID: testOrgID, Type: testUserType,
+		Attributes: json.RawMessage(`{"updated":"true"}`),
+	})
+	require.Nil(t, err)
+	require.Equal(t, "2026-08-17T09:12:03Z", resp.CreatedAt)
+	require.Equal(t, "2026-08-17T10:44:51Z", resp.UpdatedAt)
+}
+
+func TestUserService_UpdateUserAttributes_ReturnsPostUpdateTimestamps(t *testing.T) {
+	storeMock := entitymock.NewEntityServiceInterfaceMock(t)
+	storeMock.On("IsEntityDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
+	storeMock.On("GetEntity", mock.Anything, svcTestUserID1).Return(&providers.Entity{
+		Category: providers.EntityCategoryUser, ID: svcTestUserID1, Type: testUserType,
+		Attributes: json.RawMessage(`{"email":"old@example.com"}`),
+		CreatedAt:  svcTestCreatedAt, UpdatedAt: svcTestCreatedAt,
+	}, nil).Once()
+	storeMock.On("UpdateAttributes", mock.Anything, svcTestUserID1, mock.Anything).Return(nil).Once()
+	storeMock.On("GetEntity", mock.Anything, svcTestUserID1).Return(&providers.Entity{
+		Category: providers.EntityCategoryUser, ID: svcTestUserID1, Type: testUserType,
+		Attributes: json.RawMessage(`{"email":"new@example.com"}`),
+		CreatedAt:  svcTestCreatedAt, UpdatedAt: svcTestUpdatedAt,
+	}, nil).Once()
+
+	schemaMock := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	schemaMock.On("GetAttributes", mock.Anything, mock.Anything, testUserType,
+		entitytype.AttributeFilter{AllowCredential: true}).
+		Return([]entitytype.AttributeInfo{}, (*tidcommon.ServiceError)(nil)).Once()
+
+	service := &userService{
+		entityService:     storeMock,
+		entityTypeService: schemaMock,
+		authzService:      newAllowAllAuthz(t),
+	}
+
+	resp, err := service.UpdateUserAttributes(context.Background(), svcTestUserID1,
+		json.RawMessage(`{"email":"new@example.com"}`))
+	require.Nil(t, err)
+	require.Equal(t, "2026-08-17T09:12:03Z", resp.CreatedAt)
+	require.Equal(t, "2026-08-17T10:44:51Z", resp.UpdatedAt)
+}
+
+func TestUserService_UpdateUserAttributes_ReloadFailureKeepsResponse(t *testing.T) {
+	storeMock := entitymock.NewEntityServiceInterfaceMock(t)
+	storeMock.On("IsEntityDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
+	storeMock.On("GetEntity", mock.Anything, svcTestUserID1).Return(&providers.Entity{
+		Category: providers.EntityCategoryUser, ID: svcTestUserID1, Type: testUserType,
+		Attributes: json.RawMessage(`{"email":"old@example.com"}`),
+		CreatedAt:  svcTestCreatedAt, UpdatedAt: svcTestUpdatedAt,
+	}, nil).Once()
+	storeMock.On("UpdateAttributes", mock.Anything, svcTestUserID1, mock.Anything).Return(nil).Once()
+	storeMock.On("GetEntity", mock.Anything, svcTestUserID1).
+		Return((*providers.Entity)(nil), errors.New("reload failed")).Once()
+
+	schemaMock := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	schemaMock.On("GetAttributes", mock.Anything, mock.Anything, testUserType,
+		entitytype.AttributeFilter{AllowCredential: true}).
+		Return([]entitytype.AttributeInfo{}, (*tidcommon.ServiceError)(nil)).Once()
+
+	service := &userService{
+		entityService:     storeMock,
+		entityTypeService: schemaMock,
+		authzService:      newAllowAllAuthz(t),
+	}
+
+	resp, err := service.UpdateUserAttributes(context.Background(), svcTestUserID1,
+		json.RawMessage(`{"email":"new@example.com"}`))
+	require.Nil(t, err)
+	// Both pre-update values survive the failed reload; neither is cleared.
+	require.Equal(t, "2026-08-17T09:12:03Z", resp.CreatedAt)
+	require.Equal(t, "2026-08-17T10:44:51Z", resp.UpdatedAt)
 }

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 
@@ -3922,4 +3923,203 @@ func TestGetUserMetadata_GetEntityTypeSchemaError(t *testing.T) {
 	require.Nil(t, schema)
 	require.NotNil(t, svcErr)
 	require.Equal(t, entitytype.ErrorEntityTypeNotFound.Code, svcErr.Code)
+}
+
+// Timestamp exposure tests.
+
+var (
+	svcTestCreatedAt = time.Date(2026, 8, 17, 9, 12, 3, 0, time.UTC)
+	svcTestUpdatedAt = time.Date(2026, 8, 17, 10, 44, 51, 0, time.UTC)
+)
+
+func TestEntityToUser_MapsTimestamps(t *testing.T) {
+	user := entityToUser(&providers.Entity{
+		ID: svcTestUserID1, CreatedAt: svcTestCreatedAt, UpdatedAt: svcTestUpdatedAt,
+	})
+	require.Equal(t, "2026-08-17T09:12:03Z", user.CreatedAt)
+	require.Equal(t, "2026-08-17T10:44:51Z", user.UpdatedAt)
+}
+
+func TestEntityToUser_DeclarativeUserOmitsTimestamps(t *testing.T) {
+	user := entityToUser(&providers.Entity{ID: svcTestDeclarativeUserID1, IsReadOnly: true})
+	require.Empty(t, user.CreatedAt)
+	require.Empty(t, user.UpdatedAt)
+
+	encoded, err := json.Marshal(user)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "createdAt")
+	require.NotContains(t, string(encoded), "updatedAt")
+}
+
+func TestUserService_GetUser_ReturnsTimestamps(t *testing.T) {
+	storeMock := entitymock.NewEntityServiceInterfaceMock(t)
+	storeMock.On("GetEntity", mock.Anything, svcTestUserID1).Return(&providers.Entity{
+		Category: providers.EntityCategoryUser, ID: svcTestUserID1, OUID: testOrgID,
+		CreatedAt: svcTestCreatedAt, UpdatedAt: svcTestUpdatedAt,
+	}, nil).Once()
+
+	service := &userService{entityService: storeMock, authzService: newAllowAllAuthz(t)}
+
+	user, err := service.GetUser(context.Background(), svcTestUserID1, false)
+	require.Nil(t, err)
+	require.Equal(t, "2026-08-17T09:12:03Z", user.CreatedAt)
+	require.Equal(t, "2026-08-17T10:44:51Z", user.UpdatedAt)
+}
+
+func TestUserService_GetUserList_ReturnsTimestamps(t *testing.T) {
+	limit, offset := 10, 0
+	filters := map[string]interface{}{}
+
+	storeMock := entitymock.NewEntityServiceInterfaceMock(t)
+	storeMock.On("GetEntityListCount", mock.Anything, providers.EntityCategoryUser, filters).
+		Return(1, nil).Once()
+	storeMock.On("GetEntityList", mock.Anything, providers.EntityCategoryUser, limit, offset, filters).
+		Return([]providers.Entity{{
+			ID: svcTestUserID1, CreatedAt: svcTestCreatedAt, UpdatedAt: svcTestUpdatedAt,
+		}}, nil).Once()
+
+	service := &userService{entityService: storeMock, authzService: newAllowAllAuthz(t)}
+
+	resp, err := service.GetUserList(context.Background(), limit, offset, filters, false)
+	require.Nil(t, err)
+	require.Len(t, resp.Users, 1)
+	require.Equal(t, "2026-08-17T09:12:03Z", resp.Users[0].CreatedAt)
+	require.Equal(t, "2026-08-17T10:44:51Z", resp.Users[0].UpdatedAt)
+}
+
+func TestUserService_CreateUser_ReturnsTimestamps(t *testing.T) {
+	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+	ouServiceMock.On("IsOrganizationUnitExists", mock.Anything, testOrgID).
+		Return(true, (*tidcommon.ServiceError)(nil)).Once()
+
+	entityTypeMock := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	entityTypeMock.On("GetEntityTypeByName", mock.Anything, mock.Anything, testUserType).
+		Return(&entitytype.EntityType{OUID: testOrgID}, (*tidcommon.ServiceError)(nil)).Once()
+
+	storeMock := entitymock.NewEntityServiceInterfaceMock(t)
+	storeMock.On("CreateEntity", mock.Anything, mock.Anything, mock.Anything).
+		Return(&providers.Entity{
+			OUID: testOrgID, Type: testUserType, Attributes: json.RawMessage(`{}`),
+			CreatedAt: svcTestCreatedAt, UpdatedAt: svcTestCreatedAt,
+		}, nil).Once()
+
+	service := &userService{
+		entityService:     storeMock,
+		ouService:         ouServiceMock,
+		entityTypeService: entityTypeMock,
+		authzService:      newAllowAllAuthz(t),
+		uuidGenerator:     utils.GenerateUUIDv7,
+	}
+
+	created, err := service.CreateUser(context.Background(), &providers.User{
+		Type: testUserType, OUID: testOrgID, Attributes: json.RawMessage(`{}`),
+	})
+	require.Nil(t, err)
+	require.Equal(t, "2026-08-17T09:12:03Z", created.CreatedAt)
+	require.Equal(t, created.CreatedAt, created.UpdatedAt)
+}
+
+func TestUserService_UpdateUser_ReturnsTimestamps(t *testing.T) {
+	userID := svcTestUserID1
+
+	storeMock := entitymock.NewEntityServiceInterfaceMock(t)
+	storeMock.On("IsEntityDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
+	storeMock.On("GetEntity", mock.Anything, userID).Return(&providers.Entity{
+		Category: providers.EntityCategoryUser, ID: userID, OUID: testOrgID, Type: testUserType,
+		CreatedAt: svcTestCreatedAt, UpdatedAt: svcTestCreatedAt,
+	}, nil).Once()
+	storeMock.On("UpdateEntity", mock.Anything, userID, mock.Anything).Return(&providers.Entity{
+		ID: userID, Attributes: json.RawMessage(`{"updated":"true"}`),
+		CreatedAt: svcTestCreatedAt, UpdatedAt: svcTestUpdatedAt,
+	}, nil).Once()
+
+	ouServiceMock := oumock.NewOrganizationUnitServiceInterfaceMock(t)
+	ouServiceMock.On("IsOrganizationUnitExists", mock.Anything, testOrgID).
+		Return(true, (*tidcommon.ServiceError)(nil)).Once()
+
+	entityTypeMock := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	entityTypeMock.On("GetEntityTypeByName", mock.Anything, mock.Anything, testUserType).
+		Return(&entitytype.EntityType{OUID: testOrgID}, (*tidcommon.ServiceError)(nil)).Once()
+	entityTypeMock.On("GetAttributes", mock.Anything, mock.Anything, testUserType,
+		entitytype.AttributeFilter{AllowCredential: true}).
+		Return([]entitytype.AttributeInfo{}, (*tidcommon.ServiceError)(nil)).Once()
+
+	service := &userService{
+		entityService:     storeMock,
+		ouService:         ouServiceMock,
+		entityTypeService: entityTypeMock,
+		authzService:      newAllowAllAuthz(t),
+	}
+
+	resp, err := service.UpdateUser(context.Background(), userID, &providers.User{
+		ID: userID, OUID: testOrgID, Type: testUserType,
+		Attributes: json.RawMessage(`{"updated":"true"}`),
+	})
+	require.Nil(t, err)
+	require.Equal(t, "2026-08-17T09:12:03Z", resp.CreatedAt)
+	require.Equal(t, "2026-08-17T10:44:51Z", resp.UpdatedAt)
+}
+
+func TestUserService_UpdateUserAttributes_ReturnsPostUpdateTimestamps(t *testing.T) {
+	storeMock := entitymock.NewEntityServiceInterfaceMock(t)
+	storeMock.On("IsEntityDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
+	storeMock.On("GetEntity", mock.Anything, svcTestUserID1).Return(&providers.Entity{
+		Category: providers.EntityCategoryUser, ID: svcTestUserID1, Type: testUserType,
+		Attributes: json.RawMessage(`{"email":"old@example.com"}`),
+		CreatedAt:  svcTestCreatedAt, UpdatedAt: svcTestCreatedAt,
+	}, nil).Once()
+	storeMock.On("UpdateAttributes", mock.Anything, svcTestUserID1, mock.Anything).Return(nil).Once()
+	storeMock.On("GetEntity", mock.Anything, svcTestUserID1).Return(&providers.Entity{
+		Category: providers.EntityCategoryUser, ID: svcTestUserID1, Type: testUserType,
+		Attributes: json.RawMessage(`{"email":"new@example.com"}`),
+		CreatedAt:  svcTestCreatedAt, UpdatedAt: svcTestUpdatedAt,
+	}, nil).Once()
+
+	schemaMock := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	schemaMock.On("GetAttributes", mock.Anything, mock.Anything, testUserType,
+		entitytype.AttributeFilter{AllowCredential: true}).
+		Return([]entitytype.AttributeInfo{}, (*tidcommon.ServiceError)(nil)).Once()
+
+	service := &userService{
+		entityService:     storeMock,
+		entityTypeService: schemaMock,
+		authzService:      newAllowAllAuthz(t),
+	}
+
+	resp, err := service.UpdateUserAttributes(context.Background(), svcTestUserID1,
+		json.RawMessage(`{"email":"new@example.com"}`))
+	require.Nil(t, err)
+	require.Equal(t, "2026-08-17T09:12:03Z", resp.CreatedAt)
+	require.Equal(t, "2026-08-17T10:44:51Z", resp.UpdatedAt)
+}
+
+func TestUserService_UpdateUserAttributes_ReloadFailureKeepsResponse(t *testing.T) {
+	storeMock := entitymock.NewEntityServiceInterfaceMock(t)
+	storeMock.On("IsEntityDeclarative", mock.Anything, mock.Anything).Return(false, nil).Maybe()
+	storeMock.On("GetEntity", mock.Anything, svcTestUserID1).Return(&providers.Entity{
+		Category: providers.EntityCategoryUser, ID: svcTestUserID1, Type: testUserType,
+		Attributes: json.RawMessage(`{"email":"old@example.com"}`),
+		CreatedAt:  svcTestCreatedAt, UpdatedAt: svcTestUpdatedAt,
+	}, nil).Once()
+	storeMock.On("UpdateAttributes", mock.Anything, svcTestUserID1, mock.Anything).Return(nil).Once()
+	storeMock.On("GetEntity", mock.Anything, svcTestUserID1).
+		Return((*providers.Entity)(nil), errors.New("reload failed")).Once()
+
+	schemaMock := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	schemaMock.On("GetAttributes", mock.Anything, mock.Anything, testUserType,
+		entitytype.AttributeFilter{AllowCredential: true}).
+		Return([]entitytype.AttributeInfo{}, (*tidcommon.ServiceError)(nil)).Once()
+
+	service := &userService{
+		entityService:     storeMock,
+		entityTypeService: schemaMock,
+		authzService:      newAllowAllAuthz(t),
+	}
+
+	resp, err := service.UpdateUserAttributes(context.Background(), svcTestUserID1,
+		json.RawMessage(`{"email":"new@example.com"}`))
+	require.Nil(t, err)
+	// Both pre-update values survive the failed reload; neither is cleared.
+	require.Equal(t, "2026-08-17T09:12:03Z", resp.CreatedAt)
+	require.Equal(t, "2026-08-17T10:44:51Z", resp.UpdatedAt)
 }

--- a/backend/pkg/thunderidengine/providers/model.go
+++ b/backend/pkg/thunderidengine/providers/model.go
@@ -736,6 +736,8 @@ type Entity struct {
 	Attributes       json.RawMessage `json:"attributes,omitempty"`
 	SystemAttributes json.RawMessage `json:"systemAttributes,omitempty"`
 	IsReadOnly       bool            `json:"isReadOnly"`
+	CreatedAt        time.Time       `json:"createdAt,omitempty"`
+	UpdatedAt        time.Time       `json:"updatedAt,omitempty"`
 }
 
 // EntityGroup represents a group with basic information for entity group membership queries.

--- a/backend/pkg/thunderidengine/providers/model.go
+++ b/backend/pkg/thunderidengine/providers/model.go
@@ -701,6 +701,9 @@ type User struct {
 	Attributes json.RawMessage `json:"attributes,omitempty"`
 	Display    string          `json:"display,omitempty"`
 	IsReadOnly bool            `json:"isReadOnly"`
+	// CreatedAt and UpdatedAt are store-owned RFC 3339 UTC strings, read-only on the API.
+	CreatedAt string `json:"createdAt,omitempty"`
+	UpdatedAt string `json:"updatedAt,omitempty"`
 }
 
 // Agent is the service-level model for agent create operations.
@@ -765,6 +768,10 @@ type Entity struct {
 	Attributes       json.RawMessage `json:"attributes,omitempty"`
 	SystemAttributes json.RawMessage `json:"systemAttributes,omitempty"`
 	IsReadOnly       bool            `json:"isReadOnly"`
+	// omitempty does not apply to time.Time, so these always serialize; the API edge
+	// decides what to expose.
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
 }
 
 // EntityGroup represents a group with basic information for entity group membership queries.

--- a/tests/integration/composite/composite_mode_api_test.go
+++ b/tests/integration/composite/composite_mode_api_test.go
@@ -202,7 +202,14 @@ func (suite *CompositeModeSuite) TestUserDeclarativeVisibility() {
 	resp, err := client.Get(fmt.Sprintf("%s/users/decl-user-1", testutils.TestServerURL))
 	suite.Require().NoError(err)
 	suite.Equal(http.StatusOK, resp.StatusCode, "declarative user should be visible")
+
+	var payload map[string]interface{}
+	suite.Require().NoError(json.NewDecoder(resp.Body).Decode(&payload))
 	resp.Body.Close()
+
+	// Declarative users have no database row, so they carry no timestamps.
+	suite.NotContains(payload, "createdAt")
+	suite.NotContains(payload, "updatedAt")
 
 	suite.assertMergedCollectionContainsIDs("/users", "users", "decl-user-1", "user")
 }

--- a/tests/integration/testutils/models.go
+++ b/tests/integration/testutils/models.go
@@ -30,6 +30,8 @@ type User struct {
 	OUID       string          `json:"ouId"`
 	Type       string          `json:"type"`
 	Attributes json.RawMessage `json:"attributes"`
+	CreatedAt  string          `json:"createdAt"`
+	UpdatedAt  string          `json:"updatedAt"`
 }
 
 // Application represents an application in the system

--- a/tests/integration/testutils/models.go
+++ b/tests/integration/testutils/models.go
@@ -32,6 +32,8 @@ type User struct {
 	Type       string          `json:"type"`
 	Display    string          `json:"display,omitempty"`
 	Attributes json.RawMessage `json:"attributes"`
+	CreatedAt  string          `json:"createdAt"`
+	UpdatedAt  string          `json:"updatedAt"`
 }
 
 // Application represents an application in the system

--- a/tests/integration/user/user_self_api_test.go
+++ b/tests/integration/user/user_self_api_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 	"github.com/thunder-id/thunderid/tests/integration/testutils"
@@ -320,4 +321,51 @@ func (s *SelfUserEndpointsSuite) TestSelfUserUpdateCredentialsMissingAttributesR
 	s.Require().NoError(err)
 	defer verifyResp.Body.Close()
 	s.Equal(http.StatusOK, verifyResp.StatusCode, "the existing password must still grant access")
+}
+
+// TestSelfUserTimestamps verifies /users/me exposes createdAt/updatedAt and that PUT /users/me
+// returns the post-update values rather than the pre-update ones.
+func (s *SelfUserEndpointsSuite) TestSelfUserTimestamps() {
+	resp, err := s.doUserRequest(http.MethodGet, "/users/me", nil)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var before testutils.User
+	s.Require().NoError(json.NewDecoder(resp.Body).Decode(&before))
+
+	createdAt, err := time.Parse(time.RFC3339, before.CreatedAt)
+	s.Require().NoError(err, "createdAt must be RFC 3339")
+	updatedAt, err := time.Parse(time.RFC3339, before.UpdatedAt)
+	s.Require().NoError(err, "updatedAt must be RFC 3339")
+	s.Require().False(updatedAt.Before(createdAt))
+
+	payload := map[string]interface{}{
+		"attributes": map[string]interface{}{
+			"username": s.username,
+			"email":    s.email,
+		},
+	}
+	updateResp, err := s.doUserRequest(http.MethodPut, "/users/me", payload)
+	s.Require().NoError(err)
+	defer updateResp.Body.Close()
+	s.Require().Equal(http.StatusOK, updateResp.StatusCode)
+
+	var after testutils.User
+	s.Require().NoError(json.NewDecoder(updateResp.Body).Decode(&after))
+
+	s.Equal(before.CreatedAt, after.CreatedAt, "createdAt must not change on update")
+	newUpdatedAt, err := time.Parse(time.RFC3339, after.UpdatedAt)
+	s.Require().NoError(err, "updatedAt must be RFC 3339")
+	s.Require().False(newUpdatedAt.Before(updatedAt), "updatedAt must advance on update")
+
+	verifyResp, err := s.doUserRequest(http.MethodGet, "/users/me", nil)
+	s.Require().NoError(err)
+	defer verifyResp.Body.Close()
+	s.Require().Equal(http.StatusOK, verifyResp.StatusCode)
+
+	var reread testutils.User
+	s.Require().NoError(json.NewDecoder(verifyResp.Body).Decode(&reread))
+	s.Equal(after.CreatedAt, reread.CreatedAt)
+	s.Equal(after.UpdatedAt, reread.UpdatedAt)
 }

--- a/tests/integration/user/userapi_test.go
+++ b/tests/integration/user/userapi_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/thunder-id/thunderid/tests/integration/testutils"
 	"github.com/stretchr/testify/suite"
@@ -893,4 +894,91 @@ func deleteGroup(groupID string) error {
 	}
 
 	return nil
+}
+
+// TestUserTimestamps verifies createdAt/updatedAt are returned on write and read paths,
+// persist across reads, and that updatedAt advances on update while createdAt stays fixed.
+func (ts *UserAPITestSuite) TestUserTimestamps() {
+	payload := testutils.User{
+		OUID:       testOUID,
+		Type:       testUser.Type,
+		Attributes: json.RawMessage(`{"age": 41, "roles": ["viewer"]}`),
+	}
+	body, err := json.Marshal(payload)
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest(http.MethodPost, testServerURL+"/users", bytes.NewReader(body))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err)
+	var created testutils.User
+	ts.Require().NoError(json.NewDecoder(resp.Body).Decode(&created))
+	resp.Body.Close()
+	ts.Require().Equal(http.StatusCreated, resp.StatusCode)
+	ts.Require().NotEmpty(created.ID)
+
+	defer func() {
+		if err := deleteUser(created.ID); err != nil {
+			ts.T().Logf("Failed to delete timestamp test user: %v", err)
+		}
+	}()
+
+	createdAt := parseTimestamp(ts, created.CreatedAt, "createdAt on create")
+	updatedAt := parseTimestamp(ts, created.UpdatedAt, "updatedAt on create")
+	ts.Require().False(updatedAt.Before(createdAt), "updatedAt must not precede createdAt")
+
+	fetched := getUser(ts, created.ID)
+	ts.Require().Equal(created.CreatedAt, fetched.CreatedAt)
+	ts.Require().Equal(created.UpdatedAt, fetched.UpdatedAt)
+
+	update := testutils.User{
+		OUID:       testOUID,
+		Type:       testUser.Type,
+		Attributes: json.RawMessage(`{"age": 42, "roles": ["admin"]}`),
+	}
+	updateBody, err := json.Marshal(update)
+	ts.Require().NoError(err)
+
+	updateReq, err := http.NewRequest(http.MethodPut,
+		testServerURL+"/users/"+created.ID, bytes.NewReader(updateBody))
+	ts.Require().NoError(err)
+	updateReq.Header.Set("Content-Type", "application/json")
+
+	updateResp, err := testutils.GetHTTPClient().Do(updateReq)
+	ts.Require().NoError(err)
+	var updated testutils.User
+	ts.Require().NoError(json.NewDecoder(updateResp.Body).Decode(&updated))
+	updateResp.Body.Close()
+	ts.Require().Equal(http.StatusOK, updateResp.StatusCode)
+
+	ts.Require().Equal(created.CreatedAt, updated.CreatedAt, "createdAt must not change on update")
+	newUpdatedAt := parseTimestamp(ts, updated.UpdatedAt, "updatedAt on update")
+	ts.Require().False(newUpdatedAt.Before(updatedAt), "updatedAt must advance on update")
+
+	refetched := getUser(ts, created.ID)
+	ts.Require().Equal(updated.CreatedAt, refetched.CreatedAt)
+	ts.Require().Equal(updated.UpdatedAt, refetched.UpdatedAt)
+}
+
+func parseTimestamp(ts *UserAPITestSuite, value, field string) time.Time {
+	ts.Require().NotEmpty(value, "%s must not be empty", field)
+	parsed, err := time.Parse(time.RFC3339, value)
+	ts.Require().NoError(err, "%s must be RFC 3339", field)
+	return parsed
+}
+
+func getUser(ts *UserAPITestSuite, userID string) testutils.User {
+	req, err := http.NewRequest(http.MethodGet, testServerURL+"/users/"+userID, nil)
+	ts.Require().NoError(err)
+
+	resp, err := testutils.GetHTTPClient().Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	var user testutils.User
+	ts.Require().NoError(json.NewDecoder(resp.Body).Decode(&user))
+	return user
 }


### PR DESCRIPTION
### Purpose

The user management API never returned creation or last-modification timestamps, even though `ENTITY.CREATED_AT` / `ENTITY.UPDATED_AT` are `NOT NULL` and already maintained by every write path. Themes, layouts and flows already expose `createdAt` / `updatedAt`, so users were inconsistent with the rest of the management API.

Adds both as top-level, read-only, RFC 3339 UTC strings on every response carrying a user object: `GET /users`, `GET /users/{id}`, `GET /users/me`, `POST /users`, `POST /users/tree/{path}`, `PUT /users/{id}`, `PUT /users/me`.

Read path and mapping only. No DB migration.

### Approach

- `providers.Entity` carries the values as `time.Time`; formatting to RFC 3339 happens at the user API edge, mirroring how OU does it.
- `CREATED_AT, UPDATED_AT` added to the 7 entity `SELECT`s. Query IDs are unchanged and parameter numbering is unaffected, since pagination only appends `ORDER BY ID LIMIT/OFFSET` and the filter builders only append `AND` clauses.
- Parsed with the shared `sysutils.ParseDBTimeField`, which handles both the Postgres `time.Time` and the SQLite datetime string. A missing or unparseable value errors, matching the OU, theme, flow session and consent stores.
- Declarative users have no database row, so their fields stay zero and are omitted.
- `POST` / `PUT` responses are re-mapped from the stored entity so they carry post-write values. `PUT /users/me` re-reads after the attribute update, since `UpdateAttributes` returns only an error.

Two things worth reviewer attention:

1. **Entity cache.** `CreateEntity` / `UpdateEntity` seeded the by-ID cache from the caller's struct, which has no store-generated timestamps. Since `entityService.CreateEntity` re-reads inside the transaction through the same store, the create response and every subsequent `GET` would have served timestamp-less users until eviction. Both now invalidate instead, and the follow-up read populates the cache from the database. Costs one DB read per create/update.

2. **`attributes: null`.** An entity stored without attributes holds the JSON `null` literal, because `ATTRIBUTES` has no `"{}"` default the way `SYSTEM_ATTRIBUTES` and `CREDENTIALS` do. The read path now treats it as absent, matching `parseJSONColumn`. This was already the behaviour on a cold cache; the seeded cache entry was masking it.

`GET /users/tree/{path}` is unchanged: it returns bare ID stubs by design, and populating timestamps there would mean a batch entity fetch on every call, which today happens only for `include=display`.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/5019

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- User and entity responses now include read-only `createdAt` and `updatedAt` timestamps in RFC 3339 format.
- Timestamps are available across listing, creation, retrieval, updates, and self-service profile endpoints.
- Declarative users omit database-generated timestamps.

## Bug Fixes
- User updates now return refreshed persisted timestamps.
- Subsequent entity reads reflect store-generated timestamp values.
- Empty or null attributes are handled correctly.
- Cached entity data no longer overrides refreshed persisted values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->