### PR TITLE
Reject unsupported request objects instead of ignoring them

### DIFF
--- a/backend/internal/oauth/oauth2/authz/requestvalidator/validator.go
+++ b/backend/internal/oauth/oauth2/authz/requestvalidator/validator.go
@@ -19,7 +19,7 @@ import (
 // ValidateAuthorizationRequestParams validates the common authorization request parameters
 // shared by both the standard authorize endpoint and the PAR endpoint.
 //
-// This validates: prompt, grant_type, response_type, PKCE, nonce, and dpop_jkt.
+// This validates: request, prompt, grant_type, response_type, PKCE, nonce, and dpop_jkt.
 // Callers are responsible for validating client_id and redirect_uri before calling this
 // function, since those validations have endpoint-specific error handling semantics
 // (e.g., the authorize endpoint must not redirect errors when the redirect_uri is invalid).
@@ -37,6 +37,13 @@ func ValidateAuthorizationRequestParams(
 	params := url.Values(rawParams)
 	responseType := params.Get(constants.RequestParamResponseType)
 	responseMode := params.Get(constants.RequestParamResponseMode)
+
+	// ThunderID does not implement JAR (RFC 9101). A request object must be rejected rather than
+	// ignored: honoring only the query string would silently drop security parameters the client
+	// placed inside the object, notably state and nonce (OIDC Core 6.1).
+	if params.Get(constants.RequestParamRequest) != "" {
+		return constants.ErrorRequestNotSupported, "The request parameter is not supported"
+	}
 
 	// Validate the prompt parameter if present.
 	if params.Has(constants.RequestParamPrompt) {

--- a/backend/internal/oauth/oauth2/authz/requestvalidator/validator_test.go
+++ b/backend/internal/oauth/oauth2/authz/requestvalidator/validator_test.go
@@ -56,6 +56,38 @@ func (suite *AuthzValidationTestSuite) TestValidateParams_Success() {
 	assert.Empty(suite.T(), errMsg)
 }
 
+func (suite *AuthzValidationTestSuite) TestValidateParams_RequestObjectRejected() {
+	params := suite.validParams()
+	params.Set(constants.RequestParamRequest, "eyJhbGciOiAibm9uZSJ9.eyJzdGF0ZSI6ICJhYmMifQ.")
+
+	errCode, errMsg := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
+
+	assert.Equal(suite.T(), constants.ErrorRequestNotSupported, errCode)
+	assert.NotEmpty(suite.T(), errMsg)
+}
+
+// The request object is rejected before any other parameter is validated, so a request carrying
+// one is never processed on the query string alone.
+func (suite *AuthzValidationTestSuite) TestValidateParams_RequestObjectRejectedBeforeOtherParams() {
+	params := url.Values{
+		constants.RequestParamRequest: {"eyJhbGciOiAibm9uZSJ9.eyJzdGF0ZSI6ICJhYmMifQ."},
+	}
+
+	errCode, _ := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
+
+	assert.Equal(suite.T(), constants.ErrorRequestNotSupported, errCode)
+}
+
+func (suite *AuthzValidationTestSuite) TestValidateParams_EmptyRequestParamIgnored() {
+	params := suite.validParams()
+	params.Set(constants.RequestParamRequest, "")
+
+	errCode, errMsg := ValidateAuthorizationRequestParams(params, suite.oauthApp, "")
+
+	assert.Empty(suite.T(), errCode)
+	assert.Empty(suite.T(), errMsg)
+}
+
 func (suite *AuthzValidationTestSuite) TestValidateParams_MissingResponseType() {
 	params := url.Values{}
 

--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -188,8 +188,15 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(ctx context.Contex
 		}
 	}
 
-	// If request_uri is present, resolve the pushed authorization request.
+	// If request_uri is present, resolve the pushed authorization request. A request_uri that is
+	// not a PAR handle is a client-supplied request object by reference (RFC 9101), which is not
+	// supported: reject it rather than ignoring it, so the client learns its request was not
+	// honored (OIDC Core 6.1).
 	if requestURI != "" {
+		if !par.IsPARRequestURI(requestURI) {
+			return nil, as.newRequestObjectError(ctx, msg, app,
+				oauth2const.ErrorRequestURINotSupported, "The request_uri parameter is not supported")
+		}
 		return as.handlePARAuthorizationRequest(ctx, requestURI, clientID, app)
 	}
 
@@ -207,6 +214,38 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(ctx context.Contex
 	}
 
 	return as.handleStandardAuthorizationRequest(ctx, msg, app, initiatorReq)
+}
+
+// newRequestObjectError builds the rejection for an unsupported request object. The error is
+// returned to the client's redirect_uri only when that redirect_uri validates against the
+// client's registration, since an unvalidated redirect_uri must not be used as a redirect
+// target; otherwise it is shown on the server error page.
+func (as *authorizeService) newRequestObjectError(
+	ctx context.Context, msg *OAuthMessage, app *providers.OAuthClient, code string, message string,
+) *AuthorizationError {
+	queryParams := url.Values(msg.RequestQueryParams)
+	redirectURI := queryParams.Get(oauth2const.RequestParamRedirectURI)
+
+	authErr := &AuthorizationError{
+		Code:    code,
+		Message: message,
+		State:   queryParams.Get(oauth2const.RequestParamState),
+	}
+	if err := app.ValidateRedirectURI(ctx, redirectURI); err != nil {
+		as.logger.Debug(ctx, "Validation failed for redirect URI", log.Error(err))
+		return authErr
+	}
+	// ValidateRedirectURI accepts an omitted redirect_uri when the client has exactly one
+	// registered; fall back to that so the rejection still reaches the client.
+	if redirectURI == "" {
+		if len(app.RedirectURIs) == 0 {
+			return authErr
+		}
+		redirectURI = app.RedirectURIs[0]
+	}
+	authErr.SendErrorToClient = true
+	authErr.ClientRedirectURI = redirectURI
+	return authErr
 }
 
 // handlePARAuthorizationRequest resolves a request_uri from a PAR and continues the authorization flow.

--- a/backend/internal/oauth/oauth2/authz/service.go
+++ b/backend/internal/oauth/oauth2/authz/service.go
@@ -188,8 +188,15 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(ctx context.Contex
 		}
 	}
 
-	// If request_uri is present, resolve the pushed authorization request.
+	// If request_uri is present, resolve the pushed authorization request. A request_uri that is
+	// not a PAR handle is a client-supplied request object by reference (RFC 9101), which is not
+	// supported: reject it rather than ignoring it, so the client learns its request was not
+	// honored (OIDC Core 6.1).
 	if requestURI != "" {
+		if !par.IsPARRequestURI(requestURI) {
+			return nil, as.newRequestObjectError(ctx, msg, app,
+				oauth2const.ErrorRequestURINotSupported, "The request_uri parameter is not supported")
+		}
 		return as.handlePARAuthorizationRequest(ctx, requestURI, clientID, app)
 	}
 
@@ -207,6 +214,35 @@ func (as *authorizeService) HandleInitialAuthorizationRequest(ctx context.Contex
 	}
 
 	return as.handleStandardAuthorizationRequest(ctx, msg, app, initiatorReq)
+}
+
+// newRequestObjectError builds the rejection for an unsupported request object. The error is
+// returned to the client's redirect_uri only when that redirect_uri validates against the
+// client's registration, since an unvalidated redirect_uri must not be used as a redirect
+// target; otherwise it is shown on the server error page.
+func (as *authorizeService) newRequestObjectError(
+	ctx context.Context, msg *OAuthMessage, app *providers.OAuthClient, code string, message string,
+) *AuthorizationError {
+	queryParams := url.Values(msg.RequestQueryParams)
+	redirectURI := queryParams.Get(oauth2const.RequestParamRedirectURI)
+
+	authErr := &AuthorizationError{
+		Code:    code,
+		Message: message,
+		State:   queryParams.Get(oauth2const.RequestParamState),
+	}
+	if err := app.ValidateRedirectURI(ctx, redirectURI); err != nil {
+		as.logger.Debug(ctx, "Validation failed for redirect URI", log.Error(err))
+		return authErr
+	}
+	// ValidateRedirectURI only accepts an omitted redirect_uri when the client has exactly one
+	// fully qualified URI registered; fall back to that so the rejection still reaches the client.
+	if redirectURI == "" {
+		redirectURI = app.RedirectURIs[0]
+	}
+	authErr.SendErrorToClient = true
+	authErr.ClientRedirectURI = redirectURI
+	return authErr
 }
 
 // handlePARAuthorizationRequest resolves a request_uri from a PAR and continues the authorization flow.

