### PR TITLE
Support --version flag for the thunderid CLI

### DIFF
--- a/tools/cli/cmd/thunderid/main.go
+++ b/tools/cli/cmd/thunderid/main.go
@@ -16,8 +16,19 @@ import (
 	"github.com/thunder-id/thunderid/tools/cli/internal/ui"
 )
 
+// version is the CLI version. It is injected at build time via
+// -ldflags "-X main.version=<v>" and keeps the placeholder below for local builds.
+var version = "0.0.0-semantically-released"
+
 func main() {
 	args := os.Args[1:]
+
+	// --version is resolved before command dispatch so it always prints and exits,
+	// rather than falling through to a command or to install and setup.
+	if hasVersionFlag(args) {
+		fmt.Println(versionLine())
+		return
+	}
 
 	// upgrade — stop the running version, install the latest, restart on the same port.
 	if len(args) > 0 && args[0] == "upgrade" {
@@ -66,6 +77,21 @@ func main() {
 	cli.Run(verbose, forceSetup)
 }
 
+// hasVersionFlag reports whether args request the CLI version, in any position.
+func hasVersionFlag(args []string) bool {
+	for _, a := range args {
+		if a == "--version" || a == "-V" {
+			return true
+		}
+	}
+	return false
+}
+
+// versionLine renders the version string printed by --version.
+func versionLine() string {
+	return fmt.Sprintf("%s %s", product.Slug, version)
+}
+
 func printUsage() {
 	fmt.Printf(`Usage: %s [command] [flags]
 
@@ -77,6 +103,7 @@ Commands:
 Flags:
   --verbose, -v        Show detailed output
   --setup              Force re-run setup
+  --version, -V        Show the CLI version
   --help, -h           Show this help message
 `, product.Slug, product.Name)
 }

--- a/tools/cli/cmd/thunderid/main_test.go
+++ b/tools/cli/cmd/thunderid/main_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureStdout runs fn with os.Stdout redirected and returns what it printed.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+
+	original := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = original }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close pipe writer: %v", err)
+	}
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("failed to read captured output: %v", err)
+	}
+
+	return string(out)
+}
+
+func TestVersionLineUsesInjectedVersion(t *testing.T) {
+	original := version
+	t.Cleanup(func() { version = original })
+
+	version = "1.2.3"
+
+	if got, want := versionLine(), "thunderid 1.2.3"; got != want {
+		t.Errorf("versionLine() = %q, want %q", got, want)
+	}
+}
+
+func TestVersionDefaultsToPlaceholder(t *testing.T) {
+	const placeholder = "0.0.0-semantically-released"
+
+	if version != placeholder {
+		t.Errorf("version = %q, want %q when no value is injected at build time", version, placeholder)
+	}
+}
+
+func TestHasVersionFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "no args", args: nil, want: false},
+		{name: "long form", args: []string{"--version"}, want: true},
+		{name: "short form", args: []string{"-V"}, want: true},
+		{name: "after another flag", args: []string{"--verbose", "--version"}, want: true},
+		{name: "after a command", args: []string{"upgrade", "--version"}, want: true},
+		{name: "after a command with argument", args: []string{"try", "react", "-V"}, want: true},
+		{name: "verbose short form is not version", args: []string{"-v"}, want: false},
+		{name: "unrelated flags only", args: []string{"--verbose", "--setup"}, want: false},
+		{name: "command only", args: []string{"upgrade"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasVersionFlag(tt.args); got != tt.want {
+				t.Errorf("hasVersionFlag(%q) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrintUsageListsVersionFlag(t *testing.T) {
+	usage := captureStdout(t, printUsage)
+
+	if !strings.Contains(usage, "--version, -V") {
+		t.Errorf("printUsage() output does not list the --version flag:\n%s", usage)
+	}
+}

--- a/tools/cli/scripts/build.ps1
+++ b/tools/cli/scripts/build.ps1
@@ -16,6 +16,10 @@ $PRODUCT_NAME_LOWERCASE = $PRODUCT_NAME.ToLower()
 $CLI_DIR                = Join-Path $PSScriptRoot ".."
 $DIST_DIR               = Join-Path $CLI_DIR "dist"
 
+# Version reported by `--version`. Supplied by the npx build wrapper from
+# package.json; falls back to the unreleased placeholder for direct local builds.
+$VERSION = if ($env:VERSION) { $env:VERSION } else { "0.0.0-semantically-released" }
+
 New-Item -ItemType Directory -Force -Path $DIST_DIR | Out-Null
 
 $TARGETS = @(
@@ -34,7 +38,7 @@ try {
         $env:GOOS        = $t.GOOS
         $env:GOARCH      = $t.GOARCH
         $env:CGO_ENABLED = "0"
-        go build -ldflags="-s -w" -o $outPath "./cmd/${PRODUCT_NAME_LOWERCASE}/"
+        go build -ldflags="-s -w -X main.version=$VERSION" -o $outPath "./cmd/${PRODUCT_NAME_LOWERCASE}/"
     }
 } finally {
     "GOOS", "GOARCH", "CGO_ENABLED" | ForEach-Object { Remove-Item "Env:\$_" -ErrorAction SilentlyContinue }

--- a/tools/cli/scripts/build.sh
+++ b/tools/cli/scripts/build.sh
@@ -13,6 +13,10 @@ set -euo pipefail
 PRODUCT_NAME="ThunderID"
 PRODUCT_NAME_LOWERCASE="$(echo "$PRODUCT_NAME" | tr '[:upper:]' '[:lower:]')"
 
+# Version reported by `--version`. Supplied by the npx build wrapper from
+# package.json; falls back to the unreleased placeholder for direct local builds.
+VERSION="${VERSION:-0.0.0-semantically-released}"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLI_DIR="$SCRIPT_DIR/.."
 DIST_DIR="$CLI_DIR/dist"
@@ -36,7 +40,8 @@ for entry in "${TARGETS[@]}"; do
   OUT_NAME=$(echo "$entry" | awk '{print $3}')
   OUT="$DIST_DIR/$OUT_NAME"
   echo "Building $GOOS/$GOARCH → $OUT_NAME"
-  GOOS="$GOOS" GOARCH="$GOARCH" CGO_ENABLED=0 go build -ldflags="-s -w" -o "$OUT" ./cmd/"${PRODUCT_NAME_LOWERCASE}"/
+  GOOS="$GOOS" GOARCH="$GOARCH" CGO_ENABLED=0 go build \
+    -ldflags="-s -w -X main.version=$VERSION" -o "$OUT" ./cmd/"${PRODUCT_NAME_LOWERCASE}"/
 done
 
 echo "Done. Binaries written to cli/dist/"

--- a/tools/npx/README.md
+++ b/tools/npx/README.md
@@ -28,6 +28,7 @@ the cached installation and start immediately.
 | ----------------- | ---------------------------------------- |
 | `--setup`         | Force re-run setup                       |
 | `--verbose`, `-v` | Show detailed output                     |
+| `--version`, `-V` | Show the CLI version                     |
 | `--help`, `-h`    | Show help                                |
 
 ## Requirements

--- a/tools/npx/scripts/build.js
+++ b/tools/npx/scripts/build.js
@@ -1,22 +1,34 @@
 // Copyright 2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const { version } = require('../package.json');
 
 const cliDir = path.resolve(__dirname, '../../cli');
 const cliDist = path.join(cliDir, 'dist');
 const npxDist = path.resolve(__dirname, '../dist');
 
+// The published package version is what `thunderid --version` reports, so pass it
+// to the build scripts for injection via -ldflags.
+const buildEnv = { ...process.env, VERSION: version };
+
 if (process.platform === 'win32') {
-  execSync(
-    `powershell.exe -ExecutionPolicy Bypass -File "${path.join(cliDir, 'scripts', 'build.ps1')}"`,
-    { stdio: 'inherit' },
+  execFileSync(
+    'powershell.exe',
+    [
+      '-ExecutionPolicy',
+      'Bypass',
+      '-File',
+      path.join(cliDir, 'scripts', 'build.ps1'),
+    ],
+    { stdio: 'inherit', env: buildEnv },
   );
 } else {
-  execSync(`bash "${path.join(cliDir, 'scripts', 'build.sh')}"`, {
+  execFileSync('bash', [path.join(cliDir, 'scripts', 'build.sh')], {
     stdio: 'inherit',
+    env: buildEnv,
   });
 }
 


### PR DESCRIPTION
### Purpose
`npx thunderid` had no way to report its version. There was no `--version` / `-V` flag, the flag was not listed in `--help`, and any unrecognized flag fell through to `cli.Run`, so `npx thunderid --version` started the full install and setup flow instead of printing a version and exiting.

There was also no version embedded in the binary to report, since both build scripts compiled with `-ldflags="-s -w"` only. This makes it hard for users and bug reports to state exactly which build they are running.

```
$ npx thunderid --version
thunderid 1.0.2
```

### Approach
**Flag handling.** `main.go` gets a `--version` / `-V` branch placed next to the existing `--help` handling, short-circuiting before `cli.Run`. It follows the same shape as `--help`: matched on `args[0]`, prints and returns. `--version` is also listed in `printUsage()`. `-V` is used because `-v` is already taken by `--verbose`.

**Version injection.** A package-level `var version = "dev"` in `main.go` is populated at build time via `-ldflags "-X main.version=<v>"`, and stays `dev` for local `go run` and `go build`.

The value is sourced from `tools/npx/package.json`, which is what npm actually publishes. Rather than parsing JSON in both bash and PowerShell, `tools/npx/scripts/build.js` reads it (trivial in Node, and it already orchestrates both scripts) and passes it through the `VERSION` environment variable. `build.sh` and `build.ps1` each default to `dev` when `VERSION` is unset, so running either script directly still works.

No change is needed in `.github/workflows/release-tools.yml` or the `release-npm` action: the action runs `pnpm version` to bump `package.json` before building and publishing, so the published binary picks up the new version automatically.

**Scope.** This reports the CLI version only. The CLI also tracks the active ThunderID server install (`config.ReadActiveVersion`), but that version is already surfaced through the install and upgrade output, so `--version` is kept unambiguous and about the tool itself.

**Verification.** Beyond the unit tests, the full chain was exercised on each build path:

| Command | Output |
|---|---|
| `go build -ldflags "-X main.version=9.9.9"` | `thunderid 9.9.9` |
| `go build` (no ldflags) | `thunderid dev` |
| `VERSION=7.7.7 bash scripts/build.sh` | `thunderid 7.7.7` |
| `build.ps1` with `$env:VERSION=8.8.8` | `thunderid 8.8.8` |
| `node scripts/build.js` (shipped path) | `thunderid 1.0.2`, matching `package.json` |

Note: the issue mentions the npx version as `0.2.0`; it is currently `1.0.2`. Nothing in the approach depends on the specific value.

### Related Issues
- Fixes #4217

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

Unit tests in `tools/cli/cmd/thunderid/main_test.go`: the injected version renders as `thunderid <v>`, `version` defaults to `dev` when nothing is injected, and `printUsage()` lists the new flag.

The flag is self-documenting through `--help`, so no `docs/` page describes the CLI flag set today. Happy to add documentation if maintainers would like it covered.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

---

Note for reviewers: this touches `tools/cli/scripts/build.sh`, `build.ps1`, and `tools/npx/scripts/build.js`, which the issue anticipated in its suggested scope. Happy to adjust the injection point if you would prefer the version come from the release tag instead of `package.json`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--version` and `-V` options to display the CLI product version and exit.
  * Version flags are recognized regardless of their position in the command.
  * Built CLI binaries now include the package version.

* **Documentation**
  * Updated CLI usage help and documentation with the new version options.

* **Bug Fixes**
  * Standardized version embedding across build environments, with a consistent fallback version when unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->