### PR TITLE
Add MCP role management tools

### DIFF
--- a/backend/cmd/server/servicemanager.go
+++ b/backend/cmd/server/servicemanager.go
@@ -198,7 +198,14 @@ func registerServices(mux *http.ServeMux, cacheManager cache.CacheManagerInterfa
 	exporters = append(exporters, resourceExporter)
 
 	roleService, roleAssignmentService, ouRoleResolver, roleExporter, err := role.Initialize(
-		mux, entityService, groupService, ouService, resourceService, entityTypeService, ouAuthzService,
+		mux,
+		mcpServer,
+		entityService,
+		groupService,
+		ouService,
+		resourceService,
+		entityTypeService,
+		ouAuthzService,
 	)
 	fatalOnError(ctx, logger, err, "Failed to initialize RoleService")
 	exporters = append(exporters, roleExporter)

--- a/backend/internal/role/init.go
+++ b/backend/internal/role/init.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/thunder-id/thunderid/internal/entity"
 	"github.com/thunder-id/thunderid/internal/entitytype"
 	"github.com/thunder-id/thunderid/internal/group"
@@ -19,9 +20,10 @@ import (
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
 
-// Initialize initializes the role service and registers its routes.
+// Initialize initializes the role service, registers its routes, and exposes role tools when an MCP server is provided.
 func Initialize(
 	mux *http.ServeMux,
+	mcpServer *mcp.Server,
 	entityService entity.EntityServiceInterface,
 	groupService group.GroupServiceInterface,
 	ouService oupkg.OrganizationUnitServiceInterface,
@@ -56,6 +58,9 @@ func Initialize(
 	)
 	roleHandler := newRoleHandler(roleService, assignmentService)
 	registerRoutes(mux, roleHandler)
+	if mcpServer != nil {
+		registerMCPTools(mcpServer, roleService, assignmentService)
+	}
 	exporter := newRoleExporter(roleService, assignmentService)
 	ouRoleResolver := newOURoleResolver(roleStore)
 	return roleService, assignmentService, ouRoleResolver, exporter, nil

--- a/backend/internal/role/init_test.go
+++ b/backend/internal/role/init_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
@@ -642,7 +643,7 @@ func (suite *InitTestSuite) TestInitialize_DBClientError() {
 	}()
 
 	mux := http.NewServeMux()
-	_, _, _, _, err := Initialize(mux, nil, nil, nil, nil, nil, nil)
+	_, _, _, _, err := Initialize(mux, nil, nil, nil, nil, nil, nil, nil)
 
 	suite.Error(err)
 	suite.Equal("mock db client error", err.Error())
@@ -666,7 +667,7 @@ func (suite *InitTestSuite) TestInitialize_TransactionerError() {
 	}()
 
 	mux := http.NewServeMux()
-	_, _, _, _, err := Initialize(mux, nil, nil, nil, nil, nil, nil)
+	_, _, _, _, err := Initialize(mux, nil, nil, nil, nil, nil, nil, nil)
 
 	suite.Error(err)
 	suite.Equal("mock transactioner error", err.Error())
@@ -697,11 +698,57 @@ func (suite *InitTestSuite) TestInitialize_Success() {
 	}()
 
 	mux := http.NewServeMux()
-	svc, _, _, exporter, err := Initialize(mux, nil, nil, nil, nil, nil, nil)
+	mcpServer := mcp.NewServer(
+		&mcp.Implementation{
+			Name:    "test-server",
+			Version: "1.0.0",
+		},
+		nil,
+	)
+	svc, _, _, exporter, err := Initialize(mux, mcpServer, nil, nil, nil, nil, nil, nil)
 
-	suite.NoError(err)
+	suite.Require().NoError(err)
 	suite.NotNil(svc)
 	suite.NotNil(exporter)
+
+	ctx := context.Background()
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	serverSession, err := mcpServer.Connect(ctx, serverTransport, nil)
+	suite.Require().NoError(err)
+	suite.T().Cleanup(func() {
+		suite.NoError(serverSession.Close())
+	})
+
+	mcpClient := mcp.NewClient(
+		&mcp.Implementation{
+			Name:    "test-client",
+			Version: "1.0.0",
+		},
+		nil,
+	)
+	clientSession, err := mcpClient.Connect(ctx, clientTransport, nil)
+	suite.Require().NoError(err)
+	suite.T().Cleanup(func() {
+		suite.NoError(clientSession.Close())
+	})
+
+	result, err := clientSession.ListTools(ctx, nil)
+	suite.Require().NoError(err)
+
+	toolNames := make([]string, len(result.Tools))
+	for i, registeredTool := range result.Tools {
+		toolNames[i] = registeredTool.Name
+	}
+
+	suite.ElementsMatch([]string{
+		"thunderid_list_roles",
+		"thunderid_get_role",
+		"thunderid_create_role",
+		"thunderid_update_role",
+		"thunderid_delete_role",
+		"thunderid_get_role_assignments",
+		"thunderid_add_role_assignments",
+	}, toolNames)
 	mockProvider.AssertExpectations(suite.T())
 	mockClient.AssertExpectations(suite.T())
 }
@@ -733,7 +780,7 @@ func (suite *InitTestSuite) TestInitialize_StoreInitError() {
 	}()
 
 	mux := http.NewServeMux()
-	svc, _, _, exporter, err := Initialize(mux, nil, nil, nil, nil, nil, nil)
+	svc, _, _, exporter, err := Initialize(mux, nil, nil, nil, nil, nil, nil, nil)
 
 	suite.Error(err)
 	if err != nil {

--- a/backend/internal/role/tools.go
+++ b/backend/internal/role/tools.go
@@ -1,0 +1,460 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package role
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	serverconst "github.com/thunder-id/thunderid/internal/system/constants"
+	"github.com/thunder-id/thunderid/internal/system/mcp/tool"
+)
+
+type roleTools struct {
+	roleService       RoleServiceInterface
+	assignmentService RoleAssignmentServiceInterface
+}
+
+type roleListMCPResponse struct {
+	TotalResults int                   `json:"totalResults"`
+	Roles        []RoleSummaryResponse `json:"roles"`
+}
+
+type roleUpdateInput struct {
+	ID          string                `json:"id"`
+	Name        string                `json:"name"`
+	Description string                `json:"description,omitempty"`
+	OUID        string                `json:"ouId"`
+	Permissions []ResourcePermissions `json:"permissions"`
+}
+
+type roleAssignmentsInput struct {
+	ID             string       `json:"id"`
+	Limit          int          `json:"limit,omitempty"`
+	Offset         int          `json:"offset,omitempty"`
+	IncludeDisplay bool         `json:"includeDisplay,omitempty"`
+	Type           AssigneeType `json:"type,omitempty"`
+}
+
+type addRoleAssignmentsInput struct {
+	ID          string              `json:"id"`
+	Assignments []AssignmentRequest `json:"assignments"`
+}
+
+type assignmentListMCPResponse struct {
+	TotalResults int                  `json:"totalResults"`
+	Assignments  []AssignmentResponse `json:"assignments"`
+}
+
+type roleActionResponse struct {
+	Success bool `json:"success"`
+}
+
+// registerMCPTools exposes role and role-assignment operations with their input schemas and safety hints.
+func registerMCPTools(
+	server *mcp.Server,
+	roleService RoleServiceInterface,
+	assignmentService RoleAssignmentServiceInterface,
+) {
+	tools := &roleTools{
+		roleService:       roleService,
+		assignmentService: assignmentService,
+	}
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "thunderid_list_roles",
+		Description: "List roles with pagination.",
+		InputSchema: tool.GenerateSchema[tool.PaginationInput](
+			tool.WithDefault("", "limit", serverconst.DefaultPageSize),
+		),
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "List Roles",
+			ReadOnlyHint: true,
+		},
+	}, tools.listRoles)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "thunderid_get_role",
+		Description: "Retrieve a role by ID.",
+		InputSchema: tool.GenerateSchema[tool.IDInput](
+			tool.WithRequired("", "id"),
+		),
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Get Role",
+			ReadOnlyHint: true,
+		},
+	}, tools.getRole)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "thunderid_create_role",
+		Description: "Create a role with permissions and optional assignments.",
+		InputSchema: getCreateRoleSchema(),
+		Annotations: &mcp.ToolAnnotations{
+			Title:          "Create Role",
+			IdempotentHint: false,
+		},
+	}, tools.createRole)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "thunderid_update_role",
+		Description: "Update an existing role using full replacement.",
+		InputSchema: getUpdateRoleSchema(),
+		Annotations: &mcp.ToolAnnotations{
+			Title:          "Update Role",
+			IdempotentHint: true,
+		},
+	}, tools.updateRole)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "thunderid_delete_role",
+		Description: "Delete a role by ID.",
+		InputSchema: tool.GenerateSchema[tool.IDInput](
+			tool.WithRequired("", "id"),
+		),
+		Annotations: &mcp.ToolAnnotations{
+			Title: "Delete Role",
+		},
+	}, tools.deleteRole)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "thunderid_get_role_assignments",
+		Description: "Retrieve entities assigned to a role.",
+		InputSchema: getRoleAssignmentsSchema(),
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Get Role Assignments",
+			ReadOnlyHint: true,
+		},
+	}, tools.getRoleAssignments)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "thunderid_add_role_assignments",
+		Description: "Assign a role to users, applications, agents, or groups.",
+		InputSchema: getAddRoleAssignmentsSchema(),
+		Annotations: &mcp.ToolAnnotations{
+			Title:          "Add Role Assignments",
+			IdempotentHint: false,
+		},
+	}, tools.addRoleAssignments)
+}
+
+// listRoles returns a page of role summaries and applies the server default when limit is omitted.
+func (t *roleTools) listRoles(
+	ctx context.Context,
+	_ *mcp.CallToolRequest,
+	input tool.PaginationInput,
+) (*mcp.CallToolResult, *roleListMCPResponse, error) {
+	limit := input.Limit
+	if limit == 0 {
+		limit = serverconst.DefaultPageSize
+	}
+
+	roleList, svcErr := t.roleService.GetRoleList(
+		ctx,
+		limit,
+		input.Offset,
+	)
+	if svcErr != nil {
+		return nil, nil, fmt.Errorf(
+			"failed to list roles: %s",
+			svcErr.ErrorDescription,
+		)
+	}
+
+	roles := make([]RoleSummaryResponse, len(roleList.Roles))
+
+	for i, role := range roleList.Roles {
+		roles[i] = RoleSummaryResponse(role)
+	}
+
+	return nil, &roleListMCPResponse{
+		TotalResults: roleList.TotalResults,
+		Roles:        roles,
+	}, nil
+}
+
+// getRole returns one role with its organization unit and resource permissions.
+func (t *roleTools) getRole(
+	ctx context.Context,
+	_ *mcp.CallToolRequest,
+	input tool.IDInput,
+) (*mcp.CallToolResult, *RoleResponse, error) {
+	serviceRole, svcErr := t.roleService.GetRoleWithPermissions(
+		ctx,
+		input.ID,
+	)
+	if svcErr != nil {
+		return nil, nil, fmt.Errorf(
+			"failed to get role: %s",
+			svcErr.ErrorDescription,
+		)
+	}
+
+	return nil, &RoleResponse{
+		ID:          serviceRole.ID,
+		Name:        serviceRole.Name,
+		Description: serviceRole.Description,
+		OUID:        serviceRole.OUID,
+		OUHandle:    serviceRole.OUHandle,
+		Permissions: serviceRole.Permissions,
+	}, nil
+}
+
+// createRole creates a role and converts assignment inputs into service-layer assignments.
+func (t *roleTools) createRole(
+	ctx context.Context,
+	_ *mcp.CallToolRequest,
+	input CreateRoleRequest,
+) (*mcp.CallToolResult, *CreateRoleResponse, error) {
+	assignments := make([]RoleAssignment, len(input.Assignments))
+
+	for i, assignment := range input.Assignments {
+		assignments[i] = RoleAssignment{
+			ID:   assignment.ID,
+			Type: assignment.Type,
+		}
+	}
+
+	serviceRole, svcErr := t.roleService.CreateRole(
+		ctx,
+		RoleCreationDetail{
+			Name:        input.Name,
+			Description: input.Description,
+			OUID:        input.OUID,
+			Permissions: input.Permissions,
+			Assignments: assignments,
+		},
+	)
+	if svcErr != nil {
+		return nil, nil, fmt.Errorf(
+			"failed to create role: %s",
+			svcErr.ErrorDescription,
+		)
+	}
+
+	responseAssignments := make(
+		[]AssignmentResponse,
+		len(serviceRole.Assignments),
+	)
+
+	for i, assignment := range serviceRole.Assignments {
+		responseAssignments[i] = AssignmentResponse{
+			ID:   assignment.ID,
+			Type: assignment.Type,
+		}
+	}
+
+	return nil, &CreateRoleResponse{
+		ID:          serviceRole.ID,
+		Name:        serviceRole.Name,
+		Description: serviceRole.Description,
+		OUID:        serviceRole.OUID,
+		OUHandle:    serviceRole.OUHandle,
+		Permissions: serviceRole.Permissions,
+		Assignments: responseAssignments,
+	}, nil
+}
+
+// updateRole fully replaces a role's details and resource permissions.
+func (t *roleTools) updateRole(
+	ctx context.Context,
+	_ *mcp.CallToolRequest,
+	input roleUpdateInput,
+) (*mcp.CallToolResult, *RoleResponse, error) {
+	serviceRole, svcErr := t.roleService.UpdateRoleWithPermissions(
+		ctx,
+		input.ID,
+		RoleUpdateDetail{
+			Name:        input.Name,
+			Description: input.Description,
+			OUID:        input.OUID,
+			Permissions: input.Permissions,
+		},
+	)
+	if svcErr != nil {
+		return nil, nil, fmt.Errorf(
+			"failed to update role: %s",
+			svcErr.ErrorDescription,
+		)
+	}
+
+	return nil, &RoleResponse{
+		ID:          serviceRole.ID,
+		Name:        serviceRole.Name,
+		Description: serviceRole.Description,
+		OUID:        serviceRole.OUID,
+		OUHandle:    serviceRole.OUHandle,
+		Permissions: serviceRole.Permissions,
+	}, nil
+}
+
+// deleteRole deletes a role and reports whether the mutation completed successfully.
+func (t *roleTools) deleteRole(
+	ctx context.Context,
+	_ *mcp.CallToolRequest,
+	input tool.IDInput,
+) (*mcp.CallToolResult, *roleActionResponse, error) {
+	svcErr := t.roleService.DeleteRole(ctx, input.ID)
+	if svcErr != nil {
+		return nil, nil, fmt.Errorf(
+			"failed to delete role: %s",
+			svcErr.ErrorDescription,
+		)
+	}
+
+	return nil, &roleActionResponse{
+		Success: true,
+	}, nil
+}
+
+// getRoleAssignments returns a filtered, paginated assignment list with optional display details.
+func (t *roleTools) getRoleAssignments(
+	ctx context.Context,
+	_ *mcp.CallToolRequest,
+	input roleAssignmentsInput,
+) (*mcp.CallToolResult, *assignmentListMCPResponse, error) {
+	limit := input.Limit
+	if limit == 0 {
+		limit = serverconst.DefaultPageSize
+	}
+
+	serviceResponse, svcErr :=
+		t.assignmentService.GetRoleAssignmentsByType(
+			ctx,
+			input.ID,
+			limit,
+			input.Offset,
+			input.IncludeDisplay,
+			string(input.Type),
+		)
+
+	if svcErr != nil {
+		return nil, nil, fmt.Errorf(
+			"failed to get role assignments: %s",
+			svcErr.ErrorDescription,
+		)
+	}
+
+	assignments := make(
+		[]AssignmentResponse,
+		len(serviceResponse.Assignments),
+	)
+
+	for i, assignment := range serviceResponse.Assignments {
+		assignments[i] = AssignmentResponse{
+			ID:      assignment.ID,
+			Type:    assignment.Type,
+			Display: assignment.Display,
+		}
+	}
+
+	return nil, &assignmentListMCPResponse{
+		TotalResults: serviceResponse.TotalResults,
+		Assignments:  assignments,
+	}, nil
+}
+
+// addRoleAssignments assigns the role to the supplied users, applications, agents, or groups.
+func (t *roleTools) addRoleAssignments(
+	ctx context.Context,
+	_ *mcp.CallToolRequest,
+	input addRoleAssignmentsInput,
+) (*mcp.CallToolResult, *roleActionResponse, error) {
+	assignments := make(
+		[]RoleAssignment,
+		len(input.Assignments),
+	)
+
+	for i, assignment := range input.Assignments {
+		assignments[i] = RoleAssignment{
+			ID:   assignment.ID,
+			Type: assignment.Type,
+		}
+	}
+
+	svcErr := t.assignmentService.AddAssignments(
+		ctx,
+		input.ID,
+		assignments,
+	)
+	if svcErr != nil {
+		return nil, nil, fmt.Errorf(
+			"failed to add role assignments: %s",
+			svcErr.ErrorDescription,
+		)
+	}
+
+	return nil, &roleActionResponse{
+		Success: true,
+	}, nil
+}
+
+func getCreateRoleSchema() *jsonschema.Schema {
+	return tool.GenerateSchema[CreateRoleRequest](
+		tool.WithRequired("", "name", "ouId"),
+		tool.WithRequired("assignments", "id", "type"),
+		tool.WithEnum(
+			"assignments",
+			"type",
+			[]string{
+				string(AssigneeTypeUser),
+				string(AssigneeTypeApp),
+				string(AssigneeTypeAgent),
+				string(AssigneeTypeGroup),
+			},
+		),
+	)
+}
+
+func getUpdateRoleSchema() *jsonschema.Schema {
+	return tool.GenerateSchema[roleUpdateInput](
+		tool.WithRequired(
+			"",
+			"id",
+			"name",
+			"ouId",
+			"permissions",
+		),
+	)
+}
+
+func getRoleAssignmentsSchema() *jsonschema.Schema {
+	return tool.GenerateSchema[roleAssignmentsInput](
+		tool.WithRequired("", "id"),
+		tool.WithDefault(
+			"",
+			"limit",
+			serverconst.DefaultPageSize,
+		),
+		tool.WithEnum(
+			"",
+			"type",
+			[]string{
+				string(AssigneeTypeUser),
+				string(AssigneeTypeApp),
+				string(AssigneeTypeAgent),
+				string(AssigneeTypeGroup),
+			},
+		),
+	)
+}
+
+func getAddRoleAssignmentsSchema() *jsonschema.Schema {
+	return tool.GenerateSchema[addRoleAssignmentsInput](
+		tool.WithRequired("", "id", "assignments"),
+		tool.WithRequired("assignments", "id", "type"),
+		tool.WithEnum(
+			"assignments",
+			"type",
+			[]string{
+				string(AssigneeTypeUser),
+				string(AssigneeTypeApp),
+				string(AssigneeTypeAgent),
+				string(AssigneeTypeGroup),
+			},
+		),
+	)
+}

