### PR TITLE
[Docs] Update the flutter quickstart guide

### DIFF
--- a/docs/content/getting-started/connect-your-application/flutter.mdx
+++ b/docs/content/getting-started/connect-your-application/flutter.mdx
@@ -72,6 +72,12 @@ Once it's running, the console is available at [https://localhost:8090/console](
 Copy the **Application ID** from the **General** tab, under **Quick Copy**. You'll need it when configuring the SDK.
 :::
 
+10. Open the **Advanced Settings** tab, turn on **Dev Mode** under **Platform Attestation**, then click **Save**.
+
+:::warning Platform attestation
+Mobile applications prove their binary identity before starting a sign-in flow. If platform attestation is not configured and **Dev Mode** is off, sign-in fails with `FES-1016`, `Attestation not configured`. Dev Mode is a bypass for local development; configure platform attestation for production.
+:::
+
 ## Create a Flutter App
 
 Create a new Flutter project:
@@ -93,6 +99,58 @@ Add the package, which writes a version constraint to your `pubspec.yaml` and re
 flutter pub add thunderid_flutter
 ```
 
+## Configure the Platforms
+
+The `flutter create` template does not include the configuration the plugin needs.
+
+For Android, add the JitPack repository, which hosts the plugin's native dependency:
+
+```kotlin title="android/build.gradle.kts" showLineNumbers
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+        maven { url = uri("https://jitpack.io") }
+    }
+}
+```
+
+Then replace the template's `minSdk = flutter.minSdkVersion` with 26, which the plugin requires:
+
+```kotlin title="android/app/build.gradle.kts" showLineNumbers
+android {
+    defaultConfig {
+        minSdk = 26
+    }
+}
+```
+
+For iOS, build with CocoaPods rather than Swift Package Manager. This also generates `ios/Podfile`, which the next step edits:
+
+```bash
+flutter config --no-enable-swift-package-manager
+flutter pub get
+```
+
+Then set the platform to 16 and add the native SDK as a Git pod:
+
+```ruby title="ios/Podfile" showLineNumbers
+platform :ios, '16.0'
+
+# ...
+
+target 'Runner' do
+  use_frameworks!
+
+  pod 'ThunderID', :git => 'https://github.com/thunder-id/ios-sdks', :branch => 'main'
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+```
+
 ## Initialize the SDK
 
 Wrap your root widget with `ThunderIDProvider` in `lib/main.dart`:
@@ -100,6 +158,7 @@ Wrap your root widget with `ThunderIDProvider` in `lib/main.dart`:
 ```dart title="lib/main.dart" showLineNumbers
 import 'package:flutter/material.dart';
 import 'package:thunderid_flutter/thunderid_flutter.dart';
