### PR TITLE
Fixes #5139

### DIFF
--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/thunder-id/thunderid/internal/attributecache"
+	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/authz"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/dpop"
@@ -28,6 +29,7 @@ type authorizationCodeGrantHandler struct {
 	tokenBuilder    tokenservice.TokenBuilderInterface
 	attributeCache  attributecache.AttributeCacheServiceInterface
 	resourceService providers.ResourceServerProvider
+	cfg             oauthconfig.Config
 }
 
 // newAuthorizationCodeGrantHandler creates a new instance of AuthorizationCodeGrantHandler.
@@ -36,12 +38,14 @@ func newAuthorizationCodeGrantHandler(
 	tokenBuilder tokenservice.TokenBuilderInterface,
 	attributeCache attributecache.AttributeCacheServiceInterface,
 	resourceService providers.ResourceServerProvider,
+	cfg oauthconfig.Config,
 ) GrantHandlerInterface {
 	return &authorizationCodeGrantHandler{
 		authzService:    authzService,
 		tokenBuilder:    tokenBuilder,
 		attributeCache:  attributeCache,
 		resourceService: resourceService,
+		cfg:             cfg,
 	}
 }
 
@@ -135,8 +139,8 @@ func (h *authorizationCodeGrantHandler) HandleGrant(ctx context.Context, tokenRe
 	if targetRS == nil {
 		// OIDC-only (or scopeless) request with no resource: the token is not bound to a resource
 		// server, so its audience is the app's configured default audiences (falling back to the
-		// client_id) and it carries only the OIDC scopes.
-		accessTokenAudiences = []string{oauthApp.ResolveDefaultAudience(tokenRequest.ClientID)}
+		// server issuer ID) and it carries only the OIDC scopes.
+		accessTokenAudiences = []string{oauthApp.ResolveDefaultAudience(h.cfg.JWT.Issuer)}
 		accessTokenScopes = oidcScopes
 	} else {
 		downscopedNonOidc, dErr := resourceindicators.DownscopeToResourceServer(

--- a/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/authorization_code_test.go
@@ -12,6 +12,8 @@ import (
 	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
+	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
+
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 
 	"github.com/stretchr/testify/assert"
@@ -178,7 +180,8 @@ func (suite *AuthorizationCodeGrantHandlerTestSuite) stubDefaultResourceServer()
 
 func (suite *AuthorizationCodeGrantHandlerTestSuite) TestNewAuthorizationCodeGrantHandler() {
 	handler := newAuthorizationCodeGrantHandler(
-		suite.mockAuthzService, suite.mockTokenBuilder, suite.mockAttrCacheService, suite.mockResourceService)
+		suite.mockAuthzService, suite.mockTokenBuilder, suite.mockAttrCacheService, suite.mockResourceService,
+		oauthconfig.Config{})
 	assert.NotNil(suite.T(), handler)
 	assert.Implements(suite.T(), (*GrantHandlerInterface)(nil), handler)
 }

--- a/backend/internal/oauth/oauth2/granthandlers/ciba.go
+++ b/backend/internal/oauth/oauth2/granthandlers/ciba.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/thunder-id/thunderid/internal/attributecache"
+	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/ciba"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/dpop"
@@ -27,6 +28,7 @@ type cibaGrantHandler struct {
 	tokenBuilder    tokenservice.TokenBuilderInterface
 	attributeCache  attributecache.AttributeCacheServiceInterface
 	resourceService providers.ResourceServerProvider
+	cfg             oauthconfig.Config
 	logger          *log.Logger
 }
 
@@ -36,12 +38,14 @@ func newCIBAGrantHandler(
 	tokenBuilder tokenservice.TokenBuilderInterface,
 	attributeCache attributecache.AttributeCacheServiceInterface,
 	resourceService providers.ResourceServerProvider,
+	cfg oauthconfig.Config,
 ) GrantHandlerInterface {
 	return &cibaGrantHandler{
 		cibaService:     cibaService,
 		tokenBuilder:    tokenBuilder,
 		attributeCache:  attributeCache,
 		resourceService: resourceService,
+		cfg:             cfg,
 		logger:          log.GetLogger().With(log.String(log.LoggerKeyComponentName, "CIBAGrantHandler")),
 	}
 }
@@ -290,8 +294,8 @@ func (h *cibaGrantHandler) issueTokens(ctx context.Context, record *ciba.CIBAAut
 // resolveIssuedAudiencesAndScopes derives the access-token audiences and scopes for a CIBA record.
 // A resource-bound record yields the RS identifier as the sole audience, with permission scopes
 // refiltered against that RS. An unbound OIDC-only record uses the app's configured default
-// audience, falling back to the client_id; an unbound record that unexpectedly carries permission
-// scopes is rejected with invalid_grant.
+// audience, falling back to the server issuer ID; an unbound record that unexpectedly carries
+// permission scopes is rejected with invalid_grant.
 func (h *cibaGrantHandler) resolveIssuedAudiencesAndScopes(ctx context.Context,
 	record *ciba.CIBAAuthRequest, oauthApp *providers.OAuthClient, scopeStr string,
 ) ([]string, []string, *model.ErrorResponse) {
@@ -304,7 +308,7 @@ func (h *cibaGrantHandler) resolveIssuedAudiencesAndScopes(ctx context.Context,
 				ErrorDescription: "The authentication request is not bound to a resource server",
 			}
 		}
-		return []string{oauthApp.ResolveDefaultAudience(oauthApp.ClientID)}, oidcScopes, nil
+		return []string{oauthApp.ResolveDefaultAudience(h.cfg.JWT.Issuer)}, oidcScopes, nil
 	}
 
 	resourceIdentifier := record.Resources[0]

--- a/backend/internal/oauth/oauth2/granthandlers/ciba_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/ciba_test.go
@@ -16,11 +16,13 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/attributecache"
+	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/ciba"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/dpop"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/model"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/tokenservice"
+	engineconfig "github.com/thunder-id/thunderid/pkg/thunderidengine/config"
 	"github.com/thunder-id/thunderid/tests/mocks/attributecachemock"
 	"github.com/thunder-id/thunderid/tests/mocks/oauth/oauth2/cibamock"
 	"github.com/thunder-id/thunderid/tests/mocks/oauth/oauth2/tokenservicemock"
@@ -48,7 +50,8 @@ func (suite *CIBAGrantHandlerTestSuite) SetupTest() {
 	suite.mockAttrCacheService = attributecachemock.NewAttributeCacheServiceInterfaceMock(suite.T())
 	suite.mockResource = resourcemock.NewResourceServiceInterfaceMock(suite.T())
 	suite.handler = newCIBAGrantHandler(suite.mockCIBAService, suite.mockTokenBuilder,
-		suite.mockAttrCacheService, suite.mockResource)
+		suite.mockAttrCacheService, suite.mockResource,
+		oauthconfig.Config{JWT: engineconfig.JWTConfig{Issuer: testCIBAIssuer}})
 	suite.oauthApp = &providers.OAuthClient{
 		ClientID: "client-1",
 		ScopeClaims: map[string][]string{
@@ -76,6 +79,7 @@ func (suite *CIBAGrantHandlerTestSuite) pendingRecord() *ciba.CIBAAuthRequest {
 }
 
 const testCIBAResourceURL = "https://api.example.com"
+const testCIBAIssuer = "https://issuer.example.com"
 
 // boundAuthenticatedRecord returns an authenticated record bound to testCIBAResourceURL.
 func (suite *CIBAGrantHandlerTestSuite) boundAuthenticatedRecord(scopes string) *ciba.CIBAAuthRequest {
@@ -449,7 +453,7 @@ func (suite *CIBAGrantHandlerTestSuite) TestHandleGrant_BoundTokenHasResourceAud
 	suite.Equal([]string{testCIBAResourceURL}, resp.AccessToken.OriginalAudiences)
 }
 
-func (suite *CIBAGrantHandlerTestSuite) TestHandleGrant_UnboundOIDCOnlyKeepsClientAudience() {
+func (suite *CIBAGrantHandlerTestSuite) TestHandleGrant_UnboundOIDCOnlyUsesIssuerAudience() {
 	record := suite.pendingRecord()
 	record.State = ciba.CIBAStateAuthenticated
 	suite.mockCIBAService.EXPECT().GetByAuthReqID(mock.Anything, "auth-req-1").Return(record, nil)
@@ -466,8 +470,8 @@ func (suite *CIBAGrantHandlerTestSuite) TestHandleGrant_UnboundOIDCOnlyKeepsClie
 	resp, errResp := suite.handler.HandleGrant(context.Background(), suite.tokenReq, suite.oauthApp)
 	suite.Nil(errResp)
 	suite.NotNil(resp)
-	suite.Equal([]string{"client-1"}, capturedCtx.Audiences)
-	suite.Equal([]string{"client-1"}, resp.AccessToken.OriginalAudiences)
+	suite.Equal([]string{testCIBAIssuer}, capturedCtx.Audiences)
+	suite.Equal([]string{testCIBAIssuer}, resp.AccessToken.OriginalAudiences)
 }
 
 func (suite *CIBAGrantHandlerTestSuite) TestHandleGrant_UnboundWithPermissionScopesRejected() {

--- a/backend/internal/oauth/oauth2/granthandlers/client_credentials.go
+++ b/backend/internal/oauth/oauth2/granthandlers/client_credentials.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"slices"
 
+	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/dpop"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/model"
@@ -23,6 +24,7 @@ type clientCredentialsGrantHandler struct {
 	authzService    providers.AuthorizationProvider
 	actorProvider   providers.ActorProvider
 	resourceService providers.ResourceServerProvider
+	cfg             oauthconfig.Config
 }
 
 // newClientCredentialsGrantHandler creates a new instance of ClientCredentialsGrantHandler.
@@ -32,6 +34,7 @@ func newClientCredentialsGrantHandler(
 	authzService providers.AuthorizationProvider,
 	actorProvider providers.ActorProvider,
 	resourceService providers.ResourceServerProvider,
+	cfg oauthconfig.Config,
 ) GrantHandlerInterface {
 	return &clientCredentialsGrantHandler{
 		tokenBuilder:    tokenBuilder,
@@ -39,6 +42,7 @@ func newClientCredentialsGrantHandler(
 		authzService:    authzService,
 		actorProvider:   actorProvider,
 		resourceService: resourceService,
+		cfg:             cfg,
 	}
 }
 
@@ -70,15 +74,15 @@ func (h *clientCredentialsGrantHandler) HandleGrant(ctx context.Context, tokenRe
 	// A client_credentials token carries no OIDC scopes, so every requested scope is a permission
 	// scope. Bind the token to a single resource server (RFC 8707 resource or the configured
 	// default). A request with neither scopes nor a resource is not bound to a resource server: its
-	// audience is the app's configured default audiences (falling back to the client_id) and it
-	// carries no scopes.
+	// audience is the app's configured default audiences (falling back to the server issuer ID) and
+	// it carries no scopes.
 	targetRS, errResp := resourceindicators.ResolveAudienceBinding(
 		ctx, h.resourceService, tokenRequest.Resources, scopes)
 	if errResp != nil {
 		return nil, errResp
 	}
 
-	audiences := []string{oauthApp.ResolveDefaultAudience(tokenRequest.ClientID)}
+	audiences := []string{oauthApp.ResolveDefaultAudience(h.cfg.JWT.Issuer)}
 	if targetRS != nil {
 		audiences = []string{targetRS.Identifier}
 

--- a/backend/internal/oauth/oauth2/granthandlers/client_credentials_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/client_credentials_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
+	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/dpop"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/model"
@@ -40,6 +41,10 @@ const testEntityID = "agent-entity-123"
 const defaultRSID = "rs-1"
 const defaultRSIdentifier = "https://api.example.com"
 
+// testServerIssuer is the configured server issuer ID, used as the fallback aud when a request is
+// not bound to a resource server and the app has no configured default audience.
+const testServerIssuer = "https://auth.example.com"
+
 type ClientCredentialsGrantHandlerTestSuite struct {
 	suite.Suite
 	mockJWTService      *jwtmock.JWTServiceInterfaceMock
@@ -60,7 +65,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) SetupTest() {
 	// Initialize Runtime for tests
 	testConfig := &config.Config{
 		JWT: engineconfig.JWTConfig{
-			Issuer:         "https://auth.example.com",
+			Issuer:         testServerIssuer,
 			ValidityPeriod: 3600,
 		},
 	}
@@ -94,6 +99,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) SetupTest() {
 		authzService:    suite.mockAuthzService,
 		actorProvider:   suite.mockEntityProvider,
 		resourceService: suite.mockResourceService,
+		cfg:             oauthconfig.Config{JWT: engineconfig.JWTConfig{Issuer: testServerIssuer}},
 	}
 	suite.mockEntityProvider.On("GetActorGroups", mock.Anything).
 		Return([]providers.EntityGroup{}, nil).Maybe()
@@ -151,7 +157,7 @@ func mockEvaluateAccessBatch(
 func (suite *ClientCredentialsGrantHandlerTestSuite) TestNewClientCredentialsGrantHandler() {
 	handler := newClientCredentialsGrantHandler(
 		suite.mockTokenBuilder, suite.mockOUService, suite.mockAuthzService,
-		suite.mockEntityProvider, suite.mockResourceService)
+		suite.mockEntityProvider, suite.mockResourceService, oauthconfig.Config{})
 	assert.NotNil(suite.T(), handler)
 	assert.Implements(suite.T(), (*GrantHandlerInterface)(nil), handler)
 }
@@ -197,19 +203,19 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_Success() {
 			expectedAudience:  defaultRSIdentifier,
 		},
 		{
-			// No scopes and no resource: not bound to a resource server, so aud is the client_id.
+			// No scopes and no resource: not bound to a resource server, so aud is the server issuer ID.
 			name:              "WithoutScope",
 			scope:             "",
 			expectedJWTClaims: map[string]interface{}{},
 			expectedScopes:    []string{},
-			expectedAudience:  testClientID,
+			expectedAudience:  testServerIssuer,
 		},
 		{
 			name:              "WithWhitespaceScope",
 			scope:             "   ",
 			expectedJWTClaims: map[string]interface{}{},
 			expectedScopes:    []string{},
-			expectedAudience:  testClientID,
+			expectedAudience:  testServerIssuer,
 		},
 	}
 
@@ -264,8 +270,8 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_Success() {
 			// The sub claim must be the resource entity ID, not the OAuth client_id.
 			assert.Equal(t, testEntityID, result.AccessToken.Subject)
 			assert.NotEqual(t, result.AccessToken.ClientID, result.AccessToken.Subject)
-			// The token is bound to a single audience: the target resource server, or the client_id
-			// when there are no scopes to bind to a resource server.
+			// The token is bound to a single audience: the target resource server, or the server
+			// issuer ID when there are no scopes to bind to a resource server.
 			assert.Equal(t, []string{tc.expectedAudience}, result.AccessToken.Audiences)
 
 			suite.mockTokenBuilder.AssertExpectations(t)
@@ -274,7 +280,7 @@ func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_Success() {
 }
 
 // A scopeless request (not bound to a resource server) uses the app's configured default audience
-// for the aud claim instead of the client_id.
+// for the aud claim instead of the server issuer ID.
 func (suite *ClientCredentialsGrantHandlerTestSuite) TestHandleGrant_ScopelessUsesConfiguredDefaultAudience() {
 	suite.mockJWTService.Mock = mock.Mock{}
 	suite.oauthApp.Token = &providers.OAuthTokenConfig{

--- a/backend/internal/oauth/oauth2/granthandlers/jwt_bearer.go
+++ b/backend/internal/oauth/oauth2/granthandlers/jwt_bearer.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"slices"
 
+	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/dpop"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/model"
@@ -24,6 +25,7 @@ type jwtBearerGrantHandler struct {
 	tokenBuilder    tokenservice.TokenBuilderInterface
 	tokenValidator  tokenservice.TokenValidatorInterface
 	resourceService providers.ResourceServerProvider
+	cfg             oauthconfig.Config
 }
 
 // newJWTBearerGrantHandler creates a new instance of jwtBearerGrantHandler.
@@ -31,11 +33,13 @@ func newJWTBearerGrantHandler(
 	tokenBuilder tokenservice.TokenBuilderInterface,
 	tokenValidator tokenservice.TokenValidatorInterface,
 	resourceService providers.ResourceServerProvider,
+	cfg oauthconfig.Config,
 ) GrantHandlerInterface {
 	return &jwtBearerGrantHandler{
 		tokenBuilder:    tokenBuilder,
 		tokenValidator:  tokenValidator,
 		resourceService: resourceService,
+		cfg:             cfg,
 	}
 }
 
@@ -148,9 +152,9 @@ func (h *jwtBearerGrantHandler) HandleGrant(ctx context.Context, tokenRequest *m
 	var audiences []string
 	if targetRS == nil {
 		// OIDC-only assertion with no resource: the token is not bound to a resource server, so its
-		// audience is the app's configured default audiences (falling back to the client_id) and it
-		// carries only the OIDC scopes.
-		audiences = []string{oauthApp.ResolveDefaultAudience(tokenRequest.ClientID)}
+		// audience is the app's configured default audiences (falling back to the server issuer ID)
+		// and it carries only the OIDC scopes.
+		audiences = []string{oauthApp.ResolveDefaultAudience(h.cfg.JWT.Issuer)}
 		grantedScopes = oidcScopes
 	} else {
 		permissionScopes, errResp = resourceindicators.DownscopeToResourceServer(

--- a/backend/internal/oauth/oauth2/granthandlers/jwt_bearer_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/jwt_bearer_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
+	oauthconfig "github.com/thunder-id/thunderid/internal/oauth/config"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/constants"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/dpop"
 	"github.com/thunder-id/thunderid/internal/oauth/oauth2/model"
@@ -80,7 +81,7 @@ func (suite *JWTBearerGrantHandlerTestSuite) SetupTest() {
 
 func (suite *JWTBearerGrantHandlerTestSuite) TestNewJWTBearerGrantHandler() {
 	handler := newJWTBearerGrantHandler(suite.mockTokenBuilder, suite.mockTokenValidator,
-		suite.mockResourceService)
+		suite.mockResourceService, oauthconfig.Config{})
 	assert.NotNil(suite.T(), handler)
 	assert.Implements(suite.T(), (*GrantHandlerInterface)(nil), handler)
 }

--- a/backend/internal/oauth/oauth2/granthandlers/provider.go
+++ b/backend/internal/oauth/oauth2/granthandlers/provider.go
@@ -52,11 +52,11 @@ func newGrantHandlerProvider(
 	grantProvider := &GrantHandlerProvider{}
 	if isGrantTypeAllowed(allowedGrantTypes, providers.GrantTypeClientCredentials) {
 		grantProvider.clientCredentialsGrantHandler = newClientCredentialsGrantHandler(
-			tokenBuilder, ouService, rbacAuthzService, actorProvider, resourceService)
+			tokenBuilder, ouService, rbacAuthzService, actorProvider, resourceService, cfg)
 	}
 	if isGrantTypeAllowed(allowedGrantTypes, providers.GrantTypeAuthorizationCode) {
 		grantProvider.authorizationCodeGrantHandler = newAuthorizationCodeGrantHandler(
-			authzService, tokenBuilder, attrCacheService, resourceService)
+			authzService, tokenBuilder, attrCacheService, resourceService, cfg)
 	}
 	if isGrantTypeAllowed(allowedGrantTypes, providers.GrantTypeRefreshToken) {
 		grantProvider.refreshTokenGrantHandler = newRefreshTokenGrantHandler(
@@ -69,11 +69,11 @@ func newGrantHandlerProvider(
 	}
 	if isGrantTypeAllowed(allowedGrantTypes, providers.GrantTypeCIBA) {
 		grantProvider.cibaGrantHandler = newCIBAGrantHandler(cibaService, tokenBuilder, attrCacheService,
-			resourceService)
+			resourceService, cfg)
 	}
 	if isGrantTypeAllowed(allowedGrantTypes, providers.GrantTypeJWTBearer) {
 		grantProvider.jwtBearerGrantHandler = newJWTBearerGrantHandler(
-			tokenBuilder, tokenValidator, resourceService)
+			tokenBuilder, tokenValidator, resourceService, cfg)
 	}
 	return grantProvider
 }

--- a/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
+++ b/backend/internal/oauth/oauth2/granthandlers/refresh_token.go
@@ -187,9 +187,10 @@ func (h *refreshTokenGrantHandler) HandleGrant(ctx context.Context, tokenRequest
 
 	oidcScopes, nonOidcScopes := oauth2utils.SeparateOIDCAndNonOIDCScopes(
 		strings.Join(newTokenScopes, " "), oauthApp.ScopeClaims)
-	if audience == tokenRequest.ClientID {
+	if audience == h.cfg.JWT.Issuer {
 		// The original token was not bound to a resource server (OIDC-only): its audience is the
-		// client_id, which is not a resource server, so there are no permissions to downscope against.
+		// server issuer ID, which is not a resource server, so there are no permissions to downscope
+		// against.
 		newTokenScopes = oidcScopes
 	} else {
 		// Resolve the bound resource server to downscope scopes to its currently defined permissions.

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange.go
@@ -256,7 +256,7 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 	// Bind the token to a single target resource server (RFC 8707 resource or configured default).
 	// The RFC 8693 audience parameter is not honored. A request that resolves no permission scopes
 	// and carries no resource is not bound to a resource server: its audience is the app's configured
-	// default audiences, falling back to the client_id.
+	// default audiences, falling back to the server issuer ID.
 	targetRS, resErr := resourceindicators.ResolveAudienceBinding(
 		ctx, h.resourceService, tokenRequest.Resources, permissionScopes)
 	if resErr != nil {
@@ -265,7 +265,7 @@ func (h *tokenExchangeGrantHandler) HandleGrant(ctx context.Context, tokenReques
 
 	var finalAudiences []string
 	if targetRS == nil {
-		finalAudiences = []string{oauthApp.ResolveDefaultAudience(tokenRequest.ClientID)}
+		finalAudiences = []string{oauthApp.ResolveDefaultAudience(h.cfg.JWT.Issuer)}
 		finalScopes = oidcScopes
 	} else {
 		permissionScopes, resErr = resourceindicators.DownscopeToResourceServer(

--- a/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
+++ b/backend/internal/oauth/oauth2/granthandlers/token_exchange_test.go
@@ -98,6 +98,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) SetupTest() {
 		tokenBuilder:    suite.mockTokenBuilder,
 		tokenValidator:  suite.mockTokenValidator,
 		resourceService: suite.mockResourceService,
+		cfg:             oauthconfig.Config{JWT: engineconfig.JWTConfig{Issuer: testIDJAGServerIssuer}},
 	}
 
 	suite.oauthApp = &providers.OAuthClient{
@@ -709,7 +710,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_WithAct
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
 		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
 			return ctx.Subject == testUserID &&
-				len(ctx.Audiences) == 1 && ctx.Audiences[0] == testClientID &&
+				len(ctx.Audiences) == 1 && ctx.Audiences[0] == testIDJAGServerIssuer &&
 				ctx.ActorClaims != nil &&
 				ctx.ActorClaims.Sub == "service456" &&
 				ctx.ActorClaims.Iss == testCustomIssuer
@@ -894,7 +895,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_Success_Preserv
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
 		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
 			return ctx.Subject == testUserID &&
-				len(ctx.Audiences) == 1 && ctx.Audiences[0] == testClientID &&
+				len(ctx.Audiences) == 1 && ctx.Audiences[0] == testIDJAGServerIssuer &&
 				ctx.SubjectAttributes["email"] == "user@example.com" &&
 				ctx.SubjectAttributes["name"] == "Test User"
 		})).Return(&model.TokenDTO{
@@ -3544,9 +3545,9 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_IDJAG_ScopesPas
 	assert.Equal(suite.T(), []string{"read", "delete"}, result.AccessToken.Scopes)
 }
 
-func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_OIDCOnly_NoResource_AudIsClientID() {
+func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_OIDCOnly_NoResource_AudIsServerIssuer() {
 	// Only OIDC scopes and no resource: the exchanged token is not bound to a resource server, so
-	// its audience is the client_id and it carries the OIDC scopes.
+	// its audience is the server issuer ID and it carries the OIDC scopes.
 	now := time.Now().Unix()
 	subjectToken := suite.createTestJWT(map[string]interface{}{
 		"sub": testUserID,
@@ -3565,7 +3566,7 @@ func (suite *TokenExchangeGrantHandlerTestSuite) TestHandleGrant_OIDCOnly_NoReso
 		}, nil)
 	suite.mockTokenBuilder.On("BuildAccessToken", mock.Anything,
 		mock.MatchedBy(func(ctx *tokenservice.AccessTokenBuildContext) bool {
-			return len(ctx.Audiences) == 1 && ctx.Audiences[0] == testClientID &&
+			return len(ctx.Audiences) == 1 && ctx.Audiences[0] == testIDJAGServerIssuer &&
 				tokenservice.JoinScopes(ctx.Scopes) == "openid"
 		})).Return(&model.TokenDTO{Token: testTokenExchangeJWT, IssuedAt: now, ExpiresIn: 7200}, nil)
 

--- a/backend/internal/oauth/oauth2/userinfo/error_constants.go
+++ b/backend/internal/oauth/oauth2/userinfo/error_constants.go
@@ -38,6 +38,22 @@ var (
 		},
 	}
 
+	// errorAudienceNotAccepted is returned when the access token's audience does not match the
+	// client's own default audience, i.e. the token was minted for a different resource server via
+	// the 'resource' parameter and must not be redeemable at the UserInfo endpoint.
+	errorAudienceNotAccepted = tidcommon.ServiceError{
+		Type: tidcommon.ClientErrorType,
+		Code: "invalid_token",
+		Error: tidcommon.I18nMessage{
+			Key:          "error.userinfoservice.audience_not_accepted",
+			DefaultValue: "Invalid access token",
+		},
+		ErrorDescription: tidcommon.I18nMessage{
+			Key:          "error.userinfoservice.audience_not_accepted_description",
+			DefaultValue: "The access token audience is not accepted by the UserInfo endpoint",
+		},
+	}
+
 	// errorClientCredentialsNotSupported is returned when the access token was issued using client_credentials grant
 	errorClientCredentialsNotSupported = tidcommon.ServiceError{
 		Type: tidcommon.ClientErrorType,

--- a/backend/internal/oauth/oauth2/userinfo/service.go
+++ b/backend/internal/oauth/oauth2/userinfo/service.go
@@ -165,6 +165,10 @@ func (s *userInfoService) buildResponseFromClaims(
 
 	oauthApp := s.getOAuthApp(ctx, tokenClaims)
 
+	if svcErr := s.validateAudience(ctx, accessTokenClaims, oauthApp); svcErr != nil {
+		return nil, svcErr
+	}
+
 	// Extract allowed user attributes
 	var allowedUserAttributes []string
 	if oauthApp != nil && oauthApp.UserInfo != nil {
@@ -404,6 +408,22 @@ func (s *userInfoService) validateGrantType(
 		return &errorClientCredentialsNotSupported
 	}
 
+	return nil
+}
+
+// validateAudience validates that the access token's audience is the client's own default
+// audience (its configured DefaultAudience, or the server issuer ID when unset). A token whose
+// audience was bound to an external resource server via the 'resource' parameter is scoped to
+// that resource server and must not be redeemable at the UserInfo endpoint.
+func (s *userInfoService) validateAudience(
+	ctx context.Context, accessTokenClaims *tokenservice.AccessTokenClaims, oauthApp *providers.OAuthClient,
+) *tidcommon.ServiceError {
+	expectedAud := oauthApp.ResolveDefaultAudience(s.cfg.JWT.Issuer)
+	if !slices.Contains(accessTokenClaims.Aud, expectedAud) {
+		s.logger.Debug(ctx, "UserInfo request token audience does not match the client's default audience",
+			log.String("client_id", accessTokenClaims.ClientID))
+		return &errorAudienceNotAccepted
+	}
 	return nil
 }
 

--- a/backend/internal/oauth/oauth2/userinfo/service_test.go
+++ b/backend/internal/oauth/oauth2/userinfo/service_test.go
@@ -178,6 +178,21 @@ func (s *UserInfoServiceTestSuite) createToken(claims map[string]interface{}) st
 	return signingInput + "." + signatureEncoded
 }
 
+// newAccessTokenClaims builds an AccessTokenClaims value mirroring what the production
+// tokenValidator.ValidateAccessToken extracts from a token's claims (ClientID and a
+// single-value Aud defaulting to the server issuer ID), so mocked ValidateAccessToken calls stay
+// consistent with what userInfoService.validateAudience expects. Tests exercising an
+// audience mismatch construct AccessTokenClaims directly instead of using this helper.
+func newAccessTokenClaims(sub string, claims map[string]interface{}) *tokenservice.AccessTokenClaims {
+	clientID, _ := claims["client_id"].(string)
+	return &tokenservice.AccessTokenClaims{
+		Sub:      sub,
+		Claims:   claims,
+		ClientID: clientID,
+		Aud:      []string{testUserInfoIssuer},
+	}
+}
+
 // TestGetUserInfo_InvalidTokenFormat tests that invalid token format returns an error
 func (s *UserInfoServiceTestSuite) TestGetUserInfo_InvalidTokenFormat() {
 	// nolint:gosec // This is a test token, not a real credential
@@ -202,7 +217,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_NoScopes() {
 	token := s.createToken(claims)
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
 	assert.NotNil(s.T(), svcErr)
@@ -218,7 +233,7 @@ func (s *UserInfoServiceTestSuite) assertInsufficientScope(
 	token := s.createToken(claims)
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
 	assert.NotNil(s.T(), svcErr)
@@ -254,7 +269,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_ErrorFetchingUserAttributes()
 	token := s.createToken(claims)
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-err-123").Return(
 		nil, &tidcommon.InternalServerError)
 
@@ -284,7 +299,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_ErrorFetchingGroups() {
 		},
 	}
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-groups-123").Return(
 		nil, &tidcommon.InternalServerError)
 	s.mockInboundClient.On("GetOAuthClientByClientID", mock.Anything, "client123").Return(oauthApp, nil)
@@ -332,7 +347,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_StandardScopes() {
 	}
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-std-123").Return(
 		&attributecache.AttributeCache{ID: "cache-std-123", Attributes: userAttrs}, nil)
 	s.mockInboundClient.On("GetOAuthClientByClientID", mock.Anything, "client123").Return(oauthApp, nil)
@@ -381,7 +396,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_WithGroups() {
 	}
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-grp-123").Return(
 		&attributecache.AttributeCache{ID: "cache-grp-123", Attributes: userAttrs}, nil)
 	s.mockInboundClient.On("GetOAuthClientByClientID", mock.Anything, "client123").Return(oauthApp, nil)
@@ -437,7 +452,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_WithScopeClaimsMappin
 	}
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-scope-123").Return(
 		&attributecache.AttributeCache{ID: "cache-scope-123", Attributes: userAttrs}, nil)
 	s.mockInboundClient.On("GetOAuthClientByClientID", mock.Anything, "client123").Return(oauthApp, nil)
@@ -473,7 +488,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_NoAppConfig() {
 	}
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-noapp-123").Return(
 		&attributecache.AttributeCache{ID: "cache-noapp-123", Attributes: userAttrs}, nil)
 
@@ -517,7 +532,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_RawJWTPassthrough() {
 	}
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-rawjwt-123").Return(
 		&attributecache.AttributeCache{ID: "cache-rawjwt-123", Attributes: userAttrs}, nil)
 	s.mockInboundClient.On("GetOAuthClientByClientID", mock.Anything, "client123").Return(oauthApp, nil)
@@ -552,7 +567,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_MalformedClaimsRequest_Return
 	}
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-badclaims-123").Return(
 		&attributecache.AttributeCache{ID: "cache-badclaims-123", Attributes: userAttrs}, nil)
 
@@ -580,7 +595,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_AppNotFound_ReturnsInvalidTok
 	userAttrs := map[string]interface{}{}
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-anf-123").Return(
 		&attributecache.AttributeCache{ID: "cache-anf-123", Attributes: userAttrs}, nil)
 	s.mockInboundClient.On("GetOAuthClientByClientID", mock.Anything, "client123").
@@ -631,7 +646,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_GroupsNotInAllowedAtt
 	}
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-gnaa-123").Return(
 		&attributecache.AttributeCache{ID: "cache-gnaa-123", Attributes: userAttrs}, nil)
 	s.mockInboundClient.On("GetOAuthClientByClientID", mock.Anything, "client123").Return(oauthApp, nil)
@@ -673,7 +688,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_Success_EmptyUserAttributes()
 	}
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 	s.mockInboundClient.On("GetOAuthClientByClientID", mock.Anything, "client123").Return(oauthApp, nil)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
@@ -711,7 +726,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_ScopeExistsButNotString() {
 	token := s.createToken(claims)
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
 	assert.NotNil(s.T(), svcErr)
@@ -737,7 +752,7 @@ func (s *UserInfoServiceTestSuite) testGetUserInfoInvalidClientID(clientIDValue 
 	}
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-inv-cid-123").Return(
 		&attributecache.AttributeCache{ID: "cache-inv-cid-123", Attributes: userAttrs}, nil)
 
@@ -780,7 +795,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_GroupsWithNilOAuthApp() {
 	}
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-nil-app-123").Return(
 		&attributecache.AttributeCache{ID: "cache-nil-app-123", Attributes: userAttrs}, nil)
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
@@ -815,7 +830,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_GroupsWithNilToken() {
 	}
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-nil-tok-123").Return(
 		&attributecache.AttributeCache{ID: "cache-nil-tok-123", Attributes: userAttrs}, nil)
 	s.mockInboundClient.On("GetOAuthClientByClientID", mock.Anything, "client123").Return(oauthApp, nil)
@@ -856,7 +871,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_GroupsWithNilIDToken() {
 	}
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-nil-idt-123").Return(
 		&attributecache.AttributeCache{ID: "cache-nil-idt-123", Attributes: userAttrs}, nil)
 	s.mockInboundClient.On("GetOAuthClientByClientID", mock.Anything, "client123").Return(oauthApp, nil)
@@ -905,7 +920,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_GroupsWithEmptyGroups() {
 	}
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-eg-123").Return(
 		&attributecache.AttributeCache{ID: "cache-eg-123", Attributes: userAttrs}, nil)
 	s.mockInboundClient.On("GetOAuthClientByClientID", mock.Anything, "client123").Return(oauthApp, nil)
@@ -937,7 +952,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_ClientCredentialsGrant_Reject
 	token := s.createToken(claims)
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "client123", Claims: claims}, nil)
+		newAccessTokenClaims("client123", claims), nil)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
 	assert.NotNil(s.T(), svcErr)
@@ -946,6 +961,43 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_ClientCredentialsGrant_Reject
 		svcErr.ErrorDescription.DefaultValue)
 	assert.Nil(s.T(), response)
 	s.mockTokenValidator.AssertExpectations(s.T())
