### PR TITLE
Validate flow definitions from static executor metadata

### DIFF
--- a/backend/cmd/cpserver/servicemanager.go
+++ b/backend/cmd/cpserver/servicemanager.go
@@ -35,10 +35,6 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/agent"
 	"github.com/thunder-id/thunderid/internal/application"
-	"github.com/thunder-id/thunderid/internal/authn/github"
-	"github.com/thunder-id/thunderid/internal/authn/google"
-	authnOAuth "github.com/thunder-id/thunderid/internal/authn/oauth"
-	authnOIDC "github.com/thunder-id/thunderid/internal/authn/oidc"
 	"github.com/thunder-id/thunderid/internal/cert"
 	"github.com/thunder-id/thunderid/internal/connection"
 	"github.com/thunder-id/thunderid/internal/dataplanetoken"
@@ -53,7 +49,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/envmgr/thunder"
 	flowconfig "github.com/thunder-id/thunderid/internal/flow/config"
 	flowcore "github.com/thunder-id/thunderid/internal/flow/core"
-	"github.com/thunder-id/thunderid/internal/flow/executor"
+	"github.com/thunder-id/thunderid/internal/flow/executormeta"
 	"github.com/thunder-id/thunderid/internal/flow/graphbuilder"
 	"github.com/thunder-id/thunderid/internal/flow/interceptor"
 	flowmgt "github.com/thunder-id/thunderid/internal/flow/mgt"
@@ -258,40 +254,9 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 
 	// Flow MANAGEMENT (CRUD + definition validation).
 	//
-	// TEMPORARY COUPLING: flow validation needs an executor/interceptor registry and a graph
-	// builder to check that flow nodes reference known executors and that the graph is well-formed.
-	// Building that registry links the flow/executor package, which transitively imports the Data
-	// Plane authn/oauth/idp-runtime/notification-otp packages. Validation only reads static executor
-	// metadata (GetMeta / IsRegistered) and never executes a node, so runtime dependencies are left
-	// nil where the executor constructor merely stores them. The federated-auth services below are
-	// the exception: three executor constructors (github/google/oidc) type-assert their auth service
-	// at construction, so the CP builds these lightweight services (never executed here) to satisfy
-	// them. Splitting executor metadata/registration from executor execution wiring (the follow-up
-	// flow refactor) removes both this link and the need for these services entirely.
-	oauthAuthnService := authnOAuth.Initialize(idpService, entityProvider)
-	oidcAuthnService := authnOIDC.Initialize(oauthAuthnService, jwtService)
-	googleAuthnService := google.Initialize(oidcAuthnService, jwtService)
-	githubAuthnService := github.Initialize(oauthAuthnService)
-
 	flowConfig := flowconfig.FromServerRuntime()
-	flowFactory, execRegistry, interceptorRegistry, graphBuilder := initializeFlowCoreAndExecutor(ctx, logger,
-		cacheManager, executor.ExecutorDependencies{
-			OUService:             ouService,
-			IDPService:            idpService,
-			JWTService:            jwtService,
-			EntityTypeService:     entityTypeService,
-			GroupService:          groupService,
-			RoleService:           roleService,
-			RoleAssignmentService: roleAssignmentService,
-			EntityProvider:        entityProvider,
-			OAuthSvc:              oauthAuthnService,
-			OIDCSvc:               oidcAuthnService,
-			GoogleSvc:             googleAuthnService,
-			GithubSvc:             githubAuthnService,
-		},
-		interceptor.InterceptorDependencies{},
-		flowConfig,
-	)
+	flowFactory, execRegistry, interceptorRegistry, graphBuilder := initializeFlowValidation(ctx, logger,
+		cacheManager, interceptor.InterceptorDependencies{}, flowConfig)
 
 	flowMgtService, flowMgtExporter, err := flowmgt.Initialize(
 		mux, mcpServer, cacheManager, flowFactory, execRegistry, interceptorRegistry, graphBuilder)
