### PR TITLE
Add QR code component to the wallet widget

### DIFF
--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/CommonResourceProperties.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/CommonResourceProperties.tsx
@@ -69,6 +69,7 @@ const TOP_LEVEL_EDITABLE_PROPS = [
   'required',
   'src',
   'alt',
+  'source',
   'width',
   'height',
   'startIcon',

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/PresentationDefinitionSelect.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/PresentationDefinitionSelect.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {useGetVerifiablePresentations} from '@thunderid/configure-verifiable-credentials';
-import {FormControl, FormLabel, MenuItem, TextField} from '@wso2/oxygen-ui';
+import {FormControl, FormHelperText, FormLabel, MenuItem, TextField} from '@wso2/oxygen-ui';
 import type {ChangeEvent, ReactElement} from 'react';
 import {useTranslation} from 'react-i18next';
 
@@ -10,6 +10,11 @@ export interface PresentationDefinitionSelectProps {
   propertyKey: string;
   value: string;
   onChange: (value: string) => void;
+  /**
+   * Validation message for the bound property, or an empty string when it is valid.
+   * @defaultValue ''
+   */
+  errorMessage?: string;
 }
 
 /**
@@ -20,13 +25,15 @@ export default function PresentationDefinitionSelect({
   propertyKey,
   value,
   onChange,
+  errorMessage = '',
 }: PresentationDefinitionSelectProps): ReactElement {
   const {t} = useTranslation();
   const {data, isLoading} = useGetVerifiablePresentations();
   const options = data ?? [];
+  const hasError = !!errorMessage;
 
   return (
-    <FormControl fullWidth sx={{mb: 3}}>
+    <FormControl fullWidth sx={{mb: 3}} error={hasError}>
       <FormLabel htmlFor={propertyKey}>{t('verifiable-presentations:select.label')}</FormLabel>
       <TextField
         select
@@ -34,6 +41,7 @@ export default function PresentationDefinitionSelect({
         id={propertyKey}
         value={value ?? ''}
         disabled={isLoading}
+        error={hasError}
         onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
         placeholder={t('verifiable-presentations:select.placeholder')}
       >
@@ -43,6 +51,7 @@ export default function PresentationDefinitionSelect({
           </MenuItem>
         ))}
       </TextField>
+      {hasError && <FormHelperText error>{errorMessage}</FormHelperText>}
     </FormControl>
   );
 }

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/ResourceProperties.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/ResourceProperties.tsx
@@ -258,6 +258,19 @@ function ResourceProperties({
           </>
         );
       }
+      if (resource.type === ElementTypes.QrCode) {
+        return (
+          <>
+            {renderElementId(true)}
+            <TextPropertyField
+              resource={resource}
+              propertyKey="source"
+              propertyValue={(resource as Element & {source?: string}).source ?? ''}
+              onChange={(_key, value, res) => handleChange('source', value, res, true)}
+            />
+          </>
+        );
+      }
       return (
         <>
           {renderElementId(true)}

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/PresentationDefinitionSelect.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/PresentationDefinitionSelect.test.tsx
@@ -1,0 +1,62 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {render, screen} from '@testing-library/react';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import PresentationDefinitionSelect from '../PresentationDefinitionSelect';
+
+interface VpQueryResult {
+  data: {id: string; handle: string; name?: string}[] | undefined;
+  isLoading: boolean;
+}
+
+const mockUseGetVerifiablePresentations = vi.fn<() => VpQueryResult>();
+
+vi.mock('@thunderid/configure-verifiable-credentials', () => ({
+  useGetVerifiablePresentations: (): VpQueryResult => mockUseGetVerifiablePresentations(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({t: (key: string) => key}),
+}));
+
+describe('PresentationDefinitionSelect', () => {
+  const onChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseGetVerifiablePresentations.mockReturnValue({
+      data: [{id: '1', handle: 'eudi-pid', name: 'EUDI PID'}],
+      isLoading: false,
+    });
+  });
+
+  const renderComponent = (errorMessage?: string): void => {
+    render(
+      <PresentationDefinitionSelect
+        propertyKey="presentation_definition_id"
+        value=""
+        onChange={onChange}
+        errorMessage={errorMessage}
+      />,
+    );
+  };
+
+  it('should render the field validation message when one is supplied', () => {
+    renderComponent('Presentation definition is required');
+
+    expect(screen.getByText('Presentation definition is required')).toBeInTheDocument();
+  });
+
+  it('should render no validation message when the field is valid', () => {
+    renderComponent('');
+
+    expect(screen.queryByText('Presentation definition is required')).not.toBeInTheDocument();
+  });
+
+  it('should render no validation message when the prop is omitted', () => {
+    render(<PresentationDefinitionSelect propertyKey="presentation_definition_id" value="" onChange={onChange} />);
+
+    expect(screen.getByText('verifiable-presentations:select.label')).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/ResourceProperties.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/__tests__/ResourceProperties.test.tsx
@@ -465,6 +465,48 @@ describe('ResourceProperties', () => {
     });
   });
 
+  describe('Display Category - QR Code Type', () => {
+    it('should render the source TextPropertyField for QrCode type', () => {
+      const resource = createMockResource({
+        category: ElementCategories.Display,
+        type: ElementTypes.QrCode,
+        source: 'openid4vpWalletUri',
+      } as Partial<Resource>);
+
+      render(
+        <ResourceProperties
+          resource={resource}
+          properties={{}}
+          onChange={mockOnChange}
+          onVariantChange={mockOnVariantChange}
+        />,
+      );
+
+      expect(screen.getByTestId('text-property-field-source')).toHaveAttribute(
+        'data-property-value',
+        'openid4vpWalletUri',
+      );
+    });
+
+    it('should handle an unset source value', () => {
+      const resource = createMockResource({
+        category: ElementCategories.Display,
+        type: ElementTypes.QrCode,
+      } as Partial<Resource>);
+
+      render(
+        <ResourceProperties
+          resource={resource}
+          properties={{}}
+          onChange={mockOnChange}
+          onVariantChange={mockOnVariantChange}
+        />,
+      );
+
+      expect(screen.getByTestId('text-property-field-source')).toHaveAttribute('data-property-value', '');
+    });
+  });
+
   describe('Display Category - Other Types', () => {
     it('should render default property factories for other Display types', () => {
       const resource = createMockResource({

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/OpenID4VPProperties.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/OpenID4VPProperties.tsx
@@ -7,6 +7,7 @@ import {useTranslation} from 'react-i18next';
 import CheckboxWithHint from './CheckboxWithHint';
 import type {CommonResourcePropertiesPropsInterface} from './types';
 import PresentationDefinitionSelect from '@/features/flows/components/resource-property-panel/PresentationDefinitionSelect';
+import useResourceFieldError from '@/features/flows/hooks/useResourceFieldError';
 import type {StepData} from '@/features/flows/models/steps';
 
 /**
@@ -22,6 +23,8 @@ function OpenID4VPProperties({resource, onChange}: CommonResourcePropertiesProps
     return stepData?.properties ?? {};
   }, [resource]);
 
+  const errorMessage: string = useResourceFieldError(resource?.id, 'data.properties.presentation_definition_id');
+
   return (
     <Stack gap={2}>
       <Typography variant="body2" color="text.secondary">
@@ -31,6 +34,7 @@ function OpenID4VPProperties({resource, onChange}: CommonResourcePropertiesProps
         propertyKey="presentation_definition_id"
         value={(properties.presentation_definition_id as string) ?? ''}
         onChange={(value: string) => onChange('data.properties.presentation_definition_id', value, resource)}
+        errorMessage={errorMessage}
       />
       <CheckboxWithHint
         checked={!!properties.allowAuthenticationWithoutLocalUser}

--- a/frontend/apps/console/src/features/flows/components/resources/elements/CommonElementFactory.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/elements/CommonElementFactory.tsx
@@ -18,6 +18,7 @@ import DefaultInputAdapter from './adapters/input/DefaultInputAdapter';
 import OTPInputAdapter from './adapters/input/OTPInputAdapter';
 import PhoneNumberInputAdapter from './adapters/input/PhoneNumberInputAdapter';
 import SelectAdapter from './adapters/input/SelectAdapter';
+import QrCodeAdapter from './adapters/QrCodeAdapter';
 import ResendButtonAdapter from './adapters/ResendButtonAdapter';
 import RichTextAdapter from './adapters/RichTextAdapter';
 import StackAdapter from './adapters/StackAdapter';
@@ -148,6 +149,9 @@ function CommonElementFactory({
   }
   if (resource.type === ElementTypes.Timer) {
     return <TimerAdapter resource={resource} />;
+  }
+  if (resource.type === ElementTypes.QrCode) {
+    return <QrCodeAdapter resource={resource} />;
   }
   if (resource.type === ElementTypes.Consent || resource.type === ElementTypes.ConsentInput) {
     return <ConsentAdapter />;

--- a/frontend/apps/console/src/features/flows/components/resources/elements/__tests__/CommonElementFactory.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/elements/__tests__/CommonElementFactory.test.tsx
@@ -143,6 +143,14 @@ vi.mock('../adapters/TimerAdapter', () => ({
   ),
 }));
 
+vi.mock('../adapters/QrCodeAdapter', () => ({
+  default: ({resource}: {resource: Element}) => (
+    <div data-testid="qr-code-adapter" data-resource-id={resource.id}>
+      Qr Code Adapter
+    </div>
+  ),
+}));
+
 vi.mock('../adapters/CustomAdapter', () => ({
   default: ({resource}: {resource: Element}) => (
     <div data-testid="custom-adapter" data-resource-id={resource.id}>
@@ -454,6 +462,19 @@ describe('CommonElementFactory', () => {
 
       expect(screen.getByTestId('timer-adapter')).toBeInTheDocument();
       expect(screen.getByTestId('timer-adapter')).toHaveAttribute('data-resource-id', 'element-1');
+    });
+  });
+
+  describe('QR Code Element', () => {
+    it('should render QrCodeAdapter for QrCode type', () => {
+      const qrCodeElement = createMockElement({
+        type: ElementTypes.QrCode,
+      });
+
+      render(<CommonElementFactory stepId="step-1" resource={qrCodeElement} />);
+
+      expect(screen.getByTestId('qr-code-adapter')).toBeInTheDocument();
+      expect(screen.getByTestId('qr-code-adapter')).toHaveAttribute('data-resource-id', 'element-1');
     });
   });
 

--- a/frontend/apps/console/src/features/flows/components/resources/elements/adapters/QrCodeAdapter.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/elements/adapters/QrCodeAdapter.tsx
@@ -1,0 +1,110 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {Typography, Box} from '@wso2/oxygen-ui';
+import {type ReactElement} from 'react';
+import type {Element as FlowElement} from '@/features/flows/models/elements';
+
+/**
+ * QR code element type with properties at top level.
+ */
+export type QrCodeElement = FlowElement & {
+  source?: string;
+};
+
+/**
+ * Props interface for QrCodeAdapter
+ */
+export interface QrCodeAdapterPropsInterface {
+  resource?: FlowElement;
+}
+
+/** Module count of a version 1 QR symbol, which the preview imitates. */
+const MODULE_COUNT = 21;
+
+/** Top-left corner of each of the three finder patterns. */
+const FINDER_ORIGINS: readonly (readonly [number, number])[] = [
+  [0, 0],
+  [MODULE_COUNT - 7, 0],
+  [0, MODULE_COUNT - 7],
+];
+
+/**
+ * A finder pattern is a 7x7 square: a filled outer ring, a one module gap, and a
+ * filled 3x3 core. Ring distance 2 is the gap, everything else within the square is dark.
+ */
+const isFinderModule = (row: number, col: number): boolean =>
+  FINDER_ORIGINS.some(([originRow, originCol]: readonly [number, number]) => {
+    const localRow: number = row - originRow;
+    const localCol: number = col - originCol;
+
+    if (localRow < 0 || localRow > 6 || localCol < 0 || localCol > 6) {
+      return false;
+    }
+
+    return Math.max(Math.abs(localRow - 3), Math.abs(localCol - 3)) !== 2;
+  });
+
+/** The finder patterns plus their one module quiet zone, which carries no data. */
+const isReservedModule = (row: number, col: number): boolean =>
+  FINDER_ORIGINS.some(
+    ([originRow, originCol]: readonly [number, number]) =>
+      row >= originRow - 1 && row <= originRow + 7 && col >= originCol - 1 && col <= originCol + 7,
+  );
+
+/**
+ * Fills the data area from the module coordinates alone. The preview stands in for a code
+ * that only exists at runtime, so the pattern just has to look plausible and, more
+ * importantly, stay identical across renders.
+ */
+const isDataModule = (row: number, col: number): boolean => (row * 7 + col * 13 + row * col * 3) % 5 < 2;
+
+/**
+ * A canvas placeholder for the QR Code element. The real code is generated at runtime from the
+ * `additionalData` key named in `source`, which has no value while authoring, so the canvas shows
+ * a representative symbol and the bound key instead.
+ *
+ * @param props - Custom props containing the resource.
+ * @returns The QrCodeAdapter placeholder component.
+ */
+function QrCodeAdapter({resource = undefined}: QrCodeAdapterPropsInterface): ReactElement {
+  const source: string | undefined = (resource as QrCodeElement)?.source;
+
+  const modules: ReactElement[] = [];
+
+  for (let row = 0; row < MODULE_COUNT; row += 1) {
+    for (let col = 0; col < MODULE_COUNT; col += 1) {
+      if (isFinderModule(row, col) || (!isReservedModule(row, col) && isDataModule(row, col))) {
+        modules.push(<rect key={`${row}-${col}`} x={col} y={row} width={1} height={1} />);
+      }
+    }
+  }
+
+  return (
+    <Box sx={{alignItems: 'center', display: 'flex', flexDirection: 'column', gap: 1, py: 1, width: '100%'}}>
+      <Box
+        component="svg"
+        viewBox={`-1 -1 ${MODULE_COUNT + 2} ${MODULE_COUNT + 2}`}
+        role="img"
+        aria-label="QR Code"
+        shapeRendering="crispEdges"
+        sx={{
+          backgroundColor: 'common.white',
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: 1,
+          fill: 'common.black',
+          height: 120,
+          width: 120,
+        }}
+      >
+        {modules}
+      </Box>
+      <Typography variant="caption" color="textSecondary" sx={{fontFamily: 'monospace'}}>
+        {source ? `{{${source}}}` : 'No source bound'}
+      </Typography>
+    </Box>
+  );
+}
+
+export default QrCodeAdapter;

--- a/frontend/apps/console/src/features/flows/components/resources/elements/adapters/__tests__/QrCodeAdapter.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/elements/adapters/__tests__/QrCodeAdapter.test.tsx
@@ -1,0 +1,51 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import {render, screen} from '@testing-library/react';
+import {describe, it, expect} from 'vitest';
+import QrCodeAdapter, {type QrCodeElement} from '../QrCodeAdapter';
+
+describe('QrCodeAdapter', () => {
+  const createResource = (source?: string): QrCodeElement =>
+    ({
+      id: 'qr-1',
+      ...(source !== undefined ? {source} : {}),
+    }) as unknown as QrCodeElement;
+
+  it('should render the bound source key on the canvas', () => {
+    render(<QrCodeAdapter resource={createResource('openid4vpWalletUri')} />);
+
+    expect(screen.getByText('{{openid4vpWalletUri}}')).toBeInTheDocument();
+  });
+
+  it('should indicate when no source is bound', () => {
+    render(<QrCodeAdapter resource={createResource()} />);
+
+    expect(screen.getByText('No source bound')).toBeInTheDocument();
+  });
+
+  it('should indicate when the source is an empty string', () => {
+    render(<QrCodeAdapter resource={createResource('')} />);
+
+    expect(screen.getByText('No source bound')).toBeInTheDocument();
+  });
+
+  it('should render the placeholder when resource is undefined', () => {
+    render(<QrCodeAdapter />);
+
+    expect(screen.getByRole('img', {name: 'QR Code'})).toBeInTheDocument();
+    expect(screen.getByText('No source bound')).toBeInTheDocument();
+  });
+
+  it('should render a stable symbol across renders', () => {
+    const {container: first} = render(<QrCodeAdapter resource={createResource('openid4vpWalletUri')} />);
+    const {container: second} = render(<QrCodeAdapter resource={createResource('openid4vpWalletUri')} />);
+
+    const firstSvg: SVGSVGElement | null = first.querySelector('svg');
+    const secondSvg: SVGSVGElement | null = second.querySelector('svg');
+
+    expect(firstSvg).not.toBeNull();
+    expect(secondSvg).not.toBeNull();
+    expect(firstSvg!.innerHTML).toBe(secondSvg!.innerHTML);
+  });
+});

--- a/frontend/apps/console/src/features/flows/data/elements.json
+++ b/frontend/apps/console/src/features/flows/data/elements.json
@@ -477,6 +477,18 @@
   },
   {
     "resourceType": "ELEMENT",
+    "category": "DISPLAY",
+    "type": "QR_CODE",
+    "display": {
+      "label": "QR Code",
+      "description": "Render a scannable code from flow data",
+      "image": "assets/images/icons/scan.svg",
+      "showOnResourcePanel": true
+    },
+    "source": ""
+  },
+  {
+    "resourceType": "ELEMENT",
     "category": "MISCELLANEOUS",
     "type": "CUSTOM",
     "display": {

--- a/frontend/apps/console/src/features/flows/data/widgets.json
+++ b/frontend/apps/console/src/features/flows/data/widgets.json
@@ -601,7 +601,7 @@
                 "onIncomplete": "{{EUDI_WAIT_VIEW_ID}}"
               },
               "properties": {
-                "presentation_definition_id": "eudi-pid",
+                "presentation_definition_id": "",
                 "allowAuthenticationWithoutLocalUser": true
               }
             }
