### PR TITLE
Resolve inbound auth profile handles in agent update process

### DIFF
--- a/backend/internal/agent/service.go
+++ b/backend/internal/agent/service.go
@@ -944,7 +944,25 @@ func (s *agentService) reconcileInboundForUpdate(ctx context.Context, agentID st
 		return inboundmodel.InboundClient{}, nil, nil
 	}
 
-	client := buildInboundClientRecord(agentID, req.AuthFlowID, req.RegistrationFlowID,
+	// Resolve flow handles to IDs when the direct IDs are absent, same as ValidateAgent does for
+	// create - a declarative update (e.g. a re-import) that only sets authFlowHandle must not wipe
+	// out the previously-resolved AuthFlowID.
+	profile := providers.InboundAuthProfile{
+		AuthFlowID:             req.AuthFlowID,
+		AuthFlowHandle:         req.AuthFlowHandle,
+		RegistrationFlowID:     req.RegistrationFlowID,
+		RegistrationFlowHandle: req.RegistrationFlowHandle,
+	}
+	if err := s.inboundClientService.ResolveInboundAuthProfileHandles(ctx, &profile); err != nil {
+		if svcErr := translateInboundClientFKError(err); svcErr != nil {
+			return inboundmodel.InboundClient{}, nil, svcErr
+		}
+		s.logger.Error(ctx, "Failed to resolve inbound auth profile handles",
+			log.Error(err), log.String("agentID", agentID))
+		return inboundmodel.InboundClient{}, nil, &tidcommon.InternalServerError
+	}
+
+	client := buildInboundClientRecord(agentID, profile.AuthFlowID, profile.RegistrationFlowID,
 		req.IsRegistrationFlowEnabled, req.ThemeID, req.LayoutID, req.Assertion,
 		req.LoginConsent, req.AllowedUserTypes, nil)
 	setLogoProperty(&client, req.LogoURL)
@@ -1159,7 +1177,9 @@ func updateNeedsInboundClient(req *model.UpdateAgentRequest) bool {
 		return false
 	}
 	return req.AuthFlowID != "" ||
+		req.AuthFlowHandle != "" ||
 		req.RegistrationFlowID != "" ||
+		req.RegistrationFlowHandle != "" ||
 		req.IsRegistrationFlowEnabled ||
 		req.ThemeID != "" ||
 		req.LayoutID != "" ||

--- a/backend/internal/agent/service_test.go
+++ b/backend/internal/agent/service_test.go
@@ -1207,6 +1207,88 @@ func (suite *AgentServiceTestSuite) TestUpdateAgent_FlowIDResolvedToDefault() {
 	assert.Equal(suite.T(), "default-reg-flow-id", resp.RegistrationFlowID)
 }
 
+func (suite *AgentServiceTestSuite) TestUpdateAgent_ResolvesAuthFlowHandle() {
+	svc, mockEntity, mockInbound, _, _ := suite.setupService()
+
+	agentEntity := buildAgentEntityFixture("old-name", "", "", "")
+	clearMockCalls(mockEntity, "GetEntity")
+	mockEntity.On("GetEntity", mock.Anything, testAgentID).Return(agentEntity, nil)
+
+	clearMockCalls(mockEntity, "UpdateEntity")
+	mockEntity.On("UpdateEntity", mock.Anything, testAgentID, mock.Anything).
+		Return(&providers.Entity{}, nil)
+
+	clearMockCalls(mockInbound, "GetInboundClientByEntityID")
+	mockInbound.On("GetInboundClientByEntityID", mock.Anything, mock.Anything).
+		Return(&inboundmodel.InboundClient{}, nil)
+
+	clearMockCalls(mockInbound, "ResolveInboundAuthProfileHandles")
+	mockInbound.On("ResolveInboundAuthProfileHandles", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			profile := args.Get(1).(*providers.InboundAuthProfile)
+			assert.Equal(suite.T(), "wayfinder-agent-auth-flow", profile.AuthFlowHandle)
+			profile.AuthFlowID = "resolved-auth-flow-id"
+		}).Return(nil)
+
+	var capturedAuthFlowID string
+	clearMockCalls(mockInbound, "UpdateInboundClient")
+	mockInbound.On("UpdateInboundClient",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			client := args.Get(1).(*inboundmodel.InboundClient)
+			capturedAuthFlowID = client.AuthFlowID
+		}).Return(nil)
+
+	resp, svcErr := svc.UpdateAgent(context.Background(), testAgentID, &model.UpdateAgentRequest{
+		Name: testAgentName,
+		Type: testAgentType,
+		InboundAuthProfileReq: inboundmodel.InboundAuthProfileReq{
+			AuthFlowHandle: "wayfinder-agent-auth-flow",
+		},
+	})
+	suite.Require().Nil(svcErr)
+	suite.Require().NotNil(resp)
+	assert.Equal(suite.T(), "resolved-auth-flow-id", capturedAuthFlowID)
+	assert.Equal(suite.T(), "resolved-auth-flow-id", resp.AuthFlowID)
+	mockInbound.AssertNotCalled(suite.T(), "DeleteInboundClient", mock.Anything, mock.Anything)
+}
+
+func (suite *AgentServiceTestSuite) TestUpdateAgent_ResolveHandlesFails_NonFKError() {
+	svc, mockEntity, mockInbound, _, _ := suite.setupService()
+
+	agentEntity := buildAgentEntityFixture("old-name", "", "", "")
+	clearMockCalls(mockEntity, "GetEntity")
+	mockEntity.On("GetEntity", mock.Anything, testAgentID).Return(agentEntity, nil)
+
+	clearMockCalls(mockInbound, "GetInboundClientByEntityID")
+	mockInbound.On("GetInboundClientByEntityID", mock.Anything, mock.Anything).
+		Return(&inboundmodel.InboundClient{}, nil)
+
+	clearMockCalls(mockInbound, "ResolveInboundAuthProfileHandles")
+	mockInbound.On("ResolveInboundAuthProfileHandles", mock.Anything, mock.Anything).
+		Return(errors.New("resolve boom"))
+
+	resp, svcErr := svc.UpdateAgent(context.Background(), testAgentID, &model.UpdateAgentRequest{
+		Name: testAgentName,
+		Type: testAgentType,
+		InboundAuthProfileReq: inboundmodel.InboundAuthProfileReq{
+			AuthFlowHandle: "wayfinder-agent-auth-flow",
+		},
+		InboundAuthConfig: []providers.InboundAuthConfigWithSecret{
+			{
+				Type: providers.OAuthInboundAuthType,
+				OAuthConfig: &providers.OAuthConfigWithSecret{
+					GrantTypes:              []providers.GrantType{providers.GrantTypeClientCredentials},
+					TokenEndpointAuthMethod: providers.TokenEndpointAuthMethodClientSecretBasic,
+				},
+			},
+		},
+	})
+	suite.Require().Nil(resp)
+	suite.Require().NotNil(svcErr)
+	assert.Equal(suite.T(), tidcommon.InternalServerError.Code, svcErr.Code)
+}
+
 // --- owner validation ---
 
 func (suite *AgentServiceTestSuite) TestValidateOwnerExists_Empty() {

--- a/docs/content/community/contributing/documentation-guide/writing-guide.mdx
+++ b/docs/content/community/contributing/documentation-guide/writing-guide.mdx
@@ -53,7 +53,7 @@ See the Docusaurus [Mermaid guide](https://docusaurus.io/docs/markdown-features/
 - Reach for a component when the diagram needs icon cards, grouped panels, or a custom layout, which Mermaid cannot draw.
 - Build it in <RepoLink path="/blob/main/docs/src/components">`docs/src/components/`</RepoLink>, such as `SolutionArchitectureDiagram`, and use it in MDX.
 
-See [Advanced Topics](./advanced-topics) to create and register a component.
+See [Advanced Topics](./advanced-topics.mdx) to create and register a component.
 
 ## Components
 

--- a/docs/content/guides/declarative-configurations/import-resources.mdx
+++ b/docs/content/guides/declarative-configurations/import-resources.mdx
@@ -133,9 +133,13 @@ The following handle fields are supported:
 | Application | `authFlowHandle` | `authFlowId` |
 | Application | `registrationFlowHandle` | `registrationFlowId` |
 | Application | `recoveryFlowHandle` | `recoveryFlowId` |
+| Agent | `authFlowHandle` | `authFlowId` |
+| Agent | `registrationFlowHandle` | `registrationFlowId` |
 | User type | `ouHandle` | `ouId` |
 
 If you provide both a handle field and the corresponding ID field, the ID takes precedence and the handle is ignored.
+
+Updating an existing application or agent with a document that sets only a handle field re-resolves it and keeps the resolved ID.
 
 If a handle cannot be resolved (because the target resource does not exist or the required adapter is not configured), the import item fails with a descriptive error message. When `continueOnError` is `true`, the importer continues processing the remaining documents.
 

--- a/docs/versioned_docs/version-v1.0.x/community/contributing/documentation-guide/writing-guide.mdx
+++ b/docs/versioned_docs/version-v1.0.x/community/contributing/documentation-guide/writing-guide.mdx
@@ -53,7 +53,7 @@ See the Docusaurus [Mermaid guide](https://docusaurus.io/docs/markdown-features/
 - Reach for a component when the diagram needs icon cards, grouped panels, or a custom layout, which Mermaid cannot draw.
 - Build it in <RepoLink path="/blob/main/docs/src/components">`docs/src/components/`</RepoLink>, such as `SolutionArchitectureDiagram`, and use it in MDX.
 
-See [Advanced Topics](./advanced-topics) to create and register a component.
+See [Advanced Topics](./advanced-topics.mdx) to create and register a component.
 
 ## Components
 

--- a/tests/integration/agent/agent_api_test.go
+++ b/tests/integration/agent/agent_api_test.go
@@ -19,6 +19,10 @@ import (
 const (
 	testServerURL = "https://localhost:8095"
 	agentBasePath = "/agents"
+
+	// Handles of the two isolated auth flows used by the flow-handle resolution tests.
+	handleAuthFlowHandle1 = "agent-api-handle-flow-1"
+	handleAuthFlowHandle2 = "agent-api-handle-flow-2"
 )
 
 var (
@@ -76,6 +80,10 @@ var (
 	testOUID          string
 	defaultAuthFlowID string
 
+	// IDs of the isolated auth flows referenced by handle in the resolution tests.
+	handleAuthFlowID1 string
+	handleAuthFlowID2 string
+
 	// IDs set during SetupSuite for the primary agent used across multiple tests.
 	createdAgentID   string
 	createdAgentName string
@@ -112,6 +120,11 @@ func (ts *AgentAPITestSuite) SetupSuite() {
 	defaultAuthFlowID, err = testutils.GetFlowIDByHandle("default-flow", "AUTHENTICATION")
 	ts.Require().NoError(err, "Failed to get default auth flow ID")
 
+	handleAuthFlowID1, err = testutils.CreateIsolatedAuthFlow(handleAuthFlowHandle1)
+	ts.Require().NoError(err, "Failed to create the first isolated auth flow")
+	handleAuthFlowID2, err = testutils.CreateIsolatedAuthFlow(handleAuthFlowHandle2)
+	ts.Require().NoError(err, "Failed to create the second isolated auth flow")
+
 	// Create the primary agent used by list/get/update/groups tests.
 	primaryAgent := entityOnlyAgent
 	primaryAgent.OUID = testOUID
@@ -126,6 +139,14 @@ func (ts *AgentAPITestSuite) TearDownSuite() {
 	if createdAgentID != "" {
 		if err := deleteAgent(createdAgentID); err != nil {
 			ts.T().Logf("Failed to delete primary agent during teardown: %v", err)
+		}
+	}
+	for _, flowID := range []string{handleAuthFlowID1, handleAuthFlowID2} {
+		if flowID == "" {
+			continue
+		}
+		if err := testutils.DeleteFlow(flowID); err != nil {
+			ts.T().Logf("Failed to delete isolated auth flow %s during teardown: %v", flowID, err)
 		}
 	}
 	// Restore the shared agent type before deleting the OU it points at, or the singleton is left
@@ -643,6 +664,140 @@ func (ts *AgentAPITestSuite) TestUpdateAgent_RemoveInboundProfile() {
 		"AuthFlowID must be cleared after removing inbound profile")
 }
 
+// --- flow handle resolution on update ---
+//
+// Handles are input-only: the API resolves them to IDs and returns only the resolved ID, so these
+// tests send raw request bodies and assert on the ID fields of the response.
+
+// TestUpdateAgent_AuthFlowHandleOnly_ResolvesToFlowID covers an update whose only inbound field is
+// authFlowHandle. The handle must resolve and the inbound client must survive, rather than the
+// request being read as "no inbound fields supplied" and the client being dropped.
+func (ts *AgentAPITestSuite) TestUpdateAgent_AuthFlowHandleOnly_ResolvesToFlowID() {
+	agentID, err := createAgent(Agent{
+		OUID:       testOUID,
+		Type:       "default",
+		Name:       "handle-only-agent",
+		AuthFlowID: handleAuthFlowID1,
+	})
+	ts.Require().NoError(err)
+	defer func() { _ = deleteAgent(agentID) }()
+
+	resp, err := putAgentRaw(agentID, map[string]interface{}{
+		"ouId":           testOUID,
+		"type":           "default",
+		"name":           "handle-only-agent",
+		"authFlowHandle": handleAuthFlowHandle1,
+	})
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusOK, resp.StatusCode, readBody(resp))
+
+	var updated Agent
+	ts.Require().NoError(json.NewDecoder(resp.Body).Decode(&updated))
+	ts.Assert().Equal(handleAuthFlowID1, updated.AuthFlowID,
+		"authFlowHandle must resolve to its flow ID on update")
+
+	// Confirm the resolved binding was persisted, not just echoed in the response.
+	getResp, err := doGet(testServerURL + agentBasePath + "/" + agentID)
+	ts.Require().NoError(err)
+	defer getResp.Body.Close()
+	ts.Require().Equal(http.StatusOK, getResp.StatusCode, readBody(getResp))
+
+	var fetched Agent
+	ts.Require().NoError(json.NewDecoder(getResp.Body).Decode(&fetched))
+	ts.Assert().Equal(handleAuthFlowID1, fetched.AuthFlowID,
+		"the resolved auth flow ID must be persisted")
+}
+
+// TestUpdateAgent_AuthFlowHandleRepointed_SwitchesFlow covers a handle that resolves to a flow
+// other than the one currently bound: the agent must move to the new flow.
+func (ts *AgentAPITestSuite) TestUpdateAgent_AuthFlowHandleRepointed_SwitchesFlow() {
+	agentID, err := createAgent(Agent{
+		OUID:       testOUID,
+		Type:       "default",
+		Name:       "handle-repoint-agent",
+		AuthFlowID: handleAuthFlowID1,
+	})
+	ts.Require().NoError(err)
+	defer func() { _ = deleteAgent(agentID) }()
+
+	resp, err := putAgentRaw(agentID, map[string]interface{}{
+		"ouId":           testOUID,
+		"type":           "default",
+		"name":           "handle-repoint-agent",
+		"authFlowHandle": handleAuthFlowHandle2,
+	})
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusOK, resp.StatusCode, readBody(resp))
+
+	var updated Agent
+	ts.Require().NoError(json.NewDecoder(resp.Body).Decode(&updated))
+	ts.Assert().Equal(handleAuthFlowID2, updated.AuthFlowID,
+		"a handle pointing at a different flow must switch the binding")
+}
+
+// TestUpdateAgent_UnresolvableAuthFlowHandle_PreservesExistingFlow covers a handle that resolves to
+// nothing: the update must be rejected and the previously bound flow left untouched.
+func (ts *AgentAPITestSuite) TestUpdateAgent_UnresolvableAuthFlowHandle_PreservesExistingFlow() {
+	agentID, err := createAgent(Agent{
+		OUID:       testOUID,
+		Type:       "default",
+		Name:       "handle-unresolvable-agent",
+		AuthFlowID: handleAuthFlowID1,
+	})
+	ts.Require().NoError(err)
+	defer func() { _ = deleteAgent(agentID) }()
+
+	resp, err := putAgentRaw(agentID, map[string]interface{}{
+		"ouId":           testOUID,
+		"type":           "default",
+		"name":           "handle-unresolvable-agent",
+		"authFlowHandle": "agent-api-nonexistent-flow-handle",
+	})
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusBadRequest, resp.StatusCode, readBody(resp))
+
+	getResp, err := doGet(testServerURL + agentBasePath + "/" + agentID)
+	ts.Require().NoError(err)
+	defer getResp.Body.Close()
+	ts.Require().Equal(http.StatusOK, getResp.StatusCode, readBody(getResp))
+
+	var fetched Agent
+	ts.Require().NoError(json.NewDecoder(getResp.Body).Decode(&fetched))
+	ts.Assert().Equal(handleAuthFlowID1, fetched.AuthFlowID,
+		"a rejected update must leave the existing auth flow binding intact")
+}
+
+// TestUpdateAgent_AuthFlowIDTakesPrecedenceOverHandle covers a request carrying both fields: the
+// explicit ID wins and the handle is ignored.
+func (ts *AgentAPITestSuite) TestUpdateAgent_AuthFlowIDTakesPrecedenceOverHandle() {
+	agentID, err := createAgent(Agent{
+		OUID: testOUID,
+		Type: "default",
+		Name: "handle-precedence-agent",
+	})
+	ts.Require().NoError(err)
+	defer func() { _ = deleteAgent(agentID) }()
+
+	resp, err := putAgentRaw(agentID, map[string]interface{}{
+		"ouId":           testOUID,
+		"type":           "default",
+		"name":           "handle-precedence-agent",
+		"authFlowId":     handleAuthFlowID1,
+		"authFlowHandle": handleAuthFlowHandle2,
+	})
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusOK, resp.StatusCode, readBody(resp))
+
+	var updated Agent
+	ts.Require().NoError(json.NewDecoder(resp.Body).Decode(&updated))
+	ts.Assert().Equal(handleAuthFlowID1, updated.AuthFlowID,
+		"authFlowId must win when both the ID and the handle are supplied")
+}
+
 // --- helpers ---
 
 func createAgent(agent Agent) (string, error) {
@@ -686,6 +841,22 @@ func deleteAgent(agentID string) error {
 		return fmt.Errorf("expected status 204, got %d. Response: %s", resp.StatusCode, string(body))
 	}
 	return nil
+}
+
+// putAgentRaw sends an update with an arbitrary body, so tests can supply the handle fields that
+// the ID-only Agent struct deliberately omits.
+func putAgentRaw(agentID string, body map[string]interface{}) (*http.Response, error) {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	client := testutils.GetHTTPClient()
+	req, err := http.NewRequest("PUT", testServerURL+agentBasePath+"/"+agentID, bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return client.Do(req)
 }
 
 func doGet(url string) (*http.Response, error) {

--- a/tests/integration/agent/agent_import_export_test.go
+++ b/tests/integration/agent/agent_import_export_test.go
@@ -76,6 +76,10 @@ type AgentImportExportSuite struct {
 	handleSuffix       string
 	authFlowID         string
 	registrationFlowID string
+
+	// An isolated auth flow referenced by handle, for the handle-only upsert test.
+	handleAuthFlowID     string
+	handleAuthFlowHandle string
 }
 
 func TestAgentImportExportSuite(t *testing.T) {
@@ -116,9 +120,19 @@ func (s *AgentImportExportSuite) SetupSuite() {
 	regFlowID, err := testutils.GetFlowIDByHandle("default-flow", "REGISTRATION")
 	s.Require().NoError(err, "failed to get default registration flow ID")
 	s.registrationFlowID = regFlowID
+
+	s.handleAuthFlowHandle = "agent-ie-handle-flow-" + s.handleSuffix
+	handleFlowID, err := testutils.CreateIsolatedAuthFlow(s.handleAuthFlowHandle)
+	s.Require().NoError(err, "failed to create the isolated auth flow referenced by handle")
+	s.handleAuthFlowID = handleFlowID
 }
 
 func (s *AgentImportExportSuite) TearDownSuite() {
+	if s.handleAuthFlowID != "" {
+		if err := testutils.DeleteFlow(s.handleAuthFlowID); err != nil {
+			s.T().Logf("teardown: failed to delete the isolated auth flow: %v", err)
+		}
+	}
 	// Restore the shared agent type before deleting the OU it points at, or the singleton is left
 	// referencing a deleted OU and a later suite's restore fails.
 	if s.agentTypeSnapshot != nil {
@@ -291,6 +305,42 @@ func (s *AgentImportExportSuite) TestImportAgent_UpsertUpdates() {
 	s.Require().Equal(1, importResp.Summary.Imported, "import results: %+v", importResp.Results)
 	s.Assert().Equal("update", importResp.Results[0].Operation)
 	s.Assert().Equal("success", importResp.Results[0].Status)
+}
+
+// TestImportAgent_UpsertWithAuthFlowHandleOnly covers the declarative re-import case: a document
+// that binds its auth flow by handle and carries no inboundAuthConfig. The handle must resolve on
+// the update path so the agent keeps its inbound client, instead of the document being read as
+// carrying no inbound fields at all. The agent starts on a different flow, so the assertion proves
+// the handle was resolved rather than the previous binding merely being left in place.
+func (s *AgentImportExportSuite) TestImportAgent_UpsertWithAuthFlowHandleOnly() {
+	agentName := "Agent Handle Only " + s.handleSuffix
+
+	createdID, err := s.createAgent(Agent{
+		OUID:       s.ouID,
+		Type:       "default",
+		Name:       agentName,
+		AuthFlowID: s.authFlowID,
+	})
+	s.Require().NoError(err)
+	defer func() { _ = s.deleteAgent(createdID) }()
+
+	yamlContent := fmt.Sprintf(
+		"resource_type: agent\nid: %s\nouId: %s\ntype: default\nname: %s\nauthFlowHandle: %s\n",
+		createdID, s.ouID, agentName, s.handleAuthFlowHandle)
+
+	importResp, err := s.importAgents(agentImportRequest{
+		Content: yamlContent,
+		Options: agentImportOptions{Upsert: true, ContinueOnError: false, Target: "runtime"},
+	})
+	s.Require().NoError(err)
+	s.Require().Equal(1, importResp.Summary.Imported, "import results: %+v", importResp.Results)
+	s.Require().Equal("update", importResp.Results[0].Operation)
+	s.Require().Equal("success", importResp.Results[0].Status)
+
+	updated, err := s.agentGet(createdID)
+	s.Require().NoError(err)
+	s.Assert().Equal(s.handleAuthFlowID, updated.AuthFlowID,
+		"authFlowHandle must resolve to its own flow ID on a handle-only upsert")
 }
 
 // TestExportImportRoundTrip_AgentWithAllFields creates an agent with every exportable


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

Agent update requests that only supply `authFlowHandle` (e.g. a declarative re-import) were not resolved to an `AuthFlowID` before building the inbound client record, unlike agent creation which resolves handles via `ValidateAgent`. This caused the previously-resolved `AuthFlowID` (and `RegistrationFlowID`) to be silently wiped out on update whenever only the handle was set.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

`reconcileInboundForUpdate` now builds an `InboundAuthProfile` from the request and calls `ResolveInboundAuthProfileHandles` before constructing the inbound client record, mirroring the resolution already done for creates. FK resolution errors are translated via `translateInboundClientFKError`; any other error is logged and surfaced as an internal server error. Added unit tests covering successful handle resolution and the non-FK error path.

### Related Issues
- Fixes #5056 

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Agent updates now correctly associate inbound authentication and registration flows using configured handles.
  * Improved error handling for unresolved or unexpected flow-resolution failures.
  * Explicit flow IDs take precedence, while handle-only updates preserve existing associations when needed.

* **Documentation**
  * Documented authentication and registration flow handles for agent configurations.

* **Tests**
  * Added coverage for agent updates, imports, flow switching, precedence, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->