### PR TITLE
Force-push forward-port branch to survive reruns

### DIFF
--- a/.github/workflows/forward-port-pr.yml
+++ b/.github/workflows/forward-port-pr.yml
@@ -100,7 +100,7 @@ jobs:
           done
           set -e
 
-          git push origin "${FORWARD_BRANCH}"
+          git push --force origin "${FORWARD_BRANCH}"
 
           {
             echo "forward_branch=${FORWARD_BRANCH}"


### PR DESCRIPTION
### Purpose
The forward-port workflow always cuts a fresh local branch from `origin/main` and cherry-picks the source PR's commits onto it. If a prior run pushed the branch and then failed at a later step (e.g. the `pulls.create` call), the remote branch `forward-port/<src>/pr-<N>` sticks around.

On rerun, the fresh cherry-pick produces the same tree but a different commit SHA (committer timestamp is part of the hash), so `git push origin` is rejected as non-fast-forward and the run fails at the push step.

This blocked the rerun of run [32147056486](https://github.com/thunder-id/thunderid/actions/runs/32147056486/job/95766887327) after the earlier PR-creation failure left a stale `forward-port/1.0.x/pr-5049` branch on the remote.

### Approach
Change the branch push to `git push --force`. These `forward-port/<src>/pr-<N>` branches are unique per source PR and wholly owned by the automation, so overwriting is safe. Reruns of the same event will always land the latest cherry-pick.

### Related Issues
- N/A

### Related PRs
- #5077

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided.
- [ ] Tests provided.
- [ ] Breaking changes.

### Security checks
- [x] Followed secure coding standards.
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.