### PR TITLE
Add Wayfinder Agent E2E Tests

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -1380,6 +1380,105 @@ jobs:
             exit 1
           fi
 
+      # The AI agent tryout specs (tests/wayfinder/ai-agent-tryout/**) drive the Concierge chat with
+      # real, billed LLM calls, so they only run when an API key is configured - forked PRs get no
+      # secrets. Without a key the three steps below are skipped and the specs skip themselves (see
+      # their describeOrSkip), exactly as run-e2e.sh does locally.
+      - name: 🔑 Resolve Wayfinder AI Agent Configuration
+        if: ${{ !cancelled() }}
+        id: llm-config
+        env:
+          LLM_API_KEY: ${{ secrets.PLAYWRIGHT_LLM_API_KEY }}
+          VAR_LLM_PROVIDER: ${{ vars.PLAYWRIGHT_LLM_PROVIDER }}
+          VAR_MODEL_NAME: ${{ vars.PLAYWRIGHT_LLM_MODEL_NAME }}
+        run: |
+          # Provider and model are not sensitive, so they come from Variables rather than Secrets.
+          # An empty MODEL_NAME is fine: the agent falls back to its per-provider default.
+          echo "LLM_PROVIDER=${VAR_LLM_PROVIDER:-anthropic}" >> "$GITHUB_ENV"
+          echo "MODEL_NAME=${VAR_MODEL_NAME}" >> "$GITHUB_ENV"
+          if [ -z "$LLM_API_KEY" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "⏭️ PLAYWRIGHT_LLM_API_KEY not set - skipping the Wayfinder AI agent tryout tests"
+            exit 0
+          fi
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+          # The Wayfinder bundle's variables map, from the same file run-e2e.sh feeds to /import.
+          VARS=$(jq -Rnc '[inputs | select(contains("=") and (startswith("#") | not)) | split("=") | {(.[0]): (.[1:] | join("="))}] | add // {}' \
+            < samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid.env)
+          echo "WAYFINDER_IMPORT_VARS=$VARS" >> "$GITHUB_ENV"
+          echo "✅ LLM API key present - the Wayfinder AI agent tryout tests will run"
+
+      # Ahead of the AI agent starting, not just via wayfinder-sample-setup.spec.ts's own import
+      # step: the agent authenticates against WAYFINDER-CONCIERGE at startup (before any Playwright
+      # test runs), so that client must already exist by then. The setup spec still re-imports the
+      # same (upsert:true) bundle through the console UI later - that is what actually tests the
+      # import feature, and what every other @wayfinder spec depends on.
+      - name: 📦 Import Wayfinder Sample Config
+        if: ${{ !cancelled() && steps.llm-config.outputs.enabled == 'true' }}
+        uses: ./.github/actions/import-declarative-config
+        with:
+          config-path: samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid-config.yaml
+          variables-json: ${{ env.WAYFINDER_IMPORT_VARS }}
+          admin-token: ${{ steps.admin-token-wayfinder.outputs.token }}
+          label: Wayfinder sample
+
+      - name: 🚀 Start Wayfinder Backend
+        if: ${{ !cancelled() && steps.llm-config.outputs.enabled == 'true' }}
+        run: |
+          cd samples/apps/wayfinder-sample/backend
+          cp .env.example .env
+          npm install
+          setsid npm run dev > "$GITHUB_WORKSPACE/wayfinder-backend.log" 2>&1 < /dev/null &
+          disown $! 2>/dev/null || true
+          echo "Waiting for Wayfinder backend on http://localhost:8787..."
+          for i in {1..60}; do
+            if curl -s http://localhost:8787/health > /dev/null; then
+              echo "Wayfinder backend is up!"
+              break
+            fi
+            sleep 2
+          done
+          if ! curl -s http://localhost:8787/health > /dev/null; then
+            echo "❌ Wayfinder backend failed to start within 2 minutes"
+            echo "--- wayfinder-backend.log ---"
+            cat "$GITHUB_WORKSPACE/wayfinder-backend.log" || true
+            exit 1
+          fi
+
+      - name: 🚀 Start Wayfinder AI Agent
+        if: ${{ !cancelled() && steps.llm-config.outputs.enabled == 'true' }}
+        env:
+          LLM_API_KEY: ${{ secrets.PLAYWRIGHT_LLM_API_KEY }}
+        run: |
+          cd samples/apps/wayfinder-sample/ai-agent
+          cp .env.example .env
+          # Same seeding as run-e2e.sh: the E2E run owns the agent's LLM config, so drop whatever
+          # .env.example carried (MODEL_NAME is commented out there) and append the resolved values.
+          grep -vE '^[[:space:]]*#?[[:space:]]*(LLM_PROVIDER|LLM_API_KEY|MODEL_NAME)=' .env > .env.ci
+          {
+            echo "LLM_PROVIDER=${LLM_PROVIDER}"
+            echo "LLM_API_KEY=${LLM_API_KEY}"
+            echo "MODEL_NAME=${MODEL_NAME}"
+          } >> .env.ci
+          mv .env.ci .env
+          npm install
+          setsid npm run dev > "$GITHUB_WORKSPACE/wayfinder-ai-agent.log" 2>&1 < /dev/null &
+          disown $! 2>/dev/null || true
+          echo "Waiting for Wayfinder AI agent on http://localhost:8790..."
+          for i in {1..60}; do
+            if curl -s http://localhost:8790/health > /dev/null; then
+              echo "Wayfinder AI agent is up!"
+              break
+            fi
+            sleep 2
+          done
+          if ! curl -s http://localhost:8790/health > /dev/null; then
+            echo "❌ Wayfinder AI agent failed to start within 2 minutes"
+            echo "--- wayfinder-ai-agent.log ---"
+            cat "$GITHUB_WORKSPACE/wayfinder-ai-agent.log" || true
+            exit 1
+          fi
+
       - name: 🎭 Run Playwright E2E Tests (Wayfinder)
         if: ${{ !cancelled() }}
         run: |
@@ -1397,7 +1496,7 @@ jobs:
           # name the Wayfinder projects explicitly (chromium's tryout project plus the two
           # browser-agnostic ones) instead of a 'chromium' or '*wayfinder-*' filter - the former
           # would match none of them, the latter would also pull in firefox/webkit tryout runs.
-          PLAYWRIGHT_PROJECT_FILTER: ${{ github.event_name == 'pull_request' && 'wayfinder-setup chromium-wayfinder-tryout wayfinder-mock-email' || '' }}
+          PLAYWRIGHT_PROJECT_FILTER: ${{ github.event_name == 'pull_request' && 'wayfinder-setup chromium-wayfinder-tryout wayfinder-mock-email wayfinder-ai-agent' || '' }}
           PLAYWRIGHT_HTML_OUTPUT_DIR: playwright-report-wayfinder
           PLAYWRIGHT_JSON_OUTPUT_FILE: test-results-wayfinder/test-results.json
           PLAYWRIGHT_JUNIT_OUTPUT_FILE: test-results-wayfinder/junit.xml
@@ -1408,6 +1507,9 @@ jobs:
           PLAYWRIGHT_WORKERS: ${{ vars.PLAYWRIGHT_WORKERS || env.DEFAULT_PLAYWRIGHT_WORKERS }}
           DEBUG_AUTH: ${{ vars.PLAYWRIGHT_DEBUG_AUTH || env.DEFAULT_DEBUG_AUTH }}
           SERVER_URL: ${{ env.DEFAULT_SERVER_URL }}
+          # Gates the ai-agent-tryout specs: the wayfinder-ai-agent project always runs, and its
+          # specs skip themselves when this is empty (no agent was started above).
+          LLM_API_KEY: ${{ secrets.PLAYWRIGHT_LLM_API_KEY }}
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ !cancelled() }}

--- a/samples/apps/wayfinder-sample/ai-agent/agent.ts
+++ b/samples/apps/wayfinder-sample/ai-agent/agent.ts
@@ -1126,20 +1126,25 @@ async function handleConsent(
     return;
   }
 