+import 'root_screen.dart';
 
 void main() {
   runApp(
@@ -128,6 +187,8 @@ class MyApp extends StatelessWidget {
 
 :::warning Configuration
 Replace `<your-application-id>` with the **Application ID** from your <ProductName /> application settings.
+
+`localhost` works from the iOS Simulator. For Android, see [Run the App](#run-the-app).
 :::
 
 ### Configuration Parameters
@@ -188,8 +249,7 @@ class _AuthScreenState extends State<AuthScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final thunder = ThunderIDProvider.of(context);
-    final applicationId = thunder.config?.applicationId ?? '';
+    const applicationId = '<your-application-id>';
 
     return Scaffold(
       body: SafeArea(
@@ -219,6 +279,10 @@ class _AuthScreenState extends State<AuthScreen> {
   }
 }
 ```
+
+:::warning Configuration
+Replace `<your-application-id>` with the **Application ID** from your <ProductName /> application settings.
+:::
 
 ## Display User Profile Information
 
@@ -275,6 +339,14 @@ Start an iOS simulator or connect an Android device, then run:
 ```bash
 flutter run
 ```
+
+:::note Reaching a local instance from Android
+An emulator's `localhost` is the emulator itself. Map it to your machine with `adb` from the Android SDK's `platform-tools`:
+
+```bash
+adb reverse tcp:8090 tcp:8090
+```
+:::
 
 :::note Test credentials
 You'll need a user to sign in with. If you haven't created one yet, open <ConsoleUrl />, navigate to **Users**, and add a test user with an email and password.

--- a/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/flutter.mdx
+++ b/docs/versioned_docs/version-v1.0.x/getting-started/connect-your-application/flutter.mdx
@@ -72,6 +72,12 @@ Once it's running, the console is available at [https://localhost:8090/console](
 Copy the **Application ID** from the **General** tab, under **Quick Copy**. You'll need it when configuring the SDK.
 :::
 
+10. Open the **Advanced Settings** tab, turn on **Dev Mode** under **Platform Attestation**, then click **Save**.
+
+:::warning Platform attestation
+Mobile applications prove their binary identity before starting a sign-in flow. If platform attestation is not configured and **Dev Mode** is off, sign-in fails with `FES-1016`, `Attestation not configured`. Dev Mode is a bypass for local development; configure platform attestation for production.
+:::
+
 ## Create a Flutter App
 
 Create a new Flutter project:
@@ -93,6 +99,58 @@ Add the package, which writes a version constraint to your `pubspec.yaml` and re
 flutter pub add thunderid_flutter
 ```
 
+## Configure the Platforms
+
+The `flutter create` template does not include the configuration the plugin needs.
+
+For Android, add the JitPack repository, which hosts the plugin's native dependency:
+
+```kotlin title="android/build.gradle.kts" showLineNumbers
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+        maven { url = uri("https://jitpack.io") }
+    }
+}
+```
+
+Then replace the template's `minSdk = flutter.minSdkVersion` with 26, which the plugin requires:
+
+```kotlin title="android/app/build.gradle.kts" showLineNumbers
+android {
+    defaultConfig {
+        minSdk = 26
+    }
+}
+```
+
+For iOS, build with CocoaPods rather than Swift Package Manager. This also generates `ios/Podfile`, which the next step edits:
+
+```bash
+flutter config --no-enable-swift-package-manager
+flutter pub get
+```
+
+Then set the platform to 16 and add the native SDK as a Git pod:
+
+```ruby title="ios/Podfile" showLineNumbers
+platform :ios, '16.0'
+
+# ...
+
+target 'Runner' do
+  use_frameworks!
+
+  pod 'ThunderID', :git => 'https://github.com/thunder-id/ios-sdks', :branch => 'main'
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+```
+
 ## Initialize the SDK
 
 Wrap your root widget with `ThunderIDProvider` in `lib/main.dart`:
@@ -100,6 +158,7 @@ Wrap your root widget with `ThunderIDProvider` in `lib/main.dart`:
 ```dart title="lib/main.dart" showLineNumbers
 import 'package:flutter/material.dart';
 import 'package:thunderid_flutter/thunderid_flutter.dart';
+import 'root_screen.dart';
 
 void main() {
   runApp(
@@ -128,6 +187,8 @@ class MyApp extends StatelessWidget {
 
 :::warning Configuration
 Replace `<your-application-id>` with the **Application ID** from your <ProductName /> application settings.
+
+`localhost` works from the iOS Simulator. For Android, see [Run the App](#run-the-app).
 :::
 
 ### Configuration Parameters
@@ -188,8 +249,7 @@ class _AuthScreenState extends State<AuthScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final thunder = ThunderIDProvider.of(context);
-    final applicationId = thunder.config?.applicationId ?? '';
+    const applicationId = '<your-application-id>';
 
     return Scaffold(
       body: SafeArea(
@@ -219,6 +279,10 @@ class _AuthScreenState extends State<AuthScreen> {
   }
 }
 ```
+
+:::warning Configuration
+Replace `<your-application-id>` with the **Application ID** from your <ProductName /> application settings.
+:::
 
 ## Display User Profile Information
 
@@ -275,6 +339,14 @@ Start an iOS simulator or connect an Android device, then run:
 ```bash
 flutter run
 ```
+
+:::note Reaching a local instance from Android
+An emulator's `localhost` is the emulator itself. Map it to your machine with `adb` from the Android SDK's `platform-tools`:
+
+```bash
+adb reverse tcp:8090 tcp:8090
+```
+:::
 
 :::note Test credentials
 You'll need a user to sign in with. If you haven't created one yet, open <ConsoleUrl />, navigate to **Users**, and add a test user with an email and password.


### PR DESCRIPTION
### Purpose
The Flutter quickstart could not be completed as written. This adds the platform configuration the plugin needs and updates the quickstart steps.

<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach

* Added a **Configure the Platforms** step with the configuration the plugin needs: the JitPack repository, `minSdk = 26`, disabling Swift Package Manager before `flutter pub get` so `ios/Podfile` is generated, and the `ThunderID` Git pod. 

* Added the Dev Mode step required for app-native sign-in, the missing `root_screen.dart` import and `applicationId` constant, and a note on reaching a local instance from an emulator.

Reaching a local instance from Android still fails on the self-signed certificate, which needs to be fixed in the SDK by exposing allowInsecureConnections as the native Android SDK already does.



<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the Flutter quickstart with Android and iOS platform setup requirements.
  * Added guidance for enabling Dev Mode and platform attestation, including troubleshooting for authentication failures.
  * Clarified SDK initialization, application ID configuration, and Android access to local development instances.
  * Added instructions for Android JitPack, minimum SDK 26, iOS 16, CocoaPods, and the native ThunderID pod.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->