### PR TITLE
Fix flow text resolution in UserAddPage and UserCreatePage

### DIFF
--- a/frontend/packages/configure-users/src/hooks/__tests__/useFlowTextResolver.test.ts
+++ b/frontend/packages/configure-users/src/hooks/__tests__/useFlowTextResolver.test.ts
@@ -1,0 +1,86 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {renderHook} from '@testing-library/react';
+import {useTranslation} from 'react-i18next';
+import {describe, it, expect, vi, beforeAll, beforeEach} from 'vitest';
+import useFlowTextResolver from '../useFlowTextResolver';
+
+const mockMeta: {value: unknown} = {value: null};
+
+vi.mock('@thunderid/react', async (importOriginal) => {
+  const actual = await importOriginal();
+
+  return {
+    ...(actual as object),
+    useThunderID: () => ({meta: mockMeta.value}),
+  };
+});
+
+describe('useFlowTextResolver', () => {
+  beforeAll(() => {
+    // Mirrors what the Console's I18nProvider does with the payload of
+    // `GET /i18n/languages/{language}/translations/resolve`: one i18next namespace per
+    // server namespace, holding flat dot-joined keys.
+    const {result} = renderHook(() => useTranslation());
+    result.current.i18n.addResourceBundle(
+      'en-US',
+      'onboarding',
+      {'forms.add_user.title': 'Add User Details'},
+      true,
+      true,
+    );
+  });
+
+  beforeEach(() => {
+    mockMeta.value = null;
+  });
+
+  it('resolves a flow translation literal against the Console i18next bundle', () => {
+    const {result} = renderHook(() => useFlowTextResolver());
+
+    expect(result.current('{{ t(onboarding:forms.add_user.title) }}')).toBe('Add User Details');
+  });
+
+  it('resolves literals embedded in surrounding text', () => {
+    const {result} = renderHook(() => useFlowTextResolver());
+
+    expect(result.current('Step: {{ t(onboarding:forms.add_user.title) }}')).toBe('Step: Add User Details');
+  });
+
+  it('does not resolve when the namespace separator is lost', () => {
+    const {result} = renderHook(() => useFlowTextResolver());
+
+    // Guards the dot-to-colon mapping: without it i18next looks the dotted key up in the
+    // default namespace and misses, which is the #4755 symptom.
+    const {result: i18nResult} = renderHook(() => useTranslation());
+    expect(i18nResult.current.t('onboarding.forms.add_user.title')).toBe('onboarding.forms.add_user.title');
+    expect(result.current('{{ t(onboarding:forms.add_user.title) }}')).not.toBe('onboarding.forms.add_user.title');
+  });
+
+  it('returns undefined for empty input', () => {
+    const {result} = renderHook(() => useFlowTextResolver());
+
+    expect(result.current(undefined)).toBeUndefined();
+    expect(result.current('')).toBeUndefined();
+  });
+
+  it('leaves plain text untouched', () => {
+    const {result} = renderHook(() => useFlowTextResolver());
+
+    expect(result.current('Add User')).toBe('Add User');
+  });
+
+  it('resolves meta literals when flow metadata is available', () => {
+    mockMeta.value = {application: {name: 'My App'}};
+    const {result} = renderHook(() => useFlowTextResolver());
+
+    expect(result.current('Sign in to {{ meta(application.name) }}')).toBe('Sign in to My App');
+  });
+
+  it('leaves meta literals untouched when flow metadata is absent', () => {
+    const {result} = renderHook(() => useFlowTextResolver());
+
+    expect(result.current('{{ meta(application.name) }}')).toBe('{{ meta(application.name) }}');
+  });
+});

--- a/frontend/packages/configure-users/src/hooks/useFlowTextResolver.ts
+++ b/frontend/packages/configure-users/src/hooks/useFlowTextResolver.ts
@@ -1,0 +1,35 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {resolveFlowTemplateLiterals, useThunderID} from '@thunderid/react';
+import {useCallback} from 'react';
+import {useTranslation} from 'react-i18next';
+
+/**
+ * Resolves `{{ t(...) }}` and `{{ meta(...) }}` literals carried by flow-rendered components.
+ *
+ * Flow labels are authored server side, so the Console cannot ship default values for them.
+ * They are resolved against the Console's own i18next instance, which already loads every
+ * namespace from `GET /i18n/languages/{language}/translations/resolve` on start up. That keeps
+ * these labels working regardless of whether the SDK's `GET /flow/meta` bootstrap call ran.
+ *
+ * Parsing stays with the SDK resolver so both literal forms, and any added later, behave the
+ * same here as they do in the sign-in gate. Only the translation lookup differs: the SDK emits
+ * dot-separated keys (`onboarding.forms.x`), while i18next is configured with
+ * `keySeparator: false` and expects the namespace to be colon separated (`onboarding:forms.x`).
+ */
+export default function useFlowTextResolver(): (text?: string) => string | undefined {
+  const {meta} = useThunderID();
+  const {t} = useTranslation();
+
+  return useCallback(
+    (text?: string): string | undefined =>
+      text
+        ? resolveFlowTemplateLiterals(text, {
+            meta,
+            t: (key: string): string => t(key.replace('.', ':')),
+          })
+        : undefined,
+    [meta, t],
+  );
+}

