### PR TITLE
Add integration tests for SMS OTP, email OTP, recovery, and notification senders

### DIFF
--- a/tests/integration/flow/authentication/email_otp_auth_test.go
+++ b/tests/integration/flow/authentication/email_otp_auth_test.go
@@ -1,0 +1,357 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authentication
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/flow/common"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// buildEmailOTPFlow assembles an OTP authentication flow delivered over email. It mirrors the SMS
+// OTP flow, with the send half swapped for the EmailExecutor, which exercises the email side of the
+// channel agnostic OTPExecutor.
+func buildEmailOTPFlow() testutils.Flow {
+	return testutils.Flow{
+		Name:     "Email OTP Auth Flow Test",
+		FlowType: "AUTHENTICATION",
+		Handle:   "auth_flow_email_otp_test",
+		Nodes: []map[string]interface{}{
+			{"id": "start", "type": "START", "onSuccess": "prompt_email"},
+			{
+				"id":   "prompt_email",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{"ref": "input_email", "identifier": "email", "type": "EMAIL_INPUT", "required": true},
+						},
+						"action": map[string]interface{}{"ref": "action_email", "nextNode": "generate_otp"},
+					},
+				},
+			},
+			{
+				"id":   "generate_otp",
+				"type": "TASK_EXECUTION",
+				"executor": map[string]interface{}{
+					"name": "OTPExecutor",
+					"mode": "generate",
+					"inputs": []map[string]interface{}{
+						{"ref": "input_email", "identifier": "email", "type": "EMAIL_INPUT", "required": true},
+					},
+				},
+				"onSuccess": "email_send",
+			},
+			{
+				"id":         "email_send",
+				"type":       "TASK_EXECUTION",
+				"properties": map[string]interface{}{"emailTemplate": "OTP"},
+				"executor": map[string]interface{}{
+					"name": "EmailExecutor",
+					"mode": "send",
+					"inputs": []map[string]interface{}{
+						{"ref": "input_email", "identifier": "email", "type": "EMAIL_INPUT", "required": true},
+					},
+				},
+				"onSuccess": "prompt_otp",
+			},
+			{
+				"id":   "prompt_otp",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{"ref": "input_otp", "identifier": "otp", "type": "OTP_INPUT", "required": true},
+						},
+						"action": map[string]interface{}{"ref": "action_otp", "nextNode": "verify_otp"},
+					},
+				},
+			},
+			{
+				"id":        "verify_otp",
+				"type":      "TASK_EXECUTION",
+				"executor":  map[string]interface{}{"name": "OTPExecutor", "mode": "verify"},
+				"onSuccess": "auth_assert",
+			},
+			{
+				"id":        "auth_assert",
+				"type":      "TASK_EXECUTION",
+				"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+				"onSuccess": "end",
+			},
+			{"id": "end", "type": "END"},
+		},
+	}
+}
+
+var (
+	emailOTPTestOU = testutils.OrganizationUnit{
+		Handle:      "email-otp-auth-test-ou",
+		Name:        "Email OTP Auth Test OU",
+		Description: "Organization unit for email OTP authentication flow tests",
+	}
+
+	emailOTPEntityType = testutils.UserType{
+		Name: "email_otp_user",
+		Schema: map[string]interface{}{
+			"username": map[string]interface{}{"type": "string"},
+			"email":    map[string]interface{}{"type": "string"},
+		},
+	}
+)
+
+type EmailOTPAuthFlowTestSuite struct {
+	suite.Suite
+	config *common.TestSuiteConfig
+
+	mockSMTP      *testutils.MockSMTPServer
+	appID         string
+	entityTypeID  string
+	testEmail     string
+	originalEmail interface{}
+}
+
+func TestEmailOTPAuthFlowTestSuite(t *testing.T) {
+	suite.Run(t, new(EmailOTPAuthFlowTestSuite))
+}
+
+func (ts *EmailOTPAuthFlowTestSuite) SetupSuite() {
+	ts.config = &common.TestSuiteConfig{}
+	ts.testEmail = common.GenerateUniqueUsername("emailotpuser") + "@example.com"
+
+	ouID, err := testutils.CreateOrganizationUnit(emailOTPTestOU)
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	emailOTPTestOU.ID = ouID
+
+	emailOTPEntityType.OUID = ouID
+	entityTypeID, err := testutils.CreateUserType(emailOTPEntityType)
+	ts.Require().NoError(err, "Failed to create test user type")
+	ts.entityTypeID = entityTypeID
+
+	userIDs, err := testutils.CreateMultipleUsers(testutils.User{
+		OUID: ouID,
+		Type: emailOTPEntityType.Name,
+		Attributes: json.RawMessage(`{
+			"username": "emailotpuser",
+			"email": "` + ts.testEmail + `"
+		}`),
+	})
+	ts.Require().NoError(err, "Failed to create test user")
+	ts.config.CreatedUserIDs = userIDs
+
+	// Point the server at a mock SMTP server so the delivered OTP can be read back. Start binds the
+	// listener before returning, so the port is reachable as soon as it succeeds.
+	ts.mockSMTP = testutils.NewMockSMTPServer(0)
+	ts.Require().NoError(ts.mockSMTP.Start(), "Failed to start mock SMTP server")
+
+	// The distribution ships a populated email section and a patch replaces the whole key rather than
+	// merging into it, so keep the original to restore in teardown.
+	originalEmail, err := testutils.ReadDeploymentConfigKey("email")
+	ts.Require().NoError(err, "Failed to read the existing email config")
+	ts.originalEmail = originalEmail
+
+	ts.Require().NoError(testutils.PatchDeploymentConfig(map[string]interface{}{
+		"email": map[string]interface{}{
+			"smtp": map[string]interface{}{
+				"host":                  "localhost",
+				"port":                  ts.mockSMTP.GetPort(),
+				"from_address":          "noreply@thunderid.test",
+				"enable_start_tls":      false,
+				"enable_authentication": false,
+			},
+		},
+	}), "Failed to patch email config")
+	ts.Require().NoError(testutils.RestartServer(), "Failed to restart server with email config")
+	ts.Require().NoError(testutils.ObtainAdminAccessToken(), "Failed to re-obtain admin token after restart")
+
+	flowID, err := testutils.CreateFlow(buildEmailOTPFlow())
+	ts.Require().NoError(err, "Failed to create email OTP flow")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
+
+	appID, err := testutils.CreateApplication(testutils.Application{
+		OUID:                      ouID,
+		Name:                      "Email OTP Auth Flow Test Application",
+		Description:               "Application for testing email OTP authentication flows",
+		IsRegistrationFlowEnabled: false,
+		ClientID:                  "email_otp_auth_flow_test_client",
+		ClientSecret:              "email_otp_auth_flow_test_secret",
+		RedirectURIs:              []string{"http://localhost:3000/callback"},
+		AllowedUserTypes:          []string{emailOTPEntityType.Name},
+		AuthFlowID:                flowID,
+		AssertionConfig: map[string]interface{}{
+			"userAttributes": []string{"userType", "ouId", "ouName", "ouHandle"},
+		},
+	})
+	ts.Require().NoError(err, "Failed to create test application")
+	ts.appID = appID
+}
+
+func (ts *EmailOTPAuthFlowTestSuite) TearDownSuite() {
+	if err := testutils.CleanupUsers(ts.config.CreatedUserIDs); err != nil {
+		ts.T().Logf("Failed to cleanup users during teardown: %v", err)
+	}
+
+	if ts.appID != "" {
+		if err := testutils.DeleteApplication(ts.appID); err != nil {
+			ts.T().Logf("Failed to delete application during teardown: %v", err)
+		}
+	}
+
+	for _, flowID := range ts.config.CreatedFlowIDs {
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete flow %s during teardown: %v", flowID, err)
+		}
+	}
+
+	if ts.entityTypeID != "" {
+		if err := testutils.DeleteUserType(ts.entityTypeID); err != nil {
+			ts.T().Logf("Failed to delete user type during teardown: %v", err)
+		}
+	}
+
+	if emailOTPTestOU.ID != "" {
+		if err := testutils.DeleteOrganizationUnit(emailOTPTestOU.ID); err != nil {
+			ts.T().Logf("Failed to delete organization unit during teardown: %v", err)
+		}
+	}
+
+	if ts.mockSMTP != nil {
+		if err := ts.mockSMTP.Stop(); err != nil {
+			ts.T().Logf("Failed to stop mock SMTP server during teardown: %v", err)
+		}
+	}
+
+	if err := testutils.PatchDeploymentConfig(map[string]interface{}{
+		"email": ts.originalEmail,
+	}); err != nil {
+		ts.T().Logf("Failed to restore email config during teardown: %v", err)
+	}
+	if err := testutils.RestartServer(); err != nil {
+		ts.T().Logf("Server did not restart cleanly after config restore: %v", err)
+	}
+	if err := testutils.ObtainAdminAccessToken(); err != nil {
+		ts.T().Logf("Failed to re-obtain admin token after restore: %v", err)
+	}
+}
+
+// submitEmail drives the flow to the OTP prompt for the given address.
+func (ts *EmailOTPAuthFlowTestSuite) submitEmail(email string) *common.FlowStep {
+	ts.mockSMTP.ClearEmails()
+
+	step, err := common.InitiateAuthenticationFlow(ts.appID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "Expected flow status to be INCOMPLETE")
+	ts.Require().True(common.HasInput(step.Data.Inputs, "email"), "Email input should be required")
+
+	step, err = common.CompleteFlow(step.ExecutionID, map[string]string{"email": email},
+		"action_email", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit the email address")
+
+	return step
+}
+
+// waitForOTP polls the mock SMTP server until an OTP email arrives.
+func (ts *EmailOTPAuthFlowTestSuite) waitForOTP() string {
+	for i := 0; i < 20; i++ {
+		if email := ts.mockSMTP.GetLastEmail(); email != nil {
+			if otp := email.ExtractOTP(); otp != "" {
+				return otp
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return ""
+}
+
+// wrongOTP derives a code of the same length as the delivered one, differing in every position, so
+// an invalid-OTP test can never accidentally submit the real code.
+func wrongOTP(otp string) string {
+	wrong := []rune(otp)
+	for i, r := range wrong {
+		if r == '0' {
+			wrong[i] = '1'
+		} else {
+			wrong[i] = '0'
+		}
+	}
+	return string(wrong)
+}
+
+// TestEmailOTPAuthFlow_Success authenticates end to end with a code delivered by email.
+func (ts *EmailOTPAuthFlowTestSuite) TestEmailOTPAuthFlow_Success() {
+	step := ts.submitEmail(ts.testEmail)
+	ts.Require().True(common.HasInput(step.Data.Inputs, "otp"), "OTP input should be requested")
+
+	otp := ts.waitForOTP()
+	ts.Require().NotEmpty(otp, "An OTP should have been delivered by email")
+
+	finalStep, err := common.CompleteFlow(step.ExecutionID, map[string]string{"otp": otp},
+		"action_otp", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit the OTP")
+	ts.Require().Equal("COMPLETE", finalStep.FlowStatus, "Expected flow status to be COMPLETE")
+	ts.Require().Nil(finalStep.Error, "Error should be nil for a successful authentication")
+	ts.Require().NotEmpty(finalStep.Assertion, "A JWT assertion should be returned")
+
+	claims, err := testutils.ValidateJWTAssertionFields(finalStep.Assertion, ts.appID,
+		emailOTPEntityType.Name, emailOTPTestOU.ID, emailOTPTestOU.Name, emailOTPTestOU.Handle)
+	ts.Require().NoError(err, "Failed to validate JWT assertion fields")
+	ts.Require().NotNil(claims, "JWT claims should not be nil")
+}
+
+// TestEmailOTPAuthFlow_InvalidOTP rejects a wrong code and re-prompts.
+func (ts *EmailOTPAuthFlowTestSuite) TestEmailOTPAuthFlow_InvalidOTP() {
+	step := ts.submitEmail(ts.testEmail)
+	otp := ts.waitForOTP()
+	ts.Require().NotEmpty(otp, "An OTP should have been delivered by email")
+
+	finalStep, err := common.CompleteFlow(step.ExecutionID, map[string]string{"otp": wrongOTP(otp)},
+		"action_otp", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit an invalid OTP")
+	ts.Require().Equal("INCOMPLETE", finalStep.FlowStatus, "An invalid OTP should remain retryable")
+	ts.Require().NotNil(finalStep.Error, "An invalid OTP should report an error")
+	ts.Require().Empty(finalStep.Assertion, "No assertion should be issued for an invalid OTP")
+	ts.Require().True(common.HasInput(finalStep.Data.Inputs, "otp"), "The OTP input should be re-prompted")
+}
+
+// TestEmailOTPAuthFlow_RetryAfterInvalidOTP confirms the correct code still works after a wrong one.
+func (ts *EmailOTPAuthFlowTestSuite) TestEmailOTPAuthFlow_RetryAfterInvalidOTP() {
+	step := ts.submitEmail(ts.testEmail)
+	otp := ts.waitForOTP()
+	ts.Require().NotEmpty(otp, "An OTP should have been delivered by email")
+
+	retryStep, err := common.CompleteFlow(step.ExecutionID, map[string]string{"otp": wrongOTP(otp)},
+		"action_otp", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit an invalid OTP")
+	ts.Require().Equal("INCOMPLETE", retryStep.FlowStatus, "An invalid OTP should remain retryable")
+
+	finalStep, err := common.CompleteFlow(step.ExecutionID, map[string]string{"otp": otp},
+		"action_otp", retryStep.ChallengeToken)
+	ts.Require().NoError(err, "Failed to retry with the valid OTP")
+	ts.Require().Equal("COMPLETE", finalStep.FlowStatus, "Expected COMPLETE after retrying with the valid OTP")
+	ts.Require().NotEmpty(finalStep.Assertion, "A JWT assertion should be returned on a successful retry")
+}
+
+// TestEmailOTPAuthFlow_NonExistentEmail confirms an unknown address does not authenticate and does
+// not receive a code.
+func (ts *EmailOTPAuthFlowTestSuite) TestEmailOTPAuthFlow_NonExistentEmail() {
+	ts.mockSMTP.ClearEmails()
+
+	step, err := common.InitiateAuthenticationFlow(ts.appID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+
+	finalStep, err := common.CompleteFlow(step.ExecutionID,
+		map[string]string{"email": "no-such-user@example.com"}, "action_email", step.ChallengeToken)
+	ts.Require().NoError(err, "An unknown address should be reported in band, not as a failed request")
+	ts.Require().Equal("ERROR", finalStep.FlowStatus, "An unknown email address must not authenticate")
+	ts.Require().NotNil(finalStep.Error, "The flow should report why it stopped")
+	ts.Require().Empty(finalStep.Assertion, "No assertion should be issued for an unknown address")
+
+	// Absence cannot be signalled, so allow the window in which a send would have happened.
+	time.Sleep(500 * time.Millisecond)
+	ts.Require().Nil(ts.mockSMTP.GetLastEmail(), "No email should be sent for an unknown address")
+}

--- a/tests/integration/flow/authentication/sms_auth_test.go
+++ b/tests/integration/flow/authentication/sms_auth_test.go
@@ -777,6 +777,206 @@ func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowRetryAfterInvalidOTP() {
 	ts.Require().Nil(successFlowStep.Error, "No error on success")
 }
 
+// buildOTPPropertiesFlow builds a mobile-number based OTP flow whose generate node carries the given
+// properties, so the OTP configuration options can be exercised one at a time.
+func buildOTPPropertiesFlow(name, handle string, otpProperties map[string]interface{}) testutils.Flow {
+	return testutils.Flow{
+		Name:     name,
+		FlowType: "AUTHENTICATION",
+		Handle:   handle,
+		Nodes: []map[string]interface{}{
+			{"id": "start", "type": "START", "onSuccess": "prompt_mobile"},
+			{
+				"id":   "prompt_mobile",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{"ref": "input_001", "identifier": "mobile_number", "type": "PHONE_INPUT", "required": true},
+						},
+						"action": map[string]interface{}{"ref": "action_001", "nextNode": "generate_otp"},
+					},
+				},
+			},
+			{
+				"id":         "generate_otp",
+				"type":       "TASK_EXECUTION",
+				"properties": otpProperties,
+				"executor": map[string]interface{}{
+					"name": "OTPExecutor",
+					"mode": "generate",
+					"inputs": []map[string]interface{}{
+						{"ref": "input_mobile", "identifier": "mobile_number", "type": "PHONE_INPUT", "required": true},
+					},
+				},
+				"onSuccess": "sms_send",
+			},
+			{
+				"id":         "sms_send",
+				"type":       "TASK_EXECUTION",
+				"properties": map[string]interface{}{"senderId": smsAuthTestSenderID, "smsTemplate": "OTP"},
+				"executor":   map[string]interface{}{"name": "SMSExecutor"},
+				"onSuccess":  "prompt_otp",
+			},
+			{
+				"id":   "prompt_otp",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{"ref": "input_002", "identifier": "otp", "type": "OTP_INPUT", "required": true},
+						},
+						"action": map[string]interface{}{"ref": "action_002", "nextNode": "verify_otp"},
+					},
+				},
+			},
+			{
+				"id":        "verify_otp",
+				"type":      "TASK_EXECUTION",
+				"executor":  map[string]interface{}{"name": "OTPExecutor", "mode": "verify"},
+				"onSuccess": "auth_assert",
+			},
+			{
+				"id":        "auth_assert",
+				"type":      "TASK_EXECUTION",
+				"executor":  map[string]interface{}{"name": "AuthAssertExecutor"},
+				"onSuccess": "end",
+			},
+			{"id": "end", "type": "END"},
+		},
+	}
+}
+
+// useOTPPropertiesFlow creates a flow with the given OTP properties, points the test application at
+// it, and restores the default mobile flow when the test ends. The restore matters because the suite
+// shares one application and testify runs its tests in alphabetical order.
+func (ts *SMSAuthFlowTestSuite) useOTPPropertiesFlow(
+	handle string, otpProperties map[string]interface{},
+) {
+	flowID, err := testutils.CreateFlow(buildOTPPropertiesFlow("OTP Properties "+handle, handle, otpProperties))
+	ts.Require().NoError(err, "Failed to create OTP properties flow %s", handle)
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
+
+	ts.Require().NoError(common.UpdateAppConfig(smsAuthTestAppID, flowID, ""),
+		"Failed to point the application at flow %s", handle)
+
+	ts.T().Cleanup(func() {
+		if err := common.UpdateAppConfig(smsAuthTestAppID, smsAuthFlowMobileID, ""); err != nil {
+			ts.T().Errorf("Failed to restore the default mobile OTP flow, later tests would run against "+
+				"the wrong flow: %v", err)
+		}
+	})
+}
+
+// sendOTPAndCaptureMessage drives the flow to the OTP prompt and returns that step along with the
+// message the mock notification server received.
+func (ts *SMSAuthFlowTestSuite) sendOTPAndCaptureMessage() (*common.FlowStep, *testutils.SMSMessage) {
+	var userAttrs map[string]interface{}
+	ts.Require().NoError(json.Unmarshal(testUserWithMobile.Attributes, &userAttrs),
+		"Failed to unmarshal user attributes")
+
+	ts.mockServer.ClearMessages()
+
+	flowStep, err := common.InitiateAuthenticationFlow(smsAuthTestAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate authentication flow")
+
+	otpStep, err := common.CompleteFlow(flowStep.ExecutionID,
+		map[string]string{"mobile_number": userAttrs["mobile_number"].(string)},
+		"action_001", flowStep.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit the mobile number")
+	ts.Require().Equal("INCOMPLETE", otpStep.FlowStatus, "Expected flow status to be INCOMPLETE")
+
+	// GetLastMessage removes what it returns, so poll for the first arrival rather than sleeping a
+	// fixed amount and hoping the send has landed.
+	var message *testutils.SMSMessage
+	for i := 0; i < 20 && message == nil; i++ {
+		if received := ts.mockServer.GetLastMessage(); received != nil {
+			message = received
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	ts.Require().NotNil(message, "An SMS should have been sent")
+	ts.Require().NotEmpty(message.OTP, "An OTP should be present in the message")
+
+	return otpStep, message
+}
+
+// TestSMSAuthFlowMaxAttemptsExceeded confirms the configured attempt limit ends the flow rather than
+// re-prompting indefinitely.
+func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowMaxAttemptsExceeded() {
+	ts.useOTPPropertiesFlow("auth_flow_sms_max_attempts_test", map[string]interface{}{"maxAttempts": 2})
+
+	otpStep, _ := ts.sendOTPAndCaptureMessage()
+
+	// First wrong attempt, which should still be retryable.
+	step, err := common.CompleteFlow(otpStep.ExecutionID, map[string]string{"otp": "000000"},
+		"action_002", otpStep.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit the first invalid OTP")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "The first invalid OTP should be retryable")
+
+	// Second wrong attempt reaches the configured limit.
+	finalStep, err := common.CompleteFlow(otpStep.ExecutionID, map[string]string{"otp": "111111"},
+		"action_002", step.ChallengeToken)
+	ts.Require().NoError(err,
+		"Exhausting the attempts should be reported in band, not as a failed request")
+	ts.Require().NotEqual("COMPLETE", finalStep.FlowStatus,
+		"Exceeding the attempt limit must not authenticate")
+	ts.Require().NotNil(finalStep.Error, "Exceeding the attempt limit should report an error")
+}
+
+// TestSMSAuthFlowNumericOnlyOTP confirms the OTP character set and length options are applied to the
+// generated code.
+func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowNumericOnlyOTP() {
+	ts.useOTPPropertiesFlow("auth_flow_sms_numeric_otp_test", map[string]interface{}{
+		"otpLength":         6,
+		"otpUseNumericOnly": true,
+	})
+
+	_, message := ts.sendOTPAndCaptureMessage()
+
+	ts.Require().Len(message.OTP, 6, "The OTP should match the configured length")
+	ts.Require().Regexp("^[0-9]{6}$", message.OTP,
+		"A numeric-only OTP should contain digits alone, got %q", message.OTP)
+}
+
+// TestSMSAuthFlowOTPValidityBelowMinimumIgnored confirms a validity period outside the accepted
+// range is ignored rather than applied. The OTP service only honours an override between 30 and 600
+// seconds, so a 2 second setting leaves the default validity in place and the code stays usable.
+//
+// Expiry itself is not covered here: the shortest honoured validity is 30 seconds, and a test that
+// waits that long does not belong in this suite.
+func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowOTPValidityBelowMinimumIgnored() {
+	ts.useOTPPropertiesFlow("auth_flow_sms_otp_short_validity_test", map[string]interface{}{
+		"otpValidityPeriodSeconds": 2,
+	})
+
+	otpStep, message := ts.sendOTPAndCaptureMessage()
+
+	// Comfortably past the requested validity, but well inside the default.
+	time.Sleep(3 * time.Second)
+
+	finalStep, err := common.CompleteFlow(otpStep.ExecutionID, map[string]string{"otp": message.OTP},
+		"action_002", otpStep.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit the OTP")
+	ts.Require().Equal("COMPLETE", finalStep.FlowStatus,
+		"A validity period below the accepted minimum should be ignored, leaving the OTP usable")
+	ts.Require().NotEmpty(finalStep.Assertion, "A JWT assertion should be returned")
+}
+
+// TestSMSAuthFlowNonIntegerOTPLength confirms a non-integer length is ignored rather than truncated,
+// so the generated OTP falls back to the default length.
+func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowNonIntegerOTPLength() {
+	ts.useOTPPropertiesFlow("auth_flow_sms_float_otp_length_test", map[string]interface{}{
+		"otpLength": 8.5,
+	})
+
+	_, message := ts.sendOTPAndCaptureMessage()
+
+	ts.Require().Len(message.OTP, 6,
+		"A non-integer OTP length should be ignored, leaving the server default length of 6")
+}
+
 func (ts *SMSAuthFlowTestSuite) TestSMSAuthFlowSingleRequestWithMobileNumber() {
 	// Clear any previous messages
 	ts.mockServer.ClearMessages()

--- a/tests/integration/flow/recovery/basic_recovery_test.go
+++ b/tests/integration/flow/recovery/basic_recovery_test.go
@@ -374,6 +374,170 @@ func (ts *EmailLinkPasswordRecoveryTestSuite) TestBasicRecoveryFlow_RecoveryDisa
 // Flow: prompt_username → identify_user → generate_recovery_token → send_recovery_email →
 //
 //	email_sent_status → verify_recovery_token → prompt_new_password → set_credential → recovery_complete → end
+//
+// TestCredentialSetter_EmptyPassword submits an empty password at prompt_new_password. The input is
+// declared required, so the engine is expected to hold the flow rather than run the executor with an
+// empty credential.
+func (ts *EmailLinkPasswordRecoveryTestSuite) TestCredentialSetter_EmptyPassword() {
+	ts.mockSMTP.ClearEmails()
+
+	flowStep := ts.driveRecoveryToPasswordPrompt()
+
+	finalStep, err := common.CompleteFlow(
+		flowStep.ExecutionID,
+		map[string]string{"password": ""},
+		"action_submit_password",
+		flowStep.ChallengeToken,
+	)
+	if err != nil {
+		// A rejected submission is an acceptable outcome; the credential must not have been set.
+		ts.assertPasswordUnchanged()
+		return
+	}
+
+	ts.Require().NotEqual("COMPLETE", finalStep.FlowStatus,
+		"An empty password must not complete the recovery flow")
+	ts.assertPasswordUnchanged()
+}
+
+// TestCredentialSetter_NoUserInContext runs CredentialSetter in a recovery flow that never
+// identifies a user, so the executor has no user ID to set credentials for.
+func (ts *EmailLinkPasswordRecoveryTestSuite) TestCredentialSetter_NoUserInContext() {
+	// The flow is structurally valid, since CredentialSetter declares no required properties and the
+	// prompt supplies its required password input. Only at runtime is there no user to act on, so
+	// this exercises the executor's guard rather than flow validation.
+	flowID, err := testutils.CreateFlow(buildCredentialSetterWithoutUserFlow())
+	ts.Require().NoError(err, "Failed to create the recovery flow without an identify step")
+	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
+
+	appID, err := testutils.CreateApplication(testutils.Application{
+		OUID:                  ts.testOUID,
+		Name:                  "Recovery Without Identify Test App",
+		Description:           "Application for testing CredentialSetter without an identified user",
+		IsRecoveryFlowEnabled: true,
+		ClientID:              "recovery_no_identify_client",
+		ClientSecret:          "recovery_no_identify_secret",
+		RedirectURIs:          []string{"http://localhost:3000/callback"},
+		AllowedUserTypes:      []string{basicRecoveryUserSchema.Name},
+		AuthFlowID:            ts.authFlowID,
+		RecoveryFlowID:        flowID,
+	})
+	ts.Require().NoError(err, "Failed to create application for the no-identify recovery flow")
+	defer func() {
+		if err := testutils.DeleteApplication(appID); err != nil {
+			ts.T().Logf("failed to delete no-identify test app: %v", err)
+		}
+	}()
+
+	flowStep, err := common.InitiateRecoveryFlow(appID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate the no-identify recovery flow")
+	ts.Require().True(common.HasInput(flowStep.Data.Inputs, "password"),
+		"Expected the flow to prompt for a password")
+
+	finalStep, err := common.CompleteFlow(
+		flowStep.ExecutionID,
+		map[string]string{"password": "ShouldNotApply123!"},
+		"action_submit_password",
+		flowStep.ChallengeToken,
+	)
+	if err == nil {
+		ts.Require().NotEqual("COMPLETE", finalStep.FlowStatus,
+			"CredentialSetter must not complete without an identified user")
+	}
+
+	ts.assertPasswordUnchanged()
+}
+
+// driveRecoveryToPasswordPrompt runs the recovery flow up to prompt_new_password and returns that
+// step, so tests that only care about the credential setting stage can skip the setup.
+func (ts *EmailLinkPasswordRecoveryTestSuite) driveRecoveryToPasswordPrompt() *common.FlowStep {
+	flowStep, err := common.InitiateRecoveryFlow(ts.testAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate recovery flow")
+
+	flowStep, err = common.CompleteFlow(
+		flowStep.ExecutionID,
+		map[string]string{"username": ts.testUsername},
+		"action_submit_username",
+		flowStep.ChallengeToken,
+	)
+	ts.Require().NoError(err, "Failed to submit username")
+
+	// GetLastEmail removes what it returns, so poll for the first arrival rather than sleeping a
+	// fixed amount and hoping the send has landed.
+	var email *testutils.EmailMessage
+	for i := 0; i < 20 && email == nil; i++ {
+		if received := ts.mockSMTP.GetLastEmail(); received != nil {
+			email = received
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	ts.Require().NotNil(email, "Expected recovery email to be captured by mock SMTP server")
+	recoveryToken := testutils.ExtractQueryParam(email.ExtractRecoveryLink(), "inviteToken")
+	ts.Require().NotEmpty(recoveryToken, "Expected inviteToken query param in recovery link")
+
+	flowStep, err = common.CompleteFlow(
+		flowStep.ExecutionID,
+		map[string]string{"inviteToken": recoveryToken},
+		"",
+		flowStep.ChallengeToken,
+	)
+	ts.Require().NoError(err, "Failed to submit recovery token")
+	ts.Require().True(common.HasInput(flowStep.Data.Inputs, "password"),
+		"Expected password input at prompt_new_password")
+
+	return flowStep
+}
+
+// assertPasswordUnchanged confirms the user's current password still authenticates, so a failed
+// credential set is verified by its absence of effect rather than by the flow status alone.
+func (ts *EmailLinkPasswordRecoveryTestSuite) assertPasswordUnchanged() {
+	ok, err := testutils.AuthenticateWithCredential(
+		"username", ts.testUsername, "password", ts.testPassword)
+	ts.Require().NoError(err, "Failed to authenticate with the existing password")
+	ts.Require().True(ok, "The existing password should still authenticate after a failed credential set")
+}
+
+// buildCredentialSetterWithoutUserFlow builds a recovery flow that prompts for a password and runs
+// CredentialSetter without ever identifying a user.
+func buildCredentialSetterWithoutUserFlow() testutils.Flow {
+	return testutils.Flow{
+		Name:     "Recovery Without Identify Test",
+		Handle:   "recovery-without-identify-test",
+		FlowType: "RECOVERY",
+		Nodes: []map[string]interface{}{
+			{"id": "start", "type": "START", "onSuccess": "prompt_new_password"},
+			{
+				"id":   "prompt_new_password",
+				"type": "PROMPT",
+				"prompts": []map[string]interface{}{
+					{
+						"inputs": []map[string]interface{}{
+							{
+								"ref":        "input_new_password",
+								"identifier": "password",
+								"type":       "PASSWORD_INPUT",
+								"required":   true,
+							},
+						},
+						"action": map[string]interface{}{
+							"ref":      "action_submit_password",
+							"nextNode": "set_credential",
+						},
+					},
+				},
+			},
+			{
+				"id":        "set_credential",
+				"type":      "TASK_EXECUTION",
+				"executor":  map[string]interface{}{"name": "CredentialSetter"},
+				"onSuccess": "end",
+			},
+			{"id": "end", "type": "END"},
+		},
+	}
+}
+
 func buildEmailLinkPasswordRecoveryFlow() testutils.Flow {
 	return testutils.Flow{
 		Name:     "Email Link Password Recovery Flow Test",

--- a/tests/integration/notification/dispatch_test.go
+++ b/tests/integration/notification/dispatch_test.go
@@ -1,0 +1,337 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package notification
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	mockDispatchServerPort = 8099
+	otpSendEndpoint        = "/auth/otp/sms/send"
+	smsGatewayPath         = "/connections/sms-gateway"
+)
+
+var (
+	dispatchTestOU = testutils.OrganizationUnit{
+		Handle:      "notification-dispatch-test-ou",
+		Name:        "Notification Dispatch Test OU",
+		Description: "Organization unit for notification dispatch tests",
+	}
+
+	dispatchEntityType = testutils.UserType{
+		Name: "dispatch_user",
+		Schema: map[string]interface{}{
+			"username":      map[string]interface{}{"type": "string"},
+			"mobile_number": map[string]interface{}{"type": "string"},
+		},
+	}
+)
+
+// DispatchTestSuite exercises how the custom SMS sender puts a message on the wire. The connection
+// CRUD surface is covered by the connection suite; what matters here is the shape of the outbound
+// request each configuration produces, and how a gateway failure surfaces.
+type DispatchTestSuite struct {
+	suite.Suite
+	client       *http.Client
+	mockServer   *testutils.MockNotificationServer
+	ouID         string
+	entityTypeID string
+	userID       string
+	mobileNumber string
+}
+
+func TestDispatchTestSuite(t *testing.T) {
+	suite.Run(t, new(DispatchTestSuite))
+}
+
+func (ts *DispatchTestSuite) SetupSuite() {
+	ts.client = testutils.GetHTTPClient()
+	ts.mobileNumber = "+1555000111"
+
+	ouID, err := testutils.CreateOrganizationUnit(dispatchTestOU)
+	ts.Require().NoError(err, "Failed to create test organization unit")
+	ts.ouID = ouID
+
+	dispatchEntityType.OUID = ouID
+	entityTypeID, err := testutils.CreateUserType(dispatchEntityType)
+	ts.Require().NoError(err, "Failed to create test user type")
+	ts.entityTypeID = entityTypeID
+
+	userIDs, err := testutils.CreateMultipleUsers(testutils.User{
+		OUID: ouID,
+		Type: dispatchEntityType.Name,
+		Attributes: json.RawMessage(`{
+			"username": "dispatchuser",
+			"mobile_number": "` + ts.mobileNumber + `"
+		}`),
+	})
+	ts.Require().NoError(err, "Failed to create test user")
+	ts.userID = userIDs[0]
+
+	ts.mockServer = testutils.NewMockNotificationServer(mockDispatchServerPort)
+	ts.Require().NoError(ts.mockServer.Start(), "Failed to start mock notification server")
+}
+
+func (ts *DispatchTestSuite) TearDownSuite() {
+	if ts.userID != "" {
+		if err := testutils.CleanupUsers([]string{ts.userID}); err != nil {
+			ts.T().Logf("Failed to cleanup user during teardown: %v", err)
+		}
+	}
+	if ts.entityTypeID != "" {
+		if err := testutils.DeleteUserType(ts.entityTypeID); err != nil {
+			ts.T().Logf("Failed to delete user type during teardown: %v", err)
+		}
+	}
+	if ts.ouID != "" {
+		if err := testutils.DeleteOrganizationUnit(ts.ouID); err != nil {
+			ts.T().Logf("Failed to delete organization unit during teardown: %v", err)
+		}
+	}
+	if ts.mockServer != nil {
+		if err := ts.mockServer.Stop(); err != nil {
+			ts.T().Logf("Failed to stop mock notification server during teardown: %v", err)
+		}
+	}
+}
+
+func (ts *DispatchTestSuite) SetupTest() {
+	ts.mockServer.ClearMessages()
+	ts.mockServer.SetResponseStatus(0)
+}
+
+// createSender creates a custom SMS gateway connection with the given configuration and registers
+// its cleanup.
+func (ts *DispatchTestSuite) createSender(name string, extra map[string]interface{}) string {
+	body := map[string]interface{}{
+		"name":        name,
+		"description": "Sender for notification dispatch testing",
+		"url":         ts.mockServer.GetSendSMSURL(),
+	}
+	for key, value := range extra {
+		body[key] = value
+	}
+
+	payload, err := json.Marshal(body)
+	ts.Require().NoError(err, "Failed to marshal sender payload")
+
+	req, err := http.NewRequest(http.MethodPost, testutils.TestServerURL+smsGatewayPath,
+		bytes.NewReader(payload))
+	ts.Require().NoError(err, "Failed to build sender request")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err, "Failed to create sender")
+	defer resp.Body.Close()
+
+	responseBody, _ := io.ReadAll(resp.Body)
+	ts.Require().Equal(http.StatusCreated, resp.StatusCode,
+		"Failed to create sender %s: %s", name, string(responseBody))
+
+	var decoded map[string]interface{}
+	ts.Require().NoError(json.Unmarshal(responseBody, &decoded), "Failed to decode sender response")
+
+	senderID, ok := decoded["id"].(string)
+	ts.Require().True(ok, "Sender response should carry an id")
+
+	ts.T().Cleanup(func() { ts.deleteSender(senderID) })
+
+	return senderID
+}
+
+func (ts *DispatchTestSuite) deleteSender(senderID string) {
+	req, err := http.NewRequest(http.MethodDelete,
+		testutils.TestServerURL+smsGatewayPath+"/"+senderID, nil)
+	if err != nil {
+		ts.T().Logf("Failed to build sender delete request: %v", err)
+		return
+	}
+	resp, err := ts.client.Do(req)
+	if err != nil {
+		ts.T().Logf("Failed to delete sender %s: %v", senderID, err)
+		return
+	}
+	resp.Body.Close()
+}
+
+// sendOTP asks the server to deliver an OTP through the given sender and returns the status of that
+// request, so both successful dispatch and gateway failures can be inspected.
+func (ts *DispatchTestSuite) sendOTP(senderID string) int {
+	payload, err := json.Marshal(map[string]interface{}{
+		"recipient": ts.mobileNumber,
+		"senderId":  senderID,
+	})
+	ts.Require().NoError(err, "Failed to marshal OTP send payload")
+
+	req, err := http.NewRequest(http.MethodPost, testutils.TestServerURL+otpSendEndpoint,
+		bytes.NewReader(payload))
+	ts.Require().NoError(err, "Failed to build OTP send request")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err, "Failed to send the OTP request")
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+
+	return resp.StatusCode
+}
+
+// waitForDispatch waits for the mock gateway to record an inbound request.
+func (ts *DispatchTestSuite) waitForDispatch() *testutils.SMSMessage {
+	for i := 0; i < 20; i++ {
+		if message := ts.mockServer.GetLastMessage(); message != nil {
+			return message
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return nil
+}
+
+// TestDispatchJSONPost sends through a sender configured for a JSON body over POST.
+func (ts *DispatchTestSuite) TestDispatchJSONPost() {
+	senderID := ts.createSender("Dispatch JSON POST Sender", map[string]interface{}{
+		"httpMethod":  "POST",
+		"contentType": "JSON",
+	})
+
+	ts.Require().Equal(http.StatusOK, ts.sendOTP(senderID), "Expected the OTP send to succeed")
+
+	message := ts.waitForDispatch()
+	ts.Require().NotNil(message, "The gateway should have received a request")
+	ts.Equal(http.MethodPost, message.Method, "The sender should dispatch over POST")
+	ts.Contains(message.ContentType, "application/json", "The body should be sent as JSON")
+	ts.NotEmpty(message.OTP, "The dispatched message should carry the OTP")
+}
+
+// TestDispatchFormPost sends through a sender configured for a form encoded body.
+//
+// The form encoder builds its fields by splitting the rendered message into "key=value" lines. The
+// OTP SMS template renders prose rather than key value pairs, so no fields are produced and the
+// gateway receives an empty body while the send still reports success. This test pins that
+// behaviour; if the encoder is changed to carry the message, the assertion below will fail and
+// should be updated to assert the OTP is present.
+func (ts *DispatchTestSuite) TestDispatchFormPost() {
+	senderID := ts.createSender("Dispatch FORM POST Sender", map[string]interface{}{
+		"httpMethod":  "POST",
+		"contentType": "FORM",
+	})
+
+	ts.Require().Equal(http.StatusOK, ts.sendOTP(senderID), "Expected the OTP send to succeed")
+
+	message := ts.waitForDispatch()
+	ts.Require().NotNil(message, "The gateway should have received a request")
+	ts.Equal(http.MethodPost, message.Method, "The sender should dispatch over POST")
+	ts.Contains(message.ContentType, "application/x-www-form-urlencoded",
+		"The body should be form encoded")
+	ts.Empty(message.Message,
+		"A prose template produces no form fields, so the body reaches the gateway empty")
+}
+
+// TestDispatchCustomHeaders confirms configured headers reach the gateway.
+func (ts *DispatchTestSuite) TestDispatchCustomHeaders() {
+	senderID := ts.createSender("Dispatch Custom Headers Sender", map[string]interface{}{
+		"httpMethod":  "POST",
+		"contentType": "JSON",
+		"httpHeaders": "X-Dispatch-Test: integration",
+	})
+
+	ts.Require().Equal(http.StatusOK, ts.sendOTP(senderID), "Expected the OTP send to succeed")
+
+	message := ts.waitForDispatch()
+	ts.Require().NotNil(message, "The gateway should have received a request")
+	ts.Equal("integration", message.Headers["X-Dispatch-Test"],
+		"The configured header should be present on the outbound request, got %v", message.Headers)
+}
+
+// TestDispatchGatewayFailure confirms a gateway error surfaces rather than being reported as a
+// successful send.
+func (ts *DispatchTestSuite) TestDispatchGatewayFailure() {
+	senderID := ts.createSender("Dispatch Failing Sender", map[string]interface{}{
+		"httpMethod":  "POST",
+		"contentType": "JSON",
+	})
+
+	ts.mockServer.SetResponseStatus(http.StatusInternalServerError)
+
+	status := ts.sendOTP(senderID)
+	ts.NotEqual(http.StatusOK, status,
+		"A gateway failure must not be reported as a successful send, got %d", status)
+
+	message := ts.waitForDispatch()
+	ts.Require().NotNil(message, "The gateway should still have received the attempt")
+}
+
+// TestDispatchUnsupportedContentType confirms an unusable content type is rejected rather than
+// silently dispatched in some default encoding.
+func (ts *DispatchTestSuite) TestDispatchUnsupportedContentType() {
+	senderID, err := ts.tryCreateSender("Dispatch Unsupported Content Type Sender",
+		map[string]interface{}{"httpMethod": "POST", "contentType": "XML"})
+	if err != nil {
+		// Rejecting the configuration up front is a valid guard, and preferable to failing at send.
+		ts.T().Logf("the connection API rejected an unsupported content type: %v", err)
+		return
+	}
+	ts.T().Cleanup(func() { ts.deleteSender(senderID) })
+
+	status := ts.sendOTP(senderID)
+	ts.NotEqual(http.StatusOK, status,
+		"An unsupported content type must not produce a successful send, got %d", status)
+}
+
+// tryCreateSender creates a sender and returns any API error rather than failing the test, for
+// configurations that may be rejected at creation time.
+func (ts *DispatchTestSuite) tryCreateSender(name string, extra map[string]interface{}) (string, error) {
+	body := map[string]interface{}{
+		"name":        name,
+		"description": "Sender for notification dispatch testing",
+		"url":         ts.mockServer.GetSendSMSURL(),
+	}
+	for key, value := range extra {
+		body[key] = value
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, testutils.TestServerURL+smsGatewayPath,
+		bytes.NewReader(payload))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	responseBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("status %d: %s", resp.StatusCode, string(responseBody))
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(responseBody, &decoded); err != nil {
+		return "", err
+	}
+
+	senderID, ok := decoded["id"].(string)
+	if !ok || senderID == "" {
+		return "", fmt.Errorf("sender response carried no id: %s", string(responseBody))
+	}
+	return senderID, nil
+}

--- a/tests/integration/testutils/mock_notification_server.go
+++ b/tests/integration/testutils/mock_notification_server.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"sync"
 )
@@ -18,12 +19,19 @@ type MockNotificationServer struct {
 	messages []SMSMessage
 	mutex    sync.RWMutex
 	port     int
+	// failStatus, when 400 or above, is returned instead of a success response.
+	failStatus int
 }
 
-// SMSMessage represents a received SMS message
+// SMSMessage represents a received SMS message, along with the details of the request that carried
+// it, so tests can assert how a sender dispatched the message and not just what it sent.
 type SMSMessage struct {
-	Message string `json:"message"`
-	OTP     string `json:"otp,omitempty"`
+	Message     string            `json:"message"`
+	OTP         string            `json:"otp,omitempty"`
+	Method      string            `json:"method,omitempty"`
+	ContentType string            `json:"contentType,omitempty"`
+	Query       string            `json:"query,omitempty"`
+	Headers     map[string]string `json:"headers,omitempty"`
 }
 
 // SMSRequest represents the expected SMS request format
@@ -52,18 +60,23 @@ func (m *MockNotificationServer) Start() error {
 	// Handle clear messages endpoint for testing
 	mux.HandleFunc("/clear", m.handleClearMessages)
 
-	m.server = &http.Server{
-		Addr:    fmt.Sprintf(":%d", m.port),
-		Handler: mux,
+	m.server = &http.Server{Handler: mux}
+
+	// Bind before returning so the port is reachable as soon as Start succeeds, and so a port clash
+	// surfaces here rather than later as a dispatch that never arrives.
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", m.port))
+	if err != nil {
+		return fmt.Errorf("failed to start mock notification server on port %d: %w", m.port, err)
 	}
+	m.port = listener.Addr().(*net.TCPAddr).Port
 
 	go func() {
-		log.Printf("Starting mock notification server on port %d", m.port)
-		if err := m.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := m.server.Serve(listener); err != nil && err != http.ErrServerClosed {
 			log.Printf("Mock notification server error: %v", err)
 		}
 	}()
 
+	log.Printf("Mock notification server started on port %d", m.port)
 	return nil
 }
 
@@ -85,13 +98,17 @@ func (m *MockNotificationServer) GetSendSMSURL() string {
 	return fmt.Sprintf("%s/send-sms", m.GetURL())
 }
 
-// handleSendSMS handles SMS sending requests
-func (m *MockNotificationServer) handleSendSMS(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
+// SetResponseStatus makes subsequent send requests return the given status, so tests can exercise
+// how a sender failure surfaces. A status below 400 restores the normal success response.
+func (m *MockNotificationServer) SetResponseStatus(status int) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.failStatus = status
+}
 
+// handleSendSMS handles SMS sending requests. Any method is accepted so that senders configured to
+// use GET can be exercised; the method actually used is recorded on the message.
+func (m *MockNotificationServer) handleSendSMS(w http.ResponseWriter, r *http.Request) {
 	// Read the raw body as the SMS message content
 	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -101,24 +118,44 @@ func (m *MockNotificationServer) handleSendSMS(w http.ResponseWriter, r *http.Re
 
 	messageBody := string(bodyBytes)
 
-	// Extract OTP from message (assuming it's a numeric sequence)
-	otp := extractOTPFromMessage(messageBody)
+	// A sender using GET carries the message in the query string rather than the body.
+	otpSource := messageBody
+	if messageBody == "" {
+		otpSource = r.URL.RawQuery
+	}
+	otp := extractOTPFromMessage(otpSource)
+
+	headers := make(map[string]string, len(r.Header))
+	for name := range r.Header {
+		headers[name] = r.Header.Get(name)
+	}
 
 	message := SMSMessage{
-		Message: messageBody,
-		OTP:     otp,
+		Message:     messageBody,
+		OTP:         otp,
+		Method:      r.Method,
+		ContentType: r.Header.Get("Content-Type"),
+		Query:       r.URL.RawQuery,
+		Headers:     headers,
 	}
 
 	m.mutex.Lock()
 	m.messages = append(m.messages, message)
+	failStatus := m.failStatus
+	messageCount := len(m.messages)
 	m.mutex.Unlock()
 
-	log.Printf("Mock SMS received: %s (OTP: %s)", messageBody, otp)
+	log.Printf("Mock SMS received via %s: %s (OTP: %s)", r.Method, messageBody, otp)
+
+	if failStatus >= 400 {
+		http.Error(w, "mock sender failure", failStatus)
+		return
+	}
 
 	// Return success response
 	response := map[string]interface{}{
 		"success":   true,
-		"messageId": fmt.Sprintf("mock-msg-%d", len(m.messages)),
+		"messageId": fmt.Sprintf("mock-msg-%d", messageCount),
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/tests/integration/testutils/mock_smtp_server.go
+++ b/tests/integration/testutils/mock_smtp_server.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net"
 	"net/url"
+	"regexp"
 	"strings"
 	"sync"
 )
@@ -188,6 +189,22 @@ func extractSMTPAngle(s string) string {
 	s = strings.TrimPrefix(s, "<")
 	s = strings.TrimSuffix(s, ">")
 	return strings.TrimSpace(s)
+}
+
+// otpCellPattern matches the OTP the email template renders inside its own table cell.
+var otpCellPattern = regexp.MustCompile(`>\s*([A-Za-z0-9]{4,10})\s*</td>`)
+
+// ExtractOTP returns the one time code carried by an OTP email, which the template renders as the
+// sole contents of a table cell. Returns "" if no code is found.
+func (e *EmailMessage) ExtractOTP() string {
+	// Undo quoted-printable soft line breaks, which can split the code across lines.
+	body := strings.ReplaceAll(e.Body, "=\r\n", "")
+	body = strings.ReplaceAll(body, "=\n", "")
+
+	if match := otpCellPattern.FindStringSubmatch(body); match != nil {
+		return match[1]
+	}
+	return ""
 }
 
 // ExtractRecoveryLink searches the email body for a URL containing "inviteToken"


### PR DESCRIPTION
### Purpose
Extends integration coverage for the SMS OTP authentication flow, the email OTP authentication flow, the email link password recovery flow, and message sender dispatch behaviour. These paths previously had little to no integration coverage, so regressions in OTP generation, retry handling, and sender HTTP dispatch went undetected.

### Approach
Added four suites plus the test utility support they needed:

- `tests/integration/flow/authentication/sms_auth_test.go`: SMS OTP authentication via mobile number and via username, invalid OTP, retry after invalid OTP, max attempts exceeded, numeric-only OTP, OTP validity below the minimum being ignored, non-integer OTP length, and the single-request variant.
- `tests/integration/flow/authentication/email_otp_auth_test.go`: email OTP success, invalid OTP, retry after invalid OTP, and a non-existent email address.
- `tests/integration/flow/recovery/basic_recovery_test.go`: email link recovery success, unknown username, invalid token, recovery disabled on the application, and credential setter guards for an empty password and a missing user in context.
- `tests/integration/notification/dispatch_test.go`: sender dispatch as JSON POST, form POST, with custom headers, on gateway failure, and with an unsupported content type.

Supporting changes in `tests/integration/testutils`:

- `MockNotificationServer` now records the HTTP method, content type, query string, and headers on each received message so dispatch assertions can check how a sender sent the message rather than only what it sent. It accepts any method so GET-configured senders can be exercised, extracts the OTP from the query string when the body is empty, and gained `SetResponseStatus` to simulate gateway failures.
- `EmailMessage.ExtractOTP` reads the one time code from the OTP email template, undoing quoted-printable soft line breaks first so a code split across lines is still matched.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for email one-time-password authentication, including successful sign-in, invalid-code retries, and unknown email rejection.
  * Expanded SMS authentication validation for attempt limits, code format, validity periods, and configurable lengths.
  * Added recovery safeguards ensuring invalid or unidentified requests cannot change credentials.
  * Added notification delivery coverage for multiple request formats, custom headers, gateway failures, and unsupported content types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->