### PR TITLE
Reject insecure HTTP redirect URIs

### DIFF
--- a/backend/internal/inboundclient/service.go
+++ b/backend/internal/inboundclient/service.go
@@ -978,6 +978,12 @@ func validateRedirectURIs(p *providers.OAuthProfile) error {
 			(!isWebScheme && parsedURI.Host == "" && parsedURI.Path == "") {
 			return ErrOAuthInvalidRedirectURI
 		}
+		if strings.EqualFold(parsedURI.Scheme, "http") {
+			hostname := parsedURI.Hostname()
+			if !strings.EqualFold(hostname, "localhost") && hostname != "127.0.0.1" && hostname != "::1" {
+				return ErrOAuthInvalidRedirectURI
+			}
+		}
 		if parsedURI.Fragment != "" {
 			return ErrOAuthRedirectURIFragmentNotAllowed
 		}

--- a/backend/internal/inboundclient/service_test.go
+++ b/backend/internal/inboundclient/service_test.go
@@ -1677,6 +1677,39 @@ func (suite *InboundClientServiceTestSuite) TestResolveOAuthTokens_CarriesDefaul
 
 // ----- validateRedirectURIs error branches -----
 
+func (suite *InboundClientServiceTestSuite) TestValidateRedirectURIs_HTTPTransport() {
+	tests := []struct {
+		name    string
+		uri     string
+		wantErr bool
+	}{
+		{name: "HTTPS remote host", uri: "https://example.com/callback"},
+		{name: "HTTP localhost", uri: "http://localhost:3000/callback"},
+		{name: "HTTP uppercase localhost", uri: "http://LOCALHOST:3000/callback"},
+		{name: "HTTP IPv4 loopback", uri: "http://127.0.0.1:3000/callback"},
+		{name: "HTTP IPv6 loopback", uri: "http://[::1]:3000/callback"},
+		{name: "HTTP remote host", uri: "http://example.com/callback", wantErr: true},
+		{name: "HTTP private IP", uri: "http://192.168.1.10/callback", wantErr: true},
+		{name: "HTTP other IPv4 loopback", uri: "http://127.0.0.2/callback", wantErr: true},
+		{name: "HTTP localhost suffix", uri: "http://localhost.example.com/callback", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			p := &providers.OAuthProfile{
+				RedirectURIs: []string{tt.uri},
+				GrantTypes:   []string{"authorization_code"},
+			}
+			err := validateRedirectURIs(p)
+			if tt.wantErr {
+				assert.ErrorIs(t, err, ErrOAuthInvalidRedirectURI)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
 func (suite *InboundClientServiceTestSuite) TestValidateRedirectURIs_SchemeWildcardRejected() {
 	p := &providers.OAuthProfile{
 		RedirectURIs: []string{"htt*://app/cb"},

--- a/backend/pkg/thunderidengine/providers/oauth_client.go
+++ b/backend/pkg/thunderidengine/providers/oauth_client.go
@@ -118,11 +118,13 @@ func ValidateRedirectURI(ctx context.Context, redirectURIs []string, redirectURI
 		if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 			return fmt.Errorf("registered redirect URI is not fully qualified")
 		}
+		if strings.EqualFold(parsed.Scheme, "http") {
+			hostname := parsed.Hostname()
+			if !strings.EqualFold(hostname, "localhost") && hostname != "127.0.0.1" && hostname != "::1" {
+				return fmt.Errorf("http redirect URI must use localhost, 127.0.0.1, or [::1]")
+			}
+		}
 		return nil
-	}
-
-	if !matchAnyRedirectURIPattern(redirectURIs, redirectURI) {
-		return fmt.Errorf("your application's redirect URL does not match with the registered redirect URLs")
 	}
 
 	parsedRedirectURI, err := utils.ParseURL(redirectURI)
@@ -130,8 +132,17 @@ func ValidateRedirectURI(ctx context.Context, redirectURIs []string, redirectURI
 		logger.Error(ctx, "Failed to parse redirect URI", log.Error(err))
 		return fmt.Errorf("invalid redirect URI: %s", err.Error())
 	}
+	if strings.EqualFold(parsedRedirectURI.Scheme, "http") {
+		hostname := parsedRedirectURI.Hostname()
+		if !strings.EqualFold(hostname, "localhost") && hostname != "127.0.0.1" && hostname != "::1" {
+			return fmt.Errorf("http redirect URI must use localhost, 127.0.0.1, or [::1]")
+		}
+	}
 	if parsedRedirectURI.Fragment != "" {
 		return fmt.Errorf("redirect URI must not contain a fragment component")
+	}
+	if !matchAnyRedirectURIPattern(redirectURIs, redirectURI) {
+		return fmt.Errorf("your application's redirect URL does not match with the registered redirect URLs")
 	}
 
 	return nil

--- a/backend/pkg/thunderidengine/providers/oauth_client_test.go
+++ b/backend/pkg/thunderidengine/providers/oauth_client_test.go
@@ -159,6 +159,34 @@ func (suite *OAuthClientTestSuite) TestValidateRedirectURI_NoMatch() {
 	assert.Error(suite.T(), err)
 }
 
+func (suite *OAuthClientTestSuite) TestValidateRedirectURI_HTTPTransport() {
+	suite.setupRuntime(suite.T(), sysconfig.OAuthConfig{})
+	tests := []struct {
+		name    string
+		uri     string
+		wantErr bool
+	}{
+		{name: "HTTPS remote host", uri: "https://example.com/callback"},
+		{name: "HTTP localhost", uri: "http://localhost:3000/callback"},
+		{name: "HTTP IPv4 loopback", uri: "http://127.0.0.1:3000/callback"},
+		{name: "HTTP IPv6 loopback", uri: "http://[::1]:3000/callback"},
+		{name: "HTTP remote host", uri: "http://example.com/callback", wantErr: true},
+		{name: "HTTP private IP", uri: "http://192.168.1.10/callback", wantErr: true},
+		{name: "HTTP other IPv4 loopback", uri: "http://127.0.0.2/callback", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			err := ValidateRedirectURI(context.Background(), []string{tt.uri}, tt.uri)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
 func (suite *OAuthClientTestSuite) TestValidateRedirectURI_EmptyURI() {
 	suite.setupRuntime(suite.T(), sysconfig.OAuthConfig{})
 
@@ -174,6 +202,16 @@ func (suite *OAuthClientTestSuite) TestValidateRedirectURI_EmptyURI() {
 
 	suite.T().Run("wildcard in single registered URI requires explicit URI", func(t *testing.T) {
 		err := ValidateRedirectURI(context.Background(), []string{"https://*.example.com/callback"}, "")
+		assert.Error(t, err)
+	})
+
+	suite.T().Run("single HTTP loopback URI defaults to it", func(t *testing.T) {
+		err := ValidateRedirectURI(context.Background(), []string{"http://localhost:3000/callback"}, "")
+		assert.NoError(t, err)
+	})
+
+	suite.T().Run("single remote HTTP URI is rejected", func(t *testing.T) {
+		err := ValidateRedirectURI(context.Background(), []string{"http://example.com/callback"}, "")
 		assert.Error(t, err)
 	})
 }

--- a/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/RedirectURIsSection.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/RedirectURIsSection.tsx
@@ -17,6 +17,7 @@ import {
 import {Plus, Trash} from '@wso2/oxygen-ui-icons-react';
 import {useState, type JSX} from 'react';
 import {useTranslation} from 'react-i18next';
+import {isValidRedirectUriTransport} from '../../../../applications/utils/isValidRedirectUriFormat';
 import type {OAuthAgentConfig} from '../../../models/agent';
 
 const REDIRECT_USING_GRANTS = ['authorization_code'];
@@ -30,13 +31,7 @@ interface RedirectURIsSectionProps {
   disabled?: boolean;
 }
 
-const isValidURL = (value: string): boolean => {
-  try {
-    return Boolean(new URL(value));
-  } catch {
-    return false;
-  }
-};
+const isValidURL = (value: string): boolean => isValidRedirectUriTransport(value);
 
 export default function RedirectURIsSection({
   oauth2Config = undefined,
@@ -53,14 +48,7 @@ export default function RedirectURIsSection({
   // The authorization-code grant cannot complete without at least one valid redirect URI. The
   // page-level Save guard computes this same check independently from state (see AgentEditPage),
   // since this section unmounts when its tab isn't active.
-  const hasValidUri = uris.some((u) => {
-    if (!u.trim()) return false;
-    try {
-      return Boolean(new URL(u));
-    } catch {
-      return false;
-    }
-  });
+  const hasValidUri = uris.some((u) => u.trim() !== '' && isValidURL(u));
   const isMissingRequiredUri = usesRedirect && !hasValidUri;
 
   // Hide entirely when no redirect-using grant is selected — redirect URIs are meaningless then.
@@ -98,7 +86,10 @@ export default function RedirectURIsSection({
     if (!isValidURL(value)) {
       setErrors((prev) => ({
         ...prev,
-        [index]: t('agents:edit.advanced.redirectUris.error.invalid', 'Enter a valid URL'),
+        [index]: t(
+          'agents:edit.advanced.redirectUris.error.invalid',
+          'Enter a valid URL. HTTP requires localhost, 127.0.0.1, or [::1].',
+        ),
       }));
     }
   };

--- a/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/__tests__/RedirectURIsSection.test.tsx
+++ b/frontend/apps/console/src/features/agents/components/edit-agent/advanced-settings/__tests__/RedirectURIsSection.test.tsx
@@ -73,6 +73,33 @@ describe('RedirectURIsSection', () => {
     expect(screen.queryByTestId('agent-redirect-uris-required')).not.toBeInTheDocument();
   });
 
+  it.each(['http://localhost:3000/callback', 'http://127.0.0.1:3000/callback', 'http://[::1]:3000/callback'])(
+    'accepts the HTTP loopback redirect URI %s',
+    (uri) => {
+      const oauth2Config: OAuthAgentConfig = {
+        grantTypes: ['authorization_code'],
+        responseTypes: ['code'],
+        redirectUris: [uri],
+      };
+
+      render(<RedirectURIsSection oauth2Config={oauth2Config} onOAuth2ConfigChange={mockOnChange} />);
+
+      expect(screen.queryByTestId('agent-redirect-uris-required')).not.toBeInTheDocument();
+    },
+  );
+
+  it('treats a remote HTTP redirect URI as invalid', () => {
+    const oauth2Config: OAuthAgentConfig = {
+      grantTypes: ['authorization_code'],
+      responseTypes: ['code'],
+      redirectUris: ['http://example.com/callback'],
+    };
+
+    render(<RedirectURIsSection oauth2Config={oauth2Config} onOAuth2ConfigChange={mockOnChange} />);
+
+    expect(screen.getByTestId('agent-redirect-uris-required')).toBeInTheDocument();
+  });
+
   it('treats blank entries as invalid', () => {
     const oauth2Config: OAuthAgentConfig = {
       grantTypes: ['authorization_code'],
@@ -190,7 +217,24 @@ describe('RedirectURIsSection', () => {
     await user.click(input);
     await user.tab();
 
-    expect(screen.getByText('Enter a valid URL')).toBeInTheDocument();
+    expect(screen.getByText('Enter a valid URL. HTTP requires localhost, 127.0.0.1, or [::1].')).toBeInTheDocument();
+  });
+
+  it('shows an inline error for a remote HTTP redirect URI', async () => {
+    const user = userEvent.setup();
+    const oauth2Config: OAuthAgentConfig = {
+      grantTypes: ['authorization_code'],
+      responseTypes: ['code'],
+      redirectUris: ['http://example.com/callback'],
+    };
+
+    render(<RedirectURIsSection oauth2Config={oauth2Config} onOAuth2ConfigChange={mockOnChange} />);
+
+    const input = screen.getByPlaceholderText('https://example.com/callback');
+    await user.click(input);
+    await user.tab();
+
+    expect(screen.getByText('Enter a valid URL. HTTP requires localhost, 127.0.0.1, or [::1].')).toBeInTheDocument();
   });
 
   it('hides the add button and delete buttons when not editable', () => {

--- a/frontend/apps/console/src/features/agents/pages/AgentEditPage.tsx
+++ b/frontend/apps/console/src/features/agents/pages/AgentEditPage.tsx
@@ -26,6 +26,7 @@ import {useState, useCallback, useMemo, type SyntheticEvent, type JSX, type Reac
 import {useTranslation} from 'react-i18next';
 import {Link, useLocation, useNavigate, useParams} from 'react-router';
 import RouteConfig from '../../../configs/RouteConfig';
+import {isValidRedirectUriTransport} from '../../applications/utils/isValidRedirectUriFormat';
 import useGetAgent from '../api/useGetAgent';
 import useUpdateAgent from '../api/useUpdateAgent';
 import ShowClientSecret from '../components/create-agent/ShowClientSecret';
@@ -217,15 +218,24 @@ export default function AgentEditPage(): JSX.Element {
   // that content unmounts when its tab isn't active — a callback-based report would be stale or
   // never fire if the user never visits the tab before saving.
   const hasAuthorizationCodeGrant = oauth2Config?.grantTypes?.includes('authorization_code') ?? false;
-  const hasValidRedirectUri = (oauth2Config?.redirectUris ?? []).some((uri) => {
+  const redirectUris = oauth2Config?.redirectUris ?? [];
+  const hasValidRedirectUri = redirectUris.some((uri) => {
     if (!uri.trim()) return false;
     try {
-      return Boolean(new URL(uri));
+      const parsedUri = new URL(uri);
+      return Boolean(parsedUri) && isValidRedirectUriTransport(uri);
     } catch {
       return false;
     }
   });
-  const isMissingRedirectUri = hasAuthorizationCodeGrant && !hasValidRedirectUri;
+  const hasDisallowedHttpRedirectUri = redirectUris.some((uri) => {
+    try {
+      return new URL(uri).protocol === 'http:' && !isValidRedirectUriTransport(uri);
+    } catch {
+      return false;
+    }
+  });
+  const isMissingRedirectUri = (hasAuthorizationCodeGrant && !hasValidRedirectUri) || hasDisallowedHttpRedirectUri;
   const allowedUserTypes = editedAgent.allowedUserTypes ?? agent.allowedUserTypes ?? [];
   const isMissingAllowedUserType = hasAuthorizationCodeGrant && allowedUserTypes.length === 0;
   const isMissingCertificate =

--- a/frontend/apps/console/src/features/agents/pages/__tests__/AgentEditPage.test.tsx
+++ b/frontend/apps/console/src/features/agents/pages/__tests__/AgentEditPage.test.tsx
@@ -826,7 +826,7 @@ describe('AgentEditPage', () => {
               config: {
                 grantTypes: ['authorization_code'],
                 responseTypes: ['code'],
-                redirectUris: ['https://example.com/cb'],
+                redirectUris: ['http://localhost:3000/cb'],
                 clientId: 'client-id-xyz',
               },
             },
@@ -843,6 +843,67 @@ describe('AgentEditPage', () => {
 
       expect(screen.getByRole('button', {name: 'Save'})).not.toBeDisabled();
       expect(screen.getByText('You have unsaved changes')).toBeInTheDocument();
+    });
+
+    it('disables Save when authorization_code includes a remote HTTP redirect URI', async () => {
+      const user = userEvent.setup();
+      mockUseGetAgent.mockReturnValue({
+        data: {
+          ...baseAgent,
+          allowedUserTypes: ['employee'],
+          inboundAuthConfig: [
+            {
+              type: 'oauth2' as const,
+              config: {
+                grantTypes: ['authorization_code'],
+                responseTypes: ['code'],
+                redirectUris: ['https://example.com/cb', 'http://example.com/cb'],
+                clientId: 'client-id-xyz',
+              },
+            },
+          ],
+        },
+        isLoading: false,
+        error: null,
+        isError: false,
+        refetch: mockRefetch,
+      });
+
+      render(<AgentEditPage />);
+      await triggerAChange(user);
+
+      expect(screen.getByText('Before saving, add a redirect URI.')).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Save'})).toBeDisabled();
+    });
+
+    it('disables Save when a remote HTTP redirect URI remains without authorization_code', async () => {
+      const user = userEvent.setup();
+      mockUseGetAgent.mockReturnValue({
+        data: {
+          ...baseAgent,
+          inboundAuthConfig: [
+            {
+              type: 'oauth2' as const,
+              config: {
+                grantTypes: ['client_credentials'],
+                responseTypes: [],
+                redirectUris: ['http://example.com/cb'],
+                clientId: 'client-id-xyz',
+              },
+            },
+          ],
+        },
+        isLoading: false,
+        error: null,
+        isError: false,
+        refetch: mockRefetch,
+      });
+
+      render(<AgentEditPage />);
+      await triggerAChange(user);
+
+      expect(screen.getByText('Before saving, add a redirect URI.')).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Save'})).toBeDisabled();
     });
 
     it('does not block Save when authorization_code is not selected', async () => {

--- a/frontend/apps/console/src/features/applications/components/create-application/ConfigureDetails.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/ConfigureDetails.tsx
@@ -38,6 +38,7 @@ import type {PlatformApplicationTemplate, TechnologyApplicationTemplate} from '.
 import getConfigurationTypeFromTemplate from '../../utils/getConfigurationTypeFromTemplate';
 import hasInvalidCorsRows from '../../utils/hasInvalidCorsRows';
 import isRedirectCapableTemplate from '../../utils/isRedirectCapableTemplate';
+import {isValidRedirectUriTransport} from '../../utils/isValidRedirectUriFormat';
 
 /**
  * Zod schema for validating URL inputs (hosting URLs and callback URLs).
@@ -294,6 +295,7 @@ export default function ConfigureDetails({
     setRelyingPartyName,
     appName,
     corsOrigins,
+    redirectUris,
   } = useApplicationCreate();
   const {
     control,
@@ -333,6 +335,15 @@ export default function ConfigureDetails({
   // selected template can't block a step that no longer shows them.
   const showsCorsEditor: boolean = effectiveIsRedirectCapable && Boolean(selectedTemplateConfig?.capabilities?.cors);
   const hasInvalidCorsOrigins: boolean = showsCorsEditor && hasInvalidCorsRows(corsOrigins);
+  const hasDisallowedHttpRedirectUri: boolean =
+    effectiveIsRedirectCapable &&
+    redirectUris.some((uri) => {
+      try {
+        return new URL(uri).protocol === 'http:' && !isValidRedirectUriTransport(uri);
+      } catch {
+        return false;
+      }
+    });
 
   const isWallet: boolean = selectedTemplateConfig?.id === 'wallet';
   const [walletVendor, setWalletVendor] = useState<string>(CUSTOM_WALLET_VENDOR);
@@ -486,7 +497,7 @@ export default function ConfigureDetails({
 
     // A malformed CORS origin used to be dropped on submit without a word, so block here instead.
     // This reads the same rows that get merged into the allow-list, so the two cannot disagree.
-    onReadyChange(ready && !hasInvalidCorsOrigins);
+    onReadyChange(ready && !hasInvalidCorsOrigins && !hasDisallowedHttpRedirectUri);
   }, [
     isValid,
     effectiveConfigurationType,
@@ -502,6 +513,7 @@ export default function ConfigureDetails({
     selectedTemplateConfig,
     isDuplicateWalletClientId,
     hasInvalidCorsOrigins,
+    hasDisallowedHttpRedirectUri,
   ]);
 
   // For platforms that don't require configuration AND no passkey configuration needed AND the

--- a/frontend/apps/console/src/features/applications/components/create-application/ConfigureRedirectUris.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/ConfigureRedirectUris.tsx
@@ -22,6 +22,7 @@ import {useTranslation} from 'react-i18next';
 import CorsOriginsEditor from './CorsOriginsEditor';
 import DevServerLogo from './DevServerLogo';
 import useApplicationCreate from '../../contexts/ApplicationCreate/useApplicationCreate';
+import {isValidRedirectUriTransport} from '../../utils/isValidRedirectUriFormat';
 
 /** Pure URI-format check, permissive of path/host wildcards (the backend enforces wildcard rules). */
 function isValidUriFormat(uri: string): boolean {
@@ -87,12 +88,12 @@ function UriListEditor({
       });
       return false;
     }
-    if (!isValidUriFormat(uri)) {
+    if (!isValidUriFormat(uri) || (required && !isValidRedirectUriTransport(uri))) {
       setErrors((prev) => ({
         ...prev,
         [index]: t(
           'applications:edit.general.redirectUris.error.invalid',
-          'Invalid Redirect: Please enter a valid URL.',
+          'Invalid Redirect: Please enter a valid URL. HTTP requires localhost, 127.0.0.1, or [::1].',
         ),
       }));
       return false;

--- a/frontend/apps/console/src/features/applications/components/create-application/__tests__/ConfigureDetails.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/__tests__/ConfigureDetails.test.tsx
@@ -190,6 +190,60 @@ describe('ConfigureDetails', () => {
     expect(screen.getByTestId('application-configure-redirect-uris')).toBeInTheDocument();
   });
 
+  it('blocks readiness when a redirect-capable application contains a remote HTTP redirect URI', async () => {
+    const template = createTemplate('Browser App', []);
+    const onReadyChange = vi.fn();
+    const user = userEvent.setup();
+
+    renderWithContext(
+      {
+        technology: TechnologyApplicationTemplate.REACT,
+        platform: PlatformApplicationTemplate.BROWSER,
+        onReadyChange,
+      },
+      {
+        selectedTemplateConfig: template,
+        redirectUris: ['https://example.com/callback', 'http://example.com/callback'],
+      },
+    );
+
+    await user.type(
+      screen.getByPlaceholderText('applications:onboarding.configure.details.hostingUrl.placeholder'),
+      'https://example.com',
+    );
+
+    await waitFor(() => expect(onReadyChange).toHaveBeenLastCalledWith(false));
+  });
+
+  it('allows readiness when HTTP redirect URIs use the supported loopback hosts', async () => {
+    const template = createTemplate('Browser App', []);
+    const onReadyChange = vi.fn();
+    const user = userEvent.setup();
+
+    renderWithContext(
+      {
+        technology: TechnologyApplicationTemplate.REACT,
+        platform: PlatformApplicationTemplate.BROWSER,
+        onReadyChange,
+      },
+      {
+        selectedTemplateConfig: template,
+        redirectUris: [
+          'http://localhost:3000/callback',
+          'http://127.0.0.1:3000/callback',
+          'http://[::1]:3000/callback',
+        ],
+      },
+    );
+
+    await user.type(
+      screen.getByPlaceholderText('applications:onboarding.configure.details.hostingUrl.placeholder'),
+      'https://example.com',
+    );
+
+    await waitFor(() => expect(onReadyChange).toHaveBeenLastCalledWith(true));
+  });
+
   it('renders no configuration UI for a non-redirect-capable template with a prefilled redirect URI', () => {
     const template: ApplicationTemplate = {
       description: 'Backend App description',

--- a/frontend/apps/console/src/features/applications/components/create-application/__tests__/ConfigureRedirectUris.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/__tests__/ConfigureRedirectUris.test.tsx
@@ -272,6 +272,32 @@ describe('ConfigureRedirectUris', () => {
     expect(setRedirectUris).toHaveBeenCalledWith(['', '']);
   });
 
+  it('allows an HTTP localhost redirect URI', async () => {
+    renderWithContext({
+      selectedTemplateConfig: expressTemplate,
+      redirectUris: ['http://localhost:3000/callback'],
+    });
+
+    const input = screen.getByDisplayValue('http://localhost:3000/callback');
+    await user.click(input);
+    await user.tab();
+
+    expect(screen.queryByText('applications:edit.general.redirectUris.error.invalid')).not.toBeInTheDocument();
+  });
+
+  it('rejects an HTTP redirect URI with a non-loopback host', async () => {
+    renderWithContext({
+      selectedTemplateConfig: expressTemplate,
+      redirectUris: ['http://example.com/callback'],
+    });
+
+    const input = screen.getByDisplayValue('http://example.com/callback');
+    await user.click(input);
+    await user.tab();
+
+    expect(screen.getByText('applications:edit.general.redirectUris.error.invalid')).toBeInTheDocument();
+  });
+
   it('flags an invalid CORS origin (a path is not a bare origin) instead of accepting it as a pattern', async () => {
     const setCorsOrigins = vi.fn();
 

--- a/frontend/apps/console/src/features/applications/components/create-application/mcp/__tests__/ConfigureMcpConnection.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/create-application/mcp/__tests__/ConfigureMcpConnection.test.tsx
@@ -118,7 +118,9 @@ describe('ConfigureMcpConnection', () => {
     await user.type(input, 'http://example.com/cb');
     await user.tab();
 
-    expect(screen.getByText('Enter a valid loopback (http://127.0.0.1) or HTTPS URI.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Enter a valid HTTPS URI or an HTTP URI using localhost, 127.0.0.1, or [::1].'),
+    ).toBeInTheDocument();
   });
 
   it('should clear the inline error once the value becomes valid', async () => {
@@ -128,12 +130,16 @@ describe('ConfigureMcpConnection', () => {
     const input = screen.getByPlaceholderText('http://localhost:8080/callback');
     await user.type(input, 'http://example.com/cb');
     await user.tab();
-    expect(screen.getByText('Enter a valid loopback (http://127.0.0.1) or HTTPS URI.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Enter a valid HTTPS URI or an HTTP URI using localhost, 127.0.0.1, or [::1].'),
+    ).toBeInTheDocument();
 
     await user.clear(input);
     await user.type(input, 'https://agent.example.com/cb');
 
-    expect(screen.queryByText('Enter a valid loopback (http://127.0.0.1) or HTTPS URI.')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Enter a valid HTTPS URI or an HTTP URI using localhost, 127.0.0.1, or [::1].'),
+    ).not.toBeInTheDocument();
   });
 
   describe('MCP Inspector guidance', () => {

--- a/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/OAuth2ConfigSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/OAuth2ConfigSection.tsx
@@ -29,7 +29,7 @@ import {useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import type {ApplicationTemplate} from '../../../models/application-templates';
 import {getGrantTypeLabel} from '../../../utils/getGrantTypeLabel';
-import isValidRedirectUriFormat from '../../../utils/isValidRedirectUriFormat';
+import isValidRedirectUriFormat, {isValidRedirectUriTransport} from '../../../utils/isValidRedirectUriFormat';
 import {
   applyGrantTypesChange,
   applyPublicClientChange,
@@ -139,7 +139,7 @@ export default function OAuth2ConfigSection({
       setUriErrors((prev) => ({...prev, [index]: t('applications:edit.general.redirectUris.error.empty')}));
       return false;
     }
-    if (!isValidRedirectUriFormat(uri)) {
+    if (!isValidRedirectUriFormat(uri) || !isValidRedirectUriTransport(uri)) {
       setUriErrors((prev) => ({...prev, [index]: t('applications:edit.general.redirectUris.error.invalid')}));
       return false;
     }

--- a/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/__tests__/OAuth2ConfigSection.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/advanced-settings/__tests__/OAuth2ConfigSection.test.tsx
@@ -728,6 +728,43 @@ describe('OAuth2ConfigSection', () => {
       expect(onOAuth2ConfigChange).toHaveBeenCalledWith({redirectUris: ['https://example.com/callback']});
     });
 
+    it('should commit an HTTP localhost redirect URI on blur', async () => {
+      const user = userEvent.setup();
+      const onOAuth2ConfigChange = vi.fn();
+      render(
+        <OAuth2ConfigSection
+          oauth2Config={{...baseConfig, redirectUris: ['http://localhost:3000/callback']}}
+          onOAuth2ConfigChange={onOAuth2ConfigChange}
+        />,
+      );
+
+      const uriInput = screen.getByDisplayValue('http://localhost:3000/callback');
+      await user.click(uriInput);
+      await user.tab();
+
+      expect(onOAuth2ConfigChange).toHaveBeenCalledWith({redirectUris: ['http://localhost:3000/callback']});
+    });
+
+    it('should reject an HTTP redirect URI with a non-loopback host on blur', async () => {
+      const user = userEvent.setup();
+      const onOAuth2ConfigChange = vi.fn();
+      render(
+        <OAuth2ConfigSection
+          oauth2Config={{...baseConfig, redirectUris: ['http://example.com/callback']}}
+          onOAuth2ConfigChange={onOAuth2ConfigChange}
+        />,
+      );
+
+      const uriInput = screen.getByDisplayValue('http://example.com/callback');
+      await user.click(uriInput);
+      await user.tab();
+
+      expect(onOAuth2ConfigChange).not.toHaveBeenCalledWith(
+        expect.objectContaining({redirectUris: expect.anything() as unknown}),
+      );
+      expect(screen.getByText('applications:edit.general.redirectUris.error.invalid')).toBeInTheDocument();
+    });
+
     it('should not commit and should show an error when an invalid redirect URI is blurred', async () => {
       const user = userEvent.setup();
       const onOAuth2ConfigChange = vi.fn();

--- a/frontend/apps/console/src/features/applications/components/edit-application/mcp/McpAccessSection.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/mcp/McpAccessSection.tsx
@@ -301,7 +301,7 @@ export default function McpAccessSection({
           <Typography variant="caption" color="text.secondary" sx={{display: 'block', mb: 2}}>
             {t(
               'applications:onboarding.mcp.connection.redirectUris.hint',
-              'Each URI must be a loopback address (http://localhost or http://127.0.0.1) or use HTTPS. At least one is required.',
+              'Each URI must use HTTPS or HTTP with localhost, 127.0.0.1, or [::1]. At least one is required.',
             )}
           </Typography>
 

--- a/frontend/apps/console/src/features/applications/components/edit-application/mcp/__tests__/McpAccessSection.test.tsx
+++ b/frontend/apps/console/src/features/applications/components/edit-application/mcp/__tests__/McpAccessSection.test.tsx
@@ -141,7 +141,9 @@ describe('McpAccessSection', () => {
       fireEvent.change(uriInput, {target: {value: 'http://example.com/cb'}});
       fireEvent.blur(uriInput);
 
-      expect(screen.getByText(/enter a valid loopback/i)).toBeInTheDocument();
+      expect(
+        screen.getByText('Enter a valid HTTPS URI or an HTTP URI using localhost, 127.0.0.1, or [::1].'),
+      ).toBeInTheDocument();
       expect(mockOnFieldChange).not.toHaveBeenCalled();
     });
 
@@ -292,7 +294,7 @@ describe('McpAccessSection', () => {
     it('reports validation errors when a redirect URI is invalid', () => {
       const invalidUriConfig: OAuth2Config = {
         ...baseOAuth2Config,
-        redirectUris: ['not a url'],
+        redirectUris: ['enter a valid loopback'],
       } as OAuth2Config;
 
       render(

--- a/frontend/apps/console/src/features/applications/pages/ApplicationEditPage.tsx
+++ b/frontend/apps/console/src/features/applications/pages/ApplicationEditPage.tsx
@@ -47,7 +47,7 @@ import getApplicationErrorMessage from '../utils/getApplicationErrorMessage';
 import getTemplateCapabilities from '../utils/getTemplateCapabilities';
 import getTemplateFieldConstraints from '../utils/getTemplateFieldConstraints';
 import getTemplateMetadata from '../utils/getTemplateMetadata';
-import isValidRedirectUriFormat from '../utils/isValidRedirectUriFormat';
+import isValidRedirectUriFormat, {isValidRedirectUriTransport} from '../utils/isValidRedirectUriFormat';
 import {hasUserAccess} from '../utils/oauth2Rules';
 
 interface TabConfig {
@@ -268,8 +268,19 @@ export default function ApplicationEditPage() {
   // MCP clients run their own validation via McpConnectTab, so these are skipped there.
   const grantTypes = oauth2Config?.grantTypes ?? [];
   const hasAuthorizationCodeGrant = grantTypes.includes(OAuth2GrantTypes.AUTHORIZATION_CODE);
-  const hasValidRedirectUri = (oauth2Config?.redirectUris ?? []).some((uri) => isValidRedirectUriFormat(uri));
-  const isMissingRedirectUri = !isMcpClient && hasAuthorizationCodeGrant && !hasValidRedirectUri;
+  const redirectUris = oauth2Config?.redirectUris ?? [];
+  const hasValidRedirectUri = redirectUris.some(
+    (uri) => isValidRedirectUriFormat(uri) && isValidRedirectUriTransport(uri),
+  );
+  const hasDisallowedHttpRedirectUri = redirectUris.some((uri) => {
+    try {
+      return new URL(uri).protocol === 'http:' && !isValidRedirectUriTransport(uri);
+    } catch {
+      return false;
+    }
+  });
+  const isMissingRedirectUri =
+    !isMcpClient && ((hasAuthorizationCodeGrant && !hasValidRedirectUri) || hasDisallowedHttpRedirectUri);
   const isMissingCertificate =
     !isMcpClient &&
     oauth2Config?.tokenEndpointAuthMethod === TokenEndpointAuthMethods.PRIVATE_KEY_JWT &&

--- a/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationEditPage.test.tsx
+++ b/frontend/apps/console/src/features/applications/pages/__tests__/ApplicationEditPage.test.tsx
@@ -924,6 +924,76 @@ describe('ApplicationEditPage', () => {
       expect(screen.getByRole('button', {name: /save changes/i})).toBeDisabled();
     });
 
+    it('disables save when authorization_code includes a remote HTTP redirect URI', async () => {
+      const user = userEvent.setup();
+      mockUseGetApplication.mockReturnValue({
+        data: {
+          ...mockApplication,
+          inboundAuthConfig: [
+            {
+              type: 'oauth2',
+              config: {
+                grantTypes: ['authorization_code'],
+                responseTypes: ['code'],
+                redirectUris: ['https://example.com/callback', 'http://example.com/callback'],
+              },
+            },
+          ],
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as unknown as UseQueryResult<Application>);
+      renderComponent();
+
+      const nameSection = screen.getByText('Test Application').closest('div');
+      const editButton = nameSection?.querySelector('button');
+      await user.click(editButton!);
+      const nameInput = screen.getByRole('textbox');
+      await user.clear(nameInput);
+      await user.type(nameInput, 'Updated Application{Enter}');
+
+      await waitFor(() => {
+        expect(screen.getByText(/A redirect URI is required\./)).toBeInTheDocument();
+      });
+      expect(screen.getByRole('button', {name: /save changes/i})).toBeDisabled();
+    });
+
+    it('disables save when a remote HTTP redirect URI remains without authorization_code', async () => {
+      const user = userEvent.setup();
+      mockUseGetApplication.mockReturnValue({
+        data: {
+          ...mockApplication,
+          inboundAuthConfig: [
+            {
+              type: 'oauth2',
+              config: {
+                grantTypes: ['client_credentials'],
+                responseTypes: [],
+                redirectUris: ['http://example.com/callback'],
+              },
+            },
+          ],
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+      } as unknown as UseQueryResult<Application>);
+      renderComponent();
+
+      const nameSection = screen.getByText('Test Application').closest('div');
+      const editButton = nameSection?.querySelector('button');
+      await user.click(editButton!);
+      const nameInput = screen.getByRole('textbox');
+      await user.clear(nameInput);
+      await user.type(nameInput, 'Updated Application{Enter}');
+
+      await waitFor(() => {
+        expect(screen.getByText(/A redirect URI is required\./)).toBeInTheDocument();
+      });
+      expect(screen.getByRole('button', {name: /save changes/i})).toBeDisabled();
+    });
+
     it('freezes the flows tab when no user-facing grant is granted', async () => {
       const user = userEvent.setup();
       mockUseGetApplication.mockReturnValue({

--- a/frontend/apps/console/src/features/applications/utils/__tests__/isValidRedirectUriFormat.test.ts
+++ b/frontend/apps/console/src/features/applications/utils/__tests__/isValidRedirectUriFormat.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {describe, it, expect} from 'vitest';
-import isValidRedirectUriFormat from '../isValidRedirectUriFormat';
+import isValidRedirectUriFormat, {isValidRedirectUriTransport} from '../isValidRedirectUriFormat';
 
 describe('isValidRedirectUriFormat', () => {
   it('accepts well-formed URIs', () => {
@@ -27,5 +27,28 @@ describe('isValidRedirectUriFormat', () => {
   it('rejects malformed URIs', () => {
     expect(isValidRedirectUriFormat('not a uri')).toBe(false);
     expect(isValidRedirectUriFormat('://missing-scheme')).toBe(false);
+  });
+});
+
+describe('isValidRedirectUriTransport', () => {
+  it.each([
+    'https://example.com/callback',
+    'myapp:/callback',
+    'http://localhost:3000/callback',
+    'http://LOCALHOST:3000/callback',
+    'http://127.0.0.1:3000/callback',
+    'http://[::1]:3000/callback',
+  ])('accepts %s', (uri) => {
+    expect(isValidRedirectUriTransport(uri)).toBe(true);
+  });
+
+  it.each([
+    'http://example.com/callback',
+    'http://192.168.1.10/callback',
+    'http://127.1/callback',
+    'http://127.0.0.2/callback',
+    'http://localhost.example.com/callback',
+  ])('rejects %s', (uri) => {
+    expect(isValidRedirectUriTransport(uri)).toBe(false);
   });
 });

--- a/frontend/apps/console/src/features/applications/utils/__tests__/validateMcpRedirectUri.test.ts
+++ b/frontend/apps/console/src/features/applications/utils/__tests__/validateMcpRedirectUri.test.ts
@@ -68,6 +68,15 @@ describe('validateMcpRedirectUri', () => {
       expect(result.errorKey).toBe('applications:onboarding.mcp.connection.redirectUris.error.invalid');
     });
 
+    it.each(['http://127.1/cb', 'http://127.0.0.2/cb', 'http://localhost.example.com/cb'])(
+      'rejects HTTP with a non-exact loopback host: %s',
+      (uri) => {
+        const result = validateMcpRedirectUri(uri);
+        expect(result.valid).toBe(false);
+        expect(result.errorKey).toBe('applications:onboarding.mcp.connection.redirectUris.error.invalid');
+      },
+    );
+
     it('rejects the ftp scheme', () => {
       const result = validateMcpRedirectUri('ftp://x');
       expect(result.valid).toBe(false);

--- a/frontend/apps/console/src/features/applications/utils/isValidRedirectUriFormat.ts
+++ b/frontend/apps/console/src/features/applications/utils/isValidRedirectUriFormat.ts
@@ -35,3 +35,22 @@ export default function isValidRedirectUriFormat(uri: string): boolean {
     return false;
   }
 }
+
+/**
+ * Allows insecure HTTP redirect URIs only when they use an exact loopback hostname.
+ * HTTPS and custom-scheme redirect URIs are unaffected.
+ */
+export function isValidRedirectUriTransport(uri: string): boolean {
+  try {
+    const trimmedUri = uri.trim();
+    const parsedUri = new URL(trimmedUri);
+    if (parsedUri.protocol !== 'http:') return true;
+
+    const hostname = /^http:\/\/(?:[^@/?#]+@)?(\[[^\]]+\]|[^:/?#]+)(?::\d+)?(?:[/?#]|$)/i
+      .exec(trimmedUri)?.[1]
+      ?.toLowerCase();
+    return hostname !== undefined && ['localhost', '127.0.0.1', '[::1]'].includes(hostname);
+  } catch {
+    return false;
+  }
+}

--- a/frontend/apps/console/src/features/applications/utils/validateMcpRedirectUri.ts
+++ b/frontend/apps/console/src/features/applications/utils/validateMcpRedirectUri.ts
@@ -1,6 +1,8 @@
 // Copyright 2026 The ThunderID Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import {isValidRedirectUriTransport} from './isValidRedirectUriFormat';
+
 /**
  * Result of validating an MCP client redirect URI.
  *
@@ -17,12 +19,6 @@ export interface McpRedirectUriValidationResult {
    */
   errorKey?: string;
 }
-
-/**
- * Loopback hostnames accepted for the `http:` scheme. `[::1]` is how the WHATWG `URL` parser
- * reports the IPv6 loopback hostname (brackets included).
- */
-const LOOPBACK_HOSTNAMES = ['localhost', '127.0.0.1', '[::1]'];
 
 /**
  * Validates a redirect URI against the MCP client redirect URI rule: the URI must be a loopback
@@ -56,7 +52,7 @@ export default function validateMcpRedirectUri(uri: string): McpRedirectUriValid
 
   try {
     const parsedUri = new URL(trimmedUri);
-    const isLoopbackHttp = parsedUri.protocol === 'http:' && LOOPBACK_HOSTNAMES.includes(parsedUri.hostname);
+    const isLoopbackHttp = parsedUri.protocol === 'http:' && isValidRedirectUriTransport(trimmedUri);
     const isHttps = parsedUri.protocol === 'https:';
 
     if (isLoopbackHttp || isHttps) {

--- a/frontend/packages/i18n/src/locales/en-US.ts
+++ b/frontend/packages/i18n/src/locales/en-US.ts
@@ -1267,7 +1267,7 @@ const translations = {
     'edit.advanced.redirectUris.empty': 'No redirect URIs configured.',
     'edit.advanced.redirectUris.addUri': 'Add URI',
     'edit.advanced.redirectUris.error.empty': 'URI cannot be empty',
-    'edit.advanced.redirectUris.error.invalid': 'Enter a valid URL',
+    'edit.advanced.redirectUris.error.invalid': 'Enter a valid URL. HTTP requires localhost, 127.0.0.1, or [::1].',
     'edit.advanced.redirectUris.required': 'The Authorization Code grant requires at least one valid redirect URI.',
     'edit.advanced.oauthAccess.title': 'OAuth 2 Configuration',
     'edit.advanced.oauthAccess.description': 'Manage OAuth 2 settings for this agent.',
@@ -2325,11 +2325,12 @@ const translations = {
     'onboarding.mcp.connection.subtitle': 'Where should users be sent after they authorize this client?',
     'onboarding.mcp.connection.redirectUris.label': 'Redirect URIs',
     'onboarding.mcp.connection.redirectUris.hint':
-      'Each URI must be a loopback address (http://localhost or http://127.0.0.1) or use HTTPS. At least one is required.',
+      'Each URI must use HTTPS or HTTP with localhost, 127.0.0.1, or [::1]. At least one is required.',
     'onboarding.mcp.connection.redirectUris.addUri': 'Add redirect URI',
     'onboarding.mcp.connection.redirectUris.remove': 'Remove redirect URI',
     'onboarding.mcp.connection.redirectUris.error.empty': 'Enter a redirect URI.',
-    'onboarding.mcp.connection.redirectUris.error.invalid': 'Enter a valid loopback (http://127.0.0.1) or HTTPS URI.',
+    'onboarding.mcp.connection.redirectUris.error.invalid':
+      'Enter a valid HTTPS URI or an HTTP URI using localhost, 127.0.0.1, or [::1].',
     'onboarding.mcp.connection.inspectorHint.prefix': 'Testing with MCP Inspector? Use',
     'onboarding.mcp.oauthProfile.label': 'OAuth profile',
     'onboarding.mcp.oauthProfile.authCodePkce': 'Authorization Code + PKCE (required)',
@@ -2882,7 +2883,8 @@ const translations = {
     'edit.general.redirectUris.tooltip': 'OAuth2 redirect URIs where users will be redirected after authentication',
     'edit.general.redirectUris.addUri': 'Add URI',
     'edit.general.redirectUris.error.empty': 'Invalid Redirect: URI must not be empty.',
-    'edit.general.redirectUris.error.invalid': 'Invalid Redirect: Please enter a valid URL.',
+    'edit.general.redirectUris.error.invalid':
+      'Invalid Redirect: Please enter a valid URL. HTTP requires localhost, 127.0.0.1, or [::1].',
     'edit.general.postLogoutRedirectUris.title': 'Post-Logout Redirect URIs',
     'edit.general.postLogoutRedirectUris.description':
       'Allowed URIs to redirect to after logout. A post_logout_redirect_uri passed to the logout endpoint must match one of these.',

--- a/tests/integration/oauth/authz/authz_test.go
+++ b/tests/integration/oauth/authz/authz_test.go
@@ -25,7 +25,7 @@ const (
 	clientID                             = "authz_test_client_123"
 	clientSecret                         = "authz_test_secret_123"
 	appName                              = "AuthzTestApp"
-	redirectURI                          = "https://localhost:3000"
+	redirectURI                          = "http://localhost:3000"
 	authzDefaultResourceServerIdentifier = "https://authz-default.example.com"
 )
 
@@ -671,14 +671,14 @@ func (ts *AuthzTestSuite) TestRedirectURIValidation() {
 		Description    string
 	}{
 		{
-			Name:           "Valid HTTPS Redirect URI",
+			Name:           "Valid HTTP Loopback Redirect URI",
 			ClientID:       clientID,
 			RedirectURI:    redirectURI,
 			ResponseType:   "code",
 			Scope:          "openid",
-			State:          "redirect_test_valid_https",
+			State:          "redirect_test_valid_http_loopback",
 			ExpectedStatus: http.StatusFound,
-			Description:    "Standard HTTPS localhost should be valid",
+			Description:    "HTTP localhost loopback should be valid",
 		},
 		{
 			Name:           "Valid HTTPS with Path",
@@ -692,15 +692,15 @@ func (ts *AuthzTestSuite) TestRedirectURIValidation() {
 			Description:    "HTTPS with callback path should be rejected (not registered)",
 		},
 		{
-			Name:           "HTTP Redirect URI",
+			Name:           "Remote HTTP Redirect URI",
 			ClientID:       clientID,
-			RedirectURI:    "http://localhost:3000",
+			RedirectURI:    "http://example.com",
 			ResponseType:   "code",
 			Scope:          "openid",
-			State:          "redirect_test_http",
+			State:          "redirect_test_remote_http",
 			ExpectedStatus: http.StatusFound,
 			ExpectedError:  "invalid_request",
-			Description:    "HTTP should be rejected for security",
+			Description:    "Remote HTTP redirect URI should be rejected",
 		},
 		{
 			Name:           "Invalid Protocol",
@@ -771,7 +771,7 @@ func (ts *AuthzTestSuite) TestCompleteAuthorizationCodeFlow() {
 		{
 			Name:         "Successful Flow",
 			ClientID:     clientID,
-			RedirectURI:  "https://localhost:3000",
+			RedirectURI:  redirectURI,
 			ResponseType: "code",
 			Scope:        "openid",
 			State:        "test_state_456",
@@ -901,7 +901,7 @@ func (ts *AuthzTestSuite) TestAuthorizationCodeErrorScenarios() {
 		{
 			Name:           "Reused Authorization Code",
 			ClientID:       clientID,
-			RedirectURI:    "https://localhost:3000",
+			RedirectURI:    redirectURI,
 			ResponseType:   "code",
 			Scope:          "openid",
 			State:          "test_state_error",


### PR DESCRIPTION
UPDATED - Fixes #5136

### Purpose

Allow OAuth 2.0 HTTP redirect URIs only for the exact loopback hosts `localhost`, `127.0.0.1`, and `[::1]`. Other HTTP redirect URIs, such as `http://example.com`, remain rejected, while HTTPS redirect URIs remain supported.

<!-- If this PR contains breaking changes, uncomment and fill in the section below -->
<!--

---
### ⚠️ Breaking Changes

#### 🔧 Summary of Breaking Changes

_Describe what is changing_

#### 💥 Impact

_What will break? Who is affected?_

#### 🔄 Migration Guide

_How should users update their code/configuration to adapt to the breaking changes? Include examples if helpful._

---

-->

### Approach

#### Backend
>Applied the HTTP loopback restriction during client registration, updates, and authorization-time redirect validation.

#### Frontend
>Aligned application, agent, and MCP redirect URI validation with the backend behavior.

#### Tests
>Added focused backend and frontend regression coverage for the supported and rejected HTTP redirect URI cases.

#### Samples
>No sample changes were required.

#### Documentation
>No documentation changes were required.

| Change type | Files | What was changed | System influence |
|---|---|---|---|
| Backend registration validation | `service.go` | Added HTTP hostname validation during OAuth client creation and updates. | Allows HTTP only for exact `localhost`, `127.0.0.1`, and `::1`; rejects remote, private, alternative loopback, and suffix hosts. HTTPS remains allowed. |
| Backend runtime validation | `oauth_client.go` | Added the same HTTP restriction when selecting and validating redirect URIs during OAuth flows. | Prevents stored or supplied disallowed HTTP redirect URIs from being used at runtime, including the single-URI default path. |
| Backend tests: new cases | `service_test.go`, `oauth_client_test.go` | Added table-driven allow/reject cases for HTTPS, supported loopbacks, remote HTTP, private IPs, alternative loopbacks, and hostname suffixes. | Protects both configuration-time and runtime enforcement from regressions. |
| Shared frontend validator | `isValidRedirectUriFormat.ts` | Added `isValidRedirectUriTransport()` as the common HTTP transport validator. | Gives application, agent, and MCP interfaces one consistent allowlist. It also rejects aliases such as `127.1` that browser URL normalization could otherwise hide. |
| MCP validation reuse | `validateMcpRedirectUri.ts` | Replaced its separate loopback list with the shared transport validator. | Keeps MCP validation aligned with normal applications and agents. |
| Application creation validation | `ConfigureRedirectUris.tsx`, `ConfigureDetails.tsx` | Added inline redirect URI validation and blocked wizard readiness when any disallowed HTTP redirect URI exists. | Users cannot Continue or Finish application creation with `http://example.com`, even if another valid URI is present. Supported loopbacks remain usable. |
| Application editing validation | `OAuth2ConfigSection.tsx` | Added transport validation when redirect URI fields lose focus. | Disallowed HTTP values show an error and are not committed as valid configuration. |
| Application Save protection | `ApplicationEditPage.tsx` | Added page-level detection of every disallowed HTTP redirect URI. | Save remains disabled if any remote HTTP URI exists, including retained redirect URIs after `authorization_code` is removed. |
| Agent editing validation | `RedirectURIsSection.tsx` | Reused the shared validator for field and required-URI validation. | Agent redirect URI fields accept supported HTTP loopbacks and reject other HTTP hosts with an inline error. |
| Agent Save protection | `AgentEditPage.tsx` | Added page-level detection of disallowed HTTP redirect URIs. | Prevents saving invalid agent configuration even when the redirect section is unmounted or `authorization_code` is disabled. |
| User-facing validation messages | `McpAccessSection.tsx`, `en-US.ts` | Updated hints and error messages to name `localhost`, `127.0.0.1`, and `[::1]`. | Users receive an accurate explanation of which HTTP redirect hosts are allowed. |
| Frontend utility tests: new cases | `isValidRedirectUriFormat.test.ts`, `validateMcpRedirectUri.test.ts` | Added allow/reject coverage for exact loopbacks, remote HTTP, private IPs, `127.1`, `127.0.0.2`, and hostname suffixes. | Protects the shared validation rule and exact-host requirement. |
| Frontend creation tests: new cases | `ConfigureDetails.test.tsx`, `ConfigureRedirectUris.test.tsx` | Added tests for supported loopbacks, remote HTTP rejection, mixed URI lists, and wizard readiness. | Verifies invalid HTTP redirects cannot pass application creation. |
| Frontend editing tests: new cases | `OAuth2ConfigSection.test.tsx`, `ApplicationEditPage.test.tsx`, `RedirectURIsSection.test.tsx`, `AgentEditPage.test.tsx` | Added field validation and Save-guard tests for applications and agents. | Verifies supported loopbacks work and disallowed HTTP values block saving in all relevant editing states. |
| Existing MCP test updates | `ConfigureMcpConnection.test.tsx`, `McpAccessSection.test.tsx` | Updated existing message assertions and test input to match the complete loopback guidance. | Keeps MCP tests aligned with the new shared behaviour and wording. |

### Related Issues

- #5136

### Related PRs

- N/A

### Checklist

- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. Not applicable because no documentation changes were required.
  - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided.
  - [x] Unit Tests
  - [x] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
  - [ ] Breaking changes section filled.
  - [ ] `breaking change` label added.

### Manual Testing

| # | Manual test | Result | Observed behavior |
|---|---|---|---|
| 1 | Application creation validation | Pass | HTTPS and HTTP redirects using `localhost`, `127.0.0.1`, and `[::1]` were accepted. Other HTTP redirects were rejected and prevented Continue or Finish. |
| 2 | Application editing validation | Pass | Supported redirects could be saved. Disallowed HTTP redirects showed validation errors and kept Save disabled. |
| 3 | Application retained-value guard | Pass | The unpatched version allowed Save after `authorization_code` was disabled while a disallowed HTTP URI remained stored. The patched version kept the URI accessible for correction and kept Save disabled until it was corrected. |
| 4 | Agent editing validation | Pass | Supported HTTP loopback redirects were accepted. Other HTTP redirects showed validation errors and prevented saving. |
| 5 | MCP client validation | Pass | `localhost`, `127.0.0.1`, and `[::1]` HTTP redirects were accepted. Other HTTP hosts were rejected with the updated validation message. |
| 6 | Direct backend registration test | Pass | Creation with all three supported HTTP loopback hosts returned `201`. Creation and update with `http://example.com` returned `400 Invalid redirect URI`. |
| 7 | Authorization endpoint test | Pass | All three supported HTTP loopback redirects were accepted. A retained `http://example.com/callback` URI was rejected with `Invalid redirect URI`, both when explicitly supplied and when inferred from an omitted `redirect_uri`. ThunderID did not redirect to `example.com`. |

### Overall Testing

- Backend registration and update validation passed.
- Authorization-time explicit and inferred redirect validation passed.
- Application, agent, and MCP frontend validation passed.
- Focused backend and frontend regression tests passed.
- No task-related failures remain.

### Security checks

- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted HTTP redirect URIs to `localhost`, `127.0.0.1`, or `[::1]`.
  * Continued support for HTTPS and custom URI schemes.

* **Bug Fixes**
  * Blocked remote, private, and lookalike localhost HTTP redirect hosts across configuration and authorization flows.
  * Updated validation messages to clearly explain the restriction.

* **Tests**
  * Added coverage for accepted loopback URLs and rejected remote or invalid HTTP redirect URIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->