### PR TITLE
Add forward-port workflow to 1.0.x branch

### DIFF
--- a/.github/workflows/forward-port-pr.yml
+++ b/.github/workflows/forward-port-pr.yml
@@ -1,0 +1,263 @@
+# This workflow forward-ports merged PRs from configured patch branches to main.
+# For each merged PR on an enrolled branch, it fetches the original PR's commits
+# from the GitHub API and cherry-picks them (in order) onto a new branch off main,
+# preserving the original commit history. It then opens a PR. The original PR
+# author and everyone who approved the original PR are added as assignees on the
+# new PR and @mentioned in a comment. If any cherry-pick has conflicts, the branch
+# is still pushed with the conflict markers committed and the PR is opened as a
+# draft for manual resolution.
+
+name: Forward-port Merged PRs
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      # Patch branches whose merged PRs get forward-ported to main.
+      - "1.0.x"
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+env:
+  TARGET_BRANCH: "main"
+  RELEASE_GIT_USER_NAME: "thunderid-automation-bot"
+  RELEASE_GIT_USER_EMAIL: "thunderid-bot@thunderid.dev"
+
+jobs:
+  forward-port:
+    name: 🚚 Forward-port to main
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout Target Branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.THUNDER_AUTOMATION_BOT }}
+          ref: ${{ env.TARGET_BRANCH }}
+
+      - name: 🔧 Configure Git
+        run: |
+          git config --local user.name "${{ env.RELEASE_GIT_USER_NAME }}"
+          git config --local user.email "${{ env.RELEASE_GIT_USER_EMAIL }}"
+
+      - name: 🍒 Cherry-pick Original PR Commits
+        id: cherry_pick
+        env:
+          SOURCE_BRANCH: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.THUNDER_AUTOMATION_BOT }}
+        run: |
+          set -euo pipefail
+
+          FORWARD_BRANCH="forward-port/${SOURCE_BRANCH}/pr-${PR_NUMBER}"
+
+          # Fetch the target branch and the original PR's head ref so every commit
+          # from the PR is reachable locally (even after squash/rebase merges).
+          git fetch origin "${TARGET_BRANCH}"
+          git fetch origin "pull/${PR_NUMBER}/head:refs/remotes/origin/pr-${PR_NUMBER}-head"
+
+          git checkout -B "${FORWARD_BRANCH}" "origin/${TARGET_BRANCH}"
+
+          # Get the ordered list of commit SHAs from the original PR (oldest first).
+          mapfile -t COMMIT_SHAS < <(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/commits" --paginate --jq '.[].sha')
+
+          if [ "${#COMMIT_SHAS[@]}" -eq 0 ]; then
+            echo "❌ No commits found on PR #${PR_NUMBER}. Aborting."
+            exit 1
+          fi
+
+          echo "🍒 Cherry-picking ${#COMMIT_SHAS[@]} commit(s) from PR #${PR_NUMBER}"
+
+          conflict=false
+          set +e
+          for sha in "${COMMIT_SHAS[@]}"; do
+            echo "→ ${sha}"
+            # If the commit is a merge commit (>=2 parents), replay it against
+            # its first (mainline) parent so cherry-pick doesn't reject it.
+            parent_count=$(git rev-list --parents -n 1 "${sha}" | awk '{print NF-1}')
+            cherry_pick_args=(--allow-empty --keep-redundant-commits)
+            if [ "${parent_count}" -ge 2 ]; then
+              cherry_pick_args+=(-m 1)
+            fi
+            git cherry-pick "${cherry_pick_args[@]}" "${sha}"
+            rc=$?
+            if [ "${rc}" -ne 0 ]; then
+              conflict=true
+              echo "❗ Conflict on ${sha}. Committing conflict markers and continuing."
+              git add -A
+              # Complete the cherry-pick with the original commit message. If there
+              # is nothing to commit after staging, skip this commit instead.
+              if git diff --cached --quiet; then
+                git cherry-pick --skip
+              else
+                GIT_EDITOR=true git cherry-pick --continue
+              fi
+            fi
+          done
+          set -e
+
+          git push origin "${FORWARD_BRANCH}"
+
+          {
+            echo "forward_branch=${FORWARD_BRANCH}"
+            echo "source_branch=${SOURCE_BRANCH}"
+            echo "pr_number=${PR_NUMBER}"
+            echo "commit_count=${#COMMIT_SHAS[@]}"
+            echo "conflict=${conflict}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: 👥 Collect Assignees
+        id: collect_assignees
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          AUTOMATION_BOT_LOGIN: ${{ env.RELEASE_GIT_USER_NAME }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = Number(process.env.PR_NUMBER);
+            const botLogin = process.env.AUTOMATION_BOT_LOGIN;
+
+            const author = context.payload.pull_request.user.login;
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner,
+              repo,
+              pull_number: prNumber,
+              per_page: 100
+            });
+
+            const approvers = new Map();
+            for (const review of reviews) {
+              if (review.state === 'APPROVED' && review.user && review.user.login) {
+                approvers.set(review.user.login, true);
+              }
+            }
+
+            const logins = [author, ...approvers.keys()]
+              .filter(Boolean)
+              .filter((login, index, arr) => arr.indexOf(login) === index)
+              .filter(login => !login.endsWith('[bot]'))
+              .filter(login => login !== botLogin);
+
+            core.info(`Assignees: ${logins.join(', ') || '(none)'}`);
+            core.setOutput('logins', JSON.stringify(logins));
+
+      - name: 🔔 Create Forward-port PR
+        id: create_pr
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          FORWARD_BRANCH: ${{ steps.cherry_pick.outputs.forward_branch }}
+          SOURCE_BRANCH: ${{ steps.cherry_pick.outputs.source_branch }}
+          PR_NUMBER: ${{ steps.cherry_pick.outputs.pr_number }}
+          COMMIT_COUNT: ${{ steps.cherry_pick.outputs.commit_count }}
+          CONFLICT: ${{ steps.cherry_pick.outputs.conflict }}
+          ORIGINAL_TITLE: ${{ github.event.pull_request.title }}
+          ORIGINAL_URL: ${{ github.event.pull_request.html_url }}
+          ORIGINAL_BODY: ${{ github.event.pull_request.body }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const base = process.env.TARGET_BRANCH;
+            const forwardBranch = process.env.FORWARD_BRANCH;
+            const sourceBranch = process.env.SOURCE_BRANCH;
+            const prNumber = process.env.PR_NUMBER;
+            const commitCount = process.env.COMMIT_COUNT;
+            const hasConflict = process.env.CONFLICT === 'true';
+            const originalTitle = process.env.ORIGINAL_TITLE;
+            const originalUrl = process.env.ORIGINAL_URL;
+            const originalBody = process.env.ORIGINAL_BODY || '';
+            const title = `[${sourceBranch} → ${base}] ${originalTitle} (#${prNumber})`;
+
+            const bodyLines = [
+              `Automated forward-port of #${prNumber} from \`${sourceBranch}\` to \`${base}\`.`,
+              '',
+              `Original PR: ${originalUrl}`,
+              `Commits cherry-picked: ${commitCount}`,
+              `Source branch: \`${sourceBranch}\``,
+              `Target branch: \`${base}\``
+            ];
+
+            if (originalBody.trim().length > 0) {
+              bodyLines.push('', '---', '', originalBody);
+            }
+
+            const created = await github.rest.pulls.create({
+              owner,
+              repo,
+              title,
+              head: forwardBranch,
+              base,
+              body: bodyLines.join('\n'),
+              draft: hasConflict
+            });
+
+            core.info(`Created forward-port PR: #${created.data.number} ${created.data.html_url}`);
+            core.setOutput('pr_number', created.data.number);
+            core.setOutput('pr_url', created.data.html_url);
+
+      - name: 🏷️ Assign Users and Comment
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          NEW_PR_NUMBER: ${{ steps.create_pr.outputs.pr_number }}
+          ORIGINAL_PR_NUMBER: ${{ steps.cherry_pick.outputs.pr_number }}
+          ASSIGNEES_JSON: ${{ steps.collect_assignees.outputs.logins }}
+          CONFLICT: ${{ steps.cherry_pick.outputs.conflict }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const newPrNumber = Number(process.env.NEW_PR_NUMBER);
+            const originalPrNumber = Number(process.env.ORIGINAL_PR_NUMBER);
+            const assignees = JSON.parse(process.env.ASSIGNEES_JSON || '[]');
+            const hasConflict = process.env.CONFLICT === 'true';
+
+            if (assignees.length === 0) {
+              core.info('No assignees to add.');
+              return;
+            }
+
+            // GitHub caps assignees at 10 per issue; anything beyond is silently
+            // dropped. The full list is still used for @mentions below.
+            const assigneesToAdd = assignees.slice(0, 10);
+            try {
+              const response = await github.rest.issues.addAssignees({
+                owner,
+                repo,
+                issue_number: newPrNumber,
+                assignees: assigneesToAdd
+              });
+              const assigned = (response.data.assignees || []).map(a => a.login);
+              core.info(`Assigned: ${assigned.join(', ') || '(none)'}`);
+            } catch (err) {
+              core.warning(`Failed to add assignees: ${err.message}`);
+            }
+
+            const mentions = assignees.map(login => `@${login}`).join(' ');
+            const bodyLines = [
+              `👋 ${mentions} please review this forward-port of #${originalPrNumber} to \`${process.env.TARGET_BRANCH}\`.`
+            ];
+
+            if (hasConflict) {
+              bodyLines.push(
+                '',
+                '> **⚠️ Merge conflicts detected during cherry-pick.**',
+                '> The branch was pushed with unresolved conflict markers committed.',
+                '> Please resolve the conflicts on this branch and mark the PR ready for review before merging.'
+              );
+            }
+
+            const body = bodyLines.join('\n');
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: newPrNumber,
+              body
+            });


### PR DESCRIPTION
### Purpose
The `forward-port-pr.yml` workflow was added to `main` only (via #5004), but it triggers on `pull_request: [closed]` events targeting `1.0.x`.

For `pull_request`-triggered workflows, GitHub Actions loads the workflow definition from the PR's **base branch**, the branch being merged into. Since the file was absent from `1.0.x`, merges into `1.0.x` never scheduled a run (e.g. #5023 merged with no forward-port PR created, and the Actions page shows zero runs for this workflow).

This PR ports the workflow onto `1.0.x` so future merged PRs on the patch branch are forward-ported to `main`.

### Approach
Cherry-picked the original workflow commit from #5004 (`62a1f9d79`) onto `1.0.x` unchanged. No behavioral changes to the workflow itself; it simply needs to live on the base branch where the trigger fires.

### Related Issues
- N/A

### Related PRs
- #5004 (added the workflow to `main`)

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
