### PR TITLE
improved thunderidengine with cors configuration

### DIFF
--- a/backend/pkg/thunderidengine/config/config.go
+++ b/backend/pkg/thunderidengine/config/config.go
@@ -5,7 +5,11 @@
 package config
 
 import (
+	"encoding/json"
+	"fmt"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 // TrustedIssuerConfig holds configuration for trusted external issuer authentication.
@@ -422,4 +426,147 @@ type LogConfig struct {
 	Level string `yaml:"level" json:"level"`
 	// Format selects the record format: "json" or "text" (default).
 	Format string `yaml:"format" json:"format"`
+}
+
+// OriginConfig holds the allowed cross-origin origins for the engine's CORS-enabled endpoints
+// (well-known discovery, JWKS, token, userinfo, and the rest of the OAuth surface). An empty
+// AllowedOrigins leaves CORS disabled: no cross-origin request is allowed to read a response.
+//
+// The field uses the camelCase "allowedOrigins" tag (rather than this file's usual snake_case) to
+// match the wire format the engine re-encodes it to internally.
+type OriginConfig struct {
+	AllowedOrigins []OriginEntry `yaml:"allowedOrigins" json:"allowedOrigins"`
+}
+
+// UnmarshalJSON decodes cfg, leaving AllowedOrigins nil when the field is omitted but rejecting
+// an explicit "allowedOrigins": null, which would otherwise be indistinguishable from omission
+// and silently disable CORS instead of failing validation.
+func (c *OriginConfig) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		AllowedOrigins json.RawMessage `json:"allowedOrigins"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if raw.AllowedOrigins == nil {
+		c.AllowedOrigins = nil
+		return nil
+	}
+	if string(raw.AllowedOrigins) == "null" {
+		return fmt.Errorf("thunderidengine: allowedOrigins must be a list, not null")
+	}
+	var entries []OriginEntry
+	if err := json.Unmarshal(raw.AllowedOrigins, &entries); err != nil {
+		return err
+	}
+	c.AllowedOrigins = entries
+	return nil
+}
+
+// UnmarshalYAML decodes cfg, leaving AllowedOrigins nil when the field is omitted but rejecting
+// an explicit "allowedOrigins: null" for the same reason as UnmarshalJSON.
+func (c *OriginConfig) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("thunderidengine: origin configuration must be a mapping")
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value != "allowedOrigins" {
+			continue
+		}
+		value := node.Content[i+1]
+		if value.Tag == "!!null" {
+			return fmt.Errorf("thunderidengine: allowedOrigins must be a list, not null")
+		}
+		var entries []OriginEntry
+		if err := value.Decode(&entries); err != nil {
+			return err
+		}
+		c.AllowedOrigins = entries
+		return nil
+	}
+	c.AllowedOrigins = nil
+	return nil
+}
+
+// OriginEntry is one allowed-origin entry: exactly one of Origin (a literal origin, e.g.
+// "https://app.example.com") or Regex (a fully anchored pattern, e.g. "^https://.*\\.example\\.com$")
+// must be set. Decoding from YAML or JSON enforces this; a bare string decodes to Origin, and an
+// object of the shape { regex: "..." } decodes to Regex.
+type OriginEntry struct {
+	Origin string
+	Regex  string
+}
+
+// toEntry renders the origin as its wire form: a bare string for a literal, or a { "regex": ... }
+// object for a pattern.
+func (o OriginEntry) toEntry() (any, error) {
+	switch {
+	case o.Origin != "" && o.Regex != "":
+		return nil, fmt.Errorf("thunderidengine: OriginEntry must set exactly one of Origin or Regex, got both")
+	case o.Regex != "":
+		return map[string]string{"regex": o.Regex}, nil
+	case o.Origin != "":
+		return o.Origin, nil
+	default:
+		return nil, fmt.Errorf("thunderidengine: OriginEntry must set exactly one of Origin or Regex, got neither")
+	}
+}
+
+// MarshalJSON encodes the origin to its wire form.
+func (o OriginEntry) MarshalJSON() ([]byte, error) {
+	entry, err := o.toEntry()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(entry)
+}
+
+// MarshalYAML encodes the origin to its wire form.
+func (o OriginEntry) MarshalYAML() (any, error) {
+	return o.toEntry()
+}
+
+// UnmarshalJSON decodes a JSON string into Origin, or an object of the shape { "regex": "..." }
+// into Regex.
+func (o *OriginEntry) UnmarshalJSON(data []byte) error {
+	var literal string
+	if err := json.Unmarshal(data, &literal); err == nil {
+		*o = OriginEntry{Origin: literal}
+		return nil
+	}
+	var obj struct {
+		Regex string `json:"regex"`
+	}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return fmt.Errorf("thunderidengine: origin entry must be a string or { regex: ... } object: %w", err)
+	}
+	if obj.Regex == "" {
+		return fmt.Errorf("thunderidengine: origin entry: regex object missing 'regex' field")
+	}
+	*o = OriginEntry{Regex: obj.Regex}
+	return nil
+}
+
+// UnmarshalYAML decodes a YAML scalar into Origin, or a mapping of the shape { regex: "..." } into
+// Regex.
+func (o *OriginEntry) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		*o = OriginEntry{Origin: node.Value}
+		return nil
+	case yaml.MappingNode:
+		var obj struct {
+			Regex string `yaml:"regex"`
+		}
+		if err := node.Decode(&obj); err != nil {
+			return fmt.Errorf("thunderidengine: origin entry: %w", err)
+		}
+		if obj.Regex == "" {
+			return fmt.Errorf("thunderidengine: origin entry: regex object missing 'regex' field")
+		}
+		*o = OriginEntry{Regex: obj.Regex}
+		return nil
+	default:
+		return fmt.Errorf("thunderidengine: origin entry must be a string or { regex: ... } object")
+	}
 }

--- a/backend/pkg/thunderidengine/config/origin_test.go
+++ b/backend/pkg/thunderidengine/config/origin_test.go
@@ -1,0 +1,190 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v3"
+)
+
+func (suite *ValidateTestSuite) TestOriginEntry_UnmarshalJSON() {
+	suite.T().Run("literal string decodes to Origin", func(t *testing.T) {
+		var o OriginEntry
+		require.NoError(t, json.Unmarshal([]byte(`"https://app.example.com"`), &o))
+		assert.Equal(t, OriginEntry{Origin: "https://app.example.com"}, o)
+	})
+
+	suite.T().Run("regex object decodes to Regex", func(t *testing.T) {
+		var o OriginEntry
+		require.NoError(t, json.Unmarshal([]byte(`{"regex":"^https://.*$"}`), &o))
+		assert.Equal(t, OriginEntry{Regex: "^https://.*$"}, o)
+	})
+
+	suite.T().Run("regex object missing regex field fails", func(t *testing.T) {
+		var o OriginEntry
+		assert.Error(t, json.Unmarshal([]byte(`{}`), &o))
+	})
+
+	suite.T().Run("non-string non-object fails", func(t *testing.T) {
+		var o OriginEntry
+		assert.Error(t, json.Unmarshal([]byte(`42`), &o))
+	})
+}
+
+func (suite *ValidateTestSuite) TestOriginEntry_UnmarshalYAML() {
+	suite.T().Run("scalar decodes to Origin", func(t *testing.T) {
+		var o OriginEntry
+		require.NoError(t, yaml.Unmarshal([]byte(`https://app.example.com`), &o))
+		assert.Equal(t, OriginEntry{Origin: "https://app.example.com"}, o)
+	})
+
+	suite.T().Run("mapping decodes to Regex", func(t *testing.T) {
+		var o OriginEntry
+		require.NoError(t, yaml.Unmarshal([]byte(`regex: "^https://.*$"`), &o))
+		assert.Equal(t, OriginEntry{Regex: "^https://.*$"}, o)
+	})
+
+	suite.T().Run("mapping missing regex field fails", func(t *testing.T) {
+		var o OriginEntry
+		assert.Error(t, yaml.Unmarshal([]byte(`{}`), &o))
+	})
+
+	suite.T().Run("mapping with non-scalar regex field fails", func(t *testing.T) {
+		var o OriginEntry
+		assert.Error(t, yaml.Unmarshal([]byte("regex: [1, 2, 3]"), &o))
+	})
+
+	suite.T().Run("sequence fails", func(t *testing.T) {
+		var o OriginEntry
+		assert.Error(t, yaml.Unmarshal([]byte(`- foo`), &o))
+	})
+}
+
+//nolint:dupl // JSON and YAML marshal tests mirror the same shape, kept distinct per format
+func (suite *ValidateTestSuite) TestOriginEntry_MarshalJSON() {
+	suite.T().Run("literal round-trips through JSON", func(t *testing.T) {
+		o := OriginEntry{Origin: "https://app.example.com"}
+		data, err := json.Marshal(o)
+		require.NoError(t, err)
+		assert.JSONEq(t, `"https://app.example.com"`, string(data))
+	})
+
+	suite.T().Run("regex round-trips through JSON", func(t *testing.T) {
+		o := OriginEntry{Regex: "^https://.*$"}
+		data, err := json.Marshal(o)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"regex":"^https://.*$"}`, string(data))
+	})
+
+	suite.T().Run("both set fails to marshal", func(t *testing.T) {
+		o := OriginEntry{Origin: "https://app.example.com", Regex: "^https://.*$"}
+		_, err := json.Marshal(o)
+		assert.Error(t, err)
+	})
+
+	suite.T().Run("neither set fails to marshal", func(t *testing.T) {
+		_, err := json.Marshal(OriginEntry{})
+		assert.Error(t, err)
+	})
+}
+
+//nolint:dupl // JSON and YAML marshal tests mirror the same shape, kept distinct per format
+func (suite *ValidateTestSuite) TestOriginEntry_MarshalYAML() {
+	suite.T().Run("literal round-trips through YAML", func(t *testing.T) {
+		o := OriginEntry{Origin: "https://app.example.com"}
+		data, err := yaml.Marshal(o)
+		require.NoError(t, err)
+		assert.Equal(t, "https://app.example.com\n", string(data))
+	})
+
+	suite.T().Run("regex round-trips through YAML", func(t *testing.T) {
+		o := OriginEntry{Regex: "^https://.*$"}
+		data, err := yaml.Marshal(o)
+		require.NoError(t, err)
+		assert.Equal(t, "regex: ^https://.*$\n", string(data))
+	})
+
+	suite.T().Run("both set fails to marshal", func(t *testing.T) {
+		o := OriginEntry{Origin: "https://app.example.com", Regex: "^https://.*$"}
+		_, err := yaml.Marshal(o)
+		assert.Error(t, err)
+	})
+
+	suite.T().Run("neither set fails to marshal", func(t *testing.T) {
+		_, err := yaml.Marshal(OriginEntry{})
+		assert.Error(t, err)
+	})
+}
+
+func (suite *ValidateTestSuite) TestOriginConfig_Unmarshal() {
+	cases := []struct {
+		name       string
+		unmarshal  func([]byte, any) error
+		validRaw   string
+		nullRaw    string
+		malformed  string
+		notListRaw string
+	}{
+		{
+			name:       "JSON",
+			unmarshal:  json.Unmarshal,
+			validRaw:   `{"allowedOrigins":["https://app.example.com",{"regex":"^https://.*\\.example\\.com$"}]}`,
+			nullRaw:    `{"allowedOrigins":null}`,
+			malformed:  `[]`,
+			notListRaw: `{"allowedOrigins":"https://app.example.com"}`,
+		},
+		{
+			name:      "YAML",
+			unmarshal: yaml.Unmarshal,
+			validRaw: "allowedOrigins:\n  - https://app.example.com\n  - " +
+				"regex: \"^https://.*\\\\.example\\\\.com$\"\n",
+			nullRaw:    "allowedOrigins:",
+			malformed:  "- foo",
+			notListRaw: "allowedOrigins: https://app.example.com",
+		},
+	}
+
+	for _, tc := range cases {
+		suite.T().Run(tc.name+" decodes literal and regex entries", func(t *testing.T) {
+			var cfg OriginConfig
+			require.NoError(t, tc.unmarshal([]byte(tc.validRaw), &cfg))
+			assert.Equal(t, []OriginEntry{
+				{Origin: "https://app.example.com"},
+				{Regex: `^https://.*\.example\.com$`},
+			}, cfg.AllowedOrigins)
+		})
+
+		suite.T().Run(tc.name+" omitted field leaves AllowedOrigins nil", func(t *testing.T) {
+			var cfg OriginConfig
+			require.NoError(t, tc.unmarshal([]byte(`{}`), &cfg))
+			assert.Nil(t, cfg.AllowedOrigins)
+		})
+
+		suite.T().Run(tc.name+" explicit null is rejected", func(t *testing.T) {
+			var cfg OriginConfig
+			assert.Error(t, tc.unmarshal([]byte(tc.nullRaw), &cfg))
+		})
+
+		suite.T().Run(tc.name+" malformed top level is rejected", func(t *testing.T) {
+			var cfg OriginConfig
+			assert.Error(t, tc.unmarshal([]byte(tc.malformed), &cfg))
+		})
+
+		suite.T().Run(tc.name+" non-list allowedOrigins is rejected", func(t *testing.T) {
+			var cfg OriginConfig
+			assert.Error(t, tc.unmarshal([]byte(tc.notListRaw), &cfg))
+		})
+	}
+
+	suite.T().Run("YAML skips unrelated keys before allowedOrigins", func(t *testing.T) {
+		var cfg OriginConfig
+		raw := "other: value\nallowedOrigins:\n  - https://app.example.com\n"
+		require.NoError(t, yaml.Unmarshal([]byte(raw), &cfg))
+		assert.Equal(t, []OriginEntry{{Origin: "https://app.example.com"}}, cfg.AllowedOrigins)
+	})
+}

