### PR TITLE
Add logo picker to the agent edit page

### DIFF
--- a/frontend/apps/console/src/features/agents/pages/AgentEditPage.tsx
+++ b/frontend/apps/console/src/features/agents/pages/AgentEditPage.tsx
@@ -233,6 +233,10 @@ export default function AgentEditPage(): JSX.Element {
   const hasAnyValidationError =
     hasAnyOtherValidationError || isMissingRedirectUri || isMissingAllowedUserType || isMissingCertificate;
 
+  // ResourceAvatar opens its picker on any avatar click while onSelect is set, so a read-only
+  // agent has to withhold the callback rather than rely on `editable` alone.
+  const isLogoEditable = !agent.isReadOnly;
+
   // List every failing check by name rather than a single generic message, so the user knows
   // exactly what to fix instead of guessing which tab has the problem.
   const validationIssues: string[] = [];
@@ -390,7 +394,35 @@ export default function AgentEditPage(): JSX.Element {
           {t('agents:edit.page.back', 'Back to agents')}
         </PageTitle.BackButton>
         <PageTitle.Avatar sx={{overflow: 'visible'}}>
-          <ResourceAvatar size={55} value={agent.logoUrl} fallback={AgentConstants.DEFAULT_AVATAR} />
+          <ResourceAvatar
+            size={55}
+            supportedShapes={['circle']}
+            editable={isLogoEditable}
+            value={editedAgent.logoUrl ?? agent.logoUrl}
+            fallback={AgentConstants.DEFAULT_AVATAR}
+            editAriaLabel={t('agents:edit.page.logoUpdate.label', 'Update Logo')}
+            onSelect={
+              isLogoEditable
+                ? (newLogoUrl: string) => {
+                    // Not handleFieldChange: reverting to the original logo drops the key rather than setting it.
+                    if (isUpdateAgentError) {
+                      resetUpdateAgent();
+                    }
+                    setEditedAgent((prev) => {
+                      if (newLogoUrl === agent.logoUrl) {
+                        const {logoUrl, ...rest} = prev;
+                        void logoUrl;
+                        return rest;
+                      }
+                      return {...prev, logoUrl: newLogoUrl};
+                    });
+                  }
+                : undefined
+            }
+            // Withheld while the staged agent is invalid: this saves the whole payload, not just
+            // the logo, so it has to respect the same gate as the unsaved-changes bar.
+            onSave={isLogoEditable && !hasAnyValidationError ? handleSave : undefined}
+          />
         </PageTitle.Avatar>
         <PageTitle.Header>
           <Stack direction="row" alignItems="center" spacing={1} mb={1}>

--- a/frontend/apps/console/src/features/agents/pages/__tests__/AgentEditPage.test.tsx
+++ b/frontend/apps/console/src/features/agents/pages/__tests__/AgentEditPage.test.tsx
@@ -63,6 +63,55 @@ vi.mock('react-router', async () => {
   };
 });
 
+const {logoA, logoB} = vi.hoisted(() => ({
+  logoA: 'https://example.com/logo-a.png',
+  logoB: 'emoji:🚀',
+}));
+
+// Only ResourceAvatar is stubbed; LogoPicker's own behavior is covered by its own tests.
+vi.mock('@thunderid/components', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@thunderid/components')>();
+  return {
+    ...actual,
+    ResourceAvatar: ({
+      value = undefined,
+      fallback = undefined,
+      editable = false,
+      onSelect = undefined,
+      onSave = undefined,
+      editAriaLabel = undefined,
+    }: {
+      value?: string;
+      fallback?: string;
+      editable?: boolean;
+      onSelect?: (value: string) => void;
+      onSave?: () => void | Promise<void>;
+      editAriaLabel?: string;
+    }) => (
+      // Each affordance is keyed to the prop that actually enables it in ResourceAvatar: the
+      // pencil to `editable`, the picker to `onSelect`, and persisting to `onSave`.
+      <div data-testid="resource-avatar" data-value={value ?? ''} data-fallback={fallback ?? ''}>
+        {editable && onSelect && <button type="button" aria-label={editAriaLabel} />}
+        {onSelect && (
+          <>
+            <button type="button" onClick={() => onSelect(logoA)}>
+              Pick logo A
+            </button>
+            <button type="button" onClick={() => onSelect(logoB)}>
+              Pick logo B
+            </button>
+          </>
+        )}
+        {onSave && (
+          <button type="button" onClick={() => void onSave()}>
+            Save logo
+          </button>
+        )}
+      </div>
+    ),
+  };
+});
+
 vi.mock('../../api/useGetAgent', () => ({
   default: (id: string) => mockUseGetAgent(id),
 }));
@@ -338,6 +387,153 @@ describe('AgentEditPage', () => {
       descInput.dispatchEvent(new FocusEvent('blur', {bubbles: true}));
 
       expect(screen.queryByText('You have unsaved changes')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Logo', () => {
+    const renderWithLogo = (logoUrl?: string): void => {
+      mockUseGetAgent.mockReturnValue({
+        data: logoUrl === undefined ? baseAgent : {...baseAgent, logoUrl},
+        isLoading: false,
+        error: null,
+        isError: false,
+        refetch: mockRefetch,
+      });
+      render(<AgentEditPage />);
+    };
+
+    it('offers the logo picker for a writable agent', () => {
+      renderWithLogo();
+
+      expect(screen.getByRole('button', {name: 'Update Logo'})).toBeInTheDocument();
+    });
+
+    it('does not offer the logo picker for a read-only agent', () => {
+      mockUseGetAgent.mockReturnValue({
+        data: {...baseAgent, isReadOnly: true},
+        isLoading: false,
+        error: null,
+        isError: false,
+        refetch: mockRefetch,
+      });
+
+      render(<AgentEditPage />);
+
+      expect(screen.queryByRole('button', {name: 'Update Logo'})).not.toBeInTheDocument();
+      // ResourceAvatar opens its picker from the avatar itself whenever onSelect is set, so the
+      // callback has to be withheld rather than just hiding the pencil.
+      expect(screen.queryByRole('button', {name: 'Pick logo B'})).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: 'Save logo'})).not.toBeInTheDocument();
+    });
+
+    it("shows the agent's current logo as the initial value", () => {
+      renderWithLogo(logoA);
+
+      expect(screen.getByTestId('resource-avatar')).toHaveAttribute('data-value', logoA);
+    });
+
+    it('falls back to the default agent avatar when no logo is set', () => {
+      renderWithLogo();
+
+      const avatar = screen.getByTestId('resource-avatar');
+      expect(avatar).toHaveAttribute('data-value', '');
+      expect(avatar).toHaveAttribute('data-fallback', AgentConstants.DEFAULT_AVATAR);
+    });
+
+    it('stages a picked logo and surfaces the unsaved-changes bar', async () => {
+      const user = userEvent.setup();
+      renderWithLogo();
+
+      await user.click(screen.getByRole('button', {name: 'Pick logo B'}));
+
+      expect(screen.getByText('You have unsaved changes')).toBeInTheDocument();
+      expect(screen.getByTestId('resource-avatar')).toHaveAttribute('data-value', logoB);
+    });
+
+    it('hides the bar when the logo is picked back to its original value', async () => {
+      const user = userEvent.setup();
+      renderWithLogo(logoA);
+
+      await user.click(screen.getByRole('button', {name: 'Pick logo B'}));
+      expect(screen.getByText('You have unsaved changes')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', {name: 'Pick logo A'}));
+
+      await waitFor(() => {
+        expect(screen.queryByText('You have unsaved changes')).not.toBeInTheDocument();
+      });
+      expect(screen.getByTestId('resource-avatar')).toHaveAttribute('data-value', logoA);
+    });
+
+    it('sends the picked logo when the picker saves', async () => {
+      const user = userEvent.setup();
+      renderWithLogo();
+
+      await user.click(screen.getByRole('button', {name: 'Pick logo B'}));
+      await user.click(screen.getByRole('button', {name: 'Save logo'}));
+
+      await waitFor(() => {
+        expect(mockMutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({
+            agentId: 'agent-1',
+            data: expect.objectContaining({logoUrl: logoB}) as Record<string, unknown>,
+          }),
+        );
+      });
+    });
+
+    it('cannot save from the picker while the agent fails page validation', async () => {
+      const user = userEvent.setup();
+      mockUseGetAgent.mockReturnValue({
+        data: {
+          ...baseAgent,
+          allowedUserTypes: [],
+          inboundAuthConfig: [
+            {
+              type: 'oauth2' as const,
+              config: {
+                grantTypes: ['authorization_code'],
+                responseTypes: ['code'],
+                redirectUris: [],
+                clientId: 'client-id-xyz',
+              },
+            },
+          ],
+        },
+        isLoading: false,
+        error: null,
+        isError: false,
+        refetch: mockRefetch,
+      });
+
+      render(<AgentEditPage />);
+
+      // The picker still stages a pick, but persisting it would send the whole invalid payload.
+      expect(screen.queryByRole('button', {name: 'Save logo'})).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', {name: 'Pick logo B'}));
+
+      expect(mockMutateAsync).not.toHaveBeenCalled();
+      expect(
+        screen.getByText('Before saving, add a redirect URI and select at least one allowed user type.'),
+      ).toBeInTheDocument();
+    });
+
+    it('resets a stale save error when the logo changes', async () => {
+      const user = userEvent.setup();
+      const mockReset = vi.fn();
+      mockUseUpdateAgent.mockReturnValue({
+        mutateAsync: mockMutateAsync,
+        isPending: false,
+        error: new Error('Boom'),
+        isError: true,
+        reset: mockReset,
+      });
+      renderWithLogo();
+
+      await user.click(screen.getByRole('button', {name: 'Pick logo B'}));
+
+      expect(mockReset).toHaveBeenCalled();
     });
   });
 

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1121,6 +1121,7 @@ const translations = {
     'edit.page.errorTitle': 'Failed to load agent',
     'edit.page.notFound': 'Agent not found',
     'edit.page.back': 'Back to agents',
+    'edit.page.logoUpdate.label': 'Update Logo',
     'edit.page.description.empty': 'No description',
     'edit.page.description.placeholder': 'Add a description',
     'edit.page.tabs.overview': 'Overview',


### PR DESCRIPTION
### Purpose

Agents already support a logo URL and the value is persisted (#4390), but there is no way to
set or change it from the Console. `AgentCreatePage` hardcodes `AgentConstants.DEFAULT_AVATAR`
on create, so every agent ends up with the same bot avatar and users cannot customize it.

This adds the logo picker to the agent edit page, so an agent's logo can be changed the same
way an application's or an organization unit's already can. The agent edit page header already
rendered a `ResourceAvatar`, just in read only mode; this makes it editable and wires the picked
value into the existing update flow.

UI only change. The backend already accepts and persists `logoUrl` on the agent update path,
so no server side change was needed.

### Approach

Reused the shared picker rather than building a new one, so the agent, application, and
organization unit experiences stay identical. `ResourceAvatar` from `@thunderid/components`
already owns the whole interaction (pencil overlay, "Choose a Logo" dialog wrapping
`LogoPicker`, live preview behind the dialog, revert on Cancel), so the page only supplies the
value and the staging callback. The wiring mirrors `OrganizationUnitEditPage` and
`ApplicationEditPage`.

Key design decisions:

1. **Circular shape, not rounded.** The application and organization unit pages pass
   `variant="rounded" supportedShapes={['rounded']}`, but an agent's
   `AgentConstants.DEFAULT_AVATAR` is `shape=circle` and the agent page's `PageTitle.Avatar`
   has no `variant` override. Copying those pages verbatim would have offered rounded tiles in
   the picker that contradict the circular avatar actually rendered, so this passes
   `supportedShapes={['circle']}` and leaves `variant` at its circular default.

2. **Guarded mutation reset.** `onSelect` cannot go through `handleFieldChange`, so it has to
   clear a stale save error itself. The two reference pages call `mutation.reset()`
   unconditionally, but `AgentEditPage` already destructures a guarded
   `isUpdateAgentError` / `resetUpdateAgent` pair (because `useMutation` returns a fresh object
   every render), so `onSelect` reuses that pair. This keeps one convention per file and avoids
   depending on `reset` always being present.

3. **Reverting drops the staged key.** Picking the original logo back deletes `logoUrl` from
   `editedAgent` instead of setting it, so a reverted pick does not ride along in the PUT.

4. **No new save plumbing.** `logoUrl` is already on `Agent` and `UpdateAgentRequest`, and
   `handleSave` spreads `{...agent, ...editedAgent}` into the request, so staging the key is
   enough. It also makes `hasChanges` true, so the unsaved changes bar appears for free.
   `onSave={handleSave}` lets the dialog's Save button persist immediately, matching the
   reference pages.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/4393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an editable logo/avatar control to agent pages.
  * Changes can be reviewed, reverted, and saved with the agent.
  * Added an “Update Logo” label for the editing control.
  * Added support for displaying the current or fallback avatar.

* **Bug Fixes**
  * Prevented logo editing in read-only views.
  * Cleared outdated update errors when a new logo change is made.
  * Prevented saving logo changes when page validation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->