### PR TITLE
Validate entity type property names and bind JSON filter keys

### DIFF
--- a/api/agent.yaml
+++ b/api/agent.yaml
@@ -2682,7 +2682,12 @@ components:
           additionalProperties: false
         schema:
           type: object
-          description: "JSON Schema definition for the agent type"
+          description: >-
+            JSON Schema definition for the agent type. Property names must match
+            '^[A-Za-z][A-Za-z0-9$_-]*$' - the SCIM 2.0 attribute-name rule (RFC 7643 section 2.1):
+            a letter followed by letters, digits, '$', '-' and '_'. A '.' is not permitted because
+            it separates nested segments in attribute filter expressions. Use 'displayName' for a
+            human-readable label.
           additionalProperties:
             oneOf:
               - type: object
@@ -2750,7 +2755,9 @@ components:
                     description: "Human-readable label shown in the UI for this property"
                   properties:
                     type: object
-                    description: "Nested properties of the object"
+                    description: >-
+                      Nested properties of the object. Names follow the same rule as
+                      top-level property names.
                     additionalProperties:
                       $ref: "#/components/schemas/AgentType/properties/schema/additionalProperties"
                 additionalProperties: false
@@ -2892,7 +2899,12 @@ components:
           $ref: "#/components/schemas/AgentType/properties/systemAttributes"
         schema:
           type: object
-          description: "JSON Schema definition for the agent type"
+          description: >-
+            JSON Schema definition for the agent type. Property names must match
+            '^[A-Za-z][A-Za-z0-9$_-]*$' - the SCIM 2.0 attribute-name rule (RFC 7643 section 2.1):
+            a letter followed by letters, digits, '$', '-' and '_'. A '.' is not permitted because
+            it separates nested segments in attribute filter expressions. Use 'displayName' for a
+            human-readable label.
           additionalProperties:
             $ref: "#/components/schemas/AgentType/properties/schema/additionalProperties"
 
@@ -2917,7 +2929,12 @@ components:
           $ref: "#/components/schemas/AgentType/properties/systemAttributes"
         schema:
           type: object
-          description: "JSON Schema definition for the agent type"
+          description: >-
+            JSON Schema definition for the agent type. Property names must match
+            '^[A-Za-z][A-Za-z0-9$_-]*$' - the SCIM 2.0 attribute-name rule (RFC 7643 section 2.1):
+            a letter followed by letters, digits, '$', '-' and '_'. A '.' is not permitted because
+            it separates nested segments in attribute filter expressions. Use 'displayName' for a
+            human-readable label.
           additionalProperties:
             $ref: "#/components/schemas/AgentType/properties/schema/additionalProperties"
 

--- a/api/user.yaml
+++ b/api/user.yaml
@@ -2234,7 +2234,12 @@ components:
           additionalProperties: false
         schema:
           type: object
-          description: "JSON Schema definition for the user type"
+          description: >-
+            JSON Schema definition for the user type. Property names must match
+            '^[A-Za-z][A-Za-z0-9$_-]*$' - the SCIM 2.0 attribute-name rule (RFC 7643 section 2.1):
+            a letter followed by letters, digits, '$', '-' and '_'. A '.' is not permitted because
+            it separates nested segments in attribute filter expressions. Use 'displayName' for a
+            human-readable label.
           additionalProperties:
             oneOf:
               - type: object
@@ -2293,7 +2298,9 @@ components:
                     description: "Whether this attribute must be provided for the user type"
                   properties:
                     type: object
-                    description: "Nested properties of the object"
+                    description: >-
+                      Nested properties of the object. Names follow the same rule as
+                      top-level property names.
                     additionalProperties:
                       $ref: "#/components/schemas/UserType/properties/schema/additionalProperties"
                 additionalProperties: false
@@ -2455,7 +2462,12 @@ components:
           $ref: "#/components/schemas/UserType/properties/systemAttributes"
         schema:
           type: object
-          description: "JSON Schema definition for the user type"
+          description: >-
+            JSON Schema definition for the user type. Property names must match
+            '^[A-Za-z][A-Za-z0-9$_-]*$' - the SCIM 2.0 attribute-name rule (RFC 7643 section 2.1):
+            a letter followed by letters, digits, '$', '-' and '_'. A '.' is not permitted because
+            it separates nested segments in attribute filter expressions. Use 'displayName' for a
+            human-readable label.
           additionalProperties:
             $ref: "#/components/schemas/UserType/properties/schema/additionalProperties"
 
@@ -2478,7 +2490,12 @@ components:
           $ref: "#/components/schemas/UserType/properties/systemAttributes"
         schema:
           type: object
-          description: "JSON Schema definition for the user type"
+          description: >-
+            JSON Schema definition for the user type. Property names must match
+            '^[A-Za-z][A-Za-z0-9$_-]*$' - the SCIM 2.0 attribute-name rule (RFC 7643 section 2.1):
+            a letter followed by letters, digits, '$', '-' and '_'. A '.' is not permitted because
+            it separates nested segments in attribute filter expressions. Use 'displayName' for a
+            human-readable label.
           additionalProperties:
             $ref: "#/components/schemas/UserType/properties/schema/additionalProperties"
 