--- a/backend/internal/role/tools_test.go
+++ b/backend/internal/role/tools_test.go
@@ -1,0 +1,276 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package role
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/thunder-id/thunderid/internal/system/mcp/tool"
+)
+
+type RoleToolsTestSuite struct {
+	suite.Suite
+
+	roleService       *RoleServiceInterfaceMock
+	assignmentService *RoleAssignmentServiceInterfaceMock
+	tools             *roleTools
+}
+
+func TestRoleToolsTestSuite(t *testing.T) {
+	suite.Run(t, new(RoleToolsTestSuite))
+}
+
+func (suite *RoleToolsTestSuite) SetupTest() {
+	suite.roleService = NewRoleServiceInterfaceMock(suite.T())
+	suite.assignmentService = NewRoleAssignmentServiceInterfaceMock(suite.T())
+
+	suite.tools = &roleTools{
+		roleService:       suite.roleService,
+		assignmentService: suite.assignmentService,
+	}
+}
+
+func (suite *RoleToolsTestSuite) TestListRoles() {
+	suite.roleService.On(
+		"GetRoleList",
+		mock.Anything,
+		30,
+		0,
+	).Return(&RoleList{
+		TotalResults: 1,
+		Roles: []Role{
+			{ID: "role1", Name: "Admin"},
+		},
+	}, nil)
+
+	_, output, err := suite.tools.listRoles(
+		context.Background(),
+		&mcp.CallToolRequest{},
+		tool.PaginationInput{},
+	)
+
+	suite.NoError(err)
+	suite.Equal(1, output.TotalResults)
+	suite.Len(output.Roles, 1)
+	suite.Equal("role1", output.Roles[0].ID)
+}
+
+func (suite *RoleToolsTestSuite) TestGetRole() {
+	suite.roleService.On(
+		"GetRoleWithPermissions",
+		mock.Anything,
+		"role1",
+	).Return(&RoleWithPermissions{
+		ID:   "role1",
+		Name: "Admin",
+		OUID: "ou1",
+	}, nil)
+
+	_, output, err := suite.tools.getRole(
+		context.Background(),
+		&mcp.CallToolRequest{},
+		tool.IDInput{ID: "role1"},
+	)
+
+	suite.NoError(err)
+	suite.Equal("role1", output.ID)
+	suite.Equal("Admin", output.Name)
+}
+
+func (suite *RoleToolsTestSuite) TestCreateRole() {
+	suite.roleService.On(
+		"CreateRole",
+		mock.Anything,
+		mock.AnythingOfType("RoleCreationDetail"),
+	).Return(&RoleWithPermissionsAndAssignments{
+		ID:   "role1",
+		Name: "Admin",
+		OUID: "ou1",
+	}, nil)
+
+	_, output, err := suite.tools.createRole(
+		context.Background(),
+		&mcp.CallToolRequest{},
+		CreateRoleRequest{
+			Name: "Admin",
+			OUID: "ou1",
+		},
+	)
+
+	suite.NoError(err)
+	suite.Equal("role1", output.ID)
+	suite.Equal("Admin", output.Name)
+}
+
+func (suite *RoleToolsTestSuite) TestUpdateRole() {
+	suite.roleService.On(
+		"UpdateRoleWithPermissions",
+		mock.Anything,
+		"role1",
+		mock.AnythingOfType("RoleUpdateDetail"),
+	).Return(&RoleWithPermissions{
+		ID:   "role1",
+		Name: "Updated Admin",
+		OUID: "ou1",
+	}, nil)
+
+	_, output, err := suite.tools.updateRole(
+		context.Background(),
+		&mcp.CallToolRequest{},
+		roleUpdateInput{
+			ID:   "role1",
+			Name: "Updated Admin",
+			OUID: "ou1",
+		},
+	)
+
+	suite.NoError(err)
+	suite.Equal("Updated Admin", output.Name)
+}
+
+func (suite *RoleToolsTestSuite) TestDeleteRole() {
+	suite.roleService.On(
+		"DeleteRole",
+		mock.Anything,
+		"role1",
+	).Return(nil)
+
+	_, output, err := suite.tools.deleteRole(
+		context.Background(),
+		&mcp.CallToolRequest{},
+		tool.IDInput{ID: "role1"},
+	)
+
+	suite.NoError(err)
+	suite.True(output.Success)
+}
+
+func (suite *RoleToolsTestSuite) TestGetRoleAssignments() {
+	suite.assignmentService.On(
+		"GetRoleAssignmentsByType",
+		mock.Anything,
+		"role1",
+		30,
+		0,
+		false,
+		"",
+	).Return(&AssignmentList{
+		TotalResults: 1,
+		Assignments: []RoleAssignmentWithDisplay{
+			{
+				ID:   "user1",
+				Type: AssigneeTypeUser,
+			},
+		},
+	}, nil)
+
+	_, output, err := suite.tools.getRoleAssignments(
+		context.Background(),
+		&mcp.CallToolRequest{},
+		roleAssignmentsInput{
+			ID: "role1",
+		},
+	)
+
+	suite.NoError(err)
+	suite.Equal(1, output.TotalResults)
+	suite.Len(output.Assignments, 1)
+	suite.Equal("user1", output.Assignments[0].ID)
+}
+
+func (suite *RoleToolsTestSuite) TestAddRoleAssignments() {
+	suite.assignmentService.On(
+		"AddAssignments",
+		mock.Anything,
+		"role1",
+		mock.AnythingOfType("[]role.RoleAssignment"),
+	).Return(nil)
+
+	_, output, err := suite.tools.addRoleAssignments(
+		context.Background(),
+		&mcp.CallToolRequest{},
+		addRoleAssignmentsInput{
+			ID: "role1",
+			Assignments: []AssignmentRequest{
+				{
+					ID:   "user1",
+					Type: AssigneeTypeUser,
+				},
+			},
+		},
+	)
+
+	suite.NoError(err)
+	suite.True(output.Success)
+}
+
+func (suite *RoleToolsTestSuite) TestRegisterMCPTools() {
+	ctx := context.Background()
+	server := mcp.NewServer(
+		&mcp.Implementation{
+			Name:    "test-server",
+			Version: "1.0.0",
+		},
+		nil,
+	)
+
+	registerMCPTools(
+		server,
+		suite.roleService,
+		suite.assignmentService,
+	)
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	suite.Require().NoError(err)
+	suite.T().Cleanup(func() {
+		suite.NoError(serverSession.Close())
+	})
+
+	client := mcp.NewClient(
+		&mcp.Implementation{
+			Name:    "test-client",
+			Version: "1.0.0",
+		},
+		nil,
+	)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	suite.Require().NoError(err)
+	suite.T().Cleanup(func() {
+		suite.NoError(clientSession.Close())
+	})
+
+	result, err := clientSession.ListTools(ctx, nil)
+	suite.Require().NoError(err)
+
+	toolNames := make([]string, len(result.Tools))
+	for i, registeredTool := range result.Tools {
+		toolNames[i] = registeredTool.Name
+	}
+
+	suite.ElementsMatch([]string{
+		"thunderid_list_roles",
+		"thunderid_get_role",
+		"thunderid_create_role",
+		"thunderid_update_role",
+		"thunderid_delete_role",
+		"thunderid_get_role_assignments",
+		"thunderid_add_role_assignments",
+	}, toolNames)
+}
+
+func (suite *RoleToolsTestSuite) TestSchemas() {
+	suite.NotNil(getCreateRoleSchema())
+	suite.ElementsMatch(
+		[]string{"id", "name", "ouId", "permissions"},
+		getUpdateRoleSchema().Required,
+	)
+	suite.NotNil(getRoleAssignmentsSchema())
+	suite.NotNil(getAddRoleAssignmentsSchema())
+}