+}
+
+// TestGetUserInfo_ResourceServerAudience_Rejected verifies that an access token minted with its
+// audience bound to an external resource server (via the 'resource' parameter, see
+// resourceindicators.ResolveAudienceBinding) is rejected at the UserInfo endpoint even though it
+// carries the 'openid' scope and a supported grant type. Such a token is scoped to that resource
+// server, not to this authorization server's UserInfo endpoint.
+func (s *UserInfoServiceTestSuite) TestGetUserInfo_ResourceServerAudience_Rejected() {
+	claims := map[string]interface{}{
+		"exp":        float64(time.Now().Add(time.Hour).Unix()),
+		"nbf":        float64(time.Now().Add(-time.Minute).Unix()),
+		"sub":        "user123",
+		"scope":      "openid profile",
+		"grant_type": "authorization_code",
+		"client_id":  "client123",
+		"aud":        "https://api.example.com/payments",
+	}
+	token := s.createToken(claims)
+
+	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
+		&tokenservice.AccessTokenClaims{
+			Sub:      "user123",
+			Claims:   claims,
+			ClientID: "client123",
+			Aud:      []string{"https://api.example.com/payments"},
+		}, nil)
+	s.mockInboundClient.On("GetOAuthClientByClientID", mock.Anything, "client123").Return(
+		&providers.OAuthClient{}, nil)
+
+	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
+	assert.NotNil(s.T(), svcErr)
+	assert.Equal(s.T(), errorAudienceNotAccepted.Code, svcErr.Code)
+	assert.Equal(s.T(), errorAudienceNotAccepted.ErrorDescription.DefaultValue,
+		svcErr.ErrorDescription.DefaultValue)
+	assert.Nil(s.T(), response)
+	s.mockTokenValidator.AssertExpectations(s.T())
+	s.mockInboundClient.AssertExpectations(s.T())
 }
 
 // testGetUserInfoAllowedGrantType is a helper function for testing allowed grant types
