### PR TITLE
Allow backend applications without user types

### DIFF
--- a/frontend/apps/console/src/features/applications/components/create-application/ConfigureApplicationDetails.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/ConfigureApplicationDetails.tsx
@@ -85,9 +85,13 @@ export interface ConfigureApplicationDetailsProps {
   hasDesignStep: boolean;
 
   /**
-   * Available user types. The User Access section only renders when there are two or more.
+   * Available user types. The User Access section only renders for applications that allow user
+   * logins with two or more user types.
    */
   userTypes: UserTypeListItem[];
+
+  /** Whether this application supports authentication for end users. */
+  allowsUserLogins: boolean;
 
   /**
    * Currently selected user type names.
@@ -115,7 +119,7 @@ export interface ConfigureApplicationDetailsProps {
  * than one exists), name the application, choose which of that organization unit's configured
  * defaults (sign in / sign up / recovery / sign out flow, theme, layout) to snapshot into the new
  * application instead of building each one from scratch, and pick which user types can sign up
- * through it.
+ * through it when the application allows user logins.
  */
 export default function ConfigureApplicationDetails({
   hasMultipleOUs,
@@ -130,6 +134,7 @@ export default function ConfigureApplicationDetails({
   onOuDefaultsChange,
   hasSecurityStep,
   hasDesignStep,
+  allowsUserLogins,
   userTypes,
   selectedUserTypes,
   onUserTypesChange,
@@ -146,9 +151,18 @@ export default function ConfigureApplicationDetails({
     if (!onReadyChange) return;
     const nameReady = appName.trim().length > 0 && !isDuplicateName;
     const ouReady = !hasMultipleOUs || selectedOuId.length > 0;
-    const userAccessReady = userTypes.length < 2 || selectedUserTypes.length > 0;
+    const userAccessReady = !allowsUserLogins || userTypes.length < 2 || selectedUserTypes.length > 0;
     onReadyChange(nameReady && ouReady && userAccessReady);
-  }, [appName, isDuplicateName, hasMultipleOUs, selectedOuId, userTypes, selectedUserTypes, onReadyChange]);
+  }, [
+    appName,
+    isDuplicateName,
+    hasMultipleOUs,
+    selectedOuId,
+    allowsUserLogins,
+    userTypes,
+    selectedUserTypes,
+    onReadyChange,
+  ]);
 
   // Default to "allow all" the first time user types load, mirroring the master checkbox's
   // default-checked state in UserAccessSection. Seeds at most once — otherwise this would fight
@@ -156,12 +170,12 @@ export default function ConfigureApplicationDetails({
   // very next render.
   const hasSeededUserTypesRef = useRef(false);
   useEffect((): void => {
-    if (hasSeededUserTypesRef.current || userTypes.length < 2) return;
+    if (hasSeededUserTypesRef.current || !allowsUserLogins || userTypes.length < 2) return;
     hasSeededUserTypesRef.current = true;
     if (selectedUserTypes.length === 0) {
       onUserTypesChange(userTypes.map((userType) => userType.name));
     }
-  }, [userTypes, selectedUserTypes.length, onUserTypesChange]);
+  }, [allowsUserLogins, userTypes, selectedUserTypes.length, onUserTypesChange]);
 
   // Pre-check whichever organization-unit defaults are actually available, once per resolved OU
   // id, so admins don't have to manually opt into inheriting them. Keyed by OU id (not a boolean)
@@ -189,7 +203,7 @@ export default function ConfigureApplicationDetails({
         computeOrganizationUnitDefaultAvailability(organizationUnit, {hasSecurityStep, hasDesignStep}),
       ).some(Boolean),
   );
-  const showUserAccess = userTypes.length >= 2;
+  const showUserAccess = allowsUserLogins && userTypes.length >= 2;
 
   return (
     <Stack direction="column" spacing={4} data-testid="application-configure-details">

--- a/frontend/apps/console/src/features/applications/components/create-application/__tests__/ConfigureApplicationDetails.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/__tests__/ConfigureApplicationDetails.test.tsx
@@ -55,6 +55,7 @@ const baseProps = {
   onLogoSelect: vi.fn(),
   hasSecurityStep: true,
   hasDesignStep: true,
+  allowsUserLogins: true,
   userTypes: [],
   selectedUserTypes: [],
   onUserTypesChange: vi.fn(),
@@ -254,6 +255,49 @@ describe('ConfigureApplicationDetails', () => {
       render(
         <ConfigureApplicationDetails
           {...baseProps}
+          resolvedOuId={undefined}
+          ouDefaults={NO_DEFAULTS}
+          onOuDefaultsChange={vi.fn()}
+          userTypes={userTypes}
+        />,
+      );
+
+      expect(screen.getByTestId('application-configure-user-access')).toBeInTheDocument();
+    });
+
+    it('does not render or require user access when the application disallows user logins', () => {
+      mockUseGetOrganizationUnit.mockReturnValue({data: undefined, isLoading: false});
+      const onReadyChange = vi.fn();
+      const onUserTypesChange = vi.fn();
+
+      render(
+        <ConfigureApplicationDetails
+          {...baseProps}
+          hasSecurityStep={false}
+          allowsUserLogins={false}
+          resolvedOuId={undefined}
+          ouDefaults={NO_DEFAULTS}
+          onOuDefaultsChange={vi.fn()}
+          userTypes={userTypes}
+          selectedUserTypes={[]}
+          onUserTypesChange={onUserTypesChange}
+          onReadyChange={onReadyChange}
+        />,
+      );
+
+      expect(screen.queryByTestId('application-configure-user-access')).not.toBeInTheDocument();
+      expect(onUserTypesChange).not.toHaveBeenCalled();
+      expect(onReadyChange).toHaveBeenCalledWith(true);
+    });
+
+    it('uses the explicit user-login setting independently of the Security step', () => {
+      mockUseGetOrganizationUnit.mockReturnValue({data: undefined, isLoading: false});
+
+      render(
+        <ConfigureApplicationDetails
+          {...baseProps}
+          hasSecurityStep={false}
+          allowsUserLogins={true}
           resolvedOuId={undefined}
           ouDefaults={NO_DEFAULTS}
           onOuDefaultsChange={vi.fn()}

--- a/frontend/apps/console/src/features/applications/data/application-templates/platform-based/backend.json
+++ b/frontend/apps/console/src/features/applications/data/application-templates/platform-based/backend.json
@@ -11,7 +11,8 @@
   ],
   "creationFlow": {
     "steps": ["ORGANIZATION_UNIT", "DETAILS", "COMPLETE"],
-    "previewSteps": []
+    "previewSteps": [],
+    "allowsUserLogins": false
   },
   "defaults": {
     "name": "Backend Application",

--- a/frontend/apps/console/src/features/applications/data/application-templates/platform-based/custom.json
+++ b/frontend/apps/console/src/features/applications/data/application-templates/platform-based/custom.json
@@ -5,7 +5,8 @@
   "description": "Fully customizable application with all configuration options available",
   "creationFlow": {
     "steps": ["ORGANIZATION_UNIT", "DETAILS", "COMPLETE"],
-    "previewSteps": []
+    "previewSteps": [],
+    "allowsUserLogins": false
   },
   "defaults": {
     "name": "My Application",

--- a/frontend/apps/console/src/features/applications/models/creation-flow.ts
+++ b/frontend/apps/console/src/features/applications/models/creation-flow.ts
@@ -15,6 +15,8 @@ import type {ApplicationCreateFlowStep} from './application-create-flow';
 export interface CreationFlow {
   /** Ordered list of wizard steps for this flow. */
   steps: ApplicationCreateFlowStep[];
+  /** Whether the application supports authentication for end users. */
+  allowsUserLogins?: boolean;
   /**
    * Which of `steps` render the live sign-in preview panel. Templates with no hosted sign-in
    * screen at all (e.g. machine-to-machine backends) declare this as an empty array so the

--- a/frontend/apps/console/src/features/applications/pages/ApplicationCreatePage.tsx
+++ b/frontend/apps/console/src/features/applications/pages/ApplicationCreatePage.tsx
@@ -183,6 +183,9 @@ export default function ApplicationCreatePage(): JSX.Element {
   // (e.g. beyond the pagination limit). Treated as additional existing names so the details step
   // flags them and blocks readiness until the name is edited, avoiding a resubmit-and-fail loop.
   const [rejectedAppNames, setRejectedAppNames] = useState<string[]>([]);
+  // The applications query is invalidated on success and can briefly return the new application
+  // while this wizard is still mounted for navigation.
+  const [isCreationSubmitted, setIsCreationSubmitted] = useState(false);
 
   const knownAppNames = useMemo(
     (): string[] => [...existingAppNames, ...rejectedAppNames],
@@ -390,6 +393,9 @@ export default function ApplicationCreatePage(): JSX.Element {
     (): boolean => creationFlow.steps.includes(ApplicationCreateFlowStep.SECURITY),
     [creationFlow],
   );
+  const allowsUserLogins =
+    (creationFlow.allowsUserLogins ?? true) &&
+    (!isMcpClientTemplate || mcpClientType === McpClientTypes.USER_DELEGATED);
 
   // Whether this template's flow ever presents a Design step at all. Templates without one (e.g.
   // machine-to-machine backends) have no theme/layout of their own, so inheriting the organization
@@ -587,6 +593,7 @@ export default function ApplicationCreatePage(): JSX.Element {
 
     const userTypes = userTypesData?.types ?? [];
     const allowedUserTypes = (() => {
+      if (!allowsUserLogins) return undefined;
       if (userTypes.length === 1) return [userTypes[0].name];
       if (userTypes.length > 1) return selectedUserTypes.length > 0 ? selectedUserTypes : undefined;
       return undefined;
@@ -658,6 +665,7 @@ export default function ApplicationCreatePage(): JSX.Element {
       }),
     };
 
+    setIsCreationSubmitted(true);
     createApplication.mutate(applicationData, {
       onSuccess: (createdApp: Application): void => {
         // CORS is a deployment-wide setting, not per-application, so origins entered on the
@@ -728,6 +736,7 @@ export default function ApplicationCreatePage(): JSX.Element {
         });
       },
       onError: (err: Error) => {
+        setIsCreationSubmitted(false);
         // The client-side pre-check can miss names beyond the fetched list; when the backend rejects
         // a name as a duplicate, record it so the details step flags it and stays un-ready until the
         // name is edited (preventing a resubmit-and-fail loop), then return there.
@@ -922,11 +931,12 @@ export default function ApplicationCreatePage(): JSX.Element {
             onOuDefaultsChange={setOuDefaults}
             hasSecurityStep={hasSecurityStep}
             hasDesignStep={hasDesignStep}
+            allowsUserLogins={allowsUserLogins}
             userTypes={userTypesData?.types ?? []}
             selectedUserTypes={selectedUserTypes}
             onUserTypesChange={handleUserTypesChange}
             onReadyChange={handleDetailsStepReadyChange}
-            existingAppNames={knownAppNames}
+            existingAppNames={isCreationSubmitted ? knownAppNames.filter((name) => name !== appName) : knownAppNames}
           />
         );
 

--- a/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationCreatePage.test.tsx
+++ b/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationCreatePage.test.tsx
@@ -17,6 +17,13 @@ import ApplicationCreatePage from '../ApplicationCreatePage';
 const mockCreateApplication = vi.fn();
 const mockNavigate = vi.fn();
 let mockPathname = '/';
+const mockUseGetApplications = vi.hoisted(() => vi.fn());
+const mockUserTypes = vi.hoisted(() => ({
+  types: [
+    {id: 'customer', name: 'customer', displayName: 'Customer'},
+    {id: 'employee', name: 'employee', displayName: 'Employee'},
+  ],
+}));
 
 // Mock logger
 vi.mock('@thunderid/logger/react', () => ({
@@ -27,6 +34,11 @@ vi.mock('@thunderid/logger/react', () => ({
     debug: vi.fn(),
     withComponent: vi.fn().mockReturnThis(),
   }),
+}));
+
+vi.mock('@thunderid/configure-applications', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@thunderid/configure-applications')>()),
+  useGetApplications: mockUseGetApplications,
 }));
 
 // Mock react-router
@@ -87,12 +99,7 @@ vi.mock('../../api/useCreateApplication', async () => {
 // Mock user types API
 vi.mock('@thunderid/configure-user-types', () => ({
   useGetUserTypes: () => ({
-    data: {
-      types: [
-        {id: 'customer', name: 'customer', displayName: 'Customer'},
-        {id: 'employee', name: 'employee', displayName: 'Employee'},
-      ],
-    },
+    data: mockUserTypes,
     isLoading: false,
     error: null,
   }),
@@ -491,7 +498,11 @@ function TemplateSeeder(): JSX.Element {
         onClick={() =>
           seed(null, 'BACKEND', {
             id: 'backend',
-            creationFlow: {steps: ['ORGANIZATION_UNIT', 'DETAILS', 'COMPLETE'], previewSteps: []},
+            creationFlow: {
+              steps: ['ORGANIZATION_UNIT', 'DETAILS', 'COMPLETE'],
+              previewSteps: [],
+              allowsUserLogins: false,
+            },
           })
         }
       >
@@ -688,6 +699,12 @@ describe('ApplicationCreatePage', () => {
       data: undefined,
       isLoading: false,
     });
+
+    mockUseGetApplications.mockReturnValue({data: {applications: []}});
+    mockUserTypes.types = [
+      {id: 'customer', name: 'customer', displayName: 'Customer'},
+      {id: 'employee', name: 'employee', displayName: 'Employee'},
+    ];
   });
 
   describe('Initial Rendering', () => {
@@ -1456,6 +1473,84 @@ describe('ApplicationCreatePage', () => {
   });
 
   describe('Error Handling', () => {
+    it('should exclude a newly created application from duplicate-name validation after the list refreshes', async () => {
+      let applicationsData = {applications: [] as Application[]};
+      mockUseGetApplications.mockImplementation(() => ({data: applicationsData}));
+      mockCreateApplication.mockImplementation((_data, {onSuccess}: {onSuccess: (app: Application) => void}) => {
+        applicationsData = {applications: [{id: 'app-123', name: 'My App'} as Application]};
+        onSuccess({id: 'app-123', name: 'My App'} as Application);
+      });
+
+      renderWithProviders();
+
+      await goToDesignStep();
+      // DESIGN → CONFIGURE
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      await waitFor(() => {
+        expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
+      });
+      // CONFIGURE → Create
+      await user.click(screen.getByTestId('application-wizard-next-button'));
+
+      await waitFor(() => {
+        expect(mockCreateApplication).toHaveBeenCalled();
+      });
+
+      // The mocked navigation keeps the wizard mounted. Return to Details after the application
+      // list has refreshed with the created name and verify the submitted name is not treated as a
+      // duplicate while the wizard is still open.
+      await user.click(screen.getByRole('button', {name: 'Details'}));
+      await waitFor(() => {
+        expect(screen.getByTestId('application-configure-name')).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('application-configure-name')).toHaveAttribute('data-existing-names', '');
+      expect(screen.queryByTestId('app-name-duplicate-error')).not.toBeInTheDocument();
+    });
+
+    it('should restore duplicate-name validation when creation fails after a successful submission', async () => {
+      const duplicateError = Object.assign(new Error('Bad Request'), {
+        response: {status: 400, data: {code: 'APP-1020', message: 'Application already exists'}},
+      });
+      let applicationsData = {applications: [] as Application[]};
+      mockUseGetApplications.mockImplementation(() => ({data: applicationsData}));
+      let createAttempt = 0;
+      mockCreateApplication.mockImplementation(
+        (_data, options: {onError: (error: Error) => void; onSuccess: (app: Application) => void}) => {
+          createAttempt += 1;
+          if (createAttempt === 1) {
+            applicationsData = {applications: [{id: 'app-123', name: 'My App'} as Application]};
+            options.onSuccess({id: 'app-123', name: 'My App'} as Application);
+            return;
+          }
+          options.onError(duplicateError);
+        },
+      );
+
+      renderWithProviders();
+
+      await goToDesignStep();
+      // DESIGN → CONFIGURE
+      await user.click(screen.getByRole('button', {name: /continue/i}));
+      await waitFor(() => {
+        expect(screen.getByTestId('application-configure-details')).toBeInTheDocument();
+      });
+      // CONFIGURE → Create successfully once.
+      await user.click(screen.getByTestId('application-wizard-next-button'));
+      await waitFor(() => expect(mockCreateApplication).toHaveBeenCalledTimes(1));
+
+      // Submit the same still-mounted wizard again. The second failure clears isCreationSubmitted,
+      // so the refreshed application name is visible to duplicate validation again.
+      await user.click(screen.getByTestId('application-wizard-next-button'));
+      await waitFor(() => {
+        expect(screen.getByTestId('application-configure-name')).toBeInTheDocument();
+        expect(screen.getByTestId('app-name-duplicate-error')).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('application-configure-name')).toHaveAttribute(
+        'data-existing-names',
+        expect.stringContaining('My App'),
+      );
+    });
+
     it('should show error when application creation fails', async () => {
       mockCreateApplication.mockImplementation((_data, {onError}: {onError: (error: Error) => void}) => {
         onError(new Error('Failed to create application'));
@@ -1790,6 +1885,26 @@ describe('ApplicationCreatePage', () => {
       expect(createAppCall.isRegistrationFlowEnabled).toBeUndefined();
       expect(createAppCall.themeId).toBeUndefined();
       expect(createAppCall.logoUrl).toBeUndefined();
+    });
+
+    it('should create backend app without allowedUserTypes', async () => {
+      mockUserTypes.types = [{id: 'customer', name: 'customer', displayName: 'Customer'}];
+      mockCreateApplication.mockImplementation((_data, {onSuccess}: {onSuccess: (app: Application) => void}) => {
+        onSuccess({id: 'backend-app-no-user-types', name: 'My Backend App'} as Application);
+      });
+
+      renderWithProviders();
+
+      await user.click(screen.getByTestId('select-backend-platform'));
+      await user.type(screen.getByTestId('app-name-input'), 'My Backend App');
+      await user.click(screen.getByTestId('application-wizard-next-button'));
+
+      await waitFor(() => {
+        expect(mockCreateApplication).toHaveBeenCalled();
+      });
+
+      const createAppCall = mockCreateApplication.mock.calls[0][0] as Record<string, unknown>;
+      expect(createAppCall.allowedUserTypes).toBeUndefined();
     });
 
     it('should include the backend template id in the create request', async () => {
@@ -2709,6 +2824,7 @@ describe('ApplicationCreatePage', () => {
     });
 
     it('should submit the machine-to-machine oauth2 config with client_credentials overrides and no redirect URIs', async () => {
+      mockUserTypes.types = [{id: 'customer', name: 'customer', displayName: 'Customer'}];
       mockCreateApplication.mockImplementation((_data, {onSuccess}: {onSuccess: (app: Application) => void}) => {
         onSuccess({id: 'mcp-app-2', name: 'My MCP App'} as Application);
       });
@@ -2727,6 +2843,7 @@ describe('ApplicationCreatePage', () => {
       expect(requestBody.template).toBe('mcp-client');
       // The machine-to-machine MCP client override resolves to the m2m type.
       expect(requestBody.type).toBe('m2m');
+      expect(requestBody.allowedUserTypes).toBeUndefined();
 
       const oauth2Config = requestBody.inboundAuthConfig?.[0];
       expect(oauth2Config?.type).toBe('oauth2');

--- a/frontend/apps/console/src/features/applications/utils/resolveCreationFlow.ts
+++ b/frontend/apps/console/src/features/applications/utils/resolveCreationFlow.ts
@@ -14,6 +14,7 @@ const DEFAULT_USER_FACING_FLOW: CreationFlow = {
     ApplicationCreateFlowStep.CONFIGURE,
     ApplicationCreateFlowStep.COMPLETE,
   ],
+  allowsUserLogins: true,
   previewSteps: [
     ApplicationCreateFlowStep.DETAILS,
     ApplicationCreateFlowStep.SECURITY,


### PR DESCRIPTION
### Purpose
Fix application creation for backend and custom applications by removing the unnecessary user-type requirement and excluding allowedUserTypes from their create payload.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
- Use the application creation flow to determine whether an application is user-facing.
- Show and validate user-type access only when the flow includes a Security step.
- Omit allowedUserTypes from backend and custom application creation requests.
- Preserve user-type selection for applications that support end-user authentication.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4958

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Application templates now indicate whether end-user logins are supported.
  - User Access settings appear only when end-user authentication is enabled.
  - Applications without user logins are marked ready without user-type selection.
  - Standard application flows continue to support user logins by default.

- **Bug Fixes**
  - User-type settings are omitted from creation requests when logins are unavailable.
  - Duplicate-name validation no longer flags the application being created and is restored after a failed creation attempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->