### PR TITLE
Fixed the JWKS kid and alg mismatch issue

### DIFF
--- a/backend/internal/oauth/jwks/service.go
+++ b/backend/internal/oauth/jwks/service.go
@@ -61,7 +61,12 @@ func (s *jwksService) GetJWKS(ctx context.Context) (*JWKSResponse, *tidcommon.Se
 	var jwksKeys []JWKS
 
 	for _, keyInfo := range publicKeys {
-		kid := keyInfo.Thumbprint
+		kid := keyInfo.KeyID
+		if kid == "" {
+			s.logger.Error(ctx, "Public key is missing key ID")
+			return nil, &tidcommon.InternalServerError
+		}
+		alg := keyInfo.Algorithm
 
 		var x5c []string
 		var x5t, x5tS256 string
@@ -74,14 +79,14 @@ func (s *jwksService) GetJWKS(ctx context.Context) (*JWKSResponse, *tidcommon.Se
 
 		switch pub := keyInfo.PublicKey.(type) {
 		case *rsa.PublicKey:
-			jwksKeys = append(jwksKeys, getRSAPublicKeyJWKS(pub, kid, x5c, x5t, x5tS256))
+			jwksKeys = append(jwksKeys, getRSAPublicKeyJWKS(pub, kid, alg, x5c, x5t, x5tS256))
 		case *ecdsa.PublicKey:
-			jwksKeys = append(jwksKeys, getECDSAPublicKeyJWKS(pub, kid, x5c, x5t, x5tS256))
+			jwksKeys = append(jwksKeys, getECDSAPublicKeyJWKS(pub, kid, alg, x5c, x5t, x5tS256))
 		case ed25519.PublicKey:
-			jwksKeys = append(jwksKeys, getEdDSAPublicKeyJWKS(pub, kid, x5c, x5t, x5tS256))
+			jwksKeys = append(jwksKeys, getEdDSAPublicKeyJWKS(pub, kid, alg, x5c, x5t, x5tS256))
 		case *mldsa44.PublicKey, *mldsa65.PublicKey, *mldsa87.PublicKey:
 			// ML-DSA (RFC 9964 AKP).
-			mldsaJWK, ok := getMLDSAPublicKeyJWKS(pub, kid, x5c, x5t, x5tS256)
+			mldsaJWK, ok := getMLDSAPublicKeyJWKS(pub, kid, alg, x5c, x5t, x5tS256)
 			if !ok {
 				s.logger.Debug(ctx, "Unsupported public key type for JWKS", log.String("keyID", keyInfo.KeyID))
 				continue
@@ -103,7 +108,7 @@ func (s *jwksService) GetJWKS(ctx context.Context) (*JWKSResponse, *tidcommon.Se
 }
 
 // getRSAPublicKeyJWKS converts an RSA public key to JWKS format.
-func getRSAPublicKeyJWKS(pub *rsa.PublicKey, kid string, x5c []string, x5t, x5tS256 string) JWKS {
+func getRSAPublicKeyJWKS(pub *rsa.PublicKey, kid, alg string, x5c []string, x5t, x5tS256 string) JWKS {
 	n := encodeBase64URL(pub.N.Bytes())
 	// Properly encode the exponent as a big-endian byte slice, trimmed of leading zeros
 	eBytes := make([]byte, 0, 8)
@@ -121,7 +126,7 @@ func getRSAPublicKeyJWKS(pub *rsa.PublicKey, kid string, x5c []string, x5t, x5tS
 		Kid:     kid,
 		Kty:     "RSA",
 		Use:     "sig",
-		Alg:     "RS256",
+		Alg:     alg,
 		N:       n,
 		E:       eEnc,
 		X5c:     x5c,
@@ -131,19 +136,11 @@ func getRSAPublicKeyJWKS(pub *rsa.PublicKey, kid string, x5c []string, x5t, x5tS
 }
 
 // getECDSAPublicKeyJWKS converts an ECDSA public key to JWKS format.
-func getECDSAPublicKeyJWKS(pub *ecdsa.PublicKey, kid string, x5c []string, x5t, x5tS256 string) JWKS {
+func getECDSAPublicKeyJWKS(pub *ecdsa.PublicKey, kid, alg string, x5c []string, x5t, x5tS256 string) JWKS {
 	crv := pub.Curve.Params().Name
 	coordLen := (pub.Curve.Params().BitSize + 7) / 8
 	x := encodeBase64URL(padCoordinate(pub.X.Bytes(), coordLen))
 	y := encodeBase64URL(padCoordinate(pub.Y.Bytes(), coordLen))
-
-	alg := "ES256"
-	switch crv {
-	case "P-384":
-		alg = "ES384"
-	case "P-521":
-		alg = "ES512"
-	}
 
 	return JWKS{
 		Kid:     kid,
@@ -160,14 +157,14 @@ func getECDSAPublicKeyJWKS(pub *ecdsa.PublicKey, kid string, x5c []string, x5t, 
 }
 
 // getEdDSAPublicKeyJWKS converts an EdDSA public key to JWKS format.
-func getEdDSAPublicKeyJWKS(pub ed25519.PublicKey, kid string, x5c []string, x5t, x5tS256 string) JWKS {
+func getEdDSAPublicKeyJWKS(pub ed25519.PublicKey, kid, alg string, x5c []string, x5t, x5tS256 string) JWKS {
 	x := encodeBase64URL(pub)
 
 	return JWKS{
 		Kid:     kid,
 		Kty:     "OKP",
 		Use:     "sig",
-		Alg:     "EdDSA",
+		Alg:     alg,
 		Crv:     "Ed25519",
 		X:       x,
 		X5c:     x5c,
@@ -178,11 +175,7 @@ func getEdDSAPublicKeyJWKS(pub ed25519.PublicKey, kid string, x5c []string, x5t,
 
 // getMLDSAPublicKeyJWKS converts an ML-DSA public key to an AKP JWK (RFC 9964).
 // It reports false when pub is not an ML-DSA public key.
-func getMLDSAPublicKeyJWKS(pub crypto.PublicKey, kid string, x5c []string, x5t, x5tS256 string) (JWKS, bool) {
-	alg, ok := cryptolib.MLDSAAlgForPublicKey(pub)
-	if !ok {
-		return JWKS{}, false
-	}
+func getMLDSAPublicKeyJWKS(pub crypto.PublicKey, kid, alg string, x5c []string, x5t, x5tS256 string) (JWKS, bool) {
 	pubBytes, ok := cryptolib.MLDSAPublicKeyBytes(pub)
 	if !ok {
 		return JWKS{}, false
@@ -192,7 +185,7 @@ func getMLDSAPublicKeyJWKS(pub crypto.PublicKey, kid string, x5c []string, x5t, 
 		Kid:     kid,
 		Kty:     "AKP",
 		Use:     "sig",
-		Alg:     string(alg),
+		Alg:     alg,
 		Pub:     encodeBase64URL(pubBytes),
 		X5c:     x5c,
 		X5t:     x5t,

--- a/backend/internal/oauth/jwks/service_test.go
+++ b/backend/internal/oauth/jwks/service_test.go
@@ -149,7 +149,7 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_MLDSA_Success() {
 
 func (suite *JWKSServiceTestSuite) TestGetMLDSAPublicKeyJWKS_NonMLDSAKey() {
 	ecdsaKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	_, ok := getMLDSAPublicKeyJWKS(&ecdsaKey.PublicKey, "kid-1", nil, "", "")
+	_, ok := getMLDSAPublicKeyJWKS(&ecdsaKey.PublicKey, "kid-1", "", nil, "", "")
 	assert.False(suite.T(), ok)
 }
 
@@ -201,6 +201,25 @@ func (suite *JWKSServiceTestSuite) TestGetJWKS_UnsupportedPublicKeyType() {
 func (suite *JWKSServiceTestSuite) TestGetJWKS_OnlyUnsupportedKeys() {
 	keys := []providers.PublicKeyInfo{
 		{KeyID: "kid-1", PublicKey: "unsupported-key-type", Thumbprint: "kid-1"},
+	}
+	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, providers.PublicKeyFilter{}).
+		Return(keys, nil)
+
+	resp, svcErr := suite.jwksService.GetJWKS(context.Background())
+	assert.Nil(suite.T(), resp)
+	assert.NotNil(suite.T(), svcErr)
+	assert.Equal(suite.T(), tidcommon.InternalServerError.Code, svcErr.Code)
+}
+
+func (suite *JWKSServiceTestSuite) TestGetJWKS_EmptyKeyID() {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	keys := []providers.PublicKeyInfo{
+		{
+			KeyID:      "",
+			Algorithm:  string(cryptolib.AlgorithmRS256),
+			PublicKey:  &key.PublicKey,
+			Thumbprint: "kid-1",
+		},
 	}
 	suite.cryptoMock.EXPECT().GetPublicKeys(mock.Anything, providers.PublicKeyFilter{}).
 		Return(keys, nil)

--- a/backend/internal/system/kmprovider/defaultkm/runtime_crypto_provider.go
+++ b/backend/internal/system/kmprovider/defaultkm/runtime_crypto_provider.go
@@ -319,11 +319,13 @@ func (s *runtimeCryptoService) GetPublicKeys(
 			continue
 		}
 
+		thumbprint := s.pkiService.GetCertThumbprint(id)
+
 		keys = append(keys, providers.PublicKeyInfo{
-			KeyID:               id,
+			KeyID:               thumbprint,
 			Algorithm:           string(alg),
 			PublicKey:           pub,
-			Thumbprint:          s.pkiService.GetCertThumbprint(id),
+			Thumbprint:          thumbprint,
 			CertificateDER:      cert.Raw,
 			CertificateChainDER: s.pkiService.GetCertificateChain(id),
 		})

--- a/backend/internal/system/kmprovider/defaultkm/runtime_crypto_provider_test.go
+++ b/backend/internal/system/kmprovider/defaultkm/runtime_crypto_provider_test.go
@@ -624,7 +624,7 @@ func TestGetPublicKeys_RSA(t *testing.T) {
 	keys, err := svc.GetPublicKeys(context.Background(), providers.PublicKeyFilter{})
 	require.NoError(t, err)
 	require.Len(t, keys, 1)
-	assert.Equal(t, "key1", keys[0].KeyID)
+	assert.Equal(t, "thumbprint-1", keys[0].KeyID)
 	assert.Equal(t, string(cryptolib.AlgorithmRS256), keys[0].Algorithm)
 	assert.Equal(t, &rsaKey.PublicKey, keys[0].PublicKey)
 	assert.Equal(t, "thumbprint-1", keys[0].Thumbprint)
@@ -699,7 +699,7 @@ func TestGetPublicKeys_UnsupportedKeyTypeSkipped(t *testing.T) {
 	keys, err := svc.GetPublicKeys(context.Background(), providers.PublicKeyFilter{})
 	require.NoError(t, err)
 	assert.Len(t, keys, 1)
-	assert.Equal(t, "good", keys[0].KeyID)
+	assert.Equal(t, "tp", keys[0].KeyID)
 }
 
 func TestGetPublicKeys_FilterByKeyID(t *testing.T) {
@@ -722,7 +722,7 @@ func TestGetPublicKeys_FilterByKeyID(t *testing.T) {
 	keys, err := svc.GetPublicKeys(context.Background(), providers.PublicKeyFilter{KeyID: "rsa-key"})
 	require.NoError(t, err)
 	require.Len(t, keys, 1)
-	assert.Equal(t, "rsa-key", keys[0].KeyID)
+	assert.Equal(t, "rsa-tp", keys[0].KeyID)
 }
 
 func TestGetPublicKeys_FilterByAlgorithm(t *testing.T) {
@@ -746,7 +746,7 @@ func TestGetPublicKeys_FilterByAlgorithm(t *testing.T) {
 		providers.PublicKeyFilter{Algorithm: string(cryptolib.AlgorithmES256)})
 	require.NoError(t, err)
 	require.Len(t, keys, 1)
-	assert.Equal(t, "ec-key", keys[0].KeyID)
+	assert.Equal(t, "ec-tp", keys[0].KeyID)
 }
 
 // Sign


### PR DESCRIPTION
### Purpose

Fixed the JWKS kid and alg mismatch issue.

### Approach

GetPublicKeys() now computes the thumbprint once and assigns it to both KeyID and Thumbprint.
jwks/service.go reads kid := keyInfo.KeyID and alg := keyInfo.Algorithm directly from the provider and passes alg through to every builder function, removing all the per-type hardcoded/recomputed algorithm logic.

Added a guard: if KeyID comes back empty, the service logs and returns InternalServerError rather than publishing a JWK with no kid.

### Related Issues
- #5134

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JWKS reliability by using consistent certificate thumbprints as key identifiers.
  * Preserved the runtime-provided signing algorithm across supported key types.
  * JWKS generation now reports an internal error when a key lacks a required identifier.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->