### PR TITLE
added handling of direct jwt response from authnprovider

### DIFF
--- a/backend/internal/flow/executor/auth_assert_executor.go
+++ b/backend/internal/flow/executor/auth_assert_executor.go
@@ -441,6 +441,12 @@ func (a *authAssertExecutor) resolveUserAttributes(
 	fetchedAttributes map[string]interface{},
 	userID, userType, ouID string,
 ) (map[string]interface{}, error) {
+	// An opaque JWT/JWE from the authn provider is passed through as-is, bypassing the
+	// requested-attributes allow-list: it isn't an individual claim to filter, it's the whole payload.
+	if rawJWT, ok := fetchedAttributes[providers.RawJWTAttributeKey]; ok {
+		return map[string]interface{}{providers.RawJWTAttributeKey: rawJWT}, nil
+	}
+
 	if len(requestedAttributes) == 0 {
 		return nil, nil
 	}

--- a/backend/internal/flow/executor/auth_assert_executor_test.go
+++ b/backend/internal/flow/executor/auth_assert_executor_test.go
@@ -1372,6 +1372,28 @@ func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_WithOUDetail
 	suite.mockOUService.AssertNotCalled(suite.T(), "GetOrganizationUnit")
 }
 
+// TestResolveUserAttributes_RawJWT_BypassesRequestedAttributesAllowList verifies that an opaque
+// JWT/JWE returned by the identity system (the `_jwt` pseudo-claim) is passed through as the sole
+// result, even though it is never itself a requested attribute and requestedAttributes is empty.
+func (suite *AuthAssertExecutorTestSuite) TestResolveUserAttributes_RawJWT_BypassesRequestedAttributesAllowList() {
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		Context:     context.Background(),
+		RuntimeData: map[string]string{},
+	}
+
+	fetchedAttributes := map[string]interface{}{
+		providers.RawJWTAttributeKey: "header.payload.signature",
+	}
+
+	attrs, err := suite.executor.resolveUserAttributes(ctx, nil, fetchedAttributes, "user-123", "", "")
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), map[string]interface{}{
+		providers.RawJWTAttributeKey: "header.payload.signature",
+	}, attrs)
+}
+
 // ----- Execute with Attribute Cache: groups/userType/OU now go into cache -----
 
 func (suite *AuthAssertExecutorTestSuite) TestExecute_WithAttributeCache_GroupsIncludedInCache() {

--- a/backend/internal/oauth/oauth2/tokenservice/utils.go
+++ b/backend/internal/oauth/oauth2/tokenservice/utils.go
@@ -247,6 +247,11 @@ func FetchUserAttributes(
 
 	// Helper to check if a claim should be included
 	shouldInclude := func(claimName string) bool {
+		// An opaque JWT/JWE from the identity system is not a configured claim, so it is never
+		// gated by the allow-list.
+		if claimName == providers.RawJWTAttributeKey {
+			return true
+		}
 		if len(allowedClaims) == 0 {
 			return false // Only add special claims if explicitly allowed
 		}

--- a/backend/internal/oauth/oauth2/tokenservice/utils_test.go
+++ b/backend/internal/oauth/oauth2/tokenservice/utils_test.go
@@ -427,6 +427,28 @@ func (suite *UtilsTestSuite) TestFetchUserAttributes_EmptyAllowedClaims() {
 	mockAttrCacheService.AssertExpectations(suite.T())
 }
 
+func (suite *UtilsTestSuite) TestFetchUserAttributes_RawJWTIncludedRegardlessOfAllowedClaims() {
+	mockAttrCacheService := attributecachemock.NewAttributeCacheServiceInterfaceMock(suite.T())
+
+	// Mock GetAttributeCache to return a cache holding only the opaque JWT pseudo-claim
+	mockAttrCacheService.On("GetAttributeCache", mock.Anything, "cache-key-123").
+		Return(&attributecache.AttributeCache{
+			ID: "cache-key-123",
+			Attributes: map[string]interface{}{
+				providers.RawJWTAttributeKey: "header.payload.signature",
+			},
+		}, nil)
+
+	// Empty allowedClaims — _jwt is not a configured claim, so it must still come through
+	attrs, err := FetchUserAttributes(context.Background(), mockAttrCacheService,
+		[]string{}, "cache-key-123")
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "header.payload.signature", attrs[providers.RawJWTAttributeKey])
+
+	mockAttrCacheService.AssertExpectations(suite.T())
+}
+
 func (suite *UtilsTestSuite) TestFetchUserAttributes_NilAllowedClaims() {
 	mockAttrCacheService := attributecachemock.NewAttributeCacheServiceInterfaceMock(suite.T())
 

--- a/backend/internal/oauth/oauth2/userinfo/service.go
+++ b/backend/internal/oauth/oauth2/userinfo/service.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"slices"
+	"strings"
 
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 
@@ -183,16 +184,22 @@ func (s *userInfoService) buildResponseFromClaims(
 		return nil, &tidcommon.InternalServerError
 	}
 
-	response, svcErr := s.buildUserInfoResponse(ctx, sub, scopes, userAttributes, oauthApp, tokenClaims)
-	if svcErr != nil {
-		return nil, svcErr
-	}
-
 	var userInfoCfg *providers.UserInfoConfig
 	var certificate *providers.Certificate
 	if oauthApp != nil {
 		userInfoCfg = oauthApp.UserInfo
 		certificate = oauthApp.Certificate
+	}
+
+	// The authn provider returned an opaque JWT/JWE instead of individual claims: pass it
+	// through as-is rather than running it through the claims/scope/allow-list pipeline.
+	if rawToken, ok := userAttributes[providers.RawJWTAttributeKey].(string); ok && rawToken != "" {
+		return s.buildRawJWTResponse(ctx, rawToken, userInfoCfg, certificate)
+	}
+
+	response, svcErr := s.buildUserInfoResponse(ctx, sub, scopes, userAttributes, oauthApp, tokenClaims)
+	if svcErr != nil {
+		return nil, svcErr
 	}
 
 	responseType := providers.UserInfoResponseTypeJSON
@@ -260,14 +267,30 @@ func (s *userInfoService) generateNestedJWTUserInfo(
 		return nil, svcErr
 	}
 
-	rpKey, rpKID, svcErr := s.jwksResolver.ResolveEncryptionKey(
-		ctx, certificate, cfg.EncryptionAlg, jwksresolver.KeyUseStrictEnc)
+	compact, svcErr := s.encryptSignedJWT(ctx, jwsResp.JWTBody, cfg, certificate)
 	if svcErr != nil {
 		return nil, svcErr
 	}
 
+	return &UserInfoResponse{Type: providers.UserInfoResponseTypeNESTEDJWT, JWTBody: compact}, nil
+}
+
+// encryptSignedJWT encrypts an already-signed JWT into a nested-JWT (JWE with cty=JWT) compact
+// serialization, using the client's encryption key.
+func (s *userInfoService) encryptSignedJWT(
+	ctx context.Context,
+	signedJWT string,
+	cfg *providers.UserInfoConfig,
+	certificate *providers.Certificate,
+) (string, *tidcommon.ServiceError) {
+	rpKey, rpKID, svcErr := s.jwksResolver.ResolveEncryptionKey(
+		ctx, certificate, cfg.EncryptionAlg, jwksresolver.KeyUseStrictEnc)
+	if svcErr != nil {
+		return "", svcErr
+	}
+
 	compact, svcErr := s.jweService.Encrypt(ctx,
-		[]byte(jwsResp.JWTBody),
+		[]byte(signedJWT),
 		&providers.KeyRef{PublicKeyJWK: rpKey},
 		cfg.EncryptionAlg,
 		jwe.ContentEncAlgorithm(cfg.EncryptionEnc),
@@ -276,10 +299,10 @@ func (s *userInfoService) generateNestedJWTUserInfo(
 	)
 	if svcErr != nil {
 		s.logger.Error(ctx, "Failed to encrypt nested JWT userinfo JWE")
-		return nil, svcErr
+		return "", svcErr
 	}
 
-	return &UserInfoResponse{Type: providers.UserInfoResponseTypeNESTEDJWT, JWTBody: compact}, nil
+	return compact, nil
 }
 
 // generateJWSUserInfo creates a signed JWT UserInfo response
@@ -329,6 +352,37 @@ func (s *userInfoService) generateJWSUserInfo(
 		Type:    providers.UserInfoResponseTypeJWS,
 		JWTBody: signedJWT,
 	}, nil
+}
+
+// buildRawJWTResponse passes through an opaque JWT/JWE returned by the authn provider in place
+// of individual claims. The token is never re-signed or decoded; it is only encrypted when the
+// client's UserInfo response type requires it and it isn't encrypted already.
+func (s *userInfoService) buildRawJWTResponse(
+	ctx context.Context,
+	rawToken string,
+	cfg *providers.UserInfoConfig,
+	certificate *providers.Certificate,
+) (*UserInfoResponse, *tidcommon.ServiceError) {
+	// JWE compact serialization has 5 dot-separated parts; a signed JWT (JWS) has 3, matching the
+	// part-count checks used elsewhere for these formats (e.g. jwe.DecodeJWE).
+	if len(strings.Split(rawToken, ".")) == 5 {
+		return &UserInfoResponse{Type: providers.UserInfoResponseTypeJWE, JWTBody: rawToken}, nil
+	}
+
+	responseType := providers.UserInfoResponseTypeJWS
+	if cfg != nil {
+		responseType = cfg.ResponseType
+	}
+	if responseType != providers.UserInfoResponseTypeJWE && responseType != providers.UserInfoResponseTypeNESTEDJWT {
+		return &UserInfoResponse{Type: providers.UserInfoResponseTypeJWS, JWTBody: rawToken}, nil
+	}
+
+	compact, svcErr := s.encryptSignedJWT(ctx, rawToken, cfg, certificate)
+	if svcErr != nil {
+		return nil, svcErr
+	}
+
+	return &UserInfoResponse{Type: providers.UserInfoResponseTypeNESTEDJWT, JWTBody: compact}, nil
 }
 
 // validateGrantType validates that the token was not issued using client_credentials grant.

--- a/backend/internal/oauth/oauth2/userinfo/service_jwe_test.go
+++ b/backend/internal/oauth/oauth2/userinfo/service_jwe_test.go
@@ -31,6 +31,11 @@ import (
 	"github.com/thunder-id/thunderid/tests/mocks/jose/jwtmock"
 )
 
+const (
+	testRawJWSToken = "header.payload.signature"
+	testRawJWEToken = "header.encryptedKey.iv.ciphertext.tag"
+)
+
 // JWEUserInfoTestSuite defines the test suite for JWE/JWS userinfo generation.
 type JWEUserInfoTestSuite struct {
 	suite.Suite
@@ -221,6 +226,173 @@ func (s *JWEUserInfoTestSuite) TestGenerateJWSUserInfo_UnsupportedAlg() {
 		map[string]interface{}{"sub": "user1"},
 		cfg,
 	)
+	assert.Nil(s.T(), result)
+	assert.NotNil(s.T(), svcErr)
+	assert.Equal(s.T(), tidcommon.InternalServerError.Code, svcErr.Code)
+}
+
+// TestBuildRawJWTResponse_PassesThroughWithoutEncrypting covers the cases where buildRawJWTResponse
+// must not encrypt: the value is already a JWE (5 parts, regardless of config), or it's a signed
+// JWT (3 parts) and the client's UserInfo config does not request encryption (including no config
+// at all).
+func (s *JWEUserInfoTestSuite) TestBuildRawJWTResponse_PassesThroughWithoutEncrypting() {
+	testCases := []struct {
+		name     string
+		rawToken string
+		cfg      *providers.UserInfoConfig
+		wantType providers.UserInfoResponseType
+	}{
+		{
+			name:     "already JWE, passthrough regardless of config",
+			rawToken: testRawJWEToken,
+			cfg:      &providers.UserInfoConfig{ResponseType: providers.UserInfoResponseTypeJWE},
+			wantType: providers.UserInfoResponseTypeJWE,
+		},
+		{
+			name:     "signed JWT, no encryption configured",
+			rawToken: testRawJWSToken,
+			cfg:      &providers.UserInfoConfig{ResponseType: providers.UserInfoResponseTypeJWS},
+			wantType: providers.UserInfoResponseTypeJWS,
+		},
+		{
+			name:     "signed JWT, nil UserInfo config",
+			rawToken: testRawJWSToken,
+			cfg:      nil,
+			wantType: providers.UserInfoResponseTypeJWS,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			mockJWE := jwemock.NewJWEServiceInterfaceMock(s.T())
+
+			svc := &userInfoService{
+				cfg:          userInfoTestConfig(),
+				jweService:   mockJWE,
+				jwksResolver: jwksresolver.Initialize(nil),
+				logger:       log.GetLogger(),
+			}
+
+			result, svcErr := svc.buildRawJWTResponse(context.Background(), tc.rawToken, tc.cfg, nil)
+
+			assert.Nil(s.T(), svcErr)
+			assert.NotNil(s.T(), result)
+			assert.Equal(s.T(), tc.wantType, result.Type)
+			assert.Equal(s.T(), tc.rawToken, result.JWTBody)
+			mockJWE.AssertNotCalled(s.T(), "Encrypt", mock.Anything, mock.Anything, mock.Anything,
+				mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		})
+	}
+}
+
+// TestBuildRawJWTResponse_JWSValue_ClientRequestsEncryption_EncryptsToNestedJWT verifies that a
+// signed JWT is encrypted (not re-signed) into a nested JWT when the client's UserInfo config
+// requests JWE or NESTED_JWT.
+func (s *JWEUserInfoTestSuite) TestBuildRawJWTResponse_JWSValue_ClientRequestsEncryption_EncryptsToNestedJWT() {
+	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	pubJWKS := rsaPublicKeyToJWKS(&privateKey.PublicKey)
+
+	mockJWE := jwemock.NewJWEServiceInterfaceMock(s.T())
+	mockJWE.On("Encrypt",
+		mock.Anything, []byte(testRawJWSToken), mock.Anything,
+		"RSA-OAEP-256",
+		jwe.ContentEncAlgorithm("A256GCM"),
+		"JWT",
+		"",
+	).Return("nested.jwe.token", (*tidcommon.ServiceError)(nil))
+
+	svc := &userInfoService{
+		cfg:          userInfoTestConfig(),
+		jweService:   mockJWE,
+		jwksResolver: jwksresolver.Initialize(nil),
+		logger:       log.GetLogger(),
+	}
+	cfg := &providers.UserInfoConfig{
+		ResponseType:  providers.UserInfoResponseTypeNESTEDJWT,
+		EncryptionAlg: "RSA-OAEP-256",
+		EncryptionEnc: "A256GCM",
+	}
+	cert := &providers.Certificate{Type: certmodel.CertificateTypeJWKS, Value: pubJWKS}
+
+	result, svcErr := svc.buildRawJWTResponse(context.Background(), testRawJWSToken, cfg, cert)
+
+	assert.Nil(s.T(), svcErr)
+	assert.NotNil(s.T(), result)
+	assert.Equal(s.T(), providers.UserInfoResponseTypeNESTEDJWT, result.Type)
+	assert.Equal(s.T(), "nested.jwe.token", result.JWTBody)
+}
+
+// TestEncryptSignedJWT_ResolveKeyFailure verifies that a key resolution failure (e.g. no
+// certificate configured) is returned as-is, without attempting to encrypt.
+func (s *JWEUserInfoTestSuite) TestEncryptSignedJWT_ResolveKeyFailure() {
+	mockJWE := jwemock.NewJWEServiceInterfaceMock(s.T())
+
+	svc := &userInfoService{
+		cfg:          userInfoTestConfig(),
+		jweService:   mockJWE,
+		jwksResolver: jwksresolver.Initialize(nil),
+		logger:       log.GetLogger(),
+	}
+	cfg := &providers.UserInfoConfig{EncryptionAlg: "RSA-OAEP-256", EncryptionEnc: "A256GCM"}
+
+	compact, svcErr := svc.encryptSignedJWT(context.Background(), testRawJWSToken, cfg, nil)
+
+	assert.Empty(s.T(), compact)
+	assert.NotNil(s.T(), svcErr)
+	assert.Equal(s.T(), tidcommon.InternalServerError.Code, svcErr.Code)
+	mockJWE.AssertNotCalled(s.T(), "Encrypt", mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestEncryptSignedJWT_EncryptFailure verifies that a JWE encryption failure is propagated.
+func (s *JWEUserInfoTestSuite) TestEncryptSignedJWT_EncryptFailure() {
+	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	pubJWKS := rsaPublicKeyToJWKS(&privateKey.PublicKey)
+
+	mockJWE := jwemock.NewJWEServiceInterfaceMock(s.T())
+	mockJWE.On("Encrypt",
+		mock.Anything, []byte(testRawJWSToken), mock.Anything,
+		"RSA-OAEP-256",
+		jwe.ContentEncAlgorithm("A256GCM"),
+		"JWT",
+		"",
+	).Return("", &tidcommon.InternalServerError)
+
+	svc := &userInfoService{
+		cfg:          userInfoTestConfig(),
+		jweService:   mockJWE,
+		jwksResolver: jwksresolver.Initialize(nil),
+		logger:       log.GetLogger(),
+	}
+	cfg := &providers.UserInfoConfig{EncryptionAlg: "RSA-OAEP-256", EncryptionEnc: "A256GCM"}
+	cert := &providers.Certificate{Type: certmodel.CertificateTypeJWKS, Value: pubJWKS}
+
+	compact, svcErr := svc.encryptSignedJWT(context.Background(), testRawJWSToken, cfg, cert)
+
+	assert.Empty(s.T(), compact)
+	assert.NotNil(s.T(), svcErr)
+}
+
+// TestBuildRawJWTResponse_EncryptionFailure_PropagatesError verifies that when the client requests
+// encryption but the raw JWT can't be encrypted (e.g. no certificate configured), buildRawJWTResponse
+// returns the error instead of a response.
+func (s *JWEUserInfoTestSuite) TestBuildRawJWTResponse_EncryptionFailure_PropagatesError() {
+	mockJWE := jwemock.NewJWEServiceInterfaceMock(s.T())
+
+	svc := &userInfoService{
+		cfg:          userInfoTestConfig(),
+		jweService:   mockJWE,
+		jwksResolver: jwksresolver.Initialize(nil),
+		logger:       log.GetLogger(),
+	}
+	cfg := &providers.UserInfoConfig{
+		ResponseType:  providers.UserInfoResponseTypeNESTEDJWT,
+		EncryptionAlg: "RSA-OAEP-256",
+		EncryptionEnc: "A256GCM",
+	}
+
+	result, svcErr := svc.buildRawJWTResponse(context.Background(), testRawJWSToken, cfg, nil)
+
 	assert.Nil(s.T(), result)
 	assert.NotNil(s.T(), svcErr)
 	assert.Equal(s.T(), tidcommon.InternalServerError.Code, svcErr.Code)

--- a/backend/internal/oauth/oauth2/userinfo/service_test.go
+++ b/backend/internal/oauth/oauth2/userinfo/service_test.go
@@ -489,6 +489,81 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_NoAppConfig() {
 	s.mockAttributeCacheService.AssertExpectations(s.T())
 }
 
+// TestGetUserInfo_Success_RawJWTPassthrough tests that when the authn provider's attributes are
+// an opaque JWT (the `_jwt` pseudo-claim),
+// the userinfo endpoint passes the JWT through as-is instead of running it through the
+// claims/scope/allow-list pipeline.
+func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_RawJWTPassthrough() {
+	claims := map[string]interface{}{
+		"exp":       float64(time.Now().Add(time.Hour).Unix()),
+		"nbf":       float64(time.Now().Add(-time.Minute).Unix()),
+		"sub":       "user123",
+		"scope":     "openid profile email",
+		"client_id": "client123",
+		"aci":       "cache-rawjwt-123",
+	}
+	token := s.createToken(claims)
+
+	rawJWT := "kyc.header.payload.signature"
+	userAttrs := map[string]interface{}{
+		providers.RawJWTAttributeKey: rawJWT,
+	}
+
+	oauthApp := &providers.OAuthClient{
+		Token: &providers.OAuthTokenConfig{},
+		UserInfo: &providers.UserInfoConfig{
+			UserAttributes: []string{"name", "email"},
+		},
+	}
+
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
+		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-rawjwt-123").Return(
+		&attributecache.AttributeCache{ID: "cache-rawjwt-123", Attributes: userAttrs}, nil)
+	s.mockInboundClient.On("GetOAuthClientByClientID", mock.Anything, "client123").Return(oauthApp, nil)
+
+	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
+	assert.Nil(s.T(), svcErr)
+	assert.NotNil(s.T(), response)
+	assert.Equal(s.T(), providers.UserInfoResponseTypeJWS, response.Type)
+	assert.Equal(s.T(), rawJWT, response.JWTBody)
+	assert.Nil(s.T(), response.JSONBody)
+	s.mockTokenValidator.AssertExpectations(s.T())
+	s.mockAttributeCacheService.AssertExpectations(s.T())
+	s.mockInboundClient.AssertExpectations(s.T())
+}
+
+// TestGetUserInfo_MalformedClaimsRequest_ReturnsServerError tests that a token carrying a
+// malformed claims_req claim causes buildUserInfoResponse (and therefore buildResponseFromClaims)
+// to return a server error rather than a partial response.
+func (s *UserInfoServiceTestSuite) TestGetUserInfo_MalformedClaimsRequest_ReturnsServerError() {
+	claims := map[string]interface{}{
+		"exp":                        float64(time.Now().Add(time.Hour).Unix()),
+		"nbf":                        float64(time.Now().Add(-time.Minute).Unix()),
+		"sub":                        "user123",
+		"scope":                      "openid profile",
+		"aci":                        "cache-badclaims-123",
+		constants.ClaimClaimsRequest: "not-valid-json",
+	}
+	token := s.createToken(claims)
+
+	userAttrs := map[string]interface{}{
+		"name": "John Doe",
+	}
+
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
+		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-badclaims-123").Return(
+		&attributecache.AttributeCache{ID: "cache-badclaims-123", Attributes: userAttrs}, nil)
+
+	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
+	assert.Nil(s.T(), response)
+	assert.NotNil(s.T(), svcErr)
+	assert.Equal(s.T(), tidcommon.InternalServerError.Code, svcErr.Code)
+	s.mockTokenValidator.AssertExpectations(s.T())
+	s.mockAttributeCacheService.AssertExpectations(s.T())
+}
+
 // TestGetUserInfo_AppNotFound_ReturnsInvalidToken tests that a stale/orphaned token returns an error
 // when the referenced client application no longer exists.
 func (s *UserInfoServiceTestSuite) TestGetUserInfo_AppNotFound_ReturnsInvalidToken() {

--- a/backend/pkg/thunderidengine/providers/constants.go
+++ b/backend/pkg/thunderidengine/providers/constants.go
@@ -279,6 +279,11 @@ const (
 	UserInfoResponseTypeNESTEDJWT UserInfoResponseType = "NESTED_JWT"
 )
 
+// RawJWTAttributeKey is the AttributesResponse.Attributes key an authn provider uses to return
+// an opaque JWT/JWE from its backing identity system in place of individual claims. When present,
+// it is the only key in the map and its value is passed through as-is rather than treated as a claim.
+const RawJWTAttributeKey = "_jwt"
+
 // CertificateType represents the type of certificates in the system.
 type CertificateType string
 


### PR DESCRIPTION
### Purpose
Authn providers whose backing identity system issues a signed/encrypted token (e.g. the MOSIP/esignet KYC-exchange flow) are moving from decoding that token into discrete claims to passing it through as-is under a single pseudo-claim key, _jwt. ThunderID had no handling for this — it was silently dropped everywhere, leaving id_token/userinfo empty and forcing spurious re-consent/attribute-collection.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
Introduced providers.RawJWTAttributeKey = "_jwt", routed as an opaque passthrough instead of through claim-level filtering, in auth_assert_executor.resolveUserAttributes, tokenservice.FetchUserAttributes, userinfo/service.go (JWE vs JWS detection, encrypt-only-if-required), and consent/service.buildUserAttributeSet.

### Related Issues
- #5084 

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
