### PR TITLE
Distinguish agent tokens from application tokens with a sub_type claim

### DIFF
--- a/api/oauth2.yaml
+++ b/api/oauth2.yaml
@@ -880,6 +880,13 @@ components:
           format: int64
         sub:
           type: string
+        sub_type:
+          type: string
+          enum: [application, agent]
+          description: |
+            Identity class of the token subject. Present on tokens issued through the
+            `client_credentials` grant, where the OAuth client itself is the subject, so a resource
+            server can apply policy that differs by class. Absent for user-subject tokens.
         aud:
           description: Audience — may be a string or an array of strings.
           oneOf:

--- a/backend/internal/agent/service.go
+++ b/backend/internal/agent/service.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
@@ -904,6 +905,7 @@ func (s *agentService) createInboundForAgent(ctx context.Context, agentID string
 		agent.LoginConsent, agent.AllowedUserTypes, agent.SubjectAttribute)
 	setLogoProperty(&client, agent.LogoURL)
 
+	seedClientSubTypeAttribute(agent.InboundAuthConfig)
 	oauthProfile := buildOAuthProfile(agent.InboundAuthConfig)
 
 	hasSecret := clientSecret != ""
@@ -1394,6 +1396,21 @@ func (s *agentService) agentLogoMap(ctx context.Context, entities []providers.En
 		}
 	}
 	return logoByID
+}
+
+// seedClientSubTypeAttribute selects the sub_type claim for a new agent, so its own tokens are
+// distinguishable from an M2M application's. Empty grant types default to client_credentials (see
+// buildOAuthProfile), so those are seeded too.
+func seedClientSubTypeAttribute(configs []providers.InboundAuthConfigWithSecret) {
+	cfg, err := pickOAuthConfig(configs)
+	if err != nil || cfg == nil {
+		return
+	}
+	if len(cfg.GrantTypes) > 0 &&
+		!slices.Contains(cfg.GrantTypes, providers.GrantTypeClientCredentials) {
+		return
+	}
+	cfg.Token = oauthutils.EnsureClientSubTypeAttribute(cfg.Token)
 }
 
 // buildOAuthProfile maps the agent OAuth config to the inbound client profile shape.

--- a/backend/internal/agent/service_test.go
+++ b/backend/internal/agent/service_test.go
@@ -2893,3 +2893,71 @@ func (suite *AgentServiceTestSuite) TestDeleteAgent_AbortedWhenCascadeFails() {
 	assert.Equal(suite.T(), tidcommon.InternalServerError.Code, svcErr.Code)
 	mockInbound.AssertNotCalled(suite.T(), "DeleteInboundClient", mock.Anything, mock.Anything)
 }
+
+// configsWithGrants builds a one-entry inbound auth config carrying the given grant types.
+func configsWithGrants(grantTypes []providers.GrantType) []providers.InboundAuthConfigWithSecret {
+	return []providers.InboundAuthConfigWithSecret{
+		{
+			Type:        providers.OAuthInboundAuthType,
+			OAuthConfig: &providers.OAuthConfigWithSecret{GrantTypes: grantTypes},
+		},
+	}
+}
+
+// clientAttributesOf reads back the client-token attribute selection, or nil when unset.
+func clientAttributesOf(configs []providers.InboundAuthConfigWithSecret) []string {
+	token := configs[0].OAuthConfig.Token
+	if token == nil || token.AccessToken == nil || token.AccessToken.ClientConfig == nil {
+		return nil
+	}
+	return token.AccessToken.ClientConfig.Attributes
+}
+
+func (suite *AgentServiceTestSuite) TestSeedClientSubTypeAttribute_ClientCredentials() {
+	configs := configsWithGrants([]providers.GrantType{providers.GrantTypeClientCredentials})
+
+	seedClientSubTypeAttribute(configs)
+
+	assert.Equal(suite.T(), []string{"sub_type"}, clientAttributesOf(configs))
+}
+
+// An agent with no grant types receives client_credentials by default, so it is seeded too.
+func (suite *AgentServiceTestSuite) TestSeedClientSubTypeAttribute_EmptyGrantTypes() {
+	configs := configsWithGrants(nil)
+
+	seedClientSubTypeAttribute(configs)
+
+	assert.Equal(suite.T(), []string{"sub_type"}, clientAttributesOf(configs))
+}
+
+// An agent that never receives a token for itself gets no selection.
+func (suite *AgentServiceTestSuite) TestSeedClientSubTypeAttribute_SkipsNonClientGrants() {
+	configs := configsWithGrants([]providers.GrantType{providers.GrantTypeAuthorizationCode})
+
+	seedClientSubTypeAttribute(configs)
+
+	assert.Nil(suite.T(), clientAttributesOf(configs))
+}
+
+// Seeding adds to the caller's selection rather than replacing it.
+func (suite *AgentServiceTestSuite) TestSeedClientSubTypeAttribute_AppendsToCallerSelection() {
+	configs := configsWithGrants([]providers.GrantType{providers.GrantTypeClientCredentials})
+	configs[0].OAuthConfig.Token = &providers.OAuthTokenConfig{
+		AccessToken: &providers.AccessTokenConfig{
+			ClientConfig: &providers.AccessTokenSubConfig{Attributes: []string{"modelProvider"}},
+		},
+	}
+
+	seedClientSubTypeAttribute(configs)
+
+	assert.Equal(suite.T(), []string{"modelProvider", "sub_type"}, clientAttributesOf(configs))
+}
+
+// An agent with no OAuth inbound config has no client token to carry the claim.
+func (suite *AgentServiceTestSuite) TestSeedClientSubTypeAttribute_NoOAuthConfig() {
+	configs := []providers.InboundAuthConfigWithSecret{}
+
+	seedClientSubTypeAttribute(configs)
+
+	assert.Empty(suite.T(), configs)
+}

--- a/backend/internal/application/application_type_test.go
+++ b/backend/internal/application/application_type_test.go
@@ -141,3 +141,69 @@ func (s *ApplicationTypeTestSuite) TestFullStackCustomAndMCPFlowSecretEligibilit
 		s.False(isFlowSecretEligible(appType, m2mShaped), "type %q m2m-shaped should not be eligible", appType)
 	}
 }
+
+// processedDTOWithGrants builds a processed application DTO with one OAuth inbound config.
+func processedDTOWithGrants(
+	grantTypes []providers.GrantType, clientAttributes []string,
+) *model.ApplicationProcessedDTO {
+	var token *providers.OAuthTokenConfig
+	if clientAttributes != nil {
+		token = &providers.OAuthTokenConfig{
+			AccessToken: &providers.AccessTokenConfig{
+				ClientConfig: &providers.AccessTokenSubConfig{Attributes: clientAttributes},
+			},
+		}
+	}
+	return &model.ApplicationProcessedDTO{
+		InboundAuthConfig: []inboundmodel.InboundAuthConfigProcessed{
+			{
+				Type: providers.OAuthInboundAuthType,
+				OAuthConfig: &providers.OAuthClient{
+					GrantTypes: grantTypes,
+					Token:      token,
+				},
+			},
+		},
+	}
+}
+
+// clientAttributesOf reads back the client-token attribute selection, or nil when unset.
+func clientAttributesOf(dto *model.ApplicationProcessedDTO) []string {
+	cfg := dto.InboundAuthConfig[0].OAuthConfig.Token
+	if cfg == nil || cfg.AccessToken == nil || cfg.AccessToken.ClientConfig == nil {
+		return nil
+	}
+	return cfg.AccessToken.ClientConfig.Attributes
+}
+
+// Creation selects sub_type whenever the client_credentials grant is present, alone or not.
+func (s *ApplicationTypeTestSuite) TestSeedClientSubTypeAttributeForClientCredentialsGrants() {
+	for _, grantTypes := range [][]providers.GrantType{
+		{providers.GrantTypeClientCredentials},
+		{providers.GrantTypeAuthorizationCode, providers.GrantTypeClientCredentials},
+	} {
+		dto := processedDTOWithGrants(grantTypes, nil)
+
+		seedClientSubTypeAttribute(dto)
+
+		s.Equal([]string{"sub_type"}, clientAttributesOf(dto), "grants %v should receive the claim", grantTypes)
+	}
+}
+
+// An application that never receives a token for itself gets no selection.
+func (s *ApplicationTypeTestSuite) TestSeedClientSubTypeAttributeSkipsNonClientGrants() {
+	dto := processedDTOWithGrants([]providers.GrantType{providers.GrantTypeAuthorizationCode}, nil)
+
+	seedClientSubTypeAttribute(dto)
+
+	s.Nil(clientAttributesOf(dto), "an application with no client_credentials grant must not be seeded")
+}
+
+// Seeding adds to the caller's selection rather than replacing it.
+func (s *ApplicationTypeTestSuite) TestSeedClientSubTypeAttributeAppendsToCallerSelection() {
+	dto := processedDTOWithGrants([]providers.GrantType{providers.GrantTypeClientCredentials}, []string{"ouId"})
+
+	seedClientSubTypeAttribute(dto)
+
+	s.Equal([]string{"ouId", "sub_type"}, clientAttributesOf(dto))
+}

