### PR TITLE
Implement user type attribute fetching in flows

### DIFF
--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/FieldExtendedProperties.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/FieldExtendedProperties.tsx
@@ -1,15 +1,17 @@
 // Copyright 2025 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import {useGetUserTypeAttributes, type AggregatedUserTypeAttribute} from '@thunderid/configure-user-types';
 import {
   Autocomplete,
   FormHelperText,
   FormLabel,
   Stack,
   TextField,
+  Typography,
   type AutocompleteRenderInputParams,
 } from '@wso2/oxygen-ui';
-import {useMemo, useState, type ReactNode, type SyntheticEvent} from 'react';
+import {useMemo, useState, type HTMLAttributes, type ReactNode, type SyntheticEvent} from 'react';
 import {useTranslation} from 'react-i18next';
 import type {CommonResourcePropertiesPropsInterface} from '@/features/flows/components/resource-property-panel/CommonResourceProperties';
 import useResourceFieldError from '@/features/flows/hooks/useResourceFieldError';
@@ -21,6 +23,17 @@ import {ElementTypes, type Element} from '@/features/flows/models/elements';
 export type FieldExtendedPropertiesPropsInterface = CommonResourcePropertiesPropsInterface;
 
 /**
+ * Read the attribute name off an option, which is a free-solo string when the author typed a value
+ * that no user type declares.
+ *
+ * @param option - The Autocomplete option.
+ * @returns The attribute name.
+ */
+function getAttributeName(option: string | AggregatedUserTypeAttribute): string {
+  return typeof option === 'string' ? option : option.attribute;
+}
+
+/**
  * Extended properties for the field elements.
  *
  * @param props - Props injected to the component.
@@ -29,20 +42,30 @@ export type FieldExtendedPropertiesPropsInterface = CommonResourcePropertiesProp
 function FieldExtendedProperties({resource, onChange}: FieldExtendedPropertiesPropsInterface): ReactNode {
   const {t} = useTranslation();
 
-  const attributes: string[] = useMemo(() => ['email', 'username', 'given_name'], []);
-  const credentialAttributes: string[] = useMemo(() => ['password', 'pin', 'secret'], []);
+  // The user type applicable at runtime is not known while the flow is being authored, so
+  // attributes from every user type are offered as suggestions and custom values stay allowed.
+  const {attributes: allAttributes, isLoading} = useGetUserTypeAttributes();
+
+  const isCredentialField: boolean = resource.type === ElementTypes.PasswordInput;
+
+  const options: AggregatedUserTypeAttribute[] = useMemo(
+    () => allAttributes.filter((attribute) => attribute.credential === isCredentialField),
+    [allAttributes, isCredentialField],
+  );
 
   const resourceRef = (resource as Element & {ref?: string})?.ref;
 
-  // Use local state to track the selected value immediately (avoids revert on blur due to debounced updates)
-  // Initialize with the resourceRef value directly (supports free-solo values not in the predefined list)
-  const [localSelectedValue, setLocalSelectedValue] = useState<string | null>(() => resourceRef ?? null);
+  // The input text is tracked separately from the Autocomplete value. Feeding typed text back in as
+  // the value makes MUI treat the input as a pristine selection and disable option filtering, which
+  // would leave the suggestion list unfiltered while typing.
+  // Local state also keeps the text stable on blur, since updates upstream are debounced.
+  const [inputValue, setInputValue] = useState<string>(() => resourceRef ?? '');
 
   // Sync local state when resource changes (e.g., when switching to a different element)
   const [prevResourceRef, setPrevResourceRef] = useState(resourceRef);
   if (resourceRef !== prevResourceRef) {
     setPrevResourceRef(resourceRef);
-    setLocalSelectedValue(resourceRef ?? null);
+    setInputValue(resourceRef ?? '');
   }
 
   /**
@@ -53,11 +76,27 @@ function FieldExtendedProperties({resource, onChange}: FieldExtendedPropertiesPr
   return (
     <Stack>
       <Autocomplete
-        freeSolo={resource.type !== ElementTypes.PasswordInput}
+        freeSolo
         disablePortal
         key={resource.id}
-        options={(resource.type === ElementTypes.PasswordInput ? credentialAttributes : attributes) ?? []}
-        getOptionLabel={(attribute: string) => attribute}
+        options={options}
+        loading={isLoading}
+        getOptionLabel={getAttributeName}
+        renderOption={(
+          props: HTMLAttributes<HTMLLIElement> & {key?: string},
+          option: string | AggregatedUserTypeAttribute,
+        ) => (
+          <li {...props} key={getAttributeName(option)}>
+            <Stack>
+              <Typography variant="body2">{getAttributeName(option)}</Typography>
+              {typeof option !== 'string' && (
+                <Typography variant="caption" color="text.secondary">
+                  {option.userTypes.join(', ')}
+                </Typography>
+              )}
+            </Stack>
+          </li>
+        )}
         sx={{width: '100%'}}
         renderInput={(params: AutocompleteRenderInputParams) => (
           <>
@@ -70,16 +109,22 @@ function FieldExtendedProperties({resource, onChange}: FieldExtendedPropertiesPr
             />
           </>
         )}
-        value={localSelectedValue}
-        onChange={(_: SyntheticEvent, attribute: string | null) => {
-          setLocalSelectedValue(attribute);
-          onChange('ref', attribute ?? '', resource);
+        value={null}
+        inputValue={inputValue}
+        onChange={(_: SyntheticEvent, attribute: string | AggregatedUserTypeAttribute | null) => {
+          const selected: string = attribute === null ? '' : getAttributeName(attribute);
+          setInputValue(selected);
+          onChange('ref', selected, resource);
         }}
         onInputChange={(_: SyntheticEvent, value: string, reason: string) => {
           // Handle free-form input (when user types a custom value)
           if (reason === 'input') {
-            setLocalSelectedValue(value);
+            setInputValue(value);
             onChange('ref', value, resource, true);
+          } else if (reason === 'clear') {
+            // The Autocomplete value is always null, so clearing does not reach onChange.
+            setInputValue('');
+            onChange('ref', '', resource);
           }
         }}
       />

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/__tests__/FieldExtendedProperties.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/__tests__/FieldExtendedProperties.test.tsx
@@ -15,6 +15,18 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
+interface MockAttribute {
+  attribute: string;
+  credential: boolean;
+  userTypes: string[];
+}
+
+const mockUseGetUserTypeAttributes = vi.fn<() => {attributes: MockAttribute[]; isLoading: boolean}>();
+
+vi.mock('@thunderid/configure-user-types', () => ({
+  useGetUserTypeAttributes: (): {attributes: MockAttribute[]; isLoading: boolean} => mockUseGetUserTypeAttributes(),
+}));
+
 const mockHasResourceFieldNotification = vi.fn().mockReturnValue(false);
 const mockGetResourceFieldNotification = vi.fn().mockReturnValue('');
 
@@ -41,6 +53,17 @@ describe('FieldExtendedProperties', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockHasResourceFieldNotification.mockReturnValue(false);
+    mockGetResourceFieldNotification.mockReturnValue('');
+    mockUseGetUserTypeAttributes.mockReturnValue({
+      attributes: [
+        {attribute: 'department', credential: false, userTypes: ['Employee']},
+        {attribute: 'email', credential: false, userTypes: ['Person', 'Employee']},
+        {attribute: 'password', credential: true, userTypes: ['Person']},
+        {attribute: 'username', credential: false, userTypes: ['Person']},
+      ],
+      isLoading: false,
+    });
   });
 
   describe('Rendering', () => {
@@ -70,7 +93,7 @@ describe('FieldExtendedProperties', () => {
   });
 
   describe('Password Input Handling', () => {
-    it('should render with credential attributes for PasswordInput type', async () => {
+    it('should list only credential attributes for PasswordInput type', async () => {
       const user = userEvent.setup();
       const resource = createMockResource(ElementTypes.PasswordInput);
 
@@ -81,24 +104,59 @@ describe('FieldExtendedProperties', () => {
 
       await user.click(input);
 
-      expect(await screen.findByRole('option', {name: 'password'})).toBeInTheDocument();
-      expect(screen.getByRole('option', {name: 'pin'})).toBeInTheDocument();
-      expect(screen.getByRole('option', {name: 'secret'})).toBeInTheDocument();
+      expect(await screen.findByRole('option', {name: /password/})).toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: /email/})).not.toBeInTheDocument();
+    });
+
+    it('should accept a custom value for PasswordInput type', () => {
+      const resource = createMockResource(ElementTypes.PasswordInput);
+
+      render(<FieldExtendedProperties resource={resource} onChange={mockOnChange} />);
+
+      fireEvent.change(screen.getByRole('combobox'), {target: {value: 'customCredential'}});
+
+      expect(mockOnChange).toHaveBeenCalledWith('ref', 'customCredential', resource, true);
     });
   });
 
   describe('Attribute Selection', () => {
-    it('should have email, username, given_name as options', () => {
+    it('should list non credential attributes aggregated across user types', async () => {
+      const user = userEvent.setup();
       const resource = createMockResource(ElementTypes.TextInput);
 
       render(<FieldExtendedProperties resource={resource} onChange={mockOnChange} />);
 
-      const input = screen.getByPlaceholderText('flows:core.fieldExtendedProperties.selectAttribute');
-      fireEvent.focus(input);
-      fireEvent.click(input);
+      await user.click(screen.getByRole('combobox'));
 
-      // Check for dropdown options (may be in listbox)
-      expect(screen.getByRole('combobox')).toBeInTheDocument();
+      expect(await screen.findByRole('option', {name: /department/})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: /email/})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: /username/})).toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: /password/})).not.toBeInTheDocument();
+    });
+
+    // Regression: feeding typed text back in as the Autocomplete value makes MUI treat the input as
+    // a pristine selection and stop filtering, leaving the whole list showing while typing.
+    it('should filter options by the typed text', () => {
+      const resource = createMockResource(ElementTypes.TextInput);
+
+      render(<FieldExtendedProperties resource={resource} onChange={mockOnChange} />);
+
+      fireEvent.change(screen.getByRole('combobox'), {target: {value: 'dep'}});
+
+      const options = screen.queryAllByRole('option');
+      expect(options).toHaveLength(1);
+      expect(options[0]).toHaveTextContent('department');
+    });
+
+    it('should annotate options with the user types declaring them', async () => {
+      const user = userEvent.setup();
+      const resource = createMockResource(ElementTypes.TextInput);
+
+      render(<FieldExtendedProperties resource={resource} onChange={mockOnChange} />);
+
+      await user.click(screen.getByRole('combobox'));
+
+      expect(await screen.findByRole('option', {name: /email/})).toHaveTextContent('Person, Employee');
     });
 
     it('should display current ref value', () => {
@@ -145,7 +203,7 @@ describe('FieldExtendedProperties', () => {
       rerender(<FieldExtendedProperties resource={resourceWithoutRef} onChange={mockOnChange} />);
 
       input = screen.getByRole('combobox');
-      expect(input).toHaveValue('email');
+      expect(input).toHaveValue('');
     });
   });
 
@@ -160,7 +218,7 @@ describe('FieldExtendedProperties', () => {
       await user.click(input);
 
       // Wait for dropdown to open and select an option
-      const option = await screen.findByRole('option', {name: 'email'});
+      const option = await screen.findByRole('option', {name: /email/});
       await user.click(option);
 
       expect(mockOnChange).toHaveBeenCalledWith('ref', 'email', resource);

--- a/frontend/packages/configure-user-types/src/api/__tests__/useGetUserTypeAttributes.test.ts
+++ b/frontend/packages/configure-user-types/src/api/__tests__/useGetUserTypeAttributes.test.ts
@@ -1,0 +1,264 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {waitFor, renderHook} from '@thunderid/test-utils';
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import type {ApiUserType, UserTypeListResponse} from '../../types/user-types';
+import useGetUserTypeAttributes from '../useGetUserTypeAttributes';
+
+const mockHttpRequest = vi.fn();
+const mockLoggerWarn = vi.fn();
+
+vi.mock('@thunderid/react', () => ({
+  useThunderID: () => ({http: {request: mockHttpRequest}}),
+}));
+
+vi.mock('@thunderid/logger/react', () => ({
+  useLogger: () => ({
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: mockLoggerWarn,
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock('@thunderid/contexts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunderid/contexts')>();
+  return {
+    ...actual,
+    useConfig: vi.fn(),
+  };
+});
+
+const {useConfig} = await import('@thunderid/contexts');
+
+/**
+ * Build a list response for the given user types.
+ *
+ * @param types - The user types to include.
+ * @param totalResults - Total results reported by the server, defaults to the number of types.
+ * @returns The list response.
+ */
+function buildListResponse(types: {id: string; name: string}[], totalResults?: number): UserTypeListResponse {
+  return {
+    totalResults: totalResults ?? types.length,
+    startIndex: 1,
+    count: types.length,
+    types: types.map((type) => ({...type, ouId: 'root-ou', allowSelfRegistration: false})),
+  };
+}
+
+/**
+ * Route the mocked http client: the list endpoint returns the given list, and each user type
+ * endpoint returns its schema.
+ *
+ * @param list - The list response.
+ * @param schemas - Schema by user type id. A missing entry rejects, simulating a failed fetch.
+ */
+function mockRequests(list: UserTypeListResponse, schemas: Record<string, ApiUserType>): void {
+  mockHttpRequest.mockImplementation(({url}: {url: string}) => {
+    const match = /\/user-types\/([^?]+)/.exec(url);
+
+    if (!match) {
+      return Promise.resolve({data: list});
+    }
+
+    const schema = schemas[match[1]];
+    return schema ? Promise.resolve({data: schema}) : Promise.reject(new Error('failed'));
+  });
+}
+
+describe('useGetUserTypeAttributes', () => {
+  beforeEach(() => {
+    mockHttpRequest.mockReset();
+    mockLoggerWarn.mockReset();
+
+    vi.mocked(useConfig).mockReturnValue({
+      getServerUrl: vi.fn().mockReturnValue('https://api.test.com'),
+    } as unknown as ReturnType<typeof useConfig>);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should request user types with the maximum page size', async () => {
+    mockRequests(buildListResponse([{id: '1', name: 'Person'}]), {
+      '1': {id: '1', name: 'Person', ouId: 'root-ou', allowSelfRegistration: false, schema: {email: {type: 'string'}}},
+    });
+
+    renderHook(() => useGetUserTypeAttributes());
+
+    await waitFor(() => {
+      expect(mockHttpRequest).toHaveBeenCalled();
+    });
+
+    const firstCall = mockHttpRequest.mock.calls[0][0] as {url: string};
+    expect(firstCall.url).toContain('limit=100');
+  });
+
+  it('should aggregate and de-duplicate attributes across user types', async () => {
+    mockRequests(
+      buildListResponse([
+        {id: '1', name: 'Person'},
+        {id: '2', name: 'Customers'},
+      ]),
+      {
+        '1': {
+          id: '1',
+          name: 'Person',
+          ouId: 'root-ou',
+          allowSelfRegistration: false,
+          schema: {email: {type: 'string'}, username: {type: 'string'}},
+        },
+        '2': {
+          id: '2',
+          name: 'Customers',
+          ouId: 'root-ou',
+          allowSelfRegistration: false,
+          schema: {email: {type: 'string'}, gender: {type: 'string'}},
+        },
+      },
+    );
+
+    const {result} = renderHook(() => useGetUserTypeAttributes());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.attributes.map((attribute) => attribute.attribute)).toEqual(['email', 'gender', 'username']);
+    expect(result.current.attributes.find((attribute) => attribute.attribute === 'email')?.userTypes).toEqual([
+      'Person',
+      'Customers',
+    ]);
+  });
+
+  it('should keep credential and standard variants of the same attribute separate', async () => {
+    mockRequests(
+      buildListResponse([
+        {id: '1', name: 'Person'},
+        {id: '2', name: 'Customers'},
+      ]),
+      {
+        '1': {
+          id: '1',
+          name: 'Person',
+          ouId: 'root-ou',
+          allowSelfRegistration: false,
+          schema: {secret: {type: 'string', credential: true}},
+        },
+        '2': {
+          id: '2',
+          name: 'Customers',
+          ouId: 'root-ou',
+          allowSelfRegistration: false,
+          schema: {secret: {type: 'string'}},
+        },
+      },
+    );
+
+    const {result} = renderHook(() => useGetUserTypeAttributes());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const secrets = result.current.attributes.filter((attribute) => attribute.attribute === 'secret');
+    expect(secrets).toHaveLength(2);
+    expect(secrets.find((attribute) => attribute.credential)?.userTypes).toEqual(['Person']);
+    expect(secrets.find((attribute) => !attribute.credential)?.userTypes).toEqual(['Customers']);
+  });
+
+  it('should list a user type once when its schema flattens to the same attribute twice', async () => {
+    mockRequests(buildListResponse([{id: '1', name: 'Person'}]), {
+      '1': {
+        id: '1',
+        name: 'Person',
+        ouId: 'root-ou',
+        allowSelfRegistration: false,
+        // A literal dotted key collides with the path flattened out of the nested object.
+        schema: {
+          address: {type: 'object', properties: {city: {type: 'string'}}},
+          'address.city': {type: 'string'},
+        },
+      },
+    });
+
+    const {result} = renderHook(() => useGetUserTypeAttributes());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.attributes).toHaveLength(1);
+    expect(result.current.attributes[0].attribute).toBe('address.city');
+    expect(result.current.attributes[0].userTypes).toEqual(['Person']);
+  });
+
+  it('should report loading until every schema resolves', () => {
+    mockHttpRequest.mockImplementation(({url}: {url: string}) =>
+      /\/user-types\/[^?]+/.test(url)
+        ? new Promise(() => null)
+        : Promise.resolve({data: buildListResponse([{id: '1', name: 'Person'}])}),
+    );
+
+    const {result} = renderHook(() => useGetUserTypeAttributes());
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.attributes).toEqual([]);
+  });
+
+  it('should keep attributes from the user types that resolved when one schema fails', async () => {
+    mockRequests(
+      buildListResponse([
+        {id: '1', name: 'Person'},
+        {id: '2', name: 'Broken'},
+      ]),
+      {
+        '1': {
+          id: '1',
+          name: 'Person',
+          ouId: 'root-ou',
+          allowSelfRegistration: false,
+          schema: {email: {type: 'string'}},
+        },
+      },
+    );
+
+    const {result} = renderHook(() => useGetUserTypeAttributes());
+
+    await waitFor(() => {
+      expect(result.current.attributes).toHaveLength(1);
+    });
+
+    expect(result.current.attributes[0].attribute).toBe('email');
+    expect(result.current.attributes[0].userTypes).toEqual(['Person']);
+  });
+
+  it('should warn when the server reports more user types than are fetched', async () => {
+    mockRequests(buildListResponse([{id: '1', name: 'Person'}], 150), {
+      '1': {id: '1', name: 'Person', ouId: 'root-ou', allowSelfRegistration: false, schema: {email: {type: 'string'}}},
+    });
+
+    renderHook(() => useGetUserTypeAttributes());
+
+    await waitFor(() => {
+      expect(mockLoggerWarn).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({totalResults: 150}));
+    });
+  });
+
+  it('should not warn when every user type is fetched', async () => {
+    mockRequests(buildListResponse([{id: '1', name: 'Person'}]), {
+      '1': {id: '1', name: 'Person', ouId: 'root-ou', allowSelfRegistration: false, schema: {email: {type: 'string'}}},
+    });
+
+    const {result} = renderHook(() => useGetUserTypeAttributes());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/packages/configure-user-types/src/api/useGetUserTypeAttributes.ts
+++ b/frontend/packages/configure-user-types/src/api/useGetUserTypeAttributes.ts
@@ -1,0 +1,132 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {useQueries, type UseQueryResult} from '@tanstack/react-query';
+import {useConfig} from '@thunderid/contexts';
+import {useLogger} from '@thunderid/logger/react';
+import {useThunderID} from '@thunderid/react';
+import useGetUserTypes from './useGetUserTypes';
+import UserTypeQueryKeys from '../constants/userTypeQueryKeys';
+import type {ApiUserType} from '../types/user-types';
+import flattenSchemaAttributes, {type FlattenedAttribute} from '../utils/flattenSchemaAttributes';
+
+/**
+ * Matches the server's maximum page size, so a single list request covers every user type in
+ * all realistic deployments. Paging beyond this would multiply the per schema fan-out below, so
+ * the overflow is reported rather than fetched; suggestions are not an exhaustive list and custom
+ * values remain allowed.
+ */
+const USER_TYPE_FETCH_LIMIT = 100;
+
+/**
+ * User type schemas change rarely, and the flow builder property panel remounts on every
+ * element selection. Without an explicit stale time the console's default of 0 would refetch
+ * the whole fan-out on each click.
+ */
+const ATTRIBUTE_STALE_TIME: number = 5 * 60 * 1000;
+
+/**
+ * An attribute aggregated across every user type that declares it.
+ */
+export interface AggregatedUserTypeAttribute extends FlattenedAttribute {
+  /** Names of the user types declaring this attribute. */
+  userTypes: string[];
+}
+
+/**
+ * Result of {@link useGetUserTypeAttributes}.
+ */
+export interface UseGetUserTypeAttributesResult {
+  attributes: AggregatedUserTypeAttribute[];
+  isLoading: boolean;
+}
+
+/**
+ * Aggregate the schemas of the given user types into a de-duplicated, sorted attribute list.
+ *
+ * @param results - Per user type query results.
+ * @returns The aggregated attributes.
+ */
+function aggregateAttributes(results: UseQueryResult<ApiUserType>[]): AggregatedUserTypeAttribute[] {
+  const aggregated = new Map<string, AggregatedUserTypeAttribute>();
+
+  for (const {data: userType} of results) {
+    if (!userType) {
+      continue;
+    }
+
+    for (const {attribute, credential} of flattenSchemaAttributes(userType.schema)) {
+      // User types can disagree on whether an attribute is a credential, and each variant belongs
+      // to a different field control, so they are kept as separate suggestions.
+      const key = `${credential ? 'credential' : 'standard'}:${attribute}`;
+      const existing = aggregated.get(key);
+
+      if (existing) {
+        if (!existing.userTypes.includes(userType.name)) {
+          existing.userTypes.push(userType.name);
+        }
+      } else {
+        aggregated.set(key, {attribute, credential, userTypes: [userType.name]});
+      }
+    }
+  }
+
+  return Array.from(aggregated.values()).sort((a, b) => a.attribute.localeCompare(b.attribute));
+}
+
+/**
+ * Fetch every user type and aggregate their schemas into a single list of attributes.
+ *
+ * The user type applicable to a given runtime request is not known when an administrator is
+ * authoring a flow, so consumers use this as a suggestion list rather than a closed set of
+ * choices.
+ *
+ * The list endpoint omits schema bodies, so each user type's schema is fetched individually.
+ * Those per-type queries deliberately reuse the key and request shape of `useGetUserType` so the
+ * cache is shared with other consumers rather than duplicated.
+ *
+ * @returns The aggregated attributes and the combined loading state.
+ */
+export default function useGetUserTypeAttributes(): UseGetUserTypeAttributesResult {
+  const {http} = useThunderID();
+  const {getServerUrl} = useConfig();
+  const logger = useLogger('useGetUserTypeAttributes');
+
+  const {data: userTypesData, isLoading: isLoadingList} = useGetUserTypes({limit: USER_TYPE_FETCH_LIMIT});
+
+  const totalUserTypes: number = userTypesData?.totalResults ?? 0;
+  if (totalUserTypes > USER_TYPE_FETCH_LIMIT) {
+    logger.warn('Attribute suggestions cover only the first user types returned by the server', {
+      fetched: USER_TYPE_FETCH_LIMIT,
+      totalResults: totalUserTypes,
+    });
+  }
+
+  const {attributes, isLoadingSchemas} = useQueries({
+    queries: (userTypesData?.types ?? []).map((userType) => ({
+      queryKey: [UserTypeQueryKeys.USER_TYPE, userType.id],
+      queryFn: async (): Promise<ApiUserType> => {
+        const serverUrl: string = getServerUrl();
+
+        const response: {
+          data: ApiUserType;
+        } = await http.request({
+          url: `${serverUrl}/user-types/${userType.id}?include=display`,
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        } as unknown as Parameters<typeof http.request>[0]);
+
+        return response.data;
+      },
+      staleTime: ATTRIBUTE_STALE_TIME,
+    })),
+    combine: (results: UseQueryResult<ApiUserType>[]) => ({
+      attributes: aggregateAttributes(results),
+      isLoadingSchemas: results.some((result) => result.isLoading),
+    }),
+  });
+
+  return {attributes, isLoading: isLoadingList || isLoadingSchemas};
+}

--- a/frontend/packages/configure-user-types/src/index.ts
+++ b/frontend/packages/configure-user-types/src/index.ts
@@ -5,6 +5,8 @@
 export {default as useCreateUserType} from './api/useCreateUserType';
 export {default as useDeleteUserType} from './api/useDeleteUserType';
 export {default as useGetUserType} from './api/useGetUserType';
+export {default as useGetUserTypeAttributes} from './api/useGetUserTypeAttributes';
+export type {AggregatedUserTypeAttribute, UseGetUserTypeAttributesResult} from './api/useGetUserTypeAttributes';
 export {default as useGetUserTypes} from './api/useGetUserTypes';
 export {default as useUpdateUserType} from './api/useUpdateUserType';
 export type {UpdateUserTypeVariables} from './api/useUpdateUserType';
@@ -72,3 +74,5 @@ export {defaultUserTypeRoutePaths, default as useUserTypeRoutes} from './hooks/u
 
 // Utils
 export {default as getBreakingSchemaChanges} from './utils/getBreakingSchemaChanges';
+export {default as flattenSchemaAttributes} from './utils/flattenSchemaAttributes';
+export type {FlattenedAttribute} from './utils/flattenSchemaAttributes';

--- a/frontend/packages/configure-user-types/src/utils/__tests__/flattenSchemaAttributes.test.ts
+++ b/frontend/packages/configure-user-types/src/utils/__tests__/flattenSchemaAttributes.test.ts
@@ -1,0 +1,70 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {describe, expect, it} from 'vitest';
+import type {UserTypeDefinition} from '../../types/user-types';
+import flattenSchemaAttributes from '../flattenSchemaAttributes';
+
+describe('flattenSchemaAttributes', () => {
+  it('returns an empty list for an undefined schema', () => {
+    expect(flattenSchemaAttributes(undefined)).toEqual([]);
+  });
+
+  it('flattens primitive attributes', () => {
+    const schema: UserTypeDefinition = {
+      username: {type: 'string'},
+      age: {type: 'number'},
+      active: {type: 'boolean'},
+    };
+
+    expect(flattenSchemaAttributes(schema)).toEqual([
+      {attribute: 'username', credential: false},
+      {attribute: 'age', credential: false},
+      {attribute: 'active', credential: false},
+    ]);
+  });
+
+  it('flattens nested object attributes using dot notation', () => {
+    const schema: UserTypeDefinition = {
+      address: {
+        type: 'object',
+        properties: {
+          city: {type: 'string'},
+          geo: {type: 'object', properties: {lat: {type: 'number'}}},
+        },
+      },
+    };
+
+    expect(flattenSchemaAttributes(schema).map((attribute) => attribute.attribute)).toEqual([
+      'address.city',
+      'address.geo.lat',
+    ]);
+  });
+
+  it('skips array attributes', () => {
+    const schema: UserTypeDefinition = {
+      username: {type: 'string'},
+      roles: {type: 'array', items: {type: 'string'}},
+    };
+
+    expect(flattenSchemaAttributes(schema).map((attribute) => attribute.attribute)).toEqual(['username']);
+  });
+
+  it('tags credential attributes instead of dropping them', () => {
+    const schema: UserTypeDefinition = {
+      username: {type: 'string'},
+      password: {type: 'string', credential: true},
+    };
+
+    expect(flattenSchemaAttributes(schema)).toEqual([
+      {attribute: 'username', credential: false},
+      {attribute: 'password', credential: true},
+    ]);
+  });
+
+  it('applies the prefix to top level attributes', () => {
+    const schema: UserTypeDefinition = {city: {type: 'string'}};
+
+    expect(flattenSchemaAttributes(schema, 'address.')).toEqual([{attribute: 'address.city', credential: false}]);
+  });
+});

--- a/frontend/packages/configure-user-types/src/utils/flattenSchemaAttributes.ts
+++ b/frontend/packages/configure-user-types/src/utils/flattenSchemaAttributes.ts
@@ -1,0 +1,52 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import type {PropertyDefinition, UserTypeDefinition} from '../types/user-types';
+
+/**
+ * A single assignable attribute flattened out of a user type schema.
+ */
+export interface FlattenedAttribute {
+  /** Attribute name, dot-notated for attributes nested inside an object property. */
+  attribute: string;
+  /** Whether the attribute is a credential (password and similar). */
+  credential: boolean;
+}
+
+/** Credentials only exist on string and number properties; read the flag off the union safely. */
+function isCredential(definition: PropertyDefinition): boolean {
+  return 'credential' in definition && Boolean(definition.credential);
+}
+
+/**
+ * Flatten a user type schema into a list of assignable attribute names, using dot notation for
+ * attributes nested inside object properties. Array properties are skipped because they are not
+ * individually assignable. Credential attributes are tagged rather than dropped, so callers can
+ * either include or exclude them.
+ *
+ * @param schema - The user type schema to flatten.
+ * @param prefix - Dot-notation prefix applied while recursing into nested objects.
+ * @returns The flattened attributes.
+ */
+export default function flattenSchemaAttributes(
+  schema: UserTypeDefinition | undefined,
+  prefix = '',
+): FlattenedAttribute[] {
+  if (!schema) {
+    return [];
+  }
+
+  const attributes: FlattenedAttribute[] = [];
+
+  for (const [key, definition] of Object.entries(schema)) {
+    const fullKey = `${prefix}${key}`;
+
+    if (definition.type === 'object' && definition.properties) {
+      attributes.push(...flattenSchemaAttributes(definition.properties, `${fullKey}.`));
+    } else if (definition.type !== 'array') {
+      attributes.push({attribute: fullKey, credential: isCredential(definition)});
+    }
+  }
+
+  return attributes;
+}


### PR DESCRIPTION
### Purpose

This pull request introduces a new hook for aggregating user type attributes, refactors the field property panel to use it, and expands test coverage to ensure correct behavior. The main goal is to provide a unified, de-duplicated list of user attributes (including credential attributes) for use in the flow builder, improving both user experience and maintainability.

---

### Approach

**Key changes:**

### New user type attribute aggregation

* Added `useGetUserTypeAttributes` hook in `@thunderid/configure-user-types` to fetch and aggregate all user type attributes (including credential attributes) across all user types, with deduplication and user type annotations. Also exports associated types. [[1]](diffhunk://#diff-924d3d58e4b6bdffc3342e4877a55b5c9fe088a5f307cdb505a8336e573866e6R1-R117) [[2]](diffhunk://#diff-b641e6646d94907c56c75593f0ee4dbf897b03c73a2baa65080cffa0407e8e8cR8-R9) [[3]](diffhunk://#diff-b641e6646d94907c56c75593f0ee4dbf897b03c73a2baa65080cffa0407e8e8cR77-R78)

### Field property panel refactor

* Refactored `FieldExtendedProperties` to use the new `useGetUserTypeAttributes` hook, dynamically offering attribute suggestions (including credential attributes for password fields), supporting free-form input, and annotating options with the declaring user types. [[1]](diffhunk://#diff-473f091d181e869a6750deb2af8504a103d37d76cb0703d5be41196b418bd2d0R4-R14) [[2]](diffhunk://#diff-473f091d181e869a6750deb2af8504a103d37d76cb0703d5be41196b418bd2d0R25-R35) [[3]](diffhunk://#diff-473f091d181e869a6750deb2af8504a103d37d76cb0703d5be41196b418bd2d0L32-R68) [[4]](diffhunk://#diff-473f091d181e869a6750deb2af8504a103d37d76cb0703d5be41196b418bd2d0L56-R99) [[5]](diffhunk://#diff-473f091d181e869a6750deb2af8504a103d37d76cb0703d5be41196b418bd2d0L73-R127)

### Test improvements

* Updated and expanded tests for `FieldExtendedProperties` to verify correct filtering, custom value handling, and user type annotations. Added mocks for the new hook. [[1]](diffhunk://#diff-e959193b93e07d3b1bc725c2c187b32ed9f83420e87c4a0d36be9e2e577e9827R18-R29) [[2]](diffhunk://#diff-e959193b93e07d3b1bc725c2c187b32ed9f83420e87c4a0d36be9e2e577e9827R56-R66) [[3]](diffhunk://#diff-e959193b93e07d3b1bc725c2c187b32ed9f83420e87c4a0d36be9e2e577e9827L73-R96) [[4]](diffhunk://#diff-e959193b93e07d3b1bc725c2c187b32ed9f83420e87c4a0d36be9e2e577e9827L84-R159) [[5]](diffhunk://#diff-e959193b93e07d3b1bc725c2c187b32ed9f83420e87c4a0d36be9e2e577e9827L148-R206) [[6]](diffhunk://#diff-e959193b93e07d3b1bc725c2c187b32ed9f83420e87c4a0d36be9e2e577e9827L163-R221)

### Utility and type exports

* Exported `flattenSchemaAttributes` utility and its types from `@thunderid/configure-user-types` for reuse and testing.

### New utility test coverage

* Added comprehensive tests for `flattenSchemaAttributes` to ensure correct flattening of user type schemas, including nested, credential, and array attributes.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4564

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Autocomplete fields now dynamically suggest attributes from configured user types.
  - Suggestions display applicable user types and filter credential fields appropriately.
  - Nested user-type attributes are supported using dot notation.
  - Free-form custom values remain available, including for password fields.

- **Bug Fixes**
  - Improved synchronization when selecting, clearing, or typing autocomplete values.
  - Resource changes now correctly clear undefined references.

- **Tests**
  - Added coverage for filtering, aggregation, credential handling, nested attributes, loading states, and partial data responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->