### PR TITLE
DO NOT MERGE — probe: integration-test-only change (expect N/A)

### DIFF
--- a/tests/integration/healthcheck/healthcheckapi_test.go
+++ b/tests/integration/healthcheck/healthcheckapi_test.go
@@ -1,6 +1,7 @@
 // Copyright 2025 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
+// Probe comment for the backend integration patch coverage check.
 package healthcheck
 
 import (


### PR DESCRIPTION
Temporary **draft** probe for `🛡️ Backend Integration Patch Coverage` (added in #5014). **Not for merge — close once observed.**

Touches only a comment in an integration test. No backend production Go in the diff.

**Expected:** `N/A — no backend production Go changes`, exit 0, without loading any coverage artifact.

This is the semantically important N/A case: `tests/**` is excluded from the measured scope, so **adding integration tests alone never satisfies the threshold** — the backend code they exercise is what counts.

Needs the `trigger-pr-builder` label to run.