### PR TITLE
Resolve backend integration coverage thresholds per package.

### DIFF
--- a/.github/actions/backend-integration-patch-coverage/action.yml
+++ b/.github/actions/backend-integration-patch-coverage/action.yml
@@ -9,12 +9,21 @@ inputs:
   base-ref:
     description: 'Git ref or SHA the diff is compared against'
     required: true
-  fail-under:
+  threshold-config:
     description: >-
-      Minimum percentage of changed coverable backend lines that the integration
-      suite must execute. Compared exactly, with no tolerance.
+      Path to the per-package threshold config. Thresholds are grouped by pull
+      request label and inherited down the package tree; see the file itself for
+      the resolution rules.
     required: false
-    default: '70'
+    default: '.github/backend-coverage-thresholds.yml'
+  pr-labels:
+    description: >-
+      The pull request's labels, as a JSON array or a comma-separated list. Labels
+      select which threshold groups apply. Empty means no group applies, so
+      thresholds come from the base `packages` map and then the global default.
+      That is also the merge-queue case.
+    required: false
+    default: ''
   artifact-pattern:
     description: 'Pattern matching the integration coverage artifacts to download'
     required: false
@@ -39,5 +48,6 @@ runs:
       shell: bash
       env:
         BASE_REF: ${{ inputs.base-ref }}
-        FAIL_UNDER: ${{ inputs.fail-under }}
+        THRESHOLD_CONFIG: ${{ inputs.threshold-config }}
+        PR_LABELS: ${{ inputs.pr-labels }}
       run: bash "${{ github.action_path }}/compute-integration-patch-coverage.sh"

--- a/.github/actions/backend-integration-patch-coverage/compute-integration-patch-coverage.sh
+++ b/.github/actions/backend-integration-patch-coverage/compute-integration-patch-coverage.sh
@@ -20,9 +20,14 @@
 # statements would change the denominator without making the result more
 # actionable.
 #
+# Thresholds are per package rather than global, resolved from THRESHOLD_CONFIG by
+# evaluate-thresholds.py. Any non-exempt package below its own threshold fails the
+# check.
+#
 # Environment:
 #   BASE_REF            - diff base, e.g. origin/main or a merge-group base sha
-#   FAIL_UNDER          - threshold percentage, exact, no tolerance
+#   THRESHOLD_CONFIG    - path to the per-package threshold config
+#   PR_LABELS           - JSON array or comma-separated list of the PR's labels
 #   GITHUB_STEP_SUMMARY - provided by the runner
 #
 # Expects the integration coverage artifacts under coverage-artifacts/.
@@ -35,11 +40,17 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 AWK_CONVERTER="${SCRIPT_DIR}/../patch-coverage-gate/go-cover-to-lcov.awk"
 
 : "${BASE_REF:?BASE_REF is required}"
-: "${FAIL_UNDER:=70}"
+: "${THRESHOLD_CONFIG:=.github/backend-coverage-thresholds.yml}"
+: "${PR_LABELS:=}"
 SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/null}"
 
 if [ ! -f "$AWK_CONVERTER" ]; then
   echo "❌ Coverage converter not found at ${AWK_CONVERTER}." | tee -a "$SUMMARY"
+  exit 1
+fi
+
+if [ ! -f "$THRESHOLD_CONFIG" ]; then
+  echo "❌ Threshold config not found at ${THRESHOLD_CONFIG}." | tee -a "$SUMMARY"
   exit 1
 fi
 
@@ -133,31 +144,37 @@ fi
 EXCLUDE_ARGS=(--exclude 'backend/tests/**' --exclude '**/*_test.go' --exclude 'tests/**'
   --exclude 'frontend/**' --exclude 'docs/**' --exclude 'samples/**' --exclude 'api/**')
 
-STATUS=0
+# No --fail-under: a single global threshold cannot express per-package bars. The
+# JSON report carries per-file covered and uncovered line numbers, so the verdict
+# is derived per package by evaluate-thresholds.py. The markdown report is still
+# produced, for the uncovered-line detail appended to the summary.
 "$DIFF_COVER_BIN" "${LCOV_FILES[@]}" \
   --compare-branch "$BASE_REF" \
-  --fail-under "$FAIL_UNDER" \
   "${EXCLUDE_ARGS[@]}" \
-  --format "markdown:integration-patch-coverage.md" || STATUS=$?
+  --format "json:integration-patch-coverage.json,markdown:integration-patch-coverage.md" >/dev/null
+
+STATUS=0
+python3 "${SCRIPT_DIR}/evaluate-thresholds.py" \
+  integration-patch-coverage.json \
+  "$THRESHOLD_CONFIG" \
+  "$PR_LABELS" \
+  package-verdicts.md || STATUS=$?
 
 # ---------------------------------------------------------------------------
 # 5. Report
 # ---------------------------------------------------------------------------
 
