### PR TITLE
Apply the configured log format to every log record

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/cloudflare/circl v1.6.4
 	github.com/fxamacker/cbor/v2 v2.9.2
+	github.com/go-logr/logr v1.4.3
 	github.com/go-webauthn/webauthn v0.17.4
 	github.com/google/jsonschema-go v0.4.3
 	github.com/lib/pq v1.10.9
@@ -23,6 +24,7 @@ require (
 	golang.org/x/net v0.56.0
 	golang.org/x/text v0.38.0
 	google.golang.org/api v0.288.0
+	google.golang.org/grpc v1.82.1
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.53.0
 )
@@ -36,7 +38,6 @@ require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/go-webauthn/x v0.2.6 // indirect
@@ -67,7 +68,6 @@ require (
 	golang.org/x/sys v0.46.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260630182238-925bb5da69e7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260630182238-925bb5da69e7 // indirect
-	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	modernc.org/libc v1.73.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/backend/internal/system/cache/manager.go
+++ b/backend/internal/system/cache/manager.go
@@ -66,6 +66,10 @@ func Initialize(cacheConfig engineconfig.CacheConfig, deploymentID string) Cache
 	cm.enabled = true
 
 	if getCacheType(cacheConfig) == cacheTypeRedis {
+		// Route the library's own diagnostics through the framework logger; go-redis
+		// otherwise writes them to stderr as plain text, bypassing the configured format.
+		redis.SetLogger(log.NewRedisLogger(logger))
+
 		cm.redisClient = redis.NewClient(&redis.Options{
 			Addr:            cacheConfig.Redis.Address,
 			Username:        cacheConfig.Redis.Username,

--- a/backend/internal/system/database/provider/redisprovider.go
+++ b/backend/internal/system/database/provider/redisprovider.go
@@ -52,6 +52,10 @@ func initRedisProvider() {
 
 		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, "RedisProvider"))
 
+		// Route the library's own diagnostics through the framework logger; go-redis
+		// otherwise writes them to stderr as plain text, bypassing the configured format.
+		redis.SetLogger(log.NewRedisLogger(logger))
+
 		r := cfg.Redis
 		client := redis.NewClient(&redis.Options{
 			Addr:            r.Address,

--- a/backend/internal/system/log/accesslog_test.go
+++ b/backend/internal/system/log/accesslog_test.go
@@ -35,9 +35,7 @@ func (suite *AccessLogTestSuite) TestAccessLogHandler() {
 		Level: slog.LevelDebug,
 	}
 	logHandler := slog.NewTextHandler(&buf, handlerOptions)
-	log := &Logger{
-		internal: slog.New(logHandler),
-	}
+	log := newLogger(logHandler, new(slog.LevelVar), &buf)
 
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -79,9 +77,7 @@ func (suite *AccessLogTestSuite) TestAccessLogHandlerSkipPrefixes() {
 	once = sync.Once{}
 
 	logHandler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
-	log := &Logger{
-		internal: slog.New(logHandler),
-	}
+	log := newLogger(logHandler, new(slog.LevelVar), &buf)
 
 	served := false
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -140,7 +136,7 @@ func (suite *AccessLogTestSuite) TestAccessLogHandlerSkipPrefixEdgeCases() {
 	for _, tc := range cases {
 		var buf bytes.Buffer
 		logHandler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
-		log := &Logger{internal: slog.New(logHandler)}
+		log := newLogger(logHandler, new(slog.LevelVar), &buf)
 
 		handler := AccessLogHandler(log, skipPrefixes, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)

--- a/backend/internal/system/log/configure_test.go
+++ b/backend/internal/system/log/configure_test.go
@@ -5,8 +5,12 @@ package log
 
 import (
 	"context"
+	"encoding/json"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 
@@ -75,7 +79,7 @@ func TestConfigureFallsBackToStdoutWhenNothingEnabled(t *testing.T) {
 	assert.NotPanics(t, func() {
 		log.Info(context.Background(), "fallback message")
 	})
-	assert.Nil(t, log.fileWriter, "no file writer should be created")
+	assert.Nil(t, log.root.fileWriter, "no file writer should be created")
 }
 
 func TestConfigureErrorsOnInvalidFilePath(t *testing.T) {
@@ -105,4 +109,369 @@ func TestConfigureConsoleAndFileWritesFile(t *testing.T) {
 	content, err := os.ReadFile(path) // #nosec G304 -- test reads a file under t.TempDir().
 	require.NoError(t, err)
 	assert.Contains(t, string(content), "dual output")
+}
+
+// TestConfigureAppliesToLoggerDerivedBeforeConfigure is the regression test for the
+// reported defect: services cache a derived logger in their constructor, which used to
+// pin them to the boot text handler when Configure ran afterwards.
+func TestConfigureAppliesToLoggerDerivedBeforeConfigure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "thunderid.log")
+	log := freshLogger()
+
+	svc := log.With(String(LoggerKeyComponentName, "XService"))
+
+	require.NoError(t, log.Configure(OutputOptions{
+		FileEnabled: true,
+		Format:      "json",
+		File:        rollingfile.Config{Path: path},
+	}))
+	defer func() { _ = log.Close() }()
+
+	svc.Info(context.Background(), "derived before configure")
+
+	content, err := os.ReadFile(path) // #nosec G304 -- test reads a file under t.TempDir().
+	require.NoError(t, err)
+	assert.Contains(t, string(content), `"msg":"derived before configure"`)
+	assert.Contains(t, string(content), `"`+LoggerKeyComponentName+`":"XService"`)
+}
+
+func TestConfigureAppliesToNestedDerivations(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "thunderid.log")
+	log := freshLogger()
+
+	nested := log.With(String(LoggerKeyComponentName, "XService")).
+		With(String("sub", "worker")).
+		WithTraceID("trace-nested")
+
+	require.NoError(t, log.Configure(OutputOptions{
+		FileEnabled: true,
+		Format:      "json",
+		File:        rollingfile.Config{Path: path},
+	}))
+	defer func() { _ = log.Close() }()
+
+	nested.Info(context.Background(), "nested message")
+
+	content, err := os.ReadFile(path) // #nosec G304 -- test reads a file under t.TempDir().
+	require.NoError(t, err)
+	assert.Contains(t, string(content), `"msg":"nested message"`)
+	assert.Contains(t, string(content), `"`+LoggerKeyComponentName+`":"XService"`)
+	assert.Contains(t, string(content), `"sub":"worker"`)
+	assert.Contains(t, string(content), `"`+LoggerKeyTraceID+`":"trace-nested"`)
+}
+
+func TestDerivedLoggerFollowsSecondConfigure(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "first.log")
+	second := filepath.Join(dir, "second.log")
+	log := freshLogger()
+
+	require.NoError(t, log.Configure(OutputOptions{
+		FileEnabled: true,
+		File:        rollingfile.Config{Path: first},
+	}))
+
+	svc := log.With(String(LoggerKeyComponentName, "XService"))
+	svc.Info(context.Background(), "before reconfigure")
+
+	require.NoError(t, log.Configure(OutputOptions{
+		FileEnabled: true,
+		Format:      "json",
+		File:        rollingfile.Config{Path: second},
+	}))
+	defer func() { _ = log.Close() }()
+
+	svc.Info(context.Background(), "after reconfigure")
+
+	firstContent, err := os.ReadFile(first) // #nosec G304 -- test reads a file under t.TempDir().
+	require.NoError(t, err)
+	assert.Contains(t, string(firstContent), "before reconfigure")
+	assert.NotContains(t, string(firstContent), "after reconfigure")
+
+	secondContent, err := os.ReadFile(second) // #nosec G304 -- test reads a file under t.TempDir().
+	require.NoError(t, err)
+	assert.Contains(t, string(secondContent), `"msg":"after reconfigure"`)
+	assert.NotContains(t, string(secondContent), "before reconfigure")
+}
+
+// TestDerivationOrderPreservedAcrossConfigure pins the slog contract that WithAttrs and
+// WithGroup order is significant: attributes added before a group stay at the top level,
+// while attributes added after it (and the record's own) nest inside the group.
+func TestDerivationOrderPreservedAcrossConfigure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "thunderid.log")
+	log := freshLogger()
+
+	derived := &Logger{
+		internal: slog.New(log.internal.Handler().
+			WithAttrs([]slog.Attr{slog.String("top", "1")}).
+			WithGroup("g").
+			WithAttrs([]slog.Attr{slog.String("inner", "2")})),
+		root: log.root,
+	}
+
+	require.NoError(t, log.Configure(OutputOptions{
+		FileEnabled: true,
+		Format:      "json",
+		File:        rollingfile.Config{Path: path},
+	}))
+	defer func() { _ = log.Close() }()
+
+	derived.Info(context.Background(), "ordered", String("rec", "3"))
+
+	content, err := os.ReadFile(path) // #nosec G304 -- test reads a file under t.TempDir().
+	require.NoError(t, err)
+
+	var record map[string]any
+	require.NoError(t, json.Unmarshal(content, &record))
+	assert.Equal(t, "1", record["top"])
+	group, ok := record["g"].(map[string]any)
+	require.True(t, ok, "attributes after WithGroup must be nested under the group")
+	assert.Equal(t, "2", group["inner"])
+	assert.Equal(t, "3", group["rec"])
+}
+
+// TestSiblingDerivationsDoNotAlias guards the defensive slice copy in derive: two loggers
+// derived from the same parent must not share a backing array.
+func TestSiblingDerivationsDoNotAlias(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "thunderid.log")
+	log := freshLogger()
+
+	parent := log.With(String(LoggerKeyComponentName, "XService"))
+	first := parent.With(String("k", "1"))
+	second := parent.With(String("k", "2"))
+
+	require.NoError(t, log.Configure(OutputOptions{
+		FileEnabled: true,
+		Format:      "json",
+		File:        rollingfile.Config{Path: path},
+	}))
+	defer func() { _ = log.Close() }()
+
+	first.Info(context.Background(), "first message")
+	second.Info(context.Background(), "second message")
+
+	content, err := os.ReadFile(path) // #nosec G304 -- test reads a file under t.TempDir().
+	require.NoError(t, err)
+	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+	require.Len(t, lines, 2)
+	assert.Contains(t, lines[0], `"k":"1"`)
+	assert.NotContains(t, lines[0], `"k":"2"`)
+	assert.Contains(t, lines[1], `"k":"2"`)
+	assert.NotContains(t, lines[1], `"k":"1"`)
+}
+
+func TestSetLevelAffectsDerivedLoggersAfterConfigure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "thunderid.log")
+	log := freshLogger()
+
+	svc := log.With(String(LoggerKeyComponentName, "XService"))
+
+	require.NoError(t, log.Configure(OutputOptions{
+		FileEnabled: true,
+		Format:      "json",
+		File:        rollingfile.Config{Path: path},
+	}))
+	defer func() { _ = log.Close() }()
+
+	require.NoError(t, log.SetLevel("error"))
+	svc.Info(context.Background(), "suppressed message")
+
+	require.NoError(t, log.SetLevel("debug"))
+	svc.Debug(context.Background(), "emitted message")
+
+	content, err := os.ReadFile(path) // #nosec G304 -- test reads a file under t.TempDir().
+	require.NoError(t, err)
+	assert.NotContains(t, string(content), "suppressed message")
+	assert.Contains(t, string(content), "emitted message")
+}
+
+func TestTraceIDPreservedOnDerivedLoggerAfterConfigure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "thunderid.log")
+	log := freshLogger()
+
+	svc := log.With(String(LoggerKeyComponentName, "XService"))
+
+	require.NoError(t, log.Configure(OutputOptions{
+		FileEnabled: true,
+		Format:      "json",
+		File:        rollingfile.Config{Path: path},
+	}))
+	defer func() { _ = log.Close() }()
+
+	svc.Info(sysContext.WithTraceID(context.Background(), "trace-abc"), "traced message")
+
+	content, err := os.ReadFile(path) // #nosec G304 -- test reads a file under t.TempDir().
+	require.NoError(t, err)
+	assert.Contains(t, string(content), `"`+LoggerKeyTraceID+`":"trace-abc"`)
+}
+
+// TestConfigureConcurrentWithLogging exercises the atomic state swap against loggers
+// derived up front, the way the access log middleware holds one across a reconfigure.
+func TestConfigureConcurrentWithLogging(t *testing.T) {
+	dir := t.TempDir()
+	log := freshLogger()
+
+	derived := make([]*Logger, 8)
+	for i := range derived {
+		derived[i] = log.With(String(LoggerKeyComponentName, "Service"+strconv.Itoa(i)))
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for _, l := range derived {
+		wg.Add(1)
+		go func(l *Logger) {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					l.Info(context.Background(), "concurrent message")
+				}
+			}
+		}(l)
+	}
+
+	for i := range 10 {
+		format := "text"
+		if i%2 == 0 {
+			format = "json"
+		}
+		require.NoError(t, log.Configure(OutputOptions{
+			FileEnabled: true,
+			Format:      format,
+			File:        rollingfile.Config{Path: filepath.Join(dir, "run"+strconv.Itoa(i)+".log")},
+		}))
+	}
+
+	close(stop)
+	wg.Wait()
+	assert.NoError(t, log.Close())
+}
+
+func TestCloseIsSharedAndIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "thunderid.log")
+	log := freshLogger()
+
+	require.NoError(t, log.Configure(OutputOptions{
+		FileEnabled: true,
+		File:        rollingfile.Config{Path: path},
+	}))
+
+	derived := log.With(String(LoggerKeyComponentName, "XService"))
+	require.NoError(t, derived.Close())
+	assert.Nil(t, log.root.fileWriter, "closing a derived logger closes the shared writer")
+	assert.NoError(t, log.Close(), "Close must be idempotent")
+}
+
+func BenchmarkDerivedLoggerInfo(b *testing.B) {
+	path := filepath.Join(b.TempDir(), "thunderid.log")
+	log := freshLogger()
+
+	if err := log.Configure(OutputOptions{
+		FileEnabled: true,
+		Format:      "json",
+		File:        rollingfile.Config{Path: path},
+	}); err != nil {
+		b.Fatal(err)
+	}
+	defer func() { _ = log.Close() }()
+
+	svc := log.With(String(LoggerKeyComponentName, "XService"))
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for b.Loop() {
+		svc.Info(ctx, "benchmark message")
+	}
+}
+
+// TestSetFormatPreservesFileOutput is the regression test for the embedded-engine
+// defect: the engine applied its configured format by calling Configure with a
+// console-only OutputOptions, which replaced the host's output and closed its file
+// writer. SetFormat changes only the format.
+func TestSetFormatPreservesFileOutput(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "thunderid.log")
+	log := freshLogger()
+
+	require.NoError(t, log.Configure(OutputOptions{
+		ConsoleEnabled: false,
+		FileEnabled:    true,
+		Format:         formatText,
+		File:           rollingfile.Config{Path: path},
+	}))
+	defer func() { _ = log.Close() }()
+
+	log.Info(context.Background(), "before format change")
+	require.NoError(t, log.SetFormat(formatJSON))
+	log.Info(context.Background(), "after format change")
+
+	content, err := os.ReadFile(path) // #nosec G304 -- test reads a file under t.TempDir().
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+	require.Len(t, lines, 2, "file output must survive SetFormat")
+	assert.Contains(t, lines[0], "before format change")
+	assert.NotContains(t, lines[0], "{", "first record predates the format change")
+
+	var record map[string]any
+	require.NoError(t, json.Unmarshal([]byte(lines[1]), &record),
+		"record after SetFormat must be JSON")
+	assert.Equal(t, "after format change", record["msg"])
+}
+
+// TestSetFormatAppliesToLoggerDerivedBeforeCall ensures the format swap reaches loggers
+// that services captured in their constructors.
+func TestSetFormatAppliesToLoggerDerivedBeforeCall(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "thunderid.log")
+	log := freshLogger()
+
+	require.NoError(t, log.Configure(OutputOptions{
+		FileEnabled: true,
+		Format:      formatText,
+		File:        rollingfile.Config{Path: path},
+	}))
+	defer func() { _ = log.Close() }()
+
+	derived := log.With(String(LoggerKeyComponentName, "FlowEngine"))
+	require.NoError(t, log.SetFormat(formatJSON))
+	derived.Info(context.Background(), "executing node")
+
+	content, err := os.ReadFile(path) // #nosec G304 -- test reads a file under t.TempDir().
+	require.NoError(t, err)
+
+	var record map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(string(content))), &record))
+	assert.Equal(t, "executing node", record["msg"])
+	assert.Equal(t, "FlowEngine", record[LoggerKeyComponentName])
+}
+
+func TestSetFormatRejectsInvalidFormats(t *testing.T) {
+	log := freshLogger()
+
+	assert.Error(t, log.SetFormat(""), "empty format must be rejected")
+	assert.Error(t, log.SetFormat("xml"), "unsupported format must be rejected")
+	assert.NoError(t, log.SetFormat("JSON"), "format matching is case-insensitive")
+}
+
+// TestSetFormatDoesNotCloseFileWriter guards the specific mechanism that broke the
+// embedded path: Configure closes the previous file writer, so a format-only change
+// must not go through it.
+func TestSetFormatDoesNotCloseFileWriter(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "thunderid.log")
+	log := freshLogger()
+
+	require.NoError(t, log.Configure(OutputOptions{
+		FileEnabled: true,
+		Format:      formatText,
+		File:        rollingfile.Config{Path: path},
+	}))
+	defer func() { _ = log.Close() }()
+
+	writer := log.root.fileWriter
+	require.NotNil(t, writer)
+
+	require.NoError(t, log.SetFormat(formatJSON))
+	assert.Same(t, writer, log.root.fileWriter, "SetFormat must not swap the file writer")
 }

