### PR TITLE
Fix inconsistent Roles/Groups icons in Import/Export pages

### DIFF
--- a/frontend/packages/configure-import-export/src/components/ConfigureExport.tsx
+++ b/frontend/packages/configure-import-export/src/components/ConfigureExport.tsx
@@ -9,7 +9,7 @@ import {
   Building,
   Copy,
   FileDown,
-  Key,
+  Group,
   Languages,
   Layers,
   LayoutGrid,
@@ -17,9 +17,9 @@ import {
   Palette,
   Server,
   Settings,
+  ShieldCheck,
   Terminal,
   UserRoundCog,
-  Users,
   UsersRound,
   Workflow,
 } from '@wso2/oxygen-ui-icons-react';
@@ -936,7 +936,7 @@ export default function ConfigureExport({
     items.push({
       id: 'roles',
       label: t('importExport:configureExport.labels.roles'),
-      icon: <Key size={16} />,
+      icon: <ShieldCheck size={16} />,
       value: rolesCount,
       status: 'ready',
       dependencyCount: 0,
@@ -947,7 +947,7 @@ export default function ConfigureExport({
               {displayedRoles.map((role, idx) => (
                 <Stack key={role.handle ?? role.name ?? `role-${idx}`} spacing={0.5}>
                   <Stack direction="row" spacing={1} sx={{alignItems: 'center'}}>
-                    <Key size={14} />
+                    <ShieldCheck size={14} />
                     <Typography variant="body2" fontWeight={600}>
                       {role.name ?? role.handle ?? t('importExport:configureExport.fallback.unnamedRole')}
                     </Typography>
@@ -995,7 +995,7 @@ export default function ConfigureExport({
     items.push({
       id: 'groups',
       label: t('importExport:configureExport.labels.groups'),
-      icon: <Users size={16} />,
+      icon: <Group size={16} />,
       value: groupsCount,
       status: 'ready',
       dependencyCount: 0,
@@ -1006,7 +1006,7 @@ export default function ConfigureExport({
               {displayedGroups.map((group, idx) => (
                 <Stack key={group.id ?? group.name ?? `group-${idx}`} spacing={0.5}>
                   <Stack direction="row" spacing={1} sx={{alignItems: 'center'}}>
-                    <Users size={14} />
+                    <Group size={14} />
                     <Typography variant="body2" fontWeight={600}>
                       {group.name ?? t('importExport:configureExport.fallback.unnamedGroup')}
                     </Typography>

--- a/frontend/packages/configure-import-export/src/pages/ImportConfigurationSummaryPage.tsx
+++ b/frontend/packages/configure-import-export/src/pages/ImportConfigurationSummaryPage.tsx
@@ -21,8 +21,8 @@ import {
 import {
   Bot,
   Building,
+  Group,
   IdCard,
-  Key,
   Languages,
   LayoutGrid,
   Layout as LayoutIcon,
@@ -33,7 +33,6 @@ import {
   ShieldCheck,
   Upload,
   UserRoundCog,
-  Users,
   UsersRound,
   Workflow,
   X,
@@ -394,7 +393,7 @@ const RESOURCE_VIEWS: ResourceView[] = [
   {
     type: 'role',
     id: 'roles',
-    icon: Key,
+    icon: ShieldCheck,
     getLabel: (t) => t('configureExport.labels.roles'),
     getKey: (item, idx) => item.handle ?? item.name ?? `role-${idx}`,
     getName: (item, t) => item.name ?? item.handle ?? t('configureExport.fallback.unnamedRole'),
@@ -408,7 +407,7 @@ const RESOURCE_VIEWS: ResourceView[] = [
   {
     type: 'group',
     id: 'groups',
-    icon: Users,
+    icon: Group,
     getLabel: (t) => t('configureExport.labels.groups'),
     getKey: (item, idx) => item.id ?? item.name ?? `group-${idx}`,
     getName: (item, t) => item.name ?? t('configureExport.fallback.unnamedGroup'),


### PR DESCRIPTION
### Purpose
The icons for the "Roles" and "Groups" resource types in the Import/Export resource summary table did not match the icons used for the same resource types in the left navigation sidebar.

### Approach
Swapped the icons in the Export flow (`ConfigureExport.tsx`) and Import summary page (`ImportConfigurationSummaryPage.tsx`) to reuse the same icons as the sidebar (`DashboardLayout.tsx`):
- Roles: `Key` → `ShieldCheck`
- Groups: `Users` → `Group`

Removed the now-unused `Key`/`Users` icon imports in both files.

### Related Issues
- Fixes #4995

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated resource summary icons for improved visual clarity.
  * Roles now use a shield icon, groups use a group icon, and credential configurations use an ID card icon.
  * Applied the updated icons consistently across summaries and list items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->