### PR TITLE
Pick the tool release bump and npm dist-tag from the release branch

### DIFF
--- a/.github/actions/release-npm/action.yml
+++ b/.github/actions/release-npm/action.yml
@@ -14,8 +14,12 @@ inputs:
     description: 'Path to the package from the repo root (e.g. tools/npx, frontend/packages/eslint-plugin)'
     required: true
   bump-type:
-    description: 'Semver bump type: major, minor, or patch'
+    description: 'Semver bump type: major, minor, patch, or prerelease'
     required: true
+  dist-tag:
+    description: 'npm dist-tag to publish under. Defaults to latest, which is what existing consumers install.'
+    required: false
+    default: 'latest'
   git-user-name:
     description: 'Git committer name'
     required: false
@@ -106,4 +110,7 @@ runs:
       shell: bash
       run: |
         cd ${{ inputs.package-dir }}
-        pnpm publish --no-git-checks --access public --provenance
+        # --tag is load-bearing: npm assigns the 'latest' dist-tag to any publish that
+        # omits it, including a prerelease version, which would move every default
+        # consumer onto it.
+        pnpm publish --no-git-checks --access public --provenance --tag "${{ inputs.dist-tag }}"

--- a/.github/workflows/release-tools.yml
+++ b/.github/workflows/release-tools.yml
@@ -2,25 +2,13 @@
 
 name: 🔧 Release Tools
 
+# The bump type is not an input. It follows from the branch: a maintenance branch owns
+# a released line and can only patch it, and main is ahead of every released line so it
+# can only publish prereleases.
+
 on:
   workflow_dispatch:
     inputs:
-      bump_type:
-        description: 'Version bump type'
-        required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
-        default: patch
-
-      confirm_major:
-        description: 'Check to confirm intentional major bump (required when bump_type is major)'
-        required: false
-        type: boolean
-        default: false
-
       npx:
         description: 'Release npx tool'
         required: false
@@ -39,20 +27,9 @@ env:
   PNPM_VERSION: "latest"
 
 jobs:
-  validate:
-    name: ✅ Validate Inputs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Guard against accidental major bump
-        if: github.event.inputs.bump_type == 'major' && github.event.inputs.confirm_major != 'true'
-        run: |
-          echo "❌ bump_type is 'major' but confirm_major is not checked. Enable confirm_major to proceed."
-          exit 1
-
   release-npx-thunderid:
     name: ⚡ Release thunderid (npx-thunderid)
-    needs: [validate]
-    if: needs.validate.result == 'success' && github.event.inputs.npx == 'true'
+    if: github.event.inputs.npx == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout Code
@@ -60,12 +37,33 @@ jobs:
         with:
           token: ${{ secrets.THUNDER_AUTOMATION_BOT }}
 
+      - name: 🔀 Resolve Release Channel
+        id: channel
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ "$BRANCH" = "main" ]; then
+            BUMP=prerelease
+            DIST_TAG=next
+          elif [[ "$BRANCH" =~ ^[0-9]+\.[0-9]+\.x$ ]]; then
+            BUMP=patch
+            DIST_TAG=latest
+          else
+            echo "❌ Tool releases run from main or an N.M.x maintenance branch only, not '$BRANCH'."
+            exit 1
+          fi
+          echo "bump=$BUMP" >> "$GITHUB_OUTPUT"
+          echo "dist-tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+          echo "✅ $BRANCH publishes a $BUMP under the '$DIST_TAG' dist-tag."
+
       - name: 🚀 Release
         uses: ./.github/actions/release-npm
         with:
           package-dir: tools/npx
           tag-convention: 'tool/{name}/v{version}'
-          bump-type: ${{ github.event.inputs.bump_type }}
+          bump-type: ${{ steps.channel.outputs.bump }}
+          dist-tag: ${{ steps.channel.outputs.dist-tag }}
           git-user-name: ${{ env.RELEASE_GIT_USER_NAME }}
           git-user-email: ${{ env.RELEASE_GIT_USER_EMAIL }}
           node-version: ${{ env.NODE_VERSION }}


### PR DESCRIPTION
### Purpose

Two problems in the tool release path.

**1. `pnpm publish` was called without `--tag`.** npm assigns the `latest` dist-tag to any publish that omits it, **including one whose version carries a prerelease suffix**. So a prerelease published from `main` would have been handed to every existing `npx thunderid` user immediately. A version suffix on its own protects nobody; the `--tag` is the whole mechanism.

**2. `bump_type` was a free-form input.** Nothing stopped a `minor` or `major` bump from a branch that owns a released patch line, and `workflow_dispatch` has no ref restriction, so a release could be cut from any branch.

### Approach

The bump type is not really a choice, so it is no longer an input. It follows from the branch being released:

| Branch | Bump | dist-tag |
|---|---|---|
| `main` | `prerelease` | `next` |
| `N.M.x` | `patch` | `latest` |
| anything else | refused | |

So `1.0.x` can only ever patch the 1.0 line, and `main` can only ever publish prereleases, held off `latest` so existing users are not moved onto them. Trying the development line stays an explicit opt-in via `npx thunderid@next`.

Removing the input also removes the reason for `confirm_major` and the `validate` job that policed it, which is why the workflow is net shorter.

`release-npm` is shared with other packages, so `bump-type` keeps working exactly as before. It gains one optional `dist-tag` input defaulting to `latest`, so no other caller changes behaviour.

### Verification

Branch matching was checked against `main`, `1.0.x`, `1.1.x`, `2.0.x`, `10.24.x` (all resolve as intended) and against `e2e-cli`, `release/1.0`, `1.0.0`, `1.0.0.x`, `1.0.x-hotfix` (all refused).

`pnpm version` output confirmed directly:

- `patch` from `1.0.2` gives `1.0.3`, then `1.0.4`.
- `prerelease` from `1.1.0-m1.0` gives `1.1.0-m1.1`, then `1.1.0-m1.2`.

### One thing to decide before the first release from main

`tools/npx/package.json` on `main` currently reads `1.0.2`, a released stable version. `pnpm version prerelease` from there produces **`1.0.3-0`**, which reads as a prerelease of the very `1.0.3` that `1.0.x` is going to publish. Not an npm collision, but confusing.

The fix is a one-time manual set of `tools/npx/package.json` on `main` to whatever the next line should be, for example `1.1.0-m1.0`, after which `prerelease` increments it cleanly. Deliberately not done in this PR because naming the next line is a product call, not a plumbing one.

### Related Issues
- N/A

### Related PRs
- #5087 (merged) reconciled `tools/npx/package.json` on `1.0.x` with the already-published 1.0.2. Without it a patch release from that branch computed `1.0.1`, which is already on npm. With it merged, `1.0.x` now resolves to `1.0.3`.

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified. Branch resolution and `pnpm version` behaviour verified as described above. The workflow itself can only be exercised by a real `workflow_dispatch`.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any) The change is a branch-to-channel mapping inside a `workflow_dispatch` job, which the repo has no harness for.
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