--- a/backend/internal/system/log/log.go
+++ b/backend/internal/system/log/log.go
@@ -7,12 +7,14 @@ package log
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	stdlog "log"
 	"log/slog"
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/thunder-id/thunderid/internal/system/constants"
 	sysContext "github.com/thunder-id/thunderid/internal/system/context"
@@ -26,9 +28,8 @@ var (
 
 // Logger is a wrapper around the slog logger.
 type Logger struct {
-	internal   *slog.Logger
-	levelVar   *slog.LevelVar
-	fileWriter *rollingfile.Writer
+	internal *slog.Logger
+	root     *root
 }
 
 // OutputOptions describes where and how the logger writes. It is a log-package
@@ -44,6 +45,116 @@ type OutputOptions struct {
 	// File configures the rotating file writer (its Path must be resolved to an
 	// absolute path by the caller). Ignored when FileEnabled is false.
 	File rollingfile.Config
+}
+
+// root holds the process-wide logging state shared by the singleton logger and
+// every logger derived from it. Configure swaps the state atomically, so loggers
+// derived before Configure ran still write through the newly configured handler.
+type root struct {
+	state    atomic.Pointer[rootState]
+	levelVar *slog.LevelVar
+
+	// mu serializes Configure, SetFormat and Close, and guards the fields below.
+	mu         sync.Mutex
+	fileWriter *rollingfile.Writer
+	// out is the sink the current handler writes to, and format is the format it
+	// was built with. SetFormat rebuilds the handler from them so it can change the
+	// format without discarding the configured output.
+	out    io.Writer
+	format string
+}
+
+// rootState is an immutable snapshot of the configured output handler. A new
+// value is allocated on every Configure, so derived handlers can detect that
+// their cached handler chain is stale by comparing pointers.
+type rootState struct {
+	handler slog.Handler
+}
+
+// derivation records a single WithAttrs or WithGroup call so it can be replayed,
+// in order, onto a swapped root handler.
+type derivation struct {
+	// group is the group name for a WithGroup call, and empty for WithAttrs.
+	// slog treats WithGroup("") as a no-op, so an empty name is never recorded
+	// and the field is an unambiguous discriminator.
+	group string
+	attrs []slog.Attr
+}
+
+// resolvedHandler caches a replayed handler chain together with the root state
+// it was built from.
+type resolvedHandler struct {
+	from    *rootState
+	handler slog.Handler
+}
+
+// dynamicHandler is the handler installed on every Logger. It owns no output
+// handler of its own: it resolves the root's current handler and replays the
+// recorded derivations onto it. The result is cached until Configure installs a
+// new root state, so the steady-state path is two atomic loads and no allocation.
+type dynamicHandler struct {
+	// derivations is immutable once the handler is constructed.
+	derivations []derivation
+	root        *root
+	cache       atomic.Pointer[resolvedHandler]
+}
+
+var _ slog.Handler = (*dynamicHandler)(nil)
+
+// resolve returns the handler for the current root state, rebuilding and caching
+// the derivation chain when the state has been swapped since the last call.
+func (h *dynamicHandler) resolve() slog.Handler {
+	state := h.root.state.Load()
+	if cached := h.cache.Load(); cached != nil && cached.from == state {
+		return cached.handler
+	}
+
+	handler := state.handler
+	for _, d := range h.derivations {
+		if d.group != "" {
+			handler = handler.WithGroup(d.group)
+			continue
+		}
+		handler = handler.WithAttrs(d.attrs)
+	}
+	// Concurrent resolvers build equivalent chains, so the last store wins.
+	h.cache.Store(&resolvedHandler{from: state, handler: handler})
+	return handler
+}
+
+// Enabled reports whether the current handler handles records at the given level.
+func (h *dynamicHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.resolve().Enabled(ctx, level)
+}
+
+// Handle delegates the record to the current handler.
+func (h *dynamicHandler) Handle(ctx context.Context, record slog.Record) error {
+	return h.resolve().Handle(ctx, record)
+}
+
+// WithAttrs records the attributes so they are replayed on the current handler.
+func (h *dynamicHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	return h.derive(derivation{attrs: attrs})
+}
+
+// WithGroup records the group so it is replayed on the current handler.
+func (h *dynamicHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	return h.derive(derivation{group: name})
+}
+
+// derive appends d to the recorded derivations. The slice is copied rather than
+// appended in place so sibling handlers derived from the same parent never share
+// a backing array and overwrite each other's last derivation.
+func (h *dynamicHandler) derive(d derivation) *dynamicHandler {
+	derivations := make([]derivation, len(h.derivations), len(h.derivations)+1)
+	copy(derivations, h.derivations)
+	return &dynamicHandler{derivations: append(derivations, d), root: h.root}
 }
 
 // contextHandler decorates a slog.Handler to add the trace ID (correlation ID)
@@ -88,6 +199,32 @@ func GetLogger() *Logger {
 	return logger
 }
 
+// Log record formats accepted by Configure and SetFormat. Any other value is
+// treated as formatText.
+const (
+	formatText = "text"
+	formatJSON = "json"
+)
+
+// newFormatHandler builds the output handler for the given format. It is the single
+// place that maps a format name onto an slog handler, so Configure, SetFormat and the
+// rotating file's error sink cannot drift apart.
+func newFormatHandler(format string, out io.Writer, levelVar *slog.LevelVar) slog.Handler {
+	handlerOptions := &slog.HandlerOptions{Level: levelVar}
+	if strings.EqualFold(format, formatJSON) {
+		return slog.NewJSONHandler(out, handlerOptions)
+	}
+	return slog.NewTextHandler(out, handlerOptions)
+}
+
+// newLogger wires a Logger onto base. Loggers derived from the result follow
+// whatever handler Configure installs later.
+func newLogger(base slog.Handler, levelVar *slog.LevelVar, out io.Writer) *Logger {
+	r := &root{levelVar: levelVar, out: out, format: formatText}
+	r.state.Store(&rootState{handler: base})
+	return &Logger{internal: slog.New(&dynamicHandler{root: r}), root: r}
+}
+
 // initLogger initializes the slog logger.
 func initLogger() error {
 	// The logger is initialized before the deployment configuration is loaded, so it
@@ -110,10 +247,7 @@ func initLogger() error {
 		return errors.New("failed to create log handler")
 	}
 
-	logger = &Logger{
-		internal: slog.New(&contextHandler{Handler: logHandler}),
-		levelVar: levelVar,
-	}
+	logger = newLogger(&contextHandler{Handler: logHandler}, levelVar, os.Stdout)
 
 	return nil
 }
@@ -124,15 +258,16 @@ func (l *Logger) SetLevel(logLevel string) error {
 	if err != nil {
 		return err
 	}
-	l.levelVar.Set(level)
+	l.root.levelVar.Set(level)
 	return nil
 }
 
 // Configure applies the output configuration, rebuilding the underlying slog
 // handler to write to the console, a rotating file, or both. It preserves the
 // shared level variable so a prior SetLevel keeps taking effect, and keeps the
-// trace ID decoration via contextHandler. It is intended to be called once during
-// startup, right after the configured level is applied.
+// trace ID decoration via contextHandler. Because the handler lives on the shared
+// root, loggers derived before Configure ran also pick up the new output, so the
+// order of Configure relative to service construction does not matter.
 func (l *Logger) Configure(opts OutputOptions) error {
 	writers := make([]io.Writer, 0, 2)
 	if opts.ConsoleEnabled {
@@ -141,7 +276,9 @@ func (l *Logger) Configure(opts OutputOptions) error {
 
 	var fileWriter *rollingfile.Writer
 	if opts.FileEnabled {
-		w, err := rollingfile.New(opts.File)
+		fileCfg := opts.File
+		fileCfg.OnError = newFileErrorSink(opts.Format, l.root.levelVar)
+		w, err := rollingfile.New(fileCfg)
 		if err != nil {
 			return err
 		}
@@ -161,36 +298,79 @@ func (l *Logger) Configure(opts OutputOptions) error {
 		out = io.MultiWriter(writers...)
 	}
 
-	handlerOptions := &slog.HandlerOptions{Level: l.levelVar}
-	var handler slog.Handler
-	if strings.EqualFold(opts.Format, "json") {
-		handler = slog.NewJSONHandler(out, handlerOptions)
-	} else {
-		handler = slog.NewTextHandler(out, handlerOptions)
-	}
+	handler := newFormatHandler(opts.Format, out, l.root.levelVar)
 
-	previous := l.fileWriter
-	l.internal = slog.New(&contextHandler{Handler: handler})
-	l.fileWriter = fileWriter
+	l.root.mu.Lock()
+	defer l.root.mu.Unlock()
+
+	previous := l.root.fileWriter
+	l.root.state.Store(&rootState{handler: &contextHandler{Handler: handler}})
+	l.root.fileWriter = fileWriter
+	l.root.out = out
+	l.root.format = opts.Format
 	if previous != nil {
 		_ = previous.Close()
 	}
 	return nil
 }
 
-// Close releases the file writer, if any. It should be called during shutdown.
-func (l *Logger) Close() error {
-	if l.fileWriter != nil {
-		return l.fileWriter.Close()
+// SetFormat changes the record format without touching where the records go. It exists
+// for callers that own the format but not the output configuration, such as an embedded
+// engine running inside a host application that has already configured the file sink:
+// calling Configure there would replace the host's output with a console-only one and
+// close its file writer.
+func (l *Logger) SetFormat(format string) error {
+	if format == "" {
+		return errors.New("log format is empty")
 	}
+	if !strings.EqualFold(format, formatText) && !strings.EqualFold(format, formatJSON) {
+		return errors.New("unsupported log format: " + format)
+	}
+
+	l.root.mu.Lock()
+	defer l.root.mu.Unlock()
+
+	if strings.EqualFold(format, l.root.format) {
+		return nil
+	}
+
+	handler := newFormatHandler(format, l.root.out, l.root.levelVar)
+	l.root.state.Store(&rootState{handler: &contextHandler{Handler: handler}})
+	l.root.format = format
 	return nil
+}
+
+// newFileErrorSink returns the reporter for the rotating file writer's own failures.
+// They cannot go through this logger, because it writes through that same writer and a
+// file failure would recurse, so they are emitted on stderr in the configured format at
+// WARN level. That keeps them parseable by the same pipeline as the rest of the logs.
+func newFileErrorSink(format string, levelVar *slog.LevelVar) func(msg string) {
+	stderrLogger := slog.New(newFormatHandler(format, os.Stderr, levelVar))
+	return func(msg string) {
+		stderrLogger.Warn(msg)
+	}
+}
+
+// Close releases the file writer, if any. It should be called during shutdown.
+// The writer lives on the shared root, so closing any derived logger closes the
+// single process-wide file sink. Close is idempotent.
+func (l *Logger) Close() error {
+	l.root.mu.Lock()
+	defer l.root.mu.Unlock()
+
+	if l.root.fileWriter == nil {
+		return nil
+	}
+	err := l.root.fileWriter.Close()
+	l.root.fileWriter = nil
+	return err
 }
 
 // With creates a new logger instance with additional fields.
 func (l *Logger) With(fields ...Field) *Logger {
 	return &Logger{
 		internal: l.internal.With(convertFields(fields)...),
-		levelVar: l.levelVar,
+		root:     l.root,
 	}
 }
 
@@ -264,6 +444,26 @@ func (w *serverErrorWriter) Write(p []byte) (int, error) {
 // handshake errors) through the framework logger at WARN level.
 func NewServerErrorLog(logger *Logger) *stdlog.Logger {
 	return stdlog.New(&serverErrorWriter{logger: logger}, "", 0)
+}
+
+// RedisLogger adapts go-redis diagnostics into the framework logger. It satisfies
+// go-redis's logging interface structurally, so its internal package never has to be
+// imported: pass the value NewRedisLogger returns straight to redis.SetLogger.
+type RedisLogger struct {
+	logger *Logger
+}
+
+// Printf forwards a go-redis diagnostic line to the framework logger at WARN level.
+// go-redis carries no level of its own and only emits problems (pool and pub/sub
+// failures), so WARN matches how http.Server connection errors are handled above.
+func (l *RedisLogger) Printf(ctx context.Context, format string, v ...any) {
+	l.logger.Warn(ctx, strings.TrimSpace(fmt.Sprintf(format, v...)))
+}
+
+// NewRedisLogger returns an adapter for go-redis's redis.SetLogger, so the library's
+// diagnostics are emitted through the configured handler instead of raw stderr.
+func NewRedisLogger(logger *Logger) *RedisLogger {
+	return &RedisLogger{logger: logger}
 }
 
 // parseLogLevel parses the log level string and returns the corresponding slog.Level.

--- a/backend/internal/system/log/log_test.go
+++ b/backend/internal/system/log/log_test.go
@@ -120,9 +120,7 @@ func (suite *LogTestSuite) TestLogMethods() {
 		Level: slog.LevelDebug,
 	}
 	logHandler := slog.NewTextHandler(&buf, handlerOptions)
-	logger = &Logger{
-		internal: slog.New(logHandler),
-	}
+	logger = newLogger(logHandler, new(slog.LevelVar), &buf)
 	log := logger
 
 	ctx := context.Background()
@@ -153,9 +151,7 @@ func (suite *LogTestSuite) TestLoggerWith() {
 		Level: slog.LevelDebug,
 	}
 	logHandler := slog.NewTextHandler(&buf, handlerOptions)
-	logger = &Logger{
-		internal: slog.New(logHandler),
-	}
+	logger = newLogger(logHandler, new(slog.LevelVar), &buf)
 	log := logger
 
 	contextLogger := log.With(Field{Key: "context", Value: "test"})
@@ -293,9 +289,8 @@ func newContextTestLogger(buf *bytes.Buffer) *Logger {
 	handlerOptions := &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	}
-	return &Logger{
-		internal: slog.New(&contextHandler{Handler: slog.NewTextHandler(buf, handlerOptions)}),
-	}
+	handler := &contextHandler{Handler: slog.NewTextHandler(buf, handlerOptions)}
+	return newLogger(handler, new(slog.LevelVar), buf)
 }
 
 func (suite *LogTestSuite) TestContextLogMethodsWithTraceID() {
@@ -375,8 +370,10 @@ func (suite *LogTestSuite) TestGetLoggerUsesContextHandler() {
 	once = sync.Once{}
 
 	log := GetLogger()
-	_, ok := log.internal.Handler().(*contextHandler)
-	assert.True(suite.T(), ok, "GetLogger should wrap the handler with contextHandler")
+	_, ok := log.internal.Handler().(*dynamicHandler)
+	assert.True(suite.T(), ok, "GetLogger should install the dynamic handler")
+	_, ok = log.root.state.Load().handler.(*contextHandler)
+	assert.True(suite.T(), ok, "GetLogger should wrap the root handler with contextHandler")
 }
 
 func (suite *LogTestSuite) TestServerErrorWriterWrite() {
@@ -399,11 +396,10 @@ func (suite *LogTestSuite) TestServerErrorWriterWrite() {
 
 func (suite *LogTestSuite) TestServerErrorWriterRespectsLevel() {
 	var buf bytes.Buffer
-	log := newContextTestLogger(&buf)
-	log.levelVar = new(slog.LevelVar)
-	log.levelVar.Set(slog.LevelError)
-	log.internal = slog.New(&contextHandler{Handler: slog.NewTextHandler(&buf,
-		&slog.HandlerOptions{Level: log.levelVar})})
+	levelVar := new(slog.LevelVar)
+	levelVar.Set(slog.LevelError)
+	log := newLogger(&contextHandler{Handler: slog.NewTextHandler(&buf,
+		&slog.HandlerOptions{Level: levelVar})}, levelVar, &buf)
 	w := &serverErrorWriter{logger: log}
 
 	_, err := w.Write([]byte("some server error"))
@@ -447,4 +443,32 @@ func (suite *LogTestSuite) TestConvertFields() {
 	assert.Contains(suite.T(), output, "string=value")
 	assert.Contains(suite.T(), output, "int=42")
 	assert.Contains(suite.T(), output, "bool=true")
+}
+
+func TestRedisLoggerPrintf(t *testing.T) {
+	var buf bytes.Buffer
+	log := newContextTestLogger(&buf)
+
+	NewRedisLogger(log).Printf(sysContext.WithTraceID(context.Background(), "trace-redis"),
+		"redis: connection pool timeout after %ds\n", 5)
+
+	output := buf.String()
+	assert.Contains(t, output, "level=WARN")
+	assert.Contains(t, output, "redis: connection pool timeout after 5s")
+	assert.Contains(t, output, LoggerKeyTraceID+"=trace-redis")
+	// The trailing newline from the library's format string must not be logged.
+	assert.NotContains(t, output, `5s\n`)
+}
+
+func TestRedisLoggerRespectsLevel(t *testing.T) {
+	var buf bytes.Buffer
+	levelVar := new(slog.LevelVar)
+	levelVar.Set(slog.LevelError)
+	log := newLogger(&contextHandler{Handler: slog.NewTextHandler(&buf,
+		&slog.HandlerOptions{Level: levelVar})}, levelVar, &buf)
+
+	NewRedisLogger(log).Printf(context.Background(), "redis: some diagnostic")
+
+	// WARN is below the ERROR threshold, so nothing should be emitted.
+	assert.Empty(t, buf.String())
 }

--- a/backend/internal/system/log/rollingfile/rollingfile.go
+++ b/backend/internal/system/log/rollingfile/rollingfile.go
@@ -50,6 +50,10 @@ type Config struct {
 	MaxAgeDays int
 	// Compress controls whether rotated files are gzip-compressed.
 	Compress bool
+	// OnError reports a rotation, compression, or pruning failure. It must not write
+	// through this writer, or a file failure would recurse. When nil the message is
+	// written to stderr.
+	OnError func(msg string)
 }
 
 // Writer is a size- and/or time-rotating file writer that implements io.Writer.
@@ -67,6 +71,17 @@ type Writer struct {
 }
 
 var _ io.WriteCloser = (*Writer)(nil)
+
+// reportError surfaces a failure in the writer's own housekeeping. These cannot be
+// logged through the framework logger, because that logger writes through this writer
+// and a file failure would recurse; the configured sink formats them on stderr instead.
+func (w *Writer) reportError(msg string) {
+	if w.config.OnError != nil {
+		w.config.OnError(msg)
+		return
+	}
+	fmt.Fprintln(os.Stderr, msg)
+}
 
 // New opens (creating if needed) the file at cfg.Path and returns a Writer. When
 // time-based rotation is configured, it starts a background goroutine that rotates
@@ -154,7 +169,7 @@ func (w *Writer) rotateOnSchedule() {
 		return
 	}
 	if err := w.rotate(); err != nil {
-		fmt.Fprintf(os.Stderr, "rollingfile: scheduled rotation failed: %v\n", err)
+		w.reportError(fmt.Sprintf("rollingfile: scheduled rotation failed: %v", err))
 	}
 }
 
@@ -214,7 +229,7 @@ func (w *Writer) rotate() error {
 		// Closing can fail without leaving a usable descriptor; log and continue so
 		// a transient close error does not permanently block rotation. The file is
 		// reopened (or w.file cleared) below in every path.
-		fmt.Fprintf(os.Stderr, "rollingfile: failed to close file during rotation: %v\n", err)
+		w.reportError(fmt.Sprintf("rollingfile: failed to close file during rotation: %v", err))
 	}
 
 	rotatedPath := w.uniqueRotatedPath(time.Now())
@@ -235,7 +250,7 @@ func (w *Writer) rotate() error {
 	if w.config.Compress {
 		if err := compressFile(rotatedPath); err != nil {
 			// Compression is best-effort; keep the uncompressed backup and carry on.
-			fmt.Fprintf(os.Stderr, "rollingfile: failed to compress %s: %v\n", rotatedPath, err)
+			w.reportError(fmt.Sprintf("rollingfile: failed to compress %s: %v", rotatedPath, err))
 		}
 	}
 
@@ -287,7 +302,7 @@ func (w *Writer) cleanup() {
 	base := filepath.Base(w.config.Path)
 	matches, err := filepath.Glob(filepath.Join(dir, base+".*"))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "rollingfile: failed to list rotated files: %v\n", err)
+		w.reportError(fmt.Sprintf("rollingfile: failed to list rotated files: %v", err))
 		return
 	}
 
@@ -319,7 +334,7 @@ func (w *Writer) cleanup() {
 		}
 		if remove {
 			if err := os.Remove(path); err != nil {
-				fmt.Fprintf(os.Stderr, "rollingfile: failed to remove old log file %s: %v\n", path, err)
+				w.reportError(fmt.Sprintf("rollingfile: failed to remove old log file %s: %v", path, err))
 			}
 		}
 	}

--- a/backend/internal/system/log/rollingfile/rollingfile_test.go
+++ b/backend/internal/system/log/rollingfile/rollingfile_test.go
@@ -4,6 +4,7 @@
 package rollingfile
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -368,4 +369,35 @@ func TestConcurrentWrites(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+// TestReportErrorUsesConfiguredSink verifies the writer's own housekeeping failures are
+// handed to the configured reporter instead of being written straight to stderr.
+func TestReportErrorUsesConfiguredSink(t *testing.T) {
+	var reported []string
+	w := &Writer{config: Config{OnError: func(msg string) {
+		reported = append(reported, msg)
+	}}}
+
+	w.reportError("rollingfile: something went wrong")
+
+	assert.Equal(t, []string{"rollingfile: something went wrong"}, reported)
+}
+
+// TestReportErrorFallsBackToStderr verifies a writer created without a reporter still
+// surfaces its failures rather than dropping them.
+func TestReportErrorFallsBackToStderr(t *testing.T) {
+	original := os.Stderr
+	r, pipeW, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = pipeW
+	defer func() { os.Stderr = original }()
+
+	w := &Writer{config: Config{}}
+	w.reportError("rollingfile: fallback message")
+
+	require.NoError(t, pipeW.Close())
+	captured, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Contains(t, string(captured), "rollingfile: fallback message")
 }

--- a/backend/internal/system/observability/opentelemetry/provider.go
+++ b/backend/internal/system/observability/opentelemetry/provider.go
@@ -7,8 +7,11 @@ package opentelemetry
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
 	"time"
 
+	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
@@ -16,6 +19,9 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	"google.golang.org/grpc/grpclog"
+
+	"github.com/thunder-id/thunderid/internal/system/log"
 )
 
 // Config holds OpenTelemetry configuration.
@@ -37,6 +43,11 @@ func newTracerProvider(ctx context.Context, cfg Config) (*sdktrace.TracerProvide
 	if !cfg.Enabled {
 		return nil, fmt.Errorf("OpenTelemetry is disabled")
 	}
+
+	// Route OpenTelemetry's and gRPC's own diagnostics through the framework logger. This
+	// runs first because the gRPC logger must be replaced before any gRPC call is made,
+	// and the OTLP exporter created below is the first such caller.
+	routeDiagnosticsToLogger()
 
 	// Set defaults
 	if cfg.ServiceName == "" {
@@ -131,9 +142,157 @@ func createOTLPExporter(ctx context.Context, cfg Config) (sdktrace.SpanExporter,
 	return otlptracegrpc.New(ctx, opts...)
 }
 
-// createStdoutExporter creates a stdout exporter for testing.
+// createStdoutExporter creates a stdout exporter for testing. Spans are written as one
+// JSON object per line, so they do not break a line-oriented log pipeline when the log
+// format is json and both streams share stdout.
 func createStdoutExporter() (sdktrace.SpanExporter, error) {
-	return stdouttrace.New(
-		stdouttrace.WithPrettyPrint(),
-	)
+	return stdouttrace.New()
+}
+
+// loggerComponentName identifies OpenTelemetry's own diagnostics in the log records.
+const loggerComponentName = "OpenTelemetry"
+
+// grpcComponentName identifies the gRPC transport's diagnostics in the log records.
+const grpcComponentName = "gRPC"
+
+// OpenTelemetry maps its verbosity levels onto logr V-levels: warnings are logged at
+// V(1), informational messages at V(4), and debug messages at V(8).
+const (
+	otelWarnVerbosity  = 1
+	otelInfoVerbosity  = 4
+	otelDebugVerbosity = 8
+)
+
+// routeDiagnosticsOnce guards the global logger installations below. gRPC's
+// grpclog.SetLoggerV2 is explicitly not mutex-protected and must be called before any
+// gRPC call, and OpenTelemetry only honors the first SetErrorHandler, so installing them
+// exactly once is both necessary and sufficient.
+var routeDiagnosticsOnce sync.Once
+
+// routeDiagnosticsToLogger sends the internal errors and diagnostics of OpenTelemetry and
+// of the gRPC transport its OTLP exporter runs over through the framework logger. All of
+// them default to writing plain text to stderr, which bypasses the configured log level,
+// format, and file output.
+//
+// The records are emitted against context.Background(): they are raised by the libraries'
+// own background machinery (batch exporters, the global provider, connection management)
+// rather than by a request, so there is no trace ID to attach.
+func routeDiagnosticsToLogger() {
+	routeDiagnosticsOnce.Do(func() {
+		logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentName))
+
+		otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
+			logger.Error(context.Background(), "OpenTelemetry reported an error", log.Error(err))
+		}))
+		otel.SetLogger(logr.New(&otelLogSink{logger: logger}))
+
+		grpclog.SetLoggerV2(&grpcLogSink{
+			logger: log.GetLogger().With(log.String(log.LoggerKeyComponentName, grpcComponentName)),
+		})
+	})
+}
+
+// otelLogSink adapts OpenTelemetry's logr-based internal logger to the framework logger.
+type otelLogSink struct {
+	logger *log.Logger
+}
+
+var _ logr.LogSink = (*otelLogSink)(nil)
+
+// Init is required by logr.LogSink; the framework logger needs no runtime information.
+func (s *otelLogSink) Init(logr.RuntimeInfo) {}
+
+// Enabled gates the library's own work before it builds a record: debug-verbosity
+// messages are skipped unless debug logging is on. The framework logger applies the
+// configured level to everything else when the record is actually emitted.
+func (s *otelLogSink) Enabled(level int) bool {
+	return level < otelDebugVerbosity || s.logger.IsDebugEnabled()
+}
+
+// Info maps the logr verbosity onto the framework log levels.
+func (s *otelLogSink) Info(level int, msg string, keysAndValues ...any) {
+	switch {
+	case level <= otelWarnVerbosity:
+		s.logger.Warn(context.Background(), msg, pairsToFields(keysAndValues)...)
+	case level <= otelInfoVerbosity:
+		s.logger.Info(context.Background(), msg, pairsToFields(keysAndValues)...)
+	default:
+		s.logger.Debug(context.Background(), msg, pairsToFields(keysAndValues)...)
+	}
+}
+
+// Error logs an OpenTelemetry internal error.
+func (s *otelLogSink) Error(err error, msg string, keysAndValues ...any) {
+	s.logger.Error(context.Background(), msg, append(pairsToFields(keysAndValues), log.Error(err))...)
+}
+
+// WithValues returns a sink whose records carry the given key/value pairs.
+func (s *otelLogSink) WithValues(keysAndValues ...any) logr.LogSink {
+	return &otelLogSink{logger: s.logger.With(pairsToFields(keysAndValues)...)}
+}
+
+// WithName returns a sink whose records carry the given logger name.
+func (s *otelLogSink) WithName(name string) logr.LogSink {
+	return &otelLogSink{logger: s.logger.With(log.String("logger", name))}
+}
+
+// pairsToFields converts logr's flat key/value pairs into log fields. A trailing key
+// without a value is dropped, and a non-string key is rendered with its default format.
+func pairsToFields(keysAndValues []any) []log.Field {
+	fields := make([]log.Field, 0, len(keysAndValues)/2)
+	for i := 0; i+1 < len(keysAndValues); i += 2 {
+		key, ok := keysAndValues[i].(string)
+		if !ok {
+			key = fmt.Sprintf("%v", keysAndValues[i])
+		}
+		fields = append(fields, log.Any(key, keysAndValues[i+1]))
+	}
+	return fields
+}
+
+// grpcLogSink adapts gRPC's logger to the framework logger. The OTLP exporter runs over
+// gRPC, whose default logger writes warnings and errors to stderr as plain text.
+type grpcLogSink struct {
+	logger *log.Logger
+}
+
+var _ grpclog.LoggerV2 = (*grpcLogSink)(nil)
+
+// grpcDefaultVerbosity mirrors gRPC's own default verbosity level, so V-gated logging
+// behaves as it does with the library's stock logger.
+const grpcDefaultVerbosity = 0
+
+// V reports whether the requested verbosity level is enabled.
+func (s *grpcLogSink) V(level int) bool { return level <= grpcDefaultVerbosity }
+
+// gRPC's informational logging is very chatty and its own default logger discards it
+// unless GRPC_GO_LOG_SEVERITY_LEVEL asks for it, so it is mapped to debug here.
+func (s *grpcLogSink) Info(args ...any)                 { s.log(s.logger.Debug, fmt.Sprint(args...)) }
+func (s *grpcLogSink) Infoln(args ...any)               { s.log(s.logger.Debug, fmt.Sprintln(args...)) }
+func (s *grpcLogSink) Infof(format string, args ...any) { s.logf(s.logger.Debug, format, args...) }
+
+func (s *grpcLogSink) Warning(args ...any)   { s.log(s.logger.Warn, fmt.Sprint(args...)) }
+func (s *grpcLogSink) Warningln(args ...any) { s.log(s.logger.Warn, fmt.Sprintln(args...)) }
+func (s *grpcLogSink) Warningf(format string, args ...any) {
+	s.logf(s.logger.Warn, format, args...)
+}
+
+func (s *grpcLogSink) Error(args ...any)                 { s.log(s.logger.Error, fmt.Sprint(args...)) }
+func (s *grpcLogSink) Errorln(args ...any)               { s.log(s.logger.Error, fmt.Sprintln(args...)) }
+func (s *grpcLogSink) Errorf(format string, args ...any) { s.logf(s.logger.Error, format, args...) }
+
+// gRPC requires that a Fatal log exits the process, which log.Logger.Fatal does.
+func (s *grpcLogSink) Fatal(args ...any)                 { s.log(s.logger.Fatal, fmt.Sprint(args...)) }
+func (s *grpcLogSink) Fatalln(args ...any)               { s.log(s.logger.Fatal, fmt.Sprintln(args...)) }
+func (s *grpcLogSink) Fatalf(format string, args ...any) { s.logf(s.logger.Fatal, format, args...) }
+
+// log emits msg through the given level, trimming the newline the Sprintln-style
+// variants append.
+func (s *grpcLogSink) log(emit func(context.Context, string, ...log.Field), msg string) {
+	emit(context.Background(), strings.TrimSpace(msg))
+}
+
+// logf formats the message before emitting it through the given level.
+func (s *grpcLogSink) logf(emit func(context.Context, string, ...log.Field), format string, args ...any) {
+	s.log(emit, fmt.Sprintf(format, args...))
 }

--- a/backend/internal/system/observability/opentelemetry/provider_test.go
+++ b/backend/internal/system/observability/opentelemetry/provider_test.go
@@ -5,13 +5,21 @@ package opentelemetry
 
 import (
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
+	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/log/rollingfile"
 )
 
 func TestNewTracerProvider_Disabled(t *testing.T) {
@@ -602,4 +610,99 @@ func BenchmarkCreateSpanNoSampling(b *testing.B) {
 		_, span := tracer.Start(ctx, "benchmark-span")
 		span.End()
 	}
+}
+
+// configuredLogger points the framework logger at a JSON file and returns a reader for it.
+func configuredLogger(t *testing.T) (*log.Logger, func() string) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "thunderid.log")
+	logger := log.GetLogger()
+	require.NoError(t, logger.SetLevel("debug"))
+	require.NoError(t, logger.Configure(log.OutputOptions{
+		FileEnabled: true,
+		Format:      "json",
+		File:        rollingfile.Config{Path: path},
+	}))
+	t.Cleanup(func() { _ = logger.Close() })
+
+	return logger, func() string {
+		content, err := os.ReadFile(path) // #nosec G304 -- test reads a file under t.TempDir().
+		require.NoError(t, err)
+		return string(content)
+	}
+}
+
+func TestOtelLogSinkMapsVerbosityToLevels(t *testing.T) {
+	logger, read := configuredLogger(t)
+	sink := &otelLogSink{logger: logger}
+
+	sink.Info(otelWarnVerbosity, "warn message")
+	sink.Info(otelInfoVerbosity, "info message")
+	sink.Info(otelDebugVerbosity, "debug message")
+
+	output := read()
+	assert.Contains(t, output, `"level":"WARN","msg":"warn message"`)
+	assert.Contains(t, output, `"level":"INFO","msg":"info message"`)
+	assert.Contains(t, output, `"level":"DEBUG","msg":"debug message"`)
+}
+
+func TestOtelLogSinkErrorIncludesCause(t *testing.T) {
+	logger, read := configuredLogger(t)
+	sink := &otelLogSink{logger: logger}
+
+	sink.Error(errors.New("export failed"), "exporter problem", "endpoint", "localhost:4317")
+
+	output := read()
+	assert.Contains(t, output, `"level":"ERROR"`)
+	assert.Contains(t, output, `"msg":"exporter problem"`)
+	assert.Contains(t, output, `"endpoint":"localhost:4317"`)
+	assert.Contains(t, output, "export failed")
+}
+
+func TestOtelLogSinkWithValuesAndName(t *testing.T) {
+	logger, read := configuredLogger(t)
+	sink := &otelLogSink{logger: logger}
+
+	sink.WithValues("exporter", "otlp").WithName("tracer").Info(otelInfoVerbosity, "named message")
+
+	output := read()
+	assert.Contains(t, output, `"exporter":"otlp"`)
+	assert.Contains(t, output, `"logger":"tracer"`)
+	assert.Contains(t, output, `"msg":"named message"`)
+}
+
+func TestPairsToFields(t *testing.T) {
+	assert.Empty(t, pairsToFields(nil))
+
+	fields := pairsToFields([]any{"key", "value", 7, "numeric-key", "dangling"})
+	require.Len(t, fields, 2, "a trailing key without a value is dropped")
+	assert.Equal(t, "key", fields[0].Key)
+	assert.Equal(t, "value", fields[0].Value)
+	assert.Equal(t, "7", fields[1].Key, "a non-string key falls back to its default format")
+	assert.Equal(t, "numeric-key", fields[1].Value)
+}
+
+func TestGrpcLogSinkMapsSeveritiesToLevels(t *testing.T) {
+	logger, read := configuredLogger(t)
+	sink := &grpcLogSink{logger: logger}
+
+	sink.Infof("connecting to %s", "collector:4317")
+	sink.Warningln("transport", "is", "closing")
+	sink.Error("addrConn: failed to connect")
+
+	output := read()
+	assert.Contains(t, output, `"level":"DEBUG","msg":"connecting to collector:4317"`)
+	assert.Contains(t, output, `"level":"WARN","msg":"transport is closing"`)
+	assert.Contains(t, output, `"level":"ERROR","msg":"addrConn: failed to connect"`)
+	// The newline the Sprintln-style variants append must not reach the record.
+	assert.NotContains(t, output, `closing\n`)
+}
+
+func TestGrpcLogSinkVerbosity(t *testing.T) {
+	logger, _ := configuredLogger(t)
+	sink := &grpcLogSink{logger: logger}
+
+	assert.True(t, sink.V(0), "the default verbosity level is enabled")
+	assert.False(t, sink.V(1), "higher verbosity levels are disabled, as in gRPC's own logger")
 }

--- a/backend/pkg/thunderidengine/engine.go
+++ b/backend/pkg/thunderidengine/engine.go
@@ -60,6 +60,23 @@ func New(mux *http.ServeMux, opts ...Option) *Engine {
 		logger.Fatal(ctx, "Engine context is missing required fields", log.Error(err))
 	}
 
+	// Apply the logging configuration before any service is initialized, so the
+	// engine's own boot logging is emitted at the configured level and format.
+	if engineCtx.logConfig.Level != "" {
+		if err := logger.SetLevel(engineCtx.logConfig.Level); err != nil {
+			logger.Fatal(ctx, "invalid log level in LogConfig", log.Error(err))
+		}
+	}
+	if engineCtx.logConfig.Format != "" {
+		// SetFormat rather than Configure: the engine owns the format but not where the
+		// records go. A host application may have configured console and file output
+		// already, and Configure would replace it with a console-only sink and close the
+		// host's file writer.
+		if err := logger.SetFormat(engineCtx.logConfig.Format); err != nil {
+			logger.Fatal(ctx, "failed to configure logger", log.Error(err))
+		}
+	}
+
 	// Initialize the cache manager.
 	engineCtx.cacheManager = cache.Initialize(engineCtx.cacheConfig, engineCtx.serverConfig.Identifier)
 
@@ -192,20 +209,6 @@ func New(mux *http.ServeMux, opts ...Option) *Engine {
 		engineCtx.transactioner, revocationEnforcer, revocationService, oauthConfig)
 	if err != nil {
 		logger.Fatal(ctx, "Failed to initialize OAuth services", log.Error(err))
-	}
-
-	if engineCtx.logConfig.Level != "" {
-		if err := logger.SetLevel(engineCtx.logConfig.Level); err != nil {
-			logger.Fatal(ctx, "invalid log level in LogConfig", log.Error(err))
-		}
-	}
-	if engineCtx.logConfig.Format != "" {
-		if err := logger.Configure(log.OutputOptions{
-			ConsoleEnabled: true,
-			Format:         engineCtx.logConfig.Format,
-		}); err != nil {
-			logger.Fatal(ctx, "failed to configure logger", log.Error(err))
-		}
 	}
 
 	return &Engine{

--- a/backend/pkg/thunderidengine/engine_test.go
+++ b/backend/pkg/thunderidengine/engine_test.go
@@ -8,11 +8,14 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/json"
 	"encoding/pem"
+	"io"
 	"math/big"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -43,6 +46,9 @@ import (
 	"github.com/thunder-id/thunderid/tests/mocks/resourceserverprovidermock"
 	"github.com/thunder-id/thunderid/tests/mocks/runtimestoreprovidermock"
 )
+
+// testKeyID is the signing key identifier shared by the engine initialization tests.
+const testKeyID = "test-key"
 
 type EngineTestSuite struct {
 	suite.Suite
@@ -370,6 +376,99 @@ func generateSelfSignedCertFiles(t *testing.T, dir, certFile, keyFile string) []
 	return certPEM
 }
 
+// TestNew_EmitsJSONForEveryComponent pins the fix for the reported defect: services cache
+// a logger derived in their constructor, so the engine must configure the log output before
+// it builds them, and derived loggers must follow the configured handler. Any component that
+// slipped through would show up here as a plain-text line among the JSON records.
+func (suite *EngineTestSuite) TestNew_EmitsJSONForEveryComponent() {
+	t := suite.T()
+	tempDir := t.TempDir()
+
+	keyID := testKeyID
+	certPEM := generateSelfSignedCertFiles(t, tempDir, "cert.pem", "key.pem")
+	keyConfigs := []engineconfig.KeyConfig{{ID: keyID, CertFile: "cert.pem", KeyFile: "key.pem"}}
+
+	systemconfig.ResetServerRuntime()
+	t.Cleanup(systemconfig.ResetServerRuntime)
+	require.NoError(t, systemconfig.InitializeServerRuntime(tempDir, &systemconfig.Config{
+		GateClient: engineconfig.GateClientConfig{Hostname: "localhost", Port: 8080, Scheme: "https"},
+		Crypto: systemconfig.CryptoConfig{
+			Keys:       keyConfigs,
+			Encryption: engineconfig.EncryptionConfig{Key: "000102030405060708090a0b0c0d0e0f"},
+		},
+		Attestation: systemconfig.AttestationConfig{
+			Apple: systemconfig.AppleAttestationConfig{RootCertificate: string(certPEM)},
+		},
+	}))
+
+	captured := captureStdout(t, func() {
+		require.NotNil(t, New(http.NewServeMux(),
+			WithServerHome(tempDir),
+			WithServerConfig(engineconfig.ServerConfig{Identifier: "test-engine"}),
+			WithObservabilityProvider(newTestObservabilityProvider(t)),
+			WithAuthorizationProvider(newTestAuthzProvider(t)),
+			WithKeyConfigs(keyConfigs),
+			WithJWTConfig(engineconfig.JWTConfig{Issuer: "test-issuer", PreferredKeyID: keyID, ValidityPeriod: 3600}),
+			WithRuntimeStoreProvider(newTestRuntimeStoreProvider(t)),
+			WithRuntimeTransientDBType("memory"),
+			WithEncryptionConfig(engineconfig.EncryptionConfig{Key: "test-encryption-key"}),
+			WithGateClientConfig(engineconfig.GateClientConfig{Hostname: "localhost", Port: 8080, Scheme: "https"}),
+			WithCacheConfig(engineconfig.CacheConfig{Disabled: true}),
+			WithLogConfig(engineconfig.LogConfig{Level: "debug", Format: "json"}),
+			WithIDPProvider(newTestIDPProvider(t)),
+			WithActorProvider(actorprovidermock.NewActorProviderMock(t)),
+			WithDefaultAuthnProvider(newTestDefaultAuthnProvider(t)),
+			WithResourceProvider(resourceserverprovidermock.NewResourceServerProviderMock(t)),
+			WithOUProvider(ouprovidermock.NewOrganizationUnitProviderMock(t)),
+			WithDesignResolveProvider(designprovidermock.NewDesignProviderMock(t)),
+			WithFlowProvider(flowexecmock.NewFlowProviderMock(t)),
+			WithI18nProvider(i18nprovidermock.NewI18nProviderMock(t)),
+			WithConsentProvider(consentprovidermock.NewConsentProviderMock(t)),
+			WithFlowConfig(engineconfig.FlowConfig{Executors: []string{"InviteExecutor", "PermissionValidator"}}),
+		))
+	})
+
+	lines := 0
+	for _, line := range strings.Split(captured, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		lines++
+		var record map[string]any
+		require.NoErrorf(t, json.Unmarshal([]byte(line), &record),
+			"engine emitted a non-JSON log line: %s", line)
+	}
+	assert.Positive(t, lines, "the engine should log during initialization")
+}
+
+// captureStdout redirects os.Stdout for the duration of fn and returns what was written.
+// The logger builds its writer from os.Stdout when Configure runs, which is inside fn.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	original := os.Stdout
+	reader, writer, err := os.Pipe()
+	require.NoError(t, err)
+
+	done := make(chan string, 1)
+	go func() {
+		content, _ := io.ReadAll(reader)
+		done <- string(content)
+	}()
+
+	os.Stdout = writer
+	func() {
+		// Restore and close in a defer so a failure inside fn still unblocks the reader.
+		defer func() {
+			os.Stdout = original
+			_ = writer.Close()
+		}()
+		fn()
+	}()
+
+	return <-done
+}
+
 // TestNew_HappyPath drives New() through its full initialization sequence, using a real
 // self-signed key pair for the default crypto provider and an injected runtime store to avoid
 // needing a real database. The global system runtime config is seeded directly (rather than
@@ -380,7 +479,7 @@ func (suite *EngineTestSuite) TestNew_HappyPath() {
 	t := suite.T()
 	tempDir := t.TempDir()
 
-	keyID := "test-key"
+	keyID := testKeyID
 	certPEM := generateSelfSignedCertFiles(t, tempDir, "cert.pem", "key.pem")
 	keyConfigs := []engineconfig.KeyConfig{{ID: keyID, CertFile: "cert.pem", KeyFile: "key.pem"}}
 
@@ -452,7 +551,7 @@ func (suite *EngineTestSuite) TestNew_InitializesRuntimeStoreWhenNotInjected() {
 	t := suite.T()
 	tempDir := t.TempDir()
 
-	keyID := "test-key"
+	keyID := testKeyID
 	certPEM := generateSelfSignedCertFiles(t, tempDir, "cert.pem", "key.pem")
 	keyConfigs := []engineconfig.KeyConfig{{ID: keyID, CertFile: "cert.pem", KeyFile: "key.pem"}}
 

--- a/docs/content/deployment/configuration.mdx
+++ b/docs/content/deployment/configuration.mdx
@@ -93,9 +93,9 @@ By default <ProductName /> writes logs to the console (stdout) only. You can add
 | `log.output.file.format` | `text` | Log line format: `text` or `json`. Despite its position under `file`, this setting applies to console output as well, so set it to `json` to emit JSON to stdout without enabling file output |
 | `log.output.file.rotation.size.enabled` | `false` | Roll the file over once it reaches `max_size_mb` |
 | `log.output.file.rotation.size.max_size_mb` | `10` | Size (in MB, fractional values allowed, e.g. `0.5`) at which the file is rotated |
-| `log.output.file.rotation.time.enabled` | `false` | Roll the file over on a time schedule |
+| `log.output.file.rotation.time.enabled` | `true` | Roll the file over on a time schedule |
 | `log.output.file.rotation.time.interval_days` | `1` | Roll the file over every N days at local midnight |
-| `log.output.file.rotation.max_backups` | `0` | Maximum number of rotated files to keep (`0` keeps all) |
+| `log.output.file.rotation.max_backups` | `20` | Maximum number of rotated files to keep (`0` keeps all) |
 | `log.output.file.rotation.max_age_days` | `0` | Delete rotated files older than this many days (`0` disables age-based deletion) |
 | `log.output.file.rotation.compress` | `false` | Gzip-compress rotated files |
 
@@ -125,6 +125,10 @@ log:
 With the configuration above, logs are written to `<THUNDER_HOME>/logs/thunderid.log`. When the active file reaches the configured size limit, it is renamed with a timestamp suffix (for example `thunderid.log.2026-07-06-14-30-00`) and a fresh file is started. Older rotated files are then pruned by the configured backup count and age limit.
 
 Size and time triggers are independent and can run together: with both enabled, the file rolls whenever it exceeds the size limit **or** reaches the next time interval, whichever comes first. Time-based rotation rolls at local midnight and skips days with no log output (so idle days do not create empty files).
+
+:::note
+The format applies to every component's log lines, regardless of when that component was created. Diagnostics from the embedded Redis and OpenTelemetry clients are routed through the same logger, so they honor the configured level, format, and file output too. Lines emitted before the configuration is read (server home resolution and configuration loading) are the exception: they use the default text format on stdout, because the format itself is defined in the file being loaded.
+:::
 
 :::note
 This is the <ProductName /> **application log** (the `INFO`/`WARN`/`ERROR` lines the server emits). It is separate from the observability event file sink described in the [Observability](../../deployment/observability) guide, which records structured domain events such as token issuance and flow execution.


### PR DESCRIPTION
### Purpose

Setting `log.output.file.format: json` did not apply to all log output. A user reported that some records stayed in the default text format.

The root cause is that `Logger.With()` snapshots the underlying `slog.Logger`, while `Configure()`, the only place that applies the format, replaced it on the singleton. Any logger derived before `Configure()` ran stayed pinned to the boot text handler on stdout forever. Around 470 call sites cache exactly such a logger in their constructor, for example `logger: log.GetLogger().With(log.String(log.LoggerKeyComponentName, "XService"))`.

`cmd/server/main.go` was unaffected by chance, because it configures the logger before registering services. The embedded engine called `Configure()` at the end of `New()`, after every service had been built, so nearly all of its output stayed text even with `Format: "json"`.

Separately, several streams bypassed the configured handler regardless of ordering:

- go-redis wrote pool diagnostics to stderr as plain text, since `redis.SetLogger` was never called.
- OpenTelemetry export failures, its internal logger, and the gRPC transport behind the OTLP exporter all defaulted to stderr.
- The stdout span exporter used `WithPrettyPrint()`, emitting multi line JSON that breaks a line oriented log pipeline.
- Rotation and pruning failures in the rolling file writer were written to stderr as raw text.

### Approach

**Derived loggers now follow the configured handler.** A `Logger` no longer owns an output handler. It records the ordered `WithAttrs` and `WithGroup` derivations applied to it and resolves them against a shared, atomically swapped root. `Configure()` swaps one pointer, so every logger picks up the new output no matter when it was derived, and the ordering of `Configure()` relative to service construction stops mattering. The replayed chain is cached per root state, keeping the hot path at two atomic loads and zero allocations per record.

Ordering is preserved exactly, since slog treats `WithAttrs` and `WithGroup` call order as significant. Sibling derivations copy the slice rather than appending in place, so two loggers derived from the same parent cannot clobber each other.

**The engine configures logging before it builds any service**, so its own boot logging is emitted at the configured level and format.


**Third party diagnostics are routed through the framework logger.** go-redis via `redis.SetLogger` where the clients are constructed, OpenTelemetry via `otel.SetErrorHandler` and `otel.SetLogger`, and the gRPC transport via `grpclog.SetLoggerV2`. gRPC's informational chatter maps to debug, matching what its own default logger discards, so only real warnings surface at the default level. `WithPrettyPrint()` was dropped from the stdout span exporter.

**Rolling file housekeeping failures** are reported through a new `Config.OnError` sink that formats them in the configured format. They stay on stderr and never go through the file writer, because logging a file failure through the writer that just failed would recurse.

Two modules move from indirect to direct in `backend/go.mod`, `github.com/go-logr/logr` and `google.golang.org/grpc`, both required by the logger interfaces above. `go.sum` is unchanged, as both were already in the module graph.

Startup lines emitted before the configuration is read remain in the default text format, because the format itself lives in the file being loaded. This is now documented.

**The embedded engine no longer replaces the host's output configuration.** `engine.New()`
applied `LogConfig.Format` by calling `Configure()` with a console only `OutputOptions`.
`Configure()` rebuilds the sink from the options it is handed and closes the previous file
writer, so passing no file options did three things at once: it discarded a host
application's file sink, closed that host's file writer, and forced console output back on
even when the host had disabled it. A new `Logger.SetFormat()` rebuilds the handler from
the sink already recorded on the shared root, changing the format and nothing else, and
the engine now calls it. The format to handler mapping is centralised in one
`newFormatHandler` helper so `Configure()`, `SetFormat()` and the rolling file error sink
cannot drift apart.

### Issues, Root Causes and Fixes

A user reported log lines still arriving in text format. Investigation separated five
distinct causes. Only the third was a defect in this repository.

| Symptom | Root cause | Resolution |
| --- | --- | --- |
| Flow debug lines absent | Records are emitted at `Debug`; the default level is `info` | Configuration. Set `log.level: debug` |
| Flow lines in text, not JSON | The format defaults to text when unset. Server: `log.output.file.format` omitted. Engine: `LogConfig.Format` empty, so `New()` skips the format change and the boot text handler from `initLogger` stays in place | Configuration. Set the format explicitly. Text remains the documented default |
| A host application's file output stops at `engine.New()` and everything reverts to stdout | `engine.New()` called `Configure()` with a console only `OutputOptions`, rebuilding the sink and closing the host's file writer | **Code fix in this PR.** `engine.New()` now calls `Logger.SetFormat()` |
| `sql: unknown driver ""` from `DBProvider` | `Database.Config.Type` never populated, so the driver name is the empty string | Configuration. Not reachable from `deployment.yaml`: `config/default.json` supplies `sqlite` and `mergeStructs` only overrides a default when the user value is non zero, so this condition is specific to an under configured embedded engine |
| Interleaved JSON lines carrying `appName: esignet` | A separate process. `@timestamp`, `@version` and `level_value` are a Java logback layout | Out of scope. Configure that application's own logback |

### Verification

Unit tests, in addition to those already covering the derived logger behaviour:

- `TestSetFormatPreservesFileOutput` writes to a file sink, changes the format, and asserts
  the first record is text, the second is JSON, and both are in the same file.
- `TestSetFormatDoesNotCloseFileWriter` asserts the writer pointer is unchanged, guarding
  the specific mechanism that broke the embedded path.
- `TestSetFormatAppliesToLoggerDerivedBeforeCall` asserts the swap reaches loggers captured
  in constructors.
- `TestSetFormatRejectsInvalidFormats` covers the empty and unsupported cases, and
  case insensitive matching.

Manual verification against a running server, `level: debug`, `format: json`:

- Console: 133 JSON records, zero text records after JSON begins. The single preceding text
  line is the documented pre configuration exception.
- File: 132 JSON records, zero non JSON lines.
- Nine distinct components present, all as JSON records.
- Access log records are JSON and carry a populated correlation ID.
- With a Redis cache pointed at a closed port, 19 go-redis diagnostics were emitted as JSON
  and nothing leaked to stderr as raw text.
- With the format omitted, output is text and contains no JSON, confirming the documented
  default is intact.
- Size based rotation at a 0.01 MB threshold produced backups capped at `max_backups`.

`go build ./...`, the tests for `internal/system/log/...` and `pkg/thunderidengine/...`, and
`golangci-lint` over both trees all pass.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [x] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Unified application, Redis, OpenTelemetry, and gRPC diagnostics under the configured logging format, level, and output.
  - Logger changes now apply consistently to existing and newly created components.
  - Log rotation errors can be routed through a configured error handler.

- **Bug Fixes**
  - Improved logging consistency during startup and runtime reconfiguration.
  - Structured JSON output is now compact and consistent across components.

- **Documentation**
  - Time-based rotation is enabled by default, retaining up to 20 rotated files.
  - Documented logging behavior and early-startup exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