--- a/docs/content/working-with-ai/mcp-server.mdx
+++ b/docs/content/working-with-ai/mcp-server.mdx
@@ -205,8 +205,23 @@ Once connected, your AI assistant can work with <ProductName /> resources direct
 | `flows` | Design and modify authentication and registration flows |
 | `themes` | Browse and inspect login page themes, colors, and typography |
 | `organization_units` | List organization units |
+| `roles` | Manage roles, permissions, and assignments |
 | `user_types` | List user types and self-registration settings |
 | `react_sdk` | Get tailored integration code for the <ProductName /> React SDK |
+
+### Manage Roles
+
+Role assignments support users, applications, agents, and groups. Use `limit` and `offset` to paginate role lists and assignment lists. The assignment-list tool also accepts `type` to filter by assignment type and `includeDisplay` to include display details.
+
+| Tool | Inputs | Response | Mutation effect |
+|------|--------|----------|-----------------|
+| `thunderid_list_roles` | Optional `limit` and `offset` | `totalResults` and a `roles` array | None. Lists roles with pagination. |
+| `thunderid_get_role` | Role `id` | Role details, including `id`, `name`, organization unit, and `permissions` | None. |
+| `thunderid_create_role` | `name`, `ouId`, optional `description`, `permissions`, and `assignments` | The created role, including its permissions and assignments | Creates a role with permissions and optional assignments. Each assignment contains an `id` and a `type` of `user`, `app`, `agent`, or `group`. |
+| `thunderid_update_role` | `id`, `name`, `ouId`, `permissions`, and optional `description` | The updated role and its permissions | Fully replaces the role details and permissions. Send `permissions: []` to remove all permissions. |
+| `thunderid_delete_role` | Role `id` | `success: true` | Deletes the role. |
+| `thunderid_get_role_assignments` | Role `id`, optional `limit`, `offset`, `type`, and `includeDisplay` | `totalResults` and an `assignments` array | None. Lists assignments with pagination and optional filtering. |
+| `thunderid_add_role_assignments` | Role `id` and `assignments` | `success: true` | Assigns the role to users, applications, agents, or groups. Each assignment contains an `id` and `type`. |
 
 **Example prompts:**
 


### PR DESCRIPTION
### Purpose

Adds MCP tools for role management so agentic workflows can manage roles and role assignments through ThunderID.

Adds support for:
- Listing and retrieving roles
- Creating, updating, and deleting roles
- Retrieving role assignments
- Adding role assignments

### Approach

- Added MCP tool registration in `internal/role/tools.go`.
- Reused the existing `RoleServiceInterface` and `RoleAssignmentServiceInterface` instead of adding new business logic.
- Added strict input schemas using `tool.GenerateSchema`.
- Marked read-only operations with `ReadOnlyHint`.
- Integrated role MCP tools into the existing role initialization flow.
- Added unit tests for the new MCP tools.

### Related Issues
- Fixes #3108

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] `breaking change` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP tools to list, view, create, update, and delete roles.
  * Added tools to view and add role assignments.
  * Included pagination, input validation, and clear operation results for role-management actions.

* **Documentation**
  * Expanded MCP role-management guidance with response formats and mutation details.

* **Tests**
  * Added coverage for role and assignment operations, tool registration, schemas, and successful responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->