### PR TITLE
 Add OU resolver rendering and handle-based OU resolution to flows

### DIFF
--- a/backend/internal/flow/common/constants.go
+++ b/backend/internal/flow/common/constants.go
@@ -123,6 +123,10 @@ const (
 	// NodePropertyOUResolveFrom specifies the strategy for resolving the organization unit.
 	// Supported values: "caller" (use the caller's OU).
 	NodePropertyOUResolveFrom = "resolveFrom"
+	// NodePropertyOUPromptUseHandle switches the "prompt" strategy's OU selection input from a
+	// literal OU ID (ouId, the default) to a human-readable handle (ouHandle), scoped to the
+	// default OU's children and offered as selectable options.
+	NodePropertyOUPromptUseHandle = "promptUseHandle"
 	// NodePropertyAuthMethodMapping maps authentication classes to action refs on login_options PROMPT nodes.
 	NodePropertyAuthMethodMapping = "authMethodMapping"
 	// NodePropertySkipInterceptors indicates whether to skip interceptor execution for the current node.

--- a/backend/internal/flow/core/prompt_node.go
+++ b/backend/internal/flow/core/prompt_node.go
@@ -759,7 +759,8 @@ func (n *promptNode) buildSyntheticComponentList(
 		if inMeta {
 			needsRequired := input.Required && comp["required"] != true
 			needsPassword := input.Type == providers.InputTypePassword && comp["type"] != providers.InputTypePassword
-			if needsRequired || needsPassword {
+			needsOptions := len(input.Options) > 0
+			if needsRequired || needsPassword || needsOptions {
 				cloned := make(map[string]interface{}, len(comp))
 				for k, v := range comp {
 					cloned[k] = v
@@ -769,6 +770,9 @@ func (n *promptNode) buildSyntheticComponentList(
 				}
 				if needsPassword {
 					cloned["type"] = providers.InputTypePassword
+				}
+				if needsOptions {
+					cloned["options"] = input.Options
 				}
 				promotions[ref] = cloned
 			}

--- a/backend/internal/flow/core/prompt_node_test.go
+++ b/backend/internal/flow/core/prompt_node_test.go
@@ -2549,6 +2549,62 @@ func (s *PromptOnlyNodeTestSuite) TestSyntheticMeta_ExistingComponentPromotedToP
 	s.Equal(true, comp["required"], "existing meta component must reflect promoted required flag")
 }
 
+func (s *PromptOnlyNodeTestSuite) TestSyntheticMeta_ExistingComponentPromotedWithOptions() {
+	meta := map[string]interface{}{
+		"components": []interface{}{
+			map[string]interface{}{
+				"id":       "ou_selection_input",
+				"ref":      "ouHandle",
+				"type":     "SELECT",
+				"label":    "Organization",
+				"required": true,
+			},
+		},
+	}
+	node := newPromptNode("prompt-1", map[string]interface{}{}, false, false)
+	pn := node.(PromptNodeInterface)
+	pn.SetMeta(meta)
+	pn.SetPrompts([]common.Prompt{
+		{
+			Inputs: []providers.Input{{Ref: "ouHandle", Identifier: "ouHandle", Type: "SELECT", Required: true}},
+			Action: &common.Action{Ref: "submit", NextNode: "next"},
+		},
+	})
+
+	ctx := &providers.NodeContext{
+		ExecutionID:   "test-flow",
+		CurrentAction: "submit",
+		UserInputs:    map[string]string{},
+		Verbose:       true,
+		ForwardedData: map[string]interface{}{
+			common.ForwardedDataKeyInputs: []providers.Input{
+				{
+					Identifier: "ouHandle", Type: "SELECT", Required: true,
+					Options: []string{"acme-corp", "beta-inc"},
+				},
+			},
+		},
+	}
+	resp, err := node.Execute(ctx)
+
+	s.Nil(err)
+	s.NotNil(resp)
+	s.NotNil(resp.Meta)
+	s.Require().Len(resp.Inputs, 1)
+	s.Equal([]string{"acme-corp", "beta-inc"}, resp.Inputs[0].Options)
+
+	metaMap, ok := resp.Meta.(map[string]interface{})
+	s.Require().True(ok)
+	comps, ok := metaMap["components"].([]interface{})
+	s.Require().True(ok)
+	s.Require().Len(comps, 1)
+
+	comp, ok := comps[0].(map[string]interface{})
+	s.Require().True(ok)
+	s.Equal([]string{"acme-corp", "beta-inc"}, comp["options"],
+		"existing meta component must be promoted with the options the executor forwarded")
+}
+
 func (s *PromptOnlyNodeTestSuite) TestSyntheticMeta_PromotionDoesNotMutateSharedMeta() {
 	original := map[string]interface{}{
 		"components": []interface{}{

--- a/backend/internal/flow/executor/constants.go
+++ b/backend/internal/flow/executor/constants.go
@@ -74,6 +74,7 @@ const (
 	revocationInputSubject    = "subject"
 
 	ouIDKey        = "ouId"
+	ouHandleKey    = "ouHandle"
 	defaultOUIDKey = "defaultOUID"
 	userTypeKey    = "userType"
 

--- a/backend/internal/flow/executor/ou_resolver_executor.go
+++ b/backend/internal/flow/executor/ou_resolver_executor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/flow/common"
 	"github.com/thunder-id/thunderid/internal/flow/core"
 	"github.com/thunder-id/thunderid/internal/ou"
+	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	"github.com/thunder-id/thunderid/internal/system/log"
 	"github.com/thunder-id/thunderid/internal/system/security"
 )
@@ -58,6 +59,7 @@ func newOUResolverExecutor(
 		&providers.ExecutorMeta{
 			SupportedProperties: []providers.ExecutorSupportedProperties{
 				{Property: common.NodePropertyOUResolveFrom},
+				{Property: common.NodePropertyOUPromptUseHandle},
 			},
 		},
 	)
@@ -146,14 +148,46 @@ func (e *ouResolverExecutor) resolveFromPrompt(ctx *providers.NodeContext,
 		)
 	}
 
-	// If the user already provided an OU selection, validate and accept it.
-	if selectedOUID, ok := ctx.UserInputs[ouIDKey]; ok && selectedOUID != "" {
-		// Validate that the selected OU belongs to the parent OU's subtree.
-		isDescendant, svcErr := e.ouService.IsParent(ctx.Context, parentOUID, selectedOUID)
+	// The user may submit either a literal OU ID (ouId) or a handle scoped to the default OU's
+	// children (ouHandle), but not both — each identifies the same selection unambiguously on its
+	// own, so accepting both at once would leave which one takes precedence undefined.
+	selectedID, hasID := ctx.UserInputs[ouIDKey]
+	hasID = hasID && selectedID != ""
+	selectedHandle, hasHandle := ctx.UserInputs[ouHandleKey]
+	hasHandle = hasHandle && selectedHandle != ""
+
+	if hasID && hasHandle {
+		logger.Debug(ctx.Context, "Both ouId and ouHandle were submitted; exactly one is expected")
+		execResp.Status = providers.ExecUserInputRequired
+		execResp.Inputs = e.promptInputs(ctx)
+		execResp.Error = &ErrInvalidOU
+		return execResp, nil
+	}
+
+	if hasID || hasHandle {
+		resolvedOUID := selectedID
+		if hasHandle {
+			handleOUID, svcErr := e.ouService.GetOrganizationUnitIDByHandle(ctx.Context, selectedHandle, &parentOUID)
+			if svcErr != nil {
+				if svcErr.Type == tidcommon.ClientErrorType {
+					logger.Debug(ctx.Context, "Selected OU handle could not be resolved",
+						log.String(ouHandleKey, selectedHandle))
+					execResp.Status = providers.ExecUserInputRequired
+					execResp.Inputs = e.promptInputs(ctx)
+					execResp.Error = &ErrInvalidOU
+					return execResp, nil
+				}
+				return nil, errors.New("failed to resolve organization unit by handle: " + svcErr.Error.DefaultValue)
+			}
+			resolvedOUID = handleOUID
+		}
+
+		// Validate that the resolved OU belongs to the parent OU's subtree.
+		isDescendant, svcErr := e.ouService.IsParent(ctx.Context, parentOUID, resolvedOUID)
 		if svcErr != nil {
 			if svcErr.Type == tidcommon.ClientErrorType {
 				execResp.Status = providers.ExecUserInputRequired
-				execResp.Inputs = e.GetDefaultInputs()
+				execResp.Inputs = e.promptInputs(ctx)
 				execResp.Error = &ErrInvalidOU
 				return execResp, nil
 			}
@@ -162,22 +196,28 @@ func (e *ouResolverExecutor) resolveFromPrompt(ctx *providers.NodeContext,
 		}
 		if !isDescendant {
 			logger.Debug(ctx.Context, "Selected OU is not a descendant of the parent OU",
-				log.String(ouIDKey, selectedOUID),
+				log.String(ouIDKey, resolvedOUID),
 				log.String("parentOUID", parentOUID))
 			execResp.Status = providers.ExecUserInputRequired
-			execResp.Inputs = e.GetDefaultInputs()
+			execResp.Inputs = e.promptInputs(ctx)
 			execResp.Error = &ErrOUNotValidForUserType
 			return execResp, nil
 		}
 
-		logger.Debug(ctx.Context, "OU selected by user", log.String(ouIDKey, selectedOUID))
-		execResp.RuntimeData[ouIDKey] = selectedOUID
+		logger.Debug(ctx.Context, "OU selected by user", log.String(ouIDKey, resolvedOUID))
+		execResp.RuntimeData[ouIDKey] = resolvedOUID
 		execResp.Status = providers.ExecComplete
 		return execResp, nil
 	}
 
-	// Check if the parent OU has child OUs.
-	children, svcErr := e.ouService.GetOrganizationUnitChildren(ctx.Context, parentOUID, 1, 0, nil)
+	// Check if the parent OU has child OUs. In handle mode every child is fetched so its handle can
+	// be offered as a selectable option; otherwise only the count is needed.
+	useHandle := e.isPromptUseHandle(ctx)
+	childrenLimit := 1
+	if useHandle {
+		childrenLimit = serverconst.MaxPageSize
+	}
+	children, svcErr := e.ouService.GetOrganizationUnitChildren(ctx.Context, parentOUID, childrenLimit, 0, nil)
 	if svcErr != nil {
 		return nil, errors.New("failed to check child organization units: " + svcErr.Error.DefaultValue)
 	}
@@ -195,9 +235,14 @@ func (e *ouResolverExecutor) resolveFromPrompt(ctx *providers.NodeContext,
 
 	execResp.Status = providers.ExecUserInputRequired
 
-	inputs := e.GetDefaultInputs()
+	inputs := e.promptInputs(ctx)
 	if len(inputs) > 0 {
 		input := inputs[0]
+		if useHandle {
+			// Offer each child's handle as a selectable option; a caller that already knows the
+			// target OU's ID may still submit it directly under ouId instead.
+			input.Options = organizationUnitHandles(children.OrganizationUnits)
+		}
 		execResp.Inputs = []providers.Input{input}
 		// Forward the root OU ID so the frontend knows where to start the tree picker.
 		execResp.AdditionalData[common.DataRootOUID] = parentOUID
@@ -205,6 +250,45 @@ func (e *ouResolverExecutor) resolveFromPrompt(ctx *providers.NodeContext,
 	}
 
 	return execResp, nil
+}
+
+// isPromptUseHandle returns the value of the promptUseHandle node property, defaulting to false
+// (offer a literal OU ID) if absent or not a bool.
+func (e *ouResolverExecutor) isPromptUseHandle(ctx *providers.NodeContext) bool {
+	if ctx.NodeProperties == nil {
+		return false
+	}
+	if val, ok := ctx.NodeProperties[common.NodePropertyOUPromptUseHandle]; ok {
+		if boolVal, ok := val.(bool); ok {
+			return boolVal
+		}
+	}
+	return false
+}
+
+// promptInputs returns the "prompt" strategy's OU-selection input. When promptUseHandle is
+// enabled it is keyed by ouHandleKey and typed as a plain SELECT — a flat list of handles with no
+// tree data, the same shape a generic SELECT input already renders, so no dedicated OU_SELECT
+// frontend support is needed. Otherwise it falls back to the default input (ouIDKey, OU_SELECT).
+func (e *ouResolverExecutor) promptInputs(ctx *providers.NodeContext) []providers.Input {
+	defaults := e.GetDefaultInputs()
+	if !e.isPromptUseHandle(ctx) || len(defaults) == 0 {
+		return defaults
+	}
+	input := defaults[0]
+	input.Identifier = ouHandleKey
+	input.Type = providers.InputTypeSelect
+	return []providers.Input{input}
+}
+
+// organizationUnitHandles extracts the handle of each organization unit, in order, for use as a
+// selectable input's options.
+func organizationUnitHandles(units []providers.OrganizationUnitBasic) []string {
+	handles := make([]string, 0, len(units))
+	for _, unit := range units {
+		handles = append(handles, unit.Handle)
+	}
+	return handles
 }
 
 // resolveFromPromptAll shows the full OU tree from root, allowing selection of any OU.

--- a/backend/internal/flow/executor/ou_resolver_executor_test.go
+++ b/backend/internal/flow/executor/ou_resolver_executor_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/thunder-id/thunderid/internal/flow/common"
+	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
 	"github.com/thunder-id/thunderid/internal/system/security"
 	"github.com/thunder-id/thunderid/tests/mocks/flow/coremock"
 	"github.com/thunder-id/thunderid/tests/mocks/oumock"
@@ -276,6 +277,98 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_UserSelectedOU_Vali
 	suite.mockOUService.AssertExpectations(suite.T())
 }
 
+func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_UserSelectedOU_ResolvedByHandle() {
+	parentOUID := testParentOUID
+	selectedHandle := "acme-corp"
+	resolvedOUID := testChildOUID
+
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		NodeProperties: map[string]interface{}{
+			common.NodePropertyOUResolveFrom: ouResolveFromPrompt,
+		},
+		RuntimeData: map[string]string{
+			defaultOUIDKey: parentOUID,
+		},
+		UserInputs: map[string]string{
+			ouHandleKey: selectedHandle,
+		},
+	}
+
+	suite.mockOUService.On("GetOrganizationUnitIDByHandle", mock.Anything, selectedHandle, &parentOUID).
+		Return(resolvedOUID, (*tidcommon.ServiceError)(nil))
+	suite.mockOUService.On("IsParent", mock.Anything, parentOUID, resolvedOUID).
+		Return(true, (*tidcommon.ServiceError)(nil))
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecComplete, result.Status)
+	assert.Equal(suite.T(), resolvedOUID, result.RuntimeData[ouIDKey])
+	suite.mockOUService.AssertExpectations(suite.T())
+}
+
+func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_UserSelectedOU_HandleNotResolved() {
+	parentOUID := testParentOUID
+	selectedHandle := "unknown-handle"
+
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		NodeProperties: map[string]interface{}{
+			common.NodePropertyOUResolveFrom: ouResolveFromPrompt,
+		},
+		RuntimeData: map[string]string{
+			defaultOUIDKey: parentOUID,
+		},
+		UserInputs: map[string]string{
+			ouHandleKey: selectedHandle,
+		},
+	}
+
+	svcErr := &tidcommon.ServiceError{
+		Type:  tidcommon.ClientErrorType,
+		Code:  "OU-40001",
+		Error: tidcommon.I18nMessage{Key: "error.test.not_found", DefaultValue: "not found"},
+	}
+	suite.mockOUService.On("GetOrganizationUnitIDByHandle", mock.Anything, selectedHandle, &parentOUID).
+		Return("", svcErr)
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecUserInputRequired, result.Status)
+	assert.Equal(suite.T(), &ErrInvalidOU, result.Error)
+	assert.NotEmpty(suite.T(), result.Inputs)
+	assert.Equal(suite.T(), ouIDKey, result.Inputs[0].Identifier)
+	suite.mockOUService.AssertNotCalled(suite.T(), "IsParent", mock.Anything, mock.Anything, mock.Anything)
+	suite.mockOUService.AssertExpectations(suite.T())
+}
+
+func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_BothOUIDAndOUHandleSubmitted_Rejected() {
+	parentOUID := testParentOUID
+
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		NodeProperties: map[string]interface{}{
+			common.NodePropertyOUResolveFrom: ouResolveFromPrompt,
+		},
+		RuntimeData: map[string]string{
+			defaultOUIDKey: parentOUID,
+		},
+		UserInputs: map[string]string{
+			ouIDKey:     testChildOUID,
+			ouHandleKey: "acme-corp",
+		},
+	}
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecUserInputRequired, result.Status)
+	assert.Equal(suite.T(), &ErrInvalidOU, result.Error)
+	suite.mockOUService.AssertExpectations(suite.T())
+}
+
 func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_UserSelectedOU_NotInSubtree() {
 	parentOUID := testParentOUID
 	selectedOUID := "unrelated-ou-789"
@@ -420,6 +513,40 @@ func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_HasChildOUs_Request
 	assert.NotEmpty(suite.T(), result.Inputs)
 	assert.Equal(suite.T(), ouIDKey, result.Inputs[0].Identifier)
 	assert.Equal(suite.T(), providers.InputTypeOUSelect, result.Inputs[0].Type)
+	suite.mockOUService.AssertExpectations(suite.T())
+}
+
+func (suite *OUResolverExecutorTestSuite) TestExecute_Prompt_HasChildOUs_UseHandle_RequestsInputWithOptions() {
+	parentOUID := testParentOUID
+
+	ctx := &providers.NodeContext{
+		ExecutionID: "flow-123",
+		NodeProperties: map[string]interface{}{
+			common.NodePropertyOUResolveFrom:     ouResolveFromPrompt,
+			common.NodePropertyOUPromptUseHandle: true,
+		},
+		RuntimeData: map[string]string{
+			defaultOUIDKey: parentOUID,
+		},
+		UserInputs: map[string]string{},
+	}
+
+	children := []providers.OrganizationUnitBasic{
+		{ID: "child-1", Handle: "engineering"},
+		{ID: "child-2", Handle: "sales"},
+	}
+	suite.mockOUService.On("GetOrganizationUnitChildren", mock.Anything, parentOUID, serverconst.MaxPageSize, 0, mock.Anything).
+		Return(&providers.OrganizationUnitListResponse{TotalResults: 2, OrganizationUnits: children}, (*tidcommon.ServiceError)(nil))
+
+	result, err := suite.executor.Execute(ctx)
+
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), providers.ExecUserInputRequired, result.Status)
+	assert.Equal(suite.T(), parentOUID, result.AdditionalData[common.DataRootOUID])
+	assert.NotEmpty(suite.T(), result.Inputs)
+	assert.Equal(suite.T(), ouHandleKey, result.Inputs[0].Identifier)
+	assert.Equal(suite.T(), providers.InputTypeSelect, result.Inputs[0].Type)
+	assert.Equal(suite.T(), []string{"engineering", "sales"}, result.Inputs[0].Options)
 	suite.mockOUService.AssertExpectations(suite.T())
 }
 

