### PR TITLE
DO NOT MERGE — probe: docs-only change (expect N/A)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,4 +47,4 @@ Say you want to add a page explaining how adaptive authentication works in Thund
 
 - **Do not ask it to "just write the adaptive authentication page" and accept whatever it produces without supplying the real facts.** If it cannot verify a claim, that is the system working as intended. Give it the specific detail instead of nudging it to guess.
 - **Do not create a new file by hand and skip the new-page step.** Its duplicate check exists because two contributors can otherwise write two competing pages on the same topic, and its sidebar step exists because a page without a sidebar entry fails CI.
-- **Do not treat every suggestion as a blocker.** Some checks, like step count, step ordering, or sidebar placement, are deliberately not hard gates. They ask whether your structure or placement is intentional. If it is, say so and move on.
+- **Do not treat every suggestion as a blocker (probe).** Some checks, like step count, step ordering, or sidebar placement, are deliberately not hard gates. They ask whether your structure or placement is intentional. If it is, say so and move on.


### PR DESCRIPTION
Temporary **draft** probe for `🛡️ Backend Integration Patch Coverage` (added in #5014). **Not for merge — close once observed.**

Touches only `docs/README.md`. No backend production Go in the diff.

**Expected:** `N/A — no backend production Go changes`.

Secondary thing to confirm: the docs path filter only *adds* the `📚 Build Documentation` job, it does not skip `build` or `test-integration`, so the pipeline should still run in full and this check should still report rather than being skipped.

Same code path as #5033 and #5034, so largely redundant with those apart from the docs-filter question above.

Needs the `trigger-pr-builder` label to run.