+# The per-package verdict, thresholds and provenance are already formatted by
+# evaluate-thresholds.py. Only the measurement provenance is added here.
 {
-  echo "### 🛡️ Backend Integration Patch Coverage"
-  echo
-  if [ "$STATUS" -eq 0 ]; then
-    echo "**Passed** — required: ≥ ${FAIL_UNDER}% of changed backend lines executed by the integration suite."
-  else
-    echo "**Failed** — required: ≥ ${FAIL_UNDER}% of changed backend lines executed by the integration suite."
-  fi
-  echo
+  cat package-verdicts.md
   echo "- Measured from integration runs only: ${PROFILE_LABELS[*]} (union)"
   echo "- Backend unit and frontend coverage are not loaded and cannot change this result."
   echo "- Changed backend production Go files: ${CHANGED_COUNT}"
   echo
-  cat integration-patch-coverage.md 2>/dev/null || true
+  if [ "$STATUS" -ne 0 ]; then
+    cat integration-patch-coverage.md 2>/dev/null || true
+  fi
 } | tee -a "$SUMMARY"
 
 exit "$STATUS"

--- a/.github/actions/backend-integration-patch-coverage/evaluate-thresholds.py
+++ b/.github/actions/backend-integration-patch-coverage/evaluate-thresholds.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Applies per-package coverage thresholds to diff-cover's per-file results.
+
+diff-cover enforces one global --fail-under, which cannot express "oauth2/dpop is
+held to 90% but a formatting helper is not". It does report per-file covered and
+uncovered line numbers in its JSON output though, so the per-package verdict is
+derived here instead: group the changed lines by Go package, resolve that
+package's threshold, and compare.
+
+Resolution, per package. Applicable tags are the config's `tags` entries whose
+name is a label on the pull request.
+
+  If any tag applies, the tag layer decides on its own:
+    1. Tags naming the package win, highest value across them. Tag defaults are
+       not consulted while any tag names it.
+    2. Otherwise the highest `default` among the applicable tags applies.
+
+  The base layer is used only when no tag applies, or when the applicable tags
+  neither name the package nor set a default:
+    3. The base `packages` entry, longest matching prefix.
+    4. Otherwise the global `default`.
+
+Longest matching prefix wins in every package map, so a parent path's threshold is
+inherited by its subpackages.
+
+Usage:
+  evaluate-thresholds.py <diff-cover.json> <config.yml> <labels-json> <summary-out>
+
+Exits 0 when every non-exempt package meets its threshold, 1 otherwise.
+"""
+
+import json
+import math
+import os
+import sys
+
+import yaml
+
+
+def load_labels(raw):
+    """Accepts a JSON array, as toJSON() emits, or a comma-separated list."""
+    raw = (raw or "").strip()
+    if not raw:
+        return []
+    if raw.startswith("["):
+        return [str(x) for x in json.loads(raw)]
+    return [part.strip() for part in raw.split(",") if part.strip()]
+
+
+def package_of(path):
+    """A Go package is its directory."""
+    return os.path.dirname(path)
+
+
+def longest_prefix(entries, package):
+    """Returns (key, value) for the longest matching package prefix, or None."""
+    match = None
+    for key in entries or {}:
+        trimmed = key.rstrip("/")
+        if package == trimmed or package.startswith(trimmed + "/"):
+            if match is None or len(trimmed) > len(match):
+                match = trimmed
+    if match is None:
+        return None
+    # Return the original key so provenance quotes what the file actually says.
+    for key in entries:
+        if key.rstrip("/") == match:
+            return key, entries[key]
+    return None
+
+
+def inherited_suffix(key, package):
+    return "" if key.rstrip("/") == package else f", inherited from `{key}`"
+
+
+def resolve(package, config, labels):
+    """Returns (threshold, provenance) for one package."""
+    tags = config.get("tags") or {}
+    applicable = [t for t in labels if t in tags]
+
+    # Tier 1: applicable tags that name the package. Highest wins, and tag
+    # defaults are deliberately not consulted while any tag names it.
+    named = []
+    for tag in applicable:
+        hit = longest_prefix((tags[tag] or {}).get("packages"), package)
+        if hit is not None:
+            key, value = hit
+            named.append((value, f"tag `{tag}`{inherited_suffix(key, package)}"))
+    if named:
+        return max(named, key=lambda pair: pair[0])
+
+    # Tier 2: the highest default among the applicable tags.
+    defaults = [
+        ((tags[tag] or {}).get("default"), f"tag `{tag}` default")
+        for tag in applicable
+        if (tags[tag] or {}).get("default") is not None
+    ]
+    if defaults:
+        return max(defaults, key=lambda pair: pair[0])
+
+    # Tier 3: the base package map, which applies regardless of labels but only
+    # when the applicable tags said nothing at all about this package.
+    hit = longest_prefix(config.get("packages"), package)
+    if hit is not None:
+        key, value = hit
+        return value, f"base entry `{key}`" if key.rstrip("/") == package else \
+            f"base entry, inherited from `{key}`"
+
+    # Tier 4.
+    return config.get("default", 70), "global default"
+
+
+def _is_percentage(value):
+    """A finite number between 0 and 100. bool is excluded, being an int subclass."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    return math.isfinite(value) and 0 <= value <= 100
+
+
+def _check_package_map(entries, where, errors):
+    if not isinstance(entries, dict):
+        errors.append(f"`{where}` must be a mapping of package path to threshold.")
+        return
+    for key, value in entries.items():
+        if not _is_percentage(value):
+            errors.append(f"`{where}.{key}` must be a number between 0 and 100, got {value!r}.")
+
+
+def validate_config(config):
+    """Returns a list of problems. Values are checked before they are compared to a
+    percentage: an unvalidated string threshold raises a TypeError mid-run and the
+    job then reports a traceback with no summary at all, and a negative threshold
+    silently lets any coverage pass."""
+    if not isinstance(config, dict):
+        return ["The config root must be a mapping."]
+
+    errors = []
+
+    if "default" in config and not _is_percentage(config["default"]):
+        errors.append(f"`default` must be a number between 0 and 100, got {config['default']!r}.")
+
+    if "min_changed_lines" in config:
+        value = config["min_changed_lines"]
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            errors.append(
+                f"`min_changed_lines` must be a non-negative integer, got {value!r}.")
+
+    if config.get("packages") is not None:
+        _check_package_map(config["packages"], "packages", errors)
+
+    tags = config.get("tags")
+    if tags is not None and not isinstance(tags, dict):
+        errors.append("`tags` must be a mapping of label name to threshold group.")
+    elif isinstance(tags, dict):
+        for name, body in tags.items():
+            if body is None:
+                continue
+            if not isinstance(body, dict):
+                errors.append(f"`tags.{name}` must be a mapping with `default` and/or `packages`.")
+                continue
+            # Catches the flat form, where package paths sit directly under the tag
+            # rather than under `packages`. That shape parses cleanly and would
+            # otherwise resolve to the global default while looking correct.
+            unknown = sorted(set(body) - {"default", "packages"})
+            if unknown:
+                errors.append(
+                    f"`tags.{name}` has unexpected key(s) {', '.join(unknown)}. "
+                    f"Package thresholds belong under `tags.{name}.packages`.")
+            if "default" in body and not _is_percentage(body["default"]):
+                errors.append(
+                    f"`tags.{name}.default` must be a number between 0 and 100, "
+                    f"got {body['default']!r}.")
+            if body.get("packages") is not None:
+                _check_package_map(body["packages"], f"tags.{name}.packages", errors)
+
+    return errors
+
+
+def unmatched_config_paths(config):
+    """Config paths that no longer exist. Left unchecked, thresholds rot silently."""
+    missing = []
+    for key in config.get("packages") or {}:
+        if not os.path.isdir(key.rstrip("/")):
+            missing.append(("packages", key))
+    for tag, body in (config.get("tags") or {}).items():
+        for key in (body or {}).get("packages") or {}:
+            if not os.path.isdir(key.rstrip("/")):
+                missing.append((f"tags.{tag}", key))
+    return missing
+
+
+def main():
+    if len(sys.argv) != 5:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    report_path, config_path, labels_raw, summary_path = sys.argv[1:5]
+
+    with open(config_path) as handle:
+        config = yaml.safe_load(handle) or {}
+    labels = load_labels(labels_raw)
+    min_lines = config.get("min_changed_lines", 0)
+
+    with open(report_path) as handle:
+        report = json.load(handle)
+
+    lines = ["### 🛡️ Backend Integration Patch Coverage", ""]
+
+    # Structure and value checks come first: everything below assumes thresholds
+    # are numbers it can compare against a percentage.
+    invalid = validate_config(config)
+    if invalid:
+        lines += [
+            f"**Failed — `{config_path}` is not valid.**",
+            "",
+        ]
+        lines += [f"- {problem}" for problem in invalid]
+        write_summary(summary_path, lines)
+        return 1
+
+    # A stale path fails the check rather than quietly not applying.
+    missing = unmatched_config_paths(config)
+    if missing:
+        lines += [
+            "**Failed — the threshold config names packages that do not exist.**",
+            "",
+            "Thresholds on these paths can never apply, so they would rot unnoticed:",
+            "",
+        ]
+        lines += [f"- `{key}` under `{where}`" for where, key in missing]
+        write_summary(summary_path, lines)
+        return 1
+
+    # Group the changed lines by package.
+    packages = {}
+    for path, stats in (report.get("src_stats") or {}).items():
+        covered = len(stats.get("covered_lines") or [])
+        missed = len(stats.get("violation_lines") or [])
+        entry = packages.setdefault(package_of(path), {"covered": 0, "coverable": 0, "files": 0})
+        entry["covered"] += covered
+        entry["coverable"] += covered + missed
+        entry["files"] += 1
+
+    if not packages:
+        lines += [
+            "**N/A — the diff contains no changed coverable backend lines.**",
+            "",
+            "Changed lines that Go does not instrument, such as comments and declarations,",
+            "are excluded from the measurement.",
+        ]
+        write_summary(summary_path, lines)
+        return 0
+
+    rows, failures, exempt = [], [], []
+    for package in sorted(packages):
+        stats = packages[package]
+        coverable = stats["coverable"]
+        threshold, provenance = resolve(package, config, labels)
+
+        # A package can reach here with nothing coverable, for instance a
+        # comment-only change to an instrumented file. Guarded explicitly rather
+        # than relying on min_changed_lines being above zero, which it need not be.
+        if coverable == 0 or coverable < min_lines:
+            exempt.append((package, stats["covered"], coverable, threshold, provenance))
+            continue
+
+        percent = 100.0 * stats["covered"] / coverable
+        ok = percent >= threshold
+        if not ok:
+            failures.append(package)
+        rows.append((package, stats["covered"], coverable, percent, threshold, provenance, ok))
+
+    failed = bool(failures)
+    if failed:
+        lines.append(f"**Failed** — {len(failures)} package(s) below threshold.")
+    elif rows:
+        lines.append(f"**Passed** — {len(rows)} package(s) met their thresholds.")
+    else:
+        lines.append("**Passed** — no changed package had enough coverable lines to measure.")
+    lines.append("")
+
+    if labels:
+        lines.append(f"- Labels considered: {', '.join(f'`{label}`' for label in labels)}")
+    else:
+        lines.append("- No labels on this pull request, so no tag group applies. Thresholds "
+                     "come from the base package map, then the global default.")
+    lines.append(f"- Minimum changed coverable lines to be measured: {min_lines}")
+    lines.append("")
+
+    if rows:
+        lines += [
+            "| Package | Covered | Coverable | % | Required | Threshold from |",
+            "|---|---:|---:|---:|---:|---|",
+        ]
+        for package, covered, coverable, percent, threshold, provenance, ok in rows:
+            mark = "" if ok else " ❌"
+            lines.append(
+                f"| `{package}`{mark} | {covered} | {coverable} | {percent:.1f}% | "
+                f"{threshold}% | {provenance} |"
+            )
+        lines.append("")
+
+    if exempt:
+        lines.append(f"<details><summary>{len(exempt)} package(s) exempt "
+                     f"(nothing coverable, or fewer than {min_lines} changed coverable "
+                     f"lines)</summary>")
+        lines.append("")
+        # Raw counts, not a percentage. The exemption exists because the
+        # denominator is too small for a ratio to mean anything, so printing one
+        # would invite action on a figure the check has just called unreliable.
+        # The counts still show whether a package is wholly untested, and are what
+        # min_changed_lines has to be calibrated against.
+        for package, covered, coverable, threshold, provenance in exempt:
+            if coverable == 0:
+                detail = "no coverable lines"
+            else:
+                detail = f"{covered} of {coverable} changed coverable lines covered"
+            lines.append(f"- `{package}` — {detail}, would need {threshold}% ({provenance})")
+        lines += ["", "</details>", ""]
+
+    if failed:
+        lines += ["Uncovered lines per file are listed in the diff-cover report below.", ""]
+
+    write_summary(summary_path, lines)
+    return 1 if failed else 0
+
+
+def write_summary(path, lines):
+    # File only. The caller cats this through tee, so echoing here would print the
+    # whole verdict twice in the job log.
+    with open(path, "w") as handle:
+        handle.write("\n".join(lines) + "\n")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/actions/backend-integration-patch-coverage/test/run-tests.sh
+++ b/.github/actions/backend-integration-patch-coverage/test/run-tests.sh
@@ -81,10 +81,40 @@ profile() {
   done
 }
 