--- a/backend/internal/oauth/oauth2/authz/service_test.go
+++ b/backend/internal/oauth/oauth2/authz/service_test.go
@@ -252,6 +252,67 @@ func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_In
 	assert.Equal(suite.T(), oauth2const.ErrorInvalidRequest, authErr.Code)
 }
 
+// A request_uri that is not a PAR handle is a client-supplied request object by reference
+// (RFC 9101), which is not supported. It must be rejected with request_uri_not_supported and
+// returned to the client's redirect_uri, rather than resolved as a PAR handle or ignored.
+func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_RequestURINotSupported() {
+	app := suite.testApp()
+	suite.mockInboundClient.EXPECT().GetOAuthClientByClientID(mock.Anything, "test-client-id").Return(app, nil)
+
+	msg := suite.testMsg()
+	msg.RequestQueryParams["request_uri"] = []string{"https://client.example.org/request.jwt"}
+
+	svc := suite.newService()
+	result, authErr := svc.HandleInitialAuthorizationRequest(context.Background(), msg)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), authErr)
+	assert.Equal(suite.T(), oauth2const.ErrorRequestURINotSupported, authErr.Code)
+	assert.True(suite.T(), authErr.SendErrorToClient)
+	assert.Equal(suite.T(), "https://client.example.com/callback", authErr.ClientRedirectURI)
+	assert.Equal(suite.T(), "test-state", authErr.State)
+}
+
+// An unregistered redirect_uri must not be used as a redirect target, so the rejection goes to
+// the error page instead.
+func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_RequestURINotSupported_BadRedirectURI() {
+	app := suite.testApp()
+	suite.mockInboundClient.EXPECT().GetOAuthClientByClientID(mock.Anything, "test-client-id").Return(app, nil)
+
+	msg := suite.testMsg()
+	msg.RequestQueryParams["request_uri"] = []string{"https://client.example.org/request.jwt"}
+	msg.RequestQueryParams["redirect_uri"] = []string{"https://attacker.example.com/callback"}
+
+	svc := suite.newService()
+	result, authErr := svc.HandleInitialAuthorizationRequest(context.Background(), msg)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), authErr)
+	assert.Equal(suite.T(), oauth2const.ErrorRequestURINotSupported, authErr.Code)
+	assert.False(suite.T(), authErr.SendErrorToClient)
+	assert.Empty(suite.T(), authErr.ClientRedirectURI)
+}
+
+// An omitted redirect_uri falls back to the single registered one, so the rejection still
+// reaches the client.
+func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_RequestURINotSupported_NoRedirectURI() {
+	app := suite.testApp()
+	suite.mockInboundClient.EXPECT().GetOAuthClientByClientID(mock.Anything, "test-client-id").Return(app, nil)
+
+	msg := suite.testMsg()
+	msg.RequestQueryParams["request_uri"] = []string{"https://client.example.org/request.jwt"}
+	delete(msg.RequestQueryParams, "redirect_uri")
+
+	svc := suite.newService()
+	result, authErr := svc.HandleInitialAuthorizationRequest(context.Background(), msg)
+
+	assert.Nil(suite.T(), result)
+	assert.NotNil(suite.T(), authErr)
+	assert.Equal(suite.T(), oauth2const.ErrorRequestURINotSupported, authErr.Code)
+	assert.True(suite.T(), authErr.SendErrorToClient)
+	assert.Equal(suite.T(), "https://client.example.com/callback", authErr.ClientRedirectURI)
+}
+
 func (suite *AuthorizeServiceTestSuite) TestHandleInitialAuthorizationRequest_ValidationError_NoClientRedirect() {
 	app := suite.testApp()
 	suite.mockInboundClient.EXPECT().GetOAuthClientByClientID(mock.Anything, "test-client-id").Return(app, nil)

--- a/backend/internal/oauth/oauth2/constants/constants.go
+++ b/backend/internal/oauth/oauth2/constants/constants.go
@@ -47,6 +47,7 @@ const (
 	RequestParamUILocales           string = "ui_locales"
 	RequestParamNonce               string = "nonce"
 	RequestParamPrompt              string = "prompt"
+	RequestParamRequest             string = "request"
 	RequestParamRequestURI          string = "request_uri"
 	RequestParamAcrValues           string = "acr_values"
 	RequestParamMaxAge              string = "max_age"
@@ -195,6 +196,8 @@ const (
 	ErrorExpiredToken             string = "expired_token" // #nosec G101
 	ErrorUnknownUserID            string = "unknown_user_id"
 	ErrorInvalidBindingMessage    string = "invalid_binding_message"
+	ErrorRequestNotSupported      string = "request_not_supported"
+	ErrorRequestURINotSupported   string = "request_uri_not_supported"
 )
 
 // UnSupportedGrantTypeError is returned when an unsupported grant type is requested.

--- a/backend/internal/oauth/oauth2/discovery/discovery_test.go
+++ b/backend/internal/oauth/oauth2/discovery/discovery_test.go
@@ -184,6 +184,12 @@ func (suite *DiscoveryTestSuite) TestOIDCDiscovery() {
 	// Verify claims parameter support
 	assert.True(suite.T(), metadata.ClaimsParameterSupported, "claims_parameter_supported should be true")
 
+	// JAR (RFC 9101) is not implemented, so neither request object form is advertised.
+	assert.False(suite.T(), metadata.RequestParameterSupported,
+		"request_parameter_supported should be false")
+	assert.False(suite.T(), metadata.RequestURIParameterSupported,
+		"request_uri_parameter_supported should be false")
+
 	// Verify RFC 9207 advertisement (inherited from embedded OAuth2AuthorizationServerMetadata)
 	assert.True(suite.T(), metadata.AuthorizationResponseIssParameterSupported)
 	assert.Contains(suite.T(), metadata.AcrValuesSupported, "urn:thunder:acr:password")
@@ -559,3 +565,28 @@ func (suite *DiscoveryTestSuite) TestOIDCDiscovery_EngineOverridesLandInWellKnow
 }
 
 func boolPtr(b bool) *bool { return &b }
+
+// Both request object booleans must appear in the serialized document. request_parameter_supported
+// defaults to false when omitted, but request_uri_parameter_supported defaults to true
+// (OIDC Discovery 3), so omitting it would advertise support that does not exist.
+func (suite *DiscoveryTestSuite) TestRequestObjectParametersSerializedExplicitly() {
+	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, providers.PublicKeyFilter{}).
+		Return([]providers.PublicKeyInfo{{KeyID: "k1", Algorithm: string(cryptolib.AlgorithmRS256)}}, nil)
+
+	metadata, err := suite.discoveryService.GetOIDCMetadata(context.Background())
+	assert.NoError(suite.T(), err)
+
+	raw, err := json.Marshal(metadata)
+	assert.NoError(suite.T(), err)
+
+	var doc map[string]any
+	assert.NoError(suite.T(), json.Unmarshal(raw, &doc))
+
+	value, present := doc["request_uri_parameter_supported"]
+	assert.True(suite.T(), present, "request_uri_parameter_supported must be present")
+	assert.Equal(suite.T(), false, value)
+
+	value, present = doc["request_parameter_supported"]
+	assert.True(suite.T(), present, "request_parameter_supported must be present")
+	assert.Equal(suite.T(), false, value)
+}

--- a/backend/internal/oauth/oauth2/discovery/model.go
+++ b/backend/internal/oauth/oauth2/discovery/model.go
@@ -41,6 +41,8 @@ type OIDCProviderMetadata struct {
 	IDTokenEncryptionEncValuesSupported  []string `json:"id_token_encryption_enc_values_supported,omitempty"`
 	ClaimsSupported                      []string `json:"claims_supported"`
 	ClaimsParameterSupported             bool     `json:"claims_parameter_supported"`
+	RequestParameterSupported            bool     `json:"request_parameter_supported"`
+	RequestURIParameterSupported         bool     `json:"request_uri_parameter_supported"`
 	EndSessionEndpoint                   string   `json:"end_session_endpoint,omitempty"`
 	AcrValuesSupported                   []string `json:"acr_values_supported,omitempty"`
 }

--- a/backend/internal/oauth/oauth2/discovery/service.go
+++ b/backend/internal/oauth/oauth2/discovery/service.go
@@ -101,7 +101,10 @@ func (ds *discoveryService) GetOIDCMetadata(ctx context.Context) (*OIDCProviderM
 		IDTokenEncryptionEncValuesSupported:  encryptionEncs,
 		ClaimsSupported:                      ds.getAllowedClaims(),
 		ClaimsParameterSupported:             true,
-		AcrValuesSupported:                   ds.getSupportedAcrValues(),
+		// JAR (RFC 9101) is not implemented.
+		RequestParameterSupported:    false,
+		RequestURIParameterSupported: false,
+		AcrValuesSupported:           ds.getSupportedAcrValues(),
 	}
 
 	if ds.cfg.OAuth.Logout.IsEnabled() {

--- a/backend/internal/oauth/oauth2/par/service.go
+++ b/backend/internal/oauth/oauth2/par/service.go
@@ -22,6 +22,12 @@ import (
 // requestURIPrefix is the URN prefix used for PAR request URIs per RFC 9126.
 const requestURIPrefix = "urn:ietf:params:oauth:request_uri:"
 
+// IsPARRequestURI reports whether a request_uri is a PAR handle issued by this server, as
+// opposed to a client-supplied request object by reference (RFC 9101), which is not supported.
+func IsPARRequestURI(requestURI string) bool {
+	return strings.HasPrefix(requestURI, requestURIPrefix)
+}
+
 // sensitiveParParams is the deny-list of PAR body parameters that must not be persisted into
 // InitiatorRequest.QueryParams, since they carry client credentials and the PAR store is a
 // plaintext runtime cache.
@@ -197,7 +203,7 @@ func resolveDPoPJkt(paramJkt, headerJkt string) string {
 func (s *parService) ResolvePushedAuthorizationRequest(
 	ctx context.Context, requestURI string, clientID string,
 ) (*oauth2model.OAuthParameters, *providers.InitiatorRequest, error) {
-	if !strings.HasPrefix(requestURI, requestURIPrefix) {
+	if !IsPARRequestURI(requestURI) {
 		return nil, nil, errInvalidRequestURI
 	}
 	randomKey := strings.TrimPrefix(requestURI, requestURIPrefix)

--- a/backend/internal/oauth/oauth2/par/service_test.go
+++ b/backend/internal/oauth/oauth2/par/service_test.go
@@ -645,3 +645,12 @@ func (s *ServiceTestSuite) TestHandlePAR_MultipleResources_InvalidTarget() {
 	assert.Nil(s.T(), resp)
 	assert.Equal(s.T(), oauth2const.ErrorInvalidTarget, errCode)
 }
+
+// IsPARRequestURI distinguishes a PAR handle from a client-supplied request object by
+// reference (RFC 9101), which is not supported.
+func (suite *ServiceTestSuite) TestIsPARRequestURI() {
+	assert.True(suite.T(), IsPARRequestURI("urn:ietf:params:oauth:request_uri:abc123"))
+	assert.False(suite.T(), IsPARRequestURI("https://client.example.org/request.jwt"))
+	assert.False(suite.T(), IsPARRequestURI(""))
+	assert.False(suite.T(), IsPARRequestURI("urn:ietf:params:oauth:request-uri:abc123"))
+}

--- a/docs/content/guides/protocols/oauth-oidc/server-metadata.mdx
+++ b/docs/content/guides/protocols/oauth-oidc/server-metadata.mdx
@@ -77,6 +77,8 @@ curl https://{{productSlug}}.example.com/.well-known/openid-configuration
     "address"
   ],
   "claims_parameter_supported": true,
+  "request_parameter_supported": false,
+  "request_uri_parameter_supported": false,
   "require_pushed_authorization_requests": false,
   "authorization_response_iss_parameter_supported": true,
   "acr_values_supported": ["urn:mace:incommon:iap:silver"]
@@ -96,6 +98,7 @@ The OAuth-only document at `/.well-known/oauth-authorization-server` omits the O
 | Subject types | `public` only. Pairwise subject identifiers are not supported |
 | `require_pushed_authorization_requests` | Reflects the global `oauth.par.require_par` setting |
 | `authorization_response_iss_parameter_supported` | Always `true` (see [Issuer Identification](../issuer-identification)) |
+| `request_parameter_supported`, `request_uri_parameter_supported` | Both always `false`. Request objects (JAR) are not supported, by value or by reference. An authorization request carrying a `request` parameter is rejected with `request_not_supported`, and a `request_uri` that is not a pushed authorization request handle is rejected with `request_uri_not_supported`. This does not affect the `request_uri` values that [PAR](../par) itself issues |
 
 </details>
 

--- a/docs/content/guides/protocols/oauth-oidc/server-metadata.mdx
+++ b/docs/content/guides/protocols/oauth-oidc/server-metadata.mdx
@@ -77,6 +77,8 @@ curl https://{{productSlug}}.example.com/.well-known/openid-configuration
     "address"
   ],
   "claims_parameter_supported": true,
+  "request_parameter_supported": false,
+  "request_uri_parameter_supported": false,
   "require_pushed_authorization_requests": false,
   "authorization_response_iss_parameter_supported": true,
   "acr_values_supported": ["urn:mace:incommon:iap:silver"]
@@ -96,6 +98,7 @@ The OAuth-only document at `/.well-known/oauth-authorization-server` omits the O
 | Subject types | `public` only. Pairwise subject identifiers are not supported |
 | `require_pushed_authorization_requests` | Reflects the global `oauth.par.require_par` setting |
 | `authorization_response_iss_parameter_supported` | Always `true` (see [Issuer Identification](../issuer-identification)) |
+| `request_parameter_supported`, `request_uri_parameter_supported` | Both always `false`. Request objects (JAR) are not supported, by value or by reference. An authorization request carrying a `request` parameter is rejected with `request_not_supported`, and a client-supplied `request_uri` that is not shaped like a pushed authorization request handle is rejected with `request_uri_not_supported`. A `request_uri` that is shaped like a PAR handle but whose stored request is unknown, expired, or already used is rejected with `invalid_request`. This does not affect the `request_uri` values that [PAR](../par) itself issues |
 
 </details>
 

--- a/tests/integration/oauth/authz/request_object_test.go
+++ b/tests/integration/oauth/authz/request_object_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authz
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
+)
+
+// unsignedRequestObject is an unsigned JWT ("alg":"none") carrying authorization request
+// parameters, the form used by the OpenID Foundation conformance suite for its unsigned request
+// object modules.
+const unsignedRequestObject = "eyJhbGciOiAibm9uZSJ9." +
+	"eyJyZXNwb25zZV90eXBlIjogImNvZGUiLCAic3RhdGUiOiAiaW5zaWRlLW9iamVjdCJ9."
+
+// TestAuthorize_RequestObject_RequestNotSupported verifies that an authorization request carrying a
+// request parameter is rejected rather than processed on the query string alone. JAR (RFC 9101) is
+// not implemented, and silently ignoring the object would drop the parameters the client placed
+// inside it, notably state and nonce. OIDC Core 6.1 defines request_not_supported for this.
+func (ts *AuthzTestSuite) TestAuthorize_RequestObject_RequestNotSupported() {
+	resp, err := testutils.InitiateAuthorizationFlowWithExtraParams(
+		clientID, redirectURI, "code", "openid", "request-object-state",
+		map[string]string{"request": unsignedRequestObject})
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusFound, resp.StatusCode,
+		"a request object should redirect the error back to the client")
+
+	location := resp.Header.Get("Location")
+	ts.Require().NotEmpty(location, "Location header should be present")
+
+	redirected, err := url.Parse(location)
+	ts.Require().NoError(err)
+	ts.Require().Equal(redirectURI, redirected.Scheme+"://"+redirected.Host,
+		"the error must go to the client's redirect_uri")
+
+	query := redirected.Query()
+	ts.Assert().Equal("request_not_supported", query.Get("error"))
+	ts.Assert().NotEmpty(query.Get("error_description"))
+	ts.Assert().Equal("request-object-state", query.Get("state"),
+		"state must be echoed back to the client")
+}
+
+// TestAuthorize_RequestURI_RequestURINotSupported verifies that a request_uri which is not a PAR
+// handle is rejected with request_uri_not_supported. Passing a request object by reference is not
+// supported, and the reference must not be resolved or ignored.
+func (ts *AuthzTestSuite) TestAuthorize_RequestURI_RequestURINotSupported() {
+	resp, err := testutils.InitiateAuthorizationFlowWithExtraParams(
+		clientID, redirectURI, "code", "openid", "request-uri-state",
+		map[string]string{"request_uri": "https://client.example.org/request.jwt"})
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+	ts.Require().Equal(http.StatusFound, resp.StatusCode)
+
+	location := resp.Header.Get("Location")
+	ts.Require().NotEmpty(location)
+
+	redirected, err := url.Parse(location)
+	ts.Require().NoError(err)
+	ts.Require().Equal(redirectURI, redirected.Scheme+"://"+redirected.Host,
+		"the error must go to the client's redirect_uri")
+
+	query := redirected.Query()
+	ts.Assert().Equal("request_uri_not_supported", query.Get("error"))
+	ts.Assert().NotEmpty(query.Get("error_description"))
+	ts.Assert().Equal("request-uri-state", query.Get("state"),
+		"state must be echoed back to the client")
+}

--- a/tests/integration/oauth/discovery/discovery_test.go
+++ b/tests/integration/oauth/discovery/discovery_test.go
@@ -221,6 +221,31 @@ func (ts *DiscoveryTestSuite) TestOIDCDiscovery_GET_Success() {
 		"authorization_response_iss_parameter_supported must be true (RFC 9207)")
 }
 
+func (ts *DiscoveryTestSuite) TestOIDCDiscovery_RequestObjectParametersNotSupported() {
+	req, err := http.NewRequest("GET", testServerURL+oidcDiscoveryEndpoint, nil)
+	ts.Require().NoError(err)
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err)
+	defer resp.Body.Close()
+
+	ts.Equal(http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err)
+
+	var doc map[string]any
+	ts.Require().NoError(json.Unmarshal(body, &doc))
+
+	value, present := doc["request_uri_parameter_supported"]
+	ts.True(present, "request_uri_parameter_supported must be present (its default when omitted is true)")
+	ts.Equal(false, value, "request_uri_parameter_supported must be false")
+
+	value, present = doc["request_parameter_supported"]
+	ts.True(present, "request_parameter_supported must be present")
+	ts.Equal(false, value, "request_parameter_supported must be false")
+}
+
 func (ts *DiscoveryTestSuite) TestOIDCDiscovery_AcrValuesSupported() {
 	req, err := http.NewRequest("GET", testServerURL+oidcDiscoveryEndpoint, nil)
 	ts.Require().NoError(err)

--- a/tests/integration/oauth/par/par_test.go
+++ b/tests/integration/oauth/par/par_test.go
@@ -508,16 +508,19 @@ func (ts *PARTestSuite) TestPARRequestURISingleUse() {
 // TestPARInvalidRequestURI tests that an invalid request_uri is rejected by the authorize endpoint.
 func (ts *PARTestSuite) TestPARInvalidRequestURI() {
 	testCases := []struct {
-		Name       string
-		RequestURI string
+		Name          string
+		RequestURI    string
+		ExpectedError string
 	}{
 		{
-			Name:       "Completely Invalid URI",
-			RequestURI: "not-a-valid-uri",
+			Name:          "Completely Invalid URI",
+			RequestURI:    "not-a-valid-uri",
+			ExpectedError: "request_uri_not_supported",
 		},
 		{
-			Name:       "Valid Prefix But Non-existent",
-			RequestURI: "urn:ietf:params:oauth:request_uri:nonexistent-request-123",
+			Name:          "Valid Prefix But Non-existent",
+			RequestURI:    "urn:ietf:params:oauth:request_uri:nonexistent-request-123",
+			ExpectedError: "invalid_request",
 		},
 	}
 
@@ -529,8 +532,8 @@ func (ts *PARTestSuite) TestPARInvalidRequestURI() {
 
 			ts.Equal(http.StatusFound, resp.StatusCode, "Should redirect with error")
 			location := resp.Header.Get("Location")
-			err = testutils.ValidateOAuth2ErrorRedirect(location, "invalid_request", "")
-			ts.NoError(err, "Should produce an invalid_request error")
+			err = testutils.ValidateOAuth2ErrorRedirect(location, tc.ExpectedError, "")
+			ts.NoError(err, "Should produce a %s error", tc.ExpectedError)
 		})
 	}
 }

