### PR TITLE
DO NOT MERGE — probe: comments-only backend change (expect PASS, no coverable lines)

### DIFF
--- a/backend/internal/system/healthcheck/handler/healthcheckhandler.go
+++ b/backend/internal/system/healthcheck/handler/healthcheckhandler.go
@@ -25,7 +25,7 @@ func NewHealthCheckHandler(svc service.HealthCheckServiceInterface) *HealthCheck
 	}
 }
 
-// HandleLivenessRequest handles the health check livenss request.
+// HandleLivenessRequest handles the health check liveness request.
 func (hch *HealthCheckHandler) HandleLivenessRequest(w http.ResponseWriter, r *http.Request) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "HealthCheckHandler"))
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Temporary **draft** probe for `🛡️ Backend Integration Patch Coverage` (added in #5014). **Not for merge — close once observed.** Also happens to fix a real typo (`livenss` → `liveness`).

## Why this case matters

This is the reachable half of an unresolved CodeRabbit finding on #5014. The scope filter works at **file** level, so a backend production Go file with a comment-only change is still listed as in scope. The question is what happens next.

The file **does** declare functions, so it is not the declaration-only case that `check-instrumentation.sh` skips.

**Expected:** the check **passes**, reporting `No lines with coverage information in this diff.` `diff-cover` drops non-coverable lines, so the denominator is zero and nothing fails.

If instead it reports 0% and fails, the finding is more serious than my analysis concluded and statement-level scope detection is warranted.

Needs the `trigger-pr-builder` label to run.