### PR TITLE
Make post-release sync manual only and parameterized

### DIFF
--- a/.github/workflows/post-release-sync.yml
+++ b/.github/workflows/post-release-sync.yml
@@ -1,30 +1,32 @@
-# This workflow merges release back into main after a successful release run.
+# This workflow merges the selected branch, 'release' by default, back into main.
+# Started manually from the Actions tab.
 # If there are no conflicts, it commits directly to main.
 # If there are conflicts, it creates a sync PR for manual resolution.
-# Can also be started manually from the Actions tab.
 
 name: 🔁 Post-Release Sync
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["🚀 Release Builder"]
-    types: [completed]
+    inputs:
+      branch:
+        description: 'Branch to merge into main'
+        required: false
+        type: string
+        default: 'release'
 
 permissions:
   contents: write
   pull-requests: write
 
 env:
-  SOURCE_BRANCH: "release"
+  SOURCE_BRANCH: ${{ inputs.branch || 'release' }}
   TARGET_BRANCH: "main"
   RELEASE_GIT_USER_NAME: "thunderid-automation-bot"
   RELEASE_GIT_USER_EMAIL: "thunderid-bot@thunderid.dev"
 
 jobs:
-  sync-release-to-main:
-    name: 🔀 Sync release -> main
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+  sync-to-main:
+    name: 🔀 Sync to main
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout Target Branch
@@ -39,7 +41,7 @@ jobs:
           git config --local user.name "${{ env.RELEASE_GIT_USER_NAME }}"
           git config --local user.email "${{ env.RELEASE_GIT_USER_EMAIL }}"
 
-      - name: 🔄 Merge Release Branch into Main
+      - name: 🔄 Merge Source Branch into Main
         id: merge_sync
         run: |
           set -euo pipefail
@@ -79,9 +81,7 @@ jobs:
             const headBranch = process.env.SOURCE_BRANCH;
             const head = `${owner}:${headBranch}`;
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
-            const triggerLine = context.eventName === 'workflow_dispatch'
-              ? `Triggered manually from Actions: ${runUrl}`
-              : `Triggered after successful release workflow run: ${context.payload.workflow_run.html_url}`;
+            const triggerLine = `Triggered manually from Actions: ${runUrl}`;
 
             const existing = await github.rest.pulls.list({
               owner,


### PR DESCRIPTION
### Purpose
The Post-Release Sync workflow automatically merged the `release` branch into `main` after every successful Release Builder run, pushing directly to `main` with no opportunity to opt out for a given release. 
This PR removes that automatic behavior so the sync only ever runs when someone starts it deliberately from the Actions tab.


### Approach
- Dropped the `workflow_run` trigger that listened for Release Builder completions, leaving `workflow_dispatch` as the only trigger on the workflow.
Two conditionals became dead code once `workflow_run` was gone and were removed. 

- The source branch is now driven by a `branch` workflow input defaulting to `release`, replacing the previously hardcoded `SOURCE_BRANCH: "release"`. This lets a sync be run for a release built from a branch other than `release`, which matters because the workflow can no longer infer any context from a triggering run.


### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated post-release synchronization to run manually from Actions.
  * Added an optional source-branch selection, defaulting to `release`.
  * Improved conflict pull request details to identify the manual workflow run that initiated them.
  * This provides greater control over synchronization timing and the branch used for post-release updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->