### PR TITLE
[1.0.x] Pick the tool release bump and npm dist-tag from the release branch

### DIFF
--- a/.github/actions/release-npm/action.yml
+++ b/.github/actions/release-npm/action.yml
@@ -14,8 +14,12 @@ inputs:
     description: 'Path to the package from the repo root (e.g. tools/npx, frontend/packages/eslint-plugin)'
     required: true
   bump-type:
-    description: 'Semver bump type: major, minor, or patch'
+    description: 'Semver bump type: major, minor, patch, or prerelease'
     required: true
+  dist-tag:
+    description: 'npm dist-tag to publish under. Defaults to latest, which is what existing consumers install.'
+    required: false
+    default: 'latest'
   git-user-name:
     description: 'Git committer name'
     required: false
@@ -106,4 +110,7 @@ runs:
       shell: bash
       run: |
         cd ${{ inputs.package-dir }}
-        pnpm publish --no-git-checks --access public --provenance
+        # --tag is load-bearing: npm assigns the 'latest' dist-tag to any publish that
+        # omits it, including a prerelease version, which would move every default
+        # consumer onto it.
+        pnpm publish --no-git-checks --access public --provenance --tag "${{ inputs.dist-tag }}"

--- a/.github/workflows/release-tools.yml
+++ b/.github/workflows/release-tools.yml
@@ -2,25 +2,14 @@
 
 name: 🔧 Release Tools
 
+# The bump type is not an input. It follows from the branch: a maintenance branch owns
+# a released line and can only patch it, and main is ahead of every released line so it
+# can only publish prereleases. Prereleases are gated by ALLOW_PRERELEASES below, which
+# is currently off, so today only the maintenance branches can release anything.
+
 on:
   workflow_dispatch:
     inputs:
-      bump_type:
-        description: 'Version bump type'
-        required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
-        default: patch
-
-      confirm_major:
-        description: 'Check to confirm intentional major bump (required when bump_type is major)'
-        required: false
-        type: boolean
-        default: false
-
       npx:
         description: 'Release npx tool'
         required: false
@@ -37,22 +26,16 @@ env:
   RELEASE_GIT_USER_EMAIL: "thunderid-bot@thunderid.dev"
   NODE_VERSION: "lts/*"
   PNPM_VERSION: "latest"
+  # Master switch for prereleases, which are the only thing main can publish. While
+  # this is "false" a release from main is refused outright, so the only branches that
+  # can release are the maintenance branches. Flip it to "true" when main is genuinely
+  # ready to start publishing a development line under the 'next' dist-tag.
+  ALLOW_PRERELEASES: "false"
 
 jobs:
-  validate:
-    name: ✅ Validate Inputs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Guard against accidental major bump
-        if: github.event.inputs.bump_type == 'major' && github.event.inputs.confirm_major != 'true'
-        run: |
-          echo "❌ bump_type is 'major' but confirm_major is not checked. Enable confirm_major to proceed."
-          exit 1
-
   release-npx-thunderid:
     name: ⚡ Release thunderid (npx-thunderid)
-    needs: [validate]
-    if: needs.validate.result == 'success' && github.event.inputs.npx == 'true'
+    if: github.event.inputs.npx == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout Code
@@ -60,12 +43,43 @@ jobs:
         with:
           token: ${{ secrets.THUNDER_AUTOMATION_BOT }}
 
+      - name: 🔀 Resolve Release Channel
+        id: channel
+        env:
+          BRANCH: ${{ github.ref_name }}
+          ALLOW_PRERELEASES: ${{ env.ALLOW_PRERELEASES }}
+        run: |
+          set -euo pipefail
+          if [ "$BRANCH" = "main" ]; then
+            if [ "$ALLOW_PRERELEASES" != "true" ]; then
+              echo "❌ Releases from main are disabled (ALLOW_PRERELEASES is '$ALLOW_PRERELEASES')."
+              echo "   main can only publish prereleases, and prereleases are switched off."
+              echo "   To release a patch of an already-released line, dispatch this workflow"
+              echo "   from that line's N.M.x maintenance branch instead."
+              echo "   To open a development line on main, set ALLOW_PRERELEASES to 'true' in"
+              echo "   .github/workflows/release-tools.yml."
+              exit 1
+            fi
+            BUMP=prerelease
+            DIST_TAG=next
+          elif [[ "$BRANCH" =~ ^[0-9]+\.[0-9]+\.x$ ]]; then
+            BUMP=patch
+            DIST_TAG=latest
+          else
+            echo "❌ Tool releases run from main or an N.M.x maintenance branch only, not '$BRANCH'."
+            exit 1
+          fi
+          echo "bump=$BUMP" >> "$GITHUB_OUTPUT"
+          echo "dist-tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+          echo "✅ $BRANCH publishes a $BUMP under the '$DIST_TAG' dist-tag."
+
       - name: 🚀 Release
         uses: ./.github/actions/release-npm
         with:
           package-dir: tools/npx
           tag-convention: 'tool/{name}/v{version}'
