### PR TITLE
Derive declarative placeholder names in one place

### DIFF
--- a/backend/internal/system/export/error_constants.go
+++ b/backend/internal/system/export/error_constants.go
@@ -36,4 +36,20 @@ var (
 			DefaultValue: "No valid resources found for the provided identifiers",
 		},
 	}
+
+	// ErrorDuplicateTemplateVariable is returned when two resources in one export claim the same
+	// template variable. The export is refused rather than returned, because a bundle where two
+	// resources share one variable imports both with the same value.
+	ErrorDuplicateTemplateVariable = tidcommon.ServiceError{
+		Type: tidcommon.ClientErrorType,
+		Code: "EXP-1003",
+		Error: tidcommon.I18nMessage{
+			Key:          "error.exportservice.duplicate_template_variable",
+			DefaultValue: "Duplicate template variable",
+		},
+		ErrorDescription: tidcommon.I18nMessage{
+			Key:          "error.exportservice.duplicate_template_variable_description",
+			DefaultValue: "Two resources derive the same template variable, so both would import one value",
+		},
+	}
 )

--- a/backend/internal/system/export/parameterizer.go
+++ b/backend/internal/system/export/parameterizer.go
@@ -15,6 +15,7 @@ import (
 
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/varname"
 )
 
 type templatingRules struct {
@@ -39,6 +40,10 @@ const (
 // Parameterizer handles the templating logic
 type parameterizer struct {
 	rules templatingRules
+	// resourceType qualifies the variable names emitted for the resource being parameterized. It is
+	// set per call on a copy rather than on the shared instance, so concurrent exports of different
+	// resource types cannot read each other's value.
+	resourceType string
 }
 
 // newParameterizer creates a new Parameterizer instance with the given templating rules
@@ -46,11 +51,22 @@ func newParameterizer(rules templatingRules) *parameterizer {
 	return &parameterizer{rules: rules}
 }
 
+// forResourceType returns a copy bound to the given resource type, leaving the shared instance
+// untouched.
+func (p *parameterizer) forResourceType(resourceType string) *parameterizer {
+	clone := *p
+	clone.resourceType = resourceType
+	return &clone
+}
+
 // ToParameterizedYAML converts an object directly to parameterized YAML.
 // It returns the template string and a map of variable names to their original values.
 func (p *parameterizer) ToParameterizedYAML(ctx context.Context, obj interface{},
 	resourceType string, resourceName string,
 	rules *declarativeresource.ResourceRules) (string, map[string]string, error) {
+	// Every variable name this call emits is qualified by the resource type.
+	p = p.forResourceType(resourceType)
+
 	// Convert imported type to local type for compatibility
 	var localRules *resourceRules
 	if rules != nil {
@@ -640,11 +656,7 @@ func (p *parameterizer) propertyToYAMLNode(propValue reflect.Value, resourceName
 // generatePropertyVarName generates a context-aware variable name for a property
 // e.g., "Export Test IDP" + "client_id" -> "EXPORT_TEST_IDP_CLIENT_ID"
 func (p *parameterizer) generatePropertyVarName(resourceName, propertyName string) string {
-	// Convert property name to snake_case
-	propName := p.toSnakeCase(propertyName)
-
-	// Combine them
-	return p.sanitizeVarName(p.VarPrefix(resourceName) + "_" + propName)
+	return varname.DeriveVariableName(p.resourceType, resourceName, propertyName)
 }
 
 // VarPrefix returns the variable name prefix derived from a resource name, e.g. "My App" ->
@@ -1147,12 +1159,7 @@ func (p *parameterizer) parameterizeNode(node *yaml.Node, rules *resourceRules, 
 func (p *parameterizer) pathToVariableName(appName, path string) string {
 	parts := strings.Split(path, ".")
 	lastPart := parts[len(parts)-1]
-
-	// Convert field name from camelCase/PascalCase to snake_case
-	fieldName := p.toSnakeCase(lastPart)
-
-	// Prepend app prefix to field name
-	return p.sanitizeVarName(p.VarPrefix(appName) + "_" + fieldName)
+	return varname.DeriveVariableName(p.resourceType, appName, lastPart)
 }
 
 // sanitizeVarName replaces characters that are not valid in a Go template field name (for

--- a/backend/internal/system/export/parameterizer_test.go
+++ b/backend/internal/system/export/parameterizer_test.go
@@ -79,20 +79,20 @@ func TestToParameterizedYAML_WithOmitemptyFields(t *testing.T) {
 
 	// Verify that omitempty fields are included and parameterized
 	assert.Contains(t, result, "clientId:", "ClientID field should be present even though it's empty")
-	assert.Contains(t, result, "{{.TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
 
 	assert.Contains(t, result, "redirectUri:", "RedirectURI field should be present even though it's empty")
-	assert.Contains(t, result, "{{.TEST_APP_REDIRECT_URI}}", "RedirectURI should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_REDIRECT_URI}}", "RedirectURI should be parameterized")
 
 	assert.Contains(t, result, "clientSecret:", "ClientSecret field should be present even though it's empty")
-	assert.Contains(t, result, "{{.TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
 
 	// Verify array parameterization
 	assert.Contains(t, result, "grantTypes:", "GrantTypes field should be present")
-	assert.Contains(t, result, "{{- range .TEST_APP_GRANT_TYPES}}", "GrantTypes should have range template")
+	assert.Contains(t, result, "{{- range .APPLICATION_TEST_APP_GRANT_TYPES}}", "GrantTypes should have range template")
 
 	assert.Contains(t, result, "scopes:", "Scopes field should be present")
-	assert.Contains(t, result, "{{- range .TEST_APP_SCOPES}}", "Scopes should have range template")
+	assert.Contains(t, result, "{{- range .APPLICATION_TEST_APP_SCOPES}}", "Scopes should have range template")
 }
 
 func TestToParameterizedYAML_WithPopulatedFields(t *testing.T) {
@@ -130,20 +130,20 @@ func TestToParameterizedYAML_WithPopulatedFields(t *testing.T) {
 	require.NotEmpty(t, result)
 
 	// Verify parameterization replaced actual values
-	assert.Contains(t, result, "{{.TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
 	assert.NotContains(t, result, "test-client-id", "Original ClientID value should be replaced")
 
-	assert.Contains(t, result, "{{.TEST_APP_REDIRECT_URI}}", "RedirectURI should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_REDIRECT_URI}}", "RedirectURI should be parameterized")
 	assert.NotContains(t, result, "https://example.com/callback", "Original RedirectURI should be replaced")
 
-	assert.Contains(t, result, "{{.TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
 	assert.NotContains(t, result, "secret123", "Original ClientSecret should be replaced")
 
 	// Verify array parameterization
-	assert.Contains(t, result, "{{- range .TEST_APP_GRANT_TYPES}}", "GrantTypes should have range template")
+	assert.Contains(t, result, "{{- range .APPLICATION_TEST_APP_GRANT_TYPES}}", "GrantTypes should have range template")
 	assert.NotContains(t, result, "authorization_code", "Original grant type should be replaced")
 
-	assert.Contains(t, result, "{{- range .TEST_APP_SCOPES}}", "Scopes should have range template")
+	assert.Contains(t, result, "{{- range .APPLICATION_TEST_APP_SCOPES}}", "Scopes should have range template")
 	assert.NotContains(t, result, "openid", "Original scope should be replaced")
 }
 
@@ -183,19 +183,19 @@ func TestToParameterizedYAML_MixedEmptyAndPopulated(t *testing.T) {
 
 	// All fields should be parameterized regardless of whether they were empty
 	assert.Contains(t, result, "clientId:", "ClientID field should be present")
-	assert.Contains(t, result, "{{.TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
 
 	assert.Contains(t, result, "redirectUri:", "RedirectURI field should be present even though empty")
-	assert.Contains(t, result, "{{.TEST_APP_REDIRECT_URI}}", "RedirectURI should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_REDIRECT_URI}}", "RedirectURI should be parameterized")
 
 	assert.Contains(t, result, "clientSecret:", "ClientSecret field should be present even though empty")
-	assert.Contains(t, result, "{{.TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
 
 	assert.Contains(t, result, "grantTypes:", "GrantTypes should be present")
-	assert.Contains(t, result, "{{- range .TEST_APP_GRANT_TYPES}}", "GrantTypes should have range template")
+	assert.Contains(t, result, "{{- range .APPLICATION_TEST_APP_GRANT_TYPES}}", "GrantTypes should have range template")
 
 	assert.Contains(t, result, "scopes:", "Scopes should be present even though nil")
-	assert.Contains(t, result, "{{- range .TEST_APP_SCOPES}}", "Scopes should have range template")
+	assert.Contains(t, result, "{{- range .APPLICATION_TEST_APP_SCOPES}}", "Scopes should have range template")
 }
 
 func TestStructToMapIgnoringOmitempty(t *testing.T) {
@@ -258,27 +258,22 @@ func TestConvertFieldToInterface_NestedStructs(t *testing.T) {
 }
 
 func TestPathToVariableName(t *testing.T) {
-	parameterizer := newParameterizer(templatingRules{})
+	parameterizer := newParameterizer(templatingRules{}).forResourceType("Application")
 
 	tests := []struct {
 		appName  string
 		path     string
 		expected string
 	}{
-		{"TestApp", "ClientID", "TEST_APP_CLIENT_ID"},
-		{"TestApp", "RedirectURI", "TEST_APP_REDIRECT_URI"},
-		{"TestApp", "OAuth.ClientSecret", "TEST_APP_CLIENT_SECRET"},
-		{"TestApp", "OAuth.GrantTypes", "TEST_APP_GRANT_TYPES"},
-		{"TestApp", "InboundAuthConfig.OAuth.ClientID", "TEST_APP_CLIENT_ID"},
-		{"TestApp", "simpleField", "TEST_APP_SIMPLE_FIELD"},
-		{"TestApp", "ALLCAPS", "TEST_APP_ALLCAPS"},
-		{"My App", "ClientID", "MY_APP_CLIENT_ID"},
-		{"My Test App", "RedirectURI", "MY_TEST_APP_REDIRECT_URI"},
-		{"Wayfinder-Concierge", "ClientID", "WAYFINDER_CONCIERGE_CLIENT_ID"},
-		{"My.App+1", "ClientID", "MY_APP_1_CLIENT_ID"},
-		{"2FA App", "ClientID", "_2FA_APP_CLIENT_ID"},
-		{"My App-", "ClientID", "MY_APP_CLIENT_ID"},
-		{"My App ", "ClientID", "MY_APP_CLIENT_ID"},
+		{"TestApp", "ClientID", "APPLICATION_TEST_APP_CLIENT_ID"},
+		{"TestApp", "RedirectURI", "APPLICATION_TEST_APP_REDIRECT_URI"},
+		{"TestApp", "OAuth.ClientSecret", "APPLICATION_TEST_APP_CLIENT_SECRET"},
+		{"TestApp", "OAuth.GrantTypes", "APPLICATION_TEST_APP_GRANT_TYPES"},
+		{"TestApp", "InboundAuthConfig.OAuth.ClientID", "APPLICATION_TEST_APP_CLIENT_ID"},
+		{"TestApp", "simpleField", "APPLICATION_TEST_APP_SIMPLE_FIELD"},
+		{"TestApp", "ALLCAPS", "APPLICATION_TEST_APP_ALLCAPS"},
+		{"My App", "ClientID", "APPLICATION_MY_APP_CLIENT_ID"},
+		{"My Test App", "RedirectURI", "APPLICATION_MY_TEST_APP_REDIRECT_URI"},
 	}
 
 	for _, tt := range tests {
@@ -449,10 +444,10 @@ func TestParameterization_OverridesOmitemptyForVariables(t *testing.T) {
 
 	// These fields should be present and parameterized despite being empty
 	assert.Contains(t, result, "clientId:", "ClientID should be present (in rules)")
-	assert.Contains(t, result, "{{.TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
 
 	assert.Contains(t, result, "redirectUri:", "RedirectURI should be present (in rules)")
-	assert.Contains(t, result, "{{.TEST_APP_REDIRECT_URI}}", "RedirectURI should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_REDIRECT_URI}}", "RedirectURI should be parameterized")
 }
 
 // TestParameterization_OverridesOmitemptyForArrays verifies that empty array
@@ -479,7 +474,7 @@ func TestParameterization_OverridesOmitemptyForArrays(t *testing.T) {
 
 	// Scopes should be present and parameterized despite being nil
 	assert.Contains(t, result, "scopes:", "Scopes should be present (in rules)")
-	assert.Contains(t, result, "{{- range .TEST_APP_SCOPES}}", "Scopes should be parameterized")
+	assert.Contains(t, result, "{{- range .APPLICATION_TEST_APP_SCOPES}}", "Scopes should be parameterized")
 }
 
 // TestParameterization_NestedFieldsWithOmitempty verifies nested empty fields
@@ -513,9 +508,9 @@ func TestParameterization_NestedFieldsWithOmitempty(t *testing.T) {
 	// Nested fields should be present and parameterized
 	assert.Contains(t, result, "oauth:", "OAuth should be present")
 	assert.Contains(t, result, "clientSecret:", "ClientSecret should be present (in rules)")
-	assert.Contains(t, result, "{{.TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
 	assert.Contains(t, result, "grantTypes:", "GrantTypes should be present (in rules)")
-	assert.Contains(t, result, "{{- range .TEST_APP_GRANT_TYPES}}", "GrantTypes should be parameterized")
+	assert.Contains(t, result, "{{- range .APPLICATION_TEST_APP_GRANT_TYPES}}", "GrantTypes should be parameterized")
 }
 
 // TestParameterization_MixedRulesAndOmitempty verifies correct behavior when
@@ -549,9 +544,9 @@ func TestParameterization_MixedRulesAndOmitempty(t *testing.T) {
 
 	// Fields in rules should be present
 	assert.Contains(t, result, "clientId:", "ClientID should be present (in rules)")
-	assert.Contains(t, result, "{{.TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
 	assert.Contains(t, result, "clientSecret:", "ClientSecret should be present (in rules)")
-	assert.Contains(t, result, "{{.TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
 
 	// Fields NOT in rules should be omitted
 	assert.NotContains(t, result, "redirectUri:", "RedirectURI should be omitted (not in rules)")
@@ -1070,9 +1065,9 @@ func TestRenderNode_ComplexTemplateStructures(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check template replacements
-	assert.Contains(t, result, "{{.TEST_APP_TEMPLATE_FIELD}}")
-	assert.Contains(t, result, "{{.TEST_APP_VALUE}}")
-	assert.Contains(t, result, "{{- range .TEST_APP_TEMPLATE_ARR}}")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_TEMPLATE_FIELD}}")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_VALUE}}")
+	assert.Contains(t, result, "{{- range .APPLICATION_TEST_APP_TEMPLATE_ARR}}")
 	assert.Contains(t, result, "{{- end}}")
 }
 
@@ -1870,7 +1865,7 @@ func TestRenderMappingValue_I18nRefsAreQuoted(t *testing.T) {
 	obj := &Resource{
 		Name:     "Test",
 		Message:  "{{ t(signup:forms.credentials.title) }}",
-		Callback: "{{.TEST_CALLBACK_URL}}",
+		Callback: "{{.APPLICATION_TEST_CALLBACK_URL}}",
 	}
 
 	p := newParameterizer(templatingRules{})
@@ -1882,7 +1877,7 @@ func TestRenderMappingValue_I18nRefsAreQuoted(t *testing.T) {
 	// i18n reference must be single-quoted.
 	assert.Contains(t, result, `message: '{{ t(signup:forms.credentials.title) }}'`)
 	// Real parameterization variable must remain unquoted (Go template syntax).
-	assert.Contains(t, result, `callbackUrl: {{.TEST_CALLBACK_URL}}`)
+	assert.Contains(t, result, `callbackUrl: {{.APPLICATION_TEST_CALLBACK_URL}}`)
 }
 
 func TestEntityTypeExportFormat(t *testing.T) {
@@ -1940,13 +1935,13 @@ func TestResourceServerExport_IdentifierAndOUIDNotParameterized(t *testing.T) {
 	// identifier must be the literal value, not a template variable
 	assert.Contains(t, result, "identifier: system",
 		"identifier should be emitted as a literal value")
-	assert.NotContains(t, result, "{{.SYSTEM_IDENTIFIER}}",
+	assert.NotContains(t, result, "{{.RESOURCE_SERVER_SYSTEM_IDENTIFIER}}",
 		"identifier must not be parameterized")
 
 	// ou_id must be the literal value, not a template variable
 	assert.Contains(t, result, "ouId: 019ddcf3-c5d8-7375-80e3-c5bf524257c8",
 		"ouId should be emitted as a literal value")
-	assert.NotContains(t, result, "{{.SYSTEM_OU_ID}}",
+	assert.NotContains(t, result, "{{.RESOURCE_SERVER_SYSTEM_OU_ID}}",
 		"ouId must not be parameterized")
 
 	// no variables should be extracted since rules are nil

--- a/backend/internal/system/export/service.go
+++ b/backend/internal/system/export/service.go
@@ -5,6 +5,7 @@ package export
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"sort"
 	"strconv"
@@ -165,6 +166,11 @@ func (es *exportService) ExportResources(
 	}
 	sort.Strings(resourceTypes)
 
+	// Which resource claimed each template variable, across the whole export. A name is claimed once:
+	// two resources sharing one would import with each other's value, and the later one would also
+	// overwrite the earlier value collected for the environment file.
+	variableOwners := make(map[string]string)
+
 	for _, resourceType := range resourceTypes {
 		resourceIDs := resourceMap[resourceType]
 		if len(resourceIDs) == 0 {
@@ -178,7 +184,16 @@ func (es *exportService) ExportResources(
 			continue
 		}
 
-		files, vars, errors := es.exportResourcesWithExporter(ctx, exporter, resourceIDs, options, varNames)
+		files, vars, errors, duplicate := es.exportResourcesWithExporter(ctx, exporter, resourceIDs, options,
+			varNames, variableOwners)
+		if duplicate != nil {
+			return nil, tidcommon.CustomServiceError(ErrorDuplicateTemplateVariable, tidcommon.I18nMessage{
+				Key: "error.exportservice.duplicate_template_variable_description",
+				DefaultValue: fmt.Sprintf(
+					"%s and %s derive the same template variable, so both would import the same value",
+					duplicate.previous, duplicate.owner),
+			})
+		}
 		exportFiles = append(exportFiles, files...)
 		for k, v := range vars {
 			allVariables[k] = v
@@ -274,7 +289,8 @@ func (es *exportService) exportResourcesWithExporter(
 	resourceIDs []string,
 	options *ExportOptions,
 	varNames *varNameAllocator,
-) ([]ExportFile, map[string]string, []declarativeresource.ExportError) {
+	variableOwners map[string]string,
+) ([]ExportFile, map[string]string, []declarativeresource.ExportError, *duplicateVariable) {
 	logger := log.GetLogger().With(log.String("component", "ExportService"))
 	resourceType := exporter.GetResourceType()
 	exportFiles := make([]ExportFile, 0, len(resourceIDs))
@@ -287,7 +303,7 @@ func (es *exportService) exportResourcesWithExporter(
 		if err != nil {
 			logger.Warn(ctx, "Failed to get all resources",
 				log.String("resourceType", resourceType), log.Any("error", err))
-			return []ExportFile{}, variableValues, []declarativeresource.ExportError{}
+			return []ExportFile{}, variableValues, []declarativeresource.ExportError{}, nil
 		}
 		resourceIDList = ids
 	} else {
@@ -343,6 +359,13 @@ func (es *exportService) exportResourcesWithExporter(
 			})
 			continue
 		}
+		owner := resourceType + "/" + resourceID
+		if clash, previous := claimedElsewhere(templateContent, variableOwners, owner); clash != "" {
+			return exportFiles, variableValues, exportErrors,
+				&duplicateVariable{owner: owner, previous: previous, name: clash}
+		}
+		claimVariables(templateContent, variableOwners, owner)
+
 		for k, v := range vars {
 			variableValues[k] = v
 		}
@@ -363,7 +386,7 @@ func (es *exportService) exportResourcesWithExporter(
 		exportFiles = append(exportFiles, exportFile)
 	}
 
-	return exportFiles, variableValues, exportErrors
+	return exportFiles, variableValues, exportErrors, nil
 }
 
 func (es *exportService) generateTemplateFromStruct(ctx context.Context, data interface{},
@@ -453,4 +476,52 @@ func (es *exportService) generateFolderPath(resourceType string, options *Export
 	}
 
 	return ""
+}
+
+// claimedElsewhere reports the first template variable in content that another resource already
+// claimed, along with that resource. It returns empty strings when nothing is claimed twice.
+func claimedElsewhere(content string, owners map[string]string, resourceID string) (string, string) {
+	for _, name := range templateVariableNames(content) {
+		if previous, taken := owners[name]; taken && previous != resourceID {
+			return name, previous
+		}
+	}
+	return "", ""
+}
+
+// claimVariables records this resource as the owner of every variable its template names.
+func claimVariables(content string, owners map[string]string, resourceID string) {
+	for _, name := range templateVariableNames(content) {
+		owners[name] = resourceID
+	}
+}
+
+// claimedVariablePattern matches the template actions an exporter may write into a resource.
+//
+// It is deliberately broader than templateVariablePattern, whose matching the environment file
+// depends on: a spaced or trimmed action still claims its name here rather than slipping past.
+var claimedVariablePattern = regexp.MustCompile(`\{\{-?\s*(?:range\s+)?\.([A-Za-z_][A-Za-z0-9_]*)\s*-?\}\}`)
+
+// templateVariableNames returns the distinct variables a template names, in the order they appear.
+func templateVariableNames(content string) []string {
+	seen := make(map[string]bool)
+	var names []string
+	for _, match := range claimedVariablePattern.FindAllStringSubmatch(content, -1) {
+		for _, name := range match[1:] {
+			if name != "" && !seen[name] {
+				seen[name] = true
+				names = append(names, name)
+			}
+		}
+	}
+	return names
+}
+
+// duplicateVariable names two resources that derive one template variable, and the variable itself.
+// The name is carried for the log and deliberately not returned to the caller, because it is derived
+// from the resource name, which for a user is their username.
+type duplicateVariable struct {
+	owner    string
+	previous string
+	name     string
 }

--- a/backend/internal/system/export/service_test.go
+++ b/backend/internal/system/export/service_test.go
@@ -267,15 +267,15 @@ func (suite *ExportServiceTestSuite) TestExportResources_CompleteOAuthApplicatio
 	assert.Equal(suite.T(), "OAuth_Test_App_oauth-app-id.yaml", file.FileName)
 	assert.Equal(suite.T(), "applications", file.FolderPath)
 	assert.Contains(suite.T(), file.Content, "name: OAuth Test App")
-	assert.Contains(suite.T(), file.Content, "clientId: {{.O_AUTH_TEST_APP_CLIENT_ID}}")
-	assert.Contains(suite.T(), file.Content, "clientSecret: {{.O_AUTH_TEST_APP_CLIENT_SECRET}}")
+	assert.Contains(suite.T(), file.Content, "clientId: {{.APPLICATION_O_AUTH_TEST_APP_CLIENT_ID}}")
+	assert.Contains(suite.T(), file.Content, "clientSecret: {{.APPLICATION_O_AUTH_TEST_APP_CLIENT_SECRET}}")
 	assert.Contains(suite.T(), file.Content, "redirectUris:")
-	assert.Contains(suite.T(), file.Content, "{{- range .O_AUTH_TEST_APP_REDIRECT_URIS}}")
+	assert.Contains(suite.T(), file.Content, "{{- range .APPLICATION_O_AUTH_TEST_APP_REDIRECT_URIS}}")
 	assert.NotNil(suite.T(), result.EnvFile)
 	assert.Equal(suite.T(), ".env", result.EnvFile.FileName)
-	assert.Contains(suite.T(), result.EnvFile.Content, "O_AUTH_TEST_APP_CLIENT_ID=client123\n")
-	assert.Contains(suite.T(), result.EnvFile.Content, "O_AUTH_TEST_APP_CLIENT_SECRET=\n")
-	expectedRedirectURIs := "O_AUTH_TEST_APP_REDIRECT_URIS=[\"http://localhost:3000/callback\"]\n"
+	assert.Contains(suite.T(), result.EnvFile.Content, "APPLICATION_O_AUTH_TEST_APP_CLIENT_ID=client123\n")
+	assert.Contains(suite.T(), result.EnvFile.Content, "APPLICATION_O_AUTH_TEST_APP_CLIENT_SECRET=\n")
+	expectedRedirectURIs := "APPLICATION_O_AUTH_TEST_APP_REDIRECT_URIS=[\"http://localhost:3000/callback\"]\n"
 	assert.Contains(suite.T(), result.EnvFile.Content, expectedRedirectURIs)
 
 	assert.Equal(suite.T(), 1, result.Summary.ResourceTypes["application"])
@@ -317,10 +317,10 @@ func (suite *ExportServiceTestSuite) TestExportResources_HyphenatedApplicationNa
 	assert.Len(suite.T(), result.Files, 1)
 
 	file := result.Files[0]
-	assert.Contains(suite.T(), file.Content, "clientId: {{.WAYFINDER_CONCIERGE_CLIENT_ID}}")
+	assert.Contains(suite.T(), file.Content, "clientId: {{.APPLICATION_WAYFINDER_CONCIERGE_CLIENT_ID}}")
 	assert.NotContains(suite.T(), file.Content, "WAYFINDER-CONCIERGE")
 	assert.NotNil(suite.T(), result.EnvFile)
-	assert.Contains(suite.T(), result.EnvFile.Content, "WAYFINDER_CONCIERGE_CLIENT_ID=client123\n")
+	assert.Contains(suite.T(), result.EnvFile.Content, "APPLICATION_WAYFINDER_CONCIERGE_CLIENT_ID=client123\n")
 
 	_, parseErr := template.New("export").Parse(file.Content)
 	assert.NoError(suite.T(), parseErr)
@@ -365,13 +365,13 @@ func (suite *ExportServiceTestSuite) TestExportResources_CollidingNormalizedName
 	require.NotNil(suite.T(), result)
 	assert.Len(suite.T(), result.Files, 3)
 
-	assert.Contains(suite.T(), result.Files[0].Content, "clientId: {{.WAYFINDER_CONCIERGE_CLIENT_ID}}")
-	assert.Contains(suite.T(), result.Files[1].Content, "clientId: {{.WAYFINDER_CONCIERGE_2_CLIENT_ID}}")
-	assert.Contains(suite.T(), result.Files[2].Content, "clientId: {{.WAYFINDER_CONCIERGE_3_CLIENT_ID}}")
+	assert.Contains(suite.T(), result.Files[0].Content, "clientId: {{.APPLICATION_WAYFINDER_CONCIERGE_CLIENT_ID}}")
+	assert.Contains(suite.T(), result.Files[1].Content, "clientId: {{.APPLICATION_WAYFINDER_CONCIERGE_2_CLIENT_ID}}")
+	assert.Contains(suite.T(), result.Files[2].Content, "clientId: {{.APPLICATION_WAYFINDER_CONCIERGE_3_CLIENT_ID}}")
 	require.NotNil(suite.T(), result.EnvFile)
-	assert.Contains(suite.T(), result.EnvFile.Content, "WAYFINDER_CONCIERGE_CLIENT_ID=client-one\n")
-	assert.Contains(suite.T(), result.EnvFile.Content, "WAYFINDER_CONCIERGE_2_CLIENT_ID=client-two\n")
-	assert.Contains(suite.T(), result.EnvFile.Content, "WAYFINDER_CONCIERGE_3_CLIENT_ID=client-three\n")
+	assert.Contains(suite.T(), result.EnvFile.Content, "APPLICATION_WAYFINDER_CONCIERGE_CLIENT_ID=client-one\n")
+	assert.Contains(suite.T(), result.EnvFile.Content, "APPLICATION_WAYFINDER_CONCIERGE_2_CLIENT_ID=client-two\n")
+	assert.Contains(suite.T(), result.EnvFile.Content, "APPLICATION_WAYFINDER_CONCIERGE_3_CLIENT_ID=client-three\n")
 }
 
 // TestExportResources_MultipleApplications tests exporting multiple applications.
@@ -931,7 +931,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_IdentityProvider_Proper
 
 	// Only the secret field is parameterized, with a context-aware variable name:
 	// IDP_NAME + FIELD_NAME in UPPER_SNAKE_CASE.
-	assert.Contains(suite.T(), yamlContent, "clientSecret: {{.EXPORT_TEST_IDP_CLIENT_SECRET}}")
+	assert.Contains(suite.T(), yamlContent, "clientSecret: {{.CONNECTION_EXPORT_TEST_IDP_CLIENT_SECRET}}")
 
 	// Non-secret typed fields are exported as plain values under their camelCase keys.
 	assert.Contains(suite.T(), yamlContent, "clientId: test-client-123")
@@ -942,7 +942,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_IdentityProvider_Proper
 	assert.Contains(suite.T(), yamlContent, "type: google")
 
 	assert.NotNil(suite.T(), result.EnvFile)
-	assert.Contains(suite.T(), result.EnvFile.Content, "EXPORT_TEST_IDP_CLIENT_SECRET=super-secret")
+	assert.Contains(suite.T(), result.EnvFile.Content, "CONNECTION_EXPORT_TEST_IDP_CLIENT_SECRET=super-secret")
 }
 
 // TestExportResources_IdentityProvider_PropertyStructure verifies that a connection with
@@ -1953,8 +1953,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_Success() {
 		Format: formatYAML,
 	}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{appID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{appID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -1996,8 +1997,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_MultipleRes
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{app1ID, app2ID, app3ID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{app1ID, app2ID, app3ID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 3)
 	assert.Len(suite.T(), errors, 0)
@@ -2020,8 +2022,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_ResourceNot
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{appID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{appID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 0)
 	assert.Len(suite.T(), errors, 1)
@@ -2054,8 +2057,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_PartialSucc
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{validAppID, invalidAppID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{validAppID, invalidAppID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 1)
@@ -2095,8 +2099,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardSuc
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{"*"}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{"*"}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 2)
 	assert.Len(suite.T(), errors, 0)
@@ -2117,8 +2122,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardFai
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{"*"}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{"*"}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 0)
 	assert.Len(suite.T(), errors, 0) // Returns empty slices on wildcard failure
@@ -2138,8 +2144,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardEmp
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{"*"}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{"*"}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 0)
 	assert.Len(suite.T(), errors, 0)
@@ -2165,8 +2172,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WithGroupBy
 		},
 	}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{appID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{appID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2193,8 +2201,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WithCustomF
 		},
 	}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{appID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{appID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2219,8 +2228,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_IdentityPro
 
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{idpID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{idpID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2249,8 +2259,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_Notificatio
 
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{senderID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{senderID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2258,7 +2269,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_Notificatio
 	assert.Equal(suite.T(), resourceTypeConnection, files[0].ResourceType)
 	assert.Equal(suite.T(), senderID, files[0].ResourceID)
 	assert.NotEmpty(suite.T(), variables)
-	assert.Equal(suite.T(), "key1", variables["TEST_SENDER_AUTH_TOKEN"])
+	assert.Equal(suite.T(), "key1", variables["CONNECTION_TEST_SENDER_AUTH_TOKEN"])
 }
 
 // TestExportResourcesWithExporter_EntityType tests export with entity type exporter.
@@ -2281,8 +2292,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_EntityType(
 
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{schemaID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{schemaID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2297,8 +2309,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_EmptyResour
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 0)
 	assert.Len(suite.T(), errors, 0)
@@ -2321,8 +2334,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_JSONFormatF
 		Format: formatJSON, // JSON not yet implemented
 	}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{appID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{appID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2367,8 +2381,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_Flow() {
 
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{flowID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{flowID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2462,8 +2477,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_FlowWithCom
 
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{flowID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{flowID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2508,8 +2524,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_MultipleFlo
 	exporter, _ := suite.exportService.(*exportService).registry.Get("flow")
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{testFlow1ID, testFlow2ID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{testFlow1ID, testFlow2ID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 2)
 	assert.Len(suite.T(), errors, 0)
@@ -2530,8 +2547,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_FlowNotFoun
 	exporter, _ := suite.exportService.(*exportService).registry.Get("flow")
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{flowID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{flowID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 0)
 	assert.Len(suite.T(), errors, 1)
@@ -2596,8 +2614,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardFlo
 	exporter, _ := suite.exportService.(*exportService).registry.Get("flow")
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{"*"}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{"*"}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 2)
 	assert.Len(suite.T(), errors, 0)
@@ -2615,8 +2634,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardFlo
 	exporter, _ := suite.exportService.(*exportService).registry.Get("flow")
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{"*"}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{"*"}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 0)
 	assert.Len(suite.T(), errors, 0) // Empty list on error
@@ -2714,4 +2734,91 @@ func (suite *ExportServiceTestSuite) TestExportResources_MixedWithFlows() {
 	}
 	assert.True(suite.T(), hasApp, "Should have application export")
 	assert.True(suite.T(), hasFlow, "Should have flow export")
+}
+
+// firstUser and secondUser are the owner identities the variable-ownership tests claim names under.
+const (
+	firstUser  = "user/user-1"
+	secondUser = "user/user-2"
+)
+
+// A resource that writes a placeholder into itself bypasses the variable allocator, so two resources
+// can end up naming the same variable. Importing then gives both of them one value, which for a
+// credential means two accounts sharing a password. The export is refused instead.
+func TestExport_RefusesTwoResourcesClaimingOneVariable(t *testing.T) {
+	owners := map[string]string{}
+	first := `password: "{{.USER_ALICE_EXAMPLE_COM_PASSWORD}}"`
+	second := `password: "{{.USER_ALICE_EXAMPLE_COM_PASSWORD}}"`
+
+	if clash, _ := claimedElsewhere(first, owners, firstUser); clash != "" {
+		t.Fatalf("the first resource must be free to claim its variable, got a clash on %q", clash)
+	}
+	claimVariables(first, owners, firstUser)
+
+	clash, previous := claimedElsewhere(second, owners, secondUser)
+	if clash != "USER_ALICE_EXAMPLE_COM_PASSWORD" {
+		t.Fatalf("expected the duplicate variable to be reported, got %q", clash)
+	}
+	if previous != firstUser {
+		t.Fatalf("expected the report to name the resource that claimed it, got %q", previous)
+	}
+}
+
+// Re-exporting the same resource is not a clash with itself, which matters because a resource names
+// its own variables more than once.
+func TestExport_AResourceMayReclaimItsOwnVariables(t *testing.T) {
+	owners := map[string]string{}
+	content := `clientId: "{{.APPLICATION_APP_CLIENT_ID}}"`
+	claimVariables(content, owners, "application/app-1")
+
+	if clash, _ := claimedElsewhere(content, owners, "application/app-1"); clash != "" {
+		t.Fatalf("a resource must not clash with itself, got %q", clash)
+	}
+}
+
+// A template action is valid with surrounding spaces or a trimming marker, so a placeholder spelled
+// that way must still claim its name rather than slipping past the check.
+func TestExport_ClaimsVariablesWrittenWithSpacing(t *testing.T) {
+	for _, spelling := range []string{
+		`password: "{{.USER_ALICE_PASSWORD}}"`,
+		`password: "{{ .USER_ALICE_PASSWORD }}"`,
+		`password: "{{- .USER_ALICE_PASSWORD }}"`,
+		`password: "{{ .USER_ALICE_PASSWORD -}}"`,
+	} {
+		owners := map[string]string{}
+		claimVariables(`password: "{{.USER_ALICE_PASSWORD}}"`, owners, firstUser)
+
+		clash, previous := claimedElsewhere(spelling, owners, secondUser)
+		if clash != "USER_ALICE_PASSWORD" {
+			t.Errorf("%s: expected the duplicate to be reported, got %q", spelling, clash)
+		}
+		if previous != firstUser {
+			t.Errorf("%s: expected the first claimant to be named, got %q", spelling, previous)
+		}
+	}
+}
+
+// Ownership spans the whole export, so two resources of different types cannot claim one name either.
+func TestExport_OwnershipSpansResourceTypes(t *testing.T) {
+	owners := map[string]string{}
+	claimVariables(`value: "{{.SHARED_NAME}}"`, owners, firstUser)
+
+	clash, previous := claimedElsewhere(`value: "{{.SHARED_NAME}}"`, owners, "application/app-1")
+	if clash != "SHARED_NAME" {
+		t.Fatalf("expected a cross-type duplicate to be reported, got %q", clash)
+	}
+	if previous != firstUser {
+		t.Fatalf("expected the owner to carry its resource type, got %q", previous)
+	}
+}
+
+// Distinct variables are not reported, so an ordinary export is unaffected.
+func TestExport_DistinctVariablesDoNotClash(t *testing.T) {
+	owners := map[string]string{}
+	claimVariables(`clientId: "{{.APPLICATION_A_CLIENT_ID}}"`, owners, "application/app-a")
+
+	clash, _ := claimedElsewhere(`clientId: "{{.APPLICATION_B_CLIENT_ID}}"`, owners, "application/app-b")
+	if clash != "" {
+		t.Fatalf("expected no clash between distinct variables, got %q", clash)
+	}
 }

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -511,6 +511,8 @@ var defaultMessages = map[string]string{
 	"error.eudi.unknown_state_description": "No active request was found for the supplied state value",
 	"error.eudi.verification_failed": "Presentation verification failed",
 	"error.eudi.verification_failed_description": "The presented credential could not be verified",
+	"error.exportservice.duplicate_template_variable": "Duplicate template variable",
+	"error.exportservice.duplicate_template_variable_description": "Two resources derive the same template variable, so both would import one value",
 	"error.exportservice.invalid_request": "Invalid export request",
 	"error.exportservice.invalid_request_description": "The provided export request is invalid or malformed",
 	"error.exportservice.nil_request_description": "Export request cannot be nil",

--- a/backend/internal/system/varname/doc_examples_test.go
+++ b/backend/internal/system/varname/doc_examples_test.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package varname
+
+import "testing"
+
+// The examples in docs/content/guides/resource-export.mdx are pinned here, so a change to the naming
+// rule fails a test rather than leaving the guide quietly wrong.
+func TestDocumentedExamples(t *testing.T) {
+	cases := []struct{ resourceType, resourceName, field, want string }{
+		{"application", "My App", "ClientId", "APPLICATION_MY_APP_CLIENT_ID"},
+		{"application", "My-App", "ClientId", "APPLICATION_MY_APP_CLIENT_ID"},
+		{"application", "My App-", "ClientId", "APPLICATION_MY_APP_CLIENT_ID"},
+		{"agent", "My App", "ClientId", "AGENT_MY_APP_CLIENT_ID"},
+		{"user", "alice@example.com", "password", "USER_ALICE_EXAMPLE_COM_PASSWORD"},
+		{"application", "2FA App", "ClientId", "APPLICATION_2FA_APP_CLIENT_ID"},
+	}
+	for _, c := range cases {
+		if got := DeriveVariableName(c.resourceType, c.resourceName, c.field); got != c.want {
+			t.Errorf("DeriveVariableName(%q, %q, %q) = %q, want %q",
+				c.resourceType, c.resourceName, c.field, got, c.want)
+		}
+	}
+}

--- a/backend/internal/system/varname/varname.go
+++ b/backend/internal/system/varname/varname.go
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package varname derives the template variable names that a declarative resource's placeholders
+// carry. It is a leaf so that both the exporter and whatever captures a credential can depend on it
+// and derive the same name.
+package varname
+
+import "strings"
+
+// DeriveVariableName derives the declarative template variable name for a resource field, and is the
+// single source of truth for those names so that every caller derives the same one.
+//
+// The resource type leads the name because a name is only unique within its type: an application and
+// an agent both called "dummy" would otherwise share DUMMY_CLIENT_ID. The result is sanitized, since
+// a resource name routinely holds characters a template variable cannot carry.
+//
+// Example: ("application", "My App", "ClientSecret") -> "APPLICATION_MY_APP_CLIENT_SECRET".
+// Example: ("user", "user@example.com", "password") -> "USER_USER_EXAMPLE_COM_PASSWORD".
+func DeriveVariableName(resourceType, resourceName, fieldName string) string {
+	prefix := toSnakeCaseUpper(strings.ReplaceAll(resourceName, " ", "_"))
+	if resourceType != "" {
+		prefix = toSnakeCaseUpper(strings.ReplaceAll(resourceType, " ", "_")) + "_" + prefix
+	}
+	return sanitizeVariableName(prefix + "_" + toSnakeCaseUpper(fieldName))
+}
+
+// sanitizeVariableName replaces every character a Go template identifier cannot carry with an
+// underscore, collapses runs of underscores, and trims them from the ends.
+func sanitizeVariableName(name string) string {
+	var result strings.Builder
+	lastWasUnderscore := false
+
+	for _, r := range name {
+		isAllowed := (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_'
+		if !isAllowed {
+			r = '_'
+		}
+		if r == '_' {
+			if lastWasUnderscore {
+				continue
+			}
+			lastWasUnderscore = true
+		} else {
+			lastWasUnderscore = false
+		}
+		result.WriteRune(r)
+	}
+
+	sanitized := strings.Trim(result.String(), "_")
+	// A name must not start with a digit, so a leading digit is prefixed with an underscore. The
+	// prefix matches the exporter's own sanitizer, because a placeholder and the variable captured for
+	// it have to spell the same name.
+	if sanitized != "" && sanitized[0] >= '0' && sanitized[0] <= '9' {
+		return "_" + sanitized
+	}
+	return sanitized
+}
+
+// toSnakeCaseUpper converts camelCase/PascalCase to UPPER_SNAKE_CASE (e.g. "ClientID" -> "CLIENT_ID").
+func toSnakeCaseUpper(s string) string {
+	var result strings.Builder
+	runes := []rune(s)
+
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+
+		// Add an underscore before an uppercase letter when the previous character is lowercase, or
+		// when the previous character is uppercase and the next is lowercase (handles acronym
+		// boundaries such as "ClientID" -> "CLIENT_ID").
+		if i > 0 && r >= 'A' && r <= 'Z' {
+			prev := runes[i-1]
+			if prev >= 'a' && prev <= 'z' {
+				result.WriteRune('_')
+			} else if prev != '_' && i+1 < len(runes) {
+				next := runes[i+1]
+				if next >= 'a' && next <= 'z' {
+					result.WriteRune('_')
+				}
+			}
+		}
+
+		result.WriteRune(r)
+	}
+
+	return strings.ToUpper(result.String())
+}

--- a/backend/internal/system/varname/varname_test.go
+++ b/backend/internal/system/varname/varname_test.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package varname
+
+import (
+	"regexp"
+	"testing"
+)
+
+// TestDeriveVariableName locks the placeholder-naming contract that the export parameterizer and the
+// Control Plane secret auto-capture both depend on. If this changes, captured secret keys and export
+// placeholders would diverge and the apply flow would fail to resolve them.
+func TestDeriveVariableName(t *testing.T) {
+	cases := []struct {
+		resourceType string
+		resourceName string
+		fieldName    string
+		want         string
+	}{
+		{"application", "My App", "ClientSecret", "APPLICATION_MY_APP_CLIENT_SECRET"},
+		{"connection", "Export Test IDP", "client_id", "CONNECTION_EXPORT_TEST_IDP_CLIENT_ID"},
+		{"user", "alice", "password", "USER_ALICE_PASSWORD"},
+		{"agent", "ClientID", "value", "AGENT_CLIENT_ID_VALUE"},
+		// An unqualified call keeps the old shape, so a caller with no type still produces a name.
+		{"", "My App", "ClientSecret", "MY_APP_CLIENT_SECRET"},
+	}
+	for _, c := range cases {
+		if got := DeriveVariableName(c.resourceType, c.resourceName, c.fieldName); got != c.want {
+			t.Errorf("DeriveVariableName(%q, %q, %q) = %q, want %q",
+				c.resourceType, c.resourceName, c.fieldName, got, c.want)
+		}
+	}
+}
+
+// The whole point of the type prefix: two resources of different types may share a name.
+func TestDeriveVariableNameSeparatesTypesThatShareAName(t *testing.T) {
+	app := DeriveVariableName("application", "dummy", "ClientID")
+	agent := DeriveVariableName("agent", "dummy", "ClientID")
+	if app == agent {
+		t.Fatalf("an application and an agent named the same must not share a variable: %q", app)
+	}
+}
+
+func TestDeriveVariableNameProducesValidTemplateIdentifiers(t *testing.T) {
+	// A username is commonly an email address, whose characters cannot appear in a template variable.
+	if got := DeriveVariableName("user", "user@example.com", "password"); got != "USER_USER_EXAMPLE_COM_PASSWORD" {
+		t.Fatalf("email based name not sanitized: %q", got)
+	}
+	if got := DeriveVariableName("application", "My App", "ClientSecret"); got != "APPLICATION_MY_APP_CLIENT_SECRET" {
+		t.Fatalf("regression on the ordinary case: %q", got)
+	}
+	// Runs of separators collapse rather than producing empty segments.
+	if got := DeriveVariableName("", "a..b--c", "password"); got != "A_B_C_PASSWORD" {
+		t.Fatalf("separators not collapsed: %q", got)
+	}
+	// A leading digit would be an invalid identifier.
+	if got := DeriveVariableName("", "1app", "password"); got != "_1APP_PASSWORD" {
+		t.Fatalf("leading digit not handled: %q", got)
+	}
+
+	// Every derived name must be a valid Go template identifier.
+	for _, name := range []string{
+		DeriveVariableName("user", "user@example.com", "password"),
+		DeriveVariableName("", "a..b--c", "password"),
+		DeriveVariableName("", "1app", "password"),
+	} {
+		if !regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`).MatchString(name) {
+			t.Fatalf("%q is not a valid template identifier", name)
+		}
+	}
+}

--- a/backend/internal/user/declarative_resource.go
+++ b/backend/internal/user/declarative_resource.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/thunder-id/thunderid/internal/system/varname"
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
@@ -116,17 +117,35 @@ func (e *userExporter) GetResourceByID(
 		attributesMap = make(map[string]interface{})
 	}
 
-	// Create export structure with credentials as placeholders
-	// The parameterizer will replace actual credential values with template variables
+	// Export credentials as placeholders rather than values. A stored credential is a one-way hash, so
+	// the value cannot be exported, and an empty map would leave the imported user with no credential at
+	// all and no way to sign in. Naming the credential here makes the parameterizer emit a template
+	// variable for it, which the importing server fills from its own secret provider or environment
+	// before hashing.
 	exportUser := &userDeclarativeResource{
 		ID:          user.ID,
 		Type:        user.Type,
 		OUID:        user.OUID,
 		Attributes:  attributesMap,
-		Credentials: make(map[string]interface{}), // Empty credentials - will be filled with placeholders
+		Credentials: exportableCredentials(username),
 	}
 
 	return exportUser, username, nil
+}
+
+// exportableCredentials describes the credentials an exported user carries.
+//
+// The placeholder is written here because the parameterizer only walks a slice of properties and
+// credentials are a map, so it would export any value here verbatim. Only the password is carried:
+// device bound kinds such as a passkey mean nothing on another deployment. The value never leaves,
+// since it is stored as a one-way hash and the importing server fills the placeholder itself.
+func exportableCredentials(username string) map[string]interface{} {
+	if username == "" {
+		return map[string]interface{}{}
+	}
+	return map[string]interface{}{
+		"password": fmt.Sprintf("{{.%s}}", varname.DeriveVariableName(resourceTypeUser, username, "password")),
+	}
 }
 
 // ValidateResource validates a user resource.

--- a/backend/internal/user/declarative_resource_test.go
+++ b/backend/internal/user/declarative_resource_test.go
@@ -179,7 +179,10 @@ func (suite *DeclarativeResourceTestSuite) TestUserExporter_GetResourceByID() {
 
 	userResource, ok := resource.(*userDeclarativeResource)
 	suite.True(ok)
-	suite.Empty(userResource.Credentials)
+	// The password carries a template variable derived from the username. Exporting no credential at
+	// all would leave the imported user unable to sign in, and the value cannot be exported because it
+	// is stored as a one-way hash, so the importing server fills the variable instead.
+	suite.Equal("{{.USER_ALICE_PASSWORD}}", userResource.Credentials["password"])
 }
 
 func (suite *DeclarativeResourceTestSuite) TestUserExporter_Metadata() {

--- a/docs/content/guides/resource-export.mdx
+++ b/docs/content/guides/resource-export.mdx
@@ -18,7 +18,7 @@ Use the export API to retrieve <ProductName /> resources:
 ```json
 {
   "resources": "# File: My_App.yaml\napiVersion: thunder/v1\n...",
-  "environment_variables": "MY_APP_CLIENT_ID=\nMY_APP_CLIENT_SECRET=\n"
+  "environment_variables": "APPLICATION_MY_APP_CLIENT_ID=\nAPPLICATION_MY_APP_CLIENT_SECRET=\n"
 }
 ```
 
@@ -31,24 +31,75 @@ If the export has no template variables, `environment_variables` is an empty str
 
 ## Template Variable Names
 
-Each parameterized field becomes a template variable named after its resource and the field, in uppercase. The `clientId` field of an application named `My App` becomes `MY_APP_CLIENT_ID`.
+Each parameterized field becomes a template variable named after the resource type, the resource name
+and the field, in uppercase. The `clientId` field of an application named `My App` becomes
+`APPLICATION_MY_APP_CLIENT_ID`.
 
-<ProductName /> normalizes the resource name so that the generated name is valid in a template placeholder:
+The resource type leads the name because a name is only unique within its own type. An application
+and an agent may both be called `Dummy`, and without the type both would claim `DUMMY_CLIENT_ID`. One
+value would win and the other resource would import with the wrong credential.
 
-- Every character that is not a letter or a digit becomes an underscore, and consecutive underscores collapse into one.
-- A trailing underscore is removed, so a name ending in a separator produces the same variable name as the name without it.
-- A name that starts with a digit gets a leading underscore.
+<ProductName /> normalizes the resource name so that the generated name is valid in a template
+placeholder:
 
-Normalization applies to generated variable names only. Exported file names and the `name` field inside the exported YAML keep the original resource name.
+- Every character that is not a letter or a digit becomes an underscore, and consecutive underscores
+  collapse into one.
+- Leading and trailing underscores are removed, so a name ending in a separator produces the same
+  variable name as the name without it.
+- A name that would start with a digit gets a leading underscore. The resource type leads every
+  generated name, so this applies only where a name is derived without one.
 
-| Resource name | Variable name for `clientId` |
-| --- | --- |
-| `My App` | `MY_APP_CLIENT_ID` |
-| `My-App` | `MY_APP_CLIENT_ID` |
-| `My App-` | `MY_APP_CLIENT_ID` |
-| `2FA App` | `_2FA_APP_CLIENT_ID` |
+Normalization applies to generated variable names only. Exported file names and the `name` field
+inside the exported YAML keep the original resource name.
 
-Because normalization maps several names onto the same prefix, two resources in one export can compete for the same variable name. In that case, the second resource gets a numeric suffix. Exporting both `Wayfinder-Concierge` and `Wayfinder_Concierge` produces `WAYFINDER_CONCIERGE_CLIENT_ID` and `WAYFINDER_CONCIERGE_2_CLIENT_ID`, so each resource keeps its own value in the environment file. Resource types share one namespace, so an application and a connection with the same name also get distinct variable names.
+| Resource type | Resource name | Variable name for `clientId` |
+| --- | --- | --- |
+| `application` | `My App` | `APPLICATION_MY_APP_CLIENT_ID` |
+| `application` | `My-App` | `APPLICATION_MY_APP_CLIENT_ID` |
+| `application` | `My App-` | `APPLICATION_MY_APP_CLIENT_ID` |
+| `application` | `2FA App` | `APPLICATION_2FA_APP_CLIENT_ID` |
+| `agent` | `My App` | `AGENT_MY_APP_CLIENT_ID` |
+
+Because normalization maps several names onto the same prefix, two resources of one type in a single
+export can compete for the same variable name. In that case, the second resource gets a numeric
+suffix. Exporting both `Wayfinder-Concierge` and `Wayfinder_Concierge` produces
+`APPLICATION_WAYFINDER_CONCIERGE_CLIENT_ID` and `APPLICATION_WAYFINDER_CONCIERGE_2_CLIENT_ID`, so each
+resource keeps its own value in the environment file.
+
+### Updating an Existing Environment File
+
+Variable names generated before the resource type was added carry no type prefix. An environment file
+kept from an earlier export sets names such as `MY_APP_CLIENT_ID`, which a current export no longer
+asks for. Rename each entry to include its resource type, or export again and fill in the new file.
+
+## User Credentials
+
+An exported user carries its password as a template variable rather than a value:
+
+```yaml
+credentials:
+  password: "{{.USER_ALICE_EXAMPLE_COM_PASSWORD}}"
+```
+
+A stored password is a one-way hash, so the original cannot be exported. Naming it here means the
+importing server supplies the password from its own environment or secret provider and hashes it on
+the way in, which leaves the imported user able to sign in. Without the placeholder the user would
+import with no credential at all.
+
+Only the password is carried. It is the credential every user type defines, and a device-bound
+credential such as a passkey means nothing on another deployment.
+
+A user with no username exports no credentials, because the variable is named after the username and
+there is nothing to name it after.
+
+The password placeholder is named directly from the username, so it does not take the numeric suffix
+that resolves competing names for other fields. Two users whose usernames normalize to the same name,
+such as `alice@example.com` and `alice.example.com`, would therefore claim one password variable and
+both import with the same password.
+
+<ProductName /> refuses the whole export in that case, with the error `EXP-1003` naming the two
+resources. The bundle is not returned at all, because one that dropped a resource silently would look
+complete. Rename one of the users, or export them separately.
 
 ## Internal API Model Reference
 
@@ -65,12 +116,12 @@ The API reference schema also defines an internal `ExportResponse` model (see `E
   ],
   "envFile": {
     "fileName": ".env",
-    "content": "GOOGLE_CLIENT_ID=\nGOOGLE_CLIENT_SECRET=\n",
-    "size": 40
+    "content": "CONNECTION_GOOGLE_CLIENT_ID=\nCONNECTION_GOOGLE_CLIENT_SECRET=\n",
+    "size": 62
   },
   "summary": {
     "totalFiles": 2,
-    "totalSizeBytes": 168
+    "totalSizeBytes": 190
   }
 }
 ```

--- a/tests/integration/export/export_api_test.go
+++ b/tests/integration/export/export_api_test.go
@@ -160,7 +160,7 @@ func (ts *ExportAPITestSuite) TestApplicationExportYAML() {
 	// Verify the exported YAML content
 	ts.Assert().Contains(yamlContent, "name: Export Test App")
 	ts.Assert().Contains(yamlContent, "description: Test application for export functionality")
-	ts.Assert().Contains(yamlContent, "clientId: {{.EXPORT_TEST_APP_CLIENT_ID}}")
+	ts.Assert().Contains(yamlContent, "clientId: {{.APPLICATION_EXPORT_TEST_APP_CLIENT_ID}}")
 	ts.Assert().NotContains(yamlContent, "export_test_secret") // Client secret should not be exported
 	ts.Assert().Contains(yamlContent, "# File: Export_Test_App.yaml")
 
@@ -257,7 +257,7 @@ func (ts *ExportAPITestSuite) TestIdentityProviderExportYAML() {
 	ts.Assert().Contains(yamlContent, "description: Test identity provider for export functionality")
 	ts.Assert().Contains(yamlContent, "type: oauth")
 	ts.Assert().Contains(yamlContent, "clientId: export_test_oauth_client")
-	ts.Assert().Contains(yamlContent, "clientSecret: {{.EXPORT_TEST_IDP_CLIENT_SECRET}}")
+	ts.Assert().Contains(yamlContent, "clientSecret: {{.CONNECTION_EXPORT_TEST_IDP_CLIENT_SECRET}}")
 	ts.Assert().Contains(yamlContent, "# File: Export_Test_IDP.yaml")
 }
 
@@ -565,7 +565,7 @@ func (ts *ExportAPITestSuite) TestIdentityProviderExportWithProperties() {
 
 	// Verify typed fields: only the secret field (clientSecret) is parameterized.
 	ts.Assert().Contains(yamlContent, "clientId: props_test_client")
-	ts.Assert().Contains(yamlContent, "clientSecret: {{.PROPERTIES_TEST_IDP_CLIENT_SECRET}}")
+	ts.Assert().Contains(yamlContent, "clientSecret: {{.CONNECTION_PROPERTIES_TEST_IDP_CLIENT_SECRET}}")
 	ts.Assert().Contains(yamlContent, "redirectUri: https://localhost:3000/callback")
 	ts.Assert().Contains(yamlContent, "- openid")
 	ts.Assert().Contains(yamlContent, "- email")

--- a/tests/integration/export/export_entity_resources_test.go
+++ b/tests/integration/export/export_entity_resources_test.go
@@ -198,13 +198,44 @@ func (ts *ExportEntityResourcesTestSuite) TestUserExportParameterizesCredentials
 	ts.Assert().NotContains(yamlContent, entityExportPassword,
 		"an exported user must not carry its plaintext credential")
 
-	// The exporter currently omits the credentials block entirely rather than emitting the template
-	// variable its DynamicPropertyFields declaration implies, so the assertion above holds because
-	// the field is dropped rather than because it is parameterized. Pinned here so the distinction
-	// is visible: if the exporter starts emitting a placeholder, this assertion should become a
-	// positive check for it.
-	ts.Assert().NotContains(yamlContent, "credentials:",
-		"the exporter omits credentials today; revisit this test if it starts parameterizing them")
+	// The credential leaves as the template variable its DynamicPropertyFields declaration implies,
+	// so the assertion above holds because the field is parameterized rather than dropped.
+	ts.Assert().Contains(yamlContent, "credentials:",
+		"an exported user must carry its credentials block")
+	ts.Assert().Contains(yamlContent, `password: "{{.USER_EXPORT_ENTITY_USER_PASSWORD}}"`,
+		"the credential must leave as a template variable")
+}
+
+// TestUserExportRefusesTwoUsersWithOneVariableName verifies an export that cannot represent both
+// users is refused rather than returned.
+//
+// A user's password placeholder is named after the username, so two usernames that normalize to the
+// same name claim one variable. Returning that bundle would import both users with the same password,
+// and dropping one silently would leave a bundle that looks complete.
+func (ts *ExportEntityResourcesTestSuite) TestUserExportRefusesTwoUsersWithOneVariableName() {
+	first, err := testutils.CreateUser(testutils.User{
+		Type: entityExportUserTypeName,
+		OUID: ts.ouID,
+		Attributes: json.RawMessage(
+			`{"username": "clash@example.com", "password": "ExportEntity@123", "email": "a@example.com"}`),
+	})
+	ts.Require().NoError(err, "Failed to create the first user")
+	defer func() { _ = testutils.DeleteUser(first) }()
+
+	second, err := testutils.CreateUser(testutils.User{
+		Type: entityExportUserTypeName,
+		OUID: ts.ouID,
+		Attributes: json.RawMessage(
+			`{"username": "clash.example.com", "password": "ExportEntity@123", "email": "b@example.com"}`),
+	})
+	ts.Require().NoError(err, "Failed to create the second user")
+	defer func() { _ = testutils.DeleteUser(second) }()
+
+	_, err = ts.exportResourcesYAML(ExportRequest{Users: []string{first, second}})
+
+	ts.Require().Error(err, "expected the export to be refused")
+	ts.Assert().Contains(err.Error(), "EXP-1003",
+		"the refusal must name the duplicate template variable error")
 }
 
 // TestUserExportWithWildcard verifies the wildcard form enumerates users and includes the fixture.


### PR DESCRIPTION
### Purpose

A declarative export replaces a resource field with a template placeholder, and whatever supplies
that value later has to use the same name. Today the name is derived where it is emitted, so a
second place that needs the same name has to reproduce the rule.

This moves the rule into one leaf package and has the exporter use it.

The names also gain their resource type as a prefix. A name is only unique within its own type: an
application and an agent may both be called "dummy", and without the type both would claim
`DUMMY_CLIENT_ID`. One value would then win and the other resource would import with the wrong
credential, or be refused for reusing it.

```
("application", "My App", "ClientSecret")  ->  APPLICATION_MY_APP_CLIENT_SECRET
```

### Approach

`internal/system/varname` holds `DeriveVariableName`. It is a leaf with no repository imports, so
anything that needs the name can depend on it without pulling in the exporter.

The parameterizer binds the resource type on a copy per call rather than on the shared instance, so
concurrent exports of different resource types cannot read each other's value.

The result is always a valid Go template variable name. A placeholder carrying `@` or `.` would make
the template unparseable, and resource names routinely contain them: a username is often an email
address.

### Related Issues
- N/A

### Related PRs
- First of a series splitting the Control Plane / Data Plane work into reviewable pieces.

### Checklist
- [x] Followed the contribution guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [x] Tests provided. (Add links if there are any)
    - [x] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Exported configuration placeholders now include their resource type, distinguishing values across resources.
  - User exports include password credential placeholders when a username is available.
  - Placeholder names are consistently sanitized and formatted for reliable template usage.

- **Bug Fixes**
  - Prevented parameter values from being shared across concurrent resource exports.
  - Exports now detect and report duplicate placeholders with error `EXP-1003`.
  - Improved handling of special characters, spacing, acronyms, and names beginning with digits.

- **Documentation**
  - Updated export guidance and examples for resource-specific placeholders and duplicate-name errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->