### PR TITLE
Add End-to-End tests for the CLI

### DIFF
--- a/.github/actions/setup-cli-e2e/action.yml
+++ b/.github/actions/setup-cli-e2e/action.yml
@@ -1,0 +1,22 @@
+name: Setup CLI E2E Suite
+description: >-
+  Installs the tests/e2e-cli pnpm workspace and Chromium, the two setup steps every
+  job that runs the CLI e2e suite needs. Assumes Node.js and pnpm are already set up.
+
+runs:
+  using: composite
+  steps:
+    # tests/e2e-cli is its own pnpm workspace root, deliberately outside the repository's, so
+    # its node-pty dependency cannot force a native build on every other job. See the comment
+    # in tests/e2e-cli/pnpm-workspace.yaml.
+    - name: 📦 Install E2E Dependencies
+      shell: bash
+      working-directory: tests/e2e-cli
+      run: pnpm install --frozen-lockfile
+
+    # Only chromium, and only because the sample spec signs in through a browser. Every other
+    # project in this suite drives a terminal and needs no engine at all.
+    - name: 🌐 Install Chromium
+      shell: bash
+      working-directory: tests/e2e-cli
+      run: pnpm exec playwright install --with-deps chromium

--- a/.github/actions/upload-cli-e2e-report/action.yml
+++ b/.github/actions/upload-cli-e2e-report/action.yml
@@ -1,0 +1,24 @@
+name: Upload CLI E2E Report
+description: Uploads the Playwright report and test results from tests/e2e-cli. Meant to run on failure.
+
+inputs:
+  name:
+    description: Artifact name
+    required: true
+  retention-days:
+    description: How long to keep the artifact
+    required: false
+    default: '7'
+
+runs:
+  using: composite
+  steps:
+    - name: 📄 Upload Playwright Report
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      with:
+        name: ${{ inputs.name }}
+        path: |
+          tests/e2e-cli/playwright-report/
+          tests/e2e-cli/test-results/
+        if-no-files-found: ignore
+        retention-days: ${{ inputs.retention-days }}

--- a/.github/actions/verify-cli-e2e-ports/action.yml
+++ b/.github/actions/verify-cli-e2e-ports/action.yml
@@ -1,0 +1,29 @@
+name: Verify CLI E2E Ports Are Free
+description: >-
+  Fails the job if any port the CLI e2e suite needs is already bound on the runner,
+  rather than letting the suite fail later with a confusing port-conflict assertion.
+
+inputs:
+  extra-ports:
+    description: >-
+      Additional space-separated ports to check beyond the suite's fixed set (8090 for
+      ThunderID, 5173/8787/8788/2525/8795 for the Wayfinder sample). Used for a local
+      release server, for example.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: 🔌 Verify Required Ports Are Free
+      shell: bash
+      env:
+        EXTRA_PORTS: ${{ inputs.extra-ports }}
+      run: |
+        for port in 8090 5173 8787 8788 2525 8795 $EXTRA_PORTS; do
+          if lsof -ti "tcp:$port" >/dev/null 2>&1; then
+            echo "::error::port $port is already in use on this runner"
+            lsof -i "tcp:$port"
+            exit 1
+          fi
+        done

--- a/.github/workflows/nightly-build-validation.yml
+++ b/.github/workflows/nightly-build-validation.yml
@@ -1,4 +1,13 @@
-# This workflow validates platform-wise packaging nightly to catch build issues early
+# This workflow validates platform-wise packaging nightly to catch build issues early, and
+# separately checks that the published CLI and the published product still work together.
+#
+# The CLI compatibility job installs the CLI from npm rather than building it from the checkout,
+# so it is the only job in this workflow testing what a user actually gets: the wrapper as
+# packaged, and the platform binaries the release workflow built. It catches what no pull request
+# can, because nothing in the repository changed: a manifest or CDN problem, a bad publish, a
+# runner picking up a new Node, an expired certificate. Its matrix follows the release channels:
+# the 1.0.x line publishes under `latest`, main publishes prereleases under `next` (see
+# release-tools.yml).
 name: 🌙 Nightly Build Validation
 
 on:
@@ -6,6 +15,11 @@ on:
     # Runs every day at 12:00 AM IST (which is 18:30 UTC of the previous day)
     - cron: '30 18 * * *'
   workflow_dispatch:  # Allow manual triggering
+    inputs:
+      dist-tag:
+        description: "CLI compatibility: only test this npm dist-tag (latest or next). Leave empty for both."
+        required: false
+        type: string
 
 # Add permissions
 permissions:
@@ -105,10 +119,128 @@ jobs:
       - name: 📦 Build and Package Samples for macOS/${{ matrix.arch }}
         run: ./scripts/package-samples.sh macos ${{ matrix.arch }}
 
+  cli-compatibility:
+    name: 🌙 Published CLI (${{ matrix.dist-tag }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        dist-tag: [latest, next]
+    # A manual run can narrow the matrix to one channel.
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      github.event.inputs.dist-tag == '' ||
+      github.event.inputs.dist-tag == matrix.dist-tag
+    steps:
+      - name: 📥 Checkout Code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: ⚙️ Set up Node.js and pnpm
+        uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: lts/*
+
+      # No Go toolchain: this lane never builds the CLI, it installs it from npm.
+      - name: 📦 Set up CLI E2E Suite
+        uses: ./.github/actions/setup-cli-e2e
+
+      - name: 🔎 Report What Is Being Tested
+        run: |
+          echo "CLI:     $(npm view thunderid@${{ matrix.dist-tag }} version 2>/dev/null || echo 'not published')"
+          echo "Product: $(curl -fsSL https://thunderid.dev/data/releases.json | \
+            node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{
+              try { console.log(JSON.parse(s).latestRelease.tagName) } catch { console.log("unreadable") }})')"
+
+      - name: 🔌 Verify Required Ports Are Free
+        uses: ./.github/actions/verify-cli-e2e-ports
+
+      - name: 🎭 Run the Published CLI Against the Published Product
+        working-directory: tests/e2e-cli
+        env:
+          E2E_CLI_SOURCE: published
+          E2E_CLI_TAG: ${{ matrix.dist-tag }}
+        run: pnpm test
+
+      - name: 📄 Upload Playwright Report on Failure
+        if: failure()
+        uses: ./.github/actions/upload-cli-e2e-report
+        with:
+          name: nightly-cli-${{ matrix.dist-tag }}-${{ matrix.os }}
+          retention-days: '14'
+
+      # Independent of report-results' aggregated message below: this fires per matrix leg, right
+      # where the failure happened, instead of waiting on every other nightly job to finish.
+      - name: 🔔 Send Google Chat Notification on Failure
+        if: failure()
+        shell: bash
+        env:
+          GOOGLE_CHAT_WEBHOOK: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          DIST_TAG: ${{ matrix.dist-tag }}
+          OS: ${{ matrix.os }}
+          COMMIT: ${{ github.sha }}
+        run: |
+          if [ -z "$GOOGLE_CHAT_WEBHOOK" ]; then
+            echo "GOOGLE_CHAT_WEBHOOK secret is not set. Skipping Google Chat notification."
+            exit 0
+          fi
+
+          FAILURE_DATE=$(date -u +"%d-%m-%Y")
+
+          jq -n \
+            --arg dist_tag "$DIST_TAG" \
+            --arg os "$OS" \
+            --arg commit "${COMMIT:0:8}" \
+            --arg workflow_url "$WORKFLOW_URL" \
+            --arg failure_date "$FAILURE_DATE" \
+            '{
+              "cards": [{
+                "header": {
+                  "title": "🔴 ThunderID CLI E2E Failed",
+                  "subtitle": ("Nightly - " + $failure_date),
+                  "imageUrl": "https://raw.githubusercontent.com/github/explore/main/topics/cli/cli.png",
+                  "imageStyle": "AVATAR"
+                },
+                "sections": [
+                  {
+                    "widgets": [
+                      {"keyValue": {"topLabel": "Dist Tag", "content": $dist_tag}},
+                      {"keyValue": {"topLabel": "Runner", "content": $os}},
+                      {"keyValue": {"topLabel": "Commit", "content": $commit}}
+                    ]
+                  },
+                  {
+                    "widgets": [
+                      {
+                        "buttons": [
+                          {
+                            "textButton": {
+                              "text": "VIEW WORKFLOW RUN",
+                              "onClick": {"openLink": {"url": $workflow_url}}
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }]
+            }' > payload.json
+
+          if curl -f -X POST -H "Content-Type: application/json" -d @payload.json "$GOOGLE_CHAT_WEBHOOK"; then
+            echo "✅ Google Chat notification sent successfully"
+          else
+            echo "⚠️ Failed to send Google Chat notification"
+          fi
+
   report-results:
     name: 📊 Report Results
     runs-on: ubuntu-latest
-    needs: [validate-complete-build, validate-sample-packaging-linux, validate-sample-packaging-macos]
+    needs: [validate-complete-build, validate-sample-packaging-linux, validate-sample-packaging-macos, cli-compatibility]
     if: always()
     steps:
       - name: 📥 Checkout Code
@@ -120,21 +252,23 @@ jobs:
           BUILD_STATUS="${{ needs.validate-complete-build.result }}"
           LINUX_STATUS="${{ needs.validate-sample-packaging-linux.result }}"
           MACOS_STATUS="${{ needs.validate-sample-packaging-macos.result }}"
+          CLI_STATUS="${{ needs.cli-compatibility.result }}"
 
           echo "Complete build: $BUILD_STATUS"
           echo "Linux/Windows samples: $LINUX_STATUS"
           echo "macOS samples: $MACOS_STATUS"
+          echo "CLI compatibility: $CLI_STATUS"
 
           # Check if all jobs succeeded
-          if [ "$BUILD_STATUS" = "success" ] && [ "$LINUX_STATUS" = "success" ] && [ "$MACOS_STATUS" = "success" ]; then
+          if [ "$BUILD_STATUS" = "success" ] && [ "$LINUX_STATUS" = "success" ] && [ "$MACOS_STATUS" = "success" ] && [ "$CLI_STATUS" = "success" ]; then
             echo "status=success" >> $GITHUB_OUTPUT
             echo "message=✅ All nightly build validations passed successfully!" >> $GITHUB_OUTPUT
           # Check if any job was cancelled
-          elif [ "$BUILD_STATUS" = "cancelled" ] || [ "$LINUX_STATUS" = "cancelled" ] || [ "$MACOS_STATUS" = "cancelled" ]; then
+          elif [ "$BUILD_STATUS" = "cancelled" ] || [ "$LINUX_STATUS" = "cancelled" ] || [ "$MACOS_STATUS" = "cancelled" ] || [ "$CLI_STATUS" = "cancelled" ]; then
             echo "status=cancelled" >> $GITHUB_OUTPUT
             echo "message=⚠️ Nightly build validation was cancelled." >> $GITHUB_OUTPUT
           # Check if any job was skipped
-          elif [ "$BUILD_STATUS" = "skipped" ] || [ "$LINUX_STATUS" = "skipped" ] || [ "$MACOS_STATUS" = "skipped" ]; then
+          elif [ "$BUILD_STATUS" = "skipped" ] || [ "$LINUX_STATUS" = "skipped" ] || [ "$MACOS_STATUS" = "skipped" ] || [ "$CLI_STATUS" = "skipped" ]; then
             echo "status=skipped" >> $GITHUB_OUTPUT
             echo "message=⚠️ Some nightly build validation jobs were skipped." >> $GITHUB_OUTPUT
           # Otherwise, treat as failure
@@ -156,6 +290,7 @@ jobs:
           echo "- Complete Build (All Platforms): ${{ needs.validate-complete-build.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- Linux/Windows Samples: ${{ needs.validate-sample-packaging-linux.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- macOS Samples: ${{ needs.validate-sample-packaging-macos.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "- CLI Compatibility (Published): ${{ needs.cli-compatibility.result }}" >> $GITHUB_STEP_SUMMARY
 
       - name: 🔔 Notify on Failure
         if: steps.check_status.outputs.status == 'failure'
@@ -164,6 +299,7 @@ jobs:
           BUILD_RESULT: ${{ needs.validate-complete-build.result }}
           LINUX_RESULT: ${{ needs.validate-sample-packaging-linux.result }}
           MACOS_RESULT: ${{ needs.validate-sample-packaging-macos.result }}
+          CLI_RESULT: ${{ needs.cli-compatibility.result }}
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           BRANCH_NAME: ${{ github.ref_name }}
           COMMIT_SHA: ${{ github.sha }}
@@ -172,7 +308,7 @@ jobs:
             const issue_title = '🌙 Nightly Build Validation Failed';
             const issue_body = `## Nightly Build Validation Failure
 
-            The nightly build validation workflow has detected failures in platform-wise packaging.
+            The nightly build validation workflow has detected failures in platform-wise packaging or CLI compatibility.
 
             **Workflow Run:** ${process.env.WORKFLOW_URL}
             **Branch:** ${process.env.BRANCH_NAME}
@@ -182,6 +318,7 @@ jobs:
             - Complete Build (All Platforms): ${process.env.BUILD_RESULT}
             - Linux/Windows Samples: ${process.env.LINUX_RESULT}
             - macOS Samples: ${process.env.MACOS_RESULT}
+            - CLI Compatibility (Published): ${process.env.CLI_RESULT}
 
             Please investigate and fix the build issues.
 
@@ -227,6 +364,7 @@ jobs:
           BUILD_STATUS: ${{ needs.validate-complete-build.result }}
           LINUX_STATUS: ${{ needs.validate-sample-packaging-linux.result }}
           MACOS_STATUS: ${{ needs.validate-sample-packaging-macos.result }}
+          CLI_STATUS: ${{ needs.cli-compatibility.result }}
           BRANCH: ${{ github.ref_name }}
           COMMIT: ${{ github.sha }}
         run: |
@@ -247,6 +385,7 @@ jobs:
           BUILD_EMOJI=$(get_status_emoji "$BUILD_STATUS")
           LINUX_EMOJI=$(get_status_emoji "$LINUX_STATUS")
           MACOS_EMOJI=$(get_status_emoji "$MACOS_STATUS")
+          CLI_EMOJI=$(get_status_emoji "$CLI_STATUS")
 
           # Create JSON payload for Google Chat using jq for proper escaping
           jq -n \
@@ -254,6 +393,7 @@ jobs:
             --arg build_status "$BUILD_EMOJI $BUILD_STATUS" \
             --arg linux_status "$LINUX_EMOJI $LINUX_STATUS" \
             --arg macos_status "$MACOS_EMOJI $MACOS_STATUS" \
+            --arg cli_status "$CLI_EMOJI $CLI_STATUS" \
             --arg commit "${COMMIT:0:8}" \
             --arg workflow_url "$WORKFLOW_URL" \
             --arg issues_url "${{ github.server_url }}/${{ github.repository }}/issues?q=is%3Aissue+is%3Aopen+label%3Anightly-build-failure" \
@@ -285,6 +425,12 @@ jobs:
                         "keyValue": {
                           "topLabel": "macOS Samples",
                           "content": $macos_status
+                        }
+                      },
+                      {
+                        "keyValue": {
+                          "topLabel": "CLI Compatibility (Published)",
+                          "content": $cli_status
                         }
                       },
                       {

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -741,6 +741,156 @@ jobs:
           name: sample-app-react-sdk
           path: target/dist/sample-app-react-sdk-*.zip
 
+      # Kept separately from sample-app-react-sdk, which other workflows consume by name.
+      # The CLI installs this bundle for `try`, so cli-compatibility serves it with the product.
+      - name: 📦 Upload Wayfinder Sample
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sample-app-wayfinder
+          path: target/dist/sample-app-wayfinder-*.zip
+          if-no-files-found: error
+
+  # Fast gate for the CLI: everything that needs neither the network nor a running server.
+  # Kept out of the `lint` job above because the CLI lints with its own golangci-lint, built
+  # against the toolchain in tools/cli/go.mod: a published prebuilt binary is compiled with an
+  # older Go than the CLI targets and refuses to run at all in that case.
+  cli-lint-unit:
+    name: 🔍 CLI Lint and Unit Tests
+    needs: [preflight]
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: 📥 Checkout Code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: ⚙️ Set up Go Environment
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: tools/cli/go.mod
+          cache-dependency-path: tools/cli/go.sum
+
+      - name: 🧹 Lint CLI
+        run: make tools_lint_cli
+
+      - name: 🧪 Run CLI Unit Tests
+        run: make tools_test_cli
+
+  # Lane 1 of the CLI e2e strategy: does a CLI change break the CLI? Drives the npx wrapper
+  # against the currently published release, not the distribution built above: that pairing
+  # is cli-compatibility's job, below. Split from cli-lint-unit so a lint or unit failure
+  # reports without paying for this.
+  cli-e2e:
+    name: 🎭 CLI E2E (${{ matrix.os }})
+    needs: [cli-lint-unit]
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: 📥 Checkout Code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      # global-setup.ts builds the CLI binary that the npx wrapper resolves.
+      - name: ⚙️ Set up Go Environment
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: tools/cli/go.mod
+          cache-dependency-path: tools/cli/go.sum
+
+      - name: ⚙️ Set up Node.js and pnpm
+        uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: 📦 Set up CLI E2E Suite
+        uses: ./.github/actions/setup-cli-e2e
+
+      - name: 🔌 Verify Required Ports Are Free
+        uses: ./.github/actions/verify-cli-e2e-ports
+
+      - name: 🎭 Run E2E Tests
+        working-directory: tests/e2e-cli
+        run: pnpm test
+
+      - name: 📄 Upload Playwright Report on Failure
+        if: failure()
+        uses: ./.github/actions/upload-cli-e2e-report
+        with:
+          name: cli-e2e-report-${{ matrix.os }}
+
+  cli-compatibility:
+    name: 🔗 CLI Against This Build
+    needs: [preflight, build, build_samples]
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger-pr-builder') && (github.event.action != 'labeled' || github.event.label.name == 'trigger-pr-builder')) || github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: 📥 Checkout Code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      # global-setup builds the CLI from this checkout; the product comes from the artifacts.
+      - name: ⚙️ Set up Go Environment
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: tools/cli/go.mod
+          cache-dependency-path: tools/cli/go.sum
+
+      - name: ⚙️ Set up Node.js and pnpm
+        uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      # Reusing what build-product and build-samples already produced, rather than building the
+      # distribution a second time.
+      - name: 📥 Download the Built Distribution
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: product-distribution
+          path: target/dist
+
+      - name: 📥 Download the Wayfinder Sample
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: sample-app-wayfinder
+          path: target/dist
+
+      - name: 🔍 Show What Will Be Served
+        run: ls -lh target/dist/
+
+      - name: 📦 Set up CLI E2E Suite
+        uses: ./.github/actions/setup-cli-e2e
+
+      # 8899 is the local release server this run serves target/dist through, on top of the
+      # suite's own fixed ports.
+      - name: 🔌 Verify Required Ports Are Free
+        uses: ./.github/actions/verify-cli-e2e-ports
+        with:
+          extra-ports: "8899"
+
+      # E2E_PRODUCT_DIST makes the suite serve target/dist with a generated manifest and point the
+      # CLI at it, so everything it installs was built by this pull request.
+      - name: 🎭 Run the CLI Against This Build
+        working-directory: tests/e2e-cli
+        env:
+          E2E_PRODUCT_DIST: ${{ github.workspace }}/target/dist
+        run: pnpm test
+
+      - name: 📄 Upload Playwright Report on Failure
+        if: failure()
+        uses: ./.github/actions/upload-cli-e2e-report
+        with:
+          name: cli-compatibility-report
+
   test-integration:
     name: 🧪 Integration Tests (${{ matrix.database }})
     needs: [build, build_samples]

--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -400,6 +400,37 @@ jobs:
           if-no-files-found: error
           overwrite: true
 
+      # Lane 3 of the CLI end-to-end strategy: the release gate.
+      #
+      # Everything below this point publishes: the tag, the container images, the npm package.
+      # This is the last moment a broken pairing can be caught, and it is caught by driving the
+      # real CLI against the artifacts this run just built, through the same --product-version
+      # knob an operator uses for a mirror.
+      #
+      # The sample project is excluded: it needs a browser and the sample bundle packaged
+      # alongside the product. What matters here is that the release installs, sets up, starts
+      # and answers.
+      - name: 📦 Install CLI E2E Dependencies
+        working-directory: tests/e2e-cli
+        run: pnpm install --frozen-lockfile
+
+      - name: 🎭 Verify the CLI Can Install This Release
+        working-directory: tests/e2e-cli
+        env:
+          E2E_PRODUCT_DIST: ${{ github.workspace }}/target/dist
+        run: pnpm run test:no-sample
+
+      - name: 📄 Upload CLI Verification Report on Failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-cli-verification
+          path: |
+            tests/e2e-cli/playwright-report/
+            tests/e2e-cli/test-results/
+          if-no-files-found: ignore
+          retention-days: 14
+
       - name: 🏷️ Create Git Tag
         run: |
           git config --local user.email "action@github.com"

--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,8 @@ tmp
 out
 out-tsc
 backend/bin
+tools/cli/bin
+tools/i18n-extractor/bin
 backend/server
 
 # E2E extracted distribution

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,9 @@ The `.agent/skills/` entries above are internal guidance for **developing** Thun
 ## Validation Ladder
 
 - **Inner loop**: run the smallest relevant checks for the area you touched. The scoped AGENTS files say which tests to run.
-- **Pre-PR gate**: `make pr_checks` — the authoritative gate (verify_mocks → lint → format_check → unit/frontend/integration tests → builds).
+- **Pre-PR gate**: `make pr_checks` — the authoritative gate (verify_mocks → lint → format_check → tool lint and tests → unit/frontend/integration tests → builds).
+- The CLI e2e suite (`make tools_test_cli_e2e`) is not part of that gate: it downloads a real release and boots a server. CI runs it in `pr-builder.yml`, behind the `trigger-pr-builder` label, on every pull request.
+- Per-tool tasks are namespaced `tools_*` (for example `make tools_lint_cli`, `make tools_test_i18n_extractor`); `tools_build`, `tools_test` and `tools_lint` run every tool.
 - Note: `make test` is backend-only (unit + integration), not full-repo validation.
 
 ## Product Name Rules

--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,32 @@ GOLANGCI_LINT ?= $(TOOL_BIN)/golangci-lint
 MOCKERY ?= $(TOOL_BIN)/mockery
 I18N_EXTRACTOR ?= $(TOOL_BIN)/i18n-extractor
 
+# Tools under tools/. Each is its own Go module with its own Go directive, and `go install`
+# compiles a linter with whatever Go is on PATH. golangci-lint refuses to run when the Go it was
+# built with is older than the module it is linting, so each tool installs its linter into its own
+# bin directory rather than sharing the backend's, where a binary built by the backend's job would
+# carry the backend's Go version.
+TOOLS_DIR := $(realpath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))/tools
+CLI_DIR := $(TOOLS_DIR)/cli
+CLI_TOOL_BIN ?= $(CLI_DIR)/bin/tools
+CLI_GOLANGCI_LINT ?= $(CLI_TOOL_BIN)/golangci-lint
+I18N_EXTRACTOR_DIR := $(TOOLS_DIR)/i18n-extractor
+I18N_EXTRACTOR_TOOL_BIN ?= $(I18N_EXTRACTOR_DIR)/bin/tools
+I18N_EXTRACTOR_GOLANGCI_LINT ?= $(I18N_EXTRACTOR_TOOL_BIN)/golangci-lint
+CLI_E2E_DIR := $(realpath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))/tests/e2e-cli
+
 # Tools versions
 GOLANGCI_LINT_VERSION ?= v1.64.8
 MOCKERY_VERSION ?= v3.5.5
 
 $(TOOL_BIN):
 	mkdir -p $(TOOL_BIN)
+
+$(CLI_TOOL_BIN):
+	mkdir -p $(CLI_TOOL_BIN)
+
+$(I18N_EXTRACTOR_TOOL_BIN):
+	mkdir -p $(I18N_EXTRACTOR_TOOL_BIN)
 
 all: prepare clean build_with_coverage build
 
@@ -108,14 +128,39 @@ docker-build-multiarch-push:
 
 lint: lint_backend lint_frontend
 
-build_tools:
-	./build.sh build_tools
+tools_build:
+	./build.sh tools_build
 
-test_tools:
-	./build.sh test_tools
+tools_test:
+	./build.sh tools_test
 
-lint_tools:
-	./build.sh lint_tools
+tools_lint: $(CLI_GOLANGCI_LINT) $(I18N_EXTRACTOR_GOLANGCI_LINT)
+	./build.sh tools_lint
+
+tools_build_cli:
+	./build.sh tools_build_cli
+
+tools_test_cli:
+	./build.sh tools_test_cli
+
+tools_lint_cli: $(CLI_GOLANGCI_LINT)
+	./build.sh tools_lint_cli
+
+tools_build_i18n_extractor:
+	./build.sh tools_build_i18n_extractor
+
+tools_test_i18n_extractor:
+	./build.sh tools_test_i18n_extractor
+
+tools_lint_i18n_extractor: $(I18N_EXTRACTOR_GOLANGCI_LINT)
+	./build.sh tools_lint_i18n_extractor
+
+tools_test_cli_e2e:
+	cd $(CLI_E2E_DIR) && pnpm install --frozen-lockfile && pnpm test
+
+tools_checks_cli: tools_lint_cli tools_test_cli
+
+tools_checks: tools_lint tools_test
 
 lint_docs:
 	@command -v vale >/dev/null 2>&1 || (echo "vale is not installed. See https://vale.sh/docs/vale-cli/installation/ for installation instructions." && exit 1)
@@ -170,7 +215,7 @@ test_e2e:
 	chmod +x tests/e2e/run-e2e.sh
 	tests/e2e/run-e2e.sh
 
-pr_checks: verify_mocks lint format_check test_unit test_frontend test_integration build_backend build_frontend package_samples
+pr_checks: verify_mocks lint format_check tools_checks test_unit test_frontend test_integration build_backend build_frontend package_samples
 
 help:
 	@echo "Makefile targets:"
@@ -197,9 +242,18 @@ help:
 	@echo "  docker-build-multiarch        - Build multi-arch Docker image with version tag."
 	@echo "  docker-build-multiarch-latest - Build multi-arch Docker image with latest tag."
 	@echo "  docker-build-multiarch-push   - Build and push multi-arch images to registry."
-	@echo "  build_tools                   - Build all tool binaries (CLI + i18n-extractor + npm tools)."
-	@echo "  test_tools                    - Run tests for all tools."
-	@echo "  lint_tools                    - Run linting on all tools."
+	@echo "  tools_build                   - Build all tool binaries (CLI + i18n-extractor + npm tools)."
+	@echo "  tools_test                    - Run tests for all tools."
+	@echo "  tools_lint                    - Run linting on all tools."
+	@echo "  tools_build_cli               - Cross-compile the CLI for all supported platforms."
+	@echo "  tools_test_cli                - Run CLI unit tests."
+	@echo "  tools_lint_cli                - Run golangci-lint on the CLI code."
+	@echo "  tools_checks                  - Lint and test every tool (part of pr_checks)."
+	@echo "  tools_checks_cli              - Run the CLI lint and unit tests."
+	@echo "  tools_test_cli_e2e            - Run the CLI end-to-end suite against a real release."
+	@echo "  tools_build_i18n_extractor    - Build the i18n-extractor binary."
+	@echo "  tools_test_i18n_extractor     - Run i18n-extractor tests."
+	@echo "  tools_lint_i18n_extractor     - Run golangci-lint on the i18n-extractor code."
 	@echo "  lint                          - Run linting on backend and frontend code."
 	@echo "  lint_backend                  - Run golangci-lint on the backend code."
 	@echo "  lint_frontend                 - Run ESLint on the frontend code."
@@ -220,6 +274,9 @@ help:
 .PHONY: test_unit test_integration build_with_coverage build_with_coverage_only test
 .PHONY: help go_install_tool
 .PHONY: lint lint_backend lint_frontend lint_docs golangci-lint mockery install-mockery
+.PHONY: tools_build tools_test tools_lint tools_build_cli tools_test_cli tools_lint_cli
+.PHONY: tools_build_i18n_extractor tools_test_i18n_extractor tools_lint_i18n_extractor
+.PHONY: tools_test_cli_e2e tools_checks_cli tools_checks
 .PHONY: verify_mocks format_check test_frontend security_audit test_e2e pr_checks
 .PHONY: run_backend debug_backend run_frontend run_docs
 
@@ -232,6 +289,12 @@ golangci-lint: $(GOLANGCI_LINT)
 
 $(GOLANGCI_LINT): $(TOOL_BIN)
 	$(call go_install_tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+$(CLI_GOLANGCI_LINT): $(CLI_TOOL_BIN)
+	cd /tmp && GOBIN=$(CLI_TOOL_BIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
+$(I18N_EXTRACTOR_GOLANGCI_LINT): $(I18N_EXTRACTOR_TOOL_BIN)
+	cd /tmp && GOBIN=$(I18N_EXTRACTOR_TOOL_BIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 install-mockery: $(MOCKERY)
 

--- a/build.ps1
+++ b/build.ps1
@@ -473,7 +473,11 @@ function Test-I18n-Extractor {
 }
 
 function Lint-CLI {
-    $golangciLint = Join-Path $PSScriptRoot "backend/bin/tools/golangci-lint.exe"
+    # tools/cli is a separate Go module with its own Go directive, and golangci-lint refuses to
+    # run when the Go it was built with is older than the module it is linting. The CLI therefore
+    # uses a linter installed into its own bin directory with its own toolchain, rather than the
+    # backend's binary.
+    $golangciLint = Join-Path $PSScriptRoot "tools/cli/bin/tools/golangci-lint.exe"
     Write-Host "Linting CLI tool..."
     Push-Location "$PSScriptRoot/tools/cli"
     try {
@@ -485,7 +489,8 @@ function Lint-CLI {
 }
 
 function Lint-I18n-Extractor {
-    $golangciLint = Join-Path $PSScriptRoot "backend/bin/tools/golangci-lint.exe"
+    # Its own linter, not the backend's: see the note in Lint-CLI.
+    $golangciLint = Join-Path $PSScriptRoot "tools/i18n-extractor/bin/tools/golangci-lint.exe"
     Write-Host "Linting i18n-extractor..."
     Push-Location "$PSScriptRoot/tools/i18n-extractor"
     try {
@@ -1754,14 +1759,32 @@ switch ($Command) {
     'build_docs' {
         Build-Docs
     }
-    'build_tools' {
+    'tools_build' {
         Build-Tools
     }
-    'test_tools' {
+    'tools_test' {
         Test-Tools
     }
-    'lint_tools' {
+    'tools_lint' {
         Lint-Tools
+    }
+    'tools_build_cli' {
+        Build-CLI
+    }
+    'tools_test_cli' {
+        Test-CLI
+    }
+    'tools_lint_cli' {
+        Lint-CLI
+    }
+    'tools_build_i18n_extractor' {
+        Build-I18n-Extractor
+    }
+    'tools_test_i18n_extractor' {
+        Test-I18n-Extractor
+    }
+    'tools_lint_i18n_extractor' {
+        Lint-I18n-Extractor
     }
     'package_samples' {
         Package-Sample-App
@@ -1792,7 +1815,7 @@ switch ($Command) {
         Test-Integration
     }
     default {
-        Write-Host "Usage: $($MyInvocation.MyCommand.Name) {clean|build|build_backend|build_frontend|build_docs|build_tools|test_tools|lint_tools|package_samples|test_unit|test_integration|merge_coverage|run|run_backend|run_frontend|run_docs|test}"
+        Write-Host "Usage: $($MyInvocation.MyCommand.Name) {clean|build|build_backend|build_frontend|build_docs|tools_build|tools_test|tools_lint|tools_build_cli|tools_test_cli|tools_lint_cli|tools_build_i18n_extractor|tools_test_i18n_extractor|tools_lint_i18n_extractor|package_samples|test_unit|test_integration|merge_coverage|run|run_backend|run_frontend|run_docs|test}"
         exit 1
     }
 }

--- a/build.sh
+++ b/build.sh
@@ -367,14 +367,20 @@ function test_i18n_extractor() {
 }
 
 function lint_cli() {
-    local golangci_lint="$SCRIPT_DIR/backend/bin/tools/golangci-lint"
+    # tools/cli is a separate Go module with its own Go directive, and golangci-lint refuses to
+    # run when the Go it was built with is older than the module it is linting. The CLI therefore
+    # uses a linter installed into its own bin directory with its own toolchain, rather than the
+    # backend's binary. `make lint_cli` installs it.
+    local golangci_lint="$SCRIPT_DIR/tools/cli/bin/tools/golangci-lint"
     echo "Linting CLI tool..."
     cd "$SCRIPT_DIR/tools/cli" && "$golangci_lint" run ./...
     cd "$SCRIPT_DIR" || exit 1
 }
 
 function lint_i18n_extractor() {
-    local golangci_lint="$SCRIPT_DIR/backend/bin/tools/golangci-lint"
+    # Its own linter, not the backend's: see the note in lint_cli. `make tools_lint_i18n_extractor`
+    # installs it.
+    local golangci_lint="$SCRIPT_DIR/tools/i18n-extractor/bin/tools/golangci-lint"
     echo "Linting i18n-extractor..."
     cd "$SCRIPT_DIR/tools/i18n-extractor" && "$golangci_lint" run ./...
     cd "$SCRIPT_DIR" || exit 1
@@ -1198,14 +1204,32 @@ case "$1" in
     build_docs)
         build_docs
         ;;
-    build_tools)
+    tools_build)
         build_tools
         ;;
-    test_tools)
+    tools_test)
         test_tools
         ;;
-    lint_tools)
+    tools_lint)
         lint_tools
+        ;;
+    tools_build_cli)
+        build_cli
+        ;;
+    tools_test_cli)
+        test_cli
+        ;;
+    tools_lint_cli)
+        lint_cli
+        ;;
+    tools_build_i18n_extractor)
+        build_i18n_extractor
+        ;;
+    tools_test_i18n_extractor)
+        test_i18n_extractor
+        ;;
+    tools_lint_i18n_extractor)
+        lint_i18n_extractor
         ;;
     package_samples)
         package_sample_app
@@ -1252,9 +1276,15 @@ case "$1" in
         echo "  build_backend            - Build only the ${PRODUCT_NAME} backend server"
         echo "  build_frontend           - Build only the Next.js frontend applications"
         echo "  build_docs               - Build only the documentation"
-        echo "  build_tools              - Build all tool binaries (CLI + i18n-extractor + npm tools)"
-        echo "  test_tools               - Run tests for all tools (CLI + i18n-extractor)"
-        echo "  lint_tools               - Run linting for all tools (CLI + i18n-extractor)"
+        echo "  tools_build              - Build all tool binaries (CLI + i18n-extractor + npm tools)"
+        echo "  tools_test               - Run tests for all tools (CLI + i18n-extractor)"
+        echo "  tools_lint               - Run linting for all tools (CLI + i18n-extractor)"
+        echo "  tools_build_cli          - Cross-compile the CLI for all supported platforms"
+        echo "  tools_test_cli           - Run CLI unit tests"
+        echo "  tools_lint_cli           - Run golangci-lint on the CLI code"
+        echo "  tools_build_i18n_extractor - Build the i18n-extractor binary"
+        echo "  tools_test_i18n_extractor  - Run i18n-extractor tests"
+        echo "  tools_lint_i18n_extractor  - Run golangci-lint on the i18n-extractor code"
         echo "  package_samples          - Package the sample applications (samples are distributed as source)"
         echo "  test_unit                - Run unit tests with coverage"
         echo "  test_integration         - Run integration tests. Use -run and -package for filtering"

--- a/tests/e2e-cli/.gitignore
+++ b/tests/e2e-cli/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+playwright-report/
+test-results/
+blob-report/

--- a/tests/e2e-cli/.prettierrc.json
+++ b/tests/e2e-cli/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+  "semi": true,
+  "trailingComma": "es5",
+  "singleQuote": false,
+  "printWidth": 120,
+  "tabWidth": 2,
+  "useTabs": false,
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
+}

--- a/tests/e2e-cli/README.md
+++ b/tests/e2e-cli/README.md
@@ -1,0 +1,251 @@
+# CLI E2E Tests
+
+End-to-end tests for the ThunderID CLI, written with Playwright Test. They drive the same
+entry point users run, the npx wrapper at `tools/npx/bin/thunderid.js`, spawned under a
+real pseudo terminal.
+
+The release, setup, server, REPL, and sample are real; only the system-browser launch is
+stubbed. A run reaches the public release manifest, downloads a real distribution, runs
+`setup.sh`, boots the server, drives the REPL, and finally launches the Wayfinder sample
+and signs into it in a browser. The point is to catch breakage in the wrapper, the
+download and extract path, setup, port negotiation, the REPL and the sample launch as a
+single working chain, which no amount of unit testing covers.
+
+## What runs where
+
+The suite is one codebase driven in four ways. Which product and which CLI it points at is what
+distinguishes them.
+
+| Lane            | Workflow                       | CLI from          | Product from          | Answers                                        |
+| --------------- | ------------------------------- | ----------------- | --------------------- | ---------------------------------------------- |
+| 1. CLI gate     | `pr-builder.yml`                | this checkout     | published             | Does a CLI change break the CLI?               |
+| 2. Product gate | `pr-builder.yml`                | this checkout     | **this pull request** | Does a product or sample change break the CLI? |
+| 3. Release gate | `release-builder.yml`           | release commit    | the release candidate | Are we about to publish a broken pairing?      |
+| 4. Nightly      | `nightly-build-validation.yml`  | **published npm** | published             | Do the shipped artifacts still work together?  |
+
+Lane 2 exists because the CLI drives `setup.sh`, `start.sh`, `deployment.yaml`, the bootstrap
+resources and the sample bundle, none of which is CLI code. Lane 1 cannot see a change to any of
+them: it installs the published release, so it would pass while the change ships broken.
+
+Lane 4 is the only one that installs the CLI from npm, so it is the only one testing what users
+actually get. It catches what no pull request can, because nothing in the repository changed.
+
+Lanes 1 and 2 both live inside the PR builder as `cli-lint-unit`/`cli-e2e` and `cli-compatibility`.
+Lane 2 reuses the distribution that run already built, instead of building a second one. Every job
+in `pr-builder.yml`, this pair included, sits behind the `trigger-pr-builder` label (a runner-
+saturation workaround, see the workflow's own header), so unlike before, a CLI-only change no
+longer gets lint/unit feedback ahead of that label going on.
+
+Lane 4 lives inside Nightly Build Validation rather than its own workflow, as its own `cli-compatibility`
+job: one nightly schedule, and one failure report covering both platform packaging and the
+published CLI/product pairing, instead of two separate issues and Chat pings for what is really
+one "is tonight's build healthy" question.
+
+Two environment variables select the mode:
+
+| Variable                   | Effect                                                                                    |
+| -------------------------- | ----------------------------------------------------------------------------------------- |
+| `E2E_PRODUCT_DIST`         | Serve this directory of release zips (the shape of `target/dist`) and point the CLI at it |
+| `E2E_CLI_SOURCE=published` | Run `npx thunderid@<tag>` instead of building from source; `E2E_CLI_TAG` picks the tag    |
+
+Neither is a test-only backdoor. `E2E_PRODUCT_DIST` works through `--product-version`, the shipped
+flag an operator uses for a mirror or to pin a release.
+
+## Running
+
+From this directory:
+
+```bash
+pnpm install                                 # first time only
+pnpm test                                    # everything, about 2 minutes warm
+pnpm run test:no-sample                      # everything except the browser spec
+pnpm exec playwright test --project=commands # just the fast, offline command surface
+pnpm exec playwright test --project=repl     # the REPL, reusing the shared install
+pnpm exec playwright test --ui               # interactive
+```
+
+Naming a project also runs the projects it depends on, so `--project=repl` still installs
+first. Only `commands` stands alone.
+
+To run against a distribution built from this checkout rather than the published release:
+
+```bash
+./build.sh build_frontend && ./build.sh build_backend "$(go env GOOS)" "$(go env GOARCH)"
+make package_samples OS=$(go env GOOS) ARCH=$(go env GOARCH)
+E2E_PRODUCT_DIST=$PWD/target/dist pnpm --dir tests/e2e-cli test
+```
+
+To run against the published CLI, as a user would get it:
+
+```bash
+E2E_CLI_SOURCE=published E2E_CLI_TAG=latest pnpm test
+```
+
+Requirements:
+
+- network access to `thunderid.dev` and the npm registry
+- Go, to build the CLI binary the wrapper resolves (done by `global-setup.ts`)
+- Chromium, for the sample spec: `pnpm exec playwright install chromium`
+- **ports free**: 8090 for ThunderID, 8899 for the local release server when
+  `E2E_PRODUCT_DIST` is set, plus 5173, 8787, 8788, 2525 and 8795 for the Wayfinder sample. The happy path binds 8090 and the conflict specs hold it deliberately.
+  If you have a ThunderID instance running locally, stop it first; the specs fail fast
+  with a clear message rather than fighting it.
+
+This suite is separate from `tests/e2e` and does not share its configuration. That one
+starts a backend on port 8090 through Playwright's `webServer` before the first test; here
+the CLI is the thing that installs and starts ThunderID, and it needs that port free.
+
+Windows is not covered yet: the wrapper resolves a `.exe`, setup runs `setup.ps1` instead
+of `setup.sh`, and node-pty uses conpty rather than a spawn helper.
+
+## Why a pseudo terminal
+
+The CLI branches on `ui.Interactive()`, a terminal check on stdin, to decide whether to
+prompt at all. Over a pipe it takes the scripted fallbacks instead, so a piped run would
+assert code paths users never see. `internal/cli/root.go` is explicit about it:
+
+```go
+if !ui.Interactive() {
+    // A scripted or CI run cannot answer the prompt, so take the port as before
+```
+
+The REPL is also a Bubble Tea program rendering ANSI frames, which only a pty produces.
+
+## How it stays isolated
+
+Each spec gets a `Workspace`: a temp `HOME`, which relocates the CLI's
+`~/.thunderid/state.json`, and a temp working directory, which relocates the
+`./thunderid/vX` install. Every `THUNDERID_*` variable is stripped from the child
+environment, so a developer's own shell configuration cannot change what is under test.
+
+Per-spec runtime state stays inside those temp directories, with one exception the specs
+cannot avoid: the server binds a real port, and the CLI deliberately leaves it running in
+the background after the REPL exits. Teardown frees the port explicitly. Separately,
+`global-setup.ts` builds the host binary into the wrapper's own `dist/` directory once per
+run, ahead of any spec.
+
+## Layout
+
+Specs are grouped by the part of the CLI they exercise, and each folder is a Playwright
+project. The dependency graph in `playwright.config.ts` is what orders them.
+
+```text
+tests/
+├── commands/       no install, no network. The argument surface that returns early
+├── install/        the only spec that downloads. Populates the shared install
+├── repl/           warm-starts against the shared install, one session per spec
+├── restart/        running again over an existing install
+├── port-conflict/  the three answers to a contested port
+└── sample/         `try`, ending in a real browser sign-in. Runs last, destructively
+```
+
+| Project         | Depends on       | Covers                                                                                                      |
+| --------------- | ---------------- | ----------------------------------------------------------------------------------------------------------- |
+| `commands`      | nothing          | `--help`, `-h`, `integrate`, `try` with no install                                                          |
+| `install`       | nothing          | Manifest, download, extract, `setup.sh`, start, `state.json`, files on disk                                 |
+| `repl`          | `install`        | The onboarding picker and command overlay, `/status`, `/logs`, `/open-console`, `/integrate-react`, `/stop` |
+| `restart`       | `install`        | Warm start, `--setup`                                                                                       |
+| `port-conflict` | `install`        | Alternate port, abort, reclaim                                                                              |
+| `sample`        | all of the above | Unknown sample name, and `try wayfinder` through a browser login                                            |
+
+Supporting code:
+
+| Path                         | Role                                                                         |
+| ---------------------------- | ---------------------------------------------------------------------------- |
+| `global-setup.ts`            | Builds the host binary into the wrapper's `dist/`, clears the shared install |
+| `fixtures/shared-install.ts` | Creates and reads back the one install every project reuses                  |
+| `fixtures/cli.ts`            | The `repl` fixture: a session already at the prompt, torn down after         |
+| `utils/cli-session.ts`       | The pty session: spawn, expect, send keys, exit codes                        |
+| `utils/cli-process.ts`       | A non-pty runner, for commands that background work and exit                 |
+| `utils/workspace.ts`         | Temp `HOME` and working directory, plus the state file                       |
+| `utils/ports.ts`             | Port checks, readiness probes, the port holder                               |
+| `utils/sample-ports.ts`      | The sample's five fixed ports, and stopping what it leaves behind            |
+| `utils/browser-stub.ts`      | Records what the CLI asks the system browser to open                         |
+| `utils/release-source.ts`    | Serves a locally built distribution with a generated manifest                |
+| `pages/wayfinder.page.ts`    | A minimal page object for the sample and the gate                            |
+
+### Why one shared install
+
+A distribution is ~85MB extracted. `install` performs it once into a fixed path under
+`test-results/`, and everything downstream declares a dependency on that project, which is
+both the ordering mechanism and the reason those specs warm-start in seconds. Only two
+specs download: `install`, and the first-run case in `port-conflict`, which needs an
+install that setup has not yet pinned to a port.
+
+Each spec still starts its own CLI session rather than sharing a live process, so one
+wedged REPL cannot take the rest of the file down with it.
+
+## Deliberately not covered
+
+- **`/try-consumer` from inside the REPL.** The command-line `try wayfinder` covers the
+  same sample runner; the REPL path additionally drives the walkthrough overlay.
+- **`upgrade` performing a real upgrade.** It depends on two releases existing and on
+  which one is latest at the time, so it cannot assert anything stable on a PR.
+- **The offline fallback** (`root.go` warns and starts the installed version when the
+  release server is unreachable). Reaching it needs the releases URL to be injectable;
+  today it is a constant in `internal/product`.
+
+## Notes for adding specs
+
+- **Everything is serial, with one worker.** Every spec binds the default port or
+  deliberately holds it. That is a property of what is under test, not a tuning knob.
+- **A distribution is ~85MB extracted**, and the port-conflict prompt comes _after_ the
+  download, so a naive spec per branch pays for its own copy. Both slow files use
+  `test.describe.serial` over a shared workspace. Keep it that way unless a case genuinely
+  needs a clean machine.
+- **Drive slash commands with `runSlash`, never raw keystrokes.** The REPL only routes `/`
+  into command mode once it reports ready. Sent earlier it reaches the onboarding picker,
+  where the following Enter launches a use case, which hangs the spec on a sample
+  download. `runSlash` waits for the overlay before typing.
+- **Assertions match the whole buffer**, so a phrase from an earlier frame satisfies a
+  later `expect`. Call `reset()` before an interaction that reuses wording already on
+  screen; `runSlash` does it for you.
+- **`/stop` exits the program**, closing the pty. Use `exitRepl()`, not a raw Ctrl+C. When
+  a step is not asserting `/stop` itself, tear down with `shutdown(port)` instead: it exits
+  and frees the port without depending on TUI state.
+- **Match on short, distinctive phrases.** Output is compared with escape sequences
+  stripped and whitespace collapsed, so a phrase broken across a line still matches, but
+  the TUI redraws constantly and long strings are fragile.
+- The onboarding picker reappears until a use case is actually selected: `onboardingDone`
+  is only recorded by `ui.selectOnboarding`. Do not assert it is absent on a second run.
+
+## The sample spec
+
+`tests/sample/try-wayfinder.spec.ts` is the slowest and least ordinary spec here.
+
+- It runs `try wayfinder`, not `try consumer`. `consumer` is the REPL slash command; the
+  only sample name the CLI accepts is `wayfinder`, and `unknown-usecase.spec.ts` pins that
+  error message down.
+- It uses `runCli`, not a pty session. `try` exits as soon as the services are up, and
+  closing a pty at that point SIGHUPs the ThunderID server it just backgrounded. A real
+  terminal is owned by the shell, so the pty is what would be lying here, not the pipe.
+- It runs last and is destructive: `try` rewrites `<install>/config/resources/**` and
+  restarts the server, so it must not overlap the projects using the shared install.
+- Teardown is entirely ours. `try` installs no signal handler and never calls
+  `StopServices`, so it leaves npm and all five services running.
+- A cold run pays for an `npm install` across the sample's five-package workspace, so
+  budget minutes rather than seconds on a clean machine.
+
+## node-pty, and why this is a separate workspace
+
+`pnpm-workspace.yaml` here marks this directory as its own pnpm workspace root, so it is
+installed independently of the repository's workspace and has its own lockfile.
+
+That is not tidiness, it is a requirement. node-pty is a native addon that ships prebuilds
+for macOS and Windows only, so on Linux it compiles with node-gyp. As a member of the root
+workspace it would force every job that runs `pnpm install --frozen-lockfile` to build a
+native addon, and the jobs running in minimal containers have no toolchain: they fail with
+`gyp ERR! stack Error: not found: make`. Keeping the suite out of the workspace confines
+that requirement to the one job that needs it.
+
+Two consequences worth knowing:
+
+- Versions are pinned in `package.json` rather than taken from the root catalog. When the
+  catalog moves `@playwright/test` or `@types/node`, move them here too.
+- Running the CLI e2e suite on Linux needs `make` and a C++ toolchain. GitHub's
+  `ubuntu-latest` image has both.
+
+`postinstall` runs `scripts/fix-node-pty-permissions.js`. Where node-pty does ship a
+prebuilt binary, extraction into the pnpm store drops the mode bits on its `spawn-helper`.
+The addon then loads fine but every spawn fails with the opaque `posix_spawnp failed`. The
+script restores the executable bit and is a no-op once correct.

--- a/tests/e2e-cli/constants/timeouts.ts
+++ b/tests/e2e-cli/constants/timeouts.ts
@@ -1,0 +1,31 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Timeouts
+ *
+ * The install budget covers downloading and extracting a real distribution (~40MB compressed)
+ * plus setup.sh seeding the database, so it is deliberately generous.
+ */
+export const Timeouts = {
+  /** Waiting on a frame the TUI should already be rendering. */
+  SHORT: 30_000,
+  /** Waiting for the server to boot and answer. */
+  STARTUP: 180_000,
+  /** Waiting on a fetch from the docs site. */
+  REMOTE: 60_000,
+  /** Waiting for a download, extract and setup to finish. */
+  INSTALL: 600_000,
+  /** Per-test budget for a spec that installs a distribution. */
+  INSTALL_TEST: 900_000,
+  /**
+   * Waiting for `try` to bring a sample up. It downloads the sample bundle, runs a cold
+   * `npm install` across a five-package workspace, restarts ThunderID and then waits on Vite,
+   * so this is minutes rather than seconds on a first run.
+   */
+  SAMPLE: 900_000,
+  /** Per-test budget for a spec that launches a sample. */
+  SAMPLE_TEST: 1_200_000,
+  /** A browser action against the sample app or the gate. */
+  BROWSER: 60_000,
+} as const;

--- a/tests/e2e-cli/eslint.config.mjs
+++ b/tests/e2e-cli/eslint.config.mjs
@@ -1,0 +1,57 @@
+import typescriptEslint from "@typescript-eslint/eslint-plugin";
+import playwright from "eslint-plugin-playwright";
+import tsParser from "@typescript-eslint/parser";
+
+export default [
+  {
+    ignores: ["node_modules/**", "playwright-report/**", "test-results/**", "blob-report/**", "scripts/**"],
+  },
+  {
+    files: ["**/*.ts"],
+    plugins: {
+      "@typescript-eslint": typescriptEslint,
+      playwright: playwright,
+    },
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: "module",
+        project: "./tsconfig.json",
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/explicit-function-return-type": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+        },
+      ],
+      quotes: [
+        "error",
+        "double",
+        {
+          avoidEscape: true,
+          allowTemplateLiterals: true,
+        },
+      ],
+      "playwright/no-conditional-in-test": "error",
+      "playwright/no-element-handle": "error",
+      "playwright/no-eval": "error",
+      "playwright/no-focused-test": "error",
+      "playwright/no-skipped-test": "warn",
+      "playwright/valid-expect": "error",
+      "playwright/no-useless-await": "error",
+      "playwright/require-top-level-describe": "error",
+      /**
+       * This suite drives a terminal, not a page. There is no locator to auto-retry against, so
+       * the web-first assertion rule has nothing to apply to, and settling the TUI between
+       * keystrokes is a real requirement rather than a smell.
+       */
+      "playwright/prefer-web-first-assertions": "off",
+      "playwright/no-wait-for-timeout": "off",
+    },
+  },
+];

--- a/tests/e2e-cli/fixtures/cli.ts
+++ b/tests/e2e-cli/fixtures/cli.ts
@@ -1,0 +1,57 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Fixtures for specs that run against the shared install.
+ *
+ * Each spec warm-starts its own CLI session rather than sharing one live process. A warm start
+ * costs a few seconds because the install already exists, and it buys real isolation: a spec that
+ * wedges the REPL cannot take the rest of the file down with it.
+ */
+
+import { test as base } from "@playwright/test";
+import { CliSession } from "../utils/cli-session";
+import { BrowserStub } from "../utils/browser-stub";
+import { useShared } from "./shared-install";
+import { freePort, waitForReady } from "../utils/ports";
+import { Timeouts } from "../constants/timeouts";
+
+export interface ReplFixture {
+  /** A session that has reached the REPL, with the server up. */
+  session: CliSession;
+  /** The port that session's server is listening on. */
+  port: number;
+}
+
+interface CliFixtures {
+  repl: ReplFixture;
+  browserStub: BrowserStub;
+}
+
+export const test = base.extend<CliFixtures>({
+  browserStub: async ({}, use) => {
+    const stub = BrowserStub.create();
+    await use(stub);
+    stub.remove();
+  },
+
+  repl: async ({}, use) => {
+    const workspace = useShared();
+    const session = new CliSession(workspace, [], { preconfigured: true });
+
+    await session.expect("ThunderID started on port", Timeouts.STARTUP);
+    const port = session.startedPort();
+    if (!(await waitForReady(port, Timeouts.SHORT))) {
+      throw new Error(`Server did not become ready on port ${port}`);
+    }
+
+    await use({ session, port });
+
+    // The CLI backgrounds the server, so disposing the session is not enough to release the port
+    // for the next spec.
+    await session.dispose();
+    await freePort(port);
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/tests/e2e-cli/fixtures/shared-install.ts
+++ b/tests/e2e-cli/fixtures/shared-install.ts
@@ -1,0 +1,56 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared install
+ *
+ * A distribution is ~85MB extracted and takes about ten seconds to download and set up, so the
+ * suite installs one and reuses it. The `install` project populates it; the `repl` and `restart`
+ * projects declare a dependency on that project and read it back here.
+ *
+ * The workspace lives at a fixed path rather than a temp directory precisely because it has to
+ * outlive the process that created it: Playwright runs each project in its own worker.
+ */
+
+import fs from "fs";
+import path from "path";
+import { Workspace } from "../utils/workspace";
+
+/** Where the shared install lives. Gitignored, and cleared by global setup on every run. */
+export function sharedRoot(): string {
+  return path.resolve(__dirname, "..", "test-results", "shared-install");
+}
+
+/** Creates the shared workspace. Called by the install spec before it installs anything. */
+export function createShared(): Workspace {
+  return Workspace.at(sharedRoot());
+}
+
+/**
+ * Reads back the workspace the install spec populated.
+ *
+ * Throws rather than silently installing again: a missing install means the dependency graph did
+ * not run the install project first, and quietly re-downloading would hide that.
+ */
+export function useShared(): Workspace {
+  const workspace = Workspace.at(sharedRoot());
+  const state = workspace.state();
+  if (!state.active) {
+    throw new Error(
+      `No shared install at ${sharedRoot()}. The install project has to run first; ` +
+        `run the whole suite rather than this spec on its own.`
+    );
+  }
+  return workspace;
+}
+
+/** The version the shared install is on. */
+export function sharedVersion(): string {
+  const active = useShared().state().active;
+  return active as string;
+}
+
+/** Removes the shared install. Called by global setup so every run starts clean. */
+export function clearShared(): void {
+  fs.rmSync(sharedRoot(), { recursive: true, force: true });
+}

--- a/tests/e2e-cli/global-setup.ts
+++ b/tests/e2e-cli/global-setup.ts
@@ -1,0 +1,71 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Global Setup
+ *
+ * Builds the host binary into the npx wrapper's dist directory. Without it the wrapper falls back
+ * to `go run` against a tools/npx/cli directory that only exists in the published package, so the
+ * specs would exercise a path users never take.
+ */
+
+import { execFile } from "child_process";
+import fs from "fs";
+import path from "path";
+import { promisify } from "util";
+import { clearShared } from "./fixtures/shared-install";
+import { localDistDir, startDistServer } from "./utils/release-source";
+import { publishedTag } from "./utils/cli-session";
+
+const execFileAsync = promisify(execFile);
+
+/** Mirrors the platform and architecture maps in tools/npx/bin/thunderid.js. */
+const PLATFORMS: Record<string, string> = { darwin: "darwin", linux: "linux" };
+const ARCHITECTURES: Record<string, string> = { x64: "x64", arm64: "arm64" };
+
+async function globalSetup() {
+  // The shared install is deliberately at a fixed path so it can outlive the worker that creates
+  // it, which also means a previous run's copy would otherwise be inherited.
+  clearShared();
+
+  const teardowns: Array<() => Promise<void>> = [];
+
+  // Serve a locally built distribution when one is configured, so the CLI installs the product
+  // from this checkout rather than from thunderid.dev.
+  const dist = localDistDir();
+  if (dist) {
+    teardowns.push(await startDistServer(dist));
+  }
+
+  const tag = publishedTag();
+  if (tag) {
+    // Nothing to build: this run drives the CLI as published, which is the point of the mode.
+    console.log(`📦 Driving the published CLI: npx thunderid@${tag}`);
+    return async () => {
+      for (const stop of teardowns) await stop();
+    };
+  }
+
+  console.log("🔧 Building the ThunderID CLI for the npx wrapper...");
+
+  const platform = PLATFORMS[process.platform];
+  const arch = ARCHITECTURES[process.arch];
+  if (!platform || !arch) {
+    throw new Error(`Unsupported platform: ${process.platform}/${process.arch}`);
+  }
+
+  const cliDir = path.resolve(__dirname, "..", "..", "tools", "cli");
+  const distDir = path.resolve(__dirname, "..", "..", "tools", "npx", "dist");
+  fs.mkdirSync(distDir, { recursive: true });
+
+  const binary = path.join(distDir, `thunderid-${platform}-${arch}`);
+  await execFileAsync("go", ["build", "-o", binary, "./cmd/thunderid"], { cwd: cliDir });
+
+  console.log(`✅ Built ${path.relative(process.cwd(), binary)}`);
+
+  return async () => {
+    for (const stop of teardowns) await stop();
+  };
+}
+
+export default globalSetup;

--- a/tests/e2e-cli/package.json
+++ b/tests/e2e-cli/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@thunderid/e2e-cli",
+  "version": "1.0.0",
+  "private": true,
+  "description": "End-to-end tests for the ThunderID CLI using Playwright",
+  "license": "Apache-2.0",
+  "author": "The ThunderID Authors",
+  "type": "commonjs",
+  "scripts": {
+    "postinstall": "node scripts/fix-node-pty-permissions.js",
+    "test": "playwright test",
+    "test:no-sample": "playwright test --project=commands --project=install --project=repl --project=restart --project=port-conflict",
+    "test:commands": "playwright test tests/commands",
+    "test:debug": "playwright test --debug",
+    "report": "playwright show-report",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write \"**/*.{ts,json,md}\"",
+    "format:check": "prettier --check \"**/*.{ts,json,md}\"",
+    "type-check": "tsc --noEmit"
+  },
+  "keywords": [
+    "e2e",
+    "testing",
+    "playwright",
+    "cli",
+    "thunderid"
+  ],
+  "devDependencies": {
+    "@playwright/test": "1.60.0",
+    "@types/node": "24.7.2",
+    "@typescript-eslint/eslint-plugin": "8.57.2",
+    "@typescript-eslint/parser": "8.57.2",
+    "eslint": "9.0.0",
+    "eslint-plugin-playwright": "2.1.0",
+    "prettier": "3.4.2",
+    "typescript": "5.7.3"
+  },
+  "dependencies": {
+    "node-pty": "1.1.0"
+  }
+}

--- a/tests/e2e-cli/pages/wayfinder.page.ts
+++ b/tests/e2e-cli/pages/wayfinder.page.ts
@@ -1,0 +1,68 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * A minimal page object for the Wayfinder sample and the ThunderID gate it logs in through.
+ *
+ * tests/e2e has richer page objects for the same screens, but this suite is a separate workspace
+ * package and reaching across that boundary would couple two independently installed dependency
+ * trees. The selectors here are deliberately the same ones, so the two stay recognisable:
+ * see tests/e2e/pages/wayfinder-sample/wayfinder-app.page.ts and pages/gate-login.page.ts.
+ */
+
+import { Page, expect } from "@playwright/test";
+import { Timeouts } from "../constants/timeouts";
+
+/** Where the CLI serves the sample. Fixed: the bundle's redirect URIs hardcode this origin. */
+export const WAYFINDER_URL = "http://localhost:5173";
+
+export class WayfinderPage {
+  constructor(private readonly page: Page) {}
+
+  async goto(): Promise<void> {
+    await this.page.goto(WAYFINDER_URL, { waitUntil: "domcontentloaded" });
+  }
+
+  /** Signs in through the gate and waits for the redirect back to the sample. */
+  async signIn(username: string, password: string): Promise<void> {
+    const signIn = this.page.getByRole("button", { name: /^sign in$/i });
+    await signIn.waitFor({ state: "visible", timeout: Timeouts.BROWSER });
+
+    // The sample is a freshly started Vite dev server, so the button is painted before React has
+    // attached its handler and an early click is silently dropped. Retry until the navigation to
+    // the gate actually happens rather than assuming the first click takes.
+    await expect(async () => {
+      await signIn.click();
+      // "commit" rather than the default "load": the gate redirects again to add
+      // showInsecureWarning, so the load event does not settle while the URL is already right.
+      await this.page.waitForURL(/\/gate\/signin/, { timeout: 10_000, waitUntil: "commit" });
+    }).toPass({ timeout: Timeouts.BROWSER });
+
+    const usernameInput = this.page.locator('input[name="username"], input[placeholder*="username" i]').first();
+    await usernameInput.waitFor({ state: "visible", timeout: Timeouts.BROWSER });
+    await usernameInput.fill(username);
+
+    const passwordInput = this.page.locator('input[name="password"], input[placeholder*="password" i]').first();
+    await passwordInput.fill(password);
+
+    const submit = this.page
+      .locator('button[type="submit"], button:has-text("Sign In"), button:has-text("Sign in")')
+      .first();
+
+    // Wait for the redirect off the gate as part of the click, so a rejected login fails here
+    // rather than later as a confusing missing-account-menu error.
+    await Promise.all([
+      this.page.waitForURL(url => url.origin === WAYFINDER_URL, {
+        timeout: Timeouts.BROWSER,
+        waitUntil: "commit",
+      }),
+      submit.click(),
+    ]);
+  }
+
+  /** The account menu only renders for a signed-in session. */
+  async expectSignedIn(): Promise<void> {
+    const accountMenu = this.page.locator('button[aria-haspopup="menu"]').first();
+    await expect(accountMenu).toBeVisible({ timeout: Timeouts.BROWSER });
+  }
+}

--- a/tests/e2e-cli/playwright.config.ts
+++ b/tests/e2e-cli/playwright.config.ts
@@ -1,0 +1,102 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Playwright configuration for the ThunderID CLI e2e suite.
+ *
+ * This suite drives a terminal, so most projects define no browser. It also starts no web server:
+ * the CLI is the thing that installs and starts ThunderID, and it has to find the default port
+ * free to do it. That is why it cannot share tests/e2e's configuration, whose `webServer` boots a
+ * backend on 8090 before the first test runs.
+ *
+ * @see https://playwright.dev/docs/test-configuration
+ */
+
+import { defineConfig, devices } from "@playwright/test";
+import { Timeouts } from "./constants/timeouts";
+
+export default defineConfig({
+  testDir: "./tests",
+
+  /**
+   * Strictly serial. Every spec outside tests/commands binds the default port or deliberately
+   * holds it, so two running at once would fight over it. This is a property of what is under
+   * test, not a tuning knob.
+   */
+  fullyParallel: false,
+  workers: 1,
+
+  forbidOnly: !!process.env.CI,
+
+  /**
+   * No retries. A retry would re-run setup or re-download a distribution, and the failures this
+   * suite catches (a hung prompt, a port left held) are exactly the ones a retry would mask.
+   */
+  retries: 0,
+
+  reporter: [["list"], ["html", { open: "never" }], ["blob"], ["junit", { outputFile: "test-results/junit.xml" }]],
+
+  /** Generous by default; the specs that install raise it further with test.setTimeout(). */
+  timeout: Timeouts.STARTUP,
+
+  expect: {
+    timeout: Timeouts.SHORT,
+  },
+
+  globalSetup: require.resolve("./global-setup"),
+
+  /**
+   * A distribution is ~85MB extracted, so the suite installs one and reuses it. `install`
+   * populates the shared workspace and everything downstream declares a dependency on it, which
+   * is both the ordering mechanism and the reason those projects can warm-start in seconds.
+   *
+   * Only two projects download: `install`, and the first-run case in `port-conflict`, which needs
+   * an install that setup has not yet pinned to a port.
+   */
+  projects: [
+    {
+      // No install and no network: these assert the argument surface that returns early.
+      name: "commands",
+      testMatch: "**/commands/*.spec.ts",
+    },
+    {
+      name: "install",
+      testMatch: "**/install/*.spec.ts",
+    },
+    {
+      name: "repl",
+      testMatch: "**/repl/*.spec.ts",
+      dependencies: ["install"],
+    },
+    {
+      name: "restart",
+      testMatch: "**/restart/*.spec.ts",
+      dependencies: ["install"],
+    },
+    {
+      name: "port-conflict",
+      testMatch: "**/port-conflict/*.spec.ts",
+      dependencies: ["install"],
+    },
+    {
+      /**
+       * The only project with a browser, and the only destructive one: `try` rewrites the
+       * install's declarative resources and restarts the server. It depends on every other
+       * project that touches the shared install so it runs strictly after them.
+       */
+      name: "sample",
+      testMatch: "**/sample/*.spec.ts",
+      dependencies: ["install", "repl", "restart", "port-conflict"],
+      use: {
+        ...devices["Desktop Chrome"],
+        // The gate serves TLS with a self-signed certificate, exactly as the CLI's own probes
+        // assume.
+        ignoreHTTPSErrors: true,
+        // This spec is slow and depends on a lot of moving parts, so a failure has to carry
+        // enough to diagnose it without reproducing the whole run.
+        screenshot: "only-on-failure",
+        trace: "retain-on-failure",
+      },
+    },
+  ],
+});

--- a/tests/e2e-cli/pnpm-lock.yaml
+++ b/tests/e2e-cli/pnpm-lock.yaml
@@ -1,0 +1,1043 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      node-pty:
+        specifier: 1.1.0
+        version: 1.1.0
+    devDependencies:
+      '@playwright/test':
+        specifier: 1.60.0
+        version: 1.60.0
+      '@types/node':
+        specifier: 24.7.2
+        version: 24.7.2
+      '@typescript-eslint/eslint-plugin':
+        specifier: 8.57.2
+        version: 8.57.2(@typescript-eslint/parser@8.57.2(eslint@9.0.0)(typescript@5.7.3))(eslint@9.0.0)(typescript@5.7.3)
+      '@typescript-eslint/parser':
+        specifier: 8.57.2
+        version: 8.57.2(eslint@9.0.0)(typescript@5.7.3)
+      eslint:
+        specifier: 9.0.0
+        version: 9.0.0
+      eslint-plugin-playwright:
+        specifier: 2.1.0
+        version: 2.1.0(eslint@9.0.0)
+      prettier:
+        specifier: 3.4.2
+        version: 3.4.2
+      typescript:
+        specifier: 5.7.3
+        version: 5.7.3
+
+packages:
+
+  '@eslint-community/eslint-utils@4.10.1':
+    resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/eslintrc@3.3.6':
+    resolution: {integrity: sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.0.0':
+    resolution: {integrity: sha512-RThY/MnKrhubF6+s1JflwUjPEsnCEmYCWwqa/aRISKWNXGZ9epUwft4bUMM35SdKF9xvBrLydAM1RDHd1Z//ZQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@humanwhocodes/config-array@0.12.3':
+    resolution: {integrity: sha512-jsNnTBlMWuTpDkeE3on7+dWJi0D6fdDfeANj/w7MpS8ztROCoLvIO2nG0CcFj+E4k8j4QrSTh4Oryi3i2G669g==}
+    engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/object-schema@2.0.3':
+    resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
+    deprecated: Use @eslint/object-schema instead
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@types/node@24.7.2':
+    resolution: {integrity: sha512-/NbVmcGTP+lj5oa4yiYxxeBjRivKQ5Ns1eSZeB99ExsEQ6rX5XYU1Zy/gGxY/ilqtD4Etx9mKyrPxZRetiahhA==}
+
+  '@typescript-eslint/eslint-plugin@8.57.2':
+    resolution: {integrity: sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.57.2
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/parser@8.57.2':
+    resolution: {integrity: sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/project-service@8.57.2':
+    resolution: {integrity: sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/scope-manager@8.57.2':
+    resolution: {integrity: sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.57.2':
+    resolution: {integrity: sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/type-utils@8.57.2':
+    resolution: {integrity: sha512-Co6ZCShm6kIbAM/s+oYVpKFfW7LBc6FXoPXjTRQ449PPNBY8U0KZXuevz5IFuuUj2H9ss40atTaf9dlGLzbWZg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/types@8.57.2':
+    resolution: {integrity: sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.57.2':
+    resolution: {integrity: sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/utils@8.57.2':
+    resolution: {integrity: sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/visitor-keys@8.57.2':
+    resolution: {integrity: sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-plugin-playwright@2.1.0:
+    resolution: {integrity: sha512-wMbHOehofSB1cBdzz2CLaCYaKNLeTQ0YnOW+7AHa281TJqlpEJUBgTHbRUYOUxiXphfWwOyTPvgr6vvEmArbSA==}
+    engines: {node: '>=16.6.0'}
+    peerDependencies:
+      eslint: '>=8.40.0'
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@9.0.0:
+    resolution: {integrity: sha512-IMryZ5SudxzQvuod6rUdIUz29qFItWx281VhtFVc2Psy/ZhlCeD/5DT6lBIJ4H3G+iamGJoTln1v+QSuPw0p7Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
+    hasBin: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.4:
+    resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  globals@13.24.0:
+    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
+    engines: {node: '>=8'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  graphemer@1.4.0:
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.6:
+    resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-path-inside@3.0.3:
+    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
+    engines: {node: '>=8'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
+    engines: {node: '>=12'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  prettier@3.4.2:
+    resolution: {integrity: sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  text-table@0.2.0:
+    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  type-fest@0.20.2:
+    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
+
+  typescript@5.7.3:
+    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.14.0:
+    resolution: {integrity: sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+snapshots:
+
+  '@eslint-community/eslint-utils@4.10.1(eslint@9.0.0)':
+    dependencies:
+      eslint: 9.0.0
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/eslintrc@3.3.6':
+    dependencies:
+      ajv: 6.15.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.3.2
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.0.0': {}
+
+  '@humanwhocodes/config-array@0.12.3':
+    dependencies:
+      '@humanwhocodes/object-schema': 2.0.3
+      debug: 4.4.3
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
+  '@types/node@24.7.2':
+    dependencies:
+      undici-types: 7.14.0
+
+  '@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@9.0.0)(typescript@5.7.3))(eslint@9.0.0)(typescript@5.7.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.57.2(eslint@9.0.0)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.57.2
+      '@typescript-eslint/type-utils': 8.57.2(eslint@9.0.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.57.2(eslint@9.0.0)(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.57.2
+      eslint: 9.0.0
+      ignore: 7.0.6
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.57.2(eslint@9.0.0)(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.57.2
+      '@typescript-eslint/types': 8.57.2
+      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.57.2
+      debug: 4.4.3
+      eslint: 9.0.0
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.57.2(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.57.2(typescript@5.7.3)
+      '@typescript-eslint/types': 8.57.2
+      debug: 4.4.3
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.57.2':
+    dependencies:
+      '@typescript-eslint/types': 8.57.2
+      '@typescript-eslint/visitor-keys': 8.57.2
+
+  '@typescript-eslint/tsconfig-utils@8.57.2(typescript@5.7.3)':
+    dependencies:
+      typescript: 5.7.3
+
+  '@typescript-eslint/type-utils@8.57.2(eslint@9.0.0)(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.57.2
+      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.57.2(eslint@9.0.0)(typescript@5.7.3)
+      debug: 4.4.3
+      eslint: 9.0.0
+      ts-api-utils: 2.5.0(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.57.2': {}
+
+  '@typescript-eslint/typescript-estree@8.57.2(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.57.2(typescript@5.7.3)
+      '@typescript-eslint/tsconfig-utils': 8.57.2(typescript@5.7.3)
+      '@typescript-eslint/types': 8.57.2
+      '@typescript-eslint/visitor-keys': 8.57.2
+      debug: 4.4.3
+      minimatch: 10.2.6
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.57.2(eslint@9.0.0)(typescript@5.7.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@9.0.0)
+      '@typescript-eslint/scope-manager': 8.57.2
+      '@typescript-eslint/types': 8.57.2
+      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.7.3)
+      eslint: 9.0.0
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.57.2':
+    dependencies:
+      '@typescript-eslint/types': 8.57.2
+      eslint-visitor-keys: 5.0.1
+
+  acorn-jsx@5.3.2(acorn@8.18.0):
+    dependencies:
+      acorn: 8.18.0
+
+  acorn@8.18.0: {}
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  argparse@2.0.1: {}
+
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  brace-expansion@1.1.18:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@5.0.9:
+    dependencies:
+      balanced-match: 4.0.4
+
+  callsites@3.1.0: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  concat-map@0.0.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-is@0.1.4: {}
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-plugin-playwright@2.1.0(eslint@9.0.0):
+    dependencies:
+      eslint: 9.0.0
+      globals: 13.24.0
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@9.0.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@9.0.0)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/eslintrc': 3.3.6
+      '@eslint/js': 9.0.0
+      '@humanwhocodes/config-array': 0.12.3
+      '@humanwhocodes/module-importer': 1.0.1
+      '@nodelib/fs.walk': 1.2.8
+      ajv: 6.15.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      is-path-inside: 3.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+      strip-ansi: 6.0.1
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
+      eslint-visitor-keys: 4.2.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  esutils@2.0.3: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fdir@6.5.0(picomatch@4.0.7):
+    optionalDependencies:
+      picomatch: 4.0.7
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.4
+      keyv: 4.5.4
+
+  flatted@3.4.4: {}
+
+  fsevents@2.3.2:
+    optional: true
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globals@13.24.0:
+    dependencies:
+      type-fest: 0.20.2
+
+  globals@14.0.0: {}
+
+  graphemer@1.4.0: {}
+
+  has-flag@4.0.0: {}
+
+  ignore@5.3.2: {}
+
+  ignore@7.0.6: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-path-inside@3.0.3: {}
+
+  isexe@2.0.0: {}
+
+  js-yaml@4.3.2:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.18
+
+  ms@2.1.3: {}
+
+  natural-compare@1.4.0: {}
+
+  node-addon-api@7.1.1: {}
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  picomatch@4.0.7: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  prelude-ls@1.2.1: {}
+
+  prettier@3.4.2: {}
+
+  punycode@2.3.1: {}
+
+  queue-microtask@1.2.3: {}
+
+  resolve-from@4.0.0: {}
+
+  reusify@1.1.0: {}
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  semver@7.8.5: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-json-comments@3.1.1: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  text-table@0.2.0: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
+
+  ts-api-utils@2.5.0(typescript@5.7.3):
+    dependencies:
+      typescript: 5.7.3
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  type-fest@0.20.2: {}
+
+  typescript@5.7.3: {}
+
+  undici-types@7.14.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  word-wrap@1.2.5: {}
+
+  yocto-queue@0.1.0: {}

--- a/tests/e2e-cli/pnpm-workspace.yaml
+++ b/tests/e2e-cli/pnpm-workspace.yaml
@@ -1,0 +1,16 @@
+# Marks this directory as its own pnpm workspace root, which stops pnpm walking up to the
+# repository's workspace.
+#
+# This suite is kept out of the main workspace on purpose. It depends on node-pty, which ships no
+# Linux prebuild and therefore compiles with node-gyp. As a member of the root workspace it would
+# force every job that runs `pnpm install --frozen-lockfile` to build a native addon, and the jobs
+# running in minimal containers have no toolchain, so they fail outright on "not found: make".
+#
+# Nothing here is shared with the rest of the repo, so the isolation costs only this file and a
+# second lockfile.
+packages: []
+
+# node-pty has to run its install script to produce the addon. Without this pnpm skips it and
+# every pty.spawn fails at runtime.
+allowBuilds:
+  node-pty: true

--- a/tests/e2e-cli/scripts/fix-node-pty-permissions.js
+++ b/tests/e2e-cli/scripts/fix-node-pty-permissions.js
@@ -1,0 +1,39 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Restores the executable bit on node-pty's spawn-helper.
+ *
+ * node-pty ships prebuilt binaries, and the extraction into the pnpm store drops the mode bits on
+ * `spawn-helper`. The native addon then loads fine but every pty.spawn() fails with the opaque
+ * "posix_spawnp failed", because the helper it execs is not executable. Without this the whole
+ * suite fails on a fresh install.
+ *
+ * Not needed on Windows, which uses conpty rather than a helper binary.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+if (process.platform === "win32") process.exit(0);
+
+let packageDir;
+try {
+  packageDir = path.dirname(require.resolve("node-pty/package.json"));
+} catch {
+  // node-pty is absent (a lint- or type-check-only install), so there is nothing to fix.
+  process.exit(0);
+}
+
+const candidates = [
+  path.join(packageDir, "prebuilds", `${process.platform}-${process.arch}`, "spawn-helper"),
+  path.join(packageDir, "build", "Release", "spawn-helper"),
+];
+
+for (const helper of candidates) {
+  if (!fs.existsSync(helper)) continue;
+  const mode = fs.statSync(helper).mode;
+  if (mode & 0o111) continue;
+  fs.chmodSync(helper, 0o755);
+  console.log(`node-pty: restored the executable bit on ${path.relative(process.cwd(), helper)}`);
+}

--- a/tests/e2e-cli/tests/commands/help.spec.ts
+++ b/tests/e2e-cli/tests/commands/help.spec.ts
@@ -1,0 +1,40 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/** The usage output. Needs no install and no network. */
+
+import { test, expect } from "@playwright/test";
+import { CliSession } from "../../utils/cli-session";
+import { Workspace } from "../../utils/workspace";
+
+test.describe("thunderid --help", () => {
+  let workspace: Workspace;
+  let session: CliSession;
+
+  test.beforeEach(() => {
+    workspace = Workspace.create();
+  });
+
+  test.afterEach(async () => {
+    await session?.dispose();
+    workspace.remove();
+  });
+
+  for (const flag of ["--help", "-h"]) {
+    test(`${flag} lists the available commands`, async () => {
+      session = new CliSession(workspace, [flag]);
+
+      expect(await session.waitForExit()).toBe(0);
+
+      for (const phrase of [
+        "Usage: thunderid [command] [flags]",
+        "upgrade Upgrade to the latest release",
+        "try <usecase> Download and launch a use-case sample app",
+        "--verbose, -v",
+        "--setup",
+      ]) {
+        expect(session.output, `help output should mention ${JSON.stringify(phrase)}`).toContain(phrase);
+      }
+    });
+  }
+});

--- a/tests/e2e-cli/tests/commands/integrate.spec.ts
+++ b/tests/e2e-cli/tests/commands/integrate.spec.ts
@@ -1,0 +1,29 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/** The integrate command is a declared but unimplemented entry point. */
+
+import { test, expect } from "@playwright/test";
+import { CliSession } from "../../utils/cli-session";
+import { Workspace } from "../../utils/workspace";
+
+test.describe("thunderid integrate", () => {
+  let workspace: Workspace;
+  let session: CliSession;
+
+  test.beforeEach(() => {
+    workspace = Workspace.create();
+  });
+
+  test.afterEach(async () => {
+    await session?.dispose();
+    workspace.remove();
+  });
+
+  test("reports that it is not implemented", async () => {
+    session = new CliSession(workspace, ["integrate", "react"]);
+
+    await session.expect("`integrate react` is not yet implemented.");
+    expect(await session.waitForExit()).toBe(1);
+  });
+});

--- a/tests/e2e-cli/tests/commands/product-version.spec.ts
+++ b/tests/e2e-cli/tests/commands/product-version.spec.ts
@@ -1,0 +1,64 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * --product-version selects the release to install and where to read releases from.
+ *
+ * Only the rejection paths are covered here: they need no install and no network, and getting
+ * them wrong is what would let a typo silently install the wrong thing. The accepting paths are
+ * exercised for real by the product and release lanes, which run the whole suite against a
+ * locally served distribution through this same flag.
+ */
+
+import { test, expect } from "@playwright/test";
+import { CliSession, publishedTag } from "../../utils/cli-session";
+import { Workspace } from "../../utils/workspace";
+
+test.describe("thunderid --product-version", () => {
+  // The published CLI predates the flag, so asserting it there would fail for the wrong reason.
+  // This is conditional on which CLI is under test, not a parked test.
+  // eslint-disable-next-line playwright/no-skipped-test
+  test.skip(publishedTag() !== null, "the flag is newer than the published CLI");
+
+  let workspace: Workspace;
+  let session: CliSession;
+
+  test.beforeEach(() => {
+    workspace = Workspace.create();
+  });
+
+  test.afterEach(async () => {
+    await session?.dispose();
+    workspace.remove();
+  });
+
+  test("is documented in the usage output", async () => {
+    session = new CliSession(workspace, ["--help"]);
+
+    expect(await session.waitForExit()).toBe(0);
+    expect(session.output).toContain("--product-version");
+    expect(session.output, "the help should show both value shapes").toContain("https://example.com/releases.json");
+  });
+
+  test("rejects a value that is neither a version nor a URL", async () => {
+    session = new CliSession(workspace, ["--product-version", "latest"]);
+
+    await session.expect("neither a version nor a URL");
+    expect(await session.waitForExit()).toBe(1);
+  });
+
+  // Releases are executable, so a cleartext remote source is refused rather than warned about.
+  test("rejects a remote http source", async () => {
+    session = new CliSession(workspace, ["--product-version", "http://releases.example.com/releases.json"]);
+
+    await session.expect("plain http");
+    expect(await session.waitForExit()).toBe(1);
+  });
+
+  test("refuses to upgrade while pinned to a version", async () => {
+    session = new CliSession(workspace, ["upgrade", "--product-version", "1.0.1"]);
+
+    await session.expect("cannot run with a pinned --product-version");
+    expect(await session.waitForExit()).toBe(1);
+  });
+});

--- a/tests/e2e-cli/tests/commands/try.spec.ts
+++ b/tests/e2e-cli/tests/commands/try.spec.ts
@@ -1,0 +1,32 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/** The try command's refusal path. Launching a sample is covered in tests/sample. */
+
+import { test, expect } from "@playwright/test";
+import { CliSession } from "../../utils/cli-session";
+import { Workspace } from "../../utils/workspace";
+
+test.describe("thunderid try", () => {
+  let workspace: Workspace;
+  let session: CliSession;
+
+  test.beforeEach(() => {
+    workspace = Workspace.create();
+  });
+
+  test.afterEach(async () => {
+    await session?.dispose();
+    workspace.remove();
+  });
+
+  // With no install there is nothing to launch, and the message has to point at the command that
+  // creates one rather than failing deeper inside the sample runner.
+  test("without an install it directs the user to install first", async () => {
+    session = new CliSession(workspace, ["try", "consumer"]);
+
+    await session.expect("No active ThunderID install found. Run `npx thunderid` first.");
+    expect(await session.waitForExit()).toBe(1);
+    expect(workspace.state().active, "a failed try must not record state").toBeUndefined();
+  });
+});

--- a/tests/e2e-cli/tests/commands/version.spec.ts
+++ b/tests/e2e-cli/tests/commands/version.spec.ts
@@ -1,0 +1,45 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/** The version output. Needs no install and no network. */
+
+import { test, expect } from "@playwright/test";
+import { CliSession } from "../../utils/cli-session";
+import { Workspace } from "../../utils/workspace";
+
+test.describe("thunderid --version", () => {
+  let workspace: Workspace;
+  let session: CliSession;
+
+  test.beforeEach(() => {
+    workspace = Workspace.create();
+  });
+
+  test.afterEach(async () => {
+    await session?.dispose();
+    workspace.remove();
+  });
+
+  for (const flag of ["--version", "-V"]) {
+    test(`${flag} prints the CLI version and exits`, async () => {
+      session = new CliSession(workspace, [flag]);
+
+      expect(await session.waitForExit()).toBe(0);
+      expect(session.output.trim()).toMatch(/^thunderid \S+$/);
+    });
+  }
+
+  test("takes precedence over a command", async () => {
+    session = new CliSession(workspace, ["upgrade", "--version"]);
+
+    expect(await session.waitForExit()).toBe(0);
+    expect(session.output.trim()).toMatch(/^thunderid \S+$/);
+  });
+
+  test("is documented in the usage output", async () => {
+    session = new CliSession(workspace, ["--help"]);
+
+    expect(await session.waitForExit()).toBe(0);
+    expect(session.output).toContain("--version, -V");
+  });
+});

--- a/tests/e2e-cli/tests/install/first-run.spec.ts
+++ b/tests/e2e-cli/tests/install/first-run.spec.ts
@@ -1,0 +1,62 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The first run: fetch the manifest, download and extract a release, run setup.sh, start the
+ * server.
+ *
+ * This is the only spec that downloads a distribution. It populates the shared workspace that the
+ * repl, restart and sample projects then reuse, which is why they declare a dependency on this
+ * project rather than installing their own copy.
+ */
+
+import { test, expect } from "@playwright/test";
+import fs from "fs";
+import path from "path";
+import { CliSession } from "../../utils/cli-session";
+import { createShared } from "../../fixtures/shared-install";
+import { DEFAULT_PORT, freePort, requirePortFree, waitForReady } from "../../utils/ports";
+import { Timeouts } from "../../constants/timeouts";
+
+test.describe("first run", () => {
+  test("installs, sets up and starts ThunderID", async () => {
+    test.setTimeout(Timeouts.INSTALL_TEST);
+
+    await requirePortFree(DEFAULT_PORT);
+    const workspace = createShared();
+    const session = new CliSession(workspace, [], { preconfigured: true });
+
+    try {
+      await session.expect("Latest ThunderID release: v", Timeouts.INSTALL);
+      await session.expect("installed to", Timeouts.INSTALL);
+      await session.expect("Setup complete", Timeouts.INSTALL);
+      await session.expect("ThunderID started on port", Timeouts.STARTUP);
+
+      const port = session.startedPort();
+      expect(port, "a first run with a free default port should bind it").toBe(DEFAULT_PORT);
+      expect(await waitForReady(port), `server should answer readiness\n\n${session.tail(40)}`).toBe(true);
+
+      const state = workspace.state();
+      expect(state.active, "state.json should record an active version").toBeTruthy();
+      const version = state.active as string;
+
+      const recorded = state.versions?.[version];
+      expect(recorded?.setupComplete).toBe(true);
+      expect(recorded?.installPath, "an install path should be recorded").toBeTruthy();
+      expect(path.isAbsolute(recorded!.installPath!), "the install path should be absolute").toBe(true);
+
+      // The recorded path has to be the one on disk, since later runs start what it points at
+      // rather than re-deriving the location.
+      for (const name of ["setup.sh", "start.sh", "deployment.yaml"]) {
+        expect(fs.existsSync(path.join(recorded!.installPath!, name)), `${name} should be in the install`).toBe(true);
+      }
+
+      // Leave the port free for the projects that depend on this one. The install itself stays on
+      // disk: that is the artifact they reuse.
+      await session.shutdown(port);
+    } finally {
+      await session.dispose();
+      await freePort(DEFAULT_PORT);
+    }
+  });
+});

--- a/tests/e2e-cli/tests/port-conflict/abort.spec.ts
+++ b/tests/e2e-cli/tests/port-conflict/abort.spec.ts
@@ -1,0 +1,38 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * A configured install cannot be moved: setup seeded the console application's redirect URIs with
+ * its port, so serving the console anywhere else would leave a login that cannot complete. The
+ * only answers are to reclaim the port or to abort.
+ */
+
+import { test, expect } from "@playwright/test";
+import { CliSession, Keys } from "../../utils/cli-session";
+import { useShared } from "../../fixtures/shared-install";
+import { DEFAULT_PORT, PortHolder } from "../../utils/ports";
+import { Timeouts } from "../../constants/timeouts";
+
+test.describe("port conflict on a configured install", () => {
+  test("refuses to move and can be aborted", async () => {
+    const holder = await PortHolder.start(DEFAULT_PORT);
+    const session = new CliSession(useShared(), [], { preconfigured: true });
+
+    try {
+      await session.expect("is already in use", Timeouts.STARTUP);
+      await session.expect("This install is already set up on port");
+      await session.expect("cannot be moved");
+      await session.expect("Abort");
+
+      // With no alternate offered the options are kill and abort, so abort is second.
+      await session.send(Keys.DOWN, Keys.ENTER);
+
+      expect(await session.waitForExit(), "aborting is a choice, not a failure").toBe(0);
+      expect(holder.alive, "aborting must not kill the holder").toBe(true);
+      expect(await session.waitFor("ThunderID started on port", 0), "aborting must not start the server").toBe(false);
+    } finally {
+      await session.dispose();
+      await holder.stop();
+    }
+  });
+});

--- a/tests/e2e-cli/tests/port-conflict/alternate-port.spec.ts
+++ b/tests/e2e-cli/tests/port-conflict/alternate-port.spec.ts
@@ -1,0 +1,50 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * A first run finding the default port taken can be moved, because setup has not yet seeded the
+ * console's redirect URIs with a port.
+ *
+ * This is the one spec outside install/ that downloads a distribution: being movable is a
+ * property of a *first* run, so it cannot reuse the shared install, which is already configured.
+ */
+
+import { test, expect } from "@playwright/test";
+import { CliSession, Keys } from "../../utils/cli-session";
+import { Workspace } from "../../utils/workspace";
+import { DEFAULT_PORT, PortHolder, releasePortIfBound, requirePortFree, waitForReady } from "../../utils/ports";
+import { Timeouts } from "../../constants/timeouts";
+
+test.describe("port conflict on a first run", () => {
+  test("moves to an alternate port and leaves the holder alone", async () => {
+    test.setTimeout(Timeouts.INSTALL_TEST);
+
+    await requirePortFree(DEFAULT_PORT);
+    const workspace = Workspace.create();
+    const holder = await PortHolder.start(DEFAULT_PORT);
+    const session = new CliSession(workspace, [], { preconfigured: true });
+    let port = 0;
+
+    try {
+      await session.expect(`Port ${DEFAULT_PORT} is already in use`, Timeouts.INSTALL);
+      await session.expect("How would you like to proceed?");
+
+      // The alternate is the second option, after "kill the process".
+      await session.expect("instead");
+      await session.send(Keys.DOWN, Keys.ENTER);
+
+      await session.expect("Setup complete", Timeouts.INSTALL);
+      await session.expect("ThunderID started on port", Timeouts.STARTUP);
+
+      port = session.startedPort();
+      expect(port, "choosing the alternate must not bind the contested port").not.toBe(DEFAULT_PORT);
+      expect(holder.alive, "choosing the alternate must leave the holder running").toBe(true);
+      expect(await waitForReady(port), `no readiness on the alternate port\n\n${session.tail(40)}`).toBe(true);
+    } finally {
+      await session.dispose();
+      await releasePortIfBound(port);
+      await holder.stop();
+      workspace.remove();
+    }
+  });
+});

--- a/tests/e2e-cli/tests/port-conflict/reclaim.spec.ts
+++ b/tests/e2e-cli/tests/port-conflict/reclaim.spec.ts
@@ -1,0 +1,34 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/** Reclaiming the port has to actually stop the holder before the server binds. */
+
+import { test, expect } from "@playwright/test";
+import { CliSession, Keys } from "../../utils/cli-session";
+import { useShared } from "../../fixtures/shared-install";
+import { DEFAULT_PORT, PortHolder, freePort, waitForReady } from "../../utils/ports";
+import { Timeouts } from "../../constants/timeouts";
+
+test.describe("reclaiming a contested port", () => {
+  test("stops the holder and binds the port", async () => {
+    const holder = await PortHolder.start(DEFAULT_PORT);
+    const session = new CliSession(useShared(), [], { preconfigured: true });
+
+    try {
+      await session.expect("is already in use", Timeouts.STARTUP);
+      await session.expect("and continue");
+
+      // The kill option is preselected.
+      await session.send(Keys.ENTER);
+
+      await session.expect("ThunderID started on port", Timeouts.STARTUP);
+      expect(session.startedPort()).toBe(DEFAULT_PORT);
+      expect(holder.alive, "the holder should have been stopped").toBe(false);
+      expect(await waitForReady(DEFAULT_PORT), `no readiness on the reclaimed port\n\n${session.tail(40)}`).toBe(true);
+    } finally {
+      await session.dispose();
+      await freePort(DEFAULT_PORT);
+      await holder.stop();
+    }
+  });
+});

--- a/tests/e2e-cli/tests/repl/integrate.spec.ts
+++ b/tests/e2e-cli/tests/repl/integrate.spec.ts
@@ -1,0 +1,21 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * /integrate-<platform> fetches that platform's guide from the docs site and renders it in the
+ * REPL. This reaches thunderid.dev, the same host the release manifest comes from.
+ */
+
+import { test, expect } from "../../fixtures/cli";
+import { Timeouts } from "../../constants/timeouts";
+
+test.describe("REPL /integrate", () => {
+  test("loads the React guide", async ({ repl }) => {
+    await repl.session.runSlash("/integrate-react");
+
+    await repl.session.expect("React", Timeouts.REMOTE);
+    // The command reports a fetch failure inline rather than erroring out, so a broken docs URL
+    // would otherwise render as a passing test.
+    expect(repl.session.output, "the guide should have loaded").not.toContain("Could not load");
+  });
+});

--- a/tests/e2e-cli/tests/repl/logs.spec.ts
+++ b/tests/e2e-cli/tests/repl/logs.spec.ts
@@ -1,0 +1,20 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/** /logs tails the server log inside the REPL until Esc. */
+
+import { test } from "../../fixtures/cli";
+import { Keys } from "../../utils/cli-session";
+
+test.describe("REPL /logs", () => {
+  test("follows the log and returns to the prompt on Esc", async ({ repl }) => {
+    await repl.session.runSlash("/logs");
+    await repl.session.expect("Following logs");
+
+    repl.session.reset();
+    await repl.session.send(Keys.ESC);
+
+    // Leaving the follower restores the ordinary prompt rather than exiting the REPL.
+    await repl.session.expect("Type / for commands");
+  });
+});

--- a/tests/e2e-cli/tests/repl/onboarding.spec.ts
+++ b/tests/e2e-cli/tests/repl/onboarding.spec.ts
@@ -1,0 +1,25 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/** The first-run use-case picker the REPL opens on, and the command overlay it offers. */
+
+import { test, expect } from "../../fixtures/cli";
+
+test.describe("REPL onboarding", () => {
+  // Both halves share one session on purpose: each spec in this project starts and stops a real
+  // server, so splitting assertions that read the same screen would double that cost for nothing.
+  //
+  // The picker is gated on onboardingDone, which config only records when a use case is actually
+  // selected (see ui.selectOnboarding). No spec here selects one, so it is still showing.
+  test("opens on the use-case picker and offers the commands", async ({ repl }) => {
+    await repl.session.expect("What would you like to try?");
+    await repl.session.expect("Secured Web Application");
+    await repl.session.expect("Secured AI Agent");
+
+    await repl.session.openCommandOverlay();
+
+    expect(repl.session.output).toContain("/try-consumer");
+    expect(repl.session.output).toContain("/integrate-react");
+    expect(repl.session.output).toContain("Follow recent server logs");
+  });
+});

--- a/tests/e2e-cli/tests/repl/open-console.spec.ts
+++ b/tests/e2e-cli/tests/repl/open-console.spec.ts
@@ -1,0 +1,46 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * /open-console hands the console URL to the system browser.
+ *
+ * utils.OpenBrowser shells out to `open` or `xdg-open` with no suppression hook, so the session
+ * runs with a recording stub earlier on PATH. Nothing opens, and the URL the CLI chose becomes
+ * assertable, which is the part of the command worth testing.
+ */
+
+import { test, expect } from "@playwright/test";
+import { CliSession } from "../../utils/cli-session";
+import { BrowserStub } from "../../utils/browser-stub";
+import { useShared } from "../../fixtures/shared-install";
+import { releasePortIfBound, waitForReady } from "../../utils/ports";
+import { Timeouts } from "../../constants/timeouts";
+
+test.describe("REPL /open-console", () => {
+  test("opens the console URL for the port in use", async () => {
+    const stub = BrowserStub.create();
+    const session = new CliSession(useShared(), [], { preconfigured: true, pathPrefix: stub.binDir });
+    let port = 0;
+
+    try {
+      await session.expect("ThunderID started on port", Timeouts.STARTUP);
+      port = session.startedPort();
+      if (!(await waitForReady(port, Timeouts.SHORT))) {
+        throw new Error(`Server did not become ready on port ${port}`);
+      }
+
+      await session.runSlash("/open-console");
+      await session.expect("Opening");
+
+      // OpenBrowser uses cmd.Start() rather than Run, so the CLI does not wait for the opener
+      // and neither can the assertion.
+      await expect
+        .poll(() => stub.openedUrls(), { timeout: Timeouts.SHORT })
+        .toEqual([expect.stringContaining(`:${port}/console`)]);
+    } finally {
+      await session.dispose();
+      await releasePortIfBound(port);
+      stub.remove();
+    }
+  });
+});

--- a/tests/e2e-cli/tests/repl/status.spec.ts
+++ b/tests/e2e-cli/tests/repl/status.spec.ts
@@ -1,0 +1,18 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/** /status reports whether the server this session started is answering. */
+
+import { test, expect } from "../../fixtures/cli";
+
+test.describe("REPL /status", () => {
+  test("reports the running server and its console URL", async ({ repl }) => {
+    await repl.session.runSlash("/status");
+
+    await repl.session.expect("ThunderID is running at");
+    await repl.session.expect("Console:");
+    // The URL has to carry the port this session actually bound, since that is what a user would
+    // click, and a stale port would send them to nothing.
+    expect(repl.session.output).toContain(`:${repl.port}/console`);
+  });
+});

--- a/tests/e2e-cli/tests/repl/stop.spec.ts
+++ b/tests/e2e-cli/tests/repl/stop.spec.ts
@@ -1,0 +1,18 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/** /stop takes the server down and ends the session. */
+
+import { test, expect } from "../../fixtures/cli";
+import { isPortInUse } from "../../utils/ports";
+import { Timeouts } from "../../constants/timeouts";
+
+test.describe("REPL /stop", () => {
+  test("shuts the server down and exits", async ({ repl }) => {
+    await repl.session.runSlash("/stop");
+    await repl.session.expect("ThunderID stopped.", Timeouts.STARTUP);
+
+    expect(await isPortInUse(repl.port), `port ${repl.port} should be released by /stop`).toBe(false);
+    expect(await repl.session.exitRepl()).toBe(0);
+  });
+});

--- a/tests/e2e-cli/tests/restart/force-setup.spec.ts
+++ b/tests/e2e-cli/tests/restart/force-setup.spec.ts
@@ -1,0 +1,29 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/** --setup re-runs setup against an install that already exists. */
+
+import { test, expect } from "@playwright/test";
+import { CliSession } from "../../utils/cli-session";
+import { useShared } from "../../fixtures/shared-install";
+import { DEFAULT_PORT, freePort } from "../../utils/ports";
+import { Timeouts } from "../../constants/timeouts";
+
+test.describe("thunderid --setup", () => {
+  test("re-runs setup without re-downloading", async () => {
+    test.setTimeout(Timeouts.INSTALL_TEST);
+
+    const session = new CliSession(useShared(), ["--setup"], { preconfigured: true });
+
+    try {
+      await session.expect("Setup requested", Timeouts.STARTUP);
+      await session.expect("Setup complete", Timeouts.INSTALL);
+      await session.expect("ThunderID started on port", Timeouts.STARTUP);
+
+      expect(await session.waitFor("installed to", 0), "--setup must reuse the install").toBe(false);
+    } finally {
+      await session.dispose();
+      await freePort(DEFAULT_PORT);
+    }
+  });
+});

--- a/tests/e2e-cli/tests/restart/warm-start.spec.ts
+++ b/tests/e2e-cli/tests/restart/warm-start.spec.ts
@@ -1,0 +1,35 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/** Running the CLI again against an install that is already set up. */
+
+import { test, expect } from "@playwright/test";
+import { CliSession } from "../../utils/cli-session";
+import { useShared } from "../../fixtures/shared-install";
+import { DEFAULT_PORT, freePort, waitForReady } from "../../utils/ports";
+import { Timeouts } from "../../constants/timeouts";
+
+test.describe("warm start", () => {
+  test("reuses the install instead of downloading and setting up again", async () => {
+    const workspace = useShared();
+    const version = workspace.state().active as string;
+    const session = new CliSession(workspace, [], { preconfigured: true });
+
+    try {
+      await session.expect("Starting ThunderID", Timeouts.STARTUP);
+      await session.expect(`ThunderID v${version} is ready`, Timeouts.STARTUP);
+      await session.expect("ThunderID started on port", Timeouts.STARTUP);
+
+      expect(await session.waitFor("installed to", 0), "a warm start must not re-download").toBe(false);
+      expect(await session.waitFor("Setup complete", 0), "a warm start must not re-run setup").toBe(false);
+
+      // Setup fixed the port when it seeded the console's redirect URIs, so a warm start has to
+      // come back up on the same one.
+      expect(session.startedPort()).toBe(DEFAULT_PORT);
+      expect(await waitForReady(DEFAULT_PORT), `server should answer readiness\n\n${session.tail(40)}`).toBe(true);
+    } finally {
+      await session.dispose();
+      await freePort(DEFAULT_PORT);
+    }
+  });
+});

--- a/tests/e2e-cli/tests/sample/try-wayfinder.spec.ts
+++ b/tests/e2e-cli/tests/sample/try-wayfinder.spec.ts
@@ -1,0 +1,63 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `try wayfinder` end to end: the CLI downloads the sample bundle, writes its declarative
+ * resources into the install, restarts ThunderID, installs the sample's dependencies and starts
+ * its services. Then a browser signs in to prove the whole chain actually produced a working app.
+ *
+ * This is the only spec that opens a browser, and the only one that reaches past the CLI into
+ * what the CLI produced.
+ *
+ * It runs last and destructively: `try` rewrites <install>/config/resources/** and restarts the
+ * server, so it must not run while the repl, restart or port-conflict specs are using the shared
+ * install. The project dependency graph in playwright.config.ts is what orders it after them.
+ */
+
+import { test, expect } from "@playwright/test";
+import { runCli } from "../../utils/cli-process";
+import { useShared } from "../../fixtures/shared-install";
+import { WayfinderPage, WAYFINDER_URL } from "../../pages/wayfinder.page";
+import { SAMPLE_PORTS, stopSample } from "../../utils/sample-ports";
+import { DEFAULT_PORT, isPortAccepting, waitForReady } from "../../utils/ports";
+import { Timeouts } from "../../constants/timeouts";
+
+/** Seeded in the sample bundle's thunderid-config.yaml, password equal to the username. */
+const SEEDED_USER = "john.doe";
+
+test.describe("thunderid try wayfinder", () => {
+  test.beforeAll(async () => {
+    // The CLI prompts before stopping anything holding the sample's fixed ports, and under a pty
+    // that prompt is interactive with nobody to answer it. Clear them first.
+    await stopSample();
+  });
+
+  test.afterAll(async () => {
+    await stopSample();
+  });
+
+  test("launches the sample and a seeded user can sign in", async ({ page }) => {
+    test.setTimeout(Timeouts.SAMPLE_TEST);
+
+    // Deliberately not a pty session: `try` exits as soon as the services are up, and closing a
+    // pty at that point SIGHUPs the ThunderID server it just backgrounded. See utils/cli-process.
+    const result = await runCli(useShared(), ["try", "wayfinder"], Timeouts.SAMPLE);
+
+    expect(result.exitCode, `try should succeed\n\n${result.output.slice(-2000)}`).toBe(0);
+    expect(result.output).toContain("Wayfinder is running at");
+    expect(result.output, "the summary should point at the sample's fixed origin").toContain(WAYFINDER_URL);
+
+    // try restarts ThunderID, and the sample's login goes through it, so the gate has to be back
+    // up before the browser starts.
+    expect(await waitForReady(DEFAULT_PORT, Timeouts.SHORT), "the gate should be answering").toBe(true);
+
+    // The API is a plain Express app with no readiness endpoint, so accepting a connection is the
+    // most this can assert without guessing at a route.
+    expect(await isPortAccepting(SAMPLE_PORTS.BACKEND), "the sample backend should be listening").toBe(true);
+
+    const wayfinder = new WayfinderPage(page);
+    await wayfinder.goto();
+    await wayfinder.signIn(SEEDED_USER, SEEDED_USER);
+    await wayfinder.expectSignedIn();
+  });
+});

--- a/tests/e2e-cli/tests/sample/unknown-usecase.spec.ts
+++ b/tests/e2e-cli/tests/sample/unknown-usecase.spec.ts
@@ -1,0 +1,26 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/** `try` validates the sample name against knownSamples once an install exists. */
+
+import { test, expect } from "@playwright/test";
+import { CliSession } from "../../utils/cli-session";
+import { useShared } from "../../fixtures/shared-install";
+import { Timeouts } from "../../constants/timeouts";
+
+test.describe("thunderid try, unknown usecase", () => {
+  // "consumer" is the REPL slash command (/try-consumer), not a sample name, so it is the
+  // mistake a user is most likely to make on the command line. The error has to name what is
+  // actually available rather than just refusing.
+  test("names the available samples", async () => {
+    const session = new CliSession(useShared(), ["try", "consumer"], { preconfigured: true });
+
+    try {
+      await session.expect(`unknown sample "consumer"`, Timeouts.SHORT);
+      await session.expect("available: wayfinder");
+      expect(await session.waitForExit()).toBe(1);
+    } finally {
+      await session.dispose();
+    }
+  });
+});

--- a/tests/e2e-cli/tsconfig.json
+++ b/tests/e2e-cli/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "nodenext",
+    "lib": ["ES2023"],
+    "types": ["node", "@playwright/test"],
+    "moduleResolution": "nodenext",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/tests/e2e-cli/utils/browser-stub.ts
+++ b/tests/e2e-cli/utils/browser-stub.ts
@@ -1,0 +1,54 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Browser stub
+ *
+ * `utils.OpenBrowser` shells out to `open` (macOS) or `xdg-open` (Linux) with no way to suppress
+ * it, so a spec that exercises /open-console would launch a real browser window on whatever
+ * machine it runs on.
+ *
+ * This puts a recording stub earlier on PATH instead. Nothing opens, and the URL the CLI asked
+ * for becomes something the spec can assert, which is the interesting part of that command
+ * anyway.
+ */
+
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+export class BrowserStub {
+  private constructor(
+    /** Prepend to PATH so the stub shadows the real opener. */
+    readonly binDir: string,
+    private readonly recordFile: string
+  ) {}
+
+  static create(): BrowserStub {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "thunderid-browser-stub-"));
+    const recordFile = path.join(root, "opened.txt");
+    fs.writeFileSync(recordFile, "");
+
+    // Both names are stubbed regardless of platform: it costs nothing and keeps the helper
+    // working if the suite later runs somewhere the CLI picks the other one.
+    for (const name of ["open", "xdg-open"]) {
+      const script = path.join(root, name);
+      fs.writeFileSync(script, `#!/bin/sh\nprintf '%s\\n' "$@" >> ${JSON.stringify(recordFile)}\n`);
+      fs.chmodSync(script, 0o755);
+    }
+    return new BrowserStub(root, recordFile);
+  }
+
+  /** Every URL the CLI asked the system to open, in order. */
+  openedUrls(): string[] {
+    return fs
+      .readFileSync(this.recordFile, "utf8")
+      .split("\n")
+      .map(line => line.trim())
+      .filter(Boolean);
+  }
+
+  remove(): void {
+    fs.rmSync(this.binDir, { recursive: true, force: true });
+  }
+}

--- a/tests/e2e-cli/utils/cli-process.ts
+++ b/tests/e2e-cli/utils/cli-process.ts
@@ -1,0 +1,80 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Runs the CLI without a pseudo terminal, for commands that neither prompt nor render a TUI.
+ *
+ * `try` is the case this exists for. It prints a summary and exits, leaving the ThunderID server
+ * and the sample's services running in the background. Under a pty the CLI is the only process on
+ * the terminal, so its exit closes the pty and the resulting SIGHUP takes the server down with
+ * it. In a real terminal the shell owns the pty and the server survives, so the pty is what would
+ * be lying here, not the plain pipe.
+ *
+ * Everything interactive still belongs in CliSession: over a pipe the CLI takes its scripted
+ * fallbacks (see ui.Interactive), which is only correct when there is nothing to answer.
+ */
+
+import { spawn } from "child_process";
+import { ADMIN_PASSWORD, ADMIN_USERNAME, cliCommand } from "./cli-session";
+import { localManifestURL } from "./release-source";
+import { Workspace } from "./workspace";
+
+export interface CliResult {
+  /** Combined stdout and stderr, with escape sequences stripped. */
+  output: string;
+  exitCode: number;
+}
+
+const ANSI = /\x1b\[[0-9;?]*[\x20-\x2f]*[\x40-\x7e]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
+
+/**
+ * Runs the CLI to completion.
+ *
+ * The child is left in this process's group on purpose: anything it backgrounds has to outlive
+ * it, which is the whole point of the commands that use this.
+ */
+export function runCli(workspace: Workspace, args: string[], timeout: number): Promise<CliResult> {
+  return new Promise((resolve, reject) => {
+    const env: Record<string, string> = {};
+    for (const [key, value] of Object.entries(process.env)) {
+      if (value === undefined || key === "HOME" || key.startsWith("THUNDERID_")) continue;
+      env[key] = value;
+    }
+    env.HOME = workspace.home;
+    env.THUNDERID_ADMIN_USERNAME = ADMIN_USERNAME;
+    env.THUNDERID_ADMIN_PASSWORD = ADMIN_PASSWORD;
+    const manifest = localManifestURL();
+    if (manifest) {
+      env.THUNDERID_PRODUCT_VERSION = manifest;
+    }
+
+    const launch = cliCommand();
+    const child = spawn(launch.command, [...launch.args, ...args], { cwd: workspace.dir, env });
+
+    let output = "";
+    child.stdout.on("data", chunk => (output += chunk));
+    child.stderr.on("data", chunk => (output += chunk));
+
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`\`thunderid ${args.join(" ")}\` did not finish within ${timeout}ms\n\n${tail(output)}`));
+    }, timeout);
+
+    child.once("error", error => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("close", code => {
+      clearTimeout(timer);
+      resolve({ output: output.replace(ANSI, ""), exitCode: code ?? -1 });
+    });
+  });
+}
+
+function tail(output: string, lines = 40): string {
+  const kept = output
+    .replace(ANSI, "")
+    .split("\n")
+    .filter(line => line.trim() !== "");
+  return kept.slice(-lines).join("\n");
+}

--- a/tests/e2e-cli/utils/cli-session.ts
+++ b/tests/e2e-cli/utils/cli-session.ts
@@ -1,0 +1,288 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * CLI Session
+ *
+ * Drives one `npx thunderid ...` invocation attached to a pseudo terminal.
+ *
+ * A pty is required rather than a pipe. The CLI branches on `ui.Interactive()`, a terminal check
+ * on stdin, to decide whether to prompt at all: over a pipe it takes the scripted fallbacks (see
+ * `resolvePort` in internal/cli/root.go), so a piped run would assert code paths users never see.
+ * The REPL is also a bubbletea program that renders ANSI frames, which only a pty produces.
+ */
+
+import * as pty from "node-pty";
+import path from "path";
+import { Workspace } from "./workspace";
+import { freePort } from "./ports";
+import { localManifestURL } from "./release-source";
+import { Timeouts } from "../constants/timeouts";
+
+/** Key sequences written to the pty to drive the TUI. */
+export const Keys = {
+  ENTER: "\r",
+  ESC: "\x1b",
+  DOWN: "\x1b[B",
+  CTRL_C: "\x03",
+} as const;
+
+/**
+ * Admin credentials fed through the environment. setup.sh requires at least one digit and one
+ * special character, and supplying both values up front is what makes the CLI skip its
+ * interactive credential prompt (see `collectAdminCredentials` in internal/cli/root.go).
+ */
+export const ADMIN_USERNAME = "admin";
+export const ADMIN_PASSWORD = "E2eAdmin#123";
+
+/**
+ * Escape sequences the TUI emits: CSI (color, cursor movement, erase), OSC strings, and the short
+ * two-byte sequences bubbletea uses for mode switches.
+ */
+const ANSI = /\x1b\[[0-9;?]*[\x20-\x2f]*[\x40-\x7e]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|\x1b[()][A-Za-z0-9]|\x1b[=>78]/g;
+
+const WHITESPACE = /\s+/g;
+
+/** How many times, and how long, to try opening the command overlay before giving up. */
+const OVERLAY_ATTEMPTS = 6;
+const OVERLAY_WAIT = 5_000;
+
+/** Normalizes a phrase the same way session output is normalized, so the two are comparable. */
+function normalize(text: string): string {
+  return text.replace(ANSI, "").replace(WHITESPACE, " ");
+}
+
+export interface SessionOptions {
+  /** Pre-supply the admin credentials, suppressing the interactive credential prompt. */
+  preconfigured?: boolean;
+  /** Prepended to PATH, so a stub can shadow a real executable the CLI shells out to. */
+  pathPrefix?: string;
+}
+
+export class CliSession {
+  private readonly proc: pty.IPty;
+  private raw = "";
+  private code: number | null = null;
+  private readonly exited: Promise<number>;
+
+  constructor(
+    private readonly workspace: Workspace,
+    args: string[] = [],
+    options: SessionOptions = {}
+  ) {
+    const env: Record<string, string> = {};
+    for (const [key, value] of Object.entries(process.env)) {
+      // HOME is redirected at the workspace and every THUNDERID_* variable is dropped, so local
+      // shell configuration cannot change what is under test.
+      if (value === undefined || key === "HOME" || key.startsWith("THUNDERID_")) continue;
+      env[key] = value;
+    }
+    env.HOME = workspace.home;
+    env.TERM = "xterm-256color";
+
+    // Point the CLI at a locally served distribution when one is configured. This is the same
+    // knob an operator uses for a mirror, so the suite exercises the shipped feature rather than
+    // a test-only backdoor.
+    const manifest = localManifestURL();
+    if (manifest) {
+      env.THUNDERID_PRODUCT_VERSION = manifest;
+    }
+    if (options.preconfigured) {
+      env.THUNDERID_ADMIN_USERNAME = ADMIN_USERNAME;
+      env.THUNDERID_ADMIN_PASSWORD = ADMIN_PASSWORD;
+    }
+    if (options.pathPrefix) {
+      env.PATH = `${options.pathPrefix}${path.delimiter}${env.PATH ?? ""}`;
+    }
+
+    const launch = cliCommand();
+    this.proc = pty.spawn(launch.command, [...launch.args, ...args], {
+      name: "xterm-256color",
+      // A wide window keeps the TUI from wrapping the phrases assertions match on.
+      cols: 160,
+      rows: 50,
+      cwd: workspace.dir,
+      env,
+    });
+
+    this.proc.onData(chunk => {
+      this.raw += chunk;
+    });
+    this.exited = new Promise<number>(resolve => {
+      this.proc.onExit(({ exitCode }) => {
+        this.code = exitCode;
+        resolve(exitCode);
+      });
+    });
+  }
+
+  /** Everything received so far, stripped of escape sequences and whitespace-normalized. */
+  get output(): string {
+    return normalize(this.raw);
+  }
+
+  /** True once the process has exited. */
+  get hasExited(): boolean {
+    return this.code !== null;
+  }
+
+  /**
+   * Drops the output captured so far.
+   *
+   * Assertions match everything the session has printed, so a phrase from an earlier frame would
+   * satisfy a later wait. Resetting marks a fresh starting point before a new interaction.
+   */
+  reset(): void {
+    this.raw = "";
+  }
+
+  /** Resolves true once phrase appears, or false when timeout expires. Never throws. */
+  async waitFor(phrase: string, timeout: number = Timeouts.SHORT): Promise<boolean> {
+    const needle = normalize(phrase);
+    const deadline = Date.now() + timeout;
+    for (;;) {
+      if (this.output.includes(needle)) return true;
+      if (this.hasExited) {
+        // One last look: the phrase may have arrived in the same breath as the exit.
+        return this.output.includes(needle);
+      }
+      if (Date.now() >= deadline) return false;
+      await sleep(100);
+    }
+  }
+
+  /** Waits for phrase, throwing with the recent output when it does not arrive. */
+  async expect(phrase: string, timeout: number = Timeouts.SHORT): Promise<void> {
+    if (await this.waitFor(phrase, timeout)) return;
+    throw new Error(`Timed out after ${timeout}ms waiting for ${JSON.stringify(phrase)}\n\n${this.tail()}`);
+  }
+
+  /** Writes keystrokes, pausing so the TUI can process and redraw before the next assertion. */
+  async send(...keys: string[]): Promise<void> {
+    for (const key of keys) {
+      this.proc.write(key);
+      await sleep(150);
+    }
+  }
+
+  /**
+   * Opens the REPL's slash-command overlay, leaving it open.
+   *
+   * The REPL only routes "/" into command mode once its own status has flipped to ready, and that
+   * lags the server answering its readiness endpoint. A "/" sent before then is swallowed by the
+   * onboarding picker, where a following Enter would launch a use case instead of running a
+   * command, so this retries rather than assuming the first keystroke lands.
+   */
+  async openCommandOverlay(): Promise<void> {
+    for (let attempt = 1; attempt <= OVERLAY_ATTEMPTS; attempt++) {
+      // Esc first on a retry: it clears any half-open state so a second "/" cannot land in an
+      // input that already holds one.
+      if (attempt > 1) await this.send(Keys.ESC);
+
+      this.reset();
+      await this.send("/");
+      // Every overlay lists the built-in commands, so /status's description proves it is up.
+      if (await this.waitFor("Show server status", OVERLAY_WAIT)) return;
+    }
+    throw new Error(`Command overlay did not open after ${OVERLAY_ATTEMPTS} attempts\n\n${this.tail()}`);
+  }
+
+  /** Runs a slash command in the REPL. */
+  async runSlash(command: string): Promise<void> {
+    await this.openCommandOverlay();
+    this.reset();
+    await this.send(command.replace(/^\//, ""), Keys.ENTER);
+  }
+
+  /** The port from the CLI's "started on port N" line. */
+  startedPort(): number {
+    const match = /started on port (\d+)/.exec(this.output);
+    if (!match) throw new Error(`No start line in output\n\n${this.tail()}`);
+    return Number(match[1]);
+  }
+
+  /** Waits for the process to exit and returns its exit code. */
+  async waitForExit(timeout: number = Timeouts.SHORT): Promise<number> {
+    const result = await Promise.race([this.exited, sleep(timeout).then(() => "timeout" as const)]);
+    if (result === "timeout") {
+      throw new Error(`Process did not exit within ${timeout}ms\n\n${this.tail()}`);
+    }
+    return result;
+  }
+
+  /**
+   * Leaves the REPL and returns the exit code.
+   *
+   * Ctrl+C is best effort: /stop already ends the program, which closes the pty, so writing then
+   * would fail rather than tell us anything about the CLI.
+   */
+  async exitRepl(timeout: number = Timeouts.SHORT): Promise<number> {
+    if (!this.hasExited) this.proc.write(Keys.CTRL_C);
+    return this.waitForExit(timeout);
+  }
+
+  /**
+   * Ends the session and makes sure port is free for whatever runs next. The CLI backgrounds the
+   * server deliberately, so leaving the REPL is not on its own enough.
+   */
+  async shutdown(port: number): Promise<void> {
+    await this.exitRepl();
+    await freePort(port);
+  }
+
+  /** Terminates the session, tolerating one that already exited. Registered as test cleanup. */
+  async dispose(): Promise<void> {
+    if (this.hasExited) return;
+    this.proc.write(Keys.CTRL_C);
+    const raced = await Promise.race([this.exited, sleep(10_000).then(() => "timeout" as const)]);
+    if (raced === "timeout") {
+      this.proc.kill("SIGKILL");
+      await this.exited;
+    }
+  }
+
+  /** The last non-empty lines of output, for failure messages. */
+  tail(lines = 60): string {
+    const kept = this.raw
+      .replace(ANSI, "")
+      .replace(/\r/g, "\n")
+      .split("\n")
+      .map(line => line.trimEnd())
+      .filter(line => line.trim() !== "");
+    return `Last output:\n${kept.slice(-lines).join("\n")}`;
+  }
+}
+
+/**
+ * The wrapper under test. Tests drive the npx entry point rather than the Go binary so the
+ * wrapper's own platform resolution and exit-code forwarding are covered too.
+ */
+export function npxEntry(): string {
+  return path.resolve(__dirname, "..", "..", "..", "tools", "npx", "bin", "thunderid.js");
+}
+
+/**
+ * Whether to drive the CLI built from this checkout, or the one published to npm.
+ *
+ * The published mode is the only one that tests what users actually get: the wrapper as
+ * packaged, and the binaries the release workflow built. Everything else builds from source, so
+ * a PR is tested against its own code.
+ */
+export function publishedTag(): string | null {
+  if (process.env.E2E_CLI_SOURCE?.trim() !== "published") return null;
+  return process.env.E2E_CLI_TAG?.trim() || "latest";
+}
+
+/** The command that launches the CLI, honouring the source mode. */
+export function cliCommand(): { command: string; args: string[] } {
+  const tag = publishedTag();
+  if (tag) {
+    // --yes so a cold runner does not stop on the install prompt.
+    return { command: "npx", args: ["--yes", `thunderid@${tag}`] };
+  }
+  return { command: "node", args: [npxEntry()] };
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/tests/e2e-cli/utils/ports.ts
+++ b/tests/e2e-cli/utils/ports.ts
@@ -1,0 +1,230 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Port helpers
+ *
+ * The CLI negotiates over a real TCP port and backgrounds the server it starts, so tests have to
+ * inspect and release ports directly rather than relying on a process exiting.
+ */
+
+import { execFile, spawn, ChildProcess } from "child_process";
+import https from "https";
+import http from "http";
+import net from "net";
+import { promisify } from "util";
+import { sleep } from "./cli-session";
+import { Timeouts } from "../constants/timeouts";
+
+const execFileAsync = promisify(execFile);
+
+/** The port a fresh setup binds, matching health.DefaultPort. */
+export const DEFAULT_PORT = 8090;
+
+export async function isPortInUse(port: number): Promise<boolean> {
+  return new Promise(resolve => {
+    const server = net.createServer();
+    server.once("error", () => resolve(true));
+    server.once("listening", () => server.close(() => resolve(false)));
+    server.listen(port, "127.0.0.1");
+  });
+}
+
+/**
+ * Whether something is accepting connections on port.
+ *
+ * This is a different question from isPortInUse, which asks whether the port can be bound. A
+ * server listening on `localhost` may resolve to ::1 only, leaving a 127.0.0.1 bind free: the
+ * Wayfinder sample's API does exactly that. Use this to assert a service is up, and isPortInUse
+ * to assert a port is available.
+ */
+export async function isPortAccepting(port: number): Promise<boolean> {
+  const results = await Promise.all([connects("127.0.0.1", port), connects("::1", port)]);
+  return results.some(Boolean);
+}
+
+function connects(host: string, port: number): Promise<boolean> {
+  return new Promise(resolve => {
+    const socket = net.connect({ host, port });
+    const settle = (result: boolean) => {
+      socket.destroy();
+      resolve(result);
+    };
+    socket.setTimeout(2000);
+    socket.once("connect", () => settle(true));
+    socket.once("timeout", () => settle(false));
+    socket.once("error", () => settle(false));
+  });
+}
+
+/**
+ * Throws when something already holds port. The happy-path specs bind the default port, so an
+ * unrelated instance on it would fail them in a way that looks like a product bug rather than a
+ * dirty machine.
+ */
+export async function requirePortFree(port: number): Promise<void> {
+  if (await isPortInUse(port)) {
+    throw new Error(`Port ${port} is already in use; stop whatever is listening on it and re-run`);
+  }
+}
+
+/**
+ * Stops whatever is listening on port.
+ *
+ * The CLI starts the server in the background on purpose: it outlives the REPL, so exiting the
+ * CLI is not enough to release the port for the next spec.
+ */
+export async function freePort(port: number): Promise<void> {
+  // SIGTERM first. The server owns SQLite files and start.sh installs a cleanup trap, so killing
+  // it outright leaves a dirty write-ahead log for the next spec that starts on this install.
+  if (!(await signalHolders(port, "SIGTERM"))) return;
+  if (await waitForPortFree(port, 10_000)) return;
+
+  await signalHolders(port, "SIGKILL");
+  if (!(await waitForPortFree(port, 10_000))) {
+    throw new Error(`Port ${port} is still held after SIGTERM and SIGKILL`);
+  }
+}
+
+/** Signals every process listening on port. Returns false when nothing was listening. */
+async function signalHolders(port: number, signal: "SIGTERM" | "SIGKILL"): Promise<boolean> {
+  let stdout = "";
+  try {
+    ({ stdout } = await execFileAsync("lsof", ["-ti", `tcp:${port}`]));
+  } catch {
+    return false; // nothing listening
+  }
+  let signalled = false;
+  for (const field of stdout.split(/\s+/).filter(Boolean)) {
+    const pid = Number(field);
+    if (!Number.isInteger(pid)) continue;
+    try {
+      process.kill(pid, signal);
+      signalled = true;
+    } catch {
+      // already gone
+    }
+  }
+  return signalled;
+}
+
+/**
+ * Frees port only when one was actually bound. A spec that failed before the server started has
+ * no port to release, and expressing that as a guard here keeps it out of the test body.
+ */
+export async function releasePortIfBound(port: number): Promise<void> {
+  if (!port) return;
+  await freePort(port);
+}
+
+/** Polls until nothing holds port, or timeout expires. */
+export async function waitForPortFree(port: number, timeout = 15_000): Promise<boolean> {
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    if (!(await isPortInUse(port))) return true;
+    if (Date.now() >= deadline) return false;
+    await sleep(200);
+  }
+}
+
+/**
+ * Whether the server answers its readiness endpoint on port, over either scheme, mirroring
+ * internal/services/health. The distribution serves TLS with a self-signed certificate, so
+ * verification is skipped exactly as the CLI skips it.
+ */
+export async function isReady(port: number): Promise<boolean> {
+  for (const scheme of ["https", "http"] as const) {
+    if (await probe(scheme, port)) return true;
+  }
+  return false;
+}
+
+function probe(scheme: "https" | "http", port: number): Promise<boolean> {
+  return new Promise(resolve => {
+    const client = scheme === "https" ? https : http;
+    const req = client.request(
+      {
+        host: "127.0.0.1",
+        port,
+        path: "/health/readiness",
+        method: "GET",
+        timeout: 5000,
+        ...(scheme === "https" ? { rejectUnauthorized: false } : {}),
+      },
+      res => {
+        res.resume();
+        resolve(res.statusCode === 200);
+      }
+    );
+    req.on("error", () => resolve(false));
+    req.on("timeout", () => {
+      req.destroy();
+      resolve(false);
+    });
+    req.end();
+  });
+}
+
+/** Polls until the server answers on port, or timeout expires. */
+export async function waitForReady(port: number, timeout: number = Timeouts.SHORT): Promise<boolean> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (await isReady(port)) return true;
+    await sleep(500);
+  }
+  return false;
+}
+
+/**
+ * A process that squats on a port until it is stopped, used to provoke the CLI's port-conflict
+ * handling.
+ *
+ * The holder has to be a separate process: the CLI's "kill the process on this port" branch looks
+ * the owner up with lsof and terminates it, which would take the test runner itself down if the
+ * runner held the port.
+ */
+export class PortHolder {
+  private constructor(
+    private readonly proc: ChildProcess,
+    private exited = false
+  ) {}
+
+  static async start(port: number): Promise<PortHolder> {
+    // Accept and immediately drop connections, so a probe sees an open port that never answers a
+    // readiness check, which is what an unrelated process squatting on the port looks like.
+    const script = `
+      const net = require("net");
+      const server = net.createServer(socket => socket.destroy());
+      server.listen(${port}, "127.0.0.1", () => console.log("listening"));
+    `;
+    const proc = spawn(process.execPath, ["-e", script], { stdio: ["ignore", "pipe", "inherit"] });
+    const holder = new PortHolder(proc);
+    proc.on("exit", () => {
+      holder.exited = true;
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`Port holder did not bind port ${port}`)), 10_000);
+      proc.stdout?.once("data", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      proc.once("exit", () => {
+        clearTimeout(timer);
+        reject(new Error(`Port holder exited before binding port ${port}`));
+      });
+    });
+    return holder;
+  }
+
+  /** Whether the holding process is still running. */
+  get alive(): boolean {
+    return !this.exited;
+  }
+
+  async stop(): Promise<void> {
+    if (this.exited) return;
+    this.proc.kill("SIGKILL");
+    await new Promise<void>(resolve => this.proc.once("exit", () => resolve()));
+  }
+}

--- a/tests/e2e-cli/utils/release-source.ts
+++ b/tests/e2e-cli/utils/release-source.ts
@@ -1,0 +1,119 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Release source
+ *
+ * The suite runs against one of two products: whatever is published on thunderid.dev, or a
+ * distribution built in this repository. The second is what makes a product change provable: a
+ * change to setup.sh, start.sh, deployment.yaml, the bootstrap resources or the sample bundle can
+ * only break the CLI if the CLI is pointed at the build that contains it.
+ *
+ * Set E2E_PRODUCT_DIST to a directory of release zips (the shape of target/dist) and this serves
+ * it with a generated manifest. The CLI reads it through THUNDERID_PRODUCT_VERSION, the same knob
+ * an operator uses to point at their own mirror.
+ */
+
+import fs from "fs";
+import http from "http";
+import path from "path";
+
+/** Fixed so the workers can reach the server global setup starts, without sharing state. */
+export const RELEASE_SERVER_PORT = Number(process.env.E2E_RELEASE_SERVER_PORT ?? 8899);
+
+/** The directory of release zips to serve, or null when running against the published product. */
+export function localDistDir(): string | null {
+  const dir = process.env.E2E_PRODUCT_DIST?.trim();
+  return dir ? path.resolve(dir) : null;
+}
+
+/** The manifest URL the CLI should read, or null to leave it on the public one. */
+export function localManifestURL(): string | null {
+  return localDistDir() ? `http://127.0.0.1:${RELEASE_SERVER_PORT}/releases.json` : null;
+}
+
+interface Asset {
+  name: string;
+  downloadUrl: string;
+}
+
+/**
+ * Builds a manifest from the zips present in dir.
+ *
+ * Naming is the contract: build.sh emits `thunderid-<version>-<platform>-<arch>.zip` and
+ * `sample-app-<name>-<version>.zip`, which is exactly what release.PlatformAssetName and
+ * release.SampleAssetName look for. The version is taken from the product zips, and the sample
+ * zips are attached to the same release so `try` resolves against it.
+ */
+export function buildManifest(dir: string, baseUrl: string): { version: string; manifest: unknown } {
+  const zips = fs.readdirSync(dir).filter(name => name.endsWith(".zip"));
+
+  const productZips = zips.filter(name => /^thunderid-.+-(macos|linux|win)-(x64|arm64)\.zip$/.test(name));
+  if (productZips.length === 0) {
+    throw new Error(
+      `No product zips in ${dir}. Expected something like thunderid-1.0.1-linux-x64.zip; found: ${
+        zips.join(", ") || "(nothing)"
+      }`
+    );
+  }
+
+  const versions = new Set(
+    productZips.map(name => /^thunderid-(.+)-(?:macos|linux|win)-(?:x64|arm64)\.zip$/.exec(name)![1])
+  );
+  if (versions.size > 1) {
+    throw new Error(`${dir} holds more than one product version: ${[...versions].join(", ")}`);
+  }
+  const version = [...versions][0];
+
+  // Sample zips carry their own version, so they are matched by prefix rather than by the
+  // product's version.
+  const assets: Asset[] = zips
+    .filter(name => productZips.includes(name) || name.startsWith("sample-app-"))
+    .map(name => ({ name, downloadUrl: `${baseUrl}/${name}` }));
+
+  const release = { tagName: `v${version}`, isLatest: true, assets };
+  return { version, manifest: { latestRelease: release, releases: [release] } };
+}
+
+/**
+ * Serves dir over HTTP with a generated manifest at /releases.json.
+ *
+ * Returns a close function; global setup hands it back to Playwright as its teardown.
+ */
+export async function startDistServer(dir: string): Promise<() => Promise<void>> {
+  const baseUrl = `http://127.0.0.1:${RELEASE_SERVER_PORT}`;
+  const { version, manifest } = buildManifest(dir, baseUrl);
+  const body = JSON.stringify(manifest);
+
+  const server = http.createServer((req, res) => {
+    const name = decodeURIComponent((req.url ?? "/").split("?")[0].replace(/^\//, ""));
+
+    if (name === "releases.json") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(body);
+      return;
+    }
+
+    // Serve only the zips in dir, by exact name: this stands in for a release CDN, not a file
+    // browser, and a traversal here would read outside the distribution.
+    const file = path.join(dir, path.basename(name));
+    if (!name || path.basename(name) !== name || !fs.existsSync(file)) {
+      res.writeHead(404).end("not found");
+      return;
+    }
+    res.writeHead(200, { "content-type": "application/zip", "content-length": fs.statSync(file).size });
+    fs.createReadStream(file).pipe(res);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(RELEASE_SERVER_PORT, "127.0.0.1", resolve);
+  });
+
+  console.log(`📦 Serving ${path.relative(process.cwd(), dir)} as ThunderID v${version} on ${baseUrl}`);
+  return () =>
+    new Promise<void>(resolve => {
+      server.closeAllConnections?.();
+      server.close(() => resolve());
+    });
+}

--- a/tests/e2e-cli/utils/sample-ports.ts
+++ b/tests/e2e-cli/utils/sample-ports.ts
@@ -1,0 +1,36 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The fixed ports the Wayfinder sample binds, from sampleServicePorts in
+ * internal/commands/sample/sample.go. None are configurable, and the bundle's OAuth redirect
+ * URIs hardcode the frontend origin, so the sample cannot be moved off them.
+ */
+
+import { DEFAULT_PORT, freePort } from "./ports";
+
+export const SAMPLE_PORTS = {
+  /** Vite frontend. */
+  FRONTEND: 5173,
+  /** Backend API. */
+  BACKEND: 8787,
+  /** SMTP inbox UI. */
+  INBOX: 8788,
+  /** SMTP server. */
+  SMTP: 2525,
+  /** Lounge kiosk. */
+  LOUNGE: 8795,
+} as const;
+
+/**
+ * Releases everything a sample run leaves behind.
+ *
+ * `try` installs no signal handler and never calls StopServices, so the CLI exits with npm and
+ * all five services still running, plus the ThunderID server it restarted. Cleaning up is
+ * entirely the caller's job.
+ */
+export async function stopSample(): Promise<void> {
+  for (const port of [...Object.values(SAMPLE_PORTS), DEFAULT_PORT]) {
+    await freePort(port);
+  }
+}

--- a/tests/e2e-cli/utils/workspace.ts
+++ b/tests/e2e-cli/utils/workspace.ts
@@ -1,0 +1,70 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Workspace
+ *
+ * An isolated pair of directories standing in for a user's machine.
+ *
+ * `home` redirects the CLI's state file (config.StateDir reads $HOME) and `dir` is the working
+ * directory the CLI installs into (cli.BaseDir is "./thunderid"). Together they keep a test run
+ * from seeing, or disturbing, a real install on the developer's machine.
+ */
+
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+/** The on-disk shape written by internal/services/config. */
+export interface CliState {
+  active?: string;
+  versions?: Record<
+    string,
+    {
+      installPath?: string;
+      setupComplete?: boolean;
+      onboardingDone?: boolean;
+    }
+  >;
+}
+
+export class Workspace {
+  private constructor(
+    readonly home: string,
+    readonly dir: string
+  ) {}
+
+  /** A throwaway workspace under the OS temp directory, for a spec that needs a clean machine. */
+  static create(): Workspace {
+    return Workspace.at(fs.mkdtempSync(path.join(os.tmpdir(), "thunderid-e2e-")));
+  }
+
+  /**
+   * A workspace rooted at a fixed path, for the install shared between projects. Existing
+   * contents are kept, so a later project reads back what the install project wrote.
+   */
+  static at(root: string): Workspace {
+    const home = path.join(root, "home");
+    const dir = path.join(root, "work");
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(dir, { recursive: true });
+    return new Workspace(home, dir);
+  }
+
+  /** The CLI's persisted state, or an empty object when it has not written one yet. */
+  state(): CliState {
+    const file = path.join(this.home, ".thunderid", "state.json");
+    if (!fs.existsSync(file)) return {};
+    return JSON.parse(fs.readFileSync(file, "utf8")) as CliState;
+  }
+
+  /** The install directory the CLI extracts into, relative to its working directory. */
+  installDir(version: string): string {
+    return path.join(this.dir, "thunderid", `v${version}`);
+  }
+
+  /** Removes the workspace. Registered as test cleanup. */
+  remove(): void {
+    fs.rmSync(path.dirname(this.home), { recursive: true, force: true });
+  }
+}

--- a/tools/cli/.golangci.yml
+++ b/tools/cli/.golangci.yml
@@ -50,6 +50,7 @@ linters-settings:
     locale: US
     ignore-words:
       - cancelled
+      - cancelling
   lll:
     line-length: 140
     tab-width: 4

--- a/tools/cli/cmd/thunderid/main.go
+++ b/tools/cli/cmd/thunderid/main.go
@@ -7,12 +7,14 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/thunder-id/thunderid/tools/cli/internal/cli"
 	"github.com/thunder-id/thunderid/tools/cli/internal/commands/sample"
 	"github.com/thunder-id/thunderid/tools/cli/internal/commands/upgrade"
 	"github.com/thunder-id/thunderid/tools/cli/internal/product"
 	"github.com/thunder-id/thunderid/tools/cli/internal/services/config"
+	"github.com/thunder-id/thunderid/tools/cli/internal/services/release"
 	"github.com/thunder-id/thunderid/tools/cli/internal/ui"
 )
 
@@ -30,8 +32,28 @@ func main() {
 		return
 	}
 
+	// --product-version selects which release to install and where to fetch it from, so it has to
+	// be applied before any command reaches the release service.
+	if err := configureReleaseSource(args); err != nil {
+		ui.Fatal(err.Error())
+		os.Exit(1)
+	}
+
+	// --help can follow a flag, so it is matched anywhere rather than only in first position.
+	if hasFlag(args, "--help", "-h") {
+		printUsage()
+		return
+	}
+
 	// upgrade — stop the running version, install the latest, restart on the same port.
 	if len(args) > 0 && args[0] == "upgrade" {
+		// Upgrading to the latest while pinned to a version contradicts itself, and silently
+		// dropping the pin would move an operator off the release they asked for.
+		if release.Pinned() != "" {
+			ui.Fatal("`upgrade` cannot run with a pinned --product-version. " +
+				"Drop the pin to upgrade, or pass the version you want directly.")
+			os.Exit(1)
+		}
 		verbose, _ := parseFlags(args[1:])
 		_, notice, err := upgrade.Run(cli.BaseDir(), upgrade.Opts{Verbose: verbose})
 		if err != nil {
@@ -68,11 +90,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	if len(args) > 0 && (args[0] == "--help" || args[0] == "-h") {
-		printUsage()
-		return
-	}
-
 	verbose, forceSetup := parseFlags(args)
 	cli.Run(verbose, forceSetup)
 }
@@ -104,8 +121,69 @@ Flags:
   --verbose, -v        Show detailed output
   --setup              Force re-run setup
   --version, -V        Show the CLI version
+  --product-version    Release to install, or the manifest to read releases from.
+                       Takes a version (1.0.1) or a URL (https://example.com/releases.json).
+                       Pass it twice to combine the two. Also read from
+                       THUNDERID_PRODUCT_VERSION.
   --help, -h           Show this help message
-`, product.Slug, product.Name)
+
+Examples:
+  %s --product-version 1.0.1
+  %s --product-version https://releases.example.com/releases.json
+  %s --product-version https://releases.example.com/releases.json --product-version 1.0.1
+`, product.Slug, product.Name, product.Slug, product.Slug, product.Slug)
+}
+
+// configureReleaseSource applies --product-version, falling back to THUNDERID_PRODUCT_VERSION so
+// scripted runs can set it without rewriting their command lines. Flags win over the environment.
+func configureReleaseSource(args []string) error {
+	values := productVersionFlags(args)
+	if len(values) == 0 {
+		if env := strings.TrimSpace(os.Getenv("THUNDERID_PRODUCT_VERSION")); env != "" {
+			values = strings.Fields(env)
+		}
+	}
+	if len(values) == 0 {
+		return nil
+	}
+	client, err := release.Configure(values)
+	if err != nil {
+		return err
+	}
+	release.Default = client
+	return nil
+}
+
+// productVersionFlags collects every --product-version value, accepting both "--flag value" and
+// "--flag=value".
+func productVersionFlags(args []string) []string {
+	var values []string
+	for i := 0; i < len(args); i++ {
+		switch {
+		case args[i] == productVersionFlag:
+			if i+1 < len(args) {
+				values = append(values, args[i+1])
+				i++
+			}
+		case strings.HasPrefix(args[i], productVersionFlag+"="):
+			values = append(values, strings.TrimPrefix(args[i], productVersionFlag+"="))
+		}
+	}
+	return values
+}
+
+const productVersionFlag = "--product-version"
+
+// hasFlag reports whether any of names appears in args.
+func hasFlag(args []string, names ...string) bool {
+	for _, a := range args {
+		for _, name := range names {
+			if a == name {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func parseFlags(args []string) (verbose, forceSetup bool) {

--- a/tools/cli/internal/cli/root.go
+++ b/tools/cli/internal/cli/root.go
@@ -69,7 +69,14 @@ func Run(verbose, forceSetup bool) {
 		ui.Warn(nodeWarning)
 	}
 
+	// Never let a non-default release source be silent: an operator has to be able to see that
+	// this run is not reading the public manifest.
+	if release.IsCustomSource() {
+		ui.Note("Custom release source", release.SourceURL())
+	}
+
 	activeVersion := config.ReadActiveVersion()
+	pinnedVersion := release.Pinned()
 
 	fmt.Print(ui.Dim("  Fetching latest " + product.Name + " release..."))
 	latestVersion, err := release.FetchLatestVersion()
@@ -92,14 +99,20 @@ func Run(verbose, forceSetup bool) {
 	}
 
 	// Always start the active version; only download when there's no installed version yet.
+	// A pinned version overrides both: it is an explicit instruction about what to run.
 	runVersion := latestVersion
 	if activeVersion != "" {
 		runVersion = activeVersion
 	}
+	if pinnedVersion != "" {
+		runVersion = pinnedVersion
+	}
 
-	// Show a new-version banner inside the REPL (not a blocking prompt).
+	// Show a new-version banner inside the REPL (not a blocking prompt). Pinning suppresses it:
+	// the operator already said which version they want.
 	var newVersion string
-	if activeVersion != "" && activeVersion != latestVersion && !config.IsVersionSkipped(latestVersion) {
+	if pinnedVersion == "" && activeVersion != "" && activeVersion != latestVersion &&
+		!config.IsVersionSkipped(latestVersion) {
 		newVersion = latestVersion
 	}
 
@@ -111,7 +124,10 @@ func Run(verbose, forceSetup bool) {
 			installOnDisk = true
 		}
 	}
-	alreadyInstalled := activeVersion == runVersion && config.IsSetupComplete(runVersion) && installOnDisk
+	// A pinned version is judged on its own install state rather than on which version happens to
+	// be active: asking for a version that is already installed should start it, not fetch it again.
+	selected := activeVersion == runVersion || pinnedVersion != ""
+	alreadyInstalled := selected && config.IsSetupComplete(runVersion) && installOnDisk
 	isFirstRun := !config.IsOnboardingDone(runVersion)
 
 	var port int
@@ -122,7 +138,7 @@ func Run(verbose, forceSetup bool) {
 		// Setup already ran on an earlier invocation, so the port it seeded into the
 		// console application's redirect URIs is fixed: no alternate port here.
 		port = resolvePort(path, false)
-	} else if activeVersion == runVersion && installOnDisk {
+	} else if selected && installOnDisk {
 		absPath, err := filepath.Abs(path)
 		if err != nil {
 			absPath = path
@@ -141,8 +157,9 @@ func Run(verbose, forceSetup bool) {
 		creds = runSetupPhase(runVersion, path, verbose, port)
 	} else {
 		// If the previously-active version is no longer in the manifest we'd need
-		// to download it, so fall back to the latest available version.
-		if runVersion != latestVersion {
+		// to download it, so fall back to the latest available version. A pinned version is
+		// never swapped out: failing to find it has to be reported, not worked around.
+		if pinnedVersion == "" && runVersion != latestVersion {
 			runVersion = latestVersion
 			path = VersionedInstallPath(runVersion)
 			newVersion = "" // already on latest after this download
@@ -159,6 +176,15 @@ func Run(verbose, forceSetup bool) {
 		path = absPath
 		port = resolvePort(path, true)
 		creds = runSetupPhase(runVersion, path, verbose, port)
+		if err := config.WriteActiveVersion(runVersion); err != nil {
+			ui.Fatal("Failed to record active version: " + err.Error())
+			os.Exit(1)
+		}
+	}
+
+	// A pinned run switches the active version, so a later run without the pin starts what was
+	// last explicitly asked for instead of silently reverting to the previous one.
+	if config.ReadActiveVersion() != runVersion {
 		if err := config.WriteActiveVersion(runVersion); err != nil {
 			ui.Fatal("Failed to record active version: " + err.Error())
 			os.Exit(1)
@@ -202,16 +228,19 @@ func Run(verbose, forceSetup bool) {
 
 // replLoop runs the REPL repeatedly, re-entering after no-op upgrades or version switches.
 // An actual upgrade or normal exit breaks the loop.
-func replLoop(version, installPath string, proc *exec.Cmd, verbose, isFirstRun bool, newVersion, nodeWarning string, port int, creds *setup.AdminCredentials) {
+func replLoop(
+	version, installPath string, proc *exec.Cmd, verbose, isFirstRun bool,
+	newVersion, nodeWarning string, port int, creds *setup.AdminCredentials,
+) {
 	notice := ""
 	for {
-		upgradeRequested, switchRequested, err := ui.RunREPL(version, proc, installPath, verbose, isFirstRun, newVersion, nodeWarning, port, creds, notice)
+		upgradeRequested, switchRequested, err := ui.RunREPL(
+			version, proc, installPath, verbose, isFirstRun, newVersion, nodeWarning, port, creds, notice)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "\nREPL error: %v\n", err)
 			os.Exit(1)
 		}
 		isFirstRun = false
-		notice = ""
 
 		if upgradeRequested {
 			upgraded, upgradeNotice, err := upgrade.Run(BaseDir(), upgrade.Opts{Verbose: verbose, Port: port})

--- a/tools/cli/internal/services/release/release.go
+++ b/tools/cli/internal/services/release/release.go
@@ -78,18 +78,21 @@ func fetchJSON(url string, dest any) error {
 	return json.NewDecoder(resp.Body).Decode(dest)
 }
 
-func fetchReleasesData() (*releasesData, error) {
-	return fetchReleasesDataFrom(product.ReleasesURL, product.GitHubAPI)
+func (c *Client) fetchReleasesData() (*releasesData, error) {
+	return fetchReleasesDataFrom(c.ManifestURL, c.FallbackURL)
 }
 
 // fetchReleasesDataFrom reads releases metadata from primaryURL and falls back to the
-// GitHub release API at fallbackURL. The URLs are parameters so tests can point both at
-// a local server.
+// GitHub release API at fallbackURL. An empty fallbackURL disables the fallback, which is what a
+// custom source implies. The URLs are parameters so tests can point both at a local server.
 func fetchReleasesDataFrom(primaryURL, fallbackURL string) (*releasesData, error) {
 	var data releasesData
 	primaryErr := fetchJSON(primaryURL, &data)
 	if primaryErr == nil {
 		return &data, nil
+	}
+	if fallbackURL == "" {
+		return nil, primaryErr
 	}
 
 	// Fallback to GitHub API.
@@ -116,9 +119,13 @@ func fetchReleasesDataFrom(primaryURL, fallbackURL string) (*releasesData, error
 	return &releasesData{LatestRelease: r, Releases: []releaseEntry{r}}, nil
 }
 
-// FetchLatestVersion queries releases metadata and returns the latest version string (no "v" prefix).
-func FetchLatestVersion() (string, error) {
-	data, err := fetchReleasesData()
+// FetchLatestVersion returns the latest version from the configured source.
+func FetchLatestVersion() (string, error) { return Default.LatestVersion() }
+
+// LatestVersion returns the newest version the manifest advertises, without a leading "v".
+// It ignores any pinned version: callers use it to tell the operator that an upgrade exists.
+func (c *Client) LatestVersion() (string, error) {
+	data, err := c.fetchReleasesData()
 	if err != nil {
 		return "", err
 	}
@@ -135,19 +142,24 @@ type ProgressFunc func(pct int, msg string)
 
 // Download downloads and extracts the product release for the current platform.
 func Download(version, destDir string, onProgress ProgressFunc) error {
+	return Default.Download(version, destDir, onProgress)
+}
+
+// Download downloads and extracts the product release for the current platform.
+func (c *Client) Download(version, destDir string, onProgress ProgressFunc) error {
 	assetName, err := PlatformAssetName(version)
 	if err != nil {
 		return err
 	}
 
-	data, err := fetchReleasesData()
+	data, err := c.fetchReleasesData()
 	if err != nil {
 		return err
 	}
 
 	found := findAsset(data, version, assetName)
 	if found == nil {
-		return fmt.Errorf("no release asset found for %s", assetName)
+		return fmt.Errorf("no release asset found for %s at %s%s", assetName, c.ManifestURL, availableVersions(data))
 	}
 
 	if onProgress != nil {
@@ -206,19 +218,24 @@ func SampleAssetName(sampleName, version string) (string, error) {
 
 // DownloadSample downloads and extracts the named sample to destDir.
 func DownloadSample(sampleName, version, destDir string, onProgress ProgressFunc) error {
+	return Default.DownloadSample(sampleName, version, destDir, onProgress)
+}
+
+// DownloadSample downloads and extracts the named sample to destDir.
+func (c *Client) DownloadSample(sampleName, version, destDir string, onProgress ProgressFunc) error {
 	assetName, err := SampleAssetName(sampleName, version)
 	if err != nil {
 		return err
 	}
 
-	data, err := fetchReleasesData()
+	data, err := c.fetchReleasesData()
 	if err != nil {
 		return err
 	}
 
 	found := findAsset(data, version, assetName)
 	if found == nil {
-		return fmt.Errorf("no release asset found for %s", assetName)
+		return fmt.Errorf("no release asset found for %s at %s%s", assetName, c.ManifestURL, availableVersions(data))
 	}
 
 	if onProgress != nil {
@@ -242,22 +259,41 @@ func DownloadSample(sampleName, version, destDir string, onProgress ProgressFunc
 	return extractInto(zipPath, destDir)
 }
 
+// findAsset returns the named asset belonging to the requested version, or nil.
+//
+// It matches on the version and never falls back to another release: returning the latest
+// release's asset for a version the manifest does not carry would install something other than
+// what was asked for, under the name that was asked for.
 func findAsset(data *releasesData, version, assetName string) *releaseAsset {
-	for _, r := range data.Releases {
-		if r.TagName == "v"+version {
-			for i := range r.Assets {
-				if r.Assets[i].Name == assetName {
-					return &r.Assets[i]
-				}
+	for _, r := range append([]releaseEntry{data.LatestRelease}, data.Releases...) {
+		if r.TagName != "v"+version {
+			continue
+		}
+		for i := range r.Assets {
+			if r.Assets[i].Name == assetName {
+				return &r.Assets[i]
 			}
 		}
 	}
-	for i := range data.LatestRelease.Assets {
-		if data.LatestRelease.Assets[i].Name == assetName {
-			return &data.LatestRelease.Assets[i]
-		}
-	}
 	return nil
+}
+
+// availableVersions renders the versions a manifest carries, for an error that would otherwise
+// only say the asset was missing.
+func availableVersions(data *releasesData) string {
+	seen := map[string]bool{}
+	var versions []string
+	for _, r := range append([]releaseEntry{data.LatestRelease}, data.Releases...) {
+		if r.TagName == "" || seen[r.TagName] {
+			continue
+		}
+		seen[r.TagName] = true
+		versions = append(versions, r.TagName)
+	}
+	if len(versions) == 0 {
+		return ""
+	}
+	return " (available: " + strings.Join(versions, ", ") + ")"
 }
 
 func downloadFile(url, destPath string, onProgress func(received, total int64)) error {

--- a/tools/cli/internal/services/release/release_internal_test.go
+++ b/tools/cli/internal/services/release/release_internal_test.go
@@ -235,3 +235,52 @@ func TestExtractInto_KeepsPreexistingDirectory(t *testing.T) {
 	_, err := os.Stat(keep)
 	assert.NoError(t, err, "a pre-existing install must be left alone")
 }
+
+// findAsset used to fall back to the latest release's asset when the requested version was not
+// in the manifest. Nothing could request a specific version, so it never mattered; with
+// --product-version it would install the latest under the name of the version that was asked
+// for, which is worse than failing.
+func TestFindAsset_DoesNotSubstituteAnotherRelease(t *testing.T) {
+	data := &releasesData{
+		LatestRelease: releaseEntry{
+			TagName: "v2.0.0",
+			Assets:  []releaseAsset{{Name: "thunderid-2.0.0-linux-x64.zip", DownloadURL: "https://example.com/2.0.0"}},
+		},
+		Releases: []releaseEntry{
+			{
+				TagName: "v1.0.0",
+				Assets:  []releaseAsset{{Name: "thunderid-1.0.0-linux-x64.zip", DownloadURL: "https://example.com/1.0.0"}},
+			},
+		},
+	}
+
+	found := findAsset(data, "1.0.0", "thunderid-1.0.0-linux-x64.zip")
+	require.NotNil(t, found, "an asset that exists should be found")
+	assert.Equal(t, "https://example.com/1.0.0", found.DownloadURL)
+
+	assert.Nil(t, findAsset(data, "9.9.9", "thunderid-9.9.9-linux-x64.zip"),
+		"a version the manifest does not carry must not resolve to another release")
+}
+
+// The latest release is only listed under latestRelease in the manifest, so asking for it by
+// version has to match there too.
+func TestFindAsset_MatchesTheLatestReleaseByVersion(t *testing.T) {
+	data := &releasesData{
+		LatestRelease: releaseEntry{
+			TagName: "v2.0.0",
+			Assets:  []releaseAsset{{Name: "thunderid-2.0.0-linux-x64.zip", DownloadURL: "https://example.com/2.0.0"}},
+		},
+	}
+
+	found := findAsset(data, "2.0.0", "thunderid-2.0.0-linux-x64.zip")
+	require.NotNil(t, found)
+	assert.Equal(t, "https://example.com/2.0.0", found.DownloadURL)
+}
+
+// A custom source is authoritative: reaching for the public GitHub API behind the operator's back
+// would fetch something they did not point at.
+func TestFetchReleasesData_NoFallbackWhenDisabled(t *testing.T) {
+	_, err := fetchReleasesDataFrom("http://127.0.0.1:1/releases.json", "")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "fallback", "an empty fallback must not be attempted")
+}

--- a/tools/cli/internal/services/release/source.go
+++ b/tools/cli/internal/services/release/source.go
@@ -1,0 +1,133 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package release
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/thunder-id/thunderid/tools/cli/internal/product"
+)
+
+// Client resolves releases from a manifest and downloads their assets.
+//
+// The zero value is not useful; use Default, or build one with Configure. Default exists so the
+// package-level helpers keep working for the callers that only ever want the public releases:
+// the release source is process-wide configuration derived from the command line, in the same way
+// GOPROXY or npm_config_registry are.
+type Client struct {
+	// ManifestURL is the releases manifest to read.
+	ManifestURL string
+	// FallbackURL is the GitHub release API to fall back to. Empty disables the fallback, which
+	// is what a custom ManifestURL implies: quietly reaching for the public API when the operator
+	// pointed at their own mirror would defeat the point of pointing at it.
+	FallbackURL string
+	// PinnedVersion is the release to install, without a leading "v". Empty means the latest.
+	PinnedVersion string
+}
+
+// Default is the client the package-level helpers use. main replaces it once the command line
+// has been parsed.
+var Default = &Client{
+	ManifestURL: product.ReleasesURL,
+	FallbackURL: product.GitHubAPI,
+}
+
+// IsCustom reports whether releases come from somewhere other than the public manifest.
+func (c *Client) IsCustom() bool { return c.ManifestURL != product.ReleasesURL }
+
+// Pinned returns the pinned version, or "" when the latest release is wanted.
+func Pinned() string { return Default.PinnedVersion }
+
+// SourceURL returns the manifest the CLI is reading releases from.
+func SourceURL() string { return Default.ManifestURL }
+
+// IsCustomSource reports whether releases come from somewhere other than the public manifest.
+func IsCustomSource() bool { return Default.IsCustom() }
+
+// semverPattern matches the release versions the manifest carries: three numeric components with
+// an optional pre-release suffix, and an optional leading "v".
+var semverPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$`)
+
+// Configure builds a Client from --product-version values.
+//
+// Each value is classified by its shape: a URL selects the manifest to read, a semantic version
+// pins the release to install. Both may be given, in either order, so "this version from that
+// mirror" is expressible. Two of the same kind is a mistake rather than a last-one-wins.
+func Configure(values []string) (*Client, error) {
+	client := &Client{ManifestURL: product.ReleasesURL, FallbackURL: product.GitHubAPI}
+	var sawURL, sawVersion bool
+
+	for _, raw := range values {
+		value := strings.TrimSpace(raw)
+		if value == "" {
+			continue
+		}
+
+		switch {
+		case looksLikeURL(value):
+			if sawURL {
+				return nil, fmt.Errorf("--product-version was given two release sources; pass one URL at most")
+			}
+			if err := validateSourceURL(value); err != nil {
+				return nil, err
+			}
+			// A custom manifest is authoritative: no silent fallback to the public GitHub API.
+			client.ManifestURL = value
+			client.FallbackURL = ""
+			sawURL = true
+
+		case semverPattern.MatchString(value):
+			if sawVersion {
+				return nil, fmt.Errorf("--product-version was given two versions; pass one at most")
+			}
+			client.PinnedVersion = strings.TrimPrefix(value, "v")
+			sawVersion = true
+
+		default:
+			return nil, fmt.Errorf(
+				"--product-version %q is neither a version nor a URL; "+
+					"pass a version like 1.0.1 or a manifest URL like https://example.com/releases.json", value)
+		}
+	}
+	return client, nil
+}
+
+func looksLikeURL(value string) bool {
+	lower := strings.ToLower(value)
+	return strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://")
+}
+
+// validateSourceURL rejects sources that would fetch an executable distribution over cleartext.
+// Plain http is allowed only for a loopback host, which is what a local mirror or a test server
+// looks like; anything else has to be https.
+func validateSourceURL(value string) error {
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return fmt.Errorf("--product-version %q is not a valid URL: %w", value, err)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("--product-version %q is missing a host", value)
+	}
+	if parsed.Scheme == "https" {
+		return nil
+	}
+	if isLoopback(parsed.Hostname()) {
+		return nil
+	}
+	return fmt.Errorf(
+		"--product-version %q uses plain http; releases are executable, so http is allowed only "+
+			"for localhost. Use https for a remote source", value)
+}
+
+func isLoopback(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/tools/cli/internal/services/release/source_test.go
+++ b/tools/cli/internal/services/release/source_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package release_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/thunder-id/thunderid/tools/cli/internal/product"
+	"github.com/thunder-id/thunderid/tools/cli/internal/services/release"
+)
+
+func TestConfigure_ClassifiesValuesByShape(t *testing.T) {
+	tests := []struct {
+		name        string
+		values      []string
+		wantVersion string
+		wantURL     string
+	}{
+		{
+			name:        "no values keeps the public manifest",
+			values:      nil,
+			wantVersion: "",
+			wantURL:     product.ReleasesURL,
+		},
+		{
+			name:        "a version pins the release",
+			values:      []string{"1.0.1"},
+			wantVersion: "1.0.1",
+			wantURL:     product.ReleasesURL,
+		},
+		{
+			name:        "a leading v is accepted and dropped",
+			values:      []string{"v1.0.1"},
+			wantVersion: "1.0.1",
+			wantURL:     product.ReleasesURL,
+		},
+		{
+			name:        "a prerelease version is a version",
+			values:      []string{"1.1.0-m1"},
+			wantVersion: "1.1.0-m1",
+			wantURL:     product.ReleasesURL,
+		},
+		{
+			name:        "a URL selects the manifest",
+			values:      []string{"https://example.com/releases.json"},
+			wantVersion: "",
+			wantURL:     "https://example.com/releases.json",
+		},
+		{
+			name:        "both may be combined in either order",
+			values:      []string{"https://example.com/releases.json", "1.0.1"},
+			wantVersion: "1.0.1",
+			wantURL:     "https://example.com/releases.json",
+		},
+		{
+			name:        "order does not matter",
+			values:      []string{"1.0.1", "https://example.com/releases.json"},
+			wantVersion: "1.0.1",
+			wantURL:     "https://example.com/releases.json",
+		},
+		{
+			name:        "http is allowed for loopback, where a local mirror lives",
+			values:      []string{"http://127.0.0.1:8080/releases.json"},
+			wantVersion: "",
+			wantURL:     "http://127.0.0.1:8080/releases.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := release.Configure(tt.values)
+			if err != nil {
+				t.Fatalf("Configure(%q): %v", tt.values, err)
+			}
+			if client.PinnedVersion != tt.wantVersion {
+				t.Errorf("PinnedVersion = %q, want %q", client.PinnedVersion, tt.wantVersion)
+			}
+			if client.ManifestURL != tt.wantURL {
+				t.Errorf("ManifestURL = %q, want %q", client.ManifestURL, tt.wantURL)
+			}
+		})
+	}
+}
+
+// A custom manifest is authoritative. Falling back to the public GitHub API when an operator
+// pointed at their own mirror would fetch something they did not ask for.
+func TestConfigure_CustomSourceDisablesTheFallback(t *testing.T) {
+	client, err := release.Configure([]string{"https://example.com/releases.json"})
+	if err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+	if client.FallbackURL != "" {
+		t.Errorf("FallbackURL = %q, want empty for a custom source", client.FallbackURL)
+	}
+	if !client.IsCustom() {
+		t.Error("IsCustom() = false, want true")
+	}
+}
+
+func TestConfigure_DefaultSourceKeepsTheFallback(t *testing.T) {
+	client, err := release.Configure([]string{"1.0.1"})
+	if err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+	if client.FallbackURL != product.GitHubAPI {
+		t.Errorf("FallbackURL = %q, want the GitHub API", client.FallbackURL)
+	}
+	if client.IsCustom() {
+		t.Error("IsCustom() = true, want false when only a version was pinned")
+	}
+}
+
+func TestConfigure_Rejects(t *testing.T) {
+	tests := []struct {
+		name     string
+		values   []string
+		wantHint string
+	}{
+		{
+			name:     "a value that is neither a version nor a URL",
+			values:   []string{"latest"},
+			wantHint: "neither a version nor a URL",
+		},
+		{
+			name:     "an incomplete version",
+			values:   []string{"1.0"},
+			wantHint: "neither a version nor a URL",
+		},
+		{
+			// Releases are executable, so a cleartext remote source is refused outright rather
+			// than warned about.
+			name:     "plain http for a remote host",
+			values:   []string{"http://releases.example.com/releases.json"},
+			wantHint: "plain http",
+		},
+		{
+			name:     "two versions",
+			values:   []string{"1.0.1", "1.0.2"},
+			wantHint: "two versions",
+		},
+		{
+			name:     "two sources",
+			values:   []string{"https://a.example.com/r.json", "https://b.example.com/r.json"},
+			wantHint: "two release sources",
+		},
+		{
+			name:     "a URL with no host",
+			values:   []string{"https:///releases.json"},
+			wantHint: "missing a host",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := release.Configure(tt.values)
+			if err == nil {
+				t.Fatalf("Configure(%q) succeeded, want an error", tt.values)
+			}
+			if !strings.Contains(err.Error(), tt.wantHint) {
+				t.Errorf("error = %q, want it to mention %q", err, tt.wantHint)
+			}
+		})
+	}
+}

--- a/tools/cli/internal/ui/repl.go
+++ b/tools/cli/internal/ui/repl.go
@@ -201,7 +201,8 @@ func b2cWalkthroughPanes(sampleURL, consoleURL string) []walkthroughPane {
 				"  " + Dim("Explore the self-service profile page - view account details, edit attributes, and change your password."),
 				"",
 				"  3  Click the username in the top-right corner and select Profile.",
-				"  4  View account details, edit profile attributes, or change your password. The page calls " + product.Name + " directly with your session token.",
+				"  4  View account details, edit profile attributes, or change your password. The page calls " + product.Name +
+					" directly with your session token.",
 			},
 		},
 		{
@@ -224,7 +225,9 @@ func b2cWalkthroughPanes(sampleURL, consoleURL string) []walkthroughPane {
 				"     " + Dim("last name     ") + "  " + Highlight("Wilson"),
 				"     " + Dim("mobile number ") + "  " + Highlight("+15550148812"),
 				"",
-				"  5  " + product.Name + " will create a Customer user and assign the Traveler role. The browser returns to the Wayfinder app signed in as the new user.",
+				"  5  " + product.Name +
+					" will create a Customer user and assign the Traveler role. The browser returns to the Wayfinder app signed in as " +
+					"the new user.",
 			},
 		},
 		{
@@ -236,7 +239,8 @@ func b2cWalkthroughPanes(sampleURL, consoleURL string) []walkthroughPane {
 				"  1  Open " + Cyan(sampleURL) + " and click Sign in.",
 				"  2  On the " + product.Name + " sign-in page, click Forgot password?",
 				"  3  Enter " + Bold("john.doe") + " as the username and submit.",
-				"  4  " + product.Name + " sends a recovery email to John's registered address. Open it from the inbox at " + Cyan(mailInboxURL) + ".",
+				"  4  " + product.Name + " sends a recovery email to John's registered address. Open it from the inbox at " +
+					Cyan(mailInboxURL) + ".",
 				"  5  Click the reset link in the email and set a new password.",
 				"  6  Sign in again with the new credentials.",
 			},
@@ -245,15 +249,20 @@ func b2cWalkthroughPanes(sampleURL, consoleURL string) []walkthroughPane {
 			Title: "Staff Sign-Up",
 			URL:   consoleURL,
 			Lines: []string{
-				"Invite and onboard two new staff members entirely from the " + product.Name + " Console: Sam Rivera (Support) and Maya Patel (DestinationsAdmin). The admin picks the staff role and sends the invitation, and the matching role is attached automatically when the invitee completes their profile.",
+				"Invite and onboard two new staff members entirely from the " + product.Name +
+					" Console: Sam Rivera (Support) and Maya Patel (DestinationsAdmin). The admin picks the staff role and sends the " +
+					"invitation, and the matching role is attached automatically when the invitee completes their profile.",
 				"",
 				"  1  Sign in to the " + product.Name + " Console at " + Cyan(consoleURL) + " as your admin user.",
 				"  2  Navigate to Users and select Add User.",
 				"  3  Select Staff as the user type.",
-				"  4  Pick Support as the role, enter Sam Rivera's email (" + Bold("sam.rivera@example.com") + "), and click Send invitation. An invite link is emailed to Sam.",
-				"  5  Open Sam's invitation email from the inbox at " + Cyan(mailInboxURL) + " and open the link. The browser opens a Complete Your Profile page.",
+				"  4  Pick Support as the role, enter Sam Rivera's email (" + Bold("sam.rivera@example.com") +
+					"), and click Send invitation. An invite link is emailed to Sam.",
+				"  5  Open Sam's invitation email from the inbox at " + Cyan(mailInboxURL) +
+					" and open the link. The browser opens a Complete Your Profile page.",
 				"  6  Fill in the additional attributes and submit. Sam's account is now active with the Support role attached.",
-				"  7  Repeat the flow for Maya Patel (email " + Bold("maya.patel@example.com") + "), picking DestinationsAdmin as the role.",
+				"  7  Repeat the flow for Maya Patel (email " + Bold("maya.patel@example.com") +
+					"), picking DestinationsAdmin as the role.",
 			},
 		},
 	}
@@ -277,7 +286,8 @@ func agentWalkthroughPanes(sampleURL string) []walkthroughPane {
 				"     " + Dim("username") + "  " + Highlight("john.doe"),
 				"     " + Dim("password") + "  " + Highlight("john.doe"),
 				"",
-				"  2  Open the chat widget (bottom-right corner) and send any message. The concierge responds — John's token carries the " + Bold("agent:access") + " scope.",
+				"  2  Open the chat widget (bottom-right corner) and send any message. The concierge responds — John's token carries the " +
+					Bold("agent:access") + " scope.",
 				"  3  Sign out and sign in as Jane Smith.",
 				"",
 				"     " + Red("✗") + " Jane does not have access to chat with the Wayfinder chat agent",
@@ -285,7 +295,8 @@ func agentWalkthroughPanes(sampleURL string) []walkthroughPane {
 				"     " + Dim("username") + "  " + Highlight("jane.smith"),
 				"     " + Dim("password") + "  " + Highlight("jane.smith"),
 				"",
-				"  4  Open the chat. Since Jane does not have the Wayfinder Chat User role, the chat agent will not be accessible and the widget will show an error message instead.",
+				"  4  Open the chat. Since Jane does not have the Wayfinder Chat User role, the chat agent will not be accessible and " +
+					"the widget will show an error message instead.",
 			},
 		},
 		{
@@ -304,7 +315,8 @@ func agentWalkthroughPanes(sampleURL string) []walkthroughPane {
 				"     " + Dim(`"What flights are there from Colombo to Singapore?"`),
 				"",
 				"  3  The agent calls the Wayfinder MCP server with its own M2M token (client_credentials grant). No popup appears.",
-				"  4  You can also try asking for flight deals — the agent calls the recommend_bookings tool, which requires the " + Bold("booking:recommend") + " scope, granted to the Wayfinder Concierge via its Recommender role.",
+				"  4  You can also try asking for flight deals — the agent calls the recommend_bookings tool, which requires the " +
+					Bold("booking:recommend") + " scope, granted to the Wayfinder Concierge via its Recommender role.",
 				"",
 				"     " + Dim(`"Suggest a few flight deals."`),
 			},
@@ -324,9 +336,12 @@ func agentWalkthroughPanes(sampleURL string) []walkthroughPane {
 				"",
 				"     " + Dim(`"Book flight 2"`),
 				"",
-				"  3  The agent returns a consent request. A popup opens - sign in as John and select which booking permissions to grant (" + Bold("booking:read") + ", " + Bold("booking:create") + ", " + Bold("booking:cancel") + ").",
-				"  4  Click Authorize. The agent retries the action using John's context token, and the booking confirmation appears in the chat shortly after.",
-				"  5  To see the rejection path, repeat the flow but deny " + Bold("booking:create") + " in the consent screen. The agent returns a 403.",
+				"  3  The agent returns a consent request. A popup opens - sign in as John and select which booking permissions to " +
+					"grant (" + Bold("booking:read") + ", " + Bold("booking:create") + ", " + Bold("booking:cancel") + ").",
+				"  4  Click Authorize. The agent retries the action using John's context token, and the booking confirmation appears in " +
+					"the chat shortly after.",
+				"  5  To see the rejection path, repeat the flow but deny " + Bold("booking:create") +
+					" in the consent screen. The agent returns a 403.",
 			},
 		},
 	}
@@ -409,7 +424,7 @@ type ReplModel struct {
 	switchRequested   bool   // set when the /use command is executed
 	newVersion        string // non-empty shows a persistent upgrade-available notice below the banner
 
-	nodeWarning       string // non-empty shows a persistent Node.js version notice below the banner
+	nodeWarning string // non-empty shows a persistent Node.js version notice below the banner
 
 	// showAllOnEmpty shows the full command list on an empty prompt for
 	// returning users (who skip the first-run onboarding picker). It clears
@@ -479,7 +494,10 @@ func (m *ReplModel) appendTailLogLine(line string) {
 }
 
 // NewReplModel initializes the REPL model.
-func NewReplModel(version string, proc *exec.Cmd, installPath string, verbose bool, isFirstRun bool, creds *setup.AdminCredentials) ReplModel {
+func NewReplModel(
+	version string, proc *exec.Cmd, installPath string,
+	verbose bool, isFirstRun bool, creds *setup.AdminCredentials,
+) ReplModel {
 	ti := textinput.New()
 	ti.Placeholder = "Starting " + product.Name + "..."
 	ti.Prompt = "> "
@@ -827,8 +845,7 @@ func (m ReplModel) update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop,fu
 	// key prompt does nothing, and the value is too long to retype comfortably.
 	case tea.PasteMsg:
 		var tiCmd tea.Cmd
-		switch {
-		case m.showUsecaseConfig && m.ucStep < len(m.ucInputs) && len(m.ucInputs[m.ucStep].Choices) == 0:
+		if m.showUsecaseConfig && m.ucStep < len(m.ucInputs) && len(m.ucInputs[m.ucStep].Choices) == 0 {
 			m.ucText, tiCmd = m.ucText.Update(msg)
 		}
 		cmds = append(cmds, tiCmd)
@@ -1802,7 +1819,8 @@ func (m ReplModel) bodyPreamble() string {
 	}
 
 	if m.newVersion != "" && m.status == statusReady {
-		b.WriteString(Yellow("✦") + " " + Bold(product.Name+" v"+m.newVersion+" is available") + " — type " + Cyan("/upgrade") + " to upgrade\n\n")
+		b.WriteString(Yellow("✦") + " " + Bold(product.Name+" v"+m.newVersion+" is available") + " — type " + Cyan("/upgrade") +
+			" to upgrade\n\n")
 	}
 
 	switch m.status {

--- a/tools/cli/internal/ui/repl_internal_test.go
+++ b/tools/cli/internal/ui/repl_internal_test.go
@@ -493,9 +493,11 @@ func TestStop_UndeliverableSignalFallsBackToThePort(t *testing.T) {
 	}
 }
 
-// Exiting is not an explicit stop: the server an exited launcher left behind is not
-// this session's to take down on the way out.
-func TestExit_UndeliverableSignalLeavesThePortAlone(t *testing.T) {
+// Exiting a session that owns the launcher still has to clean up after it. The
+// undeliverable signal means start.sh's trap never ran, so the server it backgrounded
+// is still listening; unlike an attached session, this one started it and must not walk
+// away leaving it up.
+func TestExit_UndeliverableSignalStopsTheServerItStarted(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("uses a POSIX signal")
 	}
@@ -513,7 +515,7 @@ func TestExit_UndeliverableSignalLeavesThePortAlone(t *testing.T) {
 
 	m.killThunderID()
 
-	if len(*stopped) != 0 {
-		t.Fatalf("exiting must not port-stop, got %v", *stopped)
+	if len(*stopped) != 1 || (*stopped)[0] != 8091 {
+		t.Fatalf("expected the orphaned server to be stopped on exit, got %v", *stopped)
 	}
 }

--- a/tools/cli/internal/utils/node.go
+++ b/tools/cli/internal/utils/node.go
@@ -28,7 +28,8 @@ func NodeUpgradeHint() string {
 func DetectNodeVersion() (string, error) {
 	out, err := exec.Command("node", "--version").Output()
 	if err != nil {
-		return "", fmt.Errorf("node.js not found — v%s or later is required to run sample apps; install it from https://nodejs.org/en/download", MinNodeVersion)
+		return "", fmt.Errorf("node.js not found — v%s or later is required to run sample apps; install it from "+
+			"https://nodejs.org/en/download", MinNodeVersion)
 	}
 	return strings.TrimPrefix(strings.TrimSpace(string(out)), "v"), nil
 }

--- a/tools/i18n-extractor/generator.go
+++ b/tools/i18n-extractor/generator.go
@@ -68,12 +68,7 @@ func (g *Generator) Generate(messages []ExtractedMessage, outputPath string) err
 	sortedMessages := make([]MessageEntry, 0, len(keys))
 	for _, k := range keys {
 		msg := messageMap[k][0] // Take the first one since we are sure there are no duplicates now
-		sortedMessages = append(sortedMessages, MessageEntry{
-			Key:          msg.Key,
-			DefaultValue: msg.DefaultValue,
-			SourceFile:   msg.SourceFile,
-			Line:         msg.Line,
-		})
+		sortedMessages = append(sortedMessages, MessageEntry(msg))
 	}
 
 	data := struct {

--- a/tools/npx/README.md
+++ b/tools/npx/README.md
@@ -24,12 +24,44 @@ the cached installation and start immediately.
 
 ## Flags
 
-| Flag              | Description                              |
-| ----------------- | ---------------------------------------- |
-| `--setup`         | Force re-run setup                       |
-| `--verbose`, `-v` | Show detailed output                     |
-| `--version`, `-V` | Show the CLI version                     |
-| `--help`, `-h`    | Show help                                |
+| Flag                | Description                                                      |
+| ------------------- | ---------------------------------------------------------------- |
+| `--product-version` | Install a specific release, or read releases from another source |
+| `--setup`           | Force re-run setup                                               |
+| `--verbose`, `-v`   | Show detailed output                                             |
+| `--version`, `-V`   | Show the CLI version                                             |
+| `--help`, `-h`      | Show help                                                        |
+
+## Choosing a Version
+
+By default ThunderID installs the latest release. `--product-version` takes either a version or a
+manifest URL, so you can pin a release or point at your own mirror.
+
+```bash
+# Install and run a specific release instead of the latest.
+npx thunderid --product-version 1.0.1
+
+# Read releases from somewhere other than thunderid.dev, such as an internal mirror.
+npx thunderid --product-version https://releases.example.com/releases.json
+
+# Both: that version, from that mirror.
+npx thunderid --product-version https://releases.example.com/releases.json --product-version 1.0.1
+```
+
+The same value can be given as `THUNDERID_PRODUCT_VERSION` for scripted runs. Flags win over the
+environment.
+
+A few things worth knowing:
+
+- A version that is already installed starts straight away; nothing is downloaded again.
+- A version the manifest does not carry is an error listing the ones it does, rather than
+  quietly installing something else.
+- Pinning suppresses the upgrade notice, and `upgrade` refuses to run while pinned, so it cannot
+  move you off the release you asked for.
+- A custom source is used on its own: ThunderID will not fall back to the public releases behind
+  your back, and it prints the source it is reading so a stray environment variable is never
+  silent.
+- Releases are executable, so a custom source must be `https`, except on `localhost`.
 
 ## Requirements
 


### PR DESCRIPTION
### Purpose

The CLI under `tools/cli` had no end to end coverage, and nothing under `tools/` was built, linted or tested by any PR workflow. This adds an e2e suite that drives the CLI the way users actually invoke it, plus a workflow to run it.

It also unbreaks two pre existing failures on `main` that the new workflow gates on, so the gate is green from the start rather than red on arrival.

### Approach

**The suite drives `npx thunderid`, not the Go binary.** Specs spawn `node tools/npx/bin/thunderid.js` under a real pseudo terminal, so the wrapper, the download and extract path, `setup.sh`, the port negotiation and the bubbletea REPL are exercised as one chain. Nothing is stubbed: a run reaches the release manifest, downloads a real distribution, boots the server, and finally launches the Wayfinder sample and signs into it in a browser. 18 specs, about two minutes warm.

**Playwright Test plus node-pty, in `tests/e2e-cli`.** A pseudo terminal is required rather than a pipe. The CLI branches on `ui.Interactive()` to decide whether to prompt at all, so a piped run would assert the scripted fallbacks instead of the paths users see, and would cover neither the port conflict prompt, the credential prompt, the onboarding picker, nor the REPL.

**Why a separate Playwright project.** `tests/e2e` starts a backend on port 8090 through its `webServer` before the first test runs. Here the CLI is the thing that installs and starts ThunderID, and it needs that port free, so sharing the configuration is not possible. The new project defines no browser projects and runs no `playwright install`, since it drives a terminal.

**Isolation.** Each spec gets a temp `HOME`, which relocates `~/.thunderid/state.json`, and a temp working directory, which relocates the `./thunderid/vX` install. Every `THUNDERID_*` variable is stripped from the child environment so local shell configuration cannot change what is under test.

**Structure.** Specs are grouped by the part of the CLI they exercise, one Playwright project per folder, ordered by the project dependency graph (the same mechanism `tests/e2e` uses for `wayfinder-setup`):

| Project | Depends on | Covers |
|---|---|---|
| `commands` | nothing | `--help`, `-h`, `integrate`, `try` with no install |
| `install` | nothing | Manifest, download, extract, `setup.sh`, start, `state.json`, files on disk |
| `repl` | `install` | Onboarding picker and command overlay, `/status`, `/logs`, `/open-console`, `/integrate-react`, `/stop` |
| `restart` | `install` | Warm start, `--setup` |
| `port-conflict` | `install` | Alternate port, abort, reclaim |
| `sample` | all of the above | Unknown sample name, and `try wayfinder` through a browser login |

**Cost.** An extracted distribution is roughly 85MB, so `install` performs it once and everything downstream reuses it, warm starting in seconds. Only two specs download: `install`, and the first-run port conflict, which needs an install setup has not yet pinned to a port. The suite is single worker by necessity: every spec binds the default port or deliberately holds it.

Deliberately not covered, with reasons recorded in `tests/e2e-cli/README.md`: `/try-consumer` from inside the REPL, a real `upgrade`, and the offline fallback. The last one is unreachable until the releases URL becomes injectable; it is a constant in `internal/product` today.

**Three findings from writing the sample spec**, all worth a look in review:

- **`try consumer` is not a valid command.** The only sample name the CLI accepts is `wayfinder` (`sample.go:56-64`); `consumer` exists only as the REPL slash command `/try-consumer`. So the name a user is most likely to type from the REPL fails on the command line. The error does name what is available, and `unknown-usecase.spec.ts` now pins that message down, but the mismatch may be worth reconsidering.
- **`try` leaves everything running.** It installs no signal handler and never calls `StopServices`, so it exits with npm and all five sample services still up, plus the ThunderID server it restarted. The `Press Ctrl+C to stop.` line it prints is misleading, since the command has already returned. The spec cleans up after itself.
- **The sample spec runs the CLI without a pty**, unlike every other spec. `try` exits as soon as the services are up, and closing a pty at that point SIGHUPs the ThunderID server it just backgrounded, which broke the browser login with a discovery failure until I traced it. A real terminal is owned by the shell, so the pipe is the honest model here.

**node-pty needs two pieces of workspace wiring**, both worth a look in review:

- A `node-pty: true` entry in `allowBuilds`. Without it pnpm skips the install script and no prebuilt binary is fetched.
- A `postinstall` that restores the executable bit on node-pty's `spawn-helper`. The prebuild's mode bits are lost on extraction into the pnpm store, after which the addon loads fine but every spawn fails with the opaque `posix_spawnp failed`. This bit me during development and would bite anyone on a fresh install.

**Pre existing fixes included here.** The new `unit` job runs `go test ./...` and golangci-lint over `tools/cli`, and both failed on `main`:

- `TestExit_UndeliverableSignalLeavesThePortAlone` failed deterministically. Commit 2da93ee30 moved `if !explicit` into an `else if` so an undeliverable signal always falls through to the port stop, which is what stops an exit from stranding the server it started. The test still encoded the previous behavior and was never updated. It is now renamed and asserts the intended behavior.
- 23 golangci-lint findings, all in committed code. Long lines are wrapped, plus `gofmt`, `gocritic`, `ineffassign` and two misspells. `cancelling` joins `cancelled` in `ignore-words`, since the codebase consistently uses the British spelling in user facing strings.

The line wrapping touches user facing walkthrough copy, so every change was verified to preserve string contents exactly: the SHA-256 of all string literal contents in source order is unchanged in each of the three files touched.

**One behavior worth flagging for review.** The onboarding picker reappears on every run until a use case is actually selected, because `onboardingDone` is only recorded by `ui.selectOnboarding`. The specs document this rather than assert it, in case it is not intended.

### Related Issues
- Fixes https://github.com/thunder-id/thunderid/issues/3954

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive cross-platform end-to-end coverage for CLI installation, startup, REPL commands, port conflicts, restarts, and sample applications.
  * Added automated validation for CLI help, integration flows, readiness, authentication, and console launching.
  * Added continuous integration checks for CLI linting, unit tests, and end-to-end tests on Ubuntu and macOS.

* **Bug Fixes**
  * Improved cleanup behavior so servers started by the CLI are stopped when exiting after an undeliverable signal.

* **Documentation**
  * Added instructions for running and extending the CLI end-to-end test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->