### PR TITLE
Set the actor claim on CIBA-issued access tokens

### DIFF
--- a/api/application.yaml
+++ b/api/application.yaml
@@ -1576,8 +1576,9 @@ components:
         includeActClaim:
           type: boolean
           description: >-
-            When true, access tokens issued through this client's authorization_code flow include
-            an implicit on-behalf-of `act` claim identifying the application.
+            When true, access tokens this client obtains for a user through the authorization_code
+            or CIBA grant include an implicit on-behalf-of `act` claim identifying the application.
+            Agent clients always include the claim, regardless of this setting.
           example: false
           default: false
         scopes:
@@ -1689,8 +1690,9 @@ components:
         includeActClaim:
           type: boolean
           description: >-
-            When true, access tokens issued through this client's authorization_code flow include
-            an implicit on-behalf-of `act` claim identifying the application.
+            When true, access tokens this client obtains for a user through the authorization_code
+            or CIBA grant include an implicit on-behalf-of `act` claim identifying the application.
+            Agent clients always include the claim, regardless of this setting.
           example: false
           default: false
         scopes:

--- a/api/oauth2.yaml
+++ b/api/oauth2.yaml
@@ -206,9 +206,17 @@ paths:
       description: |
         Issues access tokens, refresh tokens, and ID tokens. Supports the following grant types:
         `authorization_code`, `client_credentials`, `refresh_token`, `password`,
+        `urn:openid:params:grant-type:ciba` (CIBA Core 1.0),
         `urn:ietf:params:oauth:grant-type:token-exchange` (RFC 8693), and
         `urn:ietf:params:oauth:grant-type:jwt-bearer` (draft-ietf-oauth-identity-assertion-authz-grant).
         Requires client authentication via HTTP Basic auth or `client_id`/`client_secret` form parameters.
+
+        An access token issued for a user through the `authorization_code` or
+        `urn:openid:params:grant-type:ciba` grant keeps that user in `sub` and adds an on-behalf-of
+        `act` claim naming the client that obtained it. Agent clients always receive the claim;
+        application clients receive it when `includeActClaim` is enabled on the client. The `act.sub`
+        value is the agent or application resource id rather than the client id, and the claim is
+        present on the access token only, never on the ID token.
 
         Token exchange additionally supports requesting an Identity Assertion Authorization Grant
         (ID-JAG) by setting `requested_token_type` to

--- a/backend/internal/oauth/oauth2/granthandlers/ciba.go
+++ b/backend/internal/oauth/oauth2/granthandlers/ciba.go
@@ -221,7 +221,7 @@ func (h *cibaGrantHandler) issueTokens(ctx context.Context, record *ciba.CIBAAut
 	}
 
 	userSubConfig := oauthApp.UserAccessTokenConfig()
