### PR TITLE
Fix duplicate name flash when creating applications

### DIFF
--- a/frontend/apps/console/src/features/applications/pages/ApplicationCreatePage.tsx
+++ b/frontend/apps/console/src/features/applications/pages/ApplicationCreatePage.tsx
@@ -173,9 +173,15 @@ export default function ApplicationCreatePage(): JSX.Element {
   );
 
   // Application names already in use, so the details step can flag a duplicate before submission.
+  // The just-created application is excluded: the success-triggered list invalidation can refetch
+  // it before this wizard unmounts, and it would otherwise flag itself as a duplicate of its own name.
   const existingAppNames = useMemo(
-    (): string[] => (applicationsData?.applications ?? []).map((app) => app.name).filter(Boolean),
-    [applicationsData],
+    (): string[] =>
+      (applicationsData?.applications ?? [])
+        .filter((app) => app.id !== createApplication.data?.id)
+        .map((app) => app.name)
+        .filter(Boolean),
+    [applicationsData, createApplication.data?.id],
   );
 
   const [selectedUserTypes, setSelectedUserTypes] = useState<string[]>([]);

--- a/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationCreatePage.test.tsx
+++ b/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationCreatePage.test.tsx
@@ -71,9 +71,11 @@ vi.mock('../../api/useCreateApplication', async () => {
 
   const useMockCreateApplication = () => {
     const [isPending, setIsPending] = useState(false);
+    const [data, setData] = useState<Application | undefined>(undefined);
 
     return {
       isPending,
+      data,
       mutate: (
         data: unknown,
         options?: {onError?: (err: Error) => void; onSuccess?: (app: Application) => void},
@@ -86,6 +88,7 @@ vi.mock('../../api/useCreateApplication', async () => {
           },
           onSuccess: (app: Application) => {
             setIsPending(false);
+            setData(app);
             options?.onSuccess?.(app);
           },
         });
@@ -2021,6 +2024,37 @@ describe('ApplicationCreatePage', () => {
       });
 
       expect(screen.queryByText(/no.*flow/i)).not.toBeInTheDocument();
+    });
+
+    it('should not flag the just-created app as a duplicate of itself after the create-triggered list refetch', async () => {
+      // Models the create success's list invalidation resolving while the wizard is still mounted
+      // (navigate() hasn't unmounted it yet): the refetched applications list now legitimately
+      // contains the app that was just created, under the exact name just submitted.
+      mockCreateApplication.mockImplementation((_data, {onSuccess}: {onSuccess: (app: Application) => void}) => {
+        mockUseGetApplications.mockReturnValue({
+          data: {applications: [{id: 'backend-app-7', name: 'My Backend App', clientId: 'backend-client-7'}]},
+        });
+        onSuccess({id: 'backend-app-7', name: 'My Backend App'} as Application);
+      });
+
+      renderWithProviders();
+
+      await user.click(screen.getByTestId('select-backend-platform'));
+      await user.type(screen.getByTestId('app-name-input'), 'My Backend App');
+
+      // NAME → create
+      await user.click(screen.getByTestId('application-wizard-next-button'));
+
+      await waitFor(() => {
+        expect(mockCreateApplication).toHaveBeenCalled();
+      });
+
+      // The wizard doesn't unmount in this test (navigate() is a no-op mock), so force a re-render
+      // unrelated to the name field to pick up the refetched list, the same way any incidental
+      // re-render during the real navigate() gap would.
+      await user.click(screen.getByTestId('logo-select-btn'));
+
+      expect(screen.queryByTestId('app-name-duplicate-error')).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationCreatePage.test.tsx
+++ b/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationCreatePage.test.tsx
@@ -59,9 +59,11 @@ vi.mock('../../api/useCreateApplication', async () => {
 
   const useMockCreateApplication = () => {
     const [isPending, setIsPending] = useState(false);
+    const [data, setData] = useState<Application | undefined>(undefined);
 
     return {
       isPending,
+      data,
       mutate: (
         data: unknown,
         options?: {onError?: (err: Error) => void; onSuccess?: (app: Application) => void},
@@ -74,6 +76,7 @@ vi.mock('../../api/useCreateApplication', async () => {
           },
           onSuccess: (app: Application) => {
             setIsPending(false);
+            setData(app);
             options?.onSuccess?.(app);
           },
         });
@@ -83,6 +86,18 @@ vi.mock('../../api/useCreateApplication', async () => {
 
   return {default: useMockCreateApplication};
 });
+
+// Mock the applications list query used to pre-flag duplicate names/client ids before submission.
+// Defaults to an empty list; individual tests override the return value to simulate the
+// create-success list invalidation resolving while the wizard is still mounted.
+const {mockUseGetApplications} = vi.hoisted(() => ({
+  mockUseGetApplications: vi.fn(),
+}));
+
+vi.mock('@thunderid/configure-applications', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@thunderid/configure-applications')>()),
+  useGetApplications: mockUseGetApplications,
+}));
 
 // Mock user types API
 vi.mock('@thunderid/configure-user-types', () => ({
@@ -688,6 +703,8 @@ describe('ApplicationCreatePage', () => {
       data: undefined,
       isLoading: false,
     });
+
+    mockUseGetApplications.mockReturnValue({data: {applications: []}});
   });
 
   describe('Initial Rendering', () => {
@@ -1906,6 +1923,37 @@ describe('ApplicationCreatePage', () => {
       });
 
       expect(screen.queryByText(/no.*flow/i)).not.toBeInTheDocument();
+    });
+
+    it('should not flag the just-created app as a duplicate of itself after the create-triggered list refetch', async () => {
+      // Models the create success's list invalidation resolving while the wizard is still mounted
+      // (navigate() hasn't unmounted it yet): the refetched applications list now legitimately
+      // contains the app that was just created, under the exact name just submitted.
+      mockCreateApplication.mockImplementation((_data, {onSuccess}: {onSuccess: (app: Application) => void}) => {
+        mockUseGetApplications.mockReturnValue({
+          data: {applications: [{id: 'backend-app-7', name: 'My Backend App', clientId: 'backend-client-7'}]},
+        });
+        onSuccess({id: 'backend-app-7', name: 'My Backend App'} as Application);
+      });
+
+      renderWithProviders();
+
+      await user.click(screen.getByTestId('select-backend-platform'));
+      await user.type(screen.getByTestId('app-name-input'), 'My Backend App');
+
+      // NAME → create
+      await user.click(screen.getByTestId('application-wizard-next-button'));
+
+      await waitFor(() => {
+        expect(mockCreateApplication).toHaveBeenCalled();
+      });
+
+      // The wizard doesn't unmount in this test (navigate() is a no-op mock), so force a re-render
+      // unrelated to the name field to pick up the refetched list, the same way any incidental
+      // re-render during the real navigate() gap would.
+      await user.click(screen.getByTestId('logo-select-btn'));
+
+      expect(screen.queryByTestId('app-name-duplicate-error')).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
### Purpose
When creating an application, the name field briefly flashes "An application with this name already exists. Choose a different name." right after a successful create, even though the name isn't actually a duplicate.

Root cause: on a successful create, `useCreateApplication`'s `onSuccess` invalidates the applications list query that the wizard's own client-side duplicate-name pre-check reads from. If that invalidation-triggered refetch resolves before the wizard unmounts (`navigate()` hasn't committed yet), the newly created application, under the exact name just submitted, shows up in the refetched list, and the wizard flags itself as a duplicate of its own name.

Fixes #4774

### Approach
Exclude the just-created application (by `id`) from `existingAppNames` in `ApplicationCreatePage.tsx`, keyed off `createApplication.data?.id`. Since a fresh `mutate()` call always resets `data` to `undefined` before it resolves, this only ever suppresses the one entry that is the wizard's own successful result. It can't mask an unrelated real duplicate, since the backend already enforces name uniqueness and no two different application ids can legitimately share a name.

Added a regression test that simulates the race (the create-triggered list refetch resolving while the wizard is still mounted) and confirmed it fails without the fix and passes with it.

### Related Issues
- Fixes #4774

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where creating an application could incorrectly trigger a duplicate-name error while the wizard remained open.
  * Newly created applications are no longer treated as duplicates after application data refreshes.
  * Duplicate-name validation is restored if a subsequent creation attempt fails.
  * Application creation now correctly hides user-type options when user logins aren’t supported, including backend and machine-to-machine applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->