+  // Claim the pending consent before awaiting: the check above only guards a duplicate request
+  // (a double-clicked Authorize, a retried POST) if the code is taken off the session before the
+  // exchange yields the event loop, since the code is single use.
+  const pending = session.pendingConsent;
+  session.pendingConsent = undefined;
+
   try {
-    const userToken = await exchangeCodeForUserToken(
-      body.code,
-      session.pendingConsent.verifier,
-    );
+    const userToken = await exchangeCodeForUserToken(body.code, pending.verifier);
     session.userToken = userToken;
     session.userToolsByName = undefined;
-    session.pendingConsent = undefined;
 
     sendJson(response, 200, {
       type: "consent_received",
       session_id: session.id,
     });
   } catch (error) {
+    // Leave the request re-authorizable: this consent attempt failed on its own merits (expired
+    // code, unreachable token endpoint), not because another request already consumed it.
+    session.pendingConsent = pending;
     console.error("Token exchange failed:", error);
     sendJson(response, 500, {
       error: error instanceof Error ? error.message : "Token exchange failed",

--- a/samples/apps/wayfinder-sample/frontend/src/App.jsx
+++ b/samples/apps/wayfinder-sample/frontend/src/App.jsx
@@ -682,13 +682,19 @@ function HomeRedirect() {
 // triggered an authorization-code flow in a popup. Posts the code (and state)
 // back to the opener window (the chat widget) and closes itself.
 function AgentCallbackRoute() {
+  const posted = useRef(false);
+
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const code = params.get("code");
     const state = params.get("state");
     const error = params.get("error");
     const errorDescription = params.get("error_description");
-    if (window.opener) {
+    // The authorization code is single use and StrictMode runs this effect twice on mount, so post
+    // it once: a second delivery makes the opener redeem the same code again, which the token
+    // endpoint rightly rejects as a replay.
+    if (window.opener && !posted.current) {
+      posted.current = true;
       window.opener.postMessage(
         {
           type: "wayfinder-agent-oauth",
@@ -720,6 +726,8 @@ function AgentCallbackRoute() {
 }
 
 function ChatTokenCallbackRoute() {
+  const posted = useRef(false);
+
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const code = params.get("code");
@@ -727,7 +735,9 @@ function ChatTokenCallbackRoute() {
     const error = params.get("error");
     const errorDescription = params.get("error_description");
 
-    if (window.opener) {
+    // Post once, for the same reason as AgentCallbackRoute above.
+    if (window.opener && !posted.current) {
+      posted.current = true;
       window.opener.postMessage(
         {
           type: "wayfinder-chat-token-oauth",

--- a/tests/e2e/.env.example
+++ b/tests/e2e/.env.example
@@ -4,6 +4,17 @@
 # .env from defaults.env on first run. Copy this file to .env only if you want to override
 # specific values (e.g. pointing at a different server or using different test credentials).
 #
+# The Wayfinder AI agent tests (tests/wayfinder/ai-agent-tryout/**) need a real LLM API key.
+# Copy this file to .env and set LLM_API_KEY below to run them. These three values are the single
+# source of truth for the agent's LLM config: run-e2e.sh overwrites them in
+# samples/apps/wayfinder-sample/ai-agent/.env, which is what the agent process reads. Without
+# a key, run-e2e.sh does not start the Wayfinder backend or AI agent, and these tests are skipped.
+# MODEL_NAME may be left unset to use the provider's default model.
+#
+# LLM_PROVIDER=anthropic
+# LLM_API_KEY=
+# MODEL_NAME=
+#
 # BASE_URL=https://localhost:8090
 # ADMIN_USERNAME=admin
 # ADMIN_PASSWORD=admin

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -84,6 +84,21 @@ To override specific values (e.g. a different server or different test credentia
 cp .env.example .env
 ```
 
+The Wayfinder AI agent tryout tests (`tests/wayfinder/ai-agent-tryout/**`) additionally need a real
+LLM API key. Set it here, along with the provider and model the agent should use:
+
+| Value          | Purpose                                                              |
+| :------------- | :------------------------------------------------------------------- |
+| `LLM_API_KEY`  | API key for the provider. Required; nothing else here has any effect without it. |
+| `LLM_PROVIDER` | `anthropic` (default) or `google`.                                   |
+| `MODEL_NAME`   | Model override. Leave unset to use the provider's default model.     |
+
+`run-e2e.sh` writes all three into `samples/apps/wayfinder-sample/ai-agent/.env`, overwriting any
+values already there, then imports the Wayfinder config bundle and starts the Wayfinder backend and
+AI agent for phase 2. Without a key none of that happens and the agent tests are skipped; the rest
+of phase 2 runs as usual, with `wayfinder-sample-setup.spec.ts` importing the bundle through the
+console UI later on.
+
 ---
 
 ## 🛠 CI/CD Configuration
@@ -103,8 +118,13 @@ To customize the CI environment, add the following to **Settings > Secrets and v
 | `PLAYWRIGHT_TEST_USER_PASSWORD` | **Secret** | Test User Password  | `admin`                  |
 | `PLAYWRIGHT_WORKERS`            | Variable   | Parallel Processing | `6`                      |
 | `PLAYWRIGHT_DEBUG_AUTH`         | Variable   | Auth Debug Logs     | `false`                  |
+| `PLAYWRIGHT_LLM_API_KEY`        | **Secret** | Wayfinder AI agent LLM key | _none - agent tests skip_ |
+| `PLAYWRIGHT_LLM_PROVIDER`       | Variable   | LLM provider        | `anthropic`              |
+| `PLAYWRIGHT_LLM_MODEL_NAME`     | Variable   | LLM model override  | provider default         |
 
 CI runs the suite in two phases against two independently provisioned servers: everything except the `@wayfinder`-tagged tests first, then the Wayfinder tests alone against a fresh server with its own sample app and mock SMTP inbox. `run-e2e.sh` reproduces both phases locally (see its `--phase` flag).
+
+The AI agent tryout tests are gated on `PLAYWRIGHT_LLM_API_KEY` in the same way as locally: the workflow only imports the Wayfinder config bundle and starts the Wayfinder backend and AI agent when that secret is set. Forked pull requests receive no secrets, so those tests skip there and no LLM calls are billed.
 
 ---
 

--- a/tests/e2e/constants/timeouts.ts
+++ b/tests/e2e/constants/timeouts.ts
@@ -40,4 +40,10 @@ export const Timeouts = {
    * connections, flows, application rewiring) rather than running a single test.
    */
   SUITE_SETUP: 60 * 1000,
+
+  /**
+   * Wait for the Wayfinder AI agent's chat reply: a real LLM call, often followed by an MCP tool
+   * round trip, so it runs far longer than a plain UI action.
+   */
+  LLM_RESPONSE: 45 * 1000,
 } as const;

--- a/tests/e2e/pages/wayfinder-sample/index.ts
+++ b/tests/e2e/pages/wayfinder-sample/index.ts
@@ -4,3 +4,4 @@
 export { WayfinderAppPage } from "./wayfinder-app.page";
 export { MockEmailAppPage } from "./mock-email.page";
 export { WayfinderProfilePage } from "./wayfinder-profile.page";
+export { WayfinderChatPage } from "./wayfinder-chat.page";

--- a/tests/e2e/pages/wayfinder-sample/wayfinder-chat.page.ts
+++ b/tests/e2e/pages/wayfinder-sample/wayfinder-chat.page.ts
@@ -1,0 +1,277 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Wayfinder AI Agent Chat Widget Page Object
+ *
+ * Drives the concierge chat widget embedded in the Wayfinder sample app's frontend (see
+ * samples/apps/wayfinder-sample/frontend/src/App.jsx, ChatWidgetCore). The widget has no test
+ * ids - every locator here is role/aria/class based, matched against that component's actual
+ * markup.
+ *
+ * Sending the first chat message of a browser session has a side effect worth calling out: with
+ * no chat access token cached yet, chatTokenService.getChatAccessToken({interactive: true}) opens
+ * its own OAuth popup (scope=agent:access) to obtain one before the message ever reaches the
+ * agent - this happens for every signed-in user, including one that lacks agent:access, since the
+ * scope reduction happens silently server-side. sendFirstMessage() drives that popup; plain
+ * sendMessage() assumes a token is already cached.
+ *
+ * A second, unrelated popup exists for the "act on behalf of user" (OBO) booking flow: when the
+ * agent asks for consent, an in-chat bubble (ConsentRequestBubble) offers an "Authorize" button
+ * that opens its own popup for the consent screen - see authorizeConsentAndGetPopup(). That popup
+ * re-authenticates (if there's no active gate SSO session) and then always shows the gate's own
+ * OAuth permission-approval screen (ConsentAdapter.tsx) - a per-scope toggle list defaulting to
+ * off, plus Allow/Deny buttons - which completeConsentAuthorization() must grant before the popup
+ * closes itself.
+ */
+
+import { Page, Locator, expect } from "@playwright/test";
+import { BasePage } from "../base.page";
+import { GateLoginPage } from "../gate-login.page";
+import { Timeouts } from "../../constants/timeouts";
+
+export class WayfinderChatPage extends BasePage {
+  readonly launcherButton: Locator;
+  readonly panel: Locator;
+  readonly composerInput: Locator;
+  readonly sendButton: Locator;
+  // Final assistant replies only - excludes the typing indicator and consent-request bubbles,
+  // which also carry the chat-message--assistant class (see App.jsx's message rendering).
+  readonly assistantMessages: Locator;
+  readonly typingIndicator: Locator;
+  readonly consentBubble: Locator;
+  readonly consentAuthorizeButton: Locator;
+  readonly consentNotNowButton: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    // Structural, not role/name based: while the panel is open, the in-panel header close button
+    // (App.jsx's chat-icon-button) carries the same "Close AI chat" aria-label as this button, so
+    // a name-based query is ambiguous whenever the panel is open (i.e. exactly when reopen() needs
+    // to click it).
+    this.launcherButton = page.locator("button.chat-launcher");
+    this.panel = page.getByRole("region", { name: "AI travel assistant" });
+    // Structural, not placeholder based: the placeholder text itself changes to "Chat unavailable"
+    // in the access-denied state (see expectChatUnavailable()), so a placeholder query wouldn't
+    // resolve to anything once that state is reached.
+    this.composerInput = page.locator(".chat-composer input");
+    this.sendButton = page.getByRole("button", { name: "Send message" });
+    this.assistantMessages = page.locator(
+      ".chat-message.chat-message--assistant:not(.chat-message--consent):not(.chat-message--typing)"
+    );
+    this.typingIndicator = page.locator(".chat-message--typing");
+    this.consentBubble = page.locator(".chat-message--consent");
+    this.consentAuthorizeButton = this.consentBubble.getByRole("button", { name: "Authorize" });
+    this.consentNotNowButton = this.consentBubble.getByRole("button", { name: "Not now" });
+  }
+
+  /** Open the chat widget if it isn't already. */
+  async open() {
+    if (await this.panel.isVisible().catch(() => false)) return;
+    await this.launcherButton.waitFor({ state: "visible", timeout: Timeouts.DEFAULT_ACTION });
+    await this.launcherButton.click();
+    await expect(this.panel).toBeVisible({ timeout: Timeouts.ELEMENT_VISIBILITY });
+  }
+
+  /**
+   * Close and reopen the chat widget. The chat-access 403 check only runs when the panel opens
+   * with a token already cached (see ChatWidgetCore's checkAccess effect), so re-triggering `isOpen`
+   * is how a rejected user's composer actually flips to the disabled "Chat unavailable" state.
+   */
+  async reopen() {
+    await this.launcherButton.click();
+    await expect(this.panel).toBeHidden({ timeout: Timeouts.ELEMENT_VISIBILITY });
+    await this.launcherButton.click();
+    await expect(this.panel).toBeVisible({ timeout: Timeouts.ELEMENT_VISIBILITY });
+  }
+
+  /**
+   * Send the first chat message of the session. With no chat access token cached, this triggers
+   * chatTokenService's own OAuth popup for the `agent:access` scope - sign in inside it if a login
+   * form appears (an active gate SSO session skips straight through), then grant the gate's own
+   * OAuth permission-approval screen if `agent:access` hasn't been consented to before (see
+   * completeConsentAuthorization()'s doc comment for why that screen isn't optional) before letting
+   * the popup close on its own.
+   * @param text - Message to send
+   * @param username - Credentials for the popup's login form, if one appears
+   * @param password - Credentials for the popup's login form, if one appears
+   */
+  async sendFirstMessage(text: string, username: string, password: string) {
+    await this.composerInput.fill(text);
+    const [popup] = await Promise.all([
+      this.page.waitForEvent("popup", { timeout: Timeouts.DEFAULT_ACTION }),
+      this.sendButton.click(),
+    ]);
+
+    // chatTokenService opens the popup with window.open("", ...) (about:blank) and only sets its
+    // location.href once the PKCE challenge is computed asynchronously - so waitForLoadState() here
+    // resolves against about:blank, not the gate. Wait for the real navigation first, or the
+    // login/consent race right after would start timing against about:blank instead of the gate.
+    await popup.waitForURL(url => url.protocol !== "about:", { timeout: Timeouts.DEFAULT_ACTION }).catch(() => {});
+    await popup.waitForLoadState();
+    const outcome = await this.raceLoginConsentClose(popup);
+    if (outcome === "login") {
+      await new GateLoginPage(popup).login(username, password);
+    }
+    await this.grantAllPermissions(popup);
+    await this.waitForPopupClose(popup);
+  }
+
+  /** Send a chat message once a chat access token is already cached (no popup expected). */
+  async sendMessage(text: string) {
+    await this.composerInput.waitFor({ state: "visible", timeout: Timeouts.DEFAULT_ACTION });
+    await this.composerInput.fill(text);
+    await this.sendButton.click();
+  }
+
+  /**
+   * Wait for a new assistant reply to arrive: the typing indicator (if it appeared at all)
+   * settles, and the count of final assistant bubbles grows past what it was before the message
+   * that triggered this reply was sent.
+   * @param previousCount - Number of assistant bubbles present before sending
+   */
+  async waitForAssistantReply(previousCount: number) {
+    await expect(this.typingIndicator).toHaveCount(0, { timeout: Timeouts.LLM_RESPONSE });
+    await expect(this.assistantMessages).not.toHaveCount(previousCount, { timeout: Timeouts.LLM_RESPONSE });
+  }
+
+  async assistantMessageCount(): Promise<number> {
+    return this.assistantMessages.count();
+  }
+
+  async lastAssistantMessage(): Promise<string> {
+    return (await this.assistantMessages.last().textContent()) ?? "";
+  }
+
+  /** Assert the composer reflects a 403'd /chat/access check (see ChatWidgetCore's accessDenied state). */
+  async expectChatUnavailable() {
+    await expect(this.composerInput).toHaveAttribute("placeholder", "Chat unavailable");
+    await expect(this.composerInput).toBeDisabled();
+  }
+
+  async waitForConsentRequest() {
+    await expect(this.consentBubble).toBeVisible({ timeout: Timeouts.LLM_RESPONSE });
+  }
+
+  /** Click "Authorize" on the in-chat consent bubble and return the OAuth consent popup it opens. */
+  async authorizeConsentAndGetPopup(): Promise<Page> {
+    const [popup] = await Promise.all([
+      this.page.waitForEvent("popup", { timeout: Timeouts.DEFAULT_ACTION }),
+      this.consentAuthorizeButton.click(),
+    ]);
+    await popup.waitForLoadState();
+    return popup;
+  }
+
+  /**
+   * Complete the OAuth consent popup opened by authorizeConsentAndGetPopup(): sign in if a login
+   * form appears (an active gate SSO session skips straight through), then grant every permission
+   * on the gate's own OAuth permission-approval screen that follows - it always appears, toggles
+   * default off, and the popup won't close until "Allow" is clicked.
+   * @param popup - Popup returned by authorizeConsentAndGetPopup()
+   * @param username - Credentials for the popup's login form, if one appears
+   * @param password - Credentials for the popup's login form, if one appears
+   */
+  async completeConsentAuthorization(popup: Page, username: string, password: string) {
+    const outcome = await this.raceLoginConsentClose(popup);
+    if (outcome === "login") {
+      await new GateLoginPage(popup).login(username, password);
+    }
+
+    await this.grantAllPermissions(popup);
+
+    await this.waitForPopupClose(popup);
+  }
+
+  /**
+   * Toggle on every permission switch on the gate's OAuth permission-approval screen (see
+   * ConsentAdapter.tsx - each requested scope renders as an off-by-default Switch) and click
+   * "Allow". A no-op if the screen never appears (e.g. scopes already granted in a prior test run).
+   * @param popup - Popup currently showing (or about to show) the permission-approval screen
+   */
+  private async grantAllPermissions(popup: Page) {
+    const allowButton = popup.getByRole("button", { name: "Allow" });
+    const consentScreenVisible = await this.waitVisibleOrPopupClosed(allowButton, popup);
+    if (!consentScreenVisible) return;
+
+    const permissionSwitches = popup.getByRole("switch");
+    const count = await permissionSwitches.count();
+    for (let i = 0; i < count; i++) {
+      const permissionSwitch = permissionSwitches.nth(i);
+      if (!(await permissionSwitch.isChecked())) {
+        await permissionSwitch.click();
+      }
+    }
+    await allowButton.click();
+  }
+
+  /**
+   * Wait for the OAuth popup to close itself. With an active gate SSO session, the popup redirects
+   * and self-closes right after grantAllPermissions() returns - often before this call is even
+   * reached - so waitForEvent("close") would miss the event and stall for the full REDIRECT
+   * timeout. Only register the listener when the popup is still open.
+   */
+  private async waitForPopupClose(popup: Page) {
+    if (popup.isClosed()) return;
+    await popup.waitForEvent("close", { timeout: Timeouts.REDIRECT }).catch(() => {});
+  }
+
+  /**
+   * Race the login form, the consent screen's "Allow" button, and popup closure against each
+   * other and report whichever appears first. An active gate SSO session can skip the login form
+   * entirely and land straight on the consent screen, or skip both and self-close the popup if
+   * consent was already granted - a fixed probe timeout for the login form alone can't tell a
+   * "this step is skipped" popup from a "the login form is just slow to render" one, so all three
+   * outcomes are raced against the same timeout instead of probing the login form in isolation.
+   */
+  private async raceLoginConsentClose(
+    popup: Page,
+    timeout: number = Timeouts.DEFAULT_ACTION
+  ): Promise<"login" | "consent" | "closed"> {
+    if (popup.isClosed()) return "closed";
+    const usernameInput = popup.locator('input[name="username"], input[placeholder*="username" i]').first();
+    const allowButton = popup.getByRole("button", { name: "Allow" });
+    try {
+      return await Promise.any([
+        usernameInput.waitFor({ state: "visible", timeout }).then(() => "login" as const),
+        allowButton.waitFor({ state: "visible", timeout }).then(() => "consent" as const),
+        popup.waitForEvent("close", { timeout }).then(() => "closed" as const),
+      ]);
+    } catch {
+      return "closed";
+    }
+  }
+
+  /**
+   * Wait for a step (login form, consent screen) to appear, but give up as soon as the popup
+   * closes instead. An active gate SSO session can skip straight past a step and let the popup
+   * self-close before it ever appears - without this race, the locator would poll for the full
+   * timeout since "closed" isn't a state waitFor() treats as failure on its own.
+   *
+   * Only remaining caller is grantAllPermissions(), reached either right after a login form
+   * submission (a real redirect may still be in flight) or right after raceLoginConsentClose()
+   * already found the consent screen (resolves immediately) - the default timeout covers both.
+   */
+  private async waitVisibleOrPopupClosed(
+    locator: Locator,
+    popup: Page,
+    timeout: number = Timeouts.DEFAULT_ACTION
+  ): Promise<boolean> {
+    if (popup.isClosed()) return false;
+    return Promise.race([
+      locator.waitFor({ state: "visible", timeout }).then(
+        () => true,
+        () => false
+      ),
+      popup.waitForEvent("close", { timeout }).then(
+        () => false,
+        () => false
+      ),
+    ]);
+  }
+
+  /** True once the consent bubble reports the popup flow completed ("Authorized — retrying…"). */
+  async waitForConsentAuthorized() {
+    await expect(this.consentBubble.getByText(/authorized/i)).toBeVisible({ timeout: Timeouts.LLM_RESPONSE });
+  }
+}

--- a/tests/e2e/pages/welcome/welcome.page.ts
+++ b/tests/e2e/pages/welcome/welcome.page.ts
@@ -19,7 +19,7 @@
  * await welcomePage.verifyOnWelcomeScreen();
  */
 
-import { Page, Locator, Download, Response, expect } from "@playwright/test";
+import { Page, Locator, Response, expect } from "@playwright/test";
 import { ConsoleRoutes } from "../../configs/routes/console-routes";
 import { BasePage } from "../base.page";
 import { Timeouts } from "../../constants/timeouts";
@@ -30,11 +30,14 @@ const WELCOME_DISMISSED_SUFFIX = ":welcome:dismissed";
 /** Suffix of the sessionStorage key that tracks whether the Wayfinder bundle has been imported. */
 const WAYFINDER_CONFIGURED_SUFFIX = ":wayfinder-config-imported";
 
-/** Matches the release asset name WayfinderSampleDownload resolves via useWayfinderReleases. */
-const WAYFINDER_ASSET_NAME_PATTERN = /^sample-app-wayfinder-[0-9A-Za-z.+-]+\.zip$/i;
-
-/** Matches the download link's href: a full URL ending in the asset name above, not the bare name. */
-const WAYFINDER_ASSET_URL_PATTERN = /\/sample-app-wayfinder-[0-9A-Za-z.+-]+\.zip$/i;
+/**
+ * Matches the download link's href: a GitHub release asset URL (see useWayfinderReleases -
+ * `downloadUrl` is GitHub's own `browser_download_url`), with the same version in both the
+ * `/releases/download/v<version>/` path segment and the `sample-app-wayfinder-<version>.zip`
+ * asset name.
+ */
+const WAYFINDER_ASSET_URL_PATTERN =
+  /^https:\/\/github\.com\/[^/]+\/[^/]+\/releases\/download\/v([0-9A-Za-z.+-]+)\/sample-app-wayfinder-\1\.zip$/i;
 
 export class WelcomePage extends BasePage {
   readonly baseUrl: string;
@@ -181,20 +184,13 @@ export class WelcomePage extends BasePage {
   }
 
   /**
-   * Click the wayfinder sample download link and assert a download starts. The link resolves to
-   * a release asset fetched at runtime (see useWayfinderReleases), so this needs live network
-   * access to whatever releasesUrl the app is configured with.
+   * Assert the wayfinder sample download link points at a release asset, without clicking it.
+   * The href resolves to a real release asset URL (see useWayfinderReleases); actually downloading
+   * it in every run just to cancel the download is real network I/O, so we verify the link instead.
    */
-  async triggerDownload(): Promise<Download> {
+  async verifyDownloadLink(): Promise<void> {
     await this.downloadLink.waitFor({ state: "visible", timeout: Timeouts.ELEMENT_VISIBILITY });
     await expect(this.downloadLink).toHaveAttribute("href", WAYFINDER_ASSET_URL_PATTERN);
-
-    const [download] = await Promise.all([
-      this.page.context().waitForEvent("download", { timeout: Timeouts.PAGE_LOAD }),
-      this.downloadLink.click(),
-    ]);
-    expect(download.suggestedFilename()).toMatch(WAYFINDER_ASSET_NAME_PATTERN);
-    return download;
   }
 
   /**

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -83,6 +83,12 @@ const WAYFINDER_TRYOUT_SPECS = ["**/wayfinder/**/*.spec.ts"];
 const MOCK_EMAIL_TRYOUT_SPEC = "**/wayfinder/mock-email-flows.spec.ts";
 
 /**
+ * ai-agent-tryout/** drives the Wayfinder Concierge chat with a real LLM: each spec is a genuine,
+ * billed API call, and LLM output is inherently nondeterministic. Runs chromium-only
+ */
+const AI_AGENT_TRYOUT_SPECS = "**/wayfinder/ai-agent-tryout/**/*.spec.ts";
+
+/**
  * Specs that have possible collisions in the system, and so must not run while
  * anything else is running. They are run in a separate project after all the
  * other specs have finished.
@@ -213,10 +219,21 @@ export default defineConfig({
       testMatch: WAYFINDER_SETUP_SPEC,
       use: { ...devices["Desktop Chrome"] },
     },
+    {
+      name: "wayfinder-ai-agent",
+      testMatch: AI_AGENT_TRYOUT_SPECS,
+      use: { ...devices["Desktop Chrome"] },
+      dependencies: ["wayfinder-setup"],
+      // browse-and-book-with-agent.spec.ts alone chains sign-in plus four LLM round trips and two
+      // OAuth popups in a single test; four Timeouts.LLM_RESPONSE (45s) waits alone already sum to
+      // 180s, leaving no budget for sign-in, the two popups, or other UI actions, so give it a
+      // bigger multiple of LLM_RESPONSE plus that overhead.
+      timeout: 4 * Timeouts.LLM_RESPONSE + 2 * 60 * 1000,
+    },
     ...BROWSERS.map(browser => ({
       name: `${browser.id}-wayfinder-tryout`,
       testMatch: WAYFINDER_TRYOUT_SPECS,
-      testIgnore: [MOCK_EMAIL_TRYOUT_SPEC],
+      testIgnore: [MOCK_EMAIL_TRYOUT_SPEC, AI_AGENT_TRYOUT_SPECS],
       // Run the tryout specs in parallel across browsers, but only after wayfinder-setup has completed
       fullyParallel: true,
       use: { ...browser.device },

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -38,15 +38,24 @@
 # Requirements: curl, jq, python3, pnpm, lsof, unzip
 
 set -euo pipefail
+# Job control, so each "cmd &" below gets its own process group (see kill_job) instead of
+# sharing this script's - without it, killing a group would kill run-e2e.sh itself. Each start
+# is followed by `disown` so job control doesn't also report "Terminated: 15" for it at cleanup;
+# the tracked PID is what kill_job uses, so nothing depends on the job table entry.
+set -m
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 SAMPLE_APP_DIR="$PROJECT_ROOT/samples/apps/react-sdk-sample"
 WAYFINDER_APP_DIR="$PROJECT_ROOT/samples/apps/wayfinder-sample/frontend"
+WAYFINDER_API_DIR="$PROJECT_ROOT/samples/apps/wayfinder-sample/backend"
+WAYFINDER_AGENT_DIR="$PROJECT_ROOT/samples/apps/wayfinder-sample/ai-agent"
 SMTP_SERVER_DIR="$PROJECT_ROOT/samples/apps/wayfinder-sample/smtp-server"
 SERVER_URL="${BASE_URL:-https://localhost:8090}"
 SAMPLE_URL="${SAMPLE_APP_URL:-https://localhost:3000}"
 WAYFINDER_URL="${WAYFINDER_APP_URL:-http://localhost:5173}"
+WAYFINDER_API_URL="${WAYFINDER_API_URL:-http://localhost:8787}"
+WAYFINDER_AGENT_URL="${WAYFINDER_AGENT_URL:-http://localhost:8790}"
 MOCK_SMTP_INBOX_URL="${MOCK_SMTP_INBOX_URL:-http://localhost:8788}"
 # Extracts the port from a URL, falling back to the scheme's default port (443/80) when the URL
 # has none (e.g. a portless override like https://myserver.example.com).
@@ -64,6 +73,8 @@ url_port() {
 SERVER_PORT=$(url_port "$SERVER_URL")
 SAMPLE_PORT=$(url_port "$SAMPLE_URL")
 WAYFINDER_PORT=$(url_port "$WAYFINDER_URL")
+WAYFINDER_API_PORT=$(url_port "$WAYFINDER_API_URL")
+WAYFINDER_AGENT_PORT=$(url_port "$WAYFINDER_AGENT_URL")
 MOCK_SMTP_INBOX_PORT=$(url_port "$MOCK_SMTP_INBOX_URL")
 
 # Pull --phase=1|2 out of the arguments, leaving the rest to pass through to Playwright unchanged.
@@ -102,8 +113,50 @@ ADMIN_USER="${ADMIN_USERNAME:-admin}"
 ADMIN_PASS="${ADMIN_PASSWORD:-admin}"
 ADMIN_TOKEN=""
 
-kill_port() {
-    lsof -ti tcp:"$1" | xargs kill -9 2>/dev/null || true
+# $! of each background server, set right after it's started (see the start_* functions below).
+# Tracking these directly - rather than only discovering them later via lsof on their port -
+# means kill_job can still reap a server that crashed or hung before ever binding its port.
+SERVER_PID=""
+SAMPLE_APP_PID=""
+WAYFINDER_APP_PID=""
+WAYFINDER_API_PID=""
+WAYFINDER_AGENT_PID=""
+MOCK_SMTP_PID=""
+
+# Sends SIGTERM to the given PID's process group (reaping a supervisor like `node --watch`
+# along with the worker it forked, not just the worker), waits up to 5s for it to exit (the Go
+# server and the Wayfinder sample apps all handle SIGTERM), then SIGKILLs anything still standing.
+kill_pgid_of() {
+    local pid="$1" pgid
+    [ -z "$pid" ] && return 0
+    pgid=$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d ' ') || true
+    [ -z "$pgid" ] && pgid="$pid"
+    kill -TERM -- -"$pgid" 2>/dev/null || true
+    local i=0
+    while [ $i -lt 10 ] && kill -0 -- -"$pgid" 2>/dev/null; do
+        sleep 0.5
+        i=$((i + 1))
+    done
+    kill -9 -- -"$pgid" 2>/dev/null || true
+}
+
+# Stops a server we started: its tracked PID (catches it even if it crashed or hung before ever
+# binding its port), then whatever is still listening on the port (catches a stale process left
+# over from an earlier, differently-torn-down run - pid may be empty if we never started it).
+kill_job() {
+    local pid="$1" port="$2" leftover
+    kill_pgid_of "$pid"
+    leftover=$(lsof -ti tcp:"$port" 2>/dev/null | head -1) || true
+    kill_pgid_of "$leftover"
+}
+
+# Reads a single KEY=VALUE line from an .env-style file (ignoring comments), or empty if the file
+# or key is absent. Unlike ADMIN_USERNAME/etc above, the LLM_* vars have no CI export step, so they
+# must be readable straight out of .env - see setup_env below.
+env_file_var() {
+    local key="$1" file="$2"
+    [ -f "$file" ] || return 0
+    grep "^${key}=" "$file" | tail -1 | cut -d= -f2-
 }
 
 wait_for_url() {
@@ -123,10 +176,12 @@ wait_for_url() {
 
 cleanup() {
     echo "Cleaning up..."
-    kill_port "$SAMPLE_PORT"
-    kill_port "$WAYFINDER_PORT"
-    kill_port "$MOCK_SMTP_INBOX_PORT"
-    kill_port "$SERVER_PORT"
+    kill_job "$SAMPLE_APP_PID" "$SAMPLE_PORT"
+    kill_job "$WAYFINDER_APP_PID" "$WAYFINDER_PORT"
+    kill_job "$WAYFINDER_API_PID" "$WAYFINDER_API_PORT"
+    kill_job "$WAYFINDER_AGENT_PID" "$WAYFINDER_AGENT_PORT"
+    kill_job "$MOCK_SMTP_PID" "$MOCK_SMTP_INBOX_PORT"
+    kill_job "$SERVER_PID" "$SERVER_PORT"
     rm -rf "$DIST_HOME"
 }
 trap cleanup EXIT
@@ -172,6 +227,8 @@ EOF
 
     echo "Starting ThunderID server..."
     (cd "$DIST_HOME" && ./start.sh) &
+    SERVER_PID=$!
+    disown
     wait_for_url "$SERVER_URL/health/liveness" "ThunderID server"
 }
 
@@ -179,7 +236,7 @@ EOF
 # start_fresh_server call is not racing an orphaned process still holding the sqlite files.
 stop_server() {
     echo "Stopping ThunderID server..."
-    kill_port "$SERVER_PORT"
+    kill_job "$SERVER_PID" "$SERVER_PORT"
     local i=0
     while curl -skf "$SERVER_URL/health/liveness" > /dev/null 2>&1 && [ $i -lt 30 ]; do
         sleep 1
@@ -355,7 +412,9 @@ start_sample_app() {
         pnpm install --frozen-lockfile
         pnpm run build
     fi
-    pnpm start &
+    pnpm --silent start &
+    SAMPLE_APP_PID=$!
+    disown
     wait_for_url "$SAMPLE_URL" "Sample app"
     cd "$SCRIPT_DIR"
 }
@@ -367,8 +426,47 @@ start_wayfinder_app() {
     cd "$WAYFINDER_APP_DIR"
     [ -f .env ] || cp .env.example .env
     [ -d node_modules ] || npm install
-    npm run dev &
+    npm --silent run dev &
+    WAYFINDER_APP_PID=$!
+    disown
     wait_for_url "$WAYFINDER_URL" "Wayfinder sample app"
+    cd "$SCRIPT_DIR"
+}
+
+# Starts the Wayfinder sample's backend (booking API + MCP server) that the AI agent tryout specs
+# need in addition to the frontend above. Only started when LLM_API_KEY is set - see phase 2 below.
+start_wayfinder_backend() {
+    echo "Setting up Wayfinder backend..."
+    cd "$WAYFINDER_API_DIR"
+    [ -f .env ] || cp .env.example .env
+    [ -d node_modules ] || npm install
+    npm --silent run dev &
+    WAYFINDER_API_PID=$!
+    disown
+    wait_for_url "$WAYFINDER_API_URL/health" "Wayfinder backend"
+    cd "$SCRIPT_DIR"
+}
+
+# Starts the Wayfinder sample's AI agent service. The E2E run owns the agent's LLM config: the
+# LLM_PROVIDER/LLM_API_KEY/MODEL_NAME resolved in setup_env always replace whatever the agent's
+# .env (or .env.example it was copied from) carried. Only called when LLM_API_KEY is set - see
+# phase 2 below.
+start_wayfinder_agent() {
+    echo "Setting up Wayfinder AI agent..."
+    cd "$WAYFINDER_AGENT_DIR"
+    [ -f .env ] || cp .env.example .env
+    grep -vE '^[[:space:]]*#?[[:space:]]*(LLM_PROVIDER|LLM_API_KEY|MODEL_NAME)=' .env > .env.e2e
+    {
+        echo "LLM_PROVIDER=${LLM_PROVIDER}"
+        echo "LLM_API_KEY=${LLM_API_KEY}"
+        echo "MODEL_NAME=${MODEL_NAME}"
+    } >> .env.e2e
+    mv .env.e2e .env
+    [ -d node_modules ] || npm install
+    npm --silent run dev &
+    WAYFINDER_AGENT_PID=$!
+    disown
+    wait_for_url "$WAYFINDER_AGENT_URL/health" "Wayfinder AI agent"
     cd "$SCRIPT_DIR"
 }
 
@@ -382,6 +480,8 @@ start_mock_smtp_server() {
     [ -d node_modules ] || npm install
     npm run build
     node src/index.js &
+    MOCK_SMTP_PID=$!
+    disown
     wait_for_url "$MOCK_SMTP_INBOX_URL/health" "Wayfinder mock SMTP inbox"
     cd "$SCRIPT_DIR"
 }
@@ -400,6 +500,13 @@ setup_env() {
     export ADMIN_PASSWORD="$ADMIN_PASS"
     export SAMPLE_APP_URL="$SAMPLE_URL"
     export WAYFINDER_APP_URL="$WAYFINDER_URL"
+    # Gates whether the Wayfinder AI agent tests run at all (see .env.example); fall back to .env
+    # since, unlike the vars above, it has no CI export step of its own.
+    export LLM_PROVIDER="${LLM_PROVIDER:-$(env_file_var LLM_PROVIDER "$SCRIPT_DIR/.env")}"
+    export LLM_PROVIDER="${LLM_PROVIDER:-anthropic}"
+    export LLM_API_KEY="${LLM_API_KEY:-$(env_file_var LLM_API_KEY "$SCRIPT_DIR/.env")}"
+    # Empty is fine: the agent falls back to its per-provider default model.
+    export MODEL_NAME="${MODEL_NAME:-$(env_file_var MODEL_NAME "$SCRIPT_DIR/.env")}"
 }
 
 # Runs "$@" without tripping `set -e` on a non-zero exit, returning its exit code instead. A
@@ -463,7 +570,7 @@ if [ -z "$PHASE" ] || [ "$PHASE" = "2" ]; then
     if [ -z "$PHASE" ]; then
         # Only phase 1's server/sample-app need tearing down when phase 1 just ran in this
         # invocation - a --phase=2 run never started them.
-        kill_port "$SAMPLE_PORT"
+        kill_job "$SAMPLE_APP_PID" "$SAMPLE_PORT"
         stop_server
     fi
     start_fresh_server
@@ -471,6 +578,25 @@ if [ -z "$PHASE" ] || [ "$PHASE" = "2" ]; then
     import_config "$SCRIPT_DIR/thunderid-config.yaml" "" "E2E admin app"
     start_wayfinder_app
     start_mock_smtp_server
+
+    # The AI agent tryout specs need a real LLM key (see tests/e2e/.env.example); without one,
+    # leave the backend and agent stopped so those specs skip cleanly instead of failing.
+    if [ -n "$LLM_API_KEY" ]; then
+        # Import the Wayfinder bundle now, ahead of wayfinder-sample-setup.spec.ts's own import
+        # step: start_wayfinder_agent makes the agent authenticate against WAYFINDER-CONCIERGE at
+        # startup (before any Playwright test runs), so that client must already exist by then.
+        # The setup spec still re-imports the same (upsert:true) bundle through the console UI
+        # later - that's what actually tests the import feature itself, and it is what every other
+        # @wayfinder spec depends on (see the wayfinder-setup project in playwright.config.ts), so
+        # nothing here is needed when the agent does not start.
+        import_config "$PROJECT_ROOT/samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid-config.yaml" \
+            "$PROJECT_ROOT/samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid.env" \
+            "Wayfinder sample"
+        start_wayfinder_backend
+        start_wayfinder_agent
+    else
+        echo "LLM_API_KEY not set - skipping Wayfinder AI agent tryout tests."
+    fi
 
     # Own report paths, or this phase's run would delete phase 1's reports and traces outright.
     echo "Running Playwright E2E tests (wayfinder)..."

--- a/tests/e2e/tests/wayfinder/ai-agent-tryout/browse-and-book-with-agent.spec.ts
+++ b/tests/e2e/tests/wayfinder/ai-agent-tryout/browse-and-book-with-agent.spec.ts
@@ -1,0 +1,135 @@
+/* eslint-disable playwright/require-top-level-describe */
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Wayfinder AI Agent Tryout - Browse and Book with Agent E2E Tests
+ *
+ * Mirrors docs/content/use-cases/ai-agents/try-it-out/act-on-its-own.mdx and
+ * act-on-behalf-of-user.mdx as one continuous chat session (the agent keeps conversation state
+ * keyed by session_id): the concierge first answers browsing questions using its own M2M token
+ * against the booking API's MCP tools (no user consent required), then, in the same session,
+ * booking a flight mutates the user's record, so the agent pauses for consent: an in-chat bubble
+ * names the requested `booking:*` scope, and a popup asks the user to re-authenticate before the
+ * booking completes on a delegated (OBO) token. Both walkthroughs share the same sign-in and
+ * first chat message, so they run as steps of a single test rather than as separate ones.
+ *
+ * This spec must run after wayfinder-sample-setup.spec.ts has imported the Wayfinder bundle - see
+ * ../../b2c-tryout/authentication.spec.ts's header - and needs the Wayfinder AI agent service
+ * actually running, which run-e2e.sh only starts when a real LLM key is configured (see
+ * tests/e2e/.env.example) - skipped entirely otherwise.
+ *
+ * LLM output is not deterministic: the tool-choice steps below (asking for flights, then asking to
+ * book) rely on the agent recognising a mutating request and returning `need_user_consent`, per
+ * the doc walkthrough; assertions otherwise only check that a reply arrived and loosely matches
+ * the topic asked about, not any exact wording.
+ *
+ * Required environment variables:
+ * - WAYFINDER_APP_URL: URL of the running Wayfinder sample app (e.g. http://localhost:5173)
+ * - LLM_API_KEY: API key for the configured LLM provider (see tests/e2e/.env.example)
+ */
+
+import { test, expect } from "@playwright/test";
+import { WayfinderAppPage, WayfinderChatPage } from "../../../pages/wayfinder-sample";
+import { TestTags } from "../../../constants/test-tags";
+
+const wayfinderUrl = process.env.WAYFINDER_APP_URL;
+
+// Seed user shipped with the Wayfinder bundle - see
+// samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid.env
+const JOHN_USERNAME = "john.doe";
+const JOHN_PASSWORD = "john.doe";
+
+// The AI agent needs a real LLM; run-e2e.sh only starts it when LLM_API_KEY is set, so skip
+// entirely otherwise (see tests/e2e/.env.example).
+const describeOrSkip = wayfinderUrl && process.env.LLM_API_KEY ? test.describe : test.describe.skip;
+
+describeOrSkip("Wayfinder AI Agent Tryout - Browse and Book with Agent", { tag: [TestTags.WAYFINDER] }, () => {
+  test("TC001: Browse flights with the concierge's own token, then book one with delegated consent", async ({
+    page,
+  }) => {
+    const wayfinderPage = new WayfinderAppPage(page);
+    const chatPage = new WayfinderChatPage(page);
+    let beforeConsent = 0;
+
+    await test.step("Sign in as john.doe", async () => {
+      await wayfinderPage.goto(wayfinderUrl!);
+      await wayfinderPage.verifyUnAuthenticatedHomePageLoaded();
+      await wayfinderPage.clickSignInButton();
+      await wayfinderPage.verifyLoginPageLoaded();
+      await wayfinderPage.login(JOHN_USERNAME, JOHN_PASSWORD);
+      await wayfinderPage.verifyLoggedIn();
+    });
+
+    await test.step("Ask for flights from Colombo to Singapore", async () => {
+      await chatPage.open();
+      const before = await chatPage.assistantMessageCount();
+      // First chat message of the session: no chat-access token is cached yet, so sending it
+      // drives chatTokenService's own OAuth popup - see sendFirstMessage()'s doc comment.
+      await chatPage.sendFirstMessage(
+        "What flights are there from Colombo to Singapore?",
+        JOHN_USERNAME,
+        JOHN_PASSWORD
+      );
+      await chatPage.waitForAssistantReply(before);
+      await expect(chatPage.assistantMessages.last()).toContainText(/colombo|singapore|flight/i);
+    });
+
+    // Regression check for the bug this suite guards against: browsing must never trigger a
+    // second, mid-conversation auth popup - only the "act on behalf of user" (OBO) booking flow
+    // below may. The chat-access token acquired above is cached for the rest of the session, so
+    // this follow-up message should need no popup of its own.
+    let popupOpened = false;
+    page.on("popup", () => {
+      popupOpened = true;
+    });
+
+    await test.step("Ask for flight deal recommendations", async () => {
+      const before = await chatPage.assistantMessageCount();
+      await chatPage.sendMessage("Suggest a few flight deals.");
+      await chatPage.waitForAssistantReply(before);
+      const reply = await chatPage.lastAssistantMessage();
+      expect(reply.trim().length).toBeGreaterThan(0);
+    });
+
+    expect(popupOpened).toBe(false);
+
+    await test.step("Ask to book a flight and receive a consent request", async () => {
+      beforeConsent = await chatPage.assistantMessageCount();
+      await chatPage.sendMessage("Book flight 2");
+      await chatPage.waitForConsentRequest();
+      // The agent's response to a mutating request isn't plain text - it's the in-chat consent
+      // bubble (ConsentRequestBubble in App.jsx), pausing for an explicit "Authorize" click before
+      // the OAuth popup for the delegated token ever opens.
+      await expect(chatPage.consentBubble).toContainText(
+        "This action needs your permission. Sign in to authorize the assistant to act on your behalf."
+      );
+      await expect(chatPage.consentBubble).toContainText(/Scope requested:.*booking/);
+      await expect(chatPage.consentAuthorizeButton).toBeVisible();
+      await expect(chatPage.consentNotNowButton).toBeVisible();
+    });
+
+    await test.step("Authorize the booking by signing in and granting permissions in the popup", async () => {
+      // The popup re-authenticates (skipped if there's an active gate SSO session) and then always
+      // shows the gate's own OAuth permission-approval screen, which completeConsentAuthorization()
+      // grants before the popup closes itself.
+      const popup = await chatPage.authorizeConsentAndGetPopup();
+      await chatPage.completeConsentAuthorization(popup, JOHN_USERNAME, JOHN_PASSWORD);
+      await chatPage.waitForConsentAuthorized();
+    });
+
+    await test.step("Verify the booking is confirmed in chat", async () => {
+      // The agent auto-retries the pending "Book flight 2" message once the OBO token lands (see
+      // App.jsx's postMessage handler), appending a new assistant reply.
+      await chatPage.waitForAssistantReply(beforeConsent);
+      const reply = await chatPage.lastAssistantMessage();
+      // create_booking's result is always rendered from the "Booking WF-XXXXXXXX (confirmed)"
+      // template (see wayfinder-sample/ai-agent/agent.ts's system prompt and
+      // backend/src/mcp.js's generateBookingReference) - the route/airline/price that follow vary
+      // with whichever flight deal "flight 2" resolved to, so only the reference format and
+      // confirmation wording are pinned here, not those non-deterministic specifics.
+      expect(reply).toMatch(/booking\s+wf-[0-9a-f]{8}/i);
+      expect(reply).toMatch(/confirmed/i);
+    });
+  });
+});

--- a/tests/e2e/tests/wayfinder/ai-agent-tryout/protect-the-agent.spec.ts
+++ b/tests/e2e/tests/wayfinder/ai-agent-tryout/protect-the-agent.spec.ts
@@ -1,0 +1,103 @@
+/* eslint-disable playwright/require-top-level-describe */
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Wayfinder AI Agent Tryout - Protect the Agent E2E Tests
+ *
+ * Mirrors docs/content/use-cases/ai-agents/try-it-out/protect-the-agent.mdx: `john.doe` holds the
+ * `agent:access` permission (via the `Chat User` role) and can use the Wayfinder Concierge chat;
+ * `jane.smith` does not and is rejected with a 403.
+ *
+ * This spec must run after wayfinder-sample-setup.spec.ts has imported the Wayfinder bundle (the
+ * seed users only exist afterward - enforced structurally by the wayfinder-setup -> wayfinder-tryout
+ * project dependency in playwright.config.ts, same as ../../b2c-tryout/authentication.spec.ts) and
+ * needs the Wayfinder AI agent service actually running, which run-e2e.sh only starts when a real
+ * LLM key is configured (see tests/e2e/.env.example) - skipped entirely otherwise.
+ *
+ * Required environment variables:
+ * - WAYFINDER_APP_URL: URL of the running Wayfinder sample app (e.g. http://localhost:5173)
+ * - LLM_API_KEY: API key for the configured LLM provider (see tests/e2e/.env.example)
+ */
+
+import { test, expect } from "@playwright/test";
+import { WayfinderAppPage, WayfinderChatPage } from "../../../pages/wayfinder-sample";
+import { TestTags } from "../../../constants/test-tags";
+import { Timeouts } from "../../../constants/timeouts";
+
+const wayfinderUrl = process.env.WAYFINDER_APP_URL;
+
+// Seed users shipped with the Wayfinder bundle - see
+// samples/apps/wayfinder-sample/thunderid-config/redirect/thunderid.env
+const JOHN_USERNAME = "john.doe";
+const JOHN_PASSWORD = "john.doe";
+const JANE_USERNAME = "jane.smith";
+const JANE_PASSWORD = "jane.smith";
+
+// The AI agent needs a real LLM; run-e2e.sh only starts it when LLM_API_KEY is set, so skip
+// entirely otherwise (see tests/e2e/.env.example).
+const describeOrSkip = wayfinderUrl && process.env.LLM_API_KEY ? test.describe : test.describe.skip;
+
+describeOrSkip("Wayfinder AI Agent Tryout - Protect the Agent", { tag: [TestTags.WAYFINDER] }, () => {
+  test("TC001: john.doe holds agent:access and receives a reply from the concierge", async ({ page }) => {
+    const wayfinderPage = new WayfinderAppPage(page);
+    const chatPage = new WayfinderChatPage(page);
+
+    await test.step("Sign in as john.doe", async () => {
+      await wayfinderPage.goto(wayfinderUrl!);
+      await wayfinderPage.verifyUnAuthenticatedHomePageLoaded();
+      await wayfinderPage.clickSignInButton();
+      await wayfinderPage.verifyLoginPageLoaded();
+      await wayfinderPage.login(JOHN_USERNAME, JOHN_PASSWORD);
+      await wayfinderPage.verifyLoggedIn();
+    });
+
+    await test.step("Open the chat and send a message", async () => {
+      await chatPage.open();
+      const before = await chatPage.assistantMessageCount();
+      // First chat message of the session: no chat-access token is cached yet, so sending it
+      // drives chatTokenService's own OAuth popup - see sendFirstMessage()'s doc comment.
+      await chatPage.sendFirstMessage("Hello, can you help me?", JOHN_USERNAME, JOHN_PASSWORD);
+      await chatPage.waitForAssistantReply(before);
+    });
+
+    await test.step("Verify a reply arrived", async () => {
+      const reply = await chatPage.lastAssistantMessage();
+      expect(reply.trim().length).toBeGreaterThan(0);
+    });
+  });
+
+  test("TC002: jane.smith lacks agent:access and is rejected", async ({ page }) => {
+    const wayfinderPage = new WayfinderAppPage(page);
+    const chatPage = new WayfinderChatPage(page);
+
+    await test.step("Sign in as jane.smith", async () => {
+      await wayfinderPage.goto(wayfinderUrl!);
+      await wayfinderPage.verifyUnAuthenticatedHomePageLoaded();
+      await wayfinderPage.clickSignInButton();
+      await wayfinderPage.verifyLoginPageLoaded();
+      await wayfinderPage.login(JANE_USERNAME, JANE_PASSWORD);
+      await wayfinderPage.verifyLoggedIn();
+    });
+
+    await test.step("Open the chat and verify it is rejected", async () => {
+      // No chat-access token is cached yet, so ChatWidgetCore's checkAccess effect (which only
+      // ever looks at a cached token) no-ops on open - the rejection only surfaces once Jane
+      // actually sends a message: that drives the same interactive OAuth popup John went through
+      // (the scope reduction to "none of agent:access" happens silently server-side), and the
+      // /chat request made with that token comes back with the 403 error below.
+      await chatPage.open();
+      await chatPage.sendFirstMessage("Hello, can you help me?", JANE_USERNAME, JANE_PASSWORD);
+      await expect(chatPage.assistantMessages.last()).toContainText(
+        "You do not have permission to access Wayfinder Concierge — missing required scope: agent:access",
+        { timeout: Timeouts.LLM_RESPONSE }
+      );
+
+      // The token from that popup is now cached (just scoped short of agent:access), so
+      // reopening the panel re-runs checkAccess against it - see reopen()'s doc comment - which
+      // is what actually flips the composer into its disabled "Chat unavailable" state.
+      await chatPage.reopen();
+      await chatPage.expectChatUnavailable();
+    });
+  });
+});

--- a/tests/e2e/tests/welcome/wayfinder-sample-setup.spec.ts
+++ b/tests/e2e/tests/welcome/wayfinder-sample-setup.spec.ts
@@ -100,6 +100,7 @@ const RESOURCE_MANIFEST: Array<{
     expected: [
       "Wayfinder Registration Flow",
       "Wayfinder Password Recovery Flow",
+      "Wayfinder Sign Out Flow",
       "Wayfinder Staff Onboarding Flow",
       "Default Wayfinder CIBA Email Notification Flow",
       "Default Wayfinder CIBA SMS Notification Flow",
@@ -127,17 +128,15 @@ test.describe("Wayfinder Sample Setup", { tag: [TestTags.WAYFINDER] }, () => {
       });
     });
 
-    /** TC002: Download button downloads the Wayfinder sample */
-    test("TC002: Download button downloads the Wayfinder sample", async ({ welcomePage }) => {
+    /** TC002: Download button links to the Wayfinder sample release asset */
+    test("TC002: Download button links to the Wayfinder sample release asset", async ({ welcomePage }) => {
       await test.step("Open the setup card", async () => {
         await welcomePage.gotoTryoutApp();
         await welcomePage.expandSetupCardIfCollapsed();
       });
 
-      await test.step("Trigger the download and verify it starts", async () => {
-        const download = await welcomePage.triggerDownload();
-        console.log("Download suggested filename:", download.suggestedFilename());
-        await download.cancel().catch(() => {});
+      await test.step("Verify the download link points at the sample release asset", async () => {
+        await welcomePage.verifyDownloadLink();
       });
     });
 


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

Adds E2E coverage for the Wayfinder Concierge AI agent, verifying the three walkthroughs in
`docs/content/use-cases/ai-agents/try-it-out/`:

- The concierge answers browsing questions on its own M2M token via the booking API's MCP tools,
  then pauses for consent on a mutating request and completes the booking on a delegated token.
- `john.doe` holds `agent:access` and can chat; `jane.smith` does not and gets a 403.

Running these surfaced two real defects in the Wayfinder sample, fixed here: both the agent's
consent handler and the app's OAuth callback routes could redeem the same single-use code twice.


<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

**Tests**

- `tests/wayfinder/ai-agent-tryout/browse-and-book-with-agent.spec.ts` runs both booking
  walkthroughs as one test, since the agent keys conversation state by `session_id`.
- `tests/wayfinder/ai-agent-tryout/protect-the-agent.spec.ts` covers the permitted and rejected users.
- `pages/wayfinder-sample/wayfinder-chat.page.ts` drives the widget, consent bubble, and OAuth popup.
- LLM output is nondeterministic, so assertions check that a reply arrived, loosely matches the
  topic, and that a mutating request yields `need_user_consent`. No exact wording.
- New `wayfinder-ai-agent` project: chromium only (calls are billed), serial, depends on
  `wayfinder-setup`, 3 minute timeout. Plus `Timeouts.LLM_RESPONSE` and `POST_LOAD_PROBE`.

**Provisioning**

- `run-e2e.sh` phase 2 starts the Wayfinder backend (`:8787`) and AI agent (`:8790`), and imports
  the Wayfinder bundle first so `WAYFINDER-CONCIERGE` exists before the agent authenticates.
- The E2E `.env` is the one place the LLM is configured: `LLM_PROVIDER`, `LLM_API_KEY`, and
  `MODEL_NAME` are written into the agent's `.env`, overwriting whatever is there.
- All gated on `LLM_API_KEY`: without it nothing extra starts, the specs skip, and the rest of
  phase 2 is unaffected. `pr-builder.yml` mirrors the gate on the `PLAYWRIGHT_LLM_API_KEY` secret,
  so forked PRs skip these tests and bill nothing.
- Teardown now tracks each server's PID and SIGTERMs its process group. The old port based kill left
  `node --watch` supervisors behind, which respawned their workers.

**Fixes**

- `agent.ts`: `handleConsent` claims the pending consent before awaiting the token exchange, and
  restores it if the exchange fails.
- `App.jsx`: both callback routes post the code once, since StrictMode ran the effect twice.
- `TC002` asserts the download link's href instead of triggering a real download.
- `RESOURCE_MANIFEST` expects `Wayfinder Sign Out Flow`.

### Related Issues
- Closes #5071

### Related PRs
Merge after these PRs.
- #5028 
- Depends on #5026 
- Depends on #5058 

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI-agent chat coverage for flight browsing, recommendations, booking, consent, authorization, and access permissions.
  * Added optional LLM provider, API key, and model configuration for end-to-end testing.
* **Bug Fixes**
  * Prevented duplicate OAuth code redemption and concurrent authorization-code reuse.
  * Restored authorization requests when token exchange fails.
* **Documentation**
  * Documented local and CI setup, secret handling, and test skip behavior.
* **Tests**
  * Added comprehensive Wayfinder chat workflows.
  * Download checks now validate release links without initiating downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->