@@ -983,7 +1035,7 @@ func (s *UserInfoServiceTestSuite) testGetUserInfoAllowedGrantType(grantTypeValu
 	}
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-agt-123").Return(
 		&attributecache.AttributeCache{ID: "cache-agt-123", Attributes: userAttrs}, nil)
 	s.mockInboundClient.On("GetOAuthClientByClientID", mock.Anything, "client123").Return(oauthApp, nil)
@@ -1037,7 +1089,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_MissingOpenIDScope_WithOtherS
 	token := s.createToken(claims)
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
 	assert.NotNil(s.T(), svcErr)
@@ -1071,7 +1123,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_OnlyOpenIDScope_Success() {
 	token := s.createToken(claims)
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-oid-only-123").Return(
 		&attributecache.AttributeCache{ID: "cache-oid-only-123", Attributes: map[string]interface{}{}}, nil)
 
@@ -1115,7 +1167,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_OpenIDScope_InMiddleOfScopeSt
 	}
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-mid-123").Return(
 		&attributecache.AttributeCache{ID: "cache-mid-123", Attributes: userAttrs}, nil)
 	s.mockInboundClient.On("GetOAuthClientByClientID", mock.Anything, "client123").Return(oauthApp, nil)
@@ -1160,7 +1212,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_OpenIDScope_AtEnd() {
 	}
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-end-123").Return(
 		&attributecache.AttributeCache{ID: "cache-end-123", Attributes: userAttrs}, nil)
 	s.mockInboundClient.On("GetOAuthClientByClientID", mock.Anything, "client123").Return(oauthApp, nil)