--- a/frontend/packages/configure-users/src/pages/UserAddPage.tsx
+++ b/frontend/packages/configure-users/src/pages/UserAddPage.tsx
@@ -10,7 +10,6 @@ import {
   EmbeddedFlowComponentType,
   EmbeddedFlowEventType,
   InviteUser,
-  useThunderID,
   type EmbeddedFlowComponent,
   type InviteUserRenderProps,
 } from '@thunderid/react';
@@ -42,6 +41,7 @@ import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
 import {z} from 'zod';
 import CredentialFieldInput from '../components/CredentialFieldInput';
+import useFlowTextResolver from '../hooks/useFlowTextResolver';
 import useUserRoutes from '../hooks/useUserRoutes';
 import getUserErrorMessage from '../utils/getUserErrorMessage';
 
@@ -178,8 +178,7 @@ function InviteUserStepContent({
     resetFlow,
     isValid: propsIsValid,
   } = renderProps;
-  const {resolveFlowTemplateLiterals: rawResolve} = useThunderID();
-  const resolve = useCallback((text?: string) => (text ? rawResolve(text) : undefined), [rawResolve]);
+  const resolve = useFlowTextResolver();
   const {t} = useTranslation();
   const [activeActionId, setActiveActionId] = useState<string | null>(null);
 
@@ -953,8 +952,7 @@ function InviteUserFlowBridge({
   onClearFlowError: () => void;
   onResetFlowAvailable?: (resetFn: () => void) => void;
 }): JSX.Element {
-  const {resolveFlowTemplateLiterals: rawResolve} = useThunderID();
-  const resolve = useCallback((text?: string) => (text ? rawResolve(text) : undefined), [rawResolve]);
+  const resolve = useFlowTextResolver();
   const {t} = useTranslation();
   const components = renderProps.components as EmbeddedFlowComponent[] | undefined;
 

--- a/frontend/packages/configure-users/src/pages/UserCreatePage.tsx
+++ b/frontend/packages/configure-users/src/pages/UserCreatePage.tsx
@@ -7,7 +7,6 @@ import {useLogger} from '@thunderid/logger/react';
 import {
   EmbeddedFlowComponentType,
   InviteUser,
-  useThunderID,
   type EmbeddedFlowComponent,
   type InviteUserRenderProps,
 } from '@thunderid/react';
@@ -29,6 +28,7 @@ import type {JSX} from 'react';
 import {useState, useCallback, useEffect, useRef} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'react-router';
+import useFlowTextResolver from '../hooks/useFlowTextResolver';
 import useUserRoutes from '../hooks/useUserRoutes';
 import getUserErrorMessage from '../utils/getUserErrorMessage';
 
@@ -68,8 +68,7 @@ function UserCreateStepContent({
   onFieldChange: () => void;
   onStepLabelChange: (label: string) => void;
 }): JSX.Element {
-  const {resolveFlowTemplateLiterals: rawResolve} = useThunderID();
-  const resolve = useCallback((text?: string) => (text ? rawResolve(text) : undefined), [rawResolve]);
+  const resolve = useFlowTextResolver();
   const {t} = useTranslation();
   const components = renderProps.components as EmbeddedFlowComponent[] | undefined;
 


### PR DESCRIPTION
### Purpose

This pull request introduces a new `useFlowTextResolver` hook to centralize and improve the resolution of template literals (such as `{{ t(...) }}` and `{{ meta(...) }}`) in flow-rendered component labels. The hook ensures that translations are correctly resolved against the Console's i18next instance, addressing previous issues with namespace handling. All usages of the previous resolver are updated to use this new hook, and comprehensive tests are added.

---

### Approach

**New hook and test coverage:**

* Added a new `useFlowTextResolver` hook in `hooks/useFlowTextResolver.ts` to resolve flow template literals using the Console's i18next instance, handling both translations and metadata.
* Added thorough unit tests for `useFlowTextResolver` covering translation resolution, meta literal handling, and edge cases.

**Refactoring and integration:**

* Replaced all usages of the previous `resolveFlowTemplateLiterals` resolver in both `UserAddPage.tsx` and `UserCreatePage.tsx` with the new `useFlowTextResolver` hook, simplifying the code and improving consistency. [[1]](diffhunk://#diff-a071b19647cbf3eb1ae2059ec96d2a396d0449987b7d7383247c69ccd224af10L181-R181) [[2]](diffhunk://#diff-a071b19647cbf3eb1ae2059ec96d2a396d0449987b7d7383247c69ccd224af10L956-R955) [[3]](diffhunk://#diff-984aae064cf29a995d9be8011657e249799a737aca554826e0b2e524dbdd64ccL71-R71)
* Updated imports in affected files to remove unused `useThunderID` and include the new hook. [[1]](diffhunk://#diff-a071b19647cbf3eb1ae2059ec96d2a396d0449987b7d7383247c69ccd224af10L13) [[2]](diffhunk://#diff-a071b19647cbf3eb1ae2059ec96d2a396d0449987b7d7383247c69ccd224af10R44) [[3]](diffhunk://#diff-984aae064cf29a995d9be8011657e249799a737aca554826e0b2e524dbdd64ccL10) [[4]](diffhunk://#diff-984aae064cf29a995d9be8011657e249799a737aca554826e0b2e524dbdd64ccR31)

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4755

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added shared resolution for flow labels, placeholders, and other text using onboarding translations and embedded literals.
  - Improved support for translation keys, namespace separators, plain text, and empty values across user creation flows.
  - Standardized text handling across user addition and creation experiences.

- **Bug Fixes**
  - Ensured flow text resolves consistently when metadata is available or missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->