@@ -632,6 +632,12 @@
                   "type": "TEXT",
                   "variant": "BODY_1",
                   "label": "Open your EUDI Wallet and present your PID, then continue."
+                },
+                {
+                  "id": "{{ID}}",
+                  "category": "DISPLAY",
+                  "type": "QR_CODE",
+                  "source": "openid4vpWalletUri"
                 },
                 {
                   "id": "{{ID}}",

--- a/frontend/apps/console/src/features/flows/models/__tests__/elements.test.ts
+++ b/frontend/apps/console/src/features/flows/models/__tests__/elements.test.ts
@@ -66,6 +66,7 @@ describe('elements models', () => {
       expect(ElementTypes.DynamicInputPlaceholder).toBe('DYNAMIC_INPUT_PLACEHOLDER');
       expect(ElementTypes.Resend).toBe('RESEND');
       expect(ElementTypes.Timer).toBe('TIMER');
+      expect(ElementTypes.QrCode).toBe('QR_CODE');
     });
 
     it('should have consent types', () => {
@@ -77,8 +78,8 @@ describe('elements models', () => {
       expect(ElementTypes.Custom).toBe('CUSTOM');
     });
 
-    it('should have exactly 24 element types', () => {
-      expect(Object.keys(ElementTypes)).toHaveLength(24);
+    it('should have exactly 25 element types', () => {
+      expect(Object.keys(ElementTypes)).toHaveLength(25);
     });
   });
 

--- a/frontend/apps/console/src/features/flows/models/elements.ts
+++ b/frontend/apps/console/src/features/flows/models/elements.ts
@@ -58,6 +58,7 @@ export const ElementTypes = {
   DynamicInputPlaceholder: 'DYNAMIC_INPUT_PLACEHOLDER',
   Resend: 'RESEND',
   Timer: 'TIMER',
+  QrCode: 'QR_CODE',
   Consent: 'CONSENT',
   ConsentInput: 'CONSENT_INPUT',
   Custom: 'CUSTOM',

--- a/frontend/apps/console/src/features/flows/validation/__tests__/computeValidationNotifications.test.ts
+++ b/frontend/apps/console/src/features/flows/validation/__tests__/computeValidationNotifications.test.ts
@@ -196,6 +196,38 @@ describe('computeValidationNotifications', () => {
 
       expect(result.has('sms-1_REQUIRED_FIELD_ERROR')).toBe(true);
     });
+
+    it('should flag an OpenID4VP executor with no presentation definition', () => {
+      const nodes = [
+        createNode({
+          id: 'vp-1',
+          data: {
+            action: {executor: {name: 'OpenID4VPVerifyExecutor'}},
+            properties: {presentation_definition_id: ''},
+          } as unknown as StepData,
+        }),
+      ];
+
+      const result = computeValidationNotifications(nodes, VALIDATION_RULES, t);
+
+      expect(result.has('vp-1_REQUIRED_FIELD_ERROR')).toBe(true);
+    });
+
+    it('should not flag an OpenID4VP executor with a presentation definition', () => {
+      const nodes = [
+        createNode({
+          id: 'vp-2',
+          data: {
+            action: {executor: {name: 'OpenID4VPVerifyExecutor'}},
+            properties: {presentation_definition_id: 'eudi-pid'},
+          } as unknown as StepData,
+        }),
+      ];
+
+      const result = computeValidationNotifications(nodes, VALIDATION_RULES, t);
+
+      expect(result.has('vp-2_REQUIRED_FIELD_ERROR')).toBe(false);
+    });
   });
 
   describe('Multiple element types', () => {

--- a/frontend/apps/console/src/features/flows/validation/validation-rules.ts
+++ b/frontend/apps/console/src/features/flows/validation/validation-rules.ts
@@ -177,6 +177,17 @@ export const VALIDATION_RULES: ValidationRuleDefinition[] = [
     fields: [],
     generalMessageKey: 'flows:core.validation.fields.executor.general',
   },
+  // OpenID4VP verify executor
+  {
+    match: (r) => (r as {data?: StepData}).data?.action?.executor?.name === ExecutionTypes.OpenID4VPVerify,
+    fields: [
+      {
+        name: 'data.properties.presentation_definition_id',
+        errorMessageKey: 'flows:core.validation.fields.input.presentationDefinitionId',
+      },
+    ],
+    generalMessageKey: 'flows:core.validation.fields.executor.general',
+  },
 
   // ---------------------------------------------------------------------------
   // Node Validation Rules

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -3808,6 +3808,7 @@ const translations = {
     'core.validation.fields.input.idpName': 'Identity provider name is required',
     'core.validation.fields.input.idpId': 'Connection is required',
     'core.validation.fields.input.senderId': 'Notification sender is required',
+    'core.validation.fields.input.presentationDefinitionId': 'Presentation definition is required',
     'core.validation.fields.input.label': 'Label is required',
     'core.validation.fields.input.ref': 'Attribute is required',
 


### PR DESCRIPTION
### Purpose
The runtime already supports the wallet QR code: the backend returns `openid4vpWalletUri` in `additionalData`, and `FlowComponentRenderer` renders a `QR_CODE` component bound to it. The gap was in the flow builder. The EUDI wallet widget's wait view never included a `QR_CODE` component, so flows generated from it had nothing to render the URI, on the canvas or at login. The widget also hardcoded `presentation_definition_id: "eudi-pid"`, which suppressed the missing-configuration error and produced flows that validated clean and failed at runtime.

<img width="1436" height="631" alt="Screenshot 2026-08-20 at 17 34 48" src="https://github.com/user-attachments/assets/bdfb0f7c-2def-472f-8c57-4f43e8d1a5f4" />

No runtime renderer or backend changes are needed.

### Approach
- Add a `QR_CODE` component bound to `openid4vpWalletUri` in the widget's wait view.
- Add `QR_CODE` to the flow builder palette with a canvas adapter and an editable `source` property.
- Ship an empty `presentation_definition_id` and add a required-field rule for the OpenID4VP executor, matching the existing `idpId` and `senderId` rules.
- Show the field-level validation message on the presentation definition selector, matching `FederationProperties`.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added QR code elements to flow designs, including editable source bindings and designer previews.
  * Added QR code display to the EUDI Wallet flow.
  * Added validation feedback when an OpenID4VP presentation definition is missing.

* **Bug Fixes**
  * Improved presentation-definition field error display and validation messaging.

* **Tests**
  * Added coverage for QR code rendering, source handling, and OpenID4VP validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->