### PR TITLE
DO NOT MERGE — probe: covered backend line (expect PASS)

### DIFF
--- a/backend/internal/system/healthcheck/handler/healthcheckhandler.go
+++ b/backend/internal/system/healthcheck/handler/healthcheckhandler.go
@@ -29,7 +29,7 @@ func NewHealthCheckHandler(svc service.HealthCheckServiceInterface) *HealthCheck
 func (hch *HealthCheckHandler) HandleLivenessRequest(w http.ResponseWriter, r *http.Request) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "HealthCheckHandler"))
 	w.WriteHeader(http.StatusOK)
-	logger.Debug(r.Context(), "Health Check Liveness response sent")
+	logger.Debug(r.Context(), "Health Check Liveness response sent to the caller")
 }
 
 // HandleReadinessRequest handles the health check readiness request.


### PR DESCRIPTION
Temporary **draft** probe for `🛡️ Backend Integration Patch Coverage` (added in #5014). **Not for merge — close once observed.**

Changes one log message in `HandleLivenessRequest`, which the integration harness polls on every run. The real coverage profile shows that line inside block `29.94,33.2 1 **1**` — executed.

**Expected:** the check **passes** at ~100%.

This is the only probe testing the pass direction; #5025 tests the fail direction. Log text only, no behaviour change.

Needs the `trigger-pr-builder` label to run.