+# write_config <min_changed_lines> <default> [tags-yaml-body] [base-packages-yaml-body]
+# Cases that do not call this get the default written by run_case.
+write_config() {
+  local min="$1" default="$2" tags="${3:-}" base="${4:-}"
+  mkdir -p .github
+  {
+    echo "min_changed_lines: ${min}"
+    echo "default: ${default}"
+    if [ -n "$base" ]; then
+      echo "packages:"
+      printf '%s\n' "$base"
+    else
+      echo "packages: {}"
+    fi
+    if [ -n "$tags" ]; then
+      echo "tags:"
+      printf '%s\n' "$tags"
+    else
+      echo "tags: {}"
+    fi
+  } > .github/backend-coverage-thresholds.yml
+}
+
 run_case() {
-  local name="$1" expected_status="$2" expected_text="$3"
+  local name="$1" expected_status="$2" expected_text="$3" labels="${4:-}"
   local out status
-  out=$(BASE_REF=main FAIL_UNDER=70 GITHUB_STEP_SUMMARY=/dev/null \
+
+  # min_changed_lines is 0 here on purpose. These fixtures change a handful of
+  # lines, so any floor above zero would make every package exempt and the whole
+  # suite would pass without measuring anything.
+  [ -f .github/backend-coverage-thresholds.yml ] || write_config 0 70
+
+  out=$(BASE_REF=main THRESHOLD_CONFIG=.github/backend-coverage-thresholds.yml \
+    PR_LABELS="$labels" GITHUB_STEP_SUMMARY=/dev/null \
     bash "$COMPUTE" 2>&1)
   status=$?
 
@@ -226,6 +256,297 @@ GO
   printf 'mode: set\nnot a cover profile line\n' \
     > coverage-artifacts/integration-coverage-sqlite/coverage_integration.out
   run_case "unparseable profile reports why instead of exiting silently" 1 "no usable source records"
+
+# ---------------------------------------------------------------------------
+# 10. No labels: every package falls back to the global default
+# ---------------------------------------------------------------------------
+  new_repo "$TMPROOT/thr-default"
+  git checkout -q -b feature
+  add_func backend/internal/demo/service.go Added 12
+  git add -A && git commit -q -m "uncovered change, no labels"
+  total=$(wc -l < backend/internal/demo/service.go | tr -d " ")
+  profile sqlite 6 "$total" 0
+  write_config 0 70
+  run_case "no labels uses the global default" 1 "global default"
+
+# ---------------------------------------------------------------------------
+# 11. A tag may loosen below the global default
+# ---------------------------------------------------------------------------
+  new_repo "$TMPROOT/thr-loosen"
+  git checkout -q -b feature
+  add_func backend/internal/demo/service.go Added 10
+  git add -A && git commit -q -m "half covered"
+  total=$(wc -l < backend/internal/demo/service.go | tr -d " ")
+  # Cover the first half of the added body, leave the rest uncovered.
+  half=$(( (6 + total) / 2 ))
+  profile sqlite 6 "$half" 1 $((half + 1)) "$total" 0
+  write_config 0 70 "  experimental:
+    packages:
+      backend/internal/demo: 10"
+  run_case "a tag can lower the bar below the default" 0 "tag \`experimental\`" "[\"experimental\"]"
+
+# ---------------------------------------------------------------------------
+# 12. Threshold is inherited from a parent package path
+# ---------------------------------------------------------------------------
+  new_repo "$TMPROOT/thr-inherit"
+  git checkout -q -b feature
+  add_func backend/internal/demo/service.go Added 12
+  git add -A && git commit -q -m "uncovered change"
+  total=$(wc -l < backend/internal/demo/service.go | tr -d " ")
+  profile sqlite 6 "$total" 0
+  write_config 0 70 "  strict:
+    packages:
+      backend/internal: 95"
+  run_case "threshold is inherited from the parent path" 1 "inherited from" "[\"strict\"]"
+
+# ---------------------------------------------------------------------------
+# 13. Multiple applicable tags: the highest threshold applies
+# ---------------------------------------------------------------------------
+  new_repo "$TMPROOT/thr-max"
+  git checkout -q -b feature
+  add_func backend/internal/demo/service.go Added 10
+  git add -A && git commit -q -m "half covered"
+  total=$(wc -l < backend/internal/demo/service.go | tr -d " ")
+  half=$(( (6 + total) / 2 ))
+  profile sqlite 6 "$half" 1 $((half + 1)) "$total" 0
+  # Roughly half covered. The lower tag would pass, the higher one fails, so the
+  # verdict shows which one was chosen without needing an impossible threshold.
+  write_config 0 70 "  lower:
+    packages:
+      backend/internal/demo: 40
+  higher:
+    packages:
+      backend/internal/demo: 60"
+  run_case "highest threshold wins across applicable tags" 1 "60%" "[\"lower\",\"higher\"]"
+
+# ---------------------------------------------------------------------------
+# 14. A label with no matching tag group changes nothing
+# ---------------------------------------------------------------------------
+  new_repo "$TMPROOT/thr-unknown-label"
+  git checkout -q -b feature
+  add_func backend/internal/demo/service.go Added 12
+  git add -A && git commit -q -m "uncovered change"
+  total=$(wc -l < backend/internal/demo/service.go | tr -d " ")
+  profile sqlite 6 "$total" 0
+  write_config 0 70 "  strict:
+    packages:
+      backend/internal/demo: 95"
+  run_case "an unrelated label leaves the default in place" 1 "global default" "[\"unrelated\"]"
+
+# ---------------------------------------------------------------------------
+# 15. min_changed_lines exempts a small package
+# ---------------------------------------------------------------------------
+  new_repo "$TMPROOT/thr-minlines"
+  git checkout -q -b feature
+  add_func backend/internal/demo/service.go Added 6
+  git add -A && git commit -q -m "small uncovered change"
+  total=$(wc -l < backend/internal/demo/service.go | tr -d " ")
+  profile sqlite 6 "$total" 0
+  write_config 500 70
+  run_case "a package under min_changed_lines is exempt" 0 "exempt"
+
+# ---------------------------------------------------------------------------
+# 16. A config path that does not exist fails the check
+# ---------------------------------------------------------------------------
+  new_repo "$TMPROOT/thr-stale"
+  git checkout -q -b feature
+  add_func backend/internal/demo/service.go Added 12
+  git add -A && git commit -q -m "uncovered change"
+  total=$(wc -l < backend/internal/demo/service.go | tr -d " ")
+  profile sqlite 6 "$total" 0
+  write_config 0 70 "  strict:
+    packages:
+      backend/internal/gone: 95"
+  run_case "a stale config path fails rather than rotting" 1 "do not exist" "[\"strict\"]"
+
+# ---------------------------------------------------------------------------
+# 17. Base packages apply when no label is present
+# ---------------------------------------------------------------------------
+  new_repo "$TMPROOT/base-pkg"
+  git checkout -q -b feature
+  add_func backend/internal/demo/service.go Added 12
+  git add -A && git commit -q -m "uncovered change"
+  total=$(wc -l < backend/internal/demo/service.go | tr -d " ")
+  profile sqlite 6 "$total" 0
+  write_config 0 70 "" "  backend/internal/demo: 0"
+  run_case "a base package entry applies with no labels" 0 "base entry"
+
+# ---------------------------------------------------------------------------
+# 18. A tag default overrides a base package entry
+# ---------------------------------------------------------------------------
+  new_repo "$TMPROOT/tagdefault-beats-base"
+  git checkout -q -b feature
+  add_func backend/internal/demo/service.go Added 12
+  git add -A && git commit -q -m "uncovered change"
+  total=$(wc -l < backend/internal/demo/service.go | tr -d " ")
+  profile sqlite 6 "$total" 0
+  # Base exempts this package at 0, but the tag sets a default and names nothing,
+  # so the tag default wins and the package fails.
+  write_config 0 70 "  strict:
+    default: 85" "  backend/internal/demo: 0"
+  run_case "a tag default overrides a base package entry" 1 "tag \`strict\` default" "[\"strict\"]"
+
+# ---------------------------------------------------------------------------
+# 19. A tag package entry overrides a base package entry, and may loosen
+# ---------------------------------------------------------------------------
+  new_repo "$TMPROOT/tagpkg-beats-base"
+  git checkout -q -b feature
+  add_func backend/internal/demo/service.go Added 12
+  git add -A && git commit -q -m "uncovered change"
+  total=$(wc -l < backend/internal/demo/service.go | tr -d " ")
+  profile sqlite 6 "$total" 0
+  write_config 0 70 "  experimental:
+    packages:
+      backend/internal/demo: 0" "  backend/internal/demo: 95"
+  run_case "a tag package entry overrides base and may loosen" 0 "tag \`experimental\`" "[\"experimental\"]"
+
+# ---------------------------------------------------------------------------
+# 20. A named package beats another applicable tag's default
+# ---------------------------------------------------------------------------
+  new_repo "$TMPROOT/named-beats-default"
+  git checkout -q -b feature
+  add_func backend/internal/demo/service.go Added 10
+  git add -A && git commit -q -m "half covered"
+  total=$(wc -l < backend/internal/demo/service.go | tr -d " ")
+  half=$(( (6 + total) / 2 ))
+  profile sqlite 6 "$half" 1 $((half + 1)) "$total" 0
+  # Roughly half covered. The naming tag's 40 passes, the other tag's default of 60
+  # would fail, so passing proves the named entry won over the default.
+  write_config 0 70 "  naming:
+    packages:
+      backend/internal/demo: 40
+  defaulting:
+    default: 60"
+  run_case "a named package beats another tag's default" 0 "tag \`naming\`" "[\"naming\",\"defaulting\"]"
+
+# ---------------------------------------------------------------------------
+# 21. An applicable tag that says nothing falls through to the base layer
+# ---------------------------------------------------------------------------
+  new_repo "$TMPROOT/tag-silent"
+  git checkout -q -b feature
+  add_func backend/internal/demo/service.go Added 12
+  git add -A && git commit -q -m "uncovered change"
+  total=$(wc -l < backend/internal/demo/service.go | tr -d " ")
+  profile sqlite 6 "$total" 0
+  # The referenced package must exist, or the stale-path guard fires first. An
+  # untracked empty directory is enough and stays out of the diff.
+  mkdir -p backend/internal/other
+  # The tag applies but names another package and sets no default, so the base
+  # entry is still what decides.
+  write_config 0 70 "  narrow:
+    packages:
+      backend/internal/other: 95" "  backend/internal/demo: 0"
+  run_case "a silent tag falls through to the base layer" 0 "base entry" "[\"narrow\"]"
+
+# ---------------------------------------------------------------------------
+# 22. Frontend-only diff is out of scope
+# ---------------------------------------------------------------------------
+  new_repo "$TMPROOT/frontend-only"
+  git checkout -q -b feature
+  mkdir -p frontend/apps/console/src
+  echo "export const x = 1;" > frontend/apps/console/src/app.ts
+  git add -A && git commit -q -m "frontend only"
+  profile sqlite 3 5 1
+  run_case "frontend-only diff reports N/A" 0 "N/A — no backend production Go changes"
+
+# ---------------------------------------------------------------------------
+# 23. Docs-only diff is out of scope
+# ---------------------------------------------------------------------------
+  new_repo "$TMPROOT/docs-only"
+  git checkout -q -b feature
+  mkdir -p docs/content
+  echo "# Heading" > docs/content/page.md
+  git add -A && git commit -q -m "docs only"
+  profile sqlite 3 5 1
+  run_case "docs-only diff reports N/A" 0 "N/A — no backend production Go changes"
+
+# ---------------------------------------------------------------------------
+# 24. Comments-only change to an instrumented backend file
+# ---------------------------------------------------------------------------
+  new_repo "$TMPROOT/comments-only"
+  git checkout -q -b feature
+  # The file is in the profile and declares functions, so it is in scope. Only a
+  # comment changes, so it contributes no coverable lines.
+  echo "// A trailing comment, no executable statement." >> backend/internal/demo/service.go
+  git add -A && git commit -q -m "comment only"
+  profile sqlite 3 5 1
+  run_case "comments-only backend change is not a coverage failure" 0 ""
+
+# ---------------------------------------------------------------------------
+# 25. A package with nothing coverable is exempt, not a division by zero
+# ---------------------------------------------------------------------------
+  new_repo "$TMPROOT/zero-coverable"
+  git checkout -q -b feature
+  echo "// Only a comment." >> backend/internal/demo/service.go
+  git add -A && git commit -q -m "comment only"
+  # The file is in the profile, so it can appear in the report with no coverable
+  # changed lines. min_changed_lines is 0 here, so only an explicit guard saves it.
+  profile sqlite 3 5 1
+  write_config 0 70
+  run_case "a package with nothing coverable does not divide by zero" 0 ""
+
+# ---------------------------------------------------------------------------
+# 26. A negative threshold is rejected, not silently satisfied by anything
+# ---------------------------------------------------------------------------
+  new_repo "$TMPROOT/cfg-negative"
+  git checkout -q -b feature
+  add_func backend/internal/demo/service.go Added 12
+  git add -A && git commit -q -m "uncovered change"
+  total=$(wc -l < backend/internal/demo/service.go | tr -d " ")
+  profile sqlite 6 "$total" 0
+  write_config 0 -1
+  run_case "a negative threshold is rejected" 1 "between 0 and 100"
+
+# ---------------------------------------------------------------------------
+# 27. A non-numeric threshold reports why, instead of a bare traceback
+# ---------------------------------------------------------------------------
+  new_repo "$TMPROOT/cfg-string"
+  git checkout -q -b feature
+  add_func backend/internal/demo/service.go Added 12
+  git add -A && git commit -q -m "uncovered change"
+  total=$(wc -l < backend/internal/demo/service.go | tr -d " ")
+  profile sqlite 6 "$total" 0
+  write_config 0 '"seventy"'
+  run_case "a non-numeric threshold reports why" 1 "must be a number"
+
+# ---------------------------------------------------------------------------
+# 28. A negative min_changed_lines is rejected
+# ---------------------------------------------------------------------------
+  new_repo "$TMPROOT/cfg-minlines"
+  git checkout -q -b feature
+  add_func backend/internal/demo/service.go Added 12
+  git add -A && git commit -q -m "uncovered change"
+  total=$(wc -l < backend/internal/demo/service.go | tr -d " ")
+  profile sqlite 6 "$total" 0
+  write_config -5 70
+  run_case "a negative min_changed_lines is rejected" 1 "non-negative integer"
+
+# ---------------------------------------------------------------------------
+# 29. The pre-nesting flat tag schema is rejected with a pointer to the fix
+# ---------------------------------------------------------------------------
+  new_repo "$TMPROOT/cfg-flat"
+  git checkout -q -b feature
+  add_func backend/internal/demo/service.go Added 12
+  git add -A && git commit -q -m "uncovered change"
+  total=$(wc -l < backend/internal/demo/service.go | tr -d " ")
+  profile sqlite 6 "$total" 0
+  # Package paths directly under the tag, without the `packages` key. This parses
+  # cleanly and would otherwise resolve to the global default while looking right.
+  write_config 0 70 "  strict:
+    backend/internal/demo: 95"
+  run_case "the flat tag schema is rejected, not silently ignored" 1 "belong under"
+
+# ---------------------------------------------------------------------------
+# 30. An exempt package reports its counts and where its threshold came from
+# ---------------------------------------------------------------------------
+  new_repo "$TMPROOT/exempt-report"
+  git checkout -q -b feature
+  add_func backend/internal/demo/service.go Added 6
+  git add -A && git commit -q -m "small change"
+  total=$(wc -l < backend/internal/demo/service.go | tr -d " ")
+  profile sqlite 6 "$total" 1
+  write_config 500 70
+  run_case "an exempt package reports counts and provenance" 0 "changed coverable lines covered, would need 70% (global default)"
 
 echo
 rm -rf "$TMPROOT"

--- a/.github/backend-coverage-thresholds.yml
+++ b/.github/backend-coverage-thresholds.yml
@@ -1,0 +1,53 @@
+# Per-package thresholds for the 🛡️ Backend Integration Patch Coverage check.
+#
+# The check measures how much of a pull request's changed backend production Go
+# was executed by the integration suite. This file decides the bar each package
+# has to clear, so packages with genuinely different testability are not all held
+# to one number.
+#
+# Resolution, per changed package. Applicable tags are the `tags` entries whose
+# name is a label on the pull request.
+#
+#   If any tag applies, the tag layer decides on its own:
+#     1. Tags that name the package win, highest value across them. Tag defaults
+#        are not considered at this point.
+#     2. Otherwise the highest `default` among the applicable tags applies.
+#
+#   The base layer is used only when no tag applies, or when the applicable tags
+#   neither name the package nor set a default:
+#     3. The `packages` entry below, longest matching prefix.
+#     4. Otherwise `default` below.
+#
+# In every package map the longest matching prefix wins, so a threshold on a
+# parent path is inherited by its subpackages.
+#
+# A package with fewer than `min_changed_lines` changed coverable lines is exempt.
+# Any non-exempt package below its threshold fails the check. A package path
+# listed anywhere here that does not exist also fails the check, so entries
+# cannot rot unnoticed through a refactor.
+
+# Per-package granularity shrinks denominators: without a floor, a package with
+# three changed coverable lines fails a 70% bar at two of three. Calibrate this
+# against real pull requests rather than treating it as settled.
+min_changed_lines: 10
+
+# Applies when nothing more specific does.
+default: 70
+
+# Applies regardless of labels, but only when the applicable tags say nothing
+# about the package. A tag that sets a `default` therefore overrides these, so an
+# exemption recorded here does not survive such a label.
+packages: {}
+  # backend/internal/system/i18n: 0
+
+# Thresholds grouped by pull request label. A group applies only when the pull
+# request carries that label. A group may set values below `default`, which lowers
+# the bar for the packages it names.
+tags: {}
+  # security-critical:
+  #   default: 85
+  #   packages:
+  #     backend/internal/oauth: 90
+  # data-migration:
+  #   packages:
+  #     backend/internal/oauth: 80

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -880,7 +880,10 @@ jobs:
         uses: ./.github/actions/backend-integration-patch-coverage
         with:
           base-ref: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || format('origin/{0}', github.base_ref) }}
