### PR TITLE
Add support to fail flow on consent denial

### DIFF
--- a/backend/internal/authn/consent/service.go
+++ b/backend/internal/authn/consent/service.go
@@ -355,16 +355,21 @@ func (s *consentEnforcerService) verifyAndDecodeConsentSession(
 	return &sessionData, nil
 }
 
-// fillMissingDecisions adds denied decision entries for any prompted purposes that are absent
-// from the user's decisions. This treats missing purposes as non-consented rather than rejecting the request.
+// fillMissingDecisions treats an incomplete submission as non-consented rather than rejecting the
+// request. A purpose entirely absent from the user's decisions is added as denied with every prompted
+// element denied. A purpose that is present but denied at the root or at its own level has any
+// omitted prompted elements added as denied too, so a minimal deny payload (e.g. root approved=false
+// with no elements listed) still persists the individual denials and lets the essential-denial check
+// see them.
 func fillMissingDecisions(session *consentSessionData, decisions *providers.ConsentDecisions) {
-	decisionMap := make(map[string]bool, len(decisions.Purposes))
-	for _, pd := range decisions.Purposes {
-		decisionMap[pd.PurposeName] = true
+	decisionIdx := make(map[string]int, len(decisions.Purposes))
+	for i, pd := range decisions.Purposes {
+		decisionIdx[pd.PurposeName] = i
 	}
 
 	for _, sp := range session.Purposes {
-		if !decisionMap[sp.PurposeName] {
+		idx, present := decisionIdx[sp.PurposeName]
+		if !present {
 			// Build element decisions marking all elements as denied
 			elements := make([]providers.ElementDecision, 0, len(sp.Essential)+len(sp.Optional))
 			for _, elem := range sp.Essential {
@@ -378,6 +383,33 @@ func fillMissingDecisions(session *consentSessionData, decisions *providers.Cons
 				Approved:    false,
 				Elements:    elements,
 			})
+			continue
+		}
+
+		// Purpose present and approved at both levels: leave the client's element list untouched.
+		// Approval is not propagated down (see applyDecisionHierarchy), so an omitted element under
+		// an approved parent stays omitted and is treated as not-consented on subsequent reads.
+		if decisions.Approved && decisions.Purposes[idx].Approved {
+			continue
+		}
+
+		// Purpose present but denied at the root or at its own level: fill in any prompted elements
+		// the client omitted so the deny is recorded explicitly against each element.
+		existing := make(map[string]bool, len(decisions.Purposes[idx].Elements))
+		for _, ed := range decisions.Purposes[idx].Elements {
+			existing[ed.Name] = true
+		}
+		for _, elem := range sp.Essential {
+			if !existing[elem] {
+				decisions.Purposes[idx].Elements = append(decisions.Purposes[idx].Elements,
+					providers.ElementDecision{Name: elem, Approved: false})
+			}
+		}
+		for _, elem := range sp.Optional {
+			if !existing[elem] {
+				decisions.Purposes[idx].Elements = append(decisions.Purposes[idx].Elements,
+					providers.ElementDecision{Name: elem, Approved: false})
+			}
 		}
 	}
 }

--- a/backend/internal/authn/consent/service_test.go
+++ b/backend/internal/authn/consent/service_test.go
@@ -1570,6 +1570,86 @@ func (s *ConsentEnforcerServiceTestSuite) TestFillMissingDecisions_MissingPurpos
 	s.False(added.Elements[1].Approved)
 }
 
+func (s *ConsentEnforcerServiceTestSuite) TestFillMissingDecisions_RootDeniedFillsMissingElements() {
+	session := &consentSessionData{
+		Purposes: []consentSessionPurpose{
+			{PurposeName: "p1", Essential: []string{"email"}, Optional: []string{"phone"}},
+		},
+	}
+	// Client sent a minimal deny payload: root approved=false and the purpose is present but its
+	// element list is empty. The backend fills in every prompted element as denied.
+	decisions := &providers.ConsentDecisions{
+		Approved: false,
+		Purposes: []providers.PurposeDecision{
+			{PurposeName: "p1", Approved: false, Elements: []providers.ElementDecision{}},
+		},
+	}
+	fillMissingDecisions(session, decisions)
+
+	s.Len(decisions.Purposes, 1)
+	filled := decisions.Purposes[0]
+	s.Len(filled.Elements, 2)
+	s.Equal("email", filled.Elements[0].Name)
+	s.False(filled.Elements[0].Approved)
+	s.Equal("phone", filled.Elements[1].Name)
+	s.False(filled.Elements[1].Approved)
+}
+
+func (s *ConsentEnforcerServiceTestSuite) TestFillMissingDecisions_PurposeDeniedFillsMissingElements() {
+	session := &consentSessionData{
+		Purposes: []consentSessionPurpose{
+			{PurposeName: "p1", Optional: []string{"address"}},
+			{PurposeName: "p2", Essential: []string{"phone"}, Optional: []string{"birthday"}},
+		},
+	}
+	// Root is approved but p2 is denied and its elements were omitted. Missing elements under the
+	// denied purpose must be filled in as denied.
+	decisions := &providers.ConsentDecisions{
+		Approved: true,
+		Purposes: []providers.PurposeDecision{
+			{PurposeName: "p1", Approved: true, Elements: []providers.ElementDecision{
+				{Name: "address", Approved: true}}},
+			{PurposeName: "p2", Approved: false},
+		},
+	}
+	fillMissingDecisions(session, decisions)
+
+	s.Len(decisions.Purposes, 2)
+	// p1 is unchanged: parent approved so omitted elements stay omitted
+	s.Len(decisions.Purposes[0].Elements, 1)
+	s.Equal("address", decisions.Purposes[0].Elements[0].Name)
+	s.True(decisions.Purposes[0].Elements[0].Approved)
+	// p2 gets both prompted elements filled in as denied
+	deniedPurpose := decisions.Purposes[1]
+	s.Len(deniedPurpose.Elements, 2)
+	s.Equal("phone", deniedPurpose.Elements[0].Name)
+	s.False(deniedPurpose.Elements[0].Approved)
+	s.Equal("birthday", deniedPurpose.Elements[1].Name)
+	s.False(deniedPurpose.Elements[1].Approved)
+}
+
+func (s *ConsentEnforcerServiceTestSuite) TestFillMissingDecisions_ApprovedPurposeLeftUntouched() {
+	session := &consentSessionData{
+		Purposes: []consentSessionPurpose{
+			{PurposeName: "p1", Essential: []string{"email"}, Optional: []string{"phone"}},
+		},
+	}
+	// Approval is not propagated down, so an omitted optional element under an approved parent
+	// stays omitted (treated as not-consented on subsequent reads).
+	decisions := &providers.ConsentDecisions{
+		Approved: true,
+		Purposes: []providers.PurposeDecision{
+			{PurposeName: "p1", Approved: true, Elements: []providers.ElementDecision{
+				{Name: "email", Approved: true}}},
+		},
+	}
+	fillMissingDecisions(session, decisions)
+
+	s.Len(decisions.Purposes, 1)
+	s.Len(decisions.Purposes[0].Elements, 1)
+	s.Equal("email", decisions.Purposes[0].Elements[0].Name)
+}
+
 // buildEssentialElementSet / hasEssentialDenials tests
 
 func (s *ConsentEnforcerServiceTestSuite) TestBuildEssentialElementSet() {

--- a/backend/internal/flow/executor/consent_executor.go
+++ b/backend/internal/flow/executor/consent_executor.go
@@ -63,6 +63,7 @@ func newConsentExecutor(
 		defaultInputs, prerequisites, &providers.ExecutorMeta{
 			SupportedProperties: []providers.ExecutorSupportedProperties{
 				{Property: "timeout"},
+				{Property: propertyKeyConsentFailOnDeny},
 			},
 		})
 
@@ -225,10 +226,19 @@ func (e *consentExecutor) handleConsentDecisions(ctx *providers.NodeContext, exe
 		return execResp, nil
 	}
 
+	failOnDeny, _ := ctx.NodeProperties[propertyKeyConsentFailOnDeny].(bool)
+
 	// A timed out prompt is not a user decision, so nothing is recorded and nothing is consented.
 	// The expiry check below is skipped because such a submission is expected to arrive late.
 	if decisions.Reason == providers.ConsentDecisionReasonTimeout {
-		logger.Debug(ctx.Context, "Consent prompt timed out; completing without recording consent")
+		if failOnDeny {
+			logger.Debug(ctx.Context, "Consent prompt timed out and failOnDeny is enabled. Failing the flow")
+			execResp.Status = providers.ExecFailure
+			execResp.Error = &ErrConsentPromptTimedOut
+			return execResp, nil
+		}
+
+		logger.Debug(ctx.Context, "Consent prompt timed out. Completing without recording consent")
 		execResp.RuntimeData[common.RuntimeKeyConsentedAttributes] = ""
 		execResp.RuntimeData[common.RuntimeKeyConsentedPermissions] = ""
 		execResp.Status = providers.ExecComplete
@@ -279,6 +289,16 @@ func (e *consentExecutor) handleConsentDecisions(ctx *providers.NodeContext, exe
 
 		logger.Error(ctx.Context, "Failed to record consent", log.Any("error", svcErr))
 		return nil, errors.New("failed to record consent")
+	}
+
+	// Fail the flow when the node opts into strict denial handling and the user did not approve
+	// the prompt. This is verified with the IsApproved flag on the consent decisions struct.
+	if failOnDeny && !decisions.Approved {
+		logger.Debug(ctx.Context, "User denied consent and failOnDeny is enabled",
+			log.String("consentID", consentRecord.ID))
+		execResp.Status = providers.ExecFailure
+		execResp.Error = &ErrConsentDenied
+		return execResp, nil
 	}
 
 	// Store the consent ID in RuntimeData for downstream usage

--- a/backend/internal/flow/executor/consent_executor_test.go
+++ b/backend/internal/flow/executor/consent_executor_test.go
@@ -799,6 +799,207 @@ func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_UserDeniedReason_Is
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
+func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_FailOnDeny_UserDenied() {
+	decisions := providers.ConsentDecisions{
+		Approved: false,
+		Reason:   providers.ConsentDecisionReasonUserDenied,
+		Purposes: []providers.PurposeDecision{
+			{PurposeName: "attributes:test-app", Approved: false},
+		},
+	}
+	decisionsJSON, _ := json.Marshal(decisions)
+
+	ctx := buildConsentNodeContext()
+	ctx.UserInputs[userInputConsentDecisions] = string(decisionsJSON)
+	ctx.NodeProperties["failOnDeny"] = true
+
+	futureExpiry := strconv.FormatInt(time.Now().Add(5*time.Minute).UnixMilli(), 10)
+	ctx.RuntimeData[common.RuntimeKeyStepTimeout] = futureExpiry
+	suite.setupDefaultAuthnProviderMocks()
+
+	suite.executor.Executor.(*coremock.ExecutorInterfaceMock).
+		On("ValidatePrerequisites", ctx, mock.AnythingOfType("*providers.ExecutorResponse"),
+			mock.Anything).Return(true)
+	suite.executor.Executor.(*coremock.ExecutorInterfaceMock).
+		On("HasRequiredInputs", ctx, mock.AnythingOfType("*providers.ExecutorResponse")).Return(true)
+
+	consentResult := &providers.Consent{
+		ID:       "consent-fod-1",
+		Purposes: []providers.ConsentPurposeItem{},
+	}
+	suite.mockConsentEnforcer.On("RecordConsent", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(consentResult, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), resp)
+	assert.Equal(suite.T(), providers.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), ErrConsentDenied.Code, resp.Error.Code)
+
+	// The failure branch must not populate downstream runtime data
+	assert.Empty(suite.T(), resp.RuntimeData[common.RuntimeKeyConsentID])
+	_, hasAttrs := resp.RuntimeData[common.RuntimeKeyConsentedAttributes]
+	assert.False(suite.T(), hasAttrs)
+	_, hasPerms := resp.RuntimeData[common.RuntimeKeyConsentedPermissions]
+	assert.False(suite.T(), hasPerms)
+
+	// The consent record is still persisted before failing the flow
+	suite.mockConsentEnforcer.AssertCalled(suite.T(), "RecordConsent", mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_FailOnDeny_UserApprovedWithOptionalToggledOff() {
+	decisions := providers.ConsentDecisions{
+		Approved: true,
+		Purposes: []providers.PurposeDecision{
+			{
+				PurposeName: "attributes:test-app",
+				Approved:    true,
+				Elements: []providers.ElementDecision{
+					{Name: "phone", Approved: false}, // Optional element toggled off, but user clicked Allow
+				},
+			},
+		},
+	}
+	decisionsJSON, _ := json.Marshal(decisions)
+
+	ctx := buildConsentNodeContext()
+	ctx.UserInputs[userInputConsentDecisions] = string(decisionsJSON)
+	ctx.NodeProperties["failOnDeny"] = true
+	suite.setupDefaultAuthnProviderMocks()
+
+	suite.executor.Executor.(*coremock.ExecutorInterfaceMock).
+		On("ValidatePrerequisites", ctx, mock.AnythingOfType("*providers.ExecutorResponse"),
+			mock.Anything).Return(true)
+	suite.executor.Executor.(*coremock.ExecutorInterfaceMock).
+		On("HasRequiredInputs", ctx, mock.AnythingOfType("*providers.ExecutorResponse")).Return(true)
+
+	consentResult := &providers.Consent{
+		ID:       "consent-fod-2",
+		Purposes: []providers.ConsentPurposeItem{},
+	}
+	suite.mockConsentEnforcer.On("RecordConsent", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(consentResult, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecComplete, resp.Status)
+	assert.Equal(suite.T(), "consent-fod-2", resp.RuntimeData[common.RuntimeKeyConsentID])
+}
+
+func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_FailOnDeny_Disabled_UserDeniedSucceeds() {
+	decisions := providers.ConsentDecisions{
+		Approved: false,
+		Reason:   providers.ConsentDecisionReasonUserDenied,
+		Purposes: []providers.PurposeDecision{
+			{PurposeName: "attributes:test-app", Approved: false},
+		},
+	}
+	decisionsJSON, _ := json.Marshal(decisions)
+
+	ctx := buildConsentNodeContext()
+	ctx.UserInputs[userInputConsentDecisions] = string(decisionsJSON)
+	// failOnDeny not set, mirroring the current default behavior
+	suite.setupDefaultAuthnProviderMocks()
+
+	suite.executor.Executor.(*coremock.ExecutorInterfaceMock).
+		On("ValidatePrerequisites", ctx, mock.AnythingOfType("*providers.ExecutorResponse"),
+			mock.Anything).Return(true)
+	suite.executor.Executor.(*coremock.ExecutorInterfaceMock).
+		On("HasRequiredInputs", ctx, mock.AnythingOfType("*providers.ExecutorResponse")).Return(true)
+
+	consentResult := &providers.Consent{
+		ID:       "consent-fod-3",
+		Purposes: []providers.ConsentPurposeItem{},
+	}
+	suite.mockConsentEnforcer.On("RecordConsent", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(consentResult, nil)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecComplete, resp.Status)
+	assert.Equal(suite.T(), "consent-fod-3", resp.RuntimeData[common.RuntimeKeyConsentID])
+}
+
+func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_FailOnDeny_EssentialDeniedStillFails() {
+	decisions := providers.ConsentDecisions{
+		Approved: true,
+		Purposes: []providers.PurposeDecision{
+			{
+				PurposeName: "attributes:test-app",
+				Approved:    true,
+				Elements: []providers.ElementDecision{
+					{Name: "email", Approved: false},
+				},
+			},
+		},
+	}
+	decisionsJSON, _ := json.Marshal(decisions)
+
+	ctx := buildConsentNodeContext()
+	ctx.UserInputs[userInputConsentDecisions] = string(decisionsJSON)
+	ctx.NodeProperties["failOnDeny"] = true
+	suite.setupDefaultAuthnProviderMocks()
+
+	suite.executor.Executor.(*coremock.ExecutorInterfaceMock).
+		On("ValidatePrerequisites", ctx, mock.AnythingOfType("*providers.ExecutorResponse"),
+			mock.Anything).Return(true)
+	suite.executor.Executor.(*coremock.ExecutorInterfaceMock).
+		On("HasRequiredInputs", ctx, mock.AnythingOfType("*providers.ExecutorResponse")).Return(true)
+
+	// The essential-denied branch runs before the failOnDeny check
+	suite.mockConsentEnforcer.On("RecordConsent", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return((*providers.Consent)(nil), &consentauthn.ErrorEssentialConsentDenied)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), ErrConsentDenied.Code, resp.Error.Code)
+}
+
+func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_FailOnDeny_TimeoutReasonFailsFlow() {
+	decisions := providers.ConsentDecisions{
+		Approved: false,
+		Reason:   providers.ConsentDecisionReasonTimeout,
+		Purposes: []providers.PurposeDecision{
+			{PurposeName: "attributes:test-app", Approved: false},
+		},
+	}
+	decisionsJSON, _ := json.Marshal(decisions)
+
+	ctx := buildConsentNodeContext()
+	ctx.UserInputs[userInputConsentDecisions] = string(decisionsJSON)
+	ctx.NodeProperties["failOnDeny"] = true
+
+	pastExpiry := strconv.FormatInt(time.Now().Add(-1*time.Minute).UnixMilli(), 10)
+	ctx.RuntimeData[common.RuntimeKeyStepTimeout] = pastExpiry
+	suite.setupDefaultAuthnProviderMocks()
+
+	suite.executor.Executor.(*coremock.ExecutorInterfaceMock).
+		On("ValidatePrerequisites", ctx, mock.AnythingOfType("*providers.ExecutorResponse"),
+			mock.Anything).Return(true)
+	suite.executor.Executor.(*coremock.ExecutorInterfaceMock).
+		On("HasRequiredInputs", ctx, mock.AnythingOfType("*providers.ExecutorResponse")).Return(true)
+
+	resp, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecFailure, resp.Status)
+	assert.Equal(suite.T(), ErrConsentPromptTimedOut.Code, resp.Error.Code)
+
+	// A timed-out prompt is not a user decision, so nothing must be recorded even when failing
+	suite.mockConsentEnforcer.AssertNotCalled(suite.T(), "RecordConsent", mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
 func (suite *ConsentExecutorTestSuite) TestExecute_HasInputs_ConsentTimeout_NotExpired() {
 	decisions := providers.ConsentDecisions{
 		Approved: true,

--- a/backend/internal/flow/executor/constants.go
+++ b/backend/internal/flow/executor/constants.go
@@ -112,6 +112,11 @@ const (
 	// confirm the logout with the End-User (via the node's onIncomplete prompt) whenever the RP-initiated
 	// logout was not accompanied by a valid id_token_hint (RuntimeKeyLogoutPromptRequired).
 	propertyKeyPromptOnSignOut = "promptOnSignOut"
+	// propertyKeyConsentFailOnDeny, when set to boolean true on a consent node, makes the executor
+	// fail the flow if the user did not approve the consent prompt, either by pressing
+	// the Deny button or by letting the prompt time out. This applies even when every prompted
+	// element is optional.
+	propertyKeyConsentFailOnDeny = "failOnDeny"
 )
 
 // nonSearchableInputs contains the list of user inputs/ attributes that are non-searchable.

--- a/docs/content/guides/consent.mdx
+++ b/docs/content/guides/consent.mdx
@@ -64,6 +64,20 @@ To set a timeout for user input in the consent flow:
 4. Expand the **Components** section, and drag and drop the **Timer** component into the **Consent View** step.
 5. Save the flow configuration.
 
+### Fail the flow when the user denies consent
+
+By default, the login flow still completes when the user clicks **Deny** on the consent prompt, as long as every requested attribute is optional. Only a denial of an essential attribute terminates the login on the default setting.
+
+Enable **Fail flow when user denies consent** on the **User Consent** node when the flow must fail instead.
+
+When enabled, the flow also fails if the consent prompt times out without a response.
+
+To enable this setting:
+
+1. In the flow builder, select the **User Consent** node.
+2. In the node configuration panel, enable **Fail flow when user denies consent**.
+3. Save the flow configuration.
+
 ### Configure validity period for granted consent
 
 By default, once a user grants consent, it remains valid indefinitely until the user revokes it. However, you can configure a validity period for granted consent to require users to re-consent after a certain duration.

--- a/docs/versioned_docs/version-v1.0.x/guides/consent.mdx
+++ b/docs/versioned_docs/version-v1.0.x/guides/consent.mdx
@@ -62,6 +62,24 @@ To set a timeout for user input in the consent flow:
 4. Expand the **Components** section, and drag and drop the **Timer** component into the **Consent View** step.
 5. Save the flow configuration.
 
+### Fail the flow when the user denies consent
+
+:::note Available from 1.0.1
+This setting is available from the 1.0.1 patch release. If you are using an earlier version, please upgrade to 1.0.1 or later to access this feature.
+:::
+
+By default, the login flow still completes when the user clicks **Deny** on the consent prompt, as long as every requested attribute is optional. Only a denial of an essential attribute terminates the login on the default setting.
+
+Enable **Fail flow when user denies consent** on the **User Consent** node when the flow must fail instead.
+
+When enabled, the flow also fails if the consent prompt times out without a response.
+
+To enable this setting:
+
+1. In the flow builder, select the **User Consent** node.
+2. In the node configuration panel, enable **Fail flow when user denies consent**.
+3. Save the flow configuration.
+
 ### Configure validity period for granted consent
 
 By default, once a user grants consent, it remains valid indefinitely until the user revokes it. However, you can configure a validity period for granted consent to require users to re-consent after a certain duration.

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/__tests__/ExecutionExtendedProperties.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/__tests__/ExecutionExtendedProperties.test.tsx
@@ -48,6 +48,9 @@ vi.mock('react-i18next', () => ({
         'flows:core.executions.consent.timeout.placeholder': '0',
         'flows:core.executions.consent.timeout.hint':
           'Time in seconds before the consent request expires. Use 0 for no timeout.',
+        'flows:core.executions.consent.failOnDeny.label': 'Fail flow when user denies consent',
+        'flows:core.executions.consent.failOnDeny.hint':
+          'When enabled, the flow fails if the user denies the consent prompt or lets it time out, even if all requested attributes and permissions are optional.',
         'flows:core.executions.federation.connection.description':
           'Select a connection from the following list to link it with the login flow.',
         'flows:core.executions.federation.connection.label': 'Connection',
@@ -726,6 +729,38 @@ describe('ExecutionExtendedProperties', () => {
       fireEvent.keyDown(timeoutInput, {key: 'Enter'});
 
       expect(mockOnChange).toHaveBeenLastCalledWith('data.properties.timeout', '15', consentResource);
+    });
+
+    it('should render the failOnDeny checkbox unchecked by default', () => {
+      render(<ExecutionExtendedProperties resource={consentResource} onChange={mockOnChange} />);
+
+      const failOnDenyCheckbox = screen.getByLabelText('Fail flow when user denies consent');
+      expect(failOnDenyCheckbox).toBeInTheDocument();
+      expect(failOnDenyCheckbox).not.toBeChecked();
+    });
+
+    it('should commit failOnDeny=true when the checkbox is checked', () => {
+      render(<ExecutionExtendedProperties resource={consentResource} onChange={mockOnChange} />);
+
+      const failOnDenyCheckbox = screen.getByLabelText('Fail flow when user denies consent');
+      fireEvent.click(failOnDenyCheckbox);
+
+      expect(mockOnChange).toHaveBeenLastCalledWith('data.properties.failOnDeny', true, consentResource);
+    });
+
+    it('should render failOnDeny checked when the property is set', () => {
+      const consentResourceWithFailOnDeny = {
+        ...consentResource,
+        data: {
+          ...(consentResource as unknown as {data: object}).data,
+          properties: {failOnDeny: true},
+        },
+      } as unknown as Resource;
+
+      render(<ExecutionExtendedProperties resource={consentResourceWithFailOnDeny} onChange={mockOnChange} />);
+
+      const failOnDenyCheckbox = screen.getByLabelText('Fail flow when user denies consent');
+      expect(failOnDenyCheckbox).toBeChecked();
     });
   });
 

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/ConsentProperties.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/ConsentProperties.tsx
@@ -1,21 +1,37 @@
 // Copyright 2025 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import {FormHelperText, FormLabel, Stack, Typography} from '@wso2/oxygen-ui';
-import {useMemo, type ReactNode} from 'react';
+import {Checkbox, FormControlLabel, FormHelperText, FormLabel, Stack, Typography} from '@wso2/oxygen-ui';
+import {useCallback, useMemo, type ReactNode} from 'react';
 import {useTranslation} from 'react-i18next';
 import DraftTextField from './DraftTextField';
 import type {CommonResourcePropertiesPropsInterface} from './types';
 import {clampToInteger} from './utils';
 import type {StepData} from '@/features/flows/models/steps';
 
+interface ConsentPropertyValues {
+  timeout?: string;
+  failOnDeny?: boolean;
+}
+
 function ConsentProperties({resource, onChange}: CommonResourcePropertiesPropsInterface): ReactNode {
   const {t} = useTranslation();
 
-  const currentTimeout = useMemo(() => {
+  const properties = useMemo<ConsentPropertyValues>(() => {
     const stepData = resource?.data as StepData | undefined;
-    return (stepData?.properties as {timeout?: string})?.timeout ?? '0';
+    return (stepData?.properties as ConsentPropertyValues | undefined) ?? {};
   }, [resource]);
+
+  const currentTimeout = properties.timeout ?? '0';
+
+  const failOnDenyChecked = !!properties.failOnDeny;
+
+  const handleFailOnDenyChange = useCallback(
+    (checked: boolean): void => {
+      onChange('data.properties.failOnDeny', checked, resource);
+    },
+    [resource, onChange],
+  );
 
   return (
     <Stack gap={2}>
@@ -38,6 +54,20 @@ function ConsentProperties({resource, onChange}: CommonResourcePropertiesPropsIn
           inputProps={{min: 0}}
         />
         <FormHelperText>{t('flows:core.executions.consent.timeout.hint')}</FormHelperText>
+      </div>
+
+      <div>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={failOnDenyChecked}
+              onChange={(e) => handleFailOnDenyChange(e.target.checked)}
+              size="small"
+            />
+          }
+          label={t('flows:core.executions.consent.failOnDeny.label')}
+        />
+        <FormHelperText>{t('flows:core.executions.consent.failOnDeny.hint')}</FormHelperText>
       </div>
     </Stack>
   );

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -3591,6 +3591,9 @@ const translations = {
     'core.executions.consent.timeout.label': 'Consent Timeout (seconds)',
     'core.executions.consent.timeout.placeholder': '0',
     'core.executions.consent.timeout.hint': 'Time in seconds before the consent request expires. Use 0 for no timeout.',
+    'core.executions.consent.failOnDeny.label': 'Fail flow when user denies consent',
+    'core.executions.consent.failOnDeny.hint':
+      'When enabled, the flow fails if the user denies the consent prompt or lets it time out, even if all requested attributes and permissions are optional.',
 
     // Identifying executor modes
     'core.executions.identifying.mode.identify': 'Identify',


### PR DESCRIPTION
### Purpose
This pull request introduces a new "fail on deny" capability for consent nodes, allowing flows to be configured to fail if a user denies a consent prompt—even if all requested attributes and permissions are optional. The change includes backend logic, frontend UI updates, internationalization, and comprehensive tests.

### Approach
**Backend: Consent Denial Handling**
- Added the `failOnDeny` property (`propertyKeyConsentFailOnDeny`) to consent executor configuration, enabling strict flow failure when users deny consent or when the consent prompt times out.

**Frontend: UI and Internationalization**
- Updated the consent properties panel (`ConsentProperties.tsx`) to include a checkbox for "Fail flow when user denies consent," with state management and change handling.
- Added English translations and test mocks for the new property label and hint.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4343
- https://github.com/thunder-id/thunderid/issues/4345

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Fail on denial** option for consent steps.
  - When enabled, explicit consent denials and timeouts fail the flow.
  - Optional consent items can still be declined without failing the flow.
  - Added a checkbox and explanatory hint in the consent step settings.

- **Bug Fixes**
  - Preserved existing behavior when the option is disabled.
  - Essential-item denials continue to fail as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->