### PR TITLE
Update PR forward port workflow

### DIFF
--- a/.github/workflows/forward-port-pr.yml
+++ b/.github/workflows/forward-port-pr.yml
@@ -10,7 +10,7 @@
 name: Forward-port Merged PRs
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches:
       # Patch branches whose merged PRs get forward-ported to main.


### PR DESCRIPTION
### Purpose
This pull request updates the workflow trigger in `.github/workflows/forward-port-pr.yml` to use the `pull_request_target` event instead of `pull_request`. This change ensures that the workflow has the necessary permissions and context to forward-port merged pull requests.

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
