### PR TITLE
Remove unreachable POST auth callback handlers from the authz package

### DIFF
--- a/backend/internal/oauth/oauth2/authz/AuthorizeHandlerInterface_mock_test.go
+++ b/backend/internal/oauth/oauth2/authz/AuthorizeHandlerInterface_mock_test.go
@@ -37,52 +37,6 @@ func (_m *AuthorizeHandlerInterfaceMock) EXPECT() *AuthorizeHandlerInterfaceMock
 	return &AuthorizeHandlerInterfaceMock_Expecter{mock: &_m.Mock}
 }
 
-// HandleAuthCallbackPostRequest provides a mock function for the type AuthorizeHandlerInterfaceMock
-func (_mock *AuthorizeHandlerInterfaceMock) HandleAuthCallbackPostRequest(w http.ResponseWriter, r *http.Request) {
-	_mock.Called(w, r)
-	return
-}
-
-// AuthorizeHandlerInterfaceMock_HandleAuthCallbackPostRequest_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HandleAuthCallbackPostRequest'
-type AuthorizeHandlerInterfaceMock_HandleAuthCallbackPostRequest_Call struct {
-	*mock.Call
-}
-
-// HandleAuthCallbackPostRequest is a helper method to define mock.On call
-//   - w http.ResponseWriter
-//   - r *http.Request
-func (_e *AuthorizeHandlerInterfaceMock_Expecter) HandleAuthCallbackPostRequest(w interface{}, r interface{}) *AuthorizeHandlerInterfaceMock_HandleAuthCallbackPostRequest_Call {
-	return &AuthorizeHandlerInterfaceMock_HandleAuthCallbackPostRequest_Call{Call: _e.mock.On("HandleAuthCallbackPostRequest", w, r)}
-}
-
-func (_c *AuthorizeHandlerInterfaceMock_HandleAuthCallbackPostRequest_Call) Run(run func(w http.ResponseWriter, r *http.Request)) *AuthorizeHandlerInterfaceMock_HandleAuthCallbackPostRequest_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 http.ResponseWriter
-		if args[0] != nil {
-			arg0 = args[0].(http.ResponseWriter)
-		}
-		var arg1 *http.Request
-		if args[1] != nil {
-			arg1 = args[1].(*http.Request)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *AuthorizeHandlerInterfaceMock_HandleAuthCallbackPostRequest_Call) Return() *AuthorizeHandlerInterfaceMock_HandleAuthCallbackPostRequest_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *AuthorizeHandlerInterfaceMock_HandleAuthCallbackPostRequest_Call) RunAndReturn(run func(w http.ResponseWriter, r *http.Request)) *AuthorizeHandlerInterfaceMock_HandleAuthCallbackPostRequest_Call {
-	_c.Run(run)
-	return _c
-}
-
 // HandleAuthorizeGetRequest provides a mock function for the type AuthorizeHandlerInterfaceMock
 func (_mock *AuthorizeHandlerInterfaceMock) HandleAuthorizeGetRequest(w http.ResponseWriter, r *http.Request) {
 	_mock.Called(w, r)

--- a/backend/internal/oauth/oauth2/authz/handler.go
+++ b/backend/internal/oauth/oauth2/authz/handler.go
@@ -20,7 +20,6 @@ import (
 // AuthorizeHandlerInterface defines the interface for handling OAuth2 authorization requests.
 type AuthorizeHandlerInterface interface {
 	HandleAuthorizeGetRequest(w http.ResponseWriter, r *http.Request)
-	HandleAuthCallbackPostRequest(w http.ResponseWriter, r *http.Request)
 }
 
 // authorizeHandler implements the AuthorizeHandlerInterface for handling OAuth2 authorization requests.
@@ -74,41 +73,6 @@ func (ah *authorizeHandler) HandleAuthorizeGetRequest(w http.ResponseWriter, r *
 	ah.redirectToLoginPage(w, r, result.QueryParams)
 }
 
-// HandleAuthCallbackPostRequest handles the POST request for OAuth2 auth callback.
-// This endpoint receives the assertion from the flow engine after successful authentication.
-func (ah *authorizeHandler) HandleAuthCallbackPostRequest(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	oAuthMessage := ah.getOAuthMessage(r, w)
-	if oAuthMessage == nil {
-		return
-	}
-
-	switch oAuthMessage.RequestType {
-	case oauth2const.TypeAuthorizationResponseFromEngine:
-		authID := oAuthMessage.AuthID
-		assertion := oAuthMessage.RequestBodyParams[oauth2const.RequestParamAssertion]
-
-		redirectURI, authErr := ah.authZService.HandleAuthorizationCallback(ctx, authID, assertion)
-		if authErr != nil {
-			if authErr.SendErrorToClient {
-				ah.writeAuthZResponseToClientRedirect(ctx, w, authErr)
-				return
-			}
-			ah.writeAuthZResponseToErrorPage(ctx, w, authErr.Code, authErr.Message, authErr.State)
-			return
-		}
-		ah.writeAuthZResponse(ctx, w, redirectURI)
-
-	case oauth2const.TypeConsentResponseFromUser:
-		// TODO: Handle the consent response from the user.
-		//  Verify whether we need separate session data key for consent flow.
-		//  Alternatively could add consent info also to the same session object.
-	default:
-		sysutils.WriteJSONError(ctx, w, oauth2const.ErrorInvalidRequest, "Invalid authorization request",
-			http.StatusBadRequest, nil)
-	}
-}
-
 // getOAuthMessage extracts the OAuth message from the request and response writer.
 func (ah *authorizeHandler) getOAuthMessage(r *http.Request, w http.ResponseWriter) *OAuthMessage {
 	logger := ah.logger
@@ -125,8 +89,6 @@ func (ah *authorizeHandler) getOAuthMessage(r *http.Request, w http.ResponseWrit
 	switch r.Method {
 	case http.MethodGet:
 		msg, err = ah.getOAuthMessageForGetRequest(r)
-	case http.MethodPost:
-		msg, err = ah.getOAuthMessageForPostRequest(r)
 	default:
 		err = errors.New("unsupported request method: " + r.Method)
 	}
@@ -165,29 +127,6 @@ func (ah *authorizeHandler) getOAuthMessageForGetRequest(r *http.Request) (*OAut
 		Resources:          resources,
 		RequestHeaders:     sysutils.SanitizeRawMultiValueStringMap(r.Header),
 		RequestQueryParams: sysutils.SanitizeRawMultiValueStringMap(queryParams),
-	}, nil
-}
-
-// getOAuthMessageForPostRequest extracts the OAuth message from an authorization POST request.
-func (ah *authorizeHandler) getOAuthMessageForPostRequest(r *http.Request) (*OAuthMessage, error) {
-	authZReq, err := sysutils.DecodeJSONBody[AuthZPostRequest](r)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode JSON body: %w", err)
-	}
-
-	if authZReq.AuthID == "" || authZReq.Assertion == "" {
-		return nil, errors.New("authId or assertion is missing")
-	}
-
-	// TODO: Require to handle other types such as user consent, etc.
-	bodyParams := map[string]string{
-		oauth2const.RequestParamAssertion: authZReq.Assertion,
-	}
-
-	return &OAuthMessage{
-		RequestType:       oauth2const.TypeAuthorizationResponseFromEngine,
-		AuthID:            authZReq.AuthID,
-		RequestBodyParams: bodyParams,
 	}, nil
 }
 
@@ -263,64 +202,4 @@ func (ah *authorizeHandler) redirectToErrorPage(w http.ResponseWriter, r *http.R
 	logger.Debug(ctx, "Redirecting to error page")
 
 	http.Redirect(w, r, redirectURL, http.StatusFound)
-}
-
-// writeAuthZResponse writes the authorization response to the HTTP response writer.
-func (ah *authorizeHandler) writeAuthZResponse(ctx context.Context, w http.ResponseWriter, redirectURI string) {
-	authZResp := AuthZPostResponse{
-		RedirectURI: redirectURI,
-	}
-	sysutils.WriteSuccessResponse(ctx, w, http.StatusOK, authZResp)
-}
-
-// writeAuthZResponseToErrorPage writes the authorization response redirecting to the error page.
-// The state parameter is included in the redirect if non-empty.
-func (
-	ah *authorizeHandler) writeAuthZResponseToErrorPage(ctx context.Context,
-	w http.ResponseWriter,
-	code,
-	msg,
-	state string) {
-	redirectURI, err := getErrorPageRedirectURL(ah.cfg, code, msg)
-	if err != nil {
-		http.Error(w, "Failed to redirect to error page", http.StatusInternalServerError)
-		return
-	}
-
-	if state != "" {
-		queryParams := map[string]string{
-			oauth2const.RequestParamState: state,
-		}
-		redirectURI, err = oauth2utils.GetURIWithQueryParams(redirectURI, queryParams)
-		if err != nil {
-			http.Error(w, "Failed to redirect to error page", http.StatusInternalServerError)
-			return
-		}
-	}
-
-	ah.writeAuthZResponse(ctx, w, redirectURI)
-}
-
-// writeAuthZResponseToClientRedirect writes the authorization error response redirecting to the
-// client's registered redirect URI.
-func (ah *authorizeHandler) writeAuthZResponseToClientRedirect(
-	ctx context.Context, w http.ResponseWriter, authErr *AuthorizationError) {
-	queryParams := map[string]string{
-		oauth2const.RequestParamError:            authErr.Code,
-		oauth2const.RequestParamErrorDescription: authErr.Message,
-		oauth2const.RequestParamIss:              ah.cfg.JWT.Issuer,
-	}
-	if authErr.State != "" {
-		queryParams[oauth2const.RequestParamState] = authErr.State
-	}
-
-	redirectURI, err := oauth2utils.GetURIWithQueryParams(authErr.ClientRedirectURI, queryParams)
-	if err != nil {
-		ah.logger.Error(ctx, "Failed to construct client redirect URI", log.Error(err))
-		ah.writeAuthZResponseToErrorPage(ctx, w, oauth2const.ErrorServerError,
-			"Failed to process authorization request", authErr.State)
-		return
-	}
-
-	ah.writeAuthZResponse(ctx, w, redirectURI)
 }

--- a/backend/internal/oauth/oauth2/authz/handler_test.go
+++ b/backend/internal/oauth/oauth2/authz/handler_test.go
@@ -4,9 +4,6 @@
 package authz
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -178,40 +175,6 @@ func (suite *AuthorizeHandlerTestSuite) TestHandleAuthorizeGetRequest_DuplicateN
 	assert.Equal(suite.T(), http.StatusBadRequest, rr.Code)
 }
 
-func (suite *AuthorizeHandlerTestSuite) TestGetOAuthMessageForPostRequest_MissingAuthID() {
-	postData := AuthZPostRequest{
-		AuthID:    "",
-		Assertion: "test-assertion",
-	}
-	jsonData, _ := json.Marshal(postData)
-
-	req := httptest.NewRequest(http.MethodPost, "/auth", bytes.NewReader(jsonData))
-	req.Header.Set("Content-Type", "application/json")
-
-	msg, err := suite.handler.getOAuthMessageForPostRequest(req)
-
-	assert.Error(suite.T(), err)
-	assert.Nil(suite.T(), msg)
-	assert.Contains(suite.T(), err.Error(), "authId or assertion is missing")
-}
-
-func (suite *AuthorizeHandlerTestSuite) TestGetOAuthMessageForPostRequest_MissingAssertion() {
-	postData := AuthZPostRequest{
-		AuthID:    testAuthID,
-		Assertion: "",
-	}
-	jsonData, _ := json.Marshal(postData)
-
-	req := httptest.NewRequest(http.MethodPost, "/auth", bytes.NewReader(jsonData))
-	req.Header.Set("Content-Type", "application/json")
-
-	msg, err := suite.handler.getOAuthMessageForPostRequest(req)
-
-	assert.Error(suite.T(), err)
-	assert.Nil(suite.T(), msg)
-	assert.Contains(suite.T(), err.Error(), "authId or assertion is missing")
-}
-
 func (suite *AuthorizeHandlerTestSuite) TestGetOAuthMessage_UnsupportedMethod() {
 	req := httptest.NewRequest(http.MethodPatch, "/auth", nil)
 	rr := httptest.NewRecorder()
@@ -333,160 +296,6 @@ func (suite *AuthorizeHandlerTestSuite) TestHandleAuthorizeGetRequest_GetOAuthMe
 	assert.Equal(suite.T(), http.StatusBadRequest, rr.Code)
 }
 
-func (suite *AuthorizeHandlerTestSuite) TestHandleAuthCallbackPostRequest_Success() {
-	redirectURI := "https://client.example.com/callback?code=test-code&state=test-state"
-	suite.mockAuthzService.EXPECT().
-		HandleAuthorizationCallback(mock.Anything, testAuthID, "test-assertion").
-		Return(redirectURI, nil)
-
-	postData := AuthZPostRequest{
-		AuthID:    testAuthID,
-		Assertion: "test-assertion",
-	}
-	jsonData, _ := json.Marshal(postData)
-
-	req := httptest.NewRequest(http.MethodPost, "/oauth2/auth/callback", bytes.NewReader(jsonData))
-	req.Header.Set("Content-Type", "application/json")
-	rr := httptest.NewRecorder()
-
-	suite.handler.HandleAuthCallbackPostRequest(rr, req)
-
-	assert.Equal(suite.T(), http.StatusOK, rr.Code)
-	var resp AuthZPostResponse
-	err := json.NewDecoder(rr.Body).Decode(&resp)
-	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), redirectURI, resp.RedirectURI)
-}
-
-func (suite *AuthorizeHandlerTestSuite) TestHandleAuthCallbackPostRequest_ServiceError() {
-	authErr := &AuthorizationError{
-		Code:    oauth2const.ErrorInvalidRequest,
-		Message: "Invalid authorization request",
-		State:   "test-state",
-	}
-	suite.mockAuthzService.EXPECT().
-		HandleAuthorizationCallback(mock.Anything, testAuthID, "test-assertion").
-		Return("", authErr)
-
-	postData := AuthZPostRequest{
-		AuthID:    testAuthID,
-		Assertion: "test-assertion",
-	}
-	jsonData, _ := json.Marshal(postData)
-
-	req := httptest.NewRequest(http.MethodPost, "/oauth2/auth/callback", bytes.NewReader(jsonData))
-	req.Header.Set("Content-Type", "application/json")
-	rr := httptest.NewRecorder()
-
-	suite.handler.HandleAuthCallbackPostRequest(rr, req)
-
-	assert.Equal(suite.T(), http.StatusOK, rr.Code)
-	var resp AuthZPostResponse
-	err := json.NewDecoder(rr.Body).Decode(&resp)
-	assert.NoError(suite.T(), err)
-	assert.Contains(suite.T(), resp.RedirectURI, "/error")
-	assert.Contains(suite.T(), resp.RedirectURI, "state=test-state")
-}
-
-func (suite *AuthorizeHandlerTestSuite) TestHandleAuthCallbackPostRequest_ServiceErrorRedirectToClient() {
-	authErr := &AuthorizationError{
-		Code:              oauth2const.ErrorServerError,
-		Message:           "Failed to process authorization request",
-		State:             "test-state",
-		SendErrorToClient: true,
-		ClientRedirectURI: "https://client.example.com/callback",
-	}
-	suite.mockAuthzService.EXPECT().HandleAuthorizationCallback(mock.Anything, testAuthID, "test-assertion").
-		Return("", authErr)
-
-	postData := AuthZPostRequest{
-		AuthID:    testAuthID,
-		Assertion: "test-assertion",
-	}
-	jsonData, _ := json.Marshal(postData)
-
-	req := httptest.NewRequest(http.MethodPost, "/oauth2/auth/callback", bytes.NewReader(jsonData))
-	req.Header.Set("Content-Type", "application/json")
-	rr := httptest.NewRecorder()
-
-	suite.handler.HandleAuthCallbackPostRequest(rr, req)
-
-	assert.Equal(suite.T(), http.StatusOK, rr.Code)
-	var resp AuthZPostResponse
-	err := json.NewDecoder(rr.Body).Decode(&resp)
-	assert.NoError(suite.T(), err)
-	assert.Contains(suite.T(), resp.RedirectURI, "https://client.example.com/callback")
-	assert.Contains(suite.T(), resp.RedirectURI, "error=server_error")
-	assert.Contains(suite.T(), resp.RedirectURI, "state=test-state")
-	assert.Contains(suite.T(), resp.RedirectURI, "iss=https%3A%2F%2Flocalhost%3A8090")
-}
-
-func (suite *AuthorizeHandlerTestSuite) TestHandleAuthCallbackPostRequest_ClientErrorIssAlwaysPresent() {
-	// RFC 9207 §2: iss is unconditional. Confirm iss is present even when state is absent.
-	authErr := &AuthorizationError{
-		Code:              oauth2const.ErrorServerError,
-		Message:           "Failed to process authorization request",
-		SendErrorToClient: true,
-		ClientRedirectURI: "https://client.example.com/callback",
-	}
-	suite.mockAuthzService.EXPECT().HandleAuthorizationCallback(mock.Anything, testAuthID, "test-assertion").
-		Return("", authErr)
-
-	postData := AuthZPostRequest{
-		AuthID:    testAuthID,
-		Assertion: "test-assertion",
-	}
-	jsonData, _ := json.Marshal(postData)
-
-	req := httptest.NewRequest(http.MethodPost, "/oauth2/auth/callback", bytes.NewReader(jsonData))
-	req.Header.Set("Content-Type", "application/json")
-	rr := httptest.NewRecorder()
-
-	suite.handler.HandleAuthCallbackPostRequest(rr, req)
-
-	assert.Equal(suite.T(), http.StatusOK, rr.Code)
-	var resp AuthZPostResponse
-	err := json.NewDecoder(rr.Body).Decode(&resp)
-	assert.NoError(suite.T(), err)
-	assert.Contains(suite.T(), resp.RedirectURI, "https://client.example.com/callback")
-	assert.Contains(suite.T(), resp.RedirectURI, "error=server_error")
-	assert.Contains(suite.T(), resp.RedirectURI, "iss=https%3A%2F%2Flocalhost%3A8090")
-	assert.NotContains(suite.T(), resp.RedirectURI, "state=")
-}
-
-func (suite *AuthorizeHandlerTestSuite) TestHandleAuthCallbackPostRequest_InvalidRequestType() {
-	// nil body causes JSON decode to fail → getOAuthMessage returns nil → 400
-	req := httptest.NewRequest(http.MethodPost, "/oauth2/auth/callback", nil)
-	rr := httptest.NewRecorder()
-
-	suite.handler.HandleAuthCallbackPostRequest(rr, req)
-
-	assert.Equal(suite.T(), http.StatusBadRequest, rr.Code)
-}
-
-func (suite *AuthorizeHandlerTestSuite) TestHandleAuthCallbackPostRequest_GetOAuthMessageReturnsNil() {
-	req := httptest.NewRequest("POST", "/oauth2/auth/callback", bytes.NewReader([]byte("invalid json")))
-	req.Header.Set("Content-Type", "application/json")
-	rr := httptest.NewRecorder()
-
-	suite.handler.HandleAuthCallbackPostRequest(rr, req)
-
-	assert.Equal(suite.T(), http.StatusBadRequest, rr.Code)
-}
-
-func (suite *AuthorizeHandlerTestSuite) TestHandleAuthCallbackPostRequest_UnsupportedMethod() {
-	req := httptest.NewRequest(http.MethodPut, "/oauth2/auth/callback", nil)
-	rr := httptest.NewRecorder()
-
-	suite.handler.HandleAuthCallbackPostRequest(rr, req)
-
-	assert.Equal(suite.T(), http.StatusBadRequest, rr.Code)
-	var response map[string]interface{}
-	err := json.NewDecoder(rr.Body).Decode(&response)
-	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), "invalid_request", response["error"])
-}
-
 func (suite *AuthorizeHandlerTestSuite) TestRedirectToLoginPage_NilResponseWriter() {
 	req := httptest.NewRequest(http.MethodGet, "/auth", nil)
 	queryParams := map[string]string{"authId": "test-key"}
@@ -530,42 +339,6 @@ func (suite *AuthorizeHandlerTestSuite) TestRedirectToErrorPage_NilRequest() {
 	suite.handler.redirectToErrorPage(rr, nil, "error_code", "error message")
 	// Should not panic; status remains unchanged
 	assert.Equal(suite.T(), http.StatusOK, rr.Code)
-}
-
-func (suite *AuthorizeHandlerTestSuite) TestWriteAuthZResponseToErrorPage_WithState() {
-	rr := httptest.NewRecorder()
-	suite.handler.writeAuthZResponseToErrorPage(context.Background(), rr, "error_code", "error message", "test-state")
-
-	assert.Equal(suite.T(), http.StatusOK, rr.Code)
-	var resp AuthZPostResponse
-	err := json.NewDecoder(rr.Body).Decode(&resp)
-	assert.NoError(suite.T(), err)
-	assert.Contains(suite.T(), resp.RedirectURI, "state=test-state")
-}
-
-func (suite *AuthorizeHandlerTestSuite) TestWriteAuthZResponseToErrorPage_NoState() {
-	rr := httptest.NewRecorder()
-	suite.handler.writeAuthZResponseToErrorPage(context.Background(), rr, "error_code", "error message", "")
-
-	assert.Equal(suite.T(), http.StatusOK, rr.Code)
-	var resp AuthZPostResponse
-	err := json.NewDecoder(rr.Body).Decode(&resp)
-	assert.NoError(suite.T(), err)
-	assert.NotEmpty(suite.T(), resp.RedirectURI)
-	assert.Contains(suite.T(), resp.RedirectURI, "/error")
-}
-
-func (suite *AuthorizeHandlerTestSuite) TestWriteAuthZResponse() {
-	rr := httptest.NewRecorder()
-
-	suite.handler.writeAuthZResponse(context.Background(), rr, "https://example.com/callback?code=abc123")
-
-	assert.Equal(suite.T(), http.StatusOK, rr.Code)
-	assert.Equal(suite.T(), "application/json", rr.Header().Get("Content-Type"))
-	var resp AuthZPostResponse
-	err := json.NewDecoder(rr.Body).Decode(&resp)
-	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), "https://example.com/callback?code=abc123", resp.RedirectURI)
 }
 
 func (suite *AuthorizeHandlerTestSuite) TestGetLoginPageRedirectURI_Success() {

--- a/backend/internal/oauth/oauth2/authz/model.go
+++ b/backend/internal/oauth/oauth2/authz/model.go
@@ -46,12 +46,6 @@ type AuthorizationCode struct {
 	TokenFamilyID string
 }
 
-// AuthZPostRequest represents the request body for the authorization POST request.
-type AuthZPostRequest struct {
-	AuthID    string `json:"authId"`
-	Assertion string `json:"assertion"`
-}
-
 // AuthZPostResponse represents the response body for the authorization POST request.
 type AuthZPostResponse struct {
 	RedirectURI string `json:"redirect_uri"`

--- a/backend/tests/mocks/oauth/oauth2/authzmock/AuthorizeHandlerInterface_mock.go
+++ b/backend/tests/mocks/oauth/oauth2/authzmock/AuthorizeHandlerInterface_mock.go
@@ -37,52 +37,6 @@ func (_m *AuthorizeHandlerInterfaceMock) EXPECT() *AuthorizeHandlerInterfaceMock
 	return &AuthorizeHandlerInterfaceMock_Expecter{mock: &_m.Mock}
 }
 
-// HandleAuthCallbackPostRequest provides a mock function for the type AuthorizeHandlerInterfaceMock
-func (_mock *AuthorizeHandlerInterfaceMock) HandleAuthCallbackPostRequest(w http.ResponseWriter, r *http.Request) {
-	_mock.Called(w, r)
-	return
-}
-
-// AuthorizeHandlerInterfaceMock_HandleAuthCallbackPostRequest_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HandleAuthCallbackPostRequest'
-type AuthorizeHandlerInterfaceMock_HandleAuthCallbackPostRequest_Call struct {
-	*mock.Call
-}
-
-// HandleAuthCallbackPostRequest is a helper method to define mock.On call
-//   - w http.ResponseWriter
-//   - r *http.Request
-func (_e *AuthorizeHandlerInterfaceMock_Expecter) HandleAuthCallbackPostRequest(w interface{}, r interface{}) *AuthorizeHandlerInterfaceMock_HandleAuthCallbackPostRequest_Call {
-	return &AuthorizeHandlerInterfaceMock_HandleAuthCallbackPostRequest_Call{Call: _e.mock.On("HandleAuthCallbackPostRequest", w, r)}
-}
-
-func (_c *AuthorizeHandlerInterfaceMock_HandleAuthCallbackPostRequest_Call) Run(run func(w http.ResponseWriter, r *http.Request)) *AuthorizeHandlerInterfaceMock_HandleAuthCallbackPostRequest_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 http.ResponseWriter
-		if args[0] != nil {
-			arg0 = args[0].(http.ResponseWriter)
-		}
-		var arg1 *http.Request
-		if args[1] != nil {
-			arg1 = args[1].(*http.Request)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *AuthorizeHandlerInterfaceMock_HandleAuthCallbackPostRequest_Call) Return() *AuthorizeHandlerInterfaceMock_HandleAuthCallbackPostRequest_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *AuthorizeHandlerInterfaceMock_HandleAuthCallbackPostRequest_Call) RunAndReturn(run func(w http.ResponseWriter, r *http.Request)) *AuthorizeHandlerInterfaceMock_HandleAuthCallbackPostRequest_Call {
-	_c.Run(run)
-	return _c
-}
-
 // HandleAuthorizeGetRequest provides a mock function for the type AuthorizeHandlerInterfaceMock
 func (_mock *AuthorizeHandlerInterfaceMock) HandleAuthorizeGetRequest(w http.ResponseWriter, r *http.Request) {
 	_mock.Called(w, r)


### PR DESCRIPTION
### Purpose
Removes five functions in `backend/internal/oauth/oauth2/authz/handler.go` that are unreachable over HTTP. They are the pre-refactor implementation of `POST /oauth2/auth/callback`, which now lives in the `callback` package. Only the interface declaration, the generated mocks, and unit tests calling them directly still referenced them.

### Approach
`authz/init.go` registers only `GET /oauth2/authorize`. The `POST /oauth2/auth/callback` route is bound in `callback/callback.go` to `callbackDispatcher.handleFlowCallback`, so nothing routes into the authz copies.

Deleted:

- `HandleAuthCallbackPostRequest`
- `getOAuthMessageForPostRequest`
- `writeAuthZResponse`
- `writeAuthZResponseToErrorPage`
- `writeAuthZResponseToClientRedirect`

`HandleAuthCallbackPostRequest` is also dropped from `AuthorizeHandlerInterface`, leaving `HandleAuthorizeGetRequest` as the only method, and the mocks were regenerated with `mockery` to match.

Two follow-on cleanups fell out of the deletion:

- `getOAuthMessage` had a `case http.MethodPost` branch that only fed `getOAuthMessageForPostRequest`. The branch is removed; the `GET` case and the `default` invalid request path are unchanged, so a non-GET request still gets `invalid_request` with HTTP 400.
- `AuthZPostRequest` in `model.go` was read only by `getOAuthMessageForPostRequest`, so it is removed too. `AuthZPostResponse` is kept, since `callback.go` still writes it in three places.

The `callback` package is untouched. Its `writeRedirectWithError` and `writeErrorPageRedirect` remain as the live implementations, so no consolidation of the surviving helpers is included here.

Verification: `go build ./...` passes, `go vet ./internal/oauth/oauth2/...` is clean, and the `authz` and `callback` package tests pass. The diff is deletion only, 446 lines across 5 files with no additions.

### Related Issues
- Fixes #4914

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

No new tests: this removes dead code and the unit tests that existed only to exercise it (`TestGetOAuthMessageForPostRequest_*`, `TestHandleAuthCallbackPostRequest_*`, `TestWriteAuthZResponse*`). The remaining `authz` handler tests continue to pass unchanged. No documentation changes, since none of the removed functions served a routed endpoint.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed support for the OAuth authorization POST callback flow.
  * Authorization now continues to support GET-based handling and redirects.
  * Removed related callback request and response processing.
  * Retained existing authorization-code, assertion-decoding, and subject-constraint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->