--- a/backend/internal/ou/ConfigurableOUService_mock_test.go
+++ b/backend/internal/ou/ConfigurableOUService_mock_test.go
@@ -772,6 +772,80 @@ func (_c *ConfigurableOUServiceMock_GetOrganizationUnitHandlesByIDs_Call) RunAnd
 	return _c
 }
 
+// GetOrganizationUnitIDByHandle provides a mock function for the type ConfigurableOUServiceMock
+func (_mock *ConfigurableOUServiceMock) GetOrganizationUnitIDByHandle(ctx context.Context, handle string, parentID *string) (string, *common.ServiceError) {
+	ret := _mock.Called(ctx, handle, parentID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetOrganizationUnitIDByHandle")
+	}
+
+	var r0 string
+	var r1 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *string) (string, *common.ServiceError)); ok {
+		return returnFunc(ctx, handle, parentID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *string) string); ok {
+		r0 = returnFunc(ctx, handle, parentID)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *string) *common.ServiceError); ok {
+		r1 = returnFunc(ctx, handle, parentID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// ConfigurableOUServiceMock_GetOrganizationUnitIDByHandle_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOrganizationUnitIDByHandle'
+type ConfigurableOUServiceMock_GetOrganizationUnitIDByHandle_Call struct {
+	*mock.Call
+}
+
+// GetOrganizationUnitIDByHandle is a helper method to define mock.On call
+//   - ctx context.Context
+//   - handle string
+//   - parentID *string
+func (_e *ConfigurableOUServiceMock_Expecter) GetOrganizationUnitIDByHandle(ctx interface{}, handle interface{}, parentID interface{}) *ConfigurableOUServiceMock_GetOrganizationUnitIDByHandle_Call {
+	return &ConfigurableOUServiceMock_GetOrganizationUnitIDByHandle_Call{Call: _e.mock.On("GetOrganizationUnitIDByHandle", ctx, handle, parentID)}
+}
+
+func (_c *ConfigurableOUServiceMock_GetOrganizationUnitIDByHandle_Call) Run(run func(ctx context.Context, handle string, parentID *string)) *ConfigurableOUServiceMock_GetOrganizationUnitIDByHandle_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 *string
+		if args[2] != nil {
+			arg2 = args[2].(*string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *ConfigurableOUServiceMock_GetOrganizationUnitIDByHandle_Call) Return(s string, serviceError *common.ServiceError) *ConfigurableOUServiceMock_GetOrganizationUnitIDByHandle_Call {
+	_c.Call.Return(s, serviceError)
+	return _c
+}
+
+func (_c *ConfigurableOUServiceMock_GetOrganizationUnitIDByHandle_Call) RunAndReturn(run func(ctx context.Context, handle string, parentID *string) (string, *common.ServiceError)) *ConfigurableOUServiceMock_GetOrganizationUnitIDByHandle_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetOrganizationUnitList provides a mock function for the type ConfigurableOUServiceMock
 func (_mock *ConfigurableOUServiceMock) GetOrganizationUnitList(ctx context.Context, limit int, offset int, f *common.FilterGroup) (*providers.OrganizationUnitListResponse, *common.ServiceError) {
 	ret := _mock.Called(ctx, limit, offset, f)

--- a/backend/internal/ou/OrganizationUnitServiceInterface_mock_test.go
+++ b/backend/internal/ou/OrganizationUnitServiceInterface_mock_test.go
@@ -771,6 +771,80 @@ func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitHandlesByIDs_C
 	return _c
 }
 
+// GetOrganizationUnitIDByHandle provides a mock function for the type OrganizationUnitServiceInterfaceMock
+func (_mock *OrganizationUnitServiceInterfaceMock) GetOrganizationUnitIDByHandle(ctx context.Context, handle string, parentID *string) (string, *common.ServiceError) {
+	ret := _mock.Called(ctx, handle, parentID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetOrganizationUnitIDByHandle")
+	}
+
+	var r0 string
+	var r1 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *string) (string, *common.ServiceError)); ok {
+		return returnFunc(ctx, handle, parentID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *string) string); ok {
+		r0 = returnFunc(ctx, handle, parentID)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *string) *common.ServiceError); ok {
+		r1 = returnFunc(ctx, handle, parentID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// OrganizationUnitServiceInterfaceMock_GetOrganizationUnitIDByHandle_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOrganizationUnitIDByHandle'
+type OrganizationUnitServiceInterfaceMock_GetOrganizationUnitIDByHandle_Call struct {
+	*mock.Call
+}
+
+// GetOrganizationUnitIDByHandle is a helper method to define mock.On call
+//   - ctx context.Context
+//   - handle string
+//   - parentID *string
+func (_e *OrganizationUnitServiceInterfaceMock_Expecter) GetOrganizationUnitIDByHandle(ctx interface{}, handle interface{}, parentID interface{}) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitIDByHandle_Call {
+	return &OrganizationUnitServiceInterfaceMock_GetOrganizationUnitIDByHandle_Call{Call: _e.mock.On("GetOrganizationUnitIDByHandle", ctx, handle, parentID)}
+}
+
+func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitIDByHandle_Call) Run(run func(ctx context.Context, handle string, parentID *string)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitIDByHandle_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 *string
+		if args[2] != nil {
+			arg2 = args[2].(*string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitIDByHandle_Call) Return(s string, serviceError *common.ServiceError) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitIDByHandle_Call {
+	_c.Call.Return(s, serviceError)
+	return _c
+}
+
+func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitIDByHandle_Call) RunAndReturn(run func(ctx context.Context, handle string, parentID *string) (string, *common.ServiceError)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitIDByHandle_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetOrganizationUnitList provides a mock function for the type OrganizationUnitServiceInterfaceMock
 func (_mock *OrganizationUnitServiceInterfaceMock) GetOrganizationUnitList(ctx context.Context, limit int, offset int, f *common.FilterGroup) (*providers.OrganizationUnitListResponse, *common.ServiceError) {
 	ret := _mock.Called(ctx, limit, offset, f)

--- a/backend/internal/ou/service.go
+++ b/backend/internal/ou/service.go
@@ -40,6 +40,9 @@ type OrganizationUnitServiceInterface interface {
 	IsOrganizationUnitExists(ctx context.Context, id string) (bool, *tidcommon.ServiceError)
 	IsOrganizationUnitDeclarative(ctx context.Context, id string) bool
 	IsParent(ctx context.Context, parentID, childID string) (bool, *tidcommon.ServiceError)
+	GetOrganizationUnitIDByHandle(
+		ctx context.Context, handle string, parentID *string,
+	) (string, *tidcommon.ServiceError)
 	UpdateOrganizationUnit(
 		ctx context.Context, id string, request providers.OrganizationUnitRequestWithID,
 	) (providers.OrganizationUnit, *tidcommon.ServiceError)
@@ -489,6 +492,29 @@ func (ous *organizationUnitService) IsOrganizationUnitExists(
 
 func (ous *organizationUnitService) IsOrganizationUnitDeclarative(ctx context.Context, id string) bool {
 	return ous.ouStore.IsOrganizationUnitDeclarative(ctx, id)
+}
+
+// GetOrganizationUnitIDByHandle resolves an organization unit's ID from its handle, scoped to the
+// given parent (or the root level when parentID is nil). Unlike GetOrganizationUnitByPath, this is
+// an unauthenticated lookup with no access check: it exists so that a self-service caller (e.g. a
+// flow resolving a human-readable org handle during registration) can resolve a handle without
+// already holding read access to the organization unit it names.
+func (ous *organizationUnitService) GetOrganizationUnitIDByHandle(
+	ctx context.Context, handle string, parentID *string,
+) (string, *tidcommon.ServiceError) {
+	logger := log.GetLogger().With(log.String(log.LoggerKeyComponentName, loggerComponentNameService))
+	logger.Debug(ctx, "Resolving organization unit ID by handle", log.String("handle", handle))
+
+	ou, err := ous.ouStore.GetOrganizationUnitByHandle(ctx, handle, parentID)
+	if err != nil {
+		if errors.Is(err, ErrOrganizationUnitNotFound) {
+			return "", &ErrorOrganizationUnitNotFound
+		}
+		logger.Error(ctx, "Failed to resolve organization unit by handle", log.Error(err))
+		return "", &tidcommon.InternalServerError
+	}
+
+	return ou.ID, nil
 }
 
 // IsParent checks whether the provided parentID is an ancestor of childID.

--- a/backend/internal/ou/service_test.go
+++ b/backend/internal/ou/service_test.go
@@ -828,6 +828,78 @@ func (suite *OrganizationUnitServiceTestSuite) TestOUService_IsOrganizationUnitE
 	}
 }
 
+func (suite *OrganizationUnitServiceTestSuite) TestOUService_GetOrganizationUnitIDByHandle() {
+	parentID := "parent-1"
+
+	testCases := []struct {
+		name     string
+		parentID *string
+		setup    func(*organizationUnitStoreInterfaceMock)
+		wantErr  *tidcommon.ServiceError
+		want     string
+	}{
+		{
+			name:     "resolved at root level",
+			parentID: nil,
+			setup: func(store *organizationUnitStoreInterfaceMock) {
+				store.On("GetOrganizationUnitByHandle", mock.Anything, "acme-corp", (*string)(nil)).
+					Return(providers.OrganizationUnit{ID: "ou-1"}, nil).
+					Once()
+			},
+			want: "ou-1",
+		},
+		{
+			name:     "resolved as a child of the given parent",
+			parentID: &parentID,
+			setup: func(store *organizationUnitStoreInterfaceMock) {
+				store.On("GetOrganizationUnitByHandle", mock.Anything, "acme-corp", &parentID).
+					Return(providers.OrganizationUnit{ID: "ou-2"}, nil).
+					Once()
+			},
+			want: "ou-2",
+		},
+		{
+			name:     "not found",
+			parentID: nil,
+			setup: func(store *organizationUnitStoreInterfaceMock) {
+				store.On("GetOrganizationUnitByHandle", mock.Anything, "acme-corp", (*string)(nil)).
+					Return(providers.OrganizationUnit{}, ErrOrganizationUnitNotFound).
+					Once()
+			},
+			wantErr: &ErrorOrganizationUnitNotFound,
+		},
+		{
+			name:     "store error",
+			parentID: nil,
+			setup: func(store *organizationUnitStoreInterfaceMock) {
+				store.On("GetOrganizationUnitByHandle", mock.Anything, "acme-corp", (*string)(nil)).
+					Return(providers.OrganizationUnit{}, errors.New("boom")).
+					Once()
+			},
+			wantErr: &tidcommon.InternalServerError,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			store := newOrganizationUnitStoreInterfaceMock(suite.T())
+			tc.setup(store)
+
+			service := suite.newService(store, newAllowAllAuthz(suite.T()))
+			result, err := service.GetOrganizationUnitIDByHandle(context.Background(), "acme-corp", tc.parentID)
+
+			if tc.wantErr != nil {
+				suite.Require().NotNil(err)
+				suite.Require().Equal(*tc.wantErr, *err)
+			} else {
+				suite.Require().Nil(err)
+				suite.Require().Equal(tc.want, result)
+			}
+		})
+	}
+}
+
 func (suite *OrganizationUnitServiceTestSuite) TestOUService_IsParent() {
 	parentID := "parent-1"
 	childID := "child-1"

--- a/backend/tests/mocks/oumock/OrganizationUnitServiceInterface_mock.go
+++ b/backend/tests/mocks/oumock/OrganizationUnitServiceInterface_mock.go
@@ -772,6 +772,80 @@ func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitHandlesByIDs_C
 	return _c
 }
 
+// GetOrganizationUnitIDByHandle provides a mock function for the type OrganizationUnitServiceInterfaceMock
+func (_mock *OrganizationUnitServiceInterfaceMock) GetOrganizationUnitIDByHandle(ctx context.Context, handle string, parentID *string) (string, *common.ServiceError) {
+	ret := _mock.Called(ctx, handle, parentID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetOrganizationUnitIDByHandle")
+	}
+
+	var r0 string
+	var r1 *common.ServiceError
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *string) (string, *common.ServiceError)); ok {
+		return returnFunc(ctx, handle, parentID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *string) string); ok {
+		r0 = returnFunc(ctx, handle, parentID)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *string) *common.ServiceError); ok {
+		r1 = returnFunc(ctx, handle, parentID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*common.ServiceError)
+		}
+	}
+	return r0, r1
+}
+
+// OrganizationUnitServiceInterfaceMock_GetOrganizationUnitIDByHandle_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOrganizationUnitIDByHandle'
+type OrganizationUnitServiceInterfaceMock_GetOrganizationUnitIDByHandle_Call struct {
+	*mock.Call
+}
+
+// GetOrganizationUnitIDByHandle is a helper method to define mock.On call
+//   - ctx context.Context
+//   - handle string
+//   - parentID *string
+func (_e *OrganizationUnitServiceInterfaceMock_Expecter) GetOrganizationUnitIDByHandle(ctx interface{}, handle interface{}, parentID interface{}) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitIDByHandle_Call {
+	return &OrganizationUnitServiceInterfaceMock_GetOrganizationUnitIDByHandle_Call{Call: _e.mock.On("GetOrganizationUnitIDByHandle", ctx, handle, parentID)}
+}
+
+func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitIDByHandle_Call) Run(run func(ctx context.Context, handle string, parentID *string)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitIDByHandle_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 *string
+		if args[2] != nil {
+			arg2 = args[2].(*string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitIDByHandle_Call) Return(s string, serviceError *common.ServiceError) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitIDByHandle_Call {
+	_c.Call.Return(s, serviceError)
+	return _c
+}
+
+func (_c *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitIDByHandle_Call) RunAndReturn(run func(ctx context.Context, handle string, parentID *string) (string, *common.ServiceError)) *OrganizationUnitServiceInterfaceMock_GetOrganizationUnitIDByHandle_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetOrganizationUnitList provides a mock function for the type OrganizationUnitServiceInterfaceMock
 func (_mock *OrganizationUnitServiceInterfaceMock) GetOrganizationUnitList(ctx context.Context, limit int, offset int, f *common.FilterGroup) (*providers.OrganizationUnitListResponse, *common.ServiceError) {
 	ret := _mock.Called(ctx, limit, offset, f)

--- a/docs/content/guides/flows/advanced-configurations.mdx
+++ b/docs/content/guides/flows/advanced-configurations.mdx
@@ -1447,7 +1447,7 @@ Resolves or selects an organizational unit based on a configured strategy. Overw
 
 | Property | UI Label | Required | Default | Behavior |
 |---|---|---|---|---|
-| `resolveFrom` | Resolve From | Yes | - | Strategy for OU resolution: `caller`, `prompt`, or `promptAll` |
+| `resolveFrom` | Resolve From | Yes | - | Strategy for OU resolution: `caller` or `prompt`. |
 
 **Resolution Strategies:**
 
@@ -1469,20 +1469,17 @@ Resolves or selects an organizational unit based on a configured strategy. Overw
   1. Place **User Type Resolver** before this executor in registration flows
   2. Add a **Blank View** immediately after this executor with an OU selection component
   3. This executor will prompt only if the default OU has child OUs. Otherwise, it completes silently
-- **Failure conditions:** Default OU not found; selected OU is not a child of the default
-
-**`promptAll` strategy:**
-- Shows the full OU tree from root, independent of User Type Resolver
-- **When to use:** Advanced onboarding with full OU tree visibility
-- **Prerequisites:** A Blank View with OU selection component must follow this executor
-- **Setup:**
-  1. No need to run User Type Resolver first (unlike `prompt` strategy)
-  2. Add a **Blank View** immediately after this executor with an OU selection component
-  3. The executor will display the complete OU tree starting from root
-- **Failure conditions:** OU service error
+- **Failure conditions:** Default OU not found; both `ouId` and `ouHandle` submitted at once; selected handle does not match a child OU; selected OU is not a descendant of the default
 
 **Input Configuration:**
-- `ouId` (required): the user's selected organizational unit. Used for `prompt` and `promptAll` strategies. Default: `ouId`
+
+The `prompt` strategy accepts exactly one of the two inputs below, never both:
+- `ouId` (default): a literal OU ID, for a caller that already knows the target OU
+- `ouHandle`: a handle scoped to the default OU's children, offered as selectable dropdown options
+
+Set the node property `promptUseHandle` to `true` to switch the rendered input from `ouId` to
+`ouHandle` and have the executor populate the child OUs' handles as selectable options. Configure
+the OU selection component's own input identifier to match (`ouHandle`).
 
 **Example:**
 

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/__tests__/ExecutionExtendedProperties.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/__tests__/ExecutionExtendedProperties.test.tsx
@@ -1048,6 +1048,44 @@ describe('ExecutionExtendedProperties', () => {
 
       expect(mockOnChange).toHaveBeenCalledWith('data.properties.resolveFrom', 'prompt', ouResolverResource);
     });
+
+    it('should not show the handle-selection toggle for the caller strategy', () => {
+      render(<ExecutionExtendedProperties resource={ouResolverResource} onChange={mockOnChange} />);
+
+      expect(screen.queryByText('flows:core.executions.ouResolver.promptUseHandle.label')).not.toBeInTheDocument();
+    });
+
+    it('should show the handle-selection toggle for the prompt strategy', () => {
+      const promptResource = {
+        ...ouResolverResource,
+        data: {
+          ...(ouResolverResource as unknown as {data: object}).data,
+          properties: {resolveFrom: 'prompt'},
+        },
+      } as unknown as Resource;
+
+      render(<ExecutionExtendedProperties resource={promptResource} onChange={mockOnChange} />);
+
+      expect(screen.getByText('flows:core.executions.ouResolver.promptUseHandle.label')).toBeInTheDocument();
+      expect(screen.getByRole('checkbox')).not.toBeChecked();
+    });
+
+    it('should call onChange when the handle-selection toggle is checked', async () => {
+      const user = userEvent.setup();
+      const promptResource = {
+        ...ouResolverResource,
+        data: {
+          ...(ouResolverResource as unknown as {data: object}).data,
+          properties: {resolveFrom: 'prompt'},
+        },
+      } as unknown as Resource;
+
+      render(<ExecutionExtendedProperties resource={promptResource} onChange={mockOnChange} />);
+
+      await user.click(screen.getByRole('checkbox'));
+
+      expect(mockOnChange).toHaveBeenCalledWith('data.properties.promptUseHandle', true, promptResource);
+    });
   });
 
   describe('Invite Executor', () => {

--- a/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/OUResolverProperties.tsx
+++ b/frontend/apps/console/src/features/flows/components/resource-property-panel/extended-properties/execution-properties/OUResolverProperties.tsx
@@ -1,8 +1,17 @@
 // Copyright 2025 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import {FormLabel, MenuItem, Select, Stack, Typography} from '@wso2/oxygen-ui';
-import {useMemo, type ReactNode} from 'react';
+import {
+  Checkbox,
+  FormControlLabel,
+  FormHelperText,
+  FormLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Typography,
+} from '@wso2/oxygen-ui';
+import {useCallback, useMemo, type ReactNode} from 'react';
 import {useTranslation} from 'react-i18next';
 import {OU_RESOLVE_FROM_OPTIONS} from './constants';
 import type {CommonResourcePropertiesPropsInterface} from './types';
@@ -17,6 +26,13 @@ function OUResolverProperties({resource, onChange}: CommonResourcePropertiesProp
   }, [resource]);
 
   const currentResolveFrom = (properties.resolveFrom as string) || 'caller';
+
+  const handleBooleanPropertyChange = useCallback(
+    (propertyName: string, value: boolean): void => {
+      onChange(`data.properties.${propertyName}`, value, resource);
+    },
+    [resource, onChange],
+  );
 
   return (
     <Stack gap={2}>
@@ -39,6 +55,22 @@ function OUResolverProperties({resource, onChange}: CommonResourcePropertiesProp
           ))}
         </Select>
       </div>
+
+      {currentResolveFrom === 'prompt' && (
+        <div>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={!!properties.promptUseHandle}
+                onChange={(e) => handleBooleanPropertyChange('promptUseHandle', e.target.checked)}
+                size="small"
+              />
+            }
+            label={t('flows:core.executions.ouResolver.promptUseHandle.label')}
+          />
+          <FormHelperText>{t('flows:core.executions.ouResolver.promptUseHandle.hint')}</FormHelperText>
+        </div>
+      )}
     </Stack>
   );
 }

--- a/frontend/apps/console/src/features/flows/components/resources/elements/__tests__/CommonElementFactory.test.tsx
+++ b/frontend/apps/console/src/features/flows/components/resources/elements/__tests__/CommonElementFactory.test.tsx
@@ -55,6 +55,14 @@ vi.mock('../adapters/input/DefaultInputAdapter', () => ({
   ),
 }));
 
+vi.mock('../adapters/input/SelectAdapter', () => ({
+  default: ({resource}: {resource: Element}) => (
+    <div data-testid="select-adapter" data-resource-id={resource.id} data-type={resource.type}>
+      Select Adapter
+    </div>
+  ),
+}));
+
 vi.mock('../adapters/ChoiceAdapter', () => ({
   default: ({resource}: {resource: Element}) => (
     <div data-testid="choice-adapter" data-resource-id={resource.id}>
@@ -318,6 +326,18 @@ describe('CommonElementFactory', () => {
       render(<CommonElementFactory stepId="step-1" resource={dropdownElement} />);
 
       expect(screen.getByTestId('choice-adapter')).toBeInTheDocument();
+    });
+  });
+
+  describe('Select Element', () => {
+    it('should render SelectAdapter for Select type', () => {
+      const selectElement = createMockElement({
+        type: ElementTypes.Select,
+      });
+
+      render(<CommonElementFactory stepId="step-1" resource={selectElement} />);
+
+      expect(screen.getByTestId('select-adapter')).toBeInTheDocument();
     });
   });
 

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -3638,6 +3638,9 @@ const translations = {
     'core.executions.ouResolver.resolveFrom.caller': 'Caller',
     'core.executions.ouResolver.resolveFrom.prompt': 'Prompt',
     'core.executions.ouResolver.resolveFrom.promptAll': 'Prompt All',
+    'core.executions.ouResolver.promptUseHandle.label': 'Use OU handle for selection',
+    'core.executions.ouResolver.promptUseHandle.hint':
+      'Offer child OUs as a dropdown of handles instead of requiring a literal OU ID.',
 
     // Invite executor
     'core.executions.invite.description': 'Configure the invite executor mode.',

--- a/tests/integration/flow/registration/ou_resolver_strategies_test.go
+++ b/tests/integration/flow/registration/ou_resolver_strategies_test.go
@@ -17,9 +17,12 @@ const (
 )
 
 // ouStrategyFlowNodes builds a registration flow that resolves the user type, then the OU with the
-// given strategy, then provisions the user. The strategy is the only thing that varies between the
-// flows this suite creates.
-func ouStrategyFlowNodes(resolveFrom string) []map[string]interface{} {
+// given strategy, then provisions the user. ouInputIdentifier is the OU selection PROMPT node's own
+// declared input identifier — the engine only considers that node's required input satisfied when a
+// submission arrives under this exact key, regardless of what the executor itself would also accept
+// (e.g. the "prompt" strategy resolves either ouId or ouHandle, but a flow whose declared identifier
+// is "ouId" still requires a submission keyed "ouId" to ever reach that resolution logic).
+func ouStrategyFlowNodes(resolveFrom, ouInputIdentifier string) []map[string]interface{} {
 	return []map[string]interface{}{
 		{
 			"id":        "start",
@@ -54,7 +57,7 @@ func ouStrategyFlowNodes(resolveFrom string) []map[string]interface{} {
 					"inputs": []map[string]interface{}{
 						{
 							"ref":        "ou_selection_input",
-							"identifier": "ouId",
+							"identifier": ouInputIdentifier,
 							"type":       "OU_SELECT",
 							"required":   true,
 						},
@@ -153,6 +156,7 @@ type OUResolverStrategiesTestSuite struct {
 
 	promptParentAppID string
 	promptChildAppID  string
+	promptHandleAppID string
 	callerAppID       string
 	unsupportedAppID  string
 
@@ -210,10 +214,16 @@ func (ts *OUResolverStrategiesTestSuite) SetupSuite() {
 	ts.Require().NoError(err, "Failed to create isolated auth flow")
 	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, ts.isolatedAuthFlowID)
 
-	promptFlowID := ts.createFlow("OU Resolver Prompt Flow", "registration_flow_ou_prompt_test", "prompt")
-	callerFlowID := ts.createFlow("OU Resolver Caller Flow", "registration_flow_ou_caller_test", "caller")
+	promptFlowID := ts.createFlow("OU Resolver Prompt Flow", "registration_flow_ou_prompt_test", "prompt", "ouId")
+	// A dedicated flow whose OU selection PROMPT node declares "ouHandle" as its own identifier,
+	// since the engine only accepts a submission for the node's declared identifier — the shared
+	// promptFlowID above always requires "ouId", regardless of the prompt strategy's own dual
+	// ouId/ouHandle support.
+	promptHandleFlowID := ts.createFlow("OU Resolver Prompt Handle Flow",
+		"registration_flow_ou_prompt_handle_test", "prompt", "ouHandle")
+	callerFlowID := ts.createFlow("OU Resolver Caller Flow", "registration_flow_ou_caller_test", "caller", "ouId")
 	unsupportedFlowID := ts.createFlow("OU Resolver Unsupported Flow",
-		"registration_flow_ou_unsupported_test", "notAStrategy")
+		"registration_flow_ou_unsupported_test", "notAStrategy", "ouId")
 
 	// The prompt flow is bound twice: once with a user type whose OU has children, and once with a
 	// user type whose OU has none, which is what decides whether a selection is asked for.
@@ -221,20 +231,22 @@ func (ts *OUResolverStrategiesTestSuite) SetupSuite() {
 		promptFlowID, ts.parentTypeName)
 	ts.promptChildAppID = ts.createApp("OU Strategy Prompt Child App", "ou_strategy_prompt_child_client",
 		promptFlowID, ts.childTypeName)
+	ts.promptHandleAppID = ts.createApp("OU Strategy Prompt Handle App", "ou_strategy_prompt_handle_client",
+		promptHandleFlowID, ts.parentTypeName)
 	ts.callerAppID = ts.createApp("OU Strategy Caller App", "ou_strategy_caller_client",
 		callerFlowID, ts.parentTypeName)
 	ts.unsupportedAppID = ts.createApp("OU Strategy Unsupported App", "ou_strategy_unsupported_client",
 		unsupportedFlowID, ts.parentTypeName)
 }
 
-func (ts *OUResolverStrategiesTestSuite) createFlow(name, handle, resolveFrom string) string {
+func (ts *OUResolverStrategiesTestSuite) createFlow(name, handle, resolveFrom, ouInputIdentifier string) string {
 	ts.T().Helper()
 
 	flowID, err := testutils.CreateFlow(testutils.Flow{
 		Name:     name,
 		FlowType: "REGISTRATION",
 		Handle:   handle,
-		Nodes:    ouStrategyFlowNodes(resolveFrom),
+		Nodes:    ouStrategyFlowNodes(resolveFrom, ouInputIdentifier),
 	})
 	ts.Require().NoError(err, "Failed to create flow %s", handle)
 	ts.config.CreatedFlowIDs = append(ts.config.CreatedFlowIDs, flowID)
@@ -262,7 +274,7 @@ func (ts *OUResolverStrategiesTestSuite) createApp(name, clientID, flowID, userT
 
 func (ts *OUResolverStrategiesTestSuite) TearDownSuite() {
 	for _, appID := range []string{
-		ts.promptParentAppID, ts.promptChildAppID, ts.callerAppID, ts.unsupportedAppID,
+		ts.promptParentAppID, ts.promptChildAppID, ts.promptHandleAppID, ts.callerAppID, ts.unsupportedAppID,
 	} {
 		if appID == "" {
 			continue
@@ -389,4 +401,29 @@ func (ts *OUResolverStrategiesTestSuite) TestUnsupportedStrategy_Fails() {
 	ts.Require().NotNil(step.Error, "An unsupported strategy must be reported")
 	ts.Equal(errCodeOUResolutionFailed, step.Error.Code,
 		"An unsupported strategy must fail OU resolution")
+}
+
+// The prompt strategy resolves a submitted handle scoped to the parent OU whose children were
+// offered, not just a raw ID — the human-readable identifier path #5122 added.
+func (ts *OUResolverStrategiesTestSuite) TestPrompt_HandleSubmissionResolved() {
+	step, err := common.InitiateRegistrationFlow(ts.promptHandleAppID, false, nil, "")
+	ts.Require().NoError(err, "Failed to initiate registration flow")
+	ts.Require().True(common.HasInput(step.Data.Inputs, "ouHandle"), "The flow should prompt for an OU")
+
+	step, err = common.CompleteFlow(step.ExecutionID,
+		map[string]string{"ouHandle": "ou_strategy_child_test_ou"}, "action_ou", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit the OU handle")
+	ts.Require().Nil(step.Error, "A valid handle among the parent's children must resolve")
+	ts.Require().Equal("INCOMPLETE", step.FlowStatus, "The flow should move on to user details")
+
+	username := common.GenerateUniqueUsername("ou_prompt_handle")
+	completed, err := common.CompleteFlow(step.ExecutionID, map[string]string{
+		"username": username,
+		"email":    username + "@ou-strategy.test",
+	}, "action_details", step.ChallengeToken)
+	ts.Require().NoError(err, "Failed to submit user details")
+	ts.Require().Equal("COMPLETE", completed.FlowStatus, "Registration should provision the user")
+
+	user := ts.trackRegisteredUser(username)
+	ts.Equal(ts.childOUID, user.OUID, "A handle submission must resolve to the same OU as the raw ID would")
 }


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

Resolve organization units by handle

OUResolver's "prompt" strategy only ever accepted a raw OU ID, something no real user filling out a signup form would know ahead of time. It now also resolves a human-readable handle, scoped to the resolved user type's own OU so the same handle can safely repeat elsewhere in the tree.

Fixes #5122.

Screenshots for UI changes:

prompt:

<img width="1018" height="698" alt="image" src="https://github.com/user-attachments/assets/6737466d-7dd1-4f97-a587-7633157eed03" />


<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes
_Describe what is changing_

#### 💥 Impact
_What will break? Who is affected?_

#### 🔄 Migration Guide
_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful_

---

-->

### Approach
<!-- Describe how you are implementing the solution, what are the key design decisions and why. Add diagrams if necessary. -->

### Related Issues

- https://github.com/thunder-id/thunderid/issues/5122

### Related PRs
- N/A

### Checklist
- [ ] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [ ] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - OU prompts now accept either a child organization unit handle or ID.
  - Flow configuration includes an option to select child units by handle.
  - Handle-based selections are resolved and validated before provisioning.

- **Bug Fixes**
  - Invalid, conflicting, or non-descendant organization unit selections now return clear input errors.

- **Documentation**
  - Updated Resolve OU guidance to describe supported prompt options and validation rules.
  - Removed documentation for the retired `promptAll` strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->