--- a/backend/pkg/thunderidengine/engine.go
+++ b/backend/pkg/thunderidengine/engine.go
@@ -6,7 +6,9 @@ package thunderidengine
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -28,6 +30,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/runtimestore"
 	"github.com/thunder-id/thunderid/internal/system/cache"
 	systemconfig "github.com/thunder-id/thunderid/internal/system/config"
+	"github.com/thunder-id/thunderid/internal/system/cors"
 	"github.com/thunder-id/thunderid/internal/system/jose"
 	joseconfig "github.com/thunder-id/thunderid/internal/system/jose/config"
 	"github.com/thunder-id/thunderid/internal/system/jose/jwe"
@@ -35,6 +38,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/kmprovider"
 	"github.com/thunder-id/thunderid/internal/system/kmprovider/defaultkm/pki"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
@@ -181,6 +185,17 @@ func New(mux *http.ServeMux, opts ...Option) *Engine {
 		engineCtx.observabilitySvc, tokenFamilyRevocationTTL,
 		engineCtx.oauthConfig.Revocation.TokenFamily.OnExplicitRevokeEnabled())
 
+	// CORS origins come from the engine's static OriginConfig; unlike the full server there is no
+	// server-config store to back a dynamic matcher. An empty config leaves CORS disabled (matcher
+	// reset to nil, so every cross-origin request to the routes registered below is denied). The
+	// matcher is global, so it must be reset explicitly rather than left as whatever a previous
+	// engine installed.
+	originReader, err := buildOriginReader(engineCtx.originConfig)
+	if err != nil {
+		logger.Fatal(ctx, "Invalid origin configuration", log.Error(err))
+	}
+	cors.InitializeDynamicMatcher(originReader)
+
 	// The embedded engine has no server-config store, so no default resource server is available: the
 	// resource provider is passed undecorated. Implicit no-resource requests that carry permission
 	// scopes are rejected (the provider resolves no server for an empty identifier); OIDC-only or