--- a/tests/integration/testutils/oauth2_utils.go
+++ b/tests/integration/testutils/oauth2_utils.go
@@ -1025,6 +1025,40 @@ func SubmitPARRequestWithoutAuth(params map[string]string) (*PARHTTPResult, erro
 	return result, nil
 }
 
+// InitiateAuthorizationFlowWithExtraParams starts the OAuth2 authorization flow with the standard
+// parameters plus the supplied extra query parameters. It is used to exercise parameters the
+// server rejects, such as a client-supplied request object.
+func InitiateAuthorizationFlowWithExtraParams(
+	clientID, redirectURI, responseType, scope, state string, extra map[string]string,
+) (*http.Response, error) {
+	authURL := TestServerURL + "/oauth2/authorize"
+	params := url.Values{}
+	params.Set("client_id", clientID)
+	params.Set("redirect_uri", redirectURI)
+	params.Set("response_type", responseType)
+	params.Set("scope", scope)
+	params.Set("state", state)
+	for key, value := range extra {
+		params.Set(key, value)
+	}
+
+	req, err := http.NewRequest("GET", authURL+"?"+params.Encode(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create authorization request: %w", err)
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	return client.Do(req)
+}
+
 // InitiateAuthorizationFlowWithRequestURI starts the OAuth2 authorization flow using a PAR request_uri.
 func InitiateAuthorizationFlowWithRequestURI(clientID, requestURI string) (*http.Response, error) {
 	authURL := TestServerURL + "/oauth2/authorize"


### PR DESCRIPTION
### Purpose

An authorization request carrying a `request` parameter was neither honored nor rejected. The
parameter was ignored and the request proceeded on the query string alone, so any parameter the
client placed inside the request object was lost, including `state` and `nonce`. Both are security
parameters: `state` is the client's CSRF defence and `nonce` binds the ID token to the
authorization request. The client received an apparently successful response that silently
violated its own request, with no error explaining why.

Discovery compounded this. `request_parameter_supported` and `request_uri_parameter_supported` were
both absent from `/.well-known/openid-configuration`, and their defaults in OIDC Discovery 3 differ:
the former defaults to `false`, but the latter defaults to **`true`**. Omitting
`request_uri_parameter_supported` therefore advertised support that does not exist, so a client
reading discovery was told it may pass a `request_uri`, did so, and had it silently ignored.

Found running the OpenID Foundation conformance suite, Basic OP plan
(`oidcc-basic-certification-test-plan`). Two modules cover it, and their names state the contract:
*supported correctly **or rejected as unsupported***. Either branch passes. Silently ignoring is the
one outcome neither allows.

### Approach

JAR (RFC 9101) remains unimplemented, which OIDC Core 6 permits an OP to do. Rather than
implementing it, the server now tells the truth and rejects:

1. **Advertise the truth in discovery.** `request_parameter_supported` and
   `request_uri_parameter_supported` are both emitted as `false`. Both are stated explicitly rather
   than relying on defaults that point in opposite directions, which also removes the asymmetry for
   anyone reading the document.

2. **Reject rather than ignore.** A `request` parameter is rejected with `request_not_supported`
   (OIDC Core 6.1), and a `request_uri` that is not a PAR handle is rejected with
   `request_uri_not_supported`.

Verified manually against a local build:

| Request | Result |
|---|---|
| `request=<unsigned JWT>` | `302` to client: `error=request_not_supported`, `state` echoed |
| `request_uri=https://client.example.org/request.jwt` | `302` to client: `error=request_uri_not_supported`, `state` echoed |
| `request` at `/oauth2/par` | `{"error":"request_not_supported"}` |
| `request_uri=urn:ietf:params:oauth:request_uri:...` (PAR handle) | unchanged, resolves normally |
| no request object | unchanged, proceeds to login |

Before the fix, the first case redirected to the login page with no error at all, and the second
redirected to the server's own error page rather than the client, which is why the `request_uri`
conformance module stalled after the redirect.


### Related Issues
- Fixes thunder-id/thunderid#5111

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [x] Documentation provided. (Add links if there are any)
    - `docs/content/guides/protocols/oauth-oidc/server-metadata.mdx`: added both fields to the
      sample document and documented the behavior, making clear that
      `request_uri_parameter_supported: false` refers to client-supplied request objects by
      reference, not to PAR handles.
    - [x] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
        - `requestvalidator/validator_test.go`: `request` rejected, rejected before other
          parameters, empty value ignored.
        - `authz/service_test.go`: non-PAR `request_uri` rejected to the client; not redirected when
          the `redirect_uri` is unregistered; falls back to the single registered URI when omitted.
        - `par/service_test.go`: `IsPARRequestURI` prefix handling.
        - `discovery/discovery_test.go`: both booleans false and present in the serialized document.
    - [x] Integration Tests
        - `tests/integration/oauth/authz/request_object_test.go`: both rejections reach the client's
          `redirect_uri` with `state` echoed.
        - `tests/integration/oauth/discovery/discovery_test.go`: both booleans present and false in
          the raw JSON.
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **OAuth/OIDC Authorization**
  * Unsupported request objects return `request_not_supported` or `request_uri_not_supported`.
  * Valid redirect URIs preserve client redirection and state; invalid or unsafe URIs are not used.
  * Missing redirect URIs may fall back to the client’s sole registered URI.
  * Pushed Authorization Request (PAR) request URIs remain supported.

* **Discovery**
  * Provider metadata now explicitly reports unsupported request objects and non-PAR request URIs.

* **Documentation**
  * Updated server metadata guidance for supported and unsupported request parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->