-          bump-type: ${{ github.event.inputs.bump_type }}
+          bump-type: ${{ steps.channel.outputs.bump }}
+          dist-tag: ${{ steps.channel.outputs.dist-tag }}
           git-user-name: ${{ env.RELEASE_GIT_USER_NAME }}
           git-user-email: ${{ env.RELEASE_GIT_USER_EMAIL }}
           node-version: ${{ env.NODE_VERSION }}


### PR DESCRIPTION
### Purpose

Back-ports #5090 to `1.0.x` (that PR is now closed in favour of this one, since `forward-port-pr.yml` carries merged `1.0.x` PRs to `main` automatically).

Two problems in the tool release path.

**1. `pnpm publish` was called without `--tag`.** npm assigns the `latest` dist-tag to any publish that omits it, **including one whose version carries a prerelease suffix**. So a prerelease published from `main` would have been handed to every existing `npx thunderid` user immediately. A version suffix on its own protects nobody; the `--tag` is the whole mechanism.

**2. `bump_type` was a free-form input.** Nothing stopped a `minor` or `major` bump from a branch that owns a released patch line, and `workflow_dispatch` has no ref restriction, so a release could be cut from any branch.

### Approach

The bump type is not really a choice, so it is no longer an input. It follows from the branch being released:

| Branch | Bump | dist-tag |
|---|---|---|
| `main` | `prerelease` | `next` |
| `N.M.x` | `patch` | `latest` |
| anything else | refused | |

Removing the input also removes the reason for `confirm_major` and the `validate` job that policed it.

#### ALLOW_PRERELEASES, currently off

Prereleases are gated behind a constant at the top of the workflow:

```yaml
ALLOW_PRERELEASES: "false"
```

Since prereleases are the only thing `main` can publish, setting this to `"false"` closes releases from `main` entirely, while leaving the maintenance branches free to patch. Flip it to `"true"` when `main` is genuinely ready to open a development line under the `next` dist-tag.

The comparison is against the exact string `"true"`, so `True`, `TRUE`, `yes`, `1` and an empty value all leave the gate shut. It fails closed.

### Why this matters right now

`main` and `1.0.x` both sit at `1.0.2`, so both compute `1.0.3`. With `main` unguarded as it is today, a release dispatched from `main` would:

1. publish `1.0.3` to the **`latest`** dist-tag, handing main's tree to every `npx thunderid` user, and
2. burn the `1.0.3` version and the `tool/npx/v1.0.3` tag that `1.0.x` needs, so the next `1.0.x` release would fail with a publish conflict.

Branch protection is not a safety net here: the `[Release] thunderid@1.0.1` and `@1.0.2` commits are both single-parent commits sitting directly on `main`, authored by `thunderid-automation-bot`, so the release token pushes straight through.

With this change, a release dispatched from `main` is refused before anything is built, tagged or published.

### Verification

Resolution was exercised across the matrix:

| Branch | `ALLOW_PRERELEASES` | Result |
|---|---|---|
| `main` | `false` | refused, prereleases off |
| `main` | `true` | `prerelease` / `next` |
| `1.0.x` | `false` | `patch` / `latest` |
| `1.1.x` | `false` | `patch` / `latest` |
| `e2e-cli` | `true` | refused, branch not releasable |

Also refused: `release/1.0`, `1.0.0`, `1.0.0.x`, `1.0.x-hotfix`. And `True` / `TRUE` / `yes` / `1` / empty all leave the gate shut.

`pnpm version` output confirmed directly: `patch` from `1.0.2` gives `1.0.3` then `1.0.4`; `prerelease` from `1.1.0-m1` gives `1.1.0-m1.0`.

### Note for whenever prereleases are switched on

`tools/npx/package.json` on `main` reads `1.0.2`, so the first `prerelease` from there produces `1.0.3-0`, which is semver-**older** than the `1.0.3` that `1.0.x` will publish. `next` would then sit behind `latest`. Setting `main`'s `tools/npx/package.json` to a development line first, for example `1.1.0-m1` (no counter, so the first publish lands on `1.1.0-m1.0`), avoids that. Not needed while `ALLOW_PRERELEASES` is `false`, and naming the line is a product call rather than a plumbing one.

### Related Issues
- N/A

### Related PRs
- #5090 is the same change against `main`, closed as redundant given the forward-port automation.
- #5087 (merged) reconciled `tools/npx/package.json` on `1.0.x` with the already-published 1.0.2, so `1.0.x` now resolves to `1.0.3`.

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified. Branch and gate resolution exercised across the matrix above, and `pnpm version` behaviour confirmed directly. The workflow end to end can only be exercised by a real `workflow_dispatch`.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any) The change is a branch-to-channel mapping inside a `workflow_dispatch` job, which the repo has no harness for.
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
