### PR TITLE
Read the per-request deployment id from one place

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -234,12 +234,16 @@ func createHTTPServer(ctx context.Context, logger *log.Logger, cfg *config.Confi
 	securityMiddleware := createSecurityMiddleware(ctx, logger, mux, jwtService, revocationEnforcer)
 
 	// Build the middleware chain with proper execution order.
-	// Request flow: CorrelationID (outermost) -> SecurityHeaders -> AccessLog -> Security -> Route Handler (innermost)
+	// Request flow: CorrelationID (outermost) -> DeploymentID -> SecurityHeaders -> AccessLog ->
+	// Security -> Route Handler (innermost)
 	// Note: Middlewares are wrapped in reverse order - the last added will execute first.
 	// The Gate and Console frontend paths are always excluded from the access log to keep it
 	// focused on API traffic. Additional prefixes can be excluded via log.access.exclude_paths.
 	handler := log.AccessLogHandler(logger, accessLogExcludePaths(cfg.Log.Access.ExcludePaths), securityMiddleware)
 	handler = middleware.SecurityHeadersMiddleware()(handler)
+	// Outside the security layer, so that every request carries the deployment id it acts for by the
+	// time any store is reached.
+	handler = middleware.DeploymentIDMiddleware(handler)
 	handler = middleware.CorrelationIDMiddleware(handler)
 
 	// Build the server address using hostname and port from the configurations.

--- a/backend/internal/entity/credential_reference_test.go
+++ b/backend/internal/entity/credential_reference_test.go
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package entity
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/thunder-id/thunderid/internal/system/cryptolib"
+	"github.com/thunder-id/thunderid/internal/system/secretresolver"
+)
+
+// serveKVHash stands up a secret provider holding one hash backed secret.
+func serveKVHash(t *testing.T, name string, hash cryptolib.Credential) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"secrets": map[string]interface{}{
+			name: map[string]interface{}{
+				"kind":      "hash",
+				"value":     hash.Hash,
+				"algorithm": string(hash.Algorithm),
+				"parameters": map[string]interface{}{
+					"salt":       hash.Parameters.Salt,
+					"iterations": hash.Parameters.Iterations,
+					"keySize":    hash.Parameters.KeySize,
+				},
+			},
+		}})
+	}))
+	t.Cleanup(srv.Close)
+
+	previous := secretresolver.Default()
+	r := secretresolver.New(secretresolver.Config{BaseURL: srv.URL})
+	if err := r.LoadAll(t.Context()); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	secretresolver.SetDefault(r)
+	t.Cleanup(func() { secretresolver.SetDefault(previous) })
+}
+
+// hashOf produces a credential the way the control plane would.
+func hashOf(t *testing.T, plaintext string) cryptolib.Credential {
+	t.Helper()
+	svc, err := cryptolib.Initialize(cryptolib.HashConfig{
+		Algorithm: cryptolib.PBKDF2, SaltSize: 16, Iterations: 1000, KeySize: 32,
+	})
+	if err != nil {
+		t.Fatalf("hash service: %v", err)
+	}
+	cred, err := svc.Generate([]byte(plaintext))
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	return cred
+}
+
+func TestCredentialReference_ResolvesAPromotedCredentialFromTheSecretProvider(t *testing.T) {
+	const plaintext = "the-client-secret"
+	hash := hashOf(t, plaintext)
+	serveKVHash(t, "MY_APP_CLIENT_SECRET", hash)
+
+	// The database holds only a reference: the credential itself never reached this deployment's DB.
+	ref, usable := credentialReference(StoredCredential{Value: "secret:MY_APP_CLIENT_SECRET"})
+	if !usable {
+		t.Fatal("a resolvable reference must be usable")
+	}
+	if ref.Hash != hash.Hash || ref.Parameters.Salt != hash.Parameters.Salt {
+		t.Fatalf("the reference should carry the provider's hash and parameters, got %+v", ref)
+	}
+	// The parameters come from wherever the credential was made, not from this server's configuration.
+	if ref.Parameters.Iterations != hash.Parameters.Iterations {
+		t.Fatalf("iterations should come from the provider, got %d", ref.Parameters.Iterations)
+	}
+}
+
+func TestCredentialReference_LeavesANativeCredentialAlone(t *testing.T) {
+	hash := hashOf(t, "created-here")
+
+	// A credential created on this deployment is stored normally and must keep working unchanged.
+	ref, usable := credentialReference(StoredCredential{
+		StorageAlgo:       hash.Algorithm,
+		Value:             hash.Hash,
+		StorageAlgoParams: hash.Parameters,
+	})
+	if !usable || ref.Hash != hash.Hash || ref.Algorithm != hash.Algorithm {
+		t.Fatalf("a stored credential should be used as it stands, got %+v usable=%v", ref, usable)
+	}
+}
+
+func TestCredentialReference_RejectsAnUnresolvableReference(t *testing.T) {
+	serveKVHash(t, "SOMETHING_ELSE", hashOf(t, "x"))
+
+	// An absent secret must reject rather than pass: treating it as a match would let any value in.
+	if _, usable := credentialReference(StoredCredential{Value: "secret:NOT_IN_THE_PROVIDER"}); usable {
+		t.Fatal("an unresolvable reference must not be usable")
+	}
+}
+
+func TestHashPlaintextCredentials_KeepsAReferenceAsItIs(t *testing.T) {
+	const plaintext = "the-client-secret"
+	hash := hashOf(t, plaintext)
+	serveKVHash(t, "MY_APP_CLIENT_SECRET", hash)
+
+	svc := &entityService{hashService: mustHashService(t)}
+	stored, err := svc.hashPlaintextCredentials(json.RawMessage(`{"clientSecret":"secret:MY_APP_CLIENT_SECRET"}`))
+	if err != nil {
+		t.Fatalf("hash credentials: %v", err)
+	}
+
+	var creds map[string][]StoredCredential
+	if err := json.Unmarshal(stored, &creds); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Hashing the reference text would store the hash of "secret:..." and reject every authentication.
+	if got := creds["clientSecret"][0].Value; got != "secret:MY_APP_CLIENT_SECRET" {
+		t.Fatalf("the reference should be stored verbatim, got %q", got)
+	}
+
+	// And the reference still resolves to the provider's hash, so the real secret verifies.
+	ref, usable := credentialReference(creds["clientSecret"][0])
+	if !usable {
+		t.Fatal("the stored reference must resolve")
+	}
+	ok, err := mustHashService(t).Verify([]byte(plaintext), ref)
+	if err != nil || !ok {
+		t.Fatalf("the promoted credential should verify, ok=%v err=%v", ok, err)
+	}
+}
+
+// mustHashService builds the hashing this server would be configured with.
+func mustHashService(t *testing.T) cryptolib.HashServiceInterface {
+	t.Helper()
+	svc, err := cryptolib.Initialize(cryptolib.HashConfig{
+		Algorithm: cryptolib.PBKDF2, SaltSize: 16, Iterations: 1000, KeySize: 32,
+	})
+	if err != nil {
+		t.Fatalf("hash service: %v", err)
+	}
+	return svc
+}

--- a/backend/internal/entity/service.go
+++ b/backend/internal/entity/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/thunder-id/thunderid/internal/ou"
 	"github.com/thunder-id/thunderid/internal/system/cryptolib"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/secretresolver"
 	sysutils "github.com/thunder-id/thunderid/internal/system/utils"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 )
@@ -560,14 +561,9 @@ func (s *entityService) verifyCredentials(credentials map[string]interface{},
 		credList := storedCreds[credType]
 		verified := false
 		for _, stored := range credList {
-			ref := cryptolib.Credential{
-				Algorithm: stored.StorageAlgo,
-				Hash:      stored.Value,
-				Parameters: cryptolib.CredParameters{
-					Salt:       stored.StorageAlgoParams.Salt,
-					Iterations: stored.StorageAlgoParams.Iterations,
-					KeySize:    stored.StorageAlgoParams.KeySize,
-				},
+			ref, usable := credentialReference(stored)
+			if !usable {
+				continue
 			}
 			ok, verifyErr := s.hashService.Verify([]byte(credValue), ref)
 			if verifyErr == nil && ok {
@@ -581,6 +577,42 @@ func (s *entityService) verifyCredentials(credentials map[string]interface{},
 	}
 
 	return nil
+}
+
+// credentialReference builds what a presented value is verified against.
+//
+// A promoted credential is stored as a reference, its hash living in the secret provider rather than
+// the database, so it is resolved here and verification is the same comparison either way.
+//
+// usable is false when a reference cannot be resolved, which must reject rather than pass.
+func credentialReference(stored StoredCredential) (cryptolib.Credential, bool) {
+	if secretresolver.IsReference(stored.Value) {
+		h, found, err := secretresolver.Default().ResolveHash(context.Background(), stored.Value)
+		if err != nil || !found {
+			return cryptolib.Credential{}, false
+		}
+		return cryptolib.Credential{
+			Algorithm: cryptolib.CredAlgorithm(h.Algorithm),
+			Hash:      h.Value,
+			Parameters: cryptolib.CredParameters{
+				Salt:        h.Salt,
+				Iterations:  h.Iterations,
+				KeySize:     h.KeySize,
+				Memory:      h.Memory,
+				Parallelism: h.Parallelism,
+			},
+		}, true
+	}
+
+	return cryptolib.Credential{
+		Algorithm: stored.StorageAlgo,
+		Hash:      stored.Value,
+		Parameters: cryptolib.CredParameters{
+			Salt:       stored.StorageAlgoParams.Salt,
+			Iterations: stored.StorageAlgoParams.Iterations,
+			KeySize:    stored.StorageAlgoParams.KeySize,
+		},
+	}, true
 }
 
 // UpdateCredentials updates schema-defined credentials (e.g., password) by hashing new
@@ -1089,6 +1121,14 @@ func (s *entityService) hashPlaintextCredentials(creds json.RawMessage) (json.Ra
 		case string:
 			// Plaintext string value — hash it.
 			if v == "" {
+				continue
+			}
+			// A reference is not a credential to hash: the hash it points at lives in this
+			// deployment's secret provider. Hashing it here would store the hash of the reference
+			// text and every authentication would fail, so it is kept as it is and resolved when a
+			// presented value is verified.
+			if secretresolver.IsReference(v) {
+				result[credType] = []StoredCredential{{Value: v}}
 				continue
 			}
 			credHash, err := s.hashService.Generate([]byte(v))

--- a/backend/internal/system/cmodels/property.go
+++ b/backend/internal/system/cmodels/property.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	kmprovider "github.com/thunder-id/thunderid/internal/system/kmprovider/common"
+	"github.com/thunder-id/thunderid/internal/system/secretresolver"
 )
 
 // configCryptoProvider is injected once during application startup via
@@ -67,9 +68,27 @@ func (p *Property) IsSecret() bool {
 	return p.isSecret
 }
 
-// GetValue returns the decrypted value if it's a secret, otherwise returns the plain value
+// GetValue returns the usable value of the property: decrypted if it is a secret, and resolved if it
+// holds a reference to a secret held elsewhere.
 func (p *Property) GetValue() (string, error) {
-	if !p.IsSecret() {
+	value, err := p.UnresolvedValue()
+	if err != nil {
+		return "", err
+	}
+	if secretresolver.IsReference(value) {
+		return p.resolveReference(value)
+	}
+	return value, nil
+}
+
+// UnresolvedValue returns the stored value, decrypted when it is a secret, but leaves a reference to
+// a secret held elsewhere as it is.
+//
+// It is for callers that do not need the credential itself, such as checking a property is set or
+// carrying it somewhere unchanged: resolving there would fail on a plane running no secret provider,
+// and put the credential where it does not belong on one that does.
+func (p *Property) UnresolvedValue() (string, error) {
+	if secretresolver.IsReference(p.value) || !p.IsSecret() {
 		return p.value, nil
 	}
 
@@ -80,8 +99,16 @@ func (p *Property) GetValue() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to decrypt secret property %s: %w", p.GetName(), err)
 	}
-
 	return string(decryptedBytes), nil
+}
+
+// resolveReference turns a secret reference into its value using the process-wide resolver.
+func (p *Property) resolveReference(reference string) (string, error) {
+	value, err := secretresolver.Default().Resolve(context.Background(), reference)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve secret property %s: %w", p.GetName(), err)
+	}
+	return value, nil
 }
 
 // Encrypt encrypts the value if it's a secret property
@@ -213,7 +240,10 @@ func (dto *PropertyDTO) ToProperty() (*Property, error) {
 
 // ToPropertyDTO converts Property to PropertyDTO.
 func (p *Property) ToPropertyDTO() (*PropertyDTO, error) {
-	value, err := p.GetValue()
+	// Deliberately unresolved: this DTO is a transport shape, and a caller that serializes it would
+	// otherwise put the credential itself in the payload. A runtime consumer that needs the value
+	// asks for it through GetValue.
+	value, err := p.UnresolvedValue()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get value for property %s: %w", p.GetName(), err)
 	}

--- a/backend/internal/system/deployment/deployment.go
+++ b/backend/internal/system/deployment/deployment.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package deployment carries the per-request deployment identifier used to scope persistence.
+//
+// The id partitions every stored resource by the DEPLOYMENT_ID column. It is put on the request
+// context at the edge, so a store reads it from one place rather than reaching for configuration.
+// This server holds one deployment, so that id is the configured identifier.
+package deployment
+
+import (
+	"context"
+	"strings"
+
+	"github.com/thunder-id/thunderid/internal/system/config"
+)
+
+// ctxKey is the private context key under which the per-request deployment id is stored.
+type ctxKey struct{}
+
+// WithID returns a context carrying the given deployment id. An empty id is ignored so callers can
+// pass an unconditionally-extracted claim without having to branch on its presence.
+func WithID(ctx context.Context, id string) context.Context {
+	if id == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxKey{}, id)
+}
+
+// fromContext returns the deployment id carried by the context, if any.
+func fromContext(ctx context.Context) (string, bool) {
+	id, ok := ctx.Value(ctxKey{}).(string)
+	return id, ok && id != ""
+}
+
+// Resolve returns the deployment id a store should scope by for this request.
+//
+// The id is put on the context at the edge, so a request always carries one and that is what a store
+// scopes by. The fallback covers the contexts that never passed through the edge: start-up tasks,
+// background jobs and command line tooling, which supply the store's own configured identifier.
+func Resolve(ctx context.Context, fallback string) string {
+	if id, ok := fromContext(ctx); ok {
+		return id
+	}
+	return fallback
+}
+
+// ResolveDefault returns the deployment id for the request using the server-configured identifier as
+// the fallback, the same value stores resolve to. It is for callers that scope by the deployment id
+// but have no configured value of their own, such as the cache layer. Where the id comes from a token
+// claim, a context carrying none returns an empty string, matching Resolve.
+func ResolveDefault(ctx context.Context) string {
+	if id, ok := fromContext(ctx); ok {
+		return id
+	}
+	if config.IsServerRuntimeInitialized() {
+		return config.GetServerRuntime().Config.Server.Identifier
+	}
+	return ""
+}
+
+// IDFromContext reports the deployment id the context carries, and whether it carries one at all.
+// It returns false for a context that never passed through the edge, such as a background job,
+// letting a caller that must fail closed tell "scoped" from "unscoped".
+func IDFromContext(ctx context.Context) (string, bool) {
+	return fromContext(ctx)
+}
+
+// OrganizationOf returns the organization a deployment id belongs to.
+//
+// An id names a gateway as "<org>:<gateway>", and what an organization owns across its gateways is
+// partitioned under the organization rather than any one of them. An id naming no organization is
+// its own, which is what a single-tenant deployment has.
+func OrganizationOf(id string) string {
+	org, _, found := strings.Cut(id, ":")
+	if !found || strings.TrimSpace(org) == "" {
+		return id
+	}
+	return org
+}

--- a/backend/internal/system/deployment/deployment_test.go
+++ b/backend/internal/system/deployment/deployment_test.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package deployment
+
+import (
+	"context"
+	"testing"
+)
+
+func TestResolve_FallsBackToConfiguredWhenNoClaim(t *testing.T) {
+	got := Resolve(context.Background(), "default-deployment")
+	if got != "default-deployment" {
+		t.Fatalf("expected fallback, got %q", got)
+	}
+}
+
+func TestResolve_UsesContextDeploymentIDWhenPresent(t *testing.T) {
+	ctx := WithID(context.Background(), "tenant-abc:dev")
+	if got := Resolve(ctx, "default-deployment"); got != "tenant-abc:dev" {
+		t.Fatalf("expected tenant id from context, got %q", got)
+	}
+}
+
+func TestWithID_EmptyIsIgnored(t *testing.T) {
+	ctx := WithID(context.Background(), "")
+	if _, ok := IDFromContext(ctx); ok {
+		t.Fatal("empty deployment id should not be stored")
+	}
+	if got := Resolve(ctx, "cfg"); got != "cfg" {
+		t.Fatalf("expected fallback for empty id, got %q", got)
+	}
+}
+
+func TestIDFromContext_ReportsPresence(t *testing.T) {
+	if _, ok := IDFromContext(context.Background()); ok {
+		t.Fatal("no id should be present on a bare context")
+	}
+	ctx := WithID(context.Background(), "t1")
+	if id, ok := IDFromContext(ctx); !ok || id != "t1" {
+		t.Fatalf("expected (t1,true), got (%q,%v)", id, ok)
+	}
+}
+
+// The edge puts the id on the context, so a request always carries one. The fallback is for the
+// contexts that never reach the edge: start-up tasks, background jobs and command line tooling.
+func TestResolve_PrefersTheContextOverTheFallback(t *testing.T) {
+	if got := Resolve(WithID(context.Background(), "acme"), "configured-id"); got != "acme" {
+		t.Fatalf("expected the id the request carries, got %q", got)
+	}
+	if got := Resolve(context.Background(), "configured-id"); got != "configured-id" {
+		t.Fatalf("expected the fallback for a context that carries no id, got %q", got)
+	}
+}

--- a/backend/internal/system/export/error_constants.go
+++ b/backend/internal/system/export/error_constants.go
@@ -36,4 +36,20 @@ var (
 			DefaultValue: "No valid resources found for the provided identifiers",
 		},
 	}
+
+	// ErrorDuplicateTemplateVariable is returned when two resources in one export claim the same
+	// template variable. The export is refused rather than returned, because a bundle where two
+	// resources share one variable imports both with the same value.
+	ErrorDuplicateTemplateVariable = tidcommon.ServiceError{
+		Type: tidcommon.ClientErrorType,
+		Code: "EXP-1003",
+		Error: tidcommon.I18nMessage{
+			Key:          "error.exportservice.duplicate_template_variable",
+			DefaultValue: "Duplicate template variable",
+		},
+		ErrorDescription: tidcommon.I18nMessage{
+			Key:          "error.exportservice.duplicate_template_variable_description",
+			DefaultValue: "Two resources derive the same template variable, so both would import one value",
+		},
+	}
 )

