### PR TITLE
DO NOT MERGE — probe: frontend-only change (expect N/A)

### DIFF
--- a/frontend/apps/console/src/App.tsx
+++ b/frontend/apps/console/src/App.tsx
@@ -1,6 +1,7 @@
 // Copyright 2025-2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
+// Probe comment for the backend integration patch coverage check.
 import {PageLoader} from '@thunderid/components';
 import {LayoutBuilderProvider, ThemeBuilderProvider} from '@thunderid/configure-design';
 import {GroupCreateProvider} from '@thunderid/configure-groups';


### PR DESCRIPTION
Temporary **draft** probe for `🛡️ Backend Integration Patch Coverage` (added in #5014). **Not for merge — close once observed.**

Touches only a comment in the console app. No backend production Go in the diff.

**Expected:** `N/A — no backend production Go changes`.

Also confirms frontend coverage cannot influence this check: only the `integration-coverage-*` artifacts are downloaded, so `console-coverage` and `gate-coverage` are never loaded.

Note this takes the **same code path** as #5033 and #5034 — the scope filter returns empty and the script exits before touching an artifact — so it is largely redundant with those.

Needs the `trigger-pr-builder` label to run.