@@ -1208,7 +1260,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_JWS_ResponseType() {
 
 	// JWT verification
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 
 	// Attribute cache fetch
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-jws-123").Return(
@@ -1255,7 +1307,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_BearerScheme_DPoPBoundToken_R
 	token := s.createToken(claims)
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 
 	response, svcErr := s.userInfoService.GetUserInfo(context.Background(), token)
 	assert.NotNil(s.T(), svcErr)
@@ -1281,7 +1333,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfoForDPoP_NotBoundToken_Rejected
 	token := s.createToken(claims)
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 
 	response, svcErr := s.userInfoService.GetUserInfoForDPoP(
 		context.Background(), token, "proof", "GET", "https://example.com/oauth2/userinfo")
@@ -1308,7 +1360,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfoForDPoP_VerifierFails_Rejected
 	token := s.createToken(claims)
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 	verifier.EXPECT().Verify(mock.Anything, mock.MatchedBy(func(p dpop.VerifyParams) bool {
 		return p.Proof == "proof" && p.HTM == "GET" && p.AccessToken == token &&
 			p.ExpectedJkt == "thumbprint-abc" &&
@@ -1351,7 +1403,7 @@ func (s *UserInfoServiceTestSuite) TestGetUserInfo_JWS_GenerateJWTFailure() {
 	issuer := "test-issuer"
 
 	s.mockTokenValidator.On("ValidateAccessToken", mock.Anything, token).Return(
-		&tokenservice.AccessTokenClaims{Sub: "user123", Claims: claims}, nil)
+		newAccessTokenClaims("user123", claims), nil)
 
 	s.mockAttributeCacheService.On("GetAttributeCache", mock.Anything, "cache-jws-fail-123").Return(
 		&attributecache.AttributeCache{ID: "cache-jws-fail-123", Attributes: userAttrs}, nil)

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -1029,6 +1029,8 @@ var defaultMessages = map[string]string{
 	"error.themeservice.invalid_limit_value_description": "Limit must be between 1 and {{param(max)}}",
 	"error.unauthorized": "Unauthorized",
 	"error.unauthorized_description": "The caller is not authorized to perform this operation",
+	"error.userinfoservice.audience_not_accepted": "Invalid access token",
+	"error.userinfoservice.audience_not_accepted_description": "The access token audience is not accepted by the UserInfo endpoint",
 	"error.userinfoservice.client_credentials_not_supported": "Invalid access token",
 	"error.userinfoservice.client_credentials_not_supported_description": "UserInfo endpoint is not applicable for client_credentials grant type",
 	"error.userinfoservice.dpop_bound_token_bearer_scheme": "Invalid access token",

--- a/backend/pkg/thunderidengine/providers/oauth_client.go
+++ b/backend/pkg/thunderidengine/providers/oauth_client.go
@@ -94,13 +94,13 @@ func (o *OAuthClient) ClientAccessTokenConfig() *AccessTokenSubConfig {
 
 // ResolveDefaultAudience returns the aud claim for an access token that is not bound to a
 // resource server (an OIDC-only or scopeless request). It returns the application's configured
-// default audience when set; otherwise it falls back to the given client_id.
-func (o *OAuthClient) ResolveDefaultAudience(clientID string) string {
+// default audience when set; otherwise it falls back to the given server issuer ID.
+func (o *OAuthClient) ResolveDefaultAudience(issuer string) string {
 	if o != nil && o.Token != nil && o.Token.AccessToken != nil &&
 		o.Token.AccessToken.DefaultAudience != "" {
 		return o.Token.AccessToken.DefaultAudience
 	}
-	return clientID
+	return issuer
 }
 
 // ValidateRedirectURI validates the provided redirect URI against the registered list.

--- a/backend/pkg/thunderidengine/providers/oauth_client_test.go
+++ b/backend/pkg/thunderidengine/providers/oauth_client_test.go
@@ -115,14 +115,15 @@ func (suite *OAuthClientTestSuite) TestOAuthClient_ResolveDefaultAudience() {
 		client := &OAuthClient{Token: &OAuthTokenConfig{AccessToken: &AccessTokenConfig{
 			DefaultAudience: "https://api.example.com",
 		}}}
-		assert.Equal(t, "https://api.example.com", client.ResolveDefaultAudience("client-123"))
+		assert.Equal(t, "https://api.example.com", client.ResolveDefaultAudience("https://issuer.example.com"))
 	})
-	suite.T().Run("falls back to client_id when default audience unset", func(t *testing.T) {
+	suite.T().Run("falls back to issuer when default audience unset", func(t *testing.T) {
 		client := &OAuthClient{Token: &OAuthTokenConfig{AccessToken: &AccessTokenConfig{}}}
-		assert.Equal(t, "client-123", client.ResolveDefaultAudience("client-123"))
+		assert.Equal(t, "https://issuer.example.com", client.ResolveDefaultAudience("https://issuer.example.com"))
 	})
-	suite.T().Run("falls back to client_id when token config unset", func(t *testing.T) {
-		assert.Equal(t, "client-123", (&OAuthClient{}).ResolveDefaultAudience("client-123"))
+	suite.T().Run("falls back to issuer when token config unset", func(t *testing.T) {
+		assert.Equal(t,
+			"https://issuer.example.com", (&OAuthClient{}).ResolveDefaultAudience("https://issuer.example.com"))
 	})
 }
 

--- a/tests/integration/oauth/attributecache/attribute_cache_test.go
+++ b/tests/integration/oauth/attributecache/attribute_cache_test.go
@@ -302,8 +302,10 @@ func (ts *AttributeCacheTestSuite) assertUserClaims(claims map[string]interface{
 // after a refresh_token grant, while the access token only references the cache via the aci claim.
 // It is mode-agnostic: the caller runs it with encryption on or off and expects the same result.
 func (ts *AttributeCacheTestSuite) assertRoundTrip() {
+	// No resource indicator is requested so the token's audience is the client's own default
+	// audience, which the UserInfo endpoint accepts.
 	tokens, err := testutils.ObtainAccessTokenWithPassword(clientID, redirectURI, "openid profile email",
-		testUsername, testPassword, false, clientSecret, resourceServerIdentifier)
+		testUsername, testPassword, false, clientSecret)
 	ts.Require().NoError(err, "failed to obtain tokens via authorization_code flow")
 	ts.Require().NotEmpty(tokens.AccessToken, "access token should not be empty")
 	ts.Require().NotEmpty(tokens.IDToken, "id token should not be empty")

--- a/tests/integration/oauth/claims/claims_parameter_test.go
+++ b/tests/integration/oauth/claims/claims_parameter_test.go
@@ -410,10 +410,10 @@ func (ts *ClaimsParameterTestSuite) getTokenWithClaims(
 		return "", "", fmt.Errorf("failed to extract authorization code: %w", err)
 	}
 
-	// Step 7: Exchange code for token
-	tokenResult, err := testutils.RequestTokenWithResource(
+	// Step 7: Exchange code for token. No 'resource' is requested so the token's audience is the
+	// client's own default audience, which the UserInfo endpoint accepts.
+	tokenResult, err := testutils.RequestToken(
 		clientID, clientSecret, code, redirectURI, "authorization_code",
-		claimsTestResource,
 	)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to request token: %w", err)
@@ -537,10 +537,10 @@ func (ts *ClaimsParameterTestSuite) getTokensWithClaims(
 		return "", "", fmt.Errorf("failed to extract authorization code: %w", err)
 	}
 
-	// Step 7: Exchange code for tokens
-	tokenResult, err := testutils.RequestTokenWithResource(
+	// Step 7: Exchange code for tokens. No 'resource' is requested so the token's audience is the
+	// client's own default audience, which the UserInfo endpoint accepts.
+	tokenResult, err := testutils.RequestToken(
 		clientID, clientSecret, code, redirectURI, "authorization_code",
-		claimsTestResource,
 	)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to request token: %w", err)

--- a/tests/integration/oauth/dpop/suite_test.go
+++ b/tests/integration/oauth/dpop/suite_test.go
@@ -262,9 +262,8 @@ func (ts *DPoPTestSuite) obtainAuthorizationCode(
 	params.Set("state", "dpop-test-state")
 	params.Set("code_challenge", challenge)
 	params.Set("code_challenge_method", "S256")
-	// Single-resource-server (RFC 8707) enforcement requires a target RS; the
-	// seeded System RS suffices since these tests don't care which RS binds.
-	params.Set("resource", testutils.SystemResourceIdentifier)
+	// No 'resource' is requested so minted tokens carry the client's own default audience,
+	// which is what the UserInfo endpoint accepts (see OAuthClient.ResolveDefaultAudience).
 	for k, v := range extraAuthzParams {
 		params.Set(k, v)
 	}

--- a/tests/integration/oauth/token/default_resource_server_test.go
+++ b/tests/integration/oauth/token/default_resource_server_test.go
@@ -152,7 +152,7 @@ func (s *DefaultResourceServerTestSuite) TestNoResourceWithPermissionScopeUsesCo
 	s.Equal(defaultRSTestIdentifier, claims.Aud)
 }
 
-func (s *DefaultResourceServerTestSuite) TestNoResourceWithoutDefaultAndNoScopesUsesClientIDAudience() {
+func (s *DefaultResourceServerTestSuite) TestNoResourceWithoutDefaultAndNoScopesUsesIssuerAudience() {
 	s.Require().NoError(testutils.PutDefaultResourceServer(""))
 
 	status, body := s.requestClientCredentials("", "")
@@ -163,7 +163,7 @@ func (s *DefaultResourceServerTestSuite) TestNoResourceWithoutDefaultAndNoScopes
 
 	claims, err := testutils.DecodeJWT(token)
 	s.Require().NoError(err)
-	s.Equal(defaultRSTestClientID, claims.Aud)
+	s.Equal(testutils.TestServerURL, claims.Aud)
 	s.NotContains(body, "scope")
 }
 
@@ -248,7 +248,7 @@ func (s *DefaultResourceServerTestSuite) requestClientCredentialsAs(
 }
 
 // A scopeless request that is not bound to a resource server uses the app's configured default
-// audience for the aud claim instead of the client_id.
+// audience for the aud claim instead of the server issuer ID.
 func (s *DefaultResourceServerTestSuite) TestScopelessWithConfiguredDefaultAudienceUsesIt() {
 	appID := s.createOAuthAppWithDefaultAudience()
 	defer func() { _ = testutils.DeleteApplication(appID) }()

--- a/tests/integration/oauth/userinfo/userinfo_test.go
+++ b/tests/integration/oauth/userinfo/userinfo_test.go
@@ -426,9 +426,10 @@ func (ts *UserInfoTestSuite) getAuthorizationCodeToken(scope string) (string, er
 		return "", fmt.Errorf("failed to extract authorization code: %w", err)
 	}
 
-	// Step 7: Exchange code for token
-	tokenResult, err := testutils.RequestTokenWithResource(clientID, clientSecret, code, redirectURI,
-		"authorization_code", userInfoDefaultResourceServerIdentifier)
+	// Step 7: Exchange code for token. No 'resource' is requested so the access token's audience
+	// defaults to the client's own default audience (see OAuthClient.ResolveDefaultAudience),
+	// which is what the UserInfo endpoint accepts.
+	tokenResult, err := testutils.RequestToken(clientID, clientSecret, code, redirectURI, "authorization_code")
 	if err != nil {
 		return "", fmt.Errorf("failed to request token: %w", err)
 	}
@@ -497,9 +498,10 @@ func (ts *UserInfoTestSuite) getRefreshToken(scope string) (string, error) {
 		return "", fmt.Errorf("failed to extract authorization code: %w", err)
 	}
 
-	// Step 7: Exchange code for token (this should include refresh_token)
-	tokenResult, err := testutils.RequestTokenWithResource(clientID, clientSecret, code, redirectURI,
-		"authorization_code", userInfoDefaultResourceServerIdentifier)
+	// Step 7: Exchange code for token (this should include refresh_token). No 'resource' is
+	// requested so the resulting token's audience is the client's own default audience, which the
+	// UserInfo endpoint accepts.
+	tokenResult, err := testutils.RequestToken(clientID, clientSecret, code, redirectURI, "authorization_code")
 	if err != nil {
 		return "", fmt.Errorf("failed to request token: %w", err)
 	}
@@ -558,13 +560,13 @@ func (ts *UserInfoTestSuite) getTokenExchangeToken(scope string) (string, error)
 		return "", err
 	}
 
-	// Exchange the subject token for a new token
+	// Exchange the subject token for a new token. No 'resource' is requested so the exchanged
+	// token's audience is the client's own default audience, which the UserInfo endpoint accepts.
 	tokenData := url.Values{}
 	tokenData.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
 	tokenData.Set("subject_token", subjectToken)
 	tokenData.Set("subject_token_type", "urn:ietf:params:oauth:token-type:access_token")
 	tokenData.Set("scope", scope)
-	tokenData.Set("resource", userInfoDefaultResourceServerIdentifier)
 
 	req, err := http.NewRequest("POST", testServerURL+"/oauth2/token", bytes.NewBufferString(tokenData.Encode()))
 	if err != nil {
@@ -1003,9 +1005,9 @@ func (ts *UserInfoTestSuite) getAuthorizationCodeTokenWithClient(scope, cID, cSe
 		return "", err
 	}
 
-	// 7. Exchange
-	tokenResult, err := testutils.RequestTokenWithResource(cID, cSecret, code, redirectURI,
-		"authorization_code", userInfoDefaultResourceServerIdentifier)
+	// 7. Exchange. No 'resource' is requested so the token's audience is the client's own default
+	// audience, which the UserInfo endpoint accepts.
+	tokenResult, err := testutils.RequestToken(cID, cSecret, code, redirectURI, "authorization_code")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
### Purpose

The /userinfo endpoint accepts any signed, unexpired ThunderID-issued access token without checking that its aud claim matches the userinfo endpoint / this resource server. A token minted for a completely different resource server can be replayed against /userinfo.


### Approach

validateAudience validates that the access token's audience is the client's own default audience (its configured DefaultAudience, or the client_id when unset). A token whose audience was bound to an external resource server via the 'resource' parameter is scoped to that resource server and must not be redeemable at the UserInfo endpoint.

Note: "client_id" is still considered to support backward compatibility.

### Related Issues
- #5139

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * OAuth tokens without an explicitly targeted resource now use the server issuer as their default audience.
  * Explicit resource targets and configured default audiences continue to take precedence.
  * UserInfo now verifies that access tokens target the client’s accepted audience.

* **Bug Fixes**
  * UserInfo rejects tokens intended for unrelated resource servers with a clear invalid-token error.
  * Refresh-token handling correctly distinguishes issuer-audience tokens from resource-bound tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->