### PR TITLE
Apply the configured log format to every log record

### DIFF
--- a/backend/internal/system/log/configure_test.go
+++ b/backend/internal/system/log/configure_test.go
@@ -5,8 +5,12 @@ package log
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -75,7 +79,7 @@ func TestConfigureFallsBackToStdoutWhenNothingEnabled(t *testing.T) {
 	assert.NotPanics(t, func() {
 		log.Info(context.Background(), "fallback message")
 	})
-	assert.Nil(t, log.fileWriter, "no file writer should be created")
+	assert.Nil(t, log.root.fileWriter, "no file writer should be created")
 }
 
 func TestConfigureErrorsOnInvalidFilePath(t *testing.T) {
@@ -105,4 +109,271 @@ func TestConfigureConsoleAndFileWritesFile(t *testing.T) {
 	content, err := os.ReadFile(path) // #nosec G304 -- test reads a file under t.TempDir().
 	require.NoError(t, err)
 	assert.Contains(t, string(content), "dual output")
+}
+
+// readLines returns the non-empty lines written to the log file at path.
+func readLines(t *testing.T, path string) []string {
+	t.Helper()
+	content, err := os.ReadFile(path) // #nosec G304 -- test reads a file under t.TempDir().
+	require.NoError(t, err)
+	return strings.Split(strings.TrimSpace(string(content)), "\n")
+}
+
+// TestConfigureAppliesFormatToLoggerDerivedBeforeConfigure covers the reported defect:
+// components derive their logger at construction time, which in the embedded engine
+// happens before the configured format is known. The derived logger must follow the
+// format installed later rather than staying on the text handler it booted with.
+func TestConfigureAppliesFormatToLoggerDerivedBeforeConfigure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "thunderid.log")
+	log := freshLogger()
+
+	derived := log.With(String(LoggerKeyComponentName, "FlowEngine"))
+
+	require.NoError(t, log.Configure(OutputOptions{
+		FileEnabled: true,
+		Format:      formatJSON,
+		File:        rollingfile.Config{Path: path},
+	}))
+	defer func() { _ = log.Close() }()
+
+	derived.Info(context.Background(), "Executing node")
+
+	var record map[string]any
+	require.NoError(t, json.Unmarshal([]byte(readLines(t, path)[0]), &record))
+	assert.Equal(t, "Executing node", record["msg"])
+	assert.Equal(t, "FlowEngine", record[LoggerKeyComponentName])
+}
+
+// TestConfigureKeepsTraceIDOnLoggerDerivedBeforeConfigure guards the context decoration,
+// which is replayed onto the swapped handler along with the recorded attributes.
+func TestConfigureKeepsTraceIDOnLoggerDerivedBeforeConfigure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "thunderid.log")
+	log := freshLogger()
+
+	derived := log.With(String(LoggerKeyComponentName, "AuthAssertExecutor"))
+
+	require.NoError(t, log.Configure(OutputOptions{
+		FileEnabled: true,
+		Format:      formatJSON,
+		File:        rollingfile.Config{Path: path},
+	}))
+	defer func() { _ = log.Close() }()
+
+	ctx := sysContext.WithTraceID(context.Background(), "trace-1")
+	derived.Info(ctx, "Generated JWT token for authentication assertion")
+
+	var record map[string]any
+	require.NoError(t, json.Unmarshal([]byte(readLines(t, path)[0]), &record))
+	assert.Equal(t, "trace-1", record[LoggerKeyTraceID])
+}
+
+// TestConfigureFollowedByReconfigureSwitchesFormatBack proves the fix is not "always
+// JSON": every live logger follows each subsequent Configure call.
+func TestConfigureFollowedByReconfigureSwitchesFormatBack(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "json.log")
+	textPath := filepath.Join(dir, "text.log")
+	log := freshLogger()
+
+	derived := log.With(String(LoggerKeyComponentName, "DBProvider"))
+
+	require.NoError(t, log.Configure(OutputOptions{
+		FileEnabled: true,
+		Format:      formatJSON,
+		File:        rollingfile.Config{Path: jsonPath},
+	}))
+	derived.Info(context.Background(), "first")
+
+	require.NoError(t, log.Configure(OutputOptions{
+		FileEnabled: true,
+		Format:      formatText,
+		File:        rollingfile.Config{Path: textPath},
+	}))
+	defer func() { _ = log.Close() }()
+	derived.Info(context.Background(), "second")
+
+	assert.Contains(t, readLines(t, jsonPath)[0], `"msg":"first"`)
+	assert.Contains(t, readLines(t, textPath)[0], `msg=second`)
+}
+
+// TestConfigureKeepsSiblingLoggersIndependent guards the derivation slice copy: siblings
+// derived from one parent must not overwrite each other's attributes.
+func TestConfigureKeepsSiblingLoggersIndependent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "thunderid.log")
+	log := freshLogger()
+
+	engine := log.With(String(LoggerKeyComponentName, "FlowEngine"))
+	first := engine.With(String("nodeID", "consent_check"))
+	second := engine.With(String("nodeID", "auth_assert"))
+	grandchild := second.With(String("nodeType", "TASK_EXECUTION"))
+
+	require.NoError(t, log.Configure(OutputOptions{
+		FileEnabled: true,
+		Format:      formatJSON,
+		File:        rollingfile.Config{Path: path},
+	}))
+	defer func() { _ = log.Close() }()
+
+	first.Info(context.Background(), "one")
+	second.Info(context.Background(), "two")
+	grandchild.Info(context.Background(), "three")
+
+	lines := readLines(t, path)
+	require.Len(t, lines, 3)
+
+	records := make([]map[string]any, len(lines))
+	for i, line := range lines {
+		require.NoError(t, json.Unmarshal([]byte(line), &records[i]))
+	}
+	assert.Equal(t, "consent_check", records[0]["nodeID"])
+	assert.Equal(t, "auth_assert", records[1]["nodeID"])
+	assert.Equal(t, "auth_assert", records[2]["nodeID"])
+	assert.Equal(t, "TASK_EXECUTION", records[2]["nodeType"])
+	for _, record := range records {
+		assert.Equal(t, "FlowEngine", record[LoggerKeyComponentName])
+	}
+}
+
+// TestConfigurePreservesLevelSetEarlier guards the shared level variable across the
+// handler swap.
+func TestConfigurePreservesLevelSetEarlier(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "thunderid.log")
+	log := freshLogger()
+
+	require.NoError(t, log.SetLevel("error"))
+	derived := log.With(String(LoggerKeyComponentName, "UserInfoHandler"))
+
+	require.NoError(t, log.Configure(OutputOptions{
+		FileEnabled: true,
+		Format:      formatJSON,
+		File:        rollingfile.Config{Path: path},
+	}))
+	defer func() { _ = log.Close() }()
+
+	derived.Debug(context.Background(), "UserInfo response sent successfully")
+	derived.Error(context.Background(), "failed")
+
+	lines := readLines(t, path)
+	require.Len(t, lines, 1)
+	assert.Contains(t, lines[0], `"msg":"failed"`)
+}
+
+func TestSetFormatChangesFormatWithoutReplacingOutput(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "thunderid.log")
+	log := freshLogger()
+
+	require.NoError(t, log.Configure(OutputOptions{
+		FileEnabled: true,
+		Format:      formatText,
+		File:        rollingfile.Config{Path: path},
+	}))
+
+	writer := log.root.fileWriter
+	derived := log.With(String(LoggerKeyComponentName, "UserInfoHandler"))
+
+	require.NoError(t, log.SetFormat(formatJSON))
+	derived.Info(context.Background(), "UserInfo response sent successfully")
+
+	assert.Same(t, writer, log.root.fileWriter, "SetFormat must keep the configured file writer")
+	assert.Contains(t, readLines(t, path)[0], `"msg":"UserInfo response sent successfully"`)
+
+	// Re-applying the same format is a no-op rather than a needless handler rebuild.
+	require.NoError(t, log.SetFormat(formatJSON))
+	assert.Same(t, writer, log.root.fileWriter)
+
+	// Close releases the file writer once; a second call is a no-op.
+	require.NoError(t, log.Close())
+	require.NoError(t, log.Close())
+}
+
+func TestSetFormatRejectsUnsupportedFormat(t *testing.T) {
+	log := freshLogger()
+
+	assert.Error(t, log.SetFormat(""))
+	assert.Error(t, log.SetFormat("xml"))
+	assert.NoError(t, log.SetFormat("JSON"))
+}
+
+// TestConfigureIsSafeUnderConcurrentLogging exercises the atomic state swap against
+// in-flight writes; it is meaningful under -race.
+func TestConfigureIsSafeUnderConcurrentLogging(t *testing.T) {
+	dir := t.TempDir()
+	log := freshLogger()
+	require.NoError(t, log.Configure(OutputOptions{
+		FileEnabled: true,
+		Format:      formatText,
+		File:        rollingfile.Config{Path: filepath.Join(dir, "initial.log")},
+	}))
+	defer func() { _ = log.Close() }()
+
+	derived := log.With(String(LoggerKeyComponentName, "FlowEngine"))
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					derived.Info(context.Background(), "concurrent")
+				}
+			}
+		}()
+	}
+
+	for i := range 20 {
+		format := formatText
+		if i%2 == 0 {
+			format = formatJSON
+		}
+		require.NoError(t, log.Configure(OutputOptions{
+			FileEnabled: true,
+			Format:      format,
+			File:        rollingfile.Config{Path: filepath.Join(dir, fmt.Sprintf("swap-%d.log", i))},
+		}))
+	}
+
+	close(stop)
+	wg.Wait()
+}
+
+// TestConfigureReplaysGroupsOnDerivedHandler covers the WithGroup derivation path: groups
+// recorded before Configure must be replayed, in order, onto the swapped handler.
+func TestConfigureReplaysGroupsOnDerivedHandler(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "thunderid.log")
+	log := freshLogger()
+
+	grouped := slog.New(log.internal.Handler().
+		WithAttrs([]slog.Attr{slog.String(LoggerKeyComponentName, "FlowEngine")}).
+		WithGroup("node").
+		WithAttrs([]slog.Attr{slog.String("nodeID", "auth_assert")}))
+
+	require.NoError(t, log.Configure(OutputOptions{
+		FileEnabled: true,
+		Format:      formatJSON,
+		File:        rollingfile.Config{Path: path},
+	}))
+	defer func() { _ = log.Close() }()
+
+	grouped.Info("Executing node")
+
+	var record map[string]any
+	require.NoError(t, json.Unmarshal([]byte(readLines(t, path)[0]), &record))
+	assert.Equal(t, "FlowEngine", record[LoggerKeyComponentName])
+	node, ok := record["node"].(map[string]any)
+	require.True(t, ok, "the group must survive the handler swap: %v", record)
+	assert.Equal(t, "auth_assert", node["nodeID"])
+}
+
+// TestDynamicHandlerIgnoresEmptyDerivations guards the no-op fast paths: slog treats an
+// empty group and an empty attribute list as no-ops, so neither may allocate a new handler.
+func TestDynamicHandlerIgnoresEmptyDerivations(t *testing.T) {
+	handler := freshLogger().internal.Handler()
+
+	assert.Same(t, handler, handler.WithGroup(""))
+	assert.Same(t, handler, handler.WithAttrs(nil))
 }

