### PR TITLE
Carry OAuth token binding flags through declarative import

### DIFF
--- a/backend/internal/system/importer/service.go
+++ b/backend/internal/system/importer/service.go
@@ -990,6 +990,8 @@ func applicationRequestToDTO(req *appmodel.ApplicationRequestWithID) *appmodel.A
 					PKCERequired:                       config.OAuthConfig.PKCERequired,
 					PublicClient:                       config.OAuthConfig.PublicClient,
 					RequirePushedAuthorizationRequests: config.OAuthConfig.RequirePushedAuthorizationRequests,
+					DPoPBoundAccessTokens:              config.OAuthConfig.DPoPBoundAccessTokens,
+					IncludeActClaim:                    config.OAuthConfig.IncludeActClaim,
 					Token:                              config.OAuthConfig.Token,
 					Scopes:                             config.OAuthConfig.Scopes,
 					UserInfo:                           config.OAuthConfig.UserInfo,

--- a/backend/internal/system/importer/service_test.go
+++ b/backend/internal/system/importer/service_test.go
@@ -2352,6 +2352,36 @@ func TestImportResources_KeepsClientSecretForConfidentialClient(t *testing.T) {
 	assert.Equal(t, statusSuccess, resp.Results[0].Status)
 }
 
+func TestImportResources_CarriesOAuthTokenBindingFlags(t *testing.T) {
+	content := strings.Join([]string{
+		"resource_type: application",
+		"id: app-1",
+		"name: My App",
+		"authFlowId: flow-1",
+		"inboundAuthConfig:",
+		"  - type: oauth2",
+		"    config:",
+		"      clientId: app-client",
+		"      clientSecret: keep-me",
+		"      grantTypes:",
+		"        - authorization_code",
+		"      tokenEndpointAuthMethod: client_secret_basic",
+		"      dpopBoundAccessTokens: true",
+		"      includeActClaim: true",
+		"",
+	}, "\n")
+	appSvc, resp, err := runOAuthClientSecretImport(t, content)
+
+	require.Nil(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, appSvc.created, 1)
+	require.Len(t, appSvc.created[0].InboundAuthConfig, 1)
+	require.NotNil(t, appSvc.created[0].InboundAuthConfig[0].OAuthConfig)
+	assert.True(t, appSvc.created[0].InboundAuthConfig[0].OAuthConfig.DPoPBoundAccessTokens)
+	assert.True(t, appSvc.created[0].InboundAuthConfig[0].OAuthConfig.IncludeActClaim)
+	assert.Equal(t, statusSuccess, resp.Results[0].Status)
+}
+
 func TestOrderDocumentsByDependencies(t *testing.T) {
 	docs := []parsedDocument{
 		{ResourceType: resourceTypeApplication, Sequence: 2},


### PR DESCRIPTION
### Purpose
Importing an application through `POST /import` (or Console -> Import) silently discarded the OAuth flags `includeActClaim` and `dpopBoundAccessTokens`. The values were read from the YAML into the request struct, then lost when that struct was converted to the service DTO, so the application was created or updated with both set to `false` while the import result still reported `create` / `update` success.

### Approach
`applicationRequestToDTO` in `backend/internal/system/importer/service.go` copies `config.OAuthConfig` field by field, and the two flags were missing between `RequirePushedAuthorizationRequests` and `Token`. This change adds the two missing assignments, keeping them in the same order as the fields on `OAuthConfigWithSecret`.

The two parallel conversion paths already handle these fields correctly: `parseApplicationYAML` in `backend/internal/application/declarative_resource.go`, used by the file based declarative loader, and the REST handler. Only the importer had drifted, so this change brings all three paths back into agreement and leaves the other two untouched.

Verification: the new unit test fails against the unpatched mapper (both assertions report `Should be true`) and passes with the fix. The full `internal/system/importer` package suite passes.

### Related Issues
- Fixes #5070

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

Unit test: `TestImportResources_CarriesOAuthTokenBindingFlags` in `backend/internal/system/importer/service_test.go`, which imports an application with `dpopBoundAccessTokens: true` and `includeActClaim: true` and asserts both reach the service DTO.

No documentation changes: this restores the already documented behaviour of the two fields rather than changing it.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth application imports now preserve DPoP-bound access token and `includeActClaim` settings.
* **Tests**
  * Added coverage to verify these OAuth configuration options remain intact during import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->