-	accessToken, err := h.tokenBuilder.BuildAccessToken(ctx, &tokenservice.AccessTokenBuildContext{
+	accessTokenCtx := &tokenservice.AccessTokenBuildContext{
 		Subject:           record.UserID,
 		Audiences:         accessTokenAudiences,
 		ClientID:          oauthApp.ClientID,
@@ -232,7 +232,11 @@ func (h *cibaGrantHandler) issueTokens(ctx context.Context, record *ciba.CIBAAut
 		OAuthApp:          oauthApp,
 		ValidityPeriod:    userSubConfig.ValidityPeriodOrZero(),
 		DPoPJkt:           dpop.GetJkt(ctx),
-	})
+	}
+	if oauthApp.ShouldAppendActorClaim() {
+		accessTokenCtx.ActorClaims = &tokenservice.SubjectTokenClaims{Sub: oauthApp.ID}
+	}
+	accessToken, err := h.tokenBuilder.BuildAccessToken(ctx, accessTokenCtx)
 	if err != nil {
 		h.logger.Error(ctx, "Failed to generate access token", log.Error(err))
 		return nil, &model.ErrorResponse{

--- a/backend/internal/oauth/oauth2/granthandlers/ciba_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/ciba_test.go
@@ -328,6 +328,62 @@ func (suite *CIBAGrantHandlerTestSuite) TestHandleGrant_Authenticated_UsesConfig
 	suite.Equal("access-token", resp.AccessToken.Token)
 }
 
+// The act claim follows the authenticated client, not the grant: an agent polling the CIBA token
+// endpoint always gets an OBO actor claim naming itself, while an application gets one only when it
+// opts in through includeActClaim.
+func (suite *CIBAGrantHandlerTestSuite) TestHandleGrant_Authenticated_ActorClaim() {
+	const actAppID = "act-entity-id"
+	testCases := []struct {
+		name            string
+		entityCategory  providers.EntityCategory
+		includeActClaim bool
+		expectActor     bool
+	}{
+		{name: "AgentClientAlwaysAppendsActor", entityCategory: providers.EntityCategoryAgent,
+			includeActClaim: false, expectActor: true},
+		{name: "AppClientWithoutFlagOmitsActor", entityCategory: providers.EntityCategoryApp,
+			includeActClaim: false, expectActor: false},
+		{name: "AppClientWithFlagAppendsActor", entityCategory: providers.EntityCategoryApp,
+			includeActClaim: true, expectActor: true},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			suite.SetupTest()
+			suite.oauthApp.ID = actAppID
+			suite.oauthApp.EntityCategory = tc.entityCategory
+			suite.oauthApp.IncludeActClaim = tc.includeActClaim
+
+			record := suite.pendingRecord()
+			record.State = ciba.CIBAStateAuthenticated
+			record.AuthorizedScopes = constants.ScopeOpenID
+			suite.mockCIBAService.EXPECT().GetByAuthReqID(mock.Anything, "auth-req-1").Return(record, nil)
+
+			var capturedActor *tokenservice.SubjectTokenClaims
+			suite.mockTokenBuilder.EXPECT().BuildAccessToken(mock.Anything, mock.MatchedBy(
+				func(ctx *tokenservice.AccessTokenBuildContext) bool {
+					capturedActor = ctx.ActorClaims
+					return ctx.GrantType == string(providers.GrantTypeCIBA)
+				})).Return(&model.TokenDTO{Token: "access-token", TokenType: "Bearer"}, nil)
+			suite.mockTokenBuilder.EXPECT().BuildIDToken(mock.Anything, mock.Anything).
+				Return(&model.TokenDTO{Token: "id-token"}, nil)
+			suite.mockCIBAService.EXPECT().MarkConsumed(mock.Anything, "auth-req-1").Return(true, nil)
+
+			resp, errResp := suite.handler.HandleGrant(context.Background(), suite.tokenReq, suite.oauthApp)
+			suite.Nil(errResp)
+			suite.NotNil(resp)
+
+			if tc.expectActor {
+				suite.Require().NotNil(capturedActor)
+				suite.Equal(actAppID, capturedActor.Sub)
+				suite.Empty(capturedActor.Iss)
+			} else {
+				suite.Nil(capturedActor)
+			}
+		})
+	}
+}
+
 func (suite *CIBAGrantHandlerTestSuite) TestHandleGrant_Authenticated_OneTimeUseRace() {
 	record := suite.boundAuthenticatedRecord(testScopeRead)
 	suite.mockCIBAService.EXPECT().GetByAuthReqID(mock.Anything, "auth-req-1").Return(record, nil)

--- a/docs/content/guides/agents/authentication/on-behalf-of-user.mdx
+++ b/docs/content/guides/agents/authentication/on-behalf-of-user.mdx
@@ -86,6 +86,15 @@ The agent cannot open a browser for the user, so it requests approval over a bac
 
 The backchannel request and approval flow is the same as for any client. See [Backchannel Authentication (CIBA)](../../../protocols/oauth-oidc/backchannel-authentication), using this agent as the client.
 
+The token the agent polls out of the token endpoint names the user as `sub` and the agent as `act`, exactly as the sign-in path does:
+
+```json
+{
+  "sub": "<user-id>",
+  "act": { "sub": "<agent-id>" }
+}
+```
+
 </DelegationContent>
 
 <DelegationContent value="exchange">
@@ -156,7 +165,7 @@ A resource reads `sub` to apply the user's permissions and `act` to see which ag
 | `aud` | The resolved resource server, or the agent's default audience (its client ID when none is set) when the request carries no permission scopes or `resource`. |
 | `scope` | A subset of the user's scopes, never more than the user's own token held. |
 | `client_id` | The agent's client ID. |
-| `act` | The agent acting for the user, on the access token only and never the ID token. It is appended automatically on the `authorization_code` grant, and built from the `actor_token` on a token exchange. |
+| `act` | The agent acting for the user, on the access token only and never the ID token. It is appended automatically on the `authorization_code` and CIBA grants, and built from the `actor_token` on a token exchange. |
 | `exp`, `iat`, `nbf`, `jti` | Standard JWT lifetime and identity claims. |
 
 ## Troubleshooting

--- a/docs/content/guides/protocols/oauth-oidc/backchannel-authentication.mdx
+++ b/docs/content/guides/protocols/oauth-oidc/backchannel-authentication.mdx
@@ -60,6 +60,7 @@ The flow proceeds in three phases:
 | Resource binding (RFC 8707) | An optional `resource` binds the request to one resource server at initiation. When a permission scope is requested without `resource`, the configured `defaultResourceServer` applies; with no default, the request is rejected with `invalid_target`. The access token's `aud` is the bound resource server identifier, and its permissions are limited to that server. OIDC-only requests without `resource` use the application's `token.accessToken.defaultAudience`, falling back to `client_id`. A `resource` supplied when polling must match the binding |
 | `binding_message` | Optional; maximum 256 printable characters; <ProductName /> generates a default message when omitted |
 | Token issuance | Access token always issued; ID token issued when `openid` is in the scope; refresh token issued when `refresh_token` grant is configured on the client |
+| Actor claim | The access token carries an `act` claim naming the client when that client is an agent, or an application with `includeActClaim` enabled. See [Actor on the Issued Token](#actor-on-the-issued-token) |
 | One-time use | <ProductName /> atomically marks the `auth_req_id` as consumed on the first successful token exchange; subsequent polls return `invalid_grant` |
 | Discovery | `backchannel_authentication_endpoint` is advertised in the OIDC discovery document |
 
@@ -150,6 +151,29 @@ Wait for the interval (or a longer interval after a `slow_down` response), then 
   "expires_in": 3600
 }
 ```
+
+## Actor on the Issued Token
+
+The issued access token represents the user who approved the request, so `sub` holds that user's subject identifier. The token additionally names the client that obtained it in an `act` (actor) claim, so a resource server sees both the user who approved the request and the client acting for them.
+
+| Client | `act` claim |
+|---|---|
+| Agent | Always present. |
+| Application with `includeActClaim` enabled | Present. |
+| Application without `includeActClaim` | Absent. |
+
+The value of `act.sub` is the agent or application resource identifier, not the client ID. The claim appears on the access token only, never on the ID token.
+
+```json
+{
+  "sub": "<user-id>",
+  "act": { "sub": "<agent-or-application-id>" },
+  "client_id": "<client-id>",
+  "grant_type": "urn:openid:params:grant-type:ciba"
+}
+```
+
+When the client also holds the `refresh_token` grant, the refresh token records the same actor, and every access token minted from it carries the actor decided at issuance rather than the client's current `includeActClaim` setting.
 
 ## Polling Error Reference
 

--- a/tests/integration/oauth/ciba/ciba_actor_claim_test.go
+++ b/tests/integration/oauth/ciba/ciba_actor_claim_test.go
@@ -1,0 +1,206 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ciba
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+const (
+	cibaActClaimClientID     = "ciba_act_claim_test_client"
+	cibaActClaimClientSecret = "ciba_act_claim_test_secret"
+	cibaAgentClientID        = "ciba_agent_test_client"
+	cibaAgentClientSecret    = "ciba_agent_test_secret"
+)
+
+// createCIBAAppWithActClaim creates a CIBA-enabled application bound to the shared test auth flow
+// with includeActClaim turned on.
+func (ts *CIBATestSuite) createCIBAAppWithActClaim(clientID, clientSecret string) string {
+	app := map[string]interface{}{
+		"name":                      "CIBAActClaimTestApp",
+		"description":               "Application for CIBA act claim integration test",
+		"ouId":                      ts.ouID,
+		"type":                      "fullstack",
+		"authFlowId":                ts.flowID,
+		"isRegistrationFlowEnabled": false,
+		"allowedUserTypes":          []string{"ciba-test-person"},
+		"inboundAuthConfig": []map[string]interface{}{
+			{
+				"type": "oauth2",
+				"config": map[string]interface{}{
+					"clientId":                clientID,
+					"clientSecret":            clientSecret,
+					"redirectUris":            []string{"https://localhost:3000"},
+					"grantTypes":              []string{cibaGrantType},
+					"tokenEndpointAuthMethod": "client_secret_basic",
+					"includeActClaim":         true,
+				},
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(app)
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testutils.TestServerURL+"/applications", bytes.NewBuffer(jsonData))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		ts.T().Fatalf("Failed to create CIBA act-claim application. Status: %d, Response: %s",
+			resp.StatusCode, string(bodyBytes))
+	}
+
+	var respData map[string]interface{}
+	ts.Require().NoError(json.NewDecoder(resp.Body).Decode(&respData))
+	return respData["id"].(string)
+}
+
+// createCIBAAgent creates a CIBA-enabled agent bound to the shared test auth flow. The agent carries
+// no includeActClaim setting: an agent's act claim is implicit.
+func (ts *CIBATestSuite) createCIBAAgent(clientID, clientSecret string) string {
+	agent := map[string]interface{}{
+		"name":             "CIBA Act Claim Test Agent",
+		"type":             "default",
+		"ouId":             ts.ouID,
+		"authFlowId":       ts.flowID,
+		"allowedUserTypes": []string{"ciba-test-person"},
+		"inboundAuthConfig": []map[string]interface{}{
+			{
+				"type": "oauth2",
+				"config": map[string]interface{}{
+					"clientId":                clientID,
+					"clientSecret":            clientSecret,
+					"grantTypes":              []string{cibaGrantType},
+					"tokenEndpointAuthMethod": "client_secret_basic",
+				},
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(agent)
+	ts.Require().NoError(err)
+
+	req, err := http.NewRequest("POST", testutils.TestServerURL+"/agents", bytes.NewBuffer(jsonData))
+	ts.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		ts.T().Fatalf("Failed to create CIBA agent. Status: %d, Response: %s",
+			resp.StatusCode, string(bodyBytes))
+	}
+
+	var respData map[string]interface{}
+	ts.Require().NoError(json.NewDecoder(resp.Body).Decode(&respData))
+	return respData["id"].(string)
+}
+
+// pollCIBATokenUntilIssued polls the token endpoint as the given client until the authenticated
+// request yields tokens, backing off past the interval enforced while the request was pending.
+func (ts *CIBATestSuite) pollCIBATokenUntilIssued(authReqID, clientID, clientSecret string) cibaTokenResult {
+	var tokenRes cibaTokenResult
+	deadline := time.Now().Add(30 * time.Second)
+	delay := cibaPollIntervalSeconds * time.Second
+	for {
+		tokenRes = ts.cibaPollTokenAs(authReqID, "", clientID, clientSecret)
+		if tokenRes.statusCode != http.StatusBadRequest ||
+			(tokenRes.errorCode != "slow_down" && tokenRes.errorCode != "authorization_pending") {
+			break
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(delay)
+		delay += cibaPollIntervalSeconds * time.Second
+	}
+	return tokenRes
+}
+
+// TestCIBAGrantFlow_ActClaimOptIn verifies that an application that opts in through includeActClaim
+// gets an on-behalf-of "act" claim naming itself on a CIBA-issued access token, matching the
+// behaviour already proven for the authorization_code grant.
+func (ts *CIBATestSuite) TestCIBAGrantFlow_ActClaimOptIn() {
+	appID := ts.createCIBAAppWithActClaim(cibaActClaimClientID, cibaActClaimClientSecret)
+	defer func() { _ = testutils.DeleteApplication(appID) }()
+
+	status, bcResp := ts.cibaBackchannelAuthorizeAs(cibaActClaimClientID, cibaActClaimClientSecret,
+		cibaTestUsername, "openid")
+	ts.Require().Equal(http.StatusOK, status, "bc-authorize should succeed")
+	ts.Require().NotEmpty(bcResp.AuthReqID)
+
+	ts.completeCIBAFlow(bcResp.AuthReqID)
+
+	tokenRes := ts.pollCIBATokenUntilIssued(bcResp.AuthReqID, cibaActClaimClientID, cibaActClaimClientSecret)
+	ts.Require().Equal(http.StatusOK, tokenRes.statusCode, "AUTHENTICATED request should issue tokens")
+	ts.Require().NotEmpty(tokenRes.accessToken)
+
+	claims, err := testutils.DecodeJWT(tokenRes.accessToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal(ts.userID, claims.Sub, "token subject should remain the CIBA user")
+
+	act, ok := claims.Additional["act"].(map[string]interface{})
+	ts.Require().True(ok, "an opted-in application should get an act claim")
+	ts.Assert().Equal(appID, act["sub"], "act.sub should name the application entity")
+}
+
+// TestCIBAGrantFlow_AgentActClaim verifies that an agent polling the CIBA token endpoint always gets
+// an act claim naming itself, without any opt-in. The user remains the token subject, so a resource
+// server can tell which agent is acting on whose behalf.
+func (ts *CIBATestSuite) TestCIBAGrantFlow_AgentActClaim() {
+	// The `default` agent type is a singleton shared with every other suite. Snapshot it before
+	// pointing it at this suite's OU, so teardown can put it back before that OU is deleted.
+	snapshot, err := testutils.SnapshotAgentType()
+	ts.Require().NoError(err, "Failed to snapshot the default agent type")
+	defer func() {
+		ts.Require().NoError(testutils.RestoreAgentType(snapshot),
+			"teardown: failed to restore the default agent type")
+	}()
+
+	_, err = testutils.CreateAgentType(testutils.UserType{
+		Name: "default",
+		OUID: ts.ouID,
+		Schema: map[string]interface{}{
+			"description": map[string]interface{}{"type": "string"},
+		},
+	})
+	ts.Require().NoError(err, "Failed to point the default agent type at the CIBA test OU")
+
+	agentID := ts.createCIBAAgent(cibaAgentClientID, cibaAgentClientSecret)
+	defer func() { _ = testutils.DeleteAgent(agentID) }()
+
+	status, bcResp := ts.cibaBackchannelAuthorizeAs(cibaAgentClientID, cibaAgentClientSecret,
+		cibaTestUsername, "openid")
+	ts.Require().Equal(http.StatusOK, status, "bc-authorize should succeed for an agent client")
+	ts.Require().NotEmpty(bcResp.AuthReqID)
+
+	ts.completeCIBAFlow(bcResp.AuthReqID)
+
+	tokenRes := ts.pollCIBATokenUntilIssued(bcResp.AuthReqID, cibaAgentClientID, cibaAgentClientSecret)
+	ts.Require().Equal(http.StatusOK, tokenRes.statusCode, "AUTHENTICATED request should issue tokens")
+	ts.Require().NotEmpty(tokenRes.accessToken)
+
+	claims, err := testutils.DecodeJWT(tokenRes.accessToken)
+	ts.Require().NoError(err)
+	ts.Require().Equal(ts.userID, claims.Sub, "token subject should remain the CIBA user")
+
+	act, ok := claims.Additional["act"].(map[string]interface{})
+	ts.Require().True(ok, "an agent should always get an act claim")
+	ts.Assert().Equal(agentID, act["sub"], "act.sub should name the agent entity")
+}

--- a/tests/integration/oauth/ciba/ciba_test.go
+++ b/tests/integration/oauth/ciba/ciba_test.go
@@ -349,6 +349,8 @@ func (ts *CIBATestSuite) TestCIBAGrantFlow() {
 	claims, err := testutils.DecodeJWT(tokenRes.accessToken)
 	ts.Require().NoError(err, "issued access token should be a decodable JWT")
 	ts.Require().Equal(ts.userID, claims.Sub, "token subject should be the CIBA user")
+	ts.Require().NotContains(claims.Additional, "act",
+		"an application that has not opted in must not get an act claim")
 
 	// Step 7: A second poll is rejected — the request is CONSUMED (one-time use).
 	reuse := ts.cibaPollToken(bcResp.AuthReqID, "")


### PR DESCRIPTION
### Purpose

An access token issued through the CIBA grant carried no `act` claim, even when the authenticated client was an agent. A resource server receiving that token could see which user it represented, but not which agent obtained it on their behalf.

The authorization code grant already appends the claim based on the authenticated client: agents always get it, applications opt in through `includeActClaim`. The CIBA grant handler never applied that rule, so the claim depended on which grant was used rather than on who the client was.

This PR closes that gap. A CIBA-issued access token now carries `act.sub` naming the agent or the opted-in application, while `sub` remains the user.

### Approach

ciba.go passed its build context to BuildAccessToken as an inline literal, leaving no place to apply the rule. The context is hoisted to a variable and the same check the authorization code grant uses is applied to it:

``
if oauthApp.ShouldAppendActorClaim() {
	accessTokenCtx.ActorClaims = &tokenservice.SubjectTokenClaims{Sub: oauthApp.ID}
}
``

**Key design decisions:**

- Reuse ShouldAppendActorClaim() rather than add configuration. The predicate already encodes the product rule (agents implicitly, applications by opt-in), so agents get the claim automatically and applications keep their existing IncludeActClaim setting. No new API surface, no migration.
- No token builder change. ActorClaims is an existing field on AccessTokenBuildContext, and the builder already emits act from it, so the change is confined to the grant handler.
- act.sub is the entity ID (oauthApp.ID), not the client ID. This matches what the authorization code and refresh grants emit, so a resource server matching on act.sub behaves identically regardless of which grant produced the token.



### Related Issues
- https://github.com/thunder-id/thunderid/issues/5020

### Related PRs
- https://github.com/thunder-id/thunderid/pull/3369


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CIBA access tokens can include an `act` claim identifying the requesting application or agent.
  * Tokens preserve the authenticated user as the subject while providing actor context.
  * Agent-issued tokens always include actor information; applications can opt in.

* **Documentation**
  * Clarified actor-claim behavior, configuration, token types, and refresh-token handling.

* **Tests**
  * Added coverage for configured and non-configured actor claims across application and agent scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->