--- a/backend/internal/application/service.go
+++ b/backend/internal/application/service.go
@@ -112,6 +112,8 @@ func (as *applicationService) CreateApplication(ctx context.Context, app *model.
 
 	appID := processedDTO.ID
 
+	seedClientSubTypeAttribute(processedDTO)
+
 	inboundClient := toInboundClient(processedDTO)
 	oauthProfile := toOAuthProfile(processedDTO)
 	if svcErr := as.resolveAttestationCredentialsForPersist(ctx, appID, &inboundClient); svcErr != nil {
@@ -556,6 +558,23 @@ func isFlowSecretEligible(appType model.ApplicationType,
 // isM2MGrantSet reports whether client_credentials is the only configured grant type.
 func isM2MGrantSet(grantTypes []providers.GrantType) bool {
 	return len(grantTypes) == 1 && grantTypes[0] == providers.GrantTypeClientCredentials
+}
+
+// seedClientSubTypeAttribute selects the sub_type claim for a new application that can use the
+// client_credentials grant, so its own tokens identify it without being reconfigured. Keyed on the
+// grant, not the type: a fullstack or custom application can hold the grant too.
+func seedClientSubTypeAttribute(processedDTO *model.ApplicationProcessedDTO) {
+	if processedDTO == nil {
+		return
+	}
+	oauthProcessed := getOAuthInboundAuthConfigProcessedDTO(processedDTO.InboundAuthConfig)
+	if oauthProcessed == nil || oauthProcessed.OAuthConfig == nil {
+		return
+	}
+	if !slices.Contains(oauthProcessed.OAuthConfig.GrantTypes, providers.GrantTypeClientCredentials) {
+		return
+	}
+	oauthProcessed.OAuthConfig.Token = oauthutils.EnsureClientSubTypeAttribute(oauthProcessed.OAuthConfig.Token)
 }
 
 // appRequiresClientSecret reports whether the OAuth config implies a confidential client requiring a secret.

--- a/backend/internal/oauth/oauth2/constants/constants.go
+++ b/backend/internal/oauth/oauth2/constants/constants.go
@@ -272,12 +272,23 @@ const (
 	// jwt-bearer-grant (ID-JAG) access token, so downstream consumers can distinguish a federated
 	// principal from a local one.
 	ClaimIDP string = "idp"
+	// ClaimSubType identifies the identity class of the token subject, so a resource server can apply
+	// policy that differs by class. Emitted on client_credentials tokens.
+	ClaimSubType string = "sub_type"
 	// ClaimTokenFamilyID identifies the token family (one authorization grant) a token belongs to.
 	// A single tfid is minted per grant during the login flow and rides every access and refresh
 	// token of that grant, unchanged across refresh rotation, so revocation can target a whole
 	// family at once. Revocation-only and not a client-managed identifier: it rides the token JWTs
 	// but is not part of any client-facing API.
 	ClaimTokenFamilyID string = "tfid"
+)
+
+// Subject type values for the sub_type claim.
+const (
+	// SubTypeApp marks the subject as an application.
+	SubTypeApp string = "application"
+	// SubTypeAgent marks the subject as an agent.
+	SubTypeAgent string = "agent"
 )
 
 // SurfaceableClientSystemClaims is the fixed set of entity system-attribute keys that may be

--- a/backend/internal/oauth/oauth2/introspect/model.go
+++ b/backend/internal/oauth/oauth2/introspect/model.go
@@ -20,6 +20,7 @@ type IntrospectResponse struct {
 	Iat       int64     `json:"iat,omitempty"`
 	Nbf       int64     `json:"nbf,omitempty"`
 	Sub       string    `json:"sub,omitempty"`
+	SubType   string    `json:"sub_type,omitempty"`
 	Aud       any       `json:"aud,omitempty"`
 	Iss       string    `json:"iss,omitempty"`
 	Jti       string    `json:"jti,omitempty"`

--- a/backend/internal/oauth/oauth2/introspect/service.go
+++ b/backend/internal/oauth/oauth2/introspect/service.go
@@ -126,6 +126,9 @@ func (s *tokenIntrospectionService) prepareValidResponse(payload map[string]inte
 	if sub, ok := payload[constants.ClaimSub].(string); ok {
 		response.Sub = sub
 	}
+	if subType, ok := payload[constants.ClaimSubType].(string); ok {
+		response.SubType = subType
+	}
 	switch aud := payload[constants.ClaimAud].(type) {
 	case string:
 		response.Aud = aud

--- a/backend/internal/oauth/oauth2/introspect/service_test.go
+++ b/backend/internal/oauth/oauth2/introspect/service_test.go
@@ -163,6 +163,38 @@ func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_EnforcementUnav
 	assert.Nil(s.T(), response)
 }
 
+// An introspecting resource server needs the subject's identity class too, so sub_type is surfaced.
+func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_SurfacesSubType() {
+	for _, subType := range []string{constants.SubTypeAgent, constants.SubTypeApp} {
+		s.Run(subType, func() {
+			token := accessTokenFor("client-token-" + subType)
+			s.stubAccessToken(token, map[string]interface{}{
+				"sub":       "entity123",
+				"sub_type":  subType,
+				"client_id": "client123",
+			})
+
+			response, err := s.introspectService.IntrospectToken(context.Background(), token, "")
+
+			assert.NoError(s.T(), err)
+			assert.True(s.T(), response.Active)
+			assert.Equal(s.T(), subType, response.SubType)
+		})
+	}
+}
+
+// A token without the claim reports no subject type rather than a guessed one.
+func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_OmitsAbsentSubType() {
+	token := accessTokenFor("no-sub-type")
+	s.stubAccessToken(token, map[string]interface{}{"sub": "user123"})
+
+	response, err := s.introspectService.IntrospectToken(context.Background(), token, "")
+
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), response.Active)
+	assert.Empty(s.T(), response.SubType)
+}
+
 // RFC 7662 Section 2.1 covers refresh tokens as well as access tokens, so a refresh token is
 // reported active with its claims surfaced.
 func (s *TokenIntrospectionServiceTestSuite) TestIntrospectToken_RefreshToken_Active() {

--- a/backend/internal/oauth/oauth2/tokenservice/builder.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder.go
@@ -6,6 +6,7 @@ package tokenservice
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
@@ -180,14 +181,28 @@ func (tb *tokenBuilder) buildAccessTokenClaims(
 		claims["grant_type"] = ctx.GrantType
 	}
 
-	// Merge the subject's attributes (already resolved and filtered by the grant handler).
+	// Merge the subject's attributes (already resolved and filtered by the grant handler), skipping
+	// claims the builder writes itself so a configured attribute cannot supply one it is trusted for.
+	ownedClaims := builderOwnedClaimNames()
 	for key, value := range ctx.SubjectAttributes {
+		if ownedClaims[key] {
+			continue
+		}
 		claims[key] = value
 	}
 
 	// Set after merging subject attributes to prevent them from overwriting this system claim.
 	if ctx.AttributeCacheID != "" {
 		claims["aci"] = ctx.AttributeCacheID
+	}
+
+	// set sub_type claim to the token if conditions are met.
+	// This is used to distinguish between an agent and an M2M application.
+	if ctx.GrantType == string(providers.GrantTypeClientCredentials) &&
+		slices.Contains(clientConfigAttributeNames(ctx.OAuthApp), constants.ClaimSubType) {
+		if subType := clientSubjectType(ctx.OAuthApp); subType != "" {
+			claims[constants.ClaimSubType] = subType
+		}
 	}
 
 	// Set after merging user attributes so a federated principal's attributes cannot spoof the source
@@ -233,6 +248,23 @@ func (tb *tokenBuilder) buildAccessTokenClaims(
 	}
 
 	return claims, nil
+}
+
+// clientSubjectType maps an OAuth client's entity category to its sub_type claim value. Returns ""
+// for a category that is not a client identity class, so the claim is omitted rather than guessed.
+func clientSubjectType(oauthApp *providers.OAuthClient) string {
+	if oauthApp == nil {
+		return ""
+	}
+
+	switch oauthApp.EntityCategory {
+	case providers.EntityCategoryAgent:
+		return constants.SubTypeAgent
+	case providers.EntityCategoryApp:
+		return constants.SubTypeApp
+	default:
+		return ""
+	}
 }
 
 // buildActorClaim builds the actor claim for token exchange.

--- a/backend/internal/oauth/oauth2/tokenservice/builder_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/builder_test.go
@@ -182,6 +182,320 @@ func (suite *TokenBuilderTestSuite) TestBuildAccessToken_ClientAttributes_Merges
 	suite.mockJWTService.AssertExpectations(suite.T())
 }
 
+// clientCredentialsCtxWithCategory builds a client_credentials context for the given entity category,
+// with sub_type selected as creation seeds it.
+func (suite *TokenBuilderTestSuite) clientCredentialsCtxWithCategory(
+	category providers.EntityCategory,
+) *AccessTokenBuildContext {
+	return suite.clientCredentialsCtxWithAttributes(category, []string{constants.ClaimSubType})
+}
+
+// clientCredentialsCtxWithAttributes builds a client_credentials context with the given category and
+// client-token attribute selection.
+func (suite *TokenBuilderTestSuite) clientCredentialsCtxWithAttributes(
+	category providers.EntityCategory, clientAttributes []string,
+) *AccessTokenBuildContext {
+	oauthApp := *suite.oauthApp
+	oauthApp.EntityCategory = category
+	oauthApp.Token = &providers.OAuthTokenConfig{
+		AccessToken: &providers.AccessTokenConfig{
+			ClientConfig: &providers.AccessTokenSubConfig{Attributes: clientAttributes},
+		},
+	}
+
+	return &AccessTokenBuildContext{
+		Subject:   "entity123",
+		Audiences: []string{"https://api.example.com"},
+		ClientID:  "test-client",
+		Scopes:    []string{"read"},
+		GrantType: string(providers.GrantTypeClientCredentials),
+		OAuthApp:  &oauthApp,
+	}
+}
+
+// expectSubTypeClaim asserts the generated claims carry the expected sub_type value. An empty
+// expectation asserts the claim is absent.
+func (suite *TokenBuilderTestSuite) expectSubTypeClaim(expected string) {
+	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.MatchedBy(func(claims map[string]interface{}) bool {
+			subType, ok := claims[constants.ClaimSubType]
+			if expected == "" {
+				return !ok
+			}
+			return ok && subType == expected
+		}), mock.Anything, mock.Anything,
+	).Return(testAccessToken, time.Now().Unix(), nil)
+}
+
+// An agent's client_credentials token carries sub_type=agent, so it is distinguishable from an M2M
+// application token of identical shape.
+func (suite *TokenBuilderTestSuite) TestBuildAccessToken_SubType_Agent() {
+	suite.expectSubTypeClaim(constants.SubTypeAgent)
+
+	result, err := suite.builder.BuildAccessToken(context.Background(),
+		suite.clientCredentialsCtxWithCategory(providers.EntityCategoryAgent))
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+func (suite *TokenBuilderTestSuite) TestBuildAccessToken_SubType_App() {
+	suite.expectSubTypeClaim(constants.SubTypeApp)
+
+	result, err := suite.builder.BuildAccessToken(context.Background(),
+		suite.clientCredentialsCtxWithCategory(providers.EntityCategoryApp))
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+// A category that is not a client identity class omits the claim rather than guessing.
+func (suite *TokenBuilderTestSuite) TestBuildAccessToken_SubType_OmittedForNonClientCategory() {
+	suite.expectSubTypeClaim("")
+
+	result, err := suite.builder.BuildAccessToken(context.Background(),
+		suite.clientCredentialsCtxWithCategory(providers.EntityCategoryUser))
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+func (suite *TokenBuilderTestSuite) TestBuildAccessToken_SubType_OmittedWhenCategoryUnset() {
+	suite.expectSubTypeClaim("")
+
+	result, err := suite.builder.BuildAccessToken(context.Background(),
+		suite.clientCredentialsCtxWithCategory(""))
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+// A client whose selection omits sub_type receives a token without it.
+func (suite *TokenBuilderTestSuite) TestBuildAccessToken_SubType_OmittedWhenNotSelected() {
+	for _, category := range []providers.EntityCategory{providers.EntityCategoryAgent, providers.EntityCategoryApp} {
+		suite.Run(string(category), func() {
+			suite.SetupTest()
+			buildCtx := suite.clientCredentialsCtxWithAttributes(category, []string{constants.ClaimOUID})
+
+			suite.expectSubTypeClaim("")
+
+			result, err := suite.builder.BuildAccessToken(context.Background(), buildCtx)
+
+			assert.NoError(suite.T(), err)
+			assert.NotNil(suite.T(), result)
+			suite.mockJWTService.AssertExpectations(suite.T())
+		})
+	}
+}
+
+// A client with no client-token configuration predates the claim, so it is not restored at issuance.
+func (suite *TokenBuilderTestSuite) TestBuildAccessToken_SubType_OmittedWithoutClientConfig() {
+	buildCtx := suite.clientCredentialsCtxWithCategory(providers.EntityCategoryAgent)
+	buildCtx.OAuthApp.Token = nil
+
+	suite.expectSubTypeClaim("")
+
+	result, err := suite.builder.BuildAccessToken(context.Background(), buildCtx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+// The selection is read from the client sub-config, so a user-token setting cannot decide it.
+func (suite *TokenBuilderTestSuite) TestBuildAccessToken_SubType_NotSelectedByUserConfigAttribute() {
+	buildCtx := suite.clientCredentialsCtxWithAttributes(providers.EntityCategoryAgent, nil)
+	buildCtx.OAuthApp.Token.AccessToken.UserConfig = &providers.AccessTokenSubConfig{
+		Attributes: []string{constants.ClaimSubType},
+	}
+
+	suite.expectSubTypeClaim("")
+
+	result, err := suite.builder.BuildAccessToken(context.Background(), buildCtx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+// Only client_credentials makes the client the subject, so a user-subject token carries no sub_type.
+func (suite *TokenBuilderTestSuite) TestBuildAccessToken_SubType_OmittedForUserSubjectGrant() {
+	buildCtx := suite.clientCredentialsCtxWithCategory(providers.EntityCategoryAgent)
+	buildCtx.GrantType = string(providers.GrantTypeAuthorizationCode)
+
+	suite.expectSubTypeClaim("")
+
+	result, err := suite.builder.BuildAccessToken(context.Background(), buildCtx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+// Every builder-written claim must be immune to a configured attribute of the same name, whether it is
+// written before the merge (scope, client_id, grant_type) or after it (act, cnf, idp, aci).
+func (suite *TokenBuilderTestSuite) TestBuildAccessToken_BuilderOwnedClaims_NotSuppliableByAttributes() {
+	forged := "FORGED"
+	attrs := map[string]interface{}{"email": "real@example.com"}
+	for name := range builderOwnedClaimNames() {
+		attrs[name] = forged
+	}
+
+	buildCtx := &AccessTokenBuildContext{
+		Subject:           "user123",
+		Audiences:         []string{"https://api.example.com"},
+		ClientID:          "real-client",
+		Scopes:            []string{"read"},
+		GrantType:         string(providers.GrantTypeAuthorizationCode),
+		OAuthApp:          suite.oauthApp,
+		SubjectAttributes: attrs,
+	}
+
+	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.MatchedBy(func(claims map[string]interface{}) bool {
+			for name := range builderOwnedClaimNames() {
+				if claims[name] == forged {
+					return false
+				}
+			}
+			// A non-reserved attribute still rides through untouched.
+			return claims["email"] == "real@example.com"
+		}), mock.Anything, mock.Anything,
+	).Return(testAccessToken, time.Now().Unix(), nil)
+
+	result, err := suite.builder.BuildAccessToken(context.Background(), buildCtx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+// The scope write is conditional, so a scopeless token must still not carry an attribute-supplied one.
+func (suite *TokenBuilderTestSuite) TestBuildAccessToken_ScopelessToken_RejectsAttributeScope() {
+	buildCtx := &AccessTokenBuildContext{
+		Subject:           "user123",
+		Audiences:         []string{"https://api.example.com"},
+		ClientID:          "real-client",
+		GrantType:         string(providers.GrantTypeAuthorizationCode),
+		OAuthApp:          suite.oauthApp,
+		SubjectAttributes: map[string]interface{}{"scope": "admin:everything"},
+	}
+
+	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.MatchedBy(func(claims map[string]interface{}) bool {
+			_, present := claims["scope"]
+			return !present
+		}), mock.Anything, mock.Anything,
+	).Return(testAccessToken, time.Now().Unix(), nil)
+
+	result, err := suite.builder.BuildAccessToken(context.Background(), buildCtx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+// The OU claims are deliberately not builder-owned, so they must still reach a user-subject token.
+func (suite *TokenBuilderTestSuite) TestBuildAccessToken_OUClaims_StillDeliveredByAttributes() {
+	buildCtx := &AccessTokenBuildContext{
+		Subject:   "user123",
+		Audiences: []string{"https://api.example.com"},
+		ClientID:  "real-client",
+		Scopes:    []string{"read"},
+		GrantType: string(providers.GrantTypeAuthorizationCode),
+		OAuthApp:  suite.oauthApp,
+		SubjectAttributes: map[string]interface{}{
+			constants.ClaimOUID:     "ou-1",
+			constants.ClaimOUName:   "Engineering",
+			constants.ClaimOUHandle: "eng",
+		},
+	}
+
+	suite.mockJWTService.On("GenerateJWT",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.MatchedBy(func(claims map[string]interface{}) bool {
+			return claims[constants.ClaimOUID] == "ou-1" &&
+				claims[constants.ClaimOUName] == "Engineering" &&
+				claims[constants.ClaimOUHandle] == "eng"
+		}), mock.Anything, mock.Anything,
+	).Return(testAccessToken, time.Now().Unix(), nil)
+
+	result, err := suite.builder.BuildAccessToken(context.Background(), buildCtx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+// Literals, not constants, so a rename of the emitted vocabulary fails here instead of passing.
+func (suite *TokenBuilderTestSuite) TestBuildAccessToken_SubType_WireValues() {
+	for category, expected := range map[providers.EntityCategory]string{
+		providers.EntityCategoryAgent: "agent",
+		providers.EntityCategoryApp:   "application",
+	} {
+		suite.Run(string(category), func() {
+			suite.SetupTest()
+			suite.expectSubTypeClaim(expected)
+
+			_, err := suite.builder.BuildAccessToken(context.Background(),
+				suite.clientCredentialsCtxWithCategory(category))
+
+			assert.NoError(suite.T(), err)
+			suite.mockJWTService.AssertExpectations(suite.T())
+		})
+	}
+}
+
+// With no OAuth client there is no identity class to state, so the claim is omitted.
+func (suite *TokenBuilderTestSuite) TestBuildAccessToken_SubType_OmittedWithoutOAuthApp() {
+	buildCtx := suite.clientCredentialsCtxWithCategory(providers.EntityCategoryAgent)
+	buildCtx.OAuthApp = nil
+
+	suite.expectSubTypeClaim("")
+
+	result, err := suite.builder.BuildAccessToken(context.Background(), buildCtx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+// No configured attribute may introduce the claim on a grant that does not stamp it.
+func (suite *TokenBuilderTestSuite) TestBuildAccessToken_SubType_StrippedFromUserSubjectToken() {
+	buildCtx := suite.clientCredentialsCtxWithCategory(providers.EntityCategoryAgent)
+	buildCtx.GrantType = string(providers.GrantTypeAuthorizationCode)
+	buildCtx.SubjectAttributes = map[string]interface{}{constants.ClaimSubType: constants.SubTypeApp}
+
+	suite.expectSubTypeClaim("")
+
+	result, err := suite.builder.BuildAccessToken(context.Background(), buildCtx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
+// The claim is set after the merge, so an attribute of that name cannot make an agent an application.
+func (suite *TokenBuilderTestSuite) TestBuildAccessToken_SubType_NotSpoofableByAttribute() {
+	buildCtx := suite.clientCredentialsCtxWithCategory(providers.EntityCategoryAgent)
+	buildCtx.SubjectAttributes = map[string]interface{}{constants.ClaimSubType: constants.SubTypeApp}
+
+	suite.expectSubTypeClaim(constants.SubTypeAgent)
+
+	result, err := suite.builder.BuildAccessToken(context.Background(), buildCtx)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), result)
+	suite.mockJWTService.AssertExpectations(suite.T())
+}
+
 // A jwt-bearer-grant (ID-JAG) access token carries the source IdP issuer as the `idp` claim so
 // downstream consumers can distinguish a federated principal from a local one.
 func (suite *TokenBuilderTestSuite) TestBuildAccessToken_Success_WithSourceIDP() {

--- a/backend/internal/oauth/oauth2/tokenservice/utils.go
+++ b/backend/internal/oauth/oauth2/tokenservice/utils.go
@@ -404,7 +404,21 @@ func ReservedAccessTokenClaimNames() map[string]bool {
 	reserved[constants.ClaimOUHandle] = true
 	reserved[constants.ClaimClaimsRequest] = true
 	reserved[constants.ClaimClaimsLocales] = true
+	reserved[constants.ClaimSubType] = true
+	reserved[constants.ClaimIDP] = true
+	reserved[constants.ClaimTokenFamilyID] = true
 	return reserved
+}
+
+// builderOwnedClaimNames returns the access-token claims the builder writes itself, so a configured
+// attribute can never supply one. The reserved set minus the OU claims, which a user-subject token
+// legitimately receives through the attribute channel.
+func builderOwnedClaimNames() map[string]bool {
+	owned := ReservedAccessTokenClaimNames()
+	delete(owned, constants.ClaimOUID)
+	delete(owned, constants.ClaimOUName)
+	delete(owned, constants.ClaimOUHandle)
+	return owned
 }
 
 // FilterAttributesByAllowList returns the subset of attrs whose keys are listed in the given

--- a/backend/internal/oauth/oauth2/tokenservice/utils_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/utils_test.go
@@ -945,6 +945,22 @@ func (suite *UtilsTestSuite) TestBuildClientAttributes_AgentOwnAttributes_SkipsR
 	assert.NotContains(suite.T(), claims, "scope")
 }
 
+// sub_type is reserved, so an agent cannot surface a schema attribute of that name.
+func (suite *UtilsTestSuite) TestBuildClientAttributes_AgentOwnAttributes_SkipsSubType() {
+	actors := actorprovidermock.NewActorProviderMock(suite.T())
+	actors.On("GetActor", testBCCAppID).Return(&providers.Entity{
+		ID:         testBCCAppID,
+		Attributes: []byte(`{"sub_type":"app","modelProvider":"anthropic"}`),
+	}, (*tidcommon.ServiceError)(nil))
+
+	app := newOAuthAppForOwnAttributes([]string{"sub_type", "modelProvider"})
+	claims, err := BuildClientAttributes(context.Background(), app, nil, actors)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "anthropic", claims["modelProvider"])
+	assert.NotContains(suite.T(), claims, "sub_type")
+}
+
 func (suite *UtilsTestSuite) TestBuildClientAttributes_AgentSystemAttributes_HappyPath() {
 	actors := actorprovidermock.NewActorProviderMock(suite.T())
 	actors.On("GetActor", testBCCAppID).Return(&providers.Entity{

--- a/backend/internal/oauth/oauth2/utils/oauthutils.go
+++ b/backend/internal/oauth/oauth2/utils/oauthutils.go
@@ -10,11 +10,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/model"
 	"github.com/thunder-id/thunderid/internal/system/utils"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
 
 // GetURIWithQueryParams constructs a URI with the given query parameters.
@@ -256,4 +258,25 @@ func SerializeClaimsRequest(cr *model.ClaimsRequest) (string, error) {
 	}
 
 	return string(data), nil
+}
+
+// EnsureClientSubTypeAttribute selects the sub_type claim in a client's own access token attribute
+// list, returning the updated token config. Called at client creation only, so a claim removed later
+// stays removed. Selection alone enables the claim; the builder supplies its value.
+func EnsureClientSubTypeAttribute(token *providers.OAuthTokenConfig) *providers.OAuthTokenConfig {
+	if token == nil {
+		token = &providers.OAuthTokenConfig{}
+	}
+	if token.AccessToken == nil {
+		token.AccessToken = &providers.AccessTokenConfig{}
+	}
+	if token.AccessToken.ClientConfig == nil {
+		token.AccessToken.ClientConfig = &providers.AccessTokenSubConfig{}
+	}
+
+	clientConfig := token.AccessToken.ClientConfig
+	if !slices.Contains(clientConfig.Attributes, constants.ClaimSubType) {
+		clientConfig.Attributes = append(clientConfig.Attributes, constants.ClaimSubType)
+	}
+	return token
 }

--- a/backend/internal/oauth/oauth2/utils/oauthutils_test.go
+++ b/backend/internal/oauth/oauth2/utils/oauthutils_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/model"
 	sysutils "github.com/thunder-id/thunderid/internal/system/utils"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
 
 type OAuth2UtilsTestSuite struct {
@@ -1844,4 +1845,55 @@ func (suite *OAuth2UtilsTestSuite) TestSanitizeErrorDescriptionKeepsRedirectBuil
 
 	assert.NoError(suite.T(), err)
 	assert.Contains(suite.T(), uri, "error=access_denied")
+}
+
+// No token configuration is the common case, so the helper builds the nested config.
+func (suite *OAuth2UtilsTestSuite) TestEnsureClientSubTypeAttribute_BuildsMissingConfig() {
+	token := EnsureClientSubTypeAttribute(nil)
+
+	assert.NotNil(suite.T(), token)
+	assert.NotNil(suite.T(), token.AccessToken)
+	assert.NotNil(suite.T(), token.AccessToken.ClientConfig)
+	assert.Equal(suite.T(), []string{constants.ClaimSubType}, token.AccessToken.ClientConfig.Attributes)
+}
+
+// Seeding adds the claim without replacing a caller-supplied selection.
+func (suite *OAuth2UtilsTestSuite) TestEnsureClientSubTypeAttribute_KeepsExistingAttributes() {
+	token := EnsureClientSubTypeAttribute(&providers.OAuthTokenConfig{
+		AccessToken: &providers.AccessTokenConfig{
+			ClientConfig: &providers.AccessTokenSubConfig{
+				ValidityPeriod: 1800,
+				Attributes:     []string{constants.ClaimOUID},
+			},
+		},
+	})
+
+	clientConfig := token.AccessToken.ClientConfig
+	assert.Equal(suite.T(), []string{constants.ClaimOUID, constants.ClaimSubType}, clientConfig.Attributes)
+	assert.Equal(suite.T(), int64(1800), clientConfig.ValidityPeriod,
+		"seeding the claim must not disturb the rest of the client config")
+}
+
+// The caller may already have set the claim, so seeding must not duplicate it.
+func (suite *OAuth2UtilsTestSuite) TestEnsureClientSubTypeAttribute_IsIdempotent() {
+	token := EnsureClientSubTypeAttribute(&providers.OAuthTokenConfig{
+		AccessToken: &providers.AccessTokenConfig{
+			ClientConfig: &providers.AccessTokenSubConfig{Attributes: []string{constants.ClaimSubType}},
+		},
+	})
+	token = EnsureClientSubTypeAttribute(token)
+
+	assert.Equal(suite.T(), []string{constants.ClaimSubType}, token.AccessToken.ClientConfig.Attributes)
+}
+
+// sub_type never appears on a user-subject token, so the user sub-config is untouched.
+func (suite *OAuth2UtilsTestSuite) TestEnsureClientSubTypeAttribute_LeavesUserConfigAlone() {
+	token := EnsureClientSubTypeAttribute(&providers.OAuthTokenConfig{
+		AccessToken: &providers.AccessTokenConfig{
+			UserConfig: &providers.AccessTokenSubConfig{Attributes: []string{"email"}},
+		},
+	})
+
+	assert.Equal(suite.T(), []string{"email"}, token.AccessToken.UserConfig.Attributes)
+	assert.Equal(suite.T(), []string{constants.ClaimSubType}, token.AccessToken.ClientConfig.Attributes)
 }

--- a/docs/content/guides/agents/authentication/agent-own-token.mdx
+++ b/docs/content/guides/agents/authentication/agent-own-token.mdx
@@ -40,6 +40,7 @@ Every agent access token is a signed JWT (`typ: at+jwt`). A `client_credentials`
 | Claim | Value |
 |---|---|
 | `sub` | The agent's resource ID. |
+| `sub_type` | `agent`, the identity class of the token's subject. An application's `client_credentials` token carries `application` instead, so a resource server can tell an agent from an application. Selected for every new agent, and removable on the **Tokens** tab. |
 | `iss` | The <ProductName /> instance URL. |
 | `aud` | The resolved resource server, or the agent's default audience (its client ID when none is set) for a scopeless request with no `resource`. |
 | `scope` | The scopes authorized through the agent's roles and groups. |
@@ -47,11 +48,11 @@ Every agent access token is a signed JWT (`typ: at+jwt`). A `client_credentials`
 | `grant_type` | `client_credentials`. |
 | `exp`, `iat`, `nbf`, `jti` | Standard JWT lifetime and identity claims. |
 
-There is no `act` claim, because the agent acts as itself and not for anyone else. The attributes and claims selected on the **Tokens** tab (the agent's schema attributes, its system attributes `name` and `owner`, the OU claims `ouId`, `ouName`, and `ouHandle`, and its `groups` and `roles`) are added only when selected.
+There is no `act` claim, because the agent acts as itself and not for anyone else. `sub_type` is the one claim above that the **Tokens** tab can remove: clear its chip when the resource servers reading these tokens do not use it. Creating an agent selects the claim for you, whether through the Console, the REST API, or a declarative import. Two cases start without it: an agent created before the claim existed, and an agent read from a declarative file in `declarative` store mode, which has to list `sub_type` under `clientConfig.attributes` itself. The attributes and claims selected on the **Tokens** tab (the agent's schema attributes, its system attributes `name` and `owner`, the OU claims `ouId`, `ouName`, and `ouHandle`, and its `groups` and `roles`) are added only when selected.
 
 ## Call a protected API with the agent token
 
-Send the token as a Bearer token. The resource verifies the token's signature with the keys from `https://localhost:8090/oauth2/jwks`, checks the `iss`, `aud`, and `exp` claims, then authorizes the request against `scope`. To identify the caller, the resource reads `sub` (the agent itself) and `client_id` (the OAuth client that obtained the token); there is no `act` claim, because the agent acts as itself.
+Send the token as a Bearer token. The resource verifies the token's signature with the keys from `https://localhost:8090/oauth2/jwks`, checks the `iss`, `aud`, and `exp` claims, then authorizes the request against `scope`. To identify the caller, the resource reads `sub` (the agent itself), `sub_type` (`agent`, to apply policy that differs by identity class), and `client_id` (the OAuth client that obtained the token); there is no `act` claim, because the agent acts as itself.
 
 ```bash
 curl https://api.example.com/invoices -H 'Authorization: Bearer <ACCESS_TOKEN>'

--- a/docs/content/guides/protocols/oauth-oidc/client-credentials.mdx
+++ b/docs/content/guides/protocols/oauth-oidc/client-credentials.mdx
@@ -29,6 +29,7 @@ Use it for service-to-service calls, internal daemons, scheduled jobs, and CLI t
 | Token subject | `sub` in the issued access token is the `client_id` |
 | End-user attributes | Not included: there is no authenticated user |
 | Client attributes | The client's own attributes can be added as subject claims via `clientConfig.attributes`. OU claims (`ouId`, `ouName`, `ouHandle`), `groups`, and `roles` are available to any client; agents can also include their schema attributes and system attributes (`name`, `owner`). All are opt-in and must be listed explicitly. |
+| Subject class | `sub_type` carries `application` or `agent`, so a resource server can apply policy that differs by identity class. Selected through `clientConfig.attributes`, and added there when the client is created, so a new client carries it without configuration. Clear the `sub_type` chip on the Console **Token** tab to drop it. Its value always comes from the server's record of the client's class |
 | Refresh token | Not issued for this grant (re-request when needed) |
 | Scope filtering | Requested scopes are filtered to permissions defined on the target resource server, then intersected with the permissions the client holds through its **role and group assignments** |
 | `aud` claim | The supplied resource server identifier, or `defaultResourceServer` for a permission-bearing request without `resource`. A scopeless request without `resource` uses the application's `token.accessToken.defaultAudience`, falling back to `client_id` |
@@ -38,6 +39,31 @@ Use it for service-to-service calls, internal daemons, scheduled jobs, and CLI t
 
 :::note
 OU claims are opt-in: a client receives only the claims it lists in `clientConfig.attributes`. Agents configure these on the **Token** tab in the Console. Applications can set `clientConfig.attributes` through the API when needed.
+:::
+
+:::info
+`sub_type` is added to `clientConfig.attributes` when a client is created, so a new client carries the claim without configuration. This covers the Console, the REST API, dynamic client registration, and resources imported with `target: runtime`, all of which create the client through the same service.
+
+A client that is only ever read from a declarative file, that is, one served by an application or agent store running in `declarative` mode, is never created through that path, so it has to list the claim itself:
+
+```yaml
+resource_type: application
+name: Reporting Service
+type: m2m
+ouHandle: default
+inboundAuthConfig:
+  - type: oauth2
+    config:
+      grantTypes:
+        - client_credentials
+      token:
+        accessToken:
+          clientConfig:
+            attributes:
+              - sub_type
+```
+
+Leaving it out is a valid choice, not an error: the client simply receives no `sub_type`. The same applies to a client created before the claim existed, which carries it once the chip is selected on the **Token** tab. A resource server should therefore treat a missing `sub_type` as an unknown identity class rather than assuming one.
 :::
 
 ## Try It in <ProductName />

--- a/frontend/apps/console/src/features/agents/components/edit-agent/tokens/AgentAccessTokenSection.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/tokens/AgentAccessTokenSection.tsx
@@ -60,6 +60,7 @@ export default function AgentAccessTokenSection({
       onValidationChange={onValidationChange}
       inputId="agent-access-token-validity"
       subjectValue={agent.id}
+      subjectType="agent"
       copy={{
         attributesTitle: t('agents:edit.tokens.agent.attributes.title', 'Access Token Attributes'),
         attributesDescription: t(

--- a/frontend/apps/console/src/features/agents/components/edit-agent/tokens/__tests__/AgentAccessTokenSection.test.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/tokens/__tests__/AgentAccessTokenSection.test.tsx
@@ -216,6 +216,26 @@ describe('AgentAccessTokenSection', () => {
     expect(screen.getByTestId('jwt-preview')).toHaveTextContent('"name":"<name>"');
   });
 
+  // The agent tab must declare its own identity class, not the application value.
+  it('previews sub_type as agent when the claim is selected', () => {
+    render(
+      <AgentAccessTokenSection
+        agent={{...baseAgent, inboundAuthConfig: baseInboundAuthConfig}}
+        editedAgent={{}}
+        oauth2Config={
+          {
+            grantTypes: ['client_credentials'],
+            responseTypes: [],
+            token: {accessToken: {clientConfig: {attributes: ['sub_type']}}},
+          } as unknown as OAuthAgentConfig
+        }
+        onFieldChange={mockOnFieldChange}
+      />,
+    );
+
+    expect(screen.getByTestId('jwt-preview')).toHaveTextContent('"sub_type":"agent"');
+  });
+
   it('does not show a scopes section', () => {
     render(
       <AgentAccessTokenSection

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/ClientAccessTokenSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/ClientAccessTokenSection.tsx
@@ -22,6 +22,7 @@ import TokenConstants from '../../../constants/token-constants';
 
 // The client_credentials grant carries no scopes, so `scope` never appears on this token.
 const ACCESS_TOKEN_DEFAULT_CLAIMS = TokenConstants.DEFAULT_TOKEN_ATTRIBUTES.filter((attr) => attr !== 'scope');
+const SUB_TYPE_CLAIM = 'sub_type';
 
 /** Display copy for the section, supplied by the caller so agents and applications read differently. */
 export interface ClientAccessTokenCopy {
@@ -50,6 +51,8 @@ interface ClientAccessTokenSectionProps {
   inputId?: string;
   /** Value shown for the `sub` claim in the preview (the client entity's own ID). */
   subjectValue?: string;
+  /** Identity class the server stamps as `sub_type` on this client's token. */
+  subjectType: 'application' | 'agent';
 }
 
 /**
@@ -69,6 +72,7 @@ export default function ClientAccessTokenSection({
   copy,
   inputId = 'client-access-token-validity',
   subjectValue = '<sub>',
+  subjectType,
 }: ClientAccessTokenSectionProps): JSX.Element {
   const {t} = useTranslation();
 
@@ -117,12 +121,19 @@ export default function ClientAccessTokenSection({
     }
   };
 
+  const previewValueFor = (claim: string): string => {
+    if (claim === 'sub') return subjectValue;
+    // sub_type carries its literal value: the server fixes it from the client's identity class.
+    if (claim === SUB_TYPE_CLAIM) return subjectType;
+    return `<${claim}>`;
+  };
+
   const jwtPreview: Record<string, unknown> = {};
   ACCESS_TOKEN_DEFAULT_CLAIMS.forEach((attr) => {
-    jwtPreview[attr] = attr === 'sub' ? subjectValue : `<${attr}>`;
+    jwtPreview[attr] = previewValueFor(attr);
   });
   currentAttributes.forEach((attr) => {
-    jwtPreview[attr] = `<${attr}>`;
+    jwtPreview[attr] = previewValueFor(attr);
   });
 
   return (

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/EditTokenSettingsTabs.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/EditTokenSettingsTabs.tsx
@@ -114,6 +114,7 @@ export default function EditTokenSettingsTabs({
           disabled={application.isReadOnly ?? false}
           onValidationChange={setClientTabHasError}
           subjectValue={application.id}
+          subjectType="application"
           copy={{
             attributesTitle: t('applications:edit.token.client.attributes.title', 'Access Token Attributes'),
             attributesDescription: t(

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/JwtPreview.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/JwtPreview.tsx
@@ -22,6 +22,7 @@ const JWT_CLAIM_DESCRIPTIONS: Record<string, string> = {
   nbf: 'Not before — token not valid before this Unix timestamp',
   scope: 'OAuth 2 scopes granted to the token',
   sub: 'Subject — the principal (user) this token represents',
+  sub_type: 'Identity class of the subject: application or agent',
 };
 
 interface MonacoLike {

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/ClientAccessTokenSection.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/ClientAccessTokenSection.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import userEvent from '@testing-library/user-event';
-import type {InboundAuthConfig} from '@thunderid/configure-applications';
+import type {InboundAuthConfig, OAuth2Config} from '@thunderid/configure-applications';
 import {render, screen} from '@thunderid/test-utils';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import ClientAccessTokenSection, {type ClientAccessTokenCopy} from '../ClientAccessTokenSection';
@@ -44,6 +44,7 @@ describe('ClientAccessTokenSection', () => {
         onFieldChange={onFieldChange}
         availableAttributes={['groups', 'roles']}
         copy={copy}
+        subjectType="application"
       />,
     );
 
@@ -60,6 +61,7 @@ describe('ClientAccessTokenSection', () => {
         onFieldChange={onFieldChange}
         availableAttributes={['groups', 'roles']}
         copy={copy}
+        subjectType="application"
       />,
     );
 
@@ -91,6 +93,7 @@ describe('ClientAccessTokenSection', () => {
         onFieldChange={onFieldChange}
         availableAttributes={['groups']}
         copy={copy}
+        subjectType="application"
         inputId="client-access-token-validity"
       />,
     );
@@ -127,6 +130,7 @@ describe('ClientAccessTokenSection', () => {
         onFieldChange={onFieldChange}
         availableAttributes={['groups']}
         copy={copy}
+        subjectType="application"
         inputId="client-access-token-validity"
         onValidationChange={onValidationChange}
       />,
@@ -148,12 +152,132 @@ describe('ClientAccessTokenSection', () => {
         onFieldChange={onFieldChange}
         availableAttributes={['groups']}
         copy={copy}
+        subjectType="application"
         subjectValue="my-agent-123"
       />,
     );
 
     const preview = JSON.parse(screen.getByTestId('jwt-preview').textContent ?? '{}') as {sub?: string};
     expect(preview.sub).toBe('my-agent-123');
+  });
+
+  // A selected sub_type shows its literal value, not a <placeholder>: the server fixes it.
+  it.each([
+    ['application', 'application'],
+    ['agent', 'agent'],
+  ] as const)('shows sub_type=%s in the preview for a %s client', (subjectType, expected) => {
+    render(
+      <ClientAccessTokenSection
+        oauth2Config={
+          {
+            grantTypes: ['client_credentials'],
+            responseTypes: [],
+            token: {accessToken: {clientConfig: {attributes: ['sub_type']}}},
+          } as unknown as OAuth2Config
+        }
+        inboundAuthConfig={inboundAuthConfig}
+        onFieldChange={onFieldChange}
+        availableAttributes={['groups', 'sub_type']}
+        copy={copy}
+        subjectType={subjectType}
+      />,
+    );
+
+    const preview = JSON.parse(screen.getByTestId('jwt-preview').textContent ?? '{}') as {sub_type?: string};
+    expect(preview.sub_type).toBe(expected);
+  });
+
+  // Creation seeds sub_type, so its chip starts filled and clicking it removes the claim.
+  it('removes sub_type from the selection when its chip is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <ClientAccessTokenSection
+        oauth2Config={
+          {
+            grantTypes: ['client_credentials'],
+            responseTypes: [],
+            token: {accessToken: {clientConfig: {attributes: ['sub_type']}}},
+          } as unknown as OAuth2Config
+        }
+        inboundAuthConfig={inboundAuthConfig}
+        onFieldChange={onFieldChange}
+        availableAttributes={['groups', 'sub_type']}
+        copy={copy}
+        subjectType="agent"
+      />,
+    );
+
+    await user.click(screen.getByText('sub_type'));
+
+    expect(onFieldChange).toHaveBeenCalledWith(
+      'inboundAuthConfig',
+      expect.arrayContaining([
+        expect.objectContaining({
+          config: expect.objectContaining({
+            token: expect.objectContaining({
+              accessToken: expect.objectContaining({
+                clientConfig: expect.objectContaining({attributes: []}) as Record<string, unknown>,
+              }) as Record<string, unknown>,
+            }) as Record<string, unknown>,
+          }) as Record<string, unknown>,
+        }),
+      ]),
+    );
+  });
+
+  it('adds sub_type back to the selection when its chip is clicked while unselected', async () => {
+    const user = userEvent.setup();
+    render(
+      <ClientAccessTokenSection
+        oauth2Config={{grantTypes: ['client_credentials'], responseTypes: []}}
+        inboundAuthConfig={inboundAuthConfig}
+        onFieldChange={onFieldChange}
+        availableAttributes={['groups', 'sub_type']}
+        copy={copy}
+        subjectType="agent"
+      />,
+    );
+
+    await user.click(screen.getByText('sub_type'));
+
+    expect(onFieldChange).toHaveBeenCalledWith(
+      'inboundAuthConfig',
+      expect.arrayContaining([
+        expect.objectContaining({
+          config: expect.objectContaining({
+            token: expect.objectContaining({
+              accessToken: expect.objectContaining({
+                clientConfig: expect.objectContaining({attributes: ['sub_type']}) as Record<string, unknown>,
+              }) as Record<string, unknown>,
+            }) as Record<string, unknown>,
+          }) as Record<string, unknown>,
+        }),
+      ]),
+    );
+  });
+
+  // A client without the claim selected must not see it in the preview.
+  it('omits sub_type from the preview when it is not selected', () => {
+    render(
+      <ClientAccessTokenSection
+        oauth2Config={
+          {
+            grantTypes: ['client_credentials'],
+            responseTypes: [],
+            token: {accessToken: {clientConfig: {attributes: ['groups']}}},
+          } as unknown as OAuth2Config
+        }
+        inboundAuthConfig={inboundAuthConfig}
+        onFieldChange={onFieldChange}
+        availableAttributes={['groups', 'sub_type']}
+        copy={copy}
+        subjectType="agent"
+      />,
+    );
+
+    const preview = JSON.parse(screen.getByTestId('jwt-preview').textContent ?? '{}') as Record<string, unknown>;
+    expect(preview).not.toHaveProperty('sub_type');
+    expect(preview.groups).toBe('<groups>');
   });
 
   it('falls back to the <sub> placeholder when no subjectValue is supplied', () => {
@@ -164,6 +288,7 @@ describe('ClientAccessTokenSection', () => {
         onFieldChange={onFieldChange}
         availableAttributes={['groups']}
         copy={copy}
+        subjectType="application"
       />,
     );
 
@@ -179,6 +304,7 @@ describe('ClientAccessTokenSection', () => {
         onFieldChange={onFieldChange}
         availableAttributes={['groups']}
         copy={copy}
+        subjectType="application"
         inputId="client-access-token-validity"
         disabled
       />,

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/EditTokenSettingsTabs.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/EditTokenSettingsTabs.test.tsx
@@ -9,10 +9,10 @@ import {describe, it, expect, vi} from 'vitest';
 import EditTokenSettingsTabs from '../EditTokenSettingsTabs';
 
 vi.mock('../ClientAccessTokenSection', () => ({
-  default: vi.fn(() => {
+  default: vi.fn(({subjectType}: {subjectType?: string}) => {
     const [clicks, setClicks] = useState(0);
     return (
-      <div data-testid="client-token-section">
+      <div data-testid="client-token-section" data-subject-type={subjectType}>
         Clicks: {clicks}
         <button type="button" data-testid="client-token-section-bump" onClick={() => setClicks((c) => c + 1)}>
           Bump
@@ -90,6 +90,20 @@ describe('EditTokenSettingsTabs', () => {
     expect(screen.getByTestId('client-token-section')).toBeInTheDocument();
     expect(screen.queryByText(clientLockMessage)).not.toBeInTheDocument();
     expect(screen.queryByText(userLockMessage)).not.toBeInTheDocument();
+  });
+
+  // The application tab must declare its own identity class, not the agent value.
+  it('tells the client section its subject type is application', () => {
+    render(
+      <EditTokenSettingsTabs
+        application={application}
+        editedApp={{}}
+        oauth2Config={oauthConfig(['client_credentials'])}
+        onFieldChange={onFieldChange}
+      />,
+    );
+
+    expect(screen.getByTestId('client-token-section')).toHaveAttribute('data-subject-type', 'application');
   });
 
   it('omits the Application audience when client_credentials is not granted', () => {

--- a/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/TokenUserAttributesSection.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/token-settings/__tests__/TokenUserAttributesSection.test.tsx
@@ -202,6 +202,14 @@ describe('TokenUserAttributesSection', () => {
       expect(screen.getByTestId('jwt-preview')).toBeInTheDocument();
     });
 
+    // A user-subject token has a user as its subject, so the server never stamps sub_type here.
+    it('does not show sub_type in a user token preview', () => {
+      render(<TokenUserAttributesSection {...baseProps} sharedAttributes={[]} />);
+
+      const payload = screen.getByTestId('jwt-preview-payload').textContent ?? '';
+      expect(payload).not.toContain('sub_type');
+    });
+
     it('shows sharedAttributes in the JWT preview payload', () => {
       render(<TokenUserAttributesSection {...baseProps} userAttributes={['email']} sharedAttributes={['email']} />);
 

--- a/frontend/apps/console/src/features/applications/constants/token-constants.ts
+++ b/frontend/apps/console/src/features/applications/constants/token-constants.ts
@@ -24,13 +24,13 @@ const TokenConstants = {
    * Agent system, OU, group, and role attributes that can be added to the agent's own access token
    * (client_credentials)
    */
-  ADDITIONAL_AGENT_ATTRIBUTES: ['name', 'owner', 'ouHandle', 'ouId', 'ouName', 'groups', 'roles'],
+  ADDITIONAL_AGENT_ATTRIBUTES: ['name', 'owner', 'ouHandle', 'ouId', 'ouName', 'groups', 'roles', 'sub_type'],
 
   /**
    * Optional claims that can be added to the client access token (client_credentials grant),
    * where there is no end user to source attributes from.
    */
-  CLIENT_TOKEN_OPTIONAL_CLAIMS: ['groups', 'ouHandle', 'ouId', 'ouName', 'roles'],
+  CLIENT_TOKEN_OPTIONAL_CLAIMS: ['groups', 'ouHandle', 'ouId', 'ouName', 'roles', 'sub_type'],
 
   /**
    * Supported UserInfo response types

--- a/tests/integration/agent/agent_client_attributes_test.go
+++ b/tests/integration/agent/agent_client_attributes_test.go
@@ -4,7 +4,10 @@
 package agent
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -64,6 +67,8 @@ func (s *AgentClientAttributesTestSuite) SetupSuite() {
 		Schema: map[string]interface{}{
 			"modelProvider": map[string]interface{}{"type": "string"},
 			"description":   map[string]interface{}{"type": "string"},
+			// Named after a reserved claim, so a test can store a conflicting value.
+			"sub_type": map[string]interface{}{"type": "string"},
 		},
 	})
 	s.Require().NoError(err)
@@ -131,6 +136,14 @@ func (s *AgentClientAttributesTestSuite) TearDownSuite() {
 func (s *AgentClientAttributesTestSuite) createAgentWithAttributes(
 	clientID string, clientAttributes []string, attributes json.RawMessage, owner string,
 ) (string, error) {
+	return s.createAgentWithClientConfig(clientID, &AccessTokenSubConfig{Attributes: clientAttributes},
+		attributes, owner)
+}
+
+// createAgentWithClientConfig creates an agent with the given token.accessToken.clientConfig block.
+func (s *AgentClientAttributesTestSuite) createAgentWithClientConfig(
+	clientID string, clientConfig *AccessTokenSubConfig, attributes json.RawMessage, owner string,
+) (string, error) {
 	return createAgent(Agent{
 		OUID:       s.ouID,
 		Type:       "default",
@@ -147,13 +160,64 @@ func (s *AgentClientAttributesTestSuite) createAgentWithAttributes(
 					TokenEndpointAuthMethod: "client_secret_basic",
 					Token: &OAuthTokenConfig{
 						AccessToken: &AccessTokenConfig{
-							ClientConfig: &AccessTokenSubConfig{Attributes: clientAttributes},
+							ClientConfig: clientConfig,
 						},
 					},
 				},
 			},
 		},
 	})
+}
+
+// updateClientAttributes replaces the agent's client-token attribute selection, as the Console does
+// when an operator toggles a chip.
+func (s *AgentClientAttributesTestSuite) updateClientAttributes(
+	agentID, clientID string, attributes []string, attrs json.RawMessage,
+) error {
+	body := Agent{
+		OUID:       s.ouID,
+		Type:       "default",
+		Name:       "Client Attrs Agent " + clientID,
+		Owner:      s.ownerUserID,
+		Attributes: attrs,
+		InboundAuthConfig: []InboundAuthConfig{
+			{
+				Type: "oauth2",
+				Config: &OAuthAgentConfig{
+					ClientID:                clientID,
+					ClientSecret:            agentClientAttrsClientSecret,
+					GrantTypes:              []string{"client_credentials"},
+					TokenEndpointAuthMethod: "client_secret_basic",
+					Token: &OAuthTokenConfig{
+						AccessToken: &AccessTokenConfig{
+							ClientConfig: &AccessTokenSubConfig{Attributes: attributes},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPut, testServerURL+"/agents/"+agentID, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("expected status 200, got %d. Response: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
 }
 
 // requestToken performs a client_credentials token request for the given client ID.
@@ -237,6 +301,91 @@ func (s *AgentClientAttributesTestSuite) TestAgentClientAttrs_SchemaAndSystemAnd
 	s.Require().True(ok, "roles claim should be present as an array")
 	s.Assert().ElementsMatch(
 		[]interface{}{"Agent Client Attrs Direct Role", "Agent Client Attrs Group Role"}, roles)
+}
+
+// TestAgentClientAttrs_SubTypeAgent verifies that an agent's client_credentials token carries
+// sub_type=agent. The agent stores a conflicting sub_type attribute and allow-lists it, so the token
+// value also proves the claim is server-set and cannot be spoofed.
+func (s *AgentClientAttributesTestSuite) TestAgentClientAttrs_SubTypeAgent() {
+	clientID := agentClientAttrsClientID + "_subtype"
+	attrs, err := json.Marshal(map[string]interface{}{
+		"modelProvider": "anthropic",
+		"sub_type":      "application",
+	})
+	s.Require().NoError(err)
+
+	agentID, err := s.createAgentWithAttributes(
+		clientID, []string{"sub_type", "modelProvider"}, attrs, s.ownerUserID)
+	s.Require().NoError(err)
+	defer func() { _ = deleteAgent(agentID) }()
+
+	status, body := s.requestToken(clientID)
+	s.Require().Equal(http.StatusOK, status, "CC token request must succeed: %v", body)
+	token, ok := body["access_token"].(string)
+	s.Require().True(ok)
+
+	claims, err := testutils.DecodeJWT(token)
+	s.Require().NoError(err)
+
+	s.Assert().Equal("agent", claims.Additional["sub_type"],
+		"a configured sub_type attribute must not override the server-asserted identity class")
+	s.Assert().Equal("anthropic", claims.Additional["modelProvider"])
+}
+
+// TestAgentClientAttrs_SubTypeSeededOnCreate verifies that an agent created with no client token
+// configuration still receives sub_type, because creation selects the claim for it.
+func (s *AgentClientAttributesTestSuite) TestAgentClientAttrs_SubTypeSeededOnCreate() {
+	clientID := agentClientAttrsClientID + "_subtype_seeded"
+	agentID, err := s.createAgentWithClientConfig(clientID, nil, nil, s.ownerUserID)
+	s.Require().NoError(err)
+	defer func() { _ = deleteAgent(agentID) }()
+
+	status, body := s.requestToken(clientID)
+	s.Require().Equal(http.StatusOK, status, "CC token request must succeed: %v", body)
+	token, ok := body["access_token"].(string)
+	s.Require().True(ok)
+
+	claims, err := testutils.DecodeJWT(token)
+	s.Require().NoError(err)
+
+	s.Assert().Equal("agent", claims.Additional["sub_type"],
+		"creation must select sub_type so a new agent is identifiable without being reconfigured")
+}
+
+// TestAgentClientAttrs_SubTypeRemovedByUpdate verifies that dropping sub_type from an agent's selection
+// stops the claim. Removal is an update, which must be authoritative: re-seeding would make it
+// unremovable.
+func (s *AgentClientAttributesTestSuite) TestAgentClientAttrs_SubTypeRemovedByUpdate() {
+	clientID := agentClientAttrsClientID + "_subtype_off"
+	attrs, err := json.Marshal(map[string]interface{}{"modelProvider": "anthropic"})
+	s.Require().NoError(err)
+
+	agentID, err := s.createAgentWithClientConfig(clientID, nil, attrs, s.ownerUserID)
+	s.Require().NoError(err)
+	defer func() { _ = deleteAgent(agentID) }()
+
+	status, body := s.requestToken(clientID)
+	s.Require().Equal(http.StatusOK, status, "CC token request must succeed: %v", body)
+	token, ok := body["access_token"].(string)
+	s.Require().True(ok)
+	claims, err := testutils.DecodeJWT(token)
+	s.Require().NoError(err)
+	s.Require().Equal("agent", claims.Additional["sub_type"],
+		"creation must select the claim, otherwise this test cannot show it being removed")
+
+	s.Require().NoError(s.updateClientAttributes(agentID, clientID, []string{"modelProvider"}, attrs))
+
+	status, body = s.requestToken(clientID)
+	s.Require().Equal(http.StatusOK, status, "CC token request must succeed: %v", body)
+	token, ok = body["access_token"].(string)
+	s.Require().True(ok)
+	claims, err = testutils.DecodeJWT(token)
+	s.Require().NoError(err)
+
+	s.Assert().NotContains(claims.Additional, "sub_type",
+		"sub_type must stay out once it is removed from the selection")
+	s.Assert().Equal("anthropic", claims.Additional["modelProvider"],
+		"the rest of the updated selection must still be surfaced")
 }
 
 // TestAgentClientAttrs_PartialAllowList verifies that only the allow-listed attributes are

--- a/tests/integration/agent/agent_import_export_test.go
+++ b/tests/integration/agent/agent_import_export_test.go
@@ -261,6 +261,13 @@ func (s *AgentImportExportSuite) TestExportImportRoundTrip_AgentWithConfidential
 	s.Require().NotNil(cfg)
 	s.Assert().Equal(clientID, cfg.ClientID)
 	s.Assert().Empty(cfg.ClientSecret, "GET response must not expose client secret")
+
+	// Creation selects sub_type, so the selection has to survive the export and the import as well.
+	s.Assert().Contains(yamlContent, "sub_type", "the exported selection must carry the claim")
+	s.Require().NotNil(cfg.Token)
+	s.Require().NotNil(cfg.Token.AccessToken)
+	s.Require().NotNil(cfg.Token.AccessToken.ClientConfig)
+	s.Assert().Contains(cfg.Token.AccessToken.ClientConfig.Attributes, "sub_type")
 }
 
 // TestImportAgent_UpsertUpdates verifies that importing the same YAML twice with

--- a/tests/integration/application/application_import_export_test.go
+++ b/tests/integration/application/application_import_export_test.go
@@ -384,6 +384,127 @@ func (s *ApplicationImportExportSuite) TestExportImportRoundTrip_PublicClientAut
 
 // --- Helpers ---
 
+// TestExportImportRoundTrip_ClientCredentialsSubType covers the sub_type claim across the whole
+// lifecycle: creation selects it, export carries the selection, and import restores it. Nothing else
+// asserts that the selection survives an export, which is how a GitOps adoption inherits the claim.
+func (s *ApplicationImportExportSuite) TestExportImportRoundTrip_ClientCredentialsSubType() {
+	appName := "App RT CC " + s.handleSuffix
+	clientID := "app-rt-cc-client-" + s.handleSuffix
+	clientSecret := "app-rt-cc-secret-" + s.handleSuffix
+
+	createdID, err := createApplication(Application{
+		OUID:        s.ouID,
+		Name:        appName,
+		Description: "Round-trip client_credentials application",
+		Type:        "m2m",
+		InboundAuthConfig: []InboundAuthConfig{
+			{
+				Type: "oauth2",
+				OAuthAppConfig: &OAuthAppConfig{
+					ClientID:                clientID,
+					ClientSecret:            clientSecret,
+					GrantTypes:              []string{"client_credentials"},
+					TokenEndpointAuthMethod: "client_secret_basic",
+				},
+			},
+		},
+	})
+	s.Require().NoError(err, "failed to create source application")
+
+	getResp, err := s.appGet(createdID)
+	s.Require().NoError(err)
+	var pre Application
+	s.Require().NoError(json.Unmarshal(getResp, &pre))
+	s.Require().Contains(clientAttributesOf(pre), "sub_type",
+		"creation must select sub_type for a client_credentials application")
+
+	exportResp, err := s.exportApps(appExportRequest{Applications: []string{createdID}})
+	s.Require().NoError(err)
+	yamlContent := exportResp.Resources
+	s.Assert().Contains(yamlContent, "sub_type", "the exported selection must carry the claim")
+
+	s.Require().NoError(deleteApplication(createdID))
+
+	// The exporter parameterizes redirectUris even for a client that has none, so the variable has to
+	// be supplied as an empty list for the template to resolve.
+	vars := s.extractTemplateVariables(yamlContent, map[string]interface{}{
+		"clientId":     clientID,
+		"clientSecret": clientSecret,
+		"redirectUris": []string{},
+	})
+	importResp, err := s.importApps(appImportRequest{
+		Content:   yamlContent,
+		Options:   appImportOptions{Upsert: true, ContinueOnError: false, Target: "runtime"},
+		Variables: vars,
+	})
+	s.Require().NoError(err)
+	s.Require().Equal(1, importResp.Summary.Imported, "import results: %+v", importResp.Results)
+
+	importedID := importResp.Results[0].ResourceID
+	s.Require().NotEmpty(importedID)
+	defer func() { _ = deleteApplication(importedID) }()
+
+	restoredResp, err := s.appGet(importedID)
+	s.Require().NoError(err)
+	var restored Application
+	s.Require().NoError(json.Unmarshal(restoredResp, &restored))
+
+	s.Assert().Contains(clientAttributesOf(restored), "sub_type",
+		"the selection must survive the export and import round-trip")
+}
+
+// TestImportApplication_SeedsSubTypeWhenOmitted covers a hand-written declarative document that does
+// not mention the claim. An import with target runtime creates the application through the same
+// service as the API, so the claim is selected for it rather than being absent until edited.
+func (s *ApplicationImportExportSuite) TestImportApplication_SeedsSubTypeWhenOmitted() {
+	clientID := "app-imp-seed-client-" + s.handleSuffix
+	yamlContent := fmt.Sprintf(`resource_type: application
+name: App Imp Seed %s
+type: m2m
+ouId: %s
+inboundAuthConfig:
+  - type: oauth2
+    config:
+      clientId: %s
+      clientSecret: app-imp-seed-secret-%s
+      grantTypes:
+        - client_credentials
+      tokenEndpointAuthMethod: client_secret_basic
+`, s.handleSuffix, s.ouID, clientID, s.handleSuffix)
+
+	importResp, err := s.importApps(appImportRequest{
+		Content: yamlContent,
+		Options: appImportOptions{Upsert: true, ContinueOnError: false, Target: "runtime"},
+	})
+	s.Require().NoError(err)
+	s.Require().Equal(1, importResp.Summary.Imported, "import results: %+v", importResp.Results)
+
+	importedID := importResp.Results[0].ResourceID
+	s.Require().NotEmpty(importedID)
+	defer func() { _ = deleteApplication(importedID) }()
+
+	restoredResp, err := s.appGet(importedID)
+	s.Require().NoError(err)
+	var restored Application
+	s.Require().NoError(json.Unmarshal(restoredResp, &restored))
+
+	s.Assert().Contains(clientAttributesOf(restored), "sub_type",
+		"an imported client_credentials application must have the claim selected for it")
+}
+
+// clientAttributesOf returns the application's client-token attribute selection, or nil when unset.
+func clientAttributesOf(app Application) []string {
+	if len(app.InboundAuthConfig) == 0 {
+		return nil
+	}
+	cfg := app.InboundAuthConfig[0].OAuthAppConfig
+	if cfg == nil || cfg.Token == nil || cfg.Token.AccessToken == nil ||
+		cfg.Token.AccessToken.ClientConfig == nil {
+		return nil
+	}
+	return cfg.Token.AccessToken.ClientConfig.Attributes
+}
+
 func (s *ApplicationImportExportSuite) appGet(appID string) ([]byte, error) {
 	req, err := http.NewRequest(http.MethodGet, testServerURL+"/applications/"+appID, nil)
 	if err != nil {

--- a/tests/integration/oauth/introspect/introspect_test.go
+++ b/tests/integration/oauth/introspect/introspect_test.go
@@ -281,6 +281,46 @@ func (ts *IntrospectionTestSuite) createTestAuthenticationFlow() string {
 	return flowID
 }
 
+// setClientAttributes replaces an application's client-token attribute selection.
+func (ts *IntrospectionTestSuite) setClientAttributes(appID, name, clientID, clientSecret string,
+	attributes []string) {
+	app := map[string]interface{}{
+		"name":        name,
+		"description": "Application for token introspection integration tests",
+		"ouId":        ts.ouID,
+		// Matches the type createApp used: an application's type is immutable after creation.
+		"type":                      "fullstack",
+		"isRegistrationFlowEnabled": false,
+		"inboundAuthConfig": []map[string]interface{}{
+			{"type": "oauth2", "config": map[string]interface{}{
+				"clientId":                clientID,
+				"clientSecret":            clientSecret,
+				"grantTypes":              []string{"client_credentials"},
+				"tokenEndpointAuthMethod": "client_secret_basic",
+				"token": map[string]interface{}{
+					"accessToken": map[string]interface{}{
+						"clientConfig": map[string]interface{}{"attributes": attributes},
+					},
+				},
+			}},
+		},
+	}
+
+	jsonData, err := json.Marshal(app)
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest(http.MethodPut, testutils.TestServerURL+"/applications/"+appID,
+		bytes.NewBuffer(jsonData))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	ts.Require().Equalf(http.StatusOK, resp.StatusCode, "failed to update application: %s", string(body))
+}
+
 // createApp registers an OAuth2 application. authFlowID and tokenConfig are optional.
 func (ts *IntrospectionTestSuite) createApp(name, clientID, clientSecret, authMethod string,
 	grantTypes []string, authFlowID string, tokenConfig map[string]interface{}) string {
@@ -507,6 +547,56 @@ func (ts *IntrospectionTestSuite) TestIntrospect_ActiveAccessToken_MatchesTokenC
 	ts.NotContains(res.Body, "cnf", "a bearer token must not carry a cnf member")
 	ts.NotContains(res.Body, "username",
 		"no self issued token carries a username claim, so the member must stay omitted")
+}
+
+// TestIntrospect_ClientToken_CarriesSubType asserts that introspection reports the subject's identity
+// class, matching the token's own claim, so an introspecting resource server sees the same signal.
+func (ts *IntrospectionTestSuite) TestIntrospect_ClientToken_CarriesSubType() {
+	token := ts.clientCredentialsToken(ccClientID, ccClientSecret)
+
+	claims, err := testutils.DecodeJWTPayloadMap(token)
+	ts.Require().NoError(err, "failed to decode the client_credentials token payload")
+	ts.Require().Equal("application", claims["sub_type"], "an application's client token must carry sub_type")
+
+	res := ts.introspectBasic(token, ccClientID, ccClientSecret)
+	ts.Require().Equalf(http.StatusOK, res.StatusCode, "introspection body: %s", string(res.Raw))
+	ts.Require().True(res.active())
+	ts.Equal(claims["sub_type"], res.Body["sub_type"], "introspection sub_type must match the token claim")
+}
+
+// TestIntrospect_ClientToken_OmitsUnselectedSubType asserts that a client whose selection omits
+// sub_type is reported without it by introspection too, so no class is recoverable that the token does
+// not assert. Removal is an update, since creation selects the claim.
+func (ts *IntrospectionTestSuite) TestIntrospect_ClientToken_OmitsUnselectedSubType() {
+	const clientID = "introspect_cc_no_subtype_client"
+	const clientSecret = "introspect_cc_no_subtype_secret"
+
+	appID := ts.createApp("IntrospectNoSubTypeApp", clientID, clientSecret, "client_secret_basic",
+		[]string{"client_credentials"}, "", nil)
+	defer ts.deleteApp(appID)
+	ts.setClientAttributes(appID, "IntrospectNoSubTypeApp", clientID, clientSecret, []string{})
+
+	token := ts.clientCredentialsToken(clientID, clientSecret)
+
+	claims, err := testutils.DecodeJWTPayloadMap(token)
+	ts.Require().NoError(err, "failed to decode the client_credentials token payload")
+	ts.Require().NotContains(claims, "sub_type",
+		"the token must not carry sub_type when the client's selection omits it")
+
+	res := ts.introspectBasic(token, clientID, clientSecret)
+	ts.Require().Equalf(http.StatusOK, res.StatusCode, "introspection body: %s", string(res.Raw))
+	ts.Require().True(res.active())
+	ts.NotContains(res.Body, "sub_type", "introspection must not report a class the token does not assert")
+}
+
+// TestIntrospect_UserToken_OmitsSubType asserts that a user-subject token reports no identity class:
+// its subject is a user, so the member must not report the client's class.
+func (ts *IntrospectionTestSuite) TestIntrospect_UserToken_OmitsSubType() {
+	res := ts.introspectPost(ts.userAccessToken, userClientID, userClientSecret)
+
+	ts.Require().Equalf(http.StatusOK, res.StatusCode, "introspection body: %s", string(res.Raw))
+	ts.Require().True(res.active())
+	ts.NotContains(res.Body, "sub_type", "a user-subject token must not report an identity class")
 }
 
 //

--- a/tests/integration/oauth/token/cc_client_attributes_test.go
+++ b/tests/integration/oauth/token/cc_client_attributes_test.go
@@ -73,6 +73,16 @@ func (s *CCClientAttributesTestSuite) TearDownSuite() {
 // createOAuthApp creates a client_credentials OAuth application with the given
 // clientConfig.attributes allow-list.
 func (s *CCClientAttributesTestSuite) createOAuthApp(clientID, clientSecret string, clientAttributes []string) (string, error) {
+	return s.createOAuthAppWithClientConfig(clientID, clientSecret, map[string]interface{}{
+		"attributes": clientAttributes,
+	})
+}
+
+// createOAuthAppWithClientConfig creates a client_credentials OAuth application with the given
+// token.accessToken.clientConfig block.
+func (s *CCClientAttributesTestSuite) createOAuthAppWithClientConfig(
+	clientID, clientSecret string, clientConfig map[string]interface{},
+) (string, error) {
 	app := map[string]interface{}{
 		"name":                      "CC Client Attrs Test App " + clientID,
 		"description":               "Application for CC client-attribute testing",
@@ -89,9 +99,7 @@ func (s *CCClientAttributesTestSuite) createOAuthApp(clientID, clientSecret stri
 					"tokenEndpointAuthMethod": "client_secret_basic",
 					"token": map[string]interface{}{
 						"accessToken": map[string]interface{}{
-							"clientConfig": map[string]interface{}{
-								"attributes": clientAttributes,
-							},
+							"clientConfig": clientConfig,
 						},
 					},
 				},
@@ -126,6 +134,33 @@ func (s *CCClientAttributesTestSuite) createOAuthApp(clientID, clientSecret stri
 		return "", err
 	}
 	return respData["id"].(string), nil
+}
+
+// updateClientAttributes replaces the application's client-token attribute selection, as the Console
+// does when an operator toggles a chip.
+func (s *CCClientAttributesTestSuite) updateClientAttributes(appID, clientID string, attributes []string) error {
+	return testutils.UpdateApplication(appID, testutils.Application{
+		Name:        "CC Client Attrs Test App " + clientID,
+		Description: "Application for CC client-attribute testing",
+		OUID:        s.ouID,
+		Type:        "m2m",
+		InboundAuthConfig: []map[string]interface{}{
+			{
+				"type": "oauth2",
+				"config": map[string]interface{}{
+					"clientId":                clientID,
+					"clientSecret":            ccClientAttrsClientSecret,
+					"grantTypes":              []string{"client_credentials"},
+					"tokenEndpointAuthMethod": "client_secret_basic",
+					"token": map[string]interface{}{
+						"accessToken": map[string]interface{}{
+							"clientConfig": map[string]interface{}{"attributes": attributes},
+						},
+					},
+				},
+			},
+		},
+	})
 }
 
 // requestToken performs a client_credentials token request for the given client credentials.
@@ -234,6 +269,58 @@ func (s *CCClientAttributesTestSuite) TestCCClientAttrs_PartialAllowList() {
 	s.Assert().NotContains(claims.Additional, "ouHandle", "ouHandle must be excluded when not allow-listed")
 	s.Assert().NotContains(claims.Additional, "groups", "groups must be excluded when not allow-listed")
 	s.Assert().NotContains(claims.Additional, "roles", "roles must be excluded when not allow-listed")
+}
+
+// TestCCClientAttrs_SubTypeApp verifies that an application's client_credentials token carries
+// sub_type=application. Created with no clientConfig, so this covers the creation-time seeding too.
+func (s *CCClientAttributesTestSuite) TestCCClientAttrs_SubTypeApp() {
+	clientID := ccClientAttrsClientID + "_subtype"
+	appID, err := s.createOAuthApp(clientID, ccClientAttrsClientSecret, nil)
+	s.Require().NoError(err)
+	defer func() { _ = testutils.DeleteApplication(appID) }()
+
+	status, body := s.requestToken(clientID, ccClientAttrsClientSecret)
+	s.Require().Equal(http.StatusOK, status)
+	token, ok := body["access_token"].(string)
+	s.Require().True(ok)
+
+	claims, err := testutils.DecodeJWT(token)
+	s.Require().NoError(err)
+
+	s.Assert().Equal("application", claims.Additional["sub_type"],
+		"an application's client_credentials token must be identifiable as an application")
+}
+
+// TestCCClientAttrs_SubTypeRemovedByUpdate verifies that dropping sub_type from the selection stops
+// the claim. Removal is an update, which must be authoritative: re-seeding would make it unremovable.
+func (s *CCClientAttributesTestSuite) TestCCClientAttrs_SubTypeRemovedByUpdate() {
+	clientID := ccClientAttrsClientID + "_subtype_off"
+	appID, err := s.createOAuthApp(clientID, ccClientAttrsClientSecret, nil)
+	s.Require().NoError(err)
+	defer func() { _ = testutils.DeleteApplication(appID) }()
+
+	status, body := s.requestToken(clientID, ccClientAttrsClientSecret)
+	s.Require().Equal(http.StatusOK, status)
+	token, ok := body["access_token"].(string)
+	s.Require().True(ok)
+	claims, err := testutils.DecodeJWT(token)
+	s.Require().NoError(err)
+	s.Require().Equal("application", claims.Additional["sub_type"],
+		"creation must select the claim, otherwise this test cannot show it being removed")
+
+	s.Require().NoError(s.updateClientAttributes(appID, clientID, []string{"ouId"}))
+
+	status, body = s.requestToken(clientID, ccClientAttrsClientSecret)
+	s.Require().Equal(http.StatusOK, status)
+	token, ok = body["access_token"].(string)
+	s.Require().True(ok)
+	claims, err = testutils.DecodeJWT(token)
+	s.Require().NoError(err)
+
+	s.Assert().NotContains(claims.Additional, "sub_type",
+		"sub_type must be omitted entirely, not emitted empty, once it is removed from the selection")
+	s.Assert().Equal(s.ouID, claims.Additional["ouId"],
+		"the rest of the updated selection must still be surfaced")
 }
 
 // TestCCClientAttrs_NoAllowListConfigured verifies that no client-scoped claims are added


### PR DESCRIPTION
### Purpose

An M2M application token and an agent token were indistinguishable: both are confidential `client_credentials` clients minting `{sub, aud, client_id, grant_type}` with no type marker, so a resource server could not tell which identity class the caller belonged to and could not apply policy that differs by class.

This emits a `sub_type` claim on `client_credentials` tokens, with values `application` and `agent`.

```json
{
  "sub": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
  "sub_type": "agent",
  "aud": "https://api.example.com",
  "client_id": "agent_7c9e6679",
  "grant_type": "client_credentials"
}
```

The claim is selected through the client's own access token attribute list, and creation adds it there, so a client nobody has configured still asserts its class while an operator can drop the claim by clearing its chip on the **Token** tab.

| Tab | Chip | Preview shows |
|---|---|---|
| Application → **Token**, application audience | `sub_type` | `"sub_type": "application"` |
| Agent → **Tokens** | `sub_type` | `"sub_type": "agent"` |

### Approach

```mermaid
flowchart TD
  C["POST /applications, POST /agents"] --> S["seedClientSubTypeAttribute"]
  S --> A["clientConfig.attributes += sub_type"]
  R["POST /oauth2/token"] --> M["ClientAuthMiddleware"]
  M --> G["clientCredentialsGrantHandler.HandleGrant"]
  G --> B["buildAccessTokenClaims"]
  A -. "read at issuance" .-> B
  B --> J["jwtService.GenerateJWT"]
  M -. "EntityCategory set, then carried unread" .-> B
```

`EntityCategory` is resolved once when the client authenticates and rides the `OAuthClient` untouched until `buildAccessTokenClaims`, where `clientSubjectType` maps it to the claim value. Key decisions:

- **The builder derives the claim, not the grant handler.** Gated on `grant_type == client_credentials`, the only grant where the OAuth client is the token's subject. No grant handler had to change, and a future grant cannot forget it. An `authorization_code` token from a client that also holds `client_credentials` therefore carries no `sub_type`: that token's subject is a user, so an identity class describing the client would be wrong.
- **Selected like any other client attribute, seeded at creation.** `sub_type` is not special-cased with a dedicated configuration flag. It lives in `clientConfig.attributes` alongside `groups`, `roles`, and the OU claims, and `seedClientSubTypeAttribute` adds it when an agent, or an application that can use the grant, is created. Seeding is keyed on the grant rather than the application type, so a `fullstack` or `custom` application holding `client_credentials` is covered too, and it runs at creation only, so a claim removed later stays removed.
- **Selection enables the claim; it never supplies the value.** `sub_type` is in `ReservedAccessTokenClaimNames()`, so a stored attribute of that name is dropped before the attribute merge and the value comes only from the server's record of the client's category. An agent that declares a `sub_type` schema attribute set to `application` still receives `sub_type: agent`.
- **Omitted rather than guessed.** `clientSubjectType` returns empty for any category that is not `app` or `agent`, so the server never asserts a class it cannot determine.
- **Introspection re-surfaces the claim** from the token payload rather than recomputing it from the client, so the two verification paths cannot disagree.

A resource server must therefore treat a missing `sub_type` as an unknown identity class rather than assuming one. Absence has three legitimate causes: the operator cleared the chip, the client predates the claim, or the client is a declarative resource that does not list it. The claim is one chip away in each case, and the guides say so.

Naming was researched against the IANA JWT registry, the relevant IETF drafts, and four vendor implementations, and is open for comment in [#5093](https://github.com/thunder-id/thunderid/discussions/5093). No standard defines this claim. `application_type` was unavailable (OIDC DCR, `web`/`native`, being implemented in #3664), `client_type` is OAuth 2.0 core terminology, and `entity_type` collides with both OpenID Federation's term of art and our own `EntityType` resource. `sub_type` names its referent, which also lets the actor axis reuse the name inside `act` later.

#### Claim precedence

The access token claim map merged the subject's configured attributes **over** claims the token builder writes itself (`scope`, `client_id`, `grant_type`), and wrote others afterwards only inside conditions that do not always fire (`act`, `cnf`, `idp`, `aci`, `claims_req`, `claims_locales`). An attribute allow-listed under one of those names therefore decided the claim's value. Builder-written names are now skipped when the attributes are merged:

```go
ownedClaims := builderOwnedClaimNames()
for key, value := range ctx.SubjectAttributes {
    if ownedClaims[key] {
        continue
    }
    claims[key] = value
}
```

Filtering at the merge rather than overwriting afterwards makes these claims deterministic regardless of the order in which they are written, so a claim added later under a condition behaves the same as the rest. Two details worth a reviewer's attention:

- `idp` and `tfid` were missing from `ReservedAccessTokenClaimNames()` and are now included.
- The OU claims are deliberately **not** builder-owned. A user-subject token receives `ouId`, `ouName` and `ouHandle` through the attribute channel, resolved by the authentication flow, so filtering them would drop claims those tokens are expected to carry. A test guards the exclusion.

Validating attribute allow-lists when they are saved, rather than ignoring unusable entries at issuance, would be a friendlier failure mode but changes API behaviour for every attribute, not just this one, so it is left as a possible follow-up.

### Related Issues
- Fixes #3578

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [Agent's own token: claims](https://github.com/thunder-id/thunderid/blob/agent-entity-type/docs/content/guides/agents/authentication/agent-own-token.mdx) and [Client Credentials](https://github.com/thunder-id/thunderid/blob/agent-entity-type/docs/content/guides/protocols/oauth-oidc/client-credentials.mdx), including the declarative-resource case, plus the `sub_type` schema in `api/oauth2.yaml`
    - [x] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
        - Builder: both classes, the literal wire-value contract, and omission for an unselected claim, no client config, a non-client category, an unset category, a user-subject grant, a missing OAuth client, and a selection made on `userConfig`
        - Builder: a stored `sub_type` attribute cannot override the claim, and no builder-written claim is suppliable by an attribute of the same name (including the scopeless case, where the `scope` write is conditional)
        - Seeding: `EnsureClientSubTypeAttribute` builds a missing config, preserves a caller's selection, is idempotent, and leaves `userConfig` alone; the application and agent services seed for CC-only and mixed grants, skip `authorization_code`-only clients, and default empty agent grants to `client_credentials`
        - Introspection: the member is surfaced and omitted; Console: chip toggles both ways, preview carries the literal class value and omits an unselected claim
    - [x] Integration Tests
        - `TestCCClientAttrs_SubTypeApp`, `TestAgentClientAttrs_SubTypeAgent`, `TestAgentClientAttrs_SubTypeSeededOnCreate`
        - `TestCCClientAttrs_SubTypeRemovedByUpdate`, `TestAgentClientAttrs_SubTypeRemovedByUpdate` (an update is authoritative: re-seeding would make the claim unremovable)
        - `TestIntrospect_ClientToken_CarriesSubType`, `TestIntrospect_ClientToken_OmitsUnselectedSubType`, `TestIntrospect_UserToken_OmitsSubType`
- [ ] Breaking changes. (Fill if applicable)
    - Additive claim only. No existing claim changes and nothing is removed. Clients created before this change carry no `sub_type` until the chip is selected, which is deliberate: no migration backfills them.
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
