### PR TITLE
Trigger forward-port on pull_request_target

### DIFF
--- a/.github/workflows/forward-port-pr.yml
+++ b/.github/workflows/forward-port-pr.yml
@@ -10,7 +10,7 @@
 name: Forward-port Merged PRs
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches:
       # Patch branches whose merged PRs get forward-ported to main.


### PR DESCRIPTION
### Purpose
The forward-port workflow was not triggering for merged PRs on `1.0.x`. After switching the trigger to `pull_request_target` (#5043), merges into `1.0.x` (#5040) produced **zero runs**.

Root cause: `pull_request` and `pull_request_target` resolve the workflow file from different refs.

| Trigger | Workflow file resolved from | Secrets for fork PRs |
|---|---|---|
| `pull_request` | the PR's base branch (`1.0.x`) | withheld |
| `pull_request_target` | the repository default branch (`main`) | available |

Per GitHub docs, `pull_request_target` "will only trigger a workflow run if the workflow file exists on the default branch" and runs in the default branch context. The `pull_request_target` trigger was added only to `1.0.x` (#5043), so it was never registered. It must live on `main`.

Contributor PRs are merged from forks, and `pull_request` withholds secrets for fork PRs, so `secrets.THUNDER_AUTOMATION_BOT` resolved to empty and `actions/checkout` failed with `Input required and not supplied: token`. `pull_request_target` runs with secrets and a write-scoped token even for fork PRs.

### Approach
Change `main`'s copy of the workflow trigger from `pull_request` to `pull_request_target`. The `branches: ["1.0.x"]` filter still applies to the PR's base ref, so the workflow only fires for merges into `1.0.x`, runs in `main`'s context, and has access to secrets.

Security: the job checks out the trusted target branch (`main`) and cherry-picks the original PR's commits by SHA. It never checks out or executes fork head code, so `pull_request_target` is safe here. The forward-ported changes land in a new PR that goes through normal review and CI.

The inert copy left on `1.0.x` (from #5037/#5043) is harmless: `pull_request_target` ignores non-default-branch definitions, so it never triggers and does not conflict with this one.

### Related Issues
- N/A

### Related PRs
- #5004, #5037, #5043

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automation workflow trigger for closed pull requests on the configured patch branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->