### PR TITLE
Fix(scim): SCIM PUT /Me returning 500 for self-service callers

### DIFF
--- a/backend/cmd/server/config/default.json
+++ b/backend/cmd/server/config/default.json
@@ -169,6 +169,9 @@
   "group": {
     "store": "composite"
   },
+  "scim": {
+    "core_attrs_on_get": false
+  },
   "declarative_resources": {
     "enabled": false
   },

--- a/backend/internal/scim/SCIMUsersServiceInterface_mock_test.go
+++ b/backend/internal/scim/SCIMUsersServiceInterface_mock_test.go
@@ -342,8 +342,8 @@ func (_c *SCIMUsersServiceInterfaceMock_ListUsers_Call) RunAndReturn(run func(ct
 }
 
 // ReplaceUser provides a mock function for the type SCIMUsersServiceInterfaceMock
-func (_mock *SCIMUsersServiceInterfaceMock) ReplaceUser(ctx context.Context, userID string, payload *SCIMUserPayload, ifMatch string, baseURL string) (*SCIMUser, *common.ServiceError) {
-	ret := _mock.Called(ctx, userID, payload, ifMatch, baseURL)
+func (_mock *SCIMUsersServiceInterfaceMock) ReplaceUser(ctx context.Context, userID string, payload *SCIMUserPayload, ifMatch string, baseURL string, isSelf bool) (*SCIMUser, *common.ServiceError) {
+	ret := _mock.Called(ctx, userID, payload, ifMatch, baseURL, isSelf)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ReplaceUser")
@@ -351,18 +351,18 @@ func (_mock *SCIMUsersServiceInterfaceMock) ReplaceUser(ctx context.Context, use
 
 	var r0 *SCIMUser
 	var r1 *common.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *SCIMUserPayload, string, string) (*SCIMUser, *common.ServiceError)); ok {
-		return returnFunc(ctx, userID, payload, ifMatch, baseURL)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *SCIMUserPayload, string, string, bool) (*SCIMUser, *common.ServiceError)); ok {
+		return returnFunc(ctx, userID, payload, ifMatch, baseURL, isSelf)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *SCIMUserPayload, string, string) *SCIMUser); ok {
-		r0 = returnFunc(ctx, userID, payload, ifMatch, baseURL)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *SCIMUserPayload, string, string, bool) *SCIMUser); ok {
+		r0 = returnFunc(ctx, userID, payload, ifMatch, baseURL, isSelf)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*SCIMUser)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *SCIMUserPayload, string, string) *common.ServiceError); ok {
-		r1 = returnFunc(ctx, userID, payload, ifMatch, baseURL)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *SCIMUserPayload, string, string, bool) *common.ServiceError); ok {
+		r1 = returnFunc(ctx, userID, payload, ifMatch, baseURL, isSelf)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*common.ServiceError)
@@ -382,11 +382,12 @@ type SCIMUsersServiceInterfaceMock_ReplaceUser_Call struct {
 //   - payload *SCIMUserPayload
 //   - ifMatch string
 //   - baseURL string
-func (_e *SCIMUsersServiceInterfaceMock_Expecter) ReplaceUser(ctx interface{}, userID interface{}, payload interface{}, ifMatch interface{}, baseURL interface{}) *SCIMUsersServiceInterfaceMock_ReplaceUser_Call {
-	return &SCIMUsersServiceInterfaceMock_ReplaceUser_Call{Call: _e.mock.On("ReplaceUser", ctx, userID, payload, ifMatch, baseURL)}
+//   - isSelf bool
+func (_e *SCIMUsersServiceInterfaceMock_Expecter) ReplaceUser(ctx interface{}, userID interface{}, payload interface{}, ifMatch interface{}, baseURL interface{}, isSelf interface{}) *SCIMUsersServiceInterfaceMock_ReplaceUser_Call {
+	return &SCIMUsersServiceInterfaceMock_ReplaceUser_Call{Call: _e.mock.On("ReplaceUser", ctx, userID, payload, ifMatch, baseURL, isSelf)}
 }
 
-func (_c *SCIMUsersServiceInterfaceMock_ReplaceUser_Call) Run(run func(ctx context.Context, userID string, payload *SCIMUserPayload, ifMatch string, baseURL string)) *SCIMUsersServiceInterfaceMock_ReplaceUser_Call {
+func (_c *SCIMUsersServiceInterfaceMock_ReplaceUser_Call) Run(run func(ctx context.Context, userID string, payload *SCIMUserPayload, ifMatch string, baseURL string, isSelf bool)) *SCIMUsersServiceInterfaceMock_ReplaceUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -408,12 +409,17 @@ func (_c *SCIMUsersServiceInterfaceMock_ReplaceUser_Call) Run(run func(ctx conte
 		if args[4] != nil {
 			arg4 = args[4].(string)
 		}
+		var arg5 bool
+		if args[5] != nil {
+			arg5 = args[5].(bool)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
 			arg4,
+			arg5,
 		)
 	})
 	return _c
@@ -424,7 +430,7 @@ func (_c *SCIMUsersServiceInterfaceMock_ReplaceUser_Call) Return(sCIMUser *SCIMU
 	return _c
 }
 
-func (_c *SCIMUsersServiceInterfaceMock_ReplaceUser_Call) RunAndReturn(run func(ctx context.Context, userID string, payload *SCIMUserPayload, ifMatch string, baseURL string) (*SCIMUser, *common.ServiceError)) *SCIMUsersServiceInterfaceMock_ReplaceUser_Call {
+func (_c *SCIMUsersServiceInterfaceMock_ReplaceUser_Call) RunAndReturn(run func(ctx context.Context, userID string, payload *SCIMUserPayload, ifMatch string, baseURL string, isSelf bool) (*SCIMUser, *common.ServiceError)) *SCIMUsersServiceInterfaceMock_ReplaceUser_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/internal/scim/config/config.go
+++ b/backend/internal/scim/config/config.go
@@ -73,30 +73,31 @@ const (
 	PaginationMaxPageSize = serverconst.MaxPageSize
 )
 
-// ReturnMappedCoreAttrsOnGet controls whether GET responses (GetUser,
-// ListUsers) include core schema fields (userName, emails, name, etc.)
-// mapped from stored attributes, or only the custom extension schema.
-// Defaults to true so GET returns the full resource representation per
-// RFC 7644. A var rather than a const: intended to become
-// request-configurable once the frontend toggle for this is implemented.
-var ReturnMappedCoreAttrsOnGet = true
-
 // SCIMConfig holds the SCIM service configuration resolved from the
-// server runtime. All protocol capability flags are code-level constants
-// above; this struct carries only the server-identity fields that must be
-// read from the runtime environment.
+// server runtime. Protocol capability flags that are not operator-configurable
+// are the code-level constants above; this struct carries the fields that
+// are read from the runtime environment.
 type SCIMConfig struct {
 	// PublicURL is the externally reachable base URL of the server,
 	// used to construct SCIM resource location URIs.
 	PublicURL string
+
+	// ReturnMappedCoreAttrsOnGet controls whether GET responses (GetUser,
+	// ListUsers) include core schema fields (userName, emails, name, etc.)
+	// mapped from stored attributes, or only the custom extension schema.
+	// RFC 7644 expects the full resource representation on GET.
+	ReturnMappedCoreAttrsOnGet bool
 }
 
 // FromServerRuntime builds a SCIMConfig from the live server runtime.
-// No SCIM-specific fields are read from the system config; all capability
-// flags are defined as package-level constants above.
 func FromServerRuntime() SCIMConfig {
 	srv := config.GetServerRuntime().Config
+	var returnCoreAttrs bool
+	if srv.SCIM.ReturnMappedCoreAttrsOnGet != nil {
+		returnCoreAttrs = *srv.SCIM.ReturnMappedCoreAttrsOnGet
+	}
 	return SCIMConfig{
-		PublicURL: engineconfig.GetServerURL(&srv.Server),
+		PublicURL:                  engineconfig.GetServerURL(&srv.Server),
+		ReturnMappedCoreAttrsOnGet: returnCoreAttrs,
 	}
 }

--- a/backend/internal/scim/constants.go
+++ b/backend/internal/scim/constants.go
@@ -87,7 +87,7 @@ const (
 	scimUniquenessGlobal SCIMUniqueness = "global"
 )
 
-// Raw entity-type schema property type strings, compared case-insensitively
+// Raw user-type schema property type strings, compared case-insensitively
 // against rawPropertyDef.Type / rawPropertyDef.Items.Type.
 const (
 	rawPropertyTypeArray  = "array"

--- a/backend/internal/scim/core_attr_mapper.go
+++ b/backend/internal/scim/core_attr_mapper.go
@@ -450,7 +450,7 @@ func reverseLookupField(rule coreAttrRule) scimCoreField {
 	}
 }
 
-// findTargetAttrName finds the entity-type schema property matching candidate, case-insensitively.
+// findTargetAttrName finds the user-type schema property matching candidate, case-insensitively.
 func findTargetAttrName(rawProps map[string]rawPropertyDef, candidate string) string {
 	for propName := range rawProps {
 		if strings.EqualFold(propName, candidate) {
@@ -460,7 +460,7 @@ func findTargetAttrName(rawProps map[string]rawPropertyDef, candidate string) st
 	return ""
 }
 
-// reverseMapRuleValue converts a single core attribute value back into its entity-type
+// reverseMapRuleValue converts a single core attribute value back into its user-type
 // schema representation, per rule.kind. ok is false when there is nothing to map.
 func reverseMapRuleValue(rule coreAttrRule, coreVal json.RawMessage, propDef rawPropertyDef,
 ) (b json.RawMessage, ok bool) {

--- a/backend/internal/scim/discovery_handler.go
+++ b/backend/internal/scim/discovery_handler.go
@@ -37,7 +37,7 @@ func (sh *scimDiscoveryHandler) HandleServiceProviderConfigGetRequest(w http.Res
 }
 
 // HandleSchemaListRequest handles GET /scim/v2/Schemas.
-// Returns all SCIM schemas: the core User schema plus one per ThunderID user-type, entity type.
+// Returns all SCIM schemas: the core User schema plus one per ThunderID user type.
 func (sh *scimDiscoveryHandler) HandleSchemaListRequest(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, handlerLoggerComponentName))

--- a/backend/internal/scim/discovery_service.go
+++ b/backend/internal/scim/discovery_service.go
@@ -39,10 +39,10 @@ type SCIMServiceInterface interface {
 const serviceLoggerComponentName = "SCIMService"
 
 // scimDiscoveryService coordinates SCIM discovery operations (ServiceProviderConfig,
-// Schemas, ResourceTypes), delegating entity type operations to existing ThunderID services.
+// Schemas, ResourceTypes), delegating user type operations to existing ThunderID services.
 type scimDiscoveryService struct {
-	entityTypeService entitytype.EntityTypeServiceInterface
-	cfg               scimconfig.SCIMConfig
+	userTypeService entitytype.EntityTypeServiceInterface
+	cfg             scimconfig.SCIMConfig
 
 	// configVersion is a short deterministic hash of the SCIM config used as the
 	// ETag value for ServiceProviderConfig. Computed once at startup and immutable
@@ -53,13 +53,13 @@ type scimDiscoveryService struct {
 
 // newSCIMDiscoveryService creates a new scimDiscoveryService instance.
 func newSCIMDiscoveryService(
-	entityTypeService entitytype.EntityTypeServiceInterface,
+	userTypeService entitytype.EntityTypeServiceInterface,
 	cfg scimconfig.SCIMConfig,
 ) *scimDiscoveryService {
 	return &scimDiscoveryService{
-		entityTypeService: entityTypeService,
-		cfg:               cfg,
-		configVersion:     computeSCIMConfigVersion(cfg),
+		userTypeService: userTypeService,
+		cfg:             cfg,
+		configVersion:   computeSCIMConfigVersion(cfg),
 	}
 }
 
@@ -168,8 +168,8 @@ func (s *scimDiscoveryService) ListSchemas(
 ) (SCIMSchemaListResponse, *tidcommon.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, serviceLoggerComponentName))
 
-	// --- 1. Collect all entity type names (single shared paginator) ---
-	names, svcErr := s.listUserEntityTypeNames(ctx)
+	// --- 1. Collect all user type names (single shared paginator) ---
+	names, svcErr := s.listUserTypeNames(ctx)
 	if svcErr != nil {
 		return SCIMSchemaListResponse{}, svcErr
 	}
@@ -179,24 +179,24 @@ func (s *scimDiscoveryService) ListSchemas(
 	schemas = append(schemas, buildCoreUserSchema(baseURL))
 	schemas = append(schemas, buildCoreGroupSchema(baseURL))
 
-	// --- 3. One extension schema per entity type ---
+	// --- 3. One extension schema per user type ---
 	runtimeCtx := security.WithRuntimeContext(ctx)
 	for _, name := range names {
-		et, svcErr := s.entityTypeService.GetEntityTypeByName(
+		et, svcErr := s.userTypeService.GetEntityTypeByName(
 			runtimeCtx, entitytype.TypeCategoryUser, name,
 		)
 		if svcErr != nil {
-			logger.Warn(ctx, "Failed to load entity type for SCIM schema list, skipping",
-				log.String("entityTypeName", name),
+			logger.Warn(ctx, "Failed to load user type for SCIM schema list, skipping",
+				log.String("userTypeName", name),
 				log.Any("error", svcErr),
 			)
 			continue
 		}
 
-		scimSchema, err := mapEntityTypeToSCIMSchema(*et, baseURL)
+		scimSchema, err := mapUserTypeToSCIMSchema(*et, baseURL)
 		if err != nil {
-			logger.Warn(ctx, "Failed to map entity type to SCIM schema, skipping",
-				log.String("entityTypeName", name),
+			logger.Warn(ctx, "Failed to map user type to SCIM schema, skipping",
+				log.String("userTypeName", name),
 				log.Error(err),
 			)
 			continue
@@ -251,37 +251,37 @@ func (s *scimDiscoveryService) GetSchema(
 	}
 
 	runtimeCtx := security.WithRuntimeContext(ctx)
-	entityTypeName, svcErr := resolveEntityTypeNameForSchemaURN(runtimeCtx, s.entityTypeService, userTypeName)
+	resolvedUserTypeName, svcErr := resolveUserTypeNameForSchemaURN(runtimeCtx, s.userTypeService, userTypeName)
 	if svcErr != nil {
 		return nil, svcErr
 	}
-	if entityTypeName == "" {
-		logger.Debug(ctx, "Entity type not found for SCIM schema URN",
+	if resolvedUserTypeName == "" {
+		logger.Debug(ctx, "User type not found for SCIM schema URN",
 			log.String("urn", schemaURN),
 			log.String("resolvedUserTypeName", userTypeName),
 		)
 		return nil, &ErrorSchemaNotFound
 	}
 
-	et, svcErr := s.entityTypeService.GetEntityTypeByName(
-		runtimeCtx, entitytype.TypeCategoryUser, entityTypeName,
+	et, svcErr := s.userTypeService.GetEntityTypeByName(
+		runtimeCtx, entitytype.TypeCategoryUser, resolvedUserTypeName,
 	)
 	if svcErr != nil {
 		if svcErr.Type == tidcommon.ServerErrorType {
 			return nil, &ErrorInternalServer
 		}
-		// Entity type not found or any other non-auth error → schema not found.
-		logger.Debug(ctx, "Entity type not found for SCIM schema URN",
+		// User type not found or any other non-auth error → schema not found.
+		logger.Debug(ctx, "User type not found for SCIM schema URN",
 			log.String("urn", schemaURN),
-			log.String("resolvedUserTypeName", entityTypeName),
+			log.String("resolvedUserTypeName", resolvedUserTypeName),
 		)
 		return nil, &ErrorSchemaNotFound
 	}
 
-	scimSchema, err := mapEntityTypeToSCIMSchema(*et, baseURL)
+	scimSchema, err := mapUserTypeToSCIMSchema(*et, baseURL)
 	if err != nil {
-		logger.Error(ctx, "Failed to map entity type to SCIM schema",
-			log.String("entityTypeName", et.Name),
+		logger.Error(ctx, "Failed to map user type to SCIM schema",
+			log.String("userTypeName", et.Name),
 			log.Error(err),
 		)
 		return nil, &ErrorInternalServer
@@ -292,7 +292,7 @@ func (s *scimDiscoveryService) GetSchema(
 
 // ListResourceTypes returns all SCIM resource types supported by ThunderID.
 // ThunderID exposes "User" and "Group" resource types. The User schemaExtensions
-// array is built dynamically — one entry per registered user-type entity type.
+// array is built dynamically — one entry per registered user type.
 func (s *scimDiscoveryService) ListResourceTypes(
 	ctx context.Context, baseURL string,
 ) (SCIMResourceTypeListResponse, *tidcommon.ServiceError) {
@@ -337,21 +337,21 @@ func (s *scimDiscoveryService) GetResourceType(
 	}
 }
 
-// listUserEntityTypeNames paginates through all user-category entity types and
+// listUserTypeNames paginates through all user-category entity types and
 // returns a flat slice of their names.
-// This is the single authoritative pagination loop for entity type name discovery.
+// This is the single authoritative pagination loop for user type name discovery.
 // ListSchemas uses it to avoid duplicating pagination logic.
-func (s *scimDiscoveryService) listUserEntityTypeNames(ctx context.Context) ([]string, *tidcommon.ServiceError) {
+func (s *scimDiscoveryService) listUserTypeNames(ctx context.Context) ([]string, *tidcommon.ServiceError) {
 	runtimeCtx := security.WithRuntimeContext(ctx)
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, serviceLoggerComponentName))
 	names := make([]string, 0, 16)
 	offset := 0
 	for {
-		page, svcErr := s.entityTypeService.GetEntityTypeList(
+		page, svcErr := s.userTypeService.GetEntityTypeList(
 			runtimeCtx, entitytype.TypeCategoryUser, serverconst.MaxPageSize, offset, false,
 		)
 		if svcErr != nil {
-			logger.Error(runtimeCtx, "Failed to list entity types",
+			logger.Error(runtimeCtx, "Failed to list user types",
 				log.Int("offset", offset), log.Any("error", svcErr))
 			return nil, svcErr
 		}
@@ -371,7 +371,7 @@ func (s *scimDiscoveryService) listUserEntityTypeNames(ctx context.Context) ([]s
 
 // buildUserResourceType constructs the SCIM User ResourceType resource.
 // The schemaExtensions array is built dynamically from all registered
-// user-type entity type names.
+// user type names.
 // The core User schema URN is always the primary Schema field; each registered
 // user-type contributes one required=false extension entry.
 func (s *scimDiscoveryService) buildUserResourceType(
@@ -380,7 +380,7 @@ func (s *scimDiscoveryService) buildUserResourceType(
 	location := fmt.Sprintf("%s%s/ResourceTypes/%s", baseURL, SCIMBasePath, scimResourceTypeUserID)
 
 	// Reuse the shared paginator — no duplicated pagination logic here.
-	names, svcErr := s.listUserEntityTypeNames(ctx)
+	names, svcErr := s.listUserTypeNames(ctx)
 	if svcErr != nil {
 		return SCIMResourceType{}, svcErr
 	}
@@ -433,15 +433,15 @@ func buildGroupResourceType(baseURL string) SCIMResourceType {
 	}
 }
 
-// resolveEntityTypeNameForSchemaURN searches all user-type entity types for one
-// whose name matches userTypeName (case-insensitive). Returns the canonical name
-// and nil on success, or empty string and nil if no match is found.
-func resolveEntityTypeNameForSchemaURN(
-	ctx context.Context, entityTypeService entitytype.EntityTypeServiceInterface, userTypeName string,
+// resolveUserTypeNameForSchemaURN searches all user types for one
+// whose name matches userTypeName (case-insensitive). Returns the resolved,
+// correctly-cased name and nil on success, or empty string and nil if no match is found.
+func resolveUserTypeNameForSchemaURN(
+	ctx context.Context, userTypeService entitytype.EntityTypeServiceInterface, userTypeName string,
 ) (string, *tidcommon.ServiceError) {
 	offset := 0
 	for {
-		page, svcErr := entityTypeService.GetEntityTypeList(
+		page, svcErr := userTypeService.GetEntityTypeList(
 			ctx, entitytype.TypeCategoryUser, serverconst.MaxPageSize, offset, false,
 		)
 		if svcErr != nil {
@@ -464,14 +464,14 @@ func resolveEntityTypeNameForSchemaURN(
 	}
 }
 
-// resolveDefaultEntityTypeName returns the sole configured user entity type's
-// canonical name, for SCIM payloads that carry only core attributes and omit
+// resolveDefaultUserTypeName returns the sole configured user type's
+// resolved name, for SCIM payloads that carry only core attributes and omit
 // the ThunderID extension URN. Errors if zero or more than one user type is
 // configured, since the default type is then ambiguous.
-func resolveDefaultEntityTypeName(
-	ctx context.Context, entityTypeService entitytype.EntityTypeServiceInterface,
+func resolveDefaultUserTypeName(
+	ctx context.Context, userTypeService entitytype.EntityTypeServiceInterface,
 ) (string, *tidcommon.ServiceError) {
-	page, svcErr := entityTypeService.GetEntityTypeList(
+	page, svcErr := userTypeService.GetEntityTypeList(
 		ctx, entitytype.TypeCategoryUser, serverconst.MaxPageSize, 0, false)
 	if svcErr != nil {
 		if svcErr.Type == tidcommon.ServerErrorType {

--- a/backend/internal/scim/discovery_service_test.go
+++ b/backend/internal/scim/discovery_service_test.go
@@ -24,7 +24,7 @@ import (
 // testGenericBaseURL is used in tests where the base URL value is irrelevant.
 const testGenericBaseURL = "https://example.com"
 
-// newTestSCIMService creates a scimDiscoveryService with a nil entity type service.
+// newTestSCIMService creates a scimDiscoveryService with a nil user type service.
 // This is safe for ServiceProviderConfig tests because GetServiceProviderConfig
 // does not use that dependency.
 func newTestSCIMService() *scimDiscoveryService {
@@ -118,7 +118,7 @@ func TestComputeSCIMConfigVersion_FollowsWeakETagFormat(t *testing.T) {
 	require.True(t, strings.HasSuffix(version, `"`), `must end with "`)
 }
 
-func TestGetSchema_ResolvesEntityTypeNameCaseInsensitively(t *testing.T) {
+func TestGetSchema_ResolvesUserTypeNameCaseInsensitively(t *testing.T) {
 	mockET := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
 	et := &entitytype.EntityType{
 		Name:   "Person",
@@ -287,23 +287,23 @@ func TestMapRawProperty_UniqueField(t *testing.T) {
 	require.Equal(t, scimUniquenessServer, attr.Uniqueness)
 }
 
-// --- mapEntityTypeToSCIMSchema ---
+// --- mapUserTypeToSCIMSchema ---
 
-func TestMapEntityTypeToSCIMSchema_InvalidJSON_ReturnsError(t *testing.T) {
+func TestMapUserTypeToSCIMSchema_InvalidJSON_ReturnsError(t *testing.T) {
 	et := entitytype.EntityType{
 		Name:   "Broken",
 		Schema: json.RawMessage(`{INVALID`),
 	}
-	_, err := mapEntityTypeToSCIMSchema(et, testGenericBaseURL)
+	_, err := mapUserTypeToSCIMSchema(et, testGenericBaseURL)
 	require.Error(t, err)
 }
 
-func TestMapEntityTypeToSCIMSchema_ValidSchema(t *testing.T) {
+func TestMapUserTypeToSCIMSchema_ValidSchema(t *testing.T) {
 	et := entitytype.EntityType{
 		Name:   "Employee",
 		Schema: json.RawMessage(`{"userName":{"type":"string","displayName":"User Name"}}`),
 	}
-	schema, err := mapEntityTypeToSCIMSchema(et, testGenericBaseURL)
+	schema, err := mapUserTypeToSCIMSchema(et, testGenericBaseURL)
 	require.NoError(t, err)
 	require.Equal(t, "urn:thunderid:params:scim:schemas:employee:2.0:User", schema.ID)
 	require.Len(t, schema.Attributes, 1)
@@ -329,7 +329,7 @@ func TestGetSchema_UnknownURN_Returns404(t *testing.T) {
 	require.Equal(t, ErrorSchemaNotFound.Code, svcErr.Code)
 }
 
-func TestGetSchema_EntityTypeNotFound_Returns404(t *testing.T) {
+func TestGetSchema_UserTypeNotFound_Returns404(t *testing.T) {
 	mockET := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
 	mockET.On("GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, mock.Anything, mock.Anything, false).
 		Return(
@@ -396,7 +396,7 @@ func TestListSchemas_IncludesExtensionSchemasForEachUserType(t *testing.T) {
 	require.Nil(t, svcErr)
 
 	schemas := resp.Resources
-	// User schema + Group schema + 1 entity-type extension = 3
+	// User schema + Group schema + 1 user-type extension = 3
 	require.Equal(t, 3, resp.TotalResults)
 	require.Len(t, schemas, 3)
 
@@ -492,7 +492,7 @@ func TestGetSchema_AuthErrorFromResolve_Returns404(t *testing.T) {
 	require.Equal(t, ErrorSchemaNotFound.Code, svcErr.Code)
 }
 
-func TestGetSchema_EntityTypeNameNotFoundAfterList_Returns404(t *testing.T) {
+func TestGetSchema_UserTypeNameNotFoundAfterList_Returns404(t *testing.T) {
 	mockET := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
 	mockET.On("GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, mock.Anything, mock.Anything, false).
 		Return(
@@ -542,7 +542,7 @@ func TestGetSchema_AuthErrorFromGetEntityTypeByName_Returns404(t *testing.T) {
 	require.Equal(t, ErrorSchemaNotFound.Code, svcErr.Code)
 }
 
-func TestGetSchema_MalformedEntityTypeSchema_Returns500(t *testing.T) {
+func TestGetSchema_MalformedUserTypeSchema_Returns500(t *testing.T) {
 	mockET := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
 	mockET.On("GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, mock.Anything, mock.Anything, false).
 		Return(
@@ -603,14 +603,14 @@ func TestListSchemas_GetEntityTypeByNameError_SkipsItem(t *testing.T) {
 
 	resp, svcErr := svc.ListSchemas(context.Background(), testGenericBaseURL)
 	require.Nil(t, svcErr)
-	// User schema + Group schema (entity type skipped due to error)
+	// User schema + Group schema (user type skipped due to error)
 	require.Equal(t, 2, resp.TotalResults)
 	urns := []string{resp.Resources[0].ID, resp.Resources[1].ID}
 	require.Contains(t, urns, SCIMCoreUserSchemaURN)
 	require.Contains(t, urns, SCIMCoreGroupSchemaURN)
 }
 
-func TestListSchemas_MalformedEntityTypeSchema_SkipsItem(t *testing.T) {
+func TestListSchemas_MalformedUserTypeSchema_SkipsItem(t *testing.T) {
 	mockET := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
 	mockET.On("GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, mock.Anything, mock.Anything, false).
 		Return(
@@ -630,7 +630,7 @@ func TestListSchemas_MalformedEntityTypeSchema_SkipsItem(t *testing.T) {
 
 	resp, svcErr := svc.ListSchemas(context.Background(), testGenericBaseURL)
 	require.Nil(t, svcErr)
-	// User schema + Group schema (malformed entity type skipped)
+	// User schema + Group schema (malformed user type skipped)
 	require.Equal(t, 2, resp.TotalResults)
 	urns := []string{resp.Resources[0].ID, resp.Resources[1].ID}
 	require.Contains(t, urns, SCIMCoreUserSchemaURN)
@@ -671,15 +671,15 @@ func TestListSchemas_PaginationFetchesSecondPage(t *testing.T) {
 
 	resp, svcErr := svc.ListSchemas(context.Background(), testGenericBaseURL)
 	require.Nil(t, svcErr)
-	// User + Group static schemas + 2 entity-type extensions = 4
+	// User + Group static schemas + 2 user-type extensions = 4
 	require.Equal(t, 4, resp.TotalResults)
 }
 
 // =====================================================================
-// resolveEntityTypeNameForSchemaURN — branch coverage
+// resolveUserTypeNameForSchemaURN — branch coverage
 // =====================================================================
 
-func TestResolveEntityTypeName_AuthError_Returns404(t *testing.T) {
+func TestResolveUserTypeName_AuthError_Returns404(t *testing.T) {
 	mockET := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
 	authErr := tidcommon.ErrorUnauthorized
 	mockET.On("GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, mock.Anything, mock.Anything, false).
@@ -696,7 +696,7 @@ func TestResolveEntityTypeName_AuthError_Returns404(t *testing.T) {
 	require.Equal(t, ErrorSchemaNotFound.Code, svcErr.Code)
 }
 
-func TestResolveEntityTypeName_NonAuthListError_Returns404(t *testing.T) {
+func TestResolveUserTypeName_NonAuthListError_Returns404(t *testing.T) {
 	mockET := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
 	mockET.On("GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, mock.Anything, mock.Anything, false).
 		Return((*entitytype.EntityTypeListResponse)(nil), &tidcommon.ServiceError{Code: "ET-DB-ERR"})
@@ -752,7 +752,7 @@ func TestListResourceTypes_SchemasField(t *testing.T) {
 	require.Equal(t, 2, resp.ItemsPerPage)
 }
 
-func TestListResourceTypes_IncludesExtensionPerEntityType(t *testing.T) {
+func TestListResourceTypes_IncludesExtensionPerUserType(t *testing.T) {
 	mockET := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
 	mockET.On("GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, mock.Anything, mock.Anything, false).
 		Return(

--- a/backend/internal/scim/groups_handler.go
+++ b/backend/internal/scim/groups_handler.go
@@ -59,7 +59,7 @@ func (h *scimGroupsHandler) HandleGroupsCreateRequest(w http.ResponseWriter, r *
 		handleSCIMError(w, r, &ErrorInvalidRequestBody)
 		return
 	}
-	payload, svcErr := validateSCIMGroupWriteRequest(body)
+	payload, svcErr := parseAndValidateSCIMGroupWriteRequest(body)
 	if svcErr != nil {
 		handleSCIMError(w, r, svcErr)
 		return
@@ -113,7 +113,7 @@ func (h *scimGroupsHandler) HandleGroupsReplaceRequest(w http.ResponseWriter, r 
 		handleSCIMError(w, r, &ErrorInvalidRequestBody)
 		return
 	}
-	payload, svcErr := validateSCIMGroupWriteRequest(body)
+	payload, svcErr := parseAndValidateSCIMGroupWriteRequest(body)
 	if svcErr != nil {
 		handleSCIMError(w, r, svcErr)
 		return
@@ -148,7 +148,7 @@ func (h *scimGroupsHandler) HandleGroupsPatchRequest(w http.ResponseWriter, r *h
 		handleSCIMError(w, r, &ErrorInvalidRequestBody)
 		return
 	}
-	actions, svcErr := validateSCIMGroupPatchRequest(body)
+	actions, svcErr := parseAndValidateSCIMGroupPatchRequest(body)
 	if svcErr != nil {
 		handleSCIMError(w, r, svcErr)
 		return

--- a/backend/internal/scim/groups_handler_test.go
+++ b/backend/internal/scim/groups_handler_test.go
@@ -354,7 +354,7 @@ func TestHandleGroupsListRequest_CustomParamsAndError(t *testing.T) {
 		require.Equal(t, http.StatusOK, rr.Code)
 	})
 
-	t.Run("InvalidParamsUseDefaults", func(t *testing.T) {
+	t.Run("InvalidStartIndexUsesDefault", func(t *testing.T) {
 		mockSvc := NewSCIMGroupsServiceInterfaceMock(t)
 		expectedResp := SCIMGroupListResponse{
 			Schemas: []string{SCIMListResponseSchemaURN}, StartIndex: 1, ItemsPerPage: constants.DefaultPageSize,
@@ -364,7 +364,24 @@ func TestHandleGroupsListRequest_CustomParamsAndError(t *testing.T) {
 			Return(expectedResp, (*tidcommon.ServiceError)(nil))
 
 		h := newSCIMGroupsHandler(mockSvc, testBaseURL)
-		req := httptest.NewRequest(http.MethodGet, "/scim/v2/Groups?startIndex=abc&count=-5", nil)
+		req := httptest.NewRequest(http.MethodGet, "/scim/v2/Groups?startIndex=abc", nil)
+		rr := httptest.NewRecorder()
+
+		h.HandleGroupsListRequest(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("NegativeCountInterpretedAsZero", func(t *testing.T) {
+		mockSvc := NewSCIMGroupsServiceInterfaceMock(t)
+		expectedResp := SCIMGroupListResponse{
+			Schemas: []string{SCIMListResponseSchemaURN}, StartIndex: 1, ItemsPerPage: 0,
+			Resources: []SCIMGroup{},
+		}
+		mockSvc.On("ListGroups", mock.Anything, 1, 0, testBaseURL).
+			Return(expectedResp, (*tidcommon.ServiceError)(nil))
+
+		h := newSCIMGroupsHandler(mockSvc, testBaseURL)
+		req := httptest.NewRequest(http.MethodGet, "/scim/v2/Groups?count=-5", nil)
 		rr := httptest.NewRecorder()
 
 		h.HandleGroupsListRequest(rr, req)

--- a/backend/internal/scim/groups_service.go
+++ b/backend/internal/scim/groups_service.go
@@ -51,15 +51,26 @@ func (s *scimGroupsService) ListGroups(ctx context.Context, startIndex, count in
 	if startIndex < 1 {
 		startIndex = 1
 	}
-	if count < 1 {
-		count = serverconst.DefaultPageSize
+	if count < 0 {
+		count = 0
+	}
+
+	// GetGroupList rejects a limit below 1, so a count of 0 (client wants only
+	// totalResults, no resources per RFC 7644 §3.4.2.4) fetches a single row
+	// and discards it below.
+	fetchLimit := count
+	if fetchLimit == 0 {
+		fetchLimit = 1
 	}
 
 	offset := startIndex - 1
-	listResp, svcErr := s.groupService.GetGroupList(ctx, count, offset, true)
+	listResp, svcErr := s.groupService.GetGroupList(ctx, fetchLimit, offset, true)
 	if svcErr != nil {
 		logger.Error(ctx, "SCIM ListGroups: failed to get group list", log.Any("error", svcErr))
 		return SCIMGroupListResponse{}, mapGroupServiceErrorToSCIM(svcErr)
+	}
+	if count == 0 {
+		return buildSCIMGroupListResponse(nil, listResp.TotalResults, startIndex, 0), nil
 	}
 	scimGroups := make([]SCIMGroup, 0, len(listResp.Groups))
 	for _, g := range listResp.Groups {

--- a/backend/internal/scim/groups_service_test.go
+++ b/backend/internal/scim/groups_service_test.go
@@ -127,6 +127,27 @@ func TestListGroups_Success(t *testing.T) {
 	require.Equal(t, "user-1", resp.Resources[0].Members[0].Value)
 }
 
+func TestListGroups_ExplicitZeroCountReturnsNoResources(t *testing.T) {
+	mockGroupService := groupmock.NewGroupServiceInterfaceMock(t)
+	service := newSCIMGroupsService(mockGroupService)
+
+	listResp := &group.GroupListResponse{
+		TotalResults: 5,
+		Groups: []group.GroupBasic{
+			{ID: "group-1", Name: "Administrators"},
+		},
+	}
+	mockGroupService.On("GetGroupList", mock.Anything, 1, 0, true).
+		Return(listResp, (*tidcommon.ServiceError)(nil))
+
+	resp, err := service.ListGroups(context.Background(), 1, 0, testBaseURL)
+
+	require.Nil(t, err)
+	require.Equal(t, 5, resp.TotalResults)
+	require.Empty(t, resp.Resources)
+	require.Equal(t, 0, resp.ItemsPerPage)
+}
+
 // TestCreateGroup_Success verifies that CreateGroup re-fetches the created group
 // instead of returning the raw creation result, since group.Service.CreateGroup
 // strips member Display when persisting and never resolves it before returning.

--- a/backend/internal/scim/init.go
+++ b/backend/internal/scim/init.go
@@ -22,14 +22,14 @@ var scimServerStartTime = time.Now().UTC().Format(time.RFC3339)
 func Initialize(
 	mux *http.ServeMux,
 	userService user.UserServiceInterface,
-	entityTypeService entitytype.EntityTypeServiceInterface,
+	userTypeService entitytype.EntityTypeServiceInterface,
 	groupService group.GroupServiceInterface,
 	cfg scimconfig.SCIMConfig,
 ) {
-	svc := newSCIMDiscoveryService(entityTypeService, cfg)
+	svc := newSCIMDiscoveryService(userTypeService, cfg)
 	h := newSCIMDiscoveryHandler(svc, cfg.PublicURL)
 
-	uSvc := newSCIMUsersService(userService, entityTypeService)
+	uSvc := newSCIMUsersService(userService, userTypeService, cfg)
 	uh := newSCIMUsersHandler(uSvc, cfg.PublicURL)
 
 	gSvc := newSCIMGroupsService(groupService)

--- a/backend/internal/scim/model.go
+++ b/backend/internal/scim/model.go
@@ -145,5 +145,5 @@ type SCIMSearchRequest struct {
 	SortBy             string   `json:"sortBy,omitempty"`
 	SortOrder          string   `json:"sortOrder,omitempty"`
 	StartIndex         int      `json:"startIndex,omitempty"`
-	Count              int      `json:"count,omitempty"`
+	Count              *int     `json:"count,omitempty"`
 }

--- a/backend/internal/scim/response.go
+++ b/backend/internal/scim/response.go
@@ -182,30 +182,37 @@ func handleSCIMError(w http.ResponseWriter, r *http.Request, svcErr *tidcommon.S
 // parseSCIMPaginationQueryParams extracts and clamps startIndex and count query parameters
 // per RFC 7644 §3.4.2.4.
 func parseSCIMPaginationQueryParams(r *http.Request) (int, int) {
-	startIndex, count := 1, constants.DefaultPageSize
+	startIndex := 1
 	if v := strings.TrimSpace(r.URL.Query().Get("startIndex")); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			startIndex = n
 		}
 	}
+	var count *int
 	if v := strings.TrimSpace(r.URL.Query().Get("count")); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			count = n
+		if n, err := strconv.Atoi(v); err == nil {
+			count = &n
 		}
 	}
 	return normalizeSCIMPagination(startIndex, count)
 }
 
-// normalizeSCIMPagination clamps integer startIndex and count parameters per RFC 7644 §3.4.2.4.
-func normalizeSCIMPagination(startIndex, count int) (int, int) {
+// normalizeSCIMPagination clamps startIndex and count per RFC 7644 §3.4.2.4. A nil count means
+// count was not specified, and falls back to the default page size; a negative count is
+// interpreted as 0 (no resources, totalResults only), matching an explicit 0.
+func normalizeSCIMPagination(startIndex int, count *int) (int, int) {
 	if startIndex < 1 {
 		startIndex = 1
 	}
-	if count < 1 {
-		count = constants.DefaultPageSize
+	resolvedCount := constants.DefaultPageSize
+	if count != nil {
+		resolvedCount = *count
+		if resolvedCount < 0 {
+			resolvedCount = 0
+		}
 	}
-	if count > scimconfig.FilterMaxResults {
-		count = scimconfig.FilterMaxResults
+	if resolvedCount > scimconfig.FilterMaxResults {
+		resolvedCount = scimconfig.FilterMaxResults
 	}
-	return startIndex, count
+	return startIndex, resolvedCount
 }

--- a/backend/internal/scim/response_test.go
+++ b/backend/internal/scim/response_test.go
@@ -170,16 +170,35 @@ func TestParseSCIMPagination(t *testing.T) {
 		require.Equal(t, 20, count)
 	})
 
-	t.Run("DefaultAndInvalidParams", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/scim/v2/Users?startIndex=invalid&count=-10", nil)
+	t.Run("MissingParamsUseDefaults", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/scim/v2/Users?startIndex=invalid", nil)
 		start, count := parseSCIMPaginationQueryParams(req)
 		require.Equal(t, 1, start)
 		require.Equal(t, constants.DefaultPageSize, count)
 	})
 
+	t.Run("NegativeCountInterpretedAsZero", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/scim/v2/Users?count=-10", nil)
+		_, count := parseSCIMPaginationQueryParams(req)
+		require.Equal(t, 0, count)
+	})
+
+	t.Run("ExplicitZeroCountPreserved", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/scim/v2/Users?count=0", nil)
+		_, count := parseSCIMPaginationQueryParams(req)
+		require.Equal(t, 0, count)
+	})
+
 	t.Run("ClampedCount", func(t *testing.T) {
-		start, count := normalizeSCIMPagination(0, 500)
+		count := 500
+		start, resolved := normalizeSCIMPagination(0, &count)
 		require.Equal(t, 1, start)
-		require.Equal(t, 100, count)
+		require.Equal(t, 100, resolved)
+	})
+
+	t.Run("NilCountUsesDefault", func(t *testing.T) {
+		start, count := normalizeSCIMPagination(0, nil)
+		require.Equal(t, 1, start)
+		require.Equal(t, constants.DefaultPageSize, count)
 	})
 }

--- a/backend/internal/scim/schema_builder.go
+++ b/backend/internal/scim/schema_builder.go
@@ -12,9 +12,9 @@ import (
 	"github.com/thunder-id/thunderid/internal/entitytype"
 )
 
-// mapEntityTypeToSCIMSchema converts a ThunderID EntityType into a SCIM Schema resource
+// mapUserTypeToSCIMSchema converts a ThunderID user type (EntityType) into a SCIM Schema resource
 // per RFC 7643 §7.
-func mapEntityTypeToSCIMSchema(et entitytype.EntityType, baseURL string) (SCIMSchema, error) {
+func mapUserTypeToSCIMSchema(et entitytype.EntityType, baseURL string) (SCIMSchema, error) {
 	schemaURN := buildSchemaURN(et.Name)
 	location := fmt.Sprintf("%s%s/Schemas/%s", baseURL, SCIMBasePath, schemaURN)
 	description := fmt.Sprintf("%s user type", et.Name)
@@ -23,7 +23,7 @@ func mapEntityTypeToSCIMSchema(et entitytype.EntityType, baseURL string) (SCIMSc
 	var rawProps map[string]rawPropertyDef
 	if err := json.Unmarshal(et.Schema, &rawProps); err != nil {
 		return SCIMSchema{}, fmt.Errorf(
-			"mapEntityTypeToSCIMSchema: failed to parse schema JSON for %q: %w",
+			"mapUserTypeToSCIMSchema: failed to parse schema JSON for %q: %w",
 			et.Name, err,
 		)
 	}
@@ -630,7 +630,7 @@ type rawPropertyDef struct {
 	Items       *rawPropertyDef           `json:"items"`      // for type=array
 }
 
-// parseSchemaRawProps unmarshals an entity-type JSON schema into a map of rawPropertyDef.
+// parseSchemaRawProps unmarshals a user-type JSON schema into a map of rawPropertyDef.
 // Returns hasSchema=false if schema is empty. Returns an error if the schema contains malformed JSON.
 func parseSchemaRawProps(schema json.RawMessage) (rawProps map[string]rawPropertyDef, hasSchema bool, err error) {
 	if len(schema) == 0 {
@@ -642,7 +642,7 @@ func parseSchemaRawProps(schema json.RawMessage) (rawProps map[string]rawPropert
 	return rawProps, true, nil
 }
 
-// missingRequiredAttrs returns the names of entity-type schema properties marked
+// missingRequiredAttrs returns the names of user-type schema properties marked
 // "required" that are absent from attrs, after core-attribute reverse-mapping has
 // already been merged in. This lets CreateUser/ReplaceUser reject a request with a
 // clear, per-user-type message instead of a generic schema-validation failure.
@@ -674,7 +674,7 @@ func missingRequiredAttrs(
 }
 
 // undeclaredAttrs returns the names of attributes present in extensionAttrs that are not
-// declared in the entity-type schema. Matching is case-insensitive per SCIM RFC 7643 §2.1.
+// declared in the user-type schema. Matching is case-insensitive per SCIM RFC 7643 §2.1.
 // This lets CreateUser/ReplaceUser reject a request with a clear, per-user-type message
 // instead of a generic failure. Core attributes are intentionally not checked: real SCIM
 // clients send standard envelope fields (active, displayName, externalId, groups, locale,

--- a/backend/internal/scim/scim_validator.go
+++ b/backend/internal/scim/scim_validator.go
@@ -18,7 +18,7 @@ import (
 type SCIMUserPayload struct {
 	// ExtensionURN is the full ThunderID extension URN exactly as sent by the client.
 	ExtensionURN string
-	// UserTypeName is the entity type name extracted from the extension URN (e.g. "employee").
+	// UserTypeName is the user type name extracted from the extension URN (e.g. "employee").
 	UserTypeName string
 	// CoreAttrs holds top-level request fields that are NOT "schemas" and NOT the extension URN object.
 	CoreAttrs map[string]json.RawMessage
@@ -26,8 +26,8 @@ type SCIMUserPayload struct {
 	ExtensionAttrs map[string]json.RawMessage
 }
 
-// validateSCIMUserRequest parses and validates a SCIM user payload.
-func validateSCIMUserRequest(body []byte) (*SCIMUserPayload, *tidcommon.ServiceError) {
+// parseAndValidateSCIMUserRequest parses, extracts, and validates a SCIM user payload.
+func parseAndValidateSCIMUserRequest(body []byte) (*SCIMUserPayload, *tidcommon.ServiceError) {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(body, &raw); err != nil {
 		return nil, &ErrorInvalidRequestBody
@@ -186,9 +186,9 @@ func validateCoreUserSchemaDeclared(schemas []string, coreAttrs map[string]json.
 // Groups — POST / PUT validation
 // ---------------------------------------------------------------------------
 
-// validateSCIMGroupWriteRequest parses and validates a SCIM Group POST/PUT request body.
+// parseAndValidateSCIMGroupWriteRequest parses, extracts, and validates a SCIM Group POST/PUT request body.
 // It ensures the core Group schema URN is declared and that displayName is non-empty.
-func validateSCIMGroupWriteRequest(body []byte) (*SCIMGroupPayload, *tidcommon.ServiceError) {
+func parseAndValidateSCIMGroupWriteRequest(body []byte) (*SCIMGroupPayload, *tidcommon.ServiceError) {
 	var raw struct {
 		Schemas     []string          `json:"schemas"`
 		DisplayName string            `json:"displayName"`
@@ -210,9 +210,9 @@ func validateSCIMGroupWriteRequest(body []byte) (*SCIMGroupPayload, *tidcommon.S
 // Groups — PATCH validation
 // ---------------------------------------------------------------------------
 
-// validateSCIMGroupPatchRequest parses and validates a SCIM Group PATCH request body,
+// parseAndValidateSCIMGroupPatchRequest parses, extracts, and validates a SCIM Group PATCH request body,
 // returning a normalized list of actions ready to apply (RFC 7644 §3.5.2).
-func validateSCIMGroupPatchRequest(body []byte) ([]SCIMGroupPatchAction, *tidcommon.ServiceError) {
+func parseAndValidateSCIMGroupPatchRequest(body []byte) ([]SCIMGroupPatchAction, *tidcommon.ServiceError) {
 	var req SCIMGroupPatchRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		return nil, &ErrorInvalidRequestBody

--- a/backend/internal/scim/scim_validator_test.go
+++ b/backend/internal/scim/scim_validator_test.go
@@ -123,7 +123,7 @@ func TestValidateSCIMUserRequest(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			payload, svcErr := validateSCIMUserRequest(tc.body)
+			payload, svcErr := parseAndValidateSCIMUserRequest(tc.body)
 			if tc.wantErrCode != "" {
 				require.NotNil(t, svcErr, "expected a ServiceError")
 				require.Equal(t, tc.wantErrCode, svcErr.Code)
@@ -143,19 +143,19 @@ func TestValidateSCIMUserRequest(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestValidateSCIMGroupWriteRequest_InvalidJSON(t *testing.T) {
-	_, err := validateSCIMGroupWriteRequest([]byte(`not json`))
+	_, err := parseAndValidateSCIMGroupWriteRequest([]byte(`not json`))
 	require.Equal(t, ErrorInvalidRequestBody.Code, err.Code)
 }
 
 func TestValidateSCIMGroupWriteRequest_MissingDisplayName(t *testing.T) {
 	body := `{"schemas":["urn:ietf:params:scim:schemas:core:2.0:Group"],"displayName":""}`
-	_, err := validateSCIMGroupWriteRequest([]byte(body))
+	_, err := parseAndValidateSCIMGroupWriteRequest([]byte(body))
 	require.Equal(t, ErrorInvalidRequestBody.Code, err.Code)
 }
 
 func TestValidateSCIMGroupWriteRequest_MissingCoreGroupSchema(t *testing.T) {
 	body := `{"schemas":[],"displayName":"Eng"}`
-	_, err := validateSCIMGroupWriteRequest([]byte(body))
+	_, err := parseAndValidateSCIMGroupWriteRequest([]byte(body))
 	require.Equal(t, ErrorMissingCoreGroupSchema.Code, err.Code)
 }
 
@@ -165,7 +165,7 @@ func TestValidateSCIMGroupWriteRequest_Valid(t *testing.T) {
 		"displayName":"Engineering",
 		"members":[{"value":"user-1","type":"User"}]
 	}`
-	payload, err := validateSCIMGroupWriteRequest([]byte(body))
+	payload, err := parseAndValidateSCIMGroupWriteRequest([]byte(body))
 	require.Nil(t, err)
 	require.Equal(t, "Engineering", payload.DisplayName)
 	require.Len(t, payload.Members, 1)
@@ -173,7 +173,7 @@ func TestValidateSCIMGroupWriteRequest_Valid(t *testing.T) {
 
 func TestValidateSCIMGroupWriteRequest_NoMembers(t *testing.T) {
 	body := `{"schemas":["urn:ietf:params:scim:schemas:core:2.0:Group"],"displayName":"Empty"}`
-	payload, err := validateSCIMGroupWriteRequest([]byte(body))
+	payload, err := parseAndValidateSCIMGroupWriteRequest([]byte(body))
 	require.Nil(t, err)
 	require.Equal(t, "Empty", payload.DisplayName)
 	require.Empty(t, payload.Members)
@@ -185,12 +185,12 @@ func TestValidateSCIMGroupWriteRequest_NoMembers(t *testing.T) {
 
 func TestValidateSCIMGroupPatchRequest_MissingSchema(t *testing.T) {
 	body := `{"Operations":[{"op":"replace","path":"displayName","value":"X"}]}`
-	_, err := validateSCIMGroupPatchRequest([]byte(body))
+	_, err := parseAndValidateSCIMGroupPatchRequest([]byte(body))
 	require.Equal(t, ErrorMissingSchemas.Code, err.Code)
 }
 
 func TestValidateSCIMGroupPatchRequest_InvalidJSON(t *testing.T) {
-	_, err := validateSCIMGroupPatchRequest([]byte(`not json`))
+	_, err := parseAndValidateSCIMGroupPatchRequest([]byte(`not json`))
 	require.Equal(t, ErrorInvalidRequestBody.Code, err.Code)
 }
 
@@ -199,7 +199,7 @@ func TestValidateSCIMGroupPatchOp_DisplayNameReplace(t *testing.T) {
 		"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
 		"Operations": [{"op": "replace", "path": "displayName", "value": "New Name"}]
 	}`
-	actions, err := validateSCIMGroupPatchRequest([]byte(body))
+	actions, err := parseAndValidateSCIMGroupPatchRequest([]byte(body))
 	require.Nil(t, err)
 	require.Len(t, actions, 1)
 	require.Equal(t, scimGroupPatchTargetDisplayName, actions[0].Target)
@@ -211,7 +211,7 @@ func TestValidateSCIMGroupPatchOp_DisplayNameRemove_Rejected(t *testing.T) {
 		"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
 		"Operations": [{"op": "remove", "path": "displayName"}]
 	}`
-	_, err := validateSCIMGroupPatchRequest([]byte(body))
+	_, err := parseAndValidateSCIMGroupPatchRequest([]byte(body))
 	require.Equal(t, ErrorInvalidPatchPath.Code, err.Code)
 }
 
@@ -220,7 +220,7 @@ func TestValidateSCIMGroupPatchOp_DisplayNameEmptyValue_Rejected(t *testing.T) {
 		"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
 		"Operations": [{"op": "replace", "path": "displayName", "value": ""}]
 	}`
-	_, err := validateSCIMGroupPatchRequest([]byte(body))
+	_, err := parseAndValidateSCIMGroupPatchRequest([]byte(body))
 	require.Equal(t, ErrorInvalidPatchValue.Code, err.Code)
 }
 
@@ -230,7 +230,7 @@ func TestValidateSCIMGroupPatchOp_AddMembers(t *testing.T) {
 		"Operations": [{"op": "add", "path": "members",
 			"value": [{"value": "user-1", "type": "User"}]}]
 	}`
-	actions, err := validateSCIMGroupPatchRequest([]byte(body))
+	actions, err := parseAndValidateSCIMGroupPatchRequest([]byte(body))
 	require.Nil(t, err)
 	require.Equal(t, scimGroupPatchTargetMembers, actions[0].Target)
 	require.Len(t, actions[0].Members, 1)
@@ -241,7 +241,7 @@ func TestValidateSCIMGroupPatchOp_AddMembers_EmptyValue_Rejected(t *testing.T) {
 		"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
 		"Operations": [{"op": "add", "path": "members", "value": []}]
 	}`
-	_, err := validateSCIMGroupPatchRequest([]byte(body))
+	_, err := parseAndValidateSCIMGroupPatchRequest([]byte(body))
 	require.Equal(t, ErrorInvalidPatchValue.Code, err.Code)
 }
 
@@ -250,7 +250,7 @@ func TestValidateSCIMGroupPatchOp_RemoveMembers_NoPath(t *testing.T) {
 		"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
 		"Operations": [{"op": "remove", "path": "members"}]
 	}`
-	actions, err := validateSCIMGroupPatchRequest([]byte(body))
+	actions, err := parseAndValidateSCIMGroupPatchRequest([]byte(body))
 	require.Nil(t, err)
 	require.Empty(t, actions[0].FilterValue)
 }
@@ -260,7 +260,7 @@ func TestValidateSCIMGroupPatchOp_RemoveMembers_FilteredPath(t *testing.T) {
 		"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
 		"Operations": [{"op": "remove", "path": "members[value eq \"user-1\"]"}]
 	}`
-	actions, err := validateSCIMGroupPatchRequest([]byte(body))
+	actions, err := parseAndValidateSCIMGroupPatchRequest([]byte(body))
 	require.Nil(t, err)
 	require.Equal(t, "user-1", actions[0].FilterValue)
 }
@@ -271,7 +271,7 @@ func TestValidateSCIMGroupPatchOp_RemoveMembers_FilteredPathWithValue_Rejected(t
 		"Operations": [{"op": "remove", "path": "members[value eq \"user-1\"]",
 			"value": [{"value": "user-1"}]}]
 	}`
-	_, err := validateSCIMGroupPatchRequest([]byte(body))
+	_, err := parseAndValidateSCIMGroupPatchRequest([]byte(body))
 	require.Equal(t, ErrorInvalidPatchValue.Code, err.Code)
 }
 
@@ -288,7 +288,7 @@ func TestValidateSCIMGroupPatchOp_MalformedFilterPath(t *testing.T) {
 			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
 			"Operations": [{"op": "remove", "path": "` + path + `"}]
 		}`
-		_, err := validateSCIMGroupPatchRequest([]byte(body))
+		_, err := parseAndValidateSCIMGroupPatchRequest([]byte(body))
 		require.Equal(t, ErrorInvalidPatchPath.Code, err.Code, "path: %s", path)
 	}
 }
@@ -299,7 +299,7 @@ func TestValidateSCIMGroupPatchOp_FilteredPath_AddRejected(t *testing.T) {
 		"Operations": [{"op": "add", "path": "members[value eq \"user-1\"]",
 			"value": [{"value": "user-1"}]}]
 	}`
-	_, err := validateSCIMGroupPatchRequest([]byte(body))
+	_, err := parseAndValidateSCIMGroupPatchRequest([]byte(body))
 	require.Equal(t, ErrorInvalidPatchPath.Code, err.Code)
 }
 
@@ -308,7 +308,7 @@ func TestValidateSCIMGroupPatchOp_UnknownPath_Rejected(t *testing.T) {
 		"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
 		"Operations": [{"op": "replace", "path": "externalId", "value": "x"}]
 	}`
-	_, err := validateSCIMGroupPatchRequest([]byte(body))
+	_, err := parseAndValidateSCIMGroupPatchRequest([]byte(body))
 	require.Equal(t, ErrorInvalidPatchPath.Code, err.Code)
 }
 
@@ -317,7 +317,7 @@ func TestValidateSCIMGroupPatchOp_InvalidOp_Rejected(t *testing.T) {
 		"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
 		"Operations": [{"op": "bogus", "path": "displayName", "value": "x"}]
 	}`
-	_, err := validateSCIMGroupPatchRequest([]byte(body))
+	_, err := parseAndValidateSCIMGroupPatchRequest([]byte(body))
 	require.Equal(t, ErrorInvalidPatchOp.Code, err.Code)
 }
 
@@ -326,7 +326,7 @@ func TestValidateSCIMGroupPatchOp_CaseInsensitiveOpAndPath(t *testing.T) {
 		"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
 		"Operations": [{"op": "REPLACE", "path": "DisplayName", "value": "X"}]
 	}`
-	actions, err := validateSCIMGroupPatchRequest([]byte(body))
+	actions, err := parseAndValidateSCIMGroupPatchRequest([]byte(body))
 	require.Nil(t, err)
 	require.Equal(t, scimGroupPatchTargetDisplayName, actions[0].Target)
 }
@@ -336,7 +336,7 @@ func TestValidateSCIMGroupPatchOp_RemoveMembersWithUnexpectedValue_Rejected(t *t
 		"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
 		"Operations": [{"op": "remove", "path": "members", "value": [{"value": "user-1"}]}]
 	}`
-	_, err := validateSCIMGroupPatchRequest([]byte(body))
+	_, err := parseAndValidateSCIMGroupPatchRequest([]byte(body))
 	require.Equal(t, ErrorInvalidPatchValue.Code, err.Code)
 }
 
@@ -345,6 +345,6 @@ func TestValidateSCIMGroupPatchOp_AddMembersWithInvalidJSONValue_Rejected(t *tes
 		"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
 		"Operations": [{"op": "add", "path": "members", "value": "not-an-array"}]
 	}`
-	_, err := validateSCIMGroupPatchRequest([]byte(body))
+	_, err := parseAndValidateSCIMGroupPatchRequest([]byte(body))
 	require.Equal(t, ErrorInvalidPatchValue.Code, err.Code)
 }

--- a/backend/internal/scim/users_handler.go
+++ b/backend/internal/scim/users_handler.go
@@ -141,7 +141,7 @@ func (h *scimUsersHandler) HandleUsersCreateRequest(w http.ResponseWriter, r *ht
 		handleSCIMError(w, r, &ErrorInvalidRequestBody)
 		return
 	}
-	payload, svcErr := validateSCIMUserRequest(body)
+	payload, svcErr := parseAndValidateSCIMUserRequest(body)
 	if svcErr != nil {
 		handleSCIMError(w, r, svcErr)
 		return
@@ -211,7 +211,7 @@ func (h *scimUsersHandler) HandleUsersReplaceRequest(w http.ResponseWriter, r *h
 		handleSCIMError(w, r, &ErrorInvalidRequestBody)
 		return
 	}
-	payload, svcErr := validateSCIMUserRequest(body)
+	payload, svcErr := parseAndValidateSCIMUserRequest(body)
 	if svcErr != nil {
 		handleSCIMError(w, r, svcErr)
 		return
@@ -223,7 +223,7 @@ func (h *scimUsersHandler) HandleUsersReplaceRequest(w http.ResponseWriter, r *h
 		return
 	}
 
-	replaced, svcErr := h.svc.ReplaceUser(ctx, userID, payload, r.Header.Get("If-Match"), h.baseURL)
+	replaced, svcErr := h.svc.ReplaceUser(ctx, userID, payload, r.Header.Get("If-Match"), h.baseURL, false)
 	if svcErr != nil {
 		handleSCIMError(w, r, svcErr)
 		return
@@ -281,7 +281,7 @@ func (h *scimUsersHandler) HandleMeReplaceRequest(w http.ResponseWriter, r *http
 		handleSCIMError(w, r, &ErrorInvalidRequestBody)
 		return
 	}
-	payload, svcErr := validateSCIMUserRequest(body)
+	payload, svcErr := parseAndValidateSCIMUserRequest(body)
 	if svcErr != nil {
 		handleSCIMError(w, r, svcErr)
 		return
@@ -292,7 +292,7 @@ func (h *scimUsersHandler) HandleMeReplaceRequest(w http.ResponseWriter, r *http
 		handleSCIMError(w, r, svcErr)
 		return
 	}
-	replaced, svcErr := h.svc.ReplaceUser(ctx, userID, payload, r.Header.Get("If-Match"), h.baseURL)
+	replaced, svcErr := h.svc.ReplaceUser(ctx, userID, payload, r.Header.Get("If-Match"), h.baseURL, true)
 	if svcErr != nil {
 		handleSCIMError(w, r, svcErr)
 		return

--- a/backend/internal/scim/users_handler_test.go
+++ b/backend/internal/scim/users_handler_test.go
@@ -146,7 +146,7 @@ func TestHandleUsersReplaceRequest_Success(t *testing.T) {
 		},
 	}
 	mockSvc.On(
-		"ReplaceUser", mock.Anything, "user-123", mock.AnythingOfType("*scim.SCIMUserPayload"), "", testBaseURL,
+		"ReplaceUser", mock.Anything, "user-123", mock.AnythingOfType("*scim.SCIMUserPayload"), "", testBaseURL, false,
 	).Return(expectedUser, (*tidcommon.ServiceError)(nil))
 
 	h := newSCIMUsersHandler(mockSvc, testBaseURL)
@@ -272,7 +272,7 @@ func TestHandleMeReplaceRequest_Success(t *testing.T) {
 		},
 	}
 	mockSvc.On(
-		"ReplaceUser", mock.Anything, "user-123", mock.AnythingOfType("*scim.SCIMUserPayload"), "", testBaseURL,
+		"ReplaceUser", mock.Anything, "user-123", mock.AnythingOfType("*scim.SCIMUserPayload"), "", testBaseURL, true,
 	).Return(expectedUser, (*tidcommon.ServiceError)(nil))
 
 	h := newSCIMUsersHandler(mockSvc, testBaseURL)
@@ -342,7 +342,7 @@ func TestHandleMeReplaceRequest_InvalidJSON_Returns400(t *testing.T) {
 func TestHandleMeReplaceRequest_ServiceError_Returns404(t *testing.T) {
 	mockSvc := NewSCIMUsersServiceInterfaceMock(t)
 	mockSvc.On("ReplaceUser", mock.Anything, "user-123",
-		mock.AnythingOfType("*scim.SCIMUserPayload"), "", testBaseURL).
+		mock.AnythingOfType("*scim.SCIMUserPayload"), "", testBaseURL, true).
 		Return((*SCIMUser)(nil), &ErrorUserNotFound)
 
 	body := `{"schemas":["urn:thunderid:params:scim:schemas:person:2.0:User"],` +
@@ -589,7 +589,7 @@ func TestHandleUsersReplaceRequest_InvalidJSON_Returns400(t *testing.T) {
 func TestHandleUsersReplaceRequest_NotFound_Returns404(t *testing.T) {
 	mockSvc := NewSCIMUsersServiceInterfaceMock(t)
 	mockSvc.On("ReplaceUser", mock.Anything, "no-such",
-		mock.AnythingOfType("*scim.SCIMUserPayload"), "", testBaseURL).
+		mock.AnythingOfType("*scim.SCIMUserPayload"), "", testBaseURL, false).
 		Return((*SCIMUser)(nil), &ErrorUserNotFound)
 
 	body := `{"schemas":["urn:thunderid:params:scim:schemas:person:2.0:User"],` +
@@ -609,7 +609,7 @@ func TestHandleUsersReplaceRequest_NotFound_Returns404(t *testing.T) {
 func TestHandleUsersReplaceRequest_MutabilityViolation_Returns400(t *testing.T) {
 	mockSvc := NewSCIMUsersServiceInterfaceMock(t)
 	mockSvc.On("ReplaceUser", mock.Anything, "readonly",
-		mock.AnythingOfType("*scim.SCIMUserPayload"), "", testBaseURL).
+		mock.AnythingOfType("*scim.SCIMUserPayload"), "", testBaseURL, false).
 		Return((*SCIMUser)(nil), &ErrorMutabilityViolation)
 
 	body := `{"schemas":["urn:thunderid:params:scim:schemas:person:2.0:User"],` +
@@ -892,6 +892,25 @@ func TestHandleUsersSearchRequest_CustomPagination(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code)
 }
 
+func TestHandleUsersSearchRequest_ExplicitZeroCount(t *testing.T) {
+	mockSvc := NewSCIMUsersServiceInterfaceMock(t)
+	mockSvc.On("ListUsers", mock.Anything, 1, 0, mock.Anything, testBaseURL).
+		Return(SCIMUserListResponse{
+			Schemas: []string{SCIMListResponseSchemaURN}, StartIndex: 1, ItemsPerPage: 0, TotalResults: 5,
+			Resources: []SCIMUser{},
+		}, (*tidcommon.ServiceError)(nil))
+
+	body := `{"schemas": ["` + SCIMSearchSchemaURN + `"], "count": 0}`
+	h := newSCIMUsersHandler(mockSvc, testBaseURL)
+	req := httptest.NewRequest(http.MethodPost, "/scim/v2/Users/.search", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", constants.SCIMContentType)
+	rr := httptest.NewRecorder()
+
+	h.HandleUsersSearchRequest(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+}
+
 func TestHandleUsersSearchRequest_CapsMaxCount(t *testing.T) {
 	mockSvc := NewSCIMUsersServiceInterfaceMock(t)
 	mockSvc.On("ListUsers", mock.Anything, 1, scimconfig.FilterMaxResults, mock.Anything, testBaseURL).
@@ -1000,7 +1019,7 @@ func TestHandleUsersSearchRequest_ServiceError_Returns500(t *testing.T) {
 func TestHandleUsersReplaceRequest_PreconditionFailed(t *testing.T) {
 	mockSvc := NewSCIMUsersServiceInterfaceMock(t)
 	mockSvc.On("ReplaceUser", mock.Anything, "user-123",
-		mock.AnythingOfType("*scim.SCIMUserPayload"), `W/"stale"`, testBaseURL).
+		mock.AnythingOfType("*scim.SCIMUserPayload"), `W/"stale"`, testBaseURL, false).
 		Return((*SCIMUser)(nil), &ErrorPreconditionFailed)
 
 	h := newSCIMUsersHandler(mockSvc, testBaseURL)
@@ -1267,7 +1286,7 @@ func TestHandleUsersReplaceRequest_AppliesAttributeProjection(t *testing.T) {
 		},
 	}
 	mockSvc.On(
-		"ReplaceUser", mock.Anything, "user-123", mock.AnythingOfType("*scim.SCIMUserPayload"), "", testBaseURL,
+		"ReplaceUser", mock.Anything, "user-123", mock.AnythingOfType("*scim.SCIMUserPayload"), "", testBaseURL, false,
 	).Return(expectedUser, (*tidcommon.ServiceError)(nil))
 
 	h := newSCIMUsersHandler(mockSvc, testBaseURL)

--- a/backend/internal/scim/users_service.go
+++ b/backend/internal/scim/users_service.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/thunder-id/thunderid/internal/entitytype"
 	scimconfig "github.com/thunder-id/thunderid/internal/scim/config"
-	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/security"
 	"github.com/thunder-id/thunderid/internal/user"
@@ -31,25 +30,28 @@ type SCIMUsersServiceInterface interface {
 	) (*SCIMUser, *tidcommon.ServiceError)
 	GetUser(ctx context.Context, userID, baseURL string) (*SCIMUser, *tidcommon.ServiceError)
 	ReplaceUser(
-		ctx context.Context, userID string, payload *SCIMUserPayload, ifMatch, baseURL string,
+		ctx context.Context, userID string, payload *SCIMUserPayload, ifMatch, baseURL string, isSelf bool,
 	) (*SCIMUser, *tidcommon.ServiceError)
 	DeleteUser(ctx context.Context, userID string, ifMatch string) *tidcommon.ServiceError
 }
 
 // scimUsersService implements SCIMUsersServiceInterface.
 type scimUsersService struct {
-	userService       user.UserServiceInterface
-	entityTypeService entitytype.EntityTypeServiceInterface
+	userService     user.UserServiceInterface
+	userTypeService entitytype.EntityTypeServiceInterface
+	cfg             scimconfig.SCIMConfig
 }
 
 // newSCIMUsersService creates a new scimUsersService.
 func newSCIMUsersService(
 	userService user.UserServiceInterface,
-	entityTypeService entitytype.EntityTypeServiceInterface,
+	userTypeService entitytype.EntityTypeServiceInterface,
+	cfg scimconfig.SCIMConfig,
 ) SCIMUsersServiceInterface {
 	return &scimUsersService{
-		userService:       userService,
-		entityTypeService: entityTypeService,
+		userService:     userService,
+		userTypeService: userTypeService,
+		cfg:             cfg,
 	}
 }
 
@@ -61,15 +63,26 @@ func (s *scimUsersService) ListUsers(ctx context.Context, startIndex, count int,
 	if startIndex < 1 {
 		startIndex = 1
 	}
-	if count < 1 {
-		count = serverconst.DefaultPageSize
+	if count < 0 {
+		count = 0
+	}
+
+	// GetUserList rejects a limit below 1, so a count of 0 (client wants only
+	// totalResults, no resources per RFC 7644 §3.4.2.4) fetches a single row
+	// and discards it below.
+	fetchLimit := count
+	if fetchLimit == 0 {
+		fetchLimit = 1
 	}
 
 	offset := startIndex - 1
-	listResp, svcErr := s.userService.GetUserList(ctx, count, offset, filters, false)
+	listResp, svcErr := s.userService.GetUserList(ctx, fetchLimit, offset, filters, false)
 	if svcErr != nil {
 		logger.Error(ctx, "SCIM ListUsers: failed to get user list", log.Any("error", svcErr))
 		return SCIMUserListResponse{}, mapUserServiceErrorToSCIM(svcErr)
+	}
+	if count == 0 {
+		return buildSCIMUserListResponse(nil, listResp.TotalResults, startIndex, 0), nil
 	}
 	scimUsers := make([]SCIMUser, 0, len(listResp.Users))
 	credKeysByType := make(map[string]map[string]struct{})
@@ -83,7 +96,7 @@ func (s *scimUsersService) ListUsers(ctx context.Context, startIndex, count int,
 			var svcErr *tidcommon.ServiceError
 			credKeys, svcErr = s.getCredentialKeys(ctx, u.Type)
 			if svcErr != nil {
-				logger.Warn(ctx, "SCIM ListUsers: omitting user with unresolvable entity type",
+				logger.Warn(ctx, "SCIM ListUsers: omitting user with unresolvable user type",
 					log.String("userID", u.ID), log.String("userType", u.Type))
 				unresolvedTypes[u.Type] = struct{}{}
 				continue
@@ -92,7 +105,7 @@ func (s *scimUsersService) ListUsers(ctx context.Context, startIndex, count int,
 		}
 		extensionURN := buildSchemaURN(u.Type)
 		scimUsers = append(scimUsers, buildSCIMUserResource(
-			ctx, u, extensionURN, baseURL, credKeys, scimconfig.ReturnMappedCoreAttrsOnGet))
+			ctx, u, extensionURN, baseURL, credKeys, s.cfg.ReturnMappedCoreAttrsOnGet))
 	}
 
 	return buildSCIMUserListResponse(scimUsers, listResp.TotalResults, startIndex, len(scimUsers)), nil
@@ -116,46 +129,47 @@ func (s *scimUsersService) GetUser(
 	if svcErr != nil {
 		return nil, svcErr
 	}
-	scimUser := buildSCIMUserResource(ctx, *u, extensionURN, baseURL, credKeys, scimconfig.ReturnMappedCoreAttrsOnGet)
+	scimUser := buildSCIMUserResource(ctx, *u, extensionURN, baseURL, credKeys, s.cfg.ReturnMappedCoreAttrsOnGet)
 	return &scimUser, nil
 }
 
-// CreateUser validates the entity type, then delegates to user.UserService.CreateUser.
+// CreateUser validates the user type, then delegates to user.UserService.CreateUser.
 func (s *scimUsersService) CreateUser(
 	ctx context.Context, payload *SCIMUserPayload, baseURL string,
 ) (*SCIMUser, *tidcommon.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, usersServiceLoggerComponentName))
 
 	runtimeCtx := security.WithRuntimeContext(ctx)
-	var canonicalName string
+	var resolvedUserTypeName string
 	var svcErr *tidcommon.ServiceError
 	if payload.UserTypeName == "" {
-		canonicalName, svcErr = resolveDefaultEntityTypeName(runtimeCtx, s.entityTypeService)
+		resolvedUserTypeName, svcErr = resolveDefaultUserTypeName(runtimeCtx, s.userTypeService)
 		if svcErr != nil {
 			logger.Error(ctx, "SCIM CreateUser: no default user type available", log.Any("error", svcErr))
 			return nil, svcErr
 		}
 	} else {
-		canonicalName, svcErr = resolveEntityTypeNameForSchemaURN(runtimeCtx, s.entityTypeService, payload.UserTypeName)
-		if svcErr != nil || canonicalName == "" {
-			logger.Error(ctx, "SCIM CreateUser: entity type not found",
+		resolvedUserTypeName, svcErr = resolveUserTypeNameForSchemaURN(
+			runtimeCtx, s.userTypeService, payload.UserTypeName)
+		if svcErr != nil || resolvedUserTypeName == "" {
+			logger.Error(ctx, "SCIM CreateUser: user type not found",
 				log.String("userTypeName", payload.UserTypeName), log.Any("error", svcErr))
 			return nil, &ErrorUnknownUserType
 		}
 	}
 
-	et, svcErr := s.entityTypeService.GetEntityTypeByName(runtimeCtx, entitytype.TypeCategoryUser, canonicalName)
+	et, svcErr := s.userTypeService.GetEntityTypeByName(runtimeCtx, entitytype.TypeCategoryUser, resolvedUserTypeName)
 
 	if svcErr != nil {
-		logger.Error(ctx, "SCIM CreateUser: entity type not found",
-			log.String("userTypeName", canonicalName), log.Any("error", svcErr))
+		logger.Error(ctx, "SCIM CreateUser: user type not found",
+			log.String("userTypeName", resolvedUserTypeName), log.Any("error", svcErr))
 		return nil, &ErrorUnknownUserType
 	}
 
 	if len(payload.CoreAttrs) > 0 {
 		reverseMapped, err := reverseMapCoreAttrsForSchema(payload.CoreAttrs, et.Schema)
 		if err != nil {
-			logger.Error(ctx, "SCIM CreateUser: failed to parse entity type schema", log.Error(err))
+			logger.Error(ctx, "SCIM CreateUser: failed to parse user type schema", log.Error(err))
 			return nil, &ErrorInternalServer
 		}
 		if svcErr := mergeReverseMappedCoreAttrs(payload.ExtensionAttrs, reverseMapped); svcErr != nil {
@@ -166,23 +180,23 @@ func (s *scimUsersService) CreateUser(
 	}
 	missing, err := missingRequiredAttrs(payload.ExtensionAttrs, et.Schema, false)
 	if err != nil {
-		logger.Error(ctx, "SCIM CreateUser: failed to parse entity type schema", log.Error(err))
+		logger.Error(ctx, "SCIM CreateUser: failed to parse user type schema", log.Error(err))
 		return nil, &ErrorInternalServer
 	}
 	if len(missing) > 0 {
 		logger.Debug(ctx, "SCIM CreateUser: missing required attributes for user type",
-			log.String("userType", canonicalName), log.Any("missing", missing))
-		return nil, newMissingRequiredAttributesError(canonicalName, missing)
+			log.String("userType", resolvedUserTypeName), log.Any("missing", missing))
+		return nil, newMissingRequiredAttributesError(resolvedUserTypeName, missing)
 	}
 	undeclared, err := undeclaredAttrs(payload.ExtensionAttrs, et.Schema)
 	if err != nil {
-		logger.Error(ctx, "SCIM CreateUser: failed to parse entity type schema", log.Error(err))
+		logger.Error(ctx, "SCIM CreateUser: failed to parse user type schema", log.Error(err))
 		return nil, &ErrorInternalServer
 	}
 	if len(undeclared) > 0 {
 		logger.Debug(ctx, "SCIM CreateUser: undeclared attributes for user type",
-			log.String("userType", canonicalName), log.Any("undeclared", undeclared))
-		return nil, newUndeclaredAttributesError(canonicalName, undeclared)
+			log.String("userType", resolvedUserTypeName), log.Any("undeclared", undeclared))
+		return nil, newUndeclaredAttributesError(resolvedUserTypeName, undeclared)
 	}
 	attrsJSON, err := json.Marshal(payload.ExtensionAttrs)
 	if err != nil {
@@ -191,7 +205,7 @@ func (s *scimUsersService) CreateUser(
 	}
 	newUser := &user.User{
 		OUID:       et.OUID,
-		Type:       canonicalName,
+		Type:       resolvedUserTypeName,
 		Attributes: attrsJSON,
 	}
 
@@ -201,7 +215,7 @@ func (s *scimUsersService) CreateUser(
 		return nil, mapUserServiceErrorToSCIM(svcErr)
 	}
 	extensionURN := buildSchemaURN(created.Type)
-	credKeys, svcErr := s.getCredentialKeys(ctx, canonicalName)
+	credKeys, svcErr := s.getCredentialKeys(ctx, resolvedUserTypeName)
 	if svcErr != nil {
 		return nil, svcErr
 	}
@@ -209,9 +223,11 @@ func (s *scimUsersService) CreateUser(
 	return &scimUser, nil
 }
 
-// ReplaceUser performs a full PUT replace on the user.
+// ReplaceUser performs a full PUT replace on the user. isSelf marks a
+// self-service caller (SCIM /Me), whose type and OU are already pinned to
+// their existing values below, so only attributes are ever mutated for them.
 func (s *scimUsersService) ReplaceUser(
-	ctx context.Context, userID string, payload *SCIMUserPayload, ifMatch, baseURL string,
+	ctx context.Context, userID string, payload *SCIMUserPayload, ifMatch, baseURL string, isSelf bool,
 ) (*SCIMUser, *tidcommon.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, usersServiceLoggerComponentName))
 
@@ -233,32 +249,33 @@ func (s *scimUsersService) ReplaceUser(
 	// The user's type is immutable, so an omitted extension URN defaults to the
 	// existing type rather than being treated as ambiguous. A supplied URN must
 	// still match the existing type.
-	canonicalName := existingUser.Type
+	resolvedUserTypeName := existingUser.Type
 	if payload.UserTypeName != "" {
-		resolvedName, svcErr := resolveEntityTypeNameForSchemaURN(runtimeCtx, s.entityTypeService, payload.UserTypeName)
-		if svcErr != nil || resolvedName == "" {
-			logger.Error(runtimeCtx, "SCIM ReplaceUser: entity type not found",
+		requestedUserTypeName, svcErr := resolveUserTypeNameForSchemaURN(
+			runtimeCtx, s.userTypeService, payload.UserTypeName)
+		if svcErr != nil || requestedUserTypeName == "" {
+			logger.Error(runtimeCtx, "SCIM ReplaceUser: user type not found",
 				log.String("userTypeName", payload.UserTypeName), log.Any("error", svcErr))
 			return nil, &ErrorUnknownUserType
 		}
-		if resolvedName != existingUser.Type {
+		if requestedUserTypeName != existingUser.Type {
 			logger.Error(ctx, "SCIM ReplaceUser: user type mismatch",
 				log.String("userID", userID), log.String("existingType", existingUser.Type),
-				log.String("requestedType", resolvedName))
+				log.String("requestedType", requestedUserTypeName))
 			return nil, &ErrorImmutableUserType
 		}
 	}
 
-	et, svcErr := s.entityTypeService.GetEntityTypeByName(runtimeCtx, entitytype.TypeCategoryUser, canonicalName)
+	et, svcErr := s.userTypeService.GetEntityTypeByName(runtimeCtx, entitytype.TypeCategoryUser, resolvedUserTypeName)
 	if svcErr != nil {
-		logger.Error(runtimeCtx, "SCIM ReplaceUser: entity type not found",
-			log.String("userTypeName", canonicalName), log.Any("error", svcErr))
+		logger.Error(runtimeCtx, "SCIM ReplaceUser: user type not found",
+			log.String("userTypeName", resolvedUserTypeName), log.Any("error", svcErr))
 		return nil, &ErrorUnknownUserType
 	}
 	if len(payload.CoreAttrs) > 0 {
 		reverseMapped, err := reverseMapCoreAttrsForSchema(payload.CoreAttrs, et.Schema)
 		if err != nil {
-			logger.Error(ctx, "SCIM ReplaceUser: failed to parse entity type schema", log.Error(err))
+			logger.Error(ctx, "SCIM ReplaceUser: failed to parse user type schema", log.Error(err))
 			return nil, &ErrorInternalServer
 		}
 		if svcErr := mergeReverseMappedCoreAttrs(payload.ExtensionAttrs, reverseMapped); svcErr != nil {
@@ -269,36 +286,46 @@ func (s *scimUsersService) ReplaceUser(
 	}
 	missing, err := missingRequiredAttrs(payload.ExtensionAttrs, et.Schema, true)
 	if err != nil {
-		logger.Error(ctx, "SCIM ReplaceUser: failed to parse entity type schema", log.Error(err))
+		logger.Error(ctx, "SCIM ReplaceUser: failed to parse user type schema", log.Error(err))
 		return nil, &ErrorInternalServer
 	}
 	if len(missing) > 0 {
 		logger.Debug(ctx, "SCIM ReplaceUser: missing required attributes for user type",
-			log.String("userType", canonicalName), log.Any("missing", missing))
-		return nil, newMissingRequiredAttributesError(canonicalName, missing)
+			log.String("userType", resolvedUserTypeName), log.Any("missing", missing))
+		return nil, newMissingRequiredAttributesError(resolvedUserTypeName, missing)
 	}
 	undeclared, err := undeclaredAttrs(payload.ExtensionAttrs, et.Schema)
 	if err != nil {
-		logger.Error(ctx, "SCIM ReplaceUser: failed to parse entity type schema", log.Error(err))
+		logger.Error(ctx, "SCIM ReplaceUser: failed to parse user type schema", log.Error(err))
 		return nil, &ErrorInternalServer
 	}
 	if len(undeclared) > 0 {
 		logger.Debug(ctx, "SCIM ReplaceUser: undeclared attributes for user type",
-			log.String("userType", canonicalName), log.Any("undeclared", undeclared))
-		return nil, newUndeclaredAttributesError(canonicalName, undeclared)
+			log.String("userType", resolvedUserTypeName), log.Any("undeclared", undeclared))
+		return nil, newUndeclaredAttributesError(resolvedUserTypeName, undeclared)
 	}
 	attrsJSON, err := json.Marshal(payload.ExtensionAttrs)
 	if err != nil {
 		logger.Error(ctx, "SCIM ReplaceUser: failed to marshal extension attrs", log.Error(err))
 		return nil, &ErrorInvalidRequestBody
 	}
-	updatedUser := &user.User{
-		ID:         userID,
-		OUID:       et.OUID,
-		Type:       canonicalName,
-		Attributes: attrsJSON,
+	var result *user.User
+	if isSelf {
+		// Self-service replace: type and OU can't change (enforced above), so this
+		// goes through the same attribute-only update path as native /users/me,
+		// skipping user.UpdateUser's OU/type validation. That validation requires
+		// system:usertype:view with no self-access bypass, so self-service callers
+		// would otherwise hit it and fail.
+		result, svcErr = s.userService.UpdateUserAttributes(ctx, userID, attrsJSON)
+	} else {
+		updatedUser := &user.User{
+			ID:         userID,
+			OUID:       et.OUID,
+			Type:       resolvedUserTypeName,
+			Attributes: attrsJSON,
+		}
+		result, svcErr = s.userService.UpdateUser(ctx, userID, updatedUser)
 	}
-	result, svcErr := s.userService.UpdateUser(ctx, userID, updatedUser)
 	if svcErr != nil {
 		logger.Error(ctx, "SCIM ReplaceUser: user service error",
 			log.String("userID", userID), log.Any("error", svcErr))
@@ -306,7 +333,7 @@ func (s *scimUsersService) ReplaceUser(
 	}
 
 	extensionURN := buildSchemaURN(result.Type)
-	credKeys, svcErr := s.getCredentialKeys(ctx, canonicalName)
+	credKeys, svcErr := s.getCredentialKeys(ctx, resolvedUserTypeName)
 	if svcErr != nil {
 		return nil, svcErr
 	}
@@ -341,17 +368,17 @@ func (s *scimUsersService) DeleteUser(ctx context.Context, userID string, ifMatc
 
 // getCredentialKeys returns a set of attribute names that represent credentials for the given user type.
 func (s *scimUsersService) getCredentialKeys(
-	ctx context.Context, canonicalName string,
+	ctx context.Context, resolvedUserTypeName string,
 ) (map[string]struct{}, *tidcommon.ServiceError) {
 	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, usersServiceLoggerComponentName))
 
 	credKeys := make(map[string]struct{})
 	// Use elevated runtime context if necessary, but we are just reading schema info.
-	credentialInfos, err := s.entityTypeService.GetAttributes(security.WithRuntimeContext(ctx),
-		entitytype.TypeCategoryUser, canonicalName, true, false, false)
+	credentialInfos, err := s.userTypeService.GetAttributes(security.WithRuntimeContext(ctx),
+		entitytype.TypeCategoryUser, resolvedUserTypeName, true, false, false)
 	if err != nil {
 		logger.Error(ctx, "SCIM: failed to resolve credential attribute keys",
-			log.String("userType", canonicalName), log.Any("error", err))
+			log.String("userType", resolvedUserTypeName), log.Any("error", err))
 		return nil, &ErrorInternalServer
 	}
 	for _, info := range credentialInfos {

--- a/backend/internal/scim/users_service_test.go
+++ b/backend/internal/scim/users_service_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/thunder-id/thunderid/internal/entitytype"
-	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
+	scimconfig "github.com/thunder-id/thunderid/internal/scim/config"
 	"github.com/thunder-id/thunderid/internal/user"
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/tests/mocks/entitytypemock"
@@ -24,9 +24,10 @@ const testOUID = "ou-abc"
 
 func TestGetUser_Success(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
 
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	internalUser := &user.User{
 		ID:         "user-123",
@@ -34,7 +35,7 @@ func TestGetUser_Success(t *testing.T) {
 		Attributes: []byte(`{"given_name": "John"}`),
 	}
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).Return(internalUser, (*tidcommon.ServiceError)(nil))
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetAttributes", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee, true, false, false,
 	).Return([]entitytype.AttributeInfo{{Attribute: "password"}}, (*tidcommon.ServiceError)(nil))
 
@@ -48,9 +49,10 @@ func TestGetUser_Success(t *testing.T) {
 
 func TestGetUser_CredentialKeyLookupFailure_DoesNotLeakAttributes(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
 
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	internalUser := &user.User{
 		ID:         "user-123",
@@ -58,7 +60,7 @@ func TestGetUser_CredentialKeyLookupFailure_DoesNotLeakAttributes(t *testing.T) 
 		Attributes: []byte(`{"given_name": "John", "password": "secret"}`),
 	}
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).Return(internalUser, (*tidcommon.ServiceError)(nil))
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetAttributes", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee, true, false, false,
 	).Return(nil, &tidcommon.ServiceError{Code: "SVC-500", Type: tidcommon.ServerErrorType})
 
@@ -71,9 +73,10 @@ func TestGetUser_CredentialKeyLookupFailure_DoesNotLeakAttributes(t *testing.T) 
 
 func TestGetUser_NotFound(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
 
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).Return((*user.User)(nil), &user.ErrorUserNotFound)
 
@@ -86,9 +89,10 @@ func TestGetUser_NotFound(t *testing.T) {
 
 func TestDeleteUser_Success(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
 
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	mockUserService.On("DeleteUser", mock.Anything, "user-123").Return((*tidcommon.ServiceError)(nil))
 
@@ -99,9 +103,10 @@ func TestDeleteUser_Success(t *testing.T) {
 
 func TestDeleteUser_NotFound(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
 
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	mockUserService.On("DeleteUser", mock.Anything, "user-123").Return(&user.ErrorUserNotFound)
 
@@ -113,9 +118,10 @@ func TestDeleteUser_NotFound(t *testing.T) {
 
 func TestDeleteUser_MutabilityViolation_MapsToSCIM(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
 
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	mockUserService.On("DeleteUser", mock.Anything, "user-123").
 		Return(&user.ErrorCannotModifyDeclarativeResource)
@@ -128,9 +134,10 @@ func TestDeleteUser_MutabilityViolation_MapsToSCIM(t *testing.T) {
 
 func TestGetUser_UniquenessConflict_MapsToSCIM(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
 
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).
 		Return((*user.User)(nil), &user.ErrorAttributeConflict)
@@ -144,9 +151,10 @@ func TestGetUser_UniquenessConflict_MapsToSCIM(t *testing.T) {
 
 func TestGetUser_SchemaValidationError_MapsToSCIM(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
 
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).
 		Return((*user.User)(nil), &user.ErrorSchemaValidationFailed)
@@ -160,9 +168,10 @@ func TestGetUser_SchemaValidationError_MapsToSCIM(t *testing.T) {
 
 func TestListUsers_Success(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
 
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	internalUser := user.User{
 		ID:         "user-1",
@@ -174,7 +183,7 @@ func TestListUsers_Success(t *testing.T) {
 			TotalResults: 1,
 			Users:        []user.User{internalUser},
 		}, (*tidcommon.ServiceError)(nil))
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetAttributes", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee, true, false, false,
 	).Return([]entitytype.AttributeInfo{}, (*tidcommon.ServiceError)(nil))
 
@@ -192,9 +201,10 @@ func TestListUsers_Success(t *testing.T) {
 // are still returned.
 func TestListUsers_UnresolvableUserType_OmitsUserButReturnsRest(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
 
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	const testUnknownUserType = "ghost-type"
 	ghostUser := user.User{
@@ -212,10 +222,10 @@ func TestListUsers_UnresolvableUserType_OmitsUserButReturnsRest(t *testing.T) {
 			TotalResults: 2,
 			Users:        []user.User{ghostUser, goodUser},
 		}, (*tidcommon.ServiceError)(nil))
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetAttributes", mock.Anything, entitytype.TypeCategoryUser, testUnknownUserType, true, false, false,
 	).Return(nil, &tidcommon.ServiceError{Code: "USRS-1002", Type: tidcommon.ClientErrorType})
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetAttributes", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee, true, false, false,
 	).Return([]entitytype.AttributeInfo{}, (*tidcommon.ServiceError)(nil))
 
@@ -228,9 +238,10 @@ func TestListUsers_UnresolvableUserType_OmitsUserButReturnsRest(t *testing.T) {
 
 func TestListUsers_ServiceError(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
 
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	mockUserService.On("GetUserList", mock.Anything, 20, 0, (map[string]interface{})(nil), false).
 		Return((*user.UserListResponse)(nil), &user.ErrorUserNotFound)
@@ -242,20 +253,24 @@ func TestListUsers_ServiceError(t *testing.T) {
 	require.Empty(t, resp.Resources)
 }
 
-func TestListUsers_DefaultsInvalidPagination(t *testing.T) {
+func TestListUsers_ExplicitZeroCountReturnsNoResources(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
 
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	mockUserService.On("GetUserList",
-		mock.Anything, serverconst.DefaultPageSize, 0, (map[string]interface{})(nil), false).
-		Return(&user.UserListResponse{TotalResults: 0, Users: []user.User{}}, (*tidcommon.ServiceError)(nil))
+		mock.Anything, 1, 0, (map[string]interface{})(nil), false).
+		Return(&user.UserListResponse{TotalResults: 5, Users: []user.User{{ID: "user-1", Type: "employee"}}},
+			(*tidcommon.ServiceError)(nil))
 
 	resp, err := service.ListUsers(context.Background(), 0, 0, nil, testBaseURL)
 
 	require.Nil(t, err)
-	require.Equal(t, 0, resp.TotalResults)
+	require.Equal(t, 5, resp.TotalResults)
+	require.Empty(t, resp.Resources)
+	require.Equal(t, 0, resp.ItemsPerPage)
 }
 
 func TestMapUserServiceErrorToSCIM_AllCodes(t *testing.T) {
@@ -296,7 +311,7 @@ func TestMapUserServiceErrorToSCIM_Nil_ReturnsNil(t *testing.T) {
 	require.Nil(t, mapUserServiceErrorToSCIM(nil))
 }
 
-// resolveEntityTypeNameForSchemaURN is called with the user type name extracted
+// resolveUserTypeNameForSchemaURN is called with the user type name extracted
 // from the schema URN. It pages through GetEntityTypeList and matches by name
 // (case-insensitive). The tests below set up the minimal mock chain:
 //   GetEntityTypeList  →  list containing the type  →  GetEntityTypeByName
@@ -316,8 +331,9 @@ func makeEntityTypeListPage() *entitytype.EntityTypeListResponse {
 
 func TestCreateUser_Success(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	payload := &SCIMUserPayload{
 		UserTypeName:   testUserTypeEmployee,
@@ -331,20 +347,20 @@ func TestCreateUser_Success(t *testing.T) {
 		Attributes: []byte(`{"given_name":"Alice"}`),
 	}
 
-	// resolveEntityTypeNameForSchemaURN pages GetEntityTypeList
-	mockEntityService.On(
+	// resolveUserTypeNameForSchemaURN pages GetEntityTypeList
+	mockUserTypeService.On(
 		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
 
 	// GetEntityTypeByName after resolution
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return(&entitytype.EntityType{Name: testUserTypeEmployee, OUID: testOUID}, (*tidcommon.ServiceError)(nil))
 
 	mockUserService.On("CreateUser", mock.Anything, mock.MatchedBy(func(u *user.User) bool {
 		return u.Type == testUserTypeEmployee && u.OUID == testOUID
 	})).Return(createdUser, (*tidcommon.ServiceError)(nil))
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetAttributes", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee, true, false, false,
 	).Return([]entitytype.AttributeInfo{}, (*tidcommon.ServiceError)(nil))
 
@@ -358,8 +374,9 @@ func TestCreateUser_Success(t *testing.T) {
 
 func TestCreateUser_MissingRequiredAttribute_ReturnsSchemaValidationError(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	payload := &SCIMUserPayload{
 		UserTypeName:   testUserTypeEmployee,
@@ -367,10 +384,10 @@ func TestCreateUser_MissingRequiredAttribute_ReturnsSchemaValidationError(t *tes
 		ExtensionAttrs: map[string]json.RawMessage{"given_name": json.RawMessage(`"Alice"`)},
 	}
 
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return(&entitytype.EntityType{
 		Name: testUserTypeEmployee, OUID: testOUID,
@@ -387,8 +404,9 @@ func TestCreateUser_MissingRequiredAttribute_ReturnsSchemaValidationError(t *tes
 
 func TestCreateUser_UndeclaredAttribute_ReturnsSchemaValidationError(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	payload := &SCIMUserPayload{
 		UserTypeName: testUserTypeEmployee,
@@ -399,10 +417,10 @@ func TestCreateUser_UndeclaredAttribute_ReturnsSchemaValidationError(t *testing.
 		},
 	}
 
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return(&entitytype.EntityType{
 		Name: testUserTypeEmployee, OUID: testOUID,
@@ -419,8 +437,9 @@ func TestCreateUser_UndeclaredAttribute_ReturnsSchemaValidationError(t *testing.
 
 func TestCreateUser_MalformedSchemaJSON_ReturnsInternalServerError(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	payload := &SCIMUserPayload{
 		UserTypeName: testUserTypeEmployee,
@@ -430,10 +449,10 @@ func TestCreateUser_MalformedSchemaJSON_ReturnsInternalServerError(t *testing.T)
 		},
 	}
 
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return(&entitytype.EntityType{
 		Name: testUserTypeEmployee, OUID: testOUID,
@@ -449,8 +468,9 @@ func TestCreateUser_MalformedSchemaJSON_ReturnsInternalServerError(t *testing.T)
 
 func TestReplaceUser_MalformedSchemaJSON_ReturnsInternalServerError(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	payload := &SCIMUserPayload{
 		UserTypeName: testUserTypeEmployee,
@@ -460,10 +480,10 @@ func TestReplaceUser_MalformedSchemaJSON_ReturnsInternalServerError(t *testing.T
 		},
 	}
 
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return(&entitytype.EntityType{
 		Name: testUserTypeEmployee, OUID: testOUID,
@@ -472,7 +492,7 @@ func TestReplaceUser_MalformedSchemaJSON_ReturnsInternalServerError(t *testing.T
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).
 		Return(&user.User{ID: "user-123", Type: testUserTypeEmployee}, (*tidcommon.ServiceError)(nil))
 
-	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL)
+	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL, false)
 
 	require.NotNil(t, err)
 	require.Equal(t, ErrorInternalServer.Code, err.Code)
@@ -504,13 +524,14 @@ func TestCreateUser_SchemaAttributeErrors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockUserService := usermock.NewUserServiceInterfaceMock(t)
-			mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-			service := newSCIMUsersService(mockUserService, mockEntityService)
+			mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+			service := newSCIMUsersService(
+				mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
-			mockEntityService.On(
+			mockUserTypeService.On(
 				"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 			).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
-			mockEntityService.On(
+			mockUserTypeService.On(
 				"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 			).Return(&entitytype.EntityType{
 				Name: testUserTypeEmployee, OUID: testOUID,
@@ -529,8 +550,9 @@ func TestCreateUser_SchemaAttributeErrors(t *testing.T) {
 
 func TestCreateUser_MatchingCoreAndCustomValue_Succeeds(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	payload := &SCIMUserPayload{
 		UserTypeName:   testUserTypeEmployee,
@@ -545,10 +567,10 @@ func TestCreateUser_MatchingCoreAndCustomValue_Succeeds(t *testing.T) {
 		Attributes: []byte(`{"username":"alice"}`),
 	}
 
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return(&entitytype.EntityType{
 		Name: testUserTypeEmployee, OUID: testOUID,
@@ -557,7 +579,7 @@ func TestCreateUser_MatchingCoreAndCustomValue_Succeeds(t *testing.T) {
 	mockUserService.On("CreateUser", mock.Anything, mock.MatchedBy(func(u *user.User) bool {
 		return u.Type == testUserTypeEmployee && u.OUID == testOUID
 	})).Return(createdUser, (*tidcommon.ServiceError)(nil))
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetAttributes", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee, true, false, false,
 	).Return([]entitytype.AttributeInfo{}, (*tidcommon.ServiceError)(nil))
 
@@ -570,8 +592,9 @@ func TestCreateUser_MatchingCoreAndCustomValue_Succeeds(t *testing.T) {
 
 func TestCreateUser_CoreOnly_SingleUserType_DefaultsToType(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	// No UserTypeName/ExtensionURN: the request carried only core attributes.
 	payload := &SCIMUserPayload{
@@ -585,12 +608,12 @@ func TestCreateUser_CoreOnly_SingleUserType_DefaultsToType(t *testing.T) {
 		Attributes: []byte(`{"username":"alice"}`),
 	}
 
-	// resolveDefaultEntityTypeName pages GetEntityTypeList and, finding
+	// resolveDefaultUserTypeName pages GetEntityTypeList and, finding
 	// exactly one configured user type, defaults to it.
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return(&entitytype.EntityType{
 		Name: testUserTypeEmployee, OUID: testOUID,
@@ -599,7 +622,7 @@ func TestCreateUser_CoreOnly_SingleUserType_DefaultsToType(t *testing.T) {
 	mockUserService.On("CreateUser", mock.Anything, mock.MatchedBy(func(u *user.User) bool {
 		return u.Type == testUserTypeEmployee && u.OUID == testOUID
 	})).Return(createdUser, (*tidcommon.ServiceError)(nil))
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetAttributes", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee, true, false, false,
 	).Return([]entitytype.AttributeInfo{}, (*tidcommon.ServiceError)(nil))
 
@@ -613,15 +636,16 @@ func TestCreateUser_CoreOnly_SingleUserType_DefaultsToType(t *testing.T) {
 
 func TestCreateUser_CoreOnly_MultipleUserTypes_ReturnsMissingCustomSchema(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	payload := &SCIMUserPayload{
 		CoreAttrs: map[string]json.RawMessage{"userName": json.RawMessage(`"alice"`)},
 	}
 
 	// Two configured user types: which one to default to is ambiguous.
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 	).Return(&entitytype.EntityTypeListResponse{
 		TotalResults: 2,
@@ -640,14 +664,15 @@ func TestCreateUser_CoreOnly_MultipleUserTypes_ReturnsMissingCustomSchema(t *tes
 
 func TestCreateUser_CoreOnly_ZeroUserTypes_ReturnsMissingCustomSchema(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	payload := &SCIMUserPayload{
 		CoreAttrs: map[string]json.RawMessage{"userName": json.RawMessage(`"alice"`)},
 	}
 
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 	).Return(&entitytype.EntityTypeListResponse{TotalResults: 0, Types: []entitytype.EntityTypeListItem{}},
 		(*tidcommon.ServiceError)(nil))
@@ -661,8 +686,9 @@ func TestCreateUser_CoreOnly_ZeroUserTypes_ReturnsMissingCustomSchema(t *testing
 
 func TestCreateUser_EntityTypeNotFound_ReturnsUnknownUserType(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	payload := &SCIMUserPayload{
 		UserTypeName: "ghost",
@@ -670,7 +696,7 @@ func TestCreateUser_EntityTypeNotFound_ReturnsUnknownUserType(t *testing.T) {
 	}
 
 	// resolver finds no match — returns empty list
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 	).Return(&entitytype.EntityTypeListResponse{TotalResults: 0, Types: []entitytype.EntityTypeListItem{}},
 		(*tidcommon.ServiceError)(nil))
@@ -684,15 +710,16 @@ func TestCreateUser_EntityTypeNotFound_ReturnsUnknownUserType(t *testing.T) {
 
 func TestCreateUser_EntityTypeListError_ReturnsUnknownUserType(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	payload := &SCIMUserPayload{
 		UserTypeName: testUserTypeEmployee,
 		ExtensionURN: "urn:thunderid:params:scim:schemas:employee:2.0:User",
 	}
 
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 	).Return((*entitytype.EntityTypeListResponse)(nil), &tidcommon.ErrorUnauthorized)
 
@@ -705,19 +732,20 @@ func TestCreateUser_EntityTypeListError_ReturnsUnknownUserType(t *testing.T) {
 
 func TestCreateUser_GetEntityTypeByNameError_ReturnsUnknownUserType(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	payload := &SCIMUserPayload{
 		UserTypeName: testUserTypeEmployee,
 		ExtensionURN: "urn:thunderid:params:scim:schemas:employee:2.0:User",
 	}
 
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
 
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return((*entitytype.EntityType)(nil), &user.ErrorEntityTypeNotFound)
 
@@ -749,8 +777,9 @@ func TestCreateUser_Error_Scenarios(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockUserService := usermock.NewUserServiceInterfaceMock(t)
-			mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-			service := newSCIMUsersService(mockUserService, mockEntityService)
+			mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+			service := newSCIMUsersService(
+				mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 			payload := &SCIMUserPayload{
 				UserTypeName:   testUserTypeEmployee,
@@ -758,10 +787,10 @@ func TestCreateUser_Error_Scenarios(t *testing.T) {
 				ExtensionAttrs: map[string]json.RawMessage{},
 			}
 
-			mockEntityService.On(
+			mockUserTypeService.On(
 				"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 			).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
-			mockEntityService.On(
+			mockUserTypeService.On(
 				"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 			).Return(&entitytype.EntityType{Name: testUserTypeEmployee, OUID: testOUID}, (*tidcommon.ServiceError)(nil))
 			mockUserService.On("CreateUser", mock.Anything, mock.Anything).
@@ -780,8 +809,9 @@ func TestCreateUser_Error_Scenarios(t *testing.T) {
 
 func TestReplaceUser_Success(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	payload := &SCIMUserPayload{
 		UserTypeName:   testUserTypeEmployee,
@@ -795,10 +825,10 @@ func TestReplaceUser_Success(t *testing.T) {
 		Attributes: []byte(`{"given_name":"Charlie"}`),
 	}
 
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return(&entitytype.EntityType{Name: testUserTypeEmployee, OUID: testOUID}, (*tidcommon.ServiceError)(nil))
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).
@@ -806,11 +836,11 @@ func TestReplaceUser_Success(t *testing.T) {
 	mockUserService.On("UpdateUser", mock.Anything, "user-123", mock.MatchedBy(func(u *user.User) bool {
 		return u.ID == "user-123" && u.Type == testUserTypeEmployee
 	})).Return(updatedUser, (*tidcommon.ServiceError)(nil))
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetAttributes", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee, true, false, false,
 	).Return([]entitytype.AttributeInfo{}, (*tidcommon.ServiceError)(nil))
 
-	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL)
+	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL, false)
 
 	require.Nil(t, err)
 	require.NotNil(t, scimUser)
@@ -818,10 +848,55 @@ func TestReplaceUser_Success(t *testing.T) {
 	require.Contains(t, scimUser.Schemas, "urn:thunderid:params:scim:schemas:employee:2.0:User")
 }
 
+func TestReplaceUser_IsSelf_UsesUpdateUserAttributes(t *testing.T) {
+	mockUserService := usermock.NewUserServiceInterfaceMock(t)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
+
+	payload := &SCIMUserPayload{
+		UserTypeName:   testUserTypeEmployee,
+		ExtensionURN:   "urn:thunderid:params:scim:schemas:employee:2.0:User",
+		ExtensionAttrs: map[string]json.RawMessage{"given_name": json.RawMessage(`"Charlie"`)},
+	}
+	updatedUser := &user.User{
+		ID:         "user-123",
+		Type:       testUserTypeEmployee,
+		OUID:       testOUID,
+		Attributes: []byte(`{"given_name":"Charlie"}`),
+	}
+
+	mockUserTypeService.On(
+		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
+	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
+	mockUserTypeService.On(
+		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
+	).Return(&entitytype.EntityType{Name: testUserTypeEmployee, OUID: testOUID}, (*tidcommon.ServiceError)(nil))
+	mockUserService.On("GetUser", mock.Anything, "user-123", false).
+		Return(&user.User{ID: "user-123", Type: testUserTypeEmployee}, (*tidcommon.ServiceError)(nil))
+	// Self-service replace must go through UpdateUserAttributes, not UpdateUser:
+	// UpdateUser's OU/type validation requires system:usertype:view with no
+	// self-access bypass, which would 500 for a self-service caller.
+	mockUserService.On(
+		"UpdateUserAttributes", mock.Anything, "user-123", json.RawMessage(`{"given_name":"Charlie"}`),
+	).Return(updatedUser, (*tidcommon.ServiceError)(nil))
+	mockUserTypeService.On(
+		"GetAttributes", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee, true, false, false,
+	).Return([]entitytype.AttributeInfo{}, (*tidcommon.ServiceError)(nil))
+
+	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL, true)
+
+	require.Nil(t, err)
+	require.NotNil(t, scimUser)
+	require.Equal(t, "user-123", scimUser.ID)
+	mockUserService.AssertNotCalled(t, "UpdateUser", mock.Anything, mock.Anything, mock.Anything)
+}
+
 func TestReplaceUser_CoreOnly_NoExtensionURN_DefaultsToExistingType(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	// The user's type is immutable, so an omitted extension URN resolves to
 	// the existing user's type instead of requiring the client to echo it.
@@ -836,7 +911,7 @@ func TestReplaceUser_CoreOnly_NoExtensionURN_DefaultsToExistingType(t *testing.T
 		Attributes: []byte(`{}`),
 	}
 
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return(&entitytype.EntityType{Name: testUserTypeEmployee, OUID: testOUID}, (*tidcommon.ServiceError)(nil))
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).
@@ -844,11 +919,11 @@ func TestReplaceUser_CoreOnly_NoExtensionURN_DefaultsToExistingType(t *testing.T
 	mockUserService.On("UpdateUser", mock.Anything, "user-123", mock.MatchedBy(func(u *user.User) bool {
 		return u.ID == "user-123" && u.Type == testUserTypeEmployee
 	})).Return(updatedUser, (*tidcommon.ServiceError)(nil))
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetAttributes", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee, true, false, false,
 	).Return([]entitytype.AttributeInfo{}, (*tidcommon.ServiceError)(nil))
 
-	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL)
+	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL, false)
 
 	require.Nil(t, err)
 	require.NotNil(t, scimUser)
@@ -857,8 +932,9 @@ func TestReplaceUser_CoreOnly_NoExtensionURN_DefaultsToExistingType(t *testing.T
 
 func TestReplaceUser_MissingRequiredAttribute_ReturnsSchemaValidationError(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	payload := &SCIMUserPayload{
 		UserTypeName:   testUserTypeEmployee,
@@ -866,10 +942,10 @@ func TestReplaceUser_MissingRequiredAttribute_ReturnsSchemaValidationError(t *te
 		ExtensionAttrs: map[string]json.RawMessage{"given_name": json.RawMessage(`"Charlie"`)},
 	}
 
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return(&entitytype.EntityType{
 		Name: testUserTypeEmployee, OUID: testOUID,
@@ -878,7 +954,7 @@ func TestReplaceUser_MissingRequiredAttribute_ReturnsSchemaValidationError(t *te
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).
 		Return(&user.User{ID: "user-123", Type: testUserTypeEmployee}, (*tidcommon.ServiceError)(nil))
 
-	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL)
+	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL, false)
 
 	require.NotNil(t, err)
 	require.Equal(t, ErrorSchemaValidationFailed.Code, err.Code)
@@ -888,8 +964,9 @@ func TestReplaceUser_MissingRequiredAttribute_ReturnsSchemaValidationError(t *te
 
 func TestReplaceUser_UndeclaredAttribute_ReturnsSchemaValidationError(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	payload := &SCIMUserPayload{
 		UserTypeName: testUserTypeEmployee,
@@ -900,10 +977,10 @@ func TestReplaceUser_UndeclaredAttribute_ReturnsSchemaValidationError(t *testing
 		},
 	}
 
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return(&entitytype.EntityType{
 		Name: testUserTypeEmployee, OUID: testOUID,
@@ -912,7 +989,7 @@ func TestReplaceUser_UndeclaredAttribute_ReturnsSchemaValidationError(t *testing
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).
 		Return(&user.User{ID: "user-123", Type: testUserTypeEmployee}, (*tidcommon.ServiceError)(nil))
 
-	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL)
+	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL, false)
 
 	require.NotNil(t, err)
 	require.Equal(t, ErrorSchemaValidationFailed.Code, err.Code)
@@ -922,8 +999,9 @@ func TestReplaceUser_UndeclaredAttribute_ReturnsSchemaValidationError(t *testing
 
 func TestReplaceUser_ConflictingCoreAndCustomValue_ReturnsConflictError(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	payload := &SCIMUserPayload{
 		UserTypeName:   testUserTypeEmployee,
@@ -932,10 +1010,10 @@ func TestReplaceUser_ConflictingCoreAndCustomValue_ReturnsConflictError(t *testi
 		ExtensionAttrs: map[string]json.RawMessage{"username": json.RawMessage(`"bob"`)},
 	}
 
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return(&entitytype.EntityType{
 		Name: testUserTypeEmployee, OUID: testOUID,
@@ -944,7 +1022,7 @@ func TestReplaceUser_ConflictingCoreAndCustomValue_ReturnsConflictError(t *testi
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).
 		Return(&user.User{ID: "user-123", Type: testUserTypeEmployee}, (*tidcommon.ServiceError)(nil))
 
-	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL)
+	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL, false)
 
 	require.NotNil(t, err)
 	require.Equal(t, ErrorConflictingAttributeValue.Code, err.Code)
@@ -954,22 +1032,23 @@ func TestReplaceUser_ConflictingCoreAndCustomValue_ReturnsConflictError(t *testi
 
 func TestReplaceUser_EntityTypeNotFound_ReturnsUnknownUserType(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	payload := &SCIMUserPayload{
 		UserTypeName: "ghost",
 		ExtensionURN: "urn:thunderid:params:scim:schemas:ghost:2.0:User",
 	}
 
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 	).Return(&entitytype.EntityTypeListResponse{TotalResults: 0, Types: []entitytype.EntityTypeListItem{}},
 		(*tidcommon.ServiceError)(nil))
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).
 		Return(&user.User{ID: "user-123", Type: testUserTypeEmployee}, (*tidcommon.ServiceError)(nil))
 
-	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL)
+	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL, false)
 
 	require.NotNil(t, err)
 	require.Equal(t, ErrorUnknownUserType.Code, err.Code)
@@ -1006,8 +1085,9 @@ func TestReplaceUser_Error_Scenarios(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockUserService := usermock.NewUserServiceInterfaceMock(t)
-			mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-			service := newSCIMUsersService(mockUserService, mockEntityService)
+			mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+			service := newSCIMUsersService(
+				mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 			payload := &SCIMUserPayload{
 				UserTypeName:   testUserTypeEmployee,
@@ -1019,10 +1099,10 @@ func TestReplaceUser_Error_Scenarios(t *testing.T) {
 				mockUserService.On("GetUser", mock.Anything, tc.userID, false).
 					Return((*user.User)(nil), tc.mockError)
 			} else {
-				mockEntityService.On(
+				mockUserTypeService.On(
 					"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 				).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
-				mockEntityService.On(
+				mockUserTypeService.On(
 					"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 				).Return(&entitytype.EntityType{
 					Name: testUserTypeEmployee, OUID: testOUID,
@@ -1033,7 +1113,7 @@ func TestReplaceUser_Error_Scenarios(t *testing.T) {
 					Return((*user.User)(nil), tc.mockError)
 			}
 
-			scimUser, err := service.ReplaceUser(context.Background(), tc.userID, payload, "", testBaseURL)
+			scimUser, err := service.ReplaceUser(context.Background(), tc.userID, payload, "", testBaseURL, false)
 
 			require.NotNil(t, err)
 			require.Equal(t, tc.expectedError.Code, err.Code)
@@ -1044,8 +1124,9 @@ func TestReplaceUser_Error_Scenarios(t *testing.T) {
 
 func TestReplaceUser_IfMatch_Match(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	payload := &SCIMUserPayload{
 		UserTypeName:   testUserTypeEmployee,
@@ -1055,10 +1136,10 @@ func TestReplaceUser_IfMatch_Match(t *testing.T) {
 	existingUser := &user.User{ID: "user-123", Type: testUserTypeEmployee, Attributes: []byte(`{"given_name":"Bob"}`)}
 	currentVersion := generateVersion(userVersionState(*existingUser))
 
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return(&entitytype.EntityType{Name: testUserTypeEmployee, OUID: testOUID}, (*tidcommon.ServiceError)(nil))
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).
@@ -1066,11 +1147,11 @@ func TestReplaceUser_IfMatch_Match(t *testing.T) {
 	mockUserService.On("UpdateUser", mock.Anything, "user-123", mock.Anything).
 		Return(&user.User{ID: "user-123", Type: testUserTypeEmployee, Attributes: []byte(`{"given_name":"Charlie"}`)},
 			(*tidcommon.ServiceError)(nil))
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetAttributes", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee, true, false, false,
 	).Return([]entitytype.AttributeInfo{}, (*tidcommon.ServiceError)(nil))
 
-	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, currentVersion, testBaseURL)
+	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, currentVersion, testBaseURL, false)
 
 	require.Nil(t, err)
 	require.NotNil(t, scimUser)
@@ -1078,8 +1159,9 @@ func TestReplaceUser_IfMatch_Match(t *testing.T) {
 
 func TestReplaceUser_IfMatch_Mismatch(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	payload := &SCIMUserPayload{
 		UserTypeName:   testUserTypeEmployee,
@@ -1091,7 +1173,7 @@ func TestReplaceUser_IfMatch_Mismatch(t *testing.T) {
 		Return(&user.User{ID: "user-123", Type: testUserTypeEmployee, Attributes: []byte(`{"given_name":"Bob"}`)},
 			(*tidcommon.ServiceError)(nil))
 
-	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, `W/"stale"`, testBaseURL)
+	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, `W/"stale"`, testBaseURL, false)
 
 	require.Nil(t, scimUser)
 	require.Equal(t, ErrorPreconditionFailed.Code, err.Code)
@@ -1100,8 +1182,9 @@ func TestReplaceUser_IfMatch_Mismatch(t *testing.T) {
 
 func TestDeleteUser_IfMatch_Match(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	existingUser := &user.User{ID: "user-123", Type: testUserTypeEmployee, Attributes: []byte(`{"given_name":"Bob"}`)}
 	currentVersion := generateVersion(userVersionState(*existingUser))
@@ -1117,8 +1200,9 @@ func TestDeleteUser_IfMatch_Match(t *testing.T) {
 
 func TestDeleteUser_IfMatch_Mismatch(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).
 		Return(&user.User{ID: "user-123", Type: testUserTypeEmployee, Attributes: []byte(`{"given_name":"Bob"}`)},
@@ -1132,22 +1216,23 @@ func TestDeleteUser_IfMatch_Mismatch(t *testing.T) {
 
 func TestReplaceUser_TypeMismatch(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	payload := &SCIMUserPayload{
 		UserTypeName: testUserTypeEmployee,
 		ExtensionURN: "urn:thunderid:params:scim:schemas:employee:2.0:User",
 	}
 
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
 
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).
 		Return(&user.User{ID: "user-123", Type: "customer"}, (*tidcommon.ServiceError)(nil))
 
-	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL)
+	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL, false)
 
 	require.Nil(t, scimUser)
 	require.Equal(t, ErrorImmutableUserType.Code, err.Code)
@@ -1155,26 +1240,27 @@ func TestReplaceUser_TypeMismatch(t *testing.T) {
 
 func TestReplaceUser_GetEntityTypeByNameError(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	payload := &SCIMUserPayload{
 		UserTypeName: testUserTypeEmployee,
 		ExtensionURN: "urn:thunderid:params:scim:schemas:employee:2.0:User",
 	}
 
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
 
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).
 		Return(&user.User{ID: "user-123", Type: testUserTypeEmployee}, (*tidcommon.ServiceError)(nil))
 
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return((*entitytype.EntityType)(nil), &user.ErrorEntityTypeNotFound)
 
-	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL)
+	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL, false)
 
 	require.Nil(t, scimUser)
 	require.Equal(t, ErrorUnknownUserType.Code, err.Code)
@@ -1182,8 +1268,9 @@ func TestReplaceUser_GetEntityTypeByNameError(t *testing.T) {
 
 func TestDeleteUser_IfMatch_GetUserError(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).
 		Return((*user.User)(nil), &user.ErrorUserNotFound)
@@ -1195,8 +1282,9 @@ func TestDeleteUser_IfMatch_GetUserError(t *testing.T) {
 
 func TestCreateUser_MarshalExtensionAttrsError(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	payload := &SCIMUserPayload{
 		UserTypeName:   testUserTypeEmployee,
@@ -1204,11 +1292,11 @@ func TestCreateUser_MarshalExtensionAttrsError(t *testing.T) {
 		ExtensionAttrs: map[string]json.RawMessage{"empty": []byte("")},
 	}
 
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
 
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return(&entitytype.EntityType{Name: testUserTypeEmployee, OUID: testOUID}, (*tidcommon.ServiceError)(nil))
 
@@ -1220,8 +1308,9 @@ func TestCreateUser_MarshalExtensionAttrsError(t *testing.T) {
 
 func TestReplaceUser_MarshalExtensionAttrsError(t *testing.T) {
 	mockUserService := usermock.NewUserServiceInterfaceMock(t)
-	mockEntityService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
-	service := newSCIMUsersService(mockUserService, mockEntityService)
+	mockUserTypeService := entitytypemock.NewEntityTypeServiceInterfaceMock(t)
+	service := newSCIMUsersService(
+		mockUserService, mockUserTypeService, scimconfig.SCIMConfig{ReturnMappedCoreAttrsOnGet: true})
 
 	payload := &SCIMUserPayload{
 		UserTypeName:   testUserTypeEmployee,
@@ -1229,18 +1318,18 @@ func TestReplaceUser_MarshalExtensionAttrsError(t *testing.T) {
 		ExtensionAttrs: map[string]json.RawMessage{"empty": []byte("")},
 	}
 
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeList", mock.Anything, entitytype.TypeCategoryUser, 100, 0, false,
 	).Return(makeEntityTypeListPage(), (*tidcommon.ServiceError)(nil))
 
 	mockUserService.On("GetUser", mock.Anything, "user-123", false).
 		Return(&user.User{ID: "user-123", Type: testUserTypeEmployee}, (*tidcommon.ServiceError)(nil))
 
-	mockEntityService.On(
+	mockUserTypeService.On(
 		"GetEntityTypeByName", mock.Anything, entitytype.TypeCategoryUser, testUserTypeEmployee,
 	).Return(&entitytype.EntityType{Name: testUserTypeEmployee, OUID: testOUID}, (*tidcommon.ServiceError)(nil))
 
-	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL)
+	scimUser, err := service.ReplaceUser(context.Background(), "user-123", payload, "", testBaseURL, false)
 
 	require.Nil(t, scimUser)
 	require.Equal(t, ErrorInvalidRequestBody.Code, err.Code)

--- a/backend/internal/system/config/config.go
+++ b/backend/internal/system/config/config.go
@@ -390,6 +390,15 @@ type GroupConfig struct {
 	Store string `yaml:"store" json:"store"`
 }
 
+// SCIMConfig holds the SCIM service configuration.
+type SCIMConfig struct {
+	// ReturnMappedCoreAttrsOnGet controls whether GET responses (GetUser,
+	// ListUsers) include core schema fields (userName, emails, name, etc.)
+	// mapped from stored attributes, or only the custom extension schema.
+	// Pointer so an explicit `false` in deployment.yaml can override the default.
+	ReturnMappedCoreAttrsOnGet *bool `yaml:"core_attrs_on_get" json:"core_attrs_on_get"`
+}
+
 // RoleConfig holds the role service configuration.
 type RoleConfig struct {
 	// Store defines the storage mode for roles.
@@ -604,6 +613,7 @@ type Config struct {
 	Translation          TranslationConfig                `yaml:"translation"           json:"translation"`
 	Email                EmailConfig                      `yaml:"email"                 json:"email"`
 	Notification         NotificationConfig               `yaml:"notification"          json:"notification"`
+	SCIM                 SCIMConfig                       `yaml:"scim"                  json:"scim"`
 }
 
 // LoadConfig loads the configurations from the specified YAML file and applies defaults.

--- a/backend/tests/mocks/scim/SCIMUsersServiceInterface_mock.go
+++ b/backend/tests/mocks/scim/SCIMUsersServiceInterface_mock.go
@@ -343,8 +343,8 @@ func (_c *SCIMUsersServiceInterfaceMock_ListUsers_Call) RunAndReturn(run func(ct
 }
 
 // ReplaceUser provides a mock function for the type SCIMUsersServiceInterfaceMock
-func (_mock *SCIMUsersServiceInterfaceMock) ReplaceUser(ctx context.Context, userID string, payload *scim.SCIMUserPayload, ifMatch string, baseURL string) (*scim.SCIMUser, *common.ServiceError) {
-	ret := _mock.Called(ctx, userID, payload, ifMatch, baseURL)
+func (_mock *SCIMUsersServiceInterfaceMock) ReplaceUser(ctx context.Context, userID string, payload *scim.SCIMUserPayload, ifMatch string, baseURL string, isSelf bool) (*scim.SCIMUser, *common.ServiceError) {
+	ret := _mock.Called(ctx, userID, payload, ifMatch, baseURL, isSelf)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ReplaceUser")
@@ -352,18 +352,18 @@ func (_mock *SCIMUsersServiceInterfaceMock) ReplaceUser(ctx context.Context, use
 
 	var r0 *scim.SCIMUser
 	var r1 *common.ServiceError
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *scim.SCIMUserPayload, string, string) (*scim.SCIMUser, *common.ServiceError)); ok {
-		return returnFunc(ctx, userID, payload, ifMatch, baseURL)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *scim.SCIMUserPayload, string, string, bool) (*scim.SCIMUser, *common.ServiceError)); ok {
+		return returnFunc(ctx, userID, payload, ifMatch, baseURL, isSelf)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *scim.SCIMUserPayload, string, string) *scim.SCIMUser); ok {
-		r0 = returnFunc(ctx, userID, payload, ifMatch, baseURL)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *scim.SCIMUserPayload, string, string, bool) *scim.SCIMUser); ok {
+		r0 = returnFunc(ctx, userID, payload, ifMatch, baseURL, isSelf)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*scim.SCIMUser)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *scim.SCIMUserPayload, string, string) *common.ServiceError); ok {
-		r1 = returnFunc(ctx, userID, payload, ifMatch, baseURL)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *scim.SCIMUserPayload, string, string, bool) *common.ServiceError); ok {
+		r1 = returnFunc(ctx, userID, payload, ifMatch, baseURL, isSelf)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*common.ServiceError)
@@ -383,11 +383,12 @@ type SCIMUsersServiceInterfaceMock_ReplaceUser_Call struct {
 //   - payload *scim.SCIMUserPayload
 //   - ifMatch string
 //   - baseURL string
-func (_e *SCIMUsersServiceInterfaceMock_Expecter) ReplaceUser(ctx interface{}, userID interface{}, payload interface{}, ifMatch interface{}, baseURL interface{}) *SCIMUsersServiceInterfaceMock_ReplaceUser_Call {
-	return &SCIMUsersServiceInterfaceMock_ReplaceUser_Call{Call: _e.mock.On("ReplaceUser", ctx, userID, payload, ifMatch, baseURL)}
+//   - isSelf bool
+func (_e *SCIMUsersServiceInterfaceMock_Expecter) ReplaceUser(ctx interface{}, userID interface{}, payload interface{}, ifMatch interface{}, baseURL interface{}, isSelf interface{}) *SCIMUsersServiceInterfaceMock_ReplaceUser_Call {
+	return &SCIMUsersServiceInterfaceMock_ReplaceUser_Call{Call: _e.mock.On("ReplaceUser", ctx, userID, payload, ifMatch, baseURL, isSelf)}
 }
 
-func (_c *SCIMUsersServiceInterfaceMock_ReplaceUser_Call) Run(run func(ctx context.Context, userID string, payload *scim.SCIMUserPayload, ifMatch string, baseURL string)) *SCIMUsersServiceInterfaceMock_ReplaceUser_Call {
+func (_c *SCIMUsersServiceInterfaceMock_ReplaceUser_Call) Run(run func(ctx context.Context, userID string, payload *scim.SCIMUserPayload, ifMatch string, baseURL string, isSelf bool)) *SCIMUsersServiceInterfaceMock_ReplaceUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -409,12 +410,17 @@ func (_c *SCIMUsersServiceInterfaceMock_ReplaceUser_Call) Run(run func(ctx conte
 		if args[4] != nil {
 			arg4 = args[4].(string)
 		}
+		var arg5 bool
+		if args[5] != nil {
+			arg5 = args[5].(bool)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
 			arg4,
+			arg5,
 		)
 	})
 	return _c
@@ -425,7 +431,7 @@ func (_c *SCIMUsersServiceInterfaceMock_ReplaceUser_Call) Return(sCIMUser *scim.
 	return _c
 }
 
-func (_c *SCIMUsersServiceInterfaceMock_ReplaceUser_Call) RunAndReturn(run func(ctx context.Context, userID string, payload *scim.SCIMUserPayload, ifMatch string, baseURL string) (*scim.SCIMUser, *common.ServiceError)) *SCIMUsersServiceInterfaceMock_ReplaceUser_Call {
+func (_c *SCIMUsersServiceInterfaceMock_ReplaceUser_Call) RunAndReturn(run func(ctx context.Context, userID string, payload *scim.SCIMUserPayload, ifMatch string, baseURL string, isSelf bool) (*scim.SCIMUser, *common.ServiceError)) *SCIMUsersServiceInterfaceMock_ReplaceUser_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/tests/integration/scim/helpers.go
+++ b/tests/integration/scim/helpers.go
@@ -85,6 +85,20 @@ func scimRequestUnauthenticated(method, path string, headers map[string]string) 
 	return resp.StatusCode, respBody, nil
 }
 
+// extensionStringValue reads a string attribute out of a decoded SCIM user
+// response's extension object (the object keyed by the extension URN). This
+// is the raw, always-present attribute representation, distinct from the
+// mapped core fields (e.g. top-level "emails") which are only populated when
+// scim.core_attrs_on_get is enabled.
+func extensionStringValue(resp map[string]interface{}, extensionURN, attr string) (string, bool) {
+	ext, ok := resp[extensionURN].(map[string]interface{})
+	if !ok {
+		return "", false
+	}
+	v, ok := ext[attr].(string)
+	return v, ok
+}
+
 // discoverExtensionSchema finds the ThunderID SCIM extension schema for the
 // given entity type name via GET /Schemas — the same discovery step a real
 // SCIM client performs before provisioning into a given user type. Returns

--- a/tests/integration/scim/me_test.go
+++ b/tests/integration/scim/me_test.go
@@ -158,20 +158,12 @@ func (ts *SCIMMeTestSuite) TestGetMe() {
 	ts.Require().NoError(json.Unmarshal(body, &me))
 	ts.Equal(ts.selfUserID, me["id"], "/Me must resolve to the caller's own user, not any other resource")
 
-	email, ok := firstEmailValue(me)
-	ts.Require().True(ok)
+	email, ok := extensionStringValue(me, ts.extensionURN, "email")
+	ts.Require().True(ok, "GET /Me response should include the custom-schema email attribute")
 	ts.Equal(ts.email, email)
 }
 
-// TestReplaceMe is skipped: PUT /Me needs only authentication, but
-// scim.ReplaceUser calls internal/user.UpdateUser, whose
-// validateOrganizationUnitForUserType check requires system:usertype:view
-// with no self-access bypass (unlike checkUserAccess just above it) — so it
-// 500s for any self-service caller. Fix belongs in internal/user/service.go,
-// out of scope here.
 func (ts *SCIMMeTestSuite) TestReplaceMe() {
-	ts.T().Skip("known bug: PUT /Me 500s for self-service callers, see internal/user.UpdateUser")
-
 	status, body := ts.doMe(http.MethodPut, ts.buildMeBody("Scimmy"), nil)
 	ts.Require().Equal(http.StatusOK, status, "PUT /Me failed: %s", body)
 

--- a/tests/integration/scim/users_test.go
+++ b/tests/integration/scim/users_test.go
@@ -184,8 +184,8 @@ func (ts *SCIMUsersTestSuite) TestCreateAndGetUser() {
 	var fetched map[string]interface{}
 	ts.Require().NoError(json.Unmarshal(body, &fetched))
 	ts.Equal(id, fetched["id"])
-	gotEmail, ok = firstEmailValue(fetched)
-	ts.Require().True(ok)
+	gotEmail, ok = extensionStringValue(fetched, ts.extensionURN, "email")
+	ts.Require().True(ok, "GET response should include the custom-schema email attribute")
 	ts.Equal(email, gotEmail)
 }
 


### PR DESCRIPTION
### Purpose
`PUT /scim/v2/Me` 500s for any self-service caller. `scim.ReplaceUser` routed through `internal/user.UpdateUser` (the admin full-replace path), whose `validateOrganizationUnitForUserType` check requires `system:usertype:view` with no self-access bypass — unlike the `checkUserAccess` check right above it. A self-service caller without that permission gets `ErrorUnauthorized` back, which `validateOrganizationUnitForUserType` then swallows into a generic `InternalServerError` instead of propagating it, so the caller sees a 500 instead of a working update (or a proper 403).

### Approach
Fixed entirely in the SCIM layer, no changes to `internal/user` or `internal/entitytype`:

- Added `isSelf bool` to `SCIMUsersServiceInterface.ReplaceUser`.
- When `isSelf` is true (self-service `/Me` calls), `ReplaceUser` skips `user.UpdateUser` and calls `user.UpdateUserAttributes` instead — the same attribute-only update path native `PUT /users/me` already uses. Type and OU are already pinned to the caller's existing values earlier in `ReplaceUser` (the immutable-type check), so nothing is lost by skipping `UpdateUser`'s OU/type validation for self.
- `HandleUsersReplaceRequest` (admin `PUT /Users/{id}`) passes `false`; `HandleMeReplaceRequest` (`PUT /Me`) passes `true`.
- Regenerated mocks via mockery.
- Un-skipped `TestReplaceMe` in `tests/integration/scim/me_test.go`, which had this exact bug documented as a known skip.

Also included in this PR :

- **Rename entity-type naming to user-type terminology** across the SCIM package's own local abstractions — struct fields (`entityTypeService` → `userTypeService`), functions (`resolveEntityTypeNameForSchemaURN` → `resolveUserTypeNameForSchemaURN`, `resolveDefaultEntityTypeName` → `resolveDefaultUserTypeName`, `listUserEntityTypeNames` → `listUserTypeNames`, `mapEntityTypeToSCIMSchema` → `mapUserTypeToSCIMSchema`), comments, and log messages. The actual `entitytype` package API (`GetEntityTypeByName`, `GetEntityTypeList`, `entitytype.EntityType`) is untouched — that's the real external agent/application entity concept, distinct from a SCIM user's type.
- **Rename `canonicalName` → `resolvedUserTypeName`** (and the colliding inner variable to `requestedUserTypeName` in `ReplaceUser`) for clarity on what the value represents.
- **Make `ReturnMappedCoreAttrsOnGet` deployment-configurable.** Previously a hardcoded Go `var`; now sourced from `scim.core_attrs_on_get` in the server config YAML/JSON (`internal/system/config.SCIMConfig`, defaulted to `true` in `default.json` to preserve current behavior).

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.