--- a/backend/internal/system/log/log.go
+++ b/backend/internal/system/log/log.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/thunder-id/thunderid/internal/system/constants"
 	sysContext "github.com/thunder-id/thunderid/internal/system/context"
@@ -24,11 +25,127 @@ var (
 	once   sync.Once
 )
 
+// Log record formats accepted by Configure and SetFormat. Any other value is treated
+// as formatText.
+const (
+	formatText = "text"
+	formatJSON = "json"
+)
+
 // Logger is a wrapper around the slog logger.
 type Logger struct {
-	internal   *slog.Logger
-	levelVar   *slog.LevelVar
+	internal *slog.Logger
+	root     *root
+}
+
+// root holds the process-wide logging state shared by the singleton logger and every
+// logger derived from it. Configure swaps the state atomically, so loggers derived
+// before Configure ran also write through the newly configured handler.
+type root struct {
+	state    atomic.Pointer[rootState]
+	levelVar *slog.LevelVar
+
+	// mu serializes Configure, SetFormat and Close, and guards the fields below.
+	mu         sync.Mutex
 	fileWriter *rollingfile.Writer
+	// out is the sink the current handler writes to, and format is the format it was
+	// built with. SetFormat rebuilds the handler from them so it can change the format
+	// without discarding the configured output.
+	out    io.Writer
+	format string
+}
+
+// rootState is an immutable snapshot of the configured output handler. A new value is
+// allocated on every Configure, so derived handlers can detect that their cached
+// handler chain is stale by comparing pointers.
+type rootState struct {
+	handler slog.Handler
+}
+
+// derivation records a single WithAttrs or WithGroup call so it can be replayed, in
+// order, onto a swapped root handler.
+type derivation struct {
+	// group is the group name for a WithGroup call, and empty for WithAttrs. slog
+	// treats WithGroup("") as a no-op, so an empty name is never recorded and the
+	// field is an unambiguous discriminator.
+	group string
+	attrs []slog.Attr
+}
+
+// resolvedHandler caches a replayed handler chain together with the root state it was
+// built from.
+type resolvedHandler struct {
+	from    *rootState
+	handler slog.Handler
+}
+
+// dynamicHandler is the handler installed on every Logger. It owns no output handler of
+// its own: it resolves the root's current handler and replays the recorded derivations
+// onto it. The result is cached until Configure installs a new root state, so the
+// steady-state path is two atomic loads and no allocation.
+type dynamicHandler struct {
+	// derivations is immutable once the handler is constructed.
+	derivations []derivation
+	root        *root
+	cache       atomic.Pointer[resolvedHandler]
+}
+
+var _ slog.Handler = (*dynamicHandler)(nil)
+
+// resolve returns the handler for the current root state, rebuilding and caching the
+// derivation chain when the state has been swapped since the last call.
+func (h *dynamicHandler) resolve() slog.Handler {
+	state := h.root.state.Load()
+	if cached := h.cache.Load(); cached != nil && cached.from == state {
+		return cached.handler
+	}
+
+	handler := state.handler
+	for _, d := range h.derivations {
+		if d.group != "" {
+			handler = handler.WithGroup(d.group)
+			continue
+		}
+		handler = handler.WithAttrs(d.attrs)
+	}
+	// Concurrent resolvers build equivalent chains, so the last store wins.
+	h.cache.Store(&resolvedHandler{from: state, handler: handler})
+	return handler
+}
+
+// Enabled reports whether the current handler handles records at the given level.
+func (h *dynamicHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.resolve().Enabled(ctx, level)
+}
+
+// Handle delegates the record to the current handler.
+func (h *dynamicHandler) Handle(ctx context.Context, record slog.Record) error {
+	return h.resolve().Handle(ctx, record)
+}
+
+// WithAttrs records the attributes so they are replayed on the current handler.
+func (h *dynamicHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	return h.derive(derivation{attrs: attrs})
+}
+
+// WithGroup records the group so it is replayed on the current handler.
+func (h *dynamicHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	return h.derive(derivation{group: name})
+}
+
+// derive appends d to the recorded derivations. The slice is copied rather than
+// appended in place so sibling handlers derived from the same parent never share a
+// backing array and overwrite each other's last derivation.
+func (h *dynamicHandler) derive(d derivation) *dynamicHandler {
+	derivations := make([]derivation, len(h.derivations), len(h.derivations)+1)
+	copy(derivations, h.derivations)
+	return &dynamicHandler{derivations: append(derivations, d), root: h.root}
 }
 
 // OutputOptions describes where and how the logger writes. It is a log-package