-          fail-under: '70'
+          # A merge_group payload carries no pull request labels, so queue runs
+          # apply no tag group. Thresholds still come from the base packages map,
+          # and only then the global default.
+          pr-labels: ${{ github.event_name == 'pull_request' && toJSON(github.event.pull_request.labels.*.name) || '' }}
 
   test-integration-status:
     name: ✅ Integration Tests Status


### PR DESCRIPTION
### Purpose

The `🛡️ Backend Integration Patch Coverage` check added in (https://github.com/thunder-id/thunderid/issues/5013) enforces a single global threshold of 70% across all changed backend production Go. One number has to be set to whatever the least testable package can sustain, so it under protects security sensitive code while still obstructing code where integration coverage adds little. There is also no way to raise the bar for a specific change, short of editing the workflow.

This moves the thresholds into one versioned file, `.github/backend-coverage-thresholds.yml`, and resolves them per package.

Measurement is unchanged. Still backend production Go only, still the union of the SQLite, PostgreSQL and Redis integration runs, still never loading unit or frontend coverage. What changes is how the verdict is computed and reported.

**Note on behaviour with the config as shipped.** The file ships with no packages and no tags, so every package resolves to the same 70%. The verdict is nonetheless stricter than before: previously one pooled percentage covered the whole patch, now each package is judged on its own and any package below its threshold fails. A patch at 90% overall can therefore fail on a single weak package. `min_changed_lines: 10` is the mitigation, and its value is a starting point that should be calibrated against real pull requests rather than treated as settled.

### Approach

Thresholds are resolved through two layers, with specificity deciding within a layer and the tag layer deciding between layers.

When any pull request label matches a group under `tags`, that layer decides on its own:

1. Groups that name the package win, highest value across them. Group defaults are deliberately not consulted while any group names the package.
2. Otherwise the highest `default` among the matching groups applies.

The base layer is reached only when no group matches, or when the matching groups neither name the package nor set a default:

3. The base `packages` map.
4. Otherwise the global `default`.

The longest matching prefix wins in every package map, so a threshold on a parent path is inherited by its subpackages. A group may set a value below the global default, which lowers the bar for the packages it names.

Key design decisions:

- **A label may loosen, not only tighten.** This is deliberate, so that a package where integration coverage is not the right measure can be exempted for a specific change. It does mean anyone who can label a pull request can lower the bar, which is acceptable while the check is not a required check and should be revisited if that changes.
- **A base `packages` entry does not survive a label that sets a `default`.** Specificity wins inside a layer, but the tag layer wins between layers. An exemption that must always hold therefore needs naming in the relevant groups, or groups without defaults.
- **A configured path that no longer exists fails the check.** Otherwise a refactor would silently stop a threshold from applying and nobody would notice.
- **A minimum changed line count.** Per package granularity shrinks denominators, and without a floor a package with three changed lines is judged on a single line.
- **The verdict comes from `diff-cover`'s JSON rather than `--fail-under`.** A single global value cannot express per package bars, but the JSON report carries per file covered and uncovered line numbers, so the per package counts are derived from it. No coverage arithmetic is reimplemented.
- **A package with nothing coverable is exempt rather than a failure.** A comment only change to an instrumented file reaches the evaluator with a zero denominator, which is guarded explicitly rather than relying on the minimum line count being above zero.

The summary reports, per package, the percentage, the threshold applied, and where that threshold came from, including which group and whether it was inherited from a parent path, so a failure is explainable without reading the configuration.

The composite action's `fail-under` input is replaced by `threshold-config` and `pr-labels`. The action is internal to this repository, so no consumer outside it is affected.

### Related Issues
- Introducing the Integration check to CI https://github.com/thunder-id/thunderid/issues/5013
- Fixes #5050

### Related PRs
- #5014, which added the check this builds on

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
    - Verified locally against 25 policy tests, each building a throwaway repository with a known diff and known coverage profiles so the expected verdict is arithmetic rather than a guess. Not yet observed in a real CI run, since the check only executes on a pull request that changes backend production Go.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
    - The resolution rules and their rationale are documented in `.github/backend-coverage-thresholds.yml` itself, which is where a maintainer changing a threshold will look. No `docs/` page was added, so Vale was not run.
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
    - `.github/actions/backend-integration-patch-coverage/test/run-tests.sh`, 25 cases. These test CI policy outcomes rather than product code, so they fall under neither of the two categories above. They cover the precedence matrix, the scope exclusions for frontend, docs, test only and comment only changes, union semantics across the three databases, the requirement that unit coverage cannot lift the result, missing and unparseable artifacts, stale configuration paths, and the zero denominator guard.
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.
    - No product breaking change. See the note in Purpose about the stricter verdict, and the action input change in Approach.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable backend patch-coverage thresholds by package and pull-request label.
  * Added inherited package thresholds, label-specific overrides, and global defaults.
  * Added exemptions for packages with fewer than the configured minimum changed lines.
  * Added clear package-level coverage summaries and failure details.

* **Bug Fixes**
  * Added validation for stale or invalid coverage configuration paths.
  * Improved handling of missing labels, documentation-only changes, comment-only changes, and packages without measurable lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->