--- a/backend/internal/system/export/parameterizer.go
+++ b/backend/internal/system/export/parameterizer.go
@@ -15,6 +15,7 @@ import (
 
 	declarativeresource "github.com/thunder-id/thunderid/internal/system/declarative_resource"
 	"github.com/thunder-id/thunderid/internal/system/log"
+	"github.com/thunder-id/thunderid/internal/system/varname"
 )
 
 type templatingRules struct {
@@ -39,6 +40,10 @@ const (
 // Parameterizer handles the templating logic
 type parameterizer struct {
 	rules templatingRules
+	// resourceType qualifies the variable names emitted for the resource being parameterized. It is
+	// set per call on a copy rather than on the shared instance, so concurrent exports of different
+	// resource types cannot read each other's value.
+	resourceType string
 }
 
 // newParameterizer creates a new Parameterizer instance with the given templating rules
@@ -46,11 +51,22 @@ func newParameterizer(rules templatingRules) *parameterizer {
 	return &parameterizer{rules: rules}
 }
 
+// forResourceType returns a copy bound to the given resource type, leaving the shared instance
+// untouched.
+func (p *parameterizer) forResourceType(resourceType string) *parameterizer {
+	clone := *p
+	clone.resourceType = resourceType
+	return &clone
+}
+
 // ToParameterizedYAML converts an object directly to parameterized YAML.
 // It returns the template string and a map of variable names to their original values.
 func (p *parameterizer) ToParameterizedYAML(ctx context.Context, obj interface{},
 	resourceType string, resourceName string,
 	rules *declarativeresource.ResourceRules) (string, map[string]string, error) {
+	// Every variable name this call emits is qualified by the resource type.
+	p = p.forResourceType(resourceType)
+
 	// Convert imported type to local type for compatibility
 	var localRules *resourceRules
 	if rules != nil {
@@ -640,11 +656,7 @@ func (p *parameterizer) propertyToYAMLNode(propValue reflect.Value, resourceName
 // generatePropertyVarName generates a context-aware variable name for a property
 // e.g., "Export Test IDP" + "client_id" -> "EXPORT_TEST_IDP_CLIENT_ID"
 func (p *parameterizer) generatePropertyVarName(resourceName, propertyName string) string {
-	// Convert property name to snake_case
-	propName := p.toSnakeCase(propertyName)
-
-	// Combine them
-	return p.sanitizeVarName(p.VarPrefix(resourceName) + "_" + propName)
+	return varname.DeriveVariableName(p.resourceType, resourceName, propertyName)
 }
 
 // VarPrefix returns the variable name prefix derived from a resource name, e.g. "My App" ->
@@ -1147,12 +1159,7 @@ func (p *parameterizer) parameterizeNode(node *yaml.Node, rules *resourceRules, 
 func (p *parameterizer) pathToVariableName(appName, path string) string {
 	parts := strings.Split(path, ".")
 	lastPart := parts[len(parts)-1]
-
-	// Convert field name from camelCase/PascalCase to snake_case
-	fieldName := p.toSnakeCase(lastPart)
-
-	// Prepend app prefix to field name
-	return p.sanitizeVarName(p.VarPrefix(appName) + "_" + fieldName)
+	return varname.DeriveVariableName(p.resourceType, appName, lastPart)
 }
 
 // sanitizeVarName replaces characters that are not valid in a Go template field name (for

--- a/backend/internal/system/export/parameterizer_test.go
+++ b/backend/internal/system/export/parameterizer_test.go
@@ -79,20 +79,20 @@ func TestToParameterizedYAML_WithOmitemptyFields(t *testing.T) {
 
 	// Verify that omitempty fields are included and parameterized
 	assert.Contains(t, result, "clientId:", "ClientID field should be present even though it's empty")
-	assert.Contains(t, result, "{{.TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
 
 	assert.Contains(t, result, "redirectUri:", "RedirectURI field should be present even though it's empty")
-	assert.Contains(t, result, "{{.TEST_APP_REDIRECT_URI}}", "RedirectURI should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_REDIRECT_URI}}", "RedirectURI should be parameterized")
 
 	assert.Contains(t, result, "clientSecret:", "ClientSecret field should be present even though it's empty")
-	assert.Contains(t, result, "{{.TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
 
 	// Verify array parameterization
 	assert.Contains(t, result, "grantTypes:", "GrantTypes field should be present")
-	assert.Contains(t, result, "{{- range .TEST_APP_GRANT_TYPES}}", "GrantTypes should have range template")
+	assert.Contains(t, result, "{{- range .APPLICATION_TEST_APP_GRANT_TYPES}}", "GrantTypes should have range template")
 
 	assert.Contains(t, result, "scopes:", "Scopes field should be present")
-	assert.Contains(t, result, "{{- range .TEST_APP_SCOPES}}", "Scopes should have range template")
+	assert.Contains(t, result, "{{- range .APPLICATION_TEST_APP_SCOPES}}", "Scopes should have range template")
 }
 
 func TestToParameterizedYAML_WithPopulatedFields(t *testing.T) {
@@ -130,20 +130,20 @@ func TestToParameterizedYAML_WithPopulatedFields(t *testing.T) {
 	require.NotEmpty(t, result)
 
 	// Verify parameterization replaced actual values
-	assert.Contains(t, result, "{{.TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
 	assert.NotContains(t, result, "test-client-id", "Original ClientID value should be replaced")
 
-	assert.Contains(t, result, "{{.TEST_APP_REDIRECT_URI}}", "RedirectURI should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_REDIRECT_URI}}", "RedirectURI should be parameterized")
 	assert.NotContains(t, result, "https://example.com/callback", "Original RedirectURI should be replaced")
 
-	assert.Contains(t, result, "{{.TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
 	assert.NotContains(t, result, "secret123", "Original ClientSecret should be replaced")
 
 	// Verify array parameterization
-	assert.Contains(t, result, "{{- range .TEST_APP_GRANT_TYPES}}", "GrantTypes should have range template")
+	assert.Contains(t, result, "{{- range .APPLICATION_TEST_APP_GRANT_TYPES}}", "GrantTypes should have range template")
 	assert.NotContains(t, result, "authorization_code", "Original grant type should be replaced")
 
-	assert.Contains(t, result, "{{- range .TEST_APP_SCOPES}}", "Scopes should have range template")
+	assert.Contains(t, result, "{{- range .APPLICATION_TEST_APP_SCOPES}}", "Scopes should have range template")
 	assert.NotContains(t, result, "openid", "Original scope should be replaced")
 }
 
@@ -183,19 +183,19 @@ func TestToParameterizedYAML_MixedEmptyAndPopulated(t *testing.T) {
 
 	// All fields should be parameterized regardless of whether they were empty
 	assert.Contains(t, result, "clientId:", "ClientID field should be present")
-	assert.Contains(t, result, "{{.TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
 
 	assert.Contains(t, result, "redirectUri:", "RedirectURI field should be present even though empty")
-	assert.Contains(t, result, "{{.TEST_APP_REDIRECT_URI}}", "RedirectURI should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_REDIRECT_URI}}", "RedirectURI should be parameterized")
 
 	assert.Contains(t, result, "clientSecret:", "ClientSecret field should be present even though empty")
-	assert.Contains(t, result, "{{.TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
 
 	assert.Contains(t, result, "grantTypes:", "GrantTypes should be present")
-	assert.Contains(t, result, "{{- range .TEST_APP_GRANT_TYPES}}", "GrantTypes should have range template")
+	assert.Contains(t, result, "{{- range .APPLICATION_TEST_APP_GRANT_TYPES}}", "GrantTypes should have range template")
 
 	assert.Contains(t, result, "scopes:", "Scopes should be present even though nil")
-	assert.Contains(t, result, "{{- range .TEST_APP_SCOPES}}", "Scopes should have range template")
+	assert.Contains(t, result, "{{- range .APPLICATION_TEST_APP_SCOPES}}", "Scopes should have range template")
 }
 
 func TestStructToMapIgnoringOmitempty(t *testing.T) {
@@ -258,27 +258,22 @@ func TestConvertFieldToInterface_NestedStructs(t *testing.T) {
 }
 
 func TestPathToVariableName(t *testing.T) {
-	parameterizer := newParameterizer(templatingRules{})
+	parameterizer := newParameterizer(templatingRules{}).forResourceType("Application")
 
 	tests := []struct {
 		appName  string
 		path     string
 		expected string
 	}{
-		{"TestApp", "ClientID", "TEST_APP_CLIENT_ID"},
-		{"TestApp", "RedirectURI", "TEST_APP_REDIRECT_URI"},
-		{"TestApp", "OAuth.ClientSecret", "TEST_APP_CLIENT_SECRET"},
-		{"TestApp", "OAuth.GrantTypes", "TEST_APP_GRANT_TYPES"},
-		{"TestApp", "InboundAuthConfig.OAuth.ClientID", "TEST_APP_CLIENT_ID"},
-		{"TestApp", "simpleField", "TEST_APP_SIMPLE_FIELD"},
-		{"TestApp", "ALLCAPS", "TEST_APP_ALLCAPS"},
-		{"My App", "ClientID", "MY_APP_CLIENT_ID"},
-		{"My Test App", "RedirectURI", "MY_TEST_APP_REDIRECT_URI"},
-		{"Wayfinder-Concierge", "ClientID", "WAYFINDER_CONCIERGE_CLIENT_ID"},
-		{"My.App+1", "ClientID", "MY_APP_1_CLIENT_ID"},
-		{"2FA App", "ClientID", "_2FA_APP_CLIENT_ID"},
-		{"My App-", "ClientID", "MY_APP_CLIENT_ID"},
-		{"My App ", "ClientID", "MY_APP_CLIENT_ID"},
+		{"TestApp", "ClientID", "APPLICATION_TEST_APP_CLIENT_ID"},
+		{"TestApp", "RedirectURI", "APPLICATION_TEST_APP_REDIRECT_URI"},
+		{"TestApp", "OAuth.ClientSecret", "APPLICATION_TEST_APP_CLIENT_SECRET"},
+		{"TestApp", "OAuth.GrantTypes", "APPLICATION_TEST_APP_GRANT_TYPES"},
+		{"TestApp", "InboundAuthConfig.OAuth.ClientID", "APPLICATION_TEST_APP_CLIENT_ID"},
+		{"TestApp", "simpleField", "APPLICATION_TEST_APP_SIMPLE_FIELD"},
+		{"TestApp", "ALLCAPS", "APPLICATION_TEST_APP_ALLCAPS"},
+		{"My App", "ClientID", "APPLICATION_MY_APP_CLIENT_ID"},
+		{"My Test App", "RedirectURI", "APPLICATION_MY_TEST_APP_REDIRECT_URI"},
 	}
 
 	for _, tt := range tests {
@@ -449,10 +444,10 @@ func TestParameterization_OverridesOmitemptyForVariables(t *testing.T) {
 
 	// These fields should be present and parameterized despite being empty
 	assert.Contains(t, result, "clientId:", "ClientID should be present (in rules)")
-	assert.Contains(t, result, "{{.TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
 
 	assert.Contains(t, result, "redirectUri:", "RedirectURI should be present (in rules)")
-	assert.Contains(t, result, "{{.TEST_APP_REDIRECT_URI}}", "RedirectURI should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_REDIRECT_URI}}", "RedirectURI should be parameterized")
 }
 
 // TestParameterization_OverridesOmitemptyForArrays verifies that empty array
@@ -479,7 +474,7 @@ func TestParameterization_OverridesOmitemptyForArrays(t *testing.T) {
 
 	// Scopes should be present and parameterized despite being nil
 	assert.Contains(t, result, "scopes:", "Scopes should be present (in rules)")
-	assert.Contains(t, result, "{{- range .TEST_APP_SCOPES}}", "Scopes should be parameterized")
+	assert.Contains(t, result, "{{- range .APPLICATION_TEST_APP_SCOPES}}", "Scopes should be parameterized")
 }
 
 // TestParameterization_NestedFieldsWithOmitempty verifies nested empty fields
@@ -513,9 +508,9 @@ func TestParameterization_NestedFieldsWithOmitempty(t *testing.T) {
 	// Nested fields should be present and parameterized
 	assert.Contains(t, result, "oauth:", "OAuth should be present")
 	assert.Contains(t, result, "clientSecret:", "ClientSecret should be present (in rules)")
-	assert.Contains(t, result, "{{.TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
 	assert.Contains(t, result, "grantTypes:", "GrantTypes should be present (in rules)")
-	assert.Contains(t, result, "{{- range .TEST_APP_GRANT_TYPES}}", "GrantTypes should be parameterized")
+	assert.Contains(t, result, "{{- range .APPLICATION_TEST_APP_GRANT_TYPES}}", "GrantTypes should be parameterized")
 }
 
 // TestParameterization_MixedRulesAndOmitempty verifies correct behavior when
@@ -549,9 +544,9 @@ func TestParameterization_MixedRulesAndOmitempty(t *testing.T) {
 
 	// Fields in rules should be present
 	assert.Contains(t, result, "clientId:", "ClientID should be present (in rules)")
-	assert.Contains(t, result, "{{.TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_CLIENT_ID}}", "ClientID should be parameterized")
 	assert.Contains(t, result, "clientSecret:", "ClientSecret should be present (in rules)")
-	assert.Contains(t, result, "{{.TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_CLIENT_SECRET}}", "ClientSecret should be parameterized")
 
 	// Fields NOT in rules should be omitted
 	assert.NotContains(t, result, "redirectUri:", "RedirectURI should be omitted (not in rules)")
@@ -1070,9 +1065,9 @@ func TestRenderNode_ComplexTemplateStructures(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check template replacements
-	assert.Contains(t, result, "{{.TEST_APP_TEMPLATE_FIELD}}")
-	assert.Contains(t, result, "{{.TEST_APP_VALUE}}")
-	assert.Contains(t, result, "{{- range .TEST_APP_TEMPLATE_ARR}}")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_TEMPLATE_FIELD}}")
+	assert.Contains(t, result, "{{.APPLICATION_TEST_APP_VALUE}}")
+	assert.Contains(t, result, "{{- range .APPLICATION_TEST_APP_TEMPLATE_ARR}}")
 	assert.Contains(t, result, "{{- end}}")
 }
 
@@ -1870,7 +1865,7 @@ func TestRenderMappingValue_I18nRefsAreQuoted(t *testing.T) {
 	obj := &Resource{
 		Name:     "Test",
 		Message:  "{{ t(signup:forms.credentials.title) }}",
-		Callback: "{{.TEST_CALLBACK_URL}}",
+		Callback: "{{.APPLICATION_TEST_CALLBACK_URL}}",
 	}
 
 	p := newParameterizer(templatingRules{})
@@ -1882,7 +1877,7 @@ func TestRenderMappingValue_I18nRefsAreQuoted(t *testing.T) {
 	// i18n reference must be single-quoted.
 	assert.Contains(t, result, `message: '{{ t(signup:forms.credentials.title) }}'`)
 	// Real parameterization variable must remain unquoted (Go template syntax).
-	assert.Contains(t, result, `callbackUrl: {{.TEST_CALLBACK_URL}}`)
+	assert.Contains(t, result, `callbackUrl: {{.APPLICATION_TEST_CALLBACK_URL}}`)
 }
 
 func TestEntityTypeExportFormat(t *testing.T) {
@@ -1940,13 +1935,13 @@ func TestResourceServerExport_IdentifierAndOUIDNotParameterized(t *testing.T) {
 	// identifier must be the literal value, not a template variable
 	assert.Contains(t, result, "identifier: system",
 		"identifier should be emitted as a literal value")
-	assert.NotContains(t, result, "{{.SYSTEM_IDENTIFIER}}",
+	assert.NotContains(t, result, "{{.RESOURCE_SERVER_SYSTEM_IDENTIFIER}}",
 		"identifier must not be parameterized")
 
 	// ou_id must be the literal value, not a template variable
 	assert.Contains(t, result, "ouId: 019ddcf3-c5d8-7375-80e3-c5bf524257c8",
 		"ouId should be emitted as a literal value")
-	assert.NotContains(t, result, "{{.SYSTEM_OU_ID}}",
+	assert.NotContains(t, result, "{{.RESOURCE_SERVER_SYSTEM_OU_ID}}",
 		"ouId must not be parameterized")
 
 	// no variables should be extracted since rules are nil

--- a/backend/internal/system/export/service.go
+++ b/backend/internal/system/export/service.go
@@ -5,6 +5,7 @@ package export
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"sort"
 	"strconv"
@@ -165,6 +166,11 @@ func (es *exportService) ExportResources(
 	}
 	sort.Strings(resourceTypes)
 
+	// Which resource claimed each template variable, across the whole export. A name is claimed once:
+	// two resources sharing one would import with each other's value, and the later one would also
+	// overwrite the earlier value collected for the environment file.
+	variableOwners := make(map[string]string)
+
 	for _, resourceType := range resourceTypes {
 		resourceIDs := resourceMap[resourceType]
 		if len(resourceIDs) == 0 {
@@ -178,7 +184,16 @@ func (es *exportService) ExportResources(
 			continue
 		}
 
-		files, vars, errors := es.exportResourcesWithExporter(ctx, exporter, resourceIDs, options, varNames)
+		files, vars, errors, duplicate := es.exportResourcesWithExporter(ctx, exporter, resourceIDs, options,
+			varNames, variableOwners)
+		if duplicate != nil {
+			return nil, tidcommon.CustomServiceError(ErrorDuplicateTemplateVariable, tidcommon.I18nMessage{
+				Key: "error.exportservice.duplicate_template_variable_description",
+				DefaultValue: fmt.Sprintf(
+					"%s and %s derive the same template variable, so both would import the same value",
+					duplicate.previous, duplicate.owner),
+			})
+		}
 		exportFiles = append(exportFiles, files...)
 		for k, v := range vars {
 			allVariables[k] = v
@@ -274,7 +289,8 @@ func (es *exportService) exportResourcesWithExporter(
 	resourceIDs []string,
 	options *ExportOptions,
 	varNames *varNameAllocator,
-) ([]ExportFile, map[string]string, []declarativeresource.ExportError) {
+	variableOwners map[string]string,
+) ([]ExportFile, map[string]string, []declarativeresource.ExportError, *duplicateVariable) {
 	logger := log.GetLogger().With(log.String("component", "ExportService"))
 	resourceType := exporter.GetResourceType()
 	exportFiles := make([]ExportFile, 0, len(resourceIDs))
@@ -287,7 +303,7 @@ func (es *exportService) exportResourcesWithExporter(
 		if err != nil {
 			logger.Warn(ctx, "Failed to get all resources",
 				log.String("resourceType", resourceType), log.Any("error", err))
-			return []ExportFile{}, variableValues, []declarativeresource.ExportError{}
+			return []ExportFile{}, variableValues, []declarativeresource.ExportError{}, nil
 		}
 		resourceIDList = ids
 	} else {
@@ -343,6 +359,13 @@ func (es *exportService) exportResourcesWithExporter(
 			})
 			continue
 		}
+		owner := resourceType + "/" + resourceID
+		if clash, previous := claimedElsewhere(templateContent, variableOwners, owner); clash != "" {
+			return exportFiles, variableValues, exportErrors,
+				&duplicateVariable{owner: owner, previous: previous, name: clash}
+		}
+		claimVariables(templateContent, variableOwners, owner)
+
 		for k, v := range vars {
 			variableValues[k] = v
 		}
@@ -363,7 +386,7 @@ func (es *exportService) exportResourcesWithExporter(
 		exportFiles = append(exportFiles, exportFile)
 	}
 
-	return exportFiles, variableValues, exportErrors
+	return exportFiles, variableValues, exportErrors, nil
 }
 
 func (es *exportService) generateTemplateFromStruct(ctx context.Context, data interface{},
@@ -453,4 +476,52 @@ func (es *exportService) generateFolderPath(resourceType string, options *Export
 	}
 
 	return ""
+}
+
+// claimedElsewhere reports the first template variable in content that another resource already
+// claimed, along with that resource. It returns empty strings when nothing is claimed twice.
+func claimedElsewhere(content string, owners map[string]string, resourceID string) (string, string) {
+	for _, name := range templateVariableNames(content) {
+		if previous, taken := owners[name]; taken && previous != resourceID {
+			return name, previous
+		}
+	}
+	return "", ""
+}
+
+// claimVariables records this resource as the owner of every variable its template names.
+func claimVariables(content string, owners map[string]string, resourceID string) {
+	for _, name := range templateVariableNames(content) {
+		owners[name] = resourceID
+	}
+}
+
+// claimedVariablePattern matches the template actions an exporter may write into a resource.
+//
+// It is deliberately broader than templateVariablePattern, whose matching the environment file
+// depends on: a spaced or trimmed action still claims its name here rather than slipping past.
+var claimedVariablePattern = regexp.MustCompile(`\{\{-?\s*(?:range\s+)?\.([A-Za-z_][A-Za-z0-9_]*)\s*-?\}\}`)
+
+// templateVariableNames returns the distinct variables a template names, in the order they appear.
+func templateVariableNames(content string) []string {
+	seen := make(map[string]bool)
+	var names []string
+	for _, match := range claimedVariablePattern.FindAllStringSubmatch(content, -1) {
+		for _, name := range match[1:] {
+			if name != "" && !seen[name] {
+				seen[name] = true
+				names = append(names, name)
+			}
+		}
+	}
+	return names
+}
+
+// duplicateVariable names two resources that derive one template variable, and the variable itself.
+// The name is carried for the log and deliberately not returned to the caller, because it is derived
+// from the resource name, which for a user is their username.
+type duplicateVariable struct {
+	owner    string
+	previous string
+	name     string
 }

--- a/backend/internal/system/export/service_test.go
+++ b/backend/internal/system/export/service_test.go
@@ -267,15 +267,15 @@ func (suite *ExportServiceTestSuite) TestExportResources_CompleteOAuthApplicatio
 	assert.Equal(suite.T(), "OAuth_Test_App_oauth-app-id.yaml", file.FileName)
 	assert.Equal(suite.T(), "applications", file.FolderPath)
 	assert.Contains(suite.T(), file.Content, "name: OAuth Test App")
-	assert.Contains(suite.T(), file.Content, "clientId: {{.O_AUTH_TEST_APP_CLIENT_ID}}")
-	assert.Contains(suite.T(), file.Content, "clientSecret: {{.O_AUTH_TEST_APP_CLIENT_SECRET}}")
+	assert.Contains(suite.T(), file.Content, "clientId: {{.APPLICATION_O_AUTH_TEST_APP_CLIENT_ID}}")
+	assert.Contains(suite.T(), file.Content, "clientSecret: {{.APPLICATION_O_AUTH_TEST_APP_CLIENT_SECRET}}")
 	assert.Contains(suite.T(), file.Content, "redirectUris:")
-	assert.Contains(suite.T(), file.Content, "{{- range .O_AUTH_TEST_APP_REDIRECT_URIS}}")
+	assert.Contains(suite.T(), file.Content, "{{- range .APPLICATION_O_AUTH_TEST_APP_REDIRECT_URIS}}")
 	assert.NotNil(suite.T(), result.EnvFile)
 	assert.Equal(suite.T(), ".env", result.EnvFile.FileName)
-	assert.Contains(suite.T(), result.EnvFile.Content, "O_AUTH_TEST_APP_CLIENT_ID=client123\n")
-	assert.Contains(suite.T(), result.EnvFile.Content, "O_AUTH_TEST_APP_CLIENT_SECRET=\n")
-	expectedRedirectURIs := "O_AUTH_TEST_APP_REDIRECT_URIS=[\"http://localhost:3000/callback\"]\n"
+	assert.Contains(suite.T(), result.EnvFile.Content, "APPLICATION_O_AUTH_TEST_APP_CLIENT_ID=client123\n")
+	assert.Contains(suite.T(), result.EnvFile.Content, "APPLICATION_O_AUTH_TEST_APP_CLIENT_SECRET=\n")
+	expectedRedirectURIs := "APPLICATION_O_AUTH_TEST_APP_REDIRECT_URIS=[\"http://localhost:3000/callback\"]\n"
 	assert.Contains(suite.T(), result.EnvFile.Content, expectedRedirectURIs)
 
 	assert.Equal(suite.T(), 1, result.Summary.ResourceTypes["application"])
@@ -317,10 +317,10 @@ func (suite *ExportServiceTestSuite) TestExportResources_HyphenatedApplicationNa
 	assert.Len(suite.T(), result.Files, 1)
 
 	file := result.Files[0]
-	assert.Contains(suite.T(), file.Content, "clientId: {{.WAYFINDER_CONCIERGE_CLIENT_ID}}")
+	assert.Contains(suite.T(), file.Content, "clientId: {{.APPLICATION_WAYFINDER_CONCIERGE_CLIENT_ID}}")
 	assert.NotContains(suite.T(), file.Content, "WAYFINDER-CONCIERGE")
 	assert.NotNil(suite.T(), result.EnvFile)
-	assert.Contains(suite.T(), result.EnvFile.Content, "WAYFINDER_CONCIERGE_CLIENT_ID=client123\n")
+	assert.Contains(suite.T(), result.EnvFile.Content, "APPLICATION_WAYFINDER_CONCIERGE_CLIENT_ID=client123\n")
 
 	_, parseErr := template.New("export").Parse(file.Content)
 	assert.NoError(suite.T(), parseErr)
@@ -365,13 +365,13 @@ func (suite *ExportServiceTestSuite) TestExportResources_CollidingNormalizedName
 	require.NotNil(suite.T(), result)
 	assert.Len(suite.T(), result.Files, 3)
 
-	assert.Contains(suite.T(), result.Files[0].Content, "clientId: {{.WAYFINDER_CONCIERGE_CLIENT_ID}}")
-	assert.Contains(suite.T(), result.Files[1].Content, "clientId: {{.WAYFINDER_CONCIERGE_2_CLIENT_ID}}")
-	assert.Contains(suite.T(), result.Files[2].Content, "clientId: {{.WAYFINDER_CONCIERGE_3_CLIENT_ID}}")
+	assert.Contains(suite.T(), result.Files[0].Content, "clientId: {{.APPLICATION_WAYFINDER_CONCIERGE_CLIENT_ID}}")
+	assert.Contains(suite.T(), result.Files[1].Content, "clientId: {{.APPLICATION_WAYFINDER_CONCIERGE_2_CLIENT_ID}}")
+	assert.Contains(suite.T(), result.Files[2].Content, "clientId: {{.APPLICATION_WAYFINDER_CONCIERGE_3_CLIENT_ID}}")
 	require.NotNil(suite.T(), result.EnvFile)
-	assert.Contains(suite.T(), result.EnvFile.Content, "WAYFINDER_CONCIERGE_CLIENT_ID=client-one\n")
-	assert.Contains(suite.T(), result.EnvFile.Content, "WAYFINDER_CONCIERGE_2_CLIENT_ID=client-two\n")
-	assert.Contains(suite.T(), result.EnvFile.Content, "WAYFINDER_CONCIERGE_3_CLIENT_ID=client-three\n")
+	assert.Contains(suite.T(), result.EnvFile.Content, "APPLICATION_WAYFINDER_CONCIERGE_CLIENT_ID=client-one\n")
+	assert.Contains(suite.T(), result.EnvFile.Content, "APPLICATION_WAYFINDER_CONCIERGE_2_CLIENT_ID=client-two\n")
+	assert.Contains(suite.T(), result.EnvFile.Content, "APPLICATION_WAYFINDER_CONCIERGE_3_CLIENT_ID=client-three\n")
 }
 
 // TestExportResources_MultipleApplications tests exporting multiple applications.
@@ -931,7 +931,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_IdentityProvider_Proper
 
 	// Only the secret field is parameterized, with a context-aware variable name:
 	// IDP_NAME + FIELD_NAME in UPPER_SNAKE_CASE.
-	assert.Contains(suite.T(), yamlContent, "clientSecret: {{.EXPORT_TEST_IDP_CLIENT_SECRET}}")
+	assert.Contains(suite.T(), yamlContent, "clientSecret: {{.CONNECTION_EXPORT_TEST_IDP_CLIENT_SECRET}}")
 
 	// Non-secret typed fields are exported as plain values under their camelCase keys.
 	assert.Contains(suite.T(), yamlContent, "clientId: test-client-123")
@@ -942,7 +942,7 @@ func (suite *ExportServiceTestSuite) TestExportResources_IdentityProvider_Proper
 	assert.Contains(suite.T(), yamlContent, "type: google")
 
 	assert.NotNil(suite.T(), result.EnvFile)
-	assert.Contains(suite.T(), result.EnvFile.Content, "EXPORT_TEST_IDP_CLIENT_SECRET=super-secret")
+	assert.Contains(suite.T(), result.EnvFile.Content, "CONNECTION_EXPORT_TEST_IDP_CLIENT_SECRET=super-secret")
 }
 
 // TestExportResources_IdentityProvider_PropertyStructure verifies that a connection with
@@ -1953,8 +1953,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_Success() {
 		Format: formatYAML,
 	}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{appID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{appID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -1996,8 +1997,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_MultipleRes
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{app1ID, app2ID, app3ID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{app1ID, app2ID, app3ID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 3)
 	assert.Len(suite.T(), errors, 0)
@@ -2020,8 +2022,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_ResourceNot
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{appID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{appID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 0)
 	assert.Len(suite.T(), errors, 1)
@@ -2054,8 +2057,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_PartialSucc
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{validAppID, invalidAppID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{validAppID, invalidAppID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 1)
@@ -2095,8 +2099,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardSuc
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{"*"}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{"*"}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 2)
 	assert.Len(suite.T(), errors, 0)
@@ -2117,8 +2122,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardFai
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{"*"}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{"*"}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 0)
 	assert.Len(suite.T(), errors, 0) // Returns empty slices on wildcard failure
@@ -2138,8 +2144,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardEmp
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{"*"}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{"*"}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 0)
 	assert.Len(suite.T(), errors, 0)
@@ -2165,8 +2172,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WithGroupBy
 		},
 	}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{appID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{appID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2193,8 +2201,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WithCustomF
 		},
 	}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{appID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{appID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2219,8 +2228,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_IdentityPro
 
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{idpID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{idpID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2249,8 +2259,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_Notificatio
 
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{senderID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{senderID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2258,7 +2269,7 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_Notificatio
 	assert.Equal(suite.T(), resourceTypeConnection, files[0].ResourceType)
 	assert.Equal(suite.T(), senderID, files[0].ResourceID)
 	assert.NotEmpty(suite.T(), variables)
-	assert.Equal(suite.T(), "key1", variables["TEST_SENDER_AUTH_TOKEN"])
+	assert.Equal(suite.T(), "key1", variables["CONNECTION_TEST_SENDER_AUTH_TOKEN"])
 }
 
 // TestExportResourcesWithExporter_EntityType tests export with entity type exporter.
@@ -2281,8 +2292,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_EntityType(
 
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{schemaID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{schemaID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2297,8 +2309,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_EmptyResour
 	exporter, _ := suite.exportService.(*exportService).registry.Get(resourceTypeApplication)
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 0)
 	assert.Len(suite.T(), errors, 0)
@@ -2321,8 +2334,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_JSONFormatF
 		Format: formatJSON, // JSON not yet implemented
 	}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{appID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{appID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2367,8 +2381,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_Flow() {
 
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{flowID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{flowID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2462,8 +2477,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_FlowWithCom
 
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{flowID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{flowID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 1)
 	assert.Len(suite.T(), errors, 0)
@@ -2508,8 +2524,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_MultipleFlo
 	exporter, _ := suite.exportService.(*exportService).registry.Get("flow")
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{testFlow1ID, testFlow2ID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{testFlow1ID, testFlow2ID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 2)
 	assert.Len(suite.T(), errors, 0)
@@ -2530,8 +2547,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_FlowNotFoun
 	exporter, _ := suite.exportService.(*exportService).registry.Get("flow")
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{flowID}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{flowID}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 0)
 	assert.Len(suite.T(), errors, 1)
@@ -2596,8 +2614,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardFlo
 	exporter, _ := suite.exportService.(*exportService).registry.Get("flow")
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{"*"}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{"*"}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 2)
 	assert.Len(suite.T(), errors, 0)
@@ -2615,8 +2634,9 @@ func (suite *ExportServiceTestSuite) TestExportResourcesWithExporter_WildcardFlo
 	exporter, _ := suite.exportService.(*exportService).registry.Get("flow")
 	options := &ExportOptions{Format: formatYAML}
 
-	files, variables, errors := suite.exportService.(*exportService).exportResourcesWithExporter(context.Background(),
-		exporter, []string{"*"}, options, suite.varNames())
+	files, variables, errors, _ := suite.exportService.(*exportService).exportResourcesWithExporter(
+		context.Background(),
+		exporter, []string{"*"}, options, suite.varNames(), map[string]string{})
 
 	assert.Len(suite.T(), files, 0)
 	assert.Len(suite.T(), errors, 0) // Empty list on error
@@ -2714,4 +2734,91 @@ func (suite *ExportServiceTestSuite) TestExportResources_MixedWithFlows() {
 	}
 	assert.True(suite.T(), hasApp, "Should have application export")
 	assert.True(suite.T(), hasFlow, "Should have flow export")
+}
+
+// firstUser and secondUser are the owner identities the variable-ownership tests claim names under.
+const (
+	firstUser  = "user/user-1"
+	secondUser = "user/user-2"
+)
+
+// A resource that writes a placeholder into itself bypasses the variable allocator, so two resources
+// can end up naming the same variable. Importing then gives both of them one value, which for a
+// credential means two accounts sharing a password. The export is refused instead.
+func TestExport_RefusesTwoResourcesClaimingOneVariable(t *testing.T) {
+	owners := map[string]string{}
+	first := `password: "{{.USER_ALICE_EXAMPLE_COM_PASSWORD}}"`
+	second := `password: "{{.USER_ALICE_EXAMPLE_COM_PASSWORD}}"`
+
+	if clash, _ := claimedElsewhere(first, owners, firstUser); clash != "" {
+		t.Fatalf("the first resource must be free to claim its variable, got a clash on %q", clash)
+	}
+	claimVariables(first, owners, firstUser)
+
+	clash, previous := claimedElsewhere(second, owners, secondUser)
+	if clash != "USER_ALICE_EXAMPLE_COM_PASSWORD" {
+		t.Fatalf("expected the duplicate variable to be reported, got %q", clash)
+	}
+	if previous != firstUser {
+		t.Fatalf("expected the report to name the resource that claimed it, got %q", previous)
+	}
+}
+
+// Re-exporting the same resource is not a clash with itself, which matters because a resource names
+// its own variables more than once.
+func TestExport_AResourceMayReclaimItsOwnVariables(t *testing.T) {
+	owners := map[string]string{}
+	content := `clientId: "{{.APPLICATION_APP_CLIENT_ID}}"`
+	claimVariables(content, owners, "application/app-1")
+
+	if clash, _ := claimedElsewhere(content, owners, "application/app-1"); clash != "" {
+		t.Fatalf("a resource must not clash with itself, got %q", clash)
+	}
+}
+
+// A template action is valid with surrounding spaces or a trimming marker, so a placeholder spelled
+// that way must still claim its name rather than slipping past the check.
+func TestExport_ClaimsVariablesWrittenWithSpacing(t *testing.T) {
+	for _, spelling := range []string{
+		`password: "{{.USER_ALICE_PASSWORD}}"`,
+		`password: "{{ .USER_ALICE_PASSWORD }}"`,
+		`password: "{{- .USER_ALICE_PASSWORD }}"`,
+		`password: "{{ .USER_ALICE_PASSWORD -}}"`,
+	} {
+		owners := map[string]string{}
+		claimVariables(`password: "{{.USER_ALICE_PASSWORD}}"`, owners, firstUser)
+
+		clash, previous := claimedElsewhere(spelling, owners, secondUser)
+		if clash != "USER_ALICE_PASSWORD" {
+			t.Errorf("%s: expected the duplicate to be reported, got %q", spelling, clash)
+		}
+		if previous != firstUser {
+			t.Errorf("%s: expected the first claimant to be named, got %q", spelling, previous)
+		}
+	}
+}
+
+// Ownership spans the whole export, so two resources of different types cannot claim one name either.
+func TestExport_OwnershipSpansResourceTypes(t *testing.T) {
+	owners := map[string]string{}
+	claimVariables(`value: "{{.SHARED_NAME}}"`, owners, firstUser)
+
+	clash, previous := claimedElsewhere(`value: "{{.SHARED_NAME}}"`, owners, "application/app-1")
+	if clash != "SHARED_NAME" {
+		t.Fatalf("expected a cross-type duplicate to be reported, got %q", clash)
+	}
+	if previous != firstUser {
+		t.Fatalf("expected the owner to carry its resource type, got %q", previous)
+	}
+}
+
+// Distinct variables are not reported, so an ordinary export is unaffected.
+func TestExport_DistinctVariablesDoNotClash(t *testing.T) {
+	owners := map[string]string{}
+	claimVariables(`clientId: "{{.APPLICATION_A_CLIENT_ID}}"`, owners, "application/app-a")
+
+	clash, _ := claimedElsewhere(`clientId: "{{.APPLICATION_B_CLIENT_ID}}"`, owners, "application/app-b")
+	if clash != "" {
+		t.Fatalf("expected no clash between distinct variables, got %q", clash)
+	}
 }

--- a/backend/internal/system/i18n/core/defaults.go
+++ b/backend/internal/system/i18n/core/defaults.go
@@ -511,6 +511,8 @@ var defaultMessages = map[string]string{
 	"error.eudi.unknown_state_description": "No active request was found for the supplied state value",
 	"error.eudi.verification_failed": "Presentation verification failed",
 	"error.eudi.verification_failed_description": "The presented credential could not be verified",
+	"error.exportservice.duplicate_template_variable": "Duplicate template variable",
+	"error.exportservice.duplicate_template_variable_description": "Two resources derive the same template variable, so both would import one value",
 	"error.exportservice.invalid_request": "Invalid export request",
 	"error.exportservice.invalid_request_description": "The provided export request is invalid or malformed",
 	"error.exportservice.nil_request_description": "Export request cannot be nil",

--- a/backend/internal/system/middleware/deploymentid.go
+++ b/backend/internal/system/middleware/deploymentid.go
@@ -1,0 +1,38 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/thunder-id/thunderid/internal/system/config"
+	"github.com/thunder-id/thunderid/internal/system/deployment"
+)
+
+// DeploymentIDMiddleware puts the deployment id this request acts for on its context, so that the
+// stores below read it from one place instead of each reaching for the configuration themselves.
+//
+// It runs for every request, so a store can rely on the context carrying an id and treat a context
+// without one as what it is: a background operation rather than a request.
+func DeploymentIDMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if id := deploymentIDForRequest(r); id != "" {
+			r = r.WithContext(deployment.WithID(r.Context(), id))
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// deploymentIDForRequest returns the deployment id a request acts for.
+//
+// This server holds one deployment, so every request acts for the configured identifier. It is a
+// function of the request rather than a constant because that is the single point a build serving
+// more than one deployment changes: it derives the id per request instead, and everything
+// downstream is unaffected, because everything downstream already reads the id from the context.
+var deploymentIDForRequest = func(_ *http.Request) string {
+	if !config.IsServerRuntimeInitialized() {
+		return ""
+	}
+	return config.GetServerRuntime().Config.Server.Identifier
+}

--- a/backend/internal/system/middleware/deploymentid_test.go
+++ b/backend/internal/system/middleware/deploymentid_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 The ThunderID Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/thunder-id/thunderid/internal/system/deployment"
+)
+
+// The point of the middleware is that a handler, and every store below it, can read the id from the
+// context instead of reaching for the configuration.
+func TestDeploymentIDMiddlewarePutsTheIDOnTheContext(t *testing.T) {
+	original := deploymentIDForRequest
+	deploymentIDForRequest = func(*http.Request) string { return "acme" }
+	t.Cleanup(func() { deploymentIDForRequest = original })
+
+	var seen string
+	var carried bool
+	handler := DeploymentIDMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen, carried = deployment.IDFromContext(r.Context())
+	}))
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/anything", nil))
+
+	if !carried || seen != "acme" {
+		t.Fatalf("expected the request to carry acme, got (%q, %v)", seen, carried)
+	}
+}
+
+// With no identifier configured, the context is left alone rather than carrying an empty id, so a
+// store falls back to its own configured value exactly as it did before.
+func TestDeploymentIDMiddlewareLeavesTheContextAloneWithoutAnIdentifier(t *testing.T) {
+	original := deploymentIDForRequest
+	deploymentIDForRequest = func(*http.Request) string { return "" }
+	t.Cleanup(func() { deploymentIDForRequest = original })
+
+	var carried bool
+	handler := DeploymentIDMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		_, carried = deployment.IDFromContext(r.Context())
+	}))
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/anything", nil))
+
+	if carried {
+		t.Fatal("expected no deployment id on the context when none is configured")
+	}
+}

--- a/backend/internal/system/secretresolver/global.go
+++ b/backend/internal/system/secretresolver/global.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package secretresolver
+
+import "sync"
+
+// The resolver is reached as a process-global because the value that needs resolving is read deep
+// inside configuration accessors that take no dependencies, the same reason the configuration crypto
+// service is a singleton. Set it once during startup, before any request is served.
+var (
+	defaultMu       sync.RWMutex
+	defaultResolver *Resolver
+)
+
+// SetDefault installs the process-wide resolver.
+func SetDefault(r *Resolver) {
+	defaultMu.Lock()
+	defaultResolver = r
+	defaultMu.Unlock()
+}
+
+// Default returns the process-wide resolver. It is never nil: when none is installed the returned
+// resolver is disabled, so a deployment without a secret provider behaves exactly as before.
+func Default() *Resolver {
+	defaultMu.RLock()
+	r := defaultResolver
+	defaultMu.RUnlock()
+	if r == nil {
+		return New(Config{})
+	}
+	return r
+}

--- a/backend/internal/system/secretresolver/resolver.go
+++ b/backend/internal/system/secretresolver/resolver.go
@@ -1,0 +1,502 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package secretresolver turns a reference such as "secret:MY_APP_CLIENT_SECRET" into its value, so
+// that promoted configuration can carry the reference and leave the secret behind.
+//
+// A store in this process is read per reference. A provider reached over HTTP is cached, loaded at
+// startup and refreshed for one name on a miss, because every miss there costs an outbound call.
+package secretresolver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Prefix marks a configuration value as a reference to a secret rather than the secret itself.
+const Prefix = "secret:"
+
+// minRefreshInterval throttles single-name refreshes, so a reference that the provider does not hold
+// cannot turn every request that reads it into an outbound call.
+const minRefreshInterval = 30 * time.Second
+
+// ErrNotConfigured is returned when a reference is met but no secret provider is configured.
+var ErrNotConfigured = errors.New("a secret reference was found but no secret provider is configured")
+
+// ErrSecretNotFound is returned when the provider does not hold the referenced secret.
+var ErrSecretNotFound = errors.New("the referenced secret is not available from the secret provider")
+
+// IsReference reports whether a stored configuration value is a secret reference.
+func IsReference(value string) bool {
+	return strings.HasPrefix(value, Prefix)
+}
+
+// ReferenceName returns the secret name a reference points at.
+func ReferenceName(value string) string {
+	return strings.TrimPrefix(value, Prefix)
+}
+
+// Config describes the secret provider to resolve against.
+type Config struct {
+	// BaseURL is the provider's base URL. Empty disables resolution.
+	BaseURL string
+	Token   string
+	Timeout time.Duration
+	// Local reads one secret from a store held in this process, and is used in place of BaseURL when
+	// set: reading its own store over HTTP would mean this server authenticating to itself.
+	//
+	// It is consulted per resolution rather than cached, because the store it reads is already a
+	// cache; a second copy would keep rejecting a credential until this process restarted.
+	Local func(ctx context.Context, name string) (LocalSecret, bool, error)
+}
+
+// LocalSecret is one secret as a store in this process holds it.
+type LocalSecret struct {
+	Kind        string
+	Value       string
+	Algorithm   string
+	Salt        string
+	Iterations  int
+	KeySize     int
+	Memory      int
+	Parallelism int
+}
+
+// providerSecret converts a locally held secret into the shape resolution works in.
+func (l LocalSecret) providerSecret(name string) providerSecret {
+	p := providerSecret{Name: name, Kind: l.Kind, Value: l.Value, Algorithm: l.Algorithm}
+	p.Parameters.Salt = l.Salt
+	p.Parameters.Iterations = l.Iterations
+	p.Parameters.KeySize = l.KeySize
+	p.Parameters.Memory = l.Memory
+	p.Parameters.Parallelism = l.Parallelism
+	return p
+}
+
+// Resolver resolves secret references against a secret provider, caching what it loads.
+type Resolver struct {
+	cfg  Config
+	http *http.Client
+
+	mu      sync.RWMutex
+	secrets map[string]string
+	// hashes holds the structured form of every hash backed secret, for verifying a presented
+	// credential against it.
+	hashes map[string]Hash
+	// lastMiss records when a name was last fetched and not found, to throttle repeat lookups.
+	lastMiss map[string]time.Time
+}
+
+// New builds a Resolver. It performs no I/O: call LoadAll to populate the cache.
+func New(cfg Config) *Resolver {
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	return &Resolver{
+		cfg:      cfg,
+		http:     &http.Client{Timeout: timeout, CheckRedirect: refuseInsecureRedirect},
+		secrets:  map[string]string{},
+		hashes:   map[string]Hash{},
+		lastMiss: map[string]time.Time{},
+	}
+}
+
+// Enabled reports whether a secret provider is configured.
+func (r *Resolver) Enabled() bool {
+	if r == nil {
+		return false
+	}
+	return r.cfg.Local != nil || strings.TrimSpace(r.cfg.BaseURL) != ""
+}
+
+// providerSecret is one entry as the secret provider serves it.
+//
+// A secret is held either as a hash, for a credential that is only ever verified, or as a readable
+// value, for one that has to be replayed to a third party. Both arrive here; Resolve turns each into the
+// form the configuration expects.
+type providerSecret struct {
+	Name       string `json:"name"`
+	Kind       string `json:"kind"`
+	Value      string `json:"value"`
+	Algorithm  string `json:"algorithm,omitempty"`
+	Parameters struct {
+		Salt        string `json:"salt,omitempty"`
+		Iterations  int    `json:"iterations,omitempty"`
+		KeySize     int    `json:"keySize,omitempty"`
+		Memory      int    `json:"memory,omitempty"`
+		Parallelism int    `json:"parallelism,omitempty"`
+	} `json:"parameters,omitempty"`
+}
+
+// kindHash marks a secret held as a one-way hash.
+const kindHash = "hash"
+
+// storedCredential mirrors the shape a declarative credential takes, so a hash can be handed to the
+// importer unchanged and end up stored exactly as one written through the API.
+type storedCredential struct {
+	StorageType       string `json:"storageType"`
+	StorageAlgo       string `json:"storageAlgo"`
+	StorageAlgoParams struct {
+		Salt        string `json:"salt,omitempty"`
+		Iterations  int    `json:"iterations,omitempty"`
+		KeySize     int    `json:"keySize,omitempty"`
+		Memory      int    `json:"memory,omitempty"`
+		Parallelism int    `json:"parallelism,omitempty"`
+	} `json:"storageAlgoParams"`
+	Value string `json:"value"`
+}
+
+// substitution returns the text that replaces a placeholder for this secret.
+//
+// A readable value is substituted as itself. A hash cannot be: the configuration expects a credential,
+// and the original is unrecoverable. It is therefore rendered as the declarative credential form, a JSON
+// array. YAML is a superset of JSON, so that text parses as a list of credential objects and the
+// importer stores the hash as it stands rather than hashing it a second time.
+func (p *providerSecret) substitution() (string, error) {
+	if p.Kind != kindHash {
+		return p.Value, nil
+	}
+
+	cred := storedCredential{StorageType: kindHash, StorageAlgo: p.Algorithm, Value: p.Value}
+	cred.StorageAlgoParams.Salt = p.Parameters.Salt
+	cred.StorageAlgoParams.Iterations = p.Parameters.Iterations
+	cred.StorageAlgoParams.KeySize = p.Parameters.KeySize
+	cred.StorageAlgoParams.Memory = p.Parameters.Memory
+	cred.StorageAlgoParams.Parallelism = p.Parameters.Parallelism
+
+	encoded, err := json.Marshal([]storedCredential{cred})
+	if err != nil {
+		return "", fmt.Errorf("failed to encode the credential for %s: %w", p.Name, err)
+	}
+	return string(encoded), nil
+}
+
+// hash returns the structured hash of a hash backed secret.
+func (p *providerSecret) hash() (Hash, bool) {
+	if p.Kind != kindHash {
+		return Hash{}, false
+	}
+	return Hash{
+		Algorithm:   p.Algorithm,
+		Value:       p.Value,
+		Salt:        p.Parameters.Salt,
+		Iterations:  p.Parameters.Iterations,
+		KeySize:     p.Parameters.KeySize,
+		Memory:      p.Parameters.Memory,
+		Parallelism: p.Parameters.Parallelism,
+	}, true
+}
+
+// LoadAll replaces the cache with every secret the provider holds. It is called at startup so that
+// resolving a reference during a request needs no outbound call.
+func (r *Resolver) LoadAll(ctx context.Context) error {
+	if !r.Enabled() {
+		return nil
+	}
+
+	// A local store is read per name, not preloaded: it is already in memory, and holding a second
+	// copy here is what would let a regenerated credential go stale.
+	if r.cfg.Local != nil {
+		return nil
+	}
+
+	var body struct {
+		Secrets map[string]providerSecret `json:"secrets"`
+	}
+	if err := r.get(ctx, "/secrets", &body); err != nil {
+		return err
+	}
+
+	resolved := make(map[string]string, len(body.Secrets))
+	hashes := map[string]Hash{}
+	for name, secret := range body.Secrets {
+		secret.Name = name
+		value, err := secret.substitution()
+		if err != nil {
+			return err
+		}
+		resolved[name] = value
+		if h, ok := secret.hash(); ok {
+			hashes[name] = h
+		}
+	}
+
+	r.mu.Lock()
+	r.secrets = resolved
+	r.hashes = hashes
+	r.lastMiss = map[string]time.Time{}
+	r.mu.Unlock()
+	return nil
+}
+
+// Hash describes a secret held as a one-way hash, with everything needed to verify against it.
+type Hash struct {
+	Algorithm   string
+	Value       string
+	Salt        string
+	Iterations  int
+	KeySize     int
+	Memory      int
+	Parallelism int
+}
+
+// ResolveHash returns the hash a reference points at, for verifying a presented credential.
+//
+// This is the counterpart to Resolve: a credential promoted from a control plane is stored as a
+// reference rather than a hash, so the value to compare against lives here rather than in the
+// database. The hash is returned with the parameters that produced it, because those come from
+// wherever the credential was created and need not match this server's own hashing configuration.
+func (r *Resolver) ResolveHash(ctx context.Context, reference string) (Hash, bool, error) {
+	if !IsReference(reference) {
+		return Hash{}, false, nil
+	}
+	if !r.Enabled() {
+		return Hash{}, false, fmt.Errorf("%w: %s", ErrNotConfigured, reference)
+	}
+
+	name := ReferenceName(reference)
+	if r.cfg.Local != nil {
+		local, found, err := r.cfg.Local(ctx, name)
+		if err != nil || !found {
+			return Hash{}, false, err
+		}
+		secret := local.providerSecret(name)
+		hash, ok := secret.hash()
+		return hash, ok, nil
+	}
+
+	r.mu.RLock()
+	cached, ok := r.hashes[name]
+	missedAt, missed := r.lastMiss[name]
+	r.mu.RUnlock()
+	if ok {
+		return cached, true, nil
+	}
+	// A recent miss is not retried, the same as Resolve. This runs on every authentication against a
+	// credential held as a reference, so without it a name the provider does not hold would mean an
+	// outbound request per attempt.
+	if missed && time.Since(missedAt) < minRefreshInterval {
+		return Hash{}, false, nil
+	}
+
+	// Not held yet: the secret may have been added after startup, so ask for it directly.
+	if _, err := r.fetch(ctx, name); err != nil {
+		if errors.Is(err, ErrSecretNotFound) {
+			return Hash{}, false, nil
+		}
+		return Hash{}, false, err
+	}
+	r.mu.RLock()
+	cached, ok = r.hashes[name]
+	r.mu.RUnlock()
+	return cached, ok, nil
+}
+
+// Count reports how many secrets are cached. Intended for startup logging, which must not log values.
+// A resolver reading a local store caches nothing, so this is zero for one; the store reports its own
+// count instead.
+func (r *Resolver) Count() int {
+	if r == nil {
+		return 0
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.secrets)
+}
+
+// Resolve returns value with a secret reference replaced by its value. A value that is not a reference
+// is returned unchanged, so callers can pass any stored configuration value through.
+func (r *Resolver) Resolve(ctx context.Context, value string) (string, error) {
+	if !IsReference(value) {
+		return value, nil
+	}
+	if !r.Enabled() {
+		return "", fmt.Errorf("%w: %s", ErrNotConfigured, value)
+	}
+
+	name := ReferenceName(value)
+	if r.cfg.Local != nil {
+		return r.resolveLocal(ctx, name)
+	}
+
+	r.mu.RLock()
+	secret, ok := r.secrets[name]
+	missedAt, missed := r.lastMiss[name]
+	r.mu.RUnlock()
+	if ok {
+		return secret, nil
+	}
+	// A recent miss is not retried: the provider has already said it does not hold this name.
+	if missed && time.Since(missedAt) < minRefreshInterval {
+		return "", fmt.Errorf("%w: %s", ErrSecretNotFound, name)
+	}
+
+	secret, err := r.fetch(ctx, name)
+	if err != nil {
+		return "", err
+	}
+	return secret, nil
+}
+
+// resolveLocal reads a secret from the store held in this process. Nothing is cached: the store is
+// already in memory, and a copy here would outlive a credential being regenerated.
+func (r *Resolver) resolveLocal(ctx context.Context, name string) (string, error) {
+	local, found, err := r.cfg.Local(ctx, name)
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		return "", fmt.Errorf("%w: %s", ErrSecretNotFound, name)
+	}
+	secret := local.providerSecret(name)
+	return secret.substitution()
+}
+
+// fetch reads a single secret from the provider and caches the outcome.
+func (r *Resolver) fetch(ctx context.Context, name string) (string, error) {
+	segment, err := secretPathSegment(name)
+	if err != nil {
+		return "", err
+	}
+
+	var body providerSecret
+	err = r.get(ctx, "/secrets/"+segment, &body)
+	if err != nil {
+		if errors.Is(err, ErrSecretNotFound) {
+			r.mu.Lock()
+			r.lastMiss[name] = time.Now()
+			r.mu.Unlock()
+		}
+		return "", err
+	}
+
+	body.Name = name
+	value, err := body.substitution()
+	if err != nil {
+		return "", err
+	}
+
+	r.mu.Lock()
+	r.secrets[name] = value
+	if h, ok := body.hash(); ok {
+		r.hashes[name] = h
+	}
+	delete(r.lastMiss, name)
+	r.mu.Unlock()
+	return value, nil
+}
+
+func (r *Resolver) get(ctx context.Context, path string, out interface{}) error {
+	url := strings.TrimRight(r.cfg.BaseURL, "/") + path
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to build secret provider request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if r.cfg.Token != "" {
+		// The token is a bearer credential, so it is never put on the wire in the clear. A provider on
+		// this host is the exception: nothing leaves the machine, which is what a local development
+		// setup runs.
+		if !carriesTokenSafely(req.URL) {
+			return fmt.Errorf(
+				"refusing to send the secret provider token over %s to %s: configure an https provider URL",
+				req.URL.Scheme, req.URL.Host)
+		}
+		req.Header.Set("Authorization", "Bearer "+r.cfg.Token)
+	}
+
+	resp, err := r.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("secret provider request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return ErrSecretNotFound
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("secret provider returned %d", resp.StatusCode)
+	}
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read secret provider response: %w", err)
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return fmt.Errorf("failed to decode secret provider response: %w", err)
+	}
+	return nil
+}
+
+// schemeHTTPS is the only scheme the provider token is sent over.
+const schemeHTTPS = "https"
+
+// secretPathSegment escapes a secret name for use as one path segment.
+//
+// A name reaches this from stored configuration, so it is not necessarily well formed. Without
+// escaping, one carrying a slash, a query character or a traversal sequence would address something
+// other than the secret it names.
+func secretPathSegment(name string) (string, error) {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return "", fmt.Errorf("%w: a secret name is required", ErrSecretNotFound)
+	}
+	escaped := url.PathEscape(trimmed)
+	if escaped == "." || escaped == ".." {
+		return "", fmt.Errorf("%w: %s", ErrSecretNotFound, name)
+	}
+	return escaped, nil
+}
+
+// carriesTokenSafely reports whether the bearer token may be sent to this address: over TLS, or to a
+// provider on this host, where the request never reaches a network.
+func carriesTokenSafely(u *url.URL) bool {
+	if u.Scheme == schemeHTTPS {
+		return true
+	}
+	host := u.Hostname()
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// refuseInsecureRedirect stops a redirect leaving the token on a plaintext hop. Go already drops the
+// header when the host changes, but not when the same host answers over http, which is the case this
+// closes.
+func refuseInsecureRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return fmt.Errorf("stopped after 10 redirects")
+	}
+	if !carriesTokenSafely(req.URL) {
+		return fmt.Errorf("refusing to follow a secret provider redirect to %s://%s",
+			req.URL.Scheme, req.URL.Host)
+	}
+	return nil
+}

--- a/backend/internal/system/secretresolver/resolver_test.go
+++ b/backend/internal/system/secretresolver/resolver_test.go
@@ -1,0 +1,410 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package secretresolver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeProvider stands in for the secret provider service and counts requests, so the caching and
+// throttling behavior can be asserted.
+type fakeProvider struct {
+	mu       sync.Mutex
+	secrets  map[string]string
+	listHits int
+	getHits  int
+	token    string
+}
+
+// gets reports the counter under the lock, because the handler increments it on the server's
+// goroutine while the test reads it on its own.
+func (f *fakeProvider) gets() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.getHits
+}
+
+func (f *fakeProvider) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /secrets", func(w http.ResponseWriter, r *http.Request) {
+		if !f.authorized(r) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		f.mu.Lock()
+		f.listHits++
+		secrets := f.secrets
+		f.mu.Unlock()
+		typed := map[string]interface{}{}
+		for k, v := range secrets {
+			typed[k] = map[string]interface{}{"name": k, "kind": "value", "value": v}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"secrets": typed})
+	})
+	mux.HandleFunc("GET /secrets/{name}", func(w http.ResponseWriter, r *http.Request) {
+		if !f.authorized(r) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		f.mu.Lock()
+		f.getHits++
+		value, ok := f.secrets[r.PathValue("name")]
+		f.mu.Unlock()
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"name": r.PathValue("name"), "kind": "value", "value": value,
+		})
+	})
+	return mux
+}
+
+func (f *fakeProvider) authorized(r *http.Request) bool {
+	if f.token == "" {
+		return true
+	}
+	return r.Header.Get("Authorization") == "Bearer "+f.token
+}
+
+func newTestResolver(t *testing.T, fake *fakeProvider) *Resolver {
+	t.Helper()
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+	return New(Config{BaseURL: srv.URL, Token: fake.token})
+}
+
+func TestIsReference(t *testing.T) {
+	if !IsReference("secret:MY_SECRET") || ReferenceName("secret:MY_SECRET") != "MY_SECRET" {
+		t.Fatal("a kv reference should be recognized and its name extracted")
+	}
+	// Values that must not be mistaken for references.
+	for _, value := range []string{"plain-secret", "${MY_SECRET}", "{{.MY_SECRET}}", ""} {
+		if IsReference(value) {
+			t.Fatalf("%q must not be treated as a reference", value)
+		}
+	}
+}
+
+func TestResolvePassesNonReferencesThrough(t *testing.T) {
+	r := newTestResolver(t, &fakeProvider{secrets: map[string]string{}})
+
+	got, err := r.Resolve(context.Background(), "a-literal-secret")
+	if err != nil || got != "a-literal-secret" {
+		t.Fatalf("expected the value unchanged, got %q err=%v", got, err)
+	}
+}
+
+func TestLoadAllPopulatesTheCacheAndResolvesWithoutFurtherCalls(t *testing.T) {
+	fake := &fakeProvider{secrets: map[string]string{"MY_SECRET": "shhh"}, token: "tok"}
+	r := newTestResolver(t, fake)
+
+	if err := r.LoadAll(context.Background()); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if r.Count() != 1 {
+		t.Fatalf("expected one cached secret, got %d", r.Count())
+	}
+
+	for i := 0; i < 3; i++ {
+		got, err := r.Resolve(context.Background(), "secret:MY_SECRET")
+		if err != nil || got != "shhh" {
+			t.Fatalf("resolve: %q err=%v", got, err)
+		}
+	}
+	// Resolution must be served from memory, so no single-name fetch should have happened.
+	if fake.gets() != 0 {
+		t.Fatalf("expected no single-secret fetches, got %d", fake.gets())
+	}
+}
+
+func TestResolveRefreshesOnCacheMiss(t *testing.T) {
+	fake := &fakeProvider{secrets: map[string]string{}}
+	r := newTestResolver(t, fake)
+	if err := r.LoadAll(context.Background()); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	// The secret appears after startup, which is exactly the case the refresh exists for.
+	fake.mu.Lock()
+	fake.secrets["LATE_SECRET"] = "arrived"
+	fake.mu.Unlock()
+
+	got, err := r.Resolve(context.Background(), "secret:LATE_SECRET")
+	if err != nil || got != "arrived" {
+		t.Fatalf("expected the late secret to be fetched, got %q err=%v", got, err)
+	}
+	// It is cached afterwards, so a second resolve costs nothing.
+	before := fake.gets()
+	if _, err := r.Resolve(context.Background(), "secret:LATE_SECRET"); err != nil {
+		t.Fatalf("second resolve: %v", err)
+	}
+	if fake.gets() != before {
+		t.Fatalf("the second resolve should be served from cache")
+	}
+}
+
+func TestResolveThrottlesRepeatedMisses(t *testing.T) {
+	fake := &fakeProvider{secrets: map[string]string{}}
+	r := newTestResolver(t, fake)
+
+	for i := 0; i < 5; i++ {
+		_, err := r.Resolve(context.Background(), "secret:ABSENT")
+		if !errors.Is(err, ErrSecretNotFound) {
+			t.Fatalf("expected ErrSecretNotFound, got %v", err)
+		}
+	}
+	// Only the first attempt should reach the provider; a known miss must not be retried per request.
+	if fake.gets() != 1 {
+		t.Fatalf("expected a single provider call for a repeated miss, got %d", fake.gets())
+	}
+}
+
+// ResolveHash runs on every authentication against a credential held as a reference, so a name the
+// provider does not hold must not mean an outbound request per attempt.
+func TestResolveHashThrottlesRepeatedMisses(t *testing.T) {
+	fake := &fakeProvider{secrets: map[string]string{}}
+	r := newTestResolver(t, fake)
+
+	for i := 0; i < 5; i++ {
+		hash, found, err := r.ResolveHash(context.Background(), "secret:ABSENT")
+		if err != nil {
+			t.Fatalf("a missing secret is not an error, got %v", err)
+		}
+		if found {
+			t.Fatalf("expected no hash for an absent secret, got %#v", hash)
+		}
+	}
+
+	if fake.gets() != 1 {
+		t.Fatalf("expected a single provider call for a repeated miss, got %d", fake.gets())
+	}
+}
+
+func TestResolveFailsClearlyWhenNotConfigured(t *testing.T) {
+	r := New(Config{})
+	if r.Enabled() {
+		t.Fatal("an empty base URL must leave the resolver disabled")
+	}
+
+	// A non-reference still passes through, so an unconfigured deployment keeps working.
+	if got, err := r.Resolve(context.Background(), "plain"); err != nil || got != "plain" {
+		t.Fatalf("expected pass-through, got %q err=%v", got, err)
+	}
+	// A reference cannot be resolved, and the error says why rather than yielding an empty secret.
+	if _, err := r.Resolve(context.Background(), "secret:MY_SECRET"); !errors.Is(err, ErrNotConfigured) {
+		t.Fatalf("expected ErrNotConfigured, got %v", err)
+	}
+}
+
+func TestLoadAllIsANoOpWhenDisabled(t *testing.T) {
+	if err := New(Config{}).LoadAll(context.Background()); err != nil {
+		t.Fatalf("expected no error when disabled, got %v", err)
+	}
+}
+
+func TestTokenIsSent(t *testing.T) {
+	fake := &fakeProvider{secrets: map[string]string{"MY_SECRET": "shhh"}, token: "expected-token"}
+	r := newTestResolver(t, fake)
+
+	if err := r.LoadAll(context.Background()); err != nil {
+		t.Fatalf("load with the right token should succeed: %v", err)
+	}
+
+	// A wrong token must surface as an error rather than an empty cache.
+	wrong := New(Config{BaseURL: r.cfg.BaseURL, Token: "nope"})
+	if err := wrong.LoadAll(context.Background()); err == nil {
+		t.Fatal("expected an error for an unauthorized load")
+	}
+}
+
+func TestResolveRendersAHashAsADeclarativeCredential(t *testing.T) {
+	// A hash cannot be substituted as itself: the configuration expects a credential. It is rendered as
+	// the declarative credential form so the importer stores it rather than hashing it again.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"secrets": map[string]interface{}{
+			"ADMIN_PASSWORD": map[string]interface{}{
+				"kind":       "hash",
+				"value":      "the-hash",
+				"algorithm":  "PBKDF2",
+				"parameters": map[string]interface{}{"salt": "the-salt", "iterations": 1000, "keySize": 32},
+			},
+		}})
+	}))
+	defer srv.Close()
+
+	r := New(Config{BaseURL: srv.URL})
+	if err := r.LoadAll(context.Background()); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	got, err := r.Resolve(context.Background(), "secret:ADMIN_PASSWORD")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	// The substitution must be JSON, which is also valid YAML, so it parses as a credential list.
+	var creds []map[string]interface{}
+	if err := json.Unmarshal([]byte(got), &creds); err != nil {
+		t.Fatalf("substitution is not valid JSON: %q", got)
+	}
+	if len(creds) != 1 || creds[0]["value"] != "the-hash" || creds[0]["storageType"] != "hash" {
+		t.Fatalf("unexpected credential: %s", got)
+	}
+	if creds[0]["storageAlgo"] != "PBKDF2" {
+		t.Fatalf("the algorithm must be carried through: %s", got)
+	}
+}
+
+func TestResolveSubstitutesAReadableValueAsItself(t *testing.T) {
+	fake := &fakeProvider{secrets: map[string]string{"VONAGE_API_SECRET": "the-api-secret"}}
+	r := newTestResolver(t, fake)
+	if err := r.LoadAll(context.Background()); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	// A credential replayed to a third party has to arrive verbatim.
+	got, err := r.Resolve(context.Background(), "secret:VONAGE_API_SECRET")
+	if err != nil || got != "the-api-secret" {
+		t.Fatalf("expected the value verbatim, got %q err=%v", got, err)
+	}
+}
+
+// A credential regenerated on the control plane is written into this deployment's store while the
+// server is running. Resolution has to see the new value: serving the old one means every login
+// against that credential fails until the process restarts.
+func TestARegeneratedSecretResolvesWithoutARestart(t *testing.T) {
+	stored := map[string]providerSecret{
+		"APP_CLIENT_SECRET": {Kind: "value", Value: "the-old-value"},
+	}
+	r := New(Config{Local: func(_ context.Context, name string) (LocalSecret, bool, error) {
+		s, ok := stored[name]
+		if !ok {
+			return LocalSecret{}, false, nil
+		}
+		return LocalSecret{Kind: s.Kind, Value: s.Value, Algorithm: s.Algorithm}, true, nil
+	}})
+	ctx := context.Background()
+
+	first, err := r.Resolve(ctx, "secret:APP_CLIENT_SECRET")
+	if err != nil || first != "the-old-value" {
+		t.Fatalf("expected the stored value, got %q %v", first, err)
+	}
+
+	// The control plane pushes a regenerated credential into the store.
+	stored["APP_CLIENT_SECRET"] = providerSecret{Kind: "value", Value: "the-new-value"}
+
+	got, err := r.Resolve(ctx, "secret:APP_CLIENT_SECRET")
+	if err != nil {
+		t.Fatalf("resolve after regeneration: %v", err)
+	}
+	if got != "the-new-value" {
+		t.Fatalf("expected the regenerated value, got %q", got)
+	}
+}
+
+// The same for a hash: a regenerated password or client secret is verified against the hash held
+// here, so a stale one rejects every attempt.
+func TestARegeneratedHashResolvesWithoutARestart(t *testing.T) {
+	stored := map[string]LocalSecret{
+		"APP_CLIENT_SECRET": {Kind: "hash", Value: "the-old-hash", Algorithm: "PBKDF2", Salt: "old-salt"},
+	}
+	r := New(Config{Local: func(_ context.Context, name string) (LocalSecret, bool, error) {
+		s, ok := stored[name]
+		return s, ok, nil
+	}})
+	ctx := context.Background()
+
+	if _, _, err := r.ResolveHash(ctx, "secret:APP_CLIENT_SECRET"); err != nil {
+		t.Fatalf("first resolve: %v", err)
+	}
+	stored["APP_CLIENT_SECRET"] = LocalSecret{
+		Kind: "hash", Value: "the-new-hash", Algorithm: "PBKDF2", Salt: "new-salt",
+	}
+
+	hash, found, err := r.ResolveHash(ctx, "secret:APP_CLIENT_SECRET")
+
+	if err != nil || !found {
+		t.Fatalf("expected the hash, got %v %v", found, err)
+	}
+	if hash.Value != "the-new-hash" || hash.Salt != "new-salt" {
+		t.Fatalf("expected the regenerated hash, got %+v", hash)
+	}
+}
+
+// A secret name comes from stored configuration, so it is not necessarily well formed. Escaping it
+// keeps a name carrying a slash or a traversal sequence from addressing something other than itself.
+func TestSecretNameIsEscapedIntoOnePathSegment(t *testing.T) {
+	cases := []struct{ name, want string }{
+		{"MY_SECRET", "MY_SECRET"},
+		{"a/b", "a%2Fb"},
+		{"../admin", "..%2Fadmin"},
+		{"a?b=c", "a%3Fb=c"},
+	}
+	for _, c := range cases {
+		got, err := secretPathSegment(c.name)
+		if err != nil {
+			t.Errorf("secretPathSegment(%q) returned %v", c.name, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("secretPathSegment(%q) = %q, want %q", c.name, got, c.want)
+		}
+	}
+
+	for _, name := range []string{"", "   ", ".", ".."} {
+		if _, err := secretPathSegment(name); err == nil {
+			t.Errorf("expected %q to be refused as a secret name", name)
+		}
+	}
+}
+
+// The provider token is a bearer credential, so it is sent over TLS, or to a provider on this host
+// where the request never reaches a network. Anything else is refused rather than sent in the clear.
+func TestTokenIsNotSentOverPlaintextToARemoteProvider(t *testing.T) {
+	var authorized bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorized = r.Header.Get("Authorization") != ""
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	// The test server answers on loopback under a name that is not one, so the request is refused.
+	remote := strings.Replace(srv.URL, "127.0.0.1", "provider.invalid", 1)
+	r := New(Config{BaseURL: remote, Token: "shhh", Timeout: time.Second})
+
+	_, err := r.Resolve(context.Background(), "secret:MY_SECRET")
+	if err == nil {
+		t.Fatal("expected the plaintext request to be refused")
+	}
+	if !strings.Contains(err.Error(), "refusing to send") {
+		t.Fatalf("expected the refusal to say why, got %v", err)
+	}
+	if authorized {
+		t.Fatal("the token must not have reached the provider")
+	}
+}

--- a/backend/internal/system/varname/doc_examples_test.go
+++ b/backend/internal/system/varname/doc_examples_test.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package varname
+
+import "testing"
+
+// The examples in docs/content/guides/resource-export.mdx are pinned here, so a change to the naming
+// rule fails a test rather than leaving the guide quietly wrong.
+func TestDocumentedExamples(t *testing.T) {
+	cases := []struct{ resourceType, resourceName, field, want string }{
+		{"application", "My App", "ClientId", "APPLICATION_MY_APP_CLIENT_ID"},
+		{"application", "My-App", "ClientId", "APPLICATION_MY_APP_CLIENT_ID"},
+		{"application", "My App-", "ClientId", "APPLICATION_MY_APP_CLIENT_ID"},
+		{"agent", "My App", "ClientId", "AGENT_MY_APP_CLIENT_ID"},
+		{"user", "alice@example.com", "password", "USER_ALICE_EXAMPLE_COM_PASSWORD"},
+		{"application", "2FA App", "ClientId", "APPLICATION_2FA_APP_CLIENT_ID"},
+	}
+	for _, c := range cases {
+		if got := DeriveVariableName(c.resourceType, c.resourceName, c.field); got != c.want {
+			t.Errorf("DeriveVariableName(%q, %q, %q) = %q, want %q",
+				c.resourceType, c.resourceName, c.field, got, c.want)
+		}
+	}
+}

--- a/backend/internal/system/varname/varname.go
+++ b/backend/internal/system/varname/varname.go
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package varname derives the template variable names that a declarative resource's placeholders
+// carry. It is a leaf so that both the exporter and whatever captures a credential can depend on it
+// and derive the same name.
+package varname
+
+import "strings"
+
+// DeriveVariableName derives the declarative template variable name for a resource field, and is the
+// single source of truth for those names so that every caller derives the same one.
+//
+// The resource type leads the name because a name is only unique within its type: an application and
+// an agent both called "dummy" would otherwise share DUMMY_CLIENT_ID. The result is sanitized, since
+// a resource name routinely holds characters a template variable cannot carry.
+//
+// Example: ("application", "My App", "ClientSecret") -> "APPLICATION_MY_APP_CLIENT_SECRET".
+// Example: ("user", "user@example.com", "password") -> "USER_USER_EXAMPLE_COM_PASSWORD".
+func DeriveVariableName(resourceType, resourceName, fieldName string) string {
+	prefix := toSnakeCaseUpper(strings.ReplaceAll(resourceName, " ", "_"))
+	if resourceType != "" {
+		prefix = toSnakeCaseUpper(strings.ReplaceAll(resourceType, " ", "_")) + "_" + prefix
+	}
+	return sanitizeVariableName(prefix + "_" + toSnakeCaseUpper(fieldName))
+}
+
+// sanitizeVariableName replaces every character a Go template identifier cannot carry with an
+// underscore, collapses runs of underscores, and trims them from the ends.
+func sanitizeVariableName(name string) string {
+	var result strings.Builder
+	lastWasUnderscore := false
+
+	for _, r := range name {
+		isAllowed := (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_'
+		if !isAllowed {
+			r = '_'
+		}
+		if r == '_' {
+			if lastWasUnderscore {
+				continue
+			}
+			lastWasUnderscore = true
+		} else {
+			lastWasUnderscore = false
+		}
+		result.WriteRune(r)
+	}
+
+	sanitized := strings.Trim(result.String(), "_")
+	// A name must not start with a digit, so a leading digit is prefixed with an underscore. The
+	// prefix matches the exporter's own sanitizer, because a placeholder and the variable captured for
+	// it have to spell the same name.
+	if sanitized != "" && sanitized[0] >= '0' && sanitized[0] <= '9' {
+		return "_" + sanitized
+	}
+	return sanitized
+}
+
+// toSnakeCaseUpper converts camelCase/PascalCase to UPPER_SNAKE_CASE (e.g. "ClientID" -> "CLIENT_ID").
+func toSnakeCaseUpper(s string) string {
+	var result strings.Builder
+	runes := []rune(s)
+
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+
+		// Add an underscore before an uppercase letter when the previous character is lowercase, or
+		// when the previous character is uppercase and the next is lowercase (handles acronym
+		// boundaries such as "ClientID" -> "CLIENT_ID").
+		if i > 0 && r >= 'A' && r <= 'Z' {
+			prev := runes[i-1]
+			if prev >= 'a' && prev <= 'z' {
+				result.WriteRune('_')
+			} else if prev != '_' && i+1 < len(runes) {
+				next := runes[i+1]
+				if next >= 'a' && next <= 'z' {
+					result.WriteRune('_')
+				}
+			}
+		}
+
+		result.WriteRune(r)
+	}
+
+	return strings.ToUpper(result.String())
+}

--- a/backend/internal/system/varname/varname_test.go
+++ b/backend/internal/system/varname/varname_test.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package varname
+
+import (
+	"regexp"
+	"testing"
+)
+
+// TestDeriveVariableName locks the placeholder-naming contract that the export parameterizer and the
+// Control Plane secret auto-capture both depend on. If this changes, captured secret keys and export
+// placeholders would diverge and the apply flow would fail to resolve them.
+func TestDeriveVariableName(t *testing.T) {
+	cases := []struct {
+		resourceType string
+		resourceName string
+		fieldName    string
+		want         string
+	}{
+		{"application", "My App", "ClientSecret", "APPLICATION_MY_APP_CLIENT_SECRET"},
+		{"connection", "Export Test IDP", "client_id", "CONNECTION_EXPORT_TEST_IDP_CLIENT_ID"},
+		{"user", "alice", "password", "USER_ALICE_PASSWORD"},
+		{"agent", "ClientID", "value", "AGENT_CLIENT_ID_VALUE"},
+		// An unqualified call keeps the old shape, so a caller with no type still produces a name.
+		{"", "My App", "ClientSecret", "MY_APP_CLIENT_SECRET"},
+	}
+	for _, c := range cases {
+		if got := DeriveVariableName(c.resourceType, c.resourceName, c.fieldName); got != c.want {
+			t.Errorf("DeriveVariableName(%q, %q, %q) = %q, want %q",
+				c.resourceType, c.resourceName, c.fieldName, got, c.want)
+		}
+	}
+}
+
+// The whole point of the type prefix: two resources of different types may share a name.
+func TestDeriveVariableNameSeparatesTypesThatShareAName(t *testing.T) {
+	app := DeriveVariableName("application", "dummy", "ClientID")
+	agent := DeriveVariableName("agent", "dummy", "ClientID")
+	if app == agent {
+		t.Fatalf("an application and an agent named the same must not share a variable: %q", app)
+	}
+}
+
+func TestDeriveVariableNameProducesValidTemplateIdentifiers(t *testing.T) {
+	// A username is commonly an email address, whose characters cannot appear in a template variable.
+	if got := DeriveVariableName("user", "user@example.com", "password"); got != "USER_USER_EXAMPLE_COM_PASSWORD" {
+		t.Fatalf("email based name not sanitized: %q", got)
+	}
+	if got := DeriveVariableName("application", "My App", "ClientSecret"); got != "APPLICATION_MY_APP_CLIENT_SECRET" {
+		t.Fatalf("regression on the ordinary case: %q", got)
+	}
+	// Runs of separators collapse rather than producing empty segments.
+	if got := DeriveVariableName("", "a..b--c", "password"); got != "A_B_C_PASSWORD" {
+		t.Fatalf("separators not collapsed: %q", got)
+	}
+	// A leading digit would be an invalid identifier.
+	if got := DeriveVariableName("", "1app", "password"); got != "_1APP_PASSWORD" {
+		t.Fatalf("leading digit not handled: %q", got)
+	}
+
+	// Every derived name must be a valid Go template identifier.
+	for _, name := range []string{
+		DeriveVariableName("user", "user@example.com", "password"),
+		DeriveVariableName("", "a..b--c", "password"),
+		DeriveVariableName("", "1app", "password"),
+	} {
+		if !regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`).MatchString(name) {
+			t.Fatalf("%q is not a valid template identifier", name)
+		}
+	}
+}

--- a/backend/internal/user/declarative_resource.go
+++ b/backend/internal/user/declarative_resource.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/thunder-id/thunderid/internal/system/varname"
 	tidcommon "github.com/thunder-id/thunderid/pkg/thunderidengine/common"
 	"github.com/thunder-id/thunderid/pkg/thunderidengine/providers"
 
@@ -116,17 +117,35 @@ func (e *userExporter) GetResourceByID(
 		attributesMap = make(map[string]interface{})
 	}
 
-	// Create export structure with credentials as placeholders
-	// The parameterizer will replace actual credential values with template variables
+	// Export credentials as placeholders rather than values. A stored credential is a one-way hash, so
+	// the value cannot be exported, and an empty map would leave the imported user with no credential at
+	// all and no way to sign in. Naming the credential here makes the parameterizer emit a template
+	// variable for it, which the importing server fills from its own secret provider or environment
+	// before hashing.
 	exportUser := &userDeclarativeResource{
 		ID:          user.ID,
 		Type:        user.Type,
 		OUID:        user.OUID,
 		Attributes:  attributesMap,
-		Credentials: make(map[string]interface{}), // Empty credentials - will be filled with placeholders
+		Credentials: exportableCredentials(username),
 	}
 
 	return exportUser, username, nil
+}
+
+// exportableCredentials describes the credentials an exported user carries.
+//
+// The placeholder is written here because the parameterizer only walks a slice of properties and
+// credentials are a map, so it would export any value here verbatim. Only the password is carried:
+// device bound kinds such as a passkey mean nothing on another deployment. The value never leaves,
+// since it is stored as a one-way hash and the importing server fills the placeholder itself.
+func exportableCredentials(username string) map[string]interface{} {
+	if username == "" {
+		return map[string]interface{}{}
+	}
+	return map[string]interface{}{
+		"password": fmt.Sprintf("{{.%s}}", varname.DeriveVariableName(resourceTypeUser, username, "password")),
+	}
 }
 
 // ValidateResource validates a user resource.

--- a/backend/internal/user/declarative_resource_test.go
+++ b/backend/internal/user/declarative_resource_test.go
@@ -179,7 +179,10 @@ func (suite *DeclarativeResourceTestSuite) TestUserExporter_GetResourceByID() {
 
 	userResource, ok := resource.(*userDeclarativeResource)
 	suite.True(ok)
-	suite.Empty(userResource.Credentials)
+	// The password carries a template variable derived from the username. Exporting no credential at
+	// all would leave the imported user unable to sign in, and the value cannot be exported because it
+	// is stored as a one-way hash, so the importing server fills the variable instead.
+	suite.Equal("{{.USER_ALICE_PASSWORD}}", userResource.Credentials["password"])
 }
 
 func (suite *DeclarativeResourceTestSuite) TestUserExporter_Metadata() {

--- a/backend/pkg/thunderidengine/config/config.go
+++ b/backend/pkg/thunderidengine/config/config.go
@@ -122,10 +122,12 @@ type RedisConfig struct {
 
 // ServerConfig holds the server configuration details.
 type ServerConfig struct {
-	Hostname       string         `yaml:"hostname"   json:"hostname"`
-	Port           int            `yaml:"port"       json:"port"`
-	HTTPOnly       bool           `yaml:"http_only"  json:"http_only"`
-	PublicURL      string         `yaml:"public_url" json:"public_url"`
+	Hostname  string `yaml:"hostname"   json:"hostname"`
+	Port      int    `yaml:"port"       json:"port"`
+	HTTPOnly  bool   `yaml:"http_only"  json:"http_only"`
+	PublicURL string `yaml:"public_url" json:"public_url"`
+	// Identifier is the deployment id that scopes all persisted resources. It is put on every
+	// request's context at the edge, and it is the only value stores partition by.
 	Identifier     string         `yaml:"identifier" json:"identifier"`
 	SecurityConfig SecurityConfig `yaml:"security"   json:"security"`
 }

--- a/docs/content/guides/declarative-configurations/secret-references.mdx
+++ b/docs/content/guides/declarative-configurations/secret-references.mdx
@@ -1,0 +1,80 @@
+---
+title: Secret References
+docType: reference
+description: Store a credential as a reference to a secret provider instead of a value, and understand how {{ProductName}} resolves it.
+sidebar_position: 5
+---
+
+# Secret References
+
+A configuration value that holds a credential can name a secret instead of carrying it. <ProductName />
+recognizes any value beginning with `secret:` as a reference and resolves it through the deployment's
+secret provider when it is needed.
+
+```yaml
+properties:
+  - name: client_secret
+    value: "secret:CONNECTION_GOOGLE_CLIENT_SECRET"
+    is_secret: true
+```
+
+The part after the prefix is the name the provider holds the credential under. It matches the template
+variable name an export generates for that field, so a credential captured under that name and a
+configuration referencing it agree without a second mapping to keep in sync. See
+[Export Resources](../resource-export.mdx) for how those names are derived.
+
+## Why Reference Instead of Store
+
+A reference lets configuration move between deployments without carrying credentials with it. The
+configuration says which credential a resource needs; the deployment says what that credential is. Two
+deployments can then run the same configuration with different credentials, and the configuration
+itself holds nothing sensitive.
+
+The reference is stored in the clear, because the name of a credential is not itself sensitive.
+
+## How a Reference Resolves
+
+Resolution depends on what the value is for.
+
+**A property that is replayed to a third party**, such as an identity provider's client secret, resolves
+to the credential itself, because <ProductName /> has to present it. Reading the property returns the
+resolved value.
+
+**A credential that is only ever verified**, such as a password, resolves to a hash and the parameters
+that produced it. Verification then compares the presented credential against that hash, exactly as it
+would for one stored locally. The original is never needed and never returned.
+
+A credential that resolves to nothing does not pass verification. An unresolvable reference rejects
+rather than matching, so a provider that is unreachable or missing the name cannot let a sign-in
+through.
+
+## Reading a Value Without Resolving It
+
+Some callers need the stored value rather than the credential: checking whether a property is set, or
+carrying it from one place to another unchanged. Those read the value as it stands, reference and all.
+
+This matters where a deployment runs no secret provider. Resolving there would fail outright, and
+resolving where one does run would copy the credential somewhere it does not belong.
+
+## When No Provider Is Configured
+
+A deployment with no secret provider resolves nothing. A value that is not a reference is returned as
+it stands, so a deployment that stores its credentials directly is unaffected. A reference cannot be
+resolved, and the attempt reports that the provider is not configured rather than yielding an empty
+credential.
+
+## Reaching the Provider
+
+The provider is addressed over HTTPS. Where a token is configured, <ProductName /> refuses to send it
+over a plaintext connection, and refuses to follow a redirect onto one, so a bearer credential is
+never put on the wire in the clear. A provider on the same host is the exception, because the request
+never reaches a network, which is what a local development setup runs.
+
+A referenced name is escaped into a single path segment, so a name carrying a separator addresses the
+secret it names and nothing else.
+
+## Names That Are Not Found
+
+A provider that does not hold a referenced name is asked once, and the miss is remembered for a short
+interval rather than retried on every request. A reference resolves as soon as the credential is added
+to the provider, without a restart, once that interval has passed.

--- a/docs/content/guides/resource-export.mdx
+++ b/docs/content/guides/resource-export.mdx
@@ -18,7 +18,7 @@ Use the export API to retrieve <ProductName /> resources:
 ```json
 {
   "resources": "# File: My_App.yaml\napiVersion: thunder/v1\n...",
-  "environment_variables": "MY_APP_CLIENT_ID=\nMY_APP_CLIENT_SECRET=\n"
+  "environment_variables": "APPLICATION_MY_APP_CLIENT_ID=\nAPPLICATION_MY_APP_CLIENT_SECRET=\n"
 }
 ```
 
@@ -31,24 +31,75 @@ If the export has no template variables, `environment_variables` is an empty str
 
 ## Template Variable Names
 
-Each parameterized field becomes a template variable named after its resource and the field, in uppercase. The `clientId` field of an application named `My App` becomes `MY_APP_CLIENT_ID`.
+Each parameterized field becomes a template variable named after the resource type, the resource name
+and the field, in uppercase. The `clientId` field of an application named `My App` becomes
+`APPLICATION_MY_APP_CLIENT_ID`.
 
-<ProductName /> normalizes the resource name so that the generated name is valid in a template placeholder:
+The resource type leads the name because a name is only unique within its own type. An application
+and an agent may both be called `Dummy`, and without the type both would claim `DUMMY_CLIENT_ID`. One
+value would win and the other resource would import with the wrong credential.
 
-- Every character that is not a letter or a digit becomes an underscore, and consecutive underscores collapse into one.
-- A trailing underscore is removed, so a name ending in a separator produces the same variable name as the name without it.
-- A name that starts with a digit gets a leading underscore.
+<ProductName /> normalizes the resource name so that the generated name is valid in a template
+placeholder:
 
-Normalization applies to generated variable names only. Exported file names and the `name` field inside the exported YAML keep the original resource name.
+- Every character that is not a letter or a digit becomes an underscore, and consecutive underscores
+  collapse into one.
+- Leading and trailing underscores are removed, so a name ending in a separator produces the same
+  variable name as the name without it.
+- A name that would start with a digit gets a leading underscore. The resource type leads every
+  generated name, so this applies only where a name is derived without one.
 
-| Resource name | Variable name for `clientId` |
-| --- | --- |
-| `My App` | `MY_APP_CLIENT_ID` |
-| `My-App` | `MY_APP_CLIENT_ID` |
-| `My App-` | `MY_APP_CLIENT_ID` |
-| `2FA App` | `_2FA_APP_CLIENT_ID` |
+Normalization applies to generated variable names only. Exported file names and the `name` field
+inside the exported YAML keep the original resource name.
 
-Because normalization maps several names onto the same prefix, two resources in one export can compete for the same variable name. In that case, the second resource gets a numeric suffix. Exporting both `Wayfinder-Concierge` and `Wayfinder_Concierge` produces `WAYFINDER_CONCIERGE_CLIENT_ID` and `WAYFINDER_CONCIERGE_2_CLIENT_ID`, so each resource keeps its own value in the environment file. Resource types share one namespace, so an application and a connection with the same name also get distinct variable names.
+| Resource type | Resource name | Variable name for `clientId` |
+| --- | --- | --- |
+| `application` | `My App` | `APPLICATION_MY_APP_CLIENT_ID` |
+| `application` | `My-App` | `APPLICATION_MY_APP_CLIENT_ID` |
+| `application` | `My App-` | `APPLICATION_MY_APP_CLIENT_ID` |
+| `application` | `2FA App` | `APPLICATION_2FA_APP_CLIENT_ID` |
+| `agent` | `My App` | `AGENT_MY_APP_CLIENT_ID` |
+
+Because normalization maps several names onto the same prefix, two resources of one type in a single
+export can compete for the same variable name. In that case, the second resource gets a numeric
+suffix. Exporting both `Wayfinder-Concierge` and `Wayfinder_Concierge` produces
+`APPLICATION_WAYFINDER_CONCIERGE_CLIENT_ID` and `APPLICATION_WAYFINDER_CONCIERGE_2_CLIENT_ID`, so each
+resource keeps its own value in the environment file.
+
+### Updating an Existing Environment File
+
+Variable names generated before the resource type was added carry no type prefix. An environment file
+kept from an earlier export sets names such as `MY_APP_CLIENT_ID`, which a current export no longer
+asks for. Rename each entry to include its resource type, or export again and fill in the new file.
+
+## User Credentials
+
+An exported user carries its password as a template variable rather than a value:
+
+```yaml
+credentials:
+  password: "{{.USER_ALICE_EXAMPLE_COM_PASSWORD}}"
+```
+
+A stored password is a one-way hash, so the original cannot be exported. Naming it here means the
+importing server supplies the password from its own environment or secret provider and hashes it on
+the way in, which leaves the imported user able to sign in. Without the placeholder the user would
+import with no credential at all.
+
+Only the password is carried. It is the credential every user type defines, and a device-bound
+credential such as a passkey means nothing on another deployment.
+
+A user with no username exports no credentials, because the variable is named after the username and
+there is nothing to name it after.
+
+The password placeholder is named directly from the username, so it does not take the numeric suffix
+that resolves competing names for other fields. Two users whose usernames normalize to the same name,
+such as `alice@example.com` and `alice.example.com`, would therefore claim one password variable and
+both import with the same password.
+
+<ProductName /> refuses the whole export in that case, with the error `EXP-1003` naming the two
+resources. The bundle is not returned at all, because one that dropped a resource silently would look
+complete. Rename one of the users, or export them separately.
 
 ## Internal API Model Reference
 
@@ -65,12 +116,12 @@ The API reference schema also defines an internal `ExportResponse` model (see `E
   ],
   "envFile": {
     "fileName": ".env",
-    "content": "GOOGLE_CLIENT_ID=\nGOOGLE_CLIENT_SECRET=\n",
-    "size": 40
+    "content": "CONNECTION_GOOGLE_CLIENT_ID=\nCONNECTION_GOOGLE_CLIENT_SECRET=\n",
+    "size": 62
   },
   "summary": {
     "totalFiles": 2,
-    "totalSizeBytes": 168
+    "totalSizeBytes": 190
   }
 }
 ```

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -1051,6 +1051,11 @@ const sidebars: SidebarsConfig = {
               id: 'guides/declarative-configurations/templates',
               label: 'Template Resources',
             },
+            {
+              type: 'doc',
+              id: 'guides/declarative-configurations/secret-references',
+              label: 'Secret References',
+            },
           ],
         },
       ],

--- a/tests/integration/export/export_api_test.go
+++ b/tests/integration/export/export_api_test.go
@@ -160,7 +160,7 @@ func (ts *ExportAPITestSuite) TestApplicationExportYAML() {
 	// Verify the exported YAML content
 	ts.Assert().Contains(yamlContent, "name: Export Test App")
 	ts.Assert().Contains(yamlContent, "description: Test application for export functionality")
-	ts.Assert().Contains(yamlContent, "clientId: {{.EXPORT_TEST_APP_CLIENT_ID}}")
+	ts.Assert().Contains(yamlContent, "clientId: {{.APPLICATION_EXPORT_TEST_APP_CLIENT_ID}}")
 	ts.Assert().NotContains(yamlContent, "export_test_secret") // Client secret should not be exported
 	ts.Assert().Contains(yamlContent, "# File: Export_Test_App.yaml")
 
@@ -257,7 +257,7 @@ func (ts *ExportAPITestSuite) TestIdentityProviderExportYAML() {
 	ts.Assert().Contains(yamlContent, "description: Test identity provider for export functionality")
 	ts.Assert().Contains(yamlContent, "type: oauth")
 	ts.Assert().Contains(yamlContent, "clientId: export_test_oauth_client")
-	ts.Assert().Contains(yamlContent, "clientSecret: {{.EXPORT_TEST_IDP_CLIENT_SECRET}}")
+	ts.Assert().Contains(yamlContent, "clientSecret: {{.CONNECTION_EXPORT_TEST_IDP_CLIENT_SECRET}}")
 	ts.Assert().Contains(yamlContent, "# File: Export_Test_IDP.yaml")
 }
 
@@ -565,7 +565,7 @@ func (ts *ExportAPITestSuite) TestIdentityProviderExportWithProperties() {
 
 	// Verify typed fields: only the secret field (clientSecret) is parameterized.
 	ts.Assert().Contains(yamlContent, "clientId: props_test_client")
-	ts.Assert().Contains(yamlContent, "clientSecret: {{.PROPERTIES_TEST_IDP_CLIENT_SECRET}}")
+	ts.Assert().Contains(yamlContent, "clientSecret: {{.CONNECTION_PROPERTIES_TEST_IDP_CLIENT_SECRET}}")
 	ts.Assert().Contains(yamlContent, "redirectUri: https://localhost:3000/callback")
 	ts.Assert().Contains(yamlContent, "- openid")
 	ts.Assert().Contains(yamlContent, "- email")

--- a/tests/integration/export/export_entity_resources_test.go
+++ b/tests/integration/export/export_entity_resources_test.go
@@ -198,13 +198,44 @@ func (ts *ExportEntityResourcesTestSuite) TestUserExportParameterizesCredentials
 	ts.Assert().NotContains(yamlContent, entityExportPassword,
 		"an exported user must not carry its plaintext credential")
 
-	// The exporter currently omits the credentials block entirely rather than emitting the template
-	// variable its DynamicPropertyFields declaration implies, so the assertion above holds because
-	// the field is dropped rather than because it is parameterized. Pinned here so the distinction
-	// is visible: if the exporter starts emitting a placeholder, this assertion should become a
-	// positive check for it.
-	ts.Assert().NotContains(yamlContent, "credentials:",
-		"the exporter omits credentials today; revisit this test if it starts parameterizing them")
+	// The credential leaves as the template variable its DynamicPropertyFields declaration implies,
+	// so the assertion above holds because the field is parameterized rather than dropped.
+	ts.Assert().Contains(yamlContent, "credentials:",
+		"an exported user must carry its credentials block")
+	ts.Assert().Contains(yamlContent, `password: "{{.USER_EXPORT_ENTITY_USER_PASSWORD}}"`,
+		"the credential must leave as a template variable")
+}
+
+// TestUserExportRefusesTwoUsersWithOneVariableName verifies an export that cannot represent both
+// users is refused rather than returned.
+//
+// A user's password placeholder is named after the username, so two usernames that normalize to the
+// same name claim one variable. Returning that bundle would import both users with the same password,
+// and dropping one silently would leave a bundle that looks complete.
+func (ts *ExportEntityResourcesTestSuite) TestUserExportRefusesTwoUsersWithOneVariableName() {
+	first, err := testutils.CreateUser(testutils.User{
+		Type: entityExportUserTypeName,
+		OUID: ts.ouID,
+		Attributes: json.RawMessage(
+			`{"username": "clash@example.com", "password": "ExportEntity@123", "email": "a@example.com"}`),
+	})
+	ts.Require().NoError(err, "Failed to create the first user")
+	defer func() { _ = testutils.DeleteUser(first) }()
+
+	second, err := testutils.CreateUser(testutils.User{
+		Type: entityExportUserTypeName,
+		OUID: ts.ouID,
+		Attributes: json.RawMessage(
+			`{"username": "clash.example.com", "password": "ExportEntity@123", "email": "b@example.com"}`),
+	})
+	ts.Require().NoError(err, "Failed to create the second user")
+	defer func() { _ = testutils.DeleteUser(second) }()
+
+	_, err = ts.exportResourcesYAML(ExportRequest{Users: []string{first, second}})
+
+	ts.Require().Error(err, "expected the export to be refused")
+	ts.Assert().Contains(err.Error(), "EXP-1003",
+		"the refusal must name the duplicate template variable error")
 }
 
 // TestUserExportWithWildcard verifies the wildcard form enumerates users and includes the fixture.


### PR DESCRIPTION
## Purpose
The stores each reach for the deployment id themselves, from configuration. That works for a server holding one deployment, but it means the id is read in as many places as there are stores, and a build that serves more than one has nowhere single to change.

## Goals
Have the deployment id put on the request context once, at the edge, and have everything below read it from there.

## Approach
- `DeploymentIDMiddleware` runs for every request and puts the deployment id on its context, just inside the correlation id middleware and outside the security layer, so any store reached during the request already has it.
- `deployment.Resolve` prefers the context and falls back to the store's configured identifier. The fallback now covers exactly one case: contexts that never passed through the edge, such as start-up tasks, background jobs and command line tooling.
- `IDFromContext` reports whether the context carries an id at all, so a caller that must fail closed can tell a request from a background operation.

Behaviour is unchanged. This server holds one deployment, so every request gets the configured identifier, which is the same value the stores were reading before.

### Deriving the id from a token is deliberately not here
An earlier revision of this PR carried a source switch, `UseTokenClaim`, and a `server.deployment_id_claim` configuration key. Both are removed. Nothing in this repository serves more than one deployment, so a token claim reader here would be a code path this product never takes.

The seam that remains is one function, `deploymentIDForRequest`. A build serving many deployments derives the id per request there and changes nothing else, because everything downstream already reads it from the context.

## User stories
As a maintainer I can see in one place where a request's deployment id comes from, rather than in every store.

## Release note
The deployment id is now placed on the request context at the edge and read from there by the stores.

## Documentation
N/A, no user-facing change. The reasoning is in the code comments on the middleware and on `Resolve`.

## Training
N/A

## Tests
Middleware tests cover the id reaching a handler's context and the context being left alone when no identifier is configured. Package tests cover the context winning over the fallback and the fallback applying to a context that carries none. `make lint_backend` reports 0 issues, the unit suite passes, and the full integration suite passes against a fresh build: 50 suites, 0 failures.