@@ -458,21 +423,25 @@ func fatalOnError(ctx context.Context, logger *log.Logger, err error, msg string
 // initializeFlowCoreAndExecutor initializes the flow core and executor registries used for flow
 // definition validation. On the CP the executor dependencies carry only management services; the
 // runtime dependencies are left nil because validation reads static executor metadata only.
-func initializeFlowCoreAndExecutor(
+// initializeFlowValidation initializes what flow definition validation and graph building need.
+//
+// The executor side is the static metadata catalog rather than the real registry: this plane
+// validates flows and never runs one, and constructing the executors would link the data-plane
+// services they are built with. The catalog honors the same configured subset, so a flow accepted
+// here is one the plane that runs it has registered.
+func initializeFlowValidation(
 	ctx context.Context,
 	logger *log.Logger,
 	cacheManager cache.CacheManagerInterface,
-	execDeps executor.ExecutorDependencies,
 	interceptorDeps interceptor.InterceptorDependencies,
 	flowConfig flowconfig.Config,
-) (flowcore.FlowFactoryInterface, executor.ExecutorRegistryInterface,
+) (flowcore.FlowFactoryInterface, flowcore.ExecutorMetadataProvider,
 	interceptor.InterceptorRegistryInterface, graphbuilder.GraphBuilderInterface) {
 	flowFactory, graphCache := flowcore.Initialize(cacheManager)
-	execDeps.FlowFactory = flowFactory
 	interceptorDeps.FlowFactory = flowFactory
 
-	execRegistry, err := executor.Initialize(execDeps, flowConfig.Flow)
-	fatalOnError(ctx, logger, err, "Failed to register flow executors")
+	execRegistry, err := executormeta.NewRegistry(flowConfig.Flow.Executors)
+	fatalOnError(ctx, logger, err, "Failed to build the flow executor metadata registry")
 	interceptorRegistry, err := interceptor.Initialize(interceptorDeps, flowConfig.Flow)
 	fatalOnError(ctx, logger, err, "Failed to initialize Interceptor registry")
 

--- a/backend/internal/flow/executor/catalog_parity_test.go
+++ b/backend/internal/flow/executor/catalog_parity_test.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package executor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/thunder-id/thunderid/internal/flow/core"
+	"github.com/thunder-id/thunderid/internal/flow/executormeta"
+	"github.com/thunder-id/thunderid/internal/system/cache"
+	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
+	"github.com/thunder-id/thunderid/tests/mocks/authn/githubmock"
+	"github.com/thunder-id/thunderid/tests/mocks/authn/googlemock"
+	"github.com/thunder-id/thunderid/tests/mocks/authn/oauthmock"
+	"github.com/thunder-id/thunderid/tests/mocks/authn/oidcmock"
+	"github.com/thunder-id/thunderid/tests/mocks/entityprovidermock"
+)
+
+// TestCatalogMatchesRegistry holds the static metadata catalog to what the real executors report.
+//
+// The catalog exists so a control plane can validate flow definitions without constructing an
+// executor, which would link the data-plane services those constructors need. Two descriptions of
+// the same thing drift, so this is what stops them: change an executor's metadata without changing
+// the catalog and this fails, naming the executor.
+//
+// The real flow factory is used rather than a mock, because a mock's CreateExecutor discards the
+// metadata it is handed and returns a stub.
+func TestCatalogMatchesRegistry(t *testing.T) {
+	factory, _ := core.Initialize(cache.Initialize(engineconfig.CacheConfig{Disabled: true}, "test"))
+	deps := ExecutorDependencies{
+		FlowFactory:    factory,
+		EntityProvider: entityprovidermock.NewEntityProviderInterfaceMock(t),
+		OAuthSvc:       oauthmock.NewOAuthAuthnServiceInterfaceMock(t),
+		OIDCSvc:        oidcmock.NewOIDCAuthnServiceInterfaceMock(t),
+		GithubSvc:      githubmock.NewGithubOAuthAuthnServiceInterfaceMock(t),
+		GoogleSvc:      googlemock.NewGoogleOIDCAuthnServiceInterfaceMock(t),
+	}
+	reg := newExecutorRegistry()
+	require.NoError(t, registerBuiltInExecutors(reg, deps, nil))
+
+	assert.ElementsMatch(t, defaultBuiltInExecutorNames(), executormeta.Names(),
+		"the catalog must name exactly the built-in executors")
+
+	for _, name := range defaultBuiltInExecutorNames() {
+		live, err := reg.GetExecutorMeta(name)
+		require.NoError(t, err, "executor %q", name)
+		static, ok := executormeta.MetaFor(name)
+		require.True(t, ok, "executor %q is missing from the catalog", name)
+
+		if live == nil {
+			assert.Empty(t, static, "executor %q reports no metadata", name)
+			continue
+		}
+		assert.Equal(t, *live, static, "catalog metadata for %q has drifted from the executor", name)
+	}
+}

--- a/backend/internal/flow/executormeta/catalog.go
+++ b/backend/internal/flow/executormeta/catalog.go
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package executormeta
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
+)
+
+// catalog is the static metadata of every built-in executor, keyed by name.
+//
+// It mirrors what each executor reports from GetMeta at runtime, so that a server which only
+// validates flow definitions can read it without constructing an executor and thereby linking the
+// data-plane services those constructors need. TestCatalogMatchesRegistry in the executor package
+// holds the two together: it registers the real executors and fails on any difference.
+var catalog = map[string]providers.ExecutorMeta{
+	ExecutorNameAttributeCollect:             {},
+	ExecutorNameAttributeUniquenessValidator: {},
+	ExecutorNameAuthAssert: {
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: propertyKeyCallbackType},
+		},
+	},
+	ExecutorNameAuthorization: {},
+	ExecutorNameConsent: {
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: "timeout"},
+		},
+	},
+	ExecutorNameCredentialSetter: {},
+	ExecutorNameCredentialsAuth:  {},
+	ExecutorNameEmailExecutor: {
+		SupportedModes: []string{ExecutorModeSend},
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: propertyKeyEmailTemplate, IsRequired: true},
+		},
+	},
+	ExecutorNameFederatedAuthResolver: {},
+	ExecutorNameGitHubAuth: {
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: "idpId", IsRequired: true},
+			{Property: "allowAuthenticationWithoutLocalUser"},
+			{Property: "allowRegistrationWithExistingUser"},
+		},
+	},
+	ExecutorNameGoogleAuth: {
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: "idpId", IsRequired: true},
+			{Property: "allowAuthenticationWithoutLocalUser"},
+			{Property: "allowRegistrationWithExistingUser"},
+		},
+	},
+	ExecutorNameHTTPRequest: {
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: "url", IsRequired: true},
+			{Property: "method"},
+			{Property: "headers"},
+			{Property: "body"},
+			{Property: "timeout"},
+			{Property: "responseMapping"},
+			{Property: "errorHandling"},
+		},
+	},
+	ExecutorNameIdentifying: {
+		DefaultMode:    ExecutorModeIdentify,
+		SupportedModes: []string{ExecutorModeIdentify, ExecutorModeResolve, ExecutorModeCheckState},
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: propertyKeyLoginHintAttribute},
+		},
+	},
+	ExecutorNameInviteExecutor: {
+		SupportedModes: []string{ExecutorModeGenerate, passkeyExecutorModeVerify},
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: propertyKeyInviteBaseURL},
+		},
+	},
+	ExecutorNameMagicLink: {
+		SupportedModes: []string{ExecutorModeGenerate, passkeyExecutorModeVerify},
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: propertyKeyTokenExpiry},
+			{Property: propertyKeyMagicLinkURL},
+		},
+	},
+	ExecutorNameOAuth: {
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: "idpId", IsRequired: true},
+			{Property: "allowAuthenticationWithoutLocalUser"},
+			{Property: "allowRegistrationWithExistingUser"},
+		},
+	},
+	ExecutorNameOIDCAuth: {
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: "idpId", IsRequired: true},
+			{Property: "allowAuthenticationWithoutLocalUser"},
+			{Property: "allowRegistrationWithExistingUser"},
+		},
+	},
+	ExecutorNameOTPExecutor: {
+		SupportedModes: []string{ExecutorModeGenerate, passkeyExecutorModeVerify},
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: propertyKeyMaxOTPAttempts},
+		},
+	},
+	ExecutorNameOUCreation: {
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: "parentOuId"},
+		},
+	},
+	ExecutorNameOUResolver: {
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: "resolveFrom"},
+		},
+	},
+	ExecutorNameOpenID4VPVerify: {
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: propertyKeyPresentationDefinitionID, IsRequired: true},
+			{Property: "allowAuthenticationWithoutLocalUser"},
+		},
+	},
+	ExecutorNamePasskeyAuth: {
+		SupportedModes: []string{
+			passkeyExecutorModeChallenge, passkeyExecutorModeVerify,
+			passkeyExecutorModeRegStart, passkeyExecutorModeRegFinish,
+		},
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{
+				Property: "relyingPartyId", IsRequired: true,
+				ApplicableModes: []string{passkeyExecutorModeChallenge, passkeyExecutorModeRegStart},
+			},
+			{Property: "relyingPartyName"},
+			{Property: "authenticatorSelection"},
+			{Property: "attestation"},
+		},
+	},
+	ExecutorNamePermissionValidator: {
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: propertyKeyRequiredScopes},
+		},
+	},
+	ExecutorNameProvisioning: {
+		SupportedFlowTypes: []providers.FlowType{"AUTHENTICATION", "REGISTRATION", "USER_ONBOARDING"},
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: propertyKeyDynamicInputsIncludeOptional},
+			{Property: propertyKeyDynamicInputsIncludeOptionalCredentials},
+			{Property: propertyKeyMaxDynamicInputsPerPrompt},
+			{Property: propertyKeyAssignGroup},
+			{Property: propertyKeyAssignRole},
+			{Property: "allowCrossOUProvisioning"},
+		},
+	},
+	ExecutorNameSMSExecutor: {
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: propertyKeyNotificationSenderID, IsRequired: true},
+			{Property: propertyKeySMSTemplate, IsRequired: true},
+		},
+	},
+	ExecutorNameSSOCheck: {
+		SupportedFlowTypes: []providers.FlowType{"AUTHENTICATION"},
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: "checkpointRef", IsRequired: true},
+		},
+	},
+	ExecutorNameSession: {
+		SupportedFlowTypes: []providers.FlowType{"AUTHENTICATION"},
+	},
+	ExecutorNameSessionSignOut: {
+		SupportedFlowTypes: []providers.FlowType{"SIGNOUT"},
+	},
+	ExecutorNameUserTypeResolver: {
+		SupportedProperties: []providers.ExecutorSupportedProperties{
+			{Property: propertyKeyAllowedUserTypes},
+		},
+	},
+}
+
+// Names returns every built-in executor name, sorted.
+func Names() []string {
+	names := make([]string, 0, len(catalog))
+	for name := range catalog {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+// MetaFor returns a copy of the static metadata for a built-in executor. The boolean reports whether
+// the name is one. A copy is returned so a caller cannot alter what every other caller reads.
+func MetaFor(name string) (providers.ExecutorMeta, bool) {
+	meta, ok := catalog[name]
+	return meta, ok
+}
+
+// Registry is the runtime-free view of the executor registry that flow definition validation and
+// graph building need. It answers from the static catalog and holds no executor, so a server that
+// only validates flows links none of the services an executor is constructed with.
+//
+// It honors the same configured subset as the runtime registry: an empty names list registers every
+// built-in, and a non-empty one restricts to those named, so validation on one plane agrees with
+// what another plane will actually run.
+type Registry struct {
+	registered map[string]bool
+}
+
+// NewRegistry builds the metadata view for the named built-in executors. An empty list means all of
+// them. An unknown name is an error, matching the runtime registry rather than silently ignoring it.
+func NewRegistry(names []string) (*Registry, error) {
+	registered := make(map[string]bool, len(catalog))
+	if len(names) == 0 {
+		for name := range catalog {
+			registered[name] = true
+		}
+		return &Registry{registered: registered}, nil
+	}
+	for _, name := range names {
+		if _, ok := catalog[name]; !ok {
+			return nil, fmt.Errorf("unknown built-in executor: %q", name)
+		}
+		registered[name] = true
+	}
+	return &Registry{registered: registered}, nil
+}
+
+// IsRegistered reports whether the named executor is one this deployment runs.
+func (r *Registry) IsRegistered(name string) bool {
+	return r.registered[name]
+}
+
+// GetExecutorMeta returns the metadata of a registered executor. A name this deployment does not
+// register is an error, so a flow referencing it fails validation rather than passing on metadata
+// nothing will honor.
+func (r *Registry) GetExecutorMeta(name string) (*providers.ExecutorMeta, error) {
+	if !r.registered[name] {
+		return nil, fmt.Errorf("executor '%s' not found", name)
+	}
+	meta := catalog[name]
+	return &meta, nil
+}

--- a/backend/internal/flow/graphbuilder/graph_builder.go
+++ b/backend/internal/flow/graphbuilder/graph_builder.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/flow/common"
 	"github.com/thunder-id/thunderid/internal/flow/core"
-	"github.com/thunder-id/thunderid/internal/flow/executor"
 	"github.com/thunder-id/thunderid/internal/flow/interceptor"
 	"github.com/thunder-id/thunderid/internal/system/log"
 )
@@ -37,7 +36,7 @@ import (
 // graphBuilder is the implementation of GraphBuilderInterface.
 type graphBuilder struct {
 	flowFactory         core.FlowFactoryInterface
-	executorRegistry    executor.ExecutorRegistryInterface
+	executorRegistry    core.ExecutorMetadataProvider
 	interceptorRegistry interceptor.InterceptorRegistryInterface
 	graphCache          core.GraphCacheInterface
 	logger              *log.Logger
@@ -46,7 +45,7 @@ type graphBuilder struct {
 // Initialize creates a new graph builder instance.
 func Initialize(
 	flowFactory core.FlowFactoryInterface,
-	executorRegistry executor.ExecutorRegistryInterface,
+	executorRegistry core.ExecutorMetadataProvider,
 	interceptorRegistry interceptor.InterceptorRegistryInterface,
 	graphCache core.GraphCacheInterface,
 ) GraphBuilderInterface {

--- a/backend/internal/flow/mgt/inference.go
+++ b/backend/internal/flow/mgt/inference.go
@@ -27,7 +27,7 @@ import (
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
 	"github.com/thunder-id/thunderid/internal/flow/common"
-	"github.com/thunder-id/thunderid/internal/flow/executor"
+	"github.com/thunder-id/thunderid/internal/flow/executormeta"
 	"github.com/thunder-id/thunderid/internal/system/log"
 )
 
@@ -285,7 +285,7 @@ func (s *flowInferenceService) addDefaultLayout(node *providers.NodeDefinition) 
 // findAuthAssertNode finds the AuthAssertExecutor node in the flow and returns its ID
 func (s *flowInferenceService) findAuthAssertNode(nodes []providers.NodeDefinition) (string, bool) {
 	for _, node := range nodes {
-		if node.Executor != nil && node.Executor.Name == executor.ExecutorNameAuthAssert {
+		if node.Executor != nil && node.Executor.Name == executormeta.ExecutorNameAuthAssert {
 			return node.ID, true
 		}
 	}
@@ -295,7 +295,7 @@ func (s *flowInferenceService) findAuthAssertNode(nodes []providers.NodeDefiniti
 // hasProvisioningNode checks if a provisioning node already exists in the flow
 func (s *flowInferenceService) hasProvisioningNode(nodes []providers.NodeDefinition) bool {
 	for _, node := range nodes {
-		if node.Executor != nil && node.Executor.Name == executor.ExecutorNameProvisioning {
+		if node.Executor != nil && node.Executor.Name == executormeta.ExecutorNameProvisioning {
 			return true
 		}
 	}
@@ -332,7 +332,7 @@ func (s *flowInferenceService) createProvisioningNode(nextNodeID string, include
 		ID:   provisioningNodeID,
 		Type: string(common.NodeTypeTaskExecution),
 		Executor: &providers.ExecutorDefinition{
-			Name: executor.ExecutorNameProvisioning,
+			Name: executormeta.ExecutorNameProvisioning,
 		},
 		OnSuccess: nextNodeID,
 	}
@@ -347,7 +347,7 @@ func (s *flowInferenceService) createProvisioningNode(nextNodeID string, include
 // hasUserTypeResolverNode checks if a user type resolver node already exists in the flow
 func (s *flowInferenceService) hasUserTypeResolverNode(nodes []providers.NodeDefinition) bool {
 	for _, node := range nodes {
-		if node.Executor != nil && node.Executor.Name == executor.ExecutorNameUserTypeResolver {
+		if node.Executor != nil && node.Executor.Name == executormeta.ExecutorNameUserTypeResolver {
 			return true
 		}
 	}
@@ -363,7 +363,7 @@ func (s *flowInferenceService) createUserTypeResolverNode(
 		ID:   userTypeResolverNodeID,
 		Type: string(common.NodeTypeTaskExecution),
 		Executor: &providers.ExecutorDefinition{
-			Name: executor.ExecutorNameUserTypeResolver,
+			Name: executormeta.ExecutorNameUserTypeResolver,
 		},
 		OnIncomplete: promptNodeID,
 	}
@@ -531,8 +531,8 @@ func (s *flowInferenceService) insertPhoneInputPromptIfNeeded(
 	for _, node := range *nodes {
 		// Check for OTP generate node and capture phone input from executor inputs if defined
 		if node.Executor != nil &&
-			node.Executor.Name == executor.ExecutorNameOTPExecutor &&
-			node.Executor.Mode == executor.ExecutorModeGenerate &&
+			node.Executor.Name == executormeta.ExecutorNameOTPExecutor &&
+			node.Executor.Mode == executormeta.ExecutorModeGenerate &&
 			otpGenerateNodeID == "" {
 			otpGenerateNodeID = node.ID
 			for _, input := range node.Executor.Inputs {

--- a/backend/internal/flow/mgt/init.go
+++ b/backend/internal/flow/mgt/init.go
@@ -27,7 +27,6 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/thunder-id/thunderid/internal/flow/core"
-	"github.com/thunder-id/thunderid/internal/flow/executor"
 	"github.com/thunder-id/thunderid/internal/flow/graphbuilder"
 	"github.com/thunder-id/thunderid/internal/flow/interceptor"
 
@@ -45,7 +44,7 @@ func Initialize(
 	mcpServer *mcp.Server,
 	cacheManager cache.CacheManagerInterface,
 	flowFactory core.FlowFactoryInterface,
-	executorRegistry executor.ExecutorRegistryInterface,
+	executorRegistry core.ExecutorMetadataProvider,
 	interceptorRegistry interceptor.InterceptorRegistryInterface,
 	graphBuilder graphbuilder.GraphBuilderInterface,
 ) (FlowMgtServiceInterface, declarativeresource.ResourceExporter, error) {

--- a/backend/internal/flow/mgt/service.go
+++ b/backend/internal/flow/mgt/service.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/flow/common"
 	"github.com/thunder-id/thunderid/internal/flow/core"
-	"github.com/thunder-id/thunderid/internal/flow/executor"
+	"github.com/thunder-id/thunderid/internal/flow/executormeta"
 	"github.com/thunder-id/thunderid/internal/flow/graphbuilder"
 	"github.com/thunder-id/thunderid/internal/flow/interceptor"
 	"github.com/thunder-id/thunderid/internal/system/config"
@@ -82,7 +82,7 @@ type flowMgtService struct {
 	store               flowStoreInterface
 	inferenceService    flowInferenceServiceInterface
 	graphBuilder        graphbuilder.GraphBuilderInterface
-	executorRegistry    executor.ExecutorRegistryInterface
+	executorRegistry    core.ExecutorMetadataProvider
 	interceptorRegistry interceptor.InterceptorRegistryInterface
 	flowValidator       FlowValidatorInterface
 	compositeStore      *compositeFlowStore
@@ -96,7 +96,7 @@ func newFlowMgtService(
 	store flowStoreInterface,
 	inferenceService flowInferenceServiceInterface,
 	graphBuilder graphbuilder.GraphBuilderInterface,
-	executorRegistry executor.ExecutorRegistryInterface,
+	executorRegistry core.ExecutorMetadataProvider,
 	interceptorRegistry interceptor.InterceptorRegistryInterface,
 	flowValidator FlowValidatorInterface,
 	compositeStore *compositeFlowStore,
@@ -782,7 +782,7 @@ func (s *flowMgtService) hasPasskeyRegistrationModes(flowDef *FlowDefinition) bo
 	hasRegFinish := false
 
 	for _, node := range flowDef.Nodes {
-		if node.Executor != nil && node.Executor.Name == executor.ExecutorNamePasskeyAuth {
+		if node.Executor != nil && node.Executor.Name == executormeta.ExecutorNamePasskeyAuth {
 			switch node.Executor.Mode {
 			case "register_start":
 				hasRegStart = true

--- a/backend/internal/flow/mgt/validator.go
+++ b/backend/internal/flow/mgt/validator.go
@@ -24,7 +24,8 @@ import (
 	"strconv"
 
 	"github.com/thunder-id/thunderid/internal/flow/common"
-	"github.com/thunder-id/thunderid/internal/flow/executor"
+	"github.com/thunder-id/thunderid/internal/flow/core"
+	"github.com/thunder-id/thunderid/internal/flow/executormeta"
 	"github.com/thunder-id/thunderid/internal/flow/graphbuilder"
 	"github.com/thunder-id/thunderid/internal/flow/interceptor"
 	"github.com/thunder-id/thunderid/internal/system/log"
@@ -42,7 +43,7 @@ type FlowValidatorInterface interface {
 // flowValidator is responsible for validating flow definitions,
 // including metadata, structure, node configurations, and registry-dependent checks.
 type flowValidator struct {
-	executorRegistry    executor.ExecutorRegistryInterface
+	executorRegistry    core.ExecutorMetadataProvider
 	interceptorRegistry interceptor.InterceptorRegistryInterface
 	graphBuilder        graphbuilder.GraphBuilderInterface
 	logger              *log.Logger
@@ -50,7 +51,7 @@ type flowValidator struct {
 
 // newFlowValidator creates a new instance of flowValidator with the provided dependencies.
 func newFlowValidator(
-	executorRegistry executor.ExecutorRegistryInterface,
+	executorRegistry core.ExecutorMetadataProvider,
 	interceptorRegistry interceptor.InterceptorRegistryInterface,
 	graphBuilder graphbuilder.GraphBuilderInterface,
 ) *flowValidator {
@@ -154,9 +155,13 @@ func (v *flowValidator) validateMetadata(flowDef *FlowDefinition) *tidcommon.Ser
 
 // requiredExecutorsByFlowType maps flow type → executor names that must appear at least once.
 var requiredExecutorsByFlowType = map[providers.FlowType][]string{
-	providers.FlowTypeAuthentication: {executor.ExecutorNameAuthAssert},
-	providers.FlowTypeRegistration:   {executor.ExecutorNameProvisioning, executor.ExecutorNameUserTypeResolver},
-	providers.FlowTypeUserOnboarding: {executor.ExecutorNameProvisioning, executor.ExecutorNameUserTypeResolver},
+	providers.FlowTypeAuthentication: {executormeta.ExecutorNameAuthAssert},
+	providers.FlowTypeRegistration: {
+		executormeta.ExecutorNameProvisioning, executormeta.ExecutorNameUserTypeResolver,
+	},
+	providers.FlowTypeUserOnboarding: {
+		executormeta.ExecutorNameProvisioning, executormeta.ExecutorNameUserTypeResolver,
+	},
 }
 
 // validateFlowTypeBasedConstraints checks forbidden and required executor rules for the flow type.
@@ -850,9 +855,9 @@ func (v *flowValidator) validateExecutorSpecificConstraints(
 	nodeIndex map[string]*providers.NodeDefinition, nodes []providers.NodeDefinition,
 ) *tidcommon.ServiceError {
 	switch node.Executor.Name {
-	case executor.ExecutorNameSSOCheck:
+	case executormeta.ExecutorNameSSOCheck:
 		return v.validateSSOCheckExecutor(node, nodeIndex)
-	case executor.ExecutorNameSession:
+	case executormeta.ExecutorNameSession:
 		return v.validateSessionExecutor(node, nodes)
 	}
 	return nil
@@ -1014,7 +1019,7 @@ func (v *flowValidator) validateSSOCheckExecutor(
 		})
 	}
 	if target.Type != string(common.NodeTypeTaskExecution) ||
-		target.Executor == nil || target.Executor.Name != executor.ExecutorNameSession {
+		target.Executor == nil || target.Executor.Name != executormeta.ExecutorNameSession {
 		return tidcommon.CustomServiceError(ErrorInvalidExecutorConfig, tidcommon.I18nMessage{
 			Key: "error.flowmgtservice.checkpoint_ref_not_session_description",
 			DefaultValue: "Node '{{param(nodeID)}}': checkpointRef must reference " +
@@ -1032,7 +1037,7 @@ func (v *flowValidator) validateSessionExecutor(
 ) *tidcommon.ServiceError {
 	for _, n := range nodes {
 		if n.Type == string(common.NodeTypeTaskExecution) &&
-			n.Executor != nil && n.Executor.Name == executor.ExecutorNameSSOCheck {
+			n.Executor != nil && n.Executor.Name == executormeta.ExecutorNameSSOCheck {
 			if ref, ok := n.Properties[common.NodePropertyCheckpointRef].(string); ok && ref == node.ID {
 				return nil
 			}


### PR DESCRIPTION
### Purpose

Flow definition validation asks the executor registry two questions: whether a node names a registered executor (`IsRegistered`), and what that executor's metadata allows (`GetExecutorMeta`). Both answers are static.

The only way to hold a registry, though, was to construct every executor, and that links `internal/flow/executor` together with the data plane's authentication, notification and session packages. The Control Plane paid that cost purely to validate flows it never runs. It also had to build four federated-auth services it never executes, because three executor constructors type-assert their auth service and `panic` on nil:

```go
oauthSvcCast, ok := authService.(authnoauth.OAuthAuthnCoreServiceInterface)
if !ok {
    panic("failed to cast GithubOAuthAuthnService to OAuthAuthnCoreServiceInterface")
}
```

That coupling was documented in place as `TEMPORARY COUPLING` in `cmd/cpserver/servicemanager.go`. This removes it.

### Approach

**One definition of the metadata, not two.** `executormeta` now holds a catalog of every built-in executor's `ExecutorMeta`, keyed by name. The executors read their own metadata from that catalog, so it is the single definition rather than a copy that can fall behind.

**A registry that constructs nothing.** `executormeta.NewRegistry` answers `IsRegistered` and `GetExecutorMeta` from the catalog. It honors the same configured subset as the runtime registry (`flow.executors`), so a flow accepted where it is authored is one the plane that runs it has actually registered, and an unknown name is an error there too.

**A narrower dependency.** `flow/mgt` and `graphbuilder` now depend on `core.ExecutorMetadataProvider` instead of `executor.ExecutorRegistryInterface`. The full registry satisfies that interface structurally, so the Data Plane and the hybrid server are wired exactly as before and behave identically.

**The result, which is the point of the change:**

```
$ go list -deps ./cmd/cpserver | grep -E "internal/authn/(oauth|oidc|google|github)$|internal/flow/executor$"
(nothing)

$ go list -deps ./cmd/dpserver | grep -cE "internal/authn/(oauth|oidc|google|github)$|internal/flow/executor$"
5
```

**Guarding against drift.** Two descriptions of the same thing drift, so `TestCatalogMatchesRegistry` registers the real executors through the real flow factory and compares every one against the catalog. Change an executor's metadata without changing the catalog and it fails, naming the executor. The catalog itself was generated from that same live registry rather than transcribed by hand.

No new validation is introduced, and no validation is removed.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