@@ -284,6 +299,45 @@ func (e *engineContext) applyCustomExecutors() error {
 	return nil
 }
 
+// buildOriginReader validates cfg and, if it carries any allowed origins, returns a
+// cors.ServerConfigReader that serves them as a static read-only layer with no writable layer.
+// An empty cfg returns a nil reader and no error: the caller then leaves the CORS dynamic matcher
+// uninstalled, which denies every cross-origin request.
+func buildOriginReader(cfg engineconfig.OriginConfig) (cors.ServerConfigReader, error) {
+	if len(cfg.AllowedOrigins) == 0 {
+		return nil, nil
+	}
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("thunderidengine: failed to encode origin configuration: %w", err)
+	}
+	decoded, err := cors.OriginHandler{}.Decode(raw)
+	if err != nil {
+		return nil, fmt.Errorf("thunderidengine: invalid origin configuration: %w", err)
+	}
+	if err := (cors.OriginHandler{}).Validate(decoded, nil, nil); err != nil {
+		return nil, fmt.Errorf("thunderidengine: invalid origin configuration: %w", err)
+	}
+	return staticOriginReader{config: decoded.(cors.OriginConfig)}, nil
+}
+
+// staticOriginReader implements cors.ServerConfigReader over a fixed origin list supplied via
+// WithOriginConfig. It has no writable layer: origins can only change by restarting the engine
+// with a new OriginConfig.
+type staticOriginReader struct {
+	config cors.OriginConfig
+}
+
+// GetReadOnlyConfig returns the engine's static origin configuration.
+func (r staticOriginReader) GetReadOnlyConfig(_ context.Context, _ string) (any, *common.ServiceError) {
+	return r.config, nil
+}
+
+// GetWritableConfig returns an empty configuration: staticOriginReader has no writable layer.
+func (r staticOriginReader) GetWritableConfig(_ context.Context, _ string) (any, *common.ServiceError) {
+	return cors.OriginConfig{}, nil
+}
+
 type engineContext struct {
 	cacheManager          cache.CacheManagerInterface
 	jwtService            jwt.JWTServiceInterface
@@ -310,6 +364,7 @@ type engineContext struct {
 	encryptionConfig       engineconfig.EncryptionConfig
 	logConfig              engineconfig.LogConfig
 	attributeCacheConfig   engineconfig.AttributeCacheConfig
+	originConfig           engineconfig.OriginConfig
 
 	actorProvider             providers.ActorProvider
 	defaultAuthnProvider      providers.AuthnProviderInterface
@@ -359,6 +414,14 @@ func WithEncryptionConfig(encryptionConfig engineconfig.EncryptionConfig) Option
 // WithAttributeCacheConfig supplies the attribute cache configuration.
 func WithAttributeCacheConfig(config engineconfig.AttributeCacheConfig) Option {
 	return func(c *engineContext) { c.attributeCacheConfig = config }
+}
+
+// WithOriginConfig supplies the allowed cross-origin origins for the engine's CORS-enabled
+// endpoints (well-known discovery, JWKS, token, userinfo, and the rest of the OAuth surface).
+// Omitting this option leaves CORS disabled: no cross-origin request is allowed to read a
+// response from those endpoints.
+func WithOriginConfig(config engineconfig.OriginConfig) Option {
+	return func(c *engineContext) { c.originConfig = config }
 }
 
 // WithServerConfig supplies the server configuration.

--- a/backend/pkg/thunderidengine/engine_test.go
+++ b/backend/pkg/thunderidengine/engine_test.go
@@ -4,6 +4,7 @@
 package thunderidengine
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -21,6 +22,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	systemconfig "github.com/thunder-id/thunderid/internal/system/config"
+	"github.com/thunder-id/thunderid/internal/system/cors"
 	joseconfig "github.com/thunder-id/thunderid/internal/system/jose/config"
 	"github.com/thunder-id/thunderid/internal/system/kmprovider"
 	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
@@ -43,6 +45,8 @@ import (
 	"github.com/thunder-id/thunderid/tests/mocks/resourceserverprovidermock"
 	"github.com/thunder-id/thunderid/tests/mocks/runtimestoreprovidermock"
 )
+
+const testKeyID = "test-key"
 
 type EngineTestSuite struct {
 	suite.Suite
@@ -380,7 +384,7 @@ func (suite *EngineTestSuite) TestNew_HappyPath() {
 	t := suite.T()
 	tempDir := t.TempDir()
 
-	keyID := "test-key"
+	keyID := testKeyID
 	certPEM := generateSelfSignedCertFiles(t, tempDir, "cert.pem", "key.pem")
 	keyConfigs := []engineconfig.KeyConfig{{ID: keyID, CertFile: "cert.pem", KeyFile: "key.pem"}}
 
@@ -452,7 +456,7 @@ func (suite *EngineTestSuite) TestNew_InitializesRuntimeStoreWhenNotInjected() {
 	t := suite.T()
 	tempDir := t.TempDir()
 
-	keyID := "test-key"
+	keyID := testKeyID
 	certPEM := generateSelfSignedCertFiles(t, tempDir, "cert.pem", "key.pem")
 	keyConfigs := []engineconfig.KeyConfig{{ID: keyID, CertFile: "cert.pem", KeyFile: "key.pem"}}
 
@@ -523,4 +527,136 @@ func (suite *EngineTestSuite) TestWithCustomAuthnProvider_AccumulatesByName() {
 	assert.Equal(suite.T(), []string{"password"}, ctx.customAuthnProviders["acme"].Creds)
 	assert.Equal(suite.T(), []string{"otp"}, ctx.customAuthnProviders["beta"].Creds)
 	assert.NotNil(suite.T(), ctx.customAuthnProviders["acme"].Instance)
+}
+
+// mustMatch parses origin and reports whether matcher allows it.
+func mustMatch(t *testing.T, matcher *cors.Matcher, origin string) bool {
+	t.Helper()
+	parsed, err := cors.ParseOrigin(origin)
+	require.NoError(t, err)
+	allow, _ := matcher.Match(parsed)
+	return allow
+}
+
+func (suite *EngineTestSuite) TestBuildOriginReader() {
+	suite.T().Run("empty config returns nil reader", func(t *testing.T) {
+		reader, err := buildOriginReader(engineconfig.OriginConfig{})
+		require.NoError(t, err)
+		assert.Nil(t, reader)
+	})
+
+	suite.T().Run("valid config installs matching reader", func(t *testing.T) {
+		t.Cleanup(func() { cors.InitializeDynamicMatcher(nil) })
+
+		reader, err := buildOriginReader(engineconfig.OriginConfig{
+			AllowedOrigins: []engineconfig.OriginEntry{
+				{Origin: "https://app.example.com"},
+				{Regex: `^https://[a-z0-9-]+\.staging\.example\.com$`},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+
+		cors.InitializeDynamicMatcher(reader)
+		matcher := cors.GetDynamicMatcher(context.Background())
+		require.NotNil(t, matcher)
+
+		assert.True(t, mustMatch(t, matcher, "https://app.example.com"))
+		assert.True(t, mustMatch(t, matcher, "https://foo.staging.example.com"))
+		assert.False(t, mustMatch(t, matcher, "https://other.example.com"))
+	})
+
+	suite.T().Run("wildcard literal is rejected", func(t *testing.T) {
+		reader, err := buildOriginReader(engineconfig.OriginConfig{
+			AllowedOrigins: []engineconfig.OriginEntry{{Origin: "*"}},
+		})
+		assert.Error(t, err)
+		assert.Nil(t, reader)
+	})
+
+	suite.T().Run("invalid regex is rejected", func(t *testing.T) {
+		reader, err := buildOriginReader(engineconfig.OriginConfig{
+			AllowedOrigins: []engineconfig.OriginEntry{{Regex: "["}},
+		})
+		assert.Error(t, err)
+		assert.Nil(t, reader)
+	})
+
+	suite.T().Run("origin and regex both set is rejected", func(t *testing.T) {
+		reader, err := buildOriginReader(engineconfig.OriginConfig{
+			AllowedOrigins: []engineconfig.OriginEntry{
+				{Origin: "https://app.example.com", Regex: "^https://.*$"},
+			},
+		})
+		assert.Error(t, err)
+		assert.Nil(t, reader)
+	})
+}
+
+// TestNew_ResetsDynamicMatcherWhenOriginConfigEmpty guards against a stale matcher from a
+// previous engine leaking into one that never called WithOriginConfig: without an explicit
+// reset, that engine would inherit the previous matcher's allowed origins instead of denying
+// all cross-origin requests.
+func (suite *EngineTestSuite) TestNew_ResetsDynamicMatcherWhenOriginConfigEmpty() {
+	t := suite.T()
+	t.Cleanup(func() { cors.InitializeDynamicMatcher(nil) })
+
+	newEngine := func(opts ...Option) *Engine {
+		tempDir := t.TempDir()
+		keyID := testKeyID
+		certPEM := generateSelfSignedCertFiles(t, tempDir, "cert.pem", "key.pem")
+		keyConfigs := []engineconfig.KeyConfig{{ID: keyID, CertFile: "cert.pem", KeyFile: "key.pem"}}
+
+		systemconfig.ResetServerRuntime()
+		t.Cleanup(systemconfig.ResetServerRuntime)
+		require.NoError(t, systemconfig.InitializeServerRuntime(tempDir, &systemconfig.Config{
+			GateClient: engineconfig.GateClientConfig{Hostname: "localhost", Port: 8080, Scheme: "https"},
+			Crypto: systemconfig.CryptoConfig{
+				Keys:       keyConfigs,
+				Encryption: engineconfig.EncryptionConfig{Key: "000102030405060708090a0b0c0d0e0f"},
+			},
+			Attestation: systemconfig.AttestationConfig{
+				Apple: systemconfig.AppleAttestationConfig{RootCertificate: string(certPEM)},
+			},
+		}))
+
+		baseOpts := []Option{
+			WithServerHome(tempDir),
+			WithServerConfig(engineconfig.ServerConfig{Identifier: "test-engine"}),
+			WithObservabilityProvider(newTestObservabilityProvider(t)),
+			WithAuthorizationProvider(newTestAuthzProvider(t)),
+			WithKeyConfigs(keyConfigs),
+			WithJWTConfig(engineconfig.JWTConfig{Issuer: "test-issuer", PreferredKeyID: keyID, ValidityPeriod: 3600}),
+			WithRuntimeStoreProvider(newTestRuntimeStoreProvider(t)),
+			WithRuntimeTransientDBType("memory"),
+			WithEncryptionConfig(engineconfig.EncryptionConfig{Key: "test-encryption-key"}),
+			WithGateClientConfig(engineconfig.GateClientConfig{Hostname: "localhost", Port: 8080, Scheme: "https"}),
+			WithCacheConfig(engineconfig.CacheConfig{Disabled: true}),
+			WithLogConfig(engineconfig.LogConfig{Level: "info", Format: "json"}),
+			WithIDPProvider(newTestIDPProvider(t)),
+			WithActorProvider(actorprovidermock.NewActorProviderMock(t)),
+			WithDefaultAuthnProvider(newTestDefaultAuthnProvider(t)),
+			WithResourceProvider(resourceserverprovidermock.NewResourceServerProviderMock(t)),
+			WithOUProvider(ouprovidermock.NewOrganizationUnitProviderMock(t)),
+			WithDesignResolveProvider(designprovidermock.NewDesignProviderMock(t)),
+			WithFlowProvider(flowexecmock.NewFlowProviderMock(t)),
+			WithI18nProvider(i18nprovidermock.NewI18nProviderMock(t)),
+			WithConsentProvider(consentprovidermock.NewConsentProviderMock(t)),
+			WithFlowConfig(engineconfig.FlowConfig{Executors: []string{"InviteExecutor", "PermissionValidator"}}),
+		}
+		return New(http.NewServeMux(), append(baseOpts, opts...)...)
+	}
+
+	eng := newEngine(WithOriginConfig(engineconfig.OriginConfig{
+		AllowedOrigins: []engineconfig.OriginEntry{{Origin: "https://app.example.com"}},
+	}))
+	require.NotNil(t, eng)
+	matcher := cors.GetDynamicMatcher(context.Background())
+	require.NotNil(t, matcher)
+	assert.True(t, mustMatch(t, matcher, "https://app.example.com"))
+
+	eng = newEngine()
+	require.NotNil(t, eng)
+	matcher = cors.GetDynamicMatcher(context.Background())
+	assert.Nil(t, matcher)
 }


### PR DESCRIPTION
### Purpose
The embedded ThunderID engine (thunderidengine) had no way to configure CORS, so cross-origin requests to its endpoints (well-known discovery, JWKS, token, userinfo, etc.) were always denied. This adds a CORSConfig option so embedders can allow specific origins.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
Added CORSConfig/CORSOrigin types supporting literal origins or regex patterns (mutually exclusive), with custom JSON/YAML marshal/unmarshal.
Added WithCORSConfig engine option; buildCORSReader validates the config and wires it into the existing cors.DynamicMatcher as a static, read-only ServerConfigReader.
Empty config leaves CORS disabled (no matcher installed), preserving current default-deny behavior.
### Related Issues
- #4939 
### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable cross-origin access rules.
  * Supports both exact origins and regular-expression-based origin matching.
  * Added JSON and YAML configuration support for origin entries.
  * Invalid, ambiguous, wildcard, or malformed origin settings are rejected during startup.

* **Bug Fixes**
  * Prevented cross-origin access when no origins are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->