@@ -88,11 +205,30 @@ func GetLogger() *Logger {
 	return logger
 }
 
+// newFormatHandler builds the output handler for the given format. It is the single
+// place that maps a format name onto an slog handler, so Configure and SetFormat cannot
+// drift apart.
+func newFormatHandler(format string, out io.Writer, levelVar *slog.LevelVar) slog.Handler {
+	handlerOptions := &slog.HandlerOptions{Level: levelVar}
+	if strings.EqualFold(format, formatJSON) {
+		return slog.NewJSONHandler(out, handlerOptions)
+	}
+	return slog.NewTextHandler(out, handlerOptions)
+}
+
+// newLogger wires a Logger onto base, which writes to out in format. Loggers derived
+// from the result follow whatever handler Configure installs later.
+func newLogger(base slog.Handler, levelVar *slog.LevelVar, out io.Writer, format string) *Logger {
+	r := &root{levelVar: levelVar, out: out, format: format}
+	r.state.Store(&rootState{handler: base})
+	return &Logger{internal: slog.New(&dynamicHandler{root: r}), root: r}
+}
+
 // initLogger initializes the slog logger.
 func initLogger() error {
 	// The logger is initialized before the deployment configuration is loaded, so it
-	// boots at the default level. The configured level from deployment.yaml is applied
-	// afterwards via SetLevel.
+	// boots at the default level and format. The configured values from deployment.yaml
+	// are applied afterwards via SetLevel and Configure.
 	level, err := parseLogLevel(constants.DefaultLogLevel)
 	if err != nil {
 		return errors.New("error parsing log level: " + err.Error())
@@ -101,19 +237,8 @@ func initLogger() error {
 	levelVar := new(slog.LevelVar)
 	levelVar.Set(level)
 
-	handlerOptions := &slog.HandlerOptions{
-		Level: levelVar,
-	}
-
-	logHandler := slog.NewTextHandler(os.Stdout, handlerOptions)
-	if logHandler == nil {
-		return errors.New("failed to create log handler")
-	}
-
-	logger = &Logger{
-		internal: slog.New(&contextHandler{Handler: logHandler}),
-		levelVar: levelVar,
-	}
+	logHandler := newFormatHandler(formatText, os.Stdout, levelVar)
+	logger = newLogger(&contextHandler{Handler: logHandler}, levelVar, os.Stdout, formatText)
 
 	return nil
 }
@@ -124,15 +249,16 @@ func (l *Logger) SetLevel(logLevel string) error {
 	if err != nil {
 		return err
 	}
-	l.levelVar.Set(level)
+	l.root.levelVar.Set(level)
 	return nil
 }
 
 // Configure applies the output configuration, rebuilding the underlying slog
 // handler to write to the console, a rotating file, or both. It preserves the
 // shared level variable so a prior SetLevel keeps taking effect, and keeps the
-// trace ID decoration via contextHandler. It is intended to be called once during
-// startup, right after the configured level is applied.
+// trace ID decoration via contextHandler. Because the handler lives on the shared
+// root, loggers derived before Configure ran also pick up the new output, so the
+// order of Configure relative to service construction does not matter.
 func (l *Logger) Configure(opts OutputOptions) error {
 	writers := make([]io.Writer, 0, 2)
 	if opts.ConsoleEnabled {
@@ -161,36 +287,66 @@ func (l *Logger) Configure(opts OutputOptions) error {
 		out = io.MultiWriter(writers...)
 	}
 
-	handlerOptions := &slog.HandlerOptions{Level: l.levelVar}
-	var handler slog.Handler
-	if strings.EqualFold(opts.Format, "json") {
-		handler = slog.NewJSONHandler(out, handlerOptions)
-	} else {
-		handler = slog.NewTextHandler(out, handlerOptions)
-	}
+	handler := newFormatHandler(opts.Format, out, l.root.levelVar)
 
-	previous := l.fileWriter
-	l.internal = slog.New(&contextHandler{Handler: handler})
-	l.fileWriter = fileWriter
+	l.root.mu.Lock()
+	defer l.root.mu.Unlock()
+
+	previous := l.root.fileWriter
+	l.root.state.Store(&rootState{handler: &contextHandler{Handler: handler}})
+	l.root.fileWriter = fileWriter
+	l.root.out = out
+	l.root.format = opts.Format
 	if previous != nil {
 		_ = previous.Close()
 	}
 	return nil
 }
 
-// Close releases the file writer, if any. It should be called during shutdown.
-func (l *Logger) Close() error {
-	if l.fileWriter != nil {
-		return l.fileWriter.Close()
+// SetFormat changes the record format without touching where the records go. It exists
+// for callers that own the format but not the output configuration, such as an embedded
+// engine running inside a host application that has already configured the file sink:
+// calling Configure there would replace the host's output with a console-only one and
+// close its file writer.
+func (l *Logger) SetFormat(format string) error {
+	if !strings.EqualFold(format, formatText) && !strings.EqualFold(format, formatJSON) {
+		return errors.New("unsupported log format: " + format)
 	}
+
+	l.root.mu.Lock()
+	defer l.root.mu.Unlock()
+
+	if strings.EqualFold(format, l.root.format) {
+		return nil
+	}
+
+	handler := newFormatHandler(format, l.root.out, l.root.levelVar)
+	l.root.state.Store(&rootState{handler: &contextHandler{Handler: handler}})
+	l.root.format = format
 	return nil
 }
 
-// With creates a new logger instance with additional fields.
+// Close releases the file writer, if any. It should be called during shutdown.
+// The writer lives on the shared root, so closing any derived logger closes the
+// single process-wide file sink. Close is idempotent.
+func (l *Logger) Close() error {
+	l.root.mu.Lock()
+	defer l.root.mu.Unlock()
+
+	if l.root.fileWriter == nil {
+		return nil
+	}
+	err := l.root.fileWriter.Close()
+	l.root.fileWriter = nil
+	return err
+}
+
+// With creates a new logger instance with additional fields. The returned logger shares
+// the root state, so it follows any later Configure or SetFormat call.
 func (l *Logger) With(fields ...Field) *Logger {
 	return &Logger{
 		internal: l.internal.With(convertFields(fields)...),
-		levelVar: l.levelVar,
+		root:     l.root,
 	}
 }
 

--- a/backend/internal/system/log/log_test.go
+++ b/backend/internal/system/log/log_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	sysContext "github.com/thunder-id/thunderid/internal/system/context"
@@ -290,12 +291,10 @@ func (suite *LogTestSuite) TestMaskedMap() {
 
 // newContextTestLogger creates a Logger backed by a contextHandler writing to buf.
 func newContextTestLogger(buf *bytes.Buffer) *Logger {
-	handlerOptions := &slog.HandlerOptions{
-		Level: slog.LevelDebug,
-	}
-	return &Logger{
-		internal: slog.New(&contextHandler{Handler: slog.NewTextHandler(buf, handlerOptions)}),
-	}
+	levelVar := new(slog.LevelVar)
+	levelVar.Set(slog.LevelDebug)
+	handler := slog.NewTextHandler(buf, &slog.HandlerOptions{Level: levelVar})
+	return newLogger(&contextHandler{Handler: handler}, levelVar, buf, formatText)
 }
 
 func (suite *LogTestSuite) TestContextLogMethodsWithTraceID() {
@@ -375,8 +374,10 @@ func (suite *LogTestSuite) TestGetLoggerUsesContextHandler() {
 	once = sync.Once{}
 
 	log := GetLogger()
-	_, ok := log.internal.Handler().(*contextHandler)
-	assert.True(suite.T(), ok, "GetLogger should wrap the handler with contextHandler")
+	dynamic, ok := log.internal.Handler().(*dynamicHandler)
+	require.True(suite.T(), ok, "GetLogger should install the dynamic handler")
+	_, ok = dynamic.resolve().(*contextHandler)
+	assert.True(suite.T(), ok, "the resolved handler should be wrapped with contextHandler")
 }
 
 func (suite *LogTestSuite) TestServerErrorWriterWrite() {
@@ -400,10 +401,7 @@ func (suite *LogTestSuite) TestServerErrorWriterWrite() {
 func (suite *LogTestSuite) TestServerErrorWriterRespectsLevel() {
 	var buf bytes.Buffer
 	log := newContextTestLogger(&buf)
-	log.levelVar = new(slog.LevelVar)
-	log.levelVar.Set(slog.LevelError)
-	log.internal = slog.New(&contextHandler{Handler: slog.NewTextHandler(&buf,
-		&slog.HandlerOptions{Level: log.levelVar})})
+	require.NoError(suite.T(), log.SetLevel("error"))
 	w := &serverErrorWriter{logger: log}
 
 	_, err := w.Write([]byte("some server error"))

--- a/backend/pkg/thunderidengine/engine.go
+++ b/backend/pkg/thunderidengine/engine.go
@@ -64,6 +64,23 @@ func New(mux *http.ServeMux, opts ...Option) *Engine {
 		logger.Fatal(ctx, "Engine context is missing required fields", log.Error(err))
 	}
 
+	// Apply the logging configuration before any service is initialized, so the engine's
+	// own boot logging is emitted at the configured level and format.
+	if engineCtx.logConfig.Level != "" {
+		if err := logger.SetLevel(engineCtx.logConfig.Level); err != nil {
+			logger.Fatal(ctx, "invalid log level in LogConfig", log.Error(err))
+		}
+	}
+	if engineCtx.logConfig.Format != "" {
+		// SetFormat rather than Configure: the engine owns the format but not where the
+		// records go. A host application may have configured console and file output
+		// already, and Configure would replace it with a console-only sink and close the
+		// host's file writer.
+		if err := logger.SetFormat(engineCtx.logConfig.Format); err != nil {
+			logger.Fatal(ctx, "failed to configure logger", log.Error(err))
+		}
+	}
+
 	// Initialize the cache manager.
 	engineCtx.cacheManager = cache.Initialize(engineCtx.cacheConfig, engineCtx.serverConfig.Identifier)
 
@@ -207,20 +224,6 @@ func New(mux *http.ServeMux, opts ...Option) *Engine {
 		engineCtx.transactioner, revocationEnforcer, revocationService, oauthConfig)
 	if err != nil {
 		logger.Fatal(ctx, "Failed to initialize OAuth services", log.Error(err))
-	}
-
-	if engineCtx.logConfig.Level != "" {
-		if err := logger.SetLevel(engineCtx.logConfig.Level); err != nil {
-			logger.Fatal(ctx, "invalid log level in LogConfig", log.Error(err))
-		}
-	}
-	if engineCtx.logConfig.Format != "" {
-		if err := logger.Configure(log.OutputOptions{
-			ConsoleEnabled: true,
-			Format:         engineCtx.logConfig.Format,
-		}); err != nil {
-			logger.Fatal(ctx, "failed to configure logger", log.Error(err))
-		}
 	}
 
 	return &Engine{

--- a/backend/pkg/thunderidengine/engine_test.go
+++ b/backend/pkg/thunderidengine/engine_test.go
@@ -9,11 +9,13 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/json"
 	"encoding/pem"
 	"math/big"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,6 +27,8 @@ import (
 	"github.com/thunder-id/thunderid/internal/system/cors"
 	joseconfig "github.com/thunder-id/thunderid/internal/system/jose/config"
 	"github.com/thunder-id/thunderid/internal/system/kmprovider"
+	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/log/rollingfile"
 	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 	"github.com/thunder-id/thunderid/tests/mocks/actorprovidermock"
@@ -591,6 +595,87 @@ func (suite *EngineTestSuite) TestBuildOriginReader() {
 		assert.Error(t, err)
 		assert.Nil(t, reader)
 	})
+}
+
+// TestNew_AppliesLogFormatToServicesBuiltInsideNew guards the reported defect from the
+// engine's side: the format is applied before any service is constructed, and it is
+// applied with SetFormat so a host application's own output configuration (here a file
+// sink) survives instead of being replaced by a console-only one.
+func (suite *EngineTestSuite) TestNew_AppliesLogFormatToServicesBuiltInsideNew() {
+	t := suite.T()
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "host.log")
+
+	// The host application configures where records go, before the engine starts.
+	logger := log.GetLogger()
+	require.NoError(t, logger.Configure(log.OutputOptions{
+		FileEnabled: true,
+		Format:      "text",
+		File:        rollingfile.Config{Path: logPath},
+	}))
+	t.Cleanup(func() {
+		_ = logger.Close()
+		_ = logger.Configure(log.OutputOptions{ConsoleEnabled: true, Format: "text"})
+	})
+
+	// Derived before the engine applies the format, the way a component of the host
+	// application (or of the engine itself) captures its logger at construction time.
+	componentLogger := logger.With(log.String(log.LoggerKeyComponentName, "FlowEngine"))
+
+	keyID := testKeyID
+	certPEM := generateSelfSignedCertFiles(t, tempDir, "log-cert.pem", "log-key.pem")
+	keyConfigs := []engineconfig.KeyConfig{{ID: keyID, CertFile: "log-cert.pem", KeyFile: "log-key.pem"}}
+
+	systemconfig.ResetServerRuntime()
+	t.Cleanup(systemconfig.ResetServerRuntime)
+	require.NoError(t, systemconfig.InitializeServerRuntime(tempDir, &systemconfig.Config{
+		GateClient: engineconfig.GateClientConfig{Hostname: "localhost", Port: 8080, Scheme: "https"},
+		Crypto: systemconfig.CryptoConfig{
+			Keys:       keyConfigs,
+			Encryption: engineconfig.EncryptionConfig{Key: "000102030405060708090a0b0c0d0e0f"},
+		},
+		Attestation: systemconfig.AttestationConfig{
+			Apple: systemconfig.AppleAttestationConfig{RootCertificate: string(certPEM)},
+		},
+	}))
+
+	eng := New(http.NewServeMux(),
+		WithServerHome(tempDir),
+		WithServerConfig(engineconfig.ServerConfig{Identifier: "test-engine"}),
+		WithObservabilityProvider(newTestObservabilityProvider(t)),
+		WithAuthorizationProvider(newTestAuthzProvider(t)),
+		WithKeyConfigs(keyConfigs),
+		WithJWTConfig(engineconfig.JWTConfig{Issuer: "test-issuer", PreferredKeyID: keyID, ValidityPeriod: 3600}),
+		WithRuntimeStoreProvider(newTestRuntimeStoreProvider(t)),
+		WithRuntimeTransientDBType("memory"),
+		WithEncryptionConfig(engineconfig.EncryptionConfig{Key: "test-encryption-key"}),
+		WithGateClientConfig(engineconfig.GateClientConfig{Hostname: "localhost", Port: 8080, Scheme: "https"}),
+		WithCacheConfig(engineconfig.CacheConfig{Disabled: true}),
+		WithLogConfig(engineconfig.LogConfig{Level: "debug", Format: "json"}),
+		WithIDPProvider(newTestIDPProvider(t)),
+		WithActorProvider(actorprovidermock.NewActorProviderMock(t)),
+		WithDefaultAuthnProvider(newTestDefaultAuthnProvider(t)),
+		WithResourceProvider(resourceserverprovidermock.NewResourceServerProviderMock(t)),
+		WithOUProvider(ouprovidermock.NewOrganizationUnitProviderMock(t)),
+		WithDesignResolveProvider(designprovidermock.NewDesignProviderMock(t)),
+		WithFlowProvider(flowexecmock.NewFlowProviderMock(t)),
+		WithI18nProvider(i18nprovidermock.NewI18nProviderMock(t)),
+		WithConsentProvider(consentprovidermock.NewConsentProviderMock(t)),
+		WithFlowConfig(engineconfig.FlowConfig{Executors: []string{"InviteExecutor", "PermissionValidator"}}),
+	)
+	require.NotNil(t, eng)
+
+	// A logger that already existed when the engine applied the format must follow it.
+	componentLogger.Info(context.Background(), "Executing node")
+
+	content, err := os.ReadFile(logPath) // #nosec G304 -- test reads a file under t.TempDir().
+	require.NoError(t, err)
+	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+	for _, line := range lines {
+		var record map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &record), "every record must be JSON: %s", line)
+	}
+	assert.Contains(t, string(content), `"msg":"Executing node"`)
 }
 
 // TestNew_ResetsDynamicMatcherWhenOriginConfigEmpty guards against a stale matcher from a

--- a/docs/content/deployment/configuration.mdx
+++ b/docs/content/deployment/configuration.mdx
@@ -127,6 +127,10 @@ With the configuration above, logs are written to `<THUNDER_HOME>/logs/thunderid
 Size and time triggers are independent and can run together: with both enabled, the file rolls whenever it exceeds the size limit **or** reaches the next time interval, whichever comes first. Time-based rotation rolls at local midnight and skips days with no log output (so idle days do not create empty files).
 
 :::note
+The format applies to every component's log lines, regardless of when that component was created. The exception is the lines emitted before the logging configuration is applied, during server home resolution and configuration loading. Those use the default text format on stdout, because the format itself is part of the configuration still being loaded.
+:::
+
+:::note
 This is the <ProductName /> **application log** (the `INFO`/`WARN`/`ERROR` lines the server emits). It is separate from the observability event file sink described in the [Observability](../../deployment/observability) guide, which records structured domain events such as token issuance and flow execution.
 :::
 

--- a/docs/versioned_docs/version-v1.0.x/deployment/configuration.mdx
+++ b/docs/versioned_docs/version-v1.0.x/deployment/configuration.mdx
@@ -125,6 +125,10 @@ With the configuration above, logs are written to `<THUNDER_HOME>/logs/thunderid
 Size and time triggers are independent and can run together: with both enabled, the file rolls whenever it exceeds the size limit **or** reaches the next time interval, whichever comes first. Time-based rotation rolls at local midnight and skips days with no log output (so idle days do not create empty files).
 
 :::note
+The format applies to every component's log lines, regardless of when that component was created. The exception is the lines emitted before the logging configuration is applied, during server home resolution and configuration loading. Those use the default text format on stdout, because the format itself is part of the configuration still being loaded.
+:::
+
+:::note
 This is the <ProductName /> **application log** (the `INFO`/`WARN`/`ERROR` lines the server emits). It is separate from the observability event file sink described in the [Observability](../../deployment/observability) guide, which records structured domain events such as token issuance and flow execution.
 :::
 


### PR DESCRIPTION
### Purpose

Setting `log.output.file.format: json` did not apply to every log record. A user reported that after switching the format, many records were still emitted in the slog `key=value` text format.

This is a real defect, not a misconfiguration.

`Logger.Configure` picks the text or JSON handler and installs it on the singleton logger, but `Logger.With(...)` used `slog.Logger.With`, which bakes the parent's handler into the child. Every component derives its logger once at construction and keeps it for the life of the process, so any component constructed before `Configure` ran stayed pinned to the boot handler that `initLogger` hardcodes to `slog.NewTextHandler(os.Stdout, ...)`. The shared `*slog.LevelVar` is passed by pointer, which is why `log.level` appeared to work everywhere while `format` did not.

Where this bites:

* Embedded engine (`pkg/thunderidengine`): `Configure` was the last statement in `New()`, after every service had been built, so all components were stale. `FlowEngine`, the flow executors, `InterceptorRunner`, `FlowGraphBuilder`, `DBProvider` and `UserInfoHandler` all kept emitting text. This is the reported deployment: ThunderID is consumed as a package, so the stale window was the entire `New()` call and every component of that deployment was affected.
* Standalone server (`cmd/server`): `Configure` runs before `registerServices`, so component loggers are correct there. Only the startup window before the configuration file is read is affected, and that window is unavoidable because the format itself lives in the file being loaded.

Reproduced against the unpatched code with a logger derived before `Configure`: the record went to stdout as text and the configured JSON file received nothing.

```
time=... level=INFO msg="Executing node" component=FlowEngine
```

### Approach

**Shared, swappable handler state (`internal/system/log/log.go`)**

The output handler now lives on a process-wide `root` behind an `atomic.Pointer`, instead of being snapshotted into each derived logger. Every `Logger` carries a `dynamicHandler` that owns no output handler of its own: it records each `WithAttrs` and `WithGroup` call and replays those derivations onto whatever handler the root currently holds. The replayed chain is cached against the root state pointer it was built from, so the steady-state path is two atomic loads and no allocation, and a `Configure` swap invalidates every cache by pointer inequality.

The result is that loggers derived before and after `Configure` both follow it, so the order of `Configure` relative to service construction no longer matters.

**`Logger.SetFormat`**

Changes the record format over the existing writer. The embedded engine owns the format but not the destination: a host application may already have configured console and file output, and calling `Configure` there would replace it with a console-only sink and close the host's file writer.

**Engine ordering (`pkg/thunderidengine/engine.go`)**

The log configuration block moved from the end of `New()` to immediately after `validateEngineContext`, so the engine's own boot logging is emitted at the configured level and format. It now calls `SetFormat` rather than `Configure`, for the reason above. The shared root already makes ordering irrelevant, so this is defence in depth.

**Documentation**

Added a note that the format applies to every component's log lines regardless of when that component was created, with the pre-configuration startup window called out as the one exception.

**Scope**

Limited to the records the user reported. Other sinks that also bypass the configured format (rolling-file self-errors, go-redis, OpenTelemetry and gRPC diagnostics) will be handled in a separate PR.

### Related Issues
- N/A

### Related PRs
- N/A

### Testing

Unit tests added in `internal/system/log/configure_test.go`:

* a logger derived before `Configure` emits JSON afterwards
* `trace_id` decoration survives the handler swap on a logger derived earlier
* text to json to text round-trip, so the fix is not "always JSON"
* sibling and grandchild loggers keep independent attribute chains, guarding the derivation slice copy
* a level set before `Configure` is preserved across the swap
* `SetFormat` changes the format without replacing or closing the configured file writer
* `SetFormat` rejects an empty or unsupported format
* groups recorded before `Configure` are replayed, in order, onto the swapped handler
* empty group and empty attribute derivations stay no-ops
* `Configure` and `Close` are idempotent
* concurrent logging against repeated `Configure` calls, meaningful under `-race`

`pkg/thunderidengine/engine_test.go` adds an engine-level test where the host configures a file sink and the engine is created with `Format: json`. On the previous ordering it fails with the exact record from the user report:

```
msg="Failed to initialize config database client" component=DBProvider
```

Manual verification against the standalone server:

* `format: json`, 123 of 123 records emitted as JSON, no text records; request-scoped records carry `trace_id` propagated from `X-Correlation-ID`
* console and file enabled together: 125 records in each, the whole file parses with `jq -s length`
* `format: text`: zero JSON records, confirming the round-trip

A base and a branch binary of `cmd/server` were also built from the same tree and run against an identical server home with `format: json`. Both emit 121 records, all JSON, and the two record streams are identical once timestamps and trace IDs are normalised. That is expected: in the standalone server `Configure` already runs before `registerServices`, so the defect never applied there and this change is a no-op for it.

Also run: `go build ./...`, `go vet`, the full backend test suite, `golangci-lint` on the changed packages (0 issues), `make format_check`, and `vale` on the two changed documentation files (0 errors).

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - [x] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