--- a/backend/internal/entity/store_constants.go
+++ b/backend/internal/entity/store_constants.go
@@ -258,9 +258,6 @@ func buildIdentifyQuery(filters map[string]interface{}, deploymentID string) (mo
 
 	keys := make([]string, 0, len(filters))
 	for key := range filters {
-		if err := utils.ValidateKey(key); err != nil {
-			return model.DBQuery{}, nil, fmt.Errorf("invalid filter key: %w", err)
-		}
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
@@ -268,15 +265,18 @@ func buildIdentifyQuery(filters map[string]interface{}, deploymentID string) (mo
 	pgQuery := `SELECT ID FROM "ENTITY" WHERE 1=1`
 	sqQuery := `SELECT ID FROM "ENTITY" WHERE 1=1`
 	args := make([]interface{}, 0, len(keys)+1)
+	paramIndex := 1
 
-	for i, key := range keys {
-		pg, sq := buildDualColumnConditions("", key, i+1)
+	for _, key := range keys {
+		pg, sq := buildDualColumnConditions("", key, paramIndex)
 		pgQuery += pg
 		sqQuery += sq
-		args = append(args, filters[key])
+		keyArgs := buildDualColumnArgs(key, filters[key])
+		args = append(args, keyArgs...)
+		paramIndex += len(keyArgs)
 	}
 
-	pgQuery += fmt.Sprintf(" AND DEPLOYMENT_ID = $%d", len(keys)+1)
+	pgQuery += fmt.Sprintf(" AND DEPLOYMENT_ID = $%d", paramIndex)
 	sqQuery += " AND DEPLOYMENT_ID = ?"
 	args = append(args, deploymentID)
 
@@ -561,9 +561,6 @@ func buildIdentifyQueryHybrid(
 
 	nonIndexedKeys := make([]string, 0, len(nonIndexedFilters))
 	for key := range nonIndexedFilters {
-		if err := utils.ValidateKey(key); err != nil {
-			return model.DBQuery{}, nil, fmt.Errorf("invalid non-indexed filter key: %w", err)
-		}
 		nonIndexedKeys = append(nonIndexedKeys, key)
 	}
 	sort.Strings(nonIndexedKeys)
@@ -572,8 +569,9 @@ func buildIdentifyQueryHybrid(
 		pg, sq := buildDualColumnConditions("e.", key, paramIndex)
 		postgresQuery += pg
 		sqliteQuery += sq
-		args = append(args, nonIndexedFilters[key])
-		paramIndex++
+		keyArgs := buildDualColumnArgs(key, nonIndexedFilters[key])
+		args = append(args, keyArgs...)
+		paramIndex += len(keyArgs)
 	}
 
 	postgresQuery += fmt.Sprintf(" AND e.DEPLOYMENT_ID = $%d", paramIndex)
@@ -601,22 +599,36 @@ func buildGetEntitiesByIDsQuery(entityIDs []string, deploymentID string) (model.
 }
 
 // buildDualColumnConditions returns AND conditions for both Postgres and SQLite that match a key
-// against both ATTRIBUTES and SYSTEM_ATTRIBUTES using COALESCE (one parameter per key).
+// against both ATTRIBUTES and SYSTEM_ATTRIBUTES using COALESCE. The key's path segments and the
+// compared value are bind parameters, numbered from paramIndex: one set of segments per column
+// followed by the value. Use buildDualColumnArgs to supply them in the matching order.
 func buildDualColumnConditions(tablePrefix, key string, paramIndex int) (pgCond, sqCond string) {
 	attrCol := tablePrefix + AttributesColumn
 	sysCol := tablePrefix + SystemAttributesColumn
-	sqCond = fmt.Sprintf(" AND COALESCE(json_extract(%s, '$.%s'), json_extract(%s, '$.%s')) = ?",
-		sysCol, key, attrCol, key)
-	if strings.Contains(key, ".") {
-		parts := strings.Split(key, ".")
-		pathArray := "{" + strings.Join(parts, ",") + "}"
-		pgCond = fmt.Sprintf(" AND COALESCE(%s#>>'%s', %s#>>'%s') = $%d",
-			sysCol, pathArray, attrCol, pathArray, paramIndex)
-		return
-	}
-	pgCond = fmt.Sprintf(" AND COALESCE(%s->>'%s', %s->>'%s') = $%d",
-		sysCol, key, attrCol, key, paramIndex)
+	segments := len(utils.SplitJSONKey(key))
+
+	sqCond = fmt.Sprintf(" AND COALESCE(%s, %s) = ?",
+		utils.BuildSQLiteJSONPathExpr(sysCol, segments),
+		utils.BuildSQLiteJSONPathExpr(attrCol, segments))
+	pgCond = fmt.Sprintf(" AND COALESCE(%s, %s) = $%d",
+		utils.BuildPostgresJSONPathExpr(sysCol, segments, paramIndex),
+		utils.BuildPostgresJSONPathExpr(attrCol, segments, paramIndex+segments),
+		paramIndex+2*segments)
 	return
+}
+
+// buildDualColumnArgs returns the bind arguments for one condition built by
+// buildDualColumnConditions: the key's path segments once for each of the two columns,
+// followed by the compared value.
+func buildDualColumnArgs(key string, value interface{}) []interface{} {
+	segments := utils.SplitJSONKey(key)
+	args := make([]interface{}, 0, 2*len(segments)+1)
+	for i := 0; i < 2; i++ {
+		for _, segment := range segments {
+			args = append(args, segment)
+		}
+	}
+	return append(args, value)
 }
 
 // buildPaginatedQuery constructs a paginated query string with ORDER BY, LIMIT, and OFFSET clauses.
@@ -636,6 +648,8 @@ func buildPaginatedQuery(baseQuery string, paramCount int, placeholder string) (
 
 // buildFilterQueryWithOffset constructs a filter query where parameter numbering starts at the given offset.
 // This is used when the base query already has parameters (e.g., CATEGORY = $1).
+//
+//nolint:unparam // The error result is kept so all query builders share one signature; callers propagate it.
 func buildFilterQueryWithOffset(
 	queryID string, baseQuery string, filters map[string]interface{}, paramOffset int,
 ) (model.DBQuery, []interface{}, error) {
@@ -645,20 +659,20 @@ func buildFilterQueryWithOffset(
 
 	keys := make([]string, 0, len(filters))
 	for key := range filters {
-		if err := utils.ValidateKey(key); err != nil {
-			return model.DBQuery{}, nil, fmt.Errorf("invalid filter key: %w", err)
-		}
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 
 	postgresQuery := baseQuery
 	sqliteQuery := strings.Replace(baseQuery, "$1", "?", 1)
+	paramIndex := paramOffset + 1
 
-	for i, key := range keys {
-		postgresQuery += utils.BuildPostgresJSONCondition(columnName, key, paramOffset+i+1)
+	for _, key := range keys {
+		postgresQuery += utils.BuildPostgresJSONCondition(columnName, key, paramIndex)
 		sqliteQuery += utils.BuildSQLiteJSONCondition(columnName, key)
-		args = append(args, filters[key])
+		keyArgs := utils.JSONConditionArgs(key, filters[key])
+		args = append(args, keyArgs...)
+		paramIndex += len(keyArgs)
 	}
 
 	resultQuery := model.DBQuery{

--- a/backend/internal/entity/store_constants_test.go
+++ b/backend/internal/entity/store_constants_test.go
@@ -19,6 +19,8 @@ func TestStoreConstantsTestSuite(t *testing.T) {
 
 const testDeploymentID = "test-deployment"
 
+const testCategoryBaseQuery = `SELECT * FROM "ENTITY" WHERE CATEGORY = $1`
+
 func (s *StoreConstantsTestSuite) TestAppendOUIDsINClause_EmptyOUIDs() {
 	q, args := appendOUIDsINClause(QueryGetEntityByID, []interface{}{"e1", "dep1"}, []string{})
 	s.Contains(q.Query, "1=0")
@@ -201,7 +203,7 @@ func (s *StoreConstantsTestSuite) TestBuildPaginatedQuery_Success() {
 }
 
 func (s *StoreConstantsTestSuite) TestBuildFilterQueryWithOffset_Success() {
-	base := `SELECT * FROM "ENTITY" WHERE CATEGORY = $1`
+	base := testCategoryBaseQuery
 	filters := map[string]interface{}{"email": "a@b.com"}
 	q, args, err := buildFilterQueryWithOffset("test-qid", base, filters, 1)
 	s.NoError(err)
@@ -210,7 +212,7 @@ func (s *StoreConstantsTestSuite) TestBuildFilterQueryWithOffset_Success() {
 }
 
 func (s *StoreConstantsTestSuite) TestBuildFilterQueryWithOffset_NoFilters() {
-	base := `SELECT * FROM "ENTITY" WHERE CATEGORY = $1`
+	base := testCategoryBaseQuery
 	q, args, err := buildFilterQueryWithOffset("test-qid", base, nil, 1)
 	s.NoError(err)
 	s.NotEmpty(q.Query)
@@ -224,43 +226,111 @@ func (s *StoreConstantsTestSuite) TestBuildIdentifyQuery_COALESCE_PostgresQuery(
 	q, args, err := buildIdentifyQuery(map[string]interface{}{"clientId": "app123"}, testDeploymentID)
 	s.NoError(err)
 	s.Contains(q.PostgresQuery, "COALESCE")
-	s.Contains(q.PostgresQuery, "ATTRIBUTES->>'clientId'")
-	s.Contains(q.PostgresQuery, "SYSTEM_ATTRIBUTES->>'clientId'")
-	s.Contains(q.PostgresQuery, "$1")
-	s.Contains(q.PostgresQuery, "$2")
-	s.Len(args, 2)
-	s.Equal("app123", args[0])
-	s.Equal(testDeploymentID, args[1])
+	s.Contains(q.PostgresQuery, "SYSTEM_ATTRIBUTES->>($1)::text")
+	s.Contains(q.PostgresQuery, "ATTRIBUTES->>($2)::text")
+	s.Contains(q.PostgresQuery, "= $3")
+	s.Contains(q.PostgresQuery, "DEPLOYMENT_ID = $4")
+	// The key is bound once per column, then the value, then the deployment ID last.
+	s.Equal([]interface{}{"clientId", "clientId", "app123", testDeploymentID}, args)
+	s.NotContains(q.PostgresQuery, "'clientId'")
 }
 
 func (s *StoreConstantsTestSuite) TestBuildIdentifyQuery_COALESCE_SQLiteQuery() {
 	q, args, err := buildIdentifyQuery(map[string]interface{}{"clientId": "app123"}, testDeploymentID)
 	s.NoError(err)
 	s.Contains(q.SQLiteQuery, "COALESCE")
-	s.Contains(q.SQLiteQuery, "json_extract(ATTRIBUTES, '$.clientId')")
-	s.Contains(q.SQLiteQuery, "json_extract(SYSTEM_ATTRIBUTES, '$.clientId')")
+	s.Contains(q.SQLiteQuery, "json_extract(ATTRIBUTES, '$' || '.' || json_quote(?))")
+	s.Contains(q.SQLiteQuery, "json_extract(SYSTEM_ATTRIBUTES, '$' || '.' || json_quote(?))")
+	s.NotContains(q.SQLiteQuery, "clientId")
 	_ = args
 }
 
 func (s *StoreConstantsTestSuite) TestBuildIdentifyQuery_MultipleFilters_CorrectParamIndexes() {
-	// keys are sorted: clientId < name, so clientId=$1, name=$2, deploymentID=$3
+	// keys are sorted: clientId < name. Each key binds its segments once per column, then its
+	// value, so clientId takes $1-$3, name takes $4-$6 and the deployment ID is last at $7.
 	filters := map[string]interface{}{"clientId": "app123", "name": "myapp"}
 	q, args, err := buildIdentifyQuery(filters, testDeploymentID)
 	s.NoError(err)
-	s.Contains(q.PostgresQuery, "$1")
-	s.Contains(q.PostgresQuery, "$2")
-	s.Contains(q.PostgresQuery, "$3")
-	s.Len(args, 3)
-	s.Equal(testDeploymentID, args[2])
+	s.Contains(q.PostgresQuery, "COALESCE(SYSTEM_ATTRIBUTES->>($1)::text, ATTRIBUTES->>($2)::text) = $3")
+	s.Contains(q.PostgresQuery, "COALESCE(SYSTEM_ATTRIBUTES->>($4)::text, ATTRIBUTES->>($5)::text) = $6")
+	s.Contains(q.PostgresQuery, "DEPLOYMENT_ID = $7")
+	s.Equal([]interface{}{
+		"clientId", "clientId", "app123",
+		"name", "name", "myapp",
+		testDeploymentID,
+	}, args)
 }
 
 func (s *StoreConstantsTestSuite) TestBuildIdentifyQuery_NestedKey_UsesPathSyntax() {
-	q, _, err := buildIdentifyQuery(map[string]interface{}{"address.city": "NYC"}, testDeploymentID)
+	q, args, err := buildIdentifyQuery(map[string]interface{}{"address.city": "NYC"}, testDeploymentID)
 	s.NoError(err)
-	s.Contains(q.PostgresQuery, "#>>")
-	s.Contains(q.PostgresQuery, "{address,city}")
-	s.Contains(q.SQLiteQuery, "json_extract")
-	s.Contains(q.SQLiteQuery, "$.address.city")
+	s.Contains(q.PostgresQuery, "SYSTEM_ATTRIBUTES->($1)::text->>($2)::text")
+	s.Contains(q.PostgresQuery, "ATTRIBUTES->($3)::text->>($4)::text")
+	s.Contains(q.SQLiteQuery, "json_extract(SYSTEM_ATTRIBUTES, '$' || '.' || json_quote(?) || '.' || json_quote(?))")
+	s.Equal([]interface{}{
+		"address", "city",
+		"address", "city",
+		"NYC", testDeploymentID,
+	}, args)
+}
+
+// TestBuildIdentifyQuery_SpecialCharacterKeys covers keys well outside the entity type property
+// name charset, including the hyphenated name from the reported issue. Schema validation keeps
+// most of these out, but not every filter key comes from a schema — the agent list handler passes
+// the requested attribute through verbatim — so the builder must bind any key it is handed rather
+// than write it into the query text.
+func (s *StoreConstantsTestSuite) TestBuildIdentifyQuery_SpecialCharacterKeys() {
+	specialKeys := []string{
+		"silver-mail",
+		"x@y",
+		"a b",
+		"o'k",
+		"h\u00e9llo",
+		"double\"quote",
+		"back\\slash",
+		"sql;injection",
+		"drop') = 1 OR 1=1 --",
+	}
+
+	for _, key := range specialKeys {
+		q, args, err := buildIdentifyQuery(map[string]interface{}{key: "value"}, testDeploymentID)
+		s.NoError(err, "Key should be accepted: %s", key)
+		s.Equal([]interface{}{key, key, "value", testDeploymentID}, args)
+		s.NotContains(q.PostgresQuery, key)
+		s.NotContains(q.SQLiteQuery, key)
+	}
+}
+
+// TestBuildFilterQueryWithOffset_SpecialCharacterKey covers the entity listing path, which
+// shares the same key handling as the uniqueness path.
+func (s *StoreConstantsTestSuite) TestBuildFilterQueryWithOffset_SpecialCharacterKey() {
+	base := testCategoryBaseQuery
+	q, args, err := buildFilterQueryWithOffset(
+		"test-qid", base, map[string]interface{}{"silver-mail": "a@b.com"}, 1)
+	s.NoError(err)
+	s.Contains(q.PostgresQuery, "ATTRIBUTES->>($2)::text = $3")
+	s.Contains(q.SQLiteQuery, "json_extract(ATTRIBUTES, '$' || '.' || json_quote(?)) = ?")
+	s.Equal([]interface{}{"silver-mail", "a@b.com"}, args)
+	s.NotContains(q.PostgresQuery, "silver-mail")
+}
+
+// TestBuildIdentifyQueryHybrid_SpecialCharacterNonIndexedKey covers the hybrid path, where an
+// indexed identifier narrows the search and a non-indexed JSON attribute completes it.
+func (s *StoreConstantsTestSuite) TestBuildIdentifyQueryHybrid_SpecialCharacterNonIndexedKey() {
+	q, args, err := buildIdentifyQueryHybrid(
+		map[string]interface{}{"email": "a@b.com"},
+		map[string]interface{}{"silver-mail": "c@d.com"},
+		testDeploymentID)
+	s.NoError(err)
+	s.Contains(q.PostgresQuery, "e.SYSTEM_ATTRIBUTES->>($3)::text")
+	s.Contains(q.PostgresQuery, "e.ATTRIBUTES->>($4)::text")
+	s.Contains(q.PostgresQuery, "e.DEPLOYMENT_ID = $6")
+	s.Equal([]interface{}{
+		"email", "a@b.com",
+		"silver-mail", "silver-mail", "c@d.com",
+		testDeploymentID,
+	}, args)
+	s.NotContains(q.PostgresQuery, "silver-mail")
 }
 
 func (s *StoreConstantsTestSuite) TestBuildIdentifyQueryHybrid_NonIndexed_UsesCOALESCE() {
@@ -269,9 +339,9 @@ func (s *StoreConstantsTestSuite) TestBuildIdentifyQueryHybrid_NonIndexed_UsesCO
 	q, _, err := buildIdentifyQueryHybrid(indexed, nonIndexed, testDeploymentID)
 	s.NoError(err)
 	s.Contains(q.PostgresQuery, "COALESCE")
-	s.Contains(q.PostgresQuery, "e.ATTRIBUTES->>'clientId'")
-	s.Contains(q.PostgresQuery, "e.SYSTEM_ATTRIBUTES->>'clientId'")
+	s.Contains(q.PostgresQuery, "e.ATTRIBUTES->>($4)::text")
+	s.Contains(q.PostgresQuery, "e.SYSTEM_ATTRIBUTES->>($3)::text")
 	s.Contains(q.SQLiteQuery, "COALESCE")
-	s.Contains(q.SQLiteQuery, "json_extract(e.ATTRIBUTES, '$.clientId')")
-	s.Contains(q.SQLiteQuery, "json_extract(e.SYSTEM_ATTRIBUTES, '$.clientId')")
+	s.Contains(q.SQLiteQuery, "json_extract(e.ATTRIBUTES, '$' || '.' || json_quote(?))")
+	s.Contains(q.SQLiteQuery, "json_extract(e.SYSTEM_ATTRIBUTES, '$' || '.' || json_quote(?))")
 }

--- a/backend/internal/entitytype/model/object.go
+++ b/backend/internal/entitytype/model/object.go
@@ -158,6 +158,9 @@ func compileObjectProperty(propMap map[string]json.RawMessage) (property, error)
 	}
 
 	for nestedName, nestedRaw := range nestedProps {
+		if err := validatePropertyName(nestedName); err != nil {
+			return nil, err
+		}
 		compiledNested, err := compileProperty(nestedName, nestedRaw)
 		if err != nil {
 			return nil, fmt.Errorf("invalid nested property '%s': %w", nestedName, err)

--- a/backend/internal/entitytype/model/schema.go
+++ b/backend/internal/entitytype/model/schema.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/thunder-id/thunderid/internal/system/log"
@@ -263,6 +264,24 @@ func convertToFloat64(value interface{}) (float64, bool) {
 	}
 }
 
+// propertyNamePattern is the SCIM 2.0 attribute-name production (RFC 7643 section 2.1):
+// a letter, followed by any number of letters, digits, '$', '-' and '_'.
+//
+// '.' is excluded deliberately. Filter keys built from a schema join nested property names with
+// '.', and the query layer splits them back on '.', so a literal dot inside a name cannot be told
+// apart from traversal into a nested object.
+var propertyNamePattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9$_-]*$`)
+
+// validatePropertyName reports whether name may be used as a schema property name. Property names
+// are machine names; use the 'displayName' field for a human-readable label.
+func validatePropertyName(name string) error {
+	if !propertyNamePattern.MatchString(name) {
+		return fmt.Errorf("invalid property name '%s': must start with a letter and contain only "+
+			"letters, digits, '-', '_' and '$'", name)
+	}
+	return nil
+}
+
 // CompileSchema compiles an entity type JSON Schema from the provided raw JSON.
 func CompileSchema(schema json.RawMessage) (*Schema, error) {
 	var schemaMap map[string]json.RawMessage
@@ -279,6 +298,9 @@ func CompileSchema(schema json.RawMessage) (*Schema, error) {
 	}
 
 	for propName, propRaw := range schemaMap {
+		if err := validatePropertyName(propName); err != nil {
+			return nil, err
+		}
 		compiledProp, err := compileProperty(propName, propRaw)
 		if err != nil {
 			return nil, fmt.Errorf("invalid property '%s': %w", propName, err)

--- a/backend/internal/entitytype/model/schema_test.go
+++ b/backend/internal/entitytype/model/schema_test.go
@@ -483,3 +483,51 @@ func (s *SchemaValidateTestSuite) TestGetAttributes_UniqueOnlyAndType() {
 	s.True(subjectCandidates[0].Required)
 	s.Equal(TypeString, subjectCandidates[0].Type)
 }
+
+func (s *SchemaValidateTestSuite) TestPropertyName_AcceptsSCIMCharset() {
+	// RFC 7643 section 2.1 names: a letter, then letters, digits, '$', '-' and '_'. The hyphen is
+	// the case reported in issue #1696.
+	schema, err := CompileSchema(json.RawMessage(`{
+		"silver-mail": {"type": "string", "unique": true},
+		"given_name": {"type": "string"},
+		"empNo2": {"type": "number"},
+		"a$ref": {"type": "string"},
+		"address": {"type": "object", "properties": {
+			"post-code": {"type": "string"}
+		}}
+	}`))
+	s.Require().NoError(err)
+	s.Len(schema.properties, 5)
+}
+
+func (s *SchemaValidateTestSuite) TestPropertyName_RejectsOutOfCharset() {
+	cases := map[string]string{
+		"dot":            `{"a.b": {"type": "string"}}`,
+		"at sign":        `{"x@y": {"type": "string"}}`,
+		"space":          `{"work phone": {"type": "string"}}`,
+		"apostrophe":     `{"o'k": {"type": "string"}}`,
+		"double quote":   `{"a\"b": {"type": "string"}}`,
+		"backslash":      `{"a\\b": {"type": "string"}}`,
+		"non-ascii":      `{"héllo": {"type": "string"}}`,
+		"leading digit":  `{"1email": {"type": "string"}}`,
+		"leading hyphen": `{"-email": {"type": "string"}}`,
+		"underscore":     `{"_email": {"type": "string"}}`,
+		"empty":          `{"": {"type": "string"}}`,
+		"sql":            `{"drop') = 1 OR 1=1 --": {"type": "string"}}`,
+	}
+	for name, schemaJSON := range cases {
+		_, err := CompileSchema(json.RawMessage(schemaJSON))
+		s.Require().Error(err, "%s must be rejected", name)
+		s.Contains(err.Error(), "invalid property name", "%s", name)
+	}
+}
+
+func (s *SchemaValidateTestSuite) TestPropertyName_RejectsOutOfCharsetWhenNested() {
+	_, err := CompileSchema(json.RawMessage(`{
+		"address": {"type": "object", "properties": {
+			"post.code": {"type": "string"}
+		}}
+	}`))
+	s.Require().Error(err)
+	s.Contains(err.Error(), "invalid property name 'post.code'")
+}

--- a/backend/internal/system/database/utils/querybuilder.go
+++ b/backend/internal/system/database/utils/querybuilder.go
@@ -25,19 +25,19 @@ func BuildFilterQuery(
 
 	keys := make([]string, 0, len(filters))
 	for key := range filters {
-		if err := ValidateKey(key); err != nil {
-			return model.DBQuery{}, nil, fmt.Errorf("invalid filter key: %w", err)
-		}
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 
 	postgresQuery := baseQuery
 	sqliteQuery := baseQuery
-	for i, key := range keys {
-		postgresQuery += BuildPostgresJSONCondition(columnName, key, i+1)
+	paramIndex := 1
+	for _, key := range keys {
+		postgresQuery += BuildPostgresJSONCondition(columnName, key, paramIndex)
 		sqliteQuery += BuildSQLiteJSONCondition(columnName, key)
-		args = append(args, filters[key])
+		keyArgs := JSONConditionArgs(key, filters[key])
+		args = append(args, keyArgs...)
+		paramIndex += len(keyArgs)
 	}
 
 	resultQuery := model.DBQuery{
@@ -71,28 +71,63 @@ func AppendDeploymentIDToFilterQuery(
 	return *updatedQuery, argsWithDeploymentID
 }
 
-// BuildPostgresJSONCondition builds a PostgreSQL JSON filter condition.
-// For nested paths (e.g., "address.city"), it uses the #>> operator with an array path.
-// For simple paths (e.g., "email"), it uses the ->> operator.
-func BuildPostgresJSONCondition(columnName, key string, paramIndex int) string {
-	if strings.Contains(key, ".") {
-		// Handle nested JSON path
-		keys := strings.Split(key, ".")
-		pathArray := "{" + strings.Join(keys, ",") + "}"
-		return fmt.Sprintf(" AND %s#>>'%s' = $%d", columnName, pathArray, paramIndex)
+// SplitJSONKey splits a filter key into its JSON path segments. A dot separates nested
+// levels, so "address.city" addresses the "city" member of the "address" object.
+func SplitJSONKey(key string) []string {
+	return strings.Split(key, ".")
+}
+
+// BuildPostgresJSONPathExpr builds a PostgreSQL expression that extracts, as text, the value at a
+// JSON path of segmentCount segments within columnName. Each segment is a bind parameter, numbered
+// consecutively from paramIndex, so a segment may contain any character. The ::text casts keep the
+// -> and ->> operator overloads unambiguous when the right operand is a bind parameter.
+func BuildPostgresJSONPathExpr(columnName string, segmentCount, paramIndex int) string {
+	expr := columnName
+	for i := 0; i < segmentCount-1; i++ {
+		expr += fmt.Sprintf("->($%d)::text", paramIndex+i)
 	}
-	// Handle simple JSON path
-	return fmt.Sprintf(" AND %s->>'%s' = $%d", columnName, key, paramIndex)
+	return expr + fmt.Sprintf("->>($%d)::text", paramIndex+segmentCount-1)
 }
 
-// BuildSQLiteJSONCondition builds a SQLite JSON filter condition.
-// For both nested and simple paths, it uses json_extract with dot notation.
+// BuildSQLiteJSONPathExpr builds the SQLite counterpart of BuildPostgresJSONPathExpr. The JSON path
+// is assembled from bind parameters with json_quote, which quotes and escapes each segment so that
+// every character is taken as part of an object label instead of as path syntax.
+func BuildSQLiteJSONPathExpr(columnName string, segmentCount int) string {
+	path := "'$'"
+	for i := 0; i < segmentCount; i++ {
+		path += " || '.' || json_quote(?)"
+	}
+	return fmt.Sprintf("json_extract(%s, %s)", columnName, path)
+}
+
+// BuildPostgresJSONCondition builds a PostgreSQL JSON filter condition. The key's path segments and
+// the compared value are bind parameters starting at paramIndex; use JSONConditionArgs to supply them.
+func BuildPostgresJSONCondition(columnName, key string, paramIndex int) string {
+	segments := SplitJSONKey(key)
+	return fmt.Sprintf(" AND %s = $%d",
+		BuildPostgresJSONPathExpr(columnName, len(segments), paramIndex), paramIndex+len(segments))
+}
+
+// BuildSQLiteJSONCondition builds the SQLite counterpart of BuildPostgresJSONCondition. It binds the
+// same arguments in the same order, so both dialects can share a single argument list.
 func BuildSQLiteJSONCondition(columnName, key string) string {
-	return fmt.Sprintf(" AND json_extract(%s, '$.%s') = ?", columnName, key)
+	return fmt.Sprintf(" AND %s = ?", BuildSQLiteJSONPathExpr(columnName, len(SplitJSONKey(key))))
 }
 
-// ValidateKey ensures that the provided key contains only safe characters (alphanumeric, underscores, and dots).
-// This validation prevents SQL injection by ensuring keys can be safely used in queries.
+// JSONConditionArgs returns the bind arguments for a condition built by BuildPostgresJSONCondition
+// or BuildSQLiteJSONCondition: the key's path segments in order, followed by the compared value.
+func JSONConditionArgs(key string, value interface{}) []interface{} {
+	segments := SplitJSONKey(key)
+	args := make([]interface{}, 0, len(segments)+1)
+	for _, segment := range segments {
+		args = append(args, segment)
+	}
+	return append(args, value)
+}
+
+// ValidateKey ensures that the provided key contains only safe characters (alphanumeric, underscores,
+// and dots). It guards identifiers such as column names, which form part of the query text and cannot
+// be bound as parameters. Filter keys are bound as parameters and are deliberately not restricted.
 func ValidateKey(key string) error {
 	for _, char := range key {
 		if !(char >= 'a' && char <= 'z' || char >= 'A' && char <= 'Z' ||

--- a/backend/internal/system/database/utils/querybuilder_test.go
+++ b/backend/internal/system/database/utils/querybuilder_test.go
@@ -40,23 +40,25 @@ func (suite *QueryBuilderTestSuite) TestBuildFilterQuery() {
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), queryID, query.ID)
-	assert.Len(suite.T(), args, 2)
+	// Each key contributes its path segments followed by the compared value.
+	assert.Len(suite.T(), args, 4)
 
 	// Verify args order due to sorting of keys
-	assert.Equal(suite.T(), int(30), args[0])
-	assert.Equal(suite.T(), "admin", args[1])
+	assert.Equal(suite.T(), "age", args[0])
+	assert.Equal(suite.T(), int(30), args[1])
+	assert.Equal(suite.T(), "role", args[2])
+	assert.Equal(suite.T(), "admin", args[3])
 
 	// Test Postgres query
 	postgresQuery := query.GetQuery("postgres")
 	assert.Contains(suite.T(), postgresQuery, baseQuery)
-	assert.Contains(suite.T(), postgresQuery, "attributes->>'age' = $1")
-	assert.Contains(suite.T(), postgresQuery, "attributes->>'role' = $2")
+	assert.Contains(suite.T(), postgresQuery, "attributes->>($1)::text = $2")
+	assert.Contains(suite.T(), postgresQuery, "attributes->>($3)::text = $4")
 
 	// Test SQLite query
 	sqliteQuery := query.GetQuery("sqlite")
 	assert.Contains(suite.T(), sqliteQuery, baseQuery)
-	assert.Contains(suite.T(), sqliteQuery, "json_extract(attributes, '$.age') = ?")
-	assert.Contains(suite.T(), sqliteQuery, "json_extract(attributes, '$.role') = ?")
+	assert.Contains(suite.T(), sqliteQuery, "json_extract(attributes, '$' || '.' || json_quote(?)) = ?")
 
 	// Test default query (should return PostgreSQL query)
 	defaultQuery := query.GetQuery("unknown")
@@ -99,21 +101,34 @@ func (suite *QueryBuilderTestSuite) TestBuildFilterQueryWithInvalidColumnName() 
 	assert.Nil(suite.T(), args)
 }
 
-func (suite *QueryBuilderTestSuite) TestBuildFilterQueryWithInvalidFilterKey() {
-	queryID := "invalid_filter_key"
-	baseQuery := testBaseQuery
-	columnName := testColumnName
-	filters := map[string]interface{}{
-		"valid":              "value",
-		"invalid-filter-key": "value", // Contains invalid character '-'
+// TestBuildFilterQuerySpecialCharacterKeys verifies that a filter key is not restricted to any
+// character set: it is bound as a parameter rather than written into the query text.
+func (suite *QueryBuilderTestSuite) TestBuildFilterQuerySpecialCharacterKeys() {
+	specialKeys := []string{
+		"silver-mail",
+		"x@y",
+		"a b",
+		"o'k",
+		"h\u00e9llo",
+		"double\"quote",
+		"back\\slash",
+		"sql;injection",
+		"drop') = 1 OR 1=1 --",
 	}
 
-	query, args, err := BuildFilterQuery(queryID, baseQuery, columnName, filters)
+	for _, key := range specialKeys {
+		filters := map[string]interface{}{key: "value"}
+		query, args, err := BuildFilterQuery("special_key", testBaseQuery, testColumnName, filters)
 
-	assert.Error(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "invalid filter key")
-	assert.Equal(suite.T(), model.DBQuery{}, query)
-	assert.Nil(suite.T(), args)
+		assert.NoError(suite.T(), err, "Key should be accepted: %s", key)
+		assert.Len(suite.T(), args, 2, "Key should be bound: %s", key)
+		assert.Equal(suite.T(), key, args[0])
+		assert.Equal(suite.T(), "value", args[1])
+
+		// The key must never appear in the query text of either dialect.
+		assert.NotContains(suite.T(), query.GetQuery("postgres"), key)
+		assert.NotContains(suite.T(), query.GetQuery("sqlite"), key)
+	}
 }
 
 func (suite *QueryBuilderTestSuite) TestValidateKey() {
@@ -164,24 +179,26 @@ func (suite *QueryBuilderTestSuite) TestBuildFilterQueryDatabaseSpecificQueries(
 
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), queryID, query.ID)
-	assert.Len(suite.T(), args, 2)
+	assert.Len(suite.T(), args, 4)
 
-	// Verify arguments are in sorted order (email, name)
-	assert.Equal(suite.T(), "test@example.com", args[0])
-	assert.Equal(suite.T(), "John Doe", args[1])
+	// Verify arguments are in sorted order (email, name), each preceded by its path segments
+	assert.Equal(suite.T(), "email", args[0])
+	assert.Equal(suite.T(), "test@example.com", args[1])
+	assert.Equal(suite.T(), "name", args[2])
+	assert.Equal(suite.T(), "John Doe", args[3])
 
 	// Test PostgreSQL-specific query
 	postgresQuery := query.GetQuery("postgres")
 	expectedPostgres := testUserBaseQuery +
-		" AND ATTRIBUTES->>'email' = $1" +
-		" AND ATTRIBUTES->>'name' = $2"
+		" AND ATTRIBUTES->>($1)::text = $2" +
+		" AND ATTRIBUTES->>($3)::text = $4"
 	assert.Equal(suite.T(), expectedPostgres, postgresQuery)
 
 	// Test SQLite-specific query
 	sqliteQuery := query.GetQuery("sqlite")
 	expectedSQLite := testUserBaseQuery +
-		" AND json_extract(ATTRIBUTES, '$.email') = ?" +
-		" AND json_extract(ATTRIBUTES, '$.name') = ?"
+		" AND json_extract(ATTRIBUTES, '$' || '.' || json_quote(?)) = ?" +
+		" AND json_extract(ATTRIBUTES, '$' || '.' || json_quote(?)) = ?"
 	assert.Equal(suite.T(), expectedSQLite, sqliteQuery)
 
 	// Test that both queries are stored in the struct
@@ -201,19 +218,20 @@ func (suite *QueryBuilderTestSuite) TestBuildFilterQuerySingleFilter() {
 	query, args, err := BuildFilterQuery(queryID, baseQuery, columnName, filters)
 
 	assert.NoError(suite.T(), err)
-	assert.Len(suite.T(), args, 1)
-	assert.Equal(suite.T(), "engineering", args[0])
+	assert.Len(suite.T(), args, 2)
+	assert.Equal(suite.T(), "department", args[0])
+	assert.Equal(suite.T(), "engineering", args[1])
 
 	// PostgreSQL query
 	postgresQuery := query.GetQuery("postgres")
 	expectedPostgres := "SELECT * FROM users WHERE active = true" +
-		" AND metadata->>'department' = $1"
+		" AND metadata->>($1)::text = $2"
 	assert.Equal(suite.T(), expectedPostgres, postgresQuery)
 
 	// SQLite query
 	sqliteQuery := query.GetQuery("sqlite")
 	expectedSQLite := "SELECT * FROM users WHERE active = true" +
-		" AND json_extract(metadata, '$.department') = ?"
+		" AND json_extract(metadata, '$' || '.' || json_quote(?)) = ?"
 	assert.Equal(suite.T(), expectedSQLite, sqliteQuery)
 }
 
@@ -229,24 +247,26 @@ func (suite *QueryBuilderTestSuite) TestBuildFilterQueryNestedPath() {
 	query, args, err := BuildFilterQuery(queryID, baseQuery, columnName, filters)
 
 	assert.NoError(suite.T(), err)
-	assert.Len(suite.T(), args, 2)
+	assert.Len(suite.T(), args, 6)
 
-	// Verify args order (sorted by key)
-	assert.Equal(suite.T(), "Mountain View", args[0])
-	assert.Equal(suite.T(), "94040", args[1])
+	// Verify args order (sorted by key), each key expanded into its path segments
+	assert.Equal(suite.T(), []interface{}{
+		"address", "city", "Mountain View",
+		"address", "zip", "94040",
+	}, args)
 
-	// PostgreSQL query - should use #>> operator for nested paths
+	// PostgreSQL query - should chain -> for each nested segment
 	postgresQuery := query.GetQuery("postgres")
 	expectedPostgres := testUserBaseQuery +
-		" AND ATTRIBUTES#>>'{address,city}' = $1" +
-		" AND ATTRIBUTES#>>'{address,zip}' = $2"
+		" AND ATTRIBUTES->($1)::text->>($2)::text = $3" +
+		" AND ATTRIBUTES->($4)::text->>($5)::text = $6"
 	assert.Equal(suite.T(), expectedPostgres, postgresQuery)
 
-	// SQLite query - should use json_extract with dot notation
+	// SQLite query - should quote each segment into the json_extract path
 	sqliteQuery := query.GetQuery("sqlite")
 	expectedSQLite := testUserBaseQuery +
-		" AND json_extract(ATTRIBUTES, '$.address.city') = ?" +
-		" AND json_extract(ATTRIBUTES, '$.address.zip') = ?"
+		" AND json_extract(ATTRIBUTES, '$' || '.' || json_quote(?) || '.' || json_quote(?)) = ?" +
+		" AND json_extract(ATTRIBUTES, '$' || '.' || json_quote(?) || '.' || json_quote(?)) = ?"
 	assert.Equal(suite.T(), expectedSQLite, sqliteQuery)
 }
 
@@ -263,27 +283,29 @@ func (suite *QueryBuilderTestSuite) TestBuildFilterQueryMixedSimpleAndNestedPath
 	query, args, err := BuildFilterQuery(queryID, baseQuery, columnName, filters)
 
 	assert.NoError(suite.T(), err)
-	assert.Len(suite.T(), args, 3)
+	assert.Len(suite.T(), args, 7)
 
 	// Verify args order (sorted by key: address.city, age, username)
-	assert.Equal(suite.T(), "San Francisco", args[0])
-	assert.Equal(suite.T(), 30, args[1])
-	assert.Equal(suite.T(), "john.doe", args[2])
+	assert.Equal(suite.T(), []interface{}{
+		"address", "city", "San Francisco",
+		"age", 30,
+		"username", "john.doe",
+	}, args)
 
 	// PostgreSQL query
 	postgresQuery := query.GetQuery("postgres")
 	expectedPostgres := testUserBaseQuery +
-		" AND ATTRIBUTES#>>'{address,city}' = $1" +
-		" AND ATTRIBUTES->>'age' = $2" +
-		" AND ATTRIBUTES->>'username' = $3"
+		" AND ATTRIBUTES->($1)::text->>($2)::text = $3" +
+		" AND ATTRIBUTES->>($4)::text = $5" +
+		" AND ATTRIBUTES->>($6)::text = $7"
 	assert.Equal(suite.T(), expectedPostgres, postgresQuery)
 
 	// SQLite query
 	sqliteQuery := query.GetQuery("sqlite")
 	expectedSQLite := testUserBaseQuery +
-		" AND json_extract(ATTRIBUTES, '$.address.city') = ?" +
-		" AND json_extract(ATTRIBUTES, '$.age') = ?" +
-		" AND json_extract(ATTRIBUTES, '$.username') = ?"
+		" AND json_extract(ATTRIBUTES, '$' || '.' || json_quote(?) || '.' || json_quote(?)) = ?" +
+		" AND json_extract(ATTRIBUTES, '$' || '.' || json_quote(?)) = ?" +
+		" AND json_extract(ATTRIBUTES, '$' || '.' || json_quote(?)) = ?"
 	assert.Equal(suite.T(), expectedSQLite, sqliteQuery)
 }
 
@@ -298,19 +320,20 @@ func (suite *QueryBuilderTestSuite) TestBuildFilterQueryDeeplyNestedPath() {
 	query, args, err := BuildFilterQuery(queryID, baseQuery, columnName, filters)
 
 	assert.NoError(suite.T(), err)
-	assert.Len(suite.T(), args, 1)
-	assert.Equal(suite.T(), "New York", args[0])
+	assert.Len(suite.T(), args, 5)
+	assert.Equal(suite.T(), []interface{}{"company", "location", "address", "city", "New York"}, args)
 
 	// PostgreSQL query - should handle deeply nested paths
 	postgresQuery := query.GetQuery("postgres")
 	expectedPostgres := "SELECT * FROM users WHERE 1=1" +
-		" AND data#>>'{company,location,address,city}' = $1"
+		" AND data->($1)::text->($2)::text->($3)::text->>($4)::text = $5"
 	assert.Equal(suite.T(), expectedPostgres, postgresQuery)
 
 	// SQLite query
 	sqliteQuery := query.GetQuery("sqlite")
 	expectedSQLite := "SELECT * FROM users WHERE 1=1" +
-		" AND json_extract(data, '$.company.location.address.city') = ?"
+		" AND json_extract(data, '$' || '.' || json_quote(?) || '.' || json_quote(?)" +
+		" || '.' || json_quote(?) || '.' || json_quote(?)) = ?"
 	assert.Equal(suite.T(), expectedSQLite, sqliteQuery)
 }
 
@@ -361,7 +384,7 @@ func (suite *QueryBuilderTestSuite) TestAppendDeploymentIDToFilterQueryWithExist
 	// Build initial filter query
 	query, args, err := BuildFilterQuery(queryID, baseQuery, columnName, filters)
 	assert.NoError(suite.T(), err)
-	assert.Len(suite.T(), args, 2)
+	assert.Len(suite.T(), args, 4)
 
 	// Append server ID
 	updatedQuery, updatedArgs := AppendDeploymentIDToFilterQuery(query, args, deploymentID)
@@ -369,24 +392,25 @@ func (suite *QueryBuilderTestSuite) TestAppendDeploymentIDToFilterQueryWithExist
 	// Verify query ID is preserved
 	assert.Equal(suite.T(), queryID, updatedQuery.ID)
 
-	// Verify args - should have original args plus server ID
-	assert.Len(suite.T(), updatedArgs, 3)
-	assert.Equal(suite.T(), "user@example.com", updatedArgs[0])
-	assert.Equal(suite.T(), "admin", updatedArgs[1])
-	assert.Equal(suite.T(), deploymentID, updatedArgs[2])
+	// Verify args - should have original args plus server ID, which stays last
+	assert.Equal(suite.T(), []interface{}{
+		"email", "user@example.com",
+		"role", "admin",
+		deploymentID,
+	}, updatedArgs)
 
 	// Verify PostgreSQL query
 	expectedPostgres := testUserBaseQuery +
-		" AND ATTRIBUTES->>'email' = $1" +
-		" AND ATTRIBUTES->>'role' = $2" +
-		" AND DEPLOYMENT_ID = $3"
+		" AND ATTRIBUTES->>($1)::text = $2" +
+		" AND ATTRIBUTES->>($3)::text = $4" +
+		" AND DEPLOYMENT_ID = $5"
 	assert.Equal(suite.T(), expectedPostgres, updatedQuery.PostgresQuery)
 	assert.Equal(suite.T(), expectedPostgres, updatedQuery.Query)
 
 	// Verify SQLite query
 	expectedSQLite := testUserBaseQuery +
-		" AND json_extract(ATTRIBUTES, '$.email') = ?" +
-		" AND json_extract(ATTRIBUTES, '$.role') = ?" +
+		" AND json_extract(ATTRIBUTES, '$' || '.' || json_quote(?)) = ?" +
+		" AND json_extract(ATTRIBUTES, '$' || '.' || json_quote(?)) = ?" +
 		" AND DEPLOYMENT_ID = ?"
 	assert.Equal(suite.T(), expectedSQLite, updatedQuery.SQLiteQuery)
 }
@@ -408,19 +432,17 @@ func (suite *QueryBuilderTestSuite) TestAppendDeploymentIDToFilterQueryWithSingl
 	updatedQuery, updatedArgs := AppendDeploymentIDToFilterQuery(query, args, deploymentID)
 
 	// Verify args
-	assert.Len(suite.T(), updatedArgs, 2)
-	assert.Equal(suite.T(), "engineering", updatedArgs[0])
-	assert.Equal(suite.T(), deploymentID, updatedArgs[1])
+	assert.Equal(suite.T(), []interface{}{"department", "engineering", deploymentID}, updatedArgs)
 
 	// Verify PostgreSQL query
 	expectedPostgres := "SELECT USER_ID FROM \"USER\" WHERE active = true" +
-		" AND metadata->>'department' = $1" +
-		" AND DEPLOYMENT_ID = $2"
+		" AND metadata->>($1)::text = $2" +
+		" AND DEPLOYMENT_ID = $3"
 	assert.Equal(suite.T(), expectedPostgres, updatedQuery.PostgresQuery)
 
 	// Verify SQLite query
 	expectedSQLite := "SELECT USER_ID FROM \"USER\" WHERE active = true" +
-		" AND json_extract(metadata, '$.department') = ?" +
+		" AND json_extract(metadata, '$' || '.' || json_quote(?)) = ?" +
 		" AND DEPLOYMENT_ID = ?"
 	assert.Equal(suite.T(), expectedSQLite, updatedQuery.SQLiteQuery)
 }
@@ -443,22 +465,23 @@ func (suite *QueryBuilderTestSuite) TestAppendDeploymentIDToFilterQueryWithNeste
 	updatedQuery, updatedArgs := AppendDeploymentIDToFilterQuery(query, args, deploymentID)
 
 	// Verify args
-	assert.Len(suite.T(), updatedArgs, 3)
-	assert.Equal(suite.T(), "San Francisco", updatedArgs[0])
-	assert.Equal(suite.T(), "John Doe", updatedArgs[1])
-	assert.Equal(suite.T(), deploymentID, updatedArgs[2])
+	assert.Equal(suite.T(), []interface{}{
+		"address", "city", "San Francisco",
+		"name", "John Doe",
+		deploymentID,
+	}, updatedArgs)
 
 	// Verify PostgreSQL query
 	expectedPostgres := testUserBaseQuery +
-		" AND ATTRIBUTES#>>'{address,city}' = $1" +
-		" AND ATTRIBUTES->>'name' = $2" +
-		" AND DEPLOYMENT_ID = $3"
+		" AND ATTRIBUTES->($1)::text->>($2)::text = $3" +
+		" AND ATTRIBUTES->>($4)::text = $5" +
+		" AND DEPLOYMENT_ID = $6"
 	assert.Equal(suite.T(), expectedPostgres, updatedQuery.PostgresQuery)
 
 	// Verify SQLite query
 	expectedSQLite := testUserBaseQuery +
-		" AND json_extract(ATTRIBUTES, '$.address.city') = ?" +
-		" AND json_extract(ATTRIBUTES, '$.name') = ?" +
+		" AND json_extract(ATTRIBUTES, '$' || '.' || json_quote(?) || '.' || json_quote(?)) = ?" +
+		" AND json_extract(ATTRIBUTES, '$' || '.' || json_quote(?)) = ?" +
 		" AND DEPLOYMENT_ID = ?"
 	assert.Equal(suite.T(), expectedSQLite, updatedQuery.SQLiteQuery)
 }

--- a/backend/internal/user/handler.go
+++ b/backend/internal/user/handler.go
@@ -633,8 +633,10 @@ func parseFilterParams(query url.Values) (map[string]interface{}, *tidcommon.Ser
 
 // parseFilterExpression parses filter expressions in the format: attribute eq "value"
 func parseFilterExpression(filterStr string) (map[string]interface{}, error) {
-	// Regex to match: attribute_name eq "value" or attribute_name eq value
-	pattern := `^(\w+(?:\.\w+)*)\s+(eq)\s+(?:"([^"]*)"|(\w+|\d+))$`
+	// Regex to match: attribute_name eq "value" or attribute_name eq value.
+	// The attribute segments accept the same characters as a schema property name, so every
+	// attribute an entity type can declare is also filterable; '.' separates nested segments.
+	pattern := `^([A-Za-z][A-Za-z0-9$_-]*(?:\.[A-Za-z][A-Za-z0-9$_-]*)*)\s+(eq)\s+(?:"([^"]*)"|(\w+|\d+))$`
 	regex := regexp.MustCompile(pattern)
 
 	matches := regex.FindStringSubmatch(filterStr)

--- a/backend/internal/user/handler_test.go
+++ b/backend/internal/user/handler_test.go
@@ -1342,3 +1342,36 @@ func TestHandleSelfUserMetadataGetRequest_ServiceError(t *testing.T) {
 
 	require.Equal(t, http.StatusNotFound, rr.Code)
 }
+
+func TestParseFilterExpression_AttributeCharset(t *testing.T) {
+	// The filter grammar accepts the same attribute names an entity type schema can declare,
+	// so every declarable attribute is filterable (issue #1696).
+	valid := map[string]struct {
+		filter string
+		key    string
+	}{
+		"hyphen":      {`silver-mail eq "a@b.com"`, "silver-mail"},
+		"underscore":  {`given_name eq "Jane"`, "given_name"},
+		"dollar":      {`a$ref eq "x"`, "a$ref"},
+		"digits":      {`empNo2 eq "7"`, "empNo2"},
+		"nested path": {`address.post-code eq "10100"`, "address.post-code"},
+	}
+	for name, tc := range valid {
+		filters, err := parseFilterExpression(tc.filter)
+		require.NoError(t, err, name)
+		require.Contains(t, filters, tc.key, name)
+	}
+
+	invalid := map[string]string{
+		"space in name":  `work phone eq "111"`,
+		"at sign":        `x@y eq "1"`,
+		"leading digit":  `1email eq "a"`,
+		"leading hyphen": `-email eq "a"`,
+		"trailing dot":   `address. eq "a"`,
+		"sql injection":  `a') = 1 OR 1=1 -- eq "a"`,
+	}
+	for name, filter := range invalid {
+		_, err := parseFilterExpression(filter)
+		require.Error(t, err, name)
+	}
+}

--- a/tests/integration/usertype/user_uniqueness_test.go
+++ b/tests/integration/usertype/user_uniqueness_test.go
@@ -6,13 +6,18 @@ package usertype
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"testing"
 
-	"github.com/thunder-id/thunderid/tests/integration/testutils"
 	"github.com/stretchr/testify/suite"
+	"github.com/thunder-id/thunderid/tests/integration/testutils"
 )
+
+// nonWordCharUserType is the user type used by the RFC 7643 attribute-name coverage.
+const nonWordCharUserType = "non-word-char-employee"
 
 // UserUniquenessTestSuite contains tests for user uniqueness validation
 type UserUniquenessTestSuite struct {
@@ -143,6 +148,128 @@ func (ts *UserUniquenessTestSuite) TestCreateUserWithUniqueConstraintViolation()
 	ts.createdUsers = append(ts.createdUsers, userID5)
 }
 
+// TestCreateUserWithNonWordCharUniqueProperties covers uniqueness validation for schema property
+// names that go beyond letters, digits and underscores. The reported failure (issue #1696) was a
+// hyphenated unique property; the accepted name charset is RFC 7643 ATTRNAME, so '-' and '$' are
+// legal and must be usable as uniqueness filters.
+func (ts *UserUniquenessTestSuite) TestCreateUserWithNonWordCharUniqueProperties() {
+	schemaID := ts.createSchemaWithNonWordCharUniqueFields()
+	ts.createdSchemas = append(ts.createdSchemas, schemaID)
+
+	// Create first user - should succeed. No duplicate exists yet, which is the case that
+	// previously failed: the uniqueness lookup rejected the property name and the error surfaced
+	// as a spurious attribute conflict.
+	userID1 := ts.createUserAndExpectSuccess(CreateUserRequest{
+		OUID: ts.oUID,
+		Type: nonWordCharUserType,
+		Attributes: json.RawMessage(`{
+			"silver-mail": "john.doe@company.com",
+			"a$ref": "JD001",
+			"work-phone-2": "111"
+		}`),
+	})
+	ts.createdUsers = append(ts.createdUsers, userID1)
+
+	// Duplicate hyphenated unique property - should conflict.
+	ts.createUserAndExpectError(CreateUserRequest{
+		OUID: ts.oUID,
+		Type: nonWordCharUserType,
+		Attributes: json.RawMessage(`{
+			"silver-mail": "john.doe@company.com",
+			"a$ref": "JD002",
+			"work-phone-2": "222"
+		}`),
+	}, "USR-1014")
+
+	// Duplicate unique property containing "$" - should conflict.
+	ts.createUserAndExpectError(CreateUserRequest{
+		OUID: ts.oUID,
+		Type: nonWordCharUserType,
+		Attributes: json.RawMessage(`{
+			"silver-mail": "jane.smith@company.com",
+			"a$ref": "JD001",
+			"work-phone-2": "333"
+		}`),
+	}, "USR-1014")
+
+	// Duplicate unique property mixing hyphens and digits - should conflict.
+	ts.createUserAndExpectError(CreateUserRequest{
+		OUID: ts.oUID,
+		Type: nonWordCharUserType,
+		Attributes: json.RawMessage(`{
+			"silver-mail": "bob.wilson@company.com",
+			"a$ref": "JD003",
+			"work-phone-2": "111"
+		}`),
+	}, "USR-1014")
+
+	// All unique values different - should succeed.
+	userID2 := ts.createUserAndExpectSuccess(CreateUserRequest{
+		OUID: ts.oUID,
+		Type: nonWordCharUserType,
+		Attributes: json.RawMessage(`{
+			"silver-mail": "alice.brown@company.com",
+			"a$ref": "JD004",
+			"work-phone-2": "444"
+		}`),
+	})
+	ts.createdUsers = append(ts.createdUsers, userID2)
+
+	// The same names must also work as list filters, not just as uniqueness filters.
+	matched := ts.usersMatching("silver-mail", "alice.brown@company.com")
+	ts.Require().Len(matched, 1, "Expected exactly one user for the hyphenated attribute filter")
+	ts.Equal(userID2, matched[0].ID)
+
+	ts.Require().Empty(ts.usersMatching("silver-mail", "nobody@company.com"),
+		"A hyphenated attribute filter with no match must return no users")
+}
+
+// usersMatching returns the users matching an exact attribute value via GET /users?filter=.
+func (ts *UserUniquenessTestSuite) usersMatching(attr, value string) []testutils.User {
+	req, err := http.NewRequest(http.MethodGet, testServerURL+"/users", nil)
+	ts.Require().NoError(err, "Failed to build the user list request")
+
+	q := url.Values{}
+	q.Add("filter", attr+` eq "`+value+`"`)
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err, "GET /users with a filter failed")
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err, "Failed to read the user list response body")
+	ts.Require().Equal(http.StatusOK, resp.StatusCode,
+		"Expected 200 from the filtered user list, got %d: %s", resp.StatusCode, string(body))
+
+	var listResp testutils.UserListResponse
+	ts.Require().NoError(json.Unmarshal(body, &listResp), "Failed to decode the user list response")
+	return listResp.Users
+}
+
+// TestCreateUserTypeWithInvalidPropertyName covers the other half of the contract: a property name
+// the query layer cannot address unambiguously is rejected when the user type is created, rather
+// than accepted and then failing on every write.
+func (ts *UserUniquenessTestSuite) TestCreateUserTypeWithInvalidPropertyName() {
+	cases := map[string]string{
+		"dot":           `{"a.b": {"type": "string", "unique": true}}`,
+		"at sign":       `{"x@y": {"type": "string", "unique": true}}`,
+		"space":         `{"work phone": {"type": "string", "unique": true}}`,
+		"leading digit": `{"1email": {"type": "string", "unique": true}}`,
+		"nested dot":    `{"addr": {"type": "object", "properties": {"post.code": {"type": "string"}}}}`,
+	}
+
+	i := 0
+	for name, schemaJSON := range cases {
+		i++
+		ts.createSchemaAndExpectError(CreateUserTypeRequest{
+			Name:   fmt.Sprintf("invalid-prop-name-%d", i),
+			OUID:   ts.oUID,
+			Schema: json.RawMessage(schemaJSON),
+		}, name)
+	}
+}
+
 // Helper methods
 
 func (ts *UserUniquenessTestSuite) createSchemaWithUniqueFields() string {
@@ -158,6 +285,44 @@ func (ts *UserUniquenessTestSuite) createSchemaWithUniqueFields() string {
 	}
 
 	return ts.createSchema(schema)
+}
+
+func (ts *UserUniquenessTestSuite) createSchemaWithNonWordCharUniqueFields() string {
+	schema := CreateUserTypeRequest{
+		Name: nonWordCharUserType,
+		OUID: ts.oUID,
+		Schema: json.RawMessage(`{
+			"silver-mail": {"type": "string", "unique": true},
+			"a$ref": {"type": "string", "unique": true},
+			"work-phone-2": {"type": "string", "unique": true}
+		}`),
+	}
+
+	return ts.createSchema(schema)
+}
+
+// createSchemaAndExpectError posts a user type expected to be rejected as a bad request.
+func (ts *UserUniquenessTestSuite) createSchemaAndExpectError(schema CreateUserTypeRequest, caseName string) {
+	jsonData, err := json.Marshal(schema)
+	ts.Require().NoError(err, "Failed to marshal schema request")
+
+	req, err := http.NewRequest("POST", testServerURL+"/user-types", bytes.NewBuffer(jsonData))
+	ts.Require().NoError(err, "Failed to create schema request")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.client.Do(req)
+	ts.Require().NoError(err, "Failed to send schema request")
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	ts.Require().NoError(err, "Failed to read schema response body")
+
+	ts.Require().Equal(400, resp.StatusCode,
+		"User type with an invalid property name (%s) should be rejected: %s", caseName, string(body))
+
+	var errorResp ErrorResponse
+	ts.Require().NoError(json.Unmarshal(body, &errorResp), "Failed to unmarshal error response")
+	ts.Require().Equal("USRS-1004", errorResp.Code, "Error code should match expected for %s", caseName)
 }
 
 func (ts *UserUniquenessTestSuite) createSchema(schema CreateUserTypeRequest) string {


### PR DESCRIPTION
### Purpose

Fixes #1696.

A schema property named with a hyphen (`silver-mail`) and marked `unique: true` made user creation
fail with a spurious `409 USR-1014`, because the uniqueness lookup builds a filter key from the
property name and `ValidateKey` only allowed `[A-Za-z0-9_.]`.

The underlying gap is that entity type creation accepted **any** JSON object key as a property name,
while the query layer accepted a strict subset. This PR makes the two agree.

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes

Entity type property names are now validated at create/update against the SCIM 2.0 attribute name
production (RFC 7643 §2.1):

```
^[A-Za-z][A-Za-z0-9$_-]*$
```

Names outside this charset are rejected with `400 USRS-1004`. Previously any JSON key was accepted.

#### 💥 Impact

Creating or updating an entity type whose property name contains `.`, `@`, a space, a quote, a
non-ASCII character, or that starts with a digit or `_` now fails. Existing stored entities are not
touched and no migration runs.

Names containing `.` were already broken before this PR: a top-level property named `a.b` was
resolved as the nested path `a` -> `b`, so uniqueness silently returned the wrong answer and
duplicates were admitted. Rejecting them at creation removes that ambiguity by construction.

#### 🔄 Migration Guide

Rename the property to the supported charset and move the human-readable form to `displayName`,
which has no charset restriction:

```json
{ "work phone": { "type": "string" } }
```
```json
{ "work-phone": { "type": "string", "displayName": "Work phone" } }
```

### Approach

Two layers, answering different questions:

- **Contract** - `validatePropertyName` in `entitytype/model`, applied to top-level and nested
  property names. `-` is allowed (SCIM allows it explicitly); `.` is excluded for the reason SCIM
  excludes it, since it is the sub-attribute path separator. `displayName` already exists per
  property, so constraining the machine name costs no readability.
- **Storage** - filter keys are now bound as parameters instead of being interpolated into the JSON
  path, in both dialects. Kept as defense in depth, since not every filter key originates from a
  validated schema.

The `/users?filter=` grammar was widened to the same charset, so an attribute that can be declared
can also be filtered. Without it the fix is invisible on the list API.

### Testing

`make pr_checks` green. Integration suite also run against PostgreSQL 18.6 (50/50 packages), since the
PR gate covers SQLite only and this change touches JSON path construction in both dialects.

New coverage: property name charset (unit + integration, accepted and rejected), the filter grammar,
and direct tests for `buildIdentifyQuery`, `buildFilterQueryWithOffset` and `buildIdentifyQueryHybrid`,
which had none.

### Related Issues
- Fixes #1696

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [x] Integration Tests
- [x] Breaking changes. (Fill if applicable)
    - [x] Breaking changes section filled.
    - [x] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for SCIM-compatible attribute names, including hyphens, underscores, dollar signs, and digits.
  * Added support for nested attributes using dot-separated paths.
  * Filter queries now safely support special-character and nested attribute names across supported database engines.

* **Bug Fixes**
  * Invalid or ambiguous attribute names are rejected consistently during schema creation and filtering.
  * Improved